### PR TITLE
Distinguish self-serve signups from team-invitation accepts in PostHog

### DIFF
--- a/docs/superpowers/plans/2026-05-10-signup-path-attribution-plan.md
+++ b/docs/superpowers/plans/2026-05-10-signup-path-attribution-plan.md
@@ -1,0 +1,716 @@
+# Signup-Path Attribution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Tag every PostHog `account_created` event with `signup_path`/`account_role`/`invited_to_org_id` at capture time, suppress `trial_started` for invitation accepts, and emit a new `team_member_joined` event so prospect funnels stop counting invited employees as failed trials.
+
+**Architecture:** Add three new localStorage helpers in `src/lib/analytics.ts` (`storeSignupPath`, `readStoredSignupClassification`, `clearStoredSignupPath`) and extend `recordAuthEvents` to read the classification at capture time. Two entry-page components (`Auth.tsx`, `AcceptInvitation.tsx`) write to localStorage on mount. Person properties are mirrored via the existing `posthog.identify(id, props)` pattern (no `people.set` — the current `PostHogLike` interface doesn't expose it).
+
+**Tech Stack:** TypeScript, React 18, Vitest (jsdom), PostHog JS SDK, React Router 6, Vite.
+
+**Spec:** `docs/superpowers/specs/2026-05-10-signup-path-attribution-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/lib/analytics.ts` | Modify | Add `SIGNUP_PATH_STORAGE_KEY` etc., `storeSignupPath`, `readStoredSignupClassification`, `clearStoredSignupPath`, and extend `recordAuthEvents` with classification logic + `team_member_joined` capture. |
+| `src/pages/Auth.tsx` | Modify | Tag `signup_path: 'self_serve'` in localStorage on mount (gated by `!isOAuthCallback` and `!localStorage.getItem(...)` first-touch). |
+| `src/pages/AcceptInvitation.tsx` | Modify | Tag `signup_path: 'invitation_accept'` + role on mount and again when `invitation.role` resolves. |
+| `tests/unit/analytics.test.ts` | Modify | Update existing `recordAuthEvents` assertions for new event-prop shape; add new `describe` block for the three new helpers; add new tests for invitation classification and pathname fallback. |
+
+No new files. All changes additive within existing files.
+
+---
+
+## Pre-flight checks
+
+- [ ] **Confirm dev environment.** Run from the worktree root: `pwd` → `/Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/posthog-signup-path-attribution`. Run `git rev-parse --abbrev-ref HEAD` → `fix/posthog-signup-path-attribution`.
+
+- [ ] **Confirm test command works.** Run: `npm test -- tests/unit/analytics.test.ts --run` → existing 30+ tests pass.
+
+---
+
+## Task 1: Add signup-path constants, types, and storage helpers in `analytics.ts`
+
+**Goal:** Introduce the storage keys, the `SignupPath` type, and the three helpers (`storeSignupPath`, `readStoredSignupClassification`, `clearStoredSignupPath`). No behavior change to `recordAuthEvents` yet — that comes in Task 2.
+
+**Files:**
+- Modify: `src/lib/analytics.ts`
+- Test: `tests/unit/analytics.test.ts` (new `describe` block)
+
+- [ ] **Step 1.1: Write the failing tests for the new helpers**
+
+Append a new `describe` block to `tests/unit/analytics.test.ts` (after the `clearStoredAttribution` block, before `recordAuthEvents`):
+
+```ts
+describe('storeSignupPath / readStoredSignupClassification / clearStoredSignupPath', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('storeSignupPath writes path and role keys', () => {
+    storeSignupPath('self_serve', 'owner');
+    expect(localStorage.getItem(SIGNUP_PATH_STORAGE_KEY)).toBe('self_serve');
+    expect(localStorage.getItem(SIGNUP_ACCOUNT_ROLE_STORAGE_KEY)).toBe('owner');
+    expect(localStorage.getItem(SIGNUP_INVITED_TO_ORG_ID_STORAGE_KEY)).toBeNull();
+  });
+
+  it('storeSignupPath writes invited_to_org_id when provided', () => {
+    storeSignupPath('invitation_accept', 'manager', 'org-123');
+    expect(localStorage.getItem(SIGNUP_PATH_STORAGE_KEY)).toBe('invitation_accept');
+    expect(localStorage.getItem(SIGNUP_ACCOUNT_ROLE_STORAGE_KEY)).toBe('manager');
+    expect(localStorage.getItem(SIGNUP_INVITED_TO_ORG_ID_STORAGE_KEY)).toBe('org-123');
+  });
+
+  it('storeSignupPath does not write invited_to_org_id when null is passed', () => {
+    storeSignupPath('invitation_accept', 'employee', null);
+    expect(localStorage.getItem(SIGNUP_INVITED_TO_ORG_ID_STORAGE_KEY)).toBeNull();
+  });
+
+  it('readStoredSignupClassification returns self_serve defaults when nothing stored', () => {
+    const result = readStoredSignupClassification('/auth');
+    expect(result).toEqual({
+      signup_path: 'self_serve',
+      account_role: 'owner',
+      invited_to_org_id: null,
+    });
+  });
+
+  it('readStoredSignupClassification derives invitation_accept from /accept-invitation pathname', () => {
+    const result = readStoredSignupClassification('/accept-invitation?token=abc');
+    expect(result).toEqual({
+      signup_path: 'invitation_accept',
+      account_role: 'employee',
+      invited_to_org_id: null,
+    });
+  });
+
+  it('readStoredSignupClassification returns stored values when present', () => {
+    storeSignupPath('invitation_accept', 'manager', 'org-456');
+    const result = readStoredSignupClassification('/auth');
+    expect(result).toEqual({
+      signup_path: 'invitation_accept',
+      account_role: 'manager',
+      invited_to_org_id: 'org-456',
+    });
+  });
+
+  it('readStoredSignupClassification: invitation_accept without role falls back to employee', () => {
+    localStorage.setItem(SIGNUP_PATH_STORAGE_KEY, 'invitation_accept');
+    const result = readStoredSignupClassification('/auth');
+    expect(result.signup_path).toBe('invitation_accept');
+    expect(result.account_role).toBe('employee');
+  });
+
+  it('readStoredSignupClassification: self_serve always returns null org id even with stale value', () => {
+    // Defensive: a stale invited_to_org_id key from a prior incomplete flow
+    // should not leak into a self_serve classification.
+    localStorage.setItem(SIGNUP_INVITED_TO_ORG_ID_STORAGE_KEY, 'stale-org');
+    const result = readStoredSignupClassification('/auth');
+    expect(result.signup_path).toBe('self_serve');
+    expect(result.invited_to_org_id).toBeNull();
+  });
+
+  it('clearStoredSignupPath removes all three keys', () => {
+    storeSignupPath('invitation_accept', 'manager', 'org-789');
+    clearStoredSignupPath();
+    expect(localStorage.getItem(SIGNUP_PATH_STORAGE_KEY)).toBeNull();
+    expect(localStorage.getItem(SIGNUP_ACCOUNT_ROLE_STORAGE_KEY)).toBeNull();
+    expect(localStorage.getItem(SIGNUP_INVITED_TO_ORG_ID_STORAGE_KEY)).toBeNull();
+  });
+
+  it('storeSignupPath survives a localStorage that throws on setItem (no rethrow)', () => {
+    const setItemMock = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('quota exceeded');
+    });
+    expect(() => storeSignupPath('self_serve', 'owner')).not.toThrow();
+    setItemMock.mockRestore();
+  });
+});
+```
+
+Update the imports at the top of `tests/unit/analytics.test.ts` to include the new symbols:
+
+```ts
+import {
+  ATTRIBUTION_STORAGE_KEY,
+  INTERNAL_DOMAINS,
+  NEW_SIGNUP_WINDOW_MS,
+  SIGNUP_ACCOUNT_ROLE_STORAGE_KEY,
+  SIGNUP_INVITED_TO_ORG_ID_STORAGE_KEY,
+  SIGNUP_PATH_STORAGE_KEY,
+  TRIAL_DURATION_DAYS,
+  accountCreatedFlagKey,
+  clearStoredAttribution,
+  clearStoredSignupPath,
+  firstPnlViewedFlagKey,
+  getStoredAttribution,
+  isInternalEmail,
+  posIntegrationCompletedFlagKey,
+  readStoredSignupClassification,
+  recordAuthEvents,
+  recordFirstPnlViewed,
+  recordPosIntegrationCompleted,
+  storeAttribution,
+  storeSignupPath,
+} from '../../src/lib/analytics';
+```
+
+- [ ] **Step 1.2: Run tests to verify they fail**
+
+Run: `npm test -- tests/unit/analytics.test.ts --run`
+Expected: 10 new tests fail with import errors / `is not a function` errors. Existing tests still pass.
+
+- [ ] **Step 1.3: Implement the helpers in `src/lib/analytics.ts`**
+
+After the `clearStoredAttribution` function (around line 95), insert the new constants, type, and helpers (before the `NEW_SIGNUP_WINDOW_MS` constant):
+
+```ts
+export const SIGNUP_PATH_STORAGE_KEY = 'signup_path';
+export const SIGNUP_ACCOUNT_ROLE_STORAGE_KEY = 'signup_account_role';
+export const SIGNUP_INVITED_TO_ORG_ID_STORAGE_KEY = 'signup_invited_to_org_id';
+
+export type SignupPath = 'self_serve' | 'invitation_accept';
+
+export interface SignupClassification {
+  signup_path: SignupPath;
+  account_role: string;
+  invited_to_org_id: string | null;
+}
+
+const ACCEPT_INVITATION_PATHNAME_PREFIX = '/accept-invitation';
+
+function defaultRoleForPath(path: SignupPath): string {
+  return path === 'invitation_accept' ? 'employee' : 'owner';
+}
+
+export function storeSignupPath(
+  path: SignupPath,
+  accountRole: string,
+  invitedToOrgId?: string | null,
+): void {
+  try {
+    localStorage.setItem(SIGNUP_PATH_STORAGE_KEY, path);
+    localStorage.setItem(SIGNUP_ACCOUNT_ROLE_STORAGE_KEY, accountRole);
+    if (invitedToOrgId) {
+      localStorage.setItem(SIGNUP_INVITED_TO_ORG_ID_STORAGE_KEY, invitedToOrgId);
+    }
+  } catch {
+    // Storage disabled / quota exceeded — analytics must never block signup.
+  }
+}
+
+export function readStoredSignupClassification(currentPathname: string): SignupClassification {
+  let storedPath: string | null = null;
+  let storedRole: string | null = null;
+  let storedOrgId: string | null = null;
+  try {
+    storedPath = localStorage.getItem(SIGNUP_PATH_STORAGE_KEY);
+    storedRole = localStorage.getItem(SIGNUP_ACCOUNT_ROLE_STORAGE_KEY);
+    storedOrgId = localStorage.getItem(SIGNUP_INVITED_TO_ORG_ID_STORAGE_KEY);
+  } catch {
+    // ignore — fall through to defaults
+  }
+
+  const isInvitationByPathname =
+    typeof currentPathname === 'string' && currentPathname.startsWith(ACCEPT_INVITATION_PATHNAME_PREFIX);
+  const signup_path: SignupPath =
+    storedPath === 'invitation_accept' || isInvitationByPathname ? 'invitation_accept' : 'self_serve';
+
+  const account_role = storedRole && storedRole.length > 0 ? storedRole : defaultRoleForPath(signup_path);
+  const invited_to_org_id = signup_path === 'invitation_accept' ? storedOrgId : null;
+
+  return { signup_path, account_role, invited_to_org_id };
+}
+
+export function clearStoredSignupPath(): void {
+  try {
+    localStorage.removeItem(SIGNUP_PATH_STORAGE_KEY);
+    localStorage.removeItem(SIGNUP_ACCOUNT_ROLE_STORAGE_KEY);
+    localStorage.removeItem(SIGNUP_INVITED_TO_ORG_ID_STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}
+```
+
+- [ ] **Step 1.4: Run tests to verify they pass**
+
+Run: `npm test -- tests/unit/analytics.test.ts --run`
+Expected: All tests pass (existing + 10 new). No `recordAuthEvents` tests changed yet.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add src/lib/analytics.ts tests/unit/analytics.test.ts
+git commit -m "feat(analytics): add signup-path classification helpers
+
+Adds storeSignupPath, readStoredSignupClassification, clearStoredSignupPath
+plus the SIGNUP_PATH_STORAGE_KEY family of constants. recordAuthEvents is
+unchanged; classification wiring lands in the next commit.
+
+Co-Authored-By: Jose Delgado <jose.delgado@easyshifthq.com>
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Wire classification into `recordAuthEvents` and emit `team_member_joined`
+
+**Goal:** Read the classification inside the fresh-signup branch, mirror it onto `posthog.identify` and `account_created`, and branch trial_started vs team_member_joined by `signup_path`.
+
+**Files:**
+- Modify: `src/lib/analytics.ts:118-173` (the `recordAuthEvents` body)
+- Test: `tests/unit/analytics.test.ts` (update existing `recordAuthEvents` assertions; add 4 new tests)
+
+- [ ] **Step 2.1: Update existing `recordAuthEvents` test assertions**
+
+In `tests/unit/analytics.test.ts`, find the test `'fires identify + account_created + trial_started for a fresh signup'` (around line 192). Modify the assertions to expect the default `self_serve` classification:
+
+```ts
+it('fires identify + account_created + trial_started for a fresh signup', () => {
+  storeAttribution('?utm_source=google&utm_medium=cpc&utm_campaign=launch', '', '/auth');
+
+  recordAuthEvents({
+    userId: 'user-1',
+    email: 'jose@example.com',
+    createdAt: RECENT_CREATED_AT,
+    posthog,
+    now: FIXED_NOW,
+  });
+
+  expect(posthog.identify).toHaveBeenCalledTimes(1);
+  expect(posthog.identify).toHaveBeenCalledWith('user-1', expect.objectContaining({
+    signup_source: 'google',
+    signup_medium: 'cpc',
+    signup_campaign: 'launch',
+    is_internal: false,
+    signup_path: 'self_serve',
+    account_role: 'owner',
+    invited_to_org_id: null,
+  }));
+  // PII: email is NOT forwarded to PostHog
+  const identifyProps = posthog.identify.mock.calls[0][1];
+  expect(identifyProps).not.toHaveProperty('email');
+
+  expect(posthog.capture).toHaveBeenCalledTimes(2);
+  expect(posthog.capture).toHaveBeenCalledWith('account_created', {
+    signup_path: 'self_serve',
+    account_role: 'owner',
+    invited_to_org_id: null,
+  });
+  const trialEndsAt = new Date(FIXED_NOW.getTime() + TRIAL_DURATION_DAYS * 24 * 60 * 60 * 1000).toISOString();
+  expect(posthog.capture).toHaveBeenCalledWith('trial_started', {
+    trial_ends_at: trialEndsAt,
+    signup_path: 'self_serve',
+    account_role: 'owner',
+    invited_to_org_id: null,
+  });
+
+  expect(localStorage.getItem(accountCreatedFlagKey('user-1'))).toBeTruthy();
+  expect(localStorage.getItem(ATTRIBUTION_STORAGE_KEY)).toBeNull();
+});
+```
+
+In `'handles missing email gracefully (still identifies, is_internal:false)'` (around line 318), update the last assertion:
+
+```ts
+expect(posthog.capture).toHaveBeenCalledWith('account_created', {
+  signup_path: 'self_serve',
+  account_role: 'owner',
+  invited_to_org_id: null,
+});
+```
+
+In `'does not re-fire account_created if trial_started capture throws (atomic dedup)'` (around line 350), the existing assertions use `expect.anything()` and string-only matchers — those continue to hold without changes.
+
+In `'does not double-fire account_created if the flag is set'` (around line 270), the assertions use `expect.anything()` — also unchanged.
+
+- [ ] **Step 2.2: Add 4 new `recordAuthEvents` tests**
+
+Append these tests to the existing `describe('recordAuthEvents')` block, before its closing `})`:
+
+```ts
+it('classifies invitation_accept from localStorage and fires team_member_joined instead of trial_started', () => {
+  storeSignupPath('invitation_accept', 'manager');
+
+  recordAuthEvents({
+    userId: 'user-invite-1',
+    email: 'jose@example.com',
+    createdAt: RECENT_CREATED_AT,
+    posthog,
+    now: FIXED_NOW,
+  });
+
+  expect(posthog.identify).toHaveBeenCalledWith('user-invite-1', expect.objectContaining({
+    signup_path: 'invitation_accept',
+    account_role: 'manager',
+    invited_to_org_id: null,
+  }));
+
+  expect(posthog.capture).toHaveBeenCalledWith('account_created', {
+    signup_path: 'invitation_accept',
+    account_role: 'manager',
+    invited_to_org_id: null,
+  });
+  expect(posthog.capture).toHaveBeenCalledWith('team_member_joined', {
+    signup_path: 'invitation_accept',
+    account_role: 'manager',
+    invited_to_org_id: null,
+  });
+  expect(posthog.capture).not.toHaveBeenCalledWith('trial_started', expect.anything());
+});
+
+it('derives invitation_accept from /accept-invitation pathname when localStorage is empty', () => {
+  // Stub window.location.pathname for this test.
+  const originalLocation = window.location;
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: { ...originalLocation, pathname: '/accept-invitation' },
+  });
+
+  try {
+    recordAuthEvents({
+      userId: 'user-invite-fallback',
+      email: 'jose@example.com',
+      createdAt: RECENT_CREATED_AT,
+      posthog,
+      now: FIXED_NOW,
+    });
+
+    expect(posthog.capture).toHaveBeenCalledWith('account_created', {
+      signup_path: 'invitation_accept',
+      account_role: 'employee',
+      invited_to_org_id: null,
+    });
+    expect(posthog.capture).toHaveBeenCalledWith('team_member_joined', expect.objectContaining({
+      signup_path: 'invitation_accept',
+    }));
+    expect(posthog.capture).not.toHaveBeenCalledWith('trial_started', expect.anything());
+  } finally {
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: originalLocation,
+    });
+  }
+});
+
+it('clears signup_path localStorage keys on success alongside attribution', () => {
+  storeAttribution('?utm_source=google', '', '/auth');
+  storeSignupPath('invitation_accept', 'chef');
+
+  recordAuthEvents({
+    userId: 'user-cleanup',
+    email: 'jose@example.com',
+    createdAt: RECENT_CREATED_AT,
+    posthog,
+    now: FIXED_NOW,
+  });
+
+  expect(localStorage.getItem(ATTRIBUTION_STORAGE_KEY)).toBeNull();
+  expect(localStorage.getItem(SIGNUP_PATH_STORAGE_KEY)).toBeNull();
+  expect(localStorage.getItem(SIGNUP_ACCOUNT_ROLE_STORAGE_KEY)).toBeNull();
+  expect(localStorage.getItem(SIGNUP_INVITED_TO_ORG_ID_STORAGE_KEY)).toBeNull();
+});
+
+it('passes invited_to_org_id through when stored', () => {
+  storeSignupPath('invitation_accept', 'staff', 'org-xyz');
+
+  recordAuthEvents({
+    userId: 'user-org-id',
+    email: 'jose@example.com',
+    createdAt: RECENT_CREATED_AT,
+    posthog,
+    now: FIXED_NOW,
+  });
+
+  expect(posthog.capture).toHaveBeenCalledWith('account_created', {
+    signup_path: 'invitation_accept',
+    account_role: 'staff',
+    invited_to_org_id: 'org-xyz',
+  });
+});
+```
+
+- [ ] **Step 2.3: Run tests to verify they fail**
+
+Run: `npm test -- tests/unit/analytics.test.ts --run`
+Expected: The 4 new tests fail; the modified existing tests fail (because `recordAuthEvents` still fires the old shape). Other tests still pass.
+
+- [ ] **Step 2.4: Modify `recordAuthEvents` in `src/lib/analytics.ts`**
+
+Find the existing implementation (around line 134-168, the inside of the `try` block). Replace it with:
+
+```ts
+  try {
+    if (isRecentSignup && !flagAlreadySet) {
+      // Set the dedup flag BEFORE firing events so a partial failure
+      // (e.g. trial_started throws after account_created succeeds) doesn't
+      // re-fire account_created on the next session restore. account_created
+      // is a one-time signup signal — losing it on a transient outage is
+      // preferable to double-counting it.
+      try {
+        localStorage.setItem(accountCreatedFlagKey(userId), '1');
+      } catch {
+        // ignore
+      }
+
+      const attribution = getStoredAttribution();
+      const trialEndsAt = new Date(now.getTime() + TRIAL_DURATION_DAYS * 24 * 60 * 60 * 1000).toISOString();
+
+      // Classify signup path. The entry-page components (Auth.tsx for self-serve,
+      // AcceptInvitation.tsx for invites) write the signup_path/account_role keys
+      // to localStorage on mount. We fall back to deriving from the current pathname
+      // for the edge case where localStorage was unavailable at the entry-page mount.
+      const initialPathname =
+        typeof window !== 'undefined' && window.location ? window.location.pathname : '';
+      const classification = readStoredSignupClassification(initialPathname);
+
+      // Email is used locally to compute is_internal and then discarded —
+      // it is NOT forwarded to PostHog (PII minimization).
+      const safeEmail = email ?? null;
+      posthog.identify(userId, {
+        signup_source: attribution?.utm_source || attribution?.referrer || 'direct',
+        signup_medium: attribution?.utm_medium || 'organic',
+        signup_campaign: attribution?.utm_campaign ?? null,
+        is_internal: isInternalEmail(safeEmail),
+        ...classification,
+      });
+
+      posthog.capture('account_created', { ...classification });
+
+      // trial_started fires only for self-serve signups. Invited team members
+      // join an existing tenant's existing subscription/trial — they don't
+      // start their own. team_member_joined gives us a separate top-of-funnel
+      // for "team growth at existing customers" without polluting the prospect
+      // funnel.
+      if (classification.signup_path === 'self_serve') {
+        posthog.capture('trial_started', { trial_ends_at: trialEndsAt, ...classification });
+      } else {
+        posthog.capture('team_member_joined', { ...classification });
+      }
+
+      clearStoredAttribution();
+      clearStoredSignupPath();
+    } else {
+      posthog.identify(userId, {
+        last_login_at: now.toISOString(),
+      });
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error('[analytics] recordAuthEvents failed:', msg);
+  }
+```
+
+- [ ] **Step 2.5: Run tests to verify they pass**
+
+Run: `npm test -- tests/unit/analytics.test.ts --run`
+Expected: All `recordAuthEvents` tests pass — existing (modified) + 4 new. All `storeSignupPath` tests still pass. All other tests still pass.
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add src/lib/analytics.ts tests/unit/analytics.test.ts
+git commit -m "feat(analytics): tag signups with path/role/org_id, emit team_member_joined
+
+recordAuthEvents now reads the signup classification from localStorage (with
+/accept-invitation pathname fallback) and mirrors it onto posthog.identify
+person properties + the account_created event. trial_started fires only for
+self_serve; invitation_accept fires team_member_joined instead.
+
+Co-Authored-By: Jose Delgado <jose.delgado@easyshifthq.com>
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Tag self-serve path in `Auth.tsx`
+
+**Goal:** Have `/auth` write `signup_path: 'self_serve'`, `account_role: 'owner'` to localStorage on mount, gated by the existing `isOAuthCallback` check and a first-touch `!localStorage.getItem(...)` guard.
+
+**Files:**
+- Modify: `src/pages/Auth.tsx:18,31-44`
+
+- [ ] **Step 3.1: Update the import**
+
+In `src/pages/Auth.tsx`, change line 18:
+
+```ts
+import { storeAttribution } from '@/lib/analytics';
+```
+
+to:
+
+```ts
+import { SIGNUP_PATH_STORAGE_KEY, storeAttribution, storeSignupPath } from '@/lib/analytics';
+```
+
+- [ ] **Step 3.2: Extend the existing useEffect**
+
+Find the existing `useEffect` at line 31-44 and replace it with:
+
+```ts
+useEffect(() => {
+  // Auth.tsx is also the OAuth callback URI. We want first-touch UTMs and
+  // legitimate referrers (e.g. user clicked a link from a blog post with no
+  // UTM tags), but we DON'T want an OAuth redirect to capture the OAuth
+  // provider's domain as the referrer. The narrowest signal for that is the
+  // OAuth response params: providers always echo back `?code=…` on success
+  // and `?error=…` on denial. Skip those; storeAttribution itself takes care
+  // of first-touch preservation for the rest.
+  const params = new URLSearchParams(window.location.search);
+  const isOAuthCallback =
+    params.has('code') || params.has('error') || params.has('error_description');
+  if (isOAuthCallback) return;
+  storeAttribution(window.location.search, document.referrer, window.location.pathname);
+
+  // Tag the signup path so recordAuthEvents can disambiguate self-serve
+  // from invitation accepts. Only write if not already set (an
+  // /accept-invitation flow may have set it first; preserve first-touch).
+  if (!localStorage.getItem(SIGNUP_PATH_STORAGE_KEY)) {
+    storeSignupPath('self_serve', 'owner');
+  }
+}, []);
+```
+
+- [ ] **Step 3.3: Run typecheck and lint**
+
+Run: `npm run typecheck`
+Expected: No errors.
+
+Run: `npm run lint -- src/pages/Auth.tsx`
+Expected: No errors.
+
+- [ ] **Step 3.4: Commit**
+
+```bash
+git add src/pages/Auth.tsx
+git commit -m "feat(auth): tag self_serve signup path on /auth mount
+
+Writes signup_path='self_serve', signup_account_role='owner' to localStorage
+unless the path was already tagged (e.g. by /accept-invitation). Gated by the
+existing isOAuthCallback short-circuit so OAuth callback redirects don't
+clobber a prior tag.
+
+Co-Authored-By: Jose Delgado <jose.delgado@easyshifthq.com>
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Tag invitation_accept path in `AcceptInvitation.tsx`
+
+**Goal:** Have `/accept-invitation` write `signup_path: 'invitation_accept'` immediately on mount with default role `'employee'`, then re-write with the real role once the invitation validates.
+
+**Files:**
+- Modify: `src/pages/AcceptInvitation.tsx:14,41-45`
+
+- [ ] **Step 4.1: Update the import**
+
+In `src/pages/AcceptInvitation.tsx`, change line 14:
+
+```ts
+import { classifyInvitationError } from '@/lib/invitationUtils';
+```
+
+Add immediately after it:
+
+```ts
+import { storeSignupPath } from '@/lib/analytics';
+```
+
+- [ ] **Step 4.2: Add the tagging useEffect**
+
+Find the existing `useEffect` at lines 41-45:
+
+```ts
+useEffect(() => {
+  if (token) {
+    validateInvitation();
+  }
+}, [token]);
+```
+
+Add a new `useEffect` immediately after it (and before the `useEffect` that handles `[user, invitation, status]`):
+
+```ts
+useEffect(() => {
+  if (!token) return;
+  // Tag the signup path BEFORE auth completes so recordAuthEvents can
+  // distinguish invited employees from prospective customers. Use the
+  // invitation's role when known (e.g. 'manager', 'chef'); fall back to
+  // 'employee' while the invitation is still validating.
+  storeSignupPath('invitation_accept', invitation?.role ?? 'employee');
+}, [token, invitation?.role]);
+```
+
+- [ ] **Step 4.3: Run typecheck and lint**
+
+Run: `npm run typecheck`
+Expected: No errors.
+
+Run: `npm run lint -- src/pages/AcceptInvitation.tsx`
+Expected: No errors.
+
+- [ ] **Step 4.4: Commit**
+
+```bash
+git add src/pages/AcceptInvitation.tsx
+git commit -m "feat(invitation): tag invitation_accept signup path on mount
+
+Writes signup_path='invitation_accept' to localStorage as soon as the token
+query param is present, with default role 'employee'. Re-writes with the
+real role once the invitation validates.
+
+Co-Authored-By: Jose Delgado <jose.delgado@easyshifthq.com>
+Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Full-suite verification
+
+**Goal:** Confirm all tests pass and the project still builds.
+
+- [ ] **Step 5.1: Run all unit tests**
+
+Run: `npm test -- --run`
+Expected: All tests pass. No new failures elsewhere in the suite.
+
+- [ ] **Step 5.2: Typecheck**
+
+Run: `npm run typecheck`
+Expected: No errors.
+
+- [ ] **Step 5.3: Lint**
+
+Run: `npm run lint`
+Expected: No new errors. (Pre-existing warnings unchanged.)
+
+- [ ] **Step 5.4: Build**
+
+Run: `npm run build`
+Expected: Build succeeds.
+
+- [ ] **Step 5.5: If any of the above fail, fix and re-commit**
+
+Loop locally until green before proceeding to PR. Max 5 iterations per CLAUDE.md.
+
+---
+
+## Self-Review checklist
+
+- [x] Spec coverage: Every requirement in `2026-05-10-signup-path-attribution-design.md` maps to a Task (1=helpers, 2=recordAuthEvents+team_member_joined, 3=Auth, 4=AcceptInvitation, 5=verify).
+- [x] No placeholders: every code block is fully written.
+- [x] Type consistency: `SignupPath`, `SignupClassification`, `storeSignupPath`, `readStoredSignupClassification`, `clearStoredSignupPath` used consistently across tasks 1, 2, 3, 4.
+- [x] PII contract preserved: tests assert email not in identify props; no test or code adds email to event props.
+- [x] Atomic dedup preserved: `accountCreatedFlagKey` is set BEFORE any capture, including the new `team_member_joined`.
+- [x] First-touch preservation: `Auth.tsx` only writes if path key is absent; `AcceptInvitation.tsx` re-runs when `invitation.role` resolves so it can overwrite the default 'employee' with the real role.

--- a/docs/superpowers/specs/2026-05-10-signup-path-attribution-design.md
+++ b/docs/superpowers/specs/2026-05-10-signup-path-attribution-design.md
@@ -1,0 +1,204 @@
+# Signup-Path Attribution Design
+
+**Date:** 2026-05-10
+**Branch:** `fix/posthog-signup-path-attribution`
+**Brief reference:** Claude Code Brief — *Distinguish self-serve signups from team-invitation accepts* (filed by Jose Delgado, 2026-05-10).
+
+## Problem
+
+The PostHog `account_created` event fires for every new Supabase account, regardless of how the account was created. Today the signup path is only visible on **person properties** (`signup_medium`, `signup_source`, `$initial_pathname: /accept-invitation`) — NOT on the event itself, so funnel filters can't see it at the right time.
+
+A new `account_created` on 2026-05-10 03:39 UTC came from `/accept-invitation?token=…` and ended up on `/employee/schedule`. Master Funnel `iXyETFXb` counted that user against trial-→-paid conversion math even though they will never personally purchase a subscription. As more existing customers add seats, every invited employee further dilutes the prospect funnel.
+
+## Goal
+
+Tag every `account_created` event at capture time with three new event properties so saved funnels can filter directly:
+
+- `signup_path: 'self_serve' | 'invitation_accept'`
+- `account_role: string` (e.g. `'owner'`, `'manager'`, `'chef'`, `'staff'`, `'employee'`)
+- `invited_to_org_id: string | null` — `null` for now (the `validate-invitation` endpoint does not expose `restaurant_id` to the client; deferred to a follow-up PR)
+
+Branch by path:
+- `self_serve` continues to fire `trial_started` (with the same three props mixed in).
+- `invitation_accept` does **not** fire `trial_started` (an invited member joins an existing tenant's subscription/trial). Instead it fires a new event `team_member_joined` so we have a separate top-of-funnel for "team growth at existing customers."
+
+Mirror the props onto person properties so cohorting and downstream events inherit them.
+
+Out of scope: PostHog insight updates (separate AQ item via PostHog MCP), `is_internal` filter fix (AQ-013), `subscription_created` event (AQ-012), historical-event migration.
+
+## How the brief reconciles with the actual code
+
+The brief was written from a prior file map (`easyshifthq/proposed-changes/2026-05-07-04-nimble-pnl-posthog-events.md`). Three points have moved since:
+
+| Brief assumption | Reality | Decision |
+|---|---|---|
+| `account_created` captured inline in `useAuth.tsx`'s `onAuthStateChange('SIGNED_IN')` handler | Capture lives in `src/lib/analytics.ts`'s `recordAuthEvents()`, called from a `useEffect` in `useAuth.tsx`. Has a 5-min `NEW_SIGNUP_WINDOW_MS` (not 60s) and a per-user localStorage dedup flag. | Add classification logic to `recordAuthEvents`, not to `useAuth.tsx`. Keep `useAuth.tsx` untouched. |
+| `posthog.people.set(signupProps)` | The `PostHogLike` interface only declares `identify` and `capture`. The codebase already sets person properties via the second arg to `posthog.identify(distinctId, props)`. | Mirror props by extending the existing `identify` call: `posthog.identify(userId, { ...attribution, ...signupProps })`. No interface change. |
+| `account_created` carries `email` + `attribution` event props | Today `account_created` fires with no props (PII minimization for email; attribution is on `identify` only — see existing test `'PII: email is NOT forwarded to PostHog'`). | Add `signupProps` only to `account_created`. Do NOT forward email or attribution event props (preserve PII contract). |
+| `account_role` defaults to `'employee'` for invitations | The validated invitation already carries a `role` field (`'manager'`, `'chef'`, `'staff'`, etc.). | Use `invitation.role` when known; fall back to `'employee'` only while the invitation is still loading. |
+| `invited_to_org_id` exposed by validate-invitation | The current `validate-invitation` response returns `restaurant: { name, address }` — no `restaurant_id` on the client. | Send `null` this PR. The brief itself flagged this as optional. Backend exposure is a follow-up. |
+
+## Architecture
+
+### Data flow
+
+```
+Auth.tsx mount         → storeSignupPath('self_serve', 'owner')              ↘
+                                                                              localStorage signup_path keys
+AcceptInvitation mount → storeSignupPath('invitation_accept', role)          ↗
+                                                                                          ↓
+                                                  useAuth.tsx user resolves → recordAuthEvents
+                                                                                          ↓
+                            readStoredSignupClassification(window.location.pathname)
+                                                                                          ↓
+                identify(userId, { ...attribution, ...classification })
+                + capture('account_created', classification)
+                                                                                          ↓
+            self_serve         → capture('trial_started', { trial_ends_at, ...classification })
+            invitation_accept  → capture('team_member_joined', classification)
+                                                                                          ↓
+                                                  clearStoredSignupPath()  +  clearStoredAttribution()
+```
+
+### Files
+
+#### 1. `src/lib/analytics.ts` (extend)
+
+New exports:
+
+```ts
+export const SIGNUP_PATH_STORAGE_KEY = 'signup_path';
+export const SIGNUP_ACCOUNT_ROLE_STORAGE_KEY = 'signup_account_role';
+export const SIGNUP_INVITED_TO_ORG_ID_STORAGE_KEY = 'signup_invited_to_org_id';
+
+export type SignupPath = 'self_serve' | 'invitation_accept';
+
+export interface SignupClassification {
+  signup_path: SignupPath;
+  account_role: string;
+  invited_to_org_id: string | null;
+}
+
+export function storeSignupPath(
+  path: SignupPath,
+  accountRole: string,
+  invitedToOrgId?: string | null,
+): void;
+
+export function readStoredSignupClassification(
+  currentPathname: string,
+): SignupClassification;
+
+export function clearStoredSignupPath(): void;
+```
+
+Behavior:
+
+- `storeSignupPath` writes the three keys (treats `undefined` `invitedToOrgId` as no-write; explicit `null` is also no-write since we never want to broadcast `'null'` as a string). Wraps `setItem` in try/catch (analytics never blocks signup).
+- `readStoredSignupClassification(currentPathname)`:
+  - If localStorage has `signup_path === 'invitation_accept'`, OR the current pathname starts with `/accept-invitation`, classify as `invitation_accept`.
+  - Otherwise classify as `self_serve`.
+  - `account_role`: stored value if present; else `'employee'` for `invitation_accept` and `'owner'` for `self_serve`.
+  - `invited_to_org_id`: stored value if path is `invitation_accept`; else `null`.
+- `clearStoredSignupPath` removes all three keys, swallows any storage exception.
+
+Modify `recordAuthEvents` fresh-signup branch:
+
+```ts
+const initialPathname = typeof window !== 'undefined' ? window.location.pathname : '';
+const classification = readStoredSignupClassification(initialPathname);
+
+posthog.identify(userId, {
+  signup_source: ...,
+  signup_medium: ...,
+  signup_campaign: ...,
+  is_internal: ...,
+  ...classification,
+});
+
+posthog.capture('account_created', classification);
+
+if (classification.signup_path === 'self_serve') {
+  posthog.capture('trial_started', { trial_ends_at, ...classification });
+} else {
+  posthog.capture('team_member_joined', classification);
+}
+
+clearStoredAttribution();
+clearStoredSignupPath();
+```
+
+The atomic-dedup pattern (set the flag BEFORE firing events) is preserved unchanged.
+
+#### 2. `src/pages/Auth.tsx` (extend the existing `useEffect`)
+
+After the `isOAuthCallback` early return (which already gates `storeAttribution`), add:
+
+```ts
+if (!localStorage.getItem(SIGNUP_PATH_STORAGE_KEY)) {
+  storeSignupPath('self_serve', 'owner');
+}
+```
+
+This is gated by the same OAuth-callback bypass so an OAuth redirect to `/auth` does not reset a path that was already tagged by `AcceptInvitation`. The `!localStorage.getItem(...)` first-touch check is the second line of defense.
+
+Imports: `SIGNUP_PATH_STORAGE_KEY, storeSignupPath` from `@/lib/analytics`.
+
+#### 3. `src/pages/AcceptInvitation.tsx` (add a `useEffect`)
+
+```ts
+useEffect(() => {
+  if (!token) return;
+  storeSignupPath('invitation_accept', invitation?.role ?? 'employee');
+}, [token, invitation?.role]);
+```
+
+Runs on mount with default role `'employee'`, then re-runs once `invitation.role` resolves to overwrite with the real role (`'manager'`, `'chef'`, etc.).
+
+Imports: `storeSignupPath` from `@/lib/analytics`.
+
+#### 4. `tests/unit/analytics.test.ts` (extend)
+
+New `describe('storeSignupPath / readStoredSignupClassification / clearStoredSignupPath')`:
+1. `storeSignupPath('self_serve', 'owner')` writes the path and role keys; `invited_to_org_id` key absent.
+2. `storeSignupPath('invitation_accept', 'manager', 'org-123')` writes all three keys.
+3. `readStoredSignupClassification('/auth')` returns `self_serve` defaults when nothing stored.
+4. `readStoredSignupClassification('/accept-invitation?token=abc')` returns `invitation_accept` / `'employee'` / `null` even with empty localStorage (pathname fallback).
+5. `readStoredSignupClassification` returns stored values when present; pathname doesn't override.
+6. Stored `signup_path: 'invitation_accept'` with no role → `account_role: 'employee'` default.
+7. Stored `signup_path: 'self_serve'` returns `invited_to_org_id: null` even if a stale org id key is present (defensive against leftover state).
+8. `clearStoredSignupPath()` removes all three keys.
+9. `storeSignupPath` survives a `localStorage.setItem` that throws (no rethrow).
+
+Updated existing `recordAuthEvents` tests + new tests:
+- The "fires identify + account_created + trial_started" test asserts `account_created` and `trial_started` carry the default `self_serve / owner / null` classification, and `identify` props include `signup_path: 'self_serve'`.
+- New: `'classifies invitation_accept from localStorage and fires team_member_joined instead of trial_started'` — given stored `signup_path: 'invitation_accept'`, `account_role: 'manager'`, the test asserts:
+  - `account_created` carries `{signup_path: 'invitation_accept', account_role: 'manager', invited_to_org_id: null}`
+  - `team_member_joined` fires once with the same classification
+  - `trial_started` does NOT fire
+- New: `'derives invitation_accept from /accept-invitation pathname when localStorage is empty'` — empty localStorage, pass `now` and stub `window.location.pathname = '/accept-invitation'`. Assert classification is `invitation_accept / 'employee' / null`.
+- New: `'clears signup_path localStorage keys on success alongside attribution'` — after fresh signup, all three signup_path keys are gone.
+
+(The existing PII assertion `expect(identifyProps).not.toHaveProperty('email')` continues to hold — we don't add email anywhere.)
+
+## Open questions / risks
+
+- The pathname-fallback in `recordAuthEvents` is defensive belt-and-suspenders. If the entry-page `useEffect` always sets localStorage first, the fallback is unreachable. Keeping it costs nothing and protects against incognito edge cases where a localStorage write might silently fail.
+- `team_member_joined` is a new event name. Brief notes "flag if you'd prefer a different convention (`account_invitation_accepted`, etc.)." — easy to rename later.
+- Existing tests covering `account_created` / `trial_started` need updates to assert the new classification props. The diff is mechanical (~6 assertions).
+
+## Verification plan
+
+- Unit tests (vitest): all new + updated assertions pass.
+- TypeScript: `npm run typecheck` clean.
+- Lint: `npm run lint` clean.
+- Build: `npm run build` clean.
+- Manual smoke test in dev (per brief Edit 4): sign up self-serve → confirm `account_created` and `trial_started` carry `signup_path: 'self_serve'`. Open `/accept-invitation?token=…` → sign up via the invite flow → confirm `account_created` carries `signup_path: 'invitation_accept'` and `team_member_joined` fires (no `trial_started`).
+
+## Out of scope
+
+- PostHog insight filter updates (Jose will queue separately via PostHog MCP after this PR merges).
+- `is_internal` filter fix (AQ-013).
+- `subscription_created` event (AQ-012).
+- Historical-event migration. The 2026-05-10 03:39 UTC `account_created` remains unattributed; we accept that.
+- Exposing `restaurant_id` from `validate-invitation` (potential follow-up).

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -218,6 +218,14 @@ export function recordAuthEvents(options: RecordAuthEventsOptions): void {
       const attribution = getStoredAttribution();
       const trialEndsAt = new Date(now.getTime() + TRIAL_DURATION_DAYS * 24 * 60 * 60 * 1000).toISOString();
 
+      // Classify signup path. The entry-page components (Auth.tsx for self-serve,
+      // AcceptInvitation.tsx for invites) write the signup_path/account_role keys
+      // to localStorage on mount. Fall back to deriving from the current pathname
+      // for the edge case where localStorage was unavailable at entry-page mount.
+      const initialPathname =
+        typeof window !== 'undefined' && window.location ? window.location.pathname : '';
+      const classification = readStoredSignupClassification(initialPathname);
+
       // Email is used locally to compute is_internal and then discarded —
       // it is NOT forwarded to PostHog (PII minimization).
       const safeEmail = email ?? null;
@@ -226,12 +234,24 @@ export function recordAuthEvents(options: RecordAuthEventsOptions): void {
         signup_medium: attribution?.utm_medium || 'organic',
         signup_campaign: attribution?.utm_campaign ?? null,
         is_internal: isInternalEmail(safeEmail),
+        ...classification,
       });
 
-      posthog.capture('account_created');
-      posthog.capture('trial_started', { trial_ends_at: trialEndsAt });
+      posthog.capture('account_created', { ...classification });
+
+      // trial_started fires only for self-serve signups. Invited team members
+      // join an existing tenant's existing subscription/trial — they don't
+      // start their own. team_member_joined gives us a separate top-of-funnel
+      // for "team growth at existing customers" without polluting the prospect
+      // funnel.
+      if (classification.signup_path === 'self_serve') {
+        posthog.capture('trial_started', { trial_ends_at: trialEndsAt, ...classification });
+      } else {
+        posthog.capture('team_member_joined', { ...classification });
+      }
 
       clearStoredAttribution();
+      clearStoredSignupPath();
     } else {
       posthog.identify(userId, {
         last_login_at: now.toISOString(),

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -94,6 +94,77 @@ export function clearStoredAttribution(): void {
   }
 }
 
+export const SIGNUP_PATH_STORAGE_KEY = 'signup_path';
+export const SIGNUP_ACCOUNT_ROLE_STORAGE_KEY = 'signup_account_role';
+export const SIGNUP_INVITED_TO_ORG_ID_STORAGE_KEY = 'signup_invited_to_org_id';
+
+export type SignupPath = 'self_serve' | 'invitation_accept';
+
+export interface SignupClassification {
+  signup_path: SignupPath;
+  account_role: string;
+  invited_to_org_id: string | null;
+}
+
+const ACCEPT_INVITATION_PATHNAME_PREFIX = '/accept-invitation';
+
+function defaultRoleForPath(path: SignupPath): string {
+  return path === 'invitation_accept' ? 'employee' : 'owner';
+}
+
+export function storeSignupPath(
+  path: SignupPath,
+  accountRole: string,
+  invitedToOrgId?: string | null,
+): void {
+  try {
+    localStorage.setItem(SIGNUP_PATH_STORAGE_KEY, path);
+    localStorage.setItem(SIGNUP_ACCOUNT_ROLE_STORAGE_KEY, accountRole);
+    if (invitedToOrgId) {
+      localStorage.setItem(SIGNUP_INVITED_TO_ORG_ID_STORAGE_KEY, invitedToOrgId);
+    }
+  } catch {
+    // Storage disabled / quota exceeded — analytics must never block signup.
+  }
+}
+
+export function readStoredSignupClassification(currentPathname: string): SignupClassification {
+  let storedPath: string | null = null;
+  let storedRole: string | null = null;
+  let storedOrgId: string | null = null;
+  try {
+    storedPath = localStorage.getItem(SIGNUP_PATH_STORAGE_KEY);
+    storedRole = localStorage.getItem(SIGNUP_ACCOUNT_ROLE_STORAGE_KEY);
+    storedOrgId = localStorage.getItem(SIGNUP_INVITED_TO_ORG_ID_STORAGE_KEY);
+  } catch {
+    // Fall through to defaults.
+  }
+
+  const isInvitationByPathname =
+    typeof currentPathname === 'string' &&
+    currentPathname.startsWith(ACCEPT_INVITATION_PATHNAME_PREFIX);
+  const signup_path: SignupPath =
+    storedPath === 'invitation_accept' || isInvitationByPathname
+      ? 'invitation_accept'
+      : 'self_serve';
+
+  const account_role =
+    storedRole && storedRole.length > 0 ? storedRole : defaultRoleForPath(signup_path);
+  const invited_to_org_id = signup_path === 'invitation_accept' ? storedOrgId : null;
+
+  return { signup_path, account_role, invited_to_org_id };
+}
+
+export function clearStoredSignupPath(): void {
+  try {
+    localStorage.removeItem(SIGNUP_PATH_STORAGE_KEY);
+    localStorage.removeItem(SIGNUP_ACCOUNT_ROLE_STORAGE_KEY);
+    localStorage.removeItem(SIGNUP_INVITED_TO_ORG_ID_STORAGE_KEY);
+  } catch {
+    // Ignore
+  }
+}
+
 export const NEW_SIGNUP_WINDOW_MS = 5 * 60 * 1000;
 export const TRIAL_DURATION_DAYS = 14;
 const ACCOUNT_CREATED_FLAG_PREFIX = 'posthog_account_created_';

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -108,10 +108,6 @@ export interface SignupClassification {
 
 const ACCEPT_INVITATION_PATHNAME_PREFIX = '/accept-invitation';
 
-function defaultRoleForPath(path: SignupPath): string {
-  return path === 'invitation_accept' ? 'employee' : 'owner';
-}
-
 export function storeSignupPath(
   path: SignupPath,
   accountRole: string,
@@ -140,16 +136,14 @@ export function readStoredSignupClassification(currentPathname: string): SignupC
     // Fall through to defaults.
   }
 
-  const isInvitationByPathname =
-    typeof currentPathname === 'string' &&
-    currentPathname.startsWith(ACCEPT_INVITATION_PATHNAME_PREFIX);
+  const isInvitationByPathname = currentPathname.startsWith(ACCEPT_INVITATION_PATHNAME_PREFIX);
   const signup_path: SignupPath =
     storedPath === 'invitation_accept' || isInvitationByPathname
       ? 'invitation_accept'
       : 'self_serve';
 
-  const account_role =
-    storedRole && storedRole.length > 0 ? storedRole : defaultRoleForPath(signup_path);
+  const defaultRole = signup_path === 'invitation_accept' ? 'employee' : 'owner';
+  const account_role = storedRole || defaultRole;
   const invited_to_org_id = signup_path === 'invitation_accept' ? storedOrgId : null;
 
   return { signup_path, account_role, invited_to_org_id };
@@ -222,8 +216,7 @@ export function recordAuthEvents(options: RecordAuthEventsOptions): void {
       // AcceptInvitation.tsx for invites) write the signup_path/account_role keys
       // to localStorage on mount. Fall back to deriving from the current pathname
       // for the edge case where localStorage was unavailable at entry-page mount.
-      const initialPathname =
-        typeof window !== 'undefined' && window.location ? window.location.pathname : '';
+      const initialPathname = typeof window !== 'undefined' ? window.location.pathname : '';
       const classification = readStoredSignupClassification(initialPathname);
 
       // Email is used locally to compute is_internal and then discarded —

--- a/src/pages/AcceptInvitation.tsx
+++ b/src/pages/AcceptInvitation.tsx
@@ -12,6 +12,7 @@ import { CheckCircle, XCircle, Clock, Users, Building, ArrowLeft } from 'lucide-
 import { GoogleSignInButton } from '@/components/GoogleSignInButton';
 import { Separator } from '@/components/ui/separator';
 import { classifyInvitationError } from '@/lib/invitationUtils';
+import { storeSignupPath } from '@/lib/analytics';
 
 interface InvitationDetails {
   email: string;
@@ -43,6 +44,15 @@ export function AcceptInvitation() {
       validateInvitation();
     }
   }, [token]);
+
+  useEffect(() => {
+    if (!token) return;
+    // Tag the signup path BEFORE auth completes so recordAuthEvents can
+    // distinguish invited employees from prospective customers. Use the
+    // invitation's role when known (e.g. 'manager', 'chef'); fall back to
+    // 'employee' while the invitation is still validating.
+    storeSignupPath('invitation_accept', invitation?.role ?? 'employee');
+  }, [token, invitation?.role]);
 
   useEffect(() => {
     if (user && invitation && user.email === invitation.email) {

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -15,7 +15,7 @@ import { Building, ArrowRight, Shield } from 'lucide-react';
 import { AppLogo } from '@/components/AppLogo';
 import { supabase } from '@/integrations/supabase/client';
 import { signInWithOAuthNative } from '@/utils/nativeRedirect';
-import { storeAttribution } from '@/lib/analytics';
+import { SIGNUP_PATH_STORAGE_KEY, storeAttribution, storeSignupPath } from '@/lib/analytics';
 
 const Auth = () => {
   const [email, setEmail] = useState('');
@@ -41,6 +41,13 @@ const Auth = () => {
       params.has('code') || params.has('error') || params.has('error_description');
     if (isOAuthCallback) return;
     storeAttribution(window.location.search, document.referrer, window.location.pathname);
+
+    // Tag the signup path so recordAuthEvents can disambiguate self-serve
+    // from invitation accepts. Only write if not already set — an
+    // /accept-invitation flow may have set it first; preserve first-touch.
+    if (!localStorage.getItem(SIGNUP_PATH_STORAGE_KEY)) {
+      storeSignupPath('self_serve', 'owner');
+    }
   }, []);
 
   useEffect(() => {

--- a/tests/unit/analytics.test.ts
+++ b/tests/unit/analytics.test.ts
@@ -3,17 +3,23 @@ import {
   ATTRIBUTION_STORAGE_KEY,
   INTERNAL_DOMAINS,
   NEW_SIGNUP_WINDOW_MS,
+  SIGNUP_ACCOUNT_ROLE_STORAGE_KEY,
+  SIGNUP_INVITED_TO_ORG_ID_STORAGE_KEY,
+  SIGNUP_PATH_STORAGE_KEY,
   TRIAL_DURATION_DAYS,
   accountCreatedFlagKey,
   clearStoredAttribution,
+  clearStoredSignupPath,
   firstPnlViewedFlagKey,
   getStoredAttribution,
   isInternalEmail,
   posIntegrationCompletedFlagKey,
+  readStoredSignupClassification,
   recordAuthEvents,
   recordFirstPnlViewed,
   recordPosIntegrationCompleted,
   storeAttribution,
+  storeSignupPath,
 } from '../../src/lib/analytics';
 
 describe('isInternalEmail', () => {
@@ -170,6 +176,95 @@ describe('storeAttribution / getStoredAttribution / clearStoredAttribution', () 
     expect(() => storeAttribution('?utm_source=google', '', '/auth')).not.toThrow();
     setItemMock.mockRestore();
     Storage.prototype.setItem = original;
+  });
+});
+
+describe('storeSignupPath / readStoredSignupClassification / clearStoredSignupPath', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('storeSignupPath writes path and role keys', () => {
+    storeSignupPath('self_serve', 'owner');
+    expect(localStorage.getItem(SIGNUP_PATH_STORAGE_KEY)).toBe('self_serve');
+    expect(localStorage.getItem(SIGNUP_ACCOUNT_ROLE_STORAGE_KEY)).toBe('owner');
+    expect(localStorage.getItem(SIGNUP_INVITED_TO_ORG_ID_STORAGE_KEY)).toBeNull();
+  });
+
+  it('storeSignupPath writes invited_to_org_id when provided', () => {
+    storeSignupPath('invitation_accept', 'manager', 'org-123');
+    expect(localStorage.getItem(SIGNUP_PATH_STORAGE_KEY)).toBe('invitation_accept');
+    expect(localStorage.getItem(SIGNUP_ACCOUNT_ROLE_STORAGE_KEY)).toBe('manager');
+    expect(localStorage.getItem(SIGNUP_INVITED_TO_ORG_ID_STORAGE_KEY)).toBe('org-123');
+  });
+
+  it('storeSignupPath does not write invited_to_org_id when null is passed', () => {
+    storeSignupPath('invitation_accept', 'employee', null);
+    expect(localStorage.getItem(SIGNUP_INVITED_TO_ORG_ID_STORAGE_KEY)).toBeNull();
+  });
+
+  it('readStoredSignupClassification returns self_serve defaults when nothing stored', () => {
+    const result = readStoredSignupClassification('/auth');
+    expect(result).toEqual({
+      signup_path: 'self_serve',
+      account_role: 'owner',
+      invited_to_org_id: null,
+    });
+  });
+
+  it('readStoredSignupClassification derives invitation_accept from /accept-invitation pathname', () => {
+    const result = readStoredSignupClassification('/accept-invitation?token=abc');
+    expect(result).toEqual({
+      signup_path: 'invitation_accept',
+      account_role: 'employee',
+      invited_to_org_id: null,
+    });
+  });
+
+  it('readStoredSignupClassification returns stored values when present', () => {
+    storeSignupPath('invitation_accept', 'manager', 'org-456');
+    const result = readStoredSignupClassification('/auth');
+    expect(result).toEqual({
+      signup_path: 'invitation_accept',
+      account_role: 'manager',
+      invited_to_org_id: 'org-456',
+    });
+  });
+
+  it('readStoredSignupClassification: invitation_accept without role falls back to employee', () => {
+    localStorage.setItem(SIGNUP_PATH_STORAGE_KEY, 'invitation_accept');
+    const result = readStoredSignupClassification('/auth');
+    expect(result.signup_path).toBe('invitation_accept');
+    expect(result.account_role).toBe('employee');
+  });
+
+  it('readStoredSignupClassification: self_serve always returns null org id even with stale value', () => {
+    // Defensive: a stale invited_to_org_id key from a prior incomplete flow
+    // should not leak into a self_serve classification.
+    localStorage.setItem(SIGNUP_INVITED_TO_ORG_ID_STORAGE_KEY, 'stale-org');
+    const result = readStoredSignupClassification('/auth');
+    expect(result.signup_path).toBe('self_serve');
+    expect(result.invited_to_org_id).toBeNull();
+  });
+
+  it('clearStoredSignupPath removes all three keys', () => {
+    storeSignupPath('invitation_accept', 'manager', 'org-789');
+    clearStoredSignupPath();
+    expect(localStorage.getItem(SIGNUP_PATH_STORAGE_KEY)).toBeNull();
+    expect(localStorage.getItem(SIGNUP_ACCOUNT_ROLE_STORAGE_KEY)).toBeNull();
+    expect(localStorage.getItem(SIGNUP_INVITED_TO_ORG_ID_STORAGE_KEY)).toBeNull();
+  });
+
+  it('storeSignupPath survives a localStorage that throws on setItem (no rethrow)', () => {
+    const setItemMock = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('quota exceeded');
+    });
+    expect(() => storeSignupPath('self_serve', 'owner')).not.toThrow();
+    setItemMock.mockRestore();
   });
 });
 

--- a/tests/unit/analytics.test.ts
+++ b/tests/unit/analytics.test.ts
@@ -301,15 +301,27 @@ describe('recordAuthEvents', () => {
       signup_medium: 'cpc',
       signup_campaign: 'launch',
       is_internal: false,
+      signup_path: 'self_serve',
+      account_role: 'owner',
+      invited_to_org_id: null,
     }));
     // PII: email is NOT forwarded to PostHog
     const identifyProps = posthog.identify.mock.calls[0][1];
     expect(identifyProps).not.toHaveProperty('email');
 
     expect(posthog.capture).toHaveBeenCalledTimes(2);
-    expect(posthog.capture).toHaveBeenCalledWith('account_created');
+    expect(posthog.capture).toHaveBeenCalledWith('account_created', {
+      signup_path: 'self_serve',
+      account_role: 'owner',
+      invited_to_org_id: null,
+    });
     const trialEndsAt = new Date(FIXED_NOW.getTime() + TRIAL_DURATION_DAYS * 24 * 60 * 60 * 1000).toISOString();
-    expect(posthog.capture).toHaveBeenCalledWith('trial_started', { trial_ends_at: trialEndsAt });
+    expect(posthog.capture).toHaveBeenCalledWith('trial_started', {
+      trial_ends_at: trialEndsAt,
+      signup_path: 'self_serve',
+      account_role: 'owner',
+      invited_to_org_id: null,
+    });
 
     expect(localStorage.getItem(accountCreatedFlagKey('user-1'))).toBeTruthy();
     expect(localStorage.getItem(ATTRIBUTION_STORAGE_KEY)).toBeNull();
@@ -425,7 +437,11 @@ describe('recordAuthEvents', () => {
     // PII: email is NOT forwarded to PostHog even when null
     const identifyProps = posthog.identify.mock.calls[0][1];
     expect(identifyProps).not.toHaveProperty('email');
-    expect(posthog.capture).toHaveBeenCalledWith('account_created');
+    expect(posthog.capture).toHaveBeenCalledWith('account_created', {
+      signup_path: 'self_serve',
+      account_role: 'owner',
+      invited_to_org_id: null,
+    });
   });
 
   it('survives if posthog.capture throws (no rethrow)', () => {
@@ -473,6 +489,106 @@ describe('recordAuthEvents', () => {
     });
     expect(posthog.capture).not.toHaveBeenCalledWith('account_created', expect.anything());
     expect(posthog.capture).not.toHaveBeenCalledWith('account_created');
+  });
+
+  it('classifies invitation_accept from localStorage and fires team_member_joined instead of trial_started', () => {
+    storeSignupPath('invitation_accept', 'manager');
+
+    recordAuthEvents({
+      userId: 'user-invite-1',
+      email: 'jose@example.com',
+      createdAt: RECENT_CREATED_AT,
+      posthog,
+      now: FIXED_NOW,
+    });
+
+    expect(posthog.identify).toHaveBeenCalledWith('user-invite-1', expect.objectContaining({
+      signup_path: 'invitation_accept',
+      account_role: 'manager',
+      invited_to_org_id: null,
+    }));
+
+    expect(posthog.capture).toHaveBeenCalledWith('account_created', {
+      signup_path: 'invitation_accept',
+      account_role: 'manager',
+      invited_to_org_id: null,
+    });
+    expect(posthog.capture).toHaveBeenCalledWith('team_member_joined', {
+      signup_path: 'invitation_accept',
+      account_role: 'manager',
+      invited_to_org_id: null,
+    });
+    expect(posthog.capture).not.toHaveBeenCalledWith('trial_started', expect.anything());
+  });
+
+  it('derives invitation_accept from /accept-invitation pathname when localStorage is empty', () => {
+    // Stub window.location.pathname for this test.
+    const originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...originalLocation, pathname: '/accept-invitation' },
+    });
+
+    try {
+      recordAuthEvents({
+        userId: 'user-invite-fallback',
+        email: 'jose@example.com',
+        createdAt: RECENT_CREATED_AT,
+        posthog,
+        now: FIXED_NOW,
+      });
+
+      expect(posthog.capture).toHaveBeenCalledWith('account_created', {
+        signup_path: 'invitation_accept',
+        account_role: 'employee',
+        invited_to_org_id: null,
+      });
+      expect(posthog.capture).toHaveBeenCalledWith('team_member_joined', expect.objectContaining({
+        signup_path: 'invitation_accept',
+      }));
+      expect(posthog.capture).not.toHaveBeenCalledWith('trial_started', expect.anything());
+    } finally {
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: originalLocation,
+      });
+    }
+  });
+
+  it('clears signup_path localStorage keys on success alongside attribution', () => {
+    storeAttribution('?utm_source=google', '', '/auth');
+    storeSignupPath('invitation_accept', 'chef');
+
+    recordAuthEvents({
+      userId: 'user-cleanup',
+      email: 'jose@example.com',
+      createdAt: RECENT_CREATED_AT,
+      posthog,
+      now: FIXED_NOW,
+    });
+
+    expect(localStorage.getItem(ATTRIBUTION_STORAGE_KEY)).toBeNull();
+    expect(localStorage.getItem(SIGNUP_PATH_STORAGE_KEY)).toBeNull();
+    expect(localStorage.getItem(SIGNUP_ACCOUNT_ROLE_STORAGE_KEY)).toBeNull();
+    expect(localStorage.getItem(SIGNUP_INVITED_TO_ORG_ID_STORAGE_KEY)).toBeNull();
+  });
+
+  it('passes invited_to_org_id through when stored', () => {
+    storeSignupPath('invitation_accept', 'staff', 'org-xyz');
+
+    recordAuthEvents({
+      userId: 'user-org-id',
+      email: 'jose@example.com',
+      createdAt: RECENT_CREATED_AT,
+      posthog,
+      now: FIXED_NOW,
+    });
+
+    expect(posthog.capture).toHaveBeenCalledWith('account_created', {
+      signup_path: 'invitation_accept',
+      account_role: 'staff',
+      invited_to_org_id: 'org-xyz',
+    });
   });
 });
 


