### PR TITLE
feat(dev): non-skippable ocr-rules reviewer in /dev Phase 7a

### DIFF
--- a/.claude/agents/ocr-rules-reviewer.md
+++ b/.claude/agents/ocr-rules-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: ocr-rules-reviewer
 description: Phase 7a reviewer that enforces ocr (open-code-review) rule packs against the branch diff. Runs on every /dev invocation — non-skippable. Reports every violation including style/convention ones; faithful rulebook enforcement is the whole point.
-subagent_type: feature-dev:code-reviewer
+subagent_type: general-purpose
 ---
 
 # OCR Rules Reviewer (Phase 7a)

--- a/.claude/agents/ocr-rules-reviewer.md
+++ b/.claude/agents/ocr-rules-reviewer.md
@@ -1,0 +1,103 @@
+---
+name: ocr-rules-reviewer
+description: Phase 7a reviewer that enforces ocr (open-code-review) rule packs against the branch diff. Runs on every /dev invocation — non-skippable. Reports every violation including style/convention ones; faithful rulebook enforcement is the whole point.
+subagent_type: feature-dev:code-reviewer
+---
+
+# OCR Rules Reviewer (Phase 7a)
+
+You are one of the parallel reviewers in Phase 7a of `/dev`. Your dimension is
+**rulebook enforcement via ocr (open-code-review)**. Stay in your lane — other
+reviewers handle logic, security, and performance.
+
+This reviewer is **non-skippable** and runs on every `/dev` invocation.
+
+## Step 1 — Get the REVIEW BRIEF
+
+Run the deterministic helper to produce the review brief:
+
+```bash
+bash dev-tools/ocr-rules-review.sh <base_ref>
+```
+
+Where `<base_ref>` is the base branch (typically `main` or `origin/main`).
+If you do not have a base ref, omit the argument to review the working tree.
+
+Capture the full stdout. It contains three sections:
+- `## Changed files` — the list of modified files.
+- `## ocr rule packs (deduped)` — the applicable ocr rule text, deduped across files.
+- `## Diff` — the unified diff of all changes.
+
+## Step 2 — Apply the rule packs to the diff
+
+Read **only the `+` (added) lines** in the diff. Removed lines (`-`) and context
+lines are not your concern.
+
+Apply **every rule** from the `## ocr rule packs (deduped)` section strictly and
+literally. Do not filter rules as "nits" — faithful rulebook enforcement is the
+entire purpose of this reviewer and distinguishes it from the bug-hunting
+reviewers.
+
+Report **every real violation** you find. A "real" violation means an added line
+that clearly breaks a stated rule. Infer the file path and line number from the
+diff header (`+++ b/<file>` and `@@` hunk offsets).
+
+## Step 3 — If ocr was unavailable
+
+If the `## ocr rule packs (deduped)` section contains
+`(ocr unavailable — apply CLAUDE.md conventions)`, fall back to enforcing the
+project's CLAUDE.md conventions on the added lines. Specifically check:
+
+1. **Semantic tokens only** — no hardcoded color classes like `bg-white`,
+   `text-black`, `bg-gray-*`, `text-gray-*`. Must use `bg-background`,
+   `text-foreground`, `bg-muted`, `text-muted-foreground`, etc.
+2. **No `var`** — variable declarations must use `const` or `let`.
+3. **Strict equality** — `==` and `!=` are prohibited; use `===` and `!==`.
+4. **No `any` without comment** — TypeScript `any` type must have an
+   explanatory comment on the same line.
+5. **React Query staleTime** — `useQuery`/`useInfiniteQuery` calls must
+   include `staleTime` ≤ 60000 ms. Missing `staleTime` or values above 60 000
+   are a violation.
+6. **Three-state rendering** — components fetching data must handle `isLoading`,
+   `error`, and empty/no-data states before rendering the happy path.
+7. **No manual caching** — `localStorage.setItem` / `sessionStorage.setItem`
+   for query results is prohibited.
+8. **Accessibility** — buttons without visible text need `aria-label`.
+
+## Output format
+
+```
+## OCR rules review
+
+### Critical
+- `<ocr:critical>` <one-line summary>. `<file>:<line>`. Rule: "<exact rule text>". Why/fix: <concise explanation>
+
+### Major
+- `<ocr:major>` ...
+
+### Minor
+- `<ocr:minor>` ...
+
+### No findings
+- (only if every added line is fully compliant with all applicable rules)
+```
+
+**Severity guidance:**
+
+- *critical* — a rule explicitly marked as "strictly prohibited" or "is
+  strictly prohibited"; also `var`, `==`/`!=`, `eval()`, `innerHTML` with
+  user input, secrets in client code.
+- *major* — a clear violation of a named rule that is not marked "strictly
+  prohibited" but is unambiguously stated (e.g., nested ternaries,
+  unhandled async errors, missing null checks, missing `staleTime`).
+- *minor* — a style or convention rule where the violation exists but its
+  impact is low (e.g., a missing explanatory comment on a simple block,
+  a slightly wrong import order).
+
+**Be thorough, not diplomatic.** Every violation must be reported. Do not
+suppress a finding because it seems cosmetic — the rule packs exist precisely
+to catch both style and correctness issues, and omitting style findings defeats
+the purpose of this reviewer.
+
+**Be honest:** if there are truly no violations, say so with `### No findings`.
+Do not manufacture findings to appear productive.

