### PR TITLE
feat: invitation UX redesign — resend, history collapse, expired-link page

### DIFF
--- a/docs/superpowers/plans/2026-04-13-employee-ft-pt-dob-plan.md
+++ b/docs/superpowers/plans/2026-04-13-employee-ft-pt-dob-plan.md
@@ -1,0 +1,928 @@
+# Employee FT/PT & DOB Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add employment type (full-time/part-time) and date of birth fields to employees, with scheduler filtering, AI prompt integration, and minor badge display.
+
+**Architecture:** Two new columns on the `employees` table. A pure utility for age/minor calculation. UI updates to EmployeeDialog (FT/PT toggle + DOB input), EmployeeList (badges), EmployeeSidebar (FT/PT filter + minor badge). AI prompt builder gets a new rule for FT/PT hour targeting.
+
+**Tech Stack:** PostgreSQL (migration), React, TypeScript, Vitest, pgTAP, Playwright
+
+---
+
+### Task 1: Database Migration
+
+**Files:**
+- Create: `supabase/migrations/20260413100000_add_employee_employment_type_dob.sql`
+- Test: `supabase/tests/employee_employment_type_dob.sql`
+
+- [ ] **Step 1: Write the pgTAP test file**
+
+```sql
+-- supabase/tests/employee_employment_type_dob.sql
+BEGIN;
+SELECT plan(7);
+
+-- Test 1: employment_type column exists with default
+SELECT has_column('public', 'employees', 'employment_type',
+  'employees table should have employment_type column');
+
+-- Test 2: date_of_birth column exists
+SELECT has_column('public', 'employees', 'date_of_birth',
+  'employees table should have date_of_birth column');
+
+-- Test 3: employment_type defaults to full_time
+INSERT INTO employees (id, restaurant_id, name, position, hourly_rate, compensation_type)
+VALUES (
+  'aaaaaaaa-0000-0000-0000-000000000001',
+  (SELECT id FROM restaurants LIMIT 1),
+  'Test Default FT',
+  'Server',
+  1500,
+  'hourly'
+);
+SELECT is(
+  (SELECT employment_type FROM employees WHERE id = 'aaaaaaaa-0000-0000-0000-000000000001'),
+  'full_time',
+  'employment_type should default to full_time'
+);
+
+-- Test 4: Can set employment_type to part_time
+UPDATE employees SET employment_type = 'part_time'
+WHERE id = 'aaaaaaaa-0000-0000-0000-000000000001';
+SELECT is(
+  (SELECT employment_type FROM employees WHERE id = 'aaaaaaaa-0000-0000-0000-000000000001'),
+  'part_time',
+  'employment_type should accept part_time'
+);
+
+-- Test 5: CHECK constraint rejects invalid values
+SELECT throws_ok(
+  $$UPDATE employees SET employment_type = 'contractor'
+    WHERE id = 'aaaaaaaa-0000-0000-0000-000000000001'$$,
+  '23514',
+  NULL,
+  'employment_type should reject invalid values'
+);
+
+-- Test 6: date_of_birth accepts valid date
+UPDATE employees SET date_of_birth = '2008-06-15'
+WHERE id = 'aaaaaaaa-0000-0000-0000-000000000001';
+SELECT is(
+  (SELECT date_of_birth FROM employees WHERE id = 'aaaaaaaa-0000-0000-0000-000000000001'),
+  '2008-06-15'::DATE,
+  'date_of_birth should accept valid date'
+);
+
+-- Test 7: date_of_birth accepts NULL
+UPDATE employees SET date_of_birth = NULL
+WHERE id = 'aaaaaaaa-0000-0000-0000-000000000001';
+SELECT is(
+  (SELECT date_of_birth FROM employees WHERE id = 'aaaaaaaa-0000-0000-0000-000000000001'),
+  NULL::DATE,
+  'date_of_birth should accept NULL'
+);
+
+-- Cleanup
+DELETE FROM employees WHERE id = 'aaaaaaaa-0000-0000-0000-000000000001';
+
+SELECT * FROM finish();
+ROLLBACK;
+```
+
+- [ ] **Step 2: Run pgTAP tests to verify they fail**
+
+Run: `npm run test:db`
+Expected: FAIL — columns don't exist yet.
+
+- [ ] **Step 3: Write the migration**
+
+```sql
+-- supabase/migrations/20260413100000_add_employee_employment_type_dob.sql
+
+-- Add employment type (full-time or part-time) for scheduling
+ALTER TABLE employees
+  ADD COLUMN employment_type TEXT NOT NULL DEFAULT 'full_time'
+  CHECK (employment_type IN ('full_time', 'part_time'));
+
+-- Add optional date of birth for minor detection
+ALTER TABLE employees
+  ADD COLUMN date_of_birth DATE;
+
+-- Comment for documentation
+COMMENT ON COLUMN employees.employment_type IS 'full_time or part_time — used by scheduler for weekly hour targeting';
+COMMENT ON COLUMN employees.date_of_birth IS 'Optional DOB for minor detection (age < 18)';
+```
+
+- [ ] **Step 4: Reset database and run pgTAP tests**
+
+Run: `npm run db:reset && npm run test:db`
+Expected: All 7 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/migrations/20260413100000_add_employee_employment_type_dob.sql supabase/tests/employee_employment_type_dob.sql
+git commit -m "feat: add employment_type and date_of_birth columns to employees"
+```
+
+---
+
+### Task 2: TypeScript Types & Utility Functions
+
+**Files:**
+- Modify: `src/types/scheduling.ts:1-5` (add type alias) and `src/types/scheduling.ts:18-72` (add fields to Employee interface)
+- Create: `src/lib/employeeUtils.ts`
+- Create: `tests/unit/employeeUtils.test.ts`
+
+- [ ] **Step 1: Write the unit tests for age/minor utilities**
+
+```typescript
+// tests/unit/employeeUtils.test.ts
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { computeAge, isMinor } from '@/lib/employeeUtils';
+
+describe('computeAge', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('computes age for a past birthday this year', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-15'));
+    expect(computeAge('1990-03-10')).toBe(36);
+  });
+
+  it('computes age when birthday has not yet occurred this year', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-02-01'));
+    expect(computeAge('1990-03-10')).toBe(35);
+  });
+
+  it('computes age on the exact birthday', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-10'));
+    expect(computeAge('1990-03-10')).toBe(36);
+  });
+
+  it('handles leap year birthday (Feb 29)', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-01'));
+    expect(computeAge('2008-02-29')).toBe(17);
+  });
+});
+
+describe('isMinor', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns true for age under 18', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-13'));
+    expect(isMinor('2010-06-15')).toBe(true);
+  });
+
+  it('returns false for exactly 18', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-13'));
+    expect(isMinor('2008-04-13')).toBe(false);
+  });
+
+  it('returns false for over 18', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-13'));
+    expect(isMinor('1990-01-01')).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isMinor(null)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isMinor(undefined)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run tests/unit/employeeUtils.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Create the utility file**
+
+```typescript
+// src/lib/employeeUtils.ts
+
+/**
+ * Compute age in whole years from a date-of-birth string (YYYY-MM-DD).
+ */
+export function computeAge(dateOfBirth: string): number {
+  const today = new Date();
+  const dob = new Date(dateOfBirth);
+  let age = today.getFullYear() - dob.getFullYear();
+  const monthDiff = today.getMonth() - dob.getMonth();
+  if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < dob.getDate())) {
+    age--;
+  }
+  return age;
+}
+
+/**
+ * Returns true if the employee is under 18 based on their DOB.
+ */
+export function isMinor(dateOfBirth: string | null | undefined): boolean {
+  if (!dateOfBirth) return false;
+  return computeAge(dateOfBirth) < 18;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx vitest run tests/unit/employeeUtils.test.ts`
+Expected: All 9 tests PASS.
+
+- [ ] **Step 5: Update TypeScript types**
+
+In `src/types/scheduling.ts`, add the type alias after line 5 (after `DeactivationReason`):
+
+```typescript
+export type EmploymentType = 'full_time' | 'part_time';
+```
+
+In the `Employee` interface, add these two fields after `is_exempt` (after line 68):
+
+```typescript
+  // Employment classification
+  employment_type: EmploymentType;
+  date_of_birth?: string; // YYYY-MM-DD, optional
+```
+
+- [ ] **Step 6: Run typecheck**
+
+Run: `npm run typecheck`
+Expected: No new errors (existing fields are optional in form code, and the hook returns `*` which includes the new columns).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/employeeUtils.ts tests/unit/employeeUtils.test.ts src/types/scheduling.ts
+git commit -m "feat: add EmploymentType, date_of_birth types and age utility"
+```
+
+---
+
+### Task 3: Employee Dialog — FT/PT Toggle & DOB Input
+
+**Files:**
+- Modify: `src/components/EmployeeDialog.tsx`
+
+- [ ] **Step 1: Add state variables**
+
+After the existing `const [area, setArea] = useState('');` (line 48), add:
+
+```typescript
+  const [employmentType, setEmploymentType] = useState<'full_time' | 'part_time'>('full_time');
+  const [dateOfBirth, setDateOfBirth] = useState('');
+```
+
+- [ ] **Step 2: Add to employee loading (useEffect)**
+
+In the `if (employee)` block (around line 120), after `setArea(employee.area || '');` (line 126), add:
+
+```typescript
+      setEmploymentType(employee.employment_type || 'full_time');
+      setDateOfBirth(employee.date_of_birth || '');
+```
+
+- [ ] **Step 3: Add to resetForm()**
+
+In `resetForm()` (around line 152), after `setArea('');` (line 157), add:
+
+```typescript
+    setEmploymentType('full_time');
+    setDateOfBirth('');
+```
+
+- [ ] **Step 4: Add to employeeData payload**
+
+In the `employeeData` object inside `proceedWithSubmit()` (around line 400), after `area: area.trim() || null,` (line 406), add:
+
+```typescript
+      employment_type: employmentType,
+      date_of_birth: dateOfBirth || null,
+```
+
+- [ ] **Step 5: Add FT/PT segmented toggle to the form**
+
+After the Area field's closing `</div>` (after line 556, which is the area `space-y-2` div), add:
+
+```tsx
+              {/* Employment Type Toggle */}
+              <div className="space-y-2">
+                <Label className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
+                  Employment Type
+                </Label>
+                <div className="flex rounded-lg border border-border/40 overflow-hidden w-fit">
+                  <button
+                    type="button"
+                    onClick={() => setEmploymentType('full_time')}
+                    className={cn(
+                      'px-4 py-2 text-[13px] font-medium transition-colors',
+                      employmentType === 'full_time'
+                        ? 'bg-foreground text-background'
+                        : 'bg-background text-muted-foreground hover:text-foreground'
+                    )}
+                    aria-label="Full-time employment"
+                    aria-pressed={employmentType === 'full_time'}
+                  >
+                    Full-Time
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setEmploymentType('part_time')}
+                    className={cn(
+                      'px-4 py-2 text-[13px] font-medium transition-colors border-l border-border/40',
+                      employmentType === 'part_time'
+                        ? 'bg-foreground text-background'
+                        : 'bg-background text-muted-foreground hover:text-foreground'
+                    )}
+                    aria-label="Part-time employment"
+                    aria-pressed={employmentType === 'part_time'}
+                  >
+                    Part-Time
+                  </button>
+                </div>
+                <p className="text-[12px] text-muted-foreground">
+                  Used by the scheduler to plan weekly hours
+                </p>
+              </div>
+```
+
+Note: Import `cn` is already imported at the top of the file. Verify by checking for `import { cn }` — if not present, add: `import { cn } from '@/lib/utils';`
+
+- [ ] **Step 6: Add DOB input to the Status/Hire Date row**
+
+Find the grid with Status and Hire Date (around line 897):
+
+```tsx
+              <div className="grid grid-cols-2 gap-4">
+```
+
+Change it to a 3-column grid and add the DOB field:
+
+```tsx
+              <div className="grid grid-cols-3 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="status">Status</Label>
+                  <Select value={status} onValueChange={(value) => setStatus(value as typeof status)}>
+                    <SelectTrigger id="status" aria-label="Employee status">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="active">Active</SelectItem>
+                      <SelectItem value="inactive">Inactive</SelectItem>
+                      <SelectItem value="terminated">Terminated</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="hireDate">Hire Date</Label>
+                  <Input
+                    id="hireDate"
+                    type="date"
+                    value={hireDate}
+                    onChange={(e) => setHireDate(e.target.value)}
+                    aria-label="Hire date"
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="dateOfBirth">Date of Birth</Label>
+                  <Input
+                    id="dateOfBirth"
+                    type="date"
+                    value={dateOfBirth}
+                    onChange={(e) => setDateOfBirth(e.target.value)}
+                    aria-label="Date of birth"
+                  />
+                  {dateOfBirth && isMinor(dateOfBirth) && (
+                    <span className="text-[11px] px-1.5 py-0.5 rounded-md bg-amber-500/10 text-amber-600 font-medium inline-block">
+                      Minor ({computeAge(dateOfBirth)} yrs)
+                    </span>
+                  )}
+                </div>
+              </div>
+```
+
+Add the import at the top of the file:
+
+```typescript
+import { computeAge, isMinor } from '@/lib/employeeUtils';
+```
+
+- [ ] **Step 7: Verify the dialog renders correctly**
+
+Run: `npm run dev`
+Open the app, navigate to Employees, click "Add Employee". Verify:
+- FT/PT toggle appears between Area and Compensation Type
+- DOB field appears in the Status/Hire Date row
+- Entering a minor's DOB shows the amber badge
+- Toggling FT/PT works
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/EmployeeDialog.tsx
+git commit -m "feat: add FT/PT toggle and DOB input to employee dialog"
+```
+
+---
+
+### Task 4: Employee List — Badges
+
+**Files:**
+- Modify: `src/components/EmployeeList.tsx:288-291` (employee info section)
+
+- [ ] **Step 1: Add import**
+
+At the top of `EmployeeList.tsx`, add:
+
+```typescript
+import { isMinor } from '@/lib/employeeUtils';
+```
+
+- [ ] **Step 2: Add FT/PT and Minor badges to employee card**
+
+In `EmployeeCard`, find the position/compensation line (around line 288-291):
+
+```tsx
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <span className="truncate">{employee.position}</span>
+              <span>•</span>
+              <span className="shrink-0">{getCompensationDisplay()}</span>
+            </div>
+```
+
+Replace with:
+
+```tsx
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <span className="truncate">{employee.position}</span>
+              <span className="text-[11px] px-1.5 py-0.5 rounded-md bg-muted shrink-0">
+                {employee.employment_type === 'part_time' ? 'PT' : 'FT'}
+              </span>
+              {isMinor(employee.date_of_birth) && (
+                <span className="text-[11px] px-1.5 py-0.5 rounded-md bg-amber-500/10 text-amber-600 font-medium shrink-0">
+                  Minor
+                </span>
+              )}
+              <span>•</span>
+              <span className="shrink-0">{getCompensationDisplay()}</span>
+            </div>
+```
+
+- [ ] **Step 3: Verify the badges render**
+
+Run: `npm run dev`
+Open the app, navigate to Employees. Check that FT/PT badges appear. If you have a test employee with a minor DOB, verify the amber "Minor" badge shows.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/EmployeeList.tsx
+git commit -m "feat: add FT/PT and Minor badges to employee list"
+```
+
+---
+
+### Task 5: Shift Planner Sidebar — Filter & Badge
+
+**Files:**
+- Modify: `src/components/scheduling/ShiftPlanner/EmployeeSidebar.tsx`
+- Create: `tests/unit/employeeSidebarFilter.test.ts`
+
+- [ ] **Step 1: Write the filter test**
+
+```typescript
+// tests/unit/employeeSidebarFilter.test.ts
+import { describe, it, expect } from 'vitest';
+import { filterEmployees } from '@/components/scheduling/ShiftPlanner/EmployeeSidebar';
+
+describe('filterEmployees with employment type', () => {
+  const employees = [
+    { id: '1', name: 'Alice', position: 'Server', area: 'FOH', employment_type: 'full_time' as const },
+    { id: '2', name: 'Bob', position: 'Cook', area: 'BOH', employment_type: 'part_time' as const },
+    { id: '3', name: 'Carol', position: 'Server', area: 'FOH', employment_type: 'part_time' as const },
+  ];
+
+  it('returns all when employmentType is "all"', () => {
+    const result = filterEmployees(employees, '', 'all', 'all', 'all');
+    expect(result).toHaveLength(3);
+  });
+
+  it('filters to full_time only', () => {
+    const result = filterEmployees(employees, '', 'all', 'all', 'full_time');
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('Alice');
+  });
+
+  it('filters to part_time only', () => {
+    const result = filterEmployees(employees, '', 'all', 'all', 'part_time');
+    expect(result).toHaveLength(2);
+    expect(result.map((e) => e.name)).toEqual(['Bob', 'Carol']);
+  });
+
+  it('combines employment type with role filter', () => {
+    const result = filterEmployees(employees, '', 'all', 'Server', 'part_time');
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('Carol');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/unit/employeeSidebarFilter.test.ts`
+Expected: FAIL — `filterEmployees` signature doesn't accept 5th arg.
+
+- [ ] **Step 3: Update the Employee interface and filterEmployees function**
+
+In `EmployeeSidebar.tsx`, update the local `Employee` interface (around line 22):
+
+```typescript
+interface Employee {
+  id: string;
+  name: string;
+  position: string | null;
+  area?: string;
+  employment_type?: 'full_time' | 'part_time';
+  date_of_birth?: string;
+}
+```
+
+Update the `filterEmployees` function (around line 28):
+
+```typescript
+export function filterEmployees(
+  employees: Employee[],
+  search: string,
+  area: string,
+  role: string,
+  employmentType: string = 'all',
+): Employee[] {
+  const q = search.toLowerCase();
+  return employees.filter((e) => {
+    if (q && !e.name.toLowerCase().includes(q)) return false;
+    if (area !== 'all' && e.area !== area) return false;
+    if (role !== 'all' && e.position !== role) return false;
+    if (employmentType !== 'all' && e.employment_type !== employmentType) return false;
+    return true;
+  });
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/unit/employeeSidebarFilter.test.ts`
+Expected: All 4 tests PASS.
+
+- [ ] **Step 5: Add employment type filter dropdown and minor badge to the sidebar**
+
+Add the import at the top:
+
+```typescript
+import { isMinor } from '@/lib/employeeUtils';
+```
+
+Add state for employment type filter. After `const [role, setRole] = useState('all');` (line 140):
+
+```typescript
+  const [empType, setEmpType] = useState('all');
+```
+
+Update the `filtered` useMemo to pass the new filter. Find the existing call (around line 195):
+
+```typescript
+  const filtered = useMemo(
+    () => filterEmployees(employees, search, effectiveArea, role, empType),
+    [employees, search, effectiveArea, role, empType],
+  );
+```
+
+Add the filter dropdown in the sticky header, after the role filter's closing `)}` (after line 257):
+
+```tsx
+        <Select value={empType} onValueChange={setEmpType}>
+          <SelectTrigger
+            className="h-8 text-[13px] bg-muted/30 border-border/40 rounded-lg"
+            aria-label="Filter by employment type"
+          >
+            <SelectValue placeholder="All types" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All types</SelectItem>
+            <SelectItem value="full_time">Full-Time</SelectItem>
+            <SelectItem value="part_time">Part-Time</SelectItem>
+          </SelectContent>
+        </Select>
+```
+
+Add minor badge to `DraggableEmployee`. After the position text (around line 118):
+
+```tsx
+        {employee.position && (
+          <div className="flex items-center gap-1">
+            <p className="text-[11px] text-muted-foreground truncate">
+              {employee.position}
+            </p>
+            {isMinor(employee.date_of_birth) && (
+              <span className="text-[10px] px-1 py-0.5 rounded bg-amber-500/10 text-amber-600 font-medium shrink-0">
+                Minor
+              </span>
+            )}
+          </div>
+        )}
+```
+
+This replaces the existing position paragraph (lines 116-119):
+
+```tsx
+        {employee.position && (
+          <p className="text-[11px] text-muted-foreground truncate">
+            {employee.position}
+          </p>
+        )}
+```
+
+Update the `DraggableEmployee` memo comparison (around line 125) to include the new fields:
+
+```typescript
+  (prev, next) =>
+    prev.employee.id === next.employee.id &&
+    prev.employee.name === next.employee.name &&
+    prev.employee.position === next.employee.position &&
+    prev.employee.date_of_birth === next.employee.date_of_birth &&
+    prev.shiftCount === next.shiftCount &&
+    prev.hours === next.hours &&
+    prev.onSelect === next.onSelect,
+```
+
+- [ ] **Step 6: Verify in the browser**
+
+Run: `npm run dev`
+Navigate to Scheduling > Shift Planner. Verify:
+- Employment type filter dropdown appears in the sidebar
+- Filtering by FT/PT works
+- Minor badge appears on employees with minor DOB
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/scheduling/ShiftPlanner/EmployeeSidebar.tsx tests/unit/employeeSidebarFilter.test.ts
+git commit -m "feat: add FT/PT filter and minor badge to shift planner sidebar"
+```
+
+---
+
+### Task 6: AI Scheduler — Prompt Integration
+
+**Files:**
+- Modify: `supabase/functions/_shared/schedule-prompt-builder.ts:9-15` (ScheduleEmployee interface) and `supabase/functions/_shared/schedule-prompt-builder.ts:68-82` (SYSTEM_PROMPT)
+- Modify: `supabase/functions/generate-schedule/index.ts:117` (employee select) and `supabase/functions/generate-schedule/index.ts:212-219` (employee mapping)
+- Create: `tests/unit/schedulePromptBuilder.test.ts`
+
+- [ ] **Step 1: Write the prompt builder test**
+
+```typescript
+// tests/unit/schedulePromptBuilder.test.ts
+import { describe, it, expect } from 'vitest';
+import { buildSchedulePrompt, ScheduleContext } from '../../supabase/functions/_shared/schedule-prompt-builder';
+
+describe('buildSchedulePrompt with employment_type', () => {
+  const baseContext: ScheduleContext = {
+    weekStart: '2026-04-13',
+    employees: [
+      { id: '1', name: 'Alice', position: 'Server', area: null, hourly_rate: 1500, employment_type: 'full_time' },
+      { id: '2', name: 'Bob', position: 'Cook', area: null, hourly_rate: 1800, employment_type: 'part_time' },
+    ],
+    templates: [],
+    availability: {},
+    staffingSettings: null,
+    priorSchedulePatterns: [],
+    hourlySalesPatterns: [],
+    weeklyBudgetTarget: null,
+    lockedShifts: [],
+  };
+
+  it('includes employment_type in employee data', () => {
+    const result = buildSchedulePrompt(baseContext);
+    const userMessage = result.messages[1].content;
+    expect(userMessage).toContain('"employment_type": "full_time"');
+    expect(userMessage).toContain('"employment_type": "part_time"');
+  });
+
+  it('includes FT/PT scheduling rule in system prompt', () => {
+    const result = buildSchedulePrompt(baseContext);
+    const systemMessage = result.messages[0].content;
+    expect(systemMessage).toContain('Full-time');
+    expect(systemMessage).toContain('Part-time');
+    expect(systemMessage).toContain('35-40 hours');
+    expect(systemMessage).toContain('15-25 hours');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/schedulePromptBuilder.test.ts`
+Expected: FAIL — `employment_type` not in interface or output.
+
+- [ ] **Step 3: Update ScheduleEmployee interface**
+
+In `supabase/functions/_shared/schedule-prompt-builder.ts`, update the `ScheduleEmployee` interface (lines 9-15):
+
+```typescript
+export interface ScheduleEmployee {
+  id: string;
+  name: string;
+  position: string;
+  area: string | null;
+  hourly_rate: number; // cents
+  employment_type: 'full_time' | 'part_time';
+}
+```
+
+- [ ] **Step 4: Update SYSTEM_PROMPT with FT/PT rule**
+
+In the `SYSTEM_PROMPT` constant (lines 68-82), add rule 11 after rule 10:
+
+```typescript
+const SYSTEM_PROMPT = `You are a restaurant schedule optimizer. Your job is to create an optimal weekly shift schedule.
+
+RULES:
+1. ONLY use the provided shift templates as shift blocks — do not invent custom time ranges.
+2. ONLY assign employees to templates matching their position.
+3. When a template has an area set, PREFER assigning employees from the same area. Only assign employees from a different area to that template if no same-area employees are available for that time slot. This is a soft preference — cross-area assignments are allowed as a fallback.
+4. ONLY assign employees on days/times they are available.
+5. Do NOT assign any employee more than once in the same time slot (no double-booking).
+6. Do NOT modify or reassign any locked shifts — they are fixed.
+7. Weight staffing toward peak sales hours — more staff during lunch/dinner rushes.
+8. If staffing settings specify minimum crew per position, meet those minimums when possible.
+9. If no staffing settings exist, use prior schedule patterns to infer typical staffing levels.
+10. Try to stay within the weekly labor budget target. If adequate coverage requires exceeding it, note the variance.
+11. Full-time employees should be scheduled for more shifts, targeting 35-40 hours per week. Part-time employees should be scheduled for fewer shifts, targeting 15-25 hours per week. When both full-time and part-time employees are available for a slot, prefer the full-time employee unless they are already near 40 hours for the week.
+
+Return valid JSON only, matching the provided schema exactly.`;
+```
+
+- [ ] **Step 5: Update buildUserPrompt to include employment_type**
+
+In the `buildUserPrompt` function, update the `employeesForPrompt` mapping (around line 132):
+
+```typescript
+  const employeesForPrompt = ctx.employees.map((e) => ({
+    id: e.id,
+    name: e.name,
+    position: e.position,
+    area: e.area ?? 'unassigned',
+    hourly_rate_dollars: (e.hourly_rate / 100).toFixed(2),
+    employment_type: e.employment_type,
+  }));
+```
+
+- [ ] **Step 6: Update the edge function to select and map employment_type**
+
+In `supabase/functions/generate-schedule/index.ts`, update the employee select query (line 117):
+
+```typescript
+        .select("id, name, position, area, hourly_rate, salary_amount, compensation_type, employment_type")
+```
+
+Update the employee mapping (around line 212):
+
+```typescript
+    const employees: ScheduleEmployee[] = activeEmployees.map((e) => ({
+      id: e.id,
+      name: e.name,
+      position: e.position ?? "Staff",
+      area: e.area ?? null,
+      hourly_rate: e.compensation_type === "salary" ? 0 : (e.hourly_rate ?? 0),
+      employment_type: e.employment_type ?? "full_time",
+    }));
+```
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+Run: `npx vitest run tests/unit/schedulePromptBuilder.test.ts`
+Expected: All 2 tests PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add supabase/functions/_shared/schedule-prompt-builder.ts supabase/functions/generate-schedule/index.ts tests/unit/schedulePromptBuilder.test.ts
+git commit -m "feat: add employment_type to AI schedule prompt for FT/PT hour targeting"
+```
+
+---
+
+### Task 7: E2E Test
+
+**Files:**
+- Create: `tests/e2e/employee-ft-pt-dob.spec.ts`
+
+- [ ] **Step 1: Write the E2E test**
+
+```typescript
+// tests/e2e/employee-ft-pt-dob.spec.ts
+import { test, expect } from '@playwright/test';
+import { generateTestUser } from '../helpers/e2e-supabase';
+
+test.describe('Employee FT/PT and DOB', () => {
+  test('can create a part-time minor employee and see badges', async ({ page }) => {
+    const testUser = generateTestUser();
+
+    // Navigate to employees page (assumes auth is handled by test setup)
+    await page.goto('/employees');
+
+    // Open add employee dialog
+    await page.getByRole('button', { name: /add/i }).click();
+
+    // Fill basic info
+    await page.getByLabel('Employee name').fill('Test Minor PT');
+    await page.getByLabel('Employee name').press('Tab');
+
+    // Toggle to Part-Time
+    await page.getByRole('button', { name: 'Part-time employment' }).click();
+
+    // Verify PT button is pressed
+    await expect(page.getByRole('button', { name: 'Part-time employment' })).toHaveAttribute('aria-pressed', 'true');
+
+    // Fill DOB for a minor (16 years old)
+    const minorDob = new Date();
+    minorDob.setFullYear(minorDob.getFullYear() - 16);
+    const dobStr = minorDob.toISOString().split('T')[0];
+    await page.getByLabel('Date of birth').fill(dobStr);
+
+    // Verify minor badge appears in dialog
+    await expect(page.getByText(/Minor \(\d+ yrs\)/)).toBeVisible();
+
+    // Fill required compensation field
+    await page.getByLabel('Hourly rate in dollars').fill('12.00');
+
+    // Submit
+    await page.getByRole('button', { name: /add employee/i }).click();
+
+    // Wait for dialog to close
+    await expect(page.getByRole('dialog')).toBeHidden({ timeout: 5000 });
+
+    // Verify badges appear in the employee list
+    await expect(page.getByText('Test Minor PT')).toBeVisible();
+    await expect(page.getByText('PT')).toBeVisible();
+    await expect(page.getByText('Minor')).toBeVisible();
+  });
+});
+```
+
+- [ ] **Step 2: Run the E2E test**
+
+Run: `npx playwright test tests/e2e/employee-ft-pt-dob.spec.ts`
+Expected: PASS (after the previous tasks are complete and dev server is running).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/e2e/employee-ft-pt-dob.spec.ts
+git commit -m "test: add E2E test for employee FT/PT toggle and DOB minor badge"
+```
+
+---
+
+### Task 8: Final Verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `npm run test`
+Expected: All unit tests PASS.
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `npm run typecheck`
+Expected: No new errors.
+
+- [ ] **Step 3: Run lint**
+
+Run: `npm run lint`
+Expected: No new errors (pre-existing ones are fine).
+
+- [ ] **Step 4: Run build**
+
+Run: `npm run build`
+Expected: Successful build.
+
+- [ ] **Step 5: Run pgTAP tests**
+
+Run: `npm run test:db`
+Expected: All tests PASS including the new ones.

--- a/docs/superpowers/plans/2026-04-16-planner-shift-template-bucketing-plan.md
+++ b/docs/superpowers/plans/2026-04-16-planner-shift-template-bucketing-plan.md
@@ -1,0 +1,352 @@
+# Planner Shift-to-Template Bucketing Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the planner bug where shifts display under the wrong template row when two templates across different areas share the same time/position/days.
+
+**Architecture:** Add a nullable `shift_template_id` foreign key to the `shifts` table. Thread the template ID through the planner's shift creation flow. Use it in `buildTemplateGridData` for deterministic bucketing, falling back to the existing fuzzy matching for legacy shifts.
+
+**Tech Stack:** PostgreSQL migration, TypeScript, React, Vitest
+
+---
+
+## File Map
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `supabase/migrations/20260416000000_add_shift_template_id.sql` | Create | Add `shift_template_id` column to `shifts` |
+| `src/types/scheduling.ts` | Modify | Add `shift_template_id` to `Shift` interface |
+| `src/hooks/useShiftPlanner.ts` | Modify | Update `buildTemplateGridData` to use template ID; add `shiftTemplateId` to `ShiftCreateInput` and `buildShiftPayload` |
+| `src/components/scheduling/ShiftPlanner/ShiftPlannerTab.tsx` | Modify | Thread template ID through `handleAssignDay`/`handleAssignAll` |
+| `tests/unit/useShiftPlanner.test.ts` | Modify | Add tests for template-ID-based bucketing |
+
+---
+
+### Task 1: Database migration — add `shift_template_id` to shifts
+
+**Files:**
+- Create: `supabase/migrations/20260416000000_add_shift_template_id.sql`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- Add shift_template_id to shifts for accurate planner bucketing.
+-- Nullable: legacy/imported shifts won't have a template reference.
+ALTER TABLE shifts
+  ADD COLUMN shift_template_id UUID REFERENCES shift_templates(id) ON DELETE SET NULL;
+
+-- Index for efficient lookups when building the planner grid
+CREATE INDEX idx_shifts_shift_template_id ON shifts(shift_template_id)
+  WHERE shift_template_id IS NOT NULL;
+```
+
+- [ ] **Step 2: Verify migration applies cleanly**
+
+Run: `npm run db:reset`
+Expected: All migrations apply without errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add supabase/migrations/20260416000000_add_shift_template_id.sql
+git commit -m "feat(db): add shift_template_id column to shifts table"
+```
+
+---
+
+### Task 2: Update TypeScript types
+
+**Files:**
+- Modify: `src/types/scheduling.ts:89-110` (Shift interface)
+
+- [ ] **Step 1: Add `shift_template_id` to the Shift interface**
+
+In `src/types/scheduling.ts`, add the field after `source`:
+
+```typescript
+  source: 'manual' | 'ai' | 'template';
+  shift_template_id?: string | null; // References shift_templates.id for planner bucketing
+  created_at: string;
+```
+
+- [ ] **Step 2: Regenerate Supabase types**
+
+Run: `npx supabase gen types typescript --local > src/integrations/supabase/types.ts`
+Expected: `shift_template_id` appears in the generated `shifts` table type.
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `npm run typecheck`
+Expected: No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/types/scheduling.ts src/integrations/supabase/types.ts
+git commit -m "feat(types): add shift_template_id to Shift interface and regenerate Supabase types"
+```
+
+---
+
+### Task 3: Update `buildTemplateGridData` to use `shift_template_id`
+
+**Files:**
+- Modify: `src/hooks/useShiftPlanner.ts:122-151`
+- Test: `tests/unit/useShiftPlanner.test.ts`
+
+- [ ] **Step 1: Write the failing test — shift with `shift_template_id` buckets correctly**
+
+Add this test to the `buildTemplateGridData` describe block in `tests/unit/useShiftPlanner.test.ts`:
+
+```typescript
+    it('should bucket shift by shift_template_id when present, ignoring time-based matching', () => {
+      // Two templates with identical time/position/days but different areas
+      const cscTemplate: ShiftTemplate = {
+        id: 't-csc', start_time: '10:00:00', end_time: '16:30:00', position: 'Server',
+        days: [5, 6, 0], name: 'Open-weekend-csc', area: 'Cold Stone',
+        restaurant_id: 'r1', break_duration: 0, capacity: 2, is_active: true, created_at: '', updated_at: '',
+      };
+      const wtzTemplate: ShiftTemplate = {
+        id: 't-wtz', start_time: '10:00:00', end_time: '16:30:00', position: 'Server',
+        days: [5, 6, 0], name: 'Open-weekend-wtz', area: "Wetzel's",
+        restaurant_id: 'r1', break_duration: 0, capacity: 2, is_active: true, created_at: '', updated_at: '',
+      };
+
+      // Shift explicitly linked to wtz template
+      const shift = mockShift({
+        id: 's1', employee_id: 'e1',
+        start_time: '2026-03-07T10:00:00', end_time: '2026-03-07T16:30:00',
+        position: 'Server', status: 'scheduled',
+        shift_template_id: 't-wtz',
+      });
+
+      const grid = buildTemplateGridData([shift], [cscTemplate, wtzTemplate], weekDays);
+
+      // Should be in wtz bucket, NOT csc (which would be the .find() first-match)
+      expect(grid.get('t-wtz')?.get('2026-03-07')).toHaveLength(1);
+      expect(grid.get('t-csc')?.get('2026-03-07') ?? []).toHaveLength(0);
+    });
+
+    it('should fall back to time-based matching when shift_template_id is absent', () => {
+      // Legacy shift without shift_template_id — should still match by time/position/day
+      const shift = mockShift({
+        id: 's1', employee_id: 'e1',
+        start_time: '2026-03-02T06:00:00', end_time: '2026-03-02T12:00:00',
+        position: 'Server', status: 'scheduled',
+        // No shift_template_id
+      });
+
+      const grid = buildTemplateGridData([shift], templates, weekDays);
+      expect(grid.get('t1')?.get('2026-03-02')).toHaveLength(1);
+    });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test -- tests/unit/useShiftPlanner.test.ts`
+Expected: The first new test fails because `buildTemplateGridData` doesn't check `shift_template_id`.
+
+- [ ] **Step 3: Update `buildTemplateGridData` to check `shift_template_id` first**
+
+In `src/hooks/useShiftPlanner.ts`, replace the `buildTemplateGridData` function (lines 122-151):
+
+```typescript
+export function buildTemplateGridData(
+  shifts: Shift[],
+  templates: ShiftTemplate[],
+  weekDays: string[],
+): Map<string, Map<string, Shift[]>> {
+  const weekDaySet = new Set(weekDays);
+  const grid = new Map<string, Map<string, Shift[]>>();
+  const templateIds = new Set(templates.map((t) => t.id));
+
+  for (const t of templates) {
+    grid.set(t.id, new Map());
+  }
+  grid.set('__unmatched__', new Map());
+
+  for (const shift of shifts) {
+    if (shift.status === 'cancelled') continue;
+    const shiftStartAt = new Date(shift.start_time);
+    const dayStr = formatLocalDate(shiftStartAt);
+    if (!weekDaySet.has(dayStr)) continue;
+
+    // Prefer explicit template ID (set during planner assignment)
+    if (shift.shift_template_id && templateIds.has(shift.shift_template_id)) {
+      pushToGridBucket(grid.get(shift.shift_template_id)!, dayStr, shift);
+      continue;
+    }
+
+    // Fallback: match by time/position/day for legacy shifts
+    const shiftStart = formatLocalTime(shift.start_time);
+    const shiftEnd = formatLocalTime(shift.end_time);
+    const dayOfWeek = shiftStartAt.getDay();
+    const match = findMatchingTemplate(templates, shiftStart, shiftEnd, shift.position, dayOfWeek);
+
+    const bucketKey = match ? match.id : '__unmatched__';
+    pushToGridBucket(grid.get(bucketKey)!, dayStr, shift);
+  }
+
+  return grid;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npm run test -- tests/unit/useShiftPlanner.test.ts`
+Expected: All tests pass, including the two new ones.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useShiftPlanner.ts tests/unit/useShiftPlanner.test.ts
+git commit -m "fix: use shift_template_id for planner grid bucketing with fallback"
+```
+
+---
+
+### Task 4: Thread template ID through shift creation
+
+**Files:**
+- Modify: `src/hooks/useShiftPlanner.ts:254-262` (ShiftCreateInput), `src/hooks/useShiftPlanner.ts:167-184` (buildShiftPayload)
+- Modify: `src/components/scheduling/ShiftPlanner/ShiftPlannerTab.tsx:186-218` (handleAssignDay), `src/components/scheduling/ShiftPlanner/ShiftPlannerTab.tsx:221-271` (handleAssignAll)
+
+- [ ] **Step 1: Add `shiftTemplateId` to `ShiftCreateInput`**
+
+In `src/hooks/useShiftPlanner.ts`, update the `ShiftCreateInput` interface:
+
+```typescript
+export interface ShiftCreateInput {
+  employeeId: string;
+  date: string;
+  startTime: string;
+  endTime: string;
+  position: string;
+  breakDuration?: number;
+  notes?: string;
+  shiftTemplateId?: string;
+}
+```
+
+- [ ] **Step 2: Pass it through `buildShiftPayload`**
+
+In `src/hooks/useShiftPlanner.ts`, update the `buildShiftPayload` function:
+
+```typescript
+function buildShiftPayload(
+  restaurantId: string,
+  input: ShiftCreateInput,
+  interval: ShiftInterval,
+) {
+  return {
+    restaurant_id: restaurantId,
+    employee_id: input.employeeId,
+    start_time: interval.startAt.toISOString(),
+    end_time: interval.endAt.toISOString(),
+    position: input.position,
+    break_duration: input.breakDuration ?? 0,
+    notes: input.notes,
+    status: 'scheduled' as const,
+    is_published: false,
+    locked: false,
+    shift_template_id: input.shiftTemplateId ?? null,
+  };
+}
+```
+
+- [ ] **Step 3: Thread template ID in `handleAssignDay`**
+
+In `src/components/scheduling/ShiftPlanner/ShiftPlannerTab.tsx`, update `handleAssignDay` to include `shiftTemplateId` in the input:
+
+```typescript
+    const input: ShiftCreateInput = {
+      employeeId: employee.id,
+      date: day,
+      startTime: startHHMM,
+      endTime: endHHMM,
+      position: template.position,
+      breakDuration: template.break_duration,
+      shiftTemplateId: template.id,
+    };
+```
+
+- [ ] **Step 4: Thread template ID in `handleAssignAll`**
+
+In `src/components/scheduling/ShiftPlanner/ShiftPlannerTab.tsx`, update `handleAssignAll` to include `shiftTemplateId` in each input:
+
+```typescript
+    const allInputs: ShiftCreateInput[] = activeDays.map((day) => ({
+      employeeId: employee.id,
+      date: day,
+      startTime: startHHMM,
+      endTime: endHHMM,
+      position: template.position,
+      breakDuration: template.break_duration,
+      shiftTemplateId: template.id,
+    }));
+```
+
+- [ ] **Step 5: Run typecheck and tests**
+
+Run: `npm run typecheck && npm run test`
+Expected: Both pass without errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/hooks/useShiftPlanner.ts src/components/scheduling/ShiftPlanner/ShiftPlannerTab.tsx
+git commit -m "fix: thread shift_template_id through planner shift creation flow"
+```
+
+---
+
+### Task 5: Include `shift_template_id` in shift query select
+
+**Files:**
+- Modify: `src/hooks/useShifts.tsx:56-68`
+
+- [ ] **Step 1: Verify the select includes `shift_template_id`**
+
+The current query uses `select('*, employee:employees(*)')` which already selects all columns including the new `shift_template_id`. No code change needed — the wildcard `*` covers it.
+
+Verify by checking `toTypedShift` handles the new field. Since it spreads `...shift` into the return object, the field passes through automatically.
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `npm run test`
+Expected: All tests pass.
+
+- [ ] **Step 3: No commit needed** (no code changes)
+
+---
+
+### Task 6: Full verification
+
+- [ ] **Step 1: Reset database and verify migration**
+
+Run: `npm run db:reset`
+Expected: All migrations apply cleanly.
+
+- [ ] **Step 2: Run all unit tests**
+
+Run: `npm run test`
+Expected: All pass.
+
+- [ ] **Step 3: Run typecheck and lint**
+
+Run: `npm run typecheck && npm run lint`
+Expected: No errors.
+
+- [ ] **Step 4: Run build**
+
+Run: `npm run build`
+Expected: Successful build.
+
+- [ ] **Step 5: Manual smoke test**
+
+Start dev server (`npm run dev:full`). In the Planner:
+1. Create two templates in different areas with identical time/position/days
+2. Drag an employee onto the first template's cell
+3. Verify the shift appears in the correct template row (not the other area's row)
+4. Verify the toast and dialog show the correct template name
+5. Repeat for the second template to confirm both work independently

--- a/docs/superpowers/plans/2026-04-21-invitation-ux-redesign-plan.md
+++ b/docs/superpowers/plans/2026-04-21-invitation-ux-redesign-plan.md
@@ -1,0 +1,850 @@
+# Invitation UX Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Improve the invitation UX with resend buttons for expired invites, a collapsed history view, pending-invite confirmation before re-sending, and a helpful expired-link page.
+
+**Architecture:** Extract shared utility functions into `src/lib/invitationUtils.ts`; modify the three affected components (`TeamInvitations`, `CollaboratorInvitations`, `AcceptInvitation`) and the `useCollaborators` hook. No backend changes required.
+
+**Tech Stack:** React 18, TypeScript, Supabase JS SDK, React Query, shadcn/ui, Vitest + React Testing Library.
+
+---
+
+### Task 1: Create `invitationUtils.ts` and tests
+
+**Files:**
+- Create: `src/lib/invitationUtils.ts`
+- Create: `tests/unit/invitationUtils.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// tests/unit/invitationUtils.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { formatExpiresIn, classifyInvitationError } from '@/lib/invitationUtils';
+
+describe('formatExpiresIn', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-21T12:00:00Z'));
+  });
+
+  it('returns "Expires in 3 days" for a future date 3 days away', () => {
+    const future = new Date('2026-04-24T12:00:00Z').toISOString();
+    expect(formatExpiresIn(future)).toBe('Expires in 3 days');
+  });
+
+  it('returns "Expires tomorrow" for a future date 1 day away', () => {
+    const tomorrow = new Date('2026-04-22T12:00:00Z').toISOString();
+    expect(formatExpiresIn(tomorrow)).toBe('Expires tomorrow');
+  });
+
+  it('returns "Expires today" when less than 1 day remains', () => {
+    const soonish = new Date('2026-04-21T18:00:00Z').toISOString();
+    expect(formatExpiresIn(soonish)).toBe('Expires today');
+  });
+
+  it('returns "Expired yesterday" for yesterday', () => {
+    const yesterday = new Date('2026-04-20T12:00:00Z').toISOString();
+    expect(formatExpiresIn(yesterday)).toBe('Expired yesterday');
+  });
+
+  it('returns "Expired 5 days ago" for 5 days past', () => {
+    const past = new Date('2026-04-16T12:00:00Z').toISOString();
+    expect(formatExpiresIn(past)).toBe('Expired 5 days ago');
+  });
+});
+
+describe('classifyInvitationError', () => {
+  it('returns "expired" for the exact expired message', () => {
+    expect(classifyInvitationError('Invitation has expired')).toBe('expired');
+  });
+
+  it('returns "invalid" for any other message', () => {
+    expect(classifyInvitationError('Invalid token')).toBe('invalid');
+    expect(classifyInvitationError('')).toBe('invalid');
+    expect(classifyInvitationError('Not found')).toBe('invalid');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npm run test -- tests/unit/invitationUtils.test.ts
+```
+Expected: FAIL with "Cannot find module '@/lib/invitationUtils'"
+
+- [ ] **Step 3: Create the utility file**
+
+```typescript
+// src/lib/invitationUtils.ts
+
+export function formatExpiresIn(expiresAt: string): string {
+  const ms = new Date(expiresAt).getTime() - Date.now();
+  const days = Math.ceil(ms / (1000 * 60 * 60 * 24));
+  if (days > 1) return `Expires in ${days} days`;
+  if (days === 1) return 'Expires tomorrow';
+  if (days === 0) return 'Expires today';
+  const expiredDays = Math.abs(days);
+  if (expiredDays === 1) return 'Expired yesterday';
+  return `Expired ${expiredDays} days ago`;
+}
+
+export function classifyInvitationError(message: string): 'expired' | 'invalid' {
+  return message === 'Invitation has expired' ? 'expired' : 'invalid';
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npm run test -- tests/unit/invitationUtils.test.ts
+```
+Expected: 7 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/invitationUtils.ts tests/unit/invitationUtils.test.ts
+git commit -m "feat: add invitation utility functions (formatExpiresIn, classifyInvitationError)"
+```
+
+---
+
+### Task 2: `AcceptInvitation.tsx` — Expired vs invalid UX
+
+**Files:**
+- Modify: `src/pages/AcceptInvitation.tsx`
+
+- [ ] **Step 1: Add `'expired'` to the status type and wire up `classifyInvitationError`**
+
+In `AcceptInvitation.tsx`, make the following changes:
+
+1. Add import at top (after existing imports):
+```typescript
+import { classifyInvitationError } from '@/lib/invitationUtils';
+```
+
+2. Change the `useState` for `status` on line 24 from:
+```typescript
+const [status, setStatus] = useState<'loading' | 'valid' | 'invalid' | 'accepted' | 'error' | 'needs_auth'>('loading');
+```
+to:
+```typescript
+const [status, setStatus] = useState<'loading' | 'valid' | 'invalid' | 'expired' | 'accepted' | 'error' | 'needs_auth'>('loading');
+```
+
+3. Change the `else` branch in `validateInvitation` (line 88–90) from:
+```typescript
+      } else {
+        throw new Error(data.error || 'Invalid invitation');
+      }
+```
+to:
+```typescript
+      } else {
+        throw new Error(data.error || '');
+      }
+```
+
+4. Change the `catch` block in `validateInvitation` (lines 91–96) from:
+```typescript
+    } catch (error: any) {
+      console.error('Error validating invitation:', error);
+      setStatus('invalid');
+    } finally {
+```
+to:
+```typescript
+    } catch (error: any) {
+      console.error('Error validating invitation:', error);
+      setStatus(classifyInvitationError(error?.message || ''));
+    } finally {
+```
+
+- [ ] **Step 2: Add the expired render branch**
+
+Add this block immediately **before** the `if (status === 'invalid')` block (before line 243):
+
+```typescript
+  if (status === 'expired') {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-primary/5 to-secondary/5">
+        <Card className="w-full max-w-md">
+          <CardHeader className="text-center">
+            <div className="mx-auto mb-4 w-12 h-12 rounded-full bg-amber-100 flex items-center justify-center">
+              <Clock className="w-6 h-6 text-amber-600" />
+            </div>
+            <CardTitle>Invitation Expired</CardTitle>
+            <CardDescription>
+              This invitation link is no longer valid. Ask your manager to resend it from the Team page.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="text-center">
+            <Button onClick={() => navigate('/')}>
+              Go to Dashboard
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+```bash
+npm run typecheck 2>&1 | grep -i "AcceptInvitation\|invitationUtils"
+```
+Expected: no errors for these files
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/AcceptInvitation.tsx
+git commit -m "feat: show helpful expired message on invitation link page"
+```
+
+---
+
+### Task 3: `TeamInvitations.tsx` — Resend button + expires-in label
+
+**Files:**
+- Modify: `src/components/TeamInvitations.tsx`
+
+- [ ] **Step 1: Add import, resend state, and resend function**
+
+1. Add `RefreshCw` to the lucide import on line 11:
+```typescript
+import { Mail, Plus, Clock, CheckCircle, XCircle, Trash2, RefreshCw } from 'lucide-react';
+```
+
+2. Add import for the utility (after the lucide import):
+```typescript
+import { formatExpiresIn } from '@/lib/invitationUtils';
+```
+
+3. Add `resendingIds` state after the existing `sending` state (after line 36):
+```typescript
+  const [resendingIds, setResendingIds] = useState<Set<string>>(new Set());
+```
+
+4. Add `resendInvitation` function after `sendInvitation` (after line 153):
+```typescript
+  const resendInvitation = async (invitation: Invitation) => {
+    setResendingIds(prev => new Set(prev).add(invitation.id));
+    try {
+      const { error } = await supabase.functions.invoke('send-team-invitation', {
+        body: { restaurantId, email: invitation.email, role: invitation.role },
+      });
+      if (error) throw error;
+      toast({ title: 'Invitation resent', description: `New invite sent to ${invitation.email}` });
+      fetchInvitations();
+    } catch {
+      toast({ title: 'Error', description: 'Failed to resend invitation', variant: 'destructive' });
+    } finally {
+      setResendingIds(prev => { const s = new Set(prev); s.delete(invitation.id); return s; });
+    }
+  };
+```
+
+- [ ] **Step 2: Update the date label and add the Resend button in the render**
+
+1. Replace the expires date display (lines 259–264) from:
+```typescript
+                      <p>
+                        {new Date(invitation.createdAt).toLocaleDateString()}
+                        {invitation.expiresAt && (
+                          <span> • Expires {new Date(invitation.expiresAt).toLocaleDateString()}</span>
+                        )}
+                      </p>
+```
+to:
+```typescript
+                      <p>
+                        {invitation.expiresAt && invitation.status === 'pending'
+                          ? formatExpiresIn(invitation.expiresAt)
+                          : invitation.expiresAt && invitation.status === 'expired'
+                          ? formatExpiresIn(invitation.expiresAt)
+                          : new Date(invitation.createdAt).toLocaleDateString()}
+                      </p>
+```
+
+2. Replace the action buttons area (lines 269–284) from:
+```typescript
+                <div className="flex items-center justify-between sm:justify-end gap-2 sm:gap-3">
+                  <Badge variant={statusColors[invitation.status]} className="flex items-center gap-1 text-xs">
+                    {statusIcons[invitation.status]}
+                    <span className="capitalize">{invitation.status}</span>
+                  </Badge>
+                  
+                  {canManageInvites && invitation.status === 'pending' && (
+                    <Button 
+                      variant="ghost" 
+                      size="sm"
+                      onClick={() => deleteInvitation(invitation.id, invitation.email)}
+                      className="text-destructive hover:text-destructive hover:bg-destructive/10 p-2"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  )}
+                </div>
+```
+to:
+```typescript
+                <div className="flex items-center justify-between sm:justify-end gap-2 sm:gap-3">
+                  <Badge variant={statusColors[invitation.status]} className="flex items-center gap-1 text-xs">
+                    {statusIcons[invitation.status]}
+                    <span className="capitalize">{invitation.status}</span>
+                  </Badge>
+                  
+                  {canManageInvites && invitation.status === 'pending' && (
+                    <Button 
+                      variant="ghost" 
+                      size="sm"
+                      onClick={() => deleteInvitation(invitation.id, invitation.email)}
+                      className="text-destructive hover:text-destructive hover:bg-destructive/10 p-2"
+                      aria-label={`Cancel invitation for ${invitation.email}`}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  )}
+
+                  {canManageInvites && invitation.status === 'expired' && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => resendInvitation(invitation)}
+                      disabled={resendingIds.has(invitation.id)}
+                      className="text-primary hover:text-primary hover:bg-primary/10 p-2"
+                      aria-label={`Resend invitation to ${invitation.email}`}
+                    >
+                      <RefreshCw className={`h-4 w-4 ${resendingIds.has(invitation.id) ? 'animate-spin' : ''}`} />
+                    </Button>
+                  )}
+                </div>
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+```bash
+npm run typecheck 2>&1 | grep -i "TeamInvitations"
+```
+Expected: no errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/TeamInvitations.tsx
+git commit -m "feat: add resend button and expires-in label to team invitations"
+```
+
+---
+
+### Task 4: `TeamInvitations.tsx` — History collapse
+
+**Files:**
+- Modify: `src/components/TeamInvitations.tsx`
+
+- [ ] **Step 1: Add `showHistory` state and split invitations into active vs history**
+
+Add after the `resendingIds` state:
+```typescript
+  const [showHistory, setShowHistory] = useState(false);
+```
+
+Add computed values after the `statusColors` object (before the return statement, around line 168):
+```typescript
+  const activeInvitations = invitations.filter(
+    inv => inv.status === 'pending' || inv.status === 'expired'
+  );
+  const historyInvitations = invitations.filter(
+    inv => inv.status === 'accepted' || inv.status === 'cancelled'
+  );
+  const visibleInvitations = showHistory ? invitations : activeInvitations;
+```
+
+- [ ] **Step 2: Replace `invitations.map(...)` with `visibleInvitations.map(...)` and add history toggle**
+
+1. In the render, change line 249 from:
+```typescript
+          <div className="space-y-3 md:space-y-4">
+            {invitations.map((invitation) => (
+```
+to:
+```typescript
+          <div className="space-y-3 md:space-y-4">
+            {visibleInvitations.map((invitation) => (
+```
+
+2. After the closing `</div>` of the map (before the closing `</div>` of the outer content div, around line 287), add the history toggle:
+```typescript
+            {historyInvitations.length > 0 && (
+              <button
+                onClick={() => setShowHistory(prev => !prev)}
+                className="w-full text-center text-xs text-muted-foreground hover:text-foreground py-2 transition-colors"
+              >
+                {showHistory
+                  ? 'Hide history'
+                  : `Show history (${historyInvitations.length})`}
+              </button>
+            )}
+```
+
+- [ ] **Step 3: Handle empty active state (all accepted/cancelled)**
+
+Change the condition on line 247 from:
+```typescript
+        ) : invitations.length > 0 ? (
+```
+to:
+```typescript
+        ) : invitations.length > 0 || activeInvitations.length === 0 ? (
+```
+
+Wait — actually the empty state should only show when `invitations.length === 0`. The current condition is correct. But when all invitations are in history (e.g., all accepted), `visibleInvitations` would be empty while `invitations.length > 0`. We need to handle that:
+
+Replace the top-level ternary (lines 247–300) — change the condition at line 247 from:
+```typescript
+        ) : invitations.length > 0 ? (
+```
+to:
+```typescript
+        ) : invitations.length > 0 ? (
+```
+(keep this the same — the outer block stays as-is since `historyInvitations` still renders the toggle when `visibleInvitations` is empty)
+
+Then inside the map block, add a fallback when `visibleInvitations` is empty but `invitations` is not:
+```typescript
+            {visibleInvitations.length === 0 && (
+              <p className="text-sm text-muted-foreground text-center py-2">
+                All invitations are in history.
+              </p>
+            )}
+```
+Add this line immediately after the `visibleInvitations.map(...)` block.
+
+- [ ] **Step 4: Verify TypeScript compiles**
+
+```bash
+npm run typecheck 2>&1 | grep -i "TeamInvitations"
+```
+Expected: no errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/TeamInvitations.tsx
+git commit -m "feat: collapse accepted/cancelled invitations behind history toggle"
+```
+
+---
+
+### Task 5: `TeamInvitations.tsx` — Pending invite confirmation
+
+**Files:**
+- Modify: `src/components/TeamInvitations.tsx`
+
+- [ ] **Step 1: Add `pendingConflict` state**
+
+Add after the `showHistory` state:
+```typescript
+  const [pendingConflict, setPendingConflict] = useState(false);
+```
+
+- [ ] **Step 2: Add conflict check to `sendInvitation`**
+
+At the top of `sendInvitation` (after the email/role validation block, around line 122), add before `setSending(true)`:
+```typescript
+    const hasConflict = invitations.some(
+      inv => inv.email.toLowerCase() === inviteForm.email.toLowerCase() && inv.status === 'pending'
+    );
+    if (hasConflict && !pendingConflict) {
+      setPendingConflict(true);
+      return;
+    }
+    setPendingConflict(false);
+```
+
+- [ ] **Step 3: Add confirmation UI inside the dialog**
+
+In the `DialogContent` section, add a warning block immediately before the `<DialogFooter>` (around line 228):
+```typescript
+                {pendingConflict && (
+                  <div className="flex items-start gap-2 p-3 rounded-lg bg-amber-500/10 border border-amber-500/20 text-[13px]">
+                    <Clock className="h-4 w-4 text-amber-600 mt-0.5 flex-shrink-0" />
+                    <p className="text-amber-800 dark:text-amber-200">
+                      A pending invite for <strong>{inviteForm.email}</strong> already exists. Sending a new one will cancel the old link.
+                    </p>
+                  </div>
+                )}
+```
+
+Change the Send button label to reflect the confirmation state (line 232):
+```typescript
+                  <Button onClick={sendInvitation} disabled={sending}>
+                    {sending ? 'Sending...' : pendingConflict ? 'Yes, resend anyway' : 'Send Invitation'}
+                  </Button>
+```
+
+Also reset `pendingConflict` when the dialog closes. Find the `onOpenChange` handler on the `Dialog` (line 180) and update it:
+```typescript
+              <Dialog open={isDialogOpen} onOpenChange={(open) => { setIsDialogOpen(open); if (!open) setPendingConflict(false); }}>
+```
+
+- [ ] **Step 4: Verify TypeScript compiles**
+
+```bash
+npm run typecheck 2>&1 | grep -i "TeamInvitations"
+```
+Expected: no errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/TeamInvitations.tsx
+git commit -m "feat: warn before re-inviting email with existing pending invite"
+```
+
+---
+
+### Task 6: `useCollaborators.ts` — Add `useResendCollaboratorInvitation`
+
+**Files:**
+- Modify: `src/hooks/useCollaborators.ts`
+- Modify: `tests/unit/useCollaborators.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+In `tests/unit/useCollaborators.test.ts`, add this describe block at the end (after existing tests):
+
+```typescript
+describe('useResendCollaboratorInvitation', () => {
+  it('calls send-team-invitation edge function with correct params', async () => {
+    mockInvoke.mockResolvedValueOnce({ data: {}, error: null });
+
+    const { result } = renderHook(() => useResendCollaboratorInvitation(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      result.current.mutate({
+        restaurantId: 'rest-1',
+        email: 'sam@example.com',
+        role: 'collaborator_accountant' as Role,
+      });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockInvoke).toHaveBeenCalledWith('send-team-invitation', {
+      body: { restaurantId: 'rest-1', email: 'sam@example.com', role: 'collaborator_accountant' },
+    });
+  });
+
+  it('invalidates collaborator-invites query on success', async () => {
+    mockInvoke.mockResolvedValueOnce({ data: {}, error: null });
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const wrapper = ({ children }: { children: React.ReactNode }) =>
+      React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+    const { result } = renderHook(() => useResendCollaboratorInvitation(), { wrapper });
+
+    await act(async () => {
+      result.current.mutate({ restaurantId: 'rest-1', email: 'sam@example.com', role: 'collaborator_accountant' as Role });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['collaborator-invites', 'rest-1'] });
+  });
+});
+```
+
+Also add `useResendCollaboratorInvitation` to the import from `@/hooks/useCollaborators`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npm run test -- tests/unit/useCollaborators.test.ts 2>&1 | tail -20
+```
+Expected: FAIL — `useResendCollaboratorInvitation` not exported
+
+- [ ] **Step 3: Add `useResendCollaboratorInvitation` to `useCollaborators.ts`**
+
+Add this export at the end of `src/hooks/useCollaborators.ts` (after the existing `useRemoveCollaborator`):
+
+```typescript
+/**
+ * Resends an expired invitation to a collaborator
+ */
+export const useResendCollaboratorInvitation = () => {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async ({ restaurantId, email, role }: SendInvitationParams) => {
+      const { error } = await supabase.functions.invoke('send-team-invitation', {
+        body: { restaurantId, email, role },
+      });
+      if (error) throw error;
+      return { email, role, restaurantId };
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['collaborator-invites', data.restaurantId] });
+      toast({
+        title: 'Invitation resent',
+        description: `New invite sent to ${data.email}`,
+      });
+    },
+    onError: (error: Error) => {
+      toast({
+        title: 'Error resending invitation',
+        description: error.message || 'Failed to resend invitation',
+        variant: 'destructive',
+      });
+    },
+  });
+};
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npm run test -- tests/unit/useCollaborators.test.ts
+```
+Expected: all tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useCollaborators.ts tests/unit/useCollaborators.test.ts
+git commit -m "feat: add useResendCollaboratorInvitation hook"
+```
+
+---
+
+### Task 7: `CollaboratorInvitations.tsx` — Expired invites, resend, history collapse
+
+**Files:**
+- Modify: `src/components/CollaboratorInvitations.tsx`
+
+- [ ] **Step 1: Import the new hook and add local state**
+
+1. Add `useResendCollaboratorInvitation` to the import from `@/hooks/useCollaborators` (line 17):
+```typescript
+import {
+  useCollaboratorsQuery,
+  useCollaboratorInvitesQuery,
+  useSendCollaboratorInvitation,
+  useCancelCollaboratorInvitation,
+  useRemoveCollaborator,
+  useResendCollaboratorInvitation,
+} from '@/hooks/useCollaborators';
+```
+
+2. Add `RefreshCw` to the lucide import (line 9):
+```typescript
+import { Calculator, Package, ChefHat, Clock, CheckCircle, XCircle, Trash2, Check, ArrowLeft, UserPlus, Users, AlertCircle, RefreshCw } from 'lucide-react';
+```
+
+3. Add state and hook after `removeCollaboratorMutation` (after line 44):
+```typescript
+  const resendInvitationMutation = useResendCollaboratorInvitation();
+  const [showCancelledInvites, setShowCancelledInvites] = useState(false);
+```
+
+4. Add handler after `handleRemoveCollaborator`:
+```typescript
+  const handleResendInvitation = (invite: { email: string; role: string }) => {
+    resendInvitationMutation.mutate({
+      restaurantId,
+      email: invite.email,
+      role: invite.role as Role,
+    });
+  };
+```
+
+- [ ] **Step 2: Update the Pending Invitations section**
+
+Replace the entire `{/* Pending Invitations */}` `Card` block (lines 314–394) with:
+
+```tsx
+      {/* Pending & Expired Invitations */}
+      {(invitesLoading || invitesError || pendingInvites?.some(i => i.status === 'pending' || i.status === 'expired')) && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">Pending Invitations</CardTitle>
+            <CardDescription>
+              Collaborator invitations waiting to be accepted
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {invitesLoading ? (
+              <div className="space-y-3">
+                {[1, 2].map((i) => (
+                  <div key={i} className="flex items-center justify-between p-3 border rounded-lg">
+                    <div className="flex items-center gap-3">
+                      <Skeleton className="h-8 w-8 rounded-lg" />
+                      <div className="space-y-2">
+                        <Skeleton className="h-4 w-40" />
+                        <Skeleton className="h-3 w-32" />
+                      </div>
+                    </div>
+                    <Skeleton className="h-6 w-20" />
+                  </div>
+                ))}
+              </div>
+            ) : invitesError ? (
+              <div className="flex items-center gap-3 p-4 rounded-lg bg-destructive/10 text-destructive">
+                <AlertCircle className="h-5 w-5 flex-shrink-0" />
+                <p className="text-sm">Failed to load invitations</p>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                {pendingInvites
+                  ?.filter(invite => invite.status === 'pending' || invite.status === 'expired')
+                  .map((invite) => {
+                    const Icon = roleIcons[invite.role] || Calculator;
+                    const isExpired = invite.status === 'expired';
+
+                    return (
+                      <div
+                        key={invite.id}
+                        className="flex items-center justify-between p-3 border rounded-lg"
+                      >
+                        <div className="flex items-center gap-3">
+                          <div className="p-2 rounded-lg bg-muted">
+                            <Icon className="h-4 w-4" />
+                          </div>
+                          <div>
+                            <p className="font-medium text-sm">{invite.email}</p>
+                            <p className="text-xs text-muted-foreground">
+                              {isExpired
+                                ? `Expired — invite ${invite.invitedBy ? `by ${invite.invitedBy}` : ''} no longer valid`
+                                : `Invited by ${invite.invitedBy} • Expires ${invite.expiresAt ? new Date(invite.expiresAt).toLocaleDateString() : 'never'}`}
+                            </p>
+                          </div>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <Badge variant={statusColors[invite.status]}>
+                            {statusIcons[invite.status]}
+                            <span className="ml-1 capitalize">{invite.status}</span>
+                          </Badge>
+                          {canManage && invite.status === 'pending' && (
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => handleCancelInvitation(invite.id, invite.email)}
+                              className="text-destructive hover:text-destructive hover:bg-destructive/10"
+                              aria-label={`Cancel invitation for ${invite.email}`}
+                            >
+                              <Trash2 className="h-4 w-4" />
+                            </Button>
+                          )}
+                          {canManage && invite.status === 'expired' && (
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => handleResendInvitation(invite)}
+                              disabled={resendInvitationMutation.isPending}
+                              className="text-primary hover:text-primary hover:bg-primary/10"
+                              aria-label={`Resend invitation to ${invite.email}`}
+                            >
+                              <RefreshCw className={`h-4 w-4 ${resendInvitationMutation.isPending ? 'animate-spin' : ''}`} />
+                            </Button>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+
+                {/* Cancelled history toggle */}
+                {(() => {
+                  const cancelled = pendingInvites?.filter(i => i.status === 'cancelled') ?? [];
+                  if (cancelled.length === 0) return null;
+                  return (
+                    <>
+                      <button
+                        onClick={() => setShowCancelledInvites(prev => !prev)}
+                        className="w-full text-center text-xs text-muted-foreground hover:text-foreground py-1 transition-colors"
+                      >
+                        {showCancelledInvites ? 'Hide cancelled' : `Show cancelled (${cancelled.length})`}
+                      </button>
+                      {showCancelledInvites && cancelled.map((invite) => {
+                        const Icon = roleIcons[invite.role] || Calculator;
+                        return (
+                          <div key={invite.id} className="flex items-center justify-between p-3 border rounded-lg opacity-50">
+                            <div className="flex items-center gap-3">
+                              <div className="p-2 rounded-lg bg-muted">
+                                <Icon className="h-4 w-4" />
+                              </div>
+                              <div>
+                                <p className="font-medium text-sm">{invite.email}</p>
+                                <p className="text-xs text-muted-foreground">Cancelled</p>
+                              </div>
+                            </div>
+                            <Badge variant="outline">
+                              <span className="capitalize">{invite.status}</span>
+                            </Badge>
+                          </div>
+                        );
+                      })}
+                    </>
+                  );
+                })()}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
+```
+
+- [ ] **Step 3: Verify TypeScript compiles**
+
+```bash
+npm run typecheck 2>&1 | grep -i "CollaboratorInvitations"
+```
+Expected: no errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/CollaboratorInvitations.tsx
+git commit -m "feat: show expired collaborator invites with resend button and history toggle"
+```
+
+---
+
+### Task 8: Full verification
+
+- [ ] **Step 1: Run all unit tests**
+
+```bash
+npm run test
+```
+Expected: all tests pass
+
+- [ ] **Step 2: Run typecheck**
+
+```bash
+npm run typecheck
+```
+Expected: no errors
+
+- [ ] **Step 3: Run lint**
+
+```bash
+npm run lint
+```
+Expected: no errors
+
+- [ ] **Step 4: Run build**
+
+```bash
+npm run build
+```
+Expected: build succeeds with no errors

--- a/docs/superpowers/specs/2026-04-13-employee-ft-pt-dob-design.md
+++ b/docs/superpowers/specs/2026-04-13-employee-ft-pt-dob-design.md
@@ -1,0 +1,156 @@
+# Employee FT/PT Employment Type & Date of Birth
+
+## Problem
+
+Managers need to distinguish full-time vs part-time employees for scheduling purposes. While employee availability captures *when* someone can work, FT/PT captures *how much* they should work per week. Not all employees fill out availability, so FT/PT provides a reliable planning signal for both manual and AI-powered scheduling.
+
+Additionally, managers need to know when an employee is a minor so they can comply with state labor laws. A date of birth field enables the system to flag minors visually, positioning the platform for future AI-powered labor rule enforcement.
+
+## Design
+
+### Database
+
+Single migration adding two columns to `employees`:
+
+| Column | Type | Nullable | Default | Constraint |
+|--------|------|----------|---------|------------|
+| `employment_type` | `TEXT` | NOT NULL | `'full_time'` | `CHECK (employment_type IN ('full_time', 'part_time'))` |
+| `date_of_birth` | `DATE` | YES | `NULL` | None |
+
+- No new tables or RLS policies needed — existing employee-level RLS covers these columns.
+- Default `'full_time'` means existing employees are automatically classified as FT without requiring backfill.
+
+### Employee Dialog (EmployeeDialog.tsx)
+
+**FT/PT segmented toggle:**
+- Placed between Area and Compensation Type fields.
+- Two-button toggle: "Full-Time" | "Part-Time". Defaults to Full-Time.
+- Helper text below: "Used by the scheduler to plan weekly hours."
+- Uses the same visual pattern as existing toggle elements in the dialog.
+
+**Date of birth input:**
+- Added as a third column in the existing Status / Hire Date row, making it a 3-column grid: Status | Hire Date | Date of Birth.
+- Standard date input, optional (no asterisk, no required validation).
+- When the computed age is under 18, an inline amber badge appears below the field: "Minor (N yrs)" using the project's standard badge styling (`text-[11px] px-1.5 py-0.5 rounded-md bg-amber-500/10 text-amber-600`).
+
+**Form state additions:**
+- `employmentType` state, initialized from `employee.employment_type` or `'full_time'`.
+- `dateOfBirth` state, initialized from `employee.date_of_birth` or `''`.
+- Both included in the `employeeData` payload for create/update.
+- Both included in `resetForm()`.
+
+### Employee List (EmployeeList.tsx)
+
+- FT/PT badge displayed next to position text on each employee card. Uses subtle styling: `text-[11px] px-1.5 py-0.5 rounded-md bg-muted` showing "FT" or "PT".
+- Minor badge (amber) shown when DOB indicates age < 18. Same badge style as the dialog: `bg-amber-500/10 text-amber-600`.
+
+### Shift Planner Sidebar (EmployeeSidebar.tsx)
+
+**New filter dropdown:**
+- "Employment type" filter added alongside existing Area and Role filters.
+- Options: "All types" | "Full-Time" | "Part-Time".
+- Follows the same `Select` component pattern as existing filters.
+
+**Employee chip updates:**
+- The sidebar's local `Employee` interface gets `employment_type` and `date_of_birth` added.
+- Minor badge shown on employee chips when applicable (amber dot or "Minor" text).
+- `filterEmployees()` function extended with an `employmentType` parameter.
+
+**Data flow:**
+- `ShiftPlannerTab.tsx` already fetches full employee objects — `employment_type` and `date_of_birth` will flow through once the hook select includes them.
+
+### AI Scheduler (schedule-prompt-builder.ts)
+
+**ScheduleEmployee interface:**
+```typescript
+export interface ScheduleEmployee {
+  id: string;
+  name: string;
+  position: string;
+  area: string | null;
+  hourly_rate: number; // cents
+  employment_type: 'full_time' | 'part_time'; // NEW
+}
+```
+
+**Prompt changes:**
+- Employee data sent to AI includes `employment_type` field.
+- New rule added to SYSTEM_PROMPT (rule 11):
+
+> 11. Full-time employees should be scheduled for more shifts, targeting 35-40 hours per week. Part-time employees should be scheduled for fewer shifts, targeting 15-25 hours per week. When both full-time and part-time employees are available for a slot, prefer the full-time employee unless they are already near 40 hours for the week.
+
+**What is NOT passed to AI:**
+- `date_of_birth` is NOT included in `ScheduleEmployee` or the prompt. Minor status is UI-only for now. Future work will pass minor status to enable AI-powered labor rule enforcement per state.
+
+### Edge Function (generate-schedule/index.ts)
+
+- The employee query in the edge function adds `employment_type` to the select.
+- Maps it into the `ScheduleEmployee` object passed to the prompt builder.
+
+### TypeScript Types (types/scheduling.ts)
+
+```typescript
+export type EmploymentType = 'full_time' | 'part_time';
+
+export interface Employee {
+  // ... existing fields ...
+  employment_type: EmploymentType;
+  date_of_birth?: string;
+}
+```
+
+### Hooks (useEmployees.tsx)
+
+- No changes needed to `useEmployees` — it uses `select('*')` which will include the new columns automatically.
+- The `useCreateEmployee` and `useUpdateEmployee` mutations already pass through the full payload.
+
+### Minor Age Calculation
+
+A pure utility function for computing age and minor status:
+
+```typescript
+// src/lib/employeeUtils.ts
+export function computeAge(dateOfBirth: string): number {
+  const today = new Date();
+  const dob = new Date(dateOfBirth);
+  let age = today.getFullYear() - dob.getFullYear();
+  const monthDiff = today.getMonth() - dob.getMonth();
+  if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < dob.getDate())) {
+    age--;
+  }
+  return age;
+}
+
+export function isMinor(dateOfBirth: string | null | undefined): boolean {
+  if (!dateOfBirth) return false;
+  return computeAge(dateOfBirth) < 18;
+}
+```
+
+This is used by EmployeeDialog, EmployeeList, and EmployeeSidebar for badge rendering. No database-level age computation needed.
+
+## Testing
+
+### pgTAP Tests
+- `employment_type` defaults to `'full_time'` when not specified.
+- `employment_type` CHECK constraint rejects invalid values (e.g., `'contractor'`).
+- `date_of_birth` accepts valid dates and NULL.
+- Existing employees retain `'full_time'` after migration.
+
+### Unit Tests
+- `computeAge()` — various DOB values, edge cases (birthday today, leap year).
+- `isMinor()` — under 18, exactly 18, over 18, null/undefined.
+- `filterEmployees()` — with employment type filter parameter.
+- `buildSchedulePrompt()` — employment_type appears in generated prompt.
+
+### E2E Test
+- Create employee with PT toggle and DOB that makes them a minor.
+- Verify "Minor" badge appears in the employee dialog and list.
+- Verify FT/PT filter works in shift planner sidebar.
+
+## Out of Scope
+
+- State-specific minor labor rules and automatic availability restrictions (future feature).
+- Passing DOB or minor status to the AI scheduler (future feature).
+- Target hours configuration per FT/PT (using hardcoded ranges in AI prompt for now — 35-40h FT, 15-25h PT).
+- Overtime/benefits implications of FT/PT classification (this is a scheduling hint only, not a legal classification tool).

--- a/docs/superpowers/specs/2026-04-16-planner-shift-template-bucketing-design.md
+++ b/docs/superpowers/specs/2026-04-16-planner-shift-template-bucketing-design.md
@@ -1,0 +1,45 @@
+# Planner Shift-to-Template Bucketing Fix
+
+## Problem
+
+When two shift templates across different areas share the same `(start_time, end_time, position, days)` — e.g., "Open-weekend-csc" (Cold Stone) and "Open-weekend-wtz" (Wetzel's) both at 10a-4:30p Server — shifts display in the wrong template row.
+
+**Root cause:** The `shifts` table has no foreign key to `shift_templates`. The planner's `buildTemplateGridData` function uses `findMatchingTemplate` which matches by time/position/day only, ignoring area. `.find()` returns the first match (alphabetical by area), so all ambiguous shifts bucket into one row.
+
+**User impact:** After assigning an employee to a template via drag-and-drop, the shift appears in the wrong template row. The toast message shows the correct template, but the grid shows it under a different area's template. This creates confusion about which area the employee is actually assigned to.
+
+## Solution
+
+Add a nullable `shift_template_id` foreign key to the `shifts` table. Store the template ID when creating shifts from the planner. Use it for deterministic bucketing in `buildTemplateGridData`.
+
+### Database
+
+- Add `shift_template_id UUID REFERENCES shift_templates(id) ON DELETE SET NULL` to `shifts` table (nullable for backward compatibility with legacy/imported shifts)
+
+### Backend (shift creation)
+
+- Update `buildShiftPayload` in `useShiftPlanner.ts` to accept and pass through `shift_template_id`
+- Update `ShiftCreateInput` interface to include optional `shiftTemplateId`
+- Thread the template ID from `handleAssignDay`/`handleAssignAll` in `ShiftPlannerTab.tsx` through to `validateAndCreate`/`forceCreate`
+
+### Display logic
+
+- Update `buildTemplateGridData` to check `shift.shift_template_id` first. If present, bucket directly by template ID. Fall back to `findMatchingTemplate` only for shifts without a template ID (legacy data).
+
+### TypeScript types
+
+- Add `shift_template_id?: string | null` to the `Shift` interface
+- Regenerate Supabase types
+
+## Scope
+
+- Migration: 1 new column, 1 foreign key
+- TypeScript: `Shift` interface, `ShiftCreateInput`, `buildShiftPayload`, `buildTemplateGridData`, `findMatchingTemplate` (kept as fallback)
+- Components: `ShiftPlannerTab.tsx` (thread template ID through creation flow)
+- Tests: Unit tests for `buildTemplateGridData` with template ID bucketing
+- No UI changes needed
+
+## Out of scope
+
+- Backfilling `shift_template_id` for existing shifts (they continue using the fallback matching)
+- Changing the drag-and-drop collision detection (rows are correctly rendered; the display bug was what made drops appear wrong)

--- a/docs/superpowers/specs/2026-04-21-invitation-ux-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-21-invitation-ux-redesign-design.md
@@ -1,0 +1,63 @@
+# Design: Invitation UX Redesign
+
+**Date:** 2026-04-21
+**Status:** Approved
+
+## Problem
+
+The invitations section has three UX gaps that make it unclear what to do when an invitation expires:
+
+1. **No resend action** — expired invitation rows have no button; the only way to resend is to re-open the "Send Invitation" dialog, which is non-obvious.
+2. **Generic expired-link page** — when a new employee clicks an expired invite link, they see "invalid/expired/already used" with no guidance on what to do next.
+3. **Cluttered list** — accepted and cancelled rows mix with actionable rows, making the list noisy and hiding what needs attention.
+4. **Silent re-invite** — resending to an email that already has a pending invite silently cancels the old link with no warning to the manager.
+
+## What Already Works (No Backend Changes Needed)
+
+- `send-team-invitation` edge function correctly cancels any existing `pending` invite and creates a fresh one when re-inviting the same email. Re-inviting is already safe.
+- The unique constraint `UNIQUE(restaurant_id, email, status)` allows one `pending` and one `expired` row to coexist — no conflicts.
+- `validate-invitation` already returns distinct error messages: `'Invitation has expired'` vs. a generic invalid-token error. The frontend just isn't using this distinction yet.
+
+## Design
+
+### 1. Resend Button on Expired Rows
+
+In `TeamInvitations.tsx` and `CollaboratorInvitations.tsx`, add a "Resend" button alongside expired invitation rows. Clicking it calls `send-team-invitation` with the same email, role, and (if present) `employeeId` from the existing invitation row. On success, show a toast: "Invitation resent to sam@example.com."
+
+No dialog is required — the parameters are already known from the expired row.
+
+### 2. History Collapse
+
+Accepted and cancelled rows are collapsed by default behind a "Show history (N)" toggle at the bottom of the list. Expired rows remain visible (they are actionable). The toggle is local UI state — no new queries needed.
+
+### 3. Pending Invite Confirmation
+
+When the "Send Invitation" dialog is submitted for an email that already has a `pending` invitation, show an inline warning before submitting: "A pending invite for this email already exists. Sending a new one will cancel the old link. Continue?" with Confirm / Cancel buttons.
+
+Detection: check the current `invitations` list (already loaded in React Query) for a `pending` row matching the entered email before calling the edge function.
+
+### 4. Improved Expired-Link Page
+
+In `AcceptInvitation.tsx`, the `validate-invitation` edge function call can return two distinct error cases:
+- HTTP 400 with message `'Invitation has expired'` → show: "This invitation has expired. Ask your manager to resend it from the Team page."
+- Any other error → keep the current generic "invalid/expired/already used" message.
+
+No changes to `validate-invitation` are required — the error message distinction already exists.
+
+### 5. "Expires in N days" on Pending Rows
+
+Replace "Sent X ago" with "Expires in N days" on pending invitation rows to give managers a clearer signal of urgency.
+
+## Components Affected
+
+| File | Change |
+|---|---|
+| `src/components/TeamInvitations.tsx` | Resend button, history collapse, pending confirmation, expires-in label |
+| `src/components/CollaboratorInvitations.tsx` | Resend button, history collapse |
+| `src/pages/AcceptInvitation.tsx` | Distinguish expired vs. invalid error state |
+
+## Out of Scope
+
+- Auto-scheduling `cleanup_expired_invitations()` (separate ops concern)
+- Notification emails to invitees when an invite expires
+- Bulk resend

--- a/docs/superpowers/specs/2026-04-21-planner-schedule-visibility-design.md
+++ b/docs/superpowers/specs/2026-04-21-planner-schedule-visibility-design.md
@@ -1,0 +1,317 @@
+# Planner Schedule Visibility & Week Sync
+
+**Date:** 2026-04-21
+**Status:** Draft — awaiting user approval
+**Scope:** Scheduling area (Schedule tab, Planner tab), mobile + desktop
+
+## Summary
+
+Two related improvements to the Scheduling page:
+
+1. **Shared week selection** — the selected week persists when the user switches between the Schedule tab and the Planner tab (and survives page reload).
+2. **Planner schedule visibility** — the Planner grows four complementary views that answer "what does this week already look like?" and, critically, "is Jose already allocated, and where does this shift overlap with his existing schedule?" — without abandoning the template-driven planning model.
+
+## Problem Statement
+
+### Issue 1 — Date desync across tabs
+`Scheduling.tsx` owns `currentWeekStart` for the Schedule tab (local `useState`). `useShiftPlanner` owns an independent `weekStart` for the Planner tab. Switching tabs presents the week each tab happens to hold, which rarely matches. Users lose their place.
+
+### Issue 2 — Planner lacks schedule context
+The Planner is template-centric: rows are templates (`Open-week-csc`, `Close-wtz`), columns are days, cells are capacity counters (`0/2`, `2/3`). Managers planning a week can't see:
+- What does each day actually look like over time? (coverage shape, peak hours, gaps)
+- Is Jose already on Monday? How many hours does he have?
+- Does this template I'm about to assign to Jose overlap his existing shift?
+
+The existing `EmployeeSidebar` shows names and total weekly hours, but not when those hours are. Conflicts surface only after the user attempts an assignment, via `AvailabilityConflictDialog` — reactive, not preventive.
+
+## Design Overview
+
+Four additions to the Planner, plus a shared week source across the Scheduling page:
+
+| Key | Addition | Purpose |
+|-----|----------|---------|
+| A | Coverage strip under day headers | See hour-by-hour headcount density per day |
+| B | "Schedule Overview" panel above grid | See each day's shift shape (mini-Gantt) + gaps |
+| 1 | Rich employee cards with mini-week | See each person's whole week at a glance |
+| 2 | Allocation overlay on hover/pick | See where the picked employee clashes, fits, or is already on |
+| — | Shared `week` URL param | Persist selected week across tabs and reloads |
+
+A and B give day-shape visibility. 1 and 2 give person-allocation visibility. They compose: A+B answer "what is this week?", 1+2 answer "where does this person fit in it?"
+
+## Feature 1 — Shared Week State
+
+**Approach:** URL search parameter `?week=YYYY-MM-DD` (Monday of the visible week).
+
+**Why URL:**
+- Survives page reload
+- Shareable via link ("look at week of May 4")
+- Orthogonal to tab selection (tab state stays local; week state is shared)
+- Single source of truth — no lift-and-prop-drill, no new context
+
+**Implementation:**
+- New `useSharedWeek()` hook in `src/hooks/useSharedWeek.ts`:
+  - Reads `week` from `useSearchParams()`. Defaults to current Monday if missing/invalid.
+  - Returns `{ weekStart: Date, setWeekStart: (Date) => void }`.
+  - Parses/serializes as `YYYY-MM-DD`. Validates as a Monday — if a non-Monday slips in, normalizes via `startOfWeek(..., { weekStartsOn: 1 })`.
+- `Scheduling.tsx` replaces its `currentWeekStart` `useState` with `useSharedWeek()`.
+- `useShiftPlanner` accepts an optional `externalWeekStart` prop. When provided, it uses that instead of internal state. `ShiftPlannerTab` passes the shared week down.
+- Tab switch still uses `<Tabs defaultValue="schedule">` (unchanged); no URL coupling for the tab itself.
+
+**Edge cases:**
+- No `week` param → default to today's Monday.
+- Invalid/malformed param → normalize silently (don't error — log in dev).
+- User navigates between `/scheduling` pages → URL carries forward.
+
+**Out of scope:** persisting the active tab itself to URL. Different concern, different fix.
+
+## Feature 2 — Coverage Strip (Option A)
+
+A thin horizontal heatmap row **under the day headers** of the template grid, showing hour-by-hour headcount density for each day.
+
+**Desktop layout:**
+```
+[SHIFT]   Mon 4   Tue 5   Wed 6   Thu 7   Fri 8   Sat 9   Sun 10
+[Coverage] ▁▂▃▄▅▆  ▂▃▄▅▆▅  ▁▂▃▄▅▆  ...
+[Open-week-csc] 2/2  2/2  1/2  ...
+```
+
+**Mobile:** Relocated. A 17-bucket heatmap across a 40px column is unreadable, so on mobile the strip lives **inside each day's Overview card** (see Feature 3). One coverage bar per day, stacked vertically.
+
+**Computation:**
+- Input: all shifts in the visible week (`shifts` from `useShifts`).
+- For each day × hour bucket (6am–11pm = 17 hours):
+  - Count shifts with `start_time ≤ hour < end_time` (ignoring breaks for v1).
+- Bucket to 5 levels (`h0`–`h4`) based on headcount:
+  - h0 = 0 people, h1 = 1, h2 = 2, h3 = 3, h4 ≥ 4.
+  - Colors tuned to pass WCAG AA against `bg-background`.
+
+**Respects area filter:** When `areaFilter` is set to "Cold Stone", coverage shows only shifts whose template belongs to Cold Stone (or, for template-less shifts, skip).
+
+**Component:** `src/components/scheduling/ShiftPlanner/CoverageStrip.tsx`
+- Props: `shifts`, `weekDays`, `areaFilter`
+- Renders 7 inline-grid bars with hour tooltips
+
+**Interaction:**
+- Hover a bucket → tooltip "Mon 2–3pm · 3 on shift"
+- Click a bucket → no action in v1 (future: scroll to that hour in Day-Overview panel)
+
+## Feature 3 — Schedule Overview Panel (Option B)
+
+A collapsible panel **above the template grid** (below Staffing Suggestions) that renders each day as a compact Gantt.
+
+**Desktop layout:** 7 columns horizontally. Each column:
+- Day label ("Mon 4")
+- 3 tracks (one per simultaneous shift layer — overflow collapses into "+N more")
+- Shift pills colored by role (server blue, cook amber, dish green, closer purple)
+- A "gap" chip if the day has a coverage hole during expected operating hours (>= 1 hour with 0 headcount after the first shift starts)
+- An "unstaffed" chip if no shifts at all
+
+**Mobile layout:** Stacked vertically. Each day is a full-width card:
+- Header row: "Mon 4" + chips ("3 shifts", "Gap 3p", etc.)
+- Timeline track with shift pills
+- A thin coverage heatmap (the mobile home for Feature 2)
+- Hour ruler beneath
+- Tapping the day card scrolls the template grid to that day's column
+
+**Expanded by default** on both desktop and mobile — the panel is the primary answer to "what does this week look like?", so it must be visible on first paint. User can collapse. (Collapsed-state persistence is deferred to a later iteration.)
+
+**Component:** `src/components/scheduling/ShiftPlanner/ScheduleOverviewPanel.tsx`
+- Props: `shifts`, `weekDays`, `areaFilter`, `timezone`
+- Sub-component: `OverviewDayCard` used in both layouts
+
+**Data computation:**
+- For each day, given shifts for that day:
+  - Sort by start time, greedy-pack into N lanes (v1: max 3 lanes, remaining → "+N more")
+  - Position each pill: `left = (start_hour - 6) / 17 * 100%`, `width = duration / 17 * 100%`
+- Gap detection: starting from the earliest shift's start hour, scan forward; if a 60+ min window has 0 headcount before the last shift ends, flag it.
+- Unstaffed: day has 0 shifts.
+
+**Respects area filter** same as Feature 2.
+
+## Feature 4 — Rich Employee Cards with Mini-Week (Option 1)
+
+Expand each employee card in the `EmployeeSidebar` to show a 7-day mini-calendar of that employee's shifts **for the visible week**.
+
+**Card layout:**
+```
+Jose Delgado                14h / 40
+Manager · Both
+┌──┬──┬──┬──┬──┬──┬──┐
+│M │T │W │T │F │S │S │
+│▓ │▓ │  │  ▓│  │  │  │   <- shift bars
+└──┴──┴──┴──┴──┴──┴──┘
+```
+
+- Mini-week is 7 columns of ~14px width (desktop) / 28px width (mobile drawer)
+- Each column is a 36px-tall vertical track representing 6am–11pm
+- Each shift is a positioned colored bar: `top = (start_hour - 6) / 17 * 100%`, `height = duration / 17 * 100%`, color by `position` field
+- Columns for days off are a lighter gray (`.off`)
+- "Today" column gets a subtle indigo inset ring
+
+**Performance consideration:** With 100+ employees, rendering 100 mini-weeks requires care.
+- Compute `shiftsByEmployee` once per week at the hook level, memoized.
+- `EmployeeCard` component is `memo`'d with `prevProps.shifts === nextProps.shifts && prevProps.employee.id === nextProps.employee.id`.
+- Mini-week itself is a pure subcomponent passed pre-computed `employeeShifts: Shift[]`.
+
+**Respects area filter** at employee-card level (already in place). Mini-week shows ALL of that employee's shifts in the week, not only shifts matching the filter — the point is to see total allocation, not filtered subset.
+
+**Components:**
+- Modify: `src/components/scheduling/ShiftPlanner/EmployeeSidebar.tsx`
+- Modify: `src/components/scheduling/ShiftPlanner/EmployeeCard.tsx` (or inline if it doesn't exist yet — will confirm during build)
+- New: `src/components/scheduling/ShiftPlanner/EmployeeMiniWeek.tsx`
+
+## Feature 5 — Allocation Overlay on Hover / Pick (Option 2)
+
+When an employee is "picked" (hover on desktop, tap-selected on mobile, or dragging), the template grid annotates itself based on each cell's relationship to that employee's existing allocation.
+
+**Annotation rules** — given picked employee E and cell (template T, day D):
+- **Already on (purple outline + "Name" chip):** E has a shift on day D where `start_time ≤ T.start_time AND end_time ≥ T.end_time` (E is already assigned to this template-slot or an encompassing shift).
+- **Conflict (red stripes + "Conflicts" chip):** E has any shift on day D whose `[start, end)` intersects `[T.start, T.end)` but isn't the encompassing case above.
+- **Fits cleanly (subtle green tint):** E has no overlapping shift on D, template is active on D.
+- **Not active / off-day:** no annotation (cell stays as-is).
+
+**Trigger states:**
+- Desktop: `onMouseEnter` / `onMouseLeave` on `EmployeeCard` → sets `hoveredEmployeeId`. Existing `onDragStart` (from `@dnd-kit`) also sets it.
+- Mobile: tapping an employee from the drawer already sets `selectedMobileEmployee`. Reuse that state as the pick signal.
+
+**State plumbing:**
+- `ShiftPlannerTab` owns new state: `pickedEmployeeId: string | null`, set by hover, drag, or mobile tap (whichever fires).
+- Passed into `TemplateGrid` → `ShiftCell`. `ShiftCell` receives a new `allocationStatus: 'none' | 'highlight' | 'conflict' | 'available'` prop (pre-computed by parent) and renders the border/bg.
+
+**Performance:**
+- `computeAllocationStatuses(shifts, pickedEmployeeId, templates, weekDays)` returns `Map<cellId, status>` in O(days × templates). Memoized on `[shifts, pickedEmployeeId, templates, weekDays]`.
+- Debounce hover changes (100ms) so quick mouse sweeps don't thrash renders.
+
+**Visual** (CLAUDE.md semantic tokens):
+- Highlight: `outline: 2px solid hsl(var(--primary))`, chip `bg-primary text-primary-foreground`
+- Conflict: diagonal striped `hsl(var(--destructive)/.1)` background, outline `hsl(var(--destructive))`, chip `bg-destructive text-destructive-foreground`
+- Available: `bg-primary/5`
+
+**Accessibility:**
+- `aria-live="polite"` region announces picked-employee count of conflicts/available slots once per selection.
+- Color is never the only signal — every state has a chip or icon.
+
+## Data & State Changes
+
+### New hook: `useSharedWeek`
+```typescript
+// src/hooks/useSharedWeek.ts
+export function useSharedWeek(): {
+  weekStart: Date;
+  setWeekStart: (date: Date) => void;
+}
+```
+
+### New hook: `usePlannerShiftsIndex`
+Memoized indexes derived from `shifts` for the visible week:
+```typescript
+// src/hooks/usePlannerShiftsIndex.ts
+export function usePlannerShiftsIndex(shifts: Shift[], weekDays: string[]): {
+  shiftsByEmployee: Map<string, Shift[]>;       // powers mini-week (Feature 4)
+  coverageByDay: Map<string, number[]>;          // powers CoverageStrip (Feature 2)
+  overviewDays: OverviewDay[];                   // powers OverviewPanel (Feature 3)
+}
+```
+
+### New utility: `computeAllocationStatus`
+```typescript
+// src/lib/shiftAllocation.ts
+export function computeAllocationStatus(
+  employeeShifts: Shift[],      // the picked employee's shifts on this day
+  template: ShiftTemplate,
+  day: string,                  // YYYY-MM-DD
+): 'highlight' | 'conflict' | 'available' | 'none'
+```
+
+### Modified component props
+
+- `TemplateGrid`: add `allocationStatuses: Map<string, AllocationStatus>` prop (cellId → status). Key format: `${templateId}:${day}`.
+- `ShiftCell`: add `allocationStatus?: AllocationStatus` prop. Render annotation layer when not `'none'`.
+- `EmployeeSidebar`: add `shifts: Shift[]` prop (already passed — confirmed in exploration). Pass to `EmployeeCard` which renders the mini-week.
+- `useShiftPlanner`: accept optional `externalWeekStart?: Date` prop to defer to shared state.
+
+### No new Supabase calls
+All data already fetched by `useShifts(restaurantId, weekStart, weekEnd)`. New features are pure derivations/memoizations over existing shifts.
+
+## Mobile-First Considerations
+
+| Feature | Desktop | Mobile |
+|---------|---------|--------|
+| Coverage strip | Under day headers (horizontal, 7 cells) | Relocated — one strip inside each day's Overview card |
+| Day-Overview panel | 7 horizontal day columns | Vertical stack, one day per row, collapsed by default |
+| Employee cards | Inline sidebar (260px) | Slide-in drawer (existing) |
+| Mini-week | Inside each card (14px cols) | Inside each card (28px cols) |
+| Overlay trigger | Hover on card + drag | Existing tap-select (no hover) |
+| Selected banner | N/A | Existing bottom banner reused |
+
+The mobile tap-to-assign flow already has an explicit "selected employee" state — the overlay reuses that state, so implementation is simpler on mobile than desktop.
+
+Touch targets: all interactive chips ≥ 32px tap target; mini-week day columns not tappable in v1 (visual only).
+
+## Visual Design (CLAUDE.md Apple/Notion scale)
+
+- Coverage bars: 5 density levels mapped to `hsl(var(--primary))` at 10%/30%/50%/70%/85% opacity.
+- Overview panel background: `bg-muted/30`, cards `bg-background border-border/40 rounded-xl`.
+- Mini-week track: `bg-muted/50`, bars at full role color (server/cook/dish/closer).
+- Overlay:
+  - highlight: `outline-primary`
+  - conflict: `bg-destructive/10` with stripe pattern, `outline-destructive`
+  - available: `bg-primary/5`
+- Typography follows CLAUDE.md: day labels `text-[12px] uppercase`, counts `text-[11px] tabular-nums`.
+
+## Testing Strategy
+
+### Unit tests (Vitest)
+- `src/lib/shiftAllocation.test.ts`
+  - `computeAllocationStatus` — highlight (exact match), conflict (partial overlap), available (no conflict), none (off-day).
+  - Edge cases: midnight-crossing shifts, zero-duration shifts, timezone boundaries.
+- `src/hooks/usePlannerShiftsIndex.test.ts`
+  - Coverage computation: empty week, one shift, multiple overlapping shifts, 5+ people at one hour.
+  - Overview packing: ≤3 shifts all fit, 5 shifts collapse 2 into "+2 more".
+  - `shiftsByEmployee` groups correctly.
+- `src/hooks/useSharedWeek.test.ts`
+  - Default to current Monday.
+  - Round-trips via URL.
+  - Non-Monday input normalizes to Monday.
+
+### Component tests (Vitest + Testing Library)
+- `<CoverageStrip>` with sample shifts → correct number of density classes applied.
+- `<OverviewDayCard>` with 0, 1, 4 shifts → renders empty state, single pill, "+1 more".
+- `<EmployeeMiniWeek>` with mixed role shifts → bars colored by role, off-day cells present.
+- `<ShiftCell>` with each `allocationStatus` → correct CSS classes and chip text.
+
+### E2E tests (Playwright)
+- **tab-week-sync.spec.ts**: navigate to Schedule tab, change to next week, switch to Planner tab, assert Planner shows the same week header.
+- **planner-allocation-overlay.spec.ts**: open Planner, assign employee A to Mon template, tap employee A again, assert Mon cell shows "already on" annotation.
+- **planner-mobile-overview.spec.ts** (emulated viewport): open Planner on iPhone viewport, assert Overview panel is collapsed by default, tap to expand, assert stacked day layout.
+
+### pgTAP
+- No new SQL — all changes are client-side derivations. No new RLS concerns.
+
+## Out of Scope / Deferred
+
+- **Option 3 — Group-by Employees view toggle.** Larger change, different mental model. Worth revisiting after 1+2 ship and we see whether they've addressed the blind spot.
+- **Option D — Coverage vs forecast overlay.** Depends on sales forecast confidence; StaffingOverlay already partly covers this. Defer.
+- **Clickable coverage bar → scroll Overview to that hour.** Nice-to-have.
+- **Mini-week click to filter or jump** — visual only for v1.
+- **Persisting collapsed state of Overview panel** — defer.
+
+## Success Criteria
+
+- Switching between Schedule and Planner tabs preserves the visible week. ✔
+- Reloading the Scheduling page preserves the visible week. ✔
+- A planner user can answer "is Jose already on Monday?" without opening any dialog or switching tabs — visible in <1 second. ✔
+- A planner user can identify coverage gaps on Tuesday without mental math. ✔
+- Attempting to double-book an employee shows visual conflict *before* drop/tap, not only in a post-hoc dialog. ✔
+- Mobile-viewport build passes all Playwright checks. ✔
+- TypeScript, lint, and full test suite green. ✔
+
+## Open Questions
+
+None — all design decisions resolved in brainstorming.
+
+## References
+
+- Existing code: `src/pages/Scheduling.tsx:331` (Schedule week state), `src/hooks/useShiftPlanner.ts:311` (Planner week state)
+- Existing mobile flow: `src/components/scheduling/ShiftPlanner/ShiftPlannerTab.tsx:504-564`
+- Mockups: `.superpowers/brainstorm/99138-1776812268/content/` (mobile-mockup.html, person-allocation-mockups.html, in-context-mockups.html)

--- a/src/components/CollaboratorInvitations.tsx
+++ b/src/components/CollaboratorInvitations.tsx
@@ -9,6 +9,7 @@ import { useToast } from '@/hooks/use-toast';
 import { Calculator, Package, ChefHat, Clock, CheckCircle, XCircle, Trash2, Check, ArrowLeft, UserPlus, Users, AlertCircle, RefreshCw } from 'lucide-react';
 import { COLLABORATOR_PRESETS, ROLE_METADATA } from '@/lib/permissions';
 import type { Role } from '@/lib/permissions';
+import { formatExpiresIn } from '@/lib/invitationUtils';
 import {
   useCollaboratorsQuery,
   useCollaboratorInvitesQuery,
@@ -44,7 +45,7 @@ export function CollaboratorInvitations({ restaurantId, userRole }: Collaborator
   const removeCollaboratorMutation = useRemoveCollaborator();
   const resendInvitationMutation = useResendCollaboratorInvitation();
   const [showCancelledInvites, setShowCancelledInvites] = useState(false);
-  const [resendingId, setResendingId] = useState<string | null>(null);
+  const [resendingIds, setResendingIds] = useState<Set<string>>(new Set());
 
   const handleSendInvitation = () => {
     if (!email || !selectedRole) {
@@ -84,16 +85,16 @@ export function CollaboratorInvitations({ restaurantId, userRole }: Collaborator
   };
 
   const handleResendInvitation = (invite: { id: string; email: string; role: string }) => {
-    setResendingId(invite.id);
+    setResendingIds(prev => new Set(prev).add(invite.id));
     resendInvitationMutation.mutate(
       { restaurantId, email: invite.email, role: invite.role as Role },
-      { onSettled: () => setResendingId(null) }
+      { onSettled: () => setResendingIds(prev => { const s = new Set(prev); s.delete(invite.id); return s; }) }
     );
   };
 
   const statusIcons = {
-    pending: <Clock className="h-4 w-4 text-yellow-500" />,
-    accepted: <CheckCircle className="h-4 w-4 text-green-500" />,
+    pending: <Clock className="h-4 w-4 text-muted-foreground" />,
+    accepted: <CheckCircle className="h-4 w-4 text-primary" />,
     expired: <XCircle className="h-4 w-4 text-destructive" />,
     cancelled: <XCircle className="h-4 w-4 text-muted-foreground" />,
   };
@@ -320,7 +321,7 @@ export function CollaboratorInvitations({ restaurantId, userRole }: Collaborator
         </CardContent>
       </Card>
 
-      {(invitesLoading || invitesError || pendingInvites?.some(i => i.status === 'pending' || i.status === 'expired')) && (
+      {(invitesLoading || invitesError || (pendingInvites && pendingInvites.length > 0)) && (
         <Card>
           <CardHeader>
             <CardTitle className="text-lg">Invitations</CardTitle>
@@ -371,7 +372,7 @@ export function CollaboratorInvitations({ restaurantId, userRole }: Collaborator
                             <p className="text-xs text-muted-foreground">
                               {isExpired
                                 ? `Expired — invited by ${invite.invitedBy || 'unknown'}`
-                                : `Invited by ${invite.invitedBy || 'unknown'} • Expires ${invite.expiresAt ? new Date(invite.expiresAt).toLocaleDateString() : 'never'}`}
+                                : `Invited by ${invite.invitedBy || 'unknown'} • ${invite.expiresAt ? formatExpiresIn(invite.expiresAt) : 'No expiry'}`}
                             </p>
                           </div>
                         </div>
@@ -396,11 +397,12 @@ export function CollaboratorInvitations({ restaurantId, userRole }: Collaborator
                               variant="ghost"
                               size="sm"
                               onClick={() => handleResendInvitation(invite)}
-                              disabled={resendingId === invite.id}
+                              disabled={resendingIds.has(invite.id)}
+                              aria-busy={resendingIds.has(invite.id)}
+                              aria-label={resendingIds.has(invite.id) ? `Sending invitation to ${invite.email}` : `Resend invitation to ${invite.email}`}
                               className="text-primary hover:text-primary hover:bg-primary/10"
-                              aria-label={`Resend invitation to ${invite.email}`}
                             >
-                              <RefreshCw className={`h-4 w-4 ${resendingId === invite.id ? 'animate-spin' : ''}`} />
+                              <RefreshCw className={`h-4 w-4 ${resendingIds.has(invite.id) ? 'animate-spin' : ''}`} />
                             </Button>
                           )}
                         </div>

--- a/src/components/CollaboratorInvitations.tsx
+++ b/src/components/CollaboratorInvitations.tsx
@@ -29,14 +29,13 @@ const roleIcons: Record<string, typeof Calculator> = {
   collaborator_chef: ChefHat,
 };
 
-export const CollaboratorInvitations = ({ restaurantId, userRole }: CollaboratorInvitationsProps) => {
+export function CollaboratorInvitations({ restaurantId, userRole }: CollaboratorInvitationsProps) {
   const [selectedRole, setSelectedRole] = useState<Role | null>(null);
   const [email, setEmail] = useState('');
   const { toast } = useToast();
 
   const canManage = userRole === 'owner' || userRole === 'manager';
 
-  // Use React Query hooks
   const { data: collaborators, isLoading: collaboratorsLoading, error: collaboratorsError } = useCollaboratorsQuery(restaurantId);
   const { data: pendingInvites, isLoading: invitesLoading, error: invitesError } = useCollaboratorInvitesQuery(restaurantId);
 
@@ -108,7 +107,6 @@ export const CollaboratorInvitations = ({ restaurantId, userRole }: Collaborator
 
   const cancelledInvites = pendingInvites?.filter(i => i.status === 'cancelled') ?? [];
 
-  // Render role selection cards
   const renderRoleSelection = () => (
     <div className="space-y-4">
       <div className="text-center mb-6">
@@ -159,7 +157,6 @@ export const CollaboratorInvitations = ({ restaurantId, userRole }: Collaborator
     </div>
   );
 
-  // Render email input for selected role
   const renderEmailInput = () => {
     const preset = COLLABORATOR_PRESETS.find(p => p.role === selectedRole);
     if (!preset) return null;
@@ -219,7 +216,6 @@ export const CollaboratorInvitations = ({ restaurantId, userRole }: Collaborator
 
   return (
     <div className="space-y-6">
-      {/* Invite New Collaborator */}
       {canManage && (
         <Card>
           <CardHeader>
@@ -241,7 +237,6 @@ export const CollaboratorInvitations = ({ restaurantId, userRole }: Collaborator
         </Card>
       )}
 
-      {/* Current Collaborators */}
       <Card>
         <CardHeader>
           <CardTitle className="text-lg">Active Collaborators</CardTitle>
@@ -325,7 +320,6 @@ export const CollaboratorInvitations = ({ restaurantId, userRole }: Collaborator
         </CardContent>
       </Card>
 
-      {/* Pending & Expired Invitations */}
       {(invitesLoading || invitesError || pendingInvites?.some(i => i.status === 'pending' || i.status === 'expired')) && (
         <Card>
           <CardHeader>
@@ -414,7 +408,6 @@ export const CollaboratorInvitations = ({ restaurantId, userRole }: Collaborator
                     );
                   })}
 
-                {/* Cancelled history toggle */}
                 {cancelledInvites.length > 0 && (
                   <>
                     <button
@@ -453,4 +446,4 @@ export const CollaboratorInvitations = ({ restaurantId, userRole }: Collaborator
       )}
     </div>
   );
-};
+}

--- a/src/components/CollaboratorInvitations.tsx
+++ b/src/components/CollaboratorInvitations.tsx
@@ -45,6 +45,7 @@ export const CollaboratorInvitations = ({ restaurantId, userRole }: Collaborator
   const removeCollaboratorMutation = useRemoveCollaborator();
   const resendInvitationMutation = useResendCollaboratorInvitation();
   const [showCancelledInvites, setShowCancelledInvites] = useState(false);
+  const [resendingId, setResendingId] = useState<string | null>(null);
 
   const handleSendInvitation = () => {
     if (!email || !selectedRole) {
@@ -83,18 +84,18 @@ export const CollaboratorInvitations = ({ restaurantId, userRole }: Collaborator
     });
   };
 
-  const handleResendInvitation = (invite: { email: string; role: string }) => {
-    resendInvitationMutation.mutate({
-      restaurantId,
-      email: invite.email,
-      role: invite.role as Role,
-    });
+  const handleResendInvitation = (invite: { id: string; email: string; role: string }) => {
+    setResendingId(invite.id);
+    resendInvitationMutation.mutate(
+      { restaurantId, email: invite.email, role: invite.role as Role },
+      { onSettled: () => setResendingId(null) }
+    );
   };
 
   const statusIcons = {
     pending: <Clock className="h-4 w-4 text-yellow-500" />,
     accepted: <CheckCircle className="h-4 w-4 text-green-500" />,
-    expired: <XCircle className="h-4 w-4 text-red-500" />,
+    expired: <XCircle className="h-4 w-4 text-destructive" />,
     cancelled: <XCircle className="h-4 w-4 text-muted-foreground" />,
   };
 
@@ -104,6 +105,8 @@ export const CollaboratorInvitations = ({ restaurantId, userRole }: Collaborator
     expired: "destructive",
     cancelled: "outline",
   } as const;
+
+  const cancelledInvites = pendingInvites?.filter(i => i.status === 'cancelled') ?? [];
 
   // Render role selection cards
   const renderRoleSelection = () => (
@@ -326,9 +329,9 @@ export const CollaboratorInvitations = ({ restaurantId, userRole }: Collaborator
       {(invitesLoading || invitesError || pendingInvites?.some(i => i.status === 'pending' || i.status === 'expired')) && (
         <Card>
           <CardHeader>
-            <CardTitle className="text-lg">Pending Invitations</CardTitle>
+            <CardTitle className="text-lg">Invitations</CardTitle>
             <CardDescription>
-              Collaborator invitations waiting to be accepted
+              Pending and expired collaborator invitations
             </CardDescription>
           </CardHeader>
           <CardContent>
@@ -374,7 +377,7 @@ export const CollaboratorInvitations = ({ restaurantId, userRole }: Collaborator
                             <p className="text-xs text-muted-foreground">
                               {isExpired
                                 ? `Expired — invited by ${invite.invitedBy || 'unknown'}`
-                                : `Invited by ${invite.invitedBy} • Expires ${invite.expiresAt ? new Date(invite.expiresAt).toLocaleDateString() : 'never'}`}
+                                : `Invited by ${invite.invitedBy || 'unknown'} • Expires ${invite.expiresAt ? new Date(invite.expiresAt).toLocaleDateString() : 'never'}`}
                             </p>
                           </div>
                         </div>
@@ -399,11 +402,11 @@ export const CollaboratorInvitations = ({ restaurantId, userRole }: Collaborator
                               variant="ghost"
                               size="sm"
                               onClick={() => handleResendInvitation(invite)}
-                              disabled={resendInvitationMutation.isPending}
+                              disabled={resendingId === invite.id}
                               className="text-primary hover:text-primary hover:bg-primary/10"
                               aria-label={`Resend invitation to ${invite.email}`}
                             >
-                              <RefreshCw className={`h-4 w-4 ${resendInvitationMutation.isPending ? 'animate-spin' : ''}`} />
+                              <RefreshCw className={`h-4 w-4 ${resendingId === invite.id ? 'animate-spin' : ''}`} />
                             </Button>
                           )}
                         </div>
@@ -412,41 +415,37 @@ export const CollaboratorInvitations = ({ restaurantId, userRole }: Collaborator
                   })}
 
                 {/* Cancelled history toggle */}
-                {(() => {
-                  const cancelled = pendingInvites?.filter(i => i.status === 'cancelled') ?? [];
-                  if (cancelled.length === 0) return null;
-                  return (
-                    <>
-                      <button
-                        type="button"
-                        aria-expanded={showCancelledInvites}
-                        onClick={() => setShowCancelledInvites(prev => !prev)}
-                        className="w-full text-center text-xs text-muted-foreground hover:text-foreground py-1 transition-colors"
-                      >
-                        {showCancelledInvites ? 'Hide cancelled' : `Show cancelled (${cancelled.length})`}
-                      </button>
-                      {showCancelledInvites && cancelled.map((invite) => {
-                        const Icon = roleIcons[invite.role] || Calculator;
-                        return (
-                          <div key={invite.id} className="flex items-center justify-between p-3 border rounded-lg opacity-50">
-                            <div className="flex items-center gap-3">
-                              <div className="p-2 rounded-lg bg-muted">
-                                <Icon className="h-4 w-4" />
-                              </div>
-                              <div>
-                                <p className="font-medium text-sm">{invite.email}</p>
-                                <p className="text-xs text-muted-foreground">Cancelled</p>
-                              </div>
+                {cancelledInvites.length > 0 && (
+                  <>
+                    <button
+                      type="button"
+                      aria-expanded={showCancelledInvites}
+                      onClick={() => setShowCancelledInvites(prev => !prev)}
+                      className="w-full text-center text-xs text-muted-foreground hover:text-foreground py-1 transition-colors"
+                    >
+                      {showCancelledInvites ? 'Hide cancelled' : `Show cancelled (${cancelledInvites.length})`}
+                    </button>
+                    {showCancelledInvites && cancelledInvites.map((invite) => {
+                      const Icon = roleIcons[invite.role] || Calculator;
+                      return (
+                        <div key={invite.id} className="flex items-center justify-between p-3 border rounded-lg opacity-50">
+                          <div className="flex items-center gap-3">
+                            <div className="p-2 rounded-lg bg-muted">
+                              <Icon className="h-4 w-4" />
                             </div>
-                            <Badge variant="outline">
-                              <span className="capitalize">{invite.status}</span>
-                            </Badge>
+                            <div>
+                              <p className="font-medium text-sm">{invite.email}</p>
+                              <p className="text-xs text-muted-foreground">Cancelled</p>
+                            </div>
                           </div>
-                        );
-                      })}
-                    </>
-                  );
-                })()}
+                          <Badge variant="outline">
+                            <span className="capitalize">{invite.status}</span>
+                          </Badge>
+                        </div>
+                      );
+                    })}
+                  </>
+                )}
               </div>
             )}
           </CardContent>

--- a/src/components/CollaboratorInvitations.tsx
+++ b/src/components/CollaboratorInvitations.tsx
@@ -253,7 +253,7 @@ export const CollaboratorInvitations = ({ restaurantId, userRole }: Collaborator
           {collaboratorsLoading ? (
             <div className="space-y-3">
               {[1, 2].map((i) => (
-                <div key={i} className="flex items-center justify-between p-3 border rounded-lg">
+                <div key={i} className="flex items-center justify-between p-3 border border-border/40 rounded-xl">
                   <div className="flex items-center gap-3">
                     <Skeleton className="h-8 w-8 rounded-lg" />
                     <div className="space-y-2">
@@ -279,7 +279,7 @@ export const CollaboratorInvitations = ({ restaurantId, userRole }: Collaborator
                 return (
                   <div
                     key={collab.id}
-                    className="flex items-center justify-between p-3 border rounded-lg"
+                    className="flex items-center justify-between p-3 border border-border/40 rounded-xl hover:border-border transition-colors"
                   >
                     <div className="flex items-center gap-3">
                       <div className="p-2 rounded-lg bg-muted">
@@ -338,7 +338,7 @@ export const CollaboratorInvitations = ({ restaurantId, userRole }: Collaborator
             {invitesLoading ? (
               <div className="space-y-3">
                 {[1, 2].map((i) => (
-                  <div key={i} className="flex items-center justify-between p-3 border rounded-lg">
+                  <div key={i} className="flex items-center justify-between p-3 border border-border/40 rounded-xl">
                     <div className="flex items-center gap-3">
                       <Skeleton className="h-8 w-8 rounded-lg" />
                       <div className="space-y-2">
@@ -366,7 +366,7 @@ export const CollaboratorInvitations = ({ restaurantId, userRole }: Collaborator
                     return (
                       <div
                         key={invite.id}
-                        className="flex items-center justify-between p-3 border rounded-lg"
+                        className="flex items-center justify-between p-3 border border-border/40 rounded-xl hover:border-border transition-colors"
                       >
                         <div className="flex items-center gap-3">
                           <div className="p-2 rounded-lg bg-muted">
@@ -428,7 +428,7 @@ export const CollaboratorInvitations = ({ restaurantId, userRole }: Collaborator
                     {showCancelledInvites && cancelledInvites.map((invite) => {
                       const Icon = roleIcons[invite.role] || Calculator;
                       return (
-                        <div key={invite.id} className="flex items-center justify-between p-3 border rounded-lg opacity-50">
+                        <div key={invite.id} className="flex items-center justify-between p-3 border border-border/40 rounded-xl opacity-50">
                           <div className="flex items-center gap-3">
                             <div className="p-2 rounded-lg bg-muted">
                               <Icon className="h-4 w-4" />

--- a/src/components/CollaboratorInvitations.tsx
+++ b/src/components/CollaboratorInvitations.tsx
@@ -6,7 +6,7 @@ import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useToast } from '@/hooks/use-toast';
-import { Calculator, Package, ChefHat, Clock, CheckCircle, XCircle, Trash2, Check, ArrowLeft, UserPlus, Users, AlertCircle } from 'lucide-react';
+import { Calculator, Package, ChefHat, Clock, CheckCircle, XCircle, Trash2, Check, ArrowLeft, UserPlus, Users, AlertCircle, RefreshCw } from 'lucide-react';
 import { COLLABORATOR_PRESETS, ROLE_METADATA } from '@/lib/permissions';
 import type { Role } from '@/lib/permissions';
 import {
@@ -15,6 +15,7 @@ import {
   useSendCollaboratorInvitation,
   useCancelCollaboratorInvitation,
   useRemoveCollaborator,
+  useResendCollaboratorInvitation,
 } from '@/hooks/useCollaborators';
 
 interface CollaboratorInvitationsProps {
@@ -42,6 +43,8 @@ export const CollaboratorInvitations = ({ restaurantId, userRole }: Collaborator
   const sendInvitationMutation = useSendCollaboratorInvitation();
   const cancelInvitationMutation = useCancelCollaboratorInvitation();
   const removeCollaboratorMutation = useRemoveCollaborator();
+  const resendInvitationMutation = useResendCollaboratorInvitation();
+  const [showCancelledInvites, setShowCancelledInvites] = useState(false);
 
   const handleSendInvitation = () => {
     if (!email || !selectedRole) {
@@ -77,6 +80,14 @@ export const CollaboratorInvitations = ({ restaurantId, userRole }: Collaborator
       collaboratorId,
       collaboratorEmail,
       restaurantId,
+    });
+  };
+
+  const handleResendInvitation = (invite: { email: string; role: string }) => {
+    resendInvitationMutation.mutate({
+      restaurantId,
+      email: invite.email,
+      role: invite.role as Role,
     });
   };
 
@@ -311,8 +322,8 @@ export const CollaboratorInvitations = ({ restaurantId, userRole }: Collaborator
         </CardContent>
       </Card>
 
-      {/* Pending Invitations */}
-      {(invitesLoading || invitesError || pendingInvites?.some(i => i.status === 'pending')) && (
+      {/* Pending & Expired Invitations */}
+      {(invitesLoading || invitesError || pendingInvites?.some(i => i.status === 'pending' || i.status === 'expired')) && (
         <Card>
           <CardHeader>
             <CardTitle className="text-lg">Pending Invitations</CardTitle>
@@ -344,9 +355,10 @@ export const CollaboratorInvitations = ({ restaurantId, userRole }: Collaborator
             ) : (
               <div className="space-y-3">
                 {pendingInvites
-                  ?.filter(invite => invite.status === 'pending')
+                  ?.filter(invite => invite.status === 'pending' || invite.status === 'expired')
                   .map((invite) => {
                     const Icon = roleIcons[invite.role] || Calculator;
+                    const isExpired = invite.status === 'expired';
 
                     return (
                       <div
@@ -360,10 +372,9 @@ export const CollaboratorInvitations = ({ restaurantId, userRole }: Collaborator
                           <div>
                             <p className="font-medium text-sm">{invite.email}</p>
                             <p className="text-xs text-muted-foreground">
-                              Invited by {invite.invitedBy} • Expires{' '}
-                              {invite.expiresAt
-                                ? new Date(invite.expiresAt).toLocaleDateString()
-                                : 'never'}
+                              {isExpired
+                                ? `Expired — invited by ${invite.invitedBy || 'unknown'}`
+                                : `Invited by ${invite.invitedBy} • Expires ${invite.expiresAt ? new Date(invite.expiresAt).toLocaleDateString() : 'never'}`}
                             </p>
                           </div>
                         </div>
@@ -383,10 +394,59 @@ export const CollaboratorInvitations = ({ restaurantId, userRole }: Collaborator
                               <Trash2 className="h-4 w-4" />
                             </Button>
                           )}
+                          {canManage && invite.status === 'expired' && (
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => handleResendInvitation(invite)}
+                              disabled={resendInvitationMutation.isPending}
+                              className="text-primary hover:text-primary hover:bg-primary/10"
+                              aria-label={`Resend invitation to ${invite.email}`}
+                            >
+                              <RefreshCw className={`h-4 w-4 ${resendInvitationMutation.isPending ? 'animate-spin' : ''}`} />
+                            </Button>
+                          )}
                         </div>
                       </div>
                     );
                   })}
+
+                {/* Cancelled history toggle */}
+                {(() => {
+                  const cancelled = pendingInvites?.filter(i => i.status === 'cancelled') ?? [];
+                  if (cancelled.length === 0) return null;
+                  return (
+                    <>
+                      <button
+                        type="button"
+                        aria-expanded={showCancelledInvites}
+                        onClick={() => setShowCancelledInvites(prev => !prev)}
+                        className="w-full text-center text-xs text-muted-foreground hover:text-foreground py-1 transition-colors"
+                      >
+                        {showCancelledInvites ? 'Hide cancelled' : `Show cancelled (${cancelled.length})`}
+                      </button>
+                      {showCancelledInvites && cancelled.map((invite) => {
+                        const Icon = roleIcons[invite.role] || Calculator;
+                        return (
+                          <div key={invite.id} className="flex items-center justify-between p-3 border rounded-lg opacity-50">
+                            <div className="flex items-center gap-3">
+                              <div className="p-2 rounded-lg bg-muted">
+                                <Icon className="h-4 w-4" />
+                              </div>
+                              <div>
+                                <p className="font-medium text-sm">{invite.email}</p>
+                                <p className="text-xs text-muted-foreground">Cancelled</p>
+                              </div>
+                            </div>
+                            <Badge variant="outline">
+                              <span className="capitalize">{invite.status}</span>
+                            </Badge>
+                          </div>
+                        );
+                      })}
+                    </>
+                  );
+                })()}
               </div>
             )}
           </CardContent>

--- a/src/components/TeamInvitations.tsx
+++ b/src/components/TeamInvitations.tsx
@@ -36,6 +36,7 @@ export const TeamInvitations = ({ restaurantId, userRole }: TeamInvitationsProps
   });
   const [sending, setSending] = useState(false);
   const [resendingIds, setResendingIds] = useState<Set<string>>(new Set());
+  const [showHistory, setShowHistory] = useState(false);
   const { toast } = useToast();
 
   const canManageInvites = userRole === 'owner' || userRole === 'manager';
@@ -185,6 +186,14 @@ export const TeamInvitations = ({ restaurantId, userRole }: TeamInvitationsProps
     cancelled: "outline",
   } as const;
 
+  const activeInvitations = invitations.filter(
+    inv => inv.status === 'pending' || inv.status === 'expired'
+  );
+  const historyInvitations = invitations.filter(
+    inv => inv.status === 'accepted' || inv.status === 'cancelled'
+  );
+  const visibleInvitations = showHistory ? invitations : activeInvitations;
+
   return (
     <Card>
       <CardHeader>
@@ -266,7 +275,7 @@ export const TeamInvitations = ({ restaurantId, userRole }: TeamInvitationsProps
           </div>
         ) : invitations.length > 0 ? (
           <div className="space-y-3 md:space-y-4">
-            {invitations.map((invitation) => (
+            {visibleInvitations.map((invitation) => (
               <div key={invitation.id} className="flex flex-col sm:flex-row sm:items-center gap-3 p-3 md:p-4 border rounded-lg">
                 <div className="flex items-start gap-3 flex-1 min-w-0">
                   <Mail className="h-5 w-5 text-muted-foreground mt-0.5 flex-shrink-0" />
@@ -284,13 +293,13 @@ export const TeamInvitations = ({ restaurantId, userRole }: TeamInvitationsProps
                     </div>
                   </div>
                 </div>
-                
+
                 <div className="flex items-center justify-between sm:justify-end gap-2 sm:gap-3">
                   <Badge variant={statusColors[invitation.status]} className="flex items-center gap-1 text-xs">
                     {statusIcons[invitation.status]}
                     <span className="capitalize">{invitation.status}</span>
                   </Badge>
-                  
+
                   {canManageInvites && invitation.status === 'pending' && (
                     <Button
                       variant="ghost"
@@ -317,6 +326,21 @@ export const TeamInvitations = ({ restaurantId, userRole }: TeamInvitationsProps
                 </div>
               </div>
             ))}
+            {visibleInvitations.length === 0 && (
+              <p className="text-sm text-muted-foreground text-center py-2">
+                All invitations are in history.
+              </p>
+            )}
+            {historyInvitations.length > 0 && (
+              <button
+                onClick={() => setShowHistory(prev => !prev)}
+                className="w-full text-center text-xs text-muted-foreground hover:text-foreground py-2 transition-colors"
+              >
+                {showHistory
+                  ? 'Hide history'
+                  : `Show history (${historyInvitations.length})`}
+              </button>
+            )}
           </div>
         ) : (
           <div className="text-center py-6 md:py-8">

--- a/src/components/TeamInvitations.tsx
+++ b/src/components/TeamInvitations.tsx
@@ -8,7 +8,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
-import { Mail, Plus, Clock, CheckCircle, XCircle, Trash2 } from 'lucide-react';
+import { Mail, Plus, Clock, CheckCircle, XCircle, Trash2, RefreshCw } from 'lucide-react';
+import { formatExpiresIn } from '@/lib/invitationUtils';
 
 interface Invitation {
   id: string;
@@ -34,6 +35,7 @@ export const TeamInvitations = ({ restaurantId, userRole }: TeamInvitationsProps
     role: 'staff',
   });
   const [sending, setSending] = useState(false);
+  const [resendingIds, setResendingIds] = useState<Set<string>>(new Set());
   const { toast } = useToast();
 
   const canManageInvites = userRole === 'owner' || userRole === 'manager';
@@ -152,6 +154,22 @@ export const TeamInvitations = ({ restaurantId, userRole }: TeamInvitationsProps
     }
   };
 
+  const resendInvitation = async (invitation: Invitation) => {
+    setResendingIds(prev => new Set(prev).add(invitation.id));
+    try {
+      const { error } = await supabase.functions.invoke('send-team-invitation', {
+        body: { restaurantId, email: invitation.email, role: invitation.role },
+      });
+      if (error) throw error;
+      toast({ title: 'Invitation resent', description: `New invite sent to ${invitation.email}` });
+      fetchInvitations();
+    } catch {
+      toast({ title: 'Error', description: 'Failed to resend invitation', variant: 'destructive' });
+    } finally {
+      setResendingIds(prev => { const s = new Set(prev); s.delete(invitation.id); return s; });
+    }
+  };
+
   const statusIcons = {
     pending: <Clock className="h-4 w-4 text-yellow-500" />,
     accepted: <CheckCircle className="h-4 w-4 text-green-500" />,
@@ -257,10 +275,9 @@ export const TeamInvitations = ({ restaurantId, userRole }: TeamInvitationsProps
                         Invited as <span className="capitalize font-medium">{invitation.role}</span> by {invitation.invitedBy}
                       </p>
                       <p>
-                        {new Date(invitation.createdAt).toLocaleDateString()}
-                        {invitation.expiresAt && (
-                          <span> • Expires {new Date(invitation.expiresAt).toLocaleDateString()}</span>
-                        )}
+                        {invitation.expiresAt && (invitation.status === 'pending' || invitation.status === 'expired')
+                          ? formatExpiresIn(invitation.expiresAt)
+                          : new Date(invitation.createdAt).toLocaleDateString()}
                       </p>
                     </div>
                   </div>
@@ -273,13 +290,26 @@ export const TeamInvitations = ({ restaurantId, userRole }: TeamInvitationsProps
                   </Badge>
                   
                   {canManageInvites && invitation.status === 'pending' && (
-                    <Button 
-                      variant="ghost" 
+                    <Button
+                      variant="ghost"
                       size="sm"
                       onClick={() => deleteInvitation(invitation.id, invitation.email)}
                       className="text-destructive hover:text-destructive hover:bg-destructive/10 p-2"
+                      aria-label={`Cancel invitation for ${invitation.email}`}
                     >
                       <Trash2 className="h-4 w-4" />
+                    </Button>
+                  )}
+                  {canManageInvites && invitation.status === 'expired' && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => resendInvitation(invitation)}
+                      disabled={resendingIds.has(invitation.id)}
+                      className="text-primary hover:text-primary hover:bg-primary/10 p-2"
+                      aria-label={`Resend invitation to ${invitation.email}`}
+                    >
+                      <RefreshCw className={`h-4 w-4 ${resendingIds.has(invitation.id) ? 'animate-spin' : ''}`} />
                     </Button>
                   )}
                 </div>

--- a/src/components/TeamInvitations.tsx
+++ b/src/components/TeamInvitations.tsx
@@ -217,7 +217,13 @@ export const TeamInvitations = ({ restaurantId, userRole }: TeamInvitationsProps
           </div>
           
           {canManageInvites && (
-            <Dialog open={isDialogOpen} onOpenChange={(open) => { setIsDialogOpen(open); if (!open) setPendingConflict(false); }}>
+            <Dialog open={isDialogOpen} onOpenChange={(open) => {
+              setIsDialogOpen(open);
+              if (!open) {
+                setPendingConflict(false);
+                setInviteForm({ email: '', role: 'staff' });
+              }
+            }}>
               <DialogTrigger asChild>
                 <Button className="flex items-center gap-2 w-full sm:w-auto" size="sm">
                   <Plus className="h-4 w-4" />
@@ -240,7 +246,10 @@ export const TeamInvitations = ({ restaurantId, userRole }: TeamInvitationsProps
                       type="email"
                       placeholder="Enter email address"
                       value={inviteForm.email}
-                      onChange={(e) => setInviteForm({ ...inviteForm, email: e.target.value })}
+                      onChange={(e) => {
+                        setPendingConflict(false);
+                        setInviteForm({ ...inviteForm, email: e.target.value });
+                      }}
                     />
                   </div>
                   
@@ -274,7 +283,7 @@ export const TeamInvitations = ({ restaurantId, userRole }: TeamInvitationsProps
                   </div>
                 )}
                 <DialogFooter>
-                  <Button variant="outline" onClick={() => setIsDialogOpen(false)}>
+                  <Button variant="outline" onClick={() => { setIsDialogOpen(false); setPendingConflict(false); }}>
                     Cancel
                   </Button>
                   <Button onClick={sendInvitation} disabled={sending}>

--- a/src/components/TeamInvitations.tsx
+++ b/src/components/TeamInvitations.tsx
@@ -42,6 +42,7 @@ export const TeamInvitations = ({ restaurantId, userRole }: TeamInvitationsProps
   const canManageInvites = userRole === 'owner' || userRole === 'manager';
 
   useEffect(() => {
+    setShowHistory(false);
     fetchInvitations();
   }, [restaurantId]);
 
@@ -333,6 +334,8 @@ export const TeamInvitations = ({ restaurantId, userRole }: TeamInvitationsProps
             )}
             {historyInvitations.length > 0 && (
               <button
+                type="button"
+                aria-expanded={showHistory}
                 onClick={() => setShowHistory(prev => !prev)}
                 className="w-full text-center text-xs text-muted-foreground hover:text-foreground py-2 transition-colors"
               >

--- a/src/components/TeamInvitations.tsx
+++ b/src/components/TeamInvitations.tsx
@@ -230,36 +230,44 @@ export const TeamInvitations = ({ restaurantId, userRole }: TeamInvitationsProps
                   <span className="sm:inline">Send Invitation</span>
                 </Button>
               </DialogTrigger>
-              <DialogContent>
-                <DialogHeader>
-                  <DialogTitle>Invite Team Member</DialogTitle>
-                  <DialogDescription>
-                    Send an invitation to join your restaurant team
-                  </DialogDescription>
+              <DialogContent className="max-w-md p-0 gap-0 border-border/40">
+                <DialogHeader className="px-6 pt-6 pb-4 border-b border-border/40">
+                  <div className="flex items-center gap-3">
+                    <div className="h-10 w-10 rounded-xl bg-muted/50 flex items-center justify-center">
+                      <Mail className="h-5 w-5 text-foreground" />
+                    </div>
+                    <div>
+                      <DialogTitle className="text-[17px] font-semibold text-foreground">Invite Team Member</DialogTitle>
+                      <DialogDescription className="text-[13px] text-muted-foreground mt-0.5">
+                        Send an invitation to join your restaurant team
+                      </DialogDescription>
+                    </div>
+                  </div>
                 </DialogHeader>
-                
-                <div className="space-y-4">
-                  <div>
-                    <Label htmlFor="email">Email Address</Label>
+
+                <div className="px-6 py-5 space-y-4">
+                  <div className="space-y-1.5">
+                    <Label htmlFor="email" className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">Email Address</Label>
                     <Input
                       id="email"
                       type="email"
                       placeholder="Enter email address"
                       value={inviteForm.email}
+                      className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
                       onChange={(e) => {
                         setPendingConflict(false);
                         setInviteForm({ ...inviteForm, email: e.target.value });
                       }}
                     />
                   </div>
-                  
-                  <div>
-                    <Label htmlFor="role">Role</Label>
+
+                  <div className="space-y-1.5">
+                    <Label htmlFor="role" className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">Role</Label>
                     <Select
                       value={inviteForm.role}
                       onValueChange={(value) => setInviteForm({ ...inviteForm, role: value })}
                     >
-                      <SelectTrigger>
+                      <SelectTrigger className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg">
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
@@ -272,21 +280,22 @@ export const TeamInvitations = ({ restaurantId, userRole }: TeamInvitationsProps
                       </SelectContent>
                     </Select>
                   </div>
+
+                  {pendingConflict && (
+                    <div className="flex items-start gap-2 p-3 rounded-lg bg-amber-500/10 border border-amber-500/20 text-[13px]">
+                      <Clock className="h-4 w-4 text-muted-foreground mt-0.5 flex-shrink-0" />
+                      <p className="text-foreground">
+                        A pending invite for <strong>{inviteForm.email}</strong> already exists. Sending a new one will cancel the old link.
+                      </p>
+                    </div>
+                  )}
                 </div>
-                
-                {pendingConflict && (
-                  <div className="flex items-start gap-2 p-3 rounded-lg bg-amber-500/10 border border-amber-500/20 text-[13px]">
-                    <Clock className="h-4 w-4 text-muted-foreground mt-0.5 flex-shrink-0" />
-                    <p className="text-foreground">
-                      A pending invite for <strong>{inviteForm.email}</strong> already exists. Sending a new one will cancel the old link.
-                    </p>
-                  </div>
-                )}
-                <DialogFooter>
-                  <Button variant="outline" onClick={() => { setIsDialogOpen(false); setPendingConflict(false); }}>
+
+                <DialogFooter className="px-6 py-4 border-t border-border/40">
+                  <Button variant="outline" className="h-9 px-4 rounded-lg text-[13px] font-medium" onClick={() => { setIsDialogOpen(false); setPendingConflict(false); }}>
                     Cancel
                   </Button>
-                  <Button onClick={sendInvitation} disabled={sending}>
+                  <Button onClick={sendInvitation} disabled={sending} className="h-9 px-4 rounded-lg text-[13px] font-medium bg-foreground text-background hover:bg-foreground/90">
                     {sending ? 'Sending...' : pendingConflict ? 'Yes, resend anyway' : 'Send Invitation'}
                   </Button>
                 </DialogFooter>
@@ -304,7 +313,7 @@ export const TeamInvitations = ({ restaurantId, userRole }: TeamInvitationsProps
         ) : invitations.length > 0 ? (
           <div className="space-y-3 md:space-y-4">
             {visibleInvitations.map((invitation) => (
-              <div key={invitation.id} className="flex flex-col sm:flex-row sm:items-center gap-3 p-3 md:p-4 border rounded-lg">
+              <div key={invitation.id} className="flex flex-col sm:flex-row sm:items-center gap-3 p-3 md:p-4 border border-border/40 rounded-xl hover:border-border transition-colors">
                 <div className="flex items-start gap-3 flex-1 min-w-0">
                   <Mail className="h-5 w-5 text-muted-foreground mt-0.5 flex-shrink-0" />
                   <div className="flex-1 min-w-0">

--- a/src/components/TeamInvitations.tsx
+++ b/src/components/TeamInvitations.tsx
@@ -37,6 +37,7 @@ export const TeamInvitations = ({ restaurantId, userRole }: TeamInvitationsProps
   const [sending, setSending] = useState(false);
   const [resendingIds, setResendingIds] = useState<Set<string>>(new Set());
   const [showHistory, setShowHistory] = useState(false);
+  const [pendingConflict, setPendingConflict] = useState(false);
   const { toast } = useToast();
 
   const canManageInvites = userRole === 'owner' || userRole === 'manager';
@@ -124,6 +125,15 @@ export const TeamInvitations = ({ restaurantId, userRole }: TeamInvitationsProps
       return;
     }
 
+    const hasConflict = invitations.some(
+      inv => inv.email.toLowerCase() === inviteForm.email.toLowerCase() && inv.status === 'pending'
+    );
+    if (hasConflict && !pendingConflict) {
+      setPendingConflict(true);
+      return;
+    }
+    setPendingConflict(false);
+
     setSending(true);
     try {
       // Call edge function to send invitation email
@@ -207,7 +217,7 @@ export const TeamInvitations = ({ restaurantId, userRole }: TeamInvitationsProps
           </div>
           
           {canManageInvites && (
-            <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+            <Dialog open={isDialogOpen} onOpenChange={(open) => { setIsDialogOpen(open); if (!open) setPendingConflict(false); }}>
               <DialogTrigger asChild>
                 <Button className="flex items-center gap-2 w-full sm:w-auto" size="sm">
                   <Plus className="h-4 w-4" />
@@ -255,12 +265,20 @@ export const TeamInvitations = ({ restaurantId, userRole }: TeamInvitationsProps
                   </div>
                 </div>
                 
+                {pendingConflict && (
+                  <div className="flex items-start gap-2 p-3 rounded-lg bg-amber-500/10 border border-amber-500/20 text-[13px]">
+                    <Clock className="h-4 w-4 text-muted-foreground mt-0.5 flex-shrink-0" />
+                    <p className="text-foreground">
+                      A pending invite for <strong>{inviteForm.email}</strong> already exists. Sending a new one will cancel the old link.
+                    </p>
+                  </div>
+                )}
                 <DialogFooter>
                   <Button variant="outline" onClick={() => setIsDialogOpen(false)}>
                     Cancel
                   </Button>
                   <Button onClick={sendInvitation} disabled={sending}>
-                    {sending ? 'Sending...' : 'Send Invitation'}
+                    {sending ? 'Sending...' : pendingConflict ? 'Yes, resend anyway' : 'Send Invitation'}
                   </Button>
                 </DialogFooter>
               </DialogContent>

--- a/src/components/TeamInvitations.tsx
+++ b/src/components/TeamInvitations.tsx
@@ -19,6 +19,7 @@ interface Invitation {
   createdAt: string;
   expiresAt?: string;
   invitedBy?: string;
+  employeeId?: string;
 }
 
 interface TeamInvitationsProps {
@@ -38,6 +39,7 @@ export function TeamInvitations({ restaurantId, userRole }: TeamInvitationsProps
   const [resendingIds, setResendingIds] = useState<Set<string>>(new Set());
   const [showHistory, setShowHistory] = useState(false);
   const [pendingConflict, setPendingConflict] = useState(false);
+  const [resendConflictId, setResendConflictId] = useState<string | null>(null);
   const { toast } = useToast();
 
   const canManageInvites = userRole === 'owner' || userRole === 'manager';
@@ -72,7 +74,8 @@ export function TeamInvitations({ restaurantId, userRole }: TeamInvitationsProps
         status: inv.status as 'pending' | 'accepted' | 'expired' | 'cancelled',
         createdAt: inv.created_at,
         expiresAt: inv.expires_at,
-        invitedBy: profilesMap.get(inv.invited_by)?.full_name || 'Unknown'
+        invitedBy: profilesMap.get(inv.invited_by)?.full_name || 'Unknown',
+        employeeId: inv.employee_id ?? undefined,
       }));
 
       setInvitations(formattedInvitations);
@@ -164,12 +167,20 @@ export function TeamInvitations({ restaurantId, userRole }: TeamInvitationsProps
     }
   };
 
-  const resendInvitation = async (invitation: Invitation) => {
+  const resendInvitation = async (invitation: Invitation, confirmed = false) => {
+    const hasPendingConflict = invitations.some(
+      inv => inv.email.toLowerCase() === invitation.email.toLowerCase() && inv.status === 'pending'
+    );
+    if (hasPendingConflict && !confirmed) {
+      setResendConflictId(invitation.id);
+      return;
+    }
+    setResendConflictId(null);
     setResendingIds(prev => new Set(prev).add(invitation.id));
     try {
-      const { error } = await supabase.functions.invoke('send-team-invitation', {
-        body: { restaurantId, email: invitation.email, role: invitation.role },
-      });
+      const body: Record<string, unknown> = { restaurantId, email: invitation.email, role: invitation.role };
+      if (invitation.employeeId) body.employeeId = invitation.employeeId;
+      const { error } = await supabase.functions.invoke('send-team-invitation', { body });
       if (error) throw error;
       toast({ title: 'Invitation resent', description: `New invite sent to ${invitation.email}` });
       fetchInvitations();
@@ -182,8 +193,8 @@ export function TeamInvitations({ restaurantId, userRole }: TeamInvitationsProps
   };
 
   const statusIcons = {
-    pending: <Clock className="h-4 w-4 text-yellow-500" />,
-    accepted: <CheckCircle className="h-4 w-4 text-green-500" />,
+    pending: <Clock className="h-4 w-4 text-muted-foreground" />,
+    accepted: <CheckCircle className="h-4 w-4 text-primary" />,
     expired: <XCircle className="h-4 w-4 text-destructive" />,
     cancelled: null,
   };
@@ -311,54 +322,77 @@ export function TeamInvitations({ restaurantId, userRole }: TeamInvitationsProps
         ) : invitations.length > 0 ? (
           <div className="space-y-3 md:space-y-4">
             {visibleInvitations.map((invitation) => (
-              <div key={invitation.id} className="flex flex-col sm:flex-row sm:items-center gap-3 p-3 md:p-4 border border-border/40 rounded-xl hover:border-border transition-colors">
-                <div className="flex items-start gap-3 flex-1 min-w-0">
-                  <Mail className="h-5 w-5 text-muted-foreground mt-0.5 flex-shrink-0" />
-                  <div className="flex-1 min-w-0">
-                    <p className="font-medium text-sm md:text-base truncate">{invitation.email}</p>
-                    <div className="text-xs md:text-sm text-muted-foreground space-y-1">
-                      <p className="truncate">
-                        Invited as <span className="capitalize font-medium">{invitation.role}</span> by {invitation.invitedBy}
-                      </p>
-                      <p>
-                        {invitation.expiresAt && (invitation.status === 'pending' || invitation.status === 'expired')
-                          ? formatExpiresIn(invitation.expiresAt)
-                          : new Date(invitation.createdAt).toLocaleDateString()}
-                      </p>
+              <div key={invitation.id} className="border border-border/40 rounded-xl hover:border-border transition-colors">
+                <div className="flex flex-col sm:flex-row sm:items-center gap-3 p-3 md:p-4">
+                  <div className="flex items-start gap-3 flex-1 min-w-0">
+                    <Mail className="h-5 w-5 text-muted-foreground mt-0.5 flex-shrink-0" />
+                    <div className="flex-1 min-w-0">
+                      <p className="font-medium text-sm md:text-base truncate">{invitation.email}</p>
+                      <div className="text-xs md:text-sm text-muted-foreground space-y-1">
+                        <p className="truncate">
+                          Invited as <span className="capitalize font-medium">{invitation.role}</span> by {invitation.invitedBy}
+                        </p>
+                        <p>
+                          {invitation.expiresAt && (invitation.status === 'pending' || invitation.status === 'expired')
+                            ? formatExpiresIn(invitation.expiresAt)
+                            : new Date(invitation.createdAt).toLocaleDateString()}
+                        </p>
+                      </div>
                     </div>
                   </div>
-                </div>
 
-                <div className="flex items-center justify-between sm:justify-end gap-2 sm:gap-3">
-                  <Badge variant={statusColors[invitation.status]} className="flex items-center gap-1 text-xs">
-                    {statusIcons[invitation.status]}
-                    <span className="capitalize">{invitation.status}</span>
-                  </Badge>
+                  <div className="flex items-center justify-between sm:justify-end gap-2 sm:gap-3">
+                    <Badge variant={statusColors[invitation.status]} className="flex items-center gap-1 text-xs">
+                      {statusIcons[invitation.status]}
+                      <span className="capitalize">{invitation.status}</span>
+                    </Badge>
 
-                  {canManageInvites && invitation.status === 'pending' && (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => deleteInvitation(invitation.id, invitation.email)}
-                      className="text-destructive hover:text-destructive hover:bg-destructive/10 p-2"
-                      aria-label={`Cancel invitation for ${invitation.email}`}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
-                  )}
-                  {canManageInvites && invitation.status === 'expired' && (
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => resendInvitation(invitation)}
-                      disabled={resendingIds.has(invitation.id)}
-                      className="text-primary hover:text-primary hover:bg-primary/10 p-2"
-                      aria-label={`Resend invitation to ${invitation.email}`}
-                    >
-                      <RefreshCw className={`h-4 w-4 ${resendingIds.has(invitation.id) ? 'animate-spin' : ''}`} />
-                    </Button>
-                  )}
+                    {canManageInvites && invitation.status === 'pending' && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => deleteInvitation(invitation.id, invitation.email)}
+                        className="text-destructive hover:text-destructive hover:bg-destructive/10 p-2"
+                        aria-label={`Cancel invitation for ${invitation.email}`}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    )}
+                    {canManageInvites && invitation.status === 'expired' && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => resendConflictId === invitation.id
+                          ? resendInvitation(invitation, true)
+                          : resendInvitation(invitation)
+                        }
+                        disabled={resendingIds.has(invitation.id)}
+                        aria-busy={resendingIds.has(invitation.id)}
+                        aria-label={
+                          resendingIds.has(invitation.id)
+                            ? `Sending invitation to ${invitation.email}`
+                            : resendConflictId === invitation.id
+                              ? `Confirm resend to ${invitation.email}, cancelling existing pending invite`
+                              : `Resend invitation to ${invitation.email}`
+                        }
+                        className={
+                          resendConflictId === invitation.id
+                            ? 'text-amber-600 hover:text-amber-600 hover:bg-amber-500/10 p-2'
+                            : 'text-primary hover:text-primary hover:bg-primary/10 p-2'
+                        }
+                      >
+                        <RefreshCw className={`h-4 w-4 ${resendingIds.has(invitation.id) ? 'animate-spin' : ''}`} />
+                      </Button>
+                    )}
+                  </div>
                 </div>
+                {resendConflictId === invitation.id && (
+                  <div className="px-3 pb-3 md:px-4">
+                    <p className="text-[11px] text-amber-600">
+                      A pending invite for this email already exists. Click again to cancel it and resend.
+                    </p>
+                  </div>
+                )}
               </div>
             ))}
             {visibleInvitations.length === 0 && (

--- a/src/components/TeamInvitations.tsx
+++ b/src/components/TeamInvitations.tsx
@@ -163,7 +163,8 @@ export const TeamInvitations = ({ restaurantId, userRole }: TeamInvitationsProps
       if (error) throw error;
       toast({ title: 'Invitation resent', description: `New invite sent to ${invitation.email}` });
       fetchInvitations();
-    } catch {
+    } catch (err) {
+      console.error('Error resending invitation:', err);
       toast({ title: 'Error', description: 'Failed to resend invitation', variant: 'destructive' });
     } finally {
       setResendingIds(prev => { const s = new Set(prev); s.delete(invitation.id); return s; });
@@ -173,7 +174,8 @@ export const TeamInvitations = ({ restaurantId, userRole }: TeamInvitationsProps
   const statusIcons = {
     pending: <Clock className="h-4 w-4 text-yellow-500" />,
     accepted: <CheckCircle className="h-4 w-4 text-green-500" />,
-    expired: <XCircle className="h-4 w-4 text-red-500" />,
+    expired: <XCircle className="h-4 w-4 text-destructive" />,
+    cancelled: null,
   };
 
   const statusColors = {

--- a/src/components/TeamInvitations.tsx
+++ b/src/components/TeamInvitations.tsx
@@ -26,7 +26,7 @@ interface TeamInvitationsProps {
   userRole: string;
 }
 
-export const TeamInvitations = ({ restaurantId, userRole }: TeamInvitationsProps) => {
+export function TeamInvitations({ restaurantId, userRole }: TeamInvitationsProps) {
   const [invitations, setInvitations] = useState<Invitation[]>([]);
   const [loading, setLoading] = useState(true);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
@@ -57,7 +57,6 @@ export const TeamInvitations = ({ restaurantId, userRole }: TeamInvitationsProps
 
       if (error) throw error;
 
-      // Get profile information for invited_by users
       const invitedByIds = [...new Set(invitations.map(inv => inv.invited_by))];
       const { data: profiles } = await supabase
         .from('profiles')
@@ -136,7 +135,6 @@ export const TeamInvitations = ({ restaurantId, userRole }: TeamInvitationsProps
 
     setSending(true);
     try {
-      // Call edge function to send invitation email
       const { data, error } = await supabase.functions.invoke('send-team-invitation', {
         body: {
           restaurantId,
@@ -396,4 +394,4 @@ export const TeamInvitations = ({ restaurantId, userRole }: TeamInvitationsProps
       </CardContent>
     </Card>
   );
-};
+}

--- a/src/hooks/useCollaborators.ts
+++ b/src/hooks/useCollaborators.ts
@@ -261,3 +261,35 @@ export const useRemoveCollaborator = () => {
     },
   });
 };
+
+/**
+ * Resends an expired invitation to a collaborator
+ */
+export const useResendCollaboratorInvitation = () => {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async ({ restaurantId, email, role }: SendInvitationParams) => {
+      const { error } = await supabase.functions.invoke('send-team-invitation', {
+        body: { restaurantId, email, role },
+      });
+      if (error) throw error;
+      return { email, role, restaurantId };
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['collaborator-invites', data.restaurantId] });
+      toast({
+        title: 'Invitation resent',
+        description: `New invite sent to ${data.email}`,
+      });
+    },
+    onError: (error: Error) => {
+      toast({
+        title: 'Error resending invitation',
+        description: error.message || 'Failed to resend invitation',
+        variant: 'destructive',
+      });
+    },
+  });
+};

--- a/src/hooks/useCollaborators.ts
+++ b/src/hooks/useCollaborators.ts
@@ -275,10 +275,10 @@ export const useResendCollaboratorInvitation = () => {
         body: { restaurantId, email, role },
       });
       if (error) throw error;
-      return { email, role, restaurantId };
+      return { email, role };
     },
-    onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ['collaborator-invites', data.restaurantId] });
+    onSuccess: (data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['collaborator-invites', variables.restaurantId] });
       toast({
         title: 'Invitation resent',
         description: `New invite sent to ${data.email}`,

--- a/src/hooks/useCollaborators.ts
+++ b/src/hooks/useCollaborators.ts
@@ -22,13 +22,6 @@ export interface PendingInvite {
   invitedBy?: string;
 }
 
-// ============================================================
-// Query Hooks
-// ============================================================
-
-/**
- * Fetches all collaborators (users with collaborator_* roles) for a restaurant
- */
 export const useCollaboratorsQuery = (restaurantId: string | null) => {
   return useQuery({
     queryKey: ['collaborators', restaurantId],
@@ -75,15 +68,12 @@ export const useCollaboratorsQuery = (restaurantId: string | null) => {
       }));
     },
     enabled: !!restaurantId,
-    staleTime: 30000, // 30 seconds
+    staleTime: 30000,
     refetchOnWindowFocus: true,
     refetchOnMount: true,
   });
 };
 
-/**
- * Fetches pending collaborator invitations for a restaurant
- */
 export const useCollaboratorInvitesQuery = (restaurantId: string | null) => {
   return useQuery({
     queryKey: ['collaborator-invites', restaurantId],
@@ -127,15 +117,11 @@ export const useCollaboratorInvitesQuery = (restaurantId: string | null) => {
       }));
     },
     enabled: !!restaurantId,
-    staleTime: 30000, // 30 seconds
+    staleTime: 30000,
     refetchOnWindowFocus: true,
     refetchOnMount: true,
   });
 };
-
-// ============================================================
-// Mutation Hooks
-// ============================================================
 
 interface SendInvitationParams {
   restaurantId: string;
@@ -143,9 +129,6 @@ interface SendInvitationParams {
   role: Role;
 }
 
-/**
- * Sends an invitation to a collaborator
- */
 export const useSendCollaboratorInvitation = () => {
   const queryClient = useQueryClient();
   const { toast } = useToast();
@@ -186,9 +169,6 @@ interface CancelInvitationParams {
   restaurantId: string;
 }
 
-/**
- * Cancels a pending invitation
- */
 export const useCancelCollaboratorInvitation = () => {
   const queryClient = useQueryClient();
   const { toast } = useToast();
@@ -227,9 +207,6 @@ interface RemoveCollaboratorParams {
   restaurantId: string;
 }
 
-/**
- * Removes a collaborator from a restaurant
- */
 export const useRemoveCollaborator = () => {
   const queryClient = useQueryClient();
   const { toast } = useToast();
@@ -262,9 +239,6 @@ export const useRemoveCollaborator = () => {
   });
 };
 
-/**
- * Resends an expired invitation to a collaborator
- */
 export const useResendCollaboratorInvitation = () => {
   const queryClient = useQueryClient();
   const { toast } = useToast();

--- a/src/lib/invitationUtils.ts
+++ b/src/lib/invitationUtils.ts
@@ -1,9 +1,13 @@
+const DAY_MS = 1000 * 60 * 60 * 24;
+
 export function formatExpiresIn(expiresAt: string): string {
-  const ms = new Date(expiresAt).getTime() - Date.now();
-  const days = Math.round(ms / (1000 * 60 * 60 * 24));
+  const expiresDate = new Date(expiresAt);
+  if (isNaN(expiresDate.getTime())) return 'Unknown expiration';
+  const ms = expiresDate.getTime() - Date.now();
+  const days = ms >= 0 ? Math.floor(ms / DAY_MS) : Math.ceil(ms / DAY_MS);
   if (days > 1) return `Expires in ${days} days`;
   if (days === 1) return 'Expires tomorrow';
-  if (days === 0) return ms > 0 ? 'Expires today' : 'Expired yesterday';
+  if (days === 0) return ms >= 0 ? 'Expires today' : 'Expired today';
   if (days === -1) return 'Expired yesterday';
   return `Expired ${Math.abs(days)} days ago`;
 }

--- a/src/lib/invitationUtils.ts
+++ b/src/lib/invitationUtils.ts
@@ -1,0 +1,13 @@
+export function formatExpiresIn(expiresAt: string): string {
+  const ms = new Date(expiresAt).getTime() - Date.now();
+  const days = Math.round(ms / (1000 * 60 * 60 * 24));
+  if (days > 1) return `Expires in ${days} days`;
+  if (days === 1) return 'Expires tomorrow';
+  if (days === 0) return ms > 0 ? 'Expires today' : 'Expired yesterday';
+  if (days === -1) return 'Expired yesterday';
+  return `Expired ${Math.abs(days)} days ago`;
+}
+
+export function classifyInvitationError(message: string): 'expired' | 'invalid' {
+  return message === 'Invitation has expired' ? 'expired' : 'invalid';
+}

--- a/src/pages/AcceptInvitation.tsx
+++ b/src/pages/AcceptInvitation.tsx
@@ -13,6 +13,14 @@ import { GoogleSignInButton } from '@/components/GoogleSignInButton';
 import { Separator } from '@/components/ui/separator';
 import { classifyInvitationError } from '@/lib/invitationUtils';
 
+interface InvitationDetails {
+  email: string;
+  role: string;
+  restaurant: { name: string; address?: string } | null;
+  invited_by: string;
+  expires_at: string;
+}
+
 export function AcceptInvitation() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
@@ -21,7 +29,7 @@ export function AcceptInvitation() {
   const [loading, setLoading] = useState(false);
   const [accepting, setAccepting] = useState(false);
   const [authSubmitting, setAuthSubmitting] = useState(false);
-  const [invitation, setInvitation] = useState<any>(null);
+  const [invitation, setInvitation] = useState<InvitationDetails | null>(null);
   const [status, setStatus] = useState<'loading' | 'valid' | 'invalid' | 'expired' | 'accepted' | 'needs_auth'>('loading');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -95,9 +103,9 @@ export function AcceptInvitation() {
       } else {
         throw new Error(data.error || 'Invalid invitation');
       }
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.error('Error validating invitation:', err);
-      setStatus(classifyInvitationError(err?.message || ''));
+      setStatus(classifyInvitationError(err instanceof Error ? err.message : ''));
     } finally {
       setLoading(false);
     }

--- a/src/pages/AcceptInvitation.tsx
+++ b/src/pages/AcceptInvitation.tsx
@@ -13,14 +13,14 @@ import { GoogleSignInButton } from '@/components/GoogleSignInButton';
 import { Separator } from '@/components/ui/separator';
 import { classifyInvitationError } from '@/lib/invitationUtils';
 
-export const AcceptInvitation = () => {
+export function AcceptInvitation() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const { toast } = useToast();
   const { user, loading: authLoading } = useAuth();
   const [loading, setLoading] = useState(false);
   const [accepting, setAccepting] = useState(false);
-  const [authLoading2, setAuthLoading2] = useState(false);
+  const [authSubmitting, setAuthLoading2] = useState(false);
   const [invitation, setInvitation] = useState<any>(null);
   const [status, setStatus] = useState<'loading' | 'valid' | 'invalid' | 'expired' | 'accepted' | 'error' | 'needs_auth'>('loading');
   const [email, setEmail] = useState('');
@@ -38,7 +38,6 @@ export const AcceptInvitation = () => {
 
   useEffect(() => {
     if (user && invitation && user.email === invitation.email) {
-      // For existing users signing in, accept the invitation
       if (status === 'valid') {
         acceptInvitation();
       }
@@ -68,10 +67,9 @@ export const AcceptInvitation = () => {
 
       if (data.success) {
         setInvitation(data.invitation);
-        setEmail(data.invitation.email); // Pre-fill email
-        
+        setEmail(data.invitation.email);
+
         if (user) {
-          // User is already authenticated, check email match
           if (user.email === data.invitation.email) {
             setStatus('valid');
           } else {
@@ -83,7 +81,6 @@ export const AcceptInvitation = () => {
             setStatus('invalid');
           }
         } else {
-          // User needs to authenticate
           setStatus('needs_auth');
         }
       } else {
@@ -115,7 +112,6 @@ export const AcceptInvitation = () => {
           description: data.message,
         });
 
-        // Immediate redirect to dashboard
         navigate('/');
       } else {
         throw new Error(data.error || 'Failed to accept invitation');
@@ -143,8 +139,7 @@ export const AcceptInvitation = () => {
       });
       
       if (error) throw error;
-      
-      // Update status to valid so useEffect can accept the invitation
+
       setStatus('valid');
     } catch (error: any) {
       toast({
@@ -178,7 +173,6 @@ export const AcceptInvitation = () => {
     setAuthLoading2(true);
 
     try {
-      // Validate email matches invitation
       if (email !== invitation?.email) {
         toast({
           title: "Email Mismatch",
@@ -188,7 +182,6 @@ export const AcceptInvitation = () => {
         return;
       }
 
-      // Use special signup function that bypasses email confirmation and accepts invitation
       const { data, error } = await supabase.functions.invoke('signup-with-invitation', {
         body: {
           email,
@@ -198,18 +191,15 @@ export const AcceptInvitation = () => {
         }
       });
 
-      if (error) {
-        throw error;
-      }
+      if (error) throw error;
 
       if (data.success) {
         toast({
           title: "Account Created!",
           description: `${data.message} Please sign in to continue.`,
         });
-        // Switch to sign-in mode after successful signup
         setShowSignIn(true);
-        setPassword(''); // Clear password field
+        setPassword('');
       } else {
         throw new Error(data.error || 'Failed to create account');
       }
@@ -305,7 +295,6 @@ export const AcceptInvitation = () => {
     );
   }
 
-  // Show authenticated user's invitation
   if (status === 'valid' && user) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-primary/5 to-secondary/5">
@@ -376,7 +365,6 @@ export const AcceptInvitation = () => {
     );
   }
 
-  // Show invitation details with authentication required - NEW USER FOCUSED FLOW
   if (status === 'needs_auth' && invitation) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-primary/5 to-secondary/5 p-4">
@@ -404,17 +392,15 @@ export const AcceptInvitation = () => {
             </div>
 
             {!showSignIn ? (
-              /* NEW USER SIGNUP - PRIMARY FLOW */
               <div className="space-y-4">
                 <div className="text-center">
                   <h4 className="font-medium mb-2">Create Your Account</h4>
                   <p className="text-sm text-muted-foreground">Join the team instantly - no email verification needed!</p>
                 </div>
 
-                {/* Google Sign-In Option */}
-                <GoogleSignInButton 
+                <GoogleSignInButton
                   onClick={handleGoogleAuth}
-                  disabled={authLoading2}
+                  disabled={authSubmitting}
                   text="continue"
                 />
 
@@ -464,8 +450,8 @@ export const AcceptInvitation = () => {
                       minLength={6}
                     />
                   </div>
-                  <Button type="submit" className="w-full" disabled={authLoading2}>
-                    {authLoading2 ? "Creating Account..." : "Join Team"}
+                  <Button type="submit" className="w-full" disabled={authSubmitting}>
+                    {authSubmitting ? "Creating Account..." : "Join Team"}
                   </Button>
                 </form>
 
@@ -481,7 +467,6 @@ export const AcceptInvitation = () => {
                 </div>
               </div>
             ) : (
-              /* EXISTING USER SIGN IN - SECONDARY FLOW */
               <div className="space-y-4">
                 <div className="flex items-center gap-2 mb-4">
                   <Button 
@@ -498,10 +483,9 @@ export const AcceptInvitation = () => {
                   </div>
                 </div>
 
-                {/* Google Sign-In Option */}
-                <GoogleSignInButton 
+                <GoogleSignInButton
                   onClick={handleGoogleAuth}
-                  disabled={authLoading2}
+                  disabled={authSubmitting}
                   text="signin"
                 />
 
@@ -539,8 +523,8 @@ export const AcceptInvitation = () => {
                       placeholder="Enter your password"
                     />
                   </div>
-                  <Button type="submit" className="w-full" disabled={authLoading2}>
-                    {authLoading2 ? "Signing In..." : "Sign In & Join Team"}
+                  <Button type="submit" className="w-full" disabled={authSubmitting}>
+                    {authSubmitting ? "Signing In..." : "Sign In & Join Team"}
                   </Button>
                 </form>
               </div>
@@ -556,4 +540,4 @@ export const AcceptInvitation = () => {
   }
 
   return null;
-};
+}

--- a/src/pages/AcceptInvitation.tsx
+++ b/src/pages/AcceptInvitation.tsx
@@ -11,6 +11,7 @@ import { signInWithOAuthNative } from '@/utils/nativeRedirect';
 import { CheckCircle, XCircle, Clock, Users, Building, ArrowLeft } from 'lucide-react';
 import { GoogleSignInButton } from '@/components/GoogleSignInButton';
 import { Separator } from '@/components/ui/separator';
+import { classifyInvitationError } from '@/lib/invitationUtils';
 
 export const AcceptInvitation = () => {
   const [searchParams] = useSearchParams();
@@ -21,7 +22,7 @@ export const AcceptInvitation = () => {
   const [accepting, setAccepting] = useState(false);
   const [authLoading2, setAuthLoading2] = useState(false);
   const [invitation, setInvitation] = useState<any>(null);
-  const [status, setStatus] = useState<'loading' | 'valid' | 'invalid' | 'accepted' | 'error' | 'needs_auth'>('loading');
+  const [status, setStatus] = useState<'loading' | 'valid' | 'invalid' | 'expired' | 'accepted' | 'error' | 'needs_auth'>('loading');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [fullName, setFullName] = useState('');
@@ -86,11 +87,11 @@ export const AcceptInvitation = () => {
           setStatus('needs_auth');
         }
       } else {
-        throw new Error(data.error || 'Invalid invitation');
+        throw new Error(data.error || '');
       }
     } catch (error: any) {
       console.error('Error validating invitation:', error);
-      setStatus('invalid');
+      setStatus(classifyInvitationError(error?.message || ''));
     } finally {
       setLoading(false);
     }
@@ -235,6 +236,29 @@ export const AcceptInvitation = () => {
             <CardTitle>Loading Invitation</CardTitle>
             <CardDescription>Please wait while we validate your invitation...</CardDescription>
           </CardHeader>
+        </Card>
+      </div>
+    );
+  }
+
+  if (status === 'expired') {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-primary/5 to-secondary/5">
+        <Card className="w-full max-w-md">
+          <CardHeader className="text-center">
+            <div className="mx-auto mb-4 w-12 h-12 rounded-full bg-amber-100 flex items-center justify-center">
+              <Clock className="w-6 h-6 text-amber-600" />
+            </div>
+            <CardTitle>Invitation Expired</CardTitle>
+            <CardDescription>
+              This invitation link is no longer valid. Ask your manager to resend it from the Team page.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="text-center">
+            <Button onClick={() => navigate('/')}>
+              Go to Dashboard
+            </Button>
+          </CardContent>
         </Card>
       </div>
     );

--- a/src/pages/AcceptInvitation.tsx
+++ b/src/pages/AcceptInvitation.tsx
@@ -292,10 +292,10 @@ export const AcceptInvitation = () => {
       <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-primary/5 to-secondary/5">
         <Card className="w-full max-w-md">
           <CardHeader className="text-center">
-            <div className="mx-auto mb-4 w-12 h-12 rounded-full bg-green-100 flex items-center justify-center">
-              <CheckCircle className="w-6 h-6 text-green-600" />
+            <div className="mx-auto mb-4 w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center">
+              <CheckCircle className="w-6 h-6 text-primary" />
             </div>
-            <CardTitle className="text-green-600">Welcome to the Team!</CardTitle>
+            <CardTitle>Welcome to the Team!</CardTitle>
             <CardDescription>
               You've successfully joined {invitation?.restaurant?.name}! Redirecting to dashboard...
             </CardDescription>

--- a/src/pages/AcceptInvitation.tsx
+++ b/src/pages/AcceptInvitation.tsx
@@ -20,7 +20,7 @@ export function AcceptInvitation() {
   const { user, loading: authLoading } = useAuth();
   const [loading, setLoading] = useState(false);
   const [accepting, setAccepting] = useState(false);
-  const [authSubmitting, setAuthLoading2] = useState(false);
+  const [authSubmitting, setAuthSubmitting] = useState(false);
   const [invitation, setInvitation] = useState<any>(null);
   const [status, setStatus] = useState<'loading' | 'valid' | 'invalid' | 'expired' | 'accepted' | 'error' | 'needs_auth'>('loading');
   const [email, setEmail] = useState('');
@@ -130,7 +130,7 @@ export function AcceptInvitation() {
 
   const handleSignIn = async (e: React.FormEvent) => {
     e.preventDefault();
-    setAuthLoading2(true);
+    setAuthSubmitting(true);
 
     try {
       const { error } = await supabase.auth.signInWithPassword({
@@ -148,12 +148,12 @@ export function AcceptInvitation() {
         variant: "destructive",
       });
     } finally {
-      setAuthLoading2(false);
+      setAuthSubmitting(false);
     }
   };
 
   const handleGoogleAuth = async () => {
-    setAuthLoading2(true);
+    setAuthSubmitting(true);
     try {
       const { error } = await signInWithOAuthNative('google', `/accept-invitation?token=${encodeURIComponent(token)}`);
 
@@ -164,13 +164,13 @@ export function AcceptInvitation() {
         description: error.message || "Failed to sign in with Google",
         variant: "destructive",
       });
-      setAuthLoading2(false);
+      setAuthSubmitting(false);
     }
   };
 
   const handleSignUp = async (e: React.FormEvent) => {
     e.preventDefault();
-    setAuthLoading2(true);
+    setAuthSubmitting(true);
 
     try {
       if (email !== invitation?.email) {
@@ -211,7 +211,7 @@ export function AcceptInvitation() {
         variant: "destructive",
       });
     } finally {
-      setAuthLoading2(false);
+      setAuthSubmitting(false);
     }
   };
 

--- a/src/pages/AcceptInvitation.tsx
+++ b/src/pages/AcceptInvitation.tsx
@@ -246,8 +246,8 @@ export const AcceptInvitation = () => {
       <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-primary/5 to-secondary/5">
         <Card className="w-full max-w-md">
           <CardHeader className="text-center">
-            <div className="mx-auto mb-4 w-12 h-12 rounded-full bg-amber-100 flex items-center justify-center">
-              <Clock className="w-6 h-6 text-amber-600" />
+            <div className="mx-auto mb-4 w-12 h-12 rounded-full bg-muted flex items-center justify-center">
+              <Clock className="w-6 h-6 text-muted-foreground" />
             </div>
             <CardTitle>Invitation Expired</CardTitle>
             <CardDescription>
@@ -274,7 +274,7 @@ export const AcceptInvitation = () => {
             </div>
             <CardTitle>Invalid Invitation</CardTitle>
             <CardDescription>
-              This invitation is invalid, expired, or has already been used.
+              This invitation is invalid or has already been used.
             </CardDescription>
           </CardHeader>
           <CardContent className="text-center">

--- a/src/pages/AcceptInvitation.tsx
+++ b/src/pages/AcceptInvitation.tsx
@@ -22,7 +22,7 @@ export function AcceptInvitation() {
   const [accepting, setAccepting] = useState(false);
   const [authSubmitting, setAuthSubmitting] = useState(false);
   const [invitation, setInvitation] = useState<any>(null);
-  const [status, setStatus] = useState<'loading' | 'valid' | 'invalid' | 'expired' | 'accepted' | 'error' | 'needs_auth'>('loading');
+  const [status, setStatus] = useState<'loading' | 'valid' | 'invalid' | 'expired' | 'accepted' | 'needs_auth'>('loading');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [fullName, setFullName] = useState('');
@@ -63,7 +63,16 @@ export function AcceptInvitation() {
         body: { token }
       });
 
-      if (error) throw error;
+      if (error) {
+        let errorMessage = error?.message || '';
+        if (error?.context) {
+          try {
+            const body = await error.context.json();
+            errorMessage = body?.error || errorMessage;
+          } catch {}
+        }
+        throw new Error(errorMessage);
+      }
 
       if (data.success) {
         setInvitation(data.invitation);
@@ -84,11 +93,11 @@ export function AcceptInvitation() {
           setStatus('needs_auth');
         }
       } else {
-        throw new Error(data.error || '');
+        throw new Error(data.error || 'Invalid invitation');
       }
-    } catch (error: any) {
-      console.error('Error validating invitation:', error);
-      setStatus(classifyInvitationError(error?.message || ''));
+    } catch (err: any) {
+      console.error('Error validating invitation:', err);
+      setStatus(classifyInvitationError(err?.message || ''));
     } finally {
       setLoading(false);
     }

--- a/supabase/functions/validate-invitation/index.ts
+++ b/supabase/functions/validate-invitation/index.ts
@@ -97,16 +97,18 @@ const handler = async (req: Request): Promise<Response> => {
     );
   } catch (error: any) {
     console.error('Error validating invitation:', error);
+    const knownErrors = ['Invitation has expired', 'Invalid or expired invitation', 'Missing token'];
+    const isApplicationError = knownErrors.includes(error.message);
     return new Response(
-      JSON.stringify({ 
+      JSON.stringify({
         error: error.message,
-        success: false 
+        success: false
       }),
       {
-        status: 500,
-        headers: { 
-          'Content-Type': 'application/json', 
-          ...corsHeaders 
+        status: isApplicationError ? 200 : 500,
+        headers: {
+          'Content-Type': 'application/json',
+          ...corsHeaders
         },
       }
     );

--- a/supabase/functions/validate-invitation/index.ts
+++ b/supabase/functions/validate-invitation/index.ts
@@ -103,8 +103,9 @@ const handler = async (req: Request): Promise<Response> => {
       'Invitation has expired': 410,
     };
     const status = statusMap[error.message] ?? 500;
+    const responseMessage = status === 500 ? 'An unexpected error occurred' : error.message;
     return new Response(
-      JSON.stringify({ error: error.message, success: false }),
+      JSON.stringify({ error: responseMessage, success: false }),
       { status, headers: { 'Content-Type': 'application/json', ...corsHeaders } }
     );
   }

--- a/supabase/functions/validate-invitation/index.ts
+++ b/supabase/functions/validate-invitation/index.ts
@@ -97,20 +97,15 @@ const handler = async (req: Request): Promise<Response> => {
     );
   } catch (error: any) {
     console.error('Error validating invitation:', error);
-    const knownErrors = ['Invitation has expired', 'Invalid or expired invitation', 'Missing token'];
-    const isApplicationError = knownErrors.includes(error.message);
+    const statusMap: Record<string, number> = {
+      'Missing token': 400,
+      'Invalid or expired invitation': 404,
+      'Invitation has expired': 410,
+    };
+    const status = statusMap[error.message] ?? 500;
     return new Response(
-      JSON.stringify({
-        error: error.message,
-        success: false
-      }),
-      {
-        status: isApplicationError ? 200 : 500,
-        headers: {
-          'Content-Type': 'application/json',
-          ...corsHeaders
-        },
-      }
+      JSON.stringify({ error: error.message, success: false }),
+      { status, headers: { 'Content-Type': 'application/json', ...corsHeaders } }
     );
   }
 };

--- a/supabase/tests/open_shift_claim_timezone.test.sql
+++ b/supabase/tests/open_shift_claim_timezone.test.sql
@@ -20,12 +20,21 @@ ALTER TABLE staffing_settings DISABLE ROW LEVEL SECURITY;
 ALTER TABLE schedule_publications DISABLE ROW LEVEL SECURITY;
 ALTER TABLE open_shift_claims DISABLE ROW LEVEL SECURITY;
 
+-- Compute a target Sunday that is always in the future.
+-- Formula: CURRENT_DATE + (7 - DOW) gives the next Sunday from today;
+-- when today is Sunday (DOW=0), adds 7 to avoid using today.
+CREATE TEMP TABLE test_config AS
+SELECT
+  CURRENT_DATE + (7 - EXTRACT(DOW FROM CURRENT_DATE)::int) AS target_sunday,
+  (CURRENT_DATE + (7 - EXTRACT(DOW FROM CURRENT_DATE)::int))::timestamp + interval '15 hours 30 minutes' AS local_start,
+  (CURRENT_DATE + (7 - EXTRACT(DOW FROM CURRENT_DATE)::int))::timestamp + interval '22 hours' AS local_end;
+
 -- Auth user for FK references
 INSERT INTO auth.users (id, email)
 VALUES ('dddddddd-d001-0000-0000-000000000001', 'tz-test@example.com')
 ON CONFLICT DO NOTHING;
 
--- Restaurant in CDT timezone (UTC-5 in April)
+-- Restaurant in CDT timezone (UTC-5 in summer, UTC-6 in winter)
 INSERT INTO restaurants (id, name, timezone)
 VALUES ('aaaaaaaa-a001-0000-0000-000000000001', 'TZ Test Restaurant', 'America/Chicago')
 ON CONFLICT (id) DO NOTHING;
@@ -64,18 +73,19 @@ VALUES ('aaaaaaaa-a001-0000-0000-000000000001', true, false)
 ON CONFLICT (restaurant_id) DO UPDATE
 SET open_shifts_enabled = true, require_shift_claim_approval = false;
 
--- Publish schedule for April 13-19, 2026 (Sun Apr 19 is day-of-week 0)
+-- Publish schedule for the week ending on target_sunday
 INSERT INTO schedule_publications (restaurant_id, week_start_date, week_end_date, published_by, shift_count)
-VALUES (
+SELECT
   'aaaaaaaa-a001-0000-0000-000000000001',
-  '2026-04-13', '2026-04-19',
+  target_sunday - 6,
+  target_sunday,
   'dddddddd-d001-0000-0000-000000000001',
   0
-);
+FROM test_config;
 
 -- ============================================
 -- Test 1: claim_open_shift (instant) creates shift with correct UTC start
--- In April, CDT = UTC-5. Template 15:30 local → 20:30 UTC
+-- Template 15:30 local → UTC equivalent depends on DST at target date
 -- ============================================
 
 SELECT is(
@@ -85,7 +95,7 @@ SELECT is(
       SELECT claim_open_shift(
         'aaaaaaaa-a001-0000-0000-000000000001',
         'bbbbbbbb-b001-0000-0000-000000000001',
-        '2026-04-19'::date,
+        (SELECT target_sunday FROM test_config),
         'cccccccc-c001-0000-0000-000000000001'
       ) AS result
     ) sub
@@ -95,7 +105,7 @@ SELECT is(
 );
 
 -- ============================================
--- Test 2: Resulting shift start_time is 20:30 UTC (15:30 CDT), not 15:30 UTC
+-- Test 2: Resulting shift start_time matches 15:30 local converted to UTC
 -- ============================================
 
 SELECT is(
@@ -107,12 +117,12 @@ SELECT is(
       AND source = 'template'
     ORDER BY created_at DESC LIMIT 1
   ),
-  '2026-04-19 20:30:00+00'::timestamptz,
-  'claim shift start_time is 20:30 UTC (15:30 CDT), not 15:30 UTC'
+  (SELECT local_start AT TIME ZONE 'America/Chicago' FROM test_config),
+  'claim shift start_time matches 15:30 local converted to UTC'
 );
 
 -- ============================================
--- Test 3: Resulting shift end_time is 03:00 UTC next day (22:00 CDT)
+-- Test 3: Resulting shift end_time matches 22:00 local converted to UTC
 -- ============================================
 
 SELECT is(
@@ -124,8 +134,8 @@ SELECT is(
       AND source = 'template'
     ORDER BY created_at DESC LIMIT 1
   ),
-  '2026-04-20 03:00:00+00'::timestamptz,
-  'claim shift end_time is 03:00 UTC next day (22:00 CDT), not 22:00 UTC'
+  (SELECT local_end AT TIME ZONE 'America/Chicago' FROM test_config),
+  'claim shift end_time matches 22:00 local converted to UTC'
 );
 
 -- ============================================
@@ -137,10 +147,10 @@ SELECT is(
     SELECT open_spots
     FROM get_open_shifts(
       'aaaaaaaa-a001-0000-0000-000000000001',
-      '2026-04-13'::date,
-      '2026-04-19'::date
+      (SELECT target_sunday - 6 FROM test_config),
+      (SELECT target_sunday FROM test_config)
     )
-    WHERE shift_date = '2026-04-19'
+    WHERE shift_date = (SELECT target_sunday FROM test_config)
     LIMIT 1
   ),
   2::bigint,
@@ -149,27 +159,27 @@ SELECT is(
 
 -- ============================================
 -- Test 5: Planner-created shift (proper UTC) is also counted by get_open_shifts
--- Insert a shift as if created by the planner: 15:30 CDT = 20:30 UTC
+-- Insert a shift as if created by the planner: 15:30 local = UTC equivalent
 -- ============================================
 
 INSERT INTO shifts (restaurant_id, employee_id, start_time, end_time, position, status, source)
-VALUES (
+SELECT
   'aaaaaaaa-a001-0000-0000-000000000001',
   'cccccccc-c001-0000-0000-000000000002',
-  '2026-04-19 20:30:00+00',  -- 15:30 CDT as proper UTC
-  '2026-04-20 03:00:00+00',  -- 22:00 CDT as proper UTC
+  local_start AT TIME ZONE 'America/Chicago',
+  local_end AT TIME ZONE 'America/Chicago',
   'Server', 'scheduled', 'manual'
-);
+FROM test_config;
 
 SELECT is(
   (
     SELECT open_spots
     FROM get_open_shifts(
       'aaaaaaaa-a001-0000-0000-000000000001',
-      '2026-04-13'::date,
-      '2026-04-19'::date
+      (SELECT target_sunday - 6 FROM test_config),
+      (SELECT target_sunday FROM test_config)
     )
-    WHERE shift_date = '2026-04-19'
+    WHERE shift_date = (SELECT target_sunday FROM test_config)
     LIMIT 1
   ),
   1::bigint,
@@ -201,7 +211,7 @@ SELECT is(
       SELECT claim_open_shift(
         'aaaaaaaa-a001-0000-0000-000000000001',
         'bbbbbbbb-b001-0000-0000-000000000001',
-        '2026-04-19'::date,
+        (SELECT target_sunday FROM test_config),
         'cccccccc-c001-0000-0000-000000000003'
       ) AS result
     ) sub
@@ -231,7 +241,7 @@ SELECT is(
 );
 
 -- ============================================
--- Test 8: Approved shift has correct UTC start time (20:30 UTC, not 15:30 UTC)
+-- Test 8: Approved shift has correct UTC start time
 -- ============================================
 
 SELECT is(
@@ -243,8 +253,8 @@ SELECT is(
       AND source = 'template'
     ORDER BY created_at DESC LIMIT 1
   ),
-  '2026-04-19 20:30:00+00'::timestamptz,
-  'approved claim shift start_time is 20:30 UTC (15:30 CDT), not 15:30 UTC'
+  (SELECT local_start AT TIME ZONE 'America/Chicago' FROM test_config),
+  'approved claim shift start_time matches 15:30 local converted to UTC'
 );
 
 SELECT * FROM finish();

--- a/tests/unit/invitationUtils.test.ts
+++ b/tests/unit/invitationUtils.test.ts
@@ -31,9 +31,23 @@ describe('formatExpiresIn', () => {
     expect(formatExpiresIn(yesterday)).toBe('Expired yesterday');
   });
 
+  it('returns "Expires today" for 22 hours away (not "Expires tomorrow")', () => {
+    const almostTomorrow = new Date('2026-04-22T10:00:00Z').toISOString();
+    expect(formatExpiresIn(almostTomorrow)).toBe('Expires today');
+  });
+
+  it('returns "Expired today" for 13 hours ago (not "Expired yesterday")', () => {
+    const recentlyExpired = new Date('2026-04-20T23:00:00Z').toISOString();
+    expect(formatExpiresIn(recentlyExpired)).toBe('Expired today');
+  });
+
   it('returns "Expired 5 days ago" for 5 days past', () => {
     const past = new Date('2026-04-16T12:00:00Z').toISOString();
     expect(formatExpiresIn(past)).toBe('Expired 5 days ago');
+  });
+
+  it('returns "Unknown expiration" for an invalid date string', () => {
+    expect(formatExpiresIn('not-a-date')).toBe('Unknown expiration');
   });
 });
 

--- a/tests/unit/invitationUtils.test.ts
+++ b/tests/unit/invitationUtils.test.ts
@@ -1,10 +1,14 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { formatExpiresIn, classifyInvitationError } from '@/lib/invitationUtils';
 
 describe('formatExpiresIn', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-04-21T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('returns "Expires in 3 days" for a future date 3 days away', () => {

--- a/tests/unit/invitationUtils.test.ts
+++ b/tests/unit/invitationUtils.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { formatExpiresIn, classifyInvitationError } from '@/lib/invitationUtils';
+
+describe('formatExpiresIn', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-21T12:00:00Z'));
+  });
+
+  it('returns "Expires in 3 days" for a future date 3 days away', () => {
+    const future = new Date('2026-04-24T12:00:00Z').toISOString();
+    expect(formatExpiresIn(future)).toBe('Expires in 3 days');
+  });
+
+  it('returns "Expires tomorrow" for a future date 1 day away', () => {
+    const tomorrow = new Date('2026-04-22T12:00:00Z').toISOString();
+    expect(formatExpiresIn(tomorrow)).toBe('Expires tomorrow');
+  });
+
+  it('returns "Expires today" when less than 1 day remains', () => {
+    const soonish = new Date('2026-04-21T18:00:00Z').toISOString();
+    expect(formatExpiresIn(soonish)).toBe('Expires today');
+  });
+
+  it('returns "Expired yesterday" for yesterday', () => {
+    const yesterday = new Date('2026-04-20T12:00:00Z').toISOString();
+    expect(formatExpiresIn(yesterday)).toBe('Expired yesterday');
+  });
+
+  it('returns "Expired 5 days ago" for 5 days past', () => {
+    const past = new Date('2026-04-16T12:00:00Z').toISOString();
+    expect(formatExpiresIn(past)).toBe('Expired 5 days ago');
+  });
+});
+
+describe('classifyInvitationError', () => {
+  it('returns "expired" for the exact expired message', () => {
+    expect(classifyInvitationError('Invitation has expired')).toBe('expired');
+  });
+
+  it('returns "invalid" for any other message', () => {
+    expect(classifyInvitationError('Invalid token')).toBe('invalid');
+    expect(classifyInvitationError('')).toBe('invalid');
+    expect(classifyInvitationError('Not found')).toBe('invalid');
+  });
+});

--- a/tests/unit/useCollaborators.test.ts
+++ b/tests/unit/useCollaborators.test.ts
@@ -27,9 +27,11 @@ import {
   useSendCollaboratorInvitation,
   useCancelCollaboratorInvitation,
   useRemoveCollaborator,
+  useResendCollaboratorInvitation,
   type Collaborator,
   type PendingInvite,
 } from '@/hooks/useCollaborators';
+import type { Role } from '@/lib/permissions';
 
 // Test wrapper component
 const createWrapper = () => {
@@ -531,6 +533,53 @@ describe('useCollaborators Hook', () => {
         };
         expect(invite.status).toBe(status);
       }
+    });
+  });
+
+  // ============================================================
+  // useResendCollaboratorInvitation Tests
+  // ============================================================
+
+  describe('useResendCollaboratorInvitation', () => {
+    it('calls send-team-invitation edge function with correct params', async () => {
+      mockInvoke.mockResolvedValueOnce({ data: {}, error: null });
+
+      const { result } = renderHook(() => useResendCollaboratorInvitation(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        result.current.mutate({
+          restaurantId: 'rest-1',
+          email: 'sam@example.com',
+          role: 'collaborator_accountant' as Role,
+        });
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      expect(mockInvoke).toHaveBeenCalledWith('send-team-invitation', {
+        body: { restaurantId: 'rest-1', email: 'sam@example.com', role: 'collaborator_accountant' },
+      });
+    });
+
+    it('invalidates collaborator-invites query on success', async () => {
+      mockInvoke.mockResolvedValueOnce({ data: {}, error: null });
+
+      const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+      const wrapper = ({ children }: { children: React.ReactNode }) =>
+        React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+      const { result } = renderHook(() => useResendCollaboratorInvitation(), { wrapper });
+
+      await act(async () => {
+        result.current.mutate({ restaurantId: 'rest-1', email: 'sam@example.com', role: 'collaborator_accountant' as Role });
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['collaborator-invites', 'rest-1'] });
     });
   });
 });

--- a/tests/unit/useCollaborators.test.ts
+++ b/tests/unit/useCollaborators.test.ts
@@ -566,20 +566,33 @@ describe('useCollaborators Hook', () => {
     it('invalidates collaborator-invites query on success', async () => {
       mockInvoke.mockResolvedValueOnce({ data: {}, error: null });
 
-      const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
-      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
-
-      const wrapper = ({ children }: { children: React.ReactNode }) =>
-        React.createElement(QueryClientProvider, { client: queryClient }, children);
-
+      const wrapper = createWrapper();
       const { result } = renderHook(() => useResendCollaboratorInvitation(), { wrapper });
 
+      // We verify the effect by checking the invoke was called correctly (covered by test 1)
+      // and that isSuccess transitions correctly
       await act(async () => {
         result.current.mutate({ restaurantId: 'rest-1', email: 'sam@example.com', role: 'collaborator_accountant' as Role });
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['collaborator-invites', 'rest-1'] });
+      expect(mockInvoke).toHaveBeenCalledWith('send-team-invitation', {
+        body: { restaurantId: 'rest-1', email: 'sam@example.com', role: 'collaborator_accountant' },
+      });
+    });
+
+    it('transitions to error state when edge function returns an error', async () => {
+      mockInvoke.mockResolvedValueOnce({ data: null, error: new Error('Rate limited') });
+
+      const { result } = renderHook(() => useResendCollaboratorInvitation(), {
+        wrapper: createWrapper(),
+      });
+
+      await act(async () => {
+        result.current.mutate({ restaurantId: 'rest-1', email: 'sam@example.com', role: 'collaborator_accountant' as Role });
+      });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
     });
   });
 });

--- a/tests/unit/useCollaborators.test.ts
+++ b/tests/unit/useCollaborators.test.ts
@@ -566,19 +566,21 @@ describe('useCollaborators Hook', () => {
     it('invalidates collaborator-invites query on success', async () => {
       mockInvoke.mockResolvedValueOnce({ data: {}, error: null });
 
-      const wrapper = createWrapper();
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false, gcTime: 0 }, mutations: { retry: false } },
+      });
+      const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+      const wrapper = ({ children }: { children: React.ReactNode }) =>
+        React.createElement(QueryClientProvider, { client: queryClient }, children);
+
       const { result } = renderHook(() => useResendCollaboratorInvitation(), { wrapper });
 
-      // We verify the effect by checking the invoke was called correctly (covered by test 1)
-      // and that isSuccess transitions correctly
       await act(async () => {
         result.current.mutate({ restaurantId: 'rest-1', email: 'sam@example.com', role: 'collaborator_accountant' as Role });
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(mockInvoke).toHaveBeenCalledWith('send-team-invitation', {
-        body: { restaurantId: 'rest-1', email: 'sam@example.com', role: 'collaborator_accountant' },
-      });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['collaborator-invites', 'rest-1'] });
     });
 
     it('transitions to error state when edge function returns an error', async () => {


### PR DESCRIPTION
## Summary

- **Resend button on expired rows** — `TeamInvitations` and `CollaboratorInvitations` now show a per-row ↻ Resend button for expired invitations; clicking it calls `send-team-invitation` with the same email/role and shows a toast on success.
- **History collapse** — Accepted and cancelled rows are hidden behind a "Show history (N)" toggle; expired rows remain visible since they're actionable.
- **Pending-conflict confirmation** — When the "Send Invitation" dialog is submitted for an email that already has a `pending` invite, an inline amber warning appears before the edge function is called; the manager must confirm to proceed.
- **Improved expired-link page** — `AcceptInvitation` distinguishes `410 Invitation has expired` from other errors and shows "Ask your manager to resend it from the Team page" instead of a generic invalid-token message.
- **"Expires in N days" label** — Pending rows show countdown (Expires today / tomorrow / in N days) instead of "Sent X ago".

## Technical notes

- `validate-invitation` edge function updated to return proper HTTP 4xx/5xx codes (410 expired, 404 invalid, 400 missing token) instead of always returning 200 for application errors. Frontend reads the error body from `FunctionsHttpError.context.json()` to preserve classification.
- `invitationUtils.formatExpiresIn` uses `Math.floor`/`Math.ceil` (not `Math.round`) to prevent off-by-one messages like "Expires tomorrow" for a date 22 hours away.
- New `useResendCollaboratorInvitation` hook in `useCollaborators.ts` follows the same mutation pattern as all other hooks in that file.

## Test plan

- [ ] 3489 unit tests pass (`npm run test`)
- [ ] TypeScript clean on changed files (`npm run typecheck`)
- [ ] Build passes (`npm run build`)
- [ ] Expired invitation row shows ↻ Resend button; clicking it sends a new invite and refreshes the list
- [ ] Accepted/cancelled rows collapse under "Show history (N)"; expired rows remain visible
- [ ] Sending an invite to an email with an existing pending invite shows the amber warning; confirming proceeds, cancelling stops
- [ ] Clicking an expired invite link shows "Invitation Expired — Ask your manager to resend it from the Team page" (not the generic invalid message)
- [ ] Pending rows show "Expires in N days" / "Expires today" / "Expires tomorrow"

Design spec: `docs/superpowers/specs/2026-04-21-invitation-ux-redesign-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * FT/PT employment type with compact badges and filter controls
  * Minor age detection with inline “Minor (X yrs)” badges
  * Resend flow and explicit “Invitation Expired” handling plus collapsible invitation history

* **Bug Fixes**
  * Deterministic shift-to-template bucketing to prevent mis-assigned shifts

* **Tests**
  * Added unit and E2E coverage for invitations, age/minor logic, FT/PT flows, and planner bucketing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->