### PR TITLE
feat(scheduling): schedule overview panel — collapsed default + CalendarRange chip

### DIFF
--- a/docs/superpowers/plans/2026-06-20-schedule-overview-panel-plan.md
+++ b/docs/superpowers/plans/2026-06-20-schedule-overview-panel-plan.md
@@ -1,0 +1,94 @@
+# Plan: Schedule overview panel pairing
+
+Design: `docs/superpowers/specs/2026-06-20-schedule-overview-panel-design.md`
+Branch: `feature/schedule-overview-panel`
+
+Scope is one component + one test. TDD: write the failing test first, then the
+implementation, then verify.
+
+## Task 1 (RED) — Failing component test
+
+**File:** `tests/unit/ScheduleOverviewPanel.test.tsx` (new)
+
+Setup: vitest + `@testing-library/react` (jsdom). The component is pure-props
+(no hooks/context) so render it directly — no `QueryClientProvider` needed.
+
+Fixtures: build `OverviewDay[]` of 7 days, 5 staffed + 2 `unstaffed: true`.
+Minimal valid `OverviewDay`: `{ day, pills: [], collapsedCount: 0, hasGap:
+false, gapLabel: null, unstaffed }`. `coverageByDay` can be an empty `Map`.
+Props: `isMobile={false}`.
+
+Stable markers (no brittle text/SVG assertions, per the role-assertion lesson):
+- Trigger state → `screen.getByRole('button', { expanded })`.
+- Day-card presence → `container.querySelectorAll('[data-overview-day]')`
+  (`OverviewDayCard` sets `data-overview-day` on its root; `CollapsibleContent`
+  unmounts when closed, so count is 0 collapsed / 7 expanded).
+
+Assertions:
+1. **Collapsed by default:** `getByRole('button', { expanded: false })` exists;
+   `querySelectorAll('[data-overview-day]')` length is 0; teaser
+   `5/7 days staffed` is visible (`getByText(/5\/7 days staffed/)`).
+2. **Expand reveals cards:** `fireEvent.click(trigger)` →
+   `getByRole('button', { expanded: true })`; `[data-overview-day]` length is 7;
+   teaser text is no longer present (`queryByText(/days staffed/)` is null).
+3. **Collapse hides again:** click → expanded false → `[data-overview-day]`
+   length 0; teaser visible again.
+4. **Rollup math:** with 5 of 7 `unstaffed: false`, teaser reads
+   `5/7 days staffed`.
+
+These fail against the current file (expanded by default; teaser always shown;
+no `expanded:false` initial state).
+
+**Verify RED:** `npx vitest run tests/unit/ScheduleOverviewPanel.test.tsx`
+shows failures. Commit: `test(scheduling): schedule overview collapse + teaser (RED)`.
+
+## Task 2 (GREEN) — Implement panel
+
+**File:** `src/components/scheduling/ShiftPlanner/ScheduleOverviewPanel.tsx`
+
+Per the design doc. Key points:
+- `useState(false)` (collapsed by default); drop `useId`.
+- Imports: `CalendarRange, ChevronDown` from `lucide-react`;
+  `Collapsible, CollapsibleContent, CollapsibleTrigger` from
+  `@/components/ui/collapsible`.
+- Structure: `<Collapsible open onOpenChange>` → `<section
+  aria-label="Weekly schedule overview" className="rounded-xl border
+  border-border/40 bg-background overflow-hidden">` → `<CollapsibleTrigger
+  asChild><button …></CollapsibleTrigger>` + `<CollapsibleContent>`.
+- Trigger button: `w-full flex items-center justify-between px-4 py-2.5
+  hover:bg-muted/30 transition-colors`. **No `aria-label`** (visible text is
+  the accessible name; Radix adds `aria-expanded`/`aria-controls`).
+- Left cluster: chip `h-7 w-7 rounded-lg bg-muted flex items-center
+  justify-center` containing `<CalendarRange className="h-3.5 w-3.5
+  text-foreground" />`; title `<span className="text-[14px] font-medium
+  text-foreground">Schedule overview</span>`; teaser, only when collapsed:
+  `{!isExpanded && overviewDays.length > 0 && <span className="text-[12px]
+  text-muted-foreground ml-2">{staffedCount}/{overviewDays.length} days
+  staffed</span>}`.
+- Right: `<ChevronDown className="h-4 w-4 text-muted-foreground
+  transition-transform {isExpanded ? 'rotate-180' : ''}" />`.
+- `CollapsibleContent` wraps the day grid: `cn('p-3', isMobile ? 'flex
+  flex-col gap-2' : 'grid grid-cols-7 gap-2')` mapping `overviewDays` →
+  `OverviewDayCard` (unchanged props).
+- Keep `memo`, `staffedCount = overviewDays.filter(d => !d.unstaffed).length`,
+  and the `shortLabel` helper.
+
+**Verify GREEN:** the test file passes. Commit:
+`feat(scheduling): schedule overview panel — collapsed default + CalendarRange chip (GREEN)`.
+
+## Task 3 (VERIFY) — typecheck, lint, test
+
+- `npx tsc --noEmit` (no new errors in the two files).
+- `npx eslint <both files>` clean.
+- `npx vitest run tests/unit/ScheduleOverviewPanel.test.tsx` green.
+- No edits expected in `ShiftPlannerTab.tsx` (props unchanged) — confirm it
+  still typechecks.
+
+## Then: Phases 5–9 (autonomous via dev-build-and-ship)
+
+UI review → simplify → multi-model review (frontend/a11y dimensions matter
+most here) → CodeRabbit → full verify (`test`, `test:db`, `test:e2e`,
+`typecheck`, `lint`, `build`) → push → PR → CI loop → comment triage.
+
+## Dependencies
+Task 1 → Task 2 → Task 3 (strictly linear; single file + its test).

