### PR TITLE
fix(revenue-breakdown): format RPC date bounds in local TZ, not UTC

### DIFF
--- a/src/hooks/useRevenueBreakdown.tsx
+++ b/src/hooks/useRevenueBreakdown.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { format } from 'date-fns';
 import { supabase } from '@/integrations/supabase/client';
 import { normalizeAdjustmentsWithPassThrough, splitPassThroughSales, classifyPassThroughItem, isTipLiability } from './utils/passThroughAdjustments';
 import type { PassThroughType } from './utils/passThroughAdjustments';
@@ -144,9 +145,15 @@ export function useRevenueBreakdown(
   dateFrom: Date, 
   dateTo: Date
 ) {
-  // Format dates as strings for stable query key
-  const fromStr = dateFrom.toISOString().split('T')[0];
-  const toStr = dateTo.toISOString().split('T')[0];
+  // Format dates in local time so the RPC bounds match the calendar month
+  // the user selected. .toISOString() emits UTC: in a UTC- offset (Americas)
+  // an end-of-month local timestamp lands on the next day in UTC, pulling
+  // next month's day 1 into the breakdown; in a UTC+ offset (Asia) the
+  // start-of-month timestamp lands on the previous day in UTC, dropping
+  // this month's day 1. useMonthlyMetrics formats bounds with date-fns
+  // format(), and the two hooks must agree.
+  const fromStr = format(dateFrom, 'yyyy-MM-dd');
+  const toStr = format(dateTo, 'yyyy-MM-dd');
   
   return useQuery({
     queryKey: ['revenue-breakdown', restaurantId, fromStr, toStr],

--- a/tests/unit/useRevenueBreakdown.dateBounds.test.ts
+++ b/tests/unit/useRevenueBreakdown.dateBounds.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Regression: useRevenueBreakdown must format the RPC date bounds in the
+ * host (local) timezone — not UTC. Previously the hook used
+ * `dateFrom.toISOString().split('T')[0]`, which returns the UTC date. In any
+ * UTC- offset (Americas), the local end-of-month timestamp shifts forward
+ * one day in UTC, so the panel queried the next month's day 1 and inflated
+ * gross / pass-through totals (Russo's April 2026 dashboard showed +$3,889
+ * gross because May 1 sales were pulled in).
+ *
+ * This test pins TZ=America/Chicago and verifies the RPC receives the
+ * calendar bounds the user picked.
+ */
+
+// Pin TZ before any imports that touch Date / date-fns.
+process.env.TZ = 'America/Chicago';
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React, { type ReactNode } from 'react';
+import { startOfMonth, endOfMonth } from 'date-fns';
+
+const mockRpc = vi.fn();
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    rpc: (...args: unknown[]) => mockRpc(...args),
+    from: vi.fn(),
+  },
+}));
+
+const createWrapper = () => {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: qc }, children);
+  };
+};
+
+describe('useRevenueBreakdown date bounds (host TZ formatting)', () => {
+  beforeEach(() => {
+    mockRpc.mockReset();
+    // Both RPCs return non-null arrays so the fast path is taken.
+    mockRpc.mockResolvedValue({ data: [], error: null });
+  });
+
+  it('passes local-TZ calendar bounds (NOT UTC) to get_pass_through_totals', async () => {
+    const { useRevenueBreakdown } = await import('@/hooks/useRevenueBreakdown');
+
+    const dateFrom = startOfMonth(new Date(2026, 3, 1));   // 2026-04-01 00:00 CDT
+    const dateTo = endOfMonth(new Date(2026, 3, 1));        // 2026-04-30 23:59 CDT
+
+    // Sanity: under TZ=America/Chicago, .toISOString() of the end bound
+    // shifts to 2026-05-01 — the bug we're guarding against.
+    expect(dateTo.toISOString().split('T')[0]).toBe('2026-05-01');
+
+    const { result } = renderHook(
+      () => useRevenueBreakdown('restaurant-uuid', dateFrom, dateTo),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const passThroughCall = mockRpc.mock.calls.find(
+      (c) => c[0] === 'get_pass_through_totals'
+    );
+    expect(passThroughCall).toBeDefined();
+    expect(passThroughCall![1]).toEqual({
+      p_restaurant_id: 'restaurant-uuid',
+      p_date_from: '2026-04-01',
+      p_date_to: '2026-04-30',
+    });
+
+    const revenueCall = mockRpc.mock.calls.find(
+      (c) => c[0] === 'get_revenue_by_account'
+    );
+    expect(revenueCall).toBeDefined();
+    expect(revenueCall![1]).toEqual({
+      p_restaurant_id: 'restaurant-uuid',
+      p_date_from: '2026-04-01',
+      p_date_to: '2026-04-30',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The dashboard "Revenue Breakdown" panel rendered larger numbers than the summary header because `useRevenueBreakdown` formatted RPC date bounds with `date.toISOString().split('T')[0]` (UTC) while `useMonthlyMetrics` formats them with `format(date, 'yyyy-MM-dd')` (local TZ). For any restaurant whose end-of-month local timestamp lands on the next UTC day, the breakdown queried one extra day and pulled the next month's day-1 sales into gross / pass-through.

## Evidence (Russo's Pizzeria, April 2026)

Verified via Supabase that the deployed RPCs are correct (PR #485 set the canonical sources). Every breakdown-vs-canonical delta equals **May 1 alone** to the penny:

| Field            | Canonical RPC | Breakdown panel | Δ          | May 1 actual |
| ---------------- | ------------- | --------------- | ---------- | ------------ |
| Gross Revenue    | $75,917.82    | $79,807         | **+$3,889** | $3,888.90    |
| Sales Tax        | $5,974.88     | $6,278          | **+$303**   | $302.83      |
| Tips             | $10,381.78    | $11,015         | **+$633**   | $633.34      |
| Discounts        | $1,477.40     | $1,552          | **+$75**    | $74.61       |
| POS Collected    | $92,274.48    | $97,100         | **+$4,826** | sum of above |

Selecting April in CDT (UTC-5) produces `endOfMonth` = `2026-04-30T23:59:59-05:00` = `2026-05-01T04:59:59Z`. `.toISOString().split('T')[0]` → `'2026-05-01'`, sent to the RPC as upper bound.

## Fix

- `src/hooks/useRevenueBreakdown.tsx`: replace `.toISOString().split('T')[0]` with `format(date, 'yyyy-MM-dd')` (date-fns, already a project dependency). One-line change to each of the two bound strings.

## Test plan

- [x] New regression test `tests/unit/useRevenueBreakdown.dateBounds.test.ts` pins `process.env.TZ = 'America/Chicago'`, builds `endOfMonth(april)`, sanity-asserts the bug condition (`.toISOString()` returns `'2026-05-01'`), then asserts the supabase RPC receives `p_date_to: '2026-04-30'`. Verified the test fails on `origin/main` (`Received: '2026-05-01'`) and passes with the fix.
- [x] `npm run typecheck` clean
- [x] All Monthly Performance / Revenue Breakdown tests pass under `TZ=UTC` (CI default): `monthlyPerformance.acceptance`, `MonthlyBreakdownTable`, `monthlyMetrics`, `useMonthlyMetrics.revenueParity`, `useRevenueBreakdown.passThrough`, `useRevenueBreakdown.dateBounds`.
- [ ] Production verification post-merge: refresh Russo's April 2026 dashboard and confirm the breakdown panel matches the summary header at $75,917.82 gross.

## Out of scope

- Other hooks across the codebase use the same `.toISOString().split('T')[0]` pattern (`useReconciliationVariance`, `useCashFlowStatement`, `useInventoryPurchases`, etc.). Those weren't observed misbehaving and changing them risks unintended date-shift in other panels — separate audit ticket.
- Pre-existing `any` lint warnings in the file are untouched (out of scope per CLAUDE.md "don't refactor beyond what the task requires").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed revenue breakdown date filtering to use local calendar dates instead of UTC-derived dates. Selected date ranges now correctly align with revenue reports and queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->