### PR TITLE
feat(checks): optional category picker on check creation

### DIFF
--- a/docs/superpowers/plans/2026-05-22-check-create-with-category-plan.md
+++ b/docs/superpowers/plans/2026-05-22-check-create-with-category-plan.md
@@ -1,0 +1,1193 @@
+# Optional category on check creation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let users optionally pick a chart-of-accounts category when creating a check, so the resulting expense lands categorized without a second screen.
+
+**Architecture:** Reuse the existing `pending_outflows.category_id` column and `SearchableAccountSelector` component on two surfaces (`PrintChecks.tsx` batch table, `PrintCheckButton.tsx` per-expense dialog). Add a same-restaurant integrity trigger and a partial index on the DB side. No new RPCs, no schema changes other than the trigger + index.
+
+**Tech Stack:** React 18 + TypeScript, Vite, shadcn/ui (Popover/Command/Dialog/Table), Vitest + @testing-library/react, PostgreSQL with pgTAP for DB tests.
+
+**Spec:** `docs/superpowers/specs/2026-05-22-check-create-with-category-design.md`
+
+---
+
+## File Structure
+
+**Create:**
+- `supabase/migrations/20260522120000_pending_outflows_category_same_restaurant.sql`
+- `supabase/migrations/20260522120100_pending_outflows_category_index.sql`
+- `supabase/tests/pending_outflows_category_same_restaurant.test.sql`
+- `tests/unit/SearchableAccountSelector.ariaLabel.test.tsx`
+- `tests/unit/PrintChecksCategoryColumn.test.tsx`
+- `tests/unit/PrintCheckButtonCategory.test.tsx`
+
+**Modify:**
+- `src/components/banking/SearchableAccountSelector.tsx` (add `triggerAriaLabel` prop, `collisionPadding`, remove `console.log`s)
+- `src/pages/PrintChecks.tsx` (widen `updateRow`, add `categoryId` to `CheckRow`, add Category column, switch to `CheckJob` loop)
+- `src/components/pending-outflows/PrintCheckButton.tsx` (add Category field, dialog overflow classes, pass `category_id`)
+
+**Read-only references** (no change, just used in tests):
+- `src/hooks/usePendingOutflows.tsx` — already accepts `category_id` in both inputs.
+- `src/types/pending-outflows.ts` — input types already correct.
+
+---
+
+## Task 1 — `SearchableAccountSelector`: add `triggerAriaLabel`, `collisionPadding`, clean up logs
+
+**Files:**
+- Modify: `src/components/banking/SearchableAccountSelector.tsx`
+- Create: `tests/unit/SearchableAccountSelector.ariaLabel.test.tsx`
+
+### Step 1.1 — Write the failing test
+
+Create `tests/unit/SearchableAccountSelector.ariaLabel.test.tsx`:
+
+```tsx
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SearchableAccountSelector } from '@/components/banking/SearchableAccountSelector';
+
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => ({
+    selectedRestaurant: { restaurant_id: 'rest-1' },
+  }),
+}));
+
+vi.mock('@/hooks/useChartOfAccounts', () => ({
+  useChartOfAccounts: () => ({
+    accounts: [
+      {
+        id: 'acc-1',
+        restaurant_id: 'rest-1',
+        account_code: '5000',
+        account_name: 'Food Costs',
+        account_type: 'cogs',
+        account_subtype: 'food',
+        parent_account_id: null,
+        is_active: true,
+      },
+    ],
+    loading: false,
+  }),
+}));
+
+describe('SearchableAccountSelector — triggerAriaLabel', () => {
+  it('forwards triggerAriaLabel to the combobox button when provided', () => {
+    render(
+      <SearchableAccountSelector
+        onValueChange={() => {}}
+        triggerAriaLabel="Category for check row 1"
+      />,
+    );
+    const combo = screen.getByRole('combobox', {
+      name: 'Category for check row 1',
+    });
+    expect(combo).toBeInTheDocument();
+  });
+
+  it('omits aria-label when prop is not provided (default behaviour unchanged)', () => {
+    render(<SearchableAccountSelector onValueChange={() => {}} />);
+    const combo = screen.getByRole('combobox');
+    expect(combo.getAttribute('aria-label')).toBeNull();
+  });
+});
+```
+
+### Step 1.2 — Run test, confirm RED
+
+```bash
+npm run test -- tests/unit/SearchableAccountSelector.ariaLabel.test.tsx
+```
+
+Expected: FAIL on the first test (prop is ignored, `combobox` has no accessible name "Category for check row 1").
+
+### Step 1.3 — Add the prop, `collisionPadding`, and remove logs
+
+Edit `src/components/banking/SearchableAccountSelector.tsx`:
+
+1. Widen the prop interface:
+
+```ts
+interface SearchableAccountSelectorProps {
+  value?: string;
+  onValueChange: (value: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  filterByTypes?: string[];
+  autoOpen?: boolean;
+  triggerAriaLabel?: string;   // NEW
+}
+```
+
+2. Destructure it in the function signature:
+
+```ts
+export function SearchableAccountSelector({
+  value,
+  onValueChange,
+  placeholder = "Select account",
+  disabled = false,
+  filterByTypes,
+  autoOpen = false,
+  triggerAriaLabel,   // NEW
+}: SearchableAccountSelectorProps) {
+```
+
+3. Forward it to the trigger button (around line 108):
+
+```tsx
+<Button
+  variant="outline"
+  role="combobox"
+  aria-expanded={open}
+  aria-busy={loading}
+  aria-label={triggerAriaLabel}   // NEW
+  className="w-full justify-between"
+  disabled={isDisabled}
+>
+```
+
+4. Add `collisionPadding` on the popover content (around line 134):
+
+```tsx
+<PopoverContent
+  className="w-[350px] p-0 bg-background z-50"
+  align="start"
+  collisionPadding={8}   // NEW
+  onWheel={(e) => e.stopPropagation()}
+  onTouchMove={(e) => e.stopPropagation()}
+>
+```
+
+5. Delete the two `console.log` calls in the `organizedAccounts` memo (lines 70–71 of the current file):
+
+```ts
+// REMOVE these two lines:
+console.log('[SearchableAccountSelector] Filtered accounts:', filteredAccounts);
+console.log('[SearchableAccountSelector] Filter types:', filterByTypes);
+```
+
+### Step 1.4 — Run test, confirm GREEN
+
+```bash
+npm run test -- tests/unit/SearchableAccountSelector.ariaLabel.test.tsx
+```
+
+Expected: Both tests PASS.
+
+### Step 1.5 — Commit
+
+```bash
+git add src/components/banking/SearchableAccountSelector.tsx tests/unit/SearchableAccountSelector.ariaLabel.test.tsx
+git commit -m "feat(account-selector): add triggerAriaLabel + collisionPadding, drop dev logs
+
+Preparing the shared category picker for use inside batch tables and
+narrow dialogs where the trigger needs a per-row accessible name and the
+popover must not clip on small viewports."
+```
+
+---
+
+## Task 2 — Migration A: same-restaurant trigger on `pending_outflows.category_id`
+
+**Files:**
+- Create: `supabase/migrations/20260522120000_pending_outflows_category_same_restaurant.sql`
+- Create: `supabase/tests/pending_outflows_category_same_restaurant.test.sql`
+
+### Step 2.1 — Write the failing pgTAP test
+
+Create `supabase/tests/pending_outflows_category_same_restaurant.test.sql`:
+
+```sql
+-- pgTAP tests for the same-restaurant guard on pending_outflows.category_id.
+--
+-- Pinning: writing a pending_outflows row whose category_id resolves to a
+-- chart_of_accounts row in a different restaurant must fail with SQLSTATE
+-- 23503 (foreign_key_violation), both on INSERT and on UPDATE.
+
+BEGIN;
+SELECT plan(7);
+
+-- Fixture: two restaurants, each with its own chart-of-accounts row.
+INSERT INTO public.restaurants (id, name)
+VALUES
+  ('00000000-0000-0000-0000-000000000a01', 'Test Restaurant A'),
+  ('00000000-0000-0000-0000-000000000a02', 'Test Restaurant B')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.chart_of_accounts
+  (id, restaurant_id, account_code, account_name, account_type, normal_balance)
+VALUES
+  ('00000000-0000-0000-0000-000000000b01',
+   '00000000-0000-0000-0000-000000000a01',
+   '5100', 'Test Food Costs A', 'cogs', 'debit'),
+  ('00000000-0000-0000-0000-000000000b02',
+   '00000000-0000-0000-0000-000000000a02',
+   '5100', 'Test Food Costs B', 'cogs', 'debit')
+ON CONFLICT (id) DO NOTHING;
+
+-- 1. Trigger function exists.
+SELECT has_function(
+  'public',
+  'assert_pending_outflow_category_same_restaurant',
+  'trigger function exists'
+);
+
+-- 2. Trigger is wired up on pending_outflows.
+SELECT ok(
+  EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgname = 'pending_outflows_category_same_restaurant'
+      AND tgrelid = 'public.pending_outflows'::regclass
+  ),
+  'trigger is attached to pending_outflows'
+);
+
+-- 3. Insert with a same-restaurant category succeeds.
+SELECT lives_ok(
+  $$
+    INSERT INTO public.pending_outflows (
+      restaurant_id, vendor_name, category_id, payment_method,
+      amount, issue_date
+    )
+    VALUES (
+      '00000000-0000-0000-0000-000000000a01',
+      'Same-Restaurant Vendor',
+      '00000000-0000-0000-0000-000000000b01',
+      'check',
+      100.00,
+      CURRENT_DATE
+    );
+  $$,
+  'insert with same-restaurant category succeeds'
+);
+
+-- 4. Insert with a cross-restaurant category fails with 23503.
+SELECT throws_ok(
+  $$
+    INSERT INTO public.pending_outflows (
+      restaurant_id, vendor_name, category_id, payment_method,
+      amount, issue_date
+    )
+    VALUES (
+      '00000000-0000-0000-0000-000000000a01',
+      'Cross-Restaurant Vendor',
+      '00000000-0000-0000-0000-000000000b02',
+      'check',
+      200.00,
+      CURRENT_DATE
+    );
+  $$,
+  '23503',
+  NULL,
+  'cross-restaurant insert raises foreign_key_violation'
+);
+
+-- 5. Insert with NULL category_id still works (category is optional).
+SELECT lives_ok(
+  $$
+    INSERT INTO public.pending_outflows (
+      restaurant_id, vendor_name, payment_method, amount, issue_date
+    )
+    VALUES (
+      '00000000-0000-0000-0000-000000000a01',
+      'Uncategorized Vendor',
+      'check',
+      300.00,
+      CURRENT_DATE
+    );
+  $$,
+  'NULL category_id is still permitted'
+);
+
+-- 6. Update from NULL → cross-restaurant category fails with 23503.
+SELECT throws_ok(
+  $$
+    UPDATE public.pending_outflows
+       SET category_id = '00000000-0000-0000-0000-000000000b02'
+     WHERE vendor_name = 'Uncategorized Vendor'
+       AND restaurant_id = '00000000-0000-0000-0000-000000000a01';
+  $$,
+  '23503',
+  NULL,
+  'cross-restaurant update raises foreign_key_violation'
+);
+
+-- 7. Update to same-restaurant category succeeds.
+SELECT lives_ok(
+  $$
+    UPDATE public.pending_outflows
+       SET category_id = '00000000-0000-0000-0000-000000000b01'
+     WHERE vendor_name = 'Uncategorized Vendor'
+       AND restaurant_id = '00000000-0000-0000-0000-000000000a01';
+  $$,
+  'same-restaurant update succeeds'
+);
+
+SELECT * FROM finish();
+ROLLBACK;
+```
+
+### Step 2.2 — Run test, confirm RED
+
+```bash
+npm run db:reset && npm run test:db -- pending_outflows_category_same_restaurant
+```
+
+Expected: tests 1 and 2 (and 4, 6) FAIL because neither the function nor the trigger exists yet. Tests 3, 5, 7 pass-by-accident because no guard is in place.
+
+### Step 2.3 — Write the migration
+
+Create `supabase/migrations/20260522120000_pending_outflows_category_same_restaurant.sql`:
+
+```sql
+-- Same-restaurant integrity guard for pending_outflows.category_id.
+--
+-- The existing FK only enforces that category_id points at SOME chart_of_accounts
+-- row. The SELECT RLS on chart_of_accounts hides foreign rows from the UI, but a
+-- direct API write supplying a foreign uuid would still pass FK validation.
+-- This trigger closes that gap by asserting category and outflow share a
+-- restaurant_id at write time.
+
+CREATE OR REPLACE FUNCTION public.assert_pending_outflow_category_same_restaurant()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.category_id IS NOT NULL THEN
+    PERFORM 1
+      FROM public.chart_of_accounts
+     WHERE id = NEW.category_id
+       AND restaurant_id = NEW.restaurant_id;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION
+        'pending_outflows.category_id % does not belong to restaurant %',
+        NEW.category_id, NEW.restaurant_id
+        USING ERRCODE = 'foreign_key_violation';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER pending_outflows_category_same_restaurant
+BEFORE INSERT OR UPDATE OF category_id, restaurant_id ON public.pending_outflows
+FOR EACH ROW
+EXECUTE FUNCTION public.assert_pending_outflow_category_same_restaurant();
+
+COMMENT ON FUNCTION public.assert_pending_outflow_category_same_restaurant() IS
+  'Asserts pending_outflows.category_id and restaurant_id refer to the same restaurant. Raises ERRCODE 23503 on mismatch.';
+```
+
+### Step 2.4 — Run test, confirm GREEN
+
+```bash
+npm run db:reset && npm run test:db -- pending_outflows_category_same_restaurant
+```
+
+Expected: All 7 tests PASS.
+
+### Step 2.5 — Commit
+
+```bash
+git add supabase/migrations/20260522120000_pending_outflows_category_same_restaurant.sql supabase/tests/pending_outflows_category_same_restaurant.test.sql
+git commit -m "feat(db): same-restaurant guard on pending_outflows.category_id
+
+Prevents writes that pair a pending_outflows row in restaurant A with a
+chart_of_accounts row in restaurant B — a leak the existing FK alone
+does not catch. pgTAP coverage included."
+```
+
+---
+
+## Task 3 — Migration B: partial index on `pending_outflows.category_id`
+
+**Files:**
+- Create: `supabase/migrations/20260522120100_pending_outflows_category_index.sql`
+- Modify: `supabase/tests/pending_outflows_category_same_restaurant.test.sql` (append index assertion — same test file because the index ships with the trigger feature)
+
+### Step 3.1 — Add the failing index assertion to the existing pgTAP test
+
+Edit `supabase/tests/pending_outflows_category_same_restaurant.test.sql`:
+
+Change `SELECT plan(7);` to `SELECT plan(8);`, then **after** test 7 (and before `SELECT * FROM finish();`), append:
+
+```sql
+-- 8. Partial index on category_id exists (non-null rows).
+SELECT ok(
+  EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND tablename = 'pending_outflows'
+      AND indexname = 'idx_pending_outflows_category'
+  ),
+  'idx_pending_outflows_category index exists'
+);
+```
+
+### Step 3.2 — Run test, confirm RED on test 8
+
+```bash
+npm run test:db -- pending_outflows_category_same_restaurant
+```
+
+Expected: Tests 1–7 PASS (from Task 2), test 8 FAILS because the index does not exist.
+
+### Step 3.3 — Write the migration
+
+Create `supabase/migrations/20260522120100_pending_outflows_category_index.sql`:
+
+```sql
+-- Partial index on pending_outflows.category_id.
+--
+-- Aggregation reads (expenseDataFetcher, useMonthlyMetrics, useExpenseHealth)
+-- already join chart_of_accounts via category_id. Historically most rows are
+-- NULL; with the optional category picker on check creation, a meaningful
+-- fraction will now be populated. The partial index keeps cost down by only
+-- indexing the populated rows.
+
+CREATE INDEX IF NOT EXISTS idx_pending_outflows_category
+  ON public.pending_outflows(category_id)
+  WHERE category_id IS NOT NULL;
+
+COMMENT ON INDEX public.idx_pending_outflows_category IS
+  'Partial index supporting category-keyed reads on pending_outflows. Excludes NULL category_id rows (the historical majority).';
+```
+
+> Note: `CREATE INDEX CONCURRENTLY` cannot run inside a transaction. The CLI applies migrations inside a transaction by default; we use plain `CREATE INDEX IF NOT EXISTS`, which is safe given the table size at our scale (tens of thousands of rows max per restaurant, all of which lock-acquire fast). If/when the table grows, a follow-up migration can replace this with a `CONCURRENTLY` version run via a manual ops step.
+
+### Step 3.4 — Run test, confirm GREEN
+
+```bash
+npm run db:reset && npm run test:db -- pending_outflows_category_same_restaurant
+```
+
+Expected: All 8 tests PASS.
+
+### Step 3.5 — Commit
+
+```bash
+git add supabase/migrations/20260522120100_pending_outflows_category_index.sql supabase/tests/pending_outflows_category_same_restaurant.test.sql
+git commit -m "perf(db): partial index on pending_outflows.category_id
+
+Aggregation reads now hit populated category_id rows after the check
+creation feature lands. Partial-on-NOT-NULL keeps index size minimal
+since most historical rows remain uncategorized."
+```
+
+---
+
+## Task 4 — `PrintChecks.tsx`: Category column in Write Checks table
+
+**Files:**
+- Modify: `src/pages/PrintChecks.tsx`
+- Create: `tests/unit/PrintChecksCategoryColumn.test.tsx`
+
+### Step 4.1 — Write the failing test
+
+Create `tests/unit/PrintChecksCategoryColumn.test.tsx`:
+
+```tsx
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const claimCheckNumbersMock = vi.fn();
+const createPendingOutflowMock = vi.fn();
+const logCheckActionMock = vi.fn();
+
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => ({
+    selectedRestaurant: { restaurant: { name: 'Test Restaurant' }, restaurant_id: 'rest-1' },
+  }),
+}));
+
+vi.mock('@/hooks/useCheckSettings', () => ({
+  useCheckSettings: () => ({
+    settings: {
+      id: 'set-1',
+      restaurant_id: 'rest-1',
+      business_name: 'Test Restaurant LLC',
+      business_address_line1: '123 Main St',
+      business_address_line2: null,
+      business_city: 'Austin',
+      business_state: 'TX',
+      business_zip: '78701',
+      bank_name: null,
+      print_bank_info: false,
+      routing_number: null,
+      signature_url: null,
+    },
+    isLoading: false,
+  }),
+}));
+
+vi.mock('@/hooks/useCheckBankAccounts', () => ({
+  useCheckBankAccounts: () => ({
+    accounts: [{
+      id: 'acct-1',
+      account_name: 'Operating',
+      bank_name: 'First National',
+      next_check_number: 1001,
+      print_bank_info: false,
+      routing_number: null,
+      account_number_last4: null,
+      is_default: true,
+    }],
+    defaultAccount: {
+      id: 'acct-1',
+      account_name: 'Operating',
+      bank_name: 'First National',
+      next_check_number: 1001,
+      print_bank_info: false,
+      routing_number: null,
+      account_number_last4: null,
+      is_default: true,
+    },
+    isLoading: false,
+    claimCheckNumbers: { mutateAsync: claimCheckNumbersMock },
+    fetchAccountSecrets: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useCheckAuditLog', () => ({
+  useCheckAuditLog: () => ({
+    auditLog: [],
+    isLoading: false,
+    logCheckAction: { mutateAsync: logCheckActionMock },
+  }),
+}));
+
+vi.mock('@/hooks/usePendingOutflows', () => ({
+  usePendingOutflowMutations: () => ({
+    createPendingOutflow: { mutateAsync: createPendingOutflowMock },
+  }),
+}));
+
+vi.mock('@/hooks/useSuppliers', () => ({
+  useSuppliers: () => ({ suppliers: [] }),
+}));
+
+vi.mock('@/components/subscription', () => ({
+  FeatureGate: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/components/banking/SearchableAccountSelector', () => ({
+  SearchableAccountSelector: ({
+    onValueChange,
+    triggerAriaLabel,
+    value,
+  }: {
+    onValueChange: (value: string) => void;
+    triggerAriaLabel?: string;
+    value?: string;
+  }) => (
+    <button
+      type="button"
+      aria-label={triggerAriaLabel}
+      data-current-value={value ?? ''}
+      onClick={() => onValueChange('acc-food')}
+    >
+      Pick category
+    </button>
+  ),
+}));
+
+vi.mock('@/utils/checkPrinting', async () => {
+  const actual = await vi.importActual<any>('@/utils/checkPrinting');
+  return {
+    ...actual,
+    generateCheckPDF: vi.fn().mockReturnValue({ save: vi.fn() }),
+    generateCheckPDFAsync: vi.fn().mockResolvedValue({ save: vi.fn() }),
+  };
+});
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import PrintChecks from '@/pages/PrintChecks';
+
+describe('PrintChecks — per-row Category column', () => {
+  beforeEach(() => {
+    claimCheckNumbersMock.mockReset().mockResolvedValue(1001);
+    createPendingOutflowMock.mockReset().mockResolvedValue({ id: 'outflow-new-1' });
+    logCheckActionMock.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('renders a Category column header', () => {
+    render(<PrintChecks />);
+    expect(screen.getByRole('columnheader', { name: /category/i })).toBeInTheDocument();
+  });
+
+  it('renders a per-row category selector with a row-scoped aria-label', () => {
+    render(<PrintChecks />);
+    expect(
+      screen.getByRole('button', { name: /category for check row 1/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('passes the chosen category_id through to createPendingOutflow', async () => {
+    const user = userEvent.setup();
+    render(<PrintChecks />);
+
+    await user.type(screen.getByPlaceholderText(/vendor name/i), 'Sysco');
+    await user.type(screen.getByPlaceholderText('0.00'), '125.50');
+
+    await user.click(screen.getByRole('button', { name: /category for check row 1/i }));
+
+    await user.click(screen.getByRole('button', { name: /^Print 1 Check$/i }));
+
+    await waitFor(() => expect(createPendingOutflowMock).toHaveBeenCalledTimes(1));
+    expect(createPendingOutflowMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        vendor_name: 'Sysco',
+        amount: 125.5,
+        category_id: 'acc-food',
+      }),
+    );
+  });
+
+  it('defaults category_id to null when no category is picked', async () => {
+    const user = userEvent.setup();
+    render(<PrintChecks />);
+
+    await user.type(screen.getByPlaceholderText(/vendor name/i), 'Sysco');
+    await user.type(screen.getByPlaceholderText('0.00'), '99.00');
+
+    await user.click(screen.getByRole('button', { name: /^Print 1 Check$/i }));
+
+    await waitFor(() => expect(createPendingOutflowMock).toHaveBeenCalledTimes(1));
+    expect(createPendingOutflowMock).toHaveBeenCalledWith(
+      expect.objectContaining({ category_id: null }),
+    );
+  });
+});
+```
+
+### Step 4.2 — Run test, confirm RED
+
+```bash
+npm run test -- tests/unit/PrintChecksCategoryColumn.test.tsx
+```
+
+Expected: All four tests FAIL (no Category column, no selector, no category_id in payload).
+
+### Step 4.3 — Edit `src/pages/PrintChecks.tsx`
+
+Apply these edits in order:
+
+**4.3a — Import `SearchableAccountSelector`.** Add to the existing imports near the top of the file:
+
+```ts
+import { SearchableAccountSelector } from '@/components/banking/SearchableAccountSelector';
+```
+
+**4.3b — Widen `CheckRow` and `createEmptyRow`:**
+
+```ts
+interface CheckRow {
+  id: string;
+  payeeName: string;
+  amount: string;
+  issueDate: string;
+  memo: string;
+  categoryId: string | null;
+  selected: boolean;
+}
+
+function createEmptyRow(): CheckRow {
+  return {
+    id: crypto.randomUUID(),
+    payeeName: '',
+    amount: '',
+    issueDate: format(new Date(), 'yyyy-MM-dd'),
+    memo: '',
+    categoryId: null,
+    selected: true,
+  };
+}
+```
+
+**4.3c — Widen `updateRow` signature:**
+
+```ts
+const updateRow = useCallback((id: string, field: keyof CheckRow, value: string | boolean | null) => {
+  setRows((prev) => prev.map((r) => (r.id === id ? { ...r, [field]: value } : r)));
+}, []);
+```
+
+**4.3d — Refactor the print loop to a `CheckJob` shape.** Replace the body of `handlePrint` (the section between `setIsPrinting(true)` and `pdf.save(filename)`) so that the per-row data flows through one structure:
+
+```ts
+const startNumber = await claimCheckNumbers.mutateAsync({
+  accountId: selectedAccount.id,
+  count: selectedRows.length,
+});
+
+type CheckJob = CheckData & { categoryId: string | null };
+const jobs: CheckJob[] = selectedRows.map((row, i) => ({
+  checkNumber: startNumber + i,
+  payeeName: row.payeeName.trim(),
+  amount: parseFloat(row.amount),
+  issueDate: row.issueDate,
+  memo: row.memo.trim() || undefined,
+  categoryId: row.categoryId,
+}));
+
+for (const job of jobs) {
+  const outflow = await createPendingOutflow.mutateAsync({
+    vendor_name: job.payeeName,
+    amount: job.amount,
+    payment_method: 'check',
+    reference_number: String(job.checkNumber),
+    issue_date: job.issueDate,
+    notes: job.memo ?? null,
+    category_id: job.categoryId,
+  });
+
+  await logCheckAction.mutateAsync({
+    check_number: job.checkNumber,
+    payee_name: job.payeeName,
+    amount: job.amount,
+    issue_date: job.issueDate,
+    memo: job.memo ?? null,
+    action: 'printed',
+    pending_outflow_id: outflow.id,
+    check_bank_account_id: selectedAccount.id,
+  });
+}
+
+const checks: CheckData[] = jobs.map(({ categoryId: _ignored, ...rest }) => rest);
+const config = buildPrintConfig(settings, selectedAccount, secrets);
+const pdf = selectedAccount.print_bank_info
+  ? await generateCheckPDFAsync(config, checks)
+  : generateCheckPDF(config, checks);
+const filename = generateCheckFilename(
+  selectedRestaurant.restaurant.name,
+  checks.map((c) => c.checkNumber),
+);
+pdf.save(filename);
+
+toast.success(`${checks.length} check${checks.length > 1 ? 's' : ''} printed`);
+
+setRows([createEmptyRow()]);
+```
+
+**4.3e — Add the Category column header.** Inside the `<TableHeader><TableRow>` block, between the Memo `<TableHead>` and the trailing empty `<TableHead className="w-10" />`, insert:
+
+```tsx
+<TableHead className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
+  Category
+</TableHead>
+```
+
+**4.3f — Add the Category body cell.** Inside the `rows.map((row, rowIndex) => ...)` block, after the Memo `<TableCell>` and before the trash `<TableCell>`, insert:
+
+```tsx
+<TableCell>
+  <div className="w-48">
+    <SearchableAccountSelector
+      value={row.categoryId ?? undefined}
+      onValueChange={(v) => updateRow(row.id, 'categoryId', v || null)}
+      filterByTypes={['expense', 'cogs', 'asset']}
+      placeholder="Optional"
+      triggerAriaLabel={`Category for check row ${rowIndex + 1}`}
+    />
+  </div>
+</TableCell>
+```
+
+### Step 4.4 — Run test, confirm GREEN
+
+```bash
+npm run test -- tests/unit/PrintChecksCategoryColumn.test.tsx
+```
+
+Expected: All four tests PASS.
+
+### Step 4.5 — Run the full unit suite to catch regressions
+
+```bash
+npm run test -- tests/unit/PrintChecks tests/unit/checkPrinting tests/unit/SearchableAccountSelector
+```
+
+Expected: No regressions in adjacent suites.
+
+### Step 4.6 — Commit
+
+```bash
+git add src/pages/PrintChecks.tsx tests/unit/PrintChecksCategoryColumn.test.tsx
+git commit -m "feat(print-checks): per-row Category column on Write Checks page
+
+Each batch check row gains an optional chart-of-accounts category
+picker. The category travels with the row through the print job and
+lands on the resulting pending_outflows row, so the user never has to
+hunt down the expense afterward to categorize it."
+```
+
+---
+
+## Task 5 — `PrintCheckButton.tsx`: Category field on per-expense print dialog
+
+**Files:**
+- Modify: `src/components/pending-outflows/PrintCheckButton.tsx`
+- Create: `tests/unit/PrintCheckButtonCategory.test.tsx`
+
+### Step 5.1 — Write the failing test
+
+Create `tests/unit/PrintCheckButtonCategory.test.tsx`:
+
+```tsx
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const claimForAccountMutateAsync = vi.fn();
+const fetchAccountSecretsMock = vi.fn();
+const updatePendingOutflowMutateAsync = vi.fn();
+const logCheckActionMutateAsync = vi.fn();
+
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => ({
+    selectedRestaurant: { restaurant: { name: 'Test Restaurant' }, restaurant_id: 'rest-1' },
+  }),
+}));
+
+vi.mock('@/hooks/useCheckSettings', () => ({
+  useCheckSettings: () => ({
+    settings: {
+      id: 'set-1',
+      restaurant_id: 'rest-1',
+      business_name: 'Test Restaurant LLC',
+      business_address_line1: '123 Main St',
+      business_address_line2: null,
+      business_city: 'Austin',
+      business_state: 'TX',
+      business_zip: '78701',
+      bank_name: null,
+      print_bank_info: false,
+      routing_number: null,
+      signature_url: null,
+    },
+  }),
+}));
+
+vi.mock('@/hooks/useCheckBankAccounts', () => ({
+  useCheckBankAccounts: () => ({
+    accounts: [{
+      id: 'acct-1',
+      account_name: 'Operating',
+      bank_name: 'First National',
+      next_check_number: 1001,
+      print_bank_info: false,
+      routing_number: null,
+      account_number_last4: null,
+      is_default: true,
+    }],
+    defaultAccount: {
+      id: 'acct-1',
+      account_name: 'Operating',
+      bank_name: 'First National',
+      next_check_number: 1001,
+      print_bank_info: false,
+      routing_number: null,
+      account_number_last4: null,
+      is_default: true,
+    },
+    claimCheckNumbers: { mutateAsync: claimForAccountMutateAsync },
+    fetchAccountSecrets: fetchAccountSecretsMock,
+  }),
+}));
+
+vi.mock('@/hooks/useCheckAuditLog', () => ({
+  useCheckAuditLog: () => ({
+    logCheckAction: { mutateAsync: logCheckActionMutateAsync },
+  }),
+}));
+
+vi.mock('@/hooks/usePendingOutflows', () => ({
+  usePendingOutflowMutations: () => ({
+    updatePendingOutflow: { mutateAsync: updatePendingOutflowMutateAsync },
+  }),
+}));
+
+vi.mock('@/components/banking/SearchableAccountSelector', () => ({
+  SearchableAccountSelector: ({
+    onValueChange,
+    value,
+  }: {
+    onValueChange: (value: string) => void;
+    value?: string;
+  }) => (
+    <button
+      type="button"
+      data-testid="category-selector"
+      data-current-value={value ?? ''}
+      onClick={() => onValueChange('acc-rent')}
+    >
+      Pick category
+    </button>
+  ),
+}));
+
+vi.mock('@/utils/checkPrinting', async () => {
+  const actual = await vi.importActual<any>('@/utils/checkPrinting');
+  return {
+    ...actual,
+    generateCheckPDF: vi.fn().mockReturnValue({ save: vi.fn() }),
+    generateCheckPDFAsync: vi.fn().mockResolvedValue({ save: vi.fn() }),
+  };
+});
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { PrintCheckButton } from '@/components/pending-outflows/PrintCheckButton';
+import type { PendingOutflow } from '@/types/pending-outflows';
+
+function makeExpense(overrides: Partial<PendingOutflow> = {}): PendingOutflow {
+  return {
+    id: 'pof-1',
+    restaurant_id: 'rest-1',
+    vendor_name: 'ACME Rent',
+    category_id: null,
+    payment_method: 'check',
+    amount: 1200,
+    issue_date: '2026-05-22',
+    due_date: null,
+    notes: null,
+    reference_number: null,
+    status: 'pending',
+    linked_bank_transaction_id: null,
+    cleared_at: null,
+    voided_at: null,
+    voided_reason: null,
+    created_at: '2026-05-22T00:00:00Z',
+    updated_at: '2026-05-22T00:00:00Z',
+    chart_account: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  claimForAccountMutateAsync.mockReset().mockResolvedValue(1001);
+  fetchAccountSecretsMock.mockReset().mockResolvedValue(null);
+  updatePendingOutflowMutateAsync.mockReset().mockResolvedValue({});
+  logCheckActionMutateAsync.mockReset().mockResolvedValue(undefined);
+});
+
+describe('PrintCheckButton — Category field', () => {
+  it('passes the newly picked category_id when the expense was uncategorized', async () => {
+    const user = userEvent.setup();
+    render(<PrintCheckButton expense={makeExpense()} />);
+
+    await user.click(screen.getByRole('button', { name: /^Print check for ACME Rent$/i }));
+    await user.click(screen.getByTestId('category-selector'));
+    await user.click(screen.getByRole('button', { name: /^Print Check$/i }));
+
+    await waitFor(() => expect(updatePendingOutflowMutateAsync).toHaveBeenCalledTimes(1));
+    expect(updatePendingOutflowMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'pof-1',
+        input: expect.objectContaining({
+          payment_method: 'check',
+          category_id: 'acc-rent',
+        }),
+      }),
+    );
+  });
+
+  it('keeps the existing category_id when the user leaves the field alone', async () => {
+    const user = userEvent.setup();
+    render(<PrintCheckButton expense={makeExpense({ category_id: 'acc-preexisting' })} />);
+
+    await user.click(screen.getByRole('button', { name: /^Print check for ACME Rent$/i }));
+    expect(screen.getByTestId('category-selector')).toHaveAttribute(
+      'data-current-value',
+      'acc-preexisting',
+    );
+
+    await user.click(screen.getByRole('button', { name: /^Print Check$/i }));
+
+    await waitFor(() => expect(updatePendingOutflowMutateAsync).toHaveBeenCalledTimes(1));
+    expect(updatePendingOutflowMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({ category_id: 'acc-preexisting' }),
+      }),
+    );
+  });
+
+  it('overrides an existing category_id when the user picks a different one', async () => {
+    const user = userEvent.setup();
+    render(<PrintCheckButton expense={makeExpense({ category_id: 'acc-old' })} />);
+
+    await user.click(screen.getByRole('button', { name: /^Print check for ACME Rent$/i }));
+    await user.click(screen.getByTestId('category-selector'));
+    await user.click(screen.getByRole('button', { name: /^Print Check$/i }));
+
+    await waitFor(() => expect(updatePendingOutflowMutateAsync).toHaveBeenCalledTimes(1));
+    expect(updatePendingOutflowMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({ category_id: 'acc-rent' }),
+      }),
+    );
+  });
+});
+```
+
+### Step 5.2 — Run test, confirm RED
+
+```bash
+npm run test -- tests/unit/PrintCheckButtonCategory.test.tsx
+```
+
+Expected: All three tests FAIL (selector not rendered, `category_id` not in payload).
+
+### Step 5.3 — Edit `src/components/pending-outflows/PrintCheckButton.tsx`
+
+**5.3a — Add the `SearchableAccountSelector` import** alongside other imports near the top:
+
+```ts
+import { SearchableAccountSelector } from '@/components/banking/SearchableAccountSelector';
+```
+
+**5.3b — Add state.** Below the existing `useState` block:
+
+```ts
+const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(
+  expense.category_id ?? null,
+);
+```
+
+**5.3c — Reset state when the dialog reopens.** Below the existing `useEffect` that resets `memo`:
+
+```ts
+useEffect(() => {
+  if (!open) return;
+  setSelectedCategoryId(expense.category_id ?? null);
+}, [open, expense.category_id]);
+```
+
+**5.3d — Pass `category_id` in the update payload.** In `handlePrint`, change the `updatePendingOutflow.mutateAsync({...})` call to include the new field:
+
+```ts
+await updatePendingOutflow.mutateAsync({
+  id: expense.id,
+  input: {
+    payment_method: 'check',
+    reference_number: String(checkNumber),
+    notes: memo.trim() || expense.notes,
+    check_bank_account_id: selectedAccount.id,
+    category_id: selectedCategoryId,
+  },
+});
+```
+
+**5.3e — Add the Category field to the dialog body.** Inside the `<div className="px-6 py-5 space-y-5">` block, immediately after the Memo block and before the closing `</div>` of that section:
+
+```tsx
+<div className="space-y-2">
+  <Label htmlFor="print-check-category" className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
+    Category (optional)
+  </Label>
+  <SearchableAccountSelector
+    value={selectedCategoryId ?? undefined}
+    onValueChange={(v) => setSelectedCategoryId(v || null)}
+    filterByTypes={['expense', 'cogs', 'asset']}
+    placeholder="Pick a chart-of-accounts category"
+    triggerAriaLabel="Category for this check"
+  />
+</div>
+```
+
+**5.3f — Add overflow classes to the dialog.** Change the `<DialogContent>` opening tag from:
+
+```tsx
+<DialogContent className="max-w-md p-0 gap-0 border-border/40">
+```
+
+…to:
+
+```tsx
+<DialogContent className="max-w-md max-h-[80vh] overflow-y-auto p-0 gap-0 border-border/40">
+```
+
+### Step 5.4 — Run test, confirm GREEN
+
+```bash
+npm run test -- tests/unit/PrintCheckButtonCategory.test.tsx
+```
+
+Expected: All three tests PASS.
+
+### Step 5.5 — Commit
+
+```bash
+git add src/components/pending-outflows/PrintCheckButton.tsx tests/unit/PrintCheckButtonCategory.test.tsx
+git commit -m "feat(print-check-button): optional category on per-expense print dialog
+
+Pre-fills from the expense's existing category_id (so already-categorized
+expenses stay categorized) and lets the user override at print time.
+Also fixes a missing max-h-[80vh] / overflow-y-auto on the dialog —
+needed now that the body grows by one field."
+```
+
+---
+
+## Task 6 — Manual sanity check + push
+
+### Step 6.1 — Typecheck, lint, build
+
+```bash
+npm run typecheck && npm run lint && npm run build
+```
+
+Expected: all three exit zero. If `typecheck` flags the `as any` removal on the `chart_account` projection, re-read `src/types/pending-outflows.ts` and make sure `chart_account?: { account_name: string } | null` still satisfies the query result.
+
+### Step 6.2 — Full unit suite
+
+```bash
+npm run test
+```
+
+Expected: all suites green. New tests included:
+- `tests/unit/SearchableAccountSelector.ariaLabel.test.tsx`
+- `tests/unit/PrintChecksCategoryColumn.test.tsx`
+- `tests/unit/PrintCheckButtonCategory.test.tsx`
+
+### Step 6.3 — Full pgTAP suite
+
+```bash
+npm run db:reset && npm run test:db
+```
+
+Expected: all pgTAP suites green, including the new `pending_outflows_category_same_restaurant.test.sql`.
+
+### Step 6.4 — End of plan
+
+No commit at this step — the Phase 8 / Phase 9 verification loop owns the rest. Hand off to the multi-model review skill.
+
+---
+
+## Self-Review
+
+1. **Spec coverage**
+   - Spec §Data model (no schema rewrite) → Tasks 2 + 3 (trigger + index, plus pgTAP). ✅
+   - Spec §`PrintChecks.tsx` (Row shape / updateRow widening / table column / print handler refactor / aria-label / collisionPadding) → Tasks 1 + 4. ✅
+   - Spec §`PrintCheckButton.tsx` (state, reset, update payload, dialog body, overflow class) → Task 5. ✅
+   - Spec §Visual notes (console.log cleanup) → Task 1.3. ✅
+   - Spec §Tests (PrintChecks Category column, PrintCheckButton three cases, new pgTAP file) → Tasks 2.1, 3.1, 4.1, 5.1. ✅
+   - Spec §Decided trade-offs → no implementation work (deferred items). ✅
+
+2. **Placeholder scan** — no "TBD" / "TODO" / vague "add appropriate error handling" / "similar to" references. All steps show concrete code or commands. ✅
+
+3. **Type consistency**
+   - `CheckRow.categoryId: string | null` is used consistently in 4.3b, 4.3c, 4.3d, 4.3f. ✅
+   - `triggerAriaLabel?: string` (Task 1) → consumed in 4.3f (`Category for check row ${rowIndex + 1}`). ✅
+   - `CheckJob = CheckData & { categoryId: string | null }` defined and used inside `handlePrint`'s scope only (Task 4.3d). ✅
+   - `category_id` snake-case at DB / API boundary (`createPendingOutflow.mutateAsync`, `updatePendingOutflow.mutateAsync`), `categoryId` camelCase in component state. Consistent with the rest of the codebase (`useBankTransactions`, `usePendingOutflows`). ✅

