### PR TITLE
fix(generate-schedule): switch to streaming AI path to avoid body-read abort

### DIFF
--- a/docs/superpowers/specs/2026-05-22-generate-schedule-streaming-design.md
+++ b/docs/superpowers/specs/2026-05-22-generate-schedule-streaming-design.md
@@ -1,0 +1,84 @@
+# generate-schedule: switch to streaming AI path — design
+
+**Date:** 2026-05-22
+**Branch:** `fix/generate-schedule-streaming`
+**Severity:** P0 production-down. AI schedule generation returns 502 for at least one production restaurant.
+
+## Symptom
+
+Frontend shows: "Something Went Wrong / The AI schedule generation failed / Generation failed / Edge Function returned a non-2xx status code".
+
+Edge function logs (production, Wetzel's Cold Stone Alamo Ranch, ID `7c0c76e3-e770-401b-a2a9-c1edd407efed`, prompt=20,089 chars):
+
+```
+[generate-schedule] Trying model: Gemini 2.5 Flash
+✅ Gemini 2.5 Flash succeeded
+[generate-schedule] Model Gemini 2.5 Flash parse failed: Signal timed out.
+[generate-schedule] Trying model: Gemini 2.5 Flash Lite
+✅ Gemini 2.5 Flash Lite succeeded
+[generate-schedule] Model Gemini 2.5 Flash Lite parse failed: Signal timed out.
+[generate-schedule] Trying model: Llama 4 Maverick
+✅ Llama 4 Maverick succeeded
+[generate-schedule] Model Llama 4 Maverick parse failed: Signal timed out.
+[generate-schedule] Model chain wall-clock budget exhausted (90010ms > 90000ms). Stopping early.
+```
+
+## Root cause
+
+`supabase/functions/_shared/ai-caller.ts:77` attaches `signal: AbortSignal.timeout(30000)` to the OpenRouter fetch and **returns the `Response` object without consuming the body**. The 30s signal stays bound to the Response's body stream.
+
+`supabase/functions/generate-schedule/index.ts:553` later calls `await response.json()`, which triggers a stream pull on that bound signal. If the body has not finished arriving within 30s of fetch initiation, the pull aborts with `DOMException("Signal timed out.", "TimeoutError")`. The catch block at line 569 logs it as "parse failed", which is misleading — the JSON parser never ran.
+
+For this restaurant the response body genuinely takes >30s to ship because:
+
+- `max_tokens: 16384` plus `response_format: { type: 'json_schema', strict: true }` forces per-token schema validation server-side, slowing emission.
+- Recent prompt growth (PR #506 added 7-day per-employee availability + Rule 12 HARD-fill; PR #511 added per-template capacity + Rule 1 active-days) pushed average output length past the 30s body-download threshold.
+
+Three consecutive 30s body-read aborts (~90s) exhaust the wall-clock budget at `index.ts:535` and the function returns synthetic 502.
+
+The misleading `✅ X succeeded` log is real — fetch headers came back fast. Only the body read timed out.
+
+## Why streaming fixes it
+
+`supabase/functions/_shared/streaming.ts` already implements `callModelWithStreaming`:
+
+- Uses `signal: AbortSignal.timeout(90000)` (90s, 3× the broken path).
+- Adds `stream: true` to the request body so OpenRouter ships SSE chunks instead of buffering the full body.
+- Consumes the SSE stream **inside the same function** via `processStreamedResponse`, then returns the accumulated content string. No bound signal can fire on a caller's `response.json()` because there is no `response.json()` — the helper returns a string, not a Response.
+- Reader runs continuously across chunks, so an isolated slow chunk does not cause an abort as long as the whole stream completes within 90s.
+
+## Fix
+
+1. Extract the model-loop logic from `generate-schedule/index.ts` into a new pure helper `supabase/functions/_shared/schedule-ai-runner.ts` so it can be unit-tested from Vitest.
+   - Signature: `runScheduleModelChain({ models, requestBody, callStreaming, now?, budgetMs? })` returns `{ data, model } | null`.
+   - `callStreaming` is injected (real impl = `callModelWithStreaming`; tests supply a fake).
+   - Loops models in order, calls `callStreaming`, strips markdown fences, `JSON.parse`, returns first success.
+   - Continues to next model on null content, parse error, or invalid shape.
+   - Respects `budgetMs` (wall-clock) using `now()` at loop start.
+2. Wire `generate-schedule/index.ts` to use the helper with `callModelWithStreaming` as the real `callStreaming`. Remove the `callModel` import and the bespoke loop.
+3. Recalibrate `MODEL_LOOP_BUDGET_MS`. Each streaming attempt can take up to 90s. Supabase edge functions hard-kill at ~150s. To allow at least one fallback attempt: budget = 130s (allows model 1 to fully consume 90s, then ~30-40s for model 2 to either succeed quickly or fail-fast on an explicit error). For most calls model 1 will succeed in 15-25s and the budget never matters.
+
+## Out of scope
+
+- Changing the prompt size or json_schema constraints. Those rules are intentional for correctness.
+- Touching other edge functions that use `callModel`. This change is scoped to schedule generation only.
+- Re-enabling Braintrust. Telemetry remains a no-op (`braintrust.ts:4` `initLogger = null`).
+
+## Test plan
+
+Vitest unit tests against `runScheduleModelChain`:
+
+1. Returns parsed JSON + model name on first model success.
+2. Falls back to next model when first returns `null` content.
+3. Falls back to next model when first returns content that fails `JSON.parse`.
+4. Strips markdown code fences (```json ... ```) before parsing.
+5. Returns `null` when every model fails.
+6. Stops iterating models once wall-clock budget is exhausted (uses injected `now`).
+7. Calls `callStreaming` exactly once per model (no extra retries — the streaming primitive owns retries internally).
+
+Manual verification post-deploy: trigger generation for the affected restaurant. Expect success in <30s with `streaming` markers in the log.
+
+## Risk
+
+- Low: the streaming primitive has been in `_shared/` since before this incident and is exercised by `callAIWithFallbackStreaming`. We are reusing it, not introducing it.
+- Behavioral diff vs. non-streaming: OpenRouter does not include token usage in SSE streams. Logging will not capture exact token counts for these calls. Acceptable trade-off given Braintrust is disabled and prompt size is already logged at line 511.

--- a/docs/superpowers/specs/2026-05-22-generate-schedule-streaming-design.md
+++ b/docs/superpowers/specs/2026-05-22-generate-schedule-streaming-design.md
@@ -10,7 +10,7 @@ Frontend shows: "Something Went Wrong / The AI schedule generation failed / Gene
 
 Edge function logs (production, Wetzel's Cold Stone Alamo Ranch, ID `7c0c76e3-e770-401b-a2a9-c1edd407efed`, prompt=20,089 chars):
 
-```
+```text
 [generate-schedule] Trying model: Gemini 2.5 Flash
 ✅ Gemini 2.5 Flash succeeded
 [generate-schedule] Model Gemini 2.5 Flash parse failed: Signal timed out.

--- a/supabase/functions/_shared/schedule-ai-runner.ts
+++ b/supabase/functions/_shared/schedule-ai-runner.ts
@@ -9,6 +9,7 @@ export type ScheduleModelChainCallStreaming = (
   openRouterApiKey: string,
   edgeFunction: string,
   restaurantId?: string,
+  signal?: AbortSignal,
 ) => Promise<string | null>;
 
 export interface RunScheduleModelChainArgs {
@@ -56,22 +57,52 @@ export async function runScheduleModelChain<T = unknown>(
 
   for (const model of models) {
     const elapsed = now() - start;
-    if (elapsed > budgetMs) {
+    const remaining = budgetMs - elapsed;
+    if (remaining <= 0) {
       console.warn(
         `[${edgeFunction}] Model chain wall-clock budget exhausted (${elapsed}ms > ${budgetMs}ms). Stopping early.`,
       );
       break;
     }
 
-    console.log(`[${edgeFunction}] Trying model: ${model.name} (streaming)`);
+    console.log(
+      `[${edgeFunction}] Trying model: ${model.name} (streaming, remaining=${remaining}ms)`,
+    );
+
+    // Bound the in-flight streaming call by the remaining chain budget so a
+    // slow model can't overshoot the edge-function hard limit (~150s on
+    // Supabase). If the budget elapses mid-call, the AbortController fires
+    // and callStreaming's fetch is cancelled.
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), remaining);
+
     let content: string | null;
     try {
-      content = await callStreaming(model, requestBody, openRouterApiKey, edgeFunction, restaurantId);
+      content = await callStreaming(
+        model,
+        requestBody,
+        openRouterApiKey,
+        edgeFunction,
+        restaurantId,
+        controller.signal,
+      );
     } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (
+        controller.signal.aborted ||
+        (err instanceof Error && err.name === "AbortError")
+      ) {
+        console.warn(
+          `[${edgeFunction}] Model ${model.name} aborted: chain budget elapsed (${message}).`,
+        );
+        break;
+      }
       console.warn(
-        `[${edgeFunction}] Model ${model.name} streaming threw: ${err instanceof Error ? err.message : String(err)}`,
+        `[${edgeFunction}] Model ${model.name} streaming threw: ${message}`,
       );
       continue;
+    } finally {
+      clearTimeout(timer);
     }
 
     if (!content) continue;

--- a/supabase/functions/_shared/schedule-ai-runner.ts
+++ b/supabase/functions/_shared/schedule-ai-runner.ts
@@ -1,0 +1,92 @@
+// Pure helper that iterates an AI model chain via an injected streaming caller,
+// strips markdown fences, and returns the first successfully parsed JSON payload.
+// Kept free of Deno-only imports so it can be unit-tested from Vitest.
+import type { ModelConfig } from "./ai-caller.ts";
+
+export type ScheduleModelChainCallStreaming = (
+  model: ModelConfig,
+  requestBody: unknown,
+  openRouterApiKey: string,
+  edgeFunction: string,
+  restaurantId?: string,
+) => Promise<string | null>;
+
+export interface RunScheduleModelChainArgs {
+  models: ModelConfig[];
+  requestBody: unknown;
+  openRouterApiKey: string;
+  edgeFunction: string;
+  restaurantId?: string;
+  callStreaming: ScheduleModelChainCallStreaming;
+  /** Override for time source. Defaults to Date.now. */
+  now?: () => number;
+  /** Wall-clock budget for the entire chain. Defaults to 130_000ms. */
+  budgetMs?: number;
+}
+
+export interface ScheduleModelChainResult<T = unknown> {
+  data: T;
+  model: string;
+}
+
+const DEFAULT_BUDGET_MS = 130_000;
+
+function stripMarkdownFences(content: string): string {
+  return content
+    .replace(/^```(?:json)?\s*\n?/i, "")
+    .replace(/\n?```\s*$/i, "")
+    .trim();
+}
+
+export async function runScheduleModelChain<T = unknown>(
+  args: RunScheduleModelChainArgs,
+): Promise<ScheduleModelChainResult<T> | null> {
+  const {
+    models,
+    requestBody,
+    openRouterApiKey,
+    edgeFunction,
+    restaurantId,
+    callStreaming,
+    now = Date.now,
+    budgetMs = DEFAULT_BUDGET_MS,
+  } = args;
+
+  const start = now();
+
+  for (const model of models) {
+    const elapsed = now() - start;
+    if (elapsed > budgetMs) {
+      console.warn(
+        `[${edgeFunction}] Model chain wall-clock budget exhausted (${elapsed}ms > ${budgetMs}ms). Stopping early.`,
+      );
+      break;
+    }
+
+    console.log(`[${edgeFunction}] Trying model: ${model.name} (streaming)`);
+    let content: string | null;
+    try {
+      content = await callStreaming(model, requestBody, openRouterApiKey, edgeFunction, restaurantId);
+    } catch (err) {
+      console.warn(
+        `[${edgeFunction}] Model ${model.name} streaming threw: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      continue;
+    }
+
+    if (!content) continue;
+
+    const cleaned = stripMarkdownFences(content);
+    try {
+      const data = JSON.parse(cleaned) as T;
+      return { data, model: model.name };
+    } catch (err) {
+      console.warn(
+        `[${edgeFunction}] Model ${model.name} parse failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      continue;
+    }
+  }
+
+  return null;
+}

--- a/supabase/functions/_shared/streaming.ts
+++ b/supabase/functions/_shared/streaming.ts
@@ -2,11 +2,17 @@
 import { ModelConfig } from "./ai-caller.ts";
 import { startStreamingSpan, logAICall, type AICallMetadata } from "./braintrust.ts";
 
+export interface StreamingResult {
+  content: string;
+  /** OpenAI/OpenRouter finish_reason from the last delta seen ("stop", "length", "tool_calls", etc.) */
+  finishReason: string | null;
+}
+
 /**
  * Process SSE (Server-Sent Events) streaming response and return complete content
  * Handles line-by-line parsing, partial JSON chunks, and [DONE] signals
  */
-export async function processStreamedResponse(response: Response): Promise<string> {
+export async function processStreamedResponse(response: Response): Promise<StreamingResult> {
   const reader = response.body?.getReader();
   if (!reader) {
     throw new Error('Response body is not readable');
@@ -15,6 +21,7 @@ export async function processStreamedResponse(response: Response): Promise<strin
   const decoder = new TextDecoder();
   let buffer = '';
   let completeContent = '';
+  let finishReason: string | null = null;
   let isComplete = false;
 
   try {
@@ -39,7 +46,7 @@ export async function processStreamedResponse(response: Response): Promise<strin
         // Parse SSE data
         if (line.startsWith('data: ')) {
           const data = line.slice(6);
-          
+
           // Check for stream completion signal
           if (data === '[DONE]') {
             isComplete = true;
@@ -60,9 +67,12 @@ export async function processStreamedResponse(response: Response): Promise<strin
               completeContent += content;
             }
 
-            // Check for error finish reason
-            if (parsed.choices?.[0]?.finish_reason === 'error') {
-              throw new Error('Stream terminated with error');
+            const reason = parsed.choices?.[0]?.finish_reason;
+            if (reason) {
+              finishReason = reason;
+              if (reason === 'error') {
+                throw new Error('Stream terminated with error');
+              }
             }
           } catch (e) {
             // If JSON parsing fails, it might be a partial chunk - continue
@@ -75,7 +85,7 @@ export async function processStreamedResponse(response: Response): Promise<strin
       if (isComplete) break;
     }
 
-    return completeContent;
+    return { content: completeContent, finishReason };
   } finally {
     reader.cancel();
   }
@@ -84,25 +94,30 @@ export async function processStreamedResponse(response: Response): Promise<strin
 /**
  * Call AI model with streaming support
  * Returns complete content string after stream finishes
+ *
+ * @param externalSignal Optional caller-supplied abort signal. Combined with the
+ *   internal 90s per-attempt timeout so an outer chain budget can cancel an
+ *   in-flight call.
  */
 export async function callModelWithStreaming(
   modelConfig: ModelConfig,
   requestBody: any,
   openRouterApiKey: string,
   edgeFunction: string = 'unknown',
-  restaurantId?: string
+  restaurantId?: string,
+  externalSignal?: AbortSignal
 ): Promise<string | null> {
   let retryCount = 0;
-  
+
   while (retryCount < modelConfig.maxRetries) {
     try {
       console.log(`🔄 ${modelConfig.name} (streaming) attempt ${retryCount + 1}/${modelConfig.maxRetries}...`);
-      
+
       // Add streaming flag and override model
-      const streamingBody = { 
-        ...requestBody, 
+      const streamingBody = {
+        ...requestBody,
         model: modelConfig.id,
-        stream: true 
+        stream: true
       };
 
       const metadata: AICallMetadata = {
@@ -119,10 +134,16 @@ export async function callModelWithStreaming(
 
       // Start streaming span
       const endSpan = startStreamingSpan(
-        `${edgeFunction}:streaming`, 
+        `${edgeFunction}:streaming`,
         { messages: requestBody.messages, model: modelConfig.id },
         metadata
       );
+
+      // Per-attempt 90s timeout, combined with any caller-supplied chain budget signal.
+      const timeoutSignal = AbortSignal.timeout(90000);
+      const signal = externalSignal
+        ? AbortSignal.any([timeoutSignal, externalSignal])
+        : timeoutSignal;
 
       const response = await fetch("https://openrouter.ai/api/v1/chat/completions", {
         method: "POST",
@@ -133,20 +154,43 @@ export async function callModelWithStreaming(
           "Content-Type": "application/json"
         },
         body: JSON.stringify(streamingBody),
-        signal: AbortSignal.timeout(90000) // 90 second timeout for large responses
+        signal,
       });
 
       if (response.ok) {
         console.log(`✅ ${modelConfig.name} stream started successfully`);
-        const content = await processStreamedResponse(response);
-        console.log(`✅ ${modelConfig.name} stream completed. Content length: ${content.length}`);
-        
+        const { content, finishReason } = await processStreamedResponse(response);
+        console.log(
+          `✅ ${modelConfig.name} stream completed. Content length: ${content.length}, finish_reason: ${finishReason ?? 'null'}`
+        );
+
+        // Reject truncated outputs (model hit max_tokens). With strict json_schema
+        // a length-truncated payload is almost never parseable, but the previous
+        // non-streaming path skipped on finish_reason=length explicitly and we
+        // restore that here so the next model in the chain gets a chance.
+        if (finishReason === 'length') {
+          console.warn(
+            `⚠️ ${modelConfig.name} truncated output (finish_reason=length), skipping to next model`
+          );
+          logAICall(
+            `${edgeFunction}:streaming:truncated`,
+            { messages: requestBody.messages, model: modelConfig.id },
+            { content_length: content.length },
+            { ...metadata, success: false, status_code: 200, error: 'finish_reason=length' },
+            null
+          );
+          if (endSpan) {
+            endSpan(content, null);
+          }
+          return null;
+        }
+
         // End streaming span with complete content
         // Note: We don't have token usage for streaming responses from OpenRouter
         if (endSpan) {
           endSpan(content, null);
         }
-        
+
         // Also log the successful streaming call
         logAICall(
           `${edgeFunction}:streaming:success`,
@@ -155,7 +199,7 @@ export async function callModelWithStreaming(
           { ...metadata, success: true, status_code: 200 },
           null
         );
-        
+
         return content;
       }
 

--- a/supabase/functions/generate-schedule/index.ts
+++ b/supabase/functions/generate-schedule/index.ts
@@ -2,7 +2,9 @@ import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { corsHeaders } from "../_shared/cors.ts";
-import { callModel, type ModelConfig } from "../_shared/ai-caller.ts";
+import { type ModelConfig } from "../_shared/ai-caller.ts";
+import { callModelWithStreaming } from "../_shared/streaming.ts";
+import { runScheduleModelChain } from "../_shared/schedule-ai-runner.ts";
 import {
   buildSchedulePrompt,
   type ScheduleContext,
@@ -520,59 +522,21 @@ serve(async (req) => {
       throw new Error("OPENROUTER_API_KEY environment variable is not set");
     }
 
-    let aiResult: AiResult | null = null;
-
     // Wall-clock budget for the entire model fallback chain. Supabase edge
-    // functions hard-kill at ~150s; each callModel uses AbortSignal.timeout(30s)
-    // per attempt, so 5 models × ≥30s could exceed the limit and prevent any
-    // diagnostic response from reaching the client. Stop early with 60s
-    // headroom for response serialization.
-    const modelLoopStart = Date.now();
-    const MODEL_LOOP_BUDGET_MS = 90_000;
-
-    for (const modelConfig of SCHEDULE_MODELS) {
-      const elapsed = Date.now() - modelLoopStart;
-      if (elapsed > MODEL_LOOP_BUDGET_MS) {
-        console.warn(
-          `[generate-schedule] Model chain wall-clock budget exhausted ` +
-            `(${elapsed}ms > ${MODEL_LOOP_BUDGET_MS}ms). Stopping early.`,
-        );
-        break;
-      }
-      console.log(`[generate-schedule] Trying model: ${modelConfig.name}`);
-      const response = await callModel(
-        modelConfig,
-        requestBody,
-        openRouterApiKey,
-        "generate-schedule",
-        restaurant_id,
-      );
-      if (!response || !response.ok) continue;
-
-      try {
-        const data = await response.json();
-        const choice = data.choices?.[0];
-        if (!choice?.message?.content) continue;
-        if (choice.finish_reason === "length") {
-          console.warn(
-            `[generate-schedule] Model ${modelConfig.name} truncated output ` +
-              `(finish_reason=length), skipping`,
-          );
-          continue;
-        }
-        const cleaned = choice.message.content
-          .replace(/^```(?:json)?\s*\n?/i, "")
-          .replace(/\n?```\s*$/i, "")
-          .trim();
-        aiResult = { data: JSON.parse(cleaned), model: modelConfig.name };
-        break;
-      } catch (err) {
-        console.warn(
-          `[generate-schedule] Model ${modelConfig.name} parse failed: ${err instanceof Error ? err.message : String(err)}`,
-        );
-        continue;
-      }
-    }
+    // functions hard-kill at ~150s; callModelWithStreaming uses
+    // AbortSignal.timeout(90s) per attempt, so we budget ~130s to allow at
+    // least one fallback if the primary model fails fast on an explicit error.
+    // Successful primary calls typically complete in 15-25s and never touch
+    // this ceiling.
+    const aiResult = await runScheduleModelChain<AiResult["data"]>({
+      models: SCHEDULE_MODELS,
+      requestBody,
+      openRouterApiKey,
+      edgeFunction: "generate-schedule",
+      restaurantId: restaurant_id,
+      callStreaming: callModelWithStreaming,
+      budgetMs: 130_000,
+    });
 
     if (!aiResult) {
       return new Response(

--- a/tests/unit/schedule-ai-runner.test.ts
+++ b/tests/unit/schedule-ai-runner.test.ts
@@ -135,8 +135,12 @@ describe('runScheduleModelChain', () => {
     });
 
     expect(callStreaming).toHaveBeenCalledTimes(2);
-    expect(callStreaming).toHaveBeenNthCalledWith(1, M1, expect.any(Object), 'sk-test', 'generate-schedule', undefined);
-    expect(callStreaming).toHaveBeenNthCalledWith(2, M2, expect.any(Object), 'sk-test', 'generate-schedule', undefined);
+    expect(callStreaming).toHaveBeenNthCalledWith(
+      1, M1, expect.any(Object), 'sk-test', 'generate-schedule', undefined, expect.any(AbortSignal),
+    );
+    expect(callStreaming).toHaveBeenNthCalledWith(
+      2, M2, expect.any(Object), 'sk-test', 'generate-schedule', undefined, expect.any(AbortSignal),
+    );
   });
 
   it('passes restaurantId through to callStreaming when provided', async () => {
@@ -151,6 +155,83 @@ describe('runScheduleModelChain', () => {
       callStreaming,
     });
 
-    expect(callStreaming).toHaveBeenCalledWith(M1, expect.any(Object), 'sk-test', 'generate-schedule', 'rest-123');
+    expect(callStreaming).toHaveBeenCalledWith(
+      M1, expect.any(Object), 'sk-test', 'generate-schedule', 'rest-123', expect.any(AbortSignal),
+    );
+  });
+
+  it('passes a non-aborted AbortSignal into each attempt', async () => {
+    let capturedSignal: AbortSignal | undefined;
+    const callStreaming: ScheduleModelChainCallStreaming = vi.fn(
+      async (_m, _b, _k, _e, _r, signal) => {
+        capturedSignal = signal;
+        return validShifts;
+      },
+    );
+
+    await runScheduleModelChain({
+      models: [M1],
+      requestBody: { messages: [] },
+      openRouterApiKey: 'sk-test',
+      edgeFunction: 'generate-schedule',
+      callStreaming,
+    });
+
+    expect(capturedSignal).toBeInstanceOf(AbortSignal);
+    expect(capturedSignal?.aborted).toBe(false);
+  });
+
+  it('aborts in-flight call when remaining budget elapses, then breaks (does not try next model)', async () => {
+    vi.useFakeTimers();
+    try {
+      const callStreaming: ScheduleModelChainCallStreaming = vi.fn(
+        (_m, _b, _k, _e, _r, signal) =>
+          new Promise<string | null>((_resolve, reject) => {
+            signal?.addEventListener('abort', () => {
+              const err = new Error('aborted');
+              err.name = 'AbortError';
+              reject(err);
+            });
+          }),
+      );
+
+      const promise = runScheduleModelChain({
+        models: [M1, M2, M3],
+        requestBody: { messages: [] },
+        openRouterApiKey: 'sk-test',
+        edgeFunction: 'generate-schedule',
+        callStreaming,
+        budgetMs: 90_000,
+      });
+
+      await vi.advanceTimersByTimeAsync(91_000);
+      const result = await promise;
+
+      expect(result).toBeNull();
+      expect(callStreaming).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stops after second attempt when remaining budget is insufficient for another call', async () => {
+    let nowMs = 1_000_000;
+    const callStreaming: ScheduleModelChainCallStreaming = vi.fn(async () => {
+      nowMs += 50_000;
+      return null;
+    });
+
+    const result = await runScheduleModelChain({
+      models: [M1, M2, M3],
+      requestBody: { messages: [] },
+      openRouterApiKey: 'sk-test',
+      edgeFunction: 'generate-schedule',
+      callStreaming,
+      budgetMs: 90_000,
+      now: () => nowMs,
+    });
+
+    expect(result).toBeNull();
+    expect(callStreaming).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/unit/schedule-ai-runner.test.ts
+++ b/tests/unit/schedule-ai-runner.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  runScheduleModelChain,
+  type ScheduleModelChainCallStreaming,
+} from '../../supabase/functions/_shared/schedule-ai-runner';
+import type { ModelConfig } from '../../supabase/functions/_shared/ai-caller';
+
+const M1: ModelConfig = { name: 'M1', id: 'm/1', maxRetries: 1 };
+const M2: ModelConfig = { name: 'M2', id: 'm/2', maxRetries: 1 };
+const M3: ModelConfig = { name: 'M3', id: 'm/3', maxRetries: 1 };
+
+const validShifts = JSON.stringify({
+  shifts: [{ employee_id: 'e1', template_id: 't1', date: '2026-05-26', start: '11:00', end: '15:00' }],
+  metadata: { estimated_cost: 100, budget_variance_pct: 0, notes: 'ok' },
+});
+
+describe('runScheduleModelChain', () => {
+  it('returns parsed JSON + model name on first successful model', async () => {
+    const callStreaming: ScheduleModelChainCallStreaming = vi.fn(async (model) => {
+      expect(model.id).toBe('m/1');
+      return validShifts;
+    });
+
+    const result = await runScheduleModelChain({
+      models: [M1, M2, M3],
+      requestBody: { messages: [] },
+      openRouterApiKey: 'sk-test',
+      edgeFunction: 'generate-schedule',
+      callStreaming,
+    });
+
+    expect(result).not.toBeNull();
+    expect(result?.model).toBe('M1');
+    expect(result?.data).toEqual(JSON.parse(validShifts));
+    expect(callStreaming).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to next model when first returns null content', async () => {
+    const callStreaming: ScheduleModelChainCallStreaming = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(validShifts);
+
+    const result = await runScheduleModelChain({
+      models: [M1, M2],
+      requestBody: { messages: [] },
+      openRouterApiKey: 'sk-test',
+      edgeFunction: 'generate-schedule',
+      callStreaming,
+    });
+
+    expect(result?.model).toBe('M2');
+    expect(callStreaming).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to next model when first returns unparseable content', async () => {
+    const callStreaming: ScheduleModelChainCallStreaming = vi
+      .fn()
+      .mockResolvedValueOnce('this is not json {{{')
+      .mockResolvedValueOnce(validShifts);
+
+    const result = await runScheduleModelChain({
+      models: [M1, M2],
+      requestBody: { messages: [] },
+      openRouterApiKey: 'sk-test',
+      edgeFunction: 'generate-schedule',
+      callStreaming,
+    });
+
+    expect(result?.model).toBe('M2');
+    expect(callStreaming).toHaveBeenCalledTimes(2);
+  });
+
+  it('strips markdown code fences before parsing', async () => {
+    const fenced = '```json\n' + validShifts + '\n```';
+    const callStreaming: ScheduleModelChainCallStreaming = vi.fn().mockResolvedValueOnce(fenced);
+
+    const result = await runScheduleModelChain({
+      models: [M1],
+      requestBody: { messages: [] },
+      openRouterApiKey: 'sk-test',
+      edgeFunction: 'generate-schedule',
+      callStreaming,
+    });
+
+    expect(result?.model).toBe('M1');
+    expect(result?.data).toEqual(JSON.parse(validShifts));
+  });
+
+  it('returns null when every model fails', async () => {
+    const callStreaming: ScheduleModelChainCallStreaming = vi.fn().mockResolvedValue(null);
+
+    const result = await runScheduleModelChain({
+      models: [M1, M2, M3],
+      requestBody: { messages: [] },
+      openRouterApiKey: 'sk-test',
+      edgeFunction: 'generate-schedule',
+      callStreaming,
+    });
+
+    expect(result).toBeNull();
+    expect(callStreaming).toHaveBeenCalledTimes(3);
+  });
+
+  it('stops iterating models once wall-clock budget is exhausted', async () => {
+    let nowMs = 1_000_000;
+    const callStreaming: ScheduleModelChainCallStreaming = vi.fn(async () => {
+      nowMs += 50_000;
+      return null;
+    });
+
+    const result = await runScheduleModelChain({
+      models: [M1, M2, M3],
+      requestBody: { messages: [] },
+      openRouterApiKey: 'sk-test',
+      edgeFunction: 'generate-schedule',
+      callStreaming,
+      budgetMs: 90_000,
+      now: () => nowMs,
+    });
+
+    expect(result).toBeNull();
+    expect(callStreaming).toHaveBeenCalledTimes(2);
+  });
+
+  it('calls callStreaming exactly once per model (no extra retries at this layer)', async () => {
+    const callStreaming: ScheduleModelChainCallStreaming = vi.fn().mockResolvedValue(null);
+
+    await runScheduleModelChain({
+      models: [M1, M2],
+      requestBody: { messages: [] },
+      openRouterApiKey: 'sk-test',
+      edgeFunction: 'generate-schedule',
+      callStreaming,
+    });
+
+    expect(callStreaming).toHaveBeenCalledTimes(2);
+    expect(callStreaming).toHaveBeenNthCalledWith(1, M1, expect.any(Object), 'sk-test', 'generate-schedule', undefined);
+    expect(callStreaming).toHaveBeenNthCalledWith(2, M2, expect.any(Object), 'sk-test', 'generate-schedule', undefined);
+  });
+
+  it('passes restaurantId through to callStreaming when provided', async () => {
+    const callStreaming: ScheduleModelChainCallStreaming = vi.fn().mockResolvedValueOnce(validShifts);
+
+    await runScheduleModelChain({
+      models: [M1],
+      requestBody: { messages: [] },
+      openRouterApiKey: 'sk-test',
+      edgeFunction: 'generate-schedule',
+      restaurantId: 'rest-123',
+      callStreaming,
+    });
+
+    expect(callStreaming).toHaveBeenCalledWith(M1, expect.any(Object), 'sk-test', 'generate-schedule', 'rest-123');
+  });
+});


### PR DESCRIPTION
## Summary

- **Production-down hotfix.** AI schedule generation was returning 502 for restaurants whose prompts produced large AI responses (e.g., 27 employees, 8 templates, 69 required slots → ~20K-char prompt, long json_schema-constrained output).
- Root cause: `_shared/ai-caller.ts:77` attaches `AbortSignal.timeout(30000)` to the OpenRouter fetch and returns the `Response` **without consuming the body**. The signal stays bound to the body stream, so the caller's `await response.json()` aborts with `DOMException("Signal timed out.")` after 30s of body download. Three consecutive aborts (~90s) exhausted the wall-clock budget and returned a synthetic 502.
- Fix: switch `generate-schedule` to the existing `callModelWithStreaming` primitive in `_shared/streaming.ts`, which uses a 90s fetch timeout, sends `stream: true`, and consumes SSE chunks inside the helper so no caller-side body read is left exposed to the bound signal.
- Refactor: extract the model-chain loop into a new pure helper `_shared/schedule-ai-runner.ts` so it can be unit-tested from Vitest with the streaming caller injected.
- Recalibrate wall-clock budget: `MODEL_LOOP_BUDGET_MS` raised from 90s → 130s so one full streaming attempt (90s ceiling) plus a fast-fail fallback fit inside Supabase's ~150s edge-function hard kill.

## Root cause evidence (from production logs)

```
[generate-schedule] Trying model: Gemini 2.5 Flash
✅ Gemini 2.5 Flash succeeded             ← fetch headers OK
[generate-schedule] Model Gemini 2.5 Flash parse failed: Signal timed out.   ← body read aborted
[generate-schedule] Trying model: Gemini 2.5 Flash Lite
✅ Gemini 2.5 Flash Lite succeeded
[generate-schedule] Model Gemini 2.5 Flash Lite parse failed: Signal timed out.
[generate-schedule] Trying model: Llama 4 Maverick
✅ Llama 4 Maverick succeeded
[generate-schedule] Model Llama 4 Maverick parse failed: Signal timed out.
[generate-schedule] Model chain wall-clock budget exhausted (90010ms > 90000ms). Stopping early.
```

The misleading `✅ X succeeded` log is real — only fetch headers were confirmed. The body never finished arriving before the 30s signal fired on the stream pull.

## Why streaming fixes it

- `processStreamedResponse` reads SSE chunks continuously; an isolated slow chunk doesn't trigger the abort as long as the whole stream completes within 90s.
- Token emission paces the abort window naturally — chunks keep the connection active.
- The helper returns the accumulated content **string**, eliminating the body-read step where the bound signal previously fired.

## Test plan

- [x] `tests/unit/schedule-ai-runner.test.ts` — 8 cases covering: first-success, null fallback, parse-error fallback, markdown-fence stripping, all-fail → null, wall-clock budget exhaustion, no extra retries at this layer, restaurantId pass-through.
- [x] `npm run typecheck` clean.
- [x] `npm run test` — 4085 unit tests pass (1 pre-existing skip).
- [x] `npm run build` succeeds.
- [x] `npx eslint` clean on all touched files.
- [ ] Post-deploy smoke: trigger AI schedule generation for the affected restaurant. Expect success in <30s with `(streaming)` markers in the edge function log.

## Out of scope

- Prompt size and `json_schema` constraints unchanged.
- Other edge functions that use `callModel` are not touched.
- Braintrust telemetry remains disabled (`_shared/braintrust.ts:4` `initLogger = null`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved schedule-generation reliability by switching to a streaming-based execution path, bounding per-attempt time, aborting truncated responses, and preventing misleading parse errors and synthetic 502s.

* **Refactor**
  * Consolidated model fallback logic into a single, testable chain that respects a total wall-clock budget and clearer abort/error handling.

* **Documentation**
  * Added a design spec describing the incident, fix, test plan, and out-of-scope items.

* **Tests**
  * Added unit tests covering fallback behavior, fence stripping, budget exhaustion, and abort scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toyiyo/nimble-pnl/pull/515?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->