### PR TITLE
fix(pos-sales): mobile responsiveness audit + fixes (UI only)

### DIFF
--- a/docs/superpowers/plans/2026-05-17-pos-sales-mobile-plan.md
+++ b/docs/superpowers/plans/2026-05-17-pos-sales-mobile-plan.md
@@ -1,0 +1,1184 @@
+# POS Sales Mobile Fixes — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the `/pos-sales` page and its reachable dialogs usable on mobile (< 640px) without changing any logic, hooks, state, or behavior — only Tailwind responsive classes and semantic-token swaps.
+
+**Architecture:** Mobile-first responsive CSS using a single breakpoint (`sm:` = 640px). Hover-only action buttons become always-visible on mobile via `opacity-100 sm:opacity-0 sm:group-hover:opacity-100`. Direct color tokens in `SplitSaleView` (`bg-blue-*`, `border-l-blue-*`) get swapped for semantic tokens. A pre-existing virtualizer key bug (`key={virtualRow.index}`) is folded into this PR because we're modifying the same lines.
+
+**Tech Stack:** React 18.3, TypeScript, TailwindCSS, shadcn/ui, Vitest, `@tanstack/react-virtual`.
+
+**Spec:** `docs/superpowers/specs/2026-05-17-pos-sales-mobile-design.md`
+
+---
+
+## File Structure
+
+**Files to modify:**
+- `src/components/pos-sales/SaleCard.tsx` — hover-only action row, AI suggestion panel layout, padding, recipe name truncation, amount-column min-width, categorized-badge Edit link.
+- `src/components/pos-sales/SplitSaleView.tsx` — drop direct `blue-*` color tokens, switch to semantic tokens + shadcn Badge variant.
+- `src/components/POSSalesDashboard.tsx` — outer row flex direction, sync timestamp position.
+- `src/components/bulk-edit/BulkActionBar.tsx` — bottom offset clears `MobileTabBar` on mobile, tighter padding.
+- `src/pages/POSSales.tsx` — header actions row (aria-labels, label spans, `order-last` for primary CTA), AI Categorization card header, restaurant pill, filter row 1 (date inputs + Clear button aria-label), filter row 2 (sort cluster), virtualized list height + virtualizer key bug fix, grouped-view "Check impact" + `type="button"`.
+
+**Files to create:**
+- `tests/unit/SaleCard.mobile.test.tsx` — render SaleCard with mock sale, assert className tokens.
+- `tests/unit/SplitSaleView.mobile.test.tsx` — render SplitSaleView, assert no `blue-*` tokens + semantic tokens present.
+- `tests/unit/POSSalesDashboard.mobile.test.tsx` — render dashboard, assert flex-col/sm:flex-row.
+- `tests/unit/BulkActionBar.mobile.test.tsx` — render bar, assert `bottom-20 sm:bottom-6`.
+- `tests/unit/POSSalesMobile.source.test.ts` — **source-text** test on `src/pages/POSSales.tsx` because mocking 20+ page hooks is brittle; the source-text assertion is faster and still catches removal of the responsive tokens.
+
+**Dialogs audited in Task 11 (POSSaleDialog, SplitPosSaleDialog, BulkCategorizePosSalesPanel, EnhancedCategoryRulesDialog):** only edited if they violate the four-point checklist in the spec; commit message records the audit outcome per dialog.
+
+---
+
+## Task 1: SaleCard — actions row, AI panel, padding, truncation, amount column, Edit link
+
+**Files:**
+- Create: `tests/unit/SaleCard.mobile.test.tsx`
+- Modify: `src/components/pos-sales/SaleCard.tsx:92` (card padding), `:156` (recipe name truncation), `:179` (amount column min-width), `:193` (AI suggestion panel), `:256` (categorized-badge Edit link), `:303` (action row)
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/unit/SaleCard.mobile.test.tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { SaleCard, SaleCardProps } from '@/components/pos-sales/SaleCard';
+import { UnifiedSaleItem } from '@/types/pos';
+
+const noop = () => {};
+
+const baseSale: UnifiedSaleItem = {
+  id: 'sale-1',
+  itemName: 'Test Burger',
+  quantity: 1,
+  totalPrice: 12.5,
+  saleDate: '2026-05-17',
+  saleTime: '12:34',
+  posSystem: 'manual',
+  externalOrderId: 'ord-1',
+  is_categorized: false,
+  is_split: false,
+} as UnifiedSaleItem;
+
+const baseProps: SaleCardProps = {
+  sale: baseSale,
+  recipe: null,
+  isSelected: false,
+  isSelectionMode: false,
+  isEditingCategory: false,
+  accounts: [],
+  canEditManualSales: true,
+  onCardClick: noop,
+  onCheckboxChange: noop,
+  onEdit: noop,
+  onDelete: noop,
+  onSimulateDeduction: noop,
+  onMapPOSItem: noop,
+  onSetEditingCategory: noop,
+  onSplit: noop,
+  onSuggestRule: noop,
+  onCategorize: noop,
+  onNavigateToRecipe: noop,
+};
+
+describe('SaleCard — mobile responsive classes', () => {
+  it('action row is always visible on mobile, hover-only at sm+', () => {
+    const { container } = render(<SaleCard {...baseProps} />);
+    const html = container.innerHTML;
+    expect(html).toContain('opacity-100');
+    expect(html).toContain('sm:opacity-0');
+    expect(html).toContain('sm:group-hover:opacity-100');
+  });
+
+  it('card padding uses px-3 on mobile and sm:px-4 at sm+', () => {
+    const { container } = render(<SaleCard {...baseProps} />);
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toContain('px-3');
+    expect(root.className).toContain('sm:px-4');
+  });
+
+  it('recipe name truncation widens at sm+', () => {
+    const { container } = render(
+      <SaleCard
+        {...baseProps}
+        recipe={{ id: 'r-1', name: 'Cheeseburger Recipe', hasIngredients: true }}
+      />,
+    );
+    const html = container.innerHTML;
+    expect(html).toContain('max-w-[120px]');
+    expect(html).toContain('sm:max-w-[180px]');
+  });
+
+  it('right-side amount column has min-w-[72px]', () => {
+    const { container } = render(<SaleCard {...baseProps} />);
+    expect(container.innerHTML).toContain('min-w-[72px]');
+  });
+
+  it('AI suggestion panel switches from flex-col to sm:flex-row', () => {
+    const saleWithSuggestion: UnifiedSaleItem = {
+      ...baseSale,
+      suggested_category_id: 'cat-1',
+      chart_account: { id: 'acc-1', account_name: 'Food', account_code: '4000' } as any,
+    } as UnifiedSaleItem;
+    const { container } = render(<SaleCard {...baseProps} sale={saleWithSuggestion} />);
+    const html = container.innerHTML;
+    expect(html).toContain('flex-col');
+    expect(html).toContain('sm:flex-row');
+  });
+
+  it('categorized badge Edit link is always visible on mobile', () => {
+    const categorizedSale: UnifiedSaleItem = {
+      ...baseSale,
+      is_categorized: true,
+      chart_account: { id: 'acc-1', account_name: 'Food', account_code: '4000' } as any,
+    } as UnifiedSaleItem;
+    const { container } = render(<SaleCard {...baseProps} sale={categorizedSale} />);
+    const html = container.innerHTML;
+    expect(html).toContain('opacity-100');
+    expect(html).toContain('sm:opacity-0');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/SaleCard.mobile.test.tsx`
+Expected: FAIL — assertions for `opacity-100`, `sm:opacity-0`, `min-w-[72px]`, `sm:max-w-[180px]`, `sm:flex-row` not yet in source.
+
+- [ ] **Step 3: Apply class changes**
+
+In `src/components/pos-sales/SaleCard.tsx`:
+
+Line 92 — card padding:
+```typescript
+// before
+className={`group flex items-start gap-3 px-4 py-3 border-b border-border/40 transition-colors ${
+// after
+className={`group flex items-start gap-3 px-3 py-3 sm:px-4 border-b border-border/40 transition-colors ${
+```
+
+Line 156 — recipe name truncation:
+```typescript
+// before
+<span className="truncate max-w-[120px]">{recipe.name}</span>
+// after
+<span className="truncate max-w-[120px] sm:max-w-[180px]">{recipe.name}</span>
+```
+
+Line 179 — amount column min-width:
+```typescript
+// before
+<div className="text-right shrink-0">
+// after
+<div className="text-right shrink-0 min-w-[72px]">
+```
+
+Line 193 — AI suggestion panel (flex direction on mobile):
+```typescript
+// before
+<div className="flex items-center justify-between gap-3 p-2.5 rounded-lg bg-amber-500/10 border border-amber-500/20">
+// after
+<div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-3 p-2.5 rounded-lg bg-amber-500/10 border border-amber-500/20">
+```
+
+Line 256 — categorized-badge Edit link (hover→always-on-mobile):
+```typescript
+// before
+className="text-[12px] text-muted-foreground hover:text-foreground transition-colors opacity-0 group-hover:opacity-100"
+// after
+className="text-[12px] text-muted-foreground hover:text-foreground transition-colors opacity-100 sm:opacity-0 sm:group-hover:opacity-100"
+```
+
+Line 303 — action row (hover→always-on-mobile + flex-wrap for narrow widths):
+```typescript
+// before
+<div className="flex items-center gap-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
+// after
+<div className="flex items-center flex-wrap gap-x-3 gap-y-1.5 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 transition-opacity">
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/SaleCard.mobile.test.tsx`
+Expected: PASS — all 6 cases green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/unit/SaleCard.mobile.test.tsx src/components/pos-sales/SaleCard.tsx
+git commit -m "$(printf 'fix(pos-sales): mobile-visible action row + responsive SaleCard layout\n\n- Action buttons no longer hidden behind hover on touch (opacity-100 sm:opacity-0 sm:group-hover:opacity-100)\n- Categorized-badge Edit link same pattern\n- AI suggestion panel switches flex-col → sm:flex-row\n- Card padding tightens on mobile (px-3 sm:px-4)\n- Recipe name truncates harder on mobile (max-w-[120px] sm:max-w-[180px])\n- Amount column gets min-w-[72px] to prevent collision\n\nCo-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 2: SplitSaleView — drop direct blue color tokens (CLAUDE.md violation)
+
+**Files:**
+- Create: `tests/unit/SplitSaleView.mobile.test.tsx`
+- Modify: `src/components/pos-sales/SplitSaleView.tsx:23` (card border), `:24` (card padding), `:30` (Split Sale badge), `:79` (expanded children border)
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/unit/SplitSaleView.mobile.test.tsx
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { SplitSaleView } from '@/components/pos-sales/SplitSaleView';
+import { UnifiedSaleItem } from '@/types/pos';
+
+const splitSale: UnifiedSaleItem = {
+  id: 'parent-1',
+  itemName: 'Combo Meal',
+  quantity: 1,
+  totalPrice: 25,
+  saleDate: '2026-05-17',
+  saleTime: '12:34',
+  posSystem: 'toast',
+  externalOrderId: 'ord-1',
+  is_split: true,
+  child_splits: [
+    { id: 'child-1', itemName: 'Burger', totalPrice: 15 } as any,
+    { id: 'child-2', itemName: 'Fries', totalPrice: 10 } as any,
+  ],
+} as UnifiedSaleItem;
+
+describe('SplitSaleView — semantic tokens only (no direct blue colors)', () => {
+  it('contains no direct blue color tokens', () => {
+    const { container } = render(
+      <SplitSaleView
+        sale={splitSale}
+        formatCurrency={(n) => `$${n.toFixed(2)}`}
+      />,
+    );
+    const html = container.innerHTML;
+    expect(html).not.toMatch(/\bbg-blue-/);
+    expect(html).not.toMatch(/\btext-blue-/);
+    expect(html).not.toMatch(/\bborder-blue-/);
+    expect(html).not.toMatch(/\bborder-l-blue-/);
+    expect(html).not.toMatch(/dark:bg-blue-/);
+    expect(html).not.toMatch(/dark:text-blue-/);
+    expect(html).not.toMatch(/dark:border-blue-/);
+  });
+
+  it('uses neutral semantic left border on the card', () => {
+    const { container } = render(
+      <SplitSaleView
+        sale={splitSale}
+        formatCurrency={(n) => `$${n.toFixed(2)}`}
+      />,
+    );
+    expect(container.innerHTML).toContain('border-l-foreground/20');
+  });
+
+  it('uses semantic border on expanded children container', () => {
+    const { container } = render(
+      <SplitSaleView
+        sale={splitSale}
+        formatCurrency={(n) => `$${n.toFixed(2)}`}
+      />,
+    );
+    // toggle expansion
+    const toggle = container.querySelector('button');
+    toggle?.click();
+    // re-query after click
+    expect(container.innerHTML).toContain('border-border/40');
+  });
+
+  it('card padding tightens on mobile (p-3 sm:p-4)', () => {
+    const { container } = render(
+      <SplitSaleView
+        sale={splitSale}
+        formatCurrency={(n) => `$${n.toFixed(2)}`}
+      />,
+    );
+    expect(container.innerHTML).toContain('p-3');
+    expect(container.innerHTML).toContain('sm:p-4');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/SplitSaleView.mobile.test.tsx`
+Expected: FAIL — current source has `border-l-blue-500`, `bg-blue-100`, etc.
+
+- [ ] **Step 3: Apply class changes**
+
+In `src/components/pos-sales/SplitSaleView.tsx`:
+
+Line 23 — card border + responsive padding:
+```typescript
+// before
+<Card className="w-full transition-all hover:shadow-md border-l-4 border-l-blue-500">
+  <CardContent className="p-4 space-y-3">
+// after
+<Card className="w-full transition-all hover:shadow-md border-l-4 border-l-foreground/20">
+  <CardContent className="p-3 sm:p-4 space-y-3">
+```
+
+Line 30 — Split Sale badge (drop className override, keep variant="secondary"):
+```typescript
+// before
+<Badge variant="secondary" className="bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
+  Split Sale
+</Badge>
+// after
+<Badge variant="secondary">
+  Split Sale
+</Badge>
+```
+
+Line 79 — expanded children left border:
+```typescript
+// before
+<div className="space-y-2 pl-4 border-l-2 border-blue-200 dark:border-blue-800">
+// after
+<div className="space-y-2 pl-4 border-l-2 border-border/40">
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/SplitSaleView.mobile.test.tsx`
+Expected: PASS — all 4 cases green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/unit/SplitSaleView.mobile.test.tsx src/components/pos-sales/SplitSaleView.tsx
+git commit -m "$(printf 'fix(pos-sales): SplitSaleView semantic tokens + mobile padding\n\nReplaces direct blue-* color tokens (CLAUDE.md violation) with neutral\nsemantic tokens: border-l-foreground/20 on parent, border-border/40 on\nexpanded children, plain Badge variant=secondary for the Split Sale\npill (no className override). Tightens card padding on mobile.\n\nCo-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 3: POSSalesDashboard — flex-col outer row on mobile
+
+**Files:**
+- Create: `tests/unit/POSSalesDashboard.mobile.test.tsx`
+- Modify: `src/components/POSSalesDashboard.tsx:98` (outer container)
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/unit/POSSalesDashboard.mobile.test.tsx
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { POSSalesDashboard } from '@/components/POSSalesDashboard';
+
+const baseProps = {
+  totalSales: 100,
+  totalRevenue: 1000,
+  discounts: 0,
+  voids: 0,
+  passThroughAmount: 0,
+  collectedAtPOS: 1000,
+  uniqueItems: 25,
+  unmappedCount: 0,
+  lastSyncTime: '2026-05-17T12:00:00Z',
+  contextCueVisible: false,
+  cuePinned: false,
+  onToggleCuePin: () => {},
+  contextDescription: '',
+  highlightToken: 0,
+  filtersActive: false,
+  isLoading: false,
+};
+
+describe('POSSalesDashboard — mobile layout', () => {
+  it('outer row stacks on mobile, switches to flex-row at sm+', () => {
+    const { container } = render(<POSSalesDashboard {...baseProps} />);
+    const html = container.innerHTML;
+    expect(html).toContain('flex-col');
+    expect(html).toContain('sm:flex-row');
+    expect(html).toContain('sm:items-center');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/POSSalesDashboard.mobile.test.tsx`
+Expected: FAIL — source has `flex items-center gap-1` only.
+
+- [ ] **Step 3: Apply class change**
+
+In `src/components/POSSalesDashboard.tsx`:
+
+Line 98 — outer row container:
+```typescript
+// before
+<div className="flex items-center gap-1">
+// after
+<div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-1">
+```
+
+(`ml-auto` on line 145 already handles itself — at mobile widths there is no flex-row to apply `ml-auto` against, so the timestamp simply falls onto its own line in the column. No additional edit needed.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/POSSalesDashboard.mobile.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/unit/POSSalesDashboard.mobile.test.tsx src/components/POSSalesDashboard.tsx
+git commit -m "$(printf 'fix(pos-sales): dashboard outer row stacks on mobile\n\nSwitches the metrics+timestamp row from flex-row only to\nflex-col → sm:flex-row, so the Synced timestamp no longer overlaps\nthe metrics on narrow viewports.\n\nCo-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 4: BulkActionBar — clear MobileTabBar on mobile
+
+**Files:**
+- Create: `tests/unit/BulkActionBar.mobile.test.tsx`
+- Modify: `src/components/bulk-edit/BulkActionBar.tsx:40` (bottom offset), `:42` (padding), `:67` (vertical divider)
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/unit/BulkActionBar.mobile.test.tsx
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { BulkActionBar } from '@/components/bulk-edit/BulkActionBar';
+
+describe('BulkActionBar — mobile clearance', () => {
+  it('sits above the MobileTabBar on mobile (bottom-20), reverts at sm+', () => {
+    const { container } = render(
+      <BulkActionBar
+        selectedCount={3}
+        onClose={() => {}}
+        actions={[{ label: 'Delete', onClick: () => {} }]}
+      />,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toContain('bottom-20');
+    expect(root.className).toContain('sm:bottom-6');
+  });
+
+  it('uses tighter padding on mobile, normal at sm+', () => {
+    const { container } = render(
+      <BulkActionBar
+        selectedCount={3}
+        onClose={() => {}}
+        actions={[{ label: 'Delete', onClick: () => {} }]}
+      />,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toContain('px-4');
+    expect(root.className).toContain('py-3');
+    expect(root.className).toContain('sm:px-6');
+    expect(root.className).toContain('sm:py-4');
+  });
+
+  it('hides the vertical divider on mobile', () => {
+    const { container } = render(
+      <BulkActionBar
+        selectedCount={3}
+        onClose={() => {}}
+        actions={[{ label: 'Delete', onClick: () => {} }]}
+      />,
+    );
+    const divider = container.querySelector('.bg-border.flex-shrink-0');
+    expect(divider?.className).toContain('hidden');
+    expect(divider?.className).toContain('sm:block');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/BulkActionBar.mobile.test.tsx`
+Expected: FAIL — source has `bottom-6`, `px-6 py-4`, divider missing `hidden sm:block`.
+
+- [ ] **Step 3: Apply class changes**
+
+In `src/components/bulk-edit/BulkActionBar.tsx`:
+
+Line 40 — bottom offset:
+```typescript
+// before
+"fixed bottom-6 left-1/2 -translate-x-1/2 z-50",
+// after
+"fixed bottom-20 sm:bottom-6 left-1/2 -translate-x-1/2 z-50",
+```
+
+Line 42 — padding:
+```typescript
+// before
+"px-6 py-4 flex items-center gap-4",
+// after
+"px-4 py-3 sm:px-6 sm:py-4 flex items-center gap-4",
+```
+
+Line 67 — vertical divider:
+```typescript
+// before
+<div className="h-8 w-px bg-border flex-shrink-0" />
+// after
+<div className="h-8 w-px bg-border flex-shrink-0 hidden sm:block" />
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/BulkActionBar.mobile.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/unit/BulkActionBar.mobile.test.tsx src/components/bulk-edit/BulkActionBar.tsx
+git commit -m "$(printf 'fix(pos-sales): BulkActionBar clears MobileTabBar on mobile\n\nbottom-6 → bottom-20 sm:bottom-6 so the floating action bar no\nlonger overlaps the staff bottom navigation. Tighter padding and a\nhidden divider on mobile to fit narrow viewports.\n\nCo-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 5: POSSales page — header actions row (aria-labels, label spans, DOM-order fix)
+
+**Files:**
+- Modify: `src/pages/POSSales.tsx:794-845`
+
+- [ ] **Step 1: Apply class + JSX changes**
+
+In `src/pages/POSSales.tsx`, replace the header actions block (lines 794-845).
+
+Important: the **DOM order** has to change so that "Add Sale" is the first child in the JSX. Combined with `order-last sm:order-none`, it renders last on desktop (where flex `order` has visual effect) and lands on its own visible line on mobile when the row wraps (where it stays first in DOM order, which is what gets rendered when wrapping).
+
+Replace lines 794-845 with:
+
+```typescript
+          {/* Action buttons - Apple style */}
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              onClick={() => {
+                setActiveTab("manual");
+                setEditingSale(null);
+                setShowSaleDialog(true);
+              }}
+              size="sm"
+              className="order-last sm:order-none h-8 px-3 text-[13px] font-medium bg-foreground text-background hover:bg-foreground/90 rounded-lg transition-colors shadow-sm"
+            >
+              <Plus className="h-3.5 w-3.5 mr-1.5" />
+              Add Sale
+            </Button>
+            {hasAnyConnectedSystem() && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleSyncSales}
+                disabled={isSyncing}
+                aria-label="Sync sales"
+                className="h-8 px-3 text-[13px] font-medium text-muted-foreground hover:text-foreground hover:bg-muted/80 rounded-lg transition-colors"
+              >
+                <RefreshCw className={`h-3.5 w-3.5 sm:mr-1.5 ${isSyncing ? "animate-spin" : ""}`} />
+                <span className="hidden sm:inline">{isSyncing ? "Syncing" : "Sync"}</span>
+              </Button>
+            )}
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setShowRulesDialog(true)}
+              aria-label="Category rules"
+              className="h-8 px-3 text-[13px] font-medium text-muted-foreground hover:text-foreground hover:bg-muted/80 rounded-lg transition-colors"
+            >
+              <Settings2 className="h-3.5 w-3.5 sm:mr-1.5" />
+              <span className="hidden sm:inline">Rules</span>
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setActiveTab("import")}
+              aria-label="Import sales"
+              className="h-8 px-3 text-[13px] font-medium text-muted-foreground hover:text-foreground hover:bg-muted/80 rounded-lg transition-colors"
+            >
+              <UploadIcon className="h-3.5 w-3.5 sm:mr-1.5" />
+              <span className="hidden sm:inline">Import</span>
+            </Button>
+            <ExportDropdown
+              onExportCSV={handleExportCSV}
+              onExportPDF={handleExportPDF}
+              isExporting={isExporting}
+            />
+            <div className="hidden sm:block w-px h-5 bg-border mx-1" />
+          </div>
+```
+
+- [ ] **Step 2: Verify in browser**
+
+Run: `npm run dev` then visit http://localhost:8080/pos-sales with DevTools mobile emulation at 375px wide.
+Expected:
+- Add Sale is visible and renders on its own line (because it wraps first due to `order-last sm:order-none` + DOM-first position).
+- Sync/Rules/Import/Export show only icons.
+- Each icon-only button has an `aria-label` (verify in DevTools: inspect the `<button>` element).
+
+At ≥ 640px: layout is identical to before (Add Sale rightmost, secondary buttons show full labels).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pages/POSSales.tsx
+git commit -m "$(printf 'fix(pos-sales): mobile-responsive header actions row\n\n- flex-wrap so the row no longer overflows on narrow viewports\n- icon-only Sync/Rules/Import/Clear on mobile with explicit aria-labels\n- Add Sale stays on its own visible line when wrap occurs\n  (DOM-first + order-last sm:order-none)\n\nCo-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 6: POSSales page — AI Categorization card header + Restaurant pill
+
+**Files:**
+- Modify: `src/pages/POSSales.tsx:869-890` (card header), `:784-787` (restaurant pill)
+
+- [ ] **Step 1: Apply class changes**
+
+In `src/pages/POSSales.tsx`:
+
+Restaurant pill (lines 784-787) — let inner row wrap on narrowest screens:
+```typescript
+// before
+<span className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded-full bg-muted text-muted-foreground">
+  <span className="h-1.5 w-1.5 rounded-full bg-green-500" />
+  {selectedRestaurant.restaurant.name}
+</span>
+// after
+<span className="inline-flex flex-wrap items-center gap-1.5 px-2 sm:px-2.5 py-1 text-xs font-medium rounded-full bg-muted text-muted-foreground">
+  <span className="h-1.5 w-1.5 rounded-full bg-green-500" />
+  {selectedRestaurant.restaurant.name}
+</span>
+```
+
+AI Categorization card header (line 871) — wrap title above button on mobile:
+```typescript
+// before
+<div className="flex items-center justify-between">
+// after
+<div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+```
+
+AI Categorize button (line 881-888) — two-span text swap so the button label fits on mobile:
+```typescript
+// before
+<Button
+  onClick={handleCategorizeClick}
+  disabled={isCategorizingPending || uncategorizedSalesCount === 0}
+  className="gap-2"
+>
+  <Sparkles className="h-4 w-4" />
+  {isCategorizingPending ? "Categorizing..." : "AI Categorize Sales"}
+</Button>
+// after
+<Button
+  onClick={handleCategorizeClick}
+  disabled={isCategorizingPending || uncategorizedSalesCount === 0}
+  className="gap-2 w-full sm:w-auto"
+>
+  <Sparkles className="h-4 w-4" />
+  {isCategorizingPending ? (
+    "Categorizing..."
+  ) : (
+    <>
+      <span className="hidden sm:inline">AI Categorize Sales</span>
+      <span className="sm:hidden">AI Categorize</span>
+    </>
+  )}
+</Button>
+```
+
+- [ ] **Step 2: Verify in browser**
+
+Run: `npm run dev` then visit http://localhost:8080/pos-sales at 375px.
+Expected:
+- AI card title is stacked above the button.
+- Button reads "AI Categorize" on mobile, "AI Categorize Sales" on desktop.
+- Restaurant pill wraps cleanly inside the heading area.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pages/POSSales.tsx
+git commit -m "$(printf 'fix(pos-sales): AI card header stacks on mobile; restaurant pill wraps\n\nAI Categorization card swaps flex-row → flex-col sm:flex-row so the\nlong-labelled button no longer collides with the title. Button label\nshortens to AI Categorize on mobile. Restaurant pill flex-wraps.\n\nCo-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 7: POSSales page — filter row 1 (search + dates + Clear)
+
+**Files:**
+- Modify: `src/pages/POSSales.tsx:954-1010`
+
+- [ ] **Step 1: Apply class changes**
+
+In `src/pages/POSSales.tsx`:
+
+Filter row 1 — switch to mobile-first flex-col, let date inputs flex, and add aria-label to the icon-only Clear button.
+
+Line 954 (outer row direction — already uses `md:flex-row`, change to `sm:flex-row`):
+```typescript
+// before
+<div className="flex flex-col md:flex-row gap-3">
+// after
+<div className="flex flex-col sm:flex-row gap-3">
+```
+
+Lines 970-986 (date inputs — let them flex on mobile, fix width at sm+):
+```typescript
+// before (start date)
+className="h-9 w-[150px] text-[13px] bg-muted/40 border-0 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
+// after (start date)
+className="h-9 flex-1 sm:w-[150px] sm:flex-none text-[13px] bg-muted/40 border-0 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
+```
+(Same swap on the end-date input on line ~985.)
+
+Also wrap the two date inputs container (line 968) with `flex-1 sm:flex-none` so the pair takes the row's full width on mobile but stays compact on desktop:
+```typescript
+// before
+<div className="flex items-center gap-2">
+// after
+<div className="flex flex-1 sm:flex-none items-center gap-2">
+```
+
+Lines 991-1009 (Clear button — icon-only on mobile + aria-label):
+```typescript
+// before
+<Button
+  variant="ghost"
+  size="sm"
+  onClick={() => {
+    setSearchTerm("");
+    setStartDate("");
+    setEndDate("");
+    setRecipeFilter('all');
+    setCategorizationFilter('all');
+    setSortBy('date');
+    setSortDirection('desc');
+  }}
+  className="h-9 px-3 text-[13px] text-muted-foreground hover:text-foreground"
+>
+  <X className="h-3.5 w-3.5 mr-1" />
+  Clear
+</Button>
+// after
+<Button
+  variant="ghost"
+  size="sm"
+  onClick={() => {
+    setSearchTerm("");
+    setStartDate("");
+    setEndDate("");
+    setRecipeFilter('all');
+    setCategorizationFilter('all');
+    setSortBy('date');
+    setSortDirection('desc');
+  }}
+  aria-label="Clear filters"
+  className="h-9 px-3 text-[13px] text-muted-foreground hover:text-foreground"
+>
+  <X className="h-3.5 w-3.5 sm:mr-1" />
+  <span className="hidden sm:inline">Clear</span>
+</Button>
+```
+
+- [ ] **Step 2: Verify in browser**
+
+At 375px wide:
+- Search input is full-width.
+- Date inputs each fill half the row (with the en-dash between them).
+- Clear is icon-only with `aria-label="Clear filters"` (DevTools accessibility tab).
+
+At ≥ 640px:
+- Search input is `max-w-md`, dates are 150px each, Clear shows "Clear" text — same as before.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pages/POSSales.tsx
+git commit -m "$(printf 'fix(pos-sales): filter row 1 stacks + responsive date inputs\n\nSwitches the outer row breakpoint from md: to sm: (matches the rest\nof the page) and lets the date pair fill the available row on mobile\nwhile staying 150px at sm+. Clear button becomes icon-only on mobile\nwith aria-label.\n\nCo-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 8: POSSales page — filter row 2 (sort cluster, breakpoint cleanup)
+
+**Files:**
+- Modify: `src/pages/POSSales.tsx:1047`, `:1074`, `:1104`
+
+- [ ] **Step 1: Apply class changes**
+
+In `src/pages/POSSales.tsx`:
+
+Line 1047 (divider — change md: to sm: for breakpoint consistency):
+```typescript
+// before
+<div className="h-5 w-px bg-border/60 hidden md:block" />
+// after
+<div className="h-5 w-px bg-border/60 hidden sm:block" />
+```
+
+Line 1074 (divider — same change):
+```typescript
+// before
+<div className="h-5 w-px bg-border/60 hidden md:block" />
+// after
+<div className="h-5 w-px bg-border/60 hidden sm:block" />
+```
+
+Line 1104 (sort cluster — full-width on mobile, ml-auto only at sm+):
+```typescript
+// before
+<div className="flex items-center gap-2 ml-auto">
+// after
+<div className="flex items-center gap-2 w-full sm:w-auto sm:ml-auto">
+```
+
+(The outer `flex flex-wrap items-center gap-4` container on line 1013 already wraps; no `overflow-x-auto` wrappers exist in the source to remove — that audit point in the spec was preventive. Confirmed by re-reading the file.)
+
+- [ ] **Step 2: Verify in browser**
+
+At 375px:
+- The three segmented control groups (Status / Recipe / View) wrap to new lines as needed.
+- Dividers between them are hidden.
+- The sort cluster lands on its own row, full-width.
+
+At ≥ 640px:
+- Dividers show.
+- Sort cluster is right-aligned via `ml-auto`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pages/POSSales.tsx
+git commit -m "$(printf 'fix(pos-sales): filter row 2 sort cluster + breakpoint unification\n\nSort cluster gets w-full on mobile + sm:w-auto sm:ml-auto so it no\nlonger collides with the segments when wrapping. Inter-group\ndividers switch from md: to sm: to match the unified breakpoint\npolicy.\n\nCo-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 9: POSSales page — virtualized list height + virtualizer key fix
+
+**Files:**
+- Modify: `src/pages/POSSales.tsx:1197` (list height), `:1214` and `:1238` (virtualizer keys — pre-existing bug)
+
+This task folds in a required correctness fix: the virtualizer keys currently use `key={virtualRow.index}`, but CLAUDE.md mandates `key={items[virtualRow.index].id}` for `@tanstack/react-virtual`. Index keys break React reconciliation when the underlying list reorders or filters.
+
+- [ ] **Step 1: Apply class + key changes**
+
+In `src/pages/POSSales.tsx`:
+
+Line 1197 — virtualized list height (dvh progressive enhancement + min height floor):
+```typescript
+// before
+<div
+  ref={salesListRef}
+  className="h-[600px] overflow-auto rounded-xl border border-border/40 bg-background"
+>
+// after
+<div
+  ref={salesListRef}
+  className="h-[calc(100vh-180px)] [height:calc(100dvh-180px)] min-h-[400px] sm:h-[600px] overflow-auto rounded-xl border border-border/40 bg-background"
+>
+```
+
+Line 1214 — split-view row key:
+```typescript
+// before
+<div
+  key={virtualRow.index}
+  data-index={virtualRow.index}
+// after
+<div
+  key={sale.id}
+  data-index={virtualRow.index}
+```
+
+Line 1238 — sale-card row key:
+```typescript
+// before
+<div
+  key={virtualRow.index}
+  data-index={virtualRow.index}
+// after
+<div
+  key={sale.id}
+  data-index={virtualRow.index}
+```
+
+- [ ] **Step 2: Verify in browser**
+
+At 375px:
+- List occupies the available viewport height (calc(100dvh-180px) with min-h-[400px] floor).
+- Smooth virtualized scrolling.
+
+At ≥ 640px:
+- List is `h-[600px]` — unchanged from before.
+
+Functional verification of key fix:
+- Apply a search filter ("burger" → "fries"). Confirm list rows do not flash incorrect content (which would happen if React was reusing DOM nodes by index).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pages/POSSales.tsx
+git commit -m "$(printf 'fix(pos-sales): responsive virtualized list height + virtualizer keys\n\n- List height adapts to viewport on mobile (calc(100dvh-180px)) with a\n  400px floor and progressive dvh enhancement\n- Fix pre-existing virtualizer key bug: key={virtualRow.index} →\n  key={sale.id} on both the split-view and sale-card rows\n  (CLAUDE.md mandates stable IDs for @tanstack/react-virtual)\n\nCo-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 10: POSSales page — grouped-view "Check impact" + type="button"
+
+**Files:**
+- Modify: `src/pages/POSSales.tsx:1396-1401`
+
+- [ ] **Step 1: Apply class + attribute changes**
+
+In `src/pages/POSSales.tsx`, lines 1396-1401:
+
+```typescript
+// before
+<button
+  onClick={() => handleSimulateDeduction(item.item_name, item.total_quantity)}
+  className="ml-auto text-[12px] text-muted-foreground hover:text-foreground transition-colors opacity-0 group-hover:opacity-100"
+>
+  Check impact
+</button>
+// after
+<button
+  type="button"
+  onClick={() => handleSimulateDeduction(item.item_name, item.total_quantity)}
+  className="ml-auto text-[12px] text-muted-foreground hover:text-foreground transition-colors opacity-100 sm:opacity-0 sm:group-hover:opacity-100"
+>
+  Check impact
+</button>
+```
+
+- [ ] **Step 2: Verify in browser**
+
+At 375px:
+- Switch to "Grouped" view.
+- Each card shows "Check impact" without needing hover.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pages/POSSales.tsx
+git commit -m "$(printf 'fix(pos-sales): grouped-view Check impact reachable on touch\n\nopacity-0 group-hover:opacity-100 → opacity-100 sm:opacity-0\nsm:group-hover:opacity-100 so the action is reachable on mobile.\nAlso adds explicit type=button to guard against default-submit\nbehavior inside any future form context.\n\nCo-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 11: POSSales source-text regression test
+
+**Files:**
+- Create: `tests/unit/POSSalesMobile.source.test.ts`
+
+POSSales.tsx imports 30+ hooks and a dozen components — full-render tests would require mocking each one. Instead we use a source-text regression guard: if any of the responsive tokens get removed in a future edit, the test fails. This is the cheapest reliable guard.
+
+- [ ] **Step 1: Write the test**
+
+```typescript
+// tests/unit/POSSalesMobile.source.test.ts
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const SOURCE = readFileSync(
+  resolve(__dirname, '../../src/pages/POSSales.tsx'),
+  'utf8',
+);
+
+describe('POSSales — mobile responsive tokens stay in source', () => {
+  it('header actions container is flex-wrap', () => {
+    expect(SOURCE).toContain('flex flex-wrap items-center gap-2');
+  });
+
+  it('Add Sale uses order-last sm:order-none for wrap behavior', () => {
+    expect(SOURCE).toContain('order-last sm:order-none');
+  });
+
+  it('Sync/Rules/Import buttons have aria-label', () => {
+    expect(SOURCE).toContain('aria-label="Sync sales"');
+    expect(SOURCE).toContain('aria-label="Category rules"');
+    expect(SOURCE).toContain('aria-label="Import sales"');
+  });
+
+  it('Clear filters button has aria-label', () => {
+    expect(SOURCE).toContain('aria-label="Clear filters"');
+  });
+
+  it('AI Categorize button has two-span label swap', () => {
+    expect(SOURCE).toContain('AI Categorize Sales');
+    expect(SOURCE).toContain('>AI Categorize<');
+  });
+
+  it('date inputs flex on mobile, fixed width at sm+', () => {
+    expect(SOURCE).toContain('flex-1 sm:w-[150px] sm:flex-none');
+  });
+
+  it('filter row 1 uses sm: breakpoint (not md:)', () => {
+    expect(SOURCE).toContain('flex flex-col sm:flex-row gap-3');
+  });
+
+  it('filter row 2 dividers use sm: not md:', () => {
+    expect(SOURCE).not.toMatch(/h-5 w-px bg-border\/60 hidden md:block/);
+    expect(SOURCE).toContain('h-5 w-px bg-border/60 hidden sm:block');
+  });
+
+  it('sort cluster full-width on mobile', () => {
+    expect(SOURCE).toContain('w-full sm:w-auto sm:ml-auto');
+  });
+
+  it('virtualized list height uses dvh progressive enhancement', () => {
+    expect(SOURCE).toContain('h-[calc(100vh-180px)]');
+    expect(SOURCE).toContain('[height:calc(100dvh-180px)]');
+    expect(SOURCE).toContain('min-h-[400px]');
+    expect(SOURCE).toContain('sm:h-[600px]');
+  });
+
+  it('virtualizer keys use sale.id (not index)', () => {
+    expect(SOURCE).not.toMatch(/key=\{virtualRow\.index\}/);
+    const saleIdKeyMatches = SOURCE.match(/key=\{sale\.id\}/g) || [];
+    expect(saleIdKeyMatches.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('grouped-view Check impact is mobile-visible and has type=button', () => {
+    expect(SOURCE).toContain('opacity-100 sm:opacity-0 sm:group-hover:opacity-100');
+    expect(SOURCE).toMatch(/type="button"[\s\S]*?onClick=\{\(\) => handleSimulateDeduction/);
+  });
+
+  it('AI Categorization card header stacks on mobile', () => {
+    expect(SOURCE).toContain('flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between');
+  });
+});
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `npx vitest run tests/unit/POSSalesMobile.source.test.ts`
+Expected: PASS (all responsive tokens were added in Tasks 5-10).
+
+If any assertion fails, find the corresponding spot in `src/pages/POSSales.tsx` and re-apply the change. Do not weaken the test.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/POSSalesMobile.source.test.ts
+git commit -m "$(printf 'test(pos-sales): source-text regression guard for mobile tokens\n\nGuards that every responsive token added in tasks 5-10 stays in\nsrc/pages/POSSales.tsx. Source-text rather than render-based because\nthe page imports 30+ hooks; mocking them all would dwarf the test\nitself and add zero value vs. grep.\n\nCo-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 12: Dialog audit (POSSaleDialog, SplitPosSaleDialog, BulkCategorizePosSalesPanel, EnhancedCategoryRulesDialog)
+
+**Files:**
+- Read and audit each dialog file
+- Modify only those that violate the spec's four-point checklist
+
+**Checklist for each dialog (from spec):**
+1. `DialogContent` uses sticky-footer pattern: `max-h-[85vh] overflow-hidden flex flex-col`
+2. Two-column form rows: `grid-cols-1 sm:grid-cols-2` (not `grid grid-cols-2` alone)
+3. Footer action rows: `flex justify-end gap-2 flex-wrap`
+4. No `min-w-[NNN]` larger than 320px on inputs
+
+- [ ] **Step 1: Audit POSSaleDialog**
+
+Run: `grep -n "DialogContent\|grid grid-cols\|justify-end gap\|min-w-\[" src/components/POSSaleDialog.tsx`
+
+For each finding, compare to the four-point checklist. If all four pass, no edits — note in commit message ("POSSaleDialog: passes audit, no changes"). If any fail, apply the corresponding fix:
+
+- Missing sticky-footer classes → add them to the `DialogContent` className.
+- `grid grid-cols-2` without responsive prefix → `grid grid-cols-1 sm:grid-cols-2`.
+- Footer missing `flex-wrap` → add it.
+- Input with `min-w-[400px]` or similar → drop to `min-w-[320px]` or remove.
+
+- [ ] **Step 2: Audit SplitPosSaleDialog**
+
+Run: `grep -n "DialogContent\|grid grid-cols\|justify-end gap\|min-w-\[" src/components/pos-sales/SplitPosSaleDialog.tsx`
+
+Apply same audit + fixes.
+
+- [ ] **Step 3: Audit BulkCategorizePosSalesPanel**
+
+Run: `grep -n "DialogContent\|grid grid-cols\|justify-end gap\|min-w-\[" src/components/pos-sales/BulkCategorizePosSalesPanel.tsx`
+
+Note: this may not be a dialog (panel). Audit the same four points anyway as they apply to any modal-ish surface.
+
+- [ ] **Step 4: Audit EnhancedCategoryRulesDialog**
+
+Run: `grep -n "DialogContent\|grid grid-cols\|justify-end gap\|min-w-\[" src/components/banking/EnhancedCategoryRulesDialog.tsx`
+
+Apply same audit + fixes.
+
+- [ ] **Step 5: Verify existing POSSaleDialog scroll test still passes**
+
+Run: `npx vitest run tests/unit/POSSaleDialog.scroll.test.tsx`
+Expected: PASS — must still contain `max-h-[85vh]`, `overflow-hidden`, `flex-col`. If we touched POSSaleDialog and broke this, revert that specific change.
+
+- [ ] **Step 6: Commit**
+
+If any files were modified:
+```bash
+git add src/components/POSSaleDialog.tsx src/components/pos-sales/SplitPosSaleDialog.tsx src/components/pos-sales/BulkCategorizePosSalesPanel.tsx src/components/banking/EnhancedCategoryRulesDialog.tsx
+git commit -m "$(printf 'fix(pos-sales): dialog mobile audit fixes\n\nAudit POSSaleDialog, SplitPosSaleDialog, BulkCategorizePosSalesPanel,\nEnhancedCategoryRulesDialog against the four-point spec checklist:\nsticky-footer DialogContent, grid-cols-1 sm:grid-cols-2 for two-col\nforms, flex-wrap on footer action rows, no min-w >320px on inputs.\n\nDialogs that passed clean: <list which ones, if any>\nDialogs touched: <list with the fix>\n\nCo-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>')"
+```
+
+If all four passed clean:
+```bash
+git commit --allow-empty -m "$(printf 'audit(pos-sales): dialogs already meet mobile spec checklist\n\nAudited POSSaleDialog, SplitPosSaleDialog, BulkCategorizePosSalesPanel,\nEnhancedCategoryRulesDialog. All four pass the sticky-footer +\nresponsive grid + wrap-footer + no-overlarge-min-width checklist.\nNo code changes required.\n\nCo-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>')"
+```
+
+---
+
+## Task 13: Final verification (full test + typecheck + lint + build)
+
+**Files:** none — verification only.
+
+- [ ] **Step 1: Run the full unit test suite**
+
+Run: `npm run test`
+Expected: all tests pass, including all 5 new mobile tests + the existing POSSaleDialog scroll test.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck`
+Expected: 0 errors. (We did not change types — but the JSX edits could surface a typo.)
+
+- [ ] **Step 3: Lint**
+
+Run: `npm run lint`
+Expected: 0 errors. New warnings only if pre-existing — note them but don't fix.
+
+- [ ] **Step 4: Production build**
+
+Run: `npm run build`
+Expected: succeeds without errors.
+
+- [ ] **Step 5: Browser sanity check**
+
+Run: `npm run dev`. Open http://localhost:8080/pos-sales in a real browser, then toggle DevTools mobile emulation at:
+- 320px (iPhone SE minimum width)
+- 375px (default iPhone)
+- 414px (iPhone Plus)
+- 640px (sm: breakpoint)
+- 768px (md: breakpoint)
+- 1024px (desktop)
+
+For each width, walk through:
+1. Header buttons render and don't overflow.
+2. Filter rows render and don't overflow.
+3. Sale cards' action buttons are visible without hover (on mobile).
+4. Tap each per-card action: Categorize, Split, Check impact, Edit, Delete — they all respond.
+5. Switch to Grouped view: "Check impact" is visible and tappable.
+6. Open Bulk select mode: BulkActionBar sits above the MobileTabBar.
+7. Open POSSaleDialog — footer pinned, body scrolls inside.
+
+If any breaks: note the issue + return to the relevant earlier task to fix.
+
+- [ ] **Step 6: No commit — push and open PR (handled by /dev workflow Phase 9)**
+
+This task ends the implementation plan. Phase 9 of the dev workflow takes over to push, open the PR, and walk the CI loop.
+
+---
+
+## Self-review checklist (verified by author)
+
+- [x] **Spec coverage:** Each of the 10 spec findings + the breakpoint policy + the virtualizer key bug + the dialog audit have a task. All Testing-section files map to a created test or the source-text guard.
+- [x] **Placeholder scan:** No "TBD", "TODO", "similar to", "add appropriate" — every step shows the actual code or command.
+- [x] **Type consistency:** Test mocks use `UnifiedSaleItem` cast for optional fields; no new types introduced.
+- [x] **Breakpoint policy:** Every responsive class added uses `sm:` only. The only remaining `md:` reference in the page (heading text size `text-[2.5rem]`) is pre-existing typography and out of scope.

--- a/docs/superpowers/specs/2026-05-17-pos-sales-mobile-design.md
+++ b/docs/superpowers/specs/2026-05-17-pos-sales-mobile-design.md
@@ -1,0 +1,165 @@
+# POS Sales Screen — Mobile Audit & Fixes
+
+**Date:** 2026-05-17
+**Branch:** `fix/pos-sales-mobile`
+**Scope:** UI only — no logic, hooks, state, or behavior changes.
+**Surfaces:** `/pos-sales` page + reachable dialogs (POS Sale, Split, Bulk Categorize, Category Rules).
+
+## Problem
+
+The POS sales screen (`src/pages/POSSales.tsx`) renders poorly on mobile
+viewports (< 768px). Several issues are functional, not cosmetic — most
+critically, every per-card action button is hidden behind `opacity-0
+group-hover:opacity-100`, which makes them **unreachable on touch
+devices**.
+
+## Audit findings (mobile, < 768px)
+
+### Critical (blocks task completion on touch)
+1. **`SaleCard.tsx`** — Action buttons (Categorize / Split / Check
+   impact / Create rule / Edit / Delete) are hover-only. Same for the
+   categorized-badge "Edit" link.
+2. **Grouped-view tiles** in `POSSales.tsx` — "Check impact" hover-only.
+
+### Major (overflow / poor layout)
+3. **Header action bar** (POSSales.tsx ~794-845) — 5 buttons in a
+   non-wrapping `flex` row overflow on narrow viewports.
+4. **AI Categorization card header** (~869-890) — title + long-labelled
+   button on one non-responsive row collide.
+5. **Filter row 1 — search + dates** (~952-1010) — date inputs locked at
+   `w-[150px]` × 2 + en-dash don't fit small viewports.
+6. **Filter row 2 — segmented controls + sort** (~1012-1126) — segments
+   crowd each other; "sort" cluster lands awkwardly when wrapping.
+7. **`POSSalesDashboard.tsx`** — "Synced …" timestamp uses `ml-auto`
+   inside a row whose siblings have `overflow-x-auto`; it ends up
+   overlapping the metrics on mobile.
+8. **`BulkActionBar.tsx`** — `fixed bottom-6` overlaps the staff
+   `MobileTabBar` (bottom nav) on mobile.
+9. **`POSSales.tsx` virtualized list** — `h-[600px]` creates a nested
+   scroll surface inside the page; on phones the list is too tall and
+   crowds the page-level scroll.
+
+### CLAUDE.md violations (direct color tokens)
+10. **`SplitSaleView.tsx`** — `border-l-blue-500`, `bg-blue-100
+    text-blue-800 dark:bg-blue-900 dark:text-blue-200`, `border-blue-200
+    dark:border-blue-800`. CLAUDE.md says use semantic tokens.
+
+## Approach
+
+**Tailwind responsive classes only.** Every fix is mobile-first
+responsive CSS plus semantic-token swaps in JSX. No `useIsMobile()`
+import, no hooks, no state, no behavior changes.
+
+Why not the BankTransactionList pattern (separate mobile card
+component)? The `SaleCard` is already card-shaped; the issues are
+purely class-level. A structural rewrite would expand blast radius
+beyond what the task asks for.
+
+## Changes by file
+
+### `src/pages/POSSales.tsx`
+
+| Region | Change |
+|---|---|
+| Header actions row | Outer flex gets `flex-wrap`. Vertical divider `hidden sm:block`. Secondary button labels (Sync / Rules / Import) hide on `<sm` via `<span className="hidden sm:inline">` so the icon remains; `aria-label` already present where needed. "AI Categorize Sales" label gets a shorter "AI Categorize" on `<sm`. |
+| Restaurant pill in heading | Pill uses `flex-wrap` on the inner row so it can drop to a new line on the narrowest screens; padding `px-2 sm:px-2.5`. |
+| AI Categorization card header | `flex items-center justify-between` → `flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between`. |
+| Filters row 1 (search + dates) | Date inputs `w-[150px]` → `flex-1 sm:w-[150px] sm:flex-none`. "Clear" button gets `hidden sm:inline` on its label so it's icon-only on mobile. |
+| Filters row 2 (segments + sort) | Sort cluster: `ml-auto` → `w-full sm:w-auto sm:ml-auto`. Each segmented-control inner div wraps in an `overflow-x-auto -mx-1 px-1` wrapper to prevent overflow. |
+| Virtualized list height | `h-[600px]` → `h-[calc(100dvh-180px)] min-h-[400px] sm:h-[600px]`. |
+| Grouped-view tile "Check impact" button | `opacity-0 group-hover:opacity-100` → `opacity-100 sm:opacity-0 sm:group-hover:opacity-100`. |
+
+### `src/components/pos-sales/SaleCard.tsx`
+
+| Region | Change |
+|---|---|
+| Bottom action row (line 303) | `opacity-0 group-hover:opacity-100 group-focus-within:opacity-100` → `opacity-100 md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100`. Add `flex-wrap gap-x-3 gap-y-1.5`. |
+| Categorized badge "Edit" link (line 256) | Same hover→always-on-mobile pattern. |
+| AI suggestion panel (line 192) | `flex items-center justify-between` → `flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between`. |
+| Card padding | `px-4 py-3` → `px-3 py-3 sm:px-4`. |
+| Recipe name truncation | `max-w-[120px]` → `max-w-[120px] sm:max-w-[180px]`. |
+| Right-side amount column | Add `min-w-[72px]` to prevent collision with item name on narrow widths. |
+
+### `src/components/pos-sales/SplitSaleView.tsx`
+
+| Region | Change |
+|---|---|
+| Card border colour | `border-l-blue-500` → `border-l-primary`. |
+| "Split Sale" badge | `bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200` → `bg-primary/10 text-primary`. |
+| Expanded children left border | `border-blue-200 dark:border-blue-800` → `border-primary/30`. |
+| Card padding | `p-4` → `p-3 sm:p-4`. |
+
+### `src/components/POSSalesDashboard.tsx`
+
+| Region | Change |
+|---|---|
+| Outer row container | `flex items-center gap-1` → `flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-1`. |
+| Sync timestamp | `ml-auto` only applies at `sm:` and up; on mobile it sits on its own line. |
+| Metrics scroll-row | Add `snap-x snap-mandatory` and `[&>div]:snap-start` so horizontal scroll feels native. |
+
+### `src/components/bulk-edit/BulkActionBar.tsx`
+
+| Region | Change |
+|---|---|
+| Bottom offset | `bottom-6` → `bottom-20 sm:bottom-6` (clears `MobileTabBar`). |
+| Padding | `px-6 py-4` → `px-4 py-3 sm:px-6 sm:py-4`. |
+| Vertical divider between count + actions | `hidden sm:block`. |
+
+### Dialogs (POSSaleDialog, SplitPosSaleDialog, BulkCategorizePosSalesPanel, EnhancedCategoryRulesDialog)
+
+For each, audit live in Phase 4 and apply only the mobile-blocking
+changes:
+- Verify `DialogContent` uses the sticky-footer pattern
+  (`max-h-[85vh] overflow-hidden flex flex-col`) per the existing
+  `POSSaleDialog.scroll.test.tsx` contract.
+- Two-column form rows (`grid grid-cols-2`) → `grid-cols-1 sm:grid-cols-2`.
+- Footer action rows: `flex justify-end gap-2` → add `flex-wrap`.
+- No `min-w-[NNN]` larger than 320px on inputs.
+
+If a dialog already passes all four checks, no edits required —
+documented in commit message.
+
+## Testing
+
+Pattern mirrors the existing `tests/unit/POSSaleDialog.scroll.test.tsx`:
+assert that the rendered component's `className` contains the
+responsive token strings.
+
+- `tests/unit/POSSalesMobile.test.tsx` — page-level: header actions
+  wrap, date input has `flex-1 sm:w-[150px]`, list container has
+  `min-h-[400px] sm:h-[600px]`.
+- `tests/unit/SaleCard.mobile.test.tsx` — actions row contains
+  `opacity-100 md:opacity-0`; AI suggestion panel contains
+  `flex-col sm:flex-row`.
+- `tests/unit/SplitSaleView.mobile.test.tsx` — assert NO occurrences of
+  `bg-blue-`, `border-l-blue-`, `text-blue-`, `border-blue-`,
+  `dark:bg-blue-`, `dark:text-blue-`, `dark:border-blue-` in the
+  rendered markup (semantic-token regression test).
+- `tests/unit/POSSalesDashboard.mobile.test.tsx` — outer container has
+  `flex-col sm:flex-row`.
+- `tests/unit/BulkActionBar.mobile.test.tsx` — container has
+  `bottom-20 sm:bottom-6`.
+
+No E2E changes. Existing `tests/e2e/bulk-edit-pos-sales.spec.ts` covers
+behavior.
+
+## Non-goals
+
+- No logic, hook, or state changes.
+- No new components.
+- No `useIsMobile()` introduced.
+- No restructuring of virtualizer code.
+- No dialog redesign — only mobile-blocking fixes per file.
+- No changes to the import / file-upload flow (it already works on
+  mobile per a recent design pass).
+
+## Risks
+
+- **Tailwind dvh support:** `100dvh` requires a modern browser. The
+  fallback `min-h-[400px]` ensures the list is never collapsed.
+- **`POSSaleDialog.scroll.test.tsx` regression:** Any class string we
+  edit on dialogs must keep `max-h-[85vh]`, `overflow-hidden`,
+  `flex-col`. Run the existing test before/after.
+- **Visual regressions on desktop:** Most changes are `sm:` and `md:`
+  prefixed; desktop output is unchanged. Verify locally at ≥1024px
+  before pushing.

--- a/docs/superpowers/specs/2026-05-17-pos-sales-mobile-design.md
+++ b/docs/superpowers/specs/2026-05-17-pos-sales-mobile-design.md
@@ -55,26 +55,40 @@ component)? The `SaleCard` is already card-shaped; the issues are
 purely class-level. A structural rewrite would expand blast radius
 beyond what the task asks for.
 
+## Breakpoint policy
+
+**One breakpoint for all mobile/desktop layout switches: `sm:` (640px).**
+Reviewer caught: the SaleCard action-row originally used `md:` while
+the rest of the page used `sm:`, which would have left a dead zone
+between 641–767px where action buttons were visible on cards but
+filter and header rows were still squeezed. All hover→always-on-mobile
+patterns and all `flex-col → sm:flex-row` switches use `sm:`.
+
+The single intentional exception is the inner segmented-control wrap
+behavior (handled in the filter section) — those don't switch on a
+breakpoint at all; they just flow inside `flex-wrap`.
+
 ## Changes by file
 
 ### `src/pages/POSSales.tsx`
 
 | Region | Change |
 |---|---|
-| Header actions row | Outer flex gets `flex-wrap`. Vertical divider `hidden sm:block`. Secondary button labels (Sync / Rules / Import) hide on `<sm` via `<span className="hidden sm:inline">` so the icon remains; `aria-label` already present where needed. "AI Categorize Sales" label gets a shorter "AI Categorize" on `<sm`. |
+| Header actions row | Outer flex gets `flex-wrap`. Vertical divider `hidden sm:block`. Secondary button labels (Sync / Rules / Import) hide on `<sm` via `<span className="hidden sm:inline">` so the icon remains. Each affected button gets an explicit `aria-label` (Sync: "Sync sales"; Rules: "Category rules"; Import: "Import sales"). "AI Categorize Sales" gets two spans: `<span className="hidden sm:inline">AI Categorize Sales</span><span className="sm:hidden">AI Categorize</span>`. **DOM order fix:** put the primary "Add Sale" button **first** in the JSX (with `order-last sm:order-none` so on desktop it still renders rightmost via flex `order`), so when the row wraps on narrow viewports the primary CTA stays on its own visible line. |
 | Restaurant pill in heading | Pill uses `flex-wrap` on the inner row so it can drop to a new line on the narrowest screens; padding `px-2 sm:px-2.5`. |
 | AI Categorization card header | `flex items-center justify-between` → `flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between`. |
-| Filters row 1 (search + dates) | Date inputs `w-[150px]` → `flex-1 sm:w-[150px] sm:flex-none`. "Clear" button gets `hidden sm:inline` on its label so it's icon-only on mobile. |
-| Filters row 2 (segments + sort) | Sort cluster: `ml-auto` → `w-full sm:w-auto sm:ml-auto`. Each segmented-control inner div wraps in an `overflow-x-auto -mx-1 px-1` wrapper to prevent overflow. |
-| Virtualized list height | `h-[600px]` → `h-[calc(100dvh-180px)] min-h-[400px] sm:h-[600px]`. |
-| Grouped-view tile "Check impact" button | `opacity-0 group-hover:opacity-100` → `opacity-100 sm:opacity-0 sm:group-hover:opacity-100`. |
+| Filters row 1 (search + dates) | Date inputs `w-[150px]` → `flex-1 sm:w-[150px] sm:flex-none`. "Clear" button gets `hidden sm:inline` on its label AND `aria-label="Clear filters"` so the icon-only mobile state remains accessible. |
+| Filters row 2 (segments + sort) | Sort cluster: `ml-auto` → `w-full sm:w-auto sm:ml-auto`. **Drop the per-segment `overflow-x-auto` wrapper** (reviewer flagged it would create stacked horizontal scroll surfaces). The outer container already uses `flex flex-wrap items-center gap-4` — segmented-control groups wrap to new lines naturally. The Status segments (4 chips with counts) can wrap their own internal `inline-flex` to a new line via `flex-wrap` on that wrapper only if needed; no overflow scroll. |
+| Virtualized list height | `h-[600px]` → `h-[calc(100vh-180px)] [height:calc(100dvh-180px)] min-h-[400px] sm:h-[600px]`. The arbitrary `[height:...]` form lets dvh layer over vh as a progressive enhancement; browsers that don't understand `dvh` ignore the later rule and fall back to `vh`, while `min-h-[400px]` floors the list height. Acceptable degradation on iOS 14 and earlier (the unsupported case shows up as "list slightly too tall under the URL bar," not "list collapses"). |
+| Virtualizer keys (pre-existing bug — required fix per reviewer) | Lines 1214 and 1238 use `key={virtualRow.index}` for both the split-view row and the sale-card row. CLAUDE.md explicitly mandates `key={items[virtualRow.index].id}`. Change both to `key={sale.id}`. This is a required correctness fix in the same code we're modifying. |
+| Grouped-view tile "Check impact" button | `opacity-0 group-hover:opacity-100` → `opacity-100 sm:opacity-0 sm:group-hover:opacity-100`. Add `type="button"` (button currently has no type attribute; reviewer caught the default-submit risk). |
 
 ### `src/components/pos-sales/SaleCard.tsx`
 
 | Region | Change |
 |---|---|
-| Bottom action row (line 303) | `opacity-0 group-hover:opacity-100 group-focus-within:opacity-100` → `opacity-100 md:opacity-0 md:group-hover:opacity-100 md:group-focus-within:opacity-100`. Add `flex-wrap gap-x-3 gap-y-1.5`. |
-| Categorized badge "Edit" link (line 256) | Same hover→always-on-mobile pattern. |
+| Bottom action row (line 303) | `opacity-0 group-hover:opacity-100 group-focus-within:opacity-100` → `opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100`. Add `flex-wrap gap-x-3 gap-y-1.5`. |
+| Categorized badge "Edit" link (line 256) | Same hover→always-on-mobile pattern with `sm:` prefix (per unified breakpoint policy). |
 | AI suggestion panel (line 192) | `flex items-center justify-between` → `flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between`. |
 | Card padding | `px-4 py-3` → `px-3 py-3 sm:px-4`. |
 | Recipe name truncation | `max-w-[120px]` → `max-w-[120px] sm:max-w-[180px]`. |
@@ -82,11 +96,20 @@ beyond what the task asks for.
 
 ### `src/components/pos-sales/SplitSaleView.tsx`
 
+Reviewer caught: shadcn `Badge variant="secondary"` already provides
+muted background + foreground colour. Overriding it with `bg-primary/10
+text-primary` (or any other coloured override) defeats the variant
+system and reintroduces the same anti-pattern. The fix is to **drop the
+className override entirely** and let the variant render. Same logic
+for the borders — use neutral semantic tokens consistent with the
+Apple/Notion palette (`border-border/40`), not `primary` accents that
+imply selection or "this is the chosen item."
+
 | Region | Change |
 |---|---|
-| Card border colour | `border-l-blue-500` → `border-l-primary`. |
-| "Split Sale" badge | `bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200` → `bg-primary/10 text-primary`. |
-| Expanded children left border | `border-blue-200 dark:border-blue-800` → `border-primary/30`. |
+| Card border colour | `border-l-4 border-l-blue-500` → `border-l-4 border-l-foreground/20`. Neutral semantic token; preserves the visual "this is a parent split row" affordance without colour coding. |
+| "Split Sale" badge | Drop `className="bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200"` entirely. The `<Badge variant="secondary">` already renders muted background + foreground correctly. |
+| Expanded children left border | `border-blue-200 dark:border-blue-800` → `border-border/40`. |
 | Card padding | `p-4` → `p-3 sm:p-4`. |
 
 ### `src/components/POSSalesDashboard.tsx`
@@ -95,7 +118,7 @@ beyond what the task asks for.
 |---|---|
 | Outer row container | `flex items-center gap-1` → `flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-1`. |
 | Sync timestamp | `ml-auto` only applies at `sm:` and up; on mobile it sits on its own line. |
-| Metrics scroll-row | Add `snap-x snap-mandatory` and `[&>div]:snap-start` so horizontal scroll feels native. |
+| Metrics scroll-row | No scroll-snap. Reviewer flagged: snap-mandatory on inline metric rows feels jerky on touch and conflicts with the page-level scroll. The existing `overflow-x-auto` is the only horizontal-scroll concession; metrics flow naturally. |
 
 ### `src/components/bulk-edit/BulkActionBar.tsx`
 
@@ -125,20 +148,30 @@ Pattern mirrors the existing `tests/unit/POSSaleDialog.scroll.test.tsx`:
 assert that the rendered component's `className` contains the
 responsive token strings.
 
-- `tests/unit/POSSalesMobile.test.tsx` — page-level: header actions
-  wrap, date input has `flex-1 sm:w-[150px]`, list container has
-  `min-h-[400px] sm:h-[600px]`.
-- `tests/unit/SaleCard.mobile.test.tsx` — actions row contains
-  `opacity-100 md:opacity-0`; AI suggestion panel contains
-  `flex-col sm:flex-row`.
+**Important:** assert each class as a **separate `.toContain` call**.
+Concatenated strings like `.toContain('opacity-100 md:opacity-0')`
+are fragile because Tailwind's class ordering is not guaranteed to
+match the source. Use `.toContain('opacity-100')` and
+`.toContain('sm:opacity-0')` as two distinct assertions.
+
+- `tests/unit/POSSalesMobile.test.tsx` — page-level. Header actions
+  container `.toContain('flex-wrap')`. Date input
+  `.toContain('flex-1')` and `.toContain('sm:w-[150px]')`. List
+  container `.toContain('min-h-[400px]')` and
+  `.toContain('sm:h-[600px]')`.
+- `tests/unit/SaleCard.mobile.test.tsx` — actions row
+  `.toContain('opacity-100')` and `.toContain('sm:opacity-0')` and
+  `.toContain('sm:group-hover:opacity-100')`. AI suggestion panel
+  `.toContain('flex-col')` and `.toContain('sm:flex-row')`.
 - `tests/unit/SplitSaleView.mobile.test.tsx` — assert NO occurrences of
   `bg-blue-`, `border-l-blue-`, `text-blue-`, `border-blue-`,
   `dark:bg-blue-`, `dark:text-blue-`, `dark:border-blue-` in the
-  rendered markup (semantic-token regression test).
-- `tests/unit/POSSalesDashboard.mobile.test.tsx` — outer container has
-  `flex-col sm:flex-row`.
-- `tests/unit/BulkActionBar.mobile.test.tsx` — container has
-  `bottom-20 sm:bottom-6`.
+  rendered markup (semantic-token regression test). Assert the parent
+  card container `.toContain('border-l-foreground/20')`.
+- `tests/unit/POSSalesDashboard.mobile.test.tsx` — outer container
+  `.toContain('flex-col')` and `.toContain('sm:flex-row')`.
+- `tests/unit/BulkActionBar.mobile.test.tsx` — container
+  `.toContain('bottom-20')` and `.toContain('sm:bottom-6')`.
 
 No E2E changes. Existing `tests/e2e/bulk-edit-pos-sales.spec.ts` covers
 behavior.
@@ -160,6 +193,6 @@ behavior.
 - **`POSSaleDialog.scroll.test.tsx` regression:** Any class string we
   edit on dialogs must keep `max-h-[85vh]`, `overflow-hidden`,
   `flex-col`. Run the existing test before/after.
-- **Visual regressions on desktop:** Most changes are `sm:` and `md:`
+- **Visual regressions on desktop:** Every responsive change is `sm:`
   prefixed; desktop output is unchanged. Verify locally at ≥1024px
   before pushing.

--- a/src/components/POSSaleDialog.tsx
+++ b/src/components/POSSaleDialog.tsx
@@ -531,7 +531,7 @@ export const POSSaleDialog: React.FC<POSSaleDialogProps> = ({
             />
 
             {/* Quantity and Price Row */}
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <FormField
                 control={form.control}
                 name="quantity"
@@ -610,7 +610,7 @@ export const POSSaleDialog: React.FC<POSSaleDialogProps> = ({
             />
 
             {/* Date and Time Row */}
-            <div className="grid grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <FormField
                 control={form.control}
                 name="saleDate"
@@ -662,7 +662,7 @@ export const POSSaleDialog: React.FC<POSSaleDialogProps> = ({
                   <span className="text-[11px] text-muted-foreground">Optional</span>
                 </div>
 
-                <div className="grid grid-cols-2 gap-3">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                   <FormField
                     control={form.control}
                     name="taxAmount"

--- a/src/components/POSSalesDashboard.tsx
+++ b/src/components/POSSalesDashboard.tsx
@@ -95,7 +95,7 @@ export const POSSalesDashboard = ({
   return (
     <div className="space-y-3">
       {/* Apple/Notion-style metrics row */}
-      <div className="flex items-center gap-1">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-1">
         {/* Filtered context indicator */}
         {showFilteredContext && (
           <button

--- a/src/components/banking/EnhancedCategoryRulesDialog.tsx
+++ b/src/components/banking/EnhancedCategoryRulesDialog.tsx
@@ -889,7 +889,7 @@ export const EnhancedCategoryRulesDialog = ({
                   )}
 
                   {/* Amount Range */}
-                  <div className="grid grid-cols-2 gap-4">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <div className="space-y-2">
                       <Label className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
                         Min Amount <span className="font-normal">(Optional)</span>
@@ -969,7 +969,7 @@ export const EnhancedCategoryRulesDialog = ({
                   )}
 
                   {/* Priority and Auto-apply */}
-                  <div className="grid grid-cols-2 gap-4">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                     <div className="space-y-2">
                       <Label className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
                         Priority <span className="font-normal">(higher = first)</span>

--- a/src/components/bulk-edit/BulkActionBar.tsx
+++ b/src/components/bulk-edit/BulkActionBar.tsx
@@ -37,9 +37,9 @@ export function BulkActionBar({
   return (
     <div
       className={cn(
-        "fixed bottom-6 left-1/2 -translate-x-1/2 z-50",
+        "fixed bottom-20 sm:bottom-6 left-1/2 -translate-x-1/2 z-50",
         "bg-background border border-border rounded-2xl shadow-2xl",
-        "px-6 py-4 flex items-center gap-4",
+        "px-4 py-3 sm:px-6 sm:py-4 flex items-center gap-4",
         "animate-in slide-in-from-bottom-8 duration-300",
         "max-w-[95vw] md:max-w-4xl w-full md:w-auto",
         className
@@ -64,7 +64,7 @@ export function BulkActionBar({
       </div>
 
       {/* Vertical divider */}
-      <div className="h-8 w-px bg-border flex-shrink-0" />
+      <div className="h-8 w-px bg-border flex-shrink-0 hidden sm:block" />
 
       {/* Primary actions */}
       <div className="flex items-center gap-2 flex-wrap">

--- a/src/components/bulk-edit/BulkActionBar.tsx
+++ b/src/components/bulk-edit/BulkActionBar.tsx
@@ -41,7 +41,7 @@ export function BulkActionBar({
         "bg-background border border-border rounded-2xl shadow-2xl",
         "px-4 py-3 sm:px-6 sm:py-4 flex items-center gap-4",
         "animate-in slide-in-from-bottom-8 duration-300",
-        "max-w-[95vw] md:max-w-4xl w-full md:w-auto",
+        "max-w-[95vw] sm:max-w-4xl w-full sm:w-auto",
         className
       )}
       role="toolbar"

--- a/src/components/pos-sales/SaleCard.tsx
+++ b/src/components/pos-sales/SaleCard.tsx
@@ -89,7 +89,7 @@ export const SaleCard = memo(function SaleCard({
 
   return (
     <div
-      className={`group flex items-start gap-3 px-4 py-3 border-b border-border/40 transition-colors ${
+      className={`group flex items-start gap-3 px-3 py-3 sm:px-4 border-b border-border/40 transition-colors ${
         isSelected ? 'bg-primary/5' : hasSuggestion ? 'bg-amber-500/5' : 'hover:bg-muted/30'
       } ${isSelectionMode ? 'cursor-pointer' : ''}`}
       style={style}
@@ -153,7 +153,7 @@ export const SaleCard = memo(function SaleCard({
                     <AlertTriangle className="h-3 w-3 text-amber-500" />
                   )}
                   <ExternalLink className="h-3 w-3" />
-                  <span className="truncate max-w-[120px]">{recipe.name}</span>
+                  <span className="truncate max-w-[120px] sm:max-w-[180px]">{recipe.name}</span>
                   {recipe.profitMargin != null && (
                     <span className="font-medium">({recipe.profitMargin.toFixed(0)}%)</span>
                   )}
@@ -176,7 +176,7 @@ export const SaleCard = memo(function SaleCard({
           </div>
 
           {/* Right side: Amount and quantity */}
-          <div className="text-right shrink-0">
+          <div className="text-right shrink-0 min-w-[72px]">
             {sale.totalPrice != null && (
               <p className="text-[15px] font-semibold text-foreground tabular-nums">
                 ${sale.totalPrice.toFixed(2)}
@@ -190,7 +190,7 @@ export const SaleCard = memo(function SaleCard({
 
         {/* AI suggestion panel */}
         {hasSuggestion && sale.chart_account && (
-          <div className="flex items-center justify-between gap-3 p-2.5 rounded-lg bg-amber-500/10 border border-amber-500/20">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-3 p-2.5 rounded-lg bg-amber-500/10 border border-amber-500/20">
             <div className="flex items-center gap-2 min-w-0">
               <Sparkles className="h-3.5 w-3.5 text-amber-600 dark:text-amber-400 shrink-0" />
               <span className="text-[13px] text-foreground truncate">
@@ -253,7 +253,7 @@ export const SaleCard = memo(function SaleCard({
                 e.stopPropagation();
                 onSetEditingCategory(sale.id);
               }}
-              className="text-[12px] text-muted-foreground hover:text-foreground transition-colors opacity-0 group-hover:opacity-100"
+              className="text-[12px] text-muted-foreground hover:text-foreground transition-colors opacity-100 sm:opacity-0 sm:group-hover:opacity-100"
             >
               Edit
             </button>
@@ -300,7 +300,7 @@ export const SaleCard = memo(function SaleCard({
 
         {/* Action buttons - show on hover or focus */}
         {!isEditingCategory && (
-          <div className="flex items-center gap-2 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity">
+          <div className="flex items-center flex-wrap gap-x-3 gap-y-1.5 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 transition-opacity">
             {/* Categorize button - only for items without suggestion and not categorized */}
             {!hasSuggestion && !sale.is_categorized && (
               <button

--- a/src/components/pos-sales/SaleCard.tsx
+++ b/src/components/pos-sales/SaleCard.tsx
@@ -143,6 +143,7 @@ export const SaleCard = memo(function SaleCard({
               {/* Recipe badge */}
               {recipe ? (
                 <button
+                  type="button"
                   onClick={(e) => {
                     e.stopPropagation();
                     onNavigateToRecipe(recipe.id);
@@ -160,6 +161,7 @@ export const SaleCard = memo(function SaleCard({
                 </button>
               ) : (
                 <button
+                  type="button"
                   onClick={(e) => {
                     e.stopPropagation();
                     onMapPOSItem(sale.itemName);
@@ -249,6 +251,7 @@ export const SaleCard = memo(function SaleCard({
               {sale.chart_account.account_code} · {sale.chart_account.account_name}
             </span>
             <button
+              type="button"
               onClick={(e) => {
                 e.stopPropagation();
                 onSetEditingCategory(sale.id);
@@ -304,6 +307,7 @@ export const SaleCard = memo(function SaleCard({
             {/* Categorize button - only for items without suggestion and not categorized */}
             {!hasSuggestion && !sale.is_categorized && (
               <button
+                type="button"
                 onClick={(e) => {
                   e.stopPropagation();
                   onSetEditingCategory(sale.id);
@@ -316,6 +320,7 @@ export const SaleCard = memo(function SaleCard({
             {/* Split - always available for non-split items */}
             {!sale.is_split && (
               <button
+                type="button"
                 onClick={(e) => {
                   e.stopPropagation();
                   onSplit(sale);
@@ -328,6 +333,7 @@ export const SaleCard = memo(function SaleCard({
             )}
             {/* Check impact - always available */}
             <button
+              type="button"
               onClick={(e) => {
                 e.stopPropagation();
                 onSimulateDeduction(sale.itemName, sale.quantity);
@@ -339,12 +345,12 @@ export const SaleCard = memo(function SaleCard({
             {/* Create rule - for categorized items */}
             {sale.is_categorized && (
               <button
+                type="button"
                 onClick={(e) => {
                   e.stopPropagation();
                   onSuggestRule(sale);
                 }}
                 className="inline-flex items-center text-[12px] text-muted-foreground hover:text-foreground transition-colors"
-                title="Create rule"
               >
                 <Settings2 className="h-3 w-3 mr-1" />
                 Create rule
@@ -354,6 +360,7 @@ export const SaleCard = memo(function SaleCard({
             {isManualSale && canEditManualSales && (
               <>
                 <button
+                  type="button"
                   onClick={(e) => {
                     e.stopPropagation();
                     onEdit(sale);
@@ -363,6 +370,7 @@ export const SaleCard = memo(function SaleCard({
                   Edit
                 </button>
                 <button
+                  type="button"
                   onClick={(e) => {
                     e.stopPropagation();
                     onDelete(sale.id);

--- a/src/components/pos-sales/SplitSaleView.tsx
+++ b/src/components/pos-sales/SplitSaleView.tsx
@@ -20,14 +20,14 @@ export function SplitSaleView({ sale, onEdit, onSplit, formatCurrency }: SplitSa
   const totalSplitAmount = childSplits.reduce((sum, split) => sum + (split.totalPrice || 0), 0);
 
   return (
-    <Card className="w-full transition-all hover:shadow-md border-l-4 border-l-blue-500">
-      <CardContent className="p-4 space-y-3">
+    <Card className="w-full transition-all hover:shadow-md border-l-4 border-l-foreground/20">
+      <CardContent className="p-3 sm:p-4 space-y-3">
         {/* Parent Sale Header */}
         <div className="flex items-start justify-between gap-2">
           <div className="flex-1 min-w-0">
             <div className="flex items-center gap-2 flex-wrap">
               <h4 className="font-semibold text-base">{sale.itemName}</h4>
-              <Badge variant="secondary" className="bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200">
+              <Badge variant="secondary">
                 Split Sale
               </Badge>
             </div>
@@ -76,7 +76,7 @@ export function SplitSaleView({ sale, onEdit, onSplit, formatCurrency }: SplitSa
 
         {/* Expanded Split Items */}
         {isExpanded && (
-          <div className="space-y-2 pl-4 border-l-2 border-blue-200 dark:border-blue-800">
+          <div className="space-y-2 pl-4 border-l-2 border-border/40">
             {childSplits.map((split) => (
               <div
                 key={split.id}

--- a/src/components/pos-sales/SplitSaleView.tsx
+++ b/src/components/pos-sales/SplitSaleView.tsx
@@ -3,7 +3,6 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ChevronDown, ChevronRight, Edit, Split } from "lucide-react";
-import { cn } from "@/lib/utils";
 import { UnifiedSaleItem } from "@/types/pos";
 import { format } from "date-fns";
 

--- a/src/pages/POSSales.tsx
+++ b/src/pages/POSSales.tsx
@@ -1055,7 +1055,7 @@ export default function POSSales() {
               </div>
 
               {/* Divider */}
-              <div className="h-5 w-px bg-border/60 hidden md:block" />
+              <div className="h-5 w-px bg-border/60 hidden sm:block" />
 
               {/* Recipe filter */}
               <div className="flex items-center gap-2">
@@ -1082,7 +1082,7 @@ export default function POSSales() {
               </div>
 
               {/* Divider */}
-              <div className="h-5 w-px bg-border/60 hidden md:block" />
+              <div className="h-5 w-px bg-border/60 hidden sm:block" />
 
               {/* View mode */}
               <div className="flex items-center gap-2">
@@ -1112,7 +1112,7 @@ export default function POSSales() {
               </div>
 
               {/* Sort controls */}
-              <div className="flex items-center gap-2 ml-auto">
+              <div className="flex items-center gap-2 w-full sm:w-auto sm:ml-auto">
                 <Select value={sortBy} onValueChange={(value: 'date' | 'name' | 'quantity' | 'amount') => setSortBy(value)}>
                   <SelectTrigger className="h-8 w-[120px] text-[13px] bg-transparent border-0 hover:bg-muted/50 rounded-lg">
                     <ArrowUpDown className="w-3.5 h-3.5 mr-1.5 text-muted-foreground" />

--- a/src/pages/POSSales.tsx
+++ b/src/pages/POSSales.tsx
@@ -781,7 +781,7 @@ export default function POSSales() {
               <h1 className="text-[2rem] md:text-[2.5rem] font-semibold tracking-tight text-foreground">
                 Sales
               </h1>
-              <span className="inline-flex items-center gap-1.5 px-2.5 py-1 text-xs font-medium rounded-full bg-muted text-muted-foreground">
+              <span className="inline-flex flex-wrap items-center gap-1.5 px-2 sm:px-2.5 py-1 text-xs font-medium rounded-full bg-muted text-muted-foreground">
                 <span className="h-1.5 w-1.5 rounded-full bg-green-500" />
                 {selectedRestaurant.restaurant.name}
               </span>
@@ -871,7 +871,7 @@ export default function POSSales() {
       {/* AI Categorization Section */}
       <Card className="border-border/50">
         <CardHeader>
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div className="space-y-1">
               <CardTitle className="flex items-center gap-2">
                 <Sparkles className="h-5 w-5 text-primary" />
@@ -881,13 +881,20 @@ export default function POSSales() {
                 Automatically categorize POS sales to chart of accounts
               </p>
             </div>
-            <Button 
+            <Button
               onClick={handleCategorizeClick}
               disabled={isCategorizingPending || uncategorizedSalesCount === 0}
-              className="gap-2"
+              className="gap-2 w-full sm:w-auto"
             >
               <Sparkles className="h-4 w-4" />
-              {isCategorizingPending ? "Categorizing..." : "AI Categorize Sales"}
+              {isCategorizingPending ? (
+                "Categorizing..."
+              ) : (
+                <>
+                  <span className="hidden sm:inline">AI Categorize Sales</span>
+                  <span className="sm:hidden">AI Categorize</span>
+                </>
+              )}
             </Button>
           </div>
         </CardHeader>

--- a/src/pages/POSSales.tsx
+++ b/src/pages/POSSales.tsx
@@ -843,7 +843,6 @@ export default function POSSales() {
               onExportPDF={handleExportPDF}
               isExporting={isExporting}
             />
-            <div className="hidden sm:block w-px h-5 bg-border mx-1" />
           </div>
         </div>
       </header>

--- a/src/pages/POSSales.tsx
+++ b/src/pages/POSSales.tsx
@@ -772,10 +772,10 @@ export default function POSSales() {
   }
 
   return (
-    <div className="space-y-8 md:space-y-10 max-w-[1400px] mx-auto">
+    <div className="space-y-8 sm:space-y-10 max-w-[1400px] mx-auto">
       {/* Apple/Notion-inspired Header */}
       <header className="space-y-6">
-        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="space-y-1">
             <div className="flex items-center gap-3">
               <h1 className="text-[2rem] md:text-[2.5rem] font-semibold tracking-tight text-foreground">

--- a/src/pages/POSSales.tsx
+++ b/src/pages/POSSales.tsx
@@ -1405,8 +1405,9 @@ export default function POSSales() {
                               <span className="text-muted-foreground ml-1">sales</span>
                             </div>
                             <button
+                              type="button"
                               onClick={() => handleSimulateDeduction(item.item_name, item.total_quantity)}
-                              className="ml-auto text-[12px] text-muted-foreground hover:text-foreground transition-colors opacity-0 group-hover:opacity-100"
+                              className="ml-auto text-[12px] text-muted-foreground hover:text-foreground transition-colors opacity-100 sm:opacity-0 sm:group-hover:opacity-100"
                             >
                               Check impact
                             </button>

--- a/src/pages/POSSales.tsx
+++ b/src/pages/POSSales.tsx
@@ -961,7 +961,7 @@ export default function POSSales() {
           {/* Apple/Notion-style filter bar */}
           <div className="space-y-4">
             {/* Search and date row */}
-            <div className="flex flex-col md:flex-row gap-3">
+            <div className="flex flex-col sm:flex-row gap-3">
               {/* Search input - clean Apple style */}
               <div className="relative flex-1 max-w-md">
                 <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground/60" aria-hidden="true" />
@@ -975,24 +975,24 @@ export default function POSSales() {
               </div>
 
               {/* Date range - compact */}
-              <div className="flex items-center gap-2">
-                <div className="relative">
+              <div className="flex flex-1 sm:flex-none items-center gap-2">
+                <div className="relative flex-1 sm:flex-none">
                   <Input
                     type="date"
                     value={startDate}
                     onChange={(e) => setStartDate(e.target.value)}
                     aria-label="Start date"
-                    className="h-9 w-[150px] text-[13px] bg-muted/40 border-0 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
+                    className="h-9 w-full sm:w-[150px] text-[13px] bg-muted/40 border-0 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
                   />
                 </div>
                 <span className="text-muted-foreground/50 text-sm" aria-hidden="true">–</span>
-                <div className="relative">
+                <div className="relative flex-1 sm:flex-none">
                   <Input
                     type="date"
                     value={endDate}
                     onChange={(e) => setEndDate(e.target.value)}
                     aria-label="End date"
-                    className="h-9 w-[150px] text-[13px] bg-muted/40 border-0 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
+                    className="h-9 w-full sm:w-[150px] text-[13px] bg-muted/40 border-0 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
                   />
                 </div>
               </div>
@@ -1011,10 +1011,11 @@ export default function POSSales() {
                     setSortBy('date');
                     setSortDirection('desc');
                   }}
+                  aria-label="Clear filters"
                   className="h-9 px-3 text-[13px] text-muted-foreground hover:text-foreground"
                 >
-                  <X className="h-3.5 w-3.5 mr-1" />
-                  Clear
+                  <X className="h-3.5 w-3.5 sm:mr-1" />
+                  <span className="hidden sm:inline">Clear</span>
                 </Button>
               )}
             </div>

--- a/src/pages/POSSales.tsx
+++ b/src/pages/POSSales.tsx
@@ -792,43 +792,7 @@ export default function POSSales() {
           </div>
 
           {/* Action buttons - Apple style */}
-          <div className="flex items-center gap-2">
-            {hasAnyConnectedSystem() && (
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={handleSyncSales}
-                disabled={isSyncing}
-                className="h-8 px-3 text-[13px] font-medium text-muted-foreground hover:text-foreground hover:bg-muted/80 rounded-lg transition-colors"
-              >
-                <RefreshCw className={`h-3.5 w-3.5 mr-1.5 ${isSyncing ? "animate-spin" : ""}`} />
-                {isSyncing ? "Syncing" : "Sync"}
-              </Button>
-            )}
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => setShowRulesDialog(true)}
-              className="h-8 px-3 text-[13px] font-medium text-muted-foreground hover:text-foreground hover:bg-muted/80 rounded-lg transition-colors"
-            >
-              <Settings2 className="h-3.5 w-3.5 mr-1.5" />
-              Rules
-            </Button>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => setActiveTab("import")}
-              className="h-8 px-3 text-[13px] font-medium text-muted-foreground hover:text-foreground hover:bg-muted/80 rounded-lg transition-colors"
-            >
-              <UploadIcon className="h-3.5 w-3.5 mr-1.5" />
-              Import
-            </Button>
-            <ExportDropdown
-              onExportCSV={handleExportCSV}
-              onExportPDF={handleExportPDF}
-              isExporting={isExporting}
-            />
-            <div className="w-px h-5 bg-border mx-1" />
+          <div className="flex flex-wrap items-center gap-2">
             <Button
               onClick={() => {
                 setActiveTab("manual");
@@ -836,11 +800,50 @@ export default function POSSales() {
                 setShowSaleDialog(true);
               }}
               size="sm"
-              className="h-8 px-3 text-[13px] font-medium bg-foreground text-background hover:bg-foreground/90 rounded-lg transition-colors shadow-sm"
+              className="order-last sm:order-none h-8 px-3 text-[13px] font-medium bg-foreground text-background hover:bg-foreground/90 rounded-lg transition-colors shadow-sm"
             >
               <Plus className="h-3.5 w-3.5 mr-1.5" />
               Add Sale
             </Button>
+            {hasAnyConnectedSystem() && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleSyncSales}
+                disabled={isSyncing}
+                aria-label="Sync sales"
+                className="h-8 px-3 text-[13px] font-medium text-muted-foreground hover:text-foreground hover:bg-muted/80 rounded-lg transition-colors"
+              >
+                <RefreshCw className={`h-3.5 w-3.5 sm:mr-1.5 ${isSyncing ? "animate-spin" : ""}`} />
+                <span className="hidden sm:inline">{isSyncing ? "Syncing" : "Sync"}</span>
+              </Button>
+            )}
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setShowRulesDialog(true)}
+              aria-label="Category rules"
+              className="h-8 px-3 text-[13px] font-medium text-muted-foreground hover:text-foreground hover:bg-muted/80 rounded-lg transition-colors"
+            >
+              <Settings2 className="h-3.5 w-3.5 sm:mr-1.5" />
+              <span className="hidden sm:inline">Rules</span>
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setActiveTab("import")}
+              aria-label="Import sales"
+              className="h-8 px-3 text-[13px] font-medium text-muted-foreground hover:text-foreground hover:bg-muted/80 rounded-lg transition-colors"
+            >
+              <UploadIcon className="h-3.5 w-3.5 sm:mr-1.5" />
+              <span className="hidden sm:inline">Import</span>
+            </Button>
+            <ExportDropdown
+              onExportCSV={handleExportCSV}
+              onExportPDF={handleExportPDF}
+              isExporting={isExporting}
+            />
+            <div className="hidden sm:block w-px h-5 bg-border mx-1" />
           </div>
         </div>
       </header>

--- a/src/pages/POSSales.tsx
+++ b/src/pages/POSSales.tsx
@@ -778,7 +778,7 @@ export default function POSSales() {
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="space-y-1">
             <div className="flex items-center gap-3">
-              <h1 className="text-[2rem] md:text-[2.5rem] font-semibold tracking-tight text-foreground">
+              <h1 className="text-[2rem] sm:text-[2.5rem] font-semibold tracking-tight text-foreground">
                 Sales
               </h1>
               <span className="inline-flex flex-wrap items-center gap-1.5 px-2 sm:px-2.5 py-1 text-xs font-medium rounded-full bg-muted text-muted-foreground">

--- a/src/pages/POSSales.tsx
+++ b/src/pages/POSSales.tsx
@@ -1205,7 +1205,7 @@ export default function POSSales() {
                   {/* Virtualized list container - Apple-style clean scrolling */}
                   <div
                     ref={salesListRef}
-                    className="h-[600px] overflow-auto rounded-xl border border-border/40 bg-background"
+                    className="h-[calc(100vh-180px)] [height:calc(100dvh-180px)] min-h-[400px] sm:h-[600px] overflow-auto rounded-xl border border-border/40 bg-background"
                   >
                     <div
                       style={{
@@ -1222,7 +1222,7 @@ export default function POSSales() {
                         if (sale.is_split && sale.child_splits && sale.child_splits.length > 0) {
                           return (
                             <div
-                              key={virtualRow.index}
+                              key={sale.id}
                               data-index={virtualRow.index}
                               ref={salesVirtualizer.measureElement}
                               style={{
@@ -1246,7 +1246,7 @@ export default function POSSales() {
                         // Regular sale card (non-split) - using extracted SaleCard component
                         return (
                           <div
-                            key={virtualRow.index}
+                            key={sale.id}
                             data-index={virtualRow.index}
                             ref={salesVirtualizer.measureElement}
                             style={{

--- a/tests/unit/BulkActionBar.mobile.test.tsx
+++ b/tests/unit/BulkActionBar.mobile.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { render } from '@testing-library/react';
+import { BulkActionBar } from '@/components/bulk-edit/BulkActionBar';
+
+describe('BulkActionBar — mobile clearance', () => {
+  it('sits above the MobileTabBar on mobile (bottom-20), reverts at sm+', () => {
+    const { container } = render(
+      <BulkActionBar
+        selectedCount={3}
+        onClose={() => {}}
+        actions={[{ label: 'Delete', onClick: () => {} }]}
+      />,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toMatch(/\bbottom-20\b/);
+    expect(root.className).toMatch(/\bsm:bottom-6\b/);
+  });
+
+  it('uses tighter padding on mobile, normal at sm+', () => {
+    const { container } = render(
+      <BulkActionBar
+        selectedCount={3}
+        onClose={() => {}}
+        actions={[{ label: 'Delete', onClick: () => {} }]}
+      />,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toMatch(/\bpx-4\b/);
+    expect(root.className).toMatch(/\bpy-3\b/);
+    expect(root.className).toMatch(/\bsm:px-6\b/);
+    expect(root.className).toMatch(/\bsm:py-4\b/);
+  });
+
+  it('hides the vertical divider on mobile', () => {
+    const { container } = render(
+      <BulkActionBar
+        selectedCount={3}
+        onClose={() => {}}
+        actions={[{ label: 'Delete', onClick: () => {} }]}
+      />,
+    );
+    const divider = container.querySelector('.bg-border.flex-shrink-0');
+    expect(divider).not.toBeNull();
+    expect(divider?.className).toMatch(/\bhidden\b/);
+    expect(divider?.className).toMatch(/\bsm:block\b/);
+  });
+});

--- a/tests/unit/BulkActionBar.mobile.test.tsx
+++ b/tests/unit/BulkActionBar.mobile.test.tsx
@@ -40,7 +40,7 @@ describe('BulkActionBar — mobile clearance', () => {
         actions={[{ label: 'Delete', onClick: () => {} }]}
       />,
     );
-    const divider = container.querySelector('.bg-border.flex-shrink-0');
+    const divider = container.querySelector('div.h-8.w-px.bg-border');
     expect(divider).not.toBeNull();
     expect(divider?.className).toMatch(/\bhidden\b/);
     expect(divider?.className).toMatch(/\bsm:block\b/);

--- a/tests/unit/BulkActionBar.mobile.test.tsx
+++ b/tests/unit/BulkActionBar.mobile.test.tsx
@@ -45,4 +45,20 @@ describe('BulkActionBar — mobile clearance', () => {
     expect(divider?.className).toMatch(/\bhidden\b/);
     expect(divider?.className).toMatch(/\bsm:block\b/);
   });
+
+  it('width and max-width switch at sm: (not md:)', () => {
+    const { container } = render(
+      <BulkActionBar
+        selectedCount={3}
+        onClose={() => {}}
+        actions={[{ label: 'Delete', onClick: () => {} }]}
+      />,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toMatch(/\bw-full\b/);
+    expect(root.className).toMatch(/\bsm:w-auto\b/);
+    expect(root.className).toMatch(/\bsm:max-w-4xl\b/);
+    expect(root.className).not.toMatch(/\bmd:w-auto\b/);
+    expect(root.className).not.toMatch(/\bmd:max-w-4xl\b/);
+  });
 });

--- a/tests/unit/POSSalesDashboard.mobile.test.tsx
+++ b/tests/unit/POSSalesDashboard.mobile.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { render } from '@testing-library/react';
+import { POSSalesDashboard } from '@/components/POSSalesDashboard';
+
+const baseProps = {
+  totalSales: 100,
+  totalRevenue: 1000,
+  discounts: 0,
+  voids: 0,
+  passThroughAmount: 0,
+  collectedAtPOS: 1000,
+  uniqueItems: 25,
+  unmappedCount: 0,
+  lastSyncTime: '2026-05-17T12:00:00Z',
+  contextCueVisible: false,
+  cuePinned: false,
+  onToggleCuePin: () => {},
+  contextDescription: '',
+  highlightToken: 0,
+  filtersActive: false,
+  isLoading: false,
+};
+
+describe('POSSalesDashboard — mobile layout', () => {
+  it('outer row stacks on mobile, switches to flex-row at sm+', () => {
+    const { container } = render(<POSSalesDashboard {...baseProps} />);
+    const html = container.innerHTML;
+    expect(html).toMatch(/\bflex-col\b/);
+    expect(html).toMatch(/\bsm:flex-row\b/);
+    expect(html).toMatch(/\bsm:items-center\b/);
+  });
+});

--- a/tests/unit/POSSalesDashboard.mobile.test.tsx
+++ b/tests/unit/POSSalesDashboard.mobile.test.tsx
@@ -25,9 +25,11 @@ const baseProps = {
 describe('POSSalesDashboard — mobile layout', () => {
   it('outer row stacks on mobile, switches to flex-row at sm+', () => {
     const { container } = render(<POSSalesDashboard {...baseProps} />);
-    const html = container.innerHTML;
-    expect(html).toMatch(/\bflex-col\b/);
-    expect(html).toMatch(/\bsm:flex-row\b/);
-    expect(html).toMatch(/\bsm:items-center\b/);
+    const outerRow = container.querySelector('[class*="sm:flex-row"]');
+    expect(outerRow).not.toBeNull();
+    const className = outerRow?.className ?? '';
+    expect(className).toMatch(/\bflex-col\b/);
+    expect(className).toMatch(/\bsm:flex-row\b/);
+    expect(className).toMatch(/\bsm:items-center\b/);
   });
 });

--- a/tests/unit/POSSalesMobile.source.test.ts
+++ b/tests/unit/POSSalesMobile.source.test.ts
@@ -19,6 +19,11 @@ describe('POSSales — mobile responsive tokens stay in source', () => {
     expect(SOURCE).not.toMatch(/flex flex-col gap-4 md:flex-row/);
   });
 
+  it('h1 title size scales at sm: not md:', () => {
+    expect(SOURCE).toContain('text-[2rem] sm:text-[2.5rem]');
+    expect(SOURCE).not.toMatch(/text-\[2rem\] md:text-\[2\.5rem\]/);
+  });
+
   it('Add Sale uses order-last sm:order-none for wrap behavior', () => {
     expect(SOURCE).toContain('order-last sm:order-none');
   });

--- a/tests/unit/POSSalesMobile.source.test.ts
+++ b/tests/unit/POSSalesMobile.source.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const SOURCE = readFileSync(
+  resolve(__dirname, '../../src/pages/POSSales.tsx'),
+  'utf8',
+);
+
+describe('POSSales — mobile responsive tokens stay in source', () => {
+  it('header actions container is flex-wrap', () => {
+    expect(SOURCE).toContain('flex flex-wrap items-center gap-2');
+  });
+
+  it('Add Sale uses order-last sm:order-none for wrap behavior', () => {
+    expect(SOURCE).toContain('order-last sm:order-none');
+  });
+
+  it('Sync/Rules/Import buttons have aria-label', () => {
+    expect(SOURCE).toContain('aria-label="Sync sales"');
+    expect(SOURCE).toContain('aria-label="Category rules"');
+    expect(SOURCE).toContain('aria-label="Import sales"');
+  });
+
+  it('Clear filters button has aria-label', () => {
+    expect(SOURCE).toContain('aria-label="Clear filters"');
+  });
+
+  it('AI Categorize button has two-span label swap', () => {
+    expect(SOURCE).toContain('AI Categorize Sales');
+    expect(SOURCE).toContain('>AI Categorize<');
+  });
+
+  it('date input wrappers flex on mobile, fixed at sm+', () => {
+    expect(SOURCE).toContain('flex flex-1 sm:flex-none items-center gap-2');
+    expect(SOURCE).toContain('relative flex-1 sm:flex-none');
+  });
+
+  it('date inputs are full-width on mobile, fixed 150px at sm+', () => {
+    expect(SOURCE).toContain('h-9 w-full sm:w-[150px]');
+  });
+
+  it('filter row 1 uses sm: breakpoint (not md:)', () => {
+    expect(SOURCE).toContain('flex flex-col sm:flex-row gap-3');
+  });
+
+  it('filter row 2 dividers use sm: not md:', () => {
+    expect(SOURCE).not.toMatch(/h-5 w-px bg-border\/60 hidden md:block/);
+    expect(SOURCE).toContain('h-5 w-px bg-border/60 hidden sm:block');
+  });
+
+  it('sort cluster full-width on mobile', () => {
+    expect(SOURCE).toContain('w-full sm:w-auto sm:ml-auto');
+  });
+
+  it('virtualized list height uses dvh progressive enhancement', () => {
+    expect(SOURCE).toContain('h-[calc(100vh-180px)]');
+    expect(SOURCE).toContain('[height:calc(100dvh-180px)]');
+    expect(SOURCE).toContain('min-h-[400px]');
+    expect(SOURCE).toContain('sm:h-[600px]');
+  });
+
+  it('virtualizer keys use sale.id (not index)', () => {
+    expect(SOURCE).not.toMatch(/key=\{virtualRow\.index\}/);
+    const saleIdKeyMatches = SOURCE.match(/key=\{sale\.id\}/g) || [];
+    expect(saleIdKeyMatches.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('grouped-view Check impact is mobile-visible and has type=button', () => {
+    expect(SOURCE).toContain('opacity-100 sm:opacity-0 sm:group-hover:opacity-100');
+    expect(SOURCE).toMatch(/type="button"[\s\S]*?onClick=\{\(\) => handleSimulateDeduction/);
+  });
+
+  it('AI Categorization card header stacks on mobile', () => {
+    expect(SOURCE).toContain('flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between');
+  });
+
+  it('restaurant pill flex-wraps inside the heading', () => {
+    expect(SOURCE).toContain('inline-flex flex-wrap items-center gap-1.5 px-2 sm:px-2.5');
+  });
+});

--- a/tests/unit/POSSalesMobile.source.test.ts
+++ b/tests/unit/POSSalesMobile.source.test.ts
@@ -12,6 +12,13 @@ describe('POSSales — mobile responsive tokens stay in source', () => {
     expect(SOURCE).toContain('flex flex-wrap items-center gap-2');
   });
 
+  it('outer page wrapper + header row use sm: not md:', () => {
+    expect(SOURCE).toContain('space-y-8 sm:space-y-10');
+    expect(SOURCE).toContain('flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between');
+    expect(SOURCE).not.toMatch(/space-y-8 md:space-y-10/);
+    expect(SOURCE).not.toMatch(/flex flex-col gap-4 md:flex-row/);
+  });
+
   it('Add Sale uses order-last sm:order-none for wrap behavior', () => {
     expect(SOURCE).toContain('order-last sm:order-none');
   });

--- a/tests/unit/SaleCard.mobile.test.tsx
+++ b/tests/unit/SaleCard.mobile.test.tsx
@@ -106,4 +106,17 @@ describe('SaleCard — mobile responsive classes', () => {
     expect(editBtn!.className).toContain('sm:opacity-0');
     expect(editBtn!.className).toContain('sm:group-hover:opacity-100');
   });
+
+  it('action-row buttons all have type="button" to prevent form-submit defaulting', () => {
+    const { container } = render(<SaleCard {...baseProps} />);
+    // The action-row labels visible on a non-categorized, non-suggestion, manual sale
+    const labels = ['Categorize', 'Split', 'Check impact', 'Edit', 'Delete'];
+    for (const label of labels) {
+      const btn = Array.from(container.querySelectorAll('button')).find(
+        (b) => b.textContent?.trim() === label,
+      ) as HTMLButtonElement | undefined;
+      expect(btn, `button "${label}" should exist`).toBeDefined();
+      expect(btn!.type, `button "${label}" should have type="button"`).toBe('button');
+    }
+  });
 });

--- a/tests/unit/SaleCard.mobile.test.tsx
+++ b/tests/unit/SaleCard.mobile.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { SaleCard, SaleCardProps } from '@/components/pos-sales/SaleCard';
+import { UnifiedSaleItem } from '@/types/pos';
+
+const noop = () => {};
+
+const baseSale: UnifiedSaleItem = {
+  id: 'sale-1',
+  itemName: 'Test Burger',
+  quantity: 1,
+  totalPrice: 12.5,
+  saleDate: '2026-05-17',
+  saleTime: '12:34',
+  posSystem: 'manual',
+  externalOrderId: 'ord-1',
+  is_categorized: false,
+  is_split: false,
+} as UnifiedSaleItem;
+
+const baseProps: SaleCardProps = {
+  sale: baseSale,
+  recipe: null,
+  isSelected: false,
+  isSelectionMode: false,
+  isEditingCategory: false,
+  accounts: [],
+  canEditManualSales: true,
+  onCardClick: noop,
+  onCheckboxChange: noop,
+  onEdit: noop,
+  onDelete: noop,
+  onSimulateDeduction: noop,
+  onMapPOSItem: noop,
+  onSetEditingCategory: noop,
+  onSplit: noop,
+  onSuggestRule: noop,
+  onCategorize: noop,
+  onNavigateToRecipe: noop,
+};
+
+describe('SaleCard — mobile responsive classes', () => {
+  it('action row is always visible on mobile, hover-only at sm+', () => {
+    const { container } = render(<SaleCard {...baseProps} />);
+    const html = container.innerHTML;
+    expect(html).toContain('opacity-100');
+    expect(html).toContain('sm:opacity-0');
+    expect(html).toContain('sm:group-hover:opacity-100');
+  });
+
+  it('card padding uses px-3 on mobile and sm:px-4 at sm+', () => {
+    const { container } = render(<SaleCard {...baseProps} />);
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.className).toContain('px-3');
+    expect(root.className).toContain('sm:px-4');
+  });
+
+  it('recipe name truncation widens at sm+', () => {
+    const { container } = render(
+      <SaleCard
+        {...baseProps}
+        recipe={{ id: 'r-1', name: 'Cheeseburger Recipe', hasIngredients: true }}
+      />,
+    );
+    const html = container.innerHTML;
+    expect(html).toContain('max-w-[120px]');
+    expect(html).toContain('sm:max-w-[180px]');
+  });
+
+  it('right-side amount column has min-w-[72px]', () => {
+    const { container } = render(<SaleCard {...baseProps} />);
+    expect(container.innerHTML).toContain('min-w-[72px]');
+  });
+
+  it('AI suggestion panel switches from flex-col to sm:flex-row', () => {
+    const saleWithSuggestion: UnifiedSaleItem = {
+      ...baseSale,
+      suggested_category_id: 'cat-1',
+      chart_account: { id: 'acc-1', account_name: 'Food', account_code: '4000' } as any,
+    } as UnifiedSaleItem;
+    const { container } = render(<SaleCard {...baseProps} sale={saleWithSuggestion} />);
+    const html = container.innerHTML;
+    expect(html).toContain('flex-col');
+    expect(html).toContain('sm:flex-row');
+  });
+
+  it('categorized badge Edit link is always visible on mobile', () => {
+    const categorizedSale: UnifiedSaleItem = {
+      ...baseSale,
+      is_categorized: true,
+      chart_account: { id: 'acc-1', account_name: 'Food', account_code: '4000' } as any,
+    } as UnifiedSaleItem;
+    const { container } = render(<SaleCard {...baseProps} sale={categorizedSale} />);
+    const html = container.innerHTML;
+    expect(html).toContain('opacity-100');
+    expect(html).toContain('sm:opacity-0');
+  });
+});

--- a/tests/unit/SaleCard.mobile.test.tsx
+++ b/tests/unit/SaleCard.mobile.test.tsx
@@ -82,7 +82,7 @@ describe('SaleCard — mobile responsive classes', () => {
     const saleWithSuggestion: UnifiedSaleItem = {
       ...baseSale,
       suggested_category_id: 'cat-1',
-      chart_account: { id: 'acc-1', account_name: 'Food', account_code: '4000' } as any,
+      chart_account: { id: 'acc-1', account_name: 'Food', account_code: '4000' },
     } as UnifiedSaleItem;
     const { container } = render(<SaleCard {...baseProps} sale={saleWithSuggestion} />);
     const html = container.innerHTML;
@@ -94,7 +94,7 @@ describe('SaleCard — mobile responsive classes', () => {
     const categorizedSale: UnifiedSaleItem = {
       ...baseSale,
       is_categorized: true,
-      chart_account: { id: 'acc-1', account_name: 'Food', account_code: '4000' } as any,
+      chart_account: { id: 'acc-1', account_name: 'Food', account_code: '4000' },
     } as UnifiedSaleItem;
     const { container } = render(<SaleCard {...baseProps} sale={categorizedSale} />);
     // Target the Edit button specifically (the small button inside the categorized badge block)

--- a/tests/unit/SaleCard.mobile.test.tsx
+++ b/tests/unit/SaleCard.mobile.test.tsx
@@ -43,10 +43,15 @@ const baseProps: SaleCardProps = {
 describe('SaleCard — mobile responsive classes', () => {
   it('action row is always visible on mobile, hover-only at sm+', () => {
     const { container } = render(<SaleCard {...baseProps} />);
-    const html = container.innerHTML;
-    expect(html).toContain('opacity-100');
-    expect(html).toContain('sm:opacity-0');
-    expect(html).toContain('sm:group-hover:opacity-100');
+    // Target the action-row div specifically — it's the unique element carrying
+    // sm:group-hover:opacity-100 in this component.
+    const actionRow = container.querySelector(
+      '[class*="sm:group-hover:opacity-100"]',
+    ) as HTMLElement | null;
+    expect(actionRow).not.toBeNull();
+    expect(actionRow!.className).toContain('opacity-100');
+    expect(actionRow!.className).toContain('sm:opacity-0');
+    expect(actionRow!.className).toContain('sm:group-hover:opacity-100');
   });
 
   it('card padding uses px-3 on mobile and sm:px-4 at sm+', () => {
@@ -92,8 +97,13 @@ describe('SaleCard — mobile responsive classes', () => {
       chart_account: { id: 'acc-1', account_name: 'Food', account_code: '4000' } as any,
     } as UnifiedSaleItem;
     const { container } = render(<SaleCard {...baseProps} sale={categorizedSale} />);
-    const html = container.innerHTML;
-    expect(html).toContain('opacity-100');
-    expect(html).toContain('sm:opacity-0');
+    // Target the Edit button specifically (the small button inside the categorized badge block)
+    const editBtn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent?.trim() === 'Edit',
+    ) as HTMLButtonElement | undefined;
+    expect(editBtn).toBeDefined();
+    expect(editBtn!.className).toContain('opacity-100');
+    expect(editBtn!.className).toContain('sm:opacity-0');
+    expect(editBtn!.className).toContain('sm:group-hover:opacity-100');
   });
 });

--- a/tests/unit/SplitSaleView.mobile.test.tsx
+++ b/tests/unit/SplitSaleView.mobile.test.tsx
@@ -15,8 +15,8 @@ const splitSale: UnifiedSaleItem = {
   externalOrderId: 'ord-1',
   is_split: true,
   child_splits: [
-    { id: 'child-1', itemName: 'Burger', totalPrice: 15 } as any,
-    { id: 'child-2', itemName: 'Fries', totalPrice: 10 } as any,
+    { id: 'child-1', itemName: 'Burger', totalPrice: 15 } as unknown as UnifiedSaleItem,
+    { id: 'child-2', itemName: 'Fries', totalPrice: 10 } as unknown as UnifiedSaleItem,
   ],
 } as UnifiedSaleItem;
 

--- a/tests/unit/SplitSaleView.mobile.test.tsx
+++ b/tests/unit/SplitSaleView.mobile.test.tsx
@@ -68,7 +68,7 @@ describe('SplitSaleView — semantic tokens only (no direct blue colors)', () =>
         formatCurrency={(n) => `$${n.toFixed(2)}`}
       />,
     );
-    expect(container.innerHTML).toContain('p-3');
-    expect(container.innerHTML).toContain('sm:p-4');
+    expect(container.innerHTML).toMatch(/\bp-3\b/);
+    expect(container.innerHTML).toMatch(/\bsm:p-4\b/);
   });
 });

--- a/tests/unit/SplitSaleView.mobile.test.tsx
+++ b/tests/unit/SplitSaleView.mobile.test.tsx
@@ -4,21 +4,32 @@ import { render, fireEvent } from '@testing-library/react';
 import { SplitSaleView } from '@/components/pos-sales/SplitSaleView';
 import { UnifiedSaleItem } from '@/types/pos';
 
-const splitSale: UnifiedSaleItem = {
+function makeSale(overrides: Partial<UnifiedSaleItem>): UnifiedSaleItem {
+  return {
+    id: 'sale-x',
+    restaurantId: 'rest-1',
+    posSystem: 'toast',
+    externalOrderId: 'ord-1',
+    itemName: 'Item',
+    quantity: 1,
+    saleDate: '2026-05-17',
+    syncedAt: '2026-05-17T12:34:00Z',
+    createdAt: '2026-05-17T12:34:00Z',
+    ...overrides,
+  };
+}
+
+const splitSale: UnifiedSaleItem = makeSale({
   id: 'parent-1',
   itemName: 'Combo Meal',
-  quantity: 1,
   totalPrice: 25,
-  saleDate: '2026-05-17',
   saleTime: '12:34',
-  posSystem: 'toast',
-  externalOrderId: 'ord-1',
   is_split: true,
   child_splits: [
-    { id: 'child-1', itemName: 'Burger', totalPrice: 15 } as unknown as UnifiedSaleItem,
-    { id: 'child-2', itemName: 'Fries', totalPrice: 10 } as unknown as UnifiedSaleItem,
+    makeSale({ id: 'child-1', itemName: 'Burger', totalPrice: 15 }),
+    makeSale({ id: 'child-2', itemName: 'Fries', totalPrice: 10 }),
   ],
-} as UnifiedSaleItem;
+});
 
 describe('SplitSaleView — semantic tokens only (no direct blue colors)', () => {
   it('contains no direct blue color tokens', () => {

--- a/tests/unit/SplitSaleView.mobile.test.tsx
+++ b/tests/unit/SplitSaleView.mobile.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import { SplitSaleView } from '@/components/pos-sales/SplitSaleView';
+import { UnifiedSaleItem } from '@/types/pos';
+
+const splitSale: UnifiedSaleItem = {
+  id: 'parent-1',
+  itemName: 'Combo Meal',
+  quantity: 1,
+  totalPrice: 25,
+  saleDate: '2026-05-17',
+  saleTime: '12:34',
+  posSystem: 'toast',
+  externalOrderId: 'ord-1',
+  is_split: true,
+  child_splits: [
+    { id: 'child-1', itemName: 'Burger', totalPrice: 15 } as any,
+    { id: 'child-2', itemName: 'Fries', totalPrice: 10 } as any,
+  ],
+} as UnifiedSaleItem;
+
+describe('SplitSaleView — semantic tokens only (no direct blue colors)', () => {
+  it('contains no direct blue color tokens', () => {
+    const { container } = render(
+      <SplitSaleView
+        sale={splitSale}
+        formatCurrency={(n) => `$${n.toFixed(2)}`}
+      />,
+    );
+    const html = container.innerHTML;
+    expect(html).not.toMatch(/\bbg-blue-/);
+    expect(html).not.toMatch(/\btext-blue-/);
+    expect(html).not.toMatch(/\bborder-blue-/);
+    expect(html).not.toMatch(/\bborder-l-blue-/);
+    expect(html).not.toMatch(/dark:bg-blue-/);
+    expect(html).not.toMatch(/dark:text-blue-/);
+    expect(html).not.toMatch(/dark:border-blue-/);
+  });
+
+  it('uses neutral semantic left border on the card', () => {
+    const { container } = render(
+      <SplitSaleView
+        sale={splitSale}
+        formatCurrency={(n) => `$${n.toFixed(2)}`}
+      />,
+    );
+    expect(container.innerHTML).toContain('border-l-foreground/20');
+  });
+
+  it('uses semantic border on expanded children container', () => {
+    const { container } = render(
+      <SplitSaleView
+        sale={splitSale}
+        formatCurrency={(n) => `$${n.toFixed(2)}`}
+      />,
+    );
+    // toggle expansion (fireEvent wraps in act so state flushes)
+    const toggle = container.querySelector('button');
+    if (toggle) fireEvent.click(toggle);
+    expect(container.innerHTML).toContain('border-border/40');
+  });
+
+  it('card padding tightens on mobile (p-3 sm:p-4)', () => {
+    const { container } = render(
+      <SplitSaleView
+        sale={splitSale}
+        formatCurrency={(n) => `$${n.toFixed(2)}`}
+      />,
+    );
+    expect(container.innerHTML).toContain('p-3');
+    expect(container.innerHTML).toContain('sm:p-4');
+  });
+});


### PR DESCRIPTION
## Summary

- Audit found the POS Sales screen (and its dialogs/components) cramped, clipped, and hard to interact with on mobile viewports.
- Tailwind-only mobile-responsive pass: every breakpoint switch standardized on `sm:` (640px). Action buttons stay reachable on touch, filter/header rows stack cleanly, dialogs collapse two-column form rows on narrow viewports, virtualized list height uses `dvh` progressive enhancement.
- **UI only** — no logic, hook, state, or data-flow changes. One latent correctness fix folded in (`virtualizer key={virtualRow.index}` → `key={sale.id}` per CLAUDE.md mandate) on lines already being modified.

## What changed

| Area | Change |
| --- | --- |
| `SaleCard.tsx` | Action row visible on mobile (hover-only at `sm:+`), responsive padding `px-3 sm:px-4`, recipe name truncation widens at `sm:+`, AI suggestion panel stacks `flex-col` on mobile, categorized-badge Edit link reachable on touch, all 9 plain `<button>` get `type="button"` |
| `SplitSaleView.tsx` | Direct blue colors → semantic tokens (`border-l-foreground/20`, Badge `variant="secondary"`), padding `p-3 sm:p-4` |
| `POSSalesDashboard.tsx` | Outer row stacks `flex-col` on mobile |
| `BulkActionBar.tsx` | Clears MobileTabBar (`bottom-20 sm:bottom-6`), tighter mobile padding, divider hidden on mobile, width/max-width breakpoint standardized to `sm:` |
| `POSSales.tsx` header | Add Sale button DOM-first with `order-last sm:order-none`, container `flex-wrap`, icon-only buttons gain `aria-label` + responsive label swap, h1 size scales at `sm:` not `md:` |
| `POSSales.tsx` AI card | Header stacks `flex-col` on mobile, restaurant pill flex-wraps, AI Categorize button full-width on mobile |
| `POSSales.tsx` filters | Filter row 1 stacks, date inputs full-width on mobile fixed 150px at `sm:+`, Clear button gains `aria-label` + hidden label, dividers `hidden sm:block`, sort cluster full-width on mobile |
| `POSSales.tsx` virtualized list | Height `h-[calc(100vh-180px)] [height:calc(100dvh-180px)] min-h-[400px] sm:h-[600px]`, virtualizer key fixed to `sale.id` |
| `POSSales.tsx` grouped view | Check impact reachable on touch with `type="button"` |
| `POSSaleDialog.tsx`, `EnhancedCategoryRulesDialog.tsx` | Two-column form rows collapse `grid-cols-1 sm:grid-cols-2` on mobile |

## Workflow

Followed full `/dev` workflow on `fix/pos-sales-mobile`:
1. Phase 2 design doc + Phase 2.5 frontend-design-reviewer
2. Phase 3 plan (13 tasks)
3. Phase 4 TDD build (subagent-driven, 13 tasks)
4. Phase 5 UI review (4 Major fixed)
5. Phase 6 simplifier (2 small cleanups)
6. Phase 7a 4 parallel reviewers (security, perf, maint, sound-logic) + Codex (CLI not installed → skipped)
7. Phase 7c CodeRabbit local CLI (1 Major folded, iter 2 clean)
8. Phase 8 local verify: 3932 tests pass, typecheck 0, lint 0, build 0

## Test plan

- [ ] Visit `/pos-sales` on a 375×667 viewport (iPhone SE): header buttons wrap, Add Sale appears at the bottom-right of the wrapped group, icon-only buttons show no labels
- [ ] Filter row 1 stacks vertically; date inputs stretch full-width
- [ ] Tap a sale card row: action buttons (Categorize, Split, Check impact, Edit, Delete) are immediately visible without hover
- [ ] Tap "Check impact" in grouped view: opens deduction dialog without first hovering
- [ ] Bulk-select 2 sales: BulkActionBar sits above the mobile tab bar without overlap
- [ ] Open AI Categorize card: button stretches full-width on mobile, header stacks
- [ ] Open POSSaleDialog and EnhancedCategoryRulesDialog: two-column form rows collapse to single-column at viewports <640px
- [ ] At ≥640px, all the above revert to the desktop hover/two-column patterns
- [ ] Verify split sales no longer show blue indent border — neutral semantic token instead
- [ ] Long sales list scrolls smoothly with virtualized rendering; no key-warning in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)