### PR TITLE
feat(scheduling): warn on cross-area shift-trade claims

### DIFF
--- a/docs/superpowers/plans/2026-07-02-shift-trade-area-warning-plan.md
+++ b/docs/superpowers/plans/2026-07-02-shift-trade-area-warning-plan.md
@@ -1,0 +1,47 @@
+# Plan: Shift-trade area-mismatch warning
+
+Design: `docs/superpowers/specs/2026-07-02-shift-trade-area-warning-design.md`
+Branch: `feature/shift-trade-area-warning`
+
+RED → GREEN → REFACTOR → COMMIT per task. No DB migration. One reachable surface
+(`AvailableShiftsPage`).
+
+## Task 1 — Pure helper `getAreaMismatch`
+- **RED:** `tests/unit/shiftTradeArea.test.ts` — both-known-and-differ → object
+  (trimmed originals); identical → null; case-insensitive identical → null;
+  null/undefined/''/whitespace on either side → null; trims before compare + in result.
+- **GREEN:** create `src/lib/shiftTradeArea.ts` (`normalizeArea` + `getAreaMismatch`,
+  `AreaMismatch` interface).
+- **Commit:** `feat(scheduling): getAreaMismatch helper`
+
+## Task 2 — Surface offering employee's area in the marketplace query
+- **GREEN:** in `src/hooks/useShiftTrades.ts`, update BOTH (separate edits):
+  (a) the `useMarketplaceTrades` embed select → add `area` to
+  `offered_by:employees!offered_by_employee_id(id, name, position, area)`, and
+  (b) the shared `ShiftTrade['offered_by']` type → add `area: string | null`.
+- FK is real (`offered_by_employee_id → employees(id)`, NOT NULL). Leave the
+  pre-existing `offered_by.email` type/select inconsistency alone (out of scope).
+- **Commit:** `feat(scheduling): include offering employee area in marketplace trades`
+
+## Task 3 — Warning UI in `AvailableShiftsPage` TradeCard
+- Parent: compute `getAreaMismatch(item.trade.offered_by?.area, currentEmployee.area)`
+  per trade row (currentEmployee non-null after early returns); pass `areaMismatch`.
+- `TradeCard`: change outer to `flex flex-col gap-2` (row 1 = existing
+  content+button; row 2 = full-width warning). Add `areaMismatch` prop; render
+  amber panel (`flex items-start gap-2 p-2.5 rounded-lg bg-amber-500/10 border
+  border-amber-500/20`, `AlertTriangle` aria-hidden, `text-[13px]` amber text,
+  id `area-mismatch-${trade.id}`, copy "This is a {offeredArea} shift — you work
+  {claimerArea}."). NO live region. Button when mismatch → "Claim anyway" /
+  "Claiming…", `aria-describedby={id}`, concise cross-area aria-label; stays
+  enabled. No-mismatch path unchanged ("Accept"/"Accepting…").
+- Extend `memo` comparator: compare `areaMismatch?.offeredArea` / `?.claimerArea`
+  field-by-field (not by reference).
+- **Verify:** `npm run test`, `npm run typecheck`, `npm run lint`, `npm run build`.
+- **Commit:** `feat(scheduling): warn on cross-area shift-trade claim`
+
+## Dependencies
+1 → 3 (helper used by page). 2 → 3 (area data used by page). 1 and 2 independent.
+
+## Verification gate (Phase 8)
+`npm run test && npm run typecheck && npm run lint && npm run build` green.
+`npm run test:db` unaffected (no SQL change).

--- a/docs/superpowers/specs/2026-07-02-shift-trade-area-warning-design.md
+++ b/docs/superpowers/specs/2026-07-02-shift-trade-area-warning-design.md
@@ -37,16 +37,31 @@ Only the **claim flow** on the one reachable surface. Verified during discovery:
 
 ### 1. Data — surface the offering employee's area
 
-`useMarketplaceTrades` (`src/hooks/useShiftTrades.ts`) currently embeds
-`offered_by:employees(id, name, position)`. Add `area`:
+Two edits in `src/hooks/useShiftTrades.ts`, and they are **separate — both are
+required** (frontend review, major):
 
-```ts
-offered_by:employees!offered_by_employee_id(id, name, position, area)
-```
+1. **The `useMarketplaceTrades` query string** (the one that actually feeds
+   `AvailableShiftsPage`) embeds `offered_by:employees!offered_by_employee_id(id,
+   name, position)`. Add `area`:
+   ```ts
+   offered_by:employees!offered_by_employee_id(id, name, position, area)
+   ```
+2. **The shared `ShiftTrade['offered_by']` type** — add `area: string | null`.
 
-Extend the `ShiftTrade['offered_by']` type (same file) with `area: string | null`.
-The `employees` FK on `shift_trades.offered_by_employee_id` already exists, so
-this embed is safe (no silent-null PostgREST embed risk).
+These are independent: the `ShiftTrade` type is shared, but the query lives in
+`useMarketplaceTrades` with its own select list. Updating only the type would
+make `offered_by.area` type-`string` but runtime-`undefined`. The main
+`useShiftTrades` query has yet another `offered_by` select; it does not feed this
+feature, so leaving its select as-is is fine — but the shared type gains `area`
+so any reader sees it. (Pre-existing note from Supabase review: `offered_by.email`
+is already in the type but not selected by the marketplace query — a pre-existing
+inconsistency we are NOT fixing here to avoid scope creep.)
+
+The `employees` FK on `shift_trades.offered_by_employee_id` is a real
+`NOT NULL REFERENCES employees(id)` (confirmed in the create migration), so this
+embed is safe — no silent-null PostgREST embed risk, and `employees` SELECT RLS
+already exposes coworkers' `area` (same sensitivity as the already-returned
+`position`).
 
 The claiming employee's area is **already available**: `useCurrentEmployee` does
 `.select('*')`, so `currentEmployee.area` is present — no hook change there.
@@ -91,32 +106,60 @@ the "keep testable logic in a pure helper" lesson.
 that contract: the **parent** computes the mismatch and passes it down as a
 precomputed prop.
 
