### PR TITLE
feat(scheduling): thread areaFilter into schedule print/PDF pipeline

### DIFF
--- a/docs/superpowers/plans/2026-06-23-schedule-print-area-filter-plan.md
+++ b/docs/superpowers/plans/2026-06-23-schedule-print-area-filter-plan.md
@@ -1,0 +1,51 @@
+# Plan: Area filter in schedule print/PDF
+
+Design: `docs/superpowers/specs/2026-06-23-schedule-print-area-filter-design.md`
+
+TDD throughout. Mirror the existing `positionFilter` flow exactly; AND semantics
+across area + position; `'all'`/undefined = no filter.
+
+## Task 1 — `scheduleExport.ts`: areaFilter in PDF generation (RED→GREEN→COMMIT)
+**File:** `src/utils/scheduleExport.ts`, `tests/unit/scheduleExport.test.ts`
+1. RED — extend `makeEmployee` in the test to accept an optional `area`; add cases:
+   - area-only filter narrows body rows to that area's employees;
+   - area + position together apply AND semantics (only employees matching both);
+   - `areaFilter: 'all'` (and omitted) is a no-op (all rows);
+   - PDF subtitle emits combined `Filtered: <area> · <position>` (assert via `mockText`).
+2. GREEN —
+   - add `areaFilter?: string` to `ScheduleExportOptions`;
+   - keep a shift when its employee matches active position **and** active area
+     (guard each with `f && f !== 'all'`);
+   - build subtitle from `[areaFilter, positionFilter].filter(f => f && f !== 'all')`,
+     render one line `Filtered: <parts joined by " · ">` when non-empty.
+3. Run `npm test -- scheduleExport`; COMMIT.
+
+## Task 2 — `ScheduleExportDialog.tsx`: accept + apply areaFilter (depends on Task 1)
+**File:** `src/components/scheduling/ScheduleExportDialog.tsx`
+1. Add `areaFilter?: string` to props and destructure.
+2. Rename `positionFilteredShifts` → `filteredShifts`; apply area + position in the
+   memo; add `areaFilter` to deps; update consumers (`allEmployeesWithShifts`,
+   `getShiftDisplay`).
+3. Preview header: render the combined "Filtered:" label (area first), replacing the
+   position-only line.
+4. Pass `areaFilter` into `generateSchedulePDF` in `handleExport`.
+5. `npm run typecheck`; COMMIT. (Behavior covered by Task 4 E2E; component is
+   Sonar-excluded.)
+
+## Task 3 — `Scheduling.tsx`: forward areaFilter (depends on Task 2)
+**File:** `src/pages/Scheduling.tsx`
+1. Add `areaFilter={areaFilter}` to the `<ScheduleExportDialog>` props (~line 2109).
+2. `npm run typecheck`; COMMIT.
+
+## Task 4 — E2E: area filter narrows print dialog (depends on Tasks 2–3)
+**File:** `tests/e2e/schedule-print-export.spec.ts`
+1. Seed employees across two distinct `area` values (so `#area-filter` renders —
+   it only shows when `areas.length > 1`); give each a shift this week.
+2. Set the grid `#area-filter` to one area, open Print, assert the dialog employee
+   list contains only that area's employees and excludes the other area's.
+3. Run the spec; COMMIT.
+
+## Verify (Phase 8)
+`npm test` (unit), `npm run typecheck`, `npm run lint`, `npm run build`, and the new
+E2E spec. SonarCloud new-code coverage ≥80% comes from Task 1 unit tests on
+`scheduleExport.ts` (the only measured file).

--- a/docs/superpowers/specs/2026-06-23-schedule-print-area-filter-design.md
+++ b/docs/superpowers/specs/2026-06-23-schedule-print-area-filter-design.md
@@ -1,0 +1,79 @@
+# Design: Area filter in schedule print/PDF
+
+**Date:** 2026-06-23
+**Branch:** `feature/schedule-print-area-filter`
+**Status:** Approved
+
+## Problem
+
+The schedule grid (`src/pages/Scheduling.tsx`) already exposes **Area** and
+**Position** filter dropdowns in the toolbar next to the **Print** button. When the
+user prints, `positionFilter` and `groupBy` are forwarded into
+`ScheduleExportDialog` and `generateSchedulePDF` — but **`areaFilter` is never
+passed through**. Filtering the grid to an area (e.g. "Wetzel's") therefore has no
+effect on the printed PDF.
+
+This is effectively a bug: Position is respected on the printout, Area is silently
+dropped. The user wants to print, e.g., **Wetzel's + backroom** employees only.
+
+## Decision
+
+Thread the existing `areaFilter` grid state through the print pipeline and apply it
+**exactly like `positionFilter`** — single-select, `'all'` = no filter, **AND**
+semantics across the two dimensions. This mirrors the canonical grid helper
+`filterEmployeesForScheduleView` (`Scheduling.tsx:142`), which already does
+`area === areaFilter` **and** `position === positionFilter`.
+
+No new dialog controls (user chose "just respect grid filters" over adding
+selectors inside the print dialog). The PDF/print becomes WYSIWYG with the grid's
+current Area + Position filters.
+
+## Changes
+
+### 1. `src/utils/scheduleExport.ts` (measured by SonarCloud)
+- Add `areaFilter?: string` to `ScheduleExportOptions`.
+- Extend the shift-filtering predicate: a shift is kept when the owning employee
+  matches **both** the active position filter **and** the active area filter.
+  Guard each dimension with `filter && filter !== 'all'`.
+- Extend the PDF "Filtered:" subtitle to list all active filters on one line, area
+  first: `Filtered: Wetzel's · backroom`. Replaces the current position-only line.
+
+### 2. `src/components/scheduling/ScheduleExportDialog.tsx` (Sonar-excluded; E2E-covered)
+- Add `areaFilter?: string` prop.
+- Apply the area filter alongside the position filter in the shift-filtering memo;
+  rename `positionFilteredShifts` → `filteredShifts` for accuracy and update its two
+  consumers (`allEmployeesWithShifts`, `getShiftDisplay`).
+- Show the same combined "Filtered:" label in the preview header.
+- Pass `areaFilter` into `generateSchedulePDF` in `handleExport`.
+
+### 3. `src/pages/Scheduling.tsx` (Sonar-excluded)
+- Pass `areaFilter={areaFilter}` to `<ScheduleExportDialog>` (one line).
+
+### 4. Tests
+- **Unit** (`tests/unit/scheduleExport.test.ts`): extend `makeEmployee` to accept an
+  `area`; add cases — (a) area-only filter narrows rows; (b) area + position together
+  apply AND semantics; (c) `areaFilter: 'all'`/undefined is a no-op; (d) combined
+  "Filtered:" subtitle text is emitted.
+- **E2E** (`tests/e2e/schedule-print-export.spec.ts`): seed employees across two
+  distinct areas (so the `#area-filter` Select renders — it only shows when
+  `areas.length > 1`), set the grid area filter, open Print, assert the dialog list
+  narrows to that area.
+
+## Edge cases
+- Employees with **no `area`** are excluded when an area filter is active
+  (`undefined !== 'Wetzel's'`) — matches grid behavior, correct.
+- Over-filtering to zero employees → empty PDF table / Download disabled at 0
+  selected. Pre-existing behavior for position over-filtering, unchanged.
+- `Scheduling.tsx:441` already resets `areaFilter` to `'all'` when the selected area
+  disappears, so the value forwarded to the dialog is always valid.
+
+## Coverage strategy
+`scheduleExport.ts` lives under `src/utils/**`, which is **not** in
+`sonar.coverage.exclusions`, so its new branches must reach ≥80% new-code coverage
+via the unit tests above. `ScheduleExportDialog.tsx` (`src/components/**/*.tsx`) and
+`Scheduling.tsx` (`src/pages/**/*.tsx`) are Sonar-excluded and covered by E2E.
+
+## Rejected alternative
+Dedicated Area/Position selectors inside the print dialog (pre-filled from grid,
+overridable). More flexible but more UI surface and diverges from the single-select
+grid filters; the user opted for the simpler grid-respecting behavior.

