### PR TITLE
feat: shift template capacity for open shift detection

### DIFF
--- a/docs/superpowers/plans/2026-04-11-open-shift-capacity-plan.md
+++ b/docs/superpowers/plans/2026-04-11-open-shift-capacity-plan.md
@@ -1,0 +1,671 @@
+# Open Shift Capacity — Implementation Plan (PR1)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Managers can set staffing capacity on shift templates and see at a glance where they're short-staffed in the planner grid.
+
+**Architecture:** Add a `capacity` column (default 1) to `shift_templates`. The planner grid compares `capacity` vs count of assigned shifts per template/day to show "assigned/needed" indicators. The publish dialog warns about unfilled spots. No new tables — this is a read-side enhancement to existing data.
+
+**Tech Stack:** PostgreSQL migration, TypeScript/React, React Query, Vitest, pgTAP, Playwright
+
+**Design spec:** `docs/superpowers/specs/2026-04-11-open-shift-claiming-design.md`
+
+---
+
+### Task 1: Add `capacity` column to `shift_templates`
+
+**Files:**
+- Create: `supabase/migrations/YYYYMMDDHHMMSS_add_capacity_to_shift_templates.sql`
+- Create: `supabase/tests/shift_template_capacity.test.sql`
+
+- [ ] **Step 1: Write the pgTAP test**
+
+Create `supabase/tests/shift_template_capacity.test.sql`:
+
+```sql
+BEGIN;
+SELECT plan(5);
+
+-- Test 1: capacity column exists with default 1
+SELECT has_column('shift_templates', 'capacity',
+  'shift_templates should have a capacity column');
+
+SELECT col_default_is('shift_templates', 'capacity', '1',
+  'capacity should default to 1');
+
+-- Test 2: capacity must be >= 1
+SELECT lives_ok(
+  $$INSERT INTO shift_templates (restaurant_id, name, days, start_time, end_time, position, capacity)
+    VALUES ((SELECT id FROM restaurants LIMIT 1), 'Test', '{1,2}', '09:00', '17:00', 'Server', 3)$$,
+  'capacity of 3 is valid'
+);
+
+SELECT throws_ok(
+  $$INSERT INTO shift_templates (restaurant_id, name, days, start_time, end_time, position, capacity)
+    VALUES ((SELECT id FROM restaurants LIMIT 1), 'Test Zero', '{1}', '09:00', '17:00', 'Server', 0)$$,
+  '23514',
+  NULL,
+  'capacity of 0 violates check constraint'
+);
+
+SELECT throws_ok(
+  $$INSERT INTO shift_templates (restaurant_id, name, days, start_time, end_time, position, capacity)
+    VALUES ((SELECT id FROM restaurants LIMIT 1), 'Test Neg', '{1}', '09:00', '17:00', 'Server', -1)$$,
+  '23514',
+  NULL,
+  'negative capacity violates check constraint'
+);
+
+SELECT * FROM finish();
+ROLLBACK;
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test:db`
+Expected: FAIL — column `capacity` does not exist.
+
+- [ ] **Step 3: Write the migration**
+
+Create the migration file (use `npx supabase migration new add_capacity_to_shift_templates` to get the timestamp):
+
+```sql
+-- Add capacity column to shift_templates
+-- Represents how many employees are needed for this shift slot
+ALTER TABLE shift_templates
+  ADD COLUMN capacity INTEGER NOT NULL DEFAULT 1;
+
+ALTER TABLE shift_templates
+  ADD CONSTRAINT valid_capacity CHECK (capacity >= 1);
+```
+
+- [ ] **Step 4: Reset the database and run tests**
+
+Run: `npx supabase db reset && npm run test:db`
+Expected: All pgTAP tests pass, including the new capacity tests.
+
+- [ ] **Step 5: Regenerate TypeScript types**
+
+Run: `npx supabase gen types typescript --local > src/integrations/supabase/types.ts`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add supabase/migrations/*_add_capacity_to_shift_templates.sql supabase/tests/shift_template_capacity.test.sql src/integrations/supabase/types.ts
+git commit -m "feat: add capacity column to shift_templates"
+```
+
+---
+
+### Task 2: Update `ShiftTemplate` TypeScript type and hook
+
+**Files:**
+- Modify: `src/types/scheduling.ts:111-123`
+- Modify: `src/hooks/useShiftTemplates.ts:25-33` (TemplateInput type) and mutation
+
+- [ ] **Step 1: Write the failing unit test**
+
+Create `tests/unit/shiftTemplateCapacity.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+
+// We're testing the type + a pure helper that computes open spots
+import { computeOpenSpots } from '@/lib/openShiftHelpers';
+
+describe('computeOpenSpots', () => {
+  it('returns capacity minus assigned count', () => {
+    expect(computeOpenSpots(3, 1)).toBe(2);
+  });
+
+  it('returns 0 when fully staffed', () => {
+    expect(computeOpenSpots(2, 2)).toBe(0);
+  });
+
+  it('returns 0 when over-staffed (clamped)', () => {
+    expect(computeOpenSpots(2, 3)).toBe(0);
+  });
+
+  it('returns full capacity when nobody assigned', () => {
+    expect(computeOpenSpots(3, 0)).toBe(3);
+  });
+
+  it('defaults capacity to 1 when undefined', () => {
+    expect(computeOpenSpots(undefined, 0)).toBe(1);
+    expect(computeOpenSpots(undefined, 1)).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run tests/unit/shiftTemplateCapacity.test.ts`
+Expected: FAIL — `computeOpenSpots` does not exist.
+
+- [ ] **Step 3: Add `capacity` to the ShiftTemplate type**
+
+In `src/types/scheduling.ts`, add `capacity` to the `ShiftTemplate` interface:
+
+```typescript
+export interface ShiftTemplate {
+  id: string;
+  restaurant_id: string;
+  name: string;
+  days: number[];
+  start_time: string;
+  end_time: string;
+  break_duration: number;
+  position: string;
+  capacity: number; // How many employees needed (default 1)
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+```
+
+- [ ] **Step 4: Create the `openShiftHelpers` module**
+
+Create `src/lib/openShiftHelpers.ts`:
+
+```typescript
+/**
+ * Compute how many open spots remain for a template on a given day.
+ * Clamps to 0 (never negative).
+ */
+export function computeOpenSpots(
+  capacity: number | undefined,
+  assignedCount: number,
+): number {
+  const cap = capacity ?? 1;
+  return Math.max(0, cap - assignedCount);
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npx vitest run tests/unit/shiftTemplateCapacity.test.ts`
+Expected: PASS
+
+- [ ] **Step 6: Update `useShiftTemplates` to include `capacity` in mutations**
+
+In `src/hooks/useShiftTemplates.ts`, the `TemplateInput` type (line 33) already uses `Omit<ShiftTemplate, 'id' | 'created_at' | 'updated_at'>`, so it will automatically include `capacity` from the updated type. No code change needed in the hook itself — the type flows through.
+
+Verify by checking the existing `createMutation` and `updateMutation` — they pass through the input object directly, so `capacity` will be included when provided.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/types/scheduling.ts src/lib/openShiftHelpers.ts tests/unit/shiftTemplateCapacity.test.ts
+git commit -m "feat: add capacity to ShiftTemplate type and open spot helper"
+```
+
+---
+
+### Task 3: Add "Staff Needed" field to `TemplateFormDialog`
+
+**Files:**
+- Modify: `src/components/scheduling/ShiftPlanner/TemplateFormDialog.tsx`
+
+- [ ] **Step 1: Add `capacity` state and form field**
+
+In `TemplateFormDialog.tsx`, add a `capacity` state variable alongside the existing form state (after line 50):
+
+```typescript
+const [capacity, setCapacity] = useState(1);
+```
+
+In the `useEffect` that pre-fills the form (lines 54-71), add capacity handling:
+
+```typescript
+// Inside the if (template) block, after setBreakDuration:
+setCapacity(template.capacity ?? 1);
+
+// Inside the else block, after setBreakDuration(0):
+setCapacity(1);
+```
+
+- [ ] **Step 2: Add the capacity field to the form UI**
+
+Add this block after the Break Duration field (after line 246) and before the Footer:
+
+```tsx
+{/* Staff Needed */}
+<div className="space-y-1.5">
+  <Label
+    htmlFor="capacity"
+    className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider"
+  >
+    Staff Needed
+  </Label>
+  <Input
+    id="capacity"
+    type="number"
+    min={1}
+    value={capacity}
+    onChange={(e) => setCapacity(Math.max(1, Number.parseInt(e.target.value, 10) || 1))}
+    className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
+  />
+  <p className="text-[11px] text-muted-foreground">
+    How many employees are needed for this shift
+  </p>
+</div>
+```
+
+- [ ] **Step 3: Include `capacity` in the onSubmit call**
+
+Update the `handleSubmit` function's `onSubmit` call (lines 87-94) to include capacity:
+
+```typescript
+await onSubmit({
+  name: name.trim(),
+  start_time: startTime,
+  end_time: endTime,
+  position: position.trim(),
+  days,
+  break_duration: breakDuration,
+  capacity,
+});
+```
+
+- [ ] **Step 4: Update the `onSubmit` prop type to include `capacity`**
+
+In the `TemplateFormDialogProps` interface (lines 25-31), add `capacity` to the data shape:
+
+```typescript
+onSubmit: (data: {
+  name: string;
+  start_time: string;
+  end_time: string;
+  position: string;
+  days: number[];
+  break_duration: number;
+  capacity: number;
+}) => void | Promise<void>;
+```
+
+- [ ] **Step 5: Run typecheck to confirm no type errors**
+
+Run: `npm run typecheck`
+Expected: No new errors. The callers of `TemplateFormDialog` pass `onSubmit` through to `createTemplate`/`updateTemplate`, which accept `TemplateInput`. Since `TemplateInput` now includes `capacity`, the types align.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/scheduling/ShiftPlanner/TemplateFormDialog.tsx
+git commit -m "feat: add Staff Needed field to template form dialog"
+```
+
+---
+
+### Task 4: Show capacity indicators in the planner grid
+
+**Files:**
+- Modify: `src/components/scheduling/ShiftPlanner/ShiftCell.tsx`
+- Modify: `src/components/scheduling/ShiftPlanner/TemplateGrid.tsx`
+- Create: `tests/unit/openShiftHelpers.test.ts` (already created in Task 2, extend)
+
+- [ ] **Step 1: Write the failing test for the capacity indicator logic**
+
+Extend `tests/unit/shiftTemplateCapacity.test.ts` with indicator classification:
+
+```typescript
+import { computeOpenSpots, classifyCapacity } from '@/lib/openShiftHelpers';
+
+describe('classifyCapacity', () => {
+  it('returns "full" when no open spots', () => {
+    expect(classifyCapacity(3, 3)).toBe('full');
+  });
+
+  it('returns "partial" when some spots filled', () => {
+    expect(classifyCapacity(3, 1)).toBe('partial');
+  });
+
+  it('returns "empty" when no spots filled', () => {
+    expect(classifyCapacity(3, 0)).toBe('empty');
+  });
+
+  it('returns "full" for default capacity of 1 with 1 assigned', () => {
+    expect(classifyCapacity(1, 1)).toBe('full');
+  });
+
+  it('returns "full" when over-staffed', () => {
+    expect(classifyCapacity(2, 3)).toBe('full');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run tests/unit/shiftTemplateCapacity.test.ts`
+Expected: FAIL — `classifyCapacity` does not exist.
+
+- [ ] **Step 3: Implement `classifyCapacity`**
+
+Add to `src/lib/openShiftHelpers.ts`:
+
+```typescript
+export type CapacityStatus = 'full' | 'partial' | 'empty';
+
+/**
+ * Classify how filled a template slot is on a given day.
+ */
+export function classifyCapacity(
+  capacity: number | undefined,
+  assignedCount: number,
+): CapacityStatus {
+  const open = computeOpenSpots(capacity, assignedCount);
+  if (open === 0) return 'full';
+  if (assignedCount > 0) return 'partial';
+  return 'empty';
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run tests/unit/shiftTemplateCapacity.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Pass `capacity` through `TemplateGrid` to `ShiftCell`**
+
+In `src/components/scheduling/ShiftPlanner/TemplateGrid.tsx`, update `ShiftCell` usage (line 96-105) to pass capacity:
+
+```tsx
+<ShiftCell
+  templateId={template.id}
+  day={day}
+  isActiveDay={isActiveDay}
+  shifts={shifts}
+  capacity={template.capacity ?? 1}
+  onRemoveShift={onRemoveShift}
+  isHighlighted={highlightCellId === `${template.id}:${day}`}
+  onMobileTap={onMobileCellTap}
+  hasMobileSelection={hasMobileSelection}
+/>
+```
+
+- [ ] **Step 6: Add capacity indicator to `ShiftCell`**
+
+In `src/components/scheduling/ShiftPlanner/ShiftCell.tsx`:
+
+Add import at top:
+```typescript
+import { computeOpenSpots, classifyCapacity } from '@/lib/openShiftHelpers';
+```
+
+Add `capacity` to the `ShiftCellProps` interface (after line 15):
+```typescript
+capacity: number;
+```
+
+Add the indicator inside the active-day return (after the shifts map, before the closing `</div>`, around line 70):
+
+```tsx
+{/* Capacity indicator — only show when capacity > 1 */}
+{capacity > 1 && (
+  <div
+    className={cn(
+      'text-[10px] font-medium px-1.5 py-0.5 rounded text-center',
+      classifyCapacity(capacity, shifts.length) === 'full'
+        ? 'text-emerald-600 bg-emerald-500/10'
+        : classifyCapacity(capacity, shifts.length) === 'partial'
+          ? 'text-amber-600 bg-amber-500/10'
+          : 'text-red-500 bg-red-500/10',
+    )}
+  >
+    {shifts.length}/{capacity}
+  </div>
+)}
+```
+
+Update the memo comparison (lines 74-82) to include `capacity`:
+```typescript
+(prev, next) =>
+  prev.templateId === next.templateId &&
+  prev.day === next.day &&
+  prev.isActiveDay === next.isActiveDay &&
+  prev.shifts === next.shifts &&
+  prev.capacity === next.capacity &&
+  prev.onRemoveShift === next.onRemoveShift &&
+  prev.isHighlighted === next.isHighlighted &&
+  prev.hasMobileSelection === next.hasMobileSelection &&
+  prev.onMobileTap === next.onMobileTap,
+```
+
+- [ ] **Step 7: Run typecheck**
+
+Run: `npm run typecheck`
+Expected: No errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/lib/openShiftHelpers.ts src/components/scheduling/ShiftPlanner/ShiftCell.tsx src/components/scheduling/ShiftPlanner/TemplateGrid.tsx tests/unit/shiftTemplateCapacity.test.ts
+git commit -m "feat: show capacity indicators in planner grid cells"
+```
+
+---
+
+### Task 5: Add open shift count to publish dialog
+
+**Files:**
+- Modify: `src/components/PublishScheduleDialog.tsx`
+
+- [ ] **Step 1: Add `openShiftCount` prop**
+
+In `PublishScheduleDialogProps` (lines 23-33), add:
+
+```typescript
+openShiftCount: number;
+```
+
+- [ ] **Step 2: Add the info alert when there are open shifts**
+
+After the Summary Stats grid (after line 98) and before the Warning Alert (line 101), add:
+
+```tsx
+{openShiftCount > 0 && (
+  <Alert className="border-amber-500/50 bg-amber-500/10">
+    <AlertTriangle className="h-4 w-4 text-amber-600" />
+    <AlertDescription className="text-sm">
+      <strong>{openShiftCount} {openShiftCount === 1 ? 'shift' : 'shifts'} still {openShiftCount === 1 ? 'needs' : 'need'} staff.</strong>{' '}
+      You can fill these now or broadcast to your team later.
+    </AlertDescription>
+  </Alert>
+)}
+```
+
+- [ ] **Step 3: Compute `openShiftCount` at the call site**
+
+Find where `PublishScheduleDialog` is rendered in `src/pages/Scheduling.tsx`. Add a `useMemo` that computes total open spots for the week:
+
+```typescript
+import { computeOpenSpots } from '@/lib/openShiftHelpers';
+
+const openShiftCount = useMemo(() => {
+  if (!templates.length) return 0;
+  let total = 0;
+  for (const template of templates) {
+    for (const day of weekDays) {
+      if (!templateAppliesToDay(template, day)) continue;
+      const assigned = templateGridData.get(template.id)?.get(day)?.length ?? 0;
+      total += computeOpenSpots(template.capacity, assigned);
+    }
+  }
+  return total;
+}, [templates, weekDays, templateGridData]);
+```
+
+Pass it to the dialog:
+
+```tsx
+<PublishScheduleDialog
+  // ...existing props
+  openShiftCount={openShiftCount}
+/>
+```
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `npm run typecheck`
+Expected: No errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/PublishScheduleDialog.tsx src/pages/Scheduling.tsx
+git commit -m "feat: show open shift count in publish schedule dialog"
+```
+
+---
+
+### Task 6: E2E test — manager sets capacity and sees indicators
+
+**Files:**
+- Create: `tests/e2e/shift-template-capacity.spec.ts`
+
+- [ ] **Step 1: Write the E2E test**
+
+Create `tests/e2e/shift-template-capacity.spec.ts`:
+
+```typescript
+import { test, expect } from '@playwright/test';
+import {
+  generateTestUser,
+  signUpAndOnboard,
+  cleanupTestUser,
+} from '../helpers/e2e-supabase';
+
+test.describe('Shift template capacity', () => {
+  let testUser: ReturnType<typeof generateTestUser>;
+
+  test.beforeEach(async ({ page }) => {
+    testUser = generateTestUser();
+    await signUpAndOnboard(page, testUser);
+  });
+
+  test.afterEach(async () => {
+    await cleanupTestUser(testUser.email);
+  });
+
+  test('manager can set staff needed on a template and see capacity indicator', async ({ page }) => {
+    // Navigate to scheduling
+    await page.goto('/scheduling');
+    await page.waitForLoadState('networkidle');
+
+    // Click "Add Shift Template"
+    await page.getByRole('button', { name: /add shift template/i }).click();
+
+    // Fill out the template form
+    const dialog = page.getByRole('dialog', { name: /add shift template/i });
+    await dialog.getByLabel(/template name/i).fill('Closing Server');
+    await dialog.getByLabel(/start time/i).fill('16:00');
+    await dialog.getByLabel(/end time/i).fill('22:00');
+    await dialog.getByLabel(/position/i).fill('Server');
+
+    // Select Monday
+    await dialog.getByRole('button', { name: 'Monday' }).click();
+
+    // Set staff needed to 3
+    await dialog.getByLabel(/staff needed/i).clear();
+    await dialog.getByLabel(/staff needed/i).fill('3');
+
+    // Submit
+    await dialog.getByRole('button', { name: /add template/i }).click();
+
+    // Verify template was created (row header should show)
+    await expect(page.getByText('Closing Server')).toBeVisible();
+
+    // Verify capacity indicator shows 0/3 on Monday (no one assigned yet)
+    await expect(page.getByText('0/3')).toBeVisible();
+  });
+
+  test('capacity defaults to 1 and no indicator shown', async ({ page }) => {
+    // Navigate to scheduling
+    await page.goto('/scheduling');
+    await page.waitForLoadState('networkidle');
+
+    // Click "Add Shift Template"
+    await page.getByRole('button', { name: /add shift template/i }).click();
+
+    // Fill out the template form without changing capacity
+    const dialog = page.getByRole('dialog', { name: /add shift template/i });
+    await dialog.getByLabel(/template name/i).fill('Morning Cashier');
+    await dialog.getByLabel(/start time/i).fill('06:00');
+    await dialog.getByLabel(/end time/i).fill('14:00');
+    await dialog.getByLabel(/position/i).fill('Cashier');
+    await dialog.getByRole('button', { name: 'Tuesday' }).click();
+
+    // Verify staff needed defaults to 1
+    await expect(dialog.getByLabel(/staff needed/i)).toHaveValue('1');
+
+    // Submit
+    await dialog.getByRole('button', { name: /add template/i }).click();
+
+    // Verify template was created
+    await expect(page.getByText('Morning Cashier')).toBeVisible();
+
+    // No capacity indicator should show (capacity=1 is hidden)
+    await expect(page.getByText(/0\/1/)).not.toBeVisible();
+  });
+});
+```
+
+- [ ] **Step 2: Run the E2E test**
+
+Run: `npx playwright test tests/e2e/shift-template-capacity.spec.ts`
+Expected: PASS (all previous tasks must be implemented first).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/e2e/shift-template-capacity.spec.ts
+git commit -m "test: E2E for shift template capacity and indicators"
+```
+
+---
+
+### Task 7: Update `TemplateRowHeader` to show capacity
+
+**Files:**
+- Modify: `src/components/scheduling/ShiftPlanner/TemplateRowHeader.tsx`
+
+- [ ] **Step 1: Add capacity display to the desktop header**
+
+In `src/components/scheduling/ShiftPlanner/TemplateRowHeader.tsx`, the desktop layout (lines 37-48) shows name, time range, and position. Add a "Need N" label after the position line (after line 47, inside the `hidden md:block` div):
+
+```tsx
+{/* Desktop: full name + time + position */}
+<div className="hidden md:block min-w-0">
+  <div className="text-[14px] font-medium text-foreground truncate">
+    {template.name}
+  </div>
+  <div className="text-[12px] text-muted-foreground">
+    {formatCompactTemplateTime(template.start_time)}-
+    {formatCompactTemplateTime(template.end_time)}
+  </div>
+  <div className="text-[12px] text-muted-foreground">
+    {template.position}
+  </div>
+  {template.capacity > 1 && (
+    <div className="text-[10px] font-medium text-amber-600">
+      Need {template.capacity}
+    </div>
+  )}
+</div>
+```
+
+- [ ] **Step 2: Update the memo comparison to include capacity**
+
+The current memo comparison (lines 83-88) only checks `template.id` and `template.updated_at`. Since `capacity` is part of the template object and `updated_at` changes when capacity is modified, this already works correctly. No change needed.
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `npm run typecheck`
+Expected: No errors (capacity is already on the ShiftTemplate type).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/scheduling/ShiftPlanner/TemplateRowHeader.tsx
+git commit -m "feat: show capacity in template row header"
+```

--- a/docs/superpowers/specs/2026-04-11-open-shift-claiming-design.md
+++ b/docs/superpowers/specs/2026-04-11-open-shift-claiming-design.md
@@ -1,0 +1,207 @@
+# Open Shift Claiming — Design Spec
+
+**Date:** 2026-04-11
+**Status:** Draft
+
+## Problem
+
+Managers set staffing needs (e.g., "need 3 closers") but currently must manually assign every employee. When a manager assigns 1 of 3 needed closers and wants the other 2 spots filled voluntarily, there's no mechanism for employees to see and claim those open spots. Managers resort to texting employees individually.
+
+## Solution
+
+Capacity-based open shift detection with employee self-service claiming. Managers define how many people they need per template. Unfilled spots surface automatically in a unified employee feed alongside existing shift trades. Employees claim spots directly (instant by default, configurable to require approval). Managers can optionally broadcast openings to eligible team members.
+
+## Delivery Plan
+
+Three value-based PRs, each independently useful:
+
+| PR | User Value | Scope |
+|----|-----------|-------|
+| PR1: Managers can see open shifts | Managers see at a glance where they're short-staffed | Capacity on templates, gap detection, planner indicators |
+| PR2: Employees can claim open shifts | Employees pick up extra hours on their own | Unified feed, claim flow, approval config |
+| PR3: Managers can broadcast openings | Managers actively recruit for gaps instead of texting | Broadcast action with preview, notifications |
+
+## Architecture
+
+### Database Changes
+
+#### 1. Add `capacity` to `shift_templates`
+
+```sql
+ALTER TABLE shift_templates ADD COLUMN capacity INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE shift_templates ADD CONSTRAINT valid_capacity CHECK (capacity >= 1);
+```
+
+The `capacity` column represents how many employees are needed for this template slot. Current behavior (1 employee per template) is preserved by the default of 1.
+
+#### 2. New table: `open_shift_claims`
+
+Separate from `shift_trades` because the semantics differ: trades are employee-initiated swaps of existing assigned shifts; claims are employee requests for unassigned capacity.
+
+```sql
+CREATE TABLE open_shift_claims (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  restaurant_id UUID NOT NULL REFERENCES restaurants(id) ON DELETE CASCADE,
+  shift_template_id UUID NOT NULL REFERENCES shift_templates(id) ON DELETE CASCADE,
+  shift_date DATE NOT NULL,
+  claimed_by_employee_id UUID NOT NULL REFERENCES employees(id) ON DELETE CASCADE,
+  status TEXT NOT NULL DEFAULT 'approved'
+    CHECK (status IN ('pending_approval', 'approved', 'rejected', 'cancelled')),
+  resulting_shift_id UUID REFERENCES shifts(id) ON DELETE SET NULL,
+  reviewed_by UUID REFERENCES auth.users(id),
+  reviewed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+```
+
+Key points:
+- `shift_template_id` + `shift_date` identifies which open slot is being claimed
+- `status` defaults to `'approved'` (instant claim mode). When approval is required, the insert sets `'pending_approval'` instead
+- `resulting_shift_id` links to the actual shift created when the claim is approved — the claim creates a real `shifts` row assigned to the employee
+- Unique constraint prevents double-claiming: `UNIQUE(shift_template_id, shift_date, claimed_by_employee_id)`
+
+#### 3. Add `require_shift_claim_approval` to `staffing_settings`
+
+```sql
+ALTER TABLE staffing_settings
+  ADD COLUMN require_shift_claim_approval BOOLEAN NOT NULL DEFAULT false;
+```
+
+Per-restaurant setting. Default `false` = instant claim (manager already expressed the need). Follows the existing pattern of domain-specific settings tables.
+
+#### 4. Add `broadcast_sent_at` tracking
+
+```sql
+-- Track which weeks have been broadcasted to avoid duplicate notifications
+ALTER TABLE schedule_publications
+  ADD COLUMN open_shifts_broadcast_at TIMESTAMPTZ,
+  ADD COLUMN open_shifts_broadcast_by UUID REFERENCES auth.users(id);
+```
+
+### Open Shift Detection (computed, not stored)
+
+Open shifts are **not stored in a table** — they're computed at query time by comparing template capacity against assigned shifts:
+
+```
+open_spots(template, date) = template.capacity - count(shifts matching template on date)
+```
+
+A shift "matches" a template when:
+- Same `restaurant_id`
+- Same `position`
+- Overlapping time range (start_time/end_time)
+- Date falls on one of the template's `days`
+- Shift is not cancelled
+
+This is computed in a SQL function `get_open_shifts(p_restaurant_id, p_week_start, p_week_end)` that returns template + date + open_spots for all templates with unfilled capacity in the date range. Pending claims (status = `'pending_approval'`) count against open spots to prevent over-claiming.
+
+### Data Flow
+
+#### Manager side (PR1)
+
+```
+shift_templates.capacity → get_open_shifts() RPC → ShiftPlannerTab
+                                                    ├── capacity badge on template headers
+                                                    ├── "2/3 assigned" indicators per day cell
+                                                    └── publish dialog shows open shift count
+```
+
+#### Employee side (PR2)
+
+```
+get_open_shifts() + useMarketplaceTrades() → useAvailableShifts() → AvailableShiftsPage
+                                                                      ├── OPEN SHIFT cards (from open shifts)
+                                                                      ├── TRADE cards (from marketplace trades)
+                                                                      └── Claim button → claim_open_shift() RPC
+```
+
+#### Broadcast side (PR3)
+
+```
+Manager clicks "Broadcast" → BroadcastOpenShiftsDialog
+                              ├── preview: which shifts, how many spots
+                              ├── preview: eligible employees (position match, no conflicts)
+                              └── confirm → broadcast-open-shifts edge function
+                                            ├── sends push notification via send-push-notification
+                                            ├── sends email via Resend
+                                            └── stamps schedule_publications.open_shifts_broadcast_at
+```
+
+### Claim Flow Detail
+
+```
+Employee taps "Claim Shift"
+  → claim_open_shift(p_template_id, p_date, p_employee_id) RPC
+    ├── verify open spots remain (capacity - assigned - pending_claims > 0)
+    ├── verify no schedule conflict for employee
+    ├── verify employee position matches template (if position-restricted)
+    ├── check restaurant's require_shift_claim_approval setting
+    │   ├── false → status='approved', create shift row, assign employee
+    │   └── true  → status='pending_approval', no shift created yet
+    └── return claim record
+```
+
+Manager approval (when required):
+```
+Manager approves claim
+  → approve_open_shift_claim(p_claim_id) RPC
+    ├── create shift row from template + date, assign employee
+    ├── update claim: status='approved', resulting_shift_id, reviewed_by/at
+    └── notify employee
+```
+
+### UI Components
+
+#### PR1: Manager Planner Enhancements
+
+- **Template capacity editor** — In the existing template create/edit dialog, add a "Staff needed" number input (default 1). Maps to `shift_templates.capacity`.
+- **Planner cell indicators** — Each day cell for a template shows `assigned/capacity` (e.g., "1/3"). Color-coded: green when full, amber when partially filled, red when empty.
+- **Publish dialog enhancement** — Existing `PublishScheduleDialog` gets a line: "N shifts still need staff. You can fill these now or broadcast to your team later."
+
+#### PR2: Employee Available Shifts Feed
+
+- **Unified `AvailableShiftsPage`** — Replaces current `EmployeeShiftMarketplace`. Same route (`/employee/shifts`). Shows both open shifts and trades in a single virtualized list.
+- **Open shift card** — Green `OPEN SHIFT` badge, template name, date, time, position, spots remaining, "Claim" button. Grayed out with "Conflict" badge if employee has an overlapping shift.
+- **Trade card** — Amber `TRADE` badge (existing design, brought into unified feed).
+- **Claim confirmation** — Brief bottom sheet: "Claim Closing Server on Fri Apr 18, 4p–10p?" with Confirm/Cancel.
+- **Approval setting hint** — In restaurant staffing settings, a toggle "Require manager approval for shift claims" with helper text: "When off, employees are instantly assigned. When on, claims go to your approval queue."
+
+#### PR3: Broadcast & Notifications
+
+- **BroadcastOpenShiftsDialog** — Shows list of open shifts for the published week, count of eligible employees per shift, "Broadcast to N Team Members" button.
+- **Notification** — Push notification (via existing `send-push-notification` function) + email (via Resend). Message: "N shifts are available for the week of [date]. Open the app to claim a spot."
+- **Claim tracking** — Manager sees claimed/pending indicators on planner cells. Approval queue tab gets open shift claims alongside trade approvals.
+
+### RLS Policies
+
+#### open_shift_claims
+- **SELECT:** Employees can see their own claims. Owners/managers can see all claims for their restaurant.
+- **INSERT:** Employees can create claims for their own restaurant (enforced: `claimed_by_employee_id` matches authenticated employee).
+- **UPDATE:** Only owners/managers can update status (approve/reject). Employees can cancel their own pending claims.
+- **DELETE:** None (use status changes).
+
+**Lesson applied:** Staff users need SELECT on `employees` table to see coworker names in the feed. An RLS policy for this already exists from the shift marketplace null-safety fix (2026-04-11 lesson).
+
+### Conflict Detection
+
+Reuses the existing `useConflictDetection` hook pattern:
+- Before showing "Claim" button, check if employee has any shift overlapping the open shift's time range on that date
+- If conflict exists, show the card grayed out with a "Schedule conflict" note
+- The `claim_open_shift` RPC double-checks server-side (client check is for UX, server check is authoritative)
+
+### Edge Cases
+
+1. **Race condition: two employees claim the last spot simultaneously** — The `claim_open_shift` RPC re-checks capacity inside a transaction. Second claimer gets a "no spots remaining" error.
+2. **Manager fills spot manually after employee claims (pending)** — When a shift is manually assigned that fills capacity, pending claims for that slot are auto-rejected.
+3. **Template capacity reduced after open shifts posted** — If capacity drops below current assignments, no action needed (existing assignments stay). Open spots recalculate to 0 or negative (clamped to 0 in the view).
+4. **Employee cancels a claim** — If instant (already has shift), the resulting shift is deleted. If pending, claim status set to 'cancelled'.
+5. **Overnight shifts** — Template with start_time > end_time (e.g., 22:00–06:00) works correctly since capacity is per-template-per-date, not time-based.
+
+### Testing Strategy
+
+| Layer | Tests |
+|-------|-------|
+| SQL (pgTAP) | `get_open_shifts` returns correct gaps; `claim_open_shift` enforces capacity, conflicts, approval mode; race condition handling; RLS policies |
+| Unit (Vitest) | `useAvailableShifts` merges open shifts + trades correctly; conflict detection; capacity computation |
+| E2E (Playwright) | PR1: manager sets capacity, sees indicators. PR2: employee views feed, claims shift, sees it on schedule. PR3: manager broadcasts, employee receives notification |

--- a/src/components/PublishScheduleDialog.tsx
+++ b/src/components/PublishScheduleDialog.tsx
@@ -28,6 +28,7 @@ interface PublishScheduleDialogProps {
   shiftCount: number;
   employeeCount: number;
   totalHours: number;
+  openShiftCount: number;
   onConfirm: (notes?: string) => void;
   isPublishing: boolean;
 }
@@ -40,6 +41,7 @@ export const PublishScheduleDialog = ({
   shiftCount,
   employeeCount,
   totalHours,
+  openShiftCount,
   onConfirm,
   isPublishing,
 }: PublishScheduleDialogProps) => {
@@ -96,6 +98,17 @@ export const PublishScheduleDialog = ({
               </div>
             </div>
           </div>
+
+          {/* Open Shifts Alert */}
+          {openShiftCount > 0 && (
+            <Alert className="border-amber-500/50 bg-amber-500/10">
+              <AlertTriangle className="h-4 w-4 text-amber-600" />
+              <AlertDescription className="text-sm">
+                <strong>{openShiftCount} {openShiftCount === 1 ? 'shift' : 'shifts'} still {openShiftCount === 1 ? 'needs' : 'need'} staff.</strong>{' '}
+                You can fill these now or broadcast to your team later.
+              </AlertDescription>
+            </Alert>
+          )}
 
           {/* Warning Alert */}
           <Alert className="border-yellow-500/50 bg-yellow-500/10">

--- a/src/components/scheduling/ShiftPlanner/ShiftCell.tsx
+++ b/src/components/scheduling/ShiftPlanner/ShiftCell.tsx
@@ -2,6 +2,7 @@ import { memo } from 'react';
 
 import { useDroppable } from '@dnd-kit/core';
 
+import { classifyCapacity } from '@/lib/openShiftHelpers';
 import type { Shift } from '@/types/scheduling';
 
 import { cn } from '@/lib/utils';
@@ -13,6 +14,7 @@ interface ShiftCellProps {
   day: string;
   isActiveDay: boolean;
   shifts: Shift[];
+  capacity: number;
   onRemoveShift: (shiftId: string) => void;
   isHighlighted?: boolean;
   /** Mobile tap-to-assign: called when cell is tapped with an employee selected */
@@ -27,6 +29,7 @@ export const ShiftCell = memo(
     day,
     isActiveDay,
     shifts,
+    capacity,
     onRemoveShift,
     isHighlighted,
     onMobileTap,
@@ -69,6 +72,20 @@ export const ShiftCell = memo(
             onRemove={onRemoveShift}
           />
         ))}
+        {capacity > 1 && (
+          <div
+            className={cn(
+              'text-[10px] font-medium px-1.5 py-0.5 rounded text-center',
+              classifyCapacity(capacity, shifts.length) === 'full'
+                ? 'text-emerald-600 bg-emerald-500/10'
+                : classifyCapacity(capacity, shifts.length) === 'partial'
+                  ? 'text-amber-600 bg-amber-500/10'
+                  : 'text-red-500 bg-red-500/10',
+            )}
+          >
+            {shifts.length}/{capacity}
+          </div>
+        )}
       </div>
     );
   },
@@ -77,6 +94,7 @@ export const ShiftCell = memo(
     prev.day === next.day &&
     prev.isActiveDay === next.isActiveDay &&
     prev.shifts === next.shifts &&
+    prev.capacity === next.capacity &&
     prev.onRemoveShift === next.onRemoveShift &&
     prev.isHighlighted === next.isHighlighted &&
     prev.hasMobileSelection === next.hasMobileSelection &&

--- a/src/components/scheduling/ShiftPlanner/ShiftCell.tsx
+++ b/src/components/scheduling/ShiftPlanner/ShiftCell.tsx
@@ -72,20 +72,23 @@ export const ShiftCell = memo(
             onRemove={onRemoveShift}
           />
         ))}
-        {capacity > 1 && (
-          <div
-            className={cn(
-              'text-[10px] font-medium px-1.5 py-0.5 rounded text-center',
-              classifyCapacity(capacity, shifts.length) === 'full'
-                ? 'text-emerald-600 bg-emerald-500/10'
-                : classifyCapacity(capacity, shifts.length) === 'partial'
-                  ? 'text-amber-600 bg-amber-500/10'
-                  : 'text-red-500 bg-red-500/10',
-            )}
-          >
-            {shifts.length}/{capacity}
-          </div>
-        )}
+        {capacity > 1 && (() => {
+          const status = classifyCapacity(capacity, shifts.length);
+          return (
+            <div
+              className={cn(
+                'text-[10px] font-medium px-1.5 py-0.5 rounded text-center',
+                status === 'full'
+                  ? 'text-emerald-600 bg-emerald-500/10'
+                  : status === 'partial'
+                    ? 'text-amber-600 bg-amber-500/10'
+                    : 'text-red-500 bg-red-500/10',
+              )}
+            >
+              {shifts.length}/{capacity}
+            </div>
+          );
+        })()}
       </div>
     );
   },

--- a/src/components/scheduling/ShiftPlanner/TemplateFormDialog.tsx
+++ b/src/components/scheduling/ShiftPlanner/TemplateFormDialog.tsx
@@ -29,6 +29,7 @@ interface TemplateFormDialogProps {
     position: string;
     days: number[];
     break_duration: number;
+    capacity: number;
   }) => void | Promise<void>;
   positions: string[];
 }
@@ -48,6 +49,7 @@ export function TemplateFormDialog({
   const [position, setPosition] = useState('');
   const [days, setDays] = useState<number[]>([]);
   const [breakDuration, setBreakDuration] = useState(0);
+  const [capacity, setCapacity] = useState(1);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   // Pre-fill form when template changes or dialog opens
@@ -59,6 +61,7 @@ export function TemplateFormDialog({
       setPosition(template.position);
       setDays([...template.days]);
       setBreakDuration(template.break_duration);
+      setCapacity(template.capacity ?? 1);
     } else {
       setName('');
       setStartTime('09:00');
@@ -66,6 +69,7 @@ export function TemplateFormDialog({
       setPosition('');
       setDays([]);
       setBreakDuration(0);
+      setCapacity(1);
     }
     setIsSubmitting(false);
   }, [template, open]);
@@ -91,6 +95,7 @@ export function TemplateFormDialog({
         position: position.trim(),
         days,
         break_duration: breakDuration,
+        capacity,
       });
       onOpenChange(false);
     } catch {
@@ -243,6 +248,27 @@ export function TemplateFormDialog({
               onChange={(e) => setBreakDuration(Math.max(0, Number.parseInt(e.target.value, 10) || 0))}
               className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
             />
+          </div>
+
+          {/* Staff Needed */}
+          <div className="space-y-1.5">
+            <Label
+              htmlFor="capacity"
+              className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider"
+            >
+              Staff Needed
+            </Label>
+            <Input
+              id="capacity"
+              type="number"
+              min={1}
+              value={capacity}
+              onChange={(e) => setCapacity(Math.max(1, Number.parseInt(e.target.value, 10) || 1))}
+              className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
+            />
+            <p className="text-[11px] text-muted-foreground">
+              How many employees are needed for this shift
+            </p>
           </div>
 
           {/* Footer */}

--- a/src/components/scheduling/ShiftPlanner/TemplateFormDialog.tsx
+++ b/src/components/scheduling/ShiftPlanner/TemplateFormDialog.tsx
@@ -266,7 +266,7 @@ export function TemplateFormDialog({
               onChange={(e) => setCapacity(Math.max(1, Number.parseInt(e.target.value, 10) || 1))}
               className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
             />
-            <p className="text-[11px] text-muted-foreground">
+            <p className="text-[13px] text-muted-foreground">
               How many employees are needed for this shift
             </p>
           </div>

--- a/src/components/scheduling/ShiftPlanner/TemplateGrid.tsx
+++ b/src/components/scheduling/ShiftPlanner/TemplateGrid.tsx
@@ -98,6 +98,7 @@ export function TemplateGrid({
                     day={day}
                     isActiveDay={isActiveDay}
                     shifts={shifts}
+                    capacity={template.capacity ?? 1}
                     onRemoveShift={onRemoveShift}
                     isHighlighted={highlightCellId === `${template.id}:${day}`}
                     onMobileTap={onMobileCellTap}

--- a/src/components/scheduling/ShiftPlanner/TemplateRowHeader.tsx
+++ b/src/components/scheduling/ShiftPlanner/TemplateRowHeader.tsx
@@ -45,6 +45,11 @@ export const TemplateRowHeader = memo(function TemplateRowHeader({
         <div className="text-[12px] text-muted-foreground">
           {template.position}
         </div>
+        {template.capacity > 1 && (
+          <div className="text-[10px] font-medium text-amber-600">
+            Need {template.capacity}
+          </div>
+        )}
       </div>
       {/* Mobile: abbreviated name + time only */}
       <div className="block md:hidden min-w-0 text-center w-full">

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1,4 +1,3 @@
-Connecting to db 5432
 export type Json =
   | string
   | number

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -1,3 +1,4 @@
+Connecting to db 5432
 export type Json =
   | string
   | number
@@ -5756,6 +5757,7 @@ export type Database = {
       shift_templates: {
         Row: {
           break_duration: number
+          capacity: number
           created_at: string | null
           days: number[]
           end_time: string
@@ -5769,6 +5771,7 @@ export type Database = {
         }
         Insert: {
           break_duration?: number
+          capacity?: number
           created_at?: string | null
           days?: number[]
           end_time: string
@@ -5782,6 +5785,7 @@ export type Database = {
         }
         Update: {
           break_duration?: number
+          capacity?: number
           created_at?: string | null
           days?: number[]
           end_time?: string

--- a/src/lib/openShiftHelpers.ts
+++ b/src/lib/openShiftHelpers.ts
@@ -1,0 +1,26 @@
+export type CapacityStatus = 'full' | 'partial' | 'empty';
+
+/**
+ * Compute how many open spots remain for a template on a given day.
+ * Clamps to 0 (never negative).
+ */
+export function computeOpenSpots(
+  capacity: number | undefined,
+  assignedCount: number,
+): number {
+  const cap = capacity ?? 1;
+  return Math.max(0, cap - assignedCount);
+}
+
+/**
+ * Classify how filled a template slot is on a given day.
+ */
+export function classifyCapacity(
+  capacity: number | undefined,
+  assignedCount: number,
+): CapacityStatus {
+  const open = computeOpenSpots(capacity, assignedCount);
+  if (open === 0) return 'full';
+  if (assignedCount > 0) return 'partial';
+  return 'empty';
+}

--- a/src/pages/Scheduling.tsx
+++ b/src/pages/Scheduling.tsx
@@ -44,7 +44,9 @@ import { DraggableShiftCard } from '@/components/scheduling/DraggableShiftCard';
 import { DroppableDayCell } from '@/components/scheduling/DroppableDayCell';
 import { ShiftDragOverlay } from '@/components/scheduling/ShiftDragOverlay';
 import { useCopyWeekShifts } from '@/hooks/useCopyWeekShifts';
-import { getMondayOfWeek, computeHoursPerEmployee } from '@/hooks/useShiftPlanner';
+import { getMondayOfWeek, computeHoursPerEmployee, buildTemplateGridData } from '@/hooks/useShiftPlanner';
+import { useShiftTemplates, templateAppliesToDay } from '@/hooks/useShiftTemplates';
+import { computeOpenSpots } from '@/lib/openShiftHelpers';
 import { RecurringShiftActionDialog, RecurringActionType } from '@/components/scheduling/RecurringShiftActionDialog';
 import { isRecurringShift, RecurringActionScope } from '@/utils/recurringShiftHelpers';
 import { BulkActionBar } from '@/components/bulk-edit/BulkActionBar';
@@ -354,6 +356,7 @@ const Scheduling = () => {
   // Fetch ALL employees (including inactive) to show historical shifts
   const { employees: allEmployees, loading: employeesLoading } = useEmployees(restaurantId, { status: 'all' });
   const { shifts, loading: shiftsLoading } = useShifts(restaurantId, currentWeekStart, weekEnd);
+  const { templates } = useShiftTemplates(restaurantId);
   const { trades: pendingTrades } = useShiftTrades(restaurantId, 'pending_approval', null);
   const deleteShift = useDeleteShift();
   const deleteShiftSeries = useDeleteShiftSeries();
@@ -466,6 +469,31 @@ const Scheduling = () => {
     .reduce((sum, shift) => sum + calculateShiftHours(shift), 0);
 
   const hoursPerEmployee = useMemo(() => computeHoursPerEmployee(shifts), [shifts]);
+
+  const openShiftCount = useMemo(() => {
+    if (!templates.length || shifts === undefined) return 0;
+
+    // Format weekDays as YYYY-MM-DD strings for templateAppliesToDay
+    const weekDayStrings = weekDays.map(d => {
+      const year = d.getFullYear();
+      const month = String(d.getMonth() + 1).padStart(2, '0');
+      const day = String(d.getDate()).padStart(2, '0');
+      return `${year}-${month}-${day}`;
+    });
+
+    // Build the grid to count assigned shifts per template/day
+    const gridData = buildTemplateGridData(shifts, templates, weekDayStrings);
+
+    let total = 0;
+    for (const template of templates) {
+      for (const dayStr of weekDayStrings) {
+        if (!templateAppliesToDay(template, dayStr)) continue;
+        const assigned = gridData.get(template.id)?.get(dayStr)?.length ?? 0;
+        total += computeOpenSpots(template.capacity, assigned);
+      }
+    }
+    return total;
+  }, [templates, shifts, weekDays]);
 
   // Grouped employees for rendering
   const employeeGroups = useMemo(
@@ -1797,6 +1825,7 @@ const Scheduling = () => {
         shiftCount={shifts.length}
         employeeCount={scheduledEmployeeCount}
         totalHours={totalScheduledHours}
+        openShiftCount={openShiftCount}
         onConfirm={handlePublishSchedule}
         isPublishing={publishSchedule.isPending}
       />

--- a/src/pages/Scheduling.tsx
+++ b/src/pages/Scheduling.tsx
@@ -47,6 +47,7 @@ import { useCopyWeekShifts } from '@/hooks/useCopyWeekShifts';
 import { getMondayOfWeek, computeHoursPerEmployee, buildTemplateGridData } from '@/hooks/useShiftPlanner';
 import { useShiftTemplates, templateAppliesToDay } from '@/hooks/useShiftTemplates';
 import { computeOpenSpots } from '@/lib/openShiftHelpers';
+import { formatLocalDate } from '@/lib/shiftInterval';
 import { RecurringShiftActionDialog, RecurringActionType } from '@/components/scheduling/RecurringShiftActionDialog';
 import { isRecurringShift, RecurringActionScope } from '@/utils/recurringShiftHelpers';
 import { BulkActionBar } from '@/components/bulk-edit/BulkActionBar';
@@ -473,13 +474,7 @@ const Scheduling = () => {
   const openShiftCount = useMemo(() => {
     if (!templates.length || shifts === undefined) return 0;
 
-    // Format weekDays as YYYY-MM-DD strings for templateAppliesToDay
-    const weekDayStrings = weekDays.map(d => {
-      const year = d.getFullYear();
-      const month = String(d.getMonth() + 1).padStart(2, '0');
-      const day = String(d.getDate()).padStart(2, '0');
-      return `${year}-${month}-${day}`;
-    });
+    const weekDayStrings = weekDays.map(formatLocalDate);
 
     // Build the grid to count assigned shifts per template/day
     const gridData = buildTemplateGridData(shifts, templates, weekDayStrings);

--- a/src/types/scheduling.ts
+++ b/src/types/scheduling.ts
@@ -118,6 +118,7 @@ export interface ShiftTemplate {
   end_time: string;
   break_duration: number;
   position: string;
+  capacity: number;
   is_active: boolean;
   created_at: string;
   updated_at: string;

--- a/supabase/migrations/20260411221543_add_capacity_to_shift_templates.sql
+++ b/supabase/migrations/20260411221543_add_capacity_to_shift_templates.sql
@@ -1,0 +1,7 @@
+-- Add capacity column to shift_templates
+-- Represents how many employees are needed for this shift slot.
+-- Default 1 preserves existing behavior for all current records.
+
+ALTER TABLE shift_templates
+  ADD COLUMN capacity INTEGER NOT NULL DEFAULT 1
+    CONSTRAINT shift_templates_capacity_min CHECK (capacity >= 1);

--- a/supabase/tests/shift_template_capacity.test.sql
+++ b/supabase/tests/shift_template_capacity.test.sql
@@ -1,0 +1,144 @@
+-- pgTAP tests for shift_templates.capacity column
+-- Tests: column exists, default is 1, capacity >= 1 CHECK constraint
+
+BEGIN;
+
+SELECT plan(6);
+
+-- ============================================
+-- Setup: disable RLS for test data creation
+-- ============================================
+
+SET LOCAL role TO postgres;
+ALTER TABLE restaurants DISABLE ROW LEVEL SECURITY;
+ALTER TABLE shift_templates DISABLE ROW LEVEL SECURITY;
+
+INSERT INTO restaurants (id, name)
+VALUES ('cccccccc-1111-0000-0000-000000000001', 'Capacity Test Restaurant')
+ON CONFLICT (id) DO NOTHING;
+
+-- ============================================
+-- Test 1: capacity column exists on shift_templates
+-- ============================================
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'shift_templates'
+      AND column_name = 'capacity'
+  ),
+  'shift_templates has a capacity column'
+);
+
+-- ============================================
+-- Test 2: capacity column is NOT NULL
+-- ============================================
+
+SELECT is(
+  (
+    SELECT is_nullable
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'shift_templates'
+      AND column_name = 'capacity'
+  ),
+  'NO',
+  'capacity column is NOT NULL'
+);
+
+-- ============================================
+-- Test 3: capacity defaults to 1
+-- ============================================
+
+INSERT INTO shift_templates (id, restaurant_id, name, start_time, end_time, break_duration, position, days)
+VALUES (
+  'cccccccc-1111-0000-0000-000000000010',
+  'cccccccc-1111-0000-0000-000000000001',
+  'Morning Shift',
+  '09:00:00',
+  '17:00:00',
+  0,
+  'Server',
+  '{1,2,3,4,5}'
+);
+
+SELECT is(
+  (SELECT capacity FROM shift_templates WHERE id = 'cccccccc-1111-0000-0000-000000000010'),
+  1,
+  'capacity defaults to 1 when not specified'
+);
+
+-- ============================================
+-- Test 4: capacity = 3 is valid (happy path)
+-- ============================================
+
+SELECT lives_ok(
+  $$
+    INSERT INTO shift_templates (id, restaurant_id, name, start_time, end_time, break_duration, position, days, capacity)
+    VALUES (
+      'cccccccc-1111-0000-0000-000000000011',
+      'cccccccc-1111-0000-0000-000000000001',
+      'Evening Shift',
+      '17:00:00',
+      '23:00:00',
+      0,
+      'Cook',
+      '{1,2,3,4,5}',
+      3
+    )
+  $$,
+  'capacity = 3 inserts successfully'
+);
+
+-- ============================================
+-- Test 5: capacity = 0 violates CHECK constraint
+-- ============================================
+
+SELECT throws_ok(
+  $$
+    INSERT INTO shift_templates (id, restaurant_id, name, start_time, end_time, break_duration, position, days, capacity)
+    VALUES (
+      'cccccccc-1111-0000-0000-000000000012',
+      'cccccccc-1111-0000-0000-000000000001',
+      'Bad Shift Zero',
+      '08:00:00',
+      '16:00:00',
+      0,
+      'Host',
+      '{1}',
+      0
+    )
+  $$,
+  '23514',
+  NULL,
+  'capacity = 0 violates check constraint'
+);
+
+-- ============================================
+-- Test 6: capacity = -1 violates CHECK constraint
+-- ============================================
+
+SELECT throws_ok(
+  $$
+    INSERT INTO shift_templates (id, restaurant_id, name, start_time, end_time, break_duration, position, days, capacity)
+    VALUES (
+      'cccccccc-1111-0000-0000-000000000013',
+      'cccccccc-1111-0000-0000-000000000001',
+      'Bad Shift Negative',
+      '08:00:00',
+      '16:00:00',
+      0,
+      'Host',
+      '{1}',
+      -1
+    )
+  $$,
+  '23514',
+  NULL,
+  'capacity = -1 violates check constraint'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/tests/e2e/shift-template-capacity.spec.ts
+++ b/tests/e2e/shift-template-capacity.spec.ts
@@ -1,0 +1,169 @@
+import { test, expect } from '@playwright/test';
+import { signUpAndCreateRestaurant, exposeSupabaseHelpers, generateTestUser } from '../helpers/e2e-supabase';
+
+test.describe('Shift Template Capacity', () => {
+  test('manager can set staff needed and see capacity indicator', async ({ page }) => {
+    // 1. Sign up and create restaurant
+    const testUser = generateTestUser('shift-cap');
+    await signUpAndCreateRestaurant(page, testUser);
+    await exposeSupabaseHelpers(page);
+
+    // Seed an employee so the planner renders (not empty-employees state)
+    const restaurantId = await page.evaluate(() => (window as any).__getRestaurantId());
+    expect(restaurantId).toBeTruthy();
+
+    await page.evaluate(
+      ({ emps, restId }) => (window as any).__insertEmployees(emps, restId),
+      {
+        emps: [
+          {
+            name: 'Alex Rivera',
+            position: 'Server',
+            status: 'active',
+            is_active: true,
+            compensation_type: 'hourly',
+            hourly_rate: 1500,
+          },
+        ],
+        restId: restaurantId,
+      },
+    );
+
+    // 2. Navigate to /scheduling
+    await page.goto('/scheduling');
+    await page.waitForURL(/\/scheduling/, { timeout: 8000 });
+
+    // Click the Planner tab
+    const plannerTab = page.getByRole('tab', { name: /planner/i });
+    await expect(plannerTab).toBeVisible({ timeout: 10000 });
+    await plannerTab.click();
+
+    // Wait for planner to load (employee sidebar or empty-template state)
+    await expect(page.getByText('Alex Rivera')).toBeVisible({ timeout: 10000 });
+
+    // 3. Click "Add Shift Template"
+    await page.getByRole('button', { name: /add shift template/i }).click();
+
+    // 4. Fill template form
+    const dialog = page.getByRole('dialog', { name: /add shift template/i });
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+
+    await dialog.locator('#template-name').fill('Closing Server');
+    await dialog.locator('#start-time').fill('16:00');
+    await dialog.locator('#end-time').fill('22:00');
+    await dialog.locator('#position').fill('Server');
+
+    // 5. Click Monday button
+    await dialog.getByRole('button', { name: 'Monday' }).click();
+
+    // 6. Set Staff Needed to 3
+    const staffNeededInput = dialog.locator('#capacity');
+    await staffNeededInput.clear();
+    await staffNeededInput.fill('3');
+
+    // 7. Submit
+    const templateCreatePromise = page.waitForResponse(
+      (resp) =>
+        resp.url().includes('rest/v1/shift_templates') && resp.status() === 201,
+      { timeout: 15000 },
+    );
+
+    await dialog.getByRole('button', { name: /add template/i }).click();
+    await templateCreatePromise;
+
+    // Dialog should close
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+
+    // 8. Wait for toast to dismiss (toast may overlay elements)
+    // Give the toast time to appear and then fade out
+    await page.waitForTimeout(2500);
+
+    // 9. Verify "Closing Server" text is visible
+    await expect(page.getByText('Closing Server')).toBeVisible({ timeout: 5000 });
+
+    // 10. Verify "0/3" capacity indicator is visible somewhere on the page
+    // The indicator shows assigned/capacity, starting at 0/3 for a new template
+    await expect(page.getByText('0/3')).toBeVisible({ timeout: 5000 });
+  });
+
+  test('default capacity shows no indicator', async ({ page }) => {
+    // 1. Sign up and create restaurant
+    const testUser = generateTestUser('shift-cap-default');
+    await signUpAndCreateRestaurant(page, testUser);
+    await exposeSupabaseHelpers(page);
+
+    // Seed an employee so the planner renders
+    const restaurantId = await page.evaluate(() => (window as any).__getRestaurantId());
+    expect(restaurantId).toBeTruthy();
+
+    await page.evaluate(
+      ({ emps, restId }) => (window as any).__insertEmployees(emps, restId),
+      {
+        emps: [
+          {
+            name: 'Sam Torres',
+            position: 'Cashier',
+            status: 'active',
+            is_active: true,
+            compensation_type: 'hourly',
+            hourly_rate: 1400,
+          },
+        ],
+        restId: restaurantId,
+      },
+    );
+
+    // 2. Navigate to /scheduling
+    await page.goto('/scheduling');
+    await page.waitForURL(/\/scheduling/, { timeout: 8000 });
+
+    // Click the Planner tab
+    const plannerTab = page.getByRole('tab', { name: /planner/i });
+    await expect(plannerTab).toBeVisible({ timeout: 10000 });
+    await plannerTab.click();
+
+    // Wait for planner to load
+    await expect(page.getByText('Sam Torres')).toBeVisible({ timeout: 10000 });
+
+    // 3. Click "Add Shift Template"
+    await page.getByRole('button', { name: /add shift template/i }).click();
+
+    // 4. Fill template form
+    const dialog = page.getByRole('dialog', { name: /add shift template/i });
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+
+    await dialog.locator('#template-name').fill('Morning Cashier');
+    await dialog.locator('#start-time').fill('06:00');
+    await dialog.locator('#end-time').fill('14:00');
+    await dialog.locator('#position').fill('Cashier');
+
+    // 5. Click Tuesday button
+    await dialog.getByRole('button', { name: 'Tuesday' }).click();
+
+    // 6. Verify "Staff Needed" input defaults to 1 — do NOT change it
+    const staffNeededInput = dialog.locator('#capacity');
+    await expect(staffNeededInput).toHaveValue('1');
+
+    // 7. Submit
+    const templateCreatePromise = page.waitForResponse(
+      (resp) =>
+        resp.url().includes('rest/v1/shift_templates') && resp.status() === 201,
+      { timeout: 15000 },
+    );
+
+    await dialog.getByRole('button', { name: /add template/i }).click();
+    await templateCreatePromise;
+
+    // Dialog should close
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+
+    // 8. Wait for toast to dismiss
+    await page.waitForTimeout(2500);
+
+    // 9. Verify "Morning Cashier" text is visible
+    await expect(page.getByText('Morning Cashier')).toBeVisible({ timeout: 5000 });
+
+    // 10. Verify NO "0/1" indicator is shown (capacity=1 is intentionally hidden)
+    await expect(page.getByText('0/1')).not.toBeVisible();
+  });
+});

--- a/tests/e2e/shift-template-capacity.spec.ts
+++ b/tests/e2e/shift-template-capacity.spec.ts
@@ -74,12 +74,14 @@ test.describe('Shift Template Capacity', () => {
     // Dialog should close
     await expect(dialog).not.toBeVisible({ timeout: 5000 });
 
-    // 8. Wait for toast to dismiss (toast may overlay elements)
-    // Give the toast time to appear and then fade out
-    await page.waitForTimeout(2500);
+    // 8. Wait for template to appear in the grid (dismisses toast naturally)
+    await expect(page.getByText('Closing Server')).toBeVisible({ timeout: 10000 });
 
-    // 9. Verify "Closing Server" text is visible
-    await expect(page.getByText('Closing Server')).toBeVisible({ timeout: 5000 });
+    // 9. Dismiss any remaining toasts that might overlay elements
+    const toast = page.locator('[data-sonner-toast]').first();
+    if (await toast.isVisible({ timeout: 1000 }).catch(() => false)) {
+      await toast.locator('button[aria-label="Close"]').click().catch(() => {});
+    }
 
     // 10. Verify "0/3" capacity indicator is visible somewhere on the page
     // The indicator shows assigned/capacity, starting at 0/3 for a new template
@@ -157,11 +159,14 @@ test.describe('Shift Template Capacity', () => {
     // Dialog should close
     await expect(dialog).not.toBeVisible({ timeout: 5000 });
 
-    // 8. Wait for toast to dismiss
-    await page.waitForTimeout(2500);
+    // 8. Wait for template to appear in the grid
+    await expect(page.getByText('Morning Cashier')).toBeVisible({ timeout: 10000 });
 
-    // 9. Verify "Morning Cashier" text is visible
-    await expect(page.getByText('Morning Cashier')).toBeVisible({ timeout: 5000 });
+    // 9. Dismiss any remaining toasts
+    const toast = page.locator('[data-sonner-toast]').first();
+    if (await toast.isVisible({ timeout: 1000 }).catch(() => false)) {
+      await toast.locator('button[aria-label="Close"]').click().catch(() => {});
+    }
 
     // 10. Verify NO "0/1" indicator is shown (capacity=1 is intentionally hidden)
     await expect(page.getByText('0/1')).not.toBeVisible();

--- a/tests/unit/shiftTemplateCapacity.test.ts
+++ b/tests/unit/shiftTemplateCapacity.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { computeOpenSpots, classifyCapacity } from '@/lib/openShiftHelpers';
+
+describe('computeOpenSpots', () => {
+  it('returns capacity minus assigned count', () => {
+    expect(computeOpenSpots(3, 1)).toBe(2);
+  });
+
+  it('returns 0 when fully staffed', () => {
+    expect(computeOpenSpots(2, 2)).toBe(0);
+  });
+
+  it('returns 0 when over-staffed (clamped)', () => {
+    expect(computeOpenSpots(2, 3)).toBe(0);
+  });
+
+  it('returns full capacity when nobody assigned', () => {
+    expect(computeOpenSpots(3, 0)).toBe(3);
+  });
+
+  it('defaults capacity to 1 when undefined', () => {
+    expect(computeOpenSpots(undefined, 0)).toBe(1);
+    expect(computeOpenSpots(undefined, 1)).toBe(0);
+  });
+});
+
+describe('classifyCapacity', () => {
+  it('returns "full" when no open spots', () => {
+    expect(classifyCapacity(3, 3)).toBe('full');
+  });
+
+  it('returns "partial" when some spots filled', () => {
+    expect(classifyCapacity(3, 1)).toBe('partial');
+  });
+
+  it('returns "empty" when no spots filled', () => {
+    expect(classifyCapacity(3, 0)).toBe('empty');
+  });
+
+  it('returns "full" for default capacity of 1 with 1 assigned', () => {
+    expect(classifyCapacity(1, 1)).toBe('full');
+  });
+
+  it('returns "full" when over-staffed', () => {
+    expect(classifyCapacity(2, 3)).toBe('full');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `capacity` column to `shift_templates` (default 1) — represents how many employees are needed per shift slot
- Shows capacity indicators (`1/3`, `0/3`) in planner grid cells, color-coded: green=full, amber=partial, red=empty
- Shows "Need N" label in template row header when capacity > 1
- Adds "Staff Needed" number input to the template create/edit dialog
- Publish dialog warns about unfilled shifts: "N shifts still need staff"
- Includes pgTAP, unit, and E2E tests

**This is PR1 of 3** for the Open Shift Claiming feature. See design spec: `docs/superpowers/specs/2026-04-11-open-shift-claiming-design.md`

## Test plan

- [x] pgTAP: capacity column exists, defaults to 1, CHECK >= 1
- [x] Unit: `computeOpenSpots` and `classifyCapacity` (10 tests)
- [x] E2E: manager creates template with capacity=3, sees 0/3 indicator; default capacity=1 hides indicator
- [x] Build passes
- [x] All 3334 unit tests pass, 1159/1160 pgTAP pass (1 pre-existing failure unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Staff Needed" field to shift template creation and editing forms, allowing managers to specify required capacity.
  * Planner grid now displays capacity indicators (e.g., "0/3") on shift cells when capacity is greater than 1.
  * Desktop layout shows capacity labels (e.g., "Need 3") next to template names.
  * Publish dialog alerts when open shift gaps exist.

* **Documentation**
  * Added implementation plan and design specification for the open shift capacity system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->