### PR TITLE
feat(analytics): wire PostHog funnel events for visitor → trial → POS → P&L → subscription

### DIFF
--- a/docs/superpowers/plans/2026-05-07-posthog-funnel-events-plan.md
+++ b/docs/superpowers/plans/2026-05-07-posthog-funnel-events-plan.md
@@ -1,0 +1,122 @@
+# PostHog Funnel Events — Plan
+
+**Spec:** [`docs/superpowers/specs/2026-05-07-posthog-funnel-events-design.md`](../specs/2026-05-07-posthog-funnel-events-design.md)
+**Branch:** `feature/posthog-funnel-events`
+
+## Task list (TDD order)
+
+### T1 — `src/lib/analytics.ts` + tests (RED → GREEN)
+**Test first:** `tests/unit/analytics.test.ts`
+- [ ] `isInternalEmail('foo@easyshifthq.com')` → true
+- [ ] `isInternalEmail('foo@easyshifthq.COM')` → true (case-insensitive)
+- [ ] `isInternalEmail('foo@example.com')` → false
+- [ ] `isInternalEmail(null)` / `isInternalEmail(undefined)` / `isInternalEmail('')` → false
+- [ ] `storeAttribution('?utm_source=google&utm_medium=cpc&utm_campaign=launch', '', '/auth')` writes JSON with those fields + `referrer:''` + `landing_page:'/auth'` + `captured_at`
+- [ ] `storeAttribution('', '', '/auth')` (no UTM, no referrer) does NOT write
+- [ ] `storeAttribution('', 'https://google.com', '/auth')` writes (referrer alone is sufficient)
+- [ ] `storeAttribution(...)` does not clobber existing data when called twice — second call adds nothing if no fresh data
+- [ ] `getStoredAttribution()` returns the parsed object; returns null when key missing
+- [ ] `getStoredAttribution()` returns null when value is malformed JSON (no throw)
+- [ ] `clearStoredAttribution()` removes the key
+- [ ] `INTERNAL_DOMAINS` constant exported as readonly array
+
+**Implementation:** `src/lib/analytics.ts`. No React, no posthog imports — pure utilities. ~70 LOC.
+
+**Commit:** `feat(analytics): add internal-domain + UTM attribution helpers`
+
+### T2 — `supabase/functions/_shared/posthogServer.ts` + Deno test
+**Test first:** `supabase/functions/_shared/posthogServer.test.ts`
+- [ ] When `POSTHOG_PROJECT_KEY` is unset → `captureServerEvent` resolves, no fetch made
+- [ ] When `POSTHOG_HOST` is unset → same
+- [ ] When both set → invokes the SDK (we mock `npm:posthog-node` via `import.meta.resolve` shim or stub `globalThis.fetch` since posthog-node uses fetch underneath)
+- [ ] Errors thrown by the SDK are caught and logged; function still resolves
+
+**Implementation:** ~40 LOC. Single async function. Pinned to `npm:posthog-node@4.18.0` (latest stable; pin exact version).
+
+**Commit:** `feat(analytics): add server-side PostHog capture helper`
+
+### T3 — Wire `useAuth.tsx` (account_created + trial_started + identify + last_login)
+**Test first:** `tests/unit/useAuth.posthog.test.tsx`
+- [ ] When user appears with `created_at` within last 5 min and no localStorage flag → `posthog.identify` called with `is_internal:false` for `@example.com`, `is_internal:true` for `@easyshifthq.com`
+- [ ] `account_created` and `trial_started` capture calls fire exactly once
+- [ ] localStorage flag `posthog_account_created_${id}` is set
+- [ ] Stored attribution from `getStoredAttribution()` is merged into person properties on identify
+- [ ] On second mount with same user → no duplicate `account_created` fire
+- [ ] When user appears with old `created_at` (>5 min) → only `last_login_at` identify fires; no `account_created`
+- [ ] When user is null → nothing fires
+
+**Implementation:** add a new effect in `AuthProvider`. Mock `posthog-js` default export with `vi.mock('posthog-js', ...)`. Don't touch existing auth logic.
+
+**Commit:** `feat(analytics): identify users + fire account_created/trial_started in useAuth`
+
+### T4 — Wire `Auth.tsx` UTM capture
+**Test first:** `tests/unit/Auth.attribution.test.tsx`
+- [ ] Mount with `?utm_source=g&utm_medium=cpc` → `localStorage.signup_attribution` is set with parsed values
+- [ ] Mount without params and no referrer → localStorage not set
+- [ ] Mount fires once (mount-only effect with empty deps)
+
+**Implementation:** Add a `useEffect(() => { storeAttribution(...) }, [])` near the top of `Auth`. ~5 lines.
+
+**Commit:** `feat(analytics): capture signup attribution to localStorage on Auth mount`
+
+### T5 — Wire POS callbacks (pos_integration_completed × 3)
+**Test first:** Smoke test per file via mocking — vitest with `vi.mock('@/integrations/supabase/client')` for the success path:
+- [ ] On `setStatus('success')` in SquareCallback, `posthog.capture('pos_integration_completed', { pos_provider: 'square', seconds_from_trial_start: <number> })` fires
+- [ ] Same for Toast → `'toast'`
+- [ ] Same for Clover → `'clover'`
+- [ ] On the error branch, no capture call fires
+
+**Implementation:** Three near-identical edits. Add `useAuth` import where missing. Compute `secondsFromTrialStart` from `user?.created_at`.
+
+**Commit:** `feat(analytics): fire pos_integration_completed on POS callbacks`
+
+### T6 — Wire `Index.tsx` first_pnl_viewed
+**Test first:** `tests/unit/Index.firstPnlViewed.test.tsx`
+- [ ] When `periodData` resolves with `net_revenue > 0` and no localStorage flag → capture fires with `has_real_data:true`
+- [ ] When `periodData` resolves with `net_revenue === 0` → capture fires with `has_real_data:false`
+- [ ] On second render with same user → no duplicate capture
+- [ ] When `periodData` is null → no capture
+
+**Implementation:** Add a `useEffect` in `Index` with guards. ~15 lines.
+
+**Commit:** `feat(analytics): fire first_pnl_viewed once per user on Index`
+
+### T7 — Wire Stripe webhook subscription_created/canceled
+**Test first:** Extend `subscription-handler.test.ts`:
+- [ ] On `customer.subscription.created` event → after DB update, server-side capture invoked with `tier`, `billing_period`, `mrr_cents`, `is_annual`, `restaurant_id`
+- [ ] On `customer.subscription.updated` (NOT created) → no `subscription_created` fire (avoid double-count on plan changes)
+- [ ] On `customer.subscription.deleted` → after DB update, `subscription_canceled` fires with `restaurant_id`
+- [ ] When PostHog server helper throws → handler still returns successfully (telemetry must not break webhook)
+
+**Implementation:** Use the same owner lookup pattern as `syncVolumeDiscountsForOwner`. Wrap in try/catch like the volume discount sync does.
+
+**Commit:** `feat(analytics): fire subscription_created/canceled from Stripe webhook`
+
+## Dependencies
+
+- T1 has no dependency
+- T2 has no dependency on T1
+- T3 depends on T1 (uses `getStoredAttribution`, `isInternalEmail`)
+- T4 depends on T1 (uses `storeAttribution`)
+- T5 depends on nothing (uses inline event constants)
+- T6 depends on nothing
+- T7 depends on T2
+
+T1 and T2 can be done in parallel; same for T5 and T6; T3 needs T1 first; T4 needs T1; T7 needs T2.
+
+## Sequencing
+
+Sequential commit order (single-developer flow): **T1 → T2 → T3 → T4 → T5 → T6 → T7**
+
+Each task is one commit. ~7 commits total.
+
+## Acceptance criteria
+
+- [ ] All 7 tasks committed
+- [ ] `npm run test` green
+- [ ] `npm run typecheck` green
+- [ ] `npm run lint` green
+- [ ] `npm run build` green
+- [ ] `coderabbit review --plain --type committed` returns no actionable findings
+- [ ] PR opened, CI green, SonarCloud quality gate green
+- [ ] Phase 9d: every CodeRabbit/Codex comment triaged

--- a/docs/superpowers/specs/2026-05-07-posthog-funnel-events-design.md
+++ b/docs/superpowers/specs/2026-05-07-posthog-funnel-events-design.md
@@ -52,14 +52,14 @@ Events: `account_created`, `trial_started`, `pos_integration_completed`, `first_
 ### `account_created` (browser, fired in `useAuth.tsx`)
 **Distinct ID:** `session.user.id`
 **Person properties** set via `posthog.identify(...)`:
-- `email` (string)
 - `signup_source` (string) — from stored attribution: `utm_source` || `referrer` || `'direct'`
 - `signup_medium` (string) — `utm_medium` || `'organic'`
 - `signup_campaign` (string | null)
-- `is_internal` (boolean) — `isInternalEmail(email)`
+- `is_internal` (boolean) — `isInternalEmail(email)` (email is read locally only and never forwarded to PostHog)
 
-**Event properties:**
-- `email` (string)
+**Event properties:** none
+
+**PII note:** Email is intentionally NOT sent to PostHog. We only need it locally to compute `is_internal`; the boolean is sufficient for funnel filtering. Distinct ID is the Supabase `user.id`, which is already pseudonymous.
 
 ### `trial_started` (browser, fired in `useAuth.tsx`)
 - `trial_ends_at` (ISO string, +14 days from `now()`)
@@ -77,18 +77,16 @@ Events: `account_created`, `trial_started`, `pos_integration_completed`, `first_
 - `has_real_data` (boolean) — `periodData.net_revenue > 0`
 
 ### `subscription_created` / `subscription_canceled` (server, in Stripe webhook)
-**Distinct ID:** `userId` looked up from `restaurants.stripe_subscription_id` → owner via `user_restaurants`.
-**Event properties (`subscription_created`):**
-- `tier` (`'starter' | 'growth' | 'pro'`) — already computed in handler
-- `billing_period` (`'monthly' | 'annual'`)
-- `mrr_cents` (number) — `price.unit_amount`
-- `is_annual` (boolean)
-- `restaurant_id` (string)
+**Distinct ID:** `subscription.metadata.user_id` (set when the checkout session was created — no DB lookup required at fire time).
+**Event properties (both events, identical shape):**
+- `tier` (`'starter' | 'growth' | 'pro' | null`) — derived from `price.id` first, then substring/amount fallback, finally metadata; `null` if all fail
+- `period` (`'monthly' | 'annual' | null`) — from `price.recurring.interval` (preferred over metadata, which can be stale after plan changes)
+- `mrr_cents` (number | null) — **always monthly**. For annual prices, `Math.round(price.unit_amount / 12)` so the metric is comparable across billing periods. `null` if no price amount is set.
+- `stripe_subscription_id` (string)
 
-**Event properties (`subscription_canceled`):**
-- `restaurant_id` (string)
+We fire `subscription_created` inside the `customer.subscription.created` case (NOT `customer.subscription.updated`) to avoid double-firing on plan changes. We fire `subscription_canceled` from `customer.subscription.deleted`. For canceled events, we re-derive `tier`/`period` from the subscription's current price (with metadata fallback) because Stripe metadata can be stale after upgrades/downgrades.
 
-We fire `subscription_created` inside the `customer.subscription.created` case (NOT `customer.subscription.updated`) to avoid double-firing on plan changes. We fire `subscription_canceled` from `customer.subscription.deleted`.
+All four shared properties use `?? null` coercion so PostHog never sees `undefined` — the property either has a real value or is explicitly null.
 
 ## Files to add
 
@@ -121,14 +119,16 @@ export async function captureServerEvent(input: ServerEventInput): Promise<void>
 ### `src/hooks/useAuth.tsx`
 - Add new `useEffect` on `[user?.id]` that:
   - If `user` is set AND `localStorage[\`posthog_account_created_${user.id}\`]` is empty AND `user.created_at` is within 5 minutes:
+    - Set the localStorage flag FIRST (atomic dedup — see note below)
     - Read attribution via `getStoredAttribution()`
-    - Call `posthog.identify(user.id, { email, signup_source, signup_medium, signup_campaign, is_internal })`
-    - `posthog.capture('account_created', { email })`
+    - Call `posthog.identify(user.id, { signup_source, signup_medium, signup_campaign, is_internal })` — **no email**
+    - `posthog.capture('account_created')` — no payload
     - `posthog.capture('trial_started', { trial_ends_at })`
-    - Set localStorage flag
     - Clear stored attribution
   - Else if `user` is set AND flag exists: fire `posthog.identify(user.id, { last_login_at })` (returning user)
 - Don't touch `signIn`/`signUp`/`signOut` business logic.
+
+**Atomic dedup note:** The flag is set BEFORE captures fire. If `trial_started` throws after `account_created` succeeded, we'd otherwise re-fire `account_created` on the next mount within the 5-min window — losing the one-time signup signal is preferable to double-counting it. (The asymmetric helpers `recordFirstPnlViewed` and `recordPosIntegrationCompleted` set their flags only on success because they're naturally retryable on the next view/connect.)
 
 ### `src/pages/Auth.tsx`
 - Add `useEffect` on `[]` (mount-only):

