### PR TITLE
fix: open shift date off-by-one and past dates in employee feed

### DIFF
--- a/src/components/schedule/TradeApprovalQueue.tsx
+++ b/src/components/schedule/TradeApprovalQueue.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { format } from 'date-fns';
+import { parseDateLocal } from '@/lib/dateUtils';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -371,7 +372,7 @@ export const TradeApprovalQueue = () => {
                   </p>
                   <p>
                     <span className="font-medium">Date:</span>{' '}
-                    {format(new Date(selectedClaim.shift_date), 'EEEE, MMMM d, yyyy')}
+                    {format(parseDateLocal(selectedClaim.shift_date), 'EEEE, MMMM d, yyyy')}
                   </p>
                   {selectedClaim.shift_template && (
                     <p>
@@ -678,7 +679,7 @@ interface ClaimRequestCardProps {
 }
 
 const ClaimRequestCard = ({ claim, onApprove, onReject, disabled }: ClaimRequestCardProps) => {
-  const shiftDate = new Date(claim.shift_date);
+  const shiftDate = parseDateLocal(claim.shift_date);
 
   return (
     <Card data-testid="pending-claim" className="border-green-200 dark:border-green-800">

--- a/src/components/scheduling/ClaimConfirmDialog.tsx
+++ b/src/components/scheduling/ClaimConfirmDialog.tsx
@@ -5,7 +5,8 @@ import { Hand, Calendar, Clock, MapPin } from 'lucide-react';
 
 import type { OpenShift } from '@/types/scheduling';
 
-import { format, parseISO } from 'date-fns';
+import { format } from 'date-fns';
+import { parseDateLocal } from '@/lib/dateUtils';
 
 interface ClaimConfirmDialogProps {
   open: boolean;
@@ -32,7 +33,7 @@ export function ClaimConfirmDialog({
 }: Readonly<ClaimConfirmDialogProps>) {
   if (!openShift) return null;
 
-  const dateLabel = format(parseISO(openShift.shift_date), 'EEEE, MMMM d');
+  const dateLabel = format(parseDateLocal(openShift.shift_date), 'EEEE, MMMM d');
   const timeLabel = `${formatCompactTime(openShift.start_time)} - ${formatCompactTime(openShift.end_time)}`;
 
   return (

--- a/src/components/scheduling/OpenShiftCard.tsx
+++ b/src/components/scheduling/OpenShiftCard.tsx
@@ -6,8 +6,9 @@ import { Calendar, Clock, MapPin, Users } from 'lucide-react';
 
 import type { OpenShift } from '@/types/scheduling';
 
-import { format, parseISO } from 'date-fns';
+import { format } from 'date-fns';
 import { cn } from '@/lib/utils';
+import { parseDateLocal } from '@/lib/dateUtils';
 import { formatCompactTime } from '@/lib/openShiftHelpers';
 
 interface OpenShiftCardProps {
@@ -23,7 +24,7 @@ export const OpenShiftCard = memo(function OpenShiftCard({
   onClaim,
   isClaiming,
 }: OpenShiftCardProps) {
-  const dateLabel = format(parseISO(openShift.shift_date), 'EEE, MMM d');
+  const dateLabel = format(parseDateLocal(openShift.shift_date), 'EEE, MMM d');
   const timeLabel = `${formatCompactTime(openShift.start_time)}-${formatCompactTime(openShift.end_time)}`;
   const spotsLabel = openShift.open_spots === 1 ? '1 spot left' : `${openShift.open_spots} spots left`;
 

--- a/src/lib/dateUtils.ts
+++ b/src/lib/dateUtils.ts
@@ -1,0 +1,12 @@
+/**
+ * Parse a date-only string (YYYY-MM-DD) as local midnight.
+ *
+ * IMPORTANT: `new Date("2026-04-10")` and `parseISO("2026-04-10")` parse
+ * date-only strings as UTC midnight. In timezones behind UTC (CDT, EST, PST),
+ * this displays as the previous day. Always use this function for date-only
+ * strings from Supabase (DATE columns like shift_date, week_start_date, etc.).
+ */
+export function parseDateLocal(dateStr: string): Date {
+  const [y, m, d] = dateStr.split('-').map(Number);
+  return new Date(y, m - 1, d);
+}

--- a/src/pages/AvailableShiftsPage.tsx
+++ b/src/pages/AvailableShiftsPage.tsx
@@ -40,7 +40,8 @@ import { ClaimConfirmDialog } from '@/components/scheduling/ClaimConfirmDialog';
 
 import type { OpenShift, OpenShiftClaim } from '@/types/scheduling';
 
-import { format, parseISO, startOfWeek, addDays } from 'date-fns';
+import { format, startOfWeek, addDays } from 'date-fns';
+import { parseDateLocal } from '@/lib/dateUtils';
 import { WEEK_STARTS_ON } from '@/lib/dateConfig';
 import { cn } from '@/lib/utils';
 
@@ -416,7 +417,7 @@ export default function AvailableShiftsPage() {
                   <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[13px] text-muted-foreground">
                     <span className="flex items-center gap-1">
                       <Calendar className="h-3.5 w-3.5" aria-hidden="true" />
-                      {format(parseISO(claim.shift_date), 'EEE, MMM d')}
+                      {format(parseDateLocal(claim.shift_date), 'EEE, MMM d')}
                     </span>
                     {(claim as any).shift_template && (
                       <span className="flex items-center gap-1">

--- a/supabase/migrations/20260412215428_fix_open_shifts_filter_past_dates.sql
+++ b/supabase/migrations/20260412215428_fix_open_shifts_filter_past_dates.sql
@@ -1,0 +1,111 @@
+-- Fix get_open_shifts to exclude past dates.
+-- Previously returned open shifts for the entire published week including days
+-- that have already passed, causing clutter in the employee feed.
+
+CREATE OR REPLACE FUNCTION public.get_open_shifts(
+    p_restaurant_id UUID,
+    p_week_start DATE,
+    p_week_end DATE
+)
+RETURNS TABLE (
+    template_id UUID,
+    template_name TEXT,
+    shift_date DATE,
+    start_time TIME,
+    end_time TIME,
+    "position" TEXT,
+    area TEXT,
+    "capacity" INT,
+    assigned_count BIGINT,
+    pending_claims BIGINT,
+    open_spots BIGINT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+    -- Check if open shifts are enabled for this restaurant
+    IF NOT EXISTS (
+        SELECT 1 FROM public.staffing_settings
+        WHERE restaurant_id = p_restaurant_id
+          AND open_shifts_enabled = true
+    ) THEN
+        RETURN;
+    END IF;
+
+    RETURN QUERY
+    WITH published_dates AS (
+        -- Get all dates within published schedule weeks, excluding past dates
+        SELECT DISTINCT d::date AS pub_date
+        FROM public.schedule_publications sp,
+             generate_series(
+                 GREATEST(sp.week_start_date, p_week_start),
+                 LEAST(sp.week_end_date, p_week_end),
+                 '1 day'::interval
+             ) AS d
+        WHERE sp.restaurant_id = p_restaurant_id
+          AND sp.week_start_date <= p_week_end
+          AND sp.week_end_date >= p_week_start
+          AND d::date >= CURRENT_DATE  -- Only today and future dates
+    ),
+    template_days AS (
+        SELECT
+            st.id AS tmpl_id,
+            st.name AS tmpl_name,
+            pd.pub_date,
+            st.start_time AS tmpl_start,
+            st.end_time AS tmpl_end,
+            st.position AS tmpl_position,
+            st.area AS tmpl_area,
+            st.capacity AS tmpl_capacity
+        FROM public.shift_templates st
+        CROSS JOIN published_dates pd
+        WHERE st.restaurant_id = p_restaurant_id
+          AND st.is_active = true
+          AND st.capacity > 1
+          AND EXTRACT(DOW FROM pd.pub_date)::int = ANY(st.days)
+    ),
+    assigned AS (
+        SELECT
+            td.tmpl_id,
+            td.pub_date,
+            COUNT(s.id) AS cnt
+        FROM template_days td
+        LEFT JOIN public.shifts s
+            ON s.restaurant_id = p_restaurant_id
+            AND s.position = td.tmpl_position
+            AND (s.start_time::time) = td.tmpl_start
+            AND (s.end_time::time) = td.tmpl_end
+            AND (s.start_time::date) = td.pub_date
+            AND s.status != 'cancelled'
+        GROUP BY td.tmpl_id, td.pub_date
+    ),
+    pending AS (
+        SELECT
+            osc.shift_template_id,
+            osc.shift_date,
+            COUNT(osc.id) AS cnt
+        FROM public.open_shift_claims osc
+        WHERE osc.restaurant_id = p_restaurant_id
+          AND osc.status = 'pending_approval'
+        GROUP BY osc.shift_template_id, osc.shift_date
+    )
+    SELECT
+        td.tmpl_id,
+        td.tmpl_name,
+        td.pub_date,
+        td.tmpl_start,
+        td.tmpl_end,
+        td.tmpl_position,
+        td.tmpl_area,
+        td.tmpl_capacity,
+        COALESCE(a.cnt, 0),
+        COALESCE(p.cnt, 0),
+        (td.tmpl_capacity - COALESCE(a.cnt, 0) - COALESCE(p.cnt, 0))
+    FROM template_days td
+    LEFT JOIN assigned a ON a.tmpl_id = td.tmpl_id AND a.pub_date = td.pub_date
+    LEFT JOIN pending p ON p.shift_template_id = td.tmpl_id AND p.shift_date = td.pub_date
+    WHERE (td.tmpl_capacity - COALESCE(a.cnt, 0) - COALESCE(p.cnt, 0)) > 0
+    ORDER BY td.pub_date, td.tmpl_start;
+END;
+$$;

--- a/tests/e2e/open-shift-claiming.spec.ts
+++ b/tests/e2e/open-shift-claiming.spec.ts
@@ -38,7 +38,7 @@ test.describe('Open Shift Claiming', () => {
           end_time: '22:00:00',
           position: 'Server',
           capacity: 3,
-          days: [1, 2, 3, 4, 5], // Mon-Fri
+          days: [0, 1, 2, 3, 4, 5, 6], // All days — ensures test works regardless of day-of-week
           is_active: true,
         })
         .select()
@@ -65,16 +65,30 @@ test.describe('Open Shift Claiming', () => {
       const userId = user?.id;
       if (!userId) throw new Error('No authenticated user found');
 
-      // Publish the current week schedule
+      // Publish current + next week (ensures future dates exist regardless of day-of-week)
+      const nextMonday = new Date(monday);
+      nextMonday.setDate(monday.getDate() + 7);
+      const nextSunday = new Date(nextMonday);
+      nextSunday.setDate(nextMonday.getDate() + 6);
+
       const { error: pubError } = await supabase
         .from('schedule_publications')
-        .insert({
-          restaurant_id: restId,
-          week_start_date: mondayStr,
-          week_end_date: sundayStr,
-          published_by: userId,
-          shift_count: 0,
-        });
+        .insert([
+          {
+            restaurant_id: restId,
+            week_start_date: mondayStr,
+            week_end_date: sundayStr,
+            published_by: userId,
+            shift_count: 0,
+          },
+          {
+            restaurant_id: restId,
+            week_start_date: toDateStr(nextMonday),
+            week_end_date: toDateStr(nextSunday),
+            published_by: userId,
+            shift_count: 0,
+          },
+        ]);
       if (pubError) throw new Error(`schedule_publications insert failed: ${pubError.message}`);
 
       // Create employee linked to the current user so useCurrentEmployee can find them

--- a/tests/unit/openShiftDateParsing.test.ts
+++ b/tests/unit/openShiftDateParsing.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { format } from 'date-fns';
+
+/**
+ * Reproduces the date-off-by-one bug in open shift claiming.
+ *
+ * Root cause: `new Date("2026-04-10")` and `parseISO("2026-04-10")` parse
+ * date-only strings as UTC midnight. In timezones behind UTC (e.g., CDT = UTC-5),
+ * this displays as the previous day (April 9 instead of April 10).
+ *
+ * The fix uses parseDateLocal() which splits the string and creates a local Date.
+ */
+
+// This is the broken pattern used in TradeApprovalQueue, OpenShiftCard, and AvailableShiftsPage
+function brokenDateParse(dateStr: string): Date {
+  return new Date(dateStr);
+}
+
+import { parseDateLocal } from '@/lib/dateUtils';
+
+describe('open shift date parsing', () => {
+  const testDate = '2026-04-10'; // Friday, April 10
+
+  it('BUG: new Date() parses date-only strings as UTC, shows wrong day in local TZ', () => {
+    const broken = brokenDateParse(testDate);
+    // new Date("2026-04-10") creates 2026-04-10T00:00:00Z (UTC midnight)
+    // In any timezone behind UTC, getDate() returns 9 (previous day)
+    // This test documents the bug — it may pass in UTC but fail in CDT/EST/PST
+    const utcDay = broken.getUTCDate();
+    expect(utcDay).toBe(10); // UTC date is correct...
+    // ...but local date may not be:
+    // In UTC: getDate() === 10 (correct)
+    // In CDT (UTC-5): getDate() === 9 (BUG!)
+  });
+
+  it('FIX: parseDateLocal splits string and creates local midnight', () => {
+    const fixed = parseDateLocal(testDate);
+    // Always local midnight — getDate() returns 10 regardless of timezone
+    expect(fixed.getDate()).toBe(10);
+    expect(fixed.getMonth()).toBe(3); // April = month 3 (0-indexed)
+    expect(fixed.getFullYear()).toBe(2026);
+  });
+
+  it('FIX: formatted output shows correct day name', () => {
+    const fixed = parseDateLocal(testDate);
+    const dayName = format(fixed, 'EEEE');
+    expect(dayName).toBe('Friday');
+  });
+
+  it('FIX: formatted output shows correct full date', () => {
+    const fixed = parseDateLocal(testDate);
+    const formatted = format(fixed, 'EEEE, MMMM d, yyyy');
+    expect(formatted).toBe('Friday, April 10, 2026');
+  });
+
+  it('FIX: short format shows correct date', () => {
+    const fixed = parseDateLocal(testDate);
+    const formatted = format(fixed, 'EEE, MMM d');
+    expect(formatted).toBe('Fri, Apr 10');
+  });
+
+  // Edge cases
+  it('handles first day of month', () => {
+    expect(parseDateLocal('2026-05-01').getDate()).toBe(1);
+    expect(parseDateLocal('2026-05-01').getMonth()).toBe(4);
+  });
+
+  it('handles last day of month', () => {
+    expect(parseDateLocal('2026-04-30').getDate()).toBe(30);
+  });
+
+  it('handles year boundary', () => {
+    expect(parseDateLocal('2027-01-01').getDate()).toBe(1);
+    expect(parseDateLocal('2027-01-01').getFullYear()).toBe(2027);
+  });
+});


### PR DESCRIPTION
## Summary

Two bugs fixed:

1. **Date off-by-one**: Employee claimed a Friday shift but manager saw Thursday. Root cause: `new Date("2026-04-10")` parses date-only strings as UTC midnight — in CDT (UTC-5), this displays as April 9. Fixed with `parseDateLocal()` that splits the date string and creates local midnight.

2. **Past shifts showing**: Employees saw open shifts for the entire published week including past days. Added `>= CURRENT_DATE` filter to `get_open_shifts` RPC.

## Test plan

- [x] Unit tests: 8 tests for `parseDateLocal` covering edge cases (month boundaries, year boundaries, day name formatting)
- [x] All 3434 unit tests pass
- [x] Build passes
- [x] DB migration applies cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected date display formatting across shift scheduling, claim approvals, and availability pages to properly handle local timezone conversions.
  * Updated open shifts filtering to exclude shift dates that have already passed, showing only currently available opportunities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->