--- a/docs/superpowers/specs/2026-06-20-schedule-overview-panel-design.md
+++ b/docs/superpowers/specs/2026-06-20-schedule-overview-panel-design.md
@@ -1,0 +1,114 @@
+# Design: Schedule overview / Staffing Suggestions panel pairing
+
+- **Date:** 2026-06-20
+- **Branch:** `feature/schedule-overview-panel`
+- **Surface:** Shift Planner (`src/components/scheduling/ShiftPlanner/`)
+- **Status:** Approved (design explored and signed off interactively before `/dev`)
+
+## Problem
+
+The Shift Planner stacks two collapsible panels above the template grid:
+
+1. **Staffing Suggestions** (`StaffingOverlay.tsx`) — the primary, actionable
+   AI insight. Already has the canonical header treatment: a blue `Users`
+   icon chip, `text-[14px] font-medium` title, a collapsed-state teaser, a
+   right-aligned rotating `ChevronDown`, built on the shadcn `Collapsible`
+   primitives. Expanded by default.
+2. **Schedule overview** (`ScheduleOverviewPanel.tsx`) — a weekly mini-Gantt
+   of per-day coverage. Today it is visually inconsistent with its sibling:
+   no icon chip, a hand-rolled button/`hidden`-div collapse, a different
+   title size (`text-[13px] font-semibold`), a left-side chevron that swaps
+   `ChevronDown`/`ChevronRight`, and a different surface (`bg-muted/30`).
+   Expanded by default.
+
+The two read as different component types even though they are peers, and the
+overview — secondary reference data — competes for attention with the primary
+suggestions panel.
+
+## Goals
+
+1. Make **Schedule overview collapsed by default**.
+2. Give it an **icon chip** matching the sibling, and pick the right icon.
+3. Bring its header into a **matched pair** with Staffing Suggestions.
+
+Non-goal: changing `StaffingOverlay.tsx` (it is the canonical reference) or
+changing any data/props.
+
+## Approved decisions
+
+### Icon: `CalendarRange` (lucide)
+
+The panel is a weekly mini-Gantt of coverage spans across 7 days.
+`CalendarRange` — a calendar with a horizontal range bar — visually echoes
+those coverage bars and the week-as-a-span concept, and pairs conceptually
+with the sibling's `Users`: **who** (Users) + **when, across the week**
+(CalendarRange).
+
+Alternatives considered and rejected:
+- `CalendarDays` — generic "calendar," not tied to the panel's content.
+- `CalendarClock` — reads as time-of-day, not a week.
+- `LayoutGrid` — a grid, but says nothing about scheduling/time.
+
+### Treatment: neutral monochrome chip
+
+`bg-muted` box (`h-7 w-7 rounded-lg`) + `CalendarRange` at
+`h-3.5 w-3.5 text-foreground` — deliberately **not** the sibling's blue.
+
+This encodes hierarchy: Staffing Suggestions is the primary actionable insight
+(blue chip, expanded by default); Schedule overview is secondary reference
+data (neutral chip, collapsed by default). Full-contrast `text-foreground`
+(not `text-muted-foreground`) keeps the icon reading as intentional rather
+than disabled. Uses semantic tokens only (per CLAUDE.md and the
+`text-yellow-500` lesson) — no literal palette colors are introduced.
+
+### Header parity
+
+Mirror `StaffingOverlay`'s header exactly:
+- Migrate to the shared shadcn `Collapsible` / `CollapsibleTrigger` /
+  `CollapsibleContent` primitives (drops the hand-rolled `useId` +
+  `hidden`-class toggle, so the two panels share one collapse mechanism).
+- Title: `text-[14px] font-medium text-foreground`.
+- Surface: `bg-background` (was `bg-muted/30`).
+- Trigger row: `w-full flex items-center justify-between px-4 py-2.5
+  hover:bg-muted/30 transition-colors`.
+- Right-aligned single `ChevronDown` that rotates 180° when expanded.
+- Inline teaser `N/M days staffed` shown **only when collapsed** (matches the
+  sibling, where the teaser is redundant once expanded). Since the panel
+  defaults collapsed, the rollup is visible by default.
+
+## Accessibility
+
+- Keep the `<section aria-label="Weekly schedule overview">` landmark.
+- Radix `CollapsibleTrigger` wires `aria-expanded` + `aria-controls`
+  automatically; the trigger button keeps a dynamic `aria-label`
+  ("Collapse/Expand schedule overview").
+- Trigger is a real `<button>` → keyboard accessible.
+- Decorative icons (`CalendarRange`, `ChevronDown`) carry no standalone
+  meaning; the visible "Schedule overview" label is the accessible name.
+
+## Scope / blast radius
+
+- **One file:** `src/components/scheduling/ShiftPlanner/ScheduleOverviewPanel.tsx`.
+- Props (`overviewDays`, `coverageByDay`, `isMobile`) are unchanged; the only
+  consumer is `ShiftPlannerTab.tsx`, which needs no edits.
+- `OverviewDayCard` and `usePlannerShiftsIndex` are untouched.
+
+## Testing
+
+New component test `tests/unit/ScheduleOverviewPanel.test.tsx`:
+- Renders **collapsed by default**: day cards are not shown; the
+  `N/M days staffed` teaser is visible.
+- Expanding via the trigger reveals the day cards; collapsing hides them
+  and restores the teaser.
+- Assert on **accessibility role / `aria-expanded`**, not on raw text
+  (per the role-assertion lesson), plus the staffed-count rollup math.
+
+## Decided trade-offs
+
+- **Radix `CollapsibleContent` unmounts when closed.** Because the panel
+  defaults collapsed, the 7 `OverviewDayCard`s do not mount until first
+  expand. This is a minor perf win and matches the sibling's behavior; the
+  cards are pure presentational, so there is no effect/state to preserve.
+- **Teaser hidden when expanded.** The `N/M days staffed` rollup disappears
+  on expand (the day cards convey per-day status). Chosen for strict parity
+  with the sibling rather than keeping a persistent right-side stat.

