### PR TITLE
fix(time-off): off-by-one display when DB date renders in non-UTC browser

### DIFF
--- a/docs/superpowers/plans/2026-05-10-timeoff-date-only-display-plan.md
+++ b/docs/superpowers/plans/2026-05-10-timeoff-date-only-display-plan.md
@@ -1,0 +1,535 @@
+# Time-Off Date Off-By-One Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the off-by-one display of time-off request dates by parsing/formatting Postgres `DATE` values without UTC-midnight semantics, and storing user-selected calendar days from the date picker without TZ math.
+
+**Architecture:** Add a tiny date-only utility module (`src/lib/dateOnly.ts`) that parses YYYY-MM-DD strings to local-midnight Dates and serializes Dates to YYYY-MM-DD via local-TZ wall-clock fields. Replace the four call sites in time-off UI (TimeOffList admin view, EmployeePortal employee view, TimeOffRequestDialog edit prefill, TimeOffRequestDialog write path).
+
+**Tech Stack:** TypeScript, React, date-fns, Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-05-10-timeoff-date-only-display-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+| --- | --- | --- |
+| `src/lib/dateOnly.ts` | Create | Local-TZ-anchored helpers: `parseDateOnly`, `toDateOnlyString`, `formatDateOnly` |
+| `tests/unit/dateOnly.test.ts` | Create | Contract tests — TZ-independent, plus a Chicago regression for Tristen's bug |
+| `src/components/TimeOffList.tsx` | Modify (lines 144–145) | Display path uses `formatDateOnly` |
+| `src/pages/EmployeePortal.tsx` | Modify (lines 205–206) | Display path uses `formatDateOnly` |
+| `src/components/TimeOffRequestDialog.tsx` | Modify (lines 1–80) | Edit-mode prefill uses `parseDateOnly`; write path uses `toDateOnlyString`; drop `fromZonedTime` import |
+
+---
+
+### Task 1: Add `dateOnly` helper module and tests
+
+**Files:**
+- Create: `src/lib/dateOnly.ts`
+- Create: `tests/unit/dateOnly.test.ts`
+
+- [ ] **Step 1.1: Write the failing tests**
+
+Create `tests/unit/dateOnly.test.ts`:
+
+```typescript
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { format } from 'date-fns';
+import { parseDateOnly, toDateOnlyString, formatDateOnly } from '@/lib/dateOnly';
+
+// All assertions here use TZ-independent properties (wall-clock fields read in
+// the runner's local TZ; helper anchors to local midnight by construction).
+// CI runs in UTC; developers may run in any TZ. The Chicago regression test
+// (Tristen's bug) at the bottom uses a manual offset comparison to remain
+// portable across vitest worker TZ subsystems.
+
+describe('parseDateOnly', () => {
+  it('parses "2026-05-29" as local midnight (May 29 in any TZ)', () => {
+    const d = parseDateOnly('2026-05-29');
+    expect(d.getFullYear()).toBe(2026);
+    expect(d.getMonth()).toBe(4); // May (0-indexed)
+    expect(d.getDate()).toBe(29);
+    expect(d.getHours()).toBe(0);
+    expect(d.getMinutes()).toBe(0);
+    expect(d.getSeconds()).toBe(0);
+    expect(d.getMilliseconds()).toBe(0);
+  });
+
+  it('parses leap-day "2024-02-29" correctly', () => {
+    const d = parseDateOnly('2024-02-29');
+    expect(d.getFullYear()).toBe(2024);
+    expect(d.getMonth()).toBe(1);
+    expect(d.getDate()).toBe(29);
+  });
+
+  it('parses single-month-end "2026-12-31" correctly', () => {
+    const d = parseDateOnly('2026-12-31');
+    expect(d.getFullYear()).toBe(2026);
+    expect(d.getMonth()).toBe(11);
+    expect(d.getDate()).toBe(31);
+  });
+
+  it('rejects malformed input', () => {
+    expect(() => parseDateOnly('2026/05/29')).toThrow(/invalid/i);
+    expect(() => parseDateOnly('2026-5-9')).toThrow(/invalid/i);
+    expect(() => parseDateOnly('2026-05-29T00:00:00')).toThrow(/invalid/i);
+    expect(() => parseDateOnly('not a date')).toThrow(/invalid/i);
+    expect(() => parseDateOnly('')).toThrow(/invalid/i);
+  });
+
+  it('rejects out-of-range month/day', () => {
+    expect(() => parseDateOnly('2026-13-01')).toThrow(/invalid/i);
+    expect(() => parseDateOnly('2026-02-30')).toThrow(/invalid/i);
+    expect(() => parseDateOnly('2026-04-31')).toThrow(/invalid/i);
+  });
+});
+
+describe('toDateOnlyString', () => {
+  it('serializes a local-midnight Date to YYYY-MM-DD', () => {
+    const d = new Date(2026, 4, 29); // May 29 LOCAL midnight
+    expect(toDateOnlyString(d)).toBe('2026-05-29');
+  });
+
+  it('zero-pads month and day', () => {
+    const d = new Date(2026, 0, 5); // Jan 5 LOCAL
+    expect(toDateOnlyString(d)).toBe('2026-01-05');
+  });
+
+  it('uses LOCAL fields (not UTC), so a calendar-day click is preserved', () => {
+    // Date constructed via numeric ctor uses local TZ — this is what
+    // react-day-picker hands back from the calendar widget.
+    const d = new Date(2026, 11, 31, 23, 59, 59); // Dec 31 LOCAL, late evening
+    expect(toDateOnlyString(d)).toBe('2026-12-31');
+  });
+});
+
+describe('round-trip', () => {
+  it('parseDateOnly -> toDateOnlyString is identity', () => {
+    for (const s of ['2026-01-01', '2026-05-29', '2026-12-31', '2024-02-29']) {
+      expect(toDateOnlyString(parseDateOnly(s))).toBe(s);
+    }
+  });
+});
+
+describe('formatDateOnly', () => {
+  it('formats with default pattern "MMM d, yyyy"', () => {
+    expect(formatDateOnly('2026-05-29')).toBe('May 29, 2026');
+  });
+
+  it('accepts a custom date-fns pattern', () => {
+    expect(formatDateOnly('2026-05-29', 'yyyy-MM-dd')).toBe('2026-05-29');
+    expect(formatDateOnly('2026-05-29', 'EEEE, MMMM d')).toBe('Friday, May 29');
+  });
+
+  it('matches a parseDateOnly + format composition', () => {
+    const expected = format(parseDateOnly('2026-05-29'), 'MMM d, yyyy');
+    expect(formatDateOnly('2026-05-29', 'MMM d, yyyy')).toBe(expected);
+  });
+});
+
+// Regression: Tristen Liu's bug. Force a Chicago-style offset by constructing
+// the bug fixture manually rather than relying on vi.stubEnv('TZ', ...) (which
+// doesn't always propagate to V8's Intl/timezone subsystem inside vitest
+// workers). We assert that parseDateOnly does NOT shift to the prior day,
+// regardless of the runner TZ.
+describe('regression: Tristen Liu off-by-one', () => {
+  it('parseDateOnly("2026-05-29") preserves day 29 (not 28)', () => {
+    const d = parseDateOnly('2026-05-29');
+    // Without the helper, `new Date("2026-05-29")` parses as UTC midnight,
+    // and in any negative-UTC-offset TZ d.getDate() would return 28.
+    // With the helper, it must always return 29.
+    expect(d.getDate()).toBe(29);
+    expect(d.getMonth()).toBe(4);
+  });
+
+  it('demonstrates the bug pattern that this helper avoids', () => {
+    // This test does NOT use the helper — it documents the trap so a future
+    // reader sees why the helper exists.
+    const buggy = new Date('2026-05-29');
+    // Buggy is always UTC midnight regardless of runner TZ:
+    expect(buggy.toISOString()).toBe('2026-05-29T00:00:00.000Z');
+    // Its LOCAL getDate() depends on the runner's TZ — proving the trap is
+    // real for any non-UTC runner. We don't assert the exact local value
+    // here (CI is UTC; locally varies) — only that the helper sidesteps it.
+  });
+});
+```
+
+- [ ] **Step 1.2: Run test to verify it fails**
+
+Run: `npm run test -- tests/unit/dateOnly.test.ts --run`
+
+Expected: every test FAILS with "Cannot find module '@/lib/dateOnly'" or "parseDateOnly is not a function".
+
+- [ ] **Step 1.3: Write the implementation**
+
+Create `src/lib/dateOnly.ts`:
+
+```typescript
+import { format } from 'date-fns';
+
+/**
+ * Date-only helpers for Postgres `DATE` values.
+ *
+ * The trap: `new Date("2026-05-29")` parses ISO date-only strings as UTC
+ * midnight per the ECMAScript spec. In any browser TZ behind UTC (US, all of
+ * the Americas, etc.), `format(date, 'MMM d, yyyy')` then renders the prior
+ * calendar day. Symmetrically, writing back via `.toISOString().substring(0,10)`
+ * after a `fromZonedTime(...)` shift only works when browser TZ matches the
+ * intended TZ — fragile and silently wrong otherwise.
+ *
+ * These helpers treat YYYY-MM-DD as a pure calendar day with no TZ semantics:
+ * - `parseDateOnly("2026-05-29")` returns a Date anchored at LOCAL midnight,
+ *   so `getDate()` always returns 29.
+ * - `toDateOnlyString(date)` reads LOCAL year/month/day fields and emits
+ *   `"2026-05-29"` — appropriate for the calendar day a user clicked on.
+ * - `formatDateOnly(value, pattern)` parses then formats via date-fns.
+ */
+
+const ISO_DATE_ONLY_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+export function parseDateOnly(value: string): Date {
+  const match = ISO_DATE_ONLY_RE.exec(value);
+  if (!match) {
+    throw new Error(`Invalid date-only string: ${JSON.stringify(value)}`);
+  }
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  // Construct via the local-time numeric ctor. Validate with round-trip
+  // because `new Date(2026, 1, 30)` silently overflows to March 2.
+  const d = new Date(year, month - 1, day);
+  if (
+    d.getFullYear() !== year ||
+    d.getMonth() !== month - 1 ||
+    d.getDate() !== day
+  ) {
+    throw new Error(`Invalid date-only string: ${JSON.stringify(value)}`);
+  }
+  return d;
+}
+
+export function toDateOnlyString(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+export function formatDateOnly(value: string, pattern = 'MMM d, yyyy'): string {
+  return format(parseDateOnly(value), pattern);
+}
+```
+
+- [ ] **Step 1.4: Run test to verify it passes**
+
+Run: `npm run test -- tests/unit/dateOnly.test.ts --run`
+
+Expected: all assertions PASS. If any test fails, fix the implementation; do not adjust the test unless the test itself has a bug (cross-check with the spec).
+
+- [ ] **Step 1.5: Run typecheck and lint**
+
+Run: `npm run typecheck && npm run lint -- src/lib/dateOnly.ts tests/unit/dateOnly.test.ts`
+
+Expected: zero errors. Fix any reported issues before committing.
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add src/lib/dateOnly.ts tests/unit/dateOnly.test.ts
+git commit -m "$(cat <<'EOF'
+feat(date-only): add parseDateOnly/toDateOnlyString/formatDateOnly helpers
+
+Pure helpers for Postgres DATE values that avoid the new Date('YYYY-MM-DD')
+UTC-midnight trap. parseDateOnly anchors to local midnight; toDateOnlyString
+emits YYYY-MM-DD from LOCAL fields; formatDateOnly composes the two.
+TZ-independent contract tests plus a Tristen-Liu regression case.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Use `formatDateOnly` in `TimeOffList`
+
+**Files:**
+- Modify: `src/components/TimeOffList.tsx` (lines 1, 144–145)
+
+- [ ] **Step 2.1: Read the current call site**
+
+Run: `sed -n '140,150p' src/components/TimeOffList.tsx`
+
+Expected: lines 144–145 contain `format(new Date(request.start_date), 'MMM d, yyyy')`.
+
+- [ ] **Step 2.2: Add the import**
+
+Find the import block at the top of `src/components/TimeOffList.tsx`. Add (alphabetically per the project's import order if there's an existing utils import group; otherwise after the date-fns import):
+
+```typescript
+import { formatDateOnly } from '@/lib/dateOnly';
+```
+
+If `format` from `date-fns` is no longer used elsewhere in the file after Task 2.3, remove its import. Verify with `grep -n "format(" src/components/TimeOffList.tsx`.
+
+- [ ] **Step 2.3: Replace the two display calls**
+
+Replace:
+
+```tsx
+{format(new Date(request.start_date), 'MMM d, yyyy')} - 
+{format(new Date(request.end_date), 'MMM d, yyyy')}
+```
+
+with:
+
+```tsx
+{formatDateOnly(request.start_date, 'MMM d, yyyy')} -{' '}
+{formatDateOnly(request.end_date, 'MMM d, yyyy')}
+```
+
+The `{' '}` after the dash preserves the existing space rendering; the dash-with-trailing-space is preserved syntactically the same way `EmployeePortal.tsx` does.
+
+- [ ] **Step 2.4: Run unit tests + typecheck**
+
+Run: `npm run test -- --run && npm run typecheck`
+
+Expected: all tests pass; zero TS errors.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add src/components/TimeOffList.tsx
+git commit -m "$(cat <<'EOF'
+fix(time-off): use formatDateOnly in admin list to avoid TZ off-by-one
+
+Prevents new Date('2026-05-29') from rendering as May 28 in any negative-UTC
+browser TZ. Tristen's graduation request stored as 2026-05-29 now displays
+as May 29 for managers in America/Chicago.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Use `formatDateOnly` in `EmployeePortal`
+
+**Files:**
+- Modify: `src/pages/EmployeePortal.tsx` (lines 205–206 + import block)
+
+- [ ] **Step 3.1: Read the current call site**
+
+Run: `sed -n '200,210p' src/pages/EmployeePortal.tsx`
+
+Expected: lines 205–206 contain `format(new Date(request.start_date), 'MMM d, yyyy')` and `format(new Date(request.end_date), 'MMM d, yyyy')`.
+
+- [ ] **Step 3.2: Add the import**
+
+Add to the import block (follow the project's import order — utils group):
+
+```typescript
+import { formatDateOnly } from '@/lib/dateOnly';
+```
+
+- [ ] **Step 3.3: Replace the two display calls**
+
+Replace:
+
+```tsx
+{format(new Date(request.start_date), 'MMM d, yyyy')} -{' '}
+{format(new Date(request.end_date), 'MMM d, yyyy')}
+```
+
+with:
+
+```tsx
+{formatDateOnly(request.start_date, 'MMM d, yyyy')} -{' '}
+{formatDateOnly(request.end_date, 'MMM d, yyyy')}
+```
+
+If `format` is no longer used elsewhere in the file, remove its import. Verify with `grep -n "format(" src/pages/EmployeePortal.tsx`.
+
+- [ ] **Step 3.4: Run unit tests + typecheck**
+
+Run: `npm run test -- --run && npm run typecheck`
+
+Expected: all tests pass; zero TS errors.
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add src/pages/EmployeePortal.tsx
+git commit -m "$(cat <<'EOF'
+fix(time-off): use formatDateOnly in EmployeePortal to avoid TZ off-by-one
+
+Tristen's view of her own request now matches the email approval and the
+manager view. Same root cause as TimeOffList — UTC-midnight ISO parse + local
+TZ render shifted the date one day earlier in negative-offset browsers.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Fix `TimeOffRequestDialog` (edit prefill + write path)
+
+**Files:**
+- Modify: `src/components/TimeOffRequestDialog.tsx` (lines 1–80)
+
+This task fixes BOTH the read prefill (line 47–48) and the write path (line 62–64) in the same file. Both changes share the new helper, and shipping them separately would leave the file with mixed conventions.
+
+- [ ] **Step 4.1: Update imports**
+
+Drop the `date-fns-tz` import (no longer needed for date-only handling):
+
+```typescript
+// Remove:
+import * as dateFnsTz from 'date-fns-tz';
+```
+
+Add:
+
+```typescript
+import { parseDateOnly, toDateOnlyString } from '@/lib/dateOnly';
+```
+
+The `format` from `date-fns` import remains because the dialog's "Pick date" button label uses it for live calendar-widget Date display (line 134, 162).
+
+- [ ] **Step 4.2: Drop the `fromZonedTime` destructure and `restaurantTimezone` if unused**
+
+Inspect the file body for any other use of `restaurantTimezone` or `fromZonedTime` after Step 4.3 lands. If `restaurantTimezone` is unused, remove:
+
+```typescript
+const restaurantTimezone = selectedRestaurant?.restaurant?.timezone || 'UTC';
+const { fromZonedTime } = dateFnsTz;
+```
+
+If `selectedRestaurant` is also otherwise unused, drop the `useRestaurantContext` import and the `const { selectedRestaurant } = useRestaurantContext();` line. Verify by grepping the file post-edit: `grep -n "selectedRestaurant\|restaurantTimezone\|fromZonedTime\|dateFnsTz" src/components/TimeOffRequestDialog.tsx` — should return zero matches.
+
+- [ ] **Step 4.3: Replace the edit-mode prefill (lines 47–48)**
+
+Replace:
+
+```typescript
+setStartDate(new Date(request.start_date));
+setEndDate(new Date(request.end_date));
+```
+
+with:
+
+```typescript
+setStartDate(parseDateOnly(request.start_date));
+setEndDate(parseDateOnly(request.end_date));
+```
+
+- [ ] **Step 4.4: Replace the write-path `toUTCDate` helper (lines 61–65, 74–75)**
+
+Replace:
+
+```typescript
+// Convert start/end dates to UTC using provided timezone; fallback is identity
+const toUTCDate = (date: Date) => {
+  const converter = fromZonedTime ?? ((value: Date) => value);
+  return converter(date, restaurantTimezone).toISOString().substring(0, 10);
+};
+```
+
+(Delete the entire `toUTCDate` block.)
+
+Replace the two call sites in `requestData`:
+
+```typescript
+start_date: toUTCDate(startDate),
+end_date:   toUTCDate(endDate),
+```
+
+with:
+
+```typescript
+start_date: toDateOnlyString(startDate),
+end_date:   toDateOnlyString(endDate),
+```
+
+- [ ] **Step 4.5: Run unit tests + typecheck + lint**
+
+Run: `npm run test -- --run && npm run typecheck && npm run lint -- src/components/TimeOffRequestDialog.tsx`
+
+Expected: all tests pass; zero TS errors; zero lint errors. The dialog's helpers are now TZ-independent.
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+git add src/components/TimeOffRequestDialog.tsx
+git commit -m "$(cat <<'EOF'
+fix(time-off): use dateOnly helpers in dialog prefill and write path
+
+Edit-mode prefill: parseDateOnly avoids the UTC-midnight trap that left the
+calendar showing the prior day. Write path: drop the fromZonedTime + ISO
+substring workaround that only worked when browser TZ matched restaurant TZ;
+toDateOnlyString reads LOCAL fields from the calendar's selected Date and
+emits YYYY-MM-DD directly — the user's clicked calendar day, no TZ math.
+
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: Final verification
+
+**Files:** none modified; this is a verification gate.
+
+- [ ] **Step 5.1: Run the full unit suite**
+
+Run: `npm run test -- --run`
+
+Expected: all tests pass.
+
+- [ ] **Step 5.2: Run typecheck**
+
+Run: `npm run typecheck`
+
+Expected: zero errors.
+
+- [ ] **Step 5.3: Run lint on touched files**
+
+Run: `npm run lint -- src/lib/dateOnly.ts tests/unit/dateOnly.test.ts src/components/TimeOffList.tsx src/pages/EmployeePortal.tsx src/components/TimeOffRequestDialog.tsx`
+
+Expected: zero errors.
+
+- [ ] **Step 5.4: Build**
+
+Run: `npm run build`
+
+Expected: build succeeds. Watch for TS errors that only appear in production build mode (path resolution, etc.).
+
+- [ ] **Step 5.5: Confirm zero remaining `new Date(*.start_date)` in time-off paths**
+
+Run: `grep -n "new Date(.*\(start_date\|end_date\))" src/components/TimeOffList.tsx src/pages/EmployeePortal.tsx src/components/TimeOffRequestDialog.tsx`
+
+Expected: zero output. (Any other components with the pattern are out of scope per the design doc.)
+
+---
+
+## Self-Review Notes
+
+Spec coverage:
+- Helper module + tests → Task 1 ✓
+- TimeOffList read path → Task 2 ✓
+- EmployeePortal read path → Task 3 ✓
+- Dialog edit prefill → Task 4 (Step 4.3) ✓
+- Dialog write path → Task 4 (Step 4.4) ✓
+- TZ-independent test contract → Task 1 (Step 1.1) ✓
+- Tristen regression test → Task 1 (Step 1.1, "regression" describe block) ✓
+
+Type consistency: `parseDateOnly`, `toDateOnlyString`, `formatDateOnly` names are stable across Tasks 1–4. The component swaps use the names defined in Task 1 verbatim.
+
+No placeholders. Every step has the exact file, the exact code, and the exact command.

--- a/docs/superpowers/specs/2026-05-10-timeoff-date-only-display-design.md
+++ b/docs/superpowers/specs/2026-05-10-timeoff-date-only-display-design.md
@@ -1,0 +1,229 @@
+# Time-Off Request Date Off-By-One Fix — Design
+
+**Date:** 2026-05-10
+**Author:** Jose M Delgado (via /dev workflow)
+**Branch:** `fix/timeoff-tz-bug`
+
+## Problem
+
+Tristen Liu submitted a time-off request for **May 29, 2026** (her graduation day). The approval email correctly stated **May 29**, but the EasyShiftHQ UI shows **May 28** — one day early.
+
+### Production data (verified via Supabase MCP)
+
+```
+request_id        : 408cc35a-5880-489f-89ab-3cfb15996c64
+employee          : Tristen Liu
+restaurant        : Wetzel's - Cold Stone - Alamo Ranch
+restaurant_tz     : America/Chicago
+start_date (DATE) : 2026-05-29
+end_date   (DATE) : 2026-05-29
+status            : approved
+created_at (UTC)  : 2026-04-22 01:50:51
+```
+
+**The DB value is correct.** The bug is purely on the read/display path.
+
+### Root cause
+
+The `time_off_requests.start_date` and `end_date` columns are PostgreSQL `DATE` (a calendar day with no time component). Supabase serializes them as ISO date-only strings (`"2026-05-29"`). The frontend then renders them like:
+
+```typescript
+{format(new Date(request.start_date), 'MMM d, yyyy')}
+```
+
+JavaScript parses ISO date-only strings (`"2026-05-29"`) as **UTC midnight** per the ECMAScript spec. In a browser running in `America/Chicago` (UTC-5 in CDT), that UTC instant is "May 28, 7:00 PM CDT", and `format()` from `date-fns` renders it in the local TZ as **May 28, 2026**.
+
+Locally reproduced (`TZ=America/Chicago`):
+
+| Expression | Output |
+| --- | --- |
+| `new Date("2026-05-29").toLocaleDateString('en-US', ...)` | "May 28, 2026" ❌ |
+| `new Date("2026-05-29T00:00:00").toLocaleDateString('en-US', ...)` | "May 29, 2026" ✅ |
+
+The email path renders correctly only because Supabase Edge Functions (Deno) run in UTC; the same expression produces "May 29, 2026" there. This is fragile — a runtime TZ change would silently break emails.
+
+### Affected sites
+
+| File | Line | Severity |
+| --- | --- | --- |
+| `src/components/TimeOffList.tsx` | 144–145 | Visible to managers (PRIMARY) |
+| `src/pages/EmployeePortal.tsx` | 205–206 | Visible to employees (PRIMARY) |
+| `src/components/TimeOffRequestDialog.tsx` | 47–48 | Edit-mode calendar prefill |
+| `src/components/TimeOffRequestDialog.tsx` | 62–64 | Write path — latent fragility |
+| `supabase/functions/send-time-off-notification/index.ts` | 54–57 | Latent (currently masked by Deno UTC) |
+
+The write path uses `fromZonedTime(date, restaurantTimezone).toISOString().substring(0, 10)`. This works **only when the browser TZ matches the restaurant TZ** (Tristen's case). If a user travels or a manager submits from a different TZ, the wall-clock components shift and the wrong day is stored. Out of scope today only because we have no production evidence of cross-TZ writes — but we should fix it preemptively since the helper makes it free.
+
+### Why subsequent commits did not fix this
+
+Reviewed `git log --since="2026-04-22"` for time-off and TZ-related commits. The only post-creation time-off commit was `1db94052` (#477 — manager email notifications), which did not touch date display. The bug is still present in `main`.
+
+## Goals
+
+1. UI shows the same calendar day that was stored (no TZ shift), regardless of browser TZ.
+2. UI shows the same calendar day that the email approval stated.
+3. Write path stores exactly the calendar day the user selected, regardless of browser TZ.
+4. The fix is reusable so future date-only columns don't repeat the trap.
+5. Tests pin the contract under TZ stubbing so regressions get caught in CI (which runs in UTC).
+
+## Non-goals
+
+- Changing the schema (DATE columns stay).
+- Changing API contracts for `time_off_requests`.
+- Refactoring banking date-only display sites (`ReconciliationReport.tsx`, `ReconciliationDialog.tsx`) — same pattern but out of scope; their behavior is correct enough today and a separate ticket can adopt the helper.
+- Replacing `Date` with `string` or Temporal polyfill across the codebase.
+
+## Approach
+
+Approach A from brainstorm: minimal helper + targeted fixes.
+
+### Helper module: `src/lib/dateOnly.ts`
+
+A small utility with two functions and zero dependencies on TZ libraries:
+
+```typescript
+/**
+ * Parse a YYYY-MM-DD calendar-day string into a Date anchored at LOCAL midnight.
+ *
+ * JavaScript's built-in `new Date("2026-05-29")` parses ISO date-only strings as UTC
+ * midnight, which then renders as the previous day in any negative-UTC-offset
+ * browser TZ (US Pacific/Mountain/Central/Eastern, all of South America, etc.).
+ * This helper sidesteps that by parsing the components manually.
+ */
+export function parseDateOnly(value: string): Date;
+
+/**
+ * Convert a Date object (typically from a calendar/date picker) into a YYYY-MM-DD
+ * calendar-day string, using the Date's LOCAL fields. The output is the calendar
+ * day the user clicked on, with no UTC math — appropriate for storing in a
+ * Postgres DATE column.
+ */
+export function toDateOnlyString(date: Date): string;
+
+/**
+ * Format a YYYY-MM-DD calendar-day string for display via date-fns.
+ * Always parses as local midnight so format() renders the correct day.
+ */
+export function formatDateOnly(value: string, fmt?: string): string;
+```
+
+`parseDateOnly` validates `value` matches `YYYY-MM-DD` exactly (rejects `YYYY-MM-DDTHH:MM:SS` to keep callers honest about the type), splits on `-`, and constructs `new Date(y, m - 1, d)` (LOCAL midnight constructor).
+
+`toDateOnlyString` uses `getFullYear()` / `getMonth() + 1` / `getDate()` (LOCAL fields) and zero-pads.
+
+`formatDateOnly` is a one-line composition: `format(parseDateOnly(value), fmt ?? 'MMM d, yyyy')`.
+
+### Read-path call-site changes
+
+Three components, each replaces `format(new Date(req.start_date), 'MMM d, yyyy')` with `formatDateOnly(req.start_date, 'MMM d, yyyy')`:
+
+- `src/components/TimeOffList.tsx` (lines 144, 145)
+- `src/pages/EmployeePortal.tsx` (lines 205, 206)
+
+The dialog edit-mode prefill replaces `setStartDate(new Date(request.start_date))` with `setStartDate(parseDateOnly(request.start_date))`:
+
+- `src/components/TimeOffRequestDialog.tsx` (lines 47, 48)
+
+### Write-path change in `TimeOffRequestDialog.tsx`
+
+Replace:
+
+```typescript
+const toUTCDate = (date: Date) => {
+  const converter = fromZonedTime ?? ((value: Date) => value);
+  return converter(date, restaurantTimezone).toISOString().substring(0, 10);
+};
+```
+
+with:
+
+```typescript
+import { toDateOnlyString } from '@/lib/dateOnly';
+// ...
+start_date: toDateOnlyString(startDate),
+end_date:   toDateOnlyString(endDate),
+```
+
+Drop the `import * as dateFnsTz from 'date-fns-tz'`, the `fromZonedTime` destructure, and the `restaurantTimezone` lookup that's no longer needed for this purpose. Keep the `restaurantTimezone` line if it's used elsewhere — verify during implementation; current read confirms it's only used for `toUTCDate`.
+
+The user clicked a calendar day. They did not pick a moment in time. Treating it as a calendar day with no TZ math is the correct semantics; the previous code only worked by coincidence when browser TZ matched restaurant TZ.
+
+### Email path
+
+The Deno edge function in `supabase/functions/send-time-off-notification/index.ts` currently does:
+
+```typescript
+const formatDate = (date: string) => new Date(date).toLocaleDateString('en-US', {
+  month: 'long', day: 'numeric', year: 'numeric',
+});
+```
+
+This works because Deno runs in UTC. Out of scope for this PR (per user's chosen Approach A — not "A + harden email"). The pattern stays as-is; we'll revisit if we ever see edge-function TZ migration.
+
+### Testing
+
+Unit tests in `tests/unit/dateOnly.test.ts` covering:
+
+1. `parseDateOnly("2026-05-29")` returns a Date whose local-TZ year/month/day are 2026/5/29 — under both `TZ=UTC` and `TZ=America/Chicago` (and one east-of-UTC TZ like `Asia/Tokyo` for symmetry).
+2. `toDateOnlyString(new Date(2026, 4, 29))` returns `"2026-05-29"` under all three TZs.
+3. Round-trip: `toDateOnlyString(parseDateOnly("2026-05-29")) === "2026-05-29"` under all three TZs.
+4. `formatDateOnly("2026-05-29", "MMM d, yyyy")` returns `"May 29, 2026"` under all three TZs.
+5. Tristen-specific regression: `formatDateOnly("2026-05-29")` under `TZ=America/Chicago` ≠ `"May 28, 2026"`.
+6. `parseDateOnly` rejects malformed input with a clear error (`"2026/05/29"`, `""`, `"2026-5-9"`, `"2026-05-29T00:00:00"`, `"not a date"`).
+
+Test strategy: assert TZ-independent properties of the helpers wherever possible — e.g. `expect(parsed.getFullYear()).toBe(2026)` and `expect(parsed.getMonth()).toBe(4)` for `parseDateOnly`, since these wall-clock-fields read in the runner's local TZ (whatever it is) and the helper anchors to local midnight by construction. For `formatDateOnly` we assert the output string `"May 29, 2026"`, which under date-fns's local rendering will be correct in any TZ as long as `parseDateOnly` already anchored to local midnight. Add one explicit Chicago-stubbed regression test using `vi.stubGlobal('Date', ...)` only if `vi.stubEnv('TZ', 'America/Chicago')` proves insufficient for V8's timezone subsystem under vitest workers — record which approach was used in the test file header. Lessons.md (PR #485, 2026-05-03) documents that CI runs in UTC, so the runner's-TZ-agnostic approach also pins behavior in CI.
+
+## Architecture & data flow
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                                                                         │
+│  Calendar widget (browser local TZ)                                     │
+│         │                                                               │
+│         │  Date object: 2026-05-29 00:00 LOCAL                          │
+│         ▼                                                               │
+│  toDateOnlyString(date)  ──→  "2026-05-29"  ──→  Supabase DATE column   │
+│                                                                         │
+│                                                                         │
+│  Supabase DATE column                                                   │
+│         │                                                               │
+│         │  ISO date-only string: "2026-05-29"                           │
+│         ▼                                                               │
+│  formatDateOnly("2026-05-29", "MMM d, yyyy")  ──→  "May 29, 2026"       │
+│  parseDateOnly("2026-05-29")                  ──→  Date(2026,4,29 LOCAL)│
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+The helper makes the read and write paths symmetric and TZ-independent for date-only values.
+
+## Error handling
+
+`parseDateOnly` throws `Error("Invalid date-only string: <value>")` on malformed input. Callers all receive validated DB output, so this throw is a safety net — not expected to fire in normal flow. We do not catch and degrade; a malformed date-only string indicates a schema or migration bug that should surface loudly.
+
+`formatDateOnly` and `toDateOnlyString` likewise do not silently degrade.
+
+## Backward compatibility
+
+Pure addition + 4 call-site replacements. No schema, API, or type changes. No data migration. Users with existing requests continue to see the correct dates after deploy.
+
+## Rollout
+
+Standard deploy via the workflow. No feature flag — the bug is visible to every employee in a non-UTC TZ, and the fix is type-equivalent to the original on the happy path (correct calendar day in, correct calendar day out).
+
+## Out of scope
+
+- Banking `ReconciliationReport.tsx` / `ReconciliationDialog.tsx` adopting the helper.
+- Email render hardening in `send-time-off-notification/index.ts`.
+- Audit of every other `format(new Date(...), ...)` call site for TZ correctness.
+- Schema change to `timestamptz` or any column type change.
+
+## Risks
+
+1. **Test TZ stubbing flakiness.** Mitigation: validate via wall-clock-field assertions as a fallback if `vi.stubEnv('TZ', '...')` doesn't propagate to the V8 timezone subsystem reliably. Document the chosen approach in the test file header.
+2. **Edit-mode calendar appears 1 day off if a user has any in-flight edits at deploy.** Mitigation: refresh page; the values stored in DB are correct. No data fix needed.
+3. **Lost write-path safety net for cross-TZ submitters.** The new `toDateOnlyString` strictly uses LOCAL fields, which is semantically right (the user picks a calendar day in their browser). If in the future we want to constrain "submit only days that exist in restaurant TZ" we can add that on top of the helper without reverting it.
+
+## Summary
+
+Add `src/lib/dateOnly.ts`, swap 4 call sites to use it, drop the `fromZonedTime` write-path workaround, add a tested contract. Diff: ~80 lines plus tests.

--- a/src/components/TimeOffList.tsx
+++ b/src/components/TimeOffList.tsx
@@ -12,7 +12,7 @@ import {
   Clock,
   User,
 } from 'lucide-react';
-import { format } from 'date-fns';
+import { formatDateOnly } from '@/lib/dateOnly';
 import { TimeOffRequest } from '@/types/scheduling';
 import { useTimeOffRequests, useApproveTimeOffRequest, useRejectTimeOffRequest, useDeleteTimeOffRequest } from '@/hooks/useTimeOffRequests';
 import { TimeOffRequestDialog } from './TimeOffRequestDialog';
@@ -141,8 +141,8 @@ export const TimeOffList = ({ restaurantId }: TimeOffListProps) => {
                       <div className="flex items-center gap-1">
                         <Calendar className="h-3 w-3" />
                         <span>
-                          {format(new Date(request.start_date), 'MMM d, yyyy')} - 
-                          {format(new Date(request.end_date), 'MMM d, yyyy')}
+                          {formatDateOnly(request.start_date, 'MMM d, yyyy')} -{' '}
+                          {formatDateOnly(request.end_date, 'MMM d, yyyy')}
                         </span>
                       </div>
                     </div>

--- a/src/components/TimeOffList.tsx
+++ b/src/components/TimeOffList.tsx
@@ -141,8 +141,8 @@ export const TimeOffList = ({ restaurantId }: TimeOffListProps) => {
                       <div className="flex items-center gap-1">
                         <Calendar className="h-3 w-3" />
                         <span>
-                          {formatDateOnly(request.start_date, 'MMM d, yyyy')} -{' '}
-                          {formatDateOnly(request.end_date, 'MMM d, yyyy')}
+                          {formatDateOnly(request.start_date)} -{' '}
+                          {formatDateOnly(request.end_date)}
                         </span>
                       </div>
                     </div>

--- a/src/components/TimeOffRequestDialog.tsx
+++ b/src/components/TimeOffRequestDialog.tsx
@@ -1,6 +1,4 @@
 import { useState, useEffect } from 'react';
-import { useRestaurantContext } from '@/contexts/RestaurantContext';
-import * as dateFnsTz from 'date-fns-tz';
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
@@ -10,6 +8,7 @@ import { format } from 'date-fns';
 import { Calendar } from '@/components/ui/calendar';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
+import { parseDateOnly, toDateOnlyString } from '@/lib/dateOnly';
 import { useCreateTimeOffRequest, useUpdateTimeOffRequest } from '@/hooks/useTimeOffRequests';
 import { TimeOffRequest } from '@/types/scheduling';
 import { Alert, AlertDescription } from '@/components/ui/alert';
@@ -34,9 +33,6 @@ export const TimeOffRequestDialog = ({
   const [startDate, setStartDate] = useState<Date | undefined>();
   const [endDate, setEndDate] = useState<Date | undefined>();
   const [reason, setReason] = useState('');
-  const { selectedRestaurant } = useRestaurantContext();
-  const restaurantTimezone = selectedRestaurant?.restaurant?.timezone || 'UTC';
-  const { fromZonedTime } = dateFnsTz;
 
   const createRequest = useCreateTimeOffRequest();
   const updateRequest = useUpdateTimeOffRequest();
@@ -44,8 +40,8 @@ export const TimeOffRequestDialog = ({
   useEffect(() => {
     if (request) {
       setEmployeeId(request.employee_id);
-      setStartDate(new Date(request.start_date));
-      setEndDate(new Date(request.end_date));
+      setStartDate(parseDateOnly(request.start_date));
+      setEndDate(parseDateOnly(request.end_date));
       setReason(request.reason || '');
     } else {
       setEmployeeId(defaultEmployeeId || '');
@@ -58,12 +54,6 @@ export const TimeOffRequestDialog = ({
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
 
-    // Convert start/end dates to UTC using provided timezone; fallback is identity
-    const toUTCDate = (date: Date) => {
-      const converter = fromZonedTime ?? ((value: Date) => value);
-      return converter(date, restaurantTimezone).toISOString().substring(0, 10);
-    };
-
     if (!employeeId || !startDate || !endDate) {
       return;
     }
@@ -71,8 +61,8 @@ export const TimeOffRequestDialog = ({
     const requestData = {
       restaurant_id: restaurantId,
       employee_id: employeeId,
-      start_date: toUTCDate(startDate),
-      end_date: toUTCDate(endDate),
+      start_date: toDateOnlyString(startDate),
+      end_date: toDateOnlyString(endDate),
       reason: reason || undefined,
       status: 'pending' as const,
       requested_at: new Date().toISOString(),

--- a/src/lib/dateOnly.ts
+++ b/src/lib/dateOnly.ts
@@ -1,0 +1,51 @@
+import { format } from 'date-fns';
+
+const ISO_DATE_ONLY_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+/**
+ * Parse a YYYY-MM-DD calendar-day string into a Date anchored at LOCAL midnight.
+ *
+ * Sidesteps the trap that `new Date("2026-05-29")` parses as UTC midnight per
+ * the ECMAScript spec — which then renders as the previous day in any browser
+ * TZ behind UTC (US, all of the Americas, etc.). Postgres `DATE` columns are
+ * pure calendar days; this helper preserves them as such.
+ */
+export function parseDateOnly(value: string): Date {
+  const match = ISO_DATE_ONLY_RE.exec(value);
+  if (!match) {
+    throw new Error(`Invalid date-only string: ${JSON.stringify(value)}`);
+  }
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const d = new Date(year, month - 1, day);
+  if (
+    d.getFullYear() !== year ||
+    d.getMonth() !== month - 1 ||
+    d.getDate() !== day
+  ) {
+    throw new Error(`Invalid date-only string: ${JSON.stringify(value)}`);
+  }
+  return d;
+}
+
+/**
+ * Convert a Date object (typically from a calendar/date picker) into a YYYY-MM-DD
+ * calendar-day string using LOCAL fields. Appropriate for storing a calendar
+ * day the user clicked on into a Postgres DATE column — no UTC math.
+ */
+export function toDateOnlyString(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Format a YYYY-MM-DD calendar-day string for display via date-fns.
+ * Always parses as local midnight first, so format() renders the correct day
+ * regardless of browser TZ.
+ */
+export function formatDateOnly(value: string, pattern = 'MMM d, yyyy'): string {
+  return format(parseDateOnly(value), pattern);
+}

--- a/src/pages/EmployeePortal.tsx
+++ b/src/pages/EmployeePortal.tsx
@@ -23,6 +23,7 @@ import {
   Clock,
 } from 'lucide-react';
 import { format } from 'date-fns';
+import { formatDateOnly } from '@/lib/dateOnly';
 import { utcTimeToLocalTime } from '@/lib/availabilityTimeUtils';
 import { TimeOffRequest, EmployeeAvailability, AvailabilityException } from '@/types/scheduling';
 import {
@@ -202,8 +203,8 @@ const EmployeePortal = () => {
                   </div>
                   <div className="space-y-1">
                     <p className="font-medium">
-                      {format(new Date(request.start_date), 'MMM d, yyyy')} -{' '}
-                      {format(new Date(request.end_date), 'MMM d, yyyy')}
+                      {formatDateOnly(request.start_date, 'MMM d, yyyy')} -{' '}
+                      {formatDateOnly(request.end_date, 'MMM d, yyyy')}
                     </p>
                     {request.reason && (
                       <p className="text-sm text-muted-foreground">{request.reason}</p>

--- a/src/pages/EmployeePortal.tsx
+++ b/src/pages/EmployeePortal.tsx
@@ -203,8 +203,8 @@ const EmployeePortal = () => {
                   </div>
                   <div className="space-y-1">
                     <p className="font-medium">
-                      {formatDateOnly(request.start_date, 'MMM d, yyyy')} -{' '}
-                      {formatDateOnly(request.end_date, 'MMM d, yyyy')}
+                      {formatDateOnly(request.start_date)} -{' '}
+                      {formatDateOnly(request.end_date)}
                     </p>
                     {request.reason && (
                       <p className="text-sm text-muted-foreground">{request.reason}</p>

--- a/tests/unit/dateOnly.test.ts
+++ b/tests/unit/dateOnly.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import { format } from 'date-fns';
+import { parseDateOnly, toDateOnlyString, formatDateOnly } from '@/lib/dateOnly';
+
+// All assertions here use TZ-independent properties (wall-clock fields read in
+// the runner's local TZ; helper anchors to local midnight by construction).
+// CI runs in UTC; developers may run in any TZ. The Tristen Liu regression
+// asserts that parseDateOnly("2026-05-29") yields a Date whose getDate()
+// returns 29 in any TZ — proving the helper sidesteps the UTC-midnight trap.
+
+describe('parseDateOnly', () => {
+  it('parses "2026-05-29" as local midnight (May 29 in any TZ)', () => {
+    const d = parseDateOnly('2026-05-29');
+    expect(d.getFullYear()).toBe(2026);
+    expect(d.getMonth()).toBe(4); // May (0-indexed)
+    expect(d.getDate()).toBe(29);
+    expect(d.getHours()).toBe(0);
+    expect(d.getMinutes()).toBe(0);
+    expect(d.getSeconds()).toBe(0);
+    expect(d.getMilliseconds()).toBe(0);
+  });
+
+  it('parses leap-day "2024-02-29" correctly', () => {
+    const d = parseDateOnly('2024-02-29');
+    expect(d.getFullYear()).toBe(2024);
+    expect(d.getMonth()).toBe(1);
+    expect(d.getDate()).toBe(29);
+  });
+
+  it('parses month-end "2026-12-31" correctly', () => {
+    const d = parseDateOnly('2026-12-31');
+    expect(d.getFullYear()).toBe(2026);
+    expect(d.getMonth()).toBe(11);
+    expect(d.getDate()).toBe(31);
+  });
+
+  it('rejects malformed input', () => {
+    expect(() => parseDateOnly('2026/05/29')).toThrow(/invalid/i);
+    expect(() => parseDateOnly('2026-5-9')).toThrow(/invalid/i);
+    expect(() => parseDateOnly('2026-05-29T00:00:00')).toThrow(/invalid/i);
+    expect(() => parseDateOnly('not a date')).toThrow(/invalid/i);
+    expect(() => parseDateOnly('')).toThrow(/invalid/i);
+  });
+
+  it('rejects out-of-range month/day', () => {
+    expect(() => parseDateOnly('2026-13-01')).toThrow(/invalid/i);
+    expect(() => parseDateOnly('2026-02-30')).toThrow(/invalid/i);
+    expect(() => parseDateOnly('2026-04-31')).toThrow(/invalid/i);
+  });
+});
+
+describe('toDateOnlyString', () => {
+  it('serializes a local-midnight Date to YYYY-MM-DD', () => {
+    const d = new Date(2026, 4, 29); // May 29 LOCAL midnight
+    expect(toDateOnlyString(d)).toBe('2026-05-29');
+  });
+
+  it('zero-pads month and day', () => {
+    const d = new Date(2026, 0, 5); // Jan 5 LOCAL
+    expect(toDateOnlyString(d)).toBe('2026-01-05');
+  });
+
+  it('uses LOCAL fields (not UTC), preserving the calendar-day click', () => {
+    // Date constructed via numeric ctor uses local TZ — this is what
+    // react-day-picker hands back from the calendar widget.
+    const d = new Date(2026, 11, 31, 23, 59, 59); // Dec 31 LOCAL, late evening
+    expect(toDateOnlyString(d)).toBe('2026-12-31');
+  });
+});
+
+describe('round-trip', () => {
+  it('parseDateOnly -> toDateOnlyString is identity', () => {
+    for (const s of ['2026-01-01', '2026-05-29', '2026-12-31', '2024-02-29']) {
+      expect(toDateOnlyString(parseDateOnly(s))).toBe(s);
+    }
+  });
+});
+
+describe('formatDateOnly', () => {
+  it('formats with default pattern "MMM d, yyyy"', () => {
+    expect(formatDateOnly('2026-05-29')).toBe('May 29, 2026');
+  });
+
+  it('accepts a custom date-fns pattern', () => {
+    expect(formatDateOnly('2026-05-29', 'yyyy-MM-dd')).toBe('2026-05-29');
+    expect(formatDateOnly('2026-05-29', 'EEEE, MMMM d')).toBe('Friday, May 29');
+  });
+
+  it('matches a parseDateOnly + format composition', () => {
+    const expected = format(parseDateOnly('2026-05-29'), 'MMM d, yyyy');
+    expect(formatDateOnly('2026-05-29', 'MMM d, yyyy')).toBe(expected);
+  });
+});
+
+// Regression: Tristen Liu's bug. parseDateOnly must NEVER shift to the prior
+// day, regardless of the runner TZ. This test would catch a regression to the
+// `new Date("YYYY-MM-DD")` UTC-midnight pattern in any negative-offset TZ
+// (where getDate() would return 28 instead of 29).
+describe('regression: Tristen Liu off-by-one', () => {
+  it('parseDateOnly("2026-05-29") preserves day 29 (not 28)', () => {
+    const d = parseDateOnly('2026-05-29');
+    expect(d.getDate()).toBe(29);
+    expect(d.getMonth()).toBe(4);
+    expect(d.getFullYear()).toBe(2026);
+  });
+
+  it('documents the trap that this helper avoids', () => {
+    // This test does NOT use the helper — it documents why the helper exists.
+    // `new Date("2026-05-29")` parses as UTC midnight regardless of runner TZ.
+    const buggy = new Date('2026-05-29');
+    expect(buggy.toISOString()).toBe('2026-05-29T00:00:00.000Z');
+    // Its LOCAL getDate() varies by runner TZ — that's the bug we sidestep.
+    // We don't assert the local value here (CI=UTC, dev=anything) because the
+    // helper test above proves the FIX is TZ-independent.
+  });
+});


### PR DESCRIPTION
## Summary

Tristen Liu reported a graduation-day time-off request: she submitted **May 29**, the manager's email approval said **May 29**, but the EasyShiftHQ UI showed **May 28**.

Root cause: `new Date("2026-05-29")` parses as **UTC midnight** per the ECMAScript spec, then `format()` (and `toLocaleDateString`) renders it in the browser's local TZ. In any timezone behind UTC (Central, Pacific, Mountain, Eastern — i.e. all of the US), that lands on the previous day. The Postgres column is `DATE` (a pure calendar day), so the storage was always correct — only the read/render path was wrong. The email worked because Supabase Edge Functions (Deno) run in UTC.

## Fix

Add a tiny `src/lib/dateOnly.ts` helper module (parse/serialize/format) that anchors `YYYY-MM-DD` strings to **local** midnight, sidestepping the UTC-midnight trap. Swap the four user-visible time-off render/persist sites to it.

- `src/lib/dateOnly.ts` — `parseDateOnly`, `toDateOnlyString`, `formatDateOnly`
- `src/components/TimeOffList.tsx` — admin list display
- `src/pages/EmployeePortal.tsx` — employee self-service display
- `src/components/TimeOffRequestDialog.tsx` — calendar prefill + form submit; drops the `RestaurantContext` + `date-fns-tz` dependency for date math

## Test plan

- [x] `tests/unit/dateOnly.test.ts` — 14 TZ-independent tests covering parse, serialize, round-trip, format, malformed/out-of-range inputs, and a Tristen-Liu regression test
- [x] All 3785 unit tests pass under `TZ=UTC` (one pre-existing labor-wages test is TZ-flaky on local non-UTC machines and unrelated to this PR)
- [x] TypeScript: `npm run typecheck` clean
- [x] ESLint: clean on touched files
- [x] `npm run build` clean
- [x] Reproduced the bug locally with `TZ=America/Chicago`; confirmed the fix lifts it
- [x] Production data verified via Supabase MCP: DB stores `2026-05-29` (correct); only the render path was buggy
- [x] Manual smoke test: load admin time-off list and employee portal in Chicago TZ → dates render correctly
- [ ] Verify Tristen's request renders as May 29 in production after deploy

## Out of scope (intentional)

- `availability_exceptions.date` rendering in `EmployeePortal.tsx:~351` (same bug class, different feature; tracked separately)
- Hardening edge-function email rendering (Deno runs in UTC; emails are correct today)
- Banking/transaction date displays (separate feature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Service Level Objectives documentation and monitoring dashboard for UX performance tracking

* **Bug Fixes**
  * Corrected calendar date display in time-off request dates

* **Documentation**
  * Added comprehensive SLO specifications and operational guidance for observability and monitoring

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toyiyo/nimble-pnl/pull/489)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->