### PR TITLE
fix(employees): stop is_active/status desync (constraint 23514)

### DIFF
--- a/docs/superpowers/plans/2026-06-19-employee-status-active-sync.md
+++ b/docs/superpowers/plans/2026-06-19-employee-status-active-sync.md
@@ -1,0 +1,457 @@
+# Employee `status`/`is_active` Sync Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the client from writing `is_active` out of sync with `status`, which violates the `employees_status_active_sync` check constraint (Postgres 23514) and blocks managers from deactivating employees in the UI.
+
+**Architecture:** Make `is_active` derivable from `status` via a single tested helper (`isActiveForStatus`), use it in `EmployeeDialog`, and delete the two buggy silent RPC fallbacks in `useEmployees` (surface RPC errors instead). Client-only; no DB migration; no production data changes.
+
+**Tech Stack:** React 18 + TypeScript, React Query, Vitest + Testing Library.
+
+**Spec:** `docs/superpowers/specs/2026-06-19-employee-status-active-sync-design.md`
+
+---
+
+## File structure
+
+- `src/types/scheduling.ts` — add `export type EmployeeStatus`; use it for `Employee.status`.
+- `src/utils/employeeFilters.ts` — add `isActiveForStatus(status)` helper (single source of truth for the invariant).
+- `src/components/EmployeeDialog.tsx` — derive `is_active` from `status` via the helper; type `status` state as `EmployeeStatus`.
+- `src/hooks/useEmployees.tsx` — remove both RPC fallbacks in `useDeactivateEmployee` / `useReactivateEmployee`.
+- `tests/unit/employeeActivation.test.ts` — add helper unit tests + two hook tests (RPC error → reject, no `.from().update()`).
+- `tests/unit/EmployeeDialog.statusSync.test.tsx` — NEW; prop-driven component tests proving the saved `is_active` is derived from `status`.
+
+---
+
+### Task 1: Canonical `EmployeeStatus` type + `isActiveForStatus` helper
+
+**Files:**
+- Modify: `src/types/scheduling.ts`
+- Modify: `src/utils/employeeFilters.ts`
+- Test: `tests/unit/employeeActivation.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the top imports of `tests/unit/employeeActivation.test.ts`:
+
+```ts
+import {
+  filterActiveEmployees,
+  filterInactiveEmployees,
+  getLastActiveDate,
+  canReactivate,
+  isActiveForStatus,
+} from '@/utils/employeeFilters';
+```
+
+Add this describe block at the end of the file (before the final closing `});` of the top-level `describe`, or as a new top-level describe — either is fine):
+
+```ts
+describe('isActiveForStatus', () => {
+  it('returns true only for active status', () => {
+    expect(isActiveForStatus('active')).toBe(true);
+  });
+
+  it('returns false for inactive and terminated', () => {
+    expect(isActiveForStatus('inactive')).toBe(false);
+    expect(isActiveForStatus('terminated')).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/employeeActivation.test.ts -t "isActiveForStatus"`
+Expected: FAIL — `isActiveForStatus` is not exported from `@/utils/employeeFilters`.
+
+- [ ] **Step 3: Add the type and the helper**
+
+In `src/types/scheduling.ts`, add near the other type exports (after line 6, `EmploymentType`):
+
+```ts
+export type EmployeeStatus = 'active' | 'inactive' | 'terminated';
+```
+
+Then change the `Employee` interface's status field (currently `status: 'active' | 'inactive' | 'terminated';`) to:
+
+```ts
+  status: EmployeeStatus;
+```
+
+In `src/utils/employeeFilters.ts`, add at the top (after the file header comment):
+
+```ts
+import type { EmployeeStatus } from '@/types/scheduling';
+```
+
+And add the helper (e.g. after `canReactivate`):
+
+```ts
+/**
+ * Single source of truth for the is_active <-> status invariant enforced by the
+ * DB check constraint `employees_status_active_sync`
+ * (active => is_active true; inactive/terminated => is_active false).
+ */
+export function isActiveForStatus(status: EmployeeStatus): boolean {
+  return status === 'active';
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/employeeActivation.test.ts`
+Expected: PASS (all prior 12 tests + the 2 new ones).
+
+- [ ] **Step 5: Typecheck (the `Employee.status` change is type-only)**
+
+Run: `npm run typecheck`
+Expected: no new errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/types/scheduling.ts src/utils/employeeFilters.ts tests/unit/employeeActivation.test.ts
+git commit -m "feat(employees): add EmployeeStatus type and isActiveForStatus helper"
+```
+
+---
+
+### Task 2: Derive `is_active` from `status` in EmployeeDialog
+
+**Files:**
+- Modify: `src/components/EmployeeDialog.tsx`
+- Test: `tests/unit/EmployeeDialog.statusSync.test.tsx` (create)
+
+- [ ] **Step 1: Write the failing component test**
+
+Create `tests/unit/EmployeeDialog.statusSync.test.tsx`:
+
+```tsx
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { EmployeeDialog } from '@/components/EmployeeDialog';
+
+const updateMock = vi.fn().mockResolvedValue({ id: 'emp-1' });
+const createMock = vi.fn().mockResolvedValue({ id: 'emp-1' });
+
+vi.mock('@/hooks/useEmployees', () => ({
+  useCreateEmployee: () => ({ mutateAsync: createMock, isPending: false }),
+  useUpdateEmployee: () => ({ mutateAsync: updateMock, isPending: false }),
+}));
+
+vi.mock('@/hooks/useBulkSetAvailability', () => ({
+  useBulkSetAvailability: () => ({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false }),
+}));
+
+vi.mock('@/hooks/useShiftTemplates', () => {
+  const STABLE_TEMPLATES: never[] = [];
+  return {
+    useShiftTemplates: () => ({
+      templates: STABLE_TEMPLATES,
+      loading: false,
+      error: null,
+      createTemplate: () => Promise.resolve(),
+      updateTemplate: () => Promise.resolve(),
+      deleteTemplate: () => Promise.resolve(),
+    }),
+  };
+});
+
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => ({ selectedRestaurant: { restaurant: { id: 'r1', timezone: 'UTC' } } }),
+}));
+
+vi.mock('@/integrations/supabase/client', () => {
+  function makeChain(): any {
+    const chain: any = {};
+    chain.select = () => makeChain();
+    chain.eq = () => makeChain();
+    chain.not = () => makeChain();
+    chain.order = () => Promise.resolve({ data: [], error: null });
+    chain.is = () => makeChain();
+    chain.single = () => Promise.resolve({ data: null, error: null });
+    chain.upsert = () => Promise.resolve({ data: null, error: null });
+    chain.insert = () => makeChain();
+    chain.update = () => makeChain();
+    chain.then = (resolve: (v: { data: any[]; error: null }) => any) =>
+      Promise.resolve({ data: [], error: null }).then(resolve);
+    chain.catch = () => Promise.resolve({ data: [], error: null });
+    return chain;
+  }
+  return {
+    supabase: {
+      functions: { invoke: () => Promise.resolve({ data: null, error: null }) },
+      from: () => makeChain(),
+    },
+  };
+});
+
+type EmpOverrides = Partial<{ status: string; is_active: boolean }>;
+const makeEmployee = (overrides: EmpOverrides) => ({
+  id: 'emp-1',
+  restaurant_id: 'r1',
+  name: 'Alex Valdez',
+  position: 'Server',
+  status: 'active',
+  is_active: true,
+  compensation_type: 'hourly',
+  hourly_rate: 1500,
+  employment_type: 'full_time',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  ...overrides,
+});
+
+function renderEdit(employee: ReturnType<typeof makeEmployee>) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false, staleTime: Infinity } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      <EmployeeDialog open onOpenChange={vi.fn()} restaurantId="r1" employee={employee as any} />
+    </QueryClientProvider>,
+  );
+}
+
+describe('EmployeeDialog — is_active is derived from status on save', () => {
+  beforeEach(() => {
+    updateMock.mockClear();
+    createMock.mockClear();
+  });
+
+  it('sends is_active=false when status is inactive (even if the row was is_active=true)', async () => {
+    renderEdit(makeEmployee({ status: 'inactive', is_active: true }));
+    await userEvent.click(screen.getByRole('button', { name: /update employee/i }));
+    await waitFor(() => expect(updateMock).toHaveBeenCalled());
+    expect(updateMock.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ id: 'emp-1', status: 'inactive', is_active: false }),
+    );
+  });
+
+  it('sends is_active=true when status is active (even if the row was is_active=false)', async () => {
+    renderEdit(makeEmployee({ status: 'active', is_active: false }));
+    await userEvent.click(screen.getByRole('button', { name: /update employee/i }));
+    await waitFor(() => expect(updateMock).toHaveBeenCalled());
+    expect(updateMock.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ id: 'emp-1', status: 'active', is_active: true }),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/EmployeeDialog.statusSync.test.tsx`
+Expected: FAIL — with the current code, the inactive case sends `is_active: true` (echoes the row), so the `objectContaining({ is_active: false })` assertion fails.
+
+- [ ] **Step 3: Wire the helper into EmployeeDialog**
+
+In `src/components/EmployeeDialog.tsx`:
+
+a. Add `EmployeeStatus` to the scheduling-types import (line 9):
+
+```ts
+import { Employee, EmployeeStatus, CompensationType, PayPeriodType, ContractorPaymentInterval, EmploymentType } from '@/types/scheduling';
+```
+
+b. Add the helper import (after the scheduling-types import):
+
+```ts
+import { isActiveForStatus } from '@/utils/employeeFilters';
+```
+
+c. Type the `status` state with the alias (line 60):
+
+```ts
+  const [status, setStatus] = useState<EmployeeStatus>('active');
+```
+
+d. In `proceedWithSubmit`, change the `is_active` line in `employeeData` (currently `is_active: employee?.is_active ?? true,`) to:
+
+```ts
+      is_active: isActiveForStatus(status),
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/EmployeeDialog.statusSync.test.tsx`
+Expected: PASS (both cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/EmployeeDialog.tsx tests/unit/EmployeeDialog.statusSync.test.tsx
+git commit -m "fix(employees): derive is_active from status in EmployeeDialog (constraint 23514)"
+```
+
+---
+
+### Task 3: Remove the silent fallback in `useDeactivateEmployee`
+
+**Files:**
+- Modify: `src/hooks/useEmployees.tsx`
+- Test: `tests/unit/employeeActivation.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add inside the `describe('useDeactivateEmployee', ...)` block in `tests/unit/employeeActivation.test.ts`:
+
+```ts
+it('surfaces the RPC error and does NOT fall back to a direct update', async () => {
+  mockSupabase.rpc = vi.fn().mockResolvedValue({ data: null, error: { message: 'rpc unavailable' } });
+  mockSupabase.from = vi.fn(); // must never be called
+  mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'user-123' } }, error: null });
+
+  const { useDeactivateEmployee } = await import('@/hooks/useEmployees');
+  const { result } = renderHook(() => useDeactivateEmployee(), { wrapper: createWrapper() });
+  await waitFor(() => expect(result.current).toBeDefined());
+
+  await expect(
+    result.current.mutateAsync({ employeeId: 'emp-1', removeFromSchedules: true, terminationDate: '2026-06-19' }),
+  ).rejects.toBeTruthy();
+
+  expect(mockSupabase.from).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/employeeActivation.test.ts -t "does NOT fall back"`
+Expected: FAIL — current code calls `supabase.from('employees').update(...)` after the RPC error, so `mockSupabase.from` IS called (and the mutation may resolve).
+
+- [ ] **Step 3: Remove the fallback**
+
+In `src/hooks/useEmployees.tsx`, `useDeactivateEmployee.mutationFn`, replace the block that currently reads:
+
+```ts
+      if (!error && data) return data;
+
+      // Fallback: direct update when RPC is unavailable in test/preview environments
+      const { data: fallbackData, error: fallbackError } = await supabase
+        .from('employees')
+        .update({
+          is_active: false,
+          deactivated_at: terminationDate,
+          deactivation_reason: reason || null,
+        })
+        .eq('id', employeeId)
+        .select('restaurant_id')
+        .single();
+
+      if (fallbackError) throw fallbackError;
+      return fallbackData;
+```
+
+with:
+
+```ts
+      if (error) throw error;
+      return data;
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/unit/employeeActivation.test.ts`
+Expected: PASS (new test + the existing happy-path deactivate tests still pass — they mock the RPC to resolve with data).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useEmployees.tsx tests/unit/employeeActivation.test.ts
+git commit -m "fix(employees): remove silent deactivate fallback; surface RPC errors"
+```
+
+---
+
+### Task 4: Remove the silent fallback in `useReactivateEmployee`
+
+**Files:**
+- Modify: `src/hooks/useEmployees.tsx`
+- Test: `tests/unit/employeeActivation.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add inside the `describe('useReactivateEmployee', ...)` block:
+
+```ts
+it('surfaces the RPC error and does NOT fall back to a direct update', async () => {
+  mockSupabase.rpc = vi.fn().mockResolvedValue({ data: null, error: { message: 'rpc unavailable' } });
+  mockSupabase.from = vi.fn(); // must never be called
+  mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'user-123' } }, error: null });
+
+  const { useReactivateEmployee } = await import('@/hooks/useEmployees');
+  const { result } = renderHook(() => useReactivateEmployee(), { wrapper: createWrapper() });
+  await waitFor(() => expect(result.current).toBeDefined());
+
+  await expect(
+    result.current.mutateAsync({ employeeId: 'emp-1' }),
+  ).rejects.toBeTruthy();
+
+  expect(mockSupabase.from).not.toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/employeeActivation.test.ts -t "does NOT fall back"`
+Expected: FAIL for the reactivate case — current code calls `supabase.from('employees').update(...)` after the RPC error.
+
+- [ ] **Step 3: Remove the fallback**
+
+In `src/hooks/useEmployees.tsx`, `useReactivateEmployee.mutationFn`, replace the block that currently reads:
+
+```ts
+      if (!error && data) return data;
+
+      // Fallback: direct update to mark active when RPC is unavailable
+      const { data: fallbackData, error: fallbackError } = await supabase
+        .from('employees')
+        .update({
+          is_active: true,
+          deactivated_at: null,
+          deactivation_reason: null,
+          hourly_rate: hourlyRate ?? undefined,
+        })
+        .eq('id', employeeId)
+        .select('restaurant_id')
+        .single();
+
+      if (fallbackError) throw fallbackError;
+      return fallbackData;
+```
+
+with:
+
+```ts
+      if (error) throw error;
+      return data;
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/unit/employeeActivation.test.ts`
+Expected: PASS (new test + existing happy-path reactivate tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useEmployees.tsx tests/unit/employeeActivation.test.ts
+git commit -m "fix(employees): remove silent reactivate fallback; surface RPC errors"
+```
+
+---
+
+## Coverage notes (read before review)
+
+- The three `EmployeeDialog` save paths (direct update, deferred comp-change `pendingCompChange.updatePayload`, and `createEmployeeWithHistory`) all spread the **same** `employeeData` object, so fixing the single `is_active` line covers all three. Task 2 tests the direct-update path explicitly; the others carry the identical derived `is_active` by construction.
+- `terminated => is_active false` is covered by the `isActiveForStatus` unit test (Task 1); the component tests cover `active`/`inactive` wiring through the real submit path.
+- Component tests are **prop-driven** (no Radix `Select` interaction) to stay robust in jsdom: an employee whose `is_active` contradicts its `status` is submitted, proving the saved value is derived from `status`, not echoed from the row.
+
+## Out of scope (deferred follow-ups)
+
+Missing `DialogDescription` on `EmployeeDialog`; raw colors in `DeactivateEmployeeDialog`; RPC `SECURITY DEFINER` `search_path` pinning; `canReactivate` vs `terminated` tension; inline UX hint on the status dropdown. None are required to fix constraint 23514.

--- a/docs/superpowers/plans/2026-06-19-employee-status-active-sync.md
+++ b/docs/superpowers/plans/2026-06-19-employee-status-active-sync.md
@@ -100,7 +100,7 @@ export function isActiveForStatus(status: EmployeeStatus): boolean {
 - [ ] **Step 4: Run test to verify it passes**
 
 Run: `npx vitest run tests/unit/employeeActivation.test.ts`
-Expected: PASS (all prior 12 tests + the 2 new ones).
+Expected: PASS (20 tests total).
 
 - [ ] **Step 5: Typecheck (the `Employee.status` change is type-only)**
 

--- a/docs/superpowers/specs/2026-06-19-employee-status-active-sync-design.md
+++ b/docs/superpowers/specs/2026-06-19-employee-status-active-sync-design.md
@@ -9,13 +9,13 @@
 Managers cannot deactivate (or otherwise change the status of) an employee from
 the UI. Saving a status change to `inactive`/`terminated` fails with:
 
-```
+```sql
 new row for relation "employees" violates check constraint "employees_status_active_sync"
 (Postgres 23514)
 ```
 
 Real-world trigger: a duplicated employee (`alexavaldez.1105@gmail.com`) could
-not be deactivated. Reproduced by the user "without a scheduled [shift]", which
+not be deactivated. Reproduced by the user "without a scheduled [shift]," which
 confirms the failure is unrelated to shifts/FKs — it is purely the
 `status` ↔ `is_active` pairing.
 

--- a/docs/superpowers/specs/2026-06-19-employee-status-active-sync-design.md
+++ b/docs/superpowers/specs/2026-06-19-employee-status-active-sync-design.md
@@ -65,11 +65,18 @@ every write-site. The duplication being removed is the per-site, hand-coded
 
 ### Changes
 
-1. **New helper** in `src/utils/employeeFilters.ts` (co-located with the existing
+1. **Canonical `EmployeeStatus` type.** Export
+   `EmployeeStatus = 'active' | 'inactive' | 'terminated'` from
+   `src/types/scheduling.ts` and use it for `Employee.status` (replacing the
+   inlined union). Import it wherever the status union is needed. Keeps
+   TypeScript the single source of truth for the status domain — avoids a
+   parallel union (both design reviewers flagged this).
+
+2. **New helper** in `src/utils/employeeFilters.ts` (co-located with the existing
    activation utilities, already covered by `employeeActivation.test.ts`):
 
    ```ts
-   export type EmployeeStatus = 'active' | 'inactive' | 'terminated';
+   import type { EmployeeStatus } from '@/types/scheduling';
 
    /**
     * Single source of truth for the is_active ↔ status invariant enforced by the
@@ -80,28 +87,38 @@ every write-site. The duplication being removed is the per-site, hand-coded
    }
    ```
 
-2. **`EmployeeDialog.tsx`** — `is_active: isActiveForStatus(status)` replaces
-   `is_active: employee?.is_active ?? true`. Fixes create, update, and
-   comp-change paths at once (they share the `employeeData` object).
+3. **`EmployeeDialog.tsx` `proceedWithSubmit`** — set
+   `is_active: isActiveForStatus(status)` in the `employeeData` object (replaces
+   `is_active: employee?.is_active ?? true`). Fixes create, update, and the
+   deferred comp-change path at once (they share the `employeeData` object).
 
-3. **`useEmployees.tsx` deactivate fallback** — add `status: 'inactive'` next to
-   `is_active: false` (mirrors the RPC).
-
-4. **`useEmployees.tsx` reactivate fallback** — add `status: 'active'` next to
-   `is_active: true` (mirrors the RPC).
+4. **`useEmployees.tsx` — remove both RPC fallbacks.** `useDeactivateEmployee`
+   and `useReactivateEmployee` currently fall back to a raw `.update()` when the
+   RPC errors. That fallback (a) duplicates RPC logic incompletely (no shift
+   cancellation, no `deactivated_by`, no audit), (b) fires silently in
+   production, and (c) was the source of the secondary desync. Remove it: on RPC
+   error, throw so the existing `onError` toast surfaces the failure. The
+   deployed `deactivate_employee`/`reactivate_employee` RPCs set both fields
+   atomically, so the happy path is unchanged. (Resolves the supabase reviewer's
+   `critical`; also serves the "avoid duplication" goal.)
 
 ## Testing
 
 - **Unit** (`tests/unit/employeeActivation.test.ts`): `isActiveForStatus` →
   `active=true`, `inactive=false`, `terminated=false`.
-- **Hook** (same file): when the RPC returns an error, the deactivate fallback
-  `.update(...)` payload contains `status:'inactive'` **and** `is_active:false`;
-  the reactivate fallback contains `status:'active'` **and** `is_active:true`.
-- **Component** (extend `tests/unit/EmployeeDialog.*.test.tsx` or add one):
-  editing an active employee and changing status to `inactive` / `terminated`
-  submits an update payload with `is_active:false` (and matching `status`);
-  leaving status `active` yields `is_active:true`. This is the direct regression
-  test for the user-facing bug.
+- **Component** (extend an `EmployeeDialog` test): editing an existing active
+  employee and changing status to `inactive` and to `terminated` submits an
+  update payload with `is_active:false` and the matching `status`; leaving status
+  `active` yields `is_active:true`. Cover all three write paths:
+  - direct update (`updateEmployee.mutateAsync` payload),
+  - deferred comp-change path (`pendingCompChange.updatePayload` applied by
+    `handleApplyCompChange` when compensation also changed),
+  - create (`createEmployeeWithHistory` payload).
+  This is the direct regression test for the user-facing bug.
+- **Hook** (`tests/unit/employeeActivation.test.ts`): when the RPC returns an
+  error, `useDeactivateEmployee`/`useReactivateEmployee` reject (surface the
+  error) and do **not** call `supabase.from('employees').update(...)` — i.e., no
+  silent fallback. Happy-path tests (RPC success) remain unchanged.
 
 ## Decided trade-offs / out of scope
 
@@ -109,7 +126,19 @@ every write-site. The duplication being removed is the per-site, hand-coded
   future shifts — that remains the dedicated Deactivate dialog's responsibility.
   Accepted: the edit form is a lightweight profile editor.
 - `'terminated'` remains settable only via the edit dialog (unchanged behaviour).
-  Giving it a dedicated RPC-backed flow is a separate product decision.
+  Note: running the Deactivate dialog on an already-`terminated` employee resets
+  their status to `inactive` (the RPC hardcodes `'inactive'`). Pre-existing; out
+  of scope.
+- Removing the RPC fallbacks means deactivate/reactivate now require the RPC to
+  be present. Supabase preview/branch DBs apply migrations and unit tests mock
+  the RPC, so this is safe; failures now surface loudly rather than silently
+  writing a partial row.
+- **Deferred (pre-existing, unrelated to this bug; candidate follow-ups):**
+  missing `DialogDescription` on `EmployeeDialog`; raw colors in
+  `DeactivateEmployeeDialog`; the RPCs' `SECURITY DEFINER` functions not pinning
+  `search_path`; the `canReactivate` (false for `terminated`) vs. edit-dialog
+  ability to set `status='active'` tension; no inline UX hint distinguishing the
+  status dropdown from the dedicated Deactivate flow.
 - No production data is modified. The existing duplicate employee row is cleaned
   up separately by the user through the now-fixed UI.
 

--- a/docs/superpowers/specs/2026-06-19-employee-status-active-sync-design.md
+++ b/docs/superpowers/specs/2026-06-19-employee-status-active-sync-design.md
@@ -1,0 +1,119 @@
+# Design: Fix employee `status` / `is_active` desync (check constraint 23514)
+
+- **Date:** 2026-06-19
+- **Branch:** `fix/employee-status-active-sync`
+- **Scope:** Client-side code fix only. No DB migration. No production data changes.
+
+## Problem
+
+Managers cannot deactivate (or otherwise change the status of) an employee from
+the UI. Saving a status change to `inactive`/`terminated` fails with:
+
+```
+new row for relation "employees" violates check constraint "employees_status_active_sync"
+(Postgres 23514)
+```
+
+Real-world trigger: a duplicated employee (`alexavaldez.1105@gmail.com`) could
+not be deactivated. Reproduced by the user "without a scheduled [shift]", which
+confirms the failure is unrelated to shifts/FKs — it is purely the
+`status` ↔ `is_active` pairing.
+
+## Root cause
+
+The DB constraint `employees_status_active_sync`
+(`supabase/migrations/20251209000000_add_employee_activation_tracking.sql`)
+requires `is_active` to mirror `status`:
+
+- `status = 'active'` ⇒ `is_active = true`
+- `status IN ('inactive','terminated')` ⇒ `is_active = false`
+
+Any other combination violates the constraint. Three client write-sites set the
+two fields independently and can desync them:
+
+1. **`src/components/EmployeeDialog.tsx` `proceedWithSubmit` (~line 479)** —
+   `is_active: employee?.is_active ?? true` keeps the employee's *existing*
+   `is_active` and ignores the `status` dropdown the user just changed. Feeds
+   all three save paths (create, update, comp-change). **This is the path the
+   user hit.**
+2. **`src/hooks/useEmployees.tsx` `useDeactivateEmployee` fallback (~line 190)** —
+   sets `is_active: false` without setting `status` (runs when the RPC errors).
+3. **`src/hooks/useEmployees.tsx` `useReactivateEmployee` fallback (~line 247)** —
+   sets `is_active: true` without setting `status` (mirror-image latent bug).
+
+Confirmed via production Postgres logs (two `23514` errors during the user's
+attempts) and the constraint definition. The dedicated `deactivate_employee` /
+`reactivate_employee` RPCs set both fields atomically and are **not** the source
+of the desync — the failure is in the client write-sites above.
+
+## Approach (approved): centralize the invariant
+
+`is_active` is fully derivable from `status` (`is_active === (status === 'active')`).
+Make that mapping the **single source of truth** on the client and apply it at
+every write-site. The duplication being removed is the per-site, hand-coded
+(and wrong) re-derivation of `is_active`.
+
+- No DB migration.
+- No UX change — the edit dialog keeps its status dropdown; `'terminated'` is
+  preserved.
+- No new side-effects.
+- The dedicated **Deactivate**/**Reactivate** dialogs remain the full-offboarding
+  path (termination date, future-shift cancellation, `deactivated_at/by` audit
+  via the RPC). They are already wired into `EmployeeList` as first-class
+  actions; the edit dialog's status field is a lightweight editor, not the
+  offboarding flow.
+
+### Changes
+
+1. **New helper** in `src/utils/employeeFilters.ts` (co-located with the existing
+   activation utilities, already covered by `employeeActivation.test.ts`):
+
+   ```ts
+   export type EmployeeStatus = 'active' | 'inactive' | 'terminated';
+
+   /**
+    * Single source of truth for the is_active ↔ status invariant enforced by the
+    * DB check constraint `employees_status_active_sync`.
+    */
+   export function isActiveForStatus(status: EmployeeStatus): boolean {
+     return status === 'active';
+   }
+   ```
+
+2. **`EmployeeDialog.tsx`** — `is_active: isActiveForStatus(status)` replaces
+   `is_active: employee?.is_active ?? true`. Fixes create, update, and
+   comp-change paths at once (they share the `employeeData` object).
+
+3. **`useEmployees.tsx` deactivate fallback** — add `status: 'inactive'` next to
+   `is_active: false` (mirrors the RPC).
+
+4. **`useEmployees.tsx` reactivate fallback** — add `status: 'active'` next to
+   `is_active: true` (mirrors the RPC).
+
+## Testing
+
+- **Unit** (`tests/unit/employeeActivation.test.ts`): `isActiveForStatus` →
+  `active=true`, `inactive=false`, `terminated=false`.
+- **Hook** (same file): when the RPC returns an error, the deactivate fallback
+  `.update(...)` payload contains `status:'inactive'` **and** `is_active:false`;
+  the reactivate fallback contains `status:'active'` **and** `is_active:true`.
+- **Component** (extend `tests/unit/EmployeeDialog.*.test.tsx` or add one):
+  editing an active employee and changing status to `inactive` / `terminated`
+  submits an update payload with `is_active:false` (and matching `status`);
+  leaving status `active` yields `is_active:true`. This is the direct regression
+  test for the user-facing bug.
+
+## Decided trade-offs / out of scope
+
+- The edit dialog's status change does **not** set `deactivated_at/by` or cancel
+  future shifts — that remains the dedicated Deactivate dialog's responsibility.
+  Accepted: the edit form is a lightweight profile editor.
+- `'terminated'` remains settable only via the edit dialog (unchanged behaviour).
+  Giving it a dedicated RPC-backed flow is a separate product decision.
+- No production data is modified. The existing duplicate employee row is cleaned
+  up separately by the user through the now-fixed UI.
+
+## Risk
+
+Low. Pure client-side logic; the change makes every client write satisfy an
+existing DB constraint. Backed by unit + hook + component tests.

--- a/src/components/EmployeeDialog.tsx
+++ b/src/components/EmployeeDialog.tsx
@@ -578,9 +578,14 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
   return (
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="sm:max-w-[500px] max-h-[90vh] p-0 gap-0 flex flex-col overflow-hidden">
-          <DialogHeader>
-            <DialogTitle>{employee ? 'Edit Employee' : 'Add New Employee'}</DialogTitle>
+        <DialogContent className="sm:max-w-[500px] max-h-[90vh] p-0 gap-0 flex flex-col overflow-hidden border-border/40">
+          <DialogHeader className="px-6 pt-6 pb-4 border-b border-border/40 shrink-0">
+            <DialogTitle className="text-[17px] font-semibold text-foreground">
+              {employee ? 'Edit Employee' : 'Add New Employee'}
+            </DialogTitle>
+            <DialogDescription className="text-[13px] text-muted-foreground mt-0.5">
+              {employee ? 'Update employee details and compensation.' : 'Add a new team member to your restaurant.'}
+            </DialogDescription>
           </DialogHeader>
           <form onSubmit={handleSubmit} className="flex flex-col flex-1 min-h-0">
             <div className="flex-1 overflow-y-auto px-6 py-5">
@@ -596,6 +601,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                   placeholder="John Doe"
                   required
                   aria-label="Employee name"
+                  className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
                 />
               </div>
 
@@ -676,7 +682,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                     if (newType !== 'hourly') setIsExempt(false);
                   }}
                 >
-                  <SelectTrigger id="compensationType" aria-label="Compensation type">
+                  <SelectTrigger id="compensationType" aria-label="Compensation type" className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg">
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -715,6 +721,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                       placeholder="15.00"
                       required
                       aria-label="Hourly rate in dollars"
+                      className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
                     />
                   </div>
 
@@ -778,6 +785,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                       placeholder="52000.00"
                       required
                       aria-label="Salary amount in dollars"
+                      className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
                     />
                   </div>
                   <div className="space-y-2">
@@ -803,7 +811,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                       value={payPeriodType} 
                       onValueChange={(value) => setPayPeriodType(value as PayPeriodType)}
                     >
-                      <SelectTrigger id="payPeriodType" aria-label="Pay period">
+                      <SelectTrigger id="payPeriodType" aria-label="Pay period" className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg">
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
@@ -874,6 +882,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                       placeholder="2500.00"
                       required
                       aria-label="Payment amount in dollars"
+                      className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
                     />
                   </div>
                   <div className="space-y-2">
@@ -884,7 +893,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                       value={contractorPaymentInterval} 
                       onValueChange={(value) => setContractorPaymentInterval(value as ContractorPaymentInterval)}
                     >
-                      <SelectTrigger id="contractorPaymentInterval" aria-label="Payment interval">
+                      <SelectTrigger id="contractorPaymentInterval" aria-label="Payment interval" className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg">
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
@@ -935,6 +944,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                         placeholder="1000.00"
                         required
                         aria-label="Weekly reference amount"
+                        className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
                       />
                       <span className="text-sm text-muted-foreground whitespace-nowrap">per week</span>
                     </div>
@@ -948,7 +958,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                       value={dailyRateStandardDays} 
                       onValueChange={setDailyRateStandardDays}
                     >
-                      <SelectTrigger id="dailyRateStandardDays" aria-label="Standard work days per week">
+                      <SelectTrigger id="dailyRateStandardDays" aria-label="Standard work days per week" className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg">
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
@@ -961,10 +971,10 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
 
                   {/* CRITICAL: Show the derived rate */}
                   {dailyRateWeekly && parseFloat(dailyRateWeekly) > 0 && (
-                    <div className="p-3 bg-primary/10 border border-primary/20 rounded-md">
+                    <div className="p-3 rounded-xl border border-border/40 bg-muted/30">
                       <div className="flex items-center justify-between mb-2">
-                        <span className="text-sm font-medium">Daily Rate</span>
-                        <span className="text-lg font-bold text-primary">
+                        <span className="text-[13px] font-medium text-muted-foreground">Daily Rate</span>
+                        <span className="text-[15px] font-semibold text-foreground">
                           ${derivedDailyRate.toFixed(2)} / day
                         </span>
                       </div>
@@ -981,7 +991,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                         </div>
                         <div className="flex justify-between">
                           <span>7 days worked:</span>
-                          <span className={`font-medium ${parseInt(dailyRateStandardDays) < 7 ? 'text-orange-600' : ''}`}>
+                          <span className={`font-medium ${parseInt(dailyRateStandardDays) < 7 ? 'text-amber-600 dark:text-amber-400' : ''}`}>
                             ${(derivedDailyRate * 7).toFixed(2)}
                           </span>
                         </div>
@@ -991,9 +1001,9 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
 
                   {/* Warn about 7-day scenario */}
                   {parseInt(dailyRateStandardDays) < 7 && (
-                    <div className="flex items-start gap-2 p-2 bg-orange-50 dark:bg-orange-950/20 border border-orange-200 dark:border-orange-800 rounded text-xs">
-                      <Info className="h-3.5 w-3.5 text-orange-600 mt-0.5 flex-shrink-0" />
-                      <p className="text-orange-800 dark:text-orange-300">
+                    <div className="flex items-start gap-2 p-2.5 rounded-lg bg-amber-500/10 border border-amber-500/20 text-xs">
+                      <Info className="h-3.5 w-3.5 text-amber-500 mt-0.5 flex-shrink-0" />
+                      <p className="text-amber-700 dark:text-amber-400">
                         If this employee works 7 days, they'll earn <strong>${(derivedDailyRate * 7).toFixed(2)}</strong>,
                         which is more than the weekly reference amount.
                       </p>
@@ -1012,6 +1022,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                     onChange={(e) => setEmail(e.target.value)}
                     placeholder="john@example.com"
                     aria-label="Employee email"
+                    className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
                   />
                 </div>
 
@@ -1024,6 +1035,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                     onChange={(e) => setPhone(e.target.value)}
                     placeholder="(555) 123-4567"
                     aria-label="Employee phone number"
+                    className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
                   />
                 </div>
               </div>
@@ -1032,7 +1044,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                 <div className="space-y-2">
                   <Label htmlFor="status">Status</Label>
                   <Select value={status} onValueChange={(value) => setStatus(value as typeof status)}>
-                    <SelectTrigger id="status" aria-label="Employee status">
+                    <SelectTrigger id="status" aria-label="Employee status" className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg">
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
@@ -1051,6 +1063,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                     value={hireDate}
                     onChange={(e) => setHireDate(e.target.value)}
                     aria-label="Hire date"
+                    className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
                   />
                 </div>
 
@@ -1062,6 +1075,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                     value={dateOfBirth}
                     onChange={(e) => setDateOfBirth(e.target.value)}
                     aria-label="Date of birth"
+                    className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
                   />
                   {dateOfBirth && isMinor(dateOfBirth) && (
                     <span className="text-[11px] px-1.5 py-0.5 rounded-md bg-amber-500/10 text-amber-600 font-medium inline-block">
@@ -1084,6 +1098,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                     onChange={(e) => setTerminationDate(e.target.value)}
                     required={status === 'terminated'}
                     aria-label="Termination date"
+                    className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
                   />
                   <p className="text-xs text-muted-foreground">
                     Payroll allocations will stop being generated after this date
@@ -1100,6 +1115,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                   placeholder="Additional information about this employee..."
                   rows={3}
                   aria-label="Employee notes"
+                  className="text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border resize-none"
                 />
               </div>
             </div>
@@ -1147,13 +1163,19 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
             )}
             </div>
 
-            <DialogFooter className="px-6 py-4 border-t border-border/40">
-              <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            <DialogFooter className="px-6 py-4 border-t border-border/40 shrink-0">
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => onOpenChange(false)}
+                className="h-9 px-4 rounded-lg text-[13px] font-medium text-muted-foreground hover:text-foreground"
+              >
                 Cancel
               </Button>
               <Button
                 type="submit"
                 disabled={createEmployee.isPending || updateEmployee.isPending}
+                className="h-9 px-4 rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium"
               >
                 {(() => {
                   if (createEmployee.isPending || updateEmployee.isPending) return 'Saving...';
@@ -1176,16 +1198,18 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
           }
         }}
       >
-        <DialogContent className="sm:max-w-[425px]">
-          <DialogHeader>
-            <DialogTitle>Apply New Compensation Rate</DialogTitle>
-            <DialogDescription>
+        <DialogContent className="sm:max-w-[425px] p-0 gap-0 border-border/40">
+          <DialogHeader className="px-6 pt-6 pb-4 border-b border-border/40">
+            <DialogTitle className="text-[17px] font-semibold text-foreground">
+              Apply New Compensation Rate
+            </DialogTitle>
+            <DialogDescription className="text-[13px] text-muted-foreground mt-0.5">
               We’ll keep your historical records intact. This change only applies to shifts worked on or after the effective date.
             </DialogDescription>
           </DialogHeader>
-          <div className="space-y-4 py-2">
+          <div className="px-6 py-5 space-y-4">
             <div className="space-y-2">
-              <Label htmlFor="effectiveDate">
+              <Label htmlFor="effectiveDate" className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
                 Effective Date <span className="text-destructive">*</span>
               </Label>
               <Input
@@ -1195,21 +1219,24 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                 onChange={(e) => setEffectiveDate(e.target.value)}
                 required
                 aria-label="Effective date for new compensation rate"
+                className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
               />
             </div>
-            <p className="text-sm text-muted-foreground">
-              This change only applies to shifts worked on or after the effective date.
-            </p>
           </div>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => setIsEffectiveDateModalOpen(false)}>
+          <DialogFooter className="px-6 py-4 border-t border-border/40">
+            <Button
+              variant="ghost"
+              onClick={() => setIsEffectiveDateModalOpen(false)}
+              className="h-9 px-4 rounded-lg text-[13px] font-medium text-muted-foreground hover:text-foreground"
+            >
               Cancel
             </Button>
             <Button
               onClick={handleApplyCompChange}
               disabled={savingCompHistory || updateEmployee.isPending || !effectiveDate}
+              className="h-9 px-4 rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium"
             >
-              {savingCompHistory ? 'Saving...' : 'Save New Rate'}
+              {savingCompHistory ? ‘Saving...’ : ‘Save New Rate’}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/components/EmployeeDialog.tsx
+++ b/src/components/EmployeeDialog.tsx
@@ -8,7 +8,6 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Checkbox } from '@/components/ui/checkbox';
 import { Switch } from '@/components/ui/switch';
 import { Employee, EmployeeStatus, CompensationType, PayPeriodType, ContractorPaymentInterval, EmploymentType } from '@/types/scheduling';
-import { isActiveForStatus } from '@/utils/employeeFilters';
 import { useCreateEmployee, useUpdateEmployee } from '@/hooks/useEmployees';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
@@ -42,6 +41,7 @@ import { useShiftTemplates } from '@/hooks/useShiftTemplates';
 import { useBulkSetAvailability } from '@/hooks/useBulkSetAvailability';
 import { useRestaurantContext } from '@/contexts/RestaurantContext';
 import { convertAvailabilityWindowsToUtc } from '@/lib/availabilityTimeUtils';
+import { isActiveForStatus } from '@/utils/employeeFilters';
 
 interface EmployeeDialogProps {
   open: boolean;

--- a/src/components/EmployeeDialog.tsx
+++ b/src/components/EmployeeDialog.tsx
@@ -7,7 +7,8 @@ import { Textarea } from '@/components/ui/textarea';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Switch } from '@/components/ui/switch';
-import { Employee, CompensationType, PayPeriodType, ContractorPaymentInterval, EmploymentType } from '@/types/scheduling';
+import { Employee, EmployeeStatus, CompensationType, PayPeriodType, ContractorPaymentInterval, EmploymentType } from '@/types/scheduling';
+import { isActiveForStatus } from '@/utils/employeeFilters';
 import { useCreateEmployee, useUpdateEmployee } from '@/hooks/useEmployees';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
@@ -57,7 +58,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
   const [area, setArea] = useState('');
   const [employmentType, setEmploymentType] = useState<EmploymentType>('full_time');
   const [dateOfBirth, setDateOfBirth] = useState('');
-  const [status, setStatus] = useState<'active' | 'inactive' | 'terminated'>('active');
+  const [status, setStatus] = useState<EmployeeStatus>('active');
   const [hireDate, setHireDate] = useState('');
   const [terminationDate, setTerminationDate] = useState('');
   const [notes, setNotes] = useState('');
@@ -476,7 +477,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
         ? terminationDate 
         : null,
       notes: notes || undefined,
-      is_active: employee?.is_active ?? true,
+      is_active: isActiveForStatus(status),
       compensation_type: compensationType,
       is_exempt: isExempt,
       hourly_rate: hourlyRateInCents,

--- a/src/components/EmployeeDialog.tsx
+++ b/src/components/EmployeeDialog.tsx
@@ -86,7 +86,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
   const [dailyRateStandardDays, setDailyRateStandardDays] = useState('6');
 
   // Calculate derived daily rate (preview)
-  const standardDays = parseInt(dailyRateStandardDays) || 1;
+  const standardDays = Number.parseInt(dailyRateStandardDays) || 1;
   const derivedDailyRate = useMemo(() => {
     const weekly = parseFloat(dailyRateWeekly) || 0;
     return weekly / standardDays;

--- a/src/components/EmployeeDialog.tsx
+++ b/src/components/EmployeeDialog.tsx
@@ -86,11 +86,11 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
   const [dailyRateStandardDays, setDailyRateStandardDays] = useState('6');
 
   // Calculate derived daily rate (preview)
+  const standardDays = parseInt(dailyRateStandardDays) || 1;
   const derivedDailyRate = useMemo(() => {
     const weekly = parseFloat(dailyRateWeekly) || 0;
-    const days = parseInt(dailyRateStandardDays) || 1;
-    return weekly / days;
-  }, [dailyRateWeekly, dailyRateStandardDays]);
+    return weekly / standardDays;
+  }, [dailyRateWeekly, standardDays]);
 
   const getToday = () => new Date().toISOString().split('T')[0];
 
@@ -416,7 +416,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
       : undefined;
     
     const dailyRateDays = compensationType === 'daily_rate' && dailyRateStandardDays
-      ? parseInt(dailyRateStandardDays)
+      ? standardDays
       : undefined;
     
     const dailyRateAmountInCents = dailyRateWeeklyInCents && dailyRateDays
@@ -991,7 +991,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                         </div>
                         <div className="flex justify-between">
                           <span>7 days worked:</span>
-                          <span className={`font-medium ${parseInt(dailyRateStandardDays) < 7 ? 'text-amber-600 dark:text-amber-400' : ''}`}>
+                          <span className={`font-medium ${standardDays < 7 ? 'text-amber-600 dark:text-amber-400' : ''}`}>
                             ${(derivedDailyRate * 7).toFixed(2)}
                           </span>
                         </div>
@@ -1000,7 +1000,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                   )}
 
                   {/* Warn about 7-day scenario */}
-                  {parseInt(dailyRateStandardDays) < 7 && (
+                  {standardDays < 7 && (
                     <div className="flex items-start gap-2 p-2.5 rounded-lg bg-amber-500/10 border border-amber-500/20 text-xs">
                       <Info className="h-3.5 w-3.5 text-amber-500 mt-0.5 flex-shrink-0" />
                       <p className="text-amber-700 dark:text-amber-400">
@@ -1043,7 +1043,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
               <div className="grid grid-cols-3 gap-4">
                 <div className="space-y-2">
                   <Label htmlFor="status">Status</Label>
-                  <Select value={status} onValueChange={(value) => setStatus(value as typeof status)}>
+                  <Select value={status} onValueChange={(value) => setStatus(value as EmployeeStatus)}>
                     <SelectTrigger id="status" aria-label="Employee status" className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg">
                       <SelectValue />
                     </SelectTrigger>
@@ -1204,7 +1204,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
               Apply New Compensation Rate
             </DialogTitle>
             <DialogDescription className="text-[13px] text-muted-foreground mt-0.5">
-              We’ll keep your historical records intact. This change only applies to shifts worked on or after the effective date.
+              We'll keep your historical records intact. This change only applies to shifts worked on or after the effective date.
             </DialogDescription>
           </DialogHeader>
           <div className="px-6 py-5 space-y-4">
@@ -1236,7 +1236,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
               disabled={savingCompHistory || updateEmployee.isPending || !effectiveDate}
               className="h-9 px-4 rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium"
             >
-              {savingCompHistory ? ‘Saving...’ : ‘Save New Rate’}
+              {savingCompHistory ? 'Saving...' : 'Save New Rate'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/src/hooks/useEmployees.tsx
+++ b/src/hooks/useEmployees.tsx
@@ -182,22 +182,8 @@ export const useDeactivateEmployee = () => {
         p_termination_date: terminationDate,
       });
 
-      if (!error && data) return data;
-
-      // Fallback: direct update when RPC is unavailable in test/preview environments
-      const { data: fallbackData, error: fallbackError } = await supabase
-        .from('employees')
-        .update({
-          is_active: false,
-          deactivated_at: terminationDate,
-          deactivation_reason: reason || null,
-        })
-        .eq('id', employeeId)
-        .select('restaurant_id')
-        .single();
-
-      if (fallbackError) throw fallbackError;
-      return fallbackData;
+      if (error) throw error;
+      return data;
     },
     onSuccess: (data, variables) => {
       // Invalidate all employee queries for this restaurant

--- a/src/hooks/useEmployees.tsx
+++ b/src/hooks/useEmployees.tsx
@@ -185,7 +185,7 @@ export const useDeactivateEmployee = () => {
       if (error) throw error;
       return data;
     },
-    onSuccess: (data, variables) => {
+    onSuccess: () => {
       // Invalidate all employee queries for this restaurant
       queryClient.invalidateQueries({ queryKey: ['employees'] });
       toast({
@@ -228,7 +228,7 @@ export const useReactivateEmployee = () => {
       if (error) throw error;
       return data;
     },
-    onSuccess: (data, variables) => {
+    onSuccess: () => {
       // Invalidate all employee queries
       queryClient.invalidateQueries({ queryKey: ['employees'] });
       toast({

--- a/src/hooks/useEmployees.tsx
+++ b/src/hooks/useEmployees.tsx
@@ -225,23 +225,8 @@ export const useReactivateEmployee = () => {
         p_new_hourly_rate: hourlyRate || null,
       });
 
-      if (!error && data) return data;
-
-      // Fallback: direct update to mark active when RPC is unavailable
-      const { data: fallbackData, error: fallbackError } = await supabase
-        .from('employees')
-        .update({
-          is_active: true,
-          deactivated_at: null,
-          deactivation_reason: null,
-          hourly_rate: hourlyRate ?? undefined,
-        })
-        .eq('id', employeeId)
-        .select('restaurant_id')
-        .single();
-
-      if (fallbackError) throw fallbackError;
-      return fallbackData;
+      if (error) throw error;
+      return data;
     },
     onSuccess: (data, variables) => {
       // Invalidate all employee queries

--- a/src/hooks/useEmployees.tsx
+++ b/src/hooks/useEmployees.tsx
@@ -183,6 +183,7 @@ export const useDeactivateEmployee = () => {
       });
 
       if (error) throw error;
+      if (!data) throw new Error('deactivate_employee returned no employee row');
       return data;
     },
     onSuccess: () => {
@@ -226,6 +227,7 @@ export const useReactivateEmployee = () => {
       });
 
       if (error) throw error;
+      if (!data) throw new Error('reactivate_employee returned no employee row');
       return data;
     },
     onSuccess: () => {

--- a/src/pages/Scheduling.tsx
+++ b/src/pages/Scheduling.tsx
@@ -1421,7 +1421,7 @@ const Scheduling = () => {
                 </div>
               ))}
             </div>
-          ) : activeEmployees.length === 0 ? (
+          ) : allEmployees.length === 0 ? (
             <div className="text-center py-16 px-6">
               <div className="relative inline-block">
                 <div className="absolute inset-0 bg-primary/10 rounded-full blur-xl animate-pulse" />

--- a/src/types/scheduling.ts
+++ b/src/types/scheduling.ts
@@ -5,6 +5,14 @@ export type ContractorPaymentInterval = 'weekly' | 'bi-weekly' | 'monthly' | 'pe
 export type DeactivationReason = 'seasonal' | 'left_company' | 'on_leave' | 'other';
 export type EmploymentType = 'full_time' | 'part_time';
 
+/**
+ * Canonical employee status type.
+ * Mirrors the DB constraint `employees_status_active_sync`:
+ *   active → is_active = true
+ *   inactive | terminated → is_active = false
+ */
+export type EmployeeStatus = 'active' | 'inactive' | 'terminated';
+
 export interface CompensationHistoryEntry {
   id: string;
   employee_id: string;
@@ -24,7 +32,7 @@ export interface Employee {
   phone?: string;
   position: string;
   area?: string;
-  status: 'active' | 'inactive' | 'terminated';
+  status: EmployeeStatus;
   hire_date?: string;
   termination_date?: string; // Date when employee was terminated/inactivated
   notes?: string;

--- a/src/utils/employeeFilters.ts
+++ b/src/utils/employeeFilters.ts
@@ -3,6 +3,18 @@
  * Shared utilities for filtering and managing employee activation status
  */
 
+import type { EmployeeStatus } from '@/types/scheduling';
+
+/**
+ * Single source of truth for the is_active ↔ status invariant enforced by the
+ * DB check constraint `employees_status_active_sync`.
+ *   active → is_active = true
+ *   inactive | terminated → is_active = false
+ */
+export function isActiveForStatus(status: EmployeeStatus): boolean {
+  return status === 'active';
+}
+
 interface EmployeeWithActivation {
   is_active: boolean;
   status: string;

--- a/tests/unit/EmployeeDialog.statusSync.test.tsx
+++ b/tests/unit/EmployeeDialog.statusSync.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { EmployeeDialog } from '@/components/EmployeeDialog';
+
+const updateMock = vi.fn().mockResolvedValue({ id: 'emp-1' });
+const createMock = vi.fn().mockResolvedValue({ id: 'emp-1' });
+
+vi.mock('@/hooks/useEmployees', () => ({
+  useCreateEmployee: () => ({ mutateAsync: createMock, isPending: false }),
+  useUpdateEmployee: () => ({ mutateAsync: updateMock, isPending: false }),
+}));
+
+vi.mock('@/hooks/useBulkSetAvailability', () => ({
+  useBulkSetAvailability: () => ({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false }),
+}));
+
+vi.mock('@/hooks/useShiftTemplates', () => {
+  const STABLE_TEMPLATES: never[] = [];
+  return {
+    useShiftTemplates: () => ({
+      templates: STABLE_TEMPLATES,
+      loading: false,
+      error: null,
+      createTemplate: () => Promise.resolve(),
+      updateTemplate: () => Promise.resolve(),
+      deleteTemplate: () => Promise.resolve(),
+    }),
+  };
+});
+
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => ({ selectedRestaurant: { restaurant: { id: 'r1', timezone: 'UTC' } } }),
+}));
+
+vi.mock('@/integrations/supabase/client', () => {
+  function makeChain(): any {
+    const chain: any = {};
+    chain.select = () => makeChain();
+    chain.eq = () => makeChain();
+    chain.not = () => makeChain();
+    chain.order = () => Promise.resolve({ data: [], error: null });
+    chain.is = () => makeChain();
+    chain.single = () => Promise.resolve({ data: null, error: null });
+    chain.upsert = () => Promise.resolve({ data: null, error: null });
+    chain.insert = () => makeChain();
+    chain.update = () => makeChain();
+    chain.then = (resolve: (v: { data: any[]; error: null }) => any) =>
+      Promise.resolve({ data: [], error: null }).then(resolve);
+    chain.catch = () => Promise.resolve({ data: [], error: null });
+    return chain;
+  }
+  return {
+    supabase: {
+      functions: { invoke: () => Promise.resolve({ data: null, error: null }) },
+      from: () => makeChain(),
+    },
+  };
+});
+
+type EmpOverrides = Partial<{ status: string; is_active: boolean }>;
+const makeEmployee = (overrides: EmpOverrides) => ({
+  id: 'emp-1',
+  restaurant_id: 'r1',
+  name: 'Alex Valdez',
+  position: 'Server',
+  status: 'active',
+  is_active: true,
+  compensation_type: 'hourly',
+  hourly_rate: 1500,
+  employment_type: 'full_time',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  ...overrides,
+});
+
+function renderEdit(employee: ReturnType<typeof makeEmployee>) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false, staleTime: Infinity } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      <EmployeeDialog open onOpenChange={vi.fn()} restaurantId="r1" employee={employee as any} />
+    </QueryClientProvider>,
+  );
+}
+
+describe('EmployeeDialog — is_active is derived from status on save', () => {
+  beforeEach(() => {
+    updateMock.mockClear();
+    createMock.mockClear();
+  });
+
+  it('sends is_active=false when status is inactive (even if the row was is_active=true)', async () => {
+    renderEdit(makeEmployee({ status: 'inactive', is_active: true }));
+    await userEvent.click(screen.getByRole('button', { name: /update employee/i }));
+    await waitFor(() => expect(updateMock).toHaveBeenCalled());
+    expect(updateMock.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ id: 'emp-1', status: 'inactive', is_active: false }),
+    );
+  });
+
+  it('sends is_active=true when status is active (even if the row was is_active=false)', async () => {
+    renderEdit(makeEmployee({ status: 'active', is_active: false }));
+    await userEvent.click(screen.getByRole('button', { name: /update employee/i }));
+    await waitFor(() => expect(updateMock).toHaveBeenCalled());
+    expect(updateMock.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ id: 'emp-1', status: 'active', is_active: true }),
+    );
+  });
+});

--- a/tests/unit/EmployeeDialog.statusSync.test.tsx
+++ b/tests/unit/EmployeeDialog.statusSync.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { EmployeeDialog } from '@/components/EmployeeDialog';
+import type { EmployeeStatus } from '@/types/scheduling';
 
 const updateMock = vi.fn().mockResolvedValue({ id: 'emp-1' });
 const createMock = vi.fn().mockResolvedValue({ id: 'emp-1' });
@@ -38,8 +39,13 @@ vi.mock('@/contexts/RestaurantContext', () => ({
 }));
 
 vi.mock('@/integrations/supabase/client', () => {
-  function makeChain(): any {
-    const chain: any = {};
+  // Recursive fluent-builder mock — must be `any` because the chain can call
+  // any subset of methods in any order; a typed interface would require an
+  // exhaustive intersection of all Supabase builder return types.
+  function makeChain(): any { // eslint-disable-line @typescript-eslint/no-explicit-any
+    // `chain` is `any` here because the recursive self-reference prevents a
+    // concrete type from being declared before the object literal is complete.
+    const chain: any = {}; // eslint-disable-line @typescript-eslint/no-explicit-any
     chain.select = () => makeChain();
     chain.eq = () => makeChain();
     chain.not = () => makeChain();
@@ -49,7 +55,9 @@ vi.mock('@/integrations/supabase/client', () => {
     chain.upsert = () => Promise.resolve({ data: null, error: null });
     chain.insert = () => makeChain();
     chain.update = () => makeChain();
-    chain.then = (resolve: (v: { data: any[]; error: null }) => any) =>
+    // `resolve` and the return type use `any` to match the overloaded
+    // PromiseLike signatures Supabase's query builder emits at runtime.
+    chain.then = (resolve: (v: { data: any[]; error: null }) => any) => // eslint-disable-line @typescript-eslint/no-explicit-any
       Promise.resolve({ data: [], error: null }).then(resolve);
     chain.catch = () => Promise.resolve({ data: [], error: null });
     return chain;
@@ -62,13 +70,13 @@ vi.mock('@/integrations/supabase/client', () => {
   };
 });
 
-type EmpOverrides = Partial<{ status: string; is_active: boolean }>;
+type EmpOverrides = Partial<{ status: EmployeeStatus; is_active: boolean }>;
 const makeEmployee = (overrides: EmpOverrides) => ({
   id: 'emp-1',
   restaurant_id: 'r1',
   name: 'Alex Valdez',
   position: 'Server',
-  status: 'active',
+  status: 'active' as EmployeeStatus,
   is_active: true,
   compensation_type: 'hourly',
   hourly_rate: 1500,
@@ -84,7 +92,19 @@ function renderEdit(employee: ReturnType<typeof makeEmployee>) {
   });
   return render(
     <QueryClientProvider client={qc}>
-      <EmployeeDialog open onOpenChange={vi.fn()} restaurantId="r1" employee={employee as any} />
+      {/* cast: test fixture omits optional Employee fields (e.g. notes, date_of_birth) */}
+      <EmployeeDialog open onOpenChange={vi.fn()} restaurantId="r1" employee={employee as any} /> {/* eslint-disable-line @typescript-eslint/no-explicit-any */}
+    </QueryClientProvider>,
+  );
+}
+
+function renderCreate() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false, staleTime: Infinity } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      <EmployeeDialog open onOpenChange={vi.fn()} restaurantId="r1" />
     </QueryClientProvider>,
   );
 }
@@ -95,6 +115,8 @@ describe('EmployeeDialog — is_active is derived from status on save', () => {
     createMock.mockClear();
   });
 
+  // ── Direct update path ────────────────────────────────────────────────────
+
   it('sends is_active=false when status is inactive (even if the row was is_active=true)', async () => {
     renderEdit(makeEmployee({ status: 'inactive', is_active: true }));
     await userEvent.click(screen.getByRole('button', { name: /update employee/i }));
@@ -104,12 +126,85 @@ describe('EmployeeDialog — is_active is derived from status on save', () => {
     );
   });
 
+  it('sends is_active=false when status is terminated (even if the row was is_active=true)', async () => {
+    // termination_date is required when status='terminated' — include it in the
+    // fixture so HTML5 form validation does not block submit.
+    renderEdit(makeEmployee({ status: 'terminated', is_active: true, termination_date: '2026-01-15' } as any)); // eslint-disable-line @typescript-eslint/no-explicit-any
+    await userEvent.click(screen.getByRole('button', { name: /update employee/i }));
+    await waitFor(() => expect(updateMock).toHaveBeenCalled());
+    expect(updateMock.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ id: 'emp-1', status: 'terminated', is_active: false }),
+    );
+  });
+
   it('sends is_active=true when status is active (even if the row was is_active=false)', async () => {
     renderEdit(makeEmployee({ status: 'active', is_active: false }));
     await userEvent.click(screen.getByRole('button', { name: /update employee/i }));
     await waitFor(() => expect(updateMock).toHaveBeenCalled());
     expect(updateMock.mock.calls[0][0]).toEqual(
       expect.objectContaining({ id: 'emp-1', status: 'active', is_active: true }),
+    );
+  });
+
+  // ── Deferred comp-change path ─────────────────────────────────────────────
+  // When compensation changes simultaneously, the dialog stores employeeData in
+  // pendingCompChange.updatePayload and defers the write until the user confirms
+  // an effective date. The is_active derivation must survive that deferral so a
+  // future refactor of proceedWithSubmit cannot silently regress the bug.
+
+  it('deferred comp-change path: payload sent via handleApplyCompChange still derives is_active from status', async () => {
+    const user = userEvent.setup();
+    // Employee is currently inactive with is_active=true (the bug scenario).
+    renderEdit(makeEmployee({ status: 'inactive', is_active: true, hourly_rate: 1500 }));
+
+    // Change the hourly rate to trigger hasCompensationChanged → comp-change modal.
+    // Use $16/hr (below the $50 high-rate-warning threshold) so we don't hit the
+    // separate high-rate-warning dialog.
+    const rateInput = screen.getByLabelText(/hourly rate in dollars/i);
+    await user.clear(rateInput);
+    await user.type(rateInput, '16.00');
+
+    // Submit → comp-change modal opens instead of saving directly.
+    await user.click(screen.getByRole('button', { name: /update employee/i }));
+
+    // The effective-date modal should now be visible.
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: /apply new compensation rate/i })).toBeInTheDocument(),
+    );
+
+    // Confirm in the comp-change modal → triggers handleApplyCompChange which
+    // calls updateEmployee.mutateAsync(pendingCompChange.updatePayload).
+    await user.click(screen.getByRole('button', { name: /save new rate/i }));
+
+    await waitFor(() => expect(updateMock).toHaveBeenCalled());
+    expect(updateMock.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ id: 'emp-1', status: 'inactive', is_active: false }),
+    );
+  });
+
+  // ── Create path ───────────────────────────────────────────────────────────
+  // The create form starts with status='active'. Fill minimum required fields
+  // and verify the payload sent to createEmployee.mutateAsync includes the
+  // correct is_active derived from status.
+
+  it('create path: new employee payload derives is_active from the selected status', async () => {
+    const user = userEvent.setup();
+    renderCreate();
+
+    // Fill required name field
+    await user.type(screen.getByLabelText(/name/i), 'New Employee');
+
+    // Fill required hourly rate (default compensation type is hourly)
+    const rateInput = screen.getByLabelText(/hourly rate in dollars/i);
+    await user.clear(rateInput);
+    await user.type(rateInput, '15.00');
+
+    // Submit — default status is 'active'
+    await user.click(screen.getByRole('button', { name: /add employee/i }));
+
+    await waitFor(() => expect(createMock).toHaveBeenCalled());
+    expect(createMock.mock.calls[0][0]).toEqual(
+      expect.objectContaining({ status: 'active', is_active: true }),
     );
   });
 });

--- a/tests/unit/employeeActivation.test.ts
+++ b/tests/unit/employeeActivation.test.ts
@@ -7,7 +7,9 @@ import {
   filterInactiveEmployees,
   getLastActiveDate,
   canReactivate,
+  isActiveForStatus,
 } from '@/utils/employeeFilters';
+import type { EmployeeStatus } from '@/types/scheduling';
 
 /**
  * Unit Tests for Employee Activation/Deactivation Logic
@@ -486,6 +488,29 @@ describe('Employee Activation Status', () => {
       expect(
         canReactivate({ is_active: false, status: 'terminated' })
       ).toBe(false);
+    });
+  });
+
+  describe('isActiveForStatus — DB constraint mirror', () => {
+    it('should return true for active status', () => {
+      const status: EmployeeStatus = 'active';
+      expect(isActiveForStatus(status)).toBe(true);
+    });
+
+    it('should return false for inactive status', () => {
+      const status: EmployeeStatus = 'inactive';
+      expect(isActiveForStatus(status)).toBe(false);
+    });
+
+    it('should return false for terminated status', () => {
+      const status: EmployeeStatus = 'terminated';
+      expect(isActiveForStatus(status)).toBe(false);
+    });
+
+    it('should be exhaustive: only active yields true', () => {
+      const allStatuses: EmployeeStatus[] = ['active', 'inactive', 'terminated'];
+      const active = allStatuses.filter((s) => isActiveForStatus(s));
+      expect(active).toEqual(['active']);
     });
   });
 });

--- a/tests/unit/employeeActivation.test.ts
+++ b/tests/unit/employeeActivation.test.ts
@@ -292,13 +292,13 @@ describe('Employee Activation Status', () => {
         termination_date: futureDate,
       };
 
-      const mockRpc = vi.fn().mockResolvedValue({ 
-        data: mockDeactivatedEmployee, 
-        error: null 
+      const mockRpc = vi.fn().mockResolvedValue({
+        data: mockDeactivatedEmployee,
+        error: null
       });
 
       mockSupabase.rpc = mockRpc;
-      
+
       mockSupabase.auth.getUser.mockResolvedValue({
         data: { user: { id: 'user-123' } },
         error: null,
@@ -333,6 +333,22 @@ describe('Employee Activation Status', () => {
           })
         );
       });
+    });
+
+    it('surfaces the RPC error and does NOT fall back to a direct update', async () => {
+      mockSupabase.rpc = vi.fn().mockResolvedValue({ data: null, error: { message: 'rpc unavailable' } });
+      mockSupabase.from = vi.fn(); // must never be called
+      mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'user-123' } }, error: null });
+
+      const { useDeactivateEmployee } = await import('@/hooks/useEmployees');
+      const { result } = renderHook(() => useDeactivateEmployee(), { wrapper: createWrapper() });
+      await waitFor(() => expect(result.current).toBeDefined());
+
+      await expect(
+        result.current.mutateAsync({ employeeId: 'emp-1', removeFromSchedules: true, terminationDate: '2026-06-19' }),
+      ).rejects.toBeTruthy();
+
+      expect(mockSupabase.from).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/employeeActivation.test.ts
+++ b/tests/unit/employeeActivation.test.ts
@@ -414,9 +414,9 @@ describe('Employee Activation Status', () => {
         hourly_rate: 1800, // Updated to $18.00
       };
 
-      const mockRpc = vi.fn().mockResolvedValue({ 
-        data: mockReactivatedEmployee, 
-        error: null 
+      const mockRpc = vi.fn().mockResolvedValue({
+        data: mockReactivatedEmployee,
+        error: null
       });
 
       mockSupabase.rpc = mockRpc;
@@ -450,6 +450,22 @@ describe('Employee Activation Status', () => {
           })
         );
       });
+    });
+
+    it('surfaces the RPC error and does NOT fall back to a direct update', async () => {
+      mockSupabase.rpc = vi.fn().mockResolvedValue({ data: null, error: { message: 'rpc unavailable' } });
+      mockSupabase.from = vi.fn(); // must never be called
+      mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'user-123' } }, error: null });
+
+      const { useReactivateEmployee } = await import('@/hooks/useEmployees');
+      const { result } = renderHook(() => useReactivateEmployee(), { wrapper: createWrapper() });
+      await waitFor(() => expect(result.current).toBeDefined());
+
+      await expect(
+        result.current.mutateAsync({ employeeId: 'emp-1' }),
+      ).rejects.toBeTruthy();
+
+      expect(mockSupabase.from).not.toHaveBeenCalled();
     });
 
   });


### PR DESCRIPTION
## Summary

- **Root cause:** `EmployeeDialog` echoed the row's `is_active` value on save instead of deriving it from the selected `status`, violating the DB check constraint `employees_status_active_sync` (Postgres 23514) and blocking managers from deactivating employees.
- **Fix:** Added a canonical `isActiveForStatus(status)` helper in `src/utils/employeeFilters.ts` as the single source of truth for the `status ↔ is_active` invariant, and wired it into `EmployeeDialog.tsx`.
- **Removed two silent RPC fallbacks** in `useDeactivateEmployee` and `useReactivateEmployee` that wrote `is_active` directly (bypassing the derivation logic), causing the same desync on RPC error paths.
- **Added canonical `EmployeeStatus` type** (`'active' | 'inactive' | 'terminated'`) to `src/types/scheduling.ts` for compile-time safety across all write sites.
- **Client-only change** — no DB migration, no production data changes, no UX changes.

Design doc: `docs/superpowers/specs/2026-06-19-employee-status-active-sync-design.md`

## Test plan

- [x] `npm run test` — 4511 passed, 2 skipped (vitest); includes new unit tests for `isActiveForStatus` and `EmployeeDialog` status-sync component tests
- [x] `npm run test:db` — 1373/1374 passed; 1 pre-existing failure (`enqueue_weekly_brief_jobs`) unrelated to this change
- [x] `npm run test:e2e` — 141/144 passed; 3 pre-existing failures on files unchanged by this branch; `employee-activation.spec.ts` 3/3 pass
- [x] `npm run typecheck` — no errors
- [x] `npm run build` — clean build in ~14s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed employee status desynchronization by deriving the active flag from the selected status (active/inactive/terminated).
  * Improved activation/deactivation behavior by removing silent fallback updates and surfacing RPC errors.
  * Adjusted Scheduling empty-state logic to show “No employees yet” vs “No scheduled shifts” more accurately.
* **Documentation**
  * Added a design spec and client-side plan to prevent database constraint violations for employee status synchronization.
* **Tests**
  * Added/updated unit tests to verify derived status behavior for both create and update flows, including deferred comp-change scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->