### PR TITLE
fix(focus): Postgres-libcurl HTTP transport (completes #557 — Deno TLS is blocked by Focus)

### DIFF
--- a/supabase/functions/_shared/focusHttpFetch.ts
+++ b/supabase/functions/_shared/focusHttpFetch.ts
@@ -1,0 +1,108 @@
+/**
+ * focusHttpFetch.ts
+ *
+ * A `fetch`-compatible transport that routes Focus POS HTTP calls through the
+ * Postgres `focus_http_request` RPC (libcurl / OpenSSL).
+ *
+ * Why: Focus's legacy Azure/IIS servers reset Deno's (rustls) TLS handshake, so
+ * Supabase Edge Functions cannot reach Focus with the built-in `fetch`. Postgres
+ * libcurl connects fine (same OpenSSL stack as curl/Node). This adapter is
+ * injected as `deps.fetch`, so focusPortalClient / focusReportClient keep ALL
+ * their login / cookie / redirect / parse logic unchanged — only the socket
+ * moves to Postgres.
+ *
+ * The RPC does not follow redirects (so a 302 + Set-Cookie is surfaced for the
+ * cookie jar) and applies its own libcurl timeout, so `redirect` and `signal`
+ * from the RequestInit are intentionally ignored here.
+ */
+
+interface RpcHeader {
+  field: string;
+  value: string;
+}
+
+interface RpcResult {
+  status: number;
+  headers: RpcHeader[] | null;
+  body: string | null;
+}
+
+/** Minimal Supabase client surface this adapter needs. */
+export interface RpcClient {
+  rpc(
+    fn: string,
+    args: Record<string, unknown>,
+  ): Promise<{ data: unknown; error: { message: string } | null }>;
+}
+
+/** Build a minimal Response-like object from the RPC result. */
+function toResponse(r: RpcResult): Response {
+  const headers = r.headers ?? [];
+  const get = (name: string): string | null => {
+    const lc = name.toLowerCase();
+    const found = headers.find((x) => (x.field ?? '').toLowerCase() === lc);
+    return found ? found.value : null;
+  };
+  const getSetCookie = (): string[] =>
+    headers.filter((x) => (x.field ?? '').toLowerCase() === 'set-cookie').map((x) => x.value);
+  const bodyText = r.body ?? '';
+
+  return {
+    status: r.status,
+    ok: r.status >= 200 && r.status < 300,
+    headers: { get, getSetCookie } as unknown as Headers,
+    text: () => Promise.resolve(bodyText),
+    // Some callers `await res.body?.cancel()`; provide a no-op so it's safe.
+    body: { cancel: () => Promise.resolve() } as unknown as ReadableStream<Uint8Array>,
+  } as unknown as Response;
+}
+
+/** Normalise a RequestInit's headers (Headers | array | record) to a plain object. */
+function headersToObject(h: HeadersInit | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!h) return out;
+  if (h instanceof Headers) {
+    h.forEach((v, k) => (out[k] = v));
+  } else if (Array.isArray(h)) {
+    for (const [k, v] of h) out[k] = v;
+  } else {
+    Object.assign(out, h);
+  }
+  return out;
+}
+
+/**
+ * Returns a `fetch`-like function bound to a Supabase service-role client.
+ * Only method / headers / body are honoured (redirect + timeout are handled by
+ * the `focus_http_request` RPC).
+ */
+export function makeFocusHttpFetch(client: RpcClient): typeof fetch {
+  const focusFetch = async (
+    input: string | URL | Request,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : (input as Request).url;
+    const method = (init?.method ?? 'GET').toUpperCase();
+    const headers = headersToObject(init?.headers);
+    const body =
+      init?.body == null ? null : typeof init.body === 'string' ? init.body : String(init.body);
+
+    const { data, error } = await client.rpc('focus_http_request', {
+      p_url: url,
+      p_method: method,
+      p_headers: headers,
+      p_body: body,
+    });
+    if (error) {
+      throw new Error(`focus_http_request transport failed: ${error.message}`);
+    }
+    return toResponse(data as RpcResult);
+  };
+
+  return focusFetch as unknown as typeof fetch;
+}

--- a/supabase/functions/focus-bulk-sync/index.ts
+++ b/supabase/functions/focus-bulk-sync/index.ts
@@ -18,6 +18,7 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { handleBulkSync } from '../_shared/focusBulkSyncHandler.ts';
+import { makeFocusHttpFetch } from '../_shared/focusHttpFetch.ts';
 // Deno server runtime does NOT have globalThis.DOMParser (browser-only API).
 // Import deno_dom so we can pass a working DOMParser to parseRevenueCenterReport.
 import { DOMParser } from 'https://deno.land/x/deno_dom@v0.1.43/deno-dom-wasm.ts';
