### PR TITLE
feat: allow deleting published shifts with warning

### DIFF
--- a/src/components/scheduling/RecurringShiftActionDialog.tsx
+++ b/src/components/scheduling/RecurringShiftActionDialog.tsx
@@ -119,22 +119,13 @@ export function RecurringShiftActionDialog({
         </AlertDialogHeader>
 
         <div className="py-4">
-          {lockedCount > 0 && isDelete && (
+          {lockedCount > 0 && (
             <Alert variant="default" className="mb-4 border-warning/50 bg-warning/10">
               <AlertTriangle className="h-4 w-4 text-warning" />
               <AlertDescription className="text-sm">
-                {lockedCount} shift{lockedCount > 1 ? 's have' : ' has'} been published and
-                employees may have already seen {lockedCount > 1 ? 'them' : 'it'}.
-                {lockedCount > 1 ? ' They' : ' It'} will also be deleted.
-              </AlertDescription>
-            </Alert>
-          )}
-          {lockedCount > 0 && !isDelete && (
-            <Alert variant="default" className="mb-4 border-warning/50 bg-warning/10">
-              <AlertTriangle className="h-4 w-4 text-warning" />
-              <AlertDescription className="text-sm">
-                {lockedCount} shift{lockedCount > 1 ? 's are' : ' is'} part of a published schedule
-                and will not be modified.
+                {isDelete
+                  ? `${lockedCount} shift${lockedCount > 1 ? 's have' : ' has'} been published and employees may have already seen ${lockedCount > 1 ? 'them' : 'it'}. ${lockedCount > 1 ? 'They' : 'It'} will also be deleted.`
+                  : `${lockedCount} shift${lockedCount > 1 ? 's are' : ' is'} part of a published schedule and will not be modified.`}
               </AlertDescription>
             </Alert>
           )}

--- a/src/components/scheduling/RecurringShiftActionDialog.tsx
+++ b/src/components/scheduling/RecurringShiftActionDialog.tsx
@@ -42,6 +42,18 @@ interface ScopeOptionProps {
   seriesCount: number;
 }
 
+function getLockedWarning(lockedCount: number, isDelete: boolean): string {
+  const plural = lockedCount > 1;
+  if (isDelete) {
+    const subject = plural ? `${lockedCount} shifts have` : `${lockedCount} shift has`;
+    const pronoun = plural ? 'them' : 'it';
+    const they = plural ? 'They' : 'It';
+    return `${subject} been published and employees may have already seen ${pronoun}. ${they} will also be deleted.`;
+  }
+  const verb = plural ? `${lockedCount} shifts are` : `${lockedCount} shift is`;
+  return `${verb} part of a published schedule and will not be modified.`;
+}
+
 function ScopeOption({ value, label, shift, seriesCount }: ScopeOptionProps): React.ReactElement {
   const id = `scope-${value}`;
 
@@ -123,9 +135,7 @@ export function RecurringShiftActionDialog({
             <Alert variant="default" className="mb-4 border-warning/50 bg-warning/10">
               <AlertTriangle className="h-4 w-4 text-warning" />
               <AlertDescription className="text-sm">
-                {isDelete
-                  ? `${lockedCount} shift${lockedCount > 1 ? 's have' : ' has'} been published and employees may have already seen ${lockedCount > 1 ? 'them' : 'it'}. ${lockedCount > 1 ? 'They' : 'It'} will also be deleted.`
-                  : `${lockedCount} shift${lockedCount > 1 ? 's are' : ' is'} part of a published schedule and will not be modified.`}
+                {getLockedWarning(lockedCount, isDelete)}
               </AlertDescription>
             </Alert>
           )}

--- a/src/components/scheduling/RecurringShiftActionDialog.tsx
+++ b/src/components/scheduling/RecurringShiftActionDialog.tsx
@@ -119,12 +119,22 @@ export function RecurringShiftActionDialog({
         </AlertDialogHeader>
 
         <div className="py-4">
-          {lockedCount > 0 && (
+          {lockedCount > 0 && isDelete && (
+            <Alert variant="default" className="mb-4 border-warning/50 bg-warning/10">
+              <AlertTriangle className="h-4 w-4 text-warning" />
+              <AlertDescription className="text-sm">
+                {lockedCount} shift{lockedCount > 1 ? 's have' : ' has'} been published and
+                employees may have already seen {lockedCount > 1 ? 'them' : 'it'}.
+                {lockedCount > 1 ? ' They' : ' It'} will also be deleted.
+              </AlertDescription>
+            </Alert>
+          )}
+          {lockedCount > 0 && !isDelete && (
             <Alert variant="default" className="mb-4 border-warning/50 bg-warning/10">
               <AlertTriangle className="h-4 w-4 text-warning" />
               <AlertDescription className="text-sm">
                 {lockedCount} shift{lockedCount > 1 ? 's are' : ' is'} part of a published schedule
-                and will not be {isDelete ? 'deleted' : 'modified'}.
+                and will not be modified.
               </AlertDescription>
             </Alert>
           )}

--- a/src/hooks/useBulkShiftActions.ts
+++ b/src/hooks/useBulkShiftActions.ts
@@ -45,22 +45,24 @@ export function useBulkShiftActions(restaurantId: string) {
 
   const bulkDelete = useCallback(
     async (shiftIds: string[]): Promise<BulkDeleteResult> => {
-      const { error } = await supabase
+      const { error, count } = await supabase
         .from('shifts')
-        .delete()
+        .delete({ count: 'exact' })
         .in('id', shiftIds)
         .eq('restaurant_id', restaurantId);
 
       if (error) throw error;
 
+      const deletedCount = count ?? shiftIds.length;
+
       queryClient.invalidateQueries({ queryKey: ['shifts', restaurantId] });
 
       toast({
         title: 'Shifts deleted',
-        description: `${shiftIds.length} ${shiftIds.length === 1 ? 'shift' : 'shifts'} deleted.`,
+        description: `${deletedCount} ${deletedCount === 1 ? 'shift' : 'shifts'} deleted.`,
       });
 
-      return { deletedCount: shiftIds.length, lockedCount: 0 };
+      return { deletedCount, lockedCount: 0 };
     },
     [restaurantId, queryClient, toast],
   );

--- a/src/hooks/useBulkShiftActions.ts
+++ b/src/hooks/useBulkShiftActions.ts
@@ -57,7 +57,7 @@ export function useBulkShiftActions(restaurantId: string) {
 
       toast({
         title: 'Shifts deleted',
-        description: `${shiftIds.length} shift${shiftIds.length !== 1 ? 's' : ''} deleted.`,
+        description: `${shiftIds.length} ${shiftIds.length === 1 ? 'shift' : 'shifts'} deleted.`,
       });
 
       return { deletedCount: shiftIds.length, lockedCount: 0 };

--- a/src/hooks/useBulkShiftActions.ts
+++ b/src/hooks/useBulkShiftActions.ts
@@ -45,34 +45,22 @@ export function useBulkShiftActions(restaurantId: string) {
 
   const bulkDelete = useCallback(
     async (shiftIds: string[]): Promise<BulkDeleteResult> => {
-      const { unlockedIds, lockedCount } = await partitionByLocked(shiftIds, restaurantId);
-
-      if (unlockedIds.length === 0) {
-        toast({
-          title: 'No shifts deleted',
-          description: buildShiftChangeDescription(0, lockedCount, 'deleted'),
-        });
-        return { deletedCount: 0, lockedCount };
-      }
-
       const { error } = await supabase
         .from('shifts')
         .delete()
-        .in('id', unlockedIds)
-        .eq('locked', false);
+        .in('id', shiftIds)
+        .eq('restaurant_id', restaurantId);
 
       if (error) throw error;
-
-      const deletedCount = unlockedIds.length;
 
       queryClient.invalidateQueries({ queryKey: ['shifts', restaurantId] });
 
       toast({
         title: 'Shifts deleted',
-        description: buildShiftChangeDescription(deletedCount, lockedCount, 'deleted'),
+        description: `${shiftIds.length} shift${shiftIds.length !== 1 ? 's' : ''} deleted.`,
       });
 
-      return { deletedCount, lockedCount };
+      return { deletedCount: shiftIds.length, lockedCount: 0 };
     },
     [restaurantId, queryClient, toast],
   );

--- a/src/hooks/useShifts.tsx
+++ b/src/hooks/useShifts.tsx
@@ -239,8 +239,6 @@ export function useDeleteShift() {
 
   return useMutation({
     mutationFn: async ({ id, restaurantId }: { id: string; restaurantId: string }) => {
-      await assertShiftNotLocked(id);
-
       const { error } = await supabase.from('shifts').delete().eq('id', id);
 
       if (error) throw error;
@@ -267,6 +265,7 @@ interface SeriesOperationParams {
   shift: Shift;
   scope: RecurringActionScope;
   restaurantId: string;
+  includePublished?: boolean;
 }
 
 interface SeriesOperationResult {
@@ -287,12 +286,8 @@ export function useDeleteShiftSeries() {
   const { toast } = useToast();
 
   return useMutation({
-    mutationFn: async ({ shift, scope, restaurantId }: SeriesOperationParams): Promise<SeriesOperationResult> => {
+    mutationFn: async ({ shift, scope, restaurantId, includePublished }: SeriesOperationParams): Promise<SeriesOperationResult> => {
       if (scope === 'this') {
-        if (shift.locked) {
-          throw new Error('Cannot delete a locked shift. The schedule has been published.');
-        }
-
         const { error } = await supabase
           .from('shifts')
           .delete()
@@ -309,6 +304,7 @@ export function useDeleteShiftSeries() {
         p_restaurant_id: restaurantId,
         p_scope: scope,
         p_from_time: scope === 'following' ? shift.start_time : null,
+        p_include_locked: includePublished ?? false,
       });
 
       if (error) throw error;
@@ -320,7 +316,7 @@ export function useDeleteShiftSeries() {
         restaurantId,
       };
     },
-    onMutate: async ({ shift, scope, restaurantId }) => {
+    onMutate: async ({ shift, scope, restaurantId, includePublished }) => {
       await queryClient.cancelQueries({ queryKey: ['shifts', restaurantId] });
 
       const previousData = queryClient.getQueriesData<Shift[]>({ queryKey: ['shifts', restaurantId] });
@@ -331,7 +327,7 @@ export function useDeleteShiftSeries() {
         if (!old) return old;
 
         return old.filter((s) => {
-          if (s.locked) return true;
+          if (s.locked && !includePublished) return true;
 
           const isInSeries = s.id === parentId || s.recurrence_parent_id === parentId;
           if (!isInSeries) return true;

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -2076,6 +2076,44 @@ export type Database = {
           },
         ]
       }
+      device_tokens: {
+        Row: {
+          created_at: string
+          id: string
+          platform: string
+          restaurant_id: string
+          token: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          platform: string
+          restaurant_id: string
+          token: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          platform?: string
+          restaurant_id?: string
+          token?: string
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "device_tokens_restaurant_id_fkey"
+            columns: ["restaurant_id"]
+            isOneToOne: false
+            referencedRelation: "restaurants"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       employee_availability: {
         Row: {
           created_at: string | null
@@ -2426,6 +2464,7 @@ export type Database = {
       employees: {
         Row: {
           allocate_daily: boolean | null
+          area: string | null
           compensation_type: string
           contractor_payment_amount: number | null
           contractor_payment_interval: string | null
@@ -2463,6 +2502,7 @@ export type Database = {
         }
         Insert: {
           allocate_daily?: boolean | null
+          area?: string | null
           compensation_type?: string
           contractor_payment_amount?: number | null
           contractor_payment_interval?: string | null
@@ -2500,6 +2540,7 @@ export type Database = {
         }
         Update: {
           allocate_daily?: boolean | null
+          area?: string | null
           compensation_type?: string
           contractor_payment_amount?: number | null
           contractor_payment_interval?: string | null
@@ -5205,9 +5246,13 @@ export type Database = {
           cuisine_type: string | null
           ein: string | null
           entity_type: string | null
+          geofence_enforcement: string
+          geofence_radius_meters: number
           grandfathered_until: string | null
           id: string
+          latitude: number | null
           legal_name: string | null
+          longitude: number | null
           name: string
           phone: string | null
           state: string | null
@@ -5236,9 +5281,13 @@ export type Database = {
           cuisine_type?: string | null
           ein?: string | null
           entity_type?: string | null
+          geofence_enforcement?: string
+          geofence_radius_meters?: number
           grandfathered_until?: string | null
           id?: string
+          latitude?: number | null
           legal_name?: string | null
+          longitude?: number | null
           name: string
           phone?: string | null
           state?: string | null
@@ -5267,9 +5316,13 @@ export type Database = {
           cuisine_type?: string | null
           ein?: string | null
           entity_type?: string | null
+          geofence_enforcement?: string
+          geofence_radius_meters?: number
           grandfathered_until?: string | null
           id?: string
+          latitude?: number | null
           legal_name?: string | null
+          longitude?: number | null
           name?: string
           phone?: string | null
           state?: string | null
@@ -9307,6 +9360,7 @@ export type Database = {
         }
         Returns: {
           allocate_daily: boolean | null
+          area: string | null
           compensation_type: string
           contractor_payment_amount: number | null
           contractor_payment_interval: string | null
@@ -9360,6 +9414,7 @@ export type Database = {
       delete_shift_series: {
         Args: {
           p_from_time?: string
+          p_include_locked?: boolean
           p_parent_id: string
           p_restaurant_id: string
           p_scope: string
@@ -9735,6 +9790,7 @@ export type Database = {
         }
         Returns: {
           allocate_daily: boolean | null
+          area: string | null
           compensation_type: string
           contractor_payment_amount: number | null
           contractor_payment_interval: string | null

--- a/src/pages/Scheduling.tsx
+++ b/src/pages/Scheduling.tsx
@@ -633,7 +633,7 @@ const Scheduling = () => {
     if (actionType === 'delete') {
       // Delete with scope
       deleteShiftSeries.mutate(
-        { shift, scope, restaurantId },
+        { shift, scope, restaurantId, includePublished: true },
         {
           onSuccess: () => {
             setRecurringActionDialog({ open: false, shift: null, actionType: 'edit' });
@@ -1784,9 +1784,15 @@ const Scheduling = () => {
               </div>
               <AlertDialogTitle className="text-lg">Delete Shift</AlertDialogTitle>
             </div>
-            <AlertDialogDescription className="text-sm leading-relaxed">
-              Are you sure you want to delete this shift? This action cannot be undone and the
-              employee will need to be rescheduled.
+            <AlertDialogDescription className="text-sm leading-relaxed space-y-2">
+              <span>Are you sure you want to delete this shift? This action cannot be undone and the
+              employee will need to be rescheduled.</span>
+              {shiftToDelete?.is_published && (
+                <span className="flex items-center gap-2 text-warning font-medium">
+                  <AlertTriangle className="h-4 w-4 shrink-0" />
+                  This shift has been published and employees may have already seen it.
+                </span>
+              )}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter className="gap-2 sm:gap-0">
@@ -1862,7 +1868,10 @@ const Scheduling = () => {
             <AlertDialogDescription className="space-y-2">
               <p>This action cannot be undone.</p>
               {hasLockedInSelection && (
-                <p className="text-muted-foreground font-medium">Locked shifts (published) will be skipped.</p>
+                <p className="flex items-center gap-2 text-warning font-medium">
+                  <AlertTriangle className="h-4 w-4 shrink-0" />
+                  Some selected shifts have been published and employees may have already seen them.
+                </p>
               )}
             </AlertDialogDescription>
           </AlertDialogHeader>

--- a/src/pages/Scheduling.tsx
+++ b/src/pages/Scheduling.tsx
@@ -1870,7 +1870,7 @@ const Scheduling = () => {
               {hasLockedInSelection && (
                 <p className="flex items-center gap-2 text-warning font-medium">
                   <AlertTriangle className="h-4 w-4 shrink-0" />
-                  Some selected shifts have been published and employees may have already seen them.
+                  Some selected shifts have been published and employees may have already seen them. They will be permanently deleted.
                 </p>
               )}
             </AlertDialogDescription>

--- a/supabase/migrations/20260408000000_allow_delete_locked_shifts.sql
+++ b/supabase/migrations/20260408000000_allow_delete_locked_shifts.sql
@@ -1,0 +1,66 @@
+-- Allow deleting locked (published) shifts when explicitly requested.
+-- Adds p_include_locked parameter to delete_shift_series function.
+-- When true, locked shifts are deleted and locked_count returns 0.
+
+CREATE OR REPLACE FUNCTION delete_shift_series(
+  p_parent_id UUID,
+  p_restaurant_id UUID,
+  p_scope TEXT, -- 'all' or 'following'
+  p_from_time TIMESTAMPTZ DEFAULT NULL, -- required for 'following' scope
+  p_include_locked BOOLEAN DEFAULT false
+)
+RETURNS TABLE(deleted_count INT, locked_count INT)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_deleted_count INT := 0;
+  v_locked_count INT := 0;
+BEGIN
+  IF p_scope = 'following' THEN
+    -- Count locked shifts that will NOT be deleted (only when not force-deleting)
+    IF NOT p_include_locked THEN
+      SELECT COUNT(*) INTO v_locked_count
+      FROM shifts
+      WHERE (id = p_parent_id OR recurrence_parent_id = p_parent_id)
+        AND restaurant_id = p_restaurant_id
+        AND start_time >= p_from_time
+        AND locked = true;
+    END IF;
+
+    -- Delete shifts (include locked if requested)
+    WITH deleted AS (
+      DELETE FROM shifts
+      WHERE (id = p_parent_id OR recurrence_parent_id = p_parent_id)
+        AND restaurant_id = p_restaurant_id
+        AND start_time >= p_from_time
+        AND (locked = false OR p_include_locked = true)
+      RETURNING id
+    )
+    SELECT COUNT(*) INTO v_deleted_count FROM deleted;
+  ELSE -- 'all'
+    -- Count locked shifts that will NOT be deleted (only when not force-deleting)
+    IF NOT p_include_locked THEN
+      SELECT COUNT(*) INTO v_locked_count
+      FROM shifts
+      WHERE (id = p_parent_id OR recurrence_parent_id = p_parent_id)
+        AND restaurant_id = p_restaurant_id
+        AND locked = true;
+    END IF;
+
+    -- Delete shifts (include locked if requested)
+    WITH deleted AS (
+      DELETE FROM shifts
+      WHERE (id = p_parent_id OR recurrence_parent_id = p_parent_id)
+        AND restaurant_id = p_restaurant_id
+        AND (locked = false OR p_include_locked = true)
+      RETURNING id
+    )
+    SELECT COUNT(*) INTO v_deleted_count FROM deleted;
+  END IF;
+
+  RETURN QUERY SELECT v_deleted_count, v_locked_count;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION delete_shift_series TO authenticated;

--- a/supabase/migrations/20260408000000_allow_delete_locked_shifts.sql
+++ b/supabase/migrations/20260408000000_allow_delete_locked_shifts.sql
@@ -20,6 +20,10 @@ DECLARE
   v_deleted_count INT := 0;
   v_locked_count INT := 0;
 BEGIN
+  IF p_scope NOT IN ('all', 'following') THEN
+    RAISE EXCEPTION 'Invalid scope: %. Must be "all" or "following".', p_scope;
+  END IF;
+
   IF p_scope = 'following' THEN
     -- Count locked shifts that will NOT be deleted (only when not force-deleting)
     IF NOT p_include_locked THEN

--- a/supabase/migrations/20260408000000_allow_delete_locked_shifts.sql
+++ b/supabase/migrations/20260408000000_allow_delete_locked_shifts.sql
@@ -2,6 +2,9 @@
 -- Adds p_include_locked parameter to delete_shift_series function.
 -- When true, locked shifts are deleted and locked_count returns 0.
 
+-- Drop old 4-param signature to avoid overload ambiguity
+DROP FUNCTION IF EXISTS delete_shift_series(UUID, UUID, TEXT, TIMESTAMPTZ);
+
 CREATE OR REPLACE FUNCTION delete_shift_series(
   p_parent_id UUID,
   p_restaurant_id UUID,

--- a/supabase/tests/allow_delete_locked_shifts.test.sql
+++ b/supabase/tests/allow_delete_locked_shifts.test.sql
@@ -3,7 +3,7 @@
 
 BEGIN;
 
-SELECT plan(8);
+SELECT plan(6);
 
 -- Setup: Create test restaurant, user, and employee
 INSERT INTO restaurants (id, name, address, phone)
@@ -26,50 +26,37 @@ ON CONFLICT (id) DO NOTHING;
 
 -- ============================================================
 -- Test Group 1: Default behavior (p_include_locked = false)
+-- Parent is locked, one child unlocked, one child locked
 -- ============================================================
 
--- Create a parent shift (unlocked) and children (mix of locked/unlocked)
 INSERT INTO shifts (id, restaurant_id, employee_id, start_time, end_time, position, locked, recurrence_parent_id)
 VALUES
   ('00000000-0000-0000-0000-000000000810'::uuid, :rest_id::uuid, :emp_id::uuid,
-   '2026-04-14 09:00:00+00', '2026-04-14 17:00:00+00', 'Server', false, NULL),
+   '2026-04-14 09:00:00+00', '2026-04-14 17:00:00+00', 'Server', true, NULL),
   ('00000000-0000-0000-0000-000000000811'::uuid, :rest_id::uuid, :emp_id::uuid,
    '2026-04-15 09:00:00+00', '2026-04-15 17:00:00+00', 'Server', false,
    '00000000-0000-0000-0000-000000000810'::uuid),
   ('00000000-0000-0000-0000-000000000812'::uuid, :rest_id::uuid, :emp_id::uuid,
    '2026-04-16 09:00:00+00', '2026-04-16 17:00:00+00', 'Server', true,
-   '00000000-0000-0000-0000-000000000810'::uuid),
-  ('00000000-0000-0000-0000-000000000813'::uuid, :rest_id::uuid, :emp_id::uuid,
-   '2026-04-17 09:00:00+00', '2026-04-17 17:00:00+00', 'Server', true,
    '00000000-0000-0000-0000-000000000810'::uuid);
 
--- Test 1: Default (p_include_locked=false) with scope='all' should only delete unlocked
-SELECT is(
-  (SELECT deleted_count FROM delete_shift_series(
+-- Test 1: Default deletes only the 1 unlocked child, reports 2 locked (parent + child)
+SELECT results_eq(
+  $$SELECT deleted_count, locked_count FROM delete_shift_series(
     '00000000-0000-0000-0000-000000000810'::uuid,
-    :rest_id::uuid,
+    '00000000-0000-0000-0000-000000000801'::uuid,
     'all'
-  )),
-  2,
-  'Default scope=all: should delete 2 unlocked shifts'
+  )$$,
+  $$VALUES (1, 2)$$,
+  'Default scope=all: deletes 1 unlocked, reports 2 locked'
 );
 
--- Test 2: Default should report 2 locked shifts remaining
-SELECT is(
-  (SELECT locked_count FROM delete_shift_series(
-    '00000000-0000-0000-0000-000000000810'::uuid,
-    :rest_id::uuid,
-    'all'
-  )),
-  2,
-  'Default scope=all: should report 2 locked shifts'
-);
-
--- Test 3: Verify locked shifts still exist in DB
+-- Test 2: Verify 2 locked shifts still exist after default delete
 SELECT is(
   (SELECT COUNT(*)::int FROM shifts
-   WHERE recurrence_parent_id = '00000000-0000-0000-0000-000000000810'::uuid
-     AND restaurant_id = :rest_id::uuid
+   WHERE (id = '00000000-0000-0000-0000-000000000810'::uuid
+     OR recurrence_parent_id = '00000000-0000-0000-0000-000000000810'::uuid)
+     AND restaurant_id = '00000000-0000-0000-0000-000000000801'::uuid
      AND locked = true),
   2,
   'Locked shifts should still exist after default delete'
@@ -79,53 +66,36 @@ SELECT is(
 -- Test Group 2: p_include_locked = true with scope='all'
 -- ============================================================
 
--- Create a new series for this test
 INSERT INTO shifts (id, restaurant_id, employee_id, start_time, end_time, position, locked, recurrence_parent_id)
 VALUES
   ('00000000-0000-0000-0000-000000000820'::uuid, :rest_id::uuid, :emp_id::uuid,
-   '2026-04-21 09:00:00+00', '2026-04-21 17:00:00+00', 'Server', false, NULL),
+   '2026-04-21 09:00:00+00', '2026-04-21 17:00:00+00', 'Server', true, NULL),
   ('00000000-0000-0000-0000-000000000821'::uuid, :rest_id::uuid, :emp_id::uuid,
    '2026-04-22 09:00:00+00', '2026-04-22 17:00:00+00', 'Server', false,
    '00000000-0000-0000-0000-000000000820'::uuid),
   ('00000000-0000-0000-0000-000000000822'::uuid, :rest_id::uuid, :emp_id::uuid,
    '2026-04-23 09:00:00+00', '2026-04-23 17:00:00+00', 'Server', true,
-   '00000000-0000-0000-0000-000000000820'::uuid),
-  ('00000000-0000-0000-0000-000000000823'::uuid, :rest_id::uuid, :emp_id::uuid,
-   '2026-04-24 09:00:00+00', '2026-04-24 17:00:00+00', 'Server', true,
    '00000000-0000-0000-0000-000000000820'::uuid);
 
--- Test 4: p_include_locked=true with scope='all' should delete all 4 shifts
-SELECT is(
-  (SELECT deleted_count FROM delete_shift_series(
+-- Test 3: p_include_locked=true deletes all 3 shifts, reports 0 locked
+SELECT results_eq(
+  $$SELECT deleted_count, locked_count FROM delete_shift_series(
     '00000000-0000-0000-0000-000000000820'::uuid,
-    :rest_id::uuid,
+    '00000000-0000-0000-0000-000000000801'::uuid,
     'all',
     NULL,
     true
-  )),
-  4,
-  'p_include_locked=true scope=all: should delete all 4 shifts'
+  )$$,
+  $$VALUES (3, 0)$$,
+  'p_include_locked=true scope=all: deletes all 3, locked_count=0'
 );
 
--- Test 5: locked_count should be 0 when force-deleting
-SELECT is(
-  (SELECT locked_count FROM delete_shift_series(
-    '00000000-0000-0000-0000-000000000820'::uuid,
-    :rest_id::uuid,
-    'all',
-    NULL,
-    true
-  )),
-  0,
-  'p_include_locked=true scope=all: locked_count should be 0'
-);
-
--- Test 6: Verify no shifts remain
+-- Test 4: Verify no shifts remain
 SELECT is(
   (SELECT COUNT(*)::int FROM shifts
    WHERE (id = '00000000-0000-0000-0000-000000000820'::uuid
      OR recurrence_parent_id = '00000000-0000-0000-0000-000000000820'::uuid)
-     AND restaurant_id = :rest_id::uuid),
+     AND restaurant_id = '00000000-0000-0000-0000-000000000801'::uuid),
   0,
   'No shifts should remain after force delete'
 );
@@ -134,7 +104,6 @@ SELECT is(
 -- Test Group 3: p_include_locked = true with scope='following'
 -- ============================================================
 
--- Create a new series for following-scope test
 INSERT INTO shifts (id, restaurant_id, employee_id, start_time, end_time, position, locked, recurrence_parent_id)
 VALUES
   ('00000000-0000-0000-0000-000000000830'::uuid, :rest_id::uuid, :emp_id::uuid,
@@ -146,24 +115,24 @@ VALUES
    '2026-04-30 09:00:00+00', '2026-04-30 17:00:00+00', 'Server', true,
    '00000000-0000-0000-0000-000000000830'::uuid);
 
--- Test 7: p_include_locked=true, scope='following' from Apr 29 should delete 2 shifts
+-- Test 5: p_include_locked=true, scope='following' from Apr 29 deletes 2 shifts
 SELECT is(
   (SELECT deleted_count FROM delete_shift_series(
     '00000000-0000-0000-0000-000000000830'::uuid,
-    :rest_id::uuid,
+    '00000000-0000-0000-0000-000000000801'::uuid,
     'following',
     '2026-04-29 00:00:00+00'::timestamptz,
     true
   )),
   2,
-  'p_include_locked=true scope=following: should delete 2 shifts from cutoff'
+  'p_include_locked=true scope=following: deletes 2 shifts from cutoff'
 );
 
--- Test 8: The parent shift before cutoff should still exist
+-- Test 6: Parent shift before cutoff still exists
 SELECT is(
   (SELECT COUNT(*)::int FROM shifts
    WHERE id = '00000000-0000-0000-0000-000000000830'::uuid
-     AND restaurant_id = :rest_id::uuid),
+     AND restaurant_id = '00000000-0000-0000-0000-000000000801'::uuid),
   1,
   'Parent shift before cutoff should still exist'
 );

--- a/supabase/tests/allow_delete_locked_shifts.test.sql
+++ b/supabase/tests/allow_delete_locked_shifts.test.sql
@@ -1,0 +1,172 @@
+-- Test: delete_shift_series with p_include_locked parameter
+-- Verifies default behavior skips locked shifts, and p_include_locked=true deletes them
+
+BEGIN;
+
+SELECT plan(8);
+
+-- Setup: Create test restaurant, user, and employee
+INSERT INTO restaurants (id, name, address, phone)
+VALUES ('00000000-0000-0000-0000-000000000801'::uuid, 'Lock Test Restaurant', '123 Lock St', '555-LOCK')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO auth.users (id, email)
+VALUES ('00000000-0000-0000-0000-000000000802'::uuid, 'lock-test@test.com')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO employees (id, restaurant_id, name, position, hourly_rate)
+VALUES ('00000000-0000-0000-0000-000000000803'::uuid,
+        '00000000-0000-0000-0000-000000000801'::uuid,
+        'Lock Test Employee', 'Server', 1500)
+ON CONFLICT (id) DO NOTHING;
+
+-- Helper variables
+\set rest_id '''00000000-0000-0000-0000-000000000801'''
+\set emp_id '''00000000-0000-0000-0000-000000000803'''
+
+-- ============================================================
+-- Test Group 1: Default behavior (p_include_locked = false)
+-- ============================================================
+
+-- Create a parent shift (unlocked) and children (mix of locked/unlocked)
+INSERT INTO shifts (id, restaurant_id, employee_id, start_time, end_time, position, locked, recurrence_parent_id)
+VALUES
+  ('00000000-0000-0000-0000-000000000810'::uuid, :rest_id::uuid, :emp_id::uuid,
+   '2026-04-14 09:00:00+00', '2026-04-14 17:00:00+00', 'Server', false, NULL),
+  ('00000000-0000-0000-0000-000000000811'::uuid, :rest_id::uuid, :emp_id::uuid,
+   '2026-04-15 09:00:00+00', '2026-04-15 17:00:00+00', 'Server', false,
+   '00000000-0000-0000-0000-000000000810'::uuid),
+  ('00000000-0000-0000-0000-000000000812'::uuid, :rest_id::uuid, :emp_id::uuid,
+   '2026-04-16 09:00:00+00', '2026-04-16 17:00:00+00', 'Server', true,
+   '00000000-0000-0000-0000-000000000810'::uuid),
+  ('00000000-0000-0000-0000-000000000813'::uuid, :rest_id::uuid, :emp_id::uuid,
+   '2026-04-17 09:00:00+00', '2026-04-17 17:00:00+00', 'Server', true,
+   '00000000-0000-0000-0000-000000000810'::uuid);
+
+-- Test 1: Default (p_include_locked=false) with scope='all' should only delete unlocked
+SELECT is(
+  (SELECT deleted_count FROM delete_shift_series(
+    '00000000-0000-0000-0000-000000000810'::uuid,
+    :rest_id::uuid,
+    'all'
+  )),
+  2,
+  'Default scope=all: should delete 2 unlocked shifts'
+);
+
+-- Test 2: Default should report 2 locked shifts remaining
+SELECT is(
+  (SELECT locked_count FROM delete_shift_series(
+    '00000000-0000-0000-0000-000000000810'::uuid,
+    :rest_id::uuid,
+    'all'
+  )),
+  2,
+  'Default scope=all: should report 2 locked shifts'
+);
+
+-- Test 3: Verify locked shifts still exist in DB
+SELECT is(
+  (SELECT COUNT(*)::int FROM shifts
+   WHERE recurrence_parent_id = '00000000-0000-0000-0000-000000000810'::uuid
+     AND restaurant_id = :rest_id::uuid
+     AND locked = true),
+  2,
+  'Locked shifts should still exist after default delete'
+);
+
+-- ============================================================
+-- Test Group 2: p_include_locked = true with scope='all'
+-- ============================================================
+
+-- Create a new series for this test
+INSERT INTO shifts (id, restaurant_id, employee_id, start_time, end_time, position, locked, recurrence_parent_id)
+VALUES
+  ('00000000-0000-0000-0000-000000000820'::uuid, :rest_id::uuid, :emp_id::uuid,
+   '2026-04-21 09:00:00+00', '2026-04-21 17:00:00+00', 'Server', false, NULL),
+  ('00000000-0000-0000-0000-000000000821'::uuid, :rest_id::uuid, :emp_id::uuid,
+   '2026-04-22 09:00:00+00', '2026-04-22 17:00:00+00', 'Server', false,
+   '00000000-0000-0000-0000-000000000820'::uuid),
+  ('00000000-0000-0000-0000-000000000822'::uuid, :rest_id::uuid, :emp_id::uuid,
+   '2026-04-23 09:00:00+00', '2026-04-23 17:00:00+00', 'Server', true,
+   '00000000-0000-0000-0000-000000000820'::uuid),
+  ('00000000-0000-0000-0000-000000000823'::uuid, :rest_id::uuid, :emp_id::uuid,
+   '2026-04-24 09:00:00+00', '2026-04-24 17:00:00+00', 'Server', true,
+   '00000000-0000-0000-0000-000000000820'::uuid);
+
+-- Test 4: p_include_locked=true with scope='all' should delete all 4 shifts
+SELECT is(
+  (SELECT deleted_count FROM delete_shift_series(
+    '00000000-0000-0000-0000-000000000820'::uuid,
+    :rest_id::uuid,
+    'all',
+    NULL,
+    true
+  )),
+  4,
+  'p_include_locked=true scope=all: should delete all 4 shifts'
+);
+
+-- Test 5: locked_count should be 0 when force-deleting
+SELECT is(
+  (SELECT locked_count FROM delete_shift_series(
+    '00000000-0000-0000-0000-000000000820'::uuid,
+    :rest_id::uuid,
+    'all',
+    NULL,
+    true
+  )),
+  0,
+  'p_include_locked=true scope=all: locked_count should be 0'
+);
+
+-- Test 6: Verify no shifts remain
+SELECT is(
+  (SELECT COUNT(*)::int FROM shifts
+   WHERE (id = '00000000-0000-0000-0000-000000000820'::uuid
+     OR recurrence_parent_id = '00000000-0000-0000-0000-000000000820'::uuid)
+     AND restaurant_id = :rest_id::uuid),
+  0,
+  'No shifts should remain after force delete'
+);
+
+-- ============================================================
+-- Test Group 3: p_include_locked = true with scope='following'
+-- ============================================================
+
+-- Create a new series for following-scope test
+INSERT INTO shifts (id, restaurant_id, employee_id, start_time, end_time, position, locked, recurrence_parent_id)
+VALUES
+  ('00000000-0000-0000-0000-000000000830'::uuid, :rest_id::uuid, :emp_id::uuid,
+   '2026-04-28 09:00:00+00', '2026-04-28 17:00:00+00', 'Server', true, NULL),
+  ('00000000-0000-0000-0000-000000000831'::uuid, :rest_id::uuid, :emp_id::uuid,
+   '2026-04-29 09:00:00+00', '2026-04-29 17:00:00+00', 'Server', true,
+   '00000000-0000-0000-0000-000000000830'::uuid),
+  ('00000000-0000-0000-0000-000000000832'::uuid, :rest_id::uuid, :emp_id::uuid,
+   '2026-04-30 09:00:00+00', '2026-04-30 17:00:00+00', 'Server', true,
+   '00000000-0000-0000-0000-000000000830'::uuid);
+
+-- Test 7: p_include_locked=true, scope='following' from Apr 29 should delete 2 shifts
+SELECT is(
+  (SELECT deleted_count FROM delete_shift_series(
+    '00000000-0000-0000-0000-000000000830'::uuid,
+    :rest_id::uuid,
+    'following',
+    '2026-04-29 00:00:00+00'::timestamptz,
+    true
+  )),
+  2,
+  'p_include_locked=true scope=following: should delete 2 shifts from cutoff'
+);
+
+-- Test 8: The parent shift before cutoff should still exist
+SELECT is(
+  (SELECT COUNT(*)::int FROM shifts
+   WHERE id = '00000000-0000-0000-0000-000000000830'::uuid
+     AND restaurant_id = :rest_id::uuid),
+  1,
+  'Parent shift before cutoff should still exist'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/allow_delete_locked_shifts.test.sql
+++ b/supabase/tests/allow_delete_locked_shifts.test.sql
@@ -3,7 +3,7 @@
 
 BEGIN;
 
-SELECT plan(6);
+SELECT plan(7);
 
 -- Setup: Create test restaurant, user, and employee
 INSERT INTO restaurants (id, name, address, phone)
@@ -115,20 +115,30 @@ VALUES
    '2026-04-30 09:00:00+00', '2026-04-30 17:00:00+00', 'Server', true,
    '00000000-0000-0000-0000-000000000830'::uuid);
 
--- Test 5: p_include_locked=true, scope='following' from Apr 29 deletes 2 shifts
-SELECT is(
-  (SELECT deleted_count FROM delete_shift_series(
+-- Test 5: p_include_locked=true, scope='following' from Apr 29 deletes 2 shifts with locked_count=0
+SELECT results_eq(
+  $$SELECT deleted_count, locked_count FROM delete_shift_series(
     '00000000-0000-0000-0000-000000000830'::uuid,
     '00000000-0000-0000-0000-000000000801'::uuid,
     'following',
     '2026-04-29 00:00:00+00'::timestamptz,
     true
-  )),
-  2,
-  'p_include_locked=true scope=following: deletes 2 shifts from cutoff'
+  )$$,
+  $$VALUES (2, 0)$$,
+  'p_include_locked=true scope=following: deletes 2, locked_count=0'
 );
 
--- Test 6: Parent shift before cutoff still exists
+-- Test 6: Invalid scope raises error
+SELECT throws_ok(
+  $$SELECT * FROM delete_shift_series(
+    '00000000-0000-0000-0000-000000000830'::uuid,
+    '00000000-0000-0000-0000-000000000801'::uuid,
+    'invalid_scope'
+  )$$,
+  'Invalid scope: invalid_scope. Must be "all" or "following".'
+);
+
+-- Test 7: Parent shift before cutoff still exists
 SELECT is(
   (SELECT COUNT(*)::int FROM shifts
    WHERE id = '00000000-0000-0000-0000-000000000830'::uuid

--- a/tests/unit/useBulkShiftActions.test.ts
+++ b/tests/unit/useBulkShiftActions.test.ts
@@ -126,7 +126,7 @@ describe('useBulkShiftActions', () => {
       mockSupabase.from.mockReturnValue({
         delete: () => ({
           in: () => ({
-            eq: () => ({ data: null, error: null }),
+            eq: () => ({ data: null, error: null, count: 3 }),
           }),
         }),
       });
@@ -155,7 +155,7 @@ describe('useBulkShiftActions', () => {
       mockSupabase.from.mockReturnValue({
         delete: () => ({
           in: () => ({
-            eq: () => ({ data: null, error: null }),
+            eq: () => ({ data: null, error: null, count: 1 }),
           }),
         }),
       });

--- a/tests/unit/useBulkShiftActions.test.ts
+++ b/tests/unit/useBulkShiftActions.test.ts
@@ -121,14 +121,15 @@ describe('useBulkShiftActions', () => {
   // ── bulkDelete ─────────────────────────────────────────────────────
 
   describe('bulkDelete', () => {
-    it('filters out locked shifts and deletes only unlocked ones', async () => {
-      const lockedRows = [
-        { id: 's1', locked: false },
-        { id: 's2', locked: true },
-        { id: 's3', locked: false },
-      ];
-
-      setupSelectThenMutate(lockedRows, { data: null, error: null, count: 2 }, 'delete');
+    it('deletes all shifts including locked ones', async () => {
+      // bulkDelete now deletes all shifts directly without partitioning
+      mockSupabase.from.mockReturnValue({
+        delete: () => ({
+          in: () => ({
+            eq: () => ({ data: null, error: null }),
+          }),
+        }),
+      });
 
       const { result } = renderHook(() => useBulkShiftActions('rest-1'), {
         wrapper: createWrapper(),
@@ -139,25 +140,25 @@ describe('useBulkShiftActions', () => {
         outcome = await result.current.bulkDelete(['s1', 's2', 's3']);
       });
 
-      expect(outcome!.deletedCount).toBe(2);
-      expect(outcome!.lockedCount).toBe(1);
+      expect(outcome!.deletedCount).toBe(3);
+      expect(outcome!.lockedCount).toBe(0);
 
-      // Verify toast was called with skip info
       expect(mockToast).toHaveBeenCalledWith(
         expect.objectContaining({
-          description: expect.stringContaining('1 locked shift was preserved'),
+          title: 'Shifts deleted',
+          description: '3 shifts deleted.',
         }),
       );
     });
 
-    it('returns zero counts when all shifts are locked', async () => {
-      const lockedRows = [
-        { id: 's1', locked: true },
-        { id: 's2', locked: true },
-      ];
-
-      // Only the SELECT call — no mutation should happen
-      setupSelectThenMutate(lockedRows, { data: null, error: null, count: 0 }, 'delete');
+    it('deletes a single shift with correct grammar', async () => {
+      mockSupabase.from.mockReturnValue({
+        delete: () => ({
+          in: () => ({
+            eq: () => ({ data: null, error: null }),
+          }),
+        }),
+      });
 
       const { result } = renderHook(() => useBulkShiftActions('rest-1'), {
         wrapper: createWrapper(),
@@ -165,32 +166,16 @@ describe('useBulkShiftActions', () => {
 
       let outcome: Awaited<ReturnType<typeof result.current.bulkDelete>>;
       await act(async () => {
-        outcome = await result.current.bulkDelete(['s1', 's2']);
+        outcome = await result.current.bulkDelete(['s1']);
       });
 
-      expect(outcome!.deletedCount).toBe(0);
-      expect(outcome!.lockedCount).toBe(2);
-    });
+      expect(outcome!.deletedCount).toBe(1);
 
-    it('deletes all shifts when none are locked', async () => {
-      const lockedRows = [
-        { id: 's1', locked: false },
-        { id: 's2', locked: false },
-      ];
-
-      setupSelectThenMutate(lockedRows, { data: null, error: null, count: 2 }, 'delete');
-
-      const { result } = renderHook(() => useBulkShiftActions('rest-1'), {
-        wrapper: createWrapper(),
-      });
-
-      let outcome: Awaited<ReturnType<typeof result.current.bulkDelete>>;
-      await act(async () => {
-        outcome = await result.current.bulkDelete(['s1', 's2']);
-      });
-
-      expect(outcome!.deletedCount).toBe(2);
-      expect(outcome!.lockedCount).toBe(0);
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          description: '1 shift deleted.',
+        }),
+      );
     });
   });
 

--- a/tests/unit/useShiftsSeries.test.ts
+++ b/tests/unit/useShiftsSeries.test.ts
@@ -264,7 +264,7 @@ describe('useDeleteShiftSeries', () => {
       );
     });
 
-    it('should throw error when trying to delete locked shift with scope "this"', async () => {
+    it('should allow deleting locked shift with scope "this"', async () => {
       setupMockForScope('this');
 
       const { Wrapper } = createWrapper();
@@ -274,19 +274,14 @@ describe('useDeleteShiftSeries', () => {
 
       const lockedShift = createMockShift({ id: 'locked-shift', locked: true });
 
-      await expect(
-        result.current.mutateAsync({
-          shift: lockedShift,
-          scope: 'this',
-          restaurantId: 'rest-123',
-        })
-      ).rejects.toThrow('Cannot delete a locked shift');
+      const outcome = await result.current.mutateAsync({
+        shift: lockedShift,
+        scope: 'this',
+        restaurantId: 'rest-123',
+      });
 
-      expect(mockToast).toHaveBeenCalledWith(
-        expect.objectContaining({
-          variant: 'destructive',
-        })
-      );
+      expect(outcome.deletedCount).toBe(1);
+      expect(outcome.lockedCount).toBe(0);
     });
   });
 


### PR DESCRIPTION
## Summary
- Replace the hard block on deleting published (locked) shifts with a warning confirmation dialog
- Add `p_include_locked` parameter to `delete_shift_series` SQL RPC for backward-compatible force-delete
- Update single-shift, recurring series, and bulk delete flows to show warnings instead of blocking
- Preserve `locked`/`is_published` columns for tracking; edit operations still respect lock

## Design doc
`docs/plans/2026-04-08-allow-delete-published-shifts-design.md`

## Test plan
- [x] pgTAP tests: `delete_shift_series` with `p_include_locked=true/false` (6 tests)
- [x] Unit tests: `useBulkShiftActions` bulk delete without partition (2 tests)
- [x] Unit tests: `useDeleteShiftSeries` locked shift delete succeeds (1 test)
- [x] TypeScript typecheck passes
- [x] Full build passes
- [x] All 3272 unit tests pass
- [x] All 1145 pgTAP tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Option to include published (locked) shifts when deleting recurring series.

* **UI Improvements**
  * Confirmation dialogs and bulk-delete warnings now warn that employees may already have seen affected shifts and use correct singular/plural wording; published-shift warnings show an alert icon.

* **Behavior Changes**
  * Bulk delete reports actual deleted count and simplified success text; individual/series deletes can include published shifts and no longer block on locked shifts.

* **Infrastructure**
  * Device token table, employee area, and restaurant geofence/location fields added.

* **Tests**
  * Unit and SQL integration tests updated to reflect new deletion behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->