### PR TITLE
feat: use branded logo everywhere (auth, sidebar, emails)

### DIFF
--- a/src/components/AppLogo.tsx
+++ b/src/components/AppLogo.tsx
@@ -1,0 +1,16 @@
+interface AppLogoProps {
+  size?: number;
+  className?: string;
+}
+
+export function AppLogo({ size = 32, className = '' }: AppLogoProps) {
+  return (
+    <img
+      src="/icon-192.png"
+      alt="EasyShiftHQ"
+      width={size}
+      height={size}
+      className={`rounded-lg ${className}`.trim()}
+    />
+  );
+}

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -45,6 +45,7 @@ import {
   ChevronDown,
 } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
+import { AppLogo } from '@/components/AppLogo';
 
 import { useAuth } from '@/hooks/useAuth';
 import { useRestaurantContext } from '@/contexts/RestaurantContext';
@@ -290,9 +291,7 @@ export function AppSidebar() {
             collapsed ? 'justify-center px-3' : 'px-4'
           }`}
         >
-          <div className="bg-gradient-to-br from-emerald-500 to-emerald-600 rounded-lg shadow-lg p-1.5 group-hover:shadow-emerald-500/50 transition-all duration-200 flex-shrink-0">
-            <CalendarCheck className="h-4 w-4 text-white" />
-          </div>
+          <AppLogo size={28} className="shadow-lg group-hover:shadow-emerald-500/50 transition-all duration-200 flex-shrink-0" />
           {!collapsed && (
             <div className="flex-1 min-w-0 text-left">
               <div className="font-bold text-sm truncate">EasyShiftHQ</div>

--- a/src/components/BiometricLockScreen.tsx
+++ b/src/components/BiometricLockScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { ShieldCheck } from 'lucide-react';
+import { AppLogo } from '@/components/AppLogo';
 import { Button } from '@/components/ui/button';
 
 interface BiometricLockScreenProps {
@@ -17,9 +17,7 @@ export function BiometricLockScreen({ onAuthenticate, failedAttempts }: Biometri
 
   return (
     <div className="fixed inset-0 z-50 bg-background flex flex-col items-center justify-center gap-6 px-8">
-      <div className="h-16 w-16 rounded-2xl bg-muted/50 flex items-center justify-center">
-        <ShieldCheck className="h-8 w-8 text-foreground" />
-      </div>
+      <AppLogo size={64} />
       <div className="text-center">
         <h1 className="text-[17px] font-semibold text-foreground">EasyShiftHQ</h1>
         <p className="text-[13px] text-muted-foreground mt-1">Verify your identity to continue</p>

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -11,7 +11,8 @@ import { useSSO } from '@/hooks/useSSO';
 import { useToast } from '@/hooks/use-toast';
 import { SSOProviderButtons } from '@/components/SSOProviderButtons';
 import { GoogleSignInButton } from '@/components/GoogleSignInButton';
-import { Building, ArrowRight, Shield, CalendarCheck } from 'lucide-react';
+import { Building, ArrowRight, Shield } from 'lucide-react';
+import { AppLogo } from '@/components/AppLogo';
 import { supabase } from '@/integrations/supabase/client';
 import { signInWithOAuthNative } from '@/utils/nativeRedirect';
 
@@ -161,7 +162,7 @@ const Auth = () => {
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">
           <div className="flex justify-center items-center gap-2 mb-2">
-            <CalendarCheck className="h-8 w-8 text-emerald-600" />
+            <AppLogo size={32} />
             <CardTitle className="text-2xl">EasyShiftHQ</CardTitle>
           </div>
           <CardDescription>

--- a/src/pages/ForgotPassword.tsx
+++ b/src/pages/ForgotPassword.tsx
@@ -6,7 +6,8 @@ import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useAuth } from '@/hooks/useAuth';
 import { useToast } from '@/hooks/use-toast';
-import { CalendarCheck, Mail, ArrowLeft, CheckCircle2 } from 'lucide-react';
+import { Mail, ArrowLeft, CheckCircle2 } from 'lucide-react';
+import { AppLogo } from '@/components/AppLogo';
 import { z } from 'zod';
 
 const emailSchema = z.string().email('Please enter a valid email address');
@@ -96,7 +97,7 @@ const ForgotPassword = () => {
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">
           <div className="flex justify-center items-center gap-2 mb-2">
-            <CalendarCheck className="h-8 w-8 text-emerald-600" />
+            <AppLogo size={32} />
             <CardTitle className="text-2xl">EasyShiftHQ</CardTitle>
           </div>
           <CardDescription>

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -6,7 +6,8 @@ import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useAuth } from '@/hooks/useAuth';
 import { useToast } from '@/hooks/use-toast';
-import { CalendarCheck, Lock, CheckCircle2 } from 'lucide-react';
+import { Lock, CheckCircle2 } from 'lucide-react';
+import { AppLogo } from '@/components/AppLogo';
 import { z } from 'zod';
 
 const passwordSchema = z.string()
@@ -141,7 +142,7 @@ const ResetPassword = () => {
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">
           <div className="flex justify-center items-center gap-2 mb-2">
-            <CalendarCheck className="h-8 w-8 text-emerald-600" />
+            <AppLogo size={32} />
             <CardTitle className="text-2xl">EasyShiftHQ</CardTitle>
           </div>
           <CardDescription>

--- a/supabase/functions/_shared/emailTemplates.ts
+++ b/supabase/functions/_shared/emailTemplates.ts
@@ -43,18 +43,11 @@ export const escapeHtml = (str: string): string => {
 /**
  * Generate the standard EasyShiftHQ email header with logo
  */
-const generateHeader = (): string => {
+export const generateHeader = (): string => {
   return `
     <div style="background: linear-gradient(135deg, #10b981 0%, #059669 100%); padding: 32px 24px; text-align: center; border-radius: 8px 8px 0 0;">
       <div style="display: inline-flex; align-items: center; justify-content: center; background-color: rgba(255, 255, 255, 0.95); border-radius: 12px; padding: 12px 20px; box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);">
