### PR TITLE
fix(focus): custom-range sync persists connection state (stale banner)

### DIFF
--- a/supabase/functions/_shared/focusSyncDataHandler.ts
+++ b/supabase/functions/_shared/focusSyncDataHandler.ts
@@ -366,6 +366,33 @@ export async function handleSyncData(
         endDate,
       );
 
+      // Persist connection state, mirroring the backfill/incremental paths:
+      // success clears any stale error banner, failure records it. Without this
+      // a range sync left the banner untouched (stale error shown after a clean
+      // run, or a clean status shown after a failed one). No cursor CAS — the
+      // range path never touches sync_cursor.
+      const rangeNowIso = now.toISOString();
+      const rangeUpdatePayload: Record<string, unknown> = {
+        last_sync_time: rangeNowIso,
+        updated_at: rangeNowIso,
+      };
+      if (rangeResult.status === 'error') {
+        rangeUpdatePayload.connection_status = 'error';
+        rangeUpdatePayload.last_error =
+          rangeResult.error ?? 'Focus custom-range sync failed';
+        rangeUpdatePayload.last_error_at = rangeNowIso;
+      } else {
+        rangeUpdatePayload.connection_status = 'connected';
+        rangeUpdatePayload.last_error = null;
+        rangeUpdatePayload.last_error_at = null;
+      }
+      await deps.serviceClient
+        .from('focus_connections')
+        .update(rangeUpdatePayload)
+        .eq('id', connRow.id)
+        .eq('restaurant_id', restaurantId)
+        .select();
+
       return new Response(
         JSON.stringify({
           daysSynced: rangeResult.daysSynced,

--- a/supabase/functions/_shared/focusSyncDataHandler.ts
+++ b/supabase/functions/_shared/focusSyncDataHandler.ts
@@ -386,12 +386,20 @@ export async function handleSyncData(
         rangeUpdatePayload.last_error = null;
         rangeUpdatePayload.last_error_at = null;
       }
-      await deps.serviceClient
+      // Best-effort: the sync itself already succeeded/failed on its own merits,
+      // so a transient state-write failure must not flip the response — but it
+      // must be visible, and the banner self-heals on the next sync's write.
+      const { error: rangeStateErr } = await deps.serviceClient
         .from('focus_connections')
         .update(rangeUpdatePayload)
         .eq('id', connRow.id)
         .eq('restaurant_id', restaurantId)
         .select();
+      if (rangeStateErr) {
+        console.warn(
+          `focus-sync-data: custom-range connection-state write failed: ${rangeStateErr.message}`,
+        );
+      }
 
       return new Response(
         JSON.stringify({

--- a/tests/unit/focusSyncDataHandler.test.ts
+++ b/tests/unit/focusSyncDataHandler.test.ts
@@ -201,7 +201,9 @@ function makeServiceClientMock(opts: { connection?: MockConnection } = {}) {
   // Last .eq returns { data: [{id}], error: null } (1 row = CAS success); expose select() for CAS check.
   const casSelectMock = vi.fn().mockResolvedValue({ data: [{ id: 'conn-uuid' }], error: null });
   const eqUpdate3Mock = vi.fn().mockReturnValue({ select: casSelectMock });
-  const eqUpdate2Mock = vi.fn().mockReturnValue({ eq: eqUpdate3Mock });
+  // Second .eq also exposes select() so the 2-eq custom-range chain
+  // (.eq('id').eq('restaurant_id').select() — no cursor CAS) works too.
+  const eqUpdate2Mock = vi.fn().mockReturnValue({ eq: eqUpdate3Mock, select: casSelectMock });
   const eqUpdateMock = vi.fn().mockReturnValue({ eq: eqUpdate2Mock });
   const updateMock = vi.fn().mockReturnValue({ eq: eqUpdateMock });
 
@@ -832,6 +834,44 @@ describe('handleSyncData', () => {
       expect(res.status).toBe(200);
       const body = await res.json();
       expect(body.daysSynced).toBe(3);
+    });
+
+    it('clears a stale error banner when the range sync succeeds', async () => {
+      const { deps, mocks } = makeDeps({
+        serviceClientOpts: { connection: MOCK_CONNECTION_LYNK_INCREMENTAL as any },
+      });
+      const req = makeRequest({
+        body: { restaurantId: RESTAURANT_ID, startDate: '2026-06-01', endDate: '2026-06-03' },
+      });
+      await handleSyncData(req, deps);
+
+      // The range path must persist connection state like every other path.
+      const updateArg = mocks.updateMock.mock.calls[0][0] as Record<string, unknown>;
+      expect(updateArg.connection_status).toBe('connected');
+      expect(updateArg.last_error).toBeNull();
+      expect(updateArg.last_error_at).toBeNull();
+      expect(typeof updateArg.last_sync_time).toBe('string');
+    });
+
+    it('persists connection_status="error" + last_error when the range sync fails', async () => {
+      mockProcessDateRangeTransactions.mockResolvedValue({
+        status: 'error',
+        error: 'Focus POS Lynk response did not contain a blob_url',
+        daysSynced: 1,
+      });
+      const { deps, mocks } = makeDeps({
+        serviceClientOpts: { connection: MOCK_CONNECTION_LYNK_INCREMENTAL as any },
+      });
+      const req = makeRequest({
+        body: { restaurantId: RESTAURANT_ID, startDate: '2026-06-01', endDate: '2026-06-03' },
+      });
+      const res = await handleSyncData(req, deps);
+
+      expect(res.status).toBe(200);
+      const updateArg = mocks.updateMock.mock.calls[0][0] as Record<string, unknown>;
+      expect(updateArg.connection_status).toBe('error');
+      expect(updateArg.last_error).toBe('Focus POS Lynk response did not contain a blob_url');
+      expect(updateArg.last_error_at).toBeDefined();
     });
   });
 

--- a/tests/unit/focusSyncDataHandler.test.ts
+++ b/tests/unit/focusSyncDataHandler.test.ts
@@ -873,6 +873,27 @@ describe('handleSyncData', () => {
       expect(updateArg.last_error).toBe('Focus POS Lynk response did not contain a blob_url');
       expect(updateArg.last_error_at).toBeDefined();
     });
+
+    it('still returns the sync result (200) when the state write itself fails', async () => {
+      const { deps, mocks } = makeDeps({
+        serviceClientOpts: { connection: MOCK_CONNECTION_LYNK_INCREMENTAL as any },
+      });
+      // Transient DB failure on the connection-state write — must be logged,
+      // never flip the (already successful) sync response.
+      mocks.casSelectMock.mockResolvedValueOnce({
+        data: null,
+        error: { message: 'connection reset' },
+      });
+      const req = makeRequest({
+        body: { restaurantId: RESTAURANT_ID, startDate: '2026-06-01', endDate: '2026-06-03' },
+      });
+      const res = await handleSyncData(req, deps);
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.daysSynced).toBe(3);
+      expect(body.status).toBe('ok');
+    });
   });
 
   // ── B3: Custom range — invalid → 400 (§8.2) ─────────────────────────────────


### PR DESCRIPTION
## Problem (verified in prod)
After deploying #572, a 7-day custom-range sync ran **cleanly** (00:34–00:36 UTC, ~18s/day, zero `546`s — the parse-CPU fix works), but the UI kept showing **yesterday's** stale error banner (`last_error_at = 2026-07-03 19:30:26`). Root cause: the custom-range branch returns right after `processDateRangeTransactions` with **no connection-state write at all** — #572's banner-hygiene fix covered the backfill/incremental/portal paths but missed this one. Same gap in the other direction: a *failing* range sync never persisted its error either.

## Fix
The range path now mirrors every other sync path: success → `connection_status='connected'`, `last_error(=null)`, `last_error_at(=null)`, `last_sync_time` bumped; failure → `connection_status='error'` + the range error message. No cursor CAS — the range path never touches `sync_cursor` (filters on id + restaurant_id only).

## Test plan
+2 tests (success clears a stale banner; failure persists the error); the shared update-chain mock's second `.eq` now also exposes `select()` for the 2-eq chain. 51/51 tests green in the suite, typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Custom date-range sync now refreshes the connection banner state on completion, updating the latest sync time and setting the connection to **connected**.
  * Previously shown error details are cleared after successful runs.
  * When the date-range processing fails, the connection banner now records the error message and error timestamp for clearer visibility.
  * If saving the connection state fails, the sync result is still returned successfully (best-effort persistence).

* **Tests**
  * Extended unit coverage for custom-range success, failure, and connection-state write failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->