### PR TITLE
fix(dashboard): exclude transfer-category transactions from P&L

### DIFF
--- a/docs/superpowers/plans/2026-04-26-transfer-category-classification-plan.md
+++ b/docs/superpowers/plans/2026-04-26-transfer-category-classification-plan.md
@@ -21,7 +21,7 @@
 | `src/lib/expenseDataFetcher.ts` | Modify — widen `chart_of_accounts` shape with `account_type`, add `account_type` to all 3 SELECT projections, filter results through `isTransferCategoryType` |
 | `tests/unit/expenseDataFetcher.test.ts` | Create — mocked Supabase, asserts asset/liability/equity-typed rows are excluded from each of the 3 returned arrays |
 | `src/hooks/useExpenseHealth.tsx` | Modify — add the missing `.eq('is_transfer', false)`, add `account_type` to projection, exclude transfer-typed rows from revenue + outflow + uncategorized reductions |
-| `tests/unit/useExpenseHealth.test.ts` | Create — mocked Supabase, asserts revenue / foodCost / laborCost / uncategorizedSpend exclude transfer-typed rows |
+| `tests/unit/useExpenseHealth.test.tsx` | Create — mocked Supabase, asserts revenue / foodCost / laborCost / uncategorizedSpend exclude transfer-typed rows |
 | `src/hooks/useBankTransactions.tsx` | Modify — add `account_type` to the embedded `chart_account` projection (line 140-143) and to the `BankTransaction.chart_account` interface (line 57-60) |
 | `src/pages/Index.tsx` | Modify — daily-spending filter at lines 310-318, exclude rows where `chart_account.account_type` is asset/liability/equity |
 | `supabase/tests/categorize_transfer_account.sql` | Create — pgTAP test pinning that `categorize_bank_transaction` does NOT touch `is_transfer`, and that the chart_of_accounts join exposes `account_type` |
@@ -507,12 +507,12 @@ git commit -m "fix(dashboard): exclude transfer-typed categories from expense ag
 ## Task 3: Fix `useExpenseHealth` (revenue + outflow + uncategorized)
 
 **Files:**
-- Create: `tests/unit/useExpenseHealth.test.ts`
+- Create: `tests/unit/useExpenseHealth.test.tsx`
 - Modify: `src/hooks/useExpenseHealth.tsx`
 
 - [ ] **Step 3.1: Write failing test**
 
-Create `tests/unit/useExpenseHealth.test.ts`:
+Create `tests/unit/useExpenseHealth.test.tsx`:
 
 ```ts
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -667,7 +667,7 @@ describe('useExpenseHealth', () => {
 - [ ] **Step 3.2: Run test, watch it fail**
 
 ```bash
-npm run test -- tests/unit/useExpenseHealth.test.ts
+npm run test -- tests/unit/useExpenseHealth.test.tsx
 ```
 
 Expected: both tests fail. (`is_transfer` filter not applied; revenue includes the transfer inflow.)
@@ -706,7 +706,7 @@ const pnlTxns = txns.filter(
 - [ ] **Step 3.4: Run test, watch it pass**
 
 ```bash
-npm run test -- tests/unit/useExpenseHealth.test.ts
+npm run test -- tests/unit/useExpenseHealth.test.tsx
 ```
 
 Expected: both tests pass.
@@ -714,7 +714,7 @@ Expected: both tests pass.
 - [ ] **Step 3.5: Commit**
 
 ```bash
