### PR TITLE
feat(ai-chat): give AI access to time-punch data

### DIFF
--- a/docs/superpowers/plans/2026-05-24-ai-chat-time-punches-plan.md
+++ b/docs/superpowers/plans/2026-05-24-ai-chat-time-punches-plan.md
@@ -1,0 +1,635 @@
+# AI Chat: Time-Punch Access — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Spec:** `docs/superpowers/specs/2026-05-24-ai-chat-time-punches-design.md`
+**Branch:** `feature/ai-chat-time-punches`
+**Goal:** Let the AI chat answer "who worked X hours?" and "show the punches" without falling back to inventory tools. Reuses existing `parseWorkPeriods` / `calculateActualLaborCost` math; closes a pre-existing per-employee name leak in `executeGetLaborCosts`; adds a composite index to keep the new query patterns fast.
+
+**Architecture:**
+- A new shared helper `calculateHoursPerEmployee` in `supabase/functions/_shared/laborCalculations.ts` extracts the per-employee per-day hours rollup that `calculateActualLaborCost` already computes internally.
+- `executeGetLaborCosts` is enhanced to (a) populate per-employee `total_hours` / `total_cost_cents` / `days_worked` / `hours_per_day` when role ≥ manager, (b) return `employee_breakdown: null` for every lower role (closes the pre-existing name leak), and (c) narrow the `employees` projection from `select('*')` to explicit columns.
+- A new tool `get_time_punches` returns parsed work periods (one row per clock-in/clock-out pair, breaks deducted, joined to employee name/position) for the manager/owner roles only.
+- A new SQL migration adds `idx_time_punches_restaurant_punch_time` (composite on `restaurant_id, punch_time`) so both new code paths hit an index.
+- Dispatcher-level (`canUseTool`) and handler-level role rejections are unified on a single `TOOL_PERMISSION_DENIED` response shape.
+- The `ai-chat-stream` system prompt gets three new bullets pointing the LLM at the right tool and warning it off `get_inventory_transactions` for labor questions.
+
+**Tech Stack:** TypeScript, Deno (Supabase Edge Functions), Vitest, PostgreSQL.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `supabase/migrations/20260524120000_idx_time_punches_restaurant_punch_time.sql` | **NEW.** Adds composite index `idx_time_punches_restaurant_punch_time ON public.time_punches (restaurant_id, punch_time)`. |
+| `supabase/functions/_shared/laborCalculations.ts` | **MODIFY.** Add `EmployeeHoursSummary` type and `calculateHoursPerEmployee(employees, timePunches, startDate, endDate)`. Refactor `calculateActualLaborCost` to call it (no behaviour change to aggregate output). |
+| `supabase/functions/_shared/tools-registry.ts` | **MODIFY.** Update `get_labor_costs` description, add `get_time_punches` tool definition (manager+owner only), add `get_time_punches` to `canUseTool` allow-list. |
+| `supabase/functions/ai-execute-tool/index.ts` | **MODIFY.** Narrow `employees` projection; thread `userRole` into `executeGetLaborCosts`; populate per-employee fields when role ≥ manager and force `employee_breakdown: null` otherwise. Add `executeGetTimePunches` and wire into switch. Replace bare `throw` permission rejection with structured `TOOL_PERMISSION_DENIED` response. |
+| `supabase/functions/ai-chat-stream/index.ts` | **MODIFY.** Append three bullets to the system prompt directing the LLM to the new capability. |
+| `tests/unit/laborCalculations.calculateHoursPerEmployee.test.ts` | **NEW.** Pure-function unit tests for the new helper (UTC fixtures, 3 employees / 5 days, break handling, UTC-boundary case, no-punches case). |
+| `tests/unit/ai-tools-date-resolution.test.ts` | **MODIFY.** Add `get_time_punches` to the period-resolution coverage. |
+| `tests/unit/permissions.test.ts` | **MODIFY.** Add `get_time_punches` per-role table including all three collaborator roles; assert unified `TOOL_PERMISSION_DENIED` shape. |
+
+---
+
+## Task 1: Add the composite index migration
+
+**Spec section:** "File map" → migration row, "Architecture" → composite index note.
+
+**Files:**
+- Create: `supabase/migrations/20260524120000_idx_time_punches_restaurant_punch_time.sql`
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- Composite index on (restaurant_id, punch_time) to support the
+-- AI chat get_labor_costs / get_time_punches query pattern.
+-- The existing schema has separate idx_time_punches_restaurant and
+-- idx_time_punches_time, but both new code paths filter on
+-- restaurant_id AND a punch_time range, so a composite is meaningfully faster.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_time_punches_restaurant_punch_time
+  ON public.time_punches (restaurant_id, punch_time);
+```
+
+- [ ] **Step 2: Verify against local Supabase**
+
+```bash
+npm run db:reset   # applies migrations from a clean slate
+psql "$LOCAL_DB_URL" -c "\\d public.time_punches" | grep idx_time_punches_restaurant_punch_time
+```
+
+The grep must return a row. If the index name differs from the expected one, fix the migration before continuing.
+
+**Acceptance:** Migration applies cleanly on a reset DB, the index is present, the index name matches the expected one, and `npm run typecheck` still passes (no codegen drift).
+
+---
+
+## Task 2: Add `EmployeeHoursSummary` type + `calculateHoursPerEmployee` helper
+
+**Spec section:** "Shared helper: `calculateHoursPerEmployee`".
+
+**Files:**
+- Modify: `supabase/functions/_shared/laborCalculations.ts`
+
+- [ ] **Step 1: Add the type**
+
+Add near the existing `WorkPeriod` interface:
+
+```ts
+export interface EmployeeHoursSummary {
+  employee_id: string;
+  employee_name: string;
+  position: string | null;
+  compensation_type: CompensationType;
+  /** Sum of hours across the period, breaks excluded. */
+  total_hours: number;
+  /** Per-period total cost in cents.
+   *  Hourly: hourly_rate × hours per day (snapshot-aware via getEmployeeSnapshotForDate).
+   *  Salary / contractor / daily_rate: total for the period using existing distribution rules. */
+  total_cost_cents: number;
+  /** Distinct dates with hours > 0. */
+  days_worked: number;
+  /** 'YYYY-MM-DD' → hours that day (host-TZ formatDateLocal). */
+  hours_per_day: Record<string, number>;
+  /** Raw parseWorkPeriods output, breaks already split. */
+  work_periods: WorkPeriod[];
+}
+```
+
+- [ ] **Step 2: Add the function**
+
+Extract the per-employee rollup logic from `calculateActualLaborCost` into a pure helper. The function must:
+
+1. Iterate `employees`, building `EmployeeHoursSummary` rows whether or not the employee has punches (a zero-hour row preserves the "everyone shows up" guarantee the tests rely on).
+2. For each employee, group their punches and call `parseWorkPeriods(punches)` exactly once.
+3. For each non-break period, bucket hours under `formatDateLocal(new Date(period.startTime))` (same convention as the existing daily-cost map — critical for key alignment).
+4. Compute `total_cost_cents` per employee:
+   - Hourly: sum of `calculateEmployeeDailyCostForDate(employee, dateStr, hoursWorked)` per day.
+   - Daily rate: sum of `calculateEmployeeDailyCost(snapshot)` for each day with hours > 0.
+   - Salary / contractor: reuse the existing per-period distribution from `calculateSalaryForPeriod` / `calculateContractorPayForPeriod` (the same functions `distributeFixedCosts` calls), then divide by the number of active employees of that type so each row gets a meaningful per-employee number that sums back to the aggregate.
+
+```ts
+export function calculateHoursPerEmployee(
+  employees: Employee[],
+  timePunches: TimePunch[],
+  startDate: Date,
+  endDate: Date,
+): EmployeeHoursSummary[];
+```
+
+- [ ] **Step 3: Refactor `calculateActualLaborCost` to call the new helper**
+
+Replace the inline `punchesByEmployee` / `hoursPerEmployeePerDay` / `employeesActivePerDay` bookkeeping with a single `calculateHoursPerEmployee` call, then aggregate the daily totals from the helper's `hours_per_day` maps. The exposed return shape (`{ breakdown, dailyCosts }`) must remain byte-identical for the existing tests.
+
+- [ ] **Step 4: Sanity check**
+
+```bash
+npm run typecheck
+npm run test -- laborCalculations
+```
+
+Existing tests must still pass without modification.
+
+**Acceptance:** New helper exported, `calculateActualLaborCost` returns identical output for its existing test fixtures, `npm run typecheck` clean.
+
+---
+
+## Task 3: Unit-test `calculateHoursPerEmployee`
+
+**Spec section:** "Testing strategy" → tests/unit/laborCalculations.calculateHoursPerEmployee.test.ts.
+
+**Files:**
+- Create: `tests/unit/laborCalculations.calculateHoursPerEmployee.test.ts`
+
+- [ ] **Step 1: Write the test file**
+
+Use UTC fixtures (`new Date(Date.UTC(...))`) so CI (UTC) and local (PT) agree. Cover:
+
+| Case | Setup | Assertion |
+|---|---|---|
+| Hourly with breaks | 1 employee, clock_in → break_start → break_end → clock_out, breaks total 30 min | `total_hours` = work span minus 30 min; `hours_per_day` bucket equals `total_hours` |
+| Multiple days | 1 employee, 3 distinct dates of punches | `days_worked` = 3; sum of `hours_per_day` values equals `total_hours` |
+| Multiple employees | 3 employees, 5-day window | one summary row per employee, including any with zero punches |
+| UTC boundary | Punch `2026-05-16T00:30:00Z` → `2026-05-16T01:00:00Z` | `hours_per_day` key is `'2026-05-16'` (matches `formatDateLocal` daily-cost convention) |
+| Salary + contractor coexist with hourly | mixed comp types, all with punches | `total_cost_cents` for salary/contractor matches the aggregate's `breakdown.salary.cost` / `breakdown.contractor.cost` divided across active members |
+| No punches | 1 employee, empty punches array | row exists, `total_hours = 0`, `days_worked = 0`, `hours_per_day = {}` |
+
+- [ ] **Step 2: Run the tests**
+
+```bash
+npm run test -- laborCalculations.calculateHoursPerEmployee
+```
+
+**Acceptance:** All new tests pass; `npm run typecheck` clean.
+
+---
+
+## Task 4: Register the `get_time_punches` tool
+
+**Spec section:** "Tool: `get_time_punches`" + "Role gating".
+
+**Files:**
+- Modify: `supabase/functions/_shared/tools-registry.ts`
+
+- [ ] **Step 1: Add the tool definition**
+
+In the same place that `get_labor_costs` is declared, add the new tool object using the exact schema from the design doc (period enum without `quarter` / `year`, optional employee_id / position / min_hours / limit). Description verbatim:
+
+> List individual work periods (clock-in/clock-out pairs with computed hours) for a date range. Use this to answer 'who worked when' and to drill into specific shifts. Returns parsed work periods, not raw punch events. Manager+owner only.
+
+- [ ] **Step 2: Gate visibility**
+
+`getTools(projectRef, userRole)` must include `get_time_punches` **only** when `userRole` is `'manager'` or `'owner'`. All other roles (kiosk, staff, chef, collaborator_accountant, collaborator_inventory, collaborator_chef) must not see it in the LLM-facing tool list.
+
+- [ ] **Step 3: Update `canUseTool`**
+
+`canUseTool('get_time_punches', userRole)` returns `true` only for `'manager'` and `'owner'`, `false` for everything else.
+
+- [ ] **Step 4: Update `get_labor_costs` description**
+
+Append to the existing `get_labor_costs.description`: "Set `include_employee_breakdown: true` to get per-employee `total_hours`, `total_cost_cents`, `days_worked`, and `hours_per_day` (manager+owner only)."
+
+**Acceptance:** `npm run typecheck` clean; `getTools` includes the tool for manager/owner only; `canUseTool` table matches the spec.
+
+---
+
+## Task 5: Update `permissions.test.ts` for the new gate
+
+**Spec section:** "Testing strategy" → permissions.test.ts.
+
+**Files:**
+- Modify: `tests/unit/permissions.test.ts`
+
+- [ ] **Step 1: Extend the existing per-role allow/deny table** with `get_time_punches`:
+
+| Role | `get_time_punches` |
+|---|---|
+| `kiosk` | deny |
+| `staff` | deny |
+| `chef` | deny |
+| `collaborator_accountant` | deny |
+| `collaborator_inventory` | deny |
+| `collaborator_chef` | deny |
+| `manager` | allow |
+| `owner` | allow |
+
+- [ ] **Step 2: Add a unified-error-shape assertion**
+
+A separate test that invokes a `canUseTool` rejection and the in-handler rejection (mocked) and asserts both produce `{ code: 'TOOL_PERMISSION_DENIED', tool, required_role, message }`. If the handler-level path is not exercisable by a pure unit test (because it requires the dispatcher), assert the shape from a tiny in-file helper that builds the error object both paths share.
+
+- [ ] **Step 3: Run**
+
+```bash
+npm run test -- permissions
+```
+
+**Acceptance:** New rows pass; the unified shape assertion passes.
+
+---
+
+## Task 6: Implement `executeGetTimePunches`
+
+**Spec section:** "Tool: `get_time_punches`" → Response shape, "Data flow" → drill-down path.
+
+**Files:**
+- Modify: `supabase/functions/ai-execute-tool/index.ts`
+
+- [ ] **Step 1: Add the handler**
+
+```ts
+async function executeGetTimePunches(
+  args: any,
+  restaurantId: string,
+  supabase: any,
+  userRole: string,
+): Promise<any> {
+  // Defense-in-depth gate (dispatcher should already block, but never trust it):
+  if (userRole !== 'manager' && userRole !== 'owner') {
+    return {
+      ok: false,
+      error: {
+        code: 'TOOL_PERMISSION_DENIED',
+        message: 'get_time_punches requires manager or owner role',
+        tool: 'get_time_punches',
+        required_role: 'manager',
+      },
+    };
+  }
+
+  const { period, start_date, end_date, employee_id, position, min_hours = 0, limit = 50 } = args;
+  const effectiveLimit = Math.min(Math.max(1, Number(limit) || 50), 200);
+
+  const { calculateHoursPerEmployee } = await import('../_shared/laborCalculations.ts');
+  const { startDate, endDate, startDateStr, endDateStr } = calculateDateRange(period, start_date, end_date);
+
+  const [punchesResult, employeesResult] = await Promise.all([
+    supabase
+      .from('time_punches')
+      .select('id, employee_id, restaurant_id, punch_time, punch_type')
+      .eq('restaurant_id', restaurantId)
+      .gte('punch_time', startDate.toISOString())
+      .lte('punch_time', endDate.toISOString())
+      .order('punch_time', { ascending: true }),
+    supabase
+      .from('employees')
+      .select('id, name, position, compensation_type, hourly_rate, salary_cents, contractor_rate_cents, daily_rate_cents, is_active')
+      .eq('restaurant_id', restaurantId),
+  ]);
+
+  if (punchesResult.error) throw new Error(`Failed to fetch time punches: ${punchesResult.error.message}`);
+  if (employeesResult.error) throw new Error(`Failed to fetch employees: ${employeesResult.error.message}`);
+
+  const allEmployees = employeesResult.data ?? [];
+  const filteredEmployees = allEmployees.filter((e: any) =>
+    (!employee_id || e.id === employee_id) &&
+    (!position   || e.position === position)
+  );
+
+  const summaries = calculateHoursPerEmployee(
+    filteredEmployees,
+    punchesResult.data ?? [],
+    startDate,
+    endDate,
+  );
+
+  // Flatten work_periods → one row per period, joined to employee fields.
+  const rows = summaries.flatMap((s) =>
+    s.work_periods
+      .filter((p) => !p.isBreak && p.hours >= min_hours)
+      .map((p) => ({
+        employee_id:   s.employee_id,
+        employee_name: s.employee_name,
+        position:      s.position,
+        date:          formatDateLocal(new Date(p.startTime)),
+        start_time:    p.startTime.toISOString(),
+        end_time:      p.endTime.toISOString(),
+        hours:         Number(p.hours.toFixed(2)),
+        cost_cents:    s.compensation_type === 'hourly'
+          ? Math.round((p.hours / s.total_hours) * s.total_cost_cents) || 0
+          : null,
+      })),
+  );
+
+  rows.sort((a, b) => b.start_time.localeCompare(a.start_time));
+  const sliced = rows.slice(0, effectiveLimit);
+  const totalHours = Number(sliced.reduce((sum, r) => sum + r.hours, 0).toFixed(2));
+
+  return {
+    ok: true,
+    data: {
+      period,
+      start_date: startDateStr,
+      end_date:   endDateStr,
+      total_periods: sliced.length,
+      total_hours:   totalHours,
+      work_periods:  sliced,
+    },
+    evidence: [
+      {
+        table: 'time_punches',
+        summary: `${punchesResult.data?.length ?? 0} punches parsed into ${rows.length} work periods from ${startDateStr} to ${endDateStr}`,
+      },
+    ],
+  };
+}
+```
+
+Notes for the implementer:
+- The `cost_cents` math above prorates the per-employee total back to each period by hours-share. If `total_hours` is 0, `cost_cents` is 0 (won't happen for `hourly` once we filter out break-only periods, but defensive). For non-hourly rows it's explicitly `null` per the spec.
+- `formatDateLocal` is imported from `_shared/laborCalculations.ts`. If it isn't already exported, export it.
+
+- [ ] **Step 2: Wire into the switch**
+
+In the dispatch `switch (tool_name)` block, add:
+
+```ts
+case 'get_time_punches':
+  result = await executeGetTimePunches(args, restaurant_id, supabase, userRestaurant.role);
+  break;
+```
+
+- [ ] **Step 3: Typecheck**
+
+```bash
+npm run typecheck
+```
+
+**Acceptance:** Compiles; new case present; the dispatcher passes `userRestaurant.role` through.
+
+---
+
+## Task 7: Enhance `executeGetLaborCosts` + close the pre-existing leak
+
+**Spec section:** "Tool: `get_labor_costs`", "Pre-existing leak being closed in this PR", "`employees` query projection".
+
+**Files:**
+- Modify: `supabase/functions/ai-execute-tool/index.ts`
+
+- [ ] **Step 1: Thread `userRole` into the handler**
+
+Change the signature to:
+
+```ts
+async function executeGetLaborCosts(
+  args: any,
+  restaurantId: string,
+  supabase: any,
+  userRole: string,
+): Promise<any>
+```
+
+Update the dispatcher case:
+
+```ts
+case 'get_labor_costs':
+  result = await executeGetLaborCosts(args, restaurant_id, supabase, userRestaurant.role);
+  break;
+```
+
+- [ ] **Step 2: Narrow the `employees` projection**
+
+Replace `.select('*')` with:
+
+```ts
+.select('id, name, position, compensation_type, hourly_rate, salary_cents, contractor_rate_cents, daily_rate_cents, is_active, status')
+```
+
+(`status` is still needed for the existing active-filter on the breakdown.)
+
+- [ ] **Step 3: Populate per-employee fields for manager/owner**
+
+Replace the existing `employeeBreakdown` block:
+
+```ts
+const isManagerOrOwner = userRole === 'manager' || userRole === 'owner';
+const wantBreakdown = include_employee_breakdown && isManagerOrOwner;
+
+let employeeBreakdown: any[] | null;
+if (wantBreakdown) {
+  const { calculateHoursPerEmployee } = await import('../_shared/laborCalculations.ts');
+  const activeEmployees = employees.filter((e: any) => e.status === 'active');
+  const summaries = calculateHoursPerEmployee(activeEmployees, timePunches, startDate, endDate);
+  employeeBreakdown = summaries.map((s) => ({
+    employee_id:       s.employee_id,
+    employee_name:     s.employee_name,
+    position:          s.position,
+    compensation_type: s.compensation_type,
+    total_hours:       Number(s.total_hours.toFixed(2)),
+    total_cost_cents:  s.total_cost_cents,
+    days_worked:       s.days_worked,
+    hours_per_day:     s.hours_per_day,
+  }));
+} else {
+  employeeBreakdown = null;
+}
+```
+
+- [ ] **Step 4: Adjust the evidence row**
+
+Replace the current pair of evidence rows with exactly one row that adapts based on the gating decision:
+
+```ts
+const evidenceSummary =
+  include_employee_breakdown && !isManagerOrOwner
+    ? `${timePunches.length} time punches from ${startDateStr} to ${endDateStr}; per-employee breakdown role-restricted`
+    : `${timePunches.length} time punches from ${startDateStr} to ${endDateStr}`;
+// ...
+evidence: [
+  { table: 'time_punches', summary: evidenceSummary },
+],
+```
+
+(The previous code returned two rows — one for `time_punches`, one for `employees`. Keeping just the `time_punches` row keeps the evidence array stable for the LLM. If a downstream consumer reads the `employees` row, we'll re-evaluate, but no current consumer does.)
+
+- [ ] **Step 5: Confirm aggregate behaviour unchanged**
+
+```bash
+npm run typecheck
+npm run test -- laborCalculations   # via the existing aggregate tests
+```
+
+**Acceptance:** Manager/owner sees the new fields; staff/kiosk/chef/collaborator_* gets `employee_breakdown: null`; aggregate `breakdown` / `daily_costs` unchanged.
+
+---
+
+## Task 8: Unify the dispatcher's `TOOL_PERMISSION_DENIED` shape
+
+**Spec section:** "Role gating" → "Unified permission-denied shape".
+
+**Files:**
+- Modify: `supabase/functions/ai-execute-tool/index.ts`
+
+- [ ] **Step 1: Build the shared error builder**
+
+Add near the top of the dispatch handler:
+
+```ts
+function toolPermissionDeniedResponse(toolName: string, requiredRole: string) {
+  return {
+    ok: false,
+    error: {
+      code: 'TOOL_PERMISSION_DENIED',
+      message: `${toolName} requires ${requiredRole} or higher role`,
+      tool: toolName,
+      required_role: requiredRole,
+    },
+  };
+}
+```
+
+- [ ] **Step 2: Replace the dispatcher throw**
+
+Replace:
+
+```ts
+if (!canUseTool(tool_name, userRestaurant.role)) {
+  throw new Error(`Permission denied for tool: ${tool_name}`);
+}
+```
+
+with:
+
+```ts
+if (!canUseTool(tool_name, userRestaurant.role)) {
+  // Lookup the role required by this tool from the registry helper.
+  const requiredRole = requiredRoleFor(tool_name);  // new helper in tools-registry.ts, see Task 4 follow-up
+  return new Response(
+    JSON.stringify(toolPermissionDeniedResponse(tool_name, requiredRole)),
+    { status: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' } },
+  );
+}
+```
+
+The 200 status is intentional: the LLM is expected to read the JSON body, not the HTTP status. The pre-existing `TOOL_EXECUTION_ERROR` 500 fallback stays in place for real exceptions.
+
+- [ ] **Step 3: Export `requiredRoleFor` from tools-registry**
+
+Extend `_shared/tools-registry.ts` with a tiny helper that returns the lowest role that can use a given tool (`'manager'` for `get_time_punches`, `'staff'` for the broadly available ones, etc.). For tools that have no role requirement, return `'staff'` (the default minimum).
+
+- [ ] **Step 4: Update `executeGetTimePunches`** (already in place from Task 6) and any other handler-level rejection to use `toolPermissionDeniedResponse(...)`.
+
+**Acceptance:** Both rejection paths produce the same JSON shape; `permissions.test.ts` unified-shape assertion (Task 5) passes.
+
+---
+
+## Task 9: Update the AI system prompt
+
+**Spec section:** "System prompt addition".
+
+**Files:**
+- Modify: `supabase/functions/ai-chat-stream/index.ts`
+
+- [ ] **Step 1: Append the labor block**
+
+Find the existing labor-related guidance in the system-prompt string (the long template literal around lines 522-647 per the spec). After the existing labor bullets, insert:
+
+```
+LABOR / TIME PUNCH QUERIES (manager+owner):
+- "Who worked X hours this period?" / "Who worked on date Y?" → call get_labor_costs with include_employee_breakdown:true. Cite each named employee's total_hours from the response. If employee_breakdown is null, the user's role doesn't allow per-employee detail; answer with the aggregate only.
+- "Show me the punches on May 16" / "List shifts last week" → call get_time_punches with the date range. Each row is one work period (clock-in to clock-out, breaks deducted). If a row has cost_cents:null, the employee is salary/contractor/daily_rate — cite the aggregate from get_labor_costs for their pay.
+- Do NOT use get_inventory_transactions to answer questions about employee work — that table is about product movement, not labor.
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+npm run typecheck
+```
+
+**Acceptance:** New bullets present in the prompt; no syntax errors.
+
+---
+
+## Task 10: Extend `ai-tools-date-resolution.test.ts`
+
+**Spec section:** "Testing strategy" → ai-tools-date-resolution.test.ts.
+
+**Files:**
+- Modify: `tests/unit/ai-tools-date-resolution.test.ts`
+
+- [ ] **Step 1: Add `get_time_punches` to whatever existing matrix already covers `get_labor_costs`**
+
+For each value in the period enum (`today`, `yesterday`, `week`, `last_week`, `month`, `last_month`, `custom`), assert that `calculateDateRange` resolves the same way `get_labor_costs` does. The point is to lock the two tools to the same date semantics so the LLM can hand off between them without surprises.
+
+- [ ] **Step 2: Run**
+
+```bash
+npm run test -- ai-tools-date-resolution
+```
+
+**Acceptance:** New cases pass.
+
+---
+
+## Task 11: Phase 4 simplification pass
+
+After Tasks 1-10 land green, run:
+
+- [ ] `Agent` with `subagent_type: code-simplifier` on the worktree diff. Goal: remove duplication between `executeGetLaborCosts.employeeBreakdown` builder and `executeGetTimePunches.summaries` mapping if any emerged; fold any one-shot intermediate variables; confirm no comments contradict the code.
+- [ ] Re-run `npm run test`, `npm run typecheck`, `npm run lint`. All green.
+
+**Acceptance:** Simplifier returns either a clean diff or a small set of focused improvements; tests still pass.
+
+---
+
+## Task 12: Phase 7a parallel review
+
+- [ ] Spawn the four Phase 7a reviewers (`security-reviewer`, `sound-logic-reviewer`, `performance-reviewer`, `maintainability-reviewer`) in a single message against the current branch diff.
+- [ ] Spawn the codex adversarial reviewer in parallel via `dev-tools/codex-adversarial-review.sh`.
+- [ ] Triage findings: fix `critical` / `major` items in this PR; defer `minor` / `nit` with one-line rationale in the PR body.
+
+**Acceptance:** All five reviews complete; critical/major issues addressed or explicitly rejected with reasons.
+
+---
+
+## Task 13: Phase 7b CodeRabbit pre-PR review
+
+- [ ] Push the branch (no PR yet) and trigger a CodeRabbit review against the branch via the existing `/dev` workflow integration.
+- [ ] Address any blocking findings.
+
+**Acceptance:** CodeRabbit report clean or any blockers fixed.
+
+---
+
+## Task 14: Phase 8 local verify
+
+- [ ] `npm run typecheck`
+- [ ] `npm run lint`
+- [ ] `npm run test`
+- [ ] `npm run build`
+- [ ] Manual smoke: start `npm run dev:full`, sign in as manager in a test restaurant, open AI chat, ask:
+  - "Who worked this month?" → response cites named employees with hours, not "I can't link punches".
+  - "Show me the punches on <recent date with punches>" → response lists work periods with start/end times.
+- [ ] Sign in as a staff/kiosk account → ask the same questions:
+  - `get_time_punches` is not visible to the LLM (verify via the `tools-registry` debug or by absence of the call in network tab).
+  - `get_labor_costs` with `include_employee_breakdown:true` returns `null` for `employee_breakdown`.
+
+**Acceptance:** All four commands pass; manual smoke confirms the bug-report scenario is resolved and the leak is closed.
+
+---
+
+## Task 15: Phase 9 PR + CI loop + comment triage
+
+- [ ] Push the branch and open a PR titled `feat(ai-chat): per-employee labor + get_time_punches tool`.
+- [ ] PR body: link the spec, summarise the two surface changes (`get_labor_costs.employee_breakdown` enhancement; `get_time_punches` new tool), call out the index migration, call out the closed pre-existing name leak, and list the deferred minor reviewer notes with rationale.
+- [ ] Wait for CI. If anything fails, fix and push (NEW commits, never `--amend`).
+- [ ] **Mandatory Phase 9d:** Even if CI is green, run the inline-comments / issue-comments / PR-level-reviews fetches via `gh api repos/<owner>/<repo>/pulls/<n>/{comments,reviews,issue/comments}` and triage every item. CI green is not Done.
+
+**Acceptance:** PR is green, all review threads addressed, ready for merge by a human reviewer.
+
+---
+
+## Out of scope (explicitly)
+
+- E2E (Playwright) test for the AI chat tool round-trip.
+- MCP server (deferred — see spec "Decided trade-offs").
+- AI-driven punch editing / creation (write surface).
+- Moving the daily-bucket convention from host-TZ `formatDateLocal` to restaurant-TZ.
+- Adding `quarter` / `year` to the period enum.
+
+## Risk notes
+
+- **Per-employee cost math for salary / contractor.** The helper splits the period aggregate across active employees of that type. If the active-employee count differs from what `distributeFixedCosts` uses internally (e.g., status filter mismatch), the per-employee number won't exactly sum to the aggregate. Task 3's "Salary + contractor coexist" test must check this invariant explicitly. If it fails, the simpler fix is to expose `total_cost_cents: null` for salary/contractor on the breakdown (mirror the work-period rule) and have the LLM cite the aggregate instead.
+- **`select(*)` callers.** The `employees` projection narrowing in Task 7 could break code paths that rely on a column we dropped. Mitigation: only this function changes; the broader `useEmployees` hook uses its own select list. `npm run typecheck` + the existing aggregate test catch most issues.
+- **Index migration timing.** `CREATE INDEX CONCURRENTLY` cannot run inside a transaction. If the Supabase migration runner wraps each file in a transaction, switch to `CREATE INDEX IF NOT EXISTS` (non-concurrent). Worth a quick check with `supabase db push --dry-run` on Task 1.

--- a/docs/superpowers/specs/2026-05-24-ai-chat-time-punches-design.md
+++ b/docs/superpowers/specs/2026-05-24-ai-chat-time-punches-design.md
@@ -1,0 +1,283 @@
+# AI Chat: Time-Punch Access
+
+**Date:** 2026-05-24
+**Branch:** `feature/ai-chat-time-punches`
+**Status:** Design
+
+## Problem
+
+A user asked the in-app AI chat: "Who worked the 2.09 labor hours logged this month?" The AI returned the correct aggregate total but could not name specific employees. It then fell back to an unrelated tool (`get_inventory_transactions`) and surfaced an inventory event by employee UUID, confusing the conversation further. Verbatim quote from the chat transcript:
+
+> "However, this is related to inventory usage, not labor hours. It seems I'm unable to directly link specific time punches to employee names with the current tools."
+
+## Root cause
+
+The `get_labor_costs` tool (`supabase/functions/ai-execute-tool/index.ts` `executeGetLaborCosts`) already fetches `time_punches` and `employees` and computes per-employee hours per day *internally* via `calculateActualLaborCost` in `supabase/functions/_shared/laborCalculations.ts`. But the tool response only returns:
+
+- Aggregate `breakdown` per compensation type (hourly / salary / contractor / daily_rate)
+- `daily_costs` per day across all employees
+- `employee_breakdown` populated with just the *config* of active employees (id, name, position, compensation_type) — **no hours, no costs per employee**
+
+So the AI sees totals and a roster but cannot map punches → employees. There is also no tool that returns individual time-punch records joined to employee names.
+
+## Goals
+
+1. Let the AI answer "who worked X hours this period?" without hallucinating or falling back to wrong tools.
+2. Let the AI drill into individual shifts: "show me the actual punches on May 16–17."
+3. Restrict per-employee labor data to manager + owner roles (matches the existing `view:time_punches` capability gate).
+4. Reuse existing `parseWorkPeriods` / `calculateActualLaborCost` math — do not duplicate punch-parsing logic.
+5. Keep the fix small enough to ship in one PR.
+
+## Non-goals
+
+- An MCP server (Model Context Protocol). See **Decided trade-offs** below.
+- AI-driven punch editing / creation (write surface deferred).
+- Per-employee tip allocation (already lives in `get_tip_summary`).
+- Per-employee manual payments allocation (already in `get_payroll_summary`).
+- Raw-punch debug output (one row per `clock_in`/`clock_out`/`break_*`). The tool returns parsed work periods.
+
+## Approach
+
+Two small, composable changes:
+
+1. **Enhance `get_labor_costs.employee_breakdown`** — populate it with `total_hours`, `total_cost`, `days_worked`, `hours_per_day` per employee (manager+owner only). The aggregate response shape stays identical so existing tests are not broken at the top level.
+2. **Add `get_time_punches` tool** — returns parsed work periods (clock-in/clock-out pairs with computed hours and breaks deducted) joined to employee name/position, filterable by employee, position, date range, and minimum hours.
+
+Both rely on a new shared helper `calculateHoursPerEmployee` extracted from the existing `calculateActualLaborCost` logic. This keeps a single source of truth for punch parsing and per-day cost math.
+
+## Architecture
+
+### File map
+
+| File | Change |
+|---|---|
+| `supabase/functions/_shared/laborCalculations.ts` | Export `calculateHoursPerEmployee(employees, timePunches, startDate, endDate)`. Refactor `calculateActualLaborCost` to call it instead of inlining the per-employee map. |
+| `supabase/functions/_shared/tools-registry.ts` | Update `get_labor_costs` description; add `get_time_punches` tool definition (manager+owner only); add `get_time_punches` to `canUseTool` allow-list. |
+| `supabase/functions/ai-execute-tool/index.ts` | Populate per-employee fields in `executeGetLaborCosts` (role-gated). Add `executeGetTimePunches`. Wire into switch. |
+| `supabase/functions/ai-chat-stream/index.ts` | Append two bullet lines to the system prompt — point the LLM at the new capability so it stops falling back to inventory tools. |
+| `tests/unit/laborCalculations.calculateHoursPerEmployee.test.ts` | New unit test (UTC fixtures) covering mixed hourly/salary/break punches across 3 employees / 5 days. |
+| `tests/unit/ai-tools-date-resolution.test.ts` | Extend with `get_time_punches` period values. |
+| `tests/unit/permissions.test.ts` | Gate test for `get_time_punches` (kiosk/staff/chef→false, manager/owner→true). |
+
+### Tool: `get_labor_costs` (existing — minimal change)
+
+Top-level response shape unchanged. When `include_employee_breakdown=true` AND the user role is manager or owner, each row in `employee_breakdown` gets four new fields:
+
+```jsonc
+{
+  "employee_id": "uuid",
+  "employee_name": "Jose Delgado",
+  "position": "Manager",
+  "compensation_type": "salary",
+
+  // new fields:
+  "total_hours": 1.05,                  // sum of punch-derived hours in the period
+  "total_cost_cents": 1047,             // hourly: rate × hours; salary/contractor: pro-rated for days worked
+  "days_worked": 2,                     // count of distinct dates with hours > 0
+  "hours_per_day": { "2026-05-16": 0.55, "2026-05-17": 0.50 }
+}
+```
+
+For staff/kiosk/chef, `employee_breakdown` is `null` even when requested (current behavior is to return config rows; we tighten it to null to avoid leaking names). A new evidence row `{ table: 'time_punches', summary: '... per-employee breakdown role-restricted' }` is added when the role gates a fill.
+
+### Tool: `get_time_punches` (new)
+
+**Definition (manager+owner only):**
+
+```jsonc
+{
+  "name": "get_time_punches",
+  "description": "List individual work periods (clock-in/clock-out pairs with computed hours) for a date range. Use this to answer 'who worked when' and to drill into specific shifts. Returns parsed work periods, not raw punch events. Manager+owner only.",
+  "parameters": {
+    "type": "object",
+    "properties": {
+      "period": {
+        "type": "string",
+        "enum": ["today", "yesterday", "week", "last_week", "month", "last_month", "custom"]
+      },
+      "start_date": { "type": "string", "format": "date" },
+      "end_date":   { "type": "string", "format": "date" },
+      "employee_id": { "type": "string", "description": "Filter to one employee" },
+      "position":    { "type": "string", "description": "Filter to one position (e.g., 'Server')" },
+      "min_hours":   { "type": "number", "description": "Drop periods shorter than this (default 0)" },
+      "limit":       { "type": "integer", "description": "Max rows (default 50, max 200)", "default": 50 }
+    },
+    "required": ["period"]
+  }
+}
+```
+
+**Response shape:**
+
+```jsonc
+{
+  "ok": true,
+  "data": {
+    "period": "month",
+    "start_date": "2026-05-01",
+    "end_date":   "2026-05-31",
+    "total_periods": 2,
+    "total_hours":   1.05,
+    "work_periods": [
+      {
+        "employee_id":   "uuid",
+        "employee_name": "Jose Delgado",
+        "position":      "Manager",
+        "date":          "2026-05-16",
+        "start_time":    "2026-05-16T18:30:00.000Z",
+        "end_time":      "2026-05-16T19:03:00.000Z",
+        "hours":         0.55,
+        "cost_cents":    548
+      }
+      // … up to `limit` rows, sorted by start_time DESC
+    ]
+  },
+  "evidence": [
+    { "table": "time_punches", "summary": "N punches parsed into M work periods from <start> to <end>" }
+  ]
+}
+```
+
+### Shared helper: `calculateHoursPerEmployee`
+
+```ts
+export interface EmployeeHoursSummary {
+  employee_id: string;
+  employee_name: string;
+  position: string | null;
+  compensation_type: CompensationType;
+  total_hours: number;            // sum across the period
+  total_cost_cents: number;       // computed via existing per-day cost rules
+  days_worked: number;            // distinct dates with hours > 0
+  hours_per_day: Record<string, number>;  // 'YYYY-MM-DD' → hours
+  work_periods: WorkPeriod[];     // parseWorkPeriods output for the period
+}
+
+export function calculateHoursPerEmployee(
+  employees: Employee[],
+  timePunches: TimePunch[],
+  startDate: Date,
+  endDate: Date,
+): EmployeeHoursSummary[];
+```
+
+The existing `calculateActualLaborCost` is refactored to call this helper internally (single source of truth for `parseWorkPeriods` per employee and per-day hours aggregation). Aggregate output is unchanged.
+
+### System prompt addition
+
+Append to the existing prompt in `ai-chat-stream/index.ts` after the existing labor-related guidance:
+
+```
+LABOR / TIME PUNCH QUERIES (manager+owner):
+- "Who worked X hours this period?" / "Who worked on date Y?" → call get_labor_costs with include_employee_breakdown:true. Cite each named employee's total_hours from the response.
+- "Show me the punches on May 16" / "List shifts last week" → call get_time_punches with the date range. Each row is one work period (clock-in to clock-out, breaks deducted).
+- Do NOT use get_inventory_transactions to answer questions about employee work — that table is about product movement, not labor.
+```
+
+### Role gating
+
+| Tool / Field | kiosk | staff | chef | manager | owner |
+|---|---|---|---|---|---|
+| `get_labor_costs` aggregate | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `get_labor_costs.employee_breakdown` (per-employee hours) | ❌ (null) | ❌ (null) | ❌ (null) | ✅ | ✅ |
+| `get_time_punches` | ❌ (not in tool list) | ❌ | ❌ | ✅ | ✅ |
+
+Implementation: `getTools()` in `tools-registry.ts` only includes `get_time_punches` for manager/owner. `canUseTool` mirrors that. `executeGetLaborCosts` checks the user role (already loaded in the calling edge function) and nulls the per-employee fields when ungated. Role is passed into the executor as a new parameter.
+
+## Data flow
+
+```
+User: "Who worked the 2.09 hours this month?"
+  → ai-chat-stream
+  → LLM emits tool_call: get_labor_costs(period: 'month', include_employee_breakdown: true)
+  → ai-execute-tool
+    → executeGetLaborCosts
+      → fetch time_punches + employees in parallel (existing)
+      → calculateActualLaborCost (existing aggregate)
+      → calculateHoursPerEmployee (new: per-employee rollup)
+      → filter+strip per-employee fields if role < manager
+    → response with named hours
+  → LLM: "Jose Delgado (Manager): 1.05h on May 16-17; Alejandra Perez (Manager): 1.04h on May 17. Total 2.09h."
+```
+
+Drill-down path:
+
+```
+User: "Show me the actual punches"
+  → ai-chat-stream
+  → LLM emits tool_call: get_time_punches(period: 'month')
+  → executeGetTimePunches → calculateHoursPerEmployee → flatten work_periods → sort+limit
+  → response with named work periods
+```
+
+## Error handling
+
+Same patterns as existing handlers:
+- Date-resolution mirrors `calculateDateRange` (already covered by `ai-tools-date-resolution.test.ts`).
+- Empty result: `ok: true, data: { total_periods: 0, work_periods: [] }` — never invent rows.
+- Supabase query error: throw with table name + message (existing handler convention).
+- Role-gating violation (manager-only tool called via ungated path): handler returns `{ ok: false, error: { code: 'TOOL_PERMISSION_DENIED', message: '…' } }`.
+
+## Timezone discipline
+
+Lesson [2026-05-03]: `startOfWeek` / `startOfDay` are host-TZ-dependent. The existing `calculateActualLaborCost` already uses `formatDateLocal` (host TZ) for the daily bucket. We adopt the same convention in `calculateHoursPerEmployee` so the per-employee `hours_per_day` keys match `daily_costs[].date` exactly. Both `get_labor_costs` and `get_time_punches` therefore inherit the existing (known) TZ behaviour — a separate audit/PR can move both to restaurant-TZ if desired, but that is explicitly out of scope for this fix.
+
+Test fixtures use UTC anchors (`new Date(Date.UTC(...))`) so CI (UTC) and local (PT) agree.
+
+## Testing strategy
+
+### Unit tests (Vitest)
+
+1. **`tests/unit/laborCalculations.calculateHoursPerEmployee.test.ts` (new)**
+   - 3 employees, 5-day window, mixed compensation types (hourly, salary, contractor).
+   - Includes break punches (verify breaks are NOT counted in `total_hours`).
+   - Includes one employee with no punches (returns 0 hours, not omitted).
+   - Verifies `hours_per_day` keys match daily-cost keys.
+   - UTC fixtures (lesson 2026-05-03).
+
+2. **`tests/unit/ai-tools-date-resolution.test.ts` (extend)**
+   - Add period values for `get_time_punches`: today, yesterday, week, last_week, month, last_month, custom.
+
+3. **`tests/unit/permissions.test.ts` (extend)**
+   - Add `get_time_punches` to the per-role allow/deny table.
+
+### Manual smoke test (Phase 8)
+
+Use the existing local Supabase + edge-function dev stack:
+1. Sign in as manager (Russo's test restaurant).
+2. Open AI chat, ask "Who worked this month?" → response cites named employees with hours.
+3. Ask "Show me the punches on <date>" → response lists work periods with start/end times.
+4. Sign in as staff → confirm `get_time_punches` is not exposed and `employee_breakdown` returns null.
+
+### Out of scope for this PR
+
+- E2E (Playwright) test for the AI chat tool round-trip — the OpenRouter dependency makes it flaky; existing chat tests are similarly scoped.
+- pgTAP tests — no SQL schema changes.
+
+## Decided trade-offs
+
+### MCP server (rejected for this PR)
+
+Considered exposing the new capability via an MCP (Model Context Protocol) server instead of bespoke tools. Rejected because:
+
+- The in-app chat client (`ai-chat-stream`) calls OpenRouter, which speaks OpenAI function-calling schemas natively — not MCP. An MCP server in between would just be re-translated to the same JSON schema that `tools-registry.ts` already emits.
+- The current tools share an auth boundary with the data (Supabase JWT → RLS). An MCP server adds a second auth surface (per-restaurant PATs or OAuth scopes), which is more code, not less.
+- MCP's value is portability across LLM clients (Claude Desktop, Cursor, ChatGPT GPTs). For the embedded chat surface, that portability buys nothing.
+
+**Forward-compatibility:** The shared helper `calculateHoursPerEmployee` extracts the logic from the tool router, so a future MCP server would be: a small Deno HTTP service that implements `tools/list` + `tools/call`, wraps the same helper, and accepts per-restaurant PAT auth. None of that work is undone by shipping this fix first. A separate spec will be filed when the MCP product is prioritized.
+
+### Manager+owner gate (vs. all roles)
+
+Per-employee labor data is treated as PII-adjacent (matches the existing `view:time_punches` capability). Aggregate labor totals stay available to all roles — a kiosk asking "how much labor today?" still gets a number, just not names.
+
+### Work periods (vs. raw punches)
+
+Raw punches would let the LLM debug missing/duplicate clock-outs but require it to do the parsing itself. We've already paid the cost of building `parseWorkPeriods`; surfacing its output directly is more useful for the 95% case ("who worked when"). A future `include_raw_punches:true` flag can be added without breaking the work-period shape.
+
+### Two tools (vs. one big tool with flags)
+
+One tool with both aggregate + raw output would have a more complex response schema and force the LLM to choose between modes via flag. Two tools keeps each schema small, lets the LLM pick by name, and keeps tool descriptions tight (a known driver of correct tool selection across the multi-model fallback list).
+
+## Open questions
+
+None blocking. Future considerations captured in **Decided trade-offs**.

--- a/docs/superpowers/specs/2026-05-24-ai-chat-time-punches-design.md
+++ b/docs/superpowers/specs/2026-05-24-ai-chat-time-punches-design.md
@@ -182,7 +182,9 @@ LABOR / TIME PUNCH QUERIES (manager+owner):
 | `get_labor_costs.employee_breakdown` (per-employee hours) | ❌ (null) | ❌ (null) | ❌ (null) | ✅ | ✅ |
 | `get_time_punches` | ❌ (not in tool list) | ❌ | ❌ | ✅ | ✅ |
 
-Implementation: `getTools()` in `tools-registry.ts` only includes `get_time_punches` for manager/owner. `canUseTool` mirrors that. `executeGetLaborCosts` checks the user role (already loaded in the calling edge function) and nulls the per-employee fields when ungated. Role is passed into the executor as a new parameter.
+Implementation: `getTools()` in `tools-registry.ts` only includes `get_time_punches` for manager/owner, so the LLM never sees it for lower roles. `canUseTool` mirrors that and is already invoked at the dispatch site (`ai-execute-tool/index.ts:3435`), so any call to `get_time_punches` from a lower role returns "Permission denied" before reaching the handler.
+
+For `get_labor_costs` the tool itself stays open to all roles (aggregate totals are valuable to staff). The per-employee field stripping inside `executeGetLaborCosts` is a defense-in-depth second layer: the handler receives `userRestaurant.role` (a new parameter — already in scope at the dispatcher, just not currently plumbed into handlers) and returns `employee_breakdown: null` for any role below manager, even if `include_employee_breakdown:true` was requested.
 
 ## Data flow
 

--- a/docs/superpowers/specs/2026-05-24-ai-chat-time-punches-design.md
+++ b/docs/superpowers/specs/2026-05-24-ai-chat-time-punches-design.md
@@ -51,13 +51,18 @@ Both rely on a new shared helper `calculateHoursPerEmployee` extracted from the 
 
 | File | Change |
 |---|---|
+| `supabase/migrations/<ts>_idx_time_punches_restaurant_punch_time.sql` | **New.** `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_time_punches_restaurant_punch_time ON public.time_punches (restaurant_id, punch_time);` The existing schema has separate `idx_time_punches_restaurant` and `idx_time_punches_time` indexes but no composite, and both new code paths (`get_labor_costs` and `get_time_punches`) filter by `restaurant_id` + a `punch_time` range. Ship the index with the query that needs it. |
 | `supabase/functions/_shared/laborCalculations.ts` | Export `calculateHoursPerEmployee(employees, timePunches, startDate, endDate)`. Refactor `calculateActualLaborCost` to call it instead of inlining the per-employee map. |
 | `supabase/functions/_shared/tools-registry.ts` | Update `get_labor_costs` description; add `get_time_punches` tool definition (manager+owner only); add `get_time_punches` to `canUseTool` allow-list. |
-| `supabase/functions/ai-execute-tool/index.ts` | Populate per-employee fields in `executeGetLaborCosts` (role-gated). Add `executeGetTimePunches`. Wire into switch. |
+| `supabase/functions/ai-execute-tool/index.ts` | Populate per-employee fields in `executeGetLaborCosts` (role-gated — closes a pre-existing leak; see below). Add `executeGetTimePunches`. Wire into switch. Narrow the `employees` projection from `select('*')` to the explicit columns the helper needs. |
 | `supabase/functions/ai-chat-stream/index.ts` | Append two bullet lines to the system prompt — point the LLM at the new capability so it stops falling back to inventory tools. |
-| `tests/unit/laborCalculations.calculateHoursPerEmployee.test.ts` | New unit test (UTC fixtures) covering mixed hourly/salary/break punches across 3 employees / 5 days. |
+| `tests/unit/laborCalculations.calculateHoursPerEmployee.test.ts` | New unit test (UTC fixtures) covering mixed hourly/salary/break punches across 3 employees / 5 days, plus a UTC-boundary case (`2026-05-16T00:30:00Z` buckets to `2026-05-16`). |
 | `tests/unit/ai-tools-date-resolution.test.ts` | Extend with `get_time_punches` period values. |
-| `tests/unit/permissions.test.ts` | Gate test for `get_time_punches` (kiosk/staff/chef→false, manager/owner→true). |
+| `tests/unit/permissions.test.ts` | Gate test for `get_time_punches` covering kiosk / staff / chef / collaborator_accountant / collaborator_inventory / collaborator_chef → false, and manager / owner → true. |
+
+### Pre-existing leak being closed in this PR
+
+The current `executeGetLaborCosts` returns `employee_breakdown` (id, name, position, compensation_type — no hours) to **every** role when `include_employee_breakdown:true` is requested. That leaks employee names to staff / kiosk / chef and to all three collaborator roles. The reviewer flagged this as a live bug that must be patched in the same PR as the original gap fix; we are no longer relying on "role< manager → empty hours but config rows still visible." The new behaviour is `employee_breakdown: null` for any role below manager — config rows included.
 
 ### Tool: `get_labor_costs` (existing — minimal change)
 
@@ -78,7 +83,7 @@ Top-level response shape unchanged. When `include_employee_breakdown=true` AND t
 }
 ```
 
-For staff/kiosk/chef, `employee_breakdown` is `null` even when requested (current behavior is to return config rows; we tighten it to null to avoid leaking names). A new evidence row `{ table: 'time_punches', summary: '... per-employee breakdown role-restricted' }` is added when the role gates a fill.
+For staff / kiosk / chef / collaborator_accountant / collaborator_inventory / collaborator_chef, `employee_breakdown` is `null` even when requested (current behaviour leaks config rows; we tighten it to null — see "Pre-existing leak being closed in this PR" above). The evidence array always carries exactly one row for this tool; when the role caused per-employee fields to be stripped, the row's `summary` includes the phrase `per-employee breakdown role-restricted`. We do not conditionally append a second row.
 
 ### Tool: `get_time_punches` (new)
 
@@ -127,7 +132,7 @@ For staff/kiosk/chef, `employee_breakdown` is `null` even when requested (curren
         "start_time":    "2026-05-16T18:30:00.000Z",
         "end_time":      "2026-05-16T19:03:00.000Z",
         "hours":         0.55,
-        "cost_cents":    548
+        "cost_cents":    548     // null for non-hourly compensation_types — see below
       }
       // … up to `limit` rows, sorted by start_time DESC
     ]
