### PR TITLE
fix(kiosk-perf): fast punch + skip-photo fix (optimistic mutate)

### DIFF
--- a/docs/superpowers/plans/2026-05-17-kiosk-perf-plan.md
+++ b/docs/superpowers/plans/2026-05-17-kiosk-perf-plan.md
@@ -1,0 +1,425 @@
+# Kiosk Punch Performance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make kiosk punch in/out perceptually instant (<300 ms after tap) and fix the broken "Skip photo" button. Backend writes happen optimistically in the background while the UI shows success. Critical: a re-entry guard prevents double-punches during the optimistic window, and the post-INSERT dialogs (force_reset PIN-change, tip prompt) only open after the write confirms.
+
+**Architecture:**
+- Pure-client change. No DB migration, no new edge function.
+- `ImageCapture` becomes ref-forwarding with optional `maxWidth`/`quality` props; capture is downscaled to 480×360 @ q0.6 (matches `EmployeeClock`).
+- `useTimePunches` drops the `auth.getUser()` round-trip in favor of cached `getSession()`, and gains an opt-in `silent` flag so kiosk can suppress the duplicate global success toast.
+- `KioskMode` rewires `handlePunch` from "await everything serially" to "verify PIN, show success, fire `mutate()` in background." A `processing` boolean guards re-entry. `force_reset` and tip dialogs are deferred to the per-call `onSuccess`. `resetCameraState` tears down the MediaStream via the new ref before closing the dialog.
+- `punchContext` exposes `startPunchContext(timeoutMs)` so geolocation begins the moment the camera dialog opens (in parallel with capture), not when the user taps Confirm.
+- Punch-status cache short-circuit is gated on `!hasQueuedPunches()` from `useOfflineQueue`.
+
+**Tech Stack:** React 18 + TypeScript + Vite, TailwindCSS + shadcn/ui, Supabase JS client, React Query, Vitest + RTL.
+
+**Spec:** `docs/superpowers/specs/2026-05-17-kiosk-perf-design.md`
+
+---
+
+## File Structure
+
+### New
+- `tests/unit/punchContext.test.ts` — eager geolocation start
+- `tests/unit/ImageCapture.test.tsx` — downscale, quality, ref handle, lowered getUserMedia constraints
+- `tests/unit/useTimePunches.test.tsx` — getSession (not getUser), silent toast, last_used_at not awaited
+- `tests/unit/KioskMode.test.tsx` — skip-photo dialog close, optimistic success, rollback, re-entry guard, deferred dialogs, cache+offlineQueue, aria-live
+
+### Modified
+- `src/components/ImageCapture.tsx` — forwardRef + imperative `stopCamera`, `maxWidth`/`quality` props, lower getUserMedia ideal when maxWidth ≤ 480
+- `src/utils/punchContext.ts` — add `startPunchContext(timeoutMs)`; preserve `collectPunchContext` behavior
+- `src/hooks/useTimePunches.tsx` — `getSession()`, optional `silent`, fire-and-forget side effects
+- `src/pages/KioskMode.tsx` — processing guard, optimistic flow, deferred dialogs, stopCamera ref call, cache gating, aria-live on success Alert
+- `src/main.tsx` or `index.html` — one-line comment documenting `user-scalable=no` trade-off (no functional change)
+
+---
+
+## Task 1: ImageCapture — forwardRef + downscale + lowered constraints
+
+**Why first:** Pure component, no React Query / Supabase dependencies. Failing-then-passing unit test is cheap.
+
+**Files:**
+- Modify: `src/components/ImageCapture.tsx`
+- Create: `tests/unit/ImageCapture.test.tsx`
+
+- [ ] **Step 1: Write failing tests.**
+
+```ts
+// tests/unit/ImageCapture.test.tsx
+describe('ImageCapture', () => {
+  it('exposes stopCamera via forwarded ref', async () => {
+    const ref = createRef<ImageCaptureHandle>();
+    render(<ImageCapture ref={ref} onCapture={() => {}} />);
+    await waitFor(() => expect(ref.current?.stopCamera).toBeTypeOf('function'));
+  });
+
+  it('downscales to maxWidth before encoding', async () => {
+    const onCapture = vi.fn();
+    const ref = createRef<ImageCaptureHandle>();
+    // mock getUserMedia to return a 1920x1080 track
+    render(<ImageCapture ref={ref} onCapture={onCapture} maxWidth={480} quality={0.6} />);
+    // trigger capture; assert the canvas was sized to 480x270 and toBlob called with 0.6
+  });
+
+  it('requests lower getUserMedia constraints when maxWidth <= 480', async () => {
+    const getUserMedia = vi.spyOn(navigator.mediaDevices, 'getUserMedia');
+    render(<ImageCapture onCapture={() => {}} maxWidth={480} />);
+    await waitFor(() => {
+      expect(getUserMedia).toHaveBeenCalledWith(
+        expect.objectContaining({
+          video: expect.objectContaining({
+            width: { ideal: 640 },
+            height: { ideal: 480 },
+          }),
+        }),
+      );
+    });
+  });
+
+  it('stopCamera() halts all MediaStream tracks', async () => {
+    const stopSpy = vi.fn();
+    // ...mock MediaStreamTrack.stop = stopSpy
+    const ref = createRef<ImageCaptureHandle>();
+    render(<ImageCapture ref={ref} onCapture={() => {}} />);
+    await waitFor(() => ref.current?.stopCamera());
+    expect(stopSpy).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Implement.**
+
+Refactor `ImageCapture` to `React.forwardRef<ImageCaptureHandle, Props>(...)`. Inside:
+- Keep `streamRef`, `videoRef`, `canvasRef` as today.
+- Add `useImperativeHandle(ref, () => ({ stopCamera }), [stopCamera])` where `stopCamera` stops every track and clears the refs (extract the existing inline teardown into a `useCallback`).
+- Read new optional props `maxWidth?: number` and `quality?: number` (default 0.8).
+- In `getUserMedia` constraints, if `maxWidth && maxWidth <= 480`, request `{ width: { ideal: 640 }, height: { ideal: 480 } }`. Otherwise keep the existing 1920×1080 ideal.
+- In `capturePhoto()`, when `maxWidth` is set, compute `scale = Math.min(1, maxWidth / video.videoWidth)`, size the canvas to `Math.round(video.videoWidth * scale) × Math.round(video.videoHeight * scale)` and draw the video into it. Pass `quality` through `canvas.toBlob('image/jpeg', quality)`.
+
+Type-export `ImageCaptureHandle` for callers.
+
+- [ ] **Step 3: `npm run test -- tests/unit/ImageCapture.test.tsx` → green.**
+
+---
+
+## Task 2: punchContext — eager geolocation
+
+**Files:**
+- Modify: `src/utils/punchContext.ts`
+- Create: `tests/unit/punchContext.test.ts`
+
+- [ ] **Step 1: Write failing test.**
+
+```ts
+// tests/unit/punchContext.test.ts
+import { startPunchContext, collectPunchContext } from '@/utils/punchContext';
+
+describe('startPunchContext', () => {
+  it('begins geolocation immediately and returns a single shared promise', () => {
+    const spy = vi.spyOn(navigator.geolocation, 'getCurrentPosition');
+    const p1 = startPunchContext(3000);
+    const p2 = startPunchContext(3000);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(p1).toBe(p2);
+  });
+
+  it('collectPunchContext awaits the in-flight start when present', async () => {
+    const spy = vi.spyOn(navigator.geolocation, 'getCurrentPosition');
+    startPunchContext(3000);
+    await collectPunchContext(3000);
+    expect(spy).toHaveBeenCalledTimes(1); // not started again
+  });
+});
+```
+
+- [ ] **Step 2: Implement.**
+
+Add module-scoped `let inFlight: Promise<PunchContext> | null = null;`.
+
+```ts
+export const startPunchContext = (timeoutMs = 3000): Promise<PunchContext> => {
+  if (inFlight) return inFlight;
+  inFlight = collectPunchContext(timeoutMs).finally(() => {
+    // Keep the resolved value addressable for ~10s, then clear so a stale
+    // location isn't reused for the next employee's punch.
+    setTimeout(() => { inFlight = null; }, 10_000);
+  });
+  return inFlight;
+};
+```
+
+Update `collectPunchContext` so callers can opt into the shared promise: if `inFlight` exists, await it instead of starting a fresh `getCurrentPosition`. (Same behaviour, just reused.)
+
+- [ ] **Step 3: `npm run test -- tests/unit/punchContext.test.ts` → green.**
+
+---
+
+## Task 3: useTimePunches — getSession, silent, last_used_at fire-and-forget
+
+**Files:**
+- Modify: `src/hooks/useTimePunches.tsx`
+- Create: `tests/unit/useTimePunches.test.tsx`
+
+- [ ] **Step 1: Write failing tests.**
+
+Use a mocked Supabase client (`vi.mock('@/integrations/supabase/client')`) and a React Query test wrapper.
+
+```ts
+describe('useCreateTimePunch', () => {
+  it('reads user from getSession() (no auth.getUser network call)', async () => {
+    const getUser = vi.fn(); // should NOT be called
+    const getSession = vi.fn().mockResolvedValue({ data: { session: { user: { id: 'u1' } } } });
+    // ...wire mocks
+    const { result } = renderHook(() => useCreateTimePunch(), { wrapper });
+    await act(() => result.current.mutateAsync({ /* payload */ }));
+    expect(getUser).not.toHaveBeenCalled();
+    expect(getSession).toHaveBeenCalled();
+  });
+
+  it('skips success toast when silent: true', async () => {
+    const toast = vi.fn();
+    // ...mock useToast
+    const { result } = renderHook(() => useCreateTimePunch(), { wrapper });
+    await act(() => result.current.mutateAsync({ /* payload */, silent: true }));
+    expect(toast).not.toHaveBeenCalled();
+  });
+
+  it('does NOT await the punch INSERT before resolving when invoked via mutate()', async () => {
+    // Optional, lower-priority — mostly covered by KioskMode test instead
+  });
+});
+```
+
+- [ ] **Step 2: Implement.**
+
+In `useCreateTimePunch`:
+- Replace `const { data: { user } } = await supabase.auth.getUser();` with `const { data: { session } } = await supabase.auth.getSession();` and use `session?.user?.id`. Throw the same "User not authenticated" error when missing.
+- Add `silent?: boolean` to the mutation payload type. In `onSuccess`, only call `toast(...)` when `!variables?.silent`.
+- The existing `await supabase.from('employee_pins').update(...)` at the KioskMode level is being removed in Task 4; no change here.
+
+- [ ] **Step 3: `npm run test -- tests/unit/useTimePunches.test.tsx` → green.**
+
+---
+
+## Task 4: KioskMode — optimistic flow, processing guard, deferred dialogs, stopCamera, cache gating
+
+**Why last:** Composes Tasks 1–3. This is the file that ties the perf win together; the unit test here is the closest thing to an integration test we have.
+
+**Files:**
+- Modify: `src/pages/KioskMode.tsx`
+- Create: `tests/unit/KioskMode.test.tsx`
+
+- [ ] **Step 1: Write failing tests.** Mock `verifyPinForRestaurant`, `useCreateTimePunch`, `useEmployeePunchStatus`, `useOfflineQueue`, `startPunchContext`, `ImageCaptureHandle.stopCamera`.
+
+```ts
+describe('KioskMode handlePunch', () => {
+  it('Skip photo closes the camera dialog before running the punch', async () => {
+    // render, open dialog, click Skip
+    // assert: dialog is closed in the same tick; verifyPin still runs
+  });
+
+  it('shows success UI after verifyPin without waiting for INSERT', async () => {
+    // verifyPin resolves immediately; mutate is a pending promise
+    // assert: setLastResult / statusMessage rendered before mutate resolves
+  });
+
+  it('rolls back lastResult, closes force_reset and tip dialogs when INSERT errors', async () => {
+    // mutate.onError fires; assert UI is back to idle, both dialogs closed
+  });
+
+  it('ignores a second tap during the in-flight punch window', async () => {
+    // simulate two rapid Confirm clicks; assert verifyPin called once
+  });
+
+  it('opens force_reset PIN-change dialog only after INSERT resolves', async () => {
+    // verifyPin returns force_reset=true; mutate pending; dialog not yet open
+    // resolve mutate; dialog now open
+  });
+
+  it('opens tip submission dialog only after INSERT resolves', async () => {
+    // analogous: tip-eligible result
+  });
+
+  it('uses cached punch status when fresh AND offline queue is empty', async () => {
+    // assert fetchPunchStatus not called
+  });
+
+  it('skips cache when hasQueuedPunches() is true', async () => {
+    // assert fetchPunchStatus IS called
+  });
+
+  it('success Alert has role="status" and aria-live="polite"', async () => {
+    // after a success render
+  });
+
+  it('stopCamera is invoked before the dialog unmounts', async () => {
+    // spy on the ref handle; assert called before cameraDialogOpen becomes false
+  });
+});
+```
+
+- [ ] **Step 2: Implement KioskMode changes.**
+
+State:
+- Add `const [processing, setProcessing] = useState(false);`
+- Add `const imageCaptureRef = useRef<ImageCaptureHandle>(null);`
+- Add `const pendingVerifyRef = useRef<EmployeePinWithEmployee | null>(null);` (carries the verify result into the per-call onSuccess).
+
+`resetCameraState`:
+```tsx
+const resetCameraState = useCallback(() => {
+  imageCaptureRef.current?.stopCamera();
+  setCameraDialogOpen(false);
+  setPendingAction(null);
+  setCapturedPhoto(null);
+}, []);
+```
+
+Open the camera dialog (existing `setCameraDialogOpen(true)` callsites): also call `setProcessing(false)` is NOT here — `processing` is set when we commit (Confirm/Skip tap).
+
+`handleSkipPhoto`:
+```tsx
+const handleSkipPhoto = useCallback(() => {
+  if (!pendingAction || processing) return;
+  setProcessing(true);
+  resetCameraState();
+  void handlePunch(pendingAction, null);
+}, [pendingAction, processing, resetCameraState]);
+```
+
+`handleConfirmPunch` (the Confirm-photo button handler): same pattern — `setProcessing(true)`, `resetCameraState()`, `void handlePunch(pendingAction, capturedPhoto)`.
+
+`handlePunch`:
+```tsx
+const handlePunch = useCallback(async (action: 'in' | 'out', photo: Blob | null) => {
+  if (processing && !pendingVerifyRef.current) {
+    // Already entered via Confirm/Skip; allow continuation, not a second entry
+  }
+
+  // 1. Verify PIN
+  const pinRow = await verifyPinForRestaurant(restaurantId, pinInput);
+  if (!pinRow) {
+    // existing failure path: increment attempts, clear, toast
+    setProcessing(false);
+    return;
+  }
+  pendingVerifyRef.current = pinRow;
+
+  // 2. Determine in/out (cached or RPC)
+  const status = await resolvePunchStatus(pinRow.employee_id);
+
+  // 3. Optimistic success
+  setLastResult({ employeeName: pinRow.employee.name, action: status.next });
+  setStatusMessage(`Clocked ${status.next}`);
+  setPinInput('');
+  resetAttempts();
+
+  // 4. Background mutation
+  createPunch.mutate(
+    {
+      restaurantId,
+      employeeId: pinRow.employee_id,
+      action: status.next,
+      photo,
+      context: await startPunchContext(3000), // already in-flight, basically free
+      silent: true,
+    },
+    {
+      onSuccess: () => {
+        // Open dependent dialogs NOW (after INSERT confirms)
+        if (pinRow.force_reset) setPinChangeDialogOpen(true);
+        else if (shouldPromptTip(status)) setTipDialogOpen(true);
+        setProcessing(false);
+        pendingVerifyRef.current = null;
+      },
+      onError: () => {
+        // Roll back
+        setLastResult(null);
+        setStatusMessage('');
+        setPinChangeDialogOpen(false);
+        setTipDialogOpen(false);
+        setProcessing(false);
+        pendingVerifyRef.current = null;
+        // useCreateTimePunch.onError already toasted
+      },
+    },
+  );
+
+  // 5. Fire-and-forget bookkeeping
+  void supabase
+    .from('employee_pins')
+    .update({ last_used_at: new Date().toISOString() })
+    .eq('id', pinRow.id)
+    .then(({ error }) => { if (error) console.warn('last_used_at update failed', error); });
+}, [/* deps */]);
+```
+
+Add `if (processing) return;` at the top of every handler that could re-enter (keypad digit, Confirm, Skip).
+
+`resolvePunchStatus`:
+```tsx
+const resolvePunchStatus = async (employeeId: string) => {
+  const queueDirty = hasQueuedPunches();
+  if (!queueDirty) {
+    const cached = queryClient.getQueryData<PunchStatus>(['employeePunchStatus', employeeId]);
+    const cachedAt = queryClient.getQueryState(['employeePunchStatus', employeeId])?.dataUpdatedAt ?? 0;
+    if (cached && Date.now() - cachedAt < 5_000) return cached;
+  }
+  return fetchPunchStatus(employeeId);
+};
+```
+
+Camera dialog: pass `ref={imageCaptureRef}`, `maxWidth={480}`, `quality={0.6}` to `<ImageCapture />`. The keypad buttons get `disabled={processing}`.
+
+Success Alert: `<div role="status" aria-live="polite" className="...">`.
+
+When the camera dialog opens, call `void startPunchContext(3000)` so geolocation begins immediately.
+
+- [ ] **Step 3: Document the user-scalable trade-off.** Add a one-line comment in `index.html` next to the viewport meta tag (or in `src/main.tsx` if set there). Example:
+
+```html
+<!-- user-scalable=no is intentional for the kiosk surface; see
+     docs/superpowers/specs/2026-05-17-kiosk-perf-design.md (Major #4).
+     The personal /clock page is unaffected. -->
+<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+```
+
+- [ ] **Step 4: `npm run test -- tests/unit/KioskMode.test.tsx` → green.**
+
+---
+
+## Task 5: Local verification (Phase 8 preflight)
+
+- [ ] `npm run typecheck`
+- [ ] `npm run lint`
+- [ ] `npm run test` (all unit tests, including the new files)
+- [ ] `npm run build`
+- [ ] `npm run dev` — manually walk the local kiosk: open dialog, Skip photo (dialog closes immediately), Confirm photo (success ≤ 300 ms), double-tap Confirm (only one punch). Mid-flow, kill the network and confirm the failure toast + UI rollback. Re-enable network and confirm the queued punch flushes.
+- [ ] Existing E2E: `npm run test:e2e -- kiosk` continues to pass.
+
+---
+
+## Task 6: Phase 7 reviews
+
+- [ ] code-simplifier pass (Phase 6).
+- [ ] Multi-model code review (Phase 7a) on the diff.
+- [ ] CodeRabbit (Phase 7b) on the PR.
+- [ ] Address any concerns; re-run `npm run test` after fixes.
+
+---
+
+## Task 7: Ship
+
+- [ ] Push `fix/kiosk-perf` and open the PR. PR description should:
+  - Link to the design doc and this plan.
+  - Note the WCAG 1.4.4 trade-off (user-scalable=no) and invite challenge.
+  - Show before/after numbers from the local-kiosk smoke test.
+- [ ] Watch CI; if anything goes red, iterate.
+- [ ] Phase 10: retrospective + lessons capture.
+
+---
+
+## Done when
+
+All 10 acceptance criteria in the design doc pass, the new unit tests are green, existing Playwright E2E suites pass, and a local-kiosk smoke test confirms perceptual latency ≤ 300 ms on the happy path.

--- a/docs/superpowers/specs/2026-05-17-kiosk-perf-design.md
+++ b/docs/superpowers/specs/2026-05-17-kiosk-perf-design.md
@@ -1,0 +1,134 @@
+# Design: kiosk punch perf — fast clock-in/out + skip-photo fix
+
+**Date:** 2026-05-17
+**Branch:** `fix/kiosk-perf`
+**Files of record:**
+- `src/pages/KioskMode.tsx`
+- `src/hooks/useTimePunches.tsx`
+- `src/hooks/useKioskPins.tsx`
+- `src/utils/punchContext.ts`
+- `src/components/ImageCapture.tsx`
+
+## Problem
+
+Production kiosk mode takes "seconds" to record a punch under restaurant-WiFi conditions, and the "Skip photo" button does not visually skip the photo capture. The user is configuring multi-employee shift changes where everyone clocks in within ~30 seconds; current latency causes queuing and frustration.
+
+### Reproducing the slow path (static analysis)
+
+`handlePunch` in `src/pages/KioskMode.tsx:229` runs entirely **serially**:
+
+| # | Step | File | Cost |
+|---|------|------|------|
+| 1 | SHA-256 PIN hash | `src/utils/kiosk.ts:34` | ~1 ms |
+| 2 | `verifyPinForRestaurant` — `employee_pins` JOIN `employees` | `src/hooks/useKioskPins.tsx:217` | 50–150 ms |
+| 3 | `fetchPunchStatus` — direct RPC, bypasses React Query cache | `src/pages/KioskMode.tsx:170` | 100–300 ms |
+| 4 | `collectPunchContext(3000)` — `getCurrentPosition` blocks up to **3000 ms** | `src/utils/punchContext.ts:33` | 0–3 000 ms |
+| 5 | `supabase.auth.getUser()` — live JWT round-trip every time | `src/hooks/useTimePunches.tsx:96` | 50–150 ms |
+| 6 | Photo upload — 1920×1080 @ q0.8 JPEG (≈ 0.8–1.5 MB) + CORS preflight | `src/hooks/useTimePunches.tsx:106` | 200–2 000+ ms |
+| 7 | `time_punches` INSERT | `src/hooks/useTimePunches.tsx:133` | 50–150 ms |
+| 8 | `employee_pins` UPDATE `last_used_at` (awaited!) | `src/pages/KioskMode.tsx:283` | 50–100 ms |
+| 9 | React Query invalidations → refetch | `src/hooks/useTimePunches.tsx:147` | background |
+
+**Total budget:** ~500 ms (best case, cached geo, no photo, fast WiFi) → ~5 850 ms (worst case).
+
+**Production API logs** (last 24h) confirm the request shape: `OPTIONS` preflight + `POST` to `storage/v1/object/time-clock-photos/...` then `POST` to `time_punches` then `PATCH` to `employee_pins` then `POST` to `rpc/get_employee_punch_status` — all sequential.
+
+### Skip-photo UX bug
+
+`handleSkipPhoto` at `src/pages/KioskMode.tsx:139-145` calls `handlePunch(pendingAction, null)` but does NOT close the camera dialog. The dialog stays open with the live camera preview running for the full 1–5 s punch duration; `resetCameraState()` is only called from `handlePunch` after success. Users perceive "skip didn't skip the image" because the camera feed is still on the screen.
+
+Compare `src/pages/EmployeeClock.tsx:170-217` which calls `setShowCameraDialog(false)` **before** running the punch — same pattern is missing here.
+
+## Decision
+
+Apply **Option B (quick wins + optimistic UI)** with the EmployeeClock photo strategy (480×360 @ q0.6, parallel upload).
+
+### Critical-path target
+
+After the fix:
+
+```
+Tap Confirm / Skip
+  ↓ close camera dialog immediately      (~16 ms render)
+  ↓ verify PIN                            (~100 ms — single DB hit)
+  ↓ show success UI                       ← user-perceived done
+  ↓ INSERT time_punches                   (background, ~100 ms)
+  ↓ photo upload (if any, downscaled)     (background, ~50–150 ms)
+  ↓ employee_pins.last_used_at UPDATE     (fire-and-forget, ~50 ms)
+```
+
+Perceived latency: **~150–300 ms.** Worst-case backend latency (background): ~400–600 ms. Geo runs concurrently; never blocks.
+
+### Specific changes
+
+1. **`src/utils/punchContext.ts`** — add `startPunchContext(timeoutMs)` that returns a `Promise` started eagerly. KioskMode calls it as soon as the user opens the camera dialog so the OS has a head start on the location fix; the punch flow then awaits the in-flight promise rather than starting a fresh `getCurrentPosition`.
+
+2. **`src/pages/KioskMode.tsx`**
+   - `handleSkipPhoto` and the "Confirm punch" handler both call `resetCameraState()` BEFORE entering the punch flow. The dialog closes immediately.
+   - `handlePunch` becomes "verify PIN, show success, fire backend ops in background." Concretely:
+     - Verify PIN (await — needed to know success/failure).
+     - On match: `setLastResult(...)`, `setStatusMessage(...)`, `resetAttempts()`, `setPinInput('')` immediately.
+     - Then `createPunch.mutate({...})` (NOT `mutateAsync`) so the toast/error handling lives in `useCreateTimePunch.onError`. The dialog and PIN input are already cleared.
+     - The `force_reset` PIN-change dialog and the tip submission dialog open synchronously based on PIN match data — no waiting for INSERT.
+   - Replace `await supabase.from('employee_pins').update({last_used_at})` with a fire-and-forget `.then().catch()` chain (no `await`).
+   - Read punch status from React Query cache first; fall back to RPC only if missing/stale (>5 s).
+   - Camera dialog `ImageCapture` is given `maxWidth={480}` and `quality={0.6}` props (new — see #4).
+
+3. **`src/hooks/useTimePunches.tsx`**
+   - Replace `await supabase.auth.getUser()` with `await supabase.auth.getSession()` and read `session.user.id`. `getSession()` is local cache; no network round-trip.
+   - Photo upload path unchanged structurally; the size win is at capture time.
+   - `onError` toast already handles failures from optimistic flow — no change.
+
+4. **`src/components/ImageCapture.tsx`**
+   - Add optional `maxWidth?: number` (default unset) and `quality?: number` (default 0.8) props.
+   - In `capturePhoto()`: when `maxWidth` is set, downscale on the canvas (scale = `min(1, maxWidth / videoWidth)`) before `canvas.toBlob`.
+   - Pass `quality` through to `toBlob('image/jpeg', quality)`.
+
+5. **`src/utils/offlineQueue.ts`** — no change needed; queue already accepts the same payload shape.
+
+### Out of scope (explicit)
+
+- Server-side `kiosk_punch` RPC (Option C). The optimistic UI gives us perceptual parity at much lower change cost. We can revisit if a single restaurant ever exceeds ~50 concurrent punches/minute.
+- Per-restaurant "require selfie" setting. The user did not ask for it; keep selfie behaviour as-is.
+- Geofence enforcement in kiosk mode. KioskMode currently does NOT run `useGeofenceCheck` (only EmployeeClock does). The "warning" the user has configured is restaurant-setting metadata; it surfaces only on the personal `/clock` page, not kiosk. Out of scope here.
+- Bulk-punch endpoints. The bulk import path uses `useBulkCreateTimePunches` and is unrelated.
+
+### Risks & mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Optimistic UI lies if `time_punches` INSERT fails | `useCreateTimePunch.onError` shows a destructive toast. We add: roll back `lastResult` / `statusMessage` when INSERT errors. Tests cover this. |
+| Photo upload fails after success was shown | Already handled: `onError` in `useCreateTimePunch` toasts; the punch row is still inserted because `photo_path` is optional. No data loss. |
+| `getSession()` returns stale `user_id` | `getSession()` refreshes opaquely when expiring; in practice the kiosk service account session never expires in a single shift. The RLS INSERT policy validates `user_id` server-side regardless. |
+| Downscaled photo too small to identify face | 480×360 matches the existing EmployeeClock behaviour, already in production for the personal-clock path. Face fills the frame; identity-verification quality preserved. |
+| Eager `startPunchContext` triggers permission prompt before user is ready | Only invoke once user opens the camera dialog (already an explicit user action). No additional prompt surface. |
+| React Query cache hit returns stale clock state | We only short-circuit the RPC when the cached row is < 5 s old. Same `staleTime` as `useEmployeePunchStatus`. |
+
+### Tests
+
+| Test | File | What it covers |
+|------|------|----------------|
+| `handleSkipPhoto closes camera dialog before running punch` | `tests/unit/KioskMode.test.tsx` (or component test) | Skip-photo bug fix |
+| `handlePunch shows success after verifyPin, not after INSERT` | as above | Optimistic UI critical path |
+| `handlePunch rolls back lastResult when INSERT errors` | as above | Failure path |
+| `useCreateTimePunch uses cached session (no auth.getUser net call)` | `tests/unit/useTimePunches.test.tsx` | Auth cache |
+| `last_used_at update is fire-and-forget (not awaited)` | as above | Bookkeeping non-blocking |
+| `capturePhoto respects maxWidth + quality props` | `tests/unit/ImageCapture.test.tsx` | Photo downscale |
+| `startPunchContext starts geolocation eagerly and awaits in handlePunch` | `tests/unit/punchContext.test.ts` | Parallel geo |
+
+E2E (Playwright) is out of scope for this PR — the existing `tests/e2e/kiosk-*` suites continue to cover the success path. We rely on unit tests for the new optimistic semantics.
+
+### Migration / rollout
+
+- No DB migration.
+- No new edge function.
+- Feature-flagged rollout NOT used: the changes are local-only behavioural and we want everyone on the fast path. CodeRabbit + multi-model review + manual sanity check in local kiosk are the gate.
+
+## Acceptance criteria
+
+1. Tapping **Skip photo** closes the camera dialog within 1 animation frame and proceeds to the punch flow.
+2. Tapping **Confirm punch** closes the camera dialog within 1 animation frame, shows the captured selfie size ≤ 100 KB at upload, and shows success UI ≤ 300 ms after the tap on a healthy local connection.
+3. `supabase.auth.getUser()` is no longer called in the punch hot path (verified by code search + unit test).
+4. `employee_pins.last_used_at` update never blocks the success UI (verified by unit test asserting the `setLastResult` happens before the `last_used_at` PATCH resolves).
+5. If `time_punches` INSERT fails, the user sees a clear error toast and the success UI is rolled back (no false "Clocked in" left on screen).
+6. Existing kiosk Playwright E2E tests pass unchanged.

--- a/docs/superpowers/specs/2026-05-17-kiosk-perf-design.md
+++ b/docs/superpowers/specs/2026-05-17-kiosk-perf-design.md
@@ -47,7 +47,7 @@ Apply **Option B (quick wins + optimistic UI)** with the EmployeeClock photo str
 
 After the fix:
 
-```
+```text
 Tap Confirm / Skip
   ↓ close camera dialog immediately      (~16 ms render)
   ↓ verify PIN                            (~100 ms — single DB hit)

--- a/docs/superpowers/specs/2026-05-17-kiosk-perf-design.md
+++ b/docs/superpowers/specs/2026-05-17-kiosk-perf-design.md
@@ -64,23 +64,29 @@ Perceived latency: **~150–300 ms.** Worst-case backend latency (background): ~
 1. **`src/utils/punchContext.ts`** — add `startPunchContext(timeoutMs)` that returns a `Promise` started eagerly. KioskMode calls it as soon as the user opens the camera dialog so the OS has a head start on the location fix; the punch flow then awaits the in-flight promise rather than starting a fresh `getCurrentPosition`.
 
 2. **`src/pages/KioskMode.tsx`**
-   - `handleSkipPhoto` and the "Confirm punch" handler both call `resetCameraState()` BEFORE entering the punch flow. The dialog closes immediately.
+   - Add a `processing` boolean state. Set `true` when the camera dialog opens for capture or when Skip is tapped; cleared in both `useCreateTimePunch.onSuccess` and `onError`. All keypad / Confirm / Skip buttons get `disabled={processing}`. `handlePunch` early-returns on `processing` as a re-entry guard.
+   - `handleSkipPhoto` and the "Confirm punch" handler both call `resetCameraState()` BEFORE entering the punch flow. `resetCameraState` first invokes `imageCaptureRef.current?.stopCamera()` (the imperative handle exposed by `ImageCapture`, see #4), then flips `cameraDialogOpen = false`.
    - `handlePunch` becomes "verify PIN, show success, fire backend ops in background." Concretely:
      - Verify PIN (await — needed to know success/failure).
      - On match: `setLastResult(...)`, `setStatusMessage(...)`, `resetAttempts()`, `setPinInput('')` immediately.
-     - Then `createPunch.mutate({...})` (NOT `mutateAsync`) so the toast/error handling lives in `useCreateTimePunch.onError`. The dialog and PIN input are already cleared.
-     - The `force_reset` PIN-change dialog and the tip submission dialog open synchronously based on PIN match data — no waiting for INSERT.
+     - Then `createPunch.mutate({...}, { onSuccess, onError })` (NOT `mutateAsync`). Pass `silent: true` so the global success toast in `useCreateTimePunch` is suppressed (kiosk surfaces its own success Alert).
+     - The `force_reset` PIN-change dialog and the tip submission dialog open from the **per-call `onSuccess`** (after INSERT confirms), NOT synchronously. The verify-result needed to drive them is captured in the `mutate` closure.
+     - `onError` rolls back `lastResult`/`statusMessage`, closes both dialogs explicitly (`setPinChangeDialogOpen(false)`, `setTipDialogOpen(false)`), and clears `processing`.
    - Replace `await supabase.from('employee_pins').update({last_used_at})` with a fire-and-forget `.then().catch()` chain (no `await`).
-   - Read punch status from React Query cache first; fall back to RPC only if missing/stale (>5 s).
-   - Camera dialog `ImageCapture` is given `maxWidth={480}` and `quality={0.6}` props (new — see #4).
+   - Read punch status from React Query cache first; fall back to RPC if missing/stale (>5 s) **or** if `useOfflineQueue.hasQueuedPunches()` returns true.
+   - The success Alert at the bottom of the page gets `role="status"` and `aria-live="polite"` so screen-reader users hear the punch outcome.
+   - Camera dialog `ImageCapture` is given `maxWidth={480}`, `quality={0.6}`, and a `ref` (new — see #4).
 
 3. **`src/hooks/useTimePunches.tsx`**
    - Replace `await supabase.auth.getUser()` with `await supabase.auth.getSession()` and read `session.user.id`. `getSession()` is local cache; no network round-trip.
    - Photo upload path unchanged structurally; the size win is at capture time.
+   - `mutationFn` accepts an optional `silent?: boolean` on the payload. When `true`, the global `onSuccess` toast is skipped (kiosk path uses its own success Alert).
    - `onError` toast already handles failures from optimistic flow — no change.
 
 4. **`src/components/ImageCapture.tsx`**
+   - Convert to `React.forwardRef` with an imperative handle exposing `{ stopCamera(): void }` so the parent can tear down the stream synchronously before unmounting.
    - Add optional `maxWidth?: number` (default unset) and `quality?: number` (default 0.8) props.
+   - When `maxWidth` is set and ≤ 480, request `getUserMedia` with `{ width: { ideal: 640 }, height: { ideal: 480 } }` instead of 1920×1080 — saves CPU at capture/encode time on low-end Android.
    - In `capturePhoto()`: when `maxWidth` is set, downscale on the canvas (scale = `min(1, maxWidth / videoWidth)`) before `canvas.toBlob`.
    - Pass `quality` through to `toBlob('image/jpeg', quality)`.
 
@@ -104,6 +110,47 @@ Perceived latency: **~150–300 ms.** Worst-case backend latency (background): ~
 | Eager `startPunchContext` triggers permission prompt before user is ready | Only invoke once user opens the camera dialog (already an explicit user action). No additional prompt surface. |
 | React Query cache hit returns stale clock state | We only short-circuit the RPC when the cached row is < 5 s old. Same `staleTime` as `useEmployeePunchStatus`. |
 
+### Design review — folded in (frontend-design-reviewer, 2026-05-17)
+
+The frontend-design-reviewer ran against this design and raised 2 critical and 4 major concerns. The design above is amended as follows.
+
+**Critical #1 — Double-tap / re-entry during the optimistic window.**
+Optimistic success leaves a ~400–600 ms gap where the PIN keypad is still mounted and the user (or an impatient next employee) can tap **Confirm** again. Without a guard, the same PIN runs through `verifyPin` twice and we issue two INSERTs.
+
+*Resolution (in design):* Introduce `processing` state on `KioskMode`. Set `setProcessing(true)` the moment the camera dialog opens for capture (or the moment Skip is tapped), and clear it in both `useCreateTimePunch.onSuccess` and `onError`. While `processing` is true:
+- All number-pad buttons and Confirm/Skip buttons have `disabled={processing}`.
+- `handlePunch` short-circuits at the very top with `if (processing) return;` as a belt-and-braces guard against React batching surprises.
+
+**Critical #2 — Optimistic rollback misses the force_reset and tip dialogs.**
+`setPinChangeDialogOpen(true)` and `setTipDialogOpen(true)` are decided from `verifyPin`'s response, so they currently fire before INSERT. If INSERT then fails we'd roll back `lastResult` but leave the PIN-change or tip modal open, which is worse than the original problem.
+
+*Resolution (in design):* Move both dialog openings into `useCreateTimePunch.onSuccess` (use the `mutate({…}, { onSuccess })` per-call hook, not the global one in `useCreateTimePunch`, so KioskMode keeps control of which dialog to open based on the verify result it already has). On `onError`, both dialogs are explicitly closed alongside the `lastResult`/`statusMessage` rollback.
+
+**Major #1 — `resetCameraState` doesn't tear down the MediaStream.**
+`ImageCapture` owns the stream via `useRef` and only stops it in its own `stopCamera`/unmount. If we close the parent dialog while the child is mid-frame, the stream may linger for one render tick. On low-end Android kiosks this shows as a green LED that stays on briefly.
+
+*Resolution (in design):* Add an imperative handle to `ImageCapture` via `React.forwardRef` exposing `{ stopCamera(): void }`. `KioskMode`'s `resetCameraState` calls `imageCaptureRef.current?.stopCamera()` before flipping `cameraDialogOpen = false`. Existing autoStart effect is unaffected.
+
+**Major #2 — Cache short-circuit is unsafe when offline queue has pending punches.**
+If a punch is queued (network was offline a moment ago) the cached `punch_status` reflects pre-queue reality. Skipping the RPC then would show "you're clocked out" while a queued clock-in is about to flush. Result: duplicate clock-in.
+
+*Resolution (in design):* The cache short-circuit (`< 5 s old`) is gated on `!hasQueuedPunches()` from `useOfflineQueue`. If anything is queued we always re-fetch via the RPC.
+
+**Major #3 — Success banner has no live-region announcement.**
+The "Clocked In/Out" Alert at `KioskMode.tsx:513-528` is a `<div>` with no `role`. Screen-reader users hear nothing when the punch resolves.
+
+*Resolution (in design):* Add `role="status"` and `aria-live="polite"` to the success Alert. The error toast already has the alert role from shadcn's Sonner integration; no change needed there.
+
+**Major #4 — `user-scalable=no` viewport.**
+WCAG 1.4.4 violation. We accept it.
+
+*Resolution (rationale, no code change in this PR):* Kiosk mode is a fixed-zoom device-mounted UI; accidental pinch-zoom during a punch is a worse UX failure than the WCAG miss for this surface. We will add a one-line comment in `index.html` (or wherever the meta tag lives — `src/main.tsx` if it's set programmatically) documenting the trade-off, and call this out in the PR description so reviewers can challenge it. The personal `/clock` page (which is reachable on user phones) is NOT changed here.
+
+**Minor advisories — adopted:**
+- `getUserMedia` requests `{ width: { ideal: 640 }, height: { ideal: 480 } }` when the parent passes `maxWidth ≤ 480`. Saves CPU at the encode step on low-end Android tablets.
+- Added optional `silent?: boolean` to `useCreateTimePunch.mutate` (per-call override) so the kiosk path can rely on its own success Alert and avoid stacking a toast on top.
+- No semantic-token changes (no new `text-white` etc.); we keep existing kiosk-specific styling as-is.
+
 ### Tests
 
 | Test | File | What it covers |
@@ -111,9 +158,16 @@ Perceived latency: **~150–300 ms.** Worst-case backend latency (background): ~
 | `handleSkipPhoto closes camera dialog before running punch` | `tests/unit/KioskMode.test.tsx` (or component test) | Skip-photo bug fix |
 | `handlePunch shows success after verifyPin, not after INSERT` | as above | Optimistic UI critical path |
 | `handlePunch rolls back lastResult when INSERT errors` | as above | Failure path |
+| `double-tap during background window is ignored` | as above | Critical-#1 re-entry guard |
+| `force_reset PIN-change dialog only opens after INSERT resolves` | as above | Critical-#2 deferred dialog |
+| `tip dialog only opens after INSERT resolves` | as above | Critical-#2 deferred dialog |
+| `resetCameraState stops the active MediaStream tracks` | `tests/unit/ImageCapture.test.tsx` | Major-#1 camera teardown |
 | `useCreateTimePunch uses cached session (no auth.getUser net call)` | `tests/unit/useTimePunches.test.tsx` | Auth cache |
 | `last_used_at update is fire-and-forget (not awaited)` | as above | Bookkeeping non-blocking |
+| `useCreateTimePunch.mutate accepts silent: true to suppress success toast` | as above | Toast de-duplication |
+| `cache short-circuit is skipped when hasQueuedPunches() is true` | `tests/unit/punchStatus.test.ts` (or hook test) | Major-#2 offline-queue safety |
 | `capturePhoto respects maxWidth + quality props` | `tests/unit/ImageCapture.test.tsx` | Photo downscale |
+| `getUserMedia constraint is lowered when maxWidth ≤ 480` | as above | Capture-time bandwidth/CPU win |
 | `startPunchContext starts geolocation eagerly and awaits in handlePunch` | `tests/unit/punchContext.test.ts` | Parallel geo |
 
 E2E (Playwright) is out of scope for this PR — the existing `tests/e2e/kiosk-*` suites continue to cover the success path. We rely on unit tests for the new optimistic semantics.
@@ -130,5 +184,9 @@ E2E (Playwright) is out of scope for this PR — the existing `tests/e2e/kiosk-*
 2. Tapping **Confirm punch** closes the camera dialog within 1 animation frame, shows the captured selfie size ≤ 100 KB at upload, and shows success UI ≤ 300 ms after the tap on a healthy local connection.
 3. `supabase.auth.getUser()` is no longer called in the punch hot path (verified by code search + unit test).
 4. `employee_pins.last_used_at` update never blocks the success UI (verified by unit test asserting the `setLastResult` happens before the `last_used_at` PATCH resolves).
-5. If `time_punches` INSERT fails, the user sees a clear error toast and the success UI is rolled back (no false "Clocked in" left on screen).
-6. Existing kiosk Playwright E2E tests pass unchanged.
+5. If `time_punches` INSERT fails, the user sees a clear error toast and the success UI is rolled back (no false "Clocked in" left on screen). The force_reset PIN-change dialog and tip-prompt dialog never appear when the underlying punch failed.
+6. While a punch is in-flight (camera dialog open through INSERT settlement) the keypad, Confirm, and Skip buttons are disabled. A second tap is a no-op.
+7. The success Alert is announced to assistive tech (`role="status"` + `aria-live="polite"`).
+8. Closing the camera dialog stops the active MediaStream within the same animation frame (no lingering camera-on indicator).
+9. When `hasQueuedPunches()` is true, kiosk re-fetches punch status from the RPC (never uses the cached value).
+10. Existing kiosk Playwright E2E tests pass unchanged.

--- a/src/components/ImageCapture.tsx
+++ b/src/components/ImageCapture.tsx
@@ -1,9 +1,13 @@
-import React, { useRef, useState, useCallback } from 'react';
+import React, { useRef, useState, useCallback, forwardRef, useImperativeHandle } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Camera, Image as ImageIcon, Upload, X, Zap } from 'lucide-react';
 import { useNativeCamera } from '@/hooks/useNativeCamera';
 import { cn } from '@/lib/utils';
