### PR TITLE
fix(prod): create missing user_has_restaurant_access helper

### DIFF
--- a/supabase/migrations/20260521222200_create_user_has_restaurant_access_helper.sql
+++ b/supabase/migrations/20260521222200_create_user_has_restaurant_access_helper.sql
@@ -1,0 +1,41 @@
+-- create_user_has_restaurant_access_helper
+--
+-- Hotfix: the earlier migration 20251123100050_create_availability_tables.sql
+-- (which defined this helper) was authored before our Supabase migration
+-- pipeline was in place, so it never ran against production. Production was
+-- bootstrapped via the Supabase SQL editor with inlined RLS checks instead.
+--
+-- 20260521133930_bulk_set_employee_availability.sql calls
+-- public.user_has_restaurant_access(p_restaurant_id, true). Without this
+-- helper present in production, the RPC fails at call time with
+--   42883 function public.user_has_restaurant_access(uuid, boolean) does not exist
+--
+-- This migration is purely additive: CREATE OR REPLACE is idempotent both
+-- locally (where the function already exists with this signature) and in
+-- production (where it doesn't exist yet). Definition matches the original
+-- in 20251123100050_create_availability_tables.sql exactly, with the addition
+-- of an explicit SET search_path = public (Supabase security advisor).
+
+CREATE OR REPLACE FUNCTION public.user_has_restaurant_access(
+  p_restaurant_id        UUID,
+  p_require_manager_role BOOLEAN DEFAULT false
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  RETURN EXISTS (
+    SELECT 1
+    FROM user_restaurants
+    WHERE user_restaurants.restaurant_id = p_restaurant_id
+      AND user_restaurants.user_id       = auth.uid()
+      AND (
+        NOT p_require_manager_role
+        OR user_restaurants.role IN ('owner', 'manager')
+      )
+  );
+END;
+$$;

--- a/supabase/tests/user_has_restaurant_access.test.sql
+++ b/supabase/tests/user_has_restaurant_access.test.sql
@@ -1,0 +1,69 @@
+-- pgTAP tests for public.user_has_restaurant_access(uuid, boolean)
+--
+-- Regression coverage for the 2026-05-21 production hotfix: ensures the helper
+-- exists with the two-arg signature expected by callers
+-- (bulk_set_employee_availability, RLS policies, future code).
+
+BEGIN;
+SELECT plan(6);
+
+-- 1. Function exists with the expected (uuid, boolean) signature in public.
+SELECT has_function(
+  'public',
+  'user_has_restaurant_access',
+  ARRAY['uuid', 'boolean'],
+  'user_has_restaurant_access(uuid, boolean) exists in public schema'
+);
+
+-- 2. Returns BOOLEAN.
+SELECT function_returns(
+  'public',
+  'user_has_restaurant_access',
+  ARRAY['uuid', 'boolean'],
+  'boolean',
+  'user_has_restaurant_access returns boolean'
+);
+
+-- 3. Defined SECURITY DEFINER (callable from RLS-protected contexts).
+SELECT ok(
+  (
+    SELECT p.prosecdef
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'user_has_restaurant_access'
+      AND pg_get_function_identity_arguments(p.oid) = 'p_restaurant_id uuid, p_require_manager_role boolean'
+  ),
+  'user_has_restaurant_access is SECURITY DEFINER'
+);
+
+-- 4. Second arg has a DEFAULT (so single-arg callers still resolve).
+SELECT ok(
+  (
+    SELECT p.pronargdefaults = 1
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'user_has_restaurant_access'
+      AND pg_get_function_identity_arguments(p.oid) = 'p_restaurant_id uuid, p_require_manager_role boolean'
+  ),
+  'p_require_manager_role has a default value'
+);
+
+-- 5. Returns FALSE when there is no matching user_restaurants row (auth.uid()
+--    is NULL during pgTAP runs, so no row will match for any restaurant_id).
+SELECT is(
+  public.user_has_restaurant_access('00000000-0000-0000-0000-000000000000'::uuid),
+  false,
+  'returns false when caller has no matching user_restaurants row'
+);
+
+-- 6. Same with explicit manager-required flag.
+SELECT is(
+  public.user_has_restaurant_access('00000000-0000-0000-0000-000000000000'::uuid, true),
+  false,
+  'returns false when caller has no matching user_restaurants row (manager-required)'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Summary

Hotfix for production error after #507 merged:

```json
{
  "code": "42883",
  "message": "function public.user_has_restaurant_access(uuid, boolean) does not exist"
}
```

Surfaces when a manager tries to bulk-set employee availability — `bulk_set_employee_availability` calls `public.user_has_restaurant_access(p_restaurant_id, true)` but the helper does not exist in production.

## Root cause

- The helper was defined in `20251123100050_create_availability_tables.sql` (Nov 2025), authored **before** our Supabase migration pipeline was in place.
- Production was bootstrapped via the Supabase SQL editor / Lovable with inlined `EXISTS` checks in RLS policies — the helper function never ran.
- The codebase migration is effectively a local-dev snapshot.
- #507's `bulk_set_employee_availability` migration assumed the helper existed (works locally) but fails at runtime in prod. PostgreSQL doesn't resolve nested function calls inside function bodies until invocation, so `CREATE FUNCTION` itself succeeded — the 42883 only fires when a user actually calls the RPC.

Verified via `mcp__supabase-prod__execute_sql`:
- `bulk_set_employee_availability(uuid, uuid[], jsonb)` exists in prod ✅
- `user_has_restaurant_access(*)` — no rows ❌
- Migration history: `20260521133930` is present; `20251123100050` is not

## Fix

Single additive migration that `CREATE OR REPLACE`s the helper with the exact signature/definition from the original 2025 migration, plus an explicit `SET search_path = public` (Supabase security advisor recommendation).

- **Local**: no-op replace of an identical function
- **Production**: creates the missing function
- **Migration history**: no edits to any existing migration — purely additive

## Test plan

- [x] `npm run db:reset` applies the new migration cleanly
- [x] New pgTAP test (`user_has_restaurant_access.test.sql`) — 6/6 pass: signature, return type, SECURITY DEFINER, default param, returns false for non-matching rows (both call signatures)
- [x] Existing `bulk_set_employee_availability.test.sql` — 16/16 still pass (no regression)
- [ ] After merge: confirm Deploy Supabase action pushes the migration to prod
- [ ] After deploy: re-query prod to confirm `user_has_restaurant_access(uuid, boolean)` exists
- [ ] After deploy: smoke-test bulk availability set as a manager in prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)