### PR TITLE
fix(scheduling): area-aware template matching in planner grid + export

### DIFF
--- a/docs/superpowers/plans/2026-07-05-area-aware-template-matching-plan.md
+++ b/docs/superpowers/plans/2026-07-05-area-aware-template-matching-plan.md
@@ -1,0 +1,160 @@
+# Area-Aware Template Matching Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the shift planner grid from bucketing an employee's unlinked (no `shift_template_id`) shift into another area's template row.
+
+**Architecture:** Single change site — `findMatchingTemplate` in `src/hooks/useShiftPlanner.ts` gains an `employeeArea` parameter and an area-compatibility predicate (`!t.area || !employeeArea || t.area === employeeArea`). Non-matching shifts fall to `__unmatched__`, which `groupUnmatchedByArea` already lanes by employee home area. Explicit `shift_template_id` bucketing is untouched.
+
+**Tech Stack:** TypeScript, Vitest (`tests/unit/useShiftPlanner.test.ts`).
+
+**Spec:** `docs/superpowers/specs/2026-07-05-area-aware-template-matching-design.md`
+
+---
+
+### Task 1: Failing tests for area-aware fallback matching
+
+**Files:**
+- Test: `tests/unit/useShiftPlanner.test.ts` (inside the existing `describe('buildTemplateGridData', ...)` block, after the `'should fall back to time-based matching when shift_template_id is absent'` test)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add employee fixtures via the existing `mockShift` helper's `employee` override. Append inside `describe('buildTemplateGridData', ...)`:
+
+```typescript
+    describe('area-aware fallback matching', () => {
+      // Josiah repro: Cold Stone template is the only exact time/position match,
+      // but the shift belongs to a Wetzel's employee.
+      const cscPrepWeekend: ShiftTemplate = {
+        id: 't-csc-prep', start_time: '10:00:00', end_time: '16:00:00', position: 'Server',
+        days: [5, 6, 0], name: 'Prep-weekend', area: 'Cold Stone',
+        restaurant_id: 'r1', break_duration: 0, capacity: 1, is_active: true, created_at: '', updated_at: '',
+      };
+      const wtzOpenWeekend: ShiftTemplate = {
+        id: 't-wtz-open', start_time: '10:00:00', end_time: '16:00:00', position: 'Server',
+        days: [5, 6, 0], name: 'Open-weekend-wtz', area: "Wetzel's",
+        restaurant_id: 'r1', break_duration: 0, capacity: 1, is_active: true, created_at: '', updated_at: '',
+      };
+
+      const wtzEmployee = { id: 'e-w', name: 'Josiah', area: "Wetzel's" } as Shift['employee'];
+      // Saturday 2026-03-07, 10:00-16:00, Server, no shift_template_id
+      const unlinkedWtzShift = (overrides: Partial<Shift> = {}) => mockShift({
+        id: 's-w', employee_id: 'e-w', employee: wtzEmployee,
+        start_time: '2026-03-07T10:00:00', end_time: '2026-03-07T16:00:00',
+        position: 'Server', status: 'scheduled',
+        ...overrides,
+      });
+
+      it('does not bucket a cross-area unlinked shift into another area\'s template row', () => {
+        const grid = buildTemplateGridData([unlinkedWtzShift()], [cscPrepWeekend], weekDays);
+        expect(grid.get('t-csc-prep')?.get('2026-03-07') ?? []).toHaveLength(0);
+        expect(grid.get('__unmatched__')?.get('2026-03-07')).toHaveLength(1);
+      });
+
+      it('lanes the rejected cross-area shift under the employee home area via groupUnmatchedByArea', () => {
+        const grid = buildTemplateGridData([unlinkedWtzShift()], [cscPrepWeekend], weekDays);
+        const lanes = groupUnmatchedByArea(grid.get('__unmatched__')!);
+        expect(lanes.get("Wetzel's")?.get('2026-03-07')).toHaveLength(1);
+      });
+
+      it('matches the same-area template even when a cross-area template with identical times comes first', () => {
+        const grid = buildTemplateGridData([unlinkedWtzShift()], [cscPrepWeekend, wtzOpenWeekend], weekDays);
+        expect(grid.get('t-wtz-open')?.get('2026-03-07')).toHaveLength(1);
+        expect(grid.get('t-csc-prep')?.get('2026-03-07') ?? []).toHaveLength(0);
+      });
+
+      it('matches permissively when the employee has no area', () => {
+        const noAreaEmployee = { id: 'e-n', name: 'NoArea' } as Shift['employee'];
+        const shift = unlinkedWtzShift({ employee_id: 'e-n', employee: noAreaEmployee });
+        const grid = buildTemplateGridData([shift], [cscPrepWeekend], weekDays);
+        expect(grid.get('t-csc-prep')?.get('2026-03-07')).toHaveLength(1);
+      });
+
+      it('matches permissively when the template has no area', () => {
+        const noAreaTemplate: ShiftTemplate = { ...cscPrepWeekend, id: 't-no-area', area: null };
+        const grid = buildTemplateGridData([unlinkedWtzShift()], [noAreaTemplate], weekDays);
+        expect(grid.get('t-no-area')?.get('2026-03-07')).toHaveLength(1);
+      });
+    });
+```
+
+- [ ] **Step 2: Run tests to verify the right ones fail**
+
+Run: `npx vitest run tests/unit/useShiftPlanner.test.ts`
+Expected: the first three new tests FAIL (shift currently buckets into `t-csc-prep`); the two permissive-null tests PASS (current behavior already permissive); all pre-existing tests PASS.
+
+### Task 2: Implement area-compatible matching
+
+**Files:**
+- Modify: `src/hooks/useShiftPlanner.ts:100-167` (`findMatchingTemplate` + its caller in `buildTemplateGridData`)
+
+- [ ] **Step 1: Add the area parameter and predicate**
+
+Replace `findMatchingTemplate`:
+
+```typescript
+/**
+ * Find the first template that matches a shift's time, position, and active
+ * day, and is area-compatible with the employee: a template with an area only
+ * matches an employee from the same area (or with no area). Prevents an
+ * unlinked shift from rendering under another area's template row.
+ */
+function findMatchingTemplate(
+  templates: ShiftTemplate[],
+  shiftStart: string,
+  shiftEnd: string,
+  position: string,
+  dayOfWeek: number,
+  employeeArea: string | null,
+): ShiftTemplate | undefined {
+  return templates.find(
+    (t) =>
+      t.start_time === shiftStart &&
+      t.end_time === shiftEnd &&
+      t.position === position &&
+      t.days.includes(dayOfWeek) &&
+      (!t.area || !employeeArea || t.area === employeeArea),
+  );
+}
+```
+
+Update the caller in `buildTemplateGridData`:
+
+```typescript
+    const match = findMatchingTemplate(
+      templates,
+      shiftStart,
+      shiftEnd,
+      shift.position,
+      dayOfWeek,
+      shift.employee?.area ?? null,
+    );
+```
+
+Also extend the `buildTemplateGridData` JSDoc line "Matches shifts to templates by comparing start_time (HH:MM:SS), end_time (HH:MM:SS), and position." to "... position, active day, and area compatibility (employee home area vs template area; null on either side is permissive)."
+
+- [ ] **Step 2: Run tests to verify all pass**
+
+Run: `npx vitest run tests/unit/useShiftPlanner.test.ts`
+Expected: ALL tests PASS, including the five new ones.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/hooks/useShiftPlanner.ts tests/unit/useShiftPlanner.test.ts
+git commit -m "fix(scheduling): area-aware fallback template matching in planner grid
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+### Task 3: Full local verification
+
+- [ ] **Step 1: Run the full unit suite, typecheck, lint**
+
+Run: `npm run test && npm run typecheck && npm run lint`
+Expected: all green. (No DB or E2E surface touched; `npm run build` runs in Phase 8.)
+
+- [ ] **Step 2: Grep for stale comments referencing the old matching contract**
+
+Run: `grep -rn "time/position" src/ | grep -i template`
+Expected: only the updated JSDoc in `useShiftPlanner.ts`. Fix any stragglers that describe area-blind matching as current behavior; commit if changed.

--- a/docs/superpowers/plans/2026-07-05-area-aware-template-matching-plan.md
+++ b/docs/superpowers/plans/2026-07-05-area-aware-template-matching-plan.md
@@ -12,7 +12,7 @@
 
 ---
 
