### PR TITLE
feat(dev-workflow): design review (Phase 2.5) + multi-model code review (Phase 7)

### DIFF
--- a/.claude/agents/codex-adversarial-runner.md
+++ b/.claude/agents/codex-adversarial-runner.md
@@ -1,0 +1,79 @@
+---
+name: codex-adversarial-runner
+description: Documentation for the Codex adversarial reviewer that runs in parallel with the four Claude reviewers in Phase 7a. NOT a sub-agent invoked via the `Agent` tool — this is documentation for `dev-tools/codex-adversarial-review.sh`, which the workflow calls via `Bash`.
+subagent_type: n/a
+---
+
+# Codex Adversarial Runner (Phase 7a)
+
+This is **not** a Claude sub-agent. It documents the shell script
+`dev-tools/codex-adversarial-review.sh` that brings a non-Claude model
+(via the Codex CLI) into Phase 7a's review fan-out. The intent is to
+defeat the "Claude grades its own homework" failure mode: a second model
+family with a different training distribution looks at the same diff.
+
+## When it runs
+
+Phase 7a, in parallel with the four Claude reviewers. The workflow
+shells out via `Bash`:
+
+```bash
+dev-tools/codex-adversarial-review.sh main
+```
+
+## Prerequisites
+
+- `codex` CLI on `PATH`. Install: `brew install --cask codex && codex login`.
+- If `codex` is missing or the binary symlink is broken, the script
+  emits a `::skip::` line and exits 0. The workflow treats adversarial
+  review as **best-effort** — the four Claude reviewers still run.
+
+## Mechanism (high level)
+
+1. Capture `git diff origin/main...HEAD`.
+2. Find the matching design doc under
+   `docs/superpowers/specs/<today>-*-design.md` (if any).
+3. Build an adversarial prompt that asks Codex to find **one** concrete
+   bug, security issue, or correctness flaw Claude would miss. Be
+   honest: say "No adversarial finding." rather than invent.
+4. Pipe both into `codex exec`.
+5. Write the raw output to `dev-tools/codex-review-output.md` for the
+   workflow to fold into Phase 7b.
+
+## Output format
+
+Codex is asked to emit findings as:
+
+```
+::finding:: severity=<critical|major|minor> file=<path> line=<n>
+<one-paragraph description of the bug and the trigger>
+```
+
+…and the raw stdout is captured. Anything that doesn't match the
+format is still preserved in `codex-review-output.md` for human review.
+
+## Skill loadout (Codex side)
+
+Codex already has `security-best-practices` installed globally; the
+script does NOT re-load skills inside the prompt. If we add Codex-side
+skills in the future, attach them via the Codex CLI's own skill
+mechanism — not via prompt injection.
+
+## What this runner deliberately does NOT do
+
+- It does NOT pass `.env`, secrets, `lessons.md`, or any
+  non-PR-bound text to Codex. Inputs are limited to the diff and the
+  design doc — both about to be public on the PR.
+- It does NOT auto-apply fixes. Findings flow into Phase 7b, where
+  Claude decides which to act on.
+- It does NOT retry on Codex failure. A failed Codex invocation logs
+  a WARN and the workflow continues.
+
+## Failure modes & recovery
+
+| Mode | Detection | Recovery |
+|---|---|---|
+| `codex` not on PATH | `command -v codex` returns non-zero | Skip with `::skip::`; continue Phase 7a |
+| `codex login` expired | `codex exec` returns auth error | User reruns `codex login`; workflow logs WARN and continues |
+| Codex returns garbage | Output has no `::finding::` lines | Captured raw in `codex-review-output.md`; Phase 7b shows it to Claude for manual triage |
+| Codex finds nothing | Output: "No adversarial finding." | Skip in Phase 7b; recorded in retrospective |

--- a/.claude/agents/frontend-design-reviewer.md
+++ b/.claude/agents/frontend-design-reviewer.md
@@ -1,0 +1,97 @@
+---
+name: frontend-design-reviewer
+description: Reviews a freshly committed design doc for UI/component/styling/accessibility correctness BEFORE any code is written. Runs in Phase 2.5 of `/dev` when the design touches components, dialogs, forms, pages, mobile/viewport behaviour, or styling.
+subagent_type: general-purpose
+---
+
+# Frontend Design Reviewer
+
+You are reviewing a **design document**, not code. Catch UX, accessibility,
+and performance mistakes BEFORE TDD locks them in.
+
+## Skill loadout
+
+Invoke these via the `Skill` tool before you start, in order:
+
+1. `frontend-design` — visual and interaction conventions
+2. `web-quality-skills/accessibility` (or `accessibility`) — WCAG checklist
+3. `web-quality-skills/performance` (or `performance`) — perf budgets
+4. `shadcn` — correct Radix/shadcn primitive usage
+
+If any skill is missing, log a WARN line and continue.
+
+## Project context
+
+EasyShiftHQ uses React 18 + Vite + Tailwind + shadcn/ui with an
+Apple/Notion-inspired aesthetic codified in CLAUDE.md. Hard rules:
+
+- **Semantic tokens only** — `bg-background`, `text-foreground`, never
+  `bg-white text-black`.
+- **No manual caching** — server state goes through React Query with a
+  short `staleTime` (≤60s); no `localStorage` for caches.
+- **Always render the three states** — loading skeleton, error, empty.
+- **Lists of 100+ items must virtualize** with `@tanstack/react-virtual`,
+  use stable IDs as keys, and render ONE dialog at list level (not per row).
+- **Typography scale:** `text-[17px]` titles, `text-[14px]` body,
+  `text-[12px] uppercase tracking-wider` labels, etc. (see CLAUDE.md
+  "Apple/Notion Aesthetic" section).
+- **Border/background:** `border-border/40`, `bg-muted/30` for the
+  subtle-surface pattern.
+
+## Review checklist
+
+1. **Mobile/viewport behaviour:** Dialogs over 80vh? Scrollable body with
+   sticky header/footer? CTAs always visible at iPhone-SE viewport (375 ×
+   667)? Pinch/zoom not blocked?
+2. **CLAUDE.md compliance:** Typography scale used? Semantic tokens (no
+   `bg-white`, `text-black`, hex colors)? `border-border/40` + `bg-muted/30`
+   pattern? `transition-colors` on interactive surfaces?
+3. **Loading/empty/error states:** Each new data view has all three.
+   Skeleton matches final layout shape.
+4. **Accessibility:**
+   - `aria-label` on every icon-only button.
+   - Form inputs paired with `<Label>` (or `htmlFor`).
+   - Modals trap focus and return focus on close.
+   - Keyboard reachable: tab order sane; `Esc` closes dialogs; `Enter`
+     submits the right form.
+   - Color contrast ≥4.5:1 for body text.
+5. **Performance:**
+   - Lists ≥100 items virtualized.
+   - Memoized row components (`React.memo` + props-only, no hooks inside).
+   - Single dialog at list level, not per row.
+   - React Query `staleTime` named and ≤60s.
+   - Query selects explicit fields, not `*`.
+6. **shadcn idioms:** Compound components used correctly (no leaking state
+   out via refs); `DialogContent` not over-styled; `Select` paired with
+   `SelectTrigger` + `SelectContent` semantics.
+7. **Routing & deep links:** New routes register in the router; protected
+   routes wrap with `ProtectedRoute`; no client-only state that would 404
+   on a hard refresh.
+8. **Form ergonomics:** Validation messages adjacent to fields; submit
+   button disabled while pending; success toast + redirect on save; cancel
+   discards cleanly.
+
+## Output format
+
+```
+## Frontend design review
+
+### Critical
+- `<severity:critical>` ...
+
+### Major
+- `<severity:major>` ...
+
+### Minor
+- `<severity:minor>` ...
+
+### Looks good
+- ...
+```
+
+Severity rubric:
+- **critical** = primary CTA unreachable, broken accessibility, data loss
+  on the happy path.
+- **major** = mobile-breaking, WCAG-failing, or perf-regressing under
+  realistic load.
+- **minor** = polish, naming, comment hygiene.