@@ -42,7 +43,7 @@ serve(async (req: Request) => {
 
     const res = await handleBulkSync(req, {
       serviceClient,
-      fetch: globalThis.fetch,
+      fetch: makeFocusHttpFetch(serviceClient),
       sleep: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
       now: () => Date.now(),
       serviceRoleKey: supabaseServiceKey,

--- a/supabase/functions/focus-save-connection/index.ts
+++ b/supabase/functions/focus-save-connection/index.ts
@@ -19,6 +19,7 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { handleSaveConnection } from '../_shared/focusSaveConnectionHandler.ts';
+import { makeFocusHttpFetch } from '../_shared/focusHttpFetch.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -44,7 +45,7 @@ serve(async (req: Request) => {
     // Service-role client: used for all writes (bypasses RLS per review S3).
     const serviceClient = createClient(supabaseUrl, supabaseServiceKey);
 
-    const res = await handleSaveConnection(req, { userClient, serviceClient, fetch: globalThis.fetch });
+    const res = await handleSaveConnection(req, { userClient, serviceClient, fetch: makeFocusHttpFetch(serviceClient) });
 
     // Attach CORS headers to the handler's response.
     const body = await res.arrayBuffer();

--- a/supabase/functions/focus-sync-data/index.ts
+++ b/supabase/functions/focus-sync-data/index.ts
@@ -23,6 +23,7 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { handleSyncData } from '../_shared/focusSyncDataHandler.ts';
+import { makeFocusHttpFetch } from '../_shared/focusHttpFetch.ts';
 // Deno server runtime does NOT have globalThis.DOMParser (browser-only API).
 // Import deno_dom so we can pass a working DOMParser to parseRevenueCenterReport.
 import { DOMParser } from 'https://deno.land/x/deno_dom@v0.1.43/deno-dom-wasm.ts';
@@ -54,7 +55,7 @@ serve(async (req: Request) => {
     const res = await handleSyncData(req, {
       userClient,
       serviceClient,
-      fetch: globalThis.fetch,
+      fetch: makeFocusHttpFetch(serviceClient),
       domParser: new DOMParser(),
     });
 

--- a/supabase/functions/focus-test-connection/index.ts
+++ b/supabase/functions/focus-test-connection/index.ts
@@ -20,6 +20,7 @@
 import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { handleTestConnection } from '../_shared/focusTestConnectionHandler.ts';
+import { makeFocusHttpFetch } from '../_shared/focusHttpFetch.ts';
 // Deno server runtime does NOT have globalThis.DOMParser (browser-only API).
 // Import deno_dom so we can pass a working DOMParser to parseRevenueCenterReport.
 import { DOMParser } from 'https://deno.land/x/deno_dom@v0.1.43/deno-dom-wasm.ts';
@@ -51,7 +52,7 @@ serve(async (req: Request) => {
     const res = await handleTestConnection(req, {
       userClient,
       serviceClient,
-      fetch: globalThis.fetch,
+      fetch: makeFocusHttpFetch(serviceClient),
       domParser: new DOMParser(),
     });
 

--- a/supabase/migrations/20260628030000_focus_http_transport.sql
+++ b/supabase/migrations/20260628030000_focus_http_transport.sql
@@ -1,0 +1,105 @@
+-- =====================================================================
+-- FOCUS POS — POSTGRES HTTP TRANSPORT
+--
+-- Why this exists: Focus's legacy Azure/IIS servers reset Deno's (rustls)
+-- TLS handshake, so Supabase Edge Functions (Deno) cannot fetch from Focus.
+-- curl / Node / Python / Postgres-libcurl (OpenSSL) all connect fine. So the
+-- edge functions delegate ONLY the socket to Postgres via the `http`
+-- extension (libcurl), keeping all login/parse logic in Deno.
+--
+-- Security:
+--   * focus_http_request is SECURITY DEFINER + SSRF-guarded (https + *.myfocuspos.com).
+--   * Callable by service_role ONLY (the edge functions); never anon/authenticated.
+--   * The raw http* extension functions are revoked from PUBLIC/anon/authenticated
+--     so they can't be used as a generic SSRF primitive — only this guarded
+--     wrapper (running as definer) can reach them.
+-- =====================================================================
+
+CREATE EXTENSION IF NOT EXISTS http WITH SCHEMA extensions;
+
+-- Lock down the raw http* functions: only the definer of focus_http_request
+-- (and superusers) may use libcurl directly.
+DO $$
+DECLARE r record;
+BEGIN
+  FOR r IN
+    SELECT p.oid::regprocedure AS sig
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'extensions' AND p.proname LIKE 'http%'
+  LOOP
+    EXECUTE format('REVOKE ALL ON FUNCTION %s FROM PUBLIC, anon, authenticated', r.sig);
+  END LOOP;
+END $$;
+
+-- ─────────────────────────────────────────────────────────────────────
+-- focus_http_request — SSRF-guarded HTTP transport for the Focus edge fns.
+--   Returns jsonb { status int, headers [{field,value}...], body text }.
+--   Does NOT follow redirects (so a 302 + Set-Cookie is surfaced to the
+--   caller, which manages the cookie jar in Deno). Bounded timeout.
+-- ─────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.focus_http_request(
+  p_url     text,
+  p_method  text  DEFAULT 'GET',
+  p_headers jsonb DEFAULT '{}'::jsonb,
+  p_body    text  DEFAULT NULL
+) RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions
+AS $$
+DECLARE
+  v_headers extensions.http_header[] := ARRAY[]::extensions.http_header[];
+  v_ctype   text := NULL;
+  v_key     text;
+  v_val     text;
+  v_resp    extensions.http_response;
+  v_out     jsonb := '[]'::jsonb;
+  h         extensions.http_header;
+BEGIN
+  -- SSRF guard: https only, host must be (sub.)myfocuspos.com (no userinfo).
+  IF p_url !~* '^https://([a-z0-9-]+\.)*myfocuspos\.com([/?#].*)?$' THEN
+    RAISE EXCEPTION 'focus_http_request: refused url (must be https *.myfocuspos.com): %', p_url;
+  END IF;
+
+  -- Build request headers; route Content-Type into the request content_type slot.
+  FOR v_key, v_val IN SELECT key, value FROM jsonb_each_text(coalesce(p_headers, '{}'::jsonb)) LOOP
+    IF lower(v_key) = 'content-type' THEN
+      v_ctype := v_val;
+    ELSE
+      v_headers := v_headers || ROW(v_key, v_val)::extensions.http_header;
+    END IF;
+  END LOOP;
+
+  -- Capture redirects (don't follow) + bound the request time.
+  PERFORM extensions.http_set_curlopt('CURLOPT_FOLLOWLOCATION', '0');
+  PERFORM extensions.http_set_curlopt('CURLOPT_TIMEOUT', '25');
+
+  v_resp := extensions.http(
+    ROW(
+      upper(p_method)::extensions.http_method,
+      p_url,
+      v_headers,
+      v_ctype,
+      p_body
+    )::extensions.http_request
+  );
+
+  PERFORM extensions.http_reset_curlopt();
+
+  IF v_resp.headers IS NOT NULL THEN
+    FOREACH h IN ARRAY v_resp.headers LOOP
+      v_out := v_out || jsonb_build_object('field', h.field, 'value', h.value);
+    END LOOP;
+  END IF;
+
+  RETURN jsonb_build_object('status', v_resp.status, 'headers', v_out, 'body', v_resp.content);
+END;
+$$;
+
+-- service_role only (the edge functions); never end users.
+REVOKE ALL ON FUNCTION public.focus_http_request(text, text, jsonb, text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.focus_http_request(text, text, jsonb, text) TO service_role;
+
+COMMENT ON FUNCTION public.focus_http_request(text, text, jsonb, text) IS
+  'SSRF-guarded libcurl transport for Focus POS edge functions (Deno rustls cannot reach Focus IIS). service_role only.';

--- a/supabase/tests/43_focus_sync_hardening.sql
+++ b/supabase/tests/43_focus_sync_hardening.sql
@@ -49,6 +49,7 @@ ON CONFLICT (user_id, restaurant_id) DO UPDATE SET role = 'owner';
 -- Connection (last_sync_time = 2 days ago so sync_all picks it up)
 INSERT INTO public.focus_connections (
   id, restaurant_id, report_base_url, report_path, store_id,
+  username, password_encrypted,
   is_active, connection_status, initial_sync_done, last_sync_time
 ) VALUES (
   '00000000-0000-0000-0000-f0c000000121',
@@ -56,6 +57,7 @@ INSERT INTO public.focus_connections (
   'https://mfprod-1.myfocuspos.com',
   '/ReportServer?/generalstorereports/revenuecenter',
   'SH999',
+  'sample.user', 'enc-placeholder',
   true, 'connected', true,
   now() - interval '2 days'
 )

--- a/supabase/tests/44_focus_http_transport.sql
+++ b/supabase/tests/44_focus_http_transport.sql
@@ -1,0 +1,48 @@
+-- pgTAP: focus_http_request transport RPC (Postgres libcurl) + SSRF guard.
+-- The SSRF guard rejects bad URLs BEFORE any network call, so these tests
+-- never touch the network.
+BEGIN;
+SELECT plan(7);
+
+-- http extension is enabled (the transport depends on libcurl).
+SELECT ok(
+  EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'http'),
+  'http extension is installed'
+);
+
+-- The transport function exists with the expected signature.
+SELECT has_function(
+  'public', 'focus_http_request', ARRAY['text', 'text', 'jsonb', 'text'],
+  'focus_http_request(text,text,jsonb,text) exists'
+);
+
+-- SSRF guard: reject a non-myfocuspos host (raises before any fetch).
+SELECT throws_ok(
+  $$ SELECT public.focus_http_request('https://evil.com/x', 'GET') $$,
+  NULL, NULL, 'rejects non-myfocuspos host'
+);
+
+-- SSRF guard: reject non-https.
+SELECT throws_ok(
+  $$ SELECT public.focus_http_request('http://my.focuspos.com/x', 'GET') $$,
+  NULL, NULL, 'rejects non-https scheme'
+);
+
+-- SSRF guard: reject a lookalike host (suffix attack).
+SELECT throws_ok(
+  $$ SELECT public.focus_http_request('https://evil.myfocuspos.com.attacker.com/x', 'GET') $$,
+  NULL, NULL, 'rejects lookalike host'
+);
+
+-- Least privilege: only service_role may execute it.
+SELECT ok(
+  has_function_privilege('service_role', 'public.focus_http_request(text,text,jsonb,text)', 'EXECUTE'),
+  'service_role can execute focus_http_request'
+);
+SELECT ok(
+  NOT has_function_privilege('authenticated', 'public.focus_http_request(text,text,jsonb,text)', 'EXECUTE'),
+  'authenticated cannot execute focus_http_request'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/tests/unit/focusHttpFetch.test.ts
+++ b/tests/unit/focusHttpFetch.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+import { makeFocusHttpFetch, type RpcClient } from '../../supabase/functions/_shared/focusHttpFetch.ts';
+
+function mockClient(result: { data?: unknown; error?: { message: string } | null }): {
+  client: RpcClient;
+  rpc: ReturnType<typeof vi.fn>;
+} {
+  const rpc = vi.fn().mockResolvedValue({ data: result.data ?? null, error: result.error ?? null });
+  return { client: { rpc } as unknown as RpcClient, rpc };
+}
+
+describe('makeFocusHttpFetch', () => {
+  it('maps a GET to the focus_http_request RPC and back to a Response', async () => {
+    const { client, rpc } = mockClient({
+      data: { status: 200, headers: [{ field: 'Content-Type', value: 'text/html' }], body: '<html>ok</html>' },
+    });
+    const fetchFn = makeFocusHttpFetch(client);
+
+    const res = await fetchFn('https://mfprod-1.myfocuspos.com/ReportServer');
+
+    expect(rpc).toHaveBeenCalledWith('focus_http_request', {
+      p_url: 'https://mfprod-1.myfocuspos.com/ReportServer',
+      p_method: 'GET',
+      p_headers: {},
+      p_body: null,
+    });
+    expect(res.status).toBe(200);
+    expect(res.ok).toBe(true);
+    expect(await res.text()).toBe('<html>ok</html>');
+  });
+
+  it('passes method, headers and body through (GET vs POST)', async () => {
+    const { client, rpc } = mockClient({ data: { status: 200, headers: [], body: '' } });
+    const fetchFn = makeFocusHttpFetch(client);
+
+    await fetchFn('https://my.focuspos.com/Login.aspx', {
+      method: 'post',
+      headers: { Cookie: 'ASP.NET_SessionId=abc', 'User-Agent': 'EasyShiftHQ-Focus/1.0' },
+      body: '__VIEWSTATE=xyz&user=sample',
+    });
+
+    expect(rpc).toHaveBeenCalledWith('focus_http_request', {
+      p_url: 'https://my.focuspos.com/Login.aspx',
+      p_method: 'POST',
+      p_headers: { Cookie: 'ASP.NET_SessionId=abc', 'User-Agent': 'EasyShiftHQ-Focus/1.0' },
+      p_body: '__VIEWSTATE=xyz&user=sample',
+    });
+  });
+
+  it('surfaces status, headers.get (case-insensitive) and getSetCookie() for the cookie jar', async () => {
+    const { client } = mockClient({
+      data: {
+        status: 302,
+        headers: [
+          { field: 'Location', value: '/Reports/NFocus.aspx' },
+          { field: 'Set-Cookie', value: 'AuthCookie=tok; path=/' },
+          { field: 'Set-Cookie', value: 'MyMenu=blob; path=/' },
+        ],
+        body: '',
+      },
+    });
+    const res = await makeFocusHttpFetch(client)('https://my.focuspos.com/Login.aspx', { method: 'POST' });
+
+    expect(res.status).toBe(302);
+    expect(res.ok).toBe(false);
+    expect(res.headers.get('location')).toBe('/Reports/NFocus.aspx'); // case-insensitive
+    // Both Set-Cookie headers returned (loginToPortal needs all of them)
+    const setCookies = (res.headers as Headers & { getSetCookie(): string[] }).getSetCookie();
+    expect(setCookies).toEqual(['AuthCookie=tok; path=/', 'MyMenu=blob; path=/']);
+  });
+
+  it('normalises a Headers instance', async () => {
+    const { client, rpc } = mockClient({ data: { status: 200, headers: [], body: '' } });
+    const h = new Headers();
+    h.set('Cookie', 'a=b');
+    await makeFocusHttpFetch(client)('https://my.focuspos.com/x', { headers: h });
+
+    expect(rpc.mock.calls[0][1].p_headers).toEqual({ cookie: 'a=b' });
+  });
+
+  it('throws when the RPC returns an error', async () => {
+    const { client } = mockClient({ error: { message: 'refused url' } });
+    await expect(makeFocusHttpFetch(client)('https://evil.example.com/x')).rejects.toThrow(
+      /focus_http_request transport failed: refused url/,
+    );
+  });
+
+  it('treats a null body in the RPC result as empty text', async () => {
+    const { client } = mockClient({ data: { status: 204, headers: null, body: null } });
+    const res = await makeFocusHttpFetch(client)('https://my.focuspos.com/x');
+    expect(await res.text()).toBe('');
+    expect((res.headers as Headers & { getSetCookie(): string[] }).getSetCookie()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Why

PR #557 (Focus POS integration) was **squash-merged at a stale commit** that did **not** include the HTTP-transport fix. As a result, the Focus integration currently in `main` cannot reach Focus from production: Focus's legacy Azure/IIS servers **reset Deno's (rustls) TLS handshake**, so the Supabase Edge Functions fail with `Connection reset by peer` and the setup form returns *"Edge Function returned a non-2xx status code."*

This PR lands the dropped fix so the merged integration actually works.

## Root cause

`curl` / Node / Python / **Postgres-libcurl** (all OpenSSL) connect to Focus fine; only Deno (rustls) is reset — server-specific TLS-fingerprint rejection by Focus's IIS. Confirmed by counter-example: the same Deno runtime reaches Lighthouse/Shift4 servers, just not Focus.

## Fix

Delegate **only the socket** to Postgres libcurl; all login/cookie/redirect/parse logic stays in Deno.

- **`20260628030000_focus_http_transport.sql`** — enables the `http` extension and adds `public.focus_http_request(url, method, headers, body)`:
  - `SECURITY DEFINER`, **SSRF-guarded** (https + `*.myfocuspos.com` only, no userinfo, lookalike-safe).
  - `service_role`-only `EXECUTE`; raw `extensions.http*` revoked from `PUBLIC`/`anon`/`authenticated` so it can't be used as a generic SSRF primitive.
  - Does **not** follow redirects (so a 302 + `Set-Cookie` is surfaced for the cookie jar); bounded 25s libcurl timeout.
- **`_shared/focusHttpFetch.ts`** — a `fetch`-shaped adapter over that RPC (case-insensitive `headers.get`, `getSetCookie()` returns **all** Set-Cookie values for the login jar, no-op `body.cancel()`). Injected as `deps.fetch`, so `focusPortalClient` / `focusReportClient` are unchanged.
- Wired into all four Focus edge functions (`focus-save-connection`, `focus-test-connection`, `focus-sync-data`, `focus-bulk-sync`).

## Tests

- `tests/unit/focusHttpFetch.test.ts` — 6 tests (GET/POST mapping, cookie jar, header normalisation, error + null-body paths).
- `supabase/tests/44_focus_http_transport.sql` — pgTAP plan(7): extension installed, function signature, SSRF guard rejects `evil.com` / non-https / lookalike host, `service_role` can execute & `authenticated` cannot.
- `supabase/tests/43_focus_sync_hardening.sql` — fixture fix (adds the now-required `username` / `password_encrypted` columns).

Local: typecheck clean · changed files lint clean · 66 focus unit tests pass.

## Note

The merged Focus integration in `main` is **non-functional until this lands** — anyone testing the setup form will get the non-2xx error. This is the missing piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