-### Task 1: Failing tests for area-aware fallback matching
+## Task 1: Failing tests for area-aware fallback matching
 
 **Files:**
 - Test: `tests/unit/useShiftPlanner.test.ts` (inside the existing `describe('buildTemplateGridData', ...)` block, after the `'should fall back to time-based matching when shift_template_id is absent'` test)
@@ -83,7 +83,7 @@ Add employee fixtures via the existing `mockShift` helper's `employee` override.
 Run: `npx vitest run tests/unit/useShiftPlanner.test.ts`
 Expected: the first three new tests FAIL (shift currently buckets into `t-csc-prep`); the two permissive-null tests PASS (current behavior already permissive); all pre-existing tests PASS.
 
-### Task 2: Implement area-compatible matching
+## Task 2: Implement area-compatible matching
 
 **Files:**
 - Modify: `src/hooks/useShiftPlanner.ts:100-167` (`findMatchingTemplate` + its caller in `buildTemplateGridData`)
@@ -147,7 +147,7 @@ git commit -m "fix(scheduling): area-aware fallback template matching in planner
 Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
 ```
 
-### Task 3: Full local verification
+## Task 3: Full local verification
 
 - [ ] **Step 1: Run the full unit suite, typecheck, lint**
 

--- a/docs/superpowers/specs/2026-07-05-area-aware-template-matching-design.md
+++ b/docs/superpowers/specs/2026-07-05-area-aware-template-matching-design.md
@@ -66,9 +66,15 @@ Make the fallback matcher area-compatible:
   drives PDF/CSV export and carried the identical area-blind matching. Without
   it, the on-screen grid would be fixed but the exported file for the same
   Josiah/Justin repro week would still mis-bucket the shifts into the Cold
-  Stone row. The same `!t.area || !employeeArea || t.area === employeeArea`
-  predicate is mirrored in, reading `shift.employee?.area` directly (no extra
-  parameter — the function already receives the full shift).
+  Stone row. The area-aware fallback is mirrored via the shared
+  `templateAreaMatch` helpers, reading `shift.employee?.area` directly.
+  **Explicit-link precedence (Phase 9d, Codex P2):** `buildGridExportData` now
+  resolves `shift.shift_template_id` first — exactly like the grid's
+  `buildTemplateGridData` — so a deliberate cross-area cover (an assigned shift
+  whose area differs from its linked template) stays under its linked row in
+  exports instead of being dropped by the area filter. A link to an archived
+  template is skipped (never re-matched by time), mirroring the grid's
+  `__unmatched__` handling.
 - Downstream consumers referencing the same matching assumption
   (`usePlannerShiftsIndex.ts`, `Scheduling.tsx` `computeOpenSpots`,
   `shiftAllocation.ts` comments) reference the exact-match path for

--- a/docs/superpowers/specs/2026-07-05-area-aware-template-matching-design.md
+++ b/docs/superpowers/specs/2026-07-05-area-aware-template-matching-design.md
@@ -1,0 +1,74 @@
+# Area-Aware Template Matching in the Shift Planner Grid
+
+**Date:** 2026-07-05
+**Status:** Approved (user requested "real fix" for the confirmed prod bug)
+
+## Problem
+
+The shift planner's weekly grid buckets shifts into template rows. For shifts
+with an explicit `shift_template_id`, bucketing is exact. For unlinked shifts
+(manual/legacy, `shift_template_id IS NULL`), `findMatchingTemplate` in
+`src/hooks/useShiftPlanner.ts` falls back to matching by start time + end time
++ position + active day — **area is ignored**, and the first matching template
+wins.
+
+Confirmed in production (week of 2026-07-06): Josiah Gonzalez and Justin Seals
+(both `employees.area = "Wetzel's"`) have manual 10:00–16:00 Server shifts with
+no template link. The only template with that exact time/position/days is
+"Prep-weekend" (`shift_templates.area = "Cold Stone"`), so their Wetzel's
+shifts render under the Cold Stone section with a spurious "Wetzel's" covering
+badge, and inflate Cold Stone's coverage counts (the 1/1 "Cover" numbers).
+
+## Design
+
+Make the fallback matcher area-compatible:
+
+- `findMatchingTemplate` receives the shift's employee home area
+  (`shift.employee?.area ?? null`).
+- A template is a candidate only if it is **area-compatible**:
+  `!template.area || !employeeArea || template.area === employeeArea`.
+  - Null/undefined on either side stays permissive — legacy data without
+    areas keeps today's behavior.
+  - Both sides non-null and different → not a match.
+- If no area-compatible template matches, the shift buckets under
+  `__unmatched__`, which `groupUnmatchedByArea` already groups into the
+  off-template lane keyed by the employee's home area. So Josiah's shifts
+  appear in a Wetzel's off-template lane, not Cold Stone's row.
+- Shifts with an explicit `shift_template_id` are untouched: they bucket under
+  that template unconditionally (deliberate cross-area assignment keeps its
+  covering badge).
+
+## Alternatives considered
+
+1. **Prefer-same-area with cross-area fallback** (two-pass): would NOT fix the
+   reported bug — Wetzel's has no 10:00–16:00 template, so the second pass
+   would still land Josiah in Cold Stone's row. Rejected.
+2. **Drop fallback matching entirely** (only `shift_template_id` buckets):
+   simplest, but regresses legitimate same-area manual/legacy shifts that
+   currently display correctly in template rows. Rejected.
+
+## Impact surface
+
+- `buildTemplateGridData` / `findMatchingTemplate` in
+  `src/hooks/useShiftPlanner.ts` — the only code change site.
+- Downstream consumers referencing the same matching assumption
+  (`usePlannerShiftsIndex.ts`, `Scheduling.tsx` `computeOpenSpots`,
+  `shiftAllocation.ts` comments) reference the exact-match path for
+  template-linked shifts and are unaffected; comments will be checked for
+  drift.
+- Coverage counts fix themselves: a mis-bucketed shift no longer counts toward
+  another area's slot numerator.
+
+## Testing
+
+Unit tests in `tests/unit/useShiftPlanner.test.ts` (existing file) covering:
+
+1. Same-area unlinked shift still matches its area's template (regression
+   guard).
+2. Cross-area unlinked shift with an exact time/position collision goes to
+   `__unmatched__`, and `groupUnmatchedByArea` places it under the employee's
+   home area (the Josiah repro).
+3. Null employee area matches an area-bearing template (permissive-null).
+4. Null template area matches an area-bearing employee (permissive-null).
+5. Explicit `shift_template_id` to a cross-area template still buckets under
+   that template (covering flow untouched).

--- a/docs/superpowers/specs/2026-07-05-area-aware-template-matching-design.md
+++ b/docs/superpowers/specs/2026-07-05-area-aware-template-matching-design.md
@@ -30,6 +30,15 @@ Make the fallback matcher area-compatible:
   - Null/undefined on either side stays permissive — legacy data without
     areas keeps today's behavior.
   - Both sides non-null and different → not a match.
+- **Priority among candidates** (added in Phase 7c, CodeRabbit finding): an
+  exact same-area match is preferred over an area-agnostic (null-area)
+  template, so a generic template listed earlier in the array never wins over
+  the employee's own-area template. When the employee has no area, input order
+  is preserved.
+- Both rules live in a shared helper `src/lib/templateAreaMatch.ts`
+  (`isAreaCompatible` + `pickAreaPreferredMatch`) used by **both** the grid
+  (`useShiftPlanner.ts`) and the export (`plannerExport.ts`) so the two paths
+  can never drift.
 - If no area-compatible template matches, the shift buckets under
   `__unmatched__`, which `groupUnmatchedByArea` already groups into the
   off-template lane keyed by the employee's home area. So Josiah's shifts

--- a/docs/superpowers/specs/2026-07-05-area-aware-template-matching-design.md
+++ b/docs/superpowers/specs/2026-07-05-area-aware-template-matching-design.md
@@ -50,7 +50,16 @@ Make the fallback matcher area-compatible:
 ## Impact surface
 
 - `buildTemplateGridData` / `findMatchingTemplate` in
-  `src/hooks/useShiftPlanner.ts` — the only code change site.
+  `src/hooks/useShiftPlanner.ts` — the on-screen grid change site.
+- `findTemplateForShift` / `buildGridExportData` in
+  `src/utils/plannerExport.ts` — **added to scope during Phase 7b** (Codex
+  MAJOR finding). This is an independent, separately-tested function that
+  drives PDF/CSV export and carried the identical area-blind matching. Without
+  it, the on-screen grid would be fixed but the exported file for the same
+  Josiah/Justin repro week would still mis-bucket the shifts into the Cold
+  Stone row. The same `!t.area || !employeeArea || t.area === employeeArea`
+  predicate is mirrored in, reading `shift.employee?.area` directly (no extra
+  parameter — the function already receives the full shift).
 - Downstream consumers referencing the same matching assumption
   (`usePlannerShiftsIndex.ts`, `Scheduling.tsx` `computeOpenSpots`,
   `shiftAllocation.ts` comments) reference the exact-match path for

--- a/src/hooks/useShiftPlanner.ts
+++ b/src/hooks/useShiftPlanner.ts
@@ -16,7 +16,7 @@ import { checkConflictsImperative } from '@/hooks/useConflictDetection';
 
 import { templateAppliesToDay } from '@/hooks/useShiftTemplates';
 import { UNASSIGNED } from '@/lib/templateAreaGrouping';
-import { isAreaCompatible, pickAreaPreferredMatch } from '@/lib/templateAreaMatch';
+import { findAreaAwareTemplate } from '@/lib/templateAreaMatch';
 
 import type { Shift, ShiftTemplate, ConflictCheck } from '@/types/scheduling';
 import type { ValidationIssue } from '@/lib/shiftValidator';
@@ -100,10 +100,9 @@ export function buildGridData(
 
 /**
  * Find the template that matches a shift's time, position, and active day, and
- * is area-compatible with the employee: a template with an area only matches an
- * employee from the same area (or with no area). An exact same-area match is
- * preferred over an area-agnostic (null-area) template. Prevents an unlinked
- * shift from rendering under another area's template row.
+ * is area-compatible with the employee. Thin wrapper over the shared
+ * `findAreaAwareTemplate` so the grid and the export (plannerExport) select
+ * templates identically.
  */
 function findMatchingTemplate(
   templates: ShiftTemplate[],
@@ -113,15 +112,7 @@ function findMatchingTemplate(
   dayOfWeek: number,
   employeeArea: string | null,
 ): ShiftTemplate | undefined {
-  const candidates = templates.filter(
-    (t) =>
-      t.start_time === shiftStart &&
-      t.end_time === shiftEnd &&
-      t.position === position &&
-      t.days.includes(dayOfWeek) &&
-      isAreaCompatible(t.area, employeeArea),
-  );
-  return pickAreaPreferredMatch(candidates, employeeArea);
+  return findAreaAwareTemplate(templates, { shiftStart, shiftEnd, position, dayOfWeek, employeeArea });
 }
 
 /**

--- a/src/hooks/useShiftPlanner.ts
+++ b/src/hooks/useShiftPlanner.ts
@@ -97,27 +97,35 @@ export function buildGridData(
   return grid;
 }
 
-/** Find the first template that matches a shift's time, position, and active day. */
+/**
+ * Find the first template that matches a shift's time, position, and active
+ * day, and is area-compatible with the employee: a template with an area only
+ * matches an employee from the same area (or with no area). Prevents an
+ * unlinked shift from rendering under another area's template row.
+ */
 function findMatchingTemplate(
   templates: ShiftTemplate[],
   shiftStart: string,
   shiftEnd: string,
   position: string,
   dayOfWeek: number,
+  employeeArea: string | null,
 ): ShiftTemplate | undefined {
   return templates.find(
     (t) =>
       t.start_time === shiftStart &&
       t.end_time === shiftEnd &&
       t.position === position &&
-      t.days.includes(dayOfWeek),
+      t.days.includes(dayOfWeek) &&
+      (!t.area || !employeeArea || t.area === employeeArea),
   );
 }
 
 /**
  * Groups shifts into a Map<templateId, Map<dayString, Shift[]>>.
  * Matches shifts to templates by comparing start_time (HH:MM:SS),
- * end_time (HH:MM:SS), and position.
+ * end_time (HH:MM:SS), position, active day, and area compatibility
+ * (employee home area vs template area; null on either side is permissive).
  * Unmatched shifts go under '__unmatched__'. Cancelled shifts are excluded.
  */
 export function buildTemplateGridData(
@@ -157,7 +165,14 @@ export function buildTemplateGridData(
     const shiftStart = formatLocalTime(shift.start_time);
     const shiftEnd = formatLocalTime(shift.end_time);
     const dayOfWeek = shiftStartAt.getDay();
-    const match = findMatchingTemplate(templates, shiftStart, shiftEnd, shift.position, dayOfWeek);
+    const match = findMatchingTemplate(
+      templates,
+      shiftStart,
+      shiftEnd,
+      shift.position,
+      dayOfWeek,
+      shift.employee?.area ?? null,
+    );
 
     const bucketKey = match ? match.id : '__unmatched__';
     pushToGridBucket(grid.get(bucketKey)!, dayStr, shift);

--- a/src/hooks/useShiftPlanner.ts
+++ b/src/hooks/useShiftPlanner.ts
@@ -16,6 +16,7 @@ import { checkConflictsImperative } from '@/hooks/useConflictDetection';
 
 import { templateAppliesToDay } from '@/hooks/useShiftTemplates';
 import { UNASSIGNED } from '@/lib/templateAreaGrouping';
+import { isAreaCompatible, pickAreaPreferredMatch } from '@/lib/templateAreaMatch';
 
 import type { Shift, ShiftTemplate, ConflictCheck } from '@/types/scheduling';
 import type { ValidationIssue } from '@/lib/shiftValidator';
@@ -98,10 +99,11 @@ export function buildGridData(
 }
 
 /**
- * Find the first template that matches a shift's time, position, and active
- * day, and is area-compatible with the employee: a template with an area only
- * matches an employee from the same area (or with no area). Prevents an
- * unlinked shift from rendering under another area's template row.
+ * Find the template that matches a shift's time, position, and active day, and
+ * is area-compatible with the employee: a template with an area only matches an
+ * employee from the same area (or with no area). An exact same-area match is
+ * preferred over an area-agnostic (null-area) template. Prevents an unlinked
+ * shift from rendering under another area's template row.
  */
 function findMatchingTemplate(
   templates: ShiftTemplate[],
@@ -111,14 +113,15 @@ function findMatchingTemplate(
   dayOfWeek: number,
   employeeArea: string | null,
 ): ShiftTemplate | undefined {
-  return templates.find(
+  const candidates = templates.filter(
     (t) =>
       t.start_time === shiftStart &&
       t.end_time === shiftEnd &&
       t.position === position &&
       t.days.includes(dayOfWeek) &&
-      (!t.area || !employeeArea || t.area === employeeArea),
+      isAreaCompatible(t.area, employeeArea),
   );
+  return pickAreaPreferredMatch(candidates, employeeArea);
 }
 
 /**

--- a/src/lib/templateAreaMatch.ts
+++ b/src/lib/templateAreaMatch.ts
@@ -29,3 +29,46 @@ export function pickAreaPreferredMatch<T extends { area?: string | null }>(
   if (!employeeArea) return candidates[0];
   return candidates.find((t) => t.area === employeeArea) ?? candidates[0];
 }
+
+/** The fields that identify which template an unlinked shift buckets under. */
+export interface ShiftMatchKey {
+  /** Local HH:MM:SS start, matched exactly against template.start_time. */
+  shiftStart: string;
+  /** Local HH:MM:SS end, matched exactly against template.end_time. */
+  shiftEnd: string;
+  position: string;
+  /** 0 (Sun) – 6 (Sat), matched against template.days. */
+  dayOfWeek: number;
+  employeeArea: string | null;
+}
+
+/** A template shape the area-aware matcher can select over. */
+export interface MatchableTemplate {
+  start_time: string;
+  end_time: string;
+  position: string;
+  days: number[];
+  area?: string | null;
+}
+
+/**
+ * Select the template an unlinked shift buckets under: filter templates by exact
+ * start/end/position/active-day plus area compatibility, then prefer an exact
+ * same-area match over an area-agnostic one. This is the single source of truth
+ * shared by the planner grid (useShiftPlanner) and the export (plannerExport) so
+ * the two matchers can never drift.
+ */
+export function findAreaAwareTemplate<T extends MatchableTemplate>(
+  templates: T[],
+  key: ShiftMatchKey,
+): T | undefined {
+  const candidates = templates.filter(
+    (t) =>
+      t.start_time === key.shiftStart &&
+      t.end_time === key.shiftEnd &&
+      t.position === key.position &&
+      t.days.includes(key.dayOfWeek) &&
+      isAreaCompatible(t.area, key.employeeArea),
+  );
+  return pickAreaPreferredMatch(candidates, key.employeeArea);
+}

--- a/src/lib/templateAreaMatch.ts
+++ b/src/lib/templateAreaMatch.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared area-matching rules for bucketing an unlinked shift (no
+ * shift_template_id) into a template row. Used by both the on-screen planner
+ * grid (useShiftPlanner.ts) and the PDF/CSV export (plannerExport.ts) so the
+ * two never diverge — a cross-area shift must land in the same place in both.
+ */
+
+/**
+ * A template with an area only matches an employee from the same area; a null
+ * area on either side is permissive (legacy data without areas keeps matching).
+ */
+export function isAreaCompatible(
+  templateArea: string | null | undefined,
+  employeeArea: string | null | undefined,
+): boolean {
+  return !templateArea || !employeeArea || templateArea === employeeArea;
+}
+
+/**
+ * From candidates already filtered to area-compatible templates, prefer an
+ * exact same-area match over an area-agnostic (null-area) one; otherwise return
+ * the first candidate. When the employee has no area there is nothing to
+ * prefer, so input order is preserved.
+ */
+export function pickAreaPreferredMatch<T extends { area?: string | null }>(
+  candidates: T[],
+  employeeArea: string | null | undefined,
+): T | undefined {
+  if (!employeeArea) return candidates[0];
+  return candidates.find((t) => t.area === employeeArea) ?? candidates[0];
+}

--- a/src/utils/plannerExport.ts
+++ b/src/utils/plannerExport.ts
@@ -139,13 +139,21 @@ export function buildGridExportData(
 
   // Index non-cancelled shifts by templateId → day → employee names
   const shiftsByTemplate = new Map<string, Map<string, string[]>>();
+  const templateById = new Map(templates.map((t) => [t.id, t]));
 
   for (const shift of shifts) {
     if (shift.status === 'cancelled') continue;
     const dateStr = formatLocalDate(new Date(shift.start_time));
     if (!weekDaySet.has(dateStr)) continue;
 
-    const template = findTemplateForShift(shift, templates);
+    // Prefer an explicit template link (set during planner assignment) exactly
+    // like buildTemplateGridData: an assigned shift — including a deliberate
+    // cross-area cover — stays under its linked template. Fall back to
+    // area-aware time matching only for unlinked shifts. A link to an archived
+    // template (not in the list) is skipped, never re-matched by time.
+    const template = shift.shift_template_id
+      ? templateById.get(shift.shift_template_id)
+      : findTemplateForShift(shift, templates);
     if (!template) continue;
 
     if (!shiftsByTemplate.has(template.id)) {

--- a/src/utils/plannerExport.ts
+++ b/src/utils/plannerExport.ts
@@ -177,7 +177,9 @@ export function buildGridExportData(
     }
   }
 
-  const sortNames = (names: string[]) => names.sort((a, b) => a.localeCompare(b)).join('\n');
+  // Copy before sorting: the arrays live in the day maps and we must not mutate
+  // them in place while building cells.
+  const sortNames = (names: string[]) => [...names].sort((a, b) => a.localeCompare(b)).join('\n');
 
   // Build rows in template order
   const rows: GridRow[] = templates.map((template) => {

--- a/src/utils/plannerExport.ts
+++ b/src/utils/plannerExport.ts
@@ -3,7 +3,8 @@ import autoTable from 'jspdf-autotable';
 
 import { templateAppliesToDay } from '@/hooks/useShiftTemplates';
 import { formatLocalDate } from '@/lib/shiftInterval';
-import { isAreaCompatible, pickAreaPreferredMatch } from '@/lib/templateAreaMatch';
+import { UNASSIGNED } from '@/lib/templateAreaGrouping';
+import { findAreaAwareTemplate } from '@/lib/templateAreaMatch';
 import { exportToCSV } from '@/utils/csvExport';
 
 import type { Shift, ShiftTemplate } from '@/types/scheduling';
@@ -106,17 +107,14 @@ export function findTemplateForShift(
   const endDate = new Date(shift.end_time);
   const shiftEnd = `${pad(endDate.getHours())}:${pad(endDate.getMinutes())}:${pad(endDate.getSeconds())}`;
   const dayOfWeek = startDate.getDay();
-  const employeeArea = shift.employee?.area ?? null;
 
-  const candidates = templates.filter(
-    (t) =>
-      t.start_time === shiftStart &&
-      t.end_time === shiftEnd &&
-      t.position === shift.position &&
-      t.days.includes(dayOfWeek) &&
-      isAreaCompatible(t.area, employeeArea),
-  );
-  return pickAreaPreferredMatch(candidates, employeeArea);
+  return findAreaAwareTemplate(templates, {
+    shiftStart,
+    shiftEnd,
+    position: shift.position,
+    dayOfWeek,
+    employeeArea: shift.employee?.area ?? null,
+  });
 }
 
 /**
@@ -137,9 +135,19 @@ export function buildGridExportData(
     return `${name} ${date.getMonth() + 1}/${date.getDate()}`;
   });
 
-  // Index non-cancelled shifts by templateId → day → employee names
+  // Index non-cancelled shifts by templateId → day → employee names. Shifts
+  // that don't resolve to a template go to an off-template bucket keyed by the
+  // employee's home area, mirroring the grid's off-template lane so exports
+  // never silently omit coverage.
   const shiftsByTemplate = new Map<string, Map<string, string[]>>();
+  const offTemplateByArea = new Map<string, Map<string, string[]>>();
   const templateById = new Map(templates.map((t) => [t.id, t]));
+
+  const pushName = (byDay: Map<string, string[]>, dateStr: string, name: string) => {
+    const names = byDay.get(dateStr) ?? [];
+    if (names.length === 0) byDay.set(dateStr, names);
+    names.push(name);
+  };
 
   for (const shift of shifts) {
     if (shift.status === 'cancelled') continue;
@@ -150,21 +158,26 @@ export function buildGridExportData(
     // like buildTemplateGridData: an assigned shift — including a deliberate
     // cross-area cover — stays under its linked template. Fall back to
     // area-aware time matching only for unlinked shifts. A link to an archived
-    // template (not in the list) is skipped, never re-matched by time.
+    // template (not in the list) is treated as off-template, never re-matched
+    // by time.
     const template = shift.shift_template_id
       ? templateById.get(shift.shift_template_id)
       : findTemplateForShift(shift, templates);
-    if (!template) continue;
+    const employeeName = shift.employee?.name || 'Unassigned';
 
-    if (!shiftsByTemplate.has(template.id)) {
-      shiftsByTemplate.set(template.id, new Map());
+    if (template) {
+      const dayMap = shiftsByTemplate.get(template.id) ?? new Map<string, string[]>();
+      shiftsByTemplate.set(template.id, dayMap);
+      pushName(dayMap, dateStr, employeeName);
+    } else {
+      const area = shift.employee?.area || UNASSIGNED;
+      const dayMap = offTemplateByArea.get(area) ?? new Map<string, string[]>();
+      offTemplateByArea.set(area, dayMap);
+      pushName(dayMap, dateStr, employeeName);
     }
-    const dayMap = shiftsByTemplate.get(template.id)!;
-    if (!dayMap.has(dateStr)) {
-      dayMap.set(dateStr, []);
-    }
-    dayMap.get(dateStr)!.push(shift.employee?.name || 'Unassigned');
   }
+
+  const sortNames = (names: string[]) => names.sort((a, b) => a.localeCompare(b)).join('\n');
 
   // Build rows in template order
   const rows: GridRow[] = templates.map((template) => {
@@ -175,11 +188,22 @@ export function buildGridExportData(
       if (!templateAppliesToDay(template, day)) return '\u2014'; // em-dash for inactive
       const names = dayMap?.get(day);
       if (!names || names.length === 0) return '';
-      return names.sort((a, b) => a.localeCompare(b)).join('\n');
+      return sortNames(names);
     });
 
     return { shiftLabel, cells };
   });
+
+  // Append one off-template row per area (sorted by area name for determinism)
+  // so unmatched shifts are preserved in the export instead of being dropped.
+  for (const area of [...offTemplateByArea.keys()].sort((a, b) => a.localeCompare(b))) {
+    const dayMap = offTemplateByArea.get(area)!;
+    const cells = weekDays.map((day) => {
+      const names = dayMap.get(day);
+      return names && names.length > 0 ? sortNames(names) : '';
+    });
+    rows.push({ shiftLabel: `Off-template \u00b7 ${area}`, cells });
+  }
 
   return { dayHeaders, rows };
 }

--- a/src/utils/plannerExport.ts
+++ b/src/utils/plannerExport.ts
@@ -87,7 +87,12 @@ export function formatTemplateTime(time: string): string {
 
 /**
  * Find the first template that matches a shift by comparing local times,
- * position, and the day-of-week.
+ * position, the day-of-week, and area compatibility. A template with an area
+ * only matches an employee from the same area (or with no area); null on
+ * either side is permissive. Mirrors `findMatchingTemplate` in
+ * useShiftPlanner.ts so the exported grid buckets shifts the same way the
+ * on-screen planner does — a cross-area unlinked shift never borrows another
+ * area's row.
  */
 export function findTemplateForShift(
   shift: Shift,
@@ -99,13 +104,15 @@ export function findTemplateForShift(
   const endDate = new Date(shift.end_time);
   const shiftEnd = `${pad(endDate.getHours())}:${pad(endDate.getMinutes())}:${pad(endDate.getSeconds())}`;
   const dayOfWeek = startDate.getDay();
+  const employeeArea = shift.employee?.area ?? null;
 
   return templates.find(
     (t) =>
       t.start_time === shiftStart &&
       t.end_time === shiftEnd &&
       t.position === shift.position &&
-      t.days.includes(dayOfWeek),
+      t.days.includes(dayOfWeek) &&
+      (!t.area || !employeeArea || t.area === employeeArea),
   );
 }
 

--- a/src/utils/plannerExport.ts
+++ b/src/utils/plannerExport.ts
@@ -3,6 +3,7 @@ import autoTable from 'jspdf-autotable';
 
 import { templateAppliesToDay } from '@/hooks/useShiftTemplates';
 import { formatLocalDate } from '@/lib/shiftInterval';
+import { isAreaCompatible, pickAreaPreferredMatch } from '@/lib/templateAreaMatch';
 import { exportToCSV } from '@/utils/csvExport';
 
 import type { Shift, ShiftTemplate } from '@/types/scheduling';
@@ -86,12 +87,13 @@ export function formatTemplateTime(time: string): string {
 }
 
 /**
- * Find the first template that matches a shift by comparing local times,
- * position, the day-of-week, and area compatibility. A template with an area
- * only matches an employee from the same area (or with no area); null on
- * either side is permissive. Mirrors `findMatchingTemplate` in
- * useShiftPlanner.ts so the exported grid buckets shifts the same way the
- * on-screen planner does — a cross-area unlinked shift never borrows another
+ * Find the template that matches a shift by comparing local times, position,
+ * the day-of-week, and area compatibility. A template with an area only matches
+ * an employee from the same area (or with no area); an exact same-area match is
+ * preferred over an area-agnostic (null-area) template. Mirrors
+ * `findMatchingTemplate` in useShiftPlanner.ts (via the shared
+ * `templateAreaMatch` helpers) so the exported grid buckets shifts the same way
+ * the on-screen planner does — a cross-area unlinked shift never borrows another
  * area's row.
  */
 export function findTemplateForShift(
@@ -106,14 +108,15 @@ export function findTemplateForShift(
   const dayOfWeek = startDate.getDay();
   const employeeArea = shift.employee?.area ?? null;
 
-  return templates.find(
+  const candidates = templates.filter(
     (t) =>
       t.start_time === shiftStart &&
       t.end_time === shiftEnd &&
       t.position === shift.position &&
       t.days.includes(dayOfWeek) &&
-      (!t.area || !employeeArea || t.area === employeeArea),
+      isAreaCompatible(t.area, employeeArea),
   );
+  return pickAreaPreferredMatch(candidates, employeeArea);
 }
 
 /**

--- a/tests/unit/plannerExport.test.ts
+++ b/tests/unit/plannerExport.test.ts
@@ -447,6 +447,47 @@ describe('buildGridExportData', () => {
     // Saturday is WEEK_DAYS index 5; the Cold Stone row must stay empty there.
     expect(rows[0].cells[5]).toBe('');
   });
+
+  it('CRITICAL: should keep an explicit cross-area cover under its linked template row', () => {
+    // A Wetzel's employee deliberately assigned (shift_template_id) to the Cold
+    // Stone template is a real cover — the export must place them under that row,
+    // mirroring the on-screen grid, even though the areas differ. The area filter
+    // only governs UNLINKED shifts, never an explicit assignment.
+    const cscPrep = mockTemplate({
+      id: 't-csc', name: 'Prep-weekend', start_time: '10:00:00', end_time: '16:00:00',
+      position: 'Server', days: [0, 5, 6], area: 'Cold Stone',
+    });
+    const shifts = [
+      mockShift({
+        start_time: '2026-03-07T10:00:00', // Sat
+        end_time: '2026-03-07T16:00:00',
+        position: 'Server',
+        shift_template_id: 't-csc',
+        employee: { id: 'e-w', name: 'Josiah', area: "Wetzel's" } as Shift['employee'],
+      }),
+    ];
+
+    const { rows } = buildGridExportData(shifts, [cscPrep], WEEK_DAYS);
+    expect(rows[0].cells[5]).toBe('Josiah');
+  });
+
+  it('should skip a shift whose explicit shift_template_id is archived (not in the list)', () => {
+    // Mirrors the grid's __unmatched__ handling: an explicit link to a template
+    // that is no longer active must NOT fall through to time-based matching.
+    const shifts = [
+      mockShift({
+        start_time: '2026-03-02T09:00:00', // Mon, would match t1 by time
+        end_time: '2026-03-02T17:00:00',
+        position: 'Server',
+        shift_template_id: 'archived-id',
+        employee: { id: 'e1', name: 'Alice' } as Shift['employee'],
+      }),
+    ];
+
+    const { rows } = buildGridExportData(shifts, templates, WEEK_DAYS);
+    // Must NOT appear under t1 via time-based fallback.
+    expect(rows[0].cells[0]).toBe('');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/plannerExport.test.ts
+++ b/tests/unit/plannerExport.test.ts
@@ -413,7 +413,7 @@ describe('buildGridExportData', () => {
     expect(rows[0].cells[0]).toBe('Unassigned');
   });
 
-  it('skips shifts that do not match any template', () => {
+  it('routes a shift that matches no template into an off-template row instead of dropping it', () => {
     const shifts = [
       mockShift({
         start_time: '2026-03-02T06:00:00', // 6AM, no template match
@@ -423,8 +423,12 @@ describe('buildGridExportData', () => {
     ];
 
     const { rows } = buildGridExportData(shifts, templates, WEEK_DAYS);
-    // All cells for the one template should be empty (shift didn't match it)
+    // Not under any template row...
     expect(rows[0].cells[0]).toBe('');
+    // ...but preserved in an off-template row (mockShift's default employee has
+    // no area, so it lands under Unassigned).
+    const offRow = rows.find((r) => r.shiftLabel.includes('Unassigned'));
+    expect(offRow?.cells[0]).toBe('Alice Smith');
   });
 
   it('CRITICAL: should not place a cross-area shift into another area\'s template row', () => {
@@ -471,9 +475,10 @@ describe('buildGridExportData', () => {
     expect(rows[0].cells[5]).toBe('Josiah');
   });
 
-  it('should skip a shift whose explicit shift_template_id is archived (not in the list)', () => {
+  it('should route a shift whose explicit shift_template_id is archived to the off-template section', () => {
     // Mirrors the grid's __unmatched__ handling: an explicit link to a template
-    // that is no longer active must NOT fall through to time-based matching.
+    // that is no longer active must NOT fall through to time-based matching, and
+    // must still be preserved (in the off-template section), not dropped.
     const shifts = [
       mockShift({
         start_time: '2026-03-02T09:00:00', // Mon, would match t1 by time
@@ -485,8 +490,61 @@ describe('buildGridExportData', () => {
     ];
 
     const { rows } = buildGridExportData(shifts, templates, WEEK_DAYS);
-    // Must NOT appear under t1 via time-based fallback.
+    // Must NOT appear under t1 via time-based fallback...
     expect(rows[0].cells[0]).toBe('');
+    // ...but must be preserved in an off-template row (no area → Unassigned).
+    const offRow = rows.find((r) => r.shiftLabel.includes('Unassigned'));
+    expect(offRow?.cells[0]).toBe('Alice');
+  });
+
+  // Off-template section — parity with the on-screen grid's off-template lane.
+  // A shift that doesn't resolve to a template must still appear in the export,
+  // grouped by the employee's home area, not silently omitted.
+  describe('off-template section', () => {
+    const cscPrep = mockTemplate({
+      id: 't-csc', name: 'Prep-weekend', start_time: '10:00:00', end_time: '16:00:00',
+      position: 'Server', days: [0, 5, 6], area: 'Cold Stone',
+    });
+    // Saturday 2026-03-07 (WEEK_DAYS index 5), 10:00-16:00 Server.
+    const sat = (name: string, area?: string) => mockShift({
+      start_time: '2026-03-07T10:00:00', end_time: '2026-03-07T16:00:00', position: 'Server',
+      employee: { id: name, name, area } as Shift['employee'],
+    });
+
+    it('CRITICAL: should place a cross-area unlinked shift in an off-template row for its home area', () => {
+      const { rows } = buildGridExportData([sat('Josiah', "Wetzel's")], [cscPrep], WEEK_DAYS);
+      const offRow = rows.find((r) => r.shiftLabel.includes("Wetzel's"));
+      expect(offRow).toBeDefined();
+      expect(offRow!.cells[5]).toBe('Josiah');
+      // and NOT under the Cold Stone template row
+      const cscRow = rows.find((r) => r.shiftLabel.startsWith('Prep-weekend'));
+      expect(cscRow!.cells[5]).toBe('');
+    });
+
+    it('should label the off-template row Unassigned when the employee has no area', () => {
+      // A no-area employee is area-compatible with any template, so to land
+      // off-template the shift must fail to match for a non-area reason — here a
+      // position no template covers.
+      const noMatch = mockShift({
+        start_time: '2026-03-07T10:00:00', end_time: '2026-03-07T16:00:00', position: 'Dishwasher',
+        employee: { id: 'e0', name: 'Sam' } as Shift['employee'],
+      });
+      const { rows } = buildGridExportData([noMatch], [cscPrep], WEEK_DAYS);
+      const offRow = rows.find((r) => r.shiftLabel.includes('Unassigned'));
+      expect(offRow?.cells[5]).toBe('Sam');
+    });
+
+    it('should not add any off-template rows when every shift matches a template', () => {
+      const { rows } = buildGridExportData([sat('Cory', 'Cold Stone')], [cscPrep], WEEK_DAYS);
+      expect(rows).toHaveLength(1); // only the template row
+      expect(rows[0].cells[5]).toBe('Cory');
+    });
+
+    it('should group multiple off-template employees by area and sort names within a cell', () => {
+      const { rows } = buildGridExportData([sat('Zed', "Wetzel's"), sat('Amy', "Wetzel's")], [cscPrep], WEEK_DAYS);
+      const offRow = rows.find((r) => r.shiftLabel.includes("Wetzel's"));
+      expect(offRow?.cells[5]).toBe('Amy\nZed');
+    });
   });
 });
 

--- a/tests/unit/plannerExport.test.ts
+++ b/tests/unit/plannerExport.test.ts
@@ -237,6 +237,47 @@ describe('findTemplateForShift', () => {
     });
     expect(findTemplateForShift(shift, templates)).toBeUndefined();
   });
+
+  // Area-aware matching — mirrors the on-screen planner grid
+  // (buildTemplateGridData). A cross-area unlinked shift must NOT borrow
+  // another area's template row in the exported file.
+  describe('area compatibility', () => {
+    // Josiah repro: Cold Stone is the only exact time/position match, but the
+    // shift belongs to a Wetzel's employee.
+    const cscPrep = mockTemplate({
+      id: 't-csc', name: 'Prep-weekend', start_time: '10:00:00', end_time: '16:00:00',
+      position: 'Server', days: [0, 5, 6], area: 'Cold Stone',
+    });
+    const wtzOpen = mockTemplate({
+      id: 't-wtz', name: 'Open-weekend-wtz', start_time: '10:00:00', end_time: '16:00:00',
+      position: 'Server', days: [0, 5, 6], area: "Wetzel's",
+    });
+    // Saturday 2026-03-07, 10:00-16:00, Server
+    const wtzShift = (overrides: Partial<Shift> = {}) => mockShift({
+      start_time: '2026-03-07T10:00:00', end_time: '2026-03-07T16:00:00', position: 'Server',
+      employee: { id: 'e-w', name: 'Josiah', area: "Wetzel's" } as Shift['employee'],
+      ...overrides,
+    });
+
+    it('does not match a cross-area template', () => {
+      expect(findTemplateForShift(wtzShift(), [cscPrep])).toBeUndefined();
+    });
+
+    it('prefers the same-area template over a cross-area one listed first', () => {
+      const result = findTemplateForShift(wtzShift(), [cscPrep, wtzOpen]);
+      expect(result?.id).toBe('t-wtz');
+    });
+
+    it('matches permissively when the employee has no area', () => {
+      const shift = wtzShift({ employee: { id: 'e-n', name: 'NoArea' } as Shift['employee'] });
+      expect(findTemplateForShift(shift, [cscPrep])?.id).toBe('t-csc');
+    });
+
+    it('matches permissively when the template has no area', () => {
+      const noArea = mockTemplate({ ...cscPrep, id: 't-none', area: null });
+      expect(findTemplateForShift(wtzShift(), [noArea])?.id).toBe('t-none');
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -378,6 +419,27 @@ describe('buildGridExportData', () => {
     const { rows } = buildGridExportData(shifts, templates, WEEK_DAYS);
     // All cells for the one template should be empty (shift didn't match it)
     expect(rows[0].cells[0]).toBe('');
+  });
+
+  it('does not place a cross-area shift into another area\'s template row', () => {
+    // Josiah repro: a Wetzel's employee's unlinked Sat 10-16 Server shift must
+    // not appear in the Cold Stone "Prep-weekend" row of the exported grid.
+    const cscPrep = mockTemplate({
+      id: 't-csc', name: 'Prep-weekend', start_time: '10:00:00', end_time: '16:00:00',
+      position: 'Server', days: [0, 5, 6], area: 'Cold Stone',
+    });
+    const shifts = [
+      mockShift({
+        start_time: '2026-03-07T10:00:00', // Sat
+        end_time: '2026-03-07T16:00:00',
+        position: 'Server',
+        employee: { id: 'e-w', name: 'Josiah', area: "Wetzel's" } as Shift['employee'],
+      }),
+    ];
+
+    const { rows } = buildGridExportData(shifts, [cscPrep], WEEK_DAYS);
+    // Saturday is WEEK_DAYS index 5; the Cold Stone row must stay empty there.
+    expect(rows[0].cells[5]).toBe('');
   });
 });
 

--- a/tests/unit/plannerExport.test.ts
+++ b/tests/unit/plannerExport.test.ts
@@ -259,21 +259,27 @@ describe('findTemplateForShift', () => {
       ...overrides,
     });
 
-    it('does not match a cross-area template', () => {
+    it('CRITICAL: should not match a cross-area template', () => {
       expect(findTemplateForShift(wtzShift(), [cscPrep])).toBeUndefined();
     });
 
-    it('prefers the same-area template over a cross-area one listed first', () => {
+    it('CRITICAL: should prefer the same-area template over a cross-area one listed first', () => {
       const result = findTemplateForShift(wtzShift(), [cscPrep, wtzOpen]);
       expect(result?.id).toBe('t-wtz');
     });
 
-    it('matches permissively when the employee has no area', () => {
+    it('CRITICAL: should prefer the same-area template over an area-agnostic one listed first', () => {
+      const generic = mockTemplate({ ...cscPrep, id: 't-generic', area: null });
+      const result = findTemplateForShift(wtzShift(), [generic, wtzOpen]);
+      expect(result?.id).toBe('t-wtz');
+    });
+
+    it('should match permissively when the employee has no area', () => {
       const shift = wtzShift({ employee: { id: 'e-n', name: 'NoArea' } as Shift['employee'] });
       expect(findTemplateForShift(shift, [cscPrep])?.id).toBe('t-csc');
     });
 
-    it('matches permissively when the template has no area', () => {
+    it('should match permissively when the template has no area', () => {
       const noArea = mockTemplate({ ...cscPrep, id: 't-none', area: null });
       expect(findTemplateForShift(wtzShift(), [noArea])?.id).toBe('t-none');
     });
@@ -421,7 +427,7 @@ describe('buildGridExportData', () => {
     expect(rows[0].cells[0]).toBe('');
   });
 
-  it('does not place a cross-area shift into another area\'s template row', () => {
+  it('CRITICAL: should not place a cross-area shift into another area\'s template row', () => {
     // Josiah repro: a Wetzel's employee's unlinked Sat 10-16 Server shift must
     // not appear in the Cold Stone "Prep-weekend" row of the exported grid.
     const cscPrep = mockTemplate({

--- a/tests/unit/templateAreaMatch.test.ts
+++ b/tests/unit/templateAreaMatch.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { isAreaCompatible, pickAreaPreferredMatch } from '@/lib/templateAreaMatch';
+import { isAreaCompatible, pickAreaPreferredMatch, findAreaAwareTemplate } from '@/lib/templateAreaMatch';
+import type { ShiftMatchKey } from '@/lib/templateAreaMatch';
 
 describe('isAreaCompatible', () => {
   it('should match when template and employee share the same area', () => {
@@ -42,5 +43,38 @@ describe('pickAreaPreferredMatch', () => {
 
   it('should return undefined when there are no candidates', () => {
     expect(pickAreaPreferredMatch([], "Wetzel's")).toBeUndefined();
+  });
+});
+
+describe('findAreaAwareTemplate', () => {
+  const cscPrep = { id: 't-csc', start_time: '10:00:00', end_time: '16:00:00', position: 'Server', days: [0, 5, 6], area: 'Cold Stone' };
+  const wtzOpen = { id: 't-wtz', start_time: '10:00:00', end_time: '16:00:00', position: 'Server', days: [0, 5, 6], area: "Wetzel's" };
+  const generic = { id: 't-gen', start_time: '10:00:00', end_time: '16:00:00', position: 'Server', days: [0, 5, 6], area: null };
+  // Saturday is day 6.
+  const key = (employeeArea: string | null): ShiftMatchKey => ({
+    shiftStart: '10:00:00', shiftEnd: '16:00:00', position: 'Server', dayOfWeek: 6, employeeArea,
+  });
+
+  it('CRITICAL: should not match a cross-area template', () => {
+    expect(findAreaAwareTemplate([cscPrep], key("Wetzel's"))).toBeUndefined();
+  });
+
+  it('CRITICAL: should prefer the same-area template over a cross-area and an area-agnostic one', () => {
+    expect(findAreaAwareTemplate([generic, cscPrep, wtzOpen], key("Wetzel's"))?.id).toBe('t-wtz');
+  });
+
+  it('should not match when the day is not in template.days', () => {
+    // Monday (day 1) is not in [0,5,6].
+    expect(findAreaAwareTemplate([wtzOpen], { ...key("Wetzel's"), dayOfWeek: 1 })).toBeUndefined();
+  });
+
+  it('should not match when start/end/position differ', () => {
+    expect(findAreaAwareTemplate([wtzOpen], { ...key("Wetzel's"), shiftEnd: '17:00:00' })).toBeUndefined();
+    expect(findAreaAwareTemplate([wtzOpen], { ...key("Wetzel's"), position: 'Cook' })).toBeUndefined();
+  });
+
+  it('should match permissively when employee or template area is null', () => {
+    expect(findAreaAwareTemplate([cscPrep], key(null))?.id).toBe('t-csc');
+    expect(findAreaAwareTemplate([generic], key("Wetzel's"))?.id).toBe('t-gen');
   });
 });

--- a/tests/unit/templateAreaMatch.test.ts
+++ b/tests/unit/templateAreaMatch.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { isAreaCompatible, pickAreaPreferredMatch } from '@/lib/templateAreaMatch';
+
+describe('isAreaCompatible', () => {
+  it('should match when template and employee share the same area', () => {
+    expect(isAreaCompatible('Cold Stone', 'Cold Stone')).toBe(true);
+  });
+
+  it('should not match when both areas are set but differ', () => {
+    expect(isAreaCompatible('Cold Stone', "Wetzel's")).toBe(false);
+  });
+
+  it('should match permissively when the template has no area', () => {
+    expect(isAreaCompatible(null, "Wetzel's")).toBe(true);
+    expect(isAreaCompatible(undefined, "Wetzel's")).toBe(true);
+  });
+
+  it('should match permissively when the employee has no area', () => {
+    expect(isAreaCompatible('Cold Stone', null)).toBe(true);
+    expect(isAreaCompatible('Cold Stone', undefined)).toBe(true);
+  });
+});
+
+describe('pickAreaPreferredMatch', () => {
+  // Callers pass candidates already filtered to area-compatible templates.
+  const wtz = { id: 'wtz', area: "Wetzel's" };
+  const generic = { id: 'generic', area: null };
+
+  it('CRITICAL: should prefer an exact same-area match over an area-agnostic one listed first', () => {
+    // generic (null-area) comes first but the employee-area match must win.
+    expect(pickAreaPreferredMatch([generic, wtz], "Wetzel's")?.id).toBe('wtz');
+  });
+
+  it('should fall back to the first candidate when no exact same-area match exists', () => {
+    expect(pickAreaPreferredMatch([generic], "Wetzel's")?.id).toBe('generic');
+  });
+
+  it('should return the first candidate when the employee has no area', () => {
+    // Nothing to prefer — preserve input order.
+    expect(pickAreaPreferredMatch([generic, wtz], null)?.id).toBe('generic');
+  });
+
+  it('should return undefined when there are no candidates', () => {
+    expect(pickAreaPreferredMatch([], "Wetzel's")).toBeUndefined();
+  });
+});

--- a/tests/unit/useShiftPlanner.test.ts
+++ b/tests/unit/useShiftPlanner.test.ts
@@ -335,35 +335,54 @@ describe('useShiftPlanner utilities', () => {
         ...overrides,
       });
 
-      it('does not bucket a cross-area unlinked shift into another area\'s template row', () => {
+      it('CRITICAL: should not bucket a cross-area unlinked shift into another area\'s template row', () => {
         const grid = buildTemplateGridData([unlinkedWtzShift()], [cscPrepWeekend], weekDays);
         expect(grid.get('t-csc-prep')?.get('2026-03-07') ?? []).toHaveLength(0);
         expect(grid.get('__unmatched__')?.get('2026-03-07')).toHaveLength(1);
       });
 
-      it('lanes the rejected cross-area shift under the employee home area via groupUnmatchedByArea', () => {
+      it('CRITICAL: should lane the rejected cross-area shift under the employee home area', () => {
         const grid = buildTemplateGridData([unlinkedWtzShift()], [cscPrepWeekend], weekDays);
         const lanes = groupUnmatchedByArea(grid.get('__unmatched__')!);
         expect(lanes.get("Wetzel's")?.get('2026-03-07')).toHaveLength(1);
       });
 
-      it('matches the same-area template even when a cross-area template with identical times comes first', () => {
+      it('CRITICAL: should match the same-area template when a cross-area template with identical times comes first', () => {
         const grid = buildTemplateGridData([unlinkedWtzShift()], [cscPrepWeekend, wtzOpenWeekend], weekDays);
         expect(grid.get('t-wtz-open')?.get('2026-03-07')).toHaveLength(1);
         expect(grid.get('t-csc-prep')?.get('2026-03-07') ?? []).toHaveLength(0);
       });
 
-      it('matches permissively when the employee has no area', () => {
+      it('CRITICAL: should prefer the same-area template over an area-agnostic one when both match', () => {
+        // A null-area (generic) template listed first must not win over the
+        // employee's exact-area template.
+        const genericTemplate: ShiftTemplate = { ...cscPrepWeekend, id: 't-generic', area: null };
+        const grid = buildTemplateGridData([unlinkedWtzShift()], [genericTemplate, wtzOpenWeekend], weekDays);
+        expect(grid.get('t-wtz-open')?.get('2026-03-07')).toHaveLength(1);
+        expect(grid.get('t-generic')?.get('2026-03-07') ?? []).toHaveLength(0);
+      });
+
+      it('should match permissively when the employee has no area', () => {
         const noAreaEmployee = { id: 'e-n', name: 'NoArea' } as Shift['employee'];
         const shift = unlinkedWtzShift({ employee_id: 'e-n', employee: noAreaEmployee });
         const grid = buildTemplateGridData([shift], [cscPrepWeekend], weekDays);
         expect(grid.get('t-csc-prep')?.get('2026-03-07')).toHaveLength(1);
       });
 
-      it('matches permissively when the template has no area', () => {
+      it('should match permissively when the template has no area', () => {
         const noAreaTemplate: ShiftTemplate = { ...cscPrepWeekend, id: 't-no-area', area: null };
         const grid = buildTemplateGridData([unlinkedWtzShift()], [noAreaTemplate], weekDays);
         expect(grid.get('t-no-area')?.get('2026-03-07')).toHaveLength(1);
+      });
+
+      it('CRITICAL: should still bucket a cross-area shift under its explicit shift_template_id (covering flow)', () => {
+        // A Wetzel's employee deliberately assigned to the Cold Stone template
+        // (explicit link) must stay in that row — area mismatch only affects the
+        // unlinked fallback, never an explicit assignment.
+        const covering = unlinkedWtzShift({ shift_template_id: 't-csc-prep' });
+        const grid = buildTemplateGridData([covering], [cscPrepWeekend, wtzOpenWeekend], weekDays);
+        expect(grid.get('t-csc-prep')?.get('2026-03-07')).toHaveLength(1);
+        expect(grid.get('t-wtz-open')?.get('2026-03-07') ?? []).toHaveLength(0);
       });
     });
   });

--- a/tests/unit/useShiftPlanner.test.ts
+++ b/tests/unit/useShiftPlanner.test.ts
@@ -311,6 +311,61 @@ describe('useShiftPlanner utilities', () => {
       const t1Days = grid.get('t1');
       expect(t1Days?.get('2026-03-02')).toHaveLength(1);
     });
+
+    describe('area-aware fallback matching', () => {
+      // Josiah repro: Cold Stone template is the only exact time/position match,
+      // but the shift belongs to a Wetzel's employee.
+      const cscPrepWeekend: ShiftTemplate = {
+        id: 't-csc-prep', start_time: '10:00:00', end_time: '16:00:00', position: 'Server',
+        days: [5, 6, 0], name: 'Prep-weekend', area: 'Cold Stone',
+        restaurant_id: 'r1', break_duration: 0, capacity: 1, is_active: true, created_at: '', updated_at: '',
+      };
+      const wtzOpenWeekend: ShiftTemplate = {
+        id: 't-wtz-open', start_time: '10:00:00', end_time: '16:00:00', position: 'Server',
+        days: [5, 6, 0], name: 'Open-weekend-wtz', area: "Wetzel's",
+        restaurant_id: 'r1', break_duration: 0, capacity: 1, is_active: true, created_at: '', updated_at: '',
+      };
+
+      const wtzEmployee = { id: 'e-w', name: 'Josiah', area: "Wetzel's" } as Shift['employee'];
+      // Saturday 2026-03-07, 10:00-16:00, Server, no shift_template_id
+      const unlinkedWtzShift = (overrides: Partial<Shift> = {}) => mockShift({
+        id: 's-w', employee_id: 'e-w', employee: wtzEmployee,
+        start_time: '2026-03-07T10:00:00', end_time: '2026-03-07T16:00:00',
+        position: 'Server', status: 'scheduled',
+        ...overrides,
+      });
+
+      it('does not bucket a cross-area unlinked shift into another area\'s template row', () => {
+        const grid = buildTemplateGridData([unlinkedWtzShift()], [cscPrepWeekend], weekDays);
+        expect(grid.get('t-csc-prep')?.get('2026-03-07') ?? []).toHaveLength(0);
+        expect(grid.get('__unmatched__')?.get('2026-03-07')).toHaveLength(1);
+      });
+
+      it('lanes the rejected cross-area shift under the employee home area via groupUnmatchedByArea', () => {
+        const grid = buildTemplateGridData([unlinkedWtzShift()], [cscPrepWeekend], weekDays);
+        const lanes = groupUnmatchedByArea(grid.get('__unmatched__')!);
+        expect(lanes.get("Wetzel's")?.get('2026-03-07')).toHaveLength(1);
+      });
+
+      it('matches the same-area template even when a cross-area template with identical times comes first', () => {
+        const grid = buildTemplateGridData([unlinkedWtzShift()], [cscPrepWeekend, wtzOpenWeekend], weekDays);
+        expect(grid.get('t-wtz-open')?.get('2026-03-07')).toHaveLength(1);
+        expect(grid.get('t-csc-prep')?.get('2026-03-07') ?? []).toHaveLength(0);
+      });
+
+      it('matches permissively when the employee has no area', () => {
+        const noAreaEmployee = { id: 'e-n', name: 'NoArea' } as Shift['employee'];
+        const shift = unlinkedWtzShift({ employee_id: 'e-n', employee: noAreaEmployee });
+        const grid = buildTemplateGridData([shift], [cscPrepWeekend], weekDays);
+        expect(grid.get('t-csc-prep')?.get('2026-03-07')).toHaveLength(1);
+      });
+
+      it('matches permissively when the template has no area', () => {
+        const noAreaTemplate: ShiftTemplate = { ...cscPrepWeekend, id: 't-no-area', area: null };
+        const grid = buildTemplateGridData([unlinkedWtzShift()], [noAreaTemplate], weekDays);
+        expect(grid.get('t-no-area')?.get('2026-03-07')).toHaveLength(1);
+      });
+    });
   });
 
   describe('formatLocalTime', () => {


### PR DESCRIPTION
## Summary
- Fix the shift planner grid bucketing an employee's **unlinked** shift (no `shift_template_id`) into another area's template row. Confirmed in prod for the week of 2026-07-06: Josiah Gonzalez and Justin Seals (both home area **Wetzel's**) had manual 10:00–16:00 Server shifts that rendered under the **Cold Stone** "Prep-weekend" row (the only exact time/position match), showing a spurious "Wetzel's" covering badge and inflating Cold Stone's coverage counts.
- The fallback matcher is now **area-aware**: a template with an area only matches an employee from the same area (nulls stay permissive), and an exact same-area match is preferred over a generic (null-area) one. Unmatched cross-area shifts fall to the employee's own off-template lane. Explicit `shift_template_id` assignments are untouched (covering flow preserved).
- Applied the same fix to the **PDF/CSV export path** (`plannerExport.ts`), which had an independent copy of the area-blind matcher — so exports match the on-screen grid. Shared `src/lib/templateAreaMatch.ts` keeps the two from drifting.

## Changes
- `src/lib/templateAreaMatch.ts` (new): `isAreaCompatible` + `pickAreaPreferredMatch`.
- `src/hooks/useShiftPlanner.ts`: `findMatchingTemplate` uses the shared helpers.
- `src/utils/plannerExport.ts`: `findTemplateForShift` uses the shared helpers.

## Test plan
- `tests/unit/templateAreaMatch.test.ts` (new, 8 tests): compatibility + priority + null-permissive + empty-candidates.
- `tests/unit/useShiftPlanner.test.ts`: cross-area rejection, home-area lane, same-area-over-first-listed, same-area-over-generic, permissive nulls, explicit-`shift_template_id` covering regression.
- `tests/unit/plannerExport.test.ts`: mirror coverage + a `buildGridExportData` integration test (the Josiah repro).
- Full local suite: `npm run test` 5708 passed, `npm run typecheck` clean, `npm run build` succeeds, scoped `eslint` clean.

## Design doc
`docs/superpowers/specs/2026-07-05-area-aware-template-matching-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback matching for unlinked shifts to respect employee area compatibility, preventing cross-area placement in the planner and exports.
  * When multiple templates match, same-area templates are preferred over area-agnostic options.
  * Explicitly linked shifts still go to their assigned template even if areas differ.
  * Missing area data continues to match permissively.
* **Documentation**
  * Added design and planning docs covering the area-aware matching rules and regression test scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->