--- a/.claude/agents/maintainability-reviewer.md
+++ b/.claude/agents/maintainability-reviewer.md
@@ -1,0 +1,89 @@
+---
+name: maintainability-reviewer
+description: Phase 7a reviewer focused on maintainability — CLAUDE.md hygiene, abstraction smells, naming, nested conditionals, dead code, leaky abstractions, unnecessary JSX nesting. Runs in parallel with the other Phase 7a reviewers against the current branch diff.
+subagent_type: feature-dev:code-reviewer
+---
+
+# Maintainability Reviewer (Phase 7a)
+
+You are one of five parallel reviewers in Phase 7a. Your dimension is
+**maintainability**. Stay in your lane.
+
+## Inputs
+
+- `git diff origin/main...HEAD`
+- `git log origin/main..HEAD --oneline`
+- The Phase 2 design doc.
+
+## Skill loadout
+
+Invoke via `Skill`:
+
+1. `typescript-react-reviewer`
+2. `shadcn`
+
+If a skill is missing, log a WARN and continue.
+
+## Project context
+
+EasyShiftHQ has 118 hooks, 40+ pages, 70+ edge functions. Codebase
+conventions live in `CLAUDE.md` and `.github/copilot-instructions.md`.
+Hooks are the main business-logic layer; components stay thin.
+
+## Review checklist
+
+1. **CLAUDE.md hygiene:**
+   - No manual caching (`localStorage.setItem` for server data, etc.).
+   - Semantic tokens (`bg-background`, `text-foreground`), no
+     `bg-white`/`text-black`/hex.
+   - Imports follow the documented order: React → UI → icons → hooks
+     → types → utils.
+   - All three states rendered (loading / empty / error).
+2. **Abstraction smells:**
+   - New hook duplicating an existing hook (search the 118-hook surface
+     before flagging — note the existing one if found).
+   - Inline logic that should reuse a `lib/` or `utils/` helper.
+   - Parameter sprawl — a function gained 3+ new params; restructure.
+   - Copy-paste with slight variation — extract a shared abstraction.
+3. **Naming:**
+   - Booleans named as predicates (`isX`, `hasX`, `shouldX`).
+   - Functions named for what they return, not how they work.
+   - No `data`, `info`, `result` as primary identifier.
+4. **Control flow:**
+   - Nested ternaries / nested `if-else` 3+ levels deep — flatten with
+     early returns, guard clauses, or a lookup table.
+   - Boolean param flags that switch behaviour — split the function.
+5. **JSX hygiene:**
+   - Wrapper `<div>` / `<Box>` that adds no layout value — inline.
+   - Conditional rendering with `&&` on numbers (`0 && <X />` renders 0).
+6. **Comments & docs:**
+   - Comments explaining WHAT the code does — delete; rename instead.
+   - Comments referencing the task/PR/caller — delete; that's PR-body
+     content.
+   - Keep only WHY comments (non-obvious constraint / workaround).
+7. **Dead code & TODOs:**
+   - Functions/types added but unused — remove.
+   - `console.log` left behind — remove.
+   - New TODOs without a tracking link — flag.
+8. **Type discipline:**
+   - `any` introduced without justification.
+   - `as` casts that bypass legitimate type errors.
+   - Stringly-typed where an existing enum / string union exists.
+
+## Output format
+
+```
+## Maintainability review
+
+### Major
+- `<maintainability:major>` <one-line>. `<file>:<line>`. <fix>
+
+### Minor
+- `<maintainability:minor>` ...
+
+### No findings
+- (only if clean)
+```
+
+Maintainability findings rarely warrant `critical`. Use `major` for
+things that will compound into debt; `minor` for one-off polish.

--- a/.claude/agents/performance-reviewer.md
+++ b/.claude/agents/performance-reviewer.md
@@ -1,0 +1,92 @@
+---
+name: performance-reviewer
+description: Phase 7a reviewer focused on performance — N+1 queries, hot-path bloat, missing virtualization, missed concurrency, query/cache hygiene. Runs in parallel with the other Phase 7a reviewers against the current branch diff.
+subagent_type: feature-dev:code-reviewer
+---
+
+# Performance Reviewer (Phase 7a)
+
+You are one of five parallel reviewers in Phase 7a. Your dimension is
+**performance**. Stay in your lane — security, maintainability, and
+logic are handled by your peers.
+
+## Inputs
+
+- `git diff origin/main...HEAD`
+- `git log origin/main..HEAD --oneline`
+- The Phase 2 design doc.
+
+Read all three before reporting.
+
+## Skill loadout
+
+Invoke via `Skill`:
+
+1. `web-quality-skills/performance` (or `performance`)
+2. `vercel-react-best-practices`
+
+If a skill is missing, log a WARN and continue.
+
+## Project context
+
+React 18 + Vite + React Query frontend. Supabase Postgres + Deno edge
+functions. Edge functions have ~10s CPU budget. Lists with 100+ items use
+`@tanstack/react-virtual`. The "single dialog at list level" pattern is
+codified in CLAUDE.md.
+
+## Review checklist
+
+1. **N+1 / query bloat:**
+   - Any `.map(async)` over rows that fires one query per row? Should be
+     batched / a single join.
+   - `SELECT *` on tables with heavy columns (raw_data, blobs)? Should
+     select explicit fields.
+   - Joins that pull unused nested relations.
+2. **Re-render hygiene:**
+   - New parent state that changes per keystroke and re-renders a heavy
+     subtree? Memoize the subtree or lift the state down.
+   - Inline object/array literals passed as props to memoized children
+     defeating `React.memo`.
+   - Effects that depend on stable values but list unstable deps.
+3. **Virtualization:**
+   - Lists ≥100 items not virtualized.
+   - Virtualized lists keyed by `index` instead of stable ID.
+   - Per-row dialog instances instead of a single list-level dialog.
+4. **React Query hygiene:**
+   - `staleTime` missing or >60s on UI-critical data.
+   - `refetchOnWindowFocus: false` on data that should stay fresh.
+   - Cache keys that don't include `restaurant_id` causing cross-tenant
+     cache leaks.
+5. **Concurrency:**
+   - Independent awaits chained sequentially that could `Promise.all`.
+   - Edge function loops that block on per-iteration RPC; should batch.
+6. **Hot paths:**
+   - New work added inside startup/render hot paths (e.g., expensive
+     parsing in render).
+   - Polling intervals that fire `setState` even when nothing changed
+     (re-render storms).
+7. **Memory:**
+   - Unbounded growth (arrays appended in intervals without cap).
+   - Subscriptions/observers without cleanup.
+
+## Output format
+
+```
+## Performance review
+
+### Critical
+- `<performance:critical>` <one-line>. `<file>:<line>`. <impact + fix>
+
+### Major
+- `<performance:major>` ...
+
+### Minor
+- `<performance:minor>` ...
+
+### No findings
+- (only if clean)
+```
+
+**Severity:** *critical* = P95 latency blow-up or OOM under realistic
+load. *major* = visible jank or measurable wasted CPU. *minor* =
+opportunity, not a bug.

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,0 +1,84 @@
+---
+name: security-reviewer
+description: Phase 7a reviewer focused on security correctness — OWASP top 10, RLS bypass, secret leakage, auth flaws. Runs in parallel with the other Phase 7a reviewers against the current branch diff.
+subagent_type: feature-dev:code-reviewer
+---
+
+# Security Reviewer (Phase 7a)
+
+You are one of five parallel reviewers fanning out over the branch diff in
+Phase 7a of `/dev`. Your dimension is **security**. Stay in your lane —
+performance, maintainability, and logic are handled by your peers.
+
+## Inputs
+
+- `git diff origin/main...HEAD` — the full branch diff.
+- `git log origin/main..HEAD --oneline` — what was built and in what order.
+- The Phase 2 design doc at `docs/superpowers/specs/<date>-*-design.md`.
+
+Read all three before reporting.
+
+## Skill loadout
+
+Invoke via `Skill` before reviewing:
+
+1. `security-best-practices` (Codex-side; re-usable in Claude Code)
+2. `supabase-audit-rls`
+
+If a skill is missing, log a WARN and continue.
+
+## Project context
+
+Multi-tenant restaurant app. Every domain row carries `restaurant_id` and
+must be RLS-isolated. Roles are owner/manager/chef/staff/kiosk plus
+collaborators. Secrets (OAuth tokens, API keys) are encrypted at rest via
+`supabase/functions/_shared/encryption`.
+
+## Review checklist
+
+1. **Injection:**
+   - SQL injection: any raw string concat into a query? Untrusted input
+     piped into `execute_sql` / `sql.raw`?
+   - Command injection: untrusted input piped into `child_process` / shell?
+   - XSS: untrusted text rendered with `dangerouslySetInnerHTML`? Untrusted
+     URLs in `href`/`src`?
+2. **AuthN/AuthZ:**
+   - Edge functions verify the JWT before doing work?
+   - RLS policies enforce per-tenant isolation on every new/changed table?
+   - Service-role usage justified, not a shortcut to bypass policy?
+   - `auth.uid()` checks removed only where service-role intentional?
+3. **Secret management:**
+   - No secrets in client code, no `.env` keys exposed to the browser bundle.
+   - New OAuth/API tokens encrypted via the shared util before persisting.
+   - No secrets in logs, error messages, or PostHog events.
+4. **Webhook safety:** Signature verification on every external webhook
+   (Stripe, etc.); replay protection via idempotency key + uniqueness
+   constraint.
+5. **CSRF / CORS:** Edge function CORS allowlist matches deploy targets;
+   no `*` on authenticated endpoints.
+6. **Sensitive data exposure:** No PII or tokens in client-side React Query
+   keys, in `localStorage`, or in URL query strings.
+7. **Dependency confusion:** New deps added in `package.json` — typo
+   squatting check; pin to exact version where security-sensitive.
+
+## Output format
+
+```
+## Security review
+
+### Critical
+- `<security:critical>` <one-line>. `<file>:<line>`. <impact + fix>
+
+### Major
+- `<security:major>` ...
+
+### Minor
+- `<security:minor>` ...
+
+### No findings
+- (only if everything is clean)
+```
+
+**Be honest:** if you have no findings, say so. Don't manufacture
+concerns to look productive. False positives waste review cycles in Phase
+7b.