--- a/docs/superpowers/specs/2026-06-23-schedule-print-area-filter-design.md
+++ b/docs/superpowers/specs/2026-06-23-schedule-print-area-filter-design.md
@@ -77,3 +77,29 @@ via the unit tests above. `ScheduleExportDialog.tsx` (`src/components/**/*.tsx`)
 Dedicated Area/Position selectors inside the print dialog (pre-filled from grid,
 overridable). More flexible but more UI surface and diverges from the single-select
 grid filters; the user opted for the simpler grid-respecting behavior.
+
+## Design review (Phase 2.5) — folded feedback
+Frontend reviewer: no critical issues; approach (mirror `positionFilter`) endorsed.
+
+- **Shift-level vs employee-level filtering (clarification).** The export path filters
+  at the **shift** level (`shifts.filter(s => emp?.area === areaFilter && …)`), then
+  derives the employee list from the surviving shifts. The grid helper
+  `filterEmployeesForScheduleView` filters at the **employee** level. The print dialog
+  only ever lists employees who have a shift this week, so the two converge; the area
+  predicate (`emp.area === areaFilter`) is identical in both. We deliberately keep the
+  existing shift-level approach to stay symmetric with the current `positionFilter`
+  path — `areaFilter` is added as a parallel clause in the same predicate.
+- **`area: undefined` test case (accepted).** Add an explicit unit case asserting an
+  employee with no `area` is excluded when an area filter is active.
+- **Rename `positionFilteredShifts` → `filteredShifts` (accepted).** Update BOTH
+  consumers — the `allEmployeesWithShifts` memo AND `getShiftDisplay` (line ~106).
+
+### Decided trade-offs (deferred, with rationale)
+- **Dialog restyle to the CLAUDE.md icon-box / `p-0 gap-0` pattern — DEFERRED.** The
+  reviewer noted `ScheduleExportDialog`'s `DialogContent` predates the current dialog
+  styling guide. Restyling the whole dialog is unrelated to area filtering and out of
+  scope for this fast, minimal change; tracked as separate polish.
+- **Long area-name overflow in the centered preview label — DEFERRED.** Pre-existing
+  for `positionFilter` too; cosmetic, not a regression.
+- **`colSpan={8}` hard-coded in the preview empty/overflow rows — NO ACTION.**
+  Pre-existing, static, untouched by this change.

--- a/progress.md
+++ b/progress.md
@@ -1,0 +1,37 @@
+# Progress: Area filter in schedule print/PDF
+
+## Spec
+- Design: docs/superpowers/specs/2026-06-23-schedule-print-area-filter-design.md (committed 157c6ad0)
+- Plan: docs/superpowers/plans/2026-06-23-schedule-print-area-filter-plan.md (committed 121a5e3a)
+
+## Current Phase
+Phase 4 (Build, strict TDD) — task 1/4 COMPLETED; task 2/4 next
+
+## Completed Tasks
+- [x] Phase 0: Consult lessons
+- [x] Phase 1: Isolate (worktree feature/schedule-print-area-filter @ origin/main cc99cbc8)
+- [x] Phase 2: Brainstorm + design doc committed (157c6ad0)
+- [x] Phase 3: Plan committed (121a5e3a)
+- [x] Phase 2.5: Frontend review folded (0c755ec9) — no critical; dialog restyle deferred
+- [x] Preflight: environment verified (gh, jq, node, coderabbit all present; codex present; .env.local symlink OK; SONAR_TOKEN set, SONAR_PROJECT_KEY missing)
+- [x] Phase 4, Task 1: scheduleExport.ts — areaFilter in PDF generation (08f854c0)
+  - Added `areaFilter?: string` to `ScheduleExportOptions`
+  - AND semantics: shift kept only when employee matches BOTH positionFilter AND areaFilter
+  - Combined "Filtered: <area> · <position>" subtitle (area first)
+  - 9 new unit tests (all green); 13 total passing
+- [ ] Phase 4, Task 2: ScheduleExportDialog.tsx — accept + apply areaFilter (queued)
+- [ ] Phase 4, Task 3: Scheduling.tsx — forward areaFilter to dialog (queued)
+- [ ] Phase 4, Task 4: E2E — area filter narrows print dialog (queued)
+
+## CI Status
+- PR: not yet created
+
+## Key Decisions
+- User chose "just respect grid filters" (no new dialog controls); wants this FAST.
+- Apply areaFilter exactly like positionFilter: single-select, 'all' = no filter, AND semantics.
+- Coverage: scheduleExport.ts (utils) Sonar-measured → unit tests; dialog + page Sonar-excluded → E2E.
+- supabase-design-reviewer SKIPPED (no DB/RLS/edge/SQL surface — pure client filtering).
+
+## Environment gotcha
+- Bash cwd is the MAIN repo, not the worktree. Use `git -C <worktree>` and worktree-absolute
+  paths for all file ops. Worktree: .claude/worktrees/feature+schedule-print-area-filter