--- a/docs/superpowers/specs/2026-06-20-schedule-overview-panel-design.md
+++ b/docs/superpowers/specs/2026-06-20-schedule-overview-panel-design.md
@@ -78,13 +78,28 @@ Mirror `StaffingOverlay`'s header exactly:
 
 ## Accessibility
 
-- Keep the `<section aria-label="Weekly schedule overview">` landmark.
-- Radix `CollapsibleTrigger` wires `aria-expanded` + `aria-controls`
-  automatically; the trigger button keeps a dynamic `aria-label`
-  ("Collapse/Expand schedule overview").
+- Keep the `<section aria-label="Weekly schedule overview">` landmark. The
+  `rounded-xl border bg-background` classes live on this `<section>` (which
+  sits inside the Radix `Collapsible` root `<div>`); the Radix wrapper is
+  unstyled, so there is no duplicated border/box.
+- **`CollapsibleTrigger` MUST use `asChild`** with a single `<button>` child
+  (exactly as `StaffingOverlay` does at lines 278–279). This makes Radix
+  inject `aria-expanded` + `aria-controls` onto the `<button>` directly and
+  avoids a nested-`<button>` violation that would silently drop the ARIA
+  wiring. (Phase 2.5 major finding.)
+- **No `aria-label` on the trigger.** The visible "Schedule overview" text is
+  the accessible name, and Radix supplies `aria-expanded` for state. This is
+  the WAI-ARIA disclosure pattern and matches the *current* file's approach
+  (visible-text-as-name + `aria-expanded`, no `aria-label`). It is a
+  deliberate, small improvement over the sibling, whose
+  `aria-label={isExpanded ? 'Collapse…' : 'Expand…'}` overrides its visible
+  title+teaser — so screen-reader users there never hear the teaser. By
+  dropping the `aria-label`, the collapsed "N/M days staffed" teaser becomes
+  part of the button's accessible name and IS announced. (Phase 2.5 major
+  finding.)
 - Trigger is a real `<button>` → keyboard accessible.