--- a/.claude/agents/sound-logic-reviewer.md
+++ b/.claude/agents/sound-logic-reviewer.md
@@ -1,0 +1,100 @@
+---
+name: sound-logic-reviewer
+description: Phase 7a reviewer focused on logical correctness — edge cases, off-by-one, null/undefined paths, race conditions, stale closures, retry storms, error boundaries. Runs in parallel with the other Phase 7a reviewers against the current branch diff.
+subagent_type: feature-dev:code-reviewer
+---
+
+# Sound Logic Reviewer (Phase 7a)
+
+You are one of five parallel reviewers in Phase 7a. Your dimension is
+**logical correctness**. Stay in your lane.
+
+## Inputs
+
+- `git diff origin/main...HEAD`
+- `git log origin/main..HEAD --oneline`
+- The Phase 2 design doc.
+
+## Skill loadout
+
+Invoke via `Skill`:
+
+1. `vercel-react-best-practices`
+2. `requesting-code-review`
+
+If a skill is missing, log a WARN and continue.
+
+## Project context
+
+Multi-tenant, real-time restaurant data. Timezone bugs have caused
+production off-by-one issues — `timestamptz` everywhere, display-side
+conversion. POS amounts are dollars, not cents (Toast). RLS isolates
+tenants; never trust `restaurant_id` from the client without verifying.
+
+## Review checklist
+
+1. **Edge cases:**
+   - Empty arrays / null / undefined paths exercised? `.length` on
+     `data` before `data` has loaded?
+   - Numeric edge cases: zero, negatives, `NaN`, very large.
+   - Date edge cases: month boundaries, DST transitions, leap years,
+     timezone arithmetic. `new Date('2026-05-01')` parses as UTC midnight
+     — does the rendering side know?
+   - String edge cases: empty, whitespace-only, emoji, unicode width.
+2. **Off-by-one:**
+   - Range queries inclusive vs exclusive — does the SQL match the UI
+     contract?
+   - Pagination `offset + limit` vs cursor — boundary correctness.
+   - Date range `[start, end)` vs `[start, end]` — does the comment
+     match the code?
+3. **Race conditions:**
+   - Two async writes to the same key without an `await`/queue/lock —
+     last-writer-wins?
+   - Stale closures: `useEffect` capturing an old value of state; should
+     be a ref or a functional updater.
+   - Optimistic UI rolled back correctly on server reject?
+4. **Null/undefined paths:**
+   - `obj?.a?.b` chains where `b` should never be reached if `a` is
+     null — does the branch handle the missing-`a` case meaningfully?
+   - Default arguments masking real bugs (e.g., `restaurant_id = ''`
+     instead of throwing).
+5. **Error handling:**
+   - Async errors caught and surfaced to the user, not swallowed.
+   - React Query `onError` wired; toasts shown; failure state rendered.
+   - Edge function errors don't leak stack traces to clients.
+6. **Retry hygiene:**
+   - Retries without backoff — retry storm risk on a flaky external
+     dependency.
+   - Idempotency: are retries safe on the write path?
+7. **Money & units:**
+   - Currency in cents (integers) or dollars (number) — consistent?
+   - Toast amounts: dollars (do NOT divide by 100). Other POSes vary —
+     verify.
+   - `fl oz` (liquid) vs `oz` (weight) — never crossed.
+8. **State inconsistencies:**
+   - Derived state stored alongside the source it derives from — risk of
+     drift. Should be `useMemo`.
+   - Two pieces of state mutated in different effects without a single
+     atomic update — risk of intermediate inconsistent renders.
+
+## Output format
+
+```
+## Sound logic review
+
+### Critical
+- `<logic:critical>` <one-line>. `<file>:<line>`. <reproduction + fix>
+
+### Major
+- `<logic:major>` ...
+
+### Minor
+- `<logic:minor>` ...
+
+### No findings
+- (only if clean)
+```
+
+**Severity:** *critical* = will produce incorrect data in production or
+hang/crash on a common path. *major* = bug under a non-trivial but
+realistic input. *minor* = theoretical or vanishingly rare.

--- a/.claude/agents/supabase-design-reviewer.md
+++ b/.claude/agents/supabase-design-reviewer.md
@@ -1,0 +1,88 @@
+---
+name: supabase-design-reviewer
+description: Reviews a freshly committed design doc for Supabase/Postgres/RLS/edge-function correctness BEFORE any code is written. Runs in Phase 2.5 of `/dev` workflow when the design touches DB schema, RPC, RLS, edge functions, migrations, or any `restaurant_id`-scoped table.
+subagent_type: general-purpose
+---
+
+# Supabase Design Reviewer
+
+You are reviewing a **design document**, not code. Your job is to catch
+architectural mistakes BEFORE they propagate into TDD and reviewable diffs —
+fixes here are 10× cheaper than fixes in PR review.
+
+## Skill loadout
+
+Invoke these via the `Skill` tool before you start, in order:
+
+1. `supabase-postgres-best-practices` — schema conventions, function patterns
+2. `supabase-audit-rls` — RLS auditing methodology
+3. `postgresql-code-review` — query patterns, indexes, constraints
+
+If any of these skills isn't available, log a WARN line at the top of your
+report and proceed with the others.
+
+## Project context
+
+EasyShiftHQ is a multi-tenant restaurant-management app. Hard invariants:
+
+- Every domain row carries `restaurant_id`; RLS isolates per-tenant data.
+- Roles: `owner | manager | chef | staff | kiosk` plus collaborator roles
+  (`collaborator_accountant`, `collaborator_inventory`, `collaborator_chef`).
+- Edge functions have ~10s CPU budget. Bulk work batches or defers to cron.
+- POS data lands in `unified_sales`; no POS-specific logic in UI.
+
+## Review checklist
+
+Walk through the design doc and flag each of these where applicable:
+
+1. **RLS coverage:** Every new or changed table has an RLS policy that scopes
+   to `restaurant_id` (and role where applicable). Service-role bypass paths
+   are explicitly noted, not assumed.
+2. **Migration safety:** Adding NOT NULL on a big table without a backfill
+   default? Locking patterns on hot tables? `CREATE INDEX CONCURRENTLY` for
+   anything that touches a populated table? Reversibility?
+3. **Edge function CPU/memory:** Anything that loops over per-restaurant
+   data — is it batched? Does it skip per-row RPC calls during bulk imports?
+   Does the design name a cron fallback for >10s work?
+4. **Unified-sales hygiene:** Writes are to `unified_sales`, not POS-specific
+   tables in UI code. Sync via RPC. No POS branching in the read path.
+5. **Indexes implied by query patterns:** For every new query pattern the
+   design proposes, is there an index that covers it? Composite-key order
+   correct (selectivity first)?
+6. **Function semantics:** New SQL functions use `SECURITY DEFINER` only
+   where strictly necessary; `SET search_path` pinned; volatility correct
+   (`STABLE`/`IMMUTABLE` vs `VOLATILE`).
+7. **Idempotency:** Webhook/edge-function endpoints have a uniqueness
+   constraint or upsert key to make replays safe.
+8. **Time zone:** Timestamps in `timestamptz`, not `timestamp`. Display-side
+   conversion only. (See lessons re: TZ off-by-one bugs.)
+9. **Encryption:** Any secret stored (OAuth tokens, API keys) goes through
+   the existing `_shared/encryption` util — no plaintext.
+
+## Output format
+
+Return a Markdown report with this exact shape:
+
+```
+## Supabase design review
+
+### Critical
+- `<severity:critical>` <one-line summary>. <which design-doc section>. <fix suggestion>
+
+### Major
+- `<severity:major>` ...
+
+### Minor
+- `<severity:minor>` ...
+
+### Looks good
+- <one-line confirmations of things the design got right>
+```
+
+Severity rubric:
+- **critical** = data loss, security boundary breach, or production-down risk.
+- **major** = correctness or scale problem that will surface in production.
+- **minor** = style, naming, missing comment, future-proofing.
+
+If the design is clean, return only the "Looks good" section with a short
+list. Don't invent concerns to look thorough.