--- a/progress.md
+++ b/progress.md
@@ -5,7 +5,7 @@
 - Plan: docs/superpowers/plans/2026-06-23-schedule-print-area-filter-plan.md (committed 121a5e3a)
 
 ## Current Phase
-Phase 4 (Build, strict TDD) — task 1/4 COMPLETED; task 2/4 next
+Phase 4 (Build, strict TDD) — task 2/4 COMPLETED; task 3/4 next
 
 ## Completed Tasks
 - [x] Phase 0: Consult lessons
@@ -19,7 +19,13 @@ Phase 4 (Build, strict TDD) — task 1/4 COMPLETED; task 2/4 next
   - AND semantics: shift kept only when employee matches BOTH positionFilter AND areaFilter
   - Combined "Filtered: <area> · <position>" subtitle (area first)
   - 9 new unit tests (all green); 13 total passing
-- [ ] Phase 4, Task 2: ScheduleExportDialog.tsx — accept + apply areaFilter (queued)
+- [x] Phase 4, Task 2: ScheduleExportDialog.tsx — accept + apply areaFilter (d8ae21b6)
+  - Added `areaFilter?: string` to ScheduleExportDialogProps and destructured it
+  - Renamed `positionFilteredShifts` → `filteredShifts`; applied AND semantics (area + position)
+  - Updated both consumers: `allEmployeesWithShifts` memo and `getShiftDisplay`
+  - Preview header: combined "Filtered: <area> · <position>" label (area first)
+  - Passed `areaFilter` into `generateSchedulePDF` in handleExport
+  - Typecheck clean; 4612 unit tests passing
 - [ ] Phase 4, Task 3: Scheduling.tsx — forward areaFilter to dialog (queued)
 - [ ] Phase 4, Task 4: E2E — area filter narrows print dialog (queued)
 

--- a/progress.md
+++ b/progress.md
@@ -48,6 +48,33 @@ Phase 4 (Build, strict TDD) — ALL TASKS COMPLETE
 - Pre-existing `text-primary` on Printer icon and full dialog restyle (icon-box/p-0 pattern) are both deferred per design spec.
 - No commits needed.
 
+## Phase 7a: Codex Adversarial Review — COMPLETE
+Finding (minor, pre-existing pattern, out of scope for this change):
+- MINOR: `src/utils/scheduleExport.ts` line 265 — PDF footer totals hours from `filteredShifts` without applying `selectedEmployeeIds`. Employee deselection in ScheduleExportDialog produces an inconsistent PDF: the table and staff count only include selected employees, but the `Total: <hours>` footer still sums every shift matching the area/position filters. Trigger: open Print, deselect one employee, download PDF — their row is absent but their hours remain in the total. This is a pre-existing defect untouched by the area-filter change; not introduced by this diff.
+
+## Phase 7: PR Setup — COMPLETE
+- git diff origin/main...HEAD captured (30,774 chars, under 60K limit, not truncated)
+- git log origin/main..HEAD --oneline captured (11 commits)
+- Design doc contents captured
+- Ready for PR creation
+
+## Phase 7a: OCR Rules Review — COMPLETE
+Findings (DO NOT fix in 7a — Phase 7b handles fixes):
+- MAJOR: `any[]` without explanatory comment used in 3 new unit-test `body.map` calls (scheduleExport.test.ts lines ~162, 179, 213) — pre-existing pattern but new occurrences
+- MAJOR: `any[]`/`any` without explanatory comment in 7 new E2E lines (schedule-print-export.spec.ts lines ~243–269) — pre-existing pattern in file, new test inlines it instead of reusing `setupWithShifts` helper
+- MINOR: Duplicate filter-parts logic — `ScheduleExportDialog.tsx:107–110` evaluates `filter && filter !== "all" ? filter : null` inline for two props, while `scheduleExport.ts:84` centralizes this in `active()`. Dialog could call a shared helper but doesn't.
+- MINOR: New E2E test inlines its own setup (signUp + insertEmployees + insertShifts) instead of extracting or reusing the existing `setupWithShifts` helper — code duplication in test file.
+
+## Phase 7b: Fold Review Findings — COMPLETE (commit 126730b7)
+Findings triaged from 6 reviewers (security, performance, maintainability, sound-logic, ocr-rules, codex):
+- FIXED (MAJOR): Added explanatory `any` comments in scheduleExport.test.ts (×4) and schedule-print-export.spec.ts (×2 comment blocks) — OCR rule requires comment when `any` is necessary.
+- SKIPPED (MINOR): Redundant `active()` call on scheduleExport.ts:133 — style/nit, skipped per instructions.
+- SKIPPED (MINOR): Duplicate filter-active inline logic in ScheduleExportDialog.tsx:107–110 — style/nit.
+- SKIPPED (MINOR): E2E test setup duplication vs setupWithShifts — style/nit.
+- NOTED (MINOR, pre-existing): Footer total hours ignores selectedEmployeeIds — pre-existing defect, not introduced by this diff; flagged as spawn task if needed.
+- All security/performance/sound-logic reviewers: no findings.
+- 4612 unit tests passing; typecheck clean after fix.
+
 ## CI Status
 - PR: not yet created
 

--- a/progress.md
+++ b/progress.md
@@ -30,7 +30,7 @@ Phase 4 (Build, strict TDD) — ALL TASKS COMPLETE
   - Added `areaFilter={areaFilter}` to `<ScheduleExportDialog>` (~line 2110)
   - Typecheck clean (no output); all 31 unit tests green
   - One-line change; completes the prop pipeline from grid state to PDF generator
-- [x] Phase 4, Task 4: E2E — area filter narrows print dialog (COMMIT_SHA_PLACEHOLDER)
+- [x] Phase 4, Task 4: E2E — area filter narrows print dialog (b08c3920)
   - Added `area filter narrows the employee list in print dialog` test to schedule-print-export.spec.ts
   - Seeds 4 employees across 2 areas (Front of House + Back of House) with shifts
   - Sets #area-filter to "Back of House", opens Print, asserts only BOH employees in dialog

--- a/progress.md
+++ b/progress.md
@@ -5,7 +5,7 @@
 - Plan: docs/superpowers/plans/2026-06-23-schedule-print-area-filter-plan.md (committed 121a5e3a)
 
 ## Current Phase
-Phase 4 (Build, strict TDD) — task 2/4 COMPLETED; task 3/4 next
+Phase 4 (Build, strict TDD) — ALL TASKS COMPLETE
 
 ## Completed Tasks
 - [x] Phase 0: Consult lessons
