### PR TITLE
fix: geofence clock-in warning requires acknowledgment

### DIFF
--- a/src/hooks/useGeofenceCheck.ts
+++ b/src/hooks/useGeofenceCheck.ts
@@ -13,6 +13,7 @@ interface GeofenceResult {
   distanceMeters?: number;
   userLat?: number;
   userLng?: number;
+  locationUnavailable?: boolean;
 }
 
 /** Pure, testable geofence evaluation */
@@ -70,7 +71,7 @@ export function useGeofenceCheck(restaurant: {
 
       return evaluateGeofence(enforcement, lat, lng, radius, pos.coords.latitude, pos.coords.longitude);
     } catch {
-      return { action: 'allow', checked: false };
+      return { action: 'allow', checked: false, locationUnavailable: true };
     } finally {
       setChecking(false);
     }

--- a/src/pages/EmployeeClock.tsx
+++ b/src/pages/EmployeeClock.tsx
@@ -5,9 +5,10 @@ import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { AlertDialog, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from '@/components/ui/alert-dialog';
 import { useRestaurantContext } from '@/contexts/RestaurantContext';
 import { useCurrentEmployee, useEmployeePunchStatus, useCreateTimePunch, useTimePunches } from '@/hooks/useTimePunches';
-import { Clock, LogIn, LogOut, Coffee, PlayCircle, AlertCircle, Camera, MapPin, Shield, CheckCircle } from 'lucide-react';
+import { Clock, LogIn, LogOut, Coffee, PlayCircle, AlertCircle, Camera, MapPin, MapPinOff, Shield, CheckCircle } from 'lucide-react';
 import { format } from 'date-fns';
 import { useToast } from '@/hooks/use-toast';
 import { collectPunchContext, mergePunchLocation } from '@/utils/punchContext';
@@ -22,6 +23,11 @@ const EmployeeClock = () => {
   const [capturedPhoto, setCapturedPhoto] = useState<string | null>(null);
   const [pendingPunchType, setPendingPunchType] = useState<'clock_in' | 'clock_out' | 'break_start' | 'break_end' | null>(null);
   const [pendingGeofenceResult, setPendingGeofenceResult] = useState<{ distanceMeters?: number; within?: boolean } | undefined>(undefined);
+  const [geofenceWarning, setGeofenceWarning] = useState<{
+    type: 'outside' | 'unavailable';
+    distanceMeters?: number;
+  } | null>(null);
+  const [pendingLocationUnavailable, setPendingLocationUnavailable] = useState(false);
   const videoRef = useRef<HTMLVideoElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const { toast } = useToast();
@@ -105,6 +111,7 @@ const EmployeeClock = () => {
     // Run geofence check before allowing clock-in
     if (punchType === 'clock_in') {
       const geofenceResult = await checkLocation();
+
       if (geofenceResult.action === 'block') {
         toast({
           title: 'Location Required',
@@ -113,16 +120,30 @@ const EmployeeClock = () => {
         });
         return;
       }
+
       if (geofenceResult.action === 'warn') {
-        toast({
-          title: 'Location Warning',
-          description: 'You appear to be away from the restaurant.',
-          variant: 'default',
-        });
+        // Show confirmation dialog instead of toast
+        setPendingPunchType(punchType);
+        setPendingGeofenceResult(geofenceResult.checked ? { distanceMeters: geofenceResult.distanceMeters, within: geofenceResult.within } : undefined);
+        setPendingLocationUnavailable(false);
+        setGeofenceWarning({ type: 'outside', distanceMeters: geofenceResult.distanceMeters });
+        return;
       }
+
+      if (geofenceResult.locationUnavailable) {
+        // Show location unavailable dialog
+        setPendingPunchType(punchType);
+        setPendingGeofenceResult(undefined);
+        setPendingLocationUnavailable(true);
+        setGeofenceWarning({ type: 'unavailable' });
+        return;
+      }
+
       setPendingGeofenceResult(geofenceResult.checked ? { distanceMeters: geofenceResult.distanceMeters, within: geofenceResult.within } : undefined);
+      setPendingLocationUnavailable(false);
     } else {
       setPendingGeofenceResult(undefined);
+      setPendingLocationUnavailable(false);
     }
 
     setPendingPunchType(punchType);
@@ -130,6 +151,20 @@ const EmployeeClock = () => {
     setCapturedPhoto(null);
     // Start camera automatically
     setTimeout(startCamera, 100);
+  };
+
+  const handleProceedAfterWarning = () => {
+    setGeofenceWarning(null);
+    setShowCameraDialog(true);
+    setCapturedPhoto(null);
+    setTimeout(startCamera, 100);
+  };
+
+  const handleCancelWarning = () => {
+    setGeofenceWarning(null);
+    setPendingPunchType(null);
+    setPendingGeofenceResult(undefined);
+    setPendingLocationUnavailable(false);
   };
 
   const handleConfirmPunch = async () => {
@@ -140,10 +175,12 @@ const EmployeeClock = () => {
     const photoToProcess = capturedPhoto;
     const punchType = pendingPunchType;
     const geofenceResult = pendingGeofenceResult;
+    const locationUnavailable = pendingLocationUnavailable;
 
     setPendingPunchType(null);
     setCapturedPhoto(null);
     setPendingGeofenceResult(undefined);
+    setPendingLocationUnavailable(false);
     if (cameraStream) {
       cameraStream.getTracks().forEach(track => track.stop());
       setCameraStream(null);
@@ -172,7 +209,7 @@ const EmployeeClock = () => {
         employee_id: employee.id,
         punch_type: punchType,
         punch_time: new Date().toISOString(),
-        location: mergePunchLocation(context?.location, geofenceResult),
+        location: mergePunchLocation(context?.location, geofenceResult, locationUnavailable),
         device_info: context?.device_info,
         photoBlob,
       });
@@ -526,6 +563,46 @@ const EmployeeClock = () => {
           </div>
         </DialogContent>
       </Dialog>
+
+      {/* Geofence Warning Dialog */}
+      <AlertDialog open={geofenceWarning !== null} onOpenChange={(open) => {
+        if (!open) handleCancelWarning();
+      }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <div className="flex items-center gap-3">
+              <div className="h-10 w-10 rounded-xl bg-amber-500/10 flex items-center justify-center">
+                {geofenceWarning?.type === 'unavailable'
+                  ? <MapPinOff className="h-5 w-5 text-amber-600" />
+                  : <MapPin className="h-5 w-5 text-amber-600" />
+                }
+              </div>
+              <div>
+                <AlertDialogTitle className="text-[17px] font-semibold">
+                  {geofenceWarning?.type === 'unavailable' ? 'Location Unavailable' : 'Location Warning'}
+                </AlertDialogTitle>
+              </div>
+            </div>
+          </AlertDialogHeader>
+          <AlertDialogDescription className="text-[14px] text-muted-foreground">
+            {geofenceWarning?.type === 'unavailable'
+              ? "We couldn't verify your location. You can still clock in, but this will be flagged for manager review."
+              : `You appear to be ${geofenceWarning?.distanceMeters ?? '?'} meters from the restaurant. Do you want to continue clocking in?`
+            }
+          </AlertDialogDescription>
+          <AlertDialogFooter>
+            <Button variant="outline" onClick={handleCancelWarning}>
+              Cancel
+            </Button>
+            <Button
+              className="bg-amber-600 hover:bg-amber-700 text-white"
+              onClick={handleProceedAfterWarning}
+            >
+              Continue Anyway
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 };

--- a/src/pages/EmployeeClock.tsx
+++ b/src/pages/EmployeeClock.tsx
@@ -587,15 +587,16 @@ const EmployeeClock = () => {
           <AlertDialogDescription className="text-[14px] text-muted-foreground">
             {geofenceWarning?.type === 'unavailable'
               ? "We couldn't verify your location. You can still clock in, but this will be flagged for manager review."
-              : `You appear to be ${geofenceWarning?.distanceMeters ?? '?'} meters from the restaurant. Do you want to continue clocking in?`
+              : `You appear to be about ${geofenceWarning?.distanceMeters != null ? (geofenceWarning.distanceMeters >= 1000 ? `${(geofenceWarning.distanceMeters / 1000).toFixed(1)} km` : `${Math.round(geofenceWarning.distanceMeters / 10) * 10} meters`) : 'some distance'} from the restaurant. Do you want to continue clocking in?`
             }
           </AlertDialogDescription>
           <AlertDialogFooter>
-            <Button variant="outline" onClick={handleCancelWarning}>
+            <Button variant="outline" className="h-9 px-4 rounded-lg text-[13px] font-medium" onClick={handleCancelWarning}>
               Cancel
             </Button>
             <Button
-              className="bg-amber-600 hover:bg-amber-700 text-white"
+              variant="destructive"
+              className="h-9 px-4 rounded-lg text-[13px] font-medium"
               onClick={handleProceedAfterWarning}
             >
               Continue Anyway

--- a/src/pages/TimePunchesManager.tsx
+++ b/src/pages/TimePunchesManager.tsx
@@ -13,11 +13,12 @@ import { useRestaurantContext } from '@/contexts/RestaurantContext';
 import { useTimePunches, useDeleteTimePunch, useUpdateTimePunch, useCreateTimePunch } from '@/hooks/useTimePunches';
 import { useEmployees } from '@/hooks/useEmployees';
 import { supabase } from '@/integrations/supabase/client';
-import { 
-  Trash2, Edit, Download, Search, Camera, MapPin, Eye,
+import {
+  Trash2, Edit, Download, Search, Camera, MapPin, MapPinOff, Eye,
   ChevronLeft, ChevronRight, ChevronDown, ChevronUp, Table as TableIcon,
   LayoutGrid, List, Code, KeyRound, PenLine, Settings2
 } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { 
   format, startOfWeek, endOfWeek, startOfMonth, endOfMonth, 
   addDays, addWeeks, addMonths, isSameDay, differenceInMinutes,
@@ -805,9 +806,37 @@ const TimePunchesManager = () => {
                             </Badge>
                           )}
                           {punch.location && (
-                            <Badge variant="outline" className="text-xs bg-blue-500/10 text-blue-700 dark:text-blue-400 border-blue-500/20">
-                              <MapPin className="h-3 w-3" />
-                            </Badge>
+                            punch.location.location_unavailable ? (
+                              <TooltipProvider>
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <Badge variant="outline" className="text-xs bg-gray-500/10 text-gray-600 dark:text-gray-400 border-gray-500/20">
+                                      <MapPinOff className="h-3 w-3" />
+                                    </Badge>
+                                  </TooltipTrigger>
+                                  <TooltipContent>
+                                    <p>Location was unavailable at clock-in</p>
+                                  </TooltipContent>
+                                </Tooltip>
+                              </TooltipProvider>
+                            ) : punch.location.within_geofence === false ? (
+                              <TooltipProvider>
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <Badge variant="outline" className="text-xs bg-amber-500/10 text-amber-700 dark:text-amber-400 border-amber-500/20">
+                                      <MapPin className="h-3 w-3" />
+                                    </Badge>
+                                  </TooltipTrigger>
+                                  <TooltipContent>
+                                    <p>Clocked in {punch.location.distance_meters}m from restaurant</p>
+                                  </TooltipContent>
+                                </Tooltip>
+                              </TooltipProvider>
+                            ) : (
+                              <Badge variant="outline" className="text-xs bg-blue-500/10 text-blue-700 dark:text-blue-400 border-blue-500/20">
+                                <MapPin className="h-3 w-3" />
+                              </Badge>
+                            )
                           )}
                         </div>
                       </div>
@@ -1078,25 +1107,38 @@ const TimePunchesManager = () => {
               )}
 
               {viewingPunch.location && (
-                <div>
-                  <div className="text-sm font-medium mb-2 flex items-center gap-2">
-                    <MapPin className="h-4 w-4" />
-                    Location
-                  </div>
-                  <div className="p-4 rounded-lg border bg-muted/50 space-y-2">
-                    <div className="text-sm font-mono">
-                      {viewingPunch.location.latitude.toFixed(6)}, {viewingPunch.location.longitude.toFixed(6)}
-                    </div>
-                    <a
-                      href={`https://www.google.com/maps?q=${viewingPunch.location.latitude},${viewingPunch.location.longitude}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-primary hover:underline text-sm inline-flex items-center gap-1"
-                    >
-                      <MapPin className="h-3 w-3" />
-                      View on Google Maps
-                    </a>
-                  </div>
+                <div className="space-y-1">
+                  <p className="text-sm font-medium">Location</p>
+                  {viewingPunch.location.location_unavailable ? (
+                    <p className="text-sm text-muted-foreground flex items-center gap-1">
+                      <MapPinOff className="h-3.5 w-3.5 text-gray-500" />
+                      Location was unavailable
+                    </p>
+                  ) : (
+                    <>
+                      {viewingPunch.location.latitude != null && viewingPunch.location.longitude != null && (
+                        <>
+                          <p className="text-sm text-muted-foreground">
+                            {viewingPunch.location.latitude.toFixed(6)}, {viewingPunch.location.longitude.toFixed(6)}
+                          </p>
+                          <a
+                            href={`https://www.google.com/maps?q=${viewingPunch.location.latitude},${viewingPunch.location.longitude}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-xs text-primary hover:underline"
+                          >
+                            View on map
+                          </a>
+                        </>
+                      )}
+                      {viewingPunch.location.within_geofence === false && (
+                        <p className="text-sm text-amber-600 flex items-center gap-1">
+                          <MapPin className="h-3.5 w-3.5" />
+                          {viewingPunch.location.distance_meters}m from restaurant
+                        </p>
+                      )}
+                    </>
+                  )}
                 </div>
               )}
 

--- a/src/pages/TimePunchesManager.tsx
+++ b/src/pages/TimePunchesManager.tsx
@@ -506,7 +506,9 @@ const TimePunchesManager = () => {
         format(punchDate, 'yyyy-MM-dd'),
         format(punchDate, 'HH:mm:ss'),
         punch.notes?.replace(/"/g, '""') || '',
-        punch.location ? `${punch.location.latitude},${punch.location.longitude}` : '',
+        punch.location?.latitude != null && punch.location?.longitude != null
+          ? `${punch.location.latitude},${punch.location.longitude}`
+          : punch.location?.location_unavailable ? 'unavailable' : '',
       ];
     });
 
@@ -828,7 +830,7 @@ const TimePunchesManager = () => {
                                     </Badge>
                                   </TooltipTrigger>
                                   <TooltipContent>
-                                    <p>Clocked in {punch.location.distance_meters}m from restaurant</p>
+                                    <p>Clocked in {punch.location.distance_meters ?? '?'}m from restaurant</p>
                                   </TooltipContent>
                                 </Tooltip>
                               </TooltipProvider>
@@ -1134,7 +1136,7 @@ const TimePunchesManager = () => {
                       {viewingPunch.location.within_geofence === false && (
                         <p className="text-sm text-amber-600 flex items-center gap-1">
                           <MapPin className="h-3.5 w-3.5" />
-                          {viewingPunch.location.distance_meters}m from restaurant
+                          {viewingPunch.location.distance_meters ?? '?'}m from restaurant
                         </p>
                       )}
                     </>

--- a/src/types/timeTracking.ts
+++ b/src/types/timeTracking.ts
@@ -6,8 +6,11 @@ export interface TimePunch {
   punch_type: 'clock_in' | 'clock_out' | 'break_start' | 'break_end';
   punch_time: string;
   location?: {
-    latitude: number;
-    longitude: number;
+    latitude?: number;
+    longitude?: number;
+    distance_meters?: number;
+    within_geofence?: boolean;
+    location_unavailable?: boolean;
   };
   device_info?: string;
   photo_path?: string; // Storage path in time-clock-photos bucket (e.g., restaurant_id/employee_id/punch-timestamp.jpg)

--- a/src/utils/punchContext.ts
+++ b/src/utils/punchContext.ts
@@ -1,21 +1,24 @@
 export interface PunchLocation {
-  latitude: number;
-  longitude: number;
+  latitude?: number;
+  longitude?: number;
   distance_meters?: number;
   within_geofence?: boolean;
+  location_unavailable?: boolean;
 }
 
 export function mergePunchLocation(
   baseLocation: { latitude: number; longitude: number } | undefined,
-  geofenceResult?: { distanceMeters?: number; within?: boolean }
+  geofenceResult?: { distanceMeters?: number; within?: boolean },
+  locationUnavailable?: boolean
 ): PunchLocation | undefined {
-  if (!baseLocation) return undefined;
+  if (!baseLocation && !locationUnavailable) return undefined;
   return {
     ...baseLocation,
     ...(geofenceResult?.distanceMeters != null && {
       distance_meters: geofenceResult.distanceMeters,
       within_geofence: geofenceResult.within,
     }),
+    ...(locationUnavailable && { location_unavailable: true }),
   };
 }
 

--- a/src/utils/punchContext.ts
+++ b/src/utils/punchContext.ts
@@ -30,7 +30,7 @@ export function getDeviceInfo(maxLength = DEFAULT_DEVICE_INFO_MAX): string {
   return navigator.userAgent.substring(0, maxLength);
 }
 
-export function getQuickLocation(timeoutMs = DEFAULT_LOCATION_TIMEOUT): Promise<PunchLocation | undefined> {
+export function getQuickLocation(timeoutMs = DEFAULT_LOCATION_TIMEOUT): Promise<{ latitude: number; longitude: number } | undefined> {
   if (typeof navigator === 'undefined' || !navigator.geolocation) {
     return Promise.resolve(undefined);
   }

--- a/tests/unit/punchContext.test.ts
+++ b/tests/unit/punchContext.test.ts
@@ -50,6 +50,39 @@ describe('mergePunchLocation', () => {
     expect(result?.latitude).toBe(0);
     expect(result?.longitude).toBe(0);
   });
+
+  it('returns location_unavailable when locationUnavailable flag is set', () => {
+    const result = mergePunchLocation(undefined, undefined, true);
+    expect(result).toEqual({ location_unavailable: true });
+  });
+
+  it('includes location_unavailable alongside coordinates when both exist', () => {
+    const result = mergePunchLocation(
+      { latitude: 40.7, longitude: -74.0 },
+      undefined,
+      true
+    );
+    expect(result).toEqual({
+      latitude: 40.7,
+      longitude: -74.0,
+      location_unavailable: true,
+    });
+  });
+
+  it('does not include location_unavailable when flag is false', () => {
+    const result = mergePunchLocation(
+      { latitude: 40.7, longitude: -74.0 },
+      { distanceMeters: 50, within: true },
+      false
+    );
+    expect(result).toEqual({
+      latitude: 40.7,
+      longitude: -74.0,
+      distance_meters: 50,
+      within_geofence: true,
+    });
+    expect(result).not.toHaveProperty('location_unavailable');
+  });
 });
 
 describe('getDeviceInfo', () => {

--- a/tests/unit/useGeofenceCheck.test.ts
+++ b/tests/unit/useGeofenceCheck.test.ts
@@ -216,6 +216,110 @@ describe('useGeofenceCheck hook – web geolocation', () => {
     expect(geofenceResult?.action).toBe('allow');
     expect(geofenceResult?.checked).toBe(false);
     expect(result.current.checking).toBe(false);
+    expect(geofenceResult?.locationUnavailable).toBe(true);
+  });
+
+  it('returns locationUnavailable=true when geolocation throws and enforcement is warn', async () => {
+    Object.defineProperty(globalThis.navigator, 'geolocation', {
+      configurable: true,
+      value: {
+        getCurrentPosition: vi.fn().mockImplementation((_res, reject) => {
+          reject(new Error('permission denied'));
+        }),
+      },
+    });
+
+    const restaurant = {
+      latitude: 40.7128,
+      longitude: -74.006,
+      geofence_radius_meters: 200,
+      geofence_enforcement: 'warn' as const,
+    };
+
+    const { result } = renderHook(() => useGeofenceCheck(restaurant));
+    let geofenceResult: Awaited<ReturnType<typeof result.current.checkLocation>> | undefined;
+
+    await act(async () => {
+      geofenceResult = await result.current.checkLocation();
+    });
+
+    expect(geofenceResult?.action).toBe('allow');
+    expect(geofenceResult?.checked).toBe(false);
+    expect(geofenceResult?.locationUnavailable).toBe(true);
+  });
+
+  it('returns locationUnavailable=true when geolocation throws and enforcement is block', async () => {
+    Object.defineProperty(globalThis.navigator, 'geolocation', {
+      configurable: true,
+      value: {
+        getCurrentPosition: vi.fn().mockImplementation((_res, reject) => {
+          reject(new Error('location services disabled'));
+        }),
+      },
+    });
+
+    const restaurant = {
+      latitude: 40.7128,
+      longitude: -74.006,
+      geofence_radius_meters: 200,
+      geofence_enforcement: 'block' as const,
+    };
+
+    const { result } = renderHook(() => useGeofenceCheck(restaurant));
+    let geofenceResult: Awaited<ReturnType<typeof result.current.checkLocation>> | undefined;
+
+    await act(async () => {
+      geofenceResult = await result.current.checkLocation();
+    });
+
+    expect(geofenceResult?.action).toBe('allow');
+    expect(geofenceResult?.checked).toBe(false);
+    expect(geofenceResult?.locationUnavailable).toBe(true);
+  });
+
+  it('does NOT set locationUnavailable when enforcement is off', async () => {
+    const restaurant = {
+      latitude: 40.7128,
+      longitude: -74.006,
+      geofence_radius_meters: 200,
+      geofence_enforcement: 'off' as const,
+    };
+
+    const { result } = renderHook(() => useGeofenceCheck(restaurant));
+    let geofenceResult: Awaited<ReturnType<typeof result.current.checkLocation>> | undefined;
+
+    await act(async () => {
+      geofenceResult = await result.current.checkLocation();
+    });
+
+    expect(geofenceResult?.locationUnavailable).toBeUndefined();
+  });
+
+  it('does NOT set locationUnavailable when geolocation succeeds', async () => {
+    Object.defineProperty(globalThis.navigator, 'geolocation', {
+      configurable: true,
+      value: {
+        getCurrentPosition: vi.fn().mockImplementation((resolve) => {
+          resolve({ coords: { latitude: 40.7129, longitude: -74.0061 } });
+        }),
+      },
+    });
+
+    const restaurant = {
+      latitude: 40.7128,
+      longitude: -74.006,
+      geofence_radius_meters: 500,
+      geofence_enforcement: 'warn' as const,
+    };
+
+    const { result } = renderHook(() => useGeofenceCheck(restaurant));
+    let geofenceResult: Awaited<ReturnType<typeof result.current.checkLocation>> | undefined;
+
+    await act(async () => {
+      geofenceResult = await result.current.checkLocation();
+    });
+
+    expect(geofenceResult?.locationUnavailable).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary
- **Geofence "warn" mode** now shows a confirmation dialog (AlertDialog) instead of a transient toast, requiring the employee to explicitly click "Continue Anyway" or "Cancel" before proceeding to clock in
- **Location permission denied/unavailable** now shows a warning dialog instead of silently allowing — the punch is flagged with `location_unavailable: true` in the JSONB for manager review
- **Manager visibility** — Time Punches list shows amber badges for outside-geofence punches and gray badges for location-unavailable punches, with tooltips showing details

## Changes
- `src/hooks/useGeofenceCheck.ts` — Added `locationUnavailable` flag to `GeofenceResult` when geolocation fails
- `src/utils/punchContext.ts` — Extended `PunchLocation` with `location_unavailable` field, updated `mergePunchLocation`
- `src/pages/EmployeeClock.tsx` — Replaced toast with AlertDialog for warn + location-unavailable cases
- `src/pages/TimePunchesManager.tsx` — Added geofence flag badges with tooltips
- `src/types/timeTracking.ts` — Updated `TimePunch.location` type to include geofence fields

## Test plan
- [x] 4 new unit tests for `useGeofenceCheck` — locationUnavailable flag behavior
- [x] 3 new unit tests for `mergePunchLocation` — location_unavailable field handling
- [x] All 3270 existing tests pass
- [x] TypeScript typecheck clean
- [x] Production build succeeds
- [ ] Verify in production: configure geofence with "warn" mode, clock in from outside radius, confirm dialog appears
- [ ] Verify in production: deny location permission, confirm "Location Unavailable" dialog appears
- [ ] Verify in production: manager sees amber/gray badges on flagged punches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit "Location Unavailable" handling and dialog during clock‑in, letting users confirm and proceed when location cannot be obtained.
  * Confirmation dialog for geofence warnings now defers clock‑in until user confirmation.
  * CSV export and verification views now show "unavailable" when coordinates are missing.

* **Bug Fixes**
  * Improved location status indicators and distance/context messaging for out‑of‑geofence punches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->