### PR TITLE
feat: broadcast open shifts to team via push + email

### DIFF
--- a/docs/superpowers/plans/2026-04-12-open-shift-broadcast-pr3-plan.md
+++ b/docs/superpowers/plans/2026-04-12-open-shift-broadcast-pr3-plan.md
@@ -1,0 +1,509 @@
+# Open Shift Broadcast PR3 — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Managers can broadcast open shifts to all active employees via push notification and email.
+
+**Architecture:** A "Broadcast" button on the scheduling page opens a confirmation dialog. On confirm, it calls a new `broadcast-open-shifts` edge function that sends web push notifications (via `sendWebPushToUser`) and emails (via Resend) to all active employees, then stamps the publication with the broadcast timestamp.
+
+**Tech Stack:** PostgreSQL migration, Deno edge function, TypeScript/React, React Query, Vitest, pgTAP, Playwright
+
+**Design spec:** `docs/superpowers/specs/2026-04-12-open-shift-broadcast-pr3-design.md`
+
+**IMPORTANT:** Before writing any Supabase query, verify actual table/column names via `npx supabase db dump --local --schema public 2>&1 | grep -A 20 "CREATE TABLE.*<table_name>"`. Never trust plan text for column names.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `supabase/migrations/YYYYMMDD_add_broadcast_to_publications.sql` | Add broadcast columns |
+| `supabase/tests/broadcast_open_shifts.test.sql` | pgTAP tests |
+| `supabase/functions/broadcast-open-shifts/index.ts` | Edge function: send notifications |
+| `src/hooks/useBroadcastOpenShifts.ts` | Mutation hook for broadcast |
+| `src/components/scheduling/BroadcastOpenShiftsDialog.tsx` | Confirmation dialog |
+| `src/pages/Scheduling.tsx` | Add broadcast button |
+| `src/hooks/useSchedulePublish.tsx` | Update to return broadcast columns |
+| `tests/unit/broadcastOpenShifts.test.ts` | Unit tests |
+| `tests/e2e/broadcast-open-shifts.spec.ts` | E2E test |
+
+---
+
+### Task 1: Database migration — add broadcast columns
+
+**Files:**
+- Create: `supabase/migrations/YYYYMMDD_add_broadcast_to_publications.sql`
+- Create: `supabase/tests/broadcast_open_shifts.test.sql`
+
+- [ ] **Step 1: Write pgTAP test**
+
+Create `supabase/tests/broadcast_open_shifts.test.sql`:
+
+```sql
+BEGIN;
+SELECT plan(4);
+
+SELECT has_column('schedule_publications', 'open_shifts_broadcast_at',
+  'schedule_publications should have open_shifts_broadcast_at column');
+
+SELECT has_column('schedule_publications', 'open_shifts_broadcast_by',
+  'schedule_publications should have open_shifts_broadcast_by column');
+
+SELECT col_is_null('schedule_publications', 'open_shifts_broadcast_at',
+  'open_shifts_broadcast_at should be nullable');
+
+SELECT col_is_null('schedule_publications', 'open_shifts_broadcast_by',
+  'open_shifts_broadcast_by should be nullable');
+
+SELECT * FROM finish();
+ROLLBACK;
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test:db`
+Expected: FAIL — columns don't exist.
+
+- [ ] **Step 3: Write the migration**
+
+Run `npx supabase migration new add_broadcast_to_publications` then write:
+
+```sql
+-- Track when open shifts were broadcast for each published week
+ALTER TABLE schedule_publications
+  ADD COLUMN IF NOT EXISTS open_shifts_broadcast_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS open_shifts_broadcast_by UUID REFERENCES auth.users(id);
+```
+
+- [ ] **Step 4: Reset DB and run tests**
+
+Run: `npx supabase db reset && npm run test:db`
+Expected: All pgTAP tests pass.
+
+- [ ] **Step 5: Regenerate types**
+
+Run: `npx supabase gen types typescript --local 2>/dev/null > src/integrations/supabase/types.ts`
+Verify line 1 starts with `export type`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add supabase/migrations/*_add_broadcast_to_publications.sql supabase/tests/broadcast_open_shifts.test.sql src/integrations/supabase/types.ts
+git commit -m "feat: add broadcast columns to schedule_publications"
+```
+
+---
+
+### Task 2: Edge function — broadcast-open-shifts
+
+**Files:**
+- Create: `supabase/functions/broadcast-open-shifts/index.ts`
+
+- [ ] **Step 1: Verify schema before writing queries**
+
+Run:
+```bash
+npx supabase db dump --local --schema public 2>&1 | grep -A 25 "CREATE TABLE.*schedule_publications"
+npx supabase db dump --local --schema public 2>&1 | grep -A 15 "CREATE TABLE.*employees"
+```
+
+Note exact column names for employees (need: `id`, `user_id`, `name`, `is_active`, `restaurant_id`) and schedule_publications.
+
+- [ ] **Step 2: Create the edge function**
+
+Create `supabase/functions/broadcast-open-shifts/index.ts`:
+
+```typescript
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { corsHeaders } from '../_shared/cors.ts';
+import { sendWebPushToUser } from '../_shared/webPushHelper.ts';
+import { sendEmail, getManagerEmails, NOTIFICATION_FROM, APP_URL } from '../_shared/notificationHelpers.ts';
+
+Deno.serve(async (req) => {
+  // CORS preflight
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) {
+      return new Response(JSON.stringify({ error: 'Missing authorization' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Create client with user's auth
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_ANON_KEY')!,
+      { global: { headers: { Authorization: authHeader } } }
+    );
+
+    // Verify authenticated user
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const { restaurant_id, publication_id } = await req.json();
+
+    if (!restaurant_id || !publication_id) {
+      return new Response(JSON.stringify({ error: 'Missing restaurant_id or publication_id' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Verify caller is owner/manager
+    const { data: userRole } = await supabase
+      .from('user_restaurants')
+      .select('role')
+      .eq('user_id', user.id)
+      .eq('restaurant_id', restaurant_id)
+      .single();
+
+    if (!userRole || !['owner', 'manager'].includes(userRole.role)) {
+      return new Response(JSON.stringify({ error: 'Manager access required' }), {
+        status: 403,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Use service role client for operations
+    const serviceClient = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    );
+
+    // Fetch publication
+    const { data: publication, error: pubError } = await serviceClient
+      .from('schedule_publications')
+      .select('*')
+      .eq('id', publication_id)
+      .eq('restaurant_id', restaurant_id)
+      .single();
+
+    if (pubError || !publication) {
+      return new Response(JSON.stringify({ error: 'Publication not found' }), {
+        status: 404,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Check open shifts exist
+    const { data: openShifts } = await serviceClient.rpc('get_open_shifts', {
+      p_restaurant_id: restaurant_id,
+      p_week_start: publication.week_start_date,
+      p_week_end: publication.week_end_date,
+    });
+
+    const openShiftCount = openShifts?.length ?? 0;
+    if (openShiftCount === 0) {
+      return new Response(JSON.stringify({ error: 'No open shifts to broadcast' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Fetch all active employees with user_id
+    const { data: employees } = await serviceClient
+      .from('employees')
+      .select('id, user_id, name, email')
+      .eq('restaurant_id', restaurant_id)
+      .eq('is_active', true);
+
+    const activeEmployees = employees ?? [];
+    let pushSent = 0;
+    let emailsSent = 0;
+
+    // Format week label
+    const weekLabel = `${publication.week_start_date} to ${publication.week_end_date}`;
+    const notificationBody = `${openShiftCount} shift${openShiftCount > 1 ? 's are' : ' is'} open for the week of ${weekLabel}. Claim a spot!`;
+
+    // Send push notifications
+    for (const emp of activeEmployees) {
+      if (!emp.user_id) continue;
+      try {
+        const result = await sendWebPushToUser(serviceClient, emp.user_id, restaurant_id, {
+          title: 'Shifts Available',
+          body: notificationBody,
+          url: '/employee/shifts',
+        });
+        pushSent += result.sent;
+      } catch {
+        // Push failures are non-fatal — continue to next employee
+      }
+    }
+
+    // Send emails
+    const resendApiKey = Deno.env.get('RESEND_API_KEY');
+    if (resendApiKey) {
+      for (const emp of activeEmployees) {
+        if (!emp.email) continue;
+        try {
+          const sent = await sendEmail(
+            resendApiKey,
+            NOTIFICATION_FROM,
+            emp.email,
+            'Shifts Available — Claim a Spot',
+            `<p>Hi ${emp.name},</p>
+            <p>${notificationBody}</p>
+            <p><a href="${APP_URL}/employee/shifts">View Available Shifts</a></p>`
+          );
+          if (sent) emailsSent++;
+        } catch {
+          // Email failures are non-fatal
+        }
+      }
+    }
+
+    // Stamp the publication
+    await serviceClient
+      .from('schedule_publications')
+      .update({
+        open_shifts_broadcast_at: new Date().toISOString(),
+        open_shifts_broadcast_by: user.id,
+      })
+      .eq('id', publication_id);
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        open_shifts: openShiftCount,
+        push_sent: pushSent,
+        emails_sent: emailsSent,
+        employees_notified: activeEmployees.length,
+      }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  } catch (error) {
+    return new Response(
+      JSON.stringify({ error: error instanceof Error ? error.message : 'Internal error' }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+});
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add supabase/functions/broadcast-open-shifts/index.ts
+git commit -m "feat: add broadcast-open-shifts edge function"
+```
+
+---
+
+### Task 3: Hook — useBroadcastOpenShifts
+
+**Files:**
+- Create: `src/hooks/useBroadcastOpenShifts.ts`
+- Modify: `src/hooks/useSchedulePublish.tsx`
+
+- [ ] **Step 1: Create the broadcast mutation hook**
+
+Create `src/hooks/useBroadcastOpenShifts.ts`:
+
+```typescript
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { useToast } from '@/hooks/use-toast';
+
+export function useBroadcastOpenShifts() {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async (params: { restaurantId: string; publicationId: string }) => {
+      const { data, error } = await supabase.functions.invoke('broadcast-open-shifts', {
+        body: {
+          restaurant_id: params.restaurantId,
+          publication_id: params.publicationId,
+        },
+      });
+
+      if (error) throw error;
+      if (!data?.success) throw new Error(data?.error ?? 'Broadcast failed');
+      return data as {
+        success: boolean;
+        open_shifts: number;
+        push_sent: number;
+        emails_sent: number;
+        employees_notified: number;
+      };
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['schedule-publication'] });
+      toast({
+        title: 'Broadcast sent',
+        description: `Notified ${data.employees_notified} team members about ${data.open_shifts} open shifts.`,
+      });
+    },
+    onError: (error: Error) => {
+      toast({
+        title: 'Broadcast failed',
+        description: error.message,
+        variant: 'destructive',
+      });
+    },
+  });
+}
+```
+
+- [ ] **Step 2: Update useSchedulePublish to return broadcast columns**
+
+Read `src/hooks/useSchedulePublish.tsx` and find the `useWeekPublicationStatus` hook. Its query selects from `schedule_publications`. Add `open_shifts_broadcast_at` and `open_shifts_broadcast_by` to the `.select()` call.
+
+Also update the return type/interface to include these fields, and the `SchedulePublication` type in `src/types/scheduling.ts` if needed.
+
+**IMPORTANT:** Verify the exact `.select()` call — per the lesson about explicit selects, check if it uses `*` or an explicit column list. If explicit, add the new columns.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/hooks/useBroadcastOpenShifts.ts src/hooks/useSchedulePublish.tsx
+git commit -m "feat: add useBroadcastOpenShifts hook and update publication query"
+```
+
+---
+
+### Task 4: BroadcastOpenShiftsDialog component
+
+**Files:**
+- Create: `src/components/scheduling/BroadcastOpenShiftsDialog.tsx`
+
+- [ ] **Step 1: Create the dialog component**
+
+```typescript
+interface BroadcastOpenShiftsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  restaurantId: string;
+  publicationId: string;
+  weekStart: Date;
+  weekEnd: Date;
+  openShiftCount: number;
+  alreadyBroadcast: boolean;
+  broadcastDate?: string | null;
+}
+```
+
+Layout following CLAUDE.md dialog structure:
+- Header: Megaphone icon + "Broadcast Open Shifts"
+- Body:
+  - "{openShiftCount} open shifts for the week of {weekStart} - {weekEnd}"
+  - "All active team members will be notified via push notification and email"
+  - If `alreadyBroadcast`: amber alert "Already broadcast on {broadcastDate}. Sending again will re-notify your team."
+- Footer: Cancel + "Broadcast to Team" button (primary style)
+- Loading state: "Broadcasting..." with spinner
+
+Import `useBroadcastOpenShifts` and call it on confirm. Close dialog on success.
+
+Use `format` from `date-fns` for dates. Use `parseDateLocal` from `@/lib/dateUtils` for any date-only strings. Use Megaphone icon from `lucide-react` (check if it exists, otherwise use `Volume2` or `Bell`).
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/scheduling/BroadcastOpenShiftsDialog.tsx
+git commit -m "feat: add BroadcastOpenShiftsDialog component"
+```
+
+---
+
+### Task 5: Add broadcast button to Scheduling page
+
+**Files:**
+- Modify: `src/pages/Scheduling.tsx`
+- Modify: `src/components/PublishScheduleDialog.tsx`
+
+- [ ] **Step 1: Add broadcast button near publish controls**
+
+In `src/pages/Scheduling.tsx`, near the publish button area (around line 1286), add a "Broadcast" button. Only show when:
+- `open_shifts_enabled` is true (from `useStaffingSettings`)
+- Week is published (`isPublished` from `useWeekPublicationStatus`)
+- There are open shifts (`openShiftCount > 0`)
+
+Button: Megaphone icon, text "Broadcast". If already broadcast, show a subtle check indicator.
+
+Add state for `broadcastDialogOpen` and render `BroadcastOpenShiftsDialog`.
+
+Pass the `publication.id`, `weekStart`, `weekEnd`, `openShiftCount`, `alreadyBroadcast` (from `publication.open_shifts_broadcast_at !== null`), and `broadcastDate`.
+
+- [ ] **Step 2: Update publish dialog text**
+
+In `PublishScheduleDialog.tsx`, when `openShiftsEnabled` is true and the week has already been broadcast, update the message from "You can fill these now or broadcast to your team later" to show "Broadcast sent on {date}" instead.
+
+Add a new prop `broadcastDate?: string | null`. Use `parseDateLocal` if it's a date-only string, or `new Date()` if it includes time.
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `npm run typecheck`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/Scheduling.tsx src/components/PublishScheduleDialog.tsx
+git commit -m "feat: add broadcast button to scheduling page"
+```
+
+---
+
+### Task 6: E2E test — manager broadcasts open shifts
+
+**Files:**
+- Create: `tests/e2e/broadcast-open-shifts.spec.ts`
+
+- [ ] **Step 1: Write the E2E test**
+
+Test flow:
+1. Sign up as manager, create restaurant
+2. Seed: enable open shifts, create template with capacity > 1, publish schedule for current+next week
+3. Navigate to `/scheduling`
+4. Verify "Broadcast" button is visible
+5. Click "Broadcast" button
+6. Verify dialog appears with open shift count
+7. Click "Broadcast to Team" button
+8. Wait for success toast
+9. Verify button shows broadcast-sent indicator
+
+Use accessible selectors. Don't assert on timezone-dependent values. Seed data for all 7 days to handle any day-of-week.
+
+Note: The edge function may not be running in CI without `supabase functions serve`. If the test can't call the edge function, mock the response or mark as a known limitation. Check how other E2E tests handle edge functions.
+
+- [ ] **Step 2: Run the test**
+
+Run: `npx playwright test tests/e2e/broadcast-open-shifts.spec.ts`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/e2e/broadcast-open-shifts.spec.ts
+git commit -m "test: E2E for broadcast open shifts"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Broadcast columns on schedule_publications: Task 1 ✓
+- Edge function (auth, permission, send push, send email, stamp): Task 2 ✓
+- Hook for broadcast mutation: Task 3 ✓
+- Update publication query to return broadcast columns: Task 3 ✓
+- BroadcastOpenShiftsDialog: Task 4 ✓
+- Broadcast button on scheduling page: Task 5 ✓
+- Publish dialog text update: Task 5 ✓
+- Already-broadcast indicator: Task 4 (dialog) + Task 5 (button) ✓
+- Re-broadcast with warning: Task 4 (amber alert in dialog) ✓
+- pgTAP tests: Task 1 ✓
+- E2E test: Task 6 ✓
+
+**Placeholder scan:** No TBDs found. Edge function has complete code. Dialog and button have clear structural guidance with exact props.
+
+**Type consistency:** `BroadcastOpenShiftsDialogProps` uses `openShiftCount`, `alreadyBroadcast`, `broadcastDate` — same names used in Task 5 when passing props. `useBroadcastOpenShifts` return type matches usage in Task 4.

--- a/src/components/PublishScheduleDialog.tsx
+++ b/src/components/PublishScheduleDialog.tsx
@@ -30,6 +30,7 @@ interface PublishScheduleDialogProps {
   totalHours: number;
   openShiftCount: number;
   openShiftsEnabled: boolean;
+  broadcastDate?: string | null;
   onConfirm: (notes?: string) => void;
   onNavigateToSettings?: () => void;
   isPublishing: boolean;
@@ -45,6 +46,7 @@ export const PublishScheduleDialog = ({
   totalHours,
   openShiftCount,
   openShiftsEnabled,
+  broadcastDate,
   onConfirm,
   onNavigateToSettings,
   isPublishing,
@@ -109,7 +111,9 @@ export const PublishScheduleDialog = ({
               <AlertTriangle className="h-4 w-4 text-amber-600" />
               <AlertDescription className="text-sm">
                 <strong>{openShiftCount} {openShiftCount === 1 ? 'shift' : 'shifts'} still {openShiftCount === 1 ? 'needs' : 'need'} staff.</strong>{' '}
-                {openShiftsEnabled ? (
+                {openShiftsEnabled && broadcastDate ? (
+                  `Broadcast sent on ${format(new Date(broadcastDate), 'MMM d')}.`
+                ) : openShiftsEnabled ? (
                   'You can fill these now or broadcast to your team later.'
                 ) : (
                   <>

--- a/src/components/scheduling/BroadcastOpenShiftsDialog.tsx
+++ b/src/components/scheduling/BroadcastOpenShiftsDialog.tsx
@@ -1,0 +1,103 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+
+import { Volume2, AlertTriangle } from 'lucide-react';
+
+import { useBroadcastOpenShifts } from '@/hooks/useBroadcastOpenShifts';
+
+import { format } from 'date-fns';
+
+interface BroadcastOpenShiftsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  restaurantId: string;
+  publicationId: string;
+  weekStart: Date;
+  weekEnd: Date;
+  openShiftCount: number;
+  alreadyBroadcast: boolean;
+  broadcastDate?: string | null;
+}
+
+export function BroadcastOpenShiftsDialog({
+  open,
+  onOpenChange,
+  restaurantId,
+  publicationId,
+  weekStart,
+  weekEnd,
+  openShiftCount,
+  alreadyBroadcast,
+  broadcastDate,
+}: Readonly<BroadcastOpenShiftsDialogProps>) {
+  const broadcastMutation = useBroadcastOpenShifts();
+  const isPending = broadcastMutation.isPending;
+
+  async function handleBroadcast() {
+    await broadcastMutation.mutateAsync({ restaurantId, publicationId });
+    onOpenChange(false);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md max-h-[80vh] overflow-y-auto p-0 gap-0 border-border/40">
+        <DialogHeader className="px-6 pt-6 pb-4 border-b border-border/40">
+          <div className="flex items-center gap-3">
+            <div className="h-10 w-10 rounded-xl bg-muted/50 flex items-center justify-center">
+              <Volume2 className="h-5 w-5 text-foreground" />
+            </div>
+            <div>
+              <DialogTitle className="text-[17px] font-semibold text-foreground">
+                Broadcast Open Shifts
+              </DialogTitle>
+              <p className="text-[13px] text-muted-foreground mt-0.5">
+                Notify your team about available shifts
+              </p>
+            </div>
+          </div>
+        </DialogHeader>
+
+        <div className="px-6 py-5 space-y-4">
+          <div className="rounded-lg bg-muted/30 p-4 space-y-2">
+            <div className="text-[14px] font-medium text-foreground">
+              {openShiftCount} open {openShiftCount === 1 ? 'shift' : 'shifts'} for{' '}
+              {format(weekStart, 'MMM d')} - {format(weekEnd, 'MMM d')}
+            </div>
+            <p className="text-[13px] text-muted-foreground">
+              All active team members will receive a push notification and email.
+            </p>
+          </div>
+
+          {alreadyBroadcast && broadcastDate && (
+            <Alert className="border-amber-500/50 bg-amber-500/10">
+              <AlertTriangle className="h-4 w-4 text-amber-600" />
+              <AlertDescription className="text-sm">
+                Already broadcast on {format(new Date(broadcastDate), 'MMM d')}. Sending again
+                will re-notify your team.
+              </AlertDescription>
+            </Alert>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-2 px-6 pb-5">
+          <Button
+            variant="ghost"
+            onClick={() => onOpenChange(false)}
+            disabled={isPending}
+            className="h-9 px-4 rounded-lg text-[13px] font-medium text-muted-foreground hover:text-foreground"
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={handleBroadcast}
+            disabled={isPending}
+            className="h-9 px-4 rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium"
+          >
+            {isPending ? 'Broadcasting...' : 'Broadcast to Team'}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/hooks/useBroadcastOpenShifts.ts
+++ b/src/hooks/useBroadcastOpenShifts.ts
@@ -21,12 +21,15 @@ export function useBroadcastOpenShifts() {
         success: boolean;
         open_shifts: number;
         push_sent: number;
-        emails_sent: number;
+        push_failed: number;
+        email_sent: number;
+        email_failed: number;
         total_employees: number;
       };
     },
     onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ['schedule-publication'] });
+      queryClient.invalidateQueries({ queryKey: ['week_publication_status'] });
+      queryClient.invalidateQueries({ queryKey: ['schedule_publications'] });
       toast({
         title: 'Broadcast sent',
         description: `Notified ${data.total_employees} team members about ${data.open_shifts} open shifts.`,

--- a/src/hooks/useBroadcastOpenShifts.ts
+++ b/src/hooks/useBroadcastOpenShifts.ts
@@ -1,0 +1,43 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { useToast } from '@/hooks/use-toast';
+
+export function useBroadcastOpenShifts() {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async (params: { restaurantId: string; publicationId: string }) => {
+      const { data, error } = await supabase.functions.invoke('broadcast-open-shifts', {
+        body: {
+          restaurant_id: params.restaurantId,
+          publication_id: params.publicationId,
+        },
+      });
+
+      if (error) throw error;
+      if (!data?.success) throw new Error(data?.error ?? 'Broadcast failed');
+      return data as {
+        success: boolean;
+        open_shifts: number;
+        push_sent: number;
+        emails_sent: number;
+        total_employees: number;
+      };
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['schedule-publication'] });
+      toast({
+        title: 'Broadcast sent',
+        description: `Notified ${data.total_employees} team members about ${data.open_shifts} open shifts.`,
+      });
+    },
+    onError: (error: Error) => {
+      toast({
+        title: 'Broadcast failed',
+        description: error.message,
+        variant: 'destructive',
+      });
+    },
+  });
+}

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -5609,6 +5609,8 @@ export type Database = {
           id: string
           notes: string | null
           notification_sent: boolean
+          open_shifts_broadcast_at: string | null
+          open_shifts_broadcast_by: string | null
           published_at: string
           published_by: string
           restaurant_id: string
@@ -5621,6 +5623,8 @@ export type Database = {
           id?: string
           notes?: string | null
           notification_sent?: boolean
+          open_shifts_broadcast_at?: string | null
+          open_shifts_broadcast_by?: string | null
           published_at?: string
           published_by: string
           restaurant_id: string
@@ -5633,6 +5637,8 @@ export type Database = {
           id?: string
           notes?: string | null
           notification_sent?: boolean
+          open_shifts_broadcast_at?: string | null
+          open_shifts_broadcast_by?: string | null
           published_at?: string
           published_by?: string
           restaurant_id?: string

--- a/src/pages/Scheduling.tsx
+++ b/src/pages/Scheduling.tsx
@@ -30,6 +30,7 @@ import { AvailabilityDialog } from '@/components/AvailabilityDialog';
 import { AvailabilityExceptionDialog } from '@/components/AvailabilityExceptionDialog';
 import { ScheduleStatusBadge } from '@/components/ScheduleStatusBadge';
 import { PublishScheduleDialog } from '@/components/PublishScheduleDialog';
+import { BroadcastOpenShiftsDialog } from '@/components/scheduling/BroadcastOpenShiftsDialog';
 import { ChangeLogDialog } from '@/components/ChangeLogDialog';
 import { TradeApprovalQueue } from '@/components/schedule/TradeApprovalQueue';
 import { LaborCostBreakdown } from '@/components/scheduling/LaborCostBreakdown';
@@ -87,6 +88,7 @@ import {
   CheckSquare,
   Check,
   Pencil,
+  Volume2,
 } from 'lucide-react';
 import { format, startOfWeek, endOfWeek, addWeeks, subWeeks, eachDayOfInterval, isSameDay, parseISO, isToday } from 'date-fns';
 import * as dateFnsTz from 'date-fns-tz';
@@ -346,6 +348,7 @@ const Scheduling = () => {
   const [changeLogDialogOpen, setChangeLogDialogOpen] = useState(false);
   const [unpublishDialogOpen, setUnpublishDialogOpen] = useState(false);
   const [exportDialogOpen, setExportDialogOpen] = useState(false);
+  const [broadcastDialogOpen, setBroadcastDialogOpen] = useState(false);
   const [shiftImportOpen, setShiftImportOpen] = useState(false);
   const [copyDialogOpen, setCopyDialogOpen] = useState(false);
   const [recurringActionDialog, setRecurringActionDialog] = useState<{
@@ -1281,6 +1284,30 @@ const Scheduling = () => {
                       <Unlock className="h-3.5 w-3.5 mr-1.5" />
                       Unpublish
                     </Button>
+                    {staffingSettings.open_shifts_enabled && openShiftCount > 0 && (
+                      <Button
+                        variant={publication?.open_shifts_broadcast_at ? 'ghost' : 'outline'}
+                        size="sm"
+                        onClick={() => setBroadcastDialogOpen(true)}
+                        className={cn(
+                          'h-9 text-xs',
+                          publication?.open_shifts_broadcast_at && 'text-muted-foreground'
+                        )}
+                        aria-label="Broadcast open shifts"
+                      >
+                        {publication?.open_shifts_broadcast_at ? (
+                          <>
+                            <Check className="h-3.5 w-3.5 mr-1.5 text-green-600" />
+                            Broadcast Sent
+                          </>
+                        ) : (
+                          <>
+                            <Volume2 className="h-3.5 w-3.5 mr-1.5" />
+                            Broadcast
+                          </>
+                        )}
+                      </Button>
+                    )}
                   </>
                 ) : (
                   <Button
@@ -1867,9 +1894,23 @@ const Scheduling = () => {
         totalHours={totalScheduledHours}
         openShiftCount={openShiftCount}
         openShiftsEnabled={staffingSettings.open_shifts_enabled}
+        broadcastDate={publication?.open_shifts_broadcast_at ?? null}
         onNavigateToSettings={() => navigate('/settings?tab=labor-planning')}
         onConfirm={handlePublishSchedule}
         isPublishing={publishSchedule.isPending}
+      />
+
+      {/* Broadcast Open Shifts Dialog */}
+      <BroadcastOpenShiftsDialog
+        open={broadcastDialogOpen}
+        onOpenChange={setBroadcastDialogOpen}
+        restaurantId={restaurantId ?? ''}
+        publicationId={publication?.id ?? ''}
+        weekStart={currentWeekStart}
+        weekEnd={weekEnd}
+        openShiftCount={openShiftCount}
+        alreadyBroadcast={!!publication?.open_shifts_broadcast_at}
+        broadcastDate={publication?.open_shifts_broadcast_at ?? null}
       />
 
       {/* Change Log Dialog */}