-git add src/hooks/useExpenseHealth.tsx tests/unit/useExpenseHealth.test.ts
+git add src/hooks/useExpenseHealth.tsx tests/unit/useExpenseHealth.test.tsx
 git commit -m "fix(dashboard): is_transfer + transfer-typed exclusion in expense health"
 ```
 

--- a/docs/superpowers/plans/2026-04-26-transfer-category-classification-plan.md
+++ b/docs/superpowers/plans/2026-04-26-transfer-category-classification-plan.md
@@ -1,0 +1,938 @@
+# Transfer-Category P&L Classification Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bank transactions whose category's `account_type` is `asset|liability|equity` (e.g., "Transfer Clearing Account") must be excluded from monthly Income, Expense, and daily-spending aggregations on the dashboard.
+
+**Architecture:** Approach B (read-path filter). A new `isTransferCategoryType()` helper in `chartOfAccountsUtils.ts` is the single source of truth. Every aggregation that derives P&L from bank transactions / pending outflows / split lines applies the helper after fetch. No write-time changes; no data migration.
+
+**Tech Stack:** TypeScript, React Query, Supabase JS client, Vitest, pgTAP.
+
+**Spec:** `docs/superpowers/specs/2026-04-26-transfer-category-classification-design.md`
+
+---
+
+## File Map
+
+| Path | Action |
+|---|---|
+| `src/lib/chartOfAccountsUtils.ts` | Modify — add `NON_PNL_ACCOUNT_TYPES` const + `isTransferCategoryType()` helper |
+| `tests/unit/chartOfAccountsUtils.test.ts` | Modify — add a `describe('isTransferCategoryType', ...)` block |
+| `src/lib/expenseDataFetcher.ts` | Modify — widen `chart_of_accounts` shape with `account_type`, add `account_type` to all 3 SELECT projections, filter results through `isTransferCategoryType` |
+| `tests/unit/expenseDataFetcher.test.ts` | Create — mocked Supabase, asserts asset/liability/equity-typed rows are excluded from each of the 3 returned arrays |
+| `src/hooks/useExpenseHealth.tsx` | Modify — add the missing `.eq('is_transfer', false)`, add `account_type` to projection, exclude transfer-typed rows from revenue + outflow + uncategorized reductions |
+| `tests/unit/useExpenseHealth.test.ts` | Create — mocked Supabase, asserts revenue / foodCost / laborCost / uncategorizedSpend exclude transfer-typed rows |
+| `src/hooks/useBankTransactions.tsx` | Modify — add `account_type` to the embedded `chart_account` projection (line 140-143) and to the `BankTransaction.chart_account` interface (line 57-60) |
+| `src/pages/Index.tsx` | Modify — daily-spending filter at lines 310-318, exclude rows where `chart_account.account_type` is asset/liability/equity |
+| `supabase/tests/categorize_transfer_account.sql` | Create — pgTAP test pinning that `categorize_bank_transaction` does NOT touch `is_transfer`, and that the chart_of_accounts join exposes `account_type` |
+
+---
+
+## Task 1: Add `isTransferCategoryType` helper
+
+**Files:**
+- Modify: `src/lib/chartOfAccountsUtils.ts`
+- Modify: `tests/unit/chartOfAccountsUtils.test.ts`
+
+- [ ] **Step 1.1: Write failing tests**
+
+Append the following block to `tests/unit/chartOfAccountsUtils.test.ts` (inside the existing top-level `describe('chartOfAccountsUtils', ...)`):
+
+```ts
+import {
+  createDefaultChartOfAccounts,
+  DEFAULT_ACCOUNTS,
+  isTransferCategoryType,
+} from '@/lib/chartOfAccountsUtils';
+
+// ... existing tests ...
+
+  describe('isTransferCategoryType', () => {
+    it.each(['asset', 'liability', 'equity'] as const)(
+      'returns true for non-P&L type "%s"',
+      (type) => {
+        expect(isTransferCategoryType(type)).toBe(true);
+      },
+    );
+
+    it.each(['expense', 'cogs', 'revenue'] as const)(
+      'returns false for P&L type "%s"',
+      (type) => {
+        expect(isTransferCategoryType(type)).toBe(false);
+      },
+    );
+
+    it('returns false for null', () => {
+      expect(isTransferCategoryType(null)).toBe(false);
+    });
+
+    it('returns false for undefined', () => {
+      expect(isTransferCategoryType(undefined)).toBe(false);
+    });
+
+    it('returns false for an empty string', () => {
+      expect(isTransferCategoryType('')).toBe(false);
+    });
+
+    it('returns false for an unknown string', () => {
+      expect(isTransferCategoryType('something_else')).toBe(false);
+    });
+  });
+```
+
+(The existing top-level import line `import { createDefaultChartOfAccounts, DEFAULT_ACCOUNTS } from '@/lib/chartOfAccountsUtils';` should be widened to include `isTransferCategoryType` as shown above — replace the existing import; do not duplicate.)
+
+- [ ] **Step 1.2: Run test, watch it fail**
+
+```bash
+npm run test -- tests/unit/chartOfAccountsUtils.test.ts
+```
+
+Expected: failures referencing `isTransferCategoryType is not a function` (or import error).
+
+- [ ] **Step 1.3: Implement helper**
+
+Append to `src/lib/chartOfAccountsUtils.ts` (after the existing exports):
+
+```ts
+import type { AccountType } from '@/hooks/useChartOfAccounts';
+
+const NON_PNL_ACCOUNT_TYPES: ReadonlySet<AccountType> = new Set([
+  'asset',
+  'liability',
+  'equity',
+]);
+
+/**
+ * Categories whose chart-of-accounts type is asset, liability, or equity
+ * are not P&L events — e.g. "Transfer Clearing Account" or "Inter-Account
+ * Transfer". The dashboard's income/expense aggregations must exclude them.
+ */
+export function isTransferCategoryType(
+  accountType: string | null | undefined,
+): boolean {
+  if (!accountType) return false;
+  return NON_PNL_ACCOUNT_TYPES.has(accountType as AccountType);
+}
+```
+
+If `chartOfAccountsUtils.ts` already imports from `@/hooks/useChartOfAccounts` somewhere, just append to that existing import; otherwise add a fresh `import type` line at the top of the file.
+
+- [ ] **Step 1.4: Run tests, watch them pass**
+
+```bash
+npm run test -- tests/unit/chartOfAccountsUtils.test.ts
+```
+
+Expected: all `isTransferCategoryType` tests pass; existing `createDefaultChartOfAccounts` tests still pass.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add src/lib/chartOfAccountsUtils.ts tests/unit/chartOfAccountsUtils.test.ts
+git commit -m "feat(coa): add isTransferCategoryType helper for P&L exclusion"
+```
+
+---
+
+## Task 2: Filter `expenseDataFetcher` by category type
+
+**Files:**
+- Create: `tests/unit/expenseDataFetcher.test.ts`
+- Modify: `src/lib/expenseDataFetcher.ts`
+
+- [ ] **Step 2.1: Write failing test**
+
+Create `tests/unit/expenseDataFetcher.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the Supabase client BEFORE importing the module under test.
+const txnRows = [
+  {
+    id: 'tx-expense-1',
+    transaction_date: '2026-04-15',
+    amount: -100,
+    status: 'posted',
+    description: 'Real expense',
+    merchant_name: null,
+    normalized_payee: null,
+    category_id: 'cat-expense',
+    is_split: false,
+    ai_confidence: null,
+    chart_of_accounts: {
+      account_name: 'Office Supplies',
+      account_subtype: 'office_supplies',
+      account_type: 'expense',
+    },
+  },
+  {
+    id: 'tx-transfer-1',
+    transaction_date: '2026-04-15',
+    amount: -500,
+    status: 'posted',
+    description: 'Transfer to savings',
+    merchant_name: null,
+    normalized_payee: null,
+    category_id: 'cat-transfer',
+    is_split: false,
+    ai_confidence: null,
+    chart_of_accounts: {
+      account_name: 'Transfer Clearing Account',
+      account_subtype: 'cash',
+      account_type: 'asset',
+    },
+  },
+];
+
+const pendingOutflowRows = [
+  {
+    amount: 200,
+    category_id: 'cat-expense',
+    issue_date: '2026-04-10',
+    status: 'pending',
+    chart_account: {
+      account_name: 'Office Supplies',
+      account_subtype: 'office_supplies',
+      account_type: 'expense',
+    },
+  },
+  {
+    amount: 800,
+    category_id: 'cat-transfer',
+    issue_date: '2026-04-10',
+    status: 'pending',
+    chart_account: {
+      account_name: 'Transfer Clearing Account',
+      account_subtype: 'cash',
+      account_type: 'asset',
+    },
+  },
+];
+
+const splitRows = [
+  {
+    transaction_id: 'tx-split-parent',
+    amount: 50,
+    category_id: 'cat-expense',
+    chart_of_accounts: {
+      account_name: 'Office Supplies',
+      account_subtype: 'office_supplies',
+      account_type: 'expense',
+    },
+  },
+  {
+    transaction_id: 'tx-split-parent',
+    amount: 70,
+    category_id: 'cat-equity',
+    chart_of_accounts: {
+      account_name: 'Inter-Account Transfer',
+      account_subtype: 'owners_equity',
+      account_type: 'equity',
+    },
+  },
+];
+
+// We need the mocked builder to be readable by the test, so define it once
+// and reuse across the three .from() calls.
+function makeQuery(returnRows: unknown) {
+  const order = vi.fn().mockResolvedValue({ data: returnRows, error: null });
+  const builder: Record<string, unknown> = {};
+  const passthrough = () => builder;
+  for (const m of ['select', 'eq', 'in', 'is', 'lt', 'lte', 'gte']) {
+    builder[m] = vi.fn(passthrough);
+  }
+  builder.order = order;
+  // For pending_outflows / splits the call doesn't end in .order — return data directly.
+  // We make these chainable methods also resolve when awaited as the terminal call.
+  for (const m of ['eq', 'in', 'is', 'lte', 'gte']) {
+    (builder[m] as ReturnType<typeof vi.fn>).mockImplementation(() =>
+      Object.assign(builder, {
+        then: (cb: (v: { data: unknown; error: null }) => unknown) =>
+          cb({ data: returnRows, error: null }),
+      }),
+    );
+  }
+  return builder;
+}
+
+vi.mock('@/integrations/supabase/client', () => {
+  return {
+    supabase: {
+      from: vi.fn((table: string) => {
+        if (table === 'bank_transactions') return makeQuery(txnRows);
+        if (table === 'pending_outflows') return makeQuery(pendingOutflowRows);
+        if (table === 'bank_transaction_splits') return makeQuery(splitRows);
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    },
+  };
+});
+
+import { fetchExpenseData } from '@/lib/expenseDataFetcher';
+
+describe('fetchExpenseData', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('excludes bank transactions whose category is asset/liability/equity-typed', async () => {
+    const result = await fetchExpenseData({
+      restaurantId: 'r-1',
+      startDate: new Date('2026-04-01'),
+      endDate: new Date('2026-04-30'),
+    });
+
+    const ids = result.transactions.map((t) => t.id);
+    expect(ids).toContain('tx-expense-1');
+    expect(ids).not.toContain('tx-transfer-1');
+  });
+
+  it('excludes pending outflows whose category is asset/liability/equity-typed', async () => {
+    const result = await fetchExpenseData({
+      restaurantId: 'r-1',
+      startDate: new Date('2026-04-01'),
+      endDate: new Date('2026-04-30'),
+    });
+
+    const amounts = result.pendingOutflows.map((p) => p.amount);
+    expect(amounts).toContain(200);
+    expect(amounts).not.toContain(800);
+  });
+
+  it('excludes split line items whose category is asset/liability/equity-typed', async () => {
+    // Make the parent appear as a split-parent so split lookup runs.
+    txnRows.push({
+      id: 'tx-split-parent',
+      transaction_date: '2026-04-15',
+      amount: -120,
+      status: 'posted',
+      description: 'Split parent',
+      merchant_name: null,
+      normalized_payee: null,
+      category_id: null,
+      is_split: true,
+      ai_confidence: null,
+      chart_of_accounts: null,
+    } as never);
+
+    const result = await fetchExpenseData({
+      restaurantId: 'r-1',
+      startDate: new Date('2026-04-01'),
+      endDate: new Date('2026-04-30'),
+    });
+
+    const splitAmounts = result.splitDetails.map((s) => s.amount);
+    expect(splitAmounts).toContain(50);
+    expect(splitAmounts).not.toContain(70);
+
+    txnRows.pop();
+  });
+});
+```
+
+- [ ] **Step 2.2: Run test, watch it fail**
+
+```bash
+npm run test -- tests/unit/expenseDataFetcher.test.ts
+```
+
+Expected: failures because `tx-transfer-1` IS in `result.transactions` (and similar for pendingOutflows / splits). The fetcher hasn't been taught to filter on `account_type` yet.
+
+- [ ] **Step 2.3: Implement the fix in `src/lib/expenseDataFetcher.ts`**
+
+Three concrete edits:
+
+(a) **Widen the three interfaces** at the top of the file:
+
+```ts
+export interface ExpenseTransaction {
+  id: string;
+  transaction_date: string;
+  amount: number;
+  status: string;
+  description: string;
+  merchant_name: string | null;
+  normalized_payee: string | null;
+  category_id: string | null;
+  is_split: boolean;
+  ai_confidence: string | null;
+  chart_of_accounts: {
+    account_name: string;
+    account_subtype: string;
+    account_type: string;
+  } | null;
+}
+
+export interface PendingOutflowRecord {
+  amount: number;
+  category_id: string | null;
+  issue_date: string;
+  status: string;
+  chart_account: {
+    account_name: string;
+    account_subtype: string;
+    account_type: string;
+  } | null;
+}
+
+export interface SplitDetail {
+  transaction_id: string;
+  amount: number;
+  category_id: string;
+  chart_of_accounts: {
+    account_name: string;
+    account_subtype: string;
+    account_type: string;
+  } | null;
+}
+```
+
+(b) **Add `account_type` to all three SELECT projections.** In `fetchExpenseData`:
+
+```ts
+// transactions
+.select(`
+  id,
+  transaction_date,
+  amount,
+  status,
+  description,
+  merchant_name,
+  normalized_payee,
+  category_id,
+  is_split,
+  ai_confidence,
+  chart_of_accounts!category_id(account_name, account_subtype, account_type)
+`)
+```
+
+```ts
+// pending outflows
+.select(`
+  amount,
+  category_id,
+  issue_date,
+  status,
+  chart_account:chart_of_accounts!category_id(account_name, account_subtype, account_type)
+`)
+```
+
+```ts
+// splits
+.select(`
+  transaction_id,
+  amount,
+  category_id,
+  chart_of_accounts:chart_of_accounts!category_id(account_name, account_subtype, account_type)
+`)
+```
+
+(c) **Filter results before returning.** Add an import at the top:
+
+```ts
+import { isTransferCategoryType } from '@/lib/chartOfAccountsUtils';
+```
+
+Then, immediately after each fetch result is captured, filter it. Concretely:
+
+After `const txns = (transactions || []) as ExpenseTransaction[];`:
+
+```ts
+const filteredTxns = txns.filter(
+  (t) => !isTransferCategoryType(t.chart_of_accounts?.account_type),
+);
+```
+
+After `const pendingOutflowRecords = (pendingOutflows || []) as PendingOutflowRecord[];`:
+
+```ts
+const filteredPendingOutflows = pendingOutflowRecords.filter(
+  (p) => !isTransferCategoryType(p.chart_account?.account_type),
+);
+```
+
+After `splitDetails = (splits || []) as SplitDetail[];`:
+
+```ts
+splitDetails = splitDetails.filter(
+  (s) => !isTransferCategoryType(s.chart_of_accounts?.account_type),
+);
+```
+
+Replace the **previously-used local names** (`txns`, `pendingOutflowRecords`) in the rest of the function with `filteredTxns` and `filteredPendingOutflows`. Specifically:
+
+- `currentPeriodTxns = filteredTxns.filter(...)`
+- The `splitParentIds` derivation must read from `filteredTxns`
+- The two `txns.filter(...)` calls inside the `includePreviousPeriod` block become `filteredTxns.filter(...)`
+- Both `return` statements use `filteredTxns` and `filteredPendingOutflows` (the variable names in the returned object stay `transactions`, `pendingOutflows`, `splitDetails` — those are the public API).
+
+Update the JSDoc comment on `fetchExpenseData` to mention the new exclusion:
+
+```ts
+/**
+ * ...
+ * - Transfer exclusion (is_transfer = false) AND category type exclusion
+ *   (asset / liability / equity categories are not P&L events)
+ * ...
+ */
+```
+
+- [ ] **Step 2.4: Run test, watch it pass**
+
+```bash
+npm run test -- tests/unit/expenseDataFetcher.test.ts
+```
+
+Expected: all 3 cases pass.
+
+- [ ] **Step 2.5: Run downstream tests for regressions**
+
+```bash
+npm run test -- tests/unit/
+```
+
+Expected: no new failures. (Existing tests for `useMonthlyExpenses`, `Index`, etc., are not directly testing the fetcher — they should remain green.)
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add src/lib/expenseDataFetcher.ts tests/unit/expenseDataFetcher.test.ts
+git commit -m "fix(dashboard): exclude transfer-typed categories from expense aggregations"
+```
+
+---
+
+## Task 3: Fix `useExpenseHealth` (revenue + outflow + uncategorized)
+
+**Files:**
+- Create: `tests/unit/useExpenseHealth.test.ts`
+- Modify: `src/hooks/useExpenseHealth.tsx`
+
+- [ ] **Step 3.1: Write failing test**
+
+Create `tests/unit/useExpenseHealth.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+const mockTxns = [
+  // Real revenue
+  {
+    transaction_date: '2026-04-10',
+    amount: 1000,
+    status: 'posted',
+    description: 'Sales deposit',
+    merchant_name: null,
+    category_id: 'cat-revenue',
+    is_split: false,
+    chart_of_accounts: {
+      account_name: 'Sales',
+      account_subtype: 'food_revenue',
+      account_type: 'revenue',
+    },
+  },
+  // Inflow that's actually a transfer (should NOT be revenue)
+  {
+    transaction_date: '2026-04-11',
+    amount: 500,
+    status: 'posted',
+    description: 'Transfer in from savings',
+    merchant_name: null,
+    category_id: 'cat-transfer',
+    is_split: false,
+    chart_of_accounts: {
+      account_name: 'Transfer Clearing Account',
+      account_subtype: 'cash',
+      account_type: 'asset',
+    },
+  },
+  // Real food cost
+  {
+    transaction_date: '2026-04-12',
+    amount: -200,
+    status: 'posted',
+    description: 'Vendor invoice',
+    merchant_name: null,
+    category_id: 'cat-cogs',
+    is_split: false,
+    chart_of_accounts: {
+      account_name: 'Food Cost',
+      account_subtype: 'cost_of_goods_sold',
+      account_type: 'expense',
+    },
+  },
+  // Outflow that's actually a transfer (should NOT count as expense)
+  {
+    transaction_date: '2026-04-13',
+    amount: -700,
+    status: 'posted',
+    description: 'Transfer to savings',
+    merchant_name: null,
+    category_id: 'cat-transfer',
+    is_split: false,
+    chart_of_accounts: {
+      account_name: 'Transfer Clearing Account',
+      account_subtype: 'cash',
+      account_type: 'asset',
+    },
+  },
+];
+
+const lteSpy = vi.fn();
+const gteSpy = vi.fn();
+const eqSpy = vi.fn();
+const inSpy = vi.fn();
+
+vi.mock('@/integrations/supabase/client', () => {
+  const builder: Record<string, unknown> = {};
+  const passthrough = () => builder;
+  builder.select = vi.fn(passthrough);
+  builder.eq = vi.fn((...args) => {
+    eqSpy(...args);
+    return builder;
+  });
+  builder.in = vi.fn((...args) => {
+    inSpy(...args);
+    return builder;
+  });
+  builder.gte = vi.fn((...args) => {
+    gteSpy(...args);
+    return builder;
+  });
+  builder.lte = vi.fn((...args) => {
+    lteSpy(...args);
+    return Promise.resolve({ data: mockTxns, error: null });
+  });
+  return {
+    supabase: {
+      from: vi.fn(() => builder),
+    },
+  };
+});
+
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => ({
+    selectedRestaurant: { restaurant_id: 'r-1' },
+  }),
+}));
+
+import { useExpenseHealth } from '@/hooks/useExpenseHealth';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+describe('useExpenseHealth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('applies is_transfer = false in the query', async () => {
+    renderHook(
+      () => useExpenseHealth(new Date('2026-04-01'), new Date('2026-04-30')),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(eqSpy).toHaveBeenCalledWith('is_transfer', false);
+    });
+  });
+
+  it('excludes asset/liability/equity inflows from revenue and outflows from cost totals', async () => {
+    const { result } = renderHook(
+      () => useExpenseHealth(new Date('2026-04-01'), new Date('2026-04-30')),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const data = result.current.data!;
+    // Revenue should be 1000 (the +500 transfer is excluded).
+    // foodCost / revenue = 200 / 1000 = 20%
+    expect(data.foodCostPercentage).toBeCloseTo(20, 5);
+    // The +500 transfer must NOT have inflated revenue (else foodCostPct would be ~13.3%).
+    expect(data.foodCostPercentage).not.toBeCloseTo(200 / 1500 * 100, 2);
+  });
+});
+```
+
+- [ ] **Step 3.2: Run test, watch it fail**
+
+```bash
+npm run test -- tests/unit/useExpenseHealth.test.ts
+```
+
+Expected: both tests fail. (`is_transfer` filter not applied; revenue includes the transfer inflow.)
+
+- [ ] **Step 3.3: Implement the fix in `src/hooks/useExpenseHealth.tsx`**
+
+(a) Add the import:
+
+```ts
+import { isTransferCategoryType } from '@/lib/chartOfAccountsUtils';
+```
+
+(b) Update the query at lines 45-51 — add the missing `is_transfer` filter and `account_type` to the projection:
+
+```ts
+let txQuery = supabase
+  .from('bank_transactions')
+  .select('transaction_date, amount, status, description, merchant_name, category_id, is_split, chart_of_accounts!category_id(account_name, account_subtype, account_type)')
+  .eq('restaurant_id', selectedRestaurant.restaurant_id)
+  .in('status', ['posted', 'pending'])
+  .eq('is_transfer', false)
+  .gte('transaction_date', format(startDate, 'yyyy-MM-dd'))
+  .lte('transaction_date', format(endDate, 'yyyy-MM-dd'));
+```
+
+(c) After `const txns = transactions || [];`, add:
+
+```ts
+const pnlTxns = txns.filter(
+  (t) => !isTransferCategoryType(t.chart_of_accounts?.account_type),
+);
+```
+
+(d) Replace `txns` with `pnlTxns` in every downstream filter inside this function — namely the `revenue`, `foodCost`, `laborCost`, `processingFees`, and `outflows` reductions. The `txns.filter(...)` calls become `pnlTxns.filter(...)`. The `txns` variable itself can be left in place (it's still useful for the count if any future logic needs it), but every numeric reduction must be over `pnlTxns`.
+
+- [ ] **Step 3.4: Run test, watch it pass**
+
+```bash
+npm run test -- tests/unit/useExpenseHealth.test.ts
+```
+
+Expected: both tests pass.
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add src/hooks/useExpenseHealth.tsx tests/unit/useExpenseHealth.test.ts
+git commit -m "fix(dashboard): is_transfer + transfer-typed exclusion in expense health"
+```
+
+---
+
+## Task 4: Fix daily-spending filter on `Index.tsx`
+
+**Files:**
+- Modify: `src/hooks/useBankTransactions.tsx`
+- Modify: `src/pages/Index.tsx`
+
+This task widens the `useBankTransactions` hook to expose `chart_account.account_type`, then uses it in the daily-spending filter. There is no dedicated unit test for this filter (it's an inline `useMemo` inside `Index.tsx`); the existing `useExpenseHealth` and `expenseDataFetcher` tests cover the calculation pattern.
+
+- [ ] **Step 4.1: Widen `BankTransaction.chart_account` interface**
+
+`src/hooks/useBankTransactions.tsx` lines 57-60 — replace:
+
+```ts
+chart_account?: {
+  id: string;
+  account_name: string;
+} | null;
+```
+
+with:
+
+```ts
+chart_account?: {
+  id: string;
+  account_name: string;
+  account_type: string | null;
+} | null;
+```
+
+- [ ] **Step 4.2: Add `account_type` to the SELECT projection**
+
+`src/hooks/useBankTransactions.tsx` lines 140-143 — replace:
+
+```ts
+chart_account:chart_of_accounts!category_id(
+  id,
+  account_name
+),
+```
+
+with:
+
+```ts
+chart_account:chart_of_accounts!category_id(
+  id,
+  account_name,
+  account_type
+),
+```
+
+- [ ] **Step 4.3: Update daily-spending filter in `Index.tsx`**
+
+Add the import at the top of `src/pages/Index.tsx` (alongside other `@/lib` imports):
+
+```ts
+import { isTransferCategoryType } from '@/lib/chartOfAccountsUtils';
+```
+
+Replace the filter at lines 310-318:
+
+```ts
+const expenses = allTransactions.filter(t => {
+  const transactionDate = new Date(t.transaction_date);
+  return (
+    t.amount < 0 && // Expenses are negative
+    !t.is_transfer && // Exclude paired transfers
+    !isTransferCategoryType(t.chart_account?.account_type) && // Exclude asset/liability/equity-categorized
+    !t.excluded_reason && // Exclude transactions marked as excluded
+    transactionDate >= thirtyDaysAgo // Last 30 days only
+  );
+});
+```
+
+- [ ] **Step 4.4: Verify typecheck and tests still pass**
+
+```bash
+npm run typecheck && npm run test -- tests/unit/
+```
+
+Expected: no errors. (`chart_account.account_type` is additive; consumers that don't read it are unaffected.)
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add src/hooks/useBankTransactions.tsx src/pages/Index.tsx
+git commit -m "fix(dashboard): exclude transfer-typed categories from daily spending filter"
+```
+
+---
+
+## Task 5: pgTAP test pinning RPC contract
+
+**Files:**
+- Create: `supabase/tests/categorize_transfer_account.sql`
+
+This test documents the *current* write-time behavior the read-path fix relies on: `categorize_bank_transaction` does NOT auto-set `is_transfer`. If a future change starts setting it, this test fails and a reviewer is forced to update both the read-path filter and this test together.
+
+- [ ] **Step 5.1: Write the pgTAP test**
+
+Create `supabase/tests/categorize_transfer_account.sql`:
+
+```sql
+-- File: supabase/tests/categorize_transfer_account.sql
+-- Description: Pins write-time contract that categorize_bank_transaction does
+-- NOT touch is_transfer when assigning an asset/equity category. The dashboard
+-- read-path (expenseDataFetcher) relies on this — if the RPC starts setting
+-- is_transfer automatically, both this test and the read-path filter need
+-- to be revisited together.
+
+BEGIN;
+SELECT plan(4);
+
+SET LOCAL role TO postgres;
+SET LOCAL "request.jwt.claims" TO '{"sub": "00000000-0000-0000-0000-000000000201"}';
+
+-- Fixture: user, restaurant, membership
+INSERT INTO auth.users (id, email) VALUES
+  ('00000000-0000-0000-0000-000000000201', 'transfer-test@example.com')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO restaurants (id, name) VALUES
+  ('00000000-0000-0000-0000-000000000299', 'Transfer Test Restaurant')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO user_restaurants (user_id, restaurant_id, role) VALUES
+  ('00000000-0000-0000-0000-000000000201', '00000000-0000-0000-0000-000000000299', 'owner')
+ON CONFLICT (user_id, restaurant_id) DO UPDATE SET role = 'owner';
+
+-- Chart of accounts: one expense account, one transfer (asset) account
+INSERT INTO chart_of_accounts (id, restaurant_id, account_code, account_name, account_type, account_subtype, normal_balance) VALUES
+  ('00000000-0000-0000-0000-000000000251', '00000000-0000-0000-0000-000000000299', '5000', 'Office Supplies', 'expense', 'office_supplies', 'debit'),
+  ('00000000-0000-0000-0000-000000000252', '00000000-0000-0000-0000-000000000299', '1050', 'Transfer Clearing Account', 'asset', 'cash', 'debit')
+ON CONFLICT (id) DO UPDATE SET account_name = EXCLUDED.account_name;
+
+-- Connected bank + bank transaction fixture
+INSERT INTO connected_banks (id, restaurant_id, institution_name, status) VALUES
+  ('00000000-0000-0000-0000-000000000261', '00000000-0000-0000-0000-000000000299', 'Test Bank', 'active')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO bank_transactions (
+  id, restaurant_id, connected_bank_id, transaction_date, amount, description, status, is_categorized, is_transfer
+) VALUES (
+  '00000000-0000-0000-0000-000000000271',
+  '00000000-0000-0000-0000-000000000299',
+  '00000000-0000-0000-0000-000000000261',
+  '2026-04-15', -500, 'Move to savings', 'posted', false, false
+)
+ON CONFLICT (id) DO UPDATE SET
+  is_categorized = false,
+  is_transfer = false,
+  category_id = NULL;
+
+-- TEST 1: chart_of_accounts row exposes account_type for joined reads
+SELECT is(
+  (SELECT account_type::text FROM chart_of_accounts WHERE id = '00000000-0000-0000-0000-000000000252'),
+  'asset',
+  'Transfer Clearing Account is account_type=asset (read-path filter relies on this)'
+);
+
+-- TEST 2: Calling categorize_bank_transaction on the transfer account does not raise
+SELECT lives_ok(
+  $$ SELECT categorize_bank_transaction(
+       '00000000-0000-0000-0000-000000000271'::uuid,
+       '00000000-0000-0000-0000-000000000252'::uuid,
+       NULL, NULL, NULL
+     ) $$,
+  'categorize_bank_transaction succeeds when assigning a Transfer (asset) category'
+);
+
+-- TEST 3: After categorization, category_id is set and is_categorized is true
+SELECT is(
+  (SELECT category_id FROM bank_transactions WHERE id = '00000000-0000-0000-0000-000000000271'),
+  '00000000-0000-0000-0000-000000000252'::uuid,
+  'category_id is updated to the transfer-clearing account'
+);
+
+-- TEST 4: is_transfer remains false (the bug surface — RPC does NOT auto-set this)
+SELECT is(
+  (SELECT is_transfer FROM bank_transactions WHERE id = '00000000-0000-0000-0000-000000000271'),
+  false,
+  'is_transfer remains false after asset-typed categorization (read-path must filter on account_type)'
+);
+
+SELECT * FROM finish();
+ROLLBACK;
+```
+
+- [ ] **Step 5.2: Run pgTAP**
+
+```bash
+npm run test:db
+```
+
+Expected: all 4 assertions pass. If `connected_banks` schema requires more columns than `id, restaurant_id, institution_name, status` in the local schema, adjust the INSERT to satisfy NOT NULL constraints — the runner will print which column is missing.
+
+- [ ] **Step 5.3: Commit**
+
+```bash
+git add supabase/tests/categorize_transfer_account.sql
+git commit -m "test(db): pin categorize_bank_transaction does not touch is_transfer"
+```
+
+---
+
+## Self-Review Checklist (verify before marking plan complete)
+
+| Spec section | Implemented in |
+|---|---|
+| `isTransferCategoryType` helper | Task 1 |
+| `expenseDataFetcher` widening + filtering | Task 2 |
+| `useExpenseHealth` is_transfer + filter | Task 3 |
+| `Index.tsx` daily-spending filter | Task 4 |
+| pgTAP RPC contract test | Task 5 |
+| Type widening of `chart_of_accounts` shape | Tasks 2 & 4 (additive `account_type` field) |
+
+No placeholders. Each step contains the actual code or actual command. Helper name `isTransferCategoryType` is consistent across all 5 tasks.

--- a/docs/superpowers/specs/2026-04-26-transfer-category-classification-design.md
+++ b/docs/superpowers/specs/2026-04-26-transfer-category-classification-design.md
@@ -98,7 +98,7 @@ Assert the returned `transactions`, `pendingOutflows`, and `splitDetails` arrays
 
 Mock the supabase response with mixed account types and assert revenue, foodCost, laborCost, and uncategorizedSpend exclude `asset|liability|equity`-typed rows. Also assert the new `is_transfer = false` filter is applied (verify the call args via spy).
 
-### 4. pgTAP test: `supabase/tests/categorize_transfer_account.test.sql`
+### 4. pgTAP test: `supabase/tests/categorize_transfer_account.sql`
 
 End-to-end DB-level reproduction:
 1. Seed restaurant + chart of accounts (insert "Transfer Clearing Account" with `account_type='asset'`)

--- a/docs/superpowers/specs/2026-04-26-transfer-category-classification-design.md
+++ b/docs/superpowers/specs/2026-04-26-transfer-category-classification-design.md
@@ -1,0 +1,123 @@
+# Design: Transfer-categorized bank transactions counted as Expenses
+
+**Date:** 2026-04-26
+**Branch:** `fix/transfer-category-classification`
+**Type:** Bug fix (financial reporting correctness)
+
+## Bug
+
+Bank transactions whose category is set to a Transfer-type chart-of-accounts account (e.g., "Transfer Clearing Account" #1050, `account_type='asset'`, or "Inter-Account Transfer" #3010, `account_type='equity'`) are summed into the monthly **Expenses** total in the dashboard. Conceptually, transfers between accounts (cash → savings, owner draws, etc.) are not P&L events and must be excluded from both Income and Expense totals.
+
+## Root cause
+
+The codebase has two independent mechanisms for marking a transaction as a transfer:
+
+1. **`bank_transactions.is_transfer` flag** — set ONLY by the `mark_as_transfer()` RPC (Transfer dialog that pairs two transactions via `transfer_pair_id`).
+2. **Assigning a chart-of-accounts category whose `account_type` is `asset|liability|equity`** — `categorize_bank_transaction` RPC (`supabase/migrations/20251020140237_*.sql:211-219`) sets `category_id` and `is_categorized=true` but never touches `is_transfer`.
+
+The dashboard's expense fetcher (`src/lib/expenseDataFetcher.ts:107`) only filters `.eq('is_transfer', false)`. Mechanism #2 leaves `is_transfer=false`, so those rows pass through and get summed as expenses.
+
+## Decision: read-path fix (Approach B)
+
+Exclude transactions/splits/pending-outflows whose category's `account_type` is `asset|liability|equity` from P&L aggregations. No write-time changes, no data migration. Existing miscategorized rows are corrected immediately because their classification is recomputed on every read.
+
+Rejected alternatives:
+- **Write-time fix in `categorize_bank_transaction`** (Approach A) — overloads the meaning of `is_transfer` (currently "paired with `transfer_pair_id`"), risks breaking `unmark_as_transfer`, and requires a backfill.
+- **Both** (Approach C) — YAGNI for a single bug.
+
+## Single source of truth
+
+Add a small helper in `src/lib/chartOfAccountsUtils.ts`:
+
+```ts
+const NON_PNL_ACCOUNT_TYPES = new Set<AccountType>(['asset', 'liability', 'equity']);
+
+export function isTransferCategoryType(
+  accountType: AccountType | string | null | undefined
+): boolean {
+  return !!accountType && NON_PNL_ACCOUNT_TYPES.has(accountType as AccountType);
+}
+```
+
+Every read path that aggregates P&L from bank-transaction-derived data uses this helper. Single source of truth → can't drift.
+
+## Files to change
+
+| File | Change |
+|---|---|
+| `src/lib/chartOfAccountsUtils.ts` | Add `isTransferCategoryType` helper + `NON_PNL_ACCOUNT_TYPES` constant |
+| `src/lib/expenseDataFetcher.ts` | Add `account_type` to all three `chart_of_accounts` SELECT projections; filter transactions, pendingOutflows, and splitDetails through `isTransferCategoryType` before return |
+| `src/hooks/useExpenseHealth.tsx` | Add the missing `.eq('is_transfer', false)` filter (pre-existing secondary bug); add `account_type` to projection; apply `isTransferCategoryType` to the revenue (`amount > 0`), outflow (`amount < 0`), and uncategorized-spend reductions |
+| `src/pages/Index.tsx` (daily-spending) | Add `isTransferCategoryType(t.chart_of_accounts?.account_type)` to the existing filter at line 310-317 (verify `chart_of_accounts` is on the row first; add to the underlying fetch projection if not) |
+
+`useMonthlyMetrics.tsx` COGS and labor sections already use `account_subtype` allowlists (`food_cost`, `cost_of_goods_sold`, `payroll`, etc.) so a Transfer-typed category cannot match — verified safe, no changes needed.
+
+## ExpenseTransaction shape change
+
+`ExpenseTransaction.chart_of_accounts` is widened to include `account_type`:
+
+```ts
+chart_of_accounts: {
+  account_name: string;
+  account_subtype: string;
+  account_type: AccountType;
+} | null;
+```
+
+Same widening applied to `PendingOutflowRecord.chart_account` and `SplitDetail.chart_of_accounts`. This is additive — existing consumers continue to work.
+
+## Test strategy (TDD)
+
+**RED first** — write tests that demonstrate the bug, watch them fail.
+
+### 1. Unit test: `isTransferCategoryType` (`tests/unit/chartOfAccountsUtils.test.ts`)
+
+| Input | Expected |
+|---|---|
+| `'asset'` | true |
+| `'liability'` | true |
+| `'equity'` | true |
+| `'expense'` | false |
+| `'cogs'` | false |
+| `'revenue'` | false |
+| `null` | false |
+| `undefined` | false |
+| `''` | false |
+
+### 2. Unit test: `expenseDataFetcher` (`tests/unit/expenseDataFetcher.test.ts`)
+
+Mock `supabase.from(...).select(...)...` chain with two transactions in the response:
+- Tx A: `amount=-500`, `chart_of_accounts.account_type='expense'` → expected in result
+- Tx B: `amount=-500`, `chart_of_accounts.account_type='asset'` (Transfer Clearing Account) → expected EXCLUDED
+
+Same for `pendingOutflows` (one expense + one asset-typed) and one split (one expense + one asset-typed).
+
+Assert the returned `transactions`, `pendingOutflows`, and `splitDetails` arrays contain only the expense-typed entries.
+
+### 3. Unit test: `useExpenseHealth` (`tests/unit/useExpenseHealth.test.ts` — extend if exists, else create)
+
+Mock the supabase response with mixed account types and assert revenue, foodCost, laborCost, and uncategorizedSpend exclude `asset|liability|equity`-typed rows. Also assert the new `is_transfer = false` filter is applied (verify the call args via spy).
+
+### 4. pgTAP test: `supabase/tests/categorize_transfer_account.test.sql`
+
+End-to-end DB-level reproduction:
+1. Seed restaurant + chart of accounts (insert "Transfer Clearing Account" with `account_type='asset'`)
+2. Insert a `bank_transaction` with `amount = -500`
+3. Call `categorize_bank_transaction(tx_id, transfer_account_id, ...)`
+4. Assert `is_transfer` remains `false` after categorization (documents current RPC behavior)
+5. Verify the row's joined `account_type` is `'asset'` (the data shape our read-path filter relies on)
+
+This test pins the *write-time* contract (RPC unchanged) so future drift is caught.
+
+## Out of scope
+
+- Auto-promote category-based transfers to `is_transfer = true` (write-time fix). Tracked as a future improvement; would need backfill + RPC semantics review.
+- Surface a "Transfer" badge in `TransactionDetailSheet` for category-based transfers. UX consistency follow-up.
+- Backfilling existing miscategorized rows — Approach B fixes them on next read with no migration.
+- Changing the category dropdown to filter out Transfer-type accounts — users should still be able to pick them; the math just needs to handle them correctly.
+
+## Risks
+
+- **Performance:** Three `.filter()` passes on already-fetched arrays. Negligible — tens to low-thousands of rows per month.
+- **Other consumers:** Anything using the widened `chart_of_accounts` shape continues to work because the new field is additive. Verified by `npm run typecheck` in Phase 8.
+- **Subtype-only consumers:** `useMonthlyMetrics` COGS/labor sections rely on `account_subtype` allowlists, so unaffected. Confirmed during exploration.

--- a/memory/lessons.md
+++ b/memory/lessons.md
@@ -1,5 +1,23 @@
 # Lessons Learned
 
+## Category: Domain — Bank Transactions / P&L
+
+### [2026-04-26] Two transfer mechanisms must both be filtered out of P&L
+- **Mistake:** Bank transactions assigned a Transfer category (asset/liability/equity-typed chart-of-accounts row, e.g. "Transfer Clearing Account") were rendered as Expenses on the dashboard. The read path filtered only on `is_transfer = false`, but `categorize_bank_transaction` does NOT flip `is_transfer` when assigning an asset-typed category — only the `mark_as_transfer` RPC does. So categorize-then-view was leaking transfers into expense aggregations.
+- **Correction:** Added `isTransferCategoryType(account_type)` helper and applied it as a second exclusion (alongside `is_transfer = false`) to every read-path aggregation: `expenseDataFetcher` (transactions, pendingOutflows, splitDetails), `useExpenseHealth`, `useBankTransactions`, and the `Index.tsx` daily-spending filter. Also added pgTAP test pinning that `categorize_bank_transaction` does NOT auto-flip `is_transfer` — if that ever changes, the read-path filter must be revisited.
+- **Rule:** A transaction is a transfer if EITHER `is_transfer = true` OR its category's `account_type` is `asset|liability|equity`. Every P&L read path must apply both filters. When adding a new aggregation hook, copy the dual-filter pattern.
+
+---
+
+## Category: TypeScript / React
+
+### [2026-04-26] Widening an interface requires grepping all `as ... []` casts
+- **Mistake:** Widened `BankTransaction.chart_account` to include `account_type: string | null`, then updated the projection in the primary `useBankTransactions` hook. Missed a sibling hook `useBankTransactionsWithRelations` that does `as unknown as BankTransaction[]` against a projection that still only selected `account_name`. Typecheck happily passed because `as unknown as` is unsafe by design. CodeRabbit caught it; would have shipped silent `undefined` for any future consumer applying the new transfer-exclusion filter through that hook.
+- **Correction:** Added `account_type` to the second projection too. Lesson committed alongside fix.
+- **Rule:** When widening an interface used by Supabase row casts, grep `as unknown as <Type>` AND `as <Type>[]` and verify every matching select projection now includes the new fields. Typecheck cannot catch projection drift behind `as unknown as`.
+
+---
+
 ## Category: Supabase Edge Functions
 
 ### [2026-04-21] Edge function error handling — HTTP codes vs 200 workaround

--- a/src/hooks/useBankTransactions.tsx
+++ b/src/hooks/useBankTransactions.tsx
@@ -382,7 +382,8 @@ export function useBankTransactionsWithRelations(restaurantId: string | null | u
             bank_account_balances(id, account_mask, account_name)
           ),
           chart_account:chart_of_accounts!category_id(
-            account_name
+            account_name,
+            account_type
           ),
           supplier:suppliers(
             id,

--- a/src/hooks/useBankTransactions.tsx
+++ b/src/hooks/useBankTransactions.tsx
@@ -57,6 +57,7 @@ export interface BankTransaction {
   chart_account?: {
     id: string;
     account_name: string;
+    account_type: string | null;
   } | null;
   // Linked outflow data (pending_outflows via reverse FK)
   linked_outflows?: Array<{
@@ -139,7 +140,8 @@ const buildBaseQuery = (restaurantId: string) =>
       ),
       chart_account:chart_of_accounts!category_id(
         id,
-        account_name
+        account_name,
+        account_type
       ),
       linked_outflows:pending_outflows!linked_bank_transaction_id(
         vendor_name,

--- a/src/hooks/useExpenseHealth.tsx
+++ b/src/hooks/useExpenseHealth.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { supabase } from "@/integrations/supabase/client";
 import { useRestaurantContext } from "@/contexts/RestaurantContext";
 import { format, parseISO } from "date-fns";
+import { isTransferCategoryType } from "@/lib/chartOfAccountsUtils";
 
 // Processing fee detection patterns
 const PROCESSING_FEE_PATTERNS = [
@@ -41,12 +42,17 @@ export function useExpenseHealth(startDate: Date, endDate: Date, bankAccountId: 
         throw new Error("No restaurant selected");
       }
 
-      // Fetch transactions for the period (including both posted and pending)
+      // Fetch transactions for the period (including both posted and pending).
+      // is_transfer = false drops paired transfers; the post-fetch
+      // isTransferCategoryType filter additionally drops rows whose category
+      // type is asset/liability/equity (e.g. "Transfer Clearing Account"),
+      // which categorize_bank_transaction does not flag as is_transfer.
       let txQuery = supabase
         .from('bank_transactions')
-        .select('transaction_date, amount, status, description, merchant_name, category_id, is_split, chart_of_accounts!category_id(account_name, account_subtype)')
+        .select('transaction_date, amount, status, description, merchant_name, category_id, is_split, chart_of_accounts!category_id(account_name, account_subtype, account_type)')
         .eq('restaurant_id', selectedRestaurant.restaurant_id)
         .in('status', ['posted', 'pending'])
+        .eq('is_transfer', false)
         .gte('transaction_date', format(startDate, 'yyyy-MM-dd'))
         .lte('transaction_date', format(endDate, 'yyyy-MM-dd'));
 
@@ -59,14 +65,21 @@ export function useExpenseHealth(startDate: Date, endDate: Date, bankAccountId: 
 
       const txns = transactions || [];
 
+      // Drop rows whose category's account_type is asset/liability/equity
+      // (e.g. Transfer Clearing Account). These are not P&L events and must
+      // not inflate revenue, expense, or uncategorized totals.
+      const pnlTxns = txns.filter(
+        (t) => !isTransferCategoryType(t.chart_of_accounts?.account_type),
+      );
+
       // Calculate revenue (inflows)
-      const revenue = txns
+      const revenue = pnlTxns
         .filter(t => t.amount > 0)
         .reduce((sum, t) => sum + t.amount, 0);
 
       // Calculate food cost (COGS)
       const foodCost = Math.abs(
-        txns
+        pnlTxns
           .filter(t => {
             if (t.amount >= 0) return false;
             if (!t.category_id || !t.chart_of_accounts) return false;
@@ -79,7 +92,7 @@ export function useExpenseHealth(startDate: Date, endDate: Date, bankAccountId: 
 
       // Calculate labor cost
       const laborCost = Math.abs(
-        txns
+        pnlTxns
           .filter(t => {
             if (t.amount >= 0) return false;
             if (!t.category_id || !t.chart_of_accounts) return false;
@@ -92,7 +105,7 @@ export function useExpenseHealth(startDate: Date, endDate: Date, bankAccountId: 
 
       // Calculate processing fees
       const processingFees = Math.abs(
-        txns
+        pnlTxns
           .filter(t => {
             if (t.amount >= 0) return false;
             const desc = (t.description || '').toLowerCase();
@@ -106,7 +119,7 @@ export function useExpenseHealth(startDate: Date, endDate: Date, bankAccountId: 
       // Calculate uncategorized spend - only transactions with NO category_id assigned
       // Note: Split transactions have category_id NULL but their categories are in bank_transaction_splits
       // So we exclude them from uncategorized count
-      const outflows = txns.filter(t => t.amount < 0);
+      const outflows = pnlTxns.filter(t => t.amount < 0);
       const totalOutflows = Math.abs(outflows.reduce((sum, t) => sum + t.amount, 0));
       const uncategorizedSpend = Math.abs(
         outflows.filter(t => !t.category_id && !t.is_split).reduce((sum, t) => sum + t.amount, 0)

--- a/src/lib/chartOfAccountsUtils.ts
+++ b/src/lib/chartOfAccountsUtils.ts
@@ -1,4 +1,23 @@
 import { SupabaseClient } from '@supabase/supabase-js';
+import type { AccountType } from '@/hooks/useChartOfAccounts';
+
+const NON_PNL_ACCOUNT_TYPES: ReadonlySet<AccountType> = new Set([
+  'asset',
+  'liability',
+  'equity',
+]);
+
+/**
+ * Categories whose chart-of-accounts type is asset, liability, or equity
+ * are not P&L events — e.g. "Transfer Clearing Account" or "Inter-Account
+ * Transfer". The dashboard's income/expense aggregations must exclude them.
+ */
+export function isTransferCategoryType(
+  accountType: string | null | undefined,
+): boolean {
+  if (!accountType) return false;
+  return NON_PNL_ACCOUNT_TYPES.has(accountType as AccountType);
+}
 
 export const DEFAULT_ACCOUNTS = [
   // ASSETS (1000-1999)

--- a/src/lib/expenseDataFetcher.ts
+++ b/src/lib/expenseDataFetcher.ts
@@ -8,6 +8,7 @@
 
 import { supabase } from '@/integrations/supabase/client';
 import { format } from 'date-fns';
+import { isTransferCategoryType } from '@/lib/chartOfAccountsUtils';
 
 export interface ExpenseTransaction {
   id: string;
@@ -23,6 +24,7 @@ export interface ExpenseTransaction {
   chart_of_accounts: {
     account_name: string;
     account_subtype: string;
+    account_type: string;
   } | null;
 }
 
@@ -34,6 +36,7 @@ export interface PendingOutflowRecord {
   chart_account: {
     account_name: string;
     account_subtype: string;
+    account_type: string;
   } | null;
 }
 
@@ -44,6 +47,7 @@ export interface SplitDetail {
   chart_of_accounts: {
     account_name: string;
     account_subtype: string;
+    account_type: string;
   } | null;
 }
 
@@ -69,10 +73,12 @@ export interface ExpenseDataResult {
 
 /**
  * Fetches unified expense data from all relevant sources.
- * 
+ *
  * This ensures consistency across all expense-related hooks by using the same:
  * - Transaction status filters (posted + pending)
- * - Transfer exclusion (is_transfer = false)
+ * - Transfer exclusion (is_transfer = false) AND category-type exclusion
+ *   (asset / liability / equity categories are not P&L events — e.g. a
+ *   "Transfer Clearing Account" assignment that does not flip is_transfer)
  * - Pending outflows inclusion (unmatched checks)
  * - Split transaction handling
  */
@@ -100,7 +106,7 @@ export async function fetchExpenseData(params: ExpenseDataParams): Promise<Expen
       category_id,
       is_split,
       ai_confidence,
-      chart_of_accounts!category_id(account_name, account_subtype)
+      chart_of_accounts!category_id(account_name, account_subtype, account_type)
     `)
     .eq('restaurant_id', restaurantId)
     .in('status', ['posted', 'pending'])
@@ -119,6 +125,14 @@ export async function fetchExpenseData(params: ExpenseDataParams): Promise<Expen
 
   const txns = (transactions || []) as ExpenseTransaction[];
 
+  // Exclude rows whose category's account_type is asset/liability/equity.
+  // These represent transfers (e.g. "Transfer Clearing Account") that are not
+  // P&L events but are not flagged with is_transfer when categorize_bank_transaction
+  // is used to assign them. See docs/superpowers/specs/2026-04-26-transfer-category-classification-design.md.
+  const filteredTxns = txns.filter(
+    (t) => !isTransferCategoryType(t.chart_of_accounts?.account_type),
+  );
+
   // 2. Fetch pending outflows (unmatched checks only)
   const { data: pendingOutflows, error: poError } = await supabase
     .from('pending_outflows')
@@ -127,7 +141,7 @@ export async function fetchExpenseData(params: ExpenseDataParams): Promise<Expen
       category_id,
       issue_date,
       status,
-      chart_account:chart_of_accounts!category_id(account_name, account_subtype)
+      chart_account:chart_of_accounts!category_id(account_name, account_subtype, account_type)
     `)
     .eq('restaurant_id', restaurantId)
     .in('status', ['pending', 'stale_30', 'stale_60', 'stale_90'])
@@ -139,13 +153,17 @@ export async function fetchExpenseData(params: ExpenseDataParams): Promise<Expen
 
   const pendingOutflowRecords = (pendingOutflows || []) as PendingOutflowRecord[];
 
+  const filteredPendingOutflows = pendingOutflowRecords.filter(
+    (p) => !isTransferCategoryType(p.chart_account?.account_type),
+  );
+
   // 3. Fetch split transaction details for split parent transactions
   // Filter to only current period transactions for split lookup
-  const currentPeriodTxns = txns.filter(t => {
+  const currentPeriodTxns = filteredTxns.filter(t => {
     const txnDate = new Date(t.transaction_date);
     return txnDate >= startDate && txnDate <= endDate;
   });
-  
+
   const splitParentIds = currentPeriodTxns.filter(t => t.is_split).map(t => t.id);
 
   let splitDetails: SplitDetail[] = [];
@@ -157,7 +175,7 @@ export async function fetchExpenseData(params: ExpenseDataParams): Promise<Expen
         transaction_id,
         amount,
         category_id,
-        chart_of_accounts:chart_of_accounts!category_id(account_name, account_subtype)
+        chart_of_accounts:chart_of_accounts!category_id(account_name, account_subtype, account_type)
       `)
       .in('transaction_id', splitParentIds);
 
