### PR TITLE
fix(scheduling): mobile squeeze — contain sr-only time-off spans in grid scroller

### DIFF
--- a/docs/superpowers/plans/2026-07-05-schedule-mobile-timeoff-overflow-plan.md
+++ b/docs/superpowers/plans/2026-07-05-schedule-mobile-timeoff-overflow-plan.md
@@ -1,0 +1,248 @@
+# Schedule Mobile Time-Off Overflow Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the /scheduling page from rendering zoomed-out/left-squeezed on phones by containing the absolutely positioned `sr-only` time-off spans inside the schedule grid's scroll container.
+
+**Architecture:** Two Tailwind class additions establish positioning contexts: `relative` on the day-cell `<td>` (`DroppableDayCell`) so every abspos descendant of a cell resolves its containing block inside the `overflow-x-auto` scroller, and `relative` on the scroller itself as defense in depth for the rest of the table. Regression tests pin the structural containment invariant (not class-string presence). See design doc: `docs/superpowers/specs/2026-07-05-schedule-mobile-timeoff-overflow-design.md`.
+
+**Tech Stack:** React 18, Tailwind, @dnd-kit/core, Vitest + @testing-library/react (jsdom).
+
+---
+
+### Task 1: Containment regression test + fix for `DroppableDayCell`
+
+**Files:**
+- Test: `tests/unit/droppableDayCell.containment.test.tsx` (create)
+- Modify: `src/components/scheduling/DroppableDayCell.tsx:30-35`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/droppableDayCell.containment.test.tsx`:
+
+```tsx
+/**
+ * Containment regression test for DroppableDayCell.
+ *
+ * Bug history: Tailwind `sr-only` is position:absolute. An absolutely
+ * positioned element is clipped by an overflow ancestor ONLY if that
+ * ancestor is also its containing block (i.e. positioned). The schedule
+ * grid renders sr-only time-off markers inside day cells; when the cell
+ * <td> was unpositioned, the spans escaped the grid's overflow-x-auto
+ * scroller and inflated documentElement.scrollWidth to ~951px on a 375px
+ * viewport, so phones zoomed out and the page looked squeezed left.
+ *
+ * jsdom has no layout engine, so this test pins the structural invariant:
+ * walking up from the sr-only span, the nearest ancestor carrying a
+ * positioning class must be the <td> itself — the cell is the containing
+ * block that keeps abspos descendants inside the scroller.
+ */
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { DndContext } from '@dnd-kit/core';
+import { DroppableDayCell } from '@/components/scheduling/DroppableDayCell';
+
+const POSITIONING_CLASSES = new Set(['relative', 'absolute', 'sticky', 'fixed']);
+
+const hasPositioningClass = (el: Element) =>
+  el.className
+    .toString()
+    .split(/\s+/)
+    .some((cls) => POSITIONING_CLASSES.has(cls));
+
+describe('DroppableDayCell containment', () => {
+  it('the <td> is the nearest positioned ancestor of sr-only descendants', () => {
+    const { container } = render(
+      <DndContext>
+        <table>
+          <tbody>
+            <tr>
+              <DroppableDayCell
+                employeeId="e1"
+                day="2026-07-01"
+                isToday={false}
+                isHighlighted={false}
+              >
+                {/* Mirrors the production off-day markup in Scheduling.tsx */}
+                <div className="space-y-1 min-h-[48px]">
+                  <span className="sr-only">Approved time off</span>
+                </div>
+              </DroppableDayCell>
+            </tr>
+          </tbody>
+        </table>
+      </DndContext>
+    );
+
+    const srOnly = container.querySelector('span.sr-only');
+    expect(srOnly).not.toBeNull();
+
+    let ancestor: Element | null = srOnly!.parentElement;
+    while (ancestor && !hasPositioningClass(ancestor)) {
+      ancestor = ancestor.parentElement;
+    }
+
+    expect(ancestor).not.toBeNull();
+    expect(ancestor!.tagName).toBe('TD');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/droppableDayCell.containment.test.tsx`
+Expected: FAIL — the walk exhausts ancestors (`ancestor` is null) because no element between the sr-only span and the document root carries a positioning class.
+
+- [ ] **Step 3: Add `relative` to the `<td>` in `DroppableDayCell.tsx`**
+
+In `src/components/scheduling/DroppableDayCell.tsx`, change the `<td>`'s class list (the string literal inside `cn(...)`):
+
+```tsx
+    <td
+      ref={setNodeRef}
+      className={cn(
+        // `relative` makes this cell the containing block for absolutely
+        // positioned descendants (e.g. sr-only markers), so they stay
+        // clipped inside the grid's overflow-x-auto scroller instead of
+        // widening the document on mobile.
+        'relative p-2 align-top transition-colors',
+        dayIsToday && 'bg-primary/5',
+        isOver && 'bg-primary/5 ring-1 ring-inset ring-primary/30 rounded-lg',
+        isHighlighted && 'bg-success/10 transition-colors duration-500',
+      )}
+    >
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/droppableDayCell.containment.test.tsx`
+Expected: PASS (1 test)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/unit/droppableDayCell.containment.test.tsx src/components/scheduling/DroppableDayCell.tsx
+git commit -m "fix(scheduling): day cell contains abspos sr-only spans (mobile squeeze)"
+```
+
+### Task 2: Scroller defense-in-depth test + fix in `Scheduling.tsx`
+
+**Files:**
+- Test: `tests/unit/schedulingGridScroller.test.ts` (create)
+- Modify: `src/pages/Scheduling.tsx:1478`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/schedulingGridScroller.test.ts`:
+
+```ts
+/**
+ * Source-level guard for the schedule grid scroller in Scheduling.tsx.
+ *
+ * The grid's overflow-x-auto wrapper must also be `relative` so that ANY
+ * absolutely positioned descendant of the table (current or future)
+ * resolves its containing block at or below the scroller and gets clipped
+ * by it, instead of leaking into documentElement scroll width on mobile.
+ *
+ * Rendering Scheduling.tsx is prohibitively hook-heavy (see
+ * memory/lessons.md — PR #504), so this parses the single className token
+ * that contains overflow-x-auto and asserts `relative` is one of its
+ * whitespace-split class tokens (same element — not a loose file regex).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('Scheduling grid scroller', () => {
+  it('pairs overflow-x-auto with relative on the same element', () => {
+    const src = readFileSync(
+      resolve(__dirname, '../../src/pages/Scheduling.tsx'),
+      'utf8'
+    );
+
+    const classAttrs = [...src.matchAll(/className="([^"]*)"/g)]
+      .map((m) => m[1])
+      .filter((cls) => cls.split(/\s+/).includes('overflow-x-auto'));
+
+    // Exactly one grid scroller exists in this page today; if that changes,
+    // every one of them must carry `relative`.
+    expect(classAttrs.length).toBeGreaterThan(0);
+    for (const cls of classAttrs) {
+      expect(cls.split(/\s+/)).toContain('relative');
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/schedulingGridScroller.test.ts`
+Expected: FAIL — `expect(cls.split(/\s+/)).toContain('relative')` fails for `"overflow-x-auto"`.
+
+- [ ] **Step 3: Add `relative` to the scroller div**
+
+In `src/pages/Scheduling.tsx` line 1478, change:
+
+```tsx
+            <div className="overflow-x-auto">
+```
+
+to:
+
+```tsx
+            {/* relative: clip abspos descendants of the table inside this scroller (mobile squeeze fix) */}
+            <div className="relative overflow-x-auto">
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/schedulingGridScroller.test.ts`
+Expected: PASS (1 test)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/unit/schedulingGridScroller.test.ts src/pages/Scheduling.tsx
+git commit -m "fix(scheduling): make grid scroller a containing block (defense in depth)"
+```
+
+### Task 3: Full-suite + live mobile verification
+
+**Files:** none created; verification only.
+
+- [ ] **Step 1: Run the full unit suite**
+
+Run: `npm run test`
+Expected: all tests pass (both new tests included).
+
+- [ ] **Step 2: Typecheck and lint**
+
+Run: `npm run typecheck && npm run lint`
+Expected: clean exit for both.
+
+- [ ] **Step 3: Live mobile verification (evidence, not assertion)**
+
+The main checkout's dev server (port 8080) and local Supabase already have
+the repro data seeded (restaurant `a1e1d70c-236f-4f85-b51f-edcda986d7dd`,
+user mobiletest@example.com, employee "Termora Johnson" with an approved
+Mon–Sun time-off in the current week). This task's changes live in the
+worktree, so serve the worktree on port 8081:
+
+```bash
+ln -sf /Users/josedelgado/Documents/GitHub/nimble-pnl/.env.local .env.local
+ln -sfn /Users/josedelgado/Documents/GitHub/nimble-pnl/node_modules node_modules
+npx vite --port 8081
+```
+
+Then in a 375px-wide browser context, log in as mobiletest@example.com /
+testpass123! and load `http://localhost:8081/scheduling`. Measure:
+
+```js
+({ docW: document.documentElement.scrollWidth, innerW: window.innerWidth })
+```
+
+Expected: `docW === innerW === 375` (before the fix, docW ≈ 951–956) and no
+horizontal scrolling (`window.scrollTo(600,0); window.scrollX === 0`).
+
+- [ ] **Step 4: Update progress.md** with verification evidence (numbers observed).

--- a/docs/superpowers/plans/2026-07-05-schedule-mobile-timeoff-overflow-plan.md
+++ b/docs/superpowers/plans/2026-07-05-schedule-mobile-timeoff-overflow-plan.md
@@ -225,7 +225,7 @@ Expected: clean exit for both.
 
 The main checkout's dev server (port 8080) and local Supabase already have
 the repro data seeded (restaurant `a1e1d70c-236f-4f85-b51f-edcda986d7dd`,
-user mobiletest@example.com, employee "Termora Johnson" with an approved
+a local-only test user, employee "Termora Johnson" with an approved
 Mon–Sun time-off in the current week). This task's changes live in the
 worktree, so serve the worktree on port 8081:
 
@@ -235,8 +235,9 @@ ln -sfn /Users/josedelgado/Documents/GitHub/nimble-pnl/node_modules node_modules
 npx vite --port 8081
 ```
 
-Then in a 375px-wide browser context, log in as mobiletest@example.com /
-testpass123! and load `http://localhost:8081/scheduling`. Measure:
+Then in a 375px-wide browser context, log in as the local-only test user
+created for this repro (obtain credentials out of band — do not commit them
+to this doc) and load `http://localhost:8081/scheduling`. Measure:
 
 ```js
 ({ docW: document.documentElement.scrollWidth, innerW: window.innerWidth })

--- a/docs/superpowers/plans/2026-07-05-schedule-mobile-timeoff-overflow-plan.md
+++ b/docs/superpowers/plans/2026-07-05-schedule-mobile-timeoff-overflow-plan.md
@@ -224,14 +224,14 @@ Expected: clean exit for both.
 - [ ] **Step 3: Live mobile verification (evidence, not assertion)**
 
 The main checkout's dev server (port 8080) and local Supabase already have
-the repro data seeded (restaurant `a1e1d70c-236f-4f85-b51f-edcda986d7dd`,
-a local-only test user, employee "Termora Johnson" with an approved
-Mon–Sun time-off in the current week). This task's changes live in the
-worktree, so serve the worktree on port 8081:
+the repro data seeded (restaurant `<REDACTED_RESTAURANT_ID>`, a local-only
+test user, employee `<REDACTED_EMPLOYEE>` with an approved Mon–Sun time-off
+in the current week). This task's changes live in the worktree, so serve
+the worktree on port 8081:
 
 ```bash
-ln -sf /Users/josedelgado/Documents/GitHub/nimble-pnl/.env.local .env.local
-ln -sfn /Users/josedelgado/Documents/GitHub/nimble-pnl/node_modules node_modules
+ln -sf "$(pwd)/.env.local" .env.local
+ln -sfn "$(pwd)/node_modules" node_modules
 npx vite --port 8081
 ```
 

--- a/docs/superpowers/specs/2026-07-05-schedule-mobile-timeoff-overflow-design.md
+++ b/docs/superpowers/specs/2026-07-05-schedule-mobile-timeoff-overflow-design.md
@@ -1,0 +1,107 @@
+# Schedule grid mobile squeeze — sr-only time-off spans leak document overflow
+
+**Date:** 2026-07-05
+**Status:** Approved (autonomous /dev run; user directive: "fix the view on phones for the scheduling screen")
+**Branch:** `fix/schedule-mobile-timeoff-overflow`
+
+## Problem
+
+On phones, the entire `/scheduling` page renders "squeezed to the left" with dead
+space on the right, on all mobile sizes. The mobile browser zooms out to fit a
+phantom page width (~951px on a 375px viewport) instead of laying out at the
+device width.
+
+## Root cause (verified live against production data)
+
+Diagnosis was performed by rendering the production app at 375px inside a
+same-origin iframe on app.easyshifthq.com with the affected restaurant's real
+data, then bisecting the DOM:
+
+- `documentElement.scrollWidth` = **951px** at a 370px viewport; `body.scrollWidth` = 370.
+- The window itself scrolls horizontally into blank space (`window.scrollTo(600,0)` → `scrollX` 581).
+- Bisection isolated the leak to schedule-grid rows whose employee has
+  **approved multi-day time off** (e.g. "Off Mon–Sun" → 951px, "Off Fri–Sun" → 918px).
+- The leaking elements are the `<span className="sr-only">Approved time off</span>`
+  markers rendered in each off-day cell
+  ([Scheduling.tsx:1740](../../../src/pages/Scheduling.tsx)). Introduced by the
+  roster-context-layer feature (#542, commit `8b20c382`).
+
+Mechanism: Tailwind's `sr-only` uses `position: absolute`. An absolutely
+positioned element is clipped by an `overflow` ancestor **only if that ancestor
+is also its containing block** (i.e. positioned). The schedule table lives in a
+`div.overflow-x-auto` scroller, but neither the scroller, the table, nor the
+day `<td>` (rendered by `DroppableDayCell`) is positioned. The sr-only spans
+therefore resolve their containing block above the scroller, take their static
+position inside the ~1066px-wide table (up to ~950px for a Sunday cell), and
+escape the scroll container into the document's scrollable overflow. The
+sticky employee-name cell (`position: sticky` = positioned) contains its own
+sr-only span, which is why only day cells leak.
+
+`body { overflow-x: hidden }` masks this on desktop, but the html-level
+scrollable overflow remains, and mobile browsers size the layout/visual
+viewport to it → zoomed-out, left-squeezed page.
+
+Why it never reproduced on a fresh local seed: the leak requires **approved
+time-off requests overlapping the displayed week** — data-dependent, not
+code-path-dependent. The deployed CSS (`index-zB3F8nXa.css`) is byte-identical
+to a local `main` build, ruling out a deploy diff.
+
+## Approaches considered
+
+**A. Add `relative` to the day-cell `<td>` in `DroppableDayCell` (chosen).**
+The cell becomes the containing block for every absolutely positioned
+descendant (both current sr-only spans — desktop and mobile branches render
+inside this td — and any future in-cell overlay). One-class change at the
+single component that renders all day cells. Verified live on the production
+page: setting `position: relative` on the day tds drops
+`documentElement.scrollWidth` from 951 → 370.
+
+**B. Add `relative` to the `div.overflow-x-auto` scroller.**
+Also contains the spans (and would clip any abspos descendant of the table).
+Works, but positions the spans relative to the scroller rather than the cell
+they describe, and doesn't give cells a positioning context that future cell
+overlays (bands, badges) will want. Kept as a defensive extra, not the primary
+fix — adopted alongside A because it protects the whole table (including any
+future abspos content outside a day cell) at zero cost.
+
+**C. Replace the sr-only spans with `aria-label`/`aria-description` on the cell.**
+Avoids abspos entirely, but changes accessibility semantics reviewed and
+approved in #542 (sr-only text order relative to cell content), and aria-label
+on non-interactive `<div>`s is unreliable across screen readers. Rejected.
+
+## Design
+
+1. `src/components/scheduling/DroppableDayCell.tsx`: add `relative` to the
+   `<td>` class list.
+2. `src/pages/Scheduling.tsx`: add `relative` to the schedule grid's
+   `div.overflow-x-auto` wrapper (defense in depth for the whole table).
+3. No visual change: neither element has absolutely positioned children that
+   were relying on a higher containing block for on-screen placement — the
+   sr-only spans are invisible (1×1, clipped) and everything else in the cells
+   is static/flow content. The Radix Tooltip/Popover content portals to
+   `document.body`, so it is unaffected by the new positioning contexts.
+
+## Testing
+
+- **Unit (regression pin):** render `DroppableDayCell` inside a minimal
+  `DndContext`/`table` harness and assert the `<td>` carries the `relative`
+  class, with a comment explaining the containment invariant it pins (jsdom
+  has no layout engine, so asserting the class is the pragmatic proxy for
+  "absolutely positioned sr-only descendants cannot escape the scroller").
+- **Unit:** source-text assertion that the schedule grid scroller in
+  `Scheduling.tsx` pairs `overflow-x-auto` with `relative` (same style as the
+  PR #504 breakpoint-policy tests; page-level rendering is prohibitively
+  hook-heavy per memory/lessons.md).
+- **Manual/visual:** local seed with a multi-day approved time-off request at
+  375px viewport — `documentElement.scrollWidth` must equal 375 and the page
+  must not scroll horizontally.
+
+## Decided trade-offs
+
+- We deliberately do NOT change `sr-only` usage or a11y semantics (approach C
+  rejected).
+- We do not add `overflow-x: hidden` to `html` — that would mask future leaks
+  of this class instead of preventing them, and the page-level
+  `overflow-x-hidden` wrappers already in App.tsx stay as-is.
+- Audit of other `sr-only`-inside-table sites is out of scope for this fix;
+  noted for retrospective.

--- a/docs/superpowers/specs/2026-07-05-schedule-mobile-timeoff-overflow-design.md
+++ b/docs/superpowers/specs/2026-07-05-schedule-mobile-timeoff-overflow-design.md
@@ -75,22 +75,39 @@ on non-interactive `<div>`s is unreliable across screen readers. Rejected.
    `<td>` class list.
 2. `src/pages/Scheduling.tsx`: add `relative` to the schedule grid's
    `div.overflow-x-auto` wrapper (defense in depth for the whole table).
-3. No visual change: neither element has absolutely positioned children that
-   were relying on a higher containing block for on-screen placement — the
-   sr-only spans are invisible (1×1, clipped) and everything else in the cells
-   is static/flow content. The Radix Tooltip/Popover content portals to
-   `document.body`, so it is unaffected by the new positioning contexts.
+3. No visual change: no abspos descendant currently depends on a containing
+   block further up than its own component. `ShiftCard` establishes its own
+   `relative` root for its hover actions and selection checkbox; the mobile
+   avatar span is `relative` for its badge dots; the dnd-kit drop highlight is
+   a `ring` (box-shadow, not abspos). The day `<td>` gains `relative` with no
+   `z-index`, so it does not create a stacking context and cannot interfere
+   with the sticky name column's `z-10`. Radix Tooltip/Popover content portals
+   to `document.body` (no `container=` override in this file), so it is
+   unaffected by the new positioning contexts.
+4. The fix is width-independent: it addresses containment, not layout sizing,
+   so verifying at one mobile width proves the behavior at every width
+   (320–767px inclusive).
 
 ## Testing
 
+Per design review, tests pin the **structural containment invariant**, not
+class-string presence (a class-grep would pass even if `relative` moved to a
+sibling or the sr-only span moved outside the td). Precedent:
+`tests/unit/shiftTimelineTab.mobileLayout.test.tsx` walks the rendered DOM to
+assert ancestor/descendant relationships without booting the full page.
+
 - **Unit (regression pin):** render `DroppableDayCell` inside a minimal
-  `DndContext`/`table` harness and assert the `<td>` carries the `relative`
-  class, with a comment explaining the containment invariant it pins (jsdom
-  has no layout engine, so asserting the class is the pragmatic proxy for
-  "absolutely positioned sr-only descendants cannot escape the scroller").
-- **Unit:** source-text assertion that the schedule grid scroller in
-  `Scheduling.tsx` pairs `overflow-x-auto` with `relative` (same style as the
-  PR #504 breakpoint-policy tests; page-level rendering is prohibitively
+  `DndContext`/`table` harness with a `span.sr-only` child (mirroring the
+  production markup), then walk from the sr-only span up to its nearest
+  ancestor whose class list contains a positioning class (`relative`,
+  `sticky`, etc.) and assert that ancestor is the `<td>` itself — i.e. the
+  cell is the containing block that keeps abspos descendants inside the
+  scroller. (jsdom has no layout engine; class-token analysis on the
+  ancestor chain is the closest structural proxy.)
+- **Unit:** parse `Scheduling.tsx` source for the single `className="..."`
+  token containing `overflow-x-auto` (the schedule-grid scroller) and assert
+  `relative` appears among its whitespace-split class tokens — same element,
+  not a loose file-wide regex (page-level rendering is prohibitively
   hook-heavy per memory/lessons.md).
 - **Manual/visual:** local seed with a multi-day approved time-off request at
   375px viewport — `documentElement.scrollWidth` must equal 375 and the page

--- a/src/components/scheduling/DroppableDayCell.tsx
+++ b/src/components/scheduling/DroppableDayCell.tsx
@@ -28,7 +28,7 @@ export function DroppableDayCell({
     <td
       ref={setNodeRef}
       className={cn(
-        'p-2 align-top transition-colors',
+        'relative p-2 align-top transition-colors',
         dayIsToday && 'bg-primary/5',
         isOver && 'bg-primary/5 ring-1 ring-inset ring-primary/30 rounded-lg',
         isHighlighted && 'bg-success/10 transition-colors duration-500',

--- a/src/pages/Scheduling.tsx
+++ b/src/pages/Scheduling.tsx
@@ -1475,7 +1475,11 @@ const Scheduling = () => {
               onDragEnd={handleDragEnd}
               onDragCancel={handleDragCancel}
             >
-            <div className="overflow-x-auto">
+            {/* `relative` makes this scroller the containing block for any absolutely
+                positioned descendant of the table (e.g. sr-only time-off overflow spans),
+                so they're clipped/scrolled here instead of leaking into document scroll
+                width on mobile. Defense in depth alongside DroppableDayCell's `relative`. */}
+            <div className="relative overflow-x-auto">
               <table className="w-full border-collapse min-w-[600px] md:min-w-[900px]">
                 <thead>
                   <tr className="bg-muted/30">

--- a/tests/unit/droppableDayCell.containment.test.tsx
+++ b/tests/unit/droppableDayCell.containment.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * Containment regression test for DroppableDayCell.
+ *
+ * Bug history: Tailwind `sr-only` is position:absolute. An absolutely
+ * positioned element is clipped by an overflow ancestor ONLY if that
+ * ancestor is also its containing block (i.e. positioned). The schedule
+ * grid renders sr-only time-off markers inside day cells; when the cell
+ * <td> was unpositioned, the spans escaped the grid's overflow-x-auto
+ * scroller and inflated documentElement.scrollWidth to ~951px on a 375px
+ * viewport, so phones zoomed out and the page looked squeezed left.
+ *
+ * jsdom has no layout engine, so this test pins the structural invariant:
+ * walking up from the sr-only span, the nearest ancestor carrying a
+ * positioning class must be the <td> itself — the cell is the containing
+ * block that keeps abspos descendants inside the scroller.
+ */
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { DndContext } from '@dnd-kit/core';
+import { DroppableDayCell } from '@/components/scheduling/DroppableDayCell';
+
+const POSITIONING_CLASSES = new Set(['relative', 'absolute', 'sticky', 'fixed']);
+
+const hasPositioningClass = (el: Element) =>
+  el.className
+    .toString()
+    .split(/\s+/)
+    .some((cls) => POSITIONING_CLASSES.has(cls));
+
+describe('DroppableDayCell containment', () => {
+  it('the <td> is the nearest positioned ancestor of sr-only descendants', () => {
+    const { container } = render(
+      <DndContext>
+        <table>
+          <tbody>
+            <tr>
+              <DroppableDayCell
+                employeeId="e1"
+                day="2026-07-01"
+                isToday={false}
+                isHighlighted={false}
+              >
+                {/* Mirrors the production off-day markup in Scheduling.tsx */}
+                <div className="space-y-1 min-h-[48px]">
+                  <span className="sr-only">Approved time off</span>
+                </div>
+              </DroppableDayCell>
+            </tr>
+          </tbody>
+        </table>
+      </DndContext>
+    );
+
+    const srOnly = container.querySelector('span.sr-only');
+    expect(srOnly).not.toBeNull();
+
+    let ancestor: Element | null = srOnly!.parentElement;
+    while (ancestor && !hasPositioningClass(ancestor)) {
+      ancestor = ancestor.parentElement;
+    }
+
+    expect(ancestor).not.toBeNull();
+    expect(ancestor!.tagName).toBe('TD');
+  });
+});

--- a/tests/unit/schedulingGridScroller.test.ts
+++ b/tests/unit/schedulingGridScroller.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Source-level guard for the schedule grid scroller in Scheduling.tsx.
+ *
+ * The grid's overflow-x-auto wrapper must also be `relative` so that ANY
+ * absolutely positioned descendant of the table (current or future)
+ * resolves its containing block at or below the scroller and gets clipped
+ * by it, instead of leaking into documentElement scroll width on mobile.
+ *
+ * Rendering Scheduling.tsx is prohibitively hook-heavy (see
+ * memory/lessons.md — PR #504), so this parses the single className token
+ * that contains overflow-x-auto and asserts `relative` is one of its
+ * whitespace-split class tokens (same element — not a loose file regex).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('Scheduling grid scroller', () => {
+  it('pairs overflow-x-auto with relative on the same element', () => {
+    const src = readFileSync(
+      resolve(__dirname, '../../src/pages/Scheduling.tsx'),
+      'utf8'
+    );
+
+    const classAttrs = [...src.matchAll(/className="([^"]*)"/g)]
+      .map((m) => m[1])
+      .filter((cls) => cls.split(/\s+/).includes('overflow-x-auto'));
+
+    // Exactly one grid scroller exists in this page today; if that changes,
+    // every one of them must carry `relative`.
+    expect(classAttrs.length).toBeGreaterThan(0);
+    for (const cls of classAttrs) {
+      expect(cls.split(/\s+/)).toContain('relative');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- The `/scheduling` page rendered zoomed-out and squeezed to the left on phones (all mobile sizes). Root cause: Tailwind `sr-only` (`position: absolute`) time-off markers rendered in **unpositioned** day-cell `<td>`s escape the schedule grid's `overflow-x-auto` scroller and inflate `documentElement.scrollWidth` to ~951px on a 375px viewport, so mobile browsers zoom out to fit. Introduced by the roster-context-layer feature (#542).
- Fix: make the day cell (`DroppableDayCell` `<td>`) `relative` so it is the containing block for its abspos descendants, and make the grid scroller `relative` as defense in depth for the rest of the table. Two-class change; width-independent (fixes containment, not a specific breakpoint).

## Why it only shows with real data
The leak requires an **approved multi-day time-off request overlapping the displayed week** — data-dependent, not code-path-dependent, which is why a fresh seed never reproduced it. Verified live against production data (injecting the fix dropped `scrollWidth` 951 → 370 at 375px).

## Test plan
- **New** `tests/unit/droppableDayCell.containment.test.tsx` — renders the cell with the production sr-only markup and walks up from the span: the nearest positioned ancestor must be the `<td>` (structural containment invariant, not a class-string grep).
- **New** `tests/unit/schedulingGridScroller.test.ts` — asserts the grid's `overflow-x-auto` className token also carries `relative` (same element).
- `npm run typecheck`, scoped ESLint, `npm run build` — all clean.
- Live verification on the built branch at 375px: `documentElement.scrollWidth === 375` (was 951–956), no horizontal scroll, all 21 day cells `position: relative`, page renders full-width.

Design doc: `docs/superpowers/specs/2026-07-05-schedule-mobile-timeoff-overflow-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)