--- a/src/types/scheduling.ts
+++ b/src/types/scheduling.ts
@@ -229,6 +229,8 @@ export interface SchedulePublication {
   published_by: string;
   notes: string | null;
   shift_count: number;
+  open_shifts_broadcast_at: string | null;
+  open_shifts_broadcast_by: string | null;
 }
 
 // Daily labor allocation for salaried/contractor employees

--- a/supabase/functions/broadcast-open-shifts/index.ts
+++ b/supabase/functions/broadcast-open-shifts/index.ts
@@ -1,0 +1,298 @@
+import { generateHeader } from '../_shared/emailTemplates.ts';
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { corsHeaders } from "../_shared/cors.ts";
+import { sendEmail, NOTIFICATION_FROM, APP_URL } from "../_shared/notificationHelpers.ts";
+import { sendWebPushToUser } from "../_shared/webPushHelper.ts";
+
+const RESEND_API_KEY = Deno.env.get("RESEND_API_KEY");
+
+interface BroadcastPayload {
+  restaurant_id: string;
+  publication_id: string;
+}
+
+serve(async (req) => {
+  // Handle CORS preflight
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    // Authenticate user
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader) {
+      throw new Error("Missing authorization header");
+    }
+
+    const supabase = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_ANON_KEY") ?? "",
+      {
+        global: {
+          headers: { Authorization: authHeader },
+        },
+      }
+    );
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      throw new Error("Unauthorized");
+    }
+
+    // Parse request body
+    const payload: BroadcastPayload = await req.json();
+    const { restaurant_id, publication_id } = payload;
+
+    if (!restaurant_id || !publication_id) {
+      return new Response(
+        JSON.stringify({ error: "restaurant_id and publication_id are required" }),
+        {
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+          status: 400,
+        }
+      );
+    }
+
+    // Verify caller is owner/manager
+    const { data: userRestaurant, error: permError } = await supabase
+      .from("user_restaurants")
+      .select("role")
+      .eq("user_id", user.id)
+      .eq("restaurant_id", restaurant_id)
+      .single();
+
+    if (permError || !userRestaurant || !["owner", "manager"].includes(userRestaurant.role)) {
+      throw new Error("Access denied");
+    }
+
+    // Create service role client for subsequent operations
+    const serviceClient = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
+    );
+
+    // Fetch the publication
+    const { data: publication, error: pubError } = await serviceClient
+      .from("schedule_publications")
+      .select("id, restaurant_id, week_start_date, week_end_date")
+      .eq("id", publication_id)
+      .eq("restaurant_id", restaurant_id)
+      .single();
+
+    if (pubError || !publication) {
+      return new Response(
+        JSON.stringify({ error: "Publication not found" }),
+        {
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+          status: 404,
+        }
+      );
+    }
+
+    // Call get_open_shifts RPC to check for open shifts
+    const { data: openShifts, error: openShiftsError } = await serviceClient
+      .rpc("get_open_shifts", {
+        p_restaurant_id: restaurant_id,
+        p_week_start: publication.week_start_date,
+        p_week_end: publication.week_end_date,
+      });
+
+    if (openShiftsError) {
+      console.error("Error fetching open shifts:", openShiftsError);
+      throw new Error("Failed to fetch open shifts");
+    }
+
+    // Sum up open spots across all shifts
+    const totalOpenSpots = (openShifts || []).reduce(
+      (sum: number, shift: { open_spots: number }) => sum + Number(shift.open_spots),
+      0
+    );
+
+    if (totalOpenSpots === 0) {
+      return new Response(
+        JSON.stringify({ error: "No open shifts available for this week" }),
+        {
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+          status: 400,
+        }
+      );
+    }
+
+    // Format dates for notification body
+    const formatDate = (dateStr: string) => {
+      const date = new Date(dateStr + "T00:00:00");
+      return date.toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+      });
+    };
+
+    const weekStartFormatted = formatDate(publication.week_start_date);
+    const weekEndFormatted = formatDate(publication.week_end_date);
+    const dateRange = `${weekStartFormatted} - ${weekEndFormatted}`;
+
+    const shiftWord = totalOpenSpots === 1 ? "shift is" : "shifts are";
+    const notificationBody = `${totalOpenSpots} ${shiftWord} open for the week of ${dateRange}. Claim a spot!`;
+
+    // Fetch all active employees for the restaurant
+    const { data: employees, error: empError } = await serviceClient
+      .from("employees")
+      .select("id, name, email, user_id")
+      .eq("restaurant_id", restaurant_id)
+      .eq("status", "active");
+
+    if (empError) {
+      console.error("Error fetching employees:", empError);
+      throw new Error("Failed to fetch employees");
+    }
+
+    const allEmployees = employees || [];
+    let pushSentCount = 0;
+    let pushFailCount = 0;
+    let emailSentCount = 0;
+    let emailFailCount = 0;
+
+    // Send web push notifications to employees with user_id
+    const pushEmployees = allEmployees.filter((emp) => emp.user_id);
+    for (const employee of pushEmployees) {
+      try {
+        const result = await sendWebPushToUser(serviceClient, employee.user_id!, restaurant_id, {
+          title: "Shifts Available",
+          body: notificationBody,
+          url: "/employee/shifts",
+        });
+        pushSentCount += result.sent;
+      } catch (err) {
+        pushFailCount++;
+        console.error(`Push notification failed for employee ${employee.id}:`, err);
+      }
+    }
+
+    // Send email notifications to employees with email
+    if (RESEND_API_KEY) {
+      const emailEmployees = allEmployees.filter((emp) => emp.email);
+      const appUrl = `${APP_URL}/employee/shifts`;
+
+      for (const employee of emailEmployees) {
+        try {
+          const subject = `${totalOpenSpots} Open Shift${totalOpenSpots === 1 ? "" : "s"} Available — ${dateRange}`;
+          const html = `
+            <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; max-width: 600px; margin: 0 auto; background-color: #ffffff;">
+              ${generateHeader()}
+
+              <!-- Content -->
+              <div style="padding: 40px 32px; background-color: #ffffff;">
+                <h1 style="color: #1f2937; font-size: 24px; font-weight: 600; margin: 0 0 16px 0; line-height: 1.3;">Shifts Available</h1>
+
+                <p style="color: #4b5563; line-height: 1.6; font-size: 16px; margin: 0 0 24px 0;">
+                  Hi <strong style="color: #1f2937;">${employee.name}</strong>,
+                </p>
+
+                <p style="color: #4b5563; line-height: 1.6; font-size: 16px; margin: 0 0 24px 0;">
+                  <strong style="color: #1f2937;">${totalOpenSpots} ${shiftWord}</strong> open for the week of <strong style="color: #1f2937;">${dateRange}</strong>. Claim a spot before they fill up!
+                </p>
+
+                <div style="background: linear-gradient(135deg, #eff6ff 0%, #dbeafe 100%); padding: 24px; border-radius: 12px; margin: 24px 0; border-left: 4px solid #3b82f6;">
+                  <table style="width: 100%; border-collapse: collapse;">
+                    <tr>
+                      <td style="padding: 6px 0; color: #4b5563; font-size: 14px; font-weight: 600;">Open Shifts:</td>
+                      <td style="padding: 6px 0; color: #1f2937; font-size: 14px; text-align: right;">${totalOpenSpots}</td>
+                    </tr>
+                    <tr>
+                      <td style="padding: 6px 0; color: #4b5563; font-size: 14px; font-weight: 600;">Week:</td>
+                      <td style="padding: 6px 0; color: #1f2937; font-size: 14px; text-align: right;">${dateRange}</td>
+                    </tr>
+                  </table>
+                </div>
+
+                <div style="text-align: center; margin: 32px 0;">
+                  <a href="${appUrl}"
+                     style="background-color: #2563eb; background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%); color: #ffffff !important; padding: 14px 32px; text-decoration: none; border-radius: 8px; display: inline-block; font-weight: 600; font-size: 16px; box-shadow: 0 4px 12px rgba(37, 99, 235, 0.3); mso-padding-alt: 14px 32px; border: 2px solid #2563eb;">
+                    <span style="color: #ffffff !important;">View Open Shifts</span>
+                  </a>
+                </div>
+
+                <p style="color: #6b7280; font-size: 14px; margin: 32px 0 0 0; line-height: 1.6;">
+                  Open shifts are available on a first-come, first-served basis. Claim yours before they're taken!
+                </p>
+              </div>
+
+              <!-- Footer -->
+              <div style="background-color: #f9fafb; padding: 24px 32px; border-radius: 0 0 8px 8px; border-top: 1px solid #e5e7eb;">
+                <p style="color: #6b7280; font-size: 13px; text-align: center; margin: 0; line-height: 1.5;">
+                  <strong style="color: #4b5563;">EasyShiftHQ</strong><br>
+                  Restaurant Operations Management System
+                </p>
+                <p style="color: #9ca3af; font-size: 12px; text-align: center; margin: 12px 0 0 0;">
+                  &copy; ${new Date().getFullYear()} EasyShiftHQ. All rights reserved.
+                </p>
+                <p style="color: #9ca3af; font-size: 12px; text-align: center; margin: 8px 0 0 0;">
+                  This is an automated notification. Please do not reply to this email.
+                </p>
+              </div>
+            </div>
+          `;
+
+          const success = await sendEmail(RESEND_API_KEY, NOTIFICATION_FROM, employee.email!, subject, html);
+          if (success) {
+            emailSentCount++;
+          } else {
+            emailFailCount++;
+          }
+        } catch (err) {
+          emailFailCount++;
+          console.error(`Email failed for employee ${employee.id}:`, err);
+        }
+      }
+    }
+
+    // Stamp the publication with broadcast timestamp and user
+    const { error: updateError } = await serviceClient
+      .from("schedule_publications")
+      .update({
+        open_shifts_broadcast_at: new Date().toISOString(),
+        open_shifts_broadcast_by: user.id,
+      })
+      .eq("id", publication_id);
+
+    if (updateError) {
+      console.error("Error updating publication broadcast timestamp:", updateError);
+    }
+
+    console.log(
+      `Broadcast open shifts: ${pushSentCount} push, ${emailSentCount} email sent for publication ${publication_id}`
+    );
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        open_shifts: totalOpenSpots,
+        push_sent: pushSentCount,
+        push_failed: pushFailCount,
+        email_sent: emailSentCount,
+        email_failed: emailFailCount,
+        total_employees: allEmployees.length,
+      }),
+      {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+        status: 200,
+      }
+    );
+  } catch (error: unknown) {
+    console.error("Error in broadcast-open-shifts:", error);
+    return new Response(
+      JSON.stringify({
+        error: error instanceof Error ? error.message : "An error occurred",
+      }),
+      {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+        status: 500,
+      }
+    );
+  }
+});

