### PR TITLE
fix(availability): cleanup migration for 140 rows from stale-bundle bulk-set

### DIFF
--- a/supabase/migrations/20260522040000_fix_bulk_set_availability_local_to_utc_batch2.sql
+++ b/supabase/migrations/20260522040000_fix_bulk_set_availability_local_to_utc_batch2.sql
@@ -1,0 +1,54 @@
+-- Production hotfix #2: a second bulk-set batch landed AFTER PR #509 merged,
+-- because a user submitted the BulkSetAvailabilitySheet from a browser tab
+-- whose JS bundle predated the fix. Same corruption pattern as the original
+-- batch (see 20260522000000_fix_bulk_set_availability_local_to_utc.sql) —
+-- restaurant-local wall-clock times were written into UTC TIME columns.
+--
+-- This migration converts the second batch (140 rows, restaurant
+-- 7c0c76e3-e770-401b-a2a9-c1edd407efed, created at 2026-05-22 02:34:28.820209+00)
+-- using each row's created_at date as the DST anchor — identical SQL pattern
+-- to the prior fix so behavior is consistent.
+--
+-- Dry-run verification (before applying):
+--   10:00:00-22:30:00  → 15:00:00-03:30:00   (80 rows, 10a-10:30p CDT)
+--   10:00:00-23:30:00  → 15:00:00-04:30:00   (60 rows, 10a-11:30p CDT)
+--
+-- Scope is intentionally narrow (single restaurant + exact transaction
+-- timestamp + value-shape guard) so the migration is idempotent: replaying
+-- it cannot touch already-corrected rows. Supabase only runs each migration
+-- once, but the value guard prevents corruption if someone manually re-runs
+-- the file in psql.
+--
+-- Value-shape guard: real UTC-stored 10am-10:30p Chicago shifts have
+-- start_time >= 15:00 (CDT) or 16:00 (CST). The bad pattern is
+-- start_time < 14:00 AND end_time >= 17:00 (both look like raw local).
+
+BEGIN;
+
+UPDATE employee_availability ea
+SET
+  start_time = (
+    (
+      (ea.created_at::date::timestamp + ea.start_time)
+      AT TIME ZONE r.timezone
+    ) AT TIME ZONE 'UTC'
+  )::time,
+  end_time = (
+    (
+      (ea.created_at::date::timestamp + ea.end_time)
+      AT TIME ZONE r.timezone
+    ) AT TIME ZONE 'UTC'
+  )::time
+FROM restaurants r
+WHERE ea.restaurant_id = r.id
+  AND ea.restaurant_id = '7c0c76e3-e770-401b-a2a9-c1edd407efed'
+  AND ea.created_at = '2026-05-22 02:34:28.820209+00'::timestamptz
+  AND ea.is_available = true
+  AND r.timezone IS NOT NULL
+  AND r.timezone <> 'UTC'
+  -- value-shape guard: only rows that still look like raw local input
+  AND ea.start_time >= '06:00:00'::time
+  AND ea.start_time <  '14:00:00'::time
+  AND ea.end_time   >= '17:00:00'::time;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Production data fix for 140 `employee_availability` rows that were corrupted by a second bad bulk-set call landing **after** PR #509 merged — a browser tab still on the pre-#509 JS bundle submitted the dialog ~10 min after deploy. The RPC is DELETE+INSERT, so it also wiped the rows the prior fix migration had corrected.

- Single restaurant only: `7c0c76e3-e770-401b-a2a9-c1edd407efed` (Wetzel's Alamo Ranch, `America/Chicago`)
- Exact `created_at = 2026-05-22 02:34:28.820209+00`
- Value-shape guard makes manual re-runs no-ops on already-corrected rows
- Same conversion pattern as `20260522000000_fix_bulk_set_availability_local_to_utc.sql` (PR #509)

**No code changes** — PR #509 already plugged the bug at all four client write paths (`BulkSetAvailabilitySheet`, `EmployeeDialog`, `AvailabilityDialog`, `AvailabilityExceptionDialog`) and has regression tests. The recurrence was a one-time stale-bundle event, not a defect in the fix.

## Dry-run against prod (read-only MCP)

| Before (UTC stored as raw local) | After (correct UTC) | Rows |
|---|---|---|
| `10:00-22:30` | `15:00-03:30` (10a-10:30p CDT) | 80 |
| `10:00-23:30` | `15:00-04:30` (10a-11:30p CDT) | 60 |

## Test plan

- [ ] Migration applies cleanly on deploy
- [ ] Wetzel's `TeamAvailabilityGrid` renders shifts as `10a-10:30p` / `10a-11:30p` (not `5a-5:30p` / `5a-6:30p`)
- [ ] `generate-schedule` for Wetzel's now treats those employees as available 10a-close
- [ ] Re-running migration body manually in psql: 0 rows updated (value-shape guard works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

- Corrected employee availability times for a specific restaurant that were previously stored with incorrect timezone information. This database update ensures all scheduling, reporting, and availability data is now accurate and consistent across the platform.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toyiyo/nimble-pnl/pull/510?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->