@@ -137,6 +142,8 @@ For staff/kiosk/chef, `employee_breakdown` is `null` even when requested (curren
   ]
 }
 ```
+
+**`cost_cents` semantics:** Only meaningful for hourly compensation (`hourly_rate × hours`). For `salary`, `contractor`, and `daily_rate`, the per-period cost is not well-defined (salary is monthly-prorated; daily_rate is a flat day total regardless of hours), so `cost_cents` is `null` in those rows. The LLM is told (in the system prompt) to cite `get_labor_costs` for compensation totals when a row has a null `cost_cents`.
 
 ### Shared helper: `calculateHoursPerEmployee`
 
@@ -176,15 +183,41 @@ LABOR / TIME PUNCH QUERIES (manager+owner):
 
 ### Role gating
 
-| Tool / Field | kiosk | staff | chef | manager | owner |
-|---|---|---|---|---|---|
-| `get_labor_costs` aggregate | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `get_labor_costs.employee_breakdown` (per-employee hours) | ❌ (null) | ❌ (null) | ❌ (null) | ✅ | ✅ |
-| `get_time_punches` | ❌ (not in tool list) | ❌ | ❌ | ✅ | ✅ |
+| Tool / Field | kiosk | staff | chef | collab_accountant | collab_inventory | collab_chef | manager | owner |
+|---|---|---|---|---|---|---|---|---|
+| `get_labor_costs` aggregate | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `get_labor_costs.employee_breakdown` (per-employee hours) | ❌ (null) | ❌ (null) | ❌ (null) | ❌ (null) | ❌ (null) | ❌ (null) | ✅ | ✅ |
+| `get_time_punches` | ❌ (not in tool list) | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ |
 
 Implementation: `getTools()` in `tools-registry.ts` only includes `get_time_punches` for manager/owner, so the LLM never sees it for lower roles. `canUseTool` mirrors that and is already invoked at the dispatch site (`ai-execute-tool/index.ts:3435`), so any call to `get_time_punches` from a lower role returns "Permission denied" before reaching the handler.
 
 For `get_labor_costs` the tool itself stays open to all roles (aggregate totals are valuable to staff). The per-employee field stripping inside `executeGetLaborCosts` is a defense-in-depth second layer: the handler receives `userRestaurant.role` (a new parameter — already in scope at the dispatcher, just not currently plumbed into handlers) and returns `employee_breakdown: null` for any role below manager, even if `include_employee_breakdown:true` was requested.
+
+**Unified permission-denied shape.** Today the dispatcher's `canUseTool` rejection returns one shape and an in-handler rejection returns another. We standardise both on the dispatcher's existing shape so the LLM can recognise the failure mode consistently:
+
+```jsonc
+{
+  "ok": false,
+  "error": {
+    "code": "TOOL_PERMISSION_DENIED",
+    "message": "<tool_name> requires manager or owner role",
+    "tool": "<tool_name>",
+    "required_role": "manager"
+  }
+}
+```
+
+This applies to both the dispatcher-level rejection of `get_time_punches` for a low-role user and any defense-in-depth rejection inside handlers.
+
+### `employees` query projection
+
+The current `executeGetLaborCosts` runs `supabase.from('employees').select('*')` and then only uses a handful of columns. We narrow to exactly what the helper needs:
+
+```ts
+select('id, name, position, compensation_type, hourly_rate, salary_cents, contractor_rate_cents, daily_rate_cents, is_active')
+```
+
+This stays in scope of this PR because the new helper requires a stable, documented input shape — adding columns implicitly via `*` makes the contract fragile.
 
 ## Data flow
 
@@ -193,12 +226,17 @@ User: "Who worked the 2.09 hours this month?"
   → ai-chat-stream
   → LLM emits tool_call: get_labor_costs(period: 'month', include_employee_breakdown: true)
   → ai-execute-tool
-    → executeGetLaborCosts
-      → fetch time_punches + employees in parallel (existing)
+    → canUseTool('get_labor_costs', role)  // dispatcher gate — allows all roles
+    → executeGetLaborCosts(args, ..., role)
+      → fetch time_punches  (filter: restaurant_id + punch_time range
+                            → hits new composite idx_time_punches_restaurant_punch_time)
+      → fetch employees     (select 'id, name, position, compensation_type,
+                            hourly_rate, salary_cents, contractor_rate_cents,
+                            daily_rate_cents, is_active' — no SELECT *)
       → calculateActualLaborCost (existing aggregate)
       → calculateHoursPerEmployee (new: per-employee rollup)
-      → filter+strip per-employee fields if role < manager
-    → response with named hours
+      → if role < manager: employee_breakdown = null  // closes the pre-existing name leak
+    → response with named hours (or null breakdown for low roles)
   → LLM: "Jose Delgado (Manager): 1.05h on May 16-17; Alejandra Perez (Manager): 1.04h on May 17. Total 2.09h."
 ```
 
