### PR TITLE
Fix FK violation when deleting published shifts (schedule_change_logs_shift_id_fkey)

### DIFF
--- a/supabase/migrations/20260617120000_fix_schedule_change_logs_delete_fk.sql
+++ b/supabase/migrations/20260617120000_fix_schedule_change_logs_delete_fk.sql
@@ -1,0 +1,44 @@
+-- Fix: deleting a published shift fails with
+--   "insert or update on table schedule_change_logs violates foreign key
+--    constraint schedule_change_logs_shift_id_fkey" (SQLSTATE 23503)
+--
+-- Root cause
+-- ----------
+-- The AFTER DELETE trigger log_shift_changes -> log_shift_change() (added in
+-- 20251123000000_schedule_publishing.sql) logs deletions of published shifts by
+-- inserting an audit row into schedule_change_logs with shift_id = OLD.id.
+-- Because the trigger fires AFTER DELETE, the shift row is already gone, so the
+-- INSERT's foreign-key check (schedule_change_logs_shift_id_fkey -> shifts.id)
+-- finds no matching shift and aborts the whole DELETE.
+--
+-- ON DELETE SET NULL on that FK does NOT prevent this: SET NULL only nullifies
+-- pre-existing child rows when the parent is deleted; it does not rescue a child
+-- row that the trigger inserts *after* the parent is already gone. The insert is
+-- validated like any other insert, and the referenced shift no longer exists.
+--
+-- This made every direct delete of a *published* shift fail (planner "remove
+-- shift" / delete-this-occurrence / bulk delete all call
+-- `supabase.from('shifts').delete()` with no locked/published guard). Deleting
+-- *unpublished* shifts was unaffected because the trigger only logs published ones.
+--
+-- Fix
+-- ---
+-- An audit/event log must not hold an *enforced* FK to the table whose deletions
+-- it records -- the deletion record inherently points at a row that no longer
+-- exists. Convert shift_id to a soft reference by dropping the FK constraint.
+--
+--   * The shift_id column and idx_schedule_change_logs_shift_id index remain, so
+--     change logs are still queryable by shift_id.
+--   * For deletions, shift_id is now RETAINED (instead of being nulled), which is
+--     strictly better for an audit trail; before_data already snapshots the full
+--     shift row (row_to_json(OLD)).
+--   * No app code embeds shifts through schedule_change_logs (only employee is
+--     embedded), so dropping the PostgREST relationship breaks nothing.
+
+ALTER TABLE public.schedule_change_logs
+  DROP CONSTRAINT IF EXISTS schedule_change_logs_shift_id_fkey;
+
+COMMENT ON COLUMN public.schedule_change_logs.shift_id IS
+  'Soft reference to the shift this change concerns. Intentionally NOT a foreign '
+  'key: a ''deleted'' audit row must retain the id of a shift that no longer '
+  'exists. Join to shifts manually and tolerate missing rows.';


### PR DESCRIPTION
## Problem
Deleting a **published** shift from the planner (remove shift / delete-this-occurrence / bulk delete) fails in production with:

```
insert or update on table "schedule_change_logs" violates foreign key
constraint "schedule_change_logs_shift_id_fkey"
DETAIL: Key (shift_id)=(…) is not present in table "shifts".   (SQLSTATE 23503)
```

## Root cause
The `log_shift_changes` trigger (`AFTER DELETE ON shifts`, from `20251123000000_schedule_publishing.sql`) logs deletions of published shifts by inserting into `schedule_change_logs` with `shift_id = OLD.id`. Because it runs **after** the delete, the shift row is already gone, so the insert's FK check (`schedule_change_logs_shift_id_fkey → shifts.id`) finds nothing and aborts the whole delete.

`ON DELETE SET NULL` on that FK does **not** help: it only nullifies *pre-existing* child rows, not a row the trigger inserts *after* the parent is gone. Unpublished deletes were unaffected because the trigger only logs published shifts. The planner delete paths (`useDeleteShift`, `useDeleteShiftSeries`, `bulkDelete`) issue `from('shifts').delete()` with no locked/published guard, so they hit this directly.

## Fix
Drop `schedule_change_logs_shift_id_fkey`, making `shift_id` a soft reference. The column and `idx_schedule_change_logs_shift_id` remain, and deleted shifts now **retain** their id in the audit log (better for auditing; `before_data` already snapshots the full row). An audit/event log must not hold an enforced FK to the table whose deletions it records. This fixes every delete path (planner single/series/bulk + the `delete_shift_series` RPC) at the DB level. No app code embeds `shifts` through this table (only `employee`), so the PostgREST relationship change breaks nothing.

## Verification
Reproduced and verified on local Supabase against a real published shift:
- **Before:** delete → `23503` on `schedule_change_logs_shift_id_fkey` (exact prod error)
- **After:** delete succeeds; the `'deleted'` audit row is written correctly (shift_id retained, `before_data` snapshot, `changed_by` set); unpublished deletes still work (no regression)

## Deploy notes
- `supabase db push` to apply
- Regenerate types (`supabase gen types`) so the stale FK relationship drops out of `src/types/supabase.ts`

## Follow-up (separate)
Shift-mutation DB errors are only surfaced as a toast and never sent to PostHog — this bug had **zero** error-tracking events over 90 days. Tracked separately to add `captureException` to the scheduling hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue preventing the deletion of published shifts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->