### PR TITLE
fix(availability): bulk-set writes local→UTC, fix 140 prod rows

### DIFF
--- a/src/components/EmployeeDialog.tsx
+++ b/src/components/EmployeeDialog.tsx
@@ -39,6 +39,8 @@ import { AvailabilityGrid, type AvailabilityRowValue } from '@/components/schedu
 import { deriveDefaultAvailability } from '@/lib/availabilityDefaults';
 import { useShiftTemplates } from '@/hooks/useShiftTemplates';
 import { useBulkSetAvailability } from '@/hooks/useBulkSetAvailability';
+import { useRestaurantContext } from '@/contexts/RestaurantContext';
+import { convertAvailabilityWindowsToUtc } from '@/lib/availabilityTimeUtils';
 
 interface EmployeeDialogProps {
   open: boolean;
@@ -120,6 +122,8 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
   const createEmployee = useCreateEmployee();
   const updateEmployee = useUpdateEmployee();
   const { toast } = useToast();
+  const { selectedRestaurant } = useRestaurantContext();
+  const restaurantTimezone = selectedRestaurant?.restaurant?.timezone || 'UTC';
 
   // --------------------------------------------------------------------------
   // Default availability (create mode only)
@@ -339,7 +343,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
           await bulkSetAvailability.mutateAsync({
             restaurantId,
             employeeIds: [newEmployee.id],
-            availability: availabilityGrid,
+            availability: convertAvailabilityWindowsToUtc(availabilityGrid, restaurantTimezone),
           });
         } catch {
           toast({

--- a/src/components/scheduling/ShiftPlanner/GenerateScheduleDialog.tsx
+++ b/src/components/scheduling/ShiftPlanner/GenerateScheduleDialog.tsx
@@ -35,6 +35,7 @@ interface GenerateScheduleDialogProps {
   onOpenChange: (open: boolean) => void;
   employees: Employee[];
   restaurantId: string;
+  restaurantTimezone: string;
   existingShifts: Shift[];
   weekStart: Date;
   weekEnd: Date;
@@ -70,6 +71,7 @@ export function GenerateScheduleDialog({
   onOpenChange,
   employees,
   restaurantId,
+  restaurantTimezone,
   existingShifts,
   weekStart,
   weekEnd,
@@ -519,6 +521,7 @@ export function GenerateScheduleDialog({
         open={bulkSheetOpen}
         onOpenChange={setBulkSheetOpen}
         restaurantId={restaurantId}
+        restaurantTimezone={restaurantTimezone}
         employees={normalizedEmployees}
         preCheckedIds={missingAvailabilityEmployees.map((e) => e.id)}
         defaults={defaultAvailability}

--- a/src/components/scheduling/ShiftPlanner/ShiftPlannerTab.tsx
+++ b/src/components/scheduling/ShiftPlanner/ShiftPlannerTab.tsx
@@ -677,6 +677,7 @@ export function ShiftPlannerTab({
         open={generateDialogOpen}
         onOpenChange={handleGenerateDialogChange}
         restaurantId={restaurantId}
+        restaurantTimezone={restaurantTimezone}
         employees={employees ?? []}
         templates={templates}
         availability={availability}

--- a/src/components/scheduling/availability/BulkSetAvailabilitySheet.tsx
+++ b/src/components/scheduling/availability/BulkSetAvailabilitySheet.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { AvailabilityGrid, type AvailabilityRowValue } from './AvailabilityGrid';
 import { useBulkSetAvailability } from '@/hooks/useBulkSetAvailability';
+import { convertAvailabilityWindowsToUtc } from '@/lib/availabilityTimeUtils';
 
 interface EmployeeLite {
   id: string;
@@ -22,15 +23,22 @@ interface BulkSetAvailabilitySheetProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   restaurantId: string;
+  /**
+   * IANA tz of the restaurant (e.g. 'America/Chicago'). Required so the
+   * local-time grid values can be converted to the UTC contract that the
+   * employee_availability table follows.
+   */
+  restaurantTimezone: string;
   employees: EmployeeLite[];
   preCheckedIds: string[];
-  defaults: AvailabilityRowValue[];   // length 7
+  defaults: AvailabilityRowValue[];   // length 7, local-time
 }
 
 export function BulkSetAvailabilitySheet({
   open,
   onOpenChange,
   restaurantId,
+  restaurantTimezone,
   employees,
   preCheckedIds,
   defaults,
@@ -77,7 +85,7 @@ export function BulkSetAvailabilitySheet({
       await mutation.mutateAsync({
         restaurantId,
         employeeIds: Array.from(selectedIds),
-        availability: grid,
+        availability: convertAvailabilityWindowsToUtc(grid, restaurantTimezone),
       });
       onOpenChange(false);
     } catch {

--- a/src/lib/availabilityTimeUtils.ts
+++ b/src/lib/availabilityTimeUtils.ts
@@ -1,5 +1,12 @@
 import { toZonedTime, fromZonedTime } from 'date-fns-tz';
 
+export type AvailabilityWindowLocal = {
+  day_of_week: number;
+  start_time: string;
+  end_time: string;
+  is_available: boolean;
+};
+
 /**
  * Convert a UTC time string (HH:MM or HH:MM:SS) to local time in the given timezone.
  *
@@ -54,4 +61,31 @@ export function localTimeToUtcTime(
   const m = String(utcDate.getUTCMinutes()).padStart(2, '0');
   const s = String(utcDate.getUTCSeconds()).padStart(2, '0');
   return `${h}:${m}:${s}`;
+}
+
+/**
+ * Convert a list of availability windows from restaurant-local time to UTC.
+ *
+ * employee_availability.start_time/end_time follow a UTC contract enforced by
+ * every reader (AvailabilityDialog, TeamAvailabilityGrid, EmployeePortal,
+ * generate-schedule edge function). Bulk-set callers receive local-time
+ * defaults derived from shift templates and business hours, so they must
+ * convert before writing.
+ *
+ * `is_available: false` rows are passed through unchanged — closed-day rows
+ * keep whatever placeholder times the caller provided.
+ */
+export function convertAvailabilityWindowsToUtc(
+  windows: AvailabilityWindowLocal[],
+  timezone: string,
+  referenceDate: Date = new Date(),
+): AvailabilityWindowLocal[] {
+  return windows.map((w) => {
+    if (!w.is_available) return w;
+    return {
+      ...w,
+      start_time: localTimeToUtcTime(w.start_time, timezone, referenceDate),
+      end_time: localTimeToUtcTime(w.end_time, timezone, referenceDate),
+    };
+  });
 }

--- a/src/lib/availabilityTimeUtils.ts
+++ b/src/lib/availabilityTimeUtils.ts
@@ -74,6 +74,16 @@ export function localTimeToUtcTime(
  *
  * `is_available: false` rows are passed through unchanged — closed-day rows
  * keep whatever placeholder times the caller provided.
+ *
+ * DST note: a single `referenceDate` (today by default) anchors the offset
+ * for every weekday row. Per-weekday anchoring would correctly handle the
+ * 1-hour gap when the next occurrence of a row's day_of_week falls on the
+ * other side of a DST boundary, BUT it would also desynchronize this writer
+ * from AvailabilityDialog, which reads/writes individual rows using
+ * today's offset. The TIME-column schema can't represent "10:00 local on
+ * whatever day this falls" — it's lossy by design. Until the schema moves
+ * to TIMESTAMPTZ or rows store an explicit anchor, every writer/reader pair
+ * must agree on the same anchor (today) for round-trips to be consistent.
  */
 export function convertAvailabilityWindowsToUtc(
   windows: AvailabilityWindowLocal[],

--- a/supabase/migrations/20260522000000_fix_bulk_set_availability_local_to_utc.sql
+++ b/supabase/migrations/20260522000000_fix_bulk_set_availability_local_to_utc.sql
@@ -1,0 +1,44 @@
+-- Production hotfix: bulk-set employee_availability rows from 2026-05-22
+-- were saved as restaurant-local wall-clock times, but every reader on this
+-- column (AvailabilityDialog, TeamAvailabilityGrid, EmployeePortal,
+-- generate-schedule edge function) interprets start_time / end_time as UTC.
+-- Result: a Chicago restaurant storing 10:00-22:30 (intended local) renders
+-- back as 05:00-17:30 CDT and the scheduler skips required slots.
+--
+-- This migration converts the 140 broken rows in restaurant
+-- 7c0c76e3-e770-401b-a2a9-c1edd407efed (America/Chicago, 20 employees) from
+-- local wall-clock to UTC, anchored to each row's created_at date so the DST
+-- offset matches what the writer would have produced.
+--
+-- Forward-only writer fix lives in src/lib/availabilityTimeUtils.ts and is
+-- called by BulkSetAvailabilitySheet + EmployeeDialog in the same release.
+--
+-- Scope is intentionally narrow (single restaurant + exact transaction
+-- timestamp) so the migration is idempotent in practice: there are no other
+-- rows that match this WHERE clause, even if the migration is replayed.
+
+BEGIN;
+
+UPDATE employee_availability ea
+SET
+  start_time = (
+    (
+      (ea.created_at::date::timestamp + ea.start_time)
+      AT TIME ZONE r.timezone
+    ) AT TIME ZONE 'UTC'
+  )::time,
+  end_time = (
+    (
+      (ea.created_at::date::timestamp + ea.end_time)
+      AT TIME ZONE r.timezone
+    ) AT TIME ZONE 'UTC'
+  )::time
+FROM restaurants r
+WHERE ea.restaurant_id = r.id
+  AND ea.restaurant_id = '7c0c76e3-e770-401b-a2a9-c1edd407efed'
+  AND ea.created_at = '2026-05-22 00:02:03.311703+00'::timestamptz
+  AND ea.is_available = true
+  AND r.timezone IS NOT NULL
+  AND r.timezone <> 'UTC';
+
+COMMIT;

--- a/tests/unit/BulkSetAvailabilitySheet.test.tsx
+++ b/tests/unit/BulkSetAvailabilitySheet.test.tsx
@@ -16,6 +16,7 @@ const baseProps = {
   open: true,
   onOpenChange: vi.fn(),
   restaurantId: 'r1',
+  restaurantTimezone: 'UTC',
   employees: [
     { id: 'e1', name: 'Alice', status: 'active' as const, position: 'Server' },
     { id: 'e2', name: 'Bob',   status: 'active' as const, position: 'Cook' },
@@ -95,5 +96,29 @@ describe('BulkSetAvailabilitySheet', () => {
     expect(document.getElementById('bulk-avail-day-6')).not.toBeNull();
     // namespace must NOT collide with the employee-dialog version
     expect(document.getElementById('employee-avail-day-0')).toBeNull();
+  });
+
+  it('converts the local-time grid to UTC before submitting (non-UTC restaurant)', () => {
+    // Regression for the 2026-05-21 production bug: the sheet was saving
+    // restaurant-local times directly into employee_availability, which all
+    // readers treat as UTC. For a Chicago restaurant that means a 10:00–22:30
+    // local intent displayed back as 05:00–17:30. The submit path must convert
+    // local → UTC first so the round-trip is correct.
+    renderSheet({ ...baseProps, restaurantTimezone: 'America/Chicago' });
+    fireEvent.click(screen.getByRole('button', { name: /apply to 2 employees/i }));
+
+    expect(mutateMock).toHaveBeenCalledTimes(1);
+    const args = mutateMock.mock.calls[0][0];
+    const monday = args.availability.find(
+      (a: { day_of_week: number }) => a.day_of_week === 1,
+    );
+    // 10:00 Chicago local should NOT round-trip to UTC as 10:00; it must shift.
+    expect(monday.start_time).not.toBe('10:00:00');
+    expect(monday.start_time).not.toBe('10:00');
+    // closed-day rows must still pass through unchanged
+    const sunday = args.availability.find(
+      (a: { day_of_week: number }) => a.day_of_week === 0,
+    );
+    expect(sunday.is_available).toBe(false);
   });
 });

--- a/tests/unit/EmployeeDialog.availabilitySection.test.tsx
+++ b/tests/unit/EmployeeDialog.availabilitySection.test.tsx
@@ -48,6 +48,12 @@ vi.mock('@/hooks/use-toast', () => ({
   useToast: () => ({ toast: toastMock }),
 }));
 
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => ({
+    selectedRestaurant: { restaurant: { id: 'r1', timezone: 'UTC' } },
+  }),
+}));
+
 vi.mock('@/integrations/supabase/client', () => {
   // Build a chainable supabase query mock that resolves at any terminal call.
   function makeChain(): any {

--- a/tests/unit/availabilityTimeUtils.test.ts
+++ b/tests/unit/availabilityTimeUtils.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { utcTimeToLocalTime, localTimeToUtcTime } from '@/lib/availabilityTimeUtils';
+import {
+  utcTimeToLocalTime,
+  localTimeToUtcTime,
+  convertAvailabilityWindowsToUtc,
+} from '@/lib/availabilityTimeUtils';
 
 describe('utcTimeToLocalTime', () => {
   it('converts UTC time to CDT (summer) correctly', () => {
@@ -116,6 +120,64 @@ describe('local-midnight reference dates (parseDateOnly callers)', () => {
     const refDate = new Date(2026, 10, 1);
     const result = utcTimeToLocalTime('20:00:00', 'America/New_York', refDate);
     expect(result).toBe('15:00'); // EST (UTC-5), the correct anchor for Nov 1
+  });
+});
+
+describe('convertAvailabilityWindowsToUtc', () => {
+  // The exact production-data shape: a Chicago (CDT) restaurant saved
+  // 10:00–22:30 local hours via the bulk-set sheet. The writer must now
+  // convert those to UTC (15:00–03:30) so readers — which all assume the
+  // UTC contract on employee_availability — render them back correctly.
+
+  it('converts CDT local windows to UTC for available days', () => {
+    const refDate = new Date('2026-07-15T12:00:00Z');
+    const windows = [
+      { day_of_week: 1, start_time: '10:00', end_time: '22:30', is_available: true },
+      { day_of_week: 2, start_time: '10:00', end_time: '22:30', is_available: true },
+    ];
+    const out = convertAvailabilityWindowsToUtc(windows, 'America/Chicago', refDate);
+    expect(out).toEqual([
+      { day_of_week: 1, start_time: '15:00:00', end_time: '03:30:00', is_available: true },
+      { day_of_week: 2, start_time: '15:00:00', end_time: '03:30:00', is_available: true },
+    ]);
+  });
+
+  it('passes is_available=false rows through unchanged', () => {
+    const refDate = new Date('2026-07-15T12:00:00Z');
+    const windows = [
+      { day_of_week: 0, start_time: '09:00', end_time: '17:00', is_available: false },
+      { day_of_week: 1, start_time: '10:00', end_time: '22:30', is_available: true },
+    ];
+    const out = convertAvailabilityWindowsToUtc(windows, 'America/Chicago', refDate);
+    expect(out[0]).toEqual({
+      day_of_week: 0,
+      start_time: '09:00',
+      end_time: '17:00',
+      is_available: false,
+    });
+    expect(out[1].start_time).toBe('15:00:00');
+    expect(out[1].end_time).toBe('03:30:00');
+  });
+
+  it('is a no-op for UTC restaurants', () => {
+    const refDate = new Date('2026-07-15T12:00:00Z');
+    const windows = [
+      { day_of_week: 1, start_time: '10:00', end_time: '22:30', is_available: true },
+    ];
+    const out = convertAvailabilityWindowsToUtc(windows, 'UTC', refDate);
+    expect(out).toEqual([
+      { day_of_week: 1, start_time: '10:00:00', end_time: '22:30:00', is_available: true },
+    ]);
+  });
+
+  it('uses CST offset in winter for Chicago', () => {
+    const refDate = new Date('2026-01-15T12:00:00Z');
+    const windows = [
+      { day_of_week: 1, start_time: '10:00', end_time: '22:30', is_available: true },
+    ];
+    const out = convertAvailabilityWindowsToUtc(windows, 'America/Chicago', refDate);
+    expect(out[0].start_time).toBe('16:00:00');
+    expect(out[0].end_time).toBe('04:30:00');
   });
 });
 


### PR DESCRIPTION
## Summary

Production bug from #507: `BulkSetAvailabilitySheet` and the create-employee default-availability path in `EmployeeDialog` were writing **restaurant-local wall-clock times** straight into `employee_availability.start_time / end_time`. Every reader on that column treats it as **UTC** (`AvailabilityDialog`, `TeamAvailabilityGrid`, `EmployeePortal`, `generate-schedule` edge fn — see line 267 of that file). So for a Chicago restaurant intending 10:00–22:30 local, the rows were stored as `10:00–22:30` and read back as `05:00–17:30 CDT`, matching the user's report exactly. The scheduler then dropped slots that fell outside the (already-shifted) window.

**Reader/writer convention is now restored:** writers always convert local → UTC; readers keep doing UTC → local on display.

## Changes

- `src/lib/availabilityTimeUtils.ts` — new `convertAvailabilityWindowsToUtc(windows, tz, refDate?)` helper; pass-through for `is_available=false` rows
- `BulkSetAvailabilitySheet.tsx` — adds required `restaurantTimezone` prop and converts on submit
- `ShiftPlannerTab.tsx` → `GenerateScheduleDialog.tsx` → sheet — thread `restaurantTimezone` end-to-end
- `EmployeeDialog.tsx` — pulls timezone from `useRestaurantContext()` and wraps the bulk-set call on create
- New unit tests for the helper (CDT/CST/UTC, closed-day pass-through) and a sheet-level regression test asserting non-UTC conversion happens
- **Data-fix migration** `20260522000000_fix_bulk_set_availability_local_to_utc.sql` — scoped to the single affected restaurant (Wetzel's Alamo Ranch, `7c0c76e3-e770-401b-a2a9-c1edd407efed`, America/Chicago) and the exact transaction `created_at` so it touches exactly the 140 broken rows and is idempotent in practice. Each row's date is used to anchor DST so the PG conversion matches what the writer would now produce.

## Verification

- `npm run typecheck` — clean
- `npm test` — 4062 passed, 1 skipped (291 files)
- Migration applied locally via `npm run db:reset` — no errors
- PG conversion sanity-checked: `10:00 CDT → 15:00 UTC`, `22:30 CDT → 03:30 UTC` (overnight UTC window, allowed by the existing constraint from `20260321100000_fix_availability_overnight_constraint.sql`)
- Lint: only **pre-existing** errors in touched files (catch-blocks + supabase chain mock); no new ones

## Production data scope (read-only MCP query)

- 1 restaurant affected: `7c0c76e3-e770-401b-a2a9-c1edd407efed` (Wetzel's Alamo Ranch, America/Chicago)
- 20 employees × 7 weekdays = 140 rows, all `is_available=true`, all from the same transaction at `2026-05-22 00:02:03.311703+00`
- No other batches matched (verified with a wider date-range query)

## Test plan

- [ ] Watch CI go green
- [ ] After merge: re-bulk-set for any restaurant and confirm storage reads back correctly in Team Availability grid
- [ ] Regenerate schedule for Wetzel's and confirm slots aren't dropped due to TZ mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timezone-aware availability: availability set in the app is converted from restaurant local time to UTC when bulk-saving or creating employees.

* **Bug Fixes**
  * Fixed historical employee availability data so stored times reflect UTC correctly.

* **Tests**
  * Added tests covering timezone conversions and the availability bulk-setting workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toyiyo/nimble-pnl/pull/509?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->