--- a/docs/superpowers/specs/2026-05-22-check-create-with-category-design.md
+++ b/docs/superpowers/specs/2026-05-22-check-create-with-category-design.md
@@ -35,23 +35,78 @@ common path ("print this check and book it to Office Supplies") is one screen.
 - New chart-of-accounts UI. We reuse `SearchableAccountSelector`.
 - Schema changes. `pending_outflows.category_id` already exists.
 
-## Data model — no changes
+## Data model — minor hardening, no schema rewrite
+
+The column itself already exists:
 
 ```
 pending_outflows.category_id uuid NULL  REFERENCES chart_of_accounts(id)
 ```
 
-That column already exists and the relevant TypeScript types already accept
-it:
+…and the TypeScript types already accept it:
 
 - `CreatePendingOutflowInput.category_id?: string | null`
 - `UpdatePendingOutflowInput.category_id?: string | null`
 
 The `usePendingOutflows` query already joins
 `chart_account:chart_of_accounts!category_id(id, account_name)`, so reading
-the category back on the expenses list also already works.
+the category back on the expenses list already works.
 
-No migration. No RPC. No RLS change.
+**Two new migrations** are included (motivated by the Phase 2.5 supabase
+reviewer):
+
+### Migration A — same-restaurant FK guard
+
+Today the FK only enforces that `category_id` references *some* row in
+`chart_of_accounts`. It does not enforce that the referenced row's
+`restaurant_id` matches the outflow's `restaurant_id`. In normal UI flow
+this is invisible because the SELECT RLS on `chart_of_accounts` prevents
+the user from seeing other restaurants' accounts. But a malicious or
+buggy client could write a foreign `category_id` directly via the API.
+Since this feature is the first one to put a category picker on a
+high-volume create path, harden it now.
+
+```sql
+CREATE OR REPLACE FUNCTION assert_pending_outflow_category_same_restaurant()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.category_id IS NOT NULL THEN
+    PERFORM 1
+      FROM chart_of_accounts
+     WHERE id = NEW.category_id
+       AND restaurant_id = NEW.restaurant_id;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION
+        'pending_outflows.category_id % does not belong to restaurant %',
+        NEW.category_id, NEW.restaurant_id
+        USING ERRCODE = 'foreign_key_violation';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER pending_outflows_category_same_restaurant
+BEFORE INSERT OR UPDATE OF category_id, restaurant_id ON pending_outflows
+FOR EACH ROW
+EXECUTE FUNCTION assert_pending_outflow_category_same_restaurant();
+```
+
+### Migration B — partial index on `category_id`
+
+Aggregation read paths (`expenseDataFetcher`, `useMonthlyMetrics`,
+`useExpenseHealth`) already join `chart_of_accounts!category_id` and
+will start hitting populated values much more often once this feature
+ships. Historical rows are mostly `NULL`, so a partial index is the
+right shape:
+
+```sql
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_pending_outflows_category
+  ON pending_outflows(category_id)
+  WHERE category_id IS NOT NULL;
+```
+
+No RPC change, no RLS policy change, no column changes.
 
 ## UI changes
 