@@ -218,7 +256,7 @@ Same patterns as existing handlers:
 - Date-resolution mirrors `calculateDateRange` (already covered by `ai-tools-date-resolution.test.ts`).
 - Empty result: `ok: true, data: { total_periods: 0, work_periods: [] }` — never invent rows.
 - Supabase query error: throw with table name + message (existing handler convention).
-- Role-gating violation (manager-only tool called via ungated path): handler returns `{ ok: false, error: { code: 'TOOL_PERMISSION_DENIED', message: '…' } }`.
+- Role-gating violation: dispatcher and handler both return the unified `TOOL_PERMISSION_DENIED` shape described in **Role gating** above.
 
 ## Timezone discipline
 
@@ -235,6 +273,7 @@ Test fixtures use UTC anchors (`new Date(Date.UTC(...))`) so CI (UTC) and local 
    - Includes break punches (verify breaks are NOT counted in `total_hours`).
    - Includes one employee with no punches (returns 0 hours, not omitted).
    - Verifies `hours_per_day` keys match daily-cost keys.
+   - **UTC boundary case**: a punch with `punch_time = '2026-05-16T00:30:00Z'` and an early clock-out at `'2026-05-16T01:00:00Z'` must bucket to `'2026-05-16'` in `hours_per_day`, matching the existing daily-cost convention.
    - UTC fixtures (lesson 2026-05-03).
 
 2. **`tests/unit/ai-tools-date-resolution.test.ts` (extend)**
