### PR TITLE
feat: labor budget comparison in scheduling view

### DIFF
--- a/src/components/scheduling/LaborBudgetIndicator.tsx
+++ b/src/components/scheduling/LaborBudgetIndicator.tsx
@@ -1,0 +1,124 @@
+import { useState } from 'react';
+import { ChevronRight, ChevronDown } from 'lucide-react';
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/lib/utils';
+import { useNavigate } from 'react-router-dom';
+import type { LaborBudgetData } from '@/hooks/useScheduleLaborBudget';
+
+interface LaborBudgetIndicatorProps {
+  budgetData: LaborBudgetData;
+}
+
+const tierColors = {
+  success: {
+    text: 'text-success',
+    bg: 'bg-success/[0.06]',
+    border: 'border-success/15',
+    bar: 'bg-success/60',
+  },
+  warning: {
+    text: 'text-warning',
+    bg: 'bg-warning/[0.06]',
+    border: 'border-warning/20',
+    bar: 'bg-warning/60',
+  },
+  danger: {
+    text: 'text-destructive/80',
+    bg: 'bg-destructive/[0.05]',
+    border: 'border-destructive/20',
+    bar: 'bg-destructive/60',
+  },
+};
+
+function formatCurrency(value: number): string {
+  return `$${Math.abs(value).toLocaleString(undefined, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  })}`;
+}
+
+function getVarianceLabel(variance: number, percentage: number): string {
+  if (percentage <= 80) return `${formatCurrency(variance)} under budget`;
+  if (percentage <= 100) return `${formatCurrency(variance)} remaining`;
+  return `${formatCurrency(variance)} over budget`;
+}
+
+export function LaborBudgetIndicator({ budgetData }: LaborBudgetIndicatorProps) {
+  const [expanded, setExpanded] = useState(false);
+  const navigate = useNavigate();
+
+  if (budgetData.isLoading) {
+    return (
+      <div className="mt-3 pt-3 border-t border-border/50">
+        <Skeleton className="h-4 w-20" />
+      </div>
+    );
+  }
+
+  const colors = tierColors[budgetData.tier];
+  const barWidth = Math.min(budgetData.percentage, 100);
+
+  return (
+    <div className="mt-3 pt-3 border-t border-border/50">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors"
+        aria-expanded={expanded}
+        aria-label="Toggle budget comparison"
+      >
+        {expanded ? (
+          <ChevronDown className="h-3 w-3" />
+        ) : (
+          <ChevronRight className="h-3 w-3" />
+        )}
+        Budget
+      </button>
+
+      {expanded && (
+        <div className="mt-2">
+          {budgetData.hasBudget ? (
+            <div
+              className={cn(
+                'p-2.5 rounded-lg border',
+                colors.bg,
+                colors.border,
+              )}
+            >
+              <div className="flex justify-between items-baseline mb-1.5">
+                <span className={cn('text-[18px] font-semibold', colors.text)}>
+                  {budgetData.percentage.toFixed(0)}%
+                </span>
+                <span className="text-[11px] text-muted-foreground">
+                  of {formatCurrency(budgetData.weeklyTarget)}/wk
+                </span>
+              </div>
+              <div className="h-[5px] bg-border/30 rounded-full overflow-hidden">
+                <div
+                  className={cn('h-full rounded-full transition-all duration-500', colors.bar)}
+                  style={{ width: `${barWidth}%` }}
+                />
+              </div>
+              <div className={cn('text-[11px] mt-1.5', colors.text)}>
+                {getVarianceLabel(budgetData.variance, budgetData.percentage)}
+              </div>
+            </div>
+          ) : (
+            <div className="p-2.5 rounded-lg border border-border/40 bg-muted/30">
+              <div className="flex justify-between items-center">
+                <span className="text-[12px] text-muted-foreground">
+                  No labor budget set
+                </span>
+                <button
+                  onClick={() => navigate('/budget')}
+                  className="text-[12px] text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  Configure →
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/scheduling/LaborBudgetIndicator.tsx
+++ b/src/components/scheduling/LaborBudgetIndicator.tsx
@@ -56,7 +56,7 @@ export function LaborBudgetIndicator({ budgetData }: LaborBudgetIndicatorProps) 
   }
 
   const colors = tierColors[budgetData.tier];
-  const barWidth = Math.min(budgetData.percentage, 100);
+  const barWidth = Math.max(0, Math.min(budgetData.percentage, 100));
 
   return (
     <div className="mt-3 pt-3 border-t border-border/50">

--- a/src/hooks/useScheduleLaborBudget.ts
+++ b/src/hooks/useScheduleLaborBudget.ts
@@ -1,0 +1,113 @@
+import { useMemo } from 'react';
+import { useOperatingCosts } from './useOperatingCosts';
+import { useBreakEvenAnalysis } from './useBreakEvenAnalysis';
+import type { OperatingCost, BreakEvenData } from '@/types/operatingCosts';
+
+type BudgetTier = 'success' | 'warning' | 'danger';
+type BudgetSource = 'sales' | 'breakeven' | 'fixed';
+
+export interface LaborBudgetData {
+  hasBudget: boolean;
+  weeklyTarget: number;
+  percentage: number;
+  variance: number;
+  tier: BudgetTier;
+  source: BudgetSource | null;
+  laborEntry: OperatingCost | null;
+  isLoading: boolean;
+}
+
+/**
+ * Pure calculation function — no hooks, easy to test.
+ *
+ * @param scheduledTotal - Total scheduled labor cost for the week ($)
+ * @param costs - All operating cost entries for the restaurant
+ * @param breakEvenData - Break-even analysis data (null if unavailable)
+ */
+export function calculateLaborBudget(
+  scheduledTotal: number,
+  costs: OperatingCost[],
+  breakEvenData: BreakEvenData | null,
+): LaborBudgetData {
+  const laborEntry = costs.find((c) => c.category === 'labor') ?? null;
+
+  const noBudget: LaborBudgetData = {
+    hasBudget: false,
+    weeklyTarget: 0,
+    percentage: 0,
+    variance: 0,
+    tier: 'success',
+    source: null,
+    laborEntry,
+    isLoading: false,
+  };
+
+  if (!laborEntry) return noBudget;
+
+  let weeklyTarget: number;
+  let source: BudgetSource;
+
+  if (laborEntry.entryType === 'value') {
+    // Fixed amount: monthlyValue is in cents
+    const monthlyDollars = laborEntry.monthlyValue / 100;
+    weeklyTarget = (monthlyDollars / 30) * 7;
+    source = 'fixed';
+  } else {
+    // Percentage-based: need a daily sales figure
+    const pct = laborEntry.percentageValue;
+    const avgDailySales = breakEvenData?.variableCosts.avgDailySales ?? 0;
+
+    if (avgDailySales > 0) {
+      weeklyTarget = avgDailySales * pct * 7;
+      source = 'sales';
+    } else {
+      // Fallback to break-even derived target
+      const dailyBE = breakEvenData?.dailyBreakEven ?? 0;
+      if (!isFinite(dailyBE) || dailyBE <= 0) return noBudget;
+      weeklyTarget = dailyBE * pct * 7;
+      source = 'breakeven';
+    }
+  }
+
+  if (weeklyTarget <= 0) return noBudget;
+
+  const percentage = (scheduledTotal / weeklyTarget) * 100;
+  const variance = weeklyTarget - scheduledTotal;
+
+  let tier: BudgetTier;
+  if (percentage < 80) tier = 'success';
+  else if (percentage <= 100) tier = 'warning';
+  else tier = 'danger';
+
+  return {
+    hasBudget: true,
+    weeklyTarget,
+    percentage,
+    variance,
+    tier,
+    source,
+    laborEntry,
+    isLoading: false,
+  };
+}
+
+/**
+ * React hook that computes labor budget comparison for the scheduling page.
+ */
+export function useScheduleLaborBudget(
+  scheduledTotal: number,
+  restaurantId: string | null,
+): LaborBudgetData {
+  const { costs, isLoading: costsLoading } = useOperatingCosts(restaurantId);
+  const { data: breakEvenData, isLoading: breakEvenLoading } =
+    useBreakEvenAnalysis(restaurantId);
+
+  const isLoading = costsLoading || breakEvenLoading;
+
+  const budgetData = useMemo(
+    () => calculateLaborBudget(scheduledTotal, costs, breakEvenData),
+    [scheduledTotal, costs, breakEvenData],
+  );
+
+  return { ...budgetData, isLoading };
+}

--- a/src/hooks/useScheduleLaborBudget.ts
+++ b/src/hooks/useScheduleLaborBudget.ts
@@ -102,7 +102,9 @@ export function useScheduleLaborBudget(
   const { data: breakEvenData, isLoading: breakEvenLoading } =
     useBreakEvenAnalysis(restaurantId);
 
-  const isLoading = costsLoading || breakEvenLoading;
+  const laborEntry = costs.find((c) => c.category === 'labor') ?? null;
+  const needsBreakEven = laborEntry?.entryType === 'percentage';
+  const isLoading = costsLoading || (needsBreakEven && breakEvenLoading);
 
   const budgetData = useMemo(
     () => calculateLaborBudget(scheduledTotal, costs, breakEvenData),

--- a/src/pages/Scheduling.tsx
+++ b/src/pages/Scheduling.tsx
@@ -31,6 +31,8 @@ import { PublishScheduleDialog } from '@/components/PublishScheduleDialog';
 import { ChangeLogDialog } from '@/components/ChangeLogDialog';
 import { TradeApprovalQueue } from '@/components/schedule/TradeApprovalQueue';
 import { LaborCostBreakdown } from '@/components/scheduling/LaborCostBreakdown';
+import { LaborBudgetIndicator } from '@/components/scheduling/LaborBudgetIndicator';
+import { useScheduleLaborBudget } from '@/hooks/useScheduleLaborBudget';
 import { ScheduleExportDialog } from '@/components/scheduling/ScheduleExportDialog';
 import { ShiftPlannerTab } from '@/components/scheduling/ShiftPlanner';
 import { ShiftImportSheet } from '@/components/scheduling/ShiftImportSheet';
@@ -400,6 +402,12 @@ const Scheduling = () => {
 
   // Calculate per-employee labor costs with outlier detection
   const laborCostSummary = useEmployeeLaborCosts(shifts, allEmployees);
+
+  // Calculate labor budget comparison
+  const laborBudgetData = useScheduleLaborBudget(
+    laborCostBreakdown.total,
+    restaurantId
+  );
 
   // Handler for clicking on an employee in the breakdown to edit them
   const handleEditEmployeeById = useCallback((employeeId: string) => {
@@ -846,13 +854,21 @@ const Scheduling = () => {
           "group relative overflow-hidden border-border/50 transition-colors duration-300",
           laborCostSummary.isAverageHigh
             ? "border-destructive/50 hover:border-destructive/70"
-            : "hover:border-success/30"
+            : laborBudgetData.hasBudget && laborBudgetData.tier === 'danger'
+              ? "border-destructive/50 hover:border-destructive/70"
+              : laborBudgetData.hasBudget && laborBudgetData.tier === 'warning'
+                ? "border-warning/50 hover:border-warning/70"
+                : "hover:border-success/30"
         )}>
           <div className={cn(
             "absolute top-0 right-0 w-24 h-24 rounded-bl-full",
             laborCostSummary.isAverageHigh
               ? "bg-gradient-to-bl from-destructive/10 to-transparent"
-              : "bg-gradient-to-bl from-success/5 to-transparent"
+              : laborBudgetData.hasBudget && laborBudgetData.tier === 'danger'
+                ? "bg-gradient-to-bl from-destructive/10 to-transparent"
+                : laborBudgetData.hasBudget && laborBudgetData.tier === 'warning'
+                  ? "bg-gradient-to-bl from-warning/10 to-transparent"
+                  : "bg-gradient-to-bl from-success/5 to-transparent"
           )} />
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-2">
@@ -874,11 +890,21 @@ const Scheduling = () => {
               "p-2 rounded-lg transition-colors",
               laborCostSummary.isAverageHigh
                 ? "bg-destructive/10 group-hover:bg-destructive/15"
-                : "bg-success/10 group-hover:bg-success/15"
+                : laborBudgetData.hasBudget && laborBudgetData.tier === 'danger'
+                  ? "bg-destructive/10 group-hover:bg-destructive/15"
+                  : laborBudgetData.hasBudget && laborBudgetData.tier === 'warning'
+                    ? "bg-warning/10 group-hover:bg-warning/15"
+                    : "bg-success/10 group-hover:bg-success/15"
             )}>
               <DollarSign className={cn(
                 "h-4 w-4",
-                laborCostSummary.isAverageHigh ? "text-destructive" : "text-success"
+                laborCostSummary.isAverageHigh
+                  ? "text-destructive"
+                  : laborBudgetData.hasBudget && laborBudgetData.tier === 'danger'
+                    ? "text-destructive"
+                    : laborBudgetData.hasBudget && laborBudgetData.tier === 'warning'
+                      ? "text-warning"
+                      : "text-success"
               )} />
             </div>
           </CardHeader>
@@ -970,6 +996,8 @@ const Scheduling = () => {
                     />
                   </div>
                 )}
+                {/* Labor Budget Comparison */}
+                <LaborBudgetIndicator budgetData={laborBudgetData} />
               </>
             )}
           </CardContent>

--- a/tests/unit/useScheduleLaborBudget.test.ts
+++ b/tests/unit/useScheduleLaborBudget.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from 'vitest';
+import { calculateLaborBudget, type LaborBudgetData } from '@/hooks/useScheduleLaborBudget';
+import type { OperatingCost, BreakEvenData } from '@/types/operatingCosts';
+
+// Helper to create a minimal labor operating cost entry
+function makeLaborEntry(overrides: Partial<OperatingCost> = {}): OperatingCost {
+  return {
+    id: 'labor-1',
+    restaurantId: 'rest-1',
+    costType: 'variable',
+    category: 'labor',
+    name: 'Labor Target',
+    entryType: 'percentage',
+    monthlyValue: 0,
+    percentageValue: 0.32,
+    isAutoCalculated: false,
+    manualOverride: false,
+    averagingMonths: 3,
+    displayOrder: 2,
+    isActive: true,
+    createdAt: '2026-01-01',
+    updatedAt: '2026-01-01',
+    ...overrides,
+  };
+}
+
+// Helper to create minimal break-even data
+function makeBreakEvenData(overrides: Partial<BreakEvenData> = {}): BreakEvenData {
+  return {
+    dailyBreakEven: 3000,
+    monthlyBreakEven: 90000,
+    yearlyBreakEven: 1080000,
+    totalVariablePercent: 0.40,
+    contributionMargin: 0.60,
+    todaySales: 3500,
+    todayStatus: 'above',
+    todayDelta: 500,
+    fixedCosts: { items: [], totalDaily: 1800, totalMonthly: 54000, totalYearly: 648000 },
+    variableCosts: { items: [], totalDaily: 1120, avgDailySales: 2800 },
+    history: [],
+    daysAbove: 10,
+    daysBelow: 4,
+    avgSurplus: 300,
+    avgShortfall: -200,
+    ...overrides,
+  };
+}
+
+describe('calculateLaborBudget', () => {
+  describe('no labor entry configured', () => {
+    it('returns hasBudget: false when no labor entry exists', () => {
+      const result = calculateLaborBudget(1000, [], null);
+      expect(result.hasBudget).toBe(false);
+      expect(result.weeklyTarget).toBe(0);
+      expect(result.laborEntry).toBeNull();
+    });
+  });
+
+  describe('fixed amount budget', () => {
+    it('calculates weekly target from monthly value in cents', () => {
+      const entry = makeLaborEntry({
+        entryType: 'value',
+        monthlyValue: 600000, // $6,000/mo in cents
+        percentageValue: 0,
+      });
+      const result = calculateLaborBudget(1000, [entry], null);
+      expect(result.hasBudget).toBe(true);
+      expect(result.source).toBe('fixed');
+      // $6,000/mo ÷ 100 (cents) ÷ 30 days × 7 days = $1,400/wk
+      expect(result.weeklyTarget).toBeCloseTo(1400, 0);
+    });
+
+    it('calculates percentage and variance correctly', () => {
+      const entry = makeLaborEntry({
+        entryType: 'value',
+        monthlyValue: 600000, // → $1,400/wk
+      });
+      const result = calculateLaborBudget(1050, [entry], null);
+      // 1050 / 1400 = 75%
+      expect(result.percentage).toBeCloseTo(75, 0);
+      expect(result.variance).toBeCloseTo(350, 0); // 1400 - 1050 = 350 under budget
+      expect(result.tier).toBe('success');
+    });
+  });
+
+  describe('percentage budget with sales data', () => {
+    it('uses avgDailySales when available', () => {
+      const entry = makeLaborEntry({ percentageValue: 0.32 });
+      const breakEven = makeBreakEvenData({
+        variableCosts: { items: [], totalDaily: 896, avgDailySales: 2800 },
+      });
+      const result = calculateLaborBudget(4000, [entry], breakEven);
+      expect(result.hasBudget).toBe(true);
+      expect(result.source).toBe('sales');
+      // $2,800/day × 0.32 × 7 = $6,272/wk
+      expect(result.weeklyTarget).toBeCloseTo(6272, 0);
+      // 4000 / 6272 ≈ 63.8%
+      expect(result.percentage).toBeCloseTo(63.8, 0);
+      expect(result.tier).toBe('success');
+    });
+  });
+
+  describe('percentage budget without sales data (break-even fallback)', () => {
+    it('uses dailyBreakEven when avgDailySales is 0', () => {
+      const entry = makeLaborEntry({ percentageValue: 0.32 });
+      const breakEven = makeBreakEvenData({
+        dailyBreakEven: 3000,
+        variableCosts: { items: [], totalDaily: 0, avgDailySales: 0 },
+      });
+      const result = calculateLaborBudget(5000, [entry], breakEven);
+      expect(result.hasBudget).toBe(true);
+      expect(result.source).toBe('breakeven');
+      // $3,000/day × 0.32 × 7 = $6,720/wk
+      expect(result.weeklyTarget).toBeCloseTo(6720, 0);
+    });
+
+    it('returns hasBudget false when break-even is Infinity', () => {
+      const entry = makeLaborEntry({ percentageValue: 0.32 });
+      const breakEven = makeBreakEvenData({
+        dailyBreakEven: Infinity,
+        variableCosts: { items: [], totalDaily: 0, avgDailySales: 0 },
+      });
+      const result = calculateLaborBudget(5000, [entry], breakEven);
+      expect(result.hasBudget).toBe(false);
+    });
+
+    it('returns hasBudget false when no break-even data at all', () => {
+      const entry = makeLaborEntry({ percentageValue: 0.32 });
+      const result = calculateLaborBudget(5000, [entry], null);
+      expect(result.hasBudget).toBe(false);
+    });
+  });
+
+  describe('tier classification', () => {
+    it('returns success tier when under 80%', () => {
+      const entry = makeLaborEntry({ entryType: 'value', monthlyValue: 600000 }); // $1,400/wk
+      const result = calculateLaborBudget(700, [entry], null); // 50%
+      expect(result.tier).toBe('success');
+    });
+
+    it('returns warning tier when 80-100%', () => {
+      const entry = makeLaborEntry({ entryType: 'value', monthlyValue: 600000 }); // $1,400/wk
+      const result = calculateLaborBudget(1260, [entry], null); // 90%
+      expect(result.tier).toBe('warning');
+    });
+
+    it('returns danger tier when over 100%', () => {
+      const entry = makeLaborEntry({ entryType: 'value', monthlyValue: 600000 }); // $1,400/wk
+      const result = calculateLaborBudget(1540, [entry], null); // 110%
+      expect(result.tier).toBe('danger');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles zero scheduled labor cost', () => {
+      const entry = makeLaborEntry({ entryType: 'value', monthlyValue: 600000 });
+      const result = calculateLaborBudget(0, [entry], null);
+      expect(result.percentage).toBe(0);
+      expect(result.variance).toBeCloseTo(1400, 0);
+      expect(result.tier).toBe('success');
+    });
+
+    it('handles zero monthly value for fixed budget', () => {
+      const entry = makeLaborEntry({ entryType: 'value', monthlyValue: 0 });
+      const result = calculateLaborBudget(1000, [entry], null);
+      expect(result.hasBudget).toBe(false);
+    });
+
+    it('picks first labor entry when multiple exist', () => {
+      const entries = [
+        makeLaborEntry({ id: 'first', percentageValue: 0.30, displayOrder: 1 }),
+        makeLaborEntry({ id: 'second', percentageValue: 0.40, displayOrder: 2 }),
+      ];
+      const breakEven = makeBreakEvenData({
+        variableCosts: { items: [], totalDaily: 840, avgDailySales: 2800 },
+      });
+      const result = calculateLaborBudget(4000, entries, breakEven);
+      // Uses first entry: 2800 × 0.30 × 7 = $5,880
+      expect(result.weeklyTarget).toBeCloseTo(5880, 0);
+      expect(result.laborEntry?.id).toBe('first');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `useScheduleLaborBudget` hook that computes weekly labor budget target from operating costs (supports fixed amount, percentage with sales data, and break-even fallback)
- Add `LaborBudgetIndicator` component with collapsible budget comparison UI featuring 3-tier color-coded progress bar (green <80%, amber 80-100%, soft red >100%)
- Integrate into the Labor Cost card on the Scheduling page — card border, icon, and gradient corner adapt to budget tier

## Design
[Spec](docs/superpowers/specs/2026-04-10-scheduling-labor-budget-comparison-design.md)

## Test plan
- [x] 13 unit tests for `calculateLaborBudget` covering all calculation paths and edge cases
- [x] TypeScript typecheck passes
- [x] Production build succeeds
- [x] CodeRabbit review: no findings
- [ ] Manual verification: scheduling page shows budget indicator when labor budget is configured
- [ ] Manual verification: "No labor budget set" with Configure link when no budget exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Labor Budget indicator on Scheduling that shows budget status, progress bar, color-coded tiers, and a toggle for detailed comparison.
  * Shows weekly target, percentage, and variance; offers a “Configure →” action when no budget is set.
* **Integration**
  * Scheduling page now reflects labor budget tiers in card styling and includes the new indicator.
* **Tests**
  * Unit tests added covering budget calculations and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->