### PR TITLE
fix: timezone-aware shift creation and counting in open shift claims

### DIFF
--- a/docs/superpowers/plans/2026-04-12-open-shift-broadcast-pr3-plan.md
+++ b/docs/superpowers/plans/2026-04-12-open-shift-broadcast-pr3-plan.md
@@ -1,0 +1,509 @@
+# Open Shift Broadcast PR3 — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Managers can broadcast open shifts to all active employees via push notification and email.
+
+**Architecture:** A "Broadcast" button on the scheduling page opens a confirmation dialog. On confirm, it calls a new `broadcast-open-shifts` edge function that sends web push notifications (via `sendWebPushToUser`) and emails (via Resend) to all active employees, then stamps the publication with the broadcast timestamp.
+
+**Tech Stack:** PostgreSQL migration, Deno edge function, TypeScript/React, React Query, Vitest, pgTAP, Playwright
+
+**Design spec:** `docs/superpowers/specs/2026-04-12-open-shift-broadcast-pr3-design.md`
+
+**IMPORTANT:** Before writing any Supabase query, verify actual table/column names via `npx supabase db dump --local --schema public 2>&1 | grep -A 20 "CREATE TABLE.*<table_name>"`. Never trust plan text for column names.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `supabase/migrations/YYYYMMDD_add_broadcast_to_publications.sql` | Add broadcast columns |
+| `supabase/tests/broadcast_open_shifts.test.sql` | pgTAP tests |
+| `supabase/functions/broadcast-open-shifts/index.ts` | Edge function: send notifications |
+| `src/hooks/useBroadcastOpenShifts.ts` | Mutation hook for broadcast |
+| `src/components/scheduling/BroadcastOpenShiftsDialog.tsx` | Confirmation dialog |
+| `src/pages/Scheduling.tsx` | Add broadcast button |
+| `src/hooks/useSchedulePublish.tsx` | Update to return broadcast columns |
+| `tests/unit/broadcastOpenShifts.test.ts` | Unit tests |
+| `tests/e2e/broadcast-open-shifts.spec.ts` | E2E test |
+
+---
+
+### Task 1: Database migration — add broadcast columns
+
+**Files:**
+- Create: `supabase/migrations/YYYYMMDD_add_broadcast_to_publications.sql`
+- Create: `supabase/tests/broadcast_open_shifts.test.sql`
+
+- [ ] **Step 1: Write pgTAP test**
+
+Create `supabase/tests/broadcast_open_shifts.test.sql`:
+
+```sql
+BEGIN;
+SELECT plan(4);
+
+SELECT has_column('schedule_publications', 'open_shifts_broadcast_at',
+  'schedule_publications should have open_shifts_broadcast_at column');
+
+SELECT has_column('schedule_publications', 'open_shifts_broadcast_by',
+  'schedule_publications should have open_shifts_broadcast_by column');
+
+SELECT col_is_null('schedule_publications', 'open_shifts_broadcast_at',
+  'open_shifts_broadcast_at should be nullable');
+
+SELECT col_is_null('schedule_publications', 'open_shifts_broadcast_by',
+  'open_shifts_broadcast_by should be nullable');
+
+SELECT * FROM finish();
+ROLLBACK;
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test:db`
+Expected: FAIL — columns don't exist.
+
+- [ ] **Step 3: Write the migration**
+
+Run `npx supabase migration new add_broadcast_to_publications` then write:
+
+```sql
+-- Track when open shifts were broadcast for each published week
+ALTER TABLE schedule_publications
+  ADD COLUMN IF NOT EXISTS open_shifts_broadcast_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS open_shifts_broadcast_by UUID REFERENCES auth.users(id);
+```
+
+- [ ] **Step 4: Reset DB and run tests**
+
+Run: `npx supabase db reset && npm run test:db`
+Expected: All pgTAP tests pass.
+
+- [ ] **Step 5: Regenerate types**
+
+Run: `npx supabase gen types typescript --local 2>/dev/null > src/integrations/supabase/types.ts`
+Verify line 1 starts with `export type`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add supabase/migrations/*_add_broadcast_to_publications.sql supabase/tests/broadcast_open_shifts.test.sql src/integrations/supabase/types.ts
+git commit -m "feat: add broadcast columns to schedule_publications"
+```
+
+---
+
+### Task 2: Edge function — broadcast-open-shifts
+
+**Files:**
+- Create: `supabase/functions/broadcast-open-shifts/index.ts`
+
+- [ ] **Step 1: Verify schema before writing queries**
+
+Run:
+```bash
+npx supabase db dump --local --schema public 2>&1 | grep -A 25 "CREATE TABLE.*schedule_publications"
+npx supabase db dump --local --schema public 2>&1 | grep -A 15 "CREATE TABLE.*employees"
+```
+
+Note exact column names for employees (need: `id`, `user_id`, `name`, `is_active`, `restaurant_id`) and schedule_publications.
+
+- [ ] **Step 2: Create the edge function**
+
+Create `supabase/functions/broadcast-open-shifts/index.ts`:
+
+```typescript
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { corsHeaders } from '../_shared/cors.ts';
+import { sendWebPushToUser } from '../_shared/webPushHelper.ts';
+import { sendEmail, getManagerEmails, NOTIFICATION_FROM, APP_URL } from '../_shared/notificationHelpers.ts';
+
+Deno.serve(async (req) => {
+  // CORS preflight
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders });
+  }
+
+  try {
+    const authHeader = req.headers.get('Authorization');
+    if (!authHeader) {
+      return new Response(JSON.stringify({ error: 'Missing authorization' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Create client with user's auth
+    const supabase = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_ANON_KEY')!,
+      { global: { headers: { Authorization: authHeader } } }
+    );
+
+    // Verify authenticated user
+    const { data: { user }, error: authError } = await supabase.auth.getUser();
+    if (authError || !user) {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    const { restaurant_id, publication_id } = await req.json();
+
+    if (!restaurant_id || !publication_id) {
+      return new Response(JSON.stringify({ error: 'Missing restaurant_id or publication_id' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Verify caller is owner/manager
+    const { data: userRole } = await supabase
+      .from('user_restaurants')
+      .select('role')
+      .eq('user_id', user.id)
+      .eq('restaurant_id', restaurant_id)
+      .single();
+
+    if (!userRole || !['owner', 'manager'].includes(userRole.role)) {
+      return new Response(JSON.stringify({ error: 'Manager access required' }), {
+        status: 403,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Use service role client for operations
+    const serviceClient = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
+    );
+
+    // Fetch publication
+    const { data: publication, error: pubError } = await serviceClient
+      .from('schedule_publications')
+      .select('*')
+      .eq('id', publication_id)
+      .eq('restaurant_id', restaurant_id)
+      .single();
+
+    if (pubError || !publication) {
+      return new Response(JSON.stringify({ error: 'Publication not found' }), {
+        status: 404,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Check open shifts exist
+    const { data: openShifts } = await serviceClient.rpc('get_open_shifts', {
+      p_restaurant_id: restaurant_id,
+      p_week_start: publication.week_start_date,
+      p_week_end: publication.week_end_date,
+    });
+
+    const openShiftCount = openShifts?.length ?? 0;
+    if (openShiftCount === 0) {
+      return new Response(JSON.stringify({ error: 'No open shifts to broadcast' }), {
+        status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Fetch all active employees with user_id
+    const { data: employees } = await serviceClient
+      .from('employees')
+      .select('id, user_id, name, email')
+      .eq('restaurant_id', restaurant_id)
+      .eq('is_active', true);
+
+    const activeEmployees = employees ?? [];
+    let pushSent = 0;
+    let emailsSent = 0;
+
+    // Format week label
+    const weekLabel = `${publication.week_start_date} to ${publication.week_end_date}`;
+    const notificationBody = `${openShiftCount} shift${openShiftCount > 1 ? 's are' : ' is'} open for the week of ${weekLabel}. Claim a spot!`;
+
+    // Send push notifications
+    for (const emp of activeEmployees) {
+      if (!emp.user_id) continue;
+      try {
+        const result = await sendWebPushToUser(serviceClient, emp.user_id, restaurant_id, {
+          title: 'Shifts Available',
+          body: notificationBody,
+          url: '/employee/shifts',
+        });
+        pushSent += result.sent;
+      } catch {
+        // Push failures are non-fatal — continue to next employee
+      }
+    }
+
+    // Send emails
+    const resendApiKey = Deno.env.get('RESEND_API_KEY');
+    if (resendApiKey) {
+      for (const emp of activeEmployees) {
+        if (!emp.email) continue;
+        try {
+          const sent = await sendEmail(
+            resendApiKey,
+            NOTIFICATION_FROM,
+            emp.email,
+            'Shifts Available — Claim a Spot',
+            `<p>Hi ${emp.name},</p>
+            <p>${notificationBody}</p>
+            <p><a href="${APP_URL}/employee/shifts">View Available Shifts</a></p>`
+          );
+          if (sent) emailsSent++;
+        } catch {
+          // Email failures are non-fatal
+        }
+      }
+    }
+
+    // Stamp the publication
+    await serviceClient
+      .from('schedule_publications')
+      .update({
+        open_shifts_broadcast_at: new Date().toISOString(),
+        open_shifts_broadcast_by: user.id,
+      })
+      .eq('id', publication_id);
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        open_shifts: openShiftCount,
+        push_sent: pushSent,
+        emails_sent: emailsSent,
+        employees_notified: activeEmployees.length,
+      }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  } catch (error) {
+    return new Response(
+      JSON.stringify({ error: error instanceof Error ? error.message : 'Internal error' }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    );
+  }
+});
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add supabase/functions/broadcast-open-shifts/index.ts
+git commit -m "feat: add broadcast-open-shifts edge function"
+```
+
+---
+
+### Task 3: Hook — useBroadcastOpenShifts
+
+**Files:**
+- Create: `src/hooks/useBroadcastOpenShifts.ts`
+- Modify: `src/hooks/useSchedulePublish.tsx`
+
+- [ ] **Step 1: Create the broadcast mutation hook**
+
+Create `src/hooks/useBroadcastOpenShifts.ts`:
+
+```typescript
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { useToast } from '@/hooks/use-toast';
+
+export function useBroadcastOpenShifts() {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async (params: { restaurantId: string; publicationId: string }) => {
+      const { data, error } = await supabase.functions.invoke('broadcast-open-shifts', {
+        body: {
+          restaurant_id: params.restaurantId,
+          publication_id: params.publicationId,
+        },
+      });
+
+      if (error) throw error;
+      if (!data?.success) throw new Error(data?.error ?? 'Broadcast failed');
+      return data as {
+        success: boolean;
+        open_shifts: number;
+        push_sent: number;
+        emails_sent: number;
+        employees_notified: number;
+      };
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['schedule-publication'] });
+      toast({
+        title: 'Broadcast sent',
+        description: `Notified ${data.employees_notified} team members about ${data.open_shifts} open shifts.`,
+      });
+    },
+    onError: (error: Error) => {
+      toast({
+        title: 'Broadcast failed',
+        description: error.message,
+        variant: 'destructive',
+      });
+    },
+  });
+}
+```
+
+- [ ] **Step 2: Update useSchedulePublish to return broadcast columns**
+
+Read `src/hooks/useSchedulePublish.tsx` and find the `useWeekPublicationStatus` hook. Its query selects from `schedule_publications`. Add `open_shifts_broadcast_at` and `open_shifts_broadcast_by` to the `.select()` call.
+
+Also update the return type/interface to include these fields, and the `SchedulePublication` type in `src/types/scheduling.ts` if needed.
+
+**IMPORTANT:** Verify the exact `.select()` call — per the lesson about explicit selects, check if it uses `*` or an explicit column list. If explicit, add the new columns.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/hooks/useBroadcastOpenShifts.ts src/hooks/useSchedulePublish.tsx
+git commit -m "feat: add useBroadcastOpenShifts hook and update publication query"
+```
+
+---
+
+### Task 4: BroadcastOpenShiftsDialog component
+
+**Files:**
+- Create: `src/components/scheduling/BroadcastOpenShiftsDialog.tsx`
+
+- [ ] **Step 1: Create the dialog component**
+
+```typescript
+interface BroadcastOpenShiftsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  restaurantId: string;
+  publicationId: string;
+  weekStart: Date;
+  weekEnd: Date;
+  openShiftCount: number;
+  alreadyBroadcast: boolean;
+  broadcastDate?: string | null;
+}
+```
+
+Layout following CLAUDE.md dialog structure:
+- Header: Megaphone icon + "Broadcast Open Shifts"
+- Body:
+  - "{openShiftCount} open shifts for the week of {weekStart} - {weekEnd}"
+  - "All active team members will be notified via push notification and email"
+  - If `alreadyBroadcast`: amber alert "Already broadcast on {broadcastDate}. Sending again will re-notify your team."
+- Footer: Cancel + "Broadcast to Team" button (primary style)
+- Loading state: "Broadcasting..." with spinner
+
+Import `useBroadcastOpenShifts` and call it on confirm. Close dialog on success.
+
+Use `format` from `date-fns` for dates. Use `parseDateLocal` from `@/lib/dateUtils` for any date-only strings. Use Megaphone icon from `lucide-react` (check if it exists, otherwise use `Volume2` or `Bell`).
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/components/scheduling/BroadcastOpenShiftsDialog.tsx
+git commit -m "feat: add BroadcastOpenShiftsDialog component"
+```
+
+---
+
+### Task 5: Add broadcast button to Scheduling page
+
+**Files:**
+- Modify: `src/pages/Scheduling.tsx`
+- Modify: `src/components/PublishScheduleDialog.tsx`
+
+- [ ] **Step 1: Add broadcast button near publish controls**
+
+In `src/pages/Scheduling.tsx`, near the publish button area (around line 1286), add a "Broadcast" button. Only show when:
+- `open_shifts_enabled` is true (from `useStaffingSettings`)
+- Week is published (`isPublished` from `useWeekPublicationStatus`)
+- There are open shifts (`openShiftCount > 0`)
+
+Button: Megaphone icon, text "Broadcast". If already broadcast, show a subtle check indicator.
+
+Add state for `broadcastDialogOpen` and render `BroadcastOpenShiftsDialog`.
+
+Pass the `publication.id`, `weekStart`, `weekEnd`, `openShiftCount`, `alreadyBroadcast` (from `publication.open_shifts_broadcast_at !== null`), and `broadcastDate`.
+
+- [ ] **Step 2: Update publish dialog text**
+
+In `PublishScheduleDialog.tsx`, when `openShiftsEnabled` is true and the week has already been broadcast, update the message from "You can fill these now or broadcast to your team later" to show "Broadcast sent on {date}" instead.
+
+Add a new prop `broadcastDate?: string | null`. Use `parseDateLocal` if it's a date-only string, or `new Date()` if it includes time.
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `npm run typecheck`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/Scheduling.tsx src/components/PublishScheduleDialog.tsx
+git commit -m "feat: add broadcast button to scheduling page"
+```
+
+---
+
+### Task 6: E2E test — manager broadcasts open shifts
+
+**Files:**
+- Create: `tests/e2e/broadcast-open-shifts.spec.ts`
+
+- [ ] **Step 1: Write the E2E test**
+
+Test flow:
+1. Sign up as manager, create restaurant
+2. Seed: enable open shifts, create template with capacity > 1, publish schedule for current+next week
+3. Navigate to `/scheduling`
+4. Verify "Broadcast" button is visible
+5. Click "Broadcast" button
+6. Verify dialog appears with open shift count
+7. Click "Broadcast to Team" button
+8. Wait for success toast
+9. Verify button shows broadcast-sent indicator
+
+Use accessible selectors. Don't assert on timezone-dependent values. Seed data for all 7 days to handle any day-of-week.
+
+Note: The edge function may not be running in CI without `supabase functions serve`. If the test can't call the edge function, mock the response or mark as a known limitation. Check how other E2E tests handle edge functions.
+
+- [ ] **Step 2: Run the test**
+
+Run: `npx playwright test tests/e2e/broadcast-open-shifts.spec.ts`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/e2e/broadcast-open-shifts.spec.ts
+git commit -m "test: E2E for broadcast open shifts"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Broadcast columns on schedule_publications: Task 1 ✓
+- Edge function (auth, permission, send push, send email, stamp): Task 2 ✓
+- Hook for broadcast mutation: Task 3 ✓
+- Update publication query to return broadcast columns: Task 3 ✓
+- BroadcastOpenShiftsDialog: Task 4 ✓
+- Broadcast button on scheduling page: Task 5 ✓
+- Publish dialog text update: Task 5 ✓
+- Already-broadcast indicator: Task 4 (dialog) + Task 5 (button) ✓
+- Re-broadcast with warning: Task 4 (amber alert in dialog) ✓
+- pgTAP tests: Task 1 ✓
+- E2E test: Task 6 ✓
+
+**Placeholder scan:** No TBDs found. Edge function has complete code. Dialog and button have clear structural guidance with exact props.
+
+**Type consistency:** `BroadcastOpenShiftsDialogProps` uses `openShiftCount`, `alreadyBroadcast`, `broadcastDate` — same names used in Task 5 when passing props. `useBroadcastOpenShifts` return type matches usage in Task 4.

--- a/supabase/migrations/20260413001912_fix_shift_claim_timezone.sql
+++ b/supabase/migrations/20260413001912_fix_shift_claim_timezone.sql
@@ -1,0 +1,351 @@
+-- Fix timezone handling in open shift claim functions.
+-- Previously, template times (local) were cast directly to timestamptz,
+-- causing PostgreSQL to interpret them as UTC. A 3:30 PM CDT shift was
+-- stored as 3:30 PM UTC (= 10:30 AM CDT). Similarly, get_open_shifts
+-- compared UTC-extracted times against local template times, under-counting
+-- assigned shifts and inflating open_spots.
+
+-- ============================================================================
+-- 1. get_open_shifts — fix assigned CTE time/date comparisons
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.get_open_shifts(
+    p_restaurant_id UUID,
+    p_week_start DATE,
+    p_week_end DATE
+)
+RETURNS TABLE (
+    template_id UUID,
+    template_name TEXT,
+    shift_date DATE,
+    start_time TIME,
+    end_time TIME,
+    "position" TEXT,
+    area TEXT,
+    "capacity" INT,
+    assigned_count BIGINT,
+    pending_claims BIGINT,
+    open_spots BIGINT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    v_tz TEXT;
+BEGIN
+    -- Look up the restaurant timezone
+    SELECT COALESCE(r.timezone, 'America/Chicago') INTO v_tz
+    FROM public.restaurants r WHERE r.id = p_restaurant_id;
+
+    -- Check if open shifts are enabled for this restaurant
+    IF NOT EXISTS (
+        SELECT 1 FROM public.staffing_settings
+        WHERE restaurant_id = p_restaurant_id
+          AND open_shifts_enabled = true
+    ) THEN
+        RETURN;
+    END IF;
+
+    RETURN QUERY
+    WITH published_dates AS (
+        -- Get all dates within published schedule weeks, excluding past dates
+        SELECT DISTINCT d::date AS pub_date
+        FROM public.schedule_publications sp,
+             generate_series(
+                 GREATEST(sp.week_start_date, p_week_start),
+                 LEAST(sp.week_end_date, p_week_end),
+                 '1 day'::interval
+             ) AS d
+        WHERE sp.restaurant_id = p_restaurant_id
+          AND sp.week_start_date <= p_week_end
+          AND sp.week_end_date >= p_week_start
+          AND d::date >= CURRENT_DATE  -- Only today and future dates
+    ),
+    template_days AS (
+        SELECT
+            st.id AS tmpl_id,
+            st.name AS tmpl_name,
+            pd.pub_date,
+            st.start_time AS tmpl_start,
+            st.end_time AS tmpl_end,
+            st.position AS tmpl_position,
+            st.area AS tmpl_area,
+            st.capacity AS tmpl_capacity
+        FROM public.shift_templates st
+        CROSS JOIN published_dates pd
+        WHERE st.restaurant_id = p_restaurant_id
+          AND st.is_active = true
+          AND st.capacity > 1
+          AND EXTRACT(DOW FROM pd.pub_date)::int = ANY(st.days)
+    ),
+    assigned AS (
+        -- Count existing shifts matching template's position + time + date
+        -- Use AT TIME ZONE to convert UTC timestamps to local before extracting
+        SELECT
+            td.tmpl_id,
+            td.pub_date,
+            COUNT(s.id) AS cnt
+        FROM template_days td
+        LEFT JOIN public.shifts s
+            ON s.restaurant_id = p_restaurant_id
+            AND s.position = td.tmpl_position
+            AND (s.start_time AT TIME ZONE v_tz)::time = td.tmpl_start
+            AND (s.end_time AT TIME ZONE v_tz)::time = td.tmpl_end
+            AND (s.start_time AT TIME ZONE v_tz)::date = td.pub_date
+            AND s.status != 'cancelled'
+        GROUP BY td.tmpl_id, td.pub_date
+    ),
+    pending AS (
+        SELECT
+            osc.shift_template_id,
+            osc.shift_date,
+            COUNT(osc.id) AS cnt
+        FROM public.open_shift_claims osc
+        WHERE osc.restaurant_id = p_restaurant_id
+          AND osc.status = 'pending_approval'
+        GROUP BY osc.shift_template_id, osc.shift_date
+    )
+    SELECT
+        td.tmpl_id,
+        td.tmpl_name,
+        td.pub_date,
+        td.tmpl_start,
+        td.tmpl_end,
+        td.tmpl_position,
+        td.tmpl_area,
+        td.tmpl_capacity,
+        COALESCE(a.cnt, 0),
+        COALESCE(p.cnt, 0),
+        (td.tmpl_capacity - COALESCE(a.cnt, 0) - COALESCE(p.cnt, 0))
+    FROM template_days td
+    LEFT JOIN assigned a ON a.tmpl_id = td.tmpl_id AND a.pub_date = td.pub_date
+    LEFT JOIN pending p ON p.shift_template_id = td.tmpl_id AND p.shift_date = td.pub_date
+    WHERE (td.tmpl_capacity - COALESCE(a.cnt, 0) - COALESCE(p.cnt, 0)) > 0
+    ORDER BY td.pub_date, td.tmpl_start;
+END;
+$$;
+
+-- ============================================================================
+-- 2. claim_open_shift — fix capacity check comparisons and shift timestamp construction
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.claim_open_shift(
+    p_restaurant_id UUID,
+    p_template_id UUID,
+    p_shift_date DATE,
+    p_employee_id UUID
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    v_tz TEXT;
+    v_template RECORD;
+    v_assigned_count BIGINT;
+    v_pending_count BIGINT;
+    v_requires_approval BOOLEAN;
+    v_claim_id UUID;
+    v_shift_id UUID;
+    v_shift_start TIMESTAMPTZ;
+    v_shift_end TIMESTAMPTZ;
+BEGIN
+    -- Look up the restaurant timezone
+    SELECT COALESCE(r.timezone, 'America/Chicago') INTO v_tz
+    FROM public.restaurants r WHERE r.id = p_restaurant_id;
+
+    -- Lock and fetch the template
+    SELECT * INTO v_template
+    FROM public.shift_templates
+    WHERE id = p_template_id
+      AND restaurant_id = p_restaurant_id
+    FOR SHARE;
+
+    IF NOT FOUND THEN
+        RETURN json_build_object('success', false, 'error', 'Template not found');
+    END IF;
+
+    -- Verify day-of-week matches
+    IF NOT (EXTRACT(DOW FROM p_shift_date)::int = ANY(v_template.days)) THEN
+        RETURN json_build_object('success', false, 'error', 'Template does not apply to this day');
+    END IF;
+
+    -- Count assigned shifts for this template+date
+    -- Use AT TIME ZONE to convert UTC timestamps to local before comparing
+    SELECT COUNT(*) INTO v_assigned_count
+    FROM public.shifts
+    WHERE restaurant_id = p_restaurant_id
+      AND position = v_template.position
+      AND (start_time AT TIME ZONE v_tz)::time = v_template.start_time
+      AND (end_time AT TIME ZONE v_tz)::time = v_template.end_time
+      AND (start_time AT TIME ZONE v_tz)::date = p_shift_date
+      AND status != 'cancelled';
+
+    -- Count pending claims
+    SELECT COUNT(*) INTO v_pending_count
+    FROM public.open_shift_claims
+    WHERE shift_template_id = p_template_id
+      AND shift_date = p_shift_date
+      AND status = 'pending_approval';
+
+    -- Check capacity
+    IF (v_assigned_count + v_pending_count) >= v_template.capacity THEN
+        RETURN json_build_object('success', false, 'error', 'No open spots available');
+    END IF;
+
+    -- Build shift timestamps from template times + shift date
+    -- Cast to timestamp (no tz) first, then interpret in restaurant timezone
+    v_shift_start := (p_shift_date || ' ' || v_template.start_time)::timestamp AT TIME ZONE v_tz;
+    v_shift_end := (p_shift_date || ' ' || v_template.end_time)::timestamp AT TIME ZONE v_tz;
+
+    -- Handle overnight shifts
+    IF v_template.end_time <= v_template.start_time THEN
+        v_shift_end := v_shift_end + interval '1 day';
+    END IF;
+
+    -- Check for schedule conflict with existing employee shifts
+    IF EXISTS (
+        SELECT 1 FROM public.shifts
+        WHERE employee_id = p_employee_id
+          AND restaurant_id = p_restaurant_id
+          AND status != 'cancelled'
+          AND (start_time, end_time) OVERLAPS (v_shift_start, v_shift_end)
+    ) THEN
+        RETURN json_build_object('success', false, 'error', 'Schedule conflict with existing shift');
+    END IF;
+
+    -- Check approval setting
+    SELECT COALESCE(require_shift_claim_approval, false) INTO v_requires_approval
+    FROM public.staffing_settings
+    WHERE restaurant_id = p_restaurant_id;
+
+    IF v_requires_approval IS NULL THEN
+        v_requires_approval := false;
+    END IF;
+
+    IF NOT v_requires_approval THEN
+        -- Instant approval: create the shift and the claim
+        INSERT INTO public.shifts (
+            restaurant_id, employee_id, start_time, end_time,
+            break_duration, position, status, source, is_published
+        ) VALUES (
+            p_restaurant_id, p_employee_id, v_shift_start, v_shift_end,
+            v_template.break_duration, v_template.position, 'scheduled', 'template', true
+        )
+        RETURNING id INTO v_shift_id;
+
+        INSERT INTO public.open_shift_claims (
+            restaurant_id, shift_template_id, shift_date,
+            claimed_by_employee_id, status, resulting_shift_id
+        ) VALUES (
+            p_restaurant_id, p_template_id, p_shift_date,
+            p_employee_id, 'approved', v_shift_id
+        )
+        RETURNING id INTO v_claim_id;
+
+        RETURN json_build_object(
+            'success', true,
+            'claim_id', v_claim_id,
+            'shift_id', v_shift_id,
+            'status', 'approved',
+            'message', 'Shift claimed and added to your schedule'
+        );
+    ELSE
+        -- Requires approval: just create the claim
+        INSERT INTO public.open_shift_claims (
+            restaurant_id, shift_template_id, shift_date,
+            claimed_by_employee_id, status
+        ) VALUES (
+            p_restaurant_id, p_template_id, p_shift_date,
+            p_employee_id, 'pending_approval'
+        )
+        RETURNING id INTO v_claim_id;
+
+        RETURN json_build_object(
+            'success', true,
+            'claim_id', v_claim_id,
+            'status', 'pending_approval',
+            'message', 'Claim submitted for manager approval'
+        );
+    END IF;
+END;
+$$;
+
+-- ============================================================================
+-- 3. approve_open_shift_claim — fix shift timestamp construction
+-- ============================================================================
+CREATE OR REPLACE FUNCTION public.approve_open_shift_claim(
+    p_claim_id UUID,
+    p_reviewer_note TEXT DEFAULT NULL
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+    v_tz TEXT;
+    v_claim RECORD;
+    v_template RECORD;
+    v_shift_id UUID;
+    v_shift_start TIMESTAMPTZ;
+    v_shift_end TIMESTAMPTZ;
+BEGIN
+    -- Lock the claim
+    SELECT * INTO v_claim
+    FROM public.open_shift_claims
+    WHERE id = p_claim_id
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RETURN json_build_object('success', false, 'error', 'Claim not found');
+    END IF;
+
+    IF v_claim.status != 'pending_approval' THEN
+        RETURN json_build_object('success', false, 'error', 'Claim is not pending approval');
+    END IF;
+
+    -- Look up the restaurant timezone (after fetching the claim to get restaurant_id)
+    SELECT COALESCE(r.timezone, 'America/Chicago') INTO v_tz
+    FROM public.restaurants r WHERE r.id = v_claim.restaurant_id;
+
+    -- Get the template
+    SELECT * INTO v_template
+    FROM public.shift_templates
+    WHERE id = v_claim.shift_template_id;
+
+    IF NOT FOUND THEN
+        RETURN json_build_object('success', false, 'error', 'Template not found');
+    END IF;
+
+    -- Build shift timestamps — cast to timestamp (no tz) first, then interpret in restaurant timezone
+    v_shift_start := (v_claim.shift_date || ' ' || v_template.start_time)::timestamp AT TIME ZONE v_tz;
+    v_shift_end := (v_claim.shift_date || ' ' || v_template.end_time)::timestamp AT TIME ZONE v_tz;
+
+    IF v_template.end_time <= v_template.start_time THEN
+        v_shift_end := v_shift_end + interval '1 day';
+    END IF;
+
+    -- Create the shift
+    INSERT INTO public.shifts (
+        restaurant_id, employee_id, start_time, end_time,
+        break_duration, position, status, source, is_published
+    ) VALUES (
+        v_claim.restaurant_id, v_claim.claimed_by_employee_id,
+        v_shift_start, v_shift_end,
+        v_template.break_duration, v_template.position, 'scheduled', 'template', true
+    )
+    RETURNING id INTO v_shift_id;
+
+    -- Update the claim
+    UPDATE public.open_shift_claims
+    SET status = 'approved',
+        resulting_shift_id = v_shift_id,
+        reviewed_by = auth.uid(),
+        reviewed_at = now()
+    WHERE id = p_claim_id;
+
+    RETURN json_build_object(
+        'success', true,
+        'shift_id', v_shift_id,
+        'message', 'Claim approved and shift created'
+    );
+END;
+$$;

--- a/supabase/tests/open_shift_claim_timezone.test.sql
+++ b/supabase/tests/open_shift_claim_timezone.test.sql
@@ -20,16 +20,21 @@ ALTER TABLE staffing_settings DISABLE ROW LEVEL SECURITY;
 ALTER TABLE schedule_publications DISABLE ROW LEVEL SECURITY;
 ALTER TABLE open_shift_claims DISABLE ROW LEVEL SECURITY;
 
+-- Auth user for FK references
+INSERT INTO auth.users (id, email)
+VALUES ('dddddddd-d001-0000-0000-000000000001', 'tz-test@example.com')
+ON CONFLICT DO NOTHING;
+
 -- Restaurant in CDT timezone (UTC-5 in April)
 INSERT INTO restaurants (id, name, timezone)
-VALUES ('aaaaaaaa-tz01-0000-0000-000000000001', 'TZ Test Restaurant', 'America/Chicago')
+VALUES ('aaaaaaaa-a001-0000-0000-000000000001', 'TZ Test Restaurant', 'America/Chicago')
 ON CONFLICT (id) DO NOTHING;
 
 -- Template: Closing shift 3:30p-10p on Sundays (day 0), capacity 3
 INSERT INTO shift_templates (id, restaurant_id, name, start_time, end_time, position, days, capacity)
 VALUES (
-  'bbbbbbbb-tz01-0000-0000-000000000001',
-  'aaaaaaaa-tz01-0000-0000-000000000001',
+  'bbbbbbbb-b001-0000-0000-000000000001',
+  'aaaaaaaa-a001-0000-0000-000000000001',
   'Closing - Weekend',
   '15:30:00', '22:00:00',
   'Server',
@@ -40,31 +45,31 @@ VALUES (
 -- Employee
 INSERT INTO employees (id, restaurant_id, name, position, status, is_active)
 VALUES (
-  'cccccccc-tz01-0000-0000-000000000001',
-  'aaaaaaaa-tz01-0000-0000-000000000001',
+  'cccccccc-c001-0000-0000-000000000001',
+  'aaaaaaaa-a001-0000-0000-000000000001',
   'Test Employee', 'Server', 'active', true
 );
 
 -- Second employee (for approve test)
 INSERT INTO employees (id, restaurant_id, name, position, status, is_active)
 VALUES (
-  'cccccccc-tz01-0000-0000-000000000002',
-  'aaaaaaaa-tz01-0000-0000-000000000001',
+  'cccccccc-c001-0000-0000-000000000002',
+  'aaaaaaaa-a001-0000-0000-000000000001',
   'Test Employee 2', 'Server', 'active', true
 );
 
 -- Enable open shifts, NO approval required (instant claim)
 INSERT INTO staffing_settings (restaurant_id, open_shifts_enabled, require_shift_claim_approval)
-VALUES ('aaaaaaaa-tz01-0000-0000-000000000001', true, false)
+VALUES ('aaaaaaaa-a001-0000-0000-000000000001', true, false)
 ON CONFLICT (restaurant_id) DO UPDATE
 SET open_shifts_enabled = true, require_shift_claim_approval = false;
 
 -- Publish schedule for April 13-19, 2026 (Sun Apr 19 is day-of-week 0)
 INSERT INTO schedule_publications (restaurant_id, week_start_date, week_end_date, published_by, shift_count)
 VALUES (
-  'aaaaaaaa-tz01-0000-0000-000000000001',
+  'aaaaaaaa-a001-0000-0000-000000000001',
   '2026-04-13', '2026-04-19',
-  '00000000-0000-0000-0000-000000000000',
+  'dddddddd-d001-0000-0000-000000000001',
   0
 );
 
@@ -78,10 +83,10 @@ SELECT is(
     SELECT (result->>'success')::boolean
     FROM (
       SELECT claim_open_shift(
-        'aaaaaaaa-tz01-0000-0000-000000000001',
-        'bbbbbbbb-tz01-0000-0000-000000000001',
+        'aaaaaaaa-a001-0000-0000-000000000001',
+        'bbbbbbbb-b001-0000-0000-000000000001',
         '2026-04-19'::date,
-        'cccccccc-tz01-0000-0000-000000000001'
+        'cccccccc-c001-0000-0000-000000000001'
       ) AS result
     ) sub
   ),
@@ -97,8 +102,8 @@ SELECT is(
   (
     SELECT start_time::timestamptz
     FROM shifts
-    WHERE restaurant_id = 'aaaaaaaa-tz01-0000-0000-000000000001'
-      AND employee_id = 'cccccccc-tz01-0000-0000-000000000001'
+    WHERE restaurant_id = 'aaaaaaaa-a001-0000-0000-000000000001'
+      AND employee_id = 'cccccccc-c001-0000-0000-000000000001'
       AND source = 'template'
     ORDER BY created_at DESC LIMIT 1
   ),
@@ -114,8 +119,8 @@ SELECT is(
   (
     SELECT end_time::timestamptz
     FROM shifts
-    WHERE restaurant_id = 'aaaaaaaa-tz01-0000-0000-000000000001'
-      AND employee_id = 'cccccccc-tz01-0000-0000-000000000001'
+    WHERE restaurant_id = 'aaaaaaaa-a001-0000-0000-000000000001'
+      AND employee_id = 'cccccccc-c001-0000-0000-000000000001'
       AND source = 'template'
     ORDER BY created_at DESC LIMIT 1
   ),
@@ -131,7 +136,7 @@ SELECT is(
   (
     SELECT open_spots
     FROM get_open_shifts(
-      'aaaaaaaa-tz01-0000-0000-000000000001',
+      'aaaaaaaa-a001-0000-0000-000000000001',
       '2026-04-13'::date,
       '2026-04-19'::date
     )
@@ -149,8 +154,8 @@ SELECT is(
 
 INSERT INTO shifts (restaurant_id, employee_id, start_time, end_time, position, status, source)
 VALUES (
-  'aaaaaaaa-tz01-0000-0000-000000000001',
-  'cccccccc-tz01-0000-0000-000000000002',
+  'aaaaaaaa-a001-0000-0000-000000000001',
+  'cccccccc-c001-0000-0000-000000000002',
   '2026-04-19 20:30:00+00',  -- 15:30 CDT as proper UTC
   '2026-04-20 03:00:00+00',  -- 22:00 CDT as proper UTC
   'Server', 'scheduled', 'manual'
@@ -160,7 +165,7 @@ SELECT is(
   (
     SELECT open_spots
     FROM get_open_shifts(
-      'aaaaaaaa-tz01-0000-0000-000000000001',
+      'aaaaaaaa-a001-0000-0000-000000000001',
       '2026-04-13'::date,
       '2026-04-19'::date
     )
@@ -178,13 +183,13 @@ SELECT is(
 
 UPDATE staffing_settings
 SET require_shift_claim_approval = true
-WHERE restaurant_id = 'aaaaaaaa-tz01-0000-0000-000000000001';
+WHERE restaurant_id = 'aaaaaaaa-a001-0000-0000-000000000001';
 
 -- Create a third employee for the approve test
 INSERT INTO employees (id, restaurant_id, name, position, status, is_active)
 VALUES (
-  'cccccccc-tz01-0000-0000-000000000003',
-  'aaaaaaaa-tz01-0000-0000-000000000001',
+  'cccccccc-c001-0000-0000-000000000003',
+  'aaaaaaaa-a001-0000-0000-000000000001',
   'Test Employee 3', 'Server', 'active', true
 );
 
@@ -194,10 +199,10 @@ SELECT is(
     SELECT (result->>'success')::boolean
     FROM (
       SELECT claim_open_shift(
-        'aaaaaaaa-tz01-0000-0000-000000000001',
-        'bbbbbbbb-tz01-0000-0000-000000000001',
+        'aaaaaaaa-a001-0000-0000-000000000001',
+        'bbbbbbbb-b001-0000-0000-000000000001',
         '2026-04-19'::date,
-        'cccccccc-tz01-0000-0000-000000000003'
+        'cccccccc-c001-0000-0000-000000000003'
       ) AS result
     ) sub
   ),
@@ -215,7 +220,7 @@ SELECT is(
     FROM (
       SELECT approve_open_shift_claim(
         (SELECT id FROM open_shift_claims
-         WHERE claimed_by_employee_id = 'cccccccc-tz01-0000-0000-000000000003'
+         WHERE claimed_by_employee_id = 'cccccccc-c001-0000-0000-000000000003'
            AND status = 'pending_approval'
          LIMIT 1)
       ) AS result
@@ -233,8 +238,8 @@ SELECT is(
   (
     SELECT start_time::timestamptz
     FROM shifts
-    WHERE restaurant_id = 'aaaaaaaa-tz01-0000-0000-000000000001'
-      AND employee_id = 'cccccccc-tz01-0000-0000-000000000003'
+    WHERE restaurant_id = 'aaaaaaaa-a001-0000-0000-000000000001'
+      AND employee_id = 'cccccccc-c001-0000-0000-000000000003'
       AND source = 'template'
     ORDER BY created_at DESC LIMIT 1
   ),

--- a/supabase/tests/open_shift_claim_timezone.test.sql
+++ b/supabase/tests/open_shift_claim_timezone.test.sql
@@ -1,0 +1,246 @@
+-- pgTAP tests for timezone-aware open shift claim functions.
+-- Verifies: claim_open_shift and approve_open_shift_claim create shifts
+-- with correct UTC timestamps, and get_open_shifts counts shifts correctly
+-- regardless of how they were created (planner vs claim).
+
+BEGIN;
+
+SELECT plan(8);
+
+-- ============================================
+-- Setup: disable RLS and seed test data
+-- ============================================
+
+SET LOCAL role TO postgres;
+ALTER TABLE restaurants DISABLE ROW LEVEL SECURITY;
+ALTER TABLE shift_templates DISABLE ROW LEVEL SECURITY;
+ALTER TABLE shifts DISABLE ROW LEVEL SECURITY;
+ALTER TABLE employees DISABLE ROW LEVEL SECURITY;
+ALTER TABLE staffing_settings DISABLE ROW LEVEL SECURITY;
+ALTER TABLE schedule_publications DISABLE ROW LEVEL SECURITY;
+ALTER TABLE open_shift_claims DISABLE ROW LEVEL SECURITY;
+
+-- Restaurant in CDT timezone (UTC-5 in April)
+INSERT INTO restaurants (id, name, timezone)
+VALUES ('aaaaaaaa-tz01-0000-0000-000000000001', 'TZ Test Restaurant', 'America/Chicago')
+ON CONFLICT (id) DO NOTHING;
+
+-- Template: Closing shift 3:30p-10p on Sundays (day 0), capacity 3
+INSERT INTO shift_templates (id, restaurant_id, name, start_time, end_time, position, days, capacity)
+VALUES (
+  'bbbbbbbb-tz01-0000-0000-000000000001',
+  'aaaaaaaa-tz01-0000-0000-000000000001',
+  'Closing - Weekend',
+  '15:30:00', '22:00:00',
+  'Server',
+  '{0}',  -- Sunday only
+  3
+);
+
+-- Employee
+INSERT INTO employees (id, restaurant_id, name, position, status, is_active)
+VALUES (
+  'cccccccc-tz01-0000-0000-000000000001',
+  'aaaaaaaa-tz01-0000-0000-000000000001',
+  'Test Employee', 'Server', 'active', true
+);
+
+-- Second employee (for approve test)
+INSERT INTO employees (id, restaurant_id, name, position, status, is_active)
+VALUES (
+  'cccccccc-tz01-0000-0000-000000000002',
+  'aaaaaaaa-tz01-0000-0000-000000000001',
+  'Test Employee 2', 'Server', 'active', true
+);
+
+-- Enable open shifts, NO approval required (instant claim)
+INSERT INTO staffing_settings (restaurant_id, open_shifts_enabled, require_shift_claim_approval)
+VALUES ('aaaaaaaa-tz01-0000-0000-000000000001', true, false)
+ON CONFLICT (restaurant_id) DO UPDATE
+SET open_shifts_enabled = true, require_shift_claim_approval = false;
+
+-- Publish schedule for April 13-19, 2026 (Sun Apr 19 is day-of-week 0)
+INSERT INTO schedule_publications (restaurant_id, week_start_date, week_end_date, published_by, shift_count)
+VALUES (
+  'aaaaaaaa-tz01-0000-0000-000000000001',
+  '2026-04-13', '2026-04-19',
+  '00000000-0000-0000-0000-000000000000',
+  0
+);
+
+-- ============================================
+-- Test 1: claim_open_shift (instant) creates shift with correct UTC start
+-- In April, CDT = UTC-5. Template 15:30 local → 20:30 UTC
+-- ============================================
+
+SELECT is(
+  (
+    SELECT (result->>'success')::boolean
+    FROM (
+      SELECT claim_open_shift(
+        'aaaaaaaa-tz01-0000-0000-000000000001',
+        'bbbbbbbb-tz01-0000-0000-000000000001',
+        '2026-04-19'::date,
+        'cccccccc-tz01-0000-0000-000000000001'
+      ) AS result
+    ) sub
+  ),
+  true,
+  'claim_open_shift returns success=true'
+);
+
+-- ============================================
+-- Test 2: Resulting shift start_time is 20:30 UTC (15:30 CDT), not 15:30 UTC
+-- ============================================
+
+SELECT is(
+  (
+    SELECT start_time::timestamptz
+    FROM shifts
+    WHERE restaurant_id = 'aaaaaaaa-tz01-0000-0000-000000000001'
+      AND employee_id = 'cccccccc-tz01-0000-0000-000000000001'
+      AND source = 'template'
+    ORDER BY created_at DESC LIMIT 1
+  ),
+  '2026-04-19 20:30:00+00'::timestamptz,
+  'claim shift start_time is 20:30 UTC (15:30 CDT), not 15:30 UTC'
+);
+
+-- ============================================
+-- Test 3: Resulting shift end_time is 03:00 UTC next day (22:00 CDT)
+-- ============================================
+
+SELECT is(
+  (
+    SELECT end_time::timestamptz
+    FROM shifts
+    WHERE restaurant_id = 'aaaaaaaa-tz01-0000-0000-000000000001'
+      AND employee_id = 'cccccccc-tz01-0000-0000-000000000001'
+      AND source = 'template'
+    ORDER BY created_at DESC LIMIT 1
+  ),
+  '2026-04-20 03:00:00+00'::timestamptz,
+  'claim shift end_time is 03:00 UTC next day (22:00 CDT), not 22:00 UTC'
+);
+
+-- ============================================
+-- Test 4: get_open_shifts counts the claimed shift correctly (2 spots left, not 3)
+-- ============================================
+
+SELECT is(
+  (
+    SELECT open_spots
+    FROM get_open_shifts(
+      'aaaaaaaa-tz01-0000-0000-000000000001',
+      '2026-04-13'::date,
+      '2026-04-19'::date
+    )
+    WHERE shift_date = '2026-04-19'
+    LIMIT 1
+  ),
+  2::bigint,
+  'get_open_shifts shows 2 open spots after 1 claim (not 3)'
+);
+
+-- ============================================
+-- Test 5: Planner-created shift (proper UTC) is also counted by get_open_shifts
+-- Insert a shift as if created by the planner: 15:30 CDT = 20:30 UTC
+-- ============================================
+
+INSERT INTO shifts (restaurant_id, employee_id, start_time, end_time, position, status, source)
+VALUES (
+  'aaaaaaaa-tz01-0000-0000-000000000001',
+  'cccccccc-tz01-0000-0000-000000000002',
+  '2026-04-19 20:30:00+00',  -- 15:30 CDT as proper UTC
+  '2026-04-20 03:00:00+00',  -- 22:00 CDT as proper UTC
+  'Server', 'scheduled', 'manual'
+);
+
+SELECT is(
+  (
+    SELECT open_spots
+    FROM get_open_shifts(
+      'aaaaaaaa-tz01-0000-0000-000000000001',
+      '2026-04-13'::date,
+      '2026-04-19'::date
+    )
+    WHERE shift_date = '2026-04-19'
+    LIMIT 1
+  ),
+  1::bigint,
+  'get_open_shifts counts planner-created (proper UTC) shifts correctly — 1 spot left'
+);
+
+-- ============================================
+-- Test 6: approve_open_shift_claim creates shift with correct UTC timestamps
+-- Switch to approval-required mode and test the approve path
+-- ============================================
+
+UPDATE staffing_settings
+SET require_shift_claim_approval = true
+WHERE restaurant_id = 'aaaaaaaa-tz01-0000-0000-000000000001';
+
+-- Create a third employee for the approve test
+INSERT INTO employees (id, restaurant_id, name, position, status, is_active)
+VALUES (
+  'cccccccc-tz01-0000-0000-000000000003',
+  'aaaaaaaa-tz01-0000-0000-000000000001',
+  'Test Employee 3', 'Server', 'active', true
+);
+
+-- Claim (this time it creates a pending claim, not an instant shift)
+SELECT is(
+  (
+    SELECT (result->>'success')::boolean
+    FROM (
+      SELECT claim_open_shift(
+        'aaaaaaaa-tz01-0000-0000-000000000001',
+        'bbbbbbbb-tz01-0000-0000-000000000001',
+        '2026-04-19'::date,
+        'cccccccc-tz01-0000-0000-000000000003'
+      ) AS result
+    ) sub
+  ),
+  true,
+  'claim_open_shift with approval required returns success=true (pending claim)'
+);
+
+-- ============================================
+-- Test 7: Approve the claim and check resulting shift timestamps
+-- ============================================
+
+SELECT is(
+  (
+    SELECT (result->>'success')::boolean
+    FROM (
+      SELECT approve_open_shift_claim(
+        (SELECT id FROM open_shift_claims
+         WHERE claimed_by_employee_id = 'cccccccc-tz01-0000-0000-000000000003'
+           AND status = 'pending_approval'
+         LIMIT 1)
+      ) AS result
+    ) sub
+  ),
+  true,
+  'approve_open_shift_claim returns success=true'
+);
+
+-- ============================================
+-- Test 8: Approved shift has correct UTC start time (20:30 UTC, not 15:30 UTC)
+-- ============================================
+
+SELECT is(
+  (
+    SELECT start_time::timestamptz
+    FROM shifts
+    WHERE restaurant_id = 'aaaaaaaa-tz01-0000-0000-000000000001'
+      AND employee_id = 'cccccccc-tz01-0000-0000-000000000003'
+      AND source = 'template'
+    ORDER BY created_at DESC LIMIT 1
+  ),
+  '2026-04-19 20:30:00+00'::timestamptz,
+  'approved claim shift start_time is 20:30 UTC (15:30 CDT), not 15:30 UTC'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/tests/e2e/open-shift-claiming.spec.ts
+++ b/tests/e2e/open-shift-claiming.spec.ts
@@ -192,10 +192,11 @@ test.describe('Open Shift Claiming', () => {
     const seedResult = await page.evaluate(async (restId: string) => {
       const supabase = (window as any).__supabase;
 
-      // Set restaurant timezone to America/Chicago (CDT = UTC-5 in April)
+      // Use a DST-free timezone so expected UTC hours are deterministic year-round.
+      // Etc/GMT+5 = UTC-5 always (POSIX sign convention is reversed).
       await supabase
         .from('restaurants')
-        .update({ timezone: 'America/Chicago' })
+        .update({ timezone: 'Etc/GMT+5' })
         .eq('id', restId);
 
       // Enable open shifts (instant approval)
@@ -211,7 +212,7 @@ test.describe('Open Shift Claiming', () => {
         );
 
       // Template: 3:30 PM - 10:00 PM (the exact scenario from the bug report)
-      const { data: template } = await supabase
+      const { data: template, error: templateError } = await supabase
         .from('shift_templates')
         .insert({
           restaurant_id: restId,
@@ -225,6 +226,7 @@ test.describe('Open Shift Claiming', () => {
         })
         .select()
         .single();
+      if (templateError) throw new Error(`shift_templates insert failed: ${templateError.message}`);
 
       // Compute next Sunday (DOW=0) that is today or in the future
       const now = new Date();
@@ -266,7 +268,7 @@ test.describe('Open Shift Claiming', () => {
           hourly_rate: 1500,
         });
 
-      return { templateId: template!.id, sundayStr, mondayStr };
+      return { templateId: template.id, sundayStr, mondayStr };
     }, restaurantId as string);
 
     // 3. Switch to staff role
@@ -315,7 +317,7 @@ test.describe('Open Shift Claiming', () => {
       const startHourUTC = new Date(shift.start_time).getUTCHours();
       const endHourUTC = new Date(shift.end_time).getUTCHours();
 
-      // In CDT (UTC-5): 15:30 local = 20:30 UTC, 22:00 local = 03:00 UTC next day
+      // In Etc/GMT+5 (UTC-5): 15:30 local = 20:30 UTC, 22:00 local = 03:00 UTC next day
       // BUG would produce: 15:30 UTC (startHourUTC=15), 22:00 UTC (endHourUTC=22)
       return {
         startHourUTC,
@@ -325,10 +327,10 @@ test.describe('Open Shift Claiming', () => {
       };
     }, { restId: restaurantId as string, sundayStr: seedResult.sundayStr });
 
-    // The shift should be stored as 20:30 UTC (15:30 CDT), not 15:30 UTC
+    // The shift should be stored as 20:30 UTC (15:30 UTC-5), not 15:30 UTC
     expect(shiftCheck).not.toHaveProperty('error');
-    expect(shiftCheck.startHourUTC).toBe(20); // 15:30 CDT = 20:30 UTC
-    expect(shiftCheck.endHourUTC).toBe(3);    // 22:00 CDT = 03:00 UTC next day
+    expect(shiftCheck.startHourUTC).toBe(20); // 15:30 local = 20:30 UTC (UTC-5)
+    expect(shiftCheck.endHourUTC).toBe(3);    // 22:00 local = 03:00 UTC next day (UTC-5)
 
     // 6. Verify open_spots via RPC
     const spotsCheck = await page.evaluate(async (args: { restId: string; mondayStr: string; sundayStr: string }) => {

--- a/tests/e2e/open-shift-claiming.spec.ts
+++ b/tests/e2e/open-shift-claiming.spec.ts
@@ -221,7 +221,7 @@ test.describe('Open Shift Claiming', () => {
           end_time: '22:00:00',
           position: 'Server',
           capacity: 3,
-          days: [0, 1, 2, 3, 4, 5, 6],
+          days: [0], // Sunday only — ensures the claim targets the exact date we verify
           is_active: true,
         })
         .select()

--- a/tests/e2e/open-shift-claiming.spec.ts
+++ b/tests/e2e/open-shift-claiming.spec.ts
@@ -178,4 +178,173 @@ test.describe('Open Shift Claiming', () => {
       await expect(successToast).toContainText(/shift claimed|claim submitted/i);
     }
   });
+
+  test('claimed shift has correct timezone-adjusted timestamps', async ({ page }) => {
+    // 1. Sign up manager, create restaurant
+    const testUser = generateTestUser('tz-claim');
+    await signUpAndCreateRestaurant(page, testUser);
+    await exposeSupabaseHelpers(page);
+
+    const restaurantId = await page.evaluate(() => (window as any).__getRestaurantId());
+    expect(restaurantId).toBeTruthy();
+
+    // 2. Seed data with explicit timezone
+    const seedResult = await page.evaluate(async (restId: string) => {
+      const supabase = (window as any).__supabase;
+
+      // Set restaurant timezone to America/Chicago (CDT = UTC-5 in April)
+      await supabase
+        .from('restaurants')
+        .update({ timezone: 'America/Chicago' })
+        .eq('id', restId);
+
+      // Enable open shifts (instant approval)
+      await supabase
+        .from('staffing_settings')
+        .upsert(
+          {
+            restaurant_id: restId,
+            open_shifts_enabled: true,
+            require_shift_claim_approval: false,
+          },
+          { onConflict: 'restaurant_id' }
+        );
+
+      // Template: 3:30 PM - 10:00 PM (the exact scenario from the bug report)
+      const { data: template } = await supabase
+        .from('shift_templates')
+        .insert({
+          restaurant_id: restId,
+          name: 'Closing TZ Test',
+          start_time: '15:30:00',
+          end_time: '22:00:00',
+          position: 'Server',
+          capacity: 3,
+          days: [0, 1, 2, 3, 4, 5, 6],
+          is_active: true,
+        })
+        .select()
+        .single();
+
+      // Compute next Sunday (DOW=0) that is today or in the future
+      const now = new Date();
+      const daysUntilSunday = (7 - now.getDay()) % 7 || 7; // next Sunday, not today
+      const nextSunday = new Date(now.getFullYear(), now.getMonth(), now.getDate() + daysUntilSunday);
+      const pad = (n: number) => String(n).padStart(2, '0');
+      const sundayStr = `${nextSunday.getFullYear()}-${pad(nextSunday.getMonth() + 1)}-${pad(nextSunday.getDate())}`;
+
+      // Compute week containing that Sunday (Mon-Sun)
+      const monday = new Date(nextSunday);
+      monday.setDate(nextSunday.getDate() - 6);
+      const mondayStr = `${monday.getFullYear()}-${pad(monday.getMonth() + 1)}-${pad(monday.getDate())}`;
+
+      // Get auth user
+      const { data: { user } } = await supabase.auth.getUser();
+
+      // Publish the week
+      await supabase
+        .from('schedule_publications')
+        .insert({
+          restaurant_id: restId,
+          week_start_date: mondayStr,
+          week_end_date: sundayStr,
+          published_by: user?.id,
+          shift_count: 0,
+        });
+
+      // Create employee linked to current user
+      await supabase
+        .from('employees')
+        .insert({
+          restaurant_id: restId,
+          user_id: user?.id,
+          name: 'TZ Test Employee',
+          position: 'Server',
+          status: 'active',
+          is_active: true,
+          compensation_type: 'hourly',
+          hourly_rate: 1500,
+        });
+
+      return { templateId: template!.id, sundayStr, mondayStr };
+    }, restaurantId as string);
+
+    // 3. Switch to staff role
+    await page.evaluate(async () => {
+      const supabase = (window as any).__supabase;
+      const { data: { user } } = await supabase.auth.getUser();
+      const restaurantId = await (window as any).__getRestaurantId(user?.id);
+      await supabase
+        .from('user_restaurants')
+        .update({ role: 'staff' })
+        .eq('user_id', user?.id)
+        .eq('restaurant_id', restaurantId);
+    });
+
+    // 4. Navigate and claim the shift
+    await page.goto('/employee/shifts');
+    await expect(page.getByText('Available Shifts')).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText('OPEN SHIFT').first()).toBeVisible({ timeout: 15000 });
+
+    const claimButton = page.getByRole('button', { name: /claim shift closing tz test/i }).first();
+    await expect(claimButton).toBeVisible({ timeout: 10000 });
+    await claimButton.click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+    await dialog.getByRole('button', { name: /confirm/i }).click();
+    await expect(dialog).not.toBeVisible({ timeout: 10000 });
+
+    // 5. Verify the resulting shift has correct UTC timestamps
+    const shiftCheck = await page.evaluate(async (args: { restId: string; sundayStr: string }) => {
+      const supabase = (window as any).__supabase;
+
+      // Read the shift created by the claim
+      const { data: shifts } = await supabase
+        .from('shifts')
+        .select('start_time, end_time')
+        .eq('restaurant_id', args.restId)
+        .eq('source', 'template')
+        .eq('status', 'scheduled')
+        .order('created_at', { ascending: false })
+        .limit(1);
+
+      if (!shifts || shifts.length === 0) return { error: 'No shift found' };
+
+      const shift = shifts[0];
+      const startHourUTC = new Date(shift.start_time).getUTCHours();
+      const endHourUTC = new Date(shift.end_time).getUTCHours();
+
+      // In CDT (UTC-5): 15:30 local = 20:30 UTC, 22:00 local = 03:00 UTC next day
+      // BUG would produce: 15:30 UTC (startHourUTC=15), 22:00 UTC (endHourUTC=22)
+      return {
+        startHourUTC,
+        endHourUTC,
+        startTime: shift.start_time,
+        endTime: shift.end_time,
+      };
+    }, { restId: restaurantId as string, sundayStr: seedResult.sundayStr });
+
+    // The shift should be stored as 20:30 UTC (15:30 CDT), not 15:30 UTC
+    expect(shiftCheck).not.toHaveProperty('error');
+    expect(shiftCheck.startHourUTC).toBe(20); // 15:30 CDT = 20:30 UTC
+    expect(shiftCheck.endHourUTC).toBe(3);    // 22:00 CDT = 03:00 UTC next day
+
+    // 6. Verify open_spots via RPC
+    const spotsCheck = await page.evaluate(async (args: { restId: string; mondayStr: string; sundayStr: string }) => {
+      const supabase = (window as any).__supabase;
+      const { data } = await supabase.rpc('get_open_shifts', {
+        p_restaurant_id: args.restId,
+        p_week_start: args.mondayStr,
+        p_week_end: args.sundayStr,
+      });
+      // Find the Sunday entry for our template
+      const entry = data?.find((d: any) => d.shift_date === args.sundayStr);
+      return { openSpots: entry?.open_spots ?? null, assignedCount: entry?.assigned_count ?? null };
+    }, { restId: restaurantId as string, mondayStr: seedResult.mondayStr, sundayStr: seedResult.sundayStr });
+
+    // After 1 claim, should show 2 open spots (capacity 3 - 1 assigned)
+    expect(spotsCheck.assignedCount).toBe(1);
+    expect(spotsCheck.openSpots).toBe(2);
+  });
 });


### PR DESCRIPTION
## Summary

- **Shift time bug**: When employee claims a shift (e.g., 3:30p-10p) and manager approves, the created shift had wrong times (10:30 AM - 5:00 PM). Root cause: `(date || ' ' || time)::timestamptz` interpreted template times as UTC, not the restaurant's local timezone.
- **Open spots count bug**: `get_open_shifts` under-counted assigned shifts because it compared UTC-extracted timestamps against local template times. Planner-created shifts (proper UTC) were invisible to the count.
- **Fix**: All 3 RPC functions (`get_open_shifts`, `claim_open_shift`, `approve_open_shift_claim`) now look up `restaurants.timezone` and use `AT TIME ZONE` for timestamp construction and comparison.

## Test plan

- [x] 8 pgTAP tests verifying timezone-correct timestamps for both instant-claim and approval paths
- [x] pgTAP test verifying `get_open_shifts` correctly counts planner-created (proper UTC) shifts
- [x] E2E test: employee claims shift → verify stored UTC hours are offset-adjusted (20:30 UTC not 15:30 UTC)
- [x] E2E test: verify `get_open_shifts` returns correct `open_spots` count after claim
- [x] All 1197 pgTAP tests pass, 3473 unit tests pass, build succeeds

## Design doc

`docs/superpowers/plans/2026-04-12-fix-shift-claim-timezone-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Managers can now broadcast open shifts to all active employees via web push notifications and email.
  * Added broadcast button to scheduling page with status indicator for previously sent broadcasts.

* **Bug Fixes**
  * Fixed timezone handling for open shift claims and availability calculations to ensure accurate local time comparisons.

* **Tests**
  * Added integration and end-to-end test coverage for shift claiming workflows and timezone-adjusted timestamp verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->