### PR TITLE
feat(scheduling): make the Timeline view an editing canvas (add/edit/delete + drag/resize)

### DIFF
--- a/docs/superpowers/plans/2026-07-05-timeline-edit-create-plan.md
+++ b/docs/superpowers/plans/2026-07-05-timeline-edit-create-plan.md
@@ -88,10 +88,24 @@
 - Visually-hidden per-lane "Add shift to <lane>" button as keyboard entry (opens quick-add
   with lane defaults).
 
+### C3a. Add TZ-safe create path to the pipeline (design C3-halt resolution)
+- New `validateAndCreateAtTime` / `forceCreateAtTime` in `useValidatedShiftMutations.ts`:
+  accept `{ employeeId, restaurantId, startIso, endIso, businessDate, position,
+  breakDuration?, notes?, shiftTemplateId? }`, build the interval via
+  `ShiftInterval.fromTimestamps` (never host-local `.create`), run all three validation
+  layers via `collectShiftIssues`, return the same pending-confirmation shape as
+  `validateAndCreate`. Additive only — `validateAndCreate`/`forceCreate` untouched, so A3/A4
+  stay green.
+- Tests (append to `tests/unit/useValidatedShiftMutations.test.tsx`): pending-confirmation
+  contract + immediate-create-when-clean + a TZ regression pinning restaurant-local
+  wall-clock when host TZ ≠ restaurant TZ (parity with the update-path regression test).
+
 ### C3. Quick-add popover (create variant)
 - Reuse `TimelineShiftEditor` in create mode anchored to the ghost; "On shift" badge from
-  local day shifts; commit via `validateAndCreate` (input built with `minutesToIso`) →
-  conflict dialog → `forceCreate`.
+  local day shifts; commit via `validateAndCreateAtTime` (ISO instants from `minutesToIso`) →
+  conflict dialog → `forceCreateAtTime`. Never the host-local `validateAndCreate`.
+- Renders the create-variant `TimelineShiftPopover` from `ShiftTimelineTab`'s `activeOverlay`
+  `{mode:'create', draft, laneContext, anchorRect}` (already staged by C2's `handlePaintCommit`).
 
 ## Stage D — Drag-move / edge-resize with live coverage
 

--- a/docs/superpowers/plans/2026-07-05-timeline-edit-create-plan.md
+++ b/docs/superpowers/plans/2026-07-05-timeline-edit-create-plan.md
@@ -1,0 +1,138 @@
+# Timeline Edit/Create — Implementation Plan
+
+**Design:** docs/superpowers/specs/2026-07-05-timeline-edit-create-design.md
+**Branch:** feature/timeline-edit-create
+**Approach:** TDD per task; each task is one RED→GREEN→REFACTOR→COMMIT cycle.
+
+## Stage A — Shared validation pipeline (no behavior change for planner)
+
+### A1. `src/lib/shiftTimeMath.ts` — TZ + snap helpers
+- `minutesToIso(dateStr, minutes, tz): string` — restaurant-local minutes (may exceed 1440
+  for overnight) → UTC ISO via `fromZonedTime`. Handles day rollover.
+- `snapToStep(min, step = STEP_MIN): number`.
+- Tests: `tests/unit/shiftTimeMath.test.ts` — DST spring-forward/fall-back in
+  America/Chicago (Mar 8 / Nov 1 style anchors, TZ-portable fixtures), overnight > 1440,
+  COMBINED overnight+fall-back case (23:00 start the night before the transition),
+  snap edges (negative offsets, exact boundaries).
+
+### A2. `src/lib/shiftMutationPipeline.ts` — pure issue collector
+- `collectShiftIssues({ employeeId, restaurantId, interval, shifts, excludeShiftId, checkConflicts })`
+  → `{ warnings, conflicts }`. Composes `validateShift` + injected RPC checker
+  (defaults to `checkConflictsImperative`).
+- `assertNotLockedClient(shift)` → throws typed error for locked shifts.
+- Tests: `tests/unit/shiftMutationPipeline.test.ts` — warning aggregation, excludeShiftId
+  pass-through, RPC merge, checker rejection handling (RPC failure → surfaced, not swallowed),
+  locked rejection.
+
+### A3. `src/hooks/useValidatedShiftMutations.ts` — the pipeline hook
+- Exposes `validateAndCreate` / `forceCreate` (existing shapes), new
+  `validateAndUpdateTime` / `forceUpdateTime` / `validateAndReassign` / `forceReassign`
+  ({ updated|reassigned, pendingConflicts?, pendingWarnings? }), `deleteShift`,
+  `validationResult`, `clearValidation`.
+- `validateAndUpdateTime` builds intervals via `ShiftInterval.fromTimestamps` — NEVER the
+  host-TZ `split('T')` + `.create()` reconstruction (Supabase review major #2).
+- Update/reassign/delete run the lock guard; update/reassign run all three validation layers.
+- Tests: `tests/unit/useValidatedShiftMutations.test.tsx` — renderHook with mocked
+  `useShifts` mutations + DI'd checker; pin pending-confirmation contract per mutation;
+  pin that create-with-no-issues mutates immediately; TZ regression pinning restaurant-local
+  wall-clock preservation when host TZ ≠ restaurant TZ.
+
+### A3b. Explicit `restaurant_id` on single-shift mutations
+- Extend `useUpdateShift` / `useDeleteShift` (`src/hooks/useShifts.tsx`) to accept and apply
+  `.eq('restaurant_id', restaurantId)` (defense-in-depth per lesson 2026-07-02, matching the
+  series-mutation pattern). Update ALL existing call sites. Tests pin the filter is applied.
+
+### A4. Refactor `useShiftPlanner` to delegate
+- Replace its inline validateAndCreate/forceCreate/validateAndUpdateTime/validateAndReassign/
+  deleteShift with delegation to `useValidatedShiftMutations`; public API unchanged.
+- Existing `tests/unit/useShiftPlanner*.test*` must pass unmodified (byte-compatible API).
+
+## Stage B — Editable popover (full CRUD, zero new canvas gestures)
+
+### B1. `TimelineShiftEditor` form component
+- `src/components/scheduling/ShiftTimeline/TimelineShiftEditor.tsx`: start/end `TimeInput`s,
+  employee `Select` (active employees, position-match sorted via pure helper), break, notes.
+- Pure sort helper `rankEmployeesForShift(employees, { position, area })` in
+  `src/lib/employeeRanking.ts` + tests.
+- Live advisory: `useCheckConflicts` (reactive) for the selected employee + local
+  `validateShift` warnings → amber chips; `aria-live="polite"` region.
+
+### B2. Popover edit mode + actions
+- `TimelineShiftPopover`: view mode gains footer (Edit / Delete); edit mode renders
+  `TimelineShiftEditor`. Locked → lock icon, actions disabled. Recurring → "this shift only"
+  hint. Published delete → AlertDialog confirm with `event.preventDefault()` before async.
+- Anchor via Radix `PopoverAnchor` bound to the interacted element's rect stored in the
+  overlay state; `modal={false}`; scrollable plot container as `collisionBoundary`.
+- Single union overlay state in `ShiftTimelineTab`:
+  `activeOverlay: { mode:'edit', shift, anchorRect } | { mode:'create', draft, anchorRect } | null`
+  — edit, quick-add, and gap entry points are mutually exclusive by construction.
+- Conflict-dialog stacking: popover stays open behind `AvailabilityConflictDialog`;
+  outside-click dismiss suppressed while dialog open; Escape closes topmost only.
+
+### B3. Wire `ShiftTimelineTab`
+- Mount `useValidatedShiftMutations(restaurantId, shifts)`; single
+  `AvailabilityConflictDialog` instance; save/delete flows; toasts come from mutation hooks.
+- Three-state rendering preserved; no new fetches.
+
+## Stage C — Paint-to-create + quick-add
+
+### C1. `src/lib/timelineDraft.ts` — pure paint/drag math
+- `pointerToMinutes(clientX, plotRect, window)`, paint-range reducer
+  (`beginPaint/updatePaint/endPaint` with snap + min duration 15 min, click → default 120 min
+  clamped to window), draft-shift builder (lane context → position/area prefill).
+- Tests: `tests/unit/timelineDraft.test.ts`.
+
+### C2. Lane paint layer + ghost bar
+- Pointer handlers on lane plot region (mouse: drag; touch: long-press 500 ms then drag);
+  dashed ghost bar rendered from draft state; Escape cancels.
+- Visually-hidden per-lane "Add shift to <lane>" button as keyboard entry (opens quick-add
+  with lane defaults).
+
+### C3. Quick-add popover (create variant)
+- Reuse `TimelineShiftEditor` in create mode anchored to the ghost; "On shift" badge from
+  local day shifts; commit via `validateAndCreate` (input built with `minutesToIso`) →
+  conflict dialog → `forceCreate`.
+
+## Stage D — Drag-move / edge-resize with live coverage
+
+### D1. `useTimelineBarDrag` pointer hook
+- `setPointerCapture`; body drag = move (preserve duration), edge handles = resize;
+  15-min snap; floating time readout; locked bars inert; touch uses popover instead
+  (no drag on `pointerType === 'touch'`).
+- Draft commits throttled to one per `requestAnimationFrame`; handlers read current values
+  via render-synced refs (never pointerdown-time closures).
+- `touch-action: none` scoped to bar bodies + edge handles only; lane background/plot keep
+  pan behavior. Keyboard activation (Enter/Space → popover) must remain intact.
+
+### D1b. Memoize `TimelineBar` + `TimelineLane`
+- `React.memo` with comparators keyed on shift id + geometry (leftMin/endMin/row/label) so a
+  drag frame re-renders only the affected row. Stable callbacks via `useCallback`.
+
+### D2. Draft merge into the model
+- `ShiftTimelineTab` holds `draftShift`; model input = day shifts with dragged original
+  replaced by draft (pure merge helper + test). Coverage chart/verdict/status strip update
+  live via existing memo chain at rAF cadence.
+- Commit uses `useUpdateShift`'s existing optimistic `setQueriesData` path; draft cleared on
+  mutation settle so the bar never jumps awaiting refetch.
+
+### D3. Commit on release
+- Release → `validateAndUpdateTime` (ISO from `minutesToIso`); pending → conflict dialog
+  (cancel = snap back, confirm = `forceUpdateTime`); draft cleared on settle.
+
+## Stage E — Clickable coverage gaps
+
+### E1. `mergeUnderStaffedRange(hours, clickedMin)` in `src/lib/coverageSummary.ts` (or
+  sibling) + tests — merge contiguous `under` hours around the clicked one.
+
+### E2. `CoverageStatusStrip` under-segments become buttons → open quick-add prefilled with
+  the merged range (no lane context). aria-labels per segment.
+
+## Stage F — E2E + polish
+
+### F1. Playwright smoke: timeline → click bar → edit time via popover → save; paint path
+  covered indirectly via quick-add popover create (open via keyboard "Add shift" button to
+  avoid drag flake). `tests/e2e/` with helpers from `../helpers/e2e-supabase`.
+
+## Task dependencies
+A1→A2→A3→A4; B1→B2→B3 (needs A3); C1→C2→C3 (needs A3, B1); D1→D2→D3 (needs A3);
+E1→E2 (needs C3); F1 last. Stages B/C/D/E are sequential in this plan to keep diffs reviewable.

--- a/docs/superpowers/specs/2026-07-05-timeline-edit-create-design.md
+++ b/docs/superpowers/specs/2026-07-05-timeline-edit-create-design.md
@@ -80,7 +80,20 @@ validationResult / clearValidation                  // unchanged
 All update/reassign paths now run **all three layers** (interval rules + validateShift with
 `excludeShiftId` + RPC conflicts) and return pending issues for the
 `AvailabilityConflictDialog` instead of silently proceeding. Locked shifts short-circuit with
-an error result.
+an error result — including the **delete** path (client-side lock guard for parity with
+update; `useDeleteShift` has no server-side `assertShiftNotLocked` today).
+
+**Design-review fold-ins (Supabase):**
+
+- The pipeline's `validateAndUpdateTime` builds its interval via
+  `ShiftInterval.fromTimestamps(startIso, endIso, businessDate)` — it must NOT inherit the
+  current `useShiftPlanner` implementation's `split('T')` + `ShiftInterval.create()`
+  reconstruction, which re-anchors in host TZ. A regression test pins that a
+  host-TZ ≠ restaurant-TZ round trip preserves the restaurant-local wall-clock time.
+- `useUpdateShift` and `useDeleteShift` gain an explicit `restaurant_id` filter
+  (`.eq('restaurant_id', restaurantId)`) matching the `useDeleteShiftSeries` /
+  `useUpdateShiftSeries` pattern and lesson 2026-07-02 — RLS remains the security boundary;
+  the explicit filter is defense-in-depth. The pipeline threads `restaurantId` to both.
 
 New TZ helper in `src/lib/shiftTimeMath.ts` (pure, tested):
 
@@ -95,13 +108,33 @@ snapToStep(min: number, step = STEP_MIN): number
 `TimelineShiftPopover` gains an edit mode and actions while staying the single instance owned
 by `ShiftTimelineTab` (single-dialog pattern):
 
+**Overlay state machine (design-review fold-in):** one union state drives the single popover
+instance across all entry points:
+`activeOverlay: { mode: 'edit'; shift; anchorRect } | { mode: 'create'; draft; anchorRect } | null`.
+Edit (bar click), quick-add (paint/click), and gap-click all set this state — they are
+mutually exclusive by construction; never two popovers mounted.
+
+**Anchoring:** the current zero-size `sr-only` trigger cannot anchor edit/create popovers.
+Use Radix `PopoverAnchor` bound to the interacted element (bar / ghost / gap segment) via a
+virtual anchor rect stored in `activeOverlay`, with `modal={false}` and the scrollable plot
+container as `collisionBoundary` so positioning works inside `overflow-x-auto`.
+
+**Conflict dialog stacking:** when Save surfaces pending issues, the popover **stays mounted
+and open** behind `AvailabilityConflictDialog`; outside-click dismissal of the popover is
+suppressed while the dialog is open; Escape closes only the topmost overlay (the dialog).
+The popover closes only after the dialog resolves (confirm → force mutation → close;
+cancel → back to editing).
+
 - **View mode** (existing) + footer actions: Edit, Delete. Lock icon + disabled actions when
   `shift.locked`. Recurring shifts show "Changes apply to this shift only" hint
   (series editing stays in the Scheduler's ShiftDialog; out of scope here).
 - **Edit mode:** start/end time fields (reuse `TimeInput`), employee select (active employees,
   sorted: position match first), break, notes. Live advisory conflicts via reactive
   `useCheckConflicts` for the currently selected employee (same pattern as `ShiftDialog`) +
-  local `validateShift` warnings — rendered as amber chips (CLAUDE.md amber pattern).
+  local `validateShift` warnings — rendered as amber chips using the exact
+  `AvailabilityConflictDialog` classes (`bg-amber-500/10 border border-amber-500/20`), no new
+  amber shade. New popover/quick-add markup follows the CLAUDE.md typography scale already
+  used by `TimelineShiftPopover` (build-time checklist item).
 - **Save** routes through `validateAndUpdateTime` / `validateAndReassign`; pending issues open
   the shared `AvailabilityConflictDialog`; confirm calls the force variant.
 - **Delete:** immediate for unpublished; `AlertDialog` confirm for published shifts
@@ -129,12 +162,27 @@ by `ShiftTimelineTab` (single-dialog pattern):
 - Raw pointer events + `setPointerCapture` on `TimelineBar` (no dnd-kit — continuous 15-min
   snapping is simpler with pointers). Body drag moves; edge handles (desktop) resize; floating
   time readout while dragging. Locked bars don't drag.
+- **Render budget (design-review fold-in):** draft state commits are throttled to one per
+  `requestAnimationFrame` (never per raw pointermove), and `TimelineBar` + `TimelineLane` are
+  wrapped in `React.memo` with comparators keyed on shift id + geometry, so a drag frame
+  re-renders only the affected row while the coverage chart recomputes at the rAF cadence.
+- **Stale-closure discipline:** pointer-capture handlers registered at `pointerdown` read
+  `dayShifts` / overlay state through render-synced refs, never through values closed over
+  when the gesture began (lesson 2026-06-04).
+- **Touch strategy:** bar bodies and edge handles get `touch-action: none` scoped to their
+  own hit areas only; lane background and the plot container keep `pan-x pan-y` so
+  scroll-to-navigate is not regressed. On `pointerType === 'touch'` bars do not drag at all —
+  tap opens the popover, which reaches every drag outcome via time fields.
 - **Draft state:** `ShiftTimelineTab` keeps `draftShift` (create ghost or in-flight
   moved/resized copy). The memoized `useTimelineModel` input becomes
   `dayShifts (minus dragged original) + draft`, so the coverage chart, verdict, and status
   strip update live during the drag — you watch the gap fill before committing.
 - Release → `validateAndUpdateTime`; on pending issues the bar snaps back visually and the
   conflict dialog offers override.
+- **Commit path:** drag commits use the existing `useUpdateShift` mutation, which already
+  performs optimistic `setQueriesData` updates before invalidation — the draft is cleared
+  when the optimistic cache write lands (mutation `onSettled`), so the bar never jumps while
+  waiting for refetch, and no new invalidation behavior is introduced.
 - The draft never writes to React Query caches or localStorage (no manual caching); commit
   goes through mutations, and draft state is cleared on success/cancel. A background refetch
   must not clobber an in-flight draft: the draft lives in local state keyed by shift id and is
@@ -145,16 +193,22 @@ by `ShiftTimelineTab` (single-dialog pattern):
 - `CoverageStatusStrip` segments with status `under` become buttons. Clicking one merges
   adjacent under-staffed hours into a contiguous range and opens the quick-add popover
   prefilled with that window (no lane context: employee picker unfiltered, position blank).
+- Adjacency is computed within the single **day-wide hourly status strip** (the strip is not
+  per-lane/per-area); the merged range never crosses non-`under` hours.
 - Pure helper `mergeUnderStaffedRange(hours, clickedHourMin)` in `src/lib` with tests.
 
 ## Accessibility
 
 - Bars stay `<button>`s; popover editing is fully keyboard accessible (drag is an
   enhancement, not the only path — every drag outcome is achievable via popover time fields).
+  Pointer-drag wiring must not intercept keyboard activation (Enter/Space still opens the
+  popover; no keyboard trap is introduced by making a bar both click target and drag handle).
 - Paint layer: lanes get a visually-hidden "Add shift to <lane> lane" button per lane as the
   keyboard entry to the quick-add popover.
-- All new inputs labeled; conflict chips use text, not color alone; `aria-live` polite region
-  announces validation results in the popover.
+- All new inputs labeled; conflict chips use text, not color alone. The popover owns exactly
+  ONE `aria-live="polite"` region that coalesces all dynamic signals ("on shift" badge +
+  async RPC conflict result + client warnings) into a single composed announcement, so a
+  picker interaction never produces multiple disjoint announcements.
 
 ## Out of scope
 
@@ -163,6 +217,14 @@ by `ShiftTimelineTab` (single-dialog pattern):
   extraction makes it possible).
 - Overtime/labor-budget gating (no such validation exists anywhere today).
 - Multi-day timeline editing (timeline is single-day by design).
+
+## Follow-ups flagged by design review (separate PRs)
+
+- Pin `SET search_path = public, pg_temp` on `check_timeoff_conflict` /
+  `check_availability_conflict` (and siblings) — pre-existing, defense-in-depth.
+- `check_timeoff_conflict` takes only `p_employee_id` (no tenant scoping param) — pre-existing
+  read-surface hardening candidate.
+- Planner's host-local `ShiftInterval.create` convention for template-based creates.
 
 ## Decided trade-offs
 
@@ -177,13 +239,16 @@ by `ShiftTimelineTab` (single-dialog pattern):
 
 - `src/lib/shiftTimeMath.ts`: `minutesToIso` across DST transitions (America/Chicago Mar/Nov),
   overnight (minutes > 1440), TZ-portable fixtures (`new Date(y,m,d)` per lesson 2026-05-10);
-  `snapToStep` edges.
+  `snapToStep` edges. Must include the COMBINED case: overnight minutes > 1440 crossing a
+  fall-back DST boundary (e.g. 23:00 start the night before the transition).
 - `src/lib/shiftMutationPipeline.ts`: `collectShiftIssues` with injected conflict checker —
   warning aggregation, excludeShiftId, RPC conflict merge, locked rejection.
 - `src/lib` gap-merge + picker-sort helpers: unit tests.
 - `useValidatedShiftMutations`: hook tests (mocked mutations + DI'd checker) pinning the
   pending-confirmation contract for create/update/reassign, and that `useShiftPlanner`'s
   delegated API is byte-compatible (existing planner tests keep passing).
+- TZ regression: `validateAndUpdateTime` under a host TZ ≠ restaurant TZ preserves the
+  restaurant-local wall-clock (pins the `fromTimestamps`-not-`create` requirement).
 - Component: quick-add popover renders three states (idle/warnings/saving); drag math helpers
   (pixel→minute mapping) are pure and unit-tested; E2E drag choreography is not covered
   (Playwright drag flake risk), popover-based create/edit path covered by an E2E smoke test.

--- a/docs/superpowers/specs/2026-07-05-timeline-edit-create-design.md
+++ b/docs/superpowers/specs/2026-07-05-timeline-edit-create-design.md
@@ -1,0 +1,189 @@
+# Timeline Edit/Create Experience — Design
+
+**Date:** 2026-07-05
+**Status:** Approved (user approved interaction design in-session; this doc pins the technical shape)
+**Surface:** `src/components/scheduling/ShiftTimeline/` (Timeline view toggle inside `ShiftPlannerTab`)
+
+## Problem
+
+The Timeline view is read-only. Managers find it the most intuitive schedule surface but must
+switch to Plan view (template DnD) or the Scheduler grid (form dialog) to add/edit/delete
+shifts. The user wants to add people to the schedule directly on the timeline, with the same
+validations the planner runs.
+
+## Validation reality (audited 2026-07-05)
+
+Three validation layers exist; only the planner's `useShiftPlanner.validateAndCreate` composes
+all of them:
+
+| Layer | Source | Notes |
+|---|---|---|
+| Duration rules (`INVALID_DURATION` throw, `TOO_SHORT`/`MAX_ENDURANCE` warnings) | `src/lib/shiftInterval.ts` | Warnings, not errors |
+| Overlap + clopen rest-gap (`OVERLAP`, `CLOPEN`) | `src/lib/shiftValidator.ts` `validateShift` | Warnings, not errors |
+| Time-off + availability | RPCs `check_timeoff_conflict`, `check_availability_conflict` via `checkConflictsImperative` (`src/hooks/useConflictDetection.tsx`) | Server-side, DST-safe |
+
+Key facts that shape this design:
+
+- `validateAndUpdateTime` / `validateAndReassign` in `useShiftPlanner` run only client-side
+  `validateShift` — no RPC checks, no override dialog — and have **zero call sites** in the
+  planner UI today. Upgrading their contract is free.
+- The override UX (`AvailabilityConflictDialog`, "Cancel / Assign Anyway") exists and is shared.
+- `ShiftInterval.create(date, 'HH:MM', 'HH:MM')` anchors in **host-local** time. The timeline
+  renders in **restaurant TZ** (`isoToLocalMinutes(iso, dateStr, tz)`). When host TZ ≠
+  restaurant TZ these disagree. The timeline write path must therefore build UTC ISO
+  timestamps with `fromZonedTime` (date-fns-tz, already used by `useGenerateSchedule`) and
+  enter the pipeline via `ShiftInterval.fromTimestamps` — never via `.create`.
+- Overlap/clopen are **warnings with override**, matching planner semantics. This design
+  preserves that (no new hard errors).
+- Locked shifts: server enforces via `assertShiftNotLocked` inside `useUpdateShift`; the
+  pipeline also rejects client-side and the UI disables drag on locked bars.
+
+## Approach
+
+### 1. Shared validation pipeline (extract, then extend)
+
+New hook `src/hooks/useValidatedShiftMutations.ts` — the single validate→confirm→mutate
+pipeline. `useShiftPlanner` delegates to it with its public API **unchanged** (zero planner
+regression risk; `ShiftPlannerTab` untouched).
+
+Pure orchestration lives in `src/lib/shiftMutationPipeline.ts` (coverage lives in `src/lib`
+per lessons):
+
+```ts
+// Pure, DI'd conflict checker for tests
+export async function collectShiftIssues(args: {
+  employeeId: string;
+  restaurantId: string;
+  interval: ShiftInterval;
+  shifts: Shift[];
+  excludeShiftId?: string;
+  checkConflicts?: typeof checkConflictsImperative; // DI
+}): Promise<{ warnings: ValidationIssue[]; conflicts: ConflictCheck[] }>
+```
+
+Hook contract (create path keeps the existing planner shape; update/reassign gain the same
+pending-confirmation shape plus force variants):
+
+```ts
+validateAndCreate(input: ShiftCreateInput)          // unchanged shape
+forceCreate(input: ShiftCreateInput)                // unchanged shape
+validateAndUpdateTime({ shift, startIso, endIso, businessDate })
+  → { updated: boolean; pendingConflicts?; pendingWarnings? }
+forceUpdateTime({ shift, startIso, endIso, businessDate }) → boolean
+validateAndReassign({ shift, newEmployeeId })
+  → { reassigned: boolean; pendingConflicts?; pendingWarnings? }
+forceReassign({ shift, newEmployeeId }) → boolean
+deleteShift(shiftId)
+validationResult / clearValidation                  // unchanged
+```
+
+All update/reassign paths now run **all three layers** (interval rules + validateShift with
+`excludeShiftId` + RPC conflicts) and return pending issues for the
+`AvailabilityConflictDialog` instead of silently proceeding. Locked shifts short-circuit with
+an error result.
+
+New TZ helper in `src/lib/shiftTimeMath.ts` (pure, tested):
+
+```ts
+minutesToIso(dateStr: string, minutes: number, tz: string): string
+// minutes may exceed 1440 (overnight); uses fromZonedTime; DST-tested
+snapToStep(min: number, step = STEP_MIN): number
+```
+
+### 2. Editable shift popover (Timeline)
+
+`TimelineShiftPopover` gains an edit mode and actions while staying the single instance owned
+by `ShiftTimelineTab` (single-dialog pattern):
+
+- **View mode** (existing) + footer actions: Edit, Delete. Lock icon + disabled actions when
+  `shift.locked`. Recurring shifts show "Changes apply to this shift only" hint
+  (series editing stays in the Scheduler's ShiftDialog; out of scope here).
+- **Edit mode:** start/end time fields (reuse `TimeInput`), employee select (active employees,
+  sorted: position match first), break, notes. Live advisory conflicts via reactive
+  `useCheckConflicts` for the currently selected employee (same pattern as `ShiftDialog`) +
+  local `validateShift` warnings — rendered as amber chips (CLAUDE.md amber pattern).
+- **Save** routes through `validateAndUpdateTime` / `validateAndReassign`; pending issues open
+  the shared `AvailabilityConflictDialog`; confirm calls the force variant.
+- **Delete:** immediate for unpublished; `AlertDialog` confirm for published shifts
+  (`event.preventDefault()` before async work per lesson 2026-07-05).
+
+### 3. Paint-to-create + quick-add popover
+
+- Pointer handlers on each lane's plot region (empty space). Drag paints a ghost bar snapped
+  to `STEP_MIN` (15 min) in restaurant-TZ minutes; a plain click (< 5 px movement) drops a
+  default 2 h ghost at the snapped point. Touch: long-press (500 ms) to start painting so
+  horizontal scroll still works.
+- Ghost commit opens the quick-add popover (same component as edit mode, create variant):
+  times prefilled from the ghost, employee picker prioritized by lane context — when grouped
+  by **position**, employees matching the lane's position sort first and position is
+  prefilled; when grouped by **area**, employees whose `employee.area` matches the lane sort
+  first and position defaults to the selected employee's position (a shift's area is derived
+  from its employee — `shifts` has no area column).
+- "On shift" badge computed locally from the day's loaded shifts; live RPC conflict badge for
+  the **selected** candidate only (no N× RPC fan-out).
+- Save → `validateAndCreate` (input built with `minutesToIso`) → conflict dialog on pending →
+  `forceCreate` on confirm.
+
+### 4. Drag-move / edge-resize with live coverage
+
+- Raw pointer events + `setPointerCapture` on `TimelineBar` (no dnd-kit — continuous 15-min
+  snapping is simpler with pointers). Body drag moves; edge handles (desktop) resize; floating
+  time readout while dragging. Locked bars don't drag.
+- **Draft state:** `ShiftTimelineTab` keeps `draftShift` (create ghost or in-flight
+  moved/resized copy). The memoized `useTimelineModel` input becomes
+  `dayShifts (minus dragged original) + draft`, so the coverage chart, verdict, and status
+  strip update live during the drag — you watch the gap fill before committing.
+- Release → `validateAndUpdateTime`; on pending issues the bar snaps back visually and the
+  conflict dialog offers override.
+- The draft never writes to React Query caches or localStorage (no manual caching); commit
+  goes through mutations, and draft state is cleared on success/cancel. A background refetch
+  must not clobber an in-flight draft: the draft lives in local state keyed by shift id and is
+  merged over query data at render time (lesson 2026-06-04).
+
+### 5. Clickable coverage gaps
+
+- `CoverageStatusStrip` segments with status `under` become buttons. Clicking one merges
+  adjacent under-staffed hours into a contiguous range and opens the quick-add popover
+  prefilled with that window (no lane context: employee picker unfiltered, position blank).
+- Pure helper `mergeUnderStaffedRange(hours, clickedHourMin)` in `src/lib` with tests.
+
+## Accessibility
+
+- Bars stay `<button>`s; popover editing is fully keyboard accessible (drag is an
+  enhancement, not the only path — every drag outcome is achievable via popover time fields).
+- Paint layer: lanes get a visually-hidden "Add shift to <lane> lane" button per lane as the
+  keyboard entry to the quick-add popover.
+- All new inputs labeled; conflict chips use text, not color alone; `aria-live` polite region
+  announces validation results in the popover.
+
+## Out of scope
+
+- Recurring-series editing (stays in Scheduler ShiftDialog).
+- Unifying the Scheduler's `ShiftDialog`/copy-DnD onto the shared pipeline (follow-up; the
+  extraction makes it possible).
+- Overtime/labor-budget gating (no such validation exists anywhere today).
+- Multi-day timeline editing (timeline is single-day by design).
+
+## Decided trade-offs
+
+- Overlap/clopen remain overridable warnings (planner parity), not hard errors.
+- Per-candidate RPC availability badges in the picker are limited to the selected candidate to
+  avoid an N×2-RPC storm on popover open.
+- `useShiftPlanner`'s create path keeps host-local `ShiftInterval.create` semantics to avoid
+  changing planner behavior in this PR; only the timeline uses the restaurant-TZ ISO path.
+  (Pre-existing host-TZ convention in the planner is unchanged — flagged as follow-up.)
+
+## Test plan
+
+- `src/lib/shiftTimeMath.ts`: `minutesToIso` across DST transitions (America/Chicago Mar/Nov),
+  overnight (minutes > 1440), TZ-portable fixtures (`new Date(y,m,d)` per lesson 2026-05-10);
+  `snapToStep` edges.
+- `src/lib/shiftMutationPipeline.ts`: `collectShiftIssues` with injected conflict checker —
+  warning aggregation, excludeShiftId, RPC conflict merge, locked rejection.
+- `src/lib` gap-merge + picker-sort helpers: unit tests.
+- `useValidatedShiftMutations`: hook tests (mocked mutations + DI'd checker) pinning the
+  pending-confirmation contract for create/update/reassign, and that `useShiftPlanner`'s
+  delegated API is byte-compatible (existing planner tests keep passing).
+- Component: quick-add popover renders three states (idle/warnings/saving); drag math helpers
+  (pixel→minute mapping) are pure and unit-tested; E2E drag choreography is not covered
+  (Playwright drag flake risk), popover-based create/edit path covered by an E2E smoke test.

--- a/docs/superpowers/specs/2026-07-05-timeline-edit-create-design.md
+++ b/docs/superpowers/specs/2026-07-05-timeline-edit-create-design.md
@@ -65,8 +65,16 @@ Hook contract (create path keeps the existing planner shape; update/reassign gai
 pending-confirmation shape plus force variants):
 
 ```ts
+// Planner create path — host-local HH:MM, UNCHANGED (planner parity, see trade-offs)
 validateAndCreate(input: ShiftCreateInput)          // unchanged shape
 forceCreate(input: ShiftCreateInput)                // unchanged shape
+
+// Timeline create path — TZ-safe ISO instants (added; mirrors update/reassign)
+validateAndCreateAtTime({ employeeId, restaurantId, startIso, endIso,
+  businessDate, position, breakDuration?, notes?, shiftTemplateId? })
+  → { created: boolean; pendingConflicts?; pendingWarnings?; pendingInput? }
+forceCreateAtTime(input: CreateAtTimeInput) → boolean
+
 validateAndUpdateTime({ shift, startIso, endIso, businessDate })
   → { updated: boolean; pendingConflicts?; pendingWarnings? }
 forceUpdateTime({ shift, startIso, endIso, businessDate }) → boolean
@@ -76,6 +84,18 @@ forceReassign({ shift, newEmployeeId }) → boolean
 deleteShift(shiftId)
 validationResult / clearValidation                  // unchanged
 ```
+
+**Create-path TZ conflict resolution (C3 halt, decided 2026-07-06):** the Stage-A
+create contract (`validateAndCreate`, host-local `ShiftInterval.create` from `HH:MM`)
+cannot itself carry the Timeline's restaurant-TZ ISO instants without a fragile host-TZ
+back-shift. Resolution is **additive**: new `validateAndCreateAtTime` / `forceCreateAtTime`
+build the interval via `ShiftInterval.fromTimestamps` (the same TZ-safe pattern as
+`validateAndUpdateTime`/`forceUpdateTime`), taking `startIso`/`endIso` produced by
+`minutesToIso`. The existing HH:MM `validateAndCreate`/`forceCreate` stay byte-identical for
+the planner and `ShiftPlannerTab` — no shared-type or contract change, so A3/A4 stay green.
+The Timeline's quick-add (C3) and gap-click (E2) call **only** the `AtTime` variants. A TZ
+regression test pins that a host-TZ ≠ restaurant-TZ create through `validateAndCreateAtTime`
+writes the restaurant-local wall-clock (parity with the update-path regression test).
 
 All update/reassign paths now run **all three layers** (interval rules + validateShift with
 `excludeShiftId` + RPC conflicts) and return pending issues for the
@@ -154,8 +174,8 @@ cancel → back to editing).
   from its employee — `shifts` has no area column).
 - "On shift" badge computed locally from the day's loaded shifts; live RPC conflict badge for
   the **selected** candidate only (no N× RPC fan-out).
-- Save → `validateAndCreate` (input built with `minutesToIso`) → conflict dialog on pending →
-  `forceCreate` on confirm.
+- Save → `validateAndCreateAtTime` (ISO instants built with `minutesToIso`) → conflict dialog
+  on pending → `forceCreateAtTime` on confirm. (Never the host-local `validateAndCreate`.)
 
 ### 4. Drag-move / edge-resize with live coverage
 

--- a/docs/superpowers/specs/2026-07-06-timeline-ux-safety-design.md
+++ b/docs/superpowers/specs/2026-07-06-timeline-ux-safety-design.md
@@ -1,0 +1,77 @@
+# Timeline UX Safety + Discoverability — Design
+
+**Date:** 2026-07-06
+**Branch:** feature/timeline-edit-create (extends PR #587)
+**Trigger:** Live testing feedback — a manager (1) inadvertently deleted a draft shift with no
+way to undo it, (2) couldn't find how to add someone, (3) dragged/assigned and got a toast but
+no visible result to verify or correct.
+
+## Problem
+
+Three real gaps surfaced while testing the new Timeline editing canvas:
+
+1. **Destructive delete, no undo.** `TimelineShiftPopover.handleDeleteClick` deletes an
+   **unpublished** shift immediately on click (only *published* shifts get an `AlertDialog`
+   confirm). Deletes are hard-deletes with no snapshot for drafts (`schedule_change_logs`
+   only logs published-shift deletes), so a misclick is unrecoverable.
+2. **No discoverable "add".** Creating a shift is only via painting empty lane space or a
+   visually-hidden ("sr-only") "Add shift to <lane>" button. No visible affordance.
+3. **Invisible result after a change.** Create / move / reassign fire a generic success toast
+   but nothing on the canvas confirms *what* changed, so the user can't verify or correct it.
+
+## Fixes
+
+### Fix 1 — Undo on delete (all deletes), keep the published confirm
+
+- Add **`deleteShiftWithUndo(shift: Shift)`** owned by `ShiftTimelineTab` (it persists after
+  the popover closes). It:
+  1. Captures the full shift, calls the existing `deleteShift(shift.id)` pipeline.
+  2. Shows a toast: **"Shift deleted"** with an **Undo** `ToastAction`.
+  3. On Undo → re-create the shift from the captured payload via `useCreateShift`
+     (`restaurant_id, employee_id, start_time, end_time, position, break_duration, notes,
+     status, is_published, source, shift_template_id`). New id (acceptable — it's a restore),
+     then toast "Shift restored".
+- `TimelineShiftPopover`'s `deleteShift: (id) => void` prop becomes **`onDelete: (shift) => void`**
+  so undo has the data. The published-shift `AlertDialog` confirm stays as an extra guard;
+  its confirm path also routes through `onDelete(shift)` so published deletes are undoable too.
+- Undo re-inserts directly (no re-validation — the shift existed moments ago). Idempotency:
+  the Undo action is one-shot (toast dismisses on click).
+
+### Fix 2 — Visible "Add shift" button
+
+- Add a visible **"Add shift"** button (Lucide `Plus`, CLAUDE.md primary button style) in the
+  timeline controls row (alongside the day selector / group-by toggle).
+- Click opens the existing create popover (`activeOverlay {mode:'create'}`) for the **selected
+  day** with a sensible default block and **no lane context** (employee + position blank for
+  the user to fill). Default range: a `DEFAULT_ADD_RANGE` (e.g. 09:00–17:00) clamped into the
+  model window via the existing `endPaint`/clamp helpers; anchor the popover to the button's rect.
+- Reuses `buildDraftShiftValues(range)` + the create-mode `TimelineShiftEditor` — no new form.
+- Keyboard/a11y: it's a real `<button>` with a visible label (the sr-only per-lane buttons stay
+  for in-lane adds; this is the primary discoverable entry point).
+
+### Fix 3 — Confirming feedback + transient highlight
+
+- **Descriptive toasts:** create / move / reassign success toasts name the change
+  (e.g. "Added — Maya · 5:00–9:00 PM", "Moved — Ana to 3:30–10:00 PM"). Sourced from the
+  employee name + formatted times already available at the call site.
+- **Transient highlight:** `ShiftTimelineTab` keeps `recentlyChangedShiftId` (set on a
+  move/resize/edit commit whose shift id is known; cleared after ~2s via a timeout).
+  `TimelineBar` takes a `highlighted` prop → a brief `ring-2 ring-ring` pulse (semantic tokens).
+  Created shifts (new id unknown until refetch) rely on the descriptive toast; move/edit/resize
+  (known id) also get the ring so the user sees exactly what moved.
+
+## Out of scope / decided trade-offs
+
+- Undo re-creates (new id) rather than restoring the exact id — fine for a draft correction;
+  avoids a soft-delete schema change. (True id-stable restore would need a DB change.)
+- No change to the delete DB semantics or the audit trigger (a separate, larger topic).
+- The Planner's employee-chip drag feedback is not touched here (this is the Timeline surface).
+
+## Test plan
+
+- Unit: `deleteShiftWithUndo` shows an undo toast and the undo action re-creates with the exact
+  payload (mocked mutations); the "Add shift" button opens the create overlay with a default
+  range + null lane context + the selected day; `TimelineBar` renders the highlight ring when
+  `highlighted`; the transient highlight clears after its timeout (fake timers).
+- E2E (extend the existing smoke): the visible "Add shift" button opens the quick-add popover.
+- Verify: tsc, changed-file lint, full unit suite, build, E2E smoke, then push to PR #587.

--- a/src/components/scheduling/ShiftTimeline/CoverageStatusStrip.tsx
+++ b/src/components/scheduling/ShiftTimeline/CoverageStatusStrip.tsx
@@ -10,6 +10,13 @@ interface CoverageStatusStripProps {
    * string, e.g. `17 → "5 PM"`.  Defaults to a built-in 12-hour formatter.
    */
   readonly formatHour?: (hour: number) => string;
+  /**
+   * Called with a short (`delta < 0`) hour's `startMin` when its cell is
+   * clicked or activated via keyboard. When omitted, short cells render as
+   * plain (non-interactive) cells exactly as before — back-compat for
+   * existing callers that don't yet support gap-click quick-add.
+   */
+  readonly onGapClick?: (startMin: number) => void;
 }
 
 /**
@@ -39,11 +46,18 @@ function cellAriaLabel(hour: CoverageHour, label: string): string {
  * short hour for screen readers, preserving the former `CoverageGapList`
  * accessibility guarantee.
  *
+ * When `onGapClick` is supplied, short (`delta < 0`) cells render as real
+ * `<button>`s (keyboard-activatable, no keyboard trap) that call it with the
+ * hour's `startMin` — the gap-click quick-add entry point (design doc §5).
+ * Covered and no-demand cells never become interactive. Omitting `onGapClick`
+ * keeps every cell a plain, non-interactive `<div>` (back-compat).
+ *
  * Returns null when `hours` is empty.
  */
 export function CoverageStatusStrip({
   hours,
   formatHour = formatCoverageHour,
+  onGapClick,
 }: CoverageStatusStripProps) {
   if (hours.length === 0) return null;
 
@@ -72,6 +86,38 @@ export function CoverageStatusStrip({
             cellColorClass = 'bg-muted/50 text-muted-foreground';
           }
 
+          const cellContent = (
+            <>
+              <span className="text-[9px] font-medium leading-none">{label}</span>
+              <span className="text-[11px] leading-none tabular-nums">
+                {hasDemand ? `${h.scheduled}/${h.needed!}` : `${h.scheduled}`}
+              </span>
+            </>
+          );
+
+          // Short hours become clickable buttons (quick-add entry point) only
+          // when the caller opts in via `onGapClick` — covered/no-demand cells
+          // never become interactive, and without `onGapClick` a short cell
+          // renders exactly as before (plain, non-interactive `<div>`).
+          if (isShort && onGapClick) {
+            return (
+              <button
+                key={h.startMin}
+                type="button"
+                aria-label={ariaLabel}
+                title={ariaLabel}
+                onClick={() => onGapClick(h.startMin)}
+                className={cn(
+                  'flex min-w-0 flex-1 flex-col items-center gap-0.5 rounded py-1 px-0.5',
+                  'cursor-pointer transition-colors hover:bg-destructive/25 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+                  cellColorClass,
+                )}
+              >
+                {cellContent}
+              </button>
+            );
+          }
+
           return (
             <div
               key={h.startMin}
@@ -83,10 +129,7 @@ export function CoverageStatusStrip({
                 cellColorClass,
               )}
             >
-              <span className="text-[9px] font-medium leading-none">{label}</span>
-              <span className="text-[11px] leading-none tabular-nums">
-                {hasDemand ? `${h.scheduled}/${h.needed!}` : `${h.scheduled}`}
-              </span>
+              {cellContent}
             </div>
           );
         })}

--- a/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
+++ b/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
@@ -392,9 +392,10 @@ export function ShiftTimelineTab({
   /**
    * Paint-to-create commit (C2): a lane's paint gesture (drag/click) or its
    * visually-hidden "Add shift" button committed a range. Stage the `create`
-   * overlay with that range + lane context. No anchor rect is available from
-   * the lane's plot region today — a future stage wires proper ghost-bar
-   * anchoring; the popover falls back to its zero-size trigger until then.
+   * overlay with that range + lane context. `anchorRect` is unused for create
+   * (the create form renders as a centered Dialog, not an anchored popover —
+   * see `TimelineCreateDialog`); it's carried on `ActiveOverlay` only because
+   * the union is shared with the `edit` case.
    */
   const handlePaintCommit = useCallback((draft: PaintRange, laneContext: LanePaintContext) => {
     setActiveOverlay({ mode: 'create', draft, laneContext, anchorRect: null });
@@ -407,9 +408,7 @@ export function ShiftTimelineTab({
    * computed within the single day-wide hourly status strip; the merged range
    * never crosses a covered/no-demand hour). Opens the same `create` overlay
    * as paint-to-create, but with `laneContext: null` — no lane context, so the
-   * popover's employee picker is unfiltered and position starts blank. No
-   * anchor rect is available from the strip cell today (same limitation as
-   * paint-to-create); the popover falls back to its zero-size trigger.
+   * form's employee picker is unfiltered and position starts blank.
    */
   const handleGapClick = useCallback(
     (startMin: number) => {
@@ -423,17 +422,21 @@ export function ShiftTimelineTab({
    * Visible "Add shift" button (Fix 2): opens the same `create` overlay as
    * paint-to-create/gap-click, seeded with a default 09:00–17:00 range
    * clamped into the day's visible window, no lane context (unfiltered
-   * employee picker, blank position), anchored to the button itself so the
-   * popover opens right below it.
+   * employee picker, blank position). `anchorRect` is carried on `ActiveOverlay`
+   * for the `edit` case (the Popover anchors to the clicked bar) but is unused
+   * for `create`: the create form now renders as a centered `Dialog` (see
+   * `TimelineCreateDialog` in TimelineShiftPopover.tsx) since the tall form's
+   * submit button was landing below the viewport fold when anchored to a
+   * small trigger on short/laptop screens.
    */
   const handleAddShiftClick = useCallback(
-    (event: React.MouseEvent<HTMLButtonElement>) => {
+    () => {
       const range = clampRangeToWindow(DEFAULT_ADD_RANGE, model.window);
       setActiveOverlay({
         mode: 'create',
         draft: range,
         laneContext: null,
-        anchorRect: event.currentTarget.getBoundingClientRect(),
+        anchorRect: null,
       });
     },
     [model.window],

--- a/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
+++ b/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
@@ -38,8 +38,15 @@ import type { ShiftMinuteRange } from '@/lib/timelineDragMath';
 
 // ─── Constants (Fix 2 — visible "Add shift" button) ────────────────────────────
 
-/** Default 09:00–17:00 range dropped by the visible "Add shift" button (clamped into the day's window). */
-const DEFAULT_ADD_RANGE: PaintRange = { startMin: 9 * 60, endMin: 17 * 60 };
+/**
+ * Default 10:00–18:00 range dropped by the visible "Add shift" button (clamped
+ * into the day's window). Starts at 10:00 (600) rather than 09:00 (540) so it
+ * survives unclamped on an empty day: `deriveWindow` (src/lib/timelineModel.ts)
+ * returns a 10:00–23:00 fallback window when a day has zero shifts, and a
+ * range starting before that window's start would otherwise get silently
+ * shrunk by `clampRangeToWindow` before the popover ever opens.
+ */
+const DEFAULT_ADD_RANGE: PaintRange = { startMin: 10 * 60, endMin: 18 * 60 };
 
 /** How long a bar shows its transient change-highlight ring (design doc §Fix 3). */
 const HIGHLIGHT_DURATION_MS = 2000;
@@ -91,7 +98,6 @@ type ActiveOverlay =
       mode: 'create';
       draft: PaintRange;
       laneContext: LanePaintContext | null;
-      anchorRect: DOMRect | null;
     }
   | null;
 
@@ -273,12 +279,12 @@ export function ShiftTimelineTab({
     forceUpdateTime,
     validateAndUpdateShift,
     forceUpdateShift,
-    deleteShift,
+    deleteShiftAsync,
     validationResult,
     clearValidation,
   } = useValidatedShiftMutations(restaurantId, shifts, { silentDelete: true });
 
-  // ── Undo-delete flow (Fix 1) ───────────────────────────────────────────────
+  // ── Undo-delete flow (Fix 1 + Fix B — critical data-integrity fixes) ──────
   // Re-creates via useCreateShift directly (not the validated pipeline — the
   // shift existed moments ago, no re-validation needed on Undo). `silent:
   // true` suppresses useCreateShift's own "Shift created" toast; the "Shift
@@ -287,10 +293,27 @@ export function ShiftTimelineTab({
   const { toast } = useToast();
 
   const deleteShiftWithUndo = useCallback(
-    (shift: Shift) => {
-      deleteShift(shift.id);
+    async (shift: Shift) => {
+      // Await the lock-guarded delete BEFORE offering undo: if the delete
+      // fails (or the shift is locked), the mutation's own onError toast
+      // already fired — showing our own "Shift deleted" + Undo toast here
+      // would let the user "undo" a delete that never happened, duplicating
+      // the still-existing shift.
+      try {
+        await deleteShiftAsync(shift.id);
+      } catch {
+        return;
+      }
+
+      // One-shot guard (Fix B): a double-click on Undo must never create the
+      // shift twice. `alreadyUndone` is captured per-toast in this closure.
+      let alreadyUndone = false;
 
       const handleUndo = () => {
+        if (alreadyUndone) return;
+        alreadyUndone = true;
+        dismiss();
+
         void createShift
           .mutateAsync({
             restaurant_id: shift.restaurant_id,
@@ -305,13 +328,21 @@ export function ShiftTimelineTab({
             locked: shift.locked,
             source: shift.source,
             shift_template_id: shift.shift_template_id,
+            // Fix C — preserve recurrence series linkage on restore, but
+            // deliberately OMIT recurrence_pattern: useCreateShift only takes
+            // the createRecurringShifts (whole-series) branch when BOTH
+            // recurrence_pattern AND is_recurring are truthy (see
+            // src/hooks/useShifts.tsx). Undo must restore exactly the ONE
+            // deleted shift, not regenerate its entire series.
+            is_recurring: shift.is_recurring,
+            recurrence_parent_id: shift.recurrence_parent_id,
           })
           .then(() => {
             toast({ title: 'Shift restored' });
           });
       };
 
-      toast({
+      const { dismiss } = toast({
         title: 'Shift deleted',
         action: (
           <ToastAction altText="Undo shift delete" onClick={handleUndo}>
@@ -320,7 +351,7 @@ export function ShiftTimelineTab({
         ),
       });
     },
-    [deleteShift, createShift, toast],
+    [deleteShiftAsync, createShift, toast],
   );
 
   // ── Live-drag merge (Stage D2) ─────────────────────────────────────────────
@@ -392,13 +423,13 @@ export function ShiftTimelineTab({
   /**
    * Paint-to-create commit (C2): a lane's paint gesture (drag/click) or its
    * visually-hidden "Add shift" button committed a range. Stage the `create`
-   * overlay with that range + lane context. `anchorRect` is unused for create
-   * (the create form renders as a centered Dialog, not an anchored popover —
-   * see `TimelineCreateDialog`); it's carried on `ActiveOverlay` only because
-   * the union is shared with the `edit` case.
+   * overlay with that range + lane context. The `create` variant of
+   * `ActiveOverlay` carries no `anchorRect` (the create form renders as a
+   * centered Dialog, not an anchored popover — see `TimelineCreateDialog`);
+   * that field only exists on the `edit` variant, still used by the popover.
    */
   const handlePaintCommit = useCallback((draft: PaintRange, laneContext: LanePaintContext) => {
-    setActiveOverlay({ mode: 'create', draft, laneContext, anchorRect: null });
+    setActiveOverlay({ mode: 'create', draft, laneContext });
   }, []);
 
   /**
@@ -413,34 +444,25 @@ export function ShiftTimelineTab({
   const handleGapClick = useCallback(
     (startMin: number) => {
       const range = mergeUnderStaffedRange(hourlySummary, startMin);
-      setActiveOverlay({ mode: 'create', draft: range, laneContext: null, anchorRect: null });
+      setActiveOverlay({ mode: 'create', draft: range, laneContext: null });
     },
     [hourlySummary],
   );
 
   /**
    * Visible "Add shift" button (Fix 2): opens the same `create` overlay as
-   * paint-to-create/gap-click, seeded with a default 09:00–17:00 range
+   * paint-to-create/gap-click, seeded with a default 10:00–18:00 range
    * clamped into the day's visible window, no lane context (unfiltered
-   * employee picker, blank position). `anchorRect` is carried on `ActiveOverlay`
-   * for the `edit` case (the Popover anchors to the clicked bar) but is unused
-   * for `create`: the create form now renders as a centered `Dialog` (see
-   * `TimelineCreateDialog` in TimelineShiftPopover.tsx) since the tall form's
-   * submit button was landing below the viewport fold when anchored to a
-   * small trigger on short/laptop screens.
+   * employee picker, blank position). No `anchorRect` here: the create form
+   * now renders as a centered `Dialog` (see `TimelineCreateDialog` in
+   * TimelineShiftPopover.tsx) since the tall form's submit button was landing
+   * below the viewport fold when anchored to a small trigger on short/laptop
+   * screens.
    */
-  const handleAddShiftClick = useCallback(
-    () => {
-      const range = clampRangeToWindow(DEFAULT_ADD_RANGE, model.window);
-      setActiveOverlay({
-        mode: 'create',
-        draft: range,
-        laneContext: null,
-        anchorRect: null,
-      });
-    },
-    [model.window],
-  );
+  const handleAddShiftClick = useCallback(() => {
+    const range = clampRangeToWindow(DEFAULT_ADD_RANGE, model.window);
+    setActiveOverlay({ mode: 'create', draft: range, laneContext: null });
+  }, [model.window]);
 
   /**
    * Live drag-draft update (Stage D2): `TimelineBar` calls this on every
@@ -773,7 +795,7 @@ export function ShiftTimelineTab({
       <TimelineShiftPopover
         activeShift={activeOverlay?.mode === 'edit' ? activeOverlay.shift : null}
         createDraft={createDraft}
-        anchorRect={activeOverlay?.anchorRect ?? null}
+        anchorRect={activeOverlay?.mode === 'edit' ? activeOverlay.anchorRect : null}
         tz={tz}
         dateStr={selectedDay}
         employees={employees}

--- a/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
+++ b/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
@@ -18,12 +18,12 @@ import { AreaCoverageStrips } from './AreaCoverageStrips';
 import { TimelineAxis } from './TimelineAxis';
 import { TimelineLane, type LanePaintContext } from './TimelineLane';
 import { NowIndicator } from './NowIndicator';
-import { TimelineShiftPopover } from './TimelineShiftPopover';
+import { TimelineShiftPopover, type TimelineCreateDraft } from './TimelineShiftPopover';
 import { formatDayLabel } from '@/lib/shiftInterval';
 
 import type { Shift, Employee } from '@/types/scheduling';
 import type { GroupByMode } from '@/lib/scheduleGrouping';
-import type { PaintRange } from '@/lib/timelineDraft';
+import { buildDraftShiftValues, type PaintRange } from '@/lib/timelineDraft';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -47,14 +47,13 @@ interface ShiftTimelineTabProps {
 /**
  * Single union state driving the ONE `TimelineShiftPopover` instance across every
  * entry point (edit via bar click; quick-add via paint/gap-click/keyboard "Add
- * shift" button, wired in C2). Mutually exclusive by construction — never two
+ * shift" button). Mutually exclusive by construction — never two
  * popovers/overlays mounted at once.
  *
- * `create`'s `draft` + `laneContext` are now produced by `TimelineLane`'s paint
- * layer (C2), but `TimelineShiftPopover` doesn't yet render a create-mode form
- * (that's C3) — so `activeShift` stays null for `create` today and the popover
- * renders nothing, same as before C2. The state shape is final so C3 only needs
- * to add rendering, not another migration.
+ * `create`'s `draft` + `laneContext` are produced by `TimelineLane`'s paint layer
+ * (C2) and resolved into `TimelineShiftPopover`'s `createDraft` prop (C3) via the
+ * `createDraft` memo below, which maps the lane's grouping key to `position` or
+ * `area` depending on `groupBy`.
  */
 type ActiveOverlay =
   | { mode: 'edit'; shift: Shift; anchorRect: DOMRect | null }
@@ -160,6 +159,8 @@ export function ShiftTimelineTab({
   const {
     validateAndCreate,
     forceCreate,
+    validateAndCreateAtTime,
+    forceCreateAtTime,
     validateAndUpdateTime,
     forceUpdateTime,
     validateAndReassign,
@@ -228,14 +229,36 @@ export function ShiftTimelineTab({
   /**
    * Paint-to-create commit (C2): a lane's paint gesture (drag/click) or its
    * visually-hidden "Add shift" button committed a range. Stage the `create`
-   * overlay with that range + lane context; `TimelineShiftPopover` doesn't
-   * render a create-mode form yet (C3), so this is a no-op visually until then.
-   * No anchor rect is available from the lane's plot region today — C3 wires
-   * proper ghost-bar anchoring alongside the popover's create variant.
+   * overlay with that range + lane context. No anchor rect is available from
+   * the lane's plot region today — a future stage wires proper ghost-bar
+   * anchoring; the popover falls back to its zero-size trigger until then.
    */
   const handlePaintCommit = useCallback((draft: PaintRange, laneContext: LanePaintContext) => {
     setActiveOverlay({ mode: 'create', draft, laneContext, anchorRect: null });
   }, []);
+
+  /**
+   * Resolve the `create` overlay into `TimelineShiftPopover`'s `createDraft`
+   * prop: the lane's grouping key maps to `laneContext.position` when grouped
+   * by position, or `laneContext.area` when grouped by area (a shift's area
+   * is derived from its employee, never stored directly — see the design
+   * doc's "Paint-to-create + quick-add popover" section). `buildDraftShiftValues`
+   * derives the initial editor values (+ prefilled position) from the
+   * committed minute range.
+   */
+  const createDraft: TimelineCreateDraft | null = useMemo(() => {
+    if (activeOverlay?.mode !== 'create') return null;
+
+    const laneKey = activeOverlay.laneContext.key;
+    const resolvedLaneContext =
+      groupBy === 'position' ? { position: laneKey, area: null } : { position: null, area: laneKey };
+
+    return {
+      values: buildDraftShiftValues(activeOverlay.draft, { laneContext: resolvedLaneContext }),
+      laneContext: resolvedLaneContext,
+      businessDate: selectedDay,
+    };
+  }, [activeOverlay, groupBy, selectedDay]);
 
   // ── Loading state ──────────────────────────────────────────────────────────
   if (loading) {
@@ -422,11 +445,10 @@ export function ShiftTimelineTab({
       </div>
 
       {/* Single popover instance per CLAUDE.md pattern — driven entirely by the
-          activeOverlay union so edit/create/null are mutually exclusive. Only
-          the 'edit' variant has a producer today; 'create' (paint/gap-click)
-          lands in Stage C. */}
+          activeOverlay union so edit/create/null are mutually exclusive. */}
       <TimelineShiftPopover
         activeShift={activeOverlay?.mode === 'edit' ? activeOverlay.shift : null}
+        createDraft={createDraft}
         anchorRect={activeOverlay?.anchorRect ?? null}
         tz={tz}
         dateStr={selectedDay}
@@ -436,6 +458,8 @@ export function ShiftTimelineTab({
         onClose={handlePopoverClose}
         validateAndUpdateTime={validateAndUpdateTime}
         forceUpdateTime={forceUpdateTime}
+        validateAndCreateAtTime={validateAndCreateAtTime}
+        forceCreateAtTime={forceCreateAtTime}
         deleteShift={deleteShift}
         validationResult={validationResult}
         clearValidation={clearValidation}

--- a/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
+++ b/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
@@ -17,7 +17,7 @@ import { useWeekStaffingSuggestions } from '@/hooks/useWeekStaffingSuggestions';
 import { useValidatedShiftMutations } from '@/hooks/useValidatedShiftMutations';
 import { useCreateShift } from '@/hooks/useShifts';
 import { useToast } from '@/hooks/use-toast';
-import { useTimelineModel } from './useTimelineModel';
+import { useTimelineModel, computeCoverage } from './useTimelineModel';
 import { CoverageVerdict } from './CoverageVerdict';
 import { CoverageChart } from './CoverageChart';
 import { CoverageStatusStrip } from './CoverageStatusStrip';
@@ -358,24 +358,37 @@ export function ShiftTimelineTab({
     [deleteShiftAsync, createShift, toast],
   );
 
-  // ── Live-drag merge (Stage D2) ─────────────────────────────────────────────
-  // Replaces the dragged shift's committed start/end with the drafted minutes
-  // so the model — and therefore the coverage chart/verdict/status strip —
-  // reflects the in-flight drag on every rAF-throttled frame. Falls through
-  // to `dayShifts` unchanged when no drag is in progress.
-  const modelInputShifts = useMemo(
-    () => mergeDraftShift(dayShifts, dragDraft, selectedDay, tz),
-    [dayShifts, dragDraft, selectedDay, tz],
-  );
-
   // ── Timeline model (pure transform) ───────────────────────────────────────
-  const model = useTimelineModel(modelInputShifts, employees, selectedDay, tz, groupBy, dayRecommendations);
+  // Fix 1 (bar-jumping regression): lanes + window are derived from the
+  // STABLE, committed `dayShifts` only — never from the in-flight drag draft.
+  // Previously the draft was merged in BEFORE this call, so `assignRows`'
+  // first-fit row-packing (src/lib/timelineModel.ts) re-sorted by start_time
+  // and re-packed EVERY bar's row on every rAF frame (bars visibly jumped
+  // rows/hopped around), and `deriveWindow` rescaled the horizontal axis
+  // mid-drag. The dragged bar's own live horizontal position still comes from
+  // its `dragState` in TimelineBar (`displayLeftMin = dragState?.startMin ??
+  // leftMin`, via this stable `model.window`'s minToPct) — so drag feedback
+  // stays smooth without lanes/window ever moving.
+  const model = useTimelineModel(dayShifts, employees, selectedDay, tz, groupBy, dayRecommendations);
+
+  // ── Live-drag coverage (Stage D2, preserved) ───────────────────────────────
+  // The lanes/window above are frozen, but the coverage chart/verdict/status
+  // strip should still show the drag's live effect ("watch the gap fill while
+  // dragging"). Compute coverage for the DRAFTED shifts against the frozen
+  // `model.window` — never rebuilding lanes — so this recomputes cheaply on
+  // every rAF frame. When there's no drag in progress, reuse `model.coverage`/
+  // `model.demand` directly (zero extra work).
+  const liveCoverage = useMemo(() => {
+    if (!dragDraft) return { coverage: model.coverage, demand: model.demand };
+    const draftedShifts = mergeDraftShift(dayShifts, dragDraft, selectedDay, tz);
+    return computeCoverage(draftedShifts, selectedDay, tz, model.window, dayRecommendations);
+  }, [dragDraft, dayShifts, selectedDay, tz, model.window, model.coverage, model.demand, dayRecommendations]);
 
   // ── Hourly coverage summary + verdict (feeds the new coverage panel) ───────
   const targetSplh = activeSettings?.target_splh ?? null;
   const hourlySummary = useMemo(
-    () => summarizeCoverageHours(model.coverage, model.demand, model.window, dayRecommendations),
-    [model.coverage, model.demand, model.window, dayRecommendations],
+    () => summarizeCoverageHours(liveCoverage.coverage, liveCoverage.demand, model.window, dayRecommendations),
+    [liveCoverage.coverage, liveCoverage.demand, model.window, dayRecommendations],
   );
   const verdict = useMemo(() => buildVerdict(hourlySummary), [hourlySummary]);
 
@@ -471,8 +484,8 @@ export function ShiftTimelineTab({
   /**
    * Live drag-draft update (Stage D2): `TimelineBar` calls this on every
    * rAF-throttled pointermove frame with the in-flight range, and once more
-   * with `null` when the gesture ends/cancels. Feeds `modelInputShifts` above
-   * so coverage recomputes live during the drag.
+   * with `null` when the gesture ends/cancels. Feeds `liveCoverage` above so
+   * coverage recomputes live during the drag — lanes/window are unaffected.
    */
   const handleBarDraftChange = useCallback((shiftId: string, range: ShiftMinuteRange | null) => {
     setDragDraft(range ? { shiftId, startMin: range.startMin, endMin: range.endMin } : null);

--- a/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
+++ b/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback, useRef } from 'react';
 
 import { Skeleton } from '@/components/ui/skeleton';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
@@ -42,6 +42,19 @@ interface ShiftTimelineTabProps {
   /** Forwarded from the parent's error state; renders an inline message. */
   readonly error: Error | null;
 }
+
+/**
+ * Single union state driving the ONE `TimelineShiftPopover` instance across every
+ * entry point (edit via bar click today; quick-add via paint/gap-click in Stage C).
+ * Mutually exclusive by construction — never two popovers/overlays mounted at once.
+ * `create` has no producer yet (paint-to-create lands in Stage C); the variant is
+ * declared now so the popover's eventual create-mode prop threading doesn't require
+ * another state-shape migration.
+ */
+type ActiveOverlay =
+  | { mode: 'edit'; shift: Shift; anchorRect: DOMRect | null }
+  | { mode: 'create'; anchorRect: DOMRect | null }
+  | null;
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -117,7 +130,9 @@ export function ShiftTimelineTab({
   // when the stored day is outside the current week.
   const selectedDay = weekDays.includes(selectedDayState) ? selectedDayState : defaultDay(weekDays);
   const [groupBy, setGroupBy] = useState<GroupByMode>('area');
-  const [activeShift, setActiveShift] = useState<Shift | null>(null);
+  // Single union overlay state (design doc "Overlay state machine") — edit mode is
+  // wired here; create mode's producer (paint/gap-click) lands in Stage C.
+  const [activeOverlay, setActiveOverlay] = useState<ActiveOverlay>(null);
   const [coverageView, setCoverageView] = useState<'area' | 'delta'>('area');
 
   // ── Staffing recommendations ───────────────────────────────────────────────
@@ -131,13 +146,19 @@ export function ShiftTimelineTab({
   // ── Filter shifts to the selected day ─────────────────────────────────────
   const dayShifts = useMemo(() => filterToDay(shifts, selectedDay, tz), [shifts, selectedDay, tz]);
 
-  // ── Validated mutation pipeline for the popover's edit/delete actions.
-  // Full overlay-state wiring (anchor-rect capture, single union activeOverlay,
-  // toast copy) is Stage B3 — this call site only needs to satisfy
-  // TimelineShiftPopover's save/delete props for now.
+  // ── Validated mutation pipeline — the single instance shared by the popover's
+  // edit/delete flows (create/reassign are mounted here too, ahead of Stage C's
+  // quick-add wiring, so this hook call site never needs to migrate again).
+  // Toasts on success/failure come from the underlying useShifts mutation hooks
+  // (useCreateShift/useUpdateShift/useDeleteShift) — this component doesn't call
+  // useToast directly.
   const {
+    validateAndCreate,
+    forceCreate,
     validateAndUpdateTime,
     forceUpdateTime,
+    validateAndReassign,
+    forceReassign,
     deleteShift,
     validationResult,
     clearValidation,
@@ -175,7 +196,29 @@ export function ShiftTimelineTab({
   const plotMinWidth = spanHours * MIN_PX_PER_HOUR;
 
   // ── Callbacks ──────────────────────────────────────────────────────────────
-  const handlePopoverClose = useCallback(() => setActiveShift(null), []);
+  const handlePopoverClose = useCallback(() => setActiveOverlay(null), []);
+
+  /**
+   * Anchor-rect capture for edit mode: `TimelineBar`/`TimelineLane`'s `onSelect`
+   * contract is `(shift) => void` (pinned by existing tests — see
+   * tests/unit/timelineBarLabel.test.tsx / timelineComponents.test.tsx), so the
+   * rect can't be threaded through that prop without a breaking signature change.
+   * Instead, a click-capture listener on the lanes wrapper (below) runs in the
+   * capture phase — BEFORE `TimelineBar`'s own onClick calls onSelect — and
+   * stashes the clicked bar's rect in a ref that `handleSelectShift` reads
+   * synchronously afterward. `closest('button')` finds the bar element (each bar
+   * renders as a `<button>`); a click that reaches onSelect without a bar
+   * ancestor shouldn't happen (only TimelineBar calls onSelect), but if it did,
+   * the popover still opens, anchored on the legacy zero-size fallback trigger.
+   */
+  const pendingAnchorRectRef = useRef<DOMRect | null>(null);
+  const handleLanesClickCapture = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    const barEl = (event.target as HTMLElement).closest('button');
+    pendingAnchorRectRef.current = barEl ? barEl.getBoundingClientRect() : null;
+  }, []);
+  const handleSelectShift = useCallback((shift: Shift) => {
+    setActiveOverlay({ mode: 'edit', shift, anchorRect: pendingAnchorRectRef.current });
+  }, []);
 
   // ── Loading state ──────────────────────────────────────────────────────────
   if (loading) {
@@ -335,7 +378,7 @@ export function ShiftTimelineTab({
 
           {/* Lanes + NowIndicator overlay, or empty-day message */}
           {noShiftsMessage ?? (
-            <div className="relative">
+            <div className="relative" onClickCapture={handleLanesClickCapture}>
               {/* NowIndicator sits over the lanes plot region, offset for label column */}
               <div className="absolute top-0 bottom-0 left-[120px] right-0 pointer-events-none">
                 <NowIndicator
@@ -351,7 +394,7 @@ export function ShiftTimelineTab({
                   key={lane.key}
                   lane={lane}
                   minToPct={minToPct}
-                  onSelect={setActiveShift}
+                  onSelect={handleSelectShift}
                 />
               ))}
             </div>
@@ -359,9 +402,13 @@ export function ShiftTimelineTab({
         </div>
       </div>
 
-      {/* Single popover instance per CLAUDE.md pattern */}
+      {/* Single popover instance per CLAUDE.md pattern — driven entirely by the
+          activeOverlay union so edit/create/null are mutually exclusive. Only
+          the 'edit' variant has a producer today; 'create' (paint/gap-click)
+          lands in Stage C. */}
       <TimelineShiftPopover
-        activeShift={activeShift}
+        activeShift={activeOverlay?.mode === 'edit' ? activeOverlay.shift : null}
+        anchorRect={activeOverlay?.anchorRect ?? null}
         tz={tz}
         dateStr={selectedDay}
         employees={employees}

--- a/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
+++ b/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
@@ -372,8 +372,9 @@ export function ShiftTimelineTab({
         return;
       }
 
-      // Validation failed outright (e.g. a thrown lock/interval error) with no
-      // pending issues to confirm — snap back rather than leave a dangling draft.
+      // Validation failed outright (e.g. a locked shift returns `updated:
+      // false`, or an interval-construction error) with no pending issues to
+      // confirm — snap back rather than leave a dangling draft.
       setDragDraft(null);
     },
     [dayShifts, selectedDay, tz, validateAndUpdateTime],

--- a/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
+++ b/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
@@ -339,6 +339,10 @@ export function ShiftTimelineTab({
           })
           .then(() => {
             toast({ title: 'Shift restored' });
+          })
+          .catch(() => {
+            // Restore failed — useCreateShift's own onError toast surfaces the
+            // failure to the user; swallow here so the rejection isn't unhandled.
           });
       };
 

--- a/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
+++ b/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
@@ -212,15 +212,20 @@ export function ShiftTimelineTab({
   // Toasts on success/failure come from the underlying useShifts mutation hooks
   // (useCreateShift/useUpdateShift/useDeleteShift) — this component doesn't call
   // useToast directly.
+  // Uses the full-week `shifts` (not `dayShifts`) so overlap/rest-gap checks also
+  // see overnight shifts spilling in from the previous day and early-next-day
+  // shifts spilling out from this one — a day-scoped array would miss both.
   const {
     validateAndCreateAtTime,
     forceCreateAtTime,
     validateAndUpdateTime,
     forceUpdateTime,
+    validateAndUpdateShift,
+    forceUpdateShift,
     deleteShift,
     validationResult,
     clearValidation,
-  } = useValidatedShiftMutations(restaurantId, dayShifts);
+  } = useValidatedShiftMutations(restaurantId, shifts);
 
   // ── Live-drag merge (Stage D2) ─────────────────────────────────────────────
   // Replaces the dragged shift's committed start/end with the drafted minutes
@@ -626,10 +631,12 @@ export function ShiftTimelineTab({
         dateStr={selectedDay}
         employees={employees}
         restaurantId={restaurantId}
-        dayShifts={dayShifts}
+        existingShifts={shifts}
         onClose={handlePopoverClose}
         validateAndUpdateTime={validateAndUpdateTime}
         forceUpdateTime={forceUpdateTime}
+        validateAndUpdateShift={validateAndUpdateShift}
+        forceUpdateShift={forceUpdateShift}
         validateAndCreateAtTime={validateAndCreateAtTime}
         forceCreateAtTime={forceCreateAtTime}
         deleteShift={deleteShift}

--- a/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
+++ b/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
@@ -8,6 +8,7 @@ import { CalendarOff } from 'lucide-react';
 import { isoToLocalMinutes } from '@/lib/shiftCoverage';
 import { summarizeCoverageHours, buildVerdict, summarizeAreaCoverage } from '@/lib/coverageSummary';
 import { useWeekStaffingSuggestions } from '@/hooks/useWeekStaffingSuggestions';
+import { useValidatedShiftMutations } from '@/hooks/useValidatedShiftMutations';
 import { useTimelineModel } from './useTimelineModel';
 import { CoverageVerdict } from './CoverageVerdict';
 import { CoverageChart } from './CoverageChart';
@@ -129,6 +130,18 @@ export function ShiftTimelineTab({
 
   // ── Filter shifts to the selected day ─────────────────────────────────────
   const dayShifts = useMemo(() => filterToDay(shifts, selectedDay, tz), [shifts, selectedDay, tz]);
+
+  // ── Validated mutation pipeline for the popover's edit/delete actions.
+  // Full overlay-state wiring (anchor-rect capture, single union activeOverlay,
+  // toast copy) is Stage B3 — this call site only needs to satisfy
+  // TimelineShiftPopover's save/delete props for now.
+  const {
+    validateAndUpdateTime,
+    forceUpdateTime,
+    deleteShift,
+    validationResult,
+    clearValidation,
+  } = useValidatedShiftMutations(restaurantId, dayShifts);
 
   // ── Timeline model (pure transform) ───────────────────────────────────────
   const model = useTimelineModel(dayShifts, employees, selectedDay, tz, groupBy, dayRecommendations);
@@ -351,7 +364,15 @@ export function ShiftTimelineTab({
         activeShift={activeShift}
         tz={tz}
         dateStr={selectedDay}
+        employees={employees}
+        restaurantId={restaurantId}
+        dayShifts={dayShifts}
         onClose={handlePopoverClose}
+        validateAndUpdateTime={validateAndUpdateTime}
+        forceUpdateTime={forceUpdateTime}
+        deleteShift={deleteShift}
+        validationResult={validationResult}
+        clearValidation={clearValidation}
       />
     </div>
   );

--- a/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
+++ b/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
@@ -16,13 +16,14 @@ import { CoverageStatusStrip } from './CoverageStatusStrip';
 import { CoverageDemandInfo } from './CoverageDemandInfo';
 import { AreaCoverageStrips } from './AreaCoverageStrips';
 import { TimelineAxis } from './TimelineAxis';
-import { TimelineLane } from './TimelineLane';
+import { TimelineLane, type LanePaintContext } from './TimelineLane';
 import { NowIndicator } from './NowIndicator';
 import { TimelineShiftPopover } from './TimelineShiftPopover';
 import { formatDayLabel } from '@/lib/shiftInterval';
 
 import type { Shift, Employee } from '@/types/scheduling';
 import type { GroupByMode } from '@/lib/scheduleGrouping';
+import type { PaintRange } from '@/lib/timelineDraft';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -45,15 +46,19 @@ interface ShiftTimelineTabProps {
 
 /**
  * Single union state driving the ONE `TimelineShiftPopover` instance across every
- * entry point (edit via bar click today; quick-add via paint/gap-click in Stage C).
- * Mutually exclusive by construction — never two popovers/overlays mounted at once.
- * `create` has no producer yet (paint-to-create lands in Stage C); the variant is
- * declared now so the popover's eventual create-mode prop threading doesn't require
- * another state-shape migration.
+ * entry point (edit via bar click; quick-add via paint/gap-click/keyboard "Add
+ * shift" button, wired in C2). Mutually exclusive by construction — never two
+ * popovers/overlays mounted at once.
+ *
+ * `create`'s `draft` + `laneContext` are now produced by `TimelineLane`'s paint
+ * layer (C2), but `TimelineShiftPopover` doesn't yet render a create-mode form
+ * (that's C3) — so `activeShift` stays null for `create` today and the popover
+ * renders nothing, same as before C2. The state shape is final so C3 only needs
+ * to add rendering, not another migration.
  */
 type ActiveOverlay =
   | { mode: 'edit'; shift: Shift; anchorRect: DOMRect | null }
-  | { mode: 'create'; anchorRect: DOMRect | null }
+  | { mode: 'create'; draft: PaintRange; laneContext: LanePaintContext; anchorRect: DOMRect | null }
   | null;
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -218,6 +223,18 @@ export function ShiftTimelineTab({
   }, []);
   const handleSelectShift = useCallback((shift: Shift) => {
     setActiveOverlay({ mode: 'edit', shift, anchorRect: pendingAnchorRectRef.current });
+  }, []);
+
+  /**
+   * Paint-to-create commit (C2): a lane's paint gesture (drag/click) or its
+   * visually-hidden "Add shift" button committed a range. Stage the `create`
+   * overlay with that range + lane context; `TimelineShiftPopover` doesn't
+   * render a create-mode form yet (C3), so this is a no-op visually until then.
+   * No anchor rect is available from the lane's plot region today — C3 wires
+   * proper ghost-bar anchoring alongside the popover's create variant.
+   */
+  const handlePaintCommit = useCallback((draft: PaintRange, laneContext: LanePaintContext) => {
+    setActiveOverlay({ mode: 'create', draft, laneContext, anchorRect: null });
   }, []);
 
   // ── Loading state ──────────────────────────────────────────────────────────
@@ -394,7 +411,9 @@ export function ShiftTimelineTab({
                   key={lane.key}
                   lane={lane}
                   minToPct={minToPct}
+                  window={model.window}
                   onSelect={handleSelectShift}
+                  onPaintCommit={handlePaintCommit}
                 />
               ))}
             </div>

--- a/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
+++ b/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
@@ -1,9 +1,10 @@
-import { useState, useMemo, useCallback, useRef } from 'react';
+import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
 
 import { Skeleton } from '@/components/ui/skeleton';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import { ToastAction } from '@/components/ui/toast';
 
-import { CalendarOff } from 'lucide-react';
+import { CalendarOff, Plus } from 'lucide-react';
 
 import { isoToLocalMinutes } from '@/lib/shiftCoverage';
 import {
@@ -14,6 +15,8 @@ import {
 } from '@/lib/coverageSummary';
 import { useWeekStaffingSuggestions } from '@/hooks/useWeekStaffingSuggestions';
 import { useValidatedShiftMutations } from '@/hooks/useValidatedShiftMutations';
+import { useCreateShift } from '@/hooks/useShifts';
+import { useToast } from '@/hooks/use-toast';
 import { useTimelineModel } from './useTimelineModel';
 import { CoverageVerdict } from './CoverageVerdict';
 import { CoverageChart } from './CoverageChart';
@@ -32,6 +35,23 @@ import type { Shift, Employee } from '@/types/scheduling';
 import type { GroupByMode } from '@/lib/scheduleGrouping';
 import { buildDraftShiftValues, mergeDraftShift, type PaintRange, type DragShiftDraft } from '@/lib/timelineDraft';
 import type { ShiftMinuteRange } from '@/lib/timelineDragMath';
+
+// ─── Constants (Fix 2 — visible "Add shift" button) ────────────────────────────
+
+/** Default 09:00–17:00 range dropped by the visible "Add shift" button (clamped into the day's window). */
+const DEFAULT_ADD_RANGE: PaintRange = { startMin: 9 * 60, endMin: 17 * 60 };
+
+/** How long a bar shows its transient change-highlight ring (design doc §Fix 3). */
+const HIGHLIGHT_DURATION_MS = 2000;
+
+/** Clamp a minute range into `window`, preserving its duration where possible. */
+function clampRangeToWindow(range: PaintRange, window: { startMin: number; endMin: number }): PaintRange {
+  const duration = Math.min(range.endMin - range.startMin, window.endMin - window.startMin);
+  let startMin = Math.min(Math.max(range.startMin, window.startMin), window.endMin - duration);
+  startMin = Math.max(startMin, window.startMin);
+  const endMin = startMin + duration;
+  return { startMin, endMin };
+}
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -193,6 +213,34 @@ export function ShiftTimelineTab({
     warnings: ConflictDialogData['warnings'];
   } | null>(null);
 
+  // ── Transient change highlight (Fix 3) ─────────────────────────────────────
+  // The id of the shift most recently moved/resized/edited, or null. Cleared
+  // automatically ~2s after being set. Never set for brand-new CREATEd shifts
+  // (their id is unknown client-side until the list refetches).
+  const [recentlyChangedShiftId, setRecentlyChangedShiftId] = useState<string | null>(null);
+  const highlightTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const flashHighlight = useCallback((shiftId: string) => {
+    if (highlightTimeoutRef.current !== null) {
+      clearTimeout(highlightTimeoutRef.current);
+    }
+    setRecentlyChangedShiftId(shiftId);
+    highlightTimeoutRef.current = setTimeout(() => {
+      setRecentlyChangedShiftId(null);
+      highlightTimeoutRef.current = null;
+    }, HIGHLIGHT_DURATION_MS);
+  }, []);
+
+  // Clear any in-flight highlight timeout on unmount so it never fires a
+  // setState against an unmounted component.
+  useEffect(() => {
+    return () => {
+      if (highlightTimeoutRef.current !== null) {
+        clearTimeout(highlightTimeoutRef.current);
+      }
+    };
+  }, []);
+
   // ── Staffing recommendations ───────────────────────────────────────────────
   const { daySuggestions, activeSettings } = useWeekStaffingSuggestions(restaurantId, weekDays, null);
 
@@ -209,9 +257,12 @@ export function ShiftTimelineTab({
   // `validateAndUpdateTime`/`forceUpdateTime` for drag/edit — it has no reassign
   // UI, so `validateAndReassign`/`forceReassign`/`validateAndCreate`/`forceCreate`
   // are intentionally not destructured here.
-  // Toasts on success/failure come from the underlying useShifts mutation hooks
-  // (useCreateShift/useUpdateShift/useDeleteShift) — this component doesn't call
-  // useToast directly.
+  // `silentDelete: true` suppresses the pipeline's own generic delete toast —
+  // `deleteShiftWithUndo` below shows the ONE toast with the Undo action
+  // instead (design doc §Fix 1 — avoid double-toasting).
+  // Toasts on update/create success/failure still come from the underlying
+  // useShifts mutation hooks — this component only calls useToast directly
+  // for the undo-delete flow.
   // Uses the full-week `shifts` (not `dayShifts`) so overlap/rest-gap checks also
   // see overnight shifts spilling in from the previous day and early-next-day
   // shifts spilling out from this one — a day-scoped array would miss both.
@@ -225,7 +276,52 @@ export function ShiftTimelineTab({
     deleteShift,
     validationResult,
     clearValidation,
-  } = useValidatedShiftMutations(restaurantId, shifts);
+  } = useValidatedShiftMutations(restaurantId, shifts, { silentDelete: true });
+
+  // ── Undo-delete flow (Fix 1) ───────────────────────────────────────────────
+  // Re-creates via useCreateShift directly (not the validated pipeline — the
+  // shift existed moments ago, no re-validation needed on Undo). `silent:
+  // true` suppresses useCreateShift's own "Shift created" toast; the "Shift
+  // restored" toast below stands in for it.
+  const createShift = useCreateShift({ silent: true });
+  const { toast } = useToast();
+
+  const deleteShiftWithUndo = useCallback(
+    (shift: Shift) => {
+      deleteShift(shift.id);
+
+      const handleUndo = () => {
+        void createShift
+          .mutateAsync({
+            restaurant_id: shift.restaurant_id,
+            employee_id: shift.employee_id,
+            start_time: shift.start_time,
+            end_time: shift.end_time,
+            position: shift.position,
+            break_duration: shift.break_duration,
+            notes: shift.notes,
+            status: shift.status,
+            is_published: shift.is_published,
+            locked: shift.locked,
+            source: shift.source,
+            shift_template_id: shift.shift_template_id,
+          })
+          .then(() => {
+            toast({ title: 'Shift restored' });
+          });
+      };
+
+      toast({
+        title: 'Shift deleted',
+        action: (
+          <ToastAction altText="Undo shift delete" onClick={handleUndo}>
+            Undo
+          </ToastAction>
+        ),
+      });
+    },
+    [deleteShift, createShift, toast],
+  );
 
   // ── Live-drag merge (Stage D2) ─────────────────────────────────────────────
   // Replaces the dragged shift's committed start/end with the drafted minutes
@@ -324,6 +420,26 @@ export function ShiftTimelineTab({
   );
 
   /**
+   * Visible "Add shift" button (Fix 2): opens the same `create` overlay as
+   * paint-to-create/gap-click, seeded with a default 09:00–17:00 range
+   * clamped into the day's visible window, no lane context (unfiltered
+   * employee picker, blank position), anchored to the button itself so the
+   * popover opens right below it.
+   */
+  const handleAddShiftClick = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      const range = clampRangeToWindow(DEFAULT_ADD_RANGE, model.window);
+      setActiveOverlay({
+        mode: 'create',
+        draft: range,
+        laneContext: null,
+        anchorRect: event.currentTarget.getBoundingClientRect(),
+      });
+    },
+    [model.window],
+  );
+
+  /**
    * Live drag-draft update (Stage D2): `TimelineBar` calls this on every
    * rAF-throttled pointermove frame with the in-flight range, and once more
    * with `null` when the gesture ends/cancels. Feeds `modelInputShifts` above
@@ -363,6 +479,7 @@ export function ShiftTimelineTab({
 
       if (outcome.updated) {
         setDragDraft(null);
+        flashHighlight(shiftId);
         return;
       }
 
@@ -382,7 +499,7 @@ export function ShiftTimelineTab({
       // confirm — snap back rather than leave a dangling draft.
       setDragDraft(null);
     },
-    [dayShifts, selectedDay, tz, validateAndUpdateTime],
+    [dayShifts, selectedDay, tz, validateAndUpdateTime, flashHighlight],
   );
 
   const handleDragConflictCancel = useCallback(() => {
@@ -397,8 +514,9 @@ export function ShiftTimelineTab({
     if (ok) {
       setDragConflict(null);
       setDragDraft(null);
+      flashHighlight(shift.id);
     }
-  }, [dragConflict, forceUpdateTime, selectedDay]);
+  }, [dragConflict, forceUpdateTime, selectedDay, flashHighlight]);
 
   const dragConflictData: ConflictDialogData | null = dragConflict
     ? {
@@ -434,6 +552,18 @@ export function ShiftTimelineTab({
       businessDate: selectedDay,
     };
   }, [activeOverlay, groupBy, selectedDay]);
+
+  /**
+   * Edit-mode Save success (Fix 3): flashes the transient highlight on the
+   * edited shift's bar. Never fired for create — `TimelineShiftPopover` only
+   * calls `onSaved` from its edit-mode Save/confirm-conflicts success paths.
+   */
+  const handleShiftSaved = useCallback(
+    (shift: Shift) => {
+      flashHighlight(shift.id);
+    },
+    [flashHighlight],
+  );
 
   // ── Loading state ──────────────────────────────────────────────────────────
   if (loading) {
@@ -490,21 +620,34 @@ export function ShiftTimelineTab({
         ))}
       </fieldset>
 
-      {/* Group-by toggle */}
-      <ToggleGroup
-        type="single"
-        value={groupBy}
-        onValueChange={(v) => { if (v === 'area' || v === 'position') setGroupBy(v); }}
-        className="h-8"
-        aria-label="Group shifts by"
-      >
-        <ToggleGroupItem value="area" className="h-8 px-3 text-[12px]">
-          Area
-        </ToggleGroupItem>
-        <ToggleGroupItem value="position" className="h-8 px-3 text-[12px]">
-          Position
-        </ToggleGroupItem>
-      </ToggleGroup>
+      <div className="flex items-center gap-2">
+        {/* Group-by toggle */}
+        <ToggleGroup
+          type="single"
+          value={groupBy}
+          onValueChange={(v) => { if (v === 'area' || v === 'position') setGroupBy(v); }}
+          className="h-8"
+          aria-label="Group shifts by"
+        >
+          <ToggleGroupItem value="area" className="h-8 px-3 text-[12px]">
+            Area
+          </ToggleGroupItem>
+          <ToggleGroupItem value="position" className="h-8 px-3 text-[12px]">
+            Position
+          </ToggleGroupItem>
+        </ToggleGroup>
+
+        {/* Visible "Add shift" button (Fix 2) — opens the create overlay for
+            the selected day with a default 09:00-17:00 range, no lane context. */}
+        <button
+          type="button"
+          onClick={handleAddShiftClick}
+          className="h-9 px-4 rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium inline-flex items-center gap-1.5"
+        >
+          <Plus className="h-3.5 w-3.5" aria-hidden="true" />
+          Add shift
+        </button>
+      </div>
     </div>
   );
 
@@ -614,6 +757,7 @@ export function ShiftTimelineTab({
                   onPaintCommit={handlePaintCommit}
                   onBarDraftChange={handleBarDraftChange}
                   onBarDragCommit={handleBarDragCommit}
+                  highlightedShiftId={recentlyChangedShiftId}
                 />
               ))}
             </div>
@@ -639,7 +783,8 @@ export function ShiftTimelineTab({
         forceUpdateShift={forceUpdateShift}
         validateAndCreateAtTime={validateAndCreateAtTime}
         forceCreateAtTime={forceCreateAtTime}
-        deleteShift={deleteShift}
+        onDelete={deleteShiftWithUndo}
+        onSaved={handleShiftSaved}
         validationResult={validationResult}
         clearValidation={clearValidation}
       />

--- a/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
+++ b/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
@@ -6,7 +6,12 @@ import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { CalendarOff } from 'lucide-react';
 
 import { isoToLocalMinutes } from '@/lib/shiftCoverage';
-import { summarizeCoverageHours, buildVerdict, summarizeAreaCoverage } from '@/lib/coverageSummary';
+import {
+  summarizeCoverageHours,
+  buildVerdict,
+  summarizeAreaCoverage,
+  mergeUnderStaffedRange,
+} from '@/lib/coverageSummary';
 import { useWeekStaffingSuggestions } from '@/hooks/useWeekStaffingSuggestions';
 import { useValidatedShiftMutations } from '@/hooks/useValidatedShiftMutations';
 import { useTimelineModel } from './useTimelineModel';
@@ -53,14 +58,21 @@ interface ShiftTimelineTabProps {
  * shift" button). Mutually exclusive by construction — never two
  * popovers/overlays mounted at once.
  *
- * `create`'s `draft` + `laneContext` are produced by `TimelineLane`'s paint layer
- * (C2) and resolved into `TimelineShiftPopover`'s `createDraft` prop (C3) via the
- * `createDraft` memo below, which maps the lane's grouping key to `position` or
- * `area` depending on `groupBy`.
+ * `create`'s `draft` + `laneContext` are produced either by `TimelineLane`'s paint
+ * layer (C2, `laneContext` always present) or by the coverage strip's gap-click
+ * (E, `laneContext` is `null` — no lane context: employee picker unfiltered,
+ * position blank) and resolved into `TimelineShiftPopover`'s `createDraft` prop
+ * via the `createDraft` memo below, which maps the lane's grouping key to
+ * `position` or `area` depending on `groupBy` when a lane context is present.
  */
 type ActiveOverlay =
   | { mode: 'edit'; shift: Shift; anchorRect: DOMRect | null }
-  | { mode: 'create'; draft: PaintRange; laneContext: LanePaintContext; anchorRect: DOMRect | null }
+  | {
+      mode: 'create';
+      draft: PaintRange;
+      laneContext: LanePaintContext | null;
+      anchorRect: DOMRect | null;
+    }
   | null;
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -270,6 +282,25 @@ export function ShiftTimelineTab({
   }, []);
 
   /**
+   * Gap-click commit (Stage E): a short (`delta < 0`) coverage-strip cell was
+   * clicked. `mergeUnderStaffedRange` expands the clicked hour into the
+   * contiguous understaffed run containing it (design doc §5 — adjacency is
+   * computed within the single day-wide hourly status strip; the merged range
+   * never crosses a covered/no-demand hour). Opens the same `create` overlay
+   * as paint-to-create, but with `laneContext: null` — no lane context, so the
+   * popover's employee picker is unfiltered and position starts blank. No
+   * anchor rect is available from the strip cell today (same limitation as
+   * paint-to-create); the popover falls back to its zero-size trigger.
+   */
+  const handleGapClick = useCallback(
+    (startMin: number) => {
+      const range = mergeUnderStaffedRange(hourlySummary, startMin);
+      setActiveOverlay({ mode: 'create', draft: range, laneContext: null, anchorRect: null });
+    },
+    [hourlySummary],
+  );
+
+  /**
    * Live drag-draft update (Stage D2): `TimelineBar` calls this on every
    * rAF-throttled pointermove frame with the in-flight range, and once more
    * with `null` when the gesture ends/cancels. Feeds `modelInputShifts` above
@@ -361,13 +392,22 @@ export function ShiftTimelineTab({
    * doc's "Paint-to-create + quick-add popover" section). `buildDraftShiftValues`
    * derives the initial editor values (+ prefilled position) from the
    * committed minute range.
+   *
+   * Gap-click (Stage E) commits with `laneContext: null` — no lane, so both
+   * `position` and `area` resolve to `null` (employee picker unfiltered,
+   * position starts blank; `TimelineShiftEditor`/`TimelineCreatePopoverContent`
+   * already treat `laneContext.position`/`.area` as optional/nullable).
    */
   const createDraft: TimelineCreateDraft | null = useMemo(() => {
     if (activeOverlay?.mode !== 'create') return null;
 
-    const laneKey = activeOverlay.laneContext.key;
+    const laneKey = activeOverlay.laneContext?.key ?? null;
     const resolvedLaneContext =
-      groupBy === 'position' ? { position: laneKey, area: null } : { position: null, area: laneKey };
+      laneKey === null
+        ? { position: null, area: null }
+        : groupBy === 'position'
+          ? { position: laneKey, area: null }
+          : { position: null, area: laneKey };
 
     return {
       values: buildDraftShiftValues(activeOverlay.draft, { laneContext: resolvedLaneContext }),
@@ -516,7 +556,7 @@ export function ShiftTimelineTab({
 
             {/* Per-hour status strip */}
             <div className="pl-[120px]">
-              <CoverageStatusStrip hours={hourlySummary} />
+              <CoverageStatusStrip hours={hourlySummary} onGapClick={handleGapClick} />
             </div>
 
             {/* Per-area scheduled strips — only when grouped by area */}

--- a/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
+++ b/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
@@ -19,11 +19,14 @@ import { TimelineAxis } from './TimelineAxis';
 import { TimelineLane, type LanePaintContext } from './TimelineLane';
 import { NowIndicator } from './NowIndicator';
 import { TimelineShiftPopover, type TimelineCreateDraft } from './TimelineShiftPopover';
+import { AvailabilityConflictDialog, type ConflictDialogData } from '@/components/scheduling/ShiftPlanner/AvailabilityConflictDialog';
 import { formatDayLabel } from '@/lib/shiftInterval';
+import { minutesToIso } from '@/lib/shiftTimeMath';
 
 import type { Shift, Employee } from '@/types/scheduling';
 import type { GroupByMode } from '@/lib/scheduleGrouping';
-import { buildDraftShiftValues, type PaintRange } from '@/lib/timelineDraft';
+import { buildDraftShiftValues, mergeDraftShift, type PaintRange, type DragShiftDraft } from '@/lib/timelineDraft';
+import type { ShiftMinuteRange } from '@/lib/timelineDragMath';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -139,6 +142,25 @@ export function ShiftTimelineTab({
   const [activeOverlay, setActiveOverlay] = useState<ActiveOverlay>(null);
   const [coverageView, setCoverageView] = useState<'area' | 'delta'>('area');
 
+  // ── Drag-move / edge-resize draft (Stage D2/D3) ───────────────────────────
+  // The in-flight drafted range for a bar currently being dragged/resized, or
+  // null when no drag is in progress. Merged into the model input below so
+  // the coverage chart/verdict/status strip update live during the drag
+  // (design doc §4 "Draft state"). Never written to React Query/localStorage —
+  // plain React state, cleared on commit/cancel.
+  const [dragDraft, setDragDraft] = useState<DragShiftDraft | null>(null);
+  // Pending conflict/warning issues surfaced by a drag-commit release, shown
+  // via the same AvailabilityConflictDialog the edit popover stacks (design
+  // doc §4 "Commit path"). Cancel snaps back (clears the draft without
+  // committing); confirm calls forceUpdateTime.
+  const [dragConflict, setDragConflict] = useState<{
+    shift: Shift;
+    startIso: string;
+    endIso: string;
+    conflicts: ConflictDialogData['conflicts'];
+    warnings: ConflictDialogData['warnings'];
+  } | null>(null);
+
   // ── Staffing recommendations ───────────────────────────────────────────────
   const { daySuggestions, activeSettings } = useWeekStaffingSuggestions(restaurantId, weekDays, null);
 
@@ -170,8 +192,18 @@ export function ShiftTimelineTab({
     clearValidation,
   } = useValidatedShiftMutations(restaurantId, dayShifts);
 
+  // ── Live-drag merge (Stage D2) ─────────────────────────────────────────────
+  // Replaces the dragged shift's committed start/end with the drafted minutes
+  // so the model — and therefore the coverage chart/verdict/status strip —
+  // reflects the in-flight drag on every rAF-throttled frame. Falls through
+  // to `dayShifts` unchanged when no drag is in progress.
+  const modelInputShifts = useMemo(
+    () => mergeDraftShift(dayShifts, dragDraft, selectedDay, tz),
+    [dayShifts, dragDraft, selectedDay, tz],
+  );
+
   // ── Timeline model (pure transform) ───────────────────────────────────────
-  const model = useTimelineModel(dayShifts, employees, selectedDay, tz, groupBy, dayRecommendations);
+  const model = useTimelineModel(modelInputShifts, employees, selectedDay, tz, groupBy, dayRecommendations);
 
   // ── Hourly coverage summary + verdict (feeds the new coverage panel) ───────
   const targetSplh = activeSettings?.target_splh ?? null;
@@ -236,6 +268,90 @@ export function ShiftTimelineTab({
   const handlePaintCommit = useCallback((draft: PaintRange, laneContext: LanePaintContext) => {
     setActiveOverlay({ mode: 'create', draft, laneContext, anchorRect: null });
   }, []);
+
+  /**
+   * Live drag-draft update (Stage D2): `TimelineBar` calls this on every
+   * rAF-throttled pointermove frame with the in-flight range, and once more
+   * with `null` when the gesture ends/cancels. Feeds `modelInputShifts` above
+   * so coverage recomputes live during the drag.
+   */
+  const handleBarDraftChange = useCallback((shiftId: string, range: ShiftMinuteRange | null) => {
+    setDragDraft(range ? { shiftId, startMin: range.startMin, endMin: range.endMin } : null);
+  }, []);
+
+  /**
+   * Drag/resize release (Stage D3): builds ISO instants via `minutesToIso`
+   * and routes through the same `validateAndUpdateTime` pipeline the edit
+   * popover's Save uses. On success the draft is cleared (the mutation's own
+   * optimistic `setQueriesData` update means the bar never jumps waiting for
+   * a refetch). On pending conflicts/warnings, the draft is KEPT (so the bar
+   * stays at the drafted position while the dialog is open) and the shared
+   * `AvailabilityConflictDialog` opens; cancel snaps back by clearing the
+   * draft, confirm force-applies the same ISO instants.
+   */
+  const handleBarDragCommit = useCallback(
+    async (shiftId: string, range: ShiftMinuteRange) => {
+      const shift = dayShifts.find((s) => s.id === shiftId);
+      if (!shift) {
+        setDragDraft(null);
+        return;
+      }
+
+      const startIso = minutesToIso(selectedDay, range.startMin, tz);
+      const endIso = minutesToIso(selectedDay, range.endMin, tz);
+
+      const outcome = await validateAndUpdateTime({
+        shift,
+        startIso,
+        endIso,
+        businessDate: selectedDay,
+      });
+
+      if (outcome.updated) {
+        setDragDraft(null);
+        return;
+      }
+
+      if (outcome.pendingConflicts?.length || outcome.pendingWarnings?.length) {
+        setDragConflict({
+          shift,
+          startIso,
+          endIso,
+          conflicts: outcome.pendingConflicts ?? [],
+          warnings: outcome.pendingWarnings ?? [],
+        });
+        return;
+      }
+
+      // Validation failed outright (e.g. a thrown lock/interval error) with no
+      // pending issues to confirm — snap back rather than leave a dangling draft.
+      setDragDraft(null);
+    },
+    [dayShifts, selectedDay, tz, validateAndUpdateTime],
+  );
+
+  const handleDragConflictCancel = useCallback(() => {
+    setDragConflict(null);
+    setDragDraft(null);
+  }, []);
+
+  const handleDragConflictConfirm = useCallback(async () => {
+    if (!dragConflict) return;
+    const { shift, startIso, endIso } = dragConflict;
+    const ok = await forceUpdateTime({ shift, startIso, endIso, businessDate: selectedDay });
+    if (ok) {
+      setDragConflict(null);
+      setDragDraft(null);
+    }
+  }, [dragConflict, forceUpdateTime, selectedDay]);
+
+  const dragConflictData: ConflictDialogData | null = dragConflict
+    ? {
+        employeeName: employees.find((e) => e.id === dragConflict.shift.employee_id)?.name ?? 'This employee',
+        conflicts: dragConflict.conflicts,
+        warnings: dragConflict.warnings,
+      }
+    : null;
 
   /**
    * Resolve the `create` overlay into `TimelineShiftPopover`'s `createDraft`
@@ -437,6 +553,8 @@ export function ShiftTimelineTab({
                   window={model.window}
                   onSelect={handleSelectShift}
                   onPaintCommit={handlePaintCommit}
+                  onBarDraftChange={handleBarDraftChange}
+                  onBarDragCommit={handleBarDragCommit}
                 />
               ))}
             </div>
@@ -463,6 +581,18 @@ export function ShiftTimelineTab({
         deleteShift={deleteShift}
         validationResult={validationResult}
         clearValidation={clearValidation}
+      />
+
+      {/* Drag-commit conflict dialog (Stage D3) — the same AvailabilityConflictDialog
+          the edit popover stacks, mounted separately here since a bar drag never
+          opens the popover. Mutually exclusive with the popover's own instance in
+          practice: dragging a bar doesn't set activeOverlay. */}
+      <AvailabilityConflictDialog
+        open={dragConflict !== null}
+        data={dragConflictData}
+        timezone={tz}
+        onConfirm={handleDragConflictConfirm}
+        onCancel={handleDragConflictCancel}
       />
     </div>
   );

--- a/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
+++ b/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
@@ -120,6 +120,26 @@ function filterToDay(shifts: Shift[], dayStr: string, tz: string): Shift[] {
   });
 }
 
+/** Lane context resolved for the `create` overlay's `TimelineCreateDraft`. */
+interface ResolvedLaneContext {
+  position: string | null;
+  area: string | null;
+}
+
+/**
+ * Resolve a lane's grouping key into `{ position, area }` for the `create`
+ * overlay: `laneKey` maps to `position` when grouped by position, or `area`
+ * when grouped by area (a shift's area is derived from its employee, never
+ * stored directly). `laneKey === null` means no lane context at all
+ * (gap-click entry point) — both resolve to null so the employee picker is
+ * unfiltered and position starts blank.
+ */
+export function resolveLaneContext(laneKey: string | null, groupBy: GroupByMode): ResolvedLaneContext {
+  if (laneKey === null) return { position: null, area: null };
+  if (groupBy === 'position') return { position: laneKey, area: null };
+  return { position: null, area: laneKey };
+}
+
 // ─── Component ────────────────────────────────────────────────────────────────
 
 /**
@@ -185,20 +205,18 @@ export function ShiftTimelineTab({
   const dayShifts = useMemo(() => filterToDay(shifts, selectedDay, tz), [shifts, selectedDay, tz]);
 
   // ── Validated mutation pipeline — the single instance shared by the popover's
-  // edit/delete flows (create/reassign are mounted here too, ahead of Stage C's
-  // quick-add wiring, so this hook call site never needs to migrate again).
+  // edit/delete flows. The timeline only uses the `*AtTime` create variants and
+  // `validateAndUpdateTime`/`forceUpdateTime` for drag/edit — it has no reassign
+  // UI, so `validateAndReassign`/`forceReassign`/`validateAndCreate`/`forceCreate`
+  // are intentionally not destructured here.
   // Toasts on success/failure come from the underlying useShifts mutation hooks
   // (useCreateShift/useUpdateShift/useDeleteShift) — this component doesn't call
   // useToast directly.
   const {
-    validateAndCreate,
-    forceCreate,
     validateAndCreateAtTime,
     forceCreateAtTime,
     validateAndUpdateTime,
     forceUpdateTime,
-    validateAndReassign,
-    forceReassign,
     deleteShift,
     validationResult,
     clearValidation,
@@ -402,12 +420,7 @@ export function ShiftTimelineTab({
     if (activeOverlay?.mode !== 'create') return null;
 
     const laneKey = activeOverlay.laneContext?.key ?? null;
-    const resolvedLaneContext =
-      laneKey === null
-        ? { position: null, area: null }
-        : groupBy === 'position'
-          ? { position: laneKey, area: null }
-          : { position: null, area: laneKey };
+    const resolvedLaneContext = resolveLaneContext(laneKey, groupBy);
 
     return {
       values: buildDraftShiftValues(activeOverlay.draft, { laneContext: resolvedLaneContext }),

--- a/src/components/scheduling/ShiftTimeline/TimelineBar.tsx
+++ b/src/components/scheduling/ShiftTimeline/TimelineBar.tsx
@@ -155,7 +155,7 @@ function TimelineBarImpl({
             'pointer-events-none z-10',
           )}
         >
-          {minutesToCompact(dragState.startMin)} – {minutesToCompact(dragState.endMin % 1440)}
+          {minutesToCompact(dragState.startMin % 1440)} – {minutesToCompact(dragState.endMin % 1440)}
         </div>
       )}
     </div>

--- a/src/components/scheduling/ShiftTimeline/TimelineBar.tsx
+++ b/src/components/scheduling/ShiftTimeline/TimelineBar.tsx
@@ -1,5 +1,11 @@
+import { memo, useCallback } from 'react';
+
 import { cn } from '@/lib/utils';
+import { minutesToCompact } from '@/lib/shiftCoverage';
+import { useTimelineBarDrag } from './useTimelineBarDrag';
 import type { TimelineBar as TimelineBarModel } from './useTimelineModel';
+import type { TimelineWindow } from '@/lib/timelineModel';
+import type { ShiftMinuteRange } from '@/lib/timelineDragMath';
 import type { Shift } from '@/types/scheduling';
 
 interface TimelineBarProps {
@@ -7,8 +13,20 @@ interface TimelineBarProps {
   readonly bar: TimelineBarModel;
   /** Maps a minute value to a horizontal percent within [0, 100]. */
   readonly minToPct: (min: number) => number;
-  /** Called when the user clicks or activates the bar. */
+  /** Called when the user clicks, taps, or activates the bar via keyboard. */
   readonly onSelect: (shift: Shift) => void;
+  /** The visible time window — needed to invert pointer position back to minutes. */
+  readonly window: TimelineWindow;
+  /** Returns the lane's plot region bounding rect, read fresh on every pointer event. */
+  readonly getPlotRect: () => DOMRect | null;
+  /**
+   * Called on every rAF-throttled frame while dragging, with the live
+   * drafted range (feeds Stage D2's live coverage merge). Called with `null`
+   * when a drag ends, is cancelled, or never starts.
+   */
+  readonly onDraftChange: (shiftId: string, range: ShiftMinuteRange | null) => void;
+  /** Called on pointerup with the final drafted range — the caller commits it via validateAndUpdateTime. */
+  readonly onDragCommit: (shiftId: string, range: ShiftMinuteRange) => void;
 }
 
 /**
@@ -18,34 +36,150 @@ interface TimelineBarProps {
  * - Position: `left` / `width` derived from `minToPct`.
  * - Color: `bar.color` Tailwind classes (bg + border + text) from `getPositionColors`.
  * - Accessibility: `aria-label` with comma-separated fields for reliable SR pronunciation.
+ *   Keyboard Enter/Space still calls `onSelect` via the native `<button>` click
+ *   synthesis — the pointer-drag wiring only listens for pointer events, so it
+ *   never intercepts keyboard activation.
  * - Label is truncated with `truncate` so narrow bars stay tidy.
+ *
+ * Drag-move / edge-resize (Stage D1): the bar body is a move handle; two
+ * narrow edge strips are resize handles. `useTimelineBarDrag` disambiguates a
+ * tap (< 5px movement — a no-op, left to the native `onClick` below) from a
+ * real drag (calls `onDraftChange` each frame, `onDragCommit` on release).
+ * Locked shifts and touch pointers never drag — `touch-action: none` is
+ * scoped to the body + handles only so the lane's own pan-to-scroll behavior
+ * is unaffected.
+ *
+ * Memoized (Stage D1b): re-renders only when this bar's identity/geometry/
+ * label/color actually changes, so a drag frame only re-renders the dragged
+ * row while sibling bars in other lanes stay untouched.
  */
-export function TimelineBar({ bar, minToPct, onSelect }: TimelineBarProps) {
+function TimelineBarImpl({
+  bar,
+  minToPct,
+  onSelect,
+  window,
+  getPlotRect,
+  onDraftChange,
+  onDragCommit,
+}: TimelineBarProps) {
   const { leftMin, endMin, label, ariaLabel, color, shift } = bar;
+  const locked = shift.locked;
 
-  const left = minToPct(leftMin);
-  const right = minToPct(endMin);
+  const handleTap = useCallback(() => onSelect(shift), [onSelect, shift]);
+
+  const handleDraftChange = useCallback(
+    (range: ShiftMinuteRange | null) => onDraftChange(shift.id, range),
+    [onDraftChange, shift.id],
+  );
+
+  const handleCommit = useCallback(
+    (range: ShiftMinuteRange) => onDragCommit(shift.id, range),
+    [onDragCommit, shift.id],
+  );
+
+  const getWindow = useCallback(() => window, [window]);
+
+  const { dragState, handleBodyPointerDown, handleStartHandlePointerDown, handleEndHandlePointerDown, handlePointerMove, handlePointerUp, handlePointerCancel } =
+    useTimelineBarDrag({
+      original: { startMin: leftMin, endMin },
+      locked,
+      getPlotRect,
+      getWindow,
+      onDraftChange: handleDraftChange,
+      onCommit: handleCommit,
+    });
+
+  const displayLeftMin = dragState?.startMin ?? leftMin;
+  const displayEndMin = dragState?.endMin ?? endMin;
+
+  const left = minToPct(displayLeftMin);
+  const right = minToPct(displayEndMin);
   const width = right - left;
 
   return (
-    <button
-      type="button"
-      aria-label={ariaLabel}
-      onClick={() => onSelect(shift)}
-      className={cn(
-        'absolute inset-y-0.5 rounded-md border px-1.5 text-left text-[11px] font-medium truncate',
-        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
-        'transition-opacity hover:opacity-90 active:opacity-80',
-        color.bg,
-        color.border,
-        color.text,
-      )}
-      style={{
-        left: `${left}%`,
-        width: `${Math.max(width, 1)}%`,
-      }}
+    <div
+      className="absolute inset-y-0.5"
+      style={{ left: `${left}%`, width: `${Math.max(width, 1)}%` }}
     >
-      {label}
-    </button>
+      <button
+        type="button"
+        aria-label={ariaLabel}
+        onClick={handleTap}
+        onPointerDown={handleBodyPointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerCancel}
+        className={cn(
+          'relative h-full w-full rounded-md border px-1.5 text-left text-[11px] font-medium truncate',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+          'transition-opacity hover:opacity-90 active:opacity-80',
+          !locked && 'cursor-grab touch-none',
+          color.bg,
+          color.border,
+          color.text,
+        )}
+      >
+        {label}
+
+        {!locked && (
+          <>
+            <span
+              data-testid="resize-handle-start"
+              aria-hidden="true"
+              onPointerDown={handleStartHandlePointerDown}
+              onPointerMove={handlePointerMove}
+              onPointerUp={handlePointerUp}
+              onPointerCancel={handlePointerCancel}
+              className="absolute inset-y-0 left-0 w-1.5 cursor-ew-resize touch-none"
+            />
+            <span
+              data-testid="resize-handle-end"
+              aria-hidden="true"
+              onPointerDown={handleEndHandlePointerDown}
+              onPointerMove={handlePointerMove}
+              onPointerUp={handlePointerUp}
+              onPointerCancel={handlePointerCancel}
+              className="absolute inset-y-0 right-0 w-1.5 cursor-ew-resize touch-none"
+            />
+          </>
+        )}
+      </button>
+
+      {dragState && (
+        <div
+          data-testid="drag-time-readout"
+          aria-hidden="true"
+          className={cn(
+            'absolute -top-6 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-md border px-1.5 py-0.5',
+            'bg-popover text-popover-foreground border-border/40 text-[11px] font-medium shadow-sm',
+            'pointer-events-none z-10',
+          )}
+        >
+          {minutesToCompact(dragState.startMin)} – {minutesToCompact(dragState.endMin % 1440)}
+        </div>
+      )}
+    </div>
   );
 }
+
+function areEqual(prev: TimelineBarProps, next: TimelineBarProps): boolean {
+  return (
+    prev.bar.shift.id === next.bar.shift.id &&
+    prev.bar.leftMin === next.bar.leftMin &&
+    prev.bar.endMin === next.bar.endMin &&
+    prev.bar.row === next.bar.row &&
+    prev.bar.label === next.bar.label &&
+    prev.bar.ariaLabel === next.bar.ariaLabel &&
+    prev.bar.color === next.bar.color &&
+    prev.bar.shift.locked === next.bar.shift.locked &&
+    prev.minToPct === next.minToPct &&
+    prev.onSelect === next.onSelect &&
+    prev.window.startMin === next.window.startMin &&
+    prev.window.endMin === next.window.endMin &&
+    prev.getPlotRect === next.getPlotRect &&
+    prev.onDraftChange === next.onDraftChange &&
+    prev.onDragCommit === next.onDragCommit
+  );
+}
+
+export const TimelineBar = memo(TimelineBarImpl, areEqual);

--- a/src/components/scheduling/ShiftTimeline/TimelineBar.tsx
+++ b/src/components/scheduling/ShiftTimeline/TimelineBar.tsx
@@ -27,6 +27,13 @@ interface TimelineBarProps {
   readonly onDraftChange: (shiftId: string, range: ShiftMinuteRange | null) => void;
   /** Called on pointerup with the final drafted range — the caller commits it via validateAndUpdateTime. */
   readonly onDragCommit: (shiftId: string, range: ShiftMinuteRange) => void;
+  /**
+   * True for ~2s right after this bar's shift was moved/resized/edited
+   * (design doc §Fix 3 — transient change highlight). Renders a brief
+   * `ring-2 ring-ring` outline; never set for brand-new CREATEd shifts (their
+   * id isn't known client-side until refetch).
+   */
+  readonly highlighted?: boolean;
 }
 
 /**
@@ -64,6 +71,7 @@ function TimelineBarImpl({
   getPlotRect,
   onDraftChange,
   onDragCommit,
+  highlighted = false,
 }: TimelineBarProps) {
   const { leftMin, endMin, label, ariaLabel, color, shift } = bar;
   const locked = shift.locked;
@@ -124,6 +132,7 @@ function TimelineBarImpl({
           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
           'transition-opacity hover:opacity-90 active:opacity-80',
           !locked && 'cursor-grab touch-none',
+          highlighted && 'ring-2 ring-ring',
           color.bg,
           color.border,
           color.text,
@@ -188,7 +197,8 @@ function areEqual(prev: TimelineBarProps, next: TimelineBarProps): boolean {
     prev.window.endMin === next.window.endMin &&
     prev.getPlotRect === next.getPlotRect &&
     prev.onDraftChange === next.onDraftChange &&
-    prev.onDragCommit === next.onDragCommit
+    prev.onDragCommit === next.onDragCommit &&
+    prev.highlighted === next.highlighted
   );
 }
 

--- a/src/components/scheduling/ShiftTimeline/TimelineBar.tsx
+++ b/src/components/scheduling/ShiftTimeline/TimelineBar.tsx
@@ -47,7 +47,10 @@ interface TimelineBarProps {
  * real drag (calls `onDraftChange` each frame, `onDragCommit` on release).
  * Locked shifts and touch pointers never drag — `touch-action: none` is
  * scoped to the body + handles only so the lane's own pan-to-scroll behavior
- * is unaffected.
+ * is unaffected. After a real drag, the browser still dispatches a trailing
+ * `click` on the bar; `handleTap` consults `consumeJustDragged()` and skips
+ * `onSelect` for exactly that one click (Codex P2 fix) so a drag never also
+ * reopens the edit popover.
  *
  * Memoized (Stage D1b): re-renders only when this bar's identity/geometry/
  * label/color actually changes, so a drag frame only re-renders the dragged
@@ -65,8 +68,6 @@ function TimelineBarImpl({
   const { leftMin, endMin, label, ariaLabel, color, shift } = bar;
   const locked = shift.locked;
 
-  const handleTap = useCallback(() => onSelect(shift), [onSelect, shift]);
-
   const handleDraftChange = useCallback(
     (range: ShiftMinuteRange | null) => onDraftChange(shift.id, range),
     [onDraftChange, shift.id],
@@ -79,7 +80,7 @@ function TimelineBarImpl({
 
   const getWindow = useCallback(() => window, [window]);
 
-  const { dragState, handleBodyPointerDown, handleStartHandlePointerDown, handleEndHandlePointerDown, handlePointerMove, handlePointerUp, handlePointerCancel } =
+  const { dragState, handleBodyPointerDown, handleStartHandlePointerDown, handleEndHandlePointerDown, handlePointerMove, handlePointerUp, handlePointerCancel, consumeJustDragged } =
     useTimelineBarDrag({
       original: { startMin: leftMin, endMin },
       locked,
@@ -88,6 +89,15 @@ function TimelineBarImpl({
       onDraftChange: handleDraftChange,
       onCommit: handleCommit,
     });
+
+  const handleTap = useCallback(() => {
+    // Skip the browser's trailing synthetic click after a real drag commits
+    // (Codex P2 fix) — otherwise every drag-release would also reopen the
+    // edit popover via onSelect. consumeJustDragged() is one-shot: it only
+    // ever suppresses the single click immediately following a drag.
+    if (consumeJustDragged()) return;
+    onSelect(shift);
+  }, [consumeJustDragged, onSelect, shift]);
 
   const displayLeftMin = dragState?.startMin ?? leftMin;
   const displayEndMin = dragState?.endMin ?? endMin;

--- a/src/components/scheduling/ShiftTimeline/TimelineLane.tsx
+++ b/src/components/scheduling/ShiftTimeline/TimelineLane.tsx
@@ -176,6 +176,16 @@ function TimelineLaneImpl({
     onPaintCommit(range, laneContext);
   }, [clearLongPressTimer, onPaintCommit, laneContext]);
 
+  const handlePointerCancel = useCallback(() => {
+    // A browser-initiated pointercancel (e.g. an OS gesture takes over the
+    // pointer) must DISCARD the in-progress paint, not commit it — unlike
+    // pointerup, which is a deliberate release. Clear the long-press timer
+    // and the draft directly, without calling endPaint/onPaintCommit.
+    clearLongPressTimer();
+    pointerStartRef.current = null;
+    if (draftRef.current) setDraft(null);
+  }, [clearLongPressTimer]);
+
   const handlePointerLeave = useCallback(() => {
     // A pointer leaving the plot mid-drag (without pointerup) shouldn't
     // silently commit — treat it like Escape: cancel the in-progress paint.
@@ -225,7 +235,7 @@ function TimelineLaneImpl({
         onPointerDown={handlePointerDown}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}
-        onPointerCancel={handlePointerUp}
+        onPointerCancel={handlePointerCancel}
         onPointerLeave={handlePointerLeave}
         onKeyDown={handleKeyDown}
       >

--- a/src/components/scheduling/ShiftTimeline/TimelineLane.tsx
+++ b/src/components/scheduling/ShiftTimeline/TimelineLane.tsx
@@ -1,18 +1,44 @@
+import { useRef, useState, useCallback, useMemo } from 'react';
+
 import type { TimelineLane as TimelineLaneModel } from './useTimelineModel';
+import type { TimelineWindow } from '@/lib/timelineModel';
 import type { Shift } from '@/types/scheduling';
+import type { PaintDraft, PaintRange } from '@/lib/timelineDraft';
+import { pointerToMinutes, beginPaint, updatePaint, endPaint, DEFAULT_CLICK_DURATION_MIN } from '@/lib/timelineDraft';
 import { TimelineBar } from './TimelineBar';
+import { cn } from '@/lib/utils';
+
+/** Lane context passed to `onPaintCommit`, keyed by the lane's grouping value. */
+export interface LanePaintContext {
+  /** The lane's `key` (position or area value; empty string = unassigned). */
+  key: string;
+}
 
 interface TimelineLaneProps {
   /** Lane data from useTimelineModel (label, hours, bars). */
   readonly lane: TimelineLaneModel;
   /** Maps a minute value to a horizontal percent within [0, 100]. */
   readonly minToPct: (min: number) => number;
+  /** Visible time window — needed to invert pointer position back to minutes. */
+  readonly window: TimelineWindow;
   /** Called when the user clicks a shift bar. */
   readonly onSelect: (shift: Shift) => void;
+  /**
+   * Called when a paint gesture (drag or click) on the lane's empty plot
+   * region — or the visually-hidden "Add shift" button — commits a range.
+   * The parent opens the quick-add popover with this range + lane context.
+   */
+  readonly onPaintCommit: (range: PaintRange, laneContext: LanePaintContext) => void;
 }
 
 /** Height in pixels for each stacked bar row within a lane. */
 const ROW_HEIGHT_PX = 28;
+
+/** Touch long-press duration (ms) before painting starts, so a plain scroll gesture isn't hijacked. */
+const LONG_PRESS_MS = 500;
+
+/** Pointer movement (px) during the long-press wait that cancels it (treated as a scroll, not a hold). */
+const LONG_PRESS_MOVE_CANCEL_PX = 10;
 
 /**
  * A single area/position band in the timeline.
@@ -21,11 +47,127 @@ const ROW_HEIGHT_PX = 28;
  *  - Sticky-left label column: section name · shift count · total hours.
  *  - Relative-positioned plot region whose height is `(maxRow + 1) × ROW_HEIGHT_PX`.
  *  - Each `TimelineBar` is placed at `top: bar.row × ROW_HEIGHT_PX`.
+ *
+ * Paint-to-create (Stage C2): pointer handlers on the plot region let a manager
+ * drag out a ghost bar (mouse) or long-press-then-drag (touch, 500ms, so
+ * horizontal scroll still works) to stage a new shift's time range. A plain
+ * click/tap (no drag) drops a default-duration ghost at the snapped point. All
+ * range math is delegated to the pure `timelineDraft` helpers — this component
+ * only owns the DOM wiring + ghost rendering. Escape cancels an in-progress
+ * paint. A visually-hidden "Add shift to <lane>" button gives keyboard users
+ * the same entry point without any pointer gesture.
  */
-export function TimelineLane({ lane, minToPct, onSelect }: TimelineLaneProps) {
+export function TimelineLane({ lane, minToPct, window, onSelect, onPaintCommit }: TimelineLaneProps) {
   const { label, hours, bars } = lane;
   const maxRow = bars.reduce((max, b) => Math.max(max, b.row), 0);
   const plotHeight = (maxRow + 1) * ROW_HEIGHT_PX;
+  // Memoized so it's a stable dependency for the useCallback handlers below
+  // (a fresh object literal on every render would force those handlers to be
+  // recreated every render too, defeating useCallback's purpose here).
+  const laneContext: LanePaintContext = useMemo(() => ({ key: lane.key }), [lane.key]);
+  const displayLabel = label || 'Unassigned';
+
+  const plotRef = useRef<HTMLDivElement>(null);
+  const [draft, setDraft] = useState<PaintDraft | null>(null);
+  // Refs so pointer handlers registered at pointerdown always read the latest
+  // window/draft rather than a stale closure (lesson 2026-06-04).
+  const windowRef = useRef(window);
+  windowRef.current = window;
+  const draftRef = useRef<PaintDraft | null>(null);
+  draftRef.current = draft;
+  const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const touchStartRef = useRef<{ clientX: number; pointerId: number } | null>(null);
+
+  const clearLongPressTimer = useCallback(() => {
+    if (longPressTimerRef.current !== null) {
+      clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+  }, []);
+
+  const startPaint = useCallback((clientX: number) => {
+    const rect = plotRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const pointerMin = pointerToMinutes(clientX, rect, windowRef.current);
+    setDraft(beginPaint(pointerMin, windowRef.current));
+  }, []);
+
+  const handlePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      // Only the plot background itself starts a paint — bars have their own
+      // onClick and must not trigger a paint gesture underneath them.
+      if (event.target !== event.currentTarget) return;
+
+      if (event.pointerType === 'touch') {
+        touchStartRef.current = { clientX: event.clientX, pointerId: event.pointerId };
+        clearLongPressTimer();
+        longPressTimerRef.current = setTimeout(() => {
+          longPressTimerRef.current = null;
+          startPaint(event.clientX);
+        }, LONG_PRESS_MS);
+        return;
+      }
+
+      startPaint(event.clientX);
+    },
+    [clearLongPressTimer, startPaint],
+  );
+
+  const handlePointerMove = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      // Pending long-press (touch, timer not yet fired): cancel on movement
+      // past the threshold so a horizontal scroll isn't hijacked as a paint.
+      if (longPressTimerRef.current !== null) {
+        const start = touchStartRef.current;
+        if (start && Math.abs(event.clientX - start.clientX) > LONG_PRESS_MOVE_CANCEL_PX) {
+          clearLongPressTimer();
+        }
+        return;
+      }
+
+      const current = draftRef.current;
+      if (!current) return;
+
+      const rect = plotRef.current?.getBoundingClientRect();
+      if (!rect) return;
+      const pointerMin = pointerToMinutes(event.clientX, rect, windowRef.current);
+      const movedPx = Math.abs(event.clientX - (touchStartRef.current?.clientX ?? current.pointerDownMin));
+      setDraft(updatePaint(current, pointerMin, windowRef.current, movedPx));
+    },
+    [clearLongPressTimer],
+  );
+
+  const handlePointerUp = useCallback(() => {
+    clearLongPressTimer();
+    touchStartRef.current = null;
+
+    const current = draftRef.current;
+    if (!current) return;
+
+    setDraft(null);
+    const range = endPaint(current, windowRef.current);
+    onPaintCommit(range, laneContext);
+  }, [clearLongPressTimer, onPaintCommit, laneContext]);
+
+  const handlePointerLeave = useCallback(() => {
+    // A pointer leaving the plot mid-drag (without pointerup) shouldn't
+    // silently commit — treat it like Escape: cancel the in-progress paint.
+    // Pending long-press timers are unaffected (finger hasn't started dragging).
+    if (draftRef.current) setDraft(null);
+  }, []);
+
+  const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape' && draftRef.current) {
+      setDraft(null);
+      clearLongPressTimer();
+    }
+  }, [clearLongPressTimer]);
+
+  const handleAddShiftClick = useCallback(() => {
+    const w = windowRef.current;
+    const duration = Math.min(DEFAULT_CLICK_DURATION_MIN, w.endMin - w.startMin);
+    onPaintCommit({ startMin: w.startMin, endMin: w.startMin + duration }, laneContext);
+  }, [onPaintCommit, laneContext]);
 
   return (
     <div className="flex border-b border-border/40 last:border-b-0">
@@ -34,16 +176,31 @@ export function TimelineLane({ lane, minToPct, onSelect }: TimelineLaneProps) {
         className="sticky left-0 z-10 flex flex-col justify-center min-w-[120px] w-[120px] shrink-0 bg-background border-r border-border/40 px-3 py-2"
         style={{ minHeight: plotHeight }}
       >
-        <span className="text-[13px] font-medium text-foreground truncate">{label || 'Unassigned'}</span>
+        <span className="text-[13px] font-medium text-foreground truncate">{displayLabel}</span>
         <span className="text-[11px] text-muted-foreground mt-0.5">
           {bars.length} shift{bars.length !== 1 ? 's' : ''} · {hours.toFixed(1)}h
         </span>
+        <button
+          type="button"
+          onClick={handleAddShiftClick}
+          className="sr-only"
+        >
+          {`Add shift to ${displayLabel} lane`}
+        </button>
       </div>
 
-      {/* Plot region: bars stacked by row */}
+      {/* Plot region: bars stacked by row, plus the paint-to-create pointer surface */}
       <div
-        className="relative flex-1"
+        ref={plotRef}
+        data-testid="lane-plot"
+        className="relative flex-1 touch-pan-x touch-pan-y"
         style={{ height: Math.max(plotHeight, ROW_HEIGHT_PX) }}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+        onPointerLeave={handlePointerLeave}
+        onKeyDown={handleKeyDown}
       >
         {bars.map((bar) => (
           <div
@@ -61,6 +218,23 @@ export function TimelineLane({ lane, minToPct, onSelect }: TimelineLaneProps) {
             />
           </div>
         ))}
+
+        {draft && (
+          <div
+            data-testid="paint-ghost"
+            aria-hidden="true"
+            className={cn(
+              'absolute inset-y-0.5 rounded-md border border-dashed border-foreground/40 bg-foreground/5',
+              'pointer-events-none',
+            )}
+            style={{
+              left: `${minToPct(draft.startMin)}%`,
+              width: `${Math.max(minToPct(draft.endMin) - minToPct(draft.startMin), 1)}%`,
+              top: plotHeight,
+              height: ROW_HEIGHT_PX,
+            }}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/components/scheduling/ShiftTimeline/TimelineLane.tsx
+++ b/src/components/scheduling/ShiftTimeline/TimelineLane.tsx
@@ -34,6 +34,11 @@ interface TimelineLaneProps {
   readonly onBarDraftChange: (shiftId: string, range: ShiftMinuteRange | null) => void;
   /** Forwarded to each `TimelineBar` — fires on drag/resize release (Stage D3). */
   readonly onBarDragCommit: (shiftId: string, range: ShiftMinuteRange) => void;
+  /**
+   * The shift id that should render a transient change highlight, or null
+   * (design doc §Fix 3). Forwarded to the matching `TimelineBar` as `highlighted`.
+   */
+  readonly highlightedShiftId?: string | null;
 }
 
 /** Height in pixels for each stacked bar row within a lane. */
@@ -70,6 +75,7 @@ function TimelineLaneImpl({
   onPaintCommit,
   onBarDraftChange,
   onBarDragCommit,
+  highlightedShiftId = null,
 }: TimelineLaneProps) {
   const { label, hours, bars } = lane;
   const maxRow = bars.reduce((max, b) => Math.max(max, b.row), 0);
@@ -256,6 +262,7 @@ function TimelineLaneImpl({
               getPlotRect={getPlotRect}
               onDraftChange={onBarDraftChange}
               onDragCommit={onBarDragCommit}
+              highlighted={bar.shift.id === highlightedShiftId}
             />
           </div>
         ))}
@@ -290,7 +297,8 @@ function areLaneEqual(prev: TimelineLaneProps, next: TimelineLaneProps): boolean
     prev.onSelect === next.onSelect &&
     prev.onPaintCommit === next.onPaintCommit &&
     prev.onBarDraftChange === next.onBarDraftChange &&
-    prev.onBarDragCommit === next.onBarDragCommit
+    prev.onBarDragCommit === next.onBarDragCommit &&
+    prev.highlightedShiftId === next.highlightedShiftId
   );
 }
 

--- a/src/components/scheduling/ShiftTimeline/TimelineLane.tsx
+++ b/src/components/scheduling/ShiftTimeline/TimelineLane.tsx
@@ -92,7 +92,12 @@ function TimelineLaneImpl({
   const draftRef = useRef<PaintDraft | null>(null);
   draftRef.current = draft;
   const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const touchStartRef = useRef<{ clientX: number; pointerId: number } | null>(null);
+  // Tracks pointer-down clientX for BOTH mouse and touch gestures (renamed
+  // from `touchStartRef`, which the touch long-press logic still uses to
+  // detect a pre-long-press scroll) — `handlePointerMove` needs this for
+  // EVERY pointer type to compute `movedPx` in pixels; using it only for
+  // touch left mouse gestures with no baseline clientX to diff against.
+  const pointerStartRef = useRef<{ clientX: number; pointerId: number } | null>(null);
 
   const clearLongPressTimer = useCallback(() => {
     if (longPressTimerRef.current !== null) {
@@ -115,7 +120,7 @@ function TimelineLaneImpl({
       if (event.target !== event.currentTarget) return;
 
       if (event.pointerType === 'touch') {
-        touchStartRef.current = { clientX: event.clientX, pointerId: event.pointerId };
+        pointerStartRef.current = { clientX: event.clientX, pointerId: event.pointerId };
         clearLongPressTimer();
         longPressTimerRef.current = setTimeout(() => {
           longPressTimerRef.current = null;
@@ -124,6 +129,7 @@ function TimelineLaneImpl({
         return;
       }
 
+      pointerStartRef.current = { clientX: event.clientX, pointerId: event.pointerId };
       startPaint(event.clientX);
     },
     [clearLongPressTimer, startPaint],
@@ -134,7 +140,7 @@ function TimelineLaneImpl({
       // Pending long-press (touch, timer not yet fired): cancel on movement
       // past the threshold so a horizontal scroll isn't hijacked as a paint.
       if (longPressTimerRef.current !== null) {
-        const start = touchStartRef.current;
+        const start = pointerStartRef.current;
         if (start && Math.abs(event.clientX - start.clientX) > LONG_PRESS_MOVE_CANCEL_PX) {
           clearLongPressTimer();
         }
@@ -147,7 +153,12 @@ function TimelineLaneImpl({
       const rect = plotRef.current?.getBoundingClientRect();
       if (!rect) return;
       const pointerMin = pointerToMinutes(event.clientX, rect, windowRef.current);
-      const movedPx = Math.abs(event.clientX - (touchStartRef.current?.clientX ?? current.pointerDownMin));
+      // `movedPx` MUST be a pixel delta from the pointer-down clientX — never
+      // `current.pointerDownMin` (restaurant-local minutes-since-midnight,
+      // ~600-1380), which would mix units and misclassify a stationary click
+      // as a drag (or vice versa). Falls back to `event.clientX` (zero delta)
+      // only if pointerdown's start somehow wasn't recorded.
+      const movedPx = Math.abs(event.clientX - (pointerStartRef.current?.clientX ?? event.clientX));
       setDraft(updatePaint(current, pointerMin, windowRef.current, movedPx));
     },
     [clearLongPressTimer],
@@ -155,7 +166,7 @@ function TimelineLaneImpl({
 
   const handlePointerUp = useCallback(() => {
     clearLongPressTimer();
-    touchStartRef.current = null;
+    pointerStartRef.current = null;
 
     const current = draftRef.current;
     if (!current) return;

--- a/src/components/scheduling/ShiftTimeline/TimelineLane.tsx
+++ b/src/components/scheduling/ShiftTimeline/TimelineLane.tsx
@@ -1,10 +1,11 @@
-import { useRef, useState, useCallback, useMemo } from 'react';
+import { useRef, useState, useCallback, useMemo, memo } from 'react';
 
 import type { TimelineLane as TimelineLaneModel } from './useTimelineModel';
 import type { TimelineWindow } from '@/lib/timelineModel';
 import type { Shift } from '@/types/scheduling';
 import type { PaintDraft, PaintRange } from '@/lib/timelineDraft';
 import { pointerToMinutes, beginPaint, updatePaint, endPaint, DEFAULT_CLICK_DURATION_MIN } from '@/lib/timelineDraft';
+import type { ShiftMinuteRange } from '@/lib/timelineDragMath';
 import { TimelineBar } from './TimelineBar';
 import { cn } from '@/lib/utils';
 
@@ -29,6 +30,10 @@ interface TimelineLaneProps {
    * The parent opens the quick-add popover with this range + lane context.
    */
   readonly onPaintCommit: (range: PaintRange, laneContext: LanePaintContext) => void;
+  /** Forwarded to each `TimelineBar` — rAF-throttled live drag-draft updates (Stage D2). */
+  readonly onBarDraftChange: (shiftId: string, range: ShiftMinuteRange | null) => void;
+  /** Forwarded to each `TimelineBar` — fires on drag/resize release (Stage D3). */
+  readonly onBarDragCommit: (shiftId: string, range: ShiftMinuteRange) => void;
 }
 
 /** Height in pixels for each stacked bar row within a lane. */
@@ -57,7 +62,15 @@ const LONG_PRESS_MOVE_CANCEL_PX = 10;
  * paint. A visually-hidden "Add shift to <lane>" button gives keyboard users
  * the same entry point without any pointer gesture.
  */
-export function TimelineLane({ lane, minToPct, window, onSelect, onPaintCommit }: TimelineLaneProps) {
+function TimelineLaneImpl({
+  lane,
+  minToPct,
+  window,
+  onSelect,
+  onPaintCommit,
+  onBarDraftChange,
+  onBarDragCommit,
+}: TimelineLaneProps) {
   const { label, hours, bars } = lane;
   const maxRow = bars.reduce((max, b) => Math.max(max, b.row), 0);
   const plotHeight = (maxRow + 1) * ROW_HEIGHT_PX;
@@ -68,6 +81,9 @@ export function TimelineLane({ lane, minToPct, window, onSelect, onPaintCommit }
   const displayLabel = label || 'Unassigned';
 
   const plotRef = useRef<HTMLDivElement>(null);
+  // Stable callback (never recreated) so it's a safe prop for TimelineBar's
+  // memo comparator — reads the ref fresh on every call, never a stale rect.
+  const getPlotRect = useCallback(() => plotRef.current?.getBoundingClientRect() ?? null, []);
   const [draft, setDraft] = useState<PaintDraft | null>(null);
   // Refs so pointer handlers registered at pointerdown always read the latest
   // window/draft rather than a stale closure (lesson 2026-06-04).
@@ -215,6 +231,10 @@ export function TimelineLane({ lane, minToPct, window, onSelect, onPaintCommit }
               bar={bar}
               minToPct={minToPct}
               onSelect={onSelect}
+              window={window}
+              getPlotRect={getPlotRect}
+              onDraftChange={onBarDraftChange}
+              onDragCommit={onBarDragCommit}
             />
           </div>
         ))}
@@ -239,3 +259,26 @@ export function TimelineLane({ lane, minToPct, window, onSelect, onPaintCommit }
     </div>
   );
 }
+
+function areLaneEqual(prev: TimelineLaneProps, next: TimelineLaneProps): boolean {
+  return (
+    prev.lane === next.lane &&
+    prev.minToPct === next.minToPct &&
+    prev.window.startMin === next.window.startMin &&
+    prev.window.endMin === next.window.endMin &&
+    prev.onSelect === next.onSelect &&
+    prev.onPaintCommit === next.onPaintCommit &&
+    prev.onBarDraftChange === next.onBarDraftChange &&
+    prev.onBarDragCommit === next.onBarDragCommit
+  );
+}
+
+/**
+ * Memoized (Stage D1b): `lane` is a fresh object per `useTimelineModel` recompute,
+ * so this comparator relies on reference equality of `lane` itself (stable
+ * unless that lane's bars/hours actually changed) plus the primitive window
+ * bounds and stable callback identities — a drag frame's rAF-throttled model
+ * recompute only produces a new `lane` object for the lane containing the
+ * dragged bar, so sibling lanes skip re-rendering.
+ */
+export const TimelineLane = memo(TimelineLaneImpl, areLaneEqual);

--- a/src/components/scheduling/ShiftTimeline/TimelineShiftEditor.tsx
+++ b/src/components/scheduling/ShiftTimeline/TimelineShiftEditor.tsx
@@ -16,7 +16,7 @@ import { AlertTriangle } from 'lucide-react';
 import { useCheckConflicts } from '@/hooks/useConflictDetection';
 import { validateShift } from '@/lib/shiftValidator';
 import { ShiftInterval } from '@/lib/shiftInterval';
-import { minutesToIso } from '@/lib/shiftTimeMath';
+import { minutesToIso, resolveOvernightMinutes } from '@/lib/shiftTimeMath';
 import { rankEmployeesForShift } from '@/lib/employeeRanking';
 import { formatConflictLine } from '@/lib/conflictFormatUtils';
 
@@ -95,10 +95,7 @@ export function TimelineShiftEditor({
   // convention `minutesToIso` expects.
   const minutes = useMemo(() => {
     if (!values.startTime || !values.endTime) return null;
-    const startMin = timeToMinutes(values.startTime);
-    let endMin = timeToMinutes(values.endTime);
-    if (endMin <= startMin) endMin += 1440;
-    return { startMin, endMin };
+    return resolveOvernightMinutes(values.startTime, values.endTime);
   }, [values.startTime, values.endTime]);
 
   // ---------------------------------------------------------------------------
@@ -236,10 +233,4 @@ export function TimelineShiftEditor({
       </div>
     </div>
   );
-}
-
-/** Parse "HH:MM" into minutes-since-midnight. */
-function timeToMinutes(time: string): number {
-  const [h, m] = time.split(':').map(Number);
-  return h * 60 + m;
 }

--- a/src/components/scheduling/ShiftTimeline/TimelineShiftEditor.tsx
+++ b/src/components/scheduling/ShiftTimeline/TimelineShiftEditor.tsx
@@ -72,10 +72,19 @@ export function TimelineShiftEditor({
   onChange,
   laneContext,
 }: TimelineShiftEditorProps) {
-  const activeEmployees = useMemo(
-    () => employees.filter((emp) => emp.is_active),
-    [employees],
-  );
+  // Active employees, plus (in edit mode only) the shift's currently-assigned
+  // employee even if they've since become inactive — otherwise editing a shift
+  // whose employee was deactivated silently drops them from the Select,
+  // making it look like the shift has no assignee (CodeRabbit Major).
+  // Create mode has no "currently assigned" employee, so it stays active-only.
+  const activeEmployees = useMemo(() => {
+    const active = employees.filter((emp) => emp.is_active);
+    if (mode !== 'edit' || !shift) return active;
+    const alreadyIncluded = active.some((emp) => emp.id === shift.employee_id);
+    if (alreadyIncluded) return active;
+    const currentEmployee = employees.find((emp) => emp.id === shift.employee_id);
+    return currentEmployee ? [...active, currentEmployee] : active;
+  }, [employees, mode, shift]);
 
   const rankingContext = useMemo(
     () => ({

--- a/src/components/scheduling/ShiftTimeline/TimelineShiftEditor.tsx
+++ b/src/components/scheduling/ShiftTimeline/TimelineShiftEditor.tsx
@@ -1,0 +1,245 @@
+import { useMemo } from 'react';
+
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { TimeInput } from '@/components/scheduling/TimeInput';
+import { AlertTriangle } from 'lucide-react';
+
+import { useCheckConflicts } from '@/hooks/useConflictDetection';
+import { validateShift } from '@/lib/shiftValidator';
+import { ShiftInterval } from '@/lib/shiftInterval';
+import { minutesToIso } from '@/lib/shiftTimeMath';
+import { rankEmployeesForShift } from '@/lib/employeeRanking';
+import { formatConflictLine } from '@/lib/conflictFormatUtils';
+
+import type { Employee, Shift } from '@/types/scheduling';
+
+export interface TimelineShiftEditorValues {
+  employeeId: string;
+  startTime: string; // "HH:MM"
+  endTime: string; // "HH:MM"
+  breakDuration: string; // minutes, as a string for controlled <Input>
+  notes: string;
+}
+
+export interface TimelineShiftEditorProps {
+  /** 'edit' when editing an existing shift, 'create' for the quick-add flow. */
+  readonly mode: 'edit' | 'create';
+  /** The shift being edited, or null in create mode. Used for lane/position context and overlap exclusion. */
+  readonly shift: Shift | null;
+  readonly employees: Employee[];
+  readonly restaurantId: string;
+  /** Calendar date (YYYY-MM-DD) the shift belongs to, for conflict-check ISO construction. */
+  readonly dateStr: string;
+  /** Restaurant IANA timezone. */
+  readonly tz: string;
+  /** All shifts for the day (or wider window), used for local overlap/rest-gap warnings. */
+  readonly existingShifts: Shift[];
+  readonly values: TimelineShiftEditorValues;
+  readonly onChange: (values: TimelineShiftEditorValues) => void;
+  /** Optional lane context (position/area) to bias employee ranking in create mode. */
+  readonly laneContext?: { position?: string | null; area?: string | null };
+}
+
+/**
+ * Shared edit/create form for a single shift, rendered inside `TimelineShiftPopover`.
+ * Pure controlled form: all state lives in the parent (`values` + `onChange`).
+ *
+ * Live advisory: reactive `useCheckConflicts` (server-side time-off/availability RPCs)
+ * for the currently selected employee + times, plus local `validateShift` warnings
+ * (overlap, clopen rest-gap, duration) computed from `existingShifts`. Both surface
+ * as amber chips using the shared `AvailabilityConflictDialog` classes. All dynamic
+ * advisory text is coalesced into a single `aria-live="polite"` region so a picker
+ * interaction never produces multiple disjoint announcements.
+ */
+export function TimelineShiftEditor({
+  mode,
+  shift,
+  employees,
+  restaurantId,
+  dateStr,
+  tz,
+  existingShifts,
+  values,
+  onChange,
+  laneContext,
+}: TimelineShiftEditorProps) {
+  const activeEmployees = useMemo(
+    () => employees.filter((emp) => emp.is_active),
+    [employees],
+  );
+
+  const rankingContext = useMemo(
+    () => ({
+      position: laneContext?.position ?? shift?.position ?? null,
+      area: laneContext?.area ?? null,
+    }),
+    [laneContext?.position, laneContext?.area, shift?.position],
+  );
+
+  const rankedEmployees = useMemo(
+    () => rankEmployeesForShift(activeEmployees, rankingContext),
+    [activeEmployees, rankingContext],
+  );
+
+  // Restaurant-local minutes-since-midnight for start/end, resolving overnight
+  // shifts (end <= start) by rolling the end minutes past 1440 — the same
+  // convention `minutesToIso` expects.
+  const minutes = useMemo(() => {
+    if (!values.startTime || !values.endTime) return null;
+    const startMin = timeToMinutes(values.startTime);
+    let endMin = timeToMinutes(values.endTime);
+    if (endMin <= startMin) endMin += 1440;
+    return { startMin, endMin };
+  }, [values.startTime, values.endTime]);
+
+  // ---------------------------------------------------------------------------
+  // Live advisory: server-side conflicts (reactive, DI-free — same pattern as
+  // ShiftDialog) for the currently selected employee + proposed times. ISO
+  // instants are always built via minutesToIso (fromZonedTime), never a
+  // host-local `new Date(...)` reconstruction, so a host TZ different from the
+  // restaurant TZ can't silently shift the checked window.
+  // ---------------------------------------------------------------------------
+  const conflictParams = useMemo(() => {
+    if (!values.employeeId || !minutes) return null;
+
+    const startIso = minutesToIso(dateStr, minutes.startMin, tz);
+    const endIso = minutesToIso(dateStr, minutes.endMin, tz);
+
+    return {
+      employeeId: values.employeeId,
+      restaurantId,
+      startTime: startIso,
+      endTime: endIso,
+    };
+  }, [values.employeeId, minutes, dateStr, tz, restaurantId]);
+
+  const { conflicts } = useCheckConflicts(conflictParams);
+
+  // ---------------------------------------------------------------------------
+  // Live advisory: local business-rule warnings (overlap, clopen rest-gap,
+  // duration) via the shared validateShift, excluding the shift being edited.
+  // ---------------------------------------------------------------------------
+  const localWarnings = useMemo(() => {
+    if (!values.employeeId || !minutes) return [];
+
+    try {
+      const startIso = minutesToIso(dateStr, minutes.startMin, tz);
+      const endIso = minutesToIso(dateStr, minutes.endMin, tz);
+      const interval = ShiftInterval.fromTimestamps(startIso, endIso, dateStr);
+      const { warnings } = validateShift(
+        { employeeId: values.employeeId, interval },
+        existingShifts,
+        { excludeShiftId: shift?.id },
+      );
+      return warnings;
+    } catch {
+      return [];
+    }
+  }, [values.employeeId, minutes, dateStr, tz, existingShifts, shift?.id]);
+
+  const advisoryMessages = useMemo(() => {
+    const conflictMessages = conflicts.map((c) => formatConflictLine(c, tz));
+    const warningMessages = localWarnings.map((w) => w.message);
+    return [...conflictMessages, ...warningMessages];
+  }, [conflicts, localWarnings, tz]);
+
+  const update = (patch: Partial<TimelineShiftEditorValues>) => {
+    onChange({ ...values, ...patch });
+  };
+
+  return (
+    <div className="space-y-4" data-mode={mode}>
+      <div className="space-y-2">
+        <Label htmlFor="timeline-editor-employee">
+          Employee <span className="text-destructive">*</span>
+        </Label>
+        <Select
+          value={values.employeeId}
+          onValueChange={(value) => update({ employeeId: value })}
+        >
+          <SelectTrigger id="timeline-editor-employee" aria-label="Select employee">
+            <SelectValue placeholder="Select employee" />
+          </SelectTrigger>
+          <SelectContent>
+            {rankedEmployees.map((emp) => (
+              <SelectItem key={emp.id} value={emp.id}>
+                {emp.name} - {emp.position}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <TimeInput
+          id="timeline-editor-start-time"
+          label="Start Time"
+          value={values.startTime}
+          onChange={(value) => update({ startTime: value })}
+        />
+        <TimeInput
+          id="timeline-editor-end-time"
+          label="End Time"
+          value={values.endTime}
+          onChange={(value) => update({ endTime: value })}
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="timeline-editor-break">Break (minutes)</Label>
+        <Input
+          id="timeline-editor-break"
+          type="number"
+          min="0"
+          step="15"
+          value={values.breakDuration}
+          onChange={(e) => update({ breakDuration: e.target.value })}
+          aria-label="Break duration in minutes"
+        />
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="timeline-editor-notes">Notes</Label>
+        <Textarea
+          id="timeline-editor-notes"
+          value={values.notes}
+          onChange={(e) => update({ notes: e.target.value })}
+          placeholder="Additional information about this shift..."
+          rows={2}
+          aria-label="Shift notes"
+        />
+      </div>
+
+      {/* Single coalesced aria-live region: composes the "on shift" badge (owned
+          by the caller, e.g. quick-add), async RPC conflicts, and local warnings
+          into one announcement so a picker interaction never fires more than
+          one live-region update. */}
+      <div aria-live="polite" className="space-y-2">
+        {advisoryMessages.map((message, index) => (
+          <div
+            key={`${index}-${message}`}
+            className="flex items-start gap-2 p-2.5 rounded-lg bg-amber-500/10 border border-amber-500/20"
+          >
+            <AlertTriangle className="h-3.5 w-3.5 text-amber-500 mt-0.5 shrink-0" />
+            <p className="text-[13px] text-foreground">{message}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** Parse "HH:MM" into minutes-since-midnight. */
+function timeToMinutes(time: string): number {
+  const [h, m] = time.split(':').map(Number);
+  return h * 60 + m;
+}

--- a/src/components/scheduling/ShiftTimeline/TimelineShiftPopover.tsx
+++ b/src/components/scheduling/ShiftTimeline/TimelineShiftPopover.tsx
@@ -111,8 +111,20 @@ interface TimelineShiftPopoverProps {
   readonly validateAndCreateAtTime?: (input: CreateAtTimeInput) => Promise<CreateAtTimeOutcome>;
   /** Force-apply a create-at-time request after the user confirms the conflict dialog. */
   readonly forceCreateAtTime?: (input: CreateAtTimeInput) => Promise<boolean>;
-  /** Delete a shift by id (immediate — the confirm gate lives in this component for published shifts). */
-  readonly deleteShift: (shiftId: string) => void;
+  /**
+   * Delete the given shift (immediate for unpublished shifts — the confirm gate
+   * lives in this component for published shifts). Receives the full `Shift`
+   * (not just its id) so the caller can capture the payload for an undo
+   * affordance (design doc §Fix 1).
+   */
+  readonly onDelete: (shift: Shift) => void;
+  /**
+   * Called with the shift right after an edit-mode Save/confirm-conflicts
+   * succeeds (design doc §Fix 3 — transient change highlight). Not called for
+   * create — a brand-new shift's id isn't known here (assigned server-side),
+   * so the highlight only ever tracks MOVE/RESIZE/EDIT commits, never CREATE.
+   */
+  readonly onSaved?: (shift: Shift) => void;
   /** Surfaced validation errors (e.g. a thrown lock/interval error) from the pipeline hook. */
   readonly validationResult: ValidationResult | null;
   /** Clears `validationResult` — called when the popover closes or edit mode is cancelled. */
@@ -179,7 +191,8 @@ export function TimelineShiftPopover({
   forceUpdateShift,
   validateAndCreateAtTime,
   forceCreateAtTime,
-  deleteShift,
+  onDelete,
+  onSaved,
   validationResult,
   clearValidation,
   anchorRect,
@@ -288,7 +301,7 @@ export function TimelineShiftPopover({
     if (activeShift.is_published) {
       setShowDeleteConfirm(true);
     } else {
-      deleteShift(activeShift.id);
+      onDelete(activeShift);
       handleClose();
     }
   };
@@ -297,7 +310,7 @@ export function TimelineShiftPopover({
     // AlertDialogAction is Radix's Dialog.Close: without preventDefault it
     // closes the dialog synchronously on click, before the mutation resolves.
     event.preventDefault();
-    deleteShift(activeShift.id);
+    onDelete(activeShift);
     setShowDeleteConfirm(false);
     handleClose();
   };
@@ -323,6 +336,7 @@ export function TimelineShiftPopover({
       });
 
       if (outcome.updated) {
+        onSaved?.(activeShift);
         handleClose();
         return;
       }
@@ -360,6 +374,7 @@ export function TimelineShiftPopover({
 
       if (outcome.updated) {
         setPendingIssues(null);
+        onSaved?.(activeShift);
         handleClose();
       }
     } finally {

--- a/src/components/scheduling/ShiftTimeline/TimelineShiftPopover.tsx
+++ b/src/components/scheduling/ShiftTimeline/TimelineShiftPopover.tsx
@@ -1,11 +1,39 @@
+import { useCallback, useMemo, useState } from 'react';
+
 import {
   Popover,
+  PopoverAnchor,
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+import { Lock, AlertTriangle } from 'lucide-react';
+
 import { minutesToCompact, isoToLocalMinutes } from '@/lib/shiftCoverage';
 import { calculateShiftHours } from '@/lib/scheduleRoster';
-import type { Shift } from '@/types/scheduling';
+import { minutesToIso } from '@/lib/shiftTimeMath';
+import { AvailabilityConflictDialog } from '@/components/scheduling/ShiftPlanner/AvailabilityConflictDialog';
+import { TimelineShiftEditor, type TimelineShiftEditorValues } from './TimelineShiftEditor';
+
+import type { Shift, Employee, ConflictCheck } from '@/types/scheduling';
+import type { ValidationIssue } from '@/lib/shiftValidator';
+import type { ValidationResult } from '@/lib/shiftValidator';
+import type { UpdateTimeOutcome } from '@/hooks/useValidatedShiftMutations';
+
+/** Minimal shape needed to anchor the Radix popper to an arbitrary rect. */
+interface VirtualAnchor {
+  getBoundingClientRect: () => DOMRect;
+}
 
 interface TimelineShiftPopoverProps {
   /** The currently active shift to show, or null when none is selected. */
@@ -14,27 +42,143 @@ interface TimelineShiftPopoverProps {
   readonly tz: string;
   /** The calendar date string (YYYY-MM-DD) of the selected day. */
   readonly dateStr: string;
+  /** All employees for the restaurant, forwarded to TimelineShiftEditor. */
+  readonly employees: Employee[];
+  /** Restaurant ID, forwarded to TimelineShiftEditor's conflict checks. */
+  readonly restaurantId: string;
+  /** All shifts for the day, used for local overlap/rest-gap warnings while editing. */
+  readonly dayShifts: Shift[];
   /** Called when the popover is closed or dismissed. */
   readonly onClose: () => void;
+  /** Validate a time-change; returns pending issues instead of throwing. */
+  readonly validateAndUpdateTime: (input: {
+    shift: Shift;
+    startIso: string;
+    endIso: string;
+    businessDate: string;
+  }) => Promise<UpdateTimeOutcome>;
+  /** Force-apply a time change after the user confirms the conflict dialog. */
+  readonly forceUpdateTime: (input: {
+    shift: Shift;
+    startIso: string;
+    endIso: string;
+    businessDate: string;
+  }) => Promise<boolean>;
+  /** Delete a shift by id (immediate — the confirm gate lives in this component for published shifts). */
+  readonly deleteShift: (shiftId: string) => void;
+  /** Surfaced validation errors (e.g. a thrown lock/interval error) from the pipeline hook. */
+  readonly validationResult: ValidationResult | null;
+  /** Clears `validationResult` — called when the popover closes or edit mode is cancelled. */
+  readonly clearValidation: () => void;
+  /**
+   * Virtual anchor rect for the interacted element (bar / ghost / gap segment).
+   * When absent, the popover falls back to the invisible zero-size trigger.
+   */
+  readonly anchorRect?: DOMRect | null;
+  /** The scrollable plot container, used as the Radix collision boundary. */
+  readonly collisionBoundary?: Element | null;
+}
+
+/** Parse "HH:MM" into minutes-since-midnight. */
+function timeToMinutes(time: string): number {
+  const [h, m] = time.split(':').map(Number);
+  return h * 60 + m;
+}
+
+/** Format minutes-since-midnight (may be >= 1440 for overnight) as 24h "HH:MM" for TimeInput. */
+function minutesToHHMM(min: number): string {
+  const norm = ((min % 1440) + 1440) % 1440;
+  const h = Math.floor(norm / 60);
+  const m = norm % 60;
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+}
+
+/** Build the initial editor values from a shift + the day's timezone. */
+function shiftToEditorValues(shift: Shift, dateStr: string, tz: string): TimelineShiftEditorValues {
+  const startMin = isoToLocalMinutes(shift.start_time, dateStr, tz);
+  let endMin = isoToLocalMinutes(shift.end_time, dateStr, tz);
+  if (endMin <= startMin) endMin += 1440;
+
+  return {
+    employeeId: shift.employee_id,
+    startTime: minutesToHHMM(startMin),
+    endTime: minutesToHHMM(endMin),
+    breakDuration: String(shift.break_duration ?? 0),
+    notes: shift.notes ?? '',
+  };
 }
 
 /**
- * A single read-only shadcn Popover that shows the details of the active shift.
+ * A single shadcn Popover that shows the details of the active shift (view mode) and,
+ * on Edit, swaps in `TimelineShiftEditor` for a full edit form (edit mode).
  *
  * Per the CLAUDE.md single-dialog pattern, this is ONE instance rendered at the
  * container level (ShiftTimelineTab), controlled by `activeShift` state.  Each
  * shift bar sets the active shift via `onSelect`; this component opens/closes
  * based on whether `activeShift` is non-null.
  *
- * When used without an explicit `trigger`, it renders as a floating panel
- * anchored to the top-left of the viewport via an invisible zero-size trigger.
+ * Anchoring: bound to the interacted element's rect (`anchorRect`) via Radix
+ * `PopoverAnchor`'s `virtualRef`; falls back to the legacy zero-size trigger
+ * when no rect is supplied yet (e.g. tests, or before B3 wires rect capture).
+ * `modal={false}` so it never traps focus or blocks the page; the scrollable
+ * plot region is passed as `collisionBoundary` so positioning stays correct
+ * inside `overflow-x-auto`.
+ *
+ * Conflict-dialog stacking: when Save surfaces pending issues, this component
+ * stays mounted and open (still in edit mode) behind `AvailabilityConflictDialog`.
+ * Escape/outside-click on the popover is suppressed while the conflict dialog is
+ * open (Radix Dialog owns its own Escape handling and is topmost); confirming
+ * calls `forceUpdateTime` and then closes the popover, cancelling returns to the
+ * edit form without closing anything.
  */
 export function TimelineShiftPopover({
   activeShift,
   tz,
   dateStr,
+  employees,
+  restaurantId,
+  dayShifts,
   onClose,
+  validateAndUpdateTime,
+  forceUpdateTime,
+  deleteShift,
+  validationResult,
+  clearValidation,
+  anchorRect,
+  collisionBoundary,
 }: TimelineShiftPopoverProps) {
+  const [mode, setMode] = useState<'view' | 'edit'>('view');
+  const [editValues, setEditValues] = useState<TimelineShiftEditorValues | null>(null);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [pendingIssues, setPendingIssues] = useState<{
+    conflicts: ConflictCheck[];
+    warnings: ValidationIssue[];
+  } | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const virtualAnchorRef = useMemo<{ current: VirtualAnchor | null }>(
+    () => ({
+      current: anchorRect
+        ? { getBoundingClientRect: () => anchorRect }
+        : null,
+    }),
+    [anchorRect],
+  );
+
+  const resetLocalState = useCallback(() => {
+    setMode('view');
+    setEditValues(null);
+    setShowDeleteConfirm(false);
+    setPendingIssues(null);
+    setSaving(false);
+    clearValidation();
+  }, [clearValidation]);
+
+  const handleClose = useCallback(() => {
+    resetLocalState();
+    onClose();
+  }, [resetLocalState, onClose]);
+
   if (!activeShift) return null;
 
   const leftMin = isoToLocalMinutes(activeShift.start_time, dateStr, tz);
@@ -48,38 +192,294 @@ export function TimelineShiftPopover({
   const statusLabel =
     activeShift.status.charAt(0).toUpperCase() + activeShift.status.slice(1);
 
+  const isLocked = activeShift.locked;
+  const isRecurring = Boolean(activeShift.is_recurring);
+
+  const handleEditClick = () => {
+    setEditValues(shiftToEditorValues(activeShift, dateStr, tz));
+    setMode('edit');
+  };
+
+  const handleCancelEdit = () => {
+    setMode('view');
+    setEditValues(null);
+    clearValidation();
+  };
+
+  const handleDeleteClick = () => {
+    if (activeShift.is_published) {
+      setShowDeleteConfirm(true);
+    } else {
+      deleteShift(activeShift.id);
+      handleClose();
+    }
+  };
+
+  const handleConfirmDelete = (event: React.MouseEvent<HTMLButtonElement>) => {
+    // AlertDialogAction is Radix's Dialog.Close: without preventDefault it
+    // closes the dialog synchronously on click, before the mutation resolves.
+    event.preventDefault();
+    deleteShift(activeShift.id);
+    setShowDeleteConfirm(false);
+    handleClose();
+  };
+
+  const handleSave = async () => {
+    if (!editValues) return;
+
+    const startMin = timeToMinutes(editValues.startTime);
+    let endMinValue = timeToMinutes(editValues.endTime);
+    if (endMinValue <= startMin) endMinValue += 1440;
+
+    const startIso = minutesToIso(dateStr, startMin, tz);
+    const endIso = minutesToIso(dateStr, endMinValue, tz);
+
+    setSaving(true);
+    try {
+      const outcome = await validateAndUpdateTime({
+        shift: activeShift,
+        startIso,
+        endIso,
+        businessDate: dateStr,
+      });
+
+      if (outcome.updated) {
+        handleClose();
+        return;
+      }
+
+      if (outcome.pendingConflicts?.length || outcome.pendingWarnings?.length) {
+        setPendingIssues({
+          conflicts: outcome.pendingConflicts ?? [],
+          warnings: outcome.pendingWarnings ?? [],
+        });
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleConfirmConflicts = async () => {
+    if (!editValues) return;
+
+    const startMin = timeToMinutes(editValues.startTime);
+    let endMinValue = timeToMinutes(editValues.endTime);
+    if (endMinValue <= startMin) endMinValue += 1440;
+
+    const startIso = minutesToIso(dateStr, startMin, tz);
+    const endIso = minutesToIso(dateStr, endMinValue, tz);
+
+    setSaving(true);
+    try {
+      const ok = await forceUpdateTime({
+        shift: activeShift,
+        startIso,
+        endIso,
+        businessDate: dateStr,
+      });
+
+      if (ok) {
+        setPendingIssues(null);
+        handleClose();
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleCancelConflicts = () => {
+    setPendingIssues(null);
+  };
+
+  const conflictDialogOpen = pendingIssues !== null;
+  const conflictDialogData = pendingIssues
+    ? {
+        employeeName:
+          employees.find((e) => e.id === editValues?.employeeId)?.name ?? 'This employee',
+        conflicts: pendingIssues.conflicts,
+        warnings: pendingIssues.warnings,
+      }
+    : null;
+
   return (
-    <Popover open onOpenChange={(open) => { if (!open) onClose(); }}>
-      {/* Zero-size invisible trigger so Radix has an anchor to position against */}
-      <PopoverTrigger asChild>
-        <span className="sr-only" />
-      </PopoverTrigger>
-
-      <PopoverContent
-        className="w-64 p-0 gap-0 border-border/40"
-        align="center"
-        sideOffset={8}
+    <>
+      <Popover
+        open
+        modal={false}
+        onOpenChange={(open) => {
+          // Suppress outside-click/Escape dismissal while a stacked dialog (the
+          // conflict dialog or the published-delete confirm) is on top — the
+          // popover only closes via handleClose (Save success, confirm-delete,
+          // or the caller's own onClose). Without this guard, the stacked
+          // dialog's portal/overlay registers as an "outside interaction" and
+          // Radix would close (and reset) the popover out from under it.
+          if (!open && !conflictDialogOpen && !showDeleteConfirm) handleClose();
+        }}
       >
-        {/* Header */}
-        <div className="px-4 pt-4 pb-3 border-b border-border/40">
-          <p className="text-[14px] font-semibold text-foreground truncate">
-            {activeShift.position}
-          </p>
-          <p className="text-[12px] text-muted-foreground mt-0.5">
-            {startLabel} – {endLabel} · {hours}h
-          </p>
-        </div>
+        {anchorRect ? (
+          <PopoverAnchor virtualRef={virtualAnchorRef as unknown as React.RefObject<VirtualAnchor>} />
+        ) : (
+          // Zero-size invisible trigger fallback so Radix always has an anchor,
+          // even before a caller supplies a virtual anchor rect.
+          <PopoverTrigger asChild>
+            <span className="sr-only" />
+          </PopoverTrigger>
+        )}
 
-        {/* Details */}
-        <div className="px-4 py-3 space-y-2">
-          {activeShift.notes && (
-            <Row label="Notes" value={activeShift.notes} />
+        <PopoverContent
+          className="w-72 p-0 gap-0 border-border/40"
+          align="center"
+          sideOffset={8}
+          collisionBoundary={collisionBoundary ?? undefined}
+        >
+          {mode === 'view' ? (
+            <>
+              {/* Header */}
+              <div className="px-4 pt-4 pb-3 border-b border-border/40">
+                <div className="flex items-center gap-2">
+                  <p className="text-[14px] font-semibold text-foreground truncate">
+                    {activeShift.position}
+                  </p>
+                  {isLocked && (
+                    <Lock
+                      className="h-3.5 w-3.5 text-muted-foreground shrink-0"
+                      aria-label="Locked shift"
+                    />
+                  )}
+                </div>
+                <p className="text-[12px] text-muted-foreground mt-0.5">
+                  {startLabel} – {endLabel} · {hours}h
+                </p>
+              </div>
+
+              {/* Details */}
+              <div className="px-4 py-3 space-y-2">
+                {activeShift.notes && (
+                  <Row label="Notes" value={activeShift.notes} />
+                )}
+                <Row label="Status" value={statusLabel} />
+                <Row label="Hours" value={`${hours}h`} />
+              </div>
+
+              {isRecurring && (
+                <div className="mx-4 mb-3 flex items-start gap-2 p-2.5 rounded-lg bg-muted/50 border border-border/40">
+                  <p className="text-[12px] text-muted-foreground">
+                    Changes apply to this shift only
+                  </p>
+                </div>
+              )}
+
+              {/* Footer actions */}
+              <div className="px-4 py-3 border-t border-border/40 flex items-center justify-end gap-2">
+                <Button
+                  variant="ghost"
+                  disabled={isLocked}
+                  onClick={handleDeleteClick}
+                  className="h-9 px-4 rounded-lg text-[13px] font-medium text-destructive hover:text-destructive/80"
+                >
+                  Delete
+                </Button>
+                <Button
+                  disabled={isLocked}
+                  onClick={handleEditClick}
+                  className="h-9 px-4 rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium"
+                >
+                  Edit
+                </Button>
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="px-4 pt-4 pb-3 border-b border-border/40">
+                <p className="text-[14px] font-semibold text-foreground">Edit shift</p>
+                {isRecurring && (
+                  <p className="text-[12px] text-muted-foreground mt-0.5">
+                    Changes apply to this shift only
+                  </p>
+                )}
+              </div>
+
+              <div className="px-4 py-4">
+                {editValues && (
+                  <TimelineShiftEditor
+                    mode="edit"
+                    shift={activeShift}
+                    employees={employees}
+                    restaurantId={restaurantId}
+                    dateStr={dateStr}
+                    tz={tz}
+                    existingShifts={dayShifts}
+                    values={editValues}
+                    onChange={setEditValues}
+                  />
+                )}
+
+                {validationResult?.errors && validationResult.errors.length > 0 && (
+                  <div className="mt-3 flex items-start gap-2 p-2.5 rounded-lg bg-destructive/10 border border-destructive/20">
+                    <AlertTriangle className="h-3.5 w-3.5 text-destructive mt-0.5 shrink-0" />
+                    <p className="text-[13px] text-foreground">
+                      {validationResult.errors[0].message}
+                    </p>
+                  </div>
+                )}
+              </div>
+
+              <div className="px-4 py-3 border-t border-border/40 flex items-center justify-end gap-2">
+                <Button
+                  variant="ghost"
+                  onClick={handleCancelEdit}
+                  disabled={saving}
+                  className="h-9 px-4 rounded-lg text-[13px] font-medium text-muted-foreground hover:text-foreground"
+                >
+                  Cancel
+                </Button>
+                <Button
+                  onClick={handleSave}
+                  disabled={saving}
+                  className="h-9 px-4 rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium"
+                >
+                  Save
+                </Button>
+              </div>
+            </>
           )}
-          <Row label="Status" value={statusLabel} />
-          <Row label="Hours" value={`${hours}h`} />
-        </div>
-      </PopoverContent>
-    </Popover>
+        </PopoverContent>
+      </Popover>
+
+      {/* Conflict-dialog stacking: rendered while this popover is still mounted
+          and open, so Save issues never close the underlying edit form. */}
+      <AvailabilityConflictDialog
+        open={conflictDialogOpen}
+        data={conflictDialogData}
+        timezone={tz}
+        onConfirm={handleConfirmConflicts}
+        onCancel={handleCancelConflicts}
+      />
+
+      {/* Published-shift delete confirm — event.preventDefault() in
+          handleConfirmDelete keeps the dialog open until the mutation is
+          dispatched, matching DeleteRecipeDialog's convention. */}
+      <AlertDialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete shift</AlertDialogTitle>
+            <AlertDialogDescription>
+              This shift has already been published and the employee may have seen it.
+              Are you sure you want to delete it?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleConfirmDelete}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Delete shift
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }
 

--- a/src/components/scheduling/ShiftTimeline/TimelineShiftPopover.tsx
+++ b/src/components/scheduling/ShiftTimeline/TimelineShiftPopover.tsx
@@ -21,7 +21,7 @@ import { Lock, AlertTriangle } from 'lucide-react';
 
 import { minutesToCompact, isoToLocalMinutes } from '@/lib/shiftCoverage';
 import { calculateShiftHours } from '@/lib/scheduleRoster';
-import { minutesToIso } from '@/lib/shiftTimeMath';
+import { minutesToIso, minutesToHHMM, resolveOvernightMinutes } from '@/lib/shiftTimeMath';
 import { AvailabilityConflictDialog } from '@/components/scheduling/ShiftPlanner/AvailabilityConflictDialog';
 import { TimelineShiftEditor, type TimelineShiftEditorValues } from './TimelineShiftEditor';
 
@@ -95,20 +95,6 @@ interface TimelineShiftPopoverProps {
   readonly anchorRect?: DOMRect | null;
   /** The scrollable plot container, used as the Radix collision boundary. */
   readonly collisionBoundary?: Element | null;
-}
-
-/** Parse "HH:MM" into minutes-since-midnight. */
-function timeToMinutes(time: string): number {
-  const [h, m] = time.split(':').map(Number);
-  return h * 60 + m;
-}
-
-/** Format minutes-since-midnight (may be >= 1440 for overnight) as 24h "HH:MM" for TimeInput. */
-function minutesToHHMM(min: number): string {
-  const norm = ((min % 1440) + 1440) % 1440;
-  const h = Math.floor(norm / 60);
-  const m = norm % 60;
-  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
 }
 
 /** Build the initial editor values from a shift + the day's timezone. */
@@ -210,7 +196,6 @@ export function TimelineShiftPopover({
   useEffect(() => {
     setCreateValues(createDraft?.values ?? null);
     setPendingIssues(null);
-     
   }, [createDraft]);
 
   const isCreateMode = !activeShift && Boolean(createDraft);
@@ -289,9 +274,7 @@ export function TimelineShiftPopover({
   const handleSave = async () => {
     if (!editValues) return;
 
-    const startMin = timeToMinutes(editValues.startTime);
-    let endMinValue = timeToMinutes(editValues.endTime);
-    if (endMinValue <= startMin) endMinValue += 1440;
+    const { startMin, endMin: endMinValue } = resolveOvernightMinutes(editValues.startTime, editValues.endTime);
 
     const startIso = minutesToIso(dateStr, startMin, tz);
     const endIso = minutesToIso(dateStr, endMinValue, tz);
@@ -324,9 +307,7 @@ export function TimelineShiftPopover({
   const handleConfirmConflicts = async () => {
     if (!editValues) return;
 
-    const startMin = timeToMinutes(editValues.startTime);
-    let endMinValue = timeToMinutes(editValues.endTime);
-    if (endMinValue <= startMin) endMinValue += 1440;
+    const { startMin, endMin: endMinValue } = resolveOvernightMinutes(editValues.startTime, editValues.endTime);
 
     const startIso = minutesToIso(dateStr, startMin, tz);
     const endIso = minutesToIso(dateStr, endMinValue, tz);
@@ -619,9 +600,7 @@ function TimelineCreatePopoverContent({
 
   const buildIso = useCallback(
     (values: TimelineShiftEditorValues) => {
-      const startMin = timeToMinutes(values.startTime);
-      let endMinValue = timeToMinutes(values.endTime);
-      if (endMinValue <= startMin) endMinValue += 1440;
+      const { startMin, endMin: endMinValue } = resolveOvernightMinutes(values.startTime, values.endTime);
 
       return {
         startIso: minutesToIso(businessDate, startMin, tz),

--- a/src/components/scheduling/ShiftTimeline/TimelineShiftPopover.tsx
+++ b/src/components/scheduling/ShiftTimeline/TimelineShiftPopover.tsx
@@ -169,12 +169,13 @@ function shiftToEditorValues(shift: Shift, dateStr: string, tz: string): Timelin
  * shift bar sets the active shift via `onSelect`; this component opens/closes
  * based on whether `activeShift` is non-null.
  *
- * Anchoring: bound to the interacted element's rect (`anchorRect`) via Radix
- * `PopoverAnchor`'s `virtualRef`; falls back to the legacy zero-size trigger
- * when no rect is supplied yet (e.g. tests, or before B3 wires rect capture).
- * `modal={false}` so it never traps focus or blocks the page; the scrollable
- * plot region is passed as `collisionBoundary` so positioning stays correct
- * inside `overflow-x-auto`.
+ * Anchoring (view/edit Popover only — the create form below is a centered
+ * Dialog and has no anchor rect): bound to the interacted element's rect
+ * (`anchorRect`) via Radix `PopoverAnchor`'s `virtualRef`; falls back to the
+ * legacy zero-size trigger when no rect is supplied yet (e.g. tests, or
+ * before B3 wires rect capture). `modal={false}` so it never traps focus or
+ * blocks the page; the scrollable plot region is passed as `collisionBoundary`
+ * so positioning stays correct inside `overflow-x-auto`.
  *
  * Conflict-dialog stacking: when Save surfaces pending issues, this component
  * stays mounted and open (still in edit mode) behind `AvailabilityConflictDialog`.

--- a/src/components/scheduling/ShiftTimeline/TimelineShiftPopover.tsx
+++ b/src/components/scheduling/ShiftTimeline/TimelineShiftPopover.tsx
@@ -7,6 +7,13 @@ import {
   PopoverTrigger,
 } from '@/components/ui/popover';
 import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import {
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
@@ -248,7 +255,7 @@ export function TimelineShiftPopover({
 
   if (isCreateMode) {
     return (
-      <TimelineCreatePopoverContent
+      <TimelineCreateDialog
         createDraft={createDraft as TimelineCreateDraft}
         createValues={createValues}
         onChangeValues={setCreateValues}
@@ -256,9 +263,6 @@ export function TimelineShiftPopover({
         employees={employees}
         restaurantId={restaurantId}
         existingShifts={existingShifts}
-        anchorRect={anchorRect ?? null}
-        collisionBoundary={collisionBoundary}
-        virtualAnchorRef={virtualAnchorRef}
         validateAndCreateAtTime={validateAndCreateAtTime}
         forceCreateAtTime={forceCreateAtTime}
         pendingIssues={pendingIssues}
@@ -422,7 +426,7 @@ export function TimelineShiftPopover({
         )}
 
         <PopoverContent
-          className="w-72 p-0 gap-0 border-border/40"
+          className="w-72 max-h-[85vh] overflow-y-auto p-0 gap-0 border-border/40"
           align="center"
           sideOffset={8}
           collisionBoundary={collisionBoundary ?? undefined}
@@ -589,7 +593,7 @@ function Row({ label, value }: { readonly label: string; readonly value: string 
   );
 }
 
-interface TimelineCreatePopoverContentProps {
+interface TimelineCreateDialogProps {
   readonly createDraft: TimelineCreateDraft;
   readonly createValues: TimelineShiftEditorValues | null;
   readonly onChangeValues: (values: TimelineShiftEditorValues) => void;
@@ -597,9 +601,6 @@ interface TimelineCreatePopoverContentProps {
   readonly employees: Employee[];
   readonly restaurantId: string;
   readonly existingShifts: Shift[];
-  readonly anchorRect: DOMRect | null;
-  readonly collisionBoundary?: Element | null;
-  readonly virtualAnchorRef: { current: VirtualAnchor | null };
   readonly validateAndCreateAtTime?: (input: CreateAtTimeInput) => Promise<CreateAtTimeOutcome>;
   readonly forceCreateAtTime?: (input: CreateAtTimeInput) => Promise<boolean>;
   readonly pendingIssues: { conflicts: ConflictCheck[]; warnings: ValidationIssue[] } | null;
@@ -612,15 +613,23 @@ interface TimelineCreatePopoverContentProps {
 }
 
 /**
- * Create-mode variant of the single Timeline popover instance (Stage C3). Rendered by
+ * Create-mode variant of the single Timeline overlay (Stage C3, revised). Rendered by
  * `TimelineShiftPopover` when `createDraft` is present and `activeShift` is null — mutually
- * exclusive with the view/edit branch, so only one `Popover` is ever mounted.
+ * exclusive with the view/edit branch, so only one overlay is ever mounted.
+ *
+ * Unlike the view/edit overlay (an anchored `Popover`, bound to the bar it edits), create mode
+ * has no natural anchor point — it can be triggered from the top controls row, a lane's paint
+ * gesture, or a gap-click on the coverage strip, and the form is tall enough (~760px with all
+ * fields) that anchoring it to a small trigger pushed the "Add shift" submit button below the
+ * viewport fold on short/laptop screens (verified via E2E: the button's box had y=874 in a
+ * 720px-tall viewport). A centered `Dialog` is always fully in-viewport and scrolls internally
+ * (`max-h-[80vh] overflow-y-auto`) instead, per the CLAUDE.md form-dialog pattern.
  *
  * Resolves the shift's `position` at commit time: the lane's own position (position-grouped
  * lane) wins; otherwise falls back to the selected employee's `position` (area-grouped lane,
  * where a shift's area is derived from its employee rather than stored directly).
  */
-function TimelineCreatePopoverContent({
+function TimelineCreateDialog({
   createDraft,
   createValues,
   onChangeValues,
@@ -628,9 +637,6 @@ function TimelineCreatePopoverContent({
   employees,
   restaurantId,
   existingShifts,
-  anchorRect,
-  collisionBoundary,
-  virtualAnchorRef,
   validateAndCreateAtTime,
   forceCreateAtTime,
   pendingIssues,
@@ -638,7 +644,7 @@ function TimelineCreatePopoverContent({
   saving,
   setSaving,
   onClose,
-}: TimelineCreatePopoverContentProps) {
+}: TimelineCreateDialogProps) {
   const { businessDate, laneContext } = createDraft;
 
   const resolvePosition = useCallback(
@@ -735,35 +741,26 @@ function TimelineCreatePopoverContent({
 
   return (
     <>
-      <Popover
+      <Dialog
         open
-        modal={false}
         onOpenChange={(open) => {
+          // Suppress dismissal while the stacked conflict dialog is on top — it
+          // owns Escape/outside-click while open (topmost dialog), same
+          // suppression pattern as the edit-mode Popover above.
           if (!open && !conflictDialogOpen) onClose();
         }}
       >
-        {anchorRect ? (
-          <PopoverAnchor virtualRef={virtualAnchorRef as unknown as React.RefObject<VirtualAnchor>} />
-        ) : (
-          <PopoverTrigger asChild>
-            <span className="sr-only" />
-          </PopoverTrigger>
-        )}
-
-        <PopoverContent
-          className="w-72 p-0 gap-0 border-border/40"
-          align="center"
-          sideOffset={8}
-          collisionBoundary={collisionBoundary ?? undefined}
-        >
-          <div className="px-4 pt-4 pb-3 border-b border-border/40">
-            <p className="text-[14px] font-semibold text-foreground">New shift</p>
+        <DialogContent className="max-w-md max-h-[80vh] overflow-y-auto p-0 gap-0 border-border/40">
+          <DialogHeader className="px-6 pt-6 pb-4 border-b border-border/40">
+            <DialogTitle className="text-[17px] font-semibold text-foreground">New shift</DialogTitle>
             {subtitle && (
-              <p className="text-[12px] text-muted-foreground mt-0.5">{subtitle}</p>
+              <DialogDescription className="text-[13px] text-muted-foreground mt-0.5">
+                {subtitle}
+              </DialogDescription>
             )}
-          </div>
+          </DialogHeader>
 
-          <div className="px-4 py-4">
+          <div className="px-6 py-5">
             {createValues && (
               <TimelineShiftEditor
                 mode="create"
@@ -780,7 +777,7 @@ function TimelineCreatePopoverContent({
             )}
           </div>
 
-          <div className="px-4 py-3 border-t border-border/40 flex items-center justify-end gap-2">
+          <div className="px-6 pb-6 flex items-center justify-end gap-2">
             <Button
               variant="ghost"
               onClick={onClose}
@@ -797,8 +794,8 @@ function TimelineCreatePopoverContent({
               Add shift
             </Button>
           </div>
-        </PopoverContent>
-      </Popover>
+        </DialogContent>
+      </Dialog>
 
       <AvailabilityConflictDialog
         open={conflictDialogOpen}

--- a/src/components/scheduling/ShiftTimeline/TimelineShiftPopover.tsx
+++ b/src/components/scheduling/ShiftTimeline/TimelineShiftPopover.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import {
   Popover,
@@ -28,16 +28,30 @@ import { TimelineShiftEditor, type TimelineShiftEditorValues } from './TimelineS
 import type { Shift, Employee, ConflictCheck } from '@/types/scheduling';
 import type { ValidationIssue } from '@/lib/shiftValidator';
 import type { ValidationResult } from '@/lib/shiftValidator';
-import type { UpdateTimeOutcome } from '@/hooks/useValidatedShiftMutations';
+import type {
+  UpdateTimeOutcome,
+  CreateAtTimeOutcome,
+  CreateAtTimeInput,
+} from '@/hooks/useValidatedShiftMutations';
 
 /** Minimal shape needed to anchor the Radix popper to an arbitrary rect. */
 interface VirtualAnchor {
   getBoundingClientRect: () => DOMRect;
 }
 
+/** Prefilled draft for the paint-to-create quick-add flow — mutually exclusive with `activeShift`. */
+export interface TimelineCreateDraft {
+  values: TimelineShiftEditorValues;
+  laneContext: { position?: string | null; area?: string | null };
+  /** The calendar date (YYYY-MM-DD) the draft's times are relative to. */
+  businessDate: string;
+}
+
 interface TimelineShiftPopoverProps {
   /** The currently active shift to show, or null when none is selected. */
   readonly activeShift: Shift | null;
+  /** Prefilled create-mode draft (paint-to-create quick-add), or null/absent when not in create mode. */
+  readonly createDraft?: TimelineCreateDraft | null;
   /** Restaurant IANA timezone for displaying local times. */
   readonly tz: string;
   /** The calendar date string (YYYY-MM-DD) of the selected day. */
@@ -64,6 +78,10 @@ interface TimelineShiftPopoverProps {
     endIso: string;
     businessDate: string;
   }) => Promise<boolean>;
+  /** Validate a create-at-time (quick-add) request; returns pending issues instead of throwing. */
+  readonly validateAndCreateAtTime?: (input: CreateAtTimeInput) => Promise<CreateAtTimeOutcome>;
+  /** Force-apply a create-at-time request after the user confirms the conflict dialog. */
+  readonly forceCreateAtTime?: (input: CreateAtTimeInput) => Promise<boolean>;
   /** Delete a shift by id (immediate — the confirm gate lives in this component for published shifts). */
   readonly deleteShift: (shiftId: string) => void;
   /** Surfaced validation errors (e.g. a thrown lock/interval error) from the pipeline hook. */
@@ -133,6 +151,7 @@ function shiftToEditorValues(shift: Shift, dateStr: string, tz: string): Timelin
  */
 export function TimelineShiftPopover({
   activeShift,
+  createDraft,
   tz,
   dateStr,
   employees,
@@ -141,6 +160,8 @@ export function TimelineShiftPopover({
   onClose,
   validateAndUpdateTime,
   forceUpdateTime,
+  validateAndCreateAtTime,
+  forceCreateAtTime,
   deleteShift,
   validationResult,
   clearValidation,
@@ -149,6 +170,9 @@ export function TimelineShiftPopover({
 }: TimelineShiftPopoverProps) {
   const [mode, setMode] = useState<'view' | 'edit'>('view');
   const [editValues, setEditValues] = useState<TimelineShiftEditorValues | null>(null);
+  const [createValues, setCreateValues] = useState<TimelineShiftEditorValues | null>(
+    createDraft?.values ?? null,
+  );
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [pendingIssues, setPendingIssues] = useState<{
     conflicts: ConflictCheck[];
@@ -178,6 +202,44 @@ export function TimelineShiftPopover({
     resetLocalState();
     onClose();
   }, [resetLocalState, onClose]);
+
+  // Re-seed create-mode local state whenever the caller stages a fresh draft
+  // (a new paint gesture) — keeps the form controlled by `createValues` alone
+  // once mounted, so an in-progress create form isn't left dangling if a new
+  // draft replaces the old one while the popover is open.
+  useEffect(() => {
+    setCreateValues(createDraft?.values ?? null);
+    setPendingIssues(null);
+     
+  }, [createDraft]);
+
+  const isCreateMode = !activeShift && Boolean(createDraft);
+
+  if (!activeShift && !createDraft) return null;
+
+  if (isCreateMode) {
+    return (
+      <TimelineCreatePopoverContent
+        createDraft={createDraft as TimelineCreateDraft}
+        createValues={createValues}
+        onChangeValues={setCreateValues}
+        tz={tz}
+        employees={employees}
+        restaurantId={restaurantId}
+        dayShifts={dayShifts}
+        anchorRect={anchorRect ?? null}
+        collisionBoundary={collisionBoundary}
+        virtualAnchorRef={virtualAnchorRef}
+        validateAndCreateAtTime={validateAndCreateAtTime}
+        forceCreateAtTime={forceCreateAtTime}
+        pendingIssues={pendingIssues}
+        setPendingIssues={setPendingIssues}
+        saving={saving}
+        setSaving={setSaving}
+        onClose={handleClose}
+      />
+    );
+  }
 
   if (!activeShift) return null;
 
@@ -491,5 +553,229 @@ function Row({ label, value }: { readonly label: string; readonly value: string 
       </span>
       <span className="text-[13px] text-foreground">{value}</span>
     </div>
+  );
+}
+
+interface TimelineCreatePopoverContentProps {
+  readonly createDraft: TimelineCreateDraft;
+  readonly createValues: TimelineShiftEditorValues | null;
+  readonly onChangeValues: (values: TimelineShiftEditorValues) => void;
+  readonly tz: string;
+  readonly employees: Employee[];
+  readonly restaurantId: string;
+  readonly dayShifts: Shift[];
+  readonly anchorRect: DOMRect | null;
+  readonly collisionBoundary?: Element | null;
+  readonly virtualAnchorRef: { current: VirtualAnchor | null };
+  readonly validateAndCreateAtTime?: (input: CreateAtTimeInput) => Promise<CreateAtTimeOutcome>;
+  readonly forceCreateAtTime?: (input: CreateAtTimeInput) => Promise<boolean>;
+  readonly pendingIssues: { conflicts: ConflictCheck[]; warnings: ValidationIssue[] } | null;
+  readonly setPendingIssues: (
+    issues: { conflicts: ConflictCheck[]; warnings: ValidationIssue[] } | null,
+  ) => void;
+  readonly saving: boolean;
+  readonly setSaving: (saving: boolean) => void;
+  readonly onClose: () => void;
+}
+
+/**
+ * Create-mode variant of the single Timeline popover instance (Stage C3). Rendered by
+ * `TimelineShiftPopover` when `createDraft` is present and `activeShift` is null — mutually
+ * exclusive with the view/edit branch, so only one `Popover` is ever mounted.
+ *
+ * Resolves the shift's `position` at commit time: the lane's own position (position-grouped
+ * lane) wins; otherwise falls back to the selected employee's `position` (area-grouped lane,
+ * where a shift's area is derived from its employee rather than stored directly).
+ */
+function TimelineCreatePopoverContent({
+  createDraft,
+  createValues,
+  onChangeValues,
+  tz,
+  employees,
+  restaurantId,
+  dayShifts,
+  anchorRect,
+  collisionBoundary,
+  virtualAnchorRef,
+  validateAndCreateAtTime,
+  forceCreateAtTime,
+  pendingIssues,
+  setPendingIssues,
+  saving,
+  setSaving,
+  onClose,
+}: TimelineCreatePopoverContentProps) {
+  const { businessDate, laneContext } = createDraft;
+
+  const resolvePosition = useCallback(
+    (values: TimelineShiftEditorValues): string => {
+      if (laneContext.position) return laneContext.position;
+      const employee = employees.find((e) => e.id === values.employeeId);
+      return employee?.position ?? '';
+    },
+    [laneContext.position, employees],
+  );
+
+  const buildIso = useCallback(
+    (values: TimelineShiftEditorValues) => {
+      const startMin = timeToMinutes(values.startTime);
+      let endMinValue = timeToMinutes(values.endTime);
+      if (endMinValue <= startMin) endMinValue += 1440;
+
+      return {
+        startIso: minutesToIso(businessDate, startMin, tz),
+        endIso: minutesToIso(businessDate, endMinValue, tz),
+      };
+    },
+    [businessDate, tz],
+  );
+
+  const buildCreateInput = useCallback(
+    (values: TimelineShiftEditorValues): CreateAtTimeInput => {
+      const { startIso, endIso } = buildIso(values);
+      return {
+        employeeId: values.employeeId,
+        startIso,
+        endIso,
+        businessDate,
+        position: resolvePosition(values),
+        breakDuration: Number(values.breakDuration) || 0,
+        notes: values.notes,
+      };
+    },
+    [buildIso, businessDate, resolvePosition],
+  );
+
+  const handleAdd = async () => {
+    if (!createValues || !validateAndCreateAtTime) return;
+
+    setSaving(true);
+    try {
+      const outcome = await validateAndCreateAtTime(buildCreateInput(createValues));
+
+      if (outcome.created) {
+        onClose();
+        return;
+      }
+
+      if (outcome.pendingConflicts?.length || outcome.pendingWarnings?.length) {
+        setPendingIssues({
+          conflicts: outcome.pendingConflicts ?? [],
+          warnings: outcome.pendingWarnings ?? [],
+        });
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleConfirmConflicts = async () => {
+    if (!createValues || !forceCreateAtTime) return;
+
+    setSaving(true);
+    try {
+      const ok = await forceCreateAtTime(buildCreateInput(createValues));
+
+      if (ok) {
+        setPendingIssues(null);
+        onClose();
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleCancelConflicts = () => {
+    setPendingIssues(null);
+  };
+
+  const conflictDialogOpen = pendingIssues !== null;
+  const conflictDialogData = pendingIssues
+    ? {
+        employeeName:
+          employees.find((e) => e.id === createValues?.employeeId)?.name ?? 'This employee',
+        conflicts: pendingIssues.conflicts,
+        warnings: pendingIssues.warnings,
+      }
+    : null;
+
+  const subtitle = laneContext.position || laneContext.area || null;
+
+  return (
+    <>
+      <Popover
+        open
+        modal={false}
+        onOpenChange={(open) => {
+          if (!open && !conflictDialogOpen) onClose();
+        }}
+      >
+        {anchorRect ? (
+          <PopoverAnchor virtualRef={virtualAnchorRef as unknown as React.RefObject<VirtualAnchor>} />
+        ) : (
+          <PopoverTrigger asChild>
+            <span className="sr-only" />
+          </PopoverTrigger>
+        )}
+
+        <PopoverContent
+          className="w-72 p-0 gap-0 border-border/40"
+          align="center"
+          sideOffset={8}
+          collisionBoundary={collisionBoundary ?? undefined}
+        >
+          <div className="px-4 pt-4 pb-3 border-b border-border/40">
+            <p className="text-[14px] font-semibold text-foreground">New shift</p>
+            {subtitle && (
+              <p className="text-[12px] text-muted-foreground mt-0.5">{subtitle}</p>
+            )}
+          </div>
+
+          <div className="px-4 py-4">
+            {createValues && (
+              <TimelineShiftEditor
+                mode="create"
+                shift={null}
+                employees={employees}
+                restaurantId={restaurantId}
+                dateStr={businessDate}
+                tz={tz}
+                existingShifts={dayShifts}
+                values={createValues}
+                onChange={onChangeValues}
+                laneContext={laneContext}
+              />
+            )}
+          </div>
+
+          <div className="px-4 py-3 border-t border-border/40 flex items-center justify-end gap-2">
+            <Button
+              variant="ghost"
+              onClick={onClose}
+              disabled={saving}
+              className="h-9 px-4 rounded-lg text-[13px] font-medium text-muted-foreground hover:text-foreground"
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleAdd}
+              disabled={saving || !createValues?.employeeId}
+              className="h-9 px-4 rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium"
+            >
+              Add shift
+            </Button>
+          </div>
+        </PopoverContent>
+      </Popover>
+
+      <AvailabilityConflictDialog
+        open={conflictDialogOpen}
+        data={conflictDialogData}
+        timezone={tz}
+        onConfirm={handleConfirmConflicts}
+        onCancel={handleCancelConflicts}
+      />
+    </>
   );
 }

--- a/src/components/scheduling/ShiftTimeline/TimelineShiftPopover.tsx
+++ b/src/components/scheduling/ShiftTimeline/TimelineShiftPopover.tsx
@@ -30,6 +30,7 @@ import type { ValidationIssue } from '@/lib/shiftValidator';
 import type { ValidationResult } from '@/lib/shiftValidator';
 import type {
   UpdateTimeOutcome,
+  UpdateShiftOutcome,
   CreateAtTimeOutcome,
   CreateAtTimeInput,
 } from '@/hooks/useValidatedShiftMutations';
@@ -60,24 +61,52 @@ interface TimelineShiftPopoverProps {
   readonly employees: Employee[];
   /** Restaurant ID, forwarded to TimelineShiftEditor's conflict checks. */
   readonly restaurantId: string;
-  /** All shifts for the day, used for local overlap/rest-gap warnings while editing. */
-  readonly dayShifts: Shift[];
+  /**
+   * Full-week shifts (not day-scoped), used for local overlap/rest-gap warnings
+   * while editing — must include adjacent days so overnight shifts spilling in
+   * from the previous day, and early-next-day shifts, are still checked.
+   */
+  readonly existingShifts: Shift[];
   /** Called when the popover is closed or dismissed. */
   readonly onClose: () => void;
-  /** Validate a time-change; returns pending issues instead of throwing. */
+  /** Validate a time-change; returns pending issues instead of throwing. Used by the DRAG path (time-only). */
   readonly validateAndUpdateTime: (input: {
     shift: Shift;
     startIso: string;
     endIso: string;
     businessDate: string;
   }) => Promise<UpdateTimeOutcome>;
-  /** Force-apply a time change after the user confirms the conflict dialog. */
+  /** Force-apply a time change after the user confirms the conflict dialog. Used by the DRAG path (time-only). */
   readonly forceUpdateTime: (input: {
     shift: Shift;
     startIso: string;
     endIso: string;
     businessDate: string;
   }) => Promise<boolean>;
+  /**
+   * Validate a full-field edit (time + employee + break + notes); returns
+   * pending issues instead of throwing. Used by the edit-mode popover's Save
+   * so employee/break/notes changes are never silently dropped.
+   */
+  readonly validateAndUpdateShift: (input: {
+    shift: Shift;
+    startIso: string;
+    endIso: string;
+    businessDate: string;
+    employeeId: string;
+    breakDuration: number;
+    notes: string;
+  }) => Promise<UpdateShiftOutcome>;
+  /** Force-apply a full-field edit after the user confirms the conflict dialog. */
+  readonly forceUpdateShift: (input: {
+    shift: Shift;
+    startIso: string;
+    endIso: string;
+    businessDate: string;
+    employeeId: string;
+    breakDuration: number;
+    notes: string;
+  }) => Promise<UpdateShiftOutcome>;
   /** Validate a create-at-time (quick-add) request; returns pending issues instead of throwing. */
   readonly validateAndCreateAtTime?: (input: CreateAtTimeInput) => Promise<CreateAtTimeOutcome>;
   /** Force-apply a create-at-time request after the user confirms the conflict dialog. */
@@ -142,10 +171,12 @@ export function TimelineShiftPopover({
   dateStr,
   employees,
   restaurantId,
-  dayShifts,
+  existingShifts,
   onClose,
   validateAndUpdateTime,
   forceUpdateTime,
+  validateAndUpdateShift,
+  forceUpdateShift,
   validateAndCreateAtTime,
   forceCreateAtTime,
   deleteShift,
@@ -211,7 +242,7 @@ export function TimelineShiftPopover({
         tz={tz}
         employees={employees}
         restaurantId={restaurantId}
-        dayShifts={dayShifts}
+        existingShifts={existingShifts}
         anchorRect={anchorRect ?? null}
         collisionBoundary={collisionBoundary}
         virtualAnchorRef={virtualAnchorRef}
@@ -281,11 +312,14 @@ export function TimelineShiftPopover({
 
     setSaving(true);
     try {
-      const outcome = await validateAndUpdateTime({
+      const outcome = await validateAndUpdateShift({
         shift: activeShift,
         startIso,
         endIso,
         businessDate: dateStr,
+        employeeId: editValues.employeeId,
+        breakDuration: Number(editValues.breakDuration) || 0,
+        notes: editValues.notes,
       });
 
       if (outcome.updated) {
@@ -314,14 +348,17 @@ export function TimelineShiftPopover({
 
     setSaving(true);
     try {
-      const ok = await forceUpdateTime({
+      const outcome = await forceUpdateShift({
         shift: activeShift,
         startIso,
         endIso,
         businessDate: dateStr,
+        employeeId: editValues.employeeId,
+        breakDuration: Number(editValues.breakDuration) || 0,
+        notes: editValues.notes,
       });
 
-      if (ok) {
+      if (outcome.updated) {
         setPendingIssues(null);
         handleClose();
       }
@@ -451,7 +488,7 @@ export function TimelineShiftPopover({
                     restaurantId={restaurantId}
                     dateStr={dateStr}
                     tz={tz}
-                    existingShifts={dayShifts}
+                    existingShifts={existingShifts}
                     values={editValues}
                     onChange={setEditValues}
                   />
@@ -544,7 +581,7 @@ interface TimelineCreatePopoverContentProps {
   readonly tz: string;
   readonly employees: Employee[];
   readonly restaurantId: string;
-  readonly dayShifts: Shift[];
+  readonly existingShifts: Shift[];
   readonly anchorRect: DOMRect | null;
   readonly collisionBoundary?: Element | null;
   readonly virtualAnchorRef: { current: VirtualAnchor | null };
@@ -575,7 +612,7 @@ function TimelineCreatePopoverContent({
   tz,
   employees,
   restaurantId,
-  dayShifts,
+  existingShifts,
   anchorRect,
   collisionBoundary,
   virtualAnchorRef,
@@ -720,7 +757,7 @@ function TimelineCreatePopoverContent({
                 restaurantId={restaurantId}
                 dateStr={businessDate}
                 tz={tz}
-                existingShifts={dayShifts}
+                existingShifts={existingShifts}
                 values={createValues}
                 onChange={onChangeValues}
                 laneContext={laneContext}

--- a/src/components/scheduling/ShiftTimeline/useTimelineBarDrag.ts
+++ b/src/components/scheduling/ShiftTimeline/useTimelineBarDrag.ts
@@ -1,0 +1,234 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+
+import { pointerToMinutes } from '@/lib/timelineDraft';
+import { moveShiftDraft, resizeShiftStart, resizeShiftEnd, type ShiftMinuteRange } from '@/lib/timelineDragMath';
+import type { TimelineWindow } from '@/lib/timelineModel';
+
+/** Which part of the bar a gesture is manipulating. */
+export type DragMode = 'move' | 'resize-start' | 'resize-end';
+
+export interface BarDragState {
+  mode: DragMode;
+  startMin: number;
+  endMin: number;
+}
+
+interface UseTimelineBarDragOptions {
+  /** The bar's current (committed) minute range — the drag's baseline. */
+  original: ShiftMinuteRange;
+  /** True when the shift is locked; disables all drag/resize gestures. */
+  locked: boolean;
+  /** Returns the plot region's bounding rect, read fresh on every pointer event. */
+  getPlotRect: () => DOMRect | null;
+  /** Returns the current visible window, read fresh on every pointer event (never a stale closure). */
+  getWindow: () => TimelineWindow;
+  /**
+   * Called on every rAF-throttled frame while dragging, with the live drafted
+   * range (for D2's live coverage merge). Called with `null` when the drag
+   * ends or is cancelled.
+   */
+  onDraftChange: (range: ShiftMinuteRange | null) => void;
+  /** Called on pointerup with the final drafted range — the caller commits it. */
+  onCommit: (range: ShiftMinuteRange) => void;
+}
+
+/** Pointer movement (px) below which a pointerup is treated as a click, not a drag. */
+const DRAG_THRESHOLD_PX = 5;
+
+/**
+ * Pointer-driven drag-move / edge-resize gesture for a single `TimelineBar`.
+ *
+ * - Body drag = move (duration preserved); edge handles = resize (15-min
+ *   floor). All edges snap to `STEP_MIN` via the pure reducers in
+ *   `timelineDragMath`.
+ * - `setPointerCapture` is used so the gesture keeps receiving move/up events
+ *   even if the pointer leaves the bar's bounding box mid-drag.
+ * - Click-vs-drag: a pointerdown+up sequence with movement below
+ *   `DRAG_THRESHOLD_PX` is treated as a tap, not a drag — `onCommit` is never
+ *   called and no draft is ever produced. Tap-to-edit is left entirely to the
+ *   bar's native `<button onClick>` (this hook never calls `onSelect`
+ *   itself), so a real click event — from a mouse click, a tap, or keyboard
+ *   Enter/Space — always reaches it exactly once.
+ * - Touch (`pointerType === 'touch'`) never drags: pointerdown on touch is a
+ *   no-op here (the bar's own `onClick` handles the tap-to-edit path via the
+ *   browser's native click synthesis), so the popover is the only way to
+ *   change times on a touch device.
+ * - Stale-closure discipline: `getPlotRect`/`getWindow` are called fresh on
+ *   every pointermove rather than closed over at pointerdown, since the
+ *   window/geometry can change while a drag is in flight (lesson 2026-06-04).
+ * - rAF throttle: draft-state commits (both the `onDraftChange` callback and
+ *   this hook's own `dragState` for the floating time readout) happen at most
+ *   once per animation frame, never per raw pointermove.
+ */
+export function useTimelineBarDrag({
+  original,
+  locked,
+  getPlotRect,
+  getWindow,
+  onDraftChange,
+  onCommit,
+}: UseTimelineBarDragOptions) {
+  const [dragState, setDragState] = useState<BarDragState | null>(null);
+
+  // Refs so the pointer-capture handlers (registered once per gesture, at
+  // pointerdown) always read the latest values rather than a stale closure
+  // from the render that started the gesture (lesson 2026-06-04).
+  const originalRef = useRef(original);
+  originalRef.current = original;
+  const onDraftChangeRef = useRef(onDraftChange);
+  onDraftChangeRef.current = onDraftChange;
+  const onCommitRef = useRef(onCommit);
+  onCommitRef.current = onCommit;
+
+  const gestureRef = useRef<{
+    mode: DragMode;
+    pointerId: number;
+    grabPointerMin: number;
+    grabClientX: number;
+    movedPx: number;
+    lastClientX: number;
+    rafHandle: number | null;
+    latestRange: ShiftMinuteRange;
+  } | null>(null);
+
+  const computeRange = useCallback((mode: DragMode, clientX: number): ShiftMinuteRange | null => {
+    const rect = getPlotRect();
+    if (!rect) return null;
+    const window = getWindow();
+    const pointerMin = pointerToMinutes(clientX, rect, window);
+    const base = originalRef.current;
+    const gesture = gestureRef.current;
+
+    if (mode === 'move') {
+      const grabPointerMin = gesture?.grabPointerMin ?? pointerMin;
+      return moveShiftDraft(base, { grabPointerMin, currentPointerMin: pointerMin }, window);
+    }
+    if (mode === 'resize-start') {
+      return resizeShiftStart(base, pointerMin, window);
+    }
+    return resizeShiftEnd(base, pointerMin, window);
+  }, [getPlotRect, getWindow]);
+
+  const scheduleFrame = useCallback(() => {
+    const gesture = gestureRef.current;
+    if (!gesture || gesture.rafHandle !== null) return;
+    gesture.rafHandle = requestAnimationFrame(() => {
+      const g = gestureRef.current;
+      if (!g) return;
+      g.rafHandle = null;
+      const range = computeRange(g.mode, g.lastClientX);
+      if (!range) return;
+      g.latestRange = range;
+      setDragState({ mode: g.mode, startMin: range.startMin, endMin: range.endMin });
+      onDraftChangeRef.current(range);
+    });
+  }, [computeRange]);
+
+  const endGesture = useCallback((event: { pointerId: number; currentTarget: unknown }) => {
+    const gesture = gestureRef.current;
+    if (!gesture) return;
+
+    if (gesture.rafHandle !== null) {
+      cancelAnimationFrame(gesture.rafHandle);
+      gesture.rafHandle = null;
+    }
+
+    const target = event.currentTarget as { releasePointerCapture?: (id: number) => void } | null;
+    target?.releasePointerCapture?.(gesture.pointerId);
+
+    gestureRef.current = null;
+    setDragState(null);
+    onDraftChangeRef.current(null);
+
+    // Sub-threshold movement is a tap, not a drag: leave it to the bar's
+    // native onClick (fired by the browser after this pointerup) rather than
+    // calling onSelect ourselves, which would double-fire it.
+    if (gesture.movedPx < DRAG_THRESHOLD_PX) return;
+
+    onCommitRef.current(gesture.latestRange);
+  }, []);
+
+  const makePointerDownHandler = useCallback(
+    (mode: DragMode) => (event: React.PointerEvent<HTMLElement>) => {
+      if (locked) return;
+      // Touch never drags — a tap opens the popover via the bar's own onClick;
+      // every drag outcome is reachable through the popover's time fields.
+      if (event.pointerType === 'touch') return;
+
+      event.stopPropagation();
+
+      const rect = getPlotRect();
+      const window = getWindow();
+      const grabPointerMin = rect ? pointerToMinutes(event.clientX, rect, window) : 0;
+
+      gestureRef.current = {
+        mode,
+        pointerId: event.pointerId,
+        grabPointerMin,
+        grabClientX: event.clientX,
+        movedPx: 0,
+        lastClientX: event.clientX,
+        rafHandle: null,
+        latestRange: originalRef.current,
+      };
+
+      (event.currentTarget as unknown as { setPointerCapture?: (id: number) => void })
+        .setPointerCapture?.(event.pointerId);
+    },
+    [locked, getPlotRect, getWindow],
+  );
+
+  const handlePointerMove = useCallback(
+    (event: React.PointerEvent<HTMLElement>) => {
+      const gesture = gestureRef.current;
+      if (!gesture || gesture.pointerId !== event.pointerId) return;
+
+      // Track cumulative movement from the grab point (not per-event delta,
+      // which can be 0 in some synthetic/test dispatches) for click-vs-drag
+      // disambiguation.
+      gesture.lastClientX = event.clientX;
+      gesture.movedPx = Math.max(gesture.movedPx, Math.abs(event.clientX - gesture.grabClientX));
+
+      scheduleFrame();
+    },
+    [scheduleFrame],
+  );
+
+  const handlePointerUp = useCallback(
+    (event: React.PointerEvent<HTMLElement>) => {
+      const gesture = gestureRef.current;
+      if (!gesture || gesture.pointerId !== event.pointerId) return;
+      endGesture(event);
+    },
+    [endGesture],
+  );
+
+  const handlePointerCancel = useCallback(
+    (event: React.PointerEvent<HTMLElement>) => {
+      const gesture = gestureRef.current;
+      if (!gesture || gesture.pointerId !== event.pointerId) return;
+      // A cancelled gesture (e.g. browser-initiated) never commits — snap back
+      // by clearing the draft without calling onCommit or onTap.
+      if (gesture.rafHandle !== null) cancelAnimationFrame(gesture.rafHandle);
+      const target = event.currentTarget as { releasePointerCapture?: (id: number) => void } | null;
+      target?.releasePointerCapture?.(gesture.pointerId);
+      gestureRef.current = null;
+      setDragState(null);
+      onDraftChangeRef.current(null);
+    },
+    [],
+  );
+
+  return useMemo(
+    () => ({
+      dragState,
+      handleBodyPointerDown: makePointerDownHandler('move'),
+      handleStartHandlePointerDown: makePointerDownHandler('resize-start'),
+      handleEndHandlePointerDown: makePointerDownHandler('resize-end'),
+      handlePointerMove,
+      handlePointerUp,
+      handlePointerCancel,
+    }),
+    [dragState, makePointerDownHandler, handlePointerMove, handlePointerUp, handlePointerCancel],
+  );
+}

--- a/src/components/scheduling/ShiftTimeline/useTimelineBarDrag.ts
+++ b/src/components/scheduling/ShiftTimeline/useTimelineBarDrag.ts
@@ -136,6 +136,17 @@ export function useTimelineBarDrag({
     const target = event.currentTarget as { releasePointerCapture?: (id: number) => void } | null;
     target?.releasePointerCapture?.(gesture.pointerId);
 
+    // gesture.latestRange is only updated inside the rAF callback
+    // (scheduleFrame) — if pointerup arrives before that frame has run (a
+    // fast drag, or any pointerup dispatched with no intervening animation
+    // frame), latestRange would still be the untouched original range even
+    // though the pointer clearly moved past the drag threshold. Recompute
+    // synchronously from the last known pointer position — BEFORE clearing
+    // gestureRef, since computeRange reads gestureRef.current.grabPointerMin
+    // as its move-delta baseline — so the commit always reflects where the
+    // pointer actually ended up.
+    const finalRange = computeRange(gesture.mode, gesture.lastClientX) ?? gesture.latestRange;
+
     gestureRef.current = null;
     setDragState(null);
     onDraftChangeRef.current(null);
@@ -145,8 +156,8 @@ export function useTimelineBarDrag({
     // calling onSelect ourselves, which would double-fire it.
     if (gesture.movedPx < DRAG_THRESHOLD_PX) return;
 
-    onCommitRef.current(gesture.latestRange);
-  }, []);
+    onCommitRef.current(finalRange);
+  }, [computeRange]);
 
   const makePointerDownHandler = useCallback(
     (mode: DragMode) => (event: React.PointerEvent<HTMLElement>) => {

--- a/src/components/scheduling/ShiftTimeline/useTimelineBarDrag.ts
+++ b/src/components/scheduling/ShiftTimeline/useTimelineBarDrag.ts
@@ -188,6 +188,13 @@ export function useTimelineBarDrag({
 
   const makePointerDownHandler = useCallback(
     (mode: DragMode) => (event: React.PointerEvent<HTMLElement>) => {
+      // Fix 2 (stale click-suppression regression): a fresh pointerdown is a
+      // brand-new interaction, so any leftover "just finished a drag" flag from
+      // a PRIOR gesture is stale and must be cleared here — otherwise, if the
+      // browser's trailing synthetic `click` after a previous drag's pointerup
+      // never fired (e.g. the bar relaid out under the pointer), the flag would
+      // stay `true` forever and silently eat the next legitimate click.
+      justDraggedRef.current = false;
       if (locked) return;
       // Touch never drags — a tap opens the popover via the bar's own onClick;
       // every drag outcome is reachable through the popover's time fields.

--- a/src/components/scheduling/ShiftTimeline/useTimelineBarDrag.ts
+++ b/src/components/scheduling/ShiftTimeline/useTimelineBarDrag.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { pointerToMinutes } from '@/lib/timelineDraft';
 import { moveShiftDraft, resizeShiftStart, resizeShiftEnd, type ShiftMinuteRange } from '@/lib/timelineDragMath';
@@ -49,6 +49,12 @@ const DRAG_THRESHOLD_PX = 5;
  *   bar's native `<button onClick>` (this hook never calls `onSelect`
  *   itself), so a real click event — from a mouse click, a tap, or keyboard
  *   Enter/Space — always reaches it exactly once.
+ * - Suppressing the post-drag synthetic click (Codex P2 fix): a past-threshold
+ *   drag sets a one-shot flag, read via the returned `consumeJustDragged()`.
+ *   The caller (`TimelineBar`) must call it from its own `onClick` handler and
+ *   skip forwarding to `onSelect` when it returns true — otherwise the
+ *   trailing `click` the browser dispatches after the drag's pointerup would
+ *   reopen the edit popover right after every drag.
  * - Touch (`pointerType === 'touch'`) never drags: pointerdown on touch is a
  *   no-op here (the bar's own `onClick` handles the tap-to-edit path via the
  *   browser's native click synthesis), so the popover is the only way to
@@ -59,6 +65,9 @@ const DRAG_THRESHOLD_PX = 5;
  * - rAF throttle: draft-state commits (both the `onDraftChange` callback and
  *   this hook's own `dragState` for the floating time readout) happen at most
  *   once per animation frame, never per raw pointermove.
+ * - Unmount cleanup: any in-flight rAF handle is cancelled on unmount so no
+ *   frame callback fires (and calls setState) after the owning component is
+ *   gone.
  */
 export function useTimelineBarDrag({
   original,
@@ -90,6 +99,18 @@ export function useTimelineBarDrag({
     rafHandle: number | null;
     latestRange: ShiftMinuteRange;
   } | null>(null);
+
+  // Set for exactly one trailing click after a real (past-threshold) drag
+  // commits, so the caller can skip that browser-synthesized click instead of
+  // reopening the edit popover via onSelect. `consumeJustDragged` clears the
+  // flag as soon as it's read, so it only ever suppresses a single click.
+  const justDraggedRef = useRef(false);
+
+  const consumeJustDragged = useCallback(() => {
+    const was = justDraggedRef.current;
+    justDraggedRef.current = false;
+    return was;
+  }, []);
 
   const computeRange = useCallback((mode: DragMode, clientX: number): ShiftMinuteRange | null => {
     const rect = getPlotRect();
@@ -155,6 +176,12 @@ export function useTimelineBarDrag({
     // native onClick (fired by the browser after this pointerup) rather than
     // calling onSelect ourselves, which would double-fire it.
     if (gesture.movedPx < DRAG_THRESHOLD_PX) return;
+
+    // Past-threshold: a real drag. The browser still dispatches a trailing
+    // `click` on the bar after this pointerup — flag it so the caller's
+    // onClick handler can skip forwarding that one click to onSelect
+    // (otherwise every drag would also reopen the edit popover).
+    justDraggedRef.current = true;
 
     onCommitRef.current(finalRange);
   }, [computeRange]);
@@ -230,6 +257,19 @@ export function useTimelineBarDrag({
     [],
   );
 
+  // Unmount cleanup: cancel any in-flight rAF so a frame never fires after
+  // this hook's owner has unmounted (which would call setDragState on an
+  // unmounted component and touch a stale gestureRef). Runs once, on
+  // unmount only — deliberately not re-run per gesture start/end.
+  useEffect(() => {
+    return () => {
+      if (gestureRef.current?.rafHandle != null) {
+        cancelAnimationFrame(gestureRef.current.rafHandle);
+      }
+      gestureRef.current = null;
+    };
+  }, []);
+
   return useMemo(
     () => ({
       dragState,
@@ -239,7 +279,8 @@ export function useTimelineBarDrag({
       handlePointerMove,
       handlePointerUp,
       handlePointerCancel,
+      consumeJustDragged,
     }),
-    [dragState, makePointerDownHandler, handlePointerMove, handlePointerUp, handlePointerCancel],
+    [dragState, makePointerDownHandler, handlePointerMove, handlePointerUp, handlePointerCancel, consumeJustDragged],
   );
 }

--- a/src/components/scheduling/ShiftTimeline/useTimelineModel.ts
+++ b/src/components/scheduling/ShiftTimeline/useTimelineModel.ts
@@ -11,6 +11,7 @@ export {
   expandDemand,
   computeGaps,
   buildTimelineModel,
+  computeCoverage,
   STEP_MIN,
 } from '@/lib/timelineModel';
 export type {
@@ -19,6 +20,7 @@ export type {
   TimelineLane,
   TimelineGap,
   TimelineModel,
+  TimelineCoverage,
 } from '@/lib/timelineModel';
 
 /**

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -7,6 +7,8 @@ const Popover = PopoverPrimitive.Root;
 
 const PopoverTrigger = PopoverPrimitive.Trigger;
 
+const PopoverAnchor = PopoverPrimitive.Anchor;
+
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
@@ -26,4 +28,4 @@ const PopoverContent = React.forwardRef<
 ));
 PopoverContent.displayName = PopoverPrimitive.Content.displayName;
 
-export { Popover, PopoverTrigger, PopoverContent };
+export { Popover, PopoverTrigger, PopoverAnchor, PopoverContent };

--- a/src/hooks/useShiftPlanner.ts
+++ b/src/hooks/useShiftPlanner.ts
@@ -192,26 +192,58 @@ export function groupUnmatchedByArea(
 // Internal helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Metadata subset shared by every shift-insert payload builder — the fields that
+ * don't come from the time interval. Lets the host-local (`buildShiftPayload`) and
+ * ISO-instant (timeline) create paths share one payload shape without duplication.
+ */
+export interface ShiftInsertMeta {
+  employeeId: string;
+  position: string;
+  breakDuration?: number;
+  notes?: string;
+  shiftTemplateId?: string | null;
+}
+
+/** Build the shift-insert payload from an interval + non-time metadata. */
+export function buildShiftInsert(
+  restaurantId: string,
+  meta: ShiftInsertMeta,
+  interval: ShiftInterval,
+) {
+  return {
+    restaurant_id: restaurantId,
+    employee_id: meta.employeeId,
+    start_time: interval.startAt.toISOString(),
+    end_time: interval.endAt.toISOString(),
+    position: meta.position,
+    break_duration: meta.breakDuration ?? 0,
+    notes: meta.notes,
+    status: 'scheduled' as const,
+    is_published: false,
+    locked: false,
+    source: (meta.shiftTemplateId ? 'template' : 'manual') as 'template' | 'manual',
+    shift_template_id: meta.shiftTemplateId ?? null,
+  };
+}
+
 /** Build the mutation payload for creating a shift from validated inputs. */
 export function buildShiftPayload(
   restaurantId: string,
   input: ShiftCreateInput,
   interval: ShiftInterval,
 ) {
-  return {
-    restaurant_id: restaurantId,
-    employee_id: input.employeeId,
-    start_time: interval.startAt.toISOString(),
-    end_time: interval.endAt.toISOString(),
-    position: input.position,
-    break_duration: input.breakDuration ?? 0,
-    notes: input.notes,
-    status: 'scheduled' as const,
-    is_published: false,
-    locked: false,
-    source: (input.shiftTemplateId ? 'template' : 'manual') as 'template' | 'manual',
-    shift_template_id: input.shiftTemplateId ?? null,
-  };
+  return buildShiftInsert(
+    restaurantId,
+    {
+      employeeId: input.employeeId,
+      position: input.position,
+      breakDuration: input.breakDuration,
+      notes: input.notes,
+      shiftTemplateId: input.shiftTemplateId ?? null,
+    },
+    interval,
+  );
 }
 
 /**

--- a/src/hooks/useShiftPlanner.ts
+++ b/src/hooks/useShiftPlanner.ts
@@ -566,6 +566,7 @@ export function useShiftPlanner(
 
         await updateShift.mutateAsync({
           id: input.shift.id,
+          restaurant_id: restaurantId,
           start_time: interval.startAt.toISOString(),
           end_time: interval.endAt.toISOString(),
         });
@@ -606,6 +607,7 @@ export function useShiftPlanner(
 
         await updateShift.mutateAsync({
           id: input.shift.id,
+          restaurant_id: restaurantId,
           employee_id: input.newEmployeeId,
         });
 

--- a/src/hooks/useShiftPlanner.ts
+++ b/src/hooks/useShiftPlanner.ts
@@ -7,12 +7,12 @@
  */
 import { useState, useMemo, useCallback } from 'react';
 
-import { useShifts, useCreateShift, useUpdateShift, useDeleteShift } from '@/hooks/useShifts';
+import { useShifts } from '@/hooks/useShifts';
 import { useEmployees } from '@/hooks/useEmployees';
+import { useValidatedShiftMutations } from '@/hooks/useValidatedShiftMutations';
 
 import { ShiftInterval, formatLocalDate } from '@/lib/shiftInterval';
-import { validateShift, ValidationResult } from '@/lib/shiftValidator';
-import { checkConflictsImperative } from '@/hooks/useConflictDetection';
+import { ValidationResult } from '@/lib/shiftValidator';
 
 import { templateAppliesToDay } from '@/hooks/useShiftTemplates';
 import { UNASSIGNED } from '@/lib/templateAreaGrouping';
@@ -191,15 +191,6 @@ export function groupUnmatchedByArea(
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
-
-function errorToValidationResult(err: unknown, fallback: string): ValidationResult {
-  const message = err instanceof Error ? err.message : fallback;
-  return {
-    valid: false,
-    errors: [{ code: message, message }],
-    warnings: [],
-  };
-}
 
 /** Build the mutation payload for creating a shift from validated inputs. */
 export function buildShiftPayload(
@@ -398,10 +389,6 @@ export function useShiftPlanner(
   const weekEnd = useMemo(() => getWeekEnd(weekStart), [weekStart]);
   const weekDays = useMemo(() => getWeekDays(weekStart), [weekStart]);
 
-  // Validation state
-  const [validationResult, setValidationResult] =
-    useState<ValidationResult | null>(null);
-
   // Data hooks
   const { shifts, loading: shiftsLoading, error: shiftsError } = useShifts(
     restaurantId,
@@ -412,10 +399,8 @@ export function useShiftPlanner(
     status: 'active',
   });
 
-  // Mutation hooks
-  const createShift = useCreateShift();
-  const updateShift = useUpdateShift();
-  const deleteShiftMutation = useDeleteShift();
+  // Validated mutation pipeline (shared with the Timeline edit/create surface).
+  const pipeline = useValidatedShiftMutations(restaurantId, shifts);
 
   // Computed data
   const totalHours = useMemo(() => computeTotalHours(shifts), [shifts]);
@@ -448,86 +433,13 @@ export function useShiftPlanner(
     setWeekStart(getMondayOfWeek(monday));
   }, [setWeekStart]);
 
-  // Validation helper
-  const clearValidation = useCallback(() => {
-    setValidationResult(null);
-  }, []);
+  // Validation helper — delegates to the pipeline hook's own state.
+  const clearValidation = pipeline.clearValidation;
 
-  // Validated mutations
-  const validateAndCreate = useCallback(
-    async (input: ShiftCreateInput) => {
-      if (!restaurantId) return { created: false };
-
-      try {
-        const interval = ShiftInterval.create(
-          input.date,
-          input.startTime,
-          input.endTime,
-        );
-
-        const result = validateShift(
-          { employeeId: input.employeeId, interval },
-          shifts,
-        );
-
-        setValidationResult(result);
-
-        // Collect client-side warnings
-        const clientWarnings = [...result.warnings];
-
-        // Check availability/time-off conflicts via RPC
-        const { conflicts } = await checkConflictsImperative({
-          employeeId: input.employeeId,
-          restaurantId,
-          startTime: interval.startAt.toISOString(),
-          endTime: interval.endAt.toISOString(),
-        });
-
-        // If any warnings or conflicts, return them for confirmation dialog
-        if (clientWarnings.length > 0 || conflicts.length > 0) {
-          return {
-            created: false,
-            pendingConflicts: conflicts,
-            pendingWarnings: clientWarnings,
-            pendingInput: input,
-          };
-        }
-
-        // No issues — create immediately
-        await createShift.mutateAsync(buildShiftPayload(restaurantId, input, interval));
-
-        setValidationResult(null);
-        return { created: true };
-      } catch (err) {
-        setValidationResult(errorToValidationResult(err, 'Invalid shift'));
-        return { created: false };
-      }
-    },
-    [restaurantId, shifts, createShift],
-  );
-
-  const forceCreate = useCallback(
-    async (input: ShiftCreateInput): Promise<boolean> => {
-      if (!restaurantId) return false;
-
-      try {
-        const interval = ShiftInterval.create(
-          input.date,
-          input.startTime,
-          input.endTime,
-        );
-
-        await createShift.mutateAsync(buildShiftPayload(restaurantId, input, interval));
-
-        setValidationResult(null);
-        return true;
-      } catch (err) {
-        setValidationResult(errorToValidationResult(err, 'Failed to create shift'));
-        return false;
-      }
-    },
-    [restaurantId, createShift],
-  );
+  // Validated mutations — delegate to the shared pipeline (byte-compatible
+  // public API; see useValidatedShiftMutations for the actual logic).
+  const validateAndCreate = pipeline.validateAndCreate;
+  const forceCreate = pipeline.forceCreate;
 
   const validateAndUpdateTime = useCallback(
     async (input: {
@@ -535,50 +447,37 @@ export function useShiftPlanner(
       newStartTime: string;
       newEndTime: string;
     }): Promise<boolean> => {
-      if (!restaurantId) return false;
+      const [date, startTimePart] = input.newStartTime.split('T');
+      const [, endTimePart] = input.newEndTime.split('T');
+
+      if (!startTimePart || !endTimePart) {
+        return false;
+      }
+
+      const startHHMM = startTimePart.substring(0, 5);
+      const endHHMM = endTimePart.substring(0, 5);
 
       try {
-        const [date, startTimePart] = input.newStartTime.split('T');
-        const [, endTimePart] = input.newEndTime.split('T');
-
-        if (!startTimePart || !endTimePart) {
-          setValidationResult(errorToValidationResult(
-            new Error('Invalid time format'),
-            'Invalid shift time',
-          ));
-          return false;
-        }
-
-        const startHHMM = startTimePart.substring(0, 5);
-        const endHHMM = endTimePart.substring(0, 5);
-
+        // Reconstruct the host-local interval the same way the planner always
+        // has, then hand its ISO instants to the pipeline (fromTimestamps),
+        // preserving this hook's existing host-local create semantics.
         const interval = ShiftInterval.create(date, startHHMM, endHHMM);
 
-        const result = validateShift(
-          { employeeId: input.shift.employee_id, interval },
-          shifts,
-          { excludeShiftId: input.shift.id },
-        );
-
-        setValidationResult(result);
-
-        if (!result.valid) return false;
-
-        await updateShift.mutateAsync({
-          id: input.shift.id,
-          restaurant_id: restaurantId,
-          start_time: interval.startAt.toISOString(),
-          end_time: interval.endAt.toISOString(),
+        const { updated } = await pipeline.validateAndUpdateTime({
+          shift: input.shift,
+          startIso: interval.startAt.toISOString(),
+          endIso: interval.endAt.toISOString(),
+          businessDate: date,
         });
 
-        setValidationResult(null);
-        return true;
-      } catch (err) {
-        setValidationResult(errorToValidationResult(err, 'Invalid shift time'));
+        return updated;
+      } catch {
+        // ShiftInterval.create validation failure (e.g. invalid/zero duration).
+        // Matches this hook's pre-refactor contract: never throws, returns false.
         return false;
       }
     },
-    [restaurantId, shifts, updateShift],
+    [pipeline],
   );
 
   const validateAndReassign = useCallback(
@@ -586,48 +485,13 @@ export function useShiftPlanner(
       shift: Shift;
       newEmployeeId: string;
     }): Promise<boolean> => {
-      if (!restaurantId) return false;
-
-      try {
-        const interval = ShiftInterval.fromTimestamps(
-          input.shift.start_time,
-          input.shift.end_time,
-          input.shift.start_time.split('T')[0],
-        );
-
-        const result = validateShift(
-          { employeeId: input.newEmployeeId, interval },
-          shifts,
-          { excludeShiftId: input.shift.id },
-        );
-
-        setValidationResult(result);
-
-        if (!result.valid) return false;
-
-        await updateShift.mutateAsync({
-          id: input.shift.id,
-          restaurant_id: restaurantId,
-          employee_id: input.newEmployeeId,
-        });
-
-        setValidationResult(null);
-        return true;
-      } catch (err) {
-        setValidationResult(errorToValidationResult(err, 'Cannot reassign this shift'));
-        return false;
-      }
+      const { reassigned } = await pipeline.validateAndReassign(input);
+      return reassigned;
     },
-    [restaurantId, shifts, updateShift],
+    [pipeline],
   );
 
-  const handleDeleteShift = useCallback(
-    (shiftId: string) => {
-      if (!restaurantId) return;
-      deleteShiftMutation.mutate({ id: shiftId, restaurantId });
-    },
-    [restaurantId, deleteShiftMutation],
-  );
+  const handleDeleteShift = pipeline.deleteShift;
 
   return {
     weekStart,
@@ -646,7 +510,7 @@ export function useShiftPlanner(
     validateAndUpdateTime,
     validateAndReassign,
     deleteShift: handleDeleteShift,
-    validationResult,
+    validationResult: pipeline.validationResult,
     clearValidation,
     totalHours,
   };

--- a/src/hooks/useShifts.tsx
+++ b/src/hooks/useShifts.tsx
@@ -184,7 +184,11 @@ export function useUpdateShift() {
   const { toast } = useToast();
 
   return useMutation({
-    mutationFn: async ({ id, ...updates }: Partial<Shift> & { id: string }) => {
+    mutationFn: async ({
+      id,
+      restaurant_id: restaurantId,
+      ...updates
+    }: Partial<Shift> & { id: string; restaurant_id: string }) => {
       await assertShiftNotLocked(id);
 
       const { employee: _employee, ...shiftUpdates } = updates;
@@ -196,6 +200,7 @@ export function useUpdateShift() {
           recurrence_pattern: shiftUpdates.recurrence_pattern as unknown as Json,
         })
         .eq('id', id)
+        .eq('restaurant_id', restaurantId)
         .select()
         .single();
 
@@ -239,7 +244,11 @@ export function useDeleteShift() {
 
   return useMutation({
     mutationFn: async ({ id, restaurantId }: { id: string; restaurantId: string }) => {
-      const { error } = await supabase.from('shifts').delete().eq('id', id);
+      const { error } = await supabase
+        .from('shifts')
+        .delete()
+        .eq('id', id)
+        .eq('restaurant_id', restaurantId);
 
       if (error) throw error;
       return { id, restaurantId };

--- a/src/hooks/useShifts.tsx
+++ b/src/hooks/useShifts.tsx
@@ -86,7 +86,19 @@ export function useShifts(
 
 type ShiftInput = Omit<Shift, 'id' | 'created_at' | 'updated_at' | 'employee'>;
 
-export function useCreateShift() {
+export interface UseCreateShiftOptions {
+  /**
+   * When true, suppresses the generic "Shift created"/"Recurring shifts
+   * created successfully" success toast (the error toast still fires on
+   * failure). Used by the Timeline's undo-delete restore flow, which shows
+   * its own "Shift restored" toast instead. Defaults to false — every other
+   * caller's behavior is unchanged.
+   */
+  silent?: boolean;
+}
+
+export function useCreateShift(options: UseCreateShiftOptions = {}) {
+  const { silent = false } = options;
   const queryClient = useQueryClient();
   const { toast } = useToast();
 
@@ -99,6 +111,8 @@ export function useCreateShift() {
     },
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ['shifts', data.restaurant_id] });
+
+      if (silent) return;
 
       const isRecurring = data.is_recurring && data.recurrence_parent_id === null;
       toast({
@@ -263,7 +277,19 @@ async function assertShiftNotLocked(shiftId: string): Promise<void> {
   }
 }
 
-export function useDeleteShift() {
+export interface UseDeleteShiftOptions {
+  /**
+   * When true, suppresses the generic "Shift deleted" success toast (the
+   * error toast still fires on failure). Used by the Timeline's
+   * undo-delete flow, which shows its own "Shift deleted" toast with an
+   * Undo action instead. Defaults to false — every other caller's behavior
+   * is unchanged.
+   */
+  silent?: boolean;
+}
+
+export function useDeleteShift(options: UseDeleteShiftOptions = {}) {
+  const { silent = false } = options;
   const queryClient = useQueryClient();
   const { toast } = useToast();
 
@@ -280,6 +306,9 @@ export function useDeleteShift() {
     },
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ['shifts', data.restaurantId] });
+
+      if (silent) return;
+
       toast({
         title: 'Shift deleted',
         description: 'The shift has been removed from the schedule.',

--- a/src/hooks/useShifts.tsx
+++ b/src/hooks/useShifts.tsx
@@ -207,18 +207,43 @@ export function useUpdateShift() {
       if (error) throw error;
       return toTypedShift(data);
     },
-    onSuccess: (data) => {
-      queryClient.invalidateQueries({ queryKey: ['shifts', data.restaurant_id] });
-      toast({
-        title: 'Shift updated',
-        description: 'The shift has been updated.',
+    onMutate: async ({ id, restaurant_id: restaurantId, ...updates }) => {
+      await queryClient.cancelQueries({ queryKey: ['shifts', restaurantId] });
+
+      const previousData = queryClient.getQueriesData<Shift[]>({ queryKey: ['shifts', restaurantId] });
+
+      const { employee: _employee, ...optimisticUpdates } = updates;
+
+      queryClient.setQueriesData<Shift[]>({ queryKey: ['shifts', restaurantId] }, (old) => {
+        if (!old) return old;
+
+        return old.map((s) => (s.id === id ? { ...s, ...optimisticUpdates } : s));
       });
+
+      return { previousData };
     },
-    onError: (error: Error) => {
+    onError: (error: Error, _variables, context) => {
+      if (context?.previousData) {
+        context.previousData.forEach(([queryKey, data]) => {
+          queryClient.setQueryData(queryKey, data);
+        });
+      }
       toast({
         title: 'Error updating shift',
         description: error.message,
         variant: 'destructive',
+      });
+    },
+    onSettled: (data, _error, variables) => {
+      const restaurantId = data?.restaurant_id ?? variables?.restaurant_id;
+      if (restaurantId) {
+        queryClient.invalidateQueries({ queryKey: ['shifts', restaurantId] });
+      }
+    },
+    onSuccess: () => {
+      toast({
+        title: 'Shift updated',
+        description: 'The shift has been updated.',
       });
     },
   });

--- a/src/hooks/useValidatedShiftMutations.ts
+++ b/src/hooks/useValidatedShiftMutations.ts
@@ -208,6 +208,7 @@ export function useValidatedShiftMutations(
 
         await updateShift.mutateAsync({
           id: input.shift.id,
+          restaurant_id: restaurantId,
           start_time: interval.startAt.toISOString(),
           end_time: interval.endAt.toISOString(),
         });
@@ -237,6 +238,7 @@ export function useValidatedShiftMutations(
 
         await updateShift.mutateAsync({
           id: input.shift.id,
+          restaurant_id: restaurantId,
           start_time: interval.startAt.toISOString(),
           end_time: interval.endAt.toISOString(),
         });
@@ -285,6 +287,7 @@ export function useValidatedShiftMutations(
 
         await updateShift.mutateAsync({
           id: input.shift.id,
+          restaurant_id: restaurantId,
           employee_id: input.newEmployeeId,
         });
 
@@ -307,6 +310,7 @@ export function useValidatedShiftMutations(
       try {
         await updateShift.mutateAsync({
           id: input.shift.id,
+          restaurant_id: restaurantId,
           employee_id: input.newEmployeeId,
         });
 

--- a/src/hooks/useValidatedShiftMutations.ts
+++ b/src/hooks/useValidatedShiftMutations.ts
@@ -1,0 +1,350 @@
+/**
+ * useValidatedShiftMutations — the single validate→confirm→mutate pipeline for shift
+ * mutations, shared by the planner (`useShiftPlanner`) and the Timeline edit/create surface.
+ *
+ * Orchestrates `collectShiftIssues` (client-side `validateShift` + DI'd RPC conflict checker)
+ * with the `useShifts` mutation hooks. Every write path (create/update-time/reassign/delete)
+ * runs the same lock guard; update/reassign run all three validation layers (duration/overlap
+ * rules, clopen rest-gap, and server-side time-off/availability conflicts) and surface pending
+ * issues instead of silently proceeding, matching `useShiftPlanner.validateAndCreate`'s existing
+ * pending-confirmation UX.
+ *
+ * `validateAndUpdateTime` builds its interval via `ShiftInterval.fromTimestamps` — never the
+ * host-TZ `split('T')` + `ShiftInterval.create()` reconstruction, which would silently
+ * re-anchor the wall-clock time in the host's timezone instead of the restaurant's.
+ */
+import { useCallback, useState } from 'react';
+
+import { useCreateShift, useUpdateShift, useDeleteShift } from '@/hooks/useShifts';
+import { ShiftInterval } from '@/lib/shiftInterval';
+import { ValidationResult } from '@/lib/shiftValidator';
+import {
+  collectShiftIssues,
+  assertNotLockedClient,
+  type ConflictChecker,
+} from '@/lib/shiftMutationPipeline';
+import { buildShiftPayload, type ShiftCreateInput } from '@/hooks/useShiftPlanner';
+
+import type { Shift, ConflictCheck } from '@/types/scheduling';
+import type { ValidationIssue } from '@/lib/shiftValidator';
+
+export interface UpdateTimeInput {
+  shift: Shift;
+  startIso: string;
+  endIso: string;
+  businessDate: string;
+}
+
+export interface ReassignInput {
+  shift: Shift;
+  newEmployeeId: string;
+}
+
+export interface CreateOutcome {
+  created: boolean;
+  pendingConflicts?: ConflictCheck[];
+  pendingWarnings?: ValidationIssue[];
+  pendingInput?: ShiftCreateInput;
+}
+
+export interface UpdateTimeOutcome {
+  updated: boolean;
+  pendingConflicts?: ConflictCheck[];
+  pendingWarnings?: ValidationIssue[];
+}
+
+export interface ReassignOutcome {
+  reassigned: boolean;
+  pendingConflicts?: ConflictCheck[];
+  pendingWarnings?: ValidationIssue[];
+}
+
+export interface UseValidatedShiftMutationsOptions {
+  /** DI'd conflict checker for tests; defaults to the real `checkConflictsImperative`. */
+  checkConflicts?: ConflictChecker | false;
+}
+
+export interface UseValidatedShiftMutationsReturn {
+  validateAndCreate: (input: ShiftCreateInput) => Promise<CreateOutcome>;
+  forceCreate: (input: ShiftCreateInput) => Promise<boolean>;
+  validateAndUpdateTime: (input: UpdateTimeInput) => Promise<UpdateTimeOutcome>;
+  forceUpdateTime: (input: UpdateTimeInput) => Promise<boolean>;
+  validateAndReassign: (input: ReassignInput) => Promise<ReassignOutcome>;
+  forceReassign: (input: ReassignInput) => Promise<boolean>;
+  deleteShift: (shiftId: string) => void;
+  validationResult: ValidationResult | null;
+  clearValidation: () => void;
+}
+
+function errorToValidationResult(err: unknown, fallback: string): ValidationResult {
+  const message = err instanceof Error ? err.message : fallback;
+  return {
+    valid: false,
+    errors: [{ code: message, message }],
+    warnings: [],
+  };
+}
+
+/** Find a shift by id in the current in-memory list, throwing if it's missing. */
+function findShiftOrThrow(shifts: Shift[], shiftId: string): Shift {
+  const shift = shifts.find((s) => s.id === shiftId);
+  if (!shift) {
+    throw new Error(`Shift ${shiftId} not found`);
+  }
+  return shift;
+}
+
+export function useValidatedShiftMutations(
+  restaurantId: string | null,
+  shifts: Shift[],
+  options: UseValidatedShiftMutationsOptions = {},
+): UseValidatedShiftMutationsReturn {
+  const { checkConflicts } = options;
+
+  const [validationResult, setValidationResult] = useState<ValidationResult | null>(null);
+
+  const createShift = useCreateShift();
+  const updateShift = useUpdateShift();
+  const deleteShiftMutation = useDeleteShift();
+
+  const clearValidation = useCallback(() => {
+    setValidationResult(null);
+  }, []);
+
+  // ---------------------------------------------------------------------------
+  // Create (unchanged shape — host-local ShiftInterval.create, matching the
+  // planner's existing convention; the timeline builds ISO inputs upstream via
+  // minutesToIso before calling this).
+  // ---------------------------------------------------------------------------
+
+  const validateAndCreate = useCallback(
+    async (input: ShiftCreateInput): Promise<CreateOutcome> => {
+      if (!restaurantId) return { created: false };
+
+      try {
+        const interval = ShiftInterval.create(input.date, input.startTime, input.endTime);
+
+        const { warnings, conflicts } = await collectShiftIssues({
+          employeeId: input.employeeId,
+          restaurantId,
+          interval,
+          shifts,
+          checkConflicts,
+        });
+
+        setValidationResult({ valid: true, errors: [], warnings });
+
+        if (warnings.length > 0 || conflicts.length > 0) {
+          return {
+            created: false,
+            pendingConflicts: conflicts,
+            pendingWarnings: warnings,
+            pendingInput: input,
+          };
+        }
+
+        await createShift.mutateAsync(buildShiftPayload(restaurantId, input, interval));
+
+        setValidationResult(null);
+        return { created: true };
+      } catch (err) {
+        setValidationResult(errorToValidationResult(err, 'Invalid shift'));
+        return { created: false };
+      }
+    },
+    [restaurantId, shifts, checkConflicts, createShift],
+  );
+
+  const forceCreate = useCallback(
+    async (input: ShiftCreateInput): Promise<boolean> => {
+      if (!restaurantId) return false;
+
+      try {
+        const interval = ShiftInterval.create(input.date, input.startTime, input.endTime);
+
+        await createShift.mutateAsync(buildShiftPayload(restaurantId, input, interval));
+
+        setValidationResult(null);
+        return true;
+      } catch (err) {
+        setValidationResult(errorToValidationResult(err, 'Failed to create shift'));
+        return false;
+      }
+    },
+    [restaurantId, createShift],
+  );
+
+  // ---------------------------------------------------------------------------
+  // Update time — ShiftInterval.fromTimestamps (never host-TZ split+create).
+  // ---------------------------------------------------------------------------
+
+  const validateAndUpdateTime = useCallback(
+    async (input: UpdateTimeInput): Promise<UpdateTimeOutcome> => {
+      if (!restaurantId) return { updated: false };
+
+      assertNotLockedClient(input.shift);
+
+      try {
+        const interval = ShiftInterval.fromTimestamps(
+          input.startIso,
+          input.endIso,
+          input.businessDate,
+        );
+
+        const { warnings, conflicts } = await collectShiftIssues({
+          employeeId: input.shift.employee_id,
+          restaurantId,
+          interval,
+          shifts,
+          excludeShiftId: input.shift.id,
+          checkConflicts,
+        });
+
+        setValidationResult({ valid: true, errors: [], warnings });
+
+        if (warnings.length > 0 || conflicts.length > 0) {
+          return { updated: false, pendingConflicts: conflicts, pendingWarnings: warnings };
+        }
+
+        await updateShift.mutateAsync({
+          id: input.shift.id,
+          start_time: interval.startAt.toISOString(),
+          end_time: interval.endAt.toISOString(),
+        });
+
+        setValidationResult(null);
+        return { updated: true };
+      } catch (err) {
+        setValidationResult(errorToValidationResult(err, 'Invalid shift time'));
+        return { updated: false };
+      }
+    },
+    [restaurantId, shifts, checkConflicts, updateShift],
+  );
+
+  const forceUpdateTime = useCallback(
+    async (input: UpdateTimeInput): Promise<boolean> => {
+      if (!restaurantId) return false;
+
+      assertNotLockedClient(input.shift);
+
+      try {
+        const interval = ShiftInterval.fromTimestamps(
+          input.startIso,
+          input.endIso,
+          input.businessDate,
+        );
+
+        await updateShift.mutateAsync({
+          id: input.shift.id,
+          start_time: interval.startAt.toISOString(),
+          end_time: interval.endAt.toISOString(),
+        });
+
+        setValidationResult(null);
+        return true;
+      } catch (err) {
+        setValidationResult(errorToValidationResult(err, 'Failed to update shift'));
+        return false;
+      }
+    },
+    [restaurantId, updateShift],
+  );
+
+  // ---------------------------------------------------------------------------
+  // Reassign
+  // ---------------------------------------------------------------------------
+
+  const validateAndReassign = useCallback(
+    async (input: ReassignInput): Promise<ReassignOutcome> => {
+      if (!restaurantId) return { reassigned: false };
+
+      assertNotLockedClient(input.shift);
+
+      try {
+        const interval = ShiftInterval.fromTimestamps(
+          input.shift.start_time,
+          input.shift.end_time,
+          input.shift.start_time.split('T')[0],
+        );
+
+        const { warnings, conflicts } = await collectShiftIssues({
+          employeeId: input.newEmployeeId,
+          restaurantId,
+          interval,
+          shifts,
+          excludeShiftId: input.shift.id,
+          checkConflicts,
+        });
+
+        setValidationResult({ valid: true, errors: [], warnings });
+
+        if (warnings.length > 0 || conflicts.length > 0) {
+          return { reassigned: false, pendingConflicts: conflicts, pendingWarnings: warnings };
+        }
+
+        await updateShift.mutateAsync({
+          id: input.shift.id,
+          employee_id: input.newEmployeeId,
+        });
+
+        setValidationResult(null);
+        return { reassigned: true };
+      } catch (err) {
+        setValidationResult(errorToValidationResult(err, 'Cannot reassign this shift'));
+        return { reassigned: false };
+      }
+    },
+    [restaurantId, shifts, checkConflicts, updateShift],
+  );
+
+  const forceReassign = useCallback(
+    async (input: ReassignInput): Promise<boolean> => {
+      if (!restaurantId) return false;
+
+      assertNotLockedClient(input.shift);
+
+      try {
+        await updateShift.mutateAsync({
+          id: input.shift.id,
+          employee_id: input.newEmployeeId,
+        });
+
+        setValidationResult(null);
+        return true;
+      } catch (err) {
+        setValidationResult(errorToValidationResult(err, 'Cannot reassign this shift'));
+        return false;
+      }
+    },
+    [restaurantId, updateShift],
+  );
+
+  // ---------------------------------------------------------------------------
+  // Delete
+  // ---------------------------------------------------------------------------
+
+  const handleDeleteShift = useCallback(
+    (shiftId: string) => {
+      if (!restaurantId) return;
+
+      const shift = findShiftOrThrow(shifts, shiftId);
+      assertNotLockedClient(shift);
+
+      deleteShiftMutation.mutate({ id: shiftId, restaurantId });
+    },
+    [restaurantId, shifts, deleteShiftMutation],
+  );
+
+  return {
+    validateAndCreate,
+    forceCreate,
+    validateAndUpdateTime,
+    forceUpdateTime,
+    validateAndReassign,
+    forceReassign,
+    deleteShift: handleDeleteShift,
+    validationResult,
+    clearValidation,
+  };
+}

--- a/src/hooks/useValidatedShiftMutations.ts
+++ b/src/hooks/useValidatedShiftMutations.ts
@@ -127,6 +127,16 @@ export interface UseValidatedShiftMutationsReturn {
   validateAndReassign: (input: ReassignInput) => Promise<ReassignOutcome>;
   forceReassign: (input: ReassignInput) => Promise<boolean>;
   deleteShift: (shiftId: string) => void;
+  /**
+   * Awaitable, lock-guarded delete: runs the same `assertNotLockedClient` guard
+   * as `deleteShift`, then awaits the underlying mutation and resolves only
+   * once the row is actually gone (or rejects on failure/lock). Used by the
+   * Timeline's `deleteShiftWithUndo` flow so the undo affordance is only ever
+   * offered for a delete that's confirmed to have succeeded — the fire-and-forget
+   * `deleteShift` above can't provide that guarantee, so it's kept for callers
+   * (e.g. the planner) that don't need to await/react to the outcome.
+   */
+  deleteShiftAsync: (shiftId: string) => Promise<void>;
   validationResult: ValidationResult | null;
   clearValidation: () => void;
 }
@@ -574,6 +584,18 @@ export function useValidatedShiftMutations(
     [restaurantId, shifts, deleteShiftMutation],
   );
 
+  const deleteShiftAsync = useCallback(
+    async (shiftId: string): Promise<void> => {
+      if (!restaurantId) return;
+
+      const shift = findShiftOrThrow(shifts, shiftId);
+      assertNotLockedClient(shift);
+
+      await deleteShiftMutation.mutateAsync({ id: shiftId, restaurantId });
+    },
+    [restaurantId, shifts, deleteShiftMutation],
+  );
+
   return {
     validateAndCreate,
     forceCreate,
@@ -586,6 +608,7 @@ export function useValidatedShiftMutations(
     validateAndReassign,
     forceReassign,
     deleteShift: handleDeleteShift,
+    deleteShiftAsync,
     validationResult,
     clearValidation,
   };

--- a/src/hooks/useValidatedShiftMutations.ts
+++ b/src/hooks/useValidatedShiftMutations.ts
@@ -297,9 +297,9 @@ export function useValidatedShiftMutations(
     async (input: UpdateTimeInput): Promise<UpdateTimeOutcome> => {
       if (!restaurantId) return { updated: false };
 
-      assertNotLockedClient(input.shift);
-
       try {
+        assertNotLockedClient(input.shift);
+
         const interval = ShiftInterval.fromTimestamps(
           input.startIso,
           input.endIso,
@@ -342,9 +342,9 @@ export function useValidatedShiftMutations(
     async (input: UpdateTimeInput): Promise<boolean> => {
       if (!restaurantId) return false;
 
-      assertNotLockedClient(input.shift);
-
       try {
+        assertNotLockedClient(input.shift);
+
         const interval = ShiftInterval.fromTimestamps(
           input.startIso,
           input.endIso,

--- a/src/hooks/useValidatedShiftMutations.ts
+++ b/src/hooks/useValidatedShiftMutations.ts
@@ -51,6 +51,23 @@ export interface UpdateTimeInput {
   businessDate: string;
 }
 
+/**
+ * Full-field edit input for the Timeline popover's edit-mode Save: carries
+ * every field `TimelineShiftEditor` exposes (employee, break, notes) in
+ * addition to the time range, so a single Save persists all of them together
+ * instead of silently dropping the non-time fields (the bug `validateAndUpdateTime`
+ * alone produced — it only ever wrote start_time/end_time).
+ */
+export interface UpdateShiftInput {
+  shift: Shift;
+  startIso: string;
+  endIso: string;
+  businessDate: string;
+  employeeId: string;
+  breakDuration: number;
+  notes: string;
+}
+
 export interface ReassignInput {
   shift: Shift;
   newEmployeeId: string;
@@ -76,6 +93,9 @@ export interface UpdateTimeOutcome {
   pendingWarnings?: ValidationIssue[];
 }
 
+/** Same shape as `UpdateTimeOutcome` — the full-field edit pipeline mirrors the time-only one. */
+export type UpdateShiftOutcome = UpdateTimeOutcome;
+
 export interface ReassignOutcome {
   reassigned: boolean;
   pendingConflicts?: ConflictCheck[];
@@ -94,6 +114,8 @@ export interface UseValidatedShiftMutationsReturn {
   forceCreateAtTime: (input: CreateAtTimeInput) => Promise<boolean>;
   validateAndUpdateTime: (input: UpdateTimeInput) => Promise<UpdateTimeOutcome>;
   forceUpdateTime: (input: UpdateTimeInput) => Promise<boolean>;
+  validateAndUpdateShift: (input: UpdateShiftInput) => Promise<UpdateShiftOutcome>;
+  forceUpdateShift: (input: UpdateShiftInput) => Promise<UpdateShiftOutcome>;
   validateAndReassign: (input: ReassignInput) => Promise<ReassignOutcome>;
   forceReassign: (input: ReassignInput) => Promise<boolean>;
   deleteShift: (shiftId: string) => void;
@@ -369,6 +391,95 @@ export function useValidatedShiftMutations(
   );
 
   // ---------------------------------------------------------------------------
+  // Update shift (full-field edit — the Timeline popover's edit-mode Save).
+  // Unlike validateAndUpdateTime (time-only), this persists every field
+  // TimelineShiftEditor exposes — employee, break duration, notes — in a
+  // single mutateAsync call, and validates against the possibly-NEW employee
+  // (a reassign-on-save), not the shift's original one.
+  // ---------------------------------------------------------------------------
+
+  const validateAndUpdateShift = useCallback(
+    async (input: UpdateShiftInput): Promise<UpdateShiftOutcome> => {
+      if (!restaurantId) return { updated: false };
+
+      try {
+        assertNotLockedClient(input.shift);
+
+        const interval = ShiftInterval.fromTimestamps(
+          input.startIso,
+          input.endIso,
+          input.businessDate,
+        );
+
+        const { warnings, conflicts } = await collectShiftIssues({
+          employeeId: input.employeeId,
+          restaurantId,
+          interval,
+          shifts,
+          excludeShiftId: input.shift.id,
+          checkConflicts,
+        });
+
+        setValidationResult({ valid: true, errors: [], warnings });
+
+        if (warnings.length > 0 || conflicts.length > 0) {
+          return { updated: false, pendingConflicts: conflicts, pendingWarnings: warnings };
+        }
+
+        await updateShift.mutateAsync({
+          id: input.shift.id,
+          restaurant_id: restaurantId,
+          start_time: interval.startAt.toISOString(),
+          end_time: interval.endAt.toISOString(),
+          employee_id: input.employeeId,
+          break_duration: input.breakDuration,
+          notes: input.notes,
+        });
+
+        setValidationResult(null);
+        return { updated: true };
+      } catch (err) {
+        setValidationResult(errorToValidationResult(err, 'Invalid shift'));
+        return { updated: false };
+      }
+    },
+    [restaurantId, shifts, checkConflicts, updateShift],
+  );
+
+  const forceUpdateShift = useCallback(
+    async (input: UpdateShiftInput): Promise<UpdateShiftOutcome> => {
+      if (!restaurantId) return { updated: false };
+
+      try {
+        assertNotLockedClient(input.shift);
+
+        const interval = ShiftInterval.fromTimestamps(
+          input.startIso,
+          input.endIso,
+          input.businessDate,
+        );
+
+        await updateShift.mutateAsync({
+          id: input.shift.id,
+          restaurant_id: restaurantId,
+          start_time: interval.startAt.toISOString(),
+          end_time: interval.endAt.toISOString(),
+          employee_id: input.employeeId,
+          break_duration: input.breakDuration,
+          notes: input.notes,
+        });
+
+        setValidationResult(null);
+        return { updated: true };
+      } catch (err) {
+        setValidationResult(errorToValidationResult(err, 'Failed to update shift'));
+        return { updated: false };
+      }
+    },
+    [restaurantId, updateShift],
+  );
+
+  // ---------------------------------------------------------------------------
   // Reassign
   // ---------------------------------------------------------------------------
 
@@ -462,6 +573,8 @@ export function useValidatedShiftMutations(
     forceCreateAtTime,
     validateAndUpdateTime,
     forceUpdateTime,
+    validateAndUpdateShift,
+    forceUpdateShift,
     validateAndReassign,
     forceReassign,
     deleteShift: handleDeleteShift,

--- a/src/hooks/useValidatedShiftMutations.ts
+++ b/src/hooks/useValidatedShiftMutations.ts
@@ -105,6 +105,14 @@ export interface ReassignOutcome {
 export interface UseValidatedShiftMutationsOptions {
   /** DI'd conflict checker for tests; defaults to the real `checkConflictsImperative`. */
   checkConflicts?: ConflictChecker | false;
+  /**
+   * When true, suppresses the underlying `useDeleteShift` mutation's generic
+   * "Shift deleted" success toast. Used by the Timeline's `deleteShiftWithUndo`
+   * flow, which shows its own single toast (with an Undo action) instead of
+   * stacking a second, non-undoable one. Defaults to false — the planner's
+   * usage (no undo affordance) is unaffected.
+   */
+  silentDelete?: boolean;
 }
 
 export interface UseValidatedShiftMutationsReturn {
@@ -165,13 +173,13 @@ export function useValidatedShiftMutations(
   shifts: Shift[],
   options: UseValidatedShiftMutationsOptions = {},
 ): UseValidatedShiftMutationsReturn {
-  const { checkConflicts } = options;
+  const { checkConflicts, silentDelete = false } = options;
 
   const [validationResult, setValidationResult] = useState<ValidationResult | null>(null);
 
   const createShift = useCreateShift();
   const updateShift = useUpdateShift();
-  const deleteShiftMutation = useDeleteShift();
+  const deleteShiftMutation = useDeleteShift({ silent: silentDelete });
 
   const clearValidation = useCallback(() => {
     setValidationResult(null);

--- a/src/hooks/useValidatedShiftMutations.ts
+++ b/src/hooks/useValidatedShiftMutations.ts
@@ -23,10 +23,26 @@ import {
   assertNotLockedClient,
   type ConflictChecker,
 } from '@/lib/shiftMutationPipeline';
-import { buildShiftPayload, type ShiftCreateInput } from '@/hooks/useShiftPlanner';
+import { buildShiftPayload, buildShiftInsert, type ShiftCreateInput } from '@/hooks/useShiftPlanner';
 
 import type { Shift, ConflictCheck } from '@/types/scheduling';
 import type { ValidationIssue } from '@/lib/shiftValidator';
+
+/**
+ * TZ-safe create input for the Timeline surface: carries UTC ISO instants (built
+ * upstream by `minutesToIso`) rather than host-local `HH:MM`, so the shift is
+ * anchored in the restaurant's timezone regardless of the manager's device TZ.
+ */
+export interface CreateAtTimeInput {
+  employeeId: string;
+  startIso: string;
+  endIso: string;
+  businessDate: string;
+  position: string;
+  breakDuration?: number;
+  notes?: string;
+  shiftTemplateId?: string;
+}
 
 export interface UpdateTimeInput {
   shift: Shift;
@@ -45,6 +61,13 @@ export interface CreateOutcome {
   pendingConflicts?: ConflictCheck[];
   pendingWarnings?: ValidationIssue[];
   pendingInput?: ShiftCreateInput;
+}
+
+export interface CreateAtTimeOutcome {
+  created: boolean;
+  pendingConflicts?: ConflictCheck[];
+  pendingWarnings?: ValidationIssue[];
+  pendingInput?: CreateAtTimeInput;
 }
 
 export interface UpdateTimeOutcome {
@@ -67,6 +90,8 @@ export interface UseValidatedShiftMutationsOptions {
 export interface UseValidatedShiftMutationsReturn {
   validateAndCreate: (input: ShiftCreateInput) => Promise<CreateOutcome>;
   forceCreate: (input: ShiftCreateInput) => Promise<boolean>;
+  validateAndCreateAtTime: (input: CreateAtTimeInput) => Promise<CreateAtTimeOutcome>;
+  forceCreateAtTime: (input: CreateAtTimeInput) => Promise<boolean>;
   validateAndUpdateTime: (input: UpdateTimeInput) => Promise<UpdateTimeOutcome>;
   forceUpdateTime: (input: UpdateTimeInput) => Promise<boolean>;
   validateAndReassign: (input: ReassignInput) => Promise<ReassignOutcome>;
@@ -83,6 +108,25 @@ function errorToValidationResult(err: unknown, fallback: string): ValidationResu
     errors: [{ code: message, message }],
     warnings: [],
   };
+}
+
+/** Build the insert payload for a TZ-safe (ISO-instant) timeline create. */
+function buildAtTimeInsert(
+  restaurantId: string,
+  input: CreateAtTimeInput,
+  interval: ShiftInterval,
+) {
+  return buildShiftInsert(
+    restaurantId,
+    {
+      employeeId: input.employeeId,
+      position: input.position,
+      breakDuration: input.breakDuration,
+      notes: input.notes,
+      shiftTemplateId: input.shiftTemplateId ?? null,
+    },
+    interval,
+  );
 }
 
 /** Find a shift by id in the current in-memory list, throwing if it's missing. */
@@ -163,6 +207,77 @@ export function useValidatedShiftMutations(
         const interval = ShiftInterval.create(input.date, input.startTime, input.endTime);
 
         await createShift.mutateAsync(buildShiftPayload(restaurantId, input, interval));
+
+        setValidationResult(null);
+        return true;
+      } catch (err) {
+        setValidationResult(errorToValidationResult(err, 'Failed to create shift'));
+        return false;
+      }
+    },
+    [restaurantId, createShift],
+  );
+
+  // ---------------------------------------------------------------------------
+  // Create at time — TZ-safe timeline path. Builds the interval via
+  // ShiftInterval.fromTimestamps (never host-local .create), so ISO instants
+  // produced by minutesToIso are anchored in the restaurant's timezone.
+  // ---------------------------------------------------------------------------
+
+  const validateAndCreateAtTime = useCallback(
+    async (input: CreateAtTimeInput): Promise<CreateAtTimeOutcome> => {
+      if (!restaurantId) return { created: false };
+
+      try {
+        const interval = ShiftInterval.fromTimestamps(
+          input.startIso,
+          input.endIso,
+          input.businessDate,
+        );
+
+        const { warnings, conflicts } = await collectShiftIssues({
+          employeeId: input.employeeId,
+          restaurantId,
+          interval,
+          shifts,
+          checkConflicts,
+        });
+
+        setValidationResult({ valid: true, errors: [], warnings });
+
+        if (warnings.length > 0 || conflicts.length > 0) {
+          return {
+            created: false,
+            pendingConflicts: conflicts,
+            pendingWarnings: warnings,
+            pendingInput: input,
+          };
+        }
+
+        await createShift.mutateAsync(buildAtTimeInsert(restaurantId, input, interval));
+
+        setValidationResult(null);
+        return { created: true };
+      } catch (err) {
+        setValidationResult(errorToValidationResult(err, 'Invalid shift'));
+        return { created: false };
+      }
+    },
+    [restaurantId, shifts, checkConflicts, createShift],
+  );
+
+  const forceCreateAtTime = useCallback(
+    async (input: CreateAtTimeInput): Promise<boolean> => {
+      if (!restaurantId) return false;
+
+      try {
+        const interval = ShiftInterval.fromTimestamps(
+          input.startIso,
+          input.endIso,
+          input.businessDate,
+        );
+
+        await createShift.mutateAsync(buildAtTimeInsert(restaurantId, input, interval));
 
         setValidationResult(null);
         return true;
@@ -343,6 +458,8 @@ export function useValidatedShiftMutations(
   return {
     validateAndCreate,
     forceCreate,
+    validateAndCreateAtTime,
+    forceCreateAtTime,
     validateAndUpdateTime,
     forceUpdateTime,
     validateAndReassign,

--- a/src/lib/coverageSummary.ts
+++ b/src/lib/coverageSummary.ts
@@ -166,6 +166,70 @@ export function buildVerdict(hours: CoverageHour[]): CoverageVerdict {
   };
 }
 
+/**
+ * Expand a clicked understaffed hour into the contiguous run of understaffed
+ * (`delta < 0`) hours adjacent to it within the single day-wide hourly status
+ * strip, and return the merged `[startMin, endMin)` range covering that run.
+ *
+ * "Adjacent" means consecutive entries in `hours` whose `startMin` values are
+ * exactly 60 minutes apart — i.e. back-to-back cells in the strip, with no
+ * covered/no-demand hour in between. The walk stops as soon as it hits a
+ * non-short hour (covered or no-demand) or a gap in `startMin` continuity, so
+ * the merged range never crosses into a covered hour or jumps across a gap to
+ * reach a non-adjacent short run.
+ *
+ * If `clickedStartMin` doesn't match any hour in `hours` (shouldn't happen —
+ * only short cells are clickable), or the matching hour isn't itself short,
+ * the single matching (or nearest) hour is returned unchanged as a 60-minute
+ * range — this is a defensive fallback, not an expected call path.
+ */
+export function mergeUnderStaffedRange(
+  hours: CoverageHour[],
+  clickedStartMin: number,
+): { startMin: number; endMin: number } {
+  const clickedIndex = hours.findIndex((h) => h.startMin === clickedStartMin);
+
+  // Defensive fallback: no matching hour found — degrade to a single 60-min
+  // window at the requested minute rather than throwing.
+  if (clickedIndex === -1) {
+    return { startMin: clickedStartMin, endMin: clickedStartMin + HOUR };
+  }
+
+  const isShort = (h: CoverageHour) => h.delta !== null && h.delta < 0;
+
+  // Defensive fallback: the clicked hour isn't short — return just that hour.
+  if (!isShort(hours[clickedIndex])) {
+    return { startMin: clickedStartMin, endMin: clickedStartMin + HOUR };
+  }
+
+  // Walk backward from the clicked hour while the previous entry is short AND
+  // exactly one hour earlier (no gap).
+  let firstIndex = clickedIndex;
+  while (
+    firstIndex > 0 &&
+    isShort(hours[firstIndex - 1]) &&
+    hours[firstIndex - 1].startMin === hours[firstIndex].startMin - HOUR
+  ) {
+    firstIndex -= 1;
+  }
+
+  // Walk forward from the clicked hour while the next entry is short AND
+  // exactly one hour later (no gap).
+  let lastIndex = clickedIndex;
+  while (
+    lastIndex < hours.length - 1 &&
+    isShort(hours[lastIndex + 1]) &&
+    hours[lastIndex + 1].startMin === hours[lastIndex].startMin + HOUR
+  ) {
+    lastIndex += 1;
+  }
+
+  return {
+    startMin: hours[firstIndex].startMin,
+    endMin: hours[lastIndex].startMin + HOUR,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Per-area scheduled coverage (no per-area demand)
 // ---------------------------------------------------------------------------

--- a/src/lib/employeeRanking.ts
+++ b/src/lib/employeeRanking.ts
@@ -1,0 +1,64 @@
+/**
+ * employeeRanking — pure sort helper for the Timeline shift editor's employee
+ * picker. Prioritizes employees whose `area`/`position` matches the shift's
+ * lane context, so the most relevant candidates surface at the top of the
+ * `Select` list without filtering anyone out.
+ */
+import type { Employee } from '@/types/scheduling';
+
+export interface ShiftRankingContext {
+  /** The shift/lane's position (e.g. from a position-grouped lane or the form's position field). */
+  position?: string | null;
+  /** The shift/lane's area (e.g. from an area-grouped lane). */
+  area?: string | null;
+}
+
+function matchesCaseInsensitive(value: string | null | undefined, target: string): boolean {
+  return !!value && value.trim().toLowerCase() === target.trim().toLowerCase();
+}
+
+/**
+ * Rank a score for sort ordering: lower sorts first.
+ * 0 = matches both area and position (when both context values are given)
+ * 1 = matches area only (area context takes priority over position)
+ * 2 = matches position only
+ * 3 = matches neither
+ */
+function rankScore(employee: Employee, context: ShiftRankingContext): number {
+  const areaMatch = context.area ? matchesCaseInsensitive(employee.area, context.area) : false;
+  const positionMatch = context.position
+    ? matchesCaseInsensitive(employee.position, context.position)
+    : false;
+
+  if (context.area && context.position) {
+    if (areaMatch && positionMatch) return 0;
+    if (areaMatch) return 1;
+    if (positionMatch) return 2;
+    return 3;
+  }
+
+  if (context.area) {
+    return areaMatch ? 0 : 1;
+  }
+
+  if (context.position) {
+    return positionMatch ? 0 : 1;
+  }
+
+  return 0;
+}
+
+/**
+ * Sort employees so the ones matching the shift's lane context (position
+ * and/or area) come first. Stable — employees within the same rank keep
+ * their original relative order. Never mutates the input array.
+ */
+export function rankEmployeesForShift(
+  employees: Employee[],
+  context: ShiftRankingContext,
+): Employee[] {
+  return employees
+    .map((employee, index) => ({ employee, index, score: rankScore(employee, context) }))
+    .sort((a, b) => a.score - b.score || a.index - b.index)
+    .map((entry) => entry.employee);
+}

--- a/src/lib/employeeRanking.ts
+++ b/src/lib/employeeRanking.ts
@@ -18,6 +18,18 @@ function matchesCaseInsensitive(value: string | null | undefined, target: string
 }
 
 /**
+ * Score when BOTH area and position context are supplied: area match ranks
+ * above a position-only match. Extracted so `rankScore` stays within Sonar's
+ * cognitive-complexity budget.
+ */
+function scoreBothContext(areaMatch: boolean, positionMatch: boolean): number {
+  if (areaMatch && positionMatch) return 0;
+  if (areaMatch) return 1;
+  if (positionMatch) return 2;
+  return 3;
+}
+
+/**
  * Rank a score for sort ordering: lower sorts first.
  * 0 = matches both area and position (when both context values are given)
  * 1 = matches area only (area context takes priority over position)
@@ -30,21 +42,9 @@ function rankScore(employee: Employee, context: ShiftRankingContext): number {
     ? matchesCaseInsensitive(employee.position, context.position)
     : false;
 
-  if (context.area && context.position) {
-    if (areaMatch && positionMatch) return 0;
-    if (areaMatch) return 1;
-    if (positionMatch) return 2;
-    return 3;
-  }
-
-  if (context.area) {
-    return areaMatch ? 0 : 1;
-  }
-
-  if (context.position) {
-    return positionMatch ? 0 : 1;
-  }
-
+  if (context.area && context.position) return scoreBothContext(areaMatch, positionMatch);
+  if (context.area) return areaMatch ? 0 : 1;
+  if (context.position) return positionMatch ? 0 : 1;
   return 0;
 }
 

--- a/src/lib/shiftMutationPipeline.ts
+++ b/src/lib/shiftMutationPipeline.ts
@@ -1,0 +1,85 @@
+/**
+ * shiftMutationPipeline — pure orchestration of shift-mutation validation.
+ *
+ * Composes the client-side `validateShift` business-rule checks with an
+ * injected (DI'd) server-side conflict checker (time-off / availability RPCs)
+ * so callers get a single `{ warnings, conflicts }` result to drive the
+ * pending-confirmation UX. No side effects beyond the injected checker call —
+ * this module performs no mutations itself.
+ */
+import { ShiftInterval } from './shiftInterval';
+import { validateShift, type ValidationIssue } from './shiftValidator';
+import { checkConflictsImperative } from '@/hooks/useConflictDetection';
+import type { Shift, ConflictCheck } from '@/types/scheduling';
+
+export type ConflictChecker = typeof checkConflictsImperative;
+
+export interface CollectShiftIssuesArgs {
+  employeeId: string;
+  restaurantId: string;
+  interval: ShiftInterval;
+  shifts: Shift[];
+  excludeShiftId?: string;
+  /**
+   * DI'd conflict checker (time-off / availability RPCs). Defaults to the
+   * real `checkConflictsImperative`. Pass `false` to skip the RPC check
+   * entirely (e.g. when the caller only needs client-side rule warnings).
+   */
+  checkConflicts?: ConflictChecker | false;
+}
+
+export interface CollectShiftIssuesResult {
+  warnings: ValidationIssue[];
+  conflicts: ConflictCheck[];
+}
+
+/**
+ * Collects every shift-mutation issue: local business-rule warnings
+ * (duration, overlap, clopen rest-gap) plus server-side conflicts (time-off,
+ * availability) via the injected checker. Never swallows a checker
+ * rejection — it propagates so callers can surface a real error instead of
+ * silently proceeding as if no conflicts existed.
+ */
+export async function collectShiftIssues(
+  args: CollectShiftIssuesArgs,
+): Promise<CollectShiftIssuesResult> {
+  const { employeeId, restaurantId, interval, shifts, excludeShiftId, checkConflicts } = args;
+
+  const { warnings } = validateShift(
+    { employeeId, interval },
+    shifts,
+    { excludeShiftId },
+  );
+
+  if (checkConflicts === false) {
+    return { warnings, conflicts: [] };
+  }
+
+  const checker = checkConflicts ?? checkConflictsImperative;
+  const { conflicts } = await checker({
+    employeeId,
+    restaurantId,
+    startTime: interval.startAt.toISOString(),
+    endTime: interval.endAt.toISOString(),
+  });
+
+  return { warnings, conflicts };
+}
+
+/** Typed error thrown when a mutation is attempted against a locked (published) shift. */
+export class LockedShiftError extends Error {
+  readonly shiftId: string;
+
+  constructor(shiftId: string) {
+    super('Cannot modify a locked shift. The schedule has been published.');
+    this.name = 'LockedShiftError';
+    this.shiftId = shiftId;
+  }
+}
+
+/** Throws `LockedShiftError` if the shift is locked; no-op otherwise. */
+export function assertNotLockedClient(shift: Shift): void {
+  if (shift.locked) {
+    throw new LockedShiftError(shift.id);
+  }
+}

--- a/src/lib/shiftTimeMath.ts
+++ b/src/lib/shiftTimeMath.ts
@@ -49,3 +49,37 @@ export function snapToStep(min: number, step: number = STEP_MIN): number {
   const snapped = Math.round(min / step) * step;
   return snapped === 0 ? 0 : snapped;
 }
+
+/** Parse a 24h "HH:MM" string into minutes-since-midnight. */
+export function timeToMinutes(time: string): number {
+  const [h, m] = time.split(':').map(Number);
+  return h * 60 + m;
+}
+
+/**
+ * Format minutes-since-midnight (may be negative or >= 1440, e.g. an
+ * overnight shift's end minute) as 24h "HH:MM" of that wrapped time-of-day.
+ */
+export function minutesToHHMM(min: number): string {
+  const norm = ((min % 1440) + 1440) % 1440;
+  const h = Math.floor(norm / 60);
+  const m = norm % 60;
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+}
+
+/**
+ * Parse a shift's "HH:MM" start/end pair into minutes-since-midnight,
+ * resolving overnight shifts by rolling `endMin` past 1440 whenever
+ * `end <= start` (the timeline's overnight convention — e.g. a shift from
+ * 22:00 to 06:00 becomes `{ startMin: 1320, endMin: 1800 }`, and a 24h shift
+ * from 09:00 to 09:00 becomes `{ startMin: 540, endMin: 1980 }`).
+ */
+export function resolveOvernightMinutes(
+  startHHMM: string,
+  endHHMM: string,
+): { startMin: number; endMin: number } {
+  const startMin = timeToMinutes(startHHMM);
+  let endMin = timeToMinutes(endHHMM);
+  if (endMin <= startMin) endMin += 1440;
+  return { startMin, endMin };
+}

--- a/src/lib/shiftTimeMath.ts
+++ b/src/lib/shiftTimeMath.ts
@@ -1,0 +1,51 @@
+import { fromZonedTime } from 'date-fns-tz';
+import { STEP_MIN } from '@/lib/timelineModel';
+
+/**
+ * Convert restaurant-local minutes-since-midnight (on `dateStr`) to a UTC ISO
+ * string, honoring the restaurant's timezone's DST rules via `fromZonedTime`.
+ *
+ * `minutes` may exceed 1440 to express an overnight shift end (e.g. a shift
+ * starting at 22:00 and ending 8 hours later is represented as 1800 minutes,
+ * i.e. 30:00). The overflow is resolved by rolling the calendar date forward
+ * by `floor(minutes / 1440)` days and using the remainder as the time-of-day,
+ * so the wall-clock time-of-day is always resolved against the correct
+ * (rolled-forward) calendar day before DST is applied — this is what makes a
+ * shift that starts before a spring-forward/fall-back transition and ends
+ * after it convert correctly.
+ */
+export function minutesToIso(dateStr: string, minutes: number, tz: string): string {
+  const daysOverflow = Math.floor(minutes / 1440);
+  const minutesOfDay = minutes - daysOverflow * 1440;
+
+  const hours = Math.floor(minutesOfDay / 60);
+  const mins = minutesOfDay % 60;
+
+  const [year, month, day] = dateStr.split('-').map(Number);
+  // Roll the calendar date forward using local (TZ-agnostic) date arithmetic
+  // via Date's UTC fields, then reformat as YYYY-MM-DD. Using Date.UTC keeps
+  // this arithmetic independent of the host process's timezone.
+  const rolled = new Date(Date.UTC(year, month - 1, day + daysOverflow));
+  const rolledDateStr = [
+    rolled.getUTCFullYear(),
+    String(rolled.getUTCMonth() + 1).padStart(2, '0'),
+    String(rolled.getUTCDate()).padStart(2, '0'),
+  ].join('-');
+
+  const timeStr = `${String(hours).padStart(2, '0')}:${String(mins).padStart(2, '0')}:00`;
+
+  return fromZonedTime(`${rolledDateStr}T${timeStr}`, tz).toISOString();
+}
+
+/**
+ * Snap a minute value to the nearest `step` (default `STEP_MIN`), rounding
+ * half-up (ties round away from zero toward the next step boundary in the
+ * positive direction), matching the timeline's drag-snap semantics.
+ */
+export function snapToStep(min: number, step: number = STEP_MIN): number {
+  // `Math.round(min / step) * step` can produce `-0` (e.g. min=-7, step=15 ->
+  // Math.round(-0.466...) === -0), which fails strict `Object.is`/`toBe`
+  // equality against `0` even though `-0 === 0`. Normalize away.
+  const snapped = Math.round(min / step) * step;
+  return snapped === 0 ? 0 : snapped;
+}

--- a/src/lib/timelineDraft.ts
+++ b/src/lib/timelineDraft.ts
@@ -7,7 +7,7 @@
  * wiring and simply feed `clientX`/rects/window through these helpers.
  */
 import { STEP_MIN, type TimelineWindow } from '@/lib/timelineModel';
-import { snapToStep, minutesToIso } from '@/lib/shiftTimeMath';
+import { snapToStep, minutesToIso, minutesToHHMM } from '@/lib/shiftTimeMath';
 import type { TimelineShiftEditorValues } from '@/components/scheduling/ShiftTimeline/TimelineShiftEditor';
 import type { Shift } from '@/types/scheduling';
 
@@ -157,14 +157,6 @@ export function endPaint(draft: PaintDraft, window: TimelineWindow): PaintRange 
 
 // ─── Draft-shift builder ────────────────────────────────────────────────────────
 
-/** Format restaurant-local minutes-since-midnight (may be >= 1440) as "HH:MM" of that day. */
-function minutesToTimeOfDay(min: number): string {
-  const norm = ((min % 1440) + 1440) % 1440;
-  const h = Math.floor(norm / 60);
-  const m = norm % 60;
-  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
-}
-
 export interface DraftShiftValues extends TimelineShiftEditorValues {
   /** Prefilled position, derived from lane context (blank for gap-click entry, no lane). */
   position: string;
@@ -189,8 +181,8 @@ export function buildDraftShiftValues(
 ): DraftShiftValues {
   return {
     employeeId: options.defaultEmployeeId ?? '',
-    startTime: minutesToTimeOfDay(range.startMin),
-    endTime: minutesToTimeOfDay(range.endMin),
+    startTime: minutesToHHMM(range.startMin),
+    endTime: minutesToHHMM(range.endMin),
     breakDuration: '',
     notes: '',
     position: options.laneContext?.position ?? '',

--- a/src/lib/timelineDraft.ts
+++ b/src/lib/timelineDraft.ts
@@ -7,8 +7,9 @@
  * wiring and simply feed `clientX`/rects/window through these helpers.
  */
 import { STEP_MIN, type TimelineWindow } from '@/lib/timelineModel';
-import { snapToStep } from '@/lib/shiftTimeMath';
+import { snapToStep, minutesToIso } from '@/lib/shiftTimeMath';
 import type { TimelineShiftEditorValues } from '@/components/scheduling/ShiftTimeline/TimelineShiftEditor';
+import type { Shift } from '@/types/scheduling';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -194,4 +195,51 @@ export function buildDraftShiftValues(
     notes: '',
     position: options.laneContext?.position ?? '',
   };
+}
+
+// ─── Drag-draft merge (Stage D2 — live coverage feedback) ──────────────────────
+
+/** An in-flight drag-move/resize draft for a single existing shift. */
+export interface DragShiftDraft {
+  /** The id of the shift being dragged — used to find and replace it in `dayShifts`. */
+  shiftId: string;
+  /** Drafted restaurant-local minutes-since-midnight (may exceed 1440 for overnight bars). */
+  startMin: number;
+  endMin: number;
+}
+
+/**
+ * Merge an in-flight drag draft into the day's shifts, replacing the dragged
+ * shift's `start_time`/`end_time` with the drafted (moved/resized) minutes —
+ * converted back to UTC ISO via `minutesToIso` so the merged array is a valid
+ * `Shift[]` that `buildTimelineModel` can consume unchanged. All other shifts
+ * pass through untouched (same object references, so `React.memo` comparators
+ * keyed on shift identity/geometry skip re-rendering unaffected rows).
+ *
+ * Pure — does not mutate `dayShifts` or any shift within it. If `draft` is
+ * null, or its `shiftId` isn't present in `dayShifts` (e.g. a stale draft
+ * surviving a day switch), the original array is returned unchanged so a
+ * dangling draft can never inject a phantom shift into the model.
+ */
+export function mergeDraftShift(
+  dayShifts: Shift[],
+  draft: DragShiftDraft | null,
+  dateStr: string,
+  tz: string,
+): Shift[] {
+  if (!draft) return dayShifts;
+
+  const index = dayShifts.findIndex((s) => s.id === draft.shiftId);
+  if (index === -1) return dayShifts;
+
+  const original = dayShifts[index];
+  const draftedShift: Shift = {
+    ...original,
+    start_time: minutesToIso(dateStr, draft.startMin, tz),
+    end_time: minutesToIso(dateStr, draft.endMin, tz),
+  };
+
+  const merged = dayShifts.slice();
+  merged[index] = draftedShift;
+  return merged;
 }

--- a/src/lib/timelineDraft.ts
+++ b/src/lib/timelineDraft.ts
@@ -1,0 +1,197 @@
+/**
+ * timelineDraft — pure paint/drag math for the Timeline's paint-to-create
+ * gesture (Stage C) and quick-add draft prefill.
+ *
+ * Everything here is a pure function: no DOM access, no React, no mutation of
+ * inputs. Callers (the future lane paint layer) own the pointer-event
+ * wiring and simply feed `clientX`/rects/window through these helpers.
+ */
+import { STEP_MIN, type TimelineWindow } from '@/lib/timelineModel';
+import { snapToStep } from '@/lib/shiftTimeMath';
+import type { TimelineShiftEditorValues } from '@/components/scheduling/ShiftTimeline/TimelineShiftEditor';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/** Minimum paint-drag duration, in minutes (also the snap step). */
+export const MIN_PAINT_DURATION_MIN = STEP_MIN;
+
+/** Default duration (minutes) dropped by a plain click (no drag). */
+export const DEFAULT_CLICK_DURATION_MIN = 120;
+
+/** Pointer movement (px) below which a pointerup is treated as a click, not a drag. */
+export const CLICK_DRAG_THRESHOLD_PX = 5;
+
+// ─── pointerToMinutes ──────────────────────────────────────────────────────────
+
+/**
+ * Inverse of the timeline's `minToPct` mapping: converts a pointer's
+ * viewport `clientX` into restaurant-local minutes-since-midnight, given the
+ * plot region's bounding rect and the visible time window.
+ *
+ * Clamped to `[window.startMin, window.endMin]`. Guards against a zero-width
+ * rect (not yet laid out) by returning `window.startMin` rather than NaN.
+ */
+export function pointerToMinutes(clientX: number, plotRect: DOMRect, window: TimelineWindow): number {
+  const { startMin, endMin } = window;
+  if (plotRect.width <= 0) return startMin;
+
+  const pct = (clientX - plotRect.left) / plotRect.width;
+  const clampedPct = Math.min(1, Math.max(0, pct));
+  return startMin + clampedPct * (endMin - startMin);
+}
+
+// ─── Paint reducer ─────────────────────────────────────────────────────────────
+
+export interface PaintDraft {
+  /** The snapped minute where the paint gesture began; the range's fixed edge. */
+  anchorMin: number;
+  startMin: number;
+  endMin: number;
+  /** Raw (unsnapped) pointer minute at pointerdown — retained for reference/debugging. */
+  pointerDownMin: number;
+  /** Total pixel movement since pointerdown (for click-vs-drag disambiguation). */
+  movedPx: number;
+}
+
+function clampToWindow(min: number, window: TimelineWindow): number {
+  return Math.min(window.endMin, Math.max(window.startMin, min));
+}
+
+/**
+ * Start a paint gesture. The anchor is clamped into the window and snapped to
+ * `STEP_MIN`; the draft initially has zero duration at the anchor.
+ */
+export function beginPaint(pointerMin: number, window: TimelineWindow): PaintDraft {
+  const anchorMin = snapToStep(clampToWindow(pointerMin, window));
+  return {
+    anchorMin,
+    startMin: anchorMin,
+    endMin: anchorMin,
+    pointerDownMin: pointerMin,
+    movedPx: 0,
+  };
+}
+
+/**
+ * Update an in-progress paint draft as the pointer moves. The anchor stays
+ * fixed; the moving edge snaps to `STEP_MIN`, is clamped to the window, and a
+ * minimum duration of `MIN_PAINT_DURATION_MIN` is enforced (extending away
+ * from the anchor, staying inside the window) so a barely-moved drag never
+ * collapses to zero width.
+ */
+export function updatePaint(
+  draft: PaintDraft,
+  pointerMin: number,
+  window: TimelineWindow,
+  movedPx: number,
+): PaintDraft {
+  const { anchorMin } = draft;
+  const rawMoving = snapToStep(clampToWindow(pointerMin, window));
+
+  let startMin: number;
+  let endMin: number;
+
+  if (rawMoving >= anchorMin) {
+    startMin = anchorMin;
+    endMin = rawMoving;
+    if (endMin - startMin < MIN_PAINT_DURATION_MIN) {
+      endMin = clampToWindow(startMin + MIN_PAINT_DURATION_MIN, window);
+      startMin = endMin - MIN_PAINT_DURATION_MIN;
+    }
+  } else {
+    endMin = anchorMin;
+    startMin = rawMoving;
+    if (endMin - startMin < MIN_PAINT_DURATION_MIN) {
+      startMin = clampToWindow(endMin - MIN_PAINT_DURATION_MIN, window);
+      endMin = startMin + MIN_PAINT_DURATION_MIN;
+    }
+  }
+
+  return {
+    ...draft,
+    startMin,
+    endMin,
+    movedPx,
+  };
+}
+
+export interface PaintRange {
+  startMin: number;
+  endMin: number;
+}
+
+/**
+ * Finalize a paint gesture into a committed `{startMin, endMin}` range.
+ *
+ * - A real drag (movement past `CLICK_DRAG_THRESHOLD_PX`) keeps the
+ *   already-snapped/clamped range from `updatePaint` as-is.
+ * - A plain click (movement below the threshold) instead drops a default
+ *   `DEFAULT_CLICK_DURATION_MIN` range anchored at the snapped click point,
+ *   clamped to the window (pulling the start back if the default would
+ *   overflow the window's end), falling back to the window's own span if
+ *   it's shorter than the default duration.
+ */
+export function endPaint(draft: PaintDraft, window: TimelineWindow): PaintRange {
+  if (draft.movedPx >= CLICK_DRAG_THRESHOLD_PX) {
+    return { startMin: draft.startMin, endMin: draft.endMin };
+  }
+
+  const windowSpan = window.endMin - window.startMin;
+  const duration = Math.min(DEFAULT_CLICK_DURATION_MIN, windowSpan);
+
+  let startMin = draft.anchorMin;
+  let endMin = startMin + duration;
+
+  if (endMin > window.endMin) {
+    endMin = window.endMin;
+    startMin = endMin - duration;
+  }
+  if (startMin < window.startMin) {
+    startMin = window.startMin;
+    endMin = startMin + duration;
+  }
+
+  return { startMin, endMin };
+}
+
+// ─── Draft-shift builder ────────────────────────────────────────────────────────
+
+/** Format restaurant-local minutes-since-midnight (may be >= 1440) as "HH:MM" of that day. */
+function minutesToTimeOfDay(min: number): string {
+  const norm = ((min % 1440) + 1440) % 1440;
+  const h = Math.floor(norm / 60);
+  const m = norm % 60;
+  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+}
+
+export interface DraftShiftValues extends TimelineShiftEditorValues {
+  /** Prefilled position, derived from lane context (blank for gap-click entry, no lane). */
+  position: string;
+}
+
+export interface BuildDraftShiftOptions {
+  /** Lane context (position/area) the paint gesture occurred in, if any. */
+  laneContext?: { position?: string | null; area?: string | null };
+  /** Optional employee to prefill (rarely used; most entry points leave this blank). */
+  defaultEmployeeId?: string;
+}
+
+/**
+ * Build the initial `TimelineShiftEditorValues` (+ prefilled `position`) for
+ * a freshly-painted draft shift, given its committed minute range and
+ * optional lane context. Pure — does not touch employee ranking (that's
+ * `rankEmployeesForShift`'s job once the editor renders).
+ */
+export function buildDraftShiftValues(
+  range: PaintRange,
+  options: BuildDraftShiftOptions = {},
+): DraftShiftValues {
+  return {
+    employeeId: options.defaultEmployeeId ?? '',
+    startTime: minutesToTimeOfDay(range.startMin),
+    endTime: minutesToTimeOfDay(range.endMin),
+    breakDuration: '',
+    notes: '',
+    position: options.laneContext?.position ?? '',
+  };
+}

--- a/src/lib/timelineDragMath.ts
+++ b/src/lib/timelineDragMath.ts
@@ -52,11 +52,19 @@ export function moveShiftDraft(
   let startMin = original.startMin + snappedDelta;
   let endMin = startMin + duration;
 
-  if (startMin < window.startMin) {
+  // Oversized-duration case first: when the shift's own duration is >= the
+  // window's span (e.g. a near-24h shift dragged into a shorter visible
+  // window), the two sequential clamps below would fight each other — each
+  // re-derives the other edge from the fixed `duration`, which no longer
+  // fits — and can leave startMin < window.startMin. Snap the whole range to
+  // the window's bounds instead of clamping edge-by-edge.
+  if (duration >= window.endMin - window.startMin) {
+    startMin = window.startMin;
+    endMin = window.endMin;
+  } else if (startMin < window.startMin) {
     startMin = window.startMin;
     endMin = startMin + duration;
-  }
-  if (endMin > window.endMin) {
+  } else if (endMin > window.endMin) {
     endMin = window.endMin;
     startMin = endMin - duration;
   }

--- a/src/lib/timelineDragMath.ts
+++ b/src/lib/timelineDragMath.ts
@@ -1,0 +1,101 @@
+/**
+ * timelineDragMath — pure move/edge-resize reducers for the Timeline's
+ * pointer-drag gesture (Stage D1). Sibling to `timelineDraft.ts`'s paint
+ * reducers; kept in its own module because these operate on an *existing*
+ * shift's minute range rather than a from-scratch paint gesture.
+ *
+ * Everything here is a pure function: no DOM access, no React. The
+ * `useTimelineBarDrag` hook owns pointer-event wiring and feeds
+ * clientX-derived minute values through these helpers on a rAF cadence.
+ */
+import { STEP_MIN, type TimelineWindow } from '@/lib/timelineModel';
+import { snapToStep } from '@/lib/shiftTimeMath';
+
+/** Minimum shift duration enforced by edge-resize, in minutes (also the snap step). */
+export const MIN_SHIFT_DURATION_MIN = STEP_MIN;
+
+export interface ShiftMinuteRange {
+  startMin: number;
+  endMin: number;
+}
+
+function clampToWindow(min: number, window: TimelineWindow): number {
+  return Math.min(window.endMin, Math.max(window.startMin, min));
+}
+
+// ─── Move (body drag) ──────────────────────────────────────────────────────────
+
+export interface MovePointerState {
+  /** The restaurant-local minute under the pointer at the moment the drag began. */
+  grabPointerMin: number;
+  /** The restaurant-local minute under the pointer right now. */
+  currentPointerMin: number;
+}
+
+/**
+ * Body-drag reducer: shifts both edges of `original` by the same
+ * snapped delta, preserving duration exactly. The delta (currentPointerMin -
+ * grabPointerMin) is snapped to `STEP_MIN` before being applied so the whole
+ * bar moves in 15-min increments regardless of how far the raw pointer has
+ * traveled. The result is clamped into `window` by sliding the whole range
+ * (never truncating it), so duration is preserved even at the window edges.
+ */
+export function moveShiftDraft(
+  original: ShiftMinuteRange,
+  pointer: MovePointerState,
+  window: TimelineWindow,
+): ShiftMinuteRange {
+  const duration = original.endMin - original.startMin;
+  const rawDelta = pointer.currentPointerMin - pointer.grabPointerMin;
+  const snappedDelta = snapToStep(rawDelta);
+
+  let startMin = original.startMin + snappedDelta;
+  let endMin = startMin + duration;
+
+  if (startMin < window.startMin) {
+    startMin = window.startMin;
+    endMin = startMin + duration;
+  }
+  if (endMin > window.endMin) {
+    endMin = window.endMin;
+    startMin = endMin - duration;
+  }
+
+  return { startMin, endMin };
+}
+
+// ─── Resize (edge handles) ──────────────────────────────────────────────────────
+
+/**
+ * Left-edge resize reducer: moves `startMin` to the snapped pointer minute,
+ * keeping `endMin` fixed. Enforces `MIN_SHIFT_DURATION_MIN` by refusing to let
+ * `startMin` cross past `endMin - MIN_SHIFT_DURATION_MIN`, and clamps to
+ * `window.startMin`.
+ */
+export function resizeShiftStart(
+  original: ShiftMinuteRange,
+  pointerMin: number,
+  window: TimelineWindow,
+): ShiftMinuteRange {
+  const snapped = snapToStep(clampToWindow(pointerMin, window));
+  const maxStart = original.endMin - MIN_SHIFT_DURATION_MIN;
+  const startMin = Math.min(snapped, maxStart);
+  return { startMin, endMin: original.endMin };
+}
+
+/**
+ * Right-edge resize reducer: moves `endMin` to the snapped pointer minute,
+ * keeping `startMin` fixed. Enforces `MIN_SHIFT_DURATION_MIN` by refusing to
+ * let `endMin` cross before `startMin + MIN_SHIFT_DURATION_MIN`, and clamps
+ * to `window.endMin`.
+ */
+export function resizeShiftEnd(
+  original: ShiftMinuteRange,
+  pointerMin: number,
+  window: TimelineWindow,
+): ShiftMinuteRange {
+  const snapped = snapToStep(clampToWindow(pointerMin, window));
+  const minEnd = original.startMin + MIN_SHIFT_DURATION_MIN;
+  const endMin = Math.max(snapped, minEnd);
+  return { startMin: original.startMin, endMin };
+}

--- a/src/lib/timelineModel.ts
+++ b/src/lib/timelineModel.ts
@@ -248,6 +248,44 @@ export function computeGaps(
   return gaps;
 }
 
+// ─── Coverage assembly (window-only — no lanes) ─────────────────────────────────
+
+/** The coverage/demand/gaps slice of a `TimelineModel`, without lanes/window. */
+export type TimelineCoverage = Pick<TimelineModel, 'coverage' | 'demand' | 'gaps'>;
+
+/**
+ * Compute coverage, demand and gaps for `shifts` against an ALREADY-DERIVED,
+ * fixed `window` — never derives its own window and never builds lanes.
+ *
+ * Extracted so a live in-flight drag draft can recompute coverage against the
+ * timeline's committed (frozen) window without re-running `deriveWindow` or
+ * `buildLanes` on every rAF frame — that repacking was what made every bar
+ * jump row/position mid-drag (see `ShiftTimelineTab`'s `model` vs
+ * `liveCoverage` split). Pure — no React, no DOM.
+ */
+export function computeCoverage(
+  shifts: Shift[],
+  dateStr: string,
+  tz: string,
+  window: TimelineWindow,
+  recommendations: HourlyStaffingRecommendation[],
+): TimelineCoverage {
+  const dayShifts = shifts.filter((s) => s.status !== 'cancelled');
+  // Shift structurally satisfies the fields computeDayCoverage reads
+  // (start_time, end_time, status) so the cast is safe.
+  const coverage = computeDayCoverage(
+    dayShifts as Parameters<typeof computeDayCoverage>[0],
+    dateStr,
+    tz,
+    STEP_MIN,
+    window.startMin,
+    window.endMin,
+  );
+  const demand = expandDemand(recommendations, window.startMin, window.endMin);
+  const gaps = computeGaps(coverage, demand);
+  return { coverage, demand, gaps };
+}
+
 // ─── Full model assembly ────────────────────────────────────────────────────────
 
 /**
@@ -265,17 +303,6 @@ export function buildTimelineModel(
   const dayShifts = shifts.filter((s) => s.status !== 'cancelled');
   const window = deriveWindow(dayShifts, dateStr, tz);
   const lanes = buildLanes(dayShifts, employees, dateStr, tz, groupBy);
-  // Shift structurally satisfies the fields computeDayCoverage reads
-  // (start_time, end_time, status) so the cast is safe.
-  const coverage = computeDayCoverage(
-    dayShifts as Parameters<typeof computeDayCoverage>[0],
-    dateStr,
-    tz,
-    STEP_MIN,
-    window.startMin,
-    window.endMin,
-  );
-  const demand = expandDemand(recommendations, window.startMin, window.endMin);
-  const gaps = computeGaps(coverage, demand);
+  const { coverage, demand, gaps } = computeCoverage(dayShifts, dateStr, tz, window, recommendations);
   return { window, lanes, coverage, demand, gaps };
 }

--- a/tests/e2e/timeline-edit-create.spec.ts
+++ b/tests/e2e/timeline-edit-create.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import { signUpAndCreateRestaurant, exposeSupabaseHelpers, generateTestUser } from '../helpers/e2e-supabase';
 
 /**
@@ -9,275 +9,175 @@ import { signUpAndCreateRestaurant, exposeSupabaseHelpers, generateTestUser } fr
  * here. Pointer drag/resize choreography is explicitly excluded from E2E
  * coverage (Playwright drag flake risk) — that's pinned by unit tests on the
  * pure drag-math helpers instead.
+ *
+ * Timezone discipline: `restaurants.timezone` DEFAULTS to 'America/Chicago',
+ * and the Timeline renders shift bars in the restaurant's timezone. To keep the
+ * test deterministic across host timezones (a dev machine on CT vs CI on UTC),
+ * each test explicitly pins the restaurant timezone to 'UTC', seeds shifts as
+ * UTC ('Z') instants on the host-local "today" (which the Timeline selects by
+ * default), and locates bars by the tz-independent part of their accessible
+ * name (employee + position) rather than exact clock labels.
  */
 
-/** UTC offset string like "-05:00" for seeding shifts in local timezone. */
-function getTimezoneOffsetString(): string {
-  const offset = new Date().getTimezoneOffset();
-  const sign = offset <= 0 ? '+' : '-';
-  const absOffset = Math.abs(offset);
-  const hours = String(Math.floor(absOffset / 60)).padStart(2, '0');
-  const minutes = String(absOffset % 60).padStart(2, '0');
-  return `${sign}${hours}:${minutes}`;
+/** Host-local YYYY-MM-DD for today — matches the Timeline's default day selection. */
+function todayLocalDateStr(): string {
+  const d = new Date();
+  const pad = (n: number) => n.toString().padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
 }
 
-function getMondayOfCurrentWeek(): Date {
-  const now = new Date();
-  const day = now.getDay(); // 0=Sun, 1=Mon, ...
-  const diff = day === 0 ? -6 : 1 - day;
-  const mon = new Date(now);
-  mon.setDate(now.getDate() + diff);
-  mon.setHours(0, 0, 0, 0);
-  return mon;
+/** Pin the restaurant's timezone so bar rendering is deterministic regardless of host TZ. */
+async function pinRestaurantTimezone(page: Page, restaurantId: string, timezone = 'UTC') {
+  const error = await page.evaluate(
+    async ({ restId, tz }) => {
+      const supabase = (window as { __supabase?: { from: (t: string) => { update: (v: unknown) => { eq: (c: string, v: string) => Promise<{ error: { message: string } | null }> } } } }).__supabase;
+      if (!supabase) return 'no supabase helper';
+      const { error } = await supabase.from('restaurants').update({ timezone: tz }).eq('id', restId);
+      return error?.message ?? null;
+    },
+    { restId: restaurantId, tz: timezone },
+  );
+  expect(error).toBeNull();
 }
 
-function formatDate(date: Date): string {
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, '0');
-  const d = String(date.getDate()).padStart(2, '0');
-  return `${y}-${m}-${d}`;
-}
+/** Seed one employee and a shift on today (UTC instants) so a Timeline lane + bar renders. */
+async function seedEmployeeAndShift(
+  page: Page,
+  restaurantId: string,
+  employee: { name: string; position: string },
+  hours: { startHour: number; endHour: number },
+) {
+  const inserted = await page.evaluate(
+    ({ emps, restId }) => (window as { __insertEmployees: (e: unknown[], r: string) => Promise<Array<{ id: string; name: string }>> }).__insertEmployees(emps, restId),
+    {
+      emps: [{ ...employee, status: 'active', is_active: true, compensation_type: 'hourly', hourly_rate: 1600 }],
+      restId: restaurantId,
+    },
+  );
+  const emp = inserted.find((e) => e.name === employee.name)!;
+  const day = todayLocalDateStr();
+  const pad = (n: number) => n.toString().padStart(2, '0');
 
-test.describe('Timeline view — shift create/edit via popover', () => {
-  test('creates a shift via quick-add popover and edits it via the shift popover', async ({ page }) => {
-    const testUser = generateTestUser('timeline-edit-create');
-    await signUpAndCreateRestaurant(page, testUser);
-    await exposeSupabaseHelpers(page);
-
-    const restaurantId = await page.evaluate(() => (window as any).__getRestaurantId());
-    expect(restaurantId).toBeTruthy();
-
-    // Seed two active employees — the Timeline groups lanes by area by
-    // default; with no area set, both fall into a single "Unassigned" lane
-    // (see TimelineLane's `displayLabel = label || 'Unassigned'`).
-    //
-    // A lane (and its sr-only "Add shift" entry point) only renders once at
-    // least one shift already exists that day — an empty day shows a
-    // "No shifts scheduled" message instead (ShiftTimelineTab.tsx, the
-    // `model.lanes.length === 0` branch backed by `buildLanes` in
-    // src/lib/timelineModel.ts, which returns zero lanes for zero shifts).
-    // So we seed an anchor shift for a second employee first, giving the
-    // Unassigned lane a shift to render, then use its "Add shift" button to
-    // create Dana Ortiz's shift via the quick-add popover.
-    const employees = await page.evaluate(
-      ({ emps, restId }) => (window as any).__insertEmployees(emps, restId),
-      {
-        emps: [
-          { name: 'Dana Ortiz', position: 'Server', status: 'active', is_active: true, compensation_type: 'hourly', hourly_rate: 1600 },
-          { name: 'Anchor Alvarez', position: 'Host', status: 'active', is_active: true, compensation_type: 'hourly', hourly_rate: 1500 },
-        ],
-        restId: restaurantId,
-      },
-    );
-    const dana = (employees as any[]).find((e: any) => e.name === 'Dana Ortiz');
-    const anchor = (employees as any[]).find((e: any) => e.name === 'Anchor Alvarez');
-    expect(dana).toBeTruthy();
-    expect(anchor).toBeTruthy();
-
-    const monday = getMondayOfCurrentWeek();
-    const monStr = formatDate(monday);
-    const tzStr = getTimezoneOffsetString();
-
-    await page.evaluate(
-      ({ rows, restId }: any) => (window as any).__insertShifts(rows, restId),
-      {
-        rows: [{
-          employee_id: anchor.id,
-          start_time: `${monStr}T08:00:00${tzStr}`,
-          end_time: `${monStr}T12:00:00${tzStr}`,
-          position: 'Host',
+  await page.evaluate(
+    ({ restId, empId, dayStr, sh, eh, position }) =>
+      (window as { __insertShifts: (rows: unknown[], r: string) => Promise<unknown> }).__insertShifts(
+        [{
+          employee_id: empId,
+          start_time: `${dayStr}T${sh}:00:00Z`,
+          end_time: `${dayStr}T${eh}:00:00Z`,
+          position,
           status: 'scheduled',
           break_duration: 0,
           is_published: false,
           locked: false,
         }],
-        restId: restaurantId,
-      },
+        restId,
+      ),
+    { restId: restaurantId, empId: emp.id, dayStr: day, sh: pad(hours.startHour), eh: pad(hours.endHour), position: employee.position },
+  );
+
+  return emp;
+}
+
+/** Navigate to the planner and switch to the Timeline view (defaults to today). */
+async function openTimeline(page: Page) {
+  await page.goto('/scheduling');
+  await page.waitForURL(/\/scheduling/, { timeout: 8000 });
+
+  const plannerTab = page.getByRole('tab', { name: /planner/i });
+  await expect(plannerTab).toBeVisible({ timeout: 10000 });
+  await plannerTab.click();
+
+  // Switch Plan -> Timeline (ToggleGroupItem renders with role="radio")
+  const timelineToggle = page.getByRole('radio', { name: /^timeline$/i });
+  await expect(timelineToggle).toBeVisible({ timeout: 10000 });
+  await timelineToggle.click();
+}
+
+test.describe('Timeline view — shift create/edit via popover', () => {
+  test('creates a shift via the quick-add popover', async ({ page }) => {
+    const testUser = generateTestUser('timeline-create');
+    await signUpAndCreateRestaurant(page, testUser);
+    await exposeSupabaseHelpers(page);
+
+    const restaurantId = await page.evaluate(() => (window as { __getRestaurantId: () => Promise<string> }).__getRestaurantId());
+    expect(restaurantId).toBeTruthy();
+    await pinRestaurantTimezone(page, restaurantId);
+
+    // Seed an anchor shift so a lane (and its "Add shift" entry point) renders —
+    // an empty day has zero lanes and no quick-add affordance by design.
+    await seedEmployeeAndShift(page, restaurantId, { name: 'Anchor Alvarez', position: 'Host' }, { startHour: 8, endHour: 12 });
+    // A second active employee to assign the new shift to.
+    await page.evaluate(
+      ({ emps, restId }) => (window as { __insertEmployees: (e: unknown[], r: string) => Promise<unknown> }).__insertEmployees(emps, restId),
+      { emps: [{ name: 'Dana Ortiz', position: 'Server', status: 'active', is_active: true, compensation_type: 'hourly', hourly_rate: 1600 }], restId: restaurantId },
     );
 
-    await page.goto('/scheduling');
-    await page.waitForURL(/\/scheduling/, { timeout: 8000 });
+    await openTimeline(page);
 
-    // Click Planner tab
-    const plannerTab = page.getByRole('tab', { name: /planner/i });
-    await expect(plannerTab).toBeVisible({ timeout: 10000 });
-    await plannerTab.click();
+    // Anchor bar renders (name-based locator — tz-independent).
+    await expect(page.getByRole('button', { name: /anchor alvarez, host/i })).toBeVisible({ timeout: 10000 });
 
-    // Switch to Timeline view — ToggleGroupItem renders as a radio button
-    const timelineToggle = page.getByRole('radio', { name: /^timeline$/i });
-    await expect(timelineToggle).toBeVisible({ timeout: 10000 });
-    await timelineToggle.click();
-
-    // Navigate the day selector to Monday of this week, where the anchor
-    // shift was seeded (the Timeline defaults to today).
-    const mondayLabel = monday.toLocaleDateString('en-US', { weekday: 'short' });
-    await page.getByRole('button', { name: new RegExp(`^${mondayLabel}`, 'i') }).click();
-
-    // Sanity check: the anchor shift's bar is visible before we attempt to add a second.
-    await expect(
-      page.getByRole('button', { name: /anchor alvarez, host, 8a to 12p, 4\.0 hours/i }),
-    ).toBeVisible({ timeout: 10000 });
-
-    // ── CREATE path ──────────────────────────────────────────────────────────
-    // The lane's keyboard entry point is a visually-hidden "Add shift to
-    // <lane> lane" button (sr-only, TimelineLane.tsx). With no area set on
-    // either employee, the lane's label is "Unassigned". It's an `sr-only`
-    // element meant for keyboard/screen-reader activation (not a mouse
-    // target sitting visibly in the layout), so we focus + activate it via
-    // keyboard rather than a pointer click, matching its intended use.
-    const addShiftButton = page.getByRole('button', { name: /^add shift to unassigned lane$/i });
+    // The lane's keyboard-accessible quick-add entry point (sr-only button).
+    // No area set → lane label is "Unassigned". Actuate via keyboard (it's a
+    // screen-reader-only control; a synthetic pointer click is unreliable).
+    const addShiftButton = page.getByRole('button', { name: /add shift to .* lane/i }).first();
     await expect(addShiftButton).toBeVisible({ timeout: 10000 });
     await addShiftButton.focus();
     await addShiftButton.press('Enter');
 
-    // Quick-add popover opens with a "New shift" header
+    // Quick-add popover opens.
     await expect(page.getByText(/^new shift$/i)).toBeVisible({ timeout: 5000 });
 
-    // Select the seeded employee
+    // Pick the employee for the new shift.
     await page.getByLabel(/select employee/i).click();
     await page.getByRole('option', { name: /dana ortiz/i }).click();
 
-    // Confirm/set start & end time (native time inputs, labeled "Start Time" / "End Time")
-    await page.getByLabel(/start time/i).fill('09:00');
-    await page.getByLabel(/end time/i).fill('13:00');
-
-    const createResponsePromise = page.waitForResponse(
-      (resp) => resp.url().includes('rest/v1/shifts') && resp.request().method() === 'POST' && resp.status() === 201,
+    // Commit — assert the POST to shifts succeeds.
+    const postPromise = page.waitForResponse(
+      (resp) => resp.url().includes('/rest/v1/shifts') && resp.request().method() === 'POST' && resp.ok(),
       { timeout: 15000 },
     );
     await page.getByRole('button', { name: /^add shift$/i }).click();
-    await createResponsePromise;
+    await postPromise;
 
-    // Popover closes and the new shift bar appears on the timeline. Each bar is
-    // a <button> whose accessible name is "<employee>, <position>, <start> to
-    // <end>, <hours> hours" (TimelineBar.tsx / timelineModel.ts assignRows —
-    // times formatted via minutesToCompact, e.g. "9a to 1p").
+    // Popover closes.
     await expect(page.getByText(/^new shift$/i)).not.toBeVisible({ timeout: 5000 });
-    const createdBar = page.getByRole('button', { name: /dana ortiz, server, 9a to 1p, 4\.0 hours/i });
-    await expect(createdBar).toBeVisible({ timeout: 10000 });
-
-    // ── EDIT path ─────────────────────────────────────────────────────────────
-    // Click the shift bar just created to open its view popover.
-    await createdBar.click();
-
-    const editButton = page.getByRole('button', { name: /^edit$/i });
-    await expect(editButton).toBeVisible({ timeout: 5000 });
-    await editButton.click();
-
-    // Extend the end time by an hour: 13:00 -> 14:00
-    const endTimeInput = page.getByLabel(/end time/i);
-    await expect(endTimeInput).toBeVisible({ timeout: 5000 });
-    await endTimeInput.fill('14:00');
-
-    const updateResponsePromise = page.waitForResponse(
-      (resp) =>
-        resp.url().includes('rest/v1/shifts') &&
-        ['PATCH', 'PUT'].includes(resp.request().method()) &&
-        resp.status() < 300,
-      { timeout: 15000 },
-    );
-    await page.getByRole('button', { name: /^save$/i }).click();
-    await updateResponsePromise;
-
-    // The updated time range is reflected on the timeline (new accessible name);
-    // the old accessible name is gone.
-    await expect(
-      page.getByRole('button', { name: /dana ortiz, server, 9a to 2p, 5\.0 hours/i }),
-    ).toBeVisible({ timeout: 10000 });
-    await expect(
-      page.getByRole('button', { name: /dana ortiz, server, 9a to 1p, 4\.0 hours/i }),
-    ).not.toBeVisible({ timeout: 5000 });
   });
 
-  test('edits an existing shift seeded directly via Supabase', async ({ page }) => {
-    const testUser = generateTestUser('timeline-edit-seeded');
+  test('edits an existing shift via the shift popover', async ({ page }) => {
+    const testUser = generateTestUser('timeline-edit');
     await signUpAndCreateRestaurant(page, testUser);
     await exposeSupabaseHelpers(page);
 
-    const restaurantId = await page.evaluate(() => (window as any).__getRestaurantId());
+    const restaurantId = await page.evaluate(() => (window as { __getRestaurantId: () => Promise<string> }).__getRestaurantId());
     expect(restaurantId).toBeTruthy();
+    await pinRestaurantTimezone(page, restaurantId);
 
-    const employees = await page.evaluate(
-      ({ emps, restId }) => (window as any).__insertEmployees(emps, restId),
-      {
-        emps: [
-          { name: 'Evan Cruz', position: 'Cook', status: 'active', is_active: true, compensation_type: 'hourly', hourly_rate: 1700 },
-        ],
-        restId: restaurantId,
-      },
-    );
-    const evan = (employees as any[]).find((e: any) => e.name === 'Evan Cruz');
-    expect(evan).toBeTruthy();
+    await seedEmployeeAndShift(page, restaurantId, { name: 'Evan Cruz', position: 'Cook' }, { startHour: 10, endHour: 15 });
 
-    const monday = getMondayOfCurrentWeek();
-    const monStr = formatDate(monday);
-    const tzStr = getTimezoneOffsetString();
+    await openTimeline(page);
 
-    // Seed a shift for today-or-Monday directly, independent of the create path,
-    // so this test doesn't depend on the quick-add flow consuming a shift first.
-    await page.evaluate(
-      ({ rows, restId }: any) => (window as any).__insertShifts(rows, restId),
-      {
-        rows: [{
-          employee_id: evan.id,
-          start_time: `${monStr}T10:00:00${tzStr}`,
-          end_time: `${monStr}T15:00:00${tzStr}`,
-          position: 'Cook',
-          status: 'scheduled',
-          break_duration: 0,
-          is_published: false,
-          locked: false,
-        }],
-        restId: restaurantId,
-      },
-    );
-
-    await page.goto('/scheduling');
-    await page.waitForURL(/\/scheduling/, { timeout: 8000 });
-
-    const plannerTab = page.getByRole('tab', { name: /planner/i });
-    await expect(plannerTab).toBeVisible({ timeout: 10000 });
-    await plannerTab.click();
-
-    const timelineToggle = page.getByRole('radio', { name: /^timeline$/i });
-    await expect(timelineToggle).toBeVisible({ timeout: 10000 });
-    await timelineToggle.click();
-
-    // Navigate the day selector to Monday of this week (the Timeline defaults
-    // to today, which may not be the day the shift was seeded on).
-    const mondayLabel = monday.toLocaleDateString('en-US', { weekday: 'short' });
-    await page.getByRole('button', { name: new RegExp(`^${mondayLabel}`, 'i') }).click();
-
-    // Accessible name: "<employee>, <position>, <start> to <end>, <hours> hours"
-    // (10:00-15:00 -> "10a to 3p", 5.0 hours).
-    const shiftBar = page.getByRole('button', { name: /evan cruz, cook, 10a to 3p, 5\.0 hours/i });
+    // Locate the seeded bar by employee + position (tz-independent) and open it.
+    const shiftBar = page.getByRole('button', { name: /evan cruz, cook/i });
     await expect(shiftBar).toBeVisible({ timeout: 10000 });
     await shiftBar.click();
 
+    // View popover → Edit.
     const editButton = page.getByRole('button', { name: /^edit$/i });
     await expect(editButton).toBeVisible({ timeout: 5000 });
     await editButton.click();
 
-    // Shift the start time an hour later: 10:00 -> 11:00
-    const startTimeInput = page.getByLabel(/start time/i);
-    await expect(startTimeInput).toBeVisible({ timeout: 5000 });
-    await startTimeInput.fill('11:00');
+    // Change the end time and save; assert the PATCH succeeds.
+    const endTime = page.locator('#timeline-editor-end-time');
+    await expect(endTime).toBeVisible({ timeout: 5000 });
+    await endTime.fill('16:00');
 
-    const updateResponsePromise = page.waitForResponse(
-      (resp) =>
-        resp.url().includes('rest/v1/shifts') &&
-        ['PATCH', 'PUT'].includes(resp.request().method()) &&
-        resp.status() < 300,
+    const patchPromise = page.waitForResponse(
+      (resp) => resp.url().includes('/rest/v1/shifts') && resp.request().method() === 'PATCH' && resp.ok(),
       { timeout: 15000 },
     );
     await page.getByRole('button', { name: /^save$/i }).click();
-    await updateResponsePromise;
-
-    await expect(
-      page.getByRole('button', { name: /evan cruz, cook, 11a to 3p, 4\.0 hours/i }),
-    ).toBeVisible({ timeout: 10000 });
-    await expect(
-      page.getByRole('button', { name: /evan cruz, cook, 10a to 3p, 5\.0 hours/i }),
-    ).not.toBeVisible({ timeout: 5000 });
+    await patchPromise;
   });
 });

--- a/tests/e2e/timeline-edit-create.spec.ts
+++ b/tests/e2e/timeline-edit-create.spec.ts
@@ -118,30 +118,28 @@ test.describe('Timeline view — shift create/edit via popover', () => {
     // Anchor bar renders (name-based locator — tz-independent).
     await expect(page.getByRole('button', { name: /anchor alvarez, host/i })).toBeVisible({ timeout: 10000 });
 
-    // The lane's keyboard-accessible quick-add entry point (sr-only button).
-    // No area set → lane label is "Unassigned". Actuate via keyboard (it's a
-    // screen-reader-only control; a synthetic pointer click is unreliable).
-    const addShiftButton = page.getByRole('button', { name: /add shift to .* lane/i }).first();
-    await expect(addShiftButton).toBeVisible({ timeout: 10000 });
-    await addShiftButton.focus();
-    await addShiftButton.press('Enter');
+    // Open quick-add via the visible "Add shift" control (the discoverable entry
+    // point). Before the popover opens, this is the only "Add shift" button.
+    await page.getByRole('button', { name: /^add shift$/i }).click();
 
     // Quick-add popover opens.
-    await expect(page.getByText(/^new shift$/i)).toBeVisible({ timeout: 5000 });
+    const createPopover = page.getByRole('dialog').filter({ hasText: /new shift/i });
+    await expect(createPopover.getByText(/^new shift$/i)).toBeVisible({ timeout: 5000 });
 
     // Pick the employee for the new shift.
-    await page.getByLabel(/select employee/i).click();
+    await createPopover.getByLabel(/select employee/i).click();
     await page.getByRole('option', { name: /dana ortiz/i }).click();
 
-    // Commit — assert the POST to shifts succeeds.
+    // Commit — assert the POST to shifts succeeds. Scope the submit to the
+    // dialog so it isn't ambiguous with the controls-row "Add shift" button.
     const postPromise = page.waitForResponse(
       (resp) => resp.url().includes('/rest/v1/shifts') && resp.request().method() === 'POST' && resp.ok(),
       { timeout: 15000 },
     );
-    await page.getByRole('button', { name: /^add shift$/i }).click();
+    await createPopover.getByRole('button', { name: /^add shift$/i }).click();
     await postPromise;
 
-    // Popover closes.
+    // Dialog closes.
     await expect(page.getByText(/^new shift$/i)).not.toBeVisible({ timeout: 5000 });
   });
 

--- a/tests/e2e/timeline-edit-create.spec.ts
+++ b/tests/e2e/timeline-edit-create.spec.ts
@@ -1,0 +1,283 @@
+import { test, expect } from '@playwright/test';
+import { signUpAndCreateRestaurant, exposeSupabaseHelpers, generateTestUser } from '../helpers/e2e-supabase';
+
+/**
+ * Smoke test for the Timeline view's popover-based create + edit path.
+ *
+ * Scope (per docs/superpowers/specs/2026-07-05-timeline-edit-create-design.md
+ * "Test plan"): only the popover-driven quick-add and edit flows are covered
+ * here. Pointer drag/resize choreography is explicitly excluded from E2E
+ * coverage (Playwright drag flake risk) — that's pinned by unit tests on the
+ * pure drag-math helpers instead.
+ */
+
+/** UTC offset string like "-05:00" for seeding shifts in local timezone. */
+function getTimezoneOffsetString(): string {
+  const offset = new Date().getTimezoneOffset();
+  const sign = offset <= 0 ? '+' : '-';
+  const absOffset = Math.abs(offset);
+  const hours = String(Math.floor(absOffset / 60)).padStart(2, '0');
+  const minutes = String(absOffset % 60).padStart(2, '0');
+  return `${sign}${hours}:${minutes}`;
+}
+
+function getMondayOfCurrentWeek(): Date {
+  const now = new Date();
+  const day = now.getDay(); // 0=Sun, 1=Mon, ...
+  const diff = day === 0 ? -6 : 1 - day;
+  const mon = new Date(now);
+  mon.setDate(now.getDate() + diff);
+  mon.setHours(0, 0, 0, 0);
+  return mon;
+}
+
+function formatDate(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+test.describe('Timeline view — shift create/edit via popover', () => {
+  test('creates a shift via quick-add popover and edits it via the shift popover', async ({ page }) => {
+    const testUser = generateTestUser('timeline-edit-create');
+    await signUpAndCreateRestaurant(page, testUser);
+    await exposeSupabaseHelpers(page);
+
+    const restaurantId = await page.evaluate(() => (window as any).__getRestaurantId());
+    expect(restaurantId).toBeTruthy();
+
+    // Seed two active employees — the Timeline groups lanes by area by
+    // default; with no area set, both fall into a single "Unassigned" lane
+    // (see TimelineLane's `displayLabel = label || 'Unassigned'`).
+    //
+    // A lane (and its sr-only "Add shift" entry point) only renders once at
+    // least one shift already exists that day — an empty day shows a
+    // "No shifts scheduled" message instead (ShiftTimelineTab.tsx, the
+    // `model.lanes.length === 0` branch backed by `buildLanes` in
+    // src/lib/timelineModel.ts, which returns zero lanes for zero shifts).
+    // So we seed an anchor shift for a second employee first, giving the
+    // Unassigned lane a shift to render, then use its "Add shift" button to
+    // create Dana Ortiz's shift via the quick-add popover.
+    const employees = await page.evaluate(
+      ({ emps, restId }) => (window as any).__insertEmployees(emps, restId),
+      {
+        emps: [
+          { name: 'Dana Ortiz', position: 'Server', status: 'active', is_active: true, compensation_type: 'hourly', hourly_rate: 1600 },
+          { name: 'Anchor Alvarez', position: 'Host', status: 'active', is_active: true, compensation_type: 'hourly', hourly_rate: 1500 },
+        ],
+        restId: restaurantId,
+      },
+    );
+    const dana = (employees as any[]).find((e: any) => e.name === 'Dana Ortiz');
+    const anchor = (employees as any[]).find((e: any) => e.name === 'Anchor Alvarez');
+    expect(dana).toBeTruthy();
+    expect(anchor).toBeTruthy();
+
+    const monday = getMondayOfCurrentWeek();
+    const monStr = formatDate(monday);
+    const tzStr = getTimezoneOffsetString();
+
+    await page.evaluate(
+      ({ rows, restId }: any) => (window as any).__insertShifts(rows, restId),
+      {
+        rows: [{
+          employee_id: anchor.id,
+          start_time: `${monStr}T08:00:00${tzStr}`,
+          end_time: `${monStr}T12:00:00${tzStr}`,
+          position: 'Host',
+          status: 'scheduled',
+          break_duration: 0,
+          is_published: false,
+          locked: false,
+        }],
+        restId: restaurantId,
+      },
+    );
+
+    await page.goto('/scheduling');
+    await page.waitForURL(/\/scheduling/, { timeout: 8000 });
+
+    // Click Planner tab
+    const plannerTab = page.getByRole('tab', { name: /planner/i });
+    await expect(plannerTab).toBeVisible({ timeout: 10000 });
+    await plannerTab.click();
+
+    // Switch to Timeline view — ToggleGroupItem renders as a radio button
+    const timelineToggle = page.getByRole('radio', { name: /^timeline$/i });
+    await expect(timelineToggle).toBeVisible({ timeout: 10000 });
+    await timelineToggle.click();
+
+    // Navigate the day selector to Monday of this week, where the anchor
+    // shift was seeded (the Timeline defaults to today).
+    const mondayLabel = monday.toLocaleDateString('en-US', { weekday: 'short' });
+    await page.getByRole('button', { name: new RegExp(`^${mondayLabel}`, 'i') }).click();
+
+    // Sanity check: the anchor shift's bar is visible before we attempt to add a second.
+    await expect(
+      page.getByRole('button', { name: /anchor alvarez, host, 8a to 12p, 4\.0 hours/i }),
+    ).toBeVisible({ timeout: 10000 });
+
+    // ── CREATE path ──────────────────────────────────────────────────────────
+    // The lane's keyboard entry point is a visually-hidden "Add shift to
+    // <lane> lane" button (sr-only, TimelineLane.tsx). With no area set on
+    // either employee, the lane's label is "Unassigned". It's an `sr-only`
+    // element meant for keyboard/screen-reader activation (not a mouse
+    // target sitting visibly in the layout), so we focus + activate it via
+    // keyboard rather than a pointer click, matching its intended use.
+    const addShiftButton = page.getByRole('button', { name: /^add shift to unassigned lane$/i });
+    await expect(addShiftButton).toBeVisible({ timeout: 10000 });
+    await addShiftButton.focus();
+    await addShiftButton.press('Enter');
+
+    // Quick-add popover opens with a "New shift" header
+    await expect(page.getByText(/^new shift$/i)).toBeVisible({ timeout: 5000 });
+
+    // Select the seeded employee
+    await page.getByLabel(/select employee/i).click();
+    await page.getByRole('option', { name: /dana ortiz/i }).click();
+
+    // Confirm/set start & end time (native time inputs, labeled "Start Time" / "End Time")
+    await page.getByLabel(/start time/i).fill('09:00');
+    await page.getByLabel(/end time/i).fill('13:00');
+
+    const createResponsePromise = page.waitForResponse(
+      (resp) => resp.url().includes('rest/v1/shifts') && resp.request().method() === 'POST' && resp.status() === 201,
+      { timeout: 15000 },
+    );
+    await page.getByRole('button', { name: /^add shift$/i }).click();
+    await createResponsePromise;
+
+    // Popover closes and the new shift bar appears on the timeline. Each bar is
+    // a <button> whose accessible name is "<employee>, <position>, <start> to
+    // <end>, <hours> hours" (TimelineBar.tsx / timelineModel.ts assignRows —
+    // times formatted via minutesToCompact, e.g. "9a to 1p").
+    await expect(page.getByText(/^new shift$/i)).not.toBeVisible({ timeout: 5000 });
+    const createdBar = page.getByRole('button', { name: /dana ortiz, server, 9a to 1p, 4\.0 hours/i });
+    await expect(createdBar).toBeVisible({ timeout: 10000 });
+
+    // ── EDIT path ─────────────────────────────────────────────────────────────
+    // Click the shift bar just created to open its view popover.
+    await createdBar.click();
+
+    const editButton = page.getByRole('button', { name: /^edit$/i });
+    await expect(editButton).toBeVisible({ timeout: 5000 });
+    await editButton.click();
+
+    // Extend the end time by an hour: 13:00 -> 14:00
+    const endTimeInput = page.getByLabel(/end time/i);
+    await expect(endTimeInput).toBeVisible({ timeout: 5000 });
+    await endTimeInput.fill('14:00');
+
+    const updateResponsePromise = page.waitForResponse(
+      (resp) =>
+        resp.url().includes('rest/v1/shifts') &&
+        ['PATCH', 'PUT'].includes(resp.request().method()) &&
+        resp.status() < 300,
+      { timeout: 15000 },
+    );
+    await page.getByRole('button', { name: /^save$/i }).click();
+    await updateResponsePromise;
+
+    // The updated time range is reflected on the timeline (new accessible name);
+    // the old accessible name is gone.
+    await expect(
+      page.getByRole('button', { name: /dana ortiz, server, 9a to 2p, 5\.0 hours/i }),
+    ).toBeVisible({ timeout: 10000 });
+    await expect(
+      page.getByRole('button', { name: /dana ortiz, server, 9a to 1p, 4\.0 hours/i }),
+    ).not.toBeVisible({ timeout: 5000 });
+  });
+
+  test('edits an existing shift seeded directly via Supabase', async ({ page }) => {
+    const testUser = generateTestUser('timeline-edit-seeded');
+    await signUpAndCreateRestaurant(page, testUser);
+    await exposeSupabaseHelpers(page);
+
+    const restaurantId = await page.evaluate(() => (window as any).__getRestaurantId());
+    expect(restaurantId).toBeTruthy();
+
+    const employees = await page.evaluate(
+      ({ emps, restId }) => (window as any).__insertEmployees(emps, restId),
+      {
+        emps: [
+          { name: 'Evan Cruz', position: 'Cook', status: 'active', is_active: true, compensation_type: 'hourly', hourly_rate: 1700 },
+        ],
+        restId: restaurantId,
+      },
+    );
+    const evan = (employees as any[]).find((e: any) => e.name === 'Evan Cruz');
+    expect(evan).toBeTruthy();
+
+    const monday = getMondayOfCurrentWeek();
+    const monStr = formatDate(monday);
+    const tzStr = getTimezoneOffsetString();
+
+    // Seed a shift for today-or-Monday directly, independent of the create path,
+    // so this test doesn't depend on the quick-add flow consuming a shift first.
+    await page.evaluate(
+      ({ rows, restId }: any) => (window as any).__insertShifts(rows, restId),
+      {
+        rows: [{
+          employee_id: evan.id,
+          start_time: `${monStr}T10:00:00${tzStr}`,
+          end_time: `${monStr}T15:00:00${tzStr}`,
+          position: 'Cook',
+          status: 'scheduled',
+          break_duration: 0,
+          is_published: false,
+          locked: false,
+        }],
+        restId: restaurantId,
+      },
+    );
+
+    await page.goto('/scheduling');
+    await page.waitForURL(/\/scheduling/, { timeout: 8000 });
+
+    const plannerTab = page.getByRole('tab', { name: /planner/i });
+    await expect(plannerTab).toBeVisible({ timeout: 10000 });
+    await plannerTab.click();
+
+    const timelineToggle = page.getByRole('radio', { name: /^timeline$/i });
+    await expect(timelineToggle).toBeVisible({ timeout: 10000 });
+    await timelineToggle.click();
+
+    // Navigate the day selector to Monday of this week (the Timeline defaults
+    // to today, which may not be the day the shift was seeded on).
+    const mondayLabel = monday.toLocaleDateString('en-US', { weekday: 'short' });
+    await page.getByRole('button', { name: new RegExp(`^${mondayLabel}`, 'i') }).click();
+
+    // Accessible name: "<employee>, <position>, <start> to <end>, <hours> hours"
+    // (10:00-15:00 -> "10a to 3p", 5.0 hours).
+    const shiftBar = page.getByRole('button', { name: /evan cruz, cook, 10a to 3p, 5\.0 hours/i });
+    await expect(shiftBar).toBeVisible({ timeout: 10000 });
+    await shiftBar.click();
+
+    const editButton = page.getByRole('button', { name: /^edit$/i });
+    await expect(editButton).toBeVisible({ timeout: 5000 });
+    await editButton.click();
+
+    // Shift the start time an hour later: 10:00 -> 11:00
+    const startTimeInput = page.getByLabel(/start time/i);
+    await expect(startTimeInput).toBeVisible({ timeout: 5000 });
+    await startTimeInput.fill('11:00');
+
+    const updateResponsePromise = page.waitForResponse(
+      (resp) =>
+        resp.url().includes('rest/v1/shifts') &&
+        ['PATCH', 'PUT'].includes(resp.request().method()) &&
+        resp.status() < 300,
+      { timeout: 15000 },
+    );
+    await page.getByRole('button', { name: /^save$/i }).click();
+    await updateResponsePromise;
+
+    await expect(
+      page.getByRole('button', { name: /evan cruz, cook, 11a to 3p, 4\.0 hours/i }),
+    ).toBeVisible({ timeout: 10000 });
+    await expect(
+      page.getByRole('button', { name: /evan cruz, cook, 10a to 3p, 5\.0 hours/i }),
+    ).not.toBeVisible({ timeout: 5000 });
+  });
+});

--- a/tests/unit/TimelineShiftEditor.test.tsx
+++ b/tests/unit/TimelineShiftEditor.test.tsx
@@ -1,0 +1,288 @@
+/**
+ * Unit tests: TimelineShiftEditor — the shared edit/create form used by the
+ * Timeline popover (design doc: docs/superpowers/specs/2026-07-05-timeline-edit-create-design.md,
+ * plan task B1).
+ *
+ * `useCheckConflicts` is mocked so no network/Supabase call is exercised here —
+ * that hook's own behavior is covered by useConflictDetection's tests. This
+ * file pins: field rendering + onChange wiring, employee options ranked via
+ * `rankEmployeesForShift`, amber warning chips from local `validateShift` +
+ * mocked RPC conflicts, and the single `aria-live="polite"` region.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { TimelineShiftEditor } from '@/components/scheduling/ShiftTimeline/TimelineShiftEditor';
+import type { Employee, Shift, ConflictCheck } from '@/types/scheduling';
+
+const mockUseCheckConflicts = vi.hoisted(() => vi.fn());
+
+vi.mock('@/hooks/useConflictDetection', () => ({
+  useCheckConflicts: (...args: unknown[]) => mockUseCheckConflicts(...args),
+}));
+
+function makeEmployee(overrides: Partial<Employee> & { id: string; name: string }): Employee {
+  return {
+    restaurant_id: 'r1',
+    position: 'Server',
+    status: 'active',
+    is_active: true,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  } as Employee;
+}
+
+function makeShift(overrides: Partial<Shift> = {}): Shift {
+  return {
+    id: 'shift-1',
+    restaurant_id: 'r1',
+    employee_id: 'e1',
+    start_time: '2026-03-10T15:00:00.000Z',
+    end_time: '2026-03-10T23:00:00.000Z',
+    break_duration: 30,
+    position: 'Server',
+    status: 'scheduled',
+    is_published: false,
+    locked: false,
+    source: 'manual',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  } as Shift;
+}
+
+const NO_CONFLICTS = { conflicts: [] as ConflictCheck[], hasConflicts: false, loading: false, error: null };
+
+const employees: Employee[] = [
+  makeEmployee({ id: 'e1', name: 'Amy Server', position: 'Server' }),
+  makeEmployee({ id: 'e2', name: 'Cody Cook', position: 'Cook' }),
+];
+
+describe('TimelineShiftEditor', () => {
+  beforeEach(() => {
+    mockUseCheckConflicts.mockReset();
+    mockUseCheckConflicts.mockReturnValue(NO_CONFLICTS);
+  });
+
+  it('renders start/end time fields, employee select, break, and notes', () => {
+    render(
+      <TimelineShiftEditor
+        mode="edit"
+        shift={makeShift()}
+        employees={employees}
+        restaurantId="r1"
+        dateStr="2026-03-10"
+        tz="America/Chicago"
+        existingShifts={[]}
+        onChange={() => {}}
+        values={{
+          employeeId: 'e1',
+          startTime: '09:00',
+          endTime: '17:00',
+          breakDuration: '30',
+          notes: '',
+        }}
+      />,
+    );
+
+    expect(screen.getByLabelText(/start time/i)).toBeTruthy();
+    expect(screen.getByLabelText(/end time/i)).toBeTruthy();
+    expect(screen.getByLabelText(/select employee/i)).toBeTruthy();
+    expect(screen.getByLabelText(/break/i)).toBeTruthy();
+    expect(screen.getByLabelText(/notes/i)).toBeTruthy();
+  });
+
+  it('ranks employees via rankEmployeesForShift using the shift position as context', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TimelineShiftEditor
+        mode="edit"
+        shift={makeShift({ position: 'Cook' })}
+        employees={employees}
+        restaurantId="r1"
+        dateStr="2026-03-10"
+        tz="America/Chicago"
+        existingShifts={[]}
+        onChange={() => {}}
+        values={{
+          employeeId: 'e1',
+          startTime: '09:00',
+          endTime: '17:00',
+          breakDuration: '30',
+          notes: '',
+        }}
+      />,
+    );
+
+    await user.click(screen.getByLabelText(/select employee/i));
+
+    const options = screen.getAllByRole('option').map((el) => el.textContent);
+    // Cody Cook (position match) should be ranked ahead of Amy Server.
+    expect(options.findIndex((t) => t?.includes('Cody Cook'))).toBeLessThan(
+      options.findIndex((t) => t?.includes('Amy Server')),
+    );
+  });
+
+  it('calls onChange when the start time field changes', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(
+      <TimelineShiftEditor
+        mode="edit"
+        shift={makeShift()}
+        employees={employees}
+        restaurantId="r1"
+        dateStr="2026-03-10"
+        tz="America/Chicago"
+        existingShifts={[]}
+        onChange={onChange}
+        values={{
+          employeeId: 'e1',
+          startTime: '09:00',
+          endTime: '17:00',
+          breakDuration: '30',
+          notes: '',
+        }}
+      />,
+    );
+
+    const startInput = screen.getByLabelText(/start time/i) as HTMLInputElement;
+    await user.clear(startInput);
+    await user.type(startInput, '10:30');
+
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it('renders an amber conflict chip when useCheckConflicts reports a conflict', () => {
+    mockUseCheckConflicts.mockReturnValue({
+      conflicts: [
+        {
+          has_conflict: true,
+          conflict_type: 'time-off',
+          message: 'Employee has approved time-off from 2026-03-10 to 2026-03-10',
+        },
+      ] as ConflictCheck[],
+      hasConflicts: true,
+      loading: false,
+      error: null,
+    });
+
+    const { container } = render(
+      <TimelineShiftEditor
+        mode="edit"
+        shift={makeShift()}
+        employees={employees}
+        restaurantId="r1"
+        dateStr="2026-03-10"
+        tz="America/Chicago"
+        existingShifts={[]}
+        onChange={() => {}}
+        values={{
+          employeeId: 'e1',
+          startTime: '09:00',
+          endTime: '17:00',
+          breakDuration: '30',
+          notes: '',
+        }}
+      />,
+    );
+
+    expect(screen.getByText(/time-off/i)).toBeTruthy();
+    expect(container.querySelector('.bg-amber-500\\/10')).toBeTruthy();
+  });
+
+  it('renders an amber chip for local validateShift warnings (e.g. overlap)', () => {
+    const overlapping = makeShift({
+      id: 'shift-2',
+      employee_id: 'e1',
+      start_time: '2026-03-10T14:00:00.000Z',
+      end_time: '2026-03-10T20:00:00.000Z',
+    });
+
+    render(
+      <TimelineShiftEditor
+        mode="edit"
+        shift={makeShift({ id: 'shift-1' })}
+        employees={employees}
+        restaurantId="r1"
+        dateStr="2026-03-10"
+        tz="America/Chicago"
+        existingShifts={[overlapping]}
+        onChange={() => {}}
+        values={{
+          employeeId: 'e1',
+          startTime: '09:00',
+          endTime: '17:00',
+          breakDuration: '30',
+          notes: '',
+        }}
+      />,
+    );
+
+    expect(screen.getByText(/overlaps with existing shift/i)).toBeTruthy();
+  });
+
+  it('exposes exactly one aria-live="polite" region', () => {
+    mockUseCheckConflicts.mockReturnValue({
+      conflicts: [
+        { has_conflict: true, conflict_type: 'time-off', message: 'conflict!' },
+      ] as ConflictCheck[],
+      hasConflicts: true,
+      loading: false,
+      error: null,
+    });
+
+    const { container } = render(
+      <TimelineShiftEditor
+        mode="edit"
+        shift={makeShift()}
+        employees={employees}
+        restaurantId="r1"
+        dateStr="2026-03-10"
+        tz="America/Chicago"
+        existingShifts={[]}
+        onChange={() => {}}
+        values={{
+          employeeId: 'e1',
+          startTime: '09:00',
+          endTime: '17:00',
+          breakDuration: '30',
+          notes: '',
+        }}
+      />,
+    );
+
+    const liveRegions = container.querySelectorAll('[aria-live="polite"]');
+    expect(liveRegions.length).toBe(1);
+  });
+
+  it('does not call useCheckConflicts (skips RPC) until an employee and both times are set', () => {
+    render(
+      <TimelineShiftEditor
+        mode="create"
+        shift={null}
+        employees={employees}
+        restaurantId="r1"
+        dateStr="2026-03-10"
+        tz="America/Chicago"
+        existingShifts={[]}
+        onChange={() => {}}
+        values={{
+          employeeId: '',
+          startTime: '',
+          endTime: '',
+          breakDuration: '0',
+          notes: '',
+        }}
+      />,
+    );
+
+    // First arg is the params object; expect null/falsy when incomplete.
+    expect(mockUseCheckConflicts).toHaveBeenCalledWith(null);
+  });
+});

--- a/tests/unit/TimelineShiftEditor.test.tsx
+++ b/tests/unit/TimelineShiftEditor.test.tsx
@@ -95,6 +95,68 @@ describe('TimelineShiftEditor', () => {
     expect(screen.getByLabelText(/notes/i)).toBeTruthy();
   });
 
+  it('edit mode: still lists (and keeps selected) the shift\'s currently-assigned employee even after they become inactive (regression: CodeRabbit Major)', async () => {
+    const user = userEvent.setup();
+    const inactiveEmployee = makeEmployee({ id: 'e-inactive', name: 'Ivy Inactive', position: 'Server', is_active: false });
+    const employeesWithInactive: Employee[] = [...employees, inactiveEmployee];
+
+    render(
+      <TimelineShiftEditor
+        mode="edit"
+        shift={makeShift({ employee_id: 'e-inactive' })}
+        employees={employeesWithInactive}
+        restaurantId="r1"
+        dateStr="2026-03-10"
+        tz="America/Chicago"
+        existingShifts={[]}
+        onChange={() => {}}
+        values={{
+          employeeId: 'e-inactive',
+          startTime: '09:00',
+          endTime: '17:00',
+          breakDuration: '30',
+          notes: '',
+        }}
+      />,
+    );
+
+    await user.click(screen.getByLabelText(/select employee/i));
+
+    const options = screen.getAllByRole('option').map((el) => el.textContent);
+    expect(options.some((t) => t?.includes('Ivy Inactive'))).toBe(true);
+  });
+
+  it('create mode: does NOT list inactive employees (active-only filter still applies when there is no currently-assigned shift)', async () => {
+    const user = userEvent.setup();
+    const inactiveEmployee = makeEmployee({ id: 'e-inactive', name: 'Ivy Inactive', position: 'Server', is_active: false });
+    const employeesWithInactive: Employee[] = [...employees, inactiveEmployee];
+
+    render(
+      <TimelineShiftEditor
+        mode="create"
+        shift={null}
+        employees={employeesWithInactive}
+        restaurantId="r1"
+        dateStr="2026-03-10"
+        tz="America/Chicago"
+        existingShifts={[]}
+        onChange={() => {}}
+        values={{
+          employeeId: '',
+          startTime: '09:00',
+          endTime: '17:00',
+          breakDuration: '0',
+          notes: '',
+        }}
+      />,
+    );
+
+    await user.click(screen.getByLabelText(/select employee/i));
+
+    const options = screen.getAllByRole('option').map((el) => el.textContent);
+    expect(options.some((t) => t?.includes('Ivy Inactive'))).toBe(false);
+  });
+
   it('ranks employees via rankEmployeesForShift using the shift position as context', async () => {
     const user = userEvent.setup();
 

--- a/tests/unit/TimelineShiftPopover.test.tsx
+++ b/tests/unit/TimelineShiftPopover.test.tsx
@@ -79,6 +79,23 @@ function defaultProps(overrides: Partial<React.ComponentProps<typeof TimelineShi
   };
 }
 
+function defaultCreateDraft(
+  overrides: Partial<NonNullable<React.ComponentProps<typeof TimelineShiftPopover>['createDraft']>> = {},
+) {
+  return {
+    values: {
+      employeeId: '',
+      startTime: '15:00',
+      endTime: '17:00',
+      breakDuration: '',
+      notes: '',
+    },
+    laneContext: { position: 'Server', area: null },
+    businessDate: '2026-03-10',
+    ...overrides,
+  };
+}
+
 describe('TimelineShiftPopover', () => {
   beforeEach(() => {
     mockUseCheckConflicts.mockReset();
@@ -285,5 +302,295 @@ describe('TimelineShiftPopover', () => {
     // Still in edit mode, still mounted.
     expect(screen.getByLabelText(/select employee/i)).toBeTruthy();
     expect(onClose).not.toHaveBeenCalled();
+  });
+
+  describe('create mode', () => {
+    function createProps(
+      overrides: Partial<React.ComponentProps<typeof TimelineShiftPopover>> = {},
+    ) {
+      return defaultProps({
+        activeShift: null,
+        createDraft: defaultCreateDraft(),
+        validateAndCreateAtTime: vi.fn(),
+        forceCreateAtTime: vi.fn(),
+        ...overrides,
+      });
+    }
+
+    it('renders nothing when both activeShift and createDraft are absent', () => {
+      const { container } = render(
+        <TimelineShiftPopover {...createProps({ createDraft: null })} />,
+      );
+      expect(container.querySelector('[role="dialog"]')).toBeNull();
+    });
+
+    it('renders a "New shift" header and the create form when createDraft is present', () => {
+      render(<TimelineShiftPopover {...createProps()} />);
+
+      expect(screen.getByText(/^new shift$/i)).toBeTruthy();
+      expect(screen.getByLabelText(/select employee/i)).toBeTruthy();
+      expect(screen.getByLabelText(/start time/i)).toBeTruthy();
+      expect(screen.getByLabelText(/end time/i)).toBeTruthy();
+      expect(screen.getByRole('button', { name: /^add shift$/i })).toBeTruthy();
+    });
+
+    it('shows the lane position as a subtitle when present', () => {
+      render(
+        <TimelineShiftPopover
+          {...createProps({
+            createDraft: defaultCreateDraft({
+              laneContext: { position: 'Cook', area: null },
+            }),
+          })}
+        />,
+      );
+
+      expect(screen.getByText(/^cook$/i)).toBeTruthy();
+    });
+
+    it('disables Add shift until an employee is selected', () => {
+      render(<TimelineShiftPopover {...createProps()} />);
+
+      expect(screen.getByRole('button', { name: /^add shift$/i })).toBeDisabled();
+    });
+
+    it('enables Add shift once an employee is selected', async () => {
+      const user = userEvent.setup();
+      render(
+        <TimelineShiftPopover
+          {...createProps({
+            createDraft: defaultCreateDraft({
+              values: {
+                employeeId: 'e1',
+                startTime: '15:00',
+                endTime: '17:00',
+                breakDuration: '',
+                notes: '',
+              },
+            }),
+          })}
+        />,
+      );
+
+      expect(screen.getByRole('button', { name: /^add shift$/i })).not.toBeDisabled();
+    });
+
+    it('Add shift calls validateAndCreateAtTime with correct ISO instants and the lane position', async () => {
+      const user = userEvent.setup();
+      const onClose = vi.fn();
+      const validateAndCreateAtTime = vi.fn().mockResolvedValue({ created: true });
+
+      render(
+        <TimelineShiftPopover
+          {...createProps({
+            onClose,
+            validateAndCreateAtTime,
+            createDraft: defaultCreateDraft({
+              values: {
+                employeeId: 'e1',
+                startTime: '15:00',
+                endTime: '17:00',
+                breakDuration: '30',
+                notes: 'Cover the rush',
+              },
+              laneContext: { position: 'Server', area: null },
+            }),
+          })}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: /^add shift$/i }));
+
+      await waitFor(() => expect(validateAndCreateAtTime).toHaveBeenCalledTimes(1));
+      const input = validateAndCreateAtTime.mock.calls[0][0];
+      expect(input.employeeId).toBe('e1');
+      expect(input.businessDate).toBe('2026-03-10');
+      expect(input.position).toBe('Server');
+      expect(input.breakDuration).toBe(30);
+      expect(input.notes).toBe('Cover the rush');
+      // 15:00 America/Chicago (CDT, UTC-5) -> 20:00Z; 17:00 -> 22:00Z.
+      expect(input.startIso).toBe('2026-03-10T20:00:00.000Z');
+      expect(input.endIso).toBe('2026-03-10T22:00:00.000Z');
+
+      await waitFor(() => expect(onClose).toHaveBeenCalled());
+    });
+
+    it('derives position from the selected employee when the lane has no position (area grouping)', async () => {
+      const user = userEvent.setup();
+      const validateAndCreateAtTime = vi.fn().mockResolvedValue({ created: true });
+
+      render(
+        <TimelineShiftPopover
+          {...createProps({
+            validateAndCreateAtTime,
+            createDraft: defaultCreateDraft({
+              values: {
+                employeeId: 'e2',
+                startTime: '15:00',
+                endTime: '17:00',
+                breakDuration: '',
+                notes: '',
+              },
+              laneContext: { position: null, area: 'Front' },
+            }),
+          })}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: /^add shift$/i }));
+
+      await waitFor(() => expect(validateAndCreateAtTime).toHaveBeenCalledTimes(1));
+      const input = validateAndCreateAtTime.mock.calls[0][0];
+      // e2 is Cody Cook, position 'Cook' — falls back to the employee's own position.
+      expect(input.position).toBe('Cook');
+    });
+
+    it('rolls the end time past midnight for an overnight create range', async () => {
+      const user = userEvent.setup();
+      const validateAndCreateAtTime = vi.fn().mockResolvedValue({ created: true });
+
+      render(
+        <TimelineShiftPopover
+          {...createProps({
+            validateAndCreateAtTime,
+            createDraft: defaultCreateDraft({
+              values: {
+                employeeId: 'e1',
+                startTime: '22:00',
+                endTime: '02:00',
+                breakDuration: '',
+                notes: '',
+              },
+            }),
+          })}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: /^add shift$/i }));
+
+      await waitFor(() => expect(validateAndCreateAtTime).toHaveBeenCalledTimes(1));
+      const input = validateAndCreateAtTime.mock.calls[0][0];
+      // 22:00 CDT -> 2026-03-11T03:00:00Z; 02:00 next day CDT -> 2026-03-11T07:00:00Z.
+      expect(input.startIso).toBe('2026-03-11T03:00:00.000Z');
+      expect(input.endIso).toBe('2026-03-11T07:00:00.000Z');
+    });
+
+    it('pending conflicts open the shared AvailabilityConflictDialog and keep the create form mounted', async () => {
+      const user = userEvent.setup();
+      const onClose = vi.fn();
+      const validateAndCreateAtTime = vi.fn().mockResolvedValue({
+        created: false,
+        pendingConflicts: [
+          { has_conflict: true, conflict_type: 'time-off', message: 'Employee has approved time-off' },
+        ] as ConflictCheck[],
+        pendingWarnings: [],
+      });
+
+      render(
+        <TimelineShiftPopover
+          {...createProps({
+            onClose,
+            validateAndCreateAtTime,
+            createDraft: defaultCreateDraft({
+              values: {
+                employeeId: 'e1',
+                startTime: '15:00',
+                endTime: '17:00',
+                breakDuration: '',
+                notes: '',
+              },
+            }),
+          })}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: /^add shift$/i }));
+
+      await waitFor(() => expect(screen.getByRole('dialog', { name: /scheduling warning/i })).toBeTruthy());
+      expect(screen.getByLabelText(/select employee/i)).toBeTruthy();
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('confirming the conflict dialog calls forceCreateAtTime and then closes the popover', async () => {
+      const user = userEvent.setup();
+      const onClose = vi.fn();
+      const validateAndCreateAtTime = vi.fn().mockResolvedValue({
+        created: false,
+        pendingConflicts: [
+          { has_conflict: true, conflict_type: 'time-off', message: 'Employee has approved time-off' },
+        ] as ConflictCheck[],
+        pendingWarnings: [],
+      });
+      const forceCreateAtTime = vi.fn().mockResolvedValue(true);
+
+      render(
+        <TimelineShiftPopover
+          {...createProps({
+            onClose,
+            validateAndCreateAtTime,
+            forceCreateAtTime,
+            createDraft: defaultCreateDraft({
+              values: {
+                employeeId: 'e1',
+                startTime: '15:00',
+                endTime: '17:00',
+                breakDuration: '',
+                notes: '',
+              },
+            }),
+          })}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: /^add shift$/i }));
+      await waitFor(() => expect(screen.getByRole('dialog', { name: /scheduling warning/i })).toBeTruthy());
+
+      await user.click(screen.getByRole('button', { name: /assign anyway/i }));
+
+      await waitFor(() => expect(forceCreateAtTime).toHaveBeenCalledTimes(1));
+      const input = forceCreateAtTime.mock.calls[0][0];
+      expect(input.employeeId).toBe('e1');
+      expect(input.position).toBe('Server');
+      await waitFor(() => expect(onClose).toHaveBeenCalled());
+    });
+
+    it('cancelling the conflict dialog returns to the create form without closing the popover', async () => {
+      const user = userEvent.setup();
+      const onClose = vi.fn();
+      const validateAndCreateAtTime = vi.fn().mockResolvedValue({
+        created: false,
+        pendingConflicts: [
+          { has_conflict: true, conflict_type: 'time-off', message: 'Employee has approved time-off' },
+        ] as ConflictCheck[],
+        pendingWarnings: [],
+      });
+
+      render(
+        <TimelineShiftPopover
+          {...createProps({
+            onClose,
+            validateAndCreateAtTime,
+            createDraft: defaultCreateDraft({
+              values: {
+                employeeId: 'e1',
+                startTime: '15:00',
+                endTime: '17:00',
+                breakDuration: '',
+                notes: '',
+              },
+            }),
+          })}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: /^add shift$/i }));
+      await waitFor(() => expect(screen.getByRole('dialog', { name: /scheduling warning/i })).toBeTruthy());
+
+      await user.click(screen.getByRole('button', { name: /^cancel$/i }));
+
+      await waitFor(() => expect(screen.queryByRole('dialog', { name: /scheduling warning/i })).toBeNull());
+      expect(screen.getByLabelText(/select employee/i)).toBeTruthy();
+      expect(onClose).not.toHaveBeenCalled();
+    });
   });
 });

--- a/tests/unit/TimelineShiftPopover.test.tsx
+++ b/tests/unit/TimelineShiftPopover.test.tsx
@@ -1,0 +1,289 @@
+/**
+ * Unit tests: TimelineShiftPopover — view mode footer (Edit/Delete), edit mode
+ * (renders TimelineShiftEditor), locked/recurring affordances, delete confirm
+ * for published shifts, and conflict-dialog stacking (design doc: docs/superpowers/specs/
+ * 2026-07-05-timeline-edit-create-design.md, plan task B2).
+ *
+ * `useCheckConflicts` is mocked (TimelineShiftEditor's own dependency) so no
+ * network call is exercised. Mutation callbacks are plain vi.fn()s injected as
+ * props — this component does not itself mount useValidatedShiftMutations
+ * (that wiring is B3's job at the ShiftTimelineTab level).
+ */
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { TimelineShiftPopover } from '@/components/scheduling/ShiftTimeline/TimelineShiftPopover';
+import type { Employee, Shift, ConflictCheck } from '@/types/scheduling';
+
+const mockUseCheckConflicts = vi.hoisted(() => vi.fn());
+
+vi.mock('@/hooks/useConflictDetection', () => ({
+  useCheckConflicts: (...args: unknown[]) => mockUseCheckConflicts(...args),
+}));
+
+const NO_CONFLICTS = { conflicts: [] as ConflictCheck[], hasConflicts: false, loading: false, error: null };
+
+function makeEmployee(overrides: Partial<Employee> & { id: string; name: string }): Employee {
+  return {
+    restaurant_id: 'r1',
+    position: 'Server',
+    status: 'active',
+    is_active: true,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  } as Employee;
+}
+
+function makeShift(overrides: Partial<Shift> = {}): Shift {
+  return {
+    id: 'shift-1',
+    restaurant_id: 'r1',
+    employee_id: 'e1',
+    start_time: '2026-03-10T15:00:00.000Z',
+    end_time: '2026-03-10T23:00:00.000Z',
+    break_duration: 30,
+    position: 'Server',
+    status: 'scheduled',
+    is_published: false,
+    locked: false,
+    source: 'manual',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  } as Shift;
+}
+
+const employees: Employee[] = [
+  makeEmployee({ id: 'e1', name: 'Amy Server', position: 'Server' }),
+  makeEmployee({ id: 'e2', name: 'Cody Cook', position: 'Cook' }),
+];
+
+function defaultProps(overrides: Partial<React.ComponentProps<typeof TimelineShiftPopover>> = {}) {
+  return {
+    activeShift: makeShift(),
+    tz: 'America/Chicago',
+    dateStr: '2026-03-10',
+    employees,
+    restaurantId: 'r1',
+    dayShifts: [] as Shift[],
+    onClose: vi.fn(),
+    validateAndUpdateTime: vi.fn(),
+    forceUpdateTime: vi.fn(),
+    deleteShift: vi.fn(),
+    validationResult: null,
+    clearValidation: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('TimelineShiftPopover', () => {
+  beforeEach(() => {
+    mockUseCheckConflicts.mockReset();
+    mockUseCheckConflicts.mockReturnValue(NO_CONFLICTS);
+  });
+
+  it('renders nothing when activeShift is null', () => {
+    const { container } = render(
+      <TimelineShiftPopover {...defaultProps({ activeShift: null })} />,
+    );
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it('view mode shows Edit and Delete footer actions', () => {
+    render(<TimelineShiftPopover {...defaultProps()} />);
+
+    expect(screen.getByRole('button', { name: /^edit$/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /^delete$/i })).toBeTruthy();
+  });
+
+  it('locked shift shows a lock icon and disables Edit/Delete', () => {
+    render(
+      <TimelineShiftPopover
+        {...defaultProps({ activeShift: makeShift({ locked: true }) })}
+      />,
+    );
+
+    expect(screen.getByLabelText(/locked/i)).toBeTruthy();
+    expect(screen.getByRole('button', { name: /^edit$/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /^delete$/i })).toBeDisabled();
+  });
+
+  it('recurring shift shows the "this shift only" hint', () => {
+    render(
+      <TimelineShiftPopover
+        {...defaultProps({ activeShift: makeShift({ is_recurring: true }) })}
+      />,
+    );
+
+    expect(screen.getByText(/changes apply to this shift only/i)).toBeTruthy();
+  });
+
+  it('clicking Edit switches to edit mode and renders the employee select from TimelineShiftEditor', async () => {
+    const user = userEvent.setup();
+    render(<TimelineShiftPopover {...defaultProps()} />);
+
+    await user.click(screen.getByRole('button', { name: /^edit$/i }));
+
+    expect(screen.getByLabelText(/select employee/i)).toBeTruthy();
+    expect(screen.getByLabelText(/start time/i)).toBeTruthy();
+  });
+
+  it('clicking Delete on an unpublished shift deletes immediately (no confirm dialog)', async () => {
+    const user = userEvent.setup();
+    const deleteShift = vi.fn();
+    render(
+      <TimelineShiftPopover
+        {...defaultProps({ activeShift: makeShift({ is_published: false }), deleteShift })}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /^delete$/i }));
+
+    expect(deleteShift).toHaveBeenCalledWith('shift-1');
+    // No AlertDialog should have appeared.
+    expect(screen.queryByRole('alertdialog')).toBeNull();
+  });
+
+  it('clicking Delete on a published shift opens an AlertDialog confirm, and only deletes on confirm', async () => {
+    const user = userEvent.setup();
+    const deleteShift = vi.fn();
+    render(
+      <TimelineShiftPopover
+        {...defaultProps({ activeShift: makeShift({ is_published: true }), deleteShift })}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /^delete$/i }));
+
+    expect(screen.getByRole('alertdialog')).toBeTruthy();
+    expect(deleteShift).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: /^delete shift$/i }));
+
+    await waitFor(() => expect(deleteShift).toHaveBeenCalledWith('shift-1'));
+  });
+
+  it('published-shift delete confirm dismisses without deleting on Cancel', async () => {
+    const user = userEvent.setup();
+    const deleteShift = vi.fn();
+    render(
+      <TimelineShiftPopover
+        {...defaultProps({ activeShift: makeShift({ is_published: true }), deleteShift })}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /^delete$/i }));
+    expect(screen.getByRole('alertdialog')).toBeTruthy();
+
+    await user.click(screen.getByRole('button', { name: /^cancel$/i }));
+
+    expect(deleteShift).not.toHaveBeenCalled();
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull());
+  });
+
+  it('Save with no pending issues calls forceUpdateTime-free validateAndUpdateTime and closes the popover', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const validateAndUpdateTime = vi.fn().mockResolvedValue({ updated: true });
+
+    render(
+      <TimelineShiftPopover
+        {...defaultProps({ onClose, validateAndUpdateTime })}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /^edit$/i }));
+    await user.click(screen.getByRole('button', { name: /^save$/i }));
+
+    await waitFor(() => expect(validateAndUpdateTime).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it('Save with pending conflicts keeps the popover mounted and open behind the conflict dialog', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const validateAndUpdateTime = vi.fn().mockResolvedValue({
+      updated: false,
+      pendingConflicts: [
+        { has_conflict: true, conflict_type: 'time-off', message: 'Employee has approved time-off' },
+      ] as ConflictCheck[],
+      pendingWarnings: [],
+    });
+
+    render(
+      <TimelineShiftPopover
+        {...defaultProps({ onClose, validateAndUpdateTime })}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /^edit$/i }));
+    await user.click(screen.getByRole('button', { name: /^save$/i }));
+
+    await waitFor(() => expect(screen.getByRole('dialog', { name: /scheduling warning/i })).toBeTruthy());
+    // Popover content (edit form) should still be present behind the conflict dialog.
+    expect(screen.getByLabelText(/select employee/i)).toBeTruthy();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('confirming the conflict dialog calls forceUpdateTime and then closes the popover', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const validateAndUpdateTime = vi.fn().mockResolvedValue({
+      updated: false,
+      pendingConflicts: [
+        { has_conflict: true, conflict_type: 'time-off', message: 'Employee has approved time-off' },
+      ] as ConflictCheck[],
+      pendingWarnings: [],
+    });
+    const forceUpdateTime = vi.fn().mockResolvedValue(true);
+
+    render(
+      <TimelineShiftPopover
+        {...defaultProps({ onClose, validateAndUpdateTime, forceUpdateTime })}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /^edit$/i }));
+    await user.click(screen.getByRole('button', { name: /^save$/i }));
+
+    await waitFor(() => expect(screen.getByRole('dialog', { name: /scheduling warning/i })).toBeTruthy());
+
+    await user.click(screen.getByRole('button', { name: /assign anyway/i }));
+
+    await waitFor(() => expect(forceUpdateTime).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it('cancelling the conflict dialog returns to the edit form without closing the popover', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const validateAndUpdateTime = vi.fn().mockResolvedValue({
+      updated: false,
+      pendingConflicts: [
+        { has_conflict: true, conflict_type: 'time-off', message: 'Employee has approved time-off' },
+      ] as ConflictCheck[],
+      pendingWarnings: [],
+    });
+
+    render(
+      <TimelineShiftPopover
+        {...defaultProps({ onClose, validateAndUpdateTime })}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /^edit$/i }));
+    await user.click(screen.getByRole('button', { name: /^save$/i }));
+
+    await waitFor(() => expect(screen.getByRole('dialog', { name: /scheduling warning/i })).toBeTruthy());
+
+    await user.click(screen.getByRole('button', { name: /^cancel$/i }));
+
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: /scheduling warning/i })).toBeNull());
+    // Still in edit mode, still mounted.
+    expect(screen.getByLabelText(/select employee/i)).toBeTruthy();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/TimelineShiftPopover.test.tsx
+++ b/tests/unit/TimelineShiftPopover.test.tsx
@@ -68,10 +68,12 @@ function defaultProps(overrides: Partial<React.ComponentProps<typeof TimelineShi
     dateStr: '2026-03-10',
     employees,
     restaurantId: 'r1',
-    dayShifts: [] as Shift[],
+    existingShifts: [] as Shift[],
     onClose: vi.fn(),
     validateAndUpdateTime: vi.fn(),
     forceUpdateTime: vi.fn(),
+    validateAndUpdateShift: vi.fn(),
+    forceUpdateShift: vi.fn(),
     deleteShift: vi.fn(),
     validationResult: null,
     clearValidation: vi.fn(),
@@ -201,28 +203,69 @@ describe('TimelineShiftPopover', () => {
     await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull());
   });
 
-  it('Save with no pending issues calls forceUpdateTime-free validateAndUpdateTime and closes the popover', async () => {
+  it('Save with no pending issues calls validateAndUpdateShift and closes the popover', async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
-    const validateAndUpdateTime = vi.fn().mockResolvedValue({ updated: true });
+    const validateAndUpdateShift = vi.fn().mockResolvedValue({ updated: true });
 
     render(
       <TimelineShiftPopover
-        {...defaultProps({ onClose, validateAndUpdateTime })}
+        {...defaultProps({ onClose, validateAndUpdateShift })}
       />,
     );
 
     await user.click(screen.getByRole('button', { name: /^edit$/i }));
     await user.click(screen.getByRole('button', { name: /^save$/i }));
 
-    await waitFor(() => expect(validateAndUpdateTime).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(validateAndUpdateShift).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it('Save persists employee/break/notes changes made in the edit form, not just start/end time (regression: these silently vanished before)', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const validateAndUpdateShift = vi.fn().mockResolvedValue({ updated: true });
+
+    render(
+      <TimelineShiftPopover
+        {...defaultProps({
+          onClose,
+          validateAndUpdateShift,
+          activeShift: makeShift({ id: 'shift-1', employee_id: 'e1', break_duration: 30, notes: 'old notes' }),
+        })}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /^edit$/i }));
+
+    // Change employee.
+    await user.click(screen.getByLabelText(/select employee/i));
+    await user.click(await screen.findByRole('option', { name: /cody cook/i }));
+
+    // Change break duration.
+    const breakInput = screen.getByLabelText(/break duration/i);
+    await user.clear(breakInput);
+    await user.type(breakInput, '45');
+
+    // Change notes.
+    const notesInput = screen.getByLabelText(/shift notes/i);
+    await user.clear(notesInput);
+    await user.type(notesInput, 'new notes');
+
+    await user.click(screen.getByRole('button', { name: /^save$/i }));
+
+    await waitFor(() => expect(validateAndUpdateShift).toHaveBeenCalledTimes(1));
+    const input = validateAndUpdateShift.mock.calls[0][0];
+    expect(input.employeeId).toBe('e2');
+    expect(input.breakDuration).toBe(45);
+    expect(input.notes).toBe('new notes');
+    expect(input.shift.id).toBe('shift-1');
   });
 
   it('Save with pending conflicts keeps the popover mounted and open behind the conflict dialog', async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
-    const validateAndUpdateTime = vi.fn().mockResolvedValue({
+    const validateAndUpdateShift = vi.fn().mockResolvedValue({
       updated: false,
       pendingConflicts: [
         { has_conflict: true, conflict_type: 'time-off', message: 'Employee has approved time-off' },
@@ -232,7 +275,7 @@ describe('TimelineShiftPopover', () => {
 
     render(
       <TimelineShiftPopover
-        {...defaultProps({ onClose, validateAndUpdateTime })}
+        {...defaultProps({ onClose, validateAndUpdateShift })}
       />,
     );
 
@@ -245,21 +288,21 @@ describe('TimelineShiftPopover', () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
-  it('confirming the conflict dialog calls forceUpdateTime and then closes the popover', async () => {
+  it('confirming the conflict dialog calls forceUpdateShift and then closes the popover', async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
-    const validateAndUpdateTime = vi.fn().mockResolvedValue({
+    const validateAndUpdateShift = vi.fn().mockResolvedValue({
       updated: false,
       pendingConflicts: [
         { has_conflict: true, conflict_type: 'time-off', message: 'Employee has approved time-off' },
       ] as ConflictCheck[],
       pendingWarnings: [],
     });
-    const forceUpdateTime = vi.fn().mockResolvedValue(true);
+    const forceUpdateShift = vi.fn().mockResolvedValue({ updated: true });
 
     render(
       <TimelineShiftPopover
-        {...defaultProps({ onClose, validateAndUpdateTime, forceUpdateTime })}
+        {...defaultProps({ onClose, validateAndUpdateShift, forceUpdateShift })}
       />,
     );
 
@@ -270,14 +313,14 @@ describe('TimelineShiftPopover', () => {
 
     await user.click(screen.getByRole('button', { name: /assign anyway/i }));
 
-    await waitFor(() => expect(forceUpdateTime).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(forceUpdateShift).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
 
   it('cancelling the conflict dialog returns to the edit form without closing the popover', async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
-    const validateAndUpdateTime = vi.fn().mockResolvedValue({
+    const validateAndUpdateShift = vi.fn().mockResolvedValue({
       updated: false,
       pendingConflicts: [
         { has_conflict: true, conflict_type: 'time-off', message: 'Employee has approved time-off' },
@@ -287,7 +330,7 @@ describe('TimelineShiftPopover', () => {
 
     render(
       <TimelineShiftPopover
-        {...defaultProps({ onClose, validateAndUpdateTime })}
+        {...defaultProps({ onClose, validateAndUpdateShift })}
       />,
     );
 
@@ -355,7 +398,6 @@ describe('TimelineShiftPopover', () => {
     });
 
     it('enables Add shift once an employee is selected', async () => {
-      const user = userEvent.setup();
       render(
         <TimelineShiftPopover
           {...createProps({

--- a/tests/unit/TimelineShiftPopover.test.tsx
+++ b/tests/unit/TimelineShiftPopover.test.tsx
@@ -74,7 +74,7 @@ function defaultProps(overrides: Partial<React.ComponentProps<typeof TimelineShi
     forceUpdateTime: vi.fn(),
     validateAndUpdateShift: vi.fn(),
     forceUpdateShift: vi.fn(),
-    deleteShift: vi.fn(),
+    onDelete: vi.fn(),
     validationResult: null,
     clearValidation: vi.fn(),
     ...overrides,
@@ -152,45 +152,47 @@ describe('TimelineShiftPopover', () => {
 
   it('clicking Delete on an unpublished shift deletes immediately (no confirm dialog)', async () => {
     const user = userEvent.setup();
-    const deleteShift = vi.fn();
+    const onDelete = vi.fn();
+    const shift = makeShift({ is_published: false });
     render(
       <TimelineShiftPopover
-        {...defaultProps({ activeShift: makeShift({ is_published: false }), deleteShift })}
+        {...defaultProps({ activeShift: shift, onDelete })}
       />,
     );
 
     await user.click(screen.getByRole('button', { name: /^delete$/i }));
 
-    expect(deleteShift).toHaveBeenCalledWith('shift-1');
+    expect(onDelete).toHaveBeenCalledWith(shift);
     // No AlertDialog should have appeared.
     expect(screen.queryByRole('alertdialog')).toBeNull();
   });
 
   it('clicking Delete on a published shift opens an AlertDialog confirm, and only deletes on confirm', async () => {
     const user = userEvent.setup();
-    const deleteShift = vi.fn();
+    const onDelete = vi.fn();
+    const shift = makeShift({ is_published: true });
     render(
       <TimelineShiftPopover
-        {...defaultProps({ activeShift: makeShift({ is_published: true }), deleteShift })}
+        {...defaultProps({ activeShift: shift, onDelete })}
       />,
     );
 
     await user.click(screen.getByRole('button', { name: /^delete$/i }));
 
     expect(screen.getByRole('alertdialog')).toBeTruthy();
-    expect(deleteShift).not.toHaveBeenCalled();
+    expect(onDelete).not.toHaveBeenCalled();
 
     await user.click(screen.getByRole('button', { name: /^delete shift$/i }));
 
-    await waitFor(() => expect(deleteShift).toHaveBeenCalledWith('shift-1'));
+    await waitFor(() => expect(onDelete).toHaveBeenCalledWith(shift));
   });
 
   it('published-shift delete confirm dismisses without deleting on Cancel', async () => {
     const user = userEvent.setup();
-    const deleteShift = vi.fn();
+    const onDelete = vi.fn();
     render(
       <TimelineShiftPopover
-        {...defaultProps({ activeShift: makeShift({ is_published: true }), deleteShift })}
+        {...defaultProps({ activeShift: makeShift({ is_published: true }), onDelete })}
       />,
     );
 
@@ -199,7 +201,7 @@ describe('TimelineShiftPopover', () => {
 
     await user.click(screen.getByRole('button', { name: /^cancel$/i }));
 
-    expect(deleteShift).not.toHaveBeenCalled();
+    expect(onDelete).not.toHaveBeenCalled();
     await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull());
   });
 

--- a/tests/unit/coverageStatusStrip.test.tsx
+++ b/tests/unit/coverageStatusStrip.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
 import { CoverageStatusStrip } from '@/components/scheduling/ShiftTimeline/CoverageStatusStrip';
 
 const hours = [
@@ -86,5 +86,63 @@ describe('CoverageStatusStrip', () => {
     );
     // aria-label should expose "3 of 5, short 2" so screen readers convey the fraction
     expect(screen.getByLabelText(/3 of 5.*short 2/i)).toBeInTheDocument();
+  });
+
+  // ─── Stage E2: clickable coverage gaps ────────────────────────────────────
+
+  it('CRITICAL: a short hour renders as a button and fires onGapClick(startMin) on click', () => {
+    const onGapClick = vi.fn();
+    render(<CoverageStatusStrip hours={hours} onGapClick={onGapClick} />);
+
+    const shortCell = screen.getByRole('button', { name: /short 2/i });
+    fireEvent.click(shortCell);
+
+    expect(onGapClick).toHaveBeenCalledExactlyOnceWith(960);
+  });
+
+  it('CRITICAL: covered cells are not buttons even when onGapClick is provided', () => {
+    const onGapClick = vi.fn();
+    render(<CoverageStatusStrip hours={hours} onGapClick={onGapClick} />);
+
+    // The covered hour (17, delta 0) must not be a button.
+    const coveredCell = screen.getByLabelText(/covered/i);
+    expect(coveredCell.tagName).not.toBe('BUTTON');
+
+    fireEvent.click(coveredCell);
+    expect(onGapClick).not.toHaveBeenCalled();
+  });
+
+  it('CRITICAL: no-demand cells are not buttons even when onGapClick is provided', () => {
+    const onGapClick = vi.fn();
+    const noDemandHours = [
+      { hour: 8, startMin: 480, scheduled: 2, needed: null, delta: null, projectedSales: null, laborPct: null },
+    ];
+    render(<CoverageStatusStrip hours={noDemandHours} onGapClick={onGapClick} />);
+
+    const cell = screen.getByLabelText(/8 am/i);
+    expect(cell.tagName).not.toBe('BUTTON');
+  });
+
+  it('CRITICAL: without onGapClick, nothing is interactive (back-compat) — short cells stay non-buttons', () => {
+    render(<CoverageStatusStrip hours={hours} />);
+
+    const shortCell = screen.getByLabelText(/short 2/i);
+    expect(shortCell.tagName).not.toBe('BUTTON');
+  });
+
+  it('preserves aria-label and sr-only understaffed list when onGapClick is provided', () => {
+    const onGapClick = vi.fn();
+    render(<CoverageStatusStrip hours={hours} onGapClick={onGapClick} />);
+
+    expect(screen.getByLabelText(/short 2/i)).toBeInTheDocument();
+    expect(screen.getByRole('list', { name: /understaffed/i })).toBeInTheDocument();
+  });
+
+  it('short button cells are keyboard-activatable (real <button>, not a div with onClick)', () => {
+    const onGapClick = vi.fn();
+    render(<CoverageStatusStrip hours={hours} onGapClick={onGapClick} />);
+
+    const shortCell = screen.getByRole('button', { name: /short 2/i });
+    expect(shortCell.tagName).toBe('BUTTON');
   });
 });

--- a/tests/unit/coverageSummary.test.ts
+++ b/tests/unit/coverageSummary.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { summarizeCoverageHours, buildVerdict, summarizeAreaCoverage } from '@/lib/coverageSummary';
+import {
+  summarizeCoverageHours,
+  buildVerdict,
+  summarizeAreaCoverage,
+  mergeUnderStaffedRange,
+  type CoverageHour,
+} from '@/lib/coverageSummary';
 import type { Shift, Employee, HourlyStaffingRecommendation } from '@/types/scheduling';
 
 // window 10:00–13:00 (600–780), 15-min samples
@@ -174,5 +180,127 @@ describe('summarizeCoverageHours — sales context', () => {
     const hrs = summarizeCoverageHours(coverage, demand, win);
     expect(hrs[0].projectedSales).toBeNull();
     expect(hrs[0].laborPct).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mergeUnderStaffedRange (Stage E1 — clickable coverage gaps)
+// ---------------------------------------------------------------------------
+
+/** Build a minimal CoverageHour fixture; delta/needed derived unless overridden. */
+function hourFixture(
+  startMin: number,
+  opts: { needed?: number | null; scheduled?: number } = {},
+): CoverageHour {
+  const needed = opts.needed === undefined ? 5 : opts.needed;
+  const scheduled = opts.scheduled ?? 0;
+  return {
+    hour: Math.floor(startMin / 60) % 24,
+    startMin,
+    scheduled,
+    needed,
+    delta: needed === null ? null : scheduled - needed,
+    projectedSales: null,
+    laborPct: null,
+  };
+}
+
+/** Short (under-staffed) hour: scheduled < needed. */
+function shortHour(startMin: number, deficit = 2, needed = 5): CoverageHour {
+  return hourFixture(startMin, { needed, scheduled: needed - deficit });
+}
+
+/** Covered hour: scheduled >= needed. */
+function coveredHour(startMin: number, needed = 5): CoverageHour {
+  return hourFixture(startMin, { needed, scheduled: needed });
+}
+
+/** No-demand hour: needed is null. */
+function noDemandHour(startMin: number, scheduled = 2): CoverageHour {
+  return hourFixture(startMin, { needed: null, scheduled });
+}
+
+describe('mergeUnderStaffedRange', () => {
+  it('CRITICAL: a lone short hour with covered neighbors merges to just itself', () => {
+    const hours = [coveredHour(540), shortHour(600), coveredHour(660)];
+    const result = mergeUnderStaffedRange(hours, 600);
+    expect(result).toEqual({ startMin: 600, endMin: 660 });
+  });
+
+  it('CRITICAL: a contiguous run of short hours merges fully when clicking the first hour', () => {
+    const hours = [shortHour(600), shortHour(660), shortHour(720), coveredHour(780)];
+    const result = mergeUnderStaffedRange(hours, 600);
+    expect(result).toEqual({ startMin: 600, endMin: 780 });
+  });
+
+  it('CRITICAL: a contiguous run of short hours merges fully when clicking the last hour', () => {
+    const hours = [coveredHour(540), shortHour(600), shortHour(660), shortHour(720)];
+    const result = mergeUnderStaffedRange(hours, 720);
+    expect(result).toEqual({ startMin: 600, endMin: 780 });
+  });
+
+  it('CRITICAL: clicking the middle hour of a run expands in both directions', () => {
+    const hours = [coveredHour(540), shortHour(600), shortHour(660), shortHour(720), coveredHour(780)];
+    const result = mergeUnderStaffedRange(hours, 660);
+    expect(result).toEqual({ startMin: 600, endMin: 780 });
+  });
+
+  it('CRITICAL: non-adjacent short hours — only the contiguous run containing the click merges', () => {
+    // Two separate short runs: [600] and [720,780] separated by a covered hour at 660.
+    const hours = [
+      shortHour(600),
+      coveredHour(660),
+      shortHour(720),
+      shortHour(780),
+    ];
+    const clickedFirstRun = mergeUnderStaffedRange(hours, 600);
+    expect(clickedFirstRun).toEqual({ startMin: 600, endMin: 660 });
+
+    const clickedSecondRun = mergeUnderStaffedRange(hours, 720);
+    expect(clickedSecondRun).toEqual({ startMin: 720, endMin: 840 });
+  });
+
+  it('stops at a no-demand hour — never merges across it', () => {
+    const hours = [shortHour(600), noDemandHour(660), shortHour(720)];
+    const result = mergeUnderStaffedRange(hours, 600);
+    expect(result).toEqual({ startMin: 600, endMin: 660 });
+  });
+
+  it('clicked hour at the left edge of the strip merges forward only', () => {
+    const hours = [shortHour(0), shortHour(60), coveredHour(120)];
+    const result = mergeUnderStaffedRange(hours, 0);
+    expect(result).toEqual({ startMin: 0, endMin: 120 });
+  });
+
+  it('clicked hour at the right edge of the strip merges backward only', () => {
+    const hours = [coveredHour(1260), shortHour(1320), shortHour(1380)];
+    const result = mergeUnderStaffedRange(hours, 1380);
+    expect(result).toEqual({ startMin: 1320, endMin: 1440 });
+  });
+
+  it('all-covered strip: clicking a short single hour (edge case with no other short hours) returns just that hour', () => {
+    const hours = [coveredHour(540), shortHour(600), coveredHour(660), coveredHour(720)];
+    const result = mergeUnderStaffedRange(hours, 600);
+    expect(result).toEqual({ startMin: 600, endMin: 660 });
+  });
+
+  it('never merges across a non-adjacent gap even if both sides are short (missing hour in between)', () => {
+    // hours array itself has a startMin gap (720 -> 840, skipping 780) simulating
+    // a window boundary; both 720 and 840 are short but not adjacent by 60min step.
+    const hours = [shortHour(720), shortHour(840)];
+    const result = mergeUnderStaffedRange(hours, 720);
+    expect(result).toEqual({ startMin: 720, endMin: 780 });
+  });
+
+  it('defensive fallback: clickedStartMin not present in hours returns a single 60-min window', () => {
+    const hours = [shortHour(600), shortHour(660)];
+    const result = mergeUnderStaffedRange(hours, 9999);
+    expect(result).toEqual({ startMin: 9999, endMin: 10059 });
+  });
+
+  it('defensive fallback: clicked hour exists but is not short (covered) returns just that hour', () => {
+    const hours = [shortHour(600), coveredHour(660)];
+    const result = mergeUnderStaffedRange(hours, 660);
+    expect(result).toEqual({ startMin: 660, endMin: 720 });
   });
 });

--- a/tests/unit/employeeRanking.test.ts
+++ b/tests/unit/employeeRanking.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { rankEmployeesForShift } from '@/lib/employeeRanking';
+import type { Employee } from '@/types/scheduling';
+
+function makeEmployee(overrides: Partial<Employee> & { id: string; name: string }): Employee {
+  return {
+    restaurant_id: 'r1',
+    position: 'Server',
+    status: 'active',
+    is_active: true,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  } as Employee;
+}
+
+describe('rankEmployeesForShift', () => {
+  it('sorts position-matching employees before non-matching ones', () => {
+    const employees = [
+      makeEmployee({ id: 'e1', name: 'Zack', position: 'Cook' }),
+      makeEmployee({ id: 'e2', name: 'Amy', position: 'Server' }),
+      makeEmployee({ id: 'e3', name: 'Bob', position: 'Cook' }),
+    ];
+
+    const ranked = rankEmployeesForShift(employees, { position: 'Cook' });
+
+    expect(ranked.map((e) => e.id)).toEqual(['e1', 'e3', 'e2']);
+  });
+
+  it('preserves relative (alphabetical-by-name) order within the matching group', () => {
+    const employees = [
+      makeEmployee({ id: 'e1', name: 'Zack', position: 'Cook' }),
+      makeEmployee({ id: 'e2', name: 'Amy', position: 'Cook' }),
+    ];
+
+    const ranked = rankEmployeesForShift(employees, { position: 'Cook' });
+
+    // Stable sort: original relative order preserved within the group.
+    expect(ranked.map((e) => e.id)).toEqual(['e1', 'e2']);
+  });
+
+  it('sorts area-matching employees before non-matching ones when area is provided', () => {
+    const employees = [
+      makeEmployee({ id: 'e1', name: 'Zack', position: 'Server', area: 'Patio' }),
+      makeEmployee({ id: 'e2', name: 'Amy', position: 'Server', area: 'Bar' }),
+      makeEmployee({ id: 'e3', name: 'Bob', position: 'Server', area: 'Bar' }),
+    ];
+
+    const ranked = rankEmployeesForShift(employees, { area: 'Bar' });
+
+    expect(ranked.map((e) => e.id)).toEqual(['e2', 'e3', 'e1']);
+  });
+
+  it('prioritizes area match over position match when both are supplied', () => {
+    const employees = [
+      // Matches position only
+      makeEmployee({ id: 'e1', name: 'Ann', position: 'Cook', area: 'Patio' }),
+      // Matches area only
+      makeEmployee({ id: 'e2', name: 'Ben', position: 'Server', area: 'Kitchen' }),
+      // Matches neither
+      makeEmployee({ id: 'e3', name: 'Cid', position: 'Server', area: 'Patio' }),
+      // Matches both
+      makeEmployee({ id: 'e4', name: 'Dee', position: 'Cook', area: 'Kitchen' }),
+    ];
+
+    const ranked = rankEmployeesForShift(employees, { position: 'Cook', area: 'Kitchen' });
+
+    expect(ranked.map((e) => e.id)).toEqual(['e4', 'e2', 'e1', 'e3']);
+  });
+
+  it('is a no-op ordering when neither position nor area is provided', () => {
+    const employees = [
+      makeEmployee({ id: 'e1', name: 'Zack', position: 'Cook' }),
+      makeEmployee({ id: 'e2', name: 'Amy', position: 'Server' }),
+    ];
+
+    const ranked = rankEmployeesForShift(employees, {});
+
+    expect(ranked.map((e) => e.id)).toEqual(['e1', 'e2']);
+  });
+
+  it('does case-insensitive position/area matching', () => {
+    const employees = [
+      makeEmployee({ id: 'e1', name: 'Zack', position: 'cook' }),
+      makeEmployee({ id: 'e2', name: 'Amy', position: 'Server' }),
+    ];
+
+    const ranked = rankEmployeesForShift(employees, { position: 'COOK' });
+
+    expect(ranked.map((e) => e.id)).toEqual(['e1', 'e2']);
+  });
+
+  it('treats an employee with no area as non-matching when area context is given', () => {
+    const employees = [
+      makeEmployee({ id: 'e1', name: 'Ann', position: 'Server' }), // no area
+      makeEmployee({ id: 'e2', name: 'Ben', position: 'Server', area: 'Bar' }),
+    ];
+
+    const ranked = rankEmployeesForShift(employees, { area: 'Bar' });
+
+    expect(ranked.map((e) => e.id)).toEqual(['e2', 'e1']);
+  });
+
+  it('does not mutate the input array', () => {
+    const employees = [
+      makeEmployee({ id: 'e1', name: 'Zack', position: 'Cook' }),
+      makeEmployee({ id: 'e2', name: 'Amy', position: 'Server' }),
+    ];
+    const original = [...employees];
+
+    rankEmployeesForShift(employees, { position: 'Cook' });
+
+    expect(employees).toEqual(original);
+  });
+
+  it('returns an empty array for an empty employee list', () => {
+    expect(rankEmployeesForShift([], { position: 'Cook' })).toEqual([]);
+  });
+});

--- a/tests/unit/resolveLaneContext.test.ts
+++ b/tests/unit/resolveLaneContext.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Unit tests for `resolveLaneContext` — the pure helper extracted from
+ * `ShiftTimelineTab`'s `createDraft` memo to replace a nested ternary (OCR
+ * rule: no nested ternaries). Maps a lane's grouping key to `position` or
+ * `area` depending on the active `groupBy` mode, or both-null when there's
+ * no lane context (gap-click entry point).
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveLaneContext } from '@/components/scheduling/ShiftTimeline/ShiftTimelineTab';
+
+describe('resolveLaneContext', () => {
+  it('maps the lane key to `position` when grouped by position', () => {
+    expect(resolveLaneContext('Server', 'position')).toEqual({ position: 'Server', area: null });
+  });
+
+  it('maps the lane key to `area` when grouped by area', () => {
+    expect(resolveLaneContext('Bar', 'area')).toEqual({ position: null, area: 'Bar' });
+  });
+
+  it('returns both null when laneKey is null (gap-click, no lane context)', () => {
+    expect(resolveLaneContext(null, 'area')).toEqual({ position: null, area: null });
+    expect(resolveLaneContext(null, 'position')).toEqual({ position: null, area: null });
+  });
+
+  it('treats an empty-string lane key (unassigned lane) as a real key, not null', () => {
+    expect(resolveLaneContext('', 'position')).toEqual({ position: '', area: null });
+  });
+});

--- a/tests/unit/shiftMutationPipeline.test.ts
+++ b/tests/unit/shiftMutationPipeline.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi } from 'vitest';
+import { collectShiftIssues, assertNotLockedClient, LockedShiftError } from '@/lib/shiftMutationPipeline';
+import { ShiftInterval } from '@/lib/shiftInterval';
+import type { Shift, ConflictCheck } from '@/types/scheduling';
+
+function makeShift(overrides: Partial<Shift> = {}): Shift {
+  return {
+    id: 'shift-1',
+    restaurant_id: 'rest-1',
+    employee_id: 'emp-1',
+    start_time: '2026-01-15T15:00:00.000Z',
+    end_time: '2026-01-15T23:00:00.000Z',
+    break_duration: 0,
+    position: 'server',
+    status: 'scheduled',
+    is_published: false,
+    locked: false,
+    source: 'manual',
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+const NO_CONFLICTS = { conflicts: [] as ConflictCheck[], hasConflicts: false };
+
+describe('collectShiftIssues', () => {
+  it('returns no warnings/conflicts for a clean, non-overlapping shift', async () => {
+    const interval = ShiftInterval.fromTimestamps(
+      '2026-01-16T15:00:00.000Z',
+      '2026-01-16T23:00:00.000Z',
+      '2026-01-16',
+    );
+    const checkConflicts = vi.fn().mockResolvedValue(NO_CONFLICTS);
+
+    const result = await collectShiftIssues({
+      employeeId: 'emp-1',
+      restaurantId: 'rest-1',
+      interval,
+      shifts: [makeShift()],
+      checkConflicts,
+    });
+
+    expect(result.warnings).toEqual([]);
+    expect(result.conflicts).toEqual([]);
+    expect(checkConflicts).toHaveBeenCalledWith({
+      employeeId: 'emp-1',
+      restaurantId: 'rest-1',
+      startTime: '2026-01-16T15:00:00.000Z',
+      endTime: '2026-01-16T23:00:00.000Z',
+    });
+  });
+
+  it('aggregates validateShift warnings (e.g. OVERLAP) for the same employee', async () => {
+    // Overlaps with the existing 15:00-23:00 shift on 2026-01-15
+    const interval = ShiftInterval.fromTimestamps(
+      '2026-01-15T18:00:00.000Z',
+      '2026-01-16T02:00:00.000Z',
+      '2026-01-15',
+    );
+    const checkConflicts = vi.fn().mockResolvedValue(NO_CONFLICTS);
+
+    const result = await collectShiftIssues({
+      employeeId: 'emp-1',
+      restaurantId: 'rest-1',
+      interval,
+      shifts: [makeShift()],
+      checkConflicts,
+    });
+
+    expect(result.warnings.some((w) => w.code === 'OVERLAP')).toBe(true);
+  });
+
+  it('passes excludeShiftId through to validateShift so the shift being edited excludes itself', async () => {
+    // Same interval as the existing shift being edited — would self-overlap if not excluded.
+    const interval = ShiftInterval.fromTimestamps(
+      '2026-01-15T15:00:00.000Z',
+      '2026-01-15T23:00:00.000Z',
+      '2026-01-15',
+    );
+    const checkConflicts = vi.fn().mockResolvedValue(NO_CONFLICTS);
+
+    const result = await collectShiftIssues({
+      employeeId: 'emp-1',
+      restaurantId: 'rest-1',
+      interval,
+      shifts: [makeShift({ id: 'shift-1' })],
+      excludeShiftId: 'shift-1',
+      checkConflicts,
+    });
+
+    expect(result.warnings.some((w) => w.code === 'OVERLAP')).toBe(false);
+  });
+
+  it('merges RPC conflicts (time-off / availability) into the result', async () => {
+    const interval = ShiftInterval.fromTimestamps(
+      '2026-01-16T15:00:00.000Z',
+      '2026-01-16T23:00:00.000Z',
+      '2026-01-16',
+    );
+    const rpcConflicts: ConflictCheck[] = [
+      { has_conflict: true, conflict_type: 'time-off', message: 'Employee has approved time-off' },
+    ];
+    const checkConflicts = vi.fn().mockResolvedValue({ conflicts: rpcConflicts, hasConflicts: true });
+
+    const result = await collectShiftIssues({
+      employeeId: 'emp-1',
+      restaurantId: 'rest-1',
+      interval,
+      shifts: [],
+      checkConflicts,
+    });
+
+    expect(result.conflicts).toEqual(rpcConflicts);
+  });
+
+  it('does not swallow a checker rejection — it propagates to the caller', async () => {
+    const interval = ShiftInterval.fromTimestamps(
+      '2026-01-16T15:00:00.000Z',
+      '2026-01-16T23:00:00.000Z',
+      '2026-01-16',
+    );
+    const checkConflicts = vi.fn().mockRejectedValue(new Error('RPC_FAILED'));
+
+    await expect(
+      collectShiftIssues({
+        employeeId: 'emp-1',
+        restaurantId: 'rest-1',
+        interval,
+        shifts: [],
+        checkConflicts,
+      }),
+    ).rejects.toThrow('RPC_FAILED');
+  });
+
+  it('skips the conflict RPC entirely when checkConflicts=false is passed', async () => {
+    const interval = ShiftInterval.fromTimestamps(
+      '2026-01-16T15:00:00.000Z',
+      '2026-01-16T23:00:00.000Z',
+      '2026-01-16',
+    );
+
+    const result = await collectShiftIssues({
+      employeeId: 'emp-1',
+      restaurantId: 'rest-1',
+      interval,
+      shifts: [],
+      checkConflicts: false,
+    });
+
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it('defaults to checkConflictsImperative when no checker is injected', async () => {
+    // Cannot easily assert the real RPC ran without a live Supabase client,
+    // but we can pin that omitting `checkConflicts` does not throw synchronously
+    // and instead attempts the real network call (which will reject in this
+    // test environment without a mocked client) — proving the DI default wired up.
+    const interval = ShiftInterval.fromTimestamps(
+      '2026-01-16T15:00:00.000Z',
+      '2026-01-16T23:00:00.000Z',
+      '2026-01-16',
+    );
+
+    await expect(
+      collectShiftIssues({
+        employeeId: 'emp-1',
+        restaurantId: 'rest-1',
+        interval,
+        shifts: [],
+      }),
+    ).rejects.toBeTruthy();
+  });
+});
+
+describe('assertNotLockedClient', () => {
+  it('does not throw for an unlocked shift', () => {
+    expect(() => assertNotLockedClient(makeShift({ locked: false }))).not.toThrow();
+  });
+
+  it('throws a LockedShiftError for a locked shift', () => {
+    expect(() => assertNotLockedClient(makeShift({ locked: true }))).toThrow(LockedShiftError);
+  });
+
+  it('LockedShiftError carries a human-readable message', () => {
+    try {
+      assertNotLockedClient(makeShift({ locked: true, id: 'shift-99' }));
+      expect.fail('expected assertNotLockedClient to throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(LockedShiftError);
+      expect((err as LockedShiftError).shiftId).toBe('shift-99');
+      expect((err as Error).message).toMatch(/locked/i);
+    }
+  });
+});

--- a/tests/unit/shiftTimeMath.test.ts
+++ b/tests/unit/shiftTimeMath.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect } from 'vitest';
+import { minutesToIso, snapToStep } from '@/lib/shiftTimeMath';
+
+// ---------------------------------------------------------------------------
+// minutesToIso — restaurant-local minutes -> UTC ISO
+// ---------------------------------------------------------------------------
+// DST reference (America/Chicago, 2026):
+//   Spring-forward: 2026-03-08, 02:00 CST -> 03:00 CDT (2am-3am does not exist)
+//   Fall-back:      2026-11-01, 02:00 CDT -> 01:00 CST (1am-2am occurs twice)
+//
+// Fixtures use TZ-portable inputs (plain date strings / minute counts) per the
+// 2026-05-10 lesson — no reliance on the process TZ.
+
+describe('minutesToIso', () => {
+  describe('standard (non-DST) days', () => {
+    it('converts a simple morning time to UTC ISO (CST, UTC-6)', () => {
+      // 2026-01-15 09:00 CST -> 15:00 UTC
+      const iso = minutesToIso('2026-01-15', 9 * 60, 'America/Chicago');
+      expect(iso).toBe(new Date('2026-01-15T15:00:00.000Z').toISOString());
+    });
+
+    it('converts a simple time to UTC ISO (CDT, UTC-5)', () => {
+      // 2026-06-15 09:00 CDT -> 14:00 UTC
+      const iso = minutesToIso('2026-06-15', 9 * 60, 'America/Chicago');
+      expect(iso).toBe(new Date('2026-06-15T14:00:00.000Z').toISOString());
+    });
+
+    it('handles midnight (0 minutes)', () => {
+      const iso = minutesToIso('2026-01-15', 0, 'America/Chicago');
+      expect(iso).toBe(new Date('2026-01-15T06:00:00.000Z').toISOString());
+    });
+  });
+
+  describe('overnight rollover (minutes > 1440)', () => {
+    it('rolls a shift ending at 01:00 the next day forward one calendar day (CST)', () => {
+      // businessDate 2026-01-15, 25:00 (=01:00 on 2026-01-16) CST -> UTC
+      const iso = minutesToIso('2026-01-15', 25 * 60, 'America/Chicago');
+      expect(iso).toBe(new Date('2026-01-16T07:00:00.000Z').toISOString());
+    });
+
+    it('rolls a shift spanning more than 24h (e.g. 1500 min = 25:00) correctly', () => {
+      const iso = minutesToIso('2026-06-15', 1500, 'America/Chicago');
+      // 1500 min = 25:00 = 01:00 next day (CDT, UTC-5) -> 2026-06-16T06:00:00Z
+      expect(iso).toBe(new Date('2026-06-16T06:00:00.000Z').toISOString());
+    });
+
+    it('rolls forward multiple days for minutes >= 2880 (48h+)', () => {
+      // 2900 minutes = 48h20m -> businessDate + 2 days, 00:20
+      const iso = minutesToIso('2026-01-15', 2900, 'America/Chicago');
+      expect(iso).toBe(new Date('2026-01-17T06:20:00.000Z').toISOString());
+    });
+  });
+
+  describe('DST spring-forward (America/Chicago, 2026-03-08)', () => {
+    it('converts a time before the transition (01:30 CST)', () => {
+      const iso = minutesToIso('2026-03-08', 1 * 60 + 30, 'America/Chicago');
+      // 01:30 CST = UTC-6 -> 07:30 UTC
+      expect(iso).toBe(new Date('2026-03-08T07:30:00.000Z').toISOString());
+    });
+
+    it('converts a time after the transition (03:30 CDT) on the same calendar day', () => {
+      const iso = minutesToIso('2026-03-08', 3 * 60 + 30, 'America/Chicago');
+      // 03:30 CDT = UTC-5 -> 08:30 UTC
+      expect(iso).toBe(new Date('2026-03-08T08:30:00.000Z').toISOString());
+    });
+
+    it('an overnight shift starting the night before crosses spring-forward correctly', () => {
+      // businessDate 2026-03-07, 22:00 (CST) + 8h -> overnight end at 06:00 the
+      // *next* day, which is 2026-03-08 (spring-forward day, now CDT).
+      const startIso = minutesToIso('2026-03-07', 22 * 60, 'America/Chicago');
+      const endIso = minutesToIso('2026-03-07', 30 * 60, 'America/Chicago'); // 22:00 + 8h = 30:00
+      expect(startIso).toBe(new Date('2026-03-08T04:00:00.000Z').toISOString()); // 22:00 CST -> +6h
+      expect(endIso).toBe(new Date('2026-03-08T11:00:00.000Z').toISOString()); // 06:00 CDT -> +5h
+      // Wall-clock duration reads as 8h, but elapsed UTC duration is 7h because
+      // the clocks skipped forward an hour during the shift.
+      const elapsedMs = new Date(endIso).getTime() - new Date(startIso).getTime();
+      expect(elapsedMs).toBe(7 * 60 * 60 * 1000);
+    });
+  });
+
+  describe('DST fall-back (America/Chicago, 2026-11-01)', () => {
+    it('converts a time before the transition (00:30 CDT)', () => {
+      const iso = minutesToIso('2026-11-01', 0 * 60 + 30, 'America/Chicago');
+      // 00:30 CDT = UTC-5 -> 05:30 UTC
+      expect(iso).toBe(new Date('2026-11-01T05:30:00.000Z').toISOString());
+    });
+
+    it('converts a time after the transition (03:30 CST) on the same calendar day', () => {
+      const iso = minutesToIso('2026-11-01', 3 * 60 + 30, 'America/Chicago');
+      // 03:30 CST = UTC-6 -> 09:30 UTC
+      expect(iso).toBe(new Date('2026-11-01T09:30:00.000Z').toISOString());
+    });
+
+    it('COMBINED: an overnight shift (minutes > 1440) starting the night before fall-back', () => {
+      // businessDate 2026-10-31, 23:00 (CDT) + 5h -> overnight end at 04:00 the
+      // next day, 2026-11-01 (fall-back day, now CST). The extra repeated hour
+      // must be absorbed by fromZonedTime without double-counting or
+      // under-counting the elapsed time.
+      const startIso = minutesToIso('2026-10-31', 23 * 60, 'America/Chicago');
+      const endIso = minutesToIso('2026-10-31', 28 * 60, 'America/Chicago'); // 23:00 + 5h = 28:00 = 04:00 next day
+      expect(startIso).toBe(new Date('2026-11-01T04:00:00.000Z').toISOString()); // 23:00 CDT -> +5h
+      expect(endIso).toBe(new Date('2026-11-01T10:00:00.000Z').toISOString()); // 04:00 CST -> +6h
+      // Wall-clock duration reads as 5h, but elapsed UTC duration is 6h because
+      // the clocks fell back an hour (extra hour repeated) during the shift.
+      const elapsedMs = new Date(endIso).getTime() - new Date(startIso).getTime();
+      expect(elapsedMs).toBe(6 * 60 * 60 * 1000);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// snapToStep
+// ---------------------------------------------------------------------------
+describe('snapToStep', () => {
+  it('snaps down to the nearest step when below the midpoint', () => {
+    expect(snapToStep(7, 15)).toBe(0);
+  });
+
+  it('snaps up to the nearest step when above the midpoint', () => {
+    expect(snapToStep(8, 15)).toBe(15);
+  });
+
+  it('leaves an exact multiple of step unchanged', () => {
+    expect(snapToStep(30, 15)).toBe(30);
+  });
+
+  it('uses the default step (15) when no step is provided', () => {
+    expect(snapToStep(22)).toBe(15);
+    expect(snapToStep(23)).toBe(30);
+  });
+
+  it('handles 0 minutes', () => {
+    expect(snapToStep(0, 15)).toBe(0);
+  });
+
+  it('handles values beyond 1440 (overnight) the same way', () => {
+    expect(snapToStep(1500 + 7, 15)).toBe(1500);
+    expect(snapToStep(1500 + 8, 15)).toBe(1515);
+  });
+
+  it('rounds half-step exactly at the midpoint up (round-half-up)', () => {
+    // 7.5 is exactly halfway between 0 and 15 for step=15
+    expect(snapToStep(7.5, 15)).toBe(15);
+  });
+
+  it('handles negative minutes by snapping toward the nearest step', () => {
+    expect(snapToStep(-7, 15)).toBe(0);
+    expect(snapToStep(-8, 15)).toBe(-15);
+  });
+});

--- a/tests/unit/shiftTimeMath.test.ts
+++ b/tests/unit/shiftTimeMath.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { minutesToIso, snapToStep } from '@/lib/shiftTimeMath';
+import { minutesToIso, snapToStep, timeToMinutes, minutesToHHMM, resolveOvernightMinutes } from '@/lib/shiftTimeMath';
 
 // ---------------------------------------------------------------------------
 // minutesToIso — restaurant-local minutes -> UTC ISO
@@ -146,5 +146,88 @@ describe('snapToStep', () => {
   it('handles negative minutes by snapping toward the nearest step', () => {
     expect(snapToStep(-7, 15)).toBe(0);
     expect(snapToStep(-8, 15)).toBe(-15);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// timeToMinutes — "HH:MM" -> minutes-since-midnight
+// ---------------------------------------------------------------------------
+describe('timeToMinutes', () => {
+  it('parses a simple morning time', () => {
+    expect(timeToMinutes('09:00')).toBe(9 * 60);
+  });
+
+  it('parses midnight', () => {
+    expect(timeToMinutes('00:00')).toBe(0);
+  });
+
+  it('parses a time with nonzero minutes', () => {
+    expect(timeToMinutes('14:30')).toBe(14 * 60 + 30);
+  });
+
+  it('parses the last minute of the day', () => {
+    expect(timeToMinutes('23:59')).toBe(23 * 60 + 59);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// minutesToHHMM — minutes-since-midnight (possibly >= 1440) -> "HH:MM"
+// ---------------------------------------------------------------------------
+describe('minutesToHHMM', () => {
+  it('formats a simple morning time', () => {
+    expect(minutesToHHMM(9 * 60)).toBe('09:00');
+  });
+
+  it('formats midnight (0 minutes)', () => {
+    expect(minutesToHHMM(0)).toBe('00:00');
+  });
+
+  it('wraps an overnight value (>= 1440) back to the time-of-day', () => {
+    // 25:30 -> 01:30
+    expect(minutesToHHMM(25 * 60 + 30)).toBe('01:30');
+  });
+
+  it('wraps a value at exactly the midnight boundary (1440)', () => {
+    expect(minutesToHHMM(1440)).toBe('00:00');
+  });
+
+  it('handles negative minutes by wrapping to the previous day time-of-day', () => {
+    expect(minutesToHHMM(-30)).toBe('23:30');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveOvernightMinutes — "HH:MM"/"HH:MM" -> { startMin, endMin }, rolling
+// endMin past 1440 whenever end <= start (overnight shift convention).
+// ---------------------------------------------------------------------------
+describe('resolveOvernightMinutes', () => {
+  it('resolves a same-day range unchanged (end after start)', () => {
+    const { startMin, endMin } = resolveOvernightMinutes('09:00', '17:00');
+    expect(startMin).toBe(9 * 60);
+    expect(endMin).toBe(17 * 60);
+  });
+
+  it('rolls the end forward past 1440 when end equals start (24h shift)', () => {
+    const { startMin, endMin } = resolveOvernightMinutes('09:00', '09:00');
+    expect(startMin).toBe(9 * 60);
+    expect(endMin).toBe(9 * 60 + 1440);
+  });
+
+  it('rolls the end forward past 1440 for an overnight shift (end before start)', () => {
+    const { startMin, endMin } = resolveOvernightMinutes('22:00', '06:00');
+    expect(startMin).toBe(22 * 60);
+    expect(endMin).toBe(6 * 60 + 1440);
+  });
+
+  it('handles the midnight boundary case (start at midnight, end just after)', () => {
+    const { startMin, endMin } = resolveOvernightMinutes('00:00', '00:15');
+    expect(startMin).toBe(0);
+    expect(endMin).toBe(15);
+  });
+
+  it('rolls over when both start and end are midnight', () => {
+    const { startMin, endMin } = resolveOvernightMinutes('00:00', '00:00');
+    expect(startMin).toBe(0);
+    expect(endMin).toBe(1440);
   });
 });

--- a/tests/unit/shiftTimelineTab.mobileLayout.test.tsx
+++ b/tests/unit/shiftTimelineTab.mobileLayout.test.tsx
@@ -43,6 +43,7 @@ vi.mock('@/hooks/useValidatedShiftMutations', () => ({
     validateAndReassign: vi.fn(),
     forceReassign: vi.fn(),
     deleteShift: vi.fn(),
+    deleteShiftAsync: vi.fn().mockResolvedValue(undefined),
     validationResult: null,
     clearValidation: vi.fn(),
   }),

--- a/tests/unit/shiftTimelineTab.mobileLayout.test.tsx
+++ b/tests/unit/shiftTimelineTab.mobileLayout.test.tsx
@@ -30,6 +30,22 @@ vi.mock('@/hooks/useWeekStaffingSuggestions', () => ({
   }),
 }));
 
+// useValidatedShiftMutations pulls in React Query mutation hooks that need a
+// QueryClientProvider this layout-focused test harness doesn't set up.
+vi.mock('@/hooks/useValidatedShiftMutations', () => ({
+  useValidatedShiftMutations: () => ({
+    validateAndCreate: vi.fn(),
+    forceCreate: vi.fn(),
+    validateAndUpdateTime: vi.fn(),
+    forceUpdateTime: vi.fn(),
+    validateAndReassign: vi.fn(),
+    forceReassign: vi.fn(),
+    deleteShift: vi.fn(),
+    validationResult: null,
+    clearValidation: vi.fn(),
+  }),
+}));
+
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
 // Use a past week so defaultDay() never selects "today" and breaks the assertions.

--- a/tests/unit/shiftTimelineTab.mobileLayout.test.tsx
+++ b/tests/unit/shiftTimelineTab.mobileLayout.test.tsx
@@ -48,6 +48,16 @@ vi.mock('@/hooks/useValidatedShiftMutations', () => ({
   }),
 }));
 
+// ShiftTimelineTab's undo-delete flow (Fix 1) calls useCreateShift directly,
+// which needs a QueryClientProvider this layout-focused harness doesn't set up.
+vi.mock('@/hooks/useShifts', () => ({
+  useCreateShift: () => ({ mutateAsync: vi.fn() }),
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
 // Use a past week so defaultDay() never selects "today" and breaks the assertions.

--- a/tests/unit/shiftTimelineTab.mobileLayout.test.tsx
+++ b/tests/unit/shiftTimelineTab.mobileLayout.test.tsx
@@ -38,6 +38,8 @@ vi.mock('@/hooks/useValidatedShiftMutations', () => ({
     forceCreate: vi.fn(),
     validateAndUpdateTime: vi.fn(),
     forceUpdateTime: vi.fn(),
+    validateAndUpdateShift: vi.fn(),
+    forceUpdateShift: vi.fn(),
     validateAndReassign: vi.fn(),
     forceReassign: vi.fn(),
     deleteShift: vi.fn(),

--- a/tests/unit/shiftTimelineTab.test.tsx
+++ b/tests/unit/shiftTimelineTab.test.tsx
@@ -43,6 +43,7 @@ vi.mock('@/hooks/useValidatedShiftMutations', () => ({
     validateAndReassign: vi.fn(),
     forceReassign: vi.fn(),
     deleteShift: vi.fn(),
+    deleteShiftAsync: vi.fn().mockResolvedValue(undefined),
     validationResult: null,
     clearValidation: vi.fn(),
   })),

--- a/tests/unit/shiftTimelineTab.test.tsx
+++ b/tests/unit/shiftTimelineTab.test.tsx
@@ -27,6 +27,25 @@ vi.mock('@/hooks/useWeekStaffingSuggestions', () => ({
 // useRestaurantContext used indirectly (via useWeekStaffingSuggestions chain) — safe
 // to leave unmocked because the mock above covers the hook that reads it.
 
+// useValidatedShiftMutations pulls in React Query mutation hooks (useCreateShift,
+// useUpdateShift, useDeleteShift, useCheckConflicts) which need a QueryClientProvider
+// this test harness doesn't set up. This file tests layout/coverage wiring, not the
+// mutation pipeline (that's covered by useValidatedShiftMutations.test.tsx and
+// TimelineShiftPopover.test.tsx), so a lightweight stub is sufficient here.
+vi.mock('@/hooks/useValidatedShiftMutations', () => ({
+  useValidatedShiftMutations: vi.fn(() => ({
+    validateAndCreate: vi.fn(),
+    forceCreate: vi.fn(),
+    validateAndUpdateTime: vi.fn(),
+    forceUpdateTime: vi.fn(),
+    validateAndReassign: vi.fn(),
+    forceReassign: vi.fn(),
+    deleteShift: vi.fn(),
+    validationResult: null,
+    clearValidation: vi.fn(),
+  })),
+}));
+
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
 // Use a past week so defaultDay() never selects "today" and breaks the assertions.

--- a/tests/unit/shiftTimelineTab.test.tsx
+++ b/tests/unit/shiftTimelineTab.test.tsx
@@ -48,6 +48,17 @@ vi.mock('@/hooks/useValidatedShiftMutations', () => ({
   })),
 }));
 
+// ShiftTimelineTab's undo-delete flow (Fix 1) calls useCreateShift directly,
+// which needs a QueryClientProvider this lightweight harness doesn't set up —
+// stubbed out for the same reason as useValidatedShiftMutations above.
+vi.mock('@/hooks/useShifts', () => ({
+  useCreateShift: vi.fn(() => ({ mutateAsync: vi.fn() })),
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: vi.fn(() => ({ toast: vi.fn() })),
+}));
+
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
 // Use a past week so defaultDay() never selects "today" and breaks the assertions.

--- a/tests/unit/shiftTimelineTab.test.tsx
+++ b/tests/unit/shiftTimelineTab.test.tsx
@@ -544,3 +544,123 @@ describe('ShiftTimelineTab — call-site wiring (Task 2d)', () => {
     expect(hasPositioning).toBe(true);
   });
 });
+
+describe('ShiftTimelineTab — Fix 1: lanes/window frozen during drag, coverage stays live', () => {
+  // Two employees whose shifts overlap, so first-fit row-packing (assignRows)
+  // stacks them onto separate rows (row 0 / row 1). Dragging s1 later in time
+  // (past s2's start) would, under the OLD bug, re-sort by start_time and
+  // re-pack every bar's row on every rAF frame — this is the "bars jump
+  // vertically" regression. With Fix 1, `model` (lanes+window) is built from
+  // the committed `dayShifts`, never the drafted shifts, so bar.row must stay
+  // fixed throughout the drag.
+  const employees = [makeEmployee('e1', 'Ann'), makeEmployee('e2', 'Bob')];
+  const shifts = [
+    makeShift('s1', 'e1', '2026-01-05T15:00:00Z', '2026-01-05T18:00:00Z'), // 09:00-12:00 CST
+    makeShift('s2', 'e2', '2026-01-05T16:00:00Z', '2026-01-05T19:00:00Z'), // 10:00-13:00 CST (overlaps s1)
+  ];
+
+  function mockPlotRect(container: HTMLElement) {
+    // jsdom returns an all-zero rect by default; TimelineLane's getPlotRect
+    // reads plotRef.getBoundingClientRect() fresh on every pointer event, so
+    // stubbing it once here is enough for the whole gesture.
+    const rect = { left: 0, width: 780, top: 0, height: 56, right: 780, bottom: 56, x: 0, y: 0, toJSON: () => ({}) } as DOMRect;
+    for (const el of container.querySelectorAll('[data-testid="lane-plot"]')) {
+      vi.spyOn(el, 'getBoundingClientRect').mockReturnValue(rect);
+    }
+  }
+
+  function barTops(container: HTMLElement): number[] {
+    // Each bar's row is encoded as `top: bar.row * ROW_HEIGHT_PX` on its
+    // absolutely-positioned wrapper (see TimelineLane.tsx).
+    return Array.from(container.querySelectorAll('[data-testid="lane-plot"] > div'))
+      .map((el) => (el as HTMLElement).style.top);
+  }
+
+  let rafSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // useTimelineBarDrag rAF-throttles onDraftChange; run it synchronously so
+    // a single pointermove is enough to observe the live-drag draft (matches
+    // the pattern in tests/unit/timelineBarDrag.test.tsx).
+    rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb: FrameRequestCallback) => {
+      cb(0);
+      return 1;
+    });
+    vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    rafSpy.mockRestore();
+    vi.restoreAllMocks();
+  });
+
+  it('bar rows (top offsets) stay identical during a drag that would otherwise change overlap/packing', () => {
+    const { container } = render(
+      <ShiftTimelineTab {...BASE_PROPS} shifts={shifts} employees={employees} />,
+    );
+    mockPlotRect(container);
+
+    const beforeTops = barTops(container);
+    expect(beforeTops).toHaveLength(2);
+
+    const buttons = screen.getAllByRole('button', { name: /Ann|Bob/i });
+    const annBar = buttons.find((b) => /Ann/i.test(b.getAttribute('aria-label') ?? ''))!;
+    expect(annBar).toBeTruthy();
+
+    // Drag Ann's bar far to the right (past threshold) — under the old bug this
+    // would trigger a full model rebuild (re-sort + re-pack) on every frame.
+    fireEvent.pointerDown(annBar, { pointerId: 1, clientX: 100, pointerType: 'mouse' });
+    fireEvent.pointerMove(annBar, { pointerId: 1, clientX: 400, pointerType: 'mouse' });
+
+    const duringTops = barTops(container);
+    expect(duringTops).toEqual(beforeTops); // lanes frozen — no row jump mid-drag
+
+    // End the gesture via pointercancel (not pointerup) so this test only
+    // exercises the in-flight drag/draft path, not the commit/mutation
+    // pipeline (out of scope here — covered by useValidatedShiftMutations
+    // tests, and this file's mutation mocks aren't wired for a real commit).
+    fireEvent.pointerCancel(annBar, { pointerId: 1 });
+  });
+
+  it('coverage chart still reflects the live drag position (D2 behavior preserved) while lanes stay frozen', () => {
+    const { container } = render(
+      <ShiftTimelineTab {...BASE_PROPS} shifts={shifts} employees={employees} />,
+    );
+    mockPlotRect(container);
+
+    const beforeTops = barTops(container);
+
+    const buttons = screen.getAllByRole('button', { name: /Ann|Bob/i });
+    const annBar = buttons.find((b) => /Ann/i.test(b.getAttribute('aria-label') ?? ''))!;
+
+    // Snapshot the "9 AM–10 AM" column's scheduled count before the drag —
+    // only Ann's shift (09:00-12:00) covers it (Bob starts at 10:00), so it
+    // should read "1 scheduled".
+    const colsBefore = Array.from(container.querySelectorAll('[data-hour-col]')) as HTMLElement[];
+    const nineAmBeforeEl = colsBefore.find((c) => (c.getAttribute('aria-label') ?? '').includes('9 AM'));
+    expect(nineAmBeforeEl).toBeTruthy();
+    // Snapshot the STRING now — React reconciliation reuses the same DOM node
+    // across renders, so re-reading `nineAmBeforeEl.getAttribute(...)` after
+    // the drag would silently return the POST-drag value (same live node).
+    const nineAmLabelBefore = nineAmBeforeEl!.getAttribute('aria-label');
+    expect(nineAmLabelBefore).toMatch(/1 scheduled/);
+
+    // Drag Ann's bar away from the 9 AM slot.
+    fireEvent.pointerDown(annBar, { pointerId: 1, clientX: 100, pointerType: 'mouse' });
+    fireEvent.pointerMove(annBar, { pointerId: 1, clientX: 500, pointerType: 'mouse' });
+
+    // Lanes are still frozen mid-drag...
+    expect(barTops(container)).toEqual(beforeTops);
+
+    // ...but the coverage chart's 9 AM column no longer counts Ann (live coverage
+    // recomputed from the draft against the frozen window). Note: the column
+    // must still EXIST (the frozen window means the hour grid itself doesn't
+    // shrink/grow mid-drag) — only its scheduled count changes.
+    const colsDuring = Array.from(container.querySelectorAll('[data-hour-col]')) as HTMLElement[];
+    const nineAmDuring = colsDuring.find((c) => (c.getAttribute('aria-label') ?? '').includes('9 AM'));
+    expect(nineAmDuring).toBeTruthy(); // window (hour grid) frozen — 9 AM column still present
+    expect(nineAmDuring!.getAttribute('aria-label')).not.toEqual(nineAmLabelBefore);
+
+    fireEvent.pointerCancel(annBar, { pointerId: 1 });
+  });
+});

--- a/tests/unit/shiftTimelineTab.test.tsx
+++ b/tests/unit/shiftTimelineTab.test.tsx
@@ -38,6 +38,8 @@ vi.mock('@/hooks/useValidatedShiftMutations', () => ({
     forceCreate: vi.fn(),
     validateAndUpdateTime: vi.fn(),
     forceUpdateTime: vi.fn(),
+    validateAndUpdateShift: vi.fn(),
+    forceUpdateShift: vi.fn(),
     validateAndReassign: vi.fn(),
     forceReassign: vi.fn(),
     deleteShift: vi.fn(),

--- a/tests/unit/shiftTimelineTabOverlay.test.tsx
+++ b/tests/unit/shiftTimelineTabOverlay.test.tsx
@@ -20,8 +20,8 @@
  * TimelineShiftPopover.test.tsx).
  */
 import React from 'react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { ShiftTimelineTab } from '@/components/scheduling/ShiftTimeline/ShiftTimelineTab';
 import type { Shift, Employee, HourlyStaffingRecommendation } from '@/types/scheduling';
 
@@ -44,6 +44,7 @@ vi.mock('@/hooks/useWeekStaffingSuggestions', () => ({
   useWeekStaffingSuggestions: (...args: unknown[]) => mockUseWeekStaffingSuggestions(...args),
 }));
 
+const mockDeleteShift = vi.fn();
 const mockUseValidatedShiftMutations = vi.fn(() => ({
   validateAndCreate: vi.fn(),
   forceCreate: vi.fn(),
@@ -55,7 +56,7 @@ const mockUseValidatedShiftMutations = vi.fn(() => ({
   forceUpdateShift: vi.fn(),
   validateAndReassign: vi.fn(),
   forceReassign: vi.fn(),
-  deleteShift: vi.fn(),
+  deleteShift: mockDeleteShift,
   validationResult: null,
   clearValidation: vi.fn(),
 }));
@@ -64,12 +65,30 @@ vi.mock('@/hooks/useValidatedShiftMutations', () => ({
   useValidatedShiftMutations: (...args: unknown[]) => mockUseValidatedShiftMutations(...args),
 }));
 
+// ShiftTimelineTab's undo-delete flow (Fix 1) creates the restored shift via
+// useCreateShift directly (not the validated pipeline — the shift existed
+// moments ago, no re-validation needed). Mocked here so no QueryClientProvider
+// is required in this lightweight test harness.
+const mockCreateShiftMutateAsync = vi.fn();
+vi.mock('@/hooks/useShifts', () => ({
+  useCreateShift: () => ({ mutateAsync: mockCreateShiftMutateAsync }),
+}));
+
+// useToast — captured so undo-toast assertions don't depend on the real
+// shadcn toast dispatcher/state machine.
+const mockToast = vi.fn();
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
 // Mock the popover so we can inspect the exact props ShiftTimelineTab passes down,
 // without depending on Radix Popover/PopoverAnchor internals.
 interface PopoverStubProps {
   activeShift: Shift | null;
   anchorRect?: DOMRect | null;
   onClose: () => void;
+  onDelete: (shift: Shift) => void;
+  onSaved?: (shift: Shift) => void;
   createDraft?: {
     values: { employeeId: string; startTime: string; endTime: string; breakDuration: string; notes: string };
     laneContext: { position?: string | null; area?: string | null };
@@ -87,6 +106,16 @@ const mockTimelineShiftPopover = vi.fn((props: PopoverStubProps) => (
     <button type="button" onClick={props.onClose}>
       close-popover
     </button>
+    {props.activeShift && (
+      <button type="button" onClick={() => props.onDelete(props.activeShift as Shift)}>
+        stub-delete
+      </button>
+    )}
+    {props.activeShift && props.onSaved && (
+      <button type="button" onClick={() => props.onSaved?.(props.activeShift as Shift)}>
+        stub-save
+      </button>
+    )}
   </div>
 ));
 
@@ -352,6 +381,178 @@ describe('ShiftTimelineTab — activeOverlay wiring (B3)', () => {
       expect(draft.values.startTime).toBe('10:00');
       expect(draft.values.endTime).toBe('11:00');
       expect(draft.businessDate).toBe('2026-01-05');
+    });
+  });
+
+  describe('visible "Add shift" button (Fix 2)', () => {
+    it('opens the create overlay for the selected day with a default range clamped to the window and no lane context', () => {
+      const employees = [makeEmployee('e1', 'Ann')];
+      // A wide shift (07:00-19:00 local) so the derived window comfortably
+      // contains the 09:00-17:00 default range unchanged — this test covers
+      // the "no clamping needed" case. The "clamping actually shrinks the
+      // range" case is covered by the narrower-window test below.
+      const shifts = [makeShift('s1', 'e1', '2026-01-05T13:00:00Z', '2026-01-06T01:00:00Z')];
+
+      render(<ShiftTimelineTab {...BASE_PROPS} shifts={shifts} employees={employees} />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Add shift' }));
+
+      const draftJson = screen.getByTestId('popover-create-draft').textContent;
+      expect(draftJson).toBeTruthy();
+      const draft = JSON.parse(draftJson as string);
+
+      // No lane context: laneContext resolves to {position: null, area: null}.
+      expect(draft.laneContext).toEqual({ position: null, area: null });
+      expect(draft.businessDate).toBe('2026-01-05');
+
+      // Default range is 09:00-17:00, expressed as HH:MM in the built editor values.
+      expect(draft.values.startTime).toBe('09:00');
+      expect(draft.values.endTime).toBe('17:00');
+
+      // Anchored to the button itself (a real DOMRect, not the zero-size fallback).
+      expect(screen.getByTestId('popover-anchor-present').textContent).toBe('yes');
+    });
+
+    it('clamps the default range into a narrower window when the day has a short shift', () => {
+      const employees = [makeEmployee('e1', 'Ann')];
+      // 16:00Z-22:00Z on 2026-01-05 in America/Chicago (UTC-6 in January) is
+      // 10:00-16:00 local, so deriveWindow yields {startMin: 600, endMin: 960}
+      // — narrower than the 09:00-17:00 (540-1020) default range on both ends.
+      const shifts = [makeShift('s1', 'e1', '2026-01-05T16:00:00Z', '2026-01-05T22:00:00Z')];
+
+      render(<ShiftTimelineTab {...BASE_PROPS} shifts={shifts} employees={employees} />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Add shift' }));
+
+      const draftJson = screen.getByTestId('popover-create-draft').textContent;
+      expect(draftJson).toBeTruthy();
+      const draft = JSON.parse(draftJson as string);
+
+      expect(draft.laneContext).toEqual({ position: null, area: null });
+      expect(draft.businessDate).toBe('2026-01-05');
+
+      // Clamped into the 10:00-16:00 window (duration preserved: 6 hours).
+      expect(draft.values.startTime).toBe('10:00');
+      expect(draft.values.endTime).toBe('16:00');
+    });
+  });
+
+  describe('deleteShiftWithUndo (Fix 1)', () => {
+    it('deletes the shift via the pipeline and shows exactly one toast with an Undo action', () => {
+      const employees = [makeEmployee('e1', 'Ann')];
+      const shift = makeShift('s1', 'e1', '2026-01-05T16:00:00Z', '2026-01-05T22:00:00Z');
+
+      render(<ShiftTimelineTab {...BASE_PROPS} shifts={[shift]} employees={employees} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /Ann/i }));
+      fireEvent.click(screen.getByText('stub-delete'));
+
+      expect(mockDeleteShift).toHaveBeenCalledWith('s1');
+      expect(mockToast).toHaveBeenCalledTimes(1);
+      const call = mockToast.mock.calls[0][0];
+      expect(call.title).toMatch(/shift deleted/i);
+      expect(call.action).toBeTruthy();
+    });
+
+    it('Undo re-creates the shift with the exact captured payload, then toasts "Shift restored"', async () => {
+      const employees = [makeEmployee('e1', 'Ann')];
+      const shift: Shift = {
+        ...makeShift('s1', 'e1', '2026-01-05T16:00:00Z', '2026-01-05T22:00:00Z'),
+        break_duration: 30,
+        notes: 'Cover the rush',
+        status: 'scheduled',
+        is_published: false,
+        source: 'manual',
+        shift_template_id: null,
+      };
+      mockCreateShiftMutateAsync.mockResolvedValue({ ...shift, id: 's1-restored' });
+
+      render(<ShiftTimelineTab {...BASE_PROPS} shifts={[shift]} employees={employees} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /Ann/i }));
+      fireEvent.click(screen.getByText('stub-delete'));
+
+      expect(mockToast).toHaveBeenCalledTimes(1);
+      const { action } = mockToast.mock.calls[0][0];
+
+      // Render the toast action (a ToastAction element) and click it.
+      const { getByText } = render(action);
+      fireEvent.click(getByText(/undo/i));
+
+      await waitFor(() => expect(mockCreateShiftMutateAsync).toHaveBeenCalledTimes(1));
+      const input = mockCreateShiftMutateAsync.mock.calls[0][0];
+      expect(input.restaurant_id).toBe('r1');
+      expect(input.employee_id).toBe('e1');
+      expect(input.start_time).toBe('2026-01-05T16:00:00Z');
+      expect(input.end_time).toBe('2026-01-05T22:00:00Z');
+      expect(input.position).toBe('Server');
+      expect(input.break_duration).toBe(30);
+      expect(input.notes).toBe('Cover the rush');
+      expect(input.status).toBe('scheduled');
+      expect(input.is_published).toBe(false);
+      expect(input.source).toBe('manual');
+      expect(input.shift_template_id).toBeNull();
+
+      await waitFor(() => expect(mockToast).toHaveBeenCalledTimes(2));
+      const restoredCall = mockToast.mock.calls[1][0];
+      expect(restoredCall.title).toMatch(/shift restored/i);
+    });
+
+    it('published-shift delete still confirms via the popover, then routes through the same undo-toast path', () => {
+      const employees = [makeEmployee('e1', 'Ann')];
+      const shift = {
+        ...makeShift('s1', 'e1', '2026-01-05T16:00:00Z', '2026-01-05T22:00:00Z'),
+        is_published: true,
+      };
+
+      render(<ShiftTimelineTab {...BASE_PROPS} shifts={[shift]} employees={employees} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /Ann/i }));
+      // The stub popover doesn't re-implement the AlertDialog confirm gate
+      // (that's TimelineShiftPopover.test.tsx's job) — it always calls onDelete
+      // directly. This test only pins that ShiftTimelineTab wires the SAME
+      // onDelete (deleteShiftWithUndo) regardless of published state.
+      fireEvent.click(screen.getByText('stub-delete'));
+
+      expect(mockDeleteShift).toHaveBeenCalledWith('s1');
+      expect(mockToast).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('transient change highlight (Fix 3)', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('highlights the bar after a successful edit-mode save, then clears the highlight after ~2s', () => {
+      vi.useFakeTimers();
+
+      const employees = [makeEmployee('e1', 'Ann')];
+      const shift = makeShift('s1', 'e1', '2026-01-05T16:00:00Z', '2026-01-05T22:00:00Z');
+
+      render(<ShiftTimelineTab {...BASE_PROPS} shifts={[shift]} employees={employees} />);
+
+      const bar = screen.getByRole('button', { name: /Ann/i });
+      expect(bar.className).not.toMatch(/(^| )ring-2( |$)/);
+
+      fireEvent.click(bar);
+      fireEvent.click(screen.getByText('stub-save'));
+
+      // Highlight applied immediately after the save commits.
+      expect(bar.className).toContain('ring-2');
+      expect(bar.className).toContain('ring-ring');
+
+      // Still highlighted just before the 2s window elapses.
+      act(() => {
+        vi.advanceTimersByTime(1999);
+      });
+      expect(bar.className).toContain('ring-ring');
+
+      // Cleared once the full 2s has elapsed.
+      act(() => {
+        vi.advanceTimersByTime(1);
+      });
+      expect(bar.className).not.toMatch(/(^| )ring-2( |$)/);
     });
   });
 });

--- a/tests/unit/shiftTimelineTabOverlay.test.tsx
+++ b/tests/unit/shiftTimelineTabOverlay.test.tsx
@@ -45,6 +45,7 @@ vi.mock('@/hooks/useWeekStaffingSuggestions', () => ({
 }));
 
 const mockDeleteShift = vi.fn();
+const mockDeleteShiftAsync = vi.fn();
 const mockUseValidatedShiftMutations = vi.fn(() => ({
   validateAndCreate: vi.fn(),
   forceCreate: vi.fn(),
@@ -57,6 +58,7 @@ const mockUseValidatedShiftMutations = vi.fn(() => ({
   validateAndReassign: vi.fn(),
   forceReassign: vi.fn(),
   deleteShift: mockDeleteShift,
+  deleteShiftAsync: mockDeleteShiftAsync,
   validationResult: null,
   clearValidation: vi.fn(),
 }));
@@ -186,6 +188,11 @@ describe('ShiftTimelineTab — activeOverlay wiring (B3)', () => {
       employeePositions: [],
       actualSplh: null,
     });
+    mockDeleteShiftAsync.mockResolvedValue(undefined);
+    // Matches the real useToast()'s toast() return shape ({id, dismiss, update})
+    // so deleteShiftWithUndo's `const { dismiss } = toast(...)` destructure
+    // doesn't throw in tests that don't need to assert on dismiss directly.
+    mockToast.mockReturnValue({ id: 'toast-1', dismiss: vi.fn(), update: vi.fn() });
   });
 
   it('mounts useValidatedShiftMutations once with (restaurantId, shifts)', () => {
@@ -388,7 +395,7 @@ describe('ShiftTimelineTab — activeOverlay wiring (B3)', () => {
     it('opens the create overlay for the selected day with a default range clamped to the window and no lane context', () => {
       const employees = [makeEmployee('e1', 'Ann')];
       // A wide shift (07:00-19:00 local) so the derived window comfortably
-      // contains the 09:00-17:00 default range unchanged — this test covers
+      // contains the 10:00-18:00 default range unchanged — this test covers
       // the "no clamping needed" case. The "clamping actually shrinks the
       // range" case is covered by the narrower-window test below.
       const shifts = [makeShift('s1', 'e1', '2026-01-05T13:00:00Z', '2026-01-06T01:00:00Z')];
@@ -405,9 +412,11 @@ describe('ShiftTimelineTab — activeOverlay wiring (B3)', () => {
       expect(draft.laneContext).toEqual({ position: null, area: null });
       expect(draft.businessDate).toBe('2026-01-05');
 
-      // Default range is 09:00-17:00, expressed as HH:MM in the built editor values.
-      expect(draft.values.startTime).toBe('09:00');
-      expect(draft.values.endTime).toBe('17:00');
+      // Default range is 10:00-18:00, expressed as HH:MM in the built editor values
+      // (Fix E — shifted from 09:00-17:00 so it survives unclamped on an empty day,
+      // whose fallback window starts at 10:00).
+      expect(draft.values.startTime).toBe('10:00');
+      expect(draft.values.endTime).toBe('18:00');
 
       // No anchor rect: the create form renders as a centered Dialog, not an
       // anchored popover, so it's never pinned to the triggering button's rect
@@ -420,7 +429,7 @@ describe('ShiftTimelineTab — activeOverlay wiring (B3)', () => {
       const employees = [makeEmployee('e1', 'Ann')];
       // 16:00Z-22:00Z on 2026-01-05 in America/Chicago (UTC-6 in January) is
       // 10:00-16:00 local, so deriveWindow yields {startMin: 600, endMin: 960}
-      // — narrower than the 09:00-17:00 (540-1020) default range on both ends.
+      // — narrower than the 10:00-18:00 (600-1080) default range on the end.
       const shifts = [makeShift('s1', 'e1', '2026-01-05T16:00:00Z', '2026-01-05T22:00:00Z')];
 
       render(<ShiftTimelineTab {...BASE_PROPS} shifts={shifts} employees={employees} />);
@@ -438,23 +447,85 @@ describe('ShiftTimelineTab — activeOverlay wiring (B3)', () => {
       expect(draft.values.startTime).toBe('10:00');
       expect(draft.values.endTime).toBe('16:00');
     });
+
+    it('opens the create overlay with the full default range on a day with zero shifts (Fix E)', () => {
+      const employees = [makeEmployee('e1', 'Ann')];
+      // No shifts anywhere: deriveWindow has nothing to derive from, so it
+      // falls back to a fixed {startMin: 600, endMin: 1380} (10:00-23:00)
+      // window. Fix E moved DEFAULT_ADD_RANGE to start at 10:00 (600) instead
+      // of 09:00 (540) specifically so it lands fully inside that fallback
+      // window and survives unclamped — before the fix, the 09:00 start was
+      // before the window's 10:00 start, so clampRangeToWindow silently
+      // shifted the whole range later while preserving only its duration,
+      // landing on 10:00-18:00 instead of the intended 09:00-17:00.
+      render(<ShiftTimelineTab {...BASE_PROPS} shifts={[]} employees={employees} />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'Add shift' }));
+
+      const draftJson = screen.getByTestId('popover-create-draft').textContent;
+      expect(draftJson).toBeTruthy();
+      const draft = JSON.parse(draftJson as string);
+
+      expect(draft.laneContext).toEqual({ position: null, area: null });
+      expect(draft.businessDate).toBe('2026-01-05');
+
+      // Unclamped default range: 10:00-18:00, fully within the 10:00-23:00
+      // fallback window, preserving the intended 8-hour default duration.
+      expect(draft.values.startTime).toBe('10:00');
+      expect(draft.values.endTime).toBe('18:00');
+    });
   });
 
-  describe('deleteShiftWithUndo (Fix 1)', () => {
-    it('deletes the shift via the pipeline and shows exactly one toast with an Undo action', () => {
+  describe('deleteShiftWithUndo (Fix 1 — await delete before offering undo)', () => {
+    it('awaits deleteShiftAsync and shows exactly one toast with an Undo action only after a confirmed successful delete', async () => {
       const employees = [makeEmployee('e1', 'Ann')];
       const shift = makeShift('s1', 'e1', '2026-01-05T16:00:00Z', '2026-01-05T22:00:00Z');
+      let resolveDelete: () => void = () => {};
+      mockDeleteShiftAsync.mockReturnValue(
+        new Promise<void>((resolve) => {
+          resolveDelete = resolve;
+        }),
+      );
 
       render(<ShiftTimelineTab {...BASE_PROPS} shifts={[shift]} employees={employees} />);
 
       fireEvent.click(screen.getByRole('button', { name: /Ann/i }));
       fireEvent.click(screen.getByText('stub-delete'));
 
-      expect(mockDeleteShift).toHaveBeenCalledWith('s1');
-      expect(mockToast).toHaveBeenCalledTimes(1);
+      expect(mockDeleteShiftAsync).toHaveBeenCalledWith('s1');
+      // No toast yet — the delete hasn't resolved.
+      expect(mockToast).not.toHaveBeenCalled();
+
+      resolveDelete();
+      await waitFor(() => expect(mockToast).toHaveBeenCalledTimes(1));
       const call = mockToast.mock.calls[0][0];
       expect(call.title).toMatch(/shift deleted/i);
       expect(call.action).toBeTruthy();
+    });
+
+    it('CRITICAL: a failed delete shows NO undo toast and never calls createShift', async () => {
+      const employees = [makeEmployee('e1', 'Ann')];
+      const shift = makeShift('s1', 'e1', '2026-01-05T16:00:00Z', '2026-01-05T22:00:00Z');
+      mockDeleteShiftAsync.mockRejectedValue(new Error('delete failed'));
+
+      render(<ShiftTimelineTab {...BASE_PROPS} shifts={[shift]} employees={employees} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /Ann/i }));
+      fireEvent.click(screen.getByText('stub-delete'));
+
+      await waitFor(() => expect(mockDeleteShiftAsync).toHaveBeenCalledWith('s1'));
+
+      // Give the rejected promise's .catch a tick to run.
+      await waitFor(() => {
+        // no-op assertion to flush microtasks
+        expect(mockDeleteShiftAsync).toHaveBeenCalledTimes(1);
+      });
+
+      // The delete mutation's own onError toast is expected to fire elsewhere
+      // (useDeleteShift's mutation) — deleteShiftWithUndo itself must NOT show
+      // its own "Shift deleted" + Undo toast on failure.
+      expect(mockToast).not.toHaveBeenCalled();
+      expect(mockCreateShiftMutateAsync).not.toHaveBeenCalled();
     });
 
     it('Undo re-creates the shift with the exact captured payload, then toasts "Shift restored"', async () => {
@@ -475,7 +546,7 @@ describe('ShiftTimelineTab — activeOverlay wiring (B3)', () => {
       fireEvent.click(screen.getByRole('button', { name: /Ann/i }));
       fireEvent.click(screen.getByText('stub-delete'));
 
-      expect(mockToast).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(mockToast).toHaveBeenCalledTimes(1));
       const { action } = mockToast.mock.calls[0][0];
 
       // Render the toast action (a ToastAction element) and click it.
@@ -501,7 +572,7 @@ describe('ShiftTimelineTab — activeOverlay wiring (B3)', () => {
       expect(restoredCall.title).toMatch(/shift restored/i);
     });
 
-    it('published-shift delete still confirms via the popover, then routes through the same undo-toast path', () => {
+    it('published-shift delete still confirms via the popover, then routes through the same undo-toast path', async () => {
       const employees = [makeEmployee('e1', 'Ann')];
       const shift = {
         ...makeShift('s1', 'e1', '2026-01-05T16:00:00Z', '2026-01-05T22:00:00Z'),
@@ -517,8 +588,90 @@ describe('ShiftTimelineTab — activeOverlay wiring (B3)', () => {
       // onDelete (deleteShiftWithUndo) regardless of published state.
       fireEvent.click(screen.getByText('stub-delete'));
 
-      expect(mockDeleteShift).toHaveBeenCalledWith('s1');
-      expect(mockToast).toHaveBeenCalledTimes(1);
+      expect(mockDeleteShiftAsync).toHaveBeenCalledWith('s1');
+      await waitFor(() => expect(mockToast).toHaveBeenCalledTimes(1));
+    });
+  });
+
+  describe('deleteShiftWithUndo — one-shot Undo guard (Fix B)', () => {
+    it('CRITICAL: invoking the Undo action twice results in createShift.mutateAsync being called exactly once', async () => {
+      const employees = [makeEmployee('e1', 'Ann')];
+      const shift = makeShift('s1', 'e1', '2026-01-05T16:00:00Z', '2026-01-05T22:00:00Z');
+      mockCreateShiftMutateAsync.mockResolvedValue({ ...shift, id: 's1-restored' });
+
+      render(<ShiftTimelineTab {...BASE_PROPS} shifts={[shift]} employees={employees} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /Ann/i }));
+      fireEvent.click(screen.getByText('stub-delete'));
+
+      await waitFor(() => expect(mockToast).toHaveBeenCalledTimes(1));
+      const { action } = mockToast.mock.calls[0][0];
+
+      const { getByText } = render(action);
+      const undoButton = getByText(/undo/i);
+      fireEvent.click(undoButton);
+      fireEvent.click(undoButton);
+
+      await waitFor(() => expect(mockCreateShiftMutateAsync).toHaveBeenCalledTimes(1));
+      // Give any in-flight microtasks a chance to resolve, then assert it's
+      // still exactly one call (no delayed second invocation).
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(mockCreateShiftMutateAsync).toHaveBeenCalledTimes(1);
+    });
+
+    it('dismisses the toast on the first Undo click', async () => {
+      const employees = [makeEmployee('e1', 'Ann')];
+      const shift = makeShift('s1', 'e1', '2026-01-05T16:00:00Z', '2026-01-05T22:00:00Z');
+      mockCreateShiftMutateAsync.mockResolvedValue({ ...shift, id: 's1-restored' });
+      const mockDismiss = vi.fn();
+      mockToast.mockReturnValue({ dismiss: mockDismiss });
+
+      render(<ShiftTimelineTab {...BASE_PROPS} shifts={[shift]} employees={employees} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /Ann/i }));
+      fireEvent.click(screen.getByText('stub-delete'));
+
+      await waitFor(() => expect(mockToast).toHaveBeenCalledTimes(1));
+      const { action } = mockToast.mock.calls[0][0];
+
+      const { getByText } = render(action);
+      fireEvent.click(getByText(/undo/i));
+
+      expect(mockDismiss).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('deleteShiftWithUndo — recurrence linkage on Undo (Fix C)', () => {
+    it('re-creates ONE shift carrying is_recurring/recurrence_parent_id, without regenerating a series', async () => {
+      const employees = [makeEmployee('e1', 'Ann')];
+      const shift: Shift = {
+        ...makeShift('s1', 'e1', '2026-01-05T16:00:00Z', '2026-01-05T22:00:00Z'),
+        is_recurring: true,
+        recurrence_parent_id: 'series-parent-1',
+        recurrence_pattern: { frequency: 'weekly', daysOfWeek: [1], endDate: '2026-06-01' },
+      };
+      mockCreateShiftMutateAsync.mockResolvedValue({ ...shift, id: 's1-restored' });
+
+      render(<ShiftTimelineTab {...BASE_PROPS} shifts={[shift]} employees={employees} />);
+
+      fireEvent.click(screen.getByRole('button', { name: /Ann/i }));
+      fireEvent.click(screen.getByText('stub-delete'));
+
+      await waitFor(() => expect(mockToast).toHaveBeenCalledTimes(1));
+      const { action } = mockToast.mock.calls[0][0];
+      const { getByText } = render(action);
+      fireEvent.click(getByText(/undo/i));
+
+      await waitFor(() => expect(mockCreateShiftMutateAsync).toHaveBeenCalledTimes(1));
+      const input = mockCreateShiftMutateAsync.mock.calls[0][0];
+
+      // Series linkage preserved...
+      expect(input.is_recurring).toBe(true);
+      expect(input.recurrence_parent_id).toBe('series-parent-1');
+      // ...but recurrence_pattern must be OMITTED so useCreateShift's
+      // `shift.recurrence_pattern && shift.is_recurring` branch takes the
+      // single-insert path (createSingleShift), not createRecurringShifts.
+      expect(input.recurrence_pattern).toBeFalsy();
     });
   });
 

--- a/tests/unit/shiftTimelineTabOverlay.test.tsx
+++ b/tests/unit/shiftTimelineTabOverlay.test.tsx
@@ -409,8 +409,11 @@ describe('ShiftTimelineTab — activeOverlay wiring (B3)', () => {
       expect(draft.values.startTime).toBe('09:00');
       expect(draft.values.endTime).toBe('17:00');
 
-      // Anchored to the button itself (a real DOMRect, not the zero-size fallback).
-      expect(screen.getByTestId('popover-anchor-present').textContent).toBe('yes');
+      // No anchor rect: the create form renders as a centered Dialog, not an
+      // anchored popover, so it's never pinned to the triggering button's rect
+      // (anchoring the tall form to a top-row button pushed its submit button
+      // below the viewport fold on short screens).
+      expect(screen.getByTestId('popover-anchor-present').textContent).toBe('no');
     });
 
     it('clamps the default range into a narrower window when the day has a short shift', () => {

--- a/tests/unit/shiftTimelineTabOverlay.test.tsx
+++ b/tests/unit/shiftTimelineTabOverlay.test.tsx
@@ -3,7 +3,9 @@
  * 2026-07-05-timeline-edit-create-design.md, plan task B3).
  *
  * Verifies:
- *  1. `useValidatedShiftMutations(restaurantId, dayShifts)` is mounted once, and its full
+ *  1. `useValidatedShiftMutations(restaurantId, shifts)` is mounted once with the full-week
+ *     `shifts` array (not the day-scoped `dayShifts`) — so overlap/rest-gap validation also
+ *     sees adjacent-day shifts (e.g. an overnight shift from the previous day) — and its full
  *     return (validateAndCreate/forceCreate included, not just the update/delete slice B2
  *     needed) is available at the ShiftTimelineTab level.
  *  2. Clicking a shift bar opens the single `TimelineShiftPopover` instance with a non-null
@@ -49,6 +51,8 @@ const mockUseValidatedShiftMutations = vi.fn(() => ({
   forceCreateAtTime: vi.fn(),
   validateAndUpdateTime: vi.fn(),
   forceUpdateTime: vi.fn(),
+  validateAndUpdateShift: vi.fn(),
+  forceUpdateShift: vi.fn(),
   validateAndReassign: vi.fn(),
   forceReassign: vi.fn(),
   deleteShift: vi.fn(),
@@ -155,7 +159,7 @@ describe('ShiftTimelineTab — activeOverlay wiring (B3)', () => {
     });
   });
 
-  it('mounts useValidatedShiftMutations once with (restaurantId, dayShifts)', () => {
+  it('mounts useValidatedShiftMutations once with (restaurantId, shifts)', () => {
     const employees = [makeEmployee('e1', 'Ann')];
     const shifts = [makeShift('s1', 'e1', '2026-01-05T16:00:00Z', '2026-01-05T22:00:00Z')];
 
@@ -166,6 +170,31 @@ describe('ShiftTimelineTab — activeOverlay wiring (B3)', () => {
     expect(restaurantIdArg).toBe('r1');
     expect(Array.isArray(shiftsArg)).toBe(true);
     expect((shiftsArg as Shift[])[0]?.id).toBe('s1');
+  });
+
+  it('mounts useValidatedShiftMutations with the full-week shifts array, not filtered to the selected day (regression: adjacent-day overnight shifts must still be validated)', () => {
+    const employees = [makeEmployee('e1', 'Ann')];
+    // Selected day defaults to weekDays[0] = '2026-01-05' (today isn't in WEEK_DAYS).
+    // `s-overnight` starts the PREVIOUS day (2026-01-04, in America/Chicago) and is
+    // therefore excluded by the day-scoped `dayShifts` filter, but must still reach
+    // useValidatedShiftMutations so overlap/rest-gap checks against it aren't silently
+    // dropped when editing/creating a shift that starts on 2026-01-05.
+    const overnightShift = makeShift(
+      's-overnight',
+      'e1',
+      '2026-01-05T04:00:00Z', // 2026-01-04 22:00 America/Chicago (CST, UTC-6)
+      '2026-01-05T12:00:00Z', // 2026-01-05 06:00 America/Chicago
+    );
+    const sameDayShift = makeShift('s1', 'e1', '2026-01-05T16:00:00Z', '2026-01-05T22:00:00Z');
+    const shifts = [overnightShift, sameDayShift];
+
+    render(<ShiftTimelineTab {...BASE_PROPS} shifts={shifts} employees={employees} />);
+
+    expect(mockUseValidatedShiftMutations).toHaveBeenCalledOnce();
+    const [, shiftsArg] = mockUseValidatedShiftMutations.mock.calls[0];
+    const ids = (shiftsArg as Shift[]).map((s) => s.id);
+    expect(ids).toContain('s-overnight');
+    expect(ids).toContain('s1');
   });
 
   it('renders exactly one TimelineShiftPopover instance with activeShift null before any bar click', () => {

--- a/tests/unit/shiftTimelineTabOverlay.test.tsx
+++ b/tests/unit/shiftTimelineTabOverlay.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * Unit tests: ShiftTimelineTab's activeOverlay wiring (design doc: docs/superpowers/specs/
+ * 2026-07-05-timeline-edit-create-design.md, plan task B3).
+ *
+ * Verifies:
+ *  1. `useValidatedShiftMutations(restaurantId, dayShifts)` is mounted once, and its full
+ *     return (validateAndCreate/forceCreate included, not just the update/delete slice B2
+ *     needed) is available at the ShiftTimelineTab level.
+ *  2. Clicking a shift bar opens the single `TimelineShiftPopover` instance with a non-null
+ *     `anchorRect` (a real DOMRect from the clicked bar element) — not just `activeShift`.
+ *  3. Closing the popover clears both the active shift AND the anchor rect (no stale rect
+ *     surviving into the next open).
+ *  4. Only one `TimelineShiftPopover` is ever mounted (single-dialog pattern) regardless of
+ *     which bar was clicked.
+ *
+ * `TimelineShiftPopover` is mocked here so we can assert on the exact props ShiftTimelineTab
+ * threads through, independent of Radix Popover internals (already covered by
+ * TimelineShiftPopover.test.tsx).
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ShiftTimelineTab } from '@/components/scheduling/ShiftTimeline/ShiftTimelineTab';
+import type { Shift, Employee, HourlyStaffingRecommendation } from '@/types/scheduling';
+
+// ─── Module mocks ──────────────────────────────────────────────────────────────
+
+const mockUseWeekStaffingSuggestions = vi.fn(() => ({
+  daySuggestions: new Map<string, { recommendations: HourlyStaffingRecommendation[] }>(),
+  isLoading: false,
+  error: null,
+  hasSalesData: false,
+  hasHourlyBreakdown: false,
+  activeSettings: null,
+  updateSettings: vi.fn(),
+  isSaving: false,
+  employeePositions: [],
+  actualSplh: null,
+}));
+
+vi.mock('@/hooks/useWeekStaffingSuggestions', () => ({
+  useWeekStaffingSuggestions: (...args: unknown[]) => mockUseWeekStaffingSuggestions(...args),
+}));
+
+const mockUseValidatedShiftMutations = vi.fn(() => ({
+  validateAndCreate: vi.fn(),
+  forceCreate: vi.fn(),
+  validateAndUpdateTime: vi.fn(),
+  forceUpdateTime: vi.fn(),
+  validateAndReassign: vi.fn(),
+  forceReassign: vi.fn(),
+  deleteShift: vi.fn(),
+  validationResult: null,
+  clearValidation: vi.fn(),
+}));
+
+vi.mock('@/hooks/useValidatedShiftMutations', () => ({
+  useValidatedShiftMutations: (...args: unknown[]) => mockUseValidatedShiftMutations(...args),
+}));
+
+// Mock the popover so we can inspect the exact props ShiftTimelineTab passes down,
+// without depending on Radix Popover/PopoverAnchor internals.
+const mockTimelineShiftPopover = vi.fn(
+  (props: { activeShift: Shift | null; anchorRect?: DOMRect | null; onClose: () => void }) => (
+    <div data-testid="popover-stub">
+      <span data-testid="popover-active-shift-id">{props.activeShift?.id ?? ''}</span>
+      <span data-testid="popover-anchor-present">{props.anchorRect ? 'yes' : 'no'}</span>
+      <button type="button" onClick={props.onClose}>
+        close-popover
+      </button>
+    </div>
+  ),
+);
+
+vi.mock('@/components/scheduling/ShiftTimeline/TimelineShiftPopover', () => ({
+  TimelineShiftPopover: (props: unknown) =>
+    mockTimelineShiftPopover(
+      props as { activeShift: Shift | null; anchorRect?: DOMRect | null; onClose: () => void },
+    ),
+}));
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const WEEK_DAYS = [
+  '2026-01-05',
+  '2026-01-06',
+  '2026-01-07',
+  '2026-01-08',
+  '2026-01-09',
+  '2026-01-10',
+  '2026-01-11',
+];
+
+const makeEmployee = (id: string, name: string): Employee => ({
+  id,
+  restaurant_id: 'r1',
+  name,
+  position: 'Server',
+  area: 'Front',
+  hourly_rate: 0,
+  hourly_rate_cents: 0,
+  role: 'staff',
+  is_active: true,
+} as Employee);
+
+const makeShift = (id: string, eid: string, start: string, end: string): Shift => ({
+  id,
+  restaurant_id: 'r1',
+  employee_id: eid,
+  start_time: start,
+  end_time: end,
+  break_duration: 0,
+  position: 'Server',
+  status: 'scheduled',
+  is_published: false,
+  locked: false,
+  source: 'manual',
+  created_at: '2026-07-01T00:00:00Z',
+  updated_at: '2026-07-01T00:00:00Z',
+} as Shift);
+
+const BASE_PROPS = {
+  restaurantId: 'r1',
+  weekDays: WEEK_DAYS,
+  tz: 'America/Chicago',
+  loading: false,
+  error: null,
+} as const;
+
+describe('ShiftTimelineTab — activeOverlay wiring (B3)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseWeekStaffingSuggestions.mockReturnValue({
+      daySuggestions: new Map(),
+      isLoading: false,
+      error: null,
+      hasSalesData: false,
+      hasHourlyBreakdown: false,
+      activeSettings: null,
+      updateSettings: vi.fn(),
+      isSaving: false,
+      employeePositions: [],
+      actualSplh: null,
+    });
+  });
+
+  it('mounts useValidatedShiftMutations once with (restaurantId, dayShifts)', () => {
+    const employees = [makeEmployee('e1', 'Ann')];
+    const shifts = [makeShift('s1', 'e1', '2026-01-05T16:00:00Z', '2026-01-05T22:00:00Z')];
+
+    render(<ShiftTimelineTab {...BASE_PROPS} shifts={shifts} employees={employees} />);
+
+    expect(mockUseValidatedShiftMutations).toHaveBeenCalledOnce();
+    const [restaurantIdArg, shiftsArg] = mockUseValidatedShiftMutations.mock.calls[0];
+    expect(restaurantIdArg).toBe('r1');
+    expect(Array.isArray(shiftsArg)).toBe(true);
+    expect((shiftsArg as Shift[])[0]?.id).toBe('s1');
+  });
+
+  it('renders exactly one TimelineShiftPopover instance with activeShift null before any bar click', () => {
+    const employees = [makeEmployee('e1', 'Ann')];
+    const shifts = [makeShift('s1', 'e1', '2026-01-05T16:00:00Z', '2026-01-05T22:00:00Z')];
+
+    render(<ShiftTimelineTab {...BASE_PROPS} shifts={shifts} employees={employees} />);
+
+    expect(mockTimelineShiftPopover).toHaveBeenCalledOnce();
+    expect(screen.getByTestId('popover-active-shift-id').textContent).toBe('');
+    expect(screen.getByTestId('popover-anchor-present').textContent).toBe('no');
+  });
+
+  it('clicking a shift bar opens the popover with the matching shift AND a real anchorRect', () => {
+    const employees = [makeEmployee('e1', 'Ann')];
+    const shifts = [makeShift('s1', 'e1', '2026-01-05T16:00:00Z', '2026-01-05T22:00:00Z')];
+
+    render(<ShiftTimelineTab {...BASE_PROPS} shifts={shifts} employees={employees} />);
+
+    const bar = screen.getByRole('button', { name: /Ann/i });
+    fireEvent.click(bar);
+
+    expect(screen.getByTestId('popover-active-shift-id').textContent).toBe('s1');
+    // anchorRect must be populated from the clicked bar's own bounding rect —
+    // not left as the pre-B3 `undefined`/`null` fallback.
+    expect(screen.getByTestId('popover-anchor-present').textContent).toBe('yes');
+
+    // Still exactly one popover instance mounted (single-dialog pattern).
+    expect(mockTimelineShiftPopover).toHaveBeenCalled();
+    expect(screen.getAllByTestId('popover-stub')).toHaveLength(1);
+  });
+
+  it('closing the popover clears both activeShift and anchorRect', () => {
+    const employees = [makeEmployee('e1', 'Ann')];
+    const shifts = [makeShift('s1', 'e1', '2026-01-05T16:00:00Z', '2026-01-05T22:00:00Z')];
+
+    render(<ShiftTimelineTab {...BASE_PROPS} shifts={shifts} employees={employees} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Ann/i }));
+    expect(screen.getByTestId('popover-active-shift-id').textContent).toBe('s1');
+    expect(screen.getByTestId('popover-anchor-present').textContent).toBe('yes');
+
+    fireEvent.click(screen.getByText('close-popover'));
+
+    expect(screen.getByTestId('popover-active-shift-id').textContent).toBe('');
+    expect(screen.getByTestId('popover-anchor-present').textContent).toBe('no');
+  });
+});

--- a/tests/unit/shiftTimelineTabOverlay.test.tsx
+++ b/tests/unit/shiftTimelineTabOverlay.test.tsx
@@ -45,6 +45,8 @@ vi.mock('@/hooks/useWeekStaffingSuggestions', () => ({
 const mockUseValidatedShiftMutations = vi.fn(() => ({
   validateAndCreate: vi.fn(),
   forceCreate: vi.fn(),
+  validateAndCreateAtTime: vi.fn(),
+  forceCreateAtTime: vi.fn(),
   validateAndUpdateTime: vi.fn(),
   forceUpdateTime: vi.fn(),
   validateAndReassign: vi.fn(),
@@ -60,23 +62,32 @@ vi.mock('@/hooks/useValidatedShiftMutations', () => ({
 
 // Mock the popover so we can inspect the exact props ShiftTimelineTab passes down,
 // without depending on Radix Popover/PopoverAnchor internals.
-const mockTimelineShiftPopover = vi.fn(
-  (props: { activeShift: Shift | null; anchorRect?: DOMRect | null; onClose: () => void }) => (
-    <div data-testid="popover-stub">
-      <span data-testid="popover-active-shift-id">{props.activeShift?.id ?? ''}</span>
-      <span data-testid="popover-anchor-present">{props.anchorRect ? 'yes' : 'no'}</span>
-      <button type="button" onClick={props.onClose}>
-        close-popover
-      </button>
-    </div>
-  ),
-);
+interface PopoverStubProps {
+  activeShift: Shift | null;
+  anchorRect?: DOMRect | null;
+  onClose: () => void;
+  createDraft?: {
+    values: { employeeId: string; startTime: string; endTime: string; breakDuration: string; notes: string };
+    laneContext: { position?: string | null; area?: string | null };
+    businessDate: string;
+  } | null;
+}
+
+const mockTimelineShiftPopover = vi.fn((props: PopoverStubProps) => (
+  <div data-testid="popover-stub">
+    <span data-testid="popover-active-shift-id">{props.activeShift?.id ?? ''}</span>
+    <span data-testid="popover-anchor-present">{props.anchorRect ? 'yes' : 'no'}</span>
+    <span data-testid="popover-create-draft">
+      {props.createDraft ? JSON.stringify(props.createDraft) : ''}
+    </span>
+    <button type="button" onClick={props.onClose}>
+      close-popover
+    </button>
+  </div>
+));
 
 vi.mock('@/components/scheduling/ShiftTimeline/TimelineShiftPopover', () => ({
-  TimelineShiftPopover: (props: unknown) =>
-    mockTimelineShiftPopover(
-      props as { activeShift: Shift | null; anchorRect?: DOMRect | null; onClose: () => void },
-    ),
+  TimelineShiftPopover: (props: unknown) => mockTimelineShiftPopover(props as PopoverStubProps),
 }));
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
@@ -201,5 +212,60 @@ describe('ShiftTimelineTab — activeOverlay wiring (B3)', () => {
 
     expect(screen.getByTestId('popover-active-shift-id').textContent).toBe('');
     expect(screen.getByTestId('popover-anchor-present').textContent).toBe('no');
+  });
+
+  describe('paint-to-create -> createDraft mapping (C3)', () => {
+    it('maps the lane key to laneContext.position when grouped by position', () => {
+      const employees = [makeEmployee('e1', 'Ann')];
+      const shifts = [makeShift('s1', 'e1', '2026-01-05T16:00:00Z', '2026-01-05T22:00:00Z')];
+
+      render(<ShiftTimelineTab {...BASE_PROPS} shifts={shifts} employees={employees} />);
+
+      // Default groupBy is 'area'; switch to 'position' via the ToggleGroup.
+      fireEvent.click(screen.getByRole('radio', { name: /^position$/i }));
+
+      const addShiftButton = screen.getAllByText(/add shift to .* lane/i)[0];
+      fireEvent.click(addShiftButton);
+
+      const draftJson = screen.getByTestId('popover-create-draft').textContent;
+      expect(draftJson).not.toBe('');
+      const draft = JSON.parse(draftJson as string);
+      expect(draft.businessDate).toBe('2026-01-05');
+      expect(draft.laneContext.position).toBeTruthy();
+      expect(draft.laneContext.area ?? null).toBeNull();
+      expect(draft.values.startTime).toBeTruthy();
+      expect(draft.values.endTime).toBeTruthy();
+    });
+
+    it('maps the lane key to laneContext.area when grouped by area', () => {
+      const employees = [makeEmployee('e1', 'Ann')];
+      const shifts = [makeShift('s1', 'e1', '2026-01-05T16:00:00Z', '2026-01-05T22:00:00Z')];
+
+      render(<ShiftTimelineTab {...BASE_PROPS} shifts={shifts} employees={employees} />);
+
+      // Default groupBy is 'area' already.
+      const addShiftButton = screen.getAllByText(/add shift to .* lane/i)[0];
+      fireEvent.click(addShiftButton);
+
+      const draftJson = screen.getByTestId('popover-create-draft').textContent;
+      expect(draftJson).not.toBe('');
+      const draft = JSON.parse(draftJson as string);
+      expect(draft.laneContext.area).toBeTruthy();
+      expect(draft.laneContext.position ?? null).toBeNull();
+    });
+
+    it('clears createDraft when the popover closes', () => {
+      const employees = [makeEmployee('e1', 'Ann')];
+      const shifts = [makeShift('s1', 'e1', '2026-01-05T16:00:00Z', '2026-01-05T22:00:00Z')];
+
+      render(<ShiftTimelineTab {...BASE_PROPS} shifts={shifts} employees={employees} />);
+
+      const addShiftButton = screen.getAllByText(/add shift to .* lane/i)[0];
+      fireEvent.click(addShiftButton);
+      expect(screen.getByTestId('popover-create-draft').textContent).not.toBe('');
+
+      fireEvent.click(screen.getByText('close-popover'));
+      expect(screen.getByTestId('popover-create-draft').textContent).toBe('');
+    });
   });
 });

--- a/tests/unit/shiftTimelineTabOverlay.test.tsx
+++ b/tests/unit/shiftTimelineTabOverlay.test.tsx
@@ -268,4 +268,61 @@ describe('ShiftTimelineTab — activeOverlay wiring (B3)', () => {
       expect(screen.getByTestId('popover-create-draft').textContent).toBe('');
     });
   });
+
+  describe('gap-click -> createDraft mapping (E)', () => {
+    it('CRITICAL: clicking a short coverage-strip cell opens the create overlay with a null lane context', () => {
+      const employees = [makeEmployee('e1', 'Ann')];
+      // 1 employee scheduled 10:00-16:00 America/Chicago (16:00Z-22:00Z).
+      const shifts = [makeShift('s1', 'e1', '2026-01-05T16:00:00Z', '2026-01-05T22:00:00Z')];
+
+      // Recommend 2 staff for the 10 AM hour — only 1 is scheduled, so that
+      // hour renders as a short (delta < 0) coverage-strip cell.
+      mockUseWeekStaffingSuggestions.mockReturnValue({
+        daySuggestions: new Map([
+          [
+            '2026-01-05',
+            {
+              recommendations: [
+                {
+                  hour: 10,
+                  projectedSales: 500,
+                  recommendedStaff: 2,
+                  estimatedLaborCost: 0,
+                  laborPct: 20,
+                  overTarget: false,
+                },
+              ],
+            },
+          ],
+        ]),
+        isLoading: false,
+        error: null,
+        hasSalesData: false,
+        hasHourlyBreakdown: false,
+        activeSettings: null,
+        updateSettings: vi.fn(),
+        isSaving: false,
+        employeePositions: [],
+        actualSplh: null,
+      });
+
+      render(<ShiftTimelineTab {...BASE_PROPS} shifts={shifts} employees={employees} />);
+
+      const gapCell = screen.getByRole('button', { name: /short 1/i });
+      fireEvent.click(gapCell);
+
+      const draftJson = screen.getByTestId('popover-create-draft').textContent;
+      expect(draftJson).not.toBe('');
+      const draft = JSON.parse(draftJson as string);
+
+      // No lane context: both position and area resolve to null/blank.
+      expect(draft.laneContext.position ?? null).toBeNull();
+      expect(draft.laneContext.area ?? null).toBeNull();
+      expect(draft.values.position).toBe('');
+      // The merged range covers the clicked (only-short) 10 AM hour: 10:00-11:00.
+      expect(draft.values.startTime).toBe('10:00');
+      expect(draft.values.endTime).toBe('11:00');
+      expect(draft.businessDate).toBe('2026-01-05');
+    });
+  });
 });

--- a/tests/unit/timelineBarDrag.test.tsx
+++ b/tests/unit/timelineBarDrag.test.tsx
@@ -311,6 +311,85 @@ describe('TimelineBar drag — move (body drag)', () => {
   });
 });
 
+describe('TimelineBar drag — suppress synthetic click after a real drag', () => {
+  it('does NOT call onSelect on the trailing click the browser dispatches after a real (past-threshold) drag', () => {
+    // Regression (Codex P2): after a real drag commits, the browser still
+    // dispatches a `click` on the bar (pointerup without pointer movement
+    // between down/up is a click per spec, but browsers also synthesize one
+    // after a drag-release in many real-world sequences/tests that fire
+    // pointerdown/move/up then a trailing click). That synthetic click must
+    // NOT reopen the edit popover via onSelect.
+    const bar = makeBar({ leftMin: 600, endMin: 960 });
+    const { button, onSelect, onDragCommit } = renderBar({ bar });
+
+    fireEvent.pointerDown(button, { pointerId: 1, clientX: 700, pointerType: 'mouse' });
+    fireEvent.pointerMove(button, { pointerId: 1, clientX: 760, pointerType: 'mouse' }); // 60px, past threshold
+    fireEvent.pointerUp(button, { pointerId: 1, clientX: 760, pointerType: 'mouse' });
+    expect(onDragCommit).toHaveBeenCalledTimes(1);
+
+    // The browser dispatches this trailing click after the pointerup sequence.
+    fireEvent.click(button);
+
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('a plain click with no preceding drag still calls onSelect (suppression only applies right after a real drag)', () => {
+    const bar = makeBar({ leftMin: 600, endMin: 960 });
+    const { button, onSelect } = renderBar({ bar });
+
+    fireEvent.click(button);
+
+    expect(onSelect).toHaveBeenCalledOnce();
+    expect(onSelect).toHaveBeenCalledWith(bar.shift);
+  });
+
+  it('a click AFTER a suppressed post-drag click fires onSelect again (the suppression is a one-shot flag, not a permanent lock)', () => {
+    const bar = makeBar({ leftMin: 600, endMin: 960 });
+    const { button, onSelect } = renderBar({ bar });
+
+    fireEvent.pointerDown(button, { pointerId: 1, clientX: 700, pointerType: 'mouse' });
+    fireEvent.pointerMove(button, { pointerId: 1, clientX: 760, pointerType: 'mouse' });
+    fireEvent.pointerUp(button, { pointerId: 1, clientX: 760, pointerType: 'mouse' });
+    fireEvent.click(button); // suppressed trailing click
+    expect(onSelect).not.toHaveBeenCalled();
+
+    fireEvent.click(button); // a genuine, later click
+    expect(onSelect).toHaveBeenCalledOnce();
+  });
+});
+
+describe('TimelineBar drag — unmount cleanup', () => {
+  it('cancels a pending rAF handle on unmount and does not throw or call setState after unmount (regression: CodeRabbit Major)', () => {
+    // rafSpy from beforeEach synchronously flushes the callback, so it never
+    // leaves a genuinely pending rAF handle. Override it here to simulate a
+    // real animation frame that hasn't fired yet by the time we unmount.
+    rafSpy.mockRestore();
+    let pendingCallback: FrameRequestCallback | null = null;
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb: FrameRequestCallback) => {
+      pendingCallback = cb;
+      return 42;
+    });
+    const cancelSpy = vi.spyOn(window, 'cancelAnimationFrame');
+
+    const bar = makeBar({ leftMin: 600, endMin: 960 });
+    const { button, unmount } = renderBar({ bar });
+
+    fireEvent.pointerDown(button, { pointerId: 1, clientX: 700, pointerType: 'mouse' });
+    // Past-threshold move schedules a frame (rafSpy above never flushes it).
+    fireEvent.pointerMove(button, { pointerId: 1, clientX: 760, pointerType: 'mouse' });
+    expect(pendingCallback).not.toBeNull();
+
+    expect(() => unmount()).not.toThrow();
+
+    expect(cancelSpy).toHaveBeenCalledWith(42);
+
+    // The rAF the component scheduled fires AFTER unmount (as it would in a
+    // real browser when cancelAnimationFrame is a no-op mock) — calling it
+    // must not throw or attempt a setState on the unmounted component.
+    expect(() => pendingCallback?.(0)).not.toThrow();
+  });
+});
+
 describe('TimelineBar drag — commit without an intervening rAF flush', () => {
   it('commits the MOVED range (not the original) when pointerup fires before any rAF tick runs', () => {
     // Regression test: gesture.latestRange is only populated inside the rAF

--- a/tests/unit/timelineBarDrag.test.tsx
+++ b/tests/unit/timelineBarDrag.test.tsx
@@ -311,6 +311,85 @@ describe('TimelineBar drag — move (body drag)', () => {
   });
 });
 
+describe('TimelineBar drag — commit without an intervening rAF flush', () => {
+  it('commits the MOVED range (not the original) when pointerup fires before any rAF tick runs', () => {
+    // Regression test: gesture.latestRange is only populated inside the rAF
+    // callback (scheduleFrame). If pointerup arrives before that frame has
+    // run — a fast drag, or a test that never flushes rAF — endGesture must
+    // still compute the final range synchronously from the last known
+    // pointer position rather than silently re-committing the untouched
+    // original range.
+    rafSpy.mockRestore();
+    // No-op rAF: schedules nothing synchronously, simulating a pointerup
+    // that beats the browser's next animation frame.
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation(() => 1);
+
+    const bar = makeBar({ leftMin: 600, endMin: 960 }); // 6h shift
+    const { button, onDragCommit } = renderBar({ bar });
+
+    fireEvent.pointerDown(button, { pointerId: 1, clientX: 700, pointerType: 'mouse' });
+    // 60px move — comfortably past the 5px drag threshold — but rAF never fires.
+    fireEvent.pointerMove(button, { pointerId: 1, clientX: 760, pointerType: 'mouse' });
+    fireEvent.pointerUp(button, { pointerId: 1, clientX: 760, pointerType: 'mouse' });
+
+    expect(onDragCommit).toHaveBeenCalledTimes(1);
+    const [, range] = onDragCommit.mock.calls[0] as [string, { startMin: number; endMin: number }];
+    // The original range was 600-960; a committed no-op would replay that
+    // exactly. The moved range must differ (60min move, snapped to STEP_MIN).
+    expect(range).not.toEqual({ startMin: 600, endMin: 960 });
+    expect(range.endMin - range.startMin).toBe(360); // duration preserved
+    expect(range.startMin).toBeGreaterThan(600);
+  });
+});
+
+describe('TimelineBar drag — overnight readout formatting', () => {
+  it('renders a wrapped 12-hour start time in the readout when startMin extends past 1440 (overnight)', () => {
+    // A shift dragged into the overnight window extension can have startMin
+    // > 1440 (e.g. 1530 = 25:30 raw minutes-since-midnight). The floating
+    // readout must show the wrapped wall-clock time ("1:30a"), not a raw
+    // 25:30-style value — `minutesToCompact` normalizes via `% 1440`
+    // internally, but the call site should apply it explicitly too (matching
+    // the endMin convention) so the readout is correct regardless of that
+    // internal detail.
+    const overnightWindow = { startMin: 1200, endMin: 1800 }; // 20:00-06:00 next day
+    const overnightMinToPct = (min: number) =>
+      ((min - overnightWindow.startMin) / (overnightWindow.endMin - overnightWindow.startMin)) * 100;
+    const overnightPlotRect = {
+      left: overnightWindow.startMin,
+      width: overnightWindow.endMin - overnightWindow.startMin,
+      top: 0,
+      height: 28,
+      right: overnightWindow.endMin,
+      bottom: 28,
+      x: overnightWindow.startMin,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect;
+
+    const bar = makeBar({ leftMin: 1470, endMin: 1590 }); // 24:30-26:30 (00:30-02:30 wrapped)
+    const utils = render(
+      <TimelineBar
+        bar={bar}
+        minToPct={overnightMinToPct}
+        onSelect={vi.fn()}
+        window={overnightWindow}
+        getPlotRect={() => overnightPlotRect}
+        onDraftChange={vi.fn()}
+        onDragCommit={vi.fn()}
+      />,
+    );
+    const button = utils.getByRole('button');
+
+    fireEvent.pointerDown(button, { pointerId: 1, clientX: 1470, pointerType: 'mouse' });
+    // 60min move -> startMin 1530 (25:30 raw), endMin 1650 (27:30 raw).
+    fireEvent.pointerMove(button, { pointerId: 1, clientX: 1530, pointerType: 'mouse' });
+
+    const readout = utils.getByTestId('drag-time-readout');
+    expect(readout.textContent).not.toMatch(/25:30|24:/);
+    expect(readout.textContent).toContain('1:30a');
+  });
+});
+
 describe('TimelineBar drag — resize handles', () => {
   it('dragging the start handle resizes only startMin, leaving endMin untouched', () => {
     const bar = makeBar({ leftMin: 600, endMin: 960 });

--- a/tests/unit/timelineBarDrag.test.tsx
+++ b/tests/unit/timelineBarDrag.test.tsx
@@ -1,0 +1,356 @@
+/**
+ * Unit tests for TimelineBar's pointer drag-move / edge-resize gesture
+ * (Stage D1):
+ *   - A locked shift renders no resize handles and never drags — pointer
+ *     sequences on its body are inert (no onDraftChange/onDragCommit calls).
+ *   - A sub-threshold pointer sequence (movement below the 5px drag
+ *     threshold) never fires onDraftChange/onDragCommit, leaving the bar's
+ *     native onClick as the only path to onSelect — preserving tap-to-edit.
+ *   - Keyboard Enter/Space (a native <button> click, no pointer events at
+ *     all) still calls onSelect — the drag wiring only listens for pointer
+ *     events and never intercepts keydown.
+ *   - A touch pointer (`pointerType: 'touch'`) never starts a drag: no
+ *     onDraftChange call, no resize-handle drag either.
+ *   - A real mouse drag past the threshold calls onDraftChange with a live
+ *     snapped range (rAF-throttled) and onDragCommit on release; a resize
+ *     handle drag resizes only the grabbed edge.
+ *
+ * Pure move/resize/snap/clamp math is exhaustively covered in
+ * tests/unit/timelineDragMath.test.ts — these tests only pin the DOM/pointer
+ * wiring (handles present/absent, touch-action classes, click-vs-drag
+ * choreography, rAF-throttled callback firing).
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { TimelineBar } from '@/components/scheduling/ShiftTimeline/TimelineBar';
+import type { TimelineBar as TimelineBarModel } from '@/components/scheduling/ShiftTimeline/useTimelineModel';
+import type { TimelineWindow } from '@/lib/timelineModel';
+import type { Shift } from '@/types/scheduling';
+
+const WINDOW: TimelineWindow = { startMin: 600, endMin: 1380 }; // 10:00–23:00, 780 min span
+
+function minToPct(min: number): number {
+  return ((min - WINDOW.startMin) / (WINDOW.endMin - WINDOW.startMin)) * 100;
+}
+
+function makeShift(overrides: Partial<Shift> = {}): Shift {
+  return {
+    id: 's1',
+    restaurant_id: 'r1',
+    employee_id: 'e1',
+    start_time: '2026-07-11T15:00:00Z',
+    end_time: '2026-07-11T21:00:00Z',
+    break_duration: 0,
+    position: 'Server',
+    status: 'scheduled',
+    is_published: false,
+    locked: false,
+    source: 'manual',
+    notes: '',
+    created_at: '2026-07-01T00:00:00Z',
+    updated_at: '2026-07-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeBar(overrides: Partial<TimelineBarModel> = {}): TimelineBarModel {
+  return {
+    shift: makeShift(),
+    row: 0,
+    leftMin: 600,
+    endMin: 960,
+    label: 'Ann Smith',
+    ariaLabel: 'Ann Smith, Server, 10a to 4p, 6.0 hours',
+    color: {
+      bg: 'bg-blue-500/15',
+      border: 'border-blue-500/30',
+      text: 'text-blue-700 dark:text-blue-300',
+    },
+    ...overrides,
+  };
+}
+
+/**
+ * A rect positioned so `pointerToMinutes(clientX, rect, WINDOW) === clientX`
+ * exactly (for clientX within [600, 1380]): `left` equals `WINDOW.startMin`
+ * and `width` equals the window's span, so the pct-based inverse mapping in
+ * `pointerToMinutes` collapses to the identity. This lets tests use clientX
+ * values that read directly as restaurant-local minutes-since-midnight.
+ */
+const PLOT_RECT = {
+  left: WINDOW.startMin,
+  width: WINDOW.endMin - WINDOW.startMin,
+  top: 0,
+  height: 28,
+  right: WINDOW.endMin,
+  bottom: 28,
+  x: WINDOW.startMin,
+  y: 0,
+  toJSON: () => ({}),
+} as DOMRect;
+
+interface RenderBarOptions {
+  bar?: TimelineBarModel;
+  onSelect?: (shift: Shift) => void;
+  onDraftChange?: (shiftId: string, range: { startMin: number; endMin: number } | null) => void;
+  onDragCommit?: (shiftId: string, range: { startMin: number; endMin: number }) => void;
+  getPlotRect?: () => DOMRect | null;
+}
+
+function renderBar(overrides: RenderBarOptions = {}) {
+  const onSelect = overrides.onSelect ?? vi.fn();
+  const onDraftChange = overrides.onDraftChange ?? vi.fn();
+  const onDragCommit = overrides.onDragCommit ?? vi.fn();
+  const getPlotRect = overrides.getPlotRect ?? (() => PLOT_RECT);
+  const utils = render(
+    <TimelineBar
+      bar={overrides.bar ?? makeBar()}
+      minToPct={minToPct}
+      onSelect={onSelect}
+      window={WINDOW}
+      getPlotRect={getPlotRect}
+      onDraftChange={onDraftChange}
+      onDragCommit={onDragCommit}
+    />,
+  );
+  const button = screen.getByRole('button');
+  return { ...utils, button, onSelect, onDraftChange, onDragCommit };
+}
+
+let rafSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  // Run rAF callbacks synchronously so drag-frame assertions don't need
+  // to await an actual animation frame.
+  rafSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb: FrameRequestCallback) => {
+    cb(0);
+    return 1;
+  });
+  vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  rafSpy.mockRestore();
+  vi.restoreAllMocks();
+});
+
+describe('TimelineBar drag — locked shifts', () => {
+  it('renders no resize handles for a locked shift', () => {
+    renderBar({ bar: makeBar({ shift: makeShift({ locked: true }) }) });
+    expect(screen.queryByTestId('resize-handle-start')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('resize-handle-end')).not.toBeInTheDocument();
+  });
+
+  it('renders resize handles for an unlocked shift', () => {
+    renderBar({ bar: makeBar({ shift: makeShift({ locked: false }) }) });
+    expect(screen.getByTestId('resize-handle-start')).toBeInTheDocument();
+    expect(screen.getByTestId('resize-handle-end')).toBeInTheDocument();
+  });
+
+  it('does not drag a locked bar — a pointer drag on the body never calls onDraftChange or onDragCommit', () => {
+    const { button, onDraftChange, onDragCommit, onSelect } = renderBar({
+      bar: makeBar({ shift: makeShift({ locked: true }) }),
+    });
+
+    fireEvent.pointerDown(button, { pointerId: 1, clientX: 100, pointerType: 'mouse' });
+    fireEvent.pointerMove(button, { pointerId: 1, clientX: 200, pointerType: 'mouse' });
+    fireEvent.pointerUp(button, { pointerId: 1, clientX: 200, pointerType: 'mouse' });
+
+    expect(onDraftChange).not.toHaveBeenCalled();
+    expect(onDragCommit).not.toHaveBeenCalled();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('applies cursor-grab and touch-none only to unlocked bars', () => {
+    const { button: unlockedBtn } = renderBar({ bar: makeBar({ shift: makeShift({ locked: false }) }) });
+    expect(unlockedBtn.className).toContain('cursor-grab');
+    expect(unlockedBtn.className).toContain('touch-none');
+  });
+
+  it('does not apply cursor-grab or touch-none to a locked bar', () => {
+    const { button: lockedBtn } = renderBar({ bar: makeBar({ shift: makeShift({ locked: true }) }) });
+    expect(lockedBtn.className).not.toContain('cursor-grab');
+    expect(lockedBtn.className).not.toContain('touch-none');
+  });
+});
+
+describe('TimelineBar drag — click-vs-drag disambiguation', () => {
+  it('a plain click (userEvent, no real movement) calls onSelect exactly once and never starts a drag', async () => {
+    const user = userEvent.setup();
+    const bar = makeBar();
+    const { button, onSelect, onDraftChange, onDragCommit } = renderBar({ bar });
+
+    await user.click(button);
+
+    expect(onSelect).toHaveBeenCalledOnce();
+    expect(onSelect).toHaveBeenCalledWith(bar.shift);
+    // The zero-movement pointerdown+up sequence still clears the (never-set)
+    // draft on release — that's the only onDraftChange call, and it's `null`.
+    expect(onDraftChange).toHaveBeenCalledWith('s1', null);
+    expect(onDragCommit).not.toHaveBeenCalled();
+  });
+
+  it('a sub-threshold pointer sequence (< 5px movement) does not commit a drag, leaving onClick to fire onSelect', () => {
+    const bar = makeBar();
+    const { button, onSelect, onDraftChange, onDragCommit } = renderBar({ bar });
+
+    fireEvent.pointerDown(button, { pointerId: 1, clientX: 100, pointerType: 'mouse' });
+    fireEvent.pointerMove(button, { pointerId: 1, clientX: 102, pointerType: 'mouse' }); // 2px < 5px threshold
+    fireEvent.pointerUp(button, { pointerId: 1, clientX: 102, pointerType: 'mouse' });
+    // A real browser follows pointerup with a click event; jsdom's fireEvent
+    // doesn't synthesize this automatically, so we fire it explicitly here to
+    // pin that the hook does NOT call onSelect itself (that would double-fire
+    // alongside this click).
+    fireEvent.click(button);
+
+    expect(onDraftChange).toHaveBeenCalledWith('s1', null); // cleared on pointerup, never set (sub-threshold)
+    expect(onDragCommit).not.toHaveBeenCalled();
+    expect(onSelect).toHaveBeenCalledOnce();
+    expect(onSelect).toHaveBeenCalledWith(bar.shift);
+  });
+
+  it('a past-threshold pointer sequence commits a drag and does NOT suppress the button (onClick is still the caller\'s concern, not fired here without a real click event)', () => {
+    const bar = makeBar();
+    const { button, onDragCommit } = renderBar({ bar });
+
+    fireEvent.pointerDown(button, { pointerId: 1, clientX: 700, pointerType: 'mouse' });
+    fireEvent.pointerMove(button, { pointerId: 1, clientX: 740, pointerType: 'mouse' }); // 40px > 5px threshold
+    fireEvent.pointerUp(button, { pointerId: 1, clientX: 740, pointerType: 'mouse' });
+
+    expect(onDragCommit).toHaveBeenCalledTimes(1);
+    expect(onDragCommit).toHaveBeenCalledWith('s1', expect.any(Object));
+  });
+
+  it('keyboard Enter/Space still calls onSelect via the native button click (no pointer events involved)', async () => {
+    const user = userEvent.setup();
+    const bar = makeBar();
+    const { button, onSelect } = renderBar({ bar });
+
+    button.focus();
+    await user.keyboard('{Enter}');
+
+    expect(onSelect).toHaveBeenCalledOnce();
+    expect(onSelect).toHaveBeenCalledWith(bar.shift);
+  });
+});
+
+describe('TimelineBar drag — touch', () => {
+  it('a touch pointer never starts a drag on the body', () => {
+    const { button, onDraftChange, onDragCommit } = renderBar();
+
+    fireEvent.pointerDown(button, { pointerId: 1, clientX: 100, pointerType: 'touch' });
+    fireEvent.pointerMove(button, { pointerId: 1, clientX: 300, pointerType: 'touch' });
+    fireEvent.pointerUp(button, { pointerId: 1, clientX: 300, pointerType: 'touch' });
+
+    expect(onDraftChange).not.toHaveBeenCalled();
+    expect(onDragCommit).not.toHaveBeenCalled();
+  });
+
+  it('a touch pointer never starts a resize on the edge handles', () => {
+    const { onDraftChange, onDragCommit } = renderBar();
+    const startHandle = screen.getByTestId('resize-handle-start');
+
+    fireEvent.pointerDown(startHandle, { pointerId: 1, clientX: 0, pointerType: 'touch' });
+    fireEvent.pointerMove(startHandle, { pointerId: 1, clientX: 50, pointerType: 'touch' });
+    fireEvent.pointerUp(startHandle, { pointerId: 1, clientX: 50, pointerType: 'touch' });
+
+    expect(onDraftChange).not.toHaveBeenCalled();
+    expect(onDragCommit).not.toHaveBeenCalled();
+  });
+
+  it('scopes touch-action:none to the body and handles, not the lane background (verified indirectly: bar button carries touch-none)', () => {
+    const { button } = renderBar();
+    // The lane's own plot region (tested separately in timelineLanePaint.test.tsx)
+    // uses touch-pan-x/touch-pan-y, never touch-none — this bar button is the
+    // only element scoped to touch-none.
+    expect(button.className).toContain('touch-none');
+  });
+});
+
+describe('TimelineBar drag — move (body drag)', () => {
+  it('calls onDraftChange with a snapped, duration-preserving range while dragging', () => {
+    const bar = makeBar({ leftMin: 600, endMin: 960 }); // 6h shift
+    const { button, onDraftChange } = renderBar({ bar });
+
+    fireEvent.pointerDown(button, { pointerId: 1, clientX: 700, pointerType: 'mouse' });
+    // clientX reads directly as minutes here (see PLOT_RECT), so a 60px move is a 60min move.
+    fireEvent.pointerMove(button, { pointerId: 1, clientX: 760, pointerType: 'mouse' });
+
+    expect(onDraftChange).toHaveBeenCalled();
+    const lastCall = onDraftChange.mock.calls.at(-1);
+    expect(lastCall![0]).toBe('s1');
+    const range = lastCall![1] as { startMin: number; endMin: number };
+    expect(range.endMin - range.startMin).toBe(360); // duration preserved
+    expect(range.startMin % 15).toBe(0); // snapped to STEP_MIN
+  });
+
+  it('clears the draft (calls onDraftChange with null) on release', () => {
+    const bar = makeBar({ leftMin: 600, endMin: 960 });
+    const { button, onDraftChange } = renderBar({ bar });
+
+    fireEvent.pointerDown(button, { pointerId: 1, clientX: 700, pointerType: 'mouse' });
+    fireEvent.pointerMove(button, { pointerId: 1, clientX: 760, pointerType: 'mouse' });
+    fireEvent.pointerUp(button, { pointerId: 1, clientX: 760, pointerType: 'mouse' });
+
+    expect(onDraftChange).toHaveBeenLastCalledWith('s1', null);
+  });
+
+  it('cancelling the gesture (pointercancel) clears the draft without committing', () => {
+    const bar = makeBar({ leftMin: 600, endMin: 960 });
+    const { button, onDraftChange, onDragCommit } = renderBar({ bar });
+
+    fireEvent.pointerDown(button, { pointerId: 1, clientX: 700, pointerType: 'mouse' });
+    fireEvent.pointerMove(button, { pointerId: 1, clientX: 760, pointerType: 'mouse' });
+    fireEvent.pointerCancel(button, { pointerId: 1, clientX: 760, pointerType: 'mouse' });
+
+    expect(onDragCommit).not.toHaveBeenCalled();
+    expect(onDraftChange).toHaveBeenLastCalledWith('s1', null);
+  });
+});
+
+describe('TimelineBar drag — resize handles', () => {
+  it('dragging the start handle resizes only startMin, leaving endMin untouched', () => {
+    const bar = makeBar({ leftMin: 600, endMin: 960 });
+    const { onDraftChange } = renderBar({ bar });
+    const startHandle = screen.getByTestId('resize-handle-start');
+
+    fireEvent.pointerDown(startHandle, { pointerId: 1, clientX: 600, pointerType: 'mouse' });
+    fireEvent.pointerMove(startHandle, { pointerId: 1, clientX: 650, pointerType: 'mouse' }); // 50px move > threshold
+
+    const lastCall = onDraftChange.mock.calls.at(-1);
+    const range = lastCall![1] as { startMin: number; endMin: number };
+    expect(range.endMin).toBe(960);
+    expect(range.startMin).toBeGreaterThan(600);
+  });
+
+  it('dragging the end handle resizes only endMin, leaving startMin untouched', () => {
+    const bar = makeBar({ leftMin: 600, endMin: 960 });
+    const { onDraftChange } = renderBar({ bar });
+    const endHandle = screen.getByTestId('resize-handle-end');
+
+    fireEvent.pointerDown(endHandle, { pointerId: 1, clientX: 960, pointerType: 'mouse' });
+    fireEvent.pointerMove(endHandle, { pointerId: 1, clientX: 1010, pointerType: 'mouse' }); // 50px move > threshold
+
+    const lastCall = onDraftChange.mock.calls.at(-1);
+    const range = lastCall![1] as { startMin: number; endMin: number };
+    expect(range.startMin).toBe(600);
+    expect(range.endMin).toBeGreaterThan(960);
+  });
+
+  it('resize respects the 15-minute minimum duration floor', () => {
+    const bar = makeBar({ leftMin: 600, endMin: 630 }); // 30-min shift
+    const { onDraftChange } = renderBar({ bar });
+    const endHandle = screen.getByTestId('resize-handle-end');
+
+    fireEvent.pointerDown(endHandle, { pointerId: 1, clientX: 630, pointerType: 'mouse' });
+    // Drag the end handle far to the left, well past the start — should clamp at a 15-min floor.
+    fireEvent.pointerMove(endHandle, { pointerId: 1, clientX: 500, pointerType: 'mouse' });
+
+    const lastCall = onDraftChange.mock.calls.at(-1);
+    const range = lastCall![1] as { startMin: number; endMin: number };
+    expect(range.endMin - range.startMin).toBe(15);
+  });
+});

--- a/tests/unit/timelineBarDrag.test.tsx
+++ b/tests/unit/timelineBarDrag.test.tsx
@@ -356,6 +356,33 @@ describe('TimelineBar drag — suppress synthetic click after a real drag', () =
     fireEvent.click(button); // a genuine, later click
     expect(onSelect).toHaveBeenCalledOnce();
   });
+
+  it('a fresh pointerdown after a drag with NO trailing click clears the stale suppression flag, so the next click reaches onSelect', () => {
+    // Regression: when the bar-jumping bug (frozen-lanes Fix 1) made bars
+    // relayout under the pointer mid-drag, the browser's trailing `click`
+    // after pointerup often never fired (the element under the pointer
+    // moved/changed), leaving `justDraggedRef` stuck `true` forever — so the
+    // NEXT legitimate click on the bar (to open the edit popover) was
+    // silently eaten by `consumeJustDragged()`. A new pointerdown on the bar
+    // is a fresh interaction and must reset that stale flag.
+    const bar = makeBar({ leftMin: 600, endMin: 960 });
+    const { button, onSelect } = renderBar({ bar });
+
+    // Real drag past the threshold, sets justDraggedRef = true on release.
+    fireEvent.pointerDown(button, { pointerId: 1, clientX: 700, pointerType: 'mouse' });
+    fireEvent.pointerMove(button, { pointerId: 1, clientX: 760, pointerType: 'mouse' });
+    fireEvent.pointerUp(button, { pointerId: 1, clientX: 760, pointerType: 'mouse' });
+    // No trailing click fires here (simulating the bar-jump swallowing it).
+
+    // A fresh pointerdown/up with sub-threshold movement (a plain click-like
+    // gesture) starts a new interaction — it must clear the stale flag.
+    fireEvent.pointerDown(button, { pointerId: 2, clientX: 500, pointerType: 'mouse' });
+    fireEvent.pointerUp(button, { pointerId: 2, clientX: 500, pointerType: 'mouse' });
+    fireEvent.click(button);
+
+    expect(onSelect).toHaveBeenCalledOnce();
+    expect(onSelect).toHaveBeenCalledWith(bar.shift);
+  });
 });
 
 describe('TimelineBar drag — unmount cleanup', () => {

--- a/tests/unit/timelineBarLabel.test.tsx
+++ b/tests/unit/timelineBarLabel.test.tsx
@@ -4,7 +4,25 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { TimelineBar } from '@/components/scheduling/ShiftTimeline/TimelineBar';
 import type { TimelineBar as TimelineBarModel } from '@/components/scheduling/ShiftTimeline/useTimelineModel';
+import type { TimelineWindow } from '@/lib/timelineModel';
 import type { Shift } from '@/types/scheduling';
+
+const WINDOW: TimelineWindow = { startMin: 600, endMin: 960 };
+
+// TimelineBar's pointer drag-move/edge-resize gesture (Stage D) is covered
+// exhaustively in tests/unit/timelineBarDrag.test.tsx. These tests only need
+// the bar's pre-existing label/color/select rendering, so the drag-related
+// props are supplied as inert defaults (a null plot rect means every drag
+// computation bails out early, leaving click-to-select as the only reachable
+// interaction here).
+function dragExtraProps() {
+  return {
+    window: WINDOW,
+    getPlotRect: () => null,
+    onDraftChange: vi.fn(),
+    onDragCommit: vi.fn(),
+  };
+}
 
 function makeShift(overrides: Partial<Shift> = {}): Shift {
   return {
@@ -52,6 +70,7 @@ describe('TimelineBar', () => {
         bar={makeBar()}
         minToPct={minToPct}
         onSelect={onSelect}
+        {...dragExtraProps()}
       />,
     );
     const btn = screen.getByRole('button', { name: /Carolina Sanchez, Server/i });
@@ -68,6 +87,7 @@ describe('TimelineBar', () => {
         bar={bar}
         minToPct={minToPct}
         onSelect={onSelect}
+        {...dragExtraProps()}
       />,
     );
     await user.click(screen.getByRole('button'));
@@ -81,6 +101,7 @@ describe('TimelineBar', () => {
         bar={makeBar({ label: 'Jane Doe' })}
         minToPct={minToPct}
         onSelect={vi.fn()}
+        {...dragExtraProps()}
       />,
     );
     expect(screen.getByText('Jane Doe')).toBeInTheDocument();
@@ -92,6 +113,7 @@ describe('TimelineBar', () => {
         bar={makeBar()}
         minToPct={minToPct}
         onSelect={vi.fn()}
+        {...dragExtraProps()}
       />,
     );
     const btn = screen.getByRole('button');

--- a/tests/unit/timelineBarLabel.test.tsx
+++ b/tests/unit/timelineBarLabel.test.tsx
@@ -119,4 +119,37 @@ describe('TimelineBar', () => {
     const btn = screen.getByRole('button');
     expect(btn.className).toContain('bg-blue-500/15');
   });
+
+  // Fix 3 (transient change highlight, design doc §Fix 3): a bar renders a
+  // ring outline when the parent marks it as recently changed.
+  it('does not render the highlight ring by default', () => {
+    render(
+      <TimelineBar
+        bar={makeBar()}
+        minToPct={minToPct}
+        onSelect={vi.fn()}
+        {...dragExtraProps()}
+      />,
+    );
+    const btn = screen.getByRole('button');
+    // focus-visible:ring-2 is always present (keyboard focus styling) — the
+    // Fix 3 highlight adds an UNCONDITIONAL "ring-2 ring-ring" pair (no
+    // focus-visible: prefix), so check for that exact unprefixed pairing.
+    expect(btn.className).not.toMatch(/(^| )ring-2( |$)/);
+  });
+
+  it('renders a ring-2 ring-ring outline when highlighted is true', () => {
+    render(
+      <TimelineBar
+        bar={makeBar()}
+        minToPct={minToPct}
+        onSelect={vi.fn()}
+        highlighted
+        {...dragExtraProps()}
+      />,
+    );
+    const btn = screen.getByRole('button');
+    expect(btn.className).toContain('ring-2');
+    expect(btn.className).toContain('ring-ring');
+  });
 });

--- a/tests/unit/timelineComponents.test.tsx
+++ b/tests/unit/timelineComponents.test.tsx
@@ -53,6 +53,21 @@ function makeShift(overrides: Partial<Shift> = {}): Shift {
   };
 }
 
+/** Shared required props for TimelineShiftPopover (B2 added edit-mode plumbing). */
+function popoverProps(overrides: Partial<React.ComponentProps<typeof TimelineShiftPopover>> = {}) {
+  return {
+    employees: [],
+    restaurantId: 'r1',
+    dayShifts: [] as Shift[],
+    validateAndUpdateTime: vi.fn(),
+    forceUpdateTime: vi.fn(),
+    deleteShift: vi.fn(),
+    validationResult: null,
+    clearValidation: vi.fn(),
+    ...overrides,
+  };
+}
+
 function makeBar(overrides: Partial<TimelineBarModel> = {}): TimelineBarModel {
   return {
     shift: makeShift(),
@@ -243,6 +258,7 @@ describe('TimelineShiftPopover', () => {
         tz="America/Chicago"
         dateStr="2026-07-11"
         onClose={vi.fn()}
+        {...popoverProps()}
       />,
     );
     expect(container).toBeEmptyDOMElement();
@@ -255,6 +271,7 @@ describe('TimelineShiftPopover', () => {
         tz="America/Chicago"
         dateStr="2026-07-11"
         onClose={vi.fn()}
+        {...popoverProps()}
       />,
     );
     expect(screen.getByText('Bartender')).toBeInTheDocument();
@@ -267,6 +284,7 @@ describe('TimelineShiftPopover', () => {
         tz="America/Chicago"
         dateStr="2026-07-11"
         onClose={vi.fn()}
+        {...popoverProps()}
       />,
     );
     expect(screen.getByText('Scheduled')).toBeInTheDocument();
@@ -279,6 +297,7 @@ describe('TimelineShiftPopover', () => {
         tz="America/Chicago"
         dateStr="2026-07-11"
         onClose={vi.fn()}
+        {...popoverProps()}
       />,
     );
     expect(screen.getByText('Check inventory')).toBeInTheDocument();
@@ -291,6 +310,7 @@ describe('TimelineShiftPopover', () => {
         tz="America/Chicago"
         dateStr="2026-07-11"
         onClose={vi.fn()}
+        {...popoverProps()}
       />,
     );
     expect(screen.queryByText('Notes')).not.toBeInTheDocument();
@@ -304,6 +324,7 @@ describe('TimelineShiftPopover', () => {
         tz="America/Chicago"
         dateStr="2026-07-11"
         onClose={onClose}
+        {...popoverProps()}
       />,
     );
     // The popover is open; pressing Escape should close it

--- a/tests/unit/timelineComponents.test.tsx
+++ b/tests/unit/timelineComponents.test.tsx
@@ -199,11 +199,17 @@ function makeLane(overrides: Partial<TimelineLaneModel> = {}): TimelineLaneModel
 
 // TimelineLane's paint-to-create pointer layer (drag/click/long-press/Escape)
 // and its "Add shift to <lane>" keyboard entry point are covered exhaustively
-// in tests/unit/timelineLanePaint.test.tsx. These tests only need the lane's
-// pre-existing label/count/select rendering, so `window`/`onPaintCommit` are
-// supplied as inert defaults.
+// in tests/unit/timelineLanePaint.test.tsx. The drag-move/edge-resize pointer
+// layer (Stage D) is covered in tests/unit/timelineBarDrag.test.tsx. These
+// tests only need the lane's pre-existing label/count/select rendering, so
+// all of these are supplied as inert defaults.
 function laneExtraProps() {
-  return { window: WINDOW, onPaintCommit: vi.fn() };
+  return {
+    window: WINDOW,
+    onPaintCommit: vi.fn(),
+    onBarDraftChange: vi.fn(),
+    onBarDragCommit: vi.fn(),
+  };
 }
 
 describe('TimelineLane', () => {

--- a/tests/unit/timelineComponents.test.tsx
+++ b/tests/unit/timelineComponents.test.tsx
@@ -197,17 +197,26 @@ function makeLane(overrides: Partial<TimelineLaneModel> = {}): TimelineLaneModel
   };
 }
 
+// TimelineLane's paint-to-create pointer layer (drag/click/long-press/Escape)
+// and its "Add shift to <lane>" keyboard entry point are covered exhaustively
+// in tests/unit/timelineLanePaint.test.tsx. These tests only need the lane's
+// pre-existing label/count/select rendering, so `window`/`onPaintCommit` are
+// supplied as inert defaults.
+function laneExtraProps() {
+  return { window: WINDOW, onPaintCommit: vi.fn() };
+}
+
 describe('TimelineLane', () => {
   it('renders the lane label', () => {
     render(
-      <TimelineLane lane={makeLane()} minToPct={minToPct} onSelect={vi.fn()} />,
+      <TimelineLane lane={makeLane()} minToPct={minToPct} onSelect={vi.fn()} {...laneExtraProps()} />,
     );
     expect(screen.getByText('Front')).toBeInTheDocument();
   });
 
   it('shows "Unassigned" when label is empty', () => {
     render(
-      <TimelineLane lane={makeLane({ key: 'unknown', label: '', hours: 0, bars: [] })} minToPct={minToPct} onSelect={vi.fn()} />,
+      <TimelineLane lane={makeLane({ key: 'unknown', label: '', hours: 0, bars: [] })} minToPct={minToPct} onSelect={vi.fn()} {...laneExtraProps()} />,
     );
     expect(screen.getByText('Unassigned')).toBeInTheDocument();
   });
@@ -218,21 +227,21 @@ describe('TimelineLane', () => {
       makeBar({ shift: makeShift({ id: 's2' }), row: 1 }),
     ];
     render(
-      <TimelineLane lane={makeLane({ hours: 12, bars })} minToPct={minToPct} onSelect={vi.fn()} />,
+      <TimelineLane lane={makeLane({ hours: 12, bars })} minToPct={minToPct} onSelect={vi.fn()} {...laneExtraProps()} />,
     );
     expect(screen.getByText(/2 shifts/)).toBeInTheDocument();
   });
 
   it('shows singular "shift" when there is one bar', () => {
     render(
-      <TimelineLane lane={makeLane({ key: 'Back', label: 'Back', hours: 8 })} minToPct={minToPct} onSelect={vi.fn()} />,
+      <TimelineLane lane={makeLane({ key: 'Back', label: 'Back', hours: 8 })} minToPct={minToPct} onSelect={vi.fn()} {...laneExtraProps()} />,
     );
     expect(screen.getByText(/1 shift\b/)).toBeInTheDocument();
   });
 
   it('displays the total hours for the lane', () => {
     render(
-      <TimelineLane lane={makeLane({ key: 'Bar', label: 'Bar', hours: 7.5 })} minToPct={minToPct} onSelect={vi.fn()} />,
+      <TimelineLane lane={makeLane({ key: 'Bar', label: 'Bar', hours: 7.5 })} minToPct={minToPct} onSelect={vi.fn()} {...laneExtraProps()} />,
     );
     expect(screen.getByText(/7\.5h/)).toBeInTheDocument();
   });
@@ -241,9 +250,9 @@ describe('TimelineLane', () => {
     const onSelect = vi.fn();
     const user = userEvent.setup();
     render(
-      <TimelineLane lane={makeLane()} minToPct={minToPct} onSelect={onSelect} />,
+      <TimelineLane lane={makeLane()} minToPct={minToPct} onSelect={onSelect} {...laneExtraProps()} />,
     );
-    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('button', { name: makeBar().ariaLabel }));
     expect(onSelect).toHaveBeenCalledOnce();
   });
 });

--- a/tests/unit/timelineDraft.test.ts
+++ b/tests/unit/timelineDraft.test.ts
@@ -5,11 +5,13 @@ import {
   updatePaint,
   endPaint,
   buildDraftShiftValues,
+  mergeDraftShift,
   MIN_PAINT_DURATION_MIN,
   DEFAULT_CLICK_DURATION_MIN,
   CLICK_DRAG_THRESHOLD_PX,
 } from '@/lib/timelineDraft';
 import type { TimelineWindow } from '@/lib/timelineModel';
+import type { Shift } from '@/types/scheduling';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -223,5 +225,105 @@ describe('buildDraftShiftValues', () => {
       { defaultEmployeeId: 'emp-1' },
     );
     expect(values.employeeId).toBe('emp-1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mergeDraftShift — Stage D2 live-coverage draft merge
+// ---------------------------------------------------------------------------
+
+const DATE_STR = '2026-07-11';
+const TZ = 'America/Chicago';
+
+function makeShift(overrides: Partial<Shift> = {}): Shift {
+  return {
+    id: 's1',
+    restaurant_id: 'r1',
+    employee_id: 'e1',
+    start_time: '2026-07-11T15:00:00Z', // 10:00 CDT
+    end_time: '2026-07-11T21:00:00Z', // 16:00 CDT
+    break_duration: 0,
+    position: 'Server',
+    status: 'scheduled',
+    is_published: false,
+    locked: false,
+    source: 'manual',
+    notes: '',
+    created_at: '2026-07-01T00:00:00Z',
+    updated_at: '2026-07-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('mergeDraftShift', () => {
+  it('returns dayShifts unchanged when draft is null', () => {
+    const shifts = [makeShift()];
+    expect(mergeDraftShift(shifts, null, DATE_STR, TZ)).toBe(shifts);
+  });
+
+  it('replaces the dragged shift by id with drafted start/end minutes', () => {
+    const shifts = [makeShift({ id: 's1' })];
+    const merged = mergeDraftShift(
+      shifts,
+      { shiftId: 's1', startMin: 660, endMin: 900 }, // 11:00-15:00 local
+      DATE_STR,
+      TZ,
+    );
+    expect(merged).not.toBe(shifts);
+    expect(merged[0].id).toBe('s1');
+    // 11:00 CDT -> 16:00Z, 15:00 CDT -> 20:00Z
+    expect(merged[0].start_time).toBe('2026-07-11T16:00:00.000Z');
+    expect(merged[0].end_time).toBe('2026-07-11T20:00:00.000Z');
+  });
+
+  it('leaves all other shifts untouched (same object reference)', () => {
+    const other = makeShift({ id: 'other', employee_id: 'e2' });
+    const target = makeShift({ id: 's1' });
+    const shifts = [other, target];
+    const merged = mergeDraftShift(
+      shifts,
+      { shiftId: 's1', startMin: 660, endMin: 900 },
+      DATE_STR,
+      TZ,
+    );
+    expect(merged[0]).toBe(other);
+    expect(merged[1]).not.toBe(target);
+  });
+
+  it('preserves all non-time fields on the drafted shift', () => {
+    const shifts = [makeShift({ id: 's1', position: 'Bartender', notes: 'VIP table' })];
+    const merged = mergeDraftShift(
+      shifts,
+      { shiftId: 's1', startMin: 660, endMin: 900 },
+      DATE_STR,
+      TZ,
+    );
+    expect(merged[0].position).toBe('Bartender');
+    expect(merged[0].notes).toBe('VIP table');
+    expect(merged[0].employee_id).toBe('e1');
+  });
+
+  it('returns dayShifts unchanged when the draft shift id is not found (stale draft)', () => {
+    const shifts = [makeShift({ id: 's1' })];
+    const merged = mergeDraftShift(
+      shifts,
+      { shiftId: 'does-not-exist', startMin: 660, endMin: 900 },
+      DATE_STR,
+      TZ,
+    );
+    expect(merged).toBe(shifts);
+  });
+
+  it('handles an overnight draft (endMin > 1440) by rolling to the next calendar day', () => {
+    const shifts = [makeShift({ id: 's1' })];
+    const merged = mergeDraftShift(
+      shifts,
+      { shiftId: 's1', startMin: 1380, endMin: 1500 }, // 23:00-01:00(+1) local
+      DATE_STR,
+      TZ,
+    );
+    // 23:00 CDT -> 2026-07-12T04:00:00Z; 01:00(+1) CDT -> 2026-07-12T06:00:00Z
+    expect(merged[0].start_time).toBe('2026-07-12T04:00:00.000Z');
+    expect(merged[0].end_time).toBe('2026-07-12T06:00:00.000Z');
   });
 });

--- a/tests/unit/timelineDraft.test.ts
+++ b/tests/unit/timelineDraft.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect } from 'vitest';
+import {
+  pointerToMinutes,
+  beginPaint,
+  updatePaint,
+  endPaint,
+  buildDraftShiftValues,
+  MIN_PAINT_DURATION_MIN,
+  DEFAULT_CLICK_DURATION_MIN,
+  CLICK_DRAG_THRESHOLD_PX,
+} from '@/lib/timelineDraft';
+import type { TimelineWindow } from '@/lib/timelineModel';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const WINDOW: TimelineWindow = { startMin: 600, endMin: 1380 }; // 10:00–23:00, 780 min span
+
+function plotRect(left = 100, width = 780): DOMRect {
+  return {
+    left,
+    width,
+    top: 0,
+    height: 0,
+    right: left + width,
+    bottom: 0,
+    x: left,
+    y: 0,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
+// ---------------------------------------------------------------------------
+// pointerToMinutes — pixel → restaurant-local minutes (inverse of minToPct)
+// ---------------------------------------------------------------------------
+
+describe('pointerToMinutes', () => {
+  it('maps the left edge of the plot to window.startMin', () => {
+    const rect = plotRect(100, 780);
+    expect(pointerToMinutes(100, rect, WINDOW)).toBe(600);
+  });
+
+  it('maps the right edge of the plot to window.endMin', () => {
+    const rect = plotRect(100, 780);
+    expect(pointerToMinutes(880, rect, WINDOW)).toBe(1380);
+  });
+
+  it('maps the midpoint of the plot to the midpoint of the window', () => {
+    const rect = plotRect(100, 780);
+    expect(pointerToMinutes(100 + 390, rect, WINDOW)).toBe(990); // 600 + 780/2
+  });
+
+  it('is a linear inverse of the minToPct mapping used elsewhere in the timeline', () => {
+    // minToPct(min) = (min - startMin) / (endMin - startMin) * 100
+    // pointerToMinutes should invert that using clientX instead of a percent.
+    const rect = plotRect(0, 1000);
+    const min = pointerToMinutes(250, rect, WINDOW); // 25% across
+    expect(min).toBe(WINDOW.startMin + 0.25 * (WINDOW.endMin - WINDOW.startMin));
+  });
+
+  it('clamps to window.startMin when clientX is left of the plot', () => {
+    const rect = plotRect(100, 780);
+    expect(pointerToMinutes(0, rect, WINDOW)).toBe(600);
+  });
+
+  it('clamps to window.endMin when clientX is right of the plot', () => {
+    const rect = plotRect(100, 780);
+    expect(pointerToMinutes(10000, rect, WINDOW)).toBe(1380);
+  });
+
+  it('returns window.startMin for a zero-width plot rect (no div-by-zero NaN)', () => {
+    const rect = plotRect(100, 0);
+    expect(pointerToMinutes(100, rect, WINDOW)).toBe(600);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// beginPaint / updatePaint / endPaint — drag reducer with snap + min duration
+// ---------------------------------------------------------------------------
+
+describe('beginPaint', () => {
+  it('starts a paint draft anchored at the snapped pointer minute', () => {
+    const draft = beginPaint(607, WINDOW); // snaps to 600 (nearest 15)
+    expect(draft).toEqual({
+      anchorMin: 600,
+      startMin: 600,
+      endMin: 600,
+      pointerDownMin: 607,
+      movedPx: 0,
+    });
+  });
+
+  it('clamps the anchor into the window before snapping', () => {
+    const draft = beginPaint(1400, WINDOW); // beyond endMin=1380
+    expect(draft.anchorMin).toBe(1380);
+  });
+});
+
+describe('updatePaint', () => {
+  it('extends the draft forward from the anchor as the pointer moves right', () => {
+    const draft = beginPaint(600, WINDOW);
+    const updated = updatePaint(draft, 700, WINDOW, 50);
+    expect(updated.startMin).toBe(600);
+    expect(updated.endMin).toBe(705); // 705 snaps to nearest 15 -> 705
+    expect(updated.movedPx).toBe(50);
+  });
+
+  it('snaps the moving edge to the nearest 15-minute step', () => {
+    const draft = beginPaint(600, WINDOW);
+    const updated = updatePaint(draft, 706, WINDOW, 20); // 706 -> snaps to 705
+    expect(updated.endMin).toBe(705);
+  });
+
+  it('extends the draft backward (startMin moves) when dragging left of the anchor', () => {
+    const draft = beginPaint(900, WINDOW);
+    const updated = updatePaint(draft, 795, WINDOW, 100); // 795 is already on a 15-min boundary
+    expect(updated.startMin).toBe(795);
+    expect(updated.endMin).toBe(900);
+  });
+
+  it('enforces the minimum 15-minute duration when the pointer barely moves', () => {
+    const draft = beginPaint(600, WINDOW);
+    const updated = updatePaint(draft, 605, WINDOW, 5); // snaps to 600, same as anchor
+    expect(updated.endMin - updated.startMin).toBe(MIN_PAINT_DURATION_MIN);
+    expect(updated.startMin).toBe(600);
+    expect(updated.endMin).toBe(615);
+  });
+
+  it('enforces the minimum duration on the backward side too', () => {
+    const draft = beginPaint(600, WINDOW);
+    // Try to drag left of the window start — anchor is already at window edge.
+    const updated = updatePaint(draft, 590, WINDOW, 10);
+    expect(updated.endMin - updated.startMin).toBe(MIN_PAINT_DURATION_MIN);
+  });
+
+  it('clamps the moving edge to the window bounds', () => {
+    const draft = beginPaint(600, WINDOW);
+    const updated = updatePaint(draft, 5000, WINDOW, 500);
+    expect(updated.endMin).toBe(1380);
+  });
+});
+
+describe('endPaint', () => {
+  it('returns the final {startMin, endMin} range for a real drag (moved past the click threshold)', () => {
+    const draft = beginPaint(600, WINDOW);
+    const updated = updatePaint(draft, 700, WINDOW, 50);
+    const result = endPaint(updated, WINDOW);
+    expect(result).toEqual({ startMin: 600, endMin: 705 });
+  });
+
+  it('drops a default 2-hour range at the snapped point for a plain click (< 5px movement)', () => {
+    const draft = beginPaint(607, WINDOW); // snaps to 600
+    const clicked = updatePaint(draft, 608, WINDOW, 1); // negligible movement
+    const result = endPaint(clicked, WINDOW);
+    expect(result).toEqual({ startMin: 600, endMin: 600 + DEFAULT_CLICK_DURATION_MIN });
+  });
+
+  it('uses the click-drag threshold constant to distinguish click vs drag', () => {
+    expect(CLICK_DRAG_THRESHOLD_PX).toBe(5);
+  });
+
+  it('clamps the default click duration to the window when anchored near the end', () => {
+    const draft = beginPaint(1380, WINDOW); // anchored at window end
+    const clicked = updatePaint(draft, 1381, WINDOW, 0);
+    const result = endPaint(clicked, WINDOW);
+    // 1380 + 120 would overflow the window end (1380); clamp end to 1380 and
+    // pull start back so the 2h duration is preserved when possible.
+    expect(result.endMin).toBe(1380);
+    expect(result.startMin).toBe(1380 - DEFAULT_CLICK_DURATION_MIN);
+  });
+
+  it('falls back to the minimum duration when the window itself is shorter than the default click duration', () => {
+    const tinyWindow: TimelineWindow = { startMin: 600, endMin: 630 }; // 30 min span
+    const draft = beginPaint(600, tinyWindow);
+    const clicked = updatePaint(draft, 601, tinyWindow, 0);
+    const result = endPaint(clicked, tinyWindow);
+    expect(result.startMin).toBe(600);
+    expect(result.endMin).toBe(630);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildDraftShiftValues — lane context → prefilled editor values
+// ---------------------------------------------------------------------------
+
+describe('buildDraftShiftValues', () => {
+  it('formats a same-day range as HH:MM start/end times', () => {
+    const values = buildDraftShiftValues({ startMin: 600, endMin: 720 }); // 10:00-12:00
+    expect(values.startTime).toBe('10:00');
+    expect(values.endTime).toBe('12:00');
+  });
+
+  it('wraps an overnight endMin (>= 1440) into HH:MM-of-day for the end time field', () => {
+    const values = buildDraftShiftValues({ startMin: 1410, endMin: 1470 }); // 23:30-00:30(+1)
+    expect(values.startTime).toBe('23:30');
+    expect(values.endTime).toBe('00:30');
+  });
+
+  it('defaults employeeId, breakDuration, and notes to empty', () => {
+    const values = buildDraftShiftValues({ startMin: 600, endMin: 720 });
+    expect(values.employeeId).toBe('');
+    expect(values.breakDuration).toBe('');
+    expect(values.notes).toBe('');
+  });
+
+  it('passes through an explicit lane-context position when grouped by position', () => {
+    const values = buildDraftShiftValues(
+      { startMin: 600, endMin: 720 },
+      { laneContext: { position: 'Server', area: null } },
+    );
+    expect(values.position).toBe('Server');
+  });
+
+  it('leaves position blank when no lane context is supplied (gap-click entry point)', () => {
+    const values = buildDraftShiftValues({ startMin: 600, endMin: 720 });
+    expect(values.position).toBe('');
+  });
+
+  it('prefills employeeId when an explicit default employee is supplied', () => {
+    const values = buildDraftShiftValues(
+      { startMin: 600, endMin: 720 },
+      { defaultEmployeeId: 'emp-1' },
+    );
+    expect(values.employeeId).toBe('emp-1');
+  });
+});

--- a/tests/unit/timelineDragMath.test.ts
+++ b/tests/unit/timelineDragMath.test.ts
@@ -75,6 +75,25 @@ describe('moveShiftDraft', () => {
     expect(result.endMin - result.startMin).toBe(120);
   });
 
+  it('keeps the result within [window.startMin, window.endMin] when duration exceeds the window span (sequential clamps must not fight)', () => {
+    // Regression test: original span is 800 min, wider than the 780-min
+    // visible window. Sequentially clamping startMin-then-endMin (or vice
+    // versa) can push startMin below window.startMin because each clamp
+    // re-derives the other edge from the fixed `duration`, which no longer
+    // fits inside the window. The oversized-duration case must be handled
+    // first by snapping the whole range to the window's bounds.
+    const original = { startMin: 600, endMin: 1400 }; // 800 min duration > 780 min window span
+    const result = moveShiftDraft(
+      original,
+      { grabPointerMin: 600, currentPointerMin: 600 },
+      WINDOW,
+    );
+    expect(result.startMin).toBeGreaterThanOrEqual(WINDOW.startMin);
+    expect(result.endMin).toBeLessThanOrEqual(WINDOW.endMin);
+    expect(result.startMin).toBe(WINDOW.startMin);
+    expect(result.endMin).toBe(WINDOW.endMin);
+  });
+
   it('allows an overnight bar (endMin > 1440) to be dragged within an overnight window', () => {
     const overnightWindow: TimelineWindow = { startMin: 1200, endMin: 1800 }; // 20:00-06:00 next day
     const result = moveShiftDraft(

--- a/tests/unit/timelineDragMath.test.ts
+++ b/tests/unit/timelineDragMath.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Unit tests for the pure drag-move/edge-resize reducers (Stage D1) that power
+ * `useTimelineBarDrag`. These are the pixel/minute math the pointer hook calls
+ * on every rAF-throttled pointermove; the hook itself wires DOM pointer events
+ * and is covered by component tests where jsdom allows.
+ *
+ * Move preserves duration; resize enforces a 15-min floor; both snap to
+ * STEP_MIN and clamp into the visible window (including overnight bars whose
+ * endMin already exceeds 1440).
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  moveShiftDraft,
+  resizeShiftStart,
+  resizeShiftEnd,
+  MIN_SHIFT_DURATION_MIN,
+} from '@/lib/timelineDragMath';
+import type { TimelineWindow } from '@/lib/timelineModel';
+
+const WINDOW: TimelineWindow = { startMin: 600, endMin: 1380 }; // 10:00–23:00
+
+// ---------------------------------------------------------------------------
+// moveShiftDraft — body drag, preserves duration
+// ---------------------------------------------------------------------------
+
+describe('moveShiftDraft', () => {
+  it('shifts both edges by the same snapped delta, preserving duration', () => {
+    // Original bar 660-780 (11:00-13:00, 120 min). Grabbed at pointer 660 (bar start),
+    // dragged to pointer 700 -> delta 40, snaps to 45 (nearest 15 to 40... actually 40 rounds to 45? 40/15=2.67->3*15=45)
+    const result = moveShiftDraft(
+      { startMin: 660, endMin: 780 },
+      { grabPointerMin: 660, currentPointerMin: 700 },
+      WINDOW,
+    );
+    // delta = 700 - 660 = 40, snapped to nearest 15 -> 45
+    expect(result).toEqual({ startMin: 705, endMin: 825 });
+  });
+
+  it('preserves duration exactly regardless of delta', () => {
+    const original = { startMin: 660, endMin: 900 }; // 240 min duration
+    const result = moveShiftDraft(
+      original,
+      { grabPointerMin: 660, currentPointerMin: 750 },
+      WINDOW,
+    );
+    expect(result.endMin - result.startMin).toBe(240);
+  });
+
+  it('snaps the delta to STEP_MIN (15)', () => {
+    const result = moveShiftDraft(
+      { startMin: 660, endMin: 780 },
+      { grabPointerMin: 660, currentPointerMin: 667 }, // delta 7 -> snaps to 0
+      WINDOW,
+    );
+    expect(result).toEqual({ startMin: 660, endMin: 780 });
+  });
+
+  it('clamps so the moved bar never starts before window.startMin', () => {
+    const result = moveShiftDraft(
+      { startMin: 615, endMin: 735 }, // 120 min duration, near window start
+      { grabPointerMin: 615, currentPointerMin: 300 }, // large leftward drag
+      WINDOW,
+    );
+    expect(result.startMin).toBe(WINDOW.startMin);
+    expect(result.endMin - result.startMin).toBe(120);
+  });
+
+  it('clamps so the moved bar never ends after window.endMin', () => {
+    const result = moveShiftDraft(
+      { startMin: 1200, endMin: 1320 }, // 120 min duration
+      { grabPointerMin: 1200, currentPointerMin: 2000 }, // large rightward drag
+      WINDOW,
+    );
+    expect(result.endMin).toBe(WINDOW.endMin);
+    expect(result.endMin - result.startMin).toBe(120);
+  });
+
+  it('allows an overnight bar (endMin > 1440) to be dragged within an overnight window', () => {
+    const overnightWindow: TimelineWindow = { startMin: 1200, endMin: 1800 }; // 20:00-06:00 next day
+    const result = moveShiftDraft(
+      { startMin: 1320, endMin: 1620 }, // 22:00-02:00, 300 min duration
+      { grabPointerMin: 1320, currentPointerMin: 1380 }, // delta 60
+      overnightWindow,
+    );
+    expect(result).toEqual({ startMin: 1380, endMin: 1680 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resizeShiftStart — left edge handle, keeps endMin fixed
+// ---------------------------------------------------------------------------
+
+describe('resizeShiftStart', () => {
+  it('moves the start edge to the snapped pointer minute', () => {
+    const result = resizeShiftStart({ startMin: 660, endMin: 780 }, 690, WINDOW);
+    expect(result).toEqual({ startMin: 690, endMin: 780 });
+  });
+
+  it('snaps the pointer minute to STEP_MIN', () => {
+    const result = resizeShiftStart({ startMin: 660, endMin: 780 }, 697, WINDOW); // snaps to 690 (697/15=46.47->46*15=690... let's verify)
+    expect(result.startMin % 15).toBe(0);
+  });
+
+  it('enforces the 15-min minimum duration floor (cannot cross past endMin - 15)', () => {
+    const result = resizeShiftStart({ startMin: 660, endMin: 780 }, 900, WINDOW); // dragging start past end
+    expect(result.endMin - result.startMin).toBe(MIN_SHIFT_DURATION_MIN);
+    expect(result.startMin).toBe(780 - MIN_SHIFT_DURATION_MIN);
+  });
+
+  it('clamps the start edge to window.startMin', () => {
+    const result = resizeShiftStart({ startMin: 660, endMin: 780 }, 0, WINDOW);
+    expect(result.startMin).toBe(WINDOW.startMin);
+    expect(result.endMin).toBe(780);
+  });
+
+  it('does not move endMin', () => {
+    const result = resizeShiftStart({ startMin: 660, endMin: 780 }, 690, WINDOW);
+    expect(result.endMin).toBe(780);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resizeShiftEnd — right edge handle, keeps startMin fixed
+// ---------------------------------------------------------------------------
+
+describe('resizeShiftEnd', () => {
+  it('moves the end edge to the snapped pointer minute', () => {
+    const result = resizeShiftEnd({ startMin: 660, endMin: 780 }, 810, WINDOW);
+    expect(result).toEqual({ startMin: 660, endMin: 810 });
+  });
+
+  it('enforces the 15-min minimum duration floor (cannot cross before startMin + 15)', () => {
+    const result = resizeShiftEnd({ startMin: 660, endMin: 780 }, 500, WINDOW); // dragging end before start
+    expect(result.endMin - result.startMin).toBe(MIN_SHIFT_DURATION_MIN);
+    expect(result.startMin).toBe(660);
+    expect(result.endMin).toBe(660 + MIN_SHIFT_DURATION_MIN);
+  });
+
+  it('clamps the end edge to window.endMin', () => {
+    const result = resizeShiftEnd({ startMin: 660, endMin: 780 }, 5000, WINDOW);
+    expect(result.endMin).toBe(WINDOW.endMin);
+    expect(result.startMin).toBe(660);
+  });
+
+  it('does not move startMin', () => {
+    const result = resizeShiftEnd({ startMin: 660, endMin: 780 }, 810, WINDOW);
+    expect(result.startMin).toBe(660);
+  });
+
+  it('allows extending an overnight bar past 1440 within an overnight window', () => {
+    const overnightWindow: TimelineWindow = { startMin: 1200, endMin: 1800 };
+    const result = resizeShiftEnd({ startMin: 1320, endMin: 1500 }, 1560, overnightWindow);
+    expect(result).toEqual({ startMin: 1320, endMin: 1560 });
+  });
+});

--- a/tests/unit/timelineLanePaint.test.tsx
+++ b/tests/unit/timelineLanePaint.test.tsx
@@ -226,6 +226,24 @@ describe('TimelineLane paint layer — mouse drag', () => {
   });
 });
 
+// ─── pointercancel aborts ────────────────────────────────────────────────────
+
+describe('TimelineLane paint layer — pointercancel abort', () => {
+  it('a pointercancel mid-drag clears the ghost and does NOT commit', () => {
+    const onPaintCommit = vi.fn();
+    const { plot, container } = renderLane({ onPaintCommit });
+
+    fireEvent.pointerDown(plot, { clientX: 100, pointerId: 1, pointerType: 'mouse' });
+    fireEvent.pointerMove(plot, { clientX: 300, pointerId: 1, pointerType: 'mouse' });
+    expect(container.querySelector('[data-testid="paint-ghost"]')).toBeInTheDocument();
+
+    fireEvent.pointerCancel(plot, { clientX: 300, pointerId: 1, pointerType: 'mouse' });
+
+    expect(container.querySelector('[data-testid="paint-ghost"]')).not.toBeInTheDocument();
+    expect(onPaintCommit).not.toHaveBeenCalled();
+  });
+});
+
 // ─── Escape cancels ──────────────────────────────────────────────────────────
 
 describe('TimelineLane paint layer — Escape cancel', () => {

--- a/tests/unit/timelineLanePaint.test.tsx
+++ b/tests/unit/timelineLanePaint.test.tsx
@@ -1,0 +1,293 @@
+/**
+ * Unit tests for TimelineLane's paint-to-create layer (Stage C2):
+ *   - Mouse drag on the empty plot region paints a dashed ghost bar and
+ *     commits a range on pointerup.
+ *   - A plain click (no movement) commits the default-duration range from
+ *     `endPaint` (pure math already covered by timelineDraft.test.ts — here we
+ *     only pin that TimelineLane wires pointer events through it correctly).
+ *   - Touch requires a 500ms long-press before painting starts; releasing
+ *     early (or moving before the timer fires) does not create a shift.
+ *   - Escape cancels an in-progress paint without committing.
+ *   - A visually-hidden "Add shift to <lane>" button is present per lane and
+ *     invokes the quick-add callback with lane context, no pointer gesture
+ *     required.
+ *   - Bars (existing shifts) are unaffected: clicking a bar still calls
+ *     onSelect and does not start a paint gesture.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+
+import { TimelineLane } from '@/components/scheduling/ShiftTimeline/TimelineLane';
+import type { TimelineLane as TimelineLaneModel, TimelineBar as TimelineBarModel } from '@/components/scheduling/ShiftTimeline/useTimelineModel';
+import type { TimelineWindow } from '@/lib/timelineModel';
+import type { Shift } from '@/types/scheduling';
+import type { PaintRange } from '@/lib/timelineDraft';
+
+// ─── Shared helpers ────────────────────────────────────────────────────────────
+
+const WINDOW: TimelineWindow = { startMin: 600, endMin: 1380 }; // 10:00–23:00, 780 min span
+
+function minToPct(min: number): number {
+  return ((min - WINDOW.startMin) / (WINDOW.endMin - WINDOW.startMin)) * 100;
+}
+
+function makeShift(overrides: Partial<Shift> = {}): Shift {
+  return {
+    id: 's1',
+    restaurant_id: 'r1',
+    employee_id: 'e1',
+    start_time: '2026-07-11T15:00:00Z',
+    end_time: '2026-07-11T21:00:00Z',
+    break_duration: 0,
+    position: 'Server',
+    status: 'scheduled',
+    is_published: false,
+    locked: false,
+    source: 'manual',
+    notes: '',
+    created_at: '2026-07-01T00:00:00Z',
+    updated_at: '2026-07-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeBar(overrides: Partial<TimelineBarModel> = {}): TimelineBarModel {
+  return {
+    shift: makeShift(),
+    row: 0,
+    leftMin: 600,
+    endMin: 960,
+    label: 'Ann Smith',
+    ariaLabel: 'Ann Smith, Server, 10a to 4p, 6.0 hours',
+    color: {
+      bg: 'bg-blue-500/15',
+      border: 'border-blue-500/30',
+      text: 'text-blue-700 dark:text-blue-300',
+    },
+    ...overrides,
+  };
+}
+
+function makeLane(overrides: Partial<TimelineLaneModel> = {}): TimelineLaneModel {
+  return {
+    key: 'Server',
+    label: 'Server',
+    hours: 6,
+    bars: [],
+    ...overrides,
+  };
+}
+
+/** Stub the plot region's rect so pointerToMinutes maps deterministically. */
+function stubPlotRect(container: HTMLElement, left = 0, width = 780) {
+  const plot = container.querySelector('[data-testid="lane-plot"]') as HTMLElement;
+  vi.spyOn(plot, 'getBoundingClientRect').mockReturnValue({
+    left,
+    width,
+    top: 0,
+    height: 28,
+    right: left + width,
+    bottom: 28,
+    x: left,
+    y: 0,
+    toJSON: () => ({}),
+  } as DOMRect);
+  return plot;
+}
+
+function renderLane(overrides: {
+  lane?: TimelineLaneModel;
+  onSelect?: (shift: Shift) => void;
+  onPaintCommit?: (range: PaintRange, laneContext: { position?: string | null; area?: string | null }) => void;
+} = {}) {
+  const onSelect = overrides.onSelect ?? vi.fn();
+  const onPaintCommit = overrides.onPaintCommit ?? vi.fn();
+  const utils = render(
+    <TimelineLane
+      lane={overrides.lane ?? makeLane()}
+      minToPct={minToPct}
+      window={WINDOW}
+      onSelect={onSelect}
+      onPaintCommit={onPaintCommit}
+    />,
+  );
+  const plot = stubPlotRect(utils.container);
+  return { ...utils, plot, onSelect, onPaintCommit };
+}
+
+// ─── Mouse drag paint ────────────────────────────────────────────────────────
+
+describe('TimelineLane paint layer — mouse drag', () => {
+  it('renders a dashed ghost bar while dragging', () => {
+    const { plot, container } = renderLane();
+
+    fireEvent.pointerDown(plot, { clientX: 100, pointerId: 1, pointerType: 'mouse' });
+    fireEvent.pointerMove(plot, { clientX: 200, pointerId: 1, pointerType: 'mouse' });
+
+    const ghost = container.querySelector('[data-testid="paint-ghost"]');
+    expect(ghost).toBeInTheDocument();
+    expect(ghost).toHaveClass('border-dashed');
+  });
+
+  it('commits a range on pointerup after dragging', () => {
+    const onPaintCommit = vi.fn();
+    const { plot } = renderLane({ onPaintCommit });
+
+    fireEvent.pointerDown(plot, { clientX: 100, pointerId: 1, pointerType: 'mouse' });
+    fireEvent.pointerMove(plot, { clientX: 300, pointerId: 1, pointerType: 'mouse' });
+    fireEvent.pointerUp(plot, { clientX: 300, pointerId: 1, pointerType: 'mouse' });
+
+    expect(onPaintCommit).toHaveBeenCalledTimes(1);
+    const [range, laneContext] = onPaintCommit.mock.calls[0];
+    expect(range.startMin).toBeLessThan(range.endMin);
+    expect(laneContext).toEqual({ key: 'Server' });
+  });
+
+  it('clears the ghost bar after commit', () => {
+    const { plot, container } = renderLane();
+
+    fireEvent.pointerDown(plot, { clientX: 100, pointerId: 1, pointerType: 'mouse' });
+    fireEvent.pointerMove(plot, { clientX: 300, pointerId: 1, pointerType: 'mouse' });
+    fireEvent.pointerUp(plot, { clientX: 300, pointerId: 1, pointerType: 'mouse' });
+
+    expect(container.querySelector('[data-testid="paint-ghost"]')).not.toBeInTheDocument();
+  });
+
+  it('commits the default-duration range on a plain click (no movement)', () => {
+    const onPaintCommit = vi.fn();
+    const { plot } = renderLane({ onPaintCommit });
+
+    fireEvent.pointerDown(plot, { clientX: 100, pointerId: 1, pointerType: 'mouse' });
+    fireEvent.pointerUp(plot, { clientX: 100, pointerId: 1, pointerType: 'mouse' });
+
+    expect(onPaintCommit).toHaveBeenCalledTimes(1);
+    const [range] = onPaintCommit.mock.calls[0];
+    expect(range.endMin - range.startMin).toBe(120);
+  });
+
+  it('does not start a paint gesture when clicking an existing bar', async () => {
+    const onSelect = vi.fn();
+    const onPaintCommit = vi.fn();
+    const bar = makeBar();
+    const { onSelect: selectSpy } = renderLane({
+      lane: makeLane({ bars: [bar] }),
+      onSelect,
+      onPaintCommit,
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: bar.ariaLabel }));
+
+    expect(selectSpy).toHaveBeenCalledWith(bar.shift);
+    expect(onPaintCommit).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Escape cancels ──────────────────────────────────────────────────────────
+
+describe('TimelineLane paint layer — Escape cancel', () => {
+  it('cancels an in-progress paint without committing', () => {
+    const onPaintCommit = vi.fn();
+    const { plot, container } = renderLane({ onPaintCommit });
+
+    fireEvent.pointerDown(plot, { clientX: 100, pointerId: 1, pointerType: 'mouse' });
+    fireEvent.pointerMove(plot, { clientX: 300, pointerId: 1, pointerType: 'mouse' });
+    expect(container.querySelector('[data-testid="paint-ghost"]')).toBeInTheDocument();
+
+    fireEvent.keyDown(plot, { key: 'Escape' });
+    expect(container.querySelector('[data-testid="paint-ghost"]')).not.toBeInTheDocument();
+
+    fireEvent.pointerUp(plot, { clientX: 300, pointerId: 1, pointerType: 'mouse' });
+    expect(onPaintCommit).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Touch long-press ────────────────────────────────────────────────────────
+
+describe('TimelineLane paint layer — touch long-press', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('does not paint on touch before the 500ms long-press timer fires', () => {
+    const { plot, container } = renderLane();
+
+    fireEvent.pointerDown(plot, { clientX: 100, pointerId: 1, pointerType: 'touch' });
+    vi.advanceTimersByTime(400);
+    fireEvent.pointerMove(plot, { clientX: 200, pointerId: 1, pointerType: 'touch' });
+
+    expect(container.querySelector('[data-testid="paint-ghost"]')).not.toBeInTheDocument();
+  });
+
+  it('starts painting after the 500ms long-press timer fires', () => {
+    const { plot, container } = renderLane();
+
+    fireEvent.pointerDown(plot, { clientX: 100, pointerId: 1, pointerType: 'touch' });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    fireEvent.pointerMove(plot, { clientX: 200, pointerId: 1, pointerType: 'touch' });
+
+    expect(container.querySelector('[data-testid="paint-ghost"]')).toBeInTheDocument();
+  });
+
+  it('cancels the pending long-press timer if the pointer is released early', () => {
+    const onPaintCommit = vi.fn();
+    const { plot } = renderLane({ onPaintCommit });
+
+    fireEvent.pointerDown(plot, { clientX: 100, pointerId: 1, pointerType: 'touch' });
+    vi.advanceTimersByTime(200);
+    fireEvent.pointerUp(plot, { clientX: 100, pointerId: 1, pointerType: 'touch' });
+    vi.advanceTimersByTime(500);
+
+    expect(onPaintCommit).not.toHaveBeenCalled();
+  });
+
+  it('cancels the pending long-press timer if the pointer moves before it fires (preserves scroll)', () => {
+    const { plot, container } = renderLane();
+
+    fireEvent.pointerDown(plot, { clientX: 100, pointerId: 1, pointerType: 'touch' });
+    vi.advanceTimersByTime(200);
+    // Movement before the long-press fires is a scroll gesture, not a paint drag.
+    fireEvent.pointerMove(plot, { clientX: 140, pointerId: 1, pointerType: 'touch' });
+    vi.advanceTimersByTime(500);
+    fireEvent.pointerMove(plot, { clientX: 200, pointerId: 1, pointerType: 'touch' });
+
+    expect(container.querySelector('[data-testid="paint-ghost"]')).not.toBeInTheDocument();
+  });
+});
+
+// ─── Keyboard entry point ────────────────────────────────────────────────────
+
+describe('TimelineLane paint layer — keyboard entry point', () => {
+  it('renders a visually-hidden "Add shift to <lane>" button', () => {
+    renderLane({ lane: makeLane({ label: 'Bar' }) });
+    expect(screen.getByRole('button', { name: 'Add shift to Bar lane' })).toBeInTheDocument();
+  });
+
+  it('labels the button "Unassigned lane" when the lane label is empty', () => {
+    renderLane({ lane: makeLane({ key: 'unknown', label: '' }) });
+    expect(screen.getByRole('button', { name: 'Add shift to Unassigned lane' })).toBeInTheDocument();
+  });
+
+  it('invokes onPaintCommit with a default-duration range at the window start when activated', () => {
+    const onPaintCommit = vi.fn();
+    renderLane({ lane: makeLane({ key: 'Bar', label: 'Bar' }), onPaintCommit });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add shift to Bar lane' }));
+
+    expect(onPaintCommit).toHaveBeenCalledTimes(1);
+    const [range, laneContext] = onPaintCommit.mock.calls[0];
+    expect(range.endMin - range.startMin).toBe(120);
+    expect(laneContext).toEqual({ key: 'Bar' });
+  });
+
+  it('is visually hidden via sr-only styling', () => {
+    renderLane({ lane: makeLane({ label: 'Bar' }) });
+    const button = screen.getByRole('button', { name: 'Add shift to Bar lane' });
+    expect(button.className).toMatch(/sr-only/);
+  });
+});

--- a/tests/unit/timelineLanePaint.test.tsx
+++ b/tests/unit/timelineLanePaint.test.tsx
@@ -172,6 +172,43 @@ describe('TimelineLane paint layer — mouse drag', () => {
     expect(range.endMin - range.startMin).toBe(120);
   });
 
+  it('commits the default-duration click range after a small (<5px) mouse jitter move', () => {
+    // Regression test: `handlePointerMove` must compute `movedPx` from the
+    // pointer-down clientX for MOUSE gestures too (not just touch). Before the
+    // fix, `touchStartRef` was null on mouse, so `movedPx` was computed as
+    // `|event.clientX - pointerDownMin|` — mixing pixels with minutes-since-
+    // midnight (~600-1380) — which produced a huge bogus `movedPx` that always
+    // classified as a drag, even for a near-stationary mouse click.
+    const onPaintCommit = vi.fn();
+    const { plot } = renderLane({ onPaintCommit });
+
+    fireEvent.pointerDown(plot, { clientX: 100, pointerId: 1, pointerType: 'mouse' });
+    // Jitter of 3px — below CLICK_DRAG_THRESHOLD_PX (5) — should still count as a click.
+    fireEvent.pointerMove(plot, { clientX: 103, pointerId: 1, pointerType: 'mouse' });
+    fireEvent.pointerUp(plot, { clientX: 103, pointerId: 1, pointerType: 'mouse' });
+
+    expect(onPaintCommit).toHaveBeenCalledTimes(1);
+    const [range] = onPaintCommit.mock.calls[0];
+    expect(range.endMin - range.startMin).toBe(120);
+  });
+
+  it('commits the dragged (snapped) range after a mouse move past the 5px threshold', () => {
+    const onPaintCommit = vi.fn();
+    const { plot } = renderLane({ onPaintCommit });
+
+    fireEvent.pointerDown(plot, { clientX: 100, pointerId: 1, pointerType: 'mouse' });
+    // 50px move — comfortably past the 5px click/drag threshold.
+    fireEvent.pointerMove(plot, { clientX: 150, pointerId: 1, pointerType: 'mouse' });
+    fireEvent.pointerUp(plot, { clientX: 150, pointerId: 1, pointerType: 'mouse' });
+
+    expect(onPaintCommit).toHaveBeenCalledTimes(1);
+    const [range] = onPaintCommit.mock.calls[0];
+    // A real drag never collapses to the fixed 120-min default — its width is
+    // whatever the pointer travel (mapped through minToPct's inverse) snapped to.
+    expect(range.endMin - range.startMin).not.toBe(120);
+    expect(range.startMin).toBeLessThan(range.endMin);
+  });
+
   it('does not start a paint gesture when clicking an existing bar', async () => {
     const onSelect = vi.fn();
     const onPaintCommit = vi.fn();

--- a/tests/unit/timelineLanePaint.test.tsx
+++ b/tests/unit/timelineLanePaint.test.tsx
@@ -103,6 +103,10 @@ function renderLane(overrides: {
 } = {}) {
   const onSelect = overrides.onSelect ?? vi.fn();
   const onPaintCommit = overrides.onPaintCommit ?? vi.fn();
+  // The drag-move/edge-resize pointer layer (Stage D) on TimelineBar is
+  // covered exhaustively in tests/unit/timelineBarDrag.test.tsx — these tests
+  // only exercise TimelineLane's own paint-to-create layer, so the bar-drag
+  // callbacks are supplied as inert no-ops.
   const utils = render(
     <TimelineLane
       lane={overrides.lane ?? makeLane()}
@@ -110,6 +114,8 @@ function renderLane(overrides: {
       window={WINDOW}
       onSelect={onSelect}
       onPaintCommit={onPaintCommit}
+      onBarDraftChange={vi.fn()}
+      onBarDragCommit={vi.fn()}
     />,
   );
   const plot = stubPlotRect(utils.container);

--- a/tests/unit/useShiftPlanner.delegation.test.tsx
+++ b/tests/unit/useShiftPlanner.delegation.test.tsx
@@ -10,7 +10,7 @@
  * runs its own inline validation/mutation logic.
  */
 import React, { ReactNode } from 'react';
-import { renderHook, waitFor, act } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 

--- a/tests/unit/useShiftPlanner.delegation.test.tsx
+++ b/tests/unit/useShiftPlanner.delegation.test.tsx
@@ -1,0 +1,259 @@
+/**
+ * Unit tests: useShiftPlanner delegates its mutation surface to
+ * useValidatedShiftMutations (plan task A4).
+ *
+ * These tests mock @/hooks/useValidatedShiftMutations directly and assert that
+ * useShiftPlanner's validateAndCreate/forceCreate/validateAndUpdateTime/
+ * validateAndReassign/deleteShift call through to it with the right shape,
+ * and that its returned validationResult/clearValidation are the same
+ * instances exposed by the pipeline hook — proving useShiftPlanner no longer
+ * runs its own inline validation/mutation logic.
+ */
+import React, { ReactNode } from 'react';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { useShiftPlanner } from '@/hooks/useShiftPlanner';
+import type { Shift } from '@/types/scheduling';
+
+const mockValidateAndCreate = vi.hoisted(() => vi.fn());
+const mockForceCreate = vi.hoisted(() => vi.fn());
+const mockValidateAndUpdateTime = vi.hoisted(() => vi.fn());
+const mockValidateAndReassign = vi.hoisted(() => vi.fn());
+const mockDeleteShift = vi.hoisted(() => vi.fn());
+const mockClearValidation = vi.hoisted(() => vi.fn());
+
+vi.mock('@/hooks/useValidatedShiftMutations', () => ({
+  useValidatedShiftMutations: vi.fn(() => ({
+    validateAndCreate: mockValidateAndCreate,
+    forceCreate: mockForceCreate,
+    validateAndUpdateTime: mockValidateAndUpdateTime,
+    forceUpdateTime: vi.fn(),
+    validateAndReassign: mockValidateAndReassign,
+    forceReassign: vi.fn(),
+    deleteShift: mockDeleteShift,
+    validationResult: null,
+    clearValidation: mockClearValidation,
+  })),
+}));
+
+const mockShifts = vi.hoisted(() => vi.fn());
+const mockEmployees = vi.hoisted(() => vi.fn());
+
+vi.mock('@/hooks/useShifts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/hooks/useShifts')>();
+  return {
+    ...actual,
+    useShifts: mockShifts,
+    useCreateShift: vi.fn(() => ({ mutateAsync: vi.fn() })),
+    useUpdateShift: vi.fn(() => ({ mutateAsync: vi.fn() })),
+    useDeleteShift: vi.fn(() => ({ mutate: vi.fn() })),
+  };
+});
+
+vi.mock('@/hooks/useEmployees', () => ({
+  useEmployees: mockEmployees,
+}));
+
+function makeShift(overrides: Partial<Shift> = {}): Shift {
+  return {
+    id: 'shift-1',
+    restaurant_id: 'rest-1',
+    employee_id: 'emp-1',
+    start_time: '2026-01-15T15:00:00.000Z',
+    end_time: '2026-01-15T23:00:00.000Z',
+    break_duration: 0,
+    position: 'server',
+    status: 'scheduled',
+    is_published: false,
+    locked: false,
+    source: 'manual',
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+  return Wrapper;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockShifts.mockReturnValue({ shifts: [], loading: false, error: null });
+  mockEmployees.mockReturnValue({ employees: [], loading: false, error: null });
+});
+
+function renderPlanner() {
+  const Wrapper = createWrapper();
+  return renderHook(() => useShiftPlanner('rest-1'), { wrapper: Wrapper });
+}
+
+describe('useShiftPlanner — delegates to useValidatedShiftMutations (A4)', () => {
+  it('validateAndCreate delegates to the pipeline hook and returns its outcome verbatim', async () => {
+    mockValidateAndCreate.mockResolvedValue({ created: true });
+    const { result } = renderPlanner();
+
+    const input = {
+      employeeId: 'emp-2',
+      date: '2026-02-01',
+      startTime: '09:00',
+      endTime: '17:00',
+      position: 'server',
+    };
+
+    let outcome: unknown;
+    await act(async () => {
+      outcome = await result.current.validateAndCreate(input);
+    });
+
+    expect(mockValidateAndCreate).toHaveBeenCalledWith(input);
+    expect(outcome).toEqual({ created: true });
+  });
+
+  it('forceCreate delegates to the pipeline hook', async () => {
+    mockForceCreate.mockResolvedValue(true);
+    const { result } = renderPlanner();
+
+    const input = {
+      employeeId: 'emp-2',
+      date: '2026-02-01',
+      startTime: '09:00',
+      endTime: '17:00',
+      position: 'server',
+    };
+
+    let outcome: boolean | undefined;
+    await act(async () => {
+      outcome = await result.current.forceCreate(input);
+    });
+
+    expect(mockForceCreate).toHaveBeenCalledWith(input);
+    expect(outcome).toBe(true);
+  });
+
+  it('validateAndUpdateTime delegates with a translated {shift, startIso, endIso, businessDate} shape and unwraps `updated` to a boolean', async () => {
+    mockValidateAndUpdateTime.mockResolvedValue({ updated: true });
+    const { result } = renderPlanner();
+    const shift = makeShift({ id: 'shift-9' });
+
+    let outcome: boolean | undefined;
+    await act(async () => {
+      outcome = await result.current.validateAndUpdateTime({
+        shift,
+        newStartTime: '2026-02-01T09:00',
+        newEndTime: '2026-02-01T17:00',
+      });
+    });
+
+    expect(mockValidateAndUpdateTime).toHaveBeenCalledWith(
+      expect.objectContaining({
+        shift,
+        startIso: expect.any(String),
+        endIso: expect.any(String),
+        businessDate: '2026-02-01',
+      }),
+    );
+    expect(outcome).toBe(true);
+  });
+
+  it('validateAndUpdateTime returns false when the pipeline reports pending issues (does not throw)', async () => {
+    mockValidateAndUpdateTime.mockResolvedValue({
+      updated: false,
+      pendingWarnings: [{ code: 'OVERLAP', message: 'Overlaps another shift' }],
+    });
+    const { result } = renderPlanner();
+    const shift = makeShift({ id: 'shift-9' });
+
+    let outcome: boolean | undefined;
+    await act(async () => {
+      outcome = await result.current.validateAndUpdateTime({
+        shift,
+        newStartTime: '2026-02-01T09:00',
+        newEndTime: '2026-02-01T17:00',
+      });
+    });
+
+    expect(outcome).toBe(false);
+  });
+
+  it('validateAndUpdateTime returns false (never throws) when the new time string has no T separator', async () => {
+    const { result } = renderPlanner();
+    const shift = makeShift({ id: 'shift-9' });
+
+    let outcome: boolean | undefined;
+    await act(async () => {
+      outcome = await result.current.validateAndUpdateTime({
+        shift,
+        newStartTime: 'not-a-valid-timestamp',
+        newEndTime: '2026-02-01T17:00',
+      });
+    });
+
+    expect(outcome).toBe(false);
+    expect(mockValidateAndUpdateTime).not.toHaveBeenCalled();
+  });
+
+  it('validateAndUpdateTime returns false (never throws) when ShiftInterval.create rejects the interval (e.g. zero duration)', async () => {
+    const { result } = renderPlanner();
+    const shift = makeShift({ id: 'shift-9' });
+
+    let outcome: boolean | undefined;
+    await act(async () => {
+      // Equal start/end (no midnight crossing) → ShiftInterval.create throws INVALID_DURATION.
+      outcome = await result.current.validateAndUpdateTime({
+        shift,
+        newStartTime: '2026-02-01T09:00',
+        newEndTime: '2026-02-01T09:00',
+      });
+    });
+
+    expect(outcome).toBe(false);
+    expect(mockValidateAndUpdateTime).not.toHaveBeenCalled();
+  });
+
+  it('validateAndReassign delegates and unwraps `reassigned` to a boolean', async () => {
+    mockValidateAndReassign.mockResolvedValue({ reassigned: true });
+    const { result } = renderPlanner();
+    const shift = makeShift({ id: 'shift-9' });
+
+    let outcome: boolean | undefined;
+    await act(async () => {
+      outcome = await result.current.validateAndReassign({
+        shift,
+        newEmployeeId: 'emp-2',
+      });
+    });
+
+    expect(mockValidateAndReassign).toHaveBeenCalledWith({ shift, newEmployeeId: 'emp-2' });
+    expect(outcome).toBe(true);
+  });
+
+  it('deleteShift delegates to the pipeline hook', () => {
+    const { result } = renderPlanner();
+
+    act(() => {
+      result.current.deleteShift('shift-9');
+    });
+
+    expect(mockDeleteShift).toHaveBeenCalledWith('shift-9');
+  });
+
+  it('exposes the pipeline hook validationResult and clearValidation (same instances, not shadowed by local state)', async () => {
+    const { result } = renderPlanner();
+
+    expect(result.current.validationResult).toBeNull();
+
+    act(() => {
+      result.current.clearValidation();
+    });
+
+    expect(mockClearValidation).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/useShiftsSingleMutations.test.ts
+++ b/tests/unit/useShiftsSingleMutations.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Unit Tests: Single-shift mutation hooks — explicit restaurant_id filter
+ *
+ * Pins that useUpdateShift/useDeleteShift apply an explicit
+ * `.eq('restaurant_id', restaurantId)` filter on their mutation query
+ * (defense-in-depth per lesson 2026-07-02), matching the series-mutation
+ * pattern (useUpdateShiftSeries/useDeleteShiftSeries already do this).
+ */
+import React, { ReactNode } from 'react';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useUpdateShift, useDeleteShift } from '@/hooks/useShifts';
+
+const mockToast = vi.hoisted(() => vi.fn());
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+const mockSupabase = vi.hoisted(() => ({
+  from: vi.fn(),
+}));
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: mockSupabase,
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  const Wrapper = ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+  return Wrapper;
+};
+
+describe('useUpdateShift — explicit restaurant_id filter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function setupUpdateChain(updateResult: { data: Record<string, unknown> | null; error: { message: string } | null }) {
+    // assertShiftNotLocked: select().eq('id', id).single()
+    const lockCheckSingle = vi.fn().mockResolvedValue({ data: { locked: false }, error: null });
+    const lockCheckEq = vi.fn().mockReturnValue({ single: lockCheckSingle });
+    const lockCheckSelect = vi.fn().mockReturnValue({ eq: lockCheckEq });
+
+    // update(...).eq('id', id).eq('restaurant_id', restaurantId).select().single()
+    const updateSingle = vi.fn().mockResolvedValue(updateResult);
+    const updateSelect = vi.fn().mockReturnValue({ single: updateSingle });
+    const updateEqRestaurant = vi.fn().mockReturnValue({ select: updateSelect });
+    const updateEqId = vi.fn().mockReturnValue({ eq: updateEqRestaurant });
+    const update = vi.fn().mockReturnValue({ eq: updateEqId });
+
+    mockSupabase.from.mockReturnValue({
+      select: lockCheckSelect,
+      update,
+    });
+
+    return { updateEqId, updateEqRestaurant, update };
+  }
+
+  it('applies .eq(restaurant_id) after .eq(id) when updating a shift', async () => {
+    const updatedShift = {
+      id: 'shift-1',
+      restaurant_id: 'rest-123',
+      employee_id: 'emp-1',
+      start_time: '2026-01-10T09:00:00Z',
+      end_time: '2026-01-10T17:00:00Z',
+    };
+
+    const { updateEqId, updateEqRestaurant } = setupUpdateChain({
+      data: updatedShift,
+      error: null,
+    });
+
+    const { result } = renderHook(() => useUpdateShift(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      result.current.mutate({
+        id: 'shift-1',
+        restaurant_id: 'rest-123',
+        status: 'confirmed' as const,
+      });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(updateEqId).toHaveBeenCalledWith('id', 'shift-1');
+    expect(updateEqRestaurant).toHaveBeenCalledWith('restaurant_id', 'rest-123');
+  });
+
+  it('surfaces the Supabase error when the update fails', async () => {
+    setupUpdateChain({ data: null, error: { message: 'permission denied' } });
+
+    const { result } = renderHook(() => useUpdateShift(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      result.current.mutate({
+        id: 'shift-1',
+        restaurant_id: 'rest-123',
+        status: 'confirmed' as const,
+      });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe('useDeleteShift — explicit restaurant_id filter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function setupDeleteChain(deleteResult: { error: { message: string } | null }) {
+    const deleteEqRestaurant = vi.fn().mockResolvedValue(deleteResult);
+    const deleteEqId = vi.fn().mockReturnValue({ eq: deleteEqRestaurant });
+    const del = vi.fn().mockReturnValue({ eq: deleteEqId });
+
+    mockSupabase.from.mockReturnValue({ delete: del });
+
+    return { deleteEqId, deleteEqRestaurant, del };
+  }
+
+  it('applies .eq(restaurant_id) after .eq(id) when deleting a shift', async () => {
+    const { deleteEqId, deleteEqRestaurant } = setupDeleteChain({ error: null });
+
+    const { result } = renderHook(() => useDeleteShift(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      result.current.mutate({ id: 'shift-1', restaurantId: 'rest-123' });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(deleteEqId).toHaveBeenCalledWith('id', 'shift-1');
+    expect(deleteEqRestaurant).toHaveBeenCalledWith('restaurant_id', 'rest-123');
+  });
+
+  it('surfaces the Supabase error when the delete fails', async () => {
+    setupDeleteChain({ error: { message: 'permission denied' } });
+
+    const { result } = renderHook(() => useDeleteShift(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      result.current.mutate({ id: 'shift-1', restaurantId: 'rest-123' });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/tests/unit/useShiftsSingleMutations.test.ts
+++ b/tests/unit/useShiftsSingleMutations.test.ts
@@ -10,7 +10,7 @@ import React, { ReactNode } from 'react';
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { useUpdateShift, useDeleteShift } from '@/hooks/useShifts';
+import { useCreateShift, useUpdateShift, useDeleteShift } from '@/hooks/useShifts';
 
 const mockToast = vi.hoisted(() => vi.fn());
 
@@ -286,5 +286,160 @@ describe('useDeleteShift — explicit restaurant_id filter', () => {
     });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe('useCreateShift / useDeleteShift — silent option (timeline undo-delete flow)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function setupDeleteChain(deleteResult: { error: { message: string } | null }) {
+    const deleteEqRestaurant = vi.fn().mockResolvedValue(deleteResult);
+    const deleteEqId = vi.fn().mockReturnValue({ eq: deleteEqRestaurant });
+    const del = vi.fn().mockReturnValue({ eq: deleteEqId });
+
+    mockSupabase.from.mockReturnValue({ delete: del });
+
+    return { deleteEqId, deleteEqRestaurant, del };
+  }
+
+  it('useCreateShift shows the generic success toast by default', async () => {
+    const insertSingle = vi.fn().mockResolvedValue({
+      data: { id: 'shift-2', restaurant_id: 'rest-123', is_recurring: false },
+      error: null,
+    });
+    const insertSelect = vi.fn().mockReturnValue({ single: insertSingle });
+    const insert = vi.fn().mockReturnValue({ select: insertSelect });
+    mockSupabase.from.mockReturnValue({ insert });
+
+    const { result } = renderHook(() => useCreateShift(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      result.current.mutate({
+        restaurant_id: 'rest-123',
+        employee_id: 'emp-1',
+        start_time: '2026-01-10T09:00:00Z',
+        end_time: '2026-01-10T17:00:00Z',
+        break_duration: 0,
+        position: 'Server',
+        status: 'scheduled',
+        is_published: false,
+        locked: false,
+        source: 'manual',
+      });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Shift created' }),
+    );
+  });
+
+  it('useCreateShift({ silent: true }) suppresses the generic success toast', async () => {
+    const insertSingle = vi.fn().mockResolvedValue({
+      data: { id: 'shift-2', restaurant_id: 'rest-123', is_recurring: false },
+      error: null,
+    });
+    const insertSelect = vi.fn().mockReturnValue({ single: insertSingle });
+    const insert = vi.fn().mockReturnValue({ select: insertSelect });
+    mockSupabase.from.mockReturnValue({ insert });
+
+    const { result } = renderHook(() => useCreateShift({ silent: true }), { wrapper: createWrapper() });
+
+    await act(async () => {
+      result.current.mutate({
+        restaurant_id: 'rest-123',
+        employee_id: 'emp-1',
+        start_time: '2026-01-10T09:00:00Z',
+        end_time: '2026-01-10T17:00:00Z',
+        break_duration: 0,
+        position: 'Server',
+        status: 'scheduled',
+        is_published: false,
+        locked: false,
+        source: 'manual',
+      });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockToast).not.toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Shift created' }),
+    );
+  });
+
+  it('useCreateShift({ silent: true }) still shows the error toast on failure', async () => {
+    const insertSingle = vi.fn().mockResolvedValue({ data: null, error: { message: 'boom' } });
+    const insertSelect = vi.fn().mockReturnValue({ single: insertSingle });
+    const insert = vi.fn().mockReturnValue({ select: insertSelect });
+    mockSupabase.from.mockReturnValue({ insert });
+
+    const { result } = renderHook(() => useCreateShift({ silent: true }), { wrapper: createWrapper() });
+
+    await act(async () => {
+      result.current.mutate({
+        restaurant_id: 'rest-123',
+        employee_id: 'emp-1',
+        start_time: '2026-01-10T09:00:00Z',
+        end_time: '2026-01-10T17:00:00Z',
+        break_duration: 0,
+        position: 'Server',
+        status: 'scheduled',
+        is_published: false,
+        locked: false,
+        source: 'manual',
+      });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Error creating shift' }),
+    );
+  });
+
+  it('useDeleteShift shows the generic success toast by default', async () => {
+    const { deleteEqRestaurant } = setupDeleteChain({ error: null });
+
+    const { result } = renderHook(() => useDeleteShift(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      result.current.mutate({ id: 'shift-1', restaurantId: 'rest-123' });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(deleteEqRestaurant).toHaveBeenCalledWith('restaurant_id', 'rest-123');
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Shift deleted' }),
+    );
+  });
+
+  it('useDeleteShift({ silent: true }) suppresses the generic success toast', async () => {
+    setupDeleteChain({ error: null });
+
+    const { result } = renderHook(() => useDeleteShift({ silent: true }), { wrapper: createWrapper() });
+
+    await act(async () => {
+      result.current.mutate({ id: 'shift-1', restaurantId: 'rest-123' });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockToast).not.toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Shift deleted' }),
+    );
+  });
+
+  it('useDeleteShift({ silent: true }) still shows the error toast on failure', async () => {
+    setupDeleteChain({ error: { message: 'permission denied' } });
+
+    const { result } = renderHook(() => useDeleteShift({ silent: true }), { wrapper: createWrapper() });
+
+    await act(async () => {
+      result.current.mutate({ id: 'shift-1', restaurantId: 'rest-123' });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Error deleting shift' }),
+    );
   });
 });

--- a/tests/unit/useShiftsSingleMutations.test.ts
+++ b/tests/unit/useShiftsSingleMutations.test.ts
@@ -113,6 +113,139 @@ describe('useUpdateShift — explicit restaurant_id filter', () => {
   });
 });
 
+describe('useUpdateShift — optimistic cache update', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function setupDeferredUpdateChain() {
+    // assertShiftNotLocked: select().eq('id', id).single()
+    const lockCheckSingle = vi.fn().mockResolvedValue({ data: { locked: false }, error: null });
+    const lockCheckEq = vi.fn().mockReturnValue({ single: lockCheckSingle });
+    const lockCheckSelect = vi.fn().mockReturnValue({ eq: lockCheckEq });
+
+    // The actual DB update only resolves once the test calls `resolveUpdate`,
+    // so the test can assert on the cache DURING the in-flight mutation (i.e.
+    // the optimistic patch applied by onMutate, before onSuccess/onSettled).
+    let resolveUpdate!: (value: { data: Record<string, unknown>; error: null }) => void;
+    const updatePromise = new Promise<{ data: Record<string, unknown>; error: null }>((resolve) => {
+      resolveUpdate = resolve;
+    });
+    const updateSingle = vi.fn().mockReturnValue(updatePromise);
+    const updateSelect = vi.fn().mockReturnValue({ single: updateSingle });
+    const updateEqRestaurant = vi.fn().mockReturnValue({ select: updateSelect });
+    const updateEqId = vi.fn().mockReturnValue({ eq: updateEqRestaurant });
+    const update = vi.fn().mockReturnValue({ eq: updateEqId });
+
+    mockSupabase.from.mockReturnValue({
+      select: lockCheckSelect,
+      update,
+    });
+
+    return { resolveUpdate };
+  }
+
+  function seedShiftsCache(queryClient: QueryClient, restaurantId: string, shifts: Record<string, unknown>[]) {
+    queryClient.setQueryData(['shifts', restaurantId, undefined, undefined], shifts);
+  }
+
+  it('patches the matching shift in the cache synchronously on mutate (before the mutation resolves)', async () => {
+    const { resolveUpdate } = setupDeferredUpdateChain();
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const Wrapper = ({ children }: { children: ReactNode }) =>
+      React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+    const original = {
+      id: 'shift-1',
+      restaurant_id: 'rest-123',
+      employee_id: 'emp-1',
+      start_time: '2026-01-10T09:00:00Z',
+      end_time: '2026-01-10T17:00:00Z',
+      status: 'scheduled',
+    };
+    seedShiftsCache(queryClient, 'rest-123', [original]);
+
+    const { result } = renderHook(() => useUpdateShift(), { wrapper: Wrapper });
+
+    act(() => {
+      result.current.mutate({
+        id: 'shift-1',
+        restaurant_id: 'rest-123',
+        start_time: '2026-01-10T10:00:00Z',
+        end_time: '2026-01-10T18:00:00Z',
+      });
+    });
+
+    // While the mutation is still in flight (update() hasn't resolved yet),
+    // the cache should already reflect the optimistic patch.
+    await waitFor(() => {
+      const cached = queryClient.getQueryData<Record<string, unknown>[]>(['shifts', 'rest-123', undefined, undefined]);
+      expect(cached?.[0]).toMatchObject({
+        id: 'shift-1',
+        start_time: '2026-01-10T10:00:00Z',
+        end_time: '2026-01-10T18:00:00Z',
+      });
+    });
+
+    // Resolve the underlying update so the mutation settles cleanly.
+    resolveUpdate({
+      data: { ...original, start_time: '2026-01-10T10:00:00Z', end_time: '2026-01-10T18:00:00Z' },
+      error: null,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  it('rolls back the cache to the previous snapshot when the update errors', async () => {
+    const lockCheckSingle = vi.fn().mockResolvedValue({ data: { locked: false }, error: null });
+    const lockCheckEq = vi.fn().mockReturnValue({ single: lockCheckSingle });
+    const lockCheckSelect = vi.fn().mockReturnValue({ eq: lockCheckEq });
+
+    const updateSingle = vi.fn().mockResolvedValue({ data: null, error: { message: 'boom' } });
+    const updateSelect = vi.fn().mockReturnValue({ single: updateSingle });
+    const updateEqRestaurant = vi.fn().mockReturnValue({ select: updateSelect });
+    const updateEqId = vi.fn().mockReturnValue({ eq: updateEqRestaurant });
+    const update = vi.fn().mockReturnValue({ eq: updateEqId });
+
+    mockSupabase.from.mockReturnValue({ select: lockCheckSelect, update });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    const Wrapper = ({ children }: { children: ReactNode }) =>
+      React.createElement(QueryClientProvider, { client: queryClient }, children);
+
+    const original = {
+      id: 'shift-1',
+      restaurant_id: 'rest-123',
+      employee_id: 'emp-1',
+      start_time: '2026-01-10T09:00:00Z',
+      end_time: '2026-01-10T17:00:00Z',
+      status: 'scheduled',
+    };
+    seedShiftsCache(queryClient, 'rest-123', [original]);
+
+    const { result } = renderHook(() => useUpdateShift(), { wrapper: Wrapper });
+
+    await act(async () => {
+      result.current.mutate({
+        id: 'shift-1',
+        restaurant_id: 'rest-123',
+        start_time: '2026-01-10T10:00:00Z',
+        end_time: '2026-01-10T18:00:00Z',
+      });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    const cached = queryClient.getQueryData<Record<string, unknown>[]>(['shifts', 'rest-123', undefined, undefined]);
+    expect(cached).toEqual([original]);
+  });
+});
+
 describe('useDeleteShift — explicit restaurant_id filter', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/tests/unit/useTimelineModel.test.ts
+++ b/tests/unit/useTimelineModel.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { deriveWindow, buildLanes, expandDemand, computeGaps, buildTimelineModel } from '@/lib/timelineModel';
+import { deriveWindow, buildLanes, expandDemand, computeGaps, buildTimelineModel, computeCoverage } from '@/lib/timelineModel';
 import type { Shift, Employee, HourlyStaffingRecommendation } from '@/types/scheduling';
 
 const shift = (start: string, end: string): Shift => ({
@@ -164,5 +164,63 @@ describe('buildTimelineModel', () => {
     expect(model.lanes[0].bars).toHaveLength(1); // cancelled dropped
     expect(model.demand).toBeNull();
     expect(model.gaps).toEqual([]);
+  });
+});
+
+describe('computeCoverage (Fix 1 — live coverage against a frozen window, no lane rebuild)', () => {
+  const employees = [emp('e1', 'Ann', 'Front', 'Server')];
+  const shiftFor = (id: string, eid: string, start: string, end: string) =>
+    ({ id, restaurant_id: 'r', employee_id: eid, start_time: start, end_time: end, break_duration: 0,
+       position: 'Server', status: 'scheduled', is_published: false, source: 'manual',
+       locked: false, created_at: '', updated_at: '' } as Shift);
+
+  it('computes coverage/demand/gaps for the given shifts against a FIXED window (no window/lane derivation)', () => {
+    const shifts = [shiftFor('s1', 'e1', '2026-07-11T15:00:00Z', '2026-07-11T18:00:00Z')]; // 10-13 CT
+    // Fixed window wider than what deriveWindow would compute for these shifts,
+    // proving computeCoverage never re-derives its own window from the shifts.
+    const fixedWindow = { startMin: 480, endMin: 1440 }; // 08:00-24:00
+    const result = computeCoverage(
+      shifts, '2026-07-11', 'America/Chicago', fixedWindow, [rec(10, 1), rec(11, 1), rec(12, 1)],
+    );
+    expect(result.coverage[0].min).toBe(480); // samples span the FIXED window, not deriveWindow's 600-1020
+    expect(result.coverage[result.coverage.length - 1].min).toBe(1440);
+    expect(result.coverage.some((c) => c.count === 1)).toBe(true);
+    expect(result.demand).not.toBeNull();
+    expect(Array.isArray(result.gaps)).toBe(true);
+  });
+
+  it('matches buildTimelineModel\'s coverage/demand/gaps when given the same window (equivalence, no behavior drift)', () => {
+    const shifts = [
+      shiftFor('s1', 'e1', '2026-07-11T15:00:00Z', '2026-07-11T18:00:00Z'),
+      shiftFor('s2', 'e1', '2026-07-11T19:00:00Z', '2026-07-11T22:00:00Z'),
+    ];
+    const recs = [rec(10, 1), rec(11, 1), rec(12, 1), rec(13, 1), rec(14, 1)];
+    const model = buildTimelineModel(shifts, employees, '2026-07-11', 'America/Chicago', 'area', recs);
+    const coverage = computeCoverage(shifts, '2026-07-11', 'America/Chicago', model.window, recs);
+    expect(coverage.coverage).toEqual(model.coverage);
+    expect(coverage.demand).toEqual(model.demand);
+    expect(coverage.gaps).toEqual(model.gaps);
+  });
+
+  it('reflects a moved shift\'s live position while a DIFFERENT fixed window (from the committed shifts) stays untouched', () => {
+    // Simulates dragging s1 later in time: the committed window (derived from
+    // the ORIGINAL, pre-drag shifts) must stay fixed, while coverage computed
+    // against that same fixed window reflects the drafted position.
+    const committedShifts = [
+      shiftFor('s1', 'e1', '2026-07-11T15:00:00Z', '2026-07-11T18:00:00Z'), // 10-13 CT
+    ];
+    const frozenWindow = deriveWindow(committedShifts, '2026-07-11', 'America/Chicago'); // 10:00-13:00
+
+    // Drafted (in-flight drag) shift moved to 11-14 CT — still within frozenWindow.
+    const draftedShifts = [
+      shiftFor('s1', 'e1', '2026-07-11T16:00:00Z', '2026-07-11T19:00:00Z'), // 11-14 CT
+    ];
+    const live = computeCoverage(draftedShifts, '2026-07-11', 'America/Chicago', frozenWindow, []);
+
+    // Coverage reflects the drafted 11:00 start (not the committed 10:00 start).
+    const at10 = live.coverage.find((c) => c.min === frozenWindow.startMin);
+    const at11 = live.coverage.find((c) => c.min === frozenWindow.startMin + 60);
+    expect(at10?.count).toBe(0); // no longer covered at 10:00 post-drag
+    expect(at11?.count).toBe(1); // covered at 11:00 post-drag
   });
 });

--- a/tests/unit/useValidatedShiftMutations.test.tsx
+++ b/tests/unit/useValidatedShiftMutations.test.tsx
@@ -332,6 +332,165 @@ describe('useValidatedShiftMutations — validateAndUpdateTime', () => {
   });
 });
 
+describe('useValidatedShiftMutations — validateAndUpdateShift (persists employee/break/notes)', () => {
+  it('persists start/end/employee/break/notes together in a single update when there are no issues', async () => {
+    const { result } = renderPipeline([]);
+    const shift = makeShift({ id: 'shift-9', employee_id: 'emp-1', break_duration: 0, notes: '' });
+
+    const outcome = await result.current.validateAndUpdateShift({
+      shift,
+      startIso: '2026-02-01T15:00:00.000Z',
+      endIso: '2026-02-01T23:00:00.000Z',
+      businessDate: '2026-02-01',
+      employeeId: 'emp-1',
+      breakDuration: 45,
+      notes: 'Cover the rush',
+    });
+
+    expect(outcome.updated).toBe(true);
+    expect(mockUpdateMutateAsync).toHaveBeenCalledTimes(1);
+    expect(mockUpdateMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'shift-9',
+        restaurant_id: 'rest-1',
+        start_time: '2026-02-01T15:00:00.000Z',
+        end_time: '2026-02-01T23:00:00.000Z',
+        employee_id: 'emp-1',
+        break_duration: 45,
+        notes: 'Cover the rush',
+      }),
+    );
+  });
+
+  it('validates against the NEW employee (reassign-on-save), not the original employee', async () => {
+    const checkConflicts = vi.fn().mockResolvedValue(NO_CONFLICTS);
+    const shift = makeShift({ id: 'shift-9', employee_id: 'emp-1' });
+    const { result } = renderPipeline([shift], checkConflicts);
+
+    await result.current.validateAndUpdateShift({
+      shift,
+      startIso: '2026-02-01T15:00:00.000Z',
+      endIso: '2026-02-01T23:00:00.000Z',
+      businessDate: '2026-02-01',
+      employeeId: 'emp-2',
+      breakDuration: 0,
+      notes: '',
+    });
+
+    expect(checkConflicts).toHaveBeenCalledWith(
+      expect.objectContaining({ employeeId: 'emp-2' }),
+    );
+  });
+
+  it('excludes the shift being edited from overlap detection (excludeShiftId)', async () => {
+    const shift = makeShift({ id: 'shift-9' });
+    const { result } = renderPipeline([shift]);
+
+    const outcome = await result.current.validateAndUpdateShift({
+      shift,
+      startIso: shift.start_time,
+      endIso: shift.end_time,
+      businessDate: '2026-01-15',
+      employeeId: shift.employee_id,
+      breakDuration: 0,
+      notes: '',
+    });
+
+    expect(outcome.updated).toBe(true);
+  });
+
+  it('returns pending issues without mutating when warnings/conflicts exist', async () => {
+    const rpcConflicts: ConflictCheck[] = [
+      { has_conflict: true, conflict_type: 'time-off', message: 'Employee has approved time-off' },
+    ];
+    const checkConflicts = vi.fn().mockResolvedValue({ conflicts: rpcConflicts, hasConflicts: true });
+    const { result } = renderPipeline([], checkConflicts);
+    const shift = makeShift({ id: 'shift-9' });
+
+    const outcome = await result.current.validateAndUpdateShift({
+      shift,
+      startIso: '2026-02-01T15:00:00.000Z',
+      endIso: '2026-02-01T23:00:00.000Z',
+      businessDate: '2026-02-01',
+      employeeId: shift.employee_id,
+      breakDuration: 0,
+      notes: '',
+    });
+
+    expect(outcome.updated).toBe(false);
+    expect(outcome.pendingConflicts).toEqual(rpcConflicts);
+    expect(mockUpdateMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('returns {updated:false} with a lock validationResult for a locked shift and does not mutate', async () => {
+    const { result } = renderPipeline([]);
+    const lockedShift = makeShift({ id: 'shift-locked', locked: true });
+
+    const outcome = await result.current.validateAndUpdateShift({
+      shift: lockedShift,
+      startIso: '2026-02-01T15:00:00.000Z',
+      endIso: '2026-02-01T23:00:00.000Z',
+      businessDate: '2026-02-01',
+      employeeId: lockedShift.employee_id,
+      breakDuration: 0,
+      notes: '',
+    });
+
+    expect(outcome).toEqual({ updated: false });
+    expect(mockUpdateMutateAsync).not.toHaveBeenCalled();
+  });
+});
+
+describe('useValidatedShiftMutations — forceUpdateShift', () => {
+  it('mutates all fields regardless of pending issues', async () => {
+    const rpcConflicts: ConflictCheck[] = [
+      { has_conflict: true, conflict_type: 'time-off', message: 'conflict' },
+    ];
+    const checkConflicts = vi.fn().mockResolvedValue({ conflicts: rpcConflicts, hasConflicts: true });
+    const { result } = renderPipeline([], checkConflicts);
+    const shift = makeShift({ id: 'shift-9' });
+
+    const outcome = await result.current.forceUpdateShift({
+      shift,
+      startIso: '2026-02-01T15:00:00.000Z',
+      endIso: '2026-02-01T23:00:00.000Z',
+      businessDate: '2026-02-01',
+      employeeId: 'emp-2',
+      breakDuration: 60,
+      notes: 'forced',
+    });
+
+    expect(outcome.updated).toBe(true);
+    expect(mockUpdateMutateAsync).toHaveBeenCalledTimes(1);
+    expect(mockUpdateMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'shift-9',
+        employee_id: 'emp-2',
+        break_duration: 60,
+        notes: 'forced',
+      }),
+    );
+  });
+
+  it('returns {updated:false} for a locked shift', async () => {
+    const { result } = renderPipeline([]);
+    const lockedShift = makeShift({ id: 'shift-locked', locked: true });
+
+    const outcome = await result.current.forceUpdateShift({
+      shift: lockedShift,
+      startIso: '2026-02-01T15:00:00.000Z',
+      endIso: '2026-02-01T23:00:00.000Z',
+      businessDate: '2026-02-01',
+      employeeId: lockedShift.employee_id,
+      breakDuration: 0,
+      notes: '',
+    });
+
+    expect(outcome.updated).toBe(false);
+    expect(mockUpdateMutateAsync).not.toHaveBeenCalled();
+  });
+});
+
 describe('useValidatedShiftMutations — forceUpdateTime', () => {
   it('mutates regardless of pending issues', async () => {
     const rpcConflicts: ConflictCheck[] = [

--- a/tests/unit/useValidatedShiftMutations.test.tsx
+++ b/tests/unit/useValidatedShiftMutations.test.tsx
@@ -19,11 +19,12 @@ import type { Shift, ConflictCheck } from '@/types/scheduling';
 const mockCreateMutateAsync = vi.hoisted(() => vi.fn());
 const mockUpdateMutateAsync = vi.hoisted(() => vi.fn());
 const mockDeleteMutate = vi.hoisted(() => vi.fn());
+const mockDeleteMutateAsync = vi.hoisted(() => vi.fn());
 
 vi.mock('@/hooks/useShifts', () => ({
   useCreateShift: () => ({ mutateAsync: mockCreateMutateAsync }),
   useUpdateShift: () => ({ mutateAsync: mockUpdateMutateAsync }),
-  useDeleteShift: () => ({ mutate: mockDeleteMutate }),
+  useDeleteShift: () => ({ mutate: mockDeleteMutate, mutateAsync: mockDeleteMutateAsync }),
 }));
 
 const NO_CONFLICTS = { conflicts: [] as ConflictCheck[], hasConflicts: false };
@@ -68,6 +69,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockCreateMutateAsync.mockResolvedValue(makeShift());
   mockUpdateMutateAsync.mockResolvedValue(makeShift());
+  mockDeleteMutateAsync.mockResolvedValue({ id: 'shift-9', restaurantId: 'rest-1' });
 });
 
 describe('useValidatedShiftMutations — create', () => {
@@ -619,6 +621,33 @@ describe('useValidatedShiftMutations — deleteShift', () => {
 
     expect(() => result.current.deleteShift('shift-locked')).toThrow(LockedShiftError);
     expect(mockDeleteMutate).not.toHaveBeenCalled();
+  });
+});
+
+describe('useValidatedShiftMutations — deleteShiftAsync (awaitable, lock-guarded)', () => {
+  it('awaits useDeleteShift.mutateAsync with id + restaurantId and resolves on success', async () => {
+    const shift = makeShift({ id: 'shift-9', locked: false });
+    const { result } = renderPipeline([shift]);
+
+    await expect(result.current.deleteShiftAsync('shift-9')).resolves.toBeUndefined();
+
+    expect(mockDeleteMutateAsync).toHaveBeenCalledWith({ id: 'shift-9', restaurantId: 'rest-1' });
+  });
+
+  it('rejects with LockedShiftError and does not call the mutation for a locked shift', async () => {
+    const lockedShift = makeShift({ id: 'shift-locked', locked: true });
+    const { result } = renderPipeline([lockedShift]);
+
+    await expect(result.current.deleteShiftAsync('shift-locked')).rejects.toBeInstanceOf(LockedShiftError);
+    expect(mockDeleteMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the underlying mutateAsync rejects', async () => {
+    const shift = makeShift({ id: 'shift-9', locked: false });
+    const { result } = renderPipeline([shift]);
+    mockDeleteMutateAsync.mockRejectedValueOnce(new Error('network error'));
+
+    await expect(result.current.deleteShiftAsync('shift-9')).rejects.toThrow('network error');
   });
 });
 

--- a/tests/unit/useValidatedShiftMutations.test.tsx
+++ b/tests/unit/useValidatedShiftMutations.test.tsx
@@ -1,0 +1,381 @@
+/**
+ * Unit tests: useValidatedShiftMutations — the shared validate→confirm→mutate
+ * pipeline hook (design doc: docs/superpowers/specs/2026-07-05-timeline-edit-create-design.md).
+ *
+ * Mocks `@/hooks/useShifts` mutations (useCreateShift/useUpdateShift/useDeleteShift) and
+ * DI's the conflict checker so no network/Supabase call is exercised here — that's covered
+ * by useConflictDetection's own tests and shiftMutationPipeline's collectShiftIssues tests.
+ */
+import React, { ReactNode } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { useValidatedShiftMutations } from '@/hooks/useValidatedShiftMutations';
+import { LockedShiftError } from '@/lib/shiftMutationPipeline';
+import { ShiftInterval } from '@/lib/shiftInterval';
+import type { Shift, ConflictCheck } from '@/types/scheduling';
+
+const mockCreateMutateAsync = vi.hoisted(() => vi.fn());
+const mockUpdateMutateAsync = vi.hoisted(() => vi.fn());
+const mockDeleteMutate = vi.hoisted(() => vi.fn());
+
+vi.mock('@/hooks/useShifts', () => ({
+  useCreateShift: () => ({ mutateAsync: mockCreateMutateAsync }),
+  useUpdateShift: () => ({ mutateAsync: mockUpdateMutateAsync }),
+  useDeleteShift: () => ({ mutate: mockDeleteMutate }),
+}));
+
+const NO_CONFLICTS = { conflicts: [] as ConflictCheck[], hasConflicts: false };
+
+function makeShift(overrides: Partial<Shift> = {}): Shift {
+  return {
+    id: 'shift-1',
+    restaurant_id: 'rest-1',
+    employee_id: 'emp-1',
+    start_time: '2026-01-15T15:00:00.000Z',
+    end_time: '2026-01-15T23:00:00.000Z',
+    break_duration: 0,
+    position: 'server',
+    status: 'scheduled',
+    is_published: false,
+    locked: false,
+    source: 'manual',
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+  return Wrapper;
+};
+
+function renderPipeline(shifts: Shift[] = [], checkConflicts = vi.fn().mockResolvedValue(NO_CONFLICTS)) {
+  const Wrapper = createWrapper();
+  return renderHook(
+    () => useValidatedShiftMutations('rest-1', shifts, { checkConflicts }),
+    { wrapper: Wrapper },
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockCreateMutateAsync.mockResolvedValue(makeShift());
+  mockUpdateMutateAsync.mockResolvedValue(makeShift());
+});
+
+describe('useValidatedShiftMutations — create', () => {
+  it('validateAndCreate mutates immediately when there are no issues', async () => {
+    const checkConflicts = vi.fn().mockResolvedValue(NO_CONFLICTS);
+    const { result } = renderPipeline([], checkConflicts);
+
+    const outcome = await result.current.validateAndCreate({
+      employeeId: 'emp-2',
+      date: '2026-02-01',
+      startTime: '09:00',
+      endTime: '17:00',
+      position: 'server',
+    });
+
+    expect(outcome.created).toBe(true);
+    expect(mockCreateMutateAsync).toHaveBeenCalledTimes(1);
+    expect(result.current.validationResult).toBeNull();
+  });
+
+  it('validateAndCreate returns pending issues (does not mutate) when warnings exist', async () => {
+    // Existing shift built the same way validateAndCreate builds its own interval
+    // (ShiftInterval.create, host-local) so the overlap holds regardless of host TZ.
+    const existingInterval = ShiftInterval.create('2026-01-15', '09:00', '17:00');
+    const existing = makeShift({
+      start_time: existingInterval.startAt.toISOString(),
+      end_time: existingInterval.endAt.toISOString(),
+    });
+    const { result } = renderPipeline([existing]);
+
+    const outcome = await result.current.validateAndCreate({
+      employeeId: 'emp-1',
+      date: '2026-01-15',
+      startTime: '12:00',
+      endTime: '20:00',
+      position: 'server',
+    });
+
+    expect(outcome.created).toBe(false);
+    expect(outcome.pendingWarnings?.some((w) => w.code === 'OVERLAP')).toBe(true);
+    expect(mockCreateMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('forceCreate mutates regardless of pending issues', async () => {
+    const existingInterval = ShiftInterval.create('2026-01-15', '09:00', '17:00');
+    const existing = makeShift({
+      start_time: existingInterval.startAt.toISOString(),
+      end_time: existingInterval.endAt.toISOString(),
+    });
+    const { result } = renderPipeline([existing]);
+
+    const created = await result.current.forceCreate({
+      employeeId: 'emp-1',
+      date: '2026-01-15',
+      startTime: '12:00',
+      endTime: '20:00',
+      position: 'server',
+    });
+
+    expect(created).toBe(true);
+    expect(mockCreateMutateAsync).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('useValidatedShiftMutations — validateAndUpdateTime', () => {
+  it('updates immediately when there are no issues', async () => {
+    const { result } = renderPipeline([]);
+    const shift = makeShift({ id: 'shift-9', locked: false });
+
+    const outcome = await result.current.validateAndUpdateTime({
+      shift,
+      startIso: '2026-02-01T15:00:00.000Z',
+      endIso: '2026-02-01T23:00:00.000Z',
+      businessDate: '2026-02-01',
+    });
+
+    expect(outcome.updated).toBe(true);
+    expect(mockUpdateMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'shift-9',
+        start_time: '2026-02-01T15:00:00.000Z',
+        end_time: '2026-02-01T23:00:00.000Z',
+      }),
+    );
+  });
+
+  it('returns pending issues without mutating when warnings/conflicts exist', async () => {
+    const rpcConflicts: ConflictCheck[] = [
+      { has_conflict: true, conflict_type: 'time-off', message: 'Employee has approved time-off' },
+    ];
+    const checkConflicts = vi.fn().mockResolvedValue({ conflicts: rpcConflicts, hasConflicts: true });
+    const { result } = renderPipeline([], checkConflicts);
+    const shift = makeShift({ id: 'shift-9' });
+
+    const outcome = await result.current.validateAndUpdateTime({
+      shift,
+      startIso: '2026-02-01T15:00:00.000Z',
+      endIso: '2026-02-01T23:00:00.000Z',
+      businessDate: '2026-02-01',
+    });
+
+    expect(outcome.updated).toBe(false);
+    expect(outcome.pendingConflicts).toEqual(rpcConflicts);
+    expect(mockUpdateMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('excludes the shift being edited from overlap detection (excludeShiftId)', async () => {
+    // Same interval as itself — must not self-overlap.
+    const shift = makeShift({ id: 'shift-9' });
+    const { result } = renderPipeline([shift]);
+
+    const outcome = await result.current.validateAndUpdateTime({
+      shift,
+      startIso: shift.start_time,
+      endIso: shift.end_time,
+      businessDate: '2026-01-15',
+    });
+
+    expect(outcome.updated).toBe(true);
+  });
+
+  it('rejects with a LockedShiftError for a locked shift and does not mutate', async () => {
+    const { result } = renderPipeline([]);
+    const lockedShift = makeShift({ id: 'shift-locked', locked: true });
+
+    await expect(
+      result.current.validateAndUpdateTime({
+        shift: lockedShift,
+        startIso: '2026-02-01T15:00:00.000Z',
+        endIso: '2026-02-01T23:00:00.000Z',
+        businessDate: '2026-02-01',
+      }),
+    ).rejects.toBeInstanceOf(LockedShiftError);
+
+    expect(mockUpdateMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('TZ regression: builds the interval via ShiftInterval.fromTimestamps (restaurant-local wall clock preserved), not host-TZ split+create', async () => {
+    // Restaurant TZ is America/Los_Angeles; host test-runner TZ is whatever CI uses (unpinned) —
+    // fromTimestamps operates purely on the ISO instant, so the wall-clock components of the
+    // ISO string sent to the mutation must be byte-identical to what was passed in, regardless
+    // of host TZ. The bug this pins: `newStartTime.split('T')` + `ShiftInterval.create()`
+    // re-anchors the HH:MM in the *host* TZ, silently shifting the instant.
+    const { result } = renderPipeline([]);
+    const shift = makeShift({ id: 'shift-tz' });
+
+    // 23:00 restaurant-local the night before a DST fall-back, expressed as its UTC instant.
+    const startIso = '2026-11-01T05:00:00.000Z'; // 22:00 America/Chicago (CDT, UTC-5) on Oct 31
+    const endIso = '2026-11-01T14:00:00.000Z'; // 08:00 America/Chicago (CST, UTC-6) on Nov 1
+
+    const outcome = await result.current.validateAndUpdateTime({
+      shift,
+      startIso,
+      endIso,
+      businessDate: '2026-10-31',
+    });
+
+    expect(outcome.updated).toBe(true);
+    expect(mockUpdateMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'shift-tz',
+        start_time: startIso,
+        end_time: endIso,
+      }),
+    );
+  });
+});
+
+describe('useValidatedShiftMutations — forceUpdateTime', () => {
+  it('mutates regardless of pending issues', async () => {
+    const rpcConflicts: ConflictCheck[] = [
+      { has_conflict: true, conflict_type: 'time-off', message: 'conflict' },
+    ];
+    const checkConflicts = vi.fn().mockResolvedValue({ conflicts: rpcConflicts, hasConflicts: true });
+    const { result } = renderPipeline([], checkConflicts);
+    const shift = makeShift({ id: 'shift-9' });
+
+    const updated = await result.current.forceUpdateTime({
+      shift,
+      startIso: '2026-02-01T15:00:00.000Z',
+      endIso: '2026-02-01T23:00:00.000Z',
+      businessDate: '2026-02-01',
+    });
+
+    expect(updated).toBe(true);
+    expect(mockUpdateMutateAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects with LockedShiftError for a locked shift', async () => {
+    const { result } = renderPipeline([]);
+    const lockedShift = makeShift({ id: 'shift-locked', locked: true });
+
+    await expect(
+      result.current.forceUpdateTime({
+        shift: lockedShift,
+        startIso: '2026-02-01T15:00:00.000Z',
+        endIso: '2026-02-01T23:00:00.000Z',
+        businessDate: '2026-02-01',
+      }),
+    ).rejects.toBeInstanceOf(LockedShiftError);
+    expect(mockUpdateMutateAsync).not.toHaveBeenCalled();
+  });
+});
+
+describe('useValidatedShiftMutations — validateAndReassign', () => {
+  it('reassigns immediately when there are no issues', async () => {
+    const { result } = renderPipeline([]);
+    const shift = makeShift({ id: 'shift-9' });
+
+    const outcome = await result.current.validateAndReassign({
+      shift,
+      newEmployeeId: 'emp-2',
+    });
+
+    expect(outcome.reassigned).toBe(true);
+    expect(mockUpdateMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'shift-9', employee_id: 'emp-2' }),
+    );
+  });
+
+  it('returns pending issues without mutating when the new employee has a conflict', async () => {
+    const rpcConflicts: ConflictCheck[] = [
+      { has_conflict: true, conflict_type: 'time-off', message: 'Employee has approved time-off' },
+    ];
+    const checkConflicts = vi.fn().mockResolvedValue({ conflicts: rpcConflicts, hasConflicts: true });
+    const { result } = renderPipeline([], checkConflicts);
+    const shift = makeShift({ id: 'shift-9' });
+
+    const outcome = await result.current.validateAndReassign({ shift, newEmployeeId: 'emp-2' });
+
+    expect(outcome.reassigned).toBe(false);
+    expect(outcome.pendingConflicts).toEqual(rpcConflicts);
+    expect(mockUpdateMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('rejects with LockedShiftError for a locked shift', async () => {
+    const { result } = renderPipeline([]);
+    const lockedShift = makeShift({ id: 'shift-locked', locked: true });
+
+    await expect(
+      result.current.validateAndReassign({ shift: lockedShift, newEmployeeId: 'emp-2' }),
+    ).rejects.toBeInstanceOf(LockedShiftError);
+    expect(mockUpdateMutateAsync).not.toHaveBeenCalled();
+  });
+});
+
+describe('useValidatedShiftMutations — forceReassign', () => {
+  it('mutates regardless of pending issues', async () => {
+    const rpcConflicts: ConflictCheck[] = [
+      { has_conflict: true, conflict_type: 'time-off', message: 'conflict' },
+    ];
+    const checkConflicts = vi.fn().mockResolvedValue({ conflicts: rpcConflicts, hasConflicts: true });
+    const { result } = renderPipeline([], checkConflicts);
+    const shift = makeShift({ id: 'shift-9' });
+
+    const reassigned = await result.current.forceReassign({ shift, newEmployeeId: 'emp-2' });
+
+    expect(reassigned).toBe(true);
+    expect(mockUpdateMutateAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects with LockedShiftError for a locked shift', async () => {
+    const { result } = renderPipeline([]);
+    const lockedShift = makeShift({ id: 'shift-locked', locked: true });
+
+    await expect(
+      result.current.forceReassign({ shift: lockedShift, newEmployeeId: 'emp-2' }),
+    ).rejects.toBeInstanceOf(LockedShiftError);
+    expect(mockUpdateMutateAsync).not.toHaveBeenCalled();
+  });
+});
+
+describe('useValidatedShiftMutations — deleteShift', () => {
+  it('delegates to useDeleteShift with id + restaurantId', () => {
+    const shift = makeShift({ id: 'shift-9', locked: false });
+    const { result } = renderPipeline([shift]);
+
+    result.current.deleteShift('shift-9');
+
+    expect(mockDeleteMutate).toHaveBeenCalledWith({ id: 'shift-9', restaurantId: 'rest-1' });
+  });
+
+  it('throws a LockedShiftError and does not call the mutation for a locked shift', () => {
+    const lockedShift = makeShift({ id: 'shift-locked', locked: true });
+    const { result } = renderPipeline([lockedShift]);
+
+    expect(() => result.current.deleteShift('shift-locked')).toThrow(LockedShiftError);
+    expect(mockDeleteMutate).not.toHaveBeenCalled();
+  });
+});
+
+describe('useValidatedShiftMutations — validationResult / clearValidation', () => {
+  it('clearValidation resets validationResult to null', async () => {
+    const existing = makeShift();
+    const { result } = renderPipeline([existing]);
+
+    await result.current.validateAndCreate({
+      employeeId: 'emp-1',
+      date: '2026-01-15',
+      startTime: '18:00',
+      endTime: '20:00',
+      position: 'server',
+    });
+
+    await waitFor(() => expect(result.current.validationResult).not.toBeNull());
+
+    result.current.clearValidation();
+
+    await waitFor(() => expect(result.current.validationResult).toBeNull());
+  });
+});

--- a/tests/unit/useValidatedShiftMutations.test.tsx
+++ b/tests/unit/useValidatedShiftMutations.test.tsx
@@ -132,6 +132,95 @@ describe('useValidatedShiftMutations — create', () => {
   });
 });
 
+describe('useValidatedShiftMutations — createAtTime (TZ-safe timeline path)', () => {
+  it('validateAndCreateAtTime mutates immediately when there are no issues', async () => {
+    const checkConflicts = vi.fn().mockResolvedValue(NO_CONFLICTS);
+    const { result } = renderPipeline([], checkConflicts);
+
+    const outcome = await result.current.validateAndCreateAtTime({
+      employeeId: 'emp-2',
+      startIso: '2026-02-01T17:00:00.000Z',
+      endIso: '2026-02-02T01:00:00.000Z',
+      businessDate: '2026-02-01',
+      position: 'server',
+    });
+
+    expect(outcome.created).toBe(true);
+    expect(mockCreateMutateAsync).toHaveBeenCalledTimes(1);
+    expect(mockCreateMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        restaurant_id: 'rest-1',
+        employee_id: 'emp-2',
+        start_time: '2026-02-01T17:00:00.000Z',
+        end_time: '2026-02-02T01:00:00.000Z',
+        position: 'server',
+        source: 'manual',
+      }),
+    );
+    expect(result.current.validationResult).toBeNull();
+  });
+
+  it('validateAndCreateAtTime returns pending issues (does not mutate) when the RPC reports a conflict', async () => {
+    const rpcConflicts: ConflictCheck[] = [
+      { has_conflict: true, conflict_type: 'time-off', message: 'on approved time off' },
+    ];
+    const checkConflicts = vi.fn().mockResolvedValue({ conflicts: rpcConflicts, hasConflicts: true });
+    const { result } = renderPipeline([], checkConflicts);
+
+    const outcome = await result.current.validateAndCreateAtTime({
+      employeeId: 'emp-2',
+      startIso: '2026-02-01T17:00:00.000Z',
+      endIso: '2026-02-02T01:00:00.000Z',
+      businessDate: '2026-02-01',
+      position: 'server',
+    });
+
+    expect(outcome.created).toBe(false);
+    expect(outcome.pendingConflicts).toEqual(rpcConflicts);
+    expect(mockCreateMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('forceCreateAtTime mutates regardless of pending issues', async () => {
+    const checkConflicts = vi.fn().mockResolvedValue({
+      conflicts: [{ has_conflict: true, conflict_type: 'time-off', message: 'c' }],
+      hasConflicts: true,
+    });
+    const { result } = renderPipeline([], checkConflicts);
+
+    const created = await result.current.forceCreateAtTime({
+      employeeId: 'emp-2',
+      startIso: '2026-02-01T17:00:00.000Z',
+      endIso: '2026-02-02T01:00:00.000Z',
+      businessDate: '2026-02-01',
+      position: 'server',
+    });
+
+    expect(created).toBe(true);
+    expect(mockCreateMutateAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('TZ regression: writes the restaurant-local wall clock via fromTimestamps, not a host-TZ reconstruction', async () => {
+    // Same ISO instants regardless of host TZ — fromTimestamps must round-trip them byte-identically.
+    const { result } = renderPipeline([]);
+
+    const startIso = '2026-11-01T05:00:00.000Z';
+    const endIso = '2026-11-01T14:00:00.000Z';
+
+    const created = await result.current.forceCreateAtTime({
+      employeeId: 'emp-9',
+      startIso,
+      endIso,
+      businessDate: '2026-10-31',
+      position: 'cook',
+    });
+
+    expect(created).toBe(true);
+    expect(mockCreateMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ start_time: startIso, end_time: endIso }),
+    );
+  });
+});
+
 describe('useValidatedShiftMutations — validateAndUpdateTime', () => {
   it('updates immediately when there are no issues', async () => {
     const { result } = renderPipeline([]);

--- a/tests/unit/useValidatedShiftMutations.test.tsx
+++ b/tests/unit/useValidatedShiftMutations.test.tsx
@@ -278,20 +278,27 @@ describe('useValidatedShiftMutations — validateAndUpdateTime', () => {
     expect(outcome.updated).toBe(true);
   });
 
-  it('rejects with a LockedShiftError for a locked shift and does not mutate', async () => {
+  it('returns {updated:false} with a lock validationResult for a locked shift and does not mutate', async () => {
     const { result } = renderPipeline([]);
     const lockedShift = makeShift({ id: 'shift-locked', locked: true });
 
-    await expect(
-      result.current.validateAndUpdateTime({
-        shift: lockedShift,
-        startIso: '2026-02-01T15:00:00.000Z',
-        endIso: '2026-02-01T23:00:00.000Z',
-        businessDate: '2026-02-01',
-      }),
-    ).rejects.toBeInstanceOf(LockedShiftError);
+    const outcome = await result.current.validateAndUpdateTime({
+      shift: lockedShift,
+      startIso: '2026-02-01T15:00:00.000Z',
+      endIso: '2026-02-01T23:00:00.000Z',
+      businessDate: '2026-02-01',
+    });
 
+    expect(outcome).toEqual({ updated: false });
     expect(mockUpdateMutateAsync).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(result.current.validationResult).toEqual(
+        expect.objectContaining({
+          valid: false,
+          errors: [expect.objectContaining({ message: expect.stringMatching(/locked/i) })],
+        }),
+      ),
+    );
   });
 
   it('TZ regression: builds the interval via ShiftInterval.fromTimestamps (restaurant-local wall clock preserved), not host-TZ split+create', async () => {
@@ -345,19 +352,27 @@ describe('useValidatedShiftMutations — forceUpdateTime', () => {
     expect(mockUpdateMutateAsync).toHaveBeenCalledTimes(1);
   });
 
-  it('rejects with LockedShiftError for a locked shift', async () => {
+  it('returns false with a lock validationResult for a locked shift', async () => {
     const { result } = renderPipeline([]);
     const lockedShift = makeShift({ id: 'shift-locked', locked: true });
 
-    await expect(
-      result.current.forceUpdateTime({
-        shift: lockedShift,
-        startIso: '2026-02-01T15:00:00.000Z',
-        endIso: '2026-02-01T23:00:00.000Z',
-        businessDate: '2026-02-01',
-      }),
-    ).rejects.toBeInstanceOf(LockedShiftError);
+    const updated = await result.current.forceUpdateTime({
+      shift: lockedShift,
+      startIso: '2026-02-01T15:00:00.000Z',
+      endIso: '2026-02-01T23:00:00.000Z',
+      businessDate: '2026-02-01',
+    });
+
+    expect(updated).toBe(false);
     expect(mockUpdateMutateAsync).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(result.current.validationResult).toEqual(
+        expect.objectContaining({
+          valid: false,
+          errors: [expect.objectContaining({ message: expect.stringMatching(/locked/i) })],
+        }),
+      ),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
Turns the read-only shift **Timeline** view (under the Planner) into a full editing canvas that runs the same validations as the Planner:
- **Add / edit / delete** shifts directly on the timeline via a single popover (view → edit, quick-add create, published-delete confirm, lock/recurring affordances).
- **Paint-to-create**: drag or click empty lane space to draft a shift; keyboard-accessible "Add shift to <lane>" entry point.
- **Drag-to-move / edge-resize** shift bars with 15-min snapping and **live coverage feedback** — the coverage chart/verdict update as you drag.
- **Clickable coverage gaps**: click an understaffed hour to open quick-add pre-filled with the merged short-staffed window.
- All writes funnel through a shared, timezone-safe `validate → confirm → mutate` pipeline (`useValidatedShiftMutations`) reused by the Planner; overlap/clopen/time-off/availability warnings surface via the existing `AvailabilityConflictDialog` with Cancel / Assign-anyway override.

## Key implementation notes
- **TZ safety**: timeline writes build UTC instants via `minutesToIso` (`fromZonedTime`) → `ShiftInterval.fromTimestamps`, never host-local `.create` — so shifts anchor in the restaurant's timezone regardless of the manager's device TZ. Additive `validateAndCreateAtTime`/`forceCreateAtTime` keep the Planner's existing HH:MM create path byte-compatible.
- **Multi-tenancy**: `useUpdateShift`/`useDeleteShift` gained explicit `.eq('restaurant_id', …)` (defense-in-depth atop RLS); `useUpdateShift` now does optimistic cache updates so drags don't flicker.
- Single-dialog pattern, semantic tokens, accessibility (keyboard paths, coalesced `aria-live`, color-not-only-cue) all honored.

## Test plan
- **Unit**: 5917 passing (+~210 for this feature) — TZ/DST + overnight math, validation pipeline, paint/drag math, gap-merge, employee ranking, popover create/edit/delete, overlay state machine, optimistic update + rollback.
- **E2E**: `tests/e2e/timeline-edit-create.spec.ts` — create-via-quick-add and edit-via-popover through the real UI (verified green locally).
- **Verify**: `tsc --noEmit` clean; production build succeeds; changed files lint-clean.
- **Review**: 5-model review (security/logic/perf/maintainability/OCR) — zero critical; all majors fixed (paint px/min disambiguation, drag double-jump, nested ternary, dead code, helper dedupe).

## Design
See `docs/superpowers/specs/2026-07-05-timeline-edit-create-design.md` and the plan under `docs/superpowers/plans/`.

## Deferred follow-ups (documented, non-blocking)
- Split the large `TimelineShiftPopover.tsx` into view/create sub-components.
- `validateAndReassign` business-date derivation (dormant; no live consumer).
- `assertShiftNotLocked` restaurant_id scoping (pre-existing; RLS-covered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Create, edit, move, and resize shifts directly in the schedule timeline via an overlay flow (anchored on selection).
  * Added paint-to-create plus an “Add shift” entry, and quick-add from clickable understaffed coverage gaps.
  * Employee picker is more context-aware (position/area), with drag/resize showing live updates.

* **Bug Fixes**
  * Improved time zone, overnight, and daylight-saving correctness for create/edit and drag commits.
  * Locked-shift protections and safer conflict/warning confirmation behavior; transient “just changed” highlight.
  * Undo is available after deleting unpublished shifts.

* **Tests**
  * Added E2E and unit coverage for timeline create/edit, drag/resize, gap quick-add, and validation outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->