### PR TITLE
fix(deploy): area-aware shift_templates index + db push --include-all

### DIFF
--- a/.github/workflows/deploy-supabase.yml
+++ b/.github/workflows/deploy-supabase.yml
@@ -37,7 +37,10 @@ jobs:
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
 
       - name: Push database migrations
-        run: supabase db push
+        # --include-all: apply pending migrations even when a feature branch merged
+        # with an older timestamp than one already on remote (parallel branches merge
+        # out of order). Our migrations are additive/idempotent, so order-independent.
+        run: supabase db push --include-all
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}

--- a/docs/superpowers/specs/2026-05-31-deploy-shift-templates-area-index-design.md
+++ b/docs/superpowers/specs/2026-05-31-deploy-shift-templates-area-index-design.md
@@ -1,0 +1,75 @@
+# Design: Fix broken Supabase deploy — area-aware shift_templates index + `--include-all`
+
+**Date:** 2026-05-31
+**Status:** Approved (design phase)
+**Branch:** `fix/deploy-shift-templates-area-index`
+**Severity:** Production — staffing overlay currently erroring; DB 2 migrations behind.
+
+## Problem (two stacked root causes, confirmed on prod)
+
+The `Deploy Supabase` workflow failed for #525 (`c09b8cd`) and #529 (`f330682`).
+
+**(1) Out-of-order migration timestamp.** `supabase db push` (no `--include-all`)
+refuses migrations older than the latest on remote. #527
+(`20260529120000`, May 29) deployed first; #525's `20260528120000` (May 28) is now
+older than remote → push aborts; #529 fails behind it. Prod's latest migration is
+`20260529120000`; **`20260528120000` (#525) and `20260529130000` (#529) are NOT
+applied** (verified via `supabase_migrations.schema_migrations` + absent
+`sold_at` column / `uq_shift_templates_active_slot` index / `safe_cast_timestamptz`).
+
+**(2) #525's unique index omits `area` — would fail even once unblocked.** Prod has
+4 active-slot groups with identical `(restaurant_id, position, start_time, end_time,
+days)` but **different `area`** ("Cold Stone" vs "Wetzel's" — a food-court operator).
+`uq_shift_templates_active_slot` as written would throw a unique violation on this
+real data. Verified: 4 dup groups *without* area, **0** dup groups *with* area.
+
+**Impact:** #525/#529 frontends are already live (Netlify/Vercel deploy separately),
+so prod UI references absent schema → staffing overlay `select(… sold_at …)` errors
+and "Apply suggested shifts" upserts onto a missing index.
+
+## Fix
+
+1. **Make `uq_shift_templates_active_slot` area-aware** by editing the *unapplied*
+   migration `20260528120000_shift_templates_idempotent_apply.sql`:
+   ```sql
+   DROP INDEX IF EXISTS public.uq_shift_templates_active_slot;
+   CREATE UNIQUE INDEX uq_shift_templates_active_slot
+     ON public.shift_templates (restaurant_id, position, start_time, end_time, days, (COALESCE(area, '')))
+     WHERE is_active = true;
+   ```
+   `COALESCE(area,'')` keeps the index a no-NULL-escape-hatch (two area-NULL Apply
+   shifts still conflict → idempotent), while area-named manager templates stay
+   distinct. Verified safe against prod (0 exact dups incl. area).
+
+   **Why edit the merged migration, not a follow-up:** under `--include-all` the
+   broken `20260528120000` runs *first* and would fail before any later corrective
+   migration. It has never reached any shared remote (prod doesn't have it), so
+   editing it is safe; local/CI pick it up on `db:reset`.
+
+2. **`supabase db push --include-all`** in `.github/workflows/deploy-supabase.yml`.
+   Out-of-order merges are normal with parallel feature branches; `--include-all`
+   is the standard CI setting to tolerate them. The migrations here are independent
+   + idempotent, so order-independence is safe.
+
+3. **Apply hook / `shiftBlocksToTemplates`:** no change needed — the upsert uses a
+   bare `ignoreDuplicates: true` (ON CONFLICT DO NOTHING, no target), which works
+   with the expression index; Apply-created templates have `area = NULL → ''`, so
+   they're idempotent among themselves and distinct from named-area templates.
+   (Confirm during build that the merged hook still uses bare `ignoreDuplicates`.)
+
+## Testing
+
+- **pgTAP** (`supabase/tests/38_shift_templates_idempotent_apply.sql`, update):
+  area-distinct rows with identical position/time/days both insert (no collision);
+  same `(…, area)` exact dup conflicts (DO NOTHING no-op); NULL-area Apply shifts
+  idempotent.
+- **Local verify:** `npm run db:reset && npm run test:db` green.
+- **Deploy verify (post-merge):** prod `schema_migrations` includes `20260528120000`
+  + `20260529130000`; `sold_at` column, `uq_shift_templates_active_slot` (area-aware),
+  and `safe_cast_timestamptz` all present.
+
+## Out of scope (follow-up)
+
+- Systemic timestamp-at-merge discipline (the orchestrator picks a timestamp at
+  *creation* relative to then-current main; a branch can still be leapfrogged).
+  `--include-all` is the pragmatic safety net; a rebase-renumber step is the deeper fix.

--- a/supabase/migrations/20260528120000_shift_templates_idempotent_apply.sql
+++ b/supabase/migrations/20260528120000_shift_templates_idempotent_apply.sql
@@ -5,17 +5,20 @@
 -- Column order: restaurant_id first for multi-tenant selectivity (most selective
 -- prefix is the restaurant, then position narrows further, then the time window).
 --
--- Note: ON CONFLICT can target this partial index by repeating its WHERE predicate:
---   ON CONFLICT (restaurant_id, position, start_time, end_time, days)
---   WHERE is_active = true DO NOTHING
+-- Note: the upsert uses a bare ON CONFLICT DO NOTHING (no target), which catches
+-- any unique violation including this partial index.
 --
--- `days` IS part of the key: each suggested block targets one day (days = {dow}),
--- so the same role + time window on different days (e.g. Server 17:00-22:00 on
--- Fri {5} and Sat {6}) must be distinct rows. Excluding `days` would silently
--- drop every day after the first via ON CONFLICT DO NOTHING.
+-- `days` AND `area` are both part of the key:
+--   * days: the same role + time on different days (Fri {5} vs Sat {6}) are distinct.
+--   * area: real operators run multiple concepts in one restaurant (e.g. a food
+--     court with "Cold Stone" and "Wetzel's"); identical role/time/days in
+--     different areas are legitimately distinct templates and must NOT collide.
+-- area is nullable, so COALESCE(area,'') is used: NULL-area rows (e.g. Apply-
+-- created suggested shifts) still conflict with each other (idempotent) while
+-- staying distinct from named-area templates.
 
 DROP INDEX IF EXISTS public.uq_shift_templates_active_slot;
 
 CREATE UNIQUE INDEX uq_shift_templates_active_slot
-  ON public.shift_templates (restaurant_id, position, start_time, end_time, days)
+  ON public.shift_templates (restaurant_id, position, start_time, end_time, days, (COALESCE(area, '')))
   WHERE is_active = true;

--- a/supabase/tests/38_shift_templates_idempotent_apply.sql
+++ b/supabase/tests/38_shift_templates_idempotent_apply.sql
@@ -6,12 +6,12 @@
 -- Depends on migration: 20260528120000_shift_templates_idempotent_apply.sql
 -- which creates:
 --   CREATE UNIQUE INDEX uq_shift_templates_active_slot
---     ON public.shift_templates (restaurant_id, position, start_time, end_time, days)
+--     ON public.shift_templates (restaurant_id, position, start_time, end_time, days, (COALESCE(area, '')))
 --     WHERE is_active = true;
 
 BEGIN;
 
-SELECT plan(4);
+SELECT plan(5);
 
 -- ============================================================
 -- Setup: disable RLS so the test can insert without auth context
@@ -81,9 +81,9 @@ SELECT lives_ok(
       2,
       true
     )
-    ON CONFLICT (restaurant_id, position, start_time, end_time, days) WHERE is_active = true DO NOTHING
+    ON CONFLICT DO NOTHING
   $$,
-  'ON CONFLICT DO NOTHING re-apply is a no-op'
+  'ON CONFLICT DO NOTHING re-apply is a no-op (bare target, mirrors the hook)'
 );
 
 -- ============================================================
@@ -129,6 +129,32 @@ SELECT lives_ok(
     )
   $$,
   'same slot on a different day inserts (days is part of the key)'
+);
+
+-- ============================================================
+-- Test 5: Same role/time/days in a DIFFERENT area does NOT collide
+-- (regression guard: area must be part of the key — food-court operators run
+-- e.g. "Cold Stone" and "Wetzel's" with identical role/time/days). The seed
+-- template has NULL area (COALESCE -> ''); this one has 'Patio'.
+-- ============================================================
+
+SELECT lives_ok(
+  $$
+    INSERT INTO shift_templates (restaurant_id, name, days, start_time, end_time, break_duration, position, capacity, is_active, area)
+    VALUES (
+      '00000000-0000-0000-0000-0000000000aa',
+      'Server 17:00-22:00 (Patio)',
+      '{5}',
+      '17:00:00',
+      '22:00:00',
+      0,
+      'Server',
+      2,
+      true,
+      'Patio'
+    )
+  $$,
+  'same role/time/day in a different area inserts (area is part of the key)'
 );
 
 SELECT * FROM finish();


