### PR TITLE
fix(focus): unblock background backfill + import transaction timestamps

### DIFF
--- a/supabase/functions/_shared/focusBackfillBatch.ts
+++ b/supabase/functions/_shared/focusBackfillBatch.ts
@@ -5,23 +5,21 @@
  *
  * Processes up to `maxDays` days (newest-first, cursor-indexed) within a
  * wall-clock `budgetMs` window. Used by:
- *   - focusSyncDataHandler (manual kick: budgetMs=12_000, maxDays=5)
- *   - focusBackfillSyncHandler (cron: budgetMs≈50_000, maxDays=7)
+ *   - focusSyncDataHandler (manual kick: budgetMs=12_000, maxDays=3)
+ *   - focusBackfillSyncHandler (cron: budgetMs≈50_000, maxDays=5)
  *
  * Design ref: spec §5.1 + §8.3.
  *
- * Side effects: writes order rows (via processDayTransactions, each with
- * skipUnifiedSalesSync:true) and, after the loop, syncs the processed date range
- * into unified_sales via the sync_focus_transactions_to_unified_sales RPC. It does
- * NOT write the connection row — cursor / flag / last_sync_time persistence is the
- * caller's responsibility (with CAS per §8.1).
+ * Side effects: writes order rows only (via processDayTransactions, each with
+ * skipUnifiedSalesSync:true). It does NOT write the connection row — cursor / flag /
+ * last_sync_time persistence is the caller's responsibility (with CAS per §8.1) —
+ * and it does NOT aggregate unified_sales.
  *