--- a/.claude/commands/our-code-review.md
+++ b/.claude/commands/our-code-review.md
@@ -1,0 +1,54 @@
+---
+description: Review working-tree (or branch) changes against ocr rule packs using Claude — no API key, no codex dependency
+---
+
+# Our Code Review
+
+Uses `dev-tools/ocr-rules-review.sh` (git + `ocr` only, $0) to build a REVIEW BRIEF, then has the current Claude session review the diff against the matched ocr rule packs. No external API calls, no Codex — just ocr's rule engine + Claude running on the Max subscription.
+
+## Context
+- Branch: !`git branch --show-current`
+- Status: !`git status --short`
+- ocr on PATH: !`command -v ocr 2>/dev/null && echo "yes ($(command -v ocr))" || echo "no"`
+
+## Instructions
+
+1. **Determine the base ref.** If the user passed an argument (e.g. `/our-code-review main`), treat it as BASE_REF and run:
+   ```
+   bash dev-tools/ocr-rules-review.sh <BASE_REF>
+   ```
+   If no argument was given, run working-tree mode:
+   ```
+   bash dev-tools/ocr-rules-review.sh
+   ```
+
+2. **Capture the REVIEW BRIEF** printed to stdout by the script. The brief has three sections:
+   - `## Changed files` — list of files in scope
+   - `## ocr rule packs (deduped)` — the rule text matched for those files (or the fallback note if `ocr` was unavailable)
+   - `## Diff` — the unified diff
+
+3. **Read the reviewer instructions** from `.claude/agents/ocr-rules-reviewer.md` (if it exists). Apply those instructions when analysing the brief. If the file does not exist yet, fall back to the conventions in `CLAUDE.md`.
+
+4. **Review the diff** against every rule in the "ocr rule packs" section. For each violation found, record:
+   - Severity: **Critical** | **High** | **Medium** | **Low** | **Informational**
+   - File path and line number (from the diff context)
+   - Which rule was violated and a one-sentence explanation
+   - A suggested fix (inline snippet when short)
+
+5. **Present findings grouped by severity**, highest first. Use this format:
+
+   ### Critical
+   - `src/foo.ts:42` — **Rule: no-direct-colors** — `bg-white` is a direct colour; use `bg-background` instead.
+     ```diff
+     - className="bg-white text-black"
+     + className="bg-background text-foreground"
+     ```
+
+   ### High
+   - `src/bar.ts:17` — **Rule: staleTime-required** — useQuery missing staleTime; add `staleTime: 30000`.
+
+   _(omit a severity section entirely if there are no findings at that level)_
+
+6. **If there are no findings**, say so clearly: "No violations found against the matched ocr rule packs."
+
+7. **Ask the user which findings to fix.** List them by number so they can reply "fix 1, 3" or "fix all". Then apply the requested fixes directly to the working tree.