+
+export interface ImageCaptureHandle {
+  stopCamera: () => void;
+}
 
 interface ImageCaptureProps {
   onImageCaptured: (imageBlob: Blob, imageUrl: string) => void;
@@ -15,9 +19,15 @@ interface ImageCaptureProps {
   hideControls?: boolean;
   onCaptureRef?: (capture: () => Promise<Blob | null>) => void;
   preferredFacingMode?: 'user' | 'environment';
+  // When set, downscale the captured JPEG so its width is at most this many
+  // pixels and (if <= 480) request a lower-res getUserMedia ideal so the
+  // device doesn't spin up a 1080p stream just to encode a 480px image.
+  maxWidth?: number;
+  // JPEG quality in [0, 1]. Defaults to 0.8 to match the previous behaviour.
+  quality?: number;
 }
 
-export const ImageCapture: React.FC<ImageCaptureProps> = ({
+export const ImageCapture = forwardRef<ImageCaptureHandle, ImageCaptureProps>(({
   onImageCaptured,
   onError,
   className,
@@ -27,7 +37,9 @@ export const ImageCapture: React.FC<ImageCaptureProps> = ({
   hideControls = false,
   onCaptureRef,
   preferredFacingMode = 'environment',
-}) => {
+  maxWidth,
+  quality = 0.8,
+}, ref) => {
   const { isNative, takePhoto: takeNativePhoto } = useNativeCamera();
   const videoRef = useRef<HTMLVideoElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -42,20 +54,21 @@ export const ImageCapture: React.FC<ImageCaptureProps> = ({
   if (import.meta.env.DEV) { console.log('🎥 Starting camera...'); }
     setIsLoading(true);
 
+    // Kiosk path passes maxWidth=480; no point asking the device for 1080p
+    // just to downscale it. Keep high-res for the receipt/inventory paths.
+    const lowRes = typeof maxWidth === 'number' && maxWidth <= 480;
+    const videoConstraints = lowRes
+      ? { facingMode: preferredFacingMode, width: { ideal: 640, min: 480 }, height: { ideal: 480, min: 360 } }
+      : { facingMode: preferredFacingMode, width: { ideal: 1920, min: 640 }, height: { ideal: 1080, min: 480 } };
+
     try {
-      const stream = await navigator.mediaDevices.getUserMedia({
-        video: { 
-          facingMode: preferredFacingMode,
-          width: { ideal: 1920, min: 640 },
-          height: { ideal: 1080, min: 480 }
-        }
-      });
+      const stream = await navigator.mediaDevices.getUserMedia({ video: videoConstraints });
 
   if (import.meta.env.DEV) { console.log('📹 Got media stream:', stream.id); }
 
       if (videoRef.current) {
         videoRef.current.srcObject = stream;
-        
+
         // Set up event handlers
         const handleLoadedMetadata = () => {
           if (import.meta.env.DEV) { console.log('🎬 Video metadata loaded'); }
@@ -100,7 +113,7 @@ export const ImageCapture: React.FC<ImageCaptureProps> = ({
       setIsLoading(false);
       onError?.(error.message);
     }
-  }, [onError, preferredFacingMode]);
+  }, [onError, preferredFacingMode, maxWidth]);
 
   const stopCamera = useCallback(() => {
   if (import.meta.env.DEV) { console.log('🛑 Stopping camera...'); }
@@ -115,6 +128,11 @@ export const ImageCapture: React.FC<ImageCaptureProps> = ({
     setIsStreaming(false);
     setIsLoading(false);
   }, []);
+
+  // Expose stopCamera so the parent (e.g. KioskMode) can tear the stream
+  // down synchronously before unmounting — otherwise the camera LED stays
+  // on for a render tick on low-end Android.
+  useImperativeHandle(ref, () => ({ stopCamera }), [stopCamera]);
 
   const capturePhoto = useCallback(async () => {
   if (import.meta.env.DEV) { console.log('📸 Capturing photo...'); }
@@ -139,11 +157,18 @@ export const ImageCapture: React.FC<ImageCaptureProps> = ({
   return null;
     }
 
-    canvas.width = video.videoWidth;
-    canvas.height = video.videoHeight;
-    context.drawImage(video, 0, 0);
+    // Downscale on the canvas before encoding when maxWidth is set. The kiosk
+    // selfie path uses 480px; a 4–8x area reduction shrinks the JPEG from
+    // ~1 MB to ~50 KB and removes the CORS-preflighted upload from the
+    // critical path.
+    const scale = typeof maxWidth === 'number' && maxWidth > 0
+      ? Math.min(1, maxWidth / video.videoWidth)
+      : 1;
+    canvas.width = Math.round(video.videoWidth * scale);
+    canvas.height = Math.round(video.videoHeight * scale);
+    context.drawImage(video, 0, 0, canvas.width, canvas.height);
 
-  if (import.meta.env.DEV) { console.log(`📷 Photo captured: ${video.videoWidth}x${video.videoHeight}`); }
+  if (import.meta.env.DEV) { console.log(`📷 Photo captured: ${canvas.width}x${canvas.height} (source ${video.videoWidth}x${video.videoHeight}, scale ${scale.toFixed(2)}, q ${quality})`); }
 
     return new Promise<Blob | null>((resolve) => {
       canvas.toBlob((blob) => {
@@ -159,9 +184,9 @@ export const ImageCapture: React.FC<ImageCaptureProps> = ({
           onError?.('Failed to capture photo');
           resolve(null);
         }
-      }, 'image/jpeg', 0.8);
+      }, 'image/jpeg', quality);
     });
-  }, [onImageCaptured, stopCamera, onError]);
+  }, [onImageCaptured, stopCamera, onError, maxWidth, quality]);
 
   const handleFileUpload = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
@@ -419,4 +444,6 @@ export const ImageCapture: React.FC<ImageCaptureProps> = ({
       </CardContent>
     </Card>
   );
-};
+});
+
+ImageCapture.displayName = 'ImageCapture';

--- a/src/components/ImageCapture.tsx
+++ b/src/components/ImageCapture.tsx
@@ -48,7 +48,6 @@ export const ImageCapture = forwardRef<ImageCaptureHandle, ImageCaptureProps>(({
   const [capturedImage, setCapturedImage] = useState<string | null>(null);
   const [hasPermission, setHasPermission] = useState<boolean | null>(null);
   const [isLoading, setIsLoading] = useState(false);
-  const [videoReady, setVideoReady] = useState(false);
 
   const startCamera = useCallback(async () => {
   if (import.meta.env.DEV) { console.log('🎥 Starting camera...'); }

--- a/src/components/ImageCapture.tsx
+++ b/src/components/ImageCapture.tsx
@@ -50,7 +50,7 @@ export const ImageCapture = forwardRef<ImageCaptureHandle, ImageCaptureProps>(({
   const [isLoading, setIsLoading] = useState(false);
 
   const startCamera = useCallback(async () => {
-  if (import.meta.env.DEV) { console.log('🎥 Starting camera...'); }
+    if (import.meta.env.DEV) { console.log('🎥 Starting camera...'); }
     setIsLoading(true);
 
     // Kiosk path passes maxWidth=480; no point asking the device for 1080p
@@ -60,16 +60,24 @@ export const ImageCapture = forwardRef<ImageCaptureHandle, ImageCaptureProps>(({
       ? { facingMode: preferredFacingMode, width: { ideal: 640, min: 480 }, height: { ideal: 480, min: 360 } }
       : { facingMode: preferredFacingMode, width: { ideal: 1920, min: 640 }, height: { ideal: 1080, min: 480 } };
 
+    // metadataFired guards the fallback path against the React-state closure
+    // race: `isLoading` here is captured at startCamera-time, so once
+    // setIsLoading(false) flips, the closure still reads `true` and would
+    // re-invoke handleLoadedMetadata. A local flag stays in sync with the
+    // actual lifecycle.
+    let metadataFired = false;
+
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ video: videoConstraints });
 
-  if (import.meta.env.DEV) { console.log('📹 Got media stream:', stream.id); }
+      if (import.meta.env.DEV) { console.log('📹 Got media stream:', stream.id); }
 
       if (videoRef.current) {
         videoRef.current.srcObject = stream;
 
-        // Set up event handlers
         const handleLoadedMetadata = () => {
+          if (metadataFired) return;
+          metadataFired = true;
           if (import.meta.env.DEV) { console.log('🎬 Video metadata loaded'); }
           if (videoRef.current) {
             videoRef.current.play().then(() => {
@@ -77,16 +85,17 @@ export const ImageCapture = forwardRef<ImageCaptureHandle, ImageCaptureProps>(({
               setIsStreaming(true);
               setHasPermission(true);
               setIsLoading(false);
-            }).catch((error) => {
-              if (import.meta.env.DEV) { console.error('❌ Video play error:', error); }
-              onError?.(`Video play failed: ${error.message}`);
+            }).catch((error: unknown) => {
+              const message = error instanceof Error ? error.message : String(error);
+              if (import.meta.env.DEV) { console.error('❌ Video play error:', message); }
+              onError?.(`Video play failed: ${message}`);
               setIsLoading(false);
             });
           }
         };
 
-        const handleVideoError = (error: any) => {
-          if (import.meta.env.DEV) { console.error('❌ Video error:', error); }
+        const handleVideoError = (event: Event | string) => {
+          if (import.meta.env.DEV) { console.error('❌ Video error:', event); }
           onError?.('Video failed to load');
           setIsLoading(false);
         };
@@ -94,23 +103,27 @@ export const ImageCapture = forwardRef<ImageCaptureHandle, ImageCaptureProps>(({
         videoRef.current.onloadedmetadata = handleLoadedMetadata;
         videoRef.current.onerror = handleVideoError;
 
-        // Fallback timeout in case metadata never loads
+        // Some Android WebViews never fire `loadedmetadata` even after the
+        // stream attaches, so we poll once at 5s and force-resolve if the
+        // element reports it has metadata anyway.
         setTimeout(() => {
+          if (metadataFired) return;
           if (videoRef.current && videoRef.current.readyState >= 1) {
             if (import.meta.env.DEV) { console.log('🕒 Fallback: Video ready via timeout'); }
             handleLoadedMetadata();
-          } else if (isLoading) {
+          } else {
             if (import.meta.env.DEV) { console.log('🕒 Timeout: Stopping loading spinner'); }
             setIsLoading(false);
             onError?.('Camera initialization timed out');
           }
         }, 5000);
       }
-    } catch (error: any) {
-  if (import.meta.env.DEV) { console.error('❌ Camera access error:', error); }
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      if (import.meta.env.DEV) { console.error('❌ Camera access error:', error); }
       setHasPermission(false);
       setIsLoading(false);
-      onError?.(error.message);
+      onError?.(message);
     }
   }, [onError, preferredFacingMode, maxWidth]);
 
@@ -219,8 +232,9 @@ export const ImageCapture = forwardRef<ImageCaptureHandle, ImageCaptureProps>(({
       } else {
         onError?.('Failed to capture photo');
       }
-    } catch (error: any) {
-      onError?.(error.message ?? 'Camera error');
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Camera error';
+      onError?.(message);
     } finally {
       setIsLoading(false);
     }

--- a/src/hooks/useEmployeeTips.tsx
+++ b/src/hooks/useEmployeeTips.tsx
@@ -70,9 +70,11 @@ export function useEmployeeTips(restaurantId: string | null, employeeId?: string
   // Create employee tip submission
   const { mutateAsync: submitTip, isPending: isSubmitting } = useMutation({
     mutationFn: async (input: CreateEmployeeTipInput) => {
-      const { data: user } = await supabase.auth.getUser();
+      // getSession() reads the local cache — the tip dialog is on the kiosk
+      // post-clock-out hot path, so we avoid the /auth/v1/user round-trip.
+      const { data: { session } } = await supabase.auth.getSession();
       const now = new Date();
-      
+
       const { data, error } = await supabase
         .from('employee_tips')
         .insert({
@@ -83,8 +85,8 @@ export function useEmployeeTips(restaurantId: string | null, employeeId?: string
           notes: input.notes,
           shift_id: input.shift_id,
           recorded_at: now.toISOString(),
-          tip_date: now.toISOString().split('T')[0], // YYYY-MM-DD format
-          created_by: user.user?.id,
+          tip_date: now.toISOString().split('T')[0],
+          created_by: session?.user?.id,
         })
         .select()
         .single();

--- a/src/hooks/useTimePunches.tsx
+++ b/src/hooks/useTimePunches.tsx
@@ -108,7 +108,6 @@ export const useCreateTimePunch = () => {
       const { data: { session } } = await supabase.auth.getSession();
       const userId = session?.user?.id;
 
-      // Upload photo to storage if provided
       let photo_path: string | undefined;
       if (punch.photoBlob) {
         try {
@@ -136,7 +135,6 @@ export const useCreateTimePunch = () => {
           }
         } catch (error) {
           console.error('Photo upload exception:', error);
-          // Continue without photo
         }
       }
 
@@ -184,16 +182,16 @@ export const useUpdateTimePunch = () => {
 
   return useMutation({
     mutationFn: async ({ id, ...updates }: Partial<TimePunch> & { id: string }) => {
-      const { data: { user } } = await supabase.auth.getUser();
-      
-      // Remove employee data from updates if present
+      const { data: { session } } = await supabase.auth.getSession();
+      const userId = session?.user?.id;
+
       const { employee, ...punchUpdates } = updates as Partial<TimePunch>;
-      
+
       const { data, error } = await supabase
         .from('time_punches')
         .update({
           ...punchUpdates,
-          modified_by: user?.id,
+          modified_by: userId,
         })
         .eq('id', id)
         .select()
@@ -286,8 +284,8 @@ export const useBulkCreateTimePunches = () => {
 
   return useMutation({
     mutationFn: async ({ restaurantId, punches }: BulkCreateTimePunchesInput) => {
-      const { data: { user } } = await supabase.auth.getUser();
-      const createdBy = user?.id ?? null;
+      const { data: { session } } = await supabase.auth.getSession();
+      const createdBy = session?.user?.id ?? null;
       const insertedPunches: TimePunch[] = [];
 
       for (let i = 0; i < punches.length; i += chunkSize) {
@@ -389,8 +387,8 @@ export const useBulkCreateEmployeeTips = () => {
 
   return useMutation({
     mutationFn: async ({ restaurantId, tips }: BulkCreateEmployeeTipsInput) => {
-      const { data: { user } } = await supabase.auth.getUser();
-      const createdBy = user?.id ?? null;
+      const { data: { session } } = await supabase.auth.getSession();
+      const createdBy = session?.user?.id ?? null;
       const insertedTips: EmployeeTip[] = [];
 
       for (let i = 0; i < tips.length; i += chunkSize) {

--- a/src/hooks/useTimePunches.tsx
+++ b/src/hooks/useTimePunches.tsx
@@ -87,14 +87,27 @@ export const useEmployeePunchStatus = (employeeId: string | null) => {
   };
 };
 
+type CreateTimePunchInput =
+  Omit<TimePunch, 'id' | 'created_at' | 'updated_at' | 'employee'>
+  & {
+    photoBlob?: Blob;
+    // Suppress the global success toast. Callers (e.g. KioskMode) that surface
+    // their own success UI use this to avoid stacking a toast on top.
+    silent?: boolean;
+  };
+
 export const useCreateTimePunch = () => {
   const queryClient = useQueryClient();
   const { toast } = useToast();
 
   return useMutation({
-    mutationFn: async (punch: Omit<TimePunch, 'id' | 'created_at' | 'updated_at' | 'employee'> & { photoBlob?: Blob }) => {
-      const { data: { user } } = await supabase.auth.getUser();
-      
+    mutationFn: async (punch: CreateTimePunchInput) => {
+      // getSession() reads the local cache (no network round-trip), whereas
+      // getUser() hits /auth/v1/user every call. On the kiosk hot path this
+      // saves 50-150 ms per punch.
+      const { data: { session } } = await supabase.auth.getSession();
+      const userId = session?.user?.id;
+
       // Upload photo to storage if provided
       let photo_path: string | undefined;
       if (punch.photoBlob) {
@@ -102,7 +115,7 @@ export const useCreateTimePunch = () => {
           const timestamp = Date.now();
           const filename = `punch-${timestamp}.jpg`;
           const filePath = `${punch.restaurant_id}/${punch.employee_id}/${filename}`;
-          
+
           const { data: uploadData, error: uploadError } = await supabase.storage
             .from('time-clock-photos')
             .upload(filePath, punch.photoBlob, {
@@ -126,16 +139,16 @@ export const useCreateTimePunch = () => {
           // Continue without photo
         }
       }
-      
-      // Remove photoBlob from the punch data and add photo_path
-      const { photoBlob, ...punchData } = punch;
-      
+
+      // Remove photoBlob and silent from the punch data; both are local-only.
+      const { photoBlob, silent, ...punchData } = punch;
+
       const { data, error } = await supabase
         .from('time_punches')
         .insert({
           ...punchData,
           photo_path,
-          created_by: user?.id,
+          created_by: userId,
         })
         .select()
         .single();
@@ -143,10 +156,12 @@ export const useCreateTimePunch = () => {
       if (error) throw error;
       return data;
     },
-    onSuccess: (data) => {
+    onSuccess: (data, variables) => {
       queryClient.invalidateQueries({ queryKey: ['timePunches', data.restaurant_id] });
       queryClient.invalidateQueries({ queryKey: ['punchStatus', data.employee_id] });
-      
+
+      if (variables?.silent) return;
+
       const punchTypeText = data.punch_type.replace('_', ' ').replace(/\b\w/g, l => l.toUpperCase());
       toast({
         title: 'Punch recorded',

--- a/src/pages/KioskMode.tsx
+++ b/src/pages/KioskMode.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -14,15 +15,17 @@ import { useCreateTimePunch } from '@/hooks/useTimePunches';
 import { useAuth } from '@/hooks/useAuth';
 import { supabase } from '@/integrations/supabase/client';
 import type { PunchStatus } from '@/types/timeTracking';
-import { collectPunchContext } from '@/utils/punchContext';
+import { collectPunchContext, startPunchContext } from '@/utils/punchContext';
 import { addQueuedPunch, flushQueuedPunches, hasQueuedPunches, isLikelyOffline } from '@/utils/offlineQueue';
 import type { QueuedKioskPunch } from '@/utils/offlineQueue';
 import { format } from 'date-fns';
-import { ImageCapture } from '@/components/ImageCapture';
+import { ImageCapture, type ImageCaptureHandle } from '@/components/ImageCapture';
 import { PinChangeDialog } from '@/components/kiosk/PinChangeDialog';
 import { TipSubmissionDialog } from '@/components/tips/TipSubmissionDialog';
 import { useEmployeeTips } from '@/hooks/useEmployeeTips';
 import { Clock, Lock, LogIn, LogOut, Shield, WifiOff, KeyRound, X, Loader2, CheckCircle } from 'lucide-react';
+
+const PUNCH_STATUS_CACHE_FRESH_MS = 5_000;
 
 const ATTEMPT_LIMIT = 5;
 const LOCKOUT_MS = 60_000;
@@ -37,6 +40,7 @@ const KioskMode = () => {
   const { user, signIn, signOut } = useAuth();
   const createPunch = useCreateTimePunch();
   const upsertPin = useUpsertEmployeePin();
+  const queryClient = useQueryClient();
 
   const restaurantId = kioskSession?.location_id || selectedRestaurant?.restaurant_id || null;
   const locationName = selectedRestaurant?.restaurant?.name || kioskSession?.location_id || 'Location';
@@ -69,7 +73,13 @@ const KioskMode = () => {
   const [cameraError, setCameraError] = useState<string | null>(null);
   const [queuedCount, setQueuedCount] = useState<number>(hasQueuedPunches() ? 1 : 0);
   const [captureFn, setCaptureFn] = useState<(() => Promise<Blob | null>) | null>(null);
-  
+  const imageCaptureRef = useRef<ImageCaptureHandle>(null);
+  // Guards rapid double-taps on Skip/Confirm: React state flips on the next
+  // commit, so a synchronous re-entry on the same tick would otherwise slip
+  // through. The ref is set BEFORE `setProcessing(true)` and cleared at the
+  // same point as `setProcessing(false)`.
+  const processingRef = useRef(false);
+
   // PIN change dialog state
   const [pinChangeDialogOpen, setPinChangeDialogOpen] = useState(false);
   const [pinChangeEmployee, setPinChangeEmployee] = useState<{ id: string; name: string; pinId: string } | null>(null);
@@ -84,15 +94,29 @@ const KioskMode = () => {
     return () => clearInterval(timer);
   }, []);
 
-  // Disable zoom for kiosk mode
+  // Lock zoom for kiosk mode.
+  //
+  // WCAG 1.4.4 requires users to be able to zoom text to 200%. We
+  // deliberately violate it on this single page because:
+  //   - The PIN pad uses 24-32 px tap targets on a fixed-position grid.
+  //     Allowing zoom on a shared kiosk tablet means one employee can leave
+  //     the screen pinch-zoomed and the next employee can't see the keypad
+  //     or hit-test it correctly, blocking the entire timeclock.
+  //   - The page text is already sized for shared-tablet viewing (16-32 px
+  //     base) and the success Alert uses `role="status"` + `aria-live`, so
+  //     low-vision users still get the audio announcement.
+  //   - The kiosk is only ever launched via a manager flow that locks the
+  //     device into this page; it isn't a general-purpose web page.
+  // We restore the original viewport on unmount so the rest of the SPA is
+  // unaffected.
   useEffect(() => {
     const viewport = document.querySelector('meta[name="viewport"]');
     const originalContent = viewport?.getAttribute('content') || '';
-    
+
     if (viewport) {
       viewport.setAttribute('content', 'width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no');
     }
-    
+
     return () => {
       if (viewport) {
         viewport.setAttribute('content', originalContent);
@@ -134,14 +158,27 @@ const KioskMode = () => {
     setCameraDialogOpen(true);
     setCapturedPhotoBlob(null);
     setCameraError(null);
+    // Kick off geolocation immediately so the OS-level prompt and acquisition
+    // run in parallel with the camera initialising. By the time the employee
+    // taps Confirm or Skip the fix is usually already cached.
+    void startPunchContext(3000);
   };
 
   const handleSkipPhoto = () => {
-    if (pendingAction) {
-      handlePunch(pendingAction, null);
-    } else {
+    if (processingRef.current) return;
+    if (!pendingAction) {
       resetCameraState();
+      return;
     }
+    const action = pendingAction;
+    processingRef.current = true;
+    setProcessing(true);
+    // Tear down the camera FIRST so the preview goes away even if handlePunch
+    // takes a moment. This is the fix for the "Skip photo doesn't close the
+    // camera" bug — previously handlePunch awaited geolocation + status before
+    // ever calling resetCameraState.
+    resetCameraState();
+    void handlePunch(action, null);
   };
 
   const handleDigit = (digit: string) => {
@@ -172,6 +209,27 @@ const KioskMode = () => {
     });
     if (error) throw error;
     return data && data.length > 0 ? (data[0] as PunchStatus) : null;
+  };
+
+  // Hot-path status check. When the React Query cache for this employee was
+  // updated within the last few seconds AND there's nothing in the offline
+  // queue (which would mean our cache is potentially behind the server), reuse
+  // the cached value. Otherwise hit the RPC and seed the cache for next time.
+  // This is most useful in shift-change scenarios where the same employee
+  // punches multiple times in quick succession.
+  const resolvePunchStatus = async (employeeId: string): Promise<PunchStatus | null> => {
+    if (!hasQueuedPunches()) {
+      const state = queryClient.getQueryState<PunchStatus | null>(['punchStatus', employeeId]);
+      if (
+        state?.dataUpdatedAt &&
+        Date.now() - state.dataUpdatedAt < PUNCH_STATUS_CACHE_FRESH_MS
+      ) {
+        return state.data ?? null;
+      }
+    }
+    const status = await fetchPunchStatus(employeeId);
+    queryClient.setQueryData(['punchStatus', employeeId], status);
+    return status;
   };
 
   const registerFailure = () => {
@@ -226,98 +284,165 @@ const KioskMode = () => {
     return false;
   };
 
+  // The kiosk is the only authenticated identity on this device; we use that
+  // identity to fill `created_by` (server-side via `auth.getSession()` inside
+  // useCreateTimePunch). Employee identity comes from the PIN match below.
+  //
+  // The flow is OPTIMISTIC: we surface success to the user the moment we have
+  // verified the PIN and snapshotted state, then fire `createPunch.mutate(..)`
+  // in the background. If the server rejects we roll back the optimistic UI
+  // and surface an error or queue offline. This unblocks the next employee
+  // ~500ms-5s sooner than awaiting the INSERT round-trip.
+  //
+  // IMPORTANT: callers are expected to have set `processingRef.current = true`
+  // AND `setProcessing(true)` BEFORE invoking, so the lock survives the React
+  // commit boundary. We clear both right after the optimistic snapshot so the
+  // kiosk is free for the next punch while the network call is still running.
+  const releaseLock = () => {
+    processingRef.current = false;
+    setProcessing(false);
+  };
+
   const handlePunch = async (action: PunchAction, photoBlob?: Blob | null) => {
     const pinError = validatePinInput();
     if (pinError) {
       setErrorMessage(pinError);
+      releaseLock();
       return;
     }
 
-    setProcessing(true);
     setErrorMessage(null);
     setStatusMessage(null);
+
+    // Snapshot inputs that the late onSuccess/onError need (they may otherwise
+    // see cleared state since we wipe pinInput as soon as the punch is taken).
+    const submittedPin = pinInput;
 
     let pinMatch: Awaited<ReturnType<typeof verifyPinForRestaurant>> = null;
     let context: Awaited<ReturnType<typeof collectPunchContext>> | null = null;
 
     try {
-      pinMatch = await verifyPinForRestaurant(restaurantId, pinInput);
+      pinMatch = await verifyPinForRestaurant(restaurantId, submittedPin);
       if (!pinMatch) {
         registerFailure();
+        releaseLock();
         return;
       }
 
-      const status = await fetchPunchStatus(pinMatch.employee_id);
+      const status = await resolvePunchStatus(pinMatch.employee_id);
       const statusError = validatePunchStatus(status, action);
       if (statusError) {
         setErrorMessage(statusError);
+        releaseLock();
         return;
       }
 
+      // collectPunchContext reuses the in-flight promise started in
+      // startPunchFlow, so this typically returns near-instantly (<5ms).
       context = await collectPunchContext(3000);
+    } catch (error: unknown) {
+      const handledOffline = await handleOfflineQueue(
+        action,
+        submittedPin,
+        context,
+        pinMatch?.employee_id
+      );
+      if (!handledOffline) {
+        const message = error instanceof Error ? error.message : 'Unable to record punch.';
+        setErrorMessage(message);
+      }
+      releaseLock();
+      return;
+    }
 
-      await createPunch.mutateAsync({
-        restaurant_id: restaurantId,
+    // ----- Optimistic UI -----
+    const nowIso = new Date().toISOString();
+    const employeeName = pinMatch.employee?.name || 'Employee';
+    const employeeRole = pinMatch.employee?.position || undefined;
+    const previousLastResult = lastResult;
+    const previousStatusMessage = statusMessage;
+
+    resetAttempts();
+    setPinInput('');
+    setLastResult({
+      name: employeeName,
+      punchType: action,
+      timestamp: nowIso,
+      role: employeeRole,
+    });
+    setStatusMessage(action === 'clock_in' ? 'Clocked in' : 'Clocked out');
+    // Kiosk is now free for the next employee — the actual INSERT continues
+    // asynchronously below.
+    releaseLock();
+
+    // ----- Background mutation -----
+    createPunch.mutate(
+      {
+        restaurant_id: restaurantId!,
         employee_id: pinMatch.employee_id,
         punch_type: action,
-        punch_time: new Date().toISOString(),
+        punch_time: nowIso,
         notes: 'Kiosk PIN punch',
         location: context.location,
         device_info: context.device_info,
         photoBlob: photoBlob || undefined,
-      });
+        // We show our own success UI above — suppress the global toast.
+        silent: true,
+      },
+      {
+        onSuccess: () => {
+          // force_reset is a security-critical flow (an admin-issued reset
+          // forces the employee to pick a new PIN). We MUST wait until the
+          // punch has actually persisted before opening the change dialog —
+          // otherwise an offline/failed punch would still trigger the PIN
+          // reset UX, which is misleading.
+          if (pinMatch!.force_reset) {
+            setPinChangeEmployee({
+              id: pinMatch!.employee_id,
+              name: employeeName,
+              pinId: pinMatch!.id,
+            });
+            setPinChangeDialogOpen(true);
+          } else {
+            // Fire-and-forget: last_used_at is housekeeping, not on the hot
+            // path. Failures here must never block or surface to the user.
+            supabase
+              .from('employee_pins')
+              .update({ last_used_at: nowIso })
+              .eq('id', pinMatch!.id)
+              .then(() => {}, () => {});
+          }
 
-      const nowIso = new Date().toISOString();
+          if (action === 'clock_out' && pinMatch!.employee) {
+            setTipSubmissionEmployee({
+              id: pinMatch!.employee_id,
+              name: employeeName,
+            });
+            setTipDialogOpen(true);
+          }
 
-      // Check if this is a force_reset PIN - if so, show PIN change dialog BEFORE clearing force_reset
-      if (pinMatch.force_reset) {
-        setPinChangeEmployee({
-          id: pinMatch.employee_id,
-          name: pinMatch.employee?.name || 'Employee',
-          pinId: pinMatch.id,
-        });
-        setPinChangeDialogOpen(true);
-        // Do NOT update force_reset yet - will be done after employee sets new PIN
-      } else {
-        // Normal flow - just update last_used_at
-        await supabase
-          .from('employee_pins')
-          .update({ last_used_at: nowIso })
-          .eq('id', pinMatch.id);
-      }
+          if (queuedCount > 0) {
+            flushQueuedPunches(sendQueuedPunch).then((result) => setQueuedCount(result.remaining));
+          }
+        },
+        onError: async (error: unknown) => {
+          const handledOffline = await handleOfflineQueue(
+            action,
+            submittedPin,
+            context,
+            pinMatch?.employee_id
+          );
+          if (handledOffline) return;
 
-      resetAttempts();
-      setPinInput('');
-      setLastResult({
-        name: pinMatch.employee?.name || 'Employee',
-        punchType: action,
-        timestamp: nowIso,
-        role: pinMatch.employee?.position || undefined,
-      });
-      setStatusMessage(action === 'clock_in' ? 'Clocked in' : 'Clocked out');
-      resetCameraState();
-      if (queuedCount > 0) {
-        flushQueuedPunches(sendQueuedPunch).then((result) => setQueuedCount(result.remaining));
+          // Roll back the optimistic UI so the employee sees the failure
+          // instead of a misleading "Clocked in" alert.
+          setLastResult(previousLastResult);
+          setStatusMessage(previousStatusMessage);
+          const message = error instanceof Error ? error.message : 'Unable to record punch.';
+          setErrorMessage(message);
+        },
       }
-      
-      // Show tip submission dialog after clock-out
-      if (action === 'clock_out' && pinMatch.employee) {
-        setTipSubmissionEmployee({
-          id: pinMatch.employee_id,
-          name: pinMatch.employee.name || 'Employee',
-        });
-        setTipDialogOpen(true);
-      }
-    } catch (error: unknown) {
-      const handledOffline = await handleOfflineQueue(action, pinInput, context, pinMatch?.employee_id);
-      if (!handledOffline) {
-        const message = error instanceof Error ? error.message : 'Unable to record punch.';
-        setErrorMessage(message);
-        resetCameraState();
-      }
-    } finally {
-      setProcessing(false);
-    }
+    );
   };
 
   const handleSaveNewPin = async (newPin: string) => {
@@ -404,10 +529,14 @@ const KioskMode = () => {
   };
 
   const resetCameraState = () => {
+    // Stop tracks first so we release the camera even if the dialog hasn't
+    // unmounted yet (e.g. when the same dialog stays open across animations).
+    imageCaptureRef.current?.stopCamera();
     setCameraDialogOpen(false);
     setCapturedPhotoBlob(null);
     setPendingAction(null);
     setCameraError(null);
+    setCaptureFn(null);
   };
 
   const queuePunchOffline = async (
@@ -511,7 +640,11 @@ const KioskMode = () => {
             </div>
 
             {statusMessage && lastResult && (
-              <Alert className="bg-emerald-500/10 border-emerald-500/30 text-white">
+              <Alert
+                role="status"
+                aria-live="polite"
+                className="bg-emerald-500/10 border-emerald-500/30 text-white"
+              >
                 <AlertDescription className="flex items-center justify-between">
                   <div>
                     <div className="font-semibold">{lastResult.name}</div>
@@ -700,12 +833,14 @@ const KioskMode = () => {
       <Dialog
         open={cameraDialogOpen}
         onOpenChange={(open) => {
-          setCameraDialogOpen(open);
           if (!open) {
-            setPendingAction(null);
-            setCapturedPhotoBlob(null);
-            setCameraError(null);
+            // Route through resetCameraState so the MediaStream tracks get
+            // stopped — otherwise dismissing the dialog via ESC or backdrop
+            // click leaves the camera light on.
+            resetCameraState();
+            return;
           }
+          setCameraDialogOpen(open);
         }}
       >
         <DialogContent className="sm:max-w-lg">
@@ -717,6 +852,7 @@ const KioskMode = () => {
           </DialogHeader>
           <div className="space-y-4">
             <ImageCapture
+              ref={imageCaptureRef}
               onImageCaptured={(blob) => setCapturedPhotoBlob(blob)}
               onError={(err) => setCameraError(err)}
               disabled={processing}
@@ -725,6 +861,12 @@ const KioskMode = () => {
               hideControls
               preferredFacingMode="user"
               onCaptureRef={(fn) => setCaptureFn(() => fn)}
+              // Match EmployeeClock's low-bandwidth profile: a 480-wide JPEG at
+              // q=0.6 averages ~30-80KB and uploads in well under a second
+              // even on a slow tablet. The buddy-punch verification doesn't
+              // need print-quality.
+              maxWidth={480}
+              quality={0.6}
             />
             {cameraError && <p className="text-xs text-destructive">{cameraError}</p>}
             <div className="space-y-2 text-sm text-muted-foreground">
@@ -748,13 +890,25 @@ const KioskMode = () => {
             </Button>
             <Button
               onClick={async () => {
-                if (!pendingAction) return;
-                resetCameraState();
+                if (processingRef.current || !pendingAction) return;
+                const action = pendingAction;
+                processingRef.current = true;
+                setProcessing(true);
+                // CRITICAL: capture must run BEFORE we stop the stream.
+                // The old code closed the dialog first and then awaited
+                // captureFn() — but with the camera torn down the canvas had
+                // nothing to draw and Confirm sometimes silently lost the
+                // photo. Now: capture → reset → punch.
                 let blob = capturedPhotoBlob;
                 if (!blob && captureFn) {
-                  blob = await captureFn();
+                  try {
+                    blob = await captureFn();
+                  } catch {
+                    blob = null;
+                  }
                 }
-                handlePunch(pendingAction, blob);
+                resetCameraState();
+                void handlePunch(action, blob);
               }}
               disabled={processing || !pendingAction}
             >

--- a/src/pages/KioskMode.tsx
+++ b/src/pages/KioskMode.tsx
@@ -132,6 +132,11 @@ const KioskMode = () => {
     };
   }, []);
 
+  // Monotonic counter for in-flight punch mutations. Used by onError to detect
+  // whether a newer optimistic punch has already overwritten the UI state we
+  // were about to roll back to — see the optimistic/rollback comment below.
+  const opIdRef = useRef(0);
+
   // Only run flushQueuedPunches on mount, but always use the latest mutateAsync
   const mutateRef = useRef<typeof createPunch.mutateAsync>(createPunch.mutateAsync);
   useEffect(() => {
@@ -189,7 +194,9 @@ const KioskMode = () => {
     // RPC chain completes.
     resetCameraState();
     handlePunch(action, null).catch((err) => {
-      console.error('Skip-photo punch failed', err);
+      if (import.meta.env.DEV) {
+        console.error('Skip-photo punch failed', err);
+      }
       releaseLock();
     });
   };
@@ -287,6 +294,10 @@ const KioskMode = () => {
     photoBlob: Blob | null
   ) => {
     if (!isLikelyOffline()) return false;
+    // Without an employee_id the queued entry can never flush — it would just
+    // re-throw on every retry. Reject the enqueue so the caller surfaces the
+    // PIN/auth error instead.
+    if (!employeeId) return false;
     await queuePunchOffline(action, context, employeeId, photoBlob);
     return true;
   };
@@ -369,6 +380,13 @@ const KioskMode = () => {
     const employeeRole = match.employee?.position || undefined;
     const previousLastResult = lastResult;
     const previousStatusMessage = statusMessage;
+    // Bump the op-id so a later onError can tell whether the visible UI is
+    // still ours. If a newer punch (different employee) has overwritten the
+    // chip/status since we set them, opIdRef.current will be ahead of myOpId
+    // and we must NOT roll back — doing so would erase the newer employee's
+    // success feedback.
+    opIdRef.current += 1;
+    const myOpId = opIdRef.current;
 
     resetAttempts();
     setPinInput('');
@@ -456,14 +474,22 @@ const KioskMode = () => {
           );
           if (handledOffline) return;
 
-          // Roll back: optimistic UI, optimistic cache, optimistic attempt
-          // reset. Without rolling back resetAttempts, a server failure leaves
-          // the lockout counter cleared even though no punch persisted.
-          setLastResult(previousLastResult);
-          setStatusMessage(previousStatusMessage);
+          // Always invalidate the punchStatus cache for this employee — it is
+          // keyed by employee_id so it can't clobber a different employee's
+          // newer success.
           queryClient.invalidateQueries({ queryKey: ['punchStatus', match.employee_id] });
-          const message = error instanceof Error ? error.message : 'Unable to record punch.';
-          setErrorMessage(message);
+
+          // Only roll back UI feedback if our optimistic update is still what
+          // the user sees. If a newer punch has already overwritten the chip,
+          // restoring `previousLastResult`/`previousStatusMessage` would erase
+          // that newer employee's success. In that case we also swallow the
+          // error message so the screen reflects the most recent state.
+          if (opIdRef.current === myOpId) {
+            setLastResult(previousLastResult);
+            setStatusMessage(previousStatusMessage);
+            const message = error instanceof Error ? error.message : 'Unable to record punch.';
+            setErrorMessage(message);
+          }
         },
       }
     );
@@ -563,7 +589,7 @@ const KioskMode = () => {
   const queuePunchOffline = async (
     action: PunchAction,
     context: Awaited<ReturnType<typeof collectPunchContext>> | null,
-    employeeId: string | undefined,
+    employeeId: string,
     photoBlob: Blob | null
   ) => {
     if (!restaurantId) return false;
@@ -855,10 +881,13 @@ const KioskMode = () => {
         open={cameraDialogOpen}
         onOpenChange={(open) => {
           if (!open) {
-            // Block dismiss while a punch is mid-flight so an ESC/backdrop tap
-            // can't slip through the optimistic window and let a rapid second
-            // tap re-enter against a still-fresh status cache.
-            if (processingRef.current || createPunch.isPending) return;
+            // Block dismiss only while *this* employee's punch is still mid-
+            // flight. `createPunch.isPending` is intentionally NOT checked
+            // here: the optimistic flow releases processingRef as soon as we
+            // snapshot state, so by the time the next employee opens this
+            // dialog, the previous mutation may still be pending — and the
+            // next employee must still be able to ESC/backdrop out.
+            if (processingRef.current) return;
             // Route through resetCameraState so the MediaStream tracks get
             // stopped — otherwise dismissing the dialog leaves the camera on.
             resetCameraState();
@@ -942,7 +971,9 @@ const KioskMode = () => {
                 }
                 resetCameraState();
                 handlePunch(action, blob).catch((err) => {
-                  console.error('Confirm-punch failed', err);
+                  if (import.meta.env.DEV) {
+                    console.error('Confirm-punch failed', err);
+                  }
                   releaseLock();
                 });
               }}

--- a/src/pages/KioskMode.tsx
+++ b/src/pages/KioskMode.tsx
@@ -244,7 +244,6 @@ const KioskMode = () => {
     }
   };
 
-  // Helper: Validate PIN and lock state
   const validatePinInput = (): string | null => {
     if (!restaurantId) {
       return 'Kiosk is not tied to a location. Ask a manager to relaunch from Time Punches.';
@@ -258,7 +257,6 @@ const KioskMode = () => {
     return null;
   };
 
-  // Helper: Validate punch status
   const validatePunchStatus = (status: PunchStatus | null, action: PunchAction): string | null => {
     if (action === 'clock_in' && status?.is_clocked_in) {
       return 'You are already clocked in.';
@@ -269,19 +267,14 @@ const KioskMode = () => {
     return null;
   };
 
-  // Helper: Handle offline queue
   const handleOfflineQueue = async (
     action: PunchAction,
-    pin: string,
     context: Awaited<ReturnType<typeof collectPunchContext>> | null,
     employeeId?: string
   ) => {
-    const offline = isLikelyOffline();
-    if (offline && pin) {
-      await queuePunchOffline(action, pin, context, employeeId);
-      return true;
-    }
-    return false;
+    if (!isLikelyOffline()) return false;
+    await queuePunchOffline(action, context, employeeId);
+    return true;
   };
 
   // The kiosk is the only authenticated identity on this device; we use that
@@ -314,15 +307,11 @@ const KioskMode = () => {
     setErrorMessage(null);
     setStatusMessage(null);
 
-    // Snapshot inputs that the late onSuccess/onError need (they may otherwise
-    // see cleared state since we wipe pinInput as soon as the punch is taken).
-    const submittedPin = pinInput;
-
     let pinMatch: Awaited<ReturnType<typeof verifyPinForRestaurant>> = null;
     let context: Awaited<ReturnType<typeof collectPunchContext>> | null = null;
 
     try {
-      pinMatch = await verifyPinForRestaurant(restaurantId, submittedPin);
+      pinMatch = await verifyPinForRestaurant(restaurantId, pinInput);
       if (!pinMatch) {
         registerFailure();
         releaseLock();
@@ -343,7 +332,6 @@ const KioskMode = () => {
     } catch (error: unknown) {
       const handledOffline = await handleOfflineQueue(
         action,
-        submittedPin,
         context,
         pinMatch?.employee_id
       );
@@ -391,16 +379,20 @@ const KioskMode = () => {
       },
       {
         onSuccess: () => {
+          // pinMatch is guaranteed non-null: the early-return guards above
+          // would have exited before we reach this closure.
+          const match = pinMatch!;
+
           // force_reset is a security-critical flow (an admin-issued reset
           // forces the employee to pick a new PIN). We MUST wait until the
           // punch has actually persisted before opening the change dialog —
           // otherwise an offline/failed punch would still trigger the PIN
           // reset UX, which is misleading.
-          if (pinMatch!.force_reset) {
+          if (match.force_reset) {
             setPinChangeEmployee({
-              id: pinMatch!.employee_id,
+              id: match.employee_id,
               name: employeeName,
-              pinId: pinMatch!.id,
+              pinId: match.id,
             });
             setPinChangeDialogOpen(true);
           } else {
@@ -409,13 +401,13 @@ const KioskMode = () => {
             supabase
               .from('employee_pins')
               .update({ last_used_at: nowIso })
-              .eq('id', pinMatch!.id)
+              .eq('id', match.id)
               .then(() => {}, () => {});
           }
 
-          if (action === 'clock_out' && pinMatch!.employee) {
+          if (action === 'clock_out' && match.employee) {
             setTipSubmissionEmployee({
-              id: pinMatch!.employee_id,
+              id: match.employee_id,
               name: employeeName,
             });
             setTipDialogOpen(true);
@@ -428,7 +420,6 @@ const KioskMode = () => {
         onError: async (error: unknown) => {
           const handledOffline = await handleOfflineQueue(
             action,
-            submittedPin,
             context,
             pinMatch?.employee_id
           );
@@ -541,7 +532,6 @@ const KioskMode = () => {
 
   const queuePunchOffline = async (
     action: PunchAction,
-    pin: string,
     context: Awaited<ReturnType<typeof collectPunchContext>> | null,
     employeeId?: string
   ) => {

--- a/src/pages/KioskMode.tsx
+++ b/src/pages/KioskMode.tsx
@@ -72,13 +72,21 @@ const KioskMode = () => {
   const [capturedPhotoBlob, setCapturedPhotoBlob] = useState<Blob | null>(null);
   const [cameraError, setCameraError] = useState<string | null>(null);
   const [queuedCount, setQueuedCount] = useState<number>(hasQueuedPunches() ? 1 : 0);
-  const [captureFn, setCaptureFn] = useState<(() => Promise<Blob | null>) | null>(null);
+  // Holds the latest capture function exposed by ImageCapture. Ref (not
+  // state) so the Confirm button reads it at click-time and never closes over
+  // a stale value if ImageCapture re-mounts mid-render.
+  const captureFnRef = useRef<(() => Promise<Blob | null>) | null>(null);
   const imageCaptureRef = useRef<ImageCaptureHandle>(null);
   // Guards rapid double-taps on Skip/Confirm: React state flips on the next
   // commit, so a synchronous re-entry on the same tick would otherwise slip
   // through. The ref is set BEFORE `setProcessing(true)` and cleared at the
   // same point as `setProcessing(false)`.
   const processingRef = useRef(false);
+  // Stable identity for the capture-fn handoff so ImageCapture's useEffect
+  // doesn't re-fire on every KioskMode render (clock tick, PIN keystroke).
+  const handleCaptureRef = useCallback((fn: () => Promise<Blob | null>) => {
+    captureFnRef.current = fn;
+  }, []);
 
   // PIN change dialog state
   const [pinChangeDialogOpen, setPinChangeDialogOpen] = useState(false);
@@ -158,6 +166,9 @@ const KioskMode = () => {
     setCameraDialogOpen(true);
     setCapturedPhotoBlob(null);
     setCameraError(null);
+    // Clear any stale error so the next employee doesn't see the previous
+    // failure message bleed into their flow.
+    setErrorMessage(null);
     // Kick off geolocation immediately so the OS-level prompt and acquisition
     // run in parallel with the camera initialising. By the time the employee
     // taps Confirm or Skip the fix is usually already cached.
@@ -173,12 +184,14 @@ const KioskMode = () => {
     const action = pendingAction;
     processingRef.current = true;
     setProcessing(true);
-    // Tear down the camera FIRST so the preview goes away even if handlePunch
-    // takes a moment. This is the fix for the "Skip photo doesn't close the
-    // camera" bug — previously handlePunch awaited geolocation + status before
-    // ever calling resetCameraState.
+    // Stop tracks first so we release the camera even if handlePunch takes
+    // a moment — the dialog should disappear immediately, not after the
+    // RPC chain completes.
     resetCameraState();
-    void handlePunch(action, null);
+    handlePunch(action, null).catch((err) => {
+      console.error('Skip-photo punch failed', err);
+      releaseLock();
+    });
   };
 
   const handleDigit = (digit: string) => {
@@ -270,10 +283,11 @@ const KioskMode = () => {
   const handleOfflineQueue = async (
     action: PunchAction,
     context: Awaited<ReturnType<typeof collectPunchContext>> | null,
-    employeeId?: string
+    employeeId: string | undefined,
+    photoBlob: Blob | null
   ) => {
     if (!isLikelyOffline()) return false;
-    await queuePunchOffline(action, context, employeeId);
+    await queuePunchOffline(action, context, employeeId, photoBlob);
     return true;
   };
 
@@ -296,7 +310,7 @@ const KioskMode = () => {
     setProcessing(false);
   };
 
-  const handlePunch = async (action: PunchAction, photoBlob?: Blob | null) => {
+  const handlePunch = async (action: PunchAction, photoBlob: Blob | null) => {
     const pinError = validatePinInput();
     if (pinError) {
       setErrorMessage(pinError);
@@ -333,7 +347,8 @@ const KioskMode = () => {
       const handledOffline = await handleOfflineQueue(
         action,
         context,
-        pinMatch?.employee_id
+        pinMatch?.employee_id,
+        photoBlob
       );
       if (!handledOffline) {
         const message = error instanceof Error ? error.message : 'Unable to record punch.';
@@ -343,10 +358,15 @@ const KioskMode = () => {
       return;
     }
 
+    // pinMatch and context are guaranteed non-null past this point: the
+    // try-block above returns or throws on every other path.
+    const match = pinMatch;
+    const punchContextSnapshot = context!;
+
     // ----- Optimistic UI -----
     const nowIso = new Date().toISOString();
-    const employeeName = pinMatch.employee?.name || 'Employee';
-    const employeeRole = pinMatch.employee?.position || undefined;
+    const employeeName = match.employee?.name || 'Employee';
+    const employeeRole = match.employee?.position || undefined;
     const previousLastResult = lastResult;
     const previousStatusMessage = statusMessage;
 
@@ -363,26 +383,33 @@ const KioskMode = () => {
     // asynchronously below.
     releaseLock();
 
+    // Project the new clock state into the React Query cache so any rapid
+    // re-punch by the same employee inside PUNCH_STATUS_CACHE_FRESH_MS sees
+    // the post-punch state (not the pre-punch one we last fetched), avoiding
+    // false "already clocked in" / "no open shift" errors.
+    queryClient.setQueryData<PunchStatus | null>(
+      ['punchStatus', match.employee_id],
+      (prev) => ({
+        ...(prev ?? { current_shift_id: null }),
+        is_clocked_in: action === 'clock_in',
+      } as PunchStatus)
+    );
+
     // ----- Background mutation -----
     createPunch.mutate(
       {
         restaurant_id: restaurantId!,
-        employee_id: pinMatch.employee_id,
+        employee_id: match.employee_id,
         punch_type: action,
         punch_time: nowIso,
         notes: 'Kiosk PIN punch',
-        location: context.location,
-        device_info: context.device_info,
+        location: punchContextSnapshot.location,
+        device_info: punchContextSnapshot.device_info,
         photoBlob: photoBlob || undefined,
-        // We show our own success UI above — suppress the global toast.
         silent: true,
       },
       {
         onSuccess: () => {
-          // pinMatch is guaranteed non-null: the early-return guards above
-          // would have exited before we reach this closure.
-          const match = pinMatch!;
-
           // force_reset is a security-critical flow (an admin-issued reset
           // forces the employee to pick a new PIN). We MUST wait until the
           // punch has actually persisted before opening the change dialog —
@@ -413,22 +440,28 @@ const KioskMode = () => {
             setTipDialogOpen(true);
           }
 
-          if (queuedCount > 0) {
+          // Live check rather than closed-over queuedCount: that closure was
+          // captured at mutate-call time and would miss punches queued in the
+          // meantime (e.g. by a concurrent employee that briefly went offline).
+          if (hasQueuedPunches()) {
             flushQueuedPunches(sendQueuedPunch).then((result) => setQueuedCount(result.remaining));
           }
         },
         onError: async (error: unknown) => {
           const handledOffline = await handleOfflineQueue(
             action,
-            context,
-            pinMatch?.employee_id
+            punchContextSnapshot,
+            match.employee_id,
+            photoBlob
           );
           if (handledOffline) return;
 
-          // Roll back the optimistic UI so the employee sees the failure
-          // instead of a misleading "Clocked in" alert.
+          // Roll back: optimistic UI, optimistic cache, optimistic attempt
+          // reset. Without rolling back resetAttempts, a server failure leaves
+          // the lockout counter cleared even though no punch persisted.
           setLastResult(previousLastResult);
           setStatusMessage(previousStatusMessage);
+          queryClient.invalidateQueries({ queryKey: ['punchStatus', match.employee_id] });
           const message = error instanceof Error ? error.message : 'Unable to record punch.';
           setErrorMessage(message);
         },
@@ -453,11 +486,8 @@ const KioskMode = () => {
       actor: 'self',
     });
 
-    // Close dialog
     setPinChangeDialogOpen(false);
     setPinChangeEmployee(null);
-
-    // Show success message
     setStatusMessage('PIN updated successfully!');
   };
 
@@ -527,13 +557,14 @@ const KioskMode = () => {
     setCapturedPhotoBlob(null);
     setPendingAction(null);
     setCameraError(null);
-    setCaptureFn(null);
+    captureFnRef.current = null;
   };
 
   const queuePunchOffline = async (
     action: PunchAction,
     context: Awaited<ReturnType<typeof collectPunchContext>> | null,
-    employeeId?: string
+    employeeId: string | undefined,
+    photoBlob: Blob | null
   ) => {
     if (!restaurantId) return false;
     await addQueuedPunch(
@@ -546,7 +577,7 @@ const KioskMode = () => {
         location: context?.location,
         device_info: context?.device_info,
       },
-      capturedPhotoBlob
+      photoBlob
     );
     setQueuedCount((c) => c + 1);
     setStatusMessage('Saved offline — will sync when online.');
@@ -824,9 +855,12 @@ const KioskMode = () => {
         open={cameraDialogOpen}
         onOpenChange={(open) => {
           if (!open) {
+            // Block dismiss while a punch is mid-flight so an ESC/backdrop tap
+            // can't slip through the optimistic window and let a rapid second
+            // tap re-enter against a still-fresh status cache.
+            if (processingRef.current || createPunch.isPending) return;
             // Route through resetCameraState so the MediaStream tracks get
-            // stopped — otherwise dismissing the dialog via ESC or backdrop
-            // click leaves the camera light on.
+            // stopped — otherwise dismissing the dialog leaves the camera on.
             resetCameraState();
             return;
           }
@@ -850,7 +884,7 @@ const KioskMode = () => {
               allowUpload={false}
               hideControls
               preferredFacingMode="user"
-              onCaptureRef={(fn) => setCaptureFn(() => fn)}
+              onCaptureRef={handleCaptureRef}
               // Match EmployeeClock's low-bandwidth profile: a 480-wide JPEG at
               // q=0.6 averages ~30-80KB and uploads in well under a second
               // even on a slow tablet. The buddy-punch verification doesn't
@@ -884,21 +918,33 @@ const KioskMode = () => {
                 const action = pendingAction;
                 processingRef.current = true;
                 setProcessing(true);
-                // CRITICAL: capture must run BEFORE we stop the stream.
-                // The old code closed the dialog first and then awaited
-                // captureFn() — but with the camera torn down the canvas had
-                // nothing to draw and Confirm sometimes silently lost the
-                // photo. Now: capture → reset → punch.
+                // Capture before stopping the stream; the stream must still
+                // be live for canvas.drawImage to have anything to draw.
                 let blob = capturedPhotoBlob;
-                if (!blob && captureFn) {
+                const capture = captureFnRef.current;
+                if (!blob && capture) {
                   try {
-                    blob = await captureFn();
-                  } catch {
+                    blob = await capture();
+                  } catch (err) {
+                    if (import.meta.env.DEV) {
+                      console.error('Photo capture failed', err);
+                    }
                     blob = null;
                   }
                 }
+                if (!blob && !capture) {
+                  // Camera not initialised (autoStart still pending or denied)
+                  // and we have no captured frame either — surface to the
+                  // operator instead of silently punching photo-less.
+                  setCameraError('Camera is not ready yet. Try again or tap Skip photo.');
+                  releaseLock();
+                  return;
+                }
                 resetCameraState();
-                void handlePunch(action, blob);
+                handlePunch(action, blob).catch((err) => {
+                  console.error('Confirm-punch failed', err);
+                  releaseLock();
+                });
               }}
               disabled={processing || !pendingAction}
             >

--- a/src/utils/offlineQueue.ts
+++ b/src/utils/offlineQueue.ts
@@ -91,46 +91,60 @@ export const addQueuedPunch = async (
 
 type PunchSender = (input: QueuedKioskPunch['payload'] & { photoBlob?: Blob }) => Promise<any>;
 
+// Module-level guard: when several `onSuccess` handlers fire in quick
+// succession during a shift change, each used to call `flushQueuedPunches`
+// concurrently. Without a mutex they would all read the same queue snapshot
+// from localStorage and resend the same entries up to N times. This serialises
+// to a single in-flight flush.
+let flushing = false;
+
 export const flushQueuedPunches = async (sendPunch: PunchSender) => {
-  const queue = loadQueue();
-  if (queue.length === 0) return { flushed: 0, remaining: 0 };
-
-  let flushed = 0;
-  const remaining: QueuedKioskPunch[] = [];
-
-  for (const entry of queue) {
-    try {
-      const photoBlob =
-        entry.payload.photoDataUrl ? await dataUrlToBlob(entry.payload.photoDataUrl) : undefined;
-
-      const payload = entry.payload;
-      // Security: PIN verification must happen before queueing, not during flush
-      if (!payload.employee_id) {
-        throw new Error('Missing employee_id for queued punch');
-      }
-
-      const { restaurant_id, employee_id, punch_type, punch_time, notes, location, device_info } = payload;
-
-      await sendPunch({
-        restaurant_id,
-        employee_id,
-        punch_type,
-        punch_time,
-        notes,
-        location,
-        device_info,
-        photoBlob,
-      });
-      flushed += 1;
-    } catch (error) {
-      console.warn('Failed to flush kiosk punch, will retry later', error);
-      remaining.push(entry);
-      break; // Stop early to avoid hammering while offline
-    }
+  if (flushing) {
+    return { flushed: 0, remaining: loadQueue().length };
   }
+  flushing = true;
+  try {
+    const queue = loadQueue();
+    if (queue.length === 0) return { flushed: 0, remaining: 0 };
 
-  saveQueue(remaining);
-  return { flushed, remaining: remaining.length };
+    let flushed = 0;
+    const remaining: QueuedKioskPunch[] = [];
+
+    for (const entry of queue) {
+      try {
+        const photoBlob =
+          entry.payload.photoDataUrl ? await dataUrlToBlob(entry.payload.photoDataUrl) : undefined;
+
+        const payload = entry.payload;
+        if (!payload.employee_id) {
+          throw new Error('Missing employee_id for queued punch');
+        }
+
+        const { restaurant_id, employee_id, punch_type, punch_time, notes, location, device_info } = payload;
+
+        await sendPunch({
+          restaurant_id,
+          employee_id,
+          punch_type,
+          punch_time,
+          notes,
+          location,
+          device_info,
+          photoBlob,
+        });
+        flushed += 1;
+      } catch (error) {
+        console.warn('Failed to flush kiosk punch, will retry later', error);
+        remaining.push(entry);
+        break;
+      }
+    }
+
+    saveQueue(remaining);
+    return { flushed, remaining: remaining.length };
+  } finally {
+    flushing = false;
+  }
 };
 
 export const hasQueuedPunches = () => loadQueue().length > 0;

--- a/src/utils/offlineQueue.ts
+++ b/src/utils/offlineQueue.ts
@@ -57,10 +57,20 @@ const dataUrlToBlob = async (dataUrl: string): Promise<Blob> => {
   return res.blob();
 };
 
-const randomId = () =>
-  typeof crypto !== 'undefined' && crypto.randomUUID
-    ? crypto.randomUUID()
-    : `kiosk-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+let idCounter = 0;
+const randomId = () => {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+    const bytes = new Uint8Array(8);
+    crypto.getRandomValues(bytes);
+    const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+    return `kiosk-${Date.now()}-${hex}`;
+  }
+  idCounter += 1;
+  return `kiosk-${Date.now()}-${idCounter}`;
+};
 
 export const addQueuedPunch = async (
   payload: QueuedKioskPunch['payload'],
@@ -89,7 +99,7 @@ export const addQueuedPunch = async (
   return entry;
 };
 
-type PunchSender = (input: QueuedKioskPunch['payload'] & { photoBlob?: Blob }) => Promise<any>;
+type PunchSender = (input: QueuedKioskPunch['payload'] & { photoBlob?: Blob }) => Promise<unknown>;
 
 // Module-level guard: when several `onSuccess` handlers fire in quick
 // succession during a shift change, each used to call `flushQueuedPunches`
@@ -110,7 +120,8 @@ export const flushQueuedPunches = async (sendPunch: PunchSender) => {
     let flushed = 0;
     const remaining: QueuedKioskPunch[] = [];
 
-    for (const entry of queue) {
+    for (let i = 0; i < queue.length; i += 1) {
+      const entry = queue[i];
       try {
         const photoBlob =
           entry.payload.photoDataUrl ? await dataUrlToBlob(entry.payload.photoDataUrl) : undefined;
@@ -135,7 +146,9 @@ export const flushQueuedPunches = async (sendPunch: PunchSender) => {
         flushed += 1;
       } catch (error) {
         console.warn('Failed to flush kiosk punch, will retry later', error);
-        remaining.push(entry);
+        // Preserve the failed entry AND every entry we never attempted —
+        // otherwise a network failure on entry 1 of 5 silently drops 2-5.
+        remaining.push(entry, ...queue.slice(i + 1));
         break;
       }
     }

--- a/src/utils/punchContext.ts
+++ b/src/utils/punchContext.ts
@@ -89,7 +89,7 @@ const buildContext = async (timeoutMs: number): Promise<PunchContextResult> => {
  * `getCurrentPosition`.
  */
 export function startPunchContext(timeoutMs = DEFAULT_LOCATION_TIMEOUT): Promise<PunchContextResult> {
-  if (inFlight) return inFlight;
+  if (inFlight !== null) return inFlight;
   inFlight = buildContext(timeoutMs).finally(() => {
     if (inFlightTimeout) clearTimeout(inFlightTimeout);
     inFlightTimeout = setTimeout(() => {
@@ -106,7 +106,7 @@ export function startPunchContext(timeoutMs = DEFAULT_LOCATION_TIMEOUT): Promise
  * of starting a redundant `getCurrentPosition`.
  */
 export async function collectPunchContext(timeoutMs = DEFAULT_LOCATION_TIMEOUT) {
-  if (inFlight) return inFlight;
+  if (inFlight !== null) return inFlight;
   return buildContext(timeoutMs);
 }
 

--- a/src/utils/punchContext.ts
+++ b/src/utils/punchContext.ts
@@ -24,6 +24,11 @@ export function mergePunchLocation(
 
 const DEFAULT_LOCATION_TIMEOUT = 3000;
 const DEFAULT_DEVICE_INFO_MAX = 100;
+// How long a resolved geolocation result stays addressable as the "in-flight"
+// promise. A second employee within this window reuses the same fix; after
+// it, the next punch starts a fresh getCurrentPosition so we don't ship a
+// stale (potentially wrong-restaurant) location for the next shift.
+const PUNCH_CONTEXT_REUSE_MS = 10_000;
 
 export function getDeviceInfo(maxLength = DEFAULT_DEVICE_INFO_MAX): string {
   if (typeof navigator === 'undefined') return 'unknown device';
@@ -58,10 +63,59 @@ export function getQuickLocation(timeoutMs = DEFAULT_LOCATION_TIMEOUT): Promise<
   });
 }
 
-export async function collectPunchContext(timeoutMs = DEFAULT_LOCATION_TIMEOUT) {
+type PunchContextResult = {
+  location: { latitude: number; longitude: number } | undefined;
+  device_info: string;
+};
+
+let inFlight: Promise<PunchContextResult> | null = null;
+let inFlightTimeout: ReturnType<typeof setTimeout> | null = null;
+
+const buildContext = async (timeoutMs: number): Promise<PunchContextResult> => {
   const location = await getQuickLocation(timeoutMs);
   return {
     location,
     device_info: getDeviceInfo(),
   };
+};
+
+/**
+ * Kick off geolocation + device_info collection eagerly, returning a single
+ * shared promise across concurrent callers. Designed to be called the moment
+ * the user opens the camera dialog so the OS has a head start before they
+ * actually tap Confirm.
+ *
+ * The result is reused for ~10s; after that, the next call starts a fresh
+ * `getCurrentPosition`.
+ */
+export function startPunchContext(timeoutMs = DEFAULT_LOCATION_TIMEOUT): Promise<PunchContextResult> {
+  if (inFlight) return inFlight;
+  inFlight = buildContext(timeoutMs).finally(() => {
+    if (inFlightTimeout) clearTimeout(inFlightTimeout);
+    inFlightTimeout = setTimeout(() => {
+      inFlight = null;
+      inFlightTimeout = null;
+    }, PUNCH_CONTEXT_REUSE_MS);
+  });
+  return inFlight;
+}
+
+/**
+ * Collect punch context. If `startPunchContext` was already called (e.g. when
+ * the camera dialog opened), this awaits the same in-flight promise instead
+ * of starting a redundant `getCurrentPosition`.
+ */
+export async function collectPunchContext(timeoutMs = DEFAULT_LOCATION_TIMEOUT) {
+  if (inFlight) return inFlight;
+  return buildContext(timeoutMs);
+}
+
+/**
+ * Test-only escape hatch so isolated tests can re-arm `startPunchContext`.
+ * Production callers must not use this.
+ */
+export function _resetPunchContextForTests() {
+  if (inFlightTimeout) clearTimeout(inFlightTimeout);
+  inFlight = null;
+  inFlightTimeout = null;
 }

--- a/tests/unit/ImageCapture.test.tsx
+++ b/tests/unit/ImageCapture.test.tsx
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import React, { createRef } from 'react';
+import { ImageCapture, type ImageCaptureHandle } from '@/components/ImageCapture';
+
+// useNativeCamera is a hook that reaches into Capacitor — stub it so the web
+// path runs in jsdom.
+vi.mock('@/hooks/useNativeCamera', () => ({
+  useNativeCamera: () => ({ isNative: false, takePhoto: vi.fn() }),
+}));
+
+// jsdom doesn't implement HTMLMediaElement.play(). Stub it so the autoStart
+// effect doesn't blow up.
+beforeEach(() => {
+  Object.defineProperty(HTMLMediaElement.prototype, 'play', {
+    configurable: true,
+    value: vi.fn().mockResolvedValue(undefined),
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/**
+ * Fake MediaStream that records stop() calls so we can assert teardown.
+ * The interesting surface for ImageCapture is just getTracks().forEach(t => t.stop()).
+ */
+function makeFakeStream(stopSpy: () => void): MediaStream {
+  const tracks = [
+    { kind: 'video', stop: stopSpy, addEventListener: vi.fn(), removeEventListener: vi.fn() },
+  ];
+  return {
+    id: 'fake-stream',
+    active: true,
+    getTracks: () => tracks,
+    getVideoTracks: () => tracks,
+    getAudioTracks: () => [],
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  } as unknown as MediaStream;
+}
+
+function mockGetUserMedia(stream: MediaStream) {
+  const spy = vi.fn().mockResolvedValue(stream);
+  Object.defineProperty(navigator, 'mediaDevices', {
+    configurable: true,
+    value: { getUserMedia: spy },
+  });
+  return spy;
+}
+
+describe('ImageCapture imperative handle', () => {
+  it('forwards a ref exposing stopCamera()', async () => {
+    const stopSpy = vi.fn();
+    const stream = makeFakeStream(stopSpy);
+    mockGetUserMedia(stream);
+
+    const ref = createRef<ImageCaptureHandle>();
+    render(
+      <ImageCapture
+        ref={ref}
+        onImageCaptured={() => {}}
+        autoStart
+      />,
+    );
+
+    await waitFor(() => expect(ref.current?.stopCamera).toBeTypeOf('function'));
+  });
+
+  it('stopCamera() halts all MediaStream tracks', async () => {
+    const stopSpy = vi.fn();
+    const stream = makeFakeStream(stopSpy);
+    mockGetUserMedia(stream);
+
+    const ref = createRef<ImageCaptureHandle>();
+    render(
+      <ImageCapture
+        ref={ref}
+        onImageCaptured={() => {}}
+        autoStart
+      />,
+    );
+
+    await waitFor(() => expect(ref.current).not.toBeNull());
+
+    // Simulate the loadedmetadata path so the stream is wired onto the <video>.
+    // (Without this, srcObject hasn't been set yet and stopCamera() is a no-op.)
+    const video = document.querySelector('video');
+    if (video) {
+      (video as HTMLVideoElement & { srcObject: MediaStream | null }).srcObject = stream;
+    }
+
+    ref.current?.stopCamera();
+    expect(stopSpy).toHaveBeenCalled();
+  });
+});
+
+describe('ImageCapture getUserMedia constraints', () => {
+  it('requests low-res constraints when maxWidth <= 480', async () => {
+    const stream = makeFakeStream(vi.fn());
+    const spy = mockGetUserMedia(stream);
+
+    render(
+      <ImageCapture
+        onImageCaptured={() => {}}
+        autoStart
+        maxWidth={480}
+      />,
+    );
+
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+    const call = spy.mock.calls[0]?.[0] as { video: { width?: { ideal?: number } } };
+    expect(call.video.width?.ideal).toBe(640);
+  });
+
+  it('requests high-res constraints when maxWidth is unset', async () => {
+    const stream = makeFakeStream(vi.fn());
+    const spy = mockGetUserMedia(stream);
+
+    render(<ImageCapture onImageCaptured={() => {}} autoStart />);
+
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+    const call = spy.mock.calls[0]?.[0] as { video: { width?: { ideal?: number } } };
+    expect(call.video.width?.ideal).toBe(1920);
+  });
+});
+
+describe('ImageCapture capturePhoto downscaling', () => {
+  it('passes the quality prop through to canvas.toBlob', async () => {
+    const stream = makeFakeStream(vi.fn());
+    mockGetUserMedia(stream);
+
+    const toBlobSpy = vi.fn((cb: BlobCallback, _type: string, quality: number) => {
+      // Resolve synchronously with a tiny fake blob; quality is what we want to assert
+      cb(new Blob([new Uint8Array([0])], { type: 'image/jpeg' }));
+      return quality; // returned so TS is happy; not used
+    });
+    Object.defineProperty(HTMLCanvasElement.prototype, 'toBlob', {
+      configurable: true,
+      value: toBlobSpy,
+    });
+    Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+      configurable: true,
+      value: () => ({ drawImage: vi.fn() }),
+    });
+
+    let captureFn: (() => Promise<Blob | null>) | null = null;
+    render(
+      <ImageCapture
+        onImageCaptured={() => {}}
+        autoStart
+        maxWidth={480}
+        quality={0.6}
+        onCaptureRef={(fn) => { captureFn = fn; }}
+      />,
+    );
+
+    await waitFor(() => expect(captureFn).not.toBeNull());
+
+    // Stub videoWidth/Height so capturePhoto thinks the video is ready.
+    const video = document.querySelector('video') as HTMLVideoElement | null;
+    if (video) {
+      Object.defineProperty(video, 'videoWidth', { configurable: true, value: 1920 });
+      Object.defineProperty(video, 'videoHeight', { configurable: true, value: 1080 });
+    }
+
+    await captureFn!();
+
+    expect(toBlobSpy).toHaveBeenCalled();
+    // toBlob(callback, type, quality) — assert the quality arg
+    expect(toBlobSpy.mock.calls[0][2]).toBe(0.6);
+  });
+
+  it('downscales the canvas to maxWidth before encoding', async () => {
+    const stream = makeFakeStream(vi.fn());
+    mockGetUserMedia(stream);
+
+    const drawImage = vi.fn();
+    Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+      configurable: true,
+      value: () => ({ drawImage }),
+    });
+    Object.defineProperty(HTMLCanvasElement.prototype, 'toBlob', {
+      configurable: true,
+      value: (cb: BlobCallback) => cb(new Blob([new Uint8Array([0])], { type: 'image/jpeg' })),
+    });
+
+    let captureFn: (() => Promise<Blob | null>) | null = null;
+    render(
+      <ImageCapture
+        onImageCaptured={() => {}}
+        autoStart
+        maxWidth={480}
+        onCaptureRef={(fn) => { captureFn = fn; }}
+      />,
+    );
+
+    await waitFor(() => expect(captureFn).not.toBeNull());
+
+    const video = document.querySelector('video') as HTMLVideoElement | null;
+    const canvas = document.querySelector('canvas') as HTMLCanvasElement | null;
+    if (video) {
+      Object.defineProperty(video, 'videoWidth', { configurable: true, value: 1920 });
+      Object.defineProperty(video, 'videoHeight', { configurable: true, value: 1080 });
+    }
+
+    await captureFn!();
+
+    // 480 / 1920 = 0.25 → 1920*0.25 = 480, 1080*0.25 = 270
+    expect(canvas?.width).toBe(480);
+    expect(canvas?.height).toBe(270);
+  });
+});

--- a/tests/unit/KioskMode.test.tsx
+++ b/tests/unit/KioskMode.test.tsx
@@ -392,3 +392,89 @@ describe('KioskMode — re-entry guard', () => {
     expect(capturedOnSuccess).not.toBeNull();
   });
 });
+
+describe('KioskMode — offline queue carries photoBlob argument (not state)', () => {
+  it('passes the photo BLOB threaded through handlePunch to addQueuedPunch', async () => {
+    // We use a real photo blob via captureFnMock and assert addQueuedPunch
+    // receives it — not null, even after resetCameraState has cleared the
+    // capturedPhotoBlob state.
+    const blob = new Blob(['fake-jpeg'], { type: 'image/jpeg' });
+    imageCaptureCaptureFnMock.mockResolvedValue(blob);
+    isLikelyOfflineMock.mockReturnValue(true);
+
+    const addQueuedPunchSpy = vi.fn();
+    const { addQueuedPunch } = await import('@/utils/offlineQueue');
+    (addQueuedPunch as unknown as { mockImplementation?: (fn: typeof addQueuedPunchSpy) => void })
+      .mockImplementation?.(addQueuedPunchSpy);
+    // Fall through: if mockImplementation isn't exposed (the module is fully
+    // mocked above), re-mock via the alias path used in the file under test.
+    // The test still verifies behavior because the assertion below runs only
+    // if the spy was actually wired.
+
+    let capturedOnError: ((err: unknown) => void) | null = null;
+    createPunchMutateMock.mockImplementation((_payload, opts) => {
+      capturedOnError = opts?.onError ?? null;
+    });
+
+    render(<KioskMode />, { wrapper });
+    enterPin('1234');
+    fireEvent.click(screen.getByRole('button', { name: /Clock In/i }));
+    // Confirm path — this calls captureFnRef.current() which returns `blob`.
+    fireEvent.click(await screen.findByRole('button', { name: /Confirm punch/i }));
+
+    await screen.findByRole('status');
+
+    // Server rejects → onError fires → handleOfflineQueue queues with blob.
+    await act(async () => {
+      capturedOnError?.(new Error('Network down'));
+    });
+
+    if (addQueuedPunchSpy.mock.calls.length > 0) {
+      const [, photoBlob] = addQueuedPunchSpy.mock.calls[0];
+      expect(photoBlob).toBe(blob);
+    }
+  });
+});
+
+describe('KioskMode — cache projection after optimistic punch', () => {
+  it('updates the punchStatus cache to reflect the optimistic clock state', async () => {
+    // Without cache projection, an immediate re-punch within 5s would read
+    // the pre-punch status and reject with "already clocked in" / "no open
+    // shift". We assert the cache was updated by verifying rpcMock is NOT
+    // called a second time when the same employee re-punches inside the
+    // freshness window.
+    let capturedOnSuccess: (() => void) | null = null;
+    createPunchMutateMock.mockImplementation((_payload, opts) => {
+      capturedOnSuccess = opts?.onSuccess ?? null;
+    });
+
+    render(<KioskMode />, { wrapper });
+    enterPin('1234');
+    fireEvent.click(screen.getByRole('button', { name: /Clock In/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /Skip photo/i }));
+
+    await screen.findByRole('status');
+    // resolvePunchStatus has run once (RPC fetched, cache seeded).
+    const rpcCallsAfterFirst = rpcMock.mock.calls.length;
+
+    // Persist the mutation so onSuccess settles.
+    await act(async () => {
+      capturedOnSuccess?.();
+    });
+
+    // The cache should now hold is_clocked_in: true. A second punch of the
+    // same employee within PUNCH_STATUS_CACHE_FRESH_MS (5s) should hit the
+    // cache short-circuit instead of re-issuing the RPC.
+    enterPin('1234');
+    fireEvent.click(screen.getByRole('button', { name: /Clock Out/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /Skip photo/i }));
+
+    await waitFor(() => {
+      // Mutate fired again → cache projection worked (no "no open shift" error).
+      expect(createPunchMutateMock).toHaveBeenCalledTimes(2);
+    });
+    // RPC should NOT have run a second time because the projected cache value
+    // (is_clocked_in: true) is fresh.
+    expect(rpcMock.mock.calls.length).toBe(rpcCallsAfterFirst);
+  });
+});

--- a/tests/unit/KioskMode.test.tsx
+++ b/tests/unit/KioskMode.test.tsx
@@ -35,6 +35,7 @@ const {
   hasQueuedPunchesMock,
   isLikelyOfflineMock,
   flushQueuedPunchesMock,
+  addQueuedPunchMock,
   imageCaptureCaptureFnMock,
   imageCaptureStopMock,
 } = vi.hoisted(() => ({
@@ -53,6 +54,7 @@ const {
   hasQueuedPunchesMock: vi.fn(() => false),
   isLikelyOfflineMock: vi.fn(() => false),
   flushQueuedPunchesMock: vi.fn(async () => ({ remaining: 0, flushed: 0 })),
+  addQueuedPunchMock: vi.fn(),
   imageCaptureCaptureFnMock: vi.fn(() => Promise.resolve<Blob | null>(null)),
   imageCaptureStopMock: vi.fn(),
 }));
@@ -144,7 +146,7 @@ vi.mock('@/utils/offlineQueue', () => ({
   hasQueuedPunches: hasQueuedPunchesMock,
   isLikelyOffline: isLikelyOfflineMock,
   flushQueuedPunches: flushQueuedPunchesMock,
-  addQueuedPunch: vi.fn(),
+  addQueuedPunch: addQueuedPunchMock,
 }));
 
 vi.mock('@/components/ImageCapture', () => {
@@ -369,6 +371,52 @@ describe('KioskMode — optimistic flow', () => {
     // Error message takes its place.
     expect(screen.getByText(/relation does not exist/)).toBeDefined();
   });
+
+  it('does NOT roll back a newer employee\'s success when an older punch errors late', async () => {
+    // Regression for the rollback-scope bug: punch A goes in-flight, punch B
+    // completes optimistically (showing employee B in the status chip), then
+    // punch A's mutate errors. Without the op-id guard, A's onError would
+    // restore the snapshot it took at A's start (lastResult = null) and erase
+    // employee B's visible success chip.
+    const onErrorByOpId: Array<(err: unknown) => void> = [];
+    createPunchMutateMock.mockImplementation((_payload, opts) => {
+      if (opts?.onError) onErrorByOpId.push(opts.onError);
+    });
+    isLikelyOfflineMock.mockReturnValue(false);
+
+    render(<KioskMode />, { wrapper });
+
+    // Punch A — employee e1 "Jose".
+    verifyPinForRestaurantMock.mockResolvedValueOnce(okPinMatch);
+    enterPin('1234');
+    fireEvent.click(screen.getByRole('button', { name: /Clock In/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /Skip photo/i }));
+    await screen.findByText(/Jose Delgado/);
+
+    // Punch B — employee e2 "Other".
+    verifyPinForRestaurantMock.mockResolvedValueOnce({
+      ...okPinMatch,
+      id: 'pin-2',
+      employee_id: 'e2',
+      employee: { id: 'e2', name: 'Other Employee', position: 'server' },
+    });
+    enterPin('5678');
+    fireEvent.click(screen.getByRole('button', { name: /Clock In/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /Skip photo/i }));
+    await screen.findByText(/Other Employee/);
+
+    // Now punch A's mutate errors (server was slow). With the bug, A's
+    // rollback would clobber B's "Other Employee" chip with null. With the
+    // fix, opIdRef has moved past A's id and the rollback is skipped.
+    await act(async () => {
+      onErrorByOpId[0]?.(new Error('Stale failure from A'));
+    });
+
+    // Employee B's chip is still visible.
+    expect(screen.queryByText(/Other Employee/)).not.toBeNull();
+    // A's stale error message must NOT have replaced B's success.
+    expect(screen.queryByText(/Stale failure from A/)).toBeNull();
+  });
 });
 
 describe('KioskMode — re-entry guard', () => {
@@ -402,15 +450,6 @@ describe('KioskMode — offline queue carries photoBlob argument (not state)', (
     imageCaptureCaptureFnMock.mockResolvedValue(blob);
     isLikelyOfflineMock.mockReturnValue(true);
 
-    const addQueuedPunchSpy = vi.fn();
-    const { addQueuedPunch } = await import('@/utils/offlineQueue');
-    (addQueuedPunch as unknown as { mockImplementation?: (fn: typeof addQueuedPunchSpy) => void })
-      .mockImplementation?.(addQueuedPunchSpy);
-    // Fall through: if mockImplementation isn't exposed (the module is fully
-    // mocked above), re-mock via the alias path used in the file under test.
-    // The test still verifies behavior because the assertion below runs only
-    // if the spy was actually wired.
-
     let capturedOnError: ((err: unknown) => void) | null = null;
     createPunchMutateMock.mockImplementation((_payload, opts) => {
       capturedOnError = opts?.onError ?? null;
@@ -429,10 +468,12 @@ describe('KioskMode — offline queue carries photoBlob argument (not state)', (
       capturedOnError?.(new Error('Network down'));
     });
 
-    if (addQueuedPunchSpy.mock.calls.length > 0) {
-      const [, photoBlob] = addQueuedPunchSpy.mock.calls[0];
-      expect(photoBlob).toBe(blob);
-    }
+    // Unconditional: the photo blob threaded through handlePunch MUST reach
+    // addQueuedPunch as its second arg, otherwise the offline queue silently
+    // drops the photo for a punch the user thought captured one.
+    expect(addQueuedPunchMock).toHaveBeenCalledTimes(1);
+    const [, photoBlobArg] = addQueuedPunchMock.mock.calls[0];
+    expect(photoBlobArg).toBe(blob);
   });
 });
 

--- a/tests/unit/KioskMode.test.tsx
+++ b/tests/unit/KioskMode.test.tsx
@@ -1,0 +1,394 @@
+/**
+ * Focused integration tests for KioskMode.tsx covering the two reported bugs
+ * AND the optimistic flow rewrite:
+ *
+ *   1. "Skip photo doesn't close the camera" — the dialog now closes
+ *      synchronously when Skip/Confirm is tapped, before any async work runs.
+ *   2. "Punches take seconds" — handlePunch now flips to optimistic UI BEFORE
+ *      awaiting the INSERT. The mutate runs in the background, and the kiosk
+ *      is unlocked for the next employee immediately after we have a PIN
+ *      match + status + context.
+ *
+ * We don't try to test the entire KioskMode page — that would require mocking
+ * dozens of contexts. Instead we mock the boundary collaborators and assert on
+ * the observable orchestration the user actually sees.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+
+const {
+  verifyPinForRestaurantMock,
+  upsertPinMock,
+  createPunchMutateMock,
+  rpcMock,
+  fromUpdateMock,
+  collectPunchContextMock,
+  startPunchContextMock,
+  resetPunchContextMock,
+  toastMock,
+  navigateMock,
+  endSessionMock,
+  submitTipMock,
+  hasQueuedPunchesMock,
+  isLikelyOfflineMock,
+  flushQueuedPunchesMock,
+  imageCaptureCaptureFnMock,
+  imageCaptureStopMock,
+} = vi.hoisted(() => ({
+  verifyPinForRestaurantMock: vi.fn(),
+  upsertPinMock: vi.fn(),
+  createPunchMutateMock: vi.fn(),
+  rpcMock: vi.fn(),
+  fromUpdateMock: vi.fn(),
+  collectPunchContextMock: vi.fn(),
+  startPunchContextMock: vi.fn(),
+  resetPunchContextMock: vi.fn(),
+  toastMock: vi.fn(),
+  navigateMock: vi.fn(),
+  endSessionMock: vi.fn(),
+  submitTipMock: vi.fn(),
+  hasQueuedPunchesMock: vi.fn(() => false),
+  isLikelyOfflineMock: vi.fn(() => false),
+  flushQueuedPunchesMock: vi.fn(async () => ({ remaining: 0, flushed: 0 })),
+  imageCaptureCaptureFnMock: vi.fn(() => Promise.resolve<Blob | null>(null)),
+  imageCaptureStopMock: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    auth: {
+      getSession: vi.fn(async () => ({ data: { session: { user: { id: 'kiosk-user' } } } })),
+      getUser: vi.fn(async () => ({ data: { user: { id: 'kiosk-user' } } })),
+    },
+    rpc: rpcMock,
+    from: () => ({
+      update: (...args: unknown[]) => {
+        fromUpdateMock(...args);
+        // Mimic the chained-eq() shape used by KioskMode.
+        return { eq: () => Promise.resolve({ data: null, error: null }) };
+      },
+      insert: () => ({ select: () => ({ single: vi.fn() }) }),
+    }),
+    storage: { from: () => ({ upload: vi.fn() }) },
+  },
+}));
+
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => ({
+    selectedRestaurant: {
+      restaurant_id: 'r1',
+      restaurant: { name: 'Test Restaurant' },
+      role: 'kiosk',
+    },
+  }),
+}));
+
+vi.mock('@/hooks/useKioskSession', () => ({
+  useKioskSession: () => ({
+    session: { location_id: 'r1', min_length: 4 },
+    endSession: endSessionMock,
+  }),
+}));
+
+vi.mock('@/hooks/useKioskPins', () => ({
+  verifyPinForRestaurant: verifyPinForRestaurantMock,
+  useUpsertEmployeePin: () => ({
+    mutateAsync: upsertPinMock,
+  }),
+}));
+
+vi.mock('@/hooks/useTimePunches', () => ({
+  useCreateTimePunch: () => ({
+    mutate: createPunchMutateMock,
+    mutateAsync: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({
+    user: { email: 'kiosk@test.com', id: 'kiosk-user' },
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+vi.mock('@/hooks/useEmployeeTips', () => ({
+  useEmployeeTips: () => ({
+    submitTip: submitTipMock,
+    isSubmitting: false,
+  }),
+}));
+
+vi.mock('@/utils/punchContext', () => ({
+  collectPunchContext: collectPunchContextMock,
+  startPunchContext: startPunchContextMock,
+  _resetPunchContextForTests: resetPunchContextMock,
+}));
+
+vi.mock('@/utils/offlineQueue', () => ({
+  hasQueuedPunches: hasQueuedPunchesMock,
+  isLikelyOffline: isLikelyOfflineMock,
+  flushQueuedPunches: flushQueuedPunchesMock,
+  addQueuedPunch: vi.fn(),
+}));
+
+vi.mock('@/components/ImageCapture', () => {
+  const ImageCapture = React.forwardRef<
+    { stopCamera: () => void },
+    {
+      onCaptureRef?: (fn: () => Promise<Blob | null>) => void;
+      onImageCaptured?: (blob: Blob) => void;
+      disabled?: boolean;
+    }
+  >((props, ref) => {
+    React.useImperativeHandle(ref, () => ({
+      stopCamera: imageCaptureStopMock,
+    }));
+    React.useEffect(() => {
+      props.onCaptureRef?.(imageCaptureCaptureFnMock);
+    }, [props]);
+    return <div data-testid="image-capture-mock" />;
+  });
+  ImageCapture.displayName = 'ImageCaptureMock';
+  return { ImageCapture };
+});
+
+vi.mock('@/components/kiosk/PinChangeDialog', () => ({
+  PinChangeDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="pin-change-dialog" /> : null,
+}));
+
+vi.mock('@/components/tips/TipSubmissionDialog', () => ({
+  TipSubmissionDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="tip-dialog" /> : null,
+}));
+
+// Import the page LAST so all the mocks above are in place.
+import KioskMode from '@/pages/KioskMode';
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return (
+    <MemoryRouter>
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    </MemoryRouter>
+  );
+};
+
+const enterPin = (pin: string) => {
+  for (const digit of pin) {
+    fireEvent.click(screen.getByRole('button', { name: `Digit ${digit}` }));
+  }
+};
+
+const okPinMatch = {
+  id: 'pin-1',
+  employee_id: 'e1',
+  restaurant_id: 'r1',
+  force_reset: false,
+  employee: { id: 'e1', name: 'Jose Delgado', position: 'cook' },
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  hasQueuedPunchesMock.mockReturnValue(false);
+  isLikelyOfflineMock.mockReturnValue(false);
+  rpcMock.mockResolvedValue({ data: [{ is_clocked_in: false }], error: null });
+  collectPunchContextMock.mockResolvedValue({
+    location: undefined,
+    device_info: 'test-agent',
+  });
+  startPunchContextMock.mockResolvedValue({
+    location: undefined,
+    device_info: 'test-agent',
+  });
+  verifyPinForRestaurantMock.mockResolvedValue(okPinMatch);
+  imageCaptureCaptureFnMock.mockResolvedValue(null);
+});
+
+describe('KioskMode — skip-photo bug fix', () => {
+  it('closes the camera dialog synchronously when Skip is tapped', async () => {
+    render(<KioskMode />, { wrapper });
+    enterPin('1234');
+    fireEvent.click(screen.getByRole('button', { name: /Clock In/i }));
+
+    // Camera dialog should now be open.
+    expect(await screen.findByTestId('image-capture-mock')).toBeDefined();
+
+    // Tap Skip photo. The dialog must close immediately — before
+    // verifyPinForRestaurant or any RPC has a chance to resolve.
+    fireEvent.click(screen.getByRole('button', { name: /Skip photo/i }));
+
+    // The mock for ImageCapture should be removed from the DOM right away.
+    await waitFor(() => {
+      expect(screen.queryByTestId('image-capture-mock')).toBeNull();
+    });
+
+    // stopCamera was called via the imperative ref BEFORE the dialog unmount.
+    expect(imageCaptureStopMock).toHaveBeenCalled();
+  });
+
+  it('starts geolocation as soon as the camera dialog opens (parallel with capture)', async () => {
+    render(<KioskMode />, { wrapper });
+    enterPin('1234');
+    fireEvent.click(screen.getByRole('button', { name: /Clock In/i }));
+
+    await waitFor(() => {
+      expect(startPunchContextMock).toHaveBeenCalled();
+    });
+  });
+});
+
+describe('KioskMode — optimistic flow', () => {
+  it('shows the success Alert with role=status BEFORE the mutate resolves', async () => {
+    // Capture the mutate call but don't immediately fire onSuccess — that
+    // simulates the network round-trip. The optimistic UI must already be
+    // visible before we resolve.
+    let capturedOnSuccess: (() => void) | null = null;
+    createPunchMutateMock.mockImplementation((_payload, opts) => {
+      capturedOnSuccess = opts?.onSuccess ?? null;
+    });
+
+    render(<KioskMode />, { wrapper });
+    enterPin('1234');
+    fireEvent.click(screen.getByRole('button', { name: /Clock In/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /Skip photo/i }));
+
+    // Optimistic Alert appears even though the mutate hasn't resolved.
+    const alert = await screen.findByRole('status');
+    expect(alert.getAttribute('aria-live')).toBe('polite');
+    expect(alert.textContent).toContain('Jose Delgado');
+    expect(alert.textContent).toContain('Clocked in');
+    expect(createPunchMutateMock).toHaveBeenCalledTimes(1);
+
+    // The PIN-change dialog and tip dialog MUST remain closed until the
+    // mutate succeeds — these flows are security/UX sensitive and shouldn't
+    // fire on an optimistic punch that the server might later reject.
+    expect(screen.queryByTestId('pin-change-dialog')).toBeNull();
+    expect(screen.queryByTestId('tip-dialog')).toBeNull();
+
+    // Now simulate the server confirming the insert.
+    await act(async () => {
+      capturedOnSuccess?.();
+    });
+
+    // PIN reset wasn't forced, so no PIN dialog. But because action='clock_in',
+    // there's no tip dialog either. Both should still be closed.
+    expect(screen.queryByTestId('pin-change-dialog')).toBeNull();
+    expect(screen.queryByTestId('tip-dialog')).toBeNull();
+  });
+
+  it('opens the PIN-change dialog ONLY after the mutate succeeds when force_reset=true', async () => {
+    verifyPinForRestaurantMock.mockResolvedValue({
+      ...okPinMatch,
+      force_reset: true,
+    });
+
+    let capturedOnSuccess: (() => void) | null = null;
+    createPunchMutateMock.mockImplementation((_payload, opts) => {
+      capturedOnSuccess = opts?.onSuccess ?? null;
+    });
+
+    render(<KioskMode />, { wrapper });
+    enterPin('1234');
+    fireEvent.click(screen.getByRole('button', { name: /Clock In/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /Skip photo/i }));
+
+    // Wait for optimistic UI; PIN dialog should NOT be open yet.
+    await screen.findByRole('status');
+    expect(screen.queryByTestId('pin-change-dialog')).toBeNull();
+
+    // Fire onSuccess — now the dialog should open.
+    await act(async () => {
+      capturedOnSuccess?.();
+    });
+    expect(screen.queryByTestId('pin-change-dialog')).not.toBeNull();
+  });
+
+  it('opens the tip dialog ONLY after a clock_out mutate succeeds', async () => {
+    rpcMock.mockResolvedValue({ data: [{ is_clocked_in: true }], error: null });
+
+    let capturedOnSuccess: (() => void) | null = null;
+    createPunchMutateMock.mockImplementation((_payload, opts) => {
+      capturedOnSuccess = opts?.onSuccess ?? null;
+    });
+
+    render(<KioskMode />, { wrapper });
+    enterPin('1234');
+    fireEvent.click(screen.getByRole('button', { name: /Clock Out/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /Skip photo/i }));
+
+    await screen.findByRole('status');
+    expect(screen.queryByTestId('tip-dialog')).toBeNull();
+
+    await act(async () => {
+      capturedOnSuccess?.();
+    });
+    expect(screen.queryByTestId('tip-dialog')).not.toBeNull();
+  });
+
+  it('rolls back the optimistic Alert when the mutate fails and is not offline', async () => {
+    let capturedOnError: ((err: unknown) => void) | null = null;
+    createPunchMutateMock.mockImplementation((_payload, opts) => {
+      capturedOnError = opts?.onError ?? null;
+    });
+    isLikelyOfflineMock.mockReturnValue(false);
+
+    render(<KioskMode />, { wrapper });
+    enterPin('1234');
+    fireEvent.click(screen.getByRole('button', { name: /Clock In/i }));
+    fireEvent.click(await screen.findByRole('button', { name: /Skip photo/i }));
+
+    // Optimistic Alert visible.
+    expect(await screen.findByRole('status')).toBeDefined();
+
+    // Server rejects.
+    await act(async () => {
+      capturedOnError?.(new Error('relation does not exist'));
+    });
+
+    // Optimistic Alert is gone.
+    expect(screen.queryByRole('status')).toBeNull();
+    // Error message takes its place.
+    expect(screen.getByText(/relation does not exist/)).toBeDefined();
+  });
+});
+
+describe('KioskMode — re-entry guard', () => {
+  it('only fires ONE mutate even when Skip is tapped multiple times in the same tick', async () => {
+    let capturedOnSuccess: (() => void) | null = null;
+    createPunchMutateMock.mockImplementation((_payload, opts) => {
+      capturedOnSuccess = opts?.onSuccess ?? null;
+    });
+
+    render(<KioskMode />, { wrapper });
+    enterPin('1234');
+    fireEvent.click(screen.getByRole('button', { name: /Clock In/i }));
+    const skipBtn = await screen.findByRole('button', { name: /Skip photo/i });
+
+    // Rapid double-tap.
+    fireEvent.click(skipBtn);
+    fireEvent.click(skipBtn);
+
+    await screen.findByRole('status');
+    expect(createPunchMutateMock).toHaveBeenCalledTimes(1);
+    expect(capturedOnSuccess).not.toBeNull();
+  });
+});

--- a/tests/unit/offlineQueue.test.ts
+++ b/tests/unit/offlineQueue.test.ts
@@ -171,4 +171,66 @@ describe('offlineQueue — flushing mutex', () => {
     expect(isLikelyOffline()).toBe(false);
     Object.defineProperty(navigator, 'onLine', { configurable: true, value: original });
   });
+
+  it('randomId falls back to crypto.getRandomValues when randomUUID is unavailable', async () => {
+    // Spy crypto so randomUUID is missing but getRandomValues remains.
+    const realRandomUUID = (globalThis.crypto as Crypto).randomUUID;
+    Object.defineProperty(globalThis.crypto, 'randomUUID', {
+      configurable: true,
+      value: undefined,
+    });
+    try {
+      const e1 = await addQueuedPunch({
+        restaurant_id: 'r1',
+        employee_id: 'e1',
+        punch_type: 'clock_in',
+        punch_time: new Date().toISOString(),
+      });
+      const e2 = await addQueuedPunch({
+        restaurant_id: 'r1',
+        employee_id: 'e2',
+        punch_type: 'clock_in',
+        punch_time: new Date().toISOString(),
+      });
+      // Both ids took the getRandomValues path → hex suffix.
+      expect(e1.id).toMatch(/^kiosk-\d+-[0-9a-f]{16}$/);
+      expect(e2.id).toMatch(/^kiosk-\d+-[0-9a-f]{16}$/);
+      expect(e1.id).not.toBe(e2.id);
+    } finally {
+      Object.defineProperty(globalThis.crypto, 'randomUUID', {
+        configurable: true,
+        value: realRandomUUID,
+      });
+    }
+  });
+
+  it('randomId falls back to a monotonic counter when crypto is entirely unavailable', async () => {
+    const realDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'crypto');
+    Object.defineProperty(globalThis, 'crypto', {
+      configurable: true,
+      value: undefined,
+    });
+    try {
+      const e1 = await addQueuedPunch({
+        restaurant_id: 'r1',
+        employee_id: 'e1',
+        punch_type: 'clock_in',
+        punch_time: new Date().toISOString(),
+      });
+      const e2 = await addQueuedPunch({
+        restaurant_id: 'r1',
+        employee_id: 'e2',
+        punch_type: 'clock_in',
+        punch_time: new Date().toISOString(),
+      });
+      // Counter fallback uses a plain integer suffix, not 16-char hex.
+      expect(e1.id).toMatch(/^kiosk-\d+-\d+$/);
+      expect(e2.id).toMatch(/^kiosk-\d+-\d+$/);
+      expect(e1.id).not.toBe(e2.id);
+    } finally {
+      if (realDescriptor) {
+        Object.defineProperty(globalThis, 'crypto', realDescriptor);
+      }
+    }
+  });
 });

--- a/tests/unit/offlineQueue.test.ts
+++ b/tests/unit/offlineQueue.test.ts
@@ -119,6 +119,45 @@ describe('offlineQueue — flushing mutex', () => {
     expect(arg.photoBlob).toBeInstanceOf(Blob);
   });
 
+  it('preserves all not-yet-attempted entries when one send fails mid-flush', async () => {
+    // Seed three queued entries; sendPunch succeeds for #1, throws on #2.
+    // Before the fix, #3 would be silently dropped because the loop pushed
+    // only the failed entry then broke.
+    await addQueuedPunch({
+      restaurant_id: 'r1',
+      employee_id: 'e1',
+      punch_type: 'clock_in',
+      punch_time: new Date().toISOString(),
+    });
+    await addQueuedPunch({
+      restaurant_id: 'r1',
+      employee_id: 'e2',
+      punch_type: 'clock_in',
+      punch_time: new Date().toISOString(),
+    });
+    await addQueuedPunch({
+      restaurant_id: 'r1',
+      employee_id: 'e3',
+      punch_type: 'clock_in',
+      punch_time: new Date().toISOString(),
+    });
+
+    let calls = 0;
+    const sendPunch = vi.fn(async () => {
+      calls += 1;
+      if (calls === 2) throw new Error('Network down on #2');
+      return null;
+    });
+
+    const result = await flushQueuedPunches(sendPunch);
+
+    expect(result.flushed).toBe(1);
+    // The remaining queue must contain BOTH the failed entry and the never-
+    // attempted entry, not just the failed one. The fix changed
+    // `remaining.push(entry); break` to also append `queue.slice(i + 1)`.
+    expect(result.remaining).toBe(2);
+  });
+
   it('isLikelyOffline reflects navigator.onLine', () => {
     const original = navigator.onLine;
     Object.defineProperty(navigator, 'onLine', { configurable: true, value: false });

--- a/tests/unit/offlineQueue.test.ts
+++ b/tests/unit/offlineQueue.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests for offlineQueue.flushQueuedPunches mutex behavior — multiple
+ * concurrent flushes triggered from concurrent kiosk punches must not
+ * double-send the same queued entries.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: () => ({
+      select: () => ({ limit: () => Promise.resolve({ error: null }) }),
+    }),
+  },
+}));
+
+vi.mock('@/hooks/useKioskPins', () => ({
+  verifyPinForRestaurant: vi.fn(),
+}));
+
+import {
+  addQueuedPunch,
+  flushQueuedPunches,
+  hasQueuedPunches,
+  isLikelyOffline,
+} from '@/utils/offlineQueue';
+
+const wipeQueue = () => {
+  try {
+    localStorage.removeItem('kiosk_punch_queue');
+  } catch {
+    // ignore
+  }
+};
+
+beforeEach(() => {
+  wipeQueue();
+});
+
+afterEach(() => {
+  wipeQueue();
+});
+
+describe('offlineQueue — flushing mutex', () => {
+  it('serializes concurrent flushQueuedPunches calls — second call is a no-op while first is in flight', async () => {
+    // Seed three queued entries.
+    await addQueuedPunch({
+      restaurant_id: 'r1',
+      employee_id: 'e1',
+      punch_type: 'clock_in',
+      punch_time: new Date().toISOString(),
+    });
+    await addQueuedPunch({
+      restaurant_id: 'r1',
+      employee_id: 'e2',
+      punch_type: 'clock_in',
+      punch_time: new Date().toISOString(),
+    });
+    await addQueuedPunch({
+      restaurant_id: 'r1',
+      employee_id: 'e3',
+      punch_type: 'clock_in',
+      punch_time: new Date().toISOString(),
+    });
+
+    // sendPunch resolves after a deterministic deferred so we can race two
+    // flush calls against each other.
+    let resolveSend: ((value: unknown) => void) | null = null;
+    const sendPunch = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          // Capture the first resolver; subsequent sends resolve immediately.
+          if (!resolveSend) {
+            resolveSend = resolve;
+          } else {
+            resolve(null);
+          }
+        }),
+    );
+
+    // Kick off two concurrent flushes.
+    const a = flushQueuedPunches(sendPunch);
+    const b = flushQueuedPunches(sendPunch);
+
+    // b should resolve first with flushed=0 because the mutex blocked it.
+    const bResult = await b;
+    expect(bResult.flushed).toBe(0);
+    expect(bResult.remaining).toBeGreaterThan(0);
+
+    // Now unblock a — the first send resolves and the loop continues.
+    resolveSend!(null);
+    const aResult = await a;
+    expect(aResult.flushed).toBe(3);
+    expect(aResult.remaining).toBe(0);
+
+    // sendPunch was only called by `a` — `b` did not double-send.
+    expect(sendPunch).toHaveBeenCalledTimes(3);
+  });
+
+  it('addQueuedPunch persists the photoDataUrl so flush can rehydrate it', async () => {
+    const blob = new Blob(['x'], { type: 'image/jpeg' });
+    await addQueuedPunch(
+      {
+        restaurant_id: 'r1',
+        employee_id: 'e1',
+        punch_type: 'clock_in',
+        punch_time: new Date().toISOString(),
+      },
+      blob,
+    );
+
+    expect(hasQueuedPunches()).toBe(true);
+
+    const sendPunch = vi.fn(() => Promise.resolve(null));
+    const result = await flushQueuedPunches(sendPunch);
+    expect(result.flushed).toBe(1);
+    expect(sendPunch).toHaveBeenCalledTimes(1);
+    const arg = sendPunch.mock.calls[0][0] as { photoBlob?: Blob };
+    // photoBlob is rehydrated from the data URL on flush.
+    expect(arg.photoBlob).toBeInstanceOf(Blob);
+  });
+
+  it('isLikelyOffline reflects navigator.onLine', () => {
+    const original = navigator.onLine;
+    Object.defineProperty(navigator, 'onLine', { configurable: true, value: false });
+    expect(isLikelyOffline()).toBe(true);
+    Object.defineProperty(navigator, 'onLine', { configurable: true, value: true });
+    expect(isLikelyOffline()).toBe(false);
+    Object.defineProperty(navigator, 'onLine', { configurable: true, value: original });
+  });
+});

--- a/tests/unit/offlineQueue.test.ts
+++ b/tests/unit/offlineQueue.test.ts
@@ -115,8 +115,13 @@ describe('offlineQueue — flushing mutex', () => {
     expect(result.flushed).toBe(1);
     expect(sendPunch).toHaveBeenCalledTimes(1);
     const arg = sendPunch.mock.calls[0][0] as { photoBlob?: Blob };
-    // photoBlob is rehydrated from the data URL on flush.
-    expect(arg.photoBlob).toBeInstanceOf(Blob);
+    // photoBlob is rehydrated from the data URL on flush. Duck-typed because
+    // `dataUrlToBlob` goes through fetch().blob() whose Blob constructor isn't
+    // reference-identical to the global `Blob` under CI's undici-backed jsdom.
+    expect(arg.photoBlob).toBeDefined();
+    expect(arg.photoBlob?.type).toBe('image/jpeg');
+    expect(typeof arg.photoBlob?.size).toBe('number');
+    expect(arg.photoBlob?.size).toBeGreaterThan(0);
   });
 
   it('preserves all not-yet-attempted entries when one send fails mid-flush', async () => {

--- a/tests/unit/punchContext.test.ts
+++ b/tests/unit/punchContext.test.ts
@@ -1,5 +1,11 @@
-import { describe, it, expect, vi } from 'vitest';
-import { mergePunchLocation, getDeviceInfo, collectPunchContext } from '@/utils/punchContext';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  mergePunchLocation,
+  getDeviceInfo,
+  collectPunchContext,
+  startPunchContext,
+  _resetPunchContextForTests,
+} from '@/utils/punchContext';
 
 describe('mergePunchLocation', () => {
   it('returns undefined when base location is undefined', () => {
@@ -113,5 +119,75 @@ describe('collectPunchContext', () => {
   it('device_info is a string', async () => {
     const ctx = await collectPunchContext(50);
     expect(typeof ctx.device_info).toBe('string');
+  });
+});
+
+describe('startPunchContext', () => {
+  beforeEach(() => {
+    _resetPunchContextForTests();
+  });
+
+  afterEach(() => {
+    _resetPunchContextForTests();
+    vi.restoreAllMocks();
+  });
+
+  it('starts geolocation immediately and returns a shared promise across calls', () => {
+    const getCurrentPosition = vi.fn((_success: PositionCallback, _error?: PositionErrorCallback) => {
+      // Never resolve — we only want to know it was scheduled.
+    });
+    Object.defineProperty(navigator, 'geolocation', {
+      configurable: true,
+      value: { getCurrentPosition },
+    });
+
+    const p1 = startPunchContext(3000);
+    const p2 = startPunchContext(3000);
+
+    expect(getCurrentPosition).toHaveBeenCalledTimes(1);
+    expect(p1).toBe(p2);
+  });
+
+  it('collectPunchContext reuses the in-flight start (no duplicate geolocation request)', async () => {
+    const getCurrentPosition = vi.fn((success: PositionCallback) => {
+      // Resolve synchronously with a fake fix.
+      success({
+        coords: {
+          latitude: 1,
+          longitude: 2,
+          accuracy: 5,
+          altitude: null,
+          altitudeAccuracy: null,
+          heading: null,
+          speed: null,
+        },
+        timestamp: Date.now(),
+      } as GeolocationPosition);
+    });
+    Object.defineProperty(navigator, 'geolocation', {
+      configurable: true,
+      value: { getCurrentPosition },
+    });
+
+    void startPunchContext(3000);
+    const ctx = await collectPunchContext(3000);
+
+    expect(getCurrentPosition).toHaveBeenCalledTimes(1);
+    expect(ctx.location).toEqual({ latitude: 1, longitude: 2 });
+  });
+
+  it('returns a fresh promise after _resetPunchContextForTests', () => {
+    const getCurrentPosition = vi.fn();
+    Object.defineProperty(navigator, 'geolocation', {
+      configurable: true,
+      value: { getCurrentPosition },
+    });
+
+    const p1 = startPunchContext(3000);
+    _resetPunchContextForTests();
+    const p2 = startPunchContext(3000);
+
+    expect(getCurrentPosition).toHaveBeenCalledTimes(2);
+    expect(p1).not.toBe(p2);
   });
 });

--- a/tests/unit/punchContext.test.ts
+++ b/tests/unit/punchContext.test.ts
@@ -190,4 +190,45 @@ describe('startPunchContext', () => {
     expect(getCurrentPosition).toHaveBeenCalledTimes(2);
     expect(p1).not.toBe(p2);
   });
+
+  it('clears the cached promise ~10s after the original fix resolves so the next shift gets a fresh position', async () => {
+    vi.useFakeTimers();
+    try {
+      const getCurrentPosition = vi.fn((success: PositionCallback) => {
+        success({
+          coords: {
+            latitude: 10,
+            longitude: 20,
+            accuracy: 5,
+            altitude: null,
+            altitudeAccuracy: null,
+            heading: null,
+            speed: null,
+          },
+          timestamp: Date.now(),
+        } as GeolocationPosition);
+      });
+      Object.defineProperty(navigator, 'geolocation', {
+        configurable: true,
+        value: { getCurrentPosition },
+      });
+
+      const first = startPunchContext(3000);
+      await vi.runOnlyPendingTimersAsync();
+      await first;
+
+      // The reset timer is armed in `.finally()`; advance past the reuse
+      // window so the inFlight cache is cleared.
+      await vi.advanceTimersByTimeAsync(11_000);
+
+      // Next call must start a fresh getCurrentPosition.
+      const second = startPunchContext(3000);
+      await vi.runOnlyPendingTimersAsync();
+      await second;
+
+      expect(getCurrentPosition).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/tests/unit/useTimePunches.test.tsx
+++ b/tests/unit/useTimePunches.test.tsx
@@ -4,9 +4,17 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 import { useCreateTimePunch } from '@/hooks/useTimePunches';
 
-const { getUserMock, getSessionMock, insertSingleMock, toastMock, uploadMock } = vi.hoisted(() => ({
+const {
+  getUserMock,
+  getSessionMock,
+  insertMock,
+  insertSingleMock,
+  toastMock,
+  uploadMock,
+} = vi.hoisted(() => ({
   getUserMock: vi.fn(),
   getSessionMock: vi.fn(),
+  insertMock: vi.fn(),
   insertSingleMock: vi.fn(),
   toastMock: vi.fn(),
   uploadMock: vi.fn(),
@@ -19,11 +27,14 @@ vi.mock('@/integrations/supabase/client', () => ({
       getSession: getSessionMock,
     },
     from: () => ({
-      insert: () => ({
-        select: () => ({
-          single: insertSingleMock,
-        }),
-      }),
+      insert: (...args: unknown[]) => {
+        insertMock(...args);
+        return {
+          select: () => ({
+            single: insertSingleMock,
+          }),
+        };
+      },
     }),
     storage: {
       from: () => ({
@@ -83,11 +94,13 @@ describe('useCreateTimePunch — auth source', () => {
     await result.current.mutateAsync(validPayload());
 
     // The hook composes the insert as { ...punchData, photo_path, created_by: user?.id }.
-    // The single mock has been called once; we can't easily inspect the row from this
-    // shape of mock, but a missing session would have made user.id undefined and the
-    // success path still works — so we additionally assert that the INSERT did fire
-    // (covering the wired return path).
-    expect(insertSingleMock).toHaveBeenCalled();
+    // Assert the actual row passed to insert() carries created_by = the session user
+    // id — the previous version only checked that INSERT fired, which would pass even
+    // if created_by were undefined.
+    expect(insertMock).toHaveBeenCalledTimes(1);
+    expect(insertMock).toHaveBeenCalledWith(
+      expect.objectContaining({ created_by: 'u1' }),
+    );
   });
 });
 

--- a/tests/unit/useTimePunches.test.tsx
+++ b/tests/unit/useTimePunches.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { useCreateTimePunch } from '@/hooks/useTimePunches';
+
+const { getUserMock, getSessionMock, insertSingleMock, toastMock, uploadMock } = vi.hoisted(() => ({
+  getUserMock: vi.fn(),
+  getSessionMock: vi.fn(),
+  insertSingleMock: vi.fn(),
+  toastMock: vi.fn(),
+  uploadMock: vi.fn(),
+}));
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    auth: {
+      getUser: getUserMock,
+      getSession: getSessionMock,
+    },
+    from: () => ({
+      insert: () => ({
+        select: () => ({
+          single: insertSingleMock,
+        }),
+      }),
+    }),
+    storage: {
+      from: () => ({
+        upload: uploadMock,
+      }),
+    },
+  },
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+};
+
+const okInsertResponse = (overrides: Record<string, unknown> = {}) => ({
+  data: {
+    id: 'p1',
+    restaurant_id: 'r1',
+    employee_id: 'e1',
+    punch_type: 'clock_in',
+    punch_time: '2026-05-17T12:00:00Z',
+    created_by: 'u1',
+    ...overrides,
+  },
+  error: null,
+});
+
+const validPayload = () => ({
+  restaurant_id: 'r1',
+  employee_id: 'e1',
+  punch_type: 'clock_in' as const,
+  punch_time: '2026-05-17T12:00:00Z',
+});
+
+describe('useCreateTimePunch — auth source', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSessionMock.mockResolvedValue({ data: { session: { user: { id: 'u1' } } } });
+    getUserMock.mockResolvedValue({ data: { user: { id: 'u1' } } });
+    insertSingleMock.mockResolvedValue(okInsertResponse());
+  });
+
+  it('uses supabase.auth.getSession() (no auth.getUser network call) in the hot path', async () => {
+    const { result } = renderHook(() => useCreateTimePunch(), { wrapper });
+    await result.current.mutateAsync(validPayload());
+
+    expect(getSessionMock).toHaveBeenCalled();
+    expect(getUserMock).not.toHaveBeenCalled();
+  });
+
+  it('still passes created_by=user.id through to the INSERT', async () => {
+    const { result } = renderHook(() => useCreateTimePunch(), { wrapper });
+    await result.current.mutateAsync(validPayload());
+
+    // The hook composes the insert as { ...punchData, photo_path, created_by: user?.id }.
+    // The single mock has been called once; we can't easily inspect the row from this
+    // shape of mock, but a missing session would have made user.id undefined and the
+    // success path still works — so we additionally assert that the INSERT did fire
+    // (covering the wired return path).
+    expect(insertSingleMock).toHaveBeenCalled();
+  });
+});
+
+describe('useCreateTimePunch — silent toast', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSessionMock.mockResolvedValue({ data: { session: { user: { id: 'u1' } } } });
+    insertSingleMock.mockResolvedValue(okInsertResponse());
+  });
+
+  it('fires the success toast by default', async () => {
+    const { result } = renderHook(() => useCreateTimePunch(), { wrapper });
+    await result.current.mutateAsync(validPayload());
+    await waitFor(() => expect(toastMock).toHaveBeenCalled());
+    expect(toastMock.mock.calls[0]?.[0]?.title).toBe('Punch recorded');
+  });
+
+  it('suppresses the global success toast when silent: true', async () => {
+    const { result } = renderHook(() => useCreateTimePunch(), { wrapper });
+    await result.current.mutateAsync({ ...validPayload(), silent: true });
+    // Allow onSuccess to flush
+    await new Promise((r) => setTimeout(r, 0));
+    expect(toastMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Diagnosed and fixed two kiosk bugs (slow punches, broken Skip-photo) so a busy restaurant can clock in/out dozens of employees rapidly:

- **Optimistic mutate** — kiosk shows success and unlocks the next employee the moment the PIN + status snapshot is ready; the INSERT runs in the background.
- **Skip-photo really skips** — camera dialog now closes synchronously before the punch RPC chain runs.
- **Eager geolocation** — `startPunchContext` kicks off when the camera dialog opens, so the GPS prompt and acquisition overlap with camera initialisation instead of stacking after capture.
- **Lighter selfie** — 480-wide JPEG @ q=0.6 (~50 KB) matches EmployeeClock and removes a CORS-preflighted upload from the critical path.
- **Faster auth** — `supabase.auth.getSession()` (local cache, 0ms) replaces `getUser()` (50-150ms network) inside `useCreateTimePunch`, `useEmployeeTips.submitTip`, and the rest of `useTimePunches`.
- **Concurrency-safe flush** — module-level mutex in `offlineQueue.flushQueuedPunches` so N concurrent kiosk `onSuccess` handlers don't double-send queued entries.
- **Hardened against rapid double-tap** — `processingRef` guard survives the React commit boundary; camera dialog dismissal is blocked while a mutate is in-flight.

## Multi-reviewer findings (all addressed)

Phase 7a ran four parallel reviewers (sound-logic, security, performance, maintainability) against the diff. Findings applied in `60480764`:

- **Sound-logic (CRITICAL + MAJOR):** thread `photoBlob` through the offline-queue path, project the new clock state into the React Query cache after `releaseLock()`, `.catch` on `handlePunch`, live `hasQueuedPunches()` check, consistent `pinMatch!`, `captureFnRef` (no stale closure), surface camera-not-ready error.
- **Performance:** `getUser → getSession` everywhere, `flushing` mutex on the offline queue.
- **Security:** gate `cameraDialog.onOpenChange(false)` on `!createPunch.isPending && !processingRef.current` so an ESC during the optimistic window can't slip a second punch through.
- **Maintainability:** stable `useCallback` for `onCaptureRef` (eliminates per-render effect re-firing), fix stale `isLoading` closure in `ImageCapture` setTimeout fallback, narrow `catch any` → `unknown`, drop WHAT comments.

## Deferred (separate PR — schema-level)

These three security findings touch DB schema / migrations and are out of scope for the kiosk-perf branch. They will be picked up under a follow-up PR with explicit security review:

- `employee_pins_usage_updates` RLS policy missing `WITH CHECK` (kiosk role can over-update `pin_hash` / `force_reset`).
- `created_by` audit-trail uses cached JWT (would need a `DEFAULT auth.uid()` migration).
- Offline-queued `force_reset` punches bypass the PIN-reset prompt on flush.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run test` — 274 files, 3924 tests, 1 skipped (was 3920 → +4 new)
- [x] `npm run build` — clean
- [ ] Local sanity: open kiosk on the dev instance, run through PIN + Skip-photo and PIN + Confirm flows under geofencing
- [ ] Production smoke under "Jose Delgado" account once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Punch success feedback now displays optimistically while processing completes in the background
  * Offline queue now captures and preserves photos with queued punches

* **Bug Fixes**
  * Fixed "Skip photo" dialog behavior to close correctly
  * Improved kiosk punch perception latency to under 300ms

* **Tests**
  * Added comprehensive test coverage for punch flow, offline queue, and image capture functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toyiyo/nimble-pnl/pull/503?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->