### PR TITLE
fix(scheduler): position-anchored validator + prompt forbids open+close stacking

### DIFF
--- a/supabase/functions/_shared/schedule-prompt-builder.ts
+++ b/supabase/functions/_shared/schedule-prompt-builder.ts
@@ -82,7 +82,7 @@ RULES:
 2. ONLY assign employees to templates matching their position (per the normalization rule above).
 3. When a template has an area set, PREFER assigning employees from the same area. Only assign employees from a different area to that template if no same-area employees are available for that time slot. This is a soft preference — cross-area assignments are allowed as a fallback.
 4. ONLY assign employees on days/times they are available. The "Employee Availability" section lists all 7 days for every employee.
-5. Do NOT assign any employee more than once in the same time slot (no double-booking).
+5. Do NOT assign the same employee to multiple shifts whose time windows overlap on the same day. This includes back-to-back Open and Close shifts: if an Open shift ends at 16:30 and a Close shift starts at 16:00, the same employee CANNOT work both. Treat overlap as "any minute of one shift falls inside another," even a one-minute overlap.
 6. Do NOT modify or reassign any locked shifts — they are fixed.
 7. Weight staffing toward peak sales hours — more staff during lunch/dinner rushes.
 8. If staffing settings specify minimum crew per position, meet those minimums when possible.

