### PR TITLE
fix(notifications): time-off manager emails + observability + UI warning

### DIFF
--- a/docs/superpowers/plans/2026-04-22-time-off-manager-notifications-fix-plan.md
+++ b/docs/superpowers/plans/2026-04-22-time-off-manager-notifications-fix-plan.md
@@ -1,0 +1,1098 @@
+# Time-Off Manager Notifications Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix silent failure where owners/managers receive no email when a time-off request is submitted, and surface future silent failures via logs + a UI warning.
+
+**Architecture:** Extract the recipient-resolution function from the edge function into a testable module using the working `profiles:user_id(email)` join pattern. Add a React Query hook and a Settings UI warning card that flags restaurants with zero configured approvers. No DB migration.
+
+**Tech Stack:** TypeScript, React 18.3, React Query, Vitest, Vite, Supabase Edge Functions (Deno), pgTAP, Tailwind/shadcn.
+
+**Spec:** `docs/superpowers/specs/2026-04-22-time-off-manager-notifications-fix-design.md`
+
+---
+
+## File Structure
+
+**Create:**
+- `supabase/functions/send-time-off-notification/buildEmails.ts` — pure recipient-resolution module (no Deno-URL imports, so Vitest can import it)
+- `src/hooks/useApproverCount.ts` — React Query hook returning count of owners+managers for a restaurant
+- `supabase/tests/notification_approver_resolution.test.sql` — pgTAP test verifying the join works
+- `tests/unit/sendTimeOffNotification-buildEmails.test.ts` — unit test for extracted module
+- `tests/unit/useApproverCount.test.ts` — unit test for the new hook
+- `tests/unit/NotificationSettings.test.tsx` — component test for the warning card
+
+**Modify:**
+- `supabase/functions/send-time-off-notification/index.ts` — use extracted buildEmails; add observability logs
+- `src/components/NotificationSettings.tsx` — render warning when approverCount is 0 and notify_managers is on
+
+**Not touched:** DB schema, `_shared/notificationHelpers.ts`, other notification edge functions.
+
+---
+
+## Task 1: Extract `buildEmails` with failing test
+
+Create a new, Vitest-importable module that replaces the broken inline function. The module MUST be free of Deno-URL imports so Node/Vitest can import it; the edge function will import it with a `.ts` extension as Deno requires.
+
+**Files:**
+- Create: `supabase/functions/send-time-off-notification/buildEmails.ts`
+- Create: `tests/unit/sendTimeOffNotification-buildEmails.test.ts`
+
+- [ ] **Step 1.1: Write the failing test file**
+
+Create `tests/unit/sendTimeOffNotification-buildEmails.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { buildEmails } from '../../supabase/functions/send-time-off-notification/buildEmails';
+
+type ManagerRow = {
+  user_id: string;
+  profiles: { email: string | null } | null;
+};
+
+interface MockResult {
+  data: ManagerRow[] | null;
+  error: { message: string } | null;
+}
+
+/**
+ * Builds a supabase-like stub that captures the call chain for assertions
+ * and returns whatever MockResult the test supplies.
+ */
+function makeSupabaseStub(result: MockResult) {
+  const calls = {
+    table: '' as string,
+    select: '' as string,
+    eqCol: '' as string,
+    eqVal: '' as string,
+    inCol: '' as string,
+    inVals: [] as string[],
+  };
+  const chain = {
+    select: (cols: string) => {
+      calls.select = cols;
+      return {
+        eq: (col: string, val: string) => {
+          calls.eqCol = col;
+          calls.eqVal = val;
+          return {
+            in: async (col: string, vals: string[]) => {
+              calls.inCol = col;
+              calls.inVals = vals;
+              return result;
+            },
+          };
+        },
+      };
+    },
+  };
+  const supabase = {
+    from: vi.fn((table: string) => {
+      calls.table = table;
+      return chain;
+    }),
+  };
+  return { supabase, calls };
+}
+
+describe('buildEmails', () => {
+  it('returns only employee when notifyEmployee=true and notifyManagers=false', async () => {
+    const { supabase } = makeSupabaseStub({ data: [], error: null });
+    const result = await buildEmails({
+      supabase: supabase as never,
+      restaurantId: 'rest-1',
+      employeeEmail: 'employee@example.com',
+      notifyEmployee: true,
+      notifyManagers: false,
+    });
+    expect(result.emails).toEqual(['employee@example.com']);
+    expect(result.employeeIncluded).toBe(true);
+    expect(result.managerCount).toBe(0);
+    expect(result.managerLookupError).toBeUndefined();
+    expect(supabase.from).not.toHaveBeenCalled();
+  });
+
+  it('queries user_restaurants joined to profiles for managers', async () => {
+    const { supabase, calls } = makeSupabaseStub({
+      data: [
+        { user_id: 'u1', profiles: { email: 'owner@example.com' } },
+        { user_id: 'u2', profiles: { email: 'manager@example.com' } },
+      ],
+      error: null,
+    });
+    const result = await buildEmails({
+      supabase: supabase as never,
+      restaurantId: 'rest-1',
+      employeeEmail: null,
+      notifyEmployee: false,
+      notifyManagers: true,
+    });
+    expect(calls.table).toBe('user_restaurants');
+    expect(calls.select).toContain('profiles:user_id');
+    expect(calls.eqCol).toBe('restaurant_id');
+    expect(calls.eqVal).toBe('rest-1');
+    expect(calls.inCol).toBe('role');
+    expect(calls.inVals).toEqual(['owner', 'manager']);
+    expect(result.emails.sort()).toEqual(['manager@example.com', 'owner@example.com']);
+    expect(result.managerCount).toBe(2);
+    expect(result.employeeIncluded).toBe(false);
+  });
+
+  it('de-duplicates when employee is also a manager', async () => {
+    const { supabase } = makeSupabaseStub({
+      data: [
+        { user_id: 'u1', profiles: { email: 'shared@example.com' } },
+        { user_id: 'u2', profiles: { email: 'other@example.com' } },
+      ],
+      error: null,
+    });
+    const result = await buildEmails({
+      supabase: supabase as never,
+      restaurantId: 'rest-1',
+      employeeEmail: 'shared@example.com',
+      notifyEmployee: true,
+      notifyManagers: true,
+    });
+    expect(result.emails.sort()).toEqual(['other@example.com', 'shared@example.com']);
+    expect(result.employeeIncluded).toBe(true);
+    expect(result.managerCount).toBe(2);
+  });
+
+  it('captures managerLookupError when the query errors', async () => {
+    const { supabase } = makeSupabaseStub({
+      data: null,
+      error: { message: 'relation profiles does not exist' },
+    });
+    const result = await buildEmails({
+      supabase: supabase as never,
+      restaurantId: 'rest-1',
+      employeeEmail: null,
+      notifyEmployee: false,
+      notifyManagers: true,
+    });
+    expect(result.emails).toEqual([]);
+    expect(result.managerCount).toBe(0);
+    expect(result.managerLookupError).toBe('relation profiles does not exist');
+  });
+
+  it('returns empty list when both flags are false', async () => {
+    const { supabase } = makeSupabaseStub({ data: [], error: null });
+    const result = await buildEmails({
+      supabase: supabase as never,
+      restaurantId: 'rest-1',
+      employeeEmail: 'employee@example.com',
+      notifyEmployee: false,
+      notifyManagers: false,
+    });
+    expect(result.emails).toEqual([]);
+    expect(result.employeeIncluded).toBe(false);
+    expect(result.managerCount).toBe(0);
+    expect(supabase.from).not.toHaveBeenCalled();
+  });
+
+  it('skips manager rows with null profiles or null email', async () => {
+    const { supabase } = makeSupabaseStub({
+      data: [
+        { user_id: 'u1', profiles: null },
+        { user_id: 'u2', profiles: { email: null } },
+        { user_id: 'u3', profiles: { email: 'real@example.com' } },
+      ],
+      error: null,
+    });
+    const result = await buildEmails({
+      supabase: supabase as never,
+      restaurantId: 'rest-1',
+      employeeEmail: null,
+      notifyEmployee: false,
+      notifyManagers: true,
+    });
+    expect(result.emails).toEqual(['real@example.com']);
+    expect(result.managerCount).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 1.2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/sendTimeOffNotification-buildEmails.test.ts`
+Expected: FAIL with "Failed to resolve import" or "Cannot find module" — the module doesn't exist yet.
+
+- [ ] **Step 1.3: Create `buildEmails.ts` module**
+
+Create `supabase/functions/send-time-off-notification/buildEmails.ts`:
+
+```ts
+/**
+ * Resolves email recipients for a time-off notification.
+ *
+ * Type-agnostic: accepts any object with a `.from()` method that returns the
+ * expected chain shape. This lets the real Deno Supabase client and mocks
+ * from Vitest both satisfy the same interface.
+ */
+
+export interface BuildEmailsInput {
+  supabase: ApproverQueryClient;
+  restaurantId: string;
+  employeeEmail?: string | null;
+  notifyEmployee: boolean;
+  notifyManagers: boolean;
+}
+
+export interface BuildEmailsResult {
+  emails: string[];
+  employeeIncluded: boolean;
+  managerCount: number;
+  managerLookupError?: string;
+}
+
+interface ApproverQueryClient {
+  from(table: string): ApproverSelectBuilder;
+}
+
+interface ApproverSelectBuilder {
+  select(columns: string): ApproverEqBuilder;
+}
+
+interface ApproverEqBuilder {
+  eq(column: string, value: string): ApproverInBuilder;
+}
+
+interface ApproverInBuilder {
+  in(
+    column: string,
+    values: string[]
+  ): Promise<{
+    data: ManagerRow[] | null;
+    error: { message: string } | null;
+  }>;
+}
+
+interface ManagerRow {
+  user_id: string;
+  profiles: { email?: string | null } | null;
+}
+
+export async function buildEmails(
+  input: BuildEmailsInput
+): Promise<BuildEmailsResult> {
+  const {
+    supabase,
+    restaurantId,
+    employeeEmail,
+    notifyEmployee,
+    notifyManagers,
+  } = input;
+
+  const emails: string[] = [];
+  let employeeIncluded = false;
+  let managerCount = 0;
+  let managerLookupError: string | undefined;
+
+  if (notifyEmployee && employeeEmail) {
+    emails.push(employeeEmail);
+    employeeIncluded = true;
+  }
+
+  if (notifyManagers) {
+    const { data: managers, error } = await supabase
+      .from('user_restaurants')
+      .select('user_id, profiles:user_id(email)')
+      .eq('restaurant_id', restaurantId)
+      .in('role', ['owner', 'manager']);
+
+    if (error) {
+      managerLookupError = error.message;
+    } else if (managers) {
+      for (const m of managers) {
+        const email = m?.profiles?.email;
+        if (email) {
+          emails.push(email);
+          managerCount++;
+        }
+      }
+    }
+  }
+
+  return {
+    emails: [...new Set(emails)],
+    employeeIncluded,
+    managerCount,
+    managerLookupError,
+  };
+}
+```
+
+- [ ] **Step 1.4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/sendTimeOffNotification-buildEmails.test.ts`
+Expected: PASS — all 6 test cases pass.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add supabase/functions/send-time-off-notification/buildEmails.ts tests/unit/sendTimeOffNotification-buildEmails.test.ts
+git commit -m "feat(time-off): extract buildEmails to testable module with profiles join
+
+Replaces the broken auth.users cross-schema join with the
+profiles:user_id(email) pattern used by _shared/notificationHelpers.
+The module is type-agnostic so Vitest can import it directly.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Wire index.ts to extracted module and add observability
+
+Replace the broken inline `buildEmails` function in the edge function with a call to the new extracted module. Add logging for the silent-failure cases identified in the spec.
+
+**Files:**
+- Modify: `supabase/functions/send-time-off-notification/index.ts`
+
+- [ ] **Step 2.1: Remove the inline `buildEmails` and add import**
+
+In `supabase/functions/send-time-off-notification/index.ts`, delete the `buildEmails` function (currently lines 52-84) and the `SupabaseClientType` alias (line 50). Add the import at the top alongside the other imports:
+
+```ts
+import { buildEmails } from './buildEmails.ts';
+```
+
+The imports section should look like:
+
+```ts
+import { generateHeader } from '../_shared/emailTemplates.ts';
+import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { Resend } from "https://esm.sh/resend@4.0.0";
+import { sendWebPushToUser } from '../_shared/webPushHelper.ts';
+import { buildEmails } from './buildEmails.ts';
+```
+
+- [ ] **Step 2.2: Replace the call site to use the new signature**
+
+Find the current block (around lines 178-198) that reads:
+
+```ts
+const uniqueEmails = await buildEmails(
+  supabase as any,
+  timeOffRequest.restaurant_id,
+  timeOffRequest.employee?.email,
+  settings.time_off_notify_employee,
+  settings.time_off_notify_managers
+);
+
+if (uniqueEmails.length === 0) {
+  console.log('No recipients found for notification');
+  return new Response(
+    JSON.stringify({
+      success: true,
+      message: 'No recipients configured'
+    }),
+    {
+      status: 200,
+      headers: { 'Content-Type': 'application/json', ...corsHeaders },
+    }
+  );
+}
+```
+
+Replace it with:
+
+```ts
+const recipients = await buildEmails({
+  supabase,
+  restaurantId: timeOffRequest.restaurant_id,
+  employeeEmail: timeOffRequest.employee?.email ?? null,
+  notifyEmployee: !!settings.time_off_notify_employee,
+  notifyManagers: !!settings.time_off_notify_managers,
+});
+
+if (recipients.managerLookupError) {
+  console.error(
+    'time-off notification: manager lookup failed for restaurant',
+    timeOffRequest.restaurant_id,
+    '-',
+    recipients.managerLookupError
+  );
+}
+
+if (settings.time_off_notify_managers && recipients.managerCount === 0) {
+  console.warn(
+    'time-off notification: notify_managers=true but 0 approvers resolved for restaurant',
+    timeOffRequest.restaurant_id
+  );
+}
+
+if (recipients.emails.length === 0) {
+  console.log('No recipients configured for notification', {
+    restaurantId: timeOffRequest.restaurant_id,
+    notifyEmployee: !!settings.time_off_notify_employee,
+    notifyManagers: !!settings.time_off_notify_managers,
+  });
+  return new Response(
+    JSON.stringify({
+      success: true,
+      message: 'No recipients configured',
+      recipients: 0,
+    }),
+    {
+      status: 200,
+      headers: { 'Content-Type': 'application/json', ...corsHeaders },
+    }
+  );
+}
+
+const uniqueEmails = recipients.emails;
+```
+
+- [ ] **Step 2.3: Add final breakdown log before the success response**
+
+Find the existing log `console.log(`Sent ${results.length} notification emails`);` (was around line 281) and replace with:
+
+```ts
+console.log('Sent time-off notification', {
+  action,
+  restaurantId: timeOffRequest.restaurant_id,
+  total: results.length,
+  employeeIncluded: recipients.employeeIncluded,
+  managerCount: recipients.managerCount,
+});
+```
+
+- [ ] **Step 2.4: Run typecheck and vitest**
+
+Run: `npm run typecheck`
+Expected: PASS — TypeScript accepts the new call shape.
+
+Run: `npx vitest run tests/unit/sendTimeOffNotification-buildEmails.test.ts`
+Expected: still PASS (no regression).
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add supabase/functions/send-time-off-notification/index.ts
+git commit -m "fix(time-off): use extracted buildEmails and log silent failures
+
+Replaces the inline buildEmails with the extracted module so that the
+manager lookup uses the working profiles:user_id(email) join. Adds
+explicit logs when the manager lookup errors or when notify_managers
+is on but zero approvers are resolved — these were previously silent.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: pgTAP test for approver resolution
+
+Prove at the database level that the `user_restaurants` → `profiles` join returns the expected owner/manager rows, and that other roles are excluded. This is a guard against future RLS or schema changes breaking the notification pipeline.
+
+**Files:**
+- Create: `supabase/tests/notification_approver_resolution.test.sql`
+
+- [ ] **Step 3.1: Ensure local DB is running and reset**
+
+Run: `npm run db:reset`
+Expected: Supabase local stack comes up and migrations are applied cleanly.
+
+- [ ] **Step 3.2: Write the pgTAP test**
+
+Create `supabase/tests/notification_approver_resolution.test.sql`:
+
+```sql
+-- Test: Time-Off Notification Approver Resolution
+-- Verifies the join pattern used by the send-time-off-notification edge function
+-- returns owner/manager profiles and excludes other roles.
+
+BEGIN;
+
+SELECT plan(6);
+
+-- Setup: create an isolated restaurant and three users with different roles.
+INSERT INTO restaurants (id, name, address, phone)
+VALUES (
+  '00000000-0000-0000-0000-000000000801'::uuid,
+  'Approver Test Restaurant',
+  '1 Test St',
+  '555-0801'
+)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO auth.users (id, email)
+VALUES
+  ('00000000-0000-0000-0000-000000000802'::uuid, 'owner-approver@test.com'),
+  ('00000000-0000-0000-0000-000000000803'::uuid, 'manager-approver@test.com'),
+  ('00000000-0000-0000-0000-000000000804'::uuid, 'chef-approver@test.com')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO profiles (user_id, email)
+VALUES
+  ('00000000-0000-0000-0000-000000000802'::uuid, 'owner-approver@test.com'),
+  ('00000000-0000-0000-0000-000000000803'::uuid, 'manager-approver@test.com'),
+  ('00000000-0000-0000-0000-000000000804'::uuid, 'chef-approver@test.com')
+ON CONFLICT (user_id) DO UPDATE SET email = EXCLUDED.email;
+
+INSERT INTO user_restaurants (user_id, restaurant_id, role)
+VALUES
+  ('00000000-0000-0000-0000-000000000802'::uuid, '00000000-0000-0000-0000-000000000801'::uuid, 'owner'),
+  ('00000000-0000-0000-0000-000000000803'::uuid, '00000000-0000-0000-0000-000000000801'::uuid, 'manager'),
+  ('00000000-0000-0000-0000-000000000804'::uuid, '00000000-0000-0000-0000-000000000801'::uuid, 'chef')
+ON CONFLICT (user_id, restaurant_id) DO UPDATE SET role = EXCLUDED.role;
+
+-- Test 1: owner is resolved through the profiles join
+SELECT ok(
+  EXISTS(
+    SELECT 1 FROM user_restaurants ur
+    JOIN profiles p ON p.user_id = ur.user_id
+    WHERE ur.restaurant_id = '00000000-0000-0000-0000-000000000801'::uuid
+      AND ur.role = 'owner'
+      AND p.email = 'owner-approver@test.com'
+  ),
+  'owner profile is resolvable via user_restaurants -> profiles join'
+);
+
+-- Test 2: manager is resolved
+SELECT ok(
+  EXISTS(
+    SELECT 1 FROM user_restaurants ur
+    JOIN profiles p ON p.user_id = ur.user_id
+    WHERE ur.restaurant_id = '00000000-0000-0000-0000-000000000801'::uuid
+      AND ur.role = 'manager'
+      AND p.email = 'manager-approver@test.com'
+  ),
+  'manager profile is resolvable via user_restaurants -> profiles join'
+);
+
+-- Test 3: approver list contains exactly owner + manager, not chef
+SELECT is(
+  (SELECT count(*)::int FROM user_restaurants
+   WHERE restaurant_id = '00000000-0000-0000-0000-000000000801'::uuid
+     AND role IN ('owner', 'manager')),
+  2,
+  'Only owner and manager roles count as approvers'
+);
+
+-- Test 4: chef is NOT in the approver list
+SELECT ok(
+  NOT EXISTS(
+    SELECT 1 FROM user_restaurants
+    WHERE restaurant_id = '00000000-0000-0000-0000-000000000801'::uuid
+      AND role = 'chef'
+      AND role IN ('owner', 'manager')
+  ),
+  'chef role is excluded from approver resolution'
+);
+
+-- Test 5: join returns email for every approver (no null-profile rows)
+SELECT is(
+  (SELECT count(*)::int FROM user_restaurants ur
+   JOIN profiles p ON p.user_id = ur.user_id
+   WHERE ur.restaurant_id = '00000000-0000-0000-0000-000000000801'::uuid
+     AND ur.role IN ('owner', 'manager')
+     AND p.email IS NOT NULL),
+  2,
+  'Both approvers have non-null emails via the join'
+);
+
+-- Test 6: empty-approver case — a new restaurant with no owners/managers returns 0
+INSERT INTO restaurants (id, name, address, phone)
+VALUES (
+  '00000000-0000-0000-0000-000000000805'::uuid,
+  'Empty Approver Restaurant',
+  '2 Test St',
+  '555-0805'
+)
+ON CONFLICT (id) DO NOTHING;
+
+SELECT is(
+  (SELECT count(*)::int FROM user_restaurants
+   WHERE restaurant_id = '00000000-0000-0000-0000-000000000805'::uuid
+     AND role IN ('owner', 'manager')),
+  0,
+  'Restaurant with no team returns 0 approvers'
+);
+
+SELECT * FROM finish();
+ROLLBACK;
+```
+
+- [ ] **Step 3.3: Run the pgTAP suite**
+
+Run: `npm run test:db`
+Expected: The new test file runs alongside existing ones; all assertions pass. Look for `notification_approver_resolution` in the output with `ok 1..6`.
+
+- [ ] **Step 3.4: Commit**
+
+```bash
+git add supabase/tests/notification_approver_resolution.test.sql
+git commit -m "test(time-off): pgTAP coverage for approver resolution join
+
+Verifies that user_restaurants -> profiles returns owners and managers
+with valid emails, and excludes other roles. Guards against schema
+or RLS changes breaking the notification recipient list.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: `useApproverCount` hook
+
+React Query hook that returns the count of users with role `owner` or `manager` for a given restaurant. Drives the Settings UI warning.
+
+**Files:**
+- Create: `src/hooks/useApproverCount.ts`
+- Create: `tests/unit/useApproverCount.test.ts`
+
+- [ ] **Step 4.1: Write the failing test**
+
+Create `tests/unit/useApproverCount.test.ts`:
+
+```ts
+import React, { ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockSupabase = vi.hoisted(() => ({
+  from: vi.fn(),
+}));
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: mockSupabase,
+}));
+
+import { useApproverCount } from '@/hooks/useApproverCount';
+
+function createWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return React.createElement(QueryClientProvider, { client }, children);
+  };
+}
+
+function makeCountStub(count: number | null, error: unknown = null) {
+  return {
+    select: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        in: vi.fn(async () => ({ count, error })),
+      })),
+    })),
+  };
+}
+
+describe('useApproverCount', () => {
+  beforeEach(() => {
+    mockSupabase.from.mockReset();
+  });
+
+  it('returns 0 when restaurantId is undefined without hitting the client', async () => {
+    const { result } = renderHook(() => useApproverCount(undefined), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(result.current.isFetching).toBe(false);
+    });
+    expect(result.current.data).toBe(0);
+    expect(mockSupabase.from).not.toHaveBeenCalled();
+  });
+
+  it('fetches count from user_restaurants with owner/manager roles', async () => {
+    const stub = makeCountStub(3);
+    mockSupabase.from.mockReturnValue(stub);
+
+    const { result } = renderHook(() => useApproverCount('rest-1'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.data).toBe(3));
+
+    expect(mockSupabase.from).toHaveBeenCalledWith('user_restaurants');
+    expect(stub.select).toHaveBeenCalledWith('*', { count: 'exact', head: true });
+    const eqCall = stub.select.mock.results[0].value.eq;
+    expect(eqCall).toHaveBeenCalledWith('restaurant_id', 'rest-1');
+    const inCall = eqCall.mock.results[0].value.in;
+    expect(inCall).toHaveBeenCalledWith('role', ['owner', 'manager']);
+  });
+
+  it('returns 0 when the count is null', async () => {
+    mockSupabase.from.mockReturnValue(makeCountStub(null));
+    const { result } = renderHook(() => useApproverCount('rest-1'), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(0);
+  });
+
+  it('surfaces errors through React Query', async () => {
+    mockSupabase.from.mockReturnValue(
+      makeCountStub(null, { message: 'boom' })
+    );
+    const { result } = renderHook(() => useApproverCount('rest-1'), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect((result.current.error as { message: string }).message).toBe('boom');
+  });
+});
+```
+
+- [ ] **Step 4.2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/useApproverCount.test.ts`
+Expected: FAIL with "Cannot find module '@/hooks/useApproverCount'" — the hook doesn't exist yet.
+
+- [ ] **Step 4.3: Create the hook**
+
+Create `src/hooks/useApproverCount.ts`:
+
+```ts
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+
+export function useApproverCount(restaurantId: string | undefined) {
+  return useQuery({
+    queryKey: ['approver-count', restaurantId],
+    queryFn: async () => {
+      if (!restaurantId) return 0;
+      const { count, error } = await supabase
+        .from('user_restaurants')
+        .select('*', { count: 'exact', head: true })
+        .eq('restaurant_id', restaurantId)
+        .in('role', ['owner', 'manager']);
+      if (error) throw error;
+      return count ?? 0;
+    },
+    staleTime: 60_000,
+    refetchOnWindowFocus: true,
+  });
+}
+```
+
+Note: the `enabled` option is intentionally omitted so the query still runs when `restaurantId` is undefined, returning 0 synchronously within the queryFn. This keeps the hook's contract simple and lets the `undefined` test assert `data === 0` without a conditional. The first test case in Step 4.1 verifies this contract.
+
+- [ ] **Step 4.4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/useApproverCount.test.ts`
+Expected: PASS — all 4 test cases pass.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add src/hooks/useApproverCount.ts tests/unit/useApproverCount.test.ts
+git commit -m "feat(notifications): add useApproverCount hook
+
+Returns the count of users with role owner or manager for a
+restaurant. Used by the NotificationSettings UI to warn when
+no approvers are configured to receive time-off notifications.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Warning card in NotificationSettings
+
+Render an amber warning card below the "Notify Managers" toggle when the setting is on AND no owners/managers exist for the restaurant.
+
+**Files:**
+- Modify: `src/components/NotificationSettings.tsx`
+- Create: `tests/unit/NotificationSettings.test.tsx`
+
+- [ ] **Step 5.1: Write the failing test**
+
+Create `tests/unit/NotificationSettings.test.tsx`:
+
+```tsx
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const approverCountMock = vi.hoisted(() => vi.fn());
+const notificationSettingsMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/hooks/useApproverCount', () => ({
+  useApproverCount: approverCountMock,
+}));
+
+vi.mock('@/hooks/useNotificationSettings', () => ({
+  useNotificationSettings: notificationSettingsMock,
+  useUpdateNotificationSettings: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock('@/hooks/useNotificationPreferences', () => ({
+  useNotificationPreferences: () => ({
+    preferences: { weekly_brief_email: true },
+    updatePreferences: vi.fn(),
+    isUpdating: false,
+  }),
+}));
+
+import { NotificationSettings } from '@/components/NotificationSettings';
+
+function renderWithClient(ui: React.ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>
+  );
+}
+
+const baseSettings = {
+  notify_time_off_request: true,
+  notify_time_off_approved: true,
+  notify_time_off_rejected: true,
+  time_off_notify_managers: true,
+  time_off_notify_employee: true,
+};
+
+describe('NotificationSettings approver warning', () => {
+  beforeEach(() => {
+    approverCountMock.mockReset();
+    notificationSettingsMock.mockReset();
+  });
+
+  it('renders warning when notify_managers is on and approver count is 0', () => {
+    notificationSettingsMock.mockReturnValue({
+      settings: baseSettings,
+      loading: false,
+    });
+    approverCountMock.mockReturnValue({ data: 0, isLoading: false });
+
+    renderWithClient(<NotificationSettings restaurantId="rest-1" />);
+
+    expect(screen.getByText('No approvers configured')).toBeInTheDocument();
+  });
+
+  it('hides warning when at least one approver exists', () => {
+    notificationSettingsMock.mockReturnValue({
+      settings: baseSettings,
+      loading: false,
+    });
+    approverCountMock.mockReturnValue({ data: 2, isLoading: false });
+
+    renderWithClient(<NotificationSettings restaurantId="rest-1" />);
+
+    expect(screen.queryByText('No approvers configured')).not.toBeInTheDocument();
+  });
+
+  it('hides warning when notify_managers is off even if approverCount is 0', () => {
+    notificationSettingsMock.mockReturnValue({
+      settings: { ...baseSettings, time_off_notify_managers: false },
+      loading: false,
+    });
+    approverCountMock.mockReturnValue({ data: 0, isLoading: false });
+
+    renderWithClient(<NotificationSettings restaurantId="rest-1" />);
+
+    expect(screen.queryByText('No approvers configured')).not.toBeInTheDocument();
+  });
+
+  it('hides warning while approverCount is still loading', () => {
+    notificationSettingsMock.mockReturnValue({
+      settings: baseSettings,
+      loading: false,
+    });
+    approverCountMock.mockReturnValue({ data: undefined, isLoading: true });
+
+    renderWithClient(<NotificationSettings restaurantId="rest-1" />);
+
+    expect(screen.queryByText('No approvers configured')).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 5.2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/NotificationSettings.test.tsx`
+Expected: FAIL — "No approvers configured" text not found (component doesn't render the warning yet).
+
+- [ ] **Step 5.3: Modify `NotificationSettings.tsx` to render the warning**
+
+In `src/components/NotificationSettings.tsx`:
+
+**a.** Add the import for `AlertTriangle` by updating line 7 from:
+```tsx
+import { Bell, Mail, Users, CheckCircle, Newspaper } from 'lucide-react';
+```
+to:
+```tsx
+import { Bell, Mail, Users, CheckCircle, Newspaper, AlertTriangle } from 'lucide-react';
+```
+
+**b.** Add the hook import after line 9:
+```tsx
+import { useApproverCount } from '@/hooks/useApproverCount';
+```
+
+**c.** Inside the component, after line 18 (`const { preferences: briefPrefs, ... } = useNotificationPreferences(restaurantId);`), add:
+
+```tsx
+const { data: approverCount, isLoading: approverCountLoading } = useApproverCount(restaurantId);
+const showNoApproversWarning =
+  !approverCountLoading &&
+  localSettings.time_off_notify_managers &&
+  (approverCount ?? 0) === 0;
+```
+
+**d.** Inside the "Notification Recipients" card, insert the warning card directly after the "Notify Managers" toggle block and before the `<Separator />` that separates it from the "Notify Employee" toggle. Change the block (current lines 161-180):
+```tsx
+<CardContent className="space-y-6">
+  <div className="flex items-center justify-between">
+    <div>
+      <Label htmlFor="notify-managers" className="text-base">
+        Notify Managers
+      </Label>
+      <p className="text-sm text-muted-foreground">
+        Send notifications to all owners and managers
+      </p>
+    </div>
+    <Switch
+      id="notify-managers"
+      checked={localSettings.time_off_notify_managers}
+      onCheckedChange={(checked) =>
+        setLocalSettings({ ...localSettings, time_off_notify_managers: checked })
+      }
+    />
+  </div>
+
+  <Separator />
+```
+
+to:
+```tsx
+<CardContent className="space-y-6">
+  <div className="flex items-center justify-between">
+    <div>
+      <Label htmlFor="notify-managers" className="text-base">
+        Notify Managers
+      </Label>
+      <p className="text-sm text-muted-foreground">
+        Send notifications to all owners and managers
+      </p>
+    </div>
+    <Switch
+      id="notify-managers"
+      checked={localSettings.time_off_notify_managers}
+      onCheckedChange={(checked) =>
+        setLocalSettings({ ...localSettings, time_off_notify_managers: checked })
+      }
+    />
+  </div>
+
+  {showNoApproversWarning && (
+    <div
+      role="alert"
+      className="flex items-start gap-3 p-3 rounded-lg bg-amber-500/10 border border-amber-500/20"
+    >
+      <AlertTriangle
+        className="h-4 w-4 text-amber-600 mt-0.5 shrink-0"
+        aria-hidden="true"
+      />
+      <div className="text-[13px]">
+        <p className="font-medium text-foreground">No approvers configured</p>
+        <p className="text-muted-foreground mt-0.5">
+          This restaurant has no owners or managers set up to receive notifications.
+          Invite a teammate with owner or manager access from the Team page.
+        </p>
+      </div>
+    </div>
+  )}
+
+  <Separator />
+```
+
+- [ ] **Step 5.4: Run the test to verify it passes**
+
+Run: `npx vitest run tests/unit/NotificationSettings.test.tsx`
+Expected: PASS — all 4 test cases pass.
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add src/components/NotificationSettings.tsx tests/unit/NotificationSettings.test.tsx
+git commit -m "feat(notifications): warn when restaurant has no approvers
+
+Renders an amber warning card below the 'Notify Managers' toggle
+when the setting is on but no owners or managers exist for the
+restaurant. Prevents the silent-failure mode where notify_managers
+is enabled but the recipient list would be empty.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Full local verification
+
+Run the complete verification suite per the superpowers:verification-before-completion skill.
+
+- [ ] **Step 6.1: Typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS — no TypeScript errors.
+
+- [ ] **Step 6.2: Lint**
+
+Run: `npm run lint`
+Expected: PASS — no new ESLint errors for the changed files. Existing warnings unrelated to this change may remain (do not fix unrelated issues).
+
+- [ ] **Step 6.3: Unit tests**
+
+Run: `npm run test`
+Expected: PASS — all Vitest suites green, including the four new test files.
+
+- [ ] **Step 6.4: DB tests**
+
+Run: `npm run test:db`
+Expected: PASS — pgTAP `notification_approver_resolution` shows `ok 1..6`.
+
+- [ ] **Step 6.5: Build**
+
+Run: `npm run build`
+Expected: PASS — production build succeeds.
+
+- [ ] **Step 6.6: E2E tests (regression check only)**
+
+Run: `npm run test:e2e`
+Expected: PASS — existing E2E suites still green. No new E2E tests were added (the notification emails are side-effects that would require intercepting Resend, which is out of scope).
+
+- [ ] **Step 6.7: Final commit of any fix-up changes (if needed)**
+
+If any verification step produces fix-up commits, bundle them:
+
+```bash
+git status
+# review
+git add -A
+git commit -m "fix(time-off): verification follow-up
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+Otherwise, nothing to commit — proceed to Phase 7 (CodeRabbit review) of the development workflow.
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:**
+- Fix broken auth.users join → Task 1 (extracted module with profiles join) + Task 2 (wire it in)
+- Surface silent failures → Task 2 (console.error/warn/log)
+- Settings UI warning → Task 5
+- Supporting hook → Task 4
+- pgTAP test → Task 3
+- Vitest unit tests → Tasks 1, 4, 5
+- No DB migration → confirmed; nothing in the plan modifies the schema
+
+**Type consistency check:**
+- `BuildEmailsResult` fields (`emails`, `employeeIncluded`, `managerCount`, `managerLookupError`) are consistent between Task 1 (definition), Task 2 (usage), and Task 1's test (assertions).
+- The query shape `user_restaurants.select('user_id, profiles:user_id(email)').eq(...).in(...)` is identical in the hook (Task 4 — with count option) and the resolver (Task 1), matching what Task 3's pgTAP test validates at the DB layer.
+- `useApproverCount` returns `number` (Task 4); consumed as `number | undefined` in Task 5 (React Query's `data` is undefined before first resolve) and guarded with `(approverCount ?? 0) === 0`.
+
+**No placeholders:** All steps include exact code, exact commands, and expected output.

--- a/docs/superpowers/plans/2026-04-22-time-off-manager-notifications-fix-plan.md
+++ b/docs/superpowers/plans/2026-04-22-time-off-manager-notifications-fix-plan.md
@@ -108,7 +108,7 @@ describe('buildEmails', () => {
     });
     expect(result.emails).toEqual(['employee@example.com']);
     expect(result.employeeIncluded).toBe(true);
-    expect(result.managerCount).toBe(0);
+    expect(result.managersFound).toBe(0);
     expect(result.managerLookupError).toBeUndefined();
     expect(supabase.from).not.toHaveBeenCalled();
   });
@@ -135,7 +135,7 @@ describe('buildEmails', () => {
     expect(calls.inCol).toBe('role');
     expect(calls.inVals).toEqual(['owner', 'manager']);
     expect(result.emails.sort()).toEqual(['manager@example.com', 'owner@example.com']);
-    expect(result.managerCount).toBe(2);
+    expect(result.managersFound).toBe(2);
     expect(result.employeeIncluded).toBe(false);
   });
 
@@ -156,7 +156,7 @@ describe('buildEmails', () => {
     });
     expect(result.emails.sort()).toEqual(['other@example.com', 'shared@example.com']);
     expect(result.employeeIncluded).toBe(true);
-    expect(result.managerCount).toBe(2);
+    expect(result.managersFound).toBe(2);
   });
 
   it('captures managerLookupError when the query errors', async () => {
@@ -172,7 +172,7 @@ describe('buildEmails', () => {
       notifyManagers: true,
     });
     expect(result.emails).toEqual([]);
-    expect(result.managerCount).toBe(0);
+    expect(result.managersFound).toBe(0);
     expect(result.managerLookupError).toBe('relation profiles does not exist');
   });
 
@@ -187,7 +187,7 @@ describe('buildEmails', () => {
     });
     expect(result.emails).toEqual([]);
     expect(result.employeeIncluded).toBe(false);
-    expect(result.managerCount).toBe(0);
+    expect(result.managersFound).toBe(0);
     expect(supabase.from).not.toHaveBeenCalled();
   });
 
@@ -208,7 +208,7 @@ describe('buildEmails', () => {
       notifyManagers: true,
     });
     expect(result.emails).toEqual(['real@example.com']);
-    expect(result.managerCount).toBe(1);
+    expect(result.managersFound).toBe(1);
   });
 });
 ```
@@ -242,7 +242,7 @@ export interface BuildEmailsInput {
 export interface BuildEmailsResult {
   emails: string[];
   employeeIncluded: boolean;
-  managerCount: number;
+  managersFound: number;
   managerLookupError?: string;
 }
 
@@ -286,7 +286,7 @@ export async function buildEmails(
 
   const emails: string[] = [];
   let employeeIncluded = false;
-  let managerCount = 0;
+  let managersFound = 0;
   let managerLookupError: string | undefined;
 
   if (notifyEmployee && employeeEmail) {
@@ -308,7 +308,7 @@ export async function buildEmails(
         const email = m?.profiles?.email;
         if (email) {
           emails.push(email);
-          managerCount++;
+          managersFound++;
         }
       }
     }
@@ -317,7 +317,7 @@ export async function buildEmails(
   return {
     emails: [...new Set(emails)],
     employeeIncluded,
-    managerCount,
+    managersFound,
     managerLookupError,
   };
 }
@@ -417,7 +417,7 @@ if (recipients.managerLookupError) {
   );
 }
 
-if (settings.time_off_notify_managers && recipients.managerCount === 0) {
+if (settings.time_off_notify_managers && recipients.managersFound === 0) {
   console.warn(
     'time-off notification: notify_managers=true but 0 approvers resolved for restaurant',
     timeOffRequest.restaurant_id
@@ -456,7 +456,7 @@ console.log('Sent time-off notification', {
   restaurantId: timeOffRequest.restaurant_id,
   total: results.length,
   employeeIncluded: recipients.employeeIncluded,
-  managerCount: recipients.managerCount,
+  managersFound: recipients.managersFound,
 });
 ```
 
@@ -1091,7 +1091,7 @@ Otherwise, nothing to commit — proceed to Phase 7 (CodeRabbit review) of the d
 - No DB migration → confirmed; nothing in the plan modifies the schema
 
 **Type consistency check:**
-- `BuildEmailsResult` fields (`emails`, `employeeIncluded`, `managerCount`, `managerLookupError`) are consistent between Task 1 (definition), Task 2 (usage), and Task 1's test (assertions).
+- `BuildEmailsResult` fields (`emails`, `employeeIncluded`, `managersFound`, `managerLookupError`) are consistent between Task 1 (definition), Task 2 (usage), and Task 1's test (assertions).
 - The query shape `user_restaurants.select('user_id, profiles:user_id(email)').eq(...).in(...)` is identical in the hook (Task 4 — with count option) and the resolver (Task 1), matching what Task 3's pgTAP test validates at the DB layer.
 - `useApproverCount` returns `number` (Task 4); consumed as `number | undefined` in Task 5 (React Query's `data` is undefined before first resolve) and guarded with `(approverCount ?? 0) === 0`.
 

--- a/docs/superpowers/specs/2026-04-22-time-off-manager-notifications-fix-design.md
+++ b/docs/superpowers/specs/2026-04-22-time-off-manager-notifications-fix-design.md
@@ -92,7 +92,7 @@ export interface BuildEmailsInput {
 export interface BuildEmailsResult {
   emails: string[];          // de-duplicated recipient list
   employeeIncluded: boolean; // true if employee email was added
-  managerCount: number;      // number of owner/manager recipients added
+  managersFound: number;     // owner/manager rows resolved with a valid email (pre-dedup)
   managerLookupError?: string;
 }
 
@@ -100,7 +100,7 @@ export async function buildEmails(input: BuildEmailsInput): Promise<BuildEmailsR
   const { supabase, restaurantId, employeeEmail, notifyEmployee, notifyManagers } = input;
   const emails: string[] = [];
   let employeeIncluded = false;
-  let managerCount = 0;
+  let managersFound = 0;
   let managerLookupError: string | undefined;
 
   if (notifyEmployee && employeeEmail) {
@@ -122,7 +122,7 @@ export async function buildEmails(input: BuildEmailsInput): Promise<BuildEmailsR
         const email = m?.profiles?.email;
         if (email) {
           emails.push(email);
-          managerCount++;
+          managersFound++;
         }
       }
     }
@@ -131,7 +131,7 @@ export async function buildEmails(input: BuildEmailsInput): Promise<BuildEmailsR
   return {
     emails: [...new Set(emails)],
     employeeIncluded,
-    managerCount,
+    managersFound,
     managerLookupError,
   };
 }
@@ -152,7 +152,7 @@ if (result.managerLookupError) {
   console.error('Manager lookup failed:', result.managerLookupError);
 }
 
-if (settings.time_off_notify_managers && result.managerCount === 0) {
+if (settings.time_off_notify_managers && result.managersFound === 0) {
   console.warn(
     `time-off notification: notify_managers=true but 0 approvers resolved for restaurant ${timeOffRequest.restaurant_id}`
   );
@@ -166,7 +166,7 @@ if (result.emails.length === 0) {
 // ... send emails using result.emails ...
 
 console.log(
-  `Sent notification: employee=${result.employeeIncluded}, managers=${result.managerCount}, total=${result.emails.length}`
+  `Sent notification: employee=${result.employeeIncluded}, managers=${result.managersFound}, total=${result.emails.length}`
 );
 ```
 
@@ -248,10 +248,10 @@ Employee submits time-off request
               WHERE restaurant_id = $1 AND role IN ('owner','manager')
               emails += profiles.email for each row with an email
        → dedupe via Set
-       → return { emails, employeeIncluded, managerCount, managerLookupError? }
+       → return { emails, employeeIncluded, managersFound, managerLookupError? }
 
        if managerLookupError       → console.error
-       if notifyManagers && managerCount === 0 → console.warn
+       if notifyManagers && managersFound === 0 → console.warn
        if emails.length === 0       → early return { recipients: 0 }
 
        send each email via Resend.emails.send()
@@ -319,10 +319,10 @@ ROLLBACK;
 
 Import the extracted `buildEmails` module with a mocked Supabase client:
 
-1. `notifyEmployee=true, notifyManagers=false, employeeEmail='e@x'` → `emails=['e@x']`, employeeIncluded=true, managerCount=0
-2. `notifyEmployee=false, notifyManagers=true` with 2 manager rows → `emails` = 2 manager emails, managerCount=2
+1. `notifyEmployee=true, notifyManagers=false, employeeEmail='e@x'` → `emails=['e@x']`, employeeIncluded=true, managersFound=0
+2. `notifyEmployee=false, notifyManagers=true` with 2 manager rows → `emails` = 2 manager emails, managersFound=2
 3. Both true, employee email also appears in manager list → de-duplicated to 2 addresses (not 3)
-4. `notifyManagers=true` but query returns `{ error }` → `managerLookupError` populated, emails empty, managerCount=0
+4. `notifyManagers=true` but query returns `{ error }` → `managerLookupError` populated, emails empty, managersFound=0
 5. Both false → `emails=[]`
 6. Manager row missing `profiles.email` (null) → skipped silently, not counted
 

--- a/docs/superpowers/specs/2026-04-22-time-off-manager-notifications-fix-design.md
+++ b/docs/superpowers/specs/2026-04-22-time-off-manager-notifications-fix-design.md
@@ -1,0 +1,362 @@
+# Time-Off "Notify Managers" Fix + Observability
+
+**Date:** 2026-04-22
+**Status:** Design approved, ready for plan
+**Owner:** jose.delgado@easyshifthq.com
+
+## Problem
+
+When employees submit time-off requests, the employee receives a notification email but owners/managers do not — even when the "Notify Managers" toggle is enabled on the restaurant's Notification Settings page.
+
+The setting label is "Send notifications to all owners and managers." The logic intent is correct: when `time_off_notify_managers=true`, everyone in `user_restaurants` with role `owner` or `manager` for that restaurant should receive the email.
+
+## Root Cause
+
+In `supabase/functions/send-time-off-notification/index.ts`, the `buildEmails()` helper queries managers with a broken cross-schema join:
+
+```ts
+// Current (broken)
+.from('user_restaurants')
+.select(`user:auth.users(email)`)
+.eq('restaurant_id', restaurantId)
+.in('role', ['owner', 'manager']);
+```
+
+PostgREST does not expose the `auth` schema for joined selects this way. The query silently returns an error or empty rows. The calling code then silently ignores the error:
+
+```ts
+if (!managersError && managers) {      // no else — error is swallowed
+  managers.forEach(...);
+}
+```
+
+The shared helper `_shared/notificationHelpers.ts::getManagerEmails` already uses the correct pattern (`profiles:user_id(email)` — public schema). Every other notification edge function uses that helper. The time-off function does not.
+
+**Observable effect:** The function returns `success: true, recipients: 1` (employee only). The frontend shows green. No error surfaces anywhere.
+
+## Goal
+
+1. Owners and managers receive time-off notification emails when `time_off_notify_managers=true`.
+2. Silent failures of the recipient-resolution path become visible (logs + UI warning).
+3. The Settings page surfaces when a restaurant has no one with approval powers to receive these notifications.
+
+## Non-Goals
+
+- Redesigning the notification settings schema.
+- Refactoring every notification edge function to use the shared helper (a broader cleanup task).
+- Adding a "Manager" designation to the `employees` table. Approval powers remain role-based on `user_restaurants`.
+- Adding per-recipient opt-out. Restaurant-level settings already exist; per-user preferences are out of scope.
+
+## Architecture
+
+Three coordinated changes. No DB migration.
+
+```
+[1] Edge function fix
+    supabase/functions/send-time-off-notification/index.ts
+    - Replace buildEmails() manager query: profiles:user_id(email)
+    - Log managerError when it fires (stop swallowing)
+    - Log recipient breakdown (employee/managers/total)
+    - Extract buildEmails to a separate module so it can be unit-tested
+
+[2] Settings UI warning
+    src/components/NotificationSettings.tsx
+    - Amber warning card shown when notify_managers toggle is on AND
+      restaurant has 0 users with role ∈ {owner, manager}
+
+[3] Supporting hook
+    src/hooks/useApproverCount.ts  (new, small)
+    - React Query: SELECT count(*) FROM user_restaurants
+      WHERE restaurant_id = $1 AND role IN ('owner','manager')
+    - 60s staleTime, refetchOnWindowFocus
+```
+
+## Component Detail
+
+### 1. `supabase/functions/send-time-off-notification/index.ts`
+
+Extract `buildEmails` into a new module `supabase/functions/send-time-off-notification/buildEmails.ts`:
+
+```ts
+// buildEmails.ts
+import type { SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+export interface BuildEmailsInput {
+  supabase: SupabaseClient;
+  restaurantId: string;
+  employeeEmail?: string | null;
+  notifyEmployee: boolean;
+  notifyManagers: boolean;
+}
+
+export interface BuildEmailsResult {
+  emails: string[];          // de-duplicated recipient list
+  employeeIncluded: boolean; // true if employee email was added
+  managerCount: number;      // number of owner/manager recipients added
+  managerLookupError?: string;
+}
+
+export async function buildEmails(input: BuildEmailsInput): Promise<BuildEmailsResult> {
+  const { supabase, restaurantId, employeeEmail, notifyEmployee, notifyManagers } = input;
+  const emails: string[] = [];
+  let employeeIncluded = false;
+  let managerCount = 0;
+  let managerLookupError: string | undefined;
+
+  if (notifyEmployee && employeeEmail) {
+    emails.push(employeeEmail);
+    employeeIncluded = true;
+  }
+
+  if (notifyManagers) {
+    const { data: managers, error } = await supabase
+      .from('user_restaurants')
+      .select('user_id, profiles:user_id(email)')
+      .eq('restaurant_id', restaurantId)
+      .in('role', ['owner', 'manager']);
+
+    if (error) {
+      managerLookupError = error.message;
+    } else if (managers) {
+      for (const m of managers as Array<{ profiles?: { email?: string } | null }>) {
+        const email = m?.profiles?.email;
+        if (email) {
+          emails.push(email);
+          managerCount++;
+        }
+      }
+    }
+  }
+
+  return {
+    emails: [...new Set(emails)],
+    employeeIncluded,
+    managerCount,
+    managerLookupError,
+  };
+}
+```
+
+In `index.ts`, replace the existing inline `buildEmails` call site:
+
+```ts
+const result = await buildEmails({
+  supabase,
+  restaurantId: timeOffRequest.restaurant_id,
+  employeeEmail: timeOffRequest.employee?.email,
+  notifyEmployee: !!settings.time_off_notify_employee,
+  notifyManagers: !!settings.time_off_notify_managers,
+});
+
+if (result.managerLookupError) {
+  console.error('Manager lookup failed:', result.managerLookupError);
+}
+
+if (settings.time_off_notify_managers && result.managerCount === 0) {
+  console.warn(
+    `time-off notification: notify_managers=true but 0 approvers resolved for restaurant ${timeOffRequest.restaurant_id}`
+  );
+}
+
+if (result.emails.length === 0) {
+  console.log('No recipients configured for notification');
+  return successResponse({ message: 'No recipients configured', recipients: 0 });
+}
+
+// ... send emails using result.emails ...
+
+console.log(
+  `Sent notification: employee=${result.employeeIncluded}, managers=${result.managerCount}, total=${result.emails.length}`
+);
+```
+
+### 2. `src/hooks/useApproverCount.ts` (new)
+
+```ts
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+
+export function useApproverCount(restaurantId: string | undefined) {
+  return useQuery({
+    queryKey: ['approver-count', restaurantId],
+    queryFn: async () => {
+      if (!restaurantId) return 0;
+      const { count, error } = await supabase
+        .from('user_restaurants')
+        .select('*', { count: 'exact', head: true })
+        .eq('restaurant_id', restaurantId)
+        .in('role', ['owner', 'manager']);
+      if (error) throw error;
+      return count ?? 0;
+    },
+    enabled: !!restaurantId,
+    staleTime: 60_000,
+    refetchOnWindowFocus: true,
+  });
+}
+```
+
+### 3. `src/components/NotificationSettings.tsx` — warning card
+
+Inside the "Notification Recipients" card, directly below the "Notify Managers" toggle row:
+
+```tsx
+import { AlertTriangle } from 'lucide-react';
+import { useApproverCount } from '@/hooks/useApproverCount';
+
+// inside component:
+const { data: approverCount = 0 } = useApproverCount(restaurantId);
+
+// render (below notify_managers toggle):
+{settings.time_off_notify_managers && approverCount === 0 && (
+  <div className="flex items-start gap-3 p-3 rounded-lg bg-amber-500/10 border border-amber-500/20">
+    <AlertTriangle className="h-4 w-4 text-amber-600 mt-0.5 shrink-0" aria-hidden="true" />
+    <div className="text-[13px]">
+      <p className="font-medium text-foreground">No approvers configured</p>
+      <p className="text-muted-foreground mt-0.5">
+        This restaurant has no owners or managers set up to receive notifications.
+        Invite a teammate with owner or manager access from the Team page.
+      </p>
+    </div>
+  </div>
+)}
+```
+
+Styling follows CLAUDE.md's "AI suggestion panel" amber-warning pattern (`bg-amber-500/10 border-amber-500/20`, `rounded-lg`, `text-[13px]`).
+
+## Data Flow (happy path, after fix)
+
+```
+Employee submits time-off request
+  → useCreateTimeOffRequest INSERT → time_off_requests (status: 'pending')
+  → invoke('send-time-off-notification', { timeOffRequestId, action: 'created' })
+
+     edge function:
+       load time_off_request + employee(name, email, user_id)
+       load restaurant.name
+       load notification_settings (or hard-coded defaults)
+       shouldNotify for action? → yes (notify_time_off_request)
+       buildEmails({
+         employeeEmail,
+         notifyEmployee:  settings.time_off_notify_employee,
+         notifyManagers:  settings.time_off_notify_managers,
+       })
+         → if notify_employee && employeeEmail:   emails += employeeEmail
+         → if notify_managers:
+              SELECT user_id, profiles:user_id(email)
+              FROM user_restaurants
+              WHERE restaurant_id = $1 AND role IN ('owner','manager')
+              emails += profiles.email for each row with an email
+       → dedupe via Set
+       → return { emails, employeeIncluded, managerCount, managerLookupError? }
+
+       if managerLookupError       → console.error
+       if notifyManagers && managerCount === 0 → console.warn
+       if emails.length === 0       → early return { recipients: 0 }
+
+       send each email via Resend.emails.send()
+       log final counts
+       return { success: true, recipients: emails.length }
+```
+
+Same sequence for `approved`/`rejected` actions (plus the existing send-push-notification branch to the employee).
+
+## Error Handling
+
+| Failure | Before | After |
+|---|---|---|
+| Cross-schema join broken | silent, 0 managers emailed | query fixed; returns rows |
+| `managerError` non-null | silently ignored | `console.error` with message |
+| `notify_managers=true` but 0 approvers exist | silent `success: true` | `console.warn` in function log; amber warning on Settings UI |
+| No recipients at all (both toggles off, or no data) | `success: true, "No recipients configured"` | unchanged — this is a valid state |
+| Resend API fails | caught, thrown as 500 | unchanged |
+
+## Testing
+
+### pgTAP — `supabase/tests/notification_approver_resolution.test.sql`
+
+```sql
+BEGIN;
+SELECT plan(3);
+
+-- Setup: restaurant with owner, manager, chef; profiles populated
+-- (uses standard pgTAP test fixtures)
+
+-- Test 1: owner is resolved
+SELECT ok(
+  EXISTS(
+    SELECT 1 FROM user_restaurants ur
+    JOIN profiles p ON p.user_id = ur.user_id
+    WHERE ur.restaurant_id = :restaurant_id AND ur.role = 'owner' AND p.email IS NOT NULL
+  ),
+  'Owner with profile email is resolvable via the notification join'
+);
+
+-- Test 2: manager is resolved
+SELECT ok(
+  EXISTS(
+    SELECT 1 FROM user_restaurants ur
+    JOIN profiles p ON p.user_id = ur.user_id
+    WHERE ur.restaurant_id = :restaurant_id AND ur.role = 'manager' AND p.email IS NOT NULL
+  ),
+  'Manager with profile email is resolvable'
+);
+
+-- Test 3: chef and other roles excluded
+SELECT is(
+  (SELECT count(*) FROM user_restaurants
+   WHERE restaurant_id = :restaurant_id
+     AND role IN ('owner','manager')),
+  2::bigint,
+  'Only owner and manager roles are counted as approvers'
+);
+
+SELECT * FROM finish();
+ROLLBACK;
+```
+
+### Vitest — `tests/unit/sendTimeOffNotification-buildEmails.test.ts`
+
+Import the extracted `buildEmails` module with a mocked Supabase client:
+
+1. `notifyEmployee=true, notifyManagers=false, employeeEmail='e@x'` → `emails=['e@x']`, employeeIncluded=true, managerCount=0
+2. `notifyEmployee=false, notifyManagers=true` with 2 manager rows → `emails` = 2 manager emails, managerCount=2
+3. Both true, employee email also appears in manager list → de-duplicated to 2 addresses (not 3)
+4. `notifyManagers=true` but query returns `{ error }` → `managerLookupError` populated, emails empty, managerCount=0
+5. Both false → `emails=[]`
+6. Manager row missing `profiles.email` (null) → skipped silently, not counted
+
+### Vitest — `tests/unit/NotificationSettings-approverWarning.test.tsx`
+
+1. Toggle on + `useApproverCount → 0` → warning card renders
+2. Toggle on + `useApproverCount → 1` → warning card does NOT render
+3. Toggle off + `useApproverCount → 0` → warning card does NOT render
+
+## Files Changed
+
+**New:**
+- `supabase/functions/send-time-off-notification/buildEmails.ts`
+- `src/hooks/useApproverCount.ts`
+- `supabase/tests/notification_approver_resolution.test.sql`
+- `tests/unit/sendTimeOffNotification-buildEmails.test.ts`
+- `tests/unit/NotificationSettings-approverWarning.test.tsx`
+
+**Modified:**
+- `supabase/functions/send-time-off-notification/index.ts` — use extracted buildEmails; add logs
+- `src/components/NotificationSettings.tsx` — render warning card conditionally
+
+**Not touched:**
+- DB schema / migrations
+- `_shared/notificationHelpers.ts`
+- Other notification edge functions
+
+## Rollout
+
+- Single PR, no flags.
+- No DB migration; `profiles` already populated.
+- Existing restaurants with approvers start receiving notifications immediately after edge function redeploy.
+- Restaurants with no approvers will see the new amber warning on their Settings page on next visit.
+
+## Open Questions
+
+None — design approved conversationally on 2026-04-22.

--- a/src/components/NotificationSettings.tsx
+++ b/src/components/NotificationSettings.tsx
@@ -17,7 +17,11 @@ export function NotificationSettings({ restaurantId }: NotificationSettingsProps
   const { settings, loading } = useNotificationSettings(restaurantId);
   const updateSettings = useUpdateNotificationSettings();
   const { preferences: briefPrefs, updatePreferences: updateBriefPrefs, isUpdating: briefUpdating } = useNotificationPreferences(restaurantId);
-  const { data: approverCount, isLoading: approverCountLoading } = useApproverCount(restaurantId);
+  const {
+    data: approverCount,
+    isLoading: approverCountLoading,
+    isError: approverCountError,
+  } = useApproverCount(restaurantId);
 
   const [localSettings, setLocalSettings] = useState({
     notify_time_off_request: true,
@@ -56,8 +60,10 @@ export function NotificationSettings({ restaurantId }: NotificationSettingsProps
 
   const showNoApproversWarning =
     !approverCountLoading &&
+    !approverCountError &&
+    approverCount !== undefined &&
     localSettings.time_off_notify_managers &&
-    (approverCount ?? 0) === 0;
+    approverCount === 0;
 
   if (loading) {
     return (

--- a/src/components/NotificationSettings.tsx
+++ b/src/components/NotificationSettings.tsx
@@ -4,9 +4,10 @@ import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Separator } from '@/components/ui/separator';
-import { Bell, Mail, Users, CheckCircle, Newspaper } from 'lucide-react';
+import { Bell, Mail, Users, CheckCircle, Newspaper, AlertTriangle } from 'lucide-react';
 import { useNotificationSettings, useUpdateNotificationSettings } from '@/hooks/useNotificationSettings';
 import { useNotificationPreferences } from '@/hooks/useNotificationPreferences';
+import { useApproverCount } from '@/hooks/useApproverCount';
 
 interface NotificationSettingsProps {
   restaurantId: string;
@@ -16,6 +17,7 @@ export function NotificationSettings({ restaurantId }: NotificationSettingsProps
   const { settings, loading } = useNotificationSettings(restaurantId);
   const updateSettings = useUpdateNotificationSettings();
   const { preferences: briefPrefs, updatePreferences: updateBriefPrefs, isUpdating: briefUpdating } = useNotificationPreferences(restaurantId);
+  const { data: approverCount, isLoading: approverCountLoading } = useApproverCount(restaurantId);
 
   const [localSettings, setLocalSettings] = useState({
     notify_time_off_request: true,
@@ -51,6 +53,11 @@ export function NotificationSettings({ restaurantId }: NotificationSettingsProps
     localSettings.time_off_notify_managers !== settings.time_off_notify_managers ||
     localSettings.time_off_notify_employee !== settings.time_off_notify_employee
   );
+
+  const showNoApproversWarning =
+    !approverCountLoading &&
+    localSettings.time_off_notify_managers &&
+    (approverCount ?? 0) === 0;
 
   if (loading) {
     return (
@@ -176,6 +183,25 @@ export function NotificationSettings({ restaurantId }: NotificationSettingsProps
               }
             />
           </div>
+
+          {showNoApproversWarning && (
+            <div
+              role="alert"
+              className="flex items-start gap-3 p-3 rounded-lg bg-amber-500/10 border border-amber-500/20"
+            >
+              <AlertTriangle
+                className="h-4 w-4 text-amber-600 mt-0.5 shrink-0"
+                aria-hidden="true"
+              />
+              <div className="text-[13px]">
+                <p className="font-medium text-foreground">No approvers configured</p>
+                <p className="text-muted-foreground mt-0.5">
+                  This restaurant has no owners or managers set up to receive notifications.
+                  Invite a teammate with owner or manager access from the Team page.
+                </p>
+              </div>
+            </div>
+          )}
 
           <Separator />
 

--- a/src/hooks/useApproverCount.ts
+++ b/src/hooks/useApproverCount.ts
@@ -5,15 +5,15 @@ export function useApproverCount(restaurantId: string | undefined) {
   return useQuery({
     queryKey: ['approver-count', restaurantId],
     queryFn: async () => {
-      if (!restaurantId) return 0;
       const { count, error } = await supabase
         .from('user_restaurants')
-        .select('*', { count: 'exact', head: true })
-        .eq('restaurant_id', restaurantId)
+        .select('id', { count: 'exact', head: true })
+        .eq('restaurant_id', restaurantId!)
         .in('role', ['owner', 'manager']);
       if (error) throw error;
       return count ?? 0;
     },
+    enabled: !!restaurantId,
     staleTime: 60_000,
     refetchOnWindowFocus: true,
   });

--- a/src/hooks/useApproverCount.ts
+++ b/src/hooks/useApproverCount.ts
@@ -1,0 +1,20 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+
+export function useApproverCount(restaurantId: string | undefined) {
+  return useQuery({
+    queryKey: ['approver-count', restaurantId],
+    queryFn: async () => {
+      if (!restaurantId) return 0;
+      const { count, error } = await supabase
+        .from('user_restaurants')
+        .select('*', { count: 'exact', head: true })
+        .eq('restaurant_id', restaurantId)
+        .in('role', ['owner', 'manager']);
+      if (error) throw error;
+      return count ?? 0;
+    },
+    staleTime: 60_000,
+    refetchOnWindowFocus: true,
+  });
+}

--- a/supabase/functions/send-time-off-notification/buildEmails.ts
+++ b/supabase/functions/send-time-off-notification/buildEmails.ts
@@ -22,25 +22,16 @@ export interface BuildEmailsResult {
 }
 
 interface ApproverQueryClient {
-  from(table: string): ApproverSelectBuilder;
-}
-
-interface ApproverSelectBuilder {
-  select(columns: string): ApproverEqBuilder;
-}
-
-interface ApproverEqBuilder {
-  eq(column: string, value: string): ApproverInBuilder;
-}
-
-interface ApproverInBuilder {
-  in(
-    column: string,
-    values: string[]
-  ): Promise<{
-    data: ManagerRow[] | null;
-    error: { message: string } | null;
-  }>;
+  from(table: string): {
+    select(columns: string): {
+      eq(column: string, value: string): {
+        in(column: string, values: string[]): Promise<{
+          data: ManagerRow[] | null;
+          error: { message: string } | null;
+        }>;
+      };
+    };
+  };
 }
 
 interface ManagerRow {

--- a/supabase/functions/send-time-off-notification/buildEmails.ts
+++ b/supabase/functions/send-time-off-notification/buildEmails.ts
@@ -1,0 +1,98 @@
+/**
+ * Resolves email recipients for a time-off notification.
+ *
+ * Type-agnostic: accepts any object with a `.from()` method that returns the
+ * expected chain shape. This lets the real Deno Supabase client and mocks
+ * from Vitest both satisfy the same interface.
+ */
+
+export interface BuildEmailsInput {
+  supabase: ApproverQueryClient;
+  restaurantId: string;
+  employeeEmail?: string | null;
+  notifyEmployee: boolean;
+  notifyManagers: boolean;
+}
+
+export interface BuildEmailsResult {
+  emails: string[];
+  employeeIncluded: boolean;
+  managerCount: number;
+  managerLookupError?: string;
+}
+
+interface ApproverQueryClient {
+  from(table: string): ApproverSelectBuilder;
+}
+
+interface ApproverSelectBuilder {
+  select(columns: string): ApproverEqBuilder;
+}
+
+interface ApproverEqBuilder {
+  eq(column: string, value: string): ApproverInBuilder;
+}
+
+interface ApproverInBuilder {
+  in(
+    column: string,
+    values: string[]
+  ): Promise<{
+    data: ManagerRow[] | null;
+    error: { message: string } | null;
+  }>;
+}
+
+interface ManagerRow {
+  user_id: string;
+  profiles: { email?: string | null } | null;
+}
+
+export async function buildEmails(
+  input: BuildEmailsInput
+): Promise<BuildEmailsResult> {
+  const {
+    supabase,
+    restaurantId,
+    employeeEmail,
+    notifyEmployee,
+    notifyManagers,
+  } = input;
+
+  const emails: string[] = [];
+  let employeeIncluded = false;
+  let managerCount = 0;
+  let managerLookupError: string | undefined;
+
+  if (notifyEmployee && employeeEmail) {
+    emails.push(employeeEmail);
+    employeeIncluded = true;
+  }
+
+  if (notifyManagers) {
+    const { data: managers, error } = await supabase
+      .from('user_restaurants')
+      .select('user_id, profiles:user_id(email)')
+      .eq('restaurant_id', restaurantId)
+      .in('role', ['owner', 'manager']);
+
+    if (error) {
+      managerLookupError = error.message;
+    } else if (managers) {
+      for (const m of managers) {
+        const email = m?.profiles?.email;
+        if (email) {
+          emails.push(email);
+          managerCount++;
+        }
+      }
+    }
+  }
+
+  return {
+    emails: [...new Set(emails)],
+    employeeIncluded,
+    managerCount,
+    managerLookupError,
+  };
+}

--- a/supabase/functions/send-time-off-notification/buildEmails.ts
+++ b/supabase/functions/send-time-off-notification/buildEmails.ts
@@ -17,7 +17,7 @@ export interface BuildEmailsInput {
 export interface BuildEmailsResult {
   emails: string[];
   employeeIncluded: boolean;
-  managerCount: number;
+  managersFound: number;
   managerLookupError?: string;
 }
 
@@ -61,7 +61,7 @@ export async function buildEmails(
 
   const emails: string[] = [];
   let employeeIncluded = false;
-  let managerCount = 0;
+  let managersFound = 0;
   let managerLookupError: string | undefined;
 
   if (notifyEmployee && employeeEmail) {
@@ -83,7 +83,7 @@ export async function buildEmails(
         const email = m?.profiles?.email;
         if (email) {
           emails.push(email);
-          managerCount++;
+          managersFound++;
         }
       }
     }
@@ -92,7 +92,7 @@ export async function buildEmails(
   return {
     emails: [...new Set(emails)],
     employeeIncluded,
-    managerCount,
+    managersFound,
     managerLookupError,
   };
 }

--- a/supabase/functions/send-time-off-notification/index.ts
+++ b/supabase/functions/send-time-off-notification/index.ts
@@ -3,6 +3,7 @@ import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { Resend } from "https://esm.sh/resend@4.0.0";
 import { sendWebPushToUser } from '../_shared/webPushHelper.ts';
+import { buildEmails } from './buildEmails.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -46,42 +47,6 @@ const formatDate = (date: string) => new Date(date).toLocaleDateString('en-US', 
   year: 'numeric'
 });
 
-// Use a type alias for the Supabase client that's more permissive
-type SupabaseClientType = ReturnType<typeof createClient>;
-
-const buildEmails = async (
-  supabase: SupabaseClientType,
-  restaurantId: string,
-  employeeEmail?: string,
-  notifyEmployee?: boolean,
-  notifyManagers?: boolean
-) => {
-  const emails: string[] = [];
-
-  if (notifyEmployee && employeeEmail) {
-    emails.push(employeeEmail);
-  }
-
-  if (notifyManagers) {
-    const { data: managers, error: managersError } = await supabase
-      .from('user_restaurants')
-      .select(`
-        user:auth.users(email)
-      `)
-      .eq('restaurant_id', restaurantId)
-      .in('role', ['owner', 'manager']);
-
-    if (!managersError && managers) {
-      managers.forEach((manager: { user?: { email?: string } | null } | null) => {
-        if (manager?.user?.email) {
-          emails.push(manager.user.email);
-        }
-      });
-    }
-  }
-
-  return [...new Set(emails)];
-};
 
 const handler = async (req: Request): Promise<Response> => {
   // Handle CORS preflight requests
@@ -175,20 +140,41 @@ const handler = async (req: Request): Promise<Response> => {
       );
     }
 
-    const uniqueEmails = await buildEmails(
-      supabase as any,
-      timeOffRequest.restaurant_id,
-      timeOffRequest.employee?.email,
-      settings.time_off_notify_employee,
-      settings.time_off_notify_managers
-    );
+    const recipients = await buildEmails({
+      supabase,
+      restaurantId: timeOffRequest.restaurant_id,
+      employeeEmail: timeOffRequest.employee?.email ?? null,
+      notifyEmployee: !!settings.time_off_notify_employee,
+      notifyManagers: !!settings.time_off_notify_managers,
+    });
 
-    if (uniqueEmails.length === 0) {
-      console.log('No recipients found for notification');
+    if (recipients.managerLookupError) {
+      console.error(
+        'time-off notification: manager lookup failed for restaurant',
+        timeOffRequest.restaurant_id,
+        '-',
+        recipients.managerLookupError
+      );
+    }
+
+    if (settings.time_off_notify_managers && recipients.managersFound === 0) {
+      console.warn(
+        'time-off notification: notify_managers=true but 0 approvers resolved for restaurant',
+        timeOffRequest.restaurant_id
+      );
+    }
+
+    if (recipients.emails.length === 0) {
+      console.log('No recipients configured for notification', {
+        restaurantId: timeOffRequest.restaurant_id,
+        notifyEmployee: !!settings.time_off_notify_employee,
+        notifyManagers: !!settings.time_off_notify_managers,
+      });
       return new Response(
         JSON.stringify({
           success: true,
-          message: 'No recipients configured'
+          message: 'No recipients configured',
+          recipients: 0,
         }),
         {
           status: 200,
@@ -196,6 +182,8 @@ const handler = async (req: Request): Promise<Response> => {
         }
       );
     }
+
+    const uniqueEmails = recipients.emails;
 
     const startDate = formatDate(timeOffRequest.start_date);
     const endDate = formatDate(timeOffRequest.end_date);
@@ -278,7 +266,13 @@ const handler = async (req: Request): Promise<Response> => {
       );
 
       const results = await Promise.all(emailPromises);
-      console.log(`Sent ${results.length} notification emails`);
+      console.log('Sent time-off notification', {
+        action,
+        restaurantId: timeOffRequest.restaurant_id,
+        total: results.length,
+        employeeIncluded: recipients.employeeIncluded,
+        managersFound: recipients.managersFound,
+      });
 
       // Send push notification to the employee for approved/rejected actions
       if ((action === 'approved' || action === 'rejected') && timeOffRequest.employee?.user_id) {

--- a/supabase/functions/send-time-off-notification/index.ts
+++ b/supabase/functions/send-time-off-notification/index.ts
@@ -47,7 +47,6 @@ const formatDate = (date: string) => new Date(date).toLocaleDateString('en-US', 
   year: 'numeric'
 });
 
-
 const handler = async (req: Request): Promise<Response> => {
   // Handle CORS preflight requests
   if (req.method === 'OPTIONS') {
@@ -157,7 +156,11 @@ const handler = async (req: Request): Promise<Response> => {
       );
     }
 
-    if (settings.time_off_notify_managers && recipients.managersFound === 0) {
+    if (
+      settings.time_off_notify_managers &&
+      recipients.managersFound === 0 &&
+      !recipients.managerLookupError
+    ) {
       console.warn(
         'time-off notification: notify_managers=true but 0 approvers resolved for restaurant',
         timeOffRequest.restaurant_id
@@ -269,7 +272,7 @@ const handler = async (req: Request): Promise<Response> => {
       console.log('Sent time-off notification', {
         action,
         restaurantId: timeOffRequest.restaurant_id,
-        total: results.length,
+        attempted: results.length,
         employeeIncluded: recipients.employeeIncluded,
         managersFound: recipients.managersFound,
       });

--- a/supabase/functions/send-time-off-notification/index.ts
+++ b/supabase/functions/send-time-off-notification/index.ts
@@ -142,7 +142,7 @@ const handler = async (req: Request): Promise<Response> => {
     const recipients = await buildEmails({
       supabase,
       restaurantId: timeOffRequest.restaurant_id,
-      employeeEmail: timeOffRequest.employee?.email ?? null,
+      employeeEmail: timeOffRequest.employee?.email || null,
       notifyEmployee: !!settings.time_off_notify_employee,
       notifyManagers: !!settings.time_off_notify_managers,
     });
@@ -186,8 +186,6 @@ const handler = async (req: Request): Promise<Response> => {
       );
     }
 
-    const uniqueEmails = recipients.emails;
-
     const startDate = formatDate(timeOffRequest.start_date);
     const endDate = formatDate(timeOffRequest.end_date);
 
@@ -197,7 +195,7 @@ const handler = async (req: Request): Promise<Response> => {
 
     // Send notification emails
     try {
-      const emailPromises = uniqueEmails.map(email => 
+      const emailPromises = recipients.emails.map(email => 
         resend.emails.send({
           from: "EasyShiftHQ <notifications@easyshifthq.com>",
           to: [email],
@@ -314,10 +312,10 @@ const handler = async (req: Request): Promise<Response> => {
       }
 
       return new Response(
-        JSON.stringify({ 
+        JSON.stringify({
           success: true,
-          message: `Notifications sent to ${uniqueEmails.length} recipient(s)`,
-          recipients: uniqueEmails.length
+          message: `Notifications sent to ${recipients.emails.length} recipient(s)`,
+          recipients: recipients.emails.length
         }),
         {
           status: 200,

--- a/supabase/tests/notification_approver_resolution.test.sql
+++ b/supabase/tests/notification_approver_resolution.test.sql
@@ -1,0 +1,114 @@
+-- Test: Time-Off Notification Approver Resolution
+-- Verifies the join pattern used by the send-time-off-notification edge function
+-- returns owner/manager profiles and excludes other roles.
+
+BEGIN;
+
+SELECT plan(6);
+
+-- Setup: create an isolated restaurant and three users with different roles.
+INSERT INTO restaurants (id, name, address, phone)
+VALUES (
+  '00000000-0000-0000-0000-000000000801'::uuid,
+  'Approver Test Restaurant',
+  '1 Test St',
+  '555-0801'
+)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO auth.users (id, email)
+VALUES
+  ('00000000-0000-0000-0000-000000000802'::uuid, 'owner-approver@test.com'),
+  ('00000000-0000-0000-0000-000000000803'::uuid, 'manager-approver@test.com'),
+  ('00000000-0000-0000-0000-000000000804'::uuid, 'chef-approver@test.com')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO profiles (user_id, email)
+VALUES
+  ('00000000-0000-0000-0000-000000000802'::uuid, 'owner-approver@test.com'),
+  ('00000000-0000-0000-0000-000000000803'::uuid, 'manager-approver@test.com'),
+  ('00000000-0000-0000-0000-000000000804'::uuid, 'chef-approver@test.com')
+ON CONFLICT (user_id) DO UPDATE SET email = EXCLUDED.email;
+
+INSERT INTO user_restaurants (user_id, restaurant_id, role)
+VALUES
+  ('00000000-0000-0000-0000-000000000802'::uuid, '00000000-0000-0000-0000-000000000801'::uuid, 'owner'),
+  ('00000000-0000-0000-0000-000000000803'::uuid, '00000000-0000-0000-0000-000000000801'::uuid, 'manager'),
+  ('00000000-0000-0000-0000-000000000804'::uuid, '00000000-0000-0000-0000-000000000801'::uuid, 'chef')
+ON CONFLICT (user_id, restaurant_id) DO UPDATE SET role = EXCLUDED.role;
+
+-- Test 1: owner is resolved through the profiles join
+SELECT ok(
+  EXISTS(
+    SELECT 1 FROM user_restaurants ur
+    JOIN profiles p ON p.user_id = ur.user_id
+    WHERE ur.restaurant_id = '00000000-0000-0000-0000-000000000801'::uuid
+      AND ur.role = 'owner'
+      AND p.email = 'owner-approver@test.com'
+  ),
+  'owner profile is resolvable via user_restaurants -> profiles join'
+);
+
+-- Test 2: manager is resolved
+SELECT ok(
+  EXISTS(
+    SELECT 1 FROM user_restaurants ur
+    JOIN profiles p ON p.user_id = ur.user_id
+    WHERE ur.restaurant_id = '00000000-0000-0000-0000-000000000801'::uuid
+      AND ur.role = 'manager'
+      AND p.email = 'manager-approver@test.com'
+  ),
+  'manager profile is resolvable via user_restaurants -> profiles join'
+);
+
+-- Test 3: approver list contains exactly owner + manager, not chef
+SELECT is(
+  (SELECT count(*)::int FROM user_restaurants
+   WHERE restaurant_id = '00000000-0000-0000-0000-000000000801'::uuid
+     AND role IN ('owner', 'manager')),
+  2,
+  'Only owner and manager roles count as approvers'
+);
+
+-- Test 4: chef is NOT in the approver list
+SELECT ok(
+  NOT EXISTS(
+    SELECT 1 FROM user_restaurants
+    WHERE restaurant_id = '00000000-0000-0000-0000-000000000801'::uuid
+      AND role = 'chef'
+      AND role IN ('owner', 'manager')
+  ),
+  'chef role is excluded from approver resolution'
+);
+
+-- Test 5: join returns email for every approver (no null-profile rows)
+SELECT is(
+  (SELECT count(*)::int FROM user_restaurants ur
+   JOIN profiles p ON p.user_id = ur.user_id
+   WHERE ur.restaurant_id = '00000000-0000-0000-0000-000000000801'::uuid
+     AND ur.role IN ('owner', 'manager')
+     AND p.email IS NOT NULL),
+  2,
+  'Both approvers have non-null emails via the join'
+);
+
+-- Test 6: empty-approver case — a new restaurant with no owners/managers returns 0
+INSERT INTO restaurants (id, name, address, phone)
+VALUES (
+  '00000000-0000-0000-0000-000000000805'::uuid,
+  'Empty Approver Restaurant',
+  '2 Test St',
+  '555-0805'
+)
+ON CONFLICT (id) DO NOTHING;
+
+SELECT is(
+  (SELECT count(*)::int FROM user_restaurants
+   WHERE restaurant_id = '00000000-0000-0000-0000-000000000805'::uuid
+     AND role IN ('owner', 'manager')),
+  0,
+  'Restaurant with no team returns 0 approvers'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/notification_approver_resolution.test.sql
+++ b/supabase/tests/notification_approver_resolution.test.sql
@@ -4,7 +4,38 @@
 
 BEGIN;
 
+-- Disable RLS so fixture inserts run under the test transaction regardless of
+-- the calling role. Rolled back at the end of the transaction.
+ALTER TABLE restaurants DISABLE ROW LEVEL SECURITY;
+ALTER TABLE profiles DISABLE ROW LEVEL SECURITY;
+ALTER TABLE user_restaurants DISABLE ROW LEVEL SECURITY;
+
 SELECT plan(6);
+
+-- Ensure deterministic state: clear any rows left by earlier failed runs sharing
+-- these fixed UUIDs, then insert fresh. Order matters for FK constraints.
+DELETE FROM user_restaurants
+WHERE restaurant_id IN (
+  '00000000-0000-0000-0000-000000000801'::uuid,
+  '00000000-0000-0000-0000-000000000805'::uuid
+);
+DELETE FROM profiles
+WHERE user_id IN (
+  '00000000-0000-0000-0000-000000000802'::uuid,
+  '00000000-0000-0000-0000-000000000803'::uuid,
+  '00000000-0000-0000-0000-000000000804'::uuid
+);
+DELETE FROM auth.users
+WHERE id IN (
+  '00000000-0000-0000-0000-000000000802'::uuid,
+  '00000000-0000-0000-0000-000000000803'::uuid,
+  '00000000-0000-0000-0000-000000000804'::uuid
+);
+DELETE FROM restaurants
+WHERE id IN (
+  '00000000-0000-0000-0000-000000000801'::uuid,
+  '00000000-0000-0000-0000-000000000805'::uuid
+);
 
 -- Setup: create an isolated restaurant and three users with different roles.
 INSERT INTO restaurants (id, name, address, phone)
@@ -13,29 +44,28 @@ VALUES (
   'Approver Test Restaurant',
   '1 Test St',
   '555-0801'
-)
-ON CONFLICT (id) DO NOTHING;
+);
 
 INSERT INTO auth.users (id, email)
 VALUES
   ('00000000-0000-0000-0000-000000000802'::uuid, 'owner-approver@test.com'),
   ('00000000-0000-0000-0000-000000000803'::uuid, 'manager-approver@test.com'),
-  ('00000000-0000-0000-0000-000000000804'::uuid, 'chef-approver@test.com')
-ON CONFLICT (id) DO NOTHING;
+  ('00000000-0000-0000-0000-000000000804'::uuid, 'chef-approver@test.com');
 
+-- A trigger on auth.users may auto-create profile rows. Upsert the emails so
+-- both the trigger-created case and a bare-table case land on the same state.
 INSERT INTO profiles (user_id, email)
 VALUES
   ('00000000-0000-0000-0000-000000000802'::uuid, 'owner-approver@test.com'),
   ('00000000-0000-0000-0000-000000000803'::uuid, 'manager-approver@test.com'),
   ('00000000-0000-0000-0000-000000000804'::uuid, 'chef-approver@test.com')
-ON CONFLICT (user_id) DO NOTHING;
+ON CONFLICT (user_id) DO UPDATE SET email = EXCLUDED.email;
 
 INSERT INTO user_restaurants (user_id, restaurant_id, role)
 VALUES
   ('00000000-0000-0000-0000-000000000802'::uuid, '00000000-0000-0000-0000-000000000801'::uuid, 'owner'),
   ('00000000-0000-0000-0000-000000000803'::uuid, '00000000-0000-0000-0000-000000000801'::uuid, 'manager'),
-  ('00000000-0000-0000-0000-000000000804'::uuid, '00000000-0000-0000-0000-000000000801'::uuid, 'chef')
-ON CONFLICT (user_id, restaurant_id) DO NOTHING;
+  ('00000000-0000-0000-0000-000000000804'::uuid, '00000000-0000-0000-0000-000000000801'::uuid, 'chef');
 
 -- Test 1: owner is resolved through the profiles join
 SELECT ok(
@@ -100,8 +130,7 @@ VALUES (
   'Empty Approver Restaurant',
   '2 Test St',
   '555-0805'
-)
-ON CONFLICT (id) DO NOTHING;
+);
 
 SELECT is(
   (SELECT count(*)::int FROM user_restaurants

--- a/supabase/tests/notification_approver_resolution.test.sql
+++ b/supabase/tests/notification_approver_resolution.test.sql
@@ -28,14 +28,14 @@ VALUES
   ('00000000-0000-0000-0000-000000000802'::uuid, 'owner-approver@test.com'),
   ('00000000-0000-0000-0000-000000000803'::uuid, 'manager-approver@test.com'),
   ('00000000-0000-0000-0000-000000000804'::uuid, 'chef-approver@test.com')
-ON CONFLICT (user_id) DO UPDATE SET email = EXCLUDED.email;
+ON CONFLICT (user_id) DO NOTHING;
 
 INSERT INTO user_restaurants (user_id, restaurant_id, role)
 VALUES
   ('00000000-0000-0000-0000-000000000802'::uuid, '00000000-0000-0000-0000-000000000801'::uuid, 'owner'),
   ('00000000-0000-0000-0000-000000000803'::uuid, '00000000-0000-0000-0000-000000000801'::uuid, 'manager'),
   ('00000000-0000-0000-0000-000000000804'::uuid, '00000000-0000-0000-0000-000000000801'::uuid, 'chef')
-ON CONFLICT (user_id, restaurant_id) DO UPDATE SET role = EXCLUDED.role;
+ON CONFLICT (user_id, restaurant_id) DO NOTHING;
 
 -- Test 1: owner is resolved through the profiles join
 SELECT ok(
@@ -70,15 +70,16 @@ SELECT is(
   'Only owner and manager roles count as approvers'
 );
 
--- Test 4: chef is NOT in the approver list
+-- Test 4: chef's email is NOT returned by the approver-filtered join
 SELECT ok(
   NOT EXISTS(
-    SELECT 1 FROM user_restaurants
-    WHERE restaurant_id = '00000000-0000-0000-0000-000000000801'::uuid
-      AND role = 'chef'
-      AND role IN ('owner', 'manager')
+    SELECT 1 FROM user_restaurants ur
+    JOIN profiles p ON p.user_id = ur.user_id
+    WHERE ur.restaurant_id = '00000000-0000-0000-0000-000000000801'::uuid
+      AND ur.role IN ('owner', 'manager')
+      AND p.email = 'chef-approver@test.com'
   ),
-  'chef role is excluded from approver resolution'
+  'chef email is excluded when filtering to owner/manager roles'
 );
 
 -- Test 5: join returns email for every approver (no null-profile rows)

--- a/tests/unit/NotificationSettings.test.tsx
+++ b/tests/unit/NotificationSettings.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const approverCountMock = vi.hoisted(() => vi.fn());
+const notificationSettingsMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/hooks/useApproverCount', () => ({
+  useApproverCount: approverCountMock,
+}));
+
+vi.mock('@/hooks/useNotificationSettings', () => ({
+  useNotificationSettings: notificationSettingsMock,
+  useUpdateNotificationSettings: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock('@/hooks/useNotificationPreferences', () => ({
+  useNotificationPreferences: () => ({
+    preferences: { weekly_brief_email: true },
+    updatePreferences: vi.fn(),
+    isUpdating: false,
+  }),
+}));
+
+import { NotificationSettings } from '@/components/NotificationSettings';
+
+function renderWithClient(ui: React.ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>
+  );
+}
+
+const baseSettings = {
+  notify_time_off_request: true,
+  notify_time_off_approved: true,
+  notify_time_off_rejected: true,
+  time_off_notify_managers: true,
+  time_off_notify_employee: true,
+};
+
+describe('NotificationSettings approver warning', () => {
+  beforeEach(() => {
+    approverCountMock.mockReset();
+    notificationSettingsMock.mockReset();
+  });
+
+  it('renders warning when notify_managers is on and approver count is 0', () => {
+    notificationSettingsMock.mockReturnValue({
+      settings: baseSettings,
+      loading: false,
+    });
+    approverCountMock.mockReturnValue({ data: 0, isLoading: false });
+
+    renderWithClient(<NotificationSettings restaurantId="rest-1" />);
+
+    expect(screen.getByText('No approvers configured')).toBeInTheDocument();
+  });
+
+  it('hides warning when at least one approver exists', () => {
+    notificationSettingsMock.mockReturnValue({
+      settings: baseSettings,
+      loading: false,
+    });
+    approverCountMock.mockReturnValue({ data: 2, isLoading: false });
+
+    renderWithClient(<NotificationSettings restaurantId="rest-1" />);
+
+    expect(screen.queryByText('No approvers configured')).not.toBeInTheDocument();
+  });
+
+  it('hides warning when notify_managers is off even if approverCount is 0', () => {
+    notificationSettingsMock.mockReturnValue({
+      settings: { ...baseSettings, time_off_notify_managers: false },
+      loading: false,
+    });
+    approverCountMock.mockReturnValue({ data: 0, isLoading: false });
+
+    renderWithClient(<NotificationSettings restaurantId="rest-1" />);
+
+    expect(screen.queryByText('No approvers configured')).not.toBeInTheDocument();
+  });
+
+  it('hides warning while approverCount is still loading', () => {
+    notificationSettingsMock.mockReturnValue({
+      settings: baseSettings,
+      loading: false,
+    });
+    approverCountMock.mockReturnValue({ data: undefined, isLoading: true });
+
+    renderWithClient(<NotificationSettings restaurantId="rest-1" />);
+
+    expect(screen.queryByText('No approvers configured')).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/NotificationSettings.test.tsx
+++ b/tests/unit/NotificationSettings.test.tsx
@@ -57,6 +57,7 @@ describe('NotificationSettings approver warning', () => {
 
     renderWithClient(<NotificationSettings restaurantId="rest-1" />);
 
+    expect(screen.getByRole('alert')).toBeInTheDocument();
     expect(screen.getByText('No approvers configured')).toBeInTheDocument();
   });
 
@@ -69,7 +70,7 @@ describe('NotificationSettings approver warning', () => {
 
     renderWithClient(<NotificationSettings restaurantId="rest-1" />);
 
-    expect(screen.queryByText('No approvers configured')).not.toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 
   it('hides warning when notify_managers is off even if approverCount is 0', () => {
@@ -81,7 +82,7 @@ describe('NotificationSettings approver warning', () => {
 
     renderWithClient(<NotificationSettings restaurantId="rest-1" />);
 
-    expect(screen.queryByText('No approvers configured')).not.toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 
   it('hides warning while approverCount is still loading', () => {
@@ -93,6 +94,6 @@ describe('NotificationSettings approver warning', () => {
 
     renderWithClient(<NotificationSettings restaurantId="rest-1" />);
 
-    expect(screen.queryByText('No approvers configured')).not.toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/NotificationSettings.test.tsx
+++ b/tests/unit/NotificationSettings.test.tsx
@@ -96,4 +96,20 @@ describe('NotificationSettings approver warning', () => {
 
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
+
+  it('hides warning when the approver count query errors (undefined count should not be treated as zero)', () => {
+    notificationSettingsMock.mockReturnValue({
+      settings: baseSettings,
+      loading: false,
+    });
+    approverCountMock.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    });
+
+    renderWithClient(<NotificationSettings restaurantId="rest-1" />);
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
 });

--- a/tests/unit/sendTimeOffNotification-buildEmails.test.ts
+++ b/tests/unit/sendTimeOffNotification-buildEmails.test.ts
@@ -3,7 +3,7 @@ import { buildEmails } from '../../supabase/functions/send-time-off-notification
 
 type ManagerRow = {
   user_id: string;
-  profiles: { email: string | null } | null;
+  profiles: { email?: string | null } | null;
 };
 
 interface MockResult {
@@ -63,7 +63,7 @@ describe('buildEmails', () => {
     });
     expect(result.emails).toEqual(['employee@example.com']);
     expect(result.employeeIncluded).toBe(true);
-    expect(result.managerCount).toBe(0);
+    expect(result.managersFound).toBe(0);
     expect(result.managerLookupError).toBeUndefined();
     expect(supabase.from).not.toHaveBeenCalled();
   });
@@ -90,7 +90,7 @@ describe('buildEmails', () => {
     expect(calls.inCol).toBe('role');
     expect(calls.inVals).toEqual(['owner', 'manager']);
     expect(result.emails.sort()).toEqual(['manager@example.com', 'owner@example.com']);
-    expect(result.managerCount).toBe(2);
+    expect(result.managersFound).toBe(2);
     expect(result.employeeIncluded).toBe(false);
   });
 
@@ -111,7 +111,7 @@ describe('buildEmails', () => {
     });
     expect(result.emails.sort()).toEqual(['other@example.com', 'shared@example.com']);
     expect(result.employeeIncluded).toBe(true);
-    expect(result.managerCount).toBe(2);
+    expect(result.managersFound).toBe(2);
   });
 
   it('captures managerLookupError when the query errors', async () => {
@@ -127,7 +127,7 @@ describe('buildEmails', () => {
       notifyManagers: true,
     });
     expect(result.emails).toEqual([]);
-    expect(result.managerCount).toBe(0);
+    expect(result.managersFound).toBe(0);
     expect(result.managerLookupError).toBe('relation profiles does not exist');
   });
 
@@ -142,7 +142,7 @@ describe('buildEmails', () => {
     });
     expect(result.emails).toEqual([]);
     expect(result.employeeIncluded).toBe(false);
-    expect(result.managerCount).toBe(0);
+    expect(result.managersFound).toBe(0);
     expect(supabase.from).not.toHaveBeenCalled();
   });
 
@@ -163,6 +163,6 @@ describe('buildEmails', () => {
       notifyManagers: true,
     });
     expect(result.emails).toEqual(['real@example.com']);
-    expect(result.managerCount).toBe(1);
+    expect(result.managersFound).toBe(1);
   });
 });

--- a/tests/unit/sendTimeOffNotification-buildEmails.test.ts
+++ b/tests/unit/sendTimeOffNotification-buildEmails.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi } from 'vitest';
+import { buildEmails } from '../../supabase/functions/send-time-off-notification/buildEmails';
+
+type ManagerRow = {
+  user_id: string;
+  profiles: { email: string | null } | null;
+};
+
+interface MockResult {
+  data: ManagerRow[] | null;
+  error: { message: string } | null;
+}
+
+/**
+ * Builds a supabase-like stub that captures the call chain for assertions
+ * and returns whatever MockResult the test supplies.
+ */
+function makeSupabaseStub(result: MockResult) {
+  const calls = {
+    table: '' as string,
+    select: '' as string,
+    eqCol: '' as string,
+    eqVal: '' as string,
+    inCol: '' as string,
+    inVals: [] as string[],
+  };
+  const chain = {
+    select: (cols: string) => {
+      calls.select = cols;
+      return {
+        eq: (col: string, val: string) => {
+          calls.eqCol = col;
+          calls.eqVal = val;
+          return {
+            in: async (col: string, vals: string[]) => {
+              calls.inCol = col;
+              calls.inVals = vals;
+              return result;
+            },
+          };
+        },
+      };
+    },
+  };
+  const supabase = {
+    from: vi.fn((table: string) => {
+      calls.table = table;
+      return chain;
+    }),
+  };
+  return { supabase, calls };
+}
+
+describe('buildEmails', () => {
+  it('returns only employee when notifyEmployee=true and notifyManagers=false', async () => {
+    const { supabase } = makeSupabaseStub({ data: [], error: null });
+    const result = await buildEmails({
+      supabase: supabase as never,
+      restaurantId: 'rest-1',
+      employeeEmail: 'employee@example.com',
+      notifyEmployee: true,
+      notifyManagers: false,
+    });
+    expect(result.emails).toEqual(['employee@example.com']);
+    expect(result.employeeIncluded).toBe(true);
+    expect(result.managerCount).toBe(0);
+    expect(result.managerLookupError).toBeUndefined();
+    expect(supabase.from).not.toHaveBeenCalled();
+  });
+
+  it('queries user_restaurants joined to profiles for managers', async () => {
+    const { supabase, calls } = makeSupabaseStub({
+      data: [
+        { user_id: 'u1', profiles: { email: 'owner@example.com' } },
+        { user_id: 'u2', profiles: { email: 'manager@example.com' } },
+      ],
+      error: null,
+    });
+    const result = await buildEmails({
+      supabase: supabase as never,
+      restaurantId: 'rest-1',
+      employeeEmail: null,
+      notifyEmployee: false,
+      notifyManagers: true,
+    });
+    expect(calls.table).toBe('user_restaurants');
+    expect(calls.select).toContain('profiles:user_id');
+    expect(calls.eqCol).toBe('restaurant_id');
+    expect(calls.eqVal).toBe('rest-1');
+    expect(calls.inCol).toBe('role');
+    expect(calls.inVals).toEqual(['owner', 'manager']);
+    expect(result.emails.sort()).toEqual(['manager@example.com', 'owner@example.com']);
+    expect(result.managerCount).toBe(2);
+    expect(result.employeeIncluded).toBe(false);
+  });
+
+  it('de-duplicates when employee is also a manager', async () => {
+    const { supabase } = makeSupabaseStub({
+      data: [
+        { user_id: 'u1', profiles: { email: 'shared@example.com' } },
+        { user_id: 'u2', profiles: { email: 'other@example.com' } },
+      ],
+      error: null,
+    });
+    const result = await buildEmails({
+      supabase: supabase as never,
+      restaurantId: 'rest-1',
+      employeeEmail: 'shared@example.com',
+      notifyEmployee: true,
+      notifyManagers: true,
+    });
+    expect(result.emails.sort()).toEqual(['other@example.com', 'shared@example.com']);
+    expect(result.employeeIncluded).toBe(true);
+    expect(result.managerCount).toBe(2);
+  });
+
+  it('captures managerLookupError when the query errors', async () => {
+    const { supabase } = makeSupabaseStub({
+      data: null,
+      error: { message: 'relation profiles does not exist' },
+    });
+    const result = await buildEmails({
+      supabase: supabase as never,
+      restaurantId: 'rest-1',
+      employeeEmail: null,
+      notifyEmployee: false,
+      notifyManagers: true,
+    });
+    expect(result.emails).toEqual([]);
+    expect(result.managerCount).toBe(0);
+    expect(result.managerLookupError).toBe('relation profiles does not exist');
+  });
+
+  it('returns empty list when both flags are false', async () => {
+    const { supabase } = makeSupabaseStub({ data: [], error: null });
+    const result = await buildEmails({
+      supabase: supabase as never,
+      restaurantId: 'rest-1',
+      employeeEmail: 'employee@example.com',
+      notifyEmployee: false,
+      notifyManagers: false,
+    });
+    expect(result.emails).toEqual([]);
+    expect(result.employeeIncluded).toBe(false);
+    expect(result.managerCount).toBe(0);
+    expect(supabase.from).not.toHaveBeenCalled();
+  });
+
+  it('skips manager rows with null profiles or null email', async () => {
+    const { supabase } = makeSupabaseStub({
+      data: [
+        { user_id: 'u1', profiles: null },
+        { user_id: 'u2', profiles: { email: null } },
+        { user_id: 'u3', profiles: { email: 'real@example.com' } },
+      ],
+      error: null,
+    });
+    const result = await buildEmails({
+      supabase: supabase as never,
+      restaurantId: 'rest-1',
+      employeeEmail: null,
+      notifyEmployee: false,
+      notifyManagers: true,
+    });
+    expect(result.emails).toEqual(['real@example.com']);
+    expect(result.managerCount).toBe(1);
+  });
+});

--- a/tests/unit/sendTimeOffNotification-buildEmails.test.ts
+++ b/tests/unit/sendTimeOffNotification-buildEmails.test.ts
@@ -52,7 +52,7 @@ function makeSupabaseStub(result: MockResult) {
 }
 
 describe('buildEmails', () => {
-  it('returns only employee when notifyEmployee=true and notifyManagers=false', async () => {
+  it('CRITICAL: returns only employee when notifyEmployee=true and notifyManagers=false', async () => {
     const { supabase } = makeSupabaseStub({ data: [], error: null });
     const result = await buildEmails({
       supabase: supabase as never,
@@ -68,7 +68,7 @@ describe('buildEmails', () => {
     expect(supabase.from).not.toHaveBeenCalled();
   });
 
-  it('queries user_restaurants joined to profiles for managers', async () => {
+  it('CRITICAL: queries user_restaurants joined to profiles for managers', async () => {
     const { supabase, calls } = makeSupabaseStub({
       data: [
         { user_id: 'u1', profiles: { email: 'owner@example.com' } },
@@ -94,7 +94,7 @@ describe('buildEmails', () => {
     expect(result.employeeIncluded).toBe(false);
   });
 
-  it('de-duplicates when employee is also a manager', async () => {
+  it('CRITICAL: de-duplicates when employee is also a manager', async () => {
     const { supabase } = makeSupabaseStub({
       data: [
         { user_id: 'u1', profiles: { email: 'shared@example.com' } },
@@ -114,7 +114,7 @@ describe('buildEmails', () => {
     expect(result.managersFound).toBe(2);
   });
 
-  it('captures managerLookupError when the query errors', async () => {
+  it('CRITICAL: captures managerLookupError when the query errors', async () => {
     const { supabase } = makeSupabaseStub({
       data: null,
       error: { message: 'relation profiles does not exist' },
@@ -131,7 +131,7 @@ describe('buildEmails', () => {
     expect(result.managerLookupError).toBe('relation profiles does not exist');
   });
 
-  it('returns empty list when both flags are false', async () => {
+  it('CRITICAL: returns empty list when both flags are false', async () => {
     const { supabase } = makeSupabaseStub({ data: [], error: null });
     const result = await buildEmails({
       supabase: supabase as never,
@@ -146,7 +146,7 @@ describe('buildEmails', () => {
     expect(supabase.from).not.toHaveBeenCalled();
   });
 
-  it('skips manager rows with null profiles or null email', async () => {
+  it('CRITICAL: skips manager rows with null profiles or null email', async () => {
     const { supabase } = makeSupabaseStub({
       data: [
         { user_id: 'u1', profiles: null },

--- a/tests/unit/useApproverCount.test.ts
+++ b/tests/unit/useApproverCount.test.ts
@@ -1,0 +1,88 @@
+import React, { ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockSupabase = vi.hoisted(() => ({
+  from: vi.fn(),
+}));
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: mockSupabase,
+}));
+
+import { useApproverCount } from '@/hooks/useApproverCount';
+
+function createWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return React.createElement(QueryClientProvider, { client }, children);
+  };
+}
+
+function makeCountStub(count: number | null, error: unknown = null) {
+  return {
+    select: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        in: vi.fn(async () => ({ count, error })),
+      })),
+    })),
+  };
+}
+
+describe('useApproverCount', () => {
+  beforeEach(() => {
+    mockSupabase.from.mockReset();
+  });
+
+  it('returns 0 when restaurantId is undefined without hitting the client', async () => {
+    const { result } = renderHook(() => useApproverCount(undefined), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(result.current.isFetching).toBe(false);
+    });
+    expect(result.current.data).toBe(0);
+    expect(mockSupabase.from).not.toHaveBeenCalled();
+  });
+
+  it('fetches count from user_restaurants with owner/manager roles', async () => {
+    const stub = makeCountStub(3);
+    mockSupabase.from.mockReturnValue(stub);
+
+    const { result } = renderHook(() => useApproverCount('rest-1'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.data).toBe(3));
+
+    expect(mockSupabase.from).toHaveBeenCalledWith('user_restaurants');
+    expect(stub.select).toHaveBeenCalledWith('*', { count: 'exact', head: true });
+    const eqCall = stub.select.mock.results[0].value.eq;
+    expect(eqCall).toHaveBeenCalledWith('restaurant_id', 'rest-1');
+    const inCall = eqCall.mock.results[0].value.in;
+    expect(inCall).toHaveBeenCalledWith('role', ['owner', 'manager']);
+  });
+
+  it('returns 0 when the count is null', async () => {
+    mockSupabase.from.mockReturnValue(makeCountStub(null));
+    const { result } = renderHook(() => useApproverCount('rest-1'), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(0);
+  });
+
+  it('surfaces errors through React Query', async () => {
+    mockSupabase.from.mockReturnValue(
+      makeCountStub(null, { message: 'boom' })
+    );
+    const { result } = renderHook(() => useApproverCount('rest-1'), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect((result.current.error as { message: string }).message).toBe('boom');
+  });
+});

--- a/tests/unit/useApproverCount.test.ts
+++ b/tests/unit/useApproverCount.test.ts
@@ -37,14 +37,14 @@ describe('useApproverCount', () => {
     mockSupabase.from.mockReset();
   });
 
-  it('returns 0 when restaurantId is undefined without hitting the client', async () => {
+  it('does not fetch when restaurantId is undefined', async () => {
     const { result } = renderHook(() => useApproverCount(undefined), {
       wrapper: createWrapper(),
     });
     await waitFor(() => {
       expect(result.current.isFetching).toBe(false);
     });
-    expect(result.current.data).toBe(0);
+    expect(result.current.data).toBeUndefined();
     expect(mockSupabase.from).not.toHaveBeenCalled();
   });
 
@@ -59,7 +59,7 @@ describe('useApproverCount', () => {
     await waitFor(() => expect(result.current.data).toBe(3));
 
     expect(mockSupabase.from).toHaveBeenCalledWith('user_restaurants');
-    expect(stub.select).toHaveBeenCalledWith('*', { count: 'exact', head: true });
+    expect(stub.select).toHaveBeenCalledWith('id', { count: 'exact', head: true });
     const eqCall = stub.select.mock.results[0].value.eq;
     expect(eqCall).toHaveBeenCalledWith('restaurant_id', 'rest-1');
     const inCall = eqCall.mock.results[0].value.in;


### PR DESCRIPTION
## Summary

Fixes a silent-failure mode where owners/managers got no email when an employee submitted a time-off request, even with **Notify Managers** enabled. The edge function used a PostgREST cross-schema join (`user:auth.users(email)`) that returned empty without erroring, so the failure was invisible to operators.

This branch:

- **Extracts** recipient resolution into a pure, Vitest-importable module (`buildEmails.ts`) using the working `profiles:user_id(email)` join pattern already used elsewhere in the codebase.
- **Adds observability** — the edge function now logs (`error`/`warn`/`info`) when the manager lookup fails, when `notify_managers=true` resolves zero approvers, and a structured summary after every send (`attempted`, `employeeIncluded`, `managersFound`).
- **Surfaces the UX gap** — a new `useApproverCount` hook drives an amber warning card in Notification Settings that tells admins when their restaurant has zero owners/managers to receive the notification.
- **Treats owners + managers as approvers** — per the user question that opened this work ("I don't think we have the concept of Manager set in the employee details"), since roles don't have a separate "manager" concept outside `user_restaurants.role`, both `owner` and `manager` roles receive notifications.

No DB migration. No external API changes. The spec and plan are committed under `docs/superpowers/`.

## Files changed

- `supabase/functions/send-time-off-notification/buildEmails.ts` — new, type-agnostic, Vitest-importable
- `supabase/functions/send-time-off-notification/index.ts` — rewired to extracted module + 3 log sites
- `supabase/tests/notification_approver_resolution.test.sql` — new, 6 pgTAP assertions
- `src/hooks/useApproverCount.ts` — new React Query hook (60s staleTime, `enabled: !!restaurantId`)
- `src/components/NotificationSettings.tsx` — amber warning card between Notify Managers toggle and its separator
- `tests/unit/sendTimeOffNotification-buildEmails.test.ts` — 6 cases
- `tests/unit/useApproverCount.test.ts` — 4 cases
- `tests/unit/NotificationSettings.test.tsx` — 4 cases

## Test plan

- [x] `npm run test` — 3566/3567 pass (1 pre-existing skip), including the 14 new unit tests (6+4+4)
- [x] `npm run test:db` — 1214/1214 pgTAP assertions pass, including the 6 new ones verifying the owner/manager join and chef exclusion
- [x] `npm run typecheck` — zero errors in branch files (4 pre-existing errors remain in unrelated files: `useShiftCopyDnd.ts`, `ShiftDialog.tsx`, `useAvailableShifts.ts`, `useMonthlyMetrics.tsx`)
- [x] `npm run lint` — no new lint errors in branch files
- [x] `npm run build` — production build succeeds
- [ ] **UI browser spot-check** — not done in the agent environment. To exercise the warning: open Notification Settings for a restaurant with no owners/managers configured, enable **Notify Managers**, confirm the amber card appears below the toggle.
- [ ] **E2E** — skipped locally due to a pre-existing Playwright auth-timeout in the environment, unrelated to this branch. CI should exercise them normally.

## Risk notes

- Existing tenants with \`time_off_notify_managers=true\` who were silently getting nothing will START receiving emails after merge. This is the intended fix, but worth calling out for support/comms.
- Rollback is a single revert — no schema change, no migration.
- The edge function still uses the service role key; the new join does not change auth boundaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a warning in notification settings alerting when manager notifications are enabled but no owner/manager approvers are configured for a restaurant.

* **Bug Fixes**
  * Improved time-off notification delivery to managers with enhanced error handling and logging when manager lookup fails.

* **Tests**
  * Added comprehensive unit and database tests for approver resolution and notification logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->