### PR TITLE
fix(dialog): sticky-footer so Record Sale stays reachable on small viewports

### DIFF
--- a/docs/superpowers/plans/2026-05-16-manual-sale-mobile-form-plan.md
+++ b/docs/superpowers/plans/2026-05-16-manual-sale-mobile-form-plan.md
@@ -1,0 +1,89 @@
+# Implementation Plan — Manual Sale dialog mobile fix
+
+**Spec:** `docs/superpowers/specs/2026-05-16-manual-sale-mobile-form-design.md`
+
+## Tasks (TDD order)
+
+### Task 1: Add primitive-default tests (RED)
+
+Create `tests/unit/dialogPrimitive.defaults.test.tsx`.
+
+1. Test: `DialogContent` without overrides has classes `max-h-[85vh]` and `overflow-y-auto`.
+2. Test: `DialogContent className="max-h-[60vh]"` resolves to `max-h-[60vh]` (no `max-h-[85vh]`).
+3. Test: `DialogContent className="overflow-hidden"` resolves to `overflow-hidden` (no `overflow-y-auto`).
+
+Run vitest, confirm tests fail.
+
+### Task 2: Update primitive defaults (GREEN)
+
+Edit `src/components/ui/dialog.tsx`:
+
+- Add `max-h-[85vh] overflow-y-auto` to `DialogContent`'s default className.
+
+Run vitest, confirm Task 1 tests now pass.
+
+### Task 3: Add POSSaleDialog sticky-footer tests (RED)
+
+Create `tests/unit/POSSaleDialog.scroll.test.tsx`. Mock hooks following the
+pattern in `tests/unit/CheckSettingsDialog.test.tsx`.
+
+1. Test: outermost dialog content has `max-h-[85vh] flex flex-col`.
+2. Test: a scrollable form body (`flex-1 overflow-y-auto`) wraps the form fields.
+3. Test: a fixed footer (`flex-shrink-0` with `border-t`) contains both
+   `Cancel` and `Record Sale` buttons.
+
+Run vitest, confirm tests fail.
+
+### Task 4: Refactor POSSaleDialog layout (GREEN)
+
+Edit `src/components/POSSaleDialog.tsx`:
+
+- Change `<DialogContent>` className to
+  `sm:max-w-md max-h-[85vh] overflow-hidden p-0 gap-0 border-border/40 flex flex-col`.
+- Add `flex-shrink-0` to `<DialogHeader>` className.
+- Wrap the existing form fields (everything between `<Form …>` open and the
+  `{/* Footer Actions */}` block) in a single
+  `<div className="flex-1 overflow-y-auto px-6 py-5 space-y-5">`. Remove the
+  matching `px-6 py-5 space-y-5` from the `<form>` element (move padding
+  from form to the new scrollable body).
+- Wrap the existing footer button row in
+  `<div className="flex-shrink-0 flex gap-2 px-6 py-4 border-t border-border/40 bg-background pb-[max(env(safe-area-inset-bottom),1rem)]">`.
+  Remove the now-redundant `pt-4 border-t border-border/40` from the inner row.
+
+Run vitest, confirm Task 3 tests now pass.
+
+### Task 5: Manual smoke test
+
+Run `npm run dev` and verify in browser:
+
+- At desktop viewport: dialog appears centered, header + footer visible, body scrolls if you fill many adjustments.
+- Resize browser to 1200 × 657 (DevTools): Save button still visible.
+- Resize to iPhone SE (320 × 568): Save button still visible at the bottom.
+- Smoke-check `MapPOSItemDialog` (POS Items page) and `ManualMatchDialog`
+  (Pending Outflows page) still render and scroll correctly with the
+  primitive change.
+
+### Task 6: Run full verification suite
+
+- `npm run typecheck`
+- `npm run lint`
+- `npm run test`
+- `npm run build`
+
+Fix any regressions. Re-run until green.
+
+### Task 7: Commit, push, open PR
+
+- Single commit (or two: primitive + dialog) on `fix/manual-sale-mobile-scroll`.
+- Open PR linking to the design doc, with summary and test plan.
+
+## Dependencies
+
+- Task 2 depends on Task 1.
+- Task 4 depends on Task 3 (and indirectly Task 2 — the primitive defaults
+  are already in place when we refactor the dialog).
+- Tasks 5–7 depend on Tasks 1–4 passing.
+
+## Estimated time
+
+~30 min total. Each task is 2–5 min.