@@ -26,8 +26,16 @@ Phase 4 (Build, strict TDD) — task 2/4 COMPLETED; task 3/4 next
   - Preview header: combined "Filtered: <area> · <position>" label (area first)
   - Passed `areaFilter` into `generateSchedulePDF` in handleExport
   - Typecheck clean; 4612 unit tests passing
-- [ ] Phase 4, Task 3: Scheduling.tsx — forward areaFilter to dialog (queued)
-- [ ] Phase 4, Task 4: E2E — area filter narrows print dialog (queued)
+- [x] Phase 4, Task 3: Scheduling.tsx — forward areaFilter to dialog (e9e2aaf5)
+  - Added `areaFilter={areaFilter}` to `<ScheduleExportDialog>` (~line 2110)
+  - Typecheck clean (no output); all 31 unit tests green
+  - One-line change; completes the prop pipeline from grid state to PDF generator
+- [x] Phase 4, Task 4: E2E — area filter narrows print dialog (COMMIT_SHA_PLACEHOLDER)
+  - Added `area filter narrows the employee list in print dialog` test to schedule-print-export.spec.ts
+  - Seeds 4 employees across 2 areas (Front of House + Back of House) with shifts
+  - Sets #area-filter to "Back of House", opens Print, asserts only BOH employees in dialog
+  - Asserts "2 of 2" count and Front of House employees are absent
+  - Typecheck clean; 31 unit tests still passing
 
 ## CI Status
 - PR: not yet created