@@ -242,6 +281,8 @@ Test fixtures use UTC anchors (`new Date(Date.UTC(...))`) so CI (UTC) and local 
 
 3. **`tests/unit/permissions.test.ts` (extend)**
    - Add `get_time_punches` to the per-role allow/deny table.
+   - Cover the three collaborator roles (`collaborator_accountant`, `collaborator_inventory`, `collaborator_chef`) → all deny.
+   - Cover the dispatcher-level and handler-level rejection paths returning the same `TOOL_PERMISSION_DENIED` shape.
 
 ### Manual smoke test (Phase 8)
 
@@ -279,6 +320,10 @@ Raw punches would let the LLM debug missing/duplicate clock-outs but require it 
 ### Two tools (vs. one big tool with flags)
 
 One tool with both aggregate + raw output would have a more complex response schema and force the LLM to choose between modes via flag. Two tools keeps each schema small, lets the LLM pick by name, and keeps tool descriptions tight (a known driver of correct tool selection across the multi-model fallback list).
+
+### Period enum: no `quarter` / `year` (yet)
+
+The reviewer asked whether `get_time_punches` should accept `quarter` and `year`. Deferred: the same coverage is already reachable via `period: 'custom'` with explicit `start_date` / `end_date`, and the existing `get_labor_costs` enum doesn't carry those values either — adding them here without aligning the rest of the tool surface would create a one-off inconsistency. If a future workflow needs them often enough to justify the LLM hint, extend both tools together.
 
 ## Open questions
 

--- a/src/services/laborCalculations.ts
+++ b/src/services/laborCalculations.ts
@@ -718,17 +718,32 @@ export function calculateHoursPerEmployee(
       (p) => p.startTime >= startDate && p.startTime <= endDate,
     );
 
+    // hoursPerDay is keyed by the period's start day (matches
+    // calculateActualLaborCost's hoursPerEmployeePerDay). activeDays tracks
+    // every calendar day a period touches — used for daily_rate cost so an
+    // overnight period (start day → next day) is charged for both days, in
+    // parity with calculateActualLaborCost's employeesActivePerDay loop.
     const hoursPerDay: Record<string, number> = {};
+    const activeDays = new Set<string>();
     let totalHours = 0;
 
     periods.forEach((period) => {
       if (period.isBreak) return;
-      const day = formatDateUTC(new Date(period.startTime));
-      hoursPerDay[day] = (hoursPerDay[day] ?? 0) + period.hours;
+      const start = new Date(period.startTime);
+      const end = new Date(period.endTime);
+      const startDay = formatDateUTC(start);
+      hoursPerDay[startDay] = (hoursPerDay[startDay] ?? 0) + period.hours;
       totalHours += period.hours;
+
+      const dayCursor = new Date(start.getFullYear(), start.getMonth(), start.getDate());
+      const lastDay = new Date(end.getFullYear(), end.getMonth(), end.getDate());
+      while (dayCursor <= lastDay) {
+        activeDays.add(formatDateUTC(dayCursor));
+        dayCursor.setDate(dayCursor.getDate() + 1);
+      }
     });
 
-    const daysWorked = Object.values(hoursPerDay).filter((h) => h > 0).length;
+    const daysWorked = activeDays.size;
 
     let totalCostCents = 0;
     totalCostCents += calculateSalaryForPeriod(employee, startDate, endDate);
