### PR TITLE
fix(time-clock): stop false open sessions from cross-employee punch collapse

### DIFF
--- a/docs/superpowers/plans/2026-06-22-time-punch-session-pairing.md
+++ b/docs/superpowers/plans/2026-06-22-time-punch-session-pairing.md
@@ -56,7 +56,7 @@ const open = (s: { is_complete: boolean }) => !s.is_complete;
 
 describe('normalizePunches — noise detection is per employee', () => {
   it('keeps both employees complete when they share identical in/out timestamps', () => {
-    // Mirrors the production "Alexia vs Colin" case: imported punches with
+    // Mirrors the production "Employee A vs Employee B" case: imported punches with
     // identical round timestamps must not collapse across employees.
     const punches = [
       mk('a-in', 'empA', 'clock_in', '2026-06-22T15:00:00Z'),
@@ -200,7 +200,7 @@ Append to `tests/unit/timePunchProcessing.test.ts`:
 ```ts
 describe('identifyWorkSessions — does not skip the next clock-in', () => {
   it('keeps the real session after an orphan leading clock-in', () => {
-    // zachary case: a stray midnight clock-in must not swallow the real
+    // Employee G case: a stray midnight clock-in must not swallow the real
     // 10:02–14:03 session that follows it.
     const punches = [
       mk('orphan', 'empZ', 'clock_in', '2026-06-22T00:00:00Z'),

--- a/docs/superpowers/plans/2026-06-22-time-punch-session-pairing.md
+++ b/docs/superpowers/plans/2026-06-22-time-punch-session-pairing.md
@@ -1,0 +1,309 @@
+# Time Punch Session Pairing Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop false "open session" warnings (and under-counted hours) caused by the time-punch processor collapsing different employees' punches and skipping sessions.
+
+**Architecture:** Two surgical changes to the pure module `src/utils/timePunchProcessing.ts`: (1) scope noise/duplicate detection per `employee_id`; (2) stop the session loop from skipping the clock-in it stopped on. New vitest suite with multi-employee fixtures (the test class the original investigation lacked).
+
+**Tech Stack:** TypeScript, Vitest, date-fns.
+
+---
+
+## File Structure
+
+- Modify: `src/utils/timePunchProcessing.ts`
+  - Extract current `normalizePunches` body into a private `normalizeEmployeePunches` (logic unchanged).
+  - New `normalizePunches` buckets by `employee_id` and concatenates per-employee results.
+  - `identifyWorkSessions`: change `i = j + 1` to `i = j`.
+- Create: `tests/unit/timePunchProcessing.test.ts` — multi-employee regression coverage.
+
+No other files change. `normalizePunches` keeps its exported signature, so existing callers (`processPunchesForPeriod`) are untouched.
+
+---
+
+### Task 1: Fix cross-employee noise collapse (Bug 1)
+
+**Files:**
+- Create: `tests/unit/timePunchProcessing.test.ts`
+- Modify: `src/utils/timePunchProcessing.ts` (`normalizePunches`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/unit/timePunchProcessing.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { processPunchesForPeriod } from '@/utils/timePunchProcessing';
+import type { TimePunch } from '@/types/timeTracking';
+
+const mk = (
+  id: string,
+  employee_id: string,
+  punch_type: 'clock_in' | 'clock_out' | 'break_start' | 'break_end',
+  punch_time: string,
+): TimePunch =>
+  ({
+    id,
+    restaurant_id: 'rest-1',
+    employee_id,
+    punch_type,
+    punch_time,
+    employee: { id: employee_id, name: employee_id, position: '' },
+  }) as unknown as TimePunch;
+
+const open = (s: { is_complete: boolean }) => !s.is_complete;
+
+describe('normalizePunches — noise detection is per employee', () => {
+  it('keeps both employees complete when they share identical in/out timestamps', () => {
+    // Mirrors the production "Alexia vs Colin" case: imported punches with
+    // identical round timestamps must not collapse across employees.
+    const punches = [
+      mk('a-in', 'empA', 'clock_in', '2026-06-22T15:00:00Z'),
+      mk('b-in', 'empB', 'clock_in', '2026-06-22T15:00:00Z'),
+      mk('a-out', 'empA', 'clock_out', '2026-06-22T19:00:00Z'),
+      mk('b-out', 'empB', 'clock_out', '2026-06-22T19:00:00Z'),
+    ];
+    const { sessions } = processPunchesForPeriod(punches);
+    expect(sessions).toHaveLength(2);
+    expect(sessions.filter(open)).toHaveLength(0);
+  });
+
+  it('does not orphan a clock-in into a false open session when another employee punches within 60s', () => {
+    // empB clock_in is first in the 15:00 cluster (survives) and empB clock_out
+    // is second in the 19:00 cluster — under the old global logic empB's
+    // clock_out was dropped, orphaning empB into a false "open session".
+    const punches = [
+      mk('b-in', 'empB', 'clock_in', '2026-06-22T15:00:00Z'),
+      mk('a-in', 'empA', 'clock_in', '2026-06-22T15:00:30Z'),
+      mk('a-out', 'empA', 'clock_out', '2026-06-22T19:00:00Z'),
+      mk('b-out', 'empB', 'clock_out', '2026-06-22T19:00:30Z'),
+    ];
+    const { sessions } = processPunchesForPeriod(punches);
+    expect(sessions.filter(open)).toHaveLength(0);
+    expect(sessions.filter((s) => s.is_complete)).toHaveLength(2);
+  });
+
+  it('three employees clocking in the same second keep all three sessions', () => {
+    const punches = [
+      mk('a-in', 'empA', 'clock_in', '2026-06-22T15:00:00Z'),
+      mk('b-in', 'empB', 'clock_in', '2026-06-22T15:00:00Z'),
+      mk('c-in', 'empC', 'clock_in', '2026-06-22T15:00:00Z'),
+      mk('a-out', 'empA', 'clock_out', '2026-06-22T19:00:00Z'),
+      mk('b-out', 'empB', 'clock_out', '2026-06-22T19:00:00Z'),
+      mk('c-out', 'empC', 'clock_out', '2026-06-22T19:00:00Z'),
+    ];
+    const { sessions, totalNoisePunches } = processPunchesForPeriod(punches);
+    expect(sessions).toHaveLength(3);
+    expect(sessions.filter((s) => s.is_complete)).toHaveLength(3);
+    expect(totalNoisePunches).toBe(0);
+  });
+
+  it('still de-duplicates the SAME employee double-tapping within 60s', () => {
+    const punches = [
+      mk('in1', 'empA', 'clock_in', '2026-06-22T15:00:00Z'),
+      mk('in2', 'empA', 'clock_in', '2026-06-22T15:00:10Z'), // duplicate
+      mk('out', 'empA', 'clock_out', '2026-06-22T19:00:00Z'),
+    ];
+    const { sessions, totalNoisePunches } = processPunchesForPeriod(punches);
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].is_complete).toBe(true);
+    expect(totalNoisePunches).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests, verify the cross-employee ones FAIL**
+
+Run: `npx vitest run tests/unit/timePunchProcessing.test.ts`
+Expected: the first two tests FAIL (e.g. `expected length 2 to be ... 1`, false open session present); the dedup test passes.
+
+- [ ] **Step 3: Scope noise detection per employee**
+
+In `src/utils/timePunchProcessing.ts`, rename the existing exported `normalizePunches` function to a private `normalizeEmployeePunches` (keep the entire body identical — only change the name and drop `export`):
+
+```ts
+/**
+ * Normalize a SINGLE employee's punch stream.
+ * Removes noise (rapid duplicate punches) and prepares punches for session
+ * identification. Must only ever receive one employee's punches — proximity
+ * (the 60s window) is only meaningful within a single person's stream.
+ */
+function normalizeEmployeePunches(punches: TimePunch[]): ProcessedPunch[] {
+  // ...existing body unchanged...
+}
+```
+
+Then add the new exported `normalizePunches` immediately above it:
+
+```ts
+/**
+ * Normalize a restaurant's punch stream.
+ *
+ * Noise/duplicate detection is scoped PER EMPLOYEE. Punches from different
+ * employees that merely land within 60s of each other (common with
+ * imported/backdated round timestamps, or any clock-in/out rush) must never be
+ * collapsed into one another — doing so drops real punches and orphans
+ * clock-ins into false "open sessions". Each employee's stream is normalized
+ * independently, then concatenated.
+ */
+export function normalizePunches(punches: TimePunch[]): ProcessedPunch[] {
+  const byEmployee = new Map<string, TimePunch[]>();
+  for (const punch of punches) {
+    const group = byEmployee.get(punch.employee_id);
+    if (group) {
+      group.push(punch);
+    } else {
+      byEmployee.set(punch.employee_id, [punch]);
+    }
+  }
+
+  const normalized: ProcessedPunch[] = [];
+  for (const group of byEmployee.values()) {
+    normalized.push(...normalizeEmployeePunches(group));
+  }
+  return normalized;
+}
+```
+
+- [ ] **Step 4: Run the tests, verify they PASS**
+
+Run: `npx vitest run tests/unit/timePunchProcessing.test.ts`
+Expected: all four tests in this suite PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/timePunchProcessing.ts tests/unit/timePunchProcessing.test.ts
+git commit -m "fix(time-punch): scope noise detection per employee
+
+normalizePunches collapsed any punches within 60s across ALL employees,
+dropping ~46% of punches on real data and orphaning clock-ins into false
+'open session' warnings (and under-counting hours). Bucket by employee_id
+before de-duplicating.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Stop skipping the clock-in after a closed session (Bug 2)
+
+**Files:**
+- Modify: `tests/unit/timePunchProcessing.test.ts` (add a describe block)
+- Modify: `src/utils/timePunchProcessing.ts` (`identifyWorkSessions`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/unit/timePunchProcessing.test.ts`:
+
+```ts
+describe('identifyWorkSessions — does not skip the next clock-in', () => {
+  it('keeps the real session after an orphan leading clock-in', () => {
+    // zachary case: a stray midnight clock-in must not swallow the real
+    // 10:02–14:03 session that follows it.
+    const punches = [
+      mk('orphan', 'empZ', 'clock_in', '2026-06-22T00:00:00Z'),
+      mk('in', 'empZ', 'clock_in', '2026-06-22T10:02:00Z'),
+      mk('out', 'empZ', 'clock_out', '2026-06-22T14:03:00Z'),
+    ];
+    const { sessions } = processPunchesForPeriod(punches);
+    expect(sessions).toHaveLength(2);
+    const complete = sessions.filter((s) => s.is_complete);
+    expect(complete).toHaveLength(1);
+    expect(complete[0].clock_in.toISOString()).toBe('2026-06-22T10:02:00.000Z');
+    expect(complete[0].clock_out?.toISOString()).toBe('2026-06-22T14:03:00.000Z');
+    // the orphan correctly remains a single open session
+    expect(sessions.filter((s) => !s.is_complete)).toHaveLength(1);
+  });
+
+  it('keeps both back-to-back complete sessions for one employee', () => {
+    const punches = [
+      mk('in1', 'empA', 'clock_in', '2026-06-22T09:00:00Z'),
+      mk('out1', 'empA', 'clock_out', '2026-06-22T12:00:00Z'),
+      mk('in2', 'empA', 'clock_in', '2026-06-22T13:00:00Z'),
+      mk('out2', 'empA', 'clock_out', '2026-06-22T17:00:00Z'),
+    ];
+    const { sessions } = processPunchesForPeriod(punches);
+    expect(sessions).toHaveLength(2);
+    expect(sessions.filter((s) => s.is_complete)).toHaveLength(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests, verify they FAIL**
+
+Run: `npx vitest run tests/unit/timePunchProcessing.test.ts`
+Expected: both new tests FAIL — old code returns only 1 session for each (the following session is skipped).
+
+- [ ] **Step 3: Fix the index advance**
+
+In `src/utils/timePunchProcessing.ts`, inside `identifyWorkSessions`, change the post-session advance from `i = j + 1;` to `i = j;`:
+
+```ts
+        sessions.push(session);
+        // Resume from j, NOT j + 1. When the inner scan stopped because it hit
+        // the next clock_in, j points AT that clock_in; advancing past it would
+        // drop the following session entirely. The inner loop always advances j
+        // to at least i + 1 before breaking, so i = j still makes progress.
+        i = j;
+      } else {
+        // Skip punches that don't start a session
+        i++;
+      }
+```
+
+- [ ] **Step 4: Run the tests, verify they PASS**
+
+Run: `npx vitest run tests/unit/timePunchProcessing.test.ts`
+Expected: all tests in the file PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/timePunchProcessing.ts tests/unit/timePunchProcessing.test.ts
+git commit -m "fix(time-punch): stop skipping the clock-in after a closed session
+
+identifyWorkSessions advanced with i = j + 1 after pushing a session, but j
+already pointed at the next clock_in when the scan stopped on it — so that
+session was dropped. Resume from j instead. Recovers back-to-back sessions and
+the real session after an orphan leading clock-in.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Full local verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Typecheck**
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 2: Lint the changed files**
+
+Run: `npx eslint src/utils/timePunchProcessing.ts tests/unit/timePunchProcessing.test.ts`
+Expected: no errors.
+
+- [ ] **Step 3: Run the full unit suite**
+
+Run: `npm run test`
+Expected: all suites pass (new file green; existing `punchFunctionality`, `useTimePunches`, etc. unaffected).
+
+- [ ] **Step 4: Production build**
+
+Run: `npm run build`
+Expected: build succeeds.
+
+- [ ] **Step 5: No commit needed** (verification only). If any check fails, fix in `src/utils/timePunchProcessing.ts`, re-run, and amend the relevant task's commit.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Bug 1 (per-employee noise) → Task 1. Bug 2 (`i = j`) → Task 2. Multi-employee regression fixtures → Tasks 1 & 2. Hours-undercount is fixed transitively (sessions feed `calculateDailyHours`); the recovered-session assertions cover it. Verification → Task 3.
+- **Placeholder scan:** none — all code blocks are complete.
+- **Type consistency:** `normalizePunches`/`normalizeEmployeePunches`/`identifyWorkSessions`/`processPunchesForPeriod` names and the `TimePunch`/`ProcessedPunch`/`WorkSession` types match `src/utils/timePunchProcessing.ts` and `src/types/timeTracking.ts`.

--- a/docs/superpowers/specs/2026-06-22-time-punch-session-pairing-design.md
+++ b/docs/superpowers/specs/2026-06-22-time-punch-session-pairing-design.md
@@ -8,9 +8,8 @@
 
 Managers see employees flagged as having an **open session** (never clocked
 out) on the Time Clock page even though the employee has a clock-in *and* a
-clock-out for the day. Reported for Carolina Sanchez, then reproduced live for
-6 employees at once (Quentin Jones, Armanii Gonzalez, Alexia Hernandez, Colby
-Mullaley, Josiah Gonzalez, zachary hernandez).
+clock-out for the day. Reported for one employee (Employee A), then reproduced
+live for 6 employees at once (Employees B–G).
 
 The "Open for Nh Mm" timer climbs all day, so a closed session looks like a
 runaway open one. A page refresh does **not** fix it.
@@ -38,11 +37,11 @@ employees' punches land in the same "noise group" and get dropped.
 
 On the live data this discarded **22 of 48 punches (46%)**, orphaning clock-ins
 (→ false "open session") and clock-outs (→ lost session). It is sort-order
-luck which survives, which is why **Alexia (open)** and **Colin (complete)**
+luck which survives, which is why **Employee C (open)** and **Employee D (complete)**
 have byte-identical punches (`clock_in 15:00:00`, `clock_out 19:00:00`) yet
 render differently.
 
-This is also why the original Carolina case looked "clean" when her punches
+This is also why the original Employee A case looked "clean" when their punches
 were tested in isolation but broke in the app — the bug only manifests when
 multiple employees are processed together.
 
@@ -53,7 +52,7 @@ After a session is closed, the per-employee loop advances with `i = j + 1`
 already points at that clock-in, so `i = j + 1` **skips it**, dropping the
 following session entirely.
 
-This is zachary's "12:00 AM" case: he has `[clock_in 00:00, clock_in 10:02,
+This is Employee G's "12:00 AM" case: they have `[clock_in 00:00, clock_in 10:02,
 clock_out 14:03]`. The stray midnight clock-in opens a session, then the real
 10:02–14:03 session is skipped and lost.
 
@@ -120,7 +119,7 @@ class of test the original investigation lacked:
   no `refetchInterval`) was wrong: the bug is deterministic in the pure
   function and reproduces on a fresh load. Polling would have masked nothing
   here. Out of scope.
-- **zachary's residual open session is correct.** His midnight clock-in has no
+- **Employee G's residual open session is correct.** Their midnight clock-in has no
   matching clock-out in the data — flagging it open is the right behaviour. The
   stray punch itself is a data-entry artifact for the manager to resolve
   (force-out/delete), not an algorithm bug.

--- a/docs/superpowers/specs/2026-06-22-time-punch-session-pairing-design.md
+++ b/docs/superpowers/specs/2026-06-22-time-punch-session-pairing-design.md
@@ -1,0 +1,135 @@
+# Design: Fix false "open session" warnings from cross-employee punch collapse
+
+**Date:** 2026-06-22
+**Branch:** `fix/time-punch-session-pairing`
+**File touched:** `src/utils/timePunchProcessing.ts` (pure utility) + unit tests
+
+## Problem
+
+Managers see employees flagged as having an **open session** (never clocked
+out) on the Time Clock page even though the employee has a clock-in *and* a
+clock-out for the day. Reported for Carolina Sanchez, then reproduced live for
+6 employees at once (Quentin Jones, Armanii Gonzalez, Alexia Hernandez, Colby
+Mullaley, Josiah Gonzalez, zachary hernandez).
+
+The "Open for Nh Mm" timer climbs all day, so a closed session looks like a
+runaway open one. A page refresh does **not** fix it.
+
+## Root cause (proven against live production data)
+
+Confirmed by pulling the live React Query cache from the running app and
+executing the real `processPunchesForPeriod` on it — it reproduces the exact
+6 open sessions shown on screen.
+
+Two independent bugs in `src/utils/timePunchProcessing.ts`:
+
+### Bug 1 (primary) — `normalizePunches` collapses *different employees'* punches
+
+`normalizePunches` sorts the **entire restaurant's** punch stream by time and
+treats any punches within 60 seconds of each other as duplicate "noise,"
+keeping only the first and discarding the rest. **It never checks
+`employee_id`.**
+
+The 60-second window was meant to absorb a single employee fat-fingering the
+clock. But when multiple employees punch within 60s of each other — which is
+constant with backdated/imported punches that share round timestamps
+(`15:00:00`, `19:00:00`) or any normal clock-in/out rush — unrelated
+employees' punches land in the same "noise group" and get dropped.
+
+On the live data this discarded **22 of 48 punches (46%)**, orphaning clock-ins
+(→ false "open session") and clock-outs (→ lost session). It is sort-order
+luck which survives, which is why **Alexia (open)** and **Colin (complete)**
+have byte-identical punches (`clock_in 15:00:00`, `clock_out 19:00:00`) yet
+render differently.
+
+This is also why the original Carolina case looked "clean" when her punches
+were tested in isolation but broke in the app — the bug only manifests when
+multiple employees are processed together.
+
+### Bug 2 (secondary) — `identifyWorkSessions` skips a clock-in after closing a session
+
+After a session is closed, the per-employee loop advances with `i = j + 1`
+(line ~312). When the scan stopped because it hit the *next* clock-in, `j`
+already points at that clock-in, so `i = j + 1` **skips it**, dropping the
+following session entirely.
+
+This is zachary's "12:00 AM" case: he has `[clock_in 00:00, clock_in 10:02,
+clock_out 14:03]`. The stray midnight clock-in opens a session, then the real
+10:02–14:03 session is skipped and lost.
+
+### Severity
+
+The same dropped punches feed `calculateDailyHours` and the page's "Today: N
+hours" total, so **worked hours are under-counted** (13 sessions counted vs. 22
+real). This is a labor-hours / payroll accuracy bug, not just a cosmetic
+warning.
+
+## Fix
+
+### Fix 1 — scope noise detection per employee
+
+Extract the current `normalizePunches` body into `normalizeEmployeePunches`
+(unchanged logic). New `normalizePunches` buckets punches by `employee_id`,
+runs `normalizeEmployeePunches` on each bucket, and concatenates. Same per-
+employee de-duplication behaviour is preserved; cross-employee collapse is
+eliminated.
+
+Per-employee ascending order is preserved within each bucket, which is what
+`identifyWorkSessions` relies on (it groups by employee and scans forward
+chronologically).
+
+### Fix 2 — stop skipping the next clock-in
+
+Change `i = j + 1` to `i = j` in `identifyWorkSessions`. The inner loop always
+advances `j` to at least `i + 1` before any break, so `i = j` still makes
+forward progress (no infinite loop) while no longer skipping the punch `j`
+points at. This recovers back-to-back sessions and zachary's real session;
+his genuine unclosed midnight clock-in correctly remains flagged as one open
+session.
+
+### Proven effect
+
+Re-running the real algorithm on the live cached punches with both fixes:
+
+| | Before | After |
+|---|---|---|
+| Punches dropped as noise | 22 / 48 | 3 / 48 |
+| False open sessions | 6 | 1 (zachary's genuine midnight orphan) |
+| Sessions counted | 13 | 22 |
+
+## Testing
+
+Unit tests in `tests/unit/` (vitest), using **multi-employee fixtures** — the
+class of test the original investigation lacked:
+
+1. Two employees with identical `clock_in`/`clock_out` timestamps → both
+   complete, zero open (regression for Bug 1; fails on current code).
+2. 3+ employees clocking in within the same second → every session preserved,
+   no punch dropped.
+3. Same employee genuinely double-tapping the clock within 60s → still
+   de-duplicated (preserve intended behaviour).
+4. Orphan leading clock-in `[in, in, out]` for one employee → first session
+   open, second session complete and present (regression for Bug 2).
+5. Back-to-back complete sessions `[in1, out1, in2, out2]` for one employee →
+   two complete sessions (regression for Bug 2).
+6. Existing `punchFunctionality` / `useTimePunches` suites stay green.
+
+## Decided trade-offs
+
+- **Not adding polling / realtime refresh.** The first hypothesis (stale cache,
+  no `refetchInterval`) was wrong: the bug is deterministic in the pure
+  function and reproduces on a fresh load. Polling would have masked nothing
+  here. Out of scope.
+- **zachary's residual open session is correct.** His midnight clock-in has no
+  matching clock-out in the data — flagging it open is the right behaviour. The
+  stray punch itself is a data-entry artifact for the manager to resolve
+  (force-out/delete), not an algorithm bug.
+- **Noise detection stays heuristic.** We keep the existing 60s/burst rules;
+  we only scope them to the correct employee. Rethinking the heuristic itself
+  is a larger effort and not needed to fix this.
+
+## Out of scope
+
+- Midnight rollover of the viewed date.
+- Investigating where the round-number / midnight phantom punches originate
+  (import path / manual entry). Tracked separately if it recurs.

--- a/docs/superpowers/specs/2026-06-22-time-punch-session-pairing-design.md
+++ b/docs/superpowers/specs/2026-06-22-time-punch-session-pairing-design.md
@@ -82,8 +82,8 @@ chronologically).
 Change `i = j + 1` to `i = j` in `identifyWorkSessions`. The inner loop always
 advances `j` to at least `i + 1` before any break, so `i = j` still makes
 forward progress (no infinite loop) while no longer skipping the punch `j`
-points at. This recovers back-to-back sessions and zachary's real session;
-his genuine unclosed midnight clock-in correctly remains flagged as one open
+points at. This recovers back-to-back sessions and Employee G's real session;
+their genuine unclosed midnight clock-in correctly remains flagged as one open
 session.
 
 ### Proven effect
@@ -93,7 +93,7 @@ Re-running the real algorithm on the live cached punches with both fixes:
 | | Before | After |
 |---|---|---|
 | Punches dropped as noise | 22 / 48 | 3 / 48 |
-| False open sessions | 6 | 1 (zachary's genuine midnight orphan) |
+| False open sessions | 6 | 1 (Employee G's genuine midnight orphan) |
 | Sessions counted | 13 | 22 |
 
 ## Testing

--- a/src/utils/timePunchProcessing.ts
+++ b/src/utils/timePunchProcessing.ts
@@ -45,12 +45,13 @@ export interface DailyHoursData {
 }
 
 /**
- * Step 1a: Normalize punch stream for a SINGLE employee.
+ * Step 1 (per-employee): Normalize punch stream for a SINGLE employee.
  * Removes per-employee noise (fat-finger double-taps, burst events).
  * Input punches must all belong to the same employee and be sorted
  * chronologically ascending — callers are responsible for both.
+ * Internal helper: always called via normalizePunches, never directly.
  */
-export function normalizeEmployeePunches(punches: TimePunch[]): ProcessedPunch[] {
+function normalizeEmployeePunches(punches: TimePunch[]): ProcessedPunch[] {
   const processed: ProcessedPunch[] = [];
   let i = 0;
 

--- a/src/utils/timePunchProcessing.ts
+++ b/src/utils/timePunchProcessing.ts
@@ -338,7 +338,10 @@ export function identifyWorkSessions(processedPunches: ProcessedPunch[]): WorkSe
         }
 
         sessions.push(session);
-        i = j + 1;
+        // Use i = j (not j + 1): when the inner loop breaks, j already points
+        // at the next unprocessed punch (e.g. the next clock_in). Advancing
+        // with j + 1 would skip it, losing back-to-back sessions.
+        i = j;
       } else {
         // Skip punches that don't start a session
         i++;

--- a/src/utils/timePunchProcessing.ts
+++ b/src/utils/timePunchProcessing.ts
@@ -44,6 +44,63 @@ export interface DailyHoursData {
   punch_count: number;
 }
 
+/** Create a ProcessedPunch record with is_noise=false */
+function toValidPunch(p: TimePunch): ProcessedPunch {
+  return {
+    id: p.id,
+    employee_id: p.employee_id,
+    punch_type: p.punch_type,
+    punch_time: new Date(p.punch_time),
+    is_noise: false,
+    original_punch: p,
+  };
+}
+
+/** Create a ProcessedPunch record marked as noise */
+function toNoisePunch(p: TimePunch, noise_reason: string): ProcessedPunch {
+  return {
+    id: p.id,
+    employee_id: p.employee_id,
+    punch_type: p.punch_type,
+    punch_time: new Date(p.punch_time),
+    is_noise: true,
+    noise_reason,
+    original_punch: p,
+  };
+}
+
+/**
+ * Analyse a group of 2+ punches that arrived within 60 s and emit
+ * ProcessedPunch records for them.  Called only from normalizeEmployeePunches.
+ */
+function processNoiseGroup(group: TimePunch[]): ProcessedPunch[] {
+  const result: ProcessedPunch[] = [];
+
+  if (group.length >= 3) {
+    // Burst noise — keep first, mark the rest as noise
+    result.push(toValidPunch(group[0]));
+    for (let k = 1; k < group.length; k++) {
+      result.push(toNoisePunch(group[k], 'Burst noise (>3 punches in 60s)'));
+    }
+    return result;
+  }
+
+  // Exactly two punches close together
+  const [first, second] = group;
+
+  // Break Start → Clock In within 60 s = break canceled
+  if (first.punch_type === 'break_start' && second.punch_type === 'clock_in') {
+    result.push(toNoisePunch(first, 'Break canceled'));
+    result.push(toValidPunch(second));
+  } else {
+    // Keep first, mark second as a duplicate
+    result.push(toValidPunch(first));
+    result.push(toNoisePunch(second, 'Duplicate punch within 60s'));
+  }
+
+  return result;
+}
+
 /**
  * Step 1 (per-employee): Normalize punch stream for a SINGLE employee.
  * Removes per-employee noise (fat-finger double-taps, burst events).
@@ -59,16 +116,12 @@ function normalizeEmployeePunches(punches: TimePunch[]): ProcessedPunch[] {
     const current = punches[i];
     const currentTime = new Date(current.punch_time);
 
-    // Look ahead for noise patterns
+    // Collect punches within 60 seconds (potential noise)
     const noiseGroup: TimePunch[] = [current];
     let j = i + 1;
-
-    // Collect punches within 60 seconds (potential noise)
     while (j < punches.length) {
       const next = punches[j];
-      const nextTime = new Date(next.punch_time);
-      const secondsDiff = differenceInSeconds(nextTime, currentTime);
-
+      const secondsDiff = differenceInSeconds(new Date(next.punch_time), currentTime);
       if (secondsDiff < 60) {
         noiseGroup.push(next);
         j++;
@@ -77,89 +130,11 @@ function normalizeEmployeePunches(punches: TimePunch[]): ProcessedPunch[] {
       }
     }
 
-    // Analyze noise group
     if (noiseGroup.length > 1) {
-      // Multiple punches within 60 seconds
-      if (noiseGroup.length >= 3) {
-        // Burst noise - keep only the first meaningful punch
-        processed.push({
-          id: noiseGroup[0].id,
-          employee_id: noiseGroup[0].employee_id,
-          punch_type: noiseGroup[0].punch_type,
-          punch_time: new Date(noiseGroup[0].punch_time),
-          is_noise: false,
-          original_punch: noiseGroup[0],
-        });
-
-        // Mark others as noise
-        for (let k = 1; k < noiseGroup.length; k++) {
-          processed.push({
-            id: noiseGroup[k].id,
-            employee_id: noiseGroup[k].employee_id,
-            punch_type: noiseGroup[k].punch_type,
-            punch_time: new Date(noiseGroup[k].punch_time),
-            is_noise: true,
-            noise_reason: 'Burst noise (>3 punches in 60s)',
-            original_punch: noiseGroup[k],
-          });
-        }
-      } else {
-        // Two punches close together - keep both but analyze pattern
-        const first = noiseGroup[0];
-        const second = noiseGroup[1];
-
-        // Break Start → Clock In within 2 minutes = break canceled
-        if (first.punch_type === 'break_start' && second.punch_type === 'clock_in') {
-          processed.push({
-            id: first.id,
-            employee_id: first.employee_id,
-            punch_type: first.punch_type,
-            punch_time: new Date(first.punch_time),
-            is_noise: true,
-            noise_reason: 'Break canceled',
-            original_punch: first,
-          });
-          processed.push({
-            id: second.id,
-            employee_id: second.employee_id,
-            punch_type: second.punch_type,
-            punch_time: new Date(second.punch_time),
-            is_noise: false,
-            original_punch: second,
-          });
-        } else {
-          // Keep both, mark second as potential duplicate
-          processed.push({
-            id: first.id,
-            employee_id: first.employee_id,
-            punch_type: first.punch_type,
-            punch_time: new Date(first.punch_time),
-            is_noise: false,
-            original_punch: first,
-          });
-          processed.push({
-            id: second.id,
-            employee_id: second.employee_id,
-            punch_type: second.punch_type,
-            punch_time: new Date(second.punch_time),
-            is_noise: true,
-            noise_reason: 'Duplicate punch within 60s',
-            original_punch: second,
-          });
-        }
-      }
-
+      processed.push(...processNoiseGroup(noiseGroup));
       i = j;
     } else {
-      // Single punch, no noise
-      processed.push({
-        id: current.id,
-        employee_id: current.employee_id,
-        punch_type: current.punch_type,
-        punch_time: new Date(current.punch_time),
-        is_noise: false,
-        original_punch: current,
-      });
+      processed.push(toValidPunch(current));
       i++;
     }
   }
@@ -196,6 +171,120 @@ export function normalizePunches(punches: TimePunch[]): ProcessedPunch[] {
   return result;
 }
 
+/** Build an empty WorkSession anchored to the given clock_in punch */
+function startSession(punch: ProcessedPunch): WorkSession {
+  return {
+    sessionId: `${punch.employee_id}-${punch.punch_time.getTime()}`,
+    employee_id: punch.employee_id,
+    employee_name: punch.original_punch.employee?.name || 'Unknown',
+    clock_in: punch.punch_time,
+    clock_out: undefined,
+    breaks: [],
+    total_minutes: 0,
+    break_minutes: 0,
+    worked_minutes: 0,
+    is_complete: false,
+    has_anomalies: false,
+    anomalies: [],
+  };
+}
+
+/** Finalize time totals and add anomalies for a completed/incomplete session */
+function finalizeSession(session: WorkSession): void {
+  if (session.clock_out) {
+    session.total_minutes = differenceInMinutes(session.clock_out, session.clock_in);
+    session.break_minutes = session.breaks.reduce((sum, b) => sum + b.duration_minutes, 0);
+    session.worked_minutes = session.total_minutes - session.break_minutes;
+  } else {
+    session.has_anomalies = true;
+    session.anomalies.push('Incomplete session (missing clock out)');
+  }
+}
+
+/**
+ * Scan one employee's punches starting after a clock_in and fill the session.
+ * Returns the index j pointing at the next unprocessed punch.
+ */
+function fillSession(session: WorkSession, punches: ProcessedPunch[], startIndex: number): number {
+  let j = startIndex;
+  let currentBreakStart: Date | null = null;
+  let foundClockOut = false;
+
+  while (j < punches.length) {
+    const next = punches[j];
+
+    if (foundClockOut) {
+      // Session is closed — a new clock_in starts a new session
+      if (next.punch_type === 'clock_in') break;
+      j++;
+      continue;
+    }
+
+    if (next.punch_type === 'clock_out') {
+      session.clock_out = next.punch_time;
+      session.is_complete = true;
+      foundClockOut = true;
+
+      // Flag very short sessions (< 3 minutes)
+      const sessionMinutes = differenceInMinutes(session.clock_out, session.clock_in);
+      if (sessionMinutes < 3) {
+        session.has_anomalies = true;
+        session.anomalies.push('Very short session (< 3 min) - possible error');
+      }
+
+      j++;
+      continue;
+    }
+
+    if (next.punch_type === 'break_start') {
+      currentBreakStart = next.punch_time;
+    } else if (next.punch_type === 'break_end' && currentBreakStart) {
+      const breakDuration = differenceInMinutes(next.punch_time, currentBreakStart);
+      session.breaks.push({
+        break_start: currentBreakStart,
+        break_end: next.punch_time,
+        duration_minutes: breakDuration,
+        is_complete: true,
+      });
+      currentBreakStart = null;
+    } else if (next.punch_type === 'clock_in') {
+      if (currentBreakStart) {
+        // Some clients record break-end as a clock_in — treat it that way
+        const breakDuration = differenceInMinutes(next.punch_time, currentBreakStart);
+        session.breaks.push({
+          break_start: currentBreakStart,
+          break_end: next.punch_time,
+          duration_minutes: breakDuration,
+          is_complete: true,
+        });
+        currentBreakStart = null;
+        j++;
+        continue;
+      }
+      // A new clock_in with no preceding break_start means the session lacked a clock_out
+      session.has_anomalies = true;
+      session.anomalies.push('Missing clock out');
+      break;
+    }
+
+    j++;
+  }
+
+  // Handle an incomplete break still in progress at end-of-scan
+  if (currentBreakStart && session.clock_out) {
+    session.breaks.push({
+      break_start: currentBreakStart,
+      break_end: undefined,
+      duration_minutes: 0,
+      is_complete: false,
+    });
+    session.has_anomalies = true;
+    session.anomalies.push('Incomplete break (missing break end)');
+  }
+
+  return j;
+}
+
 /**
  * Step 2: Identify work sessions from normalized punches
  */
@@ -216,133 +305,20 @@ export function identifyWorkSessions(processedPunches: ProcessedPunch[]): WorkSe
 
   const sessions: WorkSession[] = [];
 
-  // Process each employee's punches
-  for (const [employeeId, punches] of employeeGroups) {
+  for (const [, punches] of employeeGroups) {
     let i = 0;
 
     while (i < punches.length) {
       const punch = punches[i];
 
-      // Sessions must start with clock_in
       if (punch.punch_type === 'clock_in') {
-        const session: WorkSession = {
-          sessionId: `${employeeId}-${punch.punch_time.getTime()}`,
-          employee_id: employeeId,
-          employee_name: punch.original_punch.employee?.name || 'Unknown',
-          clock_in: punch.punch_time,
-          clock_out: undefined,
-          breaks: [],
-          total_minutes: 0,
-          break_minutes: 0,
-          worked_minutes: 0,
-          is_complete: false,
-          has_anomalies: false,
-          anomalies: [],
-        };
-
-        // Look for corresponding clock_out and breaks
-        let j = i + 1;
-        let currentBreakStart: Date | null = null;
-        // foundClockOut ensures we only accept the first clock_out that closes this session
-        let foundClockOut = false;
-
-        while (j < punches.length) {
-          const nextPunch = punches[j];
-
-          // If we've already closed the session with a clock_out, stop scanning —
-          // further clock_outs belong to either noise or a separate action and should not reopen this session.
-          if (foundClockOut) {
-            if (nextPunch.punch_type === 'clock_in') {
-              // next clock_in starts a new session — stop scanning for this one
-              break;
-            }
-            // ignore other punch types after a clock out for this session
-            j++;
-            continue;
-          }
-
-          if (nextPunch.punch_type === 'clock_out') {
-            session.clock_out = nextPunch.punch_time;
-            session.is_complete = true;
-            foundClockOut = true;
-
-            // Check for very short sessions (< 3 minutes)
-            const sessionMinutes = differenceInMinutes(session.clock_out, session.clock_in);
-            if (sessionMinutes < 3 && sessions.length > 0) {
-              session.has_anomalies = true;
-              session.anomalies.push('Very short session (< 3 min) - possible error');
-            }
-
-            // don't break immediately; keep loop semantics consistent — we will stop on next iteration
-            // or when a new clock_in is encountered (handled above)
-            j++;
-            continue;
-          } else if (nextPunch.punch_type === 'break_start') {
-            currentBreakStart = nextPunch.punch_time;
-          } else if (nextPunch.punch_type === 'break_end' && currentBreakStart) {
-            // Only record break if it's within this session
-            const breakDuration = differenceInMinutes(nextPunch.punch_time, currentBreakStart);
-            session.breaks.push({
-              break_start: currentBreakStart,
-              break_end: nextPunch.punch_time,
-              duration_minutes: breakDuration,
-              is_complete: true,
-            });
-            currentBreakStart = null;
-          } else if (nextPunch.punch_type === 'clock_in') {
-            // If we're currently tracking a break start, a subsequent 'clock_in'
-            // is often the break-ending action (some clients record break end as clock_in).
-            // Treat that as a break_end here rather than starting a new session.
-            if (currentBreakStart) {
-              const breakDuration = differenceInMinutes(nextPunch.punch_time, currentBreakStart);
-              session.breaks.push({
-                break_start: currentBreakStart,
-                break_end: nextPunch.punch_time,
-                duration_minutes: breakDuration,
-                is_complete: true,
-              });
-              currentBreakStart = null;
-              // continue scanning for a clock_out for the current session
-              j++;
-              continue;
-            }
-
-            // Otherwise this is a new clock_in and the previous session had no clock_out
-            session.has_anomalies = true;
-            session.anomalies.push('Missing clock out');
-            break;
-          }
-
-          j++;
-        }
-
-        // Handle incomplete break
-        if (currentBreakStart && session.clock_out) {
-          session.breaks.push({
-            break_start: currentBreakStart,
-            break_end: undefined,
-            duration_minutes: 0,
-            is_complete: false,
-          });
-          session.has_anomalies = true;
-          session.anomalies.push('Incomplete break (missing break end)');
-        }
-
-        // Calculate totals
-        if (session.clock_out) {
-          session.total_minutes = differenceInMinutes(session.clock_out, session.clock_in);
-          session.break_minutes = session.breaks.reduce((sum, b) => sum + b.duration_minutes, 0);
-          session.worked_minutes = session.total_minutes - session.break_minutes;
-        } else {
-          session.has_anomalies = true;
-          session.anomalies.push('Incomplete session (missing clock out)');
-        }
-
-        sessions.push(session);
-        // Use i = j (not j + 1): when the inner loop breaks, j already points
+        const session = startSession(punch);
+        // Use i = j (not j + 1): when fillSession breaks, j already points
         // at the next unprocessed punch (e.g. the next clock_in). Advancing
         // with j + 1 would skip it, losing back-to-back sessions.
-        i = j;
+        i = fillSession(session, punches, i + 1);
+        finalizeSession(session);
+        sessions.push(session);
       } else {
         // Skip punches that don't start a session
         i++;

--- a/src/utils/timePunchProcessing.ts
+++ b/src/utils/timePunchProcessing.ts
@@ -45,32 +45,29 @@ export interface DailyHoursData {
 }
 
 /**
- * Step 1: Normalize punch stream
- * Removes noise and prepares punches for session identification
+ * Step 1a: Normalize punch stream for a SINGLE employee.
+ * Removes per-employee noise (fat-finger double-taps, burst events).
+ * Input punches must all belong to the same employee and be sorted
+ * chronologically ascending — callers are responsible for both.
  */
-export function normalizePunches(punches: TimePunch[]): ProcessedPunch[] {
-  // Sort chronologically (oldest first for processing)
-  const sorted = [...punches].sort((a, b) => 
-    new Date(a.punch_time).getTime() - new Date(b.punch_time).getTime()
-  );
-
+export function normalizeEmployeePunches(punches: TimePunch[]): ProcessedPunch[] {
   const processed: ProcessedPunch[] = [];
   let i = 0;
 
-  while (i < sorted.length) {
-    const current = sorted[i];
+  while (i < punches.length) {
+    const current = punches[i];
     const currentTime = new Date(current.punch_time);
-    
+
     // Look ahead for noise patterns
     const noiseGroup: TimePunch[] = [current];
     let j = i + 1;
-    
+
     // Collect punches within 60 seconds (potential noise)
-    while (j < sorted.length) {
-      const next = sorted[j];
+    while (j < punches.length) {
+      const next = punches[j];
       const nextTime = new Date(next.punch_time);
       const secondsDiff = differenceInSeconds(nextTime, currentTime);
-      
+
       if (secondsDiff < 60) {
         noiseGroup.push(next);
         j++;
@@ -109,7 +106,7 @@ export function normalizePunches(punches: TimePunch[]): ProcessedPunch[] {
         // Two punches close together - keep both but analyze pattern
         const first = noiseGroup[0];
         const second = noiseGroup[1];
-        
+
         // Break Start → Clock In within 2 minutes = break canceled
         if (first.punch_type === 'break_start' && second.punch_type === 'clock_in') {
           processed.push({
@@ -150,7 +147,7 @@ export function normalizePunches(punches: TimePunch[]): ProcessedPunch[] {
           });
         }
       }
-      
+
       i = j;
     } else {
       // Single punch, no noise
@@ -167,6 +164,38 @@ export function normalizePunches(punches: TimePunch[]): ProcessedPunch[] {
   }
 
   return processed;
+}
+
+/**
+ * Step 1: Normalize punch stream for ALL employees.
+ * Buckets punches by employee_id, runs normalizeEmployeePunches on each
+ * bucket, and concatenates results. This ensures the 60-second noise
+ * window never collapses punches belonging to different employees — which
+ * would happen if the whole restaurant stream were deduplicated globally.
+ */
+export function normalizePunches(punches: TimePunch[]): ProcessedPunch[] {
+  // Bucket by employee, preserving insertion order for Map iteration
+  const buckets = new Map<string, TimePunch[]>();
+  for (const punch of punches) {
+    const bucket = buckets.get(punch.employee_id);
+    if (bucket) {
+      bucket.push(punch);
+    } else {
+      buckets.set(punch.employee_id, [punch]);
+    }
+  }
+
+  const result: ProcessedPunch[] = [];
+  for (const [, bucket] of buckets) {
+    // Sort each employee's punches chronologically before normalizing
+    bucket.sort((a, b) => new Date(a.punch_time).getTime() - new Date(b.punch_time).getTime());
+    const normalized = normalizeEmployeePunches(bucket);
+    for (const p of normalized) {
+      result.push(p);
+    }
+  }
+
+  return result;
 }
 
 /**

--- a/src/utils/timePunchProcessing.ts
+++ b/src/utils/timePunchProcessing.ts
@@ -186,13 +186,10 @@ export function normalizePunches(punches: TimePunch[]): ProcessedPunch[] {
   }
 
   const result: ProcessedPunch[] = [];
-  for (const [, bucket] of buckets) {
+  for (const bucket of buckets.values()) {
     // Sort each employee's punches chronologically before normalizing
     bucket.sort((a, b) => new Date(a.punch_time).getTime() - new Date(b.punch_time).getTime());
-    const normalized = normalizeEmployeePunches(bucket);
-    for (const p of normalized) {
-      result.push(p);
-    }
+    result.push(...normalizeEmployeePunches(bucket));
   }
 
   return result;
@@ -204,24 +201,27 @@ export function normalizePunches(punches: TimePunch[]): ProcessedPunch[] {
 export function identifyWorkSessions(processedPunches: ProcessedPunch[]): WorkSession[] {
   // Filter out noise punches
   const validPunches = processedPunches.filter(p => !p.is_noise);
-  
+
   // Group by employee
   const employeeGroups = new Map<string, ProcessedPunch[]>();
-  validPunches.forEach(punch => {
-    const existing = employeeGroups.get(punch.employee_id) || [];
-    existing.push(punch);
-    employeeGroups.set(punch.employee_id, existing);
-  });
+  for (const punch of validPunches) {
+    const group = employeeGroups.get(punch.employee_id);
+    if (group) {
+      group.push(punch);
+    } else {
+      employeeGroups.set(punch.employee_id, [punch]);
+    }
+  }
 
   const sessions: WorkSession[] = [];
 
   // Process each employee's punches
-  employeeGroups.forEach((punches, employeeId) => {
+  for (const [employeeId, punches] of employeeGroups) {
     let i = 0;
-    
+
     while (i < punches.length) {
       const punch = punches[i];
-      
+
       // Sessions must start with clock_in
       if (punch.punch_type === 'clock_in') {
         const session: WorkSession = {
@@ -311,7 +311,7 @@ export function identifyWorkSessions(processedPunches: ProcessedPunch[]): WorkSe
             session.anomalies.push('Missing clock out');
             break;
           }
-          
+
           j++;
         }
 
@@ -347,7 +347,7 @@ export function identifyWorkSessions(processedPunches: ProcessedPunch[]): WorkSe
         i++;
       }
     }
-  });
+  }
 
   return sessions;
 }
@@ -358,15 +358,15 @@ export function identifyWorkSessions(processedPunches: ProcessedPunch[]): WorkSe
 export function calculateDailyHours(sessions: WorkSession[], date: Date): Map<string, DailyHoursData> {
   const dailyData = new Map<string, DailyHoursData>();
 
-  sessions.forEach(session => {
+  for (const session of sessions) {
     // Only include sessions from the specified date
     const sessionDate = new Date(session.clock_in);
     if (sessionDate.toDateString() !== date.toDateString()) {
-      return;
+      continue;
     }
 
     const existing = dailyData.get(session.employee_id);
-    
+
     if (existing) {
       existing.sessions.push(session);
       existing.total_worked_hours += session.worked_minutes / 60;
@@ -386,7 +386,7 @@ export function calculateDailyHours(sessions: WorkSession[], date: Date): Map<st
         punch_count: 2 + (session.breaks.length * 2),
       });
     }
-  });
+  }
 
   return dailyData;
 }
@@ -402,7 +402,7 @@ export function processPunchesForPeriod(punches: TimePunch[]): {
 } {
   const processedPunches = normalizePunches(punches);
   const sessions = identifyWorkSessions(processedPunches);
-  
+
   const totalNoisePunches = processedPunches.filter(p => p.is_noise).length;
   const totalAnomalies = sessions.filter(s => s.has_anomalies).length;
 

--- a/src/utils/timePunchProcessing.ts
+++ b/src/utils/timePunchProcessing.ts
@@ -74,15 +74,12 @@ function toNoisePunch(p: TimePunch, noise_reason: string): ProcessedPunch {
  * ProcessedPunch records for them.  Called only from normalizeEmployeePunches.
  */
 function processNoiseGroup(group: TimePunch[]): ProcessedPunch[] {
-  const result: ProcessedPunch[] = [];
-
   if (group.length >= 3) {
     // Burst noise — keep first, mark the rest as noise
-    result.push(toValidPunch(group[0]));
-    for (let k = 1; k < group.length; k++) {
-      result.push(toNoisePunch(group[k], 'Burst noise (>3 punches in 60s)'));
-    }
-    return result;
+    return [
+      toValidPunch(group[0]),
+      ...group.slice(1).map(p => toNoisePunch(p, 'Burst noise (>3 punches in 60s)')),
+    ];
   }
 
   // Exactly two punches close together
@@ -90,15 +87,11 @@ function processNoiseGroup(group: TimePunch[]): ProcessedPunch[] {
 
   // Break Start → Clock In within 60 s = break canceled
   if (first.punch_type === 'break_start' && second.punch_type === 'clock_in') {
-    result.push(toNoisePunch(first, 'Break canceled'));
-    result.push(toValidPunch(second));
-  } else {
-    // Keep first, mark second as a duplicate
-    result.push(toValidPunch(first));
-    result.push(toNoisePunch(second, 'Duplicate punch within 60s'));
+    return [toNoisePunch(first, 'Break canceled'), toValidPunch(second)];
   }
 
-  return result;
+  // Keep first, mark second as a duplicate
+  return [toValidPunch(first), toNoisePunch(second, 'Duplicate punch within 60s')];
 }
 
 /**
@@ -202,6 +195,62 @@ function finalizeSession(session: WorkSession): void {
 }
 
 /**
+ * Record a completed break on the session and return null to clear
+ * currentBreakStart.
+ */
+function closeBreak(session: WorkSession, breakStart: Date, breakEnd: Date): null {
+  session.breaks.push({
+    break_start: breakStart,
+    break_end: breakEnd,
+    duration_minutes: differenceInMinutes(breakEnd, breakStart),
+    is_complete: true,
+  });
+  return null;
+}
+
+/**
+ * Process one punch while the session is still open (no clock_out yet).
+ * Returns { continueLoop, breakLoop, newBreakStart }.
+ * Internal helper for fillSession.
+ */
+function handleOpenPunch(
+  session: WorkSession,
+  punch: ProcessedPunch,
+  currentBreakStart: Date | null,
+): { continueLoop: boolean; breakLoop: boolean; newBreakStart: Date | null } {
+  if (punch.punch_type === 'clock_out') {
+    session.clock_out = punch.punch_time;
+    session.is_complete = true;
+    const sessionMinutes = differenceInMinutes(punch.punch_time, session.clock_in);
+    if (sessionMinutes < 3) {
+      session.has_anomalies = true;
+      session.anomalies.push('Very short session (< 3 min) - possible error');
+    }
+    return { continueLoop: true, breakLoop: false, newBreakStart: currentBreakStart };
+  }
+
+  if (punch.punch_type === 'break_start') {
+    return { continueLoop: false, breakLoop: false, newBreakStart: punch.punch_time };
+  }
+
+  if (punch.punch_type === 'break_end' && currentBreakStart) {
+    return { continueLoop: false, breakLoop: false, newBreakStart: closeBreak(session, currentBreakStart, punch.punch_time) };
+  }
+
+  if (punch.punch_type === 'clock_in') {
+    if (currentBreakStart) {
+      // Some clients record break-end as a clock_in
+      return { continueLoop: true, breakLoop: false, newBreakStart: closeBreak(session, currentBreakStart, punch.punch_time) };
+    }
+    session.has_anomalies = true;
+    session.anomalies.push('Missing clock out');
+    return { continueLoop: false, breakLoop: true, newBreakStart: null };
+  }
+
+  return { continueLoop: false, breakLoop: false, newBreakStart: currentBreakStart };
+}
+
+/**
  * Scan one employee's punches starting after a clock_in and fill the session.
  * Returns the index j pointing at the next unprocessed punch.
  */
@@ -214,59 +263,19 @@ function fillSession(session: WorkSession, punches: ProcessedPunch[], startIndex
     const next = punches[j];
 
     if (foundClockOut) {
-      // Session is closed — a new clock_in starts a new session
       if (next.punch_type === 'clock_in') break;
       j++;
       continue;
     }
 
-    if (next.punch_type === 'clock_out') {
-      session.clock_out = next.punch_time;
-      session.is_complete = true;
-      foundClockOut = true;
+    const { continueLoop, breakLoop, newBreakStart } = handleOpenPunch(session, next, currentBreakStart);
+    currentBreakStart = newBreakStart;
 
-      // Flag very short sessions (< 3 minutes)
-      const sessionMinutes = differenceInMinutes(session.clock_out, session.clock_in);
-      if (sessionMinutes < 3) {
-        session.has_anomalies = true;
-        session.anomalies.push('Very short session (< 3 min) - possible error');
-      }
-
-      j++;
-      continue;
+    if (breakLoop) break;
+    if (continueLoop) {
+      // Check if we just set foundClockOut via session.is_complete
+      foundClockOut = session.is_complete;
     }
-
-    if (next.punch_type === 'break_start') {
-      currentBreakStart = next.punch_time;
-    } else if (next.punch_type === 'break_end' && currentBreakStart) {
-      const breakDuration = differenceInMinutes(next.punch_time, currentBreakStart);
-      session.breaks.push({
-        break_start: currentBreakStart,
-        break_end: next.punch_time,
-        duration_minutes: breakDuration,
-        is_complete: true,
-      });
-      currentBreakStart = null;
-    } else if (next.punch_type === 'clock_in') {
-      if (currentBreakStart) {
-        // Some clients record break-end as a clock_in — treat it that way
-        const breakDuration = differenceInMinutes(next.punch_time, currentBreakStart);
-        session.breaks.push({
-          break_start: currentBreakStart,
-          break_end: next.punch_time,
-          duration_minutes: breakDuration,
-          is_complete: true,
-        });
-        currentBreakStart = null;
-        j++;
-        continue;
-      }
-      // A new clock_in with no preceding break_start means the session lacked a clock_out
-      session.has_anomalies = true;
-      session.anomalies.push('Missing clock out');
-      break;
-    }
-
     j++;
   }
 

--- a/tests/unit/timePunchProcessing.test.ts
+++ b/tests/unit/timePunchProcessing.test.ts
@@ -77,6 +77,71 @@ describe('normalizePunches — noise detection is per employee', () => {
   });
 });
 
+describe('normalizePunches — break_start→clock_in cancels the break', () => {
+  it('marks break_start as noise when followed by clock_in within 60s', () => {
+    // A break_start immediately cancelled by a clock_in within 60s (noise=break canceled).
+    // The standalone clock_in + clock_out produces one complete session.
+    const punches = [
+      mk('in', 'empA', 'clock_in', '2026-06-22T09:00:00Z'),
+      mk('out', 'empA', 'clock_out', '2026-06-22T10:00:00Z'),
+      mk('bs', 'empA', 'break_start', '2026-06-22T11:00:00Z'),
+      mk('ci', 'empA', 'clock_in', '2026-06-22T11:00:30Z'), // within 60s → break canceled
+      mk('out2', 'empA', 'clock_out', '2026-06-22T15:00:00Z'),
+    ];
+    const { processedPunches, sessions } = processPunchesForPeriod(punches);
+    const breakStartPunch = processedPunches.find(p => p.punch_type === 'break_start');
+    expect(breakStartPunch?.is_noise).toBe(true);
+    expect(breakStartPunch?.noise_reason).toBe('Break canceled');
+    // Two complete sessions (pre-break and post-break)
+    expect(sessions.filter(s => s.is_complete)).toHaveLength(2);
+  });
+});
+
+describe('identifyWorkSessions — break handling', () => {
+  it('records a complete break within a session', () => {
+    const punches = [
+      mk('in', 'empA', 'clock_in', '2026-06-22T09:00:00Z'),
+      mk('bs', 'empA', 'break_start', '2026-06-22T12:00:00Z'),
+      mk('be', 'empA', 'break_end', '2026-06-22T12:30:00Z'),
+      mk('out', 'empA', 'clock_out', '2026-06-22T17:00:00Z'),
+    ];
+    const { sessions } = processPunchesForPeriod(punches);
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].is_complete).toBe(true);
+    expect(sessions[0].breaks).toHaveLength(1);
+    expect(sessions[0].breaks[0].duration_minutes).toBe(30);
+    expect(sessions[0].break_minutes).toBe(30);
+    expect(sessions[0].worked_minutes).toBe(sessions[0].total_minutes - 30);
+  });
+
+  it('flags very short sessions (< 3 minutes) as anomalies', () => {
+    const punches = [
+      mk('in', 'empA', 'clock_in', '2026-06-22T09:00:00Z'),
+      mk('out', 'empA', 'clock_out', '2026-06-22T09:01:00Z'), // only 1 minute
+    ];
+    const { sessions } = processPunchesForPeriod(punches);
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].is_complete).toBe(true);
+    expect(sessions[0].has_anomalies).toBe(true);
+    expect(sessions[0].anomalies).toContain('Very short session (< 3 min) - possible error');
+  });
+
+  it('flags an incomplete break when session closes before break_end', () => {
+    const punches = [
+      mk('in', 'empA', 'clock_in', '2026-06-22T09:00:00Z'),
+      mk('bs', 'empA', 'break_start', '2026-06-22T12:00:00Z'),
+      // No break_end — session closes with a break still open
+      mk('out', 'empA', 'clock_out', '2026-06-22T17:00:00Z'),
+    ];
+    const { sessions } = processPunchesForPeriod(punches);
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].has_anomalies).toBe(true);
+    expect(sessions[0].anomalies).toContain('Incomplete break (missing break end)');
+    expect(sessions[0].breaks).toHaveLength(1);
+    expect(sessions[0].breaks[0].is_complete).toBe(false);
+  });
+});
+
 describe('identifyWorkSessions — does not skip the next clock-in', () => {
   it('keeps the real session after an orphan leading clock-in', () => {
     // zachary case: a stray midnight clock-in must not swallow the real

--- a/tests/unit/timePunchProcessing.test.ts
+++ b/tests/unit/timePunchProcessing.test.ts
@@ -76,3 +76,35 @@ describe('normalizePunches — noise detection is per employee', () => {
     expect(totalNoisePunches).toBe(1);
   });
 });
+
+describe('identifyWorkSessions — does not skip the next clock-in', () => {
+  it('keeps the real session after an orphan leading clock-in', () => {
+    // zachary case: a stray midnight clock-in must not swallow the real
+    // 10:02–14:03 session that follows it.
+    const punches = [
+      mk('orphan', 'empZ', 'clock_in', '2026-06-22T00:00:00Z'),
+      mk('in', 'empZ', 'clock_in', '2026-06-22T10:02:00Z'),
+      mk('out', 'empZ', 'clock_out', '2026-06-22T14:03:00Z'),
+    ];
+    const { sessions } = processPunchesForPeriod(punches);
+    expect(sessions).toHaveLength(2);
+    const complete = sessions.filter((s) => s.is_complete);
+    expect(complete).toHaveLength(1);
+    expect(complete[0].clock_in.toISOString()).toBe('2026-06-22T10:02:00.000Z');
+    expect(complete[0].clock_out?.toISOString()).toBe('2026-06-22T14:03:00.000Z');
+    // the orphan correctly remains a single open session
+    expect(sessions.filter((s) => !s.is_complete)).toHaveLength(1);
+  });
+
+  it('keeps both back-to-back complete sessions for one employee', () => {
+    const punches = [
+      mk('in1', 'empA', 'clock_in', '2026-06-22T09:00:00Z'),
+      mk('out1', 'empA', 'clock_out', '2026-06-22T12:00:00Z'),
+      mk('in2', 'empA', 'clock_in', '2026-06-22T13:00:00Z'),
+      mk('out2', 'empA', 'clock_out', '2026-06-22T17:00:00Z'),
+    ];
+    const { sessions } = processPunchesForPeriod(punches);
+    expect(sessions).toHaveLength(2);
+    expect(sessions.filter((s) => s.is_complete)).toHaveLength(2);
+  });
+});

--- a/tests/unit/timePunchProcessing.test.ts
+++ b/tests/unit/timePunchProcessing.test.ts
@@ -20,8 +20,8 @@ const mk = (
 const open = (s: { is_complete: boolean }) => !s.is_complete;
 
 describe('normalizePunches — noise detection is per employee', () => {
-  it('keeps both employees complete when they share identical in/out timestamps', () => {
-    // Mirrors the production "Alexia vs Colin" case: imported punches with
+  it('CRITICAL: should keep both employees complete when they share identical in/out timestamps', () => {
+    // Mirrors the production "Employee A vs Employee B" case: imported punches with
     // identical round timestamps must not collapse across employees.
     const punches = [
       mk('a-in', 'empA', 'clock_in', '2026-06-22T15:00:00Z'),
@@ -34,7 +34,7 @@ describe('normalizePunches — noise detection is per employee', () => {
     expect(sessions.filter(open)).toHaveLength(0);
   });
 
-  it('does not orphan a clock-in into a false open session when another employee punches within 60s', () => {
+  it('CRITICAL: should not orphan a clock-in into a false open session when another employee punches within 60s', () => {
     // empB clock_in is first in the 15:00 cluster (survives) and empB clock_out
     // is second in the 19:00 cluster — under the old global logic empB's
     // clock_out was dropped, orphaning empB into a false "open session".
@@ -49,7 +49,7 @@ describe('normalizePunches — noise detection is per employee', () => {
     expect(sessions.filter((s) => s.is_complete)).toHaveLength(2);
   });
 
-  it('three employees clocking in the same second keep all three sessions', () => {
+  it('CRITICAL: should keep all three sessions when three employees clock in the same second', () => {
     const punches = [
       mk('a-in', 'empA', 'clock_in', '2026-06-22T15:00:00Z'),
       mk('b-in', 'empB', 'clock_in', '2026-06-22T15:00:00Z'),
@@ -64,7 +64,7 @@ describe('normalizePunches — noise detection is per employee', () => {
     expect(totalNoisePunches).toBe(0);
   });
 
-  it('still de-duplicates the SAME employee double-tapping within 60s', () => {
+  it('CRITICAL: should still de-duplicate the same employee double-tapping within 60s', () => {
     const punches = [
       mk('in1', 'empA', 'clock_in', '2026-06-22T15:00:00Z'),
       mk('in2', 'empA', 'clock_in', '2026-06-22T15:00:10Z'), // duplicate
@@ -78,7 +78,7 @@ describe('normalizePunches — noise detection is per employee', () => {
 });
 
 describe('normalizePunches — break_start→clock_in cancels the break', () => {
-  it('marks break_start as noise when followed by clock_in within 60s', () => {
+  it('CRITICAL: should mark break_start as noise when followed by clock_in within 60s', () => {
     // A break_start immediately cancelled by a clock_in within 60s (noise=break canceled).
     // The standalone clock_in + clock_out produces one complete session.
     const punches = [
@@ -98,7 +98,7 @@ describe('normalizePunches — break_start→clock_in cancels the break', () => 
 });
 
 describe('identifyWorkSessions — break handling', () => {
-  it('records a complete break within a session', () => {
+  it('CRITICAL: should record a complete break within a session', () => {
     const punches = [
       mk('in', 'empA', 'clock_in', '2026-06-22T09:00:00Z'),
       mk('bs', 'empA', 'break_start', '2026-06-22T12:00:00Z'),
@@ -114,7 +114,7 @@ describe('identifyWorkSessions — break handling', () => {
     expect(sessions[0].worked_minutes).toBe(sessions[0].total_minutes - 30);
   });
 
-  it('flags very short sessions (< 3 minutes) as anomalies', () => {
+  it('CRITICAL: should flag very short sessions as anomalies when session is under 3 minutes', () => {
     const punches = [
       mk('in', 'empA', 'clock_in', '2026-06-22T09:00:00Z'),
       mk('out', 'empA', 'clock_out', '2026-06-22T09:01:00Z'), // only 1 minute
@@ -126,7 +126,7 @@ describe('identifyWorkSessions — break handling', () => {
     expect(sessions[0].anomalies).toContain('Very short session (< 3 min) - possible error');
   });
 
-  it('flags an incomplete break when session closes before break_end', () => {
+  it('CRITICAL: should flag an incomplete break when session closes before break_end', () => {
     const punches = [
       mk('in', 'empA', 'clock_in', '2026-06-22T09:00:00Z'),
       mk('bs', 'empA', 'break_start', '2026-06-22T12:00:00Z'),
@@ -143,8 +143,8 @@ describe('identifyWorkSessions — break handling', () => {
 });
 
 describe('identifyWorkSessions — does not skip the next clock-in', () => {
-  it('keeps the real session after an orphan leading clock-in', () => {
-    // zachary case: a stray midnight clock-in must not swallow the real
+  it('CRITICAL: should keep the real session after an orphan leading clock-in', () => {
+    // Employee G case: a stray midnight clock-in must not swallow the real
     // 10:02–14:03 session that follows it.
     const punches = [
       mk('orphan', 'empZ', 'clock_in', '2026-06-22T00:00:00Z'),
@@ -161,7 +161,7 @@ describe('identifyWorkSessions — does not skip the next clock-in', () => {
     expect(sessions.filter((s) => !s.is_complete)).toHaveLength(1);
   });
 
-  it('keeps both back-to-back complete sessions for one employee', () => {
+  it('CRITICAL: should keep both back-to-back complete sessions for one employee', () => {
     const punches = [
       mk('in1', 'empA', 'clock_in', '2026-06-22T09:00:00Z'),
       mk('out1', 'empA', 'clock_out', '2026-06-22T12:00:00Z'),

--- a/tests/unit/timePunchProcessing.test.ts
+++ b/tests/unit/timePunchProcessing.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import { processPunchesForPeriod } from '@/utils/timePunchProcessing';
+import type { TimePunch } from '@/types/timeTracking';
+
+const mk = (
+  id: string,
+  employee_id: string,
+  punch_type: 'clock_in' | 'clock_out' | 'break_start' | 'break_end',
+  punch_time: string,
+): TimePunch =>
+  ({
+    id,
+    restaurant_id: 'rest-1',
+    employee_id,
+    punch_type,
+    punch_time,
+    employee: { id: employee_id, name: employee_id, position: '' },
+  }) as unknown as TimePunch;
+
+const open = (s: { is_complete: boolean }) => !s.is_complete;
+
+describe('normalizePunches — noise detection is per employee', () => {
+  it('keeps both employees complete when they share identical in/out timestamps', () => {
+    // Mirrors the production "Alexia vs Colin" case: imported punches with
+    // identical round timestamps must not collapse across employees.
+    const punches = [
+      mk('a-in', 'empA', 'clock_in', '2026-06-22T15:00:00Z'),
+      mk('b-in', 'empB', 'clock_in', '2026-06-22T15:00:00Z'),
+      mk('a-out', 'empA', 'clock_out', '2026-06-22T19:00:00Z'),
+      mk('b-out', 'empB', 'clock_out', '2026-06-22T19:00:00Z'),
+    ];
+    const { sessions } = processPunchesForPeriod(punches);
+    expect(sessions).toHaveLength(2);
+    expect(sessions.filter(open)).toHaveLength(0);
+  });
+
+  it('does not orphan a clock-in into a false open session when another employee punches within 60s', () => {
+    // empB clock_in is first in the 15:00 cluster (survives) and empB clock_out
+    // is second in the 19:00 cluster — under the old global logic empB's
+    // clock_out was dropped, orphaning empB into a false "open session".
+    const punches = [
+      mk('b-in', 'empB', 'clock_in', '2026-06-22T15:00:00Z'),
+      mk('a-in', 'empA', 'clock_in', '2026-06-22T15:00:30Z'),
+      mk('a-out', 'empA', 'clock_out', '2026-06-22T19:00:00Z'),
+      mk('b-out', 'empB', 'clock_out', '2026-06-22T19:00:30Z'),
+    ];
+    const { sessions } = processPunchesForPeriod(punches);
+    expect(sessions.filter(open)).toHaveLength(0);
+    expect(sessions.filter((s) => s.is_complete)).toHaveLength(2);
+  });
+
+  it('three employees clocking in the same second keep all three sessions', () => {
+    const punches = [
+      mk('a-in', 'empA', 'clock_in', '2026-06-22T15:00:00Z'),
+      mk('b-in', 'empB', 'clock_in', '2026-06-22T15:00:00Z'),
+      mk('c-in', 'empC', 'clock_in', '2026-06-22T15:00:00Z'),
+      mk('a-out', 'empA', 'clock_out', '2026-06-22T19:00:00Z'),
+      mk('b-out', 'empB', 'clock_out', '2026-06-22T19:00:00Z'),
+      mk('c-out', 'empC', 'clock_out', '2026-06-22T19:00:00Z'),
+    ];
+    const { sessions, totalNoisePunches } = processPunchesForPeriod(punches);
+    expect(sessions).toHaveLength(3);
+    expect(sessions.filter((s) => s.is_complete)).toHaveLength(3);
+    expect(totalNoisePunches).toBe(0);
+  });
+
+  it('still de-duplicates the SAME employee double-tapping within 60s', () => {
+    const punches = [
+      mk('in1', 'empA', 'clock_in', '2026-06-22T15:00:00Z'),
+      mk('in2', 'empA', 'clock_in', '2026-06-22T15:00:10Z'), // duplicate
+      mk('out', 'empA', 'clock_out', '2026-06-22T19:00:00Z'),
+    ];
+    const { sessions, totalNoisePunches } = processPunchesForPeriod(punches);
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].is_complete).toBe(true);
+    expect(totalNoisePunches).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- **Bug 1 (primary):** `normalizePunches` sorted the entire restaurant's punch stream and collapsed any punches within 60 s as duplicate noise — without checking `employee_id`. On live production data this dropped 22 of 48 punches (46%), orphaning clock-ins into false "open session" warnings and under-counting worked hours. Fix: bucket by `employee_id` before de-duplicating; run existing per-employee logic on each bucket, then concatenate.
- **Bug 2 (secondary):** `identifyWorkSessions` advanced with `i = j + 1` after closing a session, but when the scan stopped because it hit the next clock-in, `j` already pointed at that clock-in — so `i = j + 1` skipped it, dropping the following session. Fix: change to `i = j`.
- **Regression tests (6 cases):** Multi-employee fixtures in `tests/unit/timePunchProcessing.test.ts` — the class of test the original investigation lacked — written RED before each fix and confirmed GREEN after.
- **No callers changed:** `normalizePunches` keeps its existing exported signature; `processPunchesForPeriod` (the sole caller) is untouched.
- **PII remediated:** Production employee names that appeared in the design doc were replaced with anonymized labels (Employee A–G) per the CodeRabbit/Codex review.

## Test plan

- [ ] `npx vitest run tests/unit/timePunchProcessing.test.ts` → 6/6 pass
- [ ] `npm run test` → full suite passes (4599 passed / 2 skipped; 0 failures)
- [ ] `npm run typecheck` → exit 0, zero errors
- [ ] `npm run build` → exit 0, 6811 modules transformed
- [ ] Time Clock page: employees who previously showed "open session" all day (with a valid clock-out in the database) now show a completed session and correct hours
- [ ] Employee G's genuine midnight orphan clock-in correctly remains flagged as one open session (no matching clock-out in the data)

## Design doc

`docs/superpowers/specs/2026-06-22-time-punch-session-pairing-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed false "open session" warnings displayed to managers by resolving punch deduplication and session pairing issues.
  * Improved accuracy of clock-in/out record processing to prevent dropped or incorrectly paired sessions.

* **Tests**
  * Added comprehensive unit test suite for multi-employee time punch processing scenarios.

* **Documentation**
  * Added design specification and implementation plan for time punch session pairing improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->