--- a/progress.md
+++ b/progress.md
@@ -75,8 +75,26 @@ Findings triaged from 6 reviewers (security, performance, maintainability, sound
 - All security/performance/sound-logic reviewers: no findings.
 - 4612 unit tests passing; typecheck clean after fix.
 
+## Phase 7c: CodeRabbit CLI Review — COMPLETE (clean=true)
+CodeRabbit returned 2 minor findings, both in files NOT changed by this feature:
+- SKIPPED: Import order in `ScheduleOverviewPanel.tsx` — not in diff (out of scope)
+- SKIPPED: Logic question in `timePunchProcessing.ts` — not in diff (out of scope)
+No actionable findings in the feature's changed files. No commits needed.
+
+## Phase 8: Verify — COMPLETE (all checks pass)
+
+### Check Results
+- npm run test: PASS — 4612 unit tests pass, 2 skipped (353/354 test files)
+- npm run typecheck: PASS — tsc --noEmit outputs nothing (clean)
+- npm run lint: PASS-BASELINE — 1438 problems (pre-existing; main branch has 50,037 problems in different node_modules). No new lint errors introduced by this branch. Changed files have same or fewer errors than origin/main.
+- npm run test:db: NEAR-PASS — 1373/1374 pass; 1 pre-existing failure in `enqueue_weekly_brief_jobs returns 0 enqueued when no restaurants exist` (also fails on origin/main)
+- npm run test:e2e: PASS — 7/7 schedule-print-export.spec.ts tests pass; 17 passed, 12 skipped, 22 did not run (all E2E); exit code 0. Note: prior E2E failures were due to a different worktree's dev server (payroll-sort-group-area) being reused on port 4173; killed that server and re-ran against correct worktree.
+- npm run build: PASS — built in ~27 min, exit code 0, chunk size warnings are pre-existing
+
+### No fixes were needed — all failures were pre-existing or environment issues.
+
 ## CI Status
-- PR: not yet created
+- PR: https://github.com/toyiyo/nimble-pnl/pull/551 (opened Phase 9a)
 
 ## Key Decisions
 - User chose "just respect grid filters" (no new dialog controls); wants this FAST.

--- a/progress.md
+++ b/progress.md
@@ -37,6 +37,17 @@ Phase 4 (Build, strict TDD) — ALL TASKS COMPLETE
   - Asserts "2 of 2" count and Front of House employees are absent
   - Typecheck clean; 31 unit tests still passing
 
+## Phase 6: Simplify — COMPLETE (commit 94201885)
+- scheduleExport.ts: extracted `active(f)` helper; eliminated 3 duplicated `f && f !== "all"` ternaries and the redundant `activePositionFilter`/`activeAreaFilter` intermediates.
+- ScheduleExportDialog.tsx: replaced IIFE `{(() => { … })()}` in JSX with `const activeFilterParts` above the return.
+- No behaviour change; 31 unit tests passing; typecheck clean.
+
+## Phase 5: UI Review — COMPLETE (no violations in new code)
+- ScheduleExportDialog.tsx new code: semantic tokens only, no direct colors, no new a11y issues.
+- Scheduling.tsx change: single prop line, no styling.
+- Pre-existing `text-primary` on Printer icon and full dialog restyle (icon-box/p-0 pattern) are both deferred per design spec.
+- No commits needed.
+
 ## CI Status
 - PR: not yet created
 

--- a/src/components/scheduling/ScheduleExportDialog.tsx
+++ b/src/components/scheduling/ScheduleExportDialog.tsx
@@ -25,6 +25,7 @@ interface ScheduleExportDialogProps {
   weekEnd: Date;
   restaurantName?: string;
   positionFilter?: string;
+  areaFilter?: string;
   groupBy?: GroupByMode;
 }
 
@@ -37,6 +38,7 @@ export const ScheduleExportDialog = ({
   weekEnd,
   restaurantName = "Restaurant",
   positionFilter,
+  areaFilter,
   groupBy = 'none',
 }: ScheduleExportDialogProps) => {
   const [includePositions, setIncludePositions] = useState(true);
@@ -45,24 +47,24 @@ export const ScheduleExportDialog = ({
 
   const weekDays = eachDayOfInterval({ start: weekStart, end: weekEnd });
 
-  // Filter shifts by position
-  const positionFilteredShifts = useMemo(() =>
-    positionFilter && positionFilter !== "all"
-      ? shifts.filter(s => {
-          const emp = employees.find(e => e.id === s.employee_id);
-          return emp?.position === positionFilter;
-        })
-      : shifts,
-    [shifts, employees, positionFilter]
+  // Filter shifts by area and position (AND semantics)
+  const filteredShifts = useMemo(() =>
+    shifts.filter(s => {
+      const emp = employees.find(e => e.id === s.employee_id);
+      if (positionFilter && positionFilter !== "all" && emp?.position !== positionFilter) return false;
+      if (areaFilter && areaFilter !== "all" && emp?.area !== areaFilter) return false;
+      return true;
+    }),
+    [shifts, employees, positionFilter, areaFilter]
   );
 
-  // All employees who have shifts (after position filter)
+  // All employees who have shifts (after area + position filter)
   const allEmployeesWithShifts = useMemo(() => {
-    const ids = new Set(positionFilteredShifts.map(s => s.employee_id));
+    const ids = new Set(filteredShifts.map(s => s.employee_id));
     return employees
       .filter(emp => ids.has(emp.id))
       .sort((a, b) => a.name.localeCompare(b.name));
-  }, [positionFilteredShifts, employees]);
+  }, [filteredShifts, employees]);
 
   // Initialize selection to all employees when dialog opens or list changes
   useEffect(() => {
@@ -103,7 +105,7 @@ export const ScheduleExportDialog = ({
   const totalAvailable = allEmployeesWithShifts.length;
 
   const getShiftDisplay = (employeeId: string, day: Date): string => {
-    const dayShifts = positionFilteredShifts.filter(
+    const dayShifts = filteredShifts.filter(
       s => s.employee_id === employeeId && isSameDay(parseISO(s.start_time), day)
     );
     if (dayShifts.length === 0) return "OFF";
@@ -132,6 +134,7 @@ export const ScheduleExportDialog = ({
       includePositions,
       includeHoursSummary,
       positionFilter,
+      areaFilter,
       groupBy,
       selectedEmployeeIds,
     });
@@ -158,11 +161,17 @@ export const ScheduleExportDialog = ({
             <div className="text-xs text-muted-foreground">
               Week of {format(weekStart, "MMM d")} - {format(weekEnd, "MMM d, yyyy")}
             </div>
-            {positionFilter && positionFilter !== "all" && (
-              <div className="text-xs text-muted-foreground mt-1">
-                Filtered: {positionFilter}
-              </div>
-            )}
+            {(() => {
+              const parts = [
+                areaFilter && areaFilter !== "all" ? areaFilter : null,
+                positionFilter && positionFilter !== "all" ? positionFilter : null,
+              ].filter(Boolean);
+              return parts.length > 0 ? (
+                <div className="text-xs text-muted-foreground mt-1">
+                  Filtered: {parts.join(" · ")}
+                </div>
+              ) : null;
+            })()}
             {groupBy !== 'none' && (
               <div className="text-xs text-muted-foreground mt-1">
                 Grouped by: {groupBy === 'area' ? 'Area' : 'Position'}

--- a/src/components/scheduling/ScheduleExportDialog.tsx
+++ b/src/components/scheduling/ScheduleExportDialog.tsx
@@ -104,6 +104,11 @@ export const ScheduleExportDialog = ({
   const selectedCount = selectedEmployeeIds.size;
   const totalAvailable = allEmployeesWithShifts.length;
 
+  const activeFilterParts = [
+    areaFilter && areaFilter !== "all" ? areaFilter : null,
+    positionFilter && positionFilter !== "all" ? positionFilter : null,
+  ].filter(Boolean) as string[];
+
   const getShiftDisplay = (employeeId: string, day: Date): string => {
     const dayShifts = filteredShifts.filter(
       s => s.employee_id === employeeId && isSameDay(parseISO(s.start_time), day)
@@ -161,17 +166,11 @@ export const ScheduleExportDialog = ({
             <div className="text-xs text-muted-foreground">
               Week of {format(weekStart, "MMM d")} - {format(weekEnd, "MMM d, yyyy")}
             </div>
-            {(() => {
-              const parts = [
-                areaFilter && areaFilter !== "all" ? areaFilter : null,
-                positionFilter && positionFilter !== "all" ? positionFilter : null,
-              ].filter(Boolean);
-              return parts.length > 0 ? (
-                <div className="text-xs text-muted-foreground mt-1">
-                  Filtered: {parts.join(" · ")}
-                </div>
-              ) : null;
-            })()}
+            {activeFilterParts.length > 0 && (
+              <div className="text-xs text-muted-foreground mt-1">
+                Filtered: {activeFilterParts.join(" · ")}
+              </div>
+            )}
             {groupBy !== 'none' && (
               <div className="text-xs text-muted-foreground mt-1">
                 Grouped by: {groupBy === 'area' ? 'Area' : 'Position'}

--- a/src/pages/Scheduling.tsx
+++ b/src/pages/Scheduling.tsx
@@ -2107,6 +2107,7 @@ const Scheduling = () => {
         weekEnd={weekEnd}
         restaurantName={selectedRestaurant?.restaurant?.name}
         positionFilter={positionFilter}
+        areaFilter={areaFilter}
         groupBy={groupBy}
       />
 

--- a/src/utils/scheduleExport.ts
+++ b/src/utils/scheduleExport.ts
@@ -13,6 +13,7 @@ export interface ScheduleExportOptions {
   includePositions?: boolean;
   includeHoursSummary?: boolean;
   positionFilter?: string;
+  areaFilter?: string;
   groupBy?: GroupByMode;
   selectedEmployeeIds?: Set<string>;
 }
@@ -71,6 +72,7 @@ export const generateSchedulePDF = (options: ScheduleExportOptions): void => {
     includePositions = true,
     includeHoursSummary = false,
     positionFilter,
+    areaFilter,
     groupBy = 'none',
     selectedEmployeeIds,
   } = options;
@@ -78,11 +80,16 @@ export const generateSchedulePDF = (options: ScheduleExportOptions): void => {
   // Get days of the week
   const weekDays = eachDayOfInterval({ start: weekStart, end: weekEnd });
 
-  // Filter shifts by position if needed
-  const filteredShifts = positionFilter && positionFilter !== "all"
+  // Filter shifts by position and/or area if needed (AND semantics)
+  const activePositionFilter = positionFilter && positionFilter !== "all" ? positionFilter : null;
+  const activeAreaFilter = areaFilter && areaFilter !== "all" ? areaFilter : null;
+  const filteredShifts = (activePositionFilter || activeAreaFilter)
     ? shifts.filter(s => {
         const emp = employees.find(e => e.id === s.employee_id);
-        return emp?.position === positionFilter;
+        if (!emp) return false;
+        if (activePositionFilter && emp.position !== activePositionFilter) return false;
+        if (activeAreaFilter && emp.area !== activeAreaFilter) return false;
+        return true;
       })
     : shifts;
 
@@ -120,10 +127,14 @@ export const generateSchedulePDF = (options: ScheduleExportOptions): void => {
 
   // Filter/grouping indicators
   let subtitleY = margin + 35;
-  if (positionFilter && positionFilter !== "all") {
+  const filterParts = [
+    areaFilter && areaFilter !== "all" ? areaFilter : null,
+    positionFilter && positionFilter !== "all" ? positionFilter : null,
+  ].filter(Boolean) as string[];
+  if (filterParts.length > 0) {
     doc.setFontSize(10);
     doc.setTextColor(100);
-    doc.text(`Filtered: ${positionFilter}`, pageWidth / 2, subtitleY, { align: "center" });
+    doc.text(`Filtered: ${filterParts.join(" · ")}`, pageWidth / 2, subtitleY, { align: "center" });
     subtitleY += 14;
   }
   if (groupBy !== 'none') {

--- a/src/utils/scheduleExport.ts
+++ b/src/utils/scheduleExport.ts
@@ -80,15 +80,18 @@ export const generateSchedulePDF = (options: ScheduleExportOptions): void => {
   // Get days of the week
   const weekDays = eachDayOfInterval({ start: weekStart, end: weekEnd });
 
+  /** Returns the filter value when active, null when "all" or absent. */
+  const active = (f?: string) => (f && f !== "all" ? f : null);
+  const activePosition = active(positionFilter);
+  const activeArea = active(areaFilter);
+
   // Filter shifts by position and/or area if needed (AND semantics)
-  const activePositionFilter = positionFilter && positionFilter !== "all" ? positionFilter : null;
-  const activeAreaFilter = areaFilter && areaFilter !== "all" ? areaFilter : null;
-  const filteredShifts = (activePositionFilter || activeAreaFilter)
+  const filteredShifts = (activePosition || activeArea)
     ? shifts.filter(s => {
         const emp = employees.find(e => e.id === s.employee_id);
         if (!emp) return false;
-        if (activePositionFilter && emp.position !== activePositionFilter) return false;
-        if (activeAreaFilter && emp.area !== activeAreaFilter) return false;
+        if (activePosition && emp.position !== activePosition) return false;
+        if (activeArea && emp.area !== activeArea) return false;
         return true;
       })
     : shifts;
@@ -127,10 +130,7 @@ export const generateSchedulePDF = (options: ScheduleExportOptions): void => {
 
   // Filter/grouping indicators
   let subtitleY = margin + 35;
-  const filterParts = [
-    areaFilter && areaFilter !== "all" ? areaFilter : null,
-    positionFilter && positionFilter !== "all" ? positionFilter : null,
-  ].filter(Boolean) as string[];
+  const filterParts = [active(areaFilter), active(positionFilter)].filter(Boolean) as string[];
   if (filterParts.length > 0) {
     doc.setFontSize(10);
     doc.setTextColor(100);

--- a/tests/e2e/schedule-print-export.spec.ts
+++ b/tests/e2e/schedule-print-export.spec.ts
@@ -240,6 +240,8 @@ test.describe('Schedule Print/Export — Employee Selection', () => {
     await signUpAndCreateRestaurant(page, testUser);
     await exposeSupabaseHelpers(page);
 
+    // page.evaluate crosses the browser boundary; helpers are injected at runtime so
+    // their return types are unknown — `any` is necessary here (same pattern as setupWithShifts).
     const restaurantId = await page.evaluate(() => (window as any).__getRestaurantId());
     expect(restaurantId).toBeTruthy();
 
@@ -256,6 +258,7 @@ test.describe('Schedule Print/Export — Employee Selection', () => {
       },
     );
 
+    // employees is the serialised JSON returned by __insertEmployees — shape is any[]
     const frontAlice = (employees as any[]).find((e: any) => e.name === 'Front Alice');
     const frontBob = (employees as any[]).find((e: any) => e.name === 'Front Bob');
     const backCarlos = (employees as any[]).find((e: any) => e.name === 'Back Carlos');

--- a/tests/e2e/schedule-print-export.spec.ts
+++ b/tests/e2e/schedule-print-export.spec.ts
@@ -232,4 +232,82 @@ test.describe('Schedule Print/Export — Employee Selection', () => {
     // Verify filename pattern
     expect(download.suggestedFilename()).toMatch(/^schedule_\d{4}-\d{2}-\d{2}_to_\d{4}-\d{2}-\d{2}\.pdf$/);
   });
+
+  test('area filter narrows the employee list in print dialog', async ({ page }) => {
+    // Seed employees across two distinct areas so #area-filter renders
+    // (the area filter select is only shown when areas.length > 1)
+    const testUser = generateTestUser('areaprint');
+    await signUpAndCreateRestaurant(page, testUser);
+    await exposeSupabaseHelpers(page);
+
+    const restaurantId = await page.evaluate(() => (window as any).__getRestaurantId());
+    expect(restaurantId).toBeTruthy();
+
+    const employees = await page.evaluate(
+      ({ emps, restId }: any) => (window as any).__insertEmployees(emps, restId),
+      {
+        emps: [
+          { name: 'Front Alice', position: 'Server', area: 'Front of House', status: 'active', is_active: true, compensation_type: 'hourly', hourly_rate: 1500 },
+          { name: 'Front Bob', position: 'Server', area: 'Front of House', status: 'active', is_active: true, compensation_type: 'hourly', hourly_rate: 1500 },
+          { name: 'Back Carlos', position: 'Cook', area: 'Back of House', status: 'active', is_active: true, compensation_type: 'hourly', hourly_rate: 1800 },
+          { name: 'Back Diana', position: 'Cook', area: 'Back of House', status: 'active', is_active: true, compensation_type: 'hourly', hourly_rate: 1800 },
+        ],
+        restId: restaurantId,
+      },
+    );
+
+    const frontAlice = (employees as any[]).find((e: any) => e.name === 'Front Alice');
+    const frontBob = (employees as any[]).find((e: any) => e.name === 'Front Bob');
+    const backCarlos = (employees as any[]).find((e: any) => e.name === 'Back Carlos');
+    const backDiana = (employees as any[]).find((e: any) => e.name === 'Back Diana');
+
+    const monday = getMondayOfCurrentWeek();
+    const tzStr = getTimezoneOffsetString();
+    const mondayStr = formatDate(monday);
+
+    await page.evaluate(
+      ({ rows, restId }: any) => (window as any).__insertShifts(rows, restId),
+      {
+        rows: [
+          { employee_id: frontAlice.id, start_time: `${mondayStr}T08:00:00${tzStr}`, end_time: `${mondayStr}T16:00:00${tzStr}`, position: 'Server', status: 'scheduled', break_duration: 0, is_published: false, locked: false },
+          { employee_id: frontBob.id, start_time: `${mondayStr}T10:00:00${tzStr}`, end_time: `${mondayStr}T18:00:00${tzStr}`, position: 'Server', status: 'scheduled', break_duration: 0, is_published: false, locked: false },
+          { employee_id: backCarlos.id, start_time: `${mondayStr}T06:00:00${tzStr}`, end_time: `${mondayStr}T14:00:00${tzStr}`, position: 'Cook', status: 'scheduled', break_duration: 0, is_published: false, locked: false },
+          { employee_id: backDiana.id, start_time: `${mondayStr}T07:00:00${tzStr}`, end_time: `${mondayStr}T15:00:00${tzStr}`, position: 'Cook', status: 'scheduled', break_duration: 0, is_published: false, locked: false },
+        ],
+        restId: restaurantId,
+      },
+    );
+
+    await page.goto('/scheduling');
+    await page.waitForURL(/\/scheduling/, { timeout: 8000 });
+    await page.waitForTimeout(2000);
+
+    // Set area filter to "Back of House"
+    // The #area-filter select is only rendered when areas.length > 1
+    const areaSelect = page.locator('#area-filter');
+    await expect(areaSelect).toBeVisible({ timeout: 10000 });
+    await areaSelect.click();
+    await page.getByRole('option', { name: 'Back of House' }).click();
+    await page.waitForTimeout(500);
+
+    // Open print dialog
+    const printButton = page.getByRole('button', { name: 'Print', exact: true });
+    await expect(printButton).toBeEnabled({ timeout: 8000 });
+    await printButton.click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+    await expect(dialog.getByText(/of \d+/)).toBeVisible({ timeout: 5000 });
+
+    // Only Back of House employees should appear
+    await expect(empCheckbox(dialog, 'Back Carlos')).toBeVisible();
+    await expect(empCheckbox(dialog, 'Back Diana')).toBeVisible();
+
+    // Front of House employees should NOT appear
+    await expect(empCheckbox(dialog, 'Front Alice')).not.toBeVisible();
+    await expect(empCheckbox(dialog, 'Front Bob')).not.toBeVisible();
+
+    // Count should show "2 of 2"
+    await expect(dialog.getByText('2 of 2')).toBeVisible();
+  });
 });

--- a/tests/unit/scheduleExport.test.ts
+++ b/tests/unit/scheduleExport.test.ts
@@ -23,11 +23,12 @@ vi.mock("jspdf-autotable", () => ({ default: mockAutoTable }));
 import { generateSchedulePDF } from "@/utils/scheduleExport";
 import type { Shift, Employee } from "@/types/scheduling";
 
-const makeEmployee = (id: string, name: string, position = "Cook"): Employee =>
+const makeEmployee = (id: string, name: string, position = "Cook", area?: string): Employee =>
   ({
     id,
     name,
     position,
+    area,
     restaurant_id: "r1",
     status: "active",
     is_active: true,
@@ -125,5 +126,149 @@ describe("generateSchedulePDF", () => {
 
     const body = mockAutoTable.mock.calls[0][1].body;
     expect(body).toHaveLength(0);
+  });
+
+  describe("areaFilter", () => {
+    const areaEmployees = [
+      makeEmployee("e1", "Ana Garcia", "Cook", "Wetzel's"),
+      makeEmployee("e2", "Bob Smith", "Server", "Bar"),
+      makeEmployee("e3", "Carlos Rivera", "Cook", "Wetzel's"),
+      makeEmployee("e4", "Diana Prince", "Manager"),  // no area
+    ];
+
+    const areaShifts = [
+      makeShift("e1", 0),
+      makeShift("e2", 0),
+      makeShift("e3", 0),
+      makeShift("e4", 0),
+    ];
+
+    const areaBaseOptions = {
+      shifts: areaShifts,
+      employees: areaEmployees,
+      weekStart: new Date("2026-03-24"),
+      weekEnd: new Date("2026-03-30"),
+      restaurantName: "Test Restaurant",
+    };
+
+    it("narrows rows to employees in the specified area", () => {
+      generateSchedulePDF({
+        ...areaBaseOptions,
+        areaFilter: "Wetzel's",
+      });
+
+      const body = mockAutoTable.mock.calls[0][1].body;
+      expect(body).toHaveLength(2);
+      const names = body.map((row: any[]) => row[0].content as string);
+      expect(names.some(n => n.includes("Ana Garcia"))).toBe(true);
+      expect(names.some(n => n.includes("Carlos Rivera"))).toBe(true);
+      expect(names.some(n => n.includes("Bob Smith"))).toBe(false);
+      expect(names.some(n => n.includes("Diana Prince"))).toBe(false);
+    });
+
+    it("applies AND semantics when both areaFilter and positionFilter are active", () => {
+      generateSchedulePDF({
+        ...areaBaseOptions,
+        areaFilter: "Wetzel's",
+        positionFilter: "Cook",
+      });
+
+      const body = mockAutoTable.mock.calls[0][1].body;
+      // Only Wetzel's Cooks: Ana Garcia and Carlos Rivera (both match area AND position)
+      expect(body).toHaveLength(2);
+      const names = body.map((row: any[]) => row[0].content as string);
+      expect(names.some(n => n.includes("Ana Garcia"))).toBe(true);
+      expect(names.some(n => n.includes("Carlos Rivera"))).toBe(true);
+    });
+
+    it("AND semantics: area matches but position does not → excluded", () => {
+      generateSchedulePDF({
+        ...areaBaseOptions,
+        areaFilter: "Wetzel's",
+        positionFilter: "Server",  // no Wetzel's Servers
+      });
+
+      const body = mockAutoTable.mock.calls[0][1].body;
+      expect(body).toHaveLength(0);
+    });
+
+    it("treats areaFilter 'all' as no-op (all employees retained)", () => {
+      generateSchedulePDF({
+        ...areaBaseOptions,
+        areaFilter: "all",
+      });
+
+      const body = mockAutoTable.mock.calls[0][1].body;
+      expect(body).toHaveLength(4);
+    });
+
+    it("treats omitted areaFilter as no-op (all employees retained)", () => {
+      generateSchedulePDF({
+        ...areaBaseOptions,
+        // no areaFilter key at all
+      });
+
+      const body = mockAutoTable.mock.calls[0][1].body;
+      expect(body).toHaveLength(4);
+    });
+
+    it("excludes employees with no area when an area filter is active", () => {
+      generateSchedulePDF({
+        ...areaBaseOptions,
+        areaFilter: "Bar",
+      });
+
+      const body = mockAutoTable.mock.calls[0][1].body;
+      expect(body).toHaveLength(1);
+      const names = body.map((row: any[]) => row[0].content as string);
+      expect(names.some(n => n.includes("Bob Smith"))).toBe(true);
+      // Diana Prince (no area) must be excluded
+      expect(names.some(n => n.includes("Diana Prince"))).toBe(false);
+    });
+
+    it("emits combined 'Filtered: <area> · <position>' subtitle when both filters active", () => {
+      generateSchedulePDF({
+        ...areaBaseOptions,
+        areaFilter: "Wetzel's",
+        positionFilter: "Cook",
+      });
+
+      const filteredCall = mockText.mock.calls.find(
+        (c: any[]) => typeof c[0] === "string" && c[0].startsWith("Filtered:")
+      );
+      expect(filteredCall).toBeDefined();
+      expect(filteredCall![0]).toContain("Wetzel's");
+      expect(filteredCall![0]).toContain("Cook");
+      expect(filteredCall![0]).toContain("·");
+    });
+
+    it("emits 'Filtered: <area>' subtitle when only areaFilter is active", () => {
+      generateSchedulePDF({
+        ...areaBaseOptions,
+        areaFilter: "Bar",
+      });
+
+      const filteredCall = mockText.mock.calls.find(
+        (c: any[]) => typeof c[0] === "string" && c[0].startsWith("Filtered:")
+      );
+      expect(filteredCall).toBeDefined();
+      expect(filteredCall![0]).toBe("Filtered: Bar");
+    });
+
+    it("emits no area in subtitle when areaFilter is 'all'", () => {
+      generateSchedulePDF({
+        ...areaBaseOptions,
+        areaFilter: "all",
+        positionFilter: "Cook",
+      });
+
+      const filteredCall = mockText.mock.calls.find(
+        (c: any[]) => typeof c[0] === "string" && c[0].startsWith("Filtered:")
+      );
+      expect(filteredCall).toBeDefined();
+      // Should only contain position, not 'all'
+      expect(filteredCall![0]).toBe("Filtered: Cook");
+      expect(filteredCall![0]).not.toContain("all");
+    });
   });
 });

--- a/tests/unit/scheduleExport.test.ts
+++ b/tests/unit/scheduleExport.test.ts
@@ -159,6 +159,7 @@ describe("generateSchedulePDF", () => {
 
       const body = mockAutoTable.mock.calls[0][1].body;
       expect(body).toHaveLength(2);
+      // jspdf-autotable body rows are untyped at the mock boundary
       const names = body.map((row: any[]) => row[0].content as string);
       expect(names.some(n => n.includes("Ana Garcia"))).toBe(true);
       expect(names.some(n => n.includes("Carlos Rivera"))).toBe(true);
@@ -176,6 +177,7 @@ describe("generateSchedulePDF", () => {
       const body = mockAutoTable.mock.calls[0][1].body;
       // Only Wetzel's Cooks: Ana Garcia and Carlos Rivera (both match area AND position)
       expect(body).toHaveLength(2);
+      // jspdf-autotable body rows are untyped at the mock boundary
       const names = body.map((row: any[]) => row[0].content as string);
       expect(names.some(n => n.includes("Ana Garcia"))).toBe(true);
       expect(names.some(n => n.includes("Carlos Rivera"))).toBe(true);
@@ -220,6 +222,7 @@ describe("generateSchedulePDF", () => {
 
       const body = mockAutoTable.mock.calls[0][1].body;
       expect(body).toHaveLength(1);
+      // jspdf-autotable body rows are untyped at the mock boundary
       const names = body.map((row: any[]) => row[0].content as string);
       expect(names.some(n => n.includes("Bob Smith"))).toBe(true);
       // Diana Prince (no area) must be excluded
@@ -233,6 +236,7 @@ describe("generateSchedulePDF", () => {
         positionFilter: "Cook",
       });
 
+      // jspdf text() call args are untyped at the mock boundary
       const filteredCall = mockText.mock.calls.find(
         (c: any[]) => typeof c[0] === "string" && c[0].startsWith("Filtered:")
       );
@@ -248,6 +252,7 @@ describe("generateSchedulePDF", () => {
         areaFilter: "Bar",
       });
 
+      // jspdf text() call args are untyped at the mock boundary
       const filteredCall = mockText.mock.calls.find(
         (c: any[]) => typeof c[0] === "string" && c[0].startsWith("Filtered:")
       );
@@ -262,6 +267,7 @@ describe("generateSchedulePDF", () => {
         positionFilter: "Cook",
       });
 
+      // jspdf text() call args are untyped at the mock boundary
       const filteredCall = mockText.mock.calls.find(
         (c: any[]) => typeof c[0] === "string" && c[0].startsWith("Filtered:")
       );


### PR DESCRIPTION
## Summary

- **Bug fix**: the schedule grid's Area filter was silently dropped when printing; only Position was respected. Print is now WYSIWYG with both grid filters.
- Added `areaFilter?: string` to `ScheduleExportOptions` in `scheduleExport.ts`; shift-keep predicate now applies Area **AND** Position with identical `'all'`/undefined guard semantics.
- PDF "Filtered:" subtitle lists both active filters on one line, area first: `Filtered: Wetzel's · backroom`.
- Added `areaFilter?: string` prop to `ScheduleExportDialog`; renamed `positionFilteredShifts` → `filteredShifts`; preview header shows combined label; prop forwarded to `generateSchedulePDF`.
- One-line change in `Scheduling.tsx`: `areaFilter={areaFilter}` passed to `<ScheduleExportDialog>` — completes the prop pipeline from grid state to PDF generator.
- No new dialog controls; user chose "just respect grid filters" over adding selectors inside the print dialog.

Design doc: `docs/superpowers/specs/2026-06-23-schedule-print-area-filter-design.md`

## Test plan

- [ ] Unit tests (`scheduleExport.test.ts`): 13 tests covering area-only filter, area+position AND semantics, `'all'`/undefined no-op, and combined subtitle text — all green (`npm test`)
- [ ] E2E test (`schedule-print-export.spec.ts`): seeds employees across two distinct areas, sets `#area-filter` to one area, opens Print dialog, asserts only that area's employees appear (and the other area's are absent) — passes (`npm run test:e2e`)
- [ ] `npm run typecheck` — clean (no output)
- [ ] `npm run build` — passes (exit code 0)
- [ ] `npm run test:db` — 1373/1374 pass; 1 pre-existing failure also present on `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)