@@ -73,6 +128,12 @@ interface CheckRow {
 
 `createEmptyRow()` initializes `categoryId: null`.
 
+**`updateRow` signature widening.** The existing helper is typed
+`(id, field: keyof CheckRow, value: string | boolean) => void`. `null`
+is not assignable to that union, so the signature widens to
+`string | boolean | null`. All existing callers pass `string` or
+`boolean`, so the widening is non-breaking.
+
 **Table layout.** Insert a new "Category" column between Memo and the trash
 button. Header cell follows the existing typography
 (`text-[12px] font-medium text-muted-foreground uppercase tracking-wider`).
@@ -93,25 +154,55 @@ height stays uniform. The selector is the same component used by
 search behavior, parent/child grouping, and keyboard navigation are
 already battle-tested.
 
-**Print handler.** In `handlePrint`, when iterating `selectedRows`:
+**Accessibility — per-row aria-label.** The header `<TableHead>Category`
+is a *column* label, not a per-cell programmatic label. Each row's
+combobox trigger needs its own accessible name. `SearchableAccountSelector`
+gains a new optional `triggerAriaLabel?: string` prop that gets forwarded
+to the underlying `<Button role="combobox">`. The Write Checks page
+passes `triggerAriaLabel={`Category for ${row.payeeName || 'check row ' + (rowIndex + 1)}`}`
+per row.
+
+**Popover collision padding.** `PopoverContent` (Radix) is portal-mounted
+so the `overflow-x-auto` wrapper does not clip it, but on narrow viewports
+the 350 px popover can collide with the right edge. Pass
+`collisionPadding={8}` on the popover content inside
+`SearchableAccountSelector`. (Already inside that component — a single
+file edit covers every consumer.)
+
+**Print handler.** Instead of relying on positional alignment between
+`checks[]` and `selectedRows[]` (fragile under later refactors), carry
+`categoryId` *on* the per-check intermediate value:
 
 ```ts
-const outflow = await createPendingOutflow.mutateAsync({
-  vendor_name: check.payeeName,
-  amount: check.amount,
-  payment_method: 'check',
-  reference_number: String(check.checkNumber),
-  issue_date: check.issueDate,
-  notes: check.memo ?? null,
-  category_id: row.categoryId ?? null,   // NEW
-});
+type CheckJob = CheckData & { categoryId: string | null };
+
+const jobs: CheckJob[] = selectedRows.map((row, i) => ({
+  checkNumber: startNumber + i,
+  payeeName: row.payeeName.trim(),
+  amount: parseFloat(row.amount),
+  issueDate: row.issueDate,
+  memo: row.memo.trim() || undefined,
+  categoryId: row.categoryId ?? null,
+}));
+
+for (const job of jobs) {
+  const outflow = await createPendingOutflow.mutateAsync({
+    vendor_name: job.payeeName,
+    amount: job.amount,
+    payment_method: 'check',
+    reference_number: String(job.checkNumber),
+    issue_date: job.issueDate,
+    notes: job.memo ?? null,
+    category_id: job.categoryId,
+  });
+  // …logCheckAction unchanged…
+}
 ```
 
-The check loop already iterates `selectedRows` post-validation; we need to
-zip the `row` reference into the loop so each `check` can look up its
-matching `categoryId`. (Simplest fix: replace the `for (const check of
-checks)` shape with `for (let i = 0; i < selectedRows.length; i++)` and
-read both `checks[i]` and `selectedRows[i]`.)
+`generateCheckPDF` then receives `jobs` cast/sliced to `CheckData[]`
+(the PDF renderer doesn't need `categoryId`). The categoryId travels
+with the row it came from, so any future filter/reorder of `jobs`
+keeps the category attached to the correct expense.
 
 **Reset.** `setRows([createEmptyRow()])` already clears state on success;
 `createEmptyRow` returns `categoryId: null`, so no extra reset wiring.
@@ -175,6 +266,15 @@ await updatePendingOutflow.mutateAsync({
   an extra column doesn't break narrow viewports — it just makes more
   horizontal scroll. Acceptable; matches today's behaviour for the wide
   layout.
+- `PrintCheckButton`'s `DialogContent` currently has no `max-h-[80vh]` /
+  `overflow-y-auto`. Adding the Category field is the natural moment to
+  add those classes so the dialog stays usable on phones with the
+  software keyboard open (the existing CLAUDE.md dialog template uses
+  exactly those classes).
+- `SearchableAccountSelector` currently emits two `console.log` calls on
+  every render (lines 70–71). Both new surfaces would re-emit them in
+  production. Removed in the same PR — one-line cleanup adjacent to the
+  prop and `collisionPadding` changes already required.
 
 ## Behaviour
 
@@ -252,11 +352,27 @@ Three cases in one file:
   via `getByRole('combobox')` / `getByRole('option', { name: ... })`
   rather than `getByText` where possible.
 
+### `supabase/tests/pending_outflows_category_same_restaurant.test.sql` (new)
+
+pgTAP test for Migration A. Two assertions:
+
+1. `lives_ok($$INSERT INTO pending_outflows (..., category_id) VALUES (..., <same-restaurant-account>)$$)`
+2. `throws_ok($$INSERT INTO pending_outflows (..., category_id) VALUES (..., <other-restaurant-account>)$$, '23503')`
+
+(ERRCODE `23503` = `foreign_key_violation`, which is what
+`RAISE EXCEPTION ... USING ERRCODE` emits.)
+
+Also a third assertion to cover the UPDATE path: insert with
+`category_id = NULL`, then attempt to update to a foreign category id;
+expect the same `23503`.
+
 ### Existing test impact
 
 - `tests/unit/checkPrinting.test.ts` (the PDF generation tests) is
   untouched — the PDF render doesn't take a category. No change there.
-- No pgTAP changes — schema is unchanged.
+- One Vitest fixture (`tests/unit/SearchableAccountSelector.test.tsx`,
+  if present) may need a small update to cover the new
+  `triggerAriaLabel` prop. Verified during implementation.
 
 ## Risk
 
@@ -266,9 +382,32 @@ Three cases in one file:
   field doesn't appear in the UI" (caught by render tests) or "the field
   appears but isn't passed through" (caught by mutation assertion tests).
 
+## Decided trade-offs (Phase 2.5 review)
+
+The Phase 2.5 frontend and supabase reviewers raised six concerns. Three
+are folded into the design above (cross-restaurant trigger, partial
+index, aria-label / collisionPadding / dialog overflow / console-log
+cleanup, positional-indexing refactor, `updateRow` typing widening). The
+remaining three are explicitly **deferred**:
+
+1. **`useChartOfAccounts` does not surface an `error` value to consumers.**
+   Pre-existing across five call sites. Mitigation: today the selector
+   shows the empty state on errors (data defaults to `[]`), so users
+   physically cannot pick a wrong value. Fixing the error surface is a
+   separate cross-cutting refactor.
+2. **`useChartOfAccounts` `staleTime: 5 * 60 * 1000` exceeds the
+   CLAUDE.md 60s cap.** Same pre-existing issue. Lowering it here would
+   reduce cache effectiveness for the five other call sites without a
+   user-visible win — chart-of-accounts edits are infrequent.
+3. **`useMonthlyMetrics` labor path matches on `account_subtype === 'labor'`
+   without applying `isTransferCategoryType`.** The supabase reviewer
+   noted this could double-count if a user creates an asset-typed
+   account with subtype "labor". Probability ≈ zero (asset/labor is a
+   nonsensical pairing in the seeded chart). Tracked but not in scope.
+
 ## Open questions
 
-None. All three design questions resolved in brainstorming:
+None. All three brainstorming questions resolved:
 
 - Q1 batch UI placement → per-row column in the table.
 - Q2 existing-expense flow → yes, add it there too for parity.

--- a/docs/superpowers/specs/2026-05-22-check-create-with-category-design.md
+++ b/docs/superpowers/specs/2026-05-22-check-create-with-category-design.md
@@ -1,0 +1,275 @@
+# Design — Optional category on check creation
+
+**Date:** 2026-05-22
+**Branch:** `feature/check-create-with-category`
+**Author:** Jose M Delgado (with Claude Code)
+
+## Problem
+
+When a user prints checks, every printed check creates a `pending_outflows`
+row (an "expense"). Today those expenses land **uncategorized**
+(`category_id IS NULL`). To attach a chart-of-accounts category the user has
+to leave the Print Checks flow, navigate to Expenses, find the row, open the
+edit sheet, pick the category, and save. That's three pages and a context
+switch per check.
+
+The user wants to pick the category **inline at check creation time** so the
+common path ("print this check and book it to Office Supplies") is one screen.
+
+## Goals
+
+- Allow setting an optional chart-of-accounts category when **creating** a
+  check on `/print-checks` (the batch "Write Checks" page).
+- Allow setting/overriding the same optional category when **printing a
+  check for an existing expense** via `PrintCheckButton` (the per-row print
+  dialog on the Pending Outflows view).
+- Keep category strictly optional — current uncategorized flow must still
+  work without any extra clicks.
+
+## Non-goals
+
+- Bulk re-categorization of historical checks. (Already covered by the
+  existing expense edit sheet and the Bank Transactions categorize panel.)
+- Default-category memory ("remember last category for vendor X"). Could
+  be a future iteration but is out of scope here.
+- New chart-of-accounts UI. We reuse `SearchableAccountSelector`.
+- Schema changes. `pending_outflows.category_id` already exists.
+
+## Data model — no changes
+
+```
+pending_outflows.category_id uuid NULL  REFERENCES chart_of_accounts(id)
+```
+
+That column already exists and the relevant TypeScript types already accept
+it:
+
+- `CreatePendingOutflowInput.category_id?: string | null`
+- `UpdatePendingOutflowInput.category_id?: string | null`
+
+The `usePendingOutflows` query already joins
+`chart_account:chart_of_accounts!category_id(id, account_name)`, so reading
+the category back on the expenses list also already works.
+
+No migration. No RPC. No RLS change.
+
+## UI changes
+
+### 1. `src/pages/PrintChecks.tsx` — batch Write Checks page
+
+**Row shape.** Extend the local `CheckRow` interface:
+
+```ts
+interface CheckRow {
+  id: string;
+  payeeName: string;
+  amount: string;
+  issueDate: string;
+  memo: string;
+  categoryId: string | null;   // NEW
+  selected: boolean;
+}
+```
+
+`createEmptyRow()` initializes `categoryId: null`.
+
+**Table layout.** Insert a new "Category" column between Memo and the trash
+button. Header cell follows the existing typography
+(`text-[12px] font-medium text-muted-foreground uppercase tracking-wider`).
+Body cell hosts:
+
+```tsx
+<SearchableAccountSelector
+  value={row.categoryId ?? undefined}
+  onValueChange={(v) => updateRow(row.id, 'categoryId', v || null)}
+  filterByTypes={['expense', 'cogs', 'asset']}
+  placeholder="Optional"
+/>
+```
+
+Sized roughly to match the Memo column (`w-48` give-or-take) so the row
+height stays uniform. The selector is the same component used by
+`AddExpenseSheet`, `AddPendingOutflowDialog`, and `EditExpenseSheet`, so
+search behavior, parent/child grouping, and keyboard navigation are
+already battle-tested.
+
+**Print handler.** In `handlePrint`, when iterating `selectedRows`:
+
+```ts
+const outflow = await createPendingOutflow.mutateAsync({
+  vendor_name: check.payeeName,
+  amount: check.amount,
+  payment_method: 'check',
+  reference_number: String(check.checkNumber),
+  issue_date: check.issueDate,
+  notes: check.memo ?? null,
+  category_id: row.categoryId ?? null,   // NEW
+});
+```
+
+The check loop already iterates `selectedRows` post-validation; we need to
+zip the `row` reference into the loop so each `check` can look up its
+matching `categoryId`. (Simplest fix: replace the `for (const check of
+checks)` shape with `for (let i = 0; i < selectedRows.length; i++)` and
+read both `checks[i]` and `selectedRows[i]`.)
+
+**Reset.** `setRows([createEmptyRow()])` already clears state on success;
+`createEmptyRow` returns `categoryId: null`, so no extra reset wiring.
+
+### 2. `src/components/pending-outflows/PrintCheckButton.tsx` — existing-expense dialog
+
+**State.** Add `selectedCategoryId: string | null`. Mirror the `memo`
+initialization pattern:
+
+```ts
+const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(
+  expense.category_id ?? null,
+);
+
+useEffect(() => {
+  if (!open) return;
+  setSelectedCategoryId(expense.category_id ?? null);
+}, [open, expense.category_id]);
+```
+
+**Dialog body.** Insert a "Category (optional)" block after the Memo input
+and before the dialog footer. Same Apple/Notion form styling already used
+elsewhere in this file:
+
+```tsx
+<div className="space-y-2">
+  <Label className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
+    Category (optional)
+  </Label>
+  <SearchableAccountSelector
+    value={selectedCategoryId ?? undefined}
+    onValueChange={(v) => setSelectedCategoryId(v || null)}
+    filterByTypes={['expense', 'cogs', 'asset']}
+    placeholder="Pick a chart-of-accounts category"
+  />
+</div>
+```
+
+**Print handler.** Add `category_id` to the `updatePendingOutflow` call:
+
+```ts
+await updatePendingOutflow.mutateAsync({
+  id: expense.id,
+  input: {
+    payment_method: 'check',
+    reference_number: String(checkNumber),
+    notes: memo.trim() || expense.notes,
+    check_bank_account_id: selectedAccount.id,
+    category_id: selectedCategoryId,   // NEW
+  },
+});
+```
+
+### 3. Visual notes / styling
+
+- Both surfaces use `SearchableAccountSelector` — that component renders a
+  `Popover` inside the trigger, which is portal-friendly and works inside
+  table cells and inside `DialogContent`.
+- Tailwind: existing tokens only. No new color usage.
+- Mobile: the Write Checks table is already inside `overflow-x-auto`, so
+  an extra column doesn't break narrow viewports — it just makes more
+  horizontal scroll. Acceptable; matches today's behaviour for the wide
+  layout.
+
+## Behaviour
+
+- **Empty category ⇒ unchanged behaviour.** `null` is still legal at the
+  database, type, and UI layer. Hitting Print without picking a category
+  produces the same `pending_outflow` rows we produce today.
+- **Per-row independence (batch page).** Two rows in the same print job
+  can have different categories.
+- **Override semantics (per-expense dialog).** When `expense.category_id`
+  is already set, the selector is prefilled. Saving without touching it
+  re-submits the same value — a no-op from the user's point of view.
+- **Order of operations (per-expense dialog).** Lesson #211 (from
+  PR #480–482): fetch encrypted MICR secrets BEFORE any write. We do not
+  change that. The `updatePendingOutflow` call (which now also carries
+  `category_id`) still runs **after** secrets resolve.
+- **Atomicity.** `category_id` rides in the same single-row insert/update
+  RPC as the rest of the expense; no second round-trip, no half-saved
+  state.
+
+## Error handling
+
+- If `chart_of_accounts` is empty for the restaurant,
+  `SearchableAccountSelector` shows its standard empty state ("No accounts
+  found") and the field stays disabled-by-effect (you literally can't pick
+  anything). Print path is unaffected because the field is optional.
+- If the user picks a category, then the chart-of-accounts row is deleted
+  between selection and print, the `category_id` insert would fail with a
+  FK violation. Probability ≈ zero (single-user dialog), and the existing
+  error toast in `createPendingOutflow.onError` surfaces it. Worth noting,
+  not worth defensive coding.
+
+## Testing
+
+All new files live under `tests/unit/` and use the existing Vitest
+fixtures and `vi.mock(...)` patterns.
+
+### `tests/unit/PrintChecksCategoryColumn.test.tsx` (new)
+
+1. Render `PrintChecks` with a mocked restaurant context, a mocked
+   `useCheckBankAccounts` returning one default account, a mocked
+   `useCheckSettings` returning configured settings, and a mocked
+   `useChartOfAccounts` returning three accounts (one expense, one COGS,
+   one asset).
+2. Fill in a payee name, amount, and date in row 1.
+3. Open the Category selector, pick "Food Costs" (the COGS account).
+4. Click Print.
+5. Assert `createPendingOutflow.mutateAsync` was called with
+   `category_id: '<food-costs-id>'`.
+
+### `tests/unit/PrintCheckButtonCategory.test.tsx` (new)
+
+Three cases in one file:
+
+1. **Uncategorized expense, user picks a category.** Render
+   `PrintCheckButton` for an expense with `category_id: null`, open the
+   dialog, pick a category from the selector, click Print. Assert
+   `updatePendingOutflow.mutateAsync` is called with the picked
+   `category_id`.
+2. **Pre-categorized expense, user keeps existing.** Render for an
+   expense already linked to "Office Supplies". Assert the selector
+   renders that account as its initial value. Click Print without
+   touching it. Assert `category_id` in the update payload equals the
+   original id.
+3. **Pre-categorized expense, user changes it.** Same setup as (2), but
+   pick a different account. Assert the update payload's `category_id`
+   matches the newly picked id.
+
+### Lesson-driven test discipline
+
+- Lesson #193 (SonarCloud new-code coverage ignores Vitest excludes):
+  these tests render the real components and the real
+  `SearchableAccountSelector` (not a mock) so the new column path and
+  the new dialog field are counted as covered lines.
+- Lesson #167 (Prefer structural `role`-based assertions): pick categories
+  via `getByRole('combobox')` / `getByRole('option', { name: ... })`
+  rather than `getByText` where possible.
+
+### Existing test impact
+
+- `tests/unit/checkPrinting.test.ts` (the PDF generation tests) is
+  untouched — the PDF render doesn't take a category. No change there.
+- No pgTAP changes — schema is unchanged.
+
+## Risk
+
+- **Low.** Surface area is two files plus two new tests, no schema
+  change, no RPC change. The new field is optional and already exists at
+  the DB layer, so a runtime regression can only manifest as either "the
+  field doesn't appear in the UI" (caught by render tests) or "the field
+  appears but isn't passed through" (caught by mutation assertion tests).
+
+## Open questions
+
+None. All three design questions resolved in brainstorming:
+
+- Q1 batch UI placement → per-row column in the table.
+- Q2 existing-expense flow → yes, add it there too for parity.
+- Q3 account filter → `['expense', 'cogs', 'asset']`.

--- a/src/components/banking/SearchableAccountSelector.tsx
+++ b/src/components/banking/SearchableAccountSelector.tsx
@@ -15,7 +15,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { useChartOfAccounts } from "@/hooks/useChartOfAccounts";
+import { useChartOfAccounts, type ChartAccount } from "@/hooks/useChartOfAccounts";
 import { useRestaurantContext } from "@/contexts/RestaurantContext";
 
 interface SearchableAccountSelectorProps {
@@ -27,6 +27,7 @@ interface SearchableAccountSelectorProps {
   autoOpen?: boolean;
   triggerAriaLabel?: string;
   triggerClassName?: string;
+  triggerId?: string;
 }
 
 export function SearchableAccountSelector({
@@ -38,6 +39,7 @@ export function SearchableAccountSelector({
   autoOpen = false,
   triggerAriaLabel,
   triggerClassName,
+  triggerId,
 }: SearchableAccountSelectorProps) {
   const [open, setOpen] = useState(autoOpen);
   const { selectedRestaurant } = useRestaurantContext();
@@ -90,7 +92,7 @@ export function SearchableAccountSelector({
         subAccounts: subsMap[account.id] || [] 
       });
       return acc;
-    }, {} as Record<string, Array<{ account: any; subAccounts: any[] }>>);
+    }, {} as Record<string, Array<{ account: ChartAccount; subAccounts: ChartAccount[] }>>);
   }, [filteredAccounts]);
 
   const isEmpty = !loading && filteredAccounts.length === 0;
@@ -107,6 +109,7 @@ export function SearchableAccountSelector({
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button
+          id={triggerId}
           variant="outline"
           role="combobox"
           aria-expanded={open}
@@ -153,7 +156,7 @@ export function SearchableAccountSelector({
                 <CommandEmpty>No account found.</CommandEmpty>
                 {Object.entries(organizedAccounts).map(([type, items]) => (
                   <CommandGroup key={type} heading={type}>
-                    {items.map(({ account, subAccounts }: any) => (
+                    {items.map(({ account, subAccounts }) => (
                       <div key={account.id}>
                         {/* Parent Account */}
                         <CommandItem
@@ -178,7 +181,7 @@ export function SearchableAccountSelector({
                         </CommandItem>
                         
                         {/* Sub-Accounts */}
-                        {subAccounts.map((subAccount: any) => (
+                        {subAccounts.map((subAccount) => (
                           <CommandItem
                             key={subAccount.id}
                             value={`${subAccount.account_code} ${subAccount.account_name} ${account.account_name}`}

--- a/src/components/banking/SearchableAccountSelector.tsx
+++ b/src/components/banking/SearchableAccountSelector.tsx
@@ -26,6 +26,7 @@ interface SearchableAccountSelectorProps {
   filterByTypes?: string[];
   autoOpen?: boolean;
   triggerAriaLabel?: string;
+  triggerClassName?: string;
 }
 
 export function SearchableAccountSelector({
@@ -36,6 +37,7 @@ export function SearchableAccountSelector({
   filterByTypes,
   autoOpen = false,
   triggerAriaLabel,
+  triggerClassName,
 }: SearchableAccountSelectorProps) {
   const [open, setOpen] = useState(autoOpen);
   const { selectedRestaurant } = useRestaurantContext();
@@ -110,7 +112,7 @@ export function SearchableAccountSelector({
           aria-expanded={open}
           aria-busy={loading}
           aria-label={triggerAriaLabel}
-          className="w-full justify-between"
+          className={cn("w-full justify-between", triggerClassName)}
           disabled={isDisabled}
         >
           {loading ? (

--- a/src/components/banking/SearchableAccountSelector.tsx
+++ b/src/components/banking/SearchableAccountSelector.tsx
@@ -25,6 +25,7 @@ interface SearchableAccountSelectorProps {
   disabled?: boolean;
   filterByTypes?: string[];
   autoOpen?: boolean;
+  triggerAriaLabel?: string;
 }
 
 export function SearchableAccountSelector({
@@ -34,6 +35,7 @@ export function SearchableAccountSelector({
   disabled = false,
   filterByTypes,
   autoOpen = false,
+  triggerAriaLabel,
 }: SearchableAccountSelectorProps) {
   const [open, setOpen] = useState(autoOpen);
   const { selectedRestaurant } = useRestaurantContext();
@@ -66,9 +68,6 @@ export function SearchableAccountSelector({
   // Organize accounts with parent-child relationships
   const organizedAccounts = useMemo(() => {
     if (!filteredAccounts) return {};
-    
-    console.log('[SearchableAccountSelector] Filtered accounts:', filteredAccounts);
-    console.log('[SearchableAccountSelector] Filter types:', filterByTypes);
     
     // Separate parents and subs
     const parents = filteredAccounts.filter(acc => !acc.parent_account_id);
@@ -110,6 +109,7 @@ export function SearchableAccountSelector({
           role="combobox"
           aria-expanded={open}
           aria-busy={loading}
+          aria-label={triggerAriaLabel}
           className="w-full justify-between"
           disabled={isDisabled}
         >
@@ -131,9 +131,10 @@ export function SearchableAccountSelector({
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent 
-        className="w-[350px] p-0 bg-background z-50" 
+      <PopoverContent
+        className="w-[350px] p-0 bg-background z-50"
         align="start"
+        collisionPadding={8}
         onWheel={(e) => e.stopPropagation()}
         onTouchMove={(e) => e.stopPropagation()}
       >

--- a/src/components/pending-outflows/PrintCheckButton.tsx
+++ b/src/components/pending-outflows/PrintCheckButton.tsx
@@ -25,6 +25,7 @@ import { useCheckSettings } from '@/hooks/useCheckSettings';
 import { useCheckBankAccounts } from '@/hooks/useCheckBankAccounts';
 import { useCheckAuditLog } from '@/hooks/useCheckAuditLog';
 import { usePendingOutflowMutations } from '@/hooks/usePendingOutflows';
+import { SearchableAccountSelector } from '@/components/banking/SearchableAccountSelector';
 import {
   generateCheckPDF,
   generateCheckPDFAsync,
@@ -52,12 +53,20 @@ export function PrintCheckButton({ expense }: PrintCheckButtonProps) {
   const [memo, setMemo] = useState(expense.notes ?? '');
   const [isPrinting, setIsPrinting] = useState(false);
   const [selectedAccountId, setSelectedAccountId] = useState<string | null>(null);
+  const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(
+    expense.category_id ?? null,
+  );
 
   // Reset memo only when opening (or expense changes before opening)
   useEffect(() => {
     if (!open) return;
     setMemo(expense.notes ?? '');
   }, [open, expense.notes]);
+
+  useEffect(() => {
+    if (!open) return;
+    setSelectedCategoryId(expense.category_id ?? null);
+  }, [open, expense.category_id]);
 
   // Initialize account selection once per open cycle
   useEffect(() => {
@@ -111,6 +120,7 @@ export function PrintCheckButton({ expense }: PrintCheckButtonProps) {
           reference_number: String(checkNumber),
           notes: memo.trim() || expense.notes,
           check_bank_account_id: selectedAccount.id,
+          category_id: selectedCategoryId,
         },
       });
 
@@ -168,7 +178,7 @@ export function PrintCheckButton({ expense }: PrintCheckButtonProps) {
       </Button>
 
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="max-w-md p-0 gap-0 border-border/40">
+        <DialogContent className="max-w-md max-h-[80vh] overflow-y-auto p-0 gap-0 border-border/40">
           <DialogHeader className="px-6 pt-6 pb-4 border-b border-border/40">
             <div className="flex items-center gap-3">
               <div className="h-10 w-10 rounded-xl bg-muted/50 flex items-center justify-center">
@@ -235,6 +245,20 @@ export function PrintCheckButton({ expense }: PrintCheckButtonProps) {
                 onChange={(e) => setMemo(e.target.value)}
                 placeholder="Purpose of payment"
                 className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
+              />
+            </div>
+
+            {/* Category */}
+            <div className="space-y-2">
+              <Label htmlFor="print-check-category" className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
+                Category (optional)
+              </Label>
+              <SearchableAccountSelector
+                value={selectedCategoryId ?? undefined}
+                onValueChange={(v) => setSelectedCategoryId(v || null)}
+                filterByTypes={['expense', 'cogs', 'asset']}
+                placeholder="Pick a chart-of-accounts category"
+                triggerAriaLabel="Category for this check"
               />
             </div>
           </div>

--- a/src/components/pending-outflows/PrintCheckButton.tsx
+++ b/src/components/pending-outflows/PrintCheckButton.tsx
@@ -250,9 +250,9 @@ export function PrintCheckButton({ expense }: PrintCheckButtonProps) {
 
             {/* Category */}
             <div className="space-y-2">
-              <Label className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
+              <p className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
                 Category (optional)
-              </Label>
+              </p>
               <SearchableAccountSelector
                 value={selectedCategoryId ?? undefined}
                 onValueChange={(v) => setSelectedCategoryId(v || null)}

--- a/src/components/pending-outflows/PrintCheckButton.tsx
+++ b/src/components/pending-outflows/PrintCheckButton.tsx
@@ -57,16 +57,12 @@ export function PrintCheckButton({ expense }: PrintCheckButtonProps) {
     expense.category_id ?? null,
   );
 
-  // Reset memo only when opening (or expense changes before opening)
+  // Reset dialog-local fields each time the dialog opens (or expense changes while open)
   useEffect(() => {
     if (!open) return;
     setMemo(expense.notes ?? '');
-  }, [open, expense.notes]);
-
-  useEffect(() => {
-    if (!open) return;
     setSelectedCategoryId(expense.category_id ?? null);
-  }, [open, expense.category_id]);
+  }, [open, expense.notes, expense.category_id]);
 
   // Initialize account selection once per open cycle
   useEffect(() => {

--- a/src/components/pending-outflows/PrintCheckButton.tsx
+++ b/src/components/pending-outflows/PrintCheckButton.tsx
@@ -246,10 +246,11 @@ export function PrintCheckButton({ expense }: PrintCheckButtonProps) {
 
             {/* Category */}
             <div className="space-y-2">
-              <p className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
+              <Label htmlFor="print-check-category" className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
                 Category (optional)
-              </p>
+              </Label>
               <SearchableAccountSelector
+                triggerId="print-check-category"
                 value={selectedCategoryId ?? undefined}
                 onValueChange={(v) => setSelectedCategoryId(v || null)}
                 filterByTypes={['expense', 'cogs', 'asset']}

--- a/src/components/pending-outflows/PrintCheckButton.tsx
+++ b/src/components/pending-outflows/PrintCheckButton.tsx
@@ -250,7 +250,7 @@ export function PrintCheckButton({ expense }: PrintCheckButtonProps) {
 
             {/* Category */}
             <div className="space-y-2">
-              <Label htmlFor="print-check-category" className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
+              <Label className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
                 Category (optional)
               </Label>
               <SearchableAccountSelector

--- a/src/pages/PrintChecks.tsx
+++ b/src/pages/PrintChecks.tsx
@@ -44,6 +44,7 @@ import { useSuppliers } from '@/hooks/useSuppliers';
 import { FeatureGate } from '@/components/subscription';
 
 import { CheckSettingsDialog } from '@/components/checks/CheckSettingsDialog';
+import { SearchableAccountSelector } from '@/components/banking/SearchableAccountSelector';
 import {
   generateCheckPDF,
   generateCheckPDFAsync,
@@ -68,6 +69,7 @@ interface CheckRow {
   amount: string;
   issueDate: string;
   memo: string;
+  categoryId: string | null;
   selected: boolean;
 }
 
@@ -78,6 +80,7 @@ function createEmptyRow(): CheckRow {
     amount: '',
     issueDate: format(new Date(), 'yyyy-MM-dd'),
     memo: '',
+    categoryId: null,
     selected: true,
   };
 }
@@ -116,7 +119,7 @@ function PrintChecksContent() {
   const selectedAccount = accounts.find((a) => a.id === selectedAccountId) ?? defaultAccount;
 
   // --- Row helpers ---
-  const updateRow = useCallback((id: string, field: keyof CheckRow, value: string | boolean) => {
+  const updateRow = useCallback((id: string, field: keyof CheckRow, value: string | boolean | null) => {
     setRows((prev) => prev.map((r) => (r.id === id ? { ...r, [field]: value } : r)));
   }, []);
 
@@ -183,36 +186,40 @@ function PrintChecksContent() {
         count: selectedRows.length,
       });
 
-      const checks: CheckData[] = selectedRows.map((row, i) => ({
+      type CheckJob = CheckData & { categoryId: string | null };
+      const jobs: CheckJob[] = selectedRows.map((row, i) => ({
         checkNumber: startNumber + i,
         payeeName: row.payeeName.trim(),
         amount: parseFloat(row.amount),
         issueDate: row.issueDate,
         memo: row.memo.trim() || undefined,
+        categoryId: row.categoryId,
       }));
 
-      for (const check of checks) {
+      for (const job of jobs) {
         const outflow = await createPendingOutflow.mutateAsync({
-          vendor_name: check.payeeName,
-          amount: check.amount,
+          vendor_name: job.payeeName,
+          amount: job.amount,
           payment_method: 'check',
-          reference_number: String(check.checkNumber),
-          issue_date: check.issueDate,
-          notes: check.memo ?? null,
+          reference_number: String(job.checkNumber),
+          issue_date: job.issueDate,
+          notes: job.memo ?? null,
+          category_id: job.categoryId,
         });
 
         await logCheckAction.mutateAsync({
-          check_number: check.checkNumber,
-          payee_name: check.payeeName,
-          amount: check.amount,
-          issue_date: check.issueDate,
-          memo: check.memo ?? null,
+          check_number: job.checkNumber,
+          payee_name: job.payeeName,
+          amount: job.amount,
+          issue_date: job.issueDate,
+          memo: job.memo ?? null,
           action: 'printed',
           pending_outflow_id: outflow.id,
           check_bank_account_id: selectedAccount.id,
         });
       }
 
+      const checks: CheckData[] = jobs.map(({ categoryId: _ignored, ...rest }) => rest);
       const config = buildPrintConfig(settings, selectedAccount, secrets);
       const pdf = selectedAccount.print_bank_info
         ? await generateCheckPDFAsync(config, checks)
@@ -225,7 +232,6 @@ function PrintChecksContent() {
 
       toast.success(`${checks.length} check${checks.length > 1 ? 's' : ''} printed`);
 
-      // Reset form
       setRows([createEmptyRow()]);
     } catch (err) {
       console.error('Print checks error:', err);
@@ -490,6 +496,9 @@ function PrintChecksContent() {
                         <TableHead className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
                           Memo
                         </TableHead>
+                        <TableHead className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
+                          Category
+                        </TableHead>
                         <TableHead className="w-10" />
                       </TableRow>
                     </TableHeader>
@@ -559,6 +568,17 @@ function PrintChecksContent() {
                                 placeholder="Optional"
                                 className="h-9 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
                               />
+                            </TableCell>
+                            <TableCell>
+                              <div className="w-48">
+                                <SearchableAccountSelector
+                                  value={row.categoryId ?? undefined}
+                                  onValueChange={(v) => updateRow(row.id, 'categoryId', v || null)}
+                                  filterByTypes={['expense', 'cogs', 'asset']}
+                                  placeholder="Optional"
+                                  triggerAriaLabel={`Category for check row ${rowIndex + 1}`}
+                                />
+                              </div>
                             </TableCell>
                             <TableCell>
                               <Button

--- a/src/pages/PrintChecks.tsx
+++ b/src/pages/PrintChecks.tsx
@@ -572,16 +572,14 @@ function PrintChecksContent() {
                               />
                             </TableCell>
                             <TableCell>
-                              <div className="w-48">
-                                <SearchableAccountSelector
-                                  value={row.categoryId ?? undefined}
-                                  onValueChange={(v) => updateRow(row.id, 'categoryId', v || null)}
-                                  filterByTypes={['expense', 'cogs', 'asset']}
-                                  placeholder="Optional"
-                                  triggerAriaLabel={`Category for check row ${rowIndex + 1}`}
-                                  triggerClassName="h-9 text-[14px] bg-muted/30 border-border/40 rounded-lg"
-                                />
-                              </div>
+                              <SearchableAccountSelector
+                                value={row.categoryId ?? undefined}
+                                onValueChange={(v) => updateRow(row.id, 'categoryId', v || null)}
+                                filterByTypes={['expense', 'cogs', 'asset']}
+                                placeholder="Optional"
+                                triggerAriaLabel={`Category for check row ${rowIndex + 1}`}
+                                triggerClassName="h-9 w-48 text-[14px] bg-muted/30 border-border/40 rounded-lg"
+                              />
                             </TableCell>
                             <TableCell>
                               <Button

--- a/src/pages/PrintChecks.tsx
+++ b/src/pages/PrintChecks.tsx
@@ -119,7 +119,11 @@ function PrintChecksContent() {
   const selectedAccount = accounts.find((a) => a.id === selectedAccountId) ?? defaultAccount;
 
   // --- Row helpers ---
-  const updateRow = useCallback((id: string, field: keyof CheckRow, value: string | boolean | null) => {
+  const updateRow = useCallback(<K extends keyof CheckRow>(
+    id: string,
+    field: K,
+    value: CheckRow[K],
+  ) => {
     setRows((prev) => prev.map((r) => (r.id === id ? { ...r, [field]: value } : r)));
   }, []);
 

--- a/src/pages/PrintChecks.tsx
+++ b/src/pages/PrintChecks.tsx
@@ -500,7 +500,7 @@ function PrintChecksContent() {
                         <TableHead className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
                           Memo
                         </TableHead>
-                        <TableHead className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
+                        <TableHead scope="col" className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
                           Category
                         </TableHead>
                         <TableHead className="w-10" />
@@ -581,6 +581,7 @@ function PrintChecksContent() {
                                   filterByTypes={['expense', 'cogs', 'asset']}
                                   placeholder="Optional"
                                   triggerAriaLabel={`Category for check row ${rowIndex + 1}`}
+                                  triggerClassName="h-9 text-[14px] bg-muted/30 border-border/40 rounded-lg"
                                 />
                               </div>
                             </TableCell>

--- a/src/pages/PrintChecks.tsx
+++ b/src/pages/PrintChecks.tsx
@@ -190,40 +190,38 @@ function PrintChecksContent() {
         count: selectedRows.length,
       });
 
-      type CheckJob = CheckData & { categoryId: string | null };
-      const jobs: CheckJob[] = selectedRows.map((row, i) => ({
+      const checks: CheckData[] = selectedRows.map((row, i) => ({
         checkNumber: startNumber + i,
         payeeName: row.payeeName.trim(),
         amount: parseFloat(row.amount),
         issueDate: row.issueDate,
         memo: row.memo.trim() || undefined,
-        categoryId: row.categoryId,
       }));
 
-      for (const job of jobs) {
+      for (let i = 0; i < checks.length; i++) {
+        const check = checks[i];
+        const row = selectedRows[i];
         const outflow = await createPendingOutflow.mutateAsync({
-          vendor_name: job.payeeName,
-          amount: job.amount,
+          vendor_name: check.payeeName,
+          amount: check.amount,
           payment_method: 'check',
-          reference_number: String(job.checkNumber),
-          issue_date: job.issueDate,
-          notes: job.memo ?? null,
-          category_id: job.categoryId,
+          reference_number: String(check.checkNumber),
+          issue_date: check.issueDate,
+          notes: check.memo ?? null,
+          category_id: row.categoryId,
         });
 
         await logCheckAction.mutateAsync({
-          check_number: job.checkNumber,
-          payee_name: job.payeeName,
-          amount: job.amount,
-          issue_date: job.issueDate,
-          memo: job.memo ?? null,
+          check_number: check.checkNumber,
+          payee_name: check.payeeName,
+          amount: check.amount,
+          issue_date: check.issueDate,
+          memo: check.memo ?? null,
           action: 'printed',
           pending_outflow_id: outflow.id,
           check_bank_account_id: selectedAccount.id,
         });
       }
-
-      const checks: CheckData[] = jobs.map(({ categoryId: _ignored, ...rest }) => rest);
       const config = buildPrintConfig(settings, selectedAccount, secrets);
       const pdf = selectedAccount.print_bank_info
         ? await generateCheckPDFAsync(config, checks)
@@ -500,7 +498,7 @@ function PrintChecksContent() {
                         <TableHead className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
                           Memo
                         </TableHead>
-                        <TableHead scope="col" className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
+                        <TableHead className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
                           Category
                         </TableHead>
                         <TableHead className="w-10" />

--- a/supabase/migrations/20260522120000_pending_outflows_category_same_restaurant.sql
+++ b/supabase/migrations/20260522120000_pending_outflows_category_same_restaurant.sql
@@ -7,7 +7,13 @@
 -- restaurant_id at write time.
 
 CREATE OR REPLACE FUNCTION public.assert_pending_outflow_category_same_restaurant()
-RETURNS TRIGGER AS $$
+RETURNS TRIGGER
+LANGUAGE plpgsql
+-- Pin search_path so the chart_of_accounts lookup can't be redirected by a
+-- caller-provided search_path. Supabase's linter flags trigger functions
+-- without this even when they're not SECURITY DEFINER.
+SET search_path = public, pg_temp
+AS $$
 BEGIN
   IF NEW.category_id IS NOT NULL THEN
     PERFORM 1
@@ -24,7 +30,7 @@ BEGIN
   END IF;
   RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
 DROP TRIGGER IF EXISTS pending_outflows_category_same_restaurant ON public.pending_outflows;
 CREATE TRIGGER pending_outflows_category_same_restaurant

--- a/supabase/migrations/20260522120000_pending_outflows_category_same_restaurant.sql
+++ b/supabase/migrations/20260522120000_pending_outflows_category_same_restaurant.sql
@@ -26,6 +26,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+DROP TRIGGER IF EXISTS pending_outflows_category_same_restaurant ON public.pending_outflows;
 CREATE TRIGGER pending_outflows_category_same_restaurant
 BEFORE INSERT OR UPDATE OF category_id, restaurant_id ON public.pending_outflows
 FOR EACH ROW

--- a/supabase/migrations/20260522120000_pending_outflows_category_same_restaurant.sql
+++ b/supabase/migrations/20260522120000_pending_outflows_category_same_restaurant.sql
@@ -1,0 +1,35 @@
+-- Same-restaurant integrity guard for pending_outflows.category_id.
+--
+-- The existing FK only enforces that category_id points at SOME chart_of_accounts
+-- row. The SELECT RLS on chart_of_accounts hides foreign rows from the UI, but a
+-- direct API write supplying a foreign uuid would still pass FK validation.
+-- This trigger closes that gap by asserting category and outflow share a
+-- restaurant_id at write time.
+
+CREATE OR REPLACE FUNCTION public.assert_pending_outflow_category_same_restaurant()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.category_id IS NOT NULL THEN
+    PERFORM 1
+      FROM public.chart_of_accounts
+     WHERE id = NEW.category_id
+       AND restaurant_id = NEW.restaurant_id;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION
+        'pending_outflows.category_id % does not belong to restaurant %',
+        NEW.category_id, NEW.restaurant_id
+        USING ERRCODE = 'foreign_key_violation';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER pending_outflows_category_same_restaurant
+BEFORE INSERT OR UPDATE OF category_id, restaurant_id ON public.pending_outflows
+FOR EACH ROW
+EXECUTE FUNCTION public.assert_pending_outflow_category_same_restaurant();
+
+COMMENT ON FUNCTION public.assert_pending_outflow_category_same_restaurant() IS
+  'Asserts pending_outflows.category_id and restaurant_id refer to the same restaurant. Raises ERRCODE 23503 on mismatch.';

--- a/supabase/migrations/20260522120100_pending_outflows_category_index.sql
+++ b/supabase/migrations/20260522120100_pending_outflows_category_index.sql
@@ -1,0 +1,14 @@
+-- Partial index on pending_outflows.category_id.
+--
+-- Aggregation reads (expenseDataFetcher, useMonthlyMetrics, useExpenseHealth)
+-- already join chart_of_accounts via category_id. Historically most rows are
+-- NULL; with the optional category picker on check creation, a meaningful
+-- fraction will now be populated. The partial index keeps cost down by only
+-- indexing the populated rows.
+
+CREATE INDEX IF NOT EXISTS idx_pending_outflows_category
+  ON public.pending_outflows(category_id)
+  WHERE category_id IS NOT NULL;
+
+COMMENT ON INDEX public.idx_pending_outflows_category IS
+  'Partial index supporting category-keyed reads on pending_outflows. Excludes NULL category_id rows (the historical majority).';

--- a/supabase/migrations/20260522120100_pending_outflows_category_index.sql
+++ b/supabase/migrations/20260522120100_pending_outflows_category_index.sql
@@ -1,14 +1,18 @@
--- Partial index on pending_outflows.category_id.
+-- Composite partial index on pending_outflows for tenant-scoped category reads.
 --
--- Aggregation reads (expenseDataFetcher, useMonthlyMetrics, useExpenseHealth)
--- already join chart_of_accounts via category_id. Historically most rows are
--- NULL; with the optional category picker on check creation, a meaningful
--- fraction will now be populated. The partial index keeps cost down by only
--- indexing the populated rows.
+-- All consumers (useMonthlyMetrics, useLaborCostsFromTransactions, useLiquidityMetrics,
+-- usePendingOutflows, useTopVendors, useCOGSFromFinancials, expenseDataFetcher) lead
+-- with `.eq('restaurant_id', ...)` then filter or aggregate by category_id. A
+-- single-column index on category_id alone would rarely be chosen by the planner
+-- because restaurant_id narrows the rowset first. The composite (restaurant_id,
+-- category_id) lets the planner satisfy both predicates from one index scan.
+--
+-- Historically most rows have NULL category_id; the partial WHERE clause keeps
+-- the index small by only covering rows the new picker will populate.
 
 CREATE INDEX IF NOT EXISTS idx_pending_outflows_category
-  ON public.pending_outflows(category_id)
+  ON public.pending_outflows(restaurant_id, category_id)
   WHERE category_id IS NOT NULL;
 
 COMMENT ON INDEX public.idx_pending_outflows_category IS
-  'Partial index supporting category-keyed reads on pending_outflows. Excludes NULL category_id rows (the historical majority).';
+  'Composite partial index supporting tenant-scoped category reads on pending_outflows. Covers (restaurant_id, category_id) for rows where category_id IS NOT NULL.';

--- a/supabase/tests/pending_outflows_category_same_restaurant.test.sql
+++ b/supabase/tests/pending_outflows_category_same_restaurant.test.sql
@@ -129,15 +129,17 @@ SELECT lives_ok(
   'same-restaurant update succeeds'
 );
 
--- 8. Partial index on category_id exists (non-null rows).
+-- 8. Composite partial index on (restaurant_id, category_id) exists for non-null rows.
 SELECT ok(
   EXISTS (
     SELECT 1 FROM pg_indexes
     WHERE schemaname = 'public'
       AND tablename = 'pending_outflows'
       AND indexname = 'idx_pending_outflows_category'
+      AND indexdef LIKE '%restaurant_id%category_id%'
+      AND indexdef LIKE '%category_id IS NOT NULL%'
   ),
-  'idx_pending_outflows_category index exists'
+  'idx_pending_outflows_category is a composite partial index on (restaurant_id, category_id) WHERE category_id IS NOT NULL'
 );
 
 SELECT * FROM finish();

--- a/supabase/tests/pending_outflows_category_same_restaurant.test.sql
+++ b/supabase/tests/pending_outflows_category_same_restaurant.test.sql
@@ -5,7 +5,7 @@
 -- 23503 (foreign_key_violation), both on INSERT and on UPDATE.
 
 BEGIN;
-SELECT plan(7);
+SELECT plan(8);
 
 -- Setup: Disable RLS so fixture INSERTs work without auth context.
 SET LOCAL role TO postgres;
@@ -127,6 +127,17 @@ SELECT lives_ok(
        AND restaurant_id = '00000000-0000-0000-0000-000000000a01';
   $$,
   'same-restaurant update succeeds'
+);
+
+-- 8. Partial index on category_id exists (non-null rows).
+SELECT ok(
+  EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND tablename = 'pending_outflows'
+      AND indexname = 'idx_pending_outflows_category'
+  ),
+  'idx_pending_outflows_category index exists'
 );
 
 SELECT * FROM finish();

--- a/supabase/tests/pending_outflows_category_same_restaurant.test.sql
+++ b/supabase/tests/pending_outflows_category_same_restaurant.test.sql
@@ -25,10 +25,10 @@ INSERT INTO public.chart_of_accounts
 VALUES
   ('00000000-0000-0000-0000-000000000b01',
    '00000000-0000-0000-0000-000000000a01',
-   '5100', 'Test Food Costs A', 'expense', 'debit'),
+   '5100', 'Test Food Costs A', 'cogs', 'debit'),
   ('00000000-0000-0000-0000-000000000b02',
    '00000000-0000-0000-0000-000000000a02',
-   '5100', 'Test Food Costs B', 'expense', 'debit')
+   '5100', 'Test Food Costs B', 'cogs', 'debit')
 ON CONFLICT (id) DO NOTHING;
 
 -- 1. Trigger function exists.

--- a/supabase/tests/pending_outflows_category_same_restaurant.test.sql
+++ b/supabase/tests/pending_outflows_category_same_restaurant.test.sql
@@ -1,0 +1,133 @@
+-- pgTAP tests for the same-restaurant guard on pending_outflows.category_id.
+--
+-- Pinning: writing a pending_outflows row whose category_id resolves to a
+-- chart_of_accounts row in a different restaurant must fail with SQLSTATE
+-- 23503 (foreign_key_violation), both on INSERT and on UPDATE.
+
+BEGIN;
+SELECT plan(7);
+
+-- Setup: Disable RLS so fixture INSERTs work without auth context.
+SET LOCAL role TO postgres;
+ALTER TABLE public.restaurants DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.chart_of_accounts DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.pending_outflows DISABLE ROW LEVEL SECURITY;
+
+-- Fixture: two restaurants, each with its own chart-of-accounts row.
+INSERT INTO public.restaurants (id, name)
+VALUES
+  ('00000000-0000-0000-0000-000000000a01', 'Test Restaurant A'),
+  ('00000000-0000-0000-0000-000000000a02', 'Test Restaurant B')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.chart_of_accounts
+  (id, restaurant_id, account_code, account_name, account_type, normal_balance)
+VALUES
+  ('00000000-0000-0000-0000-000000000b01',
+   '00000000-0000-0000-0000-000000000a01',
+   '5100', 'Test Food Costs A', 'expense', 'debit'),
+  ('00000000-0000-0000-0000-000000000b02',
+   '00000000-0000-0000-0000-000000000a02',
+   '5100', 'Test Food Costs B', 'expense', 'debit')
+ON CONFLICT (id) DO NOTHING;
+
+-- 1. Trigger function exists.
+SELECT has_function(
+  'public',
+  'assert_pending_outflow_category_same_restaurant',
+  'trigger function exists'
+);
+
+-- 2. Trigger is wired up on pending_outflows.
+SELECT ok(
+  EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgname = 'pending_outflows_category_same_restaurant'
+      AND tgrelid = 'public.pending_outflows'::regclass
+  ),
+  'trigger is attached to pending_outflows'
+);
+
+-- 3. Insert with a same-restaurant category succeeds.
+SELECT lives_ok(
+  $$
+    INSERT INTO public.pending_outflows (
+      restaurant_id, vendor_name, category_id, payment_method,
+      amount, issue_date
+    )
+    VALUES (
+      '00000000-0000-0000-0000-000000000a01',
+      'Same-Restaurant Vendor',
+      '00000000-0000-0000-0000-000000000b01',
+      'check',
+      100.00,
+      CURRENT_DATE
+    );
+  $$,
+  'insert with same-restaurant category succeeds'
+);
+
+-- 4. Insert with a cross-restaurant category fails with 23503.
+SELECT throws_ok(
+  $$
+    INSERT INTO public.pending_outflows (
+      restaurant_id, vendor_name, category_id, payment_method,
+      amount, issue_date
+    )
+    VALUES (
+      '00000000-0000-0000-0000-000000000a01',
+      'Cross-Restaurant Vendor',
+      '00000000-0000-0000-0000-000000000b02',
+      'check',
+      200.00,
+      CURRENT_DATE
+    );
+  $$,
+  '23503',
+  NULL,
+  'cross-restaurant insert raises foreign_key_violation'
+);
+
+-- 5. Insert with NULL category_id still works (category is optional).
+SELECT lives_ok(
+  $$
+    INSERT INTO public.pending_outflows (
+      restaurant_id, vendor_name, payment_method, amount, issue_date
+    )
+    VALUES (
+      '00000000-0000-0000-0000-000000000a01',
+      'Uncategorized Vendor',
+      'check',
+      300.00,
+      CURRENT_DATE
+    );
+  $$,
+  'NULL category_id is still permitted'
+);
+
+-- 6. Update from NULL → cross-restaurant category fails with 23503.
+SELECT throws_ok(
+  $$
+    UPDATE public.pending_outflows
+       SET category_id = '00000000-0000-0000-0000-000000000b02'
+     WHERE vendor_name = 'Uncategorized Vendor'
+       AND restaurant_id = '00000000-0000-0000-0000-000000000a01';
+  $$,
+  '23503',
+  NULL,
+  'cross-restaurant update raises foreign_key_violation'
+);
+
+-- 7. Update to same-restaurant category succeeds.
+SELECT lives_ok(
+  $$
+    UPDATE public.pending_outflows
+       SET category_id = '00000000-0000-0000-0000-000000000b01'
+     WHERE vendor_name = 'Uncategorized Vendor'
+       AND restaurant_id = '00000000-0000-0000-0000-000000000a01';
+  $$,
+  'same-restaurant update succeeds'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/pending_outflows_category_same_restaurant.test.sql
+++ b/supabase/tests/pending_outflows_category_same_restaurant.test.sql
@@ -5,7 +5,7 @@
 -- 23503 (foreign_key_violation), both on INSERT and on UPDATE.
 
 BEGIN;
-SELECT plan(8);
+SELECT plan(9);
 
 -- Setup: Disable RLS so fixture INSERTs work without auth context.
 SET LOCAL role TO postgres;
@@ -140,6 +140,20 @@ SELECT ok(
       AND indexdef LIKE '%category_id IS NOT NULL%'
   ),
   'idx_pending_outflows_category is a composite partial index on (restaurant_id, category_id) WHERE category_id IS NOT NULL'
+);
+
+-- 9. Trigger function has a pinned search_path so a caller's session-level
+-- search_path cannot redirect the chart_of_accounts lookup to another schema.
+SELECT ok(
+  EXISTS (
+    SELECT 1
+      FROM pg_proc p
+      JOIN pg_namespace n ON n.oid = p.pronamespace
+     WHERE n.nspname = 'public'
+       AND p.proname = 'assert_pending_outflow_category_same_restaurant'
+       AND 'search_path=public, pg_temp' = ANY(p.proconfig)
+  ),
+  'assert_pending_outflow_category_same_restaurant has SET search_path = public, pg_temp'
 );
 
 SELECT * FROM finish();

--- a/tests/unit/PrintCheckButtonCategory.test.tsx
+++ b/tests/unit/PrintCheckButtonCategory.test.tsx
@@ -1,0 +1,197 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const claimForAccountMutateAsync = vi.fn();
+const fetchAccountSecretsMock = vi.fn();
+const updatePendingOutflowMutateAsync = vi.fn();
+const logCheckActionMutateAsync = vi.fn();
+
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => ({
+    selectedRestaurant: { restaurant: { name: 'Test Restaurant' }, restaurant_id: 'rest-1' },
+  }),
+}));
+
+vi.mock('@/hooks/useCheckSettings', () => ({
+  useCheckSettings: () => ({
+    settings: {
+      id: 'set-1',
+      restaurant_id: 'rest-1',
+      business_name: 'Test Restaurant LLC',
+      business_address_line1: '123 Main St',
+      business_address_line2: null,
+      business_city: 'Austin',
+      business_state: 'TX',
+      business_zip: '78701',
+      bank_name: null,
+      print_bank_info: false,
+      routing_number: null,
+      signature_url: null,
+    },
+  }),
+}));
+
+vi.mock('@/hooks/useCheckBankAccounts', () => ({
+  useCheckBankAccounts: () => ({
+    accounts: [{
+      id: 'acct-1',
+      account_name: 'Operating',
+      bank_name: 'First National',
+      next_check_number: 1001,
+      print_bank_info: false,
+      routing_number: null,
+      account_number_last4: null,
+      is_default: true,
+    }],
+    defaultAccount: {
+      id: 'acct-1',
+      account_name: 'Operating',
+      bank_name: 'First National',
+      next_check_number: 1001,
+      print_bank_info: false,
+      routing_number: null,
+      account_number_last4: null,
+      is_default: true,
+    },
+    claimCheckNumbers: { mutateAsync: claimForAccountMutateAsync },
+    fetchAccountSecrets: fetchAccountSecretsMock,
+  }),
+}));
+
+vi.mock('@/hooks/useCheckAuditLog', () => ({
+  useCheckAuditLog: () => ({
+    logCheckAction: { mutateAsync: logCheckActionMutateAsync },
+  }),
+}));
+
+vi.mock('@/hooks/usePendingOutflows', () => ({
+  usePendingOutflowMutations: () => ({
+    updatePendingOutflow: { mutateAsync: updatePendingOutflowMutateAsync },
+  }),
+}));
+
+vi.mock('@/components/banking/SearchableAccountSelector', () => ({
+  SearchableAccountSelector: ({
+    onValueChange,
+    value,
+  }: {
+    onValueChange: (value: string) => void;
+    value?: string;
+  }) => (
+    <button
+      type="button"
+      data-testid="category-selector"
+      data-current-value={value ?? ''}
+      onClick={() => onValueChange('acc-rent')}
+    >
+      Pick category
+    </button>
+  ),
+}));
+
+vi.mock('@/utils/checkPrinting', async () => {
+  const actual = await vi.importActual<any>('@/utils/checkPrinting');
+  return {
+    ...actual,
+    generateCheckPDF: vi.fn().mockReturnValue({ save: vi.fn() }),
+    generateCheckPDFAsync: vi.fn().mockResolvedValue({ save: vi.fn() }),
+  };
+});
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { PrintCheckButton } from '@/components/pending-outflows/PrintCheckButton';
+import type { PendingOutflow } from '@/types/pending-outflows';
+
+function makeExpense(overrides: Partial<PendingOutflow> = {}): PendingOutflow {
+  return {
+    id: 'pof-1',
+    restaurant_id: 'rest-1',
+    vendor_name: 'ACME Rent',
+    category_id: null,
+    payment_method: 'check',
+    amount: 1200,
+    issue_date: '2026-05-22',
+    due_date: null,
+    notes: null,
+    reference_number: null,
+    status: 'pending',
+    linked_bank_transaction_id: null,
+    cleared_at: null,
+    voided_at: null,
+    voided_reason: null,
+    created_at: '2026-05-22T00:00:00Z',
+    updated_at: '2026-05-22T00:00:00Z',
+    chart_account: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  claimForAccountMutateAsync.mockReset().mockResolvedValue(1001);
+  fetchAccountSecretsMock.mockReset().mockResolvedValue(null);
+  updatePendingOutflowMutateAsync.mockReset().mockResolvedValue({});
+  logCheckActionMutateAsync.mockReset().mockResolvedValue(undefined);
+});
+
+describe('PrintCheckButton — Category field', () => {
+  it('passes the newly picked category_id when the expense was uncategorized', async () => {
+    const user = userEvent.setup();
+    render(<PrintCheckButton expense={makeExpense()} />);
+
+    await user.click(screen.getByRole('button', { name: /^Print check for ACME Rent$/i }));
+    await user.click(screen.getByTestId('category-selector'));
+    await user.click(screen.getByRole('button', { name: /^Print Check$/i }));
+
+    await waitFor(() => expect(updatePendingOutflowMutateAsync).toHaveBeenCalledTimes(1));
+    expect(updatePendingOutflowMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'pof-1',
+        input: expect.objectContaining({
+          payment_method: 'check',
+          category_id: 'acc-rent',
+        }),
+      }),
+    );
+  });
+
+  it('keeps the existing category_id when the user leaves the field alone', async () => {
+    const user = userEvent.setup();
+    render(<PrintCheckButton expense={makeExpense({ category_id: 'acc-preexisting' })} />);
+
+    await user.click(screen.getByRole('button', { name: /^Print check for ACME Rent$/i }));
+    expect(screen.getByTestId('category-selector')).toHaveAttribute(
+      'data-current-value',
+      'acc-preexisting',
+    );
+
+    await user.click(screen.getByRole('button', { name: /^Print Check$/i }));
+
+    await waitFor(() => expect(updatePendingOutflowMutateAsync).toHaveBeenCalledTimes(1));
+    expect(updatePendingOutflowMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({ category_id: 'acc-preexisting' }),
+      }),
+    );
+  });
+
+  it('overrides an existing category_id when the user picks a different one', async () => {
+    const user = userEvent.setup();
+    render(<PrintCheckButton expense={makeExpense({ category_id: 'acc-old' })} />);
+
+    await user.click(screen.getByRole('button', { name: /^Print check for ACME Rent$/i }));
+    await user.click(screen.getByTestId('category-selector'));
+    await user.click(screen.getByRole('button', { name: /^Print Check$/i }));
+
+    await waitFor(() => expect(updatePendingOutflowMutateAsync).toHaveBeenCalledTimes(1));
+    expect(updatePendingOutflowMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: expect.objectContaining({ category_id: 'acc-rent' }),
+      }),
+    );
+  });
+});

--- a/tests/unit/PrintCheckButtonCategory.test.tsx
+++ b/tests/unit/PrintCheckButtonCategory.test.tsx
@@ -92,7 +92,7 @@ vi.mock('@/components/banking/SearchableAccountSelector', () => ({
 }));
 
 vi.mock('@/utils/checkPrinting', async () => {
-  const actual = await vi.importActual<any>('@/utils/checkPrinting');
+  const actual = await vi.importActual<typeof import('@/utils/checkPrinting')>('@/utils/checkPrinting');
   return {
     ...actual,
     generateCheckPDF: vi.fn().mockReturnValue({ save: vi.fn() }),

--- a/tests/unit/PrintChecksCategoryColumn.test.tsx
+++ b/tests/unit/PrintChecksCategoryColumn.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 const claimCheckNumbersMock = vi.fn();

--- a/tests/unit/PrintChecksCategoryColumn.test.tsx
+++ b/tests/unit/PrintChecksCategoryColumn.test.tsx
@@ -109,7 +109,7 @@ vi.mock('@/components/banking/SearchableAccountSelector', () => ({
 }));
 
 vi.mock('@/utils/checkPrinting', async () => {
-  const actual = await vi.importActual<any>('@/utils/checkPrinting');
+  const actual = await vi.importActual<typeof import('@/utils/checkPrinting')>('@/utils/checkPrinting');
   return {
     ...actual,
     generateCheckPDF: vi.fn().mockReturnValue({ save: vi.fn() }),

--- a/tests/unit/PrintChecksCategoryColumn.test.tsx
+++ b/tests/unit/PrintChecksCategoryColumn.test.tsx
@@ -1,0 +1,180 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const claimCheckNumbersMock = vi.fn();
+const createPendingOutflowMock = vi.fn();
+const logCheckActionMock = vi.fn();
+
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => ({
+    selectedRestaurant: { restaurant: { name: 'Test Restaurant' }, restaurant_id: 'rest-1' },
+  }),
+}));
+
+vi.mock('@/hooks/useCheckSettings', () => ({
+  useCheckSettings: () => ({
+    settings: {
+      id: 'set-1',
+      restaurant_id: 'rest-1',
+      business_name: 'Test Restaurant LLC',
+      business_address_line1: '123 Main St',
+      business_address_line2: null,
+      business_city: 'Austin',
+      business_state: 'TX',
+      business_zip: '78701',
+      bank_name: null,
+      print_bank_info: false,
+      routing_number: null,
+      signature_url: null,
+    },
+    isLoading: false,
+  }),
+}));
+
+vi.mock('@/hooks/useCheckBankAccounts', () => ({
+  useCheckBankAccounts: () => ({
+    accounts: [{
+      id: 'acct-1',
+      account_name: 'Operating',
+      bank_name: 'First National',
+      next_check_number: 1001,
+      print_bank_info: false,
+      routing_number: null,
+      account_number_last4: null,
+      is_default: true,
+    }],
+    defaultAccount: {
+      id: 'acct-1',
+      account_name: 'Operating',
+      bank_name: 'First National',
+      next_check_number: 1001,
+      print_bank_info: false,
+      routing_number: null,
+      account_number_last4: null,
+      is_default: true,
+    },
+    isLoading: false,
+    claimCheckNumbers: { mutateAsync: claimCheckNumbersMock },
+    fetchAccountSecrets: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useCheckAuditLog', () => ({
+  useCheckAuditLog: () => ({
+    auditLog: [],
+    isLoading: false,
+    logCheckAction: { mutateAsync: logCheckActionMock },
+  }),
+}));
+
+vi.mock('@/hooks/usePendingOutflows', () => ({
+  usePendingOutflowMutations: () => ({
+    createPendingOutflow: { mutateAsync: createPendingOutflowMock },
+  }),
+}));
+
+vi.mock('@/hooks/useSuppliers', () => ({
+  useSuppliers: () => ({ suppliers: [] }),
+}));
+
+vi.mock('@/components/subscription', () => ({
+  FeatureGate: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/components/checks/CheckSettingsDialog', () => ({
+  CheckSettingsDialog: () => null,
+}));
+
+vi.mock('@/components/banking/SearchableAccountSelector', () => ({
+  SearchableAccountSelector: ({
+    onValueChange,
+    triggerAriaLabel,
+    value,
+  }: {
+    onValueChange: (value: string) => void;
+    triggerAriaLabel?: string;
+    value?: string;
+  }) => (
+    <button
+      type="button"
+      aria-label={triggerAriaLabel}
+      data-current-value={value ?? ''}
+      onClick={() => onValueChange('acc-food')}
+    >
+      Pick category
+    </button>
+  ),
+}));
+
+vi.mock('@/utils/checkPrinting', async () => {
+  const actual = await vi.importActual<any>('@/utils/checkPrinting');
+  return {
+    ...actual,
+    generateCheckPDF: vi.fn().mockReturnValue({ save: vi.fn() }),
+    generateCheckPDFAsync: vi.fn().mockResolvedValue({ save: vi.fn() }),
+  };
+});
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import PrintChecks from '@/pages/PrintChecks';
+
+describe('PrintChecks — per-row Category column', () => {
+  beforeEach(() => {
+    claimCheckNumbersMock.mockReset().mockResolvedValue(1001);
+    createPendingOutflowMock.mockReset().mockResolvedValue({ id: 'outflow-new-1' });
+    logCheckActionMock.mockReset().mockResolvedValue(undefined);
+  });
+
+  it('renders a Category column header', () => {
+    render(<PrintChecks />);
+    expect(screen.getByRole('columnheader', { name: /category/i })).toBeInTheDocument();
+  });
+
+  it('renders a per-row category selector with a row-scoped aria-label', () => {
+    render(<PrintChecks />);
+    expect(
+      screen.getByRole('button', { name: /category for check row 1/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('passes the chosen category_id through to createPendingOutflow', async () => {
+    const user = userEvent.setup();
+    render(<PrintChecks />);
+
+    await user.type(screen.getByPlaceholderText(/vendor name/i), 'Sysco');
+    await user.type(screen.getByPlaceholderText('0.00'), '125.50');
+
+    await user.click(screen.getByRole('button', { name: /category for check row 1/i }));
+
+    await user.click(screen.getByRole('button', { name: /^Print 1 Check$/i }));
+
+    await waitFor(() => expect(createPendingOutflowMock).toHaveBeenCalledTimes(1));
+    expect(createPendingOutflowMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        vendor_name: 'Sysco',
+        amount: 125.5,
+        category_id: 'acc-food',
+      }),
+    );
+  });
+
+  it('defaults category_id to null when no category is picked', async () => {
+    const user = userEvent.setup();
+    render(<PrintChecks />);
+
+    await user.type(screen.getByPlaceholderText(/vendor name/i), 'Sysco');
+    await user.type(screen.getByPlaceholderText('0.00'), '99.00');
+
+    await user.click(screen.getByRole('button', { name: /^Print 1 Check$/i }));
+
+    await waitFor(() => expect(createPendingOutflowMock).toHaveBeenCalledTimes(1));
+    expect(createPendingOutflowMock).toHaveBeenCalledWith(
+      expect.objectContaining({ category_id: null }),
+    );
+  });
+});

--- a/tests/unit/SearchableAccountSelector.ariaLabel.test.tsx
+++ b/tests/unit/SearchableAccountSelector.ariaLabel.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SearchableAccountSelector } from '@/components/banking/SearchableAccountSelector';
+
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => ({
+    selectedRestaurant: { restaurant_id: 'rest-1' },
+  }),
+}));
+
+vi.mock('@/hooks/useChartOfAccounts', () => ({
+  useChartOfAccounts: () => ({
+    accounts: [
+      {
+        id: 'acc-1',
+        restaurant_id: 'rest-1',
+        account_code: '5000',
+        account_name: 'Food Costs',
+        account_type: 'cogs',
+        account_subtype: 'food',
+        parent_account_id: null,
+        is_active: true,
+      },
+    ],
+    loading: false,
+  }),
+}));
+
+describe('SearchableAccountSelector — triggerAriaLabel', () => {
+  it('forwards triggerAriaLabel to the combobox button when provided', () => {
+    render(
+      <SearchableAccountSelector
+        onValueChange={() => {}}
+        triggerAriaLabel="Category for check row 1"
+      />,
+    );
+    const combo = screen.getByRole('combobox', {
+      name: 'Category for check row 1',
+    });
+    expect(combo).toBeInTheDocument();
+  });
+
+  it('omits aria-label when prop is not provided (default behaviour unchanged)', () => {
+    render(<SearchableAccountSelector onValueChange={() => {}} />);
+    const combo = screen.getByRole('combobox');
+    expect(combo.getAttribute('aria-label')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Add a per-row **Category** column on **Print Checks** (batch "Write Checks" page) so each new check's expense is categorized as it's created — no more bouncing back to the expense list.
- Add a **Category** field on the per-expense **Print Check** dialog (`PrintCheckButton`) so single-print flows can also categorize on creation, defaulting to the expense's current `category_id` if already set.
- Picker: `SearchableAccountSelector` filtered to `['expense', 'cogs', 'asset']`. Category is **optional** — `null` is a valid value and writes through unchanged.
- Server-side: new trigger `assert_pending_outflow_category_same_restaurant` rejects any `category_id` whose chart_of_accounts row belongs to another restaurant, plus a composite partial index `(restaurant_id, category_id) WHERE category_id IS NOT NULL` for category-rollup queries.

## Changes
**UI**
- `src/components/banking/SearchableAccountSelector.tsx` — new `triggerAriaLabel`, `triggerId`, `triggerClassName` props; tightened `organizedAccounts` typing (removed `any`); added `collisionPadding` to popover.
- `src/pages/PrintChecks.tsx` — Category column header + per-row picker with row-scoped aria-label (`Category for check row N`); `categoryId` plumbed through `createPendingOutflow`.
- `src/components/pending-outflows/PrintCheckButton.tsx` — Category field in dialog (labeled, defaults from `expense.category_id`); writes `category_id` on print.

**DB**
- `supabase/migrations/20260522120000_pending_outflows_category_same_restaurant.sql` — trigger function with `SET search_path = public, pg_temp` pinned; raises `foreign_key_violation` on cross-restaurant `category_id`. Idempotent (DROP IF EXISTS).
- `supabase/migrations/20260522120100_pending_outflows_category_index.sql` — composite partial index on `(restaurant_id, category_id)`.

**Tests**
- `tests/unit/PrintChecksCategoryColumn.test.tsx` — column header, row-scoped aria-label, `category_id` passed through, defaults to `null` when unpicked.
- `tests/unit/PrintCheckButtonCategory.test.tsx` — dialog field renders, default from `expense.category_id`, passes `category_id` through `updatePendingOutflow`.
- `tests/unit/SearchableAccountSelector.ariaLabel.test.tsx` — `triggerAriaLabel` ends up on the trigger button.
- `supabase/tests/pending_outflows_category_same_restaurant.test.sql` — 9 pgTAP tests: function/trigger existence, same-restaurant INSERT/UPDATE succeed, cross-restaurant INSERT/UPDATE raise `23503`, NULL still allowed, composite-partial index shape, and `search_path` pin.

## Test plan
- [ ] Local: `npm run test` (Vitest) — 4083 tests passing
- [ ] Local: `npm run test:db` — 9/9 pgTAP tests passing on the new file
- [ ] Local: `npm run typecheck` — clean
- [ ] Local: `npm run build` — succeeds
- [ ] CI: GitHub Actions on this PR — all green
- [ ] Manual: open `/print-checks`, fill a row, pick a category, print → confirm the resulting `pending_outflows` row has `category_id` set and shows up correctly in the categorization view
- [ ] Manual: open per-expense Print dialog from an existing uncategorized expense → pick a category → print → confirm `category_id` is updated on the outflow
- [ ] Manual: cross-restaurant guard — attempt (via dev tools or SQL) to set `category_id` to a chart_of_accounts row from a different restaurant → confirm rejected with `foreign_key_violation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional category assignment when printing checks individually and in batch operations. Users can now select a chart-of-accounts category directly in the print interface to streamline the check categorization workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toyiyo/nimble-pnl/pull/514?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->