-- Decorative icons (`CalendarRange`, `ChevronDown`) carry no standalone
-  meaning; the visible "Schedule overview" label is the accessible name.
+- Decorative icons (`CalendarRange`, `ChevronDown`) are bare lucide `<svg>`
+  with no role/text, so they do not pollute the accessible name.
 
 ## Scope / blast radius
 
@@ -112,3 +127,15 @@ New component test `tests/unit/ScheduleOverviewPanel.test.tsx`:
 - **Teaser hidden when expanded.** The `N/M days staffed` rollup disappears
   on expand (the day cards convey per-day status). Chosen for strict parity
   with the sibling rather than keeping a persistent right-side stat.
+- **Hover at `hover:bg-muted/30`,** matching the sibling — do NOT carry over
+  the current file's heavier `hover:bg-muted/50`.
+
+## Retrospective notes (carry to Phase 10)
+
+- `StaffingOverlay` uses literal palette colors on its icon
+  (`text-blue-600 dark:text-blue-400`), a minor CLAUDE.md "no direct colors"
+  deviation. The new panel deliberately does NOT replicate it (uses
+  `text-foreground`). Aligning the sibling is out of scope here.
+- `StaffingOverlay`'s trigger `aria-label` overrides its visible
+  title+teaser; the new panel's no-`aria-label` approach is more correct.
+  Candidate for a future sibling cleanup.