### PR DESCRIPTION
## Summary
- Tag every PostHog `account_created` event at capture time with `signup_path` / `account_role` / `invited_to_org_id` so saved funnels can filter directly without relying on person properties or query-time joins.
- Suppress `trial_started` for invitation accepts (invited employees join an existing tenant's subscription, not start their own); emit a new `team_member_joined` event instead so we have a separate top-of-funnel for team growth.
- Tag self-serve flows on `/auth` mount and invitation flows on `/accept-invitation` mount via `localStorage`, with a `/accept-invitation` pathname fallback inside `recordAuthEvents` for incognito edge cases.

## What this fixes
On 2026-05-10 03:39 UTC an `account_created` fired from a user who landed on `/accept-invitation?token=…` and is now sitting on `/employee/schedule`. Master Funnel `iXyETFXb` was counting that invited employee against trial→paid conversion, diluting prospect-funnel math. After this PR every `account_created` carries the path it came from, and `team_member_joined` gives team-growth a separate event to filter on.

## Out of scope (per brief)
- Don't update PostHog insights from this PR — funnel updates are a follow-up.
- `is_internal` filter is unchanged.
- No `subscription_created` event yet.
- No backfill of historical events.
- `invited_to_org_id` always `null` this PR — `validate-invitation` doesn't expose `restaurant_id` to the client; backend exposure is a follow-up.

## Test plan
- [x] Unit tests: 58 analytics tests + 3785 full suite (`TZ=UTC npm run test`); all green.
- [x] Typecheck clean (`npm run typecheck`).
- [x] Build green (`npm run build`, 12.68s).
- [x] Lint: no new errors on changed files (`npm run lint` baseline unchanged).
- [ ] Manual smoke (post-merge in staging): self-serve signup → confirm `account_created` and `trial_started` carry `signup_path: 'self_serve'`. Invitation signup via `/accept-invitation?token=…` → confirm `account_created` carries `signup_path: 'invitation_accept'` and `team_member_joined` fires (no `trial_started`).

## Design / plan
- Spec: `docs/superpowers/specs/2026-05-10-signup-path-attribution-design.md`
- Plan: `docs/superpowers/plans/2026-05-10-signup-path-attribution-plan.md`