-        <div style="background: linear-gradient(135deg, #10b981 0%, #059669 100%); border-radius: 8px; padding: 8px; display: inline-block; margin-right: 12px;">
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
-            <line x1="16" y1="2" x2="16" y2="6"></line>
-            <line x1="8" y1="2" x2="8" y2="6"></line>
-            <line x1="3" y1="10" x2="21" y2="10"></line>
-          </svg>
-        </div>
+        <img src="https://app.easyshifthq.com/icon-192.png" alt="EasyShiftHQ" width="40" height="40" style="display: block; border-radius: 8px; margin-right: 12px;" />
         <span style="font-size: 20px; font-weight: 700; color: #1f2937; letter-spacing: -0.5px;">EasyShiftHQ</span>
       </div>
     </div>
@@ -64,7 +57,7 @@ const generateHeader = (): string => {
 /**
  * Generate the standard EasyShiftHQ email footer
  */
-const generateFooter = (): string => {
+export const generateFooter = (): string => {
   const year = new Date().getFullYear();
   return `
     <div style="background-color: #f9fafb; padding: 24px 32px; border-radius: 0 0 8px 8px; border-top: 1px solid #e5e7eb;">
@@ -178,7 +171,7 @@ const generateCTA = (button: { text: string; url: string }): string => {
 /**
  * Generate a footer note (appears before the standard footer)
  */
-const generateFooterNote = (note: string): string => {
+export const generateFooterNote = (note: string): string => {
   const safeNote = escapeHtml(note);
   return `
     <p style="color: #6b7280; font-size: 14px; margin: 32px 0 0 0; line-height: 1.6;">

--- a/supabase/functions/notify-schedule-published/index.ts
+++ b/supabase/functions/notify-schedule-published/index.ts
@@ -1,3 +1,4 @@
+import { generateHeader } from '../_shared/emailTemplates.ts';
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { corsHeaders } from "../_shared/cors.ts";
@@ -126,20 +127,7 @@ serve(async (req) => {
           subject: `New Schedule Published: ${weekStartFormatted} - ${weekEndFormatted}`,
           html: `
             <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; max-width: 600px; margin: 0 auto; background-color: #ffffff;">
-              <!-- Header with Logo -->
-              <div style="background: linear-gradient(135deg, #10b981 0%, #059669 100%); padding: 32px 24px; text-align: center; border-radius: 8px 8px 0 0;">
-                <div style="display: inline-flex; align-items: center; justify-content: center; background-color: rgba(255, 255, 255, 0.95); border-radius: 12px; padding: 12px 20px; box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);">
-                  <div style="background: linear-gradient(135deg, #10b981 0%, #059669 100%); border-radius: 8px; padding: 8px; display: inline-block; margin-right: 12px;">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                      <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
-                      <line x1="16" y1="2" x2="16" y2="6"></line>
-                      <line x1="8" y1="2" x2="8" y2="6"></line>
-                      <line x1="3" y1="10" x2="21" y2="10"></line>
-                    </svg>
-                  </div>
-                  <span style="font-size: 20px; font-weight: 700; color: #1f2937; letter-spacing: -0.5px;">EasyShiftHQ</span>
-                </div>
-              </div>
+              ${generateHeader()}
               
               <!-- Content -->
               <div style="padding: 40px 32px; background-color: #ffffff;">

--- a/supabase/functions/send-shift-trade-notification/index.ts
+++ b/supabase/functions/send-shift-trade-notification/index.ts
@@ -1,3 +1,4 @@
+import { generateHeader } from '../_shared/emailTemplates.ts';
 import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
 import { createClient, type SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { Resend } from "https://esm.sh/resend@4.0.0";
@@ -164,21 +165,7 @@ const generateEmailHtml = (
 </head>
 <body style="margin: 0; padding: 0; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; background-color: #f3f4f6;">
   <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; max-width: 600px; margin: 0 auto; background-color: #ffffff;">
-    <!-- Header with Logo -->
-    <div style="background: linear-gradient(135deg, #10b981 0%, #059669 100%); padding: 32px 24px; text-align: center; border-radius: 8px 8px 0 0;">
-      <div style="display: inline-flex; align-items: center; justify-content: center; background-color: rgba(255, 255, 255, 0.95); border-radius: 12px; padding: 12px 20px; box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);">
-        <div style="background: linear-gradient(135deg, #10b981 0%, #059669 100%); border-radius: 8px; padding: 8px; display: inline-block; margin-right: 12px;">
-          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <polyline points="16 3 21 3 21 8"></polyline>
-            <line x1="4" y1="20" x2="21" y2="3"></line>
-            <polyline points="21 16 21 21 16 21"></polyline>
-            <line x1="15" y1="15" x2="21" y2="21"></line>
-            <line x1="4" y1="4" x2="9" y2="9"></line>
-          </svg>
-        </div>
-        <span style="font-size: 20px; font-weight: 700; color: #1f2937; letter-spacing: -0.5px;">EasyShiftHQ</span>
-      </div>
-    </div>
+    ${generateHeader()}
     
     <!-- Content -->
     <div style="padding: 40px 32px; background-color: #ffffff;">

--- a/supabase/functions/send-team-invitation/index.ts
+++ b/supabase/functions/send-team-invitation/index.ts
@@ -1,3 +1,4 @@
+import { generateHeader } from '../_shared/emailTemplates.ts';
 import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { Resend } from "https://esm.sh/resend@4.0.0";
@@ -175,18 +176,7 @@ const handler = async (req: Request): Promise<Response> => {
           : `You're invited to join ${restaurant.name}`,
         html: `
           <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; max-width: 600px; margin: 0 auto; background: #ffffff;">
-            <!-- Header with Logo -->
-            <div style="background: linear-gradient(135deg, #10b981 0%, #059669 100%); padding: 32px 24px; text-align: center; border-radius: 8px 8px 0 0;">
-              <div style="display: inline-flex; align-items: center; justify-content: center; background: rgba(255, 255, 255, 0.95); border-radius: 12px; padding: 12px 20px; box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);">
-                <div style="background: linear-gradient(135deg, #10b981 0%, #059669 100%); border-radius: 8px; padding: 8px; display: inline-block; margin-right: 12px;">
-                  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M9 11l3 3L22 4"></path>
-                    <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"></path>
-                  </svg>
-                </div>
-                <span style="font-size: 20px; font-weight: 700; color: #1f2937; letter-spacing: -0.5px;">EasyShiftHQ</span>
-              </div>
-            </div>
+            ${generateHeader()}
 
             <!-- Content -->
             <div style="padding: 40px 32px; background: #ffffff;">

--- a/supabase/functions/send-time-off-notification/index.ts
+++ b/supabase/functions/send-time-off-notification/index.ts
@@ -1,3 +1,4 @@
+import { generateHeader } from '../_shared/emailTemplates.ts';
 import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { Resend } from "https://esm.sh/resend@4.0.0";
@@ -211,20 +212,7 @@ const handler = async (req: Request): Promise<Response> => {
           subject: `${emailSubject} - ${restaurant.name}`,
           html: `
             <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; max-width: 600px; margin: 0 auto; background: #ffffff;">
-              <!-- Header with Logo -->
-              <div style="background: linear-gradient(135deg, #10b981 0%, #059669 100%); padding: 32px 24px; text-align: center; border-radius: 8px 8px 0 0;">
-                <div style="display: inline-flex; align-items: center; justify-content: center; background: rgba(255, 255, 255, 0.95); border-radius: 12px; padding: 12px 20px; box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);">
-                  <div style="background: linear-gradient(135deg, #10b981 0%, #059669 100%); border-radius: 8px; padding: 8px; display: inline-block; margin-right: 12px;">
-                    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                      <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
-                      <line x1="16" y1="2" x2="16" y2="6"></line>
-                      <line x1="8" y1="2" x2="8" y2="6"></line>
-                      <line x1="3" y1="10" x2="21" y2="10"></line>
-                    </svg>
-                  </div>
-                  <span style="font-size: 20px; font-weight: 700; color: #1f2937; letter-spacing: -0.5px;">EasyShiftHQ</span>
-                </div>
-              </div>
+              ${generateHeader()}
               
               <!-- Content -->
               <div style="padding: 40px 32px; background: #ffffff;">

--- a/supabase/functions/send-weekly-brief-email/index.ts
+++ b/supabase/functions/send-weekly-brief-email/index.ts
@@ -292,6 +292,9 @@ function buildEmailHtml(brief: BriefRow, restaurantName: string): string {
       <table width="600" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:12px;overflow:hidden;border:1px solid #e5e7eb;">
         <!-- Header -->
         <tr><td style="padding:24px 24px 16px;">
+          <div style="margin-bottom:8px;">
+            <img src="https://app.easyshifthq.com/icon-192.png" alt="EasyShiftHQ" width="32" height="32" style="display:block;border-radius:8px;" />
+          </div>
           <div style="font-size:11px;text-transform:uppercase;letter-spacing:0.05em;color:#6b7280;">Weekly Brief</div>
           <div style="font-size:17px;font-weight:600;color:#111827;margin-top:4px;">${restaurantName}</div>
           <div style="font-size:13px;color:#6b7280;margin-top:2px;">${formatWeekRange(brief.brief_week_end)}</div>

--- a/tests/unit/AppLogo.test.tsx
+++ b/tests/unit/AppLogo.test.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { AppLogo } from '@/components/AppLogo';
+
+describe('AppLogo', () => {
+  it('renders an img with the logo src', () => {
+    render(<AppLogo />);
+    const img = screen.getByAltText('EasyShiftHQ');
+    expect(img).toBeDefined();
+    expect(img.getAttribute('src')).toBe('/icon-192.png');
+  });
+
+  it('applies default size of 32px', () => {
+    render(<AppLogo />);
+    const img = screen.getByAltText('EasyShiftHQ');
+    expect(img.getAttribute('width')).toBe('32');
+    expect(img.getAttribute('height')).toBe('32');
+  });
+
+  it('accepts custom size', () => {
+    render(<AppLogo size={64} />);
+    const img = screen.getByAltText('EasyShiftHQ');
+    expect(img.getAttribute('width')).toBe('64');
+    expect(img.getAttribute('height')).toBe('64');
+  });
+
+  it('accepts custom className', () => {
+    render(<AppLogo className="my-custom-class" />);
+    const img = screen.getByAltText('EasyShiftHQ');
+    expect(img.className).toContain('my-custom-class');
+  });
+});


### PR DESCRIPTION
## Summary
- Replace generic Lucide icons (CalendarCheck, ShieldCheck) with the actual branded EasyShiftHQ logo (`/icon-192.png`) across all frontend branding locations
- Replace inline SVG logos in email templates with hosted `<img>` tag pointing to `https://app.easyshifthq.com/icon-192.png`
- Consolidate 4 duplicated email headers into the shared `generateHeader()` helper (DRY)
- Add branded logo to the weekly brief email (previously had none)

## Changes

### New
- `src/components/AppLogo.tsx` — Reusable logo component with configurable size
- `tests/unit/AppLogo.test.tsx` — 4 unit tests

### Frontend (5 files)
- Auth page, ForgotPassword, ResetPassword — CalendarCheck → AppLogo
- Sidebar header — emerald gradient wrapper + CalendarCheck → AppLogo
- Biometric lock screen — ShieldCheck → AppLogo

### Email templates (6 files)
- `_shared/emailTemplates.ts` — SVG → `<img>` tag, exported `generateHeader`/`generateFooter`
- 4 edge functions migrated from inline header HTML to shared `generateHeader()`
- Weekly brief email — added logo to compact header

## Design doc
`docs/plans/2026-04-08-branded-logo-everywhere-plan.md`

## Test plan
- [x] `npm run typecheck` — 0 errors
- [x] `npm run build` — passes
- [x] `npm run test` — 200 files, 3267 tests pass
- [ ] Visual check: auth pages show branded logo
- [ ] Visual check: sidebar shows branded logo
- [ ] Email preview shows branded logo (send test notification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)