### PR TITLE
feat: add area field to shift templates with grouping, filtering, and AI awareness

### DIFF
--- a/src/components/scheduling/ShiftPlanner/AreaFilterPills.tsx
+++ b/src/components/scheduling/ShiftPlanner/AreaFilterPills.tsx
@@ -1,0 +1,46 @@
+import { cn } from '@/lib/utils';
+
+interface AreaFilterPillsProps {
+  readonly areas: string[];
+  readonly hasUnassigned: boolean;
+  readonly selectedArea: string | null;
+  readonly onSelect: (area: string | null) => void;
+}
+
+export function AreaFilterPills({
+  areas,
+  hasUnassigned,
+  selectedArea,
+  onSelect,
+}: AreaFilterPillsProps) {
+  if (areas.length === 0 && !hasUnassigned) return null;
+
+  const pills = [
+    { label: 'All', value: null as string | null },
+    ...areas.map((a) => ({ label: a, value: a })),
+    ...(hasUnassigned ? [{ label: 'Unassigned', value: 'Unassigned' }] : []),
+  ];
+
+  return (
+    <div className="flex items-center gap-2 px-1">
+      <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
+        Area
+      </span>
+      {pills.map((pill) => (
+        <button
+          key={pill.label}
+          type="button"
+          onClick={() => onSelect(pill.value)}
+          className={cn(
+            'px-3 py-1 rounded-lg text-[12px] font-medium transition-colors',
+            selectedArea === pill.value
+              ? 'bg-foreground text-background'
+              : 'bg-muted/50 text-muted-foreground hover:text-foreground hover:bg-muted',
+          )}
+        >
+          {pill.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/scheduling/ShiftPlanner/AreaFilterPills.tsx
+++ b/src/components/scheduling/ShiftPlanner/AreaFilterPills.tsx
@@ -23,7 +23,7 @@ export function AreaFilterPills({
   ];
 
   return (
-    <div className="flex items-center gap-2 px-1">
+    <div className="flex items-center gap-2 px-1" role="group" aria-label="Filter templates by area">
       <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
         Area
       </span>
@@ -31,6 +31,7 @@ export function AreaFilterPills({
         <button
           key={pill.label}
           type="button"
+          aria-pressed={selectedArea === pill.value}
           onClick={() => onSelect(pill.value)}
           className={cn(
             'px-3 py-1 rounded-lg text-[12px] font-medium transition-colors',

--- a/src/components/scheduling/ShiftPlanner/AreaFilterPills.tsx
+++ b/src/components/scheduling/ShiftPlanner/AreaFilterPills.tsx
@@ -1,4 +1,5 @@
 import { cn } from '@/lib/utils';
+import { UNASSIGNED } from '@/lib/templateAreaGrouping';
 
 interface AreaFilterPillsProps {
   readonly areas: string[];
@@ -18,7 +19,7 @@ export function AreaFilterPills({
   const pills = [
     { label: 'All', value: null as string | null },
     ...areas.map((a) => ({ label: a, value: a })),
-    ...(hasUnassigned ? [{ label: 'Unassigned', value: 'Unassigned' }] : []),
+    ...(hasUnassigned ? [{ label: UNASSIGNED, value: UNASSIGNED }] : []),
   ];
 
   return (

--- a/src/components/scheduling/ShiftPlanner/AreaSectionHeader.tsx
+++ b/src/components/scheduling/ShiftPlanner/AreaSectionHeader.tsx
@@ -1,0 +1,47 @@
+import { ChevronDown, ChevronRight } from 'lucide-react';
+
+interface AreaSectionHeaderProps {
+  readonly area: string;
+  readonly templateCount: number;
+  readonly isCollapsed: boolean;
+  readonly onToggle: () => void;
+  readonly colSpan: number;
+}
+
+export function AreaSectionHeader({
+  area,
+  templateCount,
+  isCollapsed,
+  onToggle,
+  colSpan,
+}: AreaSectionHeaderProps) {
+  return (
+    <div
+      className="col-span-full border-t border-border/40 bg-muted/50 cursor-pointer select-none"
+      style={{ gridColumn: `1 / span ${colSpan}` }}
+      onClick={onToggle}
+      role="button"
+      tabIndex={0}
+      aria-expanded={!isCollapsed}
+      aria-label={`${area} section, ${templateCount} templates`}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onToggle();
+        }
+      }}
+    >
+      <div className="flex items-center gap-2 px-3 py-2">
+        {isCollapsed ? (
+          <ChevronRight className="h-3.5 w-3.5 text-muted-foreground" />
+        ) : (
+          <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
+        )}
+        <span className="text-[13px] font-semibold text-foreground">{area}</span>
+        <span className="text-[11px] text-muted-foreground">
+          {templateCount} {templateCount === 1 ? 'template' : 'templates'}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/scheduling/ShiftPlanner/EmployeeSidebar.tsx
+++ b/src/components/scheduling/ShiftPlanner/EmployeeSidebar.tsx
@@ -150,11 +150,13 @@ export function EmployeeSidebar({ employees, shifts, className, onEmployeeSelect
   }, [employees]);
 
   // Reset area filter when selected value is no longer available
+  // Skip when planner is controlling the area (plannerAreaFilter may reference template areas not in employee list)
   useEffect(() => {
+    if (plannerAreaFilter) return;
     if (area !== 'all' && !areas.includes(area)) {
       setArea('all');
     }
-  }, [area, areas]);
+  }, [area, areas, plannerAreaFilter]);
 
   // Sync sidebar area from planner filter pills
   useEffect(() => {

--- a/src/components/scheduling/ShiftPlanner/EmployeeSidebar.tsx
+++ b/src/components/scheduling/ShiftPlanner/EmployeeSidebar.tsx
@@ -58,6 +58,8 @@ export interface EmployeeSidebarProps {
   className?: string;
   /** Mobile tap-to-assign: called when an employee is tapped instead of dragged */
   onEmployeeSelect?: (employee: { id: string; name: string }) => void;
+  /** Area filter from the planner's filter pills — syncs the sidebar's area dropdown */
+  plannerAreaFilter?: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -132,10 +134,11 @@ const DraggableEmployee = memo(
 // EmployeeSidebar
 // ---------------------------------------------------------------------------
 
-export function EmployeeSidebar({ employees, shifts, className, onEmployeeSelect }: Readonly<EmployeeSidebarProps>) {
+export function EmployeeSidebar({ employees, shifts, className, onEmployeeSelect, plannerAreaFilter }: Readonly<EmployeeSidebarProps>) {
   const [search, setSearch] = useState('');
   const [area, setArea] = useState('all');
   const [role, setRole] = useState('all');
+  const [showAllOverride, setShowAllOverride] = useState(false);
 
   // Derive unique areas for the filter dropdown
   const areas = useMemo(() => {
@@ -152,6 +155,17 @@ export function EmployeeSidebar({ employees, shifts, className, onEmployeeSelect
       setArea('all');
     }
   }, [area, areas]);
+
+  // Sync sidebar area from planner filter pills
+  useEffect(() => {
+    if (plannerAreaFilter) {
+      setArea(plannerAreaFilter);
+      setShowAllOverride(false);
+    } else {
+      setArea('all');
+      setShowAllOverride(false);
+    }
+  }, [plannerAreaFilter]);
 
   // Derive unique roles for the filter dropdown
   const roles = useMemo(() => {
@@ -174,9 +188,11 @@ export function EmployeeSidebar({ employees, shifts, className, onEmployeeSelect
 
   const hoursPerEmployee = useMemo(() => computeHoursPerEmployee(shifts), [shifts]);
 
+  const effectiveArea = showAllOverride ? 'all' : area;
+
   const filtered = useMemo(
-    () => filterEmployees(employees, search, area, role),
-    [employees, search, area, role],
+    () => filterEmployees(employees, search, effectiveArea, role),
+    [employees, search, effectiveArea, role],
   );
 
   return (
@@ -211,6 +227,16 @@ export function EmployeeSidebar({ employees, shifts, className, onEmployeeSelect
               ))}
             </SelectContent>
           </Select>
+        )}
+        {plannerAreaFilter && (
+          <button
+            type="button"
+            onClick={() => setShowAllOverride((prev) => !prev)}
+            className="w-full text-[12px] font-medium text-muted-foreground hover:text-foreground transition-colors py-1.5 px-2 rounded-lg hover:bg-muted/50"
+            aria-label={showAllOverride ? `Show ${plannerAreaFilter} only` : 'Show all employees'}
+          >
+            {showAllOverride ? `Show ${plannerAreaFilter} only` : 'Show all employees'}
+          </button>
         )}
         {roles.length > 1 && (
           <Select value={role} onValueChange={setRole}>

--- a/src/components/scheduling/ShiftPlanner/ShiftPlannerTab.tsx
+++ b/src/components/scheduling/ShiftPlanner/ShiftPlannerTab.tsx
@@ -19,8 +19,10 @@ import type { ShiftCreateInput } from '@/hooks/useShiftPlanner';
 import type { ValidationIssue } from '@/lib/shiftValidator';
 
 import { cn } from '@/lib/utils';
+import { getTemplateAreas } from '@/lib/templateAreaGrouping';
 
 import { AssignmentPopover } from './AssignmentPopover';
+import { AreaFilterPills } from './AreaFilterPills';
 
 import { PlannerHeader } from './PlannerHeader';
 import { StaffingOverlay } from './StaffingOverlay';
@@ -86,6 +88,7 @@ export function ShiftPlannerTab({
   const generateSchedule = useGenerateSchedule();
 
   const { toast } = useToast();
+  const [areaFilter, setAreaFilter] = useState<string | null>(null);
   const [highlightCellId, setHighlightCellId] = useState<string | null>(null);
   const [activeDragEmployee, setActiveDragEmployee] = useState<{ id: string; name: string } | null>(null);
   const [pendingAssignment, setPendingAssignment] = useState<{
@@ -113,6 +116,9 @@ export function ShiftPlannerTab({
     }
     return Array.from(posSet).sort((a, b) => a.localeCompare(b));
   }, [employees, templates]);
+
+  const templateAreas = useMemo(() => getTemplateAreas(templates), [templates]);
+  const hasUnassigned = useMemo(() => templates.some((t) => !t.area), [templates]);
 
   // DnD setup — PointerSensor for mouse, TouchSensor for touch devices
   // TouchSensor uses press-and-hold (200ms) to distinguish drag from scroll
@@ -432,18 +438,27 @@ export function ShiftPlannerTab({
                 </button>
               </div>
             ) : (
-              <TemplateGrid
-                weekDays={weekDays}
-                templates={templates}
-                gridData={templateGridData}
-                onRemoveShift={deleteShift}
-                onEditTemplate={handleEditTemplate}
-                onDeleteTemplate={deleteTemplate}
-                onAddTemplate={handleAddTemplate}
-                highlightCellId={highlightCellId}
-                onMobileCellTap={isMobile ? handleMobileCellTap : undefined}
-                hasMobileSelection={isMobile && !!selectedMobileEmployee}
-              />
+              <div className="space-y-2">
+                <AreaFilterPills
+                  areas={templateAreas}
+                  hasUnassigned={hasUnassigned}
+                  selectedArea={areaFilter}
+                  onSelect={setAreaFilter}
+                />
+                <TemplateGrid
+                  weekDays={weekDays}
+                  templates={templates}
+                  gridData={templateGridData}
+                  onRemoveShift={deleteShift}
+                  onEditTemplate={handleEditTemplate}
+                  onDeleteTemplate={deleteTemplate}
+                  onAddTemplate={handleAddTemplate}
+                  highlightCellId={highlightCellId}
+                  onMobileCellTap={isMobile ? handleMobileCellTap : undefined}
+                  hasMobileSelection={isMobile && !!selectedMobileEmployee}
+                  areaFilter={areaFilter}
+                />
+              </div>
             )}
           </div>
 

--- a/src/components/scheduling/ShiftPlanner/ShiftPlannerTab.tsx
+++ b/src/components/scheduling/ShiftPlanner/ShiftPlannerTab.tsx
@@ -308,7 +308,7 @@ export function ShiftPlannerTab({
     start_time: string;
     end_time: string;
     position: string;
-    area?: string;
+    area?: string | null;
     days: number[];
     break_duration: number;
     capacity: number;

--- a/src/components/scheduling/ShiftPlanner/ShiftPlannerTab.tsx
+++ b/src/components/scheduling/ShiftPlanner/ShiftPlannerTab.tsx
@@ -464,7 +464,7 @@ export function ShiftPlannerTab({
 
           {/* Desktop: inline sidebar */}
           {!isMobile && (
-            <EmployeeSidebar employees={employees} shifts={shifts} />
+            <EmployeeSidebar employees={employees} shifts={shifts} plannerAreaFilter={areaFilter} />
           )}
 
           {/* Mobile: slide-in sidebar panel (single instance to avoid duplicate dnd IDs) */}
@@ -495,7 +495,7 @@ export function ShiftPlannerTab({
                     <X className="h-4 w-4" />
                   </Button>
                 </div>
-                <EmployeeSidebar employees={employees} shifts={shifts} className="w-full border-l-0" onEmployeeSelect={handleMobileEmployeeSelect} />
+                <EmployeeSidebar employees={employees} shifts={shifts} className="w-full border-l-0" onEmployeeSelect={handleMobileEmployeeSelect} plannerAreaFilter={areaFilter} />
               </div>
             </>
           )}

--- a/src/components/scheduling/ShiftPlanner/ShiftPlannerTab.tsx
+++ b/src/components/scheduling/ShiftPlanner/ShiftPlannerTab.tsx
@@ -302,8 +302,10 @@ export function ShiftPlannerTab({
     start_time: string;
     end_time: string;
     position: string;
+    area?: string;
     days: number[];
     break_duration: number;
+    capacity: number;
   }) => {
     if (editingTemplate) {
       await updateTemplate({ id: editingTemplate.id, ...data });
@@ -527,6 +529,7 @@ export function ShiftPlannerTab({
         template={editingTemplate}
         onSubmit={handleTemplateSubmit}
         positions={positions}
+        restaurantId={restaurantId}
       />
 
       {/* Assignment popover — shown after dropping an employee onto a shift cell */}

--- a/src/components/scheduling/ShiftPlanner/TemplateFormDialog.tsx
+++ b/src/components/scheduling/ShiftPlanner/TemplateFormDialog.tsx
@@ -14,6 +14,7 @@ import { Clock } from 'lucide-react';
 
 import type { ShiftTemplate } from '@/types/scheduling';
 
+import { AreaCombobox } from '@/components/AreaCombobox';
 import { cn } from '@/lib/utils';
 
 const DAY_LABELS = ['S', 'M', 'T', 'W', 'T', 'F', 'S'] as const;
@@ -27,11 +28,13 @@ interface TemplateFormDialogProps {
     start_time: string;
     end_time: string;
     position: string;
+    area?: string;
     days: number[];
     break_duration: number;
     capacity: number;
   }) => void | Promise<void>;
   positions: string[];
+  restaurantId: string | null;
 }
 
 export function TemplateFormDialog({
@@ -40,6 +43,7 @@ export function TemplateFormDialog({
   template,
   onSubmit,
   positions,
+  restaurantId,
 }: Readonly<TemplateFormDialogProps>) {
   const isEdit = !!template;
 
@@ -50,6 +54,7 @@ export function TemplateFormDialog({
   const [days, setDays] = useState<number[]>([]);
   const [breakDuration, setBreakDuration] = useState(0);
   const [capacity, setCapacity] = useState(1);
+  const [area, setArea] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   // Pre-fill form when template changes or dialog opens
@@ -62,6 +67,7 @@ export function TemplateFormDialog({
       setDays([...template.days]);
       setBreakDuration(template.break_duration);
       setCapacity(template.capacity ?? 1);
+      setArea(template?.area ?? '');
     } else {
       setName('');
       setStartTime('09:00');
@@ -70,6 +76,7 @@ export function TemplateFormDialog({
       setDays([]);
       setBreakDuration(0);
       setCapacity(1);
+      setArea('');
     }
     setIsSubmitting(false);
   }, [template, open]);
@@ -93,6 +100,7 @@ export function TemplateFormDialog({
         start_time: startTime,
         end_time: endTime,
         position: position.trim(),
+        area: area.trim() || undefined,
         days,
         break_duration: breakDuration,
         capacity,
@@ -199,6 +207,19 @@ export function TemplateFormDialog({
                 ))}
               </datalist>
             )}
+          </div>
+
+          {/* Area (optional) */}
+          <div className="space-y-1.5">
+            <Label className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
+              Area
+            </Label>
+            <AreaCombobox
+              restaurantId={restaurantId}
+              value={area}
+              onValueChange={setArea}
+              placeholder="Select area (optional)..."
+            />
           </div>
 
           {/* Days */}

--- a/src/components/scheduling/ShiftPlanner/TemplateFormDialog.tsx
+++ b/src/components/scheduling/ShiftPlanner/TemplateFormDialog.tsx
@@ -28,7 +28,7 @@ interface TemplateFormDialogProps {
     start_time: string;
     end_time: string;
     position: string;
-    area?: string;
+    area?: string | null;
     days: number[];
     break_duration: number;
     capacity: number;
@@ -100,7 +100,7 @@ export function TemplateFormDialog({
         start_time: startTime,
         end_time: endTime,
         position: position.trim(),
-        area: area.trim() || undefined,
+        area: area.trim() || null,
         days,
         break_duration: breakDuration,
         capacity,
@@ -211,7 +211,7 @@ export function TemplateFormDialog({
 
           {/* Area (optional) */}
           <div className="space-y-1.5">
-            <Label htmlFor="area" className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
+            <Label id="template-area-label" className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
               Area
             </Label>
             <AreaCombobox

--- a/src/components/scheduling/ShiftPlanner/TemplateFormDialog.tsx
+++ b/src/components/scheduling/ShiftPlanner/TemplateFormDialog.tsx
@@ -211,7 +211,7 @@ export function TemplateFormDialog({
 
           {/* Area (optional) */}
           <div className="space-y-1.5">
-            <Label className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
+            <Label htmlFor="area" className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
               Area
             </Label>
             <AreaCombobox

--- a/src/components/scheduling/ShiftPlanner/TemplateGrid.tsx
+++ b/src/components/scheduling/ShiftPlanner/TemplateGrid.tsx
@@ -1,11 +1,15 @@
+import { useState, useCallback } from 'react';
+
 import { templateAppliesToDay } from '@/hooks/useShiftTemplates';
 
 import type { ShiftTemplate, Shift } from '@/types/scheduling';
 
 import { cn } from '@/lib/utils';
+import { groupTemplatesByArea } from '@/lib/templateAreaGrouping';
 
 import { TemplateRowHeader } from './TemplateRowHeader';
 import { ShiftCell } from './ShiftCell';
+import { AreaSectionHeader } from './AreaSectionHeader';
 
 const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
@@ -29,6 +33,7 @@ interface TemplateGridProps {
   /** Mobile tap-to-assign */
   onMobileCellTap?: (templateId: string, day: string) => void;
   hasMobileSelection?: boolean;
+  areaFilter?: string | null;
 }
 
 export function TemplateGrid({
@@ -42,7 +47,29 @@ export function TemplateGrid({
   highlightCellId,
   onMobileCellTap,
   hasMobileSelection,
+  areaFilter,
 }: Readonly<TemplateGridProps>) {
+  const STORAGE_KEY = 'shift-planner-area-collapse';
+
+  const [collapsed, setCollapsed] = useState<Record<string, boolean>>(() => {
+    try {
+      return JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+    } catch {
+      return {};
+    }
+  });
+
+  const toggleCollapse = useCallback((area: string) => {
+    setCollapsed((prev) => {
+      const next = { ...prev, [area]: !prev[area] };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+      return next;
+    });
+  }, []);
+
+  const groups = groupTemplatesByArea(templates, areaFilter);
+  const showSectionHeaders = areaFilter === null && groups.length > 1;
+
   return (
     <div className="rounded-xl border border-border/40 overflow-x-auto">
       <div className="grid grid-cols-[56px_repeat(7,1fr)] md:grid-cols-[200px_repeat(7,1fr)] min-w-[560px] md:min-w-[1000px]">
@@ -75,38 +102,52 @@ export function TemplateGrid({
           );
         })}
 
-        {/* Template rows */}
-        {templates.map((template) => (
-          <div
-            key={template.id}
-            className="contents"
-          >
-            <div className="group border-t border-border/40">
-              <TemplateRowHeader
-                template={template}
-                onEdit={onEditTemplate}
-                onDelete={onDeleteTemplate}
+        {/* Template rows grouped by area */}
+        {groups.map((group) => (
+          <div key={group.area} className="contents">
+            {showSectionHeaders && (
+              <AreaSectionHeader
+                area={group.area}
+                templateCount={group.templates.length}
+                isCollapsed={!!collapsed[group.area]}
+                onToggle={() => toggleCollapse(group.area)}
+                colSpan={8}
               />
-            </div>
-            {weekDays.map((day) => {
-              const isActiveDay = templateAppliesToDay(template, day);
-              const shifts = gridData.get(template.id)?.get(day) ?? [];
-              return (
-                <div key={day} className="border-t border-l border-border/40">
-                  <ShiftCell
-                    templateId={template.id}
-                    day={day}
-                    isActiveDay={isActiveDay}
-                    shifts={shifts}
-                    capacity={template.capacity ?? 1}
-                    onRemoveShift={onRemoveShift}
-                    isHighlighted={highlightCellId === `${template.id}:${day}`}
-                    onMobileTap={onMobileCellTap}
-                    hasMobileSelection={hasMobileSelection}
-                  />
+            )}
+            {(!showSectionHeaders || !collapsed[group.area]) &&
+              group.templates.map((template) => (
+                <div
+                  key={template.id}
+                  className="contents"
+                >
+                  <div className="group border-t border-border/40">
+                    <TemplateRowHeader
+                      template={template}
+                      onEdit={onEditTemplate}
+                      onDelete={onDeleteTemplate}
+                    />
+                  </div>
+                  {weekDays.map((day) => {
+                    const isActiveDay = templateAppliesToDay(template, day);
+                    const shifts = gridData.get(template.id)?.get(day) ?? [];
+                    return (
+                      <div key={day} className="border-t border-l border-border/40">
+                        <ShiftCell
+                          templateId={template.id}
+                          day={day}
+                          isActiveDay={isActiveDay}
+                          shifts={shifts}
+                          capacity={template.capacity ?? 1}
+                          onRemoveShift={onRemoveShift}
+                          isHighlighted={highlightCellId === `${template.id}:${day}`}
+                          onMobileTap={onMobileCellTap}
+                          hasMobileSelection={hasMobileSelection}
+                        />
+                      </div>
+                    );
+                  })}
                 </div>
-              );
-            })}
+              ))}
           </div>
         ))}
       </div>

--- a/src/components/scheduling/ShiftPlanner/TemplateGrid.tsx
+++ b/src/components/scheduling/ShiftPlanner/TemplateGrid.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 
 import { templateAppliesToDay } from '@/hooks/useShiftTemplates';
 
@@ -12,6 +12,7 @@ import { ShiftCell } from './ShiftCell';
 import { AreaSectionHeader } from './AreaSectionHeader';
 
 const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const AREA_COLLAPSE_KEY = 'shift-planner-area-collapse';
 
 function getDayLabel(dateStr: string): { name: string; number: number; isToday: boolean } {
   const [y, m, d] = dateStr.split('-').map(Number);
@@ -49,11 +50,9 @@ export function TemplateGrid({
   hasMobileSelection,
   areaFilter,
 }: Readonly<TemplateGridProps>) {
-  const STORAGE_KEY = 'shift-planner-area-collapse';
-
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>(() => {
     try {
-      return JSON.parse(localStorage.getItem(STORAGE_KEY) || '{}');
+      return JSON.parse(localStorage.getItem(AREA_COLLAPSE_KEY) || '{}');
     } catch {
       return {};
     }
@@ -62,12 +61,12 @@ export function TemplateGrid({
   const toggleCollapse = useCallback((area: string) => {
     setCollapsed((prev) => {
       const next = { ...prev, [area]: !prev[area] };
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+      localStorage.setItem(AREA_COLLAPSE_KEY, JSON.stringify(next));
       return next;
     });
   }, []);
 
-  const groups = groupTemplatesByArea(templates, areaFilter);
+  const groups = useMemo(() => groupTemplatesByArea(templates, areaFilter), [templates, areaFilter]);
   const showSectionHeaders = areaFilter === null && groups.length > 1;
 
   return (

--- a/src/hooks/useEmployeeAreas.tsx
+++ b/src/hooks/useEmployeeAreas.tsx
@@ -8,25 +8,43 @@ export const DEFAULT_AREAS = [
   'Management',
 ];
 
+/** Merge and deduplicate area arrays, sorted alphabetically */
+export function mergeAreas(employeeAreas: string[], templateAreas: string[]): string[] {
+  const unique = new Set([...employeeAreas, ...templateAreas]);
+  return Array.from(unique).sort();
+}
+
 export const useEmployeeAreas = (restaurantId: string | null) => {
   const { data: areas, isLoading, error } = useQuery({
-    queryKey: ['employee-areas', restaurantId],
+    queryKey: ['restaurant-areas', restaurantId],
     queryFn: async () => {
       if (!restaurantId) return [];
 
-      const { data, error } = await supabase
-        .from('employees')
-        .select('area' as any)
-        .eq('restaurant_id', restaurantId)
-        .not('area', 'is', null);
+      const [employeesResult, templatesResult] = await Promise.all([
+        supabase
+          .from('employees')
+          .select('area' as any)
+          .eq('restaurant_id', restaurantId)
+          .not('area', 'is', null),
+        supabase
+          .from('shift_templates')
+          .select('area' as any)
+          .eq('restaurant_id', restaurantId)
+          .not('area', 'is', null),
+      ]);
 
-      if (error) throw error;
+      if (employeesResult.error) throw employeesResult.error;
+      if (templatesResult.error) throw templatesResult.error;
 
-      const uniqueAreas = Array.from(
-        new Set((data as any[]).map((employee) => employee.area as string).filter(Boolean))
-      ).sort((a, b) => a.localeCompare(b));
+      const employeeAreas = (employeesResult.data as any[])
+        .map((e) => e.area as string)
+        .filter(Boolean);
 
-      return uniqueAreas;
+      const templateAreas = (templatesResult.data as any[])
+        .map((t) => t.area as string)
+        .filter(Boolean);
+
+      return mergeAreas(employeeAreas, templateAreas);
     },
     enabled: !!restaurantId,
     staleTime: 30000,

--- a/src/hooks/useEmployeeAreas.tsx
+++ b/src/hooks/useEmployeeAreas.tsx
@@ -11,7 +11,7 @@ export const DEFAULT_AREAS = [
 /** Merge and deduplicate area arrays, sorted alphabetically */
 export function mergeAreas(employeeAreas: string[], templateAreas: string[]): string[] {
   const unique = new Set([...employeeAreas, ...templateAreas]);
-  return Array.from(unique).sort();
+  return Array.from(unique).sort((a, b) => a.localeCompare(b));
 }
 
 export const useEmployeeAreas = (restaurantId: string | null) => {

--- a/src/lib/templateAreaGrouping.ts
+++ b/src/lib/templateAreaGrouping.ts
@@ -1,6 +1,6 @@
 import type { ShiftTemplate } from '@/types/scheduling';
 
-const UNASSIGNED = 'Unassigned';
+export const UNASSIGNED = 'Unassigned';
 
 export interface TemplateAreaGroup {
   area: string;

--- a/src/lib/templateAreaGrouping.ts
+++ b/src/lib/templateAreaGrouping.ts
@@ -1,0 +1,54 @@
+import type { ShiftTemplate } from '@/types/scheduling';
+
+const UNASSIGNED = 'Unassigned';
+
+export interface TemplateAreaGroup {
+  area: string;
+  templates: ShiftTemplate[];
+}
+
+/**
+ * Groups templates by area, sorted alphabetically with "Unassigned" last.
+ * If areaFilter is provided, returns only that area's group.
+ */
+export function groupTemplatesByArea(
+  templates: ShiftTemplate[],
+  areaFilter?: string | null,
+): TemplateAreaGroup[] {
+  if (templates.length === 0) return [];
+
+  const filtered = areaFilter
+    ? templates.filter((t) =>
+        areaFilter === UNASSIGNED ? !t.area : t.area === areaFilter,
+      )
+    : templates;
+
+  const map = new Map<string, ShiftTemplate[]>();
+
+  for (const t of filtered) {
+    const key = t.area ?? UNASSIGNED;
+    const group = map.get(key);
+    if (group) {
+      group.push(t);
+    } else {
+      map.set(key, [t]);
+    }
+  }
+
+  return Array.from(map.entries())
+    .sort(([a], [b]) => {
+      if (a === UNASSIGNED) return 1;
+      if (b === UNASSIGNED) return -1;
+      return a.localeCompare(b);
+    })
+    .map(([area, templates]) => ({ area, templates }));
+}
+
+/** Extract unique area names from templates (for filter pills) */
+export function getTemplateAreas(templates: ShiftTemplate[]): string[] {
+  const areas = new Set<string>();
+  for (const t of templates) {
+    if (t.area) areas.add(t.area);
+  }
+  return Array.from(areas).sort();
+}

--- a/src/lib/templateAreaGrouping.ts
+++ b/src/lib/templateAreaGrouping.ts
@@ -26,7 +26,7 @@ export function groupTemplatesByArea(
   const map = new Map<string, ShiftTemplate[]>();
 
   for (const t of filtered) {
-    const key = t.area ?? UNASSIGNED;
+    const key = t.area || UNASSIGNED;
     const group = map.get(key);
     if (group) {
       group.push(t);

--- a/src/lib/templateAreaGrouping.ts
+++ b/src/lib/templateAreaGrouping.ts
@@ -50,5 +50,5 @@ export function getTemplateAreas(templates: ShiftTemplate[]): string[] {
   for (const t of templates) {
     if (t.area) areas.add(t.area);
   }
-  return Array.from(areas).sort();
+  return Array.from(areas).sort((a, b) => a.localeCompare(b));
 }

--- a/src/types/scheduling.ts
+++ b/src/types/scheduling.ts
@@ -119,6 +119,7 @@ export interface ShiftTemplate {
   break_duration: number;
   position: string;
   capacity: number;
+  area?: string;
   is_active: boolean;
   created_at: string;
   updated_at: string;

--- a/src/types/scheduling.ts
+++ b/src/types/scheduling.ts
@@ -119,7 +119,7 @@ export interface ShiftTemplate {
   break_duration: number;
   position: string;
   capacity: number;
-  area?: string;
+  area?: string | null;
   is_active: boolean;
   created_at: string;
   updated_at: string;

--- a/supabase/functions/_shared/schedule-prompt-builder.ts
+++ b/supabase/functions/_shared/schedule-prompt-builder.ts
@@ -10,6 +10,7 @@ export interface ScheduleEmployee {
   id: string;
   name: string;
   position: string;
+  area: string | null;
   hourly_rate: number; // cents
 }
 
@@ -20,6 +21,7 @@ export interface ScheduleTemplate {
   start_time: string;
   end_time: string;
   position: string;
+  area: string | null;
 }
 
 export interface AvailabilityDay {
@@ -68,13 +70,14 @@ const SYSTEM_PROMPT = `You are a restaurant schedule optimizer. Your job is to c
 RULES:
 1. ONLY use the provided shift templates as shift blocks — do not invent custom time ranges.
 2. ONLY assign employees to templates matching their position.
-3. ONLY assign employees on days/times they are available.
-4. Do NOT assign any employee more than once in the same time slot (no double-booking).
-5. Do NOT modify or reassign any locked shifts — they are fixed.
-6. Weight staffing toward peak sales hours — more staff during lunch/dinner rushes.
-7. If staffing settings specify minimum crew per position, meet those minimums when possible.
-8. If no staffing settings exist, use prior schedule patterns to infer typical staffing levels.
-9. Try to stay within the weekly labor budget target. If adequate coverage requires exceeding it, note the variance.
+3. When a template has an area set, PREFER assigning employees from the same area. Only assign employees from a different area to that template if no same-area employees are available for that time slot. This is a soft preference — cross-area assignments are allowed as a fallback.
+4. ONLY assign employees on days/times they are available.
+5. Do NOT assign any employee more than once in the same time slot (no double-booking).
+6. Do NOT modify or reassign any locked shifts — they are fixed.
+7. Weight staffing toward peak sales hours — more staff during lunch/dinner rushes.
+8. If staffing settings specify minimum crew per position, meet those minimums when possible.
+9. If no staffing settings exist, use prior schedule patterns to infer typical staffing levels.
+10. Try to stay within the weekly labor budget target. If adequate coverage requires exceeding it, note the variance.
 
 Return valid JSON only, matching the provided schema exactly.`;
 
@@ -130,6 +133,7 @@ function buildUserPrompt(ctx: ScheduleContext): string {
     id: e.id,
     name: e.name,
     position: e.position,
+    area: e.area ?? 'unassigned',
     hourly_rate_dollars: (e.hourly_rate / 100).toFixed(2),
   }));
   sections.push(`## Available Employees\n${JSON.stringify(employeesForPrompt, null, 2)}`);
@@ -137,7 +141,8 @@ function buildUserPrompt(ctx: ScheduleContext): string {
   // Shift templates
   const templatesSection = ctx.templates.map((t) => {
     const dayNames = t.days.map((d) => DAY_NAMES[d]).join(', ');
-    return `- [${t.id}] "${t.name}" | position: ${t.position} | ${t.start_time}–${t.end_time} | active days: ${dayNames}`;
+    const areaStr = t.area ? ` | area: ${t.area}` : '';
+    return `- [${t.id}] "${t.name}" | position: ${t.position}${areaStr} | ${t.start_time}–${t.end_time} | active days: ${dayNames}`;
   });
   sections.push(`## Shift Templates\n${templatesSection.join('\n')}`);
 

--- a/supabase/functions/generate-schedule/index.ts
+++ b/supabase/functions/generate-schedule/index.ts
@@ -114,14 +114,14 @@ serve(async (req) => {
       // 1. Active employees
       supabase
         .from("employees")
-        .select("id, name, position, hourly_rate, salary_amount, compensation_type")
+        .select("id, name, position, area, hourly_rate, salary_amount, compensation_type")
         .eq("restaurant_id", restaurant_id)
         .eq("status", "active"),
 
       // 2. Active shift templates
       supabase
         .from("shift_templates")
-        .select("id, name, days, start_time, end_time, position")
+        .select("id, name, days, start_time, end_time, position, area")
         .eq("restaurant_id", restaurant_id)
         .eq("is_active", true),
 
@@ -213,6 +213,7 @@ serve(async (req) => {
       id: e.id,
       name: e.name,
       position: e.position ?? "Staff",
+      area: e.area ?? null,
       // hourly_rate stored in cents; salary employees get 0
       hourly_rate: e.compensation_type === "salary" ? 0 : (e.hourly_rate ?? 0),
     }));
@@ -225,6 +226,7 @@ serve(async (req) => {
       start_time: t.start_time,
       end_time: t.end_time,
       position: t.position ?? "Staff",
+      area: t.area ?? null,
     }));
 
     // ── Build availability map ───────────────────────────────────────────────

--- a/supabase/migrations/20260411200001_add_area_to_shift_templates.sql
+++ b/supabase/migrations/20260411200001_add_area_to_shift_templates.sql
@@ -1,0 +1,7 @@
+-- Add optional area field to shift templates for grouping and AI scheduling
+ALTER TABLE shift_templates ADD COLUMN area TEXT;
+
+-- Index for filtered queries by area within a restaurant
+CREATE INDEX idx_shift_templates_area
+  ON shift_templates (restaurant_id, area)
+  WHERE area IS NOT NULL;

--- a/supabase/tests/shift_template_area.sql
+++ b/supabase/tests/shift_template_area.sql
@@ -1,0 +1,21 @@
+BEGIN;
+SELECT plan(4);
+
+-- Test 1: area column exists on shift_templates
+SELECT has_column('public', 'shift_templates', 'area',
+  'shift_templates should have an area column');
+
+-- Test 2: area column is nullable
+SELECT col_is_null('public', 'shift_templates', 'area',
+  'area column should be nullable');
+
+-- Test 3: area column is TEXT type
+SELECT col_type_is('public', 'shift_templates', 'area', 'text',
+  'area column should be TEXT');
+
+-- Test 4: index exists for area lookups
+SELECT has_index('public', 'shift_templates', 'idx_shift_templates_area',
+  'shift_templates should have an area index');
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/tests/e2e/shift-template-areas.spec.ts
+++ b/tests/e2e/shift-template-areas.spec.ts
@@ -1,0 +1,135 @@
+import { test, expect } from '@playwright/test';
+import { signUpAndCreateRestaurant, exposeSupabaseHelpers, generateTestUser } from '../helpers/e2e-supabase';
+
+test.describe('Shift Template Areas', () => {
+  test('can create templates with area, see area filter pills, and filter by area', async ({ page }) => {
+    // 1. Sign up and create restaurant
+    const testUser = generateTestUser('tmpl-area');
+    await signUpAndCreateRestaurant(page, testUser);
+    await exposeSupabaseHelpers(page);
+
+    // Seed two employees so the planner renders
+    const restaurantId = await page.evaluate(() => (window as any).__getRestaurantId());
+    expect(restaurantId).toBeTruthy();
+
+    await page.evaluate(
+      ({ emps, restId }) => (window as any).__insertEmployees(emps, restId),
+      {
+        emps: [
+          {
+            name: 'Chef Maria',
+            position: 'Prep Cook',
+            status: 'active',
+            is_active: true,
+            compensation_type: 'hourly',
+            hourly_rate: 1800,
+          },
+          {
+            name: 'Server Lisa',
+            position: 'Server',
+            status: 'active',
+            is_active: true,
+            compensation_type: 'hourly',
+            hourly_rate: 1500,
+          },
+        ],
+        restId: restaurantId,
+      },
+    );
+
+    // 2. Navigate to scheduling, click Planner tab
+    await page.goto('/scheduling');
+    await page.waitForURL(/\/scheduling/, { timeout: 8000 });
+
+    const plannerTab = page.getByRole('tab', { name: /planner/i });
+    await expect(plannerTab).toBeVisible({ timeout: 10000 });
+    await plannerTab.click();
+
+    await expect(page.getByText('Chef Maria')).toBeVisible({ timeout: 10000 });
+
+    // 3. Create first template — Back of House
+    await page.getByRole('button', { name: /add shift template/i }).click();
+
+    const dialog = page.getByRole('dialog', { name: /add shift template/i });
+    await expect(dialog).toBeVisible({ timeout: 3000 });
+
+    await dialog.locator('#template-name').fill('Opening Prep');
+    await dialog.locator('#start-time').fill('06:00');
+    await dialog.locator('#end-time').fill('14:00');
+    await dialog.locator('#position').fill('Prep Cook');
+
+    // Open the AreaCombobox (trigger has role="combobox" and aria-label="Select employee area")
+    await dialog.getByRole('combobox', { name: /select employee area/i }).click();
+
+    // CommandItem renders with role="option" via CMDK
+    await page.getByRole('option', { name: /back of house/i }).click();
+
+    // Select Monday
+    await dialog.getByRole('button', { name: 'Monday' }).click();
+
+    // Submit
+    const create1 = page.waitForResponse(
+      (resp) => resp.url().includes('rest/v1/shift_templates') && resp.status() === 201,
+      { timeout: 15000 },
+    );
+    await dialog.getByRole('button', { name: /add template/i }).click();
+    await create1;
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+
+    // Dismiss any toast so it does not block interactions
+    const toast1 = page.locator('[data-sonner-toast]').first();
+    if (await toast1.isVisible({ timeout: 1000 }).catch(() => false)) {
+      await toast1.locator('button[aria-label="Close"]').click().catch(() => {});
+    }
+
+    // 4. Create second template — Front of House
+    await page.getByRole('button', { name: /add shift template/i }).click();
+
+    const dialog2 = page.getByRole('dialog', { name: /add shift template/i });
+    await expect(dialog2).toBeVisible({ timeout: 3000 });
+
+    await dialog2.locator('#template-name').fill('Opening Server');
+    await dialog2.locator('#start-time').fill('10:00');
+    await dialog2.locator('#end-time').fill('18:00');
+    await dialog2.locator('#position').fill('Server');
+
+    await dialog2.getByRole('combobox', { name: /select employee area/i }).click();
+    await page.getByRole('option', { name: /front of house/i }).click();
+
+    await dialog2.getByRole('button', { name: 'Monday' }).click();
+
+    const create2 = page.waitForResponse(
+      (resp) => resp.url().includes('rest/v1/shift_templates') && resp.status() === 201,
+      { timeout: 15000 },
+    );
+    await dialog2.getByRole('button', { name: /add template/i }).click();
+    await create2;
+    await expect(dialog2).not.toBeVisible({ timeout: 5000 });
+
+    // 5. Verify both templates are visible in the grid
+    await expect(page.getByText('Opening Prep')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Opening Server')).toBeVisible({ timeout: 5000 });
+
+    // 6. Verify area filter pills appear (AreaFilterPills renders plain <button> elements)
+    // "All" pill is active by default (selectedArea === null matches pill.value === null)
+    const allPill = page.locator('button').filter({ hasText: /^All$/ });
+    await expect(allPill).toBeVisible({ timeout: 5000 });
+
+    const bohPill = page.locator('button').filter({ hasText: /^Back of House$/ });
+    await expect(bohPill).toBeVisible();
+
+    const fohPill = page.locator('button').filter({ hasText: /^Front of House$/ });
+    await expect(fohPill).toBeVisible();
+
+    // 7. Filter to Back of House — only Opening Prep should remain visible
+    await bohPill.click();
+
+    await expect(page.getByText('Opening Prep')).toBeVisible();
+    await expect(page.getByText('Opening Server')).not.toBeVisible({ timeout: 3000 });
+
+    // 8. Reset to All — both templates visible again
+    await allPill.click();
+    await expect(page.getByText('Opening Prep')).toBeVisible();
+    await expect(page.getByText('Opening Server')).toBeVisible();
+  });
+});

--- a/tests/unit/templateAreaGrouping.test.ts
+++ b/tests/unit/templateAreaGrouping.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { groupTemplatesByArea, getTemplateAreas } from '@/lib/templateAreaGrouping';
+import type { ShiftTemplate } from '@/types/scheduling';
+
+const makeTemplate = (overrides: Partial<ShiftTemplate>): ShiftTemplate => ({
+  id: crypto.randomUUID(),
+  restaurant_id: 'r1',
+  name: 'Test',
+  days: [1, 2, 3],
+  start_time: '09:00',
+  end_time: '17:00',
+  break_duration: 0,
+  position: 'Server',
+  capacity: 1,
+  is_active: true,
+  created_at: '',
+  updated_at: '',
+  ...overrides,
+});
+
+describe('groupTemplatesByArea', () => {
+  it('groups templates by area with Unassigned last', () => {
+    const templates = [
+      makeTemplate({ name: 'A', area: 'Kitchen' }),
+      makeTemplate({ name: 'B', area: undefined }),
+      makeTemplate({ name: 'C', area: 'Front of House' }),
+      makeTemplate({ name: 'D', area: 'Kitchen' }),
+    ];
+    const groups = groupTemplatesByArea(templates);
+    expect(groups.map((g) => g.area)).toEqual(['Front of House', 'Kitchen', 'Unassigned']);
+    expect(groups[1].templates.map((t) => t.name)).toEqual(['A', 'D']);
+    expect(groups[2].templates.map((t) => t.name)).toEqual(['B']);
+  });
+
+  it('returns single Unassigned group when no areas set', () => {
+    const templates = [makeTemplate({ name: 'X' }), makeTemplate({ name: 'Y' })];
+    const groups = groupTemplatesByArea(templates);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].area).toBe('Unassigned');
+  });
+
+  it('returns empty array for no templates', () => {
+    expect(groupTemplatesByArea([])).toEqual([]);
+  });
+
+  it('filters by area when areaFilter is provided', () => {
+    const templates = [
+      makeTemplate({ name: 'A', area: 'Kitchen' }),
+      makeTemplate({ name: 'B', area: 'Front of House' }),
+    ];
+    const groups = groupTemplatesByArea(templates, 'Kitchen');
+    expect(groups).toHaveLength(1);
+    expect(groups[0].area).toBe('Kitchen');
+    expect(groups[0].templates).toHaveLength(1);
+  });
+});
+
+describe('getTemplateAreas', () => {
+  it('returns sorted unique area names', () => {
+    const templates = [
+      makeTemplate({ area: 'Kitchen' }),
+      makeTemplate({ area: 'Bar' }),
+      makeTemplate({ area: 'Kitchen' }),
+      makeTemplate({ area: undefined }),
+    ];
+    expect(getTemplateAreas(templates)).toEqual(['Bar', 'Kitchen']);
+  });
+
+  it('returns empty for no areas', () => {
+    expect(getTemplateAreas([makeTemplate({})])).toEqual([]);
+  });
+});

--- a/tests/unit/useRestaurantAreas.test.ts
+++ b/tests/unit/useRestaurantAreas.test.ts
@@ -15,6 +15,6 @@ describe('mergeAreas', () => {
 
   it('preserves different casings as separate entries', () => {
     const result = mergeAreas(['Kitchen'], ['kitchen', 'Bar']);
-    expect(result).toEqual(['Bar', 'Kitchen', 'kitchen']);
+    expect(result).toEqual(['Bar', 'kitchen', 'Kitchen']);
   });
 });

--- a/tests/unit/useRestaurantAreas.test.ts
+++ b/tests/unit/useRestaurantAreas.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { mergeAreas } from '@/hooks/useEmployeeAreas';
+
+describe('mergeAreas', () => {
+  it('returns sorted unique areas from employees and templates', () => {
+    const employeeAreas = ['Kitchen', 'Bar'];
+    const templateAreas = ['Front of House', 'Kitchen'];
+    const result = mergeAreas(employeeAreas, templateAreas);
+    expect(result).toEqual(['Bar', 'Front of House', 'Kitchen']);
+  });
+
+  it('handles empty arrays', () => {
+    expect(mergeAreas([], [])).toEqual([]);
+  });
+
+  it('deduplicates case-sensitively', () => {
+    const result = mergeAreas(['Kitchen'], ['Kitchen', 'Bar']);
+    expect(result).toEqual(['Bar', 'Kitchen']);
+  });
+});

--- a/tests/unit/useRestaurantAreas.test.ts
+++ b/tests/unit/useRestaurantAreas.test.ts
@@ -13,8 +13,8 @@ describe('mergeAreas', () => {
     expect(mergeAreas([], [])).toEqual([]);
   });
 
-  it('deduplicates case-sensitively', () => {
-    const result = mergeAreas(['Kitchen'], ['Kitchen', 'Bar']);
-    expect(result).toEqual(['Bar', 'Kitchen']);
+  it('preserves different casings as separate entries', () => {
+    const result = mergeAreas(['Kitchen'], ['kitchen', 'Bar']);
+    expect(result).toEqual(['Bar', 'Kitchen', 'kitchen']);
   });
 });


### PR DESCRIPTION
## Summary
- Adds optional `area` column to `shift_templates` table (nullable TEXT, same pattern as `employees.area`)
- Area picker (AreaCombobox) in the template form dialog between Position and Days
- Template grid groups templates by area with collapsible section headers + filter pills (All / Kitchen / FOH / etc.)
- Employee sidebar auto-syncs area filter from planner with "Show all employees" override toggle
- AI scheduler now includes area in employee/template data and prefers same-area assignments (soft preference, cross-area fallback allowed)

## Test plan
- [x] 4 pgTAP tests: column existence, nullability, type, index
- [x] 9 unit tests: `groupTemplatesByArea`, `getTemplateAreas`, `mergeAreas`
- [x] 1 E2E test: create templates with areas, verify filter pills, test area filtering
- [x] TypeScript builds with 0 errors
- [x] All 3352 existing unit tests pass
- [x] Production build succeeds

## Design doc
`docs/superpowers/specs/2026-04-11-shift-template-areas-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Templates can be assigned an Area; area shown/edited in the template form.
  * Area filter “pills” let you filter templates; templates are grouped by area with collapsible sections (collapsed state is remembered).
  * Employee sidebar can toggle to respect an area filter.
  * Scheduling prefers assigning employees from the same area when possible.

* **Tests**
  * Added end-to-end and unit tests covering area filtering, grouping, and assignment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->