### PR TITLE
fix(scheduling): count shifts for hourly employees with stale comp history

### DIFF
--- a/docs/superpowers/plans/2026-04-13-employee-ft-pt-dob-plan.md
+++ b/docs/superpowers/plans/2026-04-13-employee-ft-pt-dob-plan.md
@@ -1,0 +1,928 @@
+# Employee FT/PT & DOB Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add employment type (full-time/part-time) and date of birth fields to employees, with scheduler filtering, AI prompt integration, and minor badge display.
+
+**Architecture:** Two new columns on the `employees` table. A pure utility for age/minor calculation. UI updates to EmployeeDialog (FT/PT toggle + DOB input), EmployeeList (badges), EmployeeSidebar (FT/PT filter + minor badge). AI prompt builder gets a new rule for FT/PT hour targeting.
+
+**Tech Stack:** PostgreSQL (migration), React, TypeScript, Vitest, pgTAP, Playwright
+
+---
+
+### Task 1: Database Migration
+
+**Files:**
+- Create: `supabase/migrations/20260413100000_add_employee_employment_type_dob.sql`
+- Test: `supabase/tests/employee_employment_type_dob.sql`
+
+- [ ] **Step 1: Write the pgTAP test file**
+
+```sql
+-- supabase/tests/employee_employment_type_dob.sql
+BEGIN;
+SELECT plan(7);
+
+-- Test 1: employment_type column exists with default
+SELECT has_column('public', 'employees', 'employment_type',
+  'employees table should have employment_type column');
+
+-- Test 2: date_of_birth column exists
+SELECT has_column('public', 'employees', 'date_of_birth',
+  'employees table should have date_of_birth column');
+
+-- Test 3: employment_type defaults to full_time
+INSERT INTO employees (id, restaurant_id, name, position, hourly_rate, compensation_type)
+VALUES (
+  'aaaaaaaa-0000-0000-0000-000000000001',
+  (SELECT id FROM restaurants LIMIT 1),
+  'Test Default FT',
+  'Server',
+  1500,
+  'hourly'
+);
+SELECT is(
+  (SELECT employment_type FROM employees WHERE id = 'aaaaaaaa-0000-0000-0000-000000000001'),
+  'full_time',
+  'employment_type should default to full_time'
+);
+
+-- Test 4: Can set employment_type to part_time
+UPDATE employees SET employment_type = 'part_time'
+WHERE id = 'aaaaaaaa-0000-0000-0000-000000000001';
+SELECT is(
+  (SELECT employment_type FROM employees WHERE id = 'aaaaaaaa-0000-0000-0000-000000000001'),
+  'part_time',
+  'employment_type should accept part_time'
+);
+
+-- Test 5: CHECK constraint rejects invalid values
+SELECT throws_ok(
+  $$UPDATE employees SET employment_type = 'contractor'
+    WHERE id = 'aaaaaaaa-0000-0000-0000-000000000001'$$,
+  '23514',
+  NULL,
+  'employment_type should reject invalid values'
+);
+
+-- Test 6: date_of_birth accepts valid date
+UPDATE employees SET date_of_birth = '2008-06-15'
+WHERE id = 'aaaaaaaa-0000-0000-0000-000000000001';
+SELECT is(
+  (SELECT date_of_birth FROM employees WHERE id = 'aaaaaaaa-0000-0000-0000-000000000001'),
+  '2008-06-15'::DATE,
+  'date_of_birth should accept valid date'
+);
+
+-- Test 7: date_of_birth accepts NULL
+UPDATE employees SET date_of_birth = NULL
+WHERE id = 'aaaaaaaa-0000-0000-0000-000000000001';
+SELECT is(
+  (SELECT date_of_birth FROM employees WHERE id = 'aaaaaaaa-0000-0000-0000-000000000001'),
+  NULL::DATE,
+  'date_of_birth should accept NULL'
+);
+
+-- Cleanup
+DELETE FROM employees WHERE id = 'aaaaaaaa-0000-0000-0000-000000000001';
+
+SELECT * FROM finish();
+ROLLBACK;
+```
+
+- [ ] **Step 2: Run pgTAP tests to verify they fail**
+
+Run: `npm run test:db`
+Expected: FAIL — columns don't exist yet.
+
+- [ ] **Step 3: Write the migration**
+
+```sql
+-- supabase/migrations/20260413100000_add_employee_employment_type_dob.sql
+
+-- Add employment type (full-time or part-time) for scheduling
+ALTER TABLE employees
+  ADD COLUMN employment_type TEXT NOT NULL DEFAULT 'full_time'
+  CHECK (employment_type IN ('full_time', 'part_time'));
+
+-- Add optional date of birth for minor detection
+ALTER TABLE employees
+  ADD COLUMN date_of_birth DATE;
+
+-- Comment for documentation
+COMMENT ON COLUMN employees.employment_type IS 'full_time or part_time — used by scheduler for weekly hour targeting';
+COMMENT ON COLUMN employees.date_of_birth IS 'Optional DOB for minor detection (age < 18)';
+```
+
+- [ ] **Step 4: Reset database and run pgTAP tests**
+
+Run: `npm run db:reset && npm run test:db`
+Expected: All 7 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/migrations/20260413100000_add_employee_employment_type_dob.sql supabase/tests/employee_employment_type_dob.sql
+git commit -m "feat: add employment_type and date_of_birth columns to employees"
+```
+
+---
+
+### Task 2: TypeScript Types & Utility Functions
+
+**Files:**
+- Modify: `src/types/scheduling.ts:1-5` (add type alias) and `src/types/scheduling.ts:18-72` (add fields to Employee interface)
+- Create: `src/lib/employeeUtils.ts`
+- Create: `tests/unit/employeeUtils.test.ts`
+
+- [ ] **Step 1: Write the unit tests for age/minor utilities**
+
+```typescript
+// tests/unit/employeeUtils.test.ts
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { computeAge, isMinor } from '@/lib/employeeUtils';
+
+describe('computeAge', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('computes age for a past birthday this year', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-15'));
+    expect(computeAge('1990-03-10')).toBe(36);
+  });
+
+  it('computes age when birthday has not yet occurred this year', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-01'));
+    expect(computeAge('1990-03-10')).toBe(35);
+  });
+
+  it('computes age on the exact birthday', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-10'));
+    expect(computeAge('1990-03-10')).toBe(36);
+  });
+
+  it('handles leap year birthday (Feb 29)', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-01'));
+    expect(computeAge('2008-02-29')).toBe(17);
+  });
+});
+
+describe('isMinor', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns true for age under 18', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-13'));
+    expect(isMinor('2010-06-15')).toBe(true);
+  });
+
+  it('returns false for exactly 18', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-13'));
+    expect(isMinor('2008-04-13')).toBe(false);
+  });
+
+  it('returns false for over 18', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-13'));
+    expect(isMinor('1990-01-01')).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isMinor(null)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isMinor(undefined)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run tests/unit/employeeUtils.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create the utility file**
+
+```typescript
+// src/lib/employeeUtils.ts
+
+/**
+ * Compute age in whole years from a date-of-birth string (YYYY-MM-DD).
+ */
+export function computeAge(dateOfBirth: string): number {
+  const today = new Date();
+  const dob = new Date(dateOfBirth);
+  let age = today.getFullYear() - dob.getFullYear();
+  const monthDiff = today.getMonth() - dob.getMonth();
+  if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < dob.getDate())) {
+    age--;
+  }
+  return age;
+}
+
+/**
+ * Returns true if the employee is under 18 based on their DOB.
+ */
+export function isMinor(dateOfBirth: string | null | undefined): boolean {
+  if (!dateOfBirth) return false;
+  return computeAge(dateOfBirth) < 18;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx vitest run tests/unit/employeeUtils.test.ts`
+Expected: All 9 tests PASS.
+
+- [ ] **Step 5: Update TypeScript types**
+
+In `src/types/scheduling.ts`, add the type alias after line 5 (after `DeactivationReason`):
+
+```typescript
+export type EmploymentType = 'full_time' | 'part_time';
+```
+
+In the `Employee` interface, add these two fields after `is_exempt` (after line 68):
+
+```typescript
+  // Employment classification
+  employment_type: EmploymentType;
+  date_of_birth?: string; // YYYY-MM-DD, optional
+```
+
+- [ ] **Step 6: Run typecheck**
+
+Run: `npm run typecheck`
+Expected: No new errors (existing fields are optional in form code, and the hook returns `*` which includes the new columns).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/employeeUtils.ts tests/unit/employeeUtils.test.ts src/types/scheduling.ts
+git commit -m "feat: add EmploymentType, date_of_birth types and age utility"
+```
+
+---
+
+### Task 3: Employee Dialog — FT/PT Toggle & DOB Input
+
+**Files:**
+- Modify: `src/components/EmployeeDialog.tsx`
+
+- [ ] **Step 1: Add state variables**
+
+After the existing `const [area, setArea] = useState('');` (line 48), add:
+
+```typescript
+  const [employmentType, setEmploymentType] = useState<'full_time' | 'part_time'>('full_time');
+  const [dateOfBirth, setDateOfBirth] = useState('');
+```
+
+- [ ] **Step 2: Add to employee loading (useEffect)**
+
+In the `if (employee)` block (around line 120), after `setArea(employee.area || '');` (line 126), add:
+
+```typescript
+      setEmploymentType(employee.employment_type || 'full_time');
+      setDateOfBirth(employee.date_of_birth || '');
+```
+
+- [ ] **Step 3: Add to resetForm()**
+
+In `resetForm()` (around line 152), after `setArea('');` (line 157), add:
+
+```typescript
+    setEmploymentType('full_time');
+    setDateOfBirth('');
+```
+
+- [ ] **Step 4: Add to employeeData payload**
+
+In the `employeeData` object inside `proceedWithSubmit()` (around line 400), after `area: area.trim() || null,` (line 406), add:
+
+```typescript
+      employment_type: employmentType,
+      date_of_birth: dateOfBirth || null,
+```
+
+- [ ] **Step 5: Add FT/PT segmented toggle to the form**
+
+After the Area field's closing `</div>` (after line 556, which is the area `space-y-2` div), add:
+
+```tsx
+              {/* Employment Type Toggle */}
+              <div className="space-y-2">
+                <Label className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
+                  Employment Type
+                </Label>
+                <div className="flex rounded-lg border border-border/40 overflow-hidden w-fit">
+                  <button
+                    type="button"
+                    onClick={() => setEmploymentType('full_time')}
+                    className={cn(
+                      'px-4 py-2 text-[13px] font-medium transition-colors',
+                      employmentType === 'full_time'
+                        ? 'bg-foreground text-background'
+                        : 'bg-background text-muted-foreground hover:text-foreground'
+                    )}
+                    aria-label="Full-time employment"
+                    aria-pressed={employmentType === 'full_time'}
+                  >
+                    Full-Time
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setEmploymentType('part_time')}
+                    className={cn(
+                      'px-4 py-2 text-[13px] font-medium transition-colors border-l border-border/40',
+                      employmentType === 'part_time'
+                        ? 'bg-foreground text-background'
+                        : 'bg-background text-muted-foreground hover:text-foreground'
+                    )}
+                    aria-label="Part-time employment"
+                    aria-pressed={employmentType === 'part_time'}
+                  >
+                    Part-Time
+                  </button>
+                </div>
+                <p className="text-[12px] text-muted-foreground">
+                  Used by the scheduler to plan weekly hours
+                </p>
+              </div>
+```
+
+Note: Import `cn` is already imported at the top of the file. Verify by checking for `import { cn }` — if not present, add: `import { cn } from '@/lib/utils';`
+
+- [ ] **Step 6: Add DOB input to the Status/Hire Date row**
+
+Find the grid with Status and Hire Date (around line 897):
+
+```tsx
+              <div className="grid grid-cols-2 gap-4">
+```
+
+Change it to a 3-column grid and add the DOB field:
+
+```tsx
+              <div className="grid grid-cols-3 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="status">Status</Label>
+                  <Select value={status} onValueChange={(value) => setStatus(value as typeof status)}>
+                    <SelectTrigger id="status" aria-label="Employee status">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="active">Active</SelectItem>
+                      <SelectItem value="inactive">Inactive</SelectItem>
+                      <SelectItem value="terminated">Terminated</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="hireDate">Hire Date</Label>
+                  <Input
+                    id="hireDate"
+                    type="date"
+                    value={hireDate}
+                    onChange={(e) => setHireDate(e.target.value)}
+                    aria-label="Hire date"
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="dateOfBirth">Date of Birth</Label>
+                  <Input
+                    id="dateOfBirth"
+                    type="date"
+                    value={dateOfBirth}
+                    onChange={(e) => setDateOfBirth(e.target.value)}
+                    aria-label="Date of birth"
+                  />
+                  {dateOfBirth && isMinor(dateOfBirth) && (
+                    <span className="text-[11px] px-1.5 py-0.5 rounded-md bg-amber-500/10 text-amber-600 font-medium inline-block">
+                      Minor ({computeAge(dateOfBirth)} yrs)
+                    </span>
+                  )}
+                </div>
+              </div>
+```
+
+Add the import at the top of the file:
+
+```typescript
+import { computeAge, isMinor } from '@/lib/employeeUtils';
+```
+
+- [ ] **Step 7: Verify the dialog renders correctly**
+
+Run: `npm run dev`
+Open the app, navigate to Employees, click "Add Employee". Verify:
+- FT/PT toggle appears between Area and Compensation Type
+- DOB field appears in the Status/Hire Date row
+- Entering a minor's DOB shows the amber badge
+- Toggling FT/PT works
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/EmployeeDialog.tsx
+git commit -m "feat: add FT/PT toggle and DOB input to employee dialog"
+```
+
+---
+
+### Task 4: Employee List — Badges
+
+**Files:**
+- Modify: `src/components/EmployeeList.tsx:288-291` (employee info section)
+
+- [ ] **Step 1: Add import**
+
+At the top of `EmployeeList.tsx`, add:
+
+```typescript
+import { isMinor } from '@/lib/employeeUtils';
+```
+
+- [ ] **Step 2: Add FT/PT and Minor badges to employee card**
+
+In `EmployeeCard`, find the position/compensation line (around line 288-291):
+
+```tsx
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <span className="truncate">{employee.position}</span>
+              <span>•</span>
+              <span className="shrink-0">{getCompensationDisplay()}</span>
+            </div>
+```
+
+Replace with:
+
+```tsx
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <span className="truncate">{employee.position}</span>
+              <span className="text-[11px] px-1.5 py-0.5 rounded-md bg-muted shrink-0">
+                {employee.employment_type === 'part_time' ? 'PT' : 'FT'}
+              </span>
+              {isMinor(employee.date_of_birth) && (
+                <span className="text-[11px] px-1.5 py-0.5 rounded-md bg-amber-500/10 text-amber-600 font-medium shrink-0">
+                  Minor
+                </span>
+              )}
+              <span>•</span>
+              <span className="shrink-0">{getCompensationDisplay()}</span>
+            </div>
+```
+
+- [ ] **Step 3: Verify the badges render**
+
+Run: `npm run dev`
+Open the app, navigate to Employees. Check that FT/PT badges appear. If you have a test employee with a minor DOB, verify the amber "Minor" badge shows.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/EmployeeList.tsx
+git commit -m "feat: add FT/PT and Minor badges to employee list"
+```
+
+---
+
+### Task 5: Shift Planner Sidebar — Filter & Badge
+
+**Files:**
+- Modify: `src/components/scheduling/ShiftPlanner/EmployeeSidebar.tsx`
+- Create: `tests/unit/employeeSidebarFilter.test.ts`
+
+- [ ] **Step 1: Write the filter test**
+
+```typescript
+// tests/unit/employeeSidebarFilter.test.ts
+import { describe, it, expect } from 'vitest';
+import { filterEmployees } from '@/components/scheduling/ShiftPlanner/EmployeeSidebar';
+
+describe('filterEmployees with employment type', () => {
+  const employees = [
+    { id: '1', name: 'Alice', position: 'Server', area: 'FOH', employment_type: 'full_time' as const },
+    { id: '2', name: 'Bob', position: 'Cook', area: 'BOH', employment_type: 'part_time' as const },
+    { id: '3', name: 'Carol', position: 'Server', area: 'FOH', employment_type: 'part_time' as const },
+  ];
+
+  it('returns all when employmentType is "all"', () => {
+    const result = filterEmployees(employees, '', 'all', 'all', 'all');
+    expect(result).toHaveLength(3);
+  });
+
+  it('filters to full_time only', () => {
+    const result = filterEmployees(employees, '', 'all', 'all', 'full_time');
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('Alice');
+  });
+
+  it('filters to part_time only', () => {
+    const result = filterEmployees(employees, '', 'all', 'all', 'part_time');
+    expect(result).toHaveLength(2);
+    expect(result.map((e) => e.name)).toEqual(['Bob', 'Carol']);
+  });
+
+  it('combines employment type with role filter', () => {
+    const result = filterEmployees(employees, '', 'all', 'Server', 'part_time');
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('Carol');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/unit/employeeSidebarFilter.test.ts`
+Expected: FAIL — `filterEmployees` signature doesn't accept 5th arg.
+
+- [ ] **Step 3: Update the Employee interface and filterEmployees function**
+
+In `EmployeeSidebar.tsx`, update the local `Employee` interface (around line 22):
+
+```typescript
+interface Employee {
+  id: string;
+  name: string;
+  position: string | null;
+  area?: string;
+  employment_type?: 'full_time' | 'part_time';
+  date_of_birth?: string;
+}
+```
+
+Update the `filterEmployees` function (around line 28):
+
+```typescript
+export function filterEmployees(
+  employees: Employee[],
+  search: string,
+  area: string,
+  role: string,
+  employmentType: string = 'all',
+): Employee[] {
+  const q = search.toLowerCase();
+  return employees.filter((e) => {
+    if (q && !e.name.toLowerCase().includes(q)) return false;
+    if (area !== 'all' && e.area !== area) return false;
+    if (role !== 'all' && e.position !== role) return false;
+    if (employmentType !== 'all' && e.employment_type !== employmentType) return false;
+    return true;
+  });
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/unit/employeeSidebarFilter.test.ts`
+Expected: All 4 tests PASS.
+
+- [ ] **Step 5: Add employment type filter dropdown and minor badge to the sidebar**
+
+Add the import at the top:
+
+```typescript
+import { isMinor } from '@/lib/employeeUtils';
+```
+
+Add state for employment type filter. After `const [role, setRole] = useState('all');` (line 140):
+
+```typescript
+  const [empType, setEmpType] = useState('all');
+```
+
+Update the `filtered` useMemo to pass the new filter. Find the existing call (around line 195):
+
+```typescript
+  const filtered = useMemo(
+    () => filterEmployees(employees, search, effectiveArea, role, empType),
+    [employees, search, effectiveArea, role, empType],
+  );
+```
+
+Add the filter dropdown in the sticky header, after the role filter's closing `)}` (after line 257):
+
+```tsx
+        <Select value={empType} onValueChange={setEmpType}>
+          <SelectTrigger
+            className="h-8 text-[13px] bg-muted/30 border-border/40 rounded-lg"
+            aria-label="Filter by employment type"
+          >
+            <SelectValue placeholder="All types" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All types</SelectItem>
+            <SelectItem value="full_time">Full-Time</SelectItem>
+            <SelectItem value="part_time">Part-Time</SelectItem>
+          </SelectContent>
+        </Select>
+```
+
+Add minor badge to `DraggableEmployee`. After the position text (around line 118):
+
+```tsx
+        {employee.position && (
+          <div className="flex items-center gap-1">
+            <p className="text-[11px] text-muted-foreground truncate">
+              {employee.position}
+            </p>
+            {isMinor(employee.date_of_birth) && (
+              <span className="text-[10px] px-1 py-0.5 rounded bg-amber-500/10 text-amber-600 font-medium shrink-0">
+                Minor
+              </span>
+            )}
+          </div>
+        )}
+```
+
+This replaces the existing position paragraph (lines 116-119):
+
+```tsx
+        {employee.position && (
+          <p className="text-[11px] text-muted-foreground truncate">
+            {employee.position}
+          </p>
+        )}
+```
+
+Update the `DraggableEmployee` memo comparison (around line 125) to include the new fields:
+
+```typescript
+  (prev, next) =>
+    prev.employee.id === next.employee.id &&
+    prev.employee.name === next.employee.name &&
+    prev.employee.position === next.employee.position &&
+    prev.employee.date_of_birth === next.employee.date_of_birth &&
+    prev.shiftCount === next.shiftCount &&
+    prev.hours === next.hours &&
+    prev.onSelect === next.onSelect,
+```
+
+- [ ] **Step 6: Verify in the browser**
+
+Run: `npm run dev`
+Navigate to Scheduling > Shift Planner. Verify:
+- Employment type filter dropdown appears in the sidebar
+- Filtering by FT/PT works
+- Minor badge appears on employees with minor DOB
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/scheduling/ShiftPlanner/EmployeeSidebar.tsx tests/unit/employeeSidebarFilter.test.ts
+git commit -m "feat: add FT/PT filter and minor badge to shift planner sidebar"
+```
+
+---
+
+### Task 6: AI Scheduler — Prompt Integration
+
+**Files:**
+- Modify: `supabase/functions/_shared/schedule-prompt-builder.ts:9-15` (ScheduleEmployee interface) and `supabase/functions/_shared/schedule-prompt-builder.ts:68-82` (SYSTEM_PROMPT)
+- Modify: `supabase/functions/generate-schedule/index.ts:117` (employee select) and `supabase/functions/generate-schedule/index.ts:212-219` (employee mapping)
+- Create: `tests/unit/schedulePromptBuilder.test.ts`
+
+- [ ] **Step 1: Write the prompt builder test**
+
+```typescript
+// tests/unit/schedulePromptBuilder.test.ts
+import { describe, it, expect } from 'vitest';
+import { buildSchedulePrompt, ScheduleContext } from '../../supabase/functions/_shared/schedule-prompt-builder';
+
+describe('buildSchedulePrompt with employment_type', () => {
+  const baseContext: ScheduleContext = {
+    weekStart: '2026-04-13',
+    employees: [
+      { id: '1', name: 'Alice', position: 'Server', area: null, hourly_rate: 1500, employment_type: 'full_time' },
+      { id: '2', name: 'Bob', position: 'Cook', area: null, hourly_rate: 1800, employment_type: 'part_time' },
+    ],
+    templates: [],
+    availability: {},
+    staffingSettings: null,
+    priorSchedulePatterns: [],
+    hourlySalesPatterns: [],
+    weeklyBudgetTarget: null,
+    lockedShifts: [],
+  };
+
+  it('includes employment_type in employee data', () => {
+    const result = buildSchedulePrompt(baseContext);
+    const userMessage = result.messages[1].content;
+    expect(userMessage).toContain('"employment_type": "full_time"');
+    expect(userMessage).toContain('"employment_type": "part_time"');
+  });
+
+  it('includes FT/PT scheduling rule in system prompt', () => {
+    const result = buildSchedulePrompt(baseContext);
+    const systemMessage = result.messages[0].content;
+    expect(systemMessage).toContain('Full-time');
+    expect(systemMessage).toContain('Part-time');
+    expect(systemMessage).toContain('35-40 hours');
+    expect(systemMessage).toContain('15-25 hours');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/schedulePromptBuilder.test.ts`
+Expected: FAIL — `employment_type` not in interface or output.
+
+- [ ] **Step 3: Update ScheduleEmployee interface**
+
+In `supabase/functions/_shared/schedule-prompt-builder.ts`, update the `ScheduleEmployee` interface (lines 9-15):
+
+```typescript
+export interface ScheduleEmployee {
+  id: string;
+  name: string;
+  position: string;
+  area: string | null;
+  hourly_rate: number; // cents
+  employment_type: 'full_time' | 'part_time';
+}
+```
+
+- [ ] **Step 4: Update SYSTEM_PROMPT with FT/PT rule**
+
+In the `SYSTEM_PROMPT` constant (lines 68-82), add rule 11 after rule 10:
+
+```typescript
+const SYSTEM_PROMPT = `You are a restaurant schedule optimizer. Your job is to create an optimal weekly shift schedule.
+
+RULES:
+1. ONLY use the provided shift templates as shift blocks — do not invent custom time ranges.
+2. ONLY assign employees to templates matching their position.
+3. When a template has an area set, PREFER assigning employees from the same area. Only assign employees from a different area to that template if no same-area employees are available for that time slot. This is a soft preference — cross-area assignments are allowed as a fallback.
+4. ONLY assign employees on days/times they are available.
+5. Do NOT assign any employee more than once in the same time slot (no double-booking).
+6. Do NOT modify or reassign any locked shifts — they are fixed.
+7. Weight staffing toward peak sales hours — more staff during lunch/dinner rushes.
+8. If staffing settings specify minimum crew per position, meet those minimums when possible.
+9. If no staffing settings exist, use prior schedule patterns to infer typical staffing levels.
+10. Try to stay within the weekly labor budget target. If adequate coverage requires exceeding it, note the variance.
+11. Full-time employees should be scheduled for more shifts, targeting 35-40 hours per week. Part-time employees should be scheduled for fewer shifts, targeting 15-25 hours per week. When both full-time and part-time employees are available for a slot, prefer the full-time employee unless they are already near 40 hours for the week.
+
+Return valid JSON only, matching the provided schema exactly.`;
+```
+
+- [ ] **Step 5: Update buildUserPrompt to include employment_type**
+
+In the `buildUserPrompt` function, update the `employeesForPrompt` mapping (around line 132):
+
+```typescript
+  const employeesForPrompt = ctx.employees.map((e) => ({
+    id: e.id,
+    name: e.name,
+    position: e.position,
+    area: e.area ?? 'unassigned',
+    hourly_rate_dollars: (e.hourly_rate / 100).toFixed(2),
+    employment_type: e.employment_type,
+  }));
+```
+
+- [ ] **Step 6: Update the edge function to select and map employment_type**
+
+In `supabase/functions/generate-schedule/index.ts`, update the employee select query (line 117):
+
+```typescript
+        .select("id, name, position, area, hourly_rate, salary_amount, compensation_type, employment_type")
+```
+
+Update the employee mapping (around line 212):
+
+```typescript
+    const employees: ScheduleEmployee[] = activeEmployees.map((e) => ({
+      id: e.id,
+      name: e.name,
+      position: e.position ?? "Staff",
+      area: e.area ?? null,
+      hourly_rate: e.compensation_type === "salary" ? 0 : (e.hourly_rate ?? 0),
+      employment_type: e.employment_type ?? "full_time",
+    }));
+```
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+Run: `npx vitest run tests/unit/schedulePromptBuilder.test.ts`
+Expected: All 2 tests PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add supabase/functions/_shared/schedule-prompt-builder.ts supabase/functions/generate-schedule/index.ts tests/unit/schedulePromptBuilder.test.ts
+git commit -m "feat: add employment_type to AI schedule prompt for FT/PT hour targeting"
+```
+
+---
+
+### Task 7: E2E Test
+
+**Files:**
+- Create: `tests/e2e/employee-ft-pt-dob.spec.ts`
+
+- [ ] **Step 1: Write the E2E test**
+
+```typescript
+// tests/e2e/employee-ft-pt-dob.spec.ts
+import { test, expect } from '@playwright/test';
+import { generateTestUser } from '../helpers/e2e-supabase';
+
+test.describe('Employee FT/PT and DOB', () => {
+  test('can create a part-time minor employee and see badges', async ({ page }) => {
+    const testUser = generateTestUser();
+
+    // Navigate to employees page (assumes auth is handled by test setup)
+    await page.goto('/employees');
+
+    // Open add employee dialog
+    await page.getByRole('button', { name: /add/i }).click();
+
+    // Fill basic info
+    await page.getByLabel('Employee name').fill('Test Minor PT');
+    await page.getByLabel('Employee name').press('Tab');
+
+    // Toggle to Part-Time
+    await page.getByRole('button', { name: 'Part-time employment' }).click();
+
+    // Verify PT button is pressed
+    await expect(page.getByRole('button', { name: 'Part-time employment' })).toHaveAttribute('aria-pressed', 'true');
+
+    // Fill DOB for a minor (16 years old)
+    const minorDob = new Date();
+    minorDob.setFullYear(minorDob.getFullYear() - 16);
+    const dobStr = minorDob.toISOString().split('T')[0];
+    await page.getByLabel('Date of birth').fill(dobStr);
+
+    // Verify minor badge appears in dialog
+    await expect(page.getByText(/Minor \(\d+ yrs\)/)).toBeVisible();
+
+    // Fill required compensation field
+    await page.getByLabel('Hourly rate in dollars').fill('12.00');
+
+    // Submit
+    await page.getByRole('button', { name: /add employee/i }).click();
+
+    // Wait for dialog to close
+    await expect(page.getByRole('dialog')).toBeHidden({ timeout: 5000 });
+
+    // Verify badges appear in the employee list
+    await expect(page.getByText('Test Minor PT')).toBeVisible();
+    await expect(page.getByText('PT')).toBeVisible();
+    await expect(page.getByText('Minor')).toBeVisible();
+  });
+});
+```
+
+- [ ] **Step 2: Run the E2E test**
+
+Run: `npx playwright test tests/e2e/employee-ft-pt-dob.spec.ts`
+Expected: PASS (after the previous tasks are complete and dev server is running).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/e2e/employee-ft-pt-dob.spec.ts
+git commit -m "test: add E2E test for employee FT/PT toggle and DOB minor badge"
+```
+
+---
+
+### Task 8: Final Verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `npm run test`
+Expected: All unit tests PASS.
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `npm run typecheck`
+Expected: No new errors.
+
+- [ ] **Step 3: Run lint**
+
+Run: `npm run lint`
+Expected: No new errors (pre-existing ones are fine).
+
+- [ ] **Step 4: Run build**
+
+Run: `npm run build`
+Expected: Successful build.
+
+- [ ] **Step 5: Run pgTAP tests**
+
+Run: `npm run test:db`
+Expected: All tests PASS including the new ones.

--- a/docs/superpowers/plans/2026-04-16-planner-shift-template-bucketing-plan.md
+++ b/docs/superpowers/plans/2026-04-16-planner-shift-template-bucketing-plan.md
@@ -1,0 +1,352 @@
+# Planner Shift-to-Template Bucketing Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the planner bug where shifts display under the wrong template row when two templates across different areas share the same time/position/days.
+
+**Architecture:** Add a nullable `shift_template_id` foreign key to the `shifts` table. Thread the template ID through the planner's shift creation flow. Use it in `buildTemplateGridData` for deterministic bucketing, falling back to the existing fuzzy matching for legacy shifts.
+
+**Tech Stack:** PostgreSQL migration, TypeScript, React, Vitest
+
+---
+
+## File Map
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `supabase/migrations/20260416000000_add_shift_template_id.sql` | Create | Add `shift_template_id` column to `shifts` |
+| `src/types/scheduling.ts` | Modify | Add `shift_template_id` to `Shift` interface |
+| `src/hooks/useShiftPlanner.ts` | Modify | Update `buildTemplateGridData` to use template ID; add `shiftTemplateId` to `ShiftCreateInput` and `buildShiftPayload` |
+| `src/components/scheduling/ShiftPlanner/ShiftPlannerTab.tsx` | Modify | Thread template ID through `handleAssignDay`/`handleAssignAll` |
+| `tests/unit/useShiftPlanner.test.ts` | Modify | Add tests for template-ID-based bucketing |
+
+---
+
+### Task 1: Database migration — add `shift_template_id` to shifts
+
+**Files:**
+- Create: `supabase/migrations/20260416000000_add_shift_template_id.sql`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- Add shift_template_id to shifts for accurate planner bucketing.
+-- Nullable: legacy/imported shifts won't have a template reference.
+ALTER TABLE shifts
+  ADD COLUMN shift_template_id UUID REFERENCES shift_templates(id) ON DELETE SET NULL;
+
+-- Index for efficient lookups when building the planner grid
+CREATE INDEX idx_shifts_shift_template_id ON shifts(shift_template_id)
+  WHERE shift_template_id IS NOT NULL;
+```
+
+- [ ] **Step 2: Verify migration applies cleanly**
+
+Run: `npm run db:reset`
+Expected: All migrations apply without errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add supabase/migrations/20260416000000_add_shift_template_id.sql
+git commit -m "feat(db): add shift_template_id column to shifts table"
+```
+
+---
+
+### Task 2: Update TypeScript types
+
+**Files:**
+- Modify: `src/types/scheduling.ts:89-110` (Shift interface)
+
+- [ ] **Step 1: Add `shift_template_id` to the Shift interface**
+
+In `src/types/scheduling.ts`, add the field after `source`:
+
+```typescript
+  source: 'manual' | 'ai' | 'template';
+  shift_template_id?: string | null; // References shift_templates.id for planner bucketing
+  created_at: string;
+```
+
+- [ ] **Step 2: Regenerate Supabase types**
+
+Run: `npx supabase gen types typescript --local > src/integrations/supabase/types.ts`
+Expected: `shift_template_id` appears in the generated `shifts` table type.
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `npm run typecheck`
+Expected: No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/types/scheduling.ts src/integrations/supabase/types.ts
+git commit -m "feat(types): add shift_template_id to Shift interface and regenerate Supabase types"
+```
+
+---
+
+### Task 3: Update `buildTemplateGridData` to use `shift_template_id`
+
+**Files:**
+- Modify: `src/hooks/useShiftPlanner.ts:122-151`
+- Test: `tests/unit/useShiftPlanner.test.ts`
+
+- [ ] **Step 1: Write the failing test — shift with `shift_template_id` buckets correctly**
+
+Add this test to the `buildTemplateGridData` describe block in `tests/unit/useShiftPlanner.test.ts`:
+
+```typescript
+    it('should bucket shift by shift_template_id when present, ignoring time-based matching', () => {
+      // Two templates with identical time/position/days but different areas
+      const cscTemplate: ShiftTemplate = {
+        id: 't-csc', start_time: '10:00:00', end_time: '16:30:00', position: 'Server',
+        days: [5, 6, 0], name: 'Open-weekend-csc', area: 'Cold Stone',
+        restaurant_id: 'r1', break_duration: 0, capacity: 2, is_active: true, created_at: '', updated_at: '',
+      };
+      const wtzTemplate: ShiftTemplate = {
+        id: 't-wtz', start_time: '10:00:00', end_time: '16:30:00', position: 'Server',
+        days: [5, 6, 0], name: 'Open-weekend-wtz', area: "Wetzel's",
+        restaurant_id: 'r1', break_duration: 0, capacity: 2, is_active: true, created_at: '', updated_at: '',
+      };
+
+      // Shift explicitly linked to wtz template
+      const shift = mockShift({
+        id: 's1', employee_id: 'e1',
+        start_time: '2026-03-07T10:00:00', end_time: '2026-03-07T16:30:00',
+        position: 'Server', status: 'scheduled',
+        shift_template_id: 't-wtz',
+      });
+
+      const grid = buildTemplateGridData([shift], [cscTemplate, wtzTemplate], weekDays);
+
+      // Should be in wtz bucket, NOT csc (which would be the .find() first-match)
+      expect(grid.get('t-wtz')?.get('2026-03-07')).toHaveLength(1);
+      expect(grid.get('t-csc')?.get('2026-03-07') ?? []).toHaveLength(0);
+    });
+
+    it('should fall back to time-based matching when shift_template_id is absent', () => {
+      // Legacy shift without shift_template_id — should still match by time/position/day
+      const shift = mockShift({
+        id: 's1', employee_id: 'e1',
+        start_time: '2026-03-02T06:00:00', end_time: '2026-03-02T12:00:00',
+        position: 'Server', status: 'scheduled',
+        // No shift_template_id
+      });
+
+      const grid = buildTemplateGridData([shift], templates, weekDays);
+      expect(grid.get('t1')?.get('2026-03-02')).toHaveLength(1);
+    });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test -- tests/unit/useShiftPlanner.test.ts`
+Expected: The first new test fails because `buildTemplateGridData` doesn't check `shift_template_id`.
+
+- [ ] **Step 3: Update `buildTemplateGridData` to check `shift_template_id` first**
+
+In `src/hooks/useShiftPlanner.ts`, replace the `buildTemplateGridData` function (lines 122-151):
+
+```typescript
+export function buildTemplateGridData(
+  shifts: Shift[],
+  templates: ShiftTemplate[],
+  weekDays: string[],
+): Map<string, Map<string, Shift[]>> {
+  const weekDaySet = new Set(weekDays);
+  const grid = new Map<string, Map<string, Shift[]>>();
+  const templateIds = new Set(templates.map((t) => t.id));
+
+  for (const t of templates) {
+    grid.set(t.id, new Map());
+  }
+  grid.set('__unmatched__', new Map());
+
+  for (const shift of shifts) {
+    if (shift.status === 'cancelled') continue;
+    const shiftStartAt = new Date(shift.start_time);
+    const dayStr = formatLocalDate(shiftStartAt);
+    if (!weekDaySet.has(dayStr)) continue;
+
+    // Prefer explicit template ID (set during planner assignment)
+    if (shift.shift_template_id && templateIds.has(shift.shift_template_id)) {
+      pushToGridBucket(grid.get(shift.shift_template_id)!, dayStr, shift);
+      continue;
+    }
+
+    // Fallback: match by time/position/day for legacy shifts
+    const shiftStart = formatLocalTime(shift.start_time);
+    const shiftEnd = formatLocalTime(shift.end_time);
+    const dayOfWeek = shiftStartAt.getDay();
+    const match = findMatchingTemplate(templates, shiftStart, shiftEnd, shift.position, dayOfWeek);
+
+    const bucketKey = match ? match.id : '__unmatched__';
+    pushToGridBucket(grid.get(bucketKey)!, dayStr, shift);
+  }
+
+  return grid;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npm run test -- tests/unit/useShiftPlanner.test.ts`
+Expected: All tests pass, including the two new ones.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useShiftPlanner.ts tests/unit/useShiftPlanner.test.ts
+git commit -m "fix: use shift_template_id for planner grid bucketing with fallback"
+```
+
+---
+
+### Task 4: Thread template ID through shift creation
+
+**Files:**
+- Modify: `src/hooks/useShiftPlanner.ts:254-262` (ShiftCreateInput), `src/hooks/useShiftPlanner.ts:167-184` (buildShiftPayload)
+- Modify: `src/components/scheduling/ShiftPlanner/ShiftPlannerTab.tsx:186-218` (handleAssignDay), `src/components/scheduling/ShiftPlanner/ShiftPlannerTab.tsx:221-271` (handleAssignAll)
+
+- [ ] **Step 1: Add `shiftTemplateId` to `ShiftCreateInput`**
+
+In `src/hooks/useShiftPlanner.ts`, update the `ShiftCreateInput` interface:
+
+```typescript
+export interface ShiftCreateInput {
+  employeeId: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  position: string;
+  breakDuration?: number;
+  notes?: string;
+  shiftTemplateId?: string;
+}
+```
+
+- [ ] **Step 2: Pass it through `buildShiftPayload`**
+
+In `src/hooks/useShiftPlanner.ts`, update the `buildShiftPayload` function:
+
+```typescript
+function buildShiftPayload(
+  restaurantId: string,
+  input: ShiftCreateInput,
+  interval: ShiftInterval,
+) {
+  return {
+    restaurant_id: restaurantId,
+    employee_id: input.employeeId,
+    start_time: interval.startAt.toISOString(),
+    end_time: interval.endAt.toISOString(),
+    position: input.position,
+    break_duration: input.breakDuration ?? 0,
+    notes: input.notes,
+    status: 'scheduled' as const,
+    is_published: false,
+    locked: false,
+    shift_template_id: input.shiftTemplateId ?? null,
+  };
+}
+```
+
+- [ ] **Step 3: Thread template ID in `handleAssignDay`**
+
+In `src/components/scheduling/ShiftPlanner/ShiftPlannerTab.tsx`, update `handleAssignDay` to include `shiftTemplateId` in the input:
+
+```typescript
+    const input: ShiftCreateInput = {
+      employeeId: employee.id,
+      date: day,
+      startTime: startHHMM,
+      endTime: endHHMM,
+      position: template.position,
+      breakDuration: template.break_duration,
+      shiftTemplateId: template.id,
+    };
+```
+
+- [ ] **Step 4: Thread template ID in `handleAssignAll`**
+
+In `src/components/scheduling/ShiftPlanner/ShiftPlannerTab.tsx`, update `handleAssignAll` to include `shiftTemplateId` in each input:
+
+```typescript
+    const allInputs: ShiftCreateInput[] = activeDays.map((day) => ({
+      employeeId: employee.id,
+      date: day,
+      startTime: startHHMM,
+      endTime: endHHMM,
+      position: template.position,
+      breakDuration: template.break_duration,
+      shiftTemplateId: template.id,
+    }));
+```
+
+- [ ] **Step 5: Run typecheck and tests**
+
+Run: `npm run typecheck && npm run test`
+Expected: Both pass without errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hooks/useShiftPlanner.ts src/components/scheduling/ShiftPlanner/ShiftPlannerTab.tsx
+git commit -m "fix: thread shift_template_id through planner shift creation flow"
+```
+
+---
+
+### Task 5: Include `shift_template_id` in shift query select
+
+**Files:**
+- Modify: `src/hooks/useShifts.tsx:56-68`
+
+- [ ] **Step 1: Verify the select includes `shift_template_id`**
+
+The current query uses `select('*, employee:employees(*)')` which already selects all columns including the new `shift_template_id`. No code change needed — the wildcard `*` covers it.
+
+Verify by checking `toTypedShift` handles the new field. Since it spreads `...shift` into the return object, the field passes through automatically.
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `npm run test`
+Expected: All tests pass.
+
+- [ ] **Step 3: No commit needed** (no code changes)
+
+---
+
+### Task 6: Full verification
+
+- [ ] **Step 1: Reset database and verify migration**
+
+Run: `npm run db:reset`
+Expected: All migrations apply cleanly.
+
+- [ ] **Step 2: Run all unit tests**
+
+Run: `npm run test`
+Expected: All pass.
+
+- [ ] **Step 3: Run typecheck and lint**
+
+Run: `npm run typecheck && npm run lint`
+Expected: No errors.
+
+- [ ] **Step 4: Run build**
+
+Run: `npm run build`
+Expected: Successful build.
+
+- [ ] **Step 5: Manual smoke test**
+
+Start dev server (`npm run dev:full`). In the Planner:
+1. Create two templates in different areas with identical time/position/days
+2. Drag an employee onto the first template's cell
+3. Verify the shift appears in the correct template row (not the other area's row)
+4. Verify the toast and dialog show the correct template name
+5. Repeat for the second template to confirm both work independently

--- a/docs/superpowers/plans/2026-04-17-labor-cost-stale-comp-history-plan.md
+++ b/docs/superpowers/plans/2026-04-17-labor-cost-stale-comp-history-plan.md
@@ -15,16 +15,16 @@
 ### Task 1: Reproduce the bug in a failing unit test for `resolveCompensationForDate`
 
 **Files:**
-- Test: `tests/unit/resolveCompensationForDate.test.ts` (new)
+- Test: `tests/unit/compensation-edge-cases.test.ts` (existing file already covering this resolver — add new cases to the "Compensation Type Transitions" describe block)
 
-- [ ] **Step 1: Check if a test file already exists for the resolver**
+- [ ] **Step 1: Confirm the existing resolver test file**
 
 Run: `ls tests/unit/ | grep -i compensation`
-If a file exists that already tests `resolveCompensationForDate`, add the new cases to it and adjust paths below. Otherwise create the new file.
+Expected: `compensation-edge-cases.test.ts` already imports `resolveCompensationForDate`. Add the new cases there (matching the existing `createEmployee` helper). Only create a new `tests/unit/resolveCompensationForDate.test.ts` if the existing file is ever removed.
 
 - [ ] **Step 2: Write two failing tests covering the bug and the fallback guarantee**
 
-Contents of `tests/unit/resolveCompensationForDate.test.ts`:
+Contents to append inside `tests/unit/compensation-edge-cases.test.ts` (the `Compensation Type Transitions` describe block), re-using its `createEmployee` helper:
 
 ```ts
 import { describe, it, expect } from 'vitest';

--- a/docs/superpowers/plans/2026-04-17-labor-cost-stale-comp-history-plan.md
+++ b/docs/superpowers/plans/2026-04-17-labor-cost-stale-comp-history-plan.md
@@ -1,0 +1,247 @@
+# Labor Cost Stale Compensation History Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the Scheduling page's Labor Cost aggregate dropping shifts when an employee's compensation history contains a stale entry of a different `compensation_type`.
+
+**Architecture:** Single narrow change to `resolveCompensationForDate` so it prefers history entries whose `compensation_type` matches the employee's current value, with a fallback to the previous behavior for legitimate past comp-type transitions. All downstream labor-cost calculators inherit the fix.
+
+**Tech Stack:** TypeScript, Vitest (unit tests), React Query (consumer, unaffected).
+
+**Spec:** `docs/superpowers/specs/2026-04-17-labor-cost-stale-comp-history-design.md`
+
+---
+
+### Task 1: Reproduce the bug in a failing unit test for `resolveCompensationForDate`
+
+**Files:**
+- Test: `tests/unit/resolveCompensationForDate.test.ts` (new)
+
+- [ ] **Step 1: Check if a test file already exists for the resolver**
+
+Run: `ls tests/unit/ | grep -i compensation`
+If a file exists that already tests `resolveCompensationForDate`, add the new cases to it and adjust paths below. Otherwise create the new file.
+
+- [ ] **Step 2: Write two failing tests covering the bug and the fallback guarantee**
+
+Contents of `tests/unit/resolveCompensationForDate.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { resolveCompensationForDate } from '@/utils/compensationCalculations';
+import type { Employee, CompensationHistoryEntry } from '@/types/scheduling';
+
+function makeEmployee(overrides: Partial<Employee>): Employee {
+  return {
+    id: 'emp-1',
+    restaurant_id: 'rest-1',
+    name: 'Test Employee',
+    position: 'Server',
+    status: 'active',
+    is_active: true,
+    compensation_type: 'hourly',
+    hourly_rate: 1000,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  } as Employee;
+}
+
+function historyEntry(
+  effective_date: string,
+  compensation_type: CompensationHistoryEntry['compensation_type'],
+  amount_cents: number,
+  extra: Partial<CompensationHistoryEntry> = {},
+): CompensationHistoryEntry {
+  return {
+    id: `hist-${effective_date}-${compensation_type}`,
+    employee_id: 'emp-1',
+    restaurant_id: 'rest-1',
+    effective_date,
+    compensation_type,
+    amount_cents,
+    created_at: `${effective_date}T00:00:00Z`,
+    ...extra,
+  };
+}
+
+describe('resolveCompensationForDate', () => {
+  it('skips a stale history entry of a different compensation_type and uses the most recent matching-type entry', () => {
+    // Reproduces the Alejandra bug: current comp_type is 'hourly' but a stale
+    // 'salary' entry sits between the shift date and the most recent hourly entry.
+    const employee = makeEmployee({
+      compensation_type: 'hourly',
+      hourly_rate: 1000,
+      compensation_history: [
+        historyEntry('2026-03-01', 'hourly', 3000),
+        historyEntry('2026-03-15', 'hourly', 1500),
+        historyEntry('2026-04-01', 'hourly', 1000),
+        historyEntry('2026-04-11', 'salary', 60000),
+      ],
+    });
+
+    const snapshot = resolveCompensationForDate(employee, '2026-04-13');
+
+    expect(snapshot.compensation_type).toBe('hourly');
+    expect(snapshot.hourly_rate).toBe(1000);
+  });
+
+  it('falls back to a mismatched-type entry when no matching-type entry exists on or before the date (legitimate comp-type transition)', () => {
+    // Employee started on salary in Jan, switched to hourly in April. A Feb shift
+    // still correctly resolves to the salary rate in effect at that time.
+    const employee = makeEmployee({
+      compensation_type: 'hourly',
+      hourly_rate: 1500,
+      salary_amount: 200000,
+      pay_period_type: 'bi-weekly',
+      compensation_history: [
+        historyEntry('2026-01-01', 'salary', 200000, { pay_period_type: 'bi-weekly' }),
+        historyEntry('2026-04-01', 'hourly', 1500),
+      ],
+    });
+
+    const snapshot = resolveCompensationForDate(employee, '2026-02-15');
+
+    expect(snapshot.compensation_type).toBe('salary');
+    expect(snapshot.salary_amount).toBe(200000);
+    expect(snapshot.pay_period_type).toBe('bi-weekly');
+  });
+});
+```
+
+- [ ] **Step 3: Run the tests and confirm they fail**
+
+Run: `npm run test -- tests/unit/resolveCompensationForDate.test.ts`
+Expected: first test FAILS with `compensation_type` being `'salary'` instead of `'hourly'`. Second test passes (fallback path already exists).
+
+- [ ] **Step 4: Commit the failing test**
+
+```bash
+git add tests/unit/resolveCompensationForDate.test.ts
+git commit -m "test: add failing coverage for stale comp-type history entries"
+```
+
+---
+
+### Task 2: Implement the resolver fix
+
+**Files:**
+- Modify: `src/utils/compensationCalculations.ts:72-100`
+
+- [ ] **Step 1: Read the current implementation to confirm location**
+
+```bash
+sed -n '70,100p' src/utils/compensationCalculations.ts
+```
+
+Expected: `resolveCompensationForDate` function starting at line 72.
+
+- [ ] **Step 2: Apply the fix**
+
+Replace the single-line lookup:
+```ts
+const entry = history.find(h => h.effective_date <= dateStr);
+```
+
+With the current-type-preferring version:
+```ts
+// Prefer the most recent entry whose compensation_type matches the employee's
+// current compensation_type; fall back to any most-recent entry for legitimate
+// historical comp-type transitions (e.g. salary→hourly).
+const matchingEntry = history.find(
+  h => h.effective_date <= dateStr && h.compensation_type === employee.compensation_type
+);
+const entry = matchingEntry ?? history.find(h => h.effective_date <= dateStr);
+```
+
+- [ ] **Step 3: Run the unit tests and confirm both pass**
+
+Run: `npm run test -- tests/unit/resolveCompensationForDate.test.ts`
+Expected: both tests PASS.
+
+- [ ] **Step 4: Run the full existing compensation/labor test suites to catch regressions**
+
+Run:
+```bash
+npm run test -- tests/unit/laborCalculations.test.ts tests/unit/useScheduledLaborCosts.test.ts tests/unit/laborCalculations-clockInOut.test.ts tests/unit/laborCalculations-dailyRate.test.ts tests/unit/dashboardLaborCosts.test.ts tests/unit/pnlLaborCosts.test.ts
+```
+Expected: all PASS. If any fail, the failure reveals an assumption that conflicts with the new preference and must be analyzed — do NOT mass-update tests to hide the failure.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/compensationCalculations.ts
+git commit -m "fix(labor-cost): prefer current comp_type when resolving history snapshot"
+```
+
+---
+
+### Task 3: Add integration test at the `calculateScheduledLaborCost` level
+
+**Files:**
+- Modify: `tests/unit/useScheduledLaborCosts.test.ts` (add one test; do not remove existing cases)
+
+- [ ] **Step 1: Read the existing test file to find a good insertion point and mock helpers**
+
+```bash
+sed -n '1,60p' tests/unit/useScheduledLaborCosts.test.ts
+```
+
+Identify how mock employees and shifts are constructed and where `describe` blocks group related assertions. Add the new test inside the same `describe` block that contains "ignores inactive employees" (nearby thematic fit).
+
+- [ ] **Step 2: Add a new `it(...)` test immediately after the existing "ignores inactive employees" test**
+
+The test must mirror the Alejandra data pattern: an hourly employee whose compensation_history contains a stale salary entry *after* all the hourly entries but *before* the shift date. Use the existing mock utilities in the file rather than creating new ones — follow whatever shape is already in use.
+
+Test contract (shape, not literal code since helper names vary by file):
+- Mock employee: `compensation_type: 'hourly'`, `hourly_rate: 1000`, plus `compensation_history` containing:
+  - `{ effective_date: '2026-04-01', compensation_type: 'hourly', amount_cents: 1000 }`
+  - `{ effective_date: '2026-04-11', compensation_type: 'salary', amount_cents: 60000 }`
+- Mock shift: `start_time: '2026-04-13T15:00:00Z'`, `end_time: '2026-04-13T21:30:00Z'`, `break_duration: 30` → 6 net hours.
+- Period: a week containing 2026-04-13.
+- Expected: `breakdown.hourly.hours` is ~6 and `breakdown.hourly.cost` is ~60 (not 0).
+
+- [ ] **Step 3: Run the new test plus the full file**
+
+Run: `npm run test -- tests/unit/useScheduledLaborCosts.test.ts`
+Expected: all tests PASS (the new one validates the end-to-end fix).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/unit/useScheduledLaborCosts.test.ts
+git commit -m "test: cover stale salary history regression in scheduled labor cost aggregate"
+```
+
+---
+
+### Task 4: Full verification
+
+- [ ] **Step 1: Type check**
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 2: Lint**
+
+Run: `npm run lint`
+Expected: no new warnings on touched files.
+
+- [ ] **Step 3: Full test suite**
+
+Run: `npm run test`
+Expected: all PASS.
+
+- [ ] **Step 4: Build**
+
+Run: `npm run build`
+Expected: success.
+
+---
+
+## Self-Review Checklist
+
+- [x] Spec coverage: every spec section maps to a task (resolver fix → Task 2, unit tests → Task 1, integration test → Task 3).
+- [x] No placeholders: all test and code blocks contain concrete content.
+- [x] Type consistency: `CompensationHistoryEntry`, `Employee`, and `resolveCompensationForDate` names match their source-of-truth definitions.
+- [x] Out-of-scope items from spec are explicitly not present in any task.

--- a/docs/superpowers/specs/2026-04-13-employee-ft-pt-dob-design.md
+++ b/docs/superpowers/specs/2026-04-13-employee-ft-pt-dob-design.md
@@ -1,0 +1,156 @@
+# Employee FT/PT Employment Type & Date of Birth
+
+## Problem
+
+Managers need to distinguish full-time vs part-time employees for scheduling purposes. While employee availability captures *when* someone can work, FT/PT captures *how much* they should work per week. Not all employees fill out availability, so FT/PT provides a reliable planning signal for both manual and AI-powered scheduling.
+
+Additionally, managers need to know when an employee is a minor so they can comply with state labor laws. A date of birth field enables the system to flag minors visually, positioning the platform for future AI-powered labor rule enforcement.
+
+## Design
+
+### Database
+
+Single migration adding two columns to `employees`:
+
+| Column | Type | Nullable | Default | Constraint |
+|--------|------|----------|---------|------------|
+| `employment_type` | `TEXT` | NOT NULL | `'full_time'` | `CHECK (employment_type IN ('full_time', 'part_time'))` |
+| `date_of_birth` | `DATE` | YES | `NULL` | None |
+
+- No new tables or RLS policies needed — existing employee-level RLS covers these columns.
+- Default `'full_time'` means existing employees are automatically classified as FT without requiring backfill.
+
+### Employee Dialog (EmployeeDialog.tsx)
+
+**FT/PT segmented toggle:**
+- Placed between Area and Compensation Type fields.
+- Two-button toggle: "Full-Time" | "Part-Time". Defaults to Full-Time.
+- Helper text below: "Used by the scheduler to plan weekly hours."
+- Uses the same visual pattern as existing toggle elements in the dialog.
+
+**Date of birth input:**
+- Added as a third column in the existing Status / Hire Date row, making it a 3-column grid: Status | Hire Date | Date of Birth.
+- Standard date input, optional (no asterisk, no required validation).
+- When the computed age is under 18, an inline amber badge appears below the field: "Minor (N yrs)" using the project's standard badge styling (`text-[11px] px-1.5 py-0.5 rounded-md bg-amber-500/10 text-amber-600`).
+
+**Form state additions:**
+- `employmentType` state, initialized from `employee.employment_type` or `'full_time'`.
+- `dateOfBirth` state, initialized from `employee.date_of_birth` or `''`.
+- Both included in the `employeeData` payload for create/update.
+- Both included in `resetForm()`.
+
+### Employee List (EmployeeList.tsx)
+
+- FT/PT badge displayed next to position text on each employee card. Uses subtle styling: `text-[11px] px-1.5 py-0.5 rounded-md bg-muted` showing "FT" or "PT".
+- Minor badge (amber) shown when DOB indicates age < 18. Same badge style as the dialog: `bg-amber-500/10 text-amber-600`.
+
+### Shift Planner Sidebar (EmployeeSidebar.tsx)
+
+**New filter dropdown:**
+- "Employment type" filter added alongside existing Area and Role filters.
+- Options: "All types" | "Full-Time" | "Part-Time".
+- Follows the same `Select` component pattern as existing filters.
+
+**Employee chip updates:**
+- The sidebar's local `Employee` interface gets `employment_type` and `date_of_birth` added.
+- Minor badge shown on employee chips when applicable (amber dot or "Minor" text).
+- `filterEmployees()` function extended with an `employmentType` parameter.
+
+**Data flow:**
+- `ShiftPlannerTab.tsx` already fetches full employee objects — `employment_type` and `date_of_birth` will flow through once the hook select includes them.
+
+### AI Scheduler (schedule-prompt-builder.ts)
+
+**ScheduleEmployee interface:**
+```typescript
+export interface ScheduleEmployee {
+  id: string;
+  name: string;
+  position: string;
+  area: string | null;
+  hourly_rate: number; // cents
+  employment_type: 'full_time' | 'part_time'; // NEW
+}
+```
+
+**Prompt changes:**
+- Employee data sent to AI includes `employment_type` field.
+- New rule added to SYSTEM_PROMPT (rule 11):
+
+> 11. Full-time employees should be scheduled for more shifts, targeting 35-40 hours per week. Part-time employees should be scheduled for fewer shifts, targeting 15-25 hours per week. When both full-time and part-time employees are available for a slot, prefer the full-time employee unless they are already near 40 hours for the week.
+
+**What is NOT passed to AI:**
+- `date_of_birth` is NOT included in `ScheduleEmployee` or the prompt. Minor status is UI-only for now. Future work will pass minor status to enable AI-powered labor rule enforcement per state.
+
+### Edge Function (generate-schedule/index.ts)
+
+- The employee query in the edge function adds `employment_type` to the select.
+- Maps it into the `ScheduleEmployee` object passed to the prompt builder.
+
+### TypeScript Types (types/scheduling.ts)
+
+```typescript
+export type EmploymentType = 'full_time' | 'part_time';
+
+export interface Employee {
+  // ... existing fields ...
+  employment_type: EmploymentType;
+  date_of_birth?: string;
+}
+```
+
+### Hooks (useEmployees.tsx)
+
+- No changes needed to `useEmployees` — it uses `select('*')` which will include the new columns automatically.
+- The `useCreateEmployee` and `useUpdateEmployee` mutations already pass through the full payload.
+
+### Minor Age Calculation
+
+A pure utility function for computing age and minor status:
+
+```typescript
+// src/lib/employeeUtils.ts
+export function computeAge(dateOfBirth: string): number {
+  const today = new Date();
+  const dob = new Date(dateOfBirth);
+  let age = today.getFullYear() - dob.getFullYear();
+  const monthDiff = today.getMonth() - dob.getMonth();
+  if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < dob.getDate())) {
+    age--;
+  }
+  return age;
+}
+
+export function isMinor(dateOfBirth: string | null | undefined): boolean {
+  if (!dateOfBirth) return false;
+  return computeAge(dateOfBirth) < 18;
+}
+```
+
+This is used by EmployeeDialog, EmployeeList, and EmployeeSidebar for badge rendering. No database-level age computation needed.
+
+## Testing
+
+### pgTAP Tests
+- `employment_type` defaults to `'full_time'` when not specified.
+- `employment_type` CHECK constraint rejects invalid values (e.g., `'contractor'`).
+- `date_of_birth` accepts valid dates and NULL.
+- Existing employees retain `'full_time'` after migration.
+
+### Unit Tests
+- `computeAge()` — various DOB values, edge cases (birthday today, leap year).
+- `isMinor()` — under 18, exactly 18, over 18, null/undefined.
+- `filterEmployees()` — with employment type filter parameter.
+- `buildSchedulePrompt()` — employment_type appears in generated prompt.
+
+### E2E Test
+- Create employee with PT toggle and DOB that makes them a minor.
+- Verify "Minor" badge appears in the employee dialog and list.
+- Verify FT/PT filter works in shift planner sidebar.
+
+## Out of Scope
+
+- State-specific minor labor rules and automatic availability restrictions (future feature).
+- Passing DOB or minor status to the AI scheduler (future feature).
+- Target hours configuration per FT/PT (using hardcoded ranges in AI prompt for now — 35-40h FT, 15-25h PT).
+- Overtime/benefits implications of FT/PT classification (this is a scheduling hint only, not a legal classification tool).

--- a/docs/superpowers/specs/2026-04-16-planner-shift-template-bucketing-design.md
+++ b/docs/superpowers/specs/2026-04-16-planner-shift-template-bucketing-design.md
@@ -1,0 +1,45 @@
+# Planner Shift-to-Template Bucketing Fix
+
+## Problem
+
+When two shift templates across different areas share the same `(start_time, end_time, position, days)` — e.g., "Open-weekend-csc" (Cold Stone) and "Open-weekend-wtz" (Wetzel's) both at 10a-4:30p Server — shifts display in the wrong template row.
+
+**Root cause:** The `shifts` table has no foreign key to `shift_templates`. The planner's `buildTemplateGridData` function uses `findMatchingTemplate` which matches by time/position/day only, ignoring area. `.find()` returns the first match (alphabetical by area), so all ambiguous shifts bucket into one row.
+
+**User impact:** After assigning an employee to a template via drag-and-drop, the shift appears in the wrong template row. The toast message shows the correct template, but the grid shows it under a different area's template. This creates confusion about which area the employee is actually assigned to.
+
+## Solution
+
+Add a nullable `shift_template_id` foreign key to the `shifts` table. Store the template ID when creating shifts from the planner. Use it for deterministic bucketing in `buildTemplateGridData`.
+
+### Database
+
+- Add `shift_template_id UUID REFERENCES shift_templates(id) ON DELETE SET NULL` to `shifts` table (nullable for backward compatibility with legacy/imported shifts)
+
+### Backend (shift creation)
+
+- Update `buildShiftPayload` in `useShiftPlanner.ts` to accept and pass through `shift_template_id`
+- Update `ShiftCreateInput` interface to include optional `shiftTemplateId`
+- Thread the template ID from `handleAssignDay`/`handleAssignAll` in `ShiftPlannerTab.tsx` through to `validateAndCreate`/`forceCreate`
+
+### Display logic
+
+- Update `buildTemplateGridData` to check `shift.shift_template_id` first. If present, bucket directly by template ID. Fall back to `findMatchingTemplate` only for shifts without a template ID (legacy data).
+
+### TypeScript types
+
+- Add `shift_template_id?: string | null` to the `Shift` interface
+- Regenerate Supabase types
+
+## Scope
+
+- Migration: 1 new column, 1 foreign key
+- TypeScript: `Shift` interface, `ShiftCreateInput`, `buildShiftPayload`, `buildTemplateGridData`, `findMatchingTemplate` (kept as fallback)
+- Components: `ShiftPlannerTab.tsx` (thread template ID through creation flow)
+- Tests: Unit tests for `buildTemplateGridData` with template ID bucketing
+- No UI changes needed
+
+## Out of scope
+
+- Backfilling `shift_template_id` for existing shifts (they continue using the fallback matching)
+- Changing the drag-and-drop collision detection (rows are correctly rendered; the display bug was what made drops appear wrong)

--- a/docs/superpowers/specs/2026-04-17-labor-cost-stale-comp-history-design.md
+++ b/docs/superpowers/specs/2026-04-17-labor-cost-stale-comp-history-design.md
@@ -1,0 +1,65 @@
+# Labor Cost: Stale Compensation History Snapshot Fix
+
+**Date:** 2026-04-17
+**Type:** Bug fix
+**Area:** Scheduling / Labor cost calculations
+
+## Problem
+
+On the Scheduling page, the Labor Cost card total is inconsistent with the Top Earners list underneath it. For a week with two scheduled shifts (Jose 7h @ $10 = $70, Alejandra 6h @ $10 = $60) the card displays `$70 (7h)` while Top Earners correctly lists both employees totalling $130.
+
+## Root Cause
+
+`resolveCompensationForDate` (`src/utils/compensationCalculations.ts:72`) picks the most recent `employee_compensation_history` entry with `effective_date <= targetDate` **regardless of the entry's `compensation_type`**. When an employee's history contains a stale entry from a prior comp-type era — e.g. a `salary` entry left over from before the switch to hourly — the resolver returns `compensation_type = 'salary'` for a shift dated after that stale entry.
+
+In `calculateScheduledLaborCost` (`src/services/laborCalculations.ts:400`), the branch selection is driven by the snapshot's `compensation_type`. A salary-typed snapshot skips the hourly branch, falls through the salary branch (zero because `pay_period_type` on the current row is unset), and the shift contributes **neither cost nor hours** to the aggregate. Meanwhile `useEmployeeLaborCosts` reads `emp.compensation_type` directly from the current row, so Top Earners stays correct.
+
+### Evidence (production data)
+
+Alejandra's `employee_compensation_history` for her current record:
+| effective_date | hist_comp_type | amount_cents |
+|----------------|----------------|--------------|
+| 2026-03-01     | hourly         | 3000         |
+| 2026-03-15     | hourly         | 1500         |
+| 2026-04-01     | hourly         | 1000         |
+| 2026-04-11     | **salary**     | 60000        |
+
+Current `employees.compensation_type = 'hourly'`, `hourly_rate = 1000`.
+
+For her shift on **2026-04-13**, the resolver returns the 2026-04-11 salary entry, and the shift is dropped from the aggregate.
+
+## Fix
+
+In `resolveCompensationForDate`, prefer history entries whose `compensation_type` matches the employee's current `compensation_type`. Only fall back to a mismatched entry if no matching entry exists for the date.
+
+```ts
+const matching = history.find(
+  h => h.effective_date <= dateStr && h.compensation_type === employee.compensation_type
+);
+const entry = matching ?? history.find(h => h.effective_date <= dateStr);
+```
+
+### Why this shape
+
+- **Targeted:** a single narrow change to the resolver fixes every downstream caller (`calculateScheduledLaborCost`, `calculateEmployeePeriodCost`, `calculateEmployeeDailyCostForDate`, `getEmployeeSnapshotForDate`).
+- **Respects historical rate changes** within the same comp type — Alejandra's 2026-03-15 $15 → 2026-04-01 $10 transition still resolves correctly by date.
+- **Respects legitimate comp-type transitions** — if no entry of the current type exists yet for the date, the fallback still returns the older-type entry, preserving historical-reality payroll math for past periods.
+- **Aligns with `useEmployeeLaborCosts`** which already treats the employee's current `compensation_type` as the source of truth.
+
+## Out of Scope
+
+- The `employee.status !== 'active'` guard in `calculateScheduledLaborCost:385` is inconsistent with `useEmployeeLaborCosts` and the hook's own "count inactive employees" comment, but it does not cause this bug (Alejandra is active). Separate PR.
+- Data hygiene: cleaning up the stale 2026-04-11 `salary` history entries on Jose's and Alejandra's records. Separate task.
+
+## Testing
+
+1. Unit test for `resolveCompensationForDate`: history containing a stale entry of a different `compensation_type` is skipped in favor of the most-recent matching-type entry.
+2. Unit test for `resolveCompensationForDate`: fallback path — when no matching-type entry exists for the date, mismatched entry is returned (legitimate historical comp-type transition).
+3. Integration test for `calculateScheduledLaborCost`: exactly reproduces the Alejandra bug — hourly employee with a stale salary entry before the shift date is still counted in the aggregate.
+
+All three tests must fail before the fix and pass after.
+
+## Risks
+
+- **Legitimate salary→hourly transition with past shifts**: unchanged behavior — when no matching-type entry exists yet, we fall back to the older entry. Covered by Test 2.
+- **Multiple comp-type switches**: covered by the `find` semantics — the resolver walks DESC-sorted history and picks the first match of the current type, which is always the most recent.

--- a/src/utils/compensationCalculations.ts
+++ b/src/utils/compensationCalculations.ts
@@ -75,13 +75,12 @@ export function resolveCompensationForDate(
 ): CompensationSnapshot {
   const dateStr = normalizeDateString(targetDate);
   const history = getSortedHistory(employee);
-  // Prefer the most recent entry whose compensation_type matches the employee's
-  // current compensation_type; fall back to any most-recent entry so legitimate
-  // historical comp-type transitions (e.g. salary→hourly) still resolve correctly.
-  const matchingEntry = history.find(
-    h => h.effective_date <= dateStr && h.compensation_type === employee.compensation_type
-  );
-  const entry = matchingEntry ?? history.find(h => h.effective_date <= dateStr);
+  // Prefer the most recent entry whose type matches the employee's current
+  // compensation_type. Fall back to any dated entry so historical type
+  // transitions (e.g. salary→hourly) still resolve correctly for past dates.
+  const entry =
+    history.find(h => h.effective_date <= dateStr && h.compensation_type === employee.compensation_type) ??
+    history.find(h => h.effective_date <= dateStr);
 
   const snapshot: CompensationSnapshot = {
     compensation_type: entry?.compensation_type || employee.compensation_type,

--- a/src/utils/compensationCalculations.ts
+++ b/src/utils/compensationCalculations.ts
@@ -75,12 +75,19 @@ export function resolveCompensationForDate(
 ): CompensationSnapshot {
   const dateStr = normalizeDateString(targetDate);
   const history = getSortedHistory(employee);
-  // Prefer the most recent entry whose type matches the employee's current
-  // compensation_type. Fall back to any dated entry so historical type
-  // transitions (e.g. salary→hourly) still resolve correctly for past dates.
-  const entry =
-    history.find(h => h.effective_date <= dateStr && h.compensation_type === employee.compensation_type) ??
-    history.find(h => h.effective_date <= dateStr);
+  // History is trustworthy when its most recent entry agrees with the
+  // employee's current compensation_type (pure chronology preserves past
+  // type transitions). When they disagree, the tail of history contains
+  // stale entries of the prior type; filter to matching-type entries to
+  // skip past them.
+  const latest = history[0];
+  const isStaleTail =
+    !!latest && latest.compensation_type !== employee.compensation_type;
+  const entry = isStaleTail
+    ? history.find(
+        h => h.effective_date <= dateStr && h.compensation_type === employee.compensation_type
+      ) ?? history.find(h => h.effective_date <= dateStr)
+    : history.find(h => h.effective_date <= dateStr);
 
   const snapshot: CompensationSnapshot = {
     compensation_type: entry?.compensation_type || employee.compensation_type,

--- a/src/utils/compensationCalculations.ts
+++ b/src/utils/compensationCalculations.ts
@@ -75,7 +75,13 @@ export function resolveCompensationForDate(
 ): CompensationSnapshot {
   const dateStr = normalizeDateString(targetDate);
   const history = getSortedHistory(employee);
-  const entry = history.find(h => h.effective_date <= dateStr);
+  // Prefer the most recent entry whose compensation_type matches the employee's
+  // current compensation_type; fall back to any most-recent entry so legitimate
+  // historical comp-type transitions (e.g. salary→hourly) still resolve correctly.
+  const matchingEntry = history.find(
+    h => h.effective_date <= dateStr && h.compensation_type === employee.compensation_type
+  );
+  const entry = matchingEntry ?? history.find(h => h.effective_date <= dateStr);
 
   const snapshot: CompensationSnapshot = {
     compensation_type: entry?.compensation_type || employee.compensation_type,

--- a/tests/unit/compensation-edge-cases.test.ts
+++ b/tests/unit/compensation-edge-cases.test.ts
@@ -1370,6 +1370,58 @@ describe('Validation Edge Cases', () => {
       expect(snapshot.salary_amount).toBe(200000);
       expect(snapshot.pay_period_type).toBe('bi-weekly');
     });
+
+    it('resolves by chronology for employees with multiple comp-type transitions when the latest history entry matches the current type', () => {
+      // salary → hourly → salary, target date lands inside the middle (hourly)
+      // era. The latest history entry (salary, 2026-04-01) matches the current
+      // compensation_type (salary), so the history is internally consistent and
+      // the resolver must use pure chronology — not filter to the current type.
+      // A naive "prefer current-type" shortcut would incorrectly return the
+      // 2026-01-01 salary entry instead of the 2026-02-01 hourly entry.
+      const employee = createEmployee({
+        compensation_type: 'salary',
+        salary_amount: 300000,
+        pay_period_type: 'monthly',
+        hourly_rate: 0,
+        compensation_history: [
+          {
+            id: 's-initial',
+            employee_id: 'emp-test',
+            restaurant_id: 'rest-test',
+            compensation_type: 'salary',
+            amount_cents: 200000,
+            pay_period_type: 'monthly',
+            effective_date: '2026-01-01',
+            created_at: '2026-01-01T00:00:00Z',
+          },
+          {
+            id: 'h-mid',
+            employee_id: 'emp-test',
+            restaurant_id: 'rest-test',
+            compensation_type: 'hourly',
+            amount_cents: 2500,
+            pay_period_type: null,
+            effective_date: '2026-02-01',
+            created_at: '2026-02-01T00:00:00Z',
+          },
+          {
+            id: 's-current',
+            employee_id: 'emp-test',
+            restaurant_id: 'rest-test',
+            compensation_type: 'salary',
+            amount_cents: 300000,
+            pay_period_type: 'monthly',
+            effective_date: '2026-04-01',
+            created_at: '2026-04-01T00:00:00Z',
+          },
+        ],
+      });
+
+      const snapshot = resolveCompensationForDate(employee, '2026-02-15');
+
+      expect(snapshot.compensation_type).toBe('hourly');
+      expect(snapshot.hourly_rate).toBe(2500);
+    });
   });
 });
 

--- a/tests/unit/compensation-edge-cases.test.ts
+++ b/tests/unit/compensation-edge-cases.test.ts
@@ -1275,6 +1275,101 @@ describe('Validation Edge Cases', () => {
 
       expect(total).toBe(200000);
     });
+
+    it('skips a stale history entry of a different compensation_type and uses the most recent matching-type entry', () => {
+      // Reproduces the Alejandra bug: current comp_type is 'hourly' but a stale
+      // 'salary' entry sits between the shift date and the most recent hourly entry.
+      const employee = createEmployee({
+        compensation_type: 'hourly',
+        hourly_rate: 1000,
+        compensation_history: [
+          {
+            id: 'h1',
+            employee_id: 'emp-test',
+            restaurant_id: 'rest-test',
+            compensation_type: 'hourly',
+            amount_cents: 3000,
+            pay_period_type: null,
+            effective_date: '2026-03-01',
+            created_at: '2026-03-01T00:00:00Z',
+          },
+          {
+            id: 'h2',
+            employee_id: 'emp-test',
+            restaurant_id: 'rest-test',
+            compensation_type: 'hourly',
+            amount_cents: 1500,
+            pay_period_type: null,
+            effective_date: '2026-03-15',
+            created_at: '2026-03-15T00:00:00Z',
+          },
+          {
+            id: 'h3',
+            employee_id: 'emp-test',
+            restaurant_id: 'rest-test',
+            compensation_type: 'hourly',
+            amount_cents: 1000,
+            pay_period_type: null,
+            effective_date: '2026-04-01',
+            created_at: '2026-04-01T00:00:00Z',
+          },
+          {
+            id: 'h4-stale',
+            employee_id: 'emp-test',
+            restaurant_id: 'rest-test',
+            compensation_type: 'salary',
+            amount_cents: 60000,
+            pay_period_type: null,
+            effective_date: '2026-04-11',
+            created_at: '2026-04-11T00:00:00Z',
+          },
+        ],
+      });
+
+      const snapshot = resolveCompensationForDate(employee, '2026-04-13');
+
+      expect(snapshot.compensation_type).toBe('hourly');
+      expect(snapshot.hourly_rate).toBe(1000);
+    });
+
+    it('falls back to a mismatched-type entry when no matching-type entry exists on or before the date (legitimate comp-type transition)', () => {
+      // Employee started on salary in Jan, switched to hourly in April. A Feb shift
+      // still correctly resolves to the salary rate in effect at that time.
+      const employee = createEmployee({
+        compensation_type: 'hourly',
+        hourly_rate: 1500,
+        salary_amount: 200000,
+        pay_period_type: 'bi-weekly',
+        compensation_history: [
+          {
+            id: 's1',
+            employee_id: 'emp-test',
+            restaurant_id: 'rest-test',
+            compensation_type: 'salary',
+            amount_cents: 200000,
+            pay_period_type: 'bi-weekly',
+            effective_date: '2026-01-01',
+            created_at: '2026-01-01T00:00:00Z',
+          },
+          {
+            id: 'h1',
+            employee_id: 'emp-test',
+            restaurant_id: 'rest-test',
+            compensation_type: 'hourly',
+            amount_cents: 1500,
+            pay_period_type: null,
+            effective_date: '2026-04-01',
+            created_at: '2026-04-01T00:00:00Z',
+          },
+        ],
+      });
+
+      const snapshot = resolveCompensationForDate(employee, '2026-02-15');
+
+      expect(snapshot.compensation_type).toBe('salary');
+      expect(snapshot.salary_amount).toBe(200000);
+      expect(snapshot.pay_period_type).toBe('bi-weekly');
+    });
   });
 });
 

--- a/tests/unit/useScheduledLaborCosts.test.ts
+++ b/tests/unit/useScheduledLaborCosts.test.ts
@@ -385,6 +385,74 @@ describe('useScheduledLaborCosts', () => {
       expect(result.current.breakdown.hourly.cost).toBeCloseTo(120, 2);
     });
 
+    it('counts shifts for hourly employees whose history has a stale salary entry', () => {
+      // Regression guard for the Alejandra Scheduling Labor Cost bug: an hourly
+      // employee has a stale salary entry in compensation_history dated between
+      // the most recent hourly entry and the shift date. Without the resolver
+      // fix, resolveCompensationForDate returned the salary entry and
+      // calculateScheduledLaborCost dropped the shift entirely.
+      const mockEmployees = [
+        {
+          id: 'emp-hourly-with-stale-salary',
+          first_name: 'Alejandra',
+          last_name: 'Perez',
+          compensation_type: 'hourly' as const,
+          hourly_rate: 1000, // $10.00/hr in cents
+          status: 'active' as const,
+          compensation_history: [
+            {
+              id: 'h1',
+              employee_id: 'emp-hourly-with-stale-salary',
+              restaurant_id: mockRestaurantId,
+              compensation_type: 'hourly' as const,
+              amount_cents: 1000,
+              pay_period_type: null,
+              effective_date: '2026-04-01',
+              created_at: '2026-04-01T00:00:00Z',
+            },
+            {
+              id: 'h2-stale',
+              employee_id: 'emp-hourly-with-stale-salary',
+              restaurant_id: mockRestaurantId,
+              compensation_type: 'salary' as const,
+              amount_cents: 60000,
+              pay_period_type: null,
+              effective_date: '2026-04-11',
+              created_at: '2026-04-11T00:00:00Z',
+            },
+          ],
+        },
+      ];
+
+      const aprDateFrom = new Date('2026-04-13T00:00:00Z');
+      const aprDateTo = new Date('2026-04-19T23:59:59Z');
+
+      const mockShifts: Shift[] = [
+        {
+          id: 'shift-stale-salary-regression',
+          employee_id: 'emp-hourly-with-stale-salary',
+          start_time: '2026-04-13T15:00:00Z',
+          end_time: '2026-04-13T21:30:00Z', // 6.5 gross hours
+          break_duration: 30, // 30 min break → 6.0 net hours
+          status: 'scheduled',
+        } as Shift,
+      ];
+
+      vi.mocked(useEmployees).mockReturnValue({
+        employees: mockEmployees,
+        loading: false,
+      } as any);
+
+      const { result } = renderHook(() =>
+        useScheduledLaborCosts(mockShifts, aprDateFrom, aprDateTo, mockRestaurantId)
+      );
+
+      // 6 hours × $10/hr = $60 — not $0 (which was the bug).
+      expect(result.current.breakdown.hourly.hours).toBeCloseTo(6, 2);
+      expect(result.current.breakdown.hourly.cost).toBeCloseTo(60, 2);
+      expect(result.current.totalCost).toBeCloseTo(60, 2);
+    });
+
     it('handles shifts without matching employee', () => {
       const mockEmployees = [
         {


### PR DESCRIPTION
## Summary
- Prefer the most recent `employee_compensation_history` entry whose `compensation_type` matches the employee's current `compensation_type` when resolving a snapshot for a date, falling back to the prior behavior only when no matching-type entry exists.
- Fixes the Scheduling page Labor Cost aggregate silently dropping shifts whose employees have a stale entry from a prior comp-type era (e.g. a leftover `salary` row after a switch to `hourly`).

## Why
`resolveCompensationForDate` was returning the most recent entry by `effective_date` regardless of `compensation_type`. `calculateScheduledLaborCost` dispatches on the snapshot's `compensation_type`, so a salary-typed snapshot with no `pay_period_type` set on the row fell through the switch and contributed neither cost nor hours. Meanwhile `useEmployeeLaborCosts` reads `employee.compensation_type` directly, so the Top Earners list stayed correct — producing the "$70 card / $130 Top Earners" mismatch reported for the Apr 13–19, 2026 week.

Spec: `docs/superpowers/specs/2026-04-17-labor-cost-stale-comp-history-design.md`
Plan: `docs/superpowers/plans/2026-04-17-labor-cost-stale-comp-history-plan.md`

## Test plan
- [x] Unit test reproducing the Alejandra data pattern (stale `salary` entry 2026-04-11 after hourly entries 2026-03-01 / 2026-03-15 / 2026-04-01, shift on 2026-04-13) fails before the fix and passes after.
- [x] Unit test for the fallback path: employee with only a January `salary` entry and an April `hourly` entry still resolves a February shift to the salary snapshot.
- [x] Integration test on `useScheduledLaborCosts`: hourly employee with a stale salary history row contributes the expected hours and cost (6h × \$10 = \$60) to the breakdown rather than 0.
- [x] `npm run test` (3479 passed, 1 skipped)
- [x] `npm run build` (success)
- [x] `npm run typecheck` / `npm run lint` clean on touched files (pre-existing baseline noise elsewhere)
- [ ] Manual QA on Scheduling page: Apr 13–19, 2026 week should now show Labor Cost = \$130 (13h) matching Top Earners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed labor cost report calculations that were incorrectly excluding shifts when employee compensation history contained outdated entries from previous compensation periods.

* **Documentation**
  * Added design specifications and implementation roadmaps for employee employment type classification (full-time/part-time), date of birth tracking with automatic minor status indicators, and shift template assignment improvements.

* **Tests**
  * Enhanced test coverage for compensation history scenarios and labor cost aggregation calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->