### PR TITLE
fix(focus): legacy cron starved the claim scheduler — prod ingestion stopped after #579

### DIFF
--- a/supabase/functions/_shared/focusBulkSyncHandler.ts
+++ b/supabase/functions/_shared/focusBulkSyncHandler.ts
@@ -368,6 +368,45 @@ async function processConnection(
   return { newSyncCursor, newInitialSyncDone };
 }
 
+// ── Budget-break requeue ──────────────────────────────────────────────────────
+
+/**
+ * Re-queue claimed-but-unprocessed rows after a wall-clock budget break.
+ *
+ * claim_focus_sync_batch bumps last_sync_time on every claimed row up front,
+ * so a row the loop never reached would otherwise wait a full
+ * sync_interval_minutes despite not having synced. Setting last_sync_time
+ * back past the row's own interval makes it immediately due again AND sorts
+ * it to the front of the next tick's stalest-first claim.
+ *
+ * Best-effort: a failed write just means that row waits one interval — the
+ * same cost as the pre-fix behavior.
+ */
+async function requeueUnprocessed(
+  rows: FocusConnectionRow[],
+  deps: BulkSyncDeps,
+): Promise<void> {
+  for (const row of rows) {
+    try {
+      await deps.serviceClient
+        .from('focus_connections')
+        .update({
+          last_sync_time: new Date(
+            deps.now() - row.sync_interval_minutes * 60_000,
+          ).toISOString(),
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', row.id)
+        .eq('restaurant_id', row.restaurant_id);
+    } catch (err: unknown) {
+      console.warn(
+        `focus-bulk-sync: requeue after budget break failed for ${row.restaurant_id}:`,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+}
+
 // ── Handler ───────────────────────────────────────────────────────────────────
 
 /**
@@ -434,6 +473,12 @@ export async function handleBulkSync(
       // Wall-clock budget check (design §8: "90s wall-clock budget guard")
       if (deps.now() - startMs > BUDGET_MS) {
         console.log('focus-bulk-sync: wall-clock budget exceeded, stopping early');
+        // The claim already bumped last_sync_time on EVERY returned row, so
+        // rows we break on before processing would silently wait a full
+        // interval. Re-queue them: push last_sync_time back past their own
+        // interval so the next tick's claim picks them up first
+        // (stalest-first ordering). (CodeRabbit Major on PR #579.)
+        await requeueUnprocessed(rows.slice(i), deps);
         break;
       }
       await deps.sleep(INTER_RESTAURANT_DELAY_MS);

--- a/supabase/functions/_shared/focusBulkSyncHandler.ts
+++ b/supabase/functions/_shared/focusBulkSyncHandler.ts
@@ -196,13 +196,27 @@ interface BulkSyncResult {
 async function processConnection(
   row: FocusConnectionRow,
   deps: BulkSyncDeps,
-): Promise<{ newSyncCursor: number; newInitialSyncDone: boolean; skipped?: boolean }> {
+): Promise<{
+  newSyncCursor: number;
+  newInitialSyncDone: boolean;
+  skipped?: boolean;
+  /**
+   * True only when every attempted day synced without an error result.
+   * Gates the caller's error-banner clear: the legacy portal branch reports
+   * day failures as non-throwing {status:'error'} results, and clearing
+   * connection_status/last_error on such a run would mask the failure
+   * (Codex P2 on PR #581). The Lynk branch throws on failed days, so
+   * reaching the final return there implies clean.
+   */
+  syncedCleanly: boolean;
+}> {
   const tz = row.timezone || 'America/Chicago';
   const now = new Date(deps.now());
   const isLynkPath = !!row.api_key;
 
   let newSyncCursor = row.sync_cursor;
   let newInitialSyncDone = row.initial_sync_done;
+  const syncedCleanly = true;
 
   if (isLynkPath) {
     // ── Lynk API path (Focus POS API with api_key / api_secret) ──────────────
@@ -220,6 +234,7 @@ async function processConnection(
         newSyncCursor: row.sync_cursor,
         newInitialSyncDone: row.initial_sync_done,
         skipped: true,
+        syncedCleanly: true, // no write happens for skipped rows anyway
       };
     }
 
@@ -355,17 +370,24 @@ async function processConnection(
         if (newSyncCursor >= TARGET_DAYS) {
           newInitialSyncDone = true;
         }
+      } else {
+        // Non-throwing failure (legacy tolerance): the cursor stays put and
+        // the caller must NOT clear the error banner for this run.
+        syncedCleanly = false;
       }
     } else {
       const [yesterday, dayBefore] = recentBusinessDays(tz, now);
-      await Promise.all([
+      const dayResults = await Promise.all([
         processReportDay(syncDeps, conn, yesterday),
         processReportDay(syncDeps, conn, dayBefore),
       ]);
+      if (dayResults.some((r) => r.status === 'error')) {
+        syncedCleanly = false;
+      }
     }
   }
 
-  return { newSyncCursor, newInitialSyncDone };
+  return { newSyncCursor, newInitialSyncDone, syncedCleanly };
 }
 
 // ── Budget-break requeue ──────────────────────────────────────────────────────
@@ -487,35 +509,41 @@ export async function handleBulkSync(
     const row = rows[i];
 
     try {
-      const { newSyncCursor, newInitialSyncDone, skipped } = await processConnection(row, deps);
+      const { newSyncCursor, newInitialSyncDone, skipped, syncedCleanly } =
+        await processConnection(row, deps);
 
       // Skipped rows (Lynk backfill — owned by focus-backfill-sync) get NO write:
       // persisting the stale cursor could regress the cron's progress and bumping
       // last_sync_time would perturb the round-robin. Still counted as processed
       // (it was handled without error). (CodeRabbit Major, 9d.)
       if (!skipped) {
+        const successPayload: Record<string, unknown> = {
+          sync_cursor: newSyncCursor,
+          initial_sync_done: newInitialSyncDone,
+          last_sync_time: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+          // Reset backoff state on success (design review #4) — a healthy
+          // sync clears the failure streak so the connection resumes its
+          // normal sync_interval_minutes cadence via the due predicate.
+          consecutive_failures: 0,
+          next_attempt_at: null,
+        };
+        // A CLEAN scheduled sync also clears the error banner — without this,
+        // a stale last_error (e.g. one transient blob_url failure) stays on
+        // screen forever even while every subsequent 30-min sync succeeds.
+        // Gated on syncedCleanly: the legacy portal branch reports day
+        // failures as non-throwing {status:'error'} results, and clearing the
+        // banner on such a run would mask a real failure (Codex P2, PR #581).
+        if (syncedCleanly) {
+          successPayload.connection_status = 'connected';
+          successPayload.last_error = null;
+          successPayload.last_error_at = null;
+        }
         // Update the connection row with the new cursor + sync time (review S3).
         // Filter by both id and restaurant_id to satisfy multi-tenant contract.
         await deps.serviceClient
           .from('focus_connections')
-          .update({
-            sync_cursor: newSyncCursor,
-            initial_sync_done: newInitialSyncDone,
-            last_sync_time: new Date().toISOString(),
-            updated_at: new Date().toISOString(),
-            // Reset backoff state on success (design review #4) — a healthy
-            // sync clears the failure streak so the connection resumes its
-            // normal sync_interval_minutes cadence via the due predicate.
-            consecutive_failures: 0,
-            next_attempt_at: null,
-            // A successful scheduled sync also clears the error banner —
-            // without this, a stale last_error (e.g. one transient blob_url
-            // failure) stays on screen forever even while every subsequent
-            // 30-min sync succeeds.
-            connection_status: 'connected',
-            last_error: null,
-            last_error_at: null,
-          })
+          .update(successPayload)
           .eq('id', row.id)
           .eq('restaurant_id', row.restaurant_id);
       }

--- a/supabase/functions/_shared/focusBulkSyncHandler.ts
+++ b/supabase/functions/_shared/focusBulkSyncHandler.ts
@@ -216,7 +216,7 @@ async function processConnection(
 
   let newSyncCursor = row.sync_cursor;
   let newInitialSyncDone = row.initial_sync_done;
-  const syncedCleanly = true;
+  let syncedCleanly = true;
 
   if (isLynkPath) {
     // ── Lynk API path (Focus POS API with api_key / api_secret) ──────────────

--- a/supabase/functions/_shared/focusBulkSyncHandler.ts
+++ b/supabase/functions/_shared/focusBulkSyncHandler.ts
@@ -463,6 +463,13 @@ export async function handleBulkSync(
             // normal sync_interval_minutes cadence via the due predicate.
             consecutive_failures: 0,
             next_attempt_at: null,
+            // A successful scheduled sync also clears the error banner —
+            // without this, a stale last_error (e.g. one transient blob_url
+            // failure) stays on screen forever even while every subsequent
+            // 30-min sync succeeds.
+            connection_status: 'connected',
+            last_error: null,
+            last_error_at: null,
           })
           .eq('id', row.id)
           .eq('restaurant_id', row.restaurant_id);

--- a/supabase/functions/_shared/focusDatafeedFingerprint.ts
+++ b/supabase/functions/_shared/focusDatafeedFingerprint.ts
@@ -102,9 +102,22 @@ export function createDatafeedStateStore(client: StateStoreClient): DatafeedStat
           .eq('restaurant_id', restaurantId)
           .eq('business_date', businessDate)
           .maybeSingle();
-        if (error || !data) return null;
+        if (error) {
+          // Fail open (null ⇒ reprocess), but LOG it — a persistent read
+          // failure silently degrades delta-skip to "always reprocess" and
+          // deserves an operational signal (observability parity with
+          // touch/record, CodeRabbit nitpick).
+          console.warn(
+            `focus_datafeed_state get failed for ${restaurantId}/${businessDate}: ${error.message}`,
+          );
+          return null;
+        }
+        if (!data) return null;
         return { bytes: data.checks_bytes, sha256: data.checks_sha256, fetchedAt: data.fetched_at };
-      } catch {
+      } catch (err: unknown) {
+        console.warn(
+          `focus_datafeed_state get threw for ${restaurantId}/${businessDate}: ${err instanceof Error ? err.message : String(err)}`,
+        );
         return null;
       }
     },

--- a/supabase/functions/_shared/focusReportClient.ts
+++ b/supabase/functions/_shared/focusReportClient.ts
@@ -165,7 +165,11 @@ export function lynkIncrementalDates(
   const today = todayInTz(tz, now);
   const yesterday = subtractDays(today, 1);
   const fetchedMs = yesterdayFetchedAt ? Date.parse(yesterdayFetchedAt) : NaN;
-  const yesterdayIsFresh = Number.isFinite(fetchedMs) && now.getTime() - fetchedMs < YESTERDAY_REFRESH_MS;
+  // ageMs >= 0: a FUTURE fetched_at (clock skew, bad state repair) counts as
+  // stale, not fresh — otherwise yesterday could be skipped far too long.
+  const ageMs = now.getTime() - fetchedMs;
+  const yesterdayIsFresh =
+    Number.isFinite(fetchedMs) && ageMs >= 0 && ageMs < YESTERDAY_REFRESH_MS;
   return yesterdayIsFresh ? [today] : [today, yesterday];
 }
 

--- a/supabase/functions/_shared/focusSaveConnectionHandler.ts
+++ b/supabase/functions/_shared/focusSaveConnectionHandler.ts
@@ -131,6 +131,14 @@ export async function handleSaveConnection(
     sync_cursor: 0,
     initial_sync_done: false,
     last_sync_time: null,
+    // This handler only saves Lynk API connections — pin the fast cadence and
+    // clear any accumulated backoff. Without this, a legacy portal row
+    // (seeded 360 by the scheduler migration) that converts to API
+    // credentials would keep syncing every 6 h instead of every 30 min
+    // (codex review).
+    sync_interval_minutes: 30,
+    next_attempt_at: null,
+    consecutive_failures: 0,
     updated_at: new Date().toISOString(),
   };
 

--- a/supabase/functions/_shared/focusTransactionSyncHandler.ts
+++ b/supabase/functions/_shared/focusTransactionSyncHandler.ts
@@ -352,6 +352,7 @@ export async function processDayTransactions(
     // focus_order_items and focus_payments automatically.
     // unified_sales orphan-delete is handled by _sync_focus_transactions_to_unified_sales_impl.
 
+    let voidDeleteFailed = false;
     for (const voidedCheckId of deletedCheckIds) {
       const { error: delError } = await deps.supabase
         .from('focus_orders')
@@ -360,7 +361,12 @@ export async function processDayTransactions(
         .eq('business_date', businessDate)
         .eq('focus_check_id', voidedCheckId);
       if (delError) {
-        // Non-fatal: log and continue — the check may not exist locally yet.
+        // Non-fatal for THIS run: log and continue — the check may not exist
+        // locally yet. But remember the failure: recording the fingerprint
+        // below would make the next tick delta-skip this identical feed and
+        // never retry the void, leaving the voided check in focus_orders /
+        // unified_sales indefinitely (codex review).
+        voidDeleteFailed = true;
         console.warn(
           `focus_orders delete (voided check ${voidedCheckId}): ${delError.message}`,
         );
@@ -397,13 +403,14 @@ export async function processDayTransactions(
       }
     }
 
-    // Record the fingerprint only once the day is fully synced (data written
-    // AND unified_sales caught up). If the RPC failed above, deliberately
-    // skip the record so the next tick re-fetches, re-parses, and retries the
-    // RPC instead of matching a "stale-success" fingerprint and delta-skipping
-    // forever (codex review: prevents unified_sales — a P&L-critical table —
-    // from silently drifting stale after a transient RPC failure).
-    if (deps.stateStore && fingerprint && !unifiedSalesSyncFailed) {
+    // Record the fingerprint only once the day is fully synced (voids applied,
+    // data written, AND unified_sales caught up). If the RPC or any void
+    // delete failed above, deliberately skip the record so the next tick
+    // re-fetches, re-parses, and retries instead of matching a
+    // "stale-success" fingerprint and delta-skipping forever (codex review:
+    // prevents unified_sales — a P&L-critical table — and voided checks from
+    // silently drifting stale after a transient failure).
+    if (deps.stateStore && fingerprint && !unifiedSalesSyncFailed && !voidDeleteFailed) {
       const stateStore = deps.stateStore;
       const fp = fingerprint;
       await safeStateStoreCall(

--- a/supabase/migrations/20260705003631_focus_legacy_cron_no_claim_bump.sql
+++ b/supabase/migrations/20260705003631_focus_legacy_cron_no_claim_bump.sql
@@ -1,0 +1,84 @@
+-- ═════════════════════════════════════════════════════════════════════════════
+-- Fix: legacy daily-report cron starves the new claim scheduler (PR #579).
+--
+-- sync_all_focus_to_unified_sales() — the every-5-min focus-unified-sales-sync
+-- job serving the legacy SSRS daily-report path — contained
+--
+--     -- Fix 2: advance last_sync_time so the round-robin ORDER BY progresses
+--     UPDATE public.focus_connections SET last_sync_time = now() ...
+--
+-- That was correct when last_sync_time was only this job's rotation cursor.
+-- Since 20260704200320_focus_sync_frequency.sql, last_sync_time is the claim
+-- scheduler's due-marker (`_focus_connection_is_due`: due when last_sync_time
+-- ≤ now() − sync_interval_minutes). A bump every 5 minutes means no connection
+-- is EVER due — incremental Focus ingestion stops entirely (observed in prod
+-- immediately after the #579 deploy).
+--
+-- This migration re-creates the function WITHOUT the bump, transcribed from
+-- the live prod definition (pg_get_functiondef, 2026-07-05). Rotation note:
+-- without a bump this job re-selects the same oldest-5 connections each tick.
+-- Lynk connections still rotate (the claim scheduler and manual syncs advance
+-- last_sync_time); a hypothetical fleet of >5 pure-SSRS connections would
+-- re-aggregate the oldest five every tick — idempotent, bounded (2-day
+-- window), and acceptable for a dormant path.
+--
+-- Also (re)schedules the focus-unified-sales-sync job idempotently: the
+-- immediate prod mitigation was `SELECT cron.unschedule('focus-unified-sales-sync')`,
+-- so this migration must converge both from the mitigated and unmitigated state.
+-- ═════════════════════════════════════════════════════════════════════════════
+
+CREATE OR REPLACE FUNCTION public.sync_all_focus_to_unified_sales()
+RETURNS TABLE(restaurant_id uuid, rows_synced integer)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  r record;
+BEGIN
+  FOR r IN
+    SELECT fc.restaurant_id
+    FROM public.focus_connections fc
+    WHERE fc.is_active = true
+    ORDER BY fc.last_sync_time ASC NULLS FIRST
+    LIMIT 5        -- S5: bound cron work per invocation
+  LOOP
+    BEGIN
+      restaurant_id := r.restaurant_id;
+      -- Use yesterday UTC as the end date instead of CURRENT_DATE.
+      -- CURRENT_DATE (UTC) may be ahead of a restaurant's local date when that
+      -- restaurant is in a negative UTC offset (e.g. America/Los_Angeles at 01:00
+      -- UTC is still the previous day locally), which would push partial-day data
+      -- into unified_sales before the business day has closed.  Capping to
+      -- (NOW() AT TIME ZONE 'UTC')::date - 1 keeps the window to completed days.
+      rows_synced   := public._sync_focus_to_unified_sales_impl(
+                         r.restaurant_id,
+                         ((NOW() AT TIME ZONE 'UTC')::date - interval '2 days')::date,
+                         ((NOW() AT TIME ZONE 'UTC')::date - interval '1 day')::date
+                       );
+      -- NO last_sync_time bump here: that column is the claim scheduler's
+      -- due-marker (20260704200320). Bumping it from an aggregation-only job
+      -- starves claim_focus_sync_batch — connections never become due.
+      RETURN NEXT;
+    EXCEPTION WHEN OTHERS THEN
+      RAISE WARNING 'sync_all_focus_to_unified_sales: failed for restaurant %: %',
+        r.restaurant_id, SQLERRM;
+    END;
+  END LOOP;
+END;
+$$;
+
+-- Idempotent (re)schedule — converges whether or not the manual mitigation
+-- (cron.unschedule) ran first.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'focus-unified-sales-sync') THEN
+    PERFORM cron.unschedule('focus-unified-sales-sync');
+  END IF;
+END $$;
+
+SELECT cron.schedule(
+  'focus-unified-sales-sync',
+  '*/5 * * * *',
+  $$SELECT public.sync_all_focus_to_unified_sales()$$
+);

--- a/supabase/tests/43_focus_sync_hardening.sql
+++ b/supabase/tests/43_focus_sync_hardening.sql
@@ -8,7 +8,9 @@
 --  4  sync_focus_to_unified_sales(uuid) IS executable by authenticated role
 --  5  Tax offset external_item_id includes revenue_center slug
 --  6  Tip offset external_item_id includes revenue_center slug
---  7  sync_all_focus_to_unified_sales updates last_sync_time
+--  7  sync_all_focus_to_unified_sales leaves last_sync_time UNTOUCHED
+--     (inverted 2026-07-05: the old "Fix 2" bump starved the claim scheduler
+--      — see 20260705003631_focus_legacy_cron_no_claim_bump.sql)
 
 BEGIN;
 SELECT plan(7);
@@ -166,7 +168,14 @@ SELECT ok(
 );
 
 -- ─────────────────────────────────────────────────────────────────────────────
--- Test 7: sync_all_focus_to_unified_sales advances last_sync_time (Fix 2)
+-- Test 7: sync_all_focus_to_unified_sales leaves last_sync_time UNTOUCHED.
+--
+-- INVERTED 2026-07-05. The original test pinned the "Fix 2" round-robin bump
+-- (SET last_sync_time = now()). Since 20260704200320_focus_sync_frequency.sql,
+-- last_sync_time is the claim scheduler's due-marker — the bump made
+-- _focus_connection_is_due permanently false and stopped ALL incremental
+-- Focus ingestion in production. 20260705003631 removed the bump; this test
+-- now pins its absence.
 -- ─────────────────────────────────────────────────────────────────────────────
 SET LOCAL role TO postgres;
 SET LOCAL "request.jwt.claims" TO '';
@@ -181,22 +190,21 @@ BEGIN
   FROM public.focus_connections
   WHERE restaurant_id = '00000000-0000-0000-0000-f0c000000111';
 
-  -- Run sync_all (operates on last 2 UTC days; daily report is for 2026-06-02
-  -- so may not overlap — what matters is last_sync_time is updated regardless)
+  -- Run sync_all: it must aggregate WITHOUT touching the claim due-marker.
   PERFORM * FROM public.sync_all_focus_to_unified_sales();
 
   SELECT last_sync_time INTO v_after
   FROM public.focus_connections
   WHERE restaurant_id = '00000000-0000-0000-0000-f0c000000111';
 
-  IF v_after IS NULL OR v_after <= v_before THEN
-    RAISE EXCEPTION 'last_sync_time was not advanced by sync_all (before=%, after=%)',
+  IF v_after IS DISTINCT FROM v_before THEN
+    RAISE EXCEPTION 'sync_all must not write last_sync_time (claim due-marker); before=%, after=%',
       v_before, v_after;
   END IF;
 END;
 $$;
 
-SELECT ok(TRUE, 'sync_all_focus_to_unified_sales advances last_sync_time (round-robin fix)');
+SELECT ok(TRUE, 'sync_all_focus_to_unified_sales leaves last_sync_time untouched (claim due-marker)');
 
 SELECT * FROM finish();
 ROLLBACK;

--- a/supabase/tests/52_focus_legacy_cron_no_claim_bump.sql
+++ b/supabase/tests/52_focus_legacy_cron_no_claim_bump.sql
@@ -1,0 +1,52 @@
+-- Tests: legacy Focus crons must never write the claim scheduler's due-marker.
+-- Migration: 20260705003631_focus_legacy_cron_no_claim_bump.sql
+--
+-- Background: last_sync_time became the claim scheduler's due-marker in
+-- 20260704200320_focus_sync_frequency.sql. The legacy daily-report
+-- aggregation job bumped it every 5 minutes ("Fix 2" round-robin advance),
+-- which made `_focus_connection_is_due` permanently false and stopped ALL incremental
+-- Focus ingestion in production. These tests pin that no aggregation-only
+-- function touches the marker again.
+--
+-- NOTE (live pg_cron): the pgTAP database runs a real pg_cron, so the job is
+-- (re)scheduled inside this rolled-back transaction before its schedule is
+-- asserted (precedent: 50_categorization_backlog_drain.sql).
+
+BEGIN;
+SELECT plan(3);
+
+-- 1. The legacy daily-report aggregator no longer bumps the due-marker.
+SELECT ok(
+  pg_get_functiondef('public.sync_all_focus_to_unified_sales()'::regprocedure)
+    NOT LIKE '%SET last_sync_time%',
+  'sync_all_focus_to_unified_sales() does not write last_sync_time (claim due-marker)'
+);
+
+-- 2. Belt-and-braces: the transactions aggregator never bumped it — pin that.
+SELECT ok(
+  pg_get_functiondef('public.sync_all_focus_transactions_to_unified_sales()'::regprocedure)
+    NOT LIKE '%SET last_sync_time%',
+  'sync_all_focus_transactions_to_unified_sales() does not write last_sync_time'
+);
+
+-- 3. The legacy job stays scheduled every 5 minutes (rescheduled in-txn,
+--    immune to the live-cron race and to the manual prod mitigation).
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'focus-unified-sales-sync') THEN
+    PERFORM cron.unschedule('focus-unified-sales-sync');
+  END IF;
+  PERFORM cron.schedule(
+    'focus-unified-sales-sync',
+    '*/5 * * * *',
+    'SELECT public.sync_all_focus_to_unified_sales()'
+  );
+END $$;
+SELECT is(
+  (SELECT schedule FROM cron.job WHERE jobname = 'focus-unified-sales-sync'),
+  '*/5 * * * *',
+  'focus-unified-sales-sync remains scheduled every 5 minutes'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/tests/unit/focusBulkSyncHandler.test.ts
+++ b/tests/unit/focusBulkSyncHandler.test.ts
@@ -1009,5 +1009,36 @@ describe('handleBulkSync', () => {
       expect(update!.payload.last_error).toBeNull();
       expect(update!.payload.last_error_at).toBeNull();
     });
+
+    it('a portal run with a failed day does NOT clear the error banner (Codex P2, PR #581)', async () => {
+      // Garbage HTML → processReportDay returns a non-throwing
+      // {status:'error'} (legacy tolerance). The success update still runs,
+      // but writing connected/null last_error would mask the failure.
+      const { deps, mocks } = makeDeps({
+        serviceClientOpts: { claimRows: [MOCK_CONN_INCREMENTAL] },
+        fetchHtml: '<html><body>SSRS exploded</body></html>',
+      });
+      const req = makeRequest({ authHeader: `Bearer ${SERVICE_ROLE_KEY}` });
+      await handleBulkSync(req, deps);
+
+      const update = mocks.updateCalls.find((c) => c.payload.initial_sync_done !== undefined);
+      expect(update).toBeDefined();
+      expect(update!.payload.connection_status).toBeUndefined();
+      expect(update!.payload.last_error).toBeUndefined();
+      expect(update!.payload.last_error_at).toBeUndefined();
+    });
+
+    it('a clean portal run clears the error banner (parity with the Lynk path)', async () => {
+      const { deps, mocks } = makeDeps({
+        serviceClientOpts: { claimRows: [MOCK_CONN_INCREMENTAL] },
+      });
+      const req = makeRequest({ authHeader: `Bearer ${SERVICE_ROLE_KEY}` });
+      await handleBulkSync(req, deps);
+
+      const update = mocks.updateCalls.find((c) => c.payload.initial_sync_done !== undefined);
+      expect(update).toBeDefined();
+      expect(update!.payload.connection_status).toBe('connected');
+      expect(update!.payload.last_error).toBeNull();
+    });
   });
 });

--- a/tests/unit/focusBulkSyncHandler.test.ts
+++ b/tests/unit/focusBulkSyncHandler.test.ts
@@ -917,5 +917,23 @@ describe('handleBulkSync', () => {
       expect(update!.payload.consecutive_failures).toBe(0);
       expect(update!.payload.next_attempt_at).toBeNull();
     });
+
+    it('a successful connection clears the error banner (connected + null last_error)', async () => {
+      // Regression: prod kept showing a stale "blob_url" error banner because
+      // the success-path update never wrote connection_status/last_error.
+      const { deps, mocks } = makeDeps({
+        serviceClientOpts: {
+          claimRows: [lynkRow({ consecutive_failures: 1 })],
+        },
+      });
+      const req = makeRequest({ authHeader: `Bearer ${SERVICE_ROLE_KEY}` });
+      await handleBulkSync(req, deps);
+
+      const update = mocks.updateCalls.find((c) => c.payload.initial_sync_done !== undefined);
+      expect(update).toBeDefined();
+      expect(update!.payload.connection_status).toBe('connected');
+      expect(update!.payload.last_error).toBeNull();
+      expect(update!.payload.last_error_at).toBeNull();
+    });
   });
 });

--- a/tests/unit/focusBulkSyncHandler.test.ts
+++ b/tests/unit/focusBulkSyncHandler.test.ts
@@ -470,6 +470,80 @@ describe('handleBulkSync', () => {
     expect(fetchMock.mock.calls.length).toBe(2);
   });
 
+  // ── Budget-break requeue (CodeRabbit Major on PR #579) ───────────────────────
+  //
+  // claim_focus_sync_batch bumps last_sync_time on EVERY claimed row up front.
+  // A row the loop breaks on before ever calling processConnection would
+  // otherwise silently wait a full sync_interval_minutes despite never having
+  // synced this tick. requeueUnprocessed must push last_sync_time back past
+  // that row's own interval so it's immediately due again on the next claim.
+
+  it('requeues an unprocessed row after a budget break: last_sync_time is set into the past, filtered by that row id', async () => {
+    // Two claimed Lynk rows with distinct ids/restaurant_ids. The clock goes
+    // over budget right after the first row completes, so the second row is
+    // never passed to processConnection — it must be requeued instead.
+    const startMs = 1_000_000;
+    let callCount = 0;
+    const nowMock = () => {
+      callCount++;
+      if (callCount === 1) return startMs; // initial startMs capture
+      return startMs + 91_000; // over budget for every call after
+    };
+
+    const row1 = lynkRow({ id: 'conn-lynk-1', restaurant_id: RESTAURANT_ID_1, sync_interval_minutes: 30 });
+    const row2 = lynkRow({ id: 'conn-lynk-2', restaurant_id: RESTAURANT_ID_2, sync_interval_minutes: 45 });
+
+    const { deps, mocks } = makeDeps({
+      serviceClientOpts: { claimRows: [row1, row2] },
+      nowFn: nowMock,
+    });
+    const req = makeRequest({ authHeader: `Bearer ${SERVICE_ROLE_KEY}` });
+    const res = await handleBulkSync(req, deps);
+
+    const body = await res.json();
+    // Only the first row was processed; the second was requeued, not synced.
+    expect(body.processed).toBe(1);
+
+    // Find the update call scoped to row2's id (the requeue write) — the
+    // chain is .update(payload).eq('id', val).eq('restaurant_id', val), so
+    // row2's id/restaurant_id appear as the arguments to the two .eq() calls
+    // that immediately follow the update() call carrying last_sync_time.
+    const updateCallForRow2Index = mocks.updateMock.mock.calls.findIndex(
+      (_call: unknown[], idx: number) =>
+        mocks.eqUpdateMock.mock.calls[idx]?.[0] === 'id' &&
+        mocks.eqUpdateMock.mock.calls[idx]?.[1] === row2.id,
+    );
+    expect(updateCallForRow2Index).toBeGreaterThanOrEqual(0);
+
+    const requeuePayload = mocks.updateMock.mock.calls[updateCallForRow2Index][0] as Record<string, unknown>;
+    expect(requeuePayload.last_sync_time).toBeTruthy();
+    expect(typeof requeuePayload.updated_at).toBe('string');
+
+    // The "now at check" the handler used for the budget check (and reused by
+    // requeueUnprocessed for deps.now()) is startMs + 91_000. The requeued
+    // last_sync_time must equal that instant minus row2's own interval — and,
+    // regardless of the exact clock-mock plumbing, it must land safely in the
+    // past relative to the pinned "now at check" instant so the row is
+    // immediately due again.
+    const nowAtCheck = startMs + 91_000;
+    const expected = new Date(nowAtCheck - row2.sync_interval_minutes * 60_000).toISOString();
+    expect(requeuePayload.last_sync_time).toBe(expected);
+    expect(Date.parse(requeuePayload.last_sync_time as string)).toBeLessThan(nowAtCheck);
+
+    // row1 (the processed row) must NOT have been requeued — only row2 should
+    // carry a bare last_sync_time-only requeue payload for its id.
+    const updateCallForRow1Index = mocks.updateMock.mock.calls.findIndex(
+      (_call: unknown[], idx: number) =>
+        mocks.eqUpdateMock.mock.calls[idx]?.[0] === 'id' &&
+        mocks.eqUpdateMock.mock.calls[idx]?.[1] === row1.id,
+    );
+    expect(updateCallForRow1Index).toBeGreaterThanOrEqual(0);
+    const row1Payload = mocks.updateMock.mock.calls[updateCallForRow1Index][0] as Record<string, unknown>;
+    // row1's write is the normal success-path update (has sync_cursor etc.),
+    // not the requeue shape (which carries ONLY last_sync_time/updated_at).
+    expect(row1Payload).toHaveProperty('consecutive_failures');
+  });
+
   // ── Empty connection list ─────────────────────────────────────────────────────
 
   it('returns 200 with processed=0 when there are no active connections', async () => {

--- a/tests/unit/focusDatafeedFingerprint.test.ts
+++ b/tests/unit/focusDatafeedFingerprint.test.ts
@@ -64,6 +64,23 @@ describe('createDatafeedStateStore', () => {
     expect(await store.get('r1', '2026-07-04')).toBeNull();
   });
 
+  it('get logs a warning on query error (observability parity with touch/record, CodeRabbit nitpick)', async () => {
+    // A persistent read failure silently degrades delta-skip to "always
+    // reprocess" — that should still fail open (null), but it deserves an
+    // operational signal instead of being swallowed entirely.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { client } = makeClient(null, { message: 'boom' });
+      const store = createDatafeedStateStore(client);
+      const got = await store.get('r1', '2026-07-04');
+      expect(got).toBeNull();
+      expect(warnSpy).toHaveBeenCalledOnce();
+      expect(warnSpy.mock.calls[0][0]).toMatch(/focus_datafeed_state get failed for r1\/2026-07-04.*boom/);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it('record upserts the fingerprint on the composite key', async () => {
     const { client, mocks } = makeClient(null);
     const store = createDatafeedStateStore(client);

--- a/tests/unit/focusReportClient.test.ts
+++ b/tests/unit/focusReportClient.test.ts
@@ -301,4 +301,13 @@ describe('lynkIncrementalDates', () => {
   it('treats an unparseable fetchedAt as stale (fail toward re-fetching)', () => {
     expect(lynkIncrementalDates(tz, now, 'not-a-date')).toEqual(['2026-07-04', '2026-07-03']);
   });
+
+  it('treats a FUTURE fetchedAt as stale, not fresh (clock skew / bad state repair)', () => {
+    // now + 1h — a fetchedAt strictly after "now" would otherwise satisfy the
+    // old `ageMs < YESTERDAY_REFRESH_MS` check by producing a large negative
+    // ageMs, incorrectly marking yesterday "fresh" and skipping it far longer
+    // than the intended 6h window.
+    const futureFetchedAt = new Date(now.getTime() + 60 * 60 * 1000).toISOString();
+    expect(lynkIncrementalDates(tz, now, futureFetchedAt)).toEqual(['2026-07-04', '2026-07-03']);
+  });
 });

--- a/tests/unit/focusSaveConnectionHandler.test.ts
+++ b/tests/unit/focusSaveConnectionHandler.test.ts
@@ -161,6 +161,21 @@ describe('handleSaveConnection (FocusLink API)', () => {
     });
   });
 
+  it('pins the 30-min sync cadence and clears backoff state on save (codex review)', async () => {
+    // A legacy portal row seeded with a 360-min (6h) interval by the scheduler
+    // migration must NOT keep that cadence after converting to API credentials
+    // via this handler — otherwise it silently syncs 12x slower than intended.
+    // Any accumulated backoff (next_attempt_at/consecutive_failures) must also
+    // be cleared so fresh credentials get an immediate clean slate.
+    const { deps, mocks } = makeDeps();
+    await handleSaveConnection(makeRequest({}), deps);
+    expect(mocks.upsertMock.mock.calls[0][0]).toMatchObject({
+      sync_interval_minutes: 30,
+      next_attempt_at: null,
+      consecutive_failures: 0,
+    });
+  });
+
   it('returns 500 when the upsert fails', async () => {
     const { deps } = makeDeps({ serviceClientOpts: { error: 'unique constraint violated' } });
     const res = await handleSaveConnection(makeRequest({}), deps);

--- a/tests/unit/focusTransactionSyncHandler.test.ts
+++ b/tests/unit/focusTransactionSyncHandler.test.ts
@@ -666,6 +666,60 @@ describe('processDayTransactions', () => {
       expect(result).toEqual({ status: 'ok', checksWritten: 1 });
       expect(stateStore.record).toHaveBeenCalledOnce();
     });
+
+    // ── voidDeleteFailed gate (codex review) ──────────────────────────────────
+    // A feed containing a DeleteRecord (voided check) whose focus_orders delete
+    // fails must NOT record the fingerprint — otherwise the next tick sees a
+    // matching fingerprint and delta-skips, leaving the voided check stranded
+    // in focus_orders / unified_sales indefinitely.
+
+    const XML_WITH_DELETE = `<DailyData><Checks>
+<Check><CheckRecord><ID>10</ID><Total>12.50</Total></CheckRecord>
+<Seats><Seat><SeatRecord><Key>1</Key></SeatRecord>
+<CheckItemRecord><SeatKey>1</SeatKey><Key>3</Key><RecordNumber>100</RecordNumber>
+  <ID>Scoop</ID><GuestCheckName>Scoop Single</GuestCheckName>
+  <ReportGroupID>10</ReportGroupID><Price>4.99</Price>
+</CheckItemRecord>
+<PaymentRecord><SeatKey>1</SeatKey><Key>1</Key><ID>5</ID>
+  <Name>Visa</Name><Amount>12.50</Amount></PaymentRecord>
+</Seat></Seats></Check>
+<DeleteRecord><ID>99</ID></DeleteRecord>
+</Checks></DailyData>`;
+
+    it('does NOT record the fingerprint when a voided-check delete fails, so the next tick retries the void', async () => {
+      const stateStore = makeStateStore(null);
+      const { client, mocks } = makeSupabaseMock();
+      // Make the focus_orders delete chain resolve with an error (the check
+      // "may not exist locally yet" case the handler tolerates non-fatally).
+      mocks.deleteEqInnermost.mockResolvedValue({ error: { message: 'boom' } });
+      const fetchDatafeedMock = makeFetchDatafeedMock(XML_WITH_DELETE);
+      const deps: TransactionSyncDeps = {
+        supabase: client as unknown as TransactionSupabaseDeps,
+        fetchDatafeed: fetchDatafeedMock as unknown as FetchDatafeedFn,
+        stateStore,
+      };
+
+      const result = await processDayTransactions(deps, MOCK_CONFIG, BUSINESS_DATE);
+
+      // Non-fatal for this run: the live check is still processed and the
+      // overall result is still 'ok', not 'error'.
+      expect(result).toEqual({ status: 'ok', checksWritten: 1 });
+      expect(mocks.ordersDelete).toHaveBeenCalledOnce();
+      // But the fingerprint must NOT be recorded — the next tick must re-fetch
+      // and retry the void instead of delta-skipping this identical feed.
+      expect(stateStore.record).not.toHaveBeenCalled();
+    });
+
+    it('records the fingerprint when the voided-check delete succeeds', async () => {
+      const stateStore = makeStateStore(null);
+      const { deps, mocks } = makeDeps({ xml: XML_WITH_DELETE });
+
+      const result = await processDayTransactions({ ...deps, stateStore }, MOCK_CONFIG, BUSINESS_DATE);
+
+      expect(result).toEqual({ status: 'ok', checksWritten: 1 });
+      expect(mocks.ordersDelete).toHaveBeenCalledOnce();
+      expect(stateStore.record).toHaveBeenCalledOnce();
+    });
   });
 });
 


### PR DESCRIPTION
## What broke
Minutes after #579 deployed, verification showed **zero Focus ingestion**: the connection was claimed once, then never became due again. Root cause: the legacy daily-report job (`focus-unified-sales-sync`, every 5 min) contains a *"Fix 2: advance last_sync_time so the round-robin progresses"* UPDATE. That was correct when `last_sync_time` was only that job's rotation cursor — but #579 made it the claim scheduler's **due-marker**, so a bump every 5 minutes means `_focus_connection_is_due` is permanently false.

## Fixes
1. **`sync_all_focus_to_unified_sales()` re-created without the bump** — transcribed from the live prod definition (`pg_get_functiondef`, not from the old migration), `search_path` hardened to `pg_catalog, public`. Job rescheduled idempotently, so it converges from both the un-mitigated state and the manual `cron.unschedule('focus-unified-sales-sync')` mitigation. Inverted the pgTAP test that pinned the old bump (`43_focus_sync_hardening.sql` test 7) and added `52_focus_legacy_cron_no_claim_bump.sql` pinning that neither aggregation function ever writes the due-marker again.
2. **Scheduled-sync success now clears the error banner** (`connection_status: 'connected'`, `last_error/last_error_at: null`) — the stale 00:25 blob_url banner would otherwise have survived every healthy 30-min sync.
3. **PR #579 review triage** (cherry-picked; all 4 bot findings + 1 nitpick fixed, each with a regression test that fails when its fix is reverted):
   - Codex P2: converting a legacy portal connection to Lynk API credentials now resets `sync_interval_minutes` to 30 (and clears backoff) in the save handler.
   - Codex P2: a failed voided-check delete now blocks fingerprint recording, so the next tick retries the void instead of delta-skipping it forever.
   - CodeRabbit Major: on a wall-clock budget break, claimed-but-unprocessed rows are re-queued (last_sync_time pushed back past their interval) instead of silently waiting a full cadence.
   - CodeRabbit Minor: a *future* `fetched_at` (clock skew) now counts as stale in `lynkIncrementalDates`.
   - CodeRabbit nitpick: `focus_datafeed_state` `get()` failures are now logged (observability parity, still fail-open).

## Test plan
- pgTAP **1,625/1,625** (3 new in file 52; test-43/7 inverted to pin the absence of the bump)
- Unit **5,672 passed** (138 across the five Focus files; every review-fix test adversarially verified against its reverted fix)
- typecheck / lint / build clean; migration `20260705003631` collision-checked vs origin/main

## Prod state at time of writing
Starvation ongoing (last_sync_time bumped at :00/:05/:10…, 0 orders for 2026-07-04, 0 fingerprint rows). Interim mitigation available: `SELECT cron.unschedule('focus-unified-sales-sync');` — this migration re-schedules the job with the fixed function either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)