### PR TITLE
fix: restore original migration to fix production deploy

### DIFF
--- a/supabase/migrations/20260411000000_add_shift_source_column.sql
+++ b/supabase/migrations/20260411000000_add_shift_source_column.sql
@@ -1,0 +1,4 @@
+-- Add source column to track how shifts were created
+ALTER TABLE shifts ADD COLUMN source TEXT NOT NULL DEFAULT 'manual';
+
+COMMENT ON COLUMN shifts.source IS 'How this shift was created: manual, ai, or template';

--- a/supabase/migrations/20260411200000_add_shift_source_column.sql
+++ b/supabase/migrations/20260411200000_add_shift_source_column.sql
@@ -1,8 +1,4 @@
--- Add source column to track how shifts were created
-ALTER TABLE shifts ADD COLUMN source TEXT NOT NULL DEFAULT 'manual';
-
+-- Add CHECK constraint to enforce valid source values
 ALTER TABLE shifts
   ADD CONSTRAINT shifts_source_check
   CHECK (source IN ('manual', 'ai', 'template'));
-
-COMMENT ON COLUMN shifts.source IS 'How this shift was created: manual, ai, or template';


### PR DESCRIPTION
## Summary

- Fixes `supabase db push` failure on production deploy after merging PR #449
- Root cause: PR #448 applied migration `20260411000000` to production, PR #449 renamed it to `20260411200000` — remote DB couldn't find its existing migration locally

## Changes

- Restore `20260411000000_add_shift_source_column.sql` with original content (ADD COLUMN)
- Reduce `20260411200000_add_shift_source_column.sql` to only the CHECK constraint

## Test plan

- [x] `npm run db:reset` applies both migrations successfully
- [x] Local DB has `source` column with CHECK constraint

🤖 Generated with [Claude Code](https://claude.com/claude-code)