--- a/docs/superpowers/specs/2026-05-07-posthog-funnel-events-design.md
+++ b/docs/superpowers/specs/2026-05-07-posthog-funnel-events-design.md
@@ -1,0 +1,199 @@
+# PostHog Funnel Events — Design
+
+**Date:** 2026-05-07
+**Author:** Jose (with Claude)
+**Status:** Proposed
+
+## Goal
+
+Wire the five funnel events that currently don't fire so we can measure where users drop off:
+
+```
+Visitor → Trial signup → POS connected → First P&L viewed → Subscription created
+```
+
+Events: `account_created`, `trial_started`, `pos_integration_completed`, `first_pnl_viewed`, `subscription_created` (+ `subscription_canceled` for churn).
+
+## Non-goals
+
+- Lead magnet page (separate branch)
+- Trial-expiry emails (Resend, follow-up PR)
+- Onboarding drawer gating (follow-up)
+- Marketing site changes (separate)
+- `.env` secret rotation (separate security ticket)
+- `pos_integration_started` event — skipped until we wire it at the click site (see Decisions)
+
+## Existing state (audited 2026-05-07)
+
+- `src/main.tsx` initializes `PostHogProvider` conditionally on `VITE_PUBLIC_POSTHOG_KEY` + `VITE_PUBLIC_POSTHOG_HOST`.
+- `posthog-js@^1.275.1` is installed. `posthog-node` is NOT.
+- Zero `posthog.capture()` calls anywhere. One unused `usePostHog()` hook in `PurchaseOrderEditor.tsx`.
+- `useAuth.tsx` has no new-user vs. returning-user branch.
+- POS callbacks (Square/Toast/Clover) all use `setStatus('success')` at known line numbers.
+- `Index.tsx` is the canonical dashboard with `periodData.net_revenue`.
+- `subscription-handler.ts` handles `customer.subscription.created`/`updated`/`deleted` and `checkout.session.completed`.
+- No PostHog mocking precedent in the test suite.
+
+## Decisions
+
+| # | Decision | Why |
+|---|----------|-----|
+| 1 | Server-side: `posthog-node` via Deno `npm:` specifier | User chose; matches doc snippet; built-in batching |
+| 2 | `first_pnl_viewed` fires only from `Index.tsx` | Single source of truth; localStorage flag per user |
+| 3 | `is_internal` covers `@easyshifthq.com` only (extensible constant) | Conservative default; partner domain can be added later |
+| 4 | Skip `pos_integration_started` for now | Putting it in callback creates nonsense back-to-back events; do it right at click site in follow-up |
+| 5 | New-account detection: `created_at` recency (≤5 min) AND localStorage flag | Avoids double-fire on session restore, magic-link clicks |
+| 6 | Centralize cross-cutting helpers in `src/lib/analytics.ts` | Internal-domain logic + UTM persistence shouldn't be inlined 5 places |
+| 7 | Inline `posthog.capture()` for simple events at the call site | Matches doc snippets; clear at the call site what fires |
+| 8 | Server-side wrapper at `supabase/functions/_shared/posthogServer.ts` | Avoid duplication if we add more server-side events |
+
+## Event schema
+
+### `account_created` (browser, fired in `useAuth.tsx`)
+**Distinct ID:** `session.user.id`
+**Person properties** set via `posthog.identify(...)`:
+- `email` (string)
+- `signup_source` (string) — from stored attribution: `utm_source` || `referrer` || `'direct'`
+- `signup_medium` (string) — `utm_medium` || `'organic'`
+- `signup_campaign` (string | null)
+- `is_internal` (boolean) — `isInternalEmail(email)`
+
+**Event properties:**
+- `email` (string)
+
+### `trial_started` (browser, fired in `useAuth.tsx`)
+- `trial_ends_at` (ISO string, +14 days from `now()`)
+
+### `pos_integration_completed` (browser, fired in each `*Callback.tsx` success branch)
+**Distinct ID:** `session.user.id`
+**Event properties:**
+- `pos_provider` (`'square' | 'toast' | 'clover'`)
+- `seconds_from_trial_start` (number) — `(Date.now() - new Date(user.created_at).getTime()) / 1000`
+
+### `first_pnl_viewed` (browser, fired once per user in `Index.tsx`)
+**Dedup:** `localStorage.getItem(\`pnl_first_view_seen_${user.id}\`)`
+**Event properties:**
+- `seconds_from_trial_start` (number)
+- `has_real_data` (boolean) — `periodData.net_revenue > 0`
+
+### `subscription_created` / `subscription_canceled` (server, in Stripe webhook)
+**Distinct ID:** `userId` looked up from `restaurants.stripe_subscription_id` → owner via `user_restaurants`.
+**Event properties (`subscription_created`):**
+- `tier` (`'starter' | 'growth' | 'pro'`) — already computed in handler
+- `billing_period` (`'monthly' | 'annual'`)
+- `mrr_cents` (number) — `price.unit_amount`
+- `is_annual` (boolean)
+- `restaurant_id` (string)
+
+**Event properties (`subscription_canceled`):**
+- `restaurant_id` (string)
+
+We fire `subscription_created` inside the `customer.subscription.created` case (NOT `customer.subscription.updated`) to avoid double-firing on plan changes. We fire `subscription_canceled` from `customer.subscription.deleted`.
+
+## Files to add
+
+### `src/lib/analytics.ts`
+Public surface:
+```ts
+export const INTERNAL_DOMAINS = ['@easyshifthq.com'] as const;
+export function isInternalEmail(email?: string | null): boolean;
+export interface SignupAttribution { ... }
+export function storeAttribution(search: string, referrer: string, pathname: string): void;
+export function getStoredAttribution(): SignupAttribution | null;
+export function clearStoredAttribution(): void;
+export const ATTRIBUTION_STORAGE_KEY = 'signup_attribution';
+```
+Pure functions, no React. Tested directly.
+
+### `supabase/functions/_shared/posthogServer.ts`
+```ts
+export interface ServerEventInput { distinctId: string; event: string; properties?: Record<string, unknown>; }
+export async function captureServerEvent(input: ServerEventInput): Promise<void>;
+```
+- Reads `POSTHOG_PROJECT_KEY` and `POSTHOG_HOST` from `Deno.env`
+- If either is missing, logs a warning and no-ops (keeps webhook robust if we ever rotate keys)
+- Uses `npm:posthog-node@^4.0.0` (latest stable as of writing; pinned)
+- Lazily instantiates a single `PostHog` client per process; calls `capture()` then `await ph.shutdown()` per event (edge functions are short-lived; flush before return)
+- Wraps everything in try/catch; errors are logged but never thrown — funnel telemetry must NEVER break a webhook
+
+## Files to modify
+
+### `src/hooks/useAuth.tsx`
+- Add new `useEffect` on `[user?.id]` that:
+  - If `user` is set AND `localStorage[\`posthog_account_created_${user.id}\`]` is empty AND `user.created_at` is within 5 minutes:
+    - Read attribution via `getStoredAttribution()`
+    - Call `posthog.identify(user.id, { email, signup_source, signup_medium, signup_campaign, is_internal })`
+    - `posthog.capture('account_created', { email })`
+    - `posthog.capture('trial_started', { trial_ends_at })`
+    - Set localStorage flag
+    - Clear stored attribution
+  - Else if `user` is set AND flag exists: fire `posthog.identify(user.id, { last_login_at })` (returning user)
+- Don't touch `signIn`/`signUp`/`signOut` business logic.
+
+### `src/pages/Auth.tsx`
+- Add `useEffect` on `[]` (mount-only):
+  - Call `storeAttribution(window.location.search, document.referrer, window.location.pathname)`
+- That's it. Mount-time only so refresh-without-params doesn't clobber.
+
+### `src/pages/SquareCallback.tsx`, `ToastCallback.tsx`, `CloverCallback.tsx`
+In each `setStatus('success')` block:
+- Compute `secondsFromTrialStart = user?.created_at ? (Date.now() - new Date(user.created_at).getTime()) / 1000 : null`
+- `posthog.capture('pos_integration_completed', { pos_provider: 'square'|'toast'|'clover', seconds_from_trial_start: secondsFromTrialStart })`
+
+Need to add `useAuth()` import in callbacks that don't have it.
+
+### `src/pages/Index.tsx`
+Add `useEffect` on `[periodData, user?.id, user?.created_at]`:
+- Guard: `user?.id && periodData && !localStorage.getItem(\`pnl_first_view_seen_${user.id}\`)`
+- Capture `first_pnl_viewed` with `seconds_from_trial_start` and `has_real_data`
+- Set the localStorage flag
+
+### `supabase/functions/stripe-subscription-webhook/subscription-handler.ts`
+- Import the new `captureServerEvent` helper.
+- In `customer.subscription.created` case (only this case, not `updated`):
+  - After successful DB update, look up owner via `user_restaurants` (similar query already in `syncVolumeDiscountsForOwner`).
+  - Compute `mrr_cents`, `billing_period`, `is_annual` from the existing `subscription.items.data[0].price`.
+  - Call `captureServerEvent({ distinctId: ownerUserId, event: 'subscription_created', properties: { ... } })`
+  - Wrap in try/catch — never break the webhook.
+- In `customer.subscription.deleted` case, after successful DB update:
+  - Look up owner same way.
+  - `captureServerEvent({ distinctId: ownerUserId, event: 'subscription_canceled', properties: { restaurant_id } })`
+- Use `event.type === 'customer.subscription.created'` to distinguish — switch case label is shared with `updated` today, so we'll need a runtime check inside.
+
+## Test plan
+
+### Unit tests (vitest)
+- `tests/unit/analytics.test.ts`:
+  - `isInternalEmail` — true for `@easyshifthq.com` (case-insensitive), false for others, false for null/undefined/empty
+  - `storeAttribution` — writes parsed UTM/referrer/landing/captured_at; no-ops when no params and no referrer
+  - `storeAttribution` — overwrites only when there's something to store (refresh without params doesn't clobber)
+  - `getStoredAttribution` — returns parsed object; returns null if missing/malformed JSON
+  - `clearStoredAttribution` — removes the key
+
+### Edge function test (Deno.test)
+- `supabase/functions/_shared/posthogServer.test.ts`:
+  - When `POSTHOG_PROJECT_KEY`/`POSTHOG_HOST` are unset, `captureServerEvent` resolves without throwing (no-op path)
+  - When set, builds correct payload via stubbed `globalThis.fetch` (we'll mock `posthog-node` by stubbing fetch)
+
+### Manual / smoke
+- Local: with prod-like env vars in `.env.local`, sign up with a fresh account; verify in PostHog Live Events:
+  - `account_created` + `trial_started` fire
+  - `pos_integration_completed` after a real Square sandbox connect
+  - `first_pnl_viewed` after dashboard load
+  - Server: trigger a Stripe test webhook → `subscription_created` appears
+- Confirm `is_internal: true` for the test account
+
+## Lessons applied (from `memory/lessons.md`)
+
+- **2026-04-22 — Worktree first:** done before any artifact ✓
+- **2026-04-22 — `unknown` not `any` in catches:** webhook try/catch will use `instanceof Error` ✓
+- **2026-04-22 — PostgREST cross-schema:** owner lookup goes through `user_restaurants` (public schema) ✓
+- **2026-04-26 — CI green ≠ comments addressed:** Phase 9d triage required ✓
+- **2026-05-01 — Bot review claims about prior version:** if any bot says "the previous version did X," diff before believing ✓
+
+## Risks / concerns
+
+1. **PostHog server SDK reliability:** `posthog-node` over `npm:` specifier in Deno edge functions. If it fails to import, the whole webhook breaks. Mitigation: import inside try/catch in the helper; fall back to no-op.
+2. **Webhook latency:** PostHog `capture()` + `shutdown()` adds ~100-300ms per webhook event. Acceptable; webhook is async from Stripe's perspective.
+3. **Magic-link / session restore double-fire:** Mitigated by the localStorage flag + `created_at` recency window.
+4. **Test account hygiene:** Without `is_internal` filtering, all your testing skews funnel data. We're shipping the property; you must remember to add the filter to PostHog insights.

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,7 +1,9 @@
 import { useState, useEffect, createContext, useContext, ReactNode, useCallback } from 'react';
 import { User, Session } from '@supabase/supabase-js';
+import posthog from 'posthog-js';
 import { supabase } from '@/integrations/supabase/client';
 import { Capacitor } from '@capacitor/core';
+import { recordAuthEvents } from '@/lib/analytics';
 
 interface AuthContextType {
   user: User | null;
@@ -102,6 +104,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       }
     };
   }, [handleAuthStateChange]);