--- a/docs/superpowers/specs/2026-05-16-manual-sale-mobile-form-design.md
+++ b/docs/superpowers/specs/2026-05-16-manual-sale-mobile-form-design.md
@@ -1,0 +1,166 @@
+# Manual Sale dialog — mobile / small-viewport fix
+
+**Date:** 2026-05-16
+**Branch:** `fix/manual-sale-mobile-scroll`
+**Origin:** PostHog session replay `019e279d-6758-7ee5-b23e-33a636421183`
+
+## Problem
+
+A user reported they "couldn't scroll" when adding a new manual sale. The replay
+shows the form opening as a modal dialog but the user is unable to reach the
+**Record Sale** button at the bottom and abandons the flow.
+
+### Root cause
+
+`src/components/POSSaleDialog.tsx:328` renders:
+
+```tsx
+<DialogContent className="sm:max-w-md p-0 gap-0 border-border/40">
+```
+
+There is **no** `max-h-[Xvh]` and **no** `overflow-y-auto`. The base
+`DialogContent` (Radix wrapper at `src/components/ui/dialog.tsx`) only sets
+`max-w-lg`, also without any height constraint or overflow rule.
+
+When the modal opens, Radix locks `body { overflow: hidden }` to prevent the
+page from scrolling behind the modal. With no height cap and no internal
+scroll on the dialog itself, content that exceeds the viewport simply
+gets clipped — the entire bottom of the form, including Save and Cancel,
+is unreachable.
+
+The Manual Sale form is tall: header → item picker → quantity/unit-price row →
+total price → date/time row → 5-field Adjustments section → totals summary
+panel → footer with buttons. Easily 800+px. The PostHog replay shows a
+**1200 × 657** viewport (small laptop with browser chrome), so the form
+overflows by ~150px. Mobile devices in portrait (≈ 360 × 640) overflow far
+more dramatically.
+
+The user described the device as "mobile" because the symptom matches what
+mobile users experience, but the bug is viewport-height-driven and affects
+small laptops too.
+
+### Other dialogs
+
+A grep of `src/components` and `src/pages` finds ~40 `<DialogContent>` usages
+that lack any `max-h`. Most are short confirmation dialogs that fit comfortably
+in any viewport, but several are form-heavy (`AccountDialog`, `EmployeeDialog`,
+`TimeOffRequestDialog`, etc.) and could exhibit the same bug on small screens.
+
+## Goals
+
+1. **Primary:** The Manual Sale dialog must work end-to-end on any viewport
+   down to iPhone SE (320 × 568). The Save / Cancel buttons must always be
+   visible while the user fills out the form.
+2. **Secondary:** Every other dialog in the codebase gets a reasonable
+   safety net by default — content beyond the viewport is reachable via
+   scroll, even if the developer forgot to add a constraint.
+3. Tests guard against regression of (1).
+
+## Non-goals
+
+- We are **not** rewriting the dialog as a native mobile Sheet/Drawer. That
+  would be a bigger UX change requiring product input; the safety-net +
+  sticky-footer pattern is sufficient.
+- We are **not** auditing each of the 40 dialogs individually. The primitive
+  default catches them as a group, and any specific dialog that needs a
+  more sophisticated layout (e.g. tabs, side panels) is unaffected because
+  `tailwind-merge` lets explicit overrides win.
+
+## Design
+
+### Layer 1 — Primitive safety net
+
+Update `DialogContent` defaults in `src/components/ui/dialog.tsx` to include
+`max-h-[85vh]` and `overflow-y-auto`. Because the project's `cn()` uses
+`tailwind-merge`, any caller that explicitly sets `max-h-X` or
+`overflow-hidden` will keep its value. Existing dialogs are not affected
+unless they had neither constraint, in which case they gain a reasonable
+fallback.
+
+We use `85vh` rather than `100vh` so the dialog never feels edge-to-edge on
+desktop while leaving generous breathing room for mobile keyboards.
+
+### Layer 2 — Sticky footer for `POSSaleDialog`
+
+Restructure the dialog to use a 3-row flex layout:
+
+```tsx
+<DialogContent className="sm:max-w-md max-h-[85vh] overflow-hidden p-0 gap-0 border-border/40 flex flex-col">
+  <DialogHeader className="flex-shrink-0 ...">…</DialogHeader>
+  <Form …>
+    <form …>
+      <div className="flex-1 overflow-y-auto px-6 py-5 space-y-5">
+        {/* all the form fields */}
+      </div>
+      <div className="flex-shrink-0 flex gap-2 px-6 py-4 border-t border-border/40 bg-background">
+        {/* Cancel + Save buttons */}
+      </div>
+    </form>
+  </Form>
+</DialogContent>
+```
+
+Key properties:
+
+- Outer container is `flex flex-col` with `max-h-[85vh]` and `overflow-hidden`
+  (overrides Layer 1's `overflow-y-auto` because we'll scroll the middle, not
+  the whole container).
+- Header is `flex-shrink-0` — always at the top.
+- Form body is `flex-1 overflow-y-auto` — fills available space and scrolls
+  when content overflows.
+- Footer is `flex-shrink-0` with a top border — always pinned at the bottom.
+
+This keeps **Save** always tappable, even on a 320 × 568 phone, while the
+user scrolls through the form fields above.
+
+### Mobile padding consideration
+
+Add `pb-[max(env(safe-area-inset-bottom),1rem)]` to the footer to respect
+iOS home-indicator safe area on phones. (Optional polish, but cheap.)
+
+## Tests
+
+### Unit (vitest + @testing-library/react)
+
+Add `tests/unit/POSSaleDialog.scroll.test.tsx`:
+
+- Renders the dialog with `open`.
+- Asserts the form body wrapper has class `flex-1` and `overflow-y-auto`.
+- Asserts the footer wrapper has class `flex-shrink-0` and contains both
+  Cancel and Record Sale buttons.
+- Asserts the outermost `DialogContent` has `max-h-[85vh]` and `flex flex-col`.
+
+These class assertions are intentionally low-level — the goal is to lock in
+the layout primitives that produce a sticky footer. A higher-fidelity
+visual test belongs to Playwright (out of scope here).
+
+### Unit (dialog primitive)
+
+Add `tests/unit/dialogPrimitive.defaults.test.tsx`:
+
+- Render `<Dialog open><DialogContent>...</DialogContent></Dialog>`.
+- Assert `DialogContent` has `max-h-[85vh]` and `overflow-y-auto`.
+- Render again with `<DialogContent className="max-h-[60vh] overflow-hidden">`.
+- Assert `max-h-[60vh]` wins (no `max-h-[85vh]`) and `overflow-hidden` wins
+  (no `overflow-y-auto`). This locks in the twMerge override contract.
+
+## Migration / rollout
+
+No data migration. No feature flag. Single PR ships both layers together —
+the primitive change is backward compatible by `tailwind-merge` semantics.
+
+## Risks
+
+- **Risk:** A dialog that intentionally extended past the viewport (e.g. for
+  a custom full-screen experience) might now have an extra `max-h-[85vh]`.
+  **Mitigation:** A grep of the codebase finds none — every full-screen
+  dialog (`prep/*Dialog`, `ManualMatch`, `EnhancedReconciliation`,
+  `AssetColumnMapping`, `Assets`) explicitly sets `h-[XXvh]` or `max-h-[XXvh]`,
+  which wins over the default.
+- **Risk:** A dialog whose outer is `flex flex-col` with no overflow rule
+  (e.g. `MapPOSItemDialog`) gains an outer `overflow-y-auto`. Inner
+  `flex-1 overflow-y-auto` regions still work because the inner div claims
+  the remaining flex space, and the outer only scrolls if total content
+  exceeds `max-h-[80vh]` (its own override).
+  **Mitigation:** Manual smoke test of `MapPOSItemDialog`,
+  `ManualMatchDialog` in the dev server.