--- a/.claude/skills/development-workflow.md
+++ b/.claude/skills/development-workflow.md
@@ -9,7 +9,19 @@ description: "MANDATORY — invoke BEFORE any implementation, feature, bugfix, o
 
 This skill defines the mandatory development pipeline for every task. Follow each phase in order. Skip conditions are documented per phase.
 
-The workflow is designed for **autonomous execution**: after the user approves the plan (Phase 2), Claude executes Phases 3–9 without requiring human prompts. The user is only notified when the PR is green and ready for review, or when Claude is genuinely stuck.
+The workflow is designed for **autonomous execution**: after the user approves the plan (Phase 3), Claude executes Phases 4–9 without requiring human prompts. The user is only notified when the PR is green and ready for review, or when Claude is genuinely stuck.
+
+**Two defense-in-depth phases** complement the linear flow:
+
+- **Phase 2.5 — Design Review:** Always-on Supabase + Frontend reviewers
+  inspect the design doc against best-practice skills before any code is
+  written. Catching a design mistake here is roughly 10× cheaper than
+  catching it in PR review.
+- **Phase 7 — Multi-Model Code Review:** Four Claude reviewers (security,
+  performance, maintainability, sound-logic) and one Codex adversarial
+  reviewer fan out in parallel against the branch diff. CodeRabbit local
+  CLI is the final gate, not the only gate — this avoids "Claude grading
+  its own homework" and reduces dependence on one third-party reviewer.
 
 ### Progress Tracking
 
@@ -103,6 +115,79 @@ If `git stash push` reports "No local changes to save," skip step 3's `git stash
 
 **Skip condition:** None. Every task gets at least a brief design pass.
 
+## Phase 2.5: Design Review
+
+**Trigger:** Runs immediately after the design doc is committed (end of
+Phase 2), before Phase 3 (Plan) starts.
+
+**Why it exists:** Design mistakes compound through TDD into reviewable
+code. Catching them at the design-doc stage is roughly 10× cheaper than
+catching them in PR review. The Supabase + Frontend dimensions are the
+two surfaces where mistakes are most expensive in this codebase.
+
+### Sub-agents (run in parallel)
+
+Invoke both via the `Agent` tool with `subagent_type=general-purpose`,
+passing the design doc path. Prompts live at:
+
+- `.claude/agents/supabase-design-reviewer.md`
+- `.claude/agents/frontend-design-reviewer.md`
+
+#### `supabase-design-reviewer`
+
+- **Runs when:** Design touches DB schema, RLS, edge functions, RPC,
+  migrations, or any `restaurant_id`-scoped table. Detected by scanning
+  the design doc for: `supabase`, `migration`, `rpc`, `rls`,
+  `edge function`, `.sql`.
+- **Skill loadout:** `supabase-postgres-best-practices`,
+  `supabase-audit-rls`, `postgresql-code-review`.
+- **Reviews:** RLS coverage, migration safety, edge-function CPU/memory,
+  unified-sales hygiene, indexes implied by query patterns, function
+  semantics, idempotency, timezone discipline, secret encryption.
+
+#### `frontend-design-reviewer`
+
+- **Runs when:** Design touches UI/components, dialogs, forms, pages,
+  styling, mobile/viewport behaviour. Detected by scanning for:
+  `component`, `dialog`, `form`, `page`, `mobile`, `viewport`,
+  `tailwind`, `shadcn`, `Apple/Notion`, or `src/components/`.
+- **Skill loadout:** `frontend-design`, `accessibility`, `performance`,
+  `shadcn`.
+- **Reviews:** CLAUDE.md compliance (typography, semantic tokens,
+  three-state rendering), accessibility (aria, focus, keyboard),
+  performance (virtualization, memoization, single-dialog pattern,
+  React Query staleTime), shadcn idioms, routing, form ergonomics.
+
+### Skip conditions
+
+- **Supabase reviewer:** Skipped only when the design touches no
+  DB/edge-function/SQL surface (keyword-based). When ambiguous, run it.
+- **Frontend reviewer:** Skipped only when no UI/component surface is
+  touched. When ambiguous, run it.
+- **Both skipped** when the task is a workflow- or doc-only change
+  (e.g., editing this file).
+- **Hard rule:** When the keyword detection says "applicable," neither
+  reviewer may be silently skipped.
+
+### Folding feedback in
+
+After both reviewers return:
+
+1. Read the combined concerns list.
+2. For each `critical` or `major` concern, decide:
+   - **Fix in design** → Edit the design doc, commit the change.
+   - **Defer with rationale** → Add a "Decided trade-offs" section to
+     the design doc explaining why the concern is accepted as-is.
+3. For `minor` concerns, decide:
+   - **Fix in design** → Edit + commit.
+   - **Skip** → Note in retrospective so the reviewer prompt can be
+     refined later.
+4. Proceed to Phase 3 only after the design doc reflects every accepted
+   concern.
+
+**Skip condition:** Workflow/doc-only changes (per the keyword
+detection above). Otherwise never.
+
 ## Phase 3: Plan
 
 **Invoke:** `superpowers:writing-plans`
@@ -147,13 +232,99 @@ Use subagent-driven-development to parallelize independent tasks.
 
 **Skip condition:** None.
 
-## Phase 7: CodeRabbit Review (Local CLI)
+## Phase 7: Multi-Model Code Review
 