### PR DESCRIPTION
## Summary

Production **Deploy Supabase** has been failing for the last two merges (#525, #529) — neither's DB migrations reached prod, while their frontends are live, so the staffing overlay (`select … sold_at`) and "Apply suggested shifts" (`ON CONFLICT` on a missing index) are **erroring in prod right now**.

**Two stacked root causes (both confirmed against prod):**
1. **Out-of-order migration.** `supabase db push` (no `--include-all`) refuses `20260528120000` (#525, May 28) because `20260529120000` (#527, May 29) deployed first. → add `--include-all` (parallel branches merge out of order; our migrations are additive/idempotent).
2. **`uq_shift_templates_active_slot` omitted `area`.** Prod has 4 active-slot groups identical except for `area` (food court: "Cold Stone" / "Wetzel's"), so `CREATE UNIQUE INDEX` would throw `23505` even once unblocked. → make it area-aware via `(COALESCE(area,''))`. Verified prod has **0** exact dups including area, so it builds cleanly.

Editing the *unapplied* `20260528120000` (rather than a follow-up) is required because `--include-all` runs it first and it would fail before any corrective migration; it never reached any shared remote.

## Test plan
- `npm run db:reset && npm run test:db` → **1374/1374** green; `38_shift_templates_idempotent_apply` now covers area-distinct (no collision) + same-area dup (no-op).
- **Post-merge deploy verify:** confirm prod `schema_migrations` gains `20260528120000` + `20260529130000`, and `sold_at` / `uq_shift_templates_active_slot` (area-aware) / `safe_cast_timestamptz` all exist.

## Follow-ups (not in this PR)
- #529's bounded backfill touches `unified_sales` multi-tenant — acceptable (90-day + `IS NULL` bound) but worth a low-traffic note / future batching.
- A `days` GIN index if templates are ever queried by single day-of-week.
- Systemic: assign migration timestamps at merge/rebase time; `--include-all` is the safety net.

Design: `docs/superpowers/specs/2026-05-31-deploy-shift-templates-area-index-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved deployment conflicts when shift templates exist across different service areas, preventing duplicate key errors during database migrations.

* **Chores**
  * Improved deployment workflow to handle concurrent feature branch merges without migration order conflicts.

* **Tests**
  * Added verification tests to ensure shift templates with different service areas are properly distinguished during deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->