--- a/src/components/POSSaleDialog.tsx
+++ b/src/components/POSSaleDialog.tsx
@@ -325,9 +325,9 @@ export const POSSaleDialog: React.FC<POSSaleDialogProps> = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md p-0 gap-0 border-border/40">
+      <DialogContent className="sm:max-w-md max-h-[85vh] overflow-hidden p-0 gap-0 border-border/40 flex flex-col">
         {/* Apple-style header */}
-        <DialogHeader className="px-6 pt-6 pb-4 border-b border-border/40">
+        <DialogHeader className="flex-shrink-0 px-6 pt-6 pb-4 border-b border-border/40">
           <div className="flex items-center gap-3">
             <div className="h-10 w-10 rounded-xl bg-muted/50 flex items-center justify-center">
               <Receipt className="h-5 w-5 text-foreground" />
@@ -344,7 +344,8 @@ export const POSSaleDialog: React.FC<POSSaleDialogProps> = ({
         </DialogHeader>
 
         <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} className="px-6 py-5 space-y-5">
+          <form onSubmit={form.handleSubmit(onSubmit)} className="flex-1 min-h-0 flex flex-col">
+            <div data-testid="pos-sale-scroll-body" className="flex-1 overflow-y-auto px-6 py-5 space-y-5">
             {/* Item Name Field */}
             <FormField
               control={form.control}
@@ -815,8 +816,13 @@ export const POSSaleDialog: React.FC<POSSaleDialogProps> = ({
               </div>
             )}
 
-            {/* Footer Actions */}
-            <div className="flex gap-2 pt-4 border-t border-border/40">
+            </div>
+
+            {/* Sticky footer actions — stays visible regardless of viewport height */}
+            <div
+              data-testid="pos-sale-footer"
+              className="flex-shrink-0 flex gap-2 px-6 pt-4 pb-[max(env(safe-area-inset-bottom),1rem)] border-t border-border/40 bg-background"
+            >
               <Button
                 type="button"
                 variant="ghost"

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg max-h-[85vh] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className,
       )}
       {...props}