-- Parent (render of each `item.type === 'trade'`):
-  `const areaMismatch = getAreaMismatch(item.trade.offered_by?.area, currentEmployee?.area)`
+- Parent (render of each `item.type === 'trade'`, where `currentEmployee` is
+  already guaranteed non-null by the page's early returns):
+  `const areaMismatch = getAreaMismatch(item.trade.offered_by?.area, currentEmployee.area)`
   passed as `areaMismatch={areaMismatch}`.
+- **Card layout** (frontend review, minor): `TradeCard`'s outer element changes
+  from the current single-row `flex items-center justify-between` to
+  `flex flex-col gap-2`. Row 1 is the existing content+button
+  `flex items-center justify-between` block (unchanged). Row 2 is the full-width
+  warning panel. The virtualizer's `measureElement` ref sits on the parent's row
+  wrapper (outside `TradeCard`), so it re-measures the taller card automatically
+  — no wrapper change around the measured element.
 - `TradeCard` gains `areaMismatch?: AreaMismatch | null`. When present:
-  - Render an amber warning row using the documented CLAUDE.md pattern
-    (`bg-amber-500/10 border border-amber-500/20`, `AlertTriangle` icon
-    `aria-hidden`, text in `text-amber-600`/amber-700 dark). Copy:
+  - Render a **full-width** amber warning panel using the documented CLAUDE.md
+    pattern: `flex items-start gap-2 p-2.5 rounded-lg bg-amber-500/10 border
+    border-amber-500/20`, `AlertTriangle` icon `aria-hidden`, sentence text at
+    **`text-[13px]`** in `text-amber-600` (established in this file for the SHIFT
+    TRADE / Pending badges). Copy:
     **"This is a {offeredArea} shift — you work {claimerArea}."**
-    Wrap in `role="status"` so it's announced without stealing focus.
-  - Relabel the claim button **"Claim anyway"** (from "Accept") and update its
-    `aria-label` to convey the cross-area intent. Button stays **enabled**
-    (warn, not block).
-- Extend the `memo` comparator to include the mismatch so the card re-renders
-  when it changes: compare `prev.areaMismatch?.offeredArea/claimerArea` to next.
+  - **Accessibility (frontend review, major + minor):** give the warning text a
+    stable id `area-mismatch-${trade.id}` and set `aria-describedby` to it on the
+    claim button, so a screen-reader user hears the area context exactly when the
+    button is focused. Do **not** use `role="status"`/a live region — in this
+    virtualized list a live region re-announces every time the row re-mounts on
+    scroll (noisy). `aria-describedby` gives the info at the right moment without
+    the spam.
+  - Relabel the claim button **"Claim anyway"** (from "Accept"), in-flight label
+    **"Claiming…"** (from "Accepting…"), and set a concise
+    `aria-label={`Claim anyway — trade from ${name} on ${dateLabel}`}` (area
+    detail comes through `aria-describedby`). Button stays **enabled** (warn,
+    not block). When there is no mismatch, the button keeps its current "Accept"
+    text, "Accepting…" in-flight label, and existing `aria-label`, with no
+    `aria-describedby`.
+- Extend the `memo` comparator to include the mismatch: compare
+  `prev.areaMismatch?.offeredArea` / `?.claimerArea` to next (field-by-field, NOT
+  by object reference — `getAreaMismatch` returns a fresh object each render, so
+  reference compare would always differ and defeat memoization). Optional-chaining
+  correctly handles the null↔object transitions.
 - Three-state / guards: the warning derives from already-loaded row data
   (`offered_by.area`) + `currentEmployee.area`, not a separate query, so there is
-  no independent loading/error state to guard. If `currentEmployee` is still
-  loading (`undefined`), `getAreaMismatch(_, undefined)` returns null → no
-  warning (fails safe). This satisfies the "warning heuristics must not fire on
-  missing/errored data" lesson: unknown area ⇒ no warning, never a false one.
+  no independent loading/error state to guard. `currentEmployee` is non-null here
+  (page early-returns a skeleton / not-linked state otherwise), and unknown area
+  on either side ⇒ `getAreaMismatch` returns null ⇒ no warning. This satisfies the
+  "warning heuristics must not fire on missing/errored data" lesson: unknown area
+  ⇒ silence, never a false alarm.
 
 ## Accessibility
 
-- Warning uses `role="status"` + visible text; icon is `aria-hidden`.
-- Button keeps a descriptive `aria-label` (now including "different area").
-- No color-only signal — the text states the areas explicitly.
+- Warning is visible sentence text (not color-only — it names both areas), icon
+  `aria-hidden`, with a stable id `area-mismatch-${trade.id}`.
+- The claim button links to it via `aria-describedby` (announced on focus), so no
+  live region is needed — this avoids the virtualized-list re-announcement noise a
+  `role="status"`/`aria-live` region would cause as rows re-mount on scroll.
+- Button `aria-label` stays action-focused ("Claim anyway — …"); the area detail
+  rides on `aria-describedby`.
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-07-02-shift-trade-area-warning-design.md
+++ b/docs/superpowers/specs/2026-07-02-shift-trade-area-warning-design.md
@@ -1,0 +1,144 @@
+# Design: Area-mismatch warning in the shift-trade claim flow
+
+**Date:** 2026-07-02
+**Branch:** `feature/shift-trade-area-warning`
+**Follow-up to:** PR #562 (manager stale-trade cleanup)
+
+## Problem
+
+When an employee claims a shift offered for trade, there is no signal that the
+shift belongs to a *different work area* than theirs. A dishwasher (BOH/Dish) can
+claim a bartender's shift (Bar) with no friction, and the manager only catches it
+at approval — if at all.
+
+## Decisions (locked, do NOT revisit)
+
+1. **Warn, allow anyway.** Never hard-block. The manager still approves/rejects.
+   The claim button becomes a deliberate "Claim anyway" when areas differ.
+2. **Area source = the offering employee's `employees.area`** (`offered_by.area`).
+   No `shifts.area` column, no `shift_templates` lookup, no schema/migration.
+3. **Only warn when BOTH areas are known and differ.** If either the offering
+   employee's or the claiming employee's area is null / empty / whitespace,
+   show no warning (we can't assert a mismatch we don't know).
+
+## Scope
+
+Only the **claim flow** on the one reachable surface. Verified during discovery:
+
+- `/employee/shifts` → `AvailableShiftsPage` is the **only routed/reachable**
+  trade-claim UI. `src/components/schedule/TradeMarketplace.tsx` is **dead**
+  (rendered nowhere) and `src/pages/EmployeeShiftMarketplace.tsx` is **dead**
+  (not routed). We touch neither — surfacing them would be scope creep and
+  risks "fixing" code no user sees.
+- NOT the poster status-tracker, NOT the `send-shift-notification` TZ bug, NOT
+  any manager-side change.
+
+## Changes
+
+### 1. Data — surface the offering employee's area
+
+`useMarketplaceTrades` (`src/hooks/useShiftTrades.ts`) currently embeds
+`offered_by:employees(id, name, position)`. Add `area`:
+
+```ts
+offered_by:employees!offered_by_employee_id(id, name, position, area)
+```
+
+Extend the `ShiftTrade['offered_by']` type (same file) with `area: string | null`.
+The `employees` FK on `shift_trades.offered_by_employee_id` already exists, so
+this embed is safe (no silent-null PostgREST embed risk).
+
+The claiming employee's area is **already available**: `useCurrentEmployee` does
+`.select('*')`, so `currentEmployee.area` is present — no hook change there.
+
+### 2. Pure helper — `src/lib/shiftTradeArea.ts` (new, unit-tested)
+
+```ts
+export interface AreaMismatch {
+  offeredArea: string;  // trimmed, original casing preserved for display
+  claimerArea: string;
+}
+
+/** Normalize an area value: trimmed string, or null when unknown/blank. */
+function normalizeArea(area: string | null | undefined): string | null {
+  const t = (area ?? '').trim();
+  return t.length > 0 ? t : null;
+}
+
+/**
+ * Returns mismatch info ONLY when both areas are known and differ
+ * (case-insensitive, trimmed comparison). Returns null otherwise —
+ * i.e. either area unknown/blank, or the two areas match.
+ */
+export function getAreaMismatch(
+  offeredArea: string | null | undefined,
+  claimerArea: string | null | undefined,
+): AreaMismatch | null {
+  const offered = normalizeArea(offeredArea);
+  const claimer = normalizeArea(claimerArea);
+  if (!offered || !claimer) return null;
+  if (offered.toLocaleLowerCase() === claimer.toLocaleLowerCase()) return null;
+  return { offeredArea: offered, claimerArea: claimer };
+}
+```
+
+Pure, no React, no clock — fully unit-testable. Chosen over inline JSX logic per
+the "keep testable logic in a pure helper" lesson.
+
+### 3. UI — warning in `AvailableShiftsPage` `TradeCard`
+
+`TradeCard` is a `memo` component with **no hooks** (data passed as props). Follow
+that contract: the **parent** computes the mismatch and passes it down as a
+precomputed prop.
+
+- Parent (render of each `item.type === 'trade'`):
+  `const areaMismatch = getAreaMismatch(item.trade.offered_by?.area, currentEmployee?.area)`
+  passed as `areaMismatch={areaMismatch}`.
+- `TradeCard` gains `areaMismatch?: AreaMismatch | null`. When present:
+  - Render an amber warning row using the documented CLAUDE.md pattern
+    (`bg-amber-500/10 border border-amber-500/20`, `AlertTriangle` icon
+    `aria-hidden`, text in `text-amber-600`/amber-700 dark). Copy:
+    **"This is a {offeredArea} shift — you work {claimerArea}."**
+    Wrap in `role="status"` so it's announced without stealing focus.
+  - Relabel the claim button **"Claim anyway"** (from "Accept") and update its
+    `aria-label` to convey the cross-area intent. Button stays **enabled**
+    (warn, not block).
+- Extend the `memo` comparator to include the mismatch so the card re-renders
+  when it changes: compare `prev.areaMismatch?.offeredArea/claimerArea` to next.
+- Three-state / guards: the warning derives from already-loaded row data
+  (`offered_by.area`) + `currentEmployee.area`, not a separate query, so there is
+  no independent loading/error state to guard. If `currentEmployee` is still
+  loading (`undefined`), `getAreaMismatch(_, undefined)` returns null → no
+  warning (fails safe). This satisfies the "warning heuristics must not fire on
+  missing/errored data" lesson: unknown area ⇒ no warning, never a false one.
+
+## Accessibility
+
+- Warning uses `role="status"` + visible text; icon is `aria-hidden`.
+- Button keeps a descriptive `aria-label` (now including "different area").
+- No color-only signal — the text states the areas explicitly.
+
+## Testing
+
+- `tests/unit/shiftTradeArea.test.ts` — `getAreaMismatch`:
+  - both known & differ → object with trimmed originals;
+  - identical → null; case-insensitive identical (`'Bar'` vs `'bar'`) → null;
+  - whitespace-only / empty / null / undefined on either side → null;
+  - trims surrounding whitespace before comparing and in the returned value.
+- Component-level coverage is optional per CLAUDE.md; the branching logic lives
+  in the pure helper, which carries the real coverage. A light render test may
+  assert the warning + "Claim anyway" label appear for a mismatched trade and
+  are absent for a same-area trade (nice-to-have, not required for the gate).
+
+## Decided trade-offs
+
+- **Offering employee's area over template area:** simplest, zero schema, and
+  correct for the common case where the poster works their home area. If a
+  poster is cross-covering another area, the warning may be based on their home
+  area rather than the shift's true area — accepted per the locked decision; a
+  future iteration can switch the source to `shift_templates.area` without
+  changing the helper's signature.
+- **Warn, not block:** cross-trained staff (a bartender who also runs food) must
+  still be able to claim; the manager is the real gate.
+- **No new query:** area rides along on the existing marketplace embed, so no
+  extra round-trip and no new loading/error surface.

--- a/src/hooks/useShiftTrades.ts
+++ b/src/hooks/useShiftTrades.ts
@@ -30,6 +30,7 @@ export interface ShiftTrade {
     name: string;
     email: string | null;
     position: string;
+    area: string | null;
   };
   accepted_by?: {
     id: string;
@@ -468,7 +469,8 @@ export const useMarketplaceTrades = (
           offered_by:employees!offered_by_employee_id(
             id,
             name,
-            position
+            position,
+            area
           )
         `)
         .eq('restaurant_id', restaurantId)

--- a/src/lib/shiftTradeArea.ts
+++ b/src/lib/shiftTradeArea.ts
@@ -1,0 +1,26 @@
+export interface AreaMismatch {
+  offeredArea: string; // trimmed, original casing preserved for display
+  claimerArea: string;
+}
+
+/** Normalize an area value: trimmed string, or null when unknown/blank. */
+function normalizeArea(area: string | null | undefined): string | null {
+  const t = (area ?? '').trim();
+  return t.length > 0 ? t : null;
+}
+
+/**
+ * Returns mismatch info ONLY when both areas are known and differ
+ * (case-insensitive, trimmed comparison). Returns null otherwise —
+ * i.e. either area unknown/blank, or the two areas match.
+ */
+export function getAreaMismatch(
+  offeredArea: string | null | undefined,
+  claimerArea: string | null | undefined,
+): AreaMismatch | null {
+  const offered = normalizeArea(offeredArea);
+  const claimer = normalizeArea(claimerArea);
+  if (!offered || !claimer) return null;
+  if (offered.toLocaleLowerCase() === claimer.toLocaleLowerCase()) return null;
+  return { offeredArea: offered, claimerArea: claimer };
+}

--- a/src/lib/shiftTradeArea.ts
+++ b/src/lib/shiftTradeArea.ts
@@ -21,6 +21,6 @@ export function getAreaMismatch(
   const offered = normalizeArea(offeredArea);
   const claimer = normalizeArea(claimerArea);
   if (!offered || !claimer) return null;
-  if (offered.toLocaleLowerCase() === claimer.toLocaleLowerCase()) return null;
+  if (offered.toLowerCase() === claimer.toLowerCase()) return null;
   return { offeredArea: offered, claimerArea: claimer };
 }

--- a/src/lib/shiftTradeArea.ts
+++ b/src/lib/shiftTradeArea.ts
@@ -5,8 +5,8 @@ export interface AreaMismatch {
 
 /** Normalize an area value: trimmed string, or null when unknown/blank. */
 function normalizeArea(area: string | null | undefined): string | null {
-  const t = (area ?? '').trim();
-  return t.length > 0 ? t : null;
+  const trimmed = (area ?? '').trim();
+  return trimmed.length > 0 ? trimmed : null;
 }
 
 /**

--- a/src/pages/AvailableShiftsPage.tsx
+++ b/src/pages/AvailableShiftsPage.tsx
@@ -117,30 +117,38 @@ const TradeCard = memo(function TradeCard({
         </div>
 
         <div className="ml-4 flex-shrink-0">
-          {trade.status === 'pending_approval' ? (
-            <span className="text-[11px] px-1.5 py-0.5 rounded-md bg-amber-500/10 text-amber-600 font-medium">
-              Pending Approval
-            </span>
-          ) : areaMismatch ? (
-            <Button
-              onClick={() => onAccept(trade.id)}
-              disabled={isPast || isAccepting}
-              className="h-9 px-4 rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium"
-              aria-label={`Claim anyway — trade from ${name} on ${dateLabel}`}
-              aria-describedby={mismatchId}
-            >
-              {isAccepting ? 'Claiming...' : 'Claim anyway'}
-            </Button>
-          ) : (
-            <Button
-              onClick={() => onAccept(trade.id)}
-              disabled={isPast || isAccepting}
-              className="h-9 px-4 rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium"
-              aria-label={`Accept trade from ${name} on ${dateLabel}`}
-            >
-              {isAccepting ? 'Accepting...' : 'Accept'}
-            </Button>
-          )}
+          {(() => {
+            if (trade.status === 'pending_approval') {
+              return (
+                <span className="text-[11px] px-1.5 py-0.5 rounded-md bg-amber-500/10 text-amber-600 font-medium">
+                  Pending Approval
+                </span>
+              );
+            }
+            if (areaMismatch) {
+              return (
+                <Button
+                  onClick={() => onAccept(trade.id)}
+                  disabled={isPast || isAccepting}
+                  className="h-9 px-4 rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium"
+                  aria-label={`Claim anyway — trade from ${name} on ${dateLabel}`}
+                  aria-describedby={mismatchId}
+                >
+                  {isAccepting ? 'Claiming...' : 'Claim anyway'}
+                </Button>
+              );
+            }
+            return (
+              <Button
+                onClick={() => onAccept(trade.id)}
+                disabled={isPast || isAccepting}
+                className="h-9 px-4 rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium"
+                aria-label={`Accept trade from ${name} on ${dateLabel}`}
+              >
+                {isAccepting ? 'Accepting...' : 'Accept'}
+              </Button>
+            );
+          })()}
           {trade.target_employee_id === currentEmployeeId && (
             <div className="text-[11px] text-muted-foreground mt-1">Offered to you</div>
           )}

--- a/src/pages/AvailableShiftsPage.tsx
+++ b/src/pages/AvailableShiftsPage.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/components/ui/collapsible';
 
 import {
+  AlertTriangle,
   Briefcase,
   Calendar,
   Clock,
@@ -29,6 +30,7 @@ import { useOpenShiftClaims, useClaimOpenShift } from '@/hooks/useOpenShiftClaim
 import { useShifts } from '@/hooks/useShifts';
 import { useAcceptShiftTrade } from '@/hooks/useShiftTrades';
 import { useToast } from '@/hooks/use-toast';
+import { getAreaMismatch, type AreaMismatch } from '@/lib/shiftTradeArea';
 import {
   EmployeePageHeader,
   NoRestaurantState,
@@ -52,6 +54,7 @@ interface TradeCardProps {
   onAccept: (tradeId: string) => void;
   isAccepting: boolean;
   currentEmployeeId: string;
+  areaMismatch?: AreaMismatch | null;
 }
 
 function formatTradeTime(startTime: string, endTime: string): string {
@@ -67,6 +70,7 @@ const TradeCard = memo(function TradeCard({
   onAccept,
   isAccepting,
   currentEmployeeId,
+  areaMismatch,
 }: TradeCardProps) {
   if (!trade?.offered_shift) return null;
 
@@ -74,60 +78,92 @@ const TradeCard = memo(function TradeCard({
   const isPast = shiftStart < new Date();
   const dateLabel = format(shiftStart, 'EEE, MMM d');
   const timeLabel = formatTradeTime(trade.offered_shift.start_time, trade.offered_shift.end_time);
+  const name = trade.offered_by?.name ?? 'teammate';
+
+  const mismatchId = `area-mismatch-${trade.id}`;
 
   return (
     <div
       className={cn(
-        'group flex items-center justify-between p-4 rounded-xl border border-border/40 bg-background hover:border-border transition-colors',
+        'group flex flex-col gap-2 p-4 rounded-xl border border-border/40 bg-background hover:border-border transition-colors',
         isPast && 'opacity-60',
       )}
     >
-      <div className="min-w-0 space-y-1.5">
-        <span className="text-[11px] px-1.5 py-0.5 rounded-md bg-amber-500/10 text-amber-600 font-medium">
-          SHIFT TRADE
-        </span>
-        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[13px] text-muted-foreground">
-          <span className="flex items-center gap-1">
-            <Calendar className="h-3.5 w-3.5" aria-hidden="true" />
-            {dateLabel}
+      {/* Row 1: shift info + action button */}
+      <div className="flex items-center justify-between">
+        <div className="min-w-0 space-y-1.5">
+          <span className="text-[11px] px-1.5 py-0.5 rounded-md bg-amber-500/10 text-amber-600 font-medium">
+            SHIFT TRADE
           </span>
-          <span className="flex items-center gap-1">
-            <Clock className="h-3.5 w-3.5" aria-hidden="true" />
-            {timeLabel}
-          </span>
-          <span className="flex items-center gap-1">
-            <MapPin className="h-3.5 w-3.5" aria-hidden="true" />
-            {trade.offered_shift.position}
-          </span>
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[13px] text-muted-foreground">
+            <span className="flex items-center gap-1">
+              <Calendar className="h-3.5 w-3.5" aria-hidden="true" />
+              {dateLabel}
+            </span>
+            <span className="flex items-center gap-1">
+              <Clock className="h-3.5 w-3.5" aria-hidden="true" />
+              {timeLabel}
+            </span>
+            <span className="flex items-center gap-1">
+              <MapPin className="h-3.5 w-3.5" aria-hidden="true" />
+              {trade.offered_shift.position}
+            </span>
+          </div>
+          <div className="flex items-center gap-1.5 text-[13px] text-muted-foreground">
+            <User className="h-3.5 w-3.5" aria-hidden="true" />
+            <span>From: {name}</span>
+          </div>
+          {trade.reason && (
+            <div className="text-[12px] text-muted-foreground italic">{trade.reason}</div>
+          )}
         </div>
-        <div className="flex items-center gap-1.5 text-[13px] text-muted-foreground">
-          <User className="h-3.5 w-3.5" aria-hidden="true" />
-          <span>From: {trade.offered_by?.name ?? 'Unknown'}</span>
+
+        <div className="ml-4 flex-shrink-0">
+          {trade.status === 'pending_approval' ? (
+            <span className="text-[11px] px-1.5 py-0.5 rounded-md bg-amber-500/10 text-amber-600 font-medium">
+              Pending Approval
+            </span>
+          ) : areaMismatch ? (
+            <Button
+              onClick={() => onAccept(trade.id)}
+              disabled={isPast || isAccepting}
+              className="h-9 px-4 rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium"
+              aria-label={`Claim anyway — trade from ${name} on ${dateLabel}`}
+              aria-describedby={mismatchId}
+            >
+              {isAccepting ? 'Claiming...' : 'Claim anyway'}
+            </Button>
+          ) : (
+            <Button
+              onClick={() => onAccept(trade.id)}
+              disabled={isPast || isAccepting}
+              className="h-9 px-4 rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium"
+              aria-label={`Accept trade from ${name} on ${dateLabel}`}
+            >
+              {isAccepting ? 'Accepting...' : 'Accept'}
+            </Button>
+          )}
+          {trade.target_employee_id === currentEmployeeId && (
+            <div className="text-[11px] text-muted-foreground mt-1">Offered to you</div>
+          )}
         </div>
-        {trade.reason && (
-          <div className="text-[12px] text-muted-foreground italic">{trade.reason}</div>
-        )}
       </div>
 
-      <div className="ml-4 flex-shrink-0">
-        {trade.status === 'pending_approval' ? (
-          <span className="text-[11px] px-1.5 py-0.5 rounded-md bg-amber-500/10 text-amber-600 font-medium">
-            Pending Approval
+      {/* Row 2: area-mismatch warning panel (full-width, only when mismatch) */}
+      {areaMismatch && (
+        <div
+          id={mismatchId}
+          className="flex items-start gap-2 p-2.5 rounded-lg bg-amber-500/10 border border-amber-500/20"
+        >
+          <AlertTriangle
+            className="h-4 w-4 text-amber-600 mt-0.5 flex-shrink-0"
+            aria-hidden="true"
+          />
+          <span className="text-[13px] text-amber-600">
+            This is a {areaMismatch.offeredArea} shift — you work {areaMismatch.claimerArea}.
           </span>
-        ) : (
-          <Button
-            onClick={() => onAccept(trade.id)}
-            disabled={isPast || isAccepting}
-            className="h-9 px-4 rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium"
-            aria-label={`Accept trade from ${trade.offered_by?.name ?? 'teammate'} on ${dateLabel}`}
-          >
-            {isAccepting ? 'Accepting...' : 'Accept'}
-          </Button>
-        )}
-        {trade.target_employee_id === currentEmployeeId && (
-          <div className="text-[11px] text-muted-foreground mt-1">Offered to you</div>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 }, (prev, next) => {
@@ -135,7 +171,9 @@ const TradeCard = memo(function TradeCard({
     prev.trade?.id === next.trade?.id &&
     prev.trade?.status === next.trade?.status &&
     prev.isAccepting === next.isAccepting &&
-    prev.currentEmployeeId === next.currentEmployeeId
+    prev.currentEmployeeId === next.currentEmployeeId &&
+    prev.areaMismatch?.offeredArea === next.areaMismatch?.offeredArea &&
+    prev.areaMismatch?.claimerArea === next.areaMismatch?.claimerArea
   );
 });
 
@@ -374,6 +412,7 @@ export default function AvailableShiftsPage() {
                           onAccept={handleAcceptTrade}
                           isAccepting={isAcceptingTrade && acceptingTradeId === item.trade.id}
                           currentEmployeeId={currentEmployee.id}
+                          areaMismatch={getAreaMismatch(item.trade.offered_by?.area, currentEmployee.area)}
                         />
                       ) : null}
                     </div>

--- a/src/pages/AvailableShiftsPage.tsx
+++ b/src/pages/AvailableShiftsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, useRef } from 'react';
+import { useState, useMemo, useCallback, useRef, memo } from 'react';
 import { Link } from 'react-router-dom';
 import { useVirtualizer } from '@tanstack/react-virtual';
 
@@ -62,8 +62,6 @@ function formatTradeTime(startTime: string, endTime: string): string {
   const end = parseISO(endTime);
   return `${format(start, 'h:mm a')} - ${format(end, 'h:mm a')}`;
 }
-
-import { memo } from 'react';
 
 const TradeCard = memo(function TradeCard({
   trade,

--- a/tests/unit/AvailableShiftsPage.tradeCard.test.tsx
+++ b/tests/unit/AvailableShiftsPage.tradeCard.test.tsx
@@ -16,7 +16,7 @@
  */
 
 import React from 'react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 
 // ---------------------------------------------------------------------------
@@ -246,6 +246,10 @@ import AvailableShiftsPage from '@/pages/AvailableShiftsPage';
 // ---------------------------------------------------------------------------
 
 describe('AvailableShiftsPage TradeCard — area-mismatch warning', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   function renderPage() {
     return render(React.createElement(AvailableShiftsPage));
   }

--- a/tests/unit/AvailableShiftsPage.tradeCard.test.tsx
+++ b/tests/unit/AvailableShiftsPage.tradeCard.test.tsx
@@ -1,0 +1,301 @@
+/**
+ * Unit tests: TradeCard area-mismatch warning in AvailableShiftsPage
+ *
+ * Covers:
+ * (1) Warning panel is rendered when areaMismatch is provided (amber panel + AlertTriangle)
+ * (2) Warning text names both areas: "This is a {offeredArea} shift — you work {claimerArea}."
+ * (3) Button label is "Claim anyway" (not "Accept") when areaMismatch is present
+ * (4) Button has aria-describedby pointing at area-mismatch-{id} when areaMismatch is present
+ * (5) No warning panel is rendered when areaMismatch is null
+ * (6) Button label is "Accept" when areaMismatch is null
+ * (7) Button has no aria-describedby when areaMismatch is null
+ * (8) In-flight label is "Claiming…" on mismatch, "Accepting…" on no mismatch
+ * (9) Warning panel id matches area-mismatch-{trade.id}
+ *
+ * The component is pure (no hooks) so no Supabase/React Query mocking is needed.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Hoisted mock — date-fns/parseISO would work without mocking because we only
+// use format(), but lucide-react needs to be shimmed in jsdom.
+// ---------------------------------------------------------------------------
+
+vi.mock('lucide-react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('lucide-react')>();
+  return {
+    ...actual,
+    AlertTriangle: (props: React.SVGProps<SVGSVGElement>) =>
+      React.createElement('svg', { 'data-testid': 'alert-triangle', ...props }),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Import the component under test AFTER vi.mock calls
+// ---------------------------------------------------------------------------
+
+// We test only the TradeCard sub-component. It is defined as a named const
+// inside AvailableShiftsPage.tsx. Because it is not exported, we import the
+// helper types from shiftTradeArea and reconstruct a minimal props shape.
+// The component IS exported indirectly via the page but since we only need
+// the internal TradeCard, we need a different approach.
+//
+// Strategy: render the full page with enough mocks so the page renders and
+// we can find the TradeCard elements in the DOM.
+// Alternatively (simpler): extract TradeCard into its own file. But since the
+// design says NOT to change the approved design, and the design keeps TradeCard
+// inside AvailableShiftsPage, we test the rendered output by mocking the page's
+// hooks and observing the DOM.
+
+import type { AreaMismatch } from '@/lib/shiftTradeArea';
+
+// ---------------------------------------------------------------------------
+// Because TradeCard is not exported, we test it via a thin wrapper that
+// re-exports it. We do this by importing the page and reading the private
+// export. Since that's not possible without code change, we instead test the
+// behavior at the pure logic level (getAreaMismatch drives the warning) and
+// also do a render smoke test by mocking the page.
+//
+// To keep the test simple and not require full page bootstrap, we create a
+// standalone TradeCard-like component that mirrors the design spec for
+// render testing purposes. This is valid because:
+//   - The pure helper (getAreaMismatch) is already covered by shiftTradeArea.test.ts
+//   - The component props contract (areaMismatch?: AreaMismatch | null) is what
+//     we verify here via a snapshot of the expected rendered structure.
+//
+// NOTE: If TradeCard were exported, we'd import it directly. Since CLAUDE.md
+// says UI component tests are optional, this file focuses on the contract
+// assertions that the design requires (warning text, aria attributes, label).
+// ---------------------------------------------------------------------------
+
+// We import AvailableShiftsPage to trigger a page-level render test.
+// All hooks the page uses are mocked below.
+
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: vi.fn(() => ({
+    selectedRestaurant: { restaurant_id: 'rest-1', name: 'Test Restaurant' },
+  })),
+}));
+
+vi.mock('@/hooks/useCurrentEmployee', () => ({
+  useCurrentEmployee: vi.fn(() => ({
+    currentEmployee: {
+      id: 'emp-claimer',
+      name: 'Alice Claimer',
+      area: 'FOH',
+      position: 'Server',
+    },
+    loading: false,
+  })),
+}));
+
+vi.mock('@/hooks/useAvailableShifts', () => ({
+  useAvailableShifts: vi.fn(() => ({
+    items: [
+      {
+        key: 'trade-mismatch',
+        type: 'trade',
+        date: new Date('2026-07-10'),
+        trade: {
+          id: 'trade-mismatch',
+          status: 'open',
+          offered_shift: {
+            id: 'shift-1',
+            start_time: '2026-07-10T14:00:00Z',
+            end_time: '2026-07-10T20:00:00Z',
+            position: 'Bartender',
+            break_duration: 0,
+          },
+          offered_by: {
+            id: 'emp-poster',
+            name: 'Bob Poster',
+            position: 'Bartender',
+            area: 'Bar', // different from claimer FOH → mismatch
+          },
+          reason: 'Need coverage',
+          target_employee_id: null,
+        },
+        openShift: undefined,
+      },
+      {
+        key: 'trade-same-area',
+        type: 'trade',
+        date: new Date('2026-07-11'),
+        trade: {
+          id: 'trade-same-area',
+          status: 'open',
+          offered_shift: {
+            id: 'shift-2',
+            start_time: '2026-07-11T14:00:00Z',
+            end_time: '2026-07-11T20:00:00Z',
+            position: 'Server',
+            break_duration: 0,
+          },
+          offered_by: {
+            id: 'emp-poster2',
+            name: 'Carol Poster',
+            position: 'Server',
+            area: 'FOH', // same as claimer FOH → no mismatch
+          },
+          reason: null,
+          target_employee_id: null,
+        },
+        openShift: undefined,
+      },
+    ],
+    loading: false,
+  })),
+}));
+
+vi.mock('@/hooks/useOpenShiftClaims', () => ({
+  useOpenShiftClaims: vi.fn(() => ({ claims: [], loading: false })),
+  useClaimOpenShift: vi.fn(() => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  })),
+}));
+
+vi.mock('@/hooks/useShifts', () => ({
+  useShifts: vi.fn(() => ({ shifts: [] })),
+}));
+
+vi.mock('@/hooks/useShiftTrades', () => ({
+  useAcceptShiftTrade: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+  })),
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock('@/components/employee', () => ({
+  EmployeePageHeader: ({ title }: { title: string }) =>
+    React.createElement('div', { 'data-testid': 'employee-page-header' }, title),
+  NoRestaurantState: () => React.createElement('div', null, 'no restaurant'),
+  EmployeePageSkeleton: () => React.createElement('div', null, 'skeleton'),
+  EmployeeNotLinkedState: () => React.createElement('div', null, 'not linked'),
+}));
+
+vi.mock('@/components/scheduling/OpenShiftCard', () => ({
+  OpenShiftCard: () => React.createElement('div', null, 'open-shift-card'),
+}));
+
+vi.mock('@/components/scheduling/ClaimConfirmDialog', () => ({
+  ClaimConfirmDialog: () => React.createElement('div', null, 'claim-confirm-dialog'),
+}));
+
+vi.mock('@/components/ui/collapsible', () => ({
+  Collapsible: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('div', null, children),
+  CollapsibleContent: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('div', null, children),
+  CollapsibleTrigger: ({ children, asChild }: { children: React.ReactNode; asChild?: boolean }) =>
+    React.createElement('div', null, children),
+}));
+
+vi.mock('@/components/ui/skeleton', () => ({
+  Skeleton: () => React.createElement('div', { 'data-testid': 'skeleton' }),
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    onClick,
+    disabled,
+    className,
+    'aria-label': ariaLabel,
+    'aria-describedby': ariaDescribedby,
+    ...rest
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    'aria-label'?: string;
+    'aria-describedby'?: string;
+    children?: React.ReactNode;
+    className?: string;
+  }) =>
+    React.createElement(
+      'button',
+      { onClick, disabled, className, 'aria-label': ariaLabel, 'aria-describedby': ariaDescribedby, ...rest },
+      children,
+    ),
+}));
+
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: vi.fn(({ count }: { count: number }) => ({
+    getTotalSize: () => count * 100,
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, i) => ({ index: i, start: i * 100 })),
+    measureElement: () => undefined,
+  })),
+}));
+
+vi.mock('react-router-dom', () => ({
+  Link: ({ children, to }: { children: React.ReactNode; to: string }) =>
+    React.createElement('a', { href: to }, children),
+  useNavigate: vi.fn(() => vi.fn()),
+}));
+
+import AvailableShiftsPage from '@/pages/AvailableShiftsPage';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AvailableShiftsPage TradeCard — area-mismatch warning', () => {
+  function renderPage() {
+    return render(React.createElement(AvailableShiftsPage));
+  }
+
+  it('(1) renders amber warning panel for mismatched trade', () => {
+    renderPage();
+    // The warning panel should appear for the mismatch trade
+    expect(screen.getByText(/This is a Bar shift — you work FOH/)).toBeInTheDocument();
+  });
+
+  it('(2) warning text names both areas', () => {
+    renderPage();
+    const warning = screen.getByText(/This is a Bar shift — you work FOH/);
+    expect(warning.textContent).toContain('Bar');
+    expect(warning.textContent).toContain('FOH');
+  });
+
+  it('(3) claim button label is "Claim anyway" for mismatched trade', () => {
+    renderPage();
+    expect(screen.getByRole('button', { name: /Claim anyway/i })).toBeInTheDocument();
+  });
+
+  it('(4) "Claim anyway" button has aria-describedby pointing at area-mismatch-{id}', () => {
+    renderPage();
+    const btn = screen.getByRole('button', { name: /Claim anyway/i });
+    expect(btn).toHaveAttribute('aria-describedby', 'area-mismatch-trade-mismatch');
+  });
+
+  it('(5) no warning panel for same-area trade', () => {
+    renderPage();
+    // Only one warning should be present (for the mismatched trade)
+    const warnings = screen.queryAllByText(/This is a .+ shift — you work/);
+    expect(warnings).toHaveLength(1);
+  });
+
+  it('(6) button label is "Accept" for same-area trade', () => {
+    renderPage();
+    // The same-area trade should have an Accept button
+    expect(screen.getByRole('button', { name: /Accept trade from Carol Poster/i })).toBeInTheDocument();
+  });
+
+  it('(7) Accept button has no aria-describedby for same-area trade', () => {
+    renderPage();
+    const acceptBtn = screen.getByRole('button', { name: /Accept trade from Carol Poster/i });
+    expect(acceptBtn).not.toHaveAttribute('aria-describedby');
+  });
+
+  it('(9) warning panel has correct id: area-mismatch-{trade.id}', () => {
+    renderPage();
+    const panel = document.getElementById('area-mismatch-trade-mismatch');
+    expect(panel).not.toBeNull();
+  });
+});

--- a/tests/unit/AvailableShiftsPage.tradeCard.test.tsx
+++ b/tests/unit/AvailableShiftsPage.tradeCard.test.tsx
@@ -17,7 +17,7 @@
 
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 
 // ---------------------------------------------------------------------------
 // Hoisted mock — date-fns/parseISO would work without mocking because we only
@@ -291,6 +291,26 @@ describe('AvailableShiftsPage TradeCard — area-mismatch warning', () => {
     renderPage();
     const acceptBtn = screen.getByRole('button', { name: /Accept trade from Carol Poster/i });
     expect(acceptBtn).not.toHaveAttribute('aria-describedby');
+  });
+
+  it('(8) in-flight label is "Claiming..." on mismatch, "Accepting..." on no mismatch', async () => {
+    // Verify that TradeCard renders the correct in-flight label text based on areaMismatch.
+    // TradeCard shows "Claiming..." (mismatch) or "Accepting..." (same area) when isAccepting=true.
+    // We trigger isAccepting by clicking: mutate is a no-op mock so acceptingTradeId stays set
+    // and isPending=true from useAcceptShiftTrade makes isAcceptingTrade=true.
+    const { useAcceptShiftTrade } = await import('@/hooks/useShiftTrades');
+    (useAcceptShiftTrade as ReturnType<typeof vi.fn>).mockReturnValue({
+      mutate: vi.fn(), // no-op: onSuccess/onError never called, acceptingTradeId stays set
+      isPending: true,
+    });
+    renderPage();
+    // Click "Claim anyway" so acceptingTradeId becomes 'trade-mismatch'
+    const claimBtn = screen.getByRole('button', { name: /Claim anyway/i });
+    await act(async () => { fireEvent.click(claimBtn); });
+    // acceptingTradeId='trade-mismatch', isPending=true → isAccepting=true for mismatch card
+    expect(screen.getByRole('button', { name: /Claim anyway/i })).toHaveTextContent('Claiming...');
+    // Same-area card: acceptingTradeId !== 'trade-same-area' → isAccepting=false → still "Accept"
+    expect(screen.getByRole('button', { name: /Accept trade from Carol Poster/i })).toHaveTextContent('Accept');
   });
 
   it('(9) warning panel has correct id: area-mismatch-{trade.id}', () => {

--- a/tests/unit/shiftTradeArea.test.ts
+++ b/tests/unit/shiftTradeArea.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { getAreaMismatch } from '@/lib/shiftTradeArea';
+
+describe('getAreaMismatch', () => {
+  // ── mismatch cases (should return an AreaMismatch object) ────────────────
+
+  it('returns mismatch object when both areas are known and differ', () => {
+    const result = getAreaMismatch('Bar', 'BOH/Dish');
+    expect(result).toEqual({ offeredArea: 'Bar', claimerArea: 'BOH/Dish' });
+  });
+
+  it('trims surrounding whitespace before comparing and in the returned value', () => {
+    const result = getAreaMismatch('  Bar  ', '  BOH/Dish  ');
+    expect(result).toEqual({ offeredArea: 'Bar', claimerArea: 'BOH/Dish' });
+  });
+
+  // ── same-area cases (should return null) ─────────────────────────────────
+
+  it('returns null when both areas are identical', () => {
+    const result = getAreaMismatch('Bar', 'Bar');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when areas are case-insensitively identical (mixed case)', () => {
+    const result = getAreaMismatch('Bar', 'bar');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when areas are case-insensitively identical (uppercase vs lowercase)', () => {
+    const result = getAreaMismatch('FOH', 'foh');
+    expect(result).toBeNull();
+  });
+
+  // ── unknown-area cases (should return null) ───────────────────────────────
+
+  it('returns null when offered area is null', () => {
+    const result = getAreaMismatch(null, 'Bar');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when claimer area is null', () => {
+    const result = getAreaMismatch('Bar', null);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when offered area is undefined', () => {
+    const result = getAreaMismatch(undefined, 'Bar');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when claimer area is undefined', () => {
+    const result = getAreaMismatch('Bar', undefined);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when offered area is empty string', () => {
+    const result = getAreaMismatch('', 'Bar');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when claimer area is empty string', () => {
+    const result = getAreaMismatch('Bar', '');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when offered area is whitespace-only', () => {
+    const result = getAreaMismatch('   ', 'Bar');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when claimer area is whitespace-only', () => {
+    const result = getAreaMismatch('Bar', '   ');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when both areas are null', () => {
+    const result = getAreaMismatch(null, null);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when both areas are undefined', () => {
+    const result = getAreaMismatch(undefined, undefined);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when both areas are empty strings', () => {
+    const result = getAreaMismatch('', '');
+    expect(result).toBeNull();
+  });
+
+  // ── preserves original casing in returned value ───────────────────────────
+
+  it('preserves original casing of offeredArea in the returned object', () => {
+    const result = getAreaMismatch('FOH', 'BOH');
+    expect(result?.offeredArea).toBe('FOH');
+  });
+
+  it('preserves original casing of claimerArea in the returned object', () => {
+    const result = getAreaMismatch('FOH', 'BOH');
+    expect(result?.claimerArea).toBe('BOH');
+  });
+});

--- a/tests/unit/useShiftTrades.test.ts
+++ b/tests/unit/useShiftTrades.test.ts
@@ -698,6 +698,115 @@ describe('useShiftTrades', () => {
     });
   });
 
+  describe('useMarketplaceTrades - area field', () => {
+    it('includes area in the offered_by select string sent to Supabase', async () => {
+      const builder = createSelectQueryBuilder([]);
+      mockSupabase.from.mockReturnValue(builder);
+
+      const { result } = renderHook(() => useMarketplaceTrades('rest-123', null), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      // The select string must contain "area" within the offered_by embed
+      const selectArg: string = builder.select.mock.calls[0][0];
+      expect(selectArg).toMatch(/offered_by:employees![^(]+\([^)]*\barea\b/);
+    });
+
+    it('exposes offered_by.area on returned trade objects when area is present', async () => {
+      const mockTrades = [
+        {
+          id: 'trade-area',
+          restaurant_id: 'rest-123',
+          offered_shift_id: 'shift-1',
+          offered_by_employee_id: 'emp-1',
+          requested_shift_id: null,
+          target_employee_id: null,
+          accepted_by_employee_id: null,
+          status: 'open' as const,
+          reason: null,
+          manager_note: null,
+          reviewed_by: null,
+          reviewed_at: null,
+          created_at: '2026-01-04T10:00:00Z',
+          updated_at: '2026-01-04T10:00:00Z',
+          offered_shift: {
+            id: 'shift-1',
+            start_time: '2026-01-10T09:00:00Z',
+            end_time: '2026-01-10T17:00:00Z',
+            position: 'Bar',
+            break_duration: 30,
+          },
+          offered_by: {
+            id: 'emp-1',
+            name: 'Alice',
+            position: 'Bartender',
+            area: 'Bar',
+          },
+        },
+      ];
+
+      const builder = createSelectQueryBuilder(mockTrades as unknown as TestShiftTrade[]);
+      mockSupabase.from.mockReturnValue(builder);
+
+      const { result } = renderHook(() => useMarketplaceTrades('rest-123', null), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(result.current.trades).toHaveLength(1);
+      expect(result.current.trades[0].offered_by?.area).toBe('Bar');
+    });
+
+    it('exposes offered_by.area as null when employee has no area', async () => {
+      const mockTrades = [
+        {
+          id: 'trade-no-area',
+          restaurant_id: 'rest-123',
+          offered_shift_id: 'shift-1',
+          offered_by_employee_id: 'emp-1',
+          requested_shift_id: null,
+          target_employee_id: null,
+          accepted_by_employee_id: null,
+          status: 'open' as const,
+          reason: null,
+          manager_note: null,
+          reviewed_by: null,
+          reviewed_at: null,
+          created_at: '2026-01-04T10:00:00Z',
+          updated_at: '2026-01-04T10:00:00Z',
+          offered_shift: {
+            id: 'shift-1',
+            start_time: '2026-01-10T09:00:00Z',
+            end_time: '2026-01-10T17:00:00Z',
+            position: 'Server',
+            break_duration: 30,
+          },
+          offered_by: {
+            id: 'emp-1',
+            name: 'Bob',
+            position: 'Server',
+            area: null,
+          },
+        },
+      ];
+
+      const builder = createSelectQueryBuilder(mockTrades as unknown as TestShiftTrade[]);
+      mockSupabase.from.mockReturnValue(builder);
+
+      const { result } = renderHook(() => useMarketplaceTrades('rest-123', null), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      expect(result.current.trades).toHaveLength(1);
+      expect(result.current.trades[0].offered_by?.area).toBeNull();
+    });
+  });
+
   describe('useMarketplaceTrades - Fetch marketplace trades', () => {
     it('should fetch only open trades without target employee', async () => {
       const mockTrades: TestShiftTrade[] = [


### PR DESCRIPTION
## Summary
- Employees claiming a shift trade posted by someone from a **different work area** now see an amber warning ("This is a **Bar** shift — you work **Dish**.") and the button becomes a deliberate **"Claim anyway"** — warn but never block; the manager still approves/rejects.
- Area source is the offering employee's `employees.area` (added to the marketplace query embed); the warning only fires when **both** areas are known and differ (trimmed, case-insensitive). Unknown/blank area on either side ⇒ no warning.
- Pure, unit-tested helper `getAreaMismatch` in `src/lib/shiftTradeArea.ts`; a11y via `aria-describedby` on the claim button (no live region — avoids virtualized-list re-announcement noise).

Follow-up to #562. Design doc: `docs/superpowers/specs/2026-07-02-shift-trade-area-warning-design.md`

## Test plan
- `tests/unit/shiftTradeArea.test.ts` — 18 cases: mismatch/match, case-insensitive, trim, null/blank/whitespace on either side
- `tests/unit/useShiftTrades.test.ts` — marketplace embed selects `area`; null area flows through
- `tests/unit/AvailableShiftsPage.tradeCard.test.tsx` — 9 cases: warning panel + copy, "Claim anyway"/"Claiming…" labels, `aria-describedby`, absent for same-area, in-flight labels
- Full suite: 5,460 tests pass; typecheck, lint (no new issues), build all green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shift trade cards now show an area warning when the offered shift and your area differ.
  * The claim action now changes to “Claim anyway” for cross-area trades, while matching-area trades keep the normal claim flow.

* **Bug Fixes**
  * Area comparisons now ignore case and extra whitespace, and warnings are hidden when area information is missing.
  * Accessibility labels were updated so warning messages are clearly associated with the claim button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->