@@ -165,31 +183,34 @@ export async function fetchExpenseData(params: ExpenseDataParams): Promise<Expen
       console.error('Error fetching split details:', splitsError);
     } else {
       splitDetails = (splits || []) as SplitDetail[];
+      splitDetails = splitDetails.filter(
+        (s) => !isTransferCategoryType(s.chart_of_accounts?.account_type),
+      );
     }
   }
 
   // Separate current and previous period transactions if needed
   if (includePreviousPeriod) {
-    const currentTransactions = txns.filter(t => {
+    const currentTransactions = filteredTxns.filter(t => {
       const txnDate = new Date(t.transaction_date);
       return txnDate >= startDate && txnDate <= endDate;
     });
-    const previousTransactions = txns.filter(t => {
+    const previousTransactions = filteredTxns.filter(t => {
       const txnDate = new Date(t.transaction_date);
       return txnDate >= previousPeriodStart && txnDate < startDate;
     });
 
     return {
       transactions: currentTransactions,
-      pendingOutflows: pendingOutflowRecords,
+      pendingOutflows: filteredPendingOutflows,
       splitDetails,
       previousPeriodTransactions: previousTransactions,
     };
   }
 
   return {
-    transactions: txns,
-    pendingOutflows: pendingOutflowRecords,
+    transactions: filteredTxns,
+    pendingOutflows: filteredPendingOutflows,
     splitDetails,
   };
 }

--- a/src/lib/expenseDataFetcher.ts
+++ b/src/lib/expenseDataFetcher.ts
@@ -24,7 +24,7 @@ export interface ExpenseTransaction {
   chart_of_accounts: {
     account_name: string;
     account_subtype: string;
-    account_type: string;
+    account_type: string | null;
   } | null;
 }
 
@@ -36,7 +36,7 @@ export interface PendingOutflowRecord {
   chart_account: {
     account_name: string;
     account_subtype: string;
-    account_type: string;
+    account_type: string | null;
   } | null;
 }
 
@@ -47,7 +47,7 @@ export interface SplitDetail {
   chart_of_accounts: {
     account_name: string;
     account_subtype: string;
-    account_type: string;
+    account_type: string | null;
   } | null;
 }
 

--- a/src/lib/expenseDataFetcher.ts
+++ b/src/lib/expenseDataFetcher.ts
@@ -182,8 +182,7 @@ export async function fetchExpenseData(params: ExpenseDataParams): Promise<Expen
     if (splitsError) {
       console.error('Error fetching split details:', splitsError);
     } else {
-      splitDetails = (splits || []) as SplitDetail[];
-      splitDetails = splitDetails.filter(
+      splitDetails = ((splits || []) as SplitDetail[]).filter(
         (s) => !isTransferCategoryType(s.chart_of_accounts?.account_type),
       );
     }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -40,6 +40,7 @@ import { CashFlowSankeyChart } from '@/components/dashboard/CashFlowSankeyChart'
 import { SalesVsBreakEvenChart } from '@/components/budget/SalesVsBreakEvenChart';
 import { useOpsInboxCount } from '@/hooks/useOpsInbox';
 import { useSubscription } from '@/hooks/useSubscription';
+import { isTransferCategoryType } from '@/lib/chartOfAccountsUtils';
 import { format, startOfDay, endOfDay, differenceInDays, startOfMonth, endOfMonth, subMonths, subDays } from 'date-fns';
 import {
   DollarSign,
@@ -311,7 +312,8 @@ const Index = () => {
       const transactionDate = new Date(t.transaction_date);
       return (
         t.amount < 0 && // Expenses are negative
-        !t.is_transfer && // Exclude transfers
+        !t.is_transfer && // Exclude paired transfers
+        !isTransferCategoryType(t.chart_account?.account_type) && // Exclude asset/liability/equity-categorized
         !t.excluded_reason && // Exclude transactions marked as excluded
         transactionDate >= thirtyDaysAgo // Last 30 days only
       );

--- a/supabase/tests/categorize_transfer_account.sql
+++ b/supabase/tests/categorize_transfer_account.sql
@@ -1,0 +1,87 @@
+-- File: supabase/tests/categorize_transfer_account.sql
+-- Description: Pins write-time contract that categorize_bank_transaction does
+-- NOT touch is_transfer when assigning an asset/equity category. The dashboard
+-- read-path (expenseDataFetcher / useExpenseHealth / Index daily-spending)
+-- relies on this — if the RPC starts setting is_transfer automatically, both
+-- this test and the read-path filter need to be revisited together.
+
+BEGIN;
+SELECT plan(4);
+
+SET LOCAL role TO postgres;
+SET LOCAL "request.jwt.claims" TO '{"sub": "00000000-0000-0000-0000-000000000201"}';
+
+-- Fixture: user, restaurant, membership
+INSERT INTO auth.users (id, email) VALUES
+  ('00000000-0000-0000-0000-000000000201'::uuid, 'transfer-test@example.com')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO restaurants (id, name) VALUES
+  ('00000000-0000-0000-0000-000000000299'::uuid, 'Transfer Test Restaurant')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO user_restaurants (user_id, restaurant_id, role) VALUES
+  ('00000000-0000-0000-0000-000000000201'::uuid, '00000000-0000-0000-0000-000000000299'::uuid, 'owner')
+ON CONFLICT (user_id, restaurant_id) DO UPDATE SET role = 'owner';
+
+-- Chart of accounts:
+--   1000 = Cash (required by categorize_bank_transaction as the offsetting account)
+--   1050 = Transfer Clearing Account (asset; the category under test)
+INSERT INTO chart_of_accounts (id, restaurant_id, account_code, account_name, account_type, account_subtype, normal_balance) VALUES
+  ('00000000-0000-0000-0000-000000000250'::uuid, '00000000-0000-0000-0000-000000000299'::uuid, '1000', 'Cash', 'asset', 'cash', 'debit'),
+  ('00000000-0000-0000-0000-000000000252'::uuid, '00000000-0000-0000-0000-000000000299'::uuid, '1050', 'Transfer Clearing Account', 'asset', 'cash', 'debit')
+ON CONFLICT (id) DO UPDATE SET account_name = EXCLUDED.account_name;
+
+-- Connected bank + bank transaction fixture
+INSERT INTO connected_banks (id, restaurant_id, stripe_financial_account_id, institution_name, status) VALUES
+  ('00000000-0000-0000-0000-000000000261'::uuid, '00000000-0000-0000-0000-000000000299'::uuid, 'fa_test_xfer_001', 'Test Bank', 'connected')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO bank_transactions (
+  id, restaurant_id, connected_bank_id, stripe_transaction_id,
+  transaction_date, amount, description, status, is_categorized, is_transfer
+) VALUES (
+  '00000000-0000-0000-0000-000000000271'::uuid,
+  '00000000-0000-0000-0000-000000000299'::uuid,
+  '00000000-0000-0000-0000-000000000261'::uuid,
+  'txn-transfer-test-1',
+  '2026-04-15', -500, 'Move to savings', 'posted', false, false
+)
+ON CONFLICT (id) DO UPDATE SET
+  is_categorized = false,
+  is_transfer = false,
+  category_id = NULL;
+
+-- TEST 1: chart_of_accounts row exposes account_type for joined reads
+SELECT is(
+  (SELECT account_type::text FROM chart_of_accounts WHERE id = '00000000-0000-0000-0000-000000000252'::uuid),
+  'asset',
+  'Transfer Clearing Account is account_type=asset (read-path filter relies on this)'
+);
+
+-- TEST 2: Calling categorize_bank_transaction on the transfer account does not raise
+SELECT lives_ok(
+  $$ SELECT categorize_bank_transaction(
+       '00000000-0000-0000-0000-000000000271'::uuid,
+       '00000000-0000-0000-0000-000000000252'::uuid,
+       NULL, NULL, NULL
+     ) $$,
+  'categorize_bank_transaction succeeds when assigning a Transfer (asset) category'
+);
+
+-- TEST 3: After categorization, category_id is set to the transfer-clearing account
+SELECT is(
+  (SELECT category_id FROM bank_transactions WHERE id = '00000000-0000-0000-0000-000000000271'::uuid),
+  '00000000-0000-0000-0000-000000000252'::uuid,
+  'category_id is updated to the transfer-clearing account'
+);
+
+-- TEST 4: is_transfer remains false (the bug surface — RPC does NOT auto-set this)
+SELECT is(
+  (SELECT is_transfer FROM bank_transactions WHERE id = '00000000-0000-0000-0000-000000000271'::uuid),
+  false,
+  'is_transfer remains false after asset-typed categorization (read-path must filter on account_type)'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/tests/unit/chartOfAccountsUtils.test.ts
+++ b/tests/unit/chartOfAccountsUtils.test.ts
@@ -1,6 +1,10 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { createDefaultChartOfAccounts, DEFAULT_ACCOUNTS } from '@/lib/chartOfAccountsUtils';
+import {
+  createDefaultChartOfAccounts,
+  DEFAULT_ACCOUNTS,
+  isTransferCategoryType,
+} from '@/lib/chartOfAccountsUtils';
 
 // Mock Supabase client
 const mockUpsert = vi.fn();
@@ -83,6 +87,38 @@ describe('chartOfAccountsUtils', () => {
         const cashAccount = DEFAULT_ACCOUNTS.find(a => a.account_code === '1000');
         expect(cashAccount).toBeDefined();
         expect(cashAccount?.account_name).toBe('Cash & Cash Equivalents');
+    });
+  });
+
+  describe('isTransferCategoryType', () => {
+    it.each(['asset', 'liability', 'equity'] as const)(
+      'returns true for non-P&L type "%s"',
+      (type) => {
+        expect(isTransferCategoryType(type)).toBe(true);
+      },
+    );
+
+    it.each(['expense', 'cogs', 'revenue'] as const)(
+      'returns false for P&L type "%s"',
+      (type) => {
+        expect(isTransferCategoryType(type)).toBe(false);
+      },
+    );
+
+    it('returns false for null', () => {
+      expect(isTransferCategoryType(null)).toBe(false);
+    });
+
+    it('returns false for undefined', () => {
+      expect(isTransferCategoryType(undefined)).toBe(false);
+    });
+
+    it('returns false for an empty string', () => {
+      expect(isTransferCategoryType('')).toBe(false);
+    });
+
+    it('returns false for an unknown string', () => {
+      expect(isTransferCategoryType('something_else')).toBe(false);
     });
   });
 });

--- a/tests/unit/expenseDataFetcher.test.ts
+++ b/tests/unit/expenseDataFetcher.test.ts
@@ -168,16 +168,20 @@ describe('fetchExpenseData', () => {
       chart_of_accounts: null,
     } as never);
 
-    const result = await fetchExpenseData({
-      restaurantId: 'r-1',
-      startDate: new Date('2026-04-01'),
-      endDate: new Date('2026-04-30'),
-    });
+    try {
+      const result = await fetchExpenseData({
+        restaurantId: 'r-1',
+        startDate: new Date('2026-04-01'),
+        endDate: new Date('2026-04-30'),
+      });
 
-    const splitAmounts = result.splitDetails.map((s) => s.amount);
-    expect(splitAmounts).toContain(50);
-    expect(splitAmounts).not.toContain(70);
-
-    txnRows.pop();
+      const splitAmounts = result.splitDetails.map((s) => s.amount);
+      expect(splitAmounts).toContain(50);
+      expect(splitAmounts).not.toContain(70);
+    } finally {
+      // Restore shared fixture even if assertions throw, so subsequent tests
+      // don't see the split-parent row leaked into txnRows.
+      txnRows.pop();
+    }
   });
 });