--- a/tests/unit/POSSaleDialog.scroll.test.tsx
+++ b/tests/unit/POSSaleDialog.scroll.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { POSSaleDialog } from '@/components/POSSaleDialog';
+
+vi.mock('@/hooks/useUnifiedSales', () => ({
+  useUnifiedSales: () => ({
+    createManualSale: vi.fn(),
+    createManualSaleWithAdjustments: vi.fn(),
+    updateManualSale: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/usePOSItems', () => ({
+  usePOSItems: () => ({
+    posItems: [],
+    loading: false,
+    refetch: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useRecipes', () => ({
+  useRecipes: () => ({
+    recipes: [],
+    loading: false,
+  }),
+}));
+
+describe('POSSaleDialog layout — sticky footer', () => {
+  it('renders the outer DialogContent with max-h-[85vh] + flex flex-col so the box has a height cap and can host a sticky footer', () => {
+    render(
+      <POSSaleDialog
+        open
+        onOpenChange={vi.fn()}
+        restaurantId="r-1"
+        editingSale={null}
+      />,
+    );
+
+    const content = screen.getByRole('dialog');
+    expect(content.className).toContain('max-h-[85vh]');
+    expect(content.className).toContain('flex-col');
+  });
+
+  it('wraps the form fields in a scrollable body (flex-1 overflow-y-auto) so long forms scroll within the dialog', () => {
+    render(
+      <POSSaleDialog
+        open
+        onOpenChange={vi.fn()}
+        restaurantId="r-1"
+        editingSale={null}
+      />,
+    );
+
+    const scrollBody = document.querySelector('[data-testid="pos-sale-scroll-body"]');
+    expect(scrollBody).not.toBeNull();
+    expect(scrollBody?.className).toContain('flex-1');
+    expect(scrollBody?.className).toContain('overflow-y-auto');
+  });
+
+  it('pins the footer with flex-shrink-0 and a top border so Cancel and Record Sale are always visible', () => {
+    render(
+      <POSSaleDialog
+        open
+        onOpenChange={vi.fn()}
+        restaurantId="r-1"
+        editingSale={null}
+      />,
+    );
+
+    const footer = document.querySelector('[data-testid="pos-sale-footer"]');
+    expect(footer).not.toBeNull();
+    expect(footer?.className).toContain('flex-shrink-0');
+    expect(footer?.className).toContain('border-t');
+
+    expect(footer?.querySelector('button[type="button"]')).toHaveTextContent('Cancel');
+    expect(footer?.querySelector('button[type="submit"]')).toHaveTextContent('Record Sale');
+  });
+});

--- a/tests/unit/dialogPrimitive.defaults.test.tsx
+++ b/tests/unit/dialogPrimitive.defaults.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+describe('DialogContent primitive defaults', () => {
+  it('applies max-h-[85vh] and overflow-y-auto safety net by default', () => {
+    render(
+      <Dialog open>
+        <DialogContent>
+          <DialogTitle>Test dialog</DialogTitle>
+          <p>Content</p>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    const content = screen.getByRole('dialog');
+    expect(content.className).toContain('max-h-[85vh]');
+    expect(content.className).toContain('overflow-y-auto');
+  });
+
+  it('lets an explicit max-h override the default', () => {
+    render(
+      <Dialog open>
+        <DialogContent className="max-h-[60vh]">
+          <DialogTitle>Test dialog</DialogTitle>
+          <p>Content</p>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    const content = screen.getByRole('dialog');
+    expect(content.className).toContain('max-h-[60vh]');
+    expect(content.className).not.toContain('max-h-[85vh]');
+  });
+
+  it('lets an explicit overflow rule override the default', () => {
+    render(
+      <Dialog open>
+        <DialogContent className="overflow-hidden">
+          <DialogTitle>Test dialog</DialogTitle>
+          <p>Content</p>
+        </DialogContent>
+      </Dialog>,
+    );
+
+    const content = screen.getByRole('dialog');
+    expect(content.className).toContain('overflow-hidden');
+    expect(content.className).not.toContain('overflow-y-auto');
+  });
+});


### PR DESCRIPTION
## Summary
- **PostHog repro**: replay [`019e279d-6758-7ee5-b23e-33a636421183`](https://us.posthog.com/project/233023/replay/019e279d-6758-7ee5-b23e-33a636421183?timestamp=1778785814945) — user opens *Add Manual Sale*, fills the form, then has no way to submit. Form is taller than the dialog box and Radix locks page scroll while the modal is open, so Cancel / Record Sale fall below the fold and become unreachable. Same failure mode on mobile and on short desktop windows (the replay itself is a 1200×657 desktop Chrome).
- **Two-layer fix**:
  1. `src/components/ui/dialog.tsx` — `DialogContent` now defaults to `max-h-[85vh] overflow-y-auto`. Any existing dialog that didn't set a height cap now degrades gracefully. `tailwind-merge` lets callers override (`max-h-[60vh]`, `overflow-hidden`, etc.).
  2. `src/components/POSSaleDialog.tsx` — opts into the explicit sticky-footer layout: outer `flex flex-col`, scrollable body (`flex-1 overflow-y-auto`), pinned footer (`flex-shrink-0 border-t`) with `pb-[max(env(safe-area-inset-bottom),1rem)]` for iOS notch.
- **Tests**: 6 new unit tests pin both layers — primitive defaults + override behavior, and the sticky-footer structure on the manual sale form.

Spec + plan committed in `docs/superpowers/specs/2026-05-16-manual-sale-mobile-form-design.md` and `docs/superpowers/plans/2026-05-16-manual-sale-mobile-form-plan.md`.

## Test plan
- [ ] Open *Add Manual Sale* on a small viewport (~640×600 or mobile) — form fields scroll inside the dialog, Cancel / Record Sale remain pinned.
- [ ] Open on a tall viewport — dialog still capped at 85vh, no layout shift.
- [ ] Submit + edit existing sale paths still work (footer button label flips Update Sale / Record Sale).
- [ ] Spot-check other dialogs (TipPayoutSheet, NewProductionRunDialog, PrepRecipeDialog, MapPOSItemDialog) — no regressions from the new primitive defaults.
- [ ] `npm run test` green; `npm run typecheck` green; `npm run build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scrolling issues preventing users from accessing all content in the Mobile Manual Sale modal on smaller screens.
  * Redesigned layout with a sticky footer to ensure Cancel and Record Sale buttons remain visible and accessible while scrolling through the form.

* **UI Enhancements**
  * Improved dialog animation transitions for a more polished user experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toyiyo/nimble-pnl/pull/496?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->