### PR TITLE
fix(dashboard): align May totals across Performance Overview, Monthly Performance, and POS Sales

### DIFF
--- a/docs/superpowers/plans/2026-05-10-dashboard-may-discrepancy-plan.md
+++ b/docs/superpowers/plans/2026-05-10-dashboard-may-discrepancy-plan.md
@@ -1,0 +1,155 @@
+# Plan — Dashboard May 2026 cross-view consistency (Russo's Pizzeria)
+
+**Branch:** `worktree-dashboard-may-discrepancy`
+**Author:** Claude (Opus 4.7) on behalf of Jose
+**Date:** 2026-05-10
+
+## Context
+
+For Russo's (timezone `America/Chicago`) on the May 2026 view, four UI surfaces show divergent numbers for the same month:
+
+| Surface | Collected at POS | COGS | Actual labor |
+|---|---|---|---|
+| Performance Overview (`usePeriodMetrics`) | n/a | **$4,004** ✓ | **$9,422** ✓ |
+| Monthly Performance row (`useMonthlyMetrics`) | **$32,951** ✗ | **$3,787** ✗ | **$9,031** ✗ |
+| POS Sales page (`useUnifiedSalesTotals`) | **$31,596.36** ✓ | n/a | n/a |
+| Cashflow viz (`useCashFlowMetrics`) | n/a | n/a | n/a |
+
+Production (queried via Supabase MCP) confirms the source-of-truth:
+
+- `SUM(unified_sales.total_price)` for May 2026 = **$31,596.36**
+- Bank-financial COGS for May 2026 = **$4,003.73** (10 bank rows on May 1 alone, $216.75 of which is COGS — exactly the $217 missing from Monthly Perf)
+- Gross revenue (positive item rows) = **$26,903.04**, Net = **$26,278.00**
+
+User decision (already collected): **"Collected at POS" should match the deposit** — i.e. `SUM(unified_sales.total_price)` over the period, including void / discount offsets. This is what `get_unified_sales_totals` already returns and what the POS Sales page already shows.
+
+## Three root causes
+
+### 1. Timezone bucketing in shared COGS aggregator
+`src/services/cogsCalculations.ts:105` and `:116` build the daily date key with:
+```typescript
+const date = format(new Date(txn.transaction_date), 'yyyy-MM-dd');
+```
+`bank_transactions.transaction_date` is `TIMESTAMPTZ` and rows arrive as ISO strings like `'2026-05-01T00:00:00+00:00'`. `new Date(...)` creates a UTC instant; `format()` then renders in the host timezone. For Russo's Chicago user this turns `2026-05-01 00:00 UTC` into `'2026-04-30'`, shoving the May 1 COGS row ($216.75) into April's bucket. The `parentDateMap` build in `useCOGSFromFinancials.tsx:99` and `useMonthlyMetrics.tsx:275` has the same shape.
+
+### 2. Timezone bucketing in `useMonthlyMetrics` labor
+`src/hooks/useMonthlyMetrics.tsx:136-154` defines `normalizeToLocalDate` which calls `new Date(rawDate)` then `getFullYear/Month/Date()`. Same shift on the same TIMESTAMPTZ data. Result: rows that occurred on a UTC business date land in the prior local month if their UTC midnight falls before local midnight. `useLaborCostsFromTransactions.tsx:91` (used by Performance Overview) deliberately keeps the raw string as the date key — so it doesn't have the bug. Monthly Perf does.
+
+### 3. "Collected at POS" formula divergence
+`useMonthlyMetrics.fetchMonthRevenueTotals` (lines 100-101) and `useRevenueBreakdown` (lines 349 / 716) compute:
+```text
+collected_at_pos = gross + tax + tips + service_charge + fee
+```
+That excludes the discount/void offset rows that actually reduce the deposit. `get_unified_sales_totals` returns `SUM(total_price)`, which is the deposit. For May Russo's, the difference is exactly `−$625.04 (discounts) − $729.40 (voids) = −$1,354.44 → $32,950.80 vs $31,596.36`.
+
+## Goal
+
+Make the same period (e.g. May 1–31 2026) produce identical values for `collected_at_pos`, `cogs`, and `actual_labor` across `usePeriodMetrics`, `useMonthlyMetrics`, `useRevenueBreakdown`, and `useUnifiedSalesTotals`. Pin Russo's May 2026 production numbers in tests.
+
+Out of scope: cashflow visualization (uses bank-only inflow/outflow, a different metric). The user listed it for cross-reference, not numeric equivalence.
+
+## Acceptance criteria
+
+For the May 1–31 2026 window on Russo's:
+
+| Metric | Expected | Tolerance |
+|---|---|---|
+| `useMonthlyMetrics[May].total_collected_at_pos` | **$31,596.36** | ±$0.01 |
+| `useRevenueBreakdown.totals.total_collected_at_pos` | **$31,596.36** | ±$0.01 |
+| `useUnifiedSalesTotals.collectedAtPOS` (POS Sales page) | **$31,596.36** | unchanged |
+| `useMonthlyMetrics[May].food_cost` | **$4,003.73** | ±$0.01 |
+| `useMonthlyMetrics[May].actual_labor_cost` | matches `useLaborCostsFromTransactions.totalCost` | ±$0.01 |
+| `useMonthlyMetrics[April].food_cost` | does **not** include the May 1 $216.75 row | ±$0.01 |
+
+Plus existing breakdown values (gross $26,903.04, discounts $625.04, net $26,278.00) remain unchanged.
+
+Lint, typecheck, and the existing test suites must remain green.
+
+## Approach
+
+### Phase A — TZ fix (low-risk, surgical)
+
+1. **`src/services/cogsCalculations.ts`** — replace both `format(new Date(txn.transaction_date), 'yyyy-MM-dd')` and `format(new Date(parent.transaction_date), 'yyyy-MM-dd')` with the raw 10-char prefix:
+   ```typescript
+   const date = txn.transaction_date.slice(0, 10);
+   ```
+   Add a small guard so non-string inputs (already a `yyyy-MM-dd` DATE string from `pending_outflows.issue_date`) pass through unchanged. Drop the unused `format` / `date-fns` imports if any become unused.
+
+2. **`src/hooks/useCOGSFromFinancials.tsx:99`** — replace the `parentDateMap` build with `parent.transaction_date.slice(0, 10)`.
+
+3. **`src/hooks/useMonthlyMetrics.tsx`**:
+   - In the financial-COGS section (line 275), build `parentDateMap` with `.slice(0, 10)` instead of `format(new Date(...), 'yyyy-MM-dd')`.
+   - In the bank/pending labor sections (lines 513-538), replace `normalizeToLocalDate(...)` with a direct `monthKey = txn.transaction_date.slice(0, 7)` (and `txn.issue_date.slice(0, 7)` for pending). Delete `normalizeToLocalDate` entirely if it has no other callers.
+
+Why slice and not the host TZ? `transaction_date` for bank rows is a banking business-date stored at `00:00:00 UTC` by Plaid/Stripe FC. The user reads "May 1" off their bank statement and expects "May 1" on the dashboard. The UTC date is the canonical bucket. `useLaborCostsFromTransactions` and `useUnifiedCOGS` already do this implicitly by keeping the raw string.
+
+### Phase B — Standardize "Collected at POS"
+
+1. **`fetchMonthRevenueTotals` (`src/hooks/useMonthlyMetrics.tsx:54-112`)**: add a third parallel call to `get_unified_sales_totals(p_restaurant_id, p_start_date, p_end_date, p_search_term=null)` and overwrite `posCollectedCents` with `toC(result.collected_at_pos)`. Keep the other RPC results for gross/discounts/tax/tips/other (those values are correct and used by the breakdown column).
+
+2. **`useRevenueBreakdown.tsx`** — update both the RPC-path (line 349) and the fallback path (line 716) `totalCollectedAtPOS` calculation:
+   - Best path: also call `get_unified_sales_totals` and use its `collected_at_pos` value as `total_collected_at_pos` in the returned `totals` object.
+   - Fallback path: mirror the RPC formula — `SUM(unified_sales.total_price) over the period` directly when fetching from the table.
+
+3. Document the contract at the top of both hooks: "`total_collected_at_pos` is the deposit-matching SUM over `unified_sales.total_price` for the period; it intentionally includes void and discount offset rows."
+
+### Phase C — Tests pinning the production numbers
+
+Three new unit tests under `tests/unit/` (Vitest):
+
+1. **`cogsCalculations.tz.test.ts`** — given a fixture with `transaction_date='2026-05-01T00:00:00+00:00'` and amount $-216.75, force the host TZ to `America/Chicago`, expect `aggregateFinancialCOGSByDate(...).get('2026-05-01') === 216.75` (red before the fix; green after).
+
+2. **`useMonthlyMetrics.collected.test.ts`** (or extension to existing) — mock the three RPCs to return the production values for Russo's May, assert `total_collected_at_pos === 31596.36`, `food_cost === 4003.73`, `net_revenue === 26278.00`.
+
+3. **`useRevenueBreakdown.collected.test.ts`** — mock the same RPCs, assert `totals.total_collected_at_pos === 31596.36`.
+
+If `process.env.TZ` doesn't propagate cleanly in Vitest, fall back to a `vi.setSystemTime` + `Intl.DateTimeFormat` resolved-options check, or use `@vitest/utils` to mock `Date#getTimezoneOffset`. We can also set `TZ=America/Chicago` in the npm test command for these specific tests via a separate Vitest project.
+
+### Phase D — Verify in browser
+
+After tests are green, start `npm run dev` and load the dashboard while logged in as a Russo's user. With "This Month" period selected (today is 2026-05-10, so range = May 1 → today):
+
+- Performance Overview: COGS card should remain $4,004; labor card should remain $9,422 (unchanged — those were already correct).
+- Monthly Performance row for May: COGS column should change from $3,787 → $4,004; Labor "Actual" should move toward $9,422; "Collected at POS" should change from $32,951 → $31,596.
+- POS Sales page filtered to May: Collected $31,596.36 unchanged.
+
+If the user's session can't easily filter the POS Sales page to a full May window inside the dev server (date pickers may default to today), record the test as a Vitest acceptance instead and call out in the PR description that visual verification was done against the existing data.
+
+## File-level change list
+
+| File | Change |
+|---|---|
+| `src/services/cogsCalculations.ts` | `slice(0,10)` instead of `format(new Date(...), 'yyyy-MM-dd')`; remove unused `format` import |
+| `src/hooks/useCOGSFromFinancials.tsx` | Same fix in `parentDateMap` build |
+| `src/hooks/useMonthlyMetrics.tsx` | Same fix in `parentDateMap`; remove `normalizeToLocalDate`; replace labor txn bucketing with `.slice(0,7)`; add `get_unified_sales_totals` call to `fetchMonthRevenueTotals` and overwrite `posCollectedCents` |
+| `src/hooks/useRevenueBreakdown.tsx` | Use `get_unified_sales_totals.collected_at_pos` for `total_collected_at_pos` (both RPC + fallback paths) |
+| `tests/unit/cogsCalculations.tz.test.ts` | NEW — pin TZ bucketing |
+| `tests/unit/useMonthlyMetrics.collected.test.ts` | NEW — pin Russo's May numbers |
+| `tests/unit/useRevenueBreakdown.collected.test.ts` | NEW — pin Russo's May numbers |
+
+No DB migrations. No edge function changes. RPCs are already in place.
+
+## Risks & rollback
+
+- **Risk**: `get_unified_sales_totals` does not currently expose category/account-level breakdown — but we only need its `collected_at_pos` field. Other fields stay sourced from `get_revenue_by_account` + `get_pass_through_totals`. Low risk.
+- **Risk**: A restaurant in a UTC+ timezone with bank rows at 00:00 UTC could see *different* (potentially still wrong) bucketing. Mitigated because slice always uses the UTC date, which is also what Plaid sends. We're standardizing on UTC date as the canonical bucket and documenting this.
+- **Risk**: Removing `normalizeToLocalDate` could affect other callers. Verified — it's defined inline inside `useMonthlyMetrics.queryFn` so no external callers.
+- **Rollback**: Revert the merge commit. No data is mutated; this is presentation-layer only.
+
+## Out of scope
+
+- Cashflow viz consistency (uses bank-only flows, separate metric).
+- April retroactive correction (the bug was *moving* a row's bucket; once fixed, April will lose the misattributed $216.75 — that's the desired behavior, not a separate fix).
+- Tip-credit and OT-D labor logic (already validated by PR #485 series).
+- Schema changes to `bank_transactions.transaction_date` (would require a separate migration; out of scope for this fix).
+
+## Build sequence
+
+1. Phase C tests first (red-first TDD).
+2. Phase A TZ fixes → tests for COGS/labor go green.
+3. Phase B Collected-at-POS standardization → tests for collected go green.
+4. Phase D verify in browser; spot-check April loses the $217.
+5. Run `npm run typecheck`, `npm run lint`, `npm run test`.
+6. code-simplifier agent on diff.
+7. feature-dev:code-reviewer agent on diff.
+8. PR + CI loop.

--- a/src/hooks/useCOGSFromFinancials.tsx
+++ b/src/hooks/useCOGSFromFinancials.tsx
@@ -1,7 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { format } from 'date-fns';
-import { aggregateFinancialCOGSByDate, type BankTransactionRow, type PendingOutflowRow, type SplitItemRow } from '@/services/cogsCalculations';
+import {
+  aggregateFinancialCOGSByDate,
+  toUtcDayKey,
+  type BankTransactionRow,
+  type PendingOutflowRow,
+  type SplitItemRow,
+} from '@/services/cogsCalculations';
 
 export interface FinancialCOGSData {
   date: string;
@@ -93,11 +99,13 @@ export function useCOGSFromFinancials(
         splitItems = (splits || []) as typeof splitItems;
       }
 
-      // Build a lookup for split parent dates
+      // Build a lookup for split parent dates.
+      // Use the canonical UTC day key so split items bucket the same way as the
+      // direct bank-txn rows (see toUtcDayKey for the TZ rationale).
       const parentDateMap = new Map<string, string>();
-      (splitParents || []).forEach((p) => {
-        parentDateMap.set(p.id, format(new Date(p.transaction_date), 'yyyy-MM-dd'));
-      });
+      for (const p of splitParents || []) {
+        parentDateMap.set(p.id, toUtcDayKey(p.transaction_date));
+      }
 
       // ---------------------------------------------------------------
       // Source 3: Pending outflows (unmatched) categorised as COGS

--- a/src/hooks/useMonthlyMetrics.tsx
+++ b/src/hooks/useMonthlyMetrics.tsx
@@ -5,6 +5,7 @@ import { calculateActualLaborCostForMonth } from '@/services/laborCalculations';
 import {
   aggregateInventoryCOGSByDate,
   aggregateFinancialCOGSByDate,
+  toUtcDayKey,
   type BankTransactionRow,
   type PendingOutflowRow,
   type SplitItemRow,
@@ -57,7 +58,11 @@ export async function fetchMonthRevenueTotals(
   fromStr: string,
   toStr: string
 ): Promise<MonthRevenueTotals> {
-  const [{ data: revRows, error: revErr }, { data: passRows, error: passErr }] = await Promise.all([
+  const [
+    { data: revRows, error: revErr },
+    { data: passRows, error: passErr },
+    { data: unifiedRows, error: unifiedErr },
+  ] = await Promise.all([
     client.rpc('get_revenue_by_account', {
       p_restaurant_id: restaurantId,
       p_date_from: fromStr,
@@ -68,10 +73,25 @@ export async function fetchMonthRevenueTotals(
       p_date_from: fromStr,
       p_date_to: toStr,
     }),
+    // Source of truth for "Collected at POS" — matches the deposit and the
+    // POS Sales page filter total. The legacy `gross + tax + tips + other`
+    // formula excludes void/discount offset rows in unified_sales.total_price
+    // and disagrees with both. See useUnifiedSalesTotals for the same call.
+    client.rpc('get_unified_sales_totals', {
+      p_restaurant_id: restaurantId,
+      p_start_date: fromStr,
+      p_end_date: toStr,
+    }),
   ]);
 
   if (revErr) throw revErr;
   if (passErr) throw passErr;
+  // Soft-fail on the unified RPC: if it errors, fall back to the legacy
+  // `gross + tax + tips + other` formula below rather than tank the whole
+  // monthly metrics query. Matches useRevenueBreakdown's behavior.
+  if (unifiedErr) {
+    console.warn('Failed to fetch unified sales totals, falling back to legacy posCollected formula:', unifiedErr);
+  }
 
   let categorizedCents = 0;
   let uncategorizedCents = 0;
@@ -97,8 +117,9 @@ export async function fetchMonthRevenueTotals(
   }
 
   const netRevenueCents = grossRevenueCents - discountsCents;
-  const posCollectedCents =
-    grossRevenueCents + salesTaxCents + tipsCents + otherLiabilitiesCents;
+  const posCollectedCents = unifiedErr
+    ? grossRevenueCents + salesTaxCents + tipsCents + otherLiabilitiesCents
+    : toC(Number(unifiedRows?.[0]?.collected_at_pos ?? 0));
 
   return {
     grossRevenueCents,
@@ -133,25 +154,11 @@ export function useMonthlyMetrics(
       const fromStr = format(dateFrom, 'yyyy-MM-dd');
       const toStr = format(dateTo, 'yyyy-MM-dd');
 
-      const normalizeToLocalDate = (rawDate: string | null | undefined, fieldName: string) => {
-        if (!rawDate) {
-          return null;
-        }
-
-        const parsed = new Date(rawDate);
-        if (!Number.isNaN(parsed.getTime())) {
-          return new Date(parsed.getFullYear(), parsed.getMonth(), parsed.getDate());
-        }
-
-        const match = /^([0-9]{4})-([0-9]{2})-([0-9]{2})/.exec(rawDate);
-        if (match) {
-          const [, year, month, day] = match;
-          return new Date(Number(year), Number(month) - 1, Number(day));
-        }
-
-        console.warn(`[useMonthlyMetrics] Unable to parse ${fieldName}:`, rawDate);
-        return null;
-      };
+      // bank_transactions.transaction_date is TIMESTAMPTZ; pending_outflows.issue_date
+      // is DATE. Slice to yyyy-MM-dd then take first 7 chars for the month bucket.
+      // See toUtcDayKey for the TZ rationale.
+      const monthKeyFor = (raw: string | null | undefined): string | null =>
+        raw ? toUtcDayKey(raw).slice(0, 7) : null;
 
       // Build monthly map (cents-based) for combining with COGS + labor below.
       const monthlyMap = new Map<string, {
@@ -269,11 +276,13 @@ export function useMonthlyMetrics(
         type SplitParentRow = { id: string; transaction_date: string };
         const splitParentIds = (splitParents || []).map((p: SplitParentRow) => p.id);
         let splitItems: SplitItemRow[] = [];
-        // Day-keyed parentDateMap (yyyy-MM-dd) — required by shared helper
+        // Day-keyed parentDateMap (yyyy-MM-dd) — required by shared helper.
+        // Use the canonical UTC day key so split items bucket the same way as
+        // the direct bank-txn rows (see toUtcDayKey).
         const parentDateMap = new Map<string, string>();
-        (splitParents || []).forEach((p: SplitParentRow) =>
-          parentDateMap.set(p.id, format(new Date(p.transaction_date), 'yyyy-MM-dd'))
-        );
+        for (const p of splitParents || [] as SplitParentRow[]) {
+          parentDateMap.set(p.id, toUtcDayKey(p.transaction_date));
+        }
 
         if (splitParentIds.length > 0) {
           const { data: splits } = await supabase
@@ -513,9 +522,8 @@ export function useMonthlyMetrics(
       bankLabor?.forEach((txn: any) => {
         const account = txn.chart_of_accounts as { account_subtype?: string } | null;
         if (account?.account_subtype === 'labor') {
-          const transactionDate = normalizeToLocalDate(txn.transaction_date, 'bank_transactions.transaction_date');
-          if (!transactionDate) return;
-          const monthKey = format(transactionDate, 'yyyy-MM');
+          const monthKey = monthKeyFor(txn.transaction_date);
+          if (!monthKey) return;
           const month = ensureMonth(monthKey);
           const actualCost = Math.round(Math.abs(txn.amount || 0) * 100);
           month.actual_labor_cost += actualCost;
@@ -527,9 +535,8 @@ export function useMonthlyMetrics(
       pendingLabor?.forEach((txn: any) => {
         const account = txn.chart_account as { account_subtype?: string } | null;
         if (account?.account_subtype === 'labor') {
-          const issueDate = normalizeToLocalDate(txn.issue_date, 'pending_outflows.issue_date');
-          if (!issueDate) return;
-          const monthKey = format(issueDate, 'yyyy-MM');
+          const monthKey = monthKeyFor(txn.issue_date);
+          if (!monthKey) return;
           const month = ensureMonth(monthKey);
           const actualCost = Math.round(Math.abs(txn.amount || 0) * 100);
           month.actual_labor_cost += actualCost;

--- a/src/hooks/useRevenueBreakdown.tsx
+++ b/src/hooks/useRevenueBreakdown.tsx
@@ -63,6 +63,9 @@ function fromC(c: number): number {
   return Math.round(c) / 100;
 }
 
+/** Row shape returned by get_unified_sales_totals. Explicit cast avoids `any`. */
+type UnifiedSalesTotalsRow = { collected_at_pos?: number | string | null };
+
 // The five adjustment types the RPC and client-side reduction are authorised to handle.
 const KNOWN_PASS_THROUGH_TYPES = new Set(['tax', 'tip', 'service_charge', 'discount', 'fee']);
 
@@ -102,7 +105,7 @@ export function reduceRevenueBreakdownPassThrough(
       case 'tax':            taxCents += cents; break;
       case 'tip':            tipsCents += cents; break;
       case 'discount':       discountsCents += Math.abs(cents); break;
-      case 'service_charge': otherLiabilitiesCents += cents; break;
+      case 'service_charge':
       case 'fee':            otherLiabilitiesCents += cents; break;
     }
   }
@@ -162,7 +165,7 @@ export function useRevenueBreakdown(
 
       // Use database aggregation for efficient totals (no row limit issues)
       // This replaces fetching individual records and processing in JavaScript
-      
+
       // 1. Get pass-through totals using RPC (tax, tips, service_charge, discount, fee)
       const { data: passThroughTotals, error: passThroughError } = await supabase
         .rpc('get_pass_through_totals', {
@@ -188,6 +191,23 @@ export function useRevenueBreakdown(
         console.warn('Failed to fetch revenue by account via RPC, falling back to individual query:', revenueError);
         // Fall back to original query method if RPC not available
       }
+
+      // 3. Source of truth for "Collected at POS": SUM(unified_sales.total_price).
+      // Matches the deposit and the POS Sales page filter total. The legacy
+      // `gross + tax + tips + other` formula excludes void/discount offset rows
+      // and disagrees with both. This is the same RPC useUnifiedSalesTotals uses.
+      const { data: unifiedSalesTotals, error: unifiedError } = await supabase
+        .rpc('get_unified_sales_totals', {
+          p_restaurant_id: restaurantId,
+          p_start_date: fromStr,
+          p_end_date: toStr,
+        });
+
+      if (unifiedError) {
+        console.warn('Failed to fetch unified sales totals via RPC:', unifiedError);
+      }
+      const unifiedRow = (unifiedSalesTotals as UnifiedSalesTotalsRow[] | null)?.[0];
+      const collectedAtPosFromRPC = Number(unifiedRow?.collected_at_pos ?? 0);
 
       // If RPC functions are available, use aggregated data
       if (passThroughTotals && revenueByAccount) {
@@ -346,7 +366,14 @@ export function useRevenueBreakdown(
         // Calculate final totals
         const grossRevenueC = categorizedRevenueC + uncategorizedRevenueC;
         const netRevenueC = grossRevenueC - combinedDiscountsC - totalRefundsC;
-        const totalCollectedAtPOSC = grossRevenueC + combinedTaxC + combinedTipsC + combinedOtherLiabilitiesC;
+        // Collected at POS = SUM(unified_sales.total_price) from get_unified_sales_totals.
+        // This matches the deposit and the POS Sales page total — the old formula
+        // (gross + tax + tips + other) excludes void/discount offset rows. If the
+        // unified RPC failed, fall back to the legacy formula so the panel still
+        // renders something rather than zeroing out silently.
+        const totalCollectedAtPOSC = unifiedError
+          ? grossRevenueC + combinedTaxC + combinedTipsC + combinedOtherLiabilitiesC
+          : toC(collectedAtPosFromRPC);
 
         // Build adjustments breakdown array
         const adjustmentsBreakdown: AdjustmentBreakdown[] = [];
@@ -712,8 +739,13 @@ export function useRevenueBreakdown(
       const totalTips = fromC(combinedTipsC);
       const totalOtherLiabilities = fromC(combinedOtherLiabilitiesC);
       
-      // Calculate total collected at POS (revenue + pass-through collections)
-      const totalCollectedAtPOSC = grossRevenueC + combinedTaxC + combinedTipsC + combinedOtherLiabilitiesC;
+      // Collected at POS = SUM(unified_sales.total_price) from get_unified_sales_totals.
+      // Matches the deposit and the POS Sales page total. If the RPC failed, fall
+      // back to the legacy formula so the panel still renders something.
+      const totalCollectedAtPOSC =
+        unifiedError
+          ? grossRevenueC + combinedTaxC + combinedTipsC + combinedOtherLiabilitiesC
+          : toC(collectedAtPosFromRPC);
       const totalCollectedAtPOS = fromC(totalCollectedAtPOSC);
       
       // Calculate categorization rate based on revenue dollars

--- a/src/services/cogsCalculations.ts
+++ b/src/services/cogsCalculations.ts
@@ -1,5 +1,3 @@
-import { format } from 'date-fns';
-
 /**
  * Canonical set of chart-of-accounts subtypes that represent Cost of Goods Sold.
  * Single source of truth — previously duplicated in useCOGSFromFinancials and useMonthlyMetrics.
@@ -10,6 +8,19 @@ export const COGS_SUBTYPES = new Set([
   'beverage_cost',
   'packaging_cost',
 ]);
+
+/**
+ * Returns the canonical UTC day key (`yyyy-MM-dd`) for a Postgres
+ * date-or-timestamptz field.
+ *
+ * `bank_transactions.transaction_date` is TIMESTAMPTZ — Postgres returns it as
+ * an ISO string like `'2026-05-01T00:00:00+00:00'`. Parsing with `new Date()`
+ * and re-formatting in the host TZ shifts a 00:00 UTC row backwards a day in
+ * any UTC- offset, dropping it into the previous month. `pending_outflows.
+ * issue_date` is DATE — already `'yyyy-MM-dd'`. Both shapes share their first
+ * 10 chars, so slicing is stable across host timezones.
+ */
+export const toUtcDayKey = (raw: string): string => raw.slice(0, 10);
 
 // ---------------------------------------------------------------------------
 // Row-shape types (lowest-common-denominator of what each Supabase query returns)
@@ -56,9 +67,7 @@ export function aggregateInventoryCOGSByDate(
   const dailyMap = new Map<string, number>();
 
   for (const row of rows) {
-    const dateKey = row.transaction_date
-      ? row.transaction_date
-      : format(new Date(row.created_at), 'yyyy-MM-dd');
+    const dateKey = toUtcDayKey(row.transaction_date ?? row.created_at);
 
     const cost = Math.abs(row.total_cost || 0);
     dailyMap.set(dateKey, (dailyMap.get(dateKey) || 0) + cost);
@@ -102,7 +111,7 @@ export function aggregateFinancialCOGSByDate({
   for (const txn of bankTxns) {
     const account = txn.chart_of_accounts;
     if (account?.account_subtype && COGS_SUBTYPES.has(account.account_subtype)) {
-      const date = format(new Date(txn.transaction_date), 'yyyy-MM-dd');
+      const date = toUtcDayKey(txn.transaction_date);
       const cost = Math.abs(txn.amount);
       dateMap.set(date, (dateMap.get(date) || 0) + cost);
     }

--- a/tests/unit/cogsCalculations.tz.test.ts
+++ b/tests/unit/cogsCalculations.tz.test.ts
@@ -17,7 +17,10 @@ process.env.TZ = 'America/Chicago';
 import { describe, it, expect } from 'vitest';
 import {
   aggregateFinancialCOGSByDate,
+  aggregateInventoryCOGSByDate,
+  toUtcDayKey,
   type BankTransactionRow,
+  type InventoryTransactionRow,
   type PendingOutflowRow,
   type SplitItemRow,
 } from '@/services/cogsCalculations';
@@ -126,5 +129,82 @@ describe('aggregateFinancialCOGSByDate — TZ bucketing', () => {
     });
 
     expect(result.get('2026-05-01')).toBeCloseTo(175, 2);
+  });
+});
+
+describe('aggregateInventoryCOGSByDate — TZ bucketing', () => {
+  it('uses transaction_date when present and slices to UTC day key', () => {
+    const rows: InventoryTransactionRow[] = [
+      {
+        // TIMESTAMPTZ-shaped value at 00:00 UTC. In Chicago a naive
+        // `new Date(...)` reformat would yield 2026-04-30; toUtcDayKey
+        // must keep it on 2026-05-01.
+        transaction_date: '2026-05-01T00:00:00+00:00',
+        created_at: '2026-04-30T18:00:00+00:00',
+        total_cost: 12.34,
+      },
+    ];
+
+    const result = aggregateInventoryCOGSByDate(rows);
+
+    expect(result.get('2026-05-01')).toBeCloseTo(12.34, 2);
+    expect(result.has('2026-04-30')).toBe(false);
+  });
+
+  it('falls back to created_at when transaction_date is null', () => {
+    const rows: InventoryTransactionRow[] = [
+      {
+        transaction_date: null,
+        created_at: '2026-05-02T00:00:00+00:00',
+        total_cost: 7.5,
+      },
+    ];
+
+    const result = aggregateInventoryCOGSByDate(rows);
+
+    expect(result.get('2026-05-02')).toBeCloseTo(7.5, 2);
+  });
+
+  it('sums multiple rows that resolve to the same UTC day key', () => {
+    const rows: InventoryTransactionRow[] = [
+      {
+        transaction_date: '2026-05-01T00:00:00+00:00',
+        created_at: '2026-04-30T20:00:00+00:00',
+        total_cost: 10,
+      },
+      {
+        transaction_date: null,
+        created_at: '2026-05-01T05:00:00+00:00',
+        total_cost: -5, // Math.abs → 5
+      },
+    ];
+
+    const result = aggregateInventoryCOGSByDate(rows);
+
+    expect(result.get('2026-05-01')).toBeCloseTo(15, 2);
+  });
+
+  it('treats null total_cost as 0', () => {
+    const rows: InventoryTransactionRow[] = [
+      {
+        transaction_date: '2026-05-01T00:00:00+00:00',
+        created_at: '2026-05-01T00:00:00+00:00',
+        total_cost: null,
+      },
+    ];
+
+    const result = aggregateInventoryCOGSByDate(rows);
+
+    expect(result.get('2026-05-01')).toBe(0);
+  });
+});
+
+describe('toUtcDayKey', () => {
+  it('returns the first 10 chars of an ISO timestamp', () => {
+    expect(toUtcDayKey('2026-05-01T00:00:00+00:00')).toBe('2026-05-01');
+  });
+
+  it('passes a yyyy-MM-dd DATE value through unchanged', () => {
+    expect(toUtcDayKey('2026-05-01')).toBe('2026-05-01');
   });
 });

--- a/tests/unit/cogsCalculations.tz.test.ts
+++ b/tests/unit/cogsCalculations.tz.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Regression: aggregateFinancialCOGSByDate must bucket each row by the UTC
+ * day stored on the row, not by the host-local day.
+ *
+ * Russo's Pizzeria (America/Chicago) had a $216.75 COGS bank transaction
+ * stored as `transaction_date = '2026-05-01T00:00:00+00:00'`. The previous
+ * implementation called `format(new Date(txn.transaction_date), 'yyyy-MM-dd')`,
+ * which parses UTC then re-formats in the host TZ. In Chicago that
+ * yielded `'2026-04-30'`, so the row landed in April's bucket and
+ * Monthly Performance reported $3,787 instead of $4,003.73 for May.
+ *
+ * Pin TZ=America/Chicago and assert the row buckets to '2026-05-01'.
+ */
+
+process.env.TZ = 'America/Chicago';
+
+import { describe, it, expect } from 'vitest';
+import {
+  aggregateFinancialCOGSByDate,
+  type BankTransactionRow,
+  type PendingOutflowRow,
+  type SplitItemRow,
+} from '@/services/cogsCalculations';
+
+describe('aggregateFinancialCOGSByDate — TZ bucketing', () => {
+  it('buckets a 00:00 UTC bank txn to its UTC date even when host TZ is west of UTC', () => {
+    // Sanity: confirm Chicago really is the host TZ for this test.
+    expect(new Date().getTimezoneOffset()).toBeGreaterThan(0);
+
+    const bankTxns: BankTransactionRow[] = [
+      {
+        transaction_date: '2026-05-01T00:00:00+00:00',
+        amount: -216.75,
+        chart_of_accounts: { account_subtype: 'food_cost' },
+      },
+    ];
+
+    const result = aggregateFinancialCOGSByDate({
+      bankTxns,
+      splitItems: [],
+      parentDateMap: new Map(),
+      pendingTxns: [],
+    });
+
+    // Bug behavior: result.get('2026-04-30') === 216.75
+    // Correct behavior: row buckets under May 1.
+    expect(result.get('2026-05-01')).toBeCloseTo(216.75, 2);
+    expect(result.has('2026-04-30')).toBe(false);
+  });
+
+  it('buckets split-parent txns by their UTC date (parentDateMap path)', () => {
+    const splitItems: SplitItemRow[] = [
+      {
+        transaction_id: 'parent-1',
+        amount: -100,
+        chart_of_accounts: { account_subtype: 'food_cost' },
+      },
+    ];
+    const parentDateMap = new Map<string, string>([
+      // Day key produced by the calling hook — must already be the canonical
+      // UTC date. With the fix, both call-sites build this from
+      // `parent.transaction_date.slice(0, 10)`.
+      ['parent-1', '2026-05-01'],
+    ]);
+
+    const result = aggregateFinancialCOGSByDate({
+      bankTxns: [],
+      splitItems,
+      parentDateMap,
+      pendingTxns: [],
+    });
+
+    expect(result.get('2026-05-01')).toBeCloseTo(100, 2);
+  });
+
+  it('passes through pending_outflows.issue_date (DATE column) unchanged', () => {
+    // pending_outflows.issue_date is a DATE — already a 'yyyy-MM-dd' string
+    // with no time component. It must round-trip identically.
+    const pendingTxns: PendingOutflowRow[] = [
+      {
+        issue_date: '2026-05-01',
+        amount: -50,
+        chart_of_accounts: { account_subtype: 'cost_of_goods_sold' },
+      },
+    ];
+
+    const result = aggregateFinancialCOGSByDate({
+      bankTxns: [],
+      splitItems: [],
+      parentDateMap: new Map(),
+      pendingTxns,
+    });
+
+    expect(result.get('2026-05-01')).toBeCloseTo(50, 2);
+  });
+
+  it('aggregates multiple sources for the same UTC date', () => {
+    const bankTxns: BankTransactionRow[] = [
+      {
+        transaction_date: '2026-05-01T00:00:00+00:00',
+        amount: -100,
+        chart_of_accounts: { account_subtype: 'food_cost' },
+      },
+    ];
+    const splitItems: SplitItemRow[] = [
+      {
+        transaction_id: 'p-1',
+        amount: -50,
+        chart_of_accounts: { account_subtype: 'beverage_cost' },
+      },
+    ];
+    const parentDateMap = new Map([['p-1', '2026-05-01']]);
+    const pendingTxns: PendingOutflowRow[] = [
+      {
+        issue_date: '2026-05-01',
+        amount: -25,
+        chart_of_accounts: { account_subtype: 'packaging_cost' },
+      },
+    ];
+
+    const result = aggregateFinancialCOGSByDate({
+      bankTxns,
+      splitItems,
+      parentDateMap,
+      pendingTxns,
+    });
+
+    expect(result.get('2026-05-01')).toBeCloseTo(175, 2);
+  });
+});

--- a/tests/unit/monthlyPerformance.acceptance.test.ts
+++ b/tests/unit/monthlyPerformance.acceptance.test.ts
@@ -20,6 +20,22 @@ describe("Monthly Performance acceptance — Russo's April 2026", () => {
         if (name === 'get_pass_through_totals') {
           return Promise.resolve({ data: passThroughTotals, error: null });
         }
+        if (name === 'get_unified_sales_totals') {
+          // Russo's April 2026 had no void/discount offset rows in unified_sales,
+          // so SUM(total_price) equals the legacy `gross + tax + tips + other`
+          // formula ($92,274.48). May 2026 is where the two formulas diverge.
+          return Promise.resolve({
+            data: [{
+              total_count: 0,
+              revenue: 75917.82,
+              discounts: 1477.40,
+              pass_through_amount: 7012.66,
+              unique_items: 0,
+              collected_at_pos: 92274.48,
+            }],
+            error: null,
+          });
+        }
         return Promise.resolve({ data: [], error: null });
       }),
     };

--- a/tests/unit/useMonthlyMetrics.collected.test.ts
+++ b/tests/unit/useMonthlyMetrics.collected.test.ts
@@ -1,0 +1,159 @@
+/**
+ * Regression: useMonthlyMetrics.fetchMonthRevenueTotals must report
+ * `total_collected_at_pos` as the deposit-matching SUM(unified_sales.total_price)
+ * over the period — i.e. the value returned by `get_unified_sales_totals`.
+ *
+ * Russo's Pizzeria May 2026 production numbers:
+ *   - SUM(unified_sales.total_price)        = $31,596.36   ← Collected at POS
+ *   - gross (positive item rows)            = $26,903.04
+ *   - discounts (negative)                  = -$625.04
+ *   - tax / tip / service_charge / fee      = $2,101.05 / $3,946.71 / 0 / 0
+ *   - implied void/discount offsets in unified_sales = -$1,354.44
+ *
+ * Old formula `gross + tax + tips + other` produced $32,950.80, which excluded
+ * the offsets and disagreed with the POS Sales page. New formula sources
+ * `total_collected_at_pos` directly from `get_unified_sales_totals` so the
+ * Monthly Performance row matches the deposit.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { fetchMonthRevenueTotals } from '@/hooks/useMonthlyMetrics';
+
+describe('fetchMonthRevenueTotals — Collected at POS source of truth', () => {
+  it('reports posCollectedCents from get_unified_sales_totals.collected_at_pos for Russo May 2026', async () => {
+    const supabaseMock = {
+      rpc: vi.fn((name: string) => {
+        if (name === 'get_revenue_by_account') {
+          return Promise.resolve({
+            data: [
+              {
+                account_id: 'food',
+                account_code: '4000',
+                account_name: 'Food Sales',
+                account_type: 'revenue',
+                account_subtype: 'food_sales',
+                total_amount: 26903.04,
+                transaction_count: 362,
+                is_categorized: true,
+              },
+            ],
+            error: null,
+          });
+        }
+        if (name === 'get_pass_through_totals') {
+          return Promise.resolve({
+            data: [
+              { adjustment_type: 'tax',      total_amount: 2101.05, transaction_count: 100 },
+              { adjustment_type: 'tip',      total_amount: 3946.71, transaction_count: 80 },
+              { adjustment_type: 'discount', total_amount: -625.04, transaction_count: 5 },
+            ],
+            error: null,
+          });
+        }
+        if (name === 'get_unified_sales_totals') {
+          return Promise.resolve({
+            data: [
+              {
+                total_count: 800,
+                revenue: 26903.04,
+                discounts: 625.04,
+                pass_through_amount: 6047.76,
+                unique_items: 362,
+                collected_at_pos: 31596.36,
+              },
+            ],
+            error: null,
+          });
+        }
+        return Promise.resolve({ data: [], error: null });
+      }),
+    };
+
+    const result = await fetchMonthRevenueTotals(
+      supabaseMock as never,
+      'adbd9392-928a-4a46-80d7-f7e453aa1956',
+      '2026-05-01',
+      '2026-05-31'
+    );
+
+    expect(result.grossRevenueCents).toBe(2_690_304);     // 26,903.04 * 100
+    expect(result.discountsCents).toBe(62_504);           // |−625.04| * 100
+    expect(result.netRevenueCents).toBe(2_627_800);       // gross − discounts = $26,278.00
+    expect(result.salesTaxCents).toBe(210_105);
+    expect(result.tipsCents).toBe(394_671);
+    // Critical: posCollectedCents now comes from get_unified_sales_totals,
+    // not gross + tax + tips + other_liabilities.
+    expect(result.posCollectedCents).toBe(3_159_636);     // $31,596.36 * 100
+  });
+
+  it('falls back to legacy gross + tax + tips + other when get_unified_sales_totals errors', async () => {
+    const supabaseMock = {
+      rpc: vi.fn((name: string) => {
+        if (name === 'get_revenue_by_account') {
+          return Promise.resolve({
+            data: [
+              { account_id: 'food', account_code: '4000', account_name: 'Food', account_type: 'revenue', account_subtype: 'food_sales', total_amount: 1000, transaction_count: 10, is_categorized: true },
+            ],
+            error: null,
+          });
+        }
+        if (name === 'get_pass_through_totals') {
+          return Promise.resolve({
+            data: [
+              { adjustment_type: 'tax', total_amount: 80, transaction_count: 10 },
+              { adjustment_type: 'tip', total_amount: 50, transaction_count: 10 },
+              { adjustment_type: 'fee', total_amount: 20, transaction_count: 10 },
+            ],
+            error: null,
+          });
+        }
+        if (name === 'get_unified_sales_totals') {
+          return Promise.resolve({ data: null, error: { message: 'rpc unavailable' } });
+        }
+        return Promise.resolve({ data: [], error: null });
+      }),
+    };
+
+    const result = await fetchMonthRevenueTotals(
+      supabaseMock as never,
+      'rest',
+      '2026-05-01',
+      '2026-05-31'
+    );
+
+    // Legacy formula: 1000 + 80 + 50 + 20 = 1150 dollars → 115_000 cents.
+    expect(result.posCollectedCents).toBe(115_000);
+  });
+
+  it('calls get_unified_sales_totals with the requested period bounds', async () => {
+    const rpc = vi.fn((name: string) => {
+      if (name === 'get_revenue_by_account') return Promise.resolve({ data: [], error: null });
+      if (name === 'get_pass_through_totals') return Promise.resolve({ data: [], error: null });
+      if (name === 'get_unified_sales_totals') {
+        return Promise.resolve({
+          data: [{
+            total_count: 0, revenue: 0, discounts: 0,
+            pass_through_amount: 0, unique_items: 0, collected_at_pos: 0,
+          }],
+          error: null,
+        });
+      }
+      return Promise.resolve({ data: [], error: null });
+    });
+
+    await fetchMonthRevenueTotals(
+      { rpc } as never,
+      'rest-uuid',
+      '2026-05-01',
+      '2026-05-31'
+    );
+
+    const call = rpc.mock.calls.find((c) => c[0] === 'get_unified_sales_totals');
+    expect(call).toBeDefined();
+    expect(call![1]).toMatchObject({
+      p_restaurant_id: 'rest-uuid',
+      p_start_date: '2026-05-01',
+      p_end_date: '2026-05-31',
+    });
+  });
+});

--- a/tests/unit/useMonthlyMetrics.revenueParity.test.ts
+++ b/tests/unit/useMonthlyMetrics.revenueParity.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { fetchMonthRevenueTotals } from '@/hooks/useMonthlyMetrics';
 
 describe('fetchMonthRevenueTotals', () => {
-  it('returns gross = categorized + uncategorized, net = gross − discounts, POS = gross + tax + tips + otherLiabilities', async () => {
+  it('returns gross = categorized + uncategorized, net = gross − discounts, and posCollected from get_unified_sales_totals', async () => {
     const supabaseMock = {
       rpc: vi.fn((name: string) => {
         if (name === 'get_revenue_by_account') {
@@ -26,12 +26,28 @@ describe('fetchMonthRevenueTotals', () => {
             error: null,
           });
         }
+        if (name === 'get_unified_sales_totals') {
+          // Deposit-matching SUM(unified_sales.total_price). Different from
+          // the legacy `gross + tax + tips + other` ($6,575.00) because
+          // unified_sales also contains void/discount offset rows.
+          return Promise.resolve({
+            data: [{
+              total_count: 13,
+              revenue: 5000,
+              discounts: 100,
+              pass_through_amount: 575,
+              unique_items: 10,
+              collected_at_pos: 6420.50,
+            }],
+            error: null,
+          });
+        }
         return Promise.resolve({ data: [], error: null });
       }),
     };
 
     const result = await fetchMonthRevenueTotals(
-      supabaseMock as any,
+      supabaseMock as never,
       'r1',
       '2026-04-01',
       '2026-04-30'
@@ -43,6 +59,7 @@ describe('fetchMonthRevenueTotals', () => {
     expect(result.salesTaxCents).toBe(30_000);
     expect(result.tipsCents).toBe(20_000);
     expect(result.otherLiabilitiesCents).toBe(7_500);   // service_charge 50 + fee 25
-    expect(result.posCollectedCents).toBe(657_500); // gross + tax + tips + otherL
+    // posCollected now comes from get_unified_sales_totals.collected_at_pos.
+    expect(result.posCollectedCents).toBe(642_050);
   });
 });

--- a/tests/unit/useRevenueBreakdown.collected.test.ts
+++ b/tests/unit/useRevenueBreakdown.collected.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Regression: useRevenueBreakdown.totals.total_collected_at_pos must equal
+ * the deposit-matching SUM(unified_sales.total_price) over the period —
+ * i.e. the value returned by `get_unified_sales_totals` and shown on the
+ * POS Sales page.
+ *
+ * The old formula `gross + tax + tips + other_liabilities` excluded
+ * void/discount offset rows and produced a value that diverged from the
+ * deposit and from the POS Sales page collected total.
+ *
+ * For Russo's Pizzeria May 2026 the canonical value is $31,596.36.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React, { type ReactNode } from 'react';
+
+const mockRpc = vi.fn();
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    rpc: (...args: unknown[]) => mockRpc(...args),
+    from: vi.fn(),
+  },
+}));
+
+const createWrapper = () => {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: qc }, children);
+  };
+};
+
+describe('useRevenueBreakdown — Collected at POS source of truth', () => {
+  beforeEach(() => {
+    mockRpc.mockReset();
+    mockRpc.mockImplementation((name: string) => {
+      if (name === 'get_revenue_by_account') {
+        return Promise.resolve({
+          data: [
+            {
+              account_id: 'food',
+              account_code: '4000',
+              account_name: 'Food Sales',
+              account_type: 'revenue',
+              account_subtype: 'food_sales',
+              total_amount: 26903.04,
+              transaction_count: 362,
+              is_categorized: true,
+            },
+          ],
+          error: null,
+        });
+      }
+      if (name === 'get_pass_through_totals') {
+        return Promise.resolve({
+          data: [
+            { adjustment_type: 'tax',      total_amount: 2101.05, transaction_count: 100 },
+            { adjustment_type: 'tip',      total_amount: 3946.71, transaction_count: 80 },
+            { adjustment_type: 'discount', total_amount: -625.04, transaction_count: 5 },
+          ],
+          error: null,
+        });
+      }
+      if (name === 'get_unified_sales_totals') {
+        return Promise.resolve({
+          data: [
+            {
+              total_count: 800,
+              revenue: 26903.04,
+              discounts: 625.04,
+              pass_through_amount: 6047.76,
+              unique_items: 362,
+              collected_at_pos: 31596.36,
+            },
+          ],
+          error: null,
+        });
+      }
+      return Promise.resolve({ data: null, error: null });
+    });
+  });
+
+  it('returns total_collected_at_pos = $31,596.36 for Russo May 2026', async () => {
+    const { useRevenueBreakdown } = await import('@/hooks/useRevenueBreakdown');
+
+    const dateFrom = new Date(2026, 4, 1);  // 2026-05-01 local
+    const dateTo = new Date(2026, 4, 31);   // 2026-05-31 local
+
+    const { result } = renderHook(
+      () => useRevenueBreakdown('adbd9392-928a-4a46-80d7-f7e453aa1956', dateFrom, dateTo),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.data).toBeDefined();
+    expect(result.current.data!.totals.total_collected_at_pos).toBeCloseTo(31596.36, 2);
+    expect(result.current.data!.totals.gross_revenue).toBeCloseTo(26903.04, 2);
+    expect(result.current.data!.totals.net_revenue).toBeCloseTo(26278.00, 2);
+  });
+});


### PR DESCRIPTION
## Summary

Russo's Pizzeria May 2026 showed **three different "Collected at POS" values** across the dashboard:
- Monthly Performance: **\$32,951**
- Performance Overview / Net Revenue: **\$26,278** (correct, but a different metric)
- POS Sales page: **\$31,596.36** (the deposit-matching truth)

Plus a \$216.75 May 1 inventory cost row that disappeared from May because of a TZ bug.

This PR fixes both root causes so the four views agree by construction.

### Root cause 1 — TZ bucketing

`format(new Date(timestamptz), 'yyyy-MM-dd')` shifted UTC-midnight `bank_transactions.transaction_date` rows backwards a day in west-of-UTC TZs (Russo's runs in `America/Chicago`). The May 1 00:00 UTC row landed in April.

**Fix:** New canonical `toUtcDayKey(raw) = raw.slice(0,10)` — safe for both TIMESTAMPTZ (`'2026-05-01T00:00:00+00:00'`) and DATE (`'2026-05-01'`) shapes — applied across `src/services/cogsCalculations.ts`, `src/hooks/useCOGSFromFinancials.tsx`, and the labor path in `src/hooks/useMonthlyMetrics.tsx` (replacing `normalizeToLocalDate`).

### Root cause 2 — Collected-at-POS formula divergence

`gross + tax + tips + other_liabilities` excluded void/discount offset rows in `unified_sales.total_price`, producing a value that disagreed with both the deposit and the POS Sales page.

**Fix:** Standardized on `get_unified_sales_totals.collected_at_pos` (the same RPC the POS Sales page uses) in:
- `useMonthlyMetrics.tsx::fetchMonthRevenueTotals` — added 3rd parallel RPC.
- `useRevenueBreakdown.tsx` — added 3rd RPC, used in both the RPC and fallback paths.

Both callsites soft-fall back to the legacy formula if the new RPC errors, so the panel never silently zeros out (caught in code review — see `useRevenueBreakdown.tsx` line ~372 and `useMonthlyMetrics.tsx` line ~115).

### Acceptance numbers (Russo's May 2026)

| Metric | Before | After | Source of truth |
|---|---|---|---|
| Collected at POS | \$32,950.80 | **\$31,596.36** | `SUM(unified_sales.total_price)` |
| Gross Revenue | \$26,903.04 | \$26,903.04 | `get_revenue_by_account` |
| Net Revenue | \$26,278.00 | \$26,278.00 | gross − discounts |
| COGS (financial) | \$3,786.98 | **\$4,003.73** | bank_transactions + splits + pending |

## Test plan

- [x] `TZ=UTC npx vitest run` — 3807/3807 passing (full suite)
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint <changed-files>` — 15 errors = baseline (no new errors)
- [x] New regression tests pin the canonical Russo's May 2026 production numbers:
  - `tests/unit/cogsCalculations.tz.test.ts` (4 tests, pinned to `process.env.TZ='America/Chicago'`)
  - `tests/unit/useMonthlyMetrics.collected.test.ts` (3 tests, includes soft-fallback)
  - `tests/unit/useRevenueBreakdown.collected.test.ts` (1 test)
- [x] Updated existing `revenueParity` and `monthlyPerformance.acceptance` tests with new RPC mock
- [ ] Manual QA: open dashboard for Russo's, select May 2026 — verify Performance Overview, Monthly Performance, cashflow viz, and POS Sales all show consistent numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)