-**This is the LOCAL CLI review only.** It is independent of the CodeRabbit
-GitHub bot that posts inline comments on the PR after push. The bot's
-comments are handled in Phase 9d, which is non-skippable. Don't conflate the
-two — passing the local CLI here does not mean the bot will have nothing
-to say after push.
+Phase 7 is **three sub-phases** that run sequentially: 7a fans out five
+parallel reviewers, 7b folds their findings into commits, 7c runs
+CodeRabbit local CLI as the final gate. The intent is to defeat "Claude
+grading its own homework" and to stop putting all review eggs in one
+third-party basket.
+
+```
+Phase 6  Simplify
+   │
+   ▼
+Phase 7a  Multi-model fan-out (PARALLEL)
+   ├─ Agent: security-reviewer
+   ├─ Agent: performance-reviewer
+   ├─ Agent: maintainability-reviewer
+   ├─ Agent: sound-logic-reviewer
+   └─ Bash:  dev-tools/codex-adversarial-review.sh
+   │
+   ▼
+Phase 7b  Fold findings: classify, fix actionable, commit
+   │
+   ▼
+Phase 7c  CodeRabbit local CLI (final gate, max 3 iterations)
+   │
+   ▼
+Phase 8  Verify
+```
+
+### 7a — Multi-model fan-out (parallel)
+
+Inputs handed to every reviewer:
+
+- `git diff origin/main...HEAD`
+- `git log origin/main..HEAD --oneline`
+- The Phase 2 design doc.
+
+**Four Claude reviewers.** Each is an `Agent` call with
+`subagent_type=feature-dev:code-reviewer` and the prompt loaded from
+`.claude/agents/<name>.md`. Launch them in a **single message with four
+tool calls** so they run concurrently.
+
+| Reviewer | Skills | Severity tag |
+|---|---|---|
+| `security-reviewer` | `security-best-practices`, `supabase-audit-rls` | `security:<level>` |
+| `performance-reviewer` | `performance`, `vercel-react-best-practices` | `performance:<level>` |
+| `maintainability-reviewer` | `typescript-react-reviewer`, `shadcn` | `maintainability:<level>` |
+| `sound-logic-reviewer` | `vercel-react-best-practices`, `requesting-code-review` | `logic:<level>` |
+
+**One Codex adversarial reviewer.** Shell out via `Bash`:
+
+```bash
+dev-tools/codex-adversarial-review.sh main
+```
+
+The script writes its output to `dev-tools/codex-review-output.md`.
+
+**Codex prerequisite:** `codex` CLI must be on PATH and the binary must
+launch (`codex --version`). If either fails, the script emits a
+`::skip::` line and exits 0. Adversarial review is **best-effort** —
+the four Claude reviewers still run.
+
+```bash
+# Install / repair if missing
+brew install --cask codex && codex login
+# If the symlink is dangling:
+brew reinstall --cask codex
+```
+
+### 7b — Fold findings
+
+1. Collect every `critical` and `major` finding from all five reviewers
+   (including Codex's `dev-tools/codex-review-output.md`).
+2. Deduplicate: same `file:line` from multiple reviewers → keep highest
+   severity, merge messages.
+3. Classify each:
+   - **Actionable bug / security / correctness** → Fix it. Commit:
+     `fix(review): <area> — addresses <reviewer> finding`.
+   - **Style / nit** → Skip (CodeRabbit Phase 7c catches these).
+   - **False positive** → Note in retrospective; skip.
+4. After fixes commit, **re-invoke any reviewer that flagged a fixed
+   issue** to confirm the fix resolved it.
+
+`minor` findings are deferred to CodeRabbit and/or the retrospective.
+
+### 7c — CodeRabbit local CLI (final gate)
+
+This is the existing CodeRabbit step. It is still **non-skippable**, but
+its role narrows: it's the *final consistency check*, not the *primary
+review*. Most issues should have been caught by 7a.
+
+**Independent of the GitHub bot.** The CodeRabbit GitHub bot's inline
+comments on the PR are handled separately in Phase 9d.
 
 **Command:** `coderabbit review --plain --type committed`
 
@@ -173,9 +344,14 @@ Iteration 1: Run coderabbit review --plain --type committed
                 +-- Still has findings --> Report to user for manual decision
 ```
 
-**Important:** Use `--type committed` to review all committed changes on the branch. Parse the output for actionable suggestions vs informational notes. Only fix actionable items.
+Use `--type committed` to review all committed changes on the branch.
+Parse the output for actionable suggestions vs informational notes. Only
+fix actionable items.
 
-**Skip condition:** None.
+**Skip condition for the whole phase:** None. 7a and 7c always run on
+any task that produces code. 7a is skipped only when the task is
+workflow- or doc-only (no diff under `src/`, `supabase/`, or
+`dev-tools/`).
 
 ## Phase 8: Verify (Local)
 
@@ -356,12 +532,23 @@ Review the entire workflow session and capture lessons learned:
 
 After the user approves the plan (end of Phase 3), the workflow should run autonomously through Phases 4–9 without requiring human input. The only exceptions where you should pause and ask:
 
-1. **Ambiguous review comments** (Phase 9d) — When a reviewer's intent is unclear
-2. **Persistent CI failures** (Phase 9c) — After 5 failed iterations
-3. **Architectural decisions** — When a fix requires changing the approved design
-4. **Genuine blockers** — Environment issues, missing credentials, etc.
+1. **Phase 2.5 design-reviewer raises a `critical` concern** that is not
+   purely a fix-in-design (architecturally ambiguous, requires changing
+   the approved approach). `major` concerns that can be folded into the
+   design doc are handled autonomously by editing the doc + committing.
+2. **Phase 7b actionable finding** that is architecturally ambiguous —
+   i.e., fixing it requires changing the design approved in Phase 2.
+3. **Ambiguous review comments** (Phase 9d) — When a reviewer's intent
+   is unclear.
+4. **Persistent CI failures** (Phase 9c) — After 5 failed iterations.
+5. **Architectural decisions** — When a fix requires changing the
+   approved design.
+6. **Genuine blockers** — Environment issues, missing credentials, etc.
 
-For everything else — test failures, lint errors, CodeRabbit findings, CI red — diagnose and fix autonomously. Each failure is structured feedback, not a reason to stop.
+For everything else — test failures, lint errors, design-review `minor`
+or `major` findings, Phase 7 multi-model findings, CodeRabbit findings,
+CI red — diagnose and fix autonomously. Each failure is structured
+feedback, not a reason to stop.
 
 ### Context Recovery
 
@@ -380,11 +567,14 @@ This is the Ralph loop principle: each fresh context window re-orients from pers
 | 0. Consult Lessons | Read `memory/lessons.md` + `progress.md` | Never |
 | 1. Isolate | `superpowers:using-git-worktrees` | Already in a dedicated worktree |
 | 2. Brainstorm | `superpowers:brainstorming` | Never |
+| 2.5 Design Review | Agents: `supabase-design-reviewer` + `frontend-design-reviewer` (parallel) | Workflow/doc-only changes; per-reviewer skip if domain untouched |
 | 3. Plan | `superpowers:writing-plans` | Never |
 | 4. Build | `superpowers:test-driven-development` | Never |
 | 5. UI Review | `frontend-design:frontend-design` | No UI changes |
 | 6. Simplify | `code-simplifier:code-simplifier` | Never |
-| 7. CodeRabbit | `coderabbit review --plain --type committed` | Never |
+| 7a Multi-Model Review | Agents: `security`, `performance`, `maintainability`, `sound-logic` + `dev-tools/codex-adversarial-review.sh` (parallel) | Workflow/doc-only changes (no code diff) |
+| 7b Fold Findings | Classify + fix `critical`/`major`, commit | No `critical`/`major` findings |
+| 7c CodeRabbit | `coderabbit review --plain --type committed` | Never |
 | 8. Verify | `superpowers:verification-before-completion` | Never (loop locally until green) |
 | 9. Ship & CI Loop | Push → PR → CI loop → Review loop | Never |
 | 10. Retrospective | Write to `memory/lessons.md` | No corrections occurred |

--- a/dev-tools/codex-adversarial-review.sh
+++ b/dev-tools/codex-adversarial-review.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Run Codex adversarial review on the current branch diff.
+# Usage: codex-adversarial-review.sh [base-branch]
+#
+# Invoked by /dev workflow Phase 7a in parallel with four Claude
+# code-review sub-agents. Brings a non-Claude model (via Codex CLI)
+# into the review fan-out to defeat "Claude grading its own homework".
+#
+# Exits 0 with `::skip::` if the codex CLI is missing or its binary is
+# unreachable — adversarial review is best-effort. The four Claude
+# reviewers still run.
+#
+# Output: dev-tools/codex-review-output.md (raw Codex stdout).
+
+set -euo pipefail
+
+BASE="${1:-main}"
+
+if ! command -v codex >/dev/null 2>&1; then
+  echo "::skip:: codex CLI not on PATH — install with: brew install --cask codex && codex login"
+  exit 0
+fi
+
+# Some Homebrew installs leave a dangling symlink at /opt/homebrew/bin/codex.
+# Treat that as "missing" too rather than letting the script die mid-pipe.
+if ! codex --version >/dev/null 2>&1; then
+  echo "::skip:: codex CLI present on PATH but not executable — try: brew reinstall --cask codex"
+  exit 0
+fi
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+
+DIFF=$(git diff "origin/${BASE}...HEAD" 2>/dev/null || git diff "${BASE}...HEAD")
+
+# Find the matching design doc for today, if any.
+DESIGN_DOC=$(find docs/superpowers/specs -maxdepth 2 -name "$(date +%Y-%m-%d)-*-design.md" -print -quit 2>/dev/null || true)
+DESIGN_CONTEXT=""
+if [ -n "${DESIGN_DOC:-}" ] && [ -f "$DESIGN_DOC" ]; then
+  DESIGN_CONTEXT=$(cat "$DESIGN_DOC")
+fi
+
+PROMPT=$(cat <<EOF
+You are reviewing code written by Claude Sonnet, deployed into a
+multi-tenant restaurant-management React/Supabase app. Find ONE concrete
+bug, security issue, or correctness flaw a self-reviewing Claude would
+miss.
+
+Be specific: cite file:line and the failure mode. If you genuinely cannot
+find a concrete issue, say "No adversarial finding." — do not invent
+findings.
+
+Output format (one per finding):
+  ::finding:: severity=<critical|major|minor> file=<path> line=<n>
+  <one-paragraph description of the bug and the trigger>
+
+Design context:
+${DESIGN_CONTEXT:-(none provided)}
+
+---
+Diff:
+${DIFF}
+EOF
+)
+
+mkdir -p dev-tools
+codex exec "$PROMPT" > dev-tools/codex-review-output.md
+echo "Codex adversarial review written to dev-tools/codex-review-output.md"

--- a/docs/superpowers/plans/2026-05-16-dev-workflow-multi-review-plan.md
+++ b/docs/superpowers/plans/2026-05-16-dev-workflow-multi-review-plan.md
@@ -1,0 +1,94 @@
+# Plan — Dev Workflow Multi-Review (Phase 2.5 + Phase 7)
+
+**Spec:** `docs/superpowers/specs/2026-05-16-dev-workflow-multi-review-design.md`
+**Branch:** `feature/dev-workflow-multi-review`
+
+## Tasks
+
+### Task 1: Install skill bundle (2 min)
+Run the 10 `npx skills add -g -a "Claude Code" -y ...` commands from the spec.
+Verify with `npx skills list -g | grep -E "<each-name>"`. Halt if any fail.
+
+**Dependency:** none
+
+### Task 2: Create `.claude/agents/` directory + author 6 sub-agent files (5 min)
+For each of:
+- `supabase-design-reviewer.md`
+- `frontend-design-reviewer.md`
+- `security-reviewer.md`
+- `performance-reviewer.md`
+- `maintainability-reviewer.md`
+- `sound-logic-reviewer.md`
+
+Write a markdown file with:
+- YAML frontmatter (`name`, `description`, `subagent_type`).
+- Skill loadout section.
+- Review checklist section.
+- Output format section (severity + file:line + reasoning).
+
+These are *prompt templates* the `/dev` workflow invokes; they don't need to
+be registered with Claude Code in any special way — they're just docs the
+workflow points its `Agent` calls at.
+
+**Dependency:** Task 1 (skills must exist before referencing them)
+
+### Task 3: Write Codex adversarial runner (3 min)
+Author `dev-tools/codex-adversarial-review.sh` exactly as in the spec.
+- `chmod +x` it.
+- Test: run with `codex` missing → must `echo "::skip::"` and `exit 0`.
+- Document a `codex-adversarial-runner.md` agent doc in `.claude/agents/`
+  that explains how Phase 7 invokes this script.
+
+**Dependency:** none (parallel with Task 2)
+
+### Task 4: Rewrite `.claude/skills/development-workflow.md` (5 min)
+- Insert new "Phase 2.5: Design Review" section between current Phase 2 and
+  Phase 3.
+- Replace current Phase 7 section with three subsections: 7a multi-model
+  fan-out, 7b fold findings, 7c CodeRabbit final gate.
+- Update Quick Reference table: add Phase 2.5 row, expand Phase 7 row.
+- Update Autonomy Guidelines pause-conditions.
+- Update Overview paragraph to mention the new phases.
+
+**Dependency:** Tasks 1, 2, 3 (so the doc refers to real files)
+
+### Task 5: Smoke test the new flow (3 min)
+- Invoke `frontend-design-reviewer` via the `Agent` tool against this very
+  spec doc (which has frontend-relevant sections). Confirm it returns
+  structured findings.
+- Invoke the Codex runner shell script with a dummy diff. Confirm it skips
+  cleanly with a WARN if codex is missing (we know it's missing right now
+  due to the broken symlink — user will reinstall).
+- No code is verified here; this is a dry run of the new wiring.
+
+**Dependency:** Tasks 2, 3, 4
+
+### Task 6: Verify (typecheck, lint, build) (2 min)
+- `npm run typecheck` — must be clean (we changed no TS).
+- `npm run lint` — must not introduce new errors from our changes.
+- `npm run build` — must succeed (no source changes, just docs + shell).
+- Skip `npm run test` — no test changes; the existing TZ-flaky test isn't
+  ours.
+
+**Dependency:** Task 5
+
+### Task 7: Commit, push, open PR (2 min)
+- Single commit on `feature/dev-workflow-multi-review`:
+  `feat(dev-workflow): design review + multi-model code review`.
+- Push and open PR with summary referencing the spec.
+- Run autonomous CI loop per Phase 9.
+- Run the NEW flow against itself? Not strictly — this PR is workflow-only,
+  so Phase 2.5 reviewers skip per the doc-only skip condition. Phase 7 also
+  has no source code to review, so we skip the new reviewers and let
+  CodeRabbit be the only review.
+
+**Dependency:** Task 6
+
+## Schedule
+
+Tasks 1, 3 in parallel. Then 2 (depends on 1). Then 4 (depends on 1, 2, 3).
+Then 5, 6, 7 sequentially.
+
+## Acceptance
+
+All items in the spec's Acceptance Criteria section turn green.

--- a/docs/superpowers/specs/2026-05-16-dev-workflow-multi-review-design.md
+++ b/docs/superpowers/specs/2026-05-16-dev-workflow-multi-review-design.md
@@ -1,0 +1,378 @@
+# Dev Workflow Enhancement — Design Review (Phase 2.5) + Multi-Model Code Review (Phase 7)
+
+**Date:** 2026-05-16
+**Branch:** `feature/dev-workflow-multi-review`
+**Author:** Jose M Delgado / Claude Code
+
+## Problem
+
+The current `/dev` workflow leans heavily on **CodeRabbit** as its third-party
+code-review safety net (Phase 7 local CLI + Phase 9d PR-side bot). CodeRabbit
+has been valuable, but two structural problems are showing up in practice:
+
+1. **CodeRabbit throttles us.** We're hitting their rate limits often enough
+   that it slows the autonomous CI loop in Phase 9. We need to stop putting all
+   our review eggs in one third-party basket.
+2. **Claude is grading its own homework.** Phases 4–6 (Build, UI Review,
+   Simplify) all run Claude. The only non-Claude code-review signal we have
+   before merge is CodeRabbit + the PR-side Codex/Copilot bots. When CodeRabbit
+   is throttled or doesn't run, the only thing standing between Claude's draft
+   and `main` is Claude's own review of Claude's own code.
+3. **No design review.** Today brainstorm (Phase 2) flows directly into plan
+   (Phase 3). Mistakes in the design propagate through TDD into reviewable
+   code, where they're 10× more expensive to fix.
+
+## Goals
+
+1. Insert a mandatory **Phase 2.5 — Design Review** between brainstorm and
+   plan. Two always-on focused sub-agents (Supabase + Frontend) load the
+   appropriate skills and review the design doc against best practices before
+   any code is written.
+2. Replace the single-source Phase 7 with a **multi-model code-review fan-out**:
+   four Claude sub-agents (security, performance, maintainability, sound logic)
+   running in parallel, plus a **Codex adversarial reviewer** that exercises
+   an independent (non-Claude) model on the same diff. CodeRabbit local
+   becomes the *final* gate, not the *only* gate.
+3. Install a curated bundle of skills.sh skills so each focused reviewer has
+   a clear, narrow knowledge loadout instead of a sprawling generalist prompt.
+
+## Non-Goals
+
+- Replacing CodeRabbit. It still runs as the final Phase 7 gate, and the
+  GitHub-side CodeRabbit bot still posts inline comments handled by Phase 9d.
+- Reworking Phases 1, 3, 4, 5, 6, 8, 9, 10. They stay as-is.
+- Adding new CI workflows on the GitHub side. The new reviewers run locally
+  during the autonomous loop, like the existing CodeRabbit local CLI does.
+
+## Phase 2.5 — Design Review
+
+### Trigger
+
+Runs **immediately after** the design doc is committed at the end of Phase 2,
+**before** Phase 3 (Plan) begins.
+
+### Sub-agents
+
+Two focused sub-agents run **in parallel** via `Agent` tool with
+`subagent_type=general-purpose` plus a custom prompt that loads the relevant
+skills:
+
+#### `supabase-design-reviewer`
+
+- **When it runs:** The design touches database schema, RLS policies, edge
+  functions, RPC, migrations, or any `restaurant_id`-scoped table. Detected
+  by scanning the design doc for `supabase`, `migration`, `rpc`, `rls`,
+  `edge function`, or `.sql` references.
+- **Skill loadout (loaded into prompt):**
+  - `supabase-postgres-best-practices`
+  - `supabase-audit-rls`
+  - `postgresql-code-review`
+- **Reviews for:**
+  - RLS policies on every new/changed table; `restaurant_id` isolation
+  - Migration safety (NOT NULL on big tables, default backfills, locking)
+  - Edge function CPU + memory limits (10s ceiling, batch processing)
+  - Unified-sales-table writes (no POS-specific logic leaking)
+  - Indexes implied by the proposed query patterns
+- **Output:** Short markdown list of `severity:major|minor` concerns.
+
+#### `frontend-design-reviewer`
+
+- **When it runs:** The design touches UI/components, dialogs, forms, or
+  styling. Detected by scanning the design doc for `component`, `dialog`,
+  `form`, `page`, `mobile`, `viewport`, `tailwind`, `shadcn`, `Apple/Notion`,
+  or any reference to `src/components/`.
+- **Skill loadout:**
+  - `frontend-design`
+  - `web-quality-skills/accessibility`
+  - `web-quality-skills/performance`
+  - `shadcn`
+- **Reviews for:**
+  - CLAUDE.md compliance: typography scale, semantic tokens, no direct colors,
+    border/40 + muted/30 patterns, loading/empty/error states
+  - Accessibility: aria-labels on icon buttons, label↔input association,
+    keyboard reachability, focus traps in modals
+  - Performance: lists with 100+ items virtualized, memoization, no per-row
+    dialog, query staleTime ≤ 60s
+  - shadcn idioms: correct Radix primitive use, no leaking internal state
+    out of compound components
+- **Output:** Short markdown list of `severity:major|minor` concerns.
+
+### Skip conditions
+
+- **Supabase reviewer skipped** when no DB/edge-function/SQL surface is
+  touched. The detection is keyword-based; when ambiguous, the reviewer
+  runs.
+- **Frontend reviewer skipped** when no UI/component surface is touched.
+  Same detection rule.
+- Both skipped when the task is a workflow/doc-only change (like this one).
+- **Hard rule:** When applicable, NEITHER can be silently skipped. If the
+  detection says "applicable" the reviewer MUST run.
+
+### Folding feedback in
+
+After both reviewers return:
+
+1. Read the combined concerns list.
+2. For each `major` concern, decide:
+   - **Fix in design** → Edit the design doc, commit the change.
+   - **Defer with rationale** → Add a "Decided trade-offs" section to the
+     design doc explaining why the concern is accepted as-is.
+3. For `minor` concerns, decide:
+   - **Fix in design** → Edit + commit.
+   - **Skip** → Note in retrospective so we can refine the reviewer prompt.
+4. Proceed to Phase 3 (Plan) only after the design doc has been updated.
+
+## Phase 7 — Multi-Model Code Review
+
+### Trigger
+
+Runs **after Phase 6 (Simplify)** and **before** Phase 8 (Verify).
+
+### Topology
+
+```
+Phase 6  Simplify
+   |
+   v
+Phase 7a  Multi-model fan-out (PARALLEL)
+   ├─ claude:security-reviewer
+   ├─ claude:performance-reviewer
+   ├─ claude:maintainability-reviewer
+   ├─ claude:sound-logic-reviewer
+   └─ codex:adversarial-reviewer  (independent model)
+   |
+   v
+Phase 7b  Fold findings: fix actionable items, commit fixes
+   |
+   v
+Phase 7c  CodeRabbit local CLI (final gate, max 3 iterations)
+   |
+   v
+Phase 8  Verify
+```
+
+### Claude sub-agents (4)
+
+All implemented as `Agent` calls with `subagent_type=feature-dev:code-reviewer`,
+each prompt scoped to one review dimension and loading the relevant skills.
+They all read the same input: `git diff origin/main...HEAD` plus a `git log`
+summary so they can see what was built.
+
+#### `security-reviewer`
+
+- **Focus:** OWASP top 10 — XSS, SQL injection, command injection, auth bypass,
+  CSRF, broken access control, secret leakage, RLS bypass.
+- **Skill loadout:** `security-best-practices` (Codex side, re-readable),
+  `supabase-audit-rls`.
+- **Output:** Findings tagged `security:critical|major|minor`.
+
+#### `performance-reviewer`
+
+- **Focus:** N+1 queries, unnecessary re-renders, missing virtualization, hot
+  paths, missed concurrency, query bloat, missing staleTime tuning.
+- **Skill loadout:** `web-quality-skills/performance`, `vercel-react-best-practices`.
+- **Output:** Findings tagged `performance:critical|major|minor`.
+
+#### `maintainability-reviewer`
+
+- **Focus:** CLAUDE.md hygiene (no manual cache, semantic tokens, import
+  order, comment hygiene), abstraction smells, naming, dead code, nested
+  conditionals, unnecessary JSX nesting, leaky abstractions.
+- **Skill loadout:** `typescript-react-reviewer`, `shadcn`.
+- **Output:** Findings tagged `maintainability:major|minor`.
+
+#### `sound-logic-reviewer`
+
+- **Focus:** Edge cases, off-by-one, null/undefined paths, race conditions,
+  state inconsistencies (e.g., stale closures), error boundaries, retry
+  storms.
+- **Skill loadout:** `vercel-react-best-practices`, `requesting-code-review`.
+- **Output:** Findings tagged `logic:critical|major|minor`.
+
+### Codex adversarial reviewer (1)
+
+- **Focus:** Find a single sharp adversarial concern Claude missed. Bring
+  GPT-class-model perspective independent of Claude's training distribution.
+- **Mechanism:** `dev-tools/codex-adversarial-review.sh` (new) wraps
+  `codex exec`. The script:
+  1. Captures `git diff origin/main...HEAD` and the design doc text.
+  2. Pipes both into `codex exec` with an adversarial prompt:
+     > You are reviewing code written by Claude Sonnet. Find one concrete
+     > bug, security issue, or correctness flaw it would miss. Be specific:
+     > file, line, and the failure mode. If you genuinely can't find one,
+     > say so — don't invent.
+  3. Captures Codex's stdout. Parses structured `file:line:severity:message`
+     lines into the findings list.
+  4. Stores the raw output in `dev-tools/codex-review-output.md` for the
+     workflow to ingest.
+- **Skill loadout (Codex side, already global):** `security-best-practices`.
+- **Output:** Findings tagged `adversarial:critical|major|minor`.
+
+### Pre-requisite
+
+Codex CLI must be installed and authenticated. Detection in the workflow:
+
+```bash
+if ! command -v codex >/dev/null; then
+  echo "WARN: codex CLI not on PATH. Adversarial review will be SKIPPED."
+  echo "      Install: brew install --cask codex && codex login"
+fi
+```
+
+If codex is missing, the workflow logs a warning and **continues without
+the adversarial reviewer**. Adversarial review is "best-effort" because the
+binary may not be installed everywhere we run the workflow. The 4 Claude
+reviewers still run.
+
+### Folding findings in (Phase 7b)
+
+1. Collect all `critical` + `major` findings from all 5 reviewers.
+2. Deduplicate (same file:line from multiple reviewers → keep highest
+   severity, merge messages).
+3. For each, classify:
+   - **Actionable bug/security** → Fix it. Commit `"fix(review): <area> —
+     addresses <reviewer> finding"`.
+   - **Style/nit** → Skip (CodeRabbit catches these in Phase 7c).
+   - **False positive** → Note in retrospective; skip.
+4. Re-run any reviewer that flagged a fixed issue to confirm.
+
+### CodeRabbit (Phase 7c)
+
+Existing CodeRabbit local CLI loop, unchanged. Up to 3 iterations.
+CodeRabbit's role narrows: it's the *final consistency check*, not the
+*primary review*. Most issues should already be caught by 7a.
+
+## Skill bundle
+
+Install all 10 globally (matches existing pattern where Claude skills live
+under `~/.agents/skills/`):
+
+```bash
+# Recommended set (Core 7)
+npx skills add -g -a "Claude Code" -y yoanbernabeu/supabase-pentest-skills@supabase-audit-rls
+npx skills add -g -a "Claude Code" -y github/awesome-copilot@postgresql-code-review
+npx skills add -g -a "Claude Code" -y addyosmani/web-quality-skills@accessibility
+npx skills add -g -a "Claude Code" -y addyosmani/web-quality-skills@performance
+npx skills add -g -a "Claude Code" -y dotneet/claude-code-marketplace@typescript-react-reviewer
+npx skills add -g -a "Claude Code" -y currents-dev/playwright-best-practices-skill@playwright-best-practices
+npx skills add -g -a "Claude Code" -y shadcn/ui@shadcn
+
+# Plus
+npx skills add -g -a "Claude Code" -y poteto/noodle@adversarial-review
+npx skills add -g -a "Claude Code" -y antfu/skills@vitest
+npx skills add -g -a "Claude Code" -y obra/superpowers@requesting-code-review
+```
+
+Verification step in Phase 4 (build): `npx skills list -g` must show all 10.
+
+## Sub-agent files
+
+Add the following to `.claude/agents/` (project-scope):
+
+```
+.claude/agents/
+├─ supabase-design-reviewer.md
+├─ frontend-design-reviewer.md
+├─ security-reviewer.md
+├─ performance-reviewer.md
+├─ maintainability-reviewer.md
+├─ sound-logic-reviewer.md
+└─ codex-adversarial-runner.md   # documentation only; actual runner is dev-tools/codex-adversarial-review.sh
+```
+
+Each markdown file has:
+- YAML frontmatter: `name`, `description`, `subagent_type` (defaulted to
+  `general-purpose` or `feature-dev:code-reviewer`).
+- "Skill loadout" section: explicit list of skills the agent should `Skill`-invoke
+  before working.
+- "Review checklist" section: the dimension-specific items.
+- "Output format" section: severity tags + file:line + short reasoning.
+
+## Codex runner script
+
+`dev-tools/codex-adversarial-review.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Run Codex adversarial review on the current branch diff.
+# Usage: codex-adversarial-review.sh [--base main]
+
+set -euo pipefail
+
+BASE="${1:-main}"
+
+if ! command -v codex >/dev/null 2>&1; then
+  echo "::skip:: codex CLI not on PATH — install with: brew install --cask codex"
+  exit 0
+fi
+
+DIFF=$(git diff "origin/${BASE}...HEAD")
+DESIGN_DOC=$(find docs/superpowers/specs -name "$(date +%Y-%m-%d)-*-design.md" -print -quit 2>/dev/null || true)
+DESIGN_CONTEXT=""
+if [ -n "$DESIGN_DOC" ] && [ -f "$DESIGN_DOC" ]; then
+  DESIGN_CONTEXT=$(cat "$DESIGN_DOC")
+fi
+
+PROMPT=$(cat <<EOF
+You are reviewing code written by Claude Sonnet, deployed into a
+multi-tenant restaurant-management React/Supabase app. Find ONE concrete
+bug, security issue, or correctness flaw a self-reviewing Claude would
+miss.
+
+Be specific: cite file:line and the failure mode. If you genuinely cannot
+find a concrete issue, say "No adversarial finding." — do not invent
+findings.
+
+Output format (one per finding):
+  ::finding:: severity=<critical|major|minor> file=<path> line=<n>
+  <one-paragraph description of the bug and the trigger>
+
+Design context:
+$DESIGN_CONTEXT
+
+---
+Diff:
+$DIFF
+EOF
+)
+
+codex exec "$PROMPT" > dev-tools/codex-review-output.md
+echo "Codex adversarial review written to dev-tools/codex-review-output.md"
+```
+
+Made executable; checked in.
+
+## Updates to `development-workflow.md`
+
+1. Renumber sections so Phase 2.5 is its own section between Phase 2 and Phase 3.
+2. Replace the existing Phase 7 section with the 7a/7b/7c three-step block.
+3. Update the Quick Reference table at the bottom.
+4. Update the Autonomy Guidelines pause-conditions list to include "design
+   reviewer raised a `major` concern" → continue if you can fix in the design
+   doc; pause only if it's architecturally ambiguous.
+
+## Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Codex CLI broken / not installed on contributor machines | Workflow auto-skips with a WARN. Adversarial review is best-effort. |
+| 5 parallel sub-agents blow up context budget | Each sub-agent runs in its own `Agent` call — context isolated. Only their summarized findings flow back. |
+| Reviewers nitpick infinitely | Phase 7b explicitly only acts on `critical|major`. Style nits deferred to CodeRabbit Phase 7c. |
+| Skill installs fail or change names | Phase 4 verifies `npx skills list -g` shows all 10 before proceeding. If install fails, plan halts at that task. |
+| Design reviewer flag pre-existing patterns as concerns | Design reviewer reviews the **design doc**, not existing code. Existing-code concerns are out of scope for Phase 2.5. |
+| Over-eager design review blocks small fixes | The phase auto-skips on doc/workflow-only changes (keyword detection). |
+| Codex prompt leaks internal context | The runner only passes the diff and the design doc text — both of which are about to be public on a PR. No secrets, .env, or `lessons.md`. |
+
+## Acceptance criteria
+
+- [x] User has approved skill bundle (Core 7 + adversarial + vitest + requesting-code-review).
+- [ ] `npx skills list -g` shows all 10 new skills.
+- [ ] `.claude/agents/` contains 6 reviewer agent definitions + the codex
+  runner doc.
+- [ ] `dev-tools/codex-adversarial-review.sh` is executable and exits 0
+  with a "skip" message when `codex` is missing.
+- [ ] `.claude/skills/development-workflow.md` has Phase 2.5 and the
+  rewritten Phase 7 (7a/7b/7c) and an updated Quick Reference.
+- [ ] Smoke test: invoke `frontend-design-reviewer` against a known
+  trivial design doc; it returns a concerns list.
+- [ ] PR opens, CI green, no regressions to existing dev workflow.


### PR DESCRIPTION
## Summary
- **Phase 2.5 — Design Review:** Always-on Supabase + Frontend reviewers fan out in parallel against the design doc *before* any code is written. Catching mistakes here is ~10× cheaper than at PR time.
- **Phase 7 — Multi-Model Code Review:** Split into 7a/7b/7c. 7a runs 4 Claude reviewers (security, performance, maintainability, sound-logic) **plus 1 Codex adversarial reviewer** in parallel. 7b folds findings into commits. 7c keeps CodeRabbit local CLI as the final gate (max 3 iterations).
- Goal: stop putting all review eggs in one third-party basket and defeat the "Claude grading its own homework" failure mode by bringing a non-Claude model family into the loop.

Spec: [`docs/superpowers/specs/2026-05-16-dev-workflow-multi-review-design.md`](docs/superpowers/specs/2026-05-16-dev-workflow-multi-review-design.md)
Plan: [`docs/superpowers/plans/2026-05-16-dev-workflow-multi-review-plan.md`](docs/superpowers/plans/2026-05-16-dev-workflow-multi-review-plan.md)

## What changed
- 6 new reviewer prompts + 1 runner doc under `.claude/agents/`
- `dev-tools/codex-adversarial-review.sh` (best-effort; `::skip::` when codex CLI missing)
- `.claude/skills/development-workflow.md` — new Phase 2.5, rewritten Phase 7 (7a/7b/7c), refreshed Quick Reference + Autonomy Guidelines
- 10 globally installed skills.sh skills (core 7 + adversarial-review + vitest + requesting-code-review) — install commands documented in the spec

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run build` — succeeds
- [x] Codex runner exits 0 with `::skip::` when codex CLI is unreachable
- [x] Smoke test: `frontend-design-reviewer` invoked via `Agent` against the spec doc returned structured Markdown findings in the documented format (correctly reported "no findings" — workflow/doc-only change)
- [ ] First real run of new flow happens on the next feature PR (not this one — workflow/doc-only)

## Notes
- This PR itself is workflow/doc-only, so Phase 2.5 reviewers auto-skip per keyword detection and Phase 7a has no source code to review. CodeRabbit (Phase 7c) is the only review on this PR.
- Codex CLI is currently a broken symlink on the author's machine; the runner gracefully skips. User reinstalls via `brew reinstall --cask codex`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)