+
+  // Fire PostHog identify + signup/login events when the user resolves.
+  // Telemetry must never break auth, so recordAuthEvents wraps everything in try/catch.
+  useEffect(() => {
+    if (!user?.id) return;
+    recordAuthEvents({
+      userId: user.id,
+      email: user.email,
+      createdAt: user.created_at,
+      posthog,
+    });
+  }, [user?.id, user?.email, user?.created_at]);
 
   const signIn = async (email: string, password: string) => {
     try {

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -107,6 +107,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   // Fire PostHog identify + signup/login events when the user resolves.
   // Telemetry must never break auth, so recordAuthEvents wraps everything in try/catch.
+  // Email is passed locally so recordAuthEvents can compute is_internal, then dropped —
+  // it is NOT forwarded to PostHog.
   useEffect(() => {
     if (!user?.id) return;
     recordAuthEvents({
@@ -115,7 +117,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       createdAt: user.created_at,
       posthog,
     });
-  }, [user?.id, user?.email, user?.created_at]);
+  }, [user?.id]);
 
   const signIn = async (email: string, password: string) => {
     try {

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,61 @@
+export const INTERNAL_DOMAINS: readonly string[] = ['@easyshifthq.com'] as const;
+
+export const ATTRIBUTION_STORAGE_KEY = 'signup_attribution';
+
+export interface SignupAttribution {
+  utm_source: string | null;
+  utm_medium: string | null;
+  utm_campaign: string | null;
+  referrer: string;
+  landing_page: string;
+  captured_at: string;
+}
+
+export function isInternalEmail(email?: string | null): boolean {
+  if (!email) return false;
+  const lower = email.toLowerCase();
+  return INTERNAL_DOMAINS.some((domain) => lower.endsWith(domain.toLowerCase()));
+}
+
+export function storeAttribution(search: string, referrer: string, landingPage: string): void {
+  const params = new URLSearchParams(search);
+  const utm_source = params.get('utm_source');
+  const utm_medium = params.get('utm_medium');
+  const utm_campaign = params.get('utm_campaign');
+
+  const hasFreshData = Boolean(utm_source || utm_medium || utm_campaign || referrer);
+  if (!hasFreshData) return;
+
+  const attribution: SignupAttribution = {
+    utm_source,
+    utm_medium,
+    utm_campaign,
+    referrer,
+    landing_page: landingPage,
+    captured_at: new Date().toISOString(),
+  };
+
+  try {
+    localStorage.setItem(ATTRIBUTION_STORAGE_KEY, JSON.stringify(attribution));
+  } catch {
+    // Quota exceeded or storage disabled — analytics must never block signup.
+  }
+}
+
+export function getStoredAttribution(): SignupAttribution | null {
+  try {
+    const raw = localStorage.getItem(ATTRIBUTION_STORAGE_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as SignupAttribution;
+  } catch {
+    return null;
+  }
+}
+
+export function clearStoredAttribution(): void {
+  try {
+    localStorage.removeItem(ATTRIBUTION_STORAGE_KEY);
+  } catch {
+    // Ignore
+  }
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -59,3 +59,75 @@ export function clearStoredAttribution(): void {
     // Ignore
   }
 }
+
+export const NEW_SIGNUP_WINDOW_MS = 5 * 60 * 1000;
+export const TRIAL_DURATION_DAYS = 14;
+const ACCOUNT_CREATED_FLAG_PREFIX = 'posthog_account_created_';
+
+export function accountCreatedFlagKey(userId: string): string {
+  return `${ACCOUNT_CREATED_FLAG_PREFIX}${userId}`;
+}
+
+export interface PostHogLike {
+  identify(distinctId: string, properties?: Record<string, unknown>): void;
+  capture(event: string, properties?: Record<string, unknown>): void;
+}
+
+export interface RecordAuthEventsOptions {
+  userId: string;
+  email: string | null | undefined;
+  createdAt: string | null | undefined;
+  posthog: PostHogLike;
+  now?: Date;
+}
+
+export function recordAuthEvents(options: RecordAuthEventsOptions): void {
+  const { userId, email, createdAt, posthog } = options;
+  if (!userId) return;
+
+  const now = options.now ?? new Date();
+  const isRecentSignup = createdAt
+    ? now.getTime() - new Date(createdAt).getTime() <= NEW_SIGNUP_WINDOW_MS
+    : false;
+
+  let flagAlreadySet = false;
+  try {
+    flagAlreadySet = !!localStorage.getItem(accountCreatedFlagKey(userId));
+  } catch {
+    flagAlreadySet = false;
+  }
+
+  try {
+    if (isRecentSignup && !flagAlreadySet) {
+      const attribution = getStoredAttribution();
+      const trialEndsAt = new Date(now.getTime() + TRIAL_DURATION_DAYS * 24 * 60 * 60 * 1000).toISOString();
+
+      const safeEmail = email ?? null;
+      posthog.identify(userId, {
+        email: safeEmail,
+        signup_source: attribution?.utm_source || attribution?.referrer || 'direct',
+        signup_medium: attribution?.utm_medium || 'organic',
+        signup_campaign: attribution?.utm_campaign ?? null,
+        is_internal: isInternalEmail(safeEmail),
+      });
+
+      posthog.capture('account_created', { email: safeEmail });
+      posthog.capture('trial_started', { trial_ends_at: trialEndsAt });
+
+      try {
+        localStorage.setItem(accountCreatedFlagKey(userId), '1');
+      } catch {
+        // ignore
+      }
+
+      clearStoredAttribution();
+    } else {
+      posthog.identify(userId, {
+        last_login_at: now.toISOString(),
+      });
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error('[analytics] recordAuthEvents failed:', msg);
+  }
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -132,6 +132,55 @@ export function recordAuthEvents(options: RecordAuthEventsOptions): void {
   }
 }
 
+const FIRST_PNL_VIEWED_FLAG_PREFIX = 'pnl_first_view_seen_';
+
+export function firstPnlViewedFlagKey(userId: string): string {
+  return `${FIRST_PNL_VIEWED_FLAG_PREFIX}${userId}`;
+}
+
+export interface RecordFirstPnlViewedOptions {
+  userId: string;
+  hasRealData: boolean;
+  userCreatedAt: string | null | undefined;
+  posthog: PostHogLike;
+  now?: Date;
+}
+
+export function recordFirstPnlViewed(options: RecordFirstPnlViewedOptions): void {
+  const { userId, hasRealData, userCreatedAt, posthog } = options;
+  if (!userId) return;
+
+  const flagKey = firstPnlViewedFlagKey(userId);
+  let alreadySeen = false;
+  try {
+    alreadySeen = !!localStorage.getItem(flagKey);
+  } catch {
+    alreadySeen = false;
+  }
+  if (alreadySeen) return;
+
+  const now = options.now ?? new Date();
+  const seconds_from_trial_start = userCreatedAt
+    ? Math.floor((now.getTime() - new Date(userCreatedAt).getTime()) / 1000)
+    : null;
+
+  try {
+    posthog.capture('first_pnl_viewed', {
+      seconds_from_trial_start,
+      has_real_data: hasRealData,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error('[analytics] recordFirstPnlViewed failed:', msg);
+  }
+
+  try {
+    localStorage.setItem(flagKey, '1');
+  } catch {
+    // ignore
+  }
+}
+
 export interface RecordPosIntegrationCompletedOptions {
   posProvider: string;
   userCreatedAt: string | null | undefined;

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -131,3 +131,29 @@ export function recordAuthEvents(options: RecordAuthEventsOptions): void {
     console.error('[analytics] recordAuthEvents failed:', msg);
   }
 }
+
+export interface RecordPosIntegrationCompletedOptions {
+  posProvider: string;
+  userCreatedAt: string | null | undefined;
+  posthog: PostHogLike;
+  now?: Date;
+}
+
+export function recordPosIntegrationCompleted(options: RecordPosIntegrationCompletedOptions): void {
+  const { posProvider, userCreatedAt, posthog } = options;
+  const now = options.now ?? new Date();
+
+  const seconds_from_trial_start = userCreatedAt
+    ? Math.floor((now.getTime() - new Date(userCreatedAt).getTime()) / 1000)
+    : null;
+
+  try {
+    posthog.capture('pos_integration_completed', {
+      pos_provider: posProvider,
+      seconds_from_trial_start,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error('[analytics] recordPosIntegrationCompleted failed:', msg);
+  }
+}

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -102,16 +102,17 @@ export function recordAuthEvents(options: RecordAuthEventsOptions): void {
       const attribution = getStoredAttribution();
       const trialEndsAt = new Date(now.getTime() + TRIAL_DURATION_DAYS * 24 * 60 * 60 * 1000).toISOString();
 
+      // Email is used locally to compute is_internal and then discarded —
+      // it is NOT forwarded to PostHog (PII minimization).
       const safeEmail = email ?? null;
       posthog.identify(userId, {
-        email: safeEmail,
         signup_source: attribution?.utm_source || attribution?.referrer || 'direct',
         signup_medium: attribution?.utm_medium || 'organic',
         signup_campaign: attribution?.utm_campaign ?? null,
         is_internal: isInternalEmail(safeEmail),
       });
 
-      posthog.capture('account_created', { email: safeEmail });
+      posthog.capture('account_created');
       posthog.capture('trial_started', { trial_ends_at: trialEndsAt });
 
       try {

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -32,9 +32,33 @@ export function storeAttribution(search: string, referrer: string, landingPage: 
   const utm_source = params.get('utm_source');
   const utm_medium = params.get('utm_medium');
   const utm_campaign = params.get('utm_campaign');
+  // utm_term and utm_content aren't persisted on the SignupAttribution shape,
+  // but their presence still counts as "fresh UTM data" for purposes of
+  // overwriting any earlier referrer-only attribution.
+  const hasUtm = Boolean(
+    utm_source ||
+      utm_medium ||
+      utm_campaign ||
+      params.get('utm_term') ||
+      params.get('utm_content'),
+  );
 
-  const hasFreshData = Boolean(utm_source || utm_medium || utm_campaign || referrer);
-  if (!hasFreshData) return;
+  // No UTM and no referrer → nothing worth capturing.
+  if (!hasUtm && !referrer) return;
+
+  // First-touch preservation: if attribution is already stored and the
+  // current call has no UTM (e.g. an OAuth callback redirect that arrives
+  // with `?code=…` and a referrer pointing at the OAuth provider), keep
+  // the existing entry rather than clobbering it.
+  if (!hasUtm) {
+    let existing: string | null = null;
+    try {
+      existing = localStorage.getItem(ATTRIBUTION_STORAGE_KEY);
+    } catch {
+      existing = null;
+    }
+    if (existing) return;
+  }
 
   const attribution: SignupAttribution = {
     utm_source,
@@ -202,7 +226,14 @@ export function recordFirstPnlViewed(options: RecordFirstPnlViewedOptions): void
   }
 }
 
+const POS_INTEGRATION_COMPLETED_FLAG_PREFIX = 'pos_integration_completed_';
+
+export function posIntegrationCompletedFlagKey(userId: string, posProvider: string): string {
+  return `${POS_INTEGRATION_COMPLETED_FLAG_PREFIX}${userId}_${posProvider}`;
+}
+
 export interface RecordPosIntegrationCompletedOptions {
+  userId: string;
   posProvider: string;
   userCreatedAt: string | null | undefined;
   posthog: PostHogLike;
@@ -210,7 +241,22 @@ export interface RecordPosIntegrationCompletedOptions {
 }
 
 export function recordPosIntegrationCompleted(options: RecordPosIntegrationCompletedOptions): void {
-  const { posProvider, userCreatedAt, posthog } = options;
+  const { userId, posProvider, userCreatedAt, posthog } = options;
+  if (!userId) return;
+
+  // Per-(user, provider) dedup. The caller-side useRef already prevents
+  // re-fires within a single mount, but a remount (page refresh on the
+  // OAuth-success state, or navigating back to the callback URL) would
+  // reset the ref and re-fire. localStorage survives those.
+  const flagKey = posIntegrationCompletedFlagKey(userId, posProvider);
+  let alreadySent = false;
+  try {
+    alreadySent = !!localStorage.getItem(flagKey);
+  } catch {
+    alreadySent = false;
+  }
+  if (alreadySent) return;
+
   const now = options.now ?? new Date();
   const seconds_from_trial_start = secondsSinceCreated(now, userCreatedAt);
 
@@ -219,6 +265,12 @@ export function recordPosIntegrationCompleted(options: RecordPosIntegrationCompl
       pos_provider: posProvider,
       seconds_from_trial_start,
     });
+    // Flag set only on successful capture, mirroring recordFirstPnlViewed.
+    try {
+      localStorage.setItem(flagKey, '1');
+    } catch {
+      // ignore
+    }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error('[analytics] recordPosIntegrationCompleted failed:', msg);

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -14,7 +14,17 @@ export interface SignupAttribution {
 export function isInternalEmail(email?: string | null): boolean {
   if (!email) return false;
   const lower = email.toLowerCase();
-  return INTERNAL_DOMAINS.some((domain) => lower.endsWith(domain.toLowerCase()));
+  const atIdx = lower.indexOf('@');
+  if (atIdx === -1) return false;
+  const host = lower.slice(atIdx); // includes leading '@', e.g. '@mail.easyshifthq.com'
+  return INTERNAL_DOMAINS.some((domain) => {
+    // domain format: '@easyshifthq.com'. Match exact host, or any subdomain
+    // (i.e., host ends with '.easyshifthq.com'). The leading '.' prevents
+    // false positives like '@evil-easyshifthq.com'.
+    if (host === domain) return true;
+    const subdomainSuffix = '.' + domain.slice(1); // '.easyshifthq.com'
+    return host.endsWith(subdomainSuffix);
+  });
 }
 
 export function storeAttribution(search: string, referrer: string, landingPage: string): void {
@@ -99,6 +109,17 @@ export function recordAuthEvents(options: RecordAuthEventsOptions): void {
 
   try {
     if (isRecentSignup && !flagAlreadySet) {
+      // Set the dedup flag BEFORE firing events so a partial failure
+      // (e.g. trial_started throws after account_created succeeds) doesn't
+      // re-fire account_created on the next session restore. account_created
+      // is a one-time signup signal — losing it on a transient outage is
+      // preferable to double-counting it.
+      try {
+        localStorage.setItem(accountCreatedFlagKey(userId), '1');
+      } catch {
+        // ignore
+      }
+
       const attribution = getStoredAttribution();
       const trialEndsAt = new Date(now.getTime() + TRIAL_DURATION_DAYS * 24 * 60 * 60 * 1000).toISOString();
 
@@ -114,12 +135,6 @@ export function recordAuthEvents(options: RecordAuthEventsOptions): void {
 
       posthog.capture('account_created');
       posthog.capture('trial_started', { trial_ends_at: trialEndsAt });
-
-      try {
-        localStorage.setItem(accountCreatedFlagKey(userId), '1');
-      } catch {
-        // ignore
-      }
 
       clearStoredAttribution();
     } else {
@@ -173,15 +188,17 @@ export function recordFirstPnlViewed(options: RecordFirstPnlViewedOptions): void
       seconds_from_trial_start,
       has_real_data: hasRealData,
     });
+    // Flag is written ONLY on successful capture so a transient PostHog
+    // failure on first view doesn't permanently suppress the event —
+    // the next dashboard view will retry until it lands.
+    try {
+      localStorage.setItem(flagKey, '1');
+    } catch {
+      // ignore
+    }
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error('[analytics] recordFirstPnlViewed failed:', msg);
-  }
-
-  try {
-    localStorage.setItem(flagKey, '1');
-  } catch {
-    // ignore
   }
 }
 

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -138,6 +138,11 @@ export function firstPnlViewedFlagKey(userId: string): string {
   return `${FIRST_PNL_VIEWED_FLAG_PREFIX}${userId}`;
 }
 
+function secondsSinceCreated(now: Date, userCreatedAt: string | null | undefined): number | null {
+  if (!userCreatedAt) return null;
+  return Math.floor((now.getTime() - new Date(userCreatedAt).getTime()) / 1000);
+}
+
 export interface RecordFirstPnlViewedOptions {
   userId: string;
   hasRealData: boolean;
@@ -160,9 +165,7 @@ export function recordFirstPnlViewed(options: RecordFirstPnlViewedOptions): void
   if (alreadySeen) return;
 
   const now = options.now ?? new Date();
-  const seconds_from_trial_start = userCreatedAt
-    ? Math.floor((now.getTime() - new Date(userCreatedAt).getTime()) / 1000)
-    : null;
+  const seconds_from_trial_start = secondsSinceCreated(now, userCreatedAt);
 
   try {
     posthog.capture('first_pnl_viewed', {
@@ -191,10 +194,7 @@ export interface RecordPosIntegrationCompletedOptions {
 export function recordPosIntegrationCompleted(options: RecordPosIntegrationCompletedOptions): void {
   const { posProvider, userCreatedAt, posthog } = options;
   const now = options.now ?? new Date();
-
-  const seconds_from_trial_start = userCreatedAt
-    ? Math.floor((now.getTime() - new Date(userCreatedAt).getTime()) / 1000)
-    : null;
+  const seconds_from_trial_start = secondsSinceCreated(now, userCreatedAt);
 
   try {
     posthog.capture('pos_integration_completed', {

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -29,6 +29,12 @@ const Auth = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
+    // Guard: Auth.tsx is also the OAuth callback URI. Only persist attribution
+    // when UTM params are present, so an OAuth redirect (which has ?code=…
+    // but no utm_*) can't overwrite first-touch attribution captured earlier.
+    const params = new URLSearchParams(window.location.search);
+    const hasUtm = params.has('utm_source') || params.has('utm_medium') || params.has('utm_campaign');
+    if (!hasUtm) return;
     storeAttribution(window.location.search, document.referrer, window.location.pathname);
   }, []);
 

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -29,19 +29,17 @@ const Auth = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    // Guard: Auth.tsx is also the OAuth callback URI. Only persist attribution
-    // when UTM params are present, so an OAuth redirect (which has ?code=…
-    // but no utm_*) can't overwrite first-touch attribution captured earlier.
-    // Check all five standard UTM params, not just the three primary ones —
-    // some campaigns send only utm_term or utm_content.
+    // Auth.tsx is also the OAuth callback URI. We want first-touch UTMs and
+    // legitimate referrers (e.g. user clicked a link from a blog post with no
+    // UTM tags), but we DON'T want an OAuth redirect to capture the OAuth
+    // provider's domain as the referrer. The narrowest signal for that is the
+    // OAuth response params: providers always echo back `?code=…` on success
+    // and `?error=…` on denial. Skip those; storeAttribution itself takes care
+    // of first-touch preservation for the rest.
     const params = new URLSearchParams(window.location.search);
-    const hasUtm =
-      params.has('utm_source') ||
-      params.has('utm_medium') ||
-      params.has('utm_campaign') ||
-      params.has('utm_term') ||
-      params.has('utm_content');
-    if (!hasUtm) return;
+    const isOAuthCallback =
+      params.has('code') || params.has('error') || params.has('error_description');
+    if (isOAuthCallback) return;
     storeAttribution(window.location.search, document.referrer, window.location.pathname);
   }, []);
 

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -15,6 +15,7 @@ import { Building, ArrowRight, Shield } from 'lucide-react';
 import { AppLogo } from '@/components/AppLogo';
 import { supabase } from '@/integrations/supabase/client';
 import { signInWithOAuthNative } from '@/utils/nativeRedirect';
+import { storeAttribution } from '@/lib/analytics';
 
 const Auth = () => {
   const [email, setEmail] = useState('');
@@ -26,6 +27,10 @@ const Auth = () => {
   const { checkSSORequired, initiateSSO } = useSSO();
   const { toast } = useToast();
   const navigate = useNavigate();
+
+  useEffect(() => {
+    storeAttribution(window.location.search, document.referrer, window.location.pathname);
+  }, []);
 
   useEffect(() => {
     if (user) {

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -32,8 +32,15 @@ const Auth = () => {
     // Guard: Auth.tsx is also the OAuth callback URI. Only persist attribution
     // when UTM params are present, so an OAuth redirect (which has ?code=…
     // but no utm_*) can't overwrite first-touch attribution captured earlier.
+    // Check all five standard UTM params, not just the three primary ones —
+    // some campaigns send only utm_term or utm_content.
     const params = new URLSearchParams(window.location.search);
-    const hasUtm = params.has('utm_source') || params.has('utm_medium') || params.has('utm_campaign');
+    const hasUtm =
+      params.has('utm_source') ||
+      params.has('utm_medium') ||
+      params.has('utm_campaign') ||
+      params.has('utm_term') ||
+      params.has('utm_content');
     if (!hasUtm) return;
     storeAttribution(window.location.search, document.referrer, window.location.pathname);
   }, []);

--- a/src/pages/CloverCallback.tsx
+++ b/src/pages/CloverCallback.tsx
@@ -91,6 +91,7 @@ export default function CloverCallback() {
     if (status !== 'success' || !user || analyticsFiredRef.current) return;
     analyticsFiredRef.current = true;
     recordPosIntegrationCompleted({
+      userId: user.id,
       posProvider: 'clover',
       userCreatedAt: user.created_at,
       posthog,

--- a/src/pages/CloverCallback.tsx
+++ b/src/pages/CloverCallback.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import posthog from 'posthog-js';
 import { supabase } from '@/integrations/supabase/client';
@@ -84,8 +84,12 @@ export default function CloverCallback() {
   }, [searchParams, navigate, toast]);
 
   // Fire analytics once both the OAuth exchange succeeded AND user is resolved.
+  // useRef guard prevents duplicate sends if the user object identity changes
+  // (e.g. background token refresh) while status is still 'success'.
+  const analyticsFiredRef = useRef(false);
   useEffect(() => {
-    if (status !== 'success' || !user) return;
+    if (status !== 'success' || !user || analyticsFiredRef.current) return;
+    analyticsFiredRef.current = true;
     recordPosIntegrationCompleted({
       posProvider: 'clover',
       userCreatedAt: user.created_at,

--- a/src/pages/CloverCallback.tsx
+++ b/src/pages/CloverCallback.tsx
@@ -58,11 +58,6 @@ export default function CloverCallback() {
 
         setStatus('success');
         setMessage('Successfully connected to Clover!');
-        recordPosIntegrationCompleted({
-          posProvider: 'clover',
-          userCreatedAt: user?.created_at,
-          posthog,
-        });
 
         toast({
           title: "Connection Successful",
@@ -87,6 +82,16 @@ export default function CloverCallback() {
 
     handleCallback();
   }, [searchParams, navigate, toast]);
+
+  // Fire analytics once both the OAuth exchange succeeded AND user is resolved.
+  useEffect(() => {
+    if (status !== 'success' || !user) return;
+    recordPosIntegrationCompleted({
+      posProvider: 'clover',
+      userCreatedAt: user.created_at,
+      posthog,
+    });
+  }, [status, user]);
 
   const getIcon = () => {
     switch (status) {

--- a/src/pages/CloverCallback.tsx
+++ b/src/pages/CloverCallback.tsx
@@ -1,14 +1,18 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import posthog from 'posthog-js';
 import { supabase } from '@/integrations/supabase/client';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Loader2, CheckCircle2, XCircle } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
+import { useAuth } from '@/hooks/useAuth';
+import { recordPosIntegrationCompleted } from '@/lib/analytics';
 
 export default function CloverCallback() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const { toast } = useToast();
+  const { user } = useAuth();
   const [status, setStatus] = useState<'loading' | 'success' | 'error'>('loading');
   const [message, setMessage] = useState('Connecting to Clover...');
 
@@ -54,7 +58,12 @@ export default function CloverCallback() {
 
         setStatus('success');
         setMessage('Successfully connected to Clover!');
-        
+        recordPosIntegrationCompleted({
+          posProvider: 'clover',
+          userCreatedAt: user?.created_at,
+          posthog,
+        });
+
         toast({
           title: "Connection Successful",
           description: "Your Clover account has been connected",

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useState, useMemo } from 'react';
+import posthog from 'posthog-js';
 import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate, Navigate, useSearchParams } from 'react-router-dom';
 import { usePermissions } from '@/hooks/usePermissions';
+import { recordFirstPnlViewed } from '@/lib/analytics';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -210,6 +212,16 @@ const Index = () => {
       prime_cost_percentage: periodMetrics.primeCostPercentage,
     };
   }, [periodMetrics]);
+
+  useEffect(() => {
+    if (!user?.id || !periodData) return;
+    recordFirstPnlViewed({
+      userId: user.id,
+      hasRealData: periodData.net_revenue > 0,
+      userCreatedAt: user.created_at,
+      posthog,
+    });
+  }, [user?.id, user?.created_at, periodData]);
 
   // Calculate previous period data for comparison
   const periodLength = differenceInDays(selectedPeriod.to, selectedPeriod.from) + 1;

--- a/src/pages/SquareCallback.tsx
+++ b/src/pages/SquareCallback.tsx
@@ -1,14 +1,18 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import posthog from 'posthog-js';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
+import { useAuth } from '@/hooks/useAuth';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { CheckCircle, XCircle, Loader2 } from 'lucide-react';
+import { recordPosIntegrationCompleted } from '@/lib/analytics';
 
 const SquareCallback = () => {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const { toast } = useToast();
+  const { user } = useAuth();
   const [status, setStatus] = useState<'loading' | 'success' | 'error'>('loading');
   const [message, setMessage] = useState('Processing Square connection...');
 
@@ -87,6 +91,11 @@ const SquareCallback = () => {
 
         setStatus('success');
         setMessage('Successfully connected to Square!');
+        recordPosIntegrationCompleted({
+          posProvider: 'square',
+          userCreatedAt: user?.created_at,
+          posthog,
+        });
         toast({
           title: "Connection Successful",
           description: "Square connected! Webhooks are registered and real-time P&L updates are now active.",

--- a/src/pages/SquareCallback.tsx
+++ b/src/pages/SquareCallback.tsx
@@ -91,11 +91,6 @@ const SquareCallback = () => {
 
         setStatus('success');
         setMessage('Successfully connected to Square!');
-        recordPosIntegrationCompleted({
-          posProvider: 'square',
-          userCreatedAt: user?.created_at,
-          posthog,
-        });
         toast({
           title: "Connection Successful",
           description: "Square connected! Webhooks are registered and real-time P&L updates are now active.",
@@ -120,6 +115,18 @@ const SquareCallback = () => {
 
     handleCallback();
   }, [searchParams, navigate, toast]);
+
+  // Fire analytics once both the OAuth exchange succeeded AND user is resolved.
+  // useAuth resolves async on this redirect page, so reading user inside
+  // handleCallback would always see null.
+  useEffect(() => {
+    if (status !== 'success' || !user) return;
+    recordPosIntegrationCompleted({
+      posProvider: 'square',
+      userCreatedAt: user.created_at,
+      posthog,
+    });
+  }, [status, user]);
 
   const getIcon = () => {
     switch (status) {

--- a/src/pages/SquareCallback.tsx
+++ b/src/pages/SquareCallback.tsx
@@ -125,6 +125,7 @@ const SquareCallback = () => {
     if (status !== 'success' || !user || analyticsFiredRef.current) return;
     analyticsFiredRef.current = true;
     recordPosIntegrationCompleted({
+      userId: user.id,
       posProvider: 'square',
       userCreatedAt: user.created_at,
       posthog,

--- a/src/pages/SquareCallback.tsx
+++ b/src/pages/SquareCallback.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import posthog from 'posthog-js';
 import { supabase } from '@/integrations/supabase/client';
@@ -118,9 +118,12 @@ const SquareCallback = () => {
 
   // Fire analytics once both the OAuth exchange succeeded AND user is resolved.
   // useAuth resolves async on this redirect page, so reading user inside
-  // handleCallback would always see null.
+  // handleCallback would always see null. The useRef guard prevents duplicate
+  // sends when the user object identity changes (e.g. background token refresh).
+  const analyticsFiredRef = useRef(false);
   useEffect(() => {
-    if (status !== 'success' || !user) return;
+    if (status !== 'success' || !user || analyticsFiredRef.current) return;
+    analyticsFiredRef.current = true;
     recordPosIntegrationCompleted({
       posProvider: 'square',
       userCreatedAt: user.created_at,

--- a/src/pages/ToastCallback.tsx
+++ b/src/pages/ToastCallback.tsx
@@ -91,11 +91,6 @@ const ToastCallback = () => {
 
         setStatus('success');
         setMessage('Successfully connected to Toast!');
-        recordPosIntegrationCompleted({
-          posProvider: 'toast',
-          userCreatedAt: user?.created_at,
-          posthog,
-        });
         toast({
           title: "Connection Successful",
           description: "Toast connected! You can now sync your data.",
@@ -120,6 +115,16 @@ const ToastCallback = () => {
 
     handleCallback();
   }, [searchParams, navigate, toast]);
+
+  // Fire analytics once both the OAuth exchange succeeded AND user is resolved.
+  useEffect(() => {
+    if (status !== 'success' || !user) return;
+    recordPosIntegrationCompleted({
+      posProvider: 'toast',
+      userCreatedAt: user.created_at,
+      posthog,
+    });
+  }, [status, user]);
 
   const getIcon = () => {
     switch (status) {

--- a/src/pages/ToastCallback.tsx
+++ b/src/pages/ToastCallback.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import posthog from 'posthog-js';
 import { supabase } from '@/integrations/supabase/client';
@@ -117,8 +117,12 @@ const ToastCallback = () => {
   }, [searchParams, navigate, toast]);
 
   // Fire analytics once both the OAuth exchange succeeded AND user is resolved.
+  // useRef guard prevents duplicate sends if the user object identity changes
+  // (e.g. background token refresh) while status is still 'success'.
+  const analyticsFiredRef = useRef(false);
   useEffect(() => {
-    if (status !== 'success' || !user) return;
+    if (status !== 'success' || !user || analyticsFiredRef.current) return;
+    analyticsFiredRef.current = true;
     recordPosIntegrationCompleted({
       posProvider: 'toast',
       userCreatedAt: user.created_at,

--- a/src/pages/ToastCallback.tsx
+++ b/src/pages/ToastCallback.tsx
@@ -124,6 +124,7 @@ const ToastCallback = () => {
     if (status !== 'success' || !user || analyticsFiredRef.current) return;
     analyticsFiredRef.current = true;
     recordPosIntegrationCompleted({
+      userId: user.id,
       posProvider: 'toast',
       userCreatedAt: user.created_at,
       posthog,

--- a/src/pages/ToastCallback.tsx
+++ b/src/pages/ToastCallback.tsx
@@ -1,14 +1,18 @@
 import { useEffect, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import posthog from 'posthog-js';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
+import { useAuth } from '@/hooks/useAuth';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { CheckCircle, XCircle, Loader2 } from 'lucide-react';
+import { recordPosIntegrationCompleted } from '@/lib/analytics';
 
 const ToastCallback = () => {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const { toast } = useToast();
+  const { user } = useAuth();
   const [status, setStatus] = useState<'loading' | 'success' | 'error'>('loading');
   const [message, setMessage] = useState('Processing Toast connection...');
 
@@ -87,6 +91,11 @@ const ToastCallback = () => {
 
         setStatus('success');
         setMessage('Successfully connected to Toast!');
+        recordPosIntegrationCompleted({
+          posProvider: 'toast',
+          userCreatedAt: user?.created_at,
+          posthog,
+        });
         toast({
           title: "Connection Successful",
           description: "Toast connected! You can now sync your data.",

--- a/supabase/functions/_shared/posthogServer.test.ts
+++ b/supabase/functions/_shared/posthogServer.test.ts
@@ -1,0 +1,56 @@
+// Deno test for the server-side PostHog capture helper.
+import { assertEquals } from "https://deno.land/std@0.208.0/assert/mod.ts";
+import {
+  type ServerEventInput,
+  _setCaptureFnForTesting,
+  captureServerEvent,
+} from "./posthogServer.ts";
+
+Deno.test("captureServerEvent forwards payload to injected impl", async () => {
+  const calls: ServerEventInput[] = [];
+  _setCaptureFnForTesting(async (payload) => {
+    calls.push(payload);
+  });
+
+  await captureServerEvent({
+    distinctId: "user-1",
+    event: "subscription_created",
+    properties: { tier: "growth", mrr_cents: 19900 },
+  });
+
+  _setCaptureFnForTesting(null);
+
+  assertEquals(calls.length, 1);
+  assertEquals(calls[0].distinctId, "user-1");
+  assertEquals(calls[0].event, "subscription_created");
+  assertEquals(calls[0].properties?.tier, "growth");
+  assertEquals(calls[0].properties?.mrr_cents, 19900);
+});
+
+Deno.test("captureServerEvent swallows errors thrown by the impl", async () => {
+  _setCaptureFnForTesting(async () => {
+    throw new Error("network down");
+  });
+
+  // Should NOT throw — telemetry must never break the calling webhook.
+  await captureServerEvent({
+    distinctId: "user-2",
+    event: "subscription_canceled",
+  });
+
+  _setCaptureFnForTesting(null);
+});
+
+Deno.test("captureServerEvent default impl is a no-op without env vars", async () => {
+  // Make sure no test pollution left an injected impl.
+  _setCaptureFnForTesting(null);
+
+  Deno.env.delete("POSTHOG_PROJECT_KEY");
+  Deno.env.delete("POSTHOG_HOST");
+
+  // Should resolve without importing posthog-node or making network calls.
+  await captureServerEvent({
+    distinctId: "user-3",
+    event: "subscription_created",
+  });
+});

--- a/supabase/functions/_shared/posthogServer.ts
+++ b/supabase/functions/_shared/posthogServer.ts
@@ -1,0 +1,65 @@
+// Server-side PostHog capture helper for Supabase edge functions.
+//
+// Telemetry must never break the calling webhook — every path swallows errors.
+// The default implementation lazily imports `npm:posthog-node` so that callers
+// without env vars (and tests) never trigger a network/npm fetch.
+
+export interface ServerEventInput {
+  distinctId: string;
+  event: string;
+  properties?: Record<string, unknown>;
+}
+
+type CaptureFn = (input: ServerEventInput) => Promise<void>;
+
+let _captureImpl: CaptureFn | null = null;
+
+async function defaultCapture(input: ServerEventInput): Promise<void> {
+  const key = Deno.env.get("POSTHOG_PROJECT_KEY");
+  const host = Deno.env.get("POSTHOG_HOST");
+
+  if (!key || !host) {
+    console.warn(
+      "[posthogServer] POSTHOG_PROJECT_KEY or POSTHOG_HOST is not set — skipping",
+      input.event,
+    );
+    return;
+  }
+
+  // Lazy dynamic import keeps tests and unconfigured environments from
+  // pulling the npm package over the network on every cold start.
+  const { PostHog } = await import("npm:posthog-node@4.18.0");
+  const client = new PostHog(key, { host, flushAt: 1, flushInterval: 0 });
+
+  try {
+    client.capture({
+      distinctId: input.distinctId,
+      event: input.event,
+      properties: input.properties,
+    });
+    await client.shutdown();
+  } catch (err) {
+    // Best-effort flush before re-raising for the outer catch in captureServerEvent.
+    try {
+      await client.shutdown();
+    } catch {
+      // Ignore double-shutdown errors.
+    }
+    throw err;
+  }
+}
+
+export async function captureServerEvent(input: ServerEventInput): Promise<void> {
+  try {
+    const impl = _captureImpl ?? defaultCapture;
+    await impl(input);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`[posthogServer] capture failed for "${input.event}":`, msg);
+  }
+}
+
+// Test seam — production code must never touch this.
+export function _setCaptureFnForTesting(fn: CaptureFn | null): void {
+  _captureImpl = fn;
+}

--- a/supabase/functions/stripe-subscription-webhook/subscription-handler.test.ts
+++ b/supabase/functions/stripe-subscription-webhook/subscription-handler.test.ts
@@ -2,6 +2,7 @@
 import { assertEquals } from "https://deno.land/std@0.208.0/assert/mod.ts";
 import type Stripe from "https://esm.sh/stripe@20.1.0";
 import { processSubscriptionEvent } from "./subscription-handler.ts";
+import { _setCaptureFnForTesting } from "../_shared/posthogServer.ts";
 
 // Minimal supabase client mock
 function createSupabaseMock() {
@@ -89,4 +90,137 @@ Deno.test("processSubscriptionEvent handles cancellation update payload", async 
   assertEquals(call.data.subscription_period, "monthly");
   assertEquals(call.data.stripe_subscription_id, "sub_1Sv5RDD9w6YUNUOUzsr1KrKl");
   assertEquals(call.data.subscription_ends_at, new Date(1772237988 * 1000).toISOString());
+});
+
+function captureMock() {
+  const events: { distinctId: string; event: string; properties?: Record<string, unknown> }[] = [];
+  return {
+    events,
+    fn: async (input: { distinctId: string; event: string; properties?: Record<string, unknown> }) => {
+      events.push(input);
+    },
+  };
+}
+
+function makeSubscriptionEvent(
+  type: "customer.subscription.created" | "customer.subscription.updated" | "customer.subscription.deleted",
+  overrides: Record<string, unknown> = {},
+): Stripe.Event {
+  return {
+    id: `evt_${type}`,
+    object: "event",
+    api_version: "2025-08-27.basil",
+    created: 1769783457,
+    livemode: false,
+    type,
+    data: {
+      object: {
+        id: "sub_test_123",
+        object: "subscription",
+        status: "active",
+        metadata: {
+          restaurant_id: "rest_abc",
+          user_id: "user_xyz",
+          tier: "growth",
+          period: "monthly",
+        },
+        current_period_end: 1772237988,
+        trial_end: null,
+        items: {
+          data: [
+            {
+              price: {
+                id: "price_growth_monthly",
+                recurring: { interval: "month" },
+                unit_amount: 19900,
+              },
+            },
+          ],
+        },
+        customer: "cus_test_123",
+        ...overrides,
+      },
+    },
+  } as unknown as Stripe.Event;
+}
+
+Deno.test("customer.subscription.created fires subscription_created PostHog event", async () => {
+  const supabaseMock = createSupabaseMock();
+  const capture = captureMock();
+  _setCaptureFnForTesting(capture.fn);
+
+  try {
+    await processSubscriptionEvent(
+      makeSubscriptionEvent("customer.subscription.created"),
+      supabaseMock as any,
+      createStripeMock(),
+    );
+
+    assertEquals(capture.events.length, 1);
+    assertEquals(capture.events[0].distinctId, "user_xyz");
+    assertEquals(capture.events[0].event, "subscription_created");
+    assertEquals(capture.events[0].properties?.tier, "growth");
+    assertEquals(capture.events[0].properties?.period, "monthly");
+    assertEquals(capture.events[0].properties?.mrr_cents, 19900);
+  } finally {
+    _setCaptureFnForTesting(null);
+  }
+});
+
+Deno.test("customer.subscription.updated does NOT fire subscription_created", async () => {
+  const supabaseMock = createSupabaseMock();
+  const capture = captureMock();
+  _setCaptureFnForTesting(capture.fn);
+
+  try {
+    await processSubscriptionEvent(
+      makeSubscriptionEvent("customer.subscription.updated"),
+      supabaseMock as any,
+      createStripeMock(),
+    );
+
+    assertEquals(capture.events.length, 0);
+  } finally {
+    _setCaptureFnForTesting(null);
+  }
+});
+
+Deno.test("customer.subscription.deleted fires subscription_canceled PostHog event", async () => {
+  const calls: any[] = [];
+  const supabaseMock = {
+    calls,
+    from(table: string) {
+      if (table !== "restaurants") throw new Error(`Unexpected table ${table}`);
+      return {
+        update: (data: Record<string, unknown>) => ({
+          eq: (col: string, val: string) => {
+            calls.push({ type: "update", data, col, val });
+            return { error: null };
+          },
+        }),
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => ({ data: { id: "rest_abc" } }),
+          }),
+        }),
+      };
+    },
+  };
+  const capture = captureMock();
+  _setCaptureFnForTesting(capture.fn);
+
+  try {
+    await processSubscriptionEvent(
+      makeSubscriptionEvent("customer.subscription.deleted"),
+      supabaseMock as any,
+      createStripeMock(),
+    );
+
+    assertEquals(capture.events.length, 1);
+    assertEquals(capture.events[0].distinctId, "user_xyz");
+    assertEquals(capture.events[0].event, "subscription_canceled");
+    assertEquals(capture.events[0].properties?.tier, "growth");
+  } finally {
+    _setCaptureFnForTesting(null);
+  }
 });

--- a/supabase/functions/stripe-subscription-webhook/subscription-handler.test.ts
+++ b/supabase/functions/stripe-subscription-webhook/subscription-handler.test.ts
@@ -224,3 +224,92 @@ Deno.test("customer.subscription.deleted fires subscription_canceled PostHog eve
     _setCaptureFnForTesting(null);
   }
 });
+
+Deno.test("subscription_created normalizes annual mrr_cents to monthly", async () => {
+  const supabaseMock = createSupabaseMock();
+  const capture = captureMock();
+  _setCaptureFnForTesting(capture.fn);
+
+  try {
+    const event = makeSubscriptionEvent("customer.subscription.created", {
+      items: {
+        data: [
+          {
+            price: {
+              id: "price_growth_annual",
+              recurring: { interval: "year" },
+              unit_amount: 199000, // $1,990/year
+            },
+          },
+        ],
+      },
+    });
+
+    await processSubscriptionEvent(event, supabaseMock as any, createStripeMock());
+
+    assertEquals(capture.events.length, 1);
+    assertEquals(capture.events[0].properties?.period, "annual");
+    // 199000 / 12 = 16583.33 → rounds to 16583
+    assertEquals(capture.events[0].properties?.mrr_cents, 16583);
+  } finally {
+    _setCaptureFnForTesting(null);
+  }
+});
+
+Deno.test("subscription_canceled derives tier and period from price (not stale metadata)", async () => {
+  const calls: any[] = [];
+  const supabaseMock = {
+    calls,
+    from(table: string) {
+      if (table !== "restaurants") throw new Error(`Unexpected table ${table}`);
+      return {
+        update: (data: Record<string, unknown>) => ({
+          eq: (col: string, val: string) => {
+            calls.push({ type: "update", data, col, val });
+            return { error: null };
+          },
+        }),
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => ({ data: { id: "rest_abc" } }),
+          }),
+        }),
+      };
+    },
+  };
+  const capture = captureMock();
+  _setCaptureFnForTesting(capture.fn);
+
+  try {
+    // Metadata says "starter/monthly" (stale from upgrade), but price says pro/annual.
+    const event = makeSubscriptionEvent("customer.subscription.deleted", {
+      metadata: {
+        restaurant_id: "rest_abc",
+        user_id: "user_xyz",
+        tier: "starter",
+        period: "monthly",
+      },
+      items: {
+        data: [
+          {
+            price: {
+              id: "price_pro_annual",
+              recurring: { interval: "year" },
+              unit_amount: 299000,
+            },
+          },
+        ],
+      },
+    });
+
+    await processSubscriptionEvent(event, supabaseMock as any, createStripeMock());
+
+    assertEquals(capture.events.length, 1);
+    assertEquals(capture.events[0].event, "subscription_canceled");
+    // Should reflect actual price, not stale metadata.
+    assertEquals(capture.events[0].properties?.tier, "pro");
+    assertEquals(capture.events[0].properties?.period, "annual");
+  } finally {
+    _setCaptureFnForTesting(null);
+  }
+});

--- a/supabase/functions/stripe-subscription-webhook/subscription-handler.test.ts
+++ b/supabase/functions/stripe-subscription-webhook/subscription-handler.test.ts
@@ -309,6 +309,8 @@ Deno.test("subscription_canceled derives tier and period from price (not stale m
     // Should reflect actual price, not stale metadata.
     assertEquals(capture.events[0].properties?.tier, "pro");
     assertEquals(capture.events[0].properties?.period, "annual");
+    // mrr_cents normalized: 299000 / 12 = 24916.67 → rounds to 24917
+    assertEquals(capture.events[0].properties?.mrr_cents, 24917);
   } finally {
     _setCaptureFnForTesting(null);
   }

--- a/supabase/functions/stripe-subscription-webhook/subscription-handler.ts
+++ b/supabase/functions/stripe-subscription-webhook/subscription-handler.ts
@@ -1,5 +1,6 @@
 import Stripe from "https://esm.sh/stripe@20.1.0";
 import type { SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2.57.2";
+import { captureServerEvent } from "../_shared/posthogServer.ts";
 
 // Volume discount coupon IDs (same as in checkout function)
 const VOLUME_COUPONS: Record<number, string> = {
@@ -325,6 +326,22 @@ export async function processSubscriptionEvent(
         console.error("[SUBSCRIPTION-WEBHOOK] Failed to update restaurant:", updateError);
       } else {
         console.log("[SUBSCRIPTION-WEBHOOK] Restaurant subscription updated:", restaurantId, updateData);
+
+        if (event.type === "customer.subscription.created") {
+          const userId = subscription.metadata?.user_id;
+          if (userId) {
+            await captureServerEvent({
+              distinctId: userId,
+              event: "subscription_created",
+              properties: {
+                tier,
+                period,
+                mrr_cents: subscription.items.data[0]?.price.unit_amount ?? null,
+                stripe_subscription_id: subscription.id,
+              },
+            });
+          }
+        }
       }
       return;
     }
@@ -354,9 +371,19 @@ export async function processSubscriptionEvent(
         } else {
           console.log("[SUBSCRIPTION-WEBHOOK] Restaurant subscription canceled:", restaurant.id);
 
-          // Sync volume discounts - may need to reduce discount tier for remaining restaurants
           const userId = subscription.metadata?.user_id;
           if (userId) {
+            await captureServerEvent({
+              distinctId: userId,
+              event: "subscription_canceled",
+              properties: {
+                tier: subscription.metadata?.tier ?? null,
+                period: subscription.metadata?.period ?? null,
+                stripe_subscription_id: subscription.id,
+              },
+            });
+
+            // Sync volume discounts - may need to reduce discount tier for remaining restaurants
             try {
               await syncVolumeDiscountsForOwner(userId, supabaseAdmin, stripe);
             } catch (error) {

--- a/supabase/functions/stripe-subscription-webhook/subscription-handler.ts
+++ b/supabase/functions/stripe-subscription-webhook/subscription-handler.ts
@@ -145,6 +145,44 @@ export const PRICE_ID_TO_TIER: Record<string, "starter" | "growth" | "pro"> = {
   [priceIdMapping.proAnnual]: "pro",
 };
 
+/**
+ * Derive tier, period, and normalized MRR (cents) from a subscription's price.
+ * MRR is always monthly: annual prices are divided by 12 so the metric is comparable.
+ */
+function deriveTierPeriodMrrFromSubscription(subscription: Stripe.Subscription): {
+  tier: string | null;
+  period: "monthly" | "annual" | null;
+  mrr_cents: number | null;
+} {
+  const item = subscription.items.data[0];
+  if (!item) return { tier: null, period: null, mrr_cents: null };
+
+  const price = item.price;
+  const priceId = price.id;
+  const interval = price.recurring?.interval;
+  const period: "monthly" | "annual" = interval === "year" ? "annual" : "monthly";
+
+  let tier: string | null = PRICE_ID_TO_TIER[priceId] ?? null;
+  if (!tier) {
+    if (priceId.includes("starter")) tier = "starter";
+    else if (priceId.includes("growth")) tier = "growth";
+    else if (priceId.includes("pro")) tier = "pro";
+  }
+  if (!tier && price.unit_amount) {
+    const amount = price.unit_amount;
+    if (amount === 9900 || amount === 99000) tier = "starter";
+    else if (amount === 19900 || amount === 199000) tier = "growth";
+    else if (amount === 29900 || amount === 299000) tier = "pro";
+  }
+
+  const rawAmount = price.unit_amount ?? null;
+  const mrr_cents = rawAmount !== null && period === "annual"
+    ? Math.round(rawAmount / 12)
+    : rawAmount;
+
+  return { tier, period, mrr_cents };
+}
+
 export async function processSubscriptionEvent(
   event: Stripe.Event,
   supabaseAdmin: SupabaseClient,
@@ -285,11 +323,14 @@ export async function processSubscriptionEvent(
         console.log("[SUBSCRIPTION-WEBHOOK] Using metadata tier (may be stale):", tier);
       }
 
-      let period = subscription.metadata?.period;
-      if (!period && subscription.items.data[0]) {
+      // Derive period from price first - DON'T trust metadata as Stripe doesn't update it on plan changes
+      let period: string | undefined;
+      if (subscription.items.data[0]) {
         const interval = subscription.items.data[0].price.recurring?.interval;
         period = interval === "year" ? "annual" : "monthly";
       }
+      // Last resort: fall back to metadata
+      if (!period) period = subscription.metadata?.period;
 
       const updateData: Record<string, any> = {
         subscription_status: subscriptionStatus,
@@ -330,13 +371,14 @@ export async function processSubscriptionEvent(
         if (event.type === "customer.subscription.created") {
           const userId = subscription.metadata?.user_id;
           if (userId) {
+            const { mrr_cents } = deriveTierPeriodMrrFromSubscription(subscription);
             await captureServerEvent({
               distinctId: userId,
               event: "subscription_created",
               properties: {
                 tier,
                 period,
-                mrr_cents: subscription.items.data[0]?.price.unit_amount ?? null,
+                mrr_cents,
                 stripe_subscription_id: subscription.id,
               },
             });
@@ -373,12 +415,13 @@ export async function processSubscriptionEvent(
 
           const userId = subscription.metadata?.user_id;
           if (userId) {
+            const { tier: canceledTier, period: canceledPeriod } = deriveTierPeriodMrrFromSubscription(subscription);
             await captureServerEvent({
               distinctId: userId,
               event: "subscription_canceled",
               properties: {
-                tier: subscription.metadata?.tier ?? null,
-                period: subscription.metadata?.period ?? null,
+                tier: canceledTier ?? subscription.metadata?.tier ?? null,
+                period: canceledPeriod ?? subscription.metadata?.period ?? null,
                 stripe_subscription_id: subscription.id,
               },
             });

--- a/supabase/functions/stripe-subscription-webhook/subscription-handler.ts
+++ b/supabase/functions/stripe-subscription-webhook/subscription-handler.ts
@@ -415,13 +415,14 @@ export async function processSubscriptionEvent(
 
           const userId = subscription.metadata?.user_id;
           if (userId) {
-            const { tier: canceledTier, period: canceledPeriod } = deriveTierPeriodMrrFromSubscription(subscription);
+            const { tier: canceledTier, period: canceledPeriod, mrr_cents } = deriveTierPeriodMrrFromSubscription(subscription);
             await captureServerEvent({
               distinctId: userId,
               event: "subscription_canceled",
               properties: {
                 tier: canceledTier ?? subscription.metadata?.tier ?? null,
                 period: canceledPeriod ?? subscription.metadata?.period ?? null,
+                mrr_cents,
                 stripe_subscription_id: subscription.id,
               },
             });

--- a/supabase/functions/stripe-subscription-webhook/subscription-handler.ts
+++ b/supabase/functions/stripe-subscription-webhook/subscription-handler.ts
@@ -376,8 +376,10 @@ export async function processSubscriptionEvent(
               distinctId: userId,
               event: "subscription_created",
               properties: {
-                tier,
-                period,
+                // Coerce to null so PostHog never sees `undefined` (matches
+                // subscription_canceled, which already does the same).
+                tier: tier ?? null,
+                period: period ?? null,
                 mrr_cents,
                 stripe_subscription_id: subscription.id,
               },

--- a/tests/unit/analytics.test.ts
+++ b/tests/unit/analytics.test.ts
@@ -2,9 +2,13 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   ATTRIBUTION_STORAGE_KEY,
   INTERNAL_DOMAINS,
+  NEW_SIGNUP_WINDOW_MS,
+  TRIAL_DURATION_DAYS,
+  accountCreatedFlagKey,
   clearStoredAttribution,
   getStoredAttribution,
   isInternalEmail,
+  recordAuthEvents,
   storeAttribution,
 } from '../../src/lib/analytics';
 
@@ -119,5 +123,176 @@ describe('storeAttribution / getStoredAttribution / clearStoredAttribution', () 
     expect(() => storeAttribution('?utm_source=google', '', '/auth')).not.toThrow();
     setItemMock.mockRestore();
     Storage.prototype.setItem = original;
+  });
+});
+
+describe('recordAuthEvents', () => {
+  const FIXED_NOW = new Date('2026-05-07T12:00:00Z');
+  const RECENT_CREATED_AT = new Date(FIXED_NOW.getTime() - 30_000).toISOString();
+  const OLD_CREATED_AT = new Date(FIXED_NOW.getTime() - NEW_SIGNUP_WINDOW_MS - 1).toISOString();
+
+  let posthog: { identify: ReturnType<typeof vi.fn>; capture: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    localStorage.clear();
+    posthog = { identify: vi.fn(), capture: vi.fn() };
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('fires identify + account_created + trial_started for a fresh signup', () => {
+    storeAttribution('?utm_source=google&utm_medium=cpc&utm_campaign=launch', '', '/auth');
+
+    recordAuthEvents({
+      userId: 'user-1',
+      email: 'jose@example.com',
+      createdAt: RECENT_CREATED_AT,
+      posthog,
+      now: FIXED_NOW,
+    });
+
+    expect(posthog.identify).toHaveBeenCalledTimes(1);
+    expect(posthog.identify).toHaveBeenCalledWith('user-1', expect.objectContaining({
+      email: 'jose@example.com',
+      signup_source: 'google',
+      signup_medium: 'cpc',
+      signup_campaign: 'launch',
+      is_internal: false,
+    }));
+
+    expect(posthog.capture).toHaveBeenCalledTimes(2);
+    expect(posthog.capture).toHaveBeenCalledWith('account_created', { email: 'jose@example.com' });
+    const trialEndsAt = new Date(FIXED_NOW.getTime() + TRIAL_DURATION_DAYS * 24 * 60 * 60 * 1000).toISOString();
+    expect(posthog.capture).toHaveBeenCalledWith('trial_started', { trial_ends_at: trialEndsAt });
+
+    expect(localStorage.getItem(accountCreatedFlagKey('user-1'))).toBeTruthy();
+    expect(localStorage.getItem(ATTRIBUTION_STORAGE_KEY)).toBeNull();
+  });
+
+  it('marks @easyshifthq.com users as is_internal:true', () => {
+    recordAuthEvents({
+      userId: 'user-internal',
+      email: 'jose@easyshifthq.com',
+      createdAt: RECENT_CREATED_AT,
+      posthog,
+      now: FIXED_NOW,
+    });
+
+    expect(posthog.identify).toHaveBeenCalledWith('user-internal', expect.objectContaining({
+      is_internal: true,
+    }));
+  });
+
+  it('falls back to referrer when UTM is absent', () => {
+    storeAttribution('', 'https://google.com', '/auth');
+
+    recordAuthEvents({
+      userId: 'user-2',
+      email: 'jose@example.com',
+      createdAt: RECENT_CREATED_AT,
+      posthog,
+      now: FIXED_NOW,
+    });
+
+    expect(posthog.identify).toHaveBeenCalledWith('user-2', expect.objectContaining({
+      signup_source: 'https://google.com',
+      signup_medium: 'organic',
+    }));
+  });
+
+  it('uses "direct" / "organic" when no attribution stored', () => {
+    recordAuthEvents({
+      userId: 'user-3',
+      email: 'jose@example.com',
+      createdAt: RECENT_CREATED_AT,
+      posthog,
+      now: FIXED_NOW,
+    });
+
+    expect(posthog.identify).toHaveBeenCalledWith('user-3', expect.objectContaining({
+      signup_source: 'direct',
+      signup_medium: 'organic',
+      signup_campaign: null,
+    }));
+  });
+
+  it('does not double-fire account_created if the flag is set', () => {
+    localStorage.setItem(accountCreatedFlagKey('user-4'), '1');
+
+    recordAuthEvents({
+      userId: 'user-4',
+      email: 'jose@example.com',
+      createdAt: RECENT_CREATED_AT,
+      posthog,
+      now: FIXED_NOW,
+    });
+
+    expect(posthog.capture).not.toHaveBeenCalledWith('account_created', expect.anything());
+    expect(posthog.capture).not.toHaveBeenCalledWith('trial_started', expect.anything());
+    // Returning users still get an identify with last_login_at
+    expect(posthog.identify).toHaveBeenCalledWith('user-4', expect.objectContaining({
+      last_login_at: expect.any(String),
+    }));
+  });
+
+  it('treats users with old created_at as returning users (only last_login_at)', () => {
+    recordAuthEvents({
+      userId: 'user-5',
+      email: 'jose@example.com',
+      createdAt: OLD_CREATED_AT,
+      posthog,
+      now: FIXED_NOW,
+    });
+
+    expect(posthog.capture).not.toHaveBeenCalled();
+    expect(posthog.identify).toHaveBeenCalledTimes(1);
+    expect(posthog.identify).toHaveBeenCalledWith('user-5', expect.objectContaining({
+      last_login_at: FIXED_NOW.toISOString(),
+    }));
+  });
+
+  it('does nothing when userId is empty', () => {
+    recordAuthEvents({
+      userId: '',
+      email: 'jose@example.com',
+      createdAt: RECENT_CREATED_AT,
+      posthog,
+      now: FIXED_NOW,
+    });
+
+    expect(posthog.identify).not.toHaveBeenCalled();
+    expect(posthog.capture).not.toHaveBeenCalled();
+  });
+
+  it('handles missing email gracefully (still identifies, is_internal:false)', () => {
+    recordAuthEvents({
+      userId: 'user-6',
+      email: null,
+      createdAt: RECENT_CREATED_AT,
+      posthog,
+      now: FIXED_NOW,
+    });
+
+    expect(posthog.identify).toHaveBeenCalledWith('user-6', expect.objectContaining({
+      email: null,
+      is_internal: false,
+    }));
+    expect(posthog.capture).toHaveBeenCalledWith('account_created', { email: null });
+  });
+
+  it('survives if posthog.capture throws (no rethrow)', () => {
+    posthog.capture = vi.fn(() => {
+      throw new Error('posthog blew up');
+    });
+
+    expect(() => recordAuthEvents({
+      userId: 'user-7',
+      email: 'jose@example.com',
+      createdAt: RECENT_CREATED_AT,
+      posthog,
+      now: FIXED_NOW,
+    })).not.toThrow();
   });
 });

--- a/tests/unit/analytics.test.ts
+++ b/tests/unit/analytics.test.ts
@@ -40,6 +40,17 @@ describe('isInternalEmail', () => {
     expect(isInternalEmail('foo@')).toBe(false);
   });
 
+  it('matches subdomain emails (e.g. user@mail.easyshifthq.com)', () => {
+    expect(isInternalEmail('jose@mail.easyshifthq.com')).toBe(true);
+    expect(isInternalEmail('jose@app.easyshifthq.com')).toBe(true);
+  });
+
+  it('does NOT false-match domains that merely contain the internal domain', () => {
+    // '@evil-easyshifthq.com' ends with 'easyshifthq.com' but is a different host
+    expect(isInternalEmail('attacker@evil-easyshifthq.com')).toBe(false);
+    expect(isInternalEmail('attacker@notreallyeasyshifthq.com')).toBe(false);
+  });
+
   it('exposes INTERNAL_DOMAINS as a readonly array', () => {
     expect(INTERNAL_DOMAINS).toContain('@easyshifthq.com');
   });
@@ -302,6 +313,39 @@ describe('recordAuthEvents', () => {
       now: FIXED_NOW,
     })).not.toThrow();
   });
+
+  it('does not re-fire account_created if trial_started capture throws (atomic dedup)', () => {
+    // Simulate: account_created succeeds, trial_started throws.
+    let callCount = 0;
+    posthog.capture = vi.fn(() => {
+      callCount += 1;
+      if (callCount === 2) throw new Error('posthog blew up on second call');
+    });
+
+    recordAuthEvents({
+      userId: 'user-partial-fail',
+      email: 'jose@example.com',
+      createdAt: RECENT_CREATED_AT,
+      posthog,
+      now: FIXED_NOW,
+    });
+
+    // Flag must be set even though trial_started threw, so the next call
+    // within the 5-min window does not re-fire account_created.
+    expect(localStorage.getItem(accountCreatedFlagKey('user-partial-fail'))).toBeTruthy();
+
+    // Second call: should treat user as returning (no account_created).
+    posthog.capture = vi.fn();
+    recordAuthEvents({
+      userId: 'user-partial-fail',
+      email: 'jose@example.com',
+      createdAt: RECENT_CREATED_AT,
+      posthog,
+      now: FIXED_NOW,
+    });
+    expect(posthog.capture).not.toHaveBeenCalledWith('account_created', expect.anything());
+    expect(posthog.capture).not.toHaveBeenCalledWith('account_created');
+  });
 });
 
 describe('recordPosIntegrationCompleted', () => {
@@ -459,7 +503,7 @@ describe('recordFirstPnlViewed', () => {
     expect(posthog.capture).not.toHaveBeenCalled();
   });
 
-  it('survives if posthog.capture throws (no rethrow, flag still set)', () => {
+  it('survives if posthog.capture throws (no rethrow)', () => {
     posthog.capture = vi.fn(() => {
       throw new Error('posthog blew up');
     });
@@ -471,5 +515,34 @@ describe('recordFirstPnlViewed', () => {
       posthog,
       now: FIXED_NOW,
     })).not.toThrow();
+  });
+
+  it('does NOT set the flag if capture throws, so a retry can succeed later', () => {
+    posthog.capture = vi.fn(() => {
+      throw new Error('posthog blew up');
+    });
+
+    recordFirstPnlViewed({
+      userId: 'user-pnl-retry',
+      hasRealData: true,
+      userCreatedAt: CREATED_AT,
+      posthog,
+      now: FIXED_NOW,
+    });
+
+    // Flag must NOT be set on capture failure, so the next view can retry.
+    expect(localStorage.getItem(firstPnlViewedFlagKey('user-pnl-retry'))).toBeNull();
+
+    // Retry: capture works this time. Event fires and flag is set.
+    posthog.capture = vi.fn();
+    recordFirstPnlViewed({
+      userId: 'user-pnl-retry',
+      hasRealData: true,
+      userCreatedAt: CREATED_AT,
+      posthog,
+      now: FIXED_NOW,
+    });
+    expect(posthog.capture).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem(firstPnlViewedFlagKey('user-pnl-retry'))).toBeTruthy();
   });
 });

--- a/tests/unit/analytics.test.ts
+++ b/tests/unit/analytics.test.ts
@@ -9,6 +9,7 @@ import {
   getStoredAttribution,
   isInternalEmail,
   recordAuthEvents,
+  recordPosIntegrationCompleted,
   storeAttribution,
 } from '../../src/lib/analytics';
 
@@ -294,5 +295,73 @@ describe('recordAuthEvents', () => {
       posthog,
       now: FIXED_NOW,
     })).not.toThrow();
+  });
+});
+
+describe('recordPosIntegrationCompleted', () => {
+  const FIXED_NOW = new Date('2026-05-07T12:00:00Z');
+  const CREATED_AT = new Date(FIXED_NOW.getTime() - 90_000).toISOString(); // 90s earlier
+
+  let posthog: { identify: ReturnType<typeof vi.fn>; capture: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    posthog = { identify: vi.fn(), capture: vi.fn() };
+  });
+
+  it('captures pos_integration_completed with provider and seconds_from_trial_start', () => {
+    recordPosIntegrationCompleted({
+      posProvider: 'square',
+      userCreatedAt: CREATED_AT,
+      posthog,
+      now: FIXED_NOW,
+    });
+
+    expect(posthog.capture).toHaveBeenCalledTimes(1);
+    expect(posthog.capture).toHaveBeenCalledWith('pos_integration_completed', {
+      pos_provider: 'square',
+      seconds_from_trial_start: 90,
+    });
+  });
+
+  it('handles missing userCreatedAt by sending null seconds_from_trial_start', () => {
+    recordPosIntegrationCompleted({
+      posProvider: 'toast',
+      userCreatedAt: null,
+      posthog,
+      now: FIXED_NOW,
+    });
+
+    expect(posthog.capture).toHaveBeenCalledWith('pos_integration_completed', {
+      pos_provider: 'toast',
+      seconds_from_trial_start: null,
+    });
+  });
+
+  it('survives if posthog.capture throws (no rethrow)', () => {
+    posthog.capture = vi.fn(() => {
+      throw new Error('posthog blew up');
+    });
+
+    expect(() => recordPosIntegrationCompleted({
+      posProvider: 'clover',
+      userCreatedAt: CREATED_AT,
+      posthog,
+      now: FIXED_NOW,
+    })).not.toThrow();
+  });
+
+  it('floors fractional seconds', () => {
+    const createdAt = new Date(FIXED_NOW.getTime() - 1_500).toISOString(); // 1.5s ago
+    recordPosIntegrationCompleted({
+      posProvider: 'square',
+      userCreatedAt: createdAt,
+      posthog,
+      now: FIXED_NOW,
+    });
+
+    expect(posthog.capture).toHaveBeenCalledWith('pos_integration_completed', {
+      pos_provider: 'square',
+      seconds_from_trial_start: 1,
+    });
   });
 });

--- a/tests/unit/analytics.test.ts
+++ b/tests/unit/analytics.test.ts
@@ -6,9 +6,11 @@ import {
   TRIAL_DURATION_DAYS,
   accountCreatedFlagKey,
   clearStoredAttribution,
+  firstPnlViewedFlagKey,
   getStoredAttribution,
   isInternalEmail,
   recordAuthEvents,
+  recordFirstPnlViewed,
   recordPosIntegrationCompleted,
   storeAttribution,
 } from '../../src/lib/analytics';
@@ -363,5 +365,107 @@ describe('recordPosIntegrationCompleted', () => {
       pos_provider: 'square',
       seconds_from_trial_start: 1,
     });
+  });
+});
+
+describe('recordFirstPnlViewed', () => {
+  const FIXED_NOW = new Date('2026-05-07T12:00:00Z');
+  const CREATED_AT = new Date(FIXED_NOW.getTime() - 120_000).toISOString(); // 120s earlier
+
+  let posthog: { identify: ReturnType<typeof vi.fn>; capture: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    localStorage.clear();
+    posthog = { identify: vi.fn(), capture: vi.fn() };
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('fires first_pnl_viewed once with seconds_from_trial_start and has_real_data:true', () => {
+    recordFirstPnlViewed({
+      userId: 'user-pnl-1',
+      hasRealData: true,
+      userCreatedAt: CREATED_AT,
+      posthog,
+      now: FIXED_NOW,
+    });
+
+    expect(posthog.capture).toHaveBeenCalledTimes(1);
+    expect(posthog.capture).toHaveBeenCalledWith('first_pnl_viewed', {
+      seconds_from_trial_start: 120,
+      has_real_data: true,
+    });
+    expect(localStorage.getItem(firstPnlViewedFlagKey('user-pnl-1'))).toBeTruthy();
+  });
+
+  it('does not double-fire when flag is already set', () => {
+    localStorage.setItem(firstPnlViewedFlagKey('user-pnl-2'), '1');
+
+    recordFirstPnlViewed({
+      userId: 'user-pnl-2',
+      hasRealData: true,
+      userCreatedAt: CREATED_AT,
+      posthog,
+      now: FIXED_NOW,
+    });
+
+    expect(posthog.capture).not.toHaveBeenCalled();
+  });
+
+  it('passes has_real_data:false when there is no revenue yet', () => {
+    recordFirstPnlViewed({
+      userId: 'user-pnl-3',
+      hasRealData: false,
+      userCreatedAt: CREATED_AT,
+      posthog,
+      now: FIXED_NOW,
+    });
+
+    expect(posthog.capture).toHaveBeenCalledWith('first_pnl_viewed', expect.objectContaining({
+      has_real_data: false,
+    }));
+  });
+
+  it('handles missing userCreatedAt by sending null seconds_from_trial_start', () => {
+    recordFirstPnlViewed({
+      userId: 'user-pnl-4',
+      hasRealData: true,
+      userCreatedAt: null,
+      posthog,
+      now: FIXED_NOW,
+    });
+
+    expect(posthog.capture).toHaveBeenCalledWith('first_pnl_viewed', {
+      seconds_from_trial_start: null,
+      has_real_data: true,
+    });
+  });
+
+  it('does nothing when userId is empty', () => {
+    recordFirstPnlViewed({
+      userId: '',
+      hasRealData: true,
+      userCreatedAt: CREATED_AT,
+      posthog,
+      now: FIXED_NOW,
+    });
+
+    expect(posthog.capture).not.toHaveBeenCalled();
+  });
+
+  it('survives if posthog.capture throws (no rethrow, flag still set)', () => {
+    posthog.capture = vi.fn(() => {
+      throw new Error('posthog blew up');
+    });
+
+    expect(() => recordFirstPnlViewed({
+      userId: 'user-pnl-5',
+      hasRealData: true,
+      userCreatedAt: CREATED_AT,
+      posthog,
+      now: FIXED_NOW,
+    })).not.toThrow();
   });
 });

--- a/tests/unit/analytics.test.ts
+++ b/tests/unit/analytics.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  ATTRIBUTION_STORAGE_KEY,
+  INTERNAL_DOMAINS,
+  clearStoredAttribution,
+  getStoredAttribution,
+  isInternalEmail,
+  storeAttribution,
+} from '../../src/lib/analytics';
+
+describe('isInternalEmail', () => {
+  it('returns true for @easyshifthq.com', () => {
+    expect(isInternalEmail('jose@easyshifthq.com')).toBe(true);
+  });
+
+  it('is case-insensitive', () => {
+    expect(isInternalEmail('Jose@EasyShiftHQ.com')).toBe(true);
+  });
+
+  it('returns false for other domains', () => {
+    expect(isInternalEmail('jose@example.com')).toBe(false);
+    expect(isInternalEmail('jose@gmail.com')).toBe(false);
+  });
+
+  it('returns false for null/undefined/empty', () => {
+    expect(isInternalEmail(null)).toBe(false);
+    expect(isInternalEmail(undefined)).toBe(false);
+    expect(isInternalEmail('')).toBe(false);
+  });
+
+  it('returns false for malformed emails', () => {
+    expect(isInternalEmail('not-an-email')).toBe(false);
+    expect(isInternalEmail('foo@')).toBe(false);
+  });
+
+  it('exposes INTERNAL_DOMAINS as a readonly array', () => {
+    expect(INTERNAL_DOMAINS).toContain('@easyshifthq.com');
+  });
+});
+
+describe('storeAttribution / getStoredAttribution / clearStoredAttribution', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('writes UTM params, referrer, and landing page', () => {
+    storeAttribution(
+      '?utm_source=google&utm_medium=cpc&utm_campaign=launch',
+      'https://google.com/search',
+      '/auth',
+    );
+
+    const stored = getStoredAttribution();
+    expect(stored).not.toBeNull();
+    expect(stored?.utm_source).toBe('google');
+    expect(stored?.utm_medium).toBe('cpc');
+    expect(stored?.utm_campaign).toBe('launch');
+    expect(stored?.referrer).toBe('https://google.com/search');
+    expect(stored?.landing_page).toBe('/auth');
+    expect(stored?.captured_at).toBeTruthy();
+  });
+
+  it('does not write when there is no UTM and no referrer', () => {
+    storeAttribution('', '', '/auth');
+    expect(localStorage.getItem(ATTRIBUTION_STORAGE_KEY)).toBeNull();
+  });
+
+  it('writes when only referrer is present', () => {
+    storeAttribution('', 'https://google.com', '/auth');
+    const stored = getStoredAttribution();
+    expect(stored?.referrer).toBe('https://google.com');
+    expect(stored?.utm_source).toBeNull();
+  });
+
+  it('writes when only one UTM param is present', () => {
+    storeAttribution('?utm_source=twitter', '', '/auth');
+    const stored = getStoredAttribution();
+    expect(stored?.utm_source).toBe('twitter');
+    expect(stored?.utm_medium).toBeNull();
+  });
+
+  it('does not clobber existing attribution when called again with no fresh data', () => {
+    storeAttribution('?utm_source=google', '', '/auth');
+    const first = getStoredAttribution();
+
+    storeAttribution('', '', '/dashboard');
+    const second = getStoredAttribution();
+
+    expect(second?.utm_source).toBe('google');
+    expect(second?.captured_at).toBe(first?.captured_at);
+  });
+
+  it('returns null when key missing', () => {
+    expect(getStoredAttribution()).toBeNull();
+  });
+
+  it('returns null when value is malformed JSON (does not throw)', () => {
+    localStorage.setItem(ATTRIBUTION_STORAGE_KEY, '{not json');
+    expect(() => getStoredAttribution()).not.toThrow();
+    expect(getStoredAttribution()).toBeNull();
+  });
+
+  it('clearStoredAttribution removes the key', () => {
+    storeAttribution('?utm_source=google', '', '/auth');
+    expect(getStoredAttribution()).not.toBeNull();
+    clearStoredAttribution();
+    expect(getStoredAttribution()).toBeNull();
+  });
+
+  it('survives a localStorage that throws on setItem (no rethrow)', () => {
+    const original = Storage.prototype.setItem;
+    const setItemMock = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('quota exceeded');
+    });
+    expect(() => storeAttribution('?utm_source=google', '', '/auth')).not.toThrow();
+    setItemMock.mockRestore();
+    Storage.prototype.setItem = original;
+  });
+});

--- a/tests/unit/analytics.test.ts
+++ b/tests/unit/analytics.test.ts
@@ -158,15 +158,17 @@ describe('recordAuthEvents', () => {
 
     expect(posthog.identify).toHaveBeenCalledTimes(1);
     expect(posthog.identify).toHaveBeenCalledWith('user-1', expect.objectContaining({
-      email: 'jose@example.com',
       signup_source: 'google',
       signup_medium: 'cpc',
       signup_campaign: 'launch',
       is_internal: false,
     }));
+    // PII: email is NOT forwarded to PostHog
+    const identifyProps = posthog.identify.mock.calls[0][1];
+    expect(identifyProps).not.toHaveProperty('email');
 
     expect(posthog.capture).toHaveBeenCalledTimes(2);
-    expect(posthog.capture).toHaveBeenCalledWith('account_created', { email: 'jose@example.com' });
+    expect(posthog.capture).toHaveBeenCalledWith('account_created');
     const trialEndsAt = new Date(FIXED_NOW.getTime() + TRIAL_DURATION_DAYS * 24 * 60 * 60 * 1000).toISOString();
     expect(posthog.capture).toHaveBeenCalledWith('trial_started', { trial_ends_at: trialEndsAt });
 
@@ -279,10 +281,12 @@ describe('recordAuthEvents', () => {
     });
 
     expect(posthog.identify).toHaveBeenCalledWith('user-6', expect.objectContaining({
-      email: null,
       is_internal: false,
     }));
-    expect(posthog.capture).toHaveBeenCalledWith('account_created', { email: null });
+    // PII: email is NOT forwarded to PostHog even when null
+    const identifyProps = posthog.identify.mock.calls[0][1];
+    expect(identifyProps).not.toHaveProperty('email');
+    expect(posthog.capture).toHaveBeenCalledWith('account_created');
   });
 
   it('survives if posthog.capture throws (no rethrow)', () => {

--- a/tests/unit/analytics.test.ts
+++ b/tests/unit/analytics.test.ts
@@ -9,6 +9,7 @@ import {
   firstPnlViewedFlagKey,
   getStoredAttribution,
   isInternalEmail,
+  posIntegrationCompletedFlagKey,
   recordAuthEvents,
   recordFirstPnlViewed,
   recordPosIntegrationCompleted,
@@ -110,6 +111,38 @@ describe('storeAttribution / getStoredAttribution / clearStoredAttribution', () 
 
     expect(second?.utm_source).toBe('google');
     expect(second?.captured_at).toBe(first?.captured_at);
+  });
+
+  it('preserves first-touch when an OAuth callback arrives with referrer but no UTM', () => {
+    // Simulate user landing first with UTM:
+    storeAttribution('?utm_source=google&utm_medium=cpc', '', '/auth');
+    const first = getStoredAttribution();
+
+    // Then an OAuth provider redirect (e.g. ?code=… and referrer=accounts.google.com)
+    // arrives without any UTM. We should NOT clobber the original UTM-based
+    // attribution with a referrer that just describes the OAuth hop.
+    storeAttribution('?code=abc123', 'https://accounts.google.com', '/auth');
+    const second = getStoredAttribution();
+
+    expect(second?.utm_source).toBe('google');
+    expect(second?.utm_medium).toBe('cpc');
+    expect(second?.captured_at).toBe(first?.captured_at);
+  });
+
+  it('treats utm_term / utm_content as fresh UTM and overwrites earlier referrer-only entry', () => {
+    // Earlier: only referrer captured.
+    storeAttribution('', 'https://google.com', '/auth');
+    const first = getStoredAttribution();
+    expect(first?.utm_source).toBeNull();
+    expect(first?.referrer).toBe('https://google.com');
+
+    // Later: hits with utm_term only (no source/medium/campaign). hasUtm should
+    // still trigger a write because utm_term/utm_content count as fresh data —
+    // proving fresh write by the referrer being overwritten to ''.
+    storeAttribution('?utm_term=brand', '', '/auth');
+    const second = getStoredAttribution();
+    expect(second?.utm_source).toBeNull();
+    expect(second?.referrer).toBe('');
   });
 
   it('returns null when key missing', () => {
@@ -355,11 +388,17 @@ describe('recordPosIntegrationCompleted', () => {
   let posthog: { identify: ReturnType<typeof vi.fn>; capture: ReturnType<typeof vi.fn> };
 
   beforeEach(() => {
+    localStorage.clear();
     posthog = { identify: vi.fn(), capture: vi.fn() };
+  });
+
+  afterEach(() => {
+    localStorage.clear();
   });
 
   it('captures pos_integration_completed with provider and seconds_from_trial_start', () => {
     recordPosIntegrationCompleted({
+      userId: 'user-pos-1',
       posProvider: 'square',
       userCreatedAt: CREATED_AT,
       posthog,
@@ -371,10 +410,12 @@ describe('recordPosIntegrationCompleted', () => {
       pos_provider: 'square',
       seconds_from_trial_start: 90,
     });
+    expect(localStorage.getItem(posIntegrationCompletedFlagKey('user-pos-1', 'square'))).toBeTruthy();
   });
 
   it('handles missing userCreatedAt by sending null seconds_from_trial_start', () => {
     recordPosIntegrationCompleted({
+      userId: 'user-pos-2',
       posProvider: 'toast',
       userCreatedAt: null,
       posthog,
@@ -393,6 +434,7 @@ describe('recordPosIntegrationCompleted', () => {
     });
 
     expect(() => recordPosIntegrationCompleted({
+      userId: 'user-pos-3',
       posProvider: 'clover',
       userCreatedAt: CREATED_AT,
       posthog,
@@ -403,6 +445,7 @@ describe('recordPosIntegrationCompleted', () => {
   it('floors fractional seconds', () => {
     const createdAt = new Date(FIXED_NOW.getTime() - 1_500).toISOString(); // 1.5s ago
     recordPosIntegrationCompleted({
+      userId: 'user-pos-4',
       posProvider: 'square',
       userCreatedAt: createdAt,
       posthog,
@@ -413,6 +456,84 @@ describe('recordPosIntegrationCompleted', () => {
       pos_provider: 'square',
       seconds_from_trial_start: 1,
     });
+  });
+
+  it('does not double-fire when the per-(user, provider) flag is already set', () => {
+    localStorage.setItem(posIntegrationCompletedFlagKey('user-pos-dup', 'square'), '1');
+
+    recordPosIntegrationCompleted({
+      userId: 'user-pos-dup',
+      posProvider: 'square',
+      userCreatedAt: CREATED_AT,
+      posthog,
+      now: FIXED_NOW,
+    });
+
+    expect(posthog.capture).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when userId is empty', () => {
+    recordPosIntegrationCompleted({
+      userId: '',
+      posProvider: 'square',
+      userCreatedAt: CREATED_AT,
+      posthog,
+      now: FIXED_NOW,
+    });
+
+    expect(posthog.capture).not.toHaveBeenCalled();
+  });
+
+  it('does NOT set the flag if capture throws, so a retry can succeed later', () => {
+    posthog.capture = vi.fn(() => {
+      throw new Error('posthog blew up');
+    });
+
+    recordPosIntegrationCompleted({
+      userId: 'user-pos-retry',
+      posProvider: 'toast',
+      userCreatedAt: CREATED_AT,
+      posthog,
+      now: FIXED_NOW,
+    });
+
+    expect(localStorage.getItem(posIntegrationCompletedFlagKey('user-pos-retry', 'toast'))).toBeNull();
+
+    // Retry: capture works this time.
+    posthog.capture = vi.fn();
+    recordPosIntegrationCompleted({
+      userId: 'user-pos-retry',
+      posProvider: 'toast',
+      userCreatedAt: CREATED_AT,
+      posthog,
+      now: FIXED_NOW,
+    });
+    expect(posthog.capture).toHaveBeenCalledTimes(1);
+    expect(localStorage.getItem(posIntegrationCompletedFlagKey('user-pos-retry', 'toast'))).toBeTruthy();
+  });
+
+  it('keeps per-provider dedup independent (square does not block toast)', () => {
+    recordPosIntegrationCompleted({
+      userId: 'user-pos-multi',
+      posProvider: 'square',
+      userCreatedAt: CREATED_AT,
+      posthog,
+      now: FIXED_NOW,
+    });
+    expect(posthog.capture).toHaveBeenCalledTimes(1);
+
+    // Different provider for the same user — should still fire.
+    recordPosIntegrationCompleted({
+      userId: 'user-pos-multi',
+      posProvider: 'toast',
+      userCreatedAt: CREATED_AT,
+      posthog,
+      now: FIXED_NOW,
+    });
+    expect(posthog.capture).toHaveBeenCalledTimes(2);
+    expect(posthog.capture).toHaveBeenLastCalledWith('pos_integration_completed', expect.objectContaining({
+      pos_provider: 'toast',
+    }));
   });
 });
 


### PR DESCRIPTION
## Summary

Instruments the activation funnel **Visitor → Trial signup → POS connected → First P&L viewed → Subscription created** with PostHog events. Includes `is_internal` person property to filter test/employee accounts and UTM attribution capture before signup.

**Scope:** 5 surfaces, all events idempotent or deduplicated.

| Surface | Event | Where |
|---|---|---|
| `Auth.tsx` mount | (capture only) | UTM + referrer → localStorage |
| `useAuth` user resolves | `identify` + `account_created` + `trial_started` | `recordAuthEvents` (5-min recent-signup window, localStorage flag) |
| Square/Toast/Clover OAuth callback | `pos_integration_completed` | per-callback `useEffect` watching `[status, user]`, useRef fire-once guard |
| `Index.tsx` (dashboard) | `first_pnl_viewed` | once per user, gated on dashboard render with periodData |
| Stripe webhook (server-side) | `subscription_created` / `subscription_canceled` | `subscription-handler.ts` via `posthog-node` |

**PII minimization:** email is used locally to compute `is_internal` and then discarded — never forwarded to PostHog. Tests assert email is NOT present in any payload.

**Server-side capture** uses a lazy dynamic `npm:posthog-node` import so unconfigured environments and tests never trigger a network/npm fetch. The helper swallows all errors so a PostHog outage cannot fail a Stripe webhook.

PostHog keys (`POSTHOG_PROJECT_KEY`, `POSTHOG_HOST`) will be set in production after merge.

## Key design choices

- **`is_internal` instead of an email allow-list in PostHog** keeps PII out of the analytics platform.
- **Tier/period/MRR derived from `subscription.items.data[0].price`** instead of metadata, because Stripe doesn't update subscription metadata on plan changes. Annual MRR is normalized to monthly (÷12) so the metric stays comparable in PostHog dashboards.
- **`account_created` flag set BEFORE captures** so a partial failure (e.g. `trial_started` throws after `account_created` succeeds) doesn't re-fire `account_created`. We'd rather lose the event on a transient outage than double-count a one-time signup signal.
- **`first_pnl_viewed` flag set ONLY on successful capture** — if PostHog is briefly down on the first dashboard view, the next view will retry until it lands.
- **`useRef` fire-once guard on POS callbacks** because `useAuth`'s `user` object identity can change on background token refreshes, which would otherwise re-fire `pos_integration_completed`.

## Test plan

- [x] `npm run test` — 38/38 analytics tests + full suite (1 pre-existing TZ-dependent failure on `monthlyPerformance.acceptance.test.ts`, fails on main too)
- [x] `deno test --no-check supabase/functions/stripe-subscription-webhook/subscription-handler.test.ts` — 6/6 (including annual MRR normalization + price-based tier-on-cancellation regressions)
- [x] `deno test --no-check supabase/functions/_shared/posthogServer.test.ts`
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean (chunk-size warnings are pre-existing)
- [x] CodeRabbit local review — 2 passes, valid findings addressed (mrr normalization, atomic dedup, subdomain match, useRef fire-once guards, UTM term/content)
- [ ] After merge: set `POSTHOG_PROJECT_KEY` + `POSTHOG_HOST` in Vercel and Supabase function env, then verify funnel populates in PostHog
- [ ] Sanity-check `is_internal` filter excludes `@easyshifthq.com` users (including subdomain emails)

## Out of scope

- `pos_integration_started` event (deferred per plan approval — start can be inferred from `pos_integration_completed` cohort)
- Shift4 callback — same pattern would apply, can be wired in a follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added analytics for account creation, trial start, POS integration, first P&L view, and subscription events; includes UTM/referrer attribution and deduplication to avoid duplicate firings.
  * Server-side capture for subscription webhooks to report normalized tier/period/MRR.

* **Documentation**
  * Added implementation plan and design spec detailing events, firing conditions, and acceptance criteria.

* **Tests**
  * Added unit and integration tests validating analytics behavior, deduplication, and safe failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->