### PR TITLE
test(dialog): assert overflow-hidden on POSSaleDialog + spec doc fixups

### DIFF
--- a/docs/superpowers/plans/2026-05-16-manual-sale-mobile-form-plan.md
+++ b/docs/superpowers/plans/2026-05-16-manual-sale-mobile-form-plan.md
@@ -27,7 +27,8 @@ Run vitest, confirm Task 1 tests now pass.
 Create `tests/unit/POSSaleDialog.scroll.test.tsx`. Mock hooks following the
 pattern in `tests/unit/CheckSettingsDialog.test.tsx`.
 
-1. Test: outermost dialog content has `max-h-[85vh] flex flex-col`.
+1. Test: outermost dialog content has `max-h-[85vh] overflow-hidden flex flex-col`
+   (outer is height-capped and non-scrolling so only the inner body scrolls).
 2. Test: a scrollable form body (`flex-1 overflow-y-auto`) wraps the form fields.
 3. Test: a fixed footer (`flex-shrink-0` with `border-t`) contains both
    `Cancel` and `Record Sale` buttons.

--- a/docs/superpowers/specs/2026-05-16-manual-sale-mobile-form-design.md
+++ b/docs/superpowers/specs/2026-05-16-manual-sale-mobile-form-design.md
@@ -161,6 +161,6 @@ the primitive change is backward compatible by `tailwind-merge` semantics.
   (e.g. `MapPOSItemDialog`) gains an outer `overflow-y-auto`. Inner
   `flex-1 overflow-y-auto` regions still work because the inner div claims
   the remaining flex space, and the outer only scrolls if total content
-  exceeds `max-h-[80vh]` (its own override).
+  exceeds `max-h-[85vh]` (its own override).
   **Mitigation:** Manual smoke test of `MapPOSItemDialog`,
   `ManualMatchDialog` in the dev server.

--- a/tests/unit/POSSaleDialog.scroll.test.tsx
+++ b/tests/unit/POSSaleDialog.scroll.test.tsx
@@ -27,7 +27,7 @@ vi.mock('@/hooks/useRecipes', () => ({
 }));
 
 describe('POSSaleDialog layout — sticky footer', () => {
-  it('renders the outer DialogContent with max-h-[85vh] + flex flex-col so the box has a height cap and can host a sticky footer', () => {
+  it('renders the outer DialogContent with max-h-[85vh] + overflow-hidden + flex flex-col so the box has a height cap and only the inner body scrolls', () => {
     render(
       <POSSaleDialog
         open
@@ -39,6 +39,7 @@ describe('POSSaleDialog layout — sticky footer', () => {
 
     const content = screen.getByRole('dialog');
     expect(content.className).toContain('max-h-[85vh]');
+    expect(content.className).toContain('overflow-hidden');
     expect(content.className).toContain('flex-col');
   });
 


### PR DESCRIPTION
## Summary
Follow-up to #496 (now merged) from the CodeRabbit local review. None of these change runtime behavior — they pin an invariant the implementation already satisfies and tidy the design docs.

- **Test**: `tests/unit/POSSaleDialog.scroll.test.tsx` now asserts `overflow-hidden` on the outer `DialogContent`. The implementation in `POSSaleDialog.tsx:328` already sets it (necessary because the primitive default is `overflow-y-auto` — without the override the outer would scroll alongside the inner `flex-1 overflow-y-auto` body, producing a double-scroll regression). The test now catches anyone removing it.
- **Spec doc** `docs/superpowers/specs/2026-05-16-manual-sale-mobile-form-design.md`: one risk paragraph said `max-h-[80vh]` while every other reference uses `max-h-[85vh]`. Fixed.
- **Plan doc** `docs/superpowers/plans/2026-05-16-manual-sale-mobile-form-plan.md`: Task 3 test description now mentions `overflow-hidden` alongside `flex flex-col` so future readers see why it matters.

## Test plan
- [ ] `npm run test -- POSSaleDialog.scroll dialogPrimitive.defaults` green (6/6).
- [ ] No runtime change expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)