--- a/src/components/scheduling/ShiftPlanner/ScheduleOverviewPanel.tsx
+++ b/src/components/scheduling/ShiftPlanner/ScheduleOverviewPanel.tsx
@@ -67,22 +67,28 @@ export const ScheduleOverviewPanel = memo(function ScheduleOverviewPanel({
         </CollapsibleTrigger>
 
         <CollapsibleContent>
-          <div
-            className={cn(
-              'p-3',
-              isMobile ? 'flex flex-col gap-2' : 'grid grid-cols-7 gap-2',
-            )}
-          >
-            {overviewDays.map((d) => (
-              <OverviewDayCard
-                key={d.day}
-                data={d}
-                dayLabel={shortLabel(d.day)}
-                variant={isMobile ? 'mobile' : 'desktop'}
-                coverage={isMobile ? coverageByDay.get(d.day) : undefined}
-              />
-            ))}
-          </div>
+          {overviewDays.length === 0 ? (
+            <div className="px-4 py-6 text-center">
+              <p className="text-[13px] text-muted-foreground">No schedule data for this week.</p>
+            </div>
+          ) : (
+            <div
+              className={cn(
+                'p-3',
+                isMobile ? 'flex flex-col gap-2' : 'grid grid-cols-7 gap-2',
+              )}
+            >
+              {overviewDays.map((d) => (
+                <OverviewDayCard
+                  key={d.day}
+                  data={d}
+                  dayLabel={shortLabel(d.day)}
+                  variant={isMobile ? 'mobile' : 'desktop'}
+                  coverage={isMobile ? coverageByDay.get(d.day) : undefined}
+                />
+              ))}
+            </div>
+          )}
         </CollapsibleContent>
       </section>
     </Collapsible>

--- a/src/components/scheduling/ShiftPlanner/ScheduleOverviewPanel.tsx
+++ b/src/components/scheduling/ShiftPlanner/ScheduleOverviewPanel.tsx
@@ -25,6 +25,11 @@ function shortLabel(day: string): string {
   return `${weekday} ${date.getDate()}`;
 }
 
+/**
+ * Collapsible weekly schedule overview panel.
+ * Collapsed by default; shows a staffed-day rollup teaser.
+ * Expanding reveals one OverviewDayCard per day in the week.
+ */
 export const ScheduleOverviewPanel = memo(function ScheduleOverviewPanel({
   overviewDays,
   coverageByDay,

--- a/src/components/scheduling/ShiftPlanner/ScheduleOverviewPanel.tsx
+++ b/src/components/scheduling/ShiftPlanner/ScheduleOverviewPanel.tsx
@@ -18,12 +18,11 @@ interface ScheduleOverviewPanelProps {
   isMobile: boolean;
 }
 
-const DAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-
+/** Returns e.g. "Mon 16" from an ISO date string "2026-06-16". */
 function shortLabel(day: string): string {
-  const [y, m, d] = day.split('-').map(Number);
-  const date = new Date(y, m - 1, d);
-  return `${DAY_LABELS[date.getDay()]} ${d}`;
+  const date = new Date(day + 'T00:00:00');
+  const weekday = date.toLocaleDateString('en-US', { weekday: 'short' });
+  return `${weekday} ${date.getDate()}`;
 }
 
 export const ScheduleOverviewPanel = memo(function ScheduleOverviewPanel({

--- a/src/components/scheduling/ShiftPlanner/ScheduleOverviewPanel.tsx
+++ b/src/components/scheduling/ShiftPlanner/ScheduleOverviewPanel.tsx
@@ -1,7 +1,12 @@
-import { memo, useId, useState } from 'react';
+import { memo, useState } from 'react';
 
-import { ChevronDown, ChevronRight } from 'lucide-react';
+import { CalendarRange, ChevronDown } from 'lucide-react';
 
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
 import { cn } from '@/lib/utils';
 
 import { OverviewDayCard } from './OverviewDayCard';
@@ -26,56 +31,60 @@ export const ScheduleOverviewPanel = memo(function ScheduleOverviewPanel({
   coverageByDay,
   isMobile,
 }: Readonly<ScheduleOverviewPanelProps>) {
-  const [expanded, setExpanded] = useState(true);
-  const bodyId = useId();
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const staffedCount = overviewDays.filter((d) => !d.unstaffed).length;
 
   return (
-    <section
-      aria-label="Weekly schedule overview"
-      className="rounded-xl border border-border/40 bg-muted/30 overflow-hidden"
-    >
-      <button
-        type="button"
-        onClick={() => setExpanded((v) => !v)}
-        aria-expanded={expanded}
-        aria-controls={bodyId}
-        className="w-full flex items-center justify-between gap-2 px-4 py-2.5 hover:bg-muted/50 transition-colors"
+    <Collapsible open={isExpanded} onOpenChange={setIsExpanded}>
+      <section
+        aria-label="Weekly schedule overview"
+        className="rounded-xl border border-border/40 bg-background overflow-hidden"
       >
-        <span className="flex items-center gap-2">
-          {expanded ? (
-            <ChevronDown className="h-4 w-4 text-muted-foreground" />
-          ) : (
-            <ChevronRight className="h-4 w-4 text-muted-foreground" />
-          )}
-          <span className="text-[13px] font-semibold text-foreground">Schedule overview</span>
-        </span>
-        <span className="text-[12px] text-muted-foreground">
-          {overviewDays.filter((d) => !d.unstaffed).length}/{overviewDays.length} days staffed
-        </span>
-      </button>
+        <CollapsibleTrigger asChild>
+          <button
+            type="button"
+            className="w-full flex items-center justify-between px-4 py-2.5 hover:bg-muted/30 transition-colors"
+          >
+            <span className="flex items-center gap-2">
+              <span className="h-7 w-7 rounded-lg bg-muted flex items-center justify-center">
+                <CalendarRange className="h-3.5 w-3.5 text-foreground" />
+              </span>
+              <span className="text-[14px] font-medium text-foreground">Schedule overview</span>
+              {!isExpanded && overviewDays.length > 0 && (
+                <span className="text-[12px] text-muted-foreground ml-2">
+                  {staffedCount}/{overviewDays.length} days staffed
+                </span>
+              )}
+            </span>
+            <ChevronDown
+              className={cn(
+                'h-4 w-4 text-muted-foreground transition-transform',
+                isExpanded && 'rotate-180',
+              )}
+            />
+          </button>
+        </CollapsibleTrigger>
 
-      <div
-        id={bodyId}
-        aria-hidden={!expanded}
-        className={cn(
-          'p-3',
-          expanded
-            ? isMobile
-              ? 'flex flex-col gap-2'
-              : 'grid grid-cols-7 gap-2'
-            : 'hidden',
-        )}
-      >
-        {overviewDays.map((d) => (
-          <OverviewDayCard
-            key={d.day}
-            data={d}
-            dayLabel={shortLabel(d.day)}
-            variant={isMobile ? 'mobile' : 'desktop'}
-            coverage={isMobile ? coverageByDay.get(d.day) : undefined}
-          />
-        ))}
-      </div>
-    </section>
+        <CollapsibleContent>
+          <div
+            className={cn(
+              'p-3',
+              isMobile ? 'flex flex-col gap-2' : 'grid grid-cols-7 gap-2',
+            )}
+          >
+            {overviewDays.map((d) => (
+              <OverviewDayCard
+                key={d.day}
+                data={d}
+                dayLabel={shortLabel(d.day)}
+                variant={isMobile ? 'mobile' : 'desktop'}
+                coverage={isMobile ? coverageByDay.get(d.day) : undefined}
+              />
+            ))}
+          </div>
+        </CollapsibleContent>
+      </section>
+    </Collapsible>
   );
 });

--- a/tests/e2e/planner-mobile-overview.spec.ts
+++ b/tests/e2e/planner-mobile-overview.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 import { signUpAndCreateRestaurant, exposeSupabaseHelpers, generateTestUser } from '../helpers/e2e-supabase';
 
 test.describe('Planner mobile layout', () => {
-  test('overview panel renders stacked with visible day cards', async ({ page }) => {
+  test('overview panel is collapsed by default; expanding shows day cards', async ({ page }) => {
     // Do signup at desktop viewport — OnboardingDrawer's SheetContent is
     // wider than a 390px mobile viewport and would intercept the "Add
     // Restaurant" click. Switch to mobile once we're ready to exercise the
@@ -25,17 +25,17 @@ test.describe('Planner mobile layout', () => {
     await page.goto('/scheduling');
     await page.getByRole('tab', { name: /planner/i }).click();
 
-    // Overview panel expanded by default
+    // Panel must be present but collapsed by default — no day cards yet.
     await expect(page.getByRole('region', { name: /weekly schedule overview/i })).toBeVisible();
-
-    // 7 day cards are rendered
     const dayCards = page.locator('[data-overview-day]');
+    await expect(dayCards).toHaveCount(0);
+
+    // Expanding the panel reveals 7 stacked day cards (mobile layout).
+    await page.getByRole('button', { expanded: false, name: /schedule overview/i }).click();
     await expect(dayCards).toHaveCount(7);
 
-    // Collapsing hides the cards. The panel body stays mounted (with the
-    // `hidden` HTML attribute) so `aria-controls` always resolves to an
-    // element, but the cards become non-visible.
+    // Collapsing hides the cards again.
     await page.getByRole('button', { expanded: true, name: /schedule overview/i }).click();
-    await expect(dayCards.first()).not.toBeVisible();
+    await expect(dayCards).toHaveCount(0);
   });
 });

--- a/tests/unit/ScheduleOverviewPanel.test.tsx
+++ b/tests/unit/ScheduleOverviewPanel.test.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { ScheduleOverviewPanel } from '@/components/scheduling/ShiftPlanner/ScheduleOverviewPanel';
+import type { OverviewDay } from '@/hooks/usePlannerShiftsIndex';
+
+// 7-day fixture: 5 staffed, 2 unstaffed
+const WEEK_DAYS = [
+  '2026-06-16',
+  '2026-06-17',
+  '2026-06-18',
+  '2026-06-19',
+  '2026-06-20',
+  '2026-06-21',
+  '2026-06-22',
+];
+
+function makeDay(day: string, unstaffed: boolean): OverviewDay {
+  return { day, pills: [], collapsedCount: 0, hasGap: false, gapLabel: null, unstaffed };
+}
+
+const overviewDays: OverviewDay[] = [
+  makeDay(WEEK_DAYS[0], false), // staffed
+  makeDay(WEEK_DAYS[1], false), // staffed
+  makeDay(WEEK_DAYS[2], false), // staffed
+  makeDay(WEEK_DAYS[3], true),  // unstaffed
+  makeDay(WEEK_DAYS[4], false), // staffed
+  makeDay(WEEK_DAYS[5], false), // staffed
+  makeDay(WEEK_DAYS[6], true),  // unstaffed
+];
+
+const coverageByDay = new Map<string, number[]>();
+
+describe('<ScheduleOverviewPanel>', () => {
+  it('is collapsed by default: no day cards visible, teaser shows 5/7 days staffed', () => {
+    const { container } = render(
+      <ScheduleOverviewPanel
+        overviewDays={overviewDays}
+        coverageByDay={coverageByDay}
+        isMobile={false}
+      />,
+    );
+
+    // Trigger button must report aria-expanded=false
+    const trigger = screen.getByRole('button', { expanded: false });
+    expect(trigger).toBeTruthy();
+
+    // CollapsibleContent is unmounted when closed → zero day cards
+    const dayCards = container.querySelectorAll('[data-overview-day]');
+    expect(dayCards).toHaveLength(0);
+
+    // Rollup teaser is visible when collapsed
+    expect(screen.getByText(/5\/7 days staffed/)).toBeTruthy();
+  });
+
+  it('expanding reveals 7 day cards and hides the teaser', () => {
+    const { container } = render(
+      <ScheduleOverviewPanel
+        overviewDays={overviewDays}
+        coverageByDay={coverageByDay}
+        isMobile={false}
+      />,
+    );
+
+    const trigger = screen.getByRole('button', { expanded: false });
+    fireEvent.click(trigger);
+
+    // After expand: aria-expanded=true
+    expect(screen.getByRole('button', { expanded: true })).toBeTruthy();
+
+    // 7 day cards mount
+    const dayCards = container.querySelectorAll('[data-overview-day]');
+    expect(dayCards).toHaveLength(7);
+
+    // Teaser disappears when expanded
+    expect(screen.queryByText(/days staffed/)).toBeNull();
+  });
+
+  it('collapsing again hides day cards and restores the teaser', () => {
+    const { container } = render(
+      <ScheduleOverviewPanel
+        overviewDays={overviewDays}
+        coverageByDay={coverageByDay}
+        isMobile={false}
+      />,
+    );
+
+    const trigger = screen.getByRole('button', { expanded: false });
+    fireEvent.click(trigger); // expand
+    fireEvent.click(screen.getByRole('button', { expanded: true })); // collapse
+
+    // Back to collapsed state
+    expect(screen.getByRole('button', { expanded: false })).toBeTruthy();
+    expect(container.querySelectorAll('[data-overview-day]')).toHaveLength(0);
+    expect(screen.getByText(/5\/7 days staffed/)).toBeTruthy();
+  });
+
+  it('rollup math: counts unstaffed:false days out of total', () => {
+    // 5 staffed of 7 total → "5/7 days staffed"
+    render(
+      <ScheduleOverviewPanel
+        overviewDays={overviewDays}
+        coverageByDay={coverageByDay}
+        isMobile={false}
+      />,
+    );
+
+    expect(screen.getByText(/5\/7 days staffed/)).toBeTruthy();
+  });
+});

--- a/tests/unit/ScheduleOverviewPanel.test.tsx
+++ b/tests/unit/ScheduleOverviewPanel.test.tsx
@@ -33,6 +33,26 @@ const overviewDays: OverviewDay[] = [
 const coverageByDay = new Map<string, number[]>();
 
 describe('<ScheduleOverviewPanel>', () => {
+  it('shows empty state when overviewDays is empty', () => {
+    const { container } = render(
+      <ScheduleOverviewPanel
+        overviewDays={[]}
+        coverageByDay={new Map<string, number[]>()}
+        isMobile={false}
+      />,
+    );
+
+    // Expand the panel first (empty state lives inside CollapsibleContent)
+    const trigger = screen.getByRole('button', { expanded: false });
+    fireEvent.click(trigger);
+
+    // Empty-state message is shown
+    expect(screen.getByText(/No schedule data for this week\./i)).toBeTruthy();
+
+    // No day cards
+    expect(container.querySelectorAll('[data-overview-day]')).toHaveLength(0);
+  });
+
   it('is collapsed by default: no day cards visible, teaser shows 5/7 days staffed', () => {
     const { container } = render(
       <ScheduleOverviewPanel


### PR DESCRIPTION
## Summary

- Restyle `ScheduleOverviewPanel.tsx` to be **collapsed by default**, pairing it visually with the `StaffingOverlay` sibling that sits above it in the Shift Planner.
- Replace the hand-rolled button/`hidden`-div collapse with shadcn `Collapsible` / `CollapsibleTrigger asChild` / `CollapsibleContent` — the same primitives `StaffingOverlay` uses — so both panels share one collapse mechanism and Radix wires `aria-expanded` / `aria-controls` automatically.
- Add a **CalendarRange icon chip** (neutral monochrome, `bg-muted h-7 w-7 rounded-lg`) encoding visual hierarchy: blue chip (Staffing Suggestions, primary, expanded) vs. neutral chip (Schedule overview, secondary, collapsed).
- Bring the header into full parity with `StaffingOverlay`: `text-[14px] font-medium text-foreground` title, `bg-background` surface, `hover:bg-muted/30` trigger row, right-aligned rotating `ChevronDown`.
- Show a collapsed-state teaser (`N/M days staffed`) that doubles as the screen-reader accessible name (no `aria-label` override — the visible text IS announced, including the rollup stat).
- Replace `DAY_LABELS` duplication with `toLocaleDateString` in `shortLabel` (simplify phase).
- Add `tests/unit/ScheduleOverviewPanel.test.tsx` with four assertions: collapsed-by-default, expand reveals 7 day cards, collapse hides them, rollup math (5/7 days staffed).
- Fix an E2E spec (`tests/e2e/planner-mobile-overview.spec.ts`) whose assertions assumed expanded-by-default; updated to expand the panel first.

No props or consumers changed; `StaffingOverlay.tsx`, `ShiftPlannerTab.tsx`, `OverviewDayCard`, and all database/edge-function code are untouched.

Design doc: `docs/superpowers/specs/2026-06-20-schedule-overview-panel-design.md`

## Test plan

- [ ] `npm run test` — 352 passed, 1 skipped (includes 4 new unit assertions in `ScheduleOverviewPanel.test.tsx`)
- [ ] `npm run typecheck` — clean (exit 0)
- [ ] `npm run lint` — zero errors in changed files (pre-existing codebase errors unchanged)
- [ ] `npm run test:e2e` — 146 passed, 12 skipped (includes updated `planner-mobile-overview.spec.ts`)
- [ ] `npm run build` — built successfully (~16 s)
- [ ] Manual: open Shift Planner → Schedule overview panel is collapsed on load; teaser `N/M days staffed` is visible; clicking the header expands the 7 day cards; chevron rotates 180°; collapsing restores the teaser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Schedule overview panel now collapses by default with an expandable header.
  * Added visual indicator (ChevronDown icon) for collapse/expand state.
  * Displays "X/Y days staffed" count when collapsed.

* **Documentation**
  * Added design specification for Schedule overview panel UI/UX.
  * Added implementation plan document.

* **Tests**
  * Added unit tests for Schedule overview panel behavior.
  * Updated end-to-end tests for collapse-by-default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->