- * Why the in-batch unified_sales sync: backfill days are written with
- * skipUnifiedSalesSync:true (a per-day RPC is too costly inside the CPU budget),
- * but the 6-hour transaction cron only re-syncs the last 2 business days — so
- * without this, backfilled history (days 3..90) would never reach unified_sales /
- * P&L. We sync the batch's own range here, and on completion do a full 90-day
- * reconciliation to close any gap left by a transient intermediate RPC failure.
+ * unified_sales aggregation for backfilled days is handled in Postgres by the
+ * 5-minute focus-transactions-unified-sales-sync cron (full-range for still-
+ * backfilling connections; migration 20260703120000). Running that RPC inside the
+ * edge worker previously caused HTTP 546 worker-CPU timeouts on busy multi-day
+ * batches, so it was moved out of the request path.
  */
 
 import {
@@ -197,37 +195,12 @@ export async function processBackfillBatch(
 
   const initialSyncDone = cursor >= targetDays;
 
-  // ── Sync the just-written days into unified_sales ──────────────────────────
-  // Backfill days were written with skipUnifiedSalesSync:true; the 6-hour
-  // transaction cron only covers the last 2 business days, so we must sync the
-  // batch's range here or the backfilled P&L history would never appear.
-  // On completion, sync the full 90-day window as a reconciliation backstop
-  // (covers any day whose per-batch RPC failed transiently).
-  if (daysProcessed > 0) {
-    const rangeStart = initialSyncDone
-      ? subtractDays(todayStr, targetDays) // full backfill window on completion
-      : subtractDays(todayStr, cursor); // oldest day processed this batch
-    const rangeEnd = initialSyncDone
-      ? subtractDays(todayStr, 1) // yesterday — newest backfill day
-      : subtractDays(todayStr, opts.syncCursor + 1); // newest day processed this batch
-
-    const { error: rpcError } = await deps.supabase.rpc(
-      'sync_focus_transactions_to_unified_sales',
-      {
-        p_restaurant_id: config.restaurantId,
-        p_start_date: rangeStart,
-        p_end_date: rangeEnd,
-      },
-    );
-    if (rpcError) {
-      // Non-fatal: orders are durably written. Log so the gap is visible; the
-      // completion full-window sync (or a later manual re-sync) re-covers it.
-      console.warn(
-        `focusBackfillBatch: unified_sales sync failed for ${config.restaurantId} ` +
-          `(${rangeStart}..${rangeEnd}): ${rpcError.message}`,
-      );
-    }
-  }
+  // unified_sales aggregation is intentionally NOT done here. Running the
+  // sync_focus_transactions_to_unified_sales RPC inside the edge worker caused
+  // HTTP 546 worker-CPU timeouts on busy multi-day batches. The aggregation now
+  // runs entirely in Postgres via the 5-minute focus-transactions-unified-sales-sync
+  // cron, which does a FULL-range sync for still-backfilling connections
+  // (migration 20260703120000). This worker only fetches + upserts focus_orders.
 
   return {
     syncCursor: cursor,

--- a/supabase/functions/_shared/focusBackfillSyncHandler.ts
+++ b/supabase/functions/_shared/focusBackfillSyncHandler.ts
@@ -15,7 +15,7 @@
  *  3. Per connection:
  *       a. Wall-clock budget check (80s). Break if exceeded.
  *       b. Decrypt api_secret_encrypted.
- *       c. processBackfillBatch({ budgetMs: ~50_000, maxDays: 7 }).
+ *       c. processBackfillBatch({ budgetMs: ~50_000, maxDays: 5 }).
  *       d. Persist cursor/flag/last_sync_time via CAS (§8.1).
  *       e. On batch error: also write connection_status='error' + last_error (§8.3).
  *       f. Per-restaurant exception caught → recorded in errors[], continue.
@@ -47,8 +47,10 @@ const LIMIT = 5;
 /** Total wall-clock budget for the entire cron run (80 seconds per spec §8.3). */
 const BUDGET_MS = 80_000;
 
-/** Maximum days to process per connection per tick (spec §8.3). */
-const MAX_DAYS_PER_CONNECTION = 7;
+/** Maximum days to process per connection per tick (spec §8.3).
+ *  Lowered 7→5: the worker no longer runs the unified_sales RPC (moved to a
+ *  Postgres cron), but fewer XML parses per tick keeps CPU well under the limit. */
+const MAX_DAYS_PER_CONNECTION = 5;
 
 /** Delay between restaurants in milliseconds. */
 const INTER_RESTAURANT_DELAY_MS = 2_000;

--- a/supabase/functions/_shared/focusSyncDataHandler.ts
+++ b/supabase/functions/_shared/focusSyncDataHandler.ts
@@ -17,7 +17,7 @@
  *          - Call processDateRangeTransactions synchronously.
  *          - Return { daysSynced, status }.
  *       b. Backfill (initial_sync_done=false):
- *          - Delegate to processBackfillBatch({ budgetMs:12_000, maxDays:5 }).
+ *          - Delegate to processBackfillBatch({ budgetMs:12_000, maxDays:3 }).
  *          - Persist cursor/flag/last_sync_time via CAS (§8.1).
  *          - On error: also write connection_status='error' + last_error (§8.3).
  *          - Return { syncCursor, initialSyncDone, status, backgrounded }.
@@ -391,7 +391,7 @@ export async function handleSyncData(
         timezone: tz,
         now,
         budgetMs: 12_000,
-        maxDays: 5,
+        maxDays: 3,
       });
 
       // Single timestamp shared across all fields in this update.

--- a/supabase/migrations/20260703120000_focus_backfill_reliability.sql
+++ b/supabase/migrations/20260703120000_focus_backfill_reliability.sql
@@ -1,0 +1,435 @@
+-- =====================================================
+-- Focus POS backfill reliability
+-- =====================================================
+-- Two production problems this fixes:
+--
+--   1. The focus-backfill-sync / focus-bulk-sync crons were rescheduled by
+--      20260702160000 to build their URL from current_setting('app.settings.supabase_url').
+--      That GUC is not set and CANNOT be set on Supabase (ALTER DATABASE ... SET is
+--      permission-denied for the postgres role), so the cron body's `WHERE url <> ''`
+--      guard is always false → the job "succeeds" with 0 rows and never calls the
+--      worker. (The follow-up edit that hardcoded the URL changed an ALREADY-APPLIED
+--      migration file, which Supabase skips — so it never took effect.) → Hardcode
+--      the public project URL here, in a NEW migration, exactly like the toast/shift4
+--      crons already do.
+--
+--   2. The backfill worker timed out (HTTP 546 / worker CPU limit) because it ran the
+--      unified_sales aggregation RPC inside the edge function. → Move that aggregation
+--      entirely into Postgres: the worker now only fetches + upserts focus_orders
+--      (fast), and sync_all_focus_transactions_to_unified_sales() does a FULL-range
+--      aggregation for still-backfilling connections, every 5 minutes, in-database
+--      (no edge CPU limit). Companion edge change: processBackfillBatch no longer
+--      calls the RPC.
+--
+-- Idempotent: unschedule guards precede every (re)schedule.
+-- =====================================================
+
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+CREATE EXTENSION IF NOT EXISTS pg_net;
+GRANT USAGE ON SCHEMA cron TO postgres;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 1. Hardcoded-URL, gate-less cron reschedule (backfill every 5 min; bulk every 6 h)
+-- ─────────────────────────────────────────────────────────────────────────────
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'focus-backfill-sync') THEN
+    PERFORM cron.unschedule('focus-backfill-sync');
+  END IF;
+END $$;
+
+SELECT cron.schedule(
+  'focus-backfill-sync',
+  '*/5 * * * *',
+  $cron$
+  SELECT net.http_post(
+    url     := 'https://ncdujvdgqtaunuyigflp.supabase.co/functions/v1/focus-backfill-sync',
+    headers := jsonb_build_object('Content-Type', 'application/json'),
+    body    := '{}'::jsonb,
+    timeout_milliseconds := 5000
+  );
+  $cron$
+);
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'focus-bulk-sync') THEN
+    PERFORM cron.unschedule('focus-bulk-sync');
+  END IF;
+END $$;
+
+SELECT cron.schedule(
+  'focus-bulk-sync',
+  '30 1,7,13,19 * * *',
+  $cron$
+  SELECT net.http_post(
+    url     := 'https://ncdujvdgqtaunuyigflp.supabase.co/functions/v1/focus-bulk-sync',
+    headers := jsonb_build_object('Content-Type', 'application/json'),
+    body    := '{}'::jsonb,
+    timeout_milliseconds := 5000
+  );
+  $cron$
+);
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 2. unified_sales aggregation moves fully into Postgres.
+--    Still-backfilling connections (initial_sync_done=false) get a FULL-range
+--    aggregation (NULL date window ⇒ all dates in _impl); connections that have
+--    finished backfilling get the light 3-day incremental window.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.sync_all_focus_transactions_to_unified_sales()
+RETURNS TABLE(restaurant_id uuid, rows_synced integer)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  r record;
+BEGIN
+  FOR r IN
+    SELECT fc.restaurant_id, fc.initial_sync_done
+    FROM public.focus_connections fc
+    WHERE fc.is_active = true
+    ORDER BY fc.last_sync_time ASC NULLS FIRST
+    LIMIT 5
+  LOOP
+    BEGIN
+      restaurant_id := r.restaurant_id;
+      IF r.initial_sync_done THEN
+        -- Incremental: 3-day lookback window (timezone-safe, matches prior behaviour).
+        rows_synced := public._sync_focus_transactions_to_unified_sales_impl(
+                         r.restaurant_id,
+                         (CURRENT_DATE - interval '3 days')::date,
+                         CURRENT_DATE
+                       );
+      ELSE
+        -- Backfill in progress: aggregate ALL dates already stored in focus_orders,
+        -- so the historical days the worker is importing reach unified_sales / P&L.
+        -- NULL date bounds ⇒ full range (see _impl p_start_date/p_end_date IS NULL).
+        rows_synced := public._sync_focus_transactions_to_unified_sales_impl(
+                         r.restaurant_id, NULL, NULL
+                       );
+      END IF;
+      RETURN NEXT;
+    EXCEPTION WHEN OTHERS THEN
+      RAISE WARNING
+        'sync_all_focus_transactions_to_unified_sales: failed for restaurant %: %',
+        r.restaurant_id, SQLERRM;
+    END;
+  END LOOP;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.sync_all_focus_transactions_to_unified_sales()
+  TO service_role;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 3. Run the transaction→unified_sales aggregation every 5 minutes (was every 6 h),
+--    so backfilled days appear in P&L within minutes while the import runs.
+-- ─────────────────────────────────────────────────────────────────────────────
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'focus-transactions-unified-sales-sync') THEN
+    PERFORM cron.unschedule('focus-transactions-unified-sales-sync');
+  END IF;
+END $$;
+
+SELECT cron.schedule(
+  'focus-transactions-unified-sales-sync',
+  '*/5 * * * *',
+  $$SELECT sync_all_focus_transactions_to_unified_sales()$$
+);
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 4. Populate unified_sales.sale_time from the Focus check timestamps.
+--
+--    The datafeed parser already captures TimeOpened/TimeClosed into
+--    focus_orders.opened_at_local / closed_at_local (text, restaurant-local,
+--    real feed format 'MM/DD/YYYY HH24:MI:SS'), but the impl never mapped them
+--    to unified_sales.sale_time — so every Focus row had a NULL time and the
+--    POS sales screen / busy-time (staffing) analysis had nothing to work with.
+--    Toast populates sale_time; Focus now mirrors it.
+--
+--    sale_time is added to all three row kinds (sale, discount, tip) and to the
+--    ON CONFLICT updates, so previously-imported rows self-heal on the next
+--    full-range sync (which §2 runs every 5 min while backfilling).
+-- ─────────────────────────────────────────────────────────────────────────────
+
+-- Tolerant local-time parser. focus_orders.opened_at_local is free text; a
+-- malformed value must yield NULL, never abort a sync batch.
+--   Accepts:  '06/29/2026 12:26:06'  (real Lynk datafeed, MM/DD/YYYY)
+--             '2026-06-29T12:26:06' / '2026-06-29 12:26:06'  (ISO variants)
+CREATE OR REPLACE FUNCTION public._focus_parse_local_time(p_raw text)
+RETURNS time
+LANGUAGE plpgsql
+IMMUTABLE
+STRICT
+AS $$
+BEGIN
+  IF p_raw ~ '^\d{1,2}/\d{1,2}/\d{4} \d{1,2}:\d{2}(:\d{2})?$' THEN
+    RETURN to_timestamp(p_raw, 'MM/DD/YYYY HH24:MI:SS')::time;
+  ELSIF p_raw ~ '^\d{4}-\d{2}-\d{2}[T ]\d{1,2}:\d{2}(:\d{2})?' THEN
+    RETURN (replace(p_raw, 'T', ' ')::timestamp)::time;
+  END IF;
+  RETURN NULL;
+EXCEPTION WHEN OTHERS THEN
+  RETURN NULL;  -- belt-and-braces: any parse surprise degrades to NULL
+END;
+$$;
+
+COMMENT ON FUNCTION public._focus_parse_local_time(text) IS
+  'Parses a Focus POS local timestamp string (MM/DD/YYYY HH24:MI:SS or ISO) '
+  'to a time-of-day. Returns NULL for NULL/malformed input — never raises.';
+
+CREATE OR REPLACE FUNCTION public._sync_focus_transactions_to_unified_sales_impl(
+  p_restaurant_id uuid,
+  p_start_date    date,   -- NULL = all dates
+  p_end_date      date    -- NULL = all dates
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+SET statement_timeout = '120s'
+AS $$
+DECLARE
+  v_count          integer := 0;
+  v_row_count      integer;
+  v_sync_start     timestamptz := clock_timestamp();
+  v_store_id       text;
+  v_order          record;
+  v_order_id       text;
+  v_sale_time      time;
+  v_current_ids    text[];
+BEGIN
+  -- Fetch the store_id from the most-recently-created active connection.
+  -- Filtering by is_active prevents stale/deleted connections from being used.
+  -- ORDER BY + LIMIT 1 makes the query deterministic when multiple rows exist.
+  SELECT fc.store_id INTO v_store_id
+  FROM public.focus_connections fc
+  WHERE fc.restaurant_id = p_restaurant_id
+    AND fc.is_active = true
+  ORDER BY fc.created_at DESC
+  LIMIT 1;
+
+  -- If no active connection found, there is nothing to key external_order_id on.
+  -- Proceeding with a NULL store_id would produce orphan unified_sales rows
+  -- (pattern: focus-unknown-YYYYMMDD-{check_id}) that can never be re-synced.
+  IF v_store_id IS NULL THEN
+    RAISE EXCEPTION
+      'sync_focus_transactions_to_unified_sales: no active focus_connections row '
+      'found for restaurant %', p_restaurant_id;
+  END IF;
+
+  -- GUC flag: skip per-row triggers during bulk sync (transaction-local).
+  PERFORM set_config('app.skip_unified_sales_triggers', 'true', true);
+
+  -- ── Iterate per check (focus_order) ────────────────────────────────────
+  FOR v_order IN
+    SELECT fo.business_date, fo.focus_check_id,
+           fo.opened_at_local, fo.closed_at_local
+    FROM public.focus_orders fo
+    WHERE fo.restaurant_id = p_restaurant_id
+      AND (p_start_date IS NULL OR fo.business_date >= p_start_date)
+      AND (p_end_date   IS NULL OR fo.business_date <= p_end_date)
+    ORDER BY fo.business_date, fo.focus_check_id
+  LOOP
+    v_order_id := 'focus-' || COALESCE(v_store_id, 'unknown')
+                  || '-' || to_char(v_order.business_date, 'YYYYMMDD')
+                  || '-' || v_order.focus_check_id;
+
+    -- Time-of-day for this check: prefer TimeOpened (when the customer
+    -- transacted — the busy-time signal), fall back to TimeClosed.
+    v_sale_time := COALESCE(
+      public._focus_parse_local_time(v_order.opened_at_local),
+      public._focus_parse_local_time(v_order.closed_at_local)
+    );
+
+    -- ── Step 1: Collect current external_item_ids (sale rows) ──────────────
+    SELECT ARRAY(
+      SELECT v_order_id || '__' || foi.item_key
+      FROM public.focus_order_items foi
+      WHERE foi.restaurant_id  = p_restaurant_id
+        AND foi.business_date  = v_order.business_date
+        AND foi.focus_check_id = v_order.focus_check_id
+        AND foi.price IS NOT NULL
+        AND foi.price != 0
+    ) INTO v_current_ids;
+
+    -- ── Step 2: DELETE orphan sale rows no longer in focus_order_items ─────
+    -- Only delete base (un-split) rows; parent_sale_id IS NULL guards user-
+    -- managed split/child rows from being silently removed on every sync.
+    DELETE FROM public.unified_sales us
+    WHERE us.restaurant_id     = p_restaurant_id
+      AND us.pos_system        = 'focus'
+      AND us.item_type         = 'sale'
+      AND us.sale_date         = v_order.business_date
+      AND us.external_order_id = v_order_id
+      AND us.parent_sale_id IS NULL
+      AND NOT (us.external_item_id = ANY(v_current_ids));
+
+    -- ── Step 3: UPSERT sale rows (one per priced item) ────────────────────
+    INSERT INTO public.unified_sales (
+      restaurant_id, pos_system,
+      external_order_id, external_item_id,
+      item_name, quantity, unit_price, total_price,
+      sale_date, sale_time, pos_category, item_type, synced_at
+    )
+    SELECT
+      foi.restaurant_id, 'focus',
+      v_order_id, v_order_id || '__' || foi.item_key,
+      foi.name, 1, foi.price, foi.price,
+      foi.business_date, v_sale_time, foi.report_group_id, 'sale', now()
+    FROM public.focus_order_items foi
+    WHERE foi.restaurant_id  = p_restaurant_id
+      AND foi.business_date  = v_order.business_date
+      AND foi.focus_check_id = v_order.focus_check_id
+      AND foi.price IS NOT NULL
+      AND foi.price != 0
+    ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
+      WHERE parent_sale_id IS NULL
+    DO UPDATE SET
+      item_name    = EXCLUDED.item_name,
+      unit_price   = EXCLUDED.unit_price,
+      total_price  = EXCLUDED.total_price,
+      sale_date    = EXCLUDED.sale_date,
+      sale_time    = EXCLUDED.sale_time,
+      pos_category = EXCLUDED.pos_category,
+      synced_at    = EXCLUDED.synced_at
+      -- category_id + is_categorized intentionally omitted →
+      -- preserves user-managed categorization on re-sync (design §4)
+    ;
+
+    GET DIAGNOSTICS v_row_count = ROW_COUNT;
+    v_count := v_count + v_row_count;
+
+    -- ── Step 4: UPSERT / DELETE discount offset rows ───────────────────────
+    -- Upsert items that have a non-zero discount.
+    -- Focus XML stores DiscountAmount as a negative value (e.g. -3.01).
+    -- Use != 0 (not > 0) so that negative amounts are also captured.
+    -- -ABS() normalises to negative regardless of stored sign.
+    INSERT INTO public.unified_sales (
+      restaurant_id, pos_system,
+      external_order_id, external_item_id,
+      item_name, quantity, unit_price, total_price,
+      sale_date, sale_time, item_type, adjustment_type, synced_at
+    )
+    SELECT
+      foi.restaurant_id, 'focus',
+      v_order_id, v_order_id || '__' || foi.item_key || '_discount',
+      'Discount - ' || COALESCE(foi.name, 'Item'), 1,
+      -ABS(foi.discount_amount), -ABS(foi.discount_amount),
+      foi.business_date, v_sale_time, 'discount', 'discount', now()
+    FROM public.focus_order_items foi
+    WHERE foi.restaurant_id  = p_restaurant_id
+      AND foi.business_date  = v_order.business_date
+      AND foi.focus_check_id = v_order.focus_check_id
+      AND foi.discount_amount != 0
+    ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
+      WHERE parent_sale_id IS NULL
+    DO UPDATE SET
+      item_name   = EXCLUDED.item_name,
+      unit_price  = EXCLUDED.unit_price,
+      total_price = EXCLUDED.total_price,
+      sale_date   = EXCLUDED.sale_date,
+      sale_time   = EXCLUDED.sale_time,
+      synced_at   = EXCLUDED.synced_at;
+
+    GET DIAGNOSTICS v_row_count = ROW_COUNT;
+    v_count := v_count + v_row_count;
+
+    -- Delete stale discount rows for items that no longer have a discount.
+    -- parent_sale_id IS NULL guards user-managed split rows.
+    DELETE FROM public.unified_sales us
+    WHERE us.restaurant_id     = p_restaurant_id
+      AND us.pos_system        = 'focus'
+      AND us.item_type         = 'discount'
+      AND us.sale_date         = v_order.business_date
+      AND us.external_order_id = v_order_id
+      AND us.parent_sale_id IS NULL
+      AND us.external_item_id NOT IN (
+        SELECT v_order_id || '__' || foi.item_key || '_discount'
+        FROM public.focus_order_items foi
+        WHERE foi.restaurant_id  = p_restaurant_id
+          AND foi.business_date  = v_order.business_date
+          AND foi.focus_check_id = v_order.focus_check_id
+          AND foi.discount_amount != 0
+      );
+
+    -- ── Step 5: UPSERT / DELETE tip offset rows ────────────────────────────
+    -- Upsert payments with a non-zero tip
+    INSERT INTO public.unified_sales (
+      restaurant_id, pos_system,
+      external_order_id, external_item_id,
+      item_name, quantity, unit_price, total_price,
+      sale_date, sale_time, item_type, adjustment_type, synced_at
+    )
+    SELECT
+      fp.restaurant_id, 'focus',
+      v_order_id, v_order_id || '_' || fp.payment_key || '_tip',
+      'Tip - ' || COALESCE(fp.name, 'Payment'), 1,
+      fp.tip, fp.tip,
+      fp.business_date, v_sale_time, 'tip', 'tip', now()
+    FROM public.focus_payments fp
+    WHERE fp.restaurant_id  = p_restaurant_id
+      AND fp.business_date  = v_order.business_date
+      AND fp.focus_check_id = v_order.focus_check_id
+      AND fp.tip != 0
+    ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
+      WHERE parent_sale_id IS NULL
+    DO UPDATE SET
+      item_name   = EXCLUDED.item_name,
+      unit_price  = EXCLUDED.unit_price,
+      total_price = EXCLUDED.total_price,
+      sale_date   = EXCLUDED.sale_date,
+      sale_time   = EXCLUDED.sale_time,
+      synced_at   = EXCLUDED.synced_at;
+
+    GET DIAGNOSTICS v_row_count = ROW_COUNT;
+    v_count := v_count + v_row_count;
+
+    -- Delete stale tip rows for payments that no longer have a tip.
+    -- parent_sale_id IS NULL guards user-managed split rows.
+    DELETE FROM public.unified_sales us
+    WHERE us.restaurant_id     = p_restaurant_id
+      AND us.pos_system        = 'focus'
+      AND us.item_type         = 'tip'
+      AND us.sale_date         = v_order.business_date
+      AND us.external_order_id = v_order_id
+      AND us.parent_sale_id IS NULL
+      AND us.external_item_id NOT IN (
+        SELECT v_order_id || '_' || fp.payment_key || '_tip'
+        FROM public.focus_payments fp
+        WHERE fp.restaurant_id  = p_restaurant_id
+          AND fp.business_date  = v_order.business_date
+          AND fp.focus_check_id = v_order.focus_check_id
+          AND fp.tip != 0
+      );
+
+  END LOOP;  -- end per-check loop
+
+  -- Reset GUC flag to re-enable per-row triggers
+  PERFORM set_config('app.skip_unified_sales_triggers', 'false', true);
+
+  -- Batch-categorize uncategorized sale rows (authenticated callers only;
+  -- service-role callers defer to the apply-categorization-rules edge function)
+  IF auth.uid() IS NOT NULL THEN
+    PERFORM apply_rules_to_pos_sales(p_restaurant_id, 10000);
+  ELSE
+    RAISE LOG
+      'sync_focus_transactions_to_unified_sales: skipping batch categorization (service-role caller)';
+  END IF;
+
+  -- Batch-aggregate daily totals for all dates touched in this sync
+  PERFORM public.aggregate_unified_sales_to_daily(p_restaurant_id, d.sale_date)
+  FROM (
+    SELECT DISTINCT sale_date
+    FROM public.unified_sales
+    WHERE restaurant_id = p_restaurant_id
+      AND pos_system    = 'focus'
+      AND synced_at    >= v_sync_start
+  ) d;
+
+  RETURN v_count;
+END;
+$$;

--- a/supabase/migrations/20260703120000_focus_backfill_reliability.sql
+++ b/supabase/migrations/20260703120000_focus_backfill_reliability.sql
@@ -85,6 +85,7 @@ SET search_path = public
 AS $$
 DECLARE
   r record;
+  v_full_range boolean;
 BEGIN
   FOR r IN
     SELECT fc.restaurant_id, fc.initial_sync_done
@@ -95,19 +96,33 @@ BEGIN
   LOOP
     BEGIN
       restaurant_id := r.restaurant_id;
-      IF r.initial_sync_done THEN
+
+      -- Full-range when the backfill is still running, OR when HISTORICAL rows
+      -- (older than the 3-day incremental window) were written recently.
+      -- The second condition closes the completion race (Codex P1, PR #567):
+      -- the worker's FINAL batch writes ~5 historical days and flips
+      -- initial_sync_done=true between two cron ticks — without this, those
+      -- days would fall to the 3-day branch and never reach unified_sales.
+      -- It also picks up custom-range re-imports of old dates for free.
+      v_full_range := (NOT r.initial_sync_done) OR EXISTS (
+        SELECT 1
+        FROM public.focus_orders fo
+        WHERE fo.restaurant_id = r.restaurant_id
+          AND fo.updated_at   > now() - interval '15 minutes'
+          AND fo.business_date < (CURRENT_DATE - 3)
+      );
+
+      IF v_full_range THEN
+        -- Aggregate ALL dates stored in focus_orders (NULL bounds ⇒ full range).
+        rows_synced := public._sync_focus_transactions_to_unified_sales_impl(
+                         r.restaurant_id, NULL, NULL
+                       );
+      ELSE
         -- Incremental: 3-day lookback window (timezone-safe, matches prior behaviour).
         rows_synced := public._sync_focus_transactions_to_unified_sales_impl(
                          r.restaurant_id,
                          (CURRENT_DATE - interval '3 days')::date,
                          CURRENT_DATE
-                       );
-      ELSE
-        -- Backfill in progress: aggregate ALL dates already stored in focus_orders,
-        -- so the historical days the worker is importing reach unified_sales / P&L.
-        -- NULL date bounds ⇒ full range (see _impl p_start_date/p_end_date IS NULL).
-        rows_synced := public._sync_focus_transactions_to_unified_sales_impl(
-                         r.restaurant_id, NULL, NULL
                        );
       END IF;
       RETURN NEXT;

--- a/supabase/tests/49_focus_backfill_reliability.sql
+++ b/supabase/tests/49_focus_backfill_reliability.sql
@@ -1,7 +1,7 @@
 -- Tests for Focus POS backfill reliability migration
 -- Migration: 20260703120000_focus_backfill_reliability.sql
 --
--- Test plan (10 tests):
+-- Test plan (13 tests):
 --  1  focus-transactions-unified-sales-sync now runs every 5 minutes (was 6 h)
 --  2  focus-backfill-sync cron uses a hardcoded URL (no current_setting GUC)
 --  3  focus-bulk-sync cron uses a hardcoded URL (no current_setting GUC)
@@ -12,9 +12,12 @@
 --  8  sale rows get sale_time from the check's TimeOpened
 --  9  tip offset rows get the same sale_time
 -- 10  malformed timestamps degrade to NULL sale_time (row still synced)
+-- 11  wrapper: backfilling connection (initial_sync_done=false) → full-range sync
+-- 12  wrapper: done + RECENT historical writes → still full-range (completion race)
+-- 13  wrapper: done + no recent historical writes → 3-day incremental (0 rows here)
 
 BEGIN;
-SELECT plan(10);
+SELECT plan(13);
 
 -- Test 1: the transaction→unified_sales aggregation cron is now every 5 minutes,
 -- so backfilled days reach P&L within minutes (in-database, no edge CPU limit).
@@ -163,6 +166,57 @@ SELECT ok(
       AND us.sale_time IS NULL
   ),
   'malformed timestamps degrade to NULL sale_time; the row is still synced'
+);
+
+-- ─────────────────────────────────────────────────────────────────────
+-- Wrapper branch selection (full-range vs 3-day incremental)
+-- Seeds live on 2026-06-20/21 — always OUTSIDE the 3-day window — so
+-- rows_synced discriminates the branch: full-range = 3 (2 sales + 1 tip),
+-- 3-day incremental = 0.
+-- ─────────────────────────────────────────────────────────────────────
+
+-- Test 11: backfilling (initial_sync_done=false) → full-range → 3 rows.
+SELECT is(
+  (SELECT sf.rows_synced
+   FROM public.sync_all_focus_transactions_to_unified_sales() sf
+   WHERE sf.restaurant_id = '00000000-0000-0000-0000-f0c200000011'),
+  3,
+  'wrapper uses the full-range sync while a connection is backfilling'
+);
+
+-- Flip the connection to "backfill complete". The seeded focus_orders rows were
+-- written moments ago (updated_at = now()) with historical business_dates, which
+-- is exactly the completion-race shape: the worker's final batch just landed.
+UPDATE public.focus_connections
+SET initial_sync_done = true
+WHERE id = '00000000-0000-0000-0000-f0c200000021';
+
+-- Test 12: done + recent historical writes → STILL full-range (Codex P1 fix).
+SELECT is(
+  (SELECT sf.rows_synced
+   FROM public.sync_all_focus_transactions_to_unified_sales() sf
+   WHERE sf.restaurant_id = '00000000-0000-0000-0000-f0c200000011'),
+  3,
+  'wrapper stays on full-range right after completion (recent historical writes)'
+);
+
+-- Age the order rows past the 15-minute grace window. focus_orders has a
+-- BEFORE UPDATE trigger that resets updated_at=now(), so disable user triggers
+-- for this aging UPDATE (transaction-local; the whole test rolls back).
+ALTER TABLE public.focus_orders DISABLE TRIGGER USER;
+UPDATE public.focus_orders
+SET updated_at = now() - interval '2 hours'
+WHERE restaurant_id = '00000000-0000-0000-0000-f0c200000011';
+ALTER TABLE public.focus_orders ENABLE TRIGGER USER;
+
+-- Test 13: done + NO recent historical writes → 3-day incremental → 0 rows
+-- (the seeded dates are outside the window; steady-state stays cheap).
+SELECT is(
+  (SELECT sf.rows_synced
+   FROM public.sync_all_focus_transactions_to_unified_sales() sf
+   WHERE sf.restaurant_id = '00000000-0000-0000-0000-f0c200000011'),
+  0,
+  'wrapper falls back to the 3-day incremental window in steady state'
 );
 
 SELECT * FROM finish();

--- a/supabase/tests/49_focus_backfill_reliability.sql
+++ b/supabase/tests/49_focus_backfill_reliability.sql
@@ -1,0 +1,169 @@
+-- Tests for Focus POS backfill reliability migration
+-- Migration: 20260703120000_focus_backfill_reliability.sql
+--
+-- Test plan (10 tests):
+--  1  focus-transactions-unified-sales-sync now runs every 5 minutes (was 6 h)
+--  2  focus-backfill-sync cron uses a hardcoded URL (no current_setting GUC)
+--  3  focus-bulk-sync cron uses a hardcoded URL (no current_setting GUC)
+--  4  sync_all_focus_transactions_to_unified_sales() still exists after CREATE OR REPLACE
+--  5  _focus_parse_local_time parses the real datafeed format (MM/DD/YYYY HH24:MI:SS)
+--  6  _focus_parse_local_time parses the ISO variant (YYYY-MM-DDTHH24:MI:SS)
+--  7  impl runs without error when a check has a malformed opened_at_local
+--  8  sale rows get sale_time from the check's TimeOpened
+--  9  tip offset rows get the same sale_time
+-- 10  malformed timestamps degrade to NULL sale_time (row still synced)
+
+BEGIN;
+SELECT plan(10);
+
+-- Test 1: the transaction→unified_sales aggregation cron is now every 5 minutes,
+-- so backfilled days reach P&L within minutes (in-database, no edge CPU limit).
+SELECT is(
+  (SELECT schedule FROM cron.job WHERE jobname = 'focus-transactions-unified-sales-sync'),
+  '*/5 * * * *',
+  'focus-transactions-unified-sales-sync runs every 5 minutes'
+);
+
+-- Test 2: the backfill cron must be hardcoded (the app.settings.supabase_url GUC
+-- cannot be set on Supabase, so a current_setting()-based URL silently no-ops).
+SELECT ok(
+  (SELECT command FROM cron.job WHERE jobname = 'focus-backfill-sync') NOT ILIKE '%current_setting%',
+  'focus-backfill-sync cron uses a hardcoded URL (no current_setting GUC dependency)'
+);
+
+-- Test 3: focus-bulk-sync must be hardcoded too (same GUC no-op failure mode).
+SELECT ok(
+  (SELECT command FROM cron.job WHERE jobname = 'focus-bulk-sync') NOT ILIKE '%current_setting%',
+  'focus-bulk-sync cron uses a hardcoded URL (no current_setting GUC dependency)'
+);
+
+-- Test 4: the aggregation function is intact after CREATE OR REPLACE.
+SELECT has_function(
+  'public',
+  'sync_all_focus_transactions_to_unified_sales',
+  'sync_all_focus_transactions_to_unified_sales() exists'
+);
+
+-- Test 5/6: the tolerant local-time parser.
+SELECT is(
+  public._focus_parse_local_time('06/29/2026 12:26:06'),
+  '12:26:06'::time,
+  '_focus_parse_local_time parses the real datafeed format (MM/DD/YYYY HH24:MI:SS)'
+);
+
+SELECT is(
+  public._focus_parse_local_time('2026-06-15T10:00:00'),
+  '10:00:00'::time,
+  '_focus_parse_local_time parses the ISO T-separated variant'
+);
+
+-- ─────────────────────────────────────────────────────────────────────
+-- Functional: sale_time flows from focus_orders → unified_sales
+-- ─────────────────────────────────────────────────────────────────────
+SET LOCAL role TO postgres;
+ALTER TABLE public.restaurants        DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.focus_connections  DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.focus_orders       DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.focus_order_items  DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.focus_payments     DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.unified_sales      DISABLE ROW LEVEL SECURITY;
+
+INSERT INTO public.restaurants (id, name, address, phone)
+VALUES ('00000000-0000-0000-0000-f0c200000011', 'Focus Time Creamery', '2 Timestamp Way', '555-0049');
+
+INSERT INTO public.focus_connections (
+  id, restaurant_id, store_id,
+  api_key, api_secret_encrypted, environment,
+  is_active, connection_status, initial_sync_done, last_sync_time
+) VALUES (
+  '00000000-0000-0000-0000-f0c200000021',
+  '00000000-0000-0000-0000-f0c200000011',
+  'TIME-TEST-STORE',
+  'test-api-key', 'enc-placeholder', 'production',
+  true, 'connected', false, now()
+);
+
+-- Check A: real datafeed timestamp format; one priced item + one tipped payment.
+-- Check B: malformed opened_at_local + NULL closed_at_local; one priced item.
+INSERT INTO public.focus_orders (
+  id, restaurant_id, business_date, focus_check_id,
+  opened_at_local, closed_at_local,
+  order_type_id, revenue_center_id, guests, total, discount_total, taxable_sales
+) VALUES
+  ('00000000-0000-0000-0000-f0c200000031',
+   '00000000-0000-0000-0000-f0c200000011',
+   '2026-06-20', '7',
+   '06/20/2026 14:33:07', '06/20/2026 14:35:00',
+   '1', 'RC1', 1, 5.50, 0.00, 5.00),
+  ('00000000-0000-0000-0000-f0c200000032',
+   '00000000-0000-0000-0000-f0c200000011',
+   '2026-06-21', '8',
+   'not-a-timestamp', NULL,
+   '1', 'RC1', 1, 3.00, 0.00, 3.00);
+
+INSERT INTO public.focus_order_items (
+  id, restaurant_id, business_date, focus_check_id, item_key,
+  record_number, item_code, name, report_group_id,
+  price, parent_key, is_modifier, discount_amount
+) VALUES
+  ('00000000-0000-0000-0000-f0c200000041',
+   '00000000-0000-0000-0000-f0c200000011',
+   '2026-06-20', '7', 'IK-T1',
+   'RN-001', 'IC-001', 'Sundae', 'Ice Cream',
+   4.50, NULL, false, 0.00),
+  ('00000000-0000-0000-0000-f0c200000042',
+   '00000000-0000-0000-0000-f0c200000011',
+   '2026-06-21', '8', 'IK-T2',
+   'RN-001', 'IC-002', 'Cone', 'Ice Cream',
+   3.00, NULL, false, 0.00);
+
+INSERT INTO public.focus_payments (
+  id, restaurant_id, business_date, focus_check_id, payment_key,
+  payment_id, name, amount, tip, card_last4
+) VALUES
+  ('00000000-0000-0000-0000-f0c200000051',
+   '00000000-0000-0000-0000-f0c200000011',
+   '2026-06-20', '7', 'PK-T1',
+   'P-1', 'Visa', 5.50, 1.00, '1234');
+
+-- Test 7: the sync survives the malformed timestamp (degrades, never raises).
+SELECT lives_ok(
+  $q$SELECT public._sync_focus_transactions_to_unified_sales_impl(
+       '00000000-0000-0000-0000-f0c200000011'::uuid, NULL, NULL)$q$,
+  'impl runs without error when a check has a malformed opened_at_local'
+);
+
+-- Test 8: sale row carries the check''s TimeOpened as sale_time.
+SELECT is(
+  (SELECT us.sale_time FROM public.unified_sales us
+   WHERE us.restaurant_id = '00000000-0000-0000-0000-f0c200000011'
+     AND us.pos_system = 'focus' AND us.item_type = 'sale'
+     AND us.sale_date = '2026-06-20'),
+  '14:33:07'::time,
+  'sale rows get sale_time from the check TimeOpened'
+);
+
+-- Test 9: tip offset row carries the same sale_time.
+SELECT is(
+  (SELECT us.sale_time FROM public.unified_sales us
+   WHERE us.restaurant_id = '00000000-0000-0000-0000-f0c200000011'
+     AND us.pos_system = 'focus' AND us.item_type = 'tip'
+     AND us.sale_date = '2026-06-20'),
+  '14:33:07'::time,
+  'tip offset rows get the same sale_time'
+);
+
+-- Test 10: malformed timestamp → row synced with NULL sale_time (not dropped).
+SELECT ok(
+  EXISTS (
+    SELECT 1 FROM public.unified_sales us
+    WHERE us.restaurant_id = '00000000-0000-0000-0000-f0c200000011'
+      AND us.pos_system = 'focus' AND us.item_type = 'sale'
+      AND us.sale_date = '2026-06-21'
+      AND us.sale_time IS NULL
+  ),
+  'malformed timestamps degrade to NULL sale_time; the row is still synced'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/tests/unit/focusBackfillBatch.test.ts
+++ b/tests/unit/focusBackfillBatch.test.ts
@@ -11,8 +11,8 @@
  *  - stops (no advance) on day inprogress
  *  - sets initialSyncDone when cursor >= targetDays
  *  - targetDays param honored (test uses small value)
- *  - never writes the connection row / calls supabase.from directly
- *  - syncs the processed range into unified_sales via rpc (range + completion window)
+ *  - never writes the connection row / calls supabase.from or supabase.rpc directly
+ *    (unified_sales aggregation moved to a Postgres cron to avoid worker CPU timeouts)
  *  - daysProcessed reflects only ok/empty days
  *
  * Design ref: plan §B1; spec §5.1 + §8.3.
@@ -76,12 +76,12 @@ function makeDeps(
     ? vi.fn(() => clockTimes[clockCallIndex++] ?? clockTimes[clockTimes.length - 1])
     : vi.fn(() => Date.now()); // real time (fast tests won't exceed budget)
 
-  // Mock supabase — processBackfillBatch must never call `.from` directly (day
-  // writes go through processDayTransactions), but it DOES call `.rpc` once after
-  // the loop to sync the batch's range into unified_sales (resolving mock).
+  // Mock supabase — processBackfillBatch must never call `.from` OR `.rpc` directly:
+  // day writes go through processDayTransactions, and unified_sales aggregation is
+  // done by a Postgres cron, not the worker. Both throw to catch a regression.
   const mockSupabase = {
     from: vi.fn(() => { throw new Error('processBackfillBatch must not call supabase.from directly'); }),
-    rpc: vi.fn(async () => ({ data: null, error: null })),
+    rpc: vi.fn(() => { throw new Error('processBackfillBatch must not call supabase.rpc directly'); }),
   } as unknown as TransactionSyncDeps['supabase'];
 
   const mockFetchDatafeed = vi.fn(() => {
@@ -455,28 +455,25 @@ describe('processBackfillBatch', () => {
   });
 });
 
-// ── unified_sales range sync (Codex P1: backfilled days must reach unified_sales) ──
-describe('processBackfillBatch — unified_sales sync', () => {
-  // now = 2026-07-02T14:00Z → Chicago date 2026-07-02; cursor 0 → yesterday (07-01)
-  it('syncs the processed batch range into unified_sales after ok days', async () => {
+// ── unified_sales aggregation is NOT done in the worker ──────────────────────
+// It was moved to the 5-minute Postgres cron (full-range for still-backfilling
+// connections) after the in-worker RPC caused HTTP 546 worker-CPU timeouts on
+// busy multi-day batches. The worker only fetches + upserts focus_orders.
+describe('processBackfillBatch — no in-worker unified_sales RPC', () => {
+  it('never calls the unified_sales RPC after processing ok days', async () => {
     const { deps } = makeDeps([
       { status: 'ok', checksWritten: 1 },
       { status: 'ok', checksWritten: 1 },
       { status: 'ok', checksWritten: 1 },
     ]);
-    await processBackfillBatch(deps, MOCK_CONFIG, { ...BASE_OPTS, maxDays: 3 });
+    const result = await processBackfillBatch(deps, MOCK_CONFIG, { ...BASE_OPTS, maxDays: 3 });
 
-    const rpc = deps.supabase.rpc as ReturnType<typeof vi.fn>;
-    expect(rpc).toHaveBeenCalledTimes(1);
-    // cursor 0→3 → dates 07-01, 06-30, 06-29; range = [oldest 06-29 .. newest 07-01]
-    expect(rpc).toHaveBeenCalledWith('sync_focus_transactions_to_unified_sales', {
-      p_restaurant_id: RESTAURANT_ID,
-      p_start_date: '2026-06-29',
-      p_end_date: '2026-07-01',
-    });
+    expect(result.daysProcessed).toBe(3);
+    expect(result.syncCursor).toBe(3);
+    expect(deps.supabase.rpc as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
   });
 
-  it('syncs the full backfill window on completion (initialSyncDone)', async () => {
+  it('never calls the unified_sales RPC on backfill completion (initialSyncDone)', async () => {
     const { deps } = makeDeps(Array(3).fill({ status: 'ok', checksWritten: 1 }));
     const result = await processBackfillBatch(deps, MOCK_CONFIG, {
       ...BASE_OPTS,
@@ -485,34 +482,6 @@ describe('processBackfillBatch — unified_sales sync', () => {
     });
 
     expect(result.initialSyncDone).toBe(true);
-    const rpc = deps.supabase.rpc as ReturnType<typeof vi.fn>;
-    expect(rpc).toHaveBeenCalledTimes(1);
-    // completion → full window [subtractDays(today, targetDays)=06-29 .. yesterday 07-01]
-    expect(rpc).toHaveBeenCalledWith('sync_focus_transactions_to_unified_sales', {
-      p_restaurant_id: RESTAURANT_ID,
-      p_start_date: '2026-06-29',
-      p_end_date: '2026-07-01',
-    });
-  });
-
-  it('does NOT sync unified_sales when no days were processed (error on first day)', async () => {
-    const { deps } = makeDeps([{ status: 'error', error: 'boom' }]);
-    const result = await processBackfillBatch(deps, MOCK_CONFIG, { ...BASE_OPTS, maxDays: 3 });
-
-    expect(result.daysProcessed).toBe(0);
-    expect((deps.supabase.rpc as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
-  });
-
-  it('is non-fatal when the unified_sales RPC returns an error (orders already written)', async () => {
-    const { deps } = makeDeps([{ status: 'ok', checksWritten: 1 }]);
-    (deps.supabase.rpc as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      data: null,
-      error: { message: 'rpc down' },
-    });
-    const result = await processBackfillBatch(deps, MOCK_CONFIG, { ...BASE_OPTS, maxDays: 1 });
-
-    // Batch still reports success — the day rows are durably written.
-    expect(result.syncCursor).toBe(1);
-    expect(result.status).toBe('ok');
+    expect(deps.supabase.rpc as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/focusBackfillSyncHandler.test.ts
+++ b/tests/unit/focusBackfillSyncHandler.test.ts
@@ -7,7 +7,7 @@
  *  - Gate-less: processes with no Authorization header (matches toast/shift4)
  *  - Query: selects only is_active=true AND initial_sync_done=false AND api_key IS NOT NULL
  *  - Query: ORDER BY last_sync_time ASC NULLS FIRST LIMIT 5
- *  - Processing: calls processBackfillBatch per restaurant with { maxDays:7 }
+ *  - Processing: calls processBackfillBatch per restaurant with { maxDays:5 }
  *  - Processing: CAS write after each restaurant (sync_cursor unchanged → filters old cursor)
  *  - Processing: on batch error → writes connection_status='error' + last_error
  *  - Processing: 2s inter-restaurant sleep (injectable deps.sleep)
@@ -290,7 +290,7 @@ describe('handleBackfillSync', () => {
 
   // ── processBackfillBatch integration ──────────────────────────────────────────
 
-  it('calls processBackfillBatch with maxDays=7 for each connection', async () => {
+  it('calls processBackfillBatch with maxDays=5 for each connection', async () => {
     const { processBackfillBatch: mockBatch } = await import(
       '../../supabase/functions/_shared/focusBackfillBatch'
     );
@@ -303,7 +303,7 @@ describe('handleBackfillSync', () => {
 
     expect(mockBatch).toHaveBeenCalledTimes(1);
     const callOpts = (mockBatch as ReturnType<typeof vi.fn>).mock.calls[0][2] as Record<string, unknown>;
-    expect(callOpts.maxDays).toBe(7);
+    expect(callOpts.maxDays).toBe(5);
   });
 
   // ── CAS write ────────────────────────────────────────────────────────────────

--- a/tests/unit/focusSyncDataHandler.test.ts
+++ b/tests/unit/focusSyncDataHandler.test.ts
@@ -24,7 +24,7 @@
  *  - Status propagated from processReportDay (ok / empty / error)
  *
  *  B3 additions (spec §5.2, §8.1, §8.2, §8.3):
- *  - Lynk backfill: delegates to processBackfillBatch(budgetMs=12_000, maxDays=5)
+ *  - Lynk backfill: delegates to processBackfillBatch(budgetMs=12_000, maxDays=3)
  *  - Lynk backfill: cursor write uses CAS (§8.1) — filters eq('sync_cursor', readCursor)
  *  - Lynk backfill error: writes connection_status='error' + last_error (§8.3)
  *  - Lynk backfill: response includes backgrounded=true when not done
@@ -628,7 +628,7 @@ describe('handleSyncData', () => {
       });
     });
 
-    it('calls processBackfillBatch with budgetMs=12_000 and maxDays=5', async () => {
+    it('calls processBackfillBatch with budgetMs=12_000 and maxDays=3', async () => {
       const { deps } = makeDeps({
         serviceClientOpts: { connection: MOCK_CONNECTION_LYNK_BACKFILL as any },
       });
@@ -638,7 +638,7 @@ describe('handleSyncData', () => {
       expect(mockProcessBackfillBatch).toHaveBeenCalledOnce();
       const [, , opts] = mockProcessBackfillBatch.mock.calls[0] as [unknown, unknown, Record<string, unknown>];
       expect(opts.budgetMs).toBe(12_000);
-      expect(opts.maxDays).toBe(5);
+      expect(opts.maxDays).toBe(3);
     });
 
     it('passes the read syncCursor to processBackfillBatch', async () => {


### PR DESCRIPTION
## Problems (verified in production)

1. **The background backfill never runs.** #565 was merged while GitHub's PR view lagged behind the final push, so `main` got the *interim* cron that reads `current_setting('app.settings.supabase_url')` — a GUC that **cannot be set on Supabase** (`ALTER DATABASE … SET` is permission-denied for `postgres`). Every 5-min tick "succeeds" with 0 rows and never calls the worker. Backfill is stuck at 10/90 days, advancing only on manual clicks.
2. **Manual syncs intermittently die with HTTP 546** (worker CPU limit, seen at 67s and 79s) because the `unified_sales` aggregation RPC ran inside the edge function.
3. **No transaction timestamps.** The datafeed's `TimeOpened`/`TimeClosed` are captured into `focus_orders`, but the Focus→`unified_sales` RPC never mapped them to `sale_time` (Toast does) — so the POS sales screen and busy-time/staffing analysis get NULL times for every Focus row.

## Fixes (one migration: `20260703120000_focus_backfill_reliability.sql`)

1. **Hardcoded-URL cron reschedule** for `focus-backfill-sync` (5 min) + `focus-bulk-sync` (6 h) — fresh migration timestamp so it *applies*; matches the toast/shift4 cron pattern. Zero post-deploy setup.
2. **Aggregation moves fully into Postgres.** `processBackfillBatch` no longer calls the RPC (worker just fetches + upserts; batch caps: manual 3, cron 5). `sync_all_focus_transactions_to_unified_sales()` now runs **every 5 min** and does a **full-range** sync for still-backfilling connections — historical days reach P&L within minutes, with no edge CPU limit.
3. **`sale_time` imported.** New tolerant `_focus_parse_local_time()` (real `MM/DD/YYYY HH24:MI:SS` feed format + ISO variants; malformed → NULL, never raises). Threaded through sale/discount/tip rows **and** the `ON CONFLICT` updates, so the ~1.8k already-imported rows **self-heal automatically** on the next full-range sync — no manual backfill.

## Expected behaviour after deploy (hands-off)
- 5-min cron imports the remaining ~80 days (~1–1.5 h total), cursor → 90/90, `initial_sync_done=true`.
- 5-min Postgres cron rolls all days into `unified_sales`/P&L and back-fills `sale_time` on existing rows.
- POS sales screen shows times; StaffingOverlay busy-time analysis works for Focus.

## Test plan
- 98 unit tests green across the three handlers (incl. new "worker never calls the unified_sales RPC" guards).
- pgTAP `49_…` (10 tests): cron cadence + hardcoded-URL regression guards for both crons, parser format tests, and **seeded end-to-end** assertions that sale/tip rows get `sale_time` and malformed timestamps degrade to NULL without aborting the sync.
- Local full suite: 5,411 pass; the 5 failures (DateRangePicker/KioskMode) **reproduce on pristine `main` with this branch's changes stashed** — pre-existing timing flakes, green in CI on the last two PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backfill and sync processing is now handled more reliably in the database, improving large-data updates.
  * Sale times are now parsed more flexibly, including common timestamp format variations.

* **Bug Fixes**
  * Reduced the chance of sync failures during heavy backfills.
  * Improved handling of malformed timestamps so records still sync instead of failing.
  * Adjusted backfill windows to make ongoing syncs lighter and more responsive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->