--- a/supabase/functions/_shared/schedule-validator.ts
+++ b/supabase/functions/_shared/schedule-validator.ts
@@ -24,10 +24,12 @@ export interface AvailabilitySlot {
 export interface ValidationContext {
   employeeIds: Set<string>;
   employeePositions: Map<string, string>;
-  /** Templates keyed by id, carrying the days-of-week (0=Sun..6=Sat) on which
-   *  they are active. The validator drops shifts whose day-of-week isn't in
-   *  the template's `days`. */
-  templates: Map<string, { days: number[] }>;
+  /** Templates keyed by id. `days` are the days-of-week (0=Sun..6=Sat) on
+   *  which the template is active. `position` is the role the template
+   *  requires — the validator drops shifts whose assigned employee does not
+   *  hold that position, even when the LLM-emitted `shift.position` matches
+   *  the employee (e.g. a Manager assigned onto a Server template). */
+  templates: Map<string, { days: number[]; position: string }>;
   /** Key: "employeeId:dayOfWeek" (0=Sun..6=Sat) */
   availability: Map<string, AvailabilitySlot>;
   excludedEmployeeIds: Set<string>;
@@ -215,7 +217,8 @@ export function normalizePosition(s: string | null | undefined): string {
  * 2. Employee exists
  * 3. Template exists
  * 4. Template is active on the shift's day-of-week
- * 5. Position matches employee's assigned position (case-insensitive)
+ * 5. Employee's assigned position AND the LLM-emitted shift.position both
+ *    match the template's required position (case-insensitive, plural-aware)
  * 6. Employee is available on that day of week
  * 7. Shift times fall within availability time window (if specific hours set)
  * 8. No double-booking (same employee, overlapping times on same day)
@@ -263,15 +266,31 @@ export function validateGeneratedShifts(
       continue;
     }
 
-    // 5. Position matches (normalized: case, whitespace, trailing -s plural)
+    // 5. Position matches the template's required role (normalized: case,
+    //    whitespace, trailing -s plural). The earlier check compared
+    //    employee.position to shift.position only — both are LLM-controlled,
+    //    so the LLM bypassed it by simply emitting shift.position equal to
+    //    the employee's own position (e.g. setting "Manager" for a manager
+    //    placed onto a Server template). Anchoring on template.position
+    //    catches that. We also re-check shift.position so the LLM-emitted
+    //    label can't disagree with what we persist downstream.
+    const requiredPosition = template.position;
     const assignedPosition = ctx.employeePositions.get(shift.employee_id);
+    const normRequired = normalizePosition(requiredPosition);
     if (
       assignedPosition === undefined ||
-      normalizePosition(assignedPosition) !== normalizePosition(shift.position)
+      normalizePosition(assignedPosition) !== normRequired
     ) {
       drop(
         "POSITION_MISMATCH",
-        `Position mismatch for employee ${shift.employee_id}: assigned "${assignedPosition}", shift requests "${shift.position}"`,
+        `Employee ${shift.employee_id} (position "${assignedPosition}") does not match template ${shift.template_id} required position "${requiredPosition}"`,
+      );
+      continue;
+    }
+    if (normalizePosition(shift.position) !== normRequired) {
+      drop(
+        "POSITION_MISMATCH",
+        `Shift position "${shift.position}" does not match template ${shift.template_id} required position "${requiredPosition}"`,
       );
       continue;
     }

--- a/supabase/functions/generate-schedule/index.ts
+++ b/supabase/functions/generate-schedule/index.ts
@@ -589,10 +589,11 @@ serve(async (req) => {
     // Build validation context
     const employeeIds = new Set(employees.map((e) => e.id));
     const employeePositions = new Map(employees.map((e) => [e.id, e.position]));
-    // Validator needs template days-of-week so it can drop shifts placed on
-    // a day the template isn't active for (Bug C).
+    // Validator needs template days-of-week and required position so it can
+    // drop shifts placed on a wrong day (Bug C) or a wrong position (Bug E
+    // — Manager onto Server template).
     const templateDays = new Map(
-      templates.map((t) => [t.id, { days: t.days }] as const),
+      templates.map((t) => [t.id, { days: t.days, position: t.position }] as const),
     );
 
     // Build availability Map for validator

--- a/tests/unit/schedule-prompt-builder.test.ts
+++ b/tests/unit/schedule-prompt-builder.test.ts
@@ -242,4 +242,22 @@ describe('buildSchedulePrompt — fill-slot enhancements', () => {
     expect(systemContent).toMatch(/only on the days listed/i);
     expect(systemContent.toLowerCase()).toContain('active days');
   });
+
+  // ── Bug F regression: Rule 5 must explicitly forbid overlapping/back-to-
+  // back same-day shifts for the same employee. The old wording ("not in
+  // the same time slot") was ambiguous and the LLM read it as exact-time
+  // match. In production it stacked Open (10:00-16:30) + Close (16:00-
+  // 23:30) on the same employee Fri/Sat/Sun; the validator then dropped
+  // the Close shift with DOUBLE_BOOKING, producing 2/4 close-weekend
+  // under-fill.
+  it('Rule 5 forbids overlapping same-day shifts and names the open+close case', () => {
+    const result = buildSchedulePrompt(makeContext());
+    const systemContent = result.messages[0].content as string;
+    expect(systemContent.toLowerCase()).toContain('overlap');
+    // The rule should call out the open+close pattern by name so the LLM
+    // sees a concrete example, not just abstract overlap language.
+    expect(systemContent.toLowerCase()).toMatch(/open .*close|close .*open/);
+    // The rule should also call out that even a one-minute overlap counts.
+    expect(systemContent.toLowerCase()).toMatch(/one[ -]minute|even.*minute/);
+  });
 });

--- a/tests/unit/schedule-validator.test.ts
+++ b/tests/unit/schedule-validator.test.ts
@@ -34,12 +34,13 @@ function makeContext(overrides?: Partial<ValidationContext>): ValidationContext 
       ['emp-2', 'cook'],
       ['emp-3', 'server'],
     ]),
-    // Default fixtures use templates active on every day of the week so existing
-    // suites that don't care about active-days continue to behave the same. New
-    // DAY_NOT_IN_TEMPLATE tests override this explicitly.
+    // Default fixtures use templates active on every day of the week and the
+    // 'server' position so existing suites that don't care about active-days
+    // or template position continue to behave the same. New
+    // DAY_NOT_IN_TEMPLATE / POSITION_MISMATCH tests override these explicitly.
     templates: new Map([
-      ['tmpl-1', { days: [0, 1, 2, 3, 4, 5, 6] }],
-      ['tmpl-2', { days: [0, 1, 2, 3, 4, 5, 6] }],
+      ['tmpl-1', { days: [0, 1, 2, 3, 4, 5, 6], position: 'server' }],
+      ['tmpl-2', { days: [0, 1, 2, 3, 4, 5, 6], position: 'server' }],
     ]),
     availability: makeAvailability(),
     excludedEmployeeIds: new Set(),
@@ -136,7 +137,7 @@ describe('validateGeneratedShifts', () => {
       employeePositions: new Map([['emp-2', 'cook']]),
       templates: new Map([
         // Weekend-only template (Sun, Fri, Sat)
-        ['weekend-close', { days: [0, 5, 6] }],
+        ['weekend-close', { days: [0, 5, 6], position: 'cook' }],
       ]),
       availability: new Map([
         ['emp-2:1', { isAvailable: true, startTime: null, endTime: null }],
@@ -159,7 +160,7 @@ describe('validateGeneratedShifts', () => {
       employeeIds: new Set(['emp-2']),
       employeePositions: new Map([['emp-2', 'cook']]),
       templates: new Map([
-        ['weekday-close', { days: [1, 2, 3, 4, 5] }],
+        ['weekday-close', { days: [1, 2, 3, 4, 5], position: 'cook' }],
       ]),
       availability: new Map([
         ['emp-2:1', { isAvailable: true, startTime: null, endTime: null }],
@@ -176,14 +177,54 @@ describe('validateGeneratedShifts', () => {
     expect(result.dropped).toHaveLength(0);
   });
 
-  it('drops shifts where employee position does not match', () => {
+  it('drops shifts where shift.position does not match template.position', () => {
     const ctx = makeContext();
-    // emp-1 is a server, but shift requests cook
+    // emp-1 is a server on tmpl-1 (server), but shift.position requests cook —
+    // the LLM-emitted label disagrees with the template's required position.
     const shift = makeShift({ position: 'cook' });
     const result = validateGeneratedShifts([shift], ctx);
     expect(result.valid).toHaveLength(0);
     expect(result.dropped).toHaveLength(1);
     expect(result.dropped[0].code).toBe('POSITION_MISMATCH');
+  });
+
+  // ── Bug E regression: validator must enforce template.position, not just
+  //    employee.position vs shift.position. Production restaurant 7c0c76e3:
+  //    Managers (Alejandra Perez, Jose Delgado) were assigned to Server
+  //    templates (Open-week-csc, Close-week-csc). The LLM emitted
+  //    shift.position="Manager" matching employee.position="Manager", and
+  //    the legacy check passed because it only compared those two
+  //    LLM-controlled fields. Result: 3/2 and 4/3 over-fills.
+  it('drops a Manager assigned to a Server template even when shift.position matches the employee', () => {
+    const ctx = makeContext({
+      employeeIds: new Set(['mgr-1']),
+      employeePositions: new Map([['mgr-1', 'Manager']]),
+      availability: new Map([
+        ['mgr-1:1', { isAvailable: true, startTime: null, endTime: null }],
+      ]),
+      // tmpl-1 default = 'server'
+    });
+    // The LLM's bypass: shift.position emitted as the manager's own position
+    // so the legacy `shift.position vs employee.position` check passed.
+    const shift = makeShift({
+      employee_id: 'mgr-1',
+      position: 'Manager',
+    });
+    const result = validateGeneratedShifts([shift], ctx);
+    expect(result.valid).toHaveLength(0);
+    expect(result.dropped).toHaveLength(1);
+    expect(result.dropped[0].code).toBe('POSITION_MISMATCH');
+    expect(result.dropped[0].message).toContain('Manager');
+    expect(result.dropped[0].message).toContain('server');
+  });
+
+  it('accepts a Server employee on a Server template (Bug E regression — happy path)', () => {
+    const ctx = makeContext();
+    // emp-1 is a server on tmpl-1 (server). All three labels match.
+    const shift = makeShift({ employee_id: 'emp-1', position: 'server' });
+    const result = validateGeneratedShifts([shift], ctx);
+    expect(result.valid).toHaveLength(1);
+    expect(result.dropped).toHaveLength(0);
   });
 
   it('drops shifts where employee is not available on that day', () => {
@@ -259,6 +300,10 @@ describe('validateGeneratedShifts — position normalization', () => {
   it('matches "Line Cook" employee with "line cook" shift (case-insensitive)', () => {
     const ctx = makeContext({
       employeePositions: new Map([['emp-1', 'Line Cook']]),
+      templates: new Map([
+        ['tmpl-1', { days: [0, 1, 2, 3, 4, 5, 6], position: 'line cook' }],
+        ['tmpl-2', { days: [0, 1, 2, 3, 4, 5, 6], position: 'server' }],
+      ]),
     });
     const shift = makeShift({ position: 'line cook' });
     const result = validateGeneratedShifts([shift], ctx);
@@ -268,6 +313,10 @@ describe('validateGeneratedShifts — position normalization', () => {
   it('matches "Cook " (trailing space) employee with "Cook" shift', () => {
     const ctx = makeContext({
       employeePositions: new Map([['emp-1', 'Cook ']]),
+      templates: new Map([
+        ['tmpl-1', { days: [0, 1, 2, 3, 4, 5, 6], position: 'Cook' }],
+        ['tmpl-2', { days: [0, 1, 2, 3, 4, 5, 6], position: 'server' }],
+      ]),
     });
     const shift = makeShift({ position: 'Cook' });
     const result = validateGeneratedShifts([shift], ctx);
@@ -277,6 +326,7 @@ describe('validateGeneratedShifts — position normalization', () => {
   it('matches "Servers" (plural) employee with "server" shift', () => {
     const ctx = makeContext({
       employeePositions: new Map([['emp-1', 'Servers']]),
+      // Default tmpl-1.position = 'server', which normalizes-matches 'Servers'.
     });
     const shift = makeShift({ position: 'server' });
     const result = validateGeneratedShifts([shift], ctx);
@@ -286,6 +336,10 @@ describe('validateGeneratedShifts — position normalization', () => {
   it('preserves "Hostess" (ends in ss, does not strip)', () => {
     const ctx = makeContext({
       employeePositions: new Map([['emp-1', 'Hostess']]),
+      templates: new Map([
+        ['tmpl-1', { days: [0, 1, 2, 3, 4, 5, 6], position: 'Hostess' }],
+        ['tmpl-2', { days: [0, 1, 2, 3, 4, 5, 6], position: 'server' }],
+      ]),
     });
     const shift = makeShift({ position: 'Hostess' });
     const result = validateGeneratedShifts([shift], ctx);
@@ -295,6 +349,10 @@ describe('validateGeneratedShifts — position normalization', () => {
   it('preserves short stems like "Bus" (stem length <= 4)', () => {
     const ctx = makeContext({
       employeePositions: new Map([['emp-1', 'Bus']]),
+      templates: new Map([
+        ['tmpl-1', { days: [0, 1, 2, 3, 4, 5, 6], position: 'Bus' }],
+        ['tmpl-2', { days: [0, 1, 2, 3, 4, 5, 6], position: 'server' }],
+      ]),
     });
     const shift = makeShift({ position: 'Bus' });
     const result = validateGeneratedShifts([shift], ctx);
@@ -375,7 +433,15 @@ describe('validateGeneratedShifts — cross-day double-booking', () => {
       start_time: '22:00:00',
       end_time: '02:00:00',
     });
-    const ctx = makeContext({ existingShifts: [existing] });
+    const ctx = makeContext({
+      existingShifts: [existing],
+      // Override defaults so emp-2 (cook) passes the template-position check
+      // and we get to the overlap check we're actually testing.
+      templates: new Map([
+        ['tmpl-1', { days: [0, 1, 2, 3, 4, 5, 6], position: 'cook' }],
+        ['tmpl-2', { days: [0, 1, 2, 3, 4, 5, 6], position: 'cook' }],
+      ]),
+    });
     const aiShift = makeShift({
       employee_id: 'emp-2',
       position: 'cook',
@@ -390,7 +456,12 @@ describe('validateGeneratedShifts — cross-day double-booking', () => {
   });
 
   it('drops second AI shift Tue 00:00-06:00 when first AI shift Mon 22:00-02:00 is already valid', () => {
-    const ctx = makeContext();
+    const ctx = makeContext({
+      templates: new Map([
+        ['tmpl-1', { days: [0, 1, 2, 3, 4, 5, 6], position: 'cook' }],
+        ['tmpl-2', { days: [0, 1, 2, 3, 4, 5, 6], position: 'cook' }],
+      ]),
+    });
     const shift1 = makeShift({
       employee_id: 'emp-2',
       position: 'cook',


### PR DESCRIPTION
## Summary

Production AI scheduler showed two persistent miscoverage patterns even after PR #511's capacity/active-day fixes:

- **3/2 open-week-csc + 4/3 close-week-csc over-fill** — a Manager (Alejandra Perez / Jose Delgado) was being placed onto Cold Stone Server templates.
- **2/4 close-weekend-csc under-fill on Fri/Sat/Sun** — Cold Stone closers (Ivy, Emmalynn) were being assigned both the Open and Close shifts on the same day, and the validator was dropping the Close ones.

Two independent root causes, fixed together.

### Bug E — Validator position check was a tautology (commit `0451e1a3`)

`schedule-validator.ts` was comparing `ctx.employeePositions.get(shift.employee_id)` against `shift.position`. Both fields are LLM-controlled, so the model could (and did) bypass the check by emitting `shift.position = "Manager"` for a manager placed onto a Server template — both sides agreed, so validator passed, and a Manager landed on a Server slot.

**Fix:** anchor the check on `template.position` (which the validator now receives via `ValidationContext.templates`). Validator now requires both:
1. The employee's `position` matches `template.position`
2. The LLM-emitted `shift.position` also matches `template.position` (so the label we persist downstream cannot disagree with the template).

`generate-schedule/index.ts` was updated to thread `{ days, position }` into the templates Map.

### Bug F — Prompt Rule 5 wording let the LLM stack Open+Close (commit `83df44be`)

Old Rule 5 said "no double-booking … in the same time slot." The LLM interpreted that as exact-time match, so it happily assigned the same employee Open (10:00–16:30) and Close (16:00–23:30) on the same day. The validator's `DOUBLE_BOOKING` step then dropped one — first-wins iteration order meant the Close shift was the one dropped, producing the 2/4 close-weekend-csc under-fill the manager kept seeing in the UI.

**Fix:** rewrite Rule 5 in `SYSTEM_PROMPT` to (a) forbid any time-window overlap on the same day, (b) explicitly name the back-to-back Open+Close pattern with concrete numbers from production, and (c) define overlap as "any minute of one shift falls inside another", including a one-minute overlap. Concrete examples in prompt rules drive compliance more reliably than abstract overlap language.

## Test plan

- [x] `npx vitest run tests/unit/schedule-validator.test.ts` — Bug E regression tests pass (Manager-on-Server drops with POSITION_MISMATCH; Server-on-Server happy path stays valid)
- [x] `npx vitest run tests/unit/schedule-prompt-builder.test.ts` — Bug F regression test pass (Rule 5 mentions overlap, open+close, one-minute)
- [x] `npx vitest run` — full unit suite (4077 tests) green
- [x] `npm run typecheck` clean
- [x] `npx eslint` on touched files clean
- [ ] Manual smoke: regenerate schedule for restaurant `7c0c76e3-e770-401b-a2a9-c1edd407efed` after merge → expect Managers no longer on Cold Stone Server templates and Cold Stone closers no longer doubled with openers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Strengthened scheduling constraints to prevent employees from working overlapping shifts on the same day, eliminating conflicts at shift boundaries.
  * Enhanced position validation to ensure generated shifts match required employee roles and template requirements more rigorously.

* **Tests**
  * Added test coverage for same-day shift overlap constraints and position validation logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toyiyo/nimble-pnl/pull/513?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->