--- a/tests/unit/expenseDataFetcher.test.ts
+++ b/tests/unit/expenseDataFetcher.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the Supabase client BEFORE importing the module under test.
+const txnRows = [
+  {
+    id: 'tx-expense-1',
+    transaction_date: '2026-04-15',
+    amount: -100,
+    status: 'posted',
+    description: 'Real expense',
+    merchant_name: null,
+    normalized_payee: null,
+    category_id: 'cat-expense',
+    is_split: false,
+    ai_confidence: null,
+    chart_of_accounts: {
+      account_name: 'Office Supplies',
+      account_subtype: 'office_supplies',
+      account_type: 'expense',
+    },
+  },
+  {
+    id: 'tx-transfer-1',
+    transaction_date: '2026-04-15',
+    amount: -500,
+    status: 'posted',
+    description: 'Transfer to savings',
+    merchant_name: null,
+    normalized_payee: null,
+    category_id: 'cat-transfer',
+    is_split: false,
+    ai_confidence: null,
+    chart_of_accounts: {
+      account_name: 'Transfer Clearing Account',
+      account_subtype: 'cash',
+      account_type: 'asset',
+    },
+  },
+];
+
+const pendingOutflowRows = [
+  {
+    amount: 200,
+    category_id: 'cat-expense',
+    issue_date: '2026-04-10',
+    status: 'pending',
+    chart_account: {
+      account_name: 'Office Supplies',
+      account_subtype: 'office_supplies',
+      account_type: 'expense',
+    },
+  },
+  {
+    amount: 800,
+    category_id: 'cat-transfer',
+    issue_date: '2026-04-10',
+    status: 'pending',
+    chart_account: {
+      account_name: 'Transfer Clearing Account',
+      account_subtype: 'cash',
+      account_type: 'asset',
+    },
+  },
+];
+
+const splitRows = [
+  {
+    transaction_id: 'tx-split-parent',
+    amount: 50,
+    category_id: 'cat-expense',
+    chart_of_accounts: {
+      account_name: 'Office Supplies',
+      account_subtype: 'office_supplies',
+      account_type: 'expense',
+    },
+  },
+  {
+    transaction_id: 'tx-split-parent',
+    amount: 70,
+    category_id: 'cat-equity',
+    chart_of_accounts: {
+      account_name: 'Inter-Account Transfer',
+      account_subtype: 'owners_equity',
+      account_type: 'equity',
+    },
+  },
+];
+
+// We need the mocked builder to be readable by the test, so define it once
+// and reuse across the three .from() calls.
+function makeQuery(returnRows: unknown) {
+  const builder: Record<string, unknown> = {};
+  const passthrough = () => builder;
+  for (const m of ['select', 'eq', 'in', 'is', 'lt', 'lte', 'gte']) {
+    builder[m] = vi.fn(passthrough);
+  }
+  builder.order = vi.fn().mockResolvedValue({ data: returnRows, error: null });
+  // For pending_outflows / splits the call doesn't end in .order — return data directly.
+  // We make these chainable methods also resolve when awaited as the terminal call.
+  for (const m of ['eq', 'in', 'is', 'lte', 'gte']) {
+    (builder[m] as ReturnType<typeof vi.fn>).mockImplementation(() =>
+      Object.assign(builder, {
+        then: (cb: (v: { data: unknown; error: null }) => unknown) =>
+          cb({ data: returnRows, error: null }),
+      }),
+    );
+  }
+  return builder;
+}
+
+vi.mock('@/integrations/supabase/client', () => {
+  return {
+    supabase: {
+      from: vi.fn((table: string) => {
+        if (table === 'bank_transactions') return makeQuery(txnRows);
+        if (table === 'pending_outflows') return makeQuery(pendingOutflowRows);
+        if (table === 'bank_transaction_splits') return makeQuery(splitRows);
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    },
+  };
+});
+
+import { fetchExpenseData } from '@/lib/expenseDataFetcher';
+
+describe('fetchExpenseData', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('excludes bank transactions whose category is asset/liability/equity-typed', async () => {
+    const result = await fetchExpenseData({
+      restaurantId: 'r-1',
+      startDate: new Date('2026-04-01'),
+      endDate: new Date('2026-04-30'),
+    });
+
+    const ids = result.transactions.map((t) => t.id);
+    expect(ids).toContain('tx-expense-1');
+    expect(ids).not.toContain('tx-transfer-1');
+  });
+
+  it('excludes pending outflows whose category is asset/liability/equity-typed', async () => {
+    const result = await fetchExpenseData({
+      restaurantId: 'r-1',
+      startDate: new Date('2026-04-01'),
+      endDate: new Date('2026-04-30'),
+    });
+
+    const amounts = result.pendingOutflows.map((p) => p.amount);
+    expect(amounts).toContain(200);
+    expect(amounts).not.toContain(800);
+  });
+
+  it('excludes split line items whose category is asset/liability/equity-typed', async () => {
+    // Make the parent appear as a split-parent so split lookup runs.
+    txnRows.push({
+      id: 'tx-split-parent',
+      transaction_date: '2026-04-15',
+      amount: -120,
+      status: 'posted',
+      description: 'Split parent',
+      merchant_name: null,
+      normalized_payee: null,
+      category_id: null,
+      is_split: true,
+      ai_confidence: null,
+      chart_of_accounts: null,
+    } as never);
+
+    const result = await fetchExpenseData({
+      restaurantId: 'r-1',
+      startDate: new Date('2026-04-01'),
+      endDate: new Date('2026-04-30'),
+    });
+
+    const splitAmounts = result.splitDetails.map((s) => s.amount);
+    expect(splitAmounts).toContain(50);
+    expect(splitAmounts).not.toContain(70);
+
+    txnRows.pop();
+  });
+});

--- a/tests/unit/useExpenseHealth.test.tsx
+++ b/tests/unit/useExpenseHealth.test.tsx
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+const mockTxns = [
+  // Real revenue
+  {
+    transaction_date: '2026-04-10',
+    amount: 1000,
+    status: 'posted',
+    description: 'Sales deposit',
+    merchant_name: null,
+    category_id: 'cat-revenue',
+    is_split: false,
+    chart_of_accounts: {
+      account_name: 'Sales',
+      account_subtype: 'food_revenue',
+      account_type: 'revenue',
+    },
+  },
+  // Inflow that's actually a transfer (should NOT be revenue)
+  {
+    transaction_date: '2026-04-11',
+    amount: 500,
+    status: 'posted',
+    description: 'Transfer in from savings',
+    merchant_name: null,
+    category_id: 'cat-transfer',
+    is_split: false,
+    chart_of_accounts: {
+      account_name: 'Transfer Clearing Account',
+      account_subtype: 'cash',
+      account_type: 'asset',
+    },
+  },
+  // Real food cost
+  {
+    transaction_date: '2026-04-12',
+    amount: -200,
+    status: 'posted',
+    description: 'Vendor invoice',
+    merchant_name: null,
+    category_id: 'cat-cogs',
+    is_split: false,
+    chart_of_accounts: {
+      account_name: 'Food Cost',
+      account_subtype: 'cost_of_goods_sold',
+      account_type: 'expense',
+    },
+  },
+  // Outflow that's actually a transfer (should NOT count as expense)
+  {
+    transaction_date: '2026-04-13',
+    amount: -700,
+    status: 'posted',
+    description: 'Transfer to savings',
+    merchant_name: null,
+    category_id: 'cat-transfer',
+    is_split: false,
+    chart_of_accounts: {
+      account_name: 'Transfer Clearing Account',
+      account_subtype: 'cash',
+      account_type: 'asset',
+    },
+  },
+];
+
+const txEqSpy = vi.fn();
+
+function makeTxBuilder() {
+  const builder: Record<string, unknown> = {};
+  const passthrough = () => builder;
+  builder.select = vi.fn(passthrough);
+  builder.eq = vi.fn((...args: unknown[]) => {
+    txEqSpy(...args);
+    return builder;
+  });
+  builder.in = vi.fn(passthrough);
+  builder.gte = vi.fn(passthrough);
+  builder.lte = vi.fn(passthrough);
+  // Make builder thenable so `await txQuery` resolves
+  (builder as { then: (cb: (v: unknown) => unknown) => unknown }).then = (cb) =>
+    cb({ data: mockTxns, error: null });
+  return builder;
+}
+
+function makeBalanceBuilder() {
+  const builder: Record<string, unknown> = {};
+  const passthrough = () => builder;
+  builder.select = vi.fn(passthrough);
+  builder.eq = vi.fn(passthrough);
+  (builder as { then: (cb: (v: unknown) => unknown) => unknown }).then = (cb) =>
+    cb({ data: [], error: null });
+  return builder;
+}
+
+vi.mock('@/integrations/supabase/client', () => {
+  return {
+    supabase: {
+      from: vi.fn((table: string) => {
+        if (table === 'bank_transactions') return makeTxBuilder();
+        if (table === 'bank_account_balances') return makeBalanceBuilder();
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    },
+  };
+});
+
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => ({
+    selectedRestaurant: { restaurant_id: 'r-1' },
+  }),
+}));
+
+import { useExpenseHealth } from '@/hooks/useExpenseHealth';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+describe('useExpenseHealth', () => {
+  beforeEach(() => {
+    txEqSpy.mockClear();
+  });
+
+  it('applies is_transfer = false in the query', async () => {
+    renderHook(
+      () => useExpenseHealth(new Date('2026-04-01'), new Date('2026-04-30')),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(txEqSpy).toHaveBeenCalledWith('is_transfer', false);
+    });
+  });
+
+  it('excludes asset/liability/equity inflows from revenue and outflows from cost totals', async () => {
+    const { result } = renderHook(
+      () => useExpenseHealth(new Date('2026-04-01'), new Date('2026-04-30')),
+      { wrapper },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const data = result.current.data!;
+    // Revenue should be 1000 (the +500 transfer is excluded).
+    // foodCost / revenue = 200 / 1000 = 20%
+    expect(data.foodCostPercentage).toBeCloseTo(20, 5);
+    // The +500 transfer must NOT have inflated revenue (else foodCostPct would be ~13.3%).
+    expect(data.foodCostPercentage).not.toBeCloseTo((200 / 1500) * 100, 2);
+  });
+});