--- a/supabase/migrations/20260412235417_add_broadcast_to_publications.sql
+++ b/supabase/migrations/20260412235417_add_broadcast_to_publications.sql
@@ -1,0 +1,3 @@
+ALTER TABLE schedule_publications
+  ADD COLUMN IF NOT EXISTS open_shifts_broadcast_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS open_shifts_broadcast_by UUID REFERENCES auth.users(id);

--- a/supabase/tests/broadcast_open_shifts.test.sql
+++ b/supabase/tests/broadcast_open_shifts.test.sql
@@ -1,0 +1,17 @@
+BEGIN;
+SELECT plan(4);
+
+SELECT has_column('schedule_publications', 'open_shifts_broadcast_at',
+  'schedule_publications should have open_shifts_broadcast_at column');
+
+SELECT has_column('schedule_publications', 'open_shifts_broadcast_by',
+  'schedule_publications should have open_shifts_broadcast_by column');
+
+SELECT col_is_null('schedule_publications', 'open_shifts_broadcast_at',
+  'open_shifts_broadcast_at should be nullable');
+
+SELECT col_is_null('schedule_publications', 'open_shifts_broadcast_by',
+  'open_shifts_broadcast_by should be nullable');
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/tests/e2e/broadcast-open-shifts.spec.ts
+++ b/tests/e2e/broadcast-open-shifts.spec.ts
@@ -1,0 +1,159 @@
+import { test, expect } from '@playwright/test';
+import { signUpAndCreateRestaurant, exposeSupabaseHelpers, generateTestUser } from '../helpers/e2e-supabase';
+
+test.describe('Broadcast Open Shifts', () => {
+  test('manager sees broadcast button and dialog when open shifts exist', async ({ page }) => {
+    // 1. Sign up, create restaurant
+    const testUser = generateTestUser('broadcast');
+    await signUpAndCreateRestaurant(page, testUser);
+    await exposeSupabaseHelpers(page);
+
+    const restaurantId = await page.evaluate(() => (window as any).__getRestaurantId());
+    expect(restaurantId).toBeTruthy();
+
+    // 2. Seed required data via page.evaluate
+    await page.evaluate(async ({ restId }) => {
+      const supabase = (window as any).__supabase;
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user?.id) throw new Error('No authenticated user found');
+
+      // Enable open shifts in staffing settings
+      const { error: settingsError } = await supabase
+        .from('staffing_settings')
+        .upsert({
+          restaurant_id: restId,
+          open_shifts_enabled: true,
+        }, { onConflict: 'restaurant_id' });
+      if (settingsError) throw new Error(`staffing_settings upsert failed: ${settingsError.message}`);
+
+      // Create an employee linked to the current user
+      const { data: employee, error: empError } = await supabase
+        .from('employees')
+        .insert({
+          restaurant_id: restId,
+          user_id: user.id,
+          name: 'Jane Server',
+          position: 'Server',
+          status: 'active',
+          is_active: true,
+          compensation_type: 'hourly',
+          hourly_rate: 1500,
+        })
+        .select()
+        .single();
+      if (empError) throw new Error(`employees insert failed: ${empError.message}`);
+
+      // Create shift template with capacity=3 for all days
+      // capacity=3 means 2 open spots after 1 assigned shift → openShiftCount > 0
+      const { error: templateError } = await supabase
+        .from('shift_templates')
+        .insert({
+          restaurant_id: restId,
+          name: 'Evening Server',
+          start_time: '16:00:00',
+          end_time: '22:00:00',
+          position: 'Server',
+          capacity: 3,
+          days: [0, 1, 2, 3, 4, 5, 6], // All days — works regardless of day-of-week
+          is_active: true,
+        });
+      if (templateError) throw new Error(`shift_templates insert failed: ${templateError.message}`);
+
+      // Compute this week's Monday date string in local time
+      // (same logic as date-fns startOfWeek({ weekStartsOn: 1 }))
+      const now = new Date();
+      const day = now.getDay();
+      const diff = day === 0 ? -6 : 1 - day;
+      const monday = new Date(now.getFullYear(), now.getMonth(), now.getDate() + diff);
+
+      const pad = (n: number) => String(n).padStart(2, '0');
+      const fmt = (d: Date) => `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+      const mondayStr = fmt(monday);
+
+      // Insert a draft shift for Monday at noon local time (avoids timezone edge cases)
+      // The publish_schedule RPC uses start_time::date which compares local date
+      const shiftStart = new Date(monday);
+      shiftStart.setHours(12, 0, 0, 0); // noon local
+
+      const shiftEnd = new Date(monday);
+      shiftEnd.setHours(18, 0, 0, 0); // 6pm local
+
+      const { error: shiftError } = await supabase
+        .from('shifts')
+        .insert({
+          restaurant_id: restId,
+          employee_id: employee.id,
+          start_time: shiftStart.toISOString(),
+          end_time: shiftEnd.toISOString(),
+          position: 'Server',
+          source: 'manual',
+        });
+      if (shiftError) throw new Error(`shifts insert failed: ${shiftError.message}`);
+
+      return { mondayStr };
+    }, { restId: restaurantId as string });
+
+    // 3. Navigate to scheduling
+    await page.goto('/scheduling');
+    await page.waitForLoadState('networkidle');
+
+    // 4. Wait for the shift to appear in the schedule grid (confirms data is loaded)
+    // Scope to the Schedule tabpanel to avoid the LaborCostBreakdown duplicate
+    await expect(page.getByRole('tabpanel', { name: 'Schedule' }).getByText('Jane Server').first()).toBeVisible({ timeout: 15000 });
+
+    // 5. Click the Publish button to enter published state
+    // The Publish button is the primary action button (not "Publish Schedule" inside the dialog)
+    const publishBtn = page.getByRole('button', { name: 'Publish', exact: true });
+    await expect(publishBtn).toBeVisible({ timeout: 10000 });
+    await publishBtn.click();
+
+    // 6. Confirm publish in the dialog
+    const publishDialog = page.getByRole('dialog', { name: /publish schedule/i });
+    await expect(publishDialog).toBeVisible({ timeout: 5000 });
+    const confirmBtn = publishDialog.getByRole('button', { name: /publish schedule/i });
+    await expect(confirmBtn).toBeVisible();
+
+    // Intercept the publish_schedule RPC call before clicking confirm
+    const publishResponsePromise = page.waitForResponse(
+      (resp) => resp.url().includes('publish_schedule') && resp.status() === 200,
+      { timeout: 20000 }
+    );
+    await confirmBtn.click();
+    await publishResponsePromise;
+
+    // Dismiss any toast that appeared after publishing (may overlay buttons)
+    const toast = page.locator('[data-sonner-toast]').first();
+    if (await toast.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await toast.locator('button[aria-label="Close"]').click().catch(() => {});
+    }
+
+    // 7. Reload the page to force React Query to refetch week_publication_status
+    // (the publish mutation invalidates shifts but not week_publication_status query key)
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+
+    // Wait for the page to reflect published state — "Unpublish" button signals success
+    await expect(page.getByRole('button', { name: /unpublish/i })).toBeVisible({ timeout: 15000 });
+
+    // 8. Verify Broadcast button appears
+    // Conditions: open_shifts_enabled=true, openShiftCount>0 (capacity=3, 1 assigned → 2 open)
+    const broadcastBtn = page.getByRole('button', { name: /broadcast open shifts/i });
+    await expect(broadcastBtn).toBeVisible({ timeout: 10000 });
+
+    // 9. Click broadcast button to open dialog
+    await broadcastBtn.click();
+
+    // 10. Verify dialog opens with correct title
+    const dialog = page.getByRole('dialog', { name: /broadcast open shifts/i });
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    // 11. Verify dialog shows open shift count info and team member notification copy
+    // Use first() to handle the title "Broadcast Open Shifts" also matching /open shift/i
+    await expect(dialog.getByText(/open shifts? for/i).first()).toBeVisible();
+    await expect(dialog.getByText(/team members/i)).toBeVisible();
+
+    // 12. Cancel the dialog (don't actually broadcast — edge function may not be running)
+    await dialog.getByRole('button', { name: /cancel/i }).click();
+    await expect(dialog).not.toBeVisible({ timeout: 3000 });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds "Broadcast" button to scheduling page (visible when open shifts exist + feature enabled + schedule published)
- `BroadcastOpenShiftsDialog` with preview of open shift count, re-broadcast warning if already sent
- `broadcast-open-shifts` edge function sends web push notifications (via `sendWebPushToUser`) and emails (via Resend) to all active employees
- Broadcast tracked per-publication via `open_shifts_broadcast_at` column to prevent accidental spam
- Publish dialog shows "Broadcast sent on {date}" when already broadcast

**This is PR3 of 3** for the Open Shift Claiming feature. Completes the feature.
- PR1: Managers see capacity gaps (#452)
- PR2: Employees claim shifts (#457)
- PR3: Managers broadcast openings (this PR)

## Test plan

- [x] pgTAP: broadcast columns exist (4 tests)
- [x] All 3473 unit tests pass
- [x] E2E: manager sees broadcast button, opens dialog, verifies content
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added broadcast button to schedule publication workflow
  * Added broadcast confirmation dialog displaying shift summary
  * Added tracking of broadcast timestamps and initiators
  * Notifications now sent to team members upon broadcast

* **Tests**
  * Added end-to-end test coverage for broadcast workflow
  * Added database schema validation tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->