### PR TITLE
fix: restore missing parseISO import crashing /employee/shifts

### DIFF
--- a/src/pages/AvailableShiftsPage.tsx
+++ b/src/pages/AvailableShiftsPage.tsx
@@ -40,7 +40,7 @@ import { ClaimConfirmDialog } from '@/components/scheduling/ClaimConfirmDialog';
 
 import type { OpenShift, OpenShiftClaim } from '@/types/scheduling';
 
-import { format, startOfWeek, addDays } from 'date-fns';
+import { format, parseISO, startOfWeek, addDays } from 'date-fns';
 import { parseDateLocal } from '@/lib/dateUtils';
 import { WEEK_STARTS_ON } from '@/lib/dateConfig';
 import { cn } from '@/lib/utils';


### PR DESCRIPTION
## Summary
- PR #462 removed `parseISO` from the `date-fns` import in `AvailableShiftsPage.tsx` while migrating one usage to `parseDateLocal`, but left three other `parseISO` calls intact in the `TradeCard` component
- This causes `ReferenceError: parseISO is not defined` when employees view available shifts at `/employee/shifts`
- Fix: re-add `parseISO` to the import (the remaining calls operate on full ISO timestamps, not date-only strings, so `parseISO` is the correct function)

## Test plan
- [x] TypeScript typecheck passes
- [x] Production build succeeds
- [ ] Visit `/employee/shifts` as an employee with available trades — page loads without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to enhance code functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->