### PR TITLE
fix(prep): shadow-recipe self-heal, loud failure, and delete guard

### DIFF
--- a/docs/superpowers/plans/2026-07-04-prep-shadow-recipe-costing-plan.md
+++ b/docs/superpowers/plans/2026-07-04-prep-shadow-recipe-costing-plan.md
@@ -1,0 +1,922 @@
+# Prep Shadow-Recipe Costing Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Production runs deduct ingredients and cost output correctly even when the prep recipe's "shadow" `recipes` row is inactive; silent $0 completions become loud exceptions; shadow recipes stop appearing (and being soft-deletable) on the Recipes page; the one bad prod row is repaired by migration.
+
+**Architecture:** One SQL migration changes `process_unified_inventory_deduction` (new optional `p_recipe_id` param → by-id lookup, no `is_active` filter) and `complete_production_run` (passes the id, raises on silent no-op), repairs data, and adds a backstop trigger. Client changes are confined to `src/hooks/useRecipes.tsx` and `src/components/DeleteRecipeDialog.tsx`.
+
+**Tech Stack:** Postgres/plpgsql (Supabase migration), pgTAP, React hook (useState/useEffect — intentionally NOT migrating to React Query, see design doc §2d), Vitest.
+
+**Design doc:** `docs/superpowers/specs/2026-07-04-prep-shadow-recipe-costing-design.md`
+
+**Local DB test command:** `npm run test:db` (requires `npm run db:start` once). Unit tests: `npm run test`.
+
+---
+
+### Task 1: Migration — deduct by recipe id, loud failure, data repair, backstop trigger
+
+**Files:**
+- Create: `supabase/migrations/20260705000000_fix_prep_shadow_recipe_costing.sql`
+- Reference (read, do not modify): `supabase/migrations/20260203000000_enhance_prep_recipes_and_production.sql`
+
+The migration has 5 sections IN THIS ORDER (order matters: §2's function body calls the 10-arg signature created in §1; §4's trigger must be created AFTER §3's repair UPDATE).
+
+- [ ] **Step 1: Write the failing pgTAP test file** (see Task 2 — write the test FIRST, run `npm run test:db`, confirm it fails because the migration doesn't exist yet). Task 2 contains the complete test file; do Task 2 Steps 1–2, then return here.
+
+- [ ] **Step 2: Create the migration file skeleton with section comments**
+
+```sql
+-- Fix prep shadow-recipe costing (see docs/superpowers/specs/2026-07-04-prep-shadow-recipe-costing-design.md)
+--
+-- Incident: soft-deleting a prep-linked "shadow" recipe from the Recipes page
+-- (is_active = false) made process_unified_inventory_deduction's name+is_active
+-- lookup silently no-op, so complete_production_run completed runs at $0 cost
+-- with no ingredient deductions.
+--
+-- ORDER MATTERS:
+--   §1 must precede §2 (complete_production_run's new body calls the 10-arg signature).
+--   §3 (data repair) must precede §4 (the backstop trigger blocks is_active=false
+--      flips on prep-linked recipes; repair only sets true, but keep the order safe).
+
+-- ============================================================
+-- §1: process_unified_inventory_deduction gains p_recipe_id
+-- ============================================================
+-- ... (Step 3)
+
+-- ============================================================
+-- §2: complete_production_run — pass recipe id + loud failure
+-- ============================================================
+-- ... (Step 4)
+
+-- ============================================================
+-- §3: Data repair — reactivate prep-linked inactive shadow recipes
+-- ============================================================
+-- ... (Step 5)
+
+-- ============================================================
+-- §4: Backstop trigger — block deactivating prep-linked recipes
+-- ============================================================
+-- ... (Step 6)
+
+-- ============================================================
+-- §5: Comments
+-- ============================================================
+-- ... (Step 7)
+```
+
+- [ ] **Step 3: §1 — Recreate `process_unified_inventory_deduction` with `p_recipe_id`**
+
+Open `supabase/migrations/20260203000000_enhance_prep_recipes_and_production.sql`. The canonical definition is at lines 142–479 (starting `DROP FUNCTION IF EXISTS public.process_unified_inventory_deduction(uuid, text, integer, text, text, text, text);` then `CREATE OR REPLACE FUNCTION public.process_unified_inventory_deduction(...)`). Copy the ENTIRE definition into §1 of the new migration, then apply exactly these three changes:
+
+Change 1 — drop the CURRENT 9-arg signature first (Postgres cannot change a signature via CREATE OR REPLACE; a defaulted 10th param is a NEW signature, and leaving the 9-arg one behind would create PostgREST overload ambiguity):
+
+```sql
+DROP FUNCTION IF EXISTS public.process_unified_inventory_deduction(uuid, text, integer, text, text, text, text, text, text);
+```
+
+Change 2 — the parameter list gains a trailing defaulted param (everything else identical):
+
+```sql
+CREATE OR REPLACE FUNCTION public.process_unified_inventory_deduction(
+    p_restaurant_id uuid,
+    p_pos_item_name text,
+    p_quantity_sold integer,
+    p_sale_date text,
+    p_external_order_id text DEFAULT NULL,
+    p_sale_time text DEFAULT NULL,
+    p_restaurant_timezone text DEFAULT 'America/Chicago',
+    p_transaction_type text DEFAULT 'usage',
+    p_reason_prefix text DEFAULT 'POS sale',
+    p_recipe_id uuid DEFAULT NULL
+)
+```
+
+Change 3 — replace the single recipe-lookup statement. The current body contains exactly this:
+
+```sql
+    SELECT * INTO v_recipe_record
+    FROM recipes
+    WHERE restaurant_id = p_restaurant_id
+      AND (pos_item_name = p_pos_item_name OR name = p_pos_item_name)
+      AND is_active = true
+    LIMIT 1;
+```
+
+Replace it with:
+
+```sql
+    IF p_recipe_id IS NOT NULL THEN
+        -- Production-run path: direct by-id lookup. Deliberately NO is_active
+        -- filter — the shadow recipe is an implementation detail and a
+        -- soft-deleted shadow row must not silently disable deductions.
+        -- Tenant guard (restaurant_id) is preserved.
+        SELECT * INTO v_recipe_record
+        FROM recipes
+        WHERE id = p_recipe_id
+          AND restaurant_id = p_restaurant_id;
+    ELSE
+        -- POS-sale path: unchanged name-based lookup, active recipes only.
+        SELECT * INTO v_recipe_record
+        FROM recipes
+        WHERE restaurant_id = p_restaurant_id
+          AND (pos_item_name = p_pos_item_name OR name = p_pos_item_name)
+          AND is_active = true
+        LIMIT 1;
+    END IF;
+```
+
+Everything else in the function body (dedup/already_processed check, unit-conversion cascade, transaction inserts, result JSON) is copied verbatim — do NOT reformat or "improve" it.
+
+- [ ] **Step 4: §2 — Recreate `complete_production_run`**
+
+Copy the ENTIRE `CREATE OR REPLACE FUNCTION public.complete_production_run(...)` definition from `20260203000000_enhance_prep_recipes_and_production.sql` (lines 482–697; signature `(p_run_id uuid, p_actual_yield numeric, p_actual_yield_unit measurement_unit, p_ingredients jsonb DEFAULT '[]'::jsonb)` — signature is UNCHANGED so plain `CREATE OR REPLACE` works). Apply exactly these two changes:
+
+Change 1 — the deduction call gains the recipe id as a 10th positional argument. Current:
+
+```sql
+  v_deduction_result := public.process_unified_inventory_deduction(
+    v_run.restaurant_id,
+    v_recipe.name,
+    v_batch_multiplier_int,
+    v_sale_date,
+    v_run.id::text,
+    NULL,
+    v_restaurant_timezone,
+    'transfer',
+    'Production'
+  );
+```
+
+New:
+
+```sql
+  v_deduction_result := public.process_unified_inventory_deduction(
+    v_run.restaurant_id,
+    v_recipe.name,
+    v_batch_multiplier_int,
+    v_sale_date,
+    v_run.id::text,
+    NULL,
+    v_restaurant_timezone,
+    'transfer',
+    'Production',
+    v_prep.recipe_id
+  );
+```
+
+Change 2 — immediately AFTER that call (before `v_reference_id := ...`), add the loud-failure guard. It checks `prep_recipe_ingredients` (the prep-side source of truth), NOT `recipe_ingredients` (the shadow list can itself desync — same bug class as the incident):
+
+```sql
+  -- Loud failure: a run whose prep expects ingredients must never complete
+  -- with zero deductions (design doc §1b). already_processed = true means an
+  -- idempotent retry whose transfer transactions already exist — never raise.
+  IF COALESCE((v_deduction_result->>'already_processed')::boolean, false) = false
+     AND jsonb_array_length(COALESCE(v_deduction_result->'ingredients_deducted', '[]'::jsonb)) = 0
+     AND EXISTS (SELECT 1 FROM prep_recipe_ingredients WHERE prep_recipe_id = v_prep.id) THEN
+    RAISE EXCEPTION 'Production run %: ingredient deduction failed for recipe % (%) — no ingredients were deducted',
+      p_run_id, v_prep.recipe_id, v_recipe.name;
+  END IF;
+```
+
+- [ ] **Step 5: §3 — Data repair**
+
+```sql
+DO $$
+DECLARE v_count integer;
+BEGIN
+  UPDATE recipes r
+  SET is_active = true, updated_at = now()
+  FROM prep_recipes pr
+  WHERE pr.recipe_id = r.id AND r.is_active = false;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RAISE NOTICE 'Reactivated % prep-linked shadow recipe(s)', v_count;
+END $$;
+```
+
+- [ ] **Step 6: §4 — Backstop trigger**
+
+```sql
+CREATE OR REPLACE FUNCTION public.prevent_shadow_recipe_deactivation()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+BEGIN
+  IF OLD.is_active = true AND NEW.is_active = false
+     AND EXISTS (SELECT 1 FROM prep_recipes WHERE recipe_id = OLD.id) THEN
+    RAISE EXCEPTION 'Recipe "%" backs a prep (batch) recipe and cannot be deactivated. Manage it from the Prep page.', OLD.name;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_prevent_shadow_recipe_deactivation ON public.recipes;
+CREATE TRIGGER trg_prevent_shadow_recipe_deactivation
+BEFORE UPDATE OF is_active ON public.recipes
+FOR EACH ROW
+EXECUTE FUNCTION public.prevent_shadow_recipe_deactivation();
+```
+
+- [ ] **Step 7: §5 — Comments (no GRANTs)**
+
+The current function has NO explicit `GRANT EXECUTE` (relies on default execute privileges) — do not add one. Re-apply the existing comment for the new signature and document the new behavior:
+
+```sql
+-- NOTE: no explicit GRANT EXECUTE existed on the prior signature (default
+-- privileges apply); intentionally not adding one here.
+COMMENT ON FUNCTION public.process_unified_inventory_deduction(uuid, text, integer, text, text, text, text, text, text, uuid) IS
+'Unified inventory deduction for POS sales and production runs. When p_recipe_id is provided (production runs), the recipe is resolved by id with no is_active filter (self-healing against soft-deleted shadow recipes); otherwise by POS item name among active recipes. Supports usage (POS/COGS) and transfer (production, not COGS until sold) transaction types.';
+
+COMMENT ON FUNCTION public.prevent_shadow_recipe_deactivation() IS
+'Backstop: blocks is_active true->false on recipes referenced by prep_recipes.recipe_id. Shadow recipes must stay active or production deduction/costing would silently break (2026-07 Cold Stone incident).';
+```
+
+- [ ] **Step 8: Apply migration locally and run the pgTAP tests**
+
+Run: `npm run db:reset` (applies all migrations; watch the output for `Reactivated 0 prep-linked shadow recipe(s)` from §3) then `npm run test:db`
+Expected: the new `26_prep_shadow_recipe_costing.sql` tests PASS, and the existing `12_prep_production_runs.sql`, `15_production_run_costing.sql`, `16_production_run_idempotency.sql`, `25_quick_cook_inventory.sql` still PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add supabase/migrations/20260705000000_fix_prep_shadow_recipe_costing.sql supabase/tests/26_prep_shadow_recipe_costing.sql
+git commit -m "fix(prep): deduct production runs by recipe id, fail loudly on zero deductions
+
+Shadow recipe soft-delete no longer silently zeroes batch costing.
+Includes data repair + backstop trigger.
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: pgTAP tests for the migration
+
+**Files:**
+- Create: `supabase/tests/26_prep_shadow_recipe_costing.sql`
+- Reference (read for patterns): `supabase/tests/25_quick_cook_inventory.sql`
+
+- [ ] **Step 1: Write the test file (complete content below)**
+
+Note on IDs: this suite uses the `26000000-...` prefix to avoid colliding with other test files. The "incident" recipe is INSERTED with `is_active = false` BEFORE the `prep_recipes` link is created — the §4 trigger only blocks UPDATE flips on already-linked recipes, so this reproduces the incident state without fighting the trigger.
+
+```sql
+-- Prep Shadow-Recipe Costing Tests
+-- Covers migration 20260705000000_fix_prep_shadow_recipe_costing.sql:
+-- 1. Self-heal: production run deducts + costs even when shadow recipe is inactive
+-- 2. Loud failure: prep has ingredients but deduction yields none -> exception
+-- 3. Idempotency (completed run): early return, no double deduction
+-- 4. Idempotency (in_progress retry with existing transactions): no exception
+-- 5. Data repair UPDATE reactivates prep-linked inactive recipes
+-- 6. Backstop trigger blocks deactivating prep-linked recipes
+
+BEGIN;
+SELECT plan(14);
+
+-- ============================================================
+-- Setup: auth context, restaurant, membership
+-- ============================================================
+SELECT set_config('request.jwt.claims', '{"sub":"26000000-0000-0000-0000-0000000000ab","role":"authenticated"}', true);
+INSERT INTO auth.users (id, email) VALUES ('26000000-0000-0000-0000-0000000000ab', 'shadow-recipe-test@example.com') ON CONFLICT DO NOTHING;
+INSERT INTO restaurants (id, name) VALUES ('26000000-0000-0000-0000-000000000001', 'Shadow Recipe Test Restaurant') ON CONFLICT DO NOTHING;
+INSERT INTO user_restaurants (user_id, restaurant_id, role)
+VALUES ('26000000-0000-0000-0000-0000000000ab', '26000000-0000-0000-0000-000000000001', 'owner')
+ON CONFLICT DO NOTHING;
+
+-- Products: mix ($24.40/case of 5 gal) and pans output (container of 2.5 gal)
+INSERT INTO products (id, restaurant_id, sku, name, uom_purchase, size_value, size_unit, cost_per_unit, current_stock)
+VALUES
+  ('26000000-0000-0000-0000-000000000010', '26000000-0000-0000-0000-000000000001', 'MIX-CASE', 'Ice Cream Mix 14%', 'case', 5, 'gal', 24.40, 75),
+  ('26000000-0000-0000-0000-000000000011', '26000000-0000-0000-0000-000000000001', 'PANS-CT',  'Sweet Cream Pans',  'container', 2.5, 'gal', 0, 0)
+ON CONFLICT (id) DO NOTHING;
+
+-- INCIDENT STATE: shadow recipe inserted ALREADY INACTIVE (bypasses the new
+-- backstop trigger, which only guards true->false UPDATE flips).
+INSERT INTO recipes (id, restaurant_id, name, serving_size, is_active)
+VALUES ('26000000-0000-0000-0000-000000000100', '26000000-0000-0000-0000-000000000001', 'Sweet Cream Pans Prep', 2, false)
+ON CONFLICT DO NOTHING;
+
+INSERT INTO recipe_ingredients (recipe_id, product_id, quantity, unit)
+VALUES ('26000000-0000-0000-0000-000000000100', '26000000-0000-0000-0000-000000000010', 2.5, 'gal')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO prep_recipes (id, restaurant_id, recipe_id, name, default_yield, default_yield_unit, output_product_id)
+VALUES ('26000000-0000-0000-0000-000000000020', '26000000-0000-0000-0000-000000000001', '26000000-0000-0000-0000-000000000100', 'Sweet Cream Pans Prep', 2, 'container', '26000000-0000-0000-0000-000000000011')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO prep_recipe_ingredients (prep_recipe_id, product_id, quantity, unit)
+VALUES ('26000000-0000-0000-0000-000000000020', '26000000-0000-0000-0000-000000000010', 2.5, 'gal')
+ON CONFLICT DO NOTHING;
+
+-- ============================================================
+-- Section 1: Self-heal — inactive shadow recipe still deducts + costs
+-- 2.5 gal of a 5-gal case = 0.5 case = $12.20; output 2 containers @ $6.10
+-- ============================================================
+INSERT INTO production_runs (id, restaurant_id, prep_recipe_id, status, target_yield, target_yield_unit, created_by)
+VALUES ('26000000-0000-0000-0000-000000000030', '26000000-0000-0000-0000-000000000001', '26000000-0000-0000-0000-000000000020', 'in_progress', 2, 'container', '26000000-0000-0000-0000-0000000000ab')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO production_run_ingredients (id, production_run_id, product_id, expected_quantity, actual_quantity, unit)
+VALUES ('26000000-0000-0000-0000-000000000040', '26000000-0000-0000-0000-000000000030', '26000000-0000-0000-0000-000000000010', 2.5, 2.5, 'gal')
+ON CONFLICT DO NOTHING;
+
+SELECT lives_ok(
+  $$SELECT complete_production_run('26000000-0000-0000-0000-000000000030', 2, 'container', '[]'::jsonb)$$,
+  'Self-heal: run completes with inactive shadow recipe'
+);
+
+SELECT is(
+  (SELECT current_stock::numeric FROM products WHERE id = '26000000-0000-0000-0000-000000000010'),
+  74.5::numeric,
+  'Self-heal: mix stock deducted 75 -> 74.5 (0.5 case)'
+);
+
+SELECT is(
+  (SELECT current_stock::numeric FROM products WHERE id = '26000000-0000-0000-0000-000000000011'),
+  2::numeric,
+  'Self-heal: output stock 0 -> 2 containers'
+);
+
+SELECT is(
+  (SELECT cost_per_unit::numeric FROM products WHERE id = '26000000-0000-0000-0000-000000000011'),
+  6.10::numeric,
+  'Self-heal: output cost_per_unit $6.10 ($12.20 / 2)'
+);
+
+SELECT is(
+  (SELECT actual_total_cost::numeric FROM production_runs WHERE id = '26000000-0000-0000-0000-000000000030'),
+  12.20::numeric,
+  'Self-heal: run actual_total_cost $12.20'
+);
+
+SELECT is(
+  (SELECT COUNT(*) FROM inventory_transactions
+   WHERE reference_id LIKE '26000000-0000-0000-0000-000000000030_%'
+   AND product_id = '26000000-0000-0000-0000-000000000010'
+   AND transaction_type = 'transfer' AND quantity < 0),
+  1::bigint,
+  'Self-heal: mix deduction transaction exists'
+);
+
+-- ============================================================
+-- Section 2: Idempotency path 1 — re-completing a completed run is a no-op
+-- ============================================================
+SELECT lives_ok(
+  $$SELECT complete_production_run('26000000-0000-0000-0000-000000000030', 2, 'container', '[]'::jsonb)$$,
+  'Idempotency: re-completing a completed run does not error'
+);
+
+SELECT is(
+  (SELECT current_stock::numeric FROM products WHERE id = '26000000-0000-0000-0000-000000000010'),
+  74.5::numeric,
+  'Idempotency: no double deduction on completed-run retry'
+);
+
+-- ============================================================
+-- Section 3: Idempotency path 2 — in_progress retry whose transactions exist
+-- (simulates a retry after partial failure: deduction committed, status not
+-- yet flipped). already_processed short-circuit must NOT trip the new guard.
+-- ============================================================
+UPDATE production_runs SET status = 'in_progress', completed_at = NULL
+WHERE id = '26000000-0000-0000-0000-000000000030';
+
+SELECT lives_ok(
+  $$SELECT complete_production_run('26000000-0000-0000-0000-000000000030', 2, 'container', '[]'::jsonb)$$,
+  'Idempotency: in_progress retry with existing transactions does not raise the deduction guard'
+);
+
+SELECT is(
+  (SELECT current_stock::numeric FROM products WHERE id = '26000000-0000-0000-0000-000000000010'),
+  74.5::numeric,
+  'Idempotency: still no double deduction after in_progress retry'
+);
+
+-- ============================================================
+-- Section 4: Loud failure — prep expects ingredients, shadow list is empty
+-- ============================================================
+INSERT INTO recipes (id, restaurant_id, name, serving_size, is_active)
+VALUES ('26000000-0000-0000-0000-000000000101', '26000000-0000-0000-0000-000000000001', 'Desynced Prep', 1, true)
+ON CONFLICT DO NOTHING;
+-- NOTE: no recipe_ingredients rows for this recipe (the shadow-side desync).
+
+INSERT INTO prep_recipes (id, restaurant_id, recipe_id, name, default_yield, default_yield_unit, output_product_id)
+VALUES ('26000000-0000-0000-0000-000000000021', '26000000-0000-0000-0000-000000000001', '26000000-0000-0000-0000-000000000101', 'Desynced Prep', 1, 'unit', NULL)
+ON CONFLICT DO NOTHING;
+
+INSERT INTO prep_recipe_ingredients (prep_recipe_id, product_id, quantity, unit)
+VALUES ('26000000-0000-0000-0000-000000000021', '26000000-0000-0000-0000-000000000010', 1, 'gal')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO production_runs (id, restaurant_id, prep_recipe_id, status, target_yield, target_yield_unit, created_by)
+VALUES ('26000000-0000-0000-0000-000000000031', '26000000-0000-0000-0000-000000000001', '26000000-0000-0000-0000-000000000021', 'in_progress', 1, 'unit', '26000000-0000-0000-0000-0000000000ab')
+ON CONFLICT DO NOTHING;
+
+SELECT throws_like(
+  $$SELECT complete_production_run('26000000-0000-0000-0000-000000000031', 1, 'unit', '[]'::jsonb)$$,
+  '%no ingredients were deducted%',
+  'Loud failure: desynced shadow ingredient list raises instead of completing at $0'
+);
+
+-- ============================================================
+-- Section 5: Data repair — reactivates prep-linked inactive recipes
+-- (re-run the same statement the migration executes)
+-- ============================================================
+UPDATE recipes r
+SET is_active = true, updated_at = now()
+FROM prep_recipes pr
+WHERE pr.recipe_id = r.id AND r.is_active = false;
+
+SELECT is(
+  (SELECT is_active FROM recipes WHERE id = '26000000-0000-0000-0000-000000000100'),
+  true,
+  'Data repair: prep-linked inactive shadow recipe reactivated'
+);
+
+-- ============================================================
+-- Section 6: Backstop trigger
+-- ============================================================
+SELECT throws_like(
+  $$UPDATE recipes SET is_active = false WHERE id = '26000000-0000-0000-0000-000000000100'$$,
+  '%cannot be deactivated%',
+  'Backstop: deactivating a prep-linked recipe is blocked'
+);
+
+-- Non-linked recipe can still be deactivated
+INSERT INTO recipes (id, restaurant_id, name, serving_size, is_active)
+VALUES ('26000000-0000-0000-0000-000000000102', '26000000-0000-0000-0000-000000000001', 'Plain Menu Recipe', 1, true)
+ON CONFLICT DO NOTHING;
+
+SELECT lives_ok(
+  $$UPDATE recipes SET is_active = false WHERE id = '26000000-0000-0000-0000-000000000102'$$,
+  'Backstop: non-linked recipe soft-delete still works'
+);
+
+SELECT * FROM finish();
+ROLLBACK;
+```
+
+- [ ] **Step 2: Run to verify it fails before the migration exists**
+
+Run: `npm run test:db`
+Expected: `26_prep_shadow_recipe_costing.sql` FAILS (self-heal assertions fail: stock stays 75, cost stays 0; `throws_like` for the guard fails because no exception is raised; trigger test fails because the trigger doesn't exist).
+
+- [ ] **Step 3: Continue with Task 1 Steps 2–8** (migration implementation makes these pass). Commit happens in Task 1 Step 9 (test + migration together).
+
+---
+
+### Task 3: `useRecipes.fetchRecipes` — filter shadow recipes, fail closed
+
+**Files:**
+- Modify: `src/hooks/useRecipes.tsx:68-127` (the `fetchRecipes` callback)
+- Test: `tests/unit/useRecipesShadowRecipes.test.tsx` (created in Task 5; TDD steps below reference it)
+
+- [ ] **Step 1: Write the failing tests** — implement Task 5 Steps 1–2 for the `fetchRecipes` describe block, run `npx vitest run tests/unit/useRecipesShadowRecipes.test.tsx`, confirm FAIL (shadow recipes are not filtered).
+
+- [ ] **Step 2: Implement.** Replace the single recipes query at `src/hooks/useRecipes.tsx:76-86` with a parallel fetch + fail-closed filter. Current code:
+
+```typescript
+      const { data, error } = await supabase
+        .from('recipes')
+        .select(`
+          *,
+          ingredients:recipe_ingredients(product_id, quantity, unit)
+        `)
+        .eq('restaurant_id', restaurantId)
+        .eq('is_active', true)
+        .order('name');
+
+      if (error) throw error;
+```
+
+New code:
+
+```typescript
+      // Shadow recipes (rows backing prep_recipes) are managed from the Prep
+      // page and must not appear here. Fail closed: if the prep_recipes query
+      // errors we abort the whole fetch rather than leak shadows back in.
+      const [recipesResult, prepLinksResult] = await Promise.all([
+        supabase
+          .from('recipes')
+          .select(`
+            *,
+            ingredients:recipe_ingredients(product_id, quantity, unit)
+          `)
+          .eq('restaurant_id', restaurantId)
+          .eq('is_active', true)
+          .order('name'),
+        supabase
+          .from('prep_recipes')
+          .select('recipe_id')
+          .eq('restaurant_id', restaurantId)
+          .not('recipe_id', 'is', null),
+      ]);
+
+      if (recipesResult.error) throw recipesResult.error;
+      if (prepLinksResult.error) throw prepLinksResult.error;
+
+      const shadowRecipeIds = new Set(
+        (prepLinksResult.data || []).map((link) => link.recipe_id)
+      );
+      const data = (recipesResult.data || []).filter(
+        (recipe) => !shadowRecipeIds.has(recipe.id)
+      );
+```
+
+The filter MUST run before the `enhancedRecipes` map (line 89) so shadow rows never get cost recomputes or `UPDATE recipes` writes. The `(data || [])` in the map becomes just `data` (it is now always an array).
+
+- [ ] **Step 3: Run the tests**
+
+Run: `npx vitest run tests/unit/useRecipesShadowRecipes.test.tsx`
+Expected: `fetchRecipes` describe block PASSES.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/hooks/useRecipes.tsx tests/unit/useRecipesShadowRecipes.test.tsx
+git commit -m "fix(recipes): hide prep-linked shadow recipes from Recipes page (fail closed)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: `useRecipes.deleteRecipe` guard + `DeleteRecipeDialog` branch
+
+**Files:**
+- Modify: `src/hooks/useRecipes.tsx:317-343` (the `deleteRecipe` function)
+- Modify: `src/components/DeleteRecipeDialog.tsx:25-37` (`handleDelete`)
+- Test: `tests/unit/useRecipesShadowRecipes.test.tsx` (delete-guard describe block) and `tests/unit/DeleteRecipeDialogGuard.test.tsx` (Task 5)
+
+- [ ] **Step 1: Write the failing tests** — implement Task 5 Steps 3–4, run them, confirm FAIL.
+
+- [ ] **Step 2: Implement the `deleteRecipe` guard.** In `src/hooks/useRecipes.tsx`, replace the start of `deleteRecipe`:
+
+Current:
+
+```typescript
+  const deleteRecipe = async (id: string): Promise<boolean> => {
+    try {
+      const { error } = await supabase
+        .from('recipes')
+        .update({ is_active: false })
+        .eq('id', id);
+```
+
+New:
+
+```typescript
+  const deleteRecipe = async (id: string): Promise<boolean> => {
+    try {
+      // Shadow recipes back a prep (batch) recipe; soft-deleting one silently
+      // breaks production deduction/costing. Blocked here AND by a DB trigger.
+      const { data: prepLink, error: prepLinkError } = await supabase
+        .from('prep_recipes')
+        .select('name')
+        .eq('recipe_id', id)
+        .limit(1)
+        .maybeSingle();
+
+      if (prepLinkError) throw prepLinkError;
+
+      if (prepLink) {
+        toast({
+          title: "Can't delete this recipe",
+          description: `It is managed by the batch recipe "${prepLink.name}". Go to the Prep page to manage it.`,
+          variant: "destructive",
+        });
+        return false;
+      }
+
+      const { error } = await supabase
+        .from('recipes')
+        .update({ is_active: false })
+        .eq('id', id);
+```
+
+(The rest of the function is unchanged.)
+
+- [ ] **Step 3: Implement the dialog branch.** In `src/components/DeleteRecipeDialog.tsx`, `handleDelete` currently closes unconditionally, which makes a blocked delete look like success. Replace:
+
+```typescript
+    setLoading(true);
+    try {
+      await deleteRecipe(recipe.id);
+      onClose();
+    } catch (error) {
+      console.error('Error deleting recipe:', error);
+    } finally {
+      setLoading(false);
+    }
+```
+
+with:
+
+```typescript
+    setLoading(true);
+    try {
+      const deleted = await deleteRecipe(recipe.id);
+      if (deleted) {
+        onClose();
+      }
+    } catch (error) {
+      console.error('Error deleting recipe:', error);
+    } finally {
+      setLoading(false);
+    }
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `npx vitest run tests/unit/useRecipesShadowRecipes.test.tsx tests/unit/DeleteRecipeDialogGuard.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useRecipes.tsx src/components/DeleteRecipeDialog.tsx tests/unit/DeleteRecipeDialogGuard.test.tsx tests/unit/useRecipesShadowRecipes.test.tsx
+git commit -m "fix(recipes): block soft-deleting prep-linked recipes; keep dialog open on rejection
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Vitest unit tests (written first, referenced by Tasks 3–4)
+
+**Files:**
+- Create: `tests/unit/useRecipesShadowRecipes.test.tsx`
+- Create: `tests/unit/DeleteRecipeDialogGuard.test.tsx`
+- Reference for mocking patterns: `tests/unit/RecipesCreateFromBase.test.tsx` (mocks `@/integrations/supabase/client`, `useAuth`, `use-toast`)
+
+- [ ] **Step 1: Create `tests/unit/useRecipesShadowRecipes.test.tsx`**
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+
+// ---- Mocks -----------------------------------------------------------------
+const toastMock = vi.fn();
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { id: 'user-1' } }),
+}));
+
+// Configurable per-test responses
+let recipesResponse: { data: unknown[] | null; error: unknown };
+let prepLinksResponse: { data: unknown[] | null; error: unknown };
+let prepLinkSingleResponse: { data: unknown | null; error: unknown };
+const recipesUpdateMock = vi.fn().mockReturnValue({
+  eq: vi.fn().mockResolvedValue({ error: null }),
+});
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: vi.fn((table: string) => {
+      if (table === 'recipes') {
+        return {
+          // fetch chain: .select().eq().eq().order()
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                order: vi.fn().mockImplementation(() => Promise.resolve(recipesResponse)),
+              }),
+            }),
+          }),
+          // deleteRecipe chain: .update().eq()
+          update: recipesUpdateMock,
+        };
+      }
+      if (table === 'prep_recipes') {
+        return {
+          select: vi.fn().mockReturnValue({
+            // fetch chain: .select('recipe_id').eq().not()
+            eq: vi.fn().mockReturnValue({
+              not: vi.fn().mockImplementation(() => Promise.resolve(prepLinksResponse)),
+              // deleteRecipe guard chain: .select('name').eq().limit().maybeSingle()
+              limit: vi.fn().mockReturnValue({
+                maybeSingle: vi.fn().mockImplementation(() => Promise.resolve(prepLinkSingleResponse)),
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === 'recipe_ingredients') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ data: [], error: null }),
+          }),
+        };
+      }
+      // unified_sales & anything else: benign empty result
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              not: vi.fn().mockResolvedValue({ data: [], error: null }),
+            }),
+          }),
+        }),
+      };
+    }),
+    channel: vi.fn().mockReturnValue({
+      on: vi.fn().mockReturnThis(),
+      subscribe: vi.fn().mockReturnThis(),
+    }),
+    removeChannel: vi.fn(),
+  },
+}));
+
+import { useRecipes } from '@/hooks/useRecipes';
+
+const makeRecipe = (id: string, name: string) => ({
+  id,
+  restaurant_id: 'rest-1',
+  name,
+  serving_size: 1,
+  estimated_cost: 0,
+  is_active: true,
+  created_at: '',
+  updated_at: '',
+  ingredients: [],
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  recipesResponse = { data: [], error: null };
+  prepLinksResponse = { data: [], error: null };
+  prepLinkSingleResponse = { data: null, error: null };
+});
+
+describe('useRecipes shadow-recipe filtering (fetchRecipes)', () => {
+  it('excludes recipes whose ids appear in prep_recipes.recipe_id', async () => {
+    recipesResponse = {
+      data: [makeRecipe('r-menu', 'Menu Item'), makeRecipe('r-shadow', 'Sweet Cream - pans')],
+      error: null,
+    };
+    prepLinksResponse = { data: [{ recipe_id: 'r-shadow' }], error: null };
+
+    const { result } = renderHook(() => useRecipes('rest-1'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.recipes.map((r) => r.id)).toEqual(['r-menu']);
+  });
+
+  it('fails closed: prep_recipes query error -> no recipes leak, error toast fires', async () => {
+    recipesResponse = {
+      data: [makeRecipe('r-menu', 'Menu Item'), makeRecipe('r-shadow', 'Sweet Cream - pans')],
+      error: null,
+    };
+    prepLinksResponse = { data: null, error: { message: 'prep_recipes unavailable' } };
+
+    const { result } = renderHook(() => useRecipes('rest-1'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.recipes).toEqual([]);
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: 'destructive' })
+    );
+  });
+});
+
+describe('useRecipes shadow-recipe guard (deleteRecipe)', () => {
+  it('blocks deleting a prep-linked recipe: destructive toast, returns false, no update', async () => {
+    prepLinkSingleResponse = { data: { name: 'Sweet Cream - pans' }, error: null };
+
+    const { result } = renderHook(() => useRecipes('rest-1'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    let deleted: boolean | undefined;
+    await act(async () => {
+      deleted = await result.current.deleteRecipe('r-shadow');
+    });
+
+    expect(deleted).toBe(false);
+    expect(recipesUpdateMock).not.toHaveBeenCalled();
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variant: 'destructive',
+        description: expect.stringContaining('Sweet Cream - pans'),
+      })
+    );
+  });
+
+  it('still soft-deletes a normal recipe', async () => {
+    prepLinkSingleResponse = { data: null, error: null };
+
+    const { result } = renderHook(() => useRecipes('rest-1'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    let deleted: boolean | undefined;
+    await act(async () => {
+      deleted = await result.current.deleteRecipe('r-menu');
+    });
+
+    expect(deleted).toBe(true);
+    expect(recipesUpdateMock).toHaveBeenCalledWith({ is_active: false });
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify the fetch tests fail before Task 3's change**
+
+Run: `npx vitest run tests/unit/useRecipesShadowRecipes.test.tsx`
+Expected: FAIL — `excludes recipes...` gets both recipes (no filtering exists yet); the delete-guard tests fail because `deleteRecipe` never queries `prep_recipes` (the mock's `maybeSingle` is never reached and the update fires).
+
+> NOTE for the implementer: if the current (pre-change) code errors on the mock shape instead of asserting cleanly, that still counts as RED. The mock chains above match the POST-change call shapes by design.
+
+- [ ] **Step 3: Create `tests/unit/DeleteRecipeDialogGuard.test.tsx`**
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const deleteRecipeMock = vi.fn();
+vi.mock('@/hooks/useRecipes', () => ({
+  useRecipes: () => ({ deleteRecipe: deleteRecipeMock }),
+}));
+
+import { DeleteRecipeDialog } from '@/components/DeleteRecipeDialog';
+
+const recipe = {
+  id: 'r-1',
+  restaurant_id: 'rest-1',
+  name: 'Sweet Cream - pans',
+  serving_size: 1,
+  estimated_cost: 0,
+  is_active: true,
+  created_at: '',
+  updated_at: '',
+} as any;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('DeleteRecipeDialog delete-guard behavior', () => {
+  it('stays open (onClose not called) when deleteRecipe returns false', async () => {
+    deleteRecipeMock.mockResolvedValue(false);
+    const onClose = vi.fn();
+    render(<DeleteRecipeDialog isOpen={true} onClose={onClose} recipe={recipe} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /delete recipe/i }));
+
+    await waitFor(() => expect(deleteRecipeMock).toHaveBeenCalledWith('r-1'));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('closes when deleteRecipe returns true', async () => {
+    deleteRecipeMock.mockResolvedValue(true);
+    const onClose = vi.fn();
+    render(<DeleteRecipeDialog isOpen={true} onClose={onClose} recipe={recipe} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /delete recipe/i }));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+});
+```
+
+- [ ] **Step 4: Run to verify the dialog test fails before Task 4's change**
+
+Run: `npx vitest run tests/unit/DeleteRecipeDialogGuard.test.tsx`
+Expected: FAIL — `stays open...` fails because the current dialog calls `onClose()` unconditionally.
+
+(Commits for these test files happen with their implementation commits in Tasks 3 and 4.)
+
+---
+
+### Task 6: Full verification sweep
+
+**Files:** none new.
+
+- [ ] **Step 1: Run everything**
+
+```bash
+npm run typecheck && npm run lint && npm run test && npm run test:db && npm run build
+```
+
+Expected: all pass. If `npm run test:db` needs the local stack: `npm run db:start` first (and `npm run db:reset` to apply the new migration).
+
+- [ ] **Step 2: Fix anything red, re-run, commit fixes**
+
+```bash
+git add -A && git commit -m "fix: address verification findings
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+(Skip the commit if nothing needed fixing.)
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: design §1a→Task 1 Step 3, §1b→Task 1 Step 4, §1c→Step 5, §1d→Step 6, §1e→Step 7, §2a→Task 3, §2b/§2c→Task 4, §2d→recorded in header, pgTAP list→Task 2 (tests 1–14 map to design tests 1–7), Vitest list→Task 5.
+- The pgTAP self-heal math mirrors the real incident numbers ($24.40/case of 5 gal, 2.5 gal → $12.20 → $6.10/container) so the test doubles as an incident regression test.
+- Types: `deleteRecipe(id)` keeps its `Promise<boolean>` contract; `DeleteRecipeDialog` consumes the boolean; mocks match the exact call chains introduced in Tasks 3–4.

--- a/docs/superpowers/plans/2026-07-04-prep-shadow-recipe-costing-plan.md
+++ b/docs/superpowers/plans/2026-07-04-prep-shadow-recipe-costing-plan.md
@@ -611,9 +611,17 @@ New:
     }
 ```
 
-with:
+with (NOTE: `AlertDialogAction` is Radix `Dialog.Close` — it closes the dialog
+synchronously on click unless the handler calls `event.preventDefault()` BEFORE any
+`await`; the signature change below is required, see design doc §2c addendum):
 
 ```typescript
+  const handleDelete = async (event: React.MouseEvent<HTMLButtonElement>) => {
+    // AlertDialogAction is Radix's Dialog.Close: without preventDefault it
+    // closes the dialog synchronously on click, before deleteRecipe resolves.
+    event.preventDefault();
+    if (!recipe) return;
+
     setLoading(true);
     try {
       const deleted = await deleteRecipe(recipe.id);
@@ -625,6 +633,7 @@ with:
     } finally {
       setLoading(false);
     }
+  };
 ```
 
 - [ ] **Step 4: Run the tests**

--- a/docs/superpowers/specs/2026-07-04-prep-shadow-recipe-costing-design.md
+++ b/docs/superpowers/specs/2026-07-04-prep-shadow-recipe-costing-design.md
@@ -151,10 +151,17 @@ manage it." — and return `false` without updating. Defense in depth in case a 
 recipe is reachable through another surface (direct link, stale cache).
 
 **c. `DeleteRecipeDialog.handleDelete`** (src/components/DeleteRecipeDialog.tsx,
-design-review major): branch on the boolean — `const ok = await deleteRecipe(recipe.id);
-if (ok) onClose();`. Today the dialog closes unconditionally, so a blocked delete would
-look like success with only a fleeting toast behind it. Keeping the dialog open anchors
-the rejection.
+design-review major): branch on the boolean — only call `onClose()` when
+`deleteRecipe` resolves `true`. Today the dialog closes unconditionally, so a blocked
+delete would look like success with only a fleeting toast behind it. Keeping the dialog
+open anchors the rejection.
+
+> **Implementation addendum (build-phase finding):** `AlertDialogAction` is Radix's
+> `Dialog.Close` under the hood — clicking it fires Radix's own `onOpenChange(false)`
+> synchronously, so an async boolean branch alone cannot keep the dialog open. The
+> handler must call `event.preventDefault()` synchronously before the `await` (the
+> standard Radix pattern for async confirmation), then call `onClose()` itself on
+> success. The `AlertDialogAction` primitive is kept.
 
 **d. Intentionally NOT migrating `useRecipes` to React Query** (design-review note):
 the hook is useState/useEffect + realtime channel today with six call sites; migrating

--- a/docs/superpowers/specs/2026-07-04-prep-shadow-recipe-costing-design.md
+++ b/docs/superpowers/specs/2026-07-04-prep-shadow-recipe-costing-design.md
@@ -72,68 +72,129 @@ END IF;
 - All existing named-param callers (`useInventoryDeduction`,
   `useAutomaticInventoryDeduction`, `supabase/functions/_shared/inventoryConversion.ts`)
   are unaffected: the new param defaults to NULL and the POS behavior is unchanged.
-- Re-apply the existing GRANT/COMMENT statements for the new signature.
+- **Grants (design-review note):** the current function has no explicit `GRANT EXECUTE`
+  (it relies on default PUBLIC execute); the migration re-applies only the existing
+  `COMMENT ON FUNCTION` for the new signature and states this explicitly in a comment —
+  do not invent grants that don't exist today.
 
 **b. `complete_production_run` passes the id and fails loudly.**
 - `CREATE OR REPLACE` (signature unchanged). Pass `v_prep.recipe_id` as `p_recipe_id`.
-- After the deduction call, guard against silent no-ops:
+- **Ordering constraint (design-review major):** part (a)'s DROP+CREATE must precede
+  this `CREATE OR REPLACE` in the migration file — the new body references the 10-arg
+  call. Add an explicit comment in the migration stating the required order.
+- After the deduction call, guard against silent no-ops. **The guard checks
+  `prep_recipe_ingredients` (the prep-side source of truth, keyed by `v_prep.id`), NOT
+  `recipe_ingredients`** (design-review major: the shadow list can itself desync — the
+  same class of bug as this incident — and a guard that trusts it would silently pass
+  the exact failure mode being fixed):
 
 ```sql
 IF COALESCE((v_deduction_result->>'already_processed')::boolean, false) = false
    AND jsonb_array_length(COALESCE(v_deduction_result->'ingredients_deducted', '[]'::jsonb)) = 0
-   AND EXISTS (SELECT 1 FROM recipe_ingredients WHERE recipe_id = v_prep.recipe_id) THEN
-  RAISE EXCEPTION 'Production run %: ingredient deduction failed for recipe % — no ingredients were deducted', p_run_id, v_prep.recipe_id;
+   AND EXISTS (SELECT 1 FROM prep_recipe_ingredients WHERE prep_recipe_id = v_prep.id) THEN
+  RAISE EXCEPTION 'Production run %: ingredient deduction failed for recipe % (%) — no ingredients were deducted', p_run_id, v_prep.recipe_id, v_recipe.name;
 END IF;
 ```
 
-  - `already_processed = true` (idempotent retry) must NOT raise.
-  - A recipe with zero `recipe_ingredients` rows must NOT raise here (some preps may
+  - `already_processed = true` (retry of a not-yet-`completed` run whose transfer
+    transactions already exist) must NOT raise.
+  - A prep with zero `prep_recipe_ingredients` rows must NOT raise (some preps may
     legitimately have no tracked ingredients); zero-cost ingredients also do not raise —
-    only "ingredients exist but none were deducted".
+    only "ingredients expected but none were deducted".
+  - Genuine desync (prep has ingredients, shadow `recipe_ingredients` empty/dangling)
+    DOES raise — that is intentional loud failure, and the exception message includes
+    the recipe name for log triage.
 
-**c. Data repair (idempotent):**
+**c. Data repair (idempotent, with visible count):**
 
 ```sql
-UPDATE recipes r
-SET is_active = true, updated_at = now()
-FROM prep_recipes pr
-WHERE pr.recipe_id = r.id AND r.is_active = false;
+DO $$
+DECLARE v_count integer;
+BEGIN
+  UPDATE recipes r
+  SET is_active = true, updated_at = now()
+  FROM prep_recipes pr
+  WHERE pr.recipe_id = r.id AND r.is_active = false;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RAISE NOTICE 'Reactivated % prep-linked shadow recipe(s)', v_count;
+END $$;
 ```
 
-This reactivates the Cold Stone shadow recipe on deploy (currently the only affected row).
+This reactivates the Cold Stone shadow recipe on deploy (currently the only affected row)
+and logs the affected-row count in deploy output.
+
+**d. DB-level backstop trigger (design-review suggestion, adopted):** a `BEFORE UPDATE`
+trigger on `recipes` raising a clear error when `is_active` flips `true → false` while a
+`prep_recipes` row references the recipe. This closes the incident vector for ALL
+surfaces (direct REST, service scripts, future UI), not just the Recipes page.
+`deletePrepRecipe` is unaffected (it hard-DELETEs the shadow row; the trigger only
+guards UPDATE). Created AFTER the repair UPDATE in (c) within the migration.
 
 ### 2. Client: stop the leak
 
-**a. `useRecipes.fetchRecipes`** (src/hooks/useRecipes.tsx): fetch
-`prep_recipes.select('recipe_id')` for the restaurant alongside the recipes query and
-filter out any recipe whose id is a prep `recipe_id`. Shadow recipes disappear from the
-Recipes page (they are managed from the Batch/Prep page).
+**a. `useRecipes.fetchRecipes`** (src/hooks/useRecipes.tsx): run
+`Promise.all([recipesQuery, prepRecipesQuery])` (where `prepRecipesQuery` is
+`prep_recipes.select('recipe_id')` scoped to the restaurant), **filter shadow recipes
+out BEFORE the per-row cost-recalculation map** (design-review major: otherwise shadow
+rows get cost recomputes and `UPDATE recipes` writes just before being hidden).
+**Failure contract (design-review major): fail closed** — if the `prep_recipes` query
+errors, the whole fetch throws into the existing catch (error toast), rather than
+treating it as "no shadow recipes", which would leak shadows back onto the page. The
+existing `!restaurantId || !user` early return covers the new query too. Both
+supporting indexes already exist (`idx_prep_recipes_restaurant`,
+`idx_prep_recipes_recipe_id`).
 
 **b. `useRecipes.deleteRecipe`**: before soft-deleting, check
 `prep_recipes` for `recipe_id = id` (scoped to the restaurant). If linked, show a
-destructive toast — "This recipe belongs to the batch recipe <name>. Manage it from the
-Prep page." — and return `false` without updating. Defense in depth in case a shadow
+destructive toast — "<name> is managed by a batch (prep) recipe. Go to the Prep page to
+manage it." — and return `false` without updating. Defense in depth in case a shadow
 recipe is reachable through another surface (direct link, stale cache).
+
+**c. `DeleteRecipeDialog.handleDelete`** (src/components/DeleteRecipeDialog.tsx,
+design-review major): branch on the boolean — `const ok = await deleteRecipe(recipe.id);
+if (ok) onClose();`. Today the dialog closes unconditionally, so a blocked delete would
+look like success with only a fleeting toast behind it. Keeping the dialog open anchors
+the rejection.
+
+**d. Intentionally NOT migrating `useRecipes` to React Query** (design-review note):
+the hook is useState/useEffect + realtime channel today with six call sites; migrating
+is out of scope for this incident fix and is recorded here so later reviewers know the
+deviation from CLAUDE.md's React Query pattern is a pre-existing, consciously deferred
+gap.
 
 ### 3. Tests
 
 **pgTAP** (`supabase/tests/26_prep_shadow_recipe_costing.sql`):
 1. Setup: restaurant, user, ingredient product with cost, prep recipe + shadow recipe +
    `recipe_ingredients` + `prep_recipe_ingredients`, output product.
+   (Note: the backstop trigger from 1d means the test soft-deletes the shadow recipe by
+   disabling/deferring around the trigger OR by deleting the `prep_recipes` link first —
+   simplest is to set `is_active = false` BEFORE inserting the `prep_recipes` row, or
+   use `ALTER TABLE recipes DISABLE TRIGGER` within the test transaction. Decide in
+   implementation; the test must still prove self-heal against an inactive shadow row.)
 2. Soft-delete the shadow recipe (`is_active = false`), create + complete a production
    run → assert: deduction transaction exists (negative qty), output product
    `cost_per_unit > 0`, run `actual_total_cost > 0`. (Self-heal proven.)
-3. Delete the `recipe_ingredients` rows, new run → `throws_ok` on
-   `complete_production_run`. (Loud failure proven.)
-4. Idempotency: re-call `complete_production_run` on a completed run → no error,
-   no double deduction (existing behavior preserved).
-5. Data repair: insert an inactive prep-linked recipe, run the repair UPDATE → active.
+3. Delete the `recipe_ingredients` rows (shadow-side desync), new run → `throws_ok` on
+   `complete_production_run`. (Loud failure proven; guard keyed on
+   `prep_recipe_ingredients`.)
+4. Idempotency path 1: re-call `complete_production_run` on a `completed` run → no
+   error, no double deduction (early return preserved).
+5. Idempotency path 2 (design-review major): run left `in_progress` with matching
+   transfer `inventory_transactions` already present (simulated partial retry) →
+   `already_processed = true` short-circuit means NO exception and no double deduction.
+6. Data repair: prep-linked inactive recipe, run the repair UPDATE → active.
+7. Backstop trigger: `UPDATE recipes SET is_active = false` on a prep-linked recipe →
+   `throws_ok`; on a non-linked recipe → `lives_ok`.
 
 **Vitest** (`tests/unit/useRecipesShadowFilter.test.tsx` or similar):
 1. `fetchRecipes` excludes recipes whose ids appear in `prep_recipes.recipe_id`.
-2. `deleteRecipe` on a prep-linked recipe: no `recipes` update issued, error toast shown,
+2. `fetchRecipes` fails closed: `prep_recipes` query error → error path, shadows do NOT
+   leak into the list.
+3. `deleteRecipe` on a prep-linked recipe: no `recipes` update issued, error toast shown,
    returns false.
-3. `deleteRecipe` on a normal recipe still soft-deletes.
+4. `deleteRecipe` on a normal recipe still soft-deletes.
+5. `DeleteRecipeDialog`: stays open when `deleteRecipe` returns false; closes on true.
 
 ## Error handling
 

--- a/docs/superpowers/specs/2026-07-04-prep-shadow-recipe-costing-design.md
+++ b/docs/superpowers/specs/2026-07-04-prep-shadow-recipe-costing-design.md
@@ -1,0 +1,153 @@
+# Prep Shadow-Recipe Costing Fix — Design
+
+**Date:** 2026-07-04
+**Status:** Approved (user selected self-heal + no backfill)
+**Related:** Prod incident at Wetzel's - Cold Stone - Alamo Ranch (`7c0c76e3-e770-401b-a2a9-c1edd407efed`)
+
+## Problem
+
+Every prep recipe has a "shadow" row in `recipes` (created by
+`20260116000000_link_prep_recipes_to_recipes.sql` and `usePrepRecipes.createPrepRecipe`,
+always with `is_active = true`). `complete_production_run` deducts ingredients by calling
+`process_unified_inventory_deduction`, which looks the recipe up **by name with
+`is_active = true`** and **silently returns an empty result** when nothing matches.
+
+The Recipes page (`useRecipes`) lists all active recipes — including shadow recipes —
+and its `deleteRecipe` is a soft-delete (`is_active = false`). A user deleted the
+"Sweet Cream - pans" shadow recipe there (it looked like a stray duplicate). Since then
+every Cook Now run at that restaurant:
+
+- created **no ingredient deduction transactions** (ICE CREAM MIX stock never decreased),
+- computed `v_total_cost_snapshot = 0`,
+- left the output product's `cost_per_unit` at `$0`,
+- and still completed "successfully" with `actual_total_cost = 0`.
+
+Confirmed in prod: 5 runs on 2026-07-03/04 completed at $0; the only prep recipe in the
+entire DB linked to an inactive shadow recipe is this one.
+
+## Goals
+
+1. Production runs must deduct and cost correctly even if the shadow recipe was
+   soft-deleted (self-healing — the shadow recipe is an implementation detail).
+2. A production run must **never complete silently at $0** when the recipe's
+   ingredient list could not be resolved.
+3. Shadow recipes must stop leaking into the Recipes page, and must not be
+   soft-deletable from there.
+4. Repair the existing bad prod data (reactivate the one inactive shadow recipe)
+   through a migration, not a manual prod write.
+
+**Non-goals (decided trade-offs):**
+- No backfill of the 5 historical $0 runs (user decision: fix forward; stock can be
+  corrected with a manual inventory adjustment).
+- No removal of the shadow-recipe pattern itself (Option C, larger refactor, rejected).
+
+## Design
+
+### 1. Migration: deduct by recipe id (self-heal) + loud failure
+
+New migration `supabase/migrations/<ts>_fix_prep_shadow_recipe_costing.sql`:
+
+**a. `process_unified_inventory_deduction` gains `p_recipe_id uuid DEFAULT NULL`.**
+- `DROP FUNCTION IF EXISTS public.process_unified_inventory_deduction(uuid, text, integer, text, text, text, text, text, text)`
+  then re-`CREATE` with the new trailing parameter (Postgres cannot `CREATE OR REPLACE`
+  across signatures). Body is copied from the current canonical definition in
+  `20260203000000_enhance_prep_recipes_and_production.sql` with one change:
+
+```sql
+IF p_recipe_id IS NOT NULL THEN
+    SELECT * INTO v_recipe_record
+    FROM recipes
+    WHERE id = p_recipe_id
+      AND restaurant_id = p_restaurant_id;   -- tenant guard; NO is_active filter
+ELSE
+    SELECT * INTO v_recipe_record
+    FROM recipes
+    WHERE restaurant_id = p_restaurant_id
+      AND (pos_item_name = p_pos_item_name OR name = p_pos_item_name)
+      AND is_active = true                    -- POS path unchanged
+    LIMIT 1;
+END IF;
+```
+
+- All existing named-param callers (`useInventoryDeduction`,
+  `useAutomaticInventoryDeduction`, `supabase/functions/_shared/inventoryConversion.ts`)
+  are unaffected: the new param defaults to NULL and the POS behavior is unchanged.
+- Re-apply the existing GRANT/COMMENT statements for the new signature.
+
+**b. `complete_production_run` passes the id and fails loudly.**
+- `CREATE OR REPLACE` (signature unchanged). Pass `v_prep.recipe_id` as `p_recipe_id`.
+- After the deduction call, guard against silent no-ops:
+
+```sql
+IF COALESCE((v_deduction_result->>'already_processed')::boolean, false) = false
+   AND jsonb_array_length(COALESCE(v_deduction_result->'ingredients_deducted', '[]'::jsonb)) = 0
+   AND EXISTS (SELECT 1 FROM recipe_ingredients WHERE recipe_id = v_prep.recipe_id) THEN
+  RAISE EXCEPTION 'Production run %: ingredient deduction failed for recipe % — no ingredients were deducted', p_run_id, v_prep.recipe_id;
+END IF;
+```
+
+  - `already_processed = true` (idempotent retry) must NOT raise.
+  - A recipe with zero `recipe_ingredients` rows must NOT raise here (some preps may
+    legitimately have no tracked ingredients); zero-cost ingredients also do not raise —
+    only "ingredients exist but none were deducted".
+
+**c. Data repair (idempotent):**
+
+```sql
+UPDATE recipes r
+SET is_active = true, updated_at = now()
+FROM prep_recipes pr
+WHERE pr.recipe_id = r.id AND r.is_active = false;
+```
+
+This reactivates the Cold Stone shadow recipe on deploy (currently the only affected row).
+
+### 2. Client: stop the leak
+
+**a. `useRecipes.fetchRecipes`** (src/hooks/useRecipes.tsx): fetch
+`prep_recipes.select('recipe_id')` for the restaurant alongside the recipes query and
+filter out any recipe whose id is a prep `recipe_id`. Shadow recipes disappear from the
+Recipes page (they are managed from the Batch/Prep page).
+
+**b. `useRecipes.deleteRecipe`**: before soft-deleting, check
+`prep_recipes` for `recipe_id = id` (scoped to the restaurant). If linked, show a
+destructive toast — "This recipe belongs to the batch recipe <name>. Manage it from the
+Prep page." — and return `false` without updating. Defense in depth in case a shadow
+recipe is reachable through another surface (direct link, stale cache).
+
+### 3. Tests
+
+**pgTAP** (`supabase/tests/26_prep_shadow_recipe_costing.sql`):
+1. Setup: restaurant, user, ingredient product with cost, prep recipe + shadow recipe +
+   `recipe_ingredients` + `prep_recipe_ingredients`, output product.
+2. Soft-delete the shadow recipe (`is_active = false`), create + complete a production
+   run → assert: deduction transaction exists (negative qty), output product
+   `cost_per_unit > 0`, run `actual_total_cost > 0`. (Self-heal proven.)
+3. Delete the `recipe_ingredients` rows, new run → `throws_ok` on
+   `complete_production_run`. (Loud failure proven.)
+4. Idempotency: re-call `complete_production_run` on a completed run → no error,
+   no double deduction (existing behavior preserved).
+5. Data repair: insert an inactive prep-linked recipe, run the repair UPDATE → active.
+
+**Vitest** (`tests/unit/useRecipesShadowFilter.test.tsx` or similar):
+1. `fetchRecipes` excludes recipes whose ids appear in `prep_recipes.recipe_id`.
+2. `deleteRecipe` on a prep-linked recipe: no `recipes` update issued, error toast shown,
+   returns false.
+3. `deleteRecipe` on a normal recipe still soft-deletes.
+
+## Error handling
+
+- The new exception from `complete_production_run` propagates to `useQuickCook` /
+  `useProductionRuns`, which already toast RPC errors and clean up the orphaned run
+  (existing `cleanupOrphanedRun` path). No client changes needed for error display.
+- Tenant guard: the by-id lookup keeps `restaurant_id = p_restaurant_id`, so a caller
+  cannot deduct against another restaurant's recipe.
+
+## Rollout
+
+- Single PR: migration + client changes + tests. Migration is safe to run any time
+  (function replacement + idempotent UPDATE touching 1 row in prod).
+- After deploy, Cook Now at Cold Stone deducts 0.5 case of ICE CREAM MIX 14% and sets
+  Sweet Cream - pans to ~$6.10/container per 2-container batch. Historical $0 runs are
+  left as-is (user decision); stock variance (~2.5 cases) to be corrected via a manual
+  inventory adjustment in the app.

--- a/src/components/DeleteRecipeDialog.tsx
+++ b/src/components/DeleteRecipeDialog.tsx
@@ -22,13 +22,18 @@ export function DeleteRecipeDialog({ isOpen, onClose, recipe }: DeleteRecipeDial
   const { deleteRecipe } = useRecipes(recipe?.restaurant_id || null);
   const [loading, setLoading] = useState(false);
 
-  const handleDelete = async () => {
+  const handleDelete = async (event: React.MouseEvent<HTMLButtonElement>) => {
+    // AlertDialogAction is Radix's Dialog.Close: without preventDefault it
+    // closes the dialog synchronously on click, before deleteRecipe resolves.
+    event.preventDefault();
     if (!recipe) return;
 
     setLoading(true);
     try {
-      await deleteRecipe(recipe.id);
-      onClose();
+      const deleted = await deleteRecipe(recipe.id);
+      if (deleted) {
+        onClose();
+      }
     } catch (error) {
       console.error('Error deleting recipe:', error);
     } finally {

--- a/src/hooks/useRecipes.tsx
+++ b/src/hooks/useRecipes.tsx
@@ -73,21 +73,39 @@ export const useRecipes = (restaurantId: string | null) => {
 
     try {
       setLoading(true);
-      const { data, error } = await supabase
-        .from('recipes')
-        .select(`
-          *,
-          ingredients:recipe_ingredients(product_id, quantity, unit)
-        `)
-        .eq('restaurant_id', restaurantId)
-        .eq('is_active', true)
-        .order('name');
+      // Shadow recipes (rows backing prep_recipes) are managed from the Prep
+      // page and must not appear here. Fail closed: if the prep_recipes query
+      // errors we abort the whole fetch rather than leak shadows back in.
+      const [recipesResult, prepLinksResult] = await Promise.all([
+        supabase
+          .from('recipes')
+          .select(`
+            *,
+            ingredients:recipe_ingredients(product_id, quantity, unit)
+          `)
+          .eq('restaurant_id', restaurantId)
+          .eq('is_active', true)
+          .order('name'),
+        supabase
+          .from('prep_recipes')
+          .select('recipe_id')
+          .eq('restaurant_id', restaurantId)
+          .not('recipe_id', 'is', null),
+      ]);
 
-      if (error) throw error;
-      
+      if (recipesResult.error) throw recipesResult.error;
+      if (prepLinksResult.error) throw prepLinksResult.error;
+
+      const shadowRecipeIds = new Set(
+        (prepLinksResult.data || []).map((link) => link.recipe_id)
+      );
+      const data = (recipesResult.data || []).filter(
+        (recipe) => !shadowRecipeIds.has(recipe.id)
+      );
+
       // Enhance recipes with updated costs and profitability data
       const enhancedRecipes = await Promise.all(
-        (data || []).map(async (recipe) => {
+        data.map(async (recipe) => {
           // Recalculate cost using the updated calculation function
           const updatedCost = await calculateRecipeCost(recipe.id);
           const recipeWithUpdatedCost = {

--- a/src/hooks/useRecipes.tsx
+++ b/src/hooks/useRecipes.tsx
@@ -525,7 +525,14 @@ export const useRecipes = (restaurantId: string | null) => {
   useEffect(() => {
     if (!restaurantId) return;
 
-    // Set up real-time subscription for recipe updates
+    // Set up real-time subscription for recipe updates. Also listen on
+    // prep_recipes: fetchRecipes filters shadow recipes out by checking
+    // prep_recipes, and usePrepRecipes.createPrepRecipe inserts the backing
+    // recipes row before the prep_recipes link row. Without this second
+    // subscription, an open Recipes page can refetch on that recipes INSERT
+    // (before the link exists) and never refetch again once the link lands,
+    // leaving the shadow recipe visible until an unrelated change or manual
+    // refresh.
     const channel = supabase
       .channel(`recipe-changes:${restaurantId}`)
       .on(
@@ -534,6 +541,18 @@ export const useRecipes = (restaurantId: string | null) => {
           event: '*',
           schema: 'public',
           table: 'recipes',
+          filter: `restaurant_id=eq.${restaurantId}`
+        },
+        () => {
+          fetchRecipesRef.current();
+        }
+      )
+      .on(
+        'postgres_changes',
+        {
+          event: '*',
+          schema: 'public',
+          table: 'prep_recipes',
           filter: `restaurant_id=eq.${restaurantId}`
         },
         () => {

--- a/src/hooks/useRecipes.tsx
+++ b/src/hooks/useRecipes.tsx
@@ -134,6 +134,10 @@ export const useRecipes = (restaurantId: string | null) => {
       setRecipes(enhancedRecipes);
     } catch (error: any) {
       console.error('Error fetching recipes:', error);
+      // Fail closed: clear any previously-loaded recipes (e.g. from a prior
+      // restaurant selection or a stale successful fetch) so a failed
+      // refetch never leaves cross-tenant/stale data on screen.
+      setRecipes([]);
       toast({
         title: "Error fetching recipes",
         description: error.message,

--- a/src/hooks/useRecipes.tsx
+++ b/src/hooks/useRecipes.tsx
@@ -344,6 +344,7 @@ export const useRecipes = (restaurantId: string | null) => {
         .from('prep_recipes')
         .select('name')
         .eq('recipe_id', id)
+        .eq('restaurant_id', restaurantId)
         .limit(1)
         .maybeSingle();
 

--- a/src/hooks/useRecipes.tsx
+++ b/src/hooks/useRecipes.tsx
@@ -334,6 +334,26 @@ export const useRecipes = (restaurantId: string | null) => {
 
   const deleteRecipe = async (id: string): Promise<boolean> => {
     try {
+      // Shadow recipes back a prep (batch) recipe; soft-deleting one silently
+      // breaks production deduction/costing. Blocked here AND by a DB trigger.
+      const { data: prepLink, error: prepLinkError } = await supabase
+        .from('prep_recipes')
+        .select('name')
+        .eq('recipe_id', id)
+        .limit(1)
+        .maybeSingle();
+
+      if (prepLinkError) throw prepLinkError;
+
+      if (prepLink) {
+        toast({
+          title: "Can't delete this recipe",
+          description: `It is managed by the batch recipe "${prepLink.name}". Go to the Prep page to manage it.`,
+          variant: "destructive",
+        });
+        return false;
+      }
+
       const { error } = await supabase
         .from('recipes')
         .update({ is_active: false })

--- a/supabase/migrations/20260705000000_fix_prep_shadow_recipe_costing.sql
+++ b/supabase/migrations/20260705000000_fix_prep_shadow_recipe_costing.sql
@@ -19,8 +19,8 @@
 -- overload ambiguity.
 DROP FUNCTION IF EXISTS public.process_unified_inventory_deduction(uuid, text, integer, text, text, text, text, text, text);
 
--- Recreate with new parameters for transaction type and reason prefix
--- This allows production runs to use 'transfer' (not COGS) vs POS using 'usage' (COGS)
+-- Recreate the function to add p_recipe_id (see §1 note above); all other
+-- parameters/behavior are unchanged from the prior signature.
 CREATE OR REPLACE FUNCTION public.process_unified_inventory_deduction(
     p_restaurant_id uuid,
     p_pos_item_name text,
@@ -107,14 +107,28 @@ BEGIN
     );
 
     IF p_recipe_id IS NOT NULL THEN
-        -- Production-run path: direct by-id lookup. Deliberately NO is_active
-        -- filter — the shadow recipe is an implementation detail and a
-        -- soft-deleted shadow row must not silently disable deductions.
-        -- Tenant guard (restaurant_id) is preserved.
+        -- Production-run path: direct by-id lookup. The is_active filter is
+        -- bypassed ONLY when the recipe is confirmed to be a prep-linked
+        -- "shadow" recipe (backs a row in prep_recipes) — that's the sole
+        -- case a soft-deleted row must not silently disable deductions for.
+        -- This gate is required because process_unified_inventory_deduction
+        -- is SECURITY DEFINER and callable directly via PostgREST RPC by any
+        -- authenticated client with restaurant access: without it, a caller
+        -- could pass an arbitrary p_recipe_id to deduct against any
+        -- soft-deleted/hidden recipe, bypassing the is_active gate POS sales
+        -- are held to (flagged in review, see PR #582).
+        -- Tenant guard (restaurant_id) is preserved in all cases.
         SELECT * INTO v_recipe_record
-        FROM recipes
-        WHERE id = p_recipe_id
-          AND restaurant_id = p_restaurant_id;
+        FROM recipes r
+        WHERE r.id = p_recipe_id
+          AND r.restaurant_id = p_restaurant_id
+          AND (
+            r.is_active = true
+            OR EXISTS (
+              SELECT 1 FROM prep_recipes pr
+              WHERE pr.recipe_id = r.id AND pr.restaurant_id = r.restaurant_id
+            )
+          );
     ELSE
         -- POS-sale path: unchanged name-based lookup, active recipes only.
         SELECT * INTO v_recipe_record
@@ -609,7 +623,10 @@ SET search_path TO 'public'
 AS $$
 BEGIN
   IF OLD.is_active = true AND NEW.is_active = false
-     AND EXISTS (SELECT 1 FROM prep_recipes WHERE recipe_id = OLD.id) THEN
+     AND EXISTS (
+       SELECT 1 FROM prep_recipes pr
+       WHERE pr.recipe_id = OLD.id AND pr.restaurant_id = OLD.restaurant_id
+     ) THEN
     RAISE EXCEPTION 'Recipe "%" backs a prep (batch) recipe and cannot be deactivated. Manage it from the Prep page.', OLD.name;
   END IF;
   RETURN NEW;
@@ -628,7 +645,7 @@ EXECUTE FUNCTION public.prevent_shadow_recipe_deactivation();
 -- NOTE: no explicit GRANT EXECUTE existed on the prior signature (default
 -- privileges apply); intentionally not adding one here.
 COMMENT ON FUNCTION public.process_unified_inventory_deduction(uuid, text, integer, text, text, text, text, text, text, uuid) IS
-'Unified inventory deduction for POS sales and production runs. When p_recipe_id is provided (production runs), the recipe is resolved by id with no is_active filter (self-healing against soft-deleted shadow recipes); otherwise by POS item name among active recipes. Supports usage (POS/COGS) and transfer (production, not COGS until sold) transaction types.';
+'Unified inventory deduction for POS sales and production runs. When p_recipe_id is provided (production runs), the recipe is resolved by id, bypassing is_active ONLY when it is confirmed to be a prep-linked shadow recipe (self-healing against soft-deleted shadow recipes); otherwise the recipe must be active (this gate also applies to the by-id path, since the function is directly callable via RPC). POS sales are resolved by item name among active recipes. Supports usage (POS/COGS) and transfer (production, not COGS until sold) transaction types.';
 
 COMMENT ON FUNCTION public.prevent_shadow_recipe_deactivation() IS
 'Backstop: blocks is_active true->false on recipes referenced by prep_recipes.recipe_id. Shadow recipes must stay active or production deduction/costing would silently break (2026-07 Cold Stone incident).';

--- a/supabase/migrations/20260705000000_fix_prep_shadow_recipe_costing.sql
+++ b/supabase/migrations/20260705000000_fix_prep_shadow_recipe_costing.sql
@@ -1,0 +1,634 @@
+-- Fix prep shadow-recipe costing (see docs/superpowers/specs/2026-07-04-prep-shadow-recipe-costing-design.md)
+--
+-- Incident: soft-deleting a prep-linked "shadow" recipe from the Recipes page
+-- (is_active = false) made process_unified_inventory_deduction's name+is_active
+-- lookup silently no-op, so complete_production_run completed runs at $0 cost
+-- with no ingredient deductions.
+--
+-- ORDER MATTERS:
+--   §1 must precede §2 (complete_production_run's new body calls the 10-arg signature).
+--   §3 (data repair) must precede §4 (the backstop trigger blocks is_active=false
+--      flips on prep-linked recipes; repair only sets true, but keep the order safe).
+
+-- ============================================================
+-- §1: process_unified_inventory_deduction gains p_recipe_id
+-- ============================================================
+-- Drop the current 9-arg signature first: Postgres cannot change a
+-- signature via CREATE OR REPLACE, and a defaulted 10th param is a NEW
+-- signature — leaving the 9-arg one behind would create PostgREST
+-- overload ambiguity.
+DROP FUNCTION IF EXISTS public.process_unified_inventory_deduction(uuid, text, integer, text, text, text, text, text, text);
+
+-- Recreate with new parameters for transaction type and reason prefix
+-- This allows production runs to use 'transfer' (not COGS) vs POS using 'usage' (COGS)
+CREATE OR REPLACE FUNCTION public.process_unified_inventory_deduction(
+    p_restaurant_id uuid,
+    p_pos_item_name text,
+    p_quantity_sold integer,
+    p_sale_date text,
+    p_external_order_id text DEFAULT NULL::text,
+    p_sale_time text DEFAULT NULL::text,
+    p_restaurant_timezone text DEFAULT 'America/Chicago'::text,
+    p_transaction_type text DEFAULT 'usage'::text,
+    p_reason_prefix text DEFAULT 'POS sale'::text,
+    p_recipe_id uuid DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+    v_recipe_record RECORD;
+    v_ingredient_record RECORD;
+    v_deduction_amount NUMERIC;
+    v_purchase_unit_deduction NUMERIC;
+    v_current_stock NUMERIC;
+    v_result jsonb;
+    v_ingredients_deducted jsonb := '[]'::jsonb;
+    v_conversion_warnings jsonb := '[]'::jsonb;
+    v_total_cost NUMERIC := 0;
+    v_cost_per_recipe_unit NUMERIC;
+    v_reference_id text;
+    v_recipe_unit_lower text;
+    v_purchase_unit_lower text;
+    v_conversion_result NUMERIC;
+    v_conversion_method text;
+    v_transaction_timestamp timestamp with time zone;
+    v_local_datetime text;
+    v_reason_text text;
+    v_size_unit_lower text;
+    v_transaction_type text;
+
+    v_volume_units text[] := ARRAY['fl oz', 'ml', 'l', 'cup', 'tbsp', 'tsp', 'gal', 'qt', 'pint'];
+    v_weight_units text[] := ARRAY['g', 'kg', 'lb', 'oz'];
+    v_container_units text[] := ARRAY['bag', 'box', 'case', 'package', 'container'];
+    v_individual_units text[] := ARRAY['each', 'piece', 'unit'];
+BEGIN
+    v_transaction_type := COALESCE(p_transaction_type, 'usage');
+    IF v_transaction_type NOT IN ('usage', 'transfer', 'adjustment', 'waste') THEN
+        v_transaction_type := 'usage';
+    END IF;
+
+    IF p_sale_time IS NOT NULL AND p_sale_time != '' THEN
+        v_local_datetime := p_sale_date || ' ' || p_sale_time;
+    ELSE
+        v_local_datetime := p_sale_date || ' 00:00:00';
+    END IF;
+
+    v_transaction_timestamp := (v_local_datetime::timestamp AT TIME ZONE p_restaurant_timezone) AT TIME ZONE 'UTC';
+
+    IF p_external_order_id IS NOT NULL THEN
+        v_reference_id := p_external_order_id || '_' || p_pos_item_name || '_' || p_sale_date;
+    ELSE
+        v_reference_id := p_pos_item_name || '_' || p_sale_date;
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM inventory_transactions
+        WHERE restaurant_id = p_restaurant_id
+        AND reference_id = v_reference_id
+        AND transaction_type = v_transaction_type
+    ) THEN
+        RETURN jsonb_build_object(
+            'recipe_name', 'Already processed',
+            'ingredients_deducted', '[]'::jsonb,
+            'total_cost', 0,
+            'conversion_warnings', '[]'::jsonb,
+            'already_processed', true
+        );
+    END IF;
+
+    v_result := jsonb_build_object(
+        'recipe_name', '',
+        'ingredients_deducted', '[]'::jsonb,
+        'total_cost', 0,
+        'conversion_warnings', '[]'::jsonb
+    );
+
+    IF p_recipe_id IS NOT NULL THEN
+        -- Production-run path: direct by-id lookup. Deliberately NO is_active
+        -- filter — the shadow recipe is an implementation detail and a
+        -- soft-deleted shadow row must not silently disable deductions.
+        -- Tenant guard (restaurant_id) is preserved.
+        SELECT * INTO v_recipe_record
+        FROM recipes
+        WHERE id = p_recipe_id
+          AND restaurant_id = p_restaurant_id;
+    ELSE
+        -- POS-sale path: unchanged name-based lookup, active recipes only.
+        SELECT * INTO v_recipe_record
+        FROM recipes
+        WHERE restaurant_id = p_restaurant_id
+          AND (pos_item_name = p_pos_item_name OR name = p_pos_item_name)
+          AND is_active = true
+        LIMIT 1;
+    END IF;
+
+    IF v_recipe_record.id IS NULL THEN
+        RAISE NOTICE 'No recipe found for POS item "%". Skipping deduction.', p_pos_item_name;
+        RETURN v_result;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM recipe_ingredients ri WHERE ri.recipe_id = v_recipe_record.id
+    ) THEN
+        RAISE NOTICE 'Recipe "%" has no ingredients. Skipping deduction.', v_recipe_record.name;
+        RETURN v_result;
+    END IF;
+
+    v_result := jsonb_set(v_result, '{recipe_name}', to_jsonb(v_recipe_record.name));
+
+    FOR v_ingredient_record IN
+        SELECT ri.*, p.name as product_name, p.current_stock, p.cost_per_unit,
+               p.uom_purchase, p.uom_recipe, p.size_value, p.size_unit, p.id as product_id
+        FROM recipe_ingredients ri
+        JOIN products p ON ri.product_id = p.id
+        WHERE ri.recipe_id = v_recipe_record.id
+    LOOP
+        v_deduction_amount := v_ingredient_record.quantity * p_quantity_sold;
+        v_recipe_unit_lower := lower(v_ingredient_record.unit::text);
+        v_purchase_unit_lower := lower(COALESCE(v_ingredient_record.uom_purchase, ''));
+        v_size_unit_lower := lower(COALESCE(v_ingredient_record.size_unit, ''));
+
+        v_conversion_result := NULL;
+        v_conversion_method := NULL;
+
+        -- Direct unit match
+        IF v_recipe_unit_lower = v_purchase_unit_lower THEN
+            v_purchase_unit_deduction := v_deduction_amount;
+            v_cost_per_recipe_unit := COALESCE(v_ingredient_record.cost_per_unit, 0);
+            v_conversion_method := '1:1';
+            v_conversion_result := 1;
+
+        -- Count-to-Container Conversion
+        ELSIF v_recipe_unit_lower = ANY(v_individual_units)
+              AND v_purchase_unit_lower = ANY(v_container_units)
+              AND COALESCE(v_ingredient_record.size_value, 0) > 0
+              AND v_size_unit_lower = ANY(v_individual_units) THEN
+            v_purchase_unit_deduction := v_deduction_amount / v_ingredient_record.size_value;
+            v_cost_per_recipe_unit := COALESCE(v_ingredient_record.cost_per_unit, 0) / v_ingredient_record.size_value;
+            v_conversion_result := 1;
+            v_conversion_method := 'count_to_container';
+
+        -- Volume-to-Volume Conversion
+        ELSIF v_recipe_unit_lower = ANY(v_volume_units) AND v_size_unit_lower = ANY(v_volume_units) THEN
+            DECLARE
+                v_recipe_in_ml NUMERIC := 0;
+                v_package_size_ml NUMERIC;
+            BEGIN
+                IF v_ingredient_record.size_value IS NOT NULL AND v_ingredient_record.size_value > 0 THEN
+                    CASE v_recipe_unit_lower
+                        WHEN 'fl oz' THEN v_recipe_in_ml := v_deduction_amount * 29.5735;
+                        WHEN 'ml' THEN v_recipe_in_ml := v_deduction_amount;
+                        WHEN 'l' THEN v_recipe_in_ml := v_deduction_amount * 1000;
+                        WHEN 'cup' THEN v_recipe_in_ml := v_deduction_amount * 236.588;
+                        WHEN 'tbsp' THEN v_recipe_in_ml := v_deduction_amount * 14.7868;
+                        WHEN 'tsp' THEN v_recipe_in_ml := v_deduction_amount * 4.92892;
+                        WHEN 'gal' THEN v_recipe_in_ml := v_deduction_amount * 3785.41;
+                        WHEN 'qt' THEN v_recipe_in_ml := v_deduction_amount * 946.353;
+                        WHEN 'pint' THEN v_recipe_in_ml := v_deduction_amount * 473.176;
+                        ELSE v_recipe_in_ml := 0;
+                    END CASE;
+
+                    IF v_recipe_in_ml > 0 THEN
+                        v_package_size_ml := v_ingredient_record.size_value;
+                        CASE v_size_unit_lower
+                            WHEN 'ml' THEN NULL;
+                            WHEN 'l' THEN v_package_size_ml := v_package_size_ml * 1000;
+                            WHEN 'gal' THEN v_package_size_ml := v_package_size_ml * 3785.41;
+                            WHEN 'qt' THEN v_package_size_ml := v_package_size_ml * 946.353;
+                            WHEN 'fl oz' THEN v_package_size_ml := v_package_size_ml * 29.5735;
+                            WHEN 'cup' THEN v_package_size_ml := v_package_size_ml * 236.588;
+                            WHEN 'tbsp' THEN v_package_size_ml := v_package_size_ml * 14.7868;
+                            WHEN 'tsp' THEN v_package_size_ml := v_package_size_ml * 4.92892;
+                            WHEN 'pint' THEN v_package_size_ml := v_package_size_ml * 473.176;
+                            ELSE NULL;
+                        END CASE;
+
+                        v_purchase_unit_deduction := v_recipe_in_ml / v_package_size_ml;
+                        v_cost_per_recipe_unit := (COALESCE(v_ingredient_record.cost_per_unit, 0) / v_package_size_ml) * (v_recipe_in_ml / v_deduction_amount);
+                        v_conversion_result := 1;
+                        v_conversion_method := 'volume_to_volume';
+                    END IF;
+                END IF;
+            END;
+
+        -- Weight-to-Weight Conversion
+        ELSIF v_recipe_unit_lower = ANY(v_weight_units) AND v_size_unit_lower = ANY(v_weight_units) THEN
+            DECLARE
+                v_recipe_in_g NUMERIC := 0;
+                v_package_size_g NUMERIC;
+            BEGIN
+                IF v_ingredient_record.size_value IS NOT NULL AND v_ingredient_record.size_value > 0 THEN
+                    CASE v_recipe_unit_lower
+                        WHEN 'g' THEN v_recipe_in_g := v_deduction_amount;
+                        WHEN 'kg' THEN v_recipe_in_g := v_deduction_amount * 1000;
+                        WHEN 'lb' THEN v_recipe_in_g := v_deduction_amount * 453.592;
+                        WHEN 'oz' THEN v_recipe_in_g := v_deduction_amount * 28.3495;
+                        ELSE v_recipe_in_g := 0;
+                    END CASE;
+
+                    IF v_recipe_in_g > 0 THEN
+                        v_package_size_g := v_ingredient_record.size_value;
+                        CASE v_size_unit_lower
+                            WHEN 'g' THEN NULL;
+                            WHEN 'kg' THEN v_package_size_g := v_package_size_g * 1000;
+                            WHEN 'lb' THEN v_package_size_g := v_package_size_g * 453.592;
+                            WHEN 'oz' THEN v_package_size_g := v_package_size_g * 28.3495;
+                            ELSE NULL;
+                        END CASE;
+
+                        v_purchase_unit_deduction := v_recipe_in_g / v_package_size_g;
+                        v_cost_per_recipe_unit := (COALESCE(v_ingredient_record.cost_per_unit, 0) / v_package_size_g) * (v_recipe_in_g / v_deduction_amount);
+                        v_conversion_result := 1;
+                        v_conversion_method := 'weight_to_weight';
+                    END IF;
+                END IF;
+            END;
+
+        -- Density Conversion (Volume to Weight)
+        ELSIF v_recipe_unit_lower IN ('cup', 'tsp', 'tbsp') AND v_size_unit_lower = ANY(v_weight_units) THEN
+            DECLARE
+                v_recipe_in_g NUMERIC := 0;
+                v_package_size_g NUMERIC;
+            BEGIN
+                IF v_ingredient_record.size_value IS NOT NULL AND v_ingredient_record.size_value > 0 THEN
+                    IF lower(v_ingredient_record.product_name) LIKE '%rice%' AND v_recipe_unit_lower = 'cup' THEN
+                        v_recipe_in_g := v_deduction_amount * 185;
+                    ELSIF lower(v_ingredient_record.product_name) LIKE '%flour%' AND v_recipe_unit_lower = 'cup' THEN
+                        v_recipe_in_g := v_deduction_amount * 120;
+                    ELSIF lower(v_ingredient_record.product_name) LIKE '%sugar%' AND v_recipe_unit_lower = 'cup' THEN
+                        v_recipe_in_g := v_deduction_amount * 200;
+                    ELSIF lower(v_ingredient_record.product_name) LIKE '%butter%' AND v_recipe_unit_lower = 'cup' THEN
+                        v_recipe_in_g := v_deduction_amount * 227;
+                    END IF;
+
+                    IF v_recipe_in_g > 0 THEN
+                        v_package_size_g := v_ingredient_record.size_value;
+                        CASE v_size_unit_lower
+                            WHEN 'g' THEN NULL;
+                            WHEN 'kg' THEN v_package_size_g := v_package_size_g * 1000;
+                            WHEN 'lb' THEN v_package_size_g := v_package_size_g * 453.592;
+                            WHEN 'oz' THEN v_package_size_g := v_package_size_g * 28.3495;
+                            ELSE NULL;
+                        END CASE;
+
+                        v_purchase_unit_deduction := v_recipe_in_g / v_package_size_g;
+                        v_cost_per_recipe_unit := (COALESCE(v_ingredient_record.cost_per_unit, 0) / v_package_size_g) * (v_recipe_in_g / v_deduction_amount);
+                        v_conversion_result := 1;
+                        v_conversion_method := 'density_to_weight';
+                    END IF;
+                END IF;
+            END;
+        END IF;
+
+        -- Fallback to 1:1
+        IF v_conversion_result IS NULL THEN
+            v_purchase_unit_deduction := v_deduction_amount;
+            v_cost_per_recipe_unit := COALESCE(v_ingredient_record.cost_per_unit, 0);
+            v_conversion_method := 'fallback_1:1';
+
+            v_conversion_warnings := v_conversion_warnings || jsonb_build_object(
+                'product_name', v_ingredient_record.product_name,
+                'recipe_quantity', v_deduction_amount,
+                'recipe_unit', v_recipe_unit_lower,
+                'purchase_unit', v_purchase_unit_lower,
+                'package_size_unit', v_size_unit_lower,
+                'deduction_amount', v_purchase_unit_deduction,
+                'warning_type', 'fallback_1:1',
+                'message', format('Could not convert %s %s to %s. Using 1:1 ratio.',
+                    v_deduction_amount, v_recipe_unit_lower, v_purchase_unit_lower)
+            );
+        END IF;
+
+        UPDATE products
+        SET current_stock = GREATEST(0, current_stock - v_purchase_unit_deduction),
+            updated_at = now()
+        WHERE id = v_ingredient_record.product_id;
+
+        SELECT current_stock INTO v_current_stock
+        FROM products WHERE id = v_ingredient_record.product_id;
+
+        v_total_cost := v_total_cost + (v_deduction_amount * v_cost_per_recipe_unit);
+
+        v_reason_text := format('%s: %s (Recipe: %s) [%s: %s %s → %s %s]',
+            COALESCE(p_reason_prefix, 'POS sale'),
+            p_pos_item_name,
+            v_recipe_record.name,
+            CASE
+                WHEN v_conversion_method = 'fallback_1:1' THEN '⚠️ FALLBACK'
+                WHEN v_conversion_method = '1:1' THEN '✓ 1:1'
+                WHEN v_conversion_method = 'count_to_container' THEN '✓ CNT-CNTR'
+                WHEN v_conversion_method = 'volume_to_volume' THEN '✓ VOL-VOL'
+                WHEN v_conversion_method = 'weight_to_weight' THEN '✓ WGT-WGT'
+                WHEN v_conversion_method = 'density_to_weight' THEN '✓ DENSITY'
+                ELSE '✓'
+            END,
+            ROUND(v_deduction_amount, 2),
+            v_recipe_unit_lower,
+            ROUND(v_purchase_unit_deduction, 3),
+            v_purchase_unit_lower
+        );
+
+        INSERT INTO inventory_transactions (
+            restaurant_id, product_id, quantity, unit_cost, total_cost,
+            transaction_type, reason, reference_id, performed_by, created_at
+        ) VALUES (
+            p_restaurant_id,
+            v_ingredient_record.product_id,
+            -v_purchase_unit_deduction,
+            v_ingredient_record.cost_per_unit,
+            -(v_purchase_unit_deduction * COALESCE(v_ingredient_record.cost_per_unit, 0)),
+            v_transaction_type,
+            v_reason_text,
+            v_reference_id,
+            auth.uid(),
+            v_transaction_timestamp
+        );
+
+        v_ingredients_deducted := v_ingredients_deducted || jsonb_build_object(
+            'product_name', v_ingredient_record.product_name,
+            'quantity_recipe_units', v_deduction_amount,
+            'recipe_unit', v_ingredient_record.unit::text,
+            'quantity_purchase_units', v_purchase_unit_deduction,
+            'purchase_unit', COALESCE(v_ingredient_record.uom_purchase, 'unit'),
+            'remaining_stock_purchase_units', v_current_stock,
+            'conversion_method', v_conversion_method
+        );
+    END LOOP;
+
+    v_result := jsonb_set(v_result, '{ingredients_deducted}', v_ingredients_deducted);
+    v_result := jsonb_set(v_result, '{total_cost}', to_jsonb(v_total_cost));
+    v_result := jsonb_set(v_result, '{conversion_warnings}', v_conversion_warnings);
+
+    RETURN v_result;
+END;
+$function$;
+
+-- ============================================================
+-- §2: complete_production_run — pass recipe id + loud failure
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.complete_production_run(
+  p_run_id UUID,
+  p_actual_yield NUMERIC,
+  p_actual_yield_unit public.measurement_unit,
+  p_ingredients JSONB DEFAULT '[]'::jsonb
+) RETURNS public.production_runs
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_run production_runs%ROWTYPE;
+  v_prep prep_recipes%ROWTYPE;
+  v_recipe recipes%ROWTYPE;
+  v_user UUID := auth.uid();
+  v_total_cost_snapshot NUMERIC := 0;
+  v_output_inventory_impact NUMERIC := 0;
+  v_reference_id TEXT;
+  v_batch_multiplier NUMERIC;
+  v_batch_multiplier_int INTEGER;
+  v_sale_date TEXT;
+  v_restaurant_timezone TEXT;
+  v_actual_yield NUMERIC;
+  v_actual_yield_unit public.measurement_unit;
+  v_deduction_result JSONB;
+BEGIN
+  IF v_user IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  SELECT * INTO v_run FROM production_runs WHERE id = p_run_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Production run not found';
+  END IF;
+
+  SELECT * INTO v_prep FROM prep_recipes WHERE id = v_run.prep_recipe_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Prep recipe not found for run %', p_run_id;
+  END IF;
+
+  IF v_prep.recipe_id IS NULL THEN
+    RAISE EXCEPTION 'Prep recipe % is missing linked recipe', v_prep.id;
+  END IF;
+
+  SELECT * INTO v_recipe FROM recipes WHERE id = v_prep.recipe_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Recipe not found for prep recipe %', v_prep.id;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM user_restaurants ur
+    WHERE ur.restaurant_id = v_run.restaurant_id AND ur.user_id = v_user
+  ) THEN
+    RAISE EXCEPTION 'Not authorized for this restaurant';
+  END IF;
+
+  IF v_run.status = 'completed' THEN
+    RETURN v_run;
+  END IF;
+
+  v_actual_yield := COALESCE(p_actual_yield, v_run.actual_yield, v_run.target_yield, v_prep.default_yield, 0);
+  v_actual_yield_unit := COALESCE(p_actual_yield_unit, v_run.actual_yield_unit, v_run.target_yield_unit, v_prep.default_yield_unit, 'unit');
+
+  IF v_prep.default_yield IS NULL OR v_prep.default_yield <= 0 THEN
+    RAISE EXCEPTION 'Prep recipe default yield is invalid for run %', p_run_id;
+  END IF;
+
+  v_batch_multiplier := v_actual_yield / v_prep.default_yield;
+
+  IF v_batch_multiplier IS NULL OR v_batch_multiplier <= 0 THEN
+    RAISE EXCEPTION 'Actual yield must be greater than zero for run %', p_run_id;
+  END IF;
+
+  IF v_batch_multiplier <> trunc(v_batch_multiplier) THEN
+    RAISE EXCEPTION 'Actual yield must be a whole-number multiple of default yield (got % / %)', v_actual_yield, v_prep.default_yield;
+  END IF;
+
+  v_batch_multiplier_int := v_batch_multiplier::integer;
+
+  SELECT timezone INTO v_restaurant_timezone FROM restaurants WHERE id = v_run.restaurant_id;
+  v_restaurant_timezone := COALESCE(v_restaurant_timezone, 'America/Chicago');
+  v_sale_date := (now() AT TIME ZONE v_restaurant_timezone)::date::text;
+
+  -- Use 'transfer' for production runs - not COGS until the product is sold
+  v_deduction_result := public.process_unified_inventory_deduction(
+    v_run.restaurant_id,
+    v_recipe.name,
+    v_batch_multiplier_int,
+    v_sale_date,
+    v_run.id::text,
+    NULL,
+    v_restaurant_timezone,
+    'transfer',
+    'Production',
+    v_prep.recipe_id
+  );
+
+  -- Loud failure: a run whose prep expects ingredients must never complete
+  -- with zero deductions (design doc §1b). already_processed = true means an
+  -- idempotent retry whose transfer transactions already exist — never raise.
+  IF COALESCE((v_deduction_result->>'already_processed')::boolean, false) = false
+     AND jsonb_array_length(COALESCE(v_deduction_result->'ingredients_deducted', '[]'::jsonb)) = 0
+     AND EXISTS (SELECT 1 FROM prep_recipe_ingredients WHERE prep_recipe_id = v_prep.id) THEN
+    RAISE EXCEPTION 'Production run %: ingredient deduction failed for recipe % (%) — no ingredients were deducted',
+      p_run_id, v_prep.recipe_id, v_recipe.name;
+  END IF;
+
+  v_reference_id := v_run.id::text || '_' || v_recipe.name || '_' || v_sale_date;
+
+  UPDATE production_run_ingredients pri
+  SET actual_quantity = COALESCE(
+        (SELECT (ing_elem->>'actual_quantity')::numeric
+         FROM jsonb_array_elements(p_ingredients) ing_elem
+         WHERE ing_elem->>'product_id' = pri.product_id::text LIMIT 1),
+        pri.actual_quantity, pri.expected_quantity, 0),
+      unit = COALESCE(
+        (SELECT (ing_elem->>'unit')::public.measurement_unit
+         FROM jsonb_array_elements(p_ingredients) ing_elem
+         WHERE ing_elem->>'product_id' = pri.product_id::text LIMIT 1),
+        pri.unit),
+      variance_percent = CASE
+        WHEN pri.expected_quantity IS NOT NULL AND pri.expected_quantity <> 0 THEN
+          ((COALESCE(
+              (SELECT (ing_elem->>'actual_quantity')::numeric
+               FROM jsonb_array_elements(p_ingredients) ing_elem
+               WHERE ing_elem->>'product_id' = pri.product_id::text LIMIT 1),
+              pri.actual_quantity, pri.expected_quantity, 0
+            ) - pri.expected_quantity) / pri.expected_quantity) * 100
+        ELSE NULL END,
+      updated_at = now()
+  WHERE pri.production_run_id = p_run_id;
+
+  UPDATE production_run_ingredients pri
+  SET unit_cost_snapshot = inv.unit_cost,
+      total_cost_snapshot = ABS(inv.total_cost),
+      updated_at = now()
+  FROM inventory_transactions inv
+  WHERE inv.reference_id = v_reference_id
+    AND inv.transaction_type = 'transfer'
+    AND inv.product_id = pri.product_id
+    AND pri.production_run_id = p_run_id;
+
+  SELECT COALESCE(SUM(ABS(total_cost)), 0) INTO v_total_cost_snapshot
+  FROM inventory_transactions
+  WHERE restaurant_id = v_run.restaurant_id
+    AND reference_id = v_reference_id
+    AND transaction_type = 'transfer';
+
+  IF v_prep.output_product_id IS NOT NULL AND v_actual_yield IS NOT NULL THEN
+    v_output_inventory_impact := public.calculate_inventory_impact_for_product(
+      v_prep.output_product_id, v_actual_yield, v_actual_yield_unit::text, v_run.restaurant_id
+    );
+    v_output_inventory_impact := COALESCE(v_output_inventory_impact, v_actual_yield, 0);
+
+    IF NOT EXISTS (
+      SELECT 1 FROM inventory_transactions
+      WHERE reference_id = v_reference_id AND transaction_type = 'transfer'
+        AND product_id = v_prep.output_product_id AND quantity > 0
+    ) THEN
+      UPDATE products
+      SET current_stock = COALESCE(current_stock, 0) + v_output_inventory_impact,
+          cost_per_unit = CASE
+            WHEN v_output_inventory_impact > 0 AND v_total_cost_snapshot > 0
+              THEN v_total_cost_snapshot / v_output_inventory_impact
+            ELSE cost_per_unit END,
+          updated_at = now()
+      WHERE id = v_prep.output_product_id;
+
+      INSERT INTO inventory_transactions (
+        restaurant_id, product_id, quantity, unit_cost, total_cost,
+        transaction_type, reason, reference_id, performed_by
+      ) VALUES (
+        v_run.restaurant_id,
+        v_prep.output_product_id,
+        v_output_inventory_impact,
+        CASE WHEN v_output_inventory_impact > 0 THEN v_total_cost_snapshot / v_output_inventory_impact ELSE 0 END,
+        v_total_cost_snapshot,
+        'transfer',
+        'Production output ' || v_reference_id,
+        v_reference_id,
+        v_user
+      );
+    ELSE
+      UPDATE products
+      SET cost_per_unit = CASE
+            WHEN v_output_inventory_impact > 0 AND v_total_cost_snapshot > 0
+              THEN v_total_cost_snapshot / v_output_inventory_impact
+            ELSE cost_per_unit END,
+          updated_at = now()
+      WHERE id = v_prep.output_product_id;
+    END IF;
+  END IF;
+
+  UPDATE production_runs
+  SET status = 'completed',
+      actual_yield = v_actual_yield,
+      actual_yield_unit = v_actual_yield_unit,
+      variance_percent = CASE
+        WHEN v_run.target_yield IS NOT NULL AND v_run.target_yield <> 0
+          THEN ((v_actual_yield - v_run.target_yield) / v_run.target_yield) * 100
+        ELSE NULL END,
+      actual_total_cost = v_total_cost_snapshot,
+      cost_per_unit = CASE
+        WHEN v_actual_yield IS NOT NULL AND v_actual_yield <> 0
+          THEN v_total_cost_snapshot / v_actual_yield
+        ELSE NULL END,
+      completed_at = now(),
+      updated_at = now()
+  WHERE id = p_run_id
+  RETURNING * INTO v_run;
+
+  RETURN v_run;
+END;
+$$;
+
+-- ============================================================
+-- §3: Data repair — reactivate prep-linked inactive shadow recipes
+-- ============================================================
+DO $$
+DECLARE v_count integer;
+BEGIN
+  UPDATE recipes r
+  SET is_active = true, updated_at = now()
+  FROM prep_recipes pr
+  WHERE pr.recipe_id = r.id AND r.is_active = false;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RAISE NOTICE 'Reactivated % prep-linked shadow recipe(s)', v_count;
+END $$;
+
+-- ============================================================
+-- §4: Backstop trigger — block deactivating prep-linked recipes
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.prevent_shadow_recipe_deactivation()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+BEGIN
+  IF OLD.is_active = true AND NEW.is_active = false
+     AND EXISTS (SELECT 1 FROM prep_recipes WHERE recipe_id = OLD.id) THEN
+    RAISE EXCEPTION 'Recipe "%" backs a prep (batch) recipe and cannot be deactivated. Manage it from the Prep page.', OLD.name;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_prevent_shadow_recipe_deactivation ON public.recipes;
+CREATE TRIGGER trg_prevent_shadow_recipe_deactivation
+BEFORE UPDATE OF is_active ON public.recipes
+FOR EACH ROW
+EXECUTE FUNCTION public.prevent_shadow_recipe_deactivation();
+
+-- ============================================================
+-- §5: Comments
+-- ============================================================
+-- NOTE: no explicit GRANT EXECUTE existed on the prior signature (default
+-- privileges apply); intentionally not adding one here.
+COMMENT ON FUNCTION public.process_unified_inventory_deduction(uuid, text, integer, text, text, text, text, text, text, uuid) IS
+'Unified inventory deduction for POS sales and production runs. When p_recipe_id is provided (production runs), the recipe is resolved by id with no is_active filter (self-healing against soft-deleted shadow recipes); otherwise by POS item name among active recipes. Supports usage (POS/COGS) and transfer (production, not COGS until sold) transaction types.';
+
+COMMENT ON FUNCTION public.prevent_shadow_recipe_deactivation() IS
+'Backstop: blocks is_active true->false on recipes referenced by prep_recipes.recipe_id. Shadow recipes must stay active or production deduction/costing would silently break (2026-07 Cold Stone incident).';

--- a/supabase/tests/03_inventory_functions.sql
+++ b/supabase/tests/03_inventory_functions.sql
@@ -29,19 +29,21 @@ SELECT function_lang_is(
 );
 
 -- Test process_unified_inventory_deduction function exists
--- Current signature: (uuid, text, integer, text, text, text, text, text, text) with 5 DEFAULT params
--- Includes p_transaction_type and p_reason_prefix for production runs (transfer) vs POS (usage)
+-- Current signature: (uuid, text, integer, text, text, text, text, text, text, uuid) with 6 DEFAULT params
+-- Includes p_transaction_type and p_reason_prefix for production runs (transfer) vs POS (usage),
+-- plus trailing p_recipe_id (uuid, DEFAULT NULL) added for the prep shadow-recipe self-heal fix
+-- (deduct by prep.recipe_id directly instead of relying on a by-name/is_active lookup).
 SELECT has_function(
     'public',
     'process_unified_inventory_deduction',
-    ARRAY['uuid', 'text', 'integer', 'text', 'text', 'text', 'text', 'text', 'text'],
+    ARRAY['uuid', 'text', 'integer', 'text', 'text', 'text', 'text', 'text', 'text', 'uuid'],
     'process_unified_inventory_deduction function should exist'
 );
 
 SELECT function_returns(
     'public',
     'process_unified_inventory_deduction',
-    ARRAY['uuid', 'text', 'integer', 'text', 'text', 'text', 'text', 'text', 'text'],
+    ARRAY['uuid', 'text', 'integer', 'text', 'text', 'text', 'text', 'text', 'text', 'uuid'],
     'jsonb',
     'process_unified_inventory_deduction should return jsonb'
 );

--- a/supabase/tests/26_prep_shadow_recipe_costing.sql
+++ b/supabase/tests/26_prep_shadow_recipe_costing.sql
@@ -1,9 +1,10 @@
 -- Prep Shadow-Recipe Costing Tests
--- Covers migration 20260705000000_fix_prep_shadow_recipe_costing.sql:
+-- Covers migration 20260705000000_fix_prep_shadow_recipe_costing.sql, in the
+-- order the sections below actually run:
 -- 1. Self-heal: production run deducts + costs even when shadow recipe is inactive
--- 2. Loud failure: prep has ingredients but deduction yields none -> exception
--- 3. Idempotency (completed run): early return, no double deduction
--- 4. Idempotency (in_progress retry with existing transactions): no exception
+-- 2. Idempotency (completed run): early return, no double deduction
+-- 3. Idempotency (in_progress retry with existing transactions): no exception
+-- 4. Loud failure: prep has ingredients but deduction yields none -> exception
 -- 5. Data repair UPDATE reactivates prep-linked inactive recipes
 -- 6. Backstop trigger blocks deactivating prep-linked recipes
 
@@ -28,10 +29,14 @@ VALUES
 ON CONFLICT (id) DO NOTHING;
 
 -- INCIDENT STATE: shadow recipe inserted ALREADY INACTIVE (bypasses the new
--- backstop trigger, which only guards true->false UPDATE flips).
+-- backstop trigger, which only guards true->false UPDATE flips). Use DO
+-- UPDATE (not DO NOTHING) so this fixture's is_active=false is always
+-- (re-)applied even if a prior non-rolled-back run left this row active --
+-- otherwise Section 1's self-heal assertions would silently test the wrong
+-- starting state.
 INSERT INTO recipes (id, restaurant_id, name, serving_size, is_active)
 VALUES ('26000000-0000-0000-0000-000000000100', '26000000-0000-0000-0000-000000000001', 'Sweet Cream Pans Prep', 2, false)
-ON CONFLICT DO NOTHING;
+ON CONFLICT (id) DO UPDATE SET is_active = EXCLUDED.is_active;
 
 INSERT INTO recipe_ingredients (recipe_id, product_id, quantity, unit)
 VALUES ('26000000-0000-0000-0000-000000000100', '26000000-0000-0000-0000-000000000010', 2.5, 'gal')

--- a/supabase/tests/26_prep_shadow_recipe_costing.sql
+++ b/supabase/tests/26_prep_shadow_recipe_costing.sql
@@ -1,0 +1,192 @@
+-- Prep Shadow-Recipe Costing Tests
+-- Covers migration 20260705000000_fix_prep_shadow_recipe_costing.sql:
+-- 1. Self-heal: production run deducts + costs even when shadow recipe is inactive
+-- 2. Loud failure: prep has ingredients but deduction yields none -> exception
+-- 3. Idempotency (completed run): early return, no double deduction
+-- 4. Idempotency (in_progress retry with existing transactions): no exception
+-- 5. Data repair UPDATE reactivates prep-linked inactive recipes
+-- 6. Backstop trigger blocks deactivating prep-linked recipes
+
+BEGIN;
+SELECT plan(14);
+
+-- ============================================================
+-- Setup: auth context, restaurant, membership
+-- ============================================================
+SELECT set_config('request.jwt.claims', '{"sub":"26000000-0000-0000-0000-0000000000ab","role":"authenticated"}', true);
+INSERT INTO auth.users (id, email) VALUES ('26000000-0000-0000-0000-0000000000ab', 'shadow-recipe-test@example.com') ON CONFLICT DO NOTHING;
+INSERT INTO restaurants (id, name) VALUES ('26000000-0000-0000-0000-000000000001', 'Shadow Recipe Test Restaurant') ON CONFLICT DO NOTHING;
+INSERT INTO user_restaurants (user_id, restaurant_id, role)
+VALUES ('26000000-0000-0000-0000-0000000000ab', '26000000-0000-0000-0000-000000000001', 'owner')
+ON CONFLICT DO NOTHING;
+
+-- Products: mix ($24.40/case of 5 gal) and pans output (container of 2.5 gal)
+INSERT INTO products (id, restaurant_id, sku, name, uom_purchase, size_value, size_unit, cost_per_unit, current_stock)
+VALUES
+  ('26000000-0000-0000-0000-000000000010', '26000000-0000-0000-0000-000000000001', 'MIX-CASE', 'Ice Cream Mix 14%', 'case', 5, 'gal', 24.40, 75),
+  ('26000000-0000-0000-0000-000000000011', '26000000-0000-0000-0000-000000000001', 'PANS-CT',  'Sweet Cream Pans',  'container', 2.5, 'gal', 0, 0)
+ON CONFLICT (id) DO NOTHING;
+
+-- INCIDENT STATE: shadow recipe inserted ALREADY INACTIVE (bypasses the new
+-- backstop trigger, which only guards true->false UPDATE flips).
+INSERT INTO recipes (id, restaurant_id, name, serving_size, is_active)
+VALUES ('26000000-0000-0000-0000-000000000100', '26000000-0000-0000-0000-000000000001', 'Sweet Cream Pans Prep', 2, false)
+ON CONFLICT DO NOTHING;
+
+INSERT INTO recipe_ingredients (recipe_id, product_id, quantity, unit)
+VALUES ('26000000-0000-0000-0000-000000000100', '26000000-0000-0000-0000-000000000010', 2.5, 'gal')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO prep_recipes (id, restaurant_id, recipe_id, name, default_yield, default_yield_unit, output_product_id)
+VALUES ('26000000-0000-0000-0000-000000000020', '26000000-0000-0000-0000-000000000001', '26000000-0000-0000-0000-000000000100', 'Sweet Cream Pans Prep', 2, 'container', '26000000-0000-0000-0000-000000000011')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO prep_recipe_ingredients (prep_recipe_id, product_id, quantity, unit)
+VALUES ('26000000-0000-0000-0000-000000000020', '26000000-0000-0000-0000-000000000010', 2.5, 'gal')
+ON CONFLICT DO NOTHING;
+
+-- ============================================================
+-- Section 1: Self-heal — inactive shadow recipe still deducts + costs
+-- 2.5 gal of a 5-gal case = 0.5 case = $12.20; output 2 containers @ $6.10
+-- ============================================================
+INSERT INTO production_runs (id, restaurant_id, prep_recipe_id, status, target_yield, target_yield_unit, created_by)
+VALUES ('26000000-0000-0000-0000-000000000030', '26000000-0000-0000-0000-000000000001', '26000000-0000-0000-0000-000000000020', 'in_progress', 2, 'container', '26000000-0000-0000-0000-0000000000ab')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO production_run_ingredients (id, production_run_id, product_id, expected_quantity, actual_quantity, unit)
+VALUES ('26000000-0000-0000-0000-000000000040', '26000000-0000-0000-0000-000000000030', '26000000-0000-0000-0000-000000000010', 2.5, 2.5, 'gal')
+ON CONFLICT DO NOTHING;
+
+SELECT lives_ok(
+  $$SELECT complete_production_run('26000000-0000-0000-0000-000000000030', 2, 'container', '[]'::jsonb)$$,
+  'Self-heal: run completes with inactive shadow recipe'
+);
+
+SELECT is(
+  (SELECT current_stock::numeric FROM products WHERE id = '26000000-0000-0000-0000-000000000010'),
+  74.5::numeric,
+  'Self-heal: mix stock deducted 75 -> 74.5 (0.5 case)'
+);
+
+SELECT is(
+  (SELECT current_stock::numeric FROM products WHERE id = '26000000-0000-0000-0000-000000000011'),
+  2::numeric,
+  'Self-heal: output stock 0 -> 2 containers'
+);
+
+SELECT is(
+  (SELECT cost_per_unit::numeric FROM products WHERE id = '26000000-0000-0000-0000-000000000011'),
+  6.10::numeric,
+  'Self-heal: output cost_per_unit $6.10 ($12.20 / 2)'
+);
+
+SELECT is(
+  (SELECT actual_total_cost::numeric FROM production_runs WHERE id = '26000000-0000-0000-0000-000000000030'),
+  12.20::numeric,
+  'Self-heal: run actual_total_cost $12.20'
+);
+
+SELECT is(
+  (SELECT COUNT(*) FROM inventory_transactions
+   WHERE reference_id LIKE '26000000-0000-0000-0000-000000000030_%'
+   AND product_id = '26000000-0000-0000-0000-000000000010'
+   AND transaction_type = 'transfer' AND quantity < 0),
+  1::bigint,
+  'Self-heal: mix deduction transaction exists'
+);
+
+-- ============================================================
+-- Section 2: Idempotency path 1 — re-completing a completed run is a no-op
+-- ============================================================
+SELECT lives_ok(
+  $$SELECT complete_production_run('26000000-0000-0000-0000-000000000030', 2, 'container', '[]'::jsonb)$$,
+  'Idempotency: re-completing a completed run does not error'
+);
+
+SELECT is(
+  (SELECT current_stock::numeric FROM products WHERE id = '26000000-0000-0000-0000-000000000010'),
+  74.5::numeric,
+  'Idempotency: no double deduction on completed-run retry'
+);
+
+-- ============================================================
+-- Section 3: Idempotency path 2 — in_progress retry whose transactions exist
+-- (simulates a retry after partial failure: deduction committed, status not
+-- yet flipped). already_processed short-circuit must NOT trip the new guard.
+-- ============================================================
+UPDATE production_runs SET status = 'in_progress', completed_at = NULL
+WHERE id = '26000000-0000-0000-0000-000000000030';
+
+SELECT lives_ok(
+  $$SELECT complete_production_run('26000000-0000-0000-0000-000000000030', 2, 'container', '[]'::jsonb)$$,
+  'Idempotency: in_progress retry with existing transactions does not raise the deduction guard'
+);
+
+SELECT is(
+  (SELECT current_stock::numeric FROM products WHERE id = '26000000-0000-0000-0000-000000000010'),
+  74.5::numeric,
+  'Idempotency: still no double deduction after in_progress retry'
+);
+
+-- ============================================================
+-- Section 4: Loud failure — prep expects ingredients, shadow list is empty
+-- ============================================================
+INSERT INTO recipes (id, restaurant_id, name, serving_size, is_active)
+VALUES ('26000000-0000-0000-0000-000000000101', '26000000-0000-0000-0000-000000000001', 'Desynced Prep', 1, true)
+ON CONFLICT DO NOTHING;
+-- NOTE: no recipe_ingredients rows for this recipe (the shadow-side desync).
+
+INSERT INTO prep_recipes (id, restaurant_id, recipe_id, name, default_yield, default_yield_unit, output_product_id)
+VALUES ('26000000-0000-0000-0000-000000000021', '26000000-0000-0000-0000-000000000001', '26000000-0000-0000-0000-000000000101', 'Desynced Prep', 1, 'unit', NULL)
+ON CONFLICT DO NOTHING;
+
+INSERT INTO prep_recipe_ingredients (prep_recipe_id, product_id, quantity, unit)
+VALUES ('26000000-0000-0000-0000-000000000021', '26000000-0000-0000-0000-000000000010', 1, 'gal')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO production_runs (id, restaurant_id, prep_recipe_id, status, target_yield, target_yield_unit, created_by)
+VALUES ('26000000-0000-0000-0000-000000000031', '26000000-0000-0000-0000-000000000001', '26000000-0000-0000-0000-000000000021', 'in_progress', 1, 'unit', '26000000-0000-0000-0000-0000000000ab')
+ON CONFLICT DO NOTHING;
+
+SELECT throws_like(
+  $$SELECT complete_production_run('26000000-0000-0000-0000-000000000031', 1, 'unit', '[]'::jsonb)$$,
+  '%no ingredients were deducted%',
+  'Loud failure: desynced shadow ingredient list raises instead of completing at $0'
+);
+
+-- ============================================================
+-- Section 5: Data repair — reactivates prep-linked inactive recipes
+-- (re-run the same statement the migration executes)
+-- ============================================================
+UPDATE recipes r
+SET is_active = true, updated_at = now()
+FROM prep_recipes pr
+WHERE pr.recipe_id = r.id AND r.is_active = false;
+
+SELECT is(
+  (SELECT is_active FROM recipes WHERE id = '26000000-0000-0000-0000-000000000100'),
+  true,
+  'Data repair: prep-linked inactive shadow recipe reactivated'
+);
+
+-- ============================================================
+-- Section 6: Backstop trigger
+-- ============================================================
+SELECT throws_like(
+  $$UPDATE recipes SET is_active = false WHERE id = '26000000-0000-0000-0000-000000000100'$$,
+  '%cannot be deactivated%',
+  'Backstop: deactivating a prep-linked recipe is blocked'
+);
+
+-- Non-linked recipe can still be deactivated
+INSERT INTO recipes (id, restaurant_id, name, serving_size, is_active)
+VALUES ('26000000-0000-0000-0000-000000000102', '26000000-0000-0000-0000-000000000001', 'Plain Menu Recipe', 1, true)
+ON CONFLICT DO NOTHING;
+
+SELECT lives_ok(
+  $$UPDATE recipes SET is_active = false WHERE id = '26000000-0000-0000-0000-000000000102'$$,
+  'Backstop: non-linked recipe soft-delete still works'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/26_prep_shadow_recipe_costing.sql
+++ b/supabase/tests/26_prep_shadow_recipe_costing.sql
@@ -8,7 +8,7 @@
 -- 6. Backstop trigger blocks deactivating prep-linked recipes
 
 BEGIN;
-SELECT plan(14);
+SELECT plan(16);
 
 -- ============================================================
 -- Setup: auth context, restaurant, membership
@@ -109,6 +109,12 @@ SELECT is(
   'Idempotency: no double deduction on completed-run retry'
 );
 
+SELECT is(
+  (SELECT current_stock::numeric FROM products WHERE id = '26000000-0000-0000-0000-000000000011'),
+  2::numeric,
+  'Idempotency: output stock not doubled on completed-run retry'
+);
+
 -- ============================================================
 -- Section 3: Idempotency path 2 — in_progress retry whose transactions exist
 -- (simulates a retry after partial failure: deduction committed, status not
@@ -126,6 +132,12 @@ SELECT is(
   (SELECT current_stock::numeric FROM products WHERE id = '26000000-0000-0000-0000-000000000010'),
   74.5::numeric,
   'Idempotency: still no double deduction after in_progress retry'
+);
+
+SELECT is(
+  (SELECT current_stock::numeric FROM products WHERE id = '26000000-0000-0000-0000-000000000011'),
+  2::numeric,
+  'Idempotency: output stock still not doubled after in_progress retry'
 );
 
 -- ============================================================

--- a/tests/unit/DeleteRecipeDialogGuard.test.tsx
+++ b/tests/unit/DeleteRecipeDialogGuard.test.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const deleteRecipeMock = vi.fn();
+vi.mock('@/hooks/useRecipes', () => ({
+  useRecipes: () => ({ deleteRecipe: deleteRecipeMock }),
+}));
+
+import { DeleteRecipeDialog } from '@/components/DeleteRecipeDialog';
+
+const recipe = {
+  id: 'r-1',
+  restaurant_id: 'rest-1',
+  name: 'Sweet Cream - pans',
+  serving_size: 1,
+  estimated_cost: 0,
+  is_active: true,
+  created_at: '',
+  updated_at: '',
+} as any;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('DeleteRecipeDialog delete-guard behavior', () => {
+  it('stays open (onClose not called) when deleteRecipe returns false', async () => {
+    deleteRecipeMock.mockResolvedValue(false);
+    const onClose = vi.fn();
+    render(<DeleteRecipeDialog isOpen={true} onClose={onClose} recipe={recipe} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /delete recipe/i }));
+
+    await waitFor(() => expect(deleteRecipeMock).toHaveBeenCalledWith('r-1'));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('closes when deleteRecipe returns true', async () => {
+    deleteRecipeMock.mockResolvedValue(true);
+    const onClose = vi.fn();
+    render(<DeleteRecipeDialog isOpen={true} onClose={onClose} recipe={recipe} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /delete recipe/i }));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+});

--- a/tests/unit/DeleteRecipeDialogGuard.test.tsx
+++ b/tests/unit/DeleteRecipeDialogGuard.test.tsx
@@ -9,6 +9,7 @@ vi.mock('@/hooks/useRecipes', () => ({
 }));
 
 import { DeleteRecipeDialog } from '@/components/DeleteRecipeDialog';
+import type { Recipe } from '@/hooks/useRecipes';
 
 const recipe = {
   id: 'r-1',
@@ -19,7 +20,7 @@ const recipe = {
   is_active: true,
   created_at: '',
   updated_at: '',
-} as any;
+} satisfies Recipe;
 
 beforeEach(() => {
   vi.clearAllMocks();

--- a/tests/unit/useRecipesShadowRecipes.test.tsx
+++ b/tests/unit/useRecipesShadowRecipes.test.tsx
@@ -130,6 +130,33 @@ describe('useRecipes shadow-recipe filtering (fetchRecipes)', () => {
       expect.objectContaining({ variant: 'destructive' })
     );
   });
+
+  it('fails closed on a later refetch: stale recipes from a prior successful fetch are cleared, not left on screen', async () => {
+    recipesResponse = {
+      data: [makeRecipe('r-menu', 'Menu Item')],
+      error: null,
+    };
+    prepLinksResponse = { data: [], error: null };
+
+    const { result, rerender } = renderHook(
+      ({ restaurantId }: { restaurantId: string }) => useRecipes(restaurantId),
+      { initialProps: { restaurantId: 'rest-1' } }
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.recipes.map((r) => r.id)).toEqual(['r-menu']);
+
+    // Simulate switching restaurants (or a realtime refetch) where the new
+    // prep_recipes query fails. Stale data from the prior successful fetch
+    // must not remain visible.
+    prepLinksResponse = { data: null, error: { message: 'prep_recipes unavailable' } };
+    rerender({ restaurantId: 'rest-2' });
+
+    await waitFor(() => expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: 'destructive' })
+    ));
+    expect(result.current.recipes).toEqual([]);
+  });
 });
 
 describe('useRecipes shadow-recipe guard (deleteRecipe)', () => {

--- a/tests/unit/useRecipesShadowRecipes.test.tsx
+++ b/tests/unit/useRecipesShadowRecipes.test.tsx
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+
+// ---- Mocks -----------------------------------------------------------------
+const toastMock = vi.fn();
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+// Stable reference: a fresh object literal per call would give fetchRecipes'
+// useCallback a new `user` dependency every render, cascading into a
+// setLoading(true)->render->refetch loop that never settles.
+const authUser = { id: 'user-1' };
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: authUser }),
+}));
+
+// Configurable per-test responses
+let recipesResponse: { data: unknown[] | null; error: unknown };
+let prepLinksResponse: { data: unknown[] | null; error: unknown };
+let prepLinkSingleResponse: { data: unknown | null; error: unknown };
+const recipesUpdateMock = vi.fn().mockReturnValue({
+  eq: vi.fn().mockResolvedValue({ error: null }),
+});
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: vi.fn((table: string) => {
+      if (table === 'recipes') {
+        return {
+          // fetch chain: .select().eq().eq().order()
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              eq: vi.fn().mockReturnValue({
+                order: vi.fn().mockImplementation(() => Promise.resolve(recipesResponse)),
+              }),
+            }),
+          }),
+          // deleteRecipe chain: .update().eq()
+          update: recipesUpdateMock,
+        };
+      }
+      if (table === 'prep_recipes') {
+        return {
+          select: vi.fn().mockReturnValue({
+            // fetch chain: .select('recipe_id').eq().not()
+            eq: vi.fn().mockReturnValue({
+              not: vi.fn().mockImplementation(() => Promise.resolve(prepLinksResponse)),
+              // deleteRecipe guard chain: .select('name').eq().limit().maybeSingle()
+              limit: vi.fn().mockReturnValue({
+                maybeSingle: vi.fn().mockImplementation(() => Promise.resolve(prepLinkSingleResponse)),
+              }),
+            }),
+          }),
+        };
+      }
+      if (table === 'recipe_ingredients') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockResolvedValue({ data: [], error: null }),
+          }),
+        };
+      }
+      // unified_sales & anything else: benign empty result
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              not: vi.fn().mockResolvedValue({ data: [], error: null }),
+            }),
+          }),
+        }),
+      };
+    }),
+    channel: vi.fn().mockReturnValue({
+      on: vi.fn().mockReturnThis(),
+      subscribe: vi.fn().mockReturnThis(),
+    }),
+    removeChannel: vi.fn(),
+  },
+}));
+
+import { useRecipes } from '@/hooks/useRecipes';
+
+const makeRecipe = (id: string, name: string) => ({
+  id,
+  restaurant_id: 'rest-1',
+  name,
+  serving_size: 1,
+  estimated_cost: 0,
+  is_active: true,
+  created_at: '',
+  updated_at: '',
+  ingredients: [],
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  recipesResponse = { data: [], error: null };
+  prepLinksResponse = { data: [], error: null };
+  prepLinkSingleResponse = { data: null, error: null };
+});
+
+describe('useRecipes shadow-recipe filtering (fetchRecipes)', () => {
+  it('excludes recipes whose ids appear in prep_recipes.recipe_id', async () => {
+    recipesResponse = {
+      data: [makeRecipe('r-menu', 'Menu Item'), makeRecipe('r-shadow', 'Sweet Cream - pans')],
+      error: null,
+    };
+    prepLinksResponse = { data: [{ recipe_id: 'r-shadow' }], error: null };
+
+    const { result } = renderHook(() => useRecipes('rest-1'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.recipes.map((r) => r.id)).toEqual(['r-menu']);
+  });
+
+  it('fails closed: prep_recipes query error -> no recipes leak, error toast fires', async () => {
+    recipesResponse = {
+      data: [makeRecipe('r-menu', 'Menu Item'), makeRecipe('r-shadow', 'Sweet Cream - pans')],
+      error: null,
+    };
+    prepLinksResponse = { data: null, error: { message: 'prep_recipes unavailable' } };
+
+    const { result } = renderHook(() => useRecipes('rest-1'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.recipes).toEqual([]);
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: 'destructive' })
+    );
+  });
+});
+
+describe('useRecipes shadow-recipe guard (deleteRecipe)', () => {
+  it('blocks deleting a prep-linked recipe: destructive toast, returns false, no update', async () => {
+    prepLinkSingleResponse = { data: { name: 'Sweet Cream - pans' }, error: null };
+
+    const { result } = renderHook(() => useRecipes('rest-1'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    let deleted: boolean | undefined;
+    await act(async () => {
+      deleted = await result.current.deleteRecipe('r-shadow');
+    });
+
+    expect(deleted).toBe(false);
+    expect(recipesUpdateMock).not.toHaveBeenCalled();
+    expect(toastMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variant: 'destructive',
+        description: expect.stringContaining('Sweet Cream - pans'),
+      })
+    );
+  });
+
+  it('still soft-deletes a normal recipe', async () => {
+    prepLinkSingleResponse = { data: null, error: null };
+
+    const { result } = renderHook(() => useRecipes('rest-1'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    let deleted: boolean | undefined;
+    await act(async () => {
+      deleted = await result.current.deleteRecipe('r-menu');
+    });
+
+    expect(deleted).toBe(true);
+    expect(recipesUpdateMock).toHaveBeenCalledWith({ is_active: false });
+  });
+});

--- a/tests/unit/useRecipesShadowRecipes.test.tsx
+++ b/tests/unit/useRecipesShadowRecipes.test.tsx
@@ -117,7 +117,7 @@ describe('useRecipes shadow-recipe filtering (fetchRecipes)', () => {
     expect(result.current.recipes.map((r) => r.id)).toEqual(['r-menu']);
   });
 
-  it('fails closed: prep_recipes query error -> no recipes leak, error toast fires', async () => {
+  it('CRITICAL: fails closed: prep_recipes query error -> no recipes leak, error toast fires', async () => {
     recipesResponse = {
       data: [makeRecipe('r-menu', 'Menu Item'), makeRecipe('r-shadow', 'Sweet Cream - pans')],
       error: null,
@@ -162,7 +162,7 @@ describe('useRecipes shadow-recipe filtering (fetchRecipes)', () => {
 });
 
 describe('useRecipes shadow-recipe guard (deleteRecipe)', () => {
-  it('blocks deleting a prep-linked recipe: destructive toast, returns false, no update', async () => {
+  it('CRITICAL: blocks deleting a prep-linked recipe: destructive toast, returns false, no update', async () => {
     prepLinkSingleResponse = { data: { name: 'Sweet Cream - pans' }, error: null };
 
     const { result } = renderHook(() => useRecipes('rest-1'));

--- a/tests/unit/useRecipesShadowRecipes.test.tsx
+++ b/tests/unit/useRecipesShadowRecipes.test.tsx
@@ -44,11 +44,13 @@ vi.mock('@/integrations/supabase/client', () => ({
         return {
           select: vi.fn().mockReturnValue({
             // fetch chain: .select('recipe_id').eq().not()
+            // deleteRecipe guard chain: .select('name').eq('recipe_id', id).eq('restaurant_id', restaurantId).limit().maybeSingle()
             eq: vi.fn().mockReturnValue({
               not: vi.fn().mockImplementation(() => Promise.resolve(prepLinksResponse)),
-              // deleteRecipe guard chain: .select('name').eq().limit().maybeSingle()
-              limit: vi.fn().mockReturnValue({
-                maybeSingle: vi.fn().mockImplementation(() => Promise.resolve(prepLinkSingleResponse)),
+              eq: vi.fn().mockReturnValue({
+                limit: vi.fn().mockReturnValue({
+                  maybeSingle: vi.fn().mockImplementation(() => Promise.resolve(prepLinkSingleResponse)),
+                }),
               }),
             }),
           }),


### PR DESCRIPTION
## Summary
- Recreates `process_unified_inventory_deduction` with a new optional `p_recipe_id` param so production runs deduct/cost by recipe id (no `is_active` filter), self-healing against a soft-deleted "shadow" recipe instead of silently deducting nothing.
- Recreates `complete_production_run` to pass the prep's `recipe_id` and to `RAISE EXCEPTION` when a run completes with zero ingredient deductions but the prep has ingredients defined (loud failure instead of a silent $0 completion) — idempotent retries are exempted.
- Adds a data-repair statement reactivating any prep-linked shadow recipe that was left `is_active = false` (fixes the one bad prod row from the incident).
- Adds a backstop `BEFORE UPDATE OF is_active` trigger on `recipes` that blocks deactivating a recipe still referenced by `prep_recipes`, with a clear error pointing to the Prep page.
- `useRecipes.fetchRecipes` now filters out prep-linked shadow recipes (parallel fetch of `recipes` + `prep_recipes.recipe_id`, fail-closed on either query erroring — clears stale recipes rather than leaking them).
- `useRecipes.deleteRecipe` blocks soft-deleting a prep-linked recipe (destructive toast, returns `false`, no update) as a second line of defense alongside the DB trigger.
- `DeleteRecipeDialog` only calls `onClose()` when `deleteRecipe` actually succeeds, so a blocked delete no longer looks like it worked (dialog stays open).

## Test plan
- [x] `supabase/tests/26_prep_shadow_recipe_costing.sql` — new 16-assertion pgTAP suite (self-heal deduction/costing, both idempotency retry paths incl. output-side stock, loud-failure guard, data repair, backstop trigger) — 16/16 pass
- [x] `npm run test:db` — 1638/1638 pgTAP tests pass, no regressions across `12_prep_production_runs.sql`, `15_production_run_costing.sql`, `16_production_run_idempotency.sql`, `25_quick_cook_inventory.sql`, `03_inventory_functions.sql`
- [x] `tests/unit/useRecipesShadowRecipes.test.tsx` — fetch filtering, fail-closed on error, stale-recipe clearing, delete guard (tenant-scoped)
- [x] `tests/unit/DeleteRecipeDialogGuard.test.tsx` — dialog stays open on blocked delete, closes on success
- [x] `npm run test` — 423 files / 5672 tests pass
- [x] `npm run test:e2e` — `prep-production.spec.ts` (covers this fix's domain) passes; 2 pre-existing, out-of-scope flaky specs unrelated to this diff tracked separately
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — no new errors vs `main`
- [x] `npm run build` — succeeds
- [x] Two rounds of CodeRabbit review, all actionable findings folded in

Design doc: [docs/superpowers/specs/2026-07-04-prep-shadow-recipe-costing-design.md](https://github.com/toyiyo/nimble-pnl/blob/fix/prep-shadow-recipe-costing/docs/superpowers/specs/2026-07-04-prep-shadow-recipe-costing-design.md)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented prep-linked “shadow” recipes from showing in the Recipes page.
  * Stopped users from deactivating recipes that are still used by prep recipes, with a clear error message.
  * Kept the delete dialog open when deletion is blocked or fails, so users can see what happened.
  * Fixed production run costing so ingredient deductions no longer silently end at $0 when linked recipes are inactive.
  * Added safeguards so affected recipes are repaired and production failures surface loudly instead of passing unnoticed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->