### PR TITLE
feat: employee open shift claiming with unified feed

### DIFF
--- a/docs/superpowers/plans/2026-04-11-open-shift-capacity-plan.md
+++ b/docs/superpowers/plans/2026-04-11-open-shift-capacity-plan.md
@@ -1,0 +1,671 @@
+# Open Shift Capacity — Implementation Plan (PR1)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Managers can set staffing capacity on shift templates and see at a glance where they're short-staffed in the planner grid.
+
+**Architecture:** Add a `capacity` column (default 1) to `shift_templates`. The planner grid compares `capacity` vs count of assigned shifts per template/day to show "assigned/needed" indicators. The publish dialog warns about unfilled spots. No new tables — this is a read-side enhancement to existing data.
+
+**Tech Stack:** PostgreSQL migration, TypeScript/React, React Query, Vitest, pgTAP, Playwright
+
+**Design spec:** `docs/superpowers/specs/2026-04-11-open-shift-claiming-design.md`
+
+---
+
+### Task 1: Add `capacity` column to `shift_templates`
+
+**Files:**
+- Create: `supabase/migrations/YYYYMMDDHHMMSS_add_capacity_to_shift_templates.sql`
+- Create: `supabase/tests/shift_template_capacity.test.sql`
+
+- [ ] **Step 1: Write the pgTAP test**
+
+Create `supabase/tests/shift_template_capacity.test.sql`:
+
+```sql
+BEGIN;
+SELECT plan(5);
+
+-- Test 1: capacity column exists with default 1
+SELECT has_column('shift_templates', 'capacity',
+  'shift_templates should have a capacity column');
+
+SELECT col_default_is('shift_templates', 'capacity', '1',
+  'capacity should default to 1');
+
+-- Test 2: capacity must be >= 1
+SELECT lives_ok(
+  $$INSERT INTO shift_templates (restaurant_id, name, days, start_time, end_time, position, capacity)
+    VALUES ((SELECT id FROM restaurants LIMIT 1), 'Test', '{1,2}', '09:00', '17:00', 'Server', 3)$$,
+  'capacity of 3 is valid'
+);
+
+SELECT throws_ok(
+  $$INSERT INTO shift_templates (restaurant_id, name, days, start_time, end_time, position, capacity)
+    VALUES ((SELECT id FROM restaurants LIMIT 1), 'Test Zero', '{1}', '09:00', '17:00', 'Server', 0)$$,
+  '23514',
+  NULL,
+  'capacity of 0 violates check constraint'
+);
+
+SELECT throws_ok(
+  $$INSERT INTO shift_templates (restaurant_id, name, days, start_time, end_time, position, capacity)
+    VALUES ((SELECT id FROM restaurants LIMIT 1), 'Test Neg', '{1}', '09:00', '17:00', 'Server', -1)$$,
+  '23514',
+  NULL,
+  'negative capacity violates check constraint'
+);
+
+SELECT * FROM finish();
+ROLLBACK;
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test:db`
+Expected: FAIL — column `capacity` does not exist.
+
+- [ ] **Step 3: Write the migration**
+
+Create the migration file (use `npx supabase migration new add_capacity_to_shift_templates` to get the timestamp):
+
+```sql
+-- Add capacity column to shift_templates
+-- Represents how many employees are needed for this shift slot
+ALTER TABLE shift_templates
+  ADD COLUMN capacity INTEGER NOT NULL DEFAULT 1;
+
+ALTER TABLE shift_templates
+  ADD CONSTRAINT valid_capacity CHECK (capacity >= 1);
+```
+
+- [ ] **Step 4: Reset the database and run tests**
+
+Run: `npx supabase db reset && npm run test:db`
+Expected: All pgTAP tests pass, including the new capacity tests.
+
+- [ ] **Step 5: Regenerate TypeScript types**
+
+Run: `npx supabase gen types typescript --local > src/integrations/supabase/types.ts`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add supabase/migrations/*_add_capacity_to_shift_templates.sql supabase/tests/shift_template_capacity.test.sql src/integrations/supabase/types.ts
+git commit -m "feat: add capacity column to shift_templates"
+```
+
+---
+
+### Task 2: Update `ShiftTemplate` TypeScript type and hook
+
+**Files:**
+- Modify: `src/types/scheduling.ts:111-123`
+- Modify: `src/hooks/useShiftTemplates.ts:25-33` (TemplateInput type) and mutation
+
+- [ ] **Step 1: Write the failing unit test**
+
+Create `tests/unit/shiftTemplateCapacity.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+
+// We're testing the type + a pure helper that computes open spots
+import { computeOpenSpots } from '@/lib/openShiftHelpers';
+
+describe('computeOpenSpots', () => {
+  it('returns capacity minus assigned count', () => {
+    expect(computeOpenSpots(3, 1)).toBe(2);
+  });
+
+  it('returns 0 when fully staffed', () => {
+    expect(computeOpenSpots(2, 2)).toBe(0);
+  });
+
+  it('returns 0 when over-staffed (clamped)', () => {
+    expect(computeOpenSpots(2, 3)).toBe(0);
+  });
+
+  it('returns full capacity when nobody assigned', () => {
+    expect(computeOpenSpots(3, 0)).toBe(3);
+  });
+
+  it('defaults capacity to 1 when undefined', () => {
+    expect(computeOpenSpots(undefined, 0)).toBe(1);
+    expect(computeOpenSpots(undefined, 1)).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run tests/unit/shiftTemplateCapacity.test.ts`
+Expected: FAIL — `computeOpenSpots` does not exist.
+
+- [ ] **Step 3: Add `capacity` to the ShiftTemplate type**
+
+In `src/types/scheduling.ts`, add `capacity` to the `ShiftTemplate` interface:
+
+```typescript
+export interface ShiftTemplate {
+  id: string;
+  restaurant_id: string;
+  name: string;
+  days: number[];
+  start_time: string;
+  end_time: string;
+  break_duration: number;
+  position: string;
+  capacity: number; // How many employees needed (default 1)
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+}
+```
+
+- [ ] **Step 4: Create the `openShiftHelpers` module**
+
+Create `src/lib/openShiftHelpers.ts`:
+
+```typescript
+/**
+ * Compute how many open spots remain for a template on a given day.
+ * Clamps to 0 (never negative).
+ */
+export function computeOpenSpots(
+  capacity: number | undefined,
+  assignedCount: number,
+): number {
+  const cap = capacity ?? 1;
+  return Math.max(0, cap - assignedCount);
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npx vitest run tests/unit/shiftTemplateCapacity.test.ts`
+Expected: PASS
+
+- [ ] **Step 6: Update `useShiftTemplates` to include `capacity` in mutations**
+
+In `src/hooks/useShiftTemplates.ts`, the `TemplateInput` type (line 33) already uses `Omit<ShiftTemplate, 'id' | 'created_at' | 'updated_at'>`, so it will automatically include `capacity` from the updated type. No code change needed in the hook itself — the type flows through.
+
+Verify by checking the existing `createMutation` and `updateMutation` — they pass through the input object directly, so `capacity` will be included when provided.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/types/scheduling.ts src/lib/openShiftHelpers.ts tests/unit/shiftTemplateCapacity.test.ts
+git commit -m "feat: add capacity to ShiftTemplate type and open spot helper"
+```
+
+---
+
+### Task 3: Add "Staff Needed" field to `TemplateFormDialog`
+
+**Files:**
+- Modify: `src/components/scheduling/ShiftPlanner/TemplateFormDialog.tsx`
+
+- [ ] **Step 1: Add `capacity` state and form field**
+
+In `TemplateFormDialog.tsx`, add a `capacity` state variable alongside the existing form state (after line 50):
+
+```typescript
+const [capacity, setCapacity] = useState(1);
+```
+
+In the `useEffect` that pre-fills the form (lines 54-71), add capacity handling:
+
+```typescript
+// Inside the if (template) block, after setBreakDuration:
+setCapacity(template.capacity ?? 1);
+
+// Inside the else block, after setBreakDuration(0):
+setCapacity(1);
+```
+
+- [ ] **Step 2: Add the capacity field to the form UI**
+
+Add this block after the Break Duration field (after line 246) and before the Footer:
+
+```tsx
+{/* Staff Needed */}
+<div className="space-y-1.5">
+  <Label
+    htmlFor="capacity"
+    className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider"
+  >
+    Staff Needed
+  </Label>
+  <Input
+    id="capacity"
+    type="number"
+    min={1}
+    value={capacity}
+    onChange={(e) => setCapacity(Math.max(1, Number.parseInt(e.target.value, 10) || 1))}
+    className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
+  />
+  <p className="text-[11px] text-muted-foreground">
+    How many employees are needed for this shift
+  </p>
+</div>
+```
+
+- [ ] **Step 3: Include `capacity` in the onSubmit call**
+
+Update the `handleSubmit` function's `onSubmit` call (lines 87-94) to include capacity:
+
+```typescript
+await onSubmit({
+  name: name.trim(),
+  start_time: startTime,
+  end_time: endTime,
+  position: position.trim(),
+  days,
+  break_duration: breakDuration,
+  capacity,
+});
+```
+
+- [ ] **Step 4: Update the `onSubmit` prop type to include `capacity`**
+
+In the `TemplateFormDialogProps` interface (lines 25-31), add `capacity` to the data shape:
+
+```typescript
+onSubmit: (data: {
+  name: string;
+  start_time: string;
+  end_time: string;
+  position: string;
+  days: number[];
+  break_duration: number;
+  capacity: number;
+}) => void | Promise<void>;
+```
+
+- [ ] **Step 5: Run typecheck to confirm no type errors**
+
+Run: `npm run typecheck`
+Expected: No new errors. The callers of `TemplateFormDialog` pass `onSubmit` through to `createTemplate`/`updateTemplate`, which accept `TemplateInput`. Since `TemplateInput` now includes `capacity`, the types align.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/scheduling/ShiftPlanner/TemplateFormDialog.tsx
+git commit -m "feat: add Staff Needed field to template form dialog"
+```
+
+---
+
+### Task 4: Show capacity indicators in the planner grid
+
+**Files:**
+- Modify: `src/components/scheduling/ShiftPlanner/ShiftCell.tsx`
+- Modify: `src/components/scheduling/ShiftPlanner/TemplateGrid.tsx`
+- Create: `tests/unit/openShiftHelpers.test.ts` (already created in Task 2, extend)
+
+- [ ] **Step 1: Write the failing test for the capacity indicator logic**
+
+Extend `tests/unit/shiftTemplateCapacity.test.ts` with indicator classification:
+
+```typescript
+import { computeOpenSpots, classifyCapacity } from '@/lib/openShiftHelpers';
+
+describe('classifyCapacity', () => {
+  it('returns "full" when no open spots', () => {
+    expect(classifyCapacity(3, 3)).toBe('full');
+  });
+
+  it('returns "partial" when some spots filled', () => {
+    expect(classifyCapacity(3, 1)).toBe('partial');
+  });
+
+  it('returns "empty" when no spots filled', () => {
+    expect(classifyCapacity(3, 0)).toBe('empty');
+  });
+
+  it('returns "full" for default capacity of 1 with 1 assigned', () => {
+    expect(classifyCapacity(1, 1)).toBe('full');
+  });
+
+  it('returns "full" when over-staffed', () => {
+    expect(classifyCapacity(2, 3)).toBe('full');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run tests/unit/shiftTemplateCapacity.test.ts`
+Expected: FAIL — `classifyCapacity` does not exist.
+
+- [ ] **Step 3: Implement `classifyCapacity`**
+
+Add to `src/lib/openShiftHelpers.ts`:
+
+```typescript
+export type CapacityStatus = 'full' | 'partial' | 'empty';
+
+/**
+ * Classify how filled a template slot is on a given day.
+ */
+export function classifyCapacity(
+  capacity: number | undefined,
+  assignedCount: number,
+): CapacityStatus {
+  const open = computeOpenSpots(capacity, assignedCount);
+  if (open === 0) return 'full';
+  if (assignedCount > 0) return 'partial';
+  return 'empty';
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run tests/unit/shiftTemplateCapacity.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Pass `capacity` through `TemplateGrid` to `ShiftCell`**
+
+In `src/components/scheduling/ShiftPlanner/TemplateGrid.tsx`, update `ShiftCell` usage (line 96-105) to pass capacity:
+
+```tsx
+<ShiftCell
+  templateId={template.id}
+  day={day}
+  isActiveDay={isActiveDay}
+  shifts={shifts}
+  capacity={template.capacity ?? 1}
+  onRemoveShift={onRemoveShift}
+  isHighlighted={highlightCellId === `${template.id}:${day}`}
+  onMobileTap={onMobileCellTap}
+  hasMobileSelection={hasMobileSelection}
+/>
+```
+
+- [ ] **Step 6: Add capacity indicator to `ShiftCell`**
+
+In `src/components/scheduling/ShiftPlanner/ShiftCell.tsx`:
+
+Add import at top:
+```typescript
+import { computeOpenSpots, classifyCapacity } from '@/lib/openShiftHelpers';
+```
+
+Add `capacity` to the `ShiftCellProps` interface (after line 15):
+```typescript
+capacity: number;
+```
+
+Add the indicator inside the active-day return (after the shifts map, before the closing `</div>`, around line 70):
+
+```tsx
+{/* Capacity indicator — only show when capacity > 1 */}
+{capacity > 1 && (
+  <div
+    className={cn(
+      'text-[10px] font-medium px-1.5 py-0.5 rounded text-center',
+      classifyCapacity(capacity, shifts.length) === 'full'
+        ? 'text-emerald-600 bg-emerald-500/10'
+        : classifyCapacity(capacity, shifts.length) === 'partial'
+          ? 'text-amber-600 bg-amber-500/10'
+          : 'text-red-500 bg-red-500/10',
+    )}
+  >
+    {shifts.length}/{capacity}
+  </div>
+)}
+```
+
+Update the memo comparison (lines 74-82) to include `capacity`:
+```typescript
+(prev, next) =>
+  prev.templateId === next.templateId &&
+  prev.day === next.day &&
+  prev.isActiveDay === next.isActiveDay &&
+  prev.shifts === next.shifts &&
+  prev.capacity === next.capacity &&
+  prev.onRemoveShift === next.onRemoveShift &&
+  prev.isHighlighted === next.isHighlighted &&
+  prev.hasMobileSelection === next.hasMobileSelection &&
+  prev.onMobileTap === next.onMobileTap,
+```
+
+- [ ] **Step 7: Run typecheck**
+
+Run: `npm run typecheck`
+Expected: No errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/lib/openShiftHelpers.ts src/components/scheduling/ShiftPlanner/ShiftCell.tsx src/components/scheduling/ShiftPlanner/TemplateGrid.tsx tests/unit/shiftTemplateCapacity.test.ts
+git commit -m "feat: show capacity indicators in planner grid cells"
+```
+
+---
+
+### Task 5: Add open shift count to publish dialog
+
+**Files:**
+- Modify: `src/components/PublishScheduleDialog.tsx`
+
+- [ ] **Step 1: Add `openShiftCount` prop**
+
+In `PublishScheduleDialogProps` (lines 23-33), add:
+
+```typescript
+openShiftCount: number;
+```
+
+- [ ] **Step 2: Add the info alert when there are open shifts**
+
+After the Summary Stats grid (after line 98) and before the Warning Alert (line 101), add:
+
+```tsx
+{openShiftCount > 0 && (
+  <Alert className="border-amber-500/50 bg-amber-500/10">
+    <AlertTriangle className="h-4 w-4 text-amber-600" />
+    <AlertDescription className="text-sm">
+      <strong>{openShiftCount} {openShiftCount === 1 ? 'shift' : 'shifts'} still {openShiftCount === 1 ? 'needs' : 'need'} staff.</strong>{' '}
+      You can fill these now or broadcast to your team later.
+    </AlertDescription>
+  </Alert>
+)}
+```
+
+- [ ] **Step 3: Compute `openShiftCount` at the call site**
+
+Find where `PublishScheduleDialog` is rendered in `src/pages/Scheduling.tsx`. Add a `useMemo` that computes total open spots for the week:
+
+```typescript
+import { computeOpenSpots } from '@/lib/openShiftHelpers';
+
+const openShiftCount = useMemo(() => {
+  if (!templates.length) return 0;
+  let total = 0;
+  for (const template of templates) {
+    for (const day of weekDays) {
+      if (!templateAppliesToDay(template, day)) continue;
+      const assigned = templateGridData.get(template.id)?.get(day)?.length ?? 0;
+      total += computeOpenSpots(template.capacity, assigned);
+    }
+  }
+  return total;
+}, [templates, weekDays, templateGridData]);
+```
+
+Pass it to the dialog:
+
+```tsx
+<PublishScheduleDialog
+  // ...existing props
+  openShiftCount={openShiftCount}
+/>
+```
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `npm run typecheck`
+Expected: No errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/PublishScheduleDialog.tsx src/pages/Scheduling.tsx
+git commit -m "feat: show open shift count in publish schedule dialog"
+```
+
+---
+
+### Task 6: E2E test — manager sets capacity and sees indicators
+
+**Files:**
+- Create: `tests/e2e/shift-template-capacity.spec.ts`
+
+- [ ] **Step 1: Write the E2E test**
+
+Create `tests/e2e/shift-template-capacity.spec.ts`:
+
+```typescript
+import { test, expect } from '@playwright/test';
+import {
+  generateTestUser,
+  signUpAndOnboard,
+  cleanupTestUser,
+} from '../helpers/e2e-supabase';
+
+test.describe('Shift template capacity', () => {
+  let testUser: ReturnType<typeof generateTestUser>;
+
+  test.beforeEach(async ({ page }) => {
+    testUser = generateTestUser();
+    await signUpAndOnboard(page, testUser);
+  });
+
+  test.afterEach(async () => {
+    await cleanupTestUser(testUser.email);
+  });
+
+  test('manager can set staff needed on a template and see capacity indicator', async ({ page }) => {
+    // Navigate to scheduling
+    await page.goto('/scheduling');
+    await page.waitForLoadState('networkidle');
+
+    // Click "Add Shift Template"
+    await page.getByRole('button', { name: /add shift template/i }).click();
+
+    // Fill out the template form
+    const dialog = page.getByRole('dialog', { name: /add shift template/i });
+    await dialog.getByLabel(/template name/i).fill('Closing Server');
+    await dialog.getByLabel(/start time/i).fill('16:00');
+    await dialog.getByLabel(/end time/i).fill('22:00');
+    await dialog.getByLabel(/position/i).fill('Server');
+
+    // Select Monday
+    await dialog.getByRole('button', { name: 'Monday' }).click();
+
+    // Set staff needed to 3
+    await dialog.getByLabel(/staff needed/i).clear();
+    await dialog.getByLabel(/staff needed/i).fill('3');
+
+    // Submit
+    await dialog.getByRole('button', { name: /add template/i }).click();
+
+    // Verify template was created (row header should show)
+    await expect(page.getByText('Closing Server')).toBeVisible();
+
+    // Verify capacity indicator shows 0/3 on Monday (no one assigned yet)
+    await expect(page.getByText('0/3')).toBeVisible();
+  });
+
+  test('capacity defaults to 1 and no indicator shown', async ({ page }) => {
+    // Navigate to scheduling
+    await page.goto('/scheduling');
+    await page.waitForLoadState('networkidle');
+
+    // Click "Add Shift Template"
+    await page.getByRole('button', { name: /add shift template/i }).click();
+
+    // Fill out the template form without changing capacity
+    const dialog = page.getByRole('dialog', { name: /add shift template/i });
+    await dialog.getByLabel(/template name/i).fill('Morning Cashier');
+    await dialog.getByLabel(/start time/i).fill('06:00');
+    await dialog.getByLabel(/end time/i).fill('14:00');
+    await dialog.getByLabel(/position/i).fill('Cashier');
+    await dialog.getByRole('button', { name: 'Tuesday' }).click();
+
+    // Verify staff needed defaults to 1
+    await expect(dialog.getByLabel(/staff needed/i)).toHaveValue('1');
+
+    // Submit
+    await dialog.getByRole('button', { name: /add template/i }).click();
+
+    // Verify template was created
+    await expect(page.getByText('Morning Cashier')).toBeVisible();
+
+    // No capacity indicator should show (capacity=1 is hidden)
+    await expect(page.getByText(/0\/1/)).not.toBeVisible();
+  });
+});
+```
+
+- [ ] **Step 2: Run the E2E test**
+
+Run: `npx playwright test tests/e2e/shift-template-capacity.spec.ts`
+Expected: PASS (all previous tasks must be implemented first).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/e2e/shift-template-capacity.spec.ts
+git commit -m "test: E2E for shift template capacity and indicators"
+```
+
+---
+
+### Task 7: Update `TemplateRowHeader` to show capacity
+
+**Files:**
+- Modify: `src/components/scheduling/ShiftPlanner/TemplateRowHeader.tsx`
+
+- [ ] **Step 1: Add capacity display to the desktop header**
+
+In `src/components/scheduling/ShiftPlanner/TemplateRowHeader.tsx`, the desktop layout (lines 37-48) shows name, time range, and position. Add a "Need N" label after the position line (after line 47, inside the `hidden md:block` div):
+
+```tsx
+{/* Desktop: full name + time + position */}
+<div className="hidden md:block min-w-0">
+  <div className="text-[14px] font-medium text-foreground truncate">
+    {template.name}
+  </div>
+  <div className="text-[12px] text-muted-foreground">
+    {formatCompactTemplateTime(template.start_time)}-
+    {formatCompactTemplateTime(template.end_time)}
+  </div>
+  <div className="text-[12px] text-muted-foreground">
+    {template.position}
+  </div>
+  {template.capacity > 1 && (
+    <div className="text-[10px] font-medium text-amber-600">
+      Need {template.capacity}
+    </div>
+  )}
+</div>
+```
+
+- [ ] **Step 2: Update the memo comparison to include capacity**
+
+The current memo comparison (lines 83-88) only checks `template.id` and `template.updated_at`. Since `capacity` is part of the template object and `updated_at` changes when capacity is modified, this already works correctly. No change needed.
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `npm run typecheck`
+Expected: No errors (capacity is already on the ShiftTemplate type).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/scheduling/ShiftPlanner/TemplateRowHeader.tsx
+git commit -m "feat: show capacity in template row header"
+```

--- a/docs/superpowers/plans/2026-04-11-open-shift-claiming-pr2-plan.md
+++ b/docs/superpowers/plans/2026-04-11-open-shift-claiming-pr2-plan.md
@@ -95,7 +95,7 @@ Run `npx supabase migration new open_shift_claims` to get the timestamp, then wr
 4. RLS ENABLE + 5 policies (employees view own, managers view all, employees insert own, employees cancel own pending, managers review)
 5. `ALTER TABLE staffing_settings ADD COLUMN open_shifts_enabled BOOLEAN NOT NULL DEFAULT false`
 6. `ALTER TABLE staffing_settings ADD COLUMN require_shift_claim_approval BOOLEAN NOT NULL DEFAULT false`
-7. `CREATE OR REPLACE FUNCTION get_open_shifts(p_restaurant_id UUID, p_week_start DATE, p_week_end DATE)` — SECURITY DEFINER, returns open spots for published weeks only when feature enabled. Use the exact SQL from the design spec.
+7. `CREATE OR REPLACE FUNCTION get_open_shifts(p_restaurant_id UUID, p_week_start DATE, p_week_end DATE)` — SECURITY DEFINER, returns open spots for published weeks only when feature enabled. Use the SQL from the design spec but add `area TEXT` to the return columns (shift_templates now has an optional `area` column). Include `st.area` in the template_days CTE and return it in the final SELECT.
 8. `CREATE OR REPLACE FUNCTION claim_open_shift(p_restaurant_id UUID, p_template_id UUID, p_shift_date DATE, p_employee_id UUID)` — SECURITY DEFINER, atomic claim with capacity check, conflict check, approval mode. Use the exact SQL from the design spec. Note: the `source` column on shifts uses `source_type` in the DB (not `source`). Verify with `npx supabase db dump --local --schema public 2>&1 | grep -A 30 "CREATE TABLE.*public.shifts"` before writing the INSERT.
 9. `CREATE OR REPLACE FUNCTION approve_open_shift_claim(p_claim_id UUID, p_reviewer_note TEXT DEFAULT NULL)` — from spec
 10. `CREATE OR REPLACE FUNCTION reject_open_shift_claim(p_claim_id UUID, p_reviewer_note TEXT DEFAULT NULL)` — from spec
@@ -169,6 +169,7 @@ export interface OpenShift {
   start_time: string;
   end_time: string;
   position: string;
+  area: string | null;
   capacity: number;
   assigned_count: number;
   pending_claims: number;
@@ -414,6 +415,7 @@ const makeOpenShift = (overrides: Partial<OpenShift> = {}): OpenShift => ({
   start_time: '16:00:00',
   end_time: '22:00:00',
   position: 'Server',
+  area: null,
   capacity: 3,
   assigned_count: 1,
   pending_claims: 0,
@@ -615,7 +617,7 @@ interface OpenShiftCardProps {
 }
 ```
 
-Display: Green `OPEN SHIFT` badge, template name, date (formatted), time range, position, spots remaining ("2 spots left"), and a "Claim" button. When `hasConflict`, gray out the card and show "Schedule conflict" instead of the button.
+Display: Green `OPEN SHIFT` badge, template name, date (formatted), time range, position, area (if set), spots remaining ("2 spots left"), and a "Claim" button. When `hasConflict`, gray out the card and show "Schedule conflict" instead of the button.
 
 Follow CLAUDE.md card styling: `rounded-xl border border-border/40 bg-background`. Use `text-[14px]` for names, `text-[13px]` for details, `text-[11px]` for badges.
 

--- a/docs/superpowers/plans/2026-04-11-open-shift-claiming-pr2-plan.md
+++ b/docs/superpowers/plans/2026-04-11-open-shift-claiming-pr2-plan.md
@@ -1,0 +1,787 @@
+# Open Shift Claiming PR2 — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Employees can find and claim open shifts in a unified feed alongside existing shift trades.
+
+**Architecture:** Server-side SQL RPCs handle open shift detection and atomic claiming. A unified React hook merges open shifts with marketplace trades. The existing `EmployeeShiftMarketplace` page is replaced with an `AvailableShiftsPage`. A restaurant-level feature gate controls visibility.
+
+**Tech Stack:** PostgreSQL (RPCs, RLS), TypeScript/React, React Query, Vitest, pgTAP, Playwright
+
+**Design spec:** `docs/superpowers/specs/2026-04-11-open-shift-claiming-pr2-design.md`
+
+**IMPORTANT:** Before writing any Supabase query, verify actual table/column names via `npx supabase db dump --local --schema public 2>&1 | grep -A 20 "CREATE TABLE.*<table_name>"`. Never trust plan text for column names.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `supabase/migrations/YYYYMMDD_open_shift_claims.sql` | Table, settings columns, RLS, RPCs |
+| `supabase/tests/open_shift_claims.test.sql` | pgTAP tests for RPCs |
+| `src/types/scheduling.ts` | Add `OpenShiftClaim` type, update `Shift.source`, update `StaffingSettings` |
+| `src/hooks/useOpenShifts.ts` | Fetch open shifts via RPC |
+| `src/hooks/useOpenShiftClaims.ts` | Claim mutations, fetch employee claims |
+| `src/hooks/useAvailableShifts.ts` | Merge open shifts + trades into unified feed |
+| `src/hooks/useStaffingSettings.ts` | Update to include new boolean columns |
+| `src/pages/AvailableShiftsPage.tsx` | Unified employee feed (replaces EmployeeShiftMarketplace) |
+| `src/components/scheduling/OpenShiftCard.tsx` | Open shift card component |
+| `src/components/scheduling/ClaimConfirmDialog.tsx` | Claim confirmation dialog |
+| `src/components/scheduling/ShiftPlanner/StaffingConfigPanel.tsx` | Add feature toggles |
+| `src/components/PublishScheduleDialog.tsx` | Update nudge text when feature disabled |
+| `src/components/schedule/TradeApprovalQueue.tsx` | Add claim approvals |
+| `tests/unit/availableShifts.test.ts` | Unit tests for merge hook |
+| `tests/e2e/open-shift-claiming.spec.ts` | E2E tests |
+
+---
+
+### Task 1: Database migration — table, settings, RLS, RPCs
+
+**Files:**
+- Create: `supabase/migrations/YYYYMMDD_open_shift_claims.sql`
+- Create: `supabase/tests/open_shift_claims.test.sql`
+
+- [ ] **Step 1: Write pgTAP tests**
+
+Create `supabase/tests/open_shift_claims.test.sql`:
+
+```sql
+BEGIN;
+SELECT plan(12);
+
+-- Test 1: open_shift_claims table exists
+SELECT has_table('open_shift_claims', 'open_shift_claims table should exist');
+
+-- Test 2: Required columns exist
+SELECT has_column('open_shift_claims', 'shift_template_id', 'should have shift_template_id');
+SELECT has_column('open_shift_claims', 'shift_date', 'should have shift_date');
+SELECT has_column('open_shift_claims', 'claimed_by_employee_id', 'should have claimed_by_employee_id');
+SELECT has_column('open_shift_claims', 'status', 'should have status');
+SELECT has_column('open_shift_claims', 'resulting_shift_id', 'should have resulting_shift_id');
+
+-- Test 3: Settings columns exist on staffing_settings
+SELECT has_column('staffing_settings', 'open_shifts_enabled', 'staffing_settings should have open_shifts_enabled');
+SELECT has_column('staffing_settings', 'require_shift_claim_approval', 'staffing_settings should have require_shift_claim_approval');
+
+-- Test 4: Default values
+SELECT col_default_is('staffing_settings', 'open_shifts_enabled', 'false',
+  'open_shifts_enabled should default to false');
+SELECT col_default_is('staffing_settings', 'require_shift_claim_approval', 'false',
+  'require_shift_claim_approval should default to false');
+
+-- Test 5: RPC functions exist
+SELECT has_function('get_open_shifts', ARRAY['uuid', 'date', 'date'],
+  'get_open_shifts function should exist');
+SELECT has_function('claim_open_shift', ARRAY['uuid', 'uuid', 'date', 'uuid'],
+  'claim_open_shift function should exist');
+
+SELECT * FROM finish();
+ROLLBACK;
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run test:db`
+Expected: FAIL — table and functions don't exist.
+
+- [ ] **Step 3: Create the migration**
+
+Run `npx supabase migration new open_shift_claims` to get the timestamp, then write the migration file. The migration must contain:
+
+1. `CREATE TABLE open_shift_claims` with all columns from the spec (id, restaurant_id, shift_template_id, shift_date, claimed_by_employee_id, status with CHECK constraint, resulting_shift_id, reviewed_by, reviewed_at, created_at, updated_at)
+2. Unique partial index on (shift_template_id, shift_date, claimed_by_employee_id) WHERE status IN ('pending_approval', 'approved')
+3. Query indexes on restaurant_id, claimed_by_employee_id, and (restaurant_id, status)
+4. RLS ENABLE + 5 policies (employees view own, managers view all, employees insert own, employees cancel own pending, managers review)
+5. `ALTER TABLE staffing_settings ADD COLUMN open_shifts_enabled BOOLEAN NOT NULL DEFAULT false`
+6. `ALTER TABLE staffing_settings ADD COLUMN require_shift_claim_approval BOOLEAN NOT NULL DEFAULT false`
+7. `CREATE OR REPLACE FUNCTION get_open_shifts(p_restaurant_id UUID, p_week_start DATE, p_week_end DATE)` — SECURITY DEFINER, returns open spots for published weeks only when feature enabled. Use the exact SQL from the design spec.
+8. `CREATE OR REPLACE FUNCTION claim_open_shift(p_restaurant_id UUID, p_template_id UUID, p_shift_date DATE, p_employee_id UUID)` — SECURITY DEFINER, atomic claim with capacity check, conflict check, approval mode. Use the exact SQL from the design spec. Note: the `source` column on shifts uses `source_type` in the DB (not `source`). Verify with `npx supabase db dump --local --schema public 2>&1 | grep -A 30 "CREATE TABLE.*public.shifts"` before writing the INSERT.
+9. `CREATE OR REPLACE FUNCTION approve_open_shift_claim(p_claim_id UUID, p_reviewer_note TEXT DEFAULT NULL)` — from spec
+10. `CREATE OR REPLACE FUNCTION reject_open_shift_claim(p_claim_id UUID, p_reviewer_note TEXT DEFAULT NULL)` — from spec
+11. `GRANT EXECUTE ON FUNCTION` for all 4 functions to `authenticated`
+12. Updated_at trigger on open_shift_claims
+
+For RLS policies, use the `user_restaurants` table pattern (not `restaurant_members` — verify the actual table name). The existing pattern is:
+```sql
+EXISTS (
+  SELECT 1 FROM user_restaurants
+  WHERE user_restaurants.user_id = auth.uid()
+  AND user_restaurants.restaurant_id = open_shift_claims.restaurant_id
+  AND user_restaurants.role IN ('owner', 'manager')
+)
+```
+
+For employee self-identification, use:
+```sql
+claimed_by_employee_id IN (
+  SELECT id FROM employees WHERE user_id = auth.uid()
+)
+```
+
+- [ ] **Step 4: Reset database and run tests**
+
+Run: `npx supabase db reset && npm run test:db`
+Expected: All pgTAP tests pass.
+
+- [ ] **Step 5: Regenerate TypeScript types**
+
+Run: `npx supabase gen types typescript --local 2>/dev/null > src/integrations/supabase/types.ts`
+Verify line 1 starts with `export type` (not a log message).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add supabase/migrations/*_open_shift_claims.sql supabase/tests/open_shift_claims.test.sql src/integrations/supabase/types.ts
+git commit -m "feat: add open_shift_claims table, settings, and RPCs"
+```
+
+---
+
+### Task 2: TypeScript types
+
+**Files:**
+- Modify: `src/types/scheduling.ts`
+
+- [ ] **Step 1: Add OpenShiftClaim interface**
+
+After the `ShiftTrade` interface (or at end of file), add:
+
+```typescript
+export interface OpenShiftClaim {
+  id: string;
+  restaurant_id: string;
+  shift_template_id: string;
+  shift_date: string;
+  claimed_by_employee_id: string;
+  status: 'pending_approval' | 'approved' | 'rejected' | 'cancelled';
+  resulting_shift_id: string | null;
+  reviewed_by: string | null;
+  reviewed_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface OpenShift {
+  template_id: string;
+  template_name: string;
+  shift_date: string;
+  start_time: string;
+  end_time: string;
+  position: string;
+  capacity: number;
+  assigned_count: number;
+  pending_claims: number;
+  open_spots: number;
+}
+```
+
+- [ ] **Step 2: Update Shift.source union**
+
+Change line 106 from:
+```typescript
+source: 'manual' | 'ai' | 'template';
+```
+to:
+```typescript
+source: 'manual' | 'ai' | 'template' | 'claimed';
+```
+
+- [ ] **Step 3: Update StaffingSettings interface**
+
+Add to the `StaffingSettings` interface (after `min_crew`):
+```typescript
+open_shifts_enabled: boolean;
+require_shift_claim_approval: boolean;
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/types/scheduling.ts
+git commit -m "feat: add OpenShiftClaim and OpenShift types"
+```
+
+---
+
+### Task 3: Hooks — useOpenShifts and useOpenShiftClaims
+
+**Files:**
+- Create: `src/hooks/useOpenShifts.ts`
+- Create: `src/hooks/useOpenShiftClaims.ts`
+- Modify: `src/hooks/useStaffingSettings.ts`
+
+- [ ] **Step 1: Create useOpenShifts hook**
+
+Create `src/hooks/useOpenShifts.ts`:
+
+```typescript
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import type { OpenShift } from '@/types/scheduling';
+
+export function useOpenShifts(restaurantId: string | null, weekStart: Date | null, weekEnd: Date | null) {
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: ['open_shifts', restaurantId, weekStart?.toISOString(), weekEnd?.toISOString()],
+    queryFn: async () => {
+      if (!restaurantId || !weekStart || !weekEnd) return [];
+
+      const startStr = weekStart.toISOString().split('T')[0];
+      const endStr = weekEnd.toISOString().split('T')[0];
+
+      const { data, error } = await (supabase.rpc as any)('get_open_shifts', {
+        p_restaurant_id: restaurantId,
+        p_week_start: startStr,
+        p_week_end: endStr,
+      });
+
+      if (error) throw error;
+      return (data ?? []) as OpenShift[];
+    },
+    enabled: !!restaurantId && !!weekStart && !!weekEnd,
+    staleTime: 30000,
+    refetchOnWindowFocus: true,
+  });
+
+  return { openShifts: data ?? [], loading: isLoading, error, refetch };
+}
+```
+
+- [ ] **Step 2: Create useOpenShiftClaims hook**
+
+Create `src/hooks/useOpenShiftClaims.ts`:
+
+```typescript
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { useToast } from '@/hooks/use-toast';
+import type { OpenShiftClaim } from '@/types/scheduling';
+
+export function useOpenShiftClaims(restaurantId: string | null, employeeId?: string | null) {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['open_shift_claims', restaurantId, employeeId],
+    queryFn: async () => {
+      if (!restaurantId) return [];
+      let query = (supabase.from('open_shift_claims') as any)
+        .select('*, shift_template:shift_templates(name, start_time, end_time, position)')
+        .eq('restaurant_id', restaurantId)
+        .order('created_at', { ascending: false });
+
+      if (employeeId) {
+        query = query.eq('claimed_by_employee_id', employeeId);
+      }
+
+      const { data, error } = await query;
+      if (error) throw error;
+      return data as (OpenShiftClaim & { shift_template?: { name: string; start_time: string; end_time: string; position: string } })[];
+    },
+    enabled: !!restaurantId,
+    staleTime: 30000,
+    refetchOnWindowFocus: true,
+  });
+
+  return { claims: data ?? [], loading: isLoading, error };
+}
+
+export function useClaimOpenShift() {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async (params: {
+      restaurantId: string;
+      templateId: string;
+      shiftDate: string;
+      employeeId: string;
+    }) => {
+      const { data, error } = await (supabase.rpc as any)('claim_open_shift', {
+        p_restaurant_id: params.restaurantId,
+        p_template_id: params.templateId,
+        p_shift_date: params.shiftDate,
+        p_employee_id: params.employeeId,
+      });
+
+      if (error) throw error;
+      const result = data as { success: boolean; error?: string; status?: string; message?: string };
+      if (!result.success) throw new Error(result.error ?? 'Failed to claim shift');
+      return result;
+    },
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ['open_shifts'] });
+      queryClient.invalidateQueries({ queryKey: ['open_shift_claims'] });
+      queryClient.invalidateQueries({ queryKey: ['shifts'] });
+      toast({
+        title: result.status === 'pending_approval' ? 'Claim submitted' : 'Shift claimed!',
+        description: result.message,
+      });
+    },
+    onError: (error: Error) => {
+      toast({ title: 'Cannot claim shift', description: error.message, variant: 'destructive' });
+    },
+  });
+}
+
+export function useApproveClaimMutation() {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async (params: { claimId: string; note?: string }) => {
+      const { data, error } = await (supabase.rpc as any)('approve_open_shift_claim', {
+        p_claim_id: params.claimId,
+        p_reviewer_note: params.note ?? null,
+      });
+      if (error) throw error;
+      const result = data as { success: boolean; error?: string };
+      if (!result.success) throw new Error(result.error ?? 'Failed to approve claim');
+      return result;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['open_shift_claims'] });
+      queryClient.invalidateQueries({ queryKey: ['open_shifts'] });
+      queryClient.invalidateQueries({ queryKey: ['shifts'] });
+      toast({ title: 'Claim approved' });
+    },
+    onError: (error: Error) => {
+      toast({ title: 'Error', description: error.message, variant: 'destructive' });
+    },
+  });
+}
+
+export function useRejectClaimMutation() {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async (params: { claimId: string; note?: string }) => {
+      const { data, error } = await (supabase.rpc as any)('reject_open_shift_claim', {
+        p_claim_id: params.claimId,
+        p_reviewer_note: params.note ?? null,
+      });
+      if (error) throw error;
+      const result = data as { success: boolean; error?: string };
+      if (!result.success) throw new Error(result.error ?? 'Failed to reject claim');
+      return result;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['open_shift_claims'] });
+      queryClient.invalidateQueries({ queryKey: ['open_shifts'] });
+      toast({ title: 'Claim rejected' });
+    },
+    onError: (error: Error) => {
+      toast({ title: 'Error', description: error.message, variant: 'destructive' });
+    },
+  });
+}
+```
+
+- [ ] **Step 3: Update useStaffingSettings defaults**
+
+In `src/hooks/useStaffingSettings.ts`, add to the DEFAULTS object (around line 9):
+```typescript
+open_shifts_enabled: false,
+require_shift_claim_approval: false,
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/hooks/useOpenShifts.ts src/hooks/useOpenShiftClaims.ts src/hooks/useStaffingSettings.ts
+git commit -m "feat: add hooks for open shifts and claims"
+```
+
+---
+
+### Task 4: useAvailableShifts — merge open shifts + trades
+
+**Files:**
+- Create: `src/hooks/useAvailableShifts.ts`
+- Create: `tests/unit/availableShifts.test.ts`
+
+- [ ] **Step 1: Write failing unit test**
+
+Create `tests/unit/availableShifts.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { mergeAvailableShifts, AvailableShiftItem } from '@/hooks/useAvailableShifts';
+import type { OpenShift } from '@/types/scheduling';
+
+const makeOpenShift = (overrides: Partial<OpenShift> = {}): OpenShift => ({
+  template_id: 'tpl-1',
+  template_name: 'Closing Server',
+  shift_date: '2026-04-18',
+  start_time: '16:00:00',
+  end_time: '22:00:00',
+  position: 'Server',
+  capacity: 3,
+  assigned_count: 1,
+  pending_claims: 0,
+  open_spots: 2,
+  ...overrides,
+});
+
+const makeTrade = (overrides: Record<string, unknown> = {}) => ({
+  id: 'trade-1',
+  status: 'open' as const,
+  offered_shift: { id: 's1', start_time: '2026-04-18T14:00:00Z', end_time: '2026-04-18T20:00:00Z', position: 'Server', break_duration: 0 },
+  offered_by: { id: 'emp-1', name: 'Maria', email: null, position: 'Server' },
+  ...overrides,
+});
+
+describe('mergeAvailableShifts', () => {
+  it('returns empty array when no shifts or trades', () => {
+    expect(mergeAvailableShifts([], [])).toEqual([]);
+  });
+
+  it('includes open shifts with type "open_shift"', () => {
+    const result = mergeAvailableShifts([makeOpenShift()], []);
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('open_shift');
+    expect(result[0].openShift?.template_name).toBe('Closing Server');
+  });
+
+  it('includes trades with type "trade"', () => {
+    const result = mergeAvailableShifts([], [makeTrade()]);
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('trade');
+  });
+
+  it('sorts by date ascending', () => {
+    const result = mergeAvailableShifts(
+      [makeOpenShift({ shift_date: '2026-04-20' })],
+      [makeTrade({ offered_shift: { id: 's1', start_time: '2026-04-18T14:00:00Z', end_time: '2026-04-18T20:00:00Z', position: 'Server', break_duration: 0 } })],
+    );
+    expect(result[0].type).toBe('trade');
+    expect(result[1].type).toBe('open_shift');
+  });
+
+  it('generates unique keys', () => {
+    const result = mergeAvailableShifts(
+      [makeOpenShift(), makeOpenShift({ template_id: 'tpl-2', template_name: 'Opener' })],
+      [makeTrade()],
+    );
+    const keys = result.map(r => r.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/availableShifts.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement mergeAvailableShifts**
+
+Create `src/hooks/useAvailableShifts.ts`:
+
+```typescript
+import { useMemo } from 'react';
+import type { OpenShift } from '@/types/scheduling';
+import type { ShiftTrade } from '@/hooks/useShiftTrades';
+import { useOpenShifts } from '@/hooks/useOpenShifts';
+import { useMarketplaceTrades } from '@/hooks/useShiftTrades';
+
+export interface AvailableShiftItem {
+  key: string;
+  type: 'open_shift' | 'trade';
+  date: string; // YYYY-MM-DD for sorting
+  openShift?: OpenShift;
+  trade?: ShiftTrade & { hasConflict?: boolean };
+}
+
+export function mergeAvailableShifts(
+  openShifts: OpenShift[],
+  trades: (ShiftTrade & { hasConflict?: boolean })[],
+): AvailableShiftItem[] {
+  const items: AvailableShiftItem[] = [];
+
+  for (const os of openShifts) {
+    items.push({
+      key: `open-${os.template_id}-${os.shift_date}`,
+      type: 'open_shift',
+      date: os.shift_date,
+      openShift: os,
+    });
+  }
+
+  for (const trade of trades) {
+    const tradeDate = trade.offered_shift?.start_time?.split('T')[0] ?? '';
+    items.push({
+      key: `trade-${trade.id}`,
+      type: 'trade',
+      date: tradeDate,
+      trade,
+    });
+  }
+
+  items.sort((a, b) => a.date.localeCompare(b.date));
+  return items;
+}
+
+export function useAvailableShifts(
+  restaurantId: string | null,
+  employeeId: string | null,
+  weekStart: Date | null,
+  weekEnd: Date | null,
+) {
+  const { openShifts, loading: openLoading } = useOpenShifts(restaurantId, weekStart, weekEnd);
+  const { trades, loading: tradesLoading } = useMarketplaceTrades(restaurantId, employeeId);
+
+  const items = useMemo(
+    () => mergeAvailableShifts(openShifts, trades),
+    [openShifts, trades],
+  );
+
+  return {
+    items,
+    loading: openLoading || tradesLoading,
+    openShiftCount: openShifts.length,
+    tradeCount: trades.length,
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/availableShifts.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useAvailableShifts.ts tests/unit/availableShifts.test.ts
+git commit -m "feat: add useAvailableShifts hook merging open shifts and trades"
+```
+
+---
+
+### Task 5: Settings UI — feature toggles in StaffingConfigPanel
+
+**Files:**
+- Modify: `src/components/scheduling/ShiftPlanner/StaffingConfigPanel.tsx`
+
+- [ ] **Step 1: Add the Open Shift Claiming section**
+
+After the existing Minimum Crew section (around line 259), add a new section with:
+
+1. A section header: "Open Shift Claiming"
+2. A Switch toggle for `open_shifts_enabled` with label "Allow employees to claim open shifts"
+3. Helper text: "When enabled, employees can see and claim unfilled shifts after you publish the schedule."
+4. When `open_shifts_enabled` is true, show a sub-toggle for `require_shift_claim_approval` with label "Require manager approval"
+5. Helper text: "When off, employees are instantly assigned. When on, claims go to your approval queue."
+6. First-enable note (show once when toggling on): "You control which shifts are open through template capacity settings."
+
+Use the existing `onSettingsChange` callback for both toggles. Import `Switch` from `@/components/ui/switch`.
+
+Follow the existing styling patterns in the panel: `text-[12px] font-medium text-muted-foreground uppercase tracking-wider` for labels, `text-[13px] text-muted-foreground` for helper text.
+
+- [ ] **Step 2: Update StaffingConfigPanel props**
+
+The `settings` prop type needs to include the new fields. Update the interface to include `open_shifts_enabled: boolean` and `require_shift_claim_approval: boolean`.
+
+- [ ] **Step 3: Verify typecheck passes**
+
+Run: `npm run typecheck`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/scheduling/ShiftPlanner/StaffingConfigPanel.tsx
+git commit -m "feat: add open shift claiming toggles to staffing settings"
+```
+
+---
+
+### Task 6: AvailableShiftsPage — unified employee feed
+
+**Files:**
+- Create: `src/pages/AvailableShiftsPage.tsx`
+- Create: `src/components/scheduling/OpenShiftCard.tsx`
+- Create: `src/components/scheduling/ClaimConfirmDialog.tsx`
+- Modify: `src/App.tsx` (route update)
+
+- [ ] **Step 1: Create OpenShiftCard component**
+
+Create `src/components/scheduling/OpenShiftCard.tsx` — a memoized card for an open shift. Props:
+
+```typescript
+interface OpenShiftCardProps {
+  openShift: OpenShift;
+  hasConflict: boolean;
+  onClaim: (openShift: OpenShift) => void;
+  isClaiming: boolean;
+}
+```
+
+Display: Green `OPEN SHIFT` badge, template name, date (formatted), time range, position, spots remaining ("2 spots left"), and a "Claim" button. When `hasConflict`, gray out the card and show "Schedule conflict" instead of the button.
+
+Follow CLAUDE.md card styling: `rounded-xl border border-border/40 bg-background`. Use `text-[14px]` for names, `text-[13px]` for details, `text-[11px]` for badges.
+
+- [ ] **Step 2: Create ClaimConfirmDialog**
+
+Create `src/components/scheduling/ClaimConfirmDialog.tsx`:
+
+```typescript
+interface ClaimConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  openShift: OpenShift | null;
+  onConfirm: () => void;
+  isPending: boolean;
+}
+```
+
+A simple confirmation dialog: "Claim [Template Name] on [Date], [Time]?" with Cancel and Confirm buttons. Follow CLAUDE.md dialog structure with icon box header.
+
+- [ ] **Step 3: Create AvailableShiftsPage**
+
+Create `src/pages/AvailableShiftsPage.tsx` — replaces EmployeeShiftMarketplace. Structure:
+
+1. Use `useRestaurantContext()` and `useCurrentEmployee()` for context
+2. Compute current and next week dates
+3. Call `useAvailableShifts(restaurantId, employeeId, weekStart, weekEnd)`
+4. Call `useOpenShiftClaims(restaurantId, employeeId)` for "My Claims" section
+5. Call `useClaimOpenShift()` for the claim mutation
+6. Check employee's existing shifts for conflict detection (reuse pattern from `useMarketplaceTrades`)
+7. Render a virtualized list of `AvailableShiftItem` cards (per CLAUDE.md performance rules):
+   - `type === 'open_shift'` → render `OpenShiftCard`
+   - `type === 'trade'` → render existing trade card UI (port from EmployeeShiftMarketplace)
+8. Handle loading, error, and empty states
+9. "My Claims" collapsible section at the bottom showing pending/approved/rejected claims
+10. `ClaimConfirmDialog` rendered at page level (single dialog pattern)
+
+Page header: "Available Shifts" with count badge showing total items.
+
+- [ ] **Step 4: Update route in App.tsx**
+
+In `src/App.tsx`, find the route for `/employee/shifts` (currently pointing to `EmployeeShiftMarketplace`) and change it to `AvailableShiftsPage`:
+
+```typescript
+import { AvailableShiftsPage } from '@/pages/AvailableShiftsPage';
+// ...
+<Route path="/employee/shifts" element={<AvailableShiftsPage />} />
+```
+
+Keep `EmployeeShiftMarketplace.tsx` file intact (don't delete) — it can be removed in a future cleanup.
+
+- [ ] **Step 5: Verify typecheck passes**
+
+Run: `npm run typecheck`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pages/AvailableShiftsPage.tsx src/components/scheduling/OpenShiftCard.tsx src/components/scheduling/ClaimConfirmDialog.tsx src/App.tsx
+git commit -m "feat: add unified available shifts page with open shift cards"
+```
+
+---
+
+### Task 7: Publish dialog nudge and TradeApprovalQueue integration
+
+**Files:**
+- Modify: `src/components/PublishScheduleDialog.tsx`
+- Modify: `src/components/schedule/TradeApprovalQueue.tsx`
+
+- [ ] **Step 1: Update publish dialog nudge**
+
+In `PublishScheduleDialog.tsx`, the open shifts alert (added in PR1) currently shows "You can fill these now or broadcast to your team later." Update to be conditional on `open_shifts_enabled`:
+
+Add `openShiftsEnabled: boolean` prop. When `openShiftsEnabled` is false and `openShiftCount > 0`:
+```
+N shifts still need staff. Want employees to fill these? Enable open shift claiming →
+```
+The link text should call a callback `onEnableOpenShifts?: () => void` that navigates to staffing settings.
+
+When `openShiftsEnabled` is true:
+```
+N shifts still need staff. You can fill these now or broadcast to your team later.
+```
+
+- [ ] **Step 2: Add claim approvals to TradeApprovalQueue**
+
+In `TradeApprovalQueue.tsx`, add a third section for pending open shift claims:
+
+1. Import `useOpenShiftClaims`, `useApproveClaimMutation`, `useRejectClaimMutation`
+2. Fetch claims with status `pending_approval` for the restaurant
+3. Render claim cards with a distinct "CLAIM" badge (green) vs "TRADE" badge (amber)
+4. Each claim card shows: employee name, template name, date, time, position
+5. Approve/Reject buttons following the existing trade approval pattern
+6. Use the existing manager note dialog pattern for approve/reject actions
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/PublishScheduleDialog.tsx src/components/schedule/TradeApprovalQueue.tsx
+git commit -m "feat: add claim approvals to trade queue and publish dialog nudge"
+```
+
+---
+
+### Task 8: E2E test — employee claims an open shift
+
+**Files:**
+- Create: `tests/e2e/open-shift-claiming.spec.ts`
+
+- [ ] **Step 1: Write the E2E test**
+
+Create `tests/e2e/open-shift-claiming.spec.ts`:
+
+Test flow:
+1. Sign up as manager, create restaurant
+2. Enable open shift claiming in staffing settings (via Supabase helper — insert into staffing_settings with open_shifts_enabled=true)
+3. Create a shift template with capacity=3 via Supabase insert
+4. Publish the schedule (insert into schedule_publications)
+5. Create a staff employee via Supabase insert
+6. Navigate to `/employee/shifts` as the staff user (or use the same user if roles allow)
+7. Verify open shift card is visible with template name
+8. Click "Claim" button
+9. Confirm in the dialog
+10. Verify success toast appears
+11. Verify the shift appears on the employee's schedule
+
+Keep assertions timezone-agnostic per the lessons learned. Use `getByRole` and `getByText` with accessible selectors.
+
+- [ ] **Step 2: Run the E2E test**
+
+Run: `npx playwright test tests/e2e/open-shift-claiming.spec.ts`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/e2e/open-shift-claiming.spec.ts
+git commit -m "test: E2E for open shift claiming flow"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- `open_shift_claims` table: Task 1 ✓
+- Settings columns: Task 1 ✓
+- RLS policies: Task 1 ✓
+- `get_open_shifts` RPC: Task 1 ✓
+- `claim_open_shift` RPC: Task 1 ✓
+- `approve/reject` RPCs: Task 1 ✓
+- TypeScript types: Task 2 ✓
+- Hooks (useOpenShifts, useClaimOpenShift, useOpenShiftClaims): Task 3 ✓
+- useAvailableShifts merge: Task 4 ✓
+- Settings UI toggles: Task 5 ✓
+- Unified employee feed: Task 6 ✓
+- OpenShiftCard: Task 6 ✓
+- ClaimConfirmDialog: Task 6 ✓
+- My Claims section: Task 6 ✓
+- Publish dialog nudge: Task 7 ✓
+- Claim approvals in queue: Task 7 ✓
+- Conflict detection: Task 6 (inline check against employee shifts) ✓
+- Feature gate (open_shifts_enabled): Tasks 1, 3, 5, 7 ✓
+- E2E tests: Task 8 ✓
+- pgTAP tests: Task 1 ✓
+- Unit tests: Task 4 ✓
+
+**Type consistency:** `OpenShift` and `OpenShiftClaim` types defined in Task 2, used consistently across Tasks 3-8. `mergeAvailableShifts` function name consistent between Task 4 test and implementation.
+
+**No placeholders found.**

--- a/docs/superpowers/specs/2026-04-11-open-shift-claiming-design.md
+++ b/docs/superpowers/specs/2026-04-11-open-shift-claiming-design.md
@@ -1,0 +1,207 @@
+# Open Shift Claiming — Design Spec
+
+**Date:** 2026-04-11
+**Status:** Draft
+
+## Problem
+
+Managers set staffing needs (e.g., "need 3 closers") but currently must manually assign every employee. When a manager assigns 1 of 3 needed closers and wants the other 2 spots filled voluntarily, there's no mechanism for employees to see and claim those open spots. Managers resort to texting employees individually.
+
+## Solution
+
+Capacity-based open shift detection with employee self-service claiming. Managers define how many people they need per template. Unfilled spots surface automatically in a unified employee feed alongside existing shift trades. Employees claim spots directly (instant by default, configurable to require approval). Managers can optionally broadcast openings to eligible team members.
+
+## Delivery Plan
+
+Three value-based PRs, each independently useful:
+
+| PR | User Value | Scope |
+|----|-----------|-------|
+| PR1: Managers can see open shifts | Managers see at a glance where they're short-staffed | Capacity on templates, gap detection, planner indicators |
+| PR2: Employees can claim open shifts | Employees pick up extra hours on their own | Unified feed, claim flow, approval config |
+| PR3: Managers can broadcast openings | Managers actively recruit for gaps instead of texting | Broadcast action with preview, notifications |
+
+## Architecture
+
+### Database Changes
+
+#### 1. Add `capacity` to `shift_templates`
+
+```sql
+ALTER TABLE shift_templates ADD COLUMN capacity INTEGER NOT NULL DEFAULT 1;
+ALTER TABLE shift_templates ADD CONSTRAINT valid_capacity CHECK (capacity >= 1);
+```
+
+The `capacity` column represents how many employees are needed for this template slot. Current behavior (1 employee per template) is preserved by the default of 1.
+
+#### 2. New table: `open_shift_claims`
+
+Separate from `shift_trades` because the semantics differ: trades are employee-initiated swaps of existing assigned shifts; claims are employee requests for unassigned capacity.
+
+```sql
+CREATE TABLE open_shift_claims (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  restaurant_id UUID NOT NULL REFERENCES restaurants(id) ON DELETE CASCADE,
+  shift_template_id UUID NOT NULL REFERENCES shift_templates(id) ON DELETE CASCADE,
+  shift_date DATE NOT NULL,
+  claimed_by_employee_id UUID NOT NULL REFERENCES employees(id) ON DELETE CASCADE,
+  status TEXT NOT NULL DEFAULT 'approved'
+    CHECK (status IN ('pending_approval', 'approved', 'rejected', 'cancelled')),
+  resulting_shift_id UUID REFERENCES shifts(id) ON DELETE SET NULL,
+  reviewed_by UUID REFERENCES auth.users(id),
+  reviewed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+```
+
+Key points:
+- `shift_template_id` + `shift_date` identifies which open slot is being claimed
+- `status` defaults to `'approved'` (instant claim mode). When approval is required, the insert sets `'pending_approval'` instead
+- `resulting_shift_id` links to the actual shift created when the claim is approved — the claim creates a real `shifts` row assigned to the employee
+- Unique constraint prevents double-claiming: `UNIQUE(shift_template_id, shift_date, claimed_by_employee_id)`
+
+#### 3. Add `require_shift_claim_approval` to `staffing_settings`
+
+```sql
+ALTER TABLE staffing_settings
+  ADD COLUMN require_shift_claim_approval BOOLEAN NOT NULL DEFAULT false;
+```
+
+Per-restaurant setting. Default `false` = instant claim (manager already expressed the need). Follows the existing pattern of domain-specific settings tables.
+
+#### 4. Add `broadcast_sent_at` tracking
+
+```sql
+-- Track which weeks have been broadcasted to avoid duplicate notifications
+ALTER TABLE schedule_publications
+  ADD COLUMN open_shifts_broadcast_at TIMESTAMPTZ,
+  ADD COLUMN open_shifts_broadcast_by UUID REFERENCES auth.users(id);
+```
+
+### Open Shift Detection (computed, not stored)
+
+Open shifts are **not stored in a table** — they're computed at query time by comparing template capacity against assigned shifts:
+
+```
+open_spots(template, date) = template.capacity - count(shifts matching template on date)
+```
+
+A shift "matches" a template when:
+- Same `restaurant_id`
+- Same `position`
+- Overlapping time range (start_time/end_time)
+- Date falls on one of the template's `days`
+- Shift is not cancelled
+
+This is computed in a SQL function `get_open_shifts(p_restaurant_id, p_week_start, p_week_end)` that returns template + date + open_spots for all templates with unfilled capacity in the date range. Pending claims (status = `'pending_approval'`) count against open spots to prevent over-claiming.
+
+### Data Flow
+
+#### Manager side (PR1)
+
+```
+shift_templates.capacity → get_open_shifts() RPC → ShiftPlannerTab
+                                                    ├── capacity badge on template headers
+                                                    ├── "2/3 assigned" indicators per day cell
+                                                    └── publish dialog shows open shift count
+```
+
+#### Employee side (PR2)
+
+```
+get_open_shifts() + useMarketplaceTrades() → useAvailableShifts() → AvailableShiftsPage
+                                                                      ├── OPEN SHIFT cards (from open shifts)
+                                                                      ├── TRADE cards (from marketplace trades)
+                                                                      └── Claim button → claim_open_shift() RPC
+```
+
+#### Broadcast side (PR3)
+
+```
+Manager clicks "Broadcast" → BroadcastOpenShiftsDialog
+                              ├── preview: which shifts, how many spots
+                              ├── preview: eligible employees (position match, no conflicts)
+                              └── confirm → broadcast-open-shifts edge function
+                                            ├── sends push notification via send-push-notification
+                                            ├── sends email via Resend
+                                            └── stamps schedule_publications.open_shifts_broadcast_at
+```
+
+### Claim Flow Detail
+
+```
+Employee taps "Claim Shift"
+  → claim_open_shift(p_template_id, p_date, p_employee_id) RPC
+    ├── verify open spots remain (capacity - assigned - pending_claims > 0)
+    ├── verify no schedule conflict for employee
+    ├── verify employee position matches template (if position-restricted)
+    ├── check restaurant's require_shift_claim_approval setting
+    │   ├── false → status='approved', create shift row, assign employee
+    │   └── true  → status='pending_approval', no shift created yet
+    └── return claim record
+```
+
+Manager approval (when required):
+```
+Manager approves claim
+  → approve_open_shift_claim(p_claim_id) RPC
+    ├── create shift row from template + date, assign employee
+    ├── update claim: status='approved', resulting_shift_id, reviewed_by/at
+    └── notify employee
+```
+
+### UI Components
+
+#### PR1: Manager Planner Enhancements
+
+- **Template capacity editor** — In the existing template create/edit dialog, add a "Staff needed" number input (default 1). Maps to `shift_templates.capacity`.
+- **Planner cell indicators** — Each day cell for a template shows `assigned/capacity` (e.g., "1/3"). Color-coded: green when full, amber when partially filled, red when empty.
+- **Publish dialog enhancement** — Existing `PublishScheduleDialog` gets a line: "N shifts still need staff. You can fill these now or broadcast to your team later."
+
+#### PR2: Employee Available Shifts Feed
+
+- **Unified `AvailableShiftsPage`** — Replaces current `EmployeeShiftMarketplace`. Same route (`/employee/shifts`). Shows both open shifts and trades in a single virtualized list.
+- **Open shift card** — Green `OPEN SHIFT` badge, template name, date, time, position, spots remaining, "Claim" button. Grayed out with "Conflict" badge if employee has an overlapping shift.
+- **Trade card** — Amber `TRADE` badge (existing design, brought into unified feed).
+- **Claim confirmation** — Brief bottom sheet: "Claim Closing Server on Fri Apr 18, 4p–10p?" with Confirm/Cancel.
+- **Approval setting hint** — In restaurant staffing settings, a toggle "Require manager approval for shift claims" with helper text: "When off, employees are instantly assigned. When on, claims go to your approval queue."
+
+#### PR3: Broadcast & Notifications
+
+- **BroadcastOpenShiftsDialog** — Shows list of open shifts for the published week, count of eligible employees per shift, "Broadcast to N Team Members" button.
+- **Notification** — Push notification (via existing `send-push-notification` function) + email (via Resend). Message: "N shifts are available for the week of [date]. Open the app to claim a spot."
+- **Claim tracking** — Manager sees claimed/pending indicators on planner cells. Approval queue tab gets open shift claims alongside trade approvals.
+
+### RLS Policies
+
+#### open_shift_claims
+- **SELECT:** Employees can see their own claims. Owners/managers can see all claims for their restaurant.
+- **INSERT:** Employees can create claims for their own restaurant (enforced: `claimed_by_employee_id` matches authenticated employee).
+- **UPDATE:** Only owners/managers can update status (approve/reject). Employees can cancel their own pending claims.
+- **DELETE:** None (use status changes).
+
+**Lesson applied:** Staff users need SELECT on `employees` table to see coworker names in the feed. An RLS policy for this already exists from the shift marketplace null-safety fix (2026-04-11 lesson).
+
+### Conflict Detection
+
+Reuses the existing `useConflictDetection` hook pattern:
+- Before showing "Claim" button, check if employee has any shift overlapping the open shift's time range on that date
+- If conflict exists, show the card grayed out with a "Schedule conflict" note
+- The `claim_open_shift` RPC double-checks server-side (client check is for UX, server check is authoritative)
+
+### Edge Cases
+
+1. **Race condition: two employees claim the last spot simultaneously** — The `claim_open_shift` RPC re-checks capacity inside a transaction. Second claimer gets a "no spots remaining" error.
+2. **Manager fills spot manually after employee claims (pending)** — When a shift is manually assigned that fills capacity, pending claims for that slot are auto-rejected.
+3. **Template capacity reduced after open shifts posted** — If capacity drops below current assignments, no action needed (existing assignments stay). Open spots recalculate to 0 or negative (clamped to 0 in the view).
+4. **Employee cancels a claim** — If instant (already has shift), the resulting shift is deleted. If pending, claim status set to 'cancelled'.
+5. **Overnight shifts** — Template with start_time > end_time (e.g., 22:00–06:00) works correctly since capacity is per-template-per-date, not time-based.
+
+### Testing Strategy
+
+| Layer | Tests |
+|-------|-------|
+| SQL (pgTAP) | `get_open_shifts` returns correct gaps; `claim_open_shift` enforces capacity, conflicts, approval mode; race condition handling; RLS policies |
+| Unit (Vitest) | `useAvailableShifts` merges open shifts + trades correctly; conflict detection; capacity computation |
+| E2E (Playwright) | PR1: manager sets capacity, sees indicators. PR2: employee views feed, claims shift, sees it on schedule. PR3: manager broadcasts, employee receives notification |

--- a/docs/superpowers/specs/2026-04-11-open-shift-claiming-pr2-design.md
+++ b/docs/superpowers/specs/2026-04-11-open-shift-claiming-pr2-design.md
@@ -1,0 +1,464 @@
+# Open Shift Claiming PR2 — Employees Can Find and Claim Open Shifts
+
+**Date:** 2026-04-11
+**Status:** Draft
+**Parent spec:** `docs/superpowers/specs/2026-04-11-open-shift-claiming-design.md`
+**Depends on:** PR1 (merged — capacity column on shift_templates)
+
+## Problem
+
+Managers can see where they're short-staffed (PR1), but employees have no way to voluntarily pick up those open shifts. Managers must manually assign every employee or text people individually.
+
+## Solution
+
+A unified "Available Shifts" feed for employees that merges open shifts (from template capacity gaps) with existing shift trades. Employees can claim open shifts directly. The feature is opt-in per restaurant — managers enable it when ready, preventing unintended exposure of planning-stage gaps.
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Feature gate | `open_shifts_enabled` on `staffing_settings`, default **false** | Managers may intentionally under-staff; don't surface gaps without consent |
+| Open shift visibility | Published weeks only | Unpublished schedules are still being planned |
+| Open shift computation | Server-side SQL RPC | Atomic capacity checks, clean RLS, prevents race conditions |
+| Approval flow | Configurable per restaurant, default instant | Manager already expressed the need via capacity; approval adds friction |
+| Onboarding | Publish dialog nudge (B) + settings page callout (C) | Contextual discovery when relevant, settings for configuration |
+
+## Database Changes
+
+### 1. New table: `open_shift_claims`
+
+```sql
+CREATE TABLE open_shift_claims (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  restaurant_id UUID NOT NULL REFERENCES restaurants(id) ON DELETE CASCADE,
+  shift_template_id UUID NOT NULL REFERENCES shift_templates(id) ON DELETE CASCADE,
+  shift_date DATE NOT NULL,
+  claimed_by_employee_id UUID NOT NULL REFERENCES employees(id) ON DELETE CASCADE,
+  status TEXT NOT NULL DEFAULT 'approved'
+    CHECK (status IN ('pending_approval', 'approved', 'rejected', 'cancelled')),
+  resulting_shift_id UUID REFERENCES shifts(id) ON DELETE SET NULL,
+  reviewed_by UUID REFERENCES auth.users(id),
+  reviewed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Prevent same employee claiming same template/date twice
+CREATE UNIQUE INDEX idx_unique_active_claim
+  ON open_shift_claims (shift_template_id, shift_date, claimed_by_employee_id)
+  WHERE status IN ('pending_approval', 'approved');
+
+-- Query indexes
+CREATE INDEX idx_claims_restaurant ON open_shift_claims (restaurant_id);
+CREATE INDEX idx_claims_employee ON open_shift_claims (claimed_by_employee_id);
+CREATE INDEX idx_claims_status ON open_shift_claims (restaurant_id, status);
+```
+
+### 2. Add settings columns to `staffing_settings`
+
+```sql
+ALTER TABLE staffing_settings
+  ADD COLUMN open_shifts_enabled BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN require_shift_claim_approval BOOLEAN NOT NULL DEFAULT false;
+```
+
+### 3. RLS policies on `open_shift_claims`
+
+```sql
+-- Employees see their own claims
+CREATE POLICY "Employees can view own claims"
+  ON open_shift_claims FOR SELECT
+  USING (claimed_by_employee_id IN (
+    SELECT id FROM employees WHERE user_id = auth.uid()
+  ));
+
+-- Managers see all claims for their restaurant
+CREATE POLICY "Managers can view restaurant claims"
+  ON open_shift_claims FOR SELECT
+  USING (restaurant_id IN (
+    SELECT restaurant_id FROM restaurant_members
+    WHERE user_id = auth.uid() AND role IN ('owner', 'manager')
+  ));
+
+-- Employees can create claims for themselves
+CREATE POLICY "Employees can create claims"
+  ON open_shift_claims FOR INSERT
+  WITH CHECK (claimed_by_employee_id IN (
+    SELECT id FROM employees WHERE user_id = auth.uid()
+  ));
+
+-- Employees can cancel their own pending claims
+CREATE POLICY "Employees can cancel own pending claims"
+  ON open_shift_claims FOR UPDATE
+  USING (
+    claimed_by_employee_id IN (SELECT id FROM employees WHERE user_id = auth.uid())
+    AND status = 'pending_approval'
+  );
+
+-- Managers can approve/reject
+CREATE POLICY "Managers can review claims"
+  ON open_shift_claims FOR UPDATE
+  USING (restaurant_id IN (
+    SELECT restaurant_id FROM restaurant_members
+    WHERE user_id = auth.uid() AND role IN ('owner', 'manager')
+  ));
+```
+
+### 4. SQL RPC: `get_open_shifts`
+
+```sql
+CREATE OR REPLACE FUNCTION get_open_shifts(
+  p_restaurant_id UUID,
+  p_week_start DATE,
+  p_week_end DATE
+) RETURNS TABLE (
+  template_id UUID,
+  template_name TEXT,
+  shift_date DATE,
+  start_time TIME,
+  end_time TIME,
+  position TEXT,
+  capacity INT,
+  assigned_count BIGINT,
+  pending_claims BIGINT,
+  open_spots BIGINT
+) AS $$
+BEGIN
+  -- Only return open shifts for published weeks when feature is enabled
+  IF NOT EXISTS (
+    SELECT 1 FROM staffing_settings
+    WHERE restaurant_id = p_restaurant_id AND open_shifts_enabled = true
+  ) THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
+  WITH published_dates AS (
+    -- Only dates within published schedule ranges
+    SELECT DISTINCT d::date AS pub_date
+    FROM schedule_publications sp,
+         generate_series(sp.week_start, sp.week_end, '1 day'::interval) d
+    WHERE sp.restaurant_id = p_restaurant_id
+      AND d::date BETWEEN p_week_start AND p_week_end
+  ),
+  template_days AS (
+    SELECT
+      st.id AS tid,
+      st.name,
+      st.start_time,
+      st.end_time,
+      st.position,
+      st.capacity,
+      pd.pub_date
+    FROM shift_templates st
+    CROSS JOIN published_dates pd
+    WHERE st.restaurant_id = p_restaurant_id
+      AND st.is_active = true
+      AND st.capacity > 1
+      AND EXTRACT(DOW FROM pd.pub_date)::int = ANY(st.days)
+  ),
+  assigned AS (
+    SELECT td.tid, td.pub_date, COUNT(s.id) AS cnt
+    FROM template_days td
+    LEFT JOIN shifts s ON s.restaurant_id = p_restaurant_id
+      AND s.position = td.position
+      AND s.start_time::time = td.start_time
+      AND s.end_time::time = td.end_time
+      AND s.start_time::date = td.pub_date
+      AND s.status != 'cancelled'
+    GROUP BY td.tid, td.pub_date
+  ),
+  pending AS (
+    SELECT td.tid, td.pub_date, COUNT(c.id) AS cnt
+    FROM template_days td
+    LEFT JOIN open_shift_claims c ON c.shift_template_id = td.tid
+      AND c.shift_date = td.pub_date
+      AND c.status = 'pending_approval'
+    GROUP BY td.tid, td.pub_date
+  )
+  SELECT
+    td.tid,
+    td.name,
+    td.pub_date,
+    td.start_time,
+    td.end_time,
+    td.position,
+    td.capacity,
+    COALESCE(a.cnt, 0),
+    COALESCE(p.cnt, 0),
+    GREATEST(0, td.capacity - COALESCE(a.cnt, 0) - COALESCE(p.cnt, 0))
+  FROM template_days td
+  LEFT JOIN assigned a ON a.tid = td.tid AND a.pub_date = td.pub_date
+  LEFT JOIN pending p ON p.tid = td.tid AND p.pub_date = td.pub_date
+  WHERE td.capacity - COALESCE(a.cnt, 0) - COALESCE(p.cnt, 0) > 0;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+```
+
+### 5. SQL RPC: `claim_open_shift`
+
+```sql
+CREATE OR REPLACE FUNCTION claim_open_shift(
+  p_restaurant_id UUID,
+  p_template_id UUID,
+  p_shift_date DATE,
+  p_employee_id UUID
+) RETURNS JSON AS $$
+DECLARE
+  v_template shift_templates%ROWTYPE;
+  v_capacity INT;
+  v_assigned INT;
+  v_pending INT;
+  v_open INT;
+  v_require_approval BOOLEAN;
+  v_claim_id UUID;
+  v_shift_id UUID;
+  v_conflict BOOLEAN;
+BEGIN
+  -- 1. Lock and fetch template
+  SELECT * INTO v_template
+  FROM shift_templates
+  WHERE id = p_template_id AND restaurant_id = p_restaurant_id AND is_active = true
+  FOR SHARE;
+
+  IF NOT FOUND THEN
+    RETURN json_build_object('success', false, 'error', 'Template not found');
+  END IF;
+
+  -- 2. Verify the date falls on a template day
+  IF NOT (EXTRACT(DOW FROM p_shift_date)::int = ANY(v_template.days)) THEN
+    RETURN json_build_object('success', false, 'error', 'Template does not apply to this date');
+  END IF;
+
+  -- 3. Check remaining capacity
+  SELECT COUNT(*) INTO v_assigned
+  FROM shifts
+  WHERE restaurant_id = p_restaurant_id
+    AND position = v_template.position
+    AND start_time::time = v_template.start_time
+    AND end_time::time = v_template.end_time
+    AND start_time::date = p_shift_date
+    AND status != 'cancelled';
+
+  SELECT COUNT(*) INTO v_pending
+  FROM open_shift_claims
+  WHERE shift_template_id = p_template_id
+    AND shift_date = p_shift_date
+    AND status = 'pending_approval';
+
+  v_open := v_template.capacity - v_assigned - v_pending;
+
+  IF v_open <= 0 THEN
+    RETURN json_build_object('success', false, 'error', 'No open spots remaining');
+  END IF;
+
+  -- 4. Check schedule conflict
+  SELECT EXISTS (
+    SELECT 1 FROM shifts
+    WHERE employee_id = p_employee_id
+      AND status != 'cancelled'
+      AND start_time::date = p_shift_date
+      AND (
+        (start_time::time, end_time::time) OVERLAPS
+        (v_template.start_time, v_template.end_time)
+      )
+  ) INTO v_conflict;
+
+  IF v_conflict THEN
+    RETURN json_build_object('success', false, 'error', 'Schedule conflict with existing shift');
+  END IF;
+
+  -- 5. Check approval setting
+  SELECT COALESCE(require_shift_claim_approval, false) INTO v_require_approval
+  FROM staffing_settings
+  WHERE restaurant_id = p_restaurant_id;
+
+  -- 6. Create claim
+  IF v_require_approval THEN
+    INSERT INTO open_shift_claims (restaurant_id, shift_template_id, shift_date, claimed_by_employee_id, status)
+    VALUES (p_restaurant_id, p_template_id, p_shift_date, p_employee_id, 'pending_approval')
+    RETURNING id INTO v_claim_id;
+
+    RETURN json_build_object(
+      'success', true,
+      'claim_id', v_claim_id,
+      'status', 'pending_approval',
+      'message', 'Claim submitted for manager approval'
+    );
+  ELSE
+    -- Instant: create shift + approved claim
+    INSERT INTO shifts (restaurant_id, employee_id, start_time, end_time, position, break_duration, status, is_published, locked, source)
+    VALUES (
+      p_restaurant_id,
+      p_employee_id,
+      (p_shift_date || ' ' || v_template.start_time)::timestamptz,
+      (p_shift_date || ' ' || v_template.end_time)::timestamptz,
+      v_template.position,
+      v_template.break_duration,
+      'scheduled',
+      true,
+      false,
+      'claimed'
+    )
+    RETURNING id INTO v_shift_id;
+
+    INSERT INTO open_shift_claims (restaurant_id, shift_template_id, shift_date, claimed_by_employee_id, status, resulting_shift_id)
+    VALUES (p_restaurant_id, p_template_id, p_shift_date, p_employee_id, 'approved', v_shift_id)
+    RETURNING id INTO v_claim_id;
+
+    RETURN json_build_object(
+      'success', true,
+      'claim_id', v_claim_id,
+      'shift_id', v_shift_id,
+      'status', 'approved',
+      'message', 'Shift claimed successfully'
+    );
+  END IF;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+```
+
+### 6. SQL RPC: `approve_open_shift_claim` / `reject_open_shift_claim`
+
+```sql
+CREATE OR REPLACE FUNCTION approve_open_shift_claim(
+  p_claim_id UUID,
+  p_reviewer_note TEXT DEFAULT NULL
+) RETURNS JSON AS $$
+DECLARE
+  v_claim open_shift_claims%ROWTYPE;
+  v_template shift_templates%ROWTYPE;
+  v_shift_id UUID;
+BEGIN
+  SELECT * INTO v_claim FROM open_shift_claims WHERE id = p_claim_id FOR UPDATE;
+  IF NOT FOUND OR v_claim.status != 'pending_approval' THEN
+    RETURN json_build_object('success', false, 'error', 'Claim not found or not pending');
+  END IF;
+
+  SELECT * INTO v_template FROM shift_templates WHERE id = v_claim.shift_template_id;
+
+  -- Create the shift
+  INSERT INTO shifts (restaurant_id, employee_id, start_time, end_time, position, break_duration, status, is_published, locked, source)
+  VALUES (
+    v_claim.restaurant_id,
+    v_claim.claimed_by_employee_id,
+    (v_claim.shift_date || ' ' || v_template.start_time)::timestamptz,
+    (v_claim.shift_date || ' ' || v_template.end_time)::timestamptz,
+    v_template.position,
+    v_template.break_duration,
+    'scheduled',
+    true,
+    false,
+    'claimed'
+  )
+  RETURNING id INTO v_shift_id;
+
+  -- Update claim
+  UPDATE open_shift_claims
+  SET status = 'approved',
+      resulting_shift_id = v_shift_id,
+      reviewed_by = auth.uid(),
+      reviewed_at = NOW()
+  WHERE id = p_claim_id;
+
+  RETURN json_build_object('success', true, 'shift_id', v_shift_id);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+CREATE OR REPLACE FUNCTION reject_open_shift_claim(
+  p_claim_id UUID,
+  p_reviewer_note TEXT DEFAULT NULL
+) RETURNS JSON AS $$
+BEGIN
+  UPDATE open_shift_claims
+  SET status = 'rejected',
+      reviewed_by = auth.uid(),
+      reviewed_at = NOW()
+  WHERE id = p_claim_id AND status = 'pending_approval';
+
+  IF NOT FOUND THEN
+    RETURN json_build_object('success', false, 'error', 'Claim not found or not pending');
+  END IF;
+
+  RETURN json_build_object('success', true);
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+```
+
+## UI Components
+
+### Employee: Unified Available Shifts Page
+
+Replaces `EmployeeShiftMarketplace` at route `/employee/shifts`.
+
+**Layout:**
+- Page header: "Available Shifts" with count badge
+- Virtualized list (per CLAUDE.md performance rules) with two card types:
+  - **Open Shift card** — Green `OPEN SHIFT` badge, template name, date, time range, position, spots remaining ("2 spots left"), "Claim" button. Grayed out with "Schedule conflict" note when employee has overlapping shift.
+  - **Trade card** — Amber `TRADE` badge, existing marketplace design brought into unified feed.
+- Empty state when no open shifts or trades available
+
+**Claim flow:**
+1. Employee taps "Claim"
+2. Confirmation dialog: "Claim [Template Name] on [Date], [Time]?" with Confirm/Cancel
+3. On confirm: call `claim_open_shift` RPC
+4. Success: toast "Shift claimed!" (instant) or "Claim submitted for approval" (pending)
+5. Card updates or removes from list
+
+### Employee: My Claims section
+
+Below the available shifts feed, a collapsible "My Claims" section showing:
+- Pending claims (amber badge, with "Cancel" option)
+- Recently approved claims (green badge)
+- Recently rejected claims (red badge, with reason if provided)
+
+### Manager: Approval Setting
+
+In the staffing settings panel (existing `StaffingConfigPanel`):
+- **"Open Shift Claiming" section** with:
+  - Toggle: "Allow employees to claim open shifts" (`open_shifts_enabled`)
+  - When enabled, sub-toggle: "Require manager approval for claims" (`require_shift_claim_approval`)
+  - Helper text for each toggle explaining the behavior
+- First-enable explanation: brief inline note when toggling on for the first time: "Employees will be able to see and claim unfilled shifts after you publish. You control which shifts are open through template capacity."
+
+### Manager: Publish Dialog Nudge
+
+When `open_shifts_enabled` is false and `openShiftCount > 0`, the existing amber alert in `PublishScheduleDialog` changes to:
+> "N shifts still need staff. Want employees to fill these? [Enable open shift claiming →]"
+
+Link goes to staffing settings. When feature is already enabled, shows the current message: "You can fill these now or broadcast to your team later."
+
+### Manager: Pending Claims in Approval Queue
+
+The existing "Trades" tab on the scheduling page shows trade approvals. Add open shift claim approvals alongside them with a distinct badge ("CLAIM" vs "TRADE").
+
+## Hooks
+
+- `useOpenShifts(restaurantId)` — calls `get_open_shifts` RPC, returns open shifts for current/next week
+- `useClaimOpenShift()` — mutation calling `claim_open_shift` RPC, invalidates open shifts + employee schedule
+- `useOpenShiftClaims(restaurantId, employeeId?)` — fetches claims, used by both employee (own) and manager (all)
+- `useApproveClaimMutation()` / `useRejectClaimMutation()` — manager actions
+- `useAvailableShifts(restaurantId, employeeId)` — merges `useOpenShifts` + `useMarketplaceTrades` into unified sorted feed
+- `useStaffingSettings(restaurantId)` — extends existing hook to include new boolean columns
+
+## Conflict Detection
+
+Before rendering "Claim" button, check employee's existing shifts for the same date/time overlap. This is a client-side UX hint — the RPC double-checks server-side.
+
+Reuse existing `useConflictDetection` pattern or compute inline from the employee's schedule data.
+
+## Edge Cases
+
+1. **Race condition** — Two employees claim last spot simultaneously. RPC uses `FOR SHARE` lock on template row; second claim gets "No open spots remaining."
+2. **Manager fills manually** — Manager assigns employee to a shift that fills capacity. Pending claims for that slot are NOT auto-rejected (they may be for a different person). The `get_open_shifts` RPC simply stops returning that slot.
+3. **Employee cancels claim** — If status is `pending_approval`, set to `cancelled`. If status is `approved` (instant mode), delete the resulting shift and set claim to `cancelled`.
+4. **Template capacity reduced** — Open spots clamp to 0. Existing claims unaffected.
+5. **Overnight shifts** — Template start_time > end_time (e.g., 22:00-06:00). The conflict detection and shift creation handle this via the existing shift model.
+
+## Testing Strategy
+
+| Layer | Tests |
+|-------|-------|
+| pgTAP | `get_open_shifts` returns correct gaps for published weeks only; `claim_open_shift` enforces capacity, conflicts, approval mode; race condition handling; RLS policies; feature gate check |
+| Unit (Vitest) | `useAvailableShifts` merges open shifts + trades; conflict detection; settings hook |
+| E2E (Playwright) | Employee views unified feed, claims shift, sees on schedule; manager enables feature, sets approval, approves claim |

--- a/docs/superpowers/specs/2026-04-11-open-shift-claiming-pr2-design.md
+++ b/docs/superpowers/specs/2026-04-11-open-shift-claiming-pr2-design.md
@@ -3,7 +3,7 @@
 **Date:** 2026-04-11
 **Status:** Draft
 **Parent spec:** `docs/superpowers/specs/2026-04-11-open-shift-claiming-design.md`
-**Depends on:** PR1 (merged — capacity column on shift_templates)
+**Depends on:** PR1 (merged — capacity column on shift_templates), area column on shift_templates (merged)
 
 ## Problem
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,6 +48,7 @@ import EmployeeTimecard from "./pages/EmployeeTimecard";
 import EmployeePay from "./pages/EmployeePay";
 import EmployeeSchedule from "./pages/EmployeeSchedule";
 import EmployeeShiftMarketplace from "./pages/EmployeeShiftMarketplace";
+import AvailableShiftsPage from "./pages/AvailableShiftsPage";
 import PrepRecipesEnhanced from "./pages/PrepRecipesEnhanced";
 import TimePunchesManager from "./pages/TimePunchesManager";
 import Payroll from "./pages/Payroll";
@@ -264,7 +265,7 @@ const App = () => (
           <Route path="/employee/timecard" element={<ProtectedRoute allowStaff={true}><EmployeeTimecard /></ProtectedRoute>} />
           <Route path="/employee/pay" element={<ProtectedRoute allowStaff={true}><EmployeePay /></ProtectedRoute>} />
           <Route path="/employee/schedule" element={<ProtectedRoute allowStaff={true}><EmployeeSchedule /></ProtectedRoute>} />
-          <Route path="/employee/shifts" element={<ProtectedRoute allowStaff={true}><EmployeeShiftMarketplace /></ProtectedRoute>} />
+          <Route path="/employee/shifts" element={<ProtectedRoute allowStaff={true}><AvailableShiftsPage /></ProtectedRoute>} />
           <Route path="/kiosk" element={<ProtectedRoute allowStaff={true} noChrome={true}><KioskMode /></ProtectedRoute>} />
           <Route path="/time-punches" element={<ProtectedRoute><TimePunchesManager /></ProtectedRoute>} />
           <Route path="/payroll" element={<ProtectedRoute><Payroll /></ProtectedRoute>} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,7 +47,6 @@ import EmployeePortal from "./pages/EmployeePortal";
 import EmployeeTimecard from "./pages/EmployeeTimecard";
 import EmployeePay from "./pages/EmployeePay";
 import EmployeeSchedule from "./pages/EmployeeSchedule";
-import EmployeeShiftMarketplace from "./pages/EmployeeShiftMarketplace";
 import AvailableShiftsPage from "./pages/AvailableShiftsPage";
 import PrepRecipesEnhanced from "./pages/PrepRecipesEnhanced";
 import TimePunchesManager from "./pages/TimePunchesManager";

--- a/src/components/PublishScheduleDialog.tsx
+++ b/src/components/PublishScheduleDialog.tsx
@@ -29,7 +29,9 @@ interface PublishScheduleDialogProps {
   employeeCount: number;
   totalHours: number;
   openShiftCount: number;
+  openShiftsEnabled: boolean;
   onConfirm: (notes?: string) => void;
+  onNavigateToSettings?: () => void;
   isPublishing: boolean;
 }
 
@@ -42,7 +44,9 @@ export const PublishScheduleDialog = ({
   employeeCount,
   totalHours,
   openShiftCount,
+  openShiftsEnabled,
   onConfirm,
+  onNavigateToSettings,
   isPublishing,
 }: PublishScheduleDialogProps) => {
   const [notes, setNotes] = useState('');
@@ -105,7 +109,20 @@ export const PublishScheduleDialog = ({
               <AlertTriangle className="h-4 w-4 text-amber-600" />
               <AlertDescription className="text-sm">
                 <strong>{openShiftCount} {openShiftCount === 1 ? 'shift' : 'shifts'} still {openShiftCount === 1 ? 'needs' : 'need'} staff.</strong>{' '}
-                You can fill these now or broadcast to your team later.
+                {openShiftsEnabled ? (
+                  'You can fill these now or broadcast to your team later.'
+                ) : (
+                  <>
+                    Want employees to fill these?{' '}
+                    <button
+                      type="button"
+                      onClick={onNavigateToSettings}
+                      className="text-amber-600 underline hover:text-amber-700 cursor-pointer"
+                    >
+                      Enable open shift claiming in Settings →
+                    </button>
+                  </>
+                )}
               </AlertDescription>
             </Alert>
           )}

--- a/src/components/schedule/TradeApprovalQueue.tsx
+++ b/src/components/schedule/TradeApprovalQueue.tsx
@@ -47,6 +47,31 @@ import { Skeleton } from '@/components/ui/skeleton';
 
 type ActionType = 'approve' | 'reject' | null;
 
+function renderClaimButtonContent(action: ActionType, isPending: boolean) {
+  if (isPending) {
+    return (
+      <>
+        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+        Processing...
+      </>
+    );
+  }
+  if (action === 'approve') {
+    return (
+      <>
+        <CheckCircle className="mr-2 h-4 w-4" />
+        Approve
+      </>
+    );
+  }
+  return (
+    <>
+      <XCircle className="mr-2 h-4 w-4" />
+      Reject
+    </>
+  );
+}
+
 export const TradeApprovalQueue = () => {
   const { selectedRestaurant } = useRestaurantContext();
   const restaurantId = selectedRestaurant?.restaurant_id || null;
@@ -403,22 +428,7 @@ export const TradeApprovalQueue = () => {
               disabled={isApprovingClaim || isRejectingClaim}
               variant={claimActionType === 'approve' ? 'default' : 'destructive'}
             >
-              {(isApprovingClaim || isRejectingClaim) ? (
-                <>
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                  Processing...
-                </>
-              ) : claimActionType === 'approve' ? (
-                <>
-                  <CheckCircle className="mr-2 h-4 w-4" />
-                  Approve
-                </>
-              ) : (
-                <>
-                  <XCircle className="mr-2 h-4 w-4" />
-                  Reject
-                </>
-              )}
+              {renderClaimButtonContent(claimActionType, isApprovingClaim || isRejectingClaim)}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/components/schedule/TradeApprovalQueue.tsx
+++ b/src/components/schedule/TradeApprovalQueue.tsx
@@ -24,6 +24,12 @@ import {
   useRejectShiftTrade,
   ShiftTrade,
 } from '@/hooks/useShiftTrades';
+import {
+  useOpenShiftClaims,
+  useApproveClaimMutation,
+  useRejectClaimMutation,
+  OpenShiftClaimWithJoins,
+} from '@/hooks/useOpenShiftClaims';
 import { useRestaurantContext } from '@/contexts/RestaurantContext';
 import { supabase } from '@/integrations/supabase/client';
 import {
@@ -44,7 +50,7 @@ type ActionType = 'approve' | 'reject' | null;
 export const TradeApprovalQueue = () => {
   const { selectedRestaurant } = useRestaurantContext();
   const restaurantId = selectedRestaurant?.restaurant_id || null;
-  
+
   // Fetch both pending_approval and open trades
   const { trades: pendingTrades, loading: pendingLoading } = useShiftTrades(
     restaurantId,
@@ -56,16 +62,27 @@ export const TradeApprovalQueue = () => {
     'open',
     null
   );
-  
+
+  // Fetch open shift claims
+  const { claims: allClaims, loading: claimsLoading } = useOpenShiftClaims(restaurantId);
+  const pendingClaims = allClaims.filter((c) => c.status === 'pending_approval');
+
   const { mutate: approveTrade, isPending: isApproving } = useApproveShiftTrade();
   const { mutate: rejectTrade, isPending: isRejecting } = useRejectShiftTrade();
+  const { mutate: approveClaim, isPending: isApprovingClaim } = useApproveClaimMutation();
+  const { mutate: rejectClaim, isPending: isRejectingClaim } = useRejectClaimMutation();
 
   const [selectedTrade, setSelectedTrade] = useState<ShiftTrade | null>(null);
   const [actionType, setActionType] = useState<ActionType>(null);
   const [managerNote, setManagerNote] = useState('');
   const [openSectionExpanded, setOpenSectionExpanded] = useState(true);
 
-  const loading = pendingLoading || openLoading;
+  // Claim dialog state
+  const [selectedClaim, setSelectedClaim] = useState<OpenShiftClaimWithJoins | null>(null);
+  const [claimActionType, setClaimActionType] = useState<ActionType>(null);
+  const [claimNote, setClaimNote] = useState('');
+
+  const loading = pendingLoading || openLoading || claimsLoading;
 
   const handleAction = (trade: ShiftTrade, action: 'approve' | 'reject') => {
     setSelectedTrade(trade);
@@ -114,6 +131,40 @@ export const TradeApprovalQueue = () => {
     setManagerNote('');
   };
 
+  const handleClaimAction = (claim: OpenShiftClaimWithJoins, action: 'approve' | 'reject') => {
+    setSelectedClaim(claim);
+    setClaimActionType(action);
+    setClaimNote('');
+  };
+
+  const handleClaimConfirm = () => {
+    if (!selectedClaim || !claimActionType) return;
+    const payload = { claimId: selectedClaim.id, note: claimNote || undefined };
+    if (claimActionType === 'approve') {
+      approveClaim(payload, {
+        onSuccess: () => {
+          setSelectedClaim(null);
+          setClaimActionType(null);
+          setClaimNote('');
+        },
+      });
+    } else {
+      rejectClaim(payload, {
+        onSuccess: () => {
+          setSelectedClaim(null);
+          setClaimActionType(null);
+          setClaimNote('');
+        },
+      });
+    }
+  };
+
+  const handleClaimCancel = () => {
+    setSelectedClaim(null);
+    setClaimActionType(null);
+    setClaimNote('');
+  };
+
   if (loading) {
     return (
       <div className="space-y-4">
@@ -126,9 +177,46 @@ export const TradeApprovalQueue = () => {
   const hasPendingTrades = pendingTrades.length > 0;
   const hasOpenTrades = openTrades.length > 0;
   const hasNoTrades = !hasPendingTrades && !hasOpenTrades;
+  const hasPendingClaims = pendingClaims.length > 0;
 
   return (
     <div className="space-y-6">
+      {/* Pending Shift Claims Section */}
+      {hasPendingClaims && (
+        <>
+          <Card className="border-green-200 bg-gradient-to-br from-green-50 via-emerald-50 to-transparent dark:border-green-800 dark:from-green-950/20 dark:via-emerald-950/20">
+            <CardHeader>
+              <div className="flex items-center gap-3">
+                <CheckCircle className="h-6 w-6 text-green-600 dark:text-green-400" />
+                <div className="flex-1">
+                  <div className="flex items-center gap-2">
+                    <CardTitle className="text-2xl text-green-900 dark:text-green-100">
+                      Pending Shift Claims
+                    </CardTitle>
+                    <Badge className="bg-green-500">{pendingClaims.length}</Badge>
+                  </div>
+                  <CardDescription className="text-green-700 dark:text-green-300">
+                    Employees requesting to claim open shifts
+                  </CardDescription>
+                </div>
+              </div>
+            </CardHeader>
+          </Card>
+
+          <div className="space-y-4">
+            {pendingClaims.map((claim) => (
+              <ClaimRequestCard
+                key={claim.id}
+                claim={claim}
+                onApprove={() => handleClaimAction(claim, 'approve')}
+                onReject={() => handleClaimAction(claim, 'reject')}
+                disabled={isApprovingClaim || isRejectingClaim}
+              />
+            ))}
+          </div>
+        </>
+      )}
+
       {/* Pending Approval Section */}
       <Card className="border-amber-200 bg-gradient-to-br from-amber-50 via-orange-50 to-transparent dark:border-amber-800 dark:from-amber-950/20 dark:via-orange-950/20">
         <CardHeader>
@@ -218,7 +306,125 @@ export const TradeApprovalQueue = () => {
         </Card>
       </Collapsible>
 
-      {/* Approval/Rejection Dialog */}
+      {/* Claim Approval/Rejection Dialog */}
+      <Dialog open={!!selectedClaim && !!claimActionType} onOpenChange={(open) => !open && handleClaimCancel()}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2">
+              {claimActionType === 'approve' ? (
+                <>
+                  <CheckCircle className="h-5 w-5 text-green-600" />
+                  Approve Shift Claim
+                </>
+              ) : (
+                <>
+                  <XCircle className="h-5 w-5 text-red-600" />
+                  Reject Shift Claim
+                </>
+              )}
+            </DialogTitle>
+            <DialogDescription>
+              {claimActionType === 'approve'
+                ? 'This will assign the shift to the claiming employee.'
+                : 'This will decline the claim request.'}
+            </DialogDescription>
+          </DialogHeader>
+
+          {selectedClaim && (
+            <div className="space-y-4">
+              {/* Claim Summary */}
+              <div className="rounded-lg border border-border bg-muted/20 p-4">
+                <h4 className="mb-3 text-sm font-semibold text-muted-foreground">Claim Summary</h4>
+                <div className="space-y-1 text-sm">
+                  <p>
+                    <span className="font-medium">Employee:</span>{' '}
+                    {selectedClaim.employee?.name ?? 'Unknown'}
+                  </p>
+                  <p>
+                    <span className="font-medium">Shift:</span>{' '}
+                    {selectedClaim.shift_template?.name ?? 'Unknown'}
+                  </p>
+                  <p>
+                    <span className="font-medium">Date:</span>{' '}
+                    {format(new Date(selectedClaim.shift_date), 'EEEE, MMMM d, yyyy')}
+                  </p>
+                  {selectedClaim.shift_template && (
+                    <p>
+                      <span className="font-medium">Time:</span>{' '}
+                      {selectedClaim.shift_template.start_time} – {selectedClaim.shift_template.end_time}
+                    </p>
+                  )}
+                  <p>
+                    <span className="font-medium">Position:</span>{' '}
+                    {selectedClaim.shift_template?.position ?? selectedClaim.employee?.position ?? '—'}
+                  </p>
+                </div>
+              </div>
+
+              {/* Manager Note */}
+              <div className="space-y-2">
+                <Label htmlFor="claim-manager-note" className="text-sm font-medium">
+                  Add Note{' '}
+                  <span className="text-muted-foreground">
+                    ({claimActionType === 'reject' ? 'Recommended' : 'Optional'})
+                  </span>
+                </Label>
+                <Textarea
+                  id="claim-manager-note"
+                  placeholder={
+                    claimActionType === 'approve'
+                      ? 'Optional note about this approval...'
+                      : 'Explain why this claim is being rejected...'
+                  }
+                  value={claimNote}
+                  onChange={(e) => setClaimNote(e.target.value)}
+                  rows={3}
+                  className="resize-none"
+                />
+              </div>
+
+              {claimActionType === 'approve' && (
+                <div className="flex items-start gap-2 rounded-lg bg-green-50 p-3 dark:bg-green-950/20">
+                  <AlertCircle className="mt-0.5 h-4 w-4 text-green-600 dark:text-green-400" />
+                  <p className="text-xs text-green-700 dark:text-green-300">
+                    The employee will be notified of your decision.
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
+
+          <DialogFooter>
+            <Button variant="outline" onClick={handleClaimCancel} disabled={isApprovingClaim || isRejectingClaim}>
+              Cancel
+            </Button>
+            <Button
+              onClick={handleClaimConfirm}
+              disabled={isApprovingClaim || isRejectingClaim}
+              variant={claimActionType === 'approve' ? 'default' : 'destructive'}
+            >
+              {(isApprovingClaim || isRejectingClaim) ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Processing...
+                </>
+              ) : claimActionType === 'approve' ? (
+                <>
+                  <CheckCircle className="mr-2 h-4 w-4" />
+                  Approve
+                </>
+              ) : (
+                <>
+                  <XCircle className="mr-2 h-4 w-4" />
+                  Reject
+                </>
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Trade Approval/Rejection Dialog */}
       <Dialog open={!!selectedTrade && !!actionType} onOpenChange={(open) => !open && handleCancel()}>
         <DialogContent>
           <DialogHeader>
@@ -444,6 +650,84 @@ const TradeRequestCard = ({ trade, onApprove, onReject, disabled }: TradeRequest
             Reject
           </Button>
           <Button onClick={onApprove} disabled={disabled} className="flex-1">
+            <CheckCircle className="mr-2 h-4 w-4" />
+            Approve
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+// Claim Request Card
+interface ClaimRequestCardProps {
+  claim: OpenShiftClaimWithJoins;
+  onApprove: () => void;
+  onReject: () => void;
+  disabled: boolean;
+}
+
+const ClaimRequestCard = ({ claim, onApprove, onReject, disabled }: ClaimRequestCardProps) => {
+  const shiftDate = new Date(claim.shift_date);
+
+  return (
+    <Card data-testid="pending-claim" className="border-green-200 dark:border-green-800">
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between">
+          <div>
+            <CardTitle className="text-lg">
+              {claim.shift_template?.position ?? '—'}
+            </CardTitle>
+            <CardDescription className="mt-1">
+              {format(shiftDate, 'EEEE, MMMM d, yyyy')}
+            </CardDescription>
+          </div>
+          <Badge className="bg-green-500">Claim</Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Time */}
+        {claim.shift_template && (
+          <div className="flex items-center gap-2 text-sm">
+            <Clock className="h-4 w-4 text-muted-foreground" />
+            <span>
+              {claim.shift_template.start_time} – {claim.shift_template.end_time}
+            </span>
+          </div>
+        )}
+
+        {/* Employee info */}
+        <div className="rounded-lg bg-muted/50 p-3 text-sm">
+          <p className="text-xs text-muted-foreground mb-1">Requesting employee</p>
+          <p className="font-medium">{claim.employee?.name ?? 'Unknown'}</p>
+          {claim.employee?.position && (
+            <p className="text-xs text-muted-foreground">{claim.employee.position}</p>
+          )}
+        </div>
+
+        {/* Shift name */}
+        {claim.shift_template?.name && (
+          <div className="flex items-start gap-2 rounded-md bg-green-50 p-3 dark:bg-green-950/20">
+            <FileText className="mt-0.5 h-4 w-4 text-green-600 dark:text-green-400" />
+            <div className="flex-1">
+              <p className="text-xs font-medium text-green-900 dark:text-green-100">Shift Template:</p>
+              <p className="mt-1 text-sm text-green-700 dark:text-green-300">{claim.shift_template.name}</p>
+            </div>
+          </div>
+        )}
+
+        {/* Action Buttons */}
+        <div className="flex gap-2">
+          <Button
+            onClick={onReject}
+            disabled={disabled}
+            variant="outline"
+            className="flex-1 border-red-200 text-red-600 hover:bg-red-50 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-950/20"
+          >
+            <XCircle className="mr-2 h-4 w-4" />
+            Reject
+          </Button>
+          <Button onClick={onApprove} disabled={disabled} className="flex-1 bg-green-600 hover:bg-green-700">
             <CheckCircle className="mr-2 h-4 w-4" />
             Approve
           </Button>

--- a/src/components/scheduling/ClaimConfirmDialog.tsx
+++ b/src/components/scheduling/ClaimConfirmDialog.tsx
@@ -1,0 +1,103 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+
+import { Hand, Calendar, Clock, MapPin } from 'lucide-react';
+
+import type { OpenShift } from '@/types/scheduling';
+
+import { format, parseISO } from 'date-fns';
+
+interface ClaimConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  openShift: OpenShift | null;
+  onConfirm: () => void;
+  isPending: boolean;
+}
+
+function formatCompactTime(time: string): string {
+  const [h, m] = time.split(':').map(Number);
+  const suffix = h >= 12 ? 'p' : 'a';
+  const hour12 = h % 12 || 12;
+  if (m === 0) return `${hour12}${suffix}`;
+  return `${hour12}:${String(m).padStart(2, '0')}${suffix}`;
+}
+
+export function ClaimConfirmDialog({
+  open,
+  onOpenChange,
+  openShift,
+  onConfirm,
+  isPending,
+}: ClaimConfirmDialogProps) {
+  if (!openShift) return null;
+
+  const dateLabel = format(parseISO(openShift.shift_date), 'EEEE, MMMM d');
+  const timeLabel = `${formatCompactTime(openShift.start_time)} - ${formatCompactTime(openShift.end_time)}`;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md max-h-[80vh] overflow-y-auto p-0 gap-0 border-border/40">
+        <DialogHeader className="px-6 pt-6 pb-4 border-b border-border/40">
+          <div className="flex items-center gap-3">
+            <div className="h-10 w-10 rounded-xl bg-muted/50 flex items-center justify-center">
+              <Hand className="h-5 w-5 text-foreground" />
+            </div>
+            <div>
+              <DialogTitle className="text-[17px] font-semibold text-foreground">
+                Claim Shift
+              </DialogTitle>
+              <DialogDescription className="text-[13px] text-muted-foreground mt-0.5">
+                Confirm you want to pick up this shift
+              </DialogDescription>
+            </div>
+          </div>
+        </DialogHeader>
+
+        <div className="px-6 py-5 space-y-4">
+          <div className="rounded-xl border border-border/40 bg-muted/30 p-4 space-y-3">
+            <div className="text-[14px] font-medium text-foreground">
+              {openShift.template_name}
+            </div>
+            <div className="space-y-2 text-[13px] text-muted-foreground">
+              <div className="flex items-center gap-2">
+                <Calendar className="h-4 w-4" aria-hidden="true" />
+                {dateLabel}
+              </div>
+              <div className="flex items-center gap-2">
+                <Clock className="h-4 w-4" aria-hidden="true" />
+                {timeLabel}
+              </div>
+              <div className="flex items-center gap-2">
+                <MapPin className="h-4 w-4" aria-hidden="true" />
+                {openShift.position}
+                {openShift.area ? ` / ${openShift.area}` : ''}
+              </div>
+            </div>
+          </div>
+
+          <p className="text-[13px] text-muted-foreground">
+            You'll be added to this shift. Your manager may need to approve the claim first.
+          </p>
+        </div>
+
+        <div className="flex justify-end gap-2 px-6 pb-5">
+          <Button
+            variant="ghost"
+            onClick={() => onOpenChange(false)}
+            className="h-9 px-4 rounded-lg text-[13px] font-medium text-muted-foreground hover:text-foreground"
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={onConfirm}
+            disabled={isPending}
+            className="h-9 px-4 rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium"
+          >
+            {isPending ? 'Claiming...' : 'Confirm'}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/scheduling/ClaimConfirmDialog.tsx
+++ b/src/components/scheduling/ClaimConfirmDialog.tsx
@@ -29,7 +29,7 @@ export function ClaimConfirmDialog({
   openShift,
   onConfirm,
   isPending,
-}: ClaimConfirmDialogProps) {
+}: Readonly<ClaimConfirmDialogProps>) {
   if (!openShift) return null;
 
   const dateLabel = format(parseISO(openShift.shift_date), 'EEEE, MMMM d');

--- a/src/components/scheduling/OpenShiftCard.tsx
+++ b/src/components/scheduling/OpenShiftCard.tsx
@@ -1,0 +1,98 @@
+import { memo } from 'react';
+
+import { Button } from '@/components/ui/button';
+
+import { Calendar, Clock, MapPin, Users } from 'lucide-react';
+
+import type { OpenShift } from '@/types/scheduling';
+
+import { format, parseISO } from 'date-fns';
+import { cn } from '@/lib/utils';
+
+interface OpenShiftCardProps {
+  openShift: OpenShift;
+  hasConflict: boolean;
+  onClaim: (openShift: OpenShift) => void;
+  isClaiming: boolean;
+}
+
+function formatCompactTime(time: string): string {
+  const [h, m] = time.split(':').map(Number);
+  const suffix = h >= 12 ? 'p' : 'a';
+  const hour12 = h % 12 || 12;
+  if (m === 0) return `${hour12}${suffix}`;
+  return `${hour12}:${String(m).padStart(2, '0')}${suffix}`;
+}
+
+export const OpenShiftCard = memo(function OpenShiftCard({
+  openShift,
+  hasConflict,
+  onClaim,
+  isClaiming,
+}: OpenShiftCardProps) {
+  const dateLabel = format(parseISO(openShift.shift_date), 'EEE, MMM d');
+  const timeLabel = `${formatCompactTime(openShift.start_time)}-${formatCompactTime(openShift.end_time)}`;
+  const spotsLabel = openShift.open_spots === 1 ? '1 spot left' : `${openShift.open_spots} spots left`;
+
+  return (
+    <div
+      className={cn(
+        'group flex items-center justify-between p-4 rounded-xl border border-border/40 bg-background hover:border-border transition-colors',
+        hasConflict && 'opacity-60',
+      )}
+    >
+      {/* Left side */}
+      <div className="min-w-0 space-y-1.5">
+        <span className="text-[11px] px-1.5 py-0.5 rounded-md bg-emerald-500/10 text-emerald-600 font-medium">
+          OPEN SHIFT
+        </span>
+        <div className="text-[14px] font-medium text-foreground truncate">
+          {openShift.template_name}
+        </div>
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[13px] text-muted-foreground">
+          <span className="flex items-center gap-1">
+            <Calendar className="h-3.5 w-3.5" aria-hidden="true" />
+            {dateLabel}
+          </span>
+          <span className="flex items-center gap-1">
+            <Clock className="h-3.5 w-3.5" aria-hidden="true" />
+            {timeLabel}
+          </span>
+          <span className="flex items-center gap-1">
+            <MapPin className="h-3.5 w-3.5" aria-hidden="true" />
+            {openShift.position}
+            {openShift.area ? ` / ${openShift.area}` : ''}
+          </span>
+          <span className="flex items-center gap-1">
+            <Users className="h-3.5 w-3.5" aria-hidden="true" />
+            {spotsLabel}
+          </span>
+        </div>
+      </div>
+
+      {/* Right side */}
+      <div className="ml-4 flex-shrink-0">
+        {hasConflict ? (
+          <span className="text-[13px] text-muted-foreground">Schedule conflict</span>
+        ) : (
+          <Button
+            onClick={() => onClaim(openShift)}
+            disabled={isClaiming}
+            className="h-9 px-4 rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium"
+            aria-label={`Claim shift ${openShift.template_name} on ${dateLabel}`}
+          >
+            {isClaiming ? 'Claiming...' : 'Claim'}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}, (prev, next) => {
+  return (
+    prev.openShift.template_id === next.openShift.template_id &&
+    prev.openShift.shift_date === next.openShift.shift_date &&
+    prev.openShift.open_spots === next.openShift.open_spots &&
+    prev.hasConflict === next.hasConflict &&
+    prev.isClaiming === next.isClaiming
+  );
+});

--- a/src/components/scheduling/OpenShiftCard.tsx
+++ b/src/components/scheduling/OpenShiftCard.tsx
@@ -8,20 +8,13 @@ import type { OpenShift } from '@/types/scheduling';
 
 import { format, parseISO } from 'date-fns';
 import { cn } from '@/lib/utils';
+import { formatCompactTime } from '@/lib/openShiftHelpers';
 
 interface OpenShiftCardProps {
   openShift: OpenShift;
   hasConflict: boolean;
   onClaim: (openShift: OpenShift) => void;
   isClaiming: boolean;
-}
-
-function formatCompactTime(time: string): string {
-  const [h, m] = time.split(':').map(Number);
-  const suffix = h >= 12 ? 'p' : 'a';
-  const hour12 = h % 12 || 12;
-  if (m === 0) return `${hour12}${suffix}`;
-  return `${hour12}:${String(m).padStart(2, '0')}${suffix}`;
 }
 
 export const OpenShiftCard = memo(function OpenShiftCard({

--- a/src/components/scheduling/ShiftPlanner/StaffingConfigPanel.tsx
+++ b/src/components/scheduling/ShiftPlanner/StaffingConfigPanel.tsx
@@ -2,6 +2,7 @@ import { memo, useCallback, useMemo, useState } from 'react';
 
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
 import {
   Tooltip,
   TooltipContent,
@@ -19,6 +20,8 @@ interface StaffingConfigPanelProps {
     target_labor_pct: number;
     min_staff: number;
     min_crew: MinCrew | null;
+    open_shifts_enabled?: boolean;
+    require_shift_claim_approval?: boolean;
   };
   onSettingsChange: (updates: Record<string, unknown>) => void;
   onSaveDefaults: () => void;
@@ -255,6 +258,51 @@ export const StaffingConfigPanel = memo(function StaffingConfigPanel({
               </button>
             </div>
           </div>
+        </div>
+      </div>
+
+      {/* Open Shift Claiming */}
+      <div className="rounded-xl border border-border/40 bg-muted/30 overflow-hidden">
+        <div className="px-4 py-3 border-b border-border/40 bg-muted/50">
+          <h3 className="text-[13px] font-semibold text-foreground">Open Shift Claiming</h3>
+        </div>
+        <div className="p-4 space-y-4">
+          <div className="flex items-center justify-between gap-4">
+            <div className="min-w-0">
+              <div className="text-[14px] font-medium text-foreground">
+                Allow employees to claim open shifts
+              </div>
+              <p className="text-[13px] text-muted-foreground mt-0.5">
+                When enabled, employees can see and claim unfilled shifts after you publish the schedule.
+              </p>
+            </div>
+            <Switch
+              checked={!!settings.open_shifts_enabled}
+              onCheckedChange={(checked) => onSettingsChange({ open_shifts_enabled: checked })}
+              disabled={isSaving}
+              className="data-[state=checked]:bg-foreground"
+              aria-label="Allow employees to claim open shifts"
+            />
+          </div>
+          {settings.open_shifts_enabled && (
+            <div className="flex items-center justify-between gap-4 pl-4 border-l-2 border-border/40">
+              <div className="min-w-0">
+                <div className="text-[14px] font-medium text-foreground">
+                  Require manager approval
+                </div>
+                <p className="text-[13px] text-muted-foreground mt-0.5">
+                  When off, employees are instantly assigned. When on, claims go to your approval queue.
+                </p>
+              </div>
+              <Switch
+                checked={!!settings.require_shift_claim_approval}
+                onCheckedChange={(checked) => onSettingsChange({ require_shift_claim_approval: checked })}
+                disabled={isSaving}
+                className="data-[state=checked]:bg-foreground"
+                aria-label="Require manager approval for shift claims"
+              />
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/hooks/useAvailableShifts.ts
+++ b/src/hooks/useAvailableShifts.ts
@@ -1,0 +1,64 @@
+import { useMemo } from 'react';
+import type { OpenShift } from '@/types/scheduling';
+import type { ShiftTrade } from '@/hooks/useShiftTrades';
+import { useOpenShifts } from '@/hooks/useOpenShifts';
+import { useMarketplaceTrades } from '@/hooks/useShiftTrades';
+
+export interface AvailableShiftItem {
+  key: string;
+  type: 'open_shift' | 'trade';
+  date: string;
+  openShift?: OpenShift;
+  trade?: ShiftTrade & { hasConflict?: boolean };
+}
+
+export function mergeAvailableShifts(
+  openShifts: OpenShift[],
+  trades: (ShiftTrade & { hasConflict?: boolean })[],
+): AvailableShiftItem[] {
+  const items: AvailableShiftItem[] = [];
+
+  for (const os of openShifts) {
+    items.push({
+      key: `open-${os.template_id}-${os.shift_date}`,
+      type: 'open_shift',
+      date: os.shift_date,
+      openShift: os,
+    });
+  }
+
+  for (const trade of trades) {
+    const tradeDate = trade.offered_shift?.start_time?.split('T')[0] ?? '';
+    items.push({
+      key: `trade-${trade.id}`,
+      type: 'trade',
+      date: tradeDate,
+      trade,
+    });
+  }
+
+  items.sort((a, b) => a.date.localeCompare(b.date));
+  return items;
+}
+
+export function useAvailableShifts(
+  restaurantId: string | null,
+  employeeId: string | null,
+  weekStart: Date | null,
+  weekEnd: Date | null,
+) {
+  const { openShifts, loading: openLoading } = useOpenShifts(restaurantId, weekStart, weekEnd);
+  const { trades, loading: tradesLoading } = useMarketplaceTrades(restaurantId, employeeId);
+
+  const items = useMemo(
+    () => mergeAvailableShifts(openShifts, trades),
+    [openShifts, trades],
+  );
+
+  return {
+    items,
+    loading: openLoading || tradesLoading,
+    openShiftCount: openShifts.length,
+    tradeCount: trades.length,
+  };
+}

--- a/src/hooks/useOpenShiftClaims.ts
+++ b/src/hooks/useOpenShiftClaims.ts
@@ -1,0 +1,121 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { useToast } from '@/hooks/use-toast';
+import type { OpenShiftClaim } from '@/types/scheduling';
+
+export function useOpenShiftClaims(restaurantId: string | null, employeeId?: string | null) {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['open_shift_claims', restaurantId, employeeId],
+    queryFn: async () => {
+      if (!restaurantId) return [];
+      let query = (supabase.from('open_shift_claims') as any)
+        .select('*, shift_template:shift_templates(name, start_time, end_time, position)')
+        .eq('restaurant_id', restaurantId)
+        .order('created_at', { ascending: false });
+
+      if (employeeId) {
+        query = query.eq('claimed_by_employee_id', employeeId);
+      }
+
+      const { data, error } = await query;
+      if (error) throw error;
+      return data as (OpenShiftClaim & { shift_template?: { name: string; start_time: string; end_time: string; position: string } })[];
+    },
+    enabled: !!restaurantId,
+    staleTime: 30000,
+    refetchOnWindowFocus: true,
+  });
+
+  return { claims: data ?? [], loading: isLoading, error };
+}
+
+export function useClaimOpenShift() {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async (params: {
+      restaurantId: string;
+      templateId: string;
+      shiftDate: string;
+      employeeId: string;
+    }) => {
+      const { data, error } = await (supabase.rpc as any)('claim_open_shift', {
+        p_restaurant_id: params.restaurantId,
+        p_template_id: params.templateId,
+        p_shift_date: params.shiftDate,
+        p_employee_id: params.employeeId,
+      });
+
+      if (error) throw error;
+      const result = data as { success: boolean; error?: string; status?: string; message?: string };
+      if (!result.success) throw new Error(result.error ?? 'Failed to claim shift');
+      return result;
+    },
+    onSuccess: (result) => {
+      queryClient.invalidateQueries({ queryKey: ['open_shifts'] });
+      queryClient.invalidateQueries({ queryKey: ['open_shift_claims'] });
+      queryClient.invalidateQueries({ queryKey: ['shifts'] });
+      toast({
+        title: result.status === 'pending_approval' ? 'Claim submitted' : 'Shift claimed!',
+        description: result.message,
+      });
+    },
+    onError: (error: Error) => {
+      toast({ title: 'Cannot claim shift', description: error.message, variant: 'destructive' });
+    },
+  });
+}
+
+export function useApproveClaimMutation() {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async (params: { claimId: string; note?: string }) => {
+      const { data, error } = await (supabase.rpc as any)('approve_open_shift_claim', {
+        p_claim_id: params.claimId,
+        p_reviewer_note: params.note ?? null,
+      });
+      if (error) throw error;
+      const result = data as { success: boolean; error?: string };
+      if (!result.success) throw new Error(result.error ?? 'Failed to approve claim');
+      return result;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['open_shift_claims'] });
+      queryClient.invalidateQueries({ queryKey: ['open_shifts'] });
+      queryClient.invalidateQueries({ queryKey: ['shifts'] });
+      toast({ title: 'Claim approved' });
+    },
+    onError: (error: Error) => {
+      toast({ title: 'Error', description: error.message, variant: 'destructive' });
+    },
+  });
+}
+
+export function useRejectClaimMutation() {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async (params: { claimId: string; note?: string }) => {
+      const { data, error } = await (supabase.rpc as any)('reject_open_shift_claim', {
+        p_claim_id: params.claimId,
+        p_reviewer_note: params.note ?? null,
+      });
+      if (error) throw error;
+      const result = data as { success: boolean; error?: string };
+      if (!result.success) throw new Error(result.error ?? 'Failed to reject claim');
+      return result;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['open_shift_claims'] });
+      queryClient.invalidateQueries({ queryKey: ['open_shifts'] });
+      toast({ title: 'Claim rejected' });
+    },
+    onError: (error: Error) => {
+      toast({ title: 'Error', description: error.message, variant: 'destructive' });
+    },
+  });
+}

--- a/src/hooks/useOpenShiftClaims.ts
+++ b/src/hooks/useOpenShiftClaims.ts
@@ -3,13 +3,18 @@ import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 import type { OpenShiftClaim } from '@/types/scheduling';
 
+export type OpenShiftClaimWithJoins = OpenShiftClaim & {
+  shift_template?: { name: string; start_time: string; end_time: string; position: string } | null;
+  employee?: { name: string; position: string | null } | null;
+};
+
 export function useOpenShiftClaims(restaurantId: string | null, employeeId?: string | null) {
   const { data, isLoading, error } = useQuery({
     queryKey: ['open_shift_claims', restaurantId, employeeId],
     queryFn: async () => {
       if (!restaurantId) return [];
       let query = (supabase.from('open_shift_claims') as any)
-        .select('*, shift_template:shift_templates(name, start_time, end_time, position)')
+        .select('*, shift_template:shift_templates(name, start_time, end_time, position), employee:employees(name, position)')
         .eq('restaurant_id', restaurantId)
         .order('created_at', { ascending: false });
 
@@ -19,14 +24,14 @@ export function useOpenShiftClaims(restaurantId: string | null, employeeId?: str
 
       const { data, error } = await query;
       if (error) throw error;
-      return data as (OpenShiftClaim & { shift_template?: { name: string; start_time: string; end_time: string; position: string } })[];
+      return data as OpenShiftClaimWithJoins[];
     },
     enabled: !!restaurantId,
     staleTime: 30000,
     refetchOnWindowFocus: true,
   });
 
-  return { claims: data ?? [], loading: isLoading, error };
+  return { claims: data ?? [] as OpenShiftClaimWithJoins[], loading: isLoading, error };
 }
 
 export function useClaimOpenShift() {

--- a/src/hooks/useOpenShifts.ts
+++ b/src/hooks/useOpenShifts.ts
@@ -1,0 +1,29 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import type { OpenShift } from '@/types/scheduling';
+
+export function useOpenShifts(restaurantId: string | null, weekStart: Date | null, weekEnd: Date | null) {
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: ['open_shifts', restaurantId, weekStart?.toISOString(), weekEnd?.toISOString()],
+    queryFn: async () => {
+      if (!restaurantId || !weekStart || !weekEnd) return [];
+
+      const startStr = weekStart.toISOString().split('T')[0];
+      const endStr = weekEnd.toISOString().split('T')[0];
+
+      const { data, error } = await (supabase.rpc as any)('get_open_shifts', {
+        p_restaurant_id: restaurantId,
+        p_week_start: startStr,
+        p_week_end: endStr,
+      });
+
+      if (error) throw error;
+      return (data ?? []) as OpenShift[];
+    },
+    enabled: !!restaurantId && !!weekStart && !!weekEnd,
+    staleTime: 30000,
+    refetchOnWindowFocus: true,
+  });
+
+  return { openShifts: data ?? [], loading: isLoading, error, refetch };
+}

--- a/src/hooks/useStaffingSettings.ts
+++ b/src/hooks/useStaffingSettings.ts
@@ -14,6 +14,8 @@ const DEFAULTS: Omit<StaffingSettings, 'id' | 'restaurant_id' | 'created_at' | '
   lookback_weeks: 4,
   manual_projections: null,
   min_crew: null,
+  open_shifts_enabled: false,
+  require_shift_claim_approval: false,
 };
 
 export function useStaffingSettings(restaurantId: string | null) {

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -3616,6 +3616,91 @@ export type Database = {
           },
         ]
       }
+      open_shift_claims: {
+        Row: {
+          claimed_by_employee_id: string
+          created_at: string
+          id: string
+          restaurant_id: string
+          resulting_shift_id: string | null
+          reviewed_at: string | null
+          reviewed_by: string | null
+          shift_date: string
+          shift_template_id: string
+          status: string
+          updated_at: string
+        }
+        Insert: {
+          claimed_by_employee_id: string
+          created_at?: string
+          id?: string
+          restaurant_id: string
+          resulting_shift_id?: string | null
+          reviewed_at?: string | null
+          reviewed_by?: string | null
+          shift_date: string
+          shift_template_id: string
+          status?: string
+          updated_at?: string
+        }
+        Update: {
+          claimed_by_employee_id?: string
+          created_at?: string
+          id?: string
+          restaurant_id?: string
+          resulting_shift_id?: string | null
+          reviewed_at?: string | null
+          reviewed_by?: string | null
+          shift_date?: string
+          shift_template_id?: string
+          status?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "open_shift_claims_claimed_by_employee_id_fkey"
+            columns: ["claimed_by_employee_id"]
+            isOneToOne: false
+            referencedRelation: "active_employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "open_shift_claims_claimed_by_employee_id_fkey"
+            columns: ["claimed_by_employee_id"]
+            isOneToOne: false
+            referencedRelation: "employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "open_shift_claims_claimed_by_employee_id_fkey"
+            columns: ["claimed_by_employee_id"]
+            isOneToOne: false
+            referencedRelation: "inactive_employees"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "open_shift_claims_restaurant_id_fkey"
+            columns: ["restaurant_id"]
+            isOneToOne: false
+            referencedRelation: "restaurants"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "open_shift_claims_resulting_shift_id_fkey"
+            columns: ["resulting_shift_id"]
+            isOneToOne: false
+            referencedRelation: "shifts"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "open_shift_claims_shift_template_id_fkey"
+            columns: ["shift_template_id"]
+            isOneToOne: false
+            referencedRelation: "shift_templates"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       ops_inbox_item: {
         Row: {
           created_at: string
@@ -5755,6 +5840,7 @@ export type Database = {
       }
       shift_templates: {
         Row: {
+          area: string | null
           break_duration: number
           capacity: number
           created_at: string | null
@@ -5769,6 +5855,7 @@ export type Database = {
           updated_at: string | null
         }
         Insert: {
+          area?: string | null
           break_duration?: number
           capacity?: number
           created_at?: string | null
@@ -5783,6 +5870,7 @@ export type Database = {
           updated_at?: string | null
         }
         Update: {
+          area?: string | null
           break_duration?: number
           capacity?: number
           created_at?: string | null
@@ -7050,6 +7138,8 @@ export type Database = {
           manual_projections: Json | null
           min_crew: Json | null
           min_staff: number
+          open_shifts_enabled: boolean
+          require_shift_claim_approval: boolean
           restaurant_id: string
           target_labor_pct: number
           target_splh: number
@@ -7063,6 +7153,8 @@ export type Database = {
           manual_projections?: Json | null
           min_crew?: Json | null
           min_staff?: number
+          open_shifts_enabled?: boolean
+          require_shift_claim_approval?: boolean
           restaurant_id: string
           target_labor_pct?: number
           target_splh?: number
@@ -7076,6 +7168,8 @@ export type Database = {
           manual_projections?: Json | null
           min_crew?: Json | null
           min_staff?: number
+          open_shifts_enabled?: boolean
+          require_shift_claim_approval?: boolean
           restaurant_id?: string
           target_labor_pct?: number
           target_splh?: number
@@ -9086,6 +9180,10 @@ export type Database = {
         }
         Returns: Json
       }
+      approve_open_shift_claim: {
+        Args: { p_claim_id: string; p_reviewer_note?: string }
+        Returns: Json
+      }
       approve_shift_trade: {
         Args: {
           p_manager_note?: string
@@ -9236,6 +9334,15 @@ export type Database = {
       claim_check_numbers_for_account: {
         Args: { p_account_id: string; p_count?: number }
         Returns: number
+      }
+      claim_open_shift: {
+        Args: {
+          p_employee_id: string
+          p_restaurant_id: string
+          p_shift_date: string
+          p_template_id: string
+        }
+        Returns: Json
       }
       cleanup_expired_invitations: { Args: never; Returns: undefined }
       cleanup_old_audit_logs: { Args: never; Returns: undefined }
@@ -9569,6 +9676,26 @@ export type Database = {
           tips: number
         }[]
       }
+      get_open_shifts: {
+        Args: {
+          p_restaurant_id: string
+          p_week_end: string
+          p_week_start: string
+        }
+        Returns: {
+          area: string
+          assigned_count: number
+          capacity: number
+          end_time: string
+          open_spots: number
+          pending_claims: number
+          position: string
+          shift_date: string
+          start_time: string
+          template_id: string
+          template_name: string
+        }[]
+      }
       get_owner_restaurant_count: {
         Args: { p_user_id?: string }
         Returns: number
@@ -9842,6 +9969,10 @@ export type Database = {
       rebuild_account_balances: {
         Args: { p_restaurant_id: string }
         Returns: number
+      }
+      reject_open_shift_claim: {
+        Args: { p_claim_id: string; p_reviewer_note?: string }
+        Returns: Json
       }
       reject_shift_trade: {
         Args: {

--- a/src/lib/openShiftHelpers.ts
+++ b/src/lib/openShiftHelpers.ts
@@ -1,6 +1,18 @@
 export type CapacityStatus = 'full' | 'partial' | 'empty';
 
 /**
+ * Format a HH:MM[:SS] time string into a compact 12-hour label.
+ * Examples: "14:00" → "2p", "09:30" → "9:30a"
+ */
+export function formatCompactTime(time: string): string {
+  const [h, m] = time.split(':').map(Number);
+  const suffix = h >= 12 ? 'p' : 'a';
+  const hour12 = h % 12 || 12;
+  if (m === 0) return `${hour12}${suffix}`;
+  return `${hour12}:${String(m).padStart(2, '0')}${suffix}`;
+}
+
+/**
  * Compute how many open spots remain for a template on a given day.
  * Clamps to 0 (never negative).
  */

--- a/src/pages/AvailableShiftsPage.tsx
+++ b/src/pages/AvailableShiftsPage.tsx
@@ -367,7 +367,7 @@ export default function AvailableShiftsPage() {
                           openShift={item.openShift}
                           hasConflict={conflictMap.get(item.key) ?? false}
                           onClaim={handleClaim}
-                          isClaiming={claimMutation.isPending && claimTarget?.template_id === item.openShift.template_id}
+                          isClaiming={claimMutation.isPending && claimTarget?.template_id === item.openShift.template_id && claimTarget?.shift_date === item.openShift.shift_date}
                         />
                       ) : item.type === 'trade' && item.trade ? (
                         <TradeCard

--- a/src/pages/AvailableShiftsPage.tsx
+++ b/src/pages/AvailableShiftsPage.tsx
@@ -1,0 +1,450 @@
+import { useState, useMemo, useCallback, useRef } from 'react';
+import { Link } from 'react-router-dom';
+import { useVirtualizer } from '@tanstack/react-virtual';
+
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Badge } from '@/components/ui/badge';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+
+import {
+  Briefcase,
+  Calendar,
+  Clock,
+  MapPin,
+  User,
+  ChevronDown,
+  ChevronUp,
+  CheckCircle,
+  XCircle,
+  ArrowRightLeft,
+} from 'lucide-react';
+
+import { useRestaurantContext } from '@/contexts/RestaurantContext';
+import { useCurrentEmployee } from '@/hooks/useCurrentEmployee';
+import { useAvailableShifts, AvailableShiftItem } from '@/hooks/useAvailableShifts';
+import { useOpenShiftClaims, useClaimOpenShift } from '@/hooks/useOpenShiftClaims';
+import { useShifts } from '@/hooks/useShifts';
+import { useAcceptShiftTrade } from '@/hooks/useShiftTrades';
+import { useToast } from '@/hooks/use-toast';
+import {
+  EmployeePageHeader,
+  NoRestaurantState,
+  EmployeePageSkeleton,
+  EmployeeNotLinkedState,
+} from '@/components/employee';
+import { OpenShiftCard } from '@/components/scheduling/OpenShiftCard';
+import { ClaimConfirmDialog } from '@/components/scheduling/ClaimConfirmDialog';
+
+import type { OpenShift, OpenShiftClaim } from '@/types/scheduling';
+
+import { format, parseISO, startOfWeek, addDays } from 'date-fns';
+import { WEEK_STARTS_ON } from '@/lib/dateConfig';
+import { cn } from '@/lib/utils';
+
+// ---- Memoized trade card (no hooks) ----
+
+interface TradeCardProps {
+  trade: AvailableShiftItem['trade'] & Record<string, unknown>;
+  onAccept: (tradeId: string) => void;
+  isAccepting: boolean;
+  currentEmployeeId: string;
+}
+
+function formatTradeTime(startTime: string, endTime: string): string {
+  const start = parseISO(startTime);
+  const end = parseISO(endTime);
+  return `${format(start, 'h:mm a')} - ${format(end, 'h:mm a')}`;
+}
+
+import { memo } from 'react';
+
+const TradeCard = memo(function TradeCard({
+  trade,
+  onAccept,
+  isAccepting,
+  currentEmployeeId,
+}: TradeCardProps) {
+  if (!trade?.offered_shift) return null;
+
+  const shiftStart = parseISO(trade.offered_shift.start_time);
+  const isPast = shiftStart < new Date();
+  const dateLabel = format(shiftStart, 'EEE, MMM d');
+  const timeLabel = formatTradeTime(trade.offered_shift.start_time, trade.offered_shift.end_time);
+
+  return (
+    <div
+      className={cn(
+        'group flex items-center justify-between p-4 rounded-xl border border-border/40 bg-background hover:border-border transition-colors',
+        isPast && 'opacity-60',
+      )}
+    >
+      <div className="min-w-0 space-y-1.5">
+        <span className="text-[11px] px-1.5 py-0.5 rounded-md bg-amber-500/10 text-amber-600 font-medium">
+          SHIFT TRADE
+        </span>
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[13px] text-muted-foreground">
+          <span className="flex items-center gap-1">
+            <Calendar className="h-3.5 w-3.5" aria-hidden="true" />
+            {dateLabel}
+          </span>
+          <span className="flex items-center gap-1">
+            <Clock className="h-3.5 w-3.5" aria-hidden="true" />
+            {timeLabel}
+          </span>
+          <span className="flex items-center gap-1">
+            <MapPin className="h-3.5 w-3.5" aria-hidden="true" />
+            {trade.offered_shift.position}
+          </span>
+        </div>
+        <div className="flex items-center gap-1.5 text-[13px] text-muted-foreground">
+          <User className="h-3.5 w-3.5" aria-hidden="true" />
+          <span>From: {trade.offered_by?.name ?? 'Unknown'}</span>
+        </div>
+        {trade.reason && (
+          <div className="text-[12px] text-muted-foreground italic">{trade.reason}</div>
+        )}
+      </div>
+
+      <div className="ml-4 flex-shrink-0">
+        {trade.status === 'pending_approval' ? (
+          <span className="text-[11px] px-1.5 py-0.5 rounded-md bg-amber-500/10 text-amber-600 font-medium">
+            Pending Approval
+          </span>
+        ) : (
+          <Button
+            onClick={() => onAccept(trade.id)}
+            disabled={isPast || isAccepting}
+            className="h-9 px-4 rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium"
+            aria-label={`Accept trade from ${trade.offered_by?.name ?? 'teammate'} on ${dateLabel}`}
+          >
+            {isAccepting ? 'Accepting...' : 'Accept'}
+          </Button>
+        )}
+        {trade.target_employee_id === currentEmployeeId && (
+          <div className="text-[11px] text-muted-foreground mt-1">Offered to you</div>
+        )}
+      </div>
+    </div>
+  );
+}, (prev, next) => {
+  return (
+    prev.trade?.id === next.trade?.id &&
+    prev.trade?.status === next.trade?.status &&
+    prev.isAccepting === next.isAccepting &&
+    prev.currentEmployeeId === next.currentEmployeeId
+  );
+});
+
+// ---- Claim status badge ----
+
+function claimStatusBadge(status: OpenShiftClaim['status']) {
+  switch (status) {
+    case 'approved':
+      return (
+        <span className="flex items-center gap-1 text-[11px] px-1.5 py-0.5 rounded-md bg-emerald-500/10 text-emerald-600 font-medium">
+          <CheckCircle className="h-3 w-3" aria-hidden="true" />
+          Approved
+        </span>
+      );
+    case 'rejected':
+      return (
+        <span className="flex items-center gap-1 text-[11px] px-1.5 py-0.5 rounded-md bg-destructive/10 text-destructive font-medium">
+          <XCircle className="h-3 w-3" aria-hidden="true" />
+          Rejected
+        </span>
+      );
+    case 'cancelled':
+      return (
+        <span className="text-[11px] px-1.5 py-0.5 rounded-md bg-muted text-muted-foreground font-medium">
+          Cancelled
+        </span>
+      );
+    default:
+      return (
+        <span className="flex items-center gap-1 text-[11px] px-1.5 py-0.5 rounded-md bg-amber-500/10 text-amber-600 font-medium">
+          <Clock className="h-3 w-3" aria-hidden="true" />
+          Pending
+        </span>
+      );
+  }
+}
+
+// ---- Main page ----
+
+export default function AvailableShiftsPage() {
+  const { selectedRestaurant } = useRestaurantContext();
+  const restaurantId = selectedRestaurant?.restaurant_id ?? null;
+  const { currentEmployee, loading: empLoading } = useCurrentEmployee(restaurantId);
+  const { toast } = useToast();
+
+  // Compute 2-week range (current + next)
+  const { weekStart, weekEnd } = useMemo(() => {
+    const now = new Date();
+    const start = startOfWeek(now, { weekStartsOn: WEEK_STARTS_ON as 0 | 1 | 2 | 3 | 4 | 5 | 6 });
+    const end = addDays(start, 13); // 2 weeks
+    return { weekStart: start, weekEnd: end };
+  }, []);
+
+  const { items, loading: feedLoading } = useAvailableShifts(
+    restaurantId,
+    currentEmployee?.id ?? null,
+    weekStart,
+    weekEnd,
+  );
+  const { claims, loading: claimsLoading } = useOpenShiftClaims(restaurantId, currentEmployee?.id);
+  const claimMutation = useClaimOpenShift();
+  const { mutate: acceptTrade, isPending: isAcceptingTrade } = useAcceptShiftTrade();
+
+  // Employee's existing shifts for conflict detection
+  const { shifts: myShifts } = useShifts(restaurantId, weekStart, weekEnd);
+  const employeeShifts = useMemo(() => {
+    if (!currentEmployee) return [];
+    return myShifts.filter((s) => s.employee_id === currentEmployee.id && s.status !== 'cancelled');
+  }, [myShifts, currentEmployee]);
+
+  // Conflict map: template_id-date -> boolean
+  const conflictMap = useMemo(() => {
+    const map = new Map<string, boolean>();
+    for (const item of items) {
+      if (item.type !== 'open_shift' || !item.openShift) continue;
+      const os = item.openShift;
+      const shiftDate = os.shift_date; // YYYY-MM-DD
+      const [startH, startM] = os.start_time.split(':').map(Number);
+      const [endH, endM] = os.end_time.split(':').map(Number);
+
+      const osStart = startH * 60 + startM;
+      const osEnd = endH * 60 + endM;
+
+      const hasConflict = employeeShifts.some((s) => {
+        const sDate = s.start_time.split('T')[0];
+        if (sDate !== shiftDate) return false;
+        const sStart = new Date(s.start_time);
+        const sEnd = new Date(s.end_time);
+        const sStartMin = sStart.getHours() * 60 + sStart.getMinutes();
+        const sEndMin = sEnd.getHours() * 60 + sEnd.getMinutes();
+        return sStartMin < osEnd && sEndMin > osStart;
+      });
+
+      map.set(item.key, hasConflict);
+    }
+    return map;
+  }, [items, employeeShifts]);
+
+  // Claim dialog state (single dialog pattern)
+  const [claimTarget, setClaimTarget] = useState<OpenShift | null>(null);
+
+  const handleClaim = useCallback((openShift: OpenShift) => {
+    setClaimTarget(openShift);
+  }, []);
+
+  const handleConfirmClaim = useCallback(async () => {
+    if (!claimTarget || !restaurantId || !currentEmployee) return;
+    await claimMutation.mutateAsync({
+      restaurantId,
+      templateId: claimTarget.template_id,
+      shiftDate: claimTarget.shift_date,
+      employeeId: currentEmployee.id,
+    });
+    setClaimTarget(null);
+  }, [claimTarget, restaurantId, currentEmployee, claimMutation]);
+
+  const [acceptingTradeId, setAcceptingTradeId] = useState<string | null>(null);
+
+  const handleAcceptTrade = useCallback((tradeId: string) => {
+    if (!currentEmployee?.id) return;
+    setAcceptingTradeId(tradeId);
+    acceptTrade(
+      { tradeId, acceptingEmployeeId: currentEmployee.id },
+      {
+        onSuccess: () => {
+          toast({ title: 'Trade accepted', description: 'Your manager will review the trade.' });
+          setAcceptingTradeId(null);
+        },
+        onError: (error) => {
+          toast({ title: 'Failed to accept trade', description: error.message, variant: 'destructive' });
+          setAcceptingTradeId(null);
+        },
+      },
+    );
+  }, [currentEmployee, acceptTrade, toast]);
+
+  // Claims collapsible
+  const [claimsOpen, setClaimsOpen] = useState(false);
+
+  // Virtualized list
+  const parentRef = useRef<HTMLDivElement>(null);
+  const virtualizer = useVirtualizer({
+    count: items.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 100,
+    overscan: 5,
+  });
+
+  // Early returns
+  if (!selectedRestaurant) return <NoRestaurantState />;
+  if (empLoading) return <EmployeePageSkeleton />;
+  if (!currentEmployee) return <EmployeeNotLinkedState />;
+
+  const loading = feedLoading;
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row gap-4 justify-between items-start sm:items-center">
+        <EmployeePageHeader
+          icon={Briefcase}
+          title="Available Shifts"
+          subtitle="Open shifts and trades you can pick up"
+        />
+        <Link to="/employee/schedule" className="w-full sm:w-auto">
+          <Button variant="outline" className="w-full sm:w-auto border-primary/20 hover:bg-primary/5">
+            <Calendar className="h-4 w-4 mr-2" aria-hidden="true" />
+            My Schedule
+          </Button>
+        </Link>
+      </div>
+
+      {/* Feed */}
+      <div className="space-y-3">
+        <div className="flex items-center gap-2">
+          <h2 className="text-[17px] font-semibold text-foreground">Shifts Available</h2>
+          {!loading && (
+            <span className="text-[11px] px-1.5 py-0.5 rounded-md bg-muted font-medium">
+              {items.length}
+            </span>
+          )}
+        </div>
+
+        {loading ? (
+          <div className="space-y-3">
+            <Skeleton className="h-[100px] w-full rounded-xl" />
+            <Skeleton className="h-[100px] w-full rounded-xl" />
+            <Skeleton className="h-[100px] w-full rounded-xl" />
+          </div>
+        ) : items.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-16 text-center">
+            <Briefcase className="h-12 w-12 text-muted-foreground mb-4" aria-hidden="true" />
+            <h3 className="text-[14px] font-medium text-foreground mb-1">No shifts available</h3>
+            <p className="text-[13px] text-muted-foreground max-w-sm">
+              There are currently no open shifts or trades. Check back later.
+            </p>
+          </div>
+        ) : (
+          <div
+            ref={parentRef}
+            className="max-h-[60vh] overflow-y-auto"
+          >
+            <div
+              style={{
+                height: `${virtualizer.getTotalSize()}px`,
+                width: '100%',
+                position: 'relative',
+              }}
+            >
+              {virtualizer.getVirtualItems().map((virtualRow) => {
+                const item = items[virtualRow.index];
+                return (
+                  <div
+                    key={item.key}
+                    data-index={virtualRow.index}
+                    ref={virtualizer.measureElement}
+                    style={{
+                      position: 'absolute',
+                      top: 0,
+                      left: 0,
+                      width: '100%',
+                      transform: `translateY(${virtualRow.start}px)`,
+                    }}
+                  >
+                    <div className="pb-3">
+                      {item.type === 'open_shift' && item.openShift ? (
+                        <OpenShiftCard
+                          openShift={item.openShift}
+                          hasConflict={conflictMap.get(item.key) ?? false}
+                          onClaim={handleClaim}
+                          isClaiming={claimMutation.isPending && claimTarget?.template_id === item.openShift.template_id}
+                        />
+                      ) : item.type === 'trade' && item.trade ? (
+                        <TradeCard
+                          trade={item.trade as TradeCardProps['trade']}
+                          onAccept={handleAcceptTrade}
+                          isAccepting={isAcceptingTrade && acceptingTradeId === item.trade.id}
+                          currentEmployeeId={currentEmployee.id}
+                        />
+                      ) : null}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* My Claims section */}
+      {!claimsLoading && claims.length > 0 && (
+        <Collapsible open={claimsOpen} onOpenChange={setClaimsOpen}>
+          <CollapsibleTrigger asChild>
+            <button
+              className="flex items-center gap-2 w-full text-left"
+              aria-label={claimsOpen ? 'Collapse my claims' : 'Expand my claims'}
+            >
+              <h2 className="text-[17px] font-semibold text-foreground">My Claims</h2>
+              <span className="text-[11px] px-1.5 py-0.5 rounded-md bg-muted font-medium">
+                {claims.length}
+              </span>
+              {claimsOpen ? (
+                <ChevronUp className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+              ) : (
+                <ChevronDown className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+              )}
+            </button>
+          </CollapsibleTrigger>
+          <CollapsibleContent className="mt-3 space-y-2">
+            {claims.map((claim) => (
+              <div
+                key={claim.id}
+                className="flex items-center justify-between p-3 rounded-xl border border-border/40 bg-background"
+              >
+                <div className="min-w-0 space-y-1">
+                  <div className="text-[14px] font-medium text-foreground">
+                    {(claim as any).shift_template?.name ?? 'Shift'}
+                  </div>
+                  <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[13px] text-muted-foreground">
+                    <span className="flex items-center gap-1">
+                      <Calendar className="h-3.5 w-3.5" aria-hidden="true" />
+                      {format(parseISO(claim.shift_date), 'EEE, MMM d')}
+                    </span>
+                    {(claim as any).shift_template && (
+                      <span className="flex items-center gap-1">
+                        <MapPin className="h-3.5 w-3.5" aria-hidden="true" />
+                        {(claim as any).shift_template.position}
+                      </span>
+                    )}
+                  </div>
+                </div>
+                <div className="ml-4 flex-shrink-0">
+                  {claimStatusBadge(claim.status)}
+                </div>
+              </div>
+            ))}
+          </CollapsibleContent>
+        </Collapsible>
+      )}
+
+      {/* Claim confirmation dialog */}
+      <ClaimConfirmDialog
+        open={!!claimTarget}
+        onOpenChange={(open) => { if (!open) setClaimTarget(null); }}
+        openShift={claimTarget}
+        onConfirm={handleConfirmClaim}
+        isPending={claimMutation.isPending}
+      />
+    </div>
+  );
+}

--- a/src/pages/AvailableShiftsPage.tsx
+++ b/src/pages/AvailableShiftsPage.tsx
@@ -4,7 +4,6 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Badge } from '@/components/ui/badge';
 import {
   Collapsible,
   CollapsibleContent,
@@ -21,7 +20,6 @@ import {
   ChevronUp,
   CheckCircle,
   XCircle,
-  ArrowRightLeft,
 } from 'lucide-react';
 
 import { useRestaurantContext } from '@/contexts/RestaurantContext';

--- a/src/pages/Scheduling.tsx
+++ b/src/pages/Scheduling.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { DndContext, DragOverlay } from '@dnd-kit/core';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -48,6 +49,7 @@ import { useCopyWeekShifts } from '@/hooks/useCopyWeekShifts';
 import { getMondayOfWeek, computeHoursPerEmployee, buildTemplateGridData } from '@/hooks/useShiftPlanner';
 import { useShiftTemplates, templateAppliesToDay } from '@/hooks/useShiftTemplates';
 import { computeOpenSpots } from '@/lib/openShiftHelpers';
+import { useStaffingSettings } from '@/hooks/useStaffingSettings';
 import { formatLocalDate } from '@/lib/shiftInterval';
 import { RecurringShiftActionDialog, RecurringActionType } from '@/components/scheduling/RecurringShiftActionDialog';
 import { isRecurringShift, RecurringActionScope } from '@/utils/recurringShiftHelpers';
@@ -318,9 +320,11 @@ const ShiftCard = ({ shift, onEdit, onDelete, isSelected, selectionMode: cardSel
 };
 
 const Scheduling = () => {
+  const navigate = useNavigate();
   const { selectedRestaurant } = useRestaurantContext();
   const restaurantId = selectedRestaurant?.restaurant_id || null;
   const restaurantTimezone = selectedRestaurant?.restaurant?.timezone || 'UTC';
+  const { effectiveSettings: staffingSettings } = useStaffingSettings(restaurantId);
 
   const [currentWeekStart, setCurrentWeekStart] = useState(startOfWeek(new Date(), { weekStartsOn: 1 }));
   const [employeeDialogOpen, setEmployeeDialogOpen] = useState(false);
@@ -1862,6 +1866,8 @@ const Scheduling = () => {
         employeeCount={scheduledEmployeeCount}
         totalHours={totalScheduledHours}
         openShiftCount={openShiftCount}
+        openShiftsEnabled={staffingSettings.open_shifts_enabled}
+        onNavigateToSettings={() => navigate('/settings?tab=staffing')}
         onConfirm={handlePublishSchedule}
         isPublishing={publishSchedule.isPending}
       />

--- a/src/types/scheduling.ts
+++ b/src/types/scheduling.ts
@@ -279,6 +279,8 @@ export interface StaffingSettings {
   lookback_weeks: number;
   manual_projections: ManualProjections | null;
   min_crew: MinCrew | null;
+  open_shifts_enabled: boolean;
+  require_shift_claim_approval: boolean;
   created_at: string;
   updated_at: string;
 }
@@ -336,4 +338,32 @@ export interface ApplyTemplateResult {
   inserted_count: number;
   skipped_count: number;
   deleted_count: number;
+}
+
+export interface OpenShiftClaim {
+  id: string;
+  restaurant_id: string;
+  shift_template_id: string;
+  shift_date: string;
+  claimed_by_employee_id: string;
+  status: 'pending_approval' | 'approved' | 'rejected' | 'cancelled';
+  resulting_shift_id: string | null;
+  reviewed_by: string | null;
+  reviewed_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface OpenShift {
+  template_id: string;
+  template_name: string;
+  shift_date: string;
+  start_time: string;
+  end_time: string;
+  position: string;
+  area: string | null;
+  capacity: number;
+  assigned_count: number;
+  pending_claims: number;
+  open_spots: number;
 }

--- a/supabase/migrations/20260412145842_open_shift_claims.sql
+++ b/supabase/migrations/20260412145842_open_shift_claims.sql
@@ -1,0 +1,475 @@
+-- ============================================================================
+-- Open Shift Claims: table, settings columns, RLS, and RPC functions
+-- ============================================================================
+
+-- A) CREATE TABLE open_shift_claims
+CREATE TABLE IF NOT EXISTS public.open_shift_claims (
+    id UUID DEFAULT gen_random_uuid() NOT NULL PRIMARY KEY,
+    restaurant_id UUID NOT NULL REFERENCES public.restaurants(id) ON DELETE CASCADE,
+    shift_template_id UUID NOT NULL REFERENCES public.shift_templates(id) ON DELETE CASCADE,
+    shift_date DATE NOT NULL,
+    claimed_by_employee_id UUID NOT NULL REFERENCES public.employees(id) ON DELETE CASCADE,
+    status TEXT NOT NULL DEFAULT 'approved'
+        CHECK (status IN ('pending_approval', 'approved', 'rejected', 'cancelled')),
+    resulting_shift_id UUID REFERENCES public.shifts(id) ON DELETE SET NULL,
+    reviewed_by UUID REFERENCES auth.users(id) ON DELETE SET NULL,
+    reviewed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ DEFAULT now() NOT NULL,
+    updated_at TIMESTAMPTZ DEFAULT now() NOT NULL
+);
+
+-- Partial unique index: one active claim per employee per template+date
+CREATE UNIQUE INDEX idx_open_shift_claims_unique_active
+    ON public.open_shift_claims (shift_template_id, shift_date, claimed_by_employee_id)
+    WHERE status IN ('pending_approval', 'approved');
+
+-- Lookup indexes
+CREATE INDEX idx_open_shift_claims_restaurant ON public.open_shift_claims (restaurant_id);
+CREATE INDEX idx_open_shift_claims_employee ON public.open_shift_claims (claimed_by_employee_id);
+CREATE INDEX idx_open_shift_claims_restaurant_status ON public.open_shift_claims (restaurant_id, status);
+
+-- Enable RLS
+ALTER TABLE public.open_shift_claims ENABLE ROW LEVEL SECURITY;
+
+-- updated_at trigger
+CREATE TRIGGER update_open_shift_claims_updated_at
+    BEFORE UPDATE ON public.open_shift_claims
+    FOR EACH ROW
+    EXECUTE FUNCTION public.update_updated_at_column();
+
+-- B) ALTER TABLE staffing_settings: add open shift settings
+ALTER TABLE public.staffing_settings
+    ADD COLUMN IF NOT EXISTS open_shifts_enabled BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE public.staffing_settings
+    ADD COLUMN IF NOT EXISTS require_shift_claim_approval BOOLEAN NOT NULL DEFAULT false;
+
+-- C) RLS policies on open_shift_claims
+
+-- 1. Employees view own claims
+CREATE POLICY "employees_view_own_claims" ON public.open_shift_claims
+    FOR SELECT
+    USING (
+        claimed_by_employee_id IN (
+            SELECT id FROM public.employees WHERE user_id = auth.uid()
+        )
+    );
+
+-- 2. Managers view all restaurant claims
+CREATE POLICY "managers_view_restaurant_claims" ON public.open_shift_claims
+    FOR SELECT
+    USING (
+        EXISTS (
+            SELECT 1 FROM public.user_restaurants
+            WHERE user_id = auth.uid()
+              AND restaurant_id = open_shift_claims.restaurant_id
+              AND role IN ('owner', 'manager')
+        )
+    );
+
+-- 3. Employees insert own claims
+CREATE POLICY "employees_insert_own_claims" ON public.open_shift_claims
+    FOR INSERT
+    WITH CHECK (
+        claimed_by_employee_id IN (
+            SELECT id FROM public.employees WHERE user_id = auth.uid()
+        )
+    );
+
+-- 4. Employees cancel own pending claims
+CREATE POLICY "employees_cancel_own_pending_claims" ON public.open_shift_claims
+    FOR UPDATE
+    USING (
+        status = 'pending_approval'
+        AND claimed_by_employee_id IN (
+            SELECT id FROM public.employees WHERE user_id = auth.uid()
+        )
+    )
+    WITH CHECK (
+        status = 'cancelled'
+    );
+
+-- 5. Managers review claims (approve/reject)
+CREATE POLICY "managers_review_claims" ON public.open_shift_claims
+    FOR UPDATE
+    USING (
+        EXISTS (
+            SELECT 1 FROM public.user_restaurants
+            WHERE user_id = auth.uid()
+              AND restaurant_id = open_shift_claims.restaurant_id
+              AND role IN ('owner', 'manager')
+        )
+    );
+
+-- ============================================================================
+-- D) get_open_shifts RPC
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.get_open_shifts(
+    p_restaurant_id UUID,
+    p_week_start DATE,
+    p_week_end DATE
+)
+RETURNS TABLE (
+    template_id UUID,
+    template_name TEXT,
+    shift_date DATE,
+    start_time TIME,
+    end_time TIME,
+    "position" TEXT,
+    area TEXT,
+    "capacity" INT,
+    assigned_count BIGINT,
+    pending_claims BIGINT,
+    open_spots BIGINT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+    -- Check if open shifts are enabled for this restaurant
+    IF NOT EXISTS (
+        SELECT 1 FROM public.staffing_settings
+        WHERE restaurant_id = p_restaurant_id
+          AND open_shifts_enabled = true
+    ) THEN
+        RETURN;
+    END IF;
+
+    RETURN QUERY
+    WITH published_dates AS (
+        -- Get all dates within published schedule weeks
+        SELECT DISTINCT d::date AS pub_date
+        FROM public.schedule_publications sp,
+             generate_series(
+                 GREATEST(sp.week_start_date, p_week_start),
+                 LEAST(sp.week_end_date, p_week_end),
+                 '1 day'::interval
+             ) AS d
+        WHERE sp.restaurant_id = p_restaurant_id
+          AND sp.week_start_date <= p_week_end
+          AND sp.week_end_date >= p_week_start
+    ),
+    template_days AS (
+        -- Active templates with capacity > 1 matched to published dates by day-of-week
+        SELECT
+            st.id AS tmpl_id,
+            st.name AS tmpl_name,
+            pd.pub_date,
+            st.start_time AS tmpl_start,
+            st.end_time AS tmpl_end,
+            st.position AS tmpl_position,
+            st.area AS tmpl_area,
+            st.capacity AS tmpl_capacity
+        FROM public.shift_templates st
+        CROSS JOIN published_dates pd
+        WHERE st.restaurant_id = p_restaurant_id
+          AND st.is_active = true
+          AND st.capacity > 1
+          AND EXTRACT(DOW FROM pd.pub_date)::int = ANY(st.days)
+    ),
+    assigned AS (
+        -- Count existing shifts matching template's position + time + date
+        SELECT
+            td.tmpl_id,
+            td.pub_date,
+            COUNT(s.id) AS cnt
+        FROM template_days td
+        LEFT JOIN public.shifts s
+            ON s.restaurant_id = p_restaurant_id
+            AND s.position = td.tmpl_position
+            AND (s.start_time::time) = td.tmpl_start
+            AND (s.end_time::time) = td.tmpl_end
+            AND (s.start_time::date) = td.pub_date
+            AND s.status != 'cancelled'
+        GROUP BY td.tmpl_id, td.pub_date
+    ),
+    pending AS (
+        -- Count pending claims for each template + date
+        SELECT
+            osc.shift_template_id,
+            osc.shift_date,
+            COUNT(osc.id) AS cnt
+        FROM public.open_shift_claims osc
+        WHERE osc.restaurant_id = p_restaurant_id
+          AND osc.status = 'pending_approval'
+        GROUP BY osc.shift_template_id, osc.shift_date
+    )
+    SELECT
+        td.tmpl_id,
+        td.tmpl_name,
+        td.pub_date,
+        td.tmpl_start,
+        td.tmpl_end,
+        td.tmpl_position,
+        td.tmpl_area,
+        td.tmpl_capacity,
+        COALESCE(a.cnt, 0),
+        COALESCE(p.cnt, 0),
+        (td.tmpl_capacity - COALESCE(a.cnt, 0) - COALESCE(p.cnt, 0))
+    FROM template_days td
+    LEFT JOIN assigned a ON a.tmpl_id = td.tmpl_id AND a.pub_date = td.pub_date
+    LEFT JOIN pending p ON p.shift_template_id = td.tmpl_id AND p.shift_date = td.pub_date
+    WHERE (td.tmpl_capacity - COALESCE(a.cnt, 0) - COALESCE(p.cnt, 0)) > 0
+    ORDER BY td.pub_date, td.tmpl_start;
+END;
+$$;
+
+-- ============================================================================
+-- E) claim_open_shift RPC
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.claim_open_shift(
+    p_restaurant_id UUID,
+    p_template_id UUID,
+    p_shift_date DATE,
+    p_employee_id UUID
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    v_template RECORD;
+    v_assigned_count BIGINT;
+    v_pending_count BIGINT;
+    v_requires_approval BOOLEAN;
+    v_claim_id UUID;
+    v_shift_id UUID;
+    v_shift_start TIMESTAMPTZ;
+    v_shift_end TIMESTAMPTZ;
+BEGIN
+    -- Lock and fetch the template
+    SELECT * INTO v_template
+    FROM public.shift_templates
+    WHERE id = p_template_id
+      AND restaurant_id = p_restaurant_id
+    FOR SHARE;
+
+    IF NOT FOUND THEN
+        RETURN json_build_object('success', false, 'error', 'Template not found');
+    END IF;
+
+    -- Verify day-of-week matches
+    IF NOT (EXTRACT(DOW FROM p_shift_date)::int = ANY(v_template.days)) THEN
+        RETURN json_build_object('success', false, 'error', 'Template does not apply to this day');
+    END IF;
+
+    -- Count assigned shifts for this template+date
+    SELECT COUNT(*) INTO v_assigned_count
+    FROM public.shifts
+    WHERE restaurant_id = p_restaurant_id
+      AND position = v_template.position
+      AND (start_time::time) = v_template.start_time
+      AND (end_time::time) = v_template.end_time
+      AND (start_time::date) = p_shift_date
+      AND status != 'cancelled';
+
+    -- Count pending claims
+    SELECT COUNT(*) INTO v_pending_count
+    FROM public.open_shift_claims
+    WHERE shift_template_id = p_template_id
+      AND shift_date = p_shift_date
+      AND status = 'pending_approval';
+
+    -- Check capacity
+    IF (v_assigned_count + v_pending_count) >= v_template.capacity THEN
+        RETURN json_build_object('success', false, 'error', 'No open spots available');
+    END IF;
+
+    -- Build shift timestamps from template times + shift date
+    v_shift_start := (p_shift_date || ' ' || v_template.start_time)::timestamptz;
+    v_shift_end := (p_shift_date || ' ' || v_template.end_time)::timestamptz;
+
+    -- Handle overnight shifts
+    IF v_template.end_time <= v_template.start_time THEN
+        v_shift_end := v_shift_end + interval '1 day';
+    END IF;
+
+    -- Check for schedule conflict with existing employee shifts
+    IF EXISTS (
+        SELECT 1 FROM public.shifts
+        WHERE employee_id = p_employee_id
+          AND restaurant_id = p_restaurant_id
+          AND status != 'cancelled'
+          AND (start_time, end_time) OVERLAPS (v_shift_start, v_shift_end)
+    ) THEN
+        RETURN json_build_object('success', false, 'error', 'Schedule conflict with existing shift');
+    END IF;
+
+    -- Check approval setting
+    SELECT COALESCE(require_shift_claim_approval, false) INTO v_requires_approval
+    FROM public.staffing_settings
+    WHERE restaurant_id = p_restaurant_id;
+
+    IF v_requires_approval IS NULL THEN
+        v_requires_approval := false;
+    END IF;
+
+    IF NOT v_requires_approval THEN
+        -- Instant approval: create the shift and the claim
+        INSERT INTO public.shifts (
+            restaurant_id, employee_id, start_time, end_time,
+            break_duration, position, status, source, is_published
+        ) VALUES (
+            p_restaurant_id, p_employee_id, v_shift_start, v_shift_end,
+            v_template.break_duration, v_template.position, 'scheduled', 'template', true
+        )
+        RETURNING id INTO v_shift_id;
+
+        INSERT INTO public.open_shift_claims (
+            restaurant_id, shift_template_id, shift_date,
+            claimed_by_employee_id, status, resulting_shift_id
+        ) VALUES (
+            p_restaurant_id, p_template_id, p_shift_date,
+            p_employee_id, 'approved', v_shift_id
+        )
+        RETURNING id INTO v_claim_id;
+
+        RETURN json_build_object(
+            'success', true,
+            'claim_id', v_claim_id,
+            'shift_id', v_shift_id,
+            'status', 'approved',
+            'message', 'Shift claimed and added to your schedule'
+        );
+    ELSE
+        -- Requires approval: just create the claim
+        INSERT INTO public.open_shift_claims (
+            restaurant_id, shift_template_id, shift_date,
+            claimed_by_employee_id, status
+        ) VALUES (
+            p_restaurant_id, p_template_id, p_shift_date,
+            p_employee_id, 'pending_approval'
+        )
+        RETURNING id INTO v_claim_id;
+
+        RETURN json_build_object(
+            'success', true,
+            'claim_id', v_claim_id,
+            'status', 'pending_approval',
+            'message', 'Claim submitted for manager approval'
+        );
+    END IF;
+END;
+$$;
+
+-- ============================================================================
+-- F) approve_open_shift_claim RPC
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.approve_open_shift_claim(
+    p_claim_id UUID,
+    p_reviewer_note TEXT DEFAULT NULL
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    v_claim RECORD;
+    v_template RECORD;
+    v_shift_id UUID;
+    v_shift_start TIMESTAMPTZ;
+    v_shift_end TIMESTAMPTZ;
+BEGIN
+    -- Lock the claim
+    SELECT * INTO v_claim
+    FROM public.open_shift_claims
+    WHERE id = p_claim_id
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RETURN json_build_object('success', false, 'error', 'Claim not found');
+    END IF;
+
+    IF v_claim.status != 'pending_approval' THEN
+        RETURN json_build_object('success', false, 'error', 'Claim is not pending approval');
+    END IF;
+
+    -- Get the template
+    SELECT * INTO v_template
+    FROM public.shift_templates
+    WHERE id = v_claim.shift_template_id;
+
+    IF NOT FOUND THEN
+        RETURN json_build_object('success', false, 'error', 'Template not found');
+    END IF;
+
+    -- Build shift timestamps
+    v_shift_start := (v_claim.shift_date || ' ' || v_template.start_time)::timestamptz;
+    v_shift_end := (v_claim.shift_date || ' ' || v_template.end_time)::timestamptz;
+
+    IF v_template.end_time <= v_template.start_time THEN
+        v_shift_end := v_shift_end + interval '1 day';
+    END IF;
+
+    -- Create the shift
+    INSERT INTO public.shifts (
+        restaurant_id, employee_id, start_time, end_time,
+        break_duration, position, status, source, is_published
+    ) VALUES (
+        v_claim.restaurant_id, v_claim.claimed_by_employee_id,
+        v_shift_start, v_shift_end,
+        v_template.break_duration, v_template.position, 'scheduled', 'template', true
+    )
+    RETURNING id INTO v_shift_id;
+
+    -- Update the claim
+    UPDATE public.open_shift_claims
+    SET status = 'approved',
+        resulting_shift_id = v_shift_id,
+        reviewed_by = auth.uid(),
+        reviewed_at = now()
+    WHERE id = p_claim_id;
+
+    RETURN json_build_object(
+        'success', true,
+        'shift_id', v_shift_id,
+        'message', 'Claim approved and shift created'
+    );
+END;
+$$;
+
+-- ============================================================================
+-- G) reject_open_shift_claim RPC
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.reject_open_shift_claim(
+    p_claim_id UUID,
+    p_reviewer_note TEXT DEFAULT NULL
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    v_claim RECORD;
+BEGIN
+    SELECT * INTO v_claim
+    FROM public.open_shift_claims
+    WHERE id = p_claim_id
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RETURN json_build_object('success', false, 'error', 'Claim not found');
+    END IF;
+
+    IF v_claim.status != 'pending_approval' THEN
+        RETURN json_build_object('success', false, 'error', 'Claim is not pending approval');
+    END IF;
+
+    UPDATE public.open_shift_claims
+    SET status = 'rejected',
+        reviewed_by = auth.uid(),
+        reviewed_at = now()
+    WHERE id = p_claim_id;
+
+    RETURN json_build_object(
+        'success', true,
+        'message', 'Claim rejected'
+    );
+END;
+$$;
+
+-- H) Grant execute on all functions to authenticated
+GRANT EXECUTE ON FUNCTION public.get_open_shifts(UUID, DATE, DATE) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.claim_open_shift(UUID, UUID, DATE, UUID) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.approve_open_shift_claim(UUID, TEXT) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.reject_open_shift_claim(UUID, TEXT) TO authenticated;

--- a/supabase/tests/open_shift_claims.test.sql
+++ b/supabase/tests/open_shift_claims.test.sql
@@ -1,0 +1,25 @@
+BEGIN;
+SELECT plan(12);
+
+-- 1. Table exists
+SELECT has_table('public', 'open_shift_claims', 'open_shift_claims table should exist');
+
+-- 2-7. Required columns exist
+SELECT has_column('public', 'open_shift_claims', 'id', 'should have id column');
+SELECT has_column('public', 'open_shift_claims', 'restaurant_id', 'should have restaurant_id column');
+SELECT has_column('public', 'open_shift_claims', 'shift_template_id', 'should have shift_template_id column');
+SELECT has_column('public', 'open_shift_claims', 'shift_date', 'should have shift_date column');
+SELECT has_column('public', 'open_shift_claims', 'claimed_by_employee_id', 'should have claimed_by_employee_id column');
+SELECT col_default_is('public', 'open_shift_claims', 'status', 'approved', 'status should default to approved');
+
+-- 8-9. Settings columns on staffing_settings
+SELECT has_column('public', 'staffing_settings', 'open_shifts_enabled', 'staffing_settings should have open_shifts_enabled');
+SELECT has_column('public', 'staffing_settings', 'require_shift_claim_approval', 'staffing_settings should have require_shift_claim_approval');
+
+-- 10-12. RPC functions exist
+SELECT has_function('public', 'get_open_shifts', ARRAY['uuid', 'date', 'date'], 'get_open_shifts function should exist');
+SELECT has_function('public', 'claim_open_shift', ARRAY['uuid', 'uuid', 'date', 'uuid'], 'claim_open_shift function should exist');
+SELECT has_function('public', 'approve_open_shift_claim', ARRAY['uuid', 'text'], 'approve_open_shift_claim function should exist');
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/tests/e2e/open-shift-claiming.spec.ts
+++ b/tests/e2e/open-shift-claiming.spec.ts
@@ -1,0 +1,167 @@
+import { test, expect } from '@playwright/test';
+import { signUpAndCreateRestaurant, exposeSupabaseHelpers, generateTestUser } from '../helpers/e2e-supabase';
+
+test.describe('Open Shift Claiming', () => {
+  test('employee can claim an open shift', async ({ page }) => {
+    // 1. Sign up manager, create restaurant
+    const testUser = generateTestUser('open-shift');
+    await signUpAndCreateRestaurant(page, testUser);
+    await exposeSupabaseHelpers(page);
+
+    const restaurantId = await page.evaluate(() => (window as any).__getRestaurantId());
+    expect(restaurantId).toBeTruthy();
+
+    // 2. Seed all required data
+    await page.evaluate(async (restId: string) => {
+      const supabase = (window as any).__supabase;
+
+      // Enable open shifts in staffing settings
+      const { error: settingsError } = await supabase
+        .from('staffing_settings')
+        .upsert(
+          {
+            restaurant_id: restId,
+            open_shifts_enabled: true,
+            require_shift_claim_approval: false,
+          },
+          { onConflict: 'restaurant_id' }
+        );
+      if (settingsError) throw new Error(`staffing_settings upsert failed: ${settingsError.message}`);
+
+      // Create a shift template with capacity=3
+      const { data: template, error: templateError } = await supabase
+        .from('shift_templates')
+        .insert({
+          restaurant_id: restId,
+          name: 'Closing Server',
+          start_time: '16:00:00',
+          end_time: '22:00:00',
+          position: 'Server',
+          capacity: 3,
+          days: [1, 2, 3, 4, 5], // Mon-Fri
+          is_active: true,
+        })
+        .select()
+        .single();
+      if (templateError) throw new Error(`shift_templates insert failed: ${templateError.message}`);
+
+      // Compute current week dates (Mon-Sun)
+      const now = new Date();
+      const day = now.getDay();
+      const diff = day === 0 ? -6 : 1 - day;
+      const monday = new Date(now.getFullYear(), now.getMonth(), now.getDate() + diff);
+      const sunday = new Date(monday);
+      sunday.setDate(monday.getDate() + 6);
+
+      const pad = (n: number) => String(n).padStart(2, '0');
+      const toDateStr = (d: Date) =>
+        `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+
+      const mondayStr = toDateStr(monday);
+      const sundayStr = toDateStr(sunday);
+
+      // Get auth user to use as published_by
+      const { data: { user } } = await supabase.auth.getUser();
+      const userId = user?.id;
+      if (!userId) throw new Error('No authenticated user found');
+
+      // Publish the current week schedule
+      const { error: pubError } = await supabase
+        .from('schedule_publications')
+        .insert({
+          restaurant_id: restId,
+          week_start_date: mondayStr,
+          week_end_date: sundayStr,
+          published_by: userId,
+          shift_count: 0,
+        });
+      if (pubError) throw new Error(`schedule_publications insert failed: ${pubError.message}`);
+
+      // Create employee linked to the current user so useCurrentEmployee can find them
+      const { error: empError } = await supabase
+        .from('employees')
+        .insert({
+          restaurant_id: restId,
+          user_id: userId,
+          name: 'Test Employee',
+          position: 'Server',
+          status: 'active',
+          is_active: true,
+          compensation_type: 'hourly',
+          hourly_rate: 1500,
+        });
+      if (empError) throw new Error(`employees insert failed: ${empError.message}`);
+
+      return { templateId: template.id, mondayStr, sundayStr };
+    }, restaurantId as string);
+
+    // Change role to staff so employee routes are accessible
+    await page.evaluate(async () => {
+      const supabase = (window as any).__supabase;
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user?.id) throw new Error('No user session');
+      const restaurantId = await (window as any).__getRestaurantId(user.id);
+      const { error } = await supabase
+        .from('user_restaurants')
+        .update({ role: 'staff' })
+        .eq('user_id', user.id)
+        .eq('restaurant_id', restaurantId);
+      if (error) throw new Error(`Failed to set role to staff: ${error.message}`);
+    });
+
+    // 3. Navigate to /employee/shifts
+    await page.goto('/employee/shifts');
+    await page.waitForURL(/\/employee\/shifts/, { timeout: 10000 });
+
+    // 4. Wait for the "Available Shifts" header to confirm page loaded
+    await expect(page.getByText('Available Shifts')).toBeVisible({ timeout: 15000 });
+
+    // 5. Wait for feed to populate — look for OPEN SHIFT badge or template name
+    // The page shows a loading skeleton first, then populates from the RPC
+    await expect(page.getByText('OPEN SHIFT').first()).toBeVisible({ timeout: 15000 });
+
+    // 6. Verify the template name is visible on the open shift card
+    await expect(page.getByText('Closing Server').first()).toBeVisible({ timeout: 5000 });
+
+    // 7. Click "Claim" on the first open shift card that has a Claim button
+    // (Some cards may show "Schedule conflict" instead of Claim button)
+    const claimButton = page.getByRole('button', { name: /claim shift closing server/i }).first();
+    await expect(claimButton).toBeVisible({ timeout: 10000 });
+    await claimButton.click();
+
+    // 8. Wait for the confirmation dialog
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+    await expect(dialog.getByText('Claim Shift')).toBeVisible();
+
+    // 9. Click "Confirm" in the dialog
+    const confirmButton = dialog.getByRole('button', { name: /confirm/i });
+    await expect(confirmButton).toBeVisible();
+
+    // Wait for the RPC response after clicking confirm
+    const claimResponsePromise = page.waitForResponse(
+      (resp) => resp.url().includes('claim_open_shift') && resp.status() === 200,
+      { timeout: 15000 }
+    ).catch(() => null); // Non-fatal: RPC may come via different URL pattern
+
+    await confirmButton.click();
+
+    // 10. Verify the claim was submitted — dialog closes and "My Claims" section appears
+    // The dialog should close after successful claim
+    await expect(dialog).not.toBeVisible({ timeout: 10000 });
+
+    // "My Claims" section appears after a successful claim (collapsible header with count > 0)
+    const myClaimsHeading = page.getByRole('heading', { name: /my claims/i });
+    await expect(myClaimsHeading).toBeVisible({ timeout: 10000 });
+
+    // Wait for the RPC response if it hasn't arrived yet
+    await claimResponsePromise;
+
+    // Also try to catch the toast if it's still visible (Sonner toasts auto-dismiss)
+    const successToast = page.locator('[data-sonner-toast]').first();
+    const toastVisible = await successToast.isVisible().catch(() => false);
+    if (toastVisible) {
+      await expect(successToast).toContainText(/shift claimed|claim submitted/i);
+    }
+  });
+});

--- a/tests/unit/availableShifts.test.ts
+++ b/tests/unit/availableShifts.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { mergeAvailableShifts } from '@/hooks/useAvailableShifts';
+import type { OpenShift } from '@/types/scheduling';
+
+const makeOpenShift = (overrides: Partial<OpenShift> = {}): OpenShift => ({
+  template_id: 'tpl-1',
+  template_name: 'Closing Server',
+  shift_date: '2026-04-18',
+  start_time: '16:00:00',
+  end_time: '22:00:00',
+  position: 'Server',
+  area: null,
+  capacity: 3,
+  assigned_count: 1,
+  pending_claims: 0,
+  open_spots: 2,
+  ...overrides,
+});
+
+const makeTrade = (overrides: Record<string, unknown> = {}) => ({
+  id: 'trade-1',
+  status: 'open' as const,
+  offered_shift: { id: 's1', start_time: '2026-04-18T14:00:00Z', end_time: '2026-04-18T20:00:00Z', position: 'Server', break_duration: 0 },
+  offered_by: { id: 'emp-1', name: 'Maria', email: null, position: 'Server' },
+  ...overrides,
+});
+
+describe('mergeAvailableShifts', () => {
+  it('returns empty array when no shifts or trades', () => {
+    expect(mergeAvailableShifts([], [])).toEqual([]);
+  });
+
+  it('includes open shifts with type "open_shift"', () => {
+    const result = mergeAvailableShifts([makeOpenShift()], []);
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('open_shift');
+    expect(result[0].openShift?.template_name).toBe('Closing Server');
+  });
+
+  it('includes trades with type "trade"', () => {
+    const result = mergeAvailableShifts([], [makeTrade()]);
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('trade');
+  });
+
+  it('sorts by date ascending', () => {
+    const result = mergeAvailableShifts(
+      [makeOpenShift({ shift_date: '2026-04-20' })],
+      [makeTrade({ offered_shift: { id: 's1', start_time: '2026-04-18T14:00:00Z', end_time: '2026-04-18T20:00:00Z', position: 'Server', break_duration: 0 } })],
+    );
+    expect(result[0].type).toBe('trade');
+    expect(result[1].type).toBe('open_shift');
+  });
+
+  it('generates unique keys', () => {
+    const result = mergeAvailableShifts(
+      [makeOpenShift(), makeOpenShift({ template_id: 'tpl-2', template_name: 'Opener' })],
+      [makeTrade()],
+    );
+    const keys = result.map(r => r.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});

--- a/tests/unit/openShiftCard.test.ts
+++ b/tests/unit/openShiftCard.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Unit Tests: Open Shift Card helpers
+ *
+ * Tests pure functions from openShiftHelpers.ts:
+ * - formatCompactTime: compact 12-hour time labels
+ * - computeOpenSpots: available slot calculation
+ * - classifyCapacity: slot fill status
+ *
+ * Also tests conflict detection logic from AvailableShiftsPage
+ * (extracted into pure helper for testability).
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  formatCompactTime,
+  computeOpenSpots,
+  classifyCapacity,
+} from '@/lib/openShiftHelpers';
+
+// ---- formatCompactTime ----
+
+describe('formatCompactTime', () => {
+  it('formats midnight as "12a"', () => {
+    expect(formatCompactTime('00:00')).toBe('12a');
+  });
+
+  it('formats noon as "12p"', () => {
+    expect(formatCompactTime('12:00')).toBe('12p');
+  });
+
+  it('formats 9am without leading zero', () => {
+    expect(formatCompactTime('09:00')).toBe('9a');
+  });
+
+  it('formats 2pm correctly', () => {
+    expect(formatCompactTime('14:00')).toBe('2p');
+  });
+
+  it('formats 9:30am with minutes', () => {
+    expect(formatCompactTime('09:30')).toBe('9:30a');
+  });
+
+  it('formats 22:45 as "10:45p"', () => {
+    expect(formatCompactTime('22:45')).toBe('10:45p');
+  });
+
+  it('omits :00 for whole hours', () => {
+    expect(formatCompactTime('11:00')).toBe('11a');
+    expect(formatCompactTime('13:00')).toBe('1p');
+  });
+
+  it('pads minutes with leading zero', () => {
+    expect(formatCompactTime('10:05')).toBe('10:05a');
+  });
+
+  it('handles time strings with seconds', () => {
+    // HH:MM:SS - only first two segments matter
+    expect(formatCompactTime('16:00:00')).toBe('4p');
+    expect(formatCompactTime('08:30:00')).toBe('8:30a');
+  });
+});
+
+// ---- computeOpenSpots ----
+
+describe('computeOpenSpots', () => {
+  it('returns capacity minus assigned count', () => {
+    expect(computeOpenSpots(3, 1)).toBe(2);
+  });
+
+  it('returns 0 when fully booked', () => {
+    expect(computeOpenSpots(3, 3)).toBe(0);
+  });
+
+  it('clamps to 0 when over-assigned', () => {
+    expect(computeOpenSpots(2, 5)).toBe(0);
+  });
+
+  it('defaults capacity to 1 when undefined', () => {
+    expect(computeOpenSpots(undefined, 0)).toBe(1);
+    expect(computeOpenSpots(undefined, 1)).toBe(0);
+  });
+
+  it('returns full capacity when no one assigned', () => {
+    expect(computeOpenSpots(5, 0)).toBe(5);
+  });
+});
+
+// ---- classifyCapacity ----
+
+describe('classifyCapacity', () => {
+  it('returns "empty" when no one is assigned', () => {
+    expect(classifyCapacity(4, 0)).toBe('empty');
+  });
+
+  it('returns "partial" when partially filled', () => {
+    expect(classifyCapacity(4, 2)).toBe('partial');
+  });
+
+  it('returns "full" when at capacity', () => {
+    expect(classifyCapacity(4, 4)).toBe('full');
+  });
+
+  it('returns "full" when over capacity', () => {
+    expect(classifyCapacity(2, 5)).toBe('full');
+  });
+
+  it('uses default capacity of 1 when undefined', () => {
+    expect(classifyCapacity(undefined, 0)).toBe('empty');
+    expect(classifyCapacity(undefined, 1)).toBe('full');
+  });
+});
+
+// ---- Conflict detection logic (mirroring AvailableShiftsPage) ----
+
+/**
+ * Pure function extracted from AvailableShiftsPage's conflict detection.
+ * Returns true if the open shift time overlaps with any of the employee's shifts.
+ */
+function hasScheduleConflict(
+  openShiftDate: string,
+  openStartTime: string, // HH:MM:SS
+  openEndTime: string,   // HH:MM:SS
+  employeeShifts: Array<{ start_time: string; end_time: string; status: string }>,
+): boolean {
+  const [startH, startM] = openStartTime.split(':').map(Number);
+  const [endH, endM] = openEndTime.split(':').map(Number);
+  const osStart = startH * 60 + startM;
+  const osEnd = endH * 60 + endM;
+
+  return employeeShifts.some((s) => {
+    if (s.status === 'cancelled') return false;
+    const sDate = s.start_time.split('T')[0];
+    if (sDate !== openShiftDate) return false;
+    const sStart = new Date(s.start_time);
+    const sEnd = new Date(s.end_time);
+    const sStartMin = sStart.getHours() * 60 + sStart.getMinutes();
+    const sEndMin = sEnd.getHours() * 60 + sEnd.getMinutes();
+    return sStartMin < osEnd && sEndMin > osStart;
+  });
+}
+
+describe('hasScheduleConflict', () => {
+  const date = '2026-04-18';
+
+  it('returns false when employee has no shifts', () => {
+    expect(hasScheduleConflict(date, '14:00:00', '20:00:00', [])).toBe(false);
+  });
+
+  it('returns false when shift is on a different date', () => {
+    const shifts = [{ start_time: '2026-04-19T14:00:00Z', end_time: '2026-04-19T20:00:00Z', status: 'scheduled' }];
+    expect(hasScheduleConflict(date, '14:00:00', '20:00:00', shifts)).toBe(false);
+  });
+
+  it('detects overlap when shifts share the same date and times', () => {
+    const shifts = [{ start_time: '2026-04-18T14:00:00Z', end_time: '2026-04-18T20:00:00Z', status: 'scheduled' }];
+    expect(hasScheduleConflict(date, '14:00:00', '20:00:00', shifts)).toBe(true);
+  });
+
+  it('detects partial overlap (open shift starts before employee shift ends)', () => {
+    const shifts = [{ start_time: '2026-04-18T16:00:00Z', end_time: '2026-04-18T22:00:00Z', status: 'scheduled' }];
+    expect(hasScheduleConflict(date, '14:00:00', '18:00:00', shifts)).toBe(true);
+  });
+
+  it('returns false for adjacent shifts (no overlap)', () => {
+    const shifts = [{ start_time: '2026-04-18T08:00:00Z', end_time: '2026-04-18T14:00:00Z', status: 'scheduled' }];
+    expect(hasScheduleConflict(date, '14:00:00', '20:00:00', shifts)).toBe(false);
+  });
+
+  it('ignores cancelled shifts', () => {
+    const shifts = [{ start_time: '2026-04-18T14:00:00Z', end_time: '2026-04-18T20:00:00Z', status: 'cancelled' }];
+    expect(hasScheduleConflict(date, '14:00:00', '20:00:00', shifts)).toBe(false);
+  });
+});

--- a/tests/unit/openShiftClaims.test.ts
+++ b/tests/unit/openShiftClaims.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Unit Tests: Open Shift Claims Logic
+ *
+ * Tests pure functions and data-shaping logic related to open shift claims:
+ * - Filtering claims by status
+ * - Claim status label derivation
+ * - Spots label computation based on open_spots count
+ *
+ * These mirror the logic in AvailableShiftsPage.tsx and
+ * the TradeApprovalQueue.tsx pending claims section.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { OpenShiftClaim } from '@/types/scheduling';
+
+// ---- Helpers mirroring component logic ----
+
+/** Returns claims that need manager action (status === 'pending_approval'). */
+function getPendingClaims(claims: OpenShiftClaim[]): OpenShiftClaim[] {
+  return claims.filter((c) => c.status === 'pending_approval');
+}
+
+/** Human-readable label for the spots remaining. */
+function spotsLabel(openSpots: number): string {
+  return openSpots === 1 ? '1 spot left' : `${openSpots} spots left`;
+}
+
+/**
+ * Derive the display variant of a claim status — maps to badge colour.
+ * Returns 'approved' | 'rejected' | 'cancelled' | 'pending'
+ */
+function claimStatusVariant(status: OpenShiftClaim['status']): string {
+  if (status === 'approved') return 'approved';
+  if (status === 'rejected') return 'rejected';
+  if (status === 'cancelled') return 'cancelled';
+  return 'pending';
+}
+
+// ---- Test fixtures ----
+
+function makeClaim(overrides: Partial<OpenShiftClaim> = {}): OpenShiftClaim {
+  return {
+    id: 'claim-1',
+    restaurant_id: 'rest-1',
+    shift_template_id: 'tpl-1',
+    shift_date: '2026-04-18',
+    claimed_by_employee_id: 'emp-1',
+    status: 'pending_approval',
+    resulting_shift_id: null,
+    reviewed_by: null,
+    reviewed_at: null,
+    created_at: '2026-04-11T10:00:00Z',
+    updated_at: '2026-04-11T10:00:00Z',
+    ...overrides,
+  };
+}
+
+// ---- Tests ----
+
+describe('getPendingClaims', () => {
+  it('returns empty array when no claims', () => {
+    expect(getPendingClaims([])).toEqual([]);
+  });
+
+  it('filters to only pending_approval claims', () => {
+    const claims = [
+      makeClaim({ id: 'c1', status: 'pending_approval' }),
+      makeClaim({ id: 'c2', status: 'approved' }),
+      makeClaim({ id: 'c3', status: 'rejected' }),
+      makeClaim({ id: 'c4', status: 'pending_approval' }),
+    ];
+    const result = getPendingClaims(claims);
+    expect(result).toHaveLength(2);
+    expect(result.map((c) => c.id)).toEqual(['c1', 'c4']);
+  });
+
+  it('returns empty array when all claims are resolved', () => {
+    const claims = [
+      makeClaim({ status: 'approved' }),
+      makeClaim({ status: 'rejected' }),
+      makeClaim({ status: 'cancelled' }),
+    ];
+    expect(getPendingClaims(claims)).toHaveLength(0);
+  });
+});
+
+describe('spotsLabel', () => {
+  it('uses singular "1 spot left"', () => {
+    expect(spotsLabel(1)).toBe('1 spot left');
+  });
+
+  it('uses plural for multiple spots', () => {
+    expect(spotsLabel(2)).toBe('2 spots left');
+    expect(spotsLabel(5)).toBe('5 spots left');
+  });
+
+  it('handles zero spots', () => {
+    expect(spotsLabel(0)).toBe('0 spots left');
+  });
+});
+
+describe('claimStatusVariant', () => {
+  it('maps approved to "approved"', () => {
+    expect(claimStatusVariant('approved')).toBe('approved');
+  });
+
+  it('maps rejected to "rejected"', () => {
+    expect(claimStatusVariant('rejected')).toBe('rejected');
+  });
+
+  it('maps cancelled to "cancelled"', () => {
+    expect(claimStatusVariant('cancelled')).toBe('cancelled');
+  });
+
+  it('maps pending_approval to "pending"', () => {
+    expect(claimStatusVariant('pending_approval')).toBe('pending');
+  });
+});
+
+describe('OpenShiftClaim data shape', () => {
+  it('is created with all required fields', () => {
+    const claim = makeClaim();
+    expect(claim.id).toBeTruthy();
+    expect(claim.restaurant_id).toBeTruthy();
+    expect(claim.shift_template_id).toBeTruthy();
+    expect(claim.shift_date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(claim.claimed_by_employee_id).toBeTruthy();
+    expect(['pending_approval', 'approved', 'rejected', 'cancelled']).toContain(claim.status);
+  });
+
+  it('allows overriding individual fields', () => {
+    const approved = makeClaim({ status: 'approved', reviewed_by: 'mgr-1' });
+    expect(approved.status).toBe('approved');
+    expect(approved.reviewed_by).toBe('mgr-1');
+  });
+
+  it('preserves shift_template_id from fixtures', () => {
+    const claim = makeClaim({ shift_template_id: 'tpl-special' });
+    expect(claim.shift_template_id).toBe('tpl-special');
+  });
+
+  it('defaults resulting_shift_id to null', () => {
+    const claim = makeClaim();
+    expect(claim.resulting_shift_id).toBeNull();
+  });
+
+  it('can be given a resulting_shift_id when approved', () => {
+    const claim = makeClaim({ status: 'approved', resulting_shift_id: 'shift-99' });
+    expect(claim.resulting_shift_id).toBe('shift-99');
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `open_shift_claims` table with RLS policies for employee claiming
- Server-side RPCs: `get_open_shifts`, `claim_open_shift`, `approve/reject_open_shift_claim`
- Restaurant-level feature gate (`open_shifts_enabled`, default off) + approval toggle
- Unified "Available Shifts" page replacing `EmployeeShiftMarketplace` — shows open shifts + trades in a virtualized feed
- Claim confirmation dialog with conflict detection
- Pending claim approvals integrated into existing Trade Approval Queue
- Publish dialog nudge linking to settings when feature is disabled

**This is PR2 of 3** for the Open Shift Claiming feature. PR1 merged (#452). See design spec: `docs/superpowers/specs/2026-04-11-open-shift-claiming-pr2-design.md`

## Test plan

- [x] pgTAP: table, columns, defaults, RPC functions exist (12 tests)
- [x] Unit: mergeAvailableShifts sorting, typing, key uniqueness (5 tests)
- [x] E2E: employee claims open shift end-to-end (seed → view → claim → verify)
- [x] Build passes
- [x] All 3357 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Employees can claim open shifts from a unified Available Shifts feed (combines marketplace trades + open shifts).
  * Managers can toggle open-shift claiming and require manager approval; pending claims surface in approval queue.
  * New “My Claims” view and in‑app claim confirmation flow; schedule publish dialog now links to staffing settings when feature is off.

* **Tests**
  * Added unit and end-to-end tests covering merge logic, UI cards, helpers, and full claim flow.

* **Documentation**
  * Added design/implementation plan for open-shift claiming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->