--- a/.claude/skills/development-workflow.md
+++ b/.claude/skills/development-workflow.md
@@ -21,8 +21,9 @@ A **Stop-hook backstop** (`.claude/hooks/dev-phase-guard.sh`, wired in `settings
   inspect the design doc against best-practice skills before any code is
   written. Catching a design mistake here is roughly 10× cheaper than
   catching it in PR review.
-- **Phase 7 — Multi-Model Code Review:** Four Claude reviewers (security,
-  performance, maintainability, sound-logic) and one Codex adversarial
+- **Phase 7 — Multi-Model Code Review:** Five Claude reviewers (security,
+  performance, maintainability, sound-logic, and the non-skippable
+  ocr-rules rulebook enforcer) and one best-effort Codex adversarial
   reviewer fan out in parallel against the branch diff. CodeRabbit local
   CLI is the final gate, not the only gate — this avoids "Claude grading
   its own homework" and reduces dependence on one third-party reviewer.
@@ -293,7 +294,8 @@ Phase 7a  Multi-model fan-out (PARALLEL)
    ├─ Agent: performance-reviewer
    ├─ Agent: maintainability-reviewer
    ├─ Agent: sound-logic-reviewer
-   └─ Bash:  dev-tools/codex-adversarial-review.sh
+   ├─ Agent: ocr-rules-reviewer          ← NON-SKIPPABLE (deterministic rulebook)
+   └─ Bash:  dev-tools/codex-adversarial-review.sh   (best-effort)
    │
    ▼
 Phase 7b  Fold findings: classify, fix actionable, commit
@@ -313,17 +315,27 @@ Inputs handed to every reviewer:
 - `git log origin/main..HEAD --oneline`
 - The Phase 2 design doc.
 
-**Four Claude reviewers.** Each is an `Agent` call with
+**Five Claude reviewers.** Each is an `Agent` call with
 `subagent_type=feature-dev:code-reviewer` and the prompt loaded from
-`.claude/agents/<name>.md`. Launch them in a **single message with four
+`.claude/agents/<name>.md`. Launch them in a **single message with five
 tool calls** so they run concurrently.
 
-| Reviewer | Skills | Severity tag |
-|---|---|---|
-| `security-reviewer` | `security-best-practices`, `supabase-audit-rls` | `security:<level>` |
-| `performance-reviewer` | `performance`, `vercel-react-best-practices` | `performance:<level>` |
-| `maintainability-reviewer` | `typescript-react-reviewer`, `shadcn` | `maintainability:<level>` |
-| `sound-logic-reviewer` | `vercel-react-best-practices`, `requesting-code-review` | `logic:<level>` |
+| Reviewer | Skills | Severity tag | Skip If |
+|---|---|---|---|
+| `security-reviewer` | `security-best-practices`, `supabase-audit-rls` | `security:<level>` | Never |
+| `performance-reviewer` | `performance`, `vercel-react-best-practices` | `performance:<level>` | Never |
+| `maintainability-reviewer` | `typescript-react-reviewer`, `shadcn` | `maintainability:<level>` | Never |
+| `sound-logic-reviewer` | `vercel-react-best-practices`, `requesting-code-review` | `logic:<level>` | Never |
+| `ocr-rules-reviewer` | ocr deterministic rule catalog (CLAUDE.md conventions as fallback) | `ocr:<level>` | **Never** — runs on every code-producing /dev invocation |
+
+The `ocr-rules-reviewer` runs the deterministic shell helper
+`dev-tools/ocr-rules-review.sh origin/main` (falling back to `main`)
+to build a REVIEW BRIEF of matched rule packs + the diff, then applies
+every rule strictly against the added lines. It is the **rulebook
+enforcement** dimension — other reviewers handle judgment-based concerns
+(logic, security, performance). The two are complementary: ocr's strict
+catalog catches rule violations that judgment-based reviewers are
+trained to tolerate as minor. Runs on the Max subscription at $0.
 
 **One Codex adversarial reviewer.** Shell out via `Bash`:
 
@@ -335,14 +347,13 @@ The script writes its output to `dev-tools/codex-review-output.md`.
 
 **Codex prerequisite:** `codex` CLI must be on PATH and the binary must
 launch (`codex --version`). If either fails, the script emits a
-`::skip::` line and exits 0. Adversarial review is **best-effort** —
-the four Claude reviewers still run.
+`::skip::` line and exits 0. Adversarial review is **best-effort and
+intermittent** on ChatGPT Plus plans — the five Claude reviewers
+(including the reliable ocr-rules reviewer) still run unconditionally.
 
 ```bash
 # Install / repair if missing
-brew install --cask codex && codex login
-# If the symlink is dangling:
-brew reinstall --cask codex
+npm i -g @openai/codex && codex login
 ```
 
 ### 7b — Fold findings
@@ -713,7 +724,7 @@ This is the Ralph loop principle: each fresh context window re-orients from pers
 | 4. Build | `superpowers:test-driven-development` | Never |
 | 5. UI Review | `frontend-design:frontend-design` | No UI changes |
 | 6. Simplify | `code-simplifier:code-simplifier` | Never |
-| 7a Multi-Model Review | Agents: `security`, `performance`, `maintainability`, `sound-logic` + `dev-tools/codex-adversarial-review.sh` (parallel) | Workflow/doc-only changes (no code diff) |
+| 7a Multi-Model Review | Agents: `security`, `performance`, `maintainability`, `sound-logic`, `ocr-rules` (all NON-SKIPPABLE, parallel) + `dev-tools/codex-adversarial-review.sh` (best-effort) | Workflow/doc-only changes (no code diff) |
 | 7b Fold Findings | Classify + fix `critical`/`major`, commit | No `critical`/`major` findings |
 | 7c CodeRabbit | `coderabbit review --plain --type committed` | Never |
 | 8. Verify | `superpowers:verification-before-completion` | Never (loop locally until green) |

--- a/.claude/workflows/dev-build-and-ship.js
+++ b/.claude/workflows/dev-build-and-ship.js
@@ -232,8 +232,14 @@ function reviewerPrompt(d) {
 // including the non-skippable ocr-rules reviewer, plus the best-effort Codex
 // adversarial reviewer.
 async function runReviewer(d) {
-  let r = await agent(reviewerPrompt(d), { label: `review:${d.key}`, phase: 'Review', agentType: 'feature-dev:code-reviewer', schema: FINDINGS })
-  if (!r) r = await agent(reviewerPrompt(d), { label: `review:${d.key}:retry`, phase: 'Review', agentType: 'feature-dev:code-reviewer', schema: FINDINGS })
+  // ocr-rules enforces a strict rulebook (style violations included), so it must
+  // NOT run as feature-dev:code-reviewer, whose purpose is confidence-based
+  // filtering of low-priority findings — that would suppress exactly what this
+  // reviewer exists to catch. Use a faithful general-purpose reviewer for it;
+  // the judgment-based dimensions keep the bug-hunting reviewer.
+  const agentType = d.key === 'ocr-rules' ? 'general-purpose' : 'feature-dev:code-reviewer'
+  let r = await agent(reviewerPrompt(d), { label: `review:${d.key}`, phase: 'Review', agentType, schema: FINDINGS })
+  if (!r) r = await agent(reviewerPrompt(d), { label: `review:${d.key}:retry`, phase: 'Review', agentType, schema: FINDINGS })
   return r
 }
 const reviewResults = await parallel([
@@ -247,9 +253,20 @@ const reviewResults = await parallel([
       : Promise.resolve({ status: 'completed', findings: [] }),
 ])
 
+// Visibility: a non-skippable Claude reviewer that returned null (both attempts
+// failed) is otherwise silently dropped by the fold's filter below. Surface it so
+// a missing reviewer — especially the ocr-rules one, which must run on every
+// invocation — is never invisible.
+REVIEWERS.forEach((d, i) => {
+  if (!reviewResults[i]) log(`⚠️ Phase 7a reviewer "${d.key}" returned no result (both attempts failed) — findings absent this run`)
+})
+
 // 7b: fold findings (single agent holds all results) -> fix actionable critical/major.
+const reviewerNames = [...REVIEWERS.map((d) => d.key), 'codex']
 const foldInput = JSON.stringify(
-  reviewResults.filter(Boolean).map((r, i) => ({ reviewer: i, status: r.status, findings: r.findings || [] })),
+  reviewResults
+    .map((r, i) => (r ? { reviewer: reviewerNames[i] || `#${i}`, status: r.status, findings: r.findings || [] } : null))
+    .filter(Boolean),
 )
 const fold = await agent(
   envelope(

--- a/.claude/workflows/dev-build-and-ship.js
+++ b/.claude/workflows/dev-build-and-ship.js
@@ -217,6 +217,7 @@ const REVIEWERS = [
   { key: 'performance', promptFile: '.claude/agents/performance-reviewer.md' },
   { key: 'maintainability', promptFile: '.claude/agents/maintainability-reviewer.md' },
   { key: 'sound-logic', promptFile: '.claude/agents/sound-logic-reviewer.md' },
+  { key: 'ocr-rules', promptFile: '.claude/agents/ocr-rules-reviewer.md' },
 ]
 function reviewerPrompt(d) {
   return envelope(
@@ -227,8 +228,9 @@ function reviewerPrompt(d) {
   )
 }
 
-// 7a: four Claude reviewers (retry-once on null — a missing security review is unsafe)
-// plus the best-effort Codex adversarial reviewer.
+// 7a: five Claude reviewers (retry-once on null — a missing review is unsafe),
+// including the non-skippable ocr-rules reviewer, plus the best-effort Codex
+// adversarial reviewer.
 async function runReviewer(d) {
   let r = await agent(reviewerPrompt(d), { label: `review:${d.key}`, phase: 'Review', agentType: 'feature-dev:code-reviewer', schema: FINDINGS })
   if (!r) r = await agent(reviewerPrompt(d), { label: `review:${d.key}:retry`, phase: 'Review', agentType: 'feature-dev:code-reviewer', schema: FINDINGS })
@@ -251,7 +253,7 @@ const foldInput = JSON.stringify(
 )
 const fold = await agent(
   envelope(
-    'PHASE 7b (Fold findings). Below is JSON with findings from all reviewers (4 Claude + Codex). Deduplicate by file:line (keep highest severity, merge messages). For each critical/major finding that is an actionable bug/security/correctness issue: FIX it and commit ("fix(review): <area> — addresses <reviewer>"). Style/nits -> skip (CodeRabbit catches them in 7c). ' +
+    'PHASE 7b (Fold findings). Below is JSON with findings from all reviewers (5 Claude — security, performance, maintainability, sound-logic, ocr-rules — plus Codex). Deduplicate by file:line (keep highest severity, merge messages). For each critical/major finding that is an actionable bug/security/correctness issue: FIX it and commit ("fix(review): <area> — addresses <reviewer>"). Style/nits -> skip (CodeRabbit catches them in 7c). ' +
       'If a critical/major fix would require changing the approved design (' + ctx.designDocPath + '), return status=needs_human with details — do NOT improvise. After fixing, re-verify critical/security findings only. Also read dev-tools/codex-review-output.md if it exists.\n\n' +
       '=== findings JSON ===\n' + foldInput,
   ),

--- a/dev-tools/ocr-rules-review.sh
+++ b/dev-tools/ocr-rules-review.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Deterministic, $0, no-LLM half of the ocr-rules reviewer.
+#
+# Produces a "REVIEW BRIEF" on stdout with three sections:
+#   (1) Changed files list
+#   (2) Deduped ocr rule packs matched to those files
+#   (3) Unified diff of the changes
+#
+# Usage:
+#   ocr-rules-review.sh [BASE_REF]
+#
+#   With BASE_REF  : reviews git diff BASE_REF...HEAD (branch diff).
+#   Without BASE_REF: reviews the working tree (staged + unstaged + untracked).
+#
+# This script is the deterministic, $0, no-LLM half of the ocr-rules reviewer.
+# The LLM step that consumes this output lives in .claude/agents/ocr-rules-reviewer.md.
+#
+# Graceful degradation: if `ocr` is not on PATH, prints Changed files + Diff
+# sections with a fallback header and exits 0. Never hard-fails on missing ocr.
+#
+# Compatible with bash 3.2+ (macOS default) — no associative arrays used.
+
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+
+BASE_REF="${1:-}"
+
+# ── 1. Collect changed files and diff ──────────────────────────────────────────
+
+if [ -n "$BASE_REF" ]; then
+  CHANGED_FILES=$(git diff --name-only "${BASE_REF}...HEAD" 2>/dev/null || git diff --name-only "${BASE_REF}..HEAD" 2>/dev/null || true)
+  DIFF=$(git diff "${BASE_REF}...HEAD" 2>/dev/null || git diff "${BASE_REF}..HEAD" 2>/dev/null || true)
+else
+  # Working tree: staged + unstaged modifications, plus untracked files.
+  CHANGED_FILES=$(
+    {
+      git diff --name-only 2>/dev/null || true
+      git diff --name-only --cached 2>/dev/null || true
+      git ls-files --others --exclude-standard 2>/dev/null || true
+    } | sort -u
+  )
+  DIFF=$(git diff 2>/dev/null || true)
+  # Include staged changes in the diff.
+  STAGED_DIFF=$(git diff --cached 2>/dev/null || true)
+  if [ -n "$STAGED_DIFF" ]; then
+    DIFF="${DIFF}
+${STAGED_DIFF}"
+  fi
+fi
+
+# ── 2. Print section 1: Changed files ─────────────────────────────────────────
+
+echo "## Changed files"
+echo ""
+if [ -z "$CHANGED_FILES" ]; then
+  echo "(no changed files)"
+else
+  while IFS= read -r f; do
+    [ -n "$f" ] && echo "- $f"
+  done <<< "$CHANGED_FILES"
+fi
+echo ""
+
+# ── 3. Collect and dedupe ocr rule packs ──────────────────────────────────────
+
+OCR_OK=false
+if command -v ocr >/dev/null 2>&1; then
+  # Smoke-test: make sure the binary actually runs.
+  if ocr --version >/dev/null 2>&1; then
+    OCR_OK=true
+  fi
+fi
+
+echo "## ocr rule packs (deduped)"
+echo ""
+
+if [ "$OCR_OK" = "false" ]; then
+  echo "(ocr unavailable — apply CLAUDE.md conventions)"
+else
+  # Dedupe by Pattern: header using a temp file for seen-set (bash 3.2 compatible).
+  SEEN_FILE=$(mktemp)
+  # shellcheck disable=SC2064
+  trap "rm -f '$SEEN_FILE'" EXIT
+
+  FOUND_ANY=false
+
+  while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    # ocr rules check may fail on non-existent (deleted) files — skip gracefully.
+    RAW_OUTPUT=$(ocr rules check "$file" 2>/dev/null || true)
+    [ -z "$RAW_OUTPUT" ] && continue
+
+    # Extract the Pattern: line (e.g. "Pattern: **/*.{ts,js,tsx,jsx}")
+    PATTERN=$(printf '%s\n' "$RAW_OUTPUT" | grep '^Pattern:' | head -1 || true)
+    [ -z "$PATTERN" ] && PATTERN="Pattern: (unknown)"
+
+    # Check if we've seen this pattern before (grep returns 0 if found, 1 if not).
+    if ! grep -qxF "$PATTERN" "$SEEN_FILE" 2>/dev/null; then
+      printf '%s\n' "$PATTERN" >> "$SEEN_FILE"
+      FOUND_ANY=true
+
+      echo "### $PATTERN"
+      echo ""
+      # Print the Rule block: everything between the separator lines.
+      IN_RULE=false
+      while IFS= read -r line; do
+        if [[ "$line" == "────"* ]]; then
+          if [ "$IN_RULE" = "false" ]; then
+            IN_RULE=true
+          else
+            IN_RULE=false
+          fi
+          continue
+        fi
+        if [ "$IN_RULE" = "true" ]; then
+          echo "$line"
+        fi
+      done <<< "$RAW_OUTPUT"
+      echo ""
+    fi
+  done <<< "$CHANGED_FILES"
+
+  if [ "$FOUND_ANY" = "false" ]; then
+    echo "(no rule packs matched — no changed files or ocr returned no output)"
+  fi
+fi
+
+echo ""
+
+# ── 4. Print section 3: Diff ──────────────────────────────────────────────────
+
+echo "## Diff"
+echo ""
+if [ -z "$DIFF" ]; then
+  echo "(no diff)"
+else
+  printf '%s\n' "$DIFF"
+fi

--- a/docs/superpowers/specs/2026-06-07-ocr-rules-review-design.md
+++ b/docs/superpowers/specs/2026-06-07-ocr-rules-review-design.md
@@ -1,0 +1,112 @@
+# Design: OCR Rules Review Integration
+
+**Date:** 2026-06-07
+**Branch:** ocr-rules-review
+**Status:** Decided — implementing
+
+---
+
+## Goal
+
+Wire `open-code-review` (OCR) as an independent, **$0**, subscription-based automated code reviewer into every `/dev` run (Phase 7a, non-skippable) and as a standalone `/our-code-review` command. OCR provides deterministic, rule-based selection and lint checks; a Claude subagent on the Max subscription provides the LLM reasoning — together replacing any metered pay-as-you-go API call.
+
+---
+
+## Journey: Why It Took Three Attempts
+
+### Attempt 1 — OCR with a raw Anthropic API key (metered, 401)
+
+`open-code-review` is a Node CLI that calls an LLM API directly. The first instinct was to give it the Anthropic key from Claude Code's own session. That key is an **OAuth bearer token** issued per session by the subscription — it authenticates the Claude Code agent, not a third-party tool. Sending it as `x-api-key` (the Anthropic Console header) produced a 401 immediately. Even forwarding it with the `anthropic-beta` header Claude Code uses internally did not help: the subscription endpoint only grants access to the authorized agent (Claude Code), not to arbitrary callers pretending to be it.
+
+**Root cause:** Subscriptions (Claude Max, ChatGPT Plus) authenticate the *official agent*. Third-party CLIs that need an LLM API key require a separate, metered pay-as-you-go key — which we are trying to avoid.
+
+### Attempt 2 — OCR with Codex / ChatGPT Plus (throttled, model rejected)
+
+The next approach was to route OCR through the OpenAI endpoint using a ChatGPT Plus session, via `codex`. A first test run succeeded; subsequent runs returned `model not supported` for the default model (`gpt-5.3-codex`). The Plus tier throttles the Codex model aggressively and the model itself is gated to API-tier customers. Pinning a Plus-compatible model (e.g. `gpt-5.2-codex`) helped intermittently but the reliability was insufficient to make this a non-skippable workflow step.
+
+**Root cause:** ChatGPT Plus Codex is throttled and its "API-only" default model is rejected on Plus. Treat codex as best-effort at most.
+
+### Attempt 3 — The breakthrough: OCR's rules are separable from the LLM
+
+`ocr review --preview` and `ocr rules check` run **entirely locally** — they select changed files, apply rule filters, and emit a structured diff — without calling any model. Cost: $0. This means the LLM is a free choice, completely decoupled from OCR's selection logic.
+
+**Consequence:** Use a Claude subagent (Max subscription) as the LLM. Claude subagents are invoked by Claude Code and inherit the subscription — reliable, $0, no separate API key needed. OCR does the deterministic work; the subagent does the reasoning.
+
+---
+
+## Chosen Architecture
+
+```
+Changed files (git diff)
+        |
+        v
+  ocr review --preview        ← deterministic rule-based selection ($0, local)
+  ocr rules check             ← lint / rule validation ($0, local)
+        |
+        v
+  Structured diff / findings
+        |
+        v
+  Claude subagent (Max sub)   ← LLM reasoning, $0 via subscription
+        |
+        v
+  Findings → /dev Phase 7a output + /our-code-review output
+```
+
+**Properties:**
+- $0 marginal cost per review (no metered API calls)
+- Deterministic rule enforcement every run (OCR layer)
+- Reliable LLM reasoning (Claude Max subscription, same agent)
+- Non-skippable: wired into Phase 7a of `/dev` before any PR is created
+
+### Workflow Integration
+
+**Phase 7a (non-skippable, inside `/dev`):**
+1. `ocr review --preview` to get the structured rule output for the current diff
+2. Pass the output to a Claude subagent with the project's `CLAUDE.md` rules context
+3. Subagent emits findings (P1/P2/Minor), classified and actionable
+4. Any P1 finding blocks PR creation until addressed
+
+**`/our-code-review` command:**
+- Runs the same pipeline on demand, outside of `/dev`
+- Useful for in-progress branches or ad-hoc review before pushing
+
+---
+
+## Metered API Key Fallback (Reference Only — Not Used)
+
+Documented here for completeness if subscription access is ever unavailable.
+
+**Anthropic Console key:**
+- Header: `x-api-key: sk-ant-...`
+- Models: `claude-opus-4-8`, `claude-sonnet-4-6`, `claude-haiku-4-5`
+- Billing: pay-as-you-go per token
+- Why avoided: adds per-run cost; this project's goal is $0 overhead review
+
+**OpenAI key:**
+- Header: `Authorization: Bearer sk-...`
+- Billing: pay-as-you-go per token
+- Why avoided: same cost concern; Plus throttling makes it unreliable anyway
+
+---
+
+## Codex: Optional Best-Effort Bonus
+
+Codex stays in the workflow as an **optional, best-effort cross-family bonus** reviewer only:
+- It runs after the OCR + Claude subagent pass
+- A `::skip::` marker is emitted and the workflow continues if codex is missing, broken, or returns `model not supported`
+- Its output is never required to unblock a PR
+- Install via `npm i -g @openai/codex` (NOT `brew install --cask codex` — the cask leaves a dangling symlink)
+- Pin a Plus-compatible model (e.g. `gpt-5.2-codex`); the default `gpt-5.3-codex` is API-tier only
+- Any `codex exec` call in a script must redirect `< /dev/null` to prevent it from hanging on stdin
+
+---
+
+## Files Involved
+
+| File | Purpose |
+|------|---------|
+| `.claude/skills/development-workflow.md` | Phase 7a: OCR + subagent review step (non-skippable) |
+| `.claude/skills/our-code-review.md` | `/our-code-review` command skill |
+| `dev-tools/ocr-review.sh` | Shell runner: `ocr review --preview` → subagent invocation |
+| `memory/lessons.md` | Lessons from the three-attempt journey (see 2026-06-07 entries) |

--- a/memory/lessons.md
+++ b/memory/lessons.md
@@ -599,3 +599,35 @@
 - **Mistake:** A new `fillHours(page, employeeName, hours)` E2E helper located the input with `page.getByRole('spinbutton', { name: new RegExp(employeeName, 'i') })`. Interpolating raw display text into a `RegExp` is unsafe: a name containing regex metacharacters (`.`, `(`, `+`, `[`, …) changes the pattern's meaning and can match unintended rows or throw. CodeRabbit flagged it during PR #538 triage.
 - **Correction:** Escape first: `const escapedName = employeeName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');` then `new RegExp(escapedName, 'i')`.
 - **Rule:** Never build a Playwright (or any) name-`RegExp` from interpolated dynamic text without escaping regex special chars — use the standard `replace(/[.*+?^${}()|[\]\\]/g, '\\$&')` escape, or pass an exact string where the API accepts one. Grep for `new RegExp(` with a variable argument when reviewing test helpers.
+
+---
+
+## Category: Development Workflow (continued)
+
+### [2026-06-07] Third-party API-key CLIs cannot authenticate against a Claude or ChatGPT subscription
+- **Mistake:** Tried to run `open-code-review` (OCR) by forwarding Claude Code's session OAuth bearer token as `x-api-key`. The Anthropic subscription endpoint only authorizes the official Claude Code agent — any third-party CLI sending the same token gets a 401. Same problem applies to ChatGPT Plus: the Plus session token only unlocks the ChatGPT web/Codex agents, not arbitrary callers.
+- **Correction:** Either use the official agent (invoke OCR's deterministic parts — `ocr review --preview`, `ocr rules check` — at $0, then hand off to a Claude subagent on the Max subscription for LLM reasoning), or obtain a separate metered API key from Anthropic Console (`sk-ant-*`) or OpenAI for tools that must call an LLM directly.
+- **Rule:** Subscriptions authenticate the *official agent*, not third-party CLIs. When a tool needs its own LLM call, either (a) split its deterministic logic from the LLM call and supply the LLM via the agent substrate, or (b) use a pay-as-you-go key from the provider's console. Never assume a subscription token is reusable as a raw API key.
+
+### [2026-06-07] Install codex via `npm i -g @openai/codex`, not `brew install --cask codex`
+- **Mistake:** The Homebrew cask `codex` installed and then left a dangling `/opt/homebrew/bin/codex` symlink pointing at a path that no longer existed. Any workflow that invoked `codex` via that PATH entry would fail or silently no-op.
+- **Correction:** Uninstall the cask (`brew uninstall --cask codex`) or remove the dangling symlink (`rm -f /opt/homebrew/bin/codex`). Install the real CLI with `npm i -g @openai/codex`. The npm binary lands on PATH earlier (via `~/.npm-global/bin` or `~/.nvm/*/bin`) and is kept current by npm.
+- **Rule:** For CLIs distributed as npm packages, prefer `npm i -g` over a Homebrew cask. The cask may be a wrapper or stub that points at an external location that can disappear. Verify installation with both `command -v codex` AND `codex --version` — a symlink that resolves but points to a nonexistent file passes `command -v` but fails `--version`.
+
+### [2026-06-07] Codex on ChatGPT Plus is throttled and its default model is API-tier only
+- **Mistake:** OCR was wired to call codex as a required reviewer. A first run succeeded; subsequent runs returned `model not supported` for the default model `gpt-5.3-codex`. The Plus tier throttles the Codex endpoint aggressively, and `gpt-5.3-codex` is gated to OpenAI API-tier customers, not Plus subscribers.
+- **Correction:** Treat codex as an optional, best-effort cross-family bonus reviewer only. Pin a Plus-compatible model (e.g. `gpt-5.2-codex`) in the runner script. Emit a `::skip:: <reason>` line and `exit 0` if codex returns `model not supported` or any non-zero exit from the model selection step. Never make codex a blocking gate on PR creation.
+- **Rule:** On ChatGPT Plus, codex is best-effort — pin `gpt-5.2-codex` (not the default `gpt-5.3-codex`) and always guard with a `::skip::` path. Any workflow step that depends on codex must be marked optional and never block the workflow if codex is throttled or unavailable.
+
+### [2026-06-07] `codex exec` in a script hangs forever without `< /dev/null`
+- **Mistake:** A runner script called `codex exec "…prompt…"` and the process blocked indefinitely with "Reading additional input from stdin…". The script was waiting for the user to close stdin, which never happens in a non-interactive pipe.
+- **Correction:** Redirect stdin from /dev/null: `codex exec "…prompt…" < /dev/null`. This closes stdin immediately so codex does not wait for interactive input.
+- **Rule:** Any `codex exec` call inside a non-interactive script (CI, workflow runner, cron) must redirect `< /dev/null`. Omitting it causes the script to hang silently — with no timeout, it blocks the entire workflow stage. Apply the same rule to any CLI that reads from stdin interactively when no TTY is present.
+
+---
+
+## Category: Code Review Process (continued)
+
+### [2026-06-07] OCR's deterministic rules are separable from its LLM call — exploit this to get $0 review
+- **Observation:** `ocr review --preview` and `ocr rules check` run entirely locally — they apply rule-based selection and file filtering with no model call. The LLM call is a separate, optional step that any caller can supply. This means OCR's selection logic can be combined with any subscription-backed LLM (e.g. a Claude subagent on Max) instead of a metered API key.
+- **Rule:** When a review CLI "requires" an LLM API key, check whether it has a `--preview`, `--dry-run`, or `rules check` mode that produces structured output without a model call. If so, run that stage at $0 and pipe its output to a subscription-backed agent. The result is identical review coverage with no metered cost. Document this split in the design doc so future contributors understand why no API key is configured.


### PR DESCRIPTION
## Summary
- Adds a **non-skippable** `ocr-rules` reviewer to `/dev` Phase 7a. **open-code-review (ocr)** supplies a deterministic rule catalog + file selection (`$0`, no LLM call); a **Claude subagent on the Max subscription** applies those rules to the branch diff (`$0`, reliable). It runs unconditionally alongside the 4 existing Claude reviewers and folds into Phase 7b.
- New `/our-code-review` command for the same review on demand.
- Codex stays a *best-effort* cross-family bonus (install hint corrected `brew` → `npm i -g @openai/codex`).

## Why this shape
Three constraints forced it (full write-up in the design doc):
1. **ocr can't run on a subscription** — it needs a raw *metered* API endpoint; subscriptions only authenticate the official *agents* (Claude Code / codex). Confirmed by a 401 from `api.anthropic.com` even with Claude Code's OAuth beta header.
2. **codex/GPT on ChatGPT Plus is throttled/intermittent** — a model worked once, then consistently returned `"model not supported"`.
3. **Breakthrough:** ocr's rules are *separable* from the LLM (`ocr review --preview` / `ocr rules check` run at `$0` with no model call), so the reviewing LLM is a free choice. A Claude subagent on the Max sub is reliable **and** `$0`.

## Files
- `dev-tools/ocr-rules-review.sh` — deterministic REVIEW BRIEF (changed files + deduped ocr rule packs + diff); graceful fallback if `ocr` is absent.
- `.claude/agents/ocr-rules-reviewer.md` — strict rulebook reviewer (`general-purpose`, no nit-filtering, CLAUDE.md fallback).
- `.claude/commands/our-code-review.md` — `/our-code-review`.
- `.claude/workflows/dev-build-and-ship.js` — wires it into Phase 7a unconditionally + surfaces dropped reviewers + labels fold entries by name.
- `.claude/skills/development-workflow.md` — Phase 7a prose, diagram, Quick Reference table.
- `docs/superpowers/specs/2026-06-07-ocr-rules-review-design.md`, `memory/lessons.md`.

## Test plan
- `bash -n dev-tools/ocr-rules-review.sh` ✓ · async-wrapped `node --check` of the workflow ✓.
- Script emits the 3-section brief and degrades gracefully when `ocr` is removed from PATH ✓.
- End-to-end: a Claude subagent applied ocr's rules to a sample diff and caught `var` / `==` / implicit-`any` ✓.
- Two independent adversarial audits confirm: invoked on every code-producing `/dev` run, runs as `general-purpose` (no nit-filter), and null results are surfaced (not silently dropped) ✓.

Design doc: `docs/superpowers/specs/2026-06-07-ocr-rules-review-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OCR (Open Code Review) rules reviewer to the automated code review pipeline as a deterministic, non-skippable review pass.
  * Added `/our-code-review` command for standalone code review with rule enforcement and customizable findings.

* **Documentation**
  * Updated development workflow to document the new OCR reviewer in Phase 7a.
  * Added design specification for OCR rules review integration and architecture.
  * Documented lessons learned about code review tools and authentication patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->