### PR TITLE
fix(open-shifts): include capacity-1 templates in claimable pool

### DIFF
--- a/docs/superpowers/plans/2026-05-29-open-shifts-capacity-one-plan.md
+++ b/docs/superpowers/plans/2026-05-29-open-shifts-capacity-one-plan.md
@@ -1,0 +1,33 @@
+# Plan: Include capacity-1 templates in open-shift pool
+
+Spec: `docs/superpowers/specs/2026-05-29-open-shifts-capacity-one-design.md`
+
+## Tasks
+
+### Task 1 — RED: write the regression test
+- Create `supabase/tests/open_shifts_capacity_one.test.sql`, `plan(3)`.
+- Fixtures: restaurant (America/Chicago), capacity-1 Sunday "Server"
+  template, two employees, `staffing_settings` (open_shifts_enabled=true,
+  require_shift_claim_approval=false), `schedule_publications` for the
+  next-Sunday week. RLS off; `BEGIN … ROLLBACK`.
+- Assert (1) capacity-1 template shows `open_spots = 1`; (2) after one
+  instant claim, template no longer returned (`NOT EXISTS`); (3) second
+  claim returns `success = false`.
+- Run `npm run test:db` → test 1 should FAIL against current schema
+  (capacity-1 excluded by `> 1`).
+- Dependency: none.
+
+### Task 2 — GREEN: write the fix migration
+- Create `supabase/migrations/20260529120000_fix_open_shifts_capacity_one.sql`.
+- `CREATE OR REPLACE FUNCTION public.get_open_shifts(...)` — body copied
+  verbatim from `20260413001912`, with: `st.capacity > 1` → `st.capacity > 0`,
+  add `SET search_path = public`, declare `STABLE`.
+- Run `npm run test:db` → all 3 new tests PASS, existing
+  `open_shift_claim_timezone` + `open_shift_claims` tests still PASS.
+- Dependency: Task 1.
+
+### Task 3 — Verify & regression-sweep
+- `npm run test:db` full suite green.
+- `npm run typecheck`, `npm run lint`, `npm run build` (no TS touched but
+  workflow Phase 8 requires the full gate).
+- Dependency: Task 2.