### PR DESCRIPTION
## Summary
- Bank transactions assigned to a Transfer-typed category (asset/liability/equity in chart of accounts) were being rendered as Expenses on the dashboard. Root cause: `categorize_bank_transaction` does not flip `is_transfer`, so the read-path filter `is_transfer = false` lets these through.
- Fix is read-path only (Approach B from the design): a new `isTransferCategoryType()` helper excludes asset/liability/equity-typed rows from `expenseDataFetcher`, `useExpenseHealth`, `useBankTransactions`, and the daily-spending filter on `Index.tsx`.
- `useExpenseHealth` was missing the `is_transfer = false` filter entirely — added.
- New pgTAP test pins the write-time RPC contract: if `categorize_bank_transaction` ever starts auto-flipping `is_transfer`, both this test and the read-path filter need to be revisited.

## Spec & plan
- Design: `docs/superpowers/specs/2026-04-26-transfer-category-classification-design.md`
- Plan:   `docs/superpowers/plans/2026-04-26-transfer-category-classification-plan.md`

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — no new issues introduced (`git diff main...HEAD` shows no new `any`)
- [x] `npm run test` — 239 files / 3622 passed / 1 skipped
- [x] `npm run test:db` — 1241 / 1241 passed (includes new `categorize_transfer_account.sql`)
- [x] `npm run build` — clean
- [ ] Manual: create a bank txn, assign to Transfer Clearing Account category, confirm it no longer appears in dashboard Expenses or daily spending

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed financial reports incorrectly including transactions from asset, liability, and equity account categories in monthly expenses and daily spending calculations.

* **Documentation**
  * Added implementation plan and design specification for transfer account categorization fix ensuring accurate P&L reporting.

* **Tests**
  * Added unit and database tests to verify correct exclusion of non-operating account types from expense aggregations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->