@@ -737,11 +752,15 @@ export function calculateHoursPerEmployee(
     for (const [day, hours] of Object.entries(hoursPerDay)) {
       if (hours <= 0) continue;
       const snapshot = getEmployeeSnapshotForDate(employee, day);
-      if (
-        snapshot.compensation_type === 'hourly' ||
-        snapshot.compensation_type === 'daily_rate'
-      ) {
+      if (snapshot.compensation_type === 'hourly') {
         totalCostCents += calculateEmployeeDailyCost(snapshot, hours);
+      }
+    }
+
+    for (const day of activeDays) {
+      const snapshot = getEmployeeSnapshotForDate(employee, day);
+      if (snapshot.compensation_type === 'daily_rate') {
+        totalCostCents += calculateEmployeeDailyCost(snapshot);
       }
     }
 

--- a/src/services/laborCalculations.ts
+++ b/src/services/laborCalculations.ts
@@ -117,6 +117,30 @@ export interface EmployeeLaborCost {
   hoursWorked?: number;
 }
 
+/**
+ * Per-employee hours/cost summary used by the AI chat tools
+ * (get_labor_costs.employee_breakdown and get_time_punches).
+ */
+export interface EmployeeHoursSummary {
+  employee_id: string;
+  employee_name: string;
+  position: string | null;
+  compensation_type: CompensationType;
+  /** Sum of work-period hours across [startDate, endDate]; breaks excluded. */
+  total_hours: number;
+  /** Total cost in cents for the period.
+   *  Hourly: sum of per-day calculateEmployeeDailyCostForDate(emp, day, hours).
+   *  Daily rate: per-day daily-rate × days with hours > 0.
+   *  Salary/contractor: existing per-period helpers (snapshot-aware). */
+  total_cost_cents: number;
+  /** Distinct dates with hours > 0. */
+  days_worked: number;
+  /** 'YYYY-MM-DD' → hours that day. Keys align with DailyLaborCost.date. */
+  hours_per_day: Record<string, number>;
+  /** parseWorkPeriods output for this employee (breaks split out). */
+  work_periods: import('@/utils/payrollCalculations').WorkPeriod[];
+}
+
 // ============================================================================
 // Core Calculation Functions
 // ============================================================================
@@ -644,6 +668,96 @@ export function calculateActualLaborCost(
   );
 
   return { breakdown, dailyCosts };
+}
+
+// ============================================================================
+// Per-employee Rollup (AI Chat: get_labor_costs.employee_breakdown,
+// get_time_punches)
+// ============================================================================
+
+/**
+ * Roll punches up per employee: total hours, per-day hours, cost, and the
+ * parsed work periods. Output is additive — one row per input employee, even
+ * if they have zero punches in the window (caller can filter).
+ *
+ * Cost rules mirror calculateActualLaborCost:
+ *   hourly      → sum of per-day calculateEmployeeDailyCostForDate
+ *   daily_rate  → per-day daily-rate × days with hours > 0
+ *   salary      → calculateSalaryForPeriod(employee, startDate, endDate)
+ *   contractor  → calculateContractorPayForPeriod(employee, startDate, endDate)
+ *
+ * Per-employee totals across the same comp type sum back to
+ * calculateActualLaborCost(...).breakdown.<type>.cost (× 100 cents).
+ */
+export function calculateHoursPerEmployee(
+  employees: Employee[],
+  timePunches: TimePunch[],
+  startDate: Date,
+  endDate: Date,
+): EmployeeHoursSummary[] {
+  const punchesByEmployee = new Map<string, TimePunch[]>();
+  timePunches.forEach((punch) => {
+    if (!punchesByEmployee.has(punch.employee_id)) {
+      punchesByEmployee.set(punch.employee_id, []);
+    }
+    punchesByEmployee.get(punch.employee_id)!.push(punch);
+  });
+
+  return employees.map((employee) => {
+    const punches = punchesByEmployee.get(employee.id) ?? [];
+    const { periods } = parseWorkPeriods(punches);
+
+    const hoursPerDay: Record<string, number> = {};
+    let totalHours = 0;
+
+    periods.forEach((period) => {
+      if (period.isBreak) return;
+      const day = formatDateUTC(new Date(period.startTime));
+      hoursPerDay[day] = (hoursPerDay[day] ?? 0) + period.hours;
+      totalHours += period.hours;
+    });
+
+    const daysWorked = Object.values(hoursPerDay).filter((h) => h > 0).length;
+
+    let totalCostCents = 0;
+    switch (employee.compensation_type) {
+      case 'hourly': {
+        for (const [day, hours] of Object.entries(hoursPerDay)) {
+          if (hours <= 0) continue;
+          totalCostCents += calculateEmployeeDailyCostForDate(employee, day, hours);
+        }
+        break;
+      }
+      case 'daily_rate': {
+        for (const [day, hours] of Object.entries(hoursPerDay)) {
+          if (hours <= 0) continue;
+          const snapshot = getEmployeeSnapshotForDate(employee, day);
+          totalCostCents += calculateEmployeeDailyCost(snapshot);
+        }
+        break;
+      }
+      case 'salary': {
+        totalCostCents = calculateSalaryForPeriod(employee, startDate, endDate);
+        break;
+      }
+      case 'contractor': {
+        totalCostCents = calculateContractorPayForPeriod(employee, startDate, endDate);
+        break;
+      }
+    }
+
+    return {
+      employee_id: employee.id,
+      employee_name: employee.name,
+      position: employee.position ?? null,
+      compensation_type: employee.compensation_type,
+      total_hours: totalHours,
+      total_cost_cents: totalCostCents,
+      days_worked: daysWorked,
+      hours_per_day: hoursPerDay,
+      work_periods: periods,
+    };
+  });
 }
 
 // ============================================================================

--- a/src/services/laborCalculations.ts
+++ b/src/services/laborCalculations.ts
@@ -680,11 +680,19 @@ export function calculateActualLaborCost(
  * parsed work periods. Output is additive — one row per input employee, even
  * if they have zero punches in the window (caller can filter).
  *
- * Cost rules mirror calculateActualLaborCost:
- *   hourly      → sum of per-day calculateEmployeeDailyCostForDate
- *   daily_rate  → per-day daily-rate × days with hours > 0
- *   salary      → calculateSalaryForPeriod(employee, startDate, endDate)
- *   contractor  → calculateContractorPayForPeriod(employee, startDate, endDate)
+ * Cost is computed via per-day snapshots so an employee whose
+ * compensation_type changed mid-window is billed correctly for each segment.
+ * The four buckets run unconditionally — each helper internally skips days
+ * where the snapshot doesn't match its type, so they never double-count:
+ *   - calculateSalaryForPeriod / calculateContractorPayForPeriod walk every
+ *     day in the window and only add on days resolving to that comp type
+ *   - per-day hourly + daily_rate via getEmployeeSnapshotForDate on each
+ *     worked day, gated by the snapshot's compensation_type
+ *
+ * Periods whose startTime falls outside [startDate, endDate] are dropped.
+ * Callers that fetch with an end-of-window lookahead (to catch shifts whose
+ * clock_out punch lands just after `endDate`) rely on this filter to drop
+ * any orphan periods whose clock_in lands in the lookahead zone.
  *
  * Per-employee totals across the same comp type sum back to
  * calculateActualLaborCost(...).breakdown.<type>.cost (× 100 cents).
@@ -705,7 +713,10 @@ export function calculateHoursPerEmployee(
 
   return employees.map((employee) => {
     const punches = punchesByEmployee.get(employee.id) ?? [];
-    const { periods } = parseWorkPeriods(punches);
+    const { periods: rawPeriods } = parseWorkPeriods(punches);
+    const periods = rawPeriods.filter(
+      (p) => p.startTime >= startDate && p.startTime <= endDate,
+    );
 
     const hoursPerDay: Record<string, number> = {};
     let totalHours = 0;
@@ -720,29 +731,17 @@ export function calculateHoursPerEmployee(
     const daysWorked = Object.values(hoursPerDay).filter((h) => h > 0).length;
 
     let totalCostCents = 0;
-    switch (employee.compensation_type) {
-      case 'hourly': {
-        for (const [day, hours] of Object.entries(hoursPerDay)) {
-          if (hours <= 0) continue;
-          totalCostCents += calculateEmployeeDailyCostForDate(employee, day, hours);
-        }
-        break;
-      }
-      case 'daily_rate': {
-        for (const [day, hours] of Object.entries(hoursPerDay)) {
-          if (hours <= 0) continue;
-          const snapshot = getEmployeeSnapshotForDate(employee, day);
-          totalCostCents += calculateEmployeeDailyCost(snapshot);
-        }
-        break;
-      }
-      case 'salary': {
-        totalCostCents = calculateSalaryForPeriod(employee, startDate, endDate);
-        break;
-      }
-      case 'contractor': {
-        totalCostCents = calculateContractorPayForPeriod(employee, startDate, endDate);
-        break;
+    totalCostCents += calculateSalaryForPeriod(employee, startDate, endDate);
+    totalCostCents += calculateContractorPayForPeriod(employee, startDate, endDate);
+
+    for (const [day, hours] of Object.entries(hoursPerDay)) {
+      if (hours <= 0) continue;
+      const snapshot = getEmployeeSnapshotForDate(employee, day);
+      if (
+        snapshot.compensation_type === 'hourly' ||
+        snapshot.compensation_type === 'daily_rate'
+      ) {
+        totalCostCents += calculateEmployeeDailyCost(snapshot, hours);
       }
     }
 

--- a/supabase/functions/_shared/laborCalculations.ts
+++ b/supabase/functions/_shared/laborCalculations.ts
@@ -135,7 +135,7 @@ const MAX_SHIFT_GAP_HOURS = 18;
 // Helper Functions
 // ============================================================================
 
-function formatDateLocal(date: Date): string {
+export function formatDateLocal(date: Date): string {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, '0');
   const day = String(date.getDate()).padStart(2, '0');
@@ -641,11 +641,19 @@ export function calculateActualLaborCost(
  * parsed work periods. Output is additive — one row per input employee, even
  * if they have zero punches in the window (caller can filter).
  *
- * Cost rules mirror calculateActualLaborCost:
- *   hourly      → sum of per-day calculateEmployeeDailyCostForDate
- *   daily_rate  → per-day daily-rate × days with hours > 0
- *   salary      → calculateSalaryForPeriod(employee, startDate, endDate)
- *   contractor  → calculateContractorPayForPeriod(employee, startDate, endDate)
+ * Cost is computed via per-day snapshots so an employee whose
+ * compensation_type changed mid-window is billed correctly for each segment.
+ * The four buckets run unconditionally — each helper internally skips days
+ * where the snapshot doesn't match its type, so they never double-count:
+ *   - calculateSalaryForPeriod / calculateContractorPayForPeriod walk every
+ *     day in the window and only add on days resolving to that comp type
+ *   - per-day hourly + daily_rate via getEmployeeSnapshotForDate on each
+ *     worked day, gated by the snapshot's compensation_type
+ *
+ * Periods whose startTime falls outside [startDate, endDate] are dropped.
+ * Callers that fetch with an end-of-window lookahead (to catch shifts whose
+ * clock_out punch lands just after `endDate`) rely on this filter to drop
+ * any orphan periods whose clock_in lands in the lookahead zone.
  *
  * Per-employee totals across the same comp type sum back to
  * calculateActualLaborCost(...).breakdown.<type>.cost (× 100 cents).
@@ -666,7 +674,10 @@ export function calculateHoursPerEmployee(
 
   return employees.map((employee) => {
     const punches = punchesByEmployee.get(employee.id) ?? [];
-    const { periods } = parseWorkPeriods(punches);
+    const { periods: rawPeriods } = parseWorkPeriods(punches);
+    const periods = rawPeriods.filter(
+      (p) => p.startTime >= startDate && p.startTime <= endDate,
+    );
 
     const hoursPerDay: Record<string, number> = {};
     let totalHours = 0;
@@ -681,29 +692,17 @@ export function calculateHoursPerEmployee(
     const daysWorked = Object.values(hoursPerDay).filter((h) => h > 0).length;
 
     let totalCostCents = 0;
-    switch (employee.compensation_type) {
-      case 'hourly': {
-        for (const [day, hours] of Object.entries(hoursPerDay)) {
-          if (hours <= 0) continue;
-          totalCostCents += calculateEmployeeDailyCostForDate(employee, day, hours);
-        }
-        break;
-      }
-      case 'daily_rate': {
-        for (const [day, hours] of Object.entries(hoursPerDay)) {
-          if (hours <= 0) continue;
-          const snapshot = getEmployeeSnapshotForDate(employee, day);
-          totalCostCents += calculateEmployeeDailyCost(snapshot);
-        }
-        break;
-      }
-      case 'salary': {
-        totalCostCents = calculateSalaryForPeriod(employee, startDate, endDate);
-        break;
-      }
-      case 'contractor': {
-        totalCostCents = calculateContractorPayForPeriod(employee, startDate, endDate);
-        break;
+    totalCostCents += calculateSalaryForPeriod(employee, startDate, endDate);
+    totalCostCents += calculateContractorPayForPeriod(employee, startDate, endDate);
+
+    for (const [day, hours] of Object.entries(hoursPerDay)) {
+      if (hours <= 0) continue;
+      const snapshot = getEmployeeSnapshotForDate(employee, day);
+      if (
+        snapshot.compensation_type === 'hourly' ||
+        snapshot.compensation_type === 'daily_rate'
+      ) {
+        totalCostCents += calculateEmployeeDailyCost(snapshot, hours);
       }
     }
 

--- a/supabase/functions/_shared/laborCalculations.ts
+++ b/supabase/functions/_shared/laborCalculations.ts
@@ -679,17 +679,32 @@ export function calculateHoursPerEmployee(
       (p) => p.startTime >= startDate && p.startTime <= endDate,
     );
 
+    // hoursPerDay is keyed by the period's start day (matches
+    // calculateActualLaborCost's hoursPerEmployeePerDay). activeDays tracks
+    // every calendar day a period touches — used for daily_rate cost so an
+    // overnight period (start day → next day) is charged for both days, in
+    // parity with calculateActualLaborCost's employeesActivePerDay loop.
     const hoursPerDay: Record<string, number> = {};
+    const activeDays = new Set<string>();
     let totalHours = 0;
 
     periods.forEach((period) => {
       if (period.isBreak) return;
-      const day = formatDateLocal(new Date(period.startTime));
-      hoursPerDay[day] = (hoursPerDay[day] ?? 0) + period.hours;
+      const start = new Date(period.startTime);
+      const end = new Date(period.endTime);
+      const startDay = formatDateLocal(start);
+      hoursPerDay[startDay] = (hoursPerDay[startDay] ?? 0) + period.hours;
       totalHours += period.hours;
+
+      const dayCursor = new Date(start.getFullYear(), start.getMonth(), start.getDate());
+      const lastDay = new Date(end.getFullYear(), end.getMonth(), end.getDate());
+      while (dayCursor <= lastDay) {
+        activeDays.add(formatDateLocal(dayCursor));
+        dayCursor.setDate(dayCursor.getDate() + 1);
+      }
     });
 
-    const daysWorked = Object.values(hoursPerDay).filter((h) => h > 0).length;
+    const daysWorked = activeDays.size;
 
     let totalCostCents = 0;
     totalCostCents += calculateSalaryForPeriod(employee, startDate, endDate);
@@ -698,11 +713,15 @@ export function calculateHoursPerEmployee(
     for (const [day, hours] of Object.entries(hoursPerDay)) {
       if (hours <= 0) continue;
       const snapshot = getEmployeeSnapshotForDate(employee, day);
-      if (
-        snapshot.compensation_type === 'hourly' ||
-        snapshot.compensation_type === 'daily_rate'
-      ) {
+      if (snapshot.compensation_type === 'hourly') {
         totalCostCents += calculateEmployeeDailyCost(snapshot, hours);
+      }
+    }
+
+    for (const day of activeDays) {
+      const snapshot = getEmployeeSnapshotForDate(employee, day);
+      if (snapshot.compensation_type === 'daily_rate') {
+        totalCostCents += calculateEmployeeDailyCost(snapshot);
       }
     }
 

--- a/supabase/functions/_shared/laborCalculations.ts
+++ b/supabase/functions/_shared/laborCalculations.ts
@@ -94,6 +94,22 @@ export interface WorkPeriod {
   isBreak: boolean;
 }
 
+/**
+ * Per-employee hours/cost summary used by the AI chat tools
+ * (get_labor_costs.employee_breakdown and get_time_punches).
+ */
+export interface EmployeeHoursSummary {
+  employee_id: string;
+  employee_name: string;
+  position: string | null;
+  compensation_type: CompensationType;
+  total_hours: number;
+  total_cost_cents: number;
+  days_worked: number;
+  hours_per_day: Record<string, number>;
+  work_periods: WorkPeriod[];
+}
+
 // ============================================================================
 // Constants
 // ============================================================================
@@ -613,6 +629,96 @@ export function calculateActualLaborCost(
   };
 
   return { breakdown, dailyCosts };
+}
+
+// ============================================================================
+// Per-employee Rollup (AI Chat: get_labor_costs.employee_breakdown,
+// get_time_punches)
+// ============================================================================
+
+/**
+ * Roll punches up per employee: total hours, per-day hours, cost, and the
+ * parsed work periods. Output is additive — one row per input employee, even
+ * if they have zero punches in the window (caller can filter).
+ *
+ * Cost rules mirror calculateActualLaborCost:
+ *   hourly      → sum of per-day calculateEmployeeDailyCostForDate
+ *   daily_rate  → per-day daily-rate × days with hours > 0
+ *   salary      → calculateSalaryForPeriod(employee, startDate, endDate)
+ *   contractor  → calculateContractorPayForPeriod(employee, startDate, endDate)
+ *
+ * Per-employee totals across the same comp type sum back to
+ * calculateActualLaborCost(...).breakdown.<type>.cost (× 100 cents).
+ */
+export function calculateHoursPerEmployee(
+  employees: Employee[],
+  timePunches: TimePunch[],
+  startDate: Date,
+  endDate: Date,
+): EmployeeHoursSummary[] {
+  const punchesByEmployee = new Map<string, TimePunch[]>();
+  timePunches.forEach((punch) => {
+    if (!punchesByEmployee.has(punch.employee_id)) {
+      punchesByEmployee.set(punch.employee_id, []);
+    }
+    punchesByEmployee.get(punch.employee_id)!.push(punch);
+  });
+
+  return employees.map((employee) => {
+    const punches = punchesByEmployee.get(employee.id) ?? [];
+    const { periods } = parseWorkPeriods(punches);
+
+    const hoursPerDay: Record<string, number> = {};
+    let totalHours = 0;
+
+    periods.forEach((period) => {
+      if (period.isBreak) return;
+      const day = formatDateLocal(new Date(period.startTime));
+      hoursPerDay[day] = (hoursPerDay[day] ?? 0) + period.hours;
+      totalHours += period.hours;
+    });
+
+    const daysWorked = Object.values(hoursPerDay).filter((h) => h > 0).length;
+
+    let totalCostCents = 0;
+    switch (employee.compensation_type) {
+      case 'hourly': {
+        for (const [day, hours] of Object.entries(hoursPerDay)) {
+          if (hours <= 0) continue;
+          totalCostCents += calculateEmployeeDailyCostForDate(employee, day, hours);
+        }
+        break;
+      }
+      case 'daily_rate': {
+        for (const [day, hours] of Object.entries(hoursPerDay)) {
+          if (hours <= 0) continue;
+          const snapshot = getEmployeeSnapshotForDate(employee, day);
+          totalCostCents += calculateEmployeeDailyCost(snapshot);
+        }
+        break;
+      }
+      case 'salary': {
+        totalCostCents = calculateSalaryForPeriod(employee, startDate, endDate);
+        break;
+      }
+      case 'contractor': {
+        totalCostCents = calculateContractorPayForPeriod(employee, startDate, endDate);
+        break;
+      }
+    }
+
+    return {
+      employee_id: employee.id,
+      employee_name: employee.name,
+      position: employee.position ?? null,
+      compensation_type: employee.compensation_type,
+      total_hours: totalHours,
+      total_cost_cents: totalCostCents,
+      days_worked: daysWorked,
+      hours_per_day: hoursPerDay,
+      work_periods: periods,
+    };
+  });
 }
 
 /**

--- a/supabase/functions/_shared/tools-registry.ts
+++ b/supabase/functions/_shared/tools-registry.ts
@@ -919,12 +919,9 @@ export function canUseTool(toolName: string, userRole: string): boolean {
 /**
  * Returns the lowest role that can use a given tool.
  * Used to build the TOOL_PERMISSION_DENIED error response.
+ * Delegates to canUseTool so the two stay in sync automatically.
  */
 export function requiredRoleFor(toolName: string): 'staff' | 'manager' | 'owner' {
-  if (toolName === 'get_ai_insights') return 'owner';
-
-  // Mirror managerOwnerTools list above; if the tool isn't in basicTools,
-  // it requires manager.
   if (canUseTool(toolName, 'staff')) return 'staff';
   if (canUseTool(toolName, 'manager')) return 'manager';
   return 'owner';

--- a/supabase/functions/_shared/tools-registry.ts
+++ b/supabase/functions/_shared/tools-registry.ts
@@ -236,7 +236,7 @@ export function getTools(restaurantId: string, userRole: string = 'viewer'): Too
     // Labor cost analysis - available to all users
     {
       name: 'get_labor_costs',
-      description: 'Get labor cost breakdown by compensation type (hourly, salary, contractor, daily_rate). Shows daily costs, total hours worked, and optional employee-level breakdown. Uses time punches + employee configs for accurate calculations.',
+      description: 'Get labor cost breakdown by compensation type (hourly, salary, contractor, daily_rate). Shows daily costs, total hours worked, and optional employee-level breakdown. Uses time punches + employee configs for accurate calculations. Set include_employee_breakdown:true to get per-employee total_hours, total_cost_cents, days_worked, and hours_per_day (manager+owner only; null for other roles).',
       parameters: {
         type: 'object',
         properties: {
@@ -376,6 +376,49 @@ export function getTools(restaurantId: string, userRole: string = 'viewer'): Too
             }
           },
           required: ['analysis_type', 'start_date', 'end_date']
+        }
+      },
+      {
+        name: 'get_time_punches',
+        description: "List individual work periods (clock-in/clock-out pairs with computed hours and breaks deducted) for a date range. Use this to answer 'who worked when' and to drill into specific shifts. Returns parsed work periods (one row per shift), joined to employee name/position. Manager+owner only.",
+        parameters: {
+          type: 'object',
+          properties: {
+            period: {
+              type: 'string',
+              enum: ['today', 'yesterday', 'week', 'last_week', 'month', 'last_month', 'custom'],
+              description: 'The time period for work periods'
+            },
+            start_date: {
+              type: 'string',
+              format: 'date',
+              description: 'Start date for custom period (YYYY-MM-DD)'
+            },
+            end_date: {
+              type: 'string',
+              format: 'date',
+              description: 'End date for custom period (YYYY-MM-DD)'
+            },
+            employee_id: {
+              type: 'string',
+              description: 'Filter to one employee by UUID'
+            },
+            position: {
+              type: 'string',
+              description: "Filter to one position (e.g., 'Server')"
+            },
+            min_hours: {
+              type: 'number',
+              description: 'Drop periods shorter than this (default 0)',
+              default: 0
+            },
+            limit: {
+              type: 'integer',
+              description: 'Max rows returned (default 50, max 200)',
+              default: 50
+            }
+          },
+          required: ['period']
         }
       },
       {
@@ -848,6 +891,7 @@ export function canUseTool(toolName: string, userRole: string): boolean {
     'get_financial_statement',
     'generate_report',
     'get_payroll_summary',              // Payroll details - manager+
+    'get_time_punches',                 // Per-shift work periods - manager+
     'get_tip_summary',                  // Tip pooling details - manager+
     'get_pending_outflows',             // Uncommitted expenses - manager+
     'get_operating_costs',              // Operating cost breakdown - manager+
@@ -870,4 +914,18 @@ export function canUseTool(toolName: string, userRole: string): boolean {
   }
 
   return false;
+}
+
+/**
+ * Returns the lowest role that can use a given tool.
+ * Used to build the TOOL_PERMISSION_DENIED error response.
+ */
+export function requiredRoleFor(toolName: string): 'staff' | 'manager' | 'owner' {
+  if (toolName === 'get_ai_insights') return 'owner';
+
+  // Mirror managerOwnerTools list above; if the tool isn't in basicTools,
+  // it requires manager.
+  if (canUseTool(toolName, 'staff')) return 'staff';
+  if (canUseTool(toolName, 'manager')) return 'manager';
+  return 'owner';
 }

--- a/supabase/functions/ai-chat-stream/index.ts
+++ b/supabase/functions/ai-chat-stream/index.ts
@@ -644,6 +644,19 @@ Tool Usage Guidelines:
      * IMPORTANT: Present the report data inline using markdown tables and formatting
      * Example: "Generate monthly P&L" → use type: 'monthly_pnl', then format the returned data as a table
 
+5. Labor & Time Punches:
+   - **get_labor_costs: REQUIRED for labor cost questions (aggregate totals available to all roles)**
+     * For per-employee detail (hours, cost, days worked) pass include_employee_breakdown: true. The employee_breakdown field is populated for manager/owner callers and null for everyone else.
+     * Example: "What's my labor cost this week?" → get_labor_costs with period: "week"
+     * Example: "Who worked the most hours last week?" → get_labor_costs with period: "last_week", include_employee_breakdown: true, then sort employee_breakdown by total_hours
+   - **get_time_punches (manager+owner only): REQUIRED to answer "who worked when" or to drill into specific shifts**
+     * Returns one row per work period (clock-in/out pair) with hours and breaks deducted, joined to employee name/position.
+     * Filter by employee_id, position, or min_hours when the user asks about a specific person, role, or full shifts only.
+     * cost_cents is populated for hourly employees (proportional share of period total) and null for salary/contractor/daily_rate (cost is period-allocated, not hours-allocated).
+     * Example: "Show me Maria's shifts last week" → get_time_punches with period: "last_week", employee_id: <Maria's id>
+     * Example: "Which servers worked yesterday?" → get_time_punches with period: "yesterday", position: "Server"
+     * If a tool call returns error code TOOL_PERMISSION_DENIED, tell the user which role is required (from required_role) — do NOT retry the same tool.
+
 🔴 REMEMBER: ANY question about numbers, data, or restaurant operations REQUIRES a tool call. NEVER make up data, even if it seems plausible. Real restaurants depend on accurate data.`,
     };
 

--- a/supabase/functions/ai-execute-tool/index.ts
+++ b/supabase/functions/ai-execute-tool/index.ts
@@ -1917,6 +1917,10 @@ async function fetchLaborData(
     .select(EMPLOYEE_LABOR_COLUMNS)
     .eq('restaurant_id', restaurantId);
 
+  if (employeeId) {
+    employeeQuery = employeeQuery.eq('id', employeeId);
+  }
+
   if (position) {
     employeeQuery = employeeQuery.ilike('position', position);
   }

--- a/supabase/functions/ai-execute-tool/index.ts
+++ b/supabase/functions/ai-execute-tool/index.ts
@@ -2,7 +2,7 @@ import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { corsHeaders } from "../_shared/cors.ts";
-import { canUseTool } from "../_shared/tools-registry.ts";
+import { canUseTool, requiredRoleFor } from "../_shared/tools-registry.ts";
 import { MODELS } from "../_shared/model-router.ts";
 import { 
   fetchInventoryTransactions,
@@ -1851,15 +1851,28 @@ async function executeGenerateReport(
  * Execute get_labor_costs tool
  * Uses same calculation logic as Dashboard (time_punches + employees)
  */
+// Columns required by the labor calculators. Narrowed projection — name and
+// position are PII; we still need them so `calculateHoursPerEmployee` can build
+// the per-employee breakdown for manager/owner callers, but we strip them
+// before returning if the caller isn't allowed to see employee identities.
+const EMPLOYEE_LABOR_COLUMNS =
+  'id, name, position, status, restaurant_id, compensation_type, ' +
+  'hourly_rate, salary_amount, pay_period_type, ' +
+  'contractor_payment_amount, contractor_payment_interval, ' +
+  'daily_rate_amount, hire_date, termination_date, compensation_history';
+
 async function executeGetLaborCosts(
   args: any,
   restaurantId: string,
-  supabase: any
+  supabase: any,
+  userRole: string
 ): Promise<any> {
   const { period, start_date, end_date, include_daily_breakdown = true, include_employee_breakdown = false } = args;
 
-  const { calculateActualLaborCost } = await import('../_shared/laborCalculations.ts');
+  const { calculateActualLaborCost, calculateHoursPerEmployee } = await import('../_shared/laborCalculations.ts');
   const { startDate, endDate, startDateStr, endDateStr } = calculateDateRange(period, start_date, end_date);
+
+  const canSeeEmployees = userRole === 'manager' || userRole === 'owner';
 
   // Fetch time punches and employees in parallel
   const [punchesResult, employeesResult] = await Promise.all([
@@ -1872,7 +1885,7 @@ async function executeGetLaborCosts(
       .order('punch_time', { ascending: true }),
     supabase
       .from('employees')
-      .select('*')
+      .select(EMPLOYEE_LABOR_COLUMNS)
       .eq('restaurant_id', restaurantId),
   ]);
 
@@ -1885,13 +1898,19 @@ async function executeGetLaborCosts(
   // Calculate labor costs
   const { breakdown, dailyCosts } = calculateActualLaborCost(employees, timePunches, startDate, endDate);
 
-  // Build employee breakdown if requested
-  const employeeBreakdown = include_employee_breakdown
-    ? employees.filter((e: any) => e.status === 'active').map((e: any) => ({
-        employee_id: e.id,
-        employee_name: e.name,
-        position: e.position,
-        compensation_type: e.compensation_type,
+  // Per-employee breakdown is manager/owner-only. Lower roles always get null
+  // so the field shape stays stable and the model knows not to ask the user
+  // for employee-level data it can't see.
+  const employeeBreakdown = include_employee_breakdown && canSeeEmployees
+    ? calculateHoursPerEmployee(employees, timePunches, startDate, endDate).map((s) => ({
+        employee_id: s.employee_id,
+        employee_name: s.employee_name,
+        position: s.position,
+        compensation_type: s.compensation_type,
+        total_hours: Number(s.total_hours.toFixed(4)),
+        total_cost_cents: s.total_cost_cents,
+        days_worked: s.days_worked,
+        hours_per_day: s.hours_per_day,
       }))
     : null;
 
@@ -1912,8 +1931,152 @@ async function executeGetLaborCosts(
       employee_breakdown: employeeBreakdown,
     },
     evidence: [
-      { table: 'time_punches', summary: `${timePunches.length} time punches from ${startDateStr} to ${endDateStr}` },
-      { table: 'employees', summary: `${employees.length} employees for labor cost calculation` },
+      { table: 'time_punches', summary: `${timePunches.length} time punches across ${employees.length} employees from ${startDateStr} to ${endDateStr}` },
+    ],
+  };
+}
+
+/**
+ * Execute get_time_punches tool
+ * Returns parsed work periods (one row per shift) joined to employee
+ * name/position, with computed hours and breaks deducted. Manager+owner only —
+ * the dispatcher's canUseTool already enforces this; we re-assert here as
+ * defense-in-depth since this function returns employee PII.
+ */
+async function executeGetTimePunches(
+  args: any,
+  restaurantId: string,
+  supabase: any,
+  userRole: string
+): Promise<any> {
+  if (userRole !== 'manager' && userRole !== 'owner') {
+    // Should never reach here — dispatcher blocks first. If it does, return the
+    // same shape the dispatcher uses so the model handles it identically.
+    return {
+      ok: false,
+      error: {
+        code: 'TOOL_PERMISSION_DENIED',
+        message: "You don't have permission to use get_time_punches.",
+        tool: 'get_time_punches',
+        required_role: 'manager',
+      },
+    };
+  }
+
+  const { period, start_date, end_date, employee_id, position, min_hours = 0, limit = 50 } = args;
+
+  const { calculateHoursPerEmployee } = await import('../_shared/laborCalculations.ts');
+  const { startDate, endDate, startDateStr, endDateStr } = calculateDateRange(period, start_date, end_date);
+
+  const cappedLimit = Math.min(Math.max(1, Number(limit) || 50), 200);
+  const minHours = Math.max(0, Number(min_hours) || 0);
+
+  // Fetch time punches and employees in parallel (narrowed projections)
+  const punchQuery = supabase
+    .from('time_punches')
+    .select('id, employee_id, restaurant_id, punch_time, punch_type')
+    .eq('restaurant_id', restaurantId)
+    .gte('punch_time', startDate.toISOString())
+    .lte('punch_time', endDate.toISOString())
+    .order('punch_time', { ascending: true });
+
+  if (employee_id) {
+    punchQuery.eq('employee_id', employee_id);
+  }
+
+  const [punchesResult, employeesResult] = await Promise.all([
+    punchQuery,
+    supabase
+      .from('employees')
+      .select(EMPLOYEE_LABOR_COLUMNS)
+      .eq('restaurant_id', restaurantId),
+  ]);
+
+  if (punchesResult.error) throw new Error(`Failed to fetch time punches: ${punchesResult.error.message}`);
+  if (employeesResult.error) throw new Error(`Failed to fetch employees: ${employeesResult.error.message}`);
+
+  const timePunches = punchesResult.data || [];
+  let employees = employeesResult.data || [];
+
+  if (position) {
+    const positionLower = String(position).toLowerCase();
+    employees = employees.filter((e: any) => (e.position || '').toLowerCase() === positionLower);
+  }
+
+  const summaries = calculateHoursPerEmployee(employees, timePunches, startDate, endDate);
+
+  // Flatten to one row per work period (clock-in/out pair). Skip pure breaks
+  // and anything below min_hours. For hourly employees, attribute a
+  // proportional share of total_cost_cents to each period; for salary /
+  // contractor / daily_rate, leave cost_cents null since the cost is
+  // period-allocated, not hours-allocated.
+  type Shift = {
+    employee_id: string;
+    employee_name: string;
+    position: string | null;
+    compensation_type: string;
+    start_time: string;
+    end_time: string;
+    hours: number;
+    cost_cents: number | null;
+    date: string;
+  };
+
+  const shifts: Shift[] = [];
+  for (const s of summaries) {
+    const workPeriods = s.work_periods.filter((p) => !p.isBreak && p.hours >= minHours);
+    const totalHours = workPeriods.reduce((sum, p) => sum + p.hours, 0);
+
+    for (const p of workPeriods) {
+      const proportional =
+        s.compensation_type === 'hourly' && totalHours > 0
+          ? Math.round((p.hours / totalHours) * s.total_cost_cents)
+          : null;
+
+      // Bucket date by local-TZ start to align with hours_per_day keys.
+      const start = p.startTime;
+      const yyyy = start.getFullYear();
+      const mm = String(start.getMonth() + 1).padStart(2, '0');
+      const dd = String(start.getDate()).padStart(2, '0');
+
+      shifts.push({
+        employee_id: s.employee_id,
+        employee_name: s.employee_name,
+        position: s.position,
+        compensation_type: s.compensation_type,
+        start_time: p.startTime.toISOString(),
+        end_time: p.endTime.toISOString(),
+        hours: Number(p.hours.toFixed(4)),
+        cost_cents: proportional,
+        date: `${yyyy}-${mm}-${dd}`,
+      });
+    }
+  }
+
+  // Newest first, then cap.
+  shifts.sort((a, b) => (a.start_time < b.start_time ? 1 : -1));
+  const limited = shifts.slice(0, cappedLimit);
+
+  return {
+    ok: true,
+    data: {
+      period,
+      start_date: startDateStr,
+      end_date: endDateStr,
+      filters: {
+        employee_id: employee_id || null,
+        position: position || null,
+        min_hours: minHours,
+      },
+      total_shifts: shifts.length,
+      returned_shifts: limited.length,
+      shifts: limited,
+    },
+    evidence: [
+      {
+        table: 'time_punches',
+        summary: `${timePunches.length} punches → ${shifts.length} shifts (returning ${limited.length}) from ${startDateStr} to ${endDateStr}`,
+      },
     ],
   };
 }
@@ -3433,7 +3596,25 @@ serve(async (req) => {
 
     // Check if user can use this tool
     if (!canUseTool(tool_name, userRestaurant.role)) {
-      throw new Error(`Permission denied for tool: ${tool_name}`);
+      const requiredRole = requiredRoleFor(tool_name);
+      return new Response(
+        JSON.stringify({
+          ok: false,
+          error: {
+            code: 'TOOL_PERMISSION_DENIED',
+            message: `You don't have permission to use ${tool_name}.`,
+            tool: tool_name,
+            required_role: requiredRole,
+          },
+        }),
+        {
+          status: 403,
+          headers: {
+            ...corsHeaders,
+            'Content-Type': 'application/json',
+          },
+        }
+      );
     }
 
     const startTime = Date.now();
@@ -3475,7 +3656,10 @@ serve(async (req) => {
         result = await executeGenerateReport(args, restaurant_id, supabase);
         break;
       case 'get_labor_costs':
-        result = await executeGetLaborCosts(args, restaurant_id, supabase);
+        result = await executeGetLaborCosts(args, restaurant_id, supabase, userRestaurant.role);
+        break;
+      case 'get_time_punches':
+        result = await executeGetTimePunches(args, restaurant_id, supabase, userRestaurant.role);
         break;
       case 'get_schedule_overview':
         result = await executeGetScheduleOverview(args, restaurant_id, supabase);

--- a/supabase/functions/ai-execute-tool/index.ts
+++ b/supabase/functions/ai-execute-tool/index.ts
@@ -1847,10 +1847,6 @@ async function executeGenerateReport(
 // NEW TOOL EXECUTION HANDLERS
 // ============================================================================
 
-/**
- * Execute get_labor_costs tool
- * Uses same calculation logic as Dashboard (time_punches + employees)
- */
 // Columns required by the labor calculators. Narrowed projection — name and
 // position are PII; we still need them so `calculateHoursPerEmployee` can build
 // the per-employee breakdown for manager/owner callers, but we strip them
@@ -1861,6 +1857,59 @@ const EMPLOYEE_LABOR_COLUMNS =
   'contractor_payment_amount, contractor_payment_interval, ' +
   'daily_rate_amount, hire_date, termination_date, compensation_history';
 
+/**
+ * Fetch time punches and employees in parallel — shared by get_labor_costs
+ * and get_time_punches. Optionally filters punches to a single employee.
+ */
+async function fetchLaborData(
+  supabase: any,
+  restaurantId: string,
+  startDate: Date,
+  endDate: Date,
+  employeeId?: string,
+): Promise<{ timePunches: any[]; employees: any[] }> {
+  let punchQuery = supabase
+    .from('time_punches')
+    .select('id, employee_id, restaurant_id, punch_time, punch_type')
+    .eq('restaurant_id', restaurantId)
+    .gte('punch_time', startDate.toISOString())
+    .lte('punch_time', endDate.toISOString())
+    .order('punch_time', { ascending: true });
+
+  if (employeeId) {
+    punchQuery = punchQuery.eq('employee_id', employeeId);
+  }
+
+  const [punchesResult, employeesResult] = await Promise.all([
+    punchQuery,
+    supabase
+      .from('employees')
+      .select(EMPLOYEE_LABOR_COLUMNS)
+      .eq('restaurant_id', restaurantId),
+  ]);
+
+  if (punchesResult.error) throw new Error(`Failed to fetch time punches: ${punchesResult.error.message}`);
+  if (employeesResult.error) throw new Error(`Failed to fetch employees: ${employeesResult.error.message}`);
+
+  return {
+    timePunches: punchesResult.data ?? [],
+    employees: employeesResult.data ?? [],
+  };
+}
+
+/** Format a Date as YYYY-MM-DD in the host's local timezone. Aligns with
+ * the hours_per_day keys produced by calculateHoursPerEmployee. */
+function formatShiftDate(date: Date): string {
+  const yyyy = date.getFullYear();
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  const dd = String(date.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+/**
+ * Execute get_labor_costs tool
+ * Uses same calculation logic as Dashboard (time_punches + employees)
+ */
 async function executeGetLaborCosts(
   args: any,
   restaurantId: string,
@@ -1874,28 +1923,8 @@ async function executeGetLaborCosts(
 
   const canSeeEmployees = userRole === 'manager' || userRole === 'owner';
 
-  // Fetch time punches and employees in parallel
-  const [punchesResult, employeesResult] = await Promise.all([
-    supabase
-      .from('time_punches')
-      .select('id, employee_id, restaurant_id, punch_time, punch_type')
-      .eq('restaurant_id', restaurantId)
-      .gte('punch_time', startDate.toISOString())
-      .lte('punch_time', endDate.toISOString())
-      .order('punch_time', { ascending: true }),
-    supabase
-      .from('employees')
-      .select(EMPLOYEE_LABOR_COLUMNS)
-      .eq('restaurant_id', restaurantId),
-  ]);
+  const { timePunches, employees } = await fetchLaborData(supabase, restaurantId, startDate, endDate);
 
-  if (punchesResult.error) throw new Error(`Failed to fetch time punches: ${punchesResult.error.message}`);
-  if (employeesResult.error) throw new Error(`Failed to fetch employees: ${employeesResult.error.message}`);
-
-  const timePunches = punchesResult.data || [];
-  const employees = employeesResult.data || [];
-
-  // Calculate labor costs
   const { breakdown, dailyCosts } = calculateActualLaborCost(employees, timePunches, startDate, endDate);
 
   // Per-employee breakdown is manager/owner-only. Lower roles always get null
@@ -1971,37 +2000,15 @@ async function executeGetTimePunches(
   const cappedLimit = Math.min(Math.max(1, Number(limit) || 50), 200);
   const minHours = Math.max(0, Number(min_hours) || 0);
 
-  // Fetch time punches and employees in parallel (narrowed projections)
-  const punchQuery = supabase
-    .from('time_punches')
-    .select('id, employee_id, restaurant_id, punch_time, punch_type')
-    .eq('restaurant_id', restaurantId)
-    .gte('punch_time', startDate.toISOString())
-    .lte('punch_time', endDate.toISOString())
-    .order('punch_time', { ascending: true });
+  const { timePunches, employees: allEmployees } = await fetchLaborData(
+    supabase, restaurantId, startDate, endDate, employee_id,
+  );
 
-  if (employee_id) {
-    punchQuery.eq('employee_id', employee_id);
-  }
-
-  const [punchesResult, employeesResult] = await Promise.all([
-    punchQuery,
-    supabase
-      .from('employees')
-      .select(EMPLOYEE_LABOR_COLUMNS)
-      .eq('restaurant_id', restaurantId),
-  ]);
-
-  if (punchesResult.error) throw new Error(`Failed to fetch time punches: ${punchesResult.error.message}`);
-  if (employeesResult.error) throw new Error(`Failed to fetch employees: ${employeesResult.error.message}`);
-
-  const timePunches = punchesResult.data || [];
-  let employees = employeesResult.data || [];
-
-  if (position) {
-    const positionLower = String(position).toLowerCase();
-    employees = employees.filter((e: any) => (e.position || '').toLowerCase() === positionLower);
-  }
+  // Filter by position client-side (the employees table has no indexed position
+  // column suitable for a server-side filter here).
+  const employees = position
+    ? allEmployees.filter((e: any) => (e.position || '').toLowerCase() === String(position).toLowerCase())
+    : allEmployees;
 
   const summaries = calculateHoursPerEmployee(employees, timePunches, startDate, endDate);
 
@@ -2028,16 +2035,12 @@ async function executeGetTimePunches(
     const totalHours = workPeriods.reduce((sum, p) => sum + p.hours, 0);
 
     for (const p of workPeriods) {
-      const proportional =
+      // Hourly employees get a proportional share of total_cost_cents per period.
+      // Salary / contractor / daily_rate costs are period-allocated, not per-shift.
+      const cost_cents =
         s.compensation_type === 'hourly' && totalHours > 0
           ? Math.round((p.hours / totalHours) * s.total_cost_cents)
           : null;
-
-      // Bucket date by local-TZ start to align with hours_per_day keys.
-      const start = p.startTime;
-      const yyyy = start.getFullYear();
-      const mm = String(start.getMonth() + 1).padStart(2, '0');
-      const dd = String(start.getDate()).padStart(2, '0');
 
       shifts.push({
         employee_id: s.employee_id,
@@ -2047,8 +2050,8 @@ async function executeGetTimePunches(
         start_time: p.startTime.toISOString(),
         end_time: p.endTime.toISOString(),
         hours: Number(p.hours.toFixed(4)),
-        cost_cents: proportional,
-        date: `${yyyy}-${mm}-${dd}`,
+        cost_cents,
+        date: formatShiftDate(p.startTime),
       });
     }
   }

--- a/supabase/functions/ai-execute-tool/index.ts
+++ b/supabase/functions/ai-execute-tool/index.ts
@@ -99,18 +99,29 @@ function calculateDateRange(
       const [sy, sm, sd] = customStartDate.split('-').map(Number);
       startDate = new Date(sy, sm - 1, sd);
       const [ey, em, ed] = customEndDate.split('-').map(Number);
-      endDate = new Date(ey, em - 1, ed);
+      // End-of-day so the inclusive range matches every other branch above.
+      endDate = new Date(ey, em - 1, ed, 23, 59, 59);
       break;
     default:
       // Default to current week
       startDate = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 7);
   }
 
+  // Format strings in the host's local timezone so they reflect the calendar
+  // date the caller asked for. toISOString drifts to the next day when local
+  // 23:59:59 lands past midnight UTC (e.g., PT users querying "today").
+  const toLocalYMD = (d: Date) => {
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+  };
+
   return {
     startDate,
     endDate,
-    startDateStr: startDate.toISOString().split('T')[0],
-    endDateStr: endDate.toISOString().split('T')[0],
+    startDateStr: toLocalYMD(startDate),
+    endDateStr: toLocalYMD(endDate),
   };
 }
 
@@ -1857,36 +1868,60 @@ const EMPLOYEE_LABOR_COLUMNS =
   'contractor_payment_amount, contractor_payment_interval, ' +
   'daily_rate_amount, hire_date, termination_date, compensation_history';
 
+interface FetchLaborDataOptions {
+  /** Optional single-employee filter. */
+  employeeId?: string;
+  /** Optional case-insensitive position filter (matches employees server-side). */
+  position?: string;
+  /**
+   * Hours past `endDate` to extend the punch fetch so we still capture the
+   * clock_out of a shift that started in-window and crossed midnight.
+   * `calculateHoursPerEmployee` filters periods by startTime <= endDate so
+   * any orphan clock_in in the lookahead zone is dropped. Default 0.
+   */
+  endLookaheadHours?: number;
+}
+
 /**
  * Fetch time punches and employees in parallel — shared by get_labor_costs
- * and get_time_punches. Optionally filters punches to a single employee.
+ * and get_time_punches.
  */
 async function fetchLaborData(
   supabase: any,
   restaurantId: string,
   startDate: Date,
   endDate: Date,
-  employeeId?: string,
+  options: FetchLaborDataOptions = {},
 ): Promise<{ timePunches: any[]; employees: any[] }> {
+  const { employeeId, position, endLookaheadHours = 0 } = options;
+
+  const upperBound =
+    endLookaheadHours > 0
+      ? new Date(endDate.getTime() + endLookaheadHours * 60 * 60 * 1000)
+      : endDate;
+
   let punchQuery = supabase
     .from('time_punches')
     .select('id, employee_id, restaurant_id, punch_time, punch_type')
     .eq('restaurant_id', restaurantId)
     .gte('punch_time', startDate.toISOString())
-    .lte('punch_time', endDate.toISOString())
+    .lte('punch_time', upperBound.toISOString())
     .order('punch_time', { ascending: true });
 
   if (employeeId) {
     punchQuery = punchQuery.eq('employee_id', employeeId);
   }
 
-  const [punchesResult, employeesResult] = await Promise.all([
-    punchQuery,
-    supabase
-      .from('employees')
-      .select(EMPLOYEE_LABOR_COLUMNS)
-      .eq('restaurant_id', restaurantId),
-  ]);
+  let employeeQuery = supabase
+    .from('employees')
+    .select(EMPLOYEE_LABOR_COLUMNS)
+    .eq('restaurant_id', restaurantId);
+
+  if (position) {
+    employeeQuery = employeeQuery.ilike('position', position);
+  }
+
+  const [punchesResult, employeesResult] = await Promise.all([punchQuery, employeeQuery]);
 
   if (punchesResult.error) throw new Error(`Failed to fetch time punches: ${punchesResult.error.message}`);
   if (employeesResult.error) throw new Error(`Failed to fetch employees: ${employeesResult.error.message}`);
@@ -1895,15 +1930,6 @@ async function fetchLaborData(
     timePunches: punchesResult.data ?? [],
     employees: employeesResult.data ?? [],
   };
-}
-
-/** Format a Date as YYYY-MM-DD in the host's local timezone. Aligns with
- * the hours_per_day keys produced by calculateHoursPerEmployee. */
-function formatShiftDate(date: Date): string {
-  const yyyy = date.getFullYear();
-  const mm = String(date.getMonth() + 1).padStart(2, '0');
-  const dd = String(date.getDate()).padStart(2, '0');
-  return `${yyyy}-${mm}-${dd}`;
 }
 
 /**
@@ -1923,7 +1949,11 @@ async function executeGetLaborCosts(
 
   const canSeeEmployees = userRole === 'manager' || userRole === 'owner';
 
-  const { timePunches, employees } = await fetchLaborData(supabase, restaurantId, startDate, endDate);
+  // 18h lookahead so shifts whose clock_out lands just after midnight at the
+  // end of the window still get paired into a complete period.
+  const { timePunches, employees } = await fetchLaborData(supabase, restaurantId, startDate, endDate, {
+    endLookaheadHours: 18,
+  });
 
   const { breakdown, dailyCosts } = calculateActualLaborCost(employees, timePunches, startDate, endDate);
 
@@ -1994,29 +2024,39 @@ async function executeGetTimePunches(
 
   const { period, start_date, end_date, employee_id, position, min_hours = 0, limit = 50 } = args;
 
-  const { calculateHoursPerEmployee } = await import('../_shared/laborCalculations.ts');
+  const { calculateHoursPerEmployee, getEmployeeSnapshotForDate, formatDateLocal } = await import(
+    '../_shared/laborCalculations.ts'
+  );
   const { startDate, endDate, startDateStr, endDateStr } = calculateDateRange(period, start_date, end_date);
 
   const cappedLimit = Math.min(Math.max(1, Number(limit) || 50), 200);
   const minHours = Math.max(0, Number(min_hours) || 0);
 
-  const { timePunches, employees: allEmployees } = await fetchLaborData(
-    supabase, restaurantId, startDate, endDate, employee_id,
+  // 18h lookahead so shifts whose clock_out lands just after midnight at the
+  // end of the window still get paired. `calculateHoursPerEmployee` filters
+  // periods by startTime <= endDate so any orphan clock_in in the lookahead
+  // zone is dropped.
+  const { timePunches, employees } = await fetchLaborData(
+    supabase,
+    restaurantId,
+    startDate,
+    endDate,
+    { employeeId: employee_id, position, endLookaheadHours: 18 },
   );
 
-  // Filter by position client-side (the employees table has no indexed position
-  // column suitable for a server-side filter here).
-  const employees = position
-    ? allEmployees.filter((e: any) => (e.position || '').toLowerCase() === String(position).toLowerCase())
-    : allEmployees;
-
   const summaries = calculateHoursPerEmployee(employees, timePunches, startDate, endDate);
+  // Index by id so we can resolve the per-day compensation snapshot below
+  // without a linear scan per shift.
+  const employeesById: Record<string, typeof employees[number]> = {};
+  for (const e of employees) {
+    employeesById[(e as { id: string }).id] = e;
+  }
 
   // Flatten to one row per work period (clock-in/out pair). Skip pure breaks
-  // and anything below min_hours. For hourly employees, attribute a
-  // proportional share of total_cost_cents to each period; for salary /
-  // contractor / daily_rate, leave cost_cents null since the cost is
-  // period-allocated, not hours-allocated.
+  // and anything below min_hours. Per-shift cost uses the snapshot for that
+  // shift's date so mid-period comp changes are billed correctly:
+  //   - hourly snapshot   → hourly_rate × hours
+  //   - daily_rate / salary / contractor → null (period-allocated, not per-shift)
   type Shift = {
     employee_id: string;
     employee_name: string;
@@ -2032,26 +2072,26 @@ async function executeGetTimePunches(
   const shifts: Shift[] = [];
   for (const s of summaries) {
     const workPeriods = s.work_periods.filter((p) => !p.isBreak && p.hours >= minHours);
-    const totalHours = workPeriods.reduce((sum, p) => sum + p.hours, 0);
+    const employee = employeesById[s.employee_id];
 
     for (const p of workPeriods) {
-      // Hourly employees get a proportional share of total_cost_cents per period.
-      // Salary / contractor / daily_rate costs are period-allocated, not per-shift.
+      const day = formatDateLocal(new Date(p.startTime));
+      const snapshot = employee ? getEmployeeSnapshotForDate(employee, day) : null;
       const cost_cents =
-        s.compensation_type === 'hourly' && totalHours > 0
-          ? Math.round((p.hours / totalHours) * s.total_cost_cents)
+        snapshot && snapshot.compensation_type === 'hourly' && snapshot.hourly_rate
+          ? Math.round((snapshot.hourly_rate / 100) * p.hours * 100)
           : null;
 
       shifts.push({
         employee_id: s.employee_id,
         employee_name: s.employee_name,
         position: s.position,
-        compensation_type: s.compensation_type,
+        compensation_type: snapshot?.compensation_type ?? s.compensation_type,
         start_time: p.startTime.toISOString(),
         end_time: p.endTime.toISOString(),
         hours: Number(p.hours.toFixed(4)),
         cost_cents,
-        date: formatShiftDate(p.startTime),
+        date: day,
       });
     }
   }
@@ -2059,6 +2099,7 @@ async function executeGetTimePunches(
   // Newest first, then cap.
   shifts.sort((a, b) => (a.start_time < b.start_time ? 1 : -1));
   const limited = shifts.slice(0, cappedLimit);
+  const hasMore = shifts.length > cappedLimit;
 
   return {
     ok: true,
@@ -2073,12 +2114,13 @@ async function executeGetTimePunches(
       },
       total_shifts: shifts.length,
       returned_shifts: limited.length,
+      has_more: hasMore,
       shifts: limited,
     },
     evidence: [
       {
         table: 'time_punches',
-        summary: `${timePunches.length} punches → ${shifts.length} shifts (returning ${limited.length}) from ${startDateStr} to ${endDateStr}`,
+        summary: `${timePunches.length} punches → ${shifts.length} shifts (returning ${limited.length}${hasMore ? `, ${shifts.length - cappedLimit} truncated` : ''}) from ${startDateStr} to ${endDateStr}`,
       },
     ],
   };

--- a/supabase/migrations/20260524120000_idx_time_punches_restaurant_punch_time.sql
+++ b/supabase/migrations/20260524120000_idx_time_punches_restaurant_punch_time.sql
@@ -1,0 +1,12 @@
+-- Composite index on (restaurant_id, punch_time) to support the
+-- AI chat get_labor_costs / get_time_punches query pattern.
+--
+-- The existing schema has separate idx_time_punches_restaurant and
+-- idx_time_punches_time indexes, but both new code paths filter on
+-- restaurant_id AND a punch_time range, so a composite is meaningfully faster.
+--
+-- CREATE INDEX CONCURRENTLY cannot run inside a transaction, so this
+-- migration intentionally contains only the index statement.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_time_punches_restaurant_punch_time
+  ON public.time_punches (restaurant_id, punch_time);

--- a/tests/unit/ai-tools-date-resolution.test.ts
+++ b/tests/unit/ai-tools-date-resolution.test.ts
@@ -77,17 +77,24 @@ function calculateDateRange(
       const [sy, sm, sd] = customStartDate.split('-').map(Number);
       startDate = new Date(sy, sm - 1, sd);
       const [ey, em, ed] = customEndDate.split('-').map(Number);
-      endDate = new Date(ey, em - 1, ed);
+      endDate = new Date(ey, em - 1, ed, 23, 59, 59);
       break;
     default:
       startDate = new Date(now.getFullYear(), now.getMonth(), now.getDate() - 7);
   }
 
+  const toLocalYMD = (d: Date) => {
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${y}-${m}-${day}`;
+  };
+
   return {
     startDate,
     endDate,
-    startDateStr: startDate.toISOString().split('T')[0],
-    endDateStr: endDate.toISOString().split('T')[0],
+    startDateStr: toLocalYMD(startDate),
+    endDateStr: toLocalYMD(endDate),
   };
 }
 
@@ -256,6 +263,16 @@ describe('get_time_punches period resolution', () => {
     const range = calculateDateRange('custom', '2026-05-10', '2026-05-17');
     expect(range.startDateStr).toBe('2026-05-10');
     expect(range.endDateStr).toBe('2026-05-17');
+  });
+
+  it('custom period endDate is inclusive end-of-day, not midnight', () => {
+    // Prevents the off-by-one where a query for 2026-05-10..2026-05-17 would
+    // exclude all of May 17 because endDate landed at 00:00:00 instead of
+    // 23:59:59. Match the other branches' behavior.
+    const range = calculateDateRange('custom', '2026-05-10', '2026-05-17');
+    expect(range.endDate.getHours()).toBe(23);
+    expect(range.endDate.getMinutes()).toBe(59);
+    expect(range.endDate.getSeconds()).toBe(59);
   });
 
   it('today and yesterday do not overlap', () => {

--- a/tests/unit/ai-tools-date-resolution.test.ts
+++ b/tests/unit/ai-tools-date-resolution.test.ts
@@ -233,6 +233,50 @@ describe('get_sales_summary previous period calculation', () => {
   });
 });
 
+describe('get_time_punches period resolution', () => {
+  // The get_time_punches tool accepts these period values per tools-registry.ts.
+  // calculateDateRange must produce a non-empty range for each of them.
+  const SUPPORTED_PERIODS = [
+    'today',
+    'yesterday',
+    'week',
+    'last_week',
+    'month',
+    'last_month',
+  ] as const;
+
+  it.each(SUPPORTED_PERIODS)('resolves period "%s" to a non-empty range', (period) => {
+    const range = calculateDateRange(period);
+    expect(range.startDate.getTime()).toBeLessThanOrEqual(range.endDate.getTime());
+    expect(range.startDateStr).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(range.endDateStr).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('resolves period "custom" with explicit dates', () => {
+    const range = calculateDateRange('custom', '2026-05-10', '2026-05-17');
+    expect(range.startDateStr).toBe('2026-05-10');
+    expect(range.endDateStr).toBe('2026-05-17');
+  });
+
+  it('today and yesterday do not overlap', () => {
+    const today = calculateDateRange('today');
+    const yesterday = calculateDateRange('yesterday');
+    expect(yesterday.endDate.getTime()).toBeLessThan(today.startDate.getTime());
+  });
+
+  it('last_week ends before week starts (no overlap)', () => {
+    const week = calculateDateRange('week');
+    const lastWeek = calculateDateRange('last_week');
+    // 'week' is "last 7 days from now"; 'last_week' is the prior Sun-Sat.
+    // last_week's end must be strictly before today.
+    const now = new Date();
+    const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    expect(lastWeek.endDate.getTime()).toBeLessThan(todayStart.getTime());
+    // And week's window must include today.
+    expect(week.endDate.getTime()).toBeGreaterThanOrEqual(todayStart.getTime());
+  });
+});
+
 describe('get_break_even_progress month param parsing', () => {
   it('parses YYYY-MM month format correctly', () => {
     const month = '2026-02';

--- a/tests/unit/laborCalculations.calculateHoursPerEmployee.test.ts
+++ b/tests/unit/laborCalculations.calculateHoursPerEmployee.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect } from 'vitest';
+import {
+  calculateActualLaborCost,
+  calculateHoursPerEmployee,
+} from '@/services/laborCalculations';
+import type { Employee } from '@/types/scheduling';
+import type { TimePunch } from '@/types/timeTracking';
+
+/**
+ * Tests for calculateHoursPerEmployee — the per-employee rollup that powers
+ * the AI chat's get_labor_costs.employee_breakdown and get_time_punches tools.
+ *
+ * Date convention (lesson [2026-05-03]): punch_time uses ISO strings without
+ * a trailing Z so new Date(...) is interpreted in the host TZ. Punches sit
+ * inside the day (9am-5pm), so the bucket date matches the string's date on
+ * both CI (UTC) and local dev (PT) without setting process.env.TZ.
+ */
+
+function punch(
+  employeeId: string,
+  time: string,
+  type: 'clock_in' | 'clock_out' | 'break_start' | 'break_end',
+): TimePunch {
+  return {
+    id: `${employeeId}-${time}-${type}`,
+    employee_id: employeeId,
+    restaurant_id: 'r1',
+    punch_type: type,
+    punch_time: new Date(time).toISOString(),
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  } as TimePunch;
+}
+
+const hourlyEmployee: Employee = {
+  id: 'emp-hourly',
+  restaurant_id: 'r1',
+  name: 'Hourly Hannah',
+  position: 'Server',
+  status: 'active',
+  is_active: true,
+  compensation_type: 'hourly',
+  hourly_rate: 2000, // $20.00/hr
+  is_exempt: false,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+} as Employee;
+
+const salaryEmployee: Employee = {
+  id: 'emp-salary',
+  restaurant_id: 'r1',
+  name: 'Salary Sam',
+  position: 'Manager',
+  status: 'active',
+  is_active: true,
+  compensation_type: 'salary',
+  hourly_rate: 0,
+  salary_amount: 100000, // $1,000/week
+  pay_period_type: 'weekly',
+  is_exempt: true,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+} as Employee;
+
+const contractorEmployee: Employee = {
+  id: 'emp-contractor',
+  restaurant_id: 'r1',
+  name: 'Contractor Chris',
+  position: 'Cook',
+  status: 'active',
+  is_active: true,
+  compensation_type: 'contractor',
+  hourly_rate: 0,
+  contractor_payment_amount: 300000, // $3,000/month
+  contractor_payment_interval: 'monthly',
+  is_exempt: true,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+} as Employee;
+
+describe('calculateHoursPerEmployee', () => {
+  describe('hourly employee with breaks', () => {
+    it('subtracts break time and credits hours to the work-period start day', () => {
+      const punches: TimePunch[] = [
+        punch('emp-hourly', '2026-05-16T09:00:00', 'clock_in'),
+        punch('emp-hourly', '2026-05-16T12:00:00', 'break_start'),
+        punch('emp-hourly', '2026-05-16T12:30:00', 'break_end'),
+        punch('emp-hourly', '2026-05-16T17:00:00', 'clock_out'),
+      ];
+
+      const start = new Date('2026-05-16T00:00:00');
+      const end = new Date('2026-05-16T23:59:59');
+
+      const summaries = calculateHoursPerEmployee([hourlyEmployee], punches, start, end);
+
+      expect(summaries).toHaveLength(1);
+      const row = summaries[0];
+      expect(row.employee_id).toBe('emp-hourly');
+      expect(row.compensation_type).toBe('hourly');
+
+      // 9-12 = 3h, 12:30-17 = 4.5h → 7.5h. Break (12-12:30) is not counted.
+      expect(row.total_hours).toBeCloseTo(7.5, 4);
+      expect(row.days_worked).toBe(1);
+      expect(Object.keys(row.hours_per_day)).toEqual(['2026-05-16']);
+      expect(row.hours_per_day['2026-05-16']).toBeCloseTo(7.5, 4);
+
+      // Hourly cost: $20/hr × 7.5h = $150 = 15000 cents
+      expect(row.total_cost_cents).toBe(15000);
+    });
+  });
+
+  describe('multi-day hourly', () => {
+    it('sums hours and counts distinct days_worked', () => {
+      const punches: TimePunch[] = [
+        punch('emp-hourly', '2026-05-14T09:00:00', 'clock_in'),
+        punch('emp-hourly', '2026-05-14T13:00:00', 'clock_out'),
+        punch('emp-hourly', '2026-05-15T09:00:00', 'clock_in'),
+        punch('emp-hourly', '2026-05-15T17:00:00', 'clock_out'),
+        punch('emp-hourly', '2026-05-16T10:00:00', 'clock_in'),
+        punch('emp-hourly', '2026-05-16T16:00:00', 'clock_out'),
+      ];
+
+      const start = new Date('2026-05-14T00:00:00');
+      const end = new Date('2026-05-16T23:59:59');
+
+      const [row] = calculateHoursPerEmployee([hourlyEmployee], punches, start, end);
+
+      expect(row.total_hours).toBeCloseTo(4 + 8 + 6, 4);
+      expect(row.days_worked).toBe(3);
+      expect(Object.keys(row.hours_per_day).sort()).toEqual([
+        '2026-05-14',
+        '2026-05-15',
+        '2026-05-16',
+      ]);
+      expect(row.hours_per_day['2026-05-14']).toBeCloseTo(4, 4);
+      expect(row.hours_per_day['2026-05-15']).toBeCloseTo(8, 4);
+      expect(row.hours_per_day['2026-05-16']).toBeCloseTo(6, 4);
+      expect(row.total_cost_cents).toBe(2000 * 18); // 18h × $20/h
+    });
+  });
+
+  describe('employee with no punches', () => {
+    it('returns a row with zero hours rather than omitting the employee', () => {
+      const start = new Date('2026-05-14T00:00:00');
+      const end = new Date('2026-05-16T23:59:59');
+
+      const summaries = calculateHoursPerEmployee([hourlyEmployee], [], start, end);
+
+      expect(summaries).toHaveLength(1);
+      const [row] = summaries;
+      expect(row.employee_id).toBe('emp-hourly');
+      expect(row.total_hours).toBe(0);
+      expect(row.days_worked).toBe(0);
+      expect(row.hours_per_day).toEqual({});
+      expect(row.work_periods).toEqual([]);
+      expect(row.total_cost_cents).toBe(0);
+    });
+  });
+
+  describe('mixed compensation types', () => {
+    it('produces a row for each employee and aggregates costs that sum back to the breakdown', () => {
+      const punches: TimePunch[] = [
+        // Hourly: 6h on May 14, 4h on May 15
+        punch('emp-hourly', '2026-05-14T09:00:00', 'clock_in'),
+        punch('emp-hourly', '2026-05-14T15:00:00', 'clock_out'),
+        punch('emp-hourly', '2026-05-15T09:00:00', 'clock_in'),
+        punch('emp-hourly', '2026-05-15T13:00:00', 'clock_out'),
+        // Salary: punches in but cost is period-allocated
+        punch('emp-salary', '2026-05-14T08:00:00', 'clock_in'),
+        punch('emp-salary', '2026-05-14T17:00:00', 'clock_out'),
+        // Contractor: punches in but cost is period-allocated
+        punch('emp-contractor', '2026-05-16T10:00:00', 'clock_in'),
+        punch('emp-contractor', '2026-05-16T18:00:00', 'clock_out'),
+      ];
+
+      const start = new Date('2026-05-14T00:00:00');
+      const end = new Date('2026-05-20T23:59:59');
+
+      const employees = [hourlyEmployee, salaryEmployee, contractorEmployee];
+      const summaries = calculateHoursPerEmployee(employees, punches, start, end);
+
+      expect(summaries).toHaveLength(3);
+      const byId = new Map(summaries.map((s) => [s.employee_id, s]));
+
+      const hourly = byId.get('emp-hourly')!;
+      expect(hourly.total_hours).toBeCloseTo(10, 4);
+      expect(hourly.days_worked).toBe(2);
+      expect(hourly.total_cost_cents).toBe(2000 * 10); // 10h × $20 = 20000c
+
+      const salary = byId.get('emp-salary')!;
+      expect(salary.total_hours).toBeCloseTo(9, 4);
+      expect(salary.days_worked).toBe(1);
+      // Salary cost: 7-day window × ($1000/7) = $1000 = 100000 cents
+      expect(salary.total_cost_cents).toBe(100000);
+
+      const contractor = byId.get('emp-contractor')!;
+      expect(contractor.total_hours).toBeCloseTo(8, 4);
+      expect(contractor.days_worked).toBe(1);
+      // Contractor: 7-day window × (300000/30.44 per day) = 68995c (rounded)
+      expect(contractor.total_cost_cents).toBeGreaterThan(60000);
+      expect(contractor.total_cost_cents).toBeLessThan(80000);
+
+      // Invariant: per-employee totals sum back to the aggregate by comp type.
+      const { breakdown } = calculateActualLaborCost(employees, punches, start, end);
+      const hourlyTotalCents = summaries
+        .filter((s) => s.compensation_type === 'hourly')
+        .reduce((sum, s) => sum + s.total_cost_cents, 0);
+      expect(hourlyTotalCents).toBe(Math.round(breakdown.hourly.cost * 100));
+
+      const salaryTotalCents = summaries
+        .filter((s) => s.compensation_type === 'salary')
+        .reduce((sum, s) => sum + s.total_cost_cents, 0);
+      expect(salaryTotalCents).toBe(Math.round(breakdown.salary.cost * 100));
+
+      const contractorTotalCents = summaries
+        .filter((s) => s.compensation_type === 'contractor')
+        .reduce((sum, s) => sum + s.total_cost_cents, 0);
+      expect(contractorTotalCents).toBe(Math.round(breakdown.contractor.cost * 100));
+    });
+  });
+
+  describe('hours_per_day key alignment', () => {
+    it('uses the same date-bucket format as calculateActualLaborCost.daily_costs', () => {
+      const punches: TimePunch[] = [
+        punch('emp-hourly', '2026-05-15T09:00:00', 'clock_in'),
+        punch('emp-hourly', '2026-05-15T17:00:00', 'clock_out'),
+      ];
+
+      const start = new Date('2026-05-14T00:00:00');
+      const end = new Date('2026-05-16T23:59:59');
+
+      const [summary] = calculateHoursPerEmployee([hourlyEmployee], punches, start, end);
+      const { dailyCosts } = calculateActualLaborCost([hourlyEmployee], punches, start, end);
+
+      const summaryKeys = Object.keys(summary.hours_per_day);
+      const dailyKeys = dailyCosts.map((d) => d.date);
+
+      // Every key in hours_per_day must exist in dailyCosts (key shape contract).
+      summaryKeys.forEach((k) => expect(dailyKeys).toContain(k));
+
+      // For the day with hours, the value must match the aggregate hours_worked.
+      const day = dailyCosts.find((d) => d.date === '2026-05-15');
+      expect(day).toBeDefined();
+      expect(summary.hours_per_day['2026-05-15']).toBeCloseTo(day!.hours_worked, 4);
+    });
+  });
+
+  describe('work_periods passthrough', () => {
+    it('returns parsed work periods for each employee with isBreak set correctly', () => {
+      const punches: TimePunch[] = [
+        punch('emp-hourly', '2026-05-15T09:00:00', 'clock_in'),
+        punch('emp-hourly', '2026-05-15T12:00:00', 'break_start'),
+        punch('emp-hourly', '2026-05-15T12:30:00', 'break_end'),
+        punch('emp-hourly', '2026-05-15T17:00:00', 'clock_out'),
+      ];
+
+      const start = new Date('2026-05-15T00:00:00');
+      const end = new Date('2026-05-15T23:59:59');
+
+      const [summary] = calculateHoursPerEmployee([hourlyEmployee], punches, start, end);
+
+      expect(summary.work_periods.length).toBeGreaterThan(0);
+      const breakPeriods = summary.work_periods.filter((p) => p.isBreak);
+      const workPeriods = summary.work_periods.filter((p) => !p.isBreak);
+
+      expect(breakPeriods).toHaveLength(1);
+      expect(breakPeriods[0].hours).toBeCloseTo(0.5, 4);
+
+      const totalWorkHours = workPeriods.reduce((sum, p) => sum + p.hours, 0);
+      expect(totalWorkHours).toBeCloseTo(summary.total_hours, 4);
+    });
+  });
+});

--- a/tests/unit/laborCalculations.calculateHoursPerEmployee.test.ts
+++ b/tests/unit/laborCalculations.calculateHoursPerEmployee.test.ts
@@ -363,4 +363,54 @@ describe('calculateHoursPerEmployee', () => {
       expect(row.total_cost_cents).toBe(8 * 2000);
     });
   });
+
+  describe('overnight daily_rate shift', () => {
+    it('charges daily_rate for every calendar day a period touches, matching the breakdown', () => {
+      // Regression for CodeRabbit's finding: a daily_rate employee with one
+      // overnight period (Mon 10pm → Tue 6am) must be charged 2 × daily_rate,
+      // because calculateActualLaborCost marks both days active. Keying off
+      // hours_per_day (start-day only) would credit just 1 day and break
+      // parity with the breakdown.
+      const dailyRateEmployee: Employee = {
+        id: 'emp-daily',
+        restaurant_id: 'r1',
+        name: 'Daily Dave',
+        position: 'Line Cook',
+        status: 'active',
+        is_active: true,
+        compensation_type: 'daily_rate',
+        hourly_rate: 0,
+        daily_rate_amount: 15000, // $150/day
+        is_exempt: true,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      } as Employee;
+
+      const punches: TimePunch[] = [
+        punch('emp-daily', '2026-05-19T22:00:00', 'clock_in'),
+        punch('emp-daily', '2026-05-20T06:00:00', 'clock_out'),
+      ];
+
+      const start = new Date('2026-05-19T00:00:00');
+      const end = new Date('2026-05-20T23:59:59');
+
+      const [row] = calculateHoursPerEmployee([dailyRateEmployee], punches, start, end);
+
+      // 2 calendar days touched → 2 × $150 = $300
+      expect(row.total_cost_cents).toBe(2 * 15000);
+      expect(row.days_worked).toBe(2);
+      // hours stay attributed to the start day (matches breakdown)
+      expect(Object.keys(row.hours_per_day)).toEqual(['2026-05-19']);
+      expect(row.total_hours).toBeCloseTo(8, 4);
+
+      // Parity check: per-employee daily_rate cost sums back to breakdown total.
+      const { breakdown } = calculateActualLaborCost(
+        [dailyRateEmployee],
+        punches,
+        start,
+        end,
+      );
+      expect(row.total_cost_cents).toBe(Math.round(breakdown.daily_rate.cost * 100));
+    });
+  });
 });

--- a/tests/unit/laborCalculations.calculateHoursPerEmployee.test.ts
+++ b/tests/unit/laborCalculations.calculateHoursPerEmployee.test.ts
@@ -270,4 +270,97 @@ describe('calculateHoursPerEmployee', () => {
       expect(totalWorkHours).toBeCloseTo(summary.total_hours, 4);
     });
   });
+
+  describe('mid-period compensation_history changes', () => {
+    it('bills hourly days at the historical rate and salary days at the historical allocation', () => {
+      // Employee starts hourly @ $20/hr through May 17, then converts to a
+      // weekly $1,000 salary effective May 18. Window covers both segments.
+      const employee: Employee = {
+        ...hourlyEmployee,
+        id: 'emp-converted',
+        name: 'Converted Cara',
+        compensation_type: 'salary', // current = salary
+        salary_amount: 100000, // $1,000/week
+        pay_period_type: 'weekly',
+        hourly_rate: 0,
+        compensation_history: [
+          {
+            id: 'h1',
+            employee_id: 'emp-converted',
+            restaurant_id: 'r1',
+            compensation_type: 'hourly',
+            amount_cents: 2000, // $20/hr
+            effective_date: '2026-01-01',
+            created_at: '2026-01-01T00:00:00Z',
+          },
+          {
+            id: 'h2',
+            employee_id: 'emp-converted',
+            restaurant_id: 'r1',
+            compensation_type: 'salary',
+            amount_cents: 100000,
+            pay_period_type: 'weekly',
+            effective_date: '2026-05-18',
+            created_at: '2026-05-18T00:00:00Z',
+          },
+        ],
+      } as Employee;
+
+      const punches: TimePunch[] = [
+        // May 16 (hourly): 8h
+        punch('emp-converted', '2026-05-16T09:00:00', 'clock_in'),
+        punch('emp-converted', '2026-05-16T17:00:00', 'clock_out'),
+        // May 17 (hourly): 6h
+        punch('emp-converted', '2026-05-17T10:00:00', 'clock_in'),
+        punch('emp-converted', '2026-05-17T16:00:00', 'clock_out'),
+        // May 18 (salary): clock-ins recorded but cost is period-allocated
+        punch('emp-converted', '2026-05-18T08:00:00', 'clock_in'),
+        punch('emp-converted', '2026-05-18T16:00:00', 'clock_out'),
+      ];
+
+      const start = new Date('2026-05-16T00:00:00');
+      const end = new Date('2026-05-22T23:59:59'); // 7-day window
+
+      const [row] = calculateHoursPerEmployee([employee], punches, start, end);
+
+      // Hourly portion: (8 + 6) h × $20/h = $280 = 28,000 cents
+      const expectedHourlyCents = (8 + 6) * 2000;
+
+      // Salary portion: 5 days in window (May 18-22) × ($1000 / 7) per day
+      const dailySalary = 100000 / 7;
+      const expectedSalaryCents = Math.round(5 * dailySalary);
+
+      // Total must include both — the bug had only the current comp_type bucket
+      // running, so 28,000 cents of hourly work would have been silently dropped.
+      expect(row.total_cost_cents).toBe(expectedHourlyCents + expectedSalaryCents);
+      expect(row.total_hours).toBeCloseTo(8 + 6 + 8, 4);
+      expect(row.days_worked).toBe(3);
+    });
+  });
+
+  describe('shift crossing midnight at window end', () => {
+    it('drops periods whose clock_in starts after endDate (lookahead-window orphans)', () => {
+      // Punches in a lookahead window (after endDate) should NOT contribute
+      // hours or cost. This protects executeGetTimePunches which fetches
+      // with an end-of-window lookahead and relies on this filter.
+      const punches: TimePunch[] = [
+        // In window: 8h
+        punch('emp-hourly', '2026-05-16T09:00:00', 'clock_in'),
+        punch('emp-hourly', '2026-05-16T17:00:00', 'clock_out'),
+        // After endDate (in lookahead zone): should be dropped
+        punch('emp-hourly', '2026-05-17T08:00:00', 'clock_in'),
+        punch('emp-hourly', '2026-05-17T14:00:00', 'clock_out'),
+      ];
+
+      const start = new Date('2026-05-16T00:00:00');
+      const end = new Date('2026-05-16T23:59:59');
+
+      const [row] = calculateHoursPerEmployee([hourlyEmployee], punches, start, end);
+
+      expect(row.total_hours).toBeCloseTo(8, 4);
+      expect(row.days_worked).toBe(1);
+      expect(Object.keys(row.hours_per_day)).toEqual(['2026-05-16']);
+      expect(row.total_cost_cents).toBe(8 * 2000);
+    });
+  });
 });

--- a/tests/unit/tools-registry.test.ts
+++ b/tests/unit/tools-registry.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getTools,
+  canUseTool,
+  requiredRoleFor,
+} from '../../supabase/functions/_shared/tools-registry';
+
+/**
+ * Tests for AI chat tool registration + role gating.
+ *
+ * Two layers of defense are exercised here:
+ *  1. `getTools()` — tool *visibility*. Tools the user can't call should not
+ *     appear in the list sent to the model, so the model can't even attempt them.
+ *  2. `canUseTool()` — dispatcher-level *enforcement*. Even if the model
+ *     hallucinates a tool name, the dispatcher must reject it.
+ *
+ * The `requiredRoleFor()` helper powers the unified TOOL_PERMISSION_DENIED
+ * response shape (see ai-execute-tool/index.ts).
+ *
+ * Scope: this file covers the edge-function tool registry only. UI capabilities
+ * (`@/lib/permissions`) are exercised separately in `permissions.test.ts`.
+ */
+
+const ALL_ROLES = [
+  'kiosk',
+  'staff',
+  'chef',
+  'manager',
+  'owner',
+  'collaborator_accountant',
+  'collaborator_inventory',
+  'collaborator_chef',
+] as const;
+
+const MANAGER_OWNER = new Set(['manager', 'owner']);
+const STAFF_AND_UP = new Set(['staff', 'chef', 'manager', 'owner']);
+
+describe('tools-registry: get_time_punches gating', () => {
+  describe('canUseTool', () => {
+    it.each(ALL_ROLES)('rejects %s unless manager/owner', (role) => {
+      const expected = MANAGER_OWNER.has(role);
+      expect(canUseTool('get_time_punches', role)).toBe(expected);
+    });
+  });
+
+  describe('getTools visibility', () => {
+    it.each(ALL_ROLES)('only exposes get_time_punches to manager/owner for %s', (role) => {
+      const tools = getTools('rest-1', role);
+      const names = tools.map((t) => t.name);
+      const expected = MANAGER_OWNER.has(role);
+      expect(names.includes('get_time_punches')).toBe(expected);
+    });
+
+    it('exposes a well-formed tool definition for manager', () => {
+      const tools = getTools('rest-1', 'manager');
+      const def = tools.find((t) => t.name === 'get_time_punches');
+      expect(def).toBeDefined();
+      expect(def!.description.toLowerCase()).toContain('work period');
+      expect(def!.parameters.required).toContain('period');
+
+      const periodProp = def!.parameters.properties.period as {
+        enum?: string[];
+      };
+      expect(periodProp.enum).toEqual(
+        expect.arrayContaining(['today', 'yesterday', 'week', 'last_week', 'month', 'last_month', 'custom']),
+      );
+    });
+  });
+
+  describe('requiredRoleFor', () => {
+    it('returns manager for get_time_punches', () => {
+      expect(requiredRoleFor('get_time_punches')).toBe('manager');
+    });
+
+    it('returns staff for a basic tool like get_kpis', () => {
+      expect(requiredRoleFor('get_kpis')).toBe('staff');
+    });
+
+    it('returns manager for other manager-tier tools', () => {
+      expect(requiredRoleFor('get_payroll_summary')).toBe('manager');
+      expect(requiredRoleFor('get_financial_intelligence')).toBe('manager');
+    });
+
+    it('returns owner for owner-only tools', () => {
+      expect(requiredRoleFor('get_ai_insights')).toBe('owner');
+    });
+  });
+});
+
+describe('tools-registry: get_labor_costs description signals per-employee fields', () => {
+  it('mentions that include_employee_breakdown is manager+owner only', () => {
+    const tools = getTools('rest-1', 'manager');
+    const def = tools.find((t) => t.name === 'get_labor_costs');
+    expect(def).toBeDefined();
+    const desc = def!.description.toLowerCase();
+    expect(desc).toContain('include_employee_breakdown');
+    expect(desc).toContain('manager');
+  });
+});
+
+describe('tools-registry: requiredRoleFor / canUseTool invariant', () => {
+  // Whatever role requiredRoleFor returns, canUseTool MUST be true for that role
+  // and false for the role one tier below it. This guards the dispatcher's
+  // "what should I tell the user they need?" message against drifting from the
+  // actual permission check.
+  const tools = [
+    'get_kpis',
+    'get_inventory_status',
+    'get_labor_costs',
+    'get_time_punches',
+    'get_payroll_summary',
+    'get_financial_intelligence',
+    'get_ai_insights',
+  ];
+
+  it.each(tools)('required role for %s satisfies canUseTool', (toolName) => {
+    const required = requiredRoleFor(toolName);
+    expect(canUseTool(toolName, required)).toBe(true);
+
+    // Staff tools should still allow manager/owner.
+    if (required === 'staff') {
+      expect(STAFF_AND_UP.has('manager')).toBe(true);
+      expect(canUseTool(toolName, 'manager')).toBe(true);
+      expect(canUseTool(toolName, 'owner')).toBe(true);
+    }
+
+    // Manager tools should not be usable by staff/chef.
+    if (required === 'manager') {
+      expect(canUseTool(toolName, 'staff')).toBe(false);
+      expect(canUseTool(toolName, 'chef')).toBe(false);
+      expect(canUseTool(toolName, 'kiosk')).toBe(false);
+      expect(canUseTool(toolName, 'collaborator_accountant')).toBe(false);
+      expect(canUseTool(toolName, 'collaborator_inventory')).toBe(false);
+      expect(canUseTool(toolName, 'collaborator_chef')).toBe(false);
+    }
+
+    // Owner tools should not be usable by manager.
+    if (required === 'owner') {
+      expect(canUseTool(toolName, 'manager')).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Enables the AI chat to answer questions about employee time punches, hours worked, and labor costs. Today the chat has no view into `time_punches`, so it can't answer \"How many hours did Jane work last week?\" or \"What's our labor cost for tonight's dinner shift?\"

This PR ships two layers of access (per the approved design):

1. **Enhance `get_labor_costs`** — already aggregates labor cost from punches but was leaking partial employee records when a position filter matched zero punches. Now returns a consistent shape and respects an 18h lookahead so shifts crossing midnight at the window end aren't dropped.
2. **New `get_time_punches` tool** — returns per-shift detail (work periods with break deduction, per-shift cost, per-employee summaries). Manager + owner only; defense-in-depth role gate at the dispatcher *and* at the handler.

## What changed

**New tool & shared helper**
- `get_time_punches` tool definition in `tools-registry.ts` (OpenAI function-calling schema)
- New `calculateHoursPerEmployee()` in the shared labor-calculations module (both `src/` and `supabase/functions/_shared/` — Deno can't import from `src/`, so the two files are intentionally kept in sync)
- Algorithm: pair punches into work periods via `parseWorkPeriods`, filter to window, then cost each day with `getEmployeeSnapshotForDate` so mid-period compensation changes (hourly → salary) are honored

**Edge-function dispatcher**
- `fetchLaborData` extracted and accepts an options bag (`employeeId`, `position`, `endLookaheadHours`)
- Position filter pushed server-side as `.ilike('position', position)` — was previously client-side
- Custom date ranges now end at 23:59:59 local (was midnight, dropping the last day's punches)
- All date strings serialized via `toLocalYMD` instead of `.toISOString().split('T')[0]` (TZ drift fix)
- `formatShiftDate` helper deduped against shared `formatDateLocal`

**Index**
- `idx_time_punches_restaurant_punch_time` migration (CREATE INDEX CONCURRENTLY, sole statement per Postgres requirement) — supports the new range queries

**RLS posture**
- Tool handlers use the *user's* JWT, not the service role, so `time_punches` and `employees` RLS policies are enforced. Kiosk / staff / chef can never invoke the tool because the dispatcher's `canUseTool` gate rejects them before any query runs.

## Triage fixes (squashed into the last commit)

While verifying I caught a handful of correctness issues in the new path:

1. **Mid-period compensation changes** — switched from \"branch on current comp_type\" to \"always run all four cost helpers, let per-day snapshot resolution gate.\" An employee converted hourly → salary mid-window was previously charged the wrong amount.
2. **Window-end lookahead** — `endLookaheadHours: 18` so a punch-in at 11pm Sun with punch-out at 2am Mon shows up under Sunday in a Sun-only range
3. **Custom period EOD** — fixed off-by-one
4. **Server-side position filter** — was client-side, paginated incorrectly with many employees
5. **`has_more` flag** in `get_time_punches` response
6. **Per-shift cost via per-day snapshot** (not employee-level current rate)
7. **Local-TZ date strings** throughout the dispatcher
8. **`formatShiftDate` dedupe**

## Test plan

- [x] Unit tests pass — `calculateHoursPerEmployee` covers: hourly only, salary only, contractor, daily-rate, mid-period comp change, shift crossing midnight at window end, position filter
- [x] `tools-registry` tests cover the new `get_time_punches` schema and role gate
- [x] `ai-tools-date-resolution` test covers custom-period inclusive EOD
- [x] Typecheck, lint, build all clean (lint net -1 vs baseline)
- [ ] Manual: in dev, ask the AI \"How many hours did <employee> work last week?\" and verify it calls `get_time_punches` and returns the right number
- [ ] Manual: same prompt as a kiosk/staff user — should be denied at the role gate, AI should not see the tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Managers and owners can now query work periods and shift details through AI chat.
  * Enhanced labor cost insights with per-employee hour and cost breakdowns (manager/owner access only).
  * Improved AI assistant guidance for labor and shift-related questions.

* **Documentation**
  * Added implementation plan and design specification for time-punch access feature.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/toyiyo/nimble-pnl/pull/519?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->