--- a/docs/superpowers/specs/2026-05-29-open-shifts-capacity-one-design.md
+++ b/docs/superpowers/specs/2026-05-29-open-shifts-capacity-one-design.md
@@ -35,16 +35,26 @@ single guard changed:
 +          AND st.capacity > 0
 ```
 
-`> 0` (equivalent to `>= 1` for the INT column) is chosen over `>= 1`
-because it also defends against any 0/negative capacity rows without
-relying on a CHECK constraint. The final `open_spots > 0` WHERE clause
-already filters out fully-claimed shifts, so a capacity-0 template would
-produce no rows anyway — `> 0` just makes the intent explicit.
+`> 0` is the clean semantic equivalent of `>= 1` for this INT column —
+"the template must allow at least one person." It is **not** extra
+defense against 0/negative rows: `20260411221543_add_capacity_to_shift_templates.sql`
+already enforces `CHECK (capacity >= 1)` (default 1), so sub-1 capacities
+cannot exist. `> 0` is chosen purely for readability; `>= 1` would be
+equally correct. The final `open_spots > 0` WHERE clause independently
+filters fully-claimed shifts.
 
 Migrations are immutable once applied; the historical migration is left
-untouched and the fix ships as a new `CREATE OR REPLACE` migration. The
-function body is otherwise copied verbatim from the latest definition
-(timezone-aware `AT TIME ZONE` comparisons preserved).
+untouched and the fix ships as a new `CREATE OR REPLACE` migration,
+filename timestamped `20260529…` (must sort after the current last
+migration `20260524120200`). The function body is otherwise copied
+verbatim from the latest definition (timezone-aware `AT TIME ZONE`
+comparisons preserved), with two opportunistic hardening tweaks since
+the whole body is being rewritten:
+
+- Add `SET search_path = public` to the `SECURITY DEFINER` function
+  (closes a pre-existing search-path-shadowing gap on this function).
+- Declare the function `STABLE` (it is read-only — more honest than the
+  default `VOLATILE` and lets the planner call it fewer times).
 
 ## `claim_open_shift` — no change needed
 
@@ -62,15 +72,30 @@ test to pin this behavior rather than changing code.
 
 ## Tests (pgTAP)
 
-New file `supabase/tests/open_shifts_capacity_one.test.sql`:
+New file `supabase/tests/open_shifts_capacity_one.test.sql`, `SELECT plan(3)`:
 
 1. A `capacity = 1` template on a published future date appears in
-   `get_open_shifts` with `open_spots = 1`. **(fails before the fix)**
-2. After one instant `claim_open_shift`, the capacity-1 template
-   disappears from `get_open_shifts` (0 open spots, filtered out).
+   `get_open_shifts` with `open_spots = 1`. **(fails before the fix —
+   no row returned)**
+2. After one instant `claim_open_shift`, the capacity-1 template no
+   longer appears in `get_open_shifts` — asserted via
+   `COUNT(*) = 0`/`NOT EXISTS`. A code comment notes *why* it drops out:
+   the instant-claim path inserts an `open_shift_claims` row with
+   `status = 'approved'` (not `'pending_approval'`), so `pending_claims`
+   stays 0; the slot count is driven to 0 by `assigned_count` (the
+   `shifts` join), then the final `open_spots > 0` WHERE filters the row.
 3. A second `claim_open_shift` on the now-full capacity-1 template
    returns `success = false` / "No open spots available" — pins the
-   `claim_open_shift` guard.
+   `claim_open_shift` guard for `capacity = 1`.
+
+**Required fixtures** (mirroring `open_shift_claim_timezone.test.sql`):
+`restaurants`, `shift_templates` (capacity 1), `employees`,
+`staffing_settings` with `open_shifts_enabled = true` +
+`require_shift_claim_approval = false` (instant claim), and a
+`schedule_publications` row covering the target week. Omitting
+`staffing_settings`/`schedule_publications` would make `get_open_shifts`
+early-return / return no rows and surface as a confusing
+"planned 3, ran 0" rather than a clear assertion failure.
 
 Dates use the `CURRENT_DATE + (7 - EXTRACT(DOW FROM CURRENT_DATE)::int)`
 next-Sunday pattern (per the 2026-04-21 lesson: never hardcode future

--- a/docs/superpowers/specs/2026-05-29-open-shifts-capacity-one-design.md
+++ b/docs/superpowers/specs/2026-05-29-open-shifts-capacity-one-design.md
@@ -1,0 +1,84 @@
+# Design: Include capacity-1 templates in the open-shift pool
+
+**Date:** 2026-05-29
+**Branch:** `fix/open-shifts-capacity-one`
+**Type:** Bug fix (SQL + pgTAP regression test)
+
+## Problem
+
+`get_open_shifts` filters templates with `AND st.capacity > 1` (line 77 of
+`supabase/migrations/20260413001912_fix_shift_claim_timezone.sql`, and
+identically in the two earlier migrations that defined the function). This
+silently excludes any `shift_template` with `capacity = 1` from the
+claimable open-shift pool.
+
+The AI scheduler routinely produces single-person crew allocations (e.g.
+"1 Server"). These are written to `shift_templates` with `capacity = 1`,
+and the user sees an "open shifts created" toast — but those shifts never
+appear in `get_open_shifts`, so no employee can ever claim them. The UI
+promise and the data contract diverge.
+
+## Root cause
+
+The `> 1` guard was almost certainly intended as a no-op optimization
+(skip templates that can hold nobody), but the correct boundary is "can
+hold **at least one** person," i.e. `capacity > 0`. `> 1` accidentally
+drops the most common case the scheduler emits.
+
+## Fix
+
+Add a new migration that `CREATE OR REPLACE`s `get_open_shifts` with the
+single guard changed:
+
+```diff
+-          AND st.capacity > 1
++          AND st.capacity > 0
+```
+
+`> 0` (equivalent to `>= 1` for the INT column) is chosen over `>= 1`
+because it also defends against any 0/negative capacity rows without
+relying on a CHECK constraint. The final `open_spots > 0` WHERE clause
+already filters out fully-claimed shifts, so a capacity-0 template would
+produce no rows anyway — `> 0` just makes the intent explicit.
+
+Migrations are immutable once applied; the historical migration is left
+untouched and the fix ships as a new `CREATE OR REPLACE` migration. The
+function body is otherwise copied verbatim from the latest definition
+(timezone-aware `AT TIME ZONE` comparisons preserved).
+
+## `claim_open_shift` — no change needed
+
+`claim_open_shift`'s capacity guard is:
+
+```sql
+IF (v_assigned_count + v_pending_count) >= v_template.capacity THEN
+    RETURN ... 'No open spots available';
+```
+
+For `capacity = 1` this is already correct: the first claim sees
+`0 >= 1` → false (allowed), the second sees `1 >= 1` → true (blocked).
+There is **no** parallel `> 1` exclusion bug here. We add a regression
+test to pin this behavior rather than changing code.
+
+## Tests (pgTAP)
+
+New file `supabase/tests/open_shifts_capacity_one.test.sql`:
+
+1. A `capacity = 1` template on a published future date appears in
+   `get_open_shifts` with `open_spots = 1`. **(fails before the fix)**
+2. After one instant `claim_open_shift`, the capacity-1 template
+   disappears from `get_open_shifts` (0 open spots, filtered out).
+3. A second `claim_open_shift` on the now-full capacity-1 template
+   returns `success = false` / "No open spots available" — pins the
+   `claim_open_shift` guard.
+
+Dates use the `CURRENT_DATE + (7 - EXTRACT(DOW FROM CURRENT_DATE)::int)`
+next-Sunday pattern (per the 2026-04-21 lesson: never hardcode future
+dates in pgTAP). Fixtures follow the deterministic pattern: RLS off,
+delete-before-insert / `ON CONFLICT DO UPDATE`, all inside
+`BEGIN … ROLLBACK`.
+
+## Scope
+
+SQL migration + pgTAP test only. No UI, no TypeScript, no edge-function
+changes.

--- a/supabase/migrations/20260529120000_fix_open_shifts_capacity_one.sql
+++ b/supabase/migrations/20260529120000_fix_open_shifts_capacity_one.sql
@@ -90,7 +90,7 @@ BEGIN
         CROSS JOIN published_dates pd
         WHERE st.restaurant_id = p_restaurant_id
           AND st.is_active = true
-          AND st.capacity > 0  -- include single-person crews (was `> 1`, which dropped capacity-1 templates)
+          AND st.capacity > 0  -- include single-person crews (capacity 1)
           AND EXTRACT(DOW FROM pd.pub_date)::int = ANY(st.days)
     ),
     assigned AS (
@@ -139,3 +139,8 @@ BEGIN
     ORDER BY td.pub_date, td.tmpl_start;
 END;
 $$;
+
+-- Re-issue EXECUTE so the privilege is self-contained in this migration.
+-- (CREATE OR REPLACE preserves the existing GRANT from 20260412145842, but
+--  re-declaring keeps the migration valid under selective replay / drop+create.)
+GRANT EXECUTE ON FUNCTION public.get_open_shifts(UUID, DATE, DATE) TO authenticated;

--- a/supabase/migrations/20260529120000_fix_open_shifts_capacity_one.sql
+++ b/supabase/migrations/20260529120000_fix_open_shifts_capacity_one.sql
@@ -1,0 +1,141 @@
+-- Include capacity-1 templates in the open-shift pool.
+--
+-- get_open_shifts filtered templates with `st.capacity > 1`, silently
+-- excluding single-person crew allocations (e.g. the AI scheduler's
+-- "1 Server") from the claimable open-shift pool. Such templates were
+-- written to shift_templates and surfaced an "open shifts created" toast,
+-- but never appeared as claimable open shifts — the UI promise diverged
+-- from the data contract.
+--
+-- Fix: change the guard to `st.capacity > 0` (the clean equivalent of
+-- `>= 1`; shift_templates already enforces CHECK (capacity >= 1)). The
+-- final `open_spots > 0` WHERE clause still filters fully-claimed shifts.
+--
+-- The body is copied verbatim from 20260413001912_fix_shift_claim_timezone.sql
+-- (timezone-aware AT TIME ZONE comparisons preserved), with two opportunistic
+-- hardening tweaks since the whole body is being rewritten:
+--   * SET search_path = public  — pin the search path on this SECURITY DEFINER
+--     function so a hostile schema can't shadow public tables.
+--   * STABLE                    — the function is read-only.
+--
+-- claim_open_shift is intentionally NOT changed: its guard
+-- (assigned + pending >= capacity) is already correct for capacity = 1
+-- (1st claim: 0 >= 1 false → allowed; 2nd: 1 >= 1 true → blocked).
+
+CREATE OR REPLACE FUNCTION public.get_open_shifts(
+    p_restaurant_id UUID,
+    p_week_start DATE,
+    p_week_end DATE
+)
+RETURNS TABLE (
+    template_id UUID,
+    template_name TEXT,
+    shift_date DATE,
+    start_time TIME,
+    end_time TIME,
+    "position" TEXT,
+    area TEXT,
+    "capacity" INT,
+    assigned_count BIGINT,
+    pending_claims BIGINT,
+    open_spots BIGINT
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_tz TEXT;
+BEGIN
+    -- Look up the restaurant timezone
+    SELECT COALESCE(r.timezone, 'America/Chicago') INTO v_tz
+    FROM public.restaurants r WHERE r.id = p_restaurant_id;
+
+    -- Check if open shifts are enabled for this restaurant
+    IF NOT EXISTS (
+        SELECT 1 FROM public.staffing_settings
+        WHERE restaurant_id = p_restaurant_id
+          AND open_shifts_enabled = true
+    ) THEN
+        RETURN;
+    END IF;
+
+    RETURN QUERY
+    WITH published_dates AS (
+        -- Get all dates within published schedule weeks, excluding past dates
+        SELECT DISTINCT d::date AS pub_date
+        FROM public.schedule_publications sp,
+             generate_series(
+                 GREATEST(sp.week_start_date, p_week_start),
+                 LEAST(sp.week_end_date, p_week_end),
+                 '1 day'::interval
+             ) AS d
+        WHERE sp.restaurant_id = p_restaurant_id
+          AND sp.week_start_date <= p_week_end
+          AND sp.week_end_date >= p_week_start
+          AND d::date >= CURRENT_DATE  -- Only today and future dates
+    ),
+    template_days AS (
+        SELECT
+            st.id AS tmpl_id,
+            st.name AS tmpl_name,
+            pd.pub_date,
+            st.start_time AS tmpl_start,
+            st.end_time AS tmpl_end,
+            st.position AS tmpl_position,
+            st.area AS tmpl_area,
+            st.capacity AS tmpl_capacity
+        FROM public.shift_templates st
+        CROSS JOIN published_dates pd
+        WHERE st.restaurant_id = p_restaurant_id
+          AND st.is_active = true
+          AND st.capacity > 0  -- include single-person crews (was `> 1`, which dropped capacity-1 templates)
+          AND EXTRACT(DOW FROM pd.pub_date)::int = ANY(st.days)
+    ),
+    assigned AS (
+        -- Count existing shifts matching template's position + time + date
+        -- Use AT TIME ZONE to convert UTC timestamps to local before extracting
+        SELECT
+            td.tmpl_id,
+            td.pub_date,
+            COUNT(s.id) AS cnt
+        FROM template_days td
+        LEFT JOIN public.shifts s
+            ON s.restaurant_id = p_restaurant_id
+            AND s.position = td.tmpl_position
+            AND (s.start_time AT TIME ZONE v_tz)::time = td.tmpl_start
+            AND (s.end_time AT TIME ZONE v_tz)::time = td.tmpl_end
+            AND (s.start_time AT TIME ZONE v_tz)::date = td.pub_date
+            AND s.status != 'cancelled'
+        GROUP BY td.tmpl_id, td.pub_date
+    ),
+    pending AS (
+        SELECT
+            osc.shift_template_id,
+            osc.shift_date,
+            COUNT(osc.id) AS cnt
+        FROM public.open_shift_claims osc
+        WHERE osc.restaurant_id = p_restaurant_id
+          AND osc.status = 'pending_approval'
+        GROUP BY osc.shift_template_id, osc.shift_date
+    )
+    SELECT
+        td.tmpl_id,
+        td.tmpl_name,
+        td.pub_date,
+        td.tmpl_start,
+        td.tmpl_end,
+        td.tmpl_position,
+        td.tmpl_area,
+        td.tmpl_capacity,
+        COALESCE(a.cnt, 0),
+        COALESCE(p.cnt, 0),
+        (td.tmpl_capacity - COALESCE(a.cnt, 0) - COALESCE(p.cnt, 0))
+    FROM template_days td
+    LEFT JOIN assigned a ON a.tmpl_id = td.tmpl_id AND a.pub_date = td.pub_date
+    LEFT JOIN pending p ON p.shift_template_id = td.tmpl_id AND p.shift_date = td.pub_date
+    WHERE (td.tmpl_capacity - COALESCE(a.cnt, 0) - COALESCE(p.cnt, 0)) > 0
+    ORDER BY td.pub_date, td.tmpl_start;
+END;
+$$;

--- a/supabase/tests/open_shifts_capacity_one.test.sql
+++ b/supabase/tests/open_shifts_capacity_one.test.sql
@@ -1,0 +1,158 @@
+-- pgTAP regression test: capacity-1 templates must be claimable open shifts.
+--
+-- Bug: get_open_shifts filtered templates with `st.capacity > 1`, silently
+-- excluding single-person crew allocations (e.g. the AI scheduler's "1 Server")
+-- from the open-shift pool. They were applied to shift_templates and surfaced
+-- an "open shifts created" toast, but never appeared as claimable shifts.
+-- Fix changes the guard to `st.capacity > 0`.
+--
+-- Also pins that claim_open_shift's capacity guard
+-- (`assigned + pending >= capacity`) correctly blocks the 2nd claim on a
+-- capacity-1 template.
+
+BEGIN;
+
+SELECT plan(3);
+
+-- ============================================
+-- Setup: disable RLS and seed test data
+-- ============================================
+
+SET LOCAL role TO postgres;
+ALTER TABLE restaurants DISABLE ROW LEVEL SECURITY;
+ALTER TABLE shift_templates DISABLE ROW LEVEL SECURITY;
+ALTER TABLE shifts DISABLE ROW LEVEL SECURITY;
+ALTER TABLE employees DISABLE ROW LEVEL SECURITY;
+ALTER TABLE staffing_settings DISABLE ROW LEVEL SECURITY;
+ALTER TABLE schedule_publications DISABLE ROW LEVEL SECURITY;
+ALTER TABLE open_shift_claims DISABLE ROW LEVEL SECURITY;
+
+-- Compute a target Sunday that is always in the future (never hardcode
+-- future dates — see lessons 2026-04-21). DOW=0 is Sunday; when today is
+-- Sunday, +7 avoids using today.
+CREATE TEMP TABLE test_config AS
+SELECT CURRENT_DATE + (7 - EXTRACT(DOW FROM CURRENT_DATE)::int) AS target_sunday;
+
+-- Auth user for FK references (schedule_publications.published_by)
+INSERT INTO auth.users (id, email)
+VALUES ('dddddddd-ca01-0000-0000-000000000001', 'cap1-test@example.com')
+ON CONFLICT DO NOTHING;
+
+-- Restaurant in CDT timezone
+INSERT INTO restaurants (id, name, timezone)
+VALUES ('aaaaaaaa-ca01-0000-0000-000000000001', 'Cap1 Test Restaurant', 'America/Chicago')
+ON CONFLICT (id) DO UPDATE SET timezone = 'America/Chicago';
+
+-- Template: capacity = 1 (the regression case). Closing 3:30p-10p Sundays.
+INSERT INTO shift_templates (id, restaurant_id, name, start_time, end_time, position, days, capacity)
+VALUES (
+  'bbbbbbbb-ca01-0000-0000-000000000001',
+  'aaaaaaaa-ca01-0000-0000-000000000001',
+  'Solo Closer',
+  '15:30:00', '22:00:00',
+  'Server',
+  '{0}',  -- Sunday only
+  1       -- single-person crew
+)
+ON CONFLICT (id) DO UPDATE SET capacity = 1;
+
+-- Two employees (second one drives the "no open spots" 2nd-claim test).
+INSERT INTO employees (id, restaurant_id, name, position, status, is_active)
+VALUES
+  ('cccccccc-ca01-0000-0000-000000000001', 'aaaaaaaa-ca01-0000-0000-000000000001', 'Cap1 Emp 1', 'Server', 'active', true),
+  ('cccccccc-ca01-0000-0000-000000000002', 'aaaaaaaa-ca01-0000-0000-000000000001', 'Cap1 Emp 2', 'Server', 'active', true)
+ON CONFLICT (id) DO NOTHING;
+
+-- Enable open shifts, NO approval required (instant claim creates the shift).
+INSERT INTO staffing_settings (restaurant_id, open_shifts_enabled, require_shift_claim_approval)
+VALUES ('aaaaaaaa-ca01-0000-0000-000000000001', true, false)
+ON CONFLICT (restaurant_id) DO UPDATE
+SET open_shifts_enabled = true, require_shift_claim_approval = false;
+
+-- Publish schedule for the week ending on target_sunday.
+INSERT INTO schedule_publications (restaurant_id, week_start_date, week_end_date, published_by, shift_count)
+SELECT
+  'aaaaaaaa-ca01-0000-0000-000000000001',
+  target_sunday - 6,
+  target_sunday,
+  'dddddddd-ca01-0000-0000-000000000001',
+  0
+FROM test_config;
+
+-- ============================================
+-- Test 1: capacity-1 template appears as a claimable open shift.
+-- (Fails before the fix: `st.capacity > 1` excludes the template entirely,
+--  so get_open_shifts returns NO row and open_spots comes back NULL.)
+-- ============================================
+
+SELECT is(
+  (
+    SELECT open_spots
+    FROM get_open_shifts(
+      'aaaaaaaa-ca01-0000-0000-000000000001',
+      (SELECT target_sunday - 6 FROM test_config),
+      (SELECT target_sunday FROM test_config)
+    )
+    WHERE shift_date = (SELECT target_sunday FROM test_config)
+    LIMIT 1
+  ),
+  1::bigint,
+  'capacity-1 template shows 1 open spot in get_open_shifts'
+);
+
+-- ============================================
+-- Test 2: after one instant claim, the now-full capacity-1 template is no
+-- longer returned by get_open_shifts.
+--
+-- Note on WHY it drops out: instant claim inserts an open_shift_claims row
+-- with status='approved' (not 'pending_approval'), so the pending_claims CTE
+-- stays 0. The slot count is driven to 0 by assigned_count (the shifts join
+-- on position+time+date), then the final `open_spots > 0` WHERE filters it.
+-- ============================================
+
+-- Instant claim by employee 1.
+SELECT claim_open_shift(
+  'aaaaaaaa-ca01-0000-0000-000000000001',
+  'bbbbbbbb-ca01-0000-0000-000000000001',
+  (SELECT target_sunday FROM test_config),
+  'cccccccc-ca01-0000-0000-000000000001'
+);
+
+SELECT ok(
+  NOT EXISTS (
+    SELECT 1
+    FROM get_open_shifts(
+      'aaaaaaaa-ca01-0000-0000-000000000001',
+      (SELECT target_sunday - 6 FROM test_config),
+      (SELECT target_sunday FROM test_config)
+    )
+    WHERE shift_date = (SELECT target_sunday FROM test_config)
+  ),
+  'fully-claimed capacity-1 template is filtered out of get_open_shifts'
+);
+
+-- ============================================
+-- Test 3: a second claim on the full capacity-1 template is rejected by
+-- claim_open_shift's capacity guard (assigned 1 + pending 0 >= capacity 1).
+-- Uses employee 2 so the capacity guard — not the schedule-conflict check —
+-- is what rejects it.
+-- ============================================
+
+SELECT is(
+  (
+    SELECT (result->>'success')::boolean
+    FROM (
+      SELECT claim_open_shift(
+        'aaaaaaaa-ca01-0000-0000-000000000001',
+        'bbbbbbbb-ca01-0000-0000-000000000001',
+        (SELECT target_sunday FROM test_config),
+        'cccccccc-ca01-0000-0000-000000000002'
+      ) AS result
+    ) sub
+  ),
+  false,
+  'second claim on full capacity-1 template returns success=false'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/open_shifts_capacity_one.test.sql
+++ b/supabase/tests/open_shifts_capacity_one.test.sql
@@ -44,7 +44,7 @@ VALUES ('aaaaaaaa-ca01-0000-0000-000000000001', 'Cap1 Test Restaurant', 'America
 ON CONFLICT (id) DO UPDATE SET timezone = 'America/Chicago';
 
 -- Template: capacity = 1 (the regression case). Closing 3:30p-10p Sundays.
-INSERT INTO shift_templates (id, restaurant_id, name, start_time, end_time, position, days, capacity)
+INSERT INTO shift_templates (id, restaurant_id, name, start_time, end_time, position, days, capacity, is_active)
 VALUES (
   'bbbbbbbb-ca01-0000-0000-000000000001',
   'aaaaaaaa-ca01-0000-0000-000000000001',
@@ -52,9 +52,10 @@ VALUES (
   '15:30:00', '22:00:00',
   'Server',
   '{0}',  -- Sunday only
-  1       -- single-person crew
+  1,      -- single-person crew
+  true
 )
-ON CONFLICT (id) DO UPDATE SET capacity = 1;
+ON CONFLICT (id) DO UPDATE SET capacity = 1, is_active = true;
 
 -- Two employees (second one drives the "no open spots" 2nd-claim test).
 INSERT INTO employees (id, restaurant_id, name, position, status, is_active)
@@ -77,7 +78,8 @@ SELECT
   target_sunday,
   'dddddddd-ca01-0000-0000-000000000001',
   0
-FROM test_config;
+FROM test_config
+ON CONFLICT DO NOTHING;
 
 -- ============================================
 -- Test 1: capacity-1 template appears as a claimable open shift.


### PR DESCRIPTION
## Summary
- `get_open_shifts` filtered templates with `AND st.capacity > 1`, silently dropping single-person crew templates (e.g. the AI scheduler's "1 Server") from the claimable open-shift pool. They were written to `shift_templates` and surfaced an "open shifts created" toast, but were never claimable — UI promise vs. data contract diverged.
- Fix ships as a new `CREATE OR REPLACE` migration changing the guard to `st.capacity > 0` (the clean equivalent of `>= 1`; `shift_templates` already enforces `CHECK (capacity >= 1)`). Historical migration left untouched.
- Opportunistic hardening while rewriting the body: `SET search_path = public` on the SECURITY DEFINER function, `STABLE` (read-only), and a self-contained `GRANT EXECUTE … TO authenticated`.
- `claim_open_shift` is intentionally **unchanged** — its `assigned + pending >= capacity` guard is already correct for capacity 1 (1st claim allowed, 2nd blocked). Pinned by a regression test.

## Test plan
New pgTAP test `supabase/tests/open_shifts_capacity_one.test.sql` (`plan(3)`):
1. A `capacity = 1` template appears in `get_open_shifts` with `open_spots = 1` — **fails before the fix** (returns NULL).
2. After one instant `claim_open_shift`, the now-full capacity-1 template is filtered out of `get_open_shifts`.
3. A second claim on the full capacity-1 template returns `success = false` — pins `claim_open_shift`'s guard.

Dates use the `CURRENT_DATE + (7 - DOW)` next-Sunday pattern (no hardcoded future dates). Verified locally: 3/3 assertions pass; `typecheck` ✓, `build` ✓ (diff is SQL + docs only, no JS/TS).

## Design doc
`docs/superpowers/specs/2026-05-29-open-shifts-capacity-one-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)