### PR TITLE
fix(dashboard): bucket monthly expenses by UTC day & honor posCollectedAtPos

### DIFF
--- a/docs/superpowers/plans/2026-05-10-monthly-expenses-tz-plan.md
+++ b/docs/superpowers/plans/2026-05-10-monthly-expenses-tz-plan.md
@@ -1,0 +1,83 @@
+# Plan — Monthly Performance: TZ-safe expense bucketing & POS collected source-of-truth
+
+**Date:** 2026-05-10
+**Spec:** `docs/superpowers/specs/2026-05-10-monthly-expenses-tz-design.md`
+**Branch:** `fix/monthly-expenses-tz`
+**Estimated PRs:** 1
+
+## Tasks (TDD order)
+
+### 1. Add failing TZ-bucketing test for `useMonthlyExpenses`
+- **File:** `tests/unit/useMonthlyExpenses.tz.test.ts` (new)
+- **Setup:** `process.env.TZ = 'America/Chicago'` at top of file before imports
+- **Approach:** Stub `@/lib/expenseDataFetcher` with `vi.mock`, return fixture
+  rows whose `transaction_date` / `issue_date` is `'2026-05-01...'`
+- **Assertions:** `result.find(m => m.period === '2026-05')` exists with the
+  expected `foodCost` / `laborCost` / `totalExpenses`; no `'2026-04'` row.
+- **Expected:** Fails on current code (rows leak into April).
+
+### 2. Fix `useMonthlyExpenses.tsx`
+- **File:** `src/hooks/useMonthlyExpenses.tsx`
+- **Edits:**
+  - Add `import { toUtcDayKey } from '@/services/cogsCalculations';`
+  - Replace line 90: `const monthKey = toUtcDayKey(t.transaction_date).slice(0, 7);`
+  - Replace line 116: `const monthKey = toUtcDayKey(parentTxn.transaction_date).slice(0, 7);`
+  - Replace line 138: `const monthKey = toUtcDayKey(t.issue_date).slice(0, 7);`
+- **Verify:** Test from step 1 goes green.
+
+### 3. Add failing source-of-truth test for `monthlyPerformance.ts`
+- **File:** `tests/unit/monthlyPerformance.test.ts` (new)
+- **Cases:**
+  - A: `totalCollectedAtPos = 31596.36` (caller passes deposit truth) →
+    expect `posCollectedFromBreakdownCents === 3_159_636`.
+  - B: `totalCollectedAtPos = null` → expect legacy `gross+passthrough`.
+  - C: `totalCollectedAtPos = 0` → expect `0` (zero is a valid value, not a "missing" sentinel).
+- **Expected:** Case A fails on current code.
+
+### 4. Fix `monthlyPerformance.ts:115`
+- **File:** `supabase/functions/_shared/monthlyPerformance.ts`
+- **Edits:**
+  - Change `totalCollectedAtPos` field type to `number | null` in
+    `MonthlyPerformanceInput`.
+  - Rewrite the `posCollectedFromBreakdownCents` derivation as in spec.
+  - Update the JSDoc on `totalCollectedAtPos` to describe the new contract
+    ("Prefer the deposit-matching `SUM(unified_sales.total_price)` from
+    `get_unified_sales_totals.collected_at_pos`. Pass `null` to fall back to
+    the legacy `gross + tax + tips + other_liabilities` formula.").
+- **Verify:** Test from step 3 goes green.
+
+### 5. Adapt `MonthlyBreakdownTable.tsx` if needed
+- **File:** `src/components/MonthlyBreakdownTable.tsx`
+- **Check:** It passes `totalCollectedAtPos: month.total_collected_at_pos`
+  directly. If `total_collected_at_pos` is `undefined` for missing months,
+  coerce to `null` (since the new contract distinguishes `null` from `0`).
+- **Verify:** Grep `total_collected_at_pos` usage; confirm `useMonthlyMetrics`
+  sets `total_collected_at_pos: posCollectedCents / 100` and never leaves it
+  undefined.
+
+### 6. Verify acceptance test still green
+- **File:** `tests/unit/monthlyPerformance.acceptance.test.ts`
+- **Action:** Run; April fixture passes `collected_at_pos: 92274.48` which
+  equals the legacy formula, so no number should shift. No edit expected.
+
+### 7. Full verification
+- `npm run typecheck`
+- `npm run lint`
+- `npm run test` (full unit suite)
+- Smoke: load `/dashboard` for Russo's, eyeball the May card.
+
+### 8. Ship
+- Commit with TDD-style message:
+  - `fix(dashboard): bucket monthly expenses by UTC day & honor caller-supplied posCollectedAtPos`
+- Push, open PR against `main`. CI must be green.
+
+## Risk
+
+Low. Frontend-only path. Pattern mirrors PR #492. Two narrow fixes, each
+covered by a new unit test.
+
+## Out of scope
+
+- Performance Overview cards (already correct).
+- "Other Expenses" composition (correct number, just unusual timing).
+- Edge function callers of `calculateMonthlyPerformance` (none today).

--- a/docs/superpowers/specs/2026-05-10-monthly-expenses-tz-design.md
+++ b/docs/superpowers/specs/2026-05-10-monthly-expenses-tz-design.md
@@ -1,0 +1,167 @@
+# Design — Monthly Performance: TZ-safe expense bucketing & POS collected source-of-truth
+
+**Date:** 2026-05-10
+**Owner:** @jdelgado2002
+**Status:** Draft → for plan approval
+**Related:** PR #492 (`2026-05-01-monthly-performance-source-of-truth`)
+
+---
+
+## Problem
+
+PR #492 aligned the May 2026 numbers across Performance Overview, Monthly
+Performance, and POS Sales for *most* code paths. Two paths it missed are still
+producing wrong numbers for Russo's Pizzeria (TZ `America/Chicago`), visible
+today (2026-05-10) on the dashboard:
+
+| Card                       | Reported       | Correct        | Delta       |
+|----------------------------|----------------|----------------|-------------|
+| Monthly Performance COGS   | **$3,787**     | $4,003.73      | −$216.75    |
+| Monthly Performance Labor  | **$10,745**    | $11,136        | −$391       |
+| Monthly Performance "Collected at POS" | **$32,950.80** | $31,596.36 | +$1,354.44 |
+
+The first two come from one bug; the third comes from a different bug.
+
+---
+
+## Bug #1 — `useMonthlyExpenses.tsx` buckets by host-local day
+
+`useMonthlyExpenses` produces the per-month aggregates that
+`MonthlyBreakdownTable.tsx` displays in the Monthly Performance row
+(`foodCost`, `laborCost`, `totalExpenses`).
+
+Three call sites still use the pre-PR-#492 pattern:
+
+```ts
+// Line 90 — bank txns
+const monthKey = format(new Date(t.transaction_date), 'yyyy-MM');
+// Line 116 — split parent
+const monthKey = format(new Date(parentTxn.transaction_date), 'yyyy-MM');
+// Line 138 — pending outflows
+const monthKey = format(new Date(t.issue_date), 'yyyy-MM');
+```
+
+`format(new Date(<utc-ts>), 'yyyy-MM')` parses the UTC timestamp, then
+re-renders it in the **host process** timezone. On Russo's browser in Chicago
+a `transaction_date = '2026-05-01T00:00:00+00:00'` row becomes
+`2026-04-30` → bucketed into April. That's exactly the May 1 COGS row
+($189.05 + $27.70 = $216.75) and the May 1 labor rows ($335.36 + $55.65 ≈ $391)
+that today's dashboard is missing from May.
+
+`pending_outflows.issue_date` is a `DATE` column — already a `yyyy-MM-dd`
+string. `new Date('2026-05-01')` ⇒ 00:00 UTC → in Chicago that renders as
+`2026-04-30` too. Same bug, different table.
+
+### Fix
+
+Replace each call site with `toUtcDayKey(raw).slice(0, 7)` — the canonical UTC
+month key, mirroring the `useMonthlyMetrics.tsx` fix from PR #492:
+
+```ts
+import { toUtcDayKey } from '@/services/cogsCalculations';
+
+const monthKey = toUtcDayKey(t.transaction_date).slice(0, 7);
+```
+
+`toUtcDayKey` is the existing pure helper (`raw => raw.slice(0, 10)`) tested by
+`tests/unit/cogsCalculations.tz.test.ts`. `slice(0, 7)` truncates the same UTC
+date string to `'yyyy-MM'`.
+
+---
+
+## Bug #2 — `monthlyPerformance.ts` discards `totalCollectedAtPos`
+
+The shared `calculateMonthlyPerformance` function intentionally re-derives
+"POS collected" from `gross + tax + tips + other_liabilities`:
+
+```ts
+// supabase/functions/_shared/monthlyPerformance.ts:115
+const posCollectedFromBreakdownCents = grossRevenueCents + passThroughTotalCents;
+```
+
+That formula was the right answer for April 2026 (no void/discount offsets
+in `unified_sales`), but is wrong for May 2026.
+
+PR #492 introduced `get_unified_sales_totals.collected_at_pos` =
+`SUM(unified_sales.total_price)`. This includes Toast's negative void/discount
+offset rows that the deposit also includes — matching the POS Sales page. For
+Russo May 2026:
+
+- legacy formula → **$32,950.80**
+- `unified_sales.SUM(total_price)` → **$31,596.36** ← POS deposit truth
+
+`useMonthlyMetrics.fetchMonthRevenueTotals` already reads
+`collected_at_pos` and stores it on `month.total_collected_at_pos`.
+`MonthlyBreakdownTable.tsx` passes it through as
+`input.revenue.totalCollectedAtPos`. The shared module silently throws it
+away — re-derives, displays the wrong number.
+
+### Fix
+
+Have `calculateMonthlyPerformance` prefer the caller-supplied
+`totalCollectedAtPos` when it is provided, falling back to the legacy
+breakdown formula only when the caller passes `null`/`undefined`:
+
+```ts
+const posCollectedFromBreakdownCents =
+  input.revenue.totalCollectedAtPos != null
+    ? toCents(input.revenue.totalCollectedAtPos)
+    : grossRevenueCents + passThroughTotalCents; // legacy fallback
+```
+
+This keeps the variable name (and `posCollectedFromBreakdownCents` field) so
+no caller renames are needed, and preserves the legacy formula for any caller
+that hasn't migrated to `get_unified_sales_totals` yet.
+
+The header comment on the `totalCollectedAtPos` input field is updated to
+reflect the new contract.
+
+---
+
+## Non-goals
+
+- Recomputing "Other Expenses" — the reported $23,274 is mathematically
+  correct (rent $12,250 + uncategorized $7,706 + other = $23,274). It is
+  inflated only because of timing (early-month rent + uncategorized items),
+  not a calculation bug.
+- Touching `usePeriodMetrics` / `useCostsFromSource` — those already use UTC
+  day keys post PR #492, and the Performance Overview numbers match
+  ground truth.
+
+---
+
+## Test strategy
+
+| Test file                                          | New / Updated | Purpose                                                                                                                                                                                          |
+|----------------------------------------------------|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `tests/unit/useMonthlyExpenses.tz.test.ts`         | New           | Pin `process.env.TZ='America/Chicago'`. Mock `fetchExpenseData` to return a bank txn at `'2026-05-01T00:00:00+00:00'`, a pending_outflow with `issue_date='2026-05-01'`, and a split. Assert each row buckets to `'2026-05'`, not `'2026-04'`. |
+| `tests/unit/monthlyPerformance.test.ts`            | New           | Unit-test `calculateMonthlyPerformance` directly. Case A: caller passes `totalCollectedAtPos: 31596.36` → `posCollectedFromBreakdownCents = 3_159_636`. Case B: caller passes `totalCollectedAtPos: null` → falls back to legacy `gross+passthrough` formula. |
+| `tests/unit/monthlyPerformance.acceptance.test.ts` | Updated       | The Russo April fixture currently passes `collected_at_pos: 92274.48` which equals the legacy formula, so no number changes. Verify the test still passes; no edit needed unless behavior shifts.   |
+
+TDD order:
+1. Write `useMonthlyExpenses.tz.test.ts` — fails (existing buggy code).
+2. Fix `useMonthlyExpenses.tsx` — test goes green.
+3. Write `monthlyPerformance.test.ts` — Case A fails (existing buggy code).
+4. Fix `monthlyPerformance.ts` — Case A goes green.
+5. Run full suite — `monthlyPerformance.acceptance.test.ts` (April fixture) still green.
+
+---
+
+## Risk / blast radius
+
+- **Server-side callers of `calculateMonthlyPerformance`:** None today. The
+  module is only consumed by `MonthlyBreakdownTable.tsx`. Future server-side
+  callers can opt in by passing `totalCollectedAtPos`, or pass `null` for the
+  legacy formula.
+- **Edge functions:** This file is in `supabase/functions/_shared/`. No edge
+  function consumes it today (verified via grep). Change is frontend-only at
+  runtime.
+- **TZ regression risk:** All three replacement sites use the same UTC-first
+  pattern as the PR #492 fixes — no new TZ paths introduced.
+
+---
+
+## Rollout
+
+Single PR, no migrations, no feature flag. Production verification via the
+Monthly Performance card immediately after deploy.

--- a/src/hooks/useMonthlyExpenses.tsx
+++ b/src/hooks/useMonthlyExpenses.tsx
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { format } from 'date-fns';
 import { getAccountDisplayName, isLaborSubtype, isFoodCostSubtype } from '@/lib/expenseCategoryUtils';
 import { fetchExpenseData } from '@/lib/expenseDataFetcher';
+import { toUtcDayKey } from '@/services/cogsCalculations';
 
 export interface MonthlyExpenseCategory {
   category: string;
@@ -87,7 +88,10 @@ export function useMonthlyExpenses(
 
       // Process bank transactions (skip split parents - use split details instead)
       transactions.filter(t => !t.is_split).forEach(t => {
-        const monthKey = format(new Date(t.transaction_date), 'yyyy-MM');
+        // Bucket by the UTC date stored on the row, not the host-local day.
+        // `format(new Date(raw), 'yyyy-MM')` is host-TZ-dependent and shifts a
+        // UTC 00:00 timestamp into the previous month for TZs west of UTC.
+        const monthKey = toUtcDayKey(t.transaction_date).slice(0, 7);
         const month = ensureMonth(monthKey);
         const txnAmount = Math.abs(t.amount);
         
@@ -113,7 +117,7 @@ export function useMonthlyExpenses(
         const parentTxn = transactions.find(t => t.id === split.transaction_id);
         if (!parentTxn) return;
 
-        const monthKey = format(new Date(parentTxn.transaction_date), 'yyyy-MM');
+        const monthKey = toUtcDayKey(parentTxn.transaction_date).slice(0, 7);
         const month = ensureMonth(monthKey);
         const splitAmount = split.amount; // Split amounts are already positive
         
@@ -135,7 +139,10 @@ export function useMonthlyExpenses(
 
       // Process pending outflows (not yet matched to bank transactions)
       pendingOutflows.forEach(t => {
-        const monthKey = format(new Date(t.issue_date), 'yyyy-MM');
+        // pending_outflows.issue_date is a DATE column ('YYYY-MM-DD').
+        // `new Date('2026-05-01')` => 00:00 UTC, which renders as 2026-04-30
+        // in TZs west of UTC. slice the canonical string instead.
+        const monthKey = toUtcDayKey(t.issue_date).slice(0, 7);
         const month = ensureMonth(monthKey);
         const txnAmount = t.amount; // Pending outflows are stored as positive amounts
         

--- a/supabase/functions/_shared/monthlyPerformance.ts
+++ b/supabase/functions/_shared/monthlyPerformance.ts
@@ -26,12 +26,13 @@ export interface MonthlyPerformanceInput {
     salesTax: number;
     tips: number;
     otherLiabilities: number;
-    /** NOT CONSUMED. The module re-derives POS-collected as
-     *  grossRevenue + salesTax + tips + otherLiabilities. This field is
-     *  accepted purely so callers can pass their hook's revenue shape via
-     *  spread; the upstream value is intentionally ignored to guarantee
-     *  the summary card and the breakdown read the same derived total. */
-    totalCollectedAtPos: number;
+    /** Deposit-matching POS-collected total in dollars. Pass the value from
+     *  `get_unified_sales_totals.collected_at_pos` (= SUM of
+     *  `unified_sales.total_price`), which includes negative Toast
+     *  void/discount offset rows the legacy `gross + tax + tips + other`
+     *  breakdown misses. Pass `null` (or omit) to fall back to the legacy
+     *  breakdown formula. `0` is treated as a valid zero-collected period. */
+    totalCollectedAtPos?: number | null;
   };
   /** Expense aggregates from useMonthlyExpenses for the same month (dollars). */
   expenses: {
@@ -108,11 +109,16 @@ export function calculateMonthlyPerformance(
   const passThroughTotalCents =
     salesTaxCents + tipsCents + otherLiabilitiesCents;
 
-  // POS — always derive from the breakdown (gross + pass-through), don't trust
-  // the caller-supplied totalCollectedAtPos field. This is the rule that fixes
-  // the $90,475 vs $87,332 mismatch: there is one POS number, sourced from
-  // breakdown.
-  const posCollectedFromBreakdownCents = grossRevenueCents + passThroughTotalCents;
+  // POS — prefer the caller-supplied deposit-matching total (from
+  // `get_unified_sales_totals.collected_at_pos`, which includes Toast
+  // void/discount offset rows). Fall back to the legacy
+  // `gross + tax + tips + other_liabilities` breakdown only when the caller
+  // explicitly passes null/undefined. `0` is a valid value, not a "missing"
+  // sentinel — a genuinely zero-collected period must round-trip to zero.
+  const posCollectedFromBreakdownCents =
+    input.revenue.totalCollectedAtPos != null
+      ? toCents(input.revenue.totalCollectedAtPos)
+      : grossRevenueCents + passThroughTotalCents;
   const posReportedCents =
     input.posReportedTotal == null ? null : toCents(input.posReportedTotal);
   const posReconciliationDeltaCents =

--- a/tests/unit/monthlyPerformance.acceptance.test.ts
+++ b/tests/unit/monthlyPerformance.acceptance.test.ts
@@ -1,3 +1,11 @@
+// Pin TZ=UTC for this file before any imports execute. The labor wages
+// assertion below is ISO-week-bucketed, and `calculateActualLaborCostForMonth`
+// uses `date-fns` `startOfWeek`, which reads `process.env.TZ`. Other test files
+// (e.g. `cogsCalculations.tz.test.ts`, `useMonthlyExpenses.tz.test.ts`) pin
+// `TZ=America/Chicago` to exercise TZ-shift bugs. Without this guard, the env
+// mutation bleeds into this worker and shifts the OT-D Hybrid week boundary.
+process.env.TZ = 'UTC';
+
 import { describe, it, expect, vi } from 'vitest';
 import { fetchMonthRevenueTotals } from '@/hooks/useMonthlyMetrics';
 import { calculateActualLaborCostForMonth } from '@/services/laborCalculations';

--- a/tests/unit/monthlyPerformance.test.ts
+++ b/tests/unit/monthlyPerformance.test.ts
@@ -91,7 +91,27 @@ describe('calculateMonthlyPerformance — revenue and pass-through', () => {
     expect(result.passThroughTotalCents).toBe(1500);
   });
 
-  it('derives POS collected as gross + pass-through (ignoring caller-supplied totalCollectedAtPos)', () => {
+  it('prefers caller-supplied totalCollectedAtPos over the legacy gross+passthrough formula', () => {
+    // Russo May 2026 shape: legacy formula would return $32,950.80, but
+    // get_unified_sales_totals.collected_at_pos is the deposit-matching truth
+    // at $31,596.36. The shared helper now passes that value through.
+    const result = calculateMonthlyPerformance(
+      makeInput({
+        revenue: {
+          grossRevenue: 26_903.04,
+          discounts: 625.04,
+          netRevenue: 26_278.00,
+          salesTax: 2_101.05,
+          tips: 3_946.71,
+          otherLiabilities: 0,
+          totalCollectedAtPos: 31_596.36,
+        },
+      })
+    );
+    expect(result.posCollectedFromBreakdownCents).toBe(3_159_636);
+  });
+
+  it('falls back to legacy gross+passthrough when totalCollectedAtPos is null', () => {
     const result = calculateMonthlyPerformance(
       makeInput({
         revenue: {
@@ -101,11 +121,45 @@ describe('calculateMonthlyPerformance — revenue and pass-through', () => {
           salesTax: 8,
           tips: 5,
           otherLiabilities: 2,
-          totalCollectedAtPos: 999, // intentionally wrong
+          totalCollectedAtPos: null as unknown as number,
         },
       })
     );
-    expect(result.posCollectedFromBreakdownCents).toBe(11500);
+    expect(result.posCollectedFromBreakdownCents).toBe(11_500);
+  });
+
+  it('falls back to legacy gross+passthrough when totalCollectedAtPos is omitted (undefined)', () => {
+    const input = makeInput({
+      revenue: {
+        grossRevenue: 100,
+        discounts: 0,
+        netRevenue: 100,
+        salesTax: 8,
+        tips: 5,
+        otherLiabilities: 2,
+        totalCollectedAtPos: 0,
+      },
+    });
+    delete (input.revenue as Partial<MonthlyPerformanceInput['revenue']>)
+      .totalCollectedAtPos;
+
+    const result = calculateMonthlyPerformance(input);
+    expect(result.posCollectedFromBreakdownCents).toBe(11_500);
+  });
+
+  it('treats 0 as a valid totalCollectedAtPos (not a missing sentinel)', () => {
+    // A genuinely-zero period must round-trip to zero, not silently fall back
+    // to a non-zero pass-through formula.
+    const result = calculateMonthlyPerformance(
+      makeInput({
+        revenue: {
+          grossRevenue: 0, discounts: 0, netRevenue: 0,
+          salesTax: 0, tips: 0, otherLiabilities: 0,
+          totalCollectedAtPos: 0,
+        },
+      })
+    );
+    expect(result.posCollectedFromBreakdownCents).toBe(0);
   });
 });
 

--- a/tests/unit/useMonthlyExpenses.tz.test.ts
+++ b/tests/unit/useMonthlyExpenses.tz.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Regression: useMonthlyExpenses must bucket each row by the UTC day stored on
+ * the row, not by the host-local day.
+ *
+ * Russo's Pizzeria (America/Chicago) had a $216.75 COGS bank transaction stored
+ * as `transaction_date = '2026-05-01T00:00:00+00:00'`. The previous
+ * implementation called `format(new Date(t.transaction_date), 'yyyy-MM')`,
+ * which parses UTC then re-formats in the host TZ. In Chicago that yielded
+ * `'2026-04'`, so the row landed in April's bucket and Monthly Performance
+ * reported $3,787 of COGS instead of $4,003.73 for May.
+ *
+ * The same bug affects split parents and pending_outflows (issue_date DATE).
+ *
+ * Pin TZ=America/Chicago and assert each row buckets into '2026-05'.
+ *
+ * Companion to tests/unit/cogsCalculations.tz.test.ts which covers the
+ * shared day-level helper used by useCOGSFromFinancials.
+ */
+
+process.env.TZ = 'America/Chicago';
+
+import React, { ReactNode } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// ---------------------------------------------------------------------------
+// Mocks — stub fetchExpenseData so we can drive the hook with synthetic rows
+// ---------------------------------------------------------------------------
+
+const mockFetchExpenseData = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/expenseDataFetcher', () => ({
+  fetchExpenseData: mockFetchExpenseData,
+}));
+
+// ---------------------------------------------------------------------------
+// Import after mocks
+// ---------------------------------------------------------------------------
+
+import { useMonthlyExpenses } from '@/hooks/useMonthlyExpenses';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+};
+
+const DATE_FROM = new Date('2026-04-01T00:00:00Z');
+const DATE_TO = new Date('2026-05-31T23:59:59Z');
+
+describe('useMonthlyExpenses — TZ bucketing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('confirms the host process is on America/Chicago (Russo TZ)', () => {
+    // Defensive: if this fails, the rest of the suite will produce false
+    // negatives because the bug is host-TZ-dependent.
+    expect(new Date().getTimezoneOffset()).toBeGreaterThan(0);
+  });
+
+  it('buckets a 00:00 UTC bank txn into its UTC month (2026-05), not the host-local month', async () => {
+    mockFetchExpenseData.mockResolvedValue({
+      transactions: [
+        {
+          id: 'bt-may-1',
+          transaction_date: '2026-05-01T00:00:00+00:00',
+          amount: -216.75,
+          is_split: false,
+          category_id: 'cat-cogs',
+          chart_of_accounts: { account_name: 'Food Cost', account_subtype: 'food_cost' },
+        },
+      ],
+      pendingOutflows: [],
+      splitDetails: [],
+    });
+
+    const { result } = renderHook(
+      () => useMonthlyExpenses('rest-russo', DATE_FROM, DATE_TO),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const may = result.current.data?.find(m => m.period === '2026-05');
+    const april = result.current.data?.find(m => m.period === '2026-04');
+
+    expect(may).toBeDefined();
+    expect(may?.foodCost).toBeCloseTo(216.75, 2);
+    expect(may?.totalExpenses).toBeCloseTo(216.75, 2);
+    // The bug would have produced an April row; assert it's not there.
+    expect(april).toBeUndefined();
+  });
+
+  it('buckets a split parent at 00:00 UTC into the UTC month (2026-05)', async () => {
+    mockFetchExpenseData.mockResolvedValue({
+      transactions: [
+        {
+          id: 'bt-split-parent',
+          transaction_date: '2026-05-01T00:00:00+00:00',
+          amount: -300,
+          is_split: true,
+          category_id: null,
+          chart_of_accounts: null,
+        },
+      ],
+      pendingOutflows: [],
+      splitDetails: [
+        {
+          transaction_id: 'bt-split-parent',
+          amount: 200,
+          category_id: 'cat-food',
+          chart_of_accounts: { account_name: 'Food Cost', account_subtype: 'food_cost' },
+        },
+        {
+          transaction_id: 'bt-split-parent',
+          amount: 100,
+          category_id: 'cat-rent',
+          chart_of_accounts: { account_name: 'Rent', account_subtype: 'rent' },
+        },
+      ],
+    });
+
+    const { result } = renderHook(
+      () => useMonthlyExpenses('rest-russo', DATE_FROM, DATE_TO),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const may = result.current.data?.find(m => m.period === '2026-05');
+    const april = result.current.data?.find(m => m.period === '2026-04');
+
+    expect(may).toBeDefined();
+    expect(may?.foodCost).toBeCloseTo(200, 2);
+    expect(may?.totalExpenses).toBeCloseTo(300, 2);
+    expect(april).toBeUndefined();
+  });
+
+  it('buckets a pending_outflows DATE issue_date by the calendar day in the string', async () => {
+    // pending_outflows.issue_date is a Postgres DATE → string 'YYYY-MM-DD'.
+    // `new Date('2026-05-01')` ⇒ 00:00 UTC. In Chicago that renders as
+    // '2026-04-30' → buggy code would bucket into April.
+    mockFetchExpenseData.mockResolvedValue({
+      transactions: [],
+      pendingOutflows: [
+        {
+          amount: 55.65,
+          category_id: 'cat-labor',
+          issue_date: '2026-05-01',
+          status: 'pending',
+          chart_account: { account_name: 'Labor', account_subtype: 'labor' },
+        },
+      ],
+      splitDetails: [],
+    });
+
+    const { result } = renderHook(
+      () => useMonthlyExpenses('rest-russo', DATE_FROM, DATE_TO),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const may = result.current.data?.find(m => m.period === '2026-05');
+    const april = result.current.data?.find(m => m.period === '2026-04');
+
+    expect(may).toBeDefined();
+    expect(may?.laborCost).toBeCloseTo(55.65, 2);
+    expect(may?.totalExpenses).toBeCloseTo(55.65, 2);
+    expect(april).toBeUndefined();
+  });
+
+  it('aggregates Russo May 1 production rows into the correct month bucket', async () => {
+    // Composite case mirroring the production discrepancy:
+    //   COGS:  $189.05 + $27.70 = $216.75
+    //   Labor: $335.36 + $55.65 = $391.01
+    mockFetchExpenseData.mockResolvedValue({
+      transactions: [
+        {
+          id: 'bt-cogs-1', transaction_date: '2026-05-01T00:00:00+00:00',
+          amount: -189.05, is_split: false, category_id: 'cat-cogs',
+          chart_of_accounts: { account_name: 'Food Cost', account_subtype: 'food_cost' },
+        },
+        {
+          id: 'bt-cogs-2', transaction_date: '2026-05-01T00:00:00+00:00',
+          amount: -27.70, is_split: false, category_id: 'cat-cogs',
+          chart_of_accounts: { account_name: 'Food Cost', account_subtype: 'food_cost' },
+        },
+        {
+          id: 'bt-labor-1', transaction_date: '2026-05-01T00:00:00+00:00',
+          amount: -335.36, is_split: false, category_id: 'cat-labor',
+          chart_of_accounts: { account_name: 'Labor', account_subtype: 'labor' },
+        },
+      ],
+      pendingOutflows: [
+        {
+          amount: 55.65, category_id: 'cat-labor', issue_date: '2026-05-01',
+          status: 'pending',
+          chart_account: { account_name: 'Labor', account_subtype: 'labor' },
+        },
+      ],
+      splitDetails: [],
+    });
+
+    const { result } = renderHook(
+      () => useMonthlyExpenses('rest-russo', DATE_FROM, DATE_TO),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const may = result.current.data?.find(m => m.period === '2026-05');
+    expect(may).toBeDefined();
+    expect(may?.foodCost).toBeCloseTo(216.75, 2);
+    expect(may?.laborCost).toBeCloseTo(391.01, 2);
+    expect(may?.totalExpenses).toBeCloseTo(607.76, 2);
+
+    // No row should have leaked into April.
+    expect(result.current.data?.find(m => m.period === '2026-04')).toBeUndefined();
+  });
+
+  it('keeps mid-month rows in the same month regardless of host TZ', async () => {
+    // Control: a mid-month row is unambiguous; bug or no bug, it stays put.
+    mockFetchExpenseData.mockResolvedValue({
+      transactions: [
+        {
+          id: 'bt-mid-may', transaction_date: '2026-05-15T18:00:00+00:00',
+          amount: -100, is_split: false, category_id: 'cat-cogs',
+          chart_of_accounts: { account_name: 'Food Cost', account_subtype: 'food_cost' },
+        },
+      ],
+      pendingOutflows: [],
+      splitDetails: [],
+    });
+
+    const { result } = renderHook(
+      () => useMonthlyExpenses('rest-russo', DATE_FROM, DATE_TO),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data?.[0].period).toBe('2026-05');
+    expect(result.current.data?.[0].foodCost).toBe(100);
+  });
+});


### PR DESCRIPTION
## Summary

Two narrow bugs that PR #492 missed, both visible on Russo's Pizzeria (TZ `America/Chicago`) May 2026:

- **`useMonthlyExpenses.tsx`** — three sites bucketed rows with `format(new Date(raw), 'yyyy-MM')`. In Chicago, `2026-05-01T00:00:00+00:00` rendered as `'2026-04-30'` → row leaked into April. Replace with `toUtcDayKey(raw).slice(0, 7)`, the same UTC-first pattern as the PR #492 fixes.
- **`_shared/monthlyPerformance.ts:115`** — silently re-derived "POS collected" from `gross + tax + tips + other_liabilities`, ignoring the caller-supplied `totalCollectedAtPos`. The legacy formula misses Toast void/discount offset rows that the deposit includes; for Russo May 2026 it overstated POS collected by $1,354.44 vs the POS Sales page. Now prefers the `get_unified_sales_totals.collected_at_pos` value when supplied; falls back to the legacy formula only on `null`/`undefined`. `0` is a valid zero-collected period.

Also pins `monthlyPerformance.acceptance.test.ts` to `TZ=UTC` at module load so its ISO-week labor-wages assertion is hermetic against TZ pollution from `cogsCalculations.tz.test.ts` / the new `useMonthlyExpenses.tz.test.ts`.

## Russo May 2026 numbers (after fix)

| Card | Before | After (correct) |
|---|---|---|
| Monthly Performance COGS | $3,787 | **$4,003.73** |
| Monthly Performance Labor | $10,745 | **$11,136** |
| Monthly Performance Collected at POS | $32,950.80 | **$31,596.36** |

Performance Overview and POS Sales already showed the correct numbers; Monthly Performance now matches them.

## Test plan

- [ ] `npm run typecheck` — clean
- [ ] `npm run lint` on changed files — clean
- [ ] `npm run test` — 264 files / 3858 tests pass (1 skipped, pre-existing)
- [ ] New `tests/unit/useMonthlyExpenses.tz.test.ts` (6 tests, pinned `TZ=America/Chicago`)
- [ ] Updated `tests/unit/monthlyPerformance.test.ts` (+4 prefer-totalCollectedAtPos cases)
- [ ] Russo's `/dashboard` May card: COGS $4,003.73, Labor $11,136, Collected $31,596.36 — matches Performance Overview & POS Sales

## Out of scope

- Performance Overview cards (already correct, no path change).
- "Other Expenses" composition (correct value, just timing-inflated).
- Edge function callers of `calculateMonthlyPerformance` (none today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Monthly expense reports now bucket transactions using UTC day boundaries for accurate timezone-independent reporting.
  * POS collected amounts now use provided actual deposit data when available.

* **Tests**
  * Added comprehensive test suite for timezone-safe monthly expense bucketing.

* **Documentation**
  * Added detailed design and implementation specifications for monthly expense and POS reconciliation updates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toyiyo/nimble-pnl/pull/495)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->