### PR TITLE
fix(scheduler): hour caps, consecutive days, minor support (Bug I)

### DIFF
--- a/docs/superpowers/plans/2026-05-23-scheduler-hour-caps-fairness-plan.md
+++ b/docs/superpowers/plans/2026-05-23-scheduler-hour-caps-fairness-plan.md
@@ -1,0 +1,719 @@
+# Plan: Scheduler Hour Caps & Fairness (Bug I)
+
+Design doc: `docs/superpowers/specs/2026-05-23-scheduler-hour-caps-fairness-design.md`
+
+## Tasks
+
+Each task is 5–20 minutes of focused work. Strict TDD: RED → GREEN →
+REFACTOR → COMMIT unless noted otherwise. The three layers in the spec
+are built bottom-up (helper first, then validator, then prompt) so that
+each layer's tests can rely on a stable contract from the layer below.
+
+---
+
+### T1 — RED: failing tests for `computeHourBudget` helper
+
+File: `tests/unit/schedule-hour-budget.test.ts` (new)
+
+Create a new test file. The helper does not exist yet — every test
+fails on import.
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { computeHourBudget } from
+  '../../supabase/functions/_shared/schedule-prompt-builder';
+```
+
+Cases (one `it` block each, per spec "Unit tests
+(`tests/unit/schedule-hour-budget.test.ts`, new file)"):
+
+1. Adult DOB → `{ is_minor: false, max_weekly_hours: 40 }`.
+2. DOB 17.5 years before weekStart → `{ is_minor: true, max_weekly_hours: 40 }`.
+3. DOB 14 years before weekStart → `{ is_minor: true, max_weekly_hours: 18 }`.
+4. `null` DOB → adult 40.
+5. `undefined` DOB → adult 40.
+6. Malformed DOB (`"not-a-date"`, `"2010-13-40"`) → adult 40.
+7. DOB in the future (one year after weekStart) → adult 40.
+8. Invalid `weekStart` (`"not-a-date"`) → throws.
+9. Birthday on the Friday of weekStart's week, employee turns 16 →
+   still treated as 15 → `{ is_minor: true, max_weekly_hours: 18 }`.
+10. **Birthday on Monday that IS weekStart, employee turns 16 →
+    treated as 16** → `{ is_minor: true, max_weekly_hours: 40 }`.
+    (Locks the inclusive-boundary rule from the spec.)
+11. **TZ-portability case.** Sets `process.env.TZ = 'America/Chicago'`,
+    asserts result. Resets `process.env.TZ = 'Pacific/Auckland'`,
+    asserts identical result. Uses DOB `"2010-06-08"` and weekStart
+    `"2026-06-08"` → both calls must return `{ is_minor: false,
+    max_weekly_hours: 40 }` (turns 16 on Monday → adult). A
+    local-time `new Date(year, monthIdx, day)` implementation will
+    fail on at least one of the two TZs.
+
+Run: `npm run test -- tests/unit/schedule-hour-budget.test.ts` —
+expect import error / all-fail.
+
+Commit: `test(scheduler): RED — assert computeHourBudget rules, DOB edge cases, TZ portability`
+
+---
+
+### T2 — GREEN: implement `computeHourBudget` + extend `ScheduleEmployee`
+
+File: `supabase/functions/_shared/schedule-prompt-builder.ts`
+
+1. Extend `ScheduleEmployee` interface (lines 9-16 per spec):
+
+   ```ts
+   export interface ScheduleEmployee {
+     id: string;
+     name: string;
+     position: string;
+     area: string | null;
+     hourly_rate: number;
+     employment_type: 'full_time' | 'part_time';
+     /** Set by the edge function from employees.date_of_birth relative
+      *  to weekStart. Null DOB → false (adult). */
+     is_minor: boolean;
+     /** Hard ceiling. Adults: 40. Under-16 minors: 18. 16-17yo: 40. */
+     max_weekly_hours: number;
+   }
+   ```
+
+2. Add `computeHourBudget` as an exported pure helper next to
+   `buildWeekDates` (no new module):
+
+   ```ts
+   /**
+    * Returns the weekly hour cap and minor flag for an employee.
+    *
+    * Both `dob` and `weekStart` are parsed as UTC midnight via
+    * `new Date(\`${s}T00:00:00Z\`)` and compared with `.getUTC*()`
+    * accessors so the result is identical across host TZs. Do NOT
+    * use the local-time `new Date(year, monthIdx, day)` constructor —
+    * see TZ-portability test in tests/unit/schedule-hour-budget.test.ts.
+    *
+    * Age is computed in full UTC years anchored on `weekStart` (the
+    * first day of the schedule week). Birthday inclusive: an employee
+    * who turns N on `weekStart` is age N.
+    *
+    * | DOB         | Age       | Result                            |
+    * | ----------- | --------- | --------------------------------- |
+    * | null/bad    | n/a       | { is_minor: false, max: 40 }      |
+    * | future      | n/a       | { is_minor: false, max: 40 }      |
+    * | ≥ 18        | adult     | { is_minor: false, max: 40 }      |
+    * | 16-17       | minor 16+ | { is_minor: true,  max: 40 }      |
+    * | < 16        | minor <16 | { is_minor: true,  max: 18 }      |
+    *
+    * @throws if weekStart is not a parseable YYYY-MM-DD string.
+    */
+   export function computeHourBudget(
+     dob: string | null | undefined,
+     weekStart: string,
+   ): { is_minor: boolean; max_weekly_hours: number } {
+     const weekDate = new Date(`${weekStart}T00:00:00Z`);
+     if (Number.isNaN(weekDate.getTime())) {
+       throw new Error(`Invalid weekStart: ${weekStart}`);
+     }
+
+     if (!dob) return { is_minor: false, max_weekly_hours: 40 };
+
+     const dobDate = new Date(`${dob}T00:00:00Z`);
+     if (Number.isNaN(dobDate.getTime())) {
+       return { is_minor: false, max_weekly_hours: 40 };
+     }
+
+     // Future DOB → data error, treat as adult.
+     if (dobDate.getTime() > weekDate.getTime()) {
+       return { is_minor: false, max_weekly_hours: 40 };
+     }
+
+     // Age in full years, inclusive birthday.
+     let age = weekDate.getUTCFullYear() - dobDate.getUTCFullYear();
+     const beforeBirthday =
+       weekDate.getUTCMonth() < dobDate.getUTCMonth() ||
+       (weekDate.getUTCMonth() === dobDate.getUTCMonth() &&
+        weekDate.getUTCDate() < dobDate.getUTCDate());
+     if (beforeBirthday) age--;
+
+     if (age < 16)  return { is_minor: true,  max_weekly_hours: 18 };
+     if (age < 18)  return { is_minor: true,  max_weekly_hours: 40 };
+     return            { is_minor: false, max_weekly_hours: 40 };
+   }
+   ```
+
+3. Re-run T1 tests — all 11 pass. Run full suite `npm run test` —
+   confirm no regression (the `ScheduleEmployee` shape change is
+   additive; existing callers will fail to typecheck until T3, but
+   nothing in Vitest's test path constructs a `ScheduleEmployee`
+   literal directly — verify with `grep -rn "ScheduleEmployee" src
+   tests supabase/functions`).
+
+Commit: `feat(scheduler): computeHourBudget helper + ScheduleEmployee is_minor/max_weekly_hours`
+
+---
+
+### T3 — Wire `date_of_birth` into edge function pipeline
+
+File: `supabase/functions/generate-schedule/index.ts`
+
+1. **Line 134 (SELECT).** Add `date_of_birth` to the active-employee
+   projection:
+
+   ```ts
+   .select('id, full_name, position, area, hourly_rate, employment_type, date_of_birth')
+   ```
+
+   (Adjust to match the existing column list — the spec confirms this
+   is a zero-RLS, zero-migration change because the calling user
+   already passes `user_has_capability(restaurant_id, 'view:employees')`.)
+
+2. **Lines 247-255 (mapper).** Add `computeHourBudget` call:
+
+   ```ts
+   import {
+     buildSchedulePrompt,
+     buildWeekDates,
+     computeHourBudget,           // NEW
+     type ScheduleEmployee,
+   } from '../_shared/schedule-prompt-builder.ts';
+
+   // …inside the .map(e => …):
+   const budget = computeHourBudget(e.date_of_birth, weekStartParam);
+   return {
+     id: e.id,
+     name: e.full_name,
+     position: e.position,
+     area: e.area ?? null,
+     hourly_rate: e.hourly_rate ?? 0,
+     employment_type: e.employment_type ?? 'full_time',
+     is_minor: budget.is_minor,
+     max_weekly_hours: budget.max_weekly_hours,
+   };
+   ```
+
+3. Typecheck: `npm run typecheck`. Expect clean. If the edge function
+   has its own Deno-style import that the typecheck step skips, run
+   `deno check supabase/functions/generate-schedule/index.ts` as a
+   spot-check.
+
+No tests in this task (the wiring is exercised by the integration
+smoke at the end). Commit:
+`feat(scheduler): pipe date_of_birth + computed hour budget into ScheduleEmployee`
+
+---
+
+### T4 — REFACTOR: promote `ValidationContext.employeeIds` to `employees: Map`
+
+File: `supabase/functions/_shared/schedule-validator.ts` and
+`tests/unit/schedule-validator.test.ts`
+
+Mechanical shape change. Existing tests must stay green after this task.
+No new behavior.
+
+1. **Validator type change** (`schedule-validator.ts` lines ~24-38 per spec):
+
+   ```ts
+   export interface ValidationContext {
+     /** Promoted from Set<string> + separate employeePositions Map.
+      *  Existence check `employeeIds.has(id)` becomes `employees.has(id)`.
+      *  Position check `employeePositions.get(id)` becomes
+      *  `employees.get(id)?.position`. */
+     employees: Map<string, {
+       position: string;
+       is_minor: boolean;
+       max_weekly_hours: number;
+     }>;
+     templates: Map<string, { days: number[]; position: string }>;
+     availability: Map<string, AvailabilitySlot>;
+     excludedEmployeeIds: Set<string>;
+     existingShifts: GeneratedShift[];
+   }
+   ```
+
+   Delete the old `employeeIds: Set<string>` and `employeePositions:
+   Map<string, string>` fields.
+
+2. **Validator body** — replace every `ctx.employeeIds.has(id)` with
+   `ctx.employees.has(id)`, every `ctx.employeePositions.get(id)` with
+   `ctx.employees.get(id)?.position`. Confirm with
+   `grep -n 'employeeIds\|employeePositions' supabase/functions/_shared/schedule-validator.ts`
+   — must return zero hits after this task.
+
+3. **Validator context build site** in `generate-schedule/index.ts`
+   (look for where `buildValidationContext` or the inline context
+   literal is constructed — search
+   `grep -n 'employeeIds\|employeePositions\|ValidationContext' supabase/functions/generate-schedule/index.ts`).
+   Replace the construction with the new `employees: Map` shape,
+   populated from `ScheduleEmployee[]` so `is_minor` and
+   `max_weekly_hours` flow through.
+
+4. **Test factory** — `tests/unit/schedule-validator.test.ts:29-49`
+   (`makeContext`). Replace the Set+Map construction with a single
+   `employees: Map` builder. Add helper:
+
+   ```ts
+   function emp(id: string, position = 'Server',
+                is_minor = false, max_weekly_hours = 40) {
+     return [id, { position, is_minor, max_weekly_hours }] as const;
+   }
+
+   function makeContext(overrides: Partial<ValidationContext> = {}): ValidationContext {
+     return {
+       employees: new Map([
+         emp('emp-1'),
+         emp('emp-2'),
+         // …existing seed ids
+       ]),
+       templates: new Map([…]),
+       availability: new Map([…]),
+       excludedEmployeeIds: new Set(),
+       existingShifts: [],
+       ...overrides,
+     };
+   }
+   ```
+
+5. **Inline overrides** at lines 32-35, 136-137, 160-161, 200-201, 302,
+   315, 328, 338, 351 (per spec's supabase-reviewer audit). Each site
+   today builds something like `{ employeeIds: new Set([...]),
+   employeePositions: new Map([...]) }` — replace with `{ employees:
+   new Map([emp('emp-x', 'Cook'), …]) }`. Confirm with
+   `grep -n 'employeeIds\|employeePositions' tests/unit/schedule-validator.test.ts`
+   — must return zero hits.
+
+6. Run `npm run test -- tests/unit/schedule-validator.test.ts` —
+   ALL EXISTING tests pass. This is a pure refactor — no behavior
+   change. Run `npm run typecheck` — clean.
+
+Commit:
+`refactor(scheduler): promote ValidationContext.employeeIds Set to employees Map`
+
+---
+
+### T5 — RED: failing tests for new validator step
+
+File: `tests/unit/schedule-validator.test.ts`
+
+Add a new `describe('validateShifts — hour caps and consecutive days', …)`
+block. Every test fails because the new step does not exist yet.
+
+Cases (per spec "Unit tests (`tests/unit/schedule-validator.test.ts`)"):
+
+1. **`HOURS_EXCEED_WEEKLY_CAP` — adult 40h cap.** 6 × 6.5h shifts (39h)
+   accept; 7th shift (+6.5h → 45.5h) drops with `HOURS_EXCEED_WEEKLY_CAP`.
+2. **`MINOR_HOURS_EXCEEDED` — under-16 18h cap.** Employee with
+   `max_weekly_hours: 18`: 3 × 6h shifts (18h) accept; 4th shift drops
+   with `MINOR_HOURS_EXCEEDED`.
+3. **Dispatch on cap value, NOT `is_minor`.** Employee with
+   `is_minor: true, max_weekly_hours: 40` (a 16-17yo): 6 × 6.5h shifts
+   accept; 7th shift drops with `HOURS_EXCEED_WEEKLY_CAP` (not
+   `MINOR_HOURS_EXCEEDED`). Locks the dispatch rule.
+4. **`CONSECUTIVE_DAYS_EXCEEDED`.** 5 shifts Mon–Fri accept; 6th shift
+   on Sat drops with the code.
+5. **Gap breaks the run.** Mon–Fri + Sun (no Sat): all 6 accept; no
+   consecutive-days drop fires.
+6. **Locked shifts seed the counter.** `existingShifts` puts employee
+   at 35h already; candidate 7h shift drops with
+   `HOURS_EXCEED_WEEKLY_CAP`.
+7. **Locked shift already over cap.** Locked = 41h: locked shift stays
+   in `valid`; new candidates for same employee drop. Validator does
+   NOT retroactively drop locked shifts.
+8. **Duplicate-day dedup.** Two locked shifts on the same Monday
+   (open + close): `longestConsecutiveRun` counts Monday once.
+   Subsequent Tue, Wed, Thu, Fri candidates all accept (5-day run not
+   exceeded).
+9. **Overnight shift counted correctly.** A 22:00→02:00 shift on Mon
+   counts as 4h (one day's minutes), not 24h or two days.
+10. **Order independence.** Same input shifts in random order produce
+    the same valid set as chronological order. Locks the `(day,
+    start_time, employee_id, template_id)` tiebreak.
+11. **DST spring-forward.** With weekStart `"2026-03-02"` (Mon) and
+    shifts Mon–Sun, the consecutive-day run is 7 (no false gap on
+    DST day March 8). Anchors UTC-math correctness.
+
+Run: `npm run test -- tests/unit/schedule-validator.test.ts` —
+expect the 11 new tests to fail; existing tests still pass.
+
+Commit:
+`test(scheduler): RED — hour caps, consecutive days, dedup, order independence, DST`
+
+---
+
+### T6 — GREEN part 1: add DropCodes + `longestConsecutiveRun` helper
+
+File: `supabase/functions/_shared/schedule-validator.ts`
+
+1. Extend `DropCode` union:
+
+   ```ts
+   export type DropCode =
+     | "EXCLUDED"
+     | "UNKNOWN_EMPLOYEE"
+     | "UNKNOWN_TEMPLATE"
+     | "DAY_NOT_IN_TEMPLATE"
+     | "POSITION_MISMATCH"
+     | "UNAVAILABLE_DAY"
+     | "OUTSIDE_WINDOW"
+     | "DOUBLE_BOOKING"
+     | "HOURS_EXCEED_WEEKLY_CAP"     // NEW
+     | "CONSECUTIVE_DAYS_EXCEEDED"   // NEW
+     | "MINOR_HOURS_EXCEEDED";       // NEW
+   ```
+
+2. Add `longestConsecutiveRun` helper (private, not exported):
+
+   ```ts
+   /**
+    * Longest consecutive-day run within the input.
+    * @param days Iterable of YYYY-MM-DD strings. Defensive dedup is
+    *   applied even if a Set is passed — a duplicate day must not
+    *   collapse the streak math into a zero-diff "gap."
+    * @remarks Correct only for inputs spanning at most one ISO month;
+    *   callers with multi-month inputs MUST sort by parsed Date.
+    *   See design doc for the reasoning.
+    */
+   function longestConsecutiveRun(days: Iterable<string>): number {
+     const sorted = [...new Set(days)].sort();
+     if (sorted.length === 0) return 0;
+     let max = 1, run = 1;
+     for (let i = 1; i < sorted.length; i++) {
+       const prev = Date.parse(`${sorted[i-1]}T00:00:00Z`);
+       const cur  = Date.parse(`${sorted[i]}T00:00:00Z`);
+       if (cur - prev === 86_400_000) run++;
+       else { max = Math.max(max, run); run = 1; }
+     }
+     return Math.max(max, run);
+   }
+   ```
+
+   Re-uses existing UTC parsing pattern; no new dependency.
+
+3. Update the existing `getDayOfWeek` JSDoc to note that the new
+   `longestConsecutiveRun` helper is the SAME-FILE counterpart for
+   day-set math, but uses UTC anchoring — the two MUST NOT be
+   composed.
+
+Run `npm run typecheck` — clean (no test changes yet; T5 tests still
+fail because the new validation step doesn't exist).
+
+Commit (T6 + T7 in one commit OR T6 alone if running tight):
+`feat(scheduler): add hour-cap DropCodes + longestConsecutiveRun helper`
+
+---
+
+### T7 — GREEN part 2: implement stateful validation step
+
+File: `supabase/functions/_shared/schedule-validator.ts`
+
+After the existing step 8 (`DOUBLE_BOOKING`), add a new stateful pass.
+Per the spec's step-ordering invariant, this MUST run after
+DOUBLE_BOOKING so duplicate-of-locked shifts get dropped before the
+counter would double-count them.
+
+1. Sort candidates (those that survived steps 1-8) by
+   `day ASC, start_time ASC, employee_id ASC, template_id ASC`.
+   Use `localeCompare` or string compare — all four fields are
+   already strings on the validated shift.
+
+2. Build the running state, seeded from `ctx.existingShifts`:
+
+   ```ts
+   type RunState = { minutesScheduled: number; daysScheduled: Set<string> };
+   const state = new Map<string, RunState>();
+
+   for (const locked of ctx.existingShifts) {
+     const entry = state.get(locked.employee_id)
+       ?? { minutesScheduled: 0, daysScheduled: new Set<string>() };
+     const overnight =
+       timeToMinutes(locked.end_time) <= timeToMinutes(locked.start_time);
+     const mins =
+       timeToMinutes(locked.end_time) - timeToMinutes(locked.start_time)
+       + (overnight ? 1440 : 0);
+     entry.minutesScheduled += mins;
+     entry.daysScheduled.add(locked.day);
+     state.set(locked.employee_id, entry);
+   }
+   ```
+
+   Use `timeToMinutes` already defined at `schedule-validator.ts:86-89`
+   — do NOT introduce a new helper.
+
+3. Iterate sorted candidates:
+
+   ```ts
+   for (const s of sortedCandidates) {
+     const meta = ctx.employees.get(s.employee_id)!;  // guaranteed by step 2
+     const entry = state.get(s.employee_id)
+       ?? { minutesScheduled: 0, daysScheduled: new Set<string>() };
+
+     const overnight =
+       timeToMinutes(s.end_time) <= timeToMinutes(s.start_time);
+     const shiftMinutes =
+       timeToMinutes(s.end_time) - timeToMinutes(s.start_time)
+       + (overnight ? 1440 : 0);
+
+     const proposedMinutes = entry.minutesScheduled + shiftMinutes;
+     if (proposedMinutes > meta.max_weekly_hours * 60) {
+       const code: DropCode = meta.max_weekly_hours === 18
+         ? "MINOR_HOURS_EXCEEDED"
+         : "HOURS_EXCEED_WEEKLY_CAP";
+       dropped.push({ shift: s, code });
+       continue;
+     }
+
+     const proposedDays = new Set(entry.daysScheduled).add(s.day);
+     if (longestConsecutiveRun(proposedDays) > 5) {
+       dropped.push({ shift: s, code: "CONSECUTIVE_DAYS_EXCEEDED" });
+       continue;
+     }
+
+     // Commit.
+     entry.minutesScheduled = proposedMinutes;
+     entry.daysScheduled = proposedDays;
+     state.set(s.employee_id, entry);
+     valid.push(s);
+   }
+   ```
+
+4. Document the step-ordering invariant directly above the new pass
+   so a future refactor cannot silently reorder:
+
+   ```ts
+   // INVARIANT: This pass MUST run after DOUBLE_BOOKING. The counter is
+   // seeded from existingShifts once; if a candidate is a duplicate of
+   // a locked shift, DOUBLE_BOOKING drops it before its minutes would
+   // be double-counted. Reordering this above DOUBLE_BOOKING is a
+   // silent cap-leak bug.
+   ```
+
+5. Re-run all validator tests: `npm run test -- tests/unit/schedule-validator.test.ts` —
+   all 11 new tests pass, all pre-existing tests still pass.
+
+Commit:
+`feat(scheduler): stateful hour-cap + consecutive-day validator step`
+
+---
+
+### T8 — COUPLED: extend `droppedReasons` switch in edge function
+
+File: `supabase/functions/generate-schedule/index.ts`
+
+Per the spec's "Diagnostic summary mapping" section, the validator
+DropCode union and the `droppedReasons` switch at lines 644-664 are a
+coupled change. Without this task, the three new codes fall into the
+`default` branch and the UI shows `"Unknown drop reason on <date>"`.
+
+1. Add three new `case` clauses to the switch:
+
+   ```ts
+   case "HOURS_EXCEED_WEEKLY_CAP":
+     return `Weekly hour cap exceeded on ${day}`;
+   case "CONSECUTIVE_DAYS_EXCEEDED":
+     return `More than 5 consecutive days on ${day}`;
+   case "MINOR_HOURS_EXCEEDED":
+     return `Minor over 18h cap on ${day}`;
+   ```
+
+2. Keep the `default` branch as the safety net.
+
+3. Confirm `drop_reason_summary` (validator-side string) and the
+   `droppedReasons` array (built by this switch) now agree for the
+   three new codes. Spot-check by searching
+   `grep -n 'drop_reason_summary\|droppedReasons' supabase/functions/generate-schedule/index.ts`.
+
+No test changes (the switch is plain string-mapping; covered by the
+manual smoke at T11).
+
+Commit:
+`fix(scheduler): map new DropCodes to diagnostic strings (coupled with validator)`
+
+---
+
+### T9 — RED: failing tests for prompt rules + Employee Hour Budgets section
+
+File: `tests/unit/schedule-prompt-builder.test.ts`
+
+Extend the existing file.
+
+1. **HARD Rules 11, 12 present in source text** (positive assertion):
+   - `"11. (HARD) No employee may be scheduled for more total weekly hours"`
+   - `"12. (HARD) No employee may work more than 5 consecutive calendar days"`
+   - `"14. When multiple eligible-and-available employees can fill the same slot, prefer the employee with the most remaining hours"`
+2. **Old soft Rule 11 absent** (negative assertion):
+   - `"Full-time employees should be scheduled for more shifts, targeting 35-40 hours per week"`
+   should NOT appear.
+3. **Rule 13 carve-out language**:
+   - `"OR if every remaining eligible employee would violate Rules 11 or 12"`
+4. **"Employee Hour Budgets" section renders** with one adult row and
+   one minor row given an `employees` array containing both:
+   - The exact line `"  Aleah Holderread     | minor  | max 18h"` (or
+     similar — name/padding shape per spec) MUST appear.
+   - The exact line `"  Ivy Benavides        | adult  | max 40h"` MUST
+     appear.
+5. **Section header present**:
+   - `"## Employee Hour Budgets"`
+   - `"Each row lists the maximum hours each employee may be scheduled for"`
+
+Run: `npm run test -- tests/unit/schedule-prompt-builder.test.ts` —
+expect the 5 new test cases to fail; existing tests still pass.
+
+Commit: `test(scheduler): RED — assert HARD Rules 11/12/14, hour-budget table, Rule 13 carve-out`
+
+---
+
+### T10 — GREEN: implement prompt changes
+
+File: `supabase/functions/_shared/schedule-prompt-builder.ts`
+
+1. **SYSTEM_PROMPT RULES** (lines 154-166 per spec). Replace the
+   current Rule 11 (soft) with the two new HARD rules (11 + 12),
+   renumber the existing HARD "Fill every required slot" to Rule 13
+   with the new carve-out clause, and add Rule 14:
+
+   ```text
+   11. (HARD) No employee may be scheduled for more total weekly hours
+       than their "Max Hours This Week" value in the Employee Hour
+       Budgets section below. This is a hard ceiling — never assign a
+       shift that would push an employee over their max, even if it
+       leaves a slot under-filled. Refer back to the budget table for
+       each assignment.
+   12. (HARD) No employee may work more than 5 consecutive calendar
+       days within this week. If an employee is assigned shifts on
+       Monday through Friday, they may not also be assigned Saturday
+       or Sunday.
+   13. (HARD) Fill every required slot: for every (template, day) listed
+       in "Required Headcount Per Slot", you MUST assign the required
+       number of eligible-and-available employees. A slot may only be
+       left below required headcount if there is NO eligible-and-available
+       employee for it OR if every remaining eligible employee would
+       violate Rules 11 or 12 by accepting the shift.
+   14. When multiple eligible-and-available employees can fill the same
+       slot, prefer the employee with the most remaining hours in their
+       weekly budget. Break ties alphabetically by employee name (then
+       by employee id if names also tie) so re-running generation for
+       the same inputs yields the same assignment, not a random one.
+       This spreads hours across the full roster and keeps employees
+       off the brink of their cap.
+   ```
+
+2. **New "Employee Hour Budgets" section** rendered in
+   `buildUserPrompt` between the existing `## Employees` and
+   `## Templates` sections:
+
+   ```ts
+   function buildEmployeeHourBudgets(employees: ScheduleEmployee[]): string {
+     if (employees.length === 0) return '';
+     // Pad employee name to the longest name + 2 for visual alignment.
+     const nameWidth = Math.max(...employees.map(e => e.name.length)) + 2;
+     const rows = employees.map(e => {
+       const namePadded = e.name.padEnd(nameWidth);
+       const minorTag = e.is_minor ? 'minor ' : 'adult ';
+       return `  ${namePadded}| ${minorTag} | max ${e.max_weekly_hours}h`;
+     });
+     return [
+       '## Employee Hour Budgets',
+       'Each row lists the maximum hours each employee may be scheduled for this week. Do not compute these yourself — use the value here.',
+       '',
+       ...rows,
+     ].join('\n');
+   }
+   ```
+
+   Inject into the `sections.push(...)` chain between Employees and
+   Templates.
+
+3. Re-run T9 tests — all 5 pass. Run full prompt-builder suite
+   (`npm run test -- tests/unit/schedule-prompt-builder.test.ts`) —
+   pre-existing tests still pass.
+
+Commit: `feat(scheduler): HARD hour-cap rules + Employee Hour Budgets prompt section`
+
+---
+
+### T11 — Full verification gate
+
+Run sequentially:
+
+```bash
+npm run typecheck
+npm run lint
+npm run test
+npm run build
+```
+
+All must be clean. If lint flags the new helper (e.g. unused-param,
+prefer-const), fix inline — no separate commit unless the fix is
+non-trivial.
+
+Commit only if any fix is needed; otherwise this is a no-op gate.
+
+---
+
+### T12 — Manual smoke (UI + diagnostic)
+
+1. `npm run dev:full`
+2. Open the scheduler at a restaurant with the AI generator enabled
+   (per the spec: ideally one with both FT and PT staff, and ideally
+   one minor on roster — but smoke is still meaningful without).
+3. Trigger `Generate Schedule` for any week.
+4. Confirm in the planner UI:
+   - No employee is shown with >40h total for the week.
+   - No employee is shown with shifts on 6+ consecutive days.
+   - Previously idle PT employees now appear in the output (compare
+     against the symptom table in the spec).
+5. If any shifts were dropped by the new validator step, confirm the
+   diagnostic toast shows the new reason strings (NOT
+   `"Unknown drop reason on <date>"`).
+6. If the restaurant has at least one minor with a populated DOB,
+   confirm their total hours are within their cap (18h or 40h
+   depending on age).
+
+Per CLAUDE.md "if you can't test the UI, say so explicitly rather
+than claiming success." Document the smoke result in `progress.md`.
+
+---
+
+## Dependencies
+
+```
+T1 → T2 → T3
+              ↘
+T4 → T5 → T6 → T7 → T8 ──→ T9 → T10 → T11 → T12
+```
+
+- T1-T2 are the helper foundation; T3 wires it through. None of T4-T10
+  can be merged without T2 because they all depend on the
+  `ScheduleEmployee.is_minor` and `max_weekly_hours` fields.
+- T4 is a pure refactor with no behavior change — must keep existing
+  tests green before any new test is written.
+- T5 → T6 → T7 are the validator RED → GREEN sequence.
+- T8 is a coupled change that MUST land in the same PR as T6-T7 (the
+  spec calls this out explicitly).
+- T9 → T10 are the prompt RED → GREEN sequence; they depend on T2
+  for the new `ScheduleEmployee` fields.
+
+## Out of scope (do NOT touch in this PR)
+
+- Daily hour caps for minors under 16 (FLSA 3h school day / 8h
+  non-school day) — requires school-calendar source.
+- State-specific child labor rules — federal FLSA only for v1.
+- Cross-week hour tracking.
+- Cross-week consecutive-day counting.
+- Per-employee custom `max_weekly_hours` override column or UI.
+- UI for entering `date_of_birth` (already exists on onboarding form).
+- Re-prompting on validator drop.
+- "Minor" badge in the planner UI.
+- Any RLS or migration change (auth posture analysis confirmed none
+  needed — see spec's "Auth posture (review correction)" paragraph).
+
+## Acceptance
+
+- `npm run typecheck` clean.
+- `npm run lint` clean.
+- `npm run test` all pass (including the 5 new prompt-builder tests,
+  the 11 new validator tests, and the 11 new hour-budget tests).
+- `npm run build` clean.
+- `npm run test:db` (pgTAP) still green — no DB changes in this PR.
+- Lint/build/Supabase preview/Database tests all green in CI.
+- Manual smoke (T12) confirms the symptom from the spec is resolved
+  on at least one real restaurant.
+- `drop_reason_summary` and `droppedReasons` agree for all three new
+  codes (no `"Unknown drop reason"` fallback fires for them).

--- a/docs/superpowers/plans/2026-05-23-scheduler-hour-caps-fairness-plan.md
+++ b/docs/superpowers/plans/2026-05-23-scheduler-hour-caps-fairness-plan.md
@@ -43,10 +43,10 @@ Cases (one `it` block each, per spec "Unit tests
 11. **TZ-portability case.** Sets `process.env.TZ = 'America/Chicago'`,
     asserts result. Resets `process.env.TZ = 'Pacific/Auckland'`,
     asserts identical result. Uses DOB `"2010-06-08"` and weekStart
-    `"2026-06-08"` → both calls must return `{ is_minor: false,
-    max_weekly_hours: 40 }` (turns 16 on Monday → adult). A
-    local-time `new Date(year, monthIdx, day)` implementation will
-    fail on at least one of the two TZs.
+    `"2026-06-08"` → both calls must return `{ is_minor: true,
+    max_weekly_hours: 40 }` (turns 16 on Monday → 16yo minor, no 18h
+    cap but still tagged minor). A local-time `new Date(year, monthIdx,
+    day)` implementation will fail on at least one of the two TZs.
 
 Run: `npm run test -- tests/unit/schedule-hour-budget.test.ts` —
 expect import error / all-fail.
@@ -673,7 +673,7 @@ than claiming success." Document the smoke result in `progress.md`.
 
 ## Dependencies
 
-```
+```text
 T1 → T2 → T3
               ↘
 T4 → T5 → T6 → T7 → T8 ──→ T9 → T10 → T11 → T12

--- a/docs/superpowers/specs/2026-05-23-scheduler-hour-caps-fairness-design.md
+++ b/docs/superpowers/specs/2026-05-23-scheduler-hour-caps-fairness-design.md
@@ -472,8 +472,9 @@ Every layer either reads the field or is documented as "not applicable."
   is seeded from locked, no retroactive drop, new shifts get
   `CONSECUTIVE_DAYS_EXCEEDED`.
 - **Overnight shifts** (start 22:00, end 02:00). Counted as ONE day
-  (the `day` field's value), not two. Hours computed via
-  `projectMinutes` to handle midnight crossing correctly.
+  (the `day` field's value), not two. Hours computed via `shiftHours`
+  helper, which detects `end <= start` and adds 1440 minutes (24h) so
+  a 22:00–02:00 shift returns 4h, not -20h or 22h.
 - **Employee with no DOB and no `employment_type`.** Defaults: adult
   + 40h cap + `employment_type === 'full_time'` (existing fallback at
   `index.ts:255`). Both fall back independently.

--- a/docs/superpowers/specs/2026-05-23-scheduler-hour-caps-fairness-design.md
+++ b/docs/superpowers/specs/2026-05-23-scheduler-hour-caps-fairness-design.md
@@ -1,0 +1,494 @@
+# Scheduler Hour Caps & Fairness (Bug I)
+
+**Status:** Draft (pending design review)
+**Date:** 2026-05-23
+**Branch:** `fix/scheduler-hour-caps-fairness`
+
+## Summary
+
+The AI schedule generator now lands shifts on the correct dates (Bug H,
+PR #516), but distributes hours badly: full-time and part-time employees
+are stacked to ~45–48h on 7 consecutive days while ~14 other available
+employees get zero hours. There is no hard ceiling for weekly hours,
+no consecutive-days rule, and no concept of "minor" anywhere in the
+schedule pipeline.
+
+This change pushes those constraints into all three layers that already
+exist for templates and positions:
+
+1. **Prompt** — promote workload distribution from a soft preference
+   (Rule 11) to HARD rules with a pre-computed per-employee hour-budget
+   table the LLM does not have to compute itself.
+2. **Schema/edge function** — extend `ScheduleEmployee` with
+   `is_minor` and `max_weekly_hours` derived from existing
+   `employees.date_of_birth`; pipe them through `generate-schedule`.
+3. **Validator** — add three new drop reasons
+   (`HOURS_EXCEED_WEEKLY_CAP`, `CONSECUTIVE_DAYS_EXCEEDED`,
+   `MINOR_HOURS_EXCEEDED`) as a deterministic backstop so an LLM lapse
+   never reaches `shifts` insert.
+
+## Background
+
+### Observed symptom (one real run, week of 2026-06-08)
+
+Across 9 employees the LLM emitted 6.5–7.5h shifts every single day of
+the week:
+
+| Employee | Type | Total | Days |
+|---|---|---|---|
+| Ivy Benavides | FT | 45.5h | 7 |
+| Emmalynn Hoover | FT | 45.5h | 7 |
+| Natalie Garza | FT | 45.5h | 7 |
+| Colin Kuehn | FT | 45.5h | 7 |
+| Reba Navarro | FT | 48.5h | 7 |
+| Aubrey Large | FT | 48.5h | 7 |
+| Nicole Crosson | FT | 48.5h | 7 |
+| Termora Johnson | **PT** | 48.5h | 7 |
+| Lynnette Lewis | **PT** | 48.5h | 7 |
+
+One full-time employee (Noah Santillano) and thirteen part-time
+employees received zero shifts. Only two PT employees landed in the
+~22h target band. The LLM did obey availability and template rules —
+it just stacked the same 9 people because nothing told it not to.
+
+### Why the LLM does this
+
+The current prompt (`_shared/schedule-prompt-builder.ts:154-166`) has:
+
+- Rule 11 (soft preference): "Full-time employees should be scheduled
+  for more shifts, targeting 35-40 hours per week. Part-time employees
+  should be scheduled for fewer shifts, targeting 15-25 hours per week."
+- Rule 12 (HARD): "Fill every required slot."
+
+Rule 12 is HARD; Rule 11 is soft. The LLM honors hard constraints and
+treats soft ones as advisory — that's correct behavior, and the
+output proves it. No HARD rule exists for any of:
+
+- Maximum hours per employee per week.
+- "No overtime" (≤40h, regardless of preference targets).
+- Maximum consecutive days per employee.
+- Minor hour limits.
+
+The prompt also asks the LLM to *track* each employee's running hours
+across slots in order to apply the soft preference. LLMs are bad at
+arithmetic over many items (Bug H established the same lesson for
+calendar math). Anything we ask the model to compute, it will drift on.
+
+### Root causes (the four problems behind the symptom)
+
+1. **Soft preference instead of HARD constraint** for ≤40h/wk and
+   zero overtime.
+2. **No consecutive-day rule** anywhere in prompt or validator.
+3. **No minor concept in the schedule path.** `employees.date_of_birth`
+   exists (migration `20260413100000_add_employee_employment_type_dob`)
+   and is on `EmployeeWithAvailability`, but never crosses into
+   `ScheduleEmployee` or the prompt.
+4. **LLM-computed running totals.** The prompt forces the model to sum
+   each employee's hours across slots — pre-computing and emitting the
+   budget as a literal table is the same fix that landed Bug H.
+
+### Why a validator backstop is required (not just a prompt fix)
+
+PR #511 (Bug E) and PR #513 (Bug G) demonstrated that the validator is
+the layer that actually stops bad shifts from persisting — prompt rules
+are the LLM's *goal*, not the system's guarantee. Bug H landed Rule 12
+in the prompt AND added the `DAY_NOT_IN_TEMPLATE` validator. Shipping
+hour caps as prompt-only would leave us exposed the next time a model
+under-performs (different vendor, busier hour of day, prompt length
+crossing a cache boundary). The validator is what makes "no overtime"
+a *guarantee* rather than a *request*.
+
+## Goals
+
+- No employee assigned more than `max_weekly_hours` in the generated
+  schedule. Adults (`is_minor = false`): 40h. Minors under 16:
+  18h (FLSA school-week limit applied year-round as the conservative
+  default). Minors 16-17: 40h (federal FLSA allows it; state laws may
+  be stricter but match the user-stated "16+ use a 40 hour max").
+- No employee scheduled more than 5 consecutive calendar days within
+  the generation week.
+- Idle available employees preferred over stacking hours on already-busy
+  employees, so the model uses the full roster.
+- LLM never computes a running hour total — the prompt hands it a
+  per-employee budget table refreshed at prompt-build time.
+- Validator catches and drops shifts that violate any of these rules,
+  with diagnostic-summary mappings so the UI displays the reason.
+
+## Non-goals (deferred)
+
+- **Daily hour caps for minors under 16** (FLSA 3h on school days, 8h
+  on non-school days). Requires a per-restaurant school-calendar source
+  we do not have. Captured as a follow-up issue.
+- **State-specific child-labor rules.** Federal FLSA only for v1.
+  Per-state overrides would need a `restaurant.state_code` lookup.
+- **Cross-week hour tracking.** "Hours so far this week" is computed
+  from the generation window only. Prior weeks' shifts are not counted.
+- **Per-employee custom `max_weekly_hours` override column.** Today's
+  cap is derived from `date_of_birth` + `employment_type`. A manual
+  override (e.g. a senior staffer who explicitly wants 36h) is a
+  follow-up.
+- **UI for entering `date_of_birth`.** The field already exists on the
+  employees table and the onboarding form. Bug I assumes it's
+  populated; missing-DOB rows are treated as adult (40h cap) and
+  documented in the read-site guard.
+- **Re-prompting on validator drop.** Today the validator surfaces
+  drops in the diagnostic summary; the manager can re-run if too many
+  slots come back unfilled. A retry-with-feedback loop is a separate
+  feature.
+
+## Approach
+
+### Layer 1 — Prompt (schedule-prompt-builder.ts)
+
+Replace Rule 11 with two HARD rules and insert a new section.
+
+#### New HARD Rules
+
+```text
+11. (HARD) No employee may be scheduled for more total weekly hours
+    than their "Max Hours This Week" value in the Employee Hour
+    Budgets section below. This is a hard ceiling — never assign a
+    shift that would push an employee over their max, even if it
+    leaves a slot under-filled. Refer back to the budget table for
+    each assignment.
+12. (HARD) No employee may work more than 5 consecutive calendar
+    days within this week. If an employee is assigned shifts on
+    Monday through Friday, they may not also be assigned Saturday
+    or Sunday.
+```
+
+Renumber the existing Rule 12 (fill every slot) to Rule 13 and add a
+new tie-breaker as Rule 14:
+
+```text
+13. (HARD) Fill every required slot: for every (template, day) listed
+    in "Required Headcount Per Slot", you MUST assign the required
+    number of eligible-and-available employees. A slot may only be
+    left below required headcount if there is NO eligible-and-available
+    employee for it OR if every remaining eligible employee would
+    violate Rules 11 or 12 by accepting the shift.
+14. When multiple eligible-and-available employees can fill the same
+    slot, prefer the employee with the most remaining hours in their
+    weekly budget. This spreads hours across the full roster and
+    keeps employees off the brink of their cap.
+```
+
+#### New "Employee Hour Budgets" section
+
+Inserted between "Employees" and "Templates":
+
+```text
+## Employee Hour Budgets
+
+Each row lists the maximum hours each employee may be scheduled for
+this week. Do not compute these yourself — use the value here.
+
+  Ivy Benavides        | adult  | max 40h
+  Termora Johnson      | adult  | max 40h
+  Aleah Holderread     | minor  | max 18h
+  ...
+```
+
+Same right-padded column technique as `DATE_MAP_LABELS` from PR #516 —
+the LLM reads it as a table, not prose.
+
+### Layer 2 — Schema → context pipeline (`ScheduleEmployee` + `generate-schedule`)
+
+Add two fields to `ScheduleEmployee`:
+
+```typescript
+export interface ScheduleEmployee {
+  id: string;
+  name: string;
+  position: string;
+  area: string | null;
+  hourly_rate: number;
+  employment_type: 'full_time' | 'part_time';
+  /** Computed in the edge function from `employees.date_of_birth`
+   *  relative to weekStart. Null DOB → treated as adult. */
+  is_minor: boolean;
+  /** Hard ceiling for weekly hours. Adults: 40. Minors under 16: 18
+   *  (FLSA school-week limit). Minors 16-17: 40. */
+  max_weekly_hours: number;
+}
+```
+
+In `generate-schedule/index.ts` (lines 134, 248-255):
+
+- Add `date_of_birth` to the existing SELECT.
+- Compute `is_minor` and `max_weekly_hours` in a pure helper
+  `computeHourBudget(dob: string | null, weekStart: string)` placed
+  alongside `ScheduleEmployee` in the shared module (testable from
+  Vitest without importing Deno-only edge entry points).
+
+#### `computeHourBudget` rules
+
+| `date_of_birth` | Age on `weekStart` | `is_minor` | `max_weekly_hours` |
+|---|---|---|---|
+| null / undefined / unparseable | n/a | `false` | `40` |
+| valid, age ≥ 18 | adult | `false` | `40` |
+| valid, age 16-17 | minor 16+ | `true` | `40` |
+| valid, age < 16 | minor under 16 | `true` | `18` |
+| valid, age in future (DOB > weekStart) | n/a (data error) | `false` | `40` |
+
+Age computed in calendar years, anchored on `weekStart` (the first day
+of the schedule week). A minor who turns 16 mid-week is treated by
+their age on Monday — this is the most predictable rule and matches
+how managers think about the week as a unit. Documented in JSDoc on
+`computeHourBudget`.
+
+Defensive guards (lesson [2026-05-22]: a new schema field is only
+useful if every consumer reads it correctly, and pre-existing rows
+can poison the runtime):
+
+- DOB malformed (not YYYY-MM-DD or `Date.parse` fails) → treat as
+  null → adult.
+- DOB in the future → treat as adult; do not throw. A `date_of_birth`
+  in the future is a data-entry error, not a schedule-blocking event.
+
+### Layer 3 — Validator (`schedule-validator.ts`)
+
+Add three drop codes and a single new validation step that runs
+stateful-per-employee.
+
+#### Drop codes
+
+```typescript
+export type DropCode =
+  | "EXCLUDED"
+  | "UNKNOWN_EMPLOYEE"
+  | "UNKNOWN_TEMPLATE"
+  | "DAY_NOT_IN_TEMPLATE"
+  | "POSITION_MISMATCH"
+  | "UNAVAILABLE_DAY"
+  | "OUTSIDE_WINDOW"
+  | "DOUBLE_BOOKING"
+  | "HOURS_EXCEED_WEEKLY_CAP"
+  | "CONSECUTIVE_DAYS_EXCEEDED"
+  | "MINOR_HOURS_EXCEEDED";
+```
+
+`MINOR_HOURS_EXCEEDED` is separate from `HOURS_EXCEED_WEEKLY_CAP`
+intentionally — the diagnostic summary shows them as distinct reasons
+("Adult over 40h" vs "Minor over 18h") so a manager fixing the latter
+knows to look at DOB data quality rather than at staffing.
+
+#### Validator context extension
+
+Promote `employeeIds: Set<string>` to a Map carrying the budget
+(lesson [2026-05-22] "Set vs Map for richer per-id data"):
+
+```typescript
+export interface ValidationContext {
+  /** Promoted from Set<string>. Contains hour budget + minor status
+   *  required for HOURS_EXCEED_WEEKLY_CAP, MINOR_HOURS_EXCEEDED, and
+   *  CONSECUTIVE_DAYS_EXCEEDED checks. Existence checks (was
+   *  `employeeIds.has(id)`) become `employees.has(id)`. */
+  employees: Map<string, {
+    position: string;
+    is_minor: boolean;
+    max_weekly_hours: number;
+  }>;
+  templates: Map<string, { days: number[]; position: string }>;
+  availability: Map<string, AvailabilitySlot>;
+  excludedEmployeeIds: Set<string>;
+  existingShifts: GeneratedShift[];
+}
+```
+
+`employeePositions` collapses into the new `employees` Map's
+`position` field — one structure, one lookup, no drift risk.
+
+#### New validation step (runs after current step 8 DOUBLE_BOOKING)
+
+Stateful pass — maintains a running `Map<employeeId, { minutesScheduled,
+daysScheduled: Set<dayString> }>` seeded from `existingShifts` and
+updated for each shift that passes the prior checks. For each
+candidate shift:
+
+1. Compute `proposedMinutes = current.minutesScheduled + shiftMinutes`.
+   If `proposedMinutes > employees.get(id).max_weekly_hours * 60`,
+   drop with `HOURS_EXCEED_WEEKLY_CAP` (or `MINOR_HOURS_EXCEEDED` if
+   `is_minor === true`).
+2. Compute `proposedDays = new Set([...current.daysScheduled,
+   shift.day])`. If the longest consecutive run of days in
+   `proposedDays` (sorted) exceeds 5, drop with
+   `CONSECUTIVE_DAYS_EXCEEDED`.
+3. Otherwise commit: update the running state and accept.
+
+Process candidates sorted by `day ASC, start_time ASC` so the
+"first 5 wins" outcome is deterministic regardless of LLM emission
+order. Shift duration computed with the same `shiftsConflict` /
+`projectMinutes` math from `schedule-validator.ts` (lesson
+[2026-05-18]: don't reinvent day-aware time math).
+
+#### Consecutive-day calculation
+
+For a set of YYYY-MM-DD strings within a single week:
+
+```typescript
+function longestConsecutiveRun(days: Set<string>): number {
+  const sorted = [...days].sort();
+  if (sorted.length === 0) return 0;
+  let max = 1, run = 1;
+  for (let i = 1; i < sorted.length; i++) {
+    const prev = Date.UTC(...parseYMD(sorted[i-1]));
+    const cur  = Date.UTC(...parseYMD(sorted[i]));
+    if (cur - prev === 86_400_000) run++;
+    else { max = Math.max(max, run); run = 1; }
+  }
+  return Math.max(max, run);
+}
+```
+
+UTC-anchored math (lesson [2026-05-18]) so DST and local-TZ midnight
+shifts cannot create a false gap on the spring-forward day.
+
+#### Diagnostic summary mapping
+
+Extend `droppedReasons` (in the diagnostic summary path inside
+`generate-schedule/index.ts`) to map the three new codes to
+human-readable strings:
+
+- `HOURS_EXCEED_WEEKLY_CAP` → `"Adult over 40h cap"`
+- `CONSECUTIVE_DAYS_EXCEEDED` → `"More than 5 consecutive days"`
+- `MINOR_HOURS_EXCEEDED` → `"Minor over 18h cap"`
+
+## Data flow walkthrough (end-to-end audit per lesson [2026-05-22])
+
+| Layer | Reads `date_of_birth` / `is_minor` / `max_weekly_hours` | File |
+|---|---|---|
+| DB | `employees.date_of_birth DATE NULL` | `supabase/migrations/20260413100000_*.sql` |
+| Edge SELECT | adds `date_of_birth` to active-employee projection | `generate-schedule/index.ts:134` |
+| Mapper | calls `computeHourBudget(e.date_of_birth, weekStart)` → populates `is_minor` and `max_weekly_hours` on the `ScheduleEmployee` | `generate-schedule/index.ts:247-255` |
+| Prompt | renders "Employee Hour Budgets" table from `ctx.employees` | `_shared/schedule-prompt-builder.ts` (new section after `## Employees`) |
+| LLM input | sees the table directly; never asked to compute it | — |
+| LLM output | `shift.employee_id` only — minor status not in response schema | — |
+| Validator context build | `buildValidationContext` populates new `employees` Map from same `ScheduleEmployee[]` | `generate-schedule/index.ts` |
+| Validator | new step enforces caps as backstop | `_shared/schedule-validator.ts` |
+| Diagnostic UI | new drop reasons surface in the partial-fill toast | `generate-schedule/index.ts` + `useGenerateSchedule.ts` |
+| Persistence | `shift_template_id`, `employee_id`, etc. — DOB itself is NOT persisted into `shifts` (the employee→shift FK + DOB lookup at read time is sufficient) | unchanged |
+
+Every layer either reads the field or is documented as "not applicable."
+
+## Edge cases
+
+- **Locked shifts already over cap.** `existingShifts` seeds the
+  per-employee minutes counter. If a locked shift already pushes
+  someone over 40h, new shifts for that employee get
+  `HOURS_EXCEED_WEEKLY_CAP`; the locked shift itself is unaffected
+  (validator does not retroactively drop locked shifts). Documented.
+- **Locked shifts already over consecutive-days.** Same — the counter
+  is seeded from locked, no retroactive drop, new shifts get
+  `CONSECUTIVE_DAYS_EXCEEDED`.
+- **Overnight shifts** (start 22:00, end 02:00). Counted as ONE day
+  (the `day` field's value), not two. Hours computed via
+  `projectMinutes` to handle midnight crossing correctly.
+- **Employee with no DOB and no `employment_type`.** Defaults: adult
+  + 40h cap + `employment_type === 'full_time'` (existing fallback at
+  `index.ts:255`). Both fall back independently.
+- **`weekStart` invalid.** `buildWeekDates` already throws (PR #516).
+  `computeHourBudget` follows the same pattern — throws on invalid
+  `weekStart`, treats invalid DOB as null.
+- **Birthday on Friday of the schedule week.** Age computed as-of
+  Monday (weekStart). A 15-year-old who turns 16 on Friday is treated
+  as 15 for the whole week → 18h cap. Documented in JSDoc.
+- **Empty employees Map.** Validator gracefully returns all shifts as
+  `UNKNOWN_EMPLOYEE` (existing behavior; no special case).
+- **No minors on staff.** No prompt change visible (every row shows
+  `adult | max 40h`) but the table still renders — the LLM gets used
+  to seeing the structure so future minor additions don't require a
+  prompt-shape change.
+
+## Test plan
+
+### Unit tests (`tests/unit/schedule-prompt-builder.test.ts`)
+
+Extend the existing file:
+
+- New "Employee Hour Budgets" section renders with adult + minor rows.
+- Empty employees → section still renders with header only (or is
+  omitted — decide in implementation; either is acceptable as long
+  as the prompt doesn't break).
+- HARD Rules 11, 12, 14 present in the system prompt source text
+  (negative assertion that old Rule 11 soft text is gone).
+- Rule 13 (fill every slot) language now mentions Rules 11/12 exception
+  ("OR if every remaining eligible employee would violate Rules 11 or
+  12").
+
+### Unit tests (`tests/unit/schedule-hour-budget.test.ts`, new file)
+
+Cover `computeHourBudget`:
+
+- Adult DOB → `{ is_minor: false, max_weekly_hours: 40 }`.
+- DOB 17.5 years before weekStart → `{ is_minor: true, max: 40 }`.
+- DOB 14 years before weekStart → `{ is_minor: true, max: 18 }`.
+- Null DOB → adult 40.
+- Malformed DOB string → adult 40.
+- DOB in the future → adult 40.
+- Invalid `weekStart` → throws.
+- Birthday on the Friday of weekStart's week, employee turns 16 →
+  still treated as 15 (minor under 16, 18h cap).
+
+### Unit tests (`tests/unit/schedule-validator.test.ts`)
+
+Extend the existing file:
+
+- `HOURS_EXCEED_WEEKLY_CAP`: 6 × 6.5h shifts (39h) accept; 7th shift
+  (+6.5h → 45.5h) drops with code.
+- `MINOR_HOURS_EXCEEDED`: minor with 18h cap, 3 × 6h shifts (18h)
+  accept; 4th shift drops with `MINOR_HOURS_EXCEEDED` (not
+  `HOURS_EXCEED_WEEKLY_CAP` — verify the dispatch).
+- `CONSECUTIVE_DAYS_EXCEEDED`: 5 shifts Mon–Fri accept; 6th shift Sat
+  drops with code. Shift on Sun without Sat accepts (gap breaks the run).
+- Locked shifts seed the counter: existingShifts puts employee at 35h
+  already, candidate 7h shift drops.
+- Overnight shift: 22:00-02:00 counts as one day's worth of minutes
+  (4h), not two days.
+- Order independence: shifts emitted in random order produce the same
+  valid set as the same shifts emitted in chronological order.
+- DST spring-forward day (March 8 2026 in US/Central): consecutive-day
+  math does not lose a day.
+
+### Integration / regression
+
+- Existing schedule-validator and schedule-prompt-builder tests pass
+  unchanged after the `employeeIds → employees` Map promotion (rename
+  the symbol everywhere a test references it).
+
+### Manual smoke
+
+- Generate one schedule on a real restaurant with a mix of FT/PT and
+  (if available) one minor. Confirm:
+  - No employee exceeds their cap.
+  - No employee is scheduled 6+ consecutive days.
+  - Previously idle PT employees now appear in the output.
+  - Diagnostic toast shows new drop reasons if any shifts are dropped.
+
+## Risk & rollback
+
+- **Risk:** Hard caps may cause more partial-fill schedules
+  (under-staffed slots) in cases where a restaurant genuinely lacks
+  enough labor to cover the week within the cap. Mitigation: this is
+  exactly what the diagnostic toast (PR #506) is designed for — surface
+  the under-fill clearly. A manager seeing "20 of 30 slots filled
+  (employees over 40h cap)" can make an informed call to raise caps
+  or hire.
+- **Risk:** DOB data quality. Many restaurants will have null DOB on
+  most employees. The default (adult 40h) is safe — they get treated
+  the same as before for the cap, and the new fairness rule still
+  applies. The only behavior change for null-DOB rosters is that no
+  employee gets stacked >40h.
+- **Rollback:** Single-PR change, easy to revert. The schema migration
+  for DOB is already in production; nothing new is added at the DB
+  level. Reverting just removes the prompt rules + validator step +
+  ScheduleEmployee field expansion.
+
+## Out of scope (future work)
+
+- Daily hour caps for minors under 16 (needs school calendar source).
+- State-specific child labor rule lookup.
+- Cross-week hour tracking.
+- Per-employee custom `max_weekly_hours` override column + UI.
+- Re-prompting with feedback when too many shifts are dropped.
+- "Minor" badge in the planner UI.

--- a/docs/superpowers/specs/2026-05-23-scheduler-hour-caps-fairness-design.md
+++ b/docs/superpowers/specs/2026-05-23-scheduler-hour-caps-fairness-design.md
@@ -1,6 +1,6 @@
 # Scheduler Hour Caps & Fairness (Bug I)
 
-**Status:** Draft (pending design review)
+**Status:** Reviewed (supabase + sound-logic findings folded)
 **Date:** 2026-05-23
 **Branch:** `fix/scheduler-hour-caps-fairness`
 
@@ -123,6 +123,12 @@ a *guarantee* rather than a *request*.
   Per-state overrides would need a `restaurant.state_code` lookup.
 - **Cross-week hour tracking.** "Hours so far this week" is computed
   from the generation window only. Prior weeks' shifts are not counted.
+- **Cross-week consecutive-day counting.** The 5-day streak is
+  measured only within the 7 calendar days starting at `weekStart`.
+  An employee who worked Saturday last week and Mon-Fri this week
+  appears as a 5-day streak to the validator, not 6. Cross-week
+  enforcement would require a wider `existingShifts` window and is
+  deferred.
 - **Per-employee custom `max_weekly_hours` override column.** Today's
   cap is derived from `date_of_birth` + `employment_type`. A manual
   override (e.g. a senior staffer who explicitly wants 36h) is a
@@ -169,8 +175,11 @@ new tie-breaker as Rule 14:
     violate Rules 11 or 12 by accepting the shift.
 14. When multiple eligible-and-available employees can fill the same
     slot, prefer the employee with the most remaining hours in their
-    weekly budget. This spreads hours across the full roster and
-    keeps employees off the brink of their cap.
+    weekly budget. Break ties alphabetically by employee name (then
+    by employee id if names also tie) so re-running generation for
+    the same inputs yields the same assignment, not a random one.
+    This spreads hours across the full roster and keeps employees
+    off the brink of their cap.
 ```
 
 #### New "Employee Hour Budgets" section
@@ -218,8 +227,22 @@ In `generate-schedule/index.ts` (lines 134, 248-255):
 - Add `date_of_birth` to the existing SELECT.
 - Compute `is_minor` and `max_weekly_hours` in a pure helper
   `computeHourBudget(dob: string | null, weekStart: string)` placed
-  alongside `ScheduleEmployee` in the shared module (testable from
-  Vitest without importing Deno-only edge entry points).
+  in `supabase/functions/_shared/schedule-prompt-builder.ts` next to
+  `buildWeekDates` and the `ScheduleEmployee` interface — one file,
+  no new module. The helper has no Deno-specific imports and is
+  testable from Vitest without any shim.
+
+**Auth posture (review correction).** The edge function authenticates
+the caller with `SUPABASE_ANON_KEY` + the user's `Authorization`
+header (`index.ts:68-72`), NOT the service role. The new
+`date_of_birth` field is therefore read through the existing
+`employees` SELECT policy `"Users can view employees for their
+restaurants"` (`20260120100100_update_rls_for_collaborators.sql:426`)
+which gates on `user_has_capability(restaurant_id, 'view:employees')`.
+Owner and manager callers — the only roles that can invoke
+`generate-schedule` — pass that capability check today, so no RLS,
+policy, or migration change is required. Adding `date_of_birth` to
+the projection is a zero-RLS, zero-migration, zero-lock change.
 
 #### `computeHourBudget` rules
 
@@ -231,11 +254,30 @@ In `generate-schedule/index.ts` (lines 134, 248-255):
 | valid, age < 16 | minor under 16 | `true` | `18` |
 | valid, age in future (DOB > weekStart) | n/a (data error) | `false` | `40` |
 
+**UTC-anchored age math.** Both `weekStart` and `date_of_birth` MUST
+be parsed as UTC midnight using the same form as `buildWeekDates`:
+`new Date(\`${s}T00:00:00Z\`)`. Computation MUST use UTC accessors
+(`getUTCFullYear`, `getUTCMonth`, `getUTCDate`). Using the
+local-time `new Date(year, monthIdx, day)` constructor for either
+side introduces a host-TZ offset (e.g. UTC-6 in `America/Chicago`)
+that can flip the age computation by one year when a DOB lands on
+the same day as `weekStart`. The unit tests pin this — see "DST and
+TZ" cases in the test plan.
+
 Age computed in calendar years, anchored on `weekStart` (the first day
 of the schedule week). A minor who turns 16 mid-week is treated by
 their age on Monday — this is the most predictable rule and matches
 how managers think about the week as a unit. Documented in JSDoc on
 `computeHourBudget`.
+
+**Birthday equals `weekStart` boundary (inclusive).** If an
+employee's 16th birthday IS the `weekStart` Monday, they are
+evaluated as 16 (≥ 16 → adult 40h cap). The birthday is inclusive:
+on the day of N's birthday the employee has *already turned N*. The
+boundary rule: `age = (weekStart - DOB)` in full UTC years; if
+`(DOB.month, DOB.day) <= (weekStart.month, weekStart.day)` the
+employee has had their birthday this year. Documented in JSDoc with
+a worked example for the boundary day.
 
 Defensive guards (lesson [2026-05-22]: a new schema field is only
 useful if every consumer reads it correctly, and pre-existing rows
@@ -268,10 +310,15 @@ export type DropCode =
   | "MINOR_HOURS_EXCEEDED";
 ```
 
-`MINOR_HOURS_EXCEEDED` is separate from `HOURS_EXCEED_WEEKLY_CAP`
-intentionally — the diagnostic summary shows them as distinct reasons
-("Adult over 40h" vs "Minor over 18h") so a manager fixing the latter
-knows to look at DOB data quality rather than at staffing.
+**Dispatch rule (review correction).** `MINOR_HOURS_EXCEEDED` fires
+**only when `max_weekly_hours === 18`** — i.e. minors under 16. A
+17-year-old minor with the same 40h cap as an adult who exceeds it
+gets `HOURS_EXCEED_WEEKLY_CAP`, not `MINOR_HOURS_EXCEEDED`. This
+keeps the diagnostic label "Minor over 18h cap" factually accurate
+in every case it fires, and gives managers a distinct signal to
+audit DOB data quality only when an under-16 cap is in play. The
+`is_minor` flag is informational (for the prompt budget table); it
+is NOT the dispatch predicate for the drop code.
 
 #### Validator context extension
 
@@ -306,29 +353,59 @@ daysScheduled: Set<dayString> }>` seeded from `existingShifts` and
 updated for each shift that passes the prior checks. For each
 candidate shift:
 
-1. Compute `proposedMinutes = current.minutesScheduled + shiftMinutes`.
+1. Compute `shiftMinutes = timeToMinutes(end_time) -
+   timeToMinutes(start_time) + (overnight ? 1440 : 0)` where
+   `overnight = timeToMinutes(end_time) <= timeToMinutes(start_time)`.
+   Same formula already used inside `shiftsOverlap` /
+   `shiftsConflict` in `schedule-validator.ts:86-89` — do NOT
+   introduce a new helper. (Earlier draft referenced a phantom
+   `projectMinutes`; corrected per supabase reviewer.)
+2. Compute `proposedMinutes = current.minutesScheduled + shiftMinutes`.
    If `proposedMinutes > employees.get(id).max_weekly_hours * 60`,
-   drop with `HOURS_EXCEED_WEEKLY_CAP` (or `MINOR_HOURS_EXCEEDED` if
-   `is_minor === true`).
-2. Compute `proposedDays = new Set([...current.daysScheduled,
-   shift.day])`. If the longest consecutive run of days in
-   `proposedDays` (sorted) exceeds 5, drop with
-   `CONSECUTIVE_DAYS_EXCEEDED`.
-3. Otherwise commit: update the running state and accept.
+   dispatch the drop code on the **cap value**:
+   - `max_weekly_hours === 18` → `MINOR_HOURS_EXCEEDED`
+   - `max_weekly_hours === 40` → `HOURS_EXCEED_WEEKLY_CAP` (regardless
+     of `is_minor`)
+3. Compute `proposedDays = new Set([...current.daysScheduled,
+   shift.day])`. If `longestConsecutiveRun(proposedDays) > 5`, drop
+   with `CONSECUTIVE_DAYS_EXCEEDED`.
+4. Otherwise commit: update the running state and accept.
 
-Process candidates sorted by `day ASC, start_time ASC` so the
-"first 5 wins" outcome is deterministic regardless of LLM emission
-order. Shift duration computed with the same `shiftsConflict` /
-`projectMinutes` math from `schedule-validator.ts` (lesson
-[2026-05-18]: don't reinvent day-aware time math).
+**Processing order.** Sort candidates by `day ASC, start_time ASC,
+employee_id ASC, template_id ASC` so the "first 5 wins" outcome is
+deterministic regardless of LLM emission order. The
+`employee_id, template_id` secondary keys protect against the case
+where two candidates share `(day, start_time)` — without them the
+tie-break would be implementation-defined and the validator output
+would change run-to-run on identical inputs.
+
+**Step ordering constraint.** This new step MUST run after step 8
+(`DOUBLE_BOOKING`). The running counter is seeded from
+`existingShifts` once, so if the LLM emits a duplicate of a locked
+shift, `DOUBLE_BOOKING` drops it before the counter would
+double-count those hours. Document this invariant on the validator
+function so a future refactor cannot silently reorder steps and
+re-introduce the cap leak.
 
 #### Consecutive-day calculation
 
-For a set of YYYY-MM-DD strings within a single week:
+For a set of YYYY-MM-DD strings within a single schedule week:
 
 ```typescript
-function longestConsecutiveRun(days: Set<string>): number {
-  const sorted = [...days].sort();
+/**
+ * Longest consecutive-day run within the input set.
+ * @param days Iterable of YYYY-MM-DD strings. Defensive dedup is
+ *   applied even if a Set is passed, so a future caller that
+ *   accidentally hands in an array does not silently undercount
+ *   the run (sound-logic review #1).
+ * @remarks Lexicographic sort agrees with chronological order only
+ *   within a single ISO month (e.g. "09" sorts after "10"). This
+ *   helper is correct for a single 7-day schedule week. Callers
+ *   reusing it for multi-month inputs MUST sort by parsed Date
+ *   instead.
+ */
+function longestConsecutiveRun(days: Iterable<string>): number {
+  const sorted = [...new Set(days)].sort();
   if (sorted.length === 0) return 0;
   let max = 1, run = 1;
   for (let i = 1; i < sorted.length; i++) {
@@ -342,32 +419,45 @@ function longestConsecutiveRun(days: Set<string>): number {
 ```
 
 UTC-anchored math (lesson [2026-05-18]) so DST and local-TZ midnight
-shifts cannot create a false gap on the spring-forward day.
+shifts cannot create a false gap on the spring-forward day. Defensive
+dedup at the top means a duplicate day (e.g. an open + a close on the
+same Monday seeded from `existingShifts`) cannot collapse the streak
+math by treating the duplicate as a zero-diff "gap."
 
 #### Diagnostic summary mapping
 
-Extend `droppedReasons` (in the diagnostic summary path inside
-`generate-schedule/index.ts`) to map the three new codes to
-human-readable strings:
+The `droppedReasons` switch at `generate-schedule/index.ts:644-664`
+has a `default` branch that emits `"Unknown drop reason on
+<date>"` for any unrecognized code. Adding the three new validator
+codes WITHOUT updating this switch in the same commit creates a
+silent UI regression: `drop_reason_summary` (which maps the code
+string correctly via the validator) and `dropped_reasons` (which
+falls into `default`) would disagree. The switch MUST be updated
+in the same PR:
 
-- `HOURS_EXCEED_WEEKLY_CAP` → `"Adult over 40h cap"`
-- `CONSECUTIVE_DAYS_EXCEEDED` → `"More than 5 consecutive days"`
-- `MINOR_HOURS_EXCEEDED` → `"Minor over 18h cap"`
+- `HOURS_EXCEED_WEEKLY_CAP` → `"Weekly hour cap exceeded on ${day}"`
+- `CONSECUTIVE_DAYS_EXCEEDED` → `"More than 5 consecutive days on ${day}"`
+- `MINOR_HOURS_EXCEEDED` → `"Minor over 18h cap on ${day}"`
+
+The implementation plan calls out the switch + validator union as a
+coupled change. The `default` branch is retained as a safety net for
+any future code added to the union without a switch update.
 
 ## Data flow walkthrough (end-to-end audit per lesson [2026-05-22])
 
 | Layer | Reads `date_of_birth` / `is_minor` / `max_weekly_hours` | File |
 |---|---|---|
-| DB | `employees.date_of_birth DATE NULL` | `supabase/migrations/20260413100000_*.sql` |
-| Edge SELECT | adds `date_of_birth` to active-employee projection | `generate-schedule/index.ts:134` |
+| DB | `employees.date_of_birth DATE NULL` (added by migration `20260413100000_add_employee_employment_type_dob.sql`) | `supabase/migrations/` |
+| RLS | gated by existing `"Users can view employees for their restaurants"` policy via `user_has_capability(restaurant_id, 'view:employees')` — owner/manager pass; no policy change needed | `supabase/migrations/20260120100100_update_rls_for_collaborators.sql:426` |
+| Edge SELECT | adds `date_of_birth` to active-employee projection. **Auth: anon key + user `Authorization` header**, NOT service role (`index.ts:68-72`). RLS evaluates as the calling user. | `generate-schedule/index.ts:134` |
 | Mapper | calls `computeHourBudget(e.date_of_birth, weekStart)` → populates `is_minor` and `max_weekly_hours` on the `ScheduleEmployee` | `generate-schedule/index.ts:247-255` |
 | Prompt | renders "Employee Hour Budgets" table from `ctx.employees` | `_shared/schedule-prompt-builder.ts` (new section after `## Employees`) |
 | LLM input | sees the table directly; never asked to compute it | — |
 | LLM output | `shift.employee_id` only — minor status not in response schema | — |
 | Validator context build | `buildValidationContext` populates new `employees` Map from same `ScheduleEmployee[]` | `generate-schedule/index.ts` |
 | Validator | new step enforces caps as backstop | `_shared/schedule-validator.ts` |
-| Diagnostic UI | new drop reasons surface in the partial-fill toast | `generate-schedule/index.ts` + `useGenerateSchedule.ts` |
-| Persistence | `shift_template_id`, `employee_id`, etc. — DOB itself is NOT persisted into `shifts` (the employee→shift FK + DOB lookup at read time is sufficient) | unchanged |
+| Diagnostic UI | three new drop reasons added to the `droppedReasons` switch at `generate-schedule/index.ts:644-664`. Coupled change — validator union + switch updated together. | `generate-schedule/index.ts` + `useGenerateSchedule.ts` |
+| Persistence | `shift_template_id`, `employee_id`, etc. — DOB itself is NOT persisted into `shifts` (the employee→shift FK + DOB lookup at read time is sufficient). PR #511's `shift_template_id` wiring is untouched. | unchanged |
 
 Every layer either reads the field or is documented as "not applicable."
 
@@ -426,27 +516,54 @@ Cover `computeHourBudget`:
 - Null DOB → adult 40.
 - Malformed DOB string → adult 40.
 - DOB in the future → adult 40.
-- Invalid `weekStart` → throws.
+- Invalid `weekStart` → throws (note: `buildWeekDates` is the
+  primary error boundary in the real call path, but
+  `computeHourBudget` validates independently as defense-in-depth).
 - Birthday on the Friday of weekStart's week, employee turns 16 →
   still treated as 15 (minor under 16, 18h cap).
+- **Birthday on the Monday that IS weekStart, employee turns 16 →
+  treated as 16 (adult 40h cap).** Locks the inclusive boundary.
+- **TZ-portability case.** Run with `process.env.TZ = 'America/Chicago'`
+  (UTC-6) and `'Pacific/Auckland'` (UTC+12). For DOB = `"2010-06-08"`
+  and weekStart = `"2026-06-08"`, the helper must return age 16
+  regardless of host TZ. A local-time `new Date(year, monthIdx, day)`
+  implementation will fail this on at least one of the two TZs.
 
 ### Unit tests (`tests/unit/schedule-validator.test.ts`)
 
-Extend the existing file:
+Extend the existing file. Note that the `ValidationContext` shape
+change (`employeeIds: Set` + `employeePositions: Map` → unified
+`employees: Map`) requires updating the `makeContext()` factory at
+`tests/unit/schedule-validator.test.ts:29-49` AND ~11 inline
+overrides at lines 32-35, 136-137, 160-161, 200-201, 302, 315, 328,
+338, 351 (per supabase reviewer's audit). Implementation plan calls
+this out as a single mechanical pass with a grep-confirmation step.
+
+New behavior tests:
 
 - `HOURS_EXCEED_WEEKLY_CAP`: 6 × 6.5h shifts (39h) accept; 7th shift
   (+6.5h → 45.5h) drops with code.
-- `MINOR_HOURS_EXCEEDED`: minor with 18h cap, 3 × 6h shifts (18h)
-  accept; 4th shift drops with `MINOR_HOURS_EXCEEDED` (not
-  `HOURS_EXCEED_WEEKLY_CAP` — verify the dispatch).
+- **`MINOR_HOURS_EXCEEDED` dispatch on cap value, not `is_minor`:**
+  - Minor with `max_weekly_hours: 18` (under-16): 3 × 6h shifts (18h)
+    accept; 4th shift drops with `MINOR_HOURS_EXCEEDED`.
+  - Minor with `max_weekly_hours: 40` (16-17yo): 6 × 6.5h shifts
+    accept; 7th shift drops with `HOURS_EXCEED_WEEKLY_CAP` (NOT
+    `MINOR_HOURS_EXCEEDED` — locks the dispatch rule).
 - `CONSECUTIVE_DAYS_EXCEEDED`: 5 shifts Mon–Fri accept; 6th shift Sat
   drops with code. Shift on Sun without Sat accepts (gap breaks the run).
 - Locked shifts seed the counter: existingShifts puts employee at 35h
   already, candidate 7h shift drops.
+- Locked shift already over cap (locked = 41h): locked shift stays
+  in `valid`; new candidates for same employee drop. Documents that
+  the validator never retroactively drops locked shifts.
+- Two locked shifts on the same calendar day (open + close): the
+  `longestConsecutiveRun` dedup means that Monday counts once, not
+  twice as zero-diff "gap." Locks the dedup behavior.
 - Overnight shift: 22:00-02:00 counts as one day's worth of minutes
   (4h), not two days.
 - Order independence: shifts emitted in random order produce the same
-  valid set as the same shifts emitted in chronological order.
+  valid set as the same shifts emitted in chronological order. Locks
+  the `(day, start_time, employee_id, template_id)` tiebreak.
 - DST spring-forward day (March 8 2026 in US/Central): consecutive-day
   math does not lose a day.
 

--- a/supabase/functions/_shared/schedule-prompt-builder.ts
+++ b/supabase/functions/_shared/schedule-prompt-builder.ts
@@ -234,9 +234,11 @@ RULES:
 7. Weight staffing toward peak sales hours — more staff during lunch/dinner rushes.
 8. If staffing settings specify minimum crew per position, meet those minimums when possible.
 9. If no staffing settings exist, use prior schedule patterns to infer typical staffing levels.
-10. Among schedules that meet required headcount (see Rule 12), prefer ones that stay within the weekly labor budget target.
-11. Full-time employees should be scheduled for more shifts, targeting 35-40 hours per week. Part-time employees should be scheduled for fewer shifts, targeting 15-25 hours per week. When both full-time and part-time employees are available for a slot, prefer the full-time employee unless they are already near 40 hours for the week.
-12. (HARD) Fill every required slot: for every (template, day) listed in "Required Headcount Per Slot", you MUST assign the required number of eligible-and-available employees. A slot may only be left below required headcount if there is NO eligible-and-available employee for it. Coverage is more important than budget — never under-fill to save cost.
+10. Among schedules that meet required headcount (see Rule 13), prefer ones that stay within the weekly labor budget target.
+11. (HARD Rule 11) Per-employee weekly hour cap. Each employee in the "Employee Hour Budgets" section has a max_weekly_hours value (their hour budget / weekly hour cap). The sum of scheduled hours for any single employee across the target week MUST NOT exceed that cap. This rule is absolute — never schedule overtime (more than 40 hours in the same week for any employee), even to fill an otherwise required slot. If no eligible employee has remaining hours, leave the slot short rather than push anyone over their cap. Spread hours across the available pool rather than concentrating them on the fewest people.
+12. (HARD Rule 12) No more than 5 consecutive days. No employee may be scheduled for more than 5 consecutive days in a row within the target week. After 5 days straight, the next day must be off for that employee. Prefer schedules that give every employee at least one day off after each 5-day block.
+13. (HARD Rule 13) Fill every required slot: for every (template, day) listed in "Required Headcount Per Slot", you MUST assign the required number of eligible-and-available employees. A slot may only be left below required headcount if there is NO eligible-and-available employee for it (or every eligible employee would breach Rule 11 or Rule 12). Coverage is more important than budget — never under-fill to save cost.
+14. (HARD Rule 14) Under-16 minors are capped at about 18h per week. Any employee tagged "minor" with a max_weekly_hours of 18 in the "Employee Hour Budgets" section is under 16 and subject to FLSA school-week limits. Their scheduled hours must not exceed 18h for the week. 16-17 year-old minors are tagged "minor" but keep the standard 40h cap — only the 18h budget signals under 16.
 
 Return valid JSON only, matching the provided schema exactly.`;
 
@@ -304,6 +306,25 @@ function buildUserPrompt(ctx: ScheduleContext): string {
     employment_type: e.employment_type,
   }));
   sections.push(`## Available Employees\n${JSON.stringify(employeesForPrompt, null, 2)}`);
+
+  // Employee Hour Budgets — per-employee weekly cap surfaced as a flat
+  // table so the LLM cannot miss it inside the larger Available Employees
+  // JSON blob. Sort by id so re-runs of the same context produce
+  // identical text (prompt-cache hits). Minor tagging is dispatched on
+  // max_weekly_hours: cap=18 → "minor, under 16" (FLSA school-week);
+  // cap=40 + is_minor → "minor" (16-17yo, full cap). See Rules 11/14.
+  const budgetLines = [...ctx.employees]
+    .sort((a, b) => a.id.localeCompare(b.id))
+    .map((e) => {
+      const tags: string[] = [];
+      if (e.is_minor) {
+        tags.push('minor');
+        if (e.max_weekly_hours === 18) tags.push('under 16');
+      }
+      const tagStr = tags.length > 0 ? ` [${tags.join(', ')}]` : '';
+      return `- ${e.id} (${e.name}): ${e.max_weekly_hours}h/week max${tagStr}`;
+    });
+  sections.push(`## Employee Hour Budgets\n${budgetLines.join('\n')}`);
 
   // Shift templates
   const templatesSection = ctx.templates.map((t) => {

--- a/supabase/functions/_shared/schedule-prompt-builder.ts
+++ b/supabase/functions/_shared/schedule-prompt-builder.ts
@@ -13,6 +13,14 @@ export interface ScheduleEmployee {
   area: string | null;
   hourly_rate: number; // cents
   employment_type: 'full_time' | 'part_time';
+  /** Set by the edge function from `employees.date_of_birth` relative
+   *  to `weekStart` via `computeHourBudget`. Null/missing DOB → false. */
+  is_minor: boolean;
+  /** Hard ceiling for weekly hours. Adults and 16-17yo minors: 40.
+   *  Under-16 minors: 18 (FLSA school-week limit applied year-round as
+   *  the conservative default). Validator dispatches MINOR_HOURS_EXCEEDED
+   *  vs HOURS_EXCEED_WEEKLY_CAP on this value, NOT on `is_minor`. */
+  max_weekly_hours: number;
 }
 
 export interface ScheduleTemplate {
@@ -145,6 +153,71 @@ function buildWeekDates(weekStart: string): { rows: string; byDayOfWeek: string[
   ];
   const rows = DATE_MAP_LABELS.map((label, i) => `  ${label} ${formatted[i]}`).join('\n');
   return { rows, byDayOfWeek };
+}
+
+/**
+ * Returns the weekly hour cap and minor flag for an employee given
+ * their date of birth and the first day of the schedule week.
+ *
+ * Both `dob` and `weekStart` are parsed as UTC midnight via
+ * `new Date(\`${s}T00:00:00Z\`)` and compared with `.getUTC*()`
+ * accessors so the result is identical across host TZs. Do NOT use
+ * the local-time `new Date(year, monthIdx, day)` constructor —
+ * see the TZ-portability test in
+ * `tests/unit/schedule-hour-budget.test.ts`.
+ *
+ * Age is computed in full UTC years anchored on `weekStart` (the first
+ * day of the schedule week). Birthday inclusive: an employee who turns
+ * N on `weekStart` is age N — not N-1.
+ *
+ * | DOB             | Age on weekStart | Result                       |
+ * | --------------- | ---------------- | ---------------------------- |
+ * | null/bad string | n/a              | { is_minor: false, max: 40 } |
+ * | future          | n/a              | { is_minor: false, max: 40 } |
+ * | ≥ 18            | adult            | { is_minor: false, max: 40 } |
+ * | 16-17           | minor 16+        | { is_minor: true,  max: 40 } |
+ * | < 16            | minor < 16       | { is_minor: true,  max: 18 } |
+ *
+ * @throws if `weekStart` does not parse to a valid Date. Throwing here
+ *   matches `buildWeekDates`'s behavior — an `Invalid Date` weekStart
+ *   would silently propagate as NaN age and bypass every cap.
+ */
+export function computeHourBudget(
+  dob: string | null | undefined,
+  weekStart: string,
+): { is_minor: boolean; max_weekly_hours: number } {
+  const weekDate = new Date(`${weekStart}T00:00:00Z`);
+  if (Number.isNaN(weekDate.getTime())) {
+    throw new Error(
+      `computeHourBudget: invalid weekStart "${weekStart}" — expected YYYY-MM-DD`,
+    );
+  }
+
+  if (!dob) return { is_minor: false, max_weekly_hours: 40 };
+
+  const dobDate = new Date(`${dob}T00:00:00Z`);
+  if (Number.isNaN(dobDate.getTime())) {
+    return { is_minor: false, max_weekly_hours: 40 };
+  }
+
+  // Future DOB → data error, treat as adult rather than blocking.
+  if (dobDate.getTime() > weekDate.getTime()) {
+    return { is_minor: false, max_weekly_hours: 40 };
+  }
+
+  // Age in full years, inclusive birthday. The employee has already had
+  // their birthday this year if (dob.month, dob.day) is on or before
+  // (weekStart.month, weekStart.day).
+  let age = weekDate.getUTCFullYear() - dobDate.getUTCFullYear();
+  const beforeBirthday =
+    weekDate.getUTCMonth() < dobDate.getUTCMonth() ||
+    (weekDate.getUTCMonth() === dobDate.getUTCMonth() &&
+      weekDate.getUTCDate() < dobDate.getUTCDate());
+  if (beforeBirthday) age--;
+
+  if (age < 16) return { is_minor: true, max_weekly_hours: 18 };
+  if (age < 18) return { is_minor: true, max_weekly_hours: 40 };
+  return { is_minor: false, max_weekly_hours: 40 };
 }
 
 const SYSTEM_PROMPT = `You are a restaurant schedule optimizer. Your job is to create an optimal weekly shift schedule.

--- a/supabase/functions/_shared/schedule-validator.ts
+++ b/supabase/functions/_shared/schedule-validator.ts
@@ -56,7 +56,10 @@ export type DropCode =
   | "POSITION_MISMATCH"
   | "UNAVAILABLE_DAY"
   | "OUTSIDE_WINDOW"
-  | "DOUBLE_BOOKING";
+  | "DOUBLE_BOOKING"
+  | "HOURS_EXCEED_WEEKLY_CAP"
+  | "MINOR_HOURS_EXCEEDED"
+  | "CONSECUTIVE_DAYS_EXCEEDED";
 
 export interface DroppedShift {
   shift: GeneratedShift;
@@ -97,6 +100,58 @@ export function getDayOfWeek(dateStr: string): number {
 export function timeToMinutes(time: string): number {
   const [hours, minutes] = time.split(':').map(Number);
   return hours * 60 + minutes;
+}
+
+/**
+ * Duration of a shift in hours, with overnight handling.
+ *
+ * 22:00→02:00 = 4h (not 24h). We anchor on the time-of-day diff, not
+ * on (next-day − day), because `shift.day` is the calendar day the
+ * shift nominally STARTS on; an overnight shift's `day` field never
+ * shifts to the next day. Using a day-diff here would inflate every
+ * overnight shift by ~24h and trigger spurious HOURS_EXCEED_WEEKLY_CAP
+ * drops.
+ */
+export function shiftHours(s: GeneratedShift): number {
+  const start = timeToMinutes(s.start_time);
+  let end = timeToMinutes(s.end_time);
+  if (end <= start) end += 1440; // overnight
+  return (end - start) / 60;
+}
+
+/**
+ * Longest run of consecutive calendar days in a set of YYYY-MM-DD strings.
+ * Returns 0 for an empty set; returns 1 for any single day.
+ *
+ * UTC-anchored (matches `shiftsConflict` and `computeHourBudget` in
+ * schedule-prompt-builder). Sorting by ms-since-epoch and stepping by
+ * 86_400_000 is DST-safe — that's the point of using UTC. A local-time
+ * implementation would see a 23h or 25h gap on DST transitions and
+ * misreport the streak.
+ */
+export function longestConsecutiveRun(days: Set<string>): number {
+  if (days.size === 0) return 0;
+  const ms = Array.from(days)
+    .map((d) => Date.parse(`${d}T00:00:00Z`))
+    .filter((n) => !Number.isNaN(n))
+    .sort((a, b) => a - b);
+  if (ms.length === 0) return 0;
+
+  let longest = 1;
+  let current = 1;
+  for (let i = 1; i < ms.length; i++) {
+    const diff = Math.round((ms[i] - ms[i - 1]) / 86_400_000);
+    if (diff === 1) {
+      current++;
+      if (current > longest) longest = current;
+    } else if (diff > 1) {
+      current = 1;
+    }
+    // diff === 0 (duplicate day): keep current; dedup-by-set means this
+    // branch is unreachable from a Set<string> input, but kept for
+    // defensive parity if callers ever pass a list.
+  }
+  return longest;
 }
 
 /**

--- a/supabase/functions/_shared/schedule-validator.ts
+++ b/supabase/functions/_shared/schedule-validator.ts
@@ -295,8 +295,16 @@ export function normalizePosition(s: string | null | undefined): string {
  * 6. Employee is available on that day of week
  * 7. Shift times fall within availability time window (if specific hours set)
  * 8. No double-booking (same employee, overlapping times on same day)
+ * 9. Weekly hour cap (HOURS_EXCEED_WEEKLY_CAP or MINOR_HOURS_EXCEEDED) —
+ *    stateful; seeded from existingShifts. MUST run AFTER step 8 so a
+ *    double-booked shift doesn't also consume the employee's hour budget.
+ *10. Consecutive-day cap (>5 days in a row → CONSECUTIVE_DAYS_EXCEEDED) —
+ *    stateful; uses the same per-employee state as step 9.
  *
- * For double-booking: first valid shift wins.
+ * For double-booking: first valid shift wins. Iteration order is
+ * deterministic — input shifts are sorted by (day, start_time,
+ * employee_id, template_id) at the top of the function so the valid
+ * set is identical regardless of LLM emission order.
  */
 export function validateGeneratedShifts(
   shifts: GeneratedShift[],
@@ -305,7 +313,48 @@ export function validateGeneratedShifts(
   const valid: GeneratedShift[] = [];
   const dropped: DroppedShift[] = [];
 
-  for (const shift of shifts) {
+  // Order-independence guard: sort once at the boundary so the {valid,
+  // dropped} set is deterministic regardless of LLM emission order.
+  // Earlier-day / earlier-start shifts win contested resources (hour
+  // budget remainder, double-booking tiebreak).
+  const sortedShifts = [...shifts].sort((a, b) => {
+    if (a.day !== b.day) return a.day < b.day ? -1 : 1;
+    if (a.start_time !== b.start_time) {
+      return a.start_time < b.start_time ? -1 : 1;
+    }
+    if (a.employee_id !== b.employee_id) {
+      return a.employee_id < b.employee_id ? -1 : 1;
+    }
+    if (a.template_id !== b.template_id) {
+      return a.template_id < b.template_id ? -1 : 1;
+    }
+    return 0;
+  });
+
+  // Per-employee accumulator for steps 9-10. Seeded from existingShifts
+  // (locked shifts) so the LLM's new candidates "see" the running totals
+  // already in place. Locked shifts that are themselves over cap are
+  // NEVER retroactively dropped — we record the over-cap reality and let
+  // new candidates drop if accepting them would push further.
+  const employeeState = new Map<
+    string,
+    { totalMinutes: number; days: Set<string> }
+  >();
+  const stateFor = (empId: string) => {
+    let st = employeeState.get(empId);
+    if (!st) {
+      st = { totalMinutes: 0, days: new Set<string>() };
+      employeeState.set(empId, st);
+    }
+    return st;
+  };
+  for (const e of ctx.existingShifts) {
+    const st = stateFor(e.employee_id);
+    st.totalMinutes += shiftHours(e) * 60;
+    st.days.add(e.day);
+  }
+
+  for (const shift of sortedShifts) {
     const drop = (code: DropCode, message: string) =>
       dropped.push({ shift, code, message });
 
@@ -421,6 +470,46 @@ export function validateGeneratedShifts(
       continue;
     }
 
+    // 9. Weekly hour cap. Dispatch on max_weekly_hours === 18 (the
+    //    under-16 floor) so the label is factually accurate: 16-17yo
+    //    minors at 40h fall through to HOURS_EXCEED_WEEKLY_CAP, not
+    //    MINOR_HOURS_EXCEEDED. Step 2 already proved the employee
+    //    exists; the lookup is defensive against future refactors.
+    const meta = ctx.employees.get(shift.employee_id);
+    if (!meta) continue;
+    const st = stateFor(shift.employee_id);
+    const candidateMinutes = shiftHours(shift) * 60;
+    const tentativeMinutes = st.totalMinutes + candidateMinutes;
+    const capMinutes = meta.max_weekly_hours * 60;
+
+    if (tentativeMinutes > capMinutes) {
+      const code: DropCode = meta.max_weekly_hours === 18
+        ? "MINOR_HOURS_EXCEEDED"
+        : "HOURS_EXCEED_WEEKLY_CAP";
+      drop(
+        code,
+        `Employee ${shift.employee_id} would reach ${(tentativeMinutes / 60).toFixed(1)}h on ${shift.day} (cap ${meta.max_weekly_hours}h)`,
+      );
+      continue;
+    }
+
+    // 10. Consecutive-day cap (>5 in a row drops). Tentative-set
+    //     evaluation: build a candidate-included view and ask the helper.
+    //     Set-based dedup means two shifts on the same calendar day
+    //     (open+close) count once, not twice.
+    const tentativeDays = new Set(st.days);
+    tentativeDays.add(shift.day);
+    if (longestConsecutiveRun(tentativeDays) > 5) {
+      drop(
+        "CONSECUTIVE_DAYS_EXCEEDED",
+        `Employee ${shift.employee_id} would exceed 5 consecutive days with ${shift.day}`,
+      );
+      continue;
+    }
+
+    // Commit the candidate to state and the valid list.
+    st.totalMinutes = tentativeMinutes;
+    st.days.add(shift.day);
     valid.push(shift);
   }
 

--- a/supabase/functions/_shared/schedule-validator.ts
+++ b/supabase/functions/_shared/schedule-validator.ts
@@ -22,8 +22,19 @@ export interface AvailabilitySlot {
 }
 
 export interface ValidationContext {
-  employeeIds: Set<string>;
-  employeePositions: Map<string, string>;
+  /** Employees keyed by id. Carries position (for POSITION_MISMATCH),
+   *  is_minor (informational for the prompt; NOT the validator's
+   *  dispatch predicate), and max_weekly_hours (used by the
+   *  HOURS_EXCEED_WEEKLY_CAP / MINOR_HOURS_EXCEEDED step).
+   *
+   *  Promoted from `employeeIds: Set<string>` + `employeePositions:
+   *  Map<string, string>`: one structure, one lookup, no drift risk.
+   *  Existence check `employeeIds.has(id)` becomes `employees.has(id)`. */
+  employees: Map<string, {
+    position: string;
+    is_minor: boolean;
+    max_weekly_hours: number;
+  }>;
   /** Templates keyed by id. `days` are the days-of-week (0=Sun..6=Sat) on
    *  which the template is active. `position` is the role the template
    *  requires — the validator drops shifts whose assigned employee does not
@@ -250,7 +261,7 @@ export function validateGeneratedShifts(
     }
 
     // 2. Employee exists
-    if (!ctx.employeeIds.has(shift.employee_id)) {
+    if (!ctx.employees.has(shift.employee_id)) {
       drop("UNKNOWN_EMPLOYEE", `Unknown employee ID: ${shift.employee_id}`);
       continue;
     }
@@ -282,7 +293,7 @@ export function validateGeneratedShifts(
     //    catches that. We also re-check shift.position so the LLM-emitted
     //    label can't disagree with what we persist downstream.
     const requiredPosition = template.position;
-    const assignedPosition = ctx.employeePositions.get(shift.employee_id);
+    const assignedPosition = ctx.employees.get(shift.employee_id)?.position;
     const normRequired = normalizePosition(requiredPosition);
     if (
       assignedPosition === undefined ||

--- a/supabase/functions/generate-schedule/index.ts
+++ b/supabase/functions/generate-schedule/index.ts
@@ -676,6 +676,12 @@ serve(async (req) => {
           return `Unknown template on ${d.shift.day}`;
         case "DAY_NOT_IN_TEMPLATE":
           return `Template not active on ${d.shift.day}`;
+        case "HOURS_EXCEED_WEEKLY_CAP":
+          return `Weekly hour cap exceeded on ${d.shift.day}`;
+        case "MINOR_HOURS_EXCEEDED":
+          return `Minor weekly hour cap exceeded on ${d.shift.day}`;
+        case "CONSECUTIVE_DAYS_EXCEEDED":
+          return `More than 5 consecutive days on ${d.shift.day}`;
         default:
           return `Unknown drop reason on ${d.shift.day}`;
       }

--- a/supabase/functions/generate-schedule/index.ts
+++ b/supabase/functions/generate-schedule/index.ts
@@ -560,8 +560,17 @@ serve(async (req) => {
       : [];
 
     // Build validation context
-    const employeeIds = new Set(employees.map((e) => e.id));
-    const employeePositions = new Map(employees.map((e) => [e.id, e.position]));
+    // Bug I: validator now carries is_minor + max_weekly_hours per
+    // employee (one Map instead of Set + parallel position Map) so the
+    // new hour-cap step can dispatch on max_weekly_hours and the
+    // POSITION_MISMATCH check still reads `.position` via one lookup.
+    const employeeMeta = new Map(
+      employees.map((e) => [e.id, {
+        position: e.position,
+        is_minor: e.is_minor,
+        max_weekly_hours: e.max_weekly_hours,
+      }] as const),
+    );
     // Validator needs template days-of-week and required position so it can
     // drop shifts placed on a wrong day (Bug C) or a wrong position (Bug E
     // — Manager onto Server template).
@@ -598,8 +607,7 @@ serve(async (req) => {
     });
 
     const validationCtx: ValidationContext = {
-      employeeIds,
-      employeePositions,
+      employees: employeeMeta,
       templates: templateDays,
       availability: availabilityMap,
       excludedEmployeeIds: new Set(excluded_employee_ids),

--- a/supabase/functions/generate-schedule/index.ts
+++ b/supabase/functions/generate-schedule/index.ts
@@ -7,6 +7,7 @@ import { callModelWithStreaming } from "../_shared/streaming.ts";
 import { runScheduleModelChain } from "../_shared/schedule-ai-runner.ts";
 import {
   buildSchedulePrompt,
+  computeHourBudget,
   type ScheduleContext,
   type ScheduleEmployee,
   type ScheduleTemplate,
@@ -131,7 +132,7 @@ serve(async (req) => {
       // 1. Active employees
       supabase
         .from("employees")
-        .select("id, name, position, area, hourly_rate, salary_amount, compensation_type, employment_type")
+        .select("id, name, position, area, hourly_rate, salary_amount, compensation_type, employment_type, date_of_birth")
         .eq("restaurant_id", restaurant_id)
         .eq("status", "active"),
 
@@ -245,15 +246,23 @@ serve(async (req) => {
     }
 
     // ── Build ScheduleEmployee[] ─────────────────────────────────────────────
-    const employees: ScheduleEmployee[] = activeEmployees.map((e) => ({
-      id: e.id,
-      name: e.name,
-      position: e.position ?? "Staff",
-      area: e.area ?? null,
-      // hourly_rate stored in cents; salary employees get 0
-      hourly_rate: e.compensation_type === "salary" ? 0 : (e.hourly_rate ?? 0),
-      employment_type: e.employment_type ?? "full_time",
-    }));
+    const employees: ScheduleEmployee[] = activeEmployees.map((e) => {
+      // Bug I: derive the per-employee weekly hour cap from DOB so the
+      // prompt's Employee Hour Budgets table and the validator backstop
+      // share one anchor. Defaults to adult 40h when DOB is null/bad.
+      const budget = computeHourBudget(e.date_of_birth, week_start);
+      return {
+        id: e.id,
+        name: e.name,
+        position: e.position ?? "Staff",
+        area: e.area ?? null,
+        // hourly_rate stored in cents; salary employees get 0
+        hourly_rate: e.compensation_type === "salary" ? 0 : (e.hourly_rate ?? 0),
+        employment_type: e.employment_type ?? "full_time",
+        is_minor: budget.is_minor,
+        max_weekly_hours: budget.max_weekly_hours,
+      };
+    });
 
     // ── Build ScheduleTemplate[] ─────────────────────────────────────────────
     const templates: ScheduleTemplate[] = rawTemplates.map((t) => ({

--- a/tests/unit/schedule-hour-budget.test.ts
+++ b/tests/unit/schedule-hour-budget.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { computeHourBudget } from
   '../../supabase/functions/_shared/schedule-prompt-builder';
 
@@ -67,6 +67,24 @@ describe('computeHourBudget', () => {
 
   it('throws on invalid weekStart', () => {
     expect(() => computeHourBudget('1996-06-08', 'not-a-date')).toThrow();
+  });
+
+  it('treats empty-string DOB as missing (adult fallback)', () => {
+    // dob === '' is falsy, so it routes through the same branch as
+    // null/undefined. Adult + 40h cap, no throw. Edge function
+    // currently never emits '' for date_of_birth, but this locks
+    // the fail-safe path in case the upstream contract slips.
+    expect(computeHourBudget('', weekStart)).toEqual({
+      is_minor: false,
+      max_weekly_hours: 40,
+    });
+  });
+
+  it('throws on empty-string weekStart', () => {
+    // Mirrors invalid weekStart: empty string parses to Invalid Date,
+    // and silently treating a missing week anchor as adult/40 would
+    // bypass every cap. Fail fast at the helper boundary.
+    expect(() => computeHourBudget('1996-06-08', '')).toThrow();
   });
 
   it('treats employee as 15 when their 16th birthday is later in the same week', () => {

--- a/tests/unit/schedule-hour-budget.test.ts
+++ b/tests/unit/schedule-hour-budget.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { computeHourBudget } from
+  '../../supabase/functions/_shared/schedule-prompt-builder';
+
+// `computeHourBudget(dob, weekStart)` returns the weekly cap for an
+// employee given their date of birth and the first day of the schedule
+// week. Both inputs are YYYY-MM-DD strings; the helper is UTC-anchored
+// so the result is identical regardless of host TZ.
+
+describe('computeHourBudget', () => {
+  // The schedule week we test against; June 8 2026 is a Monday.
+  const weekStart = '2026-06-08';
+
+  it('returns adult cap for an adult DOB (30 years before weekStart)', () => {
+    expect(computeHourBudget('1996-06-08', weekStart)).toEqual({
+      is_minor: false,
+      max_weekly_hours: 40,
+    });
+  });
+
+  it('returns 16-17yo minor cap (40h) for DOB ~17.5 years before weekStart', () => {
+    // Born ~17.5 years ago → age 17 on weekStart.
+    expect(computeHourBudget('2008-12-08', weekStart)).toEqual({
+      is_minor: true,
+      max_weekly_hours: 40,
+    });
+  });
+
+  it('returns under-16 minor cap (18h) for DOB 14 years before weekStart', () => {
+    expect(computeHourBudget('2012-06-08', weekStart)).toEqual({
+      is_minor: true,
+      max_weekly_hours: 18,
+    });
+  });
+
+  it('returns adult cap for null DOB', () => {
+    expect(computeHourBudget(null, weekStart)).toEqual({
+      is_minor: false,
+      max_weekly_hours: 40,
+    });
+  });
+
+  it('returns adult cap for undefined DOB', () => {
+    expect(computeHourBudget(undefined, weekStart)).toEqual({
+      is_minor: false,
+      max_weekly_hours: 40,
+    });
+  });
+
+  it('returns adult cap for malformed DOB strings', () => {
+    expect(computeHourBudget('not-a-date', weekStart)).toEqual({
+      is_minor: false,
+      max_weekly_hours: 40,
+    });
+    expect(computeHourBudget('2010-13-40', weekStart)).toEqual({
+      is_minor: false,
+      max_weekly_hours: 40,
+    });
+  });
+
+  it('returns adult cap for future DOB (data error)', () => {
+    expect(computeHourBudget('2027-06-08', weekStart)).toEqual({
+      is_minor: false,
+      max_weekly_hours: 40,
+    });
+  });
+
+  it('throws on invalid weekStart', () => {
+    expect(() => computeHourBudget('1996-06-08', 'not-a-date')).toThrow();
+  });
+
+  it('treats employee as 15 when their 16th birthday is later in the same week', () => {
+    // weekStart = Mon 2026-06-08; birthday is Fri 2026-06-12 → still 15
+    // on Monday → under-16 minor cap.
+    expect(computeHourBudget('2010-06-12', weekStart)).toEqual({
+      is_minor: true,
+      max_weekly_hours: 18,
+    });
+  });
+
+  it('treats employee as 16 when their 16th birthday IS the weekStart Monday (inclusive boundary)', () => {
+    // Birthday inclusive: an employee who turns 16 on weekStart is age 16,
+    // not 15. They get the 16-17yo minor cap (40h), not the under-16 cap.
+    expect(computeHourBudget('2010-06-08', weekStart)).toEqual({
+      is_minor: true,
+      max_weekly_hours: 40,
+    });
+  });
+
+  // ── TZ portability ────────────────────────────────────────────────────────
+  // A local-time `new Date(year, monthIdx, day)` implementation would flip
+  // the age across the date-line on Pacific/Auckland (UTC+12). Both runs
+  // must produce identical output because the helper parses YMD as
+  // UTC midnight.
+  describe('TZ portability', () => {
+    const originalTz = process.env.TZ;
+    afterEach(() => {
+      process.env.TZ = originalTz;
+    });
+
+    it('returns the same result in America/Chicago (UTC-6) and Pacific/Auckland (UTC+12)', () => {
+      process.env.TZ = 'America/Chicago';
+      const chicago = computeHourBudget('2010-06-08', '2026-06-08');
+
+      process.env.TZ = 'Pacific/Auckland';
+      const auckland = computeHourBudget('2010-06-08', '2026-06-08');
+
+      // DOB 2010-06-08, weekStart 2026-06-08 → turns 16 on Monday →
+      // inclusive boundary → { is_minor: true, max: 40 }.
+      expect(chicago).toEqual({ is_minor: true, max_weekly_hours: 40 });
+      expect(auckland).toEqual(chicago);
+    });
+  });
+});

--- a/tests/unit/schedule-prompt-builder.test.ts
+++ b/tests/unit/schedule-prompt-builder.test.ts
@@ -9,8 +9,10 @@ import {
 
 function makeContext(overrides: Partial<ScheduleContext> = {}): ScheduleContext {
   const employees: ScheduleEmployee[] = [
-    { id: 'emp-1', name: 'Maria', position: 'server', hourly_rate: 1500 },
-    { id: 'emp-2', name: 'Carlos', position: 'cook', hourly_rate: 1800 },
+    { id: 'emp-1', name: 'Maria', position: 'server', hourly_rate: 1500,
+      is_minor: false, max_weekly_hours: 40 },
+    { id: 'emp-2', name: 'Carlos', position: 'cook', hourly_rate: 1800,
+      is_minor: false, max_weekly_hours: 40 },
   ];
 
   const templates: ScheduleTemplate[] = [
@@ -383,5 +385,111 @@ describe('buildSchedulePrompt — Target Week date map (Bug H)', () => {
     // fail structured output with no signal to the caller. Test locks
     // in a fail-fast error at the helper boundary.
     expect(() => buildSchedulePrompt(makeContext({ weekStart: 'garbage' }))).toThrow(/invalid weekStart/);
+  });
+});
+
+// ── Bug I regression: AI generator was scheduling fulltimers over 40h
+// while leaving other employees with zero hours, and minors were getting
+// the same 40h cap as adults. Three new HARD rules in the system prompt
+// and a new "Employee Hour Budgets" table in the user prompt give the
+// LLM the per-employee max it must respect, plus the validator backstop
+// that drops over-cap shifts. These tests lock the prompt copy.
+describe('buildSchedulePrompt — hour caps and consecutive days (Bug I)', () => {
+  it('includes HARD Rule 11 capping weekly hours at the employee budget', () => {
+    const result = buildSchedulePrompt(makeContext());
+    const systemContent = result.messages[0].content as string;
+    // Rule 11 is the hard cap. Phrasing should call out the per-employee
+    // budget and explicitly forbid overtime so the LLM cannot interpret
+    // "soft preference" the way prior wording allowed.
+    expect(systemContent).toMatch(/HARD Rule 11/i);
+    expect(systemContent.toLowerCase()).toMatch(/max_weekly_hours|weekly hour cap|hour budget/);
+    expect(systemContent.toLowerCase()).toMatch(/never .*overtime|no overtime/);
+  });
+
+  it('includes HARD Rule 12 limiting consecutive scheduled days to 5', () => {
+    const result = buildSchedulePrompt(makeContext());
+    const systemContent = result.messages[0].content as string;
+    expect(systemContent).toMatch(/HARD Rule 12/i);
+    expect(systemContent.toLowerCase()).toMatch(/5 (consecutive|days? straight|days? in a row)/);
+  });
+
+  it('includes HARD Rule 14 for the under-16 minor cap (about 18h)', () => {
+    const result = buildSchedulePrompt(makeContext());
+    const systemContent = result.messages[0].content as string;
+    expect(systemContent).toMatch(/HARD Rule 14/i);
+    // Cap value (18) and the under-16 qualifier should both be present so
+    // the LLM does not infer a different threshold from "minor".
+    expect(systemContent).toMatch(/18\s*h/i);
+    expect(systemContent.toLowerCase()).toMatch(/under.?16|under 16/);
+  });
+
+  it('renders an Employee Hour Budgets section listing each employee max', () => {
+    const result = buildSchedulePrompt(makeContext());
+    const userContent = result.messages[1].content as string;
+    expect(userContent).toContain('Employee Hour Budgets');
+    // Each employee id followed by their cap. Exact string match locks
+    // the renderer format so a refactor can't silently drop the cap.
+    expect(userContent).toMatch(/emp-1[^\n]*40h/);
+    expect(userContent).toMatch(/emp-2[^\n]*40h/);
+  });
+
+  it('marks an under-16 minor with both the 18h cap AND a minor label', () => {
+    const ctx = makeContext({
+      employees: [
+        { id: 'emp-1', name: 'Maria', position: 'server', hourly_rate: 1500,
+          is_minor: false, max_weekly_hours: 40 },
+        { id: 'emp-3', name: 'Ana', position: 'server', hourly_rate: 1200,
+          is_minor: true, max_weekly_hours: 18 },
+      ],
+    });
+    const userContent = buildSchedulePrompt(ctx).messages[1].content as string;
+    // The minor row should pair the id with the 18h cap and tag it as
+    // "minor" so the LLM doesn't lump them with the adult 40h pool.
+    expect(userContent).toMatch(/emp-3[^\n]*18h/);
+    expect(userContent).toMatch(/emp-3[^\n]*minor/i);
+  });
+
+  it('marks a 16-17yo minor (40h cap) as minor without the under-16 tag', () => {
+    // Dispatch parity with the validator: is_minor=true + cap=40 means
+    // a 16-17yo. The prompt should flag them as a minor for awareness
+    // (managers may want to be conservative) but the cap stays 40h.
+    const ctx = makeContext({
+      employees: [
+        { id: 'emp-4', name: 'Sam', position: 'server', hourly_rate: 1400,
+          is_minor: true, max_weekly_hours: 40 },
+      ],
+    });
+    const userContent = buildSchedulePrompt(ctx).messages[1].content as string;
+    expect(userContent).toMatch(/emp-4[^\n]*40h/);
+    expect(userContent).toMatch(/emp-4[^\n]*minor/i);
+    // Should NOT carry the "under 16" qualifier — that's only for the 18h cap.
+    expect(userContent).not.toMatch(/emp-4[^\n]*under.?16/i);
+  });
+
+  it('renders the budget section in deterministic order (by employee id)', () => {
+    const ctx = makeContext({
+      employees: [
+        { id: 'emp-z', name: 'Zoe', position: 'server', hourly_rate: 1500,
+          is_minor: false, max_weekly_hours: 40 },
+        { id: 'emp-a', name: 'Aaron', position: 'server', hourly_rate: 1500,
+          is_minor: false, max_weekly_hours: 40 },
+        { id: 'emp-m', name: 'Maya', position: 'server', hourly_rate: 1500,
+          is_minor: true, max_weekly_hours: 18 },
+      ],
+    });
+    const userContent = buildSchedulePrompt(ctx).messages[1].content as string;
+    // Extract budget section by anchoring on the header and the first
+    // double newline that follows. Sort key is employee id so re-runs of
+    // the prompt with the same context produce identical text — needed
+    // for prompt-cache hits.
+    const sectionStart = userContent.indexOf('Employee Hour Budgets');
+    expect(sectionStart).toBeGreaterThan(-1);
+    const section = userContent.slice(sectionStart, sectionStart + 600);
+    const idxA = section.indexOf('emp-a');
+    const idxM = section.indexOf('emp-m');
+    const idxZ = section.indexOf('emp-z');
+    expect(idxA).toBeGreaterThan(-1);
+    expect(idxM).toBeGreaterThan(idxA);
+    expect(idxZ).toBeGreaterThan(idxM);
   });
 });

--- a/tests/unit/schedule-validator.test.ts
+++ b/tests/unit/schedule-validator.test.ts
@@ -624,11 +624,23 @@ describe('validateGeneratedShifts — hour caps and consecutive days', () => {
   }
 
   it('drops 7th 6.5h shift when employee would exceed adult 40h cap', () => {
+    // Setup avoids the consec rule colliding with the hour cap: 5 weekday
+    // shifts (Mon-Fri = 5 consec, OK) + 2 Sunday shifts (open + close,
+    // dedup to 1 day, isolated from Mon-Fri streak by the Sat gap).
+    //   Mon-Fri  5 × 6.5h = 32.5h  (5 consec → OK)
+    //   Sun open 10-16:30 = +6.5h → 39h (longest run still 5 → OK)
+    //   Sun close 17-23:30 = +6.5h → 45.5h > 40h → DROP HOURS_EXCEED
     const ctx = makeContext({
       employees: new Map([emp('emp-1', 'server', /* is_minor */ false, /* cap */ 40)]),
       availability: makeAllWeekAvailability('emp-1'),
     });
-    const shifts = dailyShifts({ employee_id: 'emp-1' });
+    const shifts: GeneratedShift[] = [
+      ...dailyShifts({ employee_id: 'emp-1', days: WEEK_DAYS.slice(0, 5) }),
+      { employee_id: 'emp-1', template_id: 'tmpl-1', day: '2026-06-14',
+        start_time: '10:00:00', end_time: '16:30:00', position: 'server' },
+      { employee_id: 'emp-1', template_id: 'tmpl-1', day: '2026-06-14',
+        start_time: '17:00:00', end_time: '23:30:00', position: 'server' },
+    ];
     const result = validateGeneratedShifts(shifts, ctx);
 
     expect(result.valid).toHaveLength(6); // 6 × 6.5h = 39h
@@ -657,11 +669,19 @@ describe('validateGeneratedShifts — hour caps and consecutive days', () => {
   it('16-17yo minor (40h cap) dispatches HOURS_EXCEED_WEEKLY_CAP, NOT MINOR_HOURS_EXCEEDED', () => {
     // Dispatch rule: MINOR_HOURS_EXCEEDED fires ONLY when cap === 18.
     // A 17yo with the 40h cap that exceeds it gets the adult code.
+    // Setup mirrors the adult cap test (5 weekdays + 2 Sunday shifts)
+    // so the consec rule does not collide with the hour cap.
     const ctx = makeContext({
       employees: new Map([emp('emp-1', 'server', /* is_minor */ true, /* cap */ 40)]),
       availability: makeAllWeekAvailability('emp-1'),
     });
-    const shifts = dailyShifts({ employee_id: 'emp-1' }); // 7 × 6.5h
+    const shifts: GeneratedShift[] = [
+      ...dailyShifts({ employee_id: 'emp-1', days: WEEK_DAYS.slice(0, 5) }),
+      { employee_id: 'emp-1', template_id: 'tmpl-1', day: '2026-06-14',
+        start_time: '10:00:00', end_time: '16:30:00', position: 'server' },
+      { employee_id: 'emp-1', template_id: 'tmpl-1', day: '2026-06-14',
+        start_time: '17:00:00', end_time: '23:30:00', position: 'server' },
+    ];
     const result = validateGeneratedShifts(shifts, ctx);
 
     expect(result.valid).toHaveLength(6);
@@ -807,9 +827,12 @@ describe('validateGeneratedShifts — hour caps and consecutive days', () => {
       employees: new Map([emp('emp-1', 'server', false, 40)]),
       availability: makeAllWeekAvailability('emp-1'),
     });
-    // 9 overnight 4h shifts = 36h. If the validator wrongly counted
-    // each as 24h, we'd drop after the 2nd (48h > 40h).
-    const shifts = WEEK_DAYS.slice(0, 7).map((day) => ({
+    // 6 overnight 4h shifts on Mon-Sat. With proper 4h counting, total
+    // is 24h ≤ 40 — hour cap stays silent. The consec rule drops the
+    // 6th (Sat). If overnight were wrongly counted as 24h each, we'd
+    // hit 48h after just 2 shifts and HOURS_EXCEED_WEEKLY_CAP would
+    // fire instead — the assertion on the drop CODE catches that bug.
+    const shifts = WEEK_DAYS.slice(0, 6).map((day) => ({
       employee_id: 'emp-1',
       template_id: 'tmpl-1',
       day,
@@ -817,48 +840,60 @@ describe('validateGeneratedShifts — hour caps and consecutive days', () => {
       end_time: '02:00:00',
       position: 'server',
     }));
-    // 7 days at 4h = 28h. Should all fit under 40h. But 7 consecutive
-    // days violates Rule 12 → drop on day 6.
     const result = validateGeneratedShifts(shifts, ctx);
 
-    // 5 accept (consecutive-day rule kicks in on day 6), 2 drop with
-    // CONSECUTIVE_DAYS_EXCEEDED — proves hour cap did NOT drop them
-    // (which would imply 24h-per-shift miscounting).
-    expect(result.valid).toHaveLength(5);
-    expect(result.dropped).toHaveLength(2);
-    expect(result.dropped.every((d) => d.code === 'CONSECUTIVE_DAYS_EXCEEDED')).toBe(true);
+    expect(result.valid).toHaveLength(5); // Mon-Fri
+    expect(result.dropped).toHaveLength(1);
+    expect(result.dropped[0].code).toBe('CONSECUTIVE_DAYS_EXCEEDED');
+    expect(result.dropped[0].shift.day).toBe('2026-06-13'); // Saturday
   });
 
   it('produces same valid set regardless of input order (sorted by day/start/employee/template)', () => {
-    // Bug I requires deterministic "first 5 wins" — sort key (day,
+    // Bug I requires deterministic "first 6 wins" — sort key (day,
     // start_time, employee_id, template_id) so re-runs on identical
-    // inputs produce identical output.
+    // inputs produce identical output. Uses the same isolated-Sunday
+    // setup as the adult-cap test to keep the hour rule isolated from
+    // the consec rule.
     const ctx = makeContext({
       employees: new Map([emp('emp-1', 'server', false, 40)]),
       availability: makeAllWeekAvailability('emp-1'),
     });
-    const shifts = dailyShifts({ employee_id: 'emp-1' }); // 7 × 6.5h = 45.5h
+    const shifts: GeneratedShift[] = [
+      ...dailyShifts({ employee_id: 'emp-1', days: WEEK_DAYS.slice(0, 5) }),
+      { employee_id: 'emp-1', template_id: 'tmpl-1', day: '2026-06-14',
+        start_time: '10:00:00', end_time: '16:30:00', position: 'server' },
+      { employee_id: 'emp-1', template_id: 'tmpl-1', day: '2026-06-14',
+        start_time: '17:00:00', end_time: '23:30:00', position: 'server' },
+    ];
     // Shuffle by reversing — should yield identical valid set after sort.
     const reversed = [...shifts].reverse();
 
     const r1 = validateGeneratedShifts(shifts, ctx);
     const r2 = validateGeneratedShifts(reversed, ctx);
 
-    const days1 = r1.valid.map((s) => s.day).sort();
-    const days2 = r2.valid.map((s) => s.day).sort();
-    expect(days2).toEqual(days1);
+    const key = (s: GeneratedShift) => `${s.day}|${s.start_time}`;
+    const set1 = r1.valid.map(key).sort();
+    const set2 = r2.valid.map(key).sort();
+    expect(set2).toEqual(set1);
     expect(r1.valid).toHaveLength(6);
     expect(r2.valid).toHaveLength(6);
     expect(r1.dropped[0].code).toBe('HOURS_EXCEED_WEEKLY_CAP');
     expect(r2.dropped[0].code).toBe('HOURS_EXCEED_WEEKLY_CAP');
+    // Determinism also covers which exact shift drops: the late Sun close.
+    expect(r1.dropped[0].shift.start_time).toBe('17:00:00');
+    expect(r2.dropped[0].shift.start_time).toBe('17:00:00');
   });
 
   it('counts consecutive days correctly across DST spring-forward (March 8 2026)', () => {
-    // Mar 2-8 2026; Mar 8 is the US DST spring-forward day. UTC-anchored
-    // math means the consecutive-day count is 7, not 6 (no false gap).
+    // Mar 3-8 2026 (Tue-Sun); Mar 8 is the US DST spring-forward day.
+    // The Sat→Sun day-diff is the DST-sensitive boundary. With UTC math
+    // it is exactly 24h; with local-time math the gap is 23h (spring)
+    // or 25h (fall), which Math.floor would round to 0 and treat as a
+    // false gap. We assert Mar 8 (Sun, day 6 of streak) drops with
+    // CONSECUTIVE_DAYS_EXCEEDED — a false gap would let Mar 8 through.
     const dstWeek = [
-      '2026-03-02', '2026-03-03', '2026-03-04', '2026-03-05',
-      '2026-03-06', '2026-03-07', '2026-03-08',
+      '2026-03-03', '2026-03-04', '2026-03-05', '2026-03-06',
+      '2026-03-07', '2026-03-08',
     ];
     const ctx = makeContext({
       employees: new Map([emp('emp-1', 'server', false, 40)]),
@@ -871,10 +906,9 @@ describe('validateGeneratedShifts — hour caps and consecutive days', () => {
     });
     const result = validateGeneratedShifts(shifts, ctx);
 
-    // 5 accept Mon-Fri; 2 drop (Sat, Sun) with consecutive-days code.
-    // If DST created a false gap, we'd see 6 valid (no drop on Sat).
-    expect(result.valid).toHaveLength(5);
-    expect(result.dropped).toHaveLength(2);
-    expect(result.dropped.every((d) => d.code === 'CONSECUTIVE_DAYS_EXCEEDED')).toBe(true);
+    expect(result.valid).toHaveLength(5); // Tue-Sat
+    expect(result.dropped).toHaveLength(1);
+    expect(result.dropped[0].code).toBe('CONSECUTIVE_DAYS_EXCEEDED');
+    expect(result.dropped[0].shift.day).toBe('2026-03-08'); // DST Sun
   });
 });

--- a/tests/unit/schedule-validator.test.ts
+++ b/tests/unit/schedule-validator.test.ts
@@ -26,13 +26,24 @@ function makeAvailability(): Map<string, AvailabilitySlot> {
   return map;
 }
 
+// Bug I: ValidationContext.employees promoted from Set + parallel Map.
+// `emp()` factory builds one entry; default cap is adult 40h so existing
+// suites that don't care about hour caps behave the same.
+function emp(
+  id: string,
+  position = 'server',
+  is_minor = false,
+  max_weekly_hours = 40,
+): readonly [string, { position: string; is_minor: boolean; max_weekly_hours: number }] {
+  return [id, { position, is_minor, max_weekly_hours }] as const;
+}
+
 function makeContext(overrides?: Partial<ValidationContext>): ValidationContext {
   return {
-    employeeIds: new Set(['emp-1', 'emp-2', 'emp-3']),
-    employeePositions: new Map([
-      ['emp-1', 'server'],
-      ['emp-2', 'cook'],
-      ['emp-3', 'server'],
+    employees: new Map([
+      emp('emp-1', 'server'),
+      emp('emp-2', 'cook'),
+      emp('emp-3', 'server'),
     ]),
     // Default fixtures use templates active on every day of the week and the
     // 'server' position so existing suites that don't care about active-days
@@ -133,8 +144,7 @@ describe('validateGeneratedShifts', () => {
 
   it('drops a shift whose day-of-week is not in the template active days', () => {
     const ctx = makeContext({
-      employeeIds: new Set(['emp-2']),
-      employeePositions: new Map([['emp-2', 'cook']]),
+      employees: new Map([emp('emp-2', 'cook')]),
       templates: new Map([
         // Weekend-only template (Sun, Fri, Sat)
         ['weekend-close', { days: [0, 5, 6], position: 'cook' }],
@@ -157,8 +167,7 @@ describe('validateGeneratedShifts', () => {
 
   it('allows a shift whose day-of-week IS in the template active days', () => {
     const ctx = makeContext({
-      employeeIds: new Set(['emp-2']),
-      employeePositions: new Map([['emp-2', 'cook']]),
+      employees: new Map([emp('emp-2', 'cook')]),
       templates: new Map([
         ['weekday-close', { days: [1, 2, 3, 4, 5], position: 'cook' }],
       ]),
@@ -197,8 +206,7 @@ describe('validateGeneratedShifts', () => {
   //    LLM-controlled fields. Result: 3/2 and 4/3 over-fills.
   it('drops a Manager assigned to a Server template even when shift.position matches the employee', () => {
     const ctx = makeContext({
-      employeeIds: new Set(['mgr-1']),
-      employeePositions: new Map([['mgr-1', 'Manager']]),
+      employees: new Map([emp('mgr-1', 'Manager')]),
       availability: new Map([
         ['mgr-1:1', { isAvailable: true, startTime: null, endTime: null }],
       ]),
@@ -299,7 +307,11 @@ describe('validateGeneratedShifts', () => {
 describe('validateGeneratedShifts — position normalization', () => {
   it('matches "Line Cook" employee with "line cook" shift (case-insensitive)', () => {
     const ctx = makeContext({
-      employeePositions: new Map([['emp-1', 'Line Cook']]),
+      employees: new Map([
+        emp('emp-1', 'Line Cook'),
+        emp('emp-2', 'cook'),
+        emp('emp-3', 'server'),
+      ]),
       templates: new Map([
         ['tmpl-1', { days: [0, 1, 2, 3, 4, 5, 6], position: 'line cook' }],
         ['tmpl-2', { days: [0, 1, 2, 3, 4, 5, 6], position: 'server' }],
@@ -312,7 +324,11 @@ describe('validateGeneratedShifts — position normalization', () => {
 
   it('matches "Cook " (trailing space) employee with "Cook" shift', () => {
     const ctx = makeContext({
-      employeePositions: new Map([['emp-1', 'Cook ']]),
+      employees: new Map([
+        emp('emp-1', 'Cook '),
+        emp('emp-2', 'cook'),
+        emp('emp-3', 'server'),
+      ]),
       templates: new Map([
         ['tmpl-1', { days: [0, 1, 2, 3, 4, 5, 6], position: 'Cook' }],
         ['tmpl-2', { days: [0, 1, 2, 3, 4, 5, 6], position: 'server' }],
@@ -325,7 +341,11 @@ describe('validateGeneratedShifts — position normalization', () => {
 
   it('matches "Servers" (plural) employee with "server" shift', () => {
     const ctx = makeContext({
-      employeePositions: new Map([['emp-1', 'Servers']]),
+      employees: new Map([
+        emp('emp-1', 'Servers'),
+        emp('emp-2', 'cook'),
+        emp('emp-3', 'server'),
+      ]),
       // Default tmpl-1.position = 'server', which normalizes-matches 'Servers'.
     });
     const shift = makeShift({ position: 'server' });
@@ -335,7 +355,11 @@ describe('validateGeneratedShifts — position normalization', () => {
 
   it('preserves "Hostess" (ends in ss, does not strip)', () => {
     const ctx = makeContext({
-      employeePositions: new Map([['emp-1', 'Hostess']]),
+      employees: new Map([
+        emp('emp-1', 'Hostess'),
+        emp('emp-2', 'cook'),
+        emp('emp-3', 'server'),
+      ]),
       templates: new Map([
         ['tmpl-1', { days: [0, 1, 2, 3, 4, 5, 6], position: 'Hostess' }],
         ['tmpl-2', { days: [0, 1, 2, 3, 4, 5, 6], position: 'server' }],
@@ -348,7 +372,11 @@ describe('validateGeneratedShifts — position normalization', () => {
 
   it('preserves short stems like "Bus" (stem length <= 4)', () => {
     const ctx = makeContext({
-      employeePositions: new Map([['emp-1', 'Bus']]),
+      employees: new Map([
+        emp('emp-1', 'Bus'),
+        emp('emp-2', 'cook'),
+        emp('emp-3', 'server'),
+      ]),
       templates: new Map([
         ['tmpl-1', { days: [0, 1, 2, 3, 4, 5, 6], position: 'Bus' }],
         ['tmpl-2', { days: [0, 1, 2, 3, 4, 5, 6], position: 'server' }],

--- a/tests/unit/schedule-validator.test.ts
+++ b/tests/unit/schedule-validator.test.ts
@@ -570,3 +570,311 @@ describe('validateGeneratedShifts — overnight availability window', () => {
     expect(result.valid).toHaveLength(1);
   });
 });
+
+// ─── Bug I: hour caps + consecutive days ────────────────────────────────────
+//
+// The 2026-05-23 production symptom: 9 employees got 45.5-48.5h each
+// across 7 consecutive days while 14 PT employees got zero shifts. The
+// LLM prompt's soft Rule 11 ("target 35-40h") was honored as advisory
+// while the HARD fill-every-slot rule won.
+//
+// These tests lock the validator backstop: even if the prompt-side rules
+// fail (different LLM, longer prompt, etc.), the validator drops any
+// shift that would push an employee over their weekly cap or onto a 6th
+// consecutive day.
+//
+// Helpers below build a Server-only context with one employee available
+// every day, then enumerate 7 daily 6.5h shifts (39h total in the first
+// 6 days). Each test tweaks one variable to verify the new step's
+// dispatch and bookkeeping.
+
+describe('validateGeneratedShifts — hour caps and consecutive days', () => {
+  // Mon 2026-06-08 through Sun 2026-06-14 (Bug I production week)
+  const WEEK_DAYS = [
+    '2026-06-08', '2026-06-09', '2026-06-10', '2026-06-11',
+    '2026-06-12', '2026-06-13', '2026-06-14',
+  ];
+
+  function makeAllWeekAvailability(empId: string): Map<string, AvailabilitySlot> {
+    const map = new Map<string, AvailabilitySlot>();
+    // 0=Sun..6=Sat
+    for (let dow = 0; dow < 7; dow++) {
+      map.set(`${empId}:${dow}`, { isAvailable: true, startTime: null, endTime: null });
+    }
+    return map;
+  }
+
+  function dailyShifts(opts: {
+    employee_id: string;
+    template_id?: string;
+    position?: string;
+    start_time?: string;
+    end_time?: string;
+    days?: string[];
+  }): GeneratedShift[] {
+    const days = opts.days ?? WEEK_DAYS;
+    return days.map((day) => ({
+      employee_id: opts.employee_id,
+      template_id: opts.template_id ?? 'tmpl-1',
+      day,
+      start_time: opts.start_time ?? '10:00:00',
+      end_time: opts.end_time ?? '16:30:00', // 6.5h
+      position: opts.position ?? 'server',
+    }));
+  }
+
+  it('drops 7th 6.5h shift when employee would exceed adult 40h cap', () => {
+    const ctx = makeContext({
+      employees: new Map([emp('emp-1', 'server', /* is_minor */ false, /* cap */ 40)]),
+      availability: makeAllWeekAvailability('emp-1'),
+    });
+    const shifts = dailyShifts({ employee_id: 'emp-1' });
+    const result = validateGeneratedShifts(shifts, ctx);
+
+    expect(result.valid).toHaveLength(6); // 6 × 6.5h = 39h
+    expect(result.dropped).toHaveLength(1);
+    expect(result.dropped[0].code).toBe('HOURS_EXCEED_WEEKLY_CAP');
+  });
+
+  it('drops 4th shift for under-16 minor (18h cap)', () => {
+    const ctx = makeContext({
+      employees: new Map([emp('emp-1', 'server', /* is_minor */ true, /* cap */ 18)]),
+      availability: makeAllWeekAvailability('emp-1'),
+    });
+    // 3 × 6h shifts = 18h; 4th would push to 24h.
+    const shifts = dailyShifts({
+      employee_id: 'emp-1',
+      end_time: '16:00:00', // 6h
+      days: WEEK_DAYS.slice(0, 4),
+    });
+    const result = validateGeneratedShifts(shifts, ctx);
+
+    expect(result.valid).toHaveLength(3);
+    expect(result.dropped).toHaveLength(1);
+    expect(result.dropped[0].code).toBe('MINOR_HOURS_EXCEEDED');
+  });
+
+  it('16-17yo minor (40h cap) dispatches HOURS_EXCEED_WEEKLY_CAP, NOT MINOR_HOURS_EXCEEDED', () => {
+    // Dispatch rule: MINOR_HOURS_EXCEEDED fires ONLY when cap === 18.
+    // A 17yo with the 40h cap that exceeds it gets the adult code.
+    const ctx = makeContext({
+      employees: new Map([emp('emp-1', 'server', /* is_minor */ true, /* cap */ 40)]),
+      availability: makeAllWeekAvailability('emp-1'),
+    });
+    const shifts = dailyShifts({ employee_id: 'emp-1' }); // 7 × 6.5h
+    const result = validateGeneratedShifts(shifts, ctx);
+
+    expect(result.valid).toHaveLength(6);
+    expect(result.dropped).toHaveLength(1);
+    expect(result.dropped[0].code).toBe('HOURS_EXCEED_WEEKLY_CAP');
+  });
+
+  it('drops 6th consecutive day even when employee is well under hour cap', () => {
+    const ctx = makeContext({
+      employees: new Map([emp('emp-1', 'server', false, 40)]),
+      availability: makeAllWeekAvailability('emp-1'),
+    });
+    // 6 × 4h shifts = 24h (under 40h cap), but 6 consecutive days
+    // violates Rule 12.
+    const shifts = dailyShifts({
+      employee_id: 'emp-1',
+      end_time: '14:00:00', // 4h
+      days: WEEK_DAYS.slice(0, 6), // Mon-Sat
+    });
+    const result = validateGeneratedShifts(shifts, ctx);
+
+    expect(result.valid).toHaveLength(5); // Mon-Fri
+    expect(result.dropped).toHaveLength(1);
+    expect(result.dropped[0].code).toBe('CONSECUTIVE_DAYS_EXCEEDED');
+    expect(result.dropped[0].shift.day).toBe('2026-06-13'); // Saturday
+  });
+
+  it('accepts Mon-Fri + Sun (gap on Saturday breaks the run)', () => {
+    const ctx = makeContext({
+      employees: new Map([emp('emp-1', 'server', false, 40)]),
+      availability: makeAllWeekAvailability('emp-1'),
+    });
+    // Mon, Tue, Wed, Thu, Fri, (skip Sat), Sun — longest run is 5.
+    const shifts = dailyShifts({
+      employee_id: 'emp-1',
+      end_time: '14:00:00', // 4h
+      days: ['2026-06-08','2026-06-09','2026-06-10','2026-06-11','2026-06-12','2026-06-14'],
+    });
+    const result = validateGeneratedShifts(shifts, ctx);
+
+    expect(result.valid).toHaveLength(6);
+    expect(result.dropped).toHaveLength(0);
+  });
+
+  it('locked shifts seed the hour counter — candidate drops when sum would exceed cap', () => {
+    // Locked shifts put the employee at 35h already. A new 7h candidate
+    // (total 42h) must drop.
+    const lockedShifts: GeneratedShift[] = [
+      // 5 × 7h locked = 35h on Mon-Fri
+      ...WEEK_DAYS.slice(0, 5).map((day) => ({
+        employee_id: 'emp-1',
+        template_id: 'tmpl-1',
+        day,
+        start_time: '10:00:00',
+        end_time: '17:00:00', // 7h
+        position: 'server',
+      })),
+    ];
+    const ctx = makeContext({
+      employees: new Map([emp('emp-1', 'server', false, 40)]),
+      availability: makeAllWeekAvailability('emp-1'),
+      existingShifts: lockedShifts,
+    });
+    const candidate = makeShift({
+      employee_id: 'emp-1',
+      day: '2026-06-13', // Saturday — not in locked
+      start_time: '10:00:00',
+      end_time: '17:00:00',
+      position: 'server',
+    });
+    const result = validateGeneratedShifts([candidate], ctx);
+
+    expect(result.valid).toHaveLength(0);
+    expect(result.dropped).toHaveLength(1);
+    expect(result.dropped[0].code).toBe('HOURS_EXCEED_WEEKLY_CAP');
+  });
+
+  it('locked shift already over cap is never retroactively dropped; only new candidates drop', () => {
+    // Locked = 41h (over 40h cap). Validator keeps the lock untouched
+    // — it never modifies existingShifts — but any new candidate for
+    // the same employee drops because the counter is already past cap.
+    const lockedShifts: GeneratedShift[] = [
+      { employee_id: 'emp-1', template_id: 'tmpl-1', day: '2026-06-08',
+        start_time: '08:00:00', end_time: '20:00:00', position: 'server' }, // 12h
+      { employee_id: 'emp-1', template_id: 'tmpl-1', day: '2026-06-09',
+        start_time: '08:00:00', end_time: '20:00:00', position: 'server' }, // 12h
+      { employee_id: 'emp-1', template_id: 'tmpl-1', day: '2026-06-10',
+        start_time: '08:00:00', end_time: '17:00:00', position: 'server' }, // 9h
+      { employee_id: 'emp-1', template_id: 'tmpl-1', day: '2026-06-11',
+        start_time: '08:00:00', end_time: '16:00:00', position: 'server' }, // 8h
+    ]; // 41h total
+    const ctx = makeContext({
+      employees: new Map([emp('emp-1', 'server', false, 40)]),
+      availability: makeAllWeekAvailability('emp-1'),
+      existingShifts: lockedShifts,
+    });
+    const candidate = makeShift({
+      employee_id: 'emp-1',
+      day: '2026-06-12',
+      start_time: '10:00:00',
+      end_time: '14:00:00', // 4h
+      position: 'server',
+    });
+    const result = validateGeneratedShifts([candidate], ctx);
+
+    expect(result.valid).toHaveLength(0);
+    expect(result.dropped).toHaveLength(1);
+    expect(result.dropped[0].code).toBe('HOURS_EXCEED_WEEKLY_CAP');
+  });
+
+  it('duplicate day in existingShifts (open + close on same Monday) does not collapse streak math', () => {
+    // Two locked shifts on the same Monday → dedup means Monday counts
+    // once, not twice as a zero-diff "gap." Subsequent Tue/Wed/Thu/Fri
+    // candidates all accept (run = 5, not 6).
+    const lockedShifts: GeneratedShift[] = [
+      { employee_id: 'emp-1', template_id: 'tmpl-1', day: '2026-06-08',
+        start_time: '08:00:00', end_time: '12:00:00', position: 'server' }, // 4h open
+      { employee_id: 'emp-1', template_id: 'tmpl-1', day: '2026-06-08',
+        start_time: '13:00:00', end_time: '17:00:00', position: 'server' }, // 4h close
+    ];
+    const ctx = makeContext({
+      employees: new Map([emp('emp-1', 'server', false, 40)]),
+      availability: makeAllWeekAvailability('emp-1'),
+      existingShifts: lockedShifts,
+    });
+    // 4 new candidates on Tue-Fri (Mon already locked).
+    const shifts = dailyShifts({
+      employee_id: 'emp-1',
+      end_time: '14:00:00', // 4h each
+      days: ['2026-06-09', '2026-06-10', '2026-06-11', '2026-06-12'],
+    });
+    const result = validateGeneratedShifts(shifts, ctx);
+
+    expect(result.valid).toHaveLength(4);
+    expect(result.dropped).toHaveLength(0);
+  });
+
+  it('overnight shift counts as one day, not two (4h hours, not 24h)', () => {
+    // 22:00-02:00 on Monday = 4h, NOT 24h. The shift's `day` field is the
+    // calendar day it nominally starts on; the validator must use the
+    // time-diff formula (with overnight handling), not (next-day - day).
+    const ctx = makeContext({
+      employees: new Map([emp('emp-1', 'server', false, 40)]),
+      availability: makeAllWeekAvailability('emp-1'),
+    });
+    // 9 overnight 4h shifts = 36h. If the validator wrongly counted
+    // each as 24h, we'd drop after the 2nd (48h > 40h).
+    const shifts = WEEK_DAYS.slice(0, 7).map((day) => ({
+      employee_id: 'emp-1',
+      template_id: 'tmpl-1',
+      day,
+      start_time: '22:00:00',
+      end_time: '02:00:00',
+      position: 'server',
+    }));
+    // 7 days at 4h = 28h. Should all fit under 40h. But 7 consecutive
+    // days violates Rule 12 → drop on day 6.
+    const result = validateGeneratedShifts(shifts, ctx);
+
+    // 5 accept (consecutive-day rule kicks in on day 6), 2 drop with
+    // CONSECUTIVE_DAYS_EXCEEDED — proves hour cap did NOT drop them
+    // (which would imply 24h-per-shift miscounting).
+    expect(result.valid).toHaveLength(5);
+    expect(result.dropped).toHaveLength(2);
+    expect(result.dropped.every((d) => d.code === 'CONSECUTIVE_DAYS_EXCEEDED')).toBe(true);
+  });
+
+  it('produces same valid set regardless of input order (sorted by day/start/employee/template)', () => {
+    // Bug I requires deterministic "first 5 wins" — sort key (day,
+    // start_time, employee_id, template_id) so re-runs on identical
+    // inputs produce identical output.
+    const ctx = makeContext({
+      employees: new Map([emp('emp-1', 'server', false, 40)]),
+      availability: makeAllWeekAvailability('emp-1'),
+    });
+    const shifts = dailyShifts({ employee_id: 'emp-1' }); // 7 × 6.5h = 45.5h
+    // Shuffle by reversing — should yield identical valid set after sort.
+    const reversed = [...shifts].reverse();
+
+    const r1 = validateGeneratedShifts(shifts, ctx);
+    const r2 = validateGeneratedShifts(reversed, ctx);
+
+    const days1 = r1.valid.map((s) => s.day).sort();
+    const days2 = r2.valid.map((s) => s.day).sort();
+    expect(days2).toEqual(days1);
+    expect(r1.valid).toHaveLength(6);
+    expect(r2.valid).toHaveLength(6);
+    expect(r1.dropped[0].code).toBe('HOURS_EXCEED_WEEKLY_CAP');
+    expect(r2.dropped[0].code).toBe('HOURS_EXCEED_WEEKLY_CAP');
+  });
+
+  it('counts consecutive days correctly across DST spring-forward (March 8 2026)', () => {
+    // Mar 2-8 2026; Mar 8 is the US DST spring-forward day. UTC-anchored
+    // math means the consecutive-day count is 7, not 6 (no false gap).
+    const dstWeek = [
+      '2026-03-02', '2026-03-03', '2026-03-04', '2026-03-05',
+      '2026-03-06', '2026-03-07', '2026-03-08',
+    ];
+    const ctx = makeContext({
+      employees: new Map([emp('emp-1', 'server', false, 40)]),
+      availability: makeAllWeekAvailability('emp-1'),
+    });
+    const shifts = dailyShifts({
+      employee_id: 'emp-1',
+      end_time: '14:00:00', // 4h each
+      days: dstWeek,
+    });
+    const result = validateGeneratedShifts(shifts, ctx);
+
+    // 5 accept Mon-Fri; 2 drop (Sat, Sun) with consecutive-days code.
+    // If DST created a false gap, we'd see 6 valid (no drop on Sat).
+    expect(result.valid).toHaveLength(5);
+    expect(result.dropped).toHaveLength(2);
+    expect(result.dropped.every((d) => d.code === 'CONSECUTIVE_DAYS_EXCEEDED')).toBe(true);
+  });
+});

--- a/tests/unit/schedulePromptBuilder.test.ts
+++ b/tests/unit/schedulePromptBuilder.test.ts
@@ -5,8 +5,8 @@ describe('buildSchedulePrompt with employment_type', () => {
   const baseContext: ScheduleContext = {
     weekStart: '2026-04-13',
     employees: [
-      { id: '1', name: 'Alice', position: 'Server', area: null, hourly_rate: 1500, employment_type: 'full_time' },
-      { id: '2', name: 'Bob', position: 'Cook', area: null, hourly_rate: 1800, employment_type: 'part_time' },
+      { id: '1', name: 'Alice', position: 'Server', area: null, hourly_rate: 1500, employment_type: 'full_time', is_minor: false, max_weekly_hours: 40 },
+      { id: '2', name: 'Bob', position: 'Cook', area: null, hourly_rate: 1800, employment_type: 'part_time', is_minor: false, max_weekly_hours: 40 },
     ],
     templates: [],
     availability: {},
@@ -24,12 +24,10 @@ describe('buildSchedulePrompt with employment_type', () => {
     expect(userMessage).toContain('"employment_type": "part_time"');
   });
 
-  it('includes FT/PT scheduling rule in system prompt', () => {
-    const result = buildSchedulePrompt(baseContext);
-    const systemMessage = result.messages[0].content;
-    expect(systemMessage).toContain('Full-time');
-    expect(systemMessage).toContain('Part-time');
-    expect(systemMessage).toContain('35-40 hours');
-    expect(systemMessage).toContain('15-25 hours');
-  });
+  // Bug I removed the soft 35-40h FT / 15-25h PT preference rule —
+  // it was the root cause of fulltimers getting scheduled over 40h while
+  // others got zero. Replaced by HARD Rule 11 (per-employee weekly cap)
+  // + Employee Hour Budgets section. Regression coverage for the new
+  // behavior lives in schedule-prompt-builder.test.ts under the
+  // "hour caps and consecutive days (Bug I)" describe block.
 });


### PR DESCRIPTION
## Summary

Fixes **Bug I**: the AI schedule generator was concentrating hours on a few fulltimers (over 40h/week, i.e. overtime) while leaving other employees with zero hours, and gave 14-15yo minors the same 40h cap as adults.

**Root cause**: the LLM Rule 11 was a soft preference (\"targeting 35-40 hours per week\") with no enforcement, so the LLM treated it as guidance rather than a constraint. Minors had no special handling at all.

**Fix** — three layers (defense in depth):

1. **Helper + schema** — `computeHourBudget` derives `{is_minor, max_weekly_hours}` from `date_of_birth` + `weekStart`. Adults & 16-17yo: 40h. Under-16: 18h (FLSA school-week, applied year-round as the conservative default). UTC-anchored age math with inclusive-birthday boundary, DST-safe.
2. **Prompt** — replace soft Rule 11 with new HARD Rule 11 (per-employee cap, never overtime, spread the pool), add HARD Rule 12 (≤5 consecutive days), renumber old Rule 12 → Rule 13, add HARD Rule 14 (under-16 18h cap). New `## Employee Hour Budgets` section in the user prompt surfaces every employee's cap + minor tag.
3. **Validator backstop** — two new steps drop over-cap candidates with new `HOURS_EXCEED_WEEKLY_CAP` / `MINOR_HOURS_EXCEEDED` / `CONSECUTIVE_DAYS_EXCEEDED` DropCodes, dispatched on `max_weekly_hours === 18` (NOT on `is_minor`) so 16-17yo minors fall through to the adult code path with factually-accurate labels. Locked over-cap shifts stay (state records reality); only new candidates are dropped.

## Behavior — verified end-to-end smoke

```
computeHourBudget('2010-06-08', '2026-06-08') → cap=40 (turns 16 ON weekStart, inclusive)
computeHourBudget('2010-06-09', '2026-06-08') → cap=18 (turns 16 day AFTER)
computeHourBudget('2009-01-01', '2026-06-08') → cap=40, is_minor=true (17yo)

## Employee Hour Budgets section renders:
- emp-1 (Maria): 40h/week max
- emp-3 (Ana):   18h/week max [minor, under 16]
- emp-4 (Sam):   40h/week max [minor]

Validator drops:
  MINOR_HOURS_EXCEEDED  → emp-3 (cap=18) on day 3 of 6.5h shifts (19.5h)
  CONSECUTIVE_DAYS_EXCEEDED → emp-1 on Sat after Mon-Fri+Sat (6 days straight)
```

## Test plan

- [x] `tests/unit/schedule-prompt-builder.test.ts` (Bug I describe block) — 7 new tests, all GREEN
- [x] `tests/unit/schedule-validator.test.ts` — 11 new hour-cap / consec-day / minor tests, all GREEN
- [x] `tests/unit/computeHourBudget` — DOB edge cases (null, future, leap, TZ-portable, inclusive birthday) GREEN
- [x] `tests/unit/schedulePromptBuilder.test.ts` — removed obsolete soft-Rule-11 assertion, baseContext patched for new required fields
- [x] Full unit suite: **4134 passed**, 1 skipped, 0 failed
- [x] `npm run typecheck` clean
- [x] `npm run lint` — zero new errors in touched files
- [x] `npm run build` succeeds
- [x] End-to-end smoke confirms prompt, helper, and validator all behave as designed

## Notes

- Minor dispatch is gated on `max_weekly_hours === 18` (the actual constraint), not `is_minor`. Keeps 16-17yo minors on the adult code path so labels stay factually accurate (\"weekly hour cap\" not \"minor cap\" for a 17yo at 40h).
- Validator step ordering: hour-cap runs **after** `DOUBLE_BOOKING` so double-booked shifts don't consume budget.
- Locked over-cap shifts are NEVER retroactively dropped — state seeds from `existingShifts` so reality is preserved; only fresh candidates that push further over cap drop.
- Sort by `(day, start_time, employee_id, template_id)` at validator entry makes results order-independent vs LLM output order.
- Birthday inclusive boundary documented in `computeHourBudget` JSDoc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-employee weekly hour budgets shown in the prompt and enforced
  * Maximum 5 consecutive scheduled workdays enforced
  * Special weekly cap for under-16 minors (≈18h/week)

* **Improvements**
  * Deterministic scheduling/validation and clearer dropped-shift diagnostics
  * Updated prompt rules to prefer employees with most remaining weekly budget

* **Tests**
  * Expanded unit tests covering budget, birthday boundaries, overnight/DST, and determinism

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toyiyo/nimble-pnl/pull/518?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->