### PR TITLE
fix(timeline): shared-row shift bars stay editable (pointer-event scoping)

### DIFF
--- a/docs/superpowers/plans/2026-07-07-timeline-bar-pointer-events-plan.md
+++ b/docs/superpowers/plans/2026-07-07-timeline-bar-pointer-events-plan.md
@@ -1,0 +1,37 @@
+# Plan: Timeline bar pointer-event theft fix
+
+Design: `docs/superpowers/specs/2026-07-07-timeline-bar-pointer-events-design.md`
+
+## Tasks
+
+### T1 — RED: structural regression test (new file)
+`tests/unit/timelineLanePointerEvents.test.tsx`
+- Render `TimelineLane` with two abutting bars on the same `row` (0):
+  bar A 10:00–14:00, bar B 14:00–21:30 (fictional fixture names), B rendered
+  after A.
+- Assert each full-width bar wrapper carries `pointer-events-none`.
+- Assert each bar rect (button's positioned parent) carries `pointer-events-auto`.
+- Run against unfixed code → expect FAIL (wrapper lacks the class).
+Depends on: none.
+
+### T2 — GREEN: scope pointer capture
+- `TimelineLane.tsx`: add `pointer-events-none` to the `absolute left-0 right-0`
+  bar wrapper.
+- `TimelineBar.tsx`: add `pointer-events-auto` to the `absolute inset-y-0.5`
+  bar rect.
+- Re-run T1 → GREEN.
+Depends on: T1.
+
+### T3 — Regression guard: existing suites stay green
+- Run `timelineLanePaint.test.tsx` (empty-space paint still works — wrapper
+  none must not block the plot handlers) and `timelineBarDrag.test.tsx`
+  (bar interaction still works — rect auto).
+Depends on: T2.
+
+## Verify (Phase 8)
+`npm run test` (timeline suites) · `npm run typecheck` · `npm run lint` ·
+`npm run build`.
+
+## Out of scope
+- `buildLanes` dropping inactive-employee shifts (separate latent bug).
+- PostHog dead-click instrumentation (noted as follow-up, not code here).

--- a/docs/superpowers/specs/2026-07-07-timeline-bar-pointer-events-design.md
+++ b/docs/superpowers/specs/2026-07-07-timeline-bar-pointer-events-design.md
@@ -1,0 +1,111 @@
+# Design: Fix Timeline shift bars that can't be hovered/edited when they share a row
+
+**Date:** 2026-07-07
+**Branch:** `fix/timeline-bar-pointer-events`
+**Type:** Bug fix (rendering / pointer events)
+
+## Problem
+
+In the Timeline view (Planner → Timeline), some shift bars cannot be
+edited: hovering shows no grab cursor and clicks/drags do nothing. Reported
+concretely for two employees at one franchise location (details verified
+in the production DB; omitted here — no PII in the repo).
+
+### What it is NOT
+
+The initial hypothesis was that the shifts were `locked` (published). This
+was **disproven via the production DB**: every shift for both employees in
+the affected week is `is_published: false, locked: false`. The schedule is
+unpublished; nothing in the data model blocks editing.
+
+Telemetry was inconclusive: `$dead_click` is not instrumented in this
+project, and recent `$rageclick`s on the scheduling page landed on the
+staffing suggestions toggle and week-nav arrows, not the bars. (Follow-up:
+consider enabling dead-click autocapture — it is the exact signal for this
+class of bug.)
+
+## Root cause
+
+`TimelineLane` renders each bar inside a **full-width** wrapper:
+
+```tsx
+// src/components/scheduling/ShiftTimeline/TimelineLane.tsx
+<div className="absolute left-0 right-0" style={{ top: bar.row * ROW_HEIGHT_PX, height: ROW_HEIGHT_PX }}>
+  <TimelineBar ... />   // inner rect is absolutely positioned via left%/width%
+</div>
+```
+
+The wrapper spans the **entire lane width** at its row's vertical band, and
+(default `pointer-events: auto`) captures pointer events across that whole
+band — even though it is visually empty except for the narrow inner bar rect.
+
+When two shifts share a row (the first-fit `assignRows` packer places a
+later-starting, non-overlapping shift on the same row), the **later-rendered
+bar's full-width wrapper paints on top of the earlier bar's rect** and
+swallows all hover/click/drag over it. The earlier bar becomes inert.
+
+The production data confirms the two affected bars are each the *earlier*
+bar in a shared row — an abutting later shift lands on the same row:
+
+| Inert bar | Shares row with | Relationship |
+|---|---|---|
+| Bar A 10:00–16:00 | Bar B 16:00–22:30 | abut → same row; B's wrapper covers A |
+| Bar A 10:00–14:00 | Bar B 14:00–21:30 | same row; B's wrapper covers A |
+
+This is a **pre-existing rendering bug** in the #587 timeline; it only became
+user-visible once bars became interactive (edit/drag).
+
+## Fix
+
+Scope pointer capture to the actual bar rectangle instead of the full-width
+wrapper. Two class changes, no JS / geometry / layout change:
+
+1. **`TimelineLane.tsx`** — full-width bar wrapper gains `pointer-events-none`
+   so the empty band no longer intercepts events.
+2. **`TimelineBar.tsx`** — the positioned bar rect (`absolute inset-y-0.5`,
+   scoped by `left%`/`width%`) gains `pointer-events-auto` so the real bar
+   still receives hover/click/drag.
+
+### Why this is correct and complete
+
+- Only the bar's real rect (its `left`/`width` extent) captures events →
+  sibling bars on the same row no longer overlap in the hit-test region.
+- Empty row space now falls through `pointer-events-none` to the lane plot's
+  own `onPointerDown` handlers — which is the **desired** behavior (paint-to-
+  create a new shift on empty space).
+- Resize handles and the drag-readout live *inside* the bar rect, so they
+  inherit `pointer-events-auto` (the readout keeps its own explicit
+  `pointer-events-none`). Keyboard activation is unaffected.
+
+### Alternatives considered
+
+- **Give each wrapper the bar's `left`/`width` instead of full-width.** Also
+  works, but duplicates geometry already computed inside `TimelineBar` and
+  risks drift with the drag-draft offsets. Rejected as more invasive.
+- **z-index juggling.** Doesn't fix the root cause — a higher bar still
+  captures events over its full width. Rejected.
+
+## Test plan
+
+jsdom has no layout/hit-testing, so a literal "the click lands on the right
+bar" test is not possible. Assert the **structural invariant** that prevents
+the bug instead:
+
+- Render a lane with two abutting bars on the same row.
+- Assert every full-width bar wrapper has `pointer-events-none`.
+- Assert every bar rect has `pointer-events-auto`.
+
+Removing either class (regressing the bug) fails the test. Existing
+paint-layer and bar-drag tests guard that empty-space paint and bar
+interaction still work.
+
+## Scope / risk
+
+- Files: `TimelineLane.tsx`, `TimelineBar.tsx` (2 className edits) + 1 new
+  test file. Both components are under `src/components/**` (coverage-excluded
+  in vitest + Sonar), so no new-code-coverage regression.
+- No DB, RLS, edge-function, or API surface touched → Supabase design review
+  N/A. Frontend surface is a pure pointer-events class change.
+- **Privacy:** no employee names, restaurant names, or other PII are recorded
+  in this doc, the plan, the tests, or commit messages — fixtures use
+  fictional names.

--- a/src/components/scheduling/ShiftTimeline/TimelineBar.tsx
+++ b/src/components/scheduling/ShiftTimeline/TimelineBar.tsx
@@ -116,7 +116,11 @@ function TimelineBarImpl({
 
   return (
     <div
-      className="absolute inset-y-0.5"
+      // Re-enable pointer events on the actual bar rect (its parent row band
+      // is `pointer-events-none`). Scoped by left%/width%, so only this bar's
+      // real extent captures events — siblings sharing the row no longer
+      // overlap in the hit-test region.
+      className="absolute inset-y-0.5 pointer-events-auto"
       style={{ left: `${left}%`, width: `${Math.max(width, 1)}%` }}
     >
       <button

--- a/src/components/scheduling/ShiftTimeline/TimelineLane.tsx
+++ b/src/components/scheduling/ShiftTimeline/TimelineLane.tsx
@@ -248,7 +248,13 @@ function TimelineLaneImpl({
         {bars.map((bar) => (
           <div
             key={bar.shift.id}
-            className="absolute left-0 right-0"
+            // Full-width row band is `pointer-events-none` so it never
+            // intercepts events over a sibling bar sharing this row: the
+            // later-rendered wrapper would otherwise cover the earlier bar's
+            // rect and swallow its hover/click/drag. Empty space falls
+            // through to the lane's paint-to-create handlers; only the bar
+            // rect itself (in TimelineBar) re-enables pointer events.
+            className="absolute left-0 right-0 pointer-events-none"
             style={{
               top: bar.row * ROW_HEIGHT_PX,
               height: ROW_HEIGHT_PX,

--- a/tests/unit/timelineLanePointerEvents.test.tsx
+++ b/tests/unit/timelineLanePointerEvents.test.tsx
@@ -1,0 +1,145 @@
+/**
+ * Regression test for the "shared-row shift bar can't be hovered/edited" bug.
+ *
+ * `TimelineLane` wraps every bar in a full-width (`absolute left-0 right-0`)
+ * div positioned at the bar's row band. When two shifts share a row (the
+ * first-fit `assignRows` packer places a later, non-overlapping shift on the
+ * same row), the later-rendered bar's full-width wrapper paints on top of the
+ * earlier bar's narrow rect and — with the default `pointer-events: auto` —
+ * swallows all hover/click/drag over it, making the earlier bar inert. This
+ * was reported in production for the *earlier* bar in a shared row, whose
+ * shifts were verified `locked: false` (not a lock bug). Fixtures below use
+ * fictional names — no PII in the repo.
+ *
+ * The fix scopes pointer capture to the bar's real rect:
+ *   - the full-width wrapper is `pointer-events-none` (empty band ignores
+ *     pointer events; they fall through to the lane's paint-to-create layer),
+ *   - the bar rect (`absolute inset-y-0.5`, scoped by left%/width%) is
+ *     `pointer-events-auto`, so only the actual bar captures events and
+ *     siblings on the same row no longer overlap in the hit-test region.
+ *
+ * jsdom performs no layout / hit-testing, so we assert the structural class
+ * invariant that prevents the overlap rather than simulating a real click.
+ */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { TimelineLane } from '@/components/scheduling/ShiftTimeline/TimelineLane';
+import type {
+  TimelineLane as TimelineLaneModel,
+  TimelineBar as TimelineBarModel,
+} from '@/components/scheduling/ShiftTimeline/useTimelineModel';
+import type { TimelineWindow } from '@/lib/timelineModel';
+import type { Shift } from '@/types/scheduling';
+
+const WINDOW: TimelineWindow = { startMin: 600, endMin: 1380 }; // 10:00–23:00
+
+function minToPct(min: number): number {
+  return ((min - WINDOW.startMin) / (WINDOW.endMin - WINDOW.startMin)) * 100;
+}
+
+function makeShift(overrides: Partial<Shift> = {}): Shift {
+  return {
+    id: 's1',
+    restaurant_id: 'r1',
+    employee_id: 'e1',
+    start_time: '2026-07-06T15:00:00Z',
+    end_time: '2026-07-06T19:00:00Z',
+    break_duration: 0,
+    position: 'Server',
+    status: 'scheduled',
+    is_published: false,
+    locked: false,
+    source: 'manual',
+    notes: '',
+    created_at: '2026-07-01T00:00:00Z',
+    updated_at: '2026-07-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+const COLOR = {
+  bg: 'bg-blue-500/15',
+  border: 'border-blue-500/30',
+  text: 'text-blue-700 dark:text-blue-300',
+} as const;
+
+function makeBar(overrides: Partial<TimelineBarModel> = {}): TimelineBarModel {
+  return {
+    shift: makeShift(),
+    row: 0,
+    leftMin: 600,
+    endMin: 840,
+    label: 'Ann Smith',
+    ariaLabel: 'Ann Smith, Server, 10a to 2p, 4.0 hours',
+    color: COLOR,
+    ...overrides,
+  };
+}
+
+/** Two abutting, non-overlapping shifts packed onto the SAME row (row 0). */
+function makeSharedRowLane(): TimelineLaneModel {
+  const earlier = makeBar({
+    shift: makeShift({ id: 'bar-a', employee_id: 'bar-a' }),
+    row: 0,
+    leftMin: 600, // 10:00
+    endMin: 840, //  14:00
+    label: 'Ada Early',
+    ariaLabel: 'Ada Early, Server, 10a to 2p, 4.0 hours',
+  });
+  const later = makeBar({
+    shift: makeShift({ id: 'bar-b', employee_id: 'bar-b' }),
+    row: 0,
+    leftMin: 840, //  14:00  (abuts Ada — same row)
+    endMin: 1290, // 21:30
+    label: 'Bess Late',
+    ariaLabel: 'Bess Late, Server, 2p to 930p, 7.5 hours',
+  });
+  return {
+    key: 'Server',
+    label: 'Server',
+    hours: 11.5,
+    bars: [earlier, later], // render order: earlier first, later on top
+  };
+}
+
+function renderSharedRowLane() {
+  return render(
+    <TimelineLane
+      lane={makeSharedRowLane()}
+      minToPct={minToPct}
+      window={WINDOW}
+      onSelect={vi.fn()}
+      onPaintCommit={vi.fn()}
+      onBarDraftChange={vi.fn()}
+      onBarDragCommit={vi.fn()}
+    />,
+  );
+}
+
+describe('TimelineLane — shared-row bars do not steal each other’s pointer events', () => {
+  it('renders the full-width bar wrapper with pointer-events-none', () => {
+    renderSharedRowLane();
+
+    for (const name of [/ada early/i, /bess late/i]) {
+      const button = screen.getByRole('button', { name });
+      // button → bar rect (inset-y-0.5) → full-width wrapper (left-0 right-0)
+      const wrapper = button.parentElement?.parentElement as HTMLElement;
+      expect(wrapper.className).toContain('left-0');
+      expect(wrapper.className).toContain('right-0');
+      expect(wrapper).toHaveClass('pointer-events-none');
+    }
+  });
+
+  it('renders each bar rect with pointer-events-auto so the real bar stays interactive', () => {
+    renderSharedRowLane();
+
+    for (const name of [/ada early/i, /bess late/i]) {
+      const button = screen.getByRole('button', { name });
+      const rect = button.parentElement as HTMLElement;
+      expect(rect.className).toContain('inset-y-0.5');
+      expect(rect).toHaveClass('pointer-events-auto');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Timeline shift bars that share a row couldn't be hovered/clicked/dragged — no grab cursor, edits ignored. Reported for two employees at one location (details in the production DB; no PII in the repo).
- **Root cause (rendering, not lock):** `TimelineLane` wraps each bar in a full-width (`absolute left-0 right-0`) row band with default `pointer-events: auto`. When two shifts share a row, the later-rendered bar's full-width wrapper paints on top of the earlier bar's narrow rect and swallows its pointer events. Verified via the production DB that the affected shifts are `is_published: false, locked: false` — the earlier "locked shift" theory was disproven.
- **Fix:** wrapper is `pointer-events-none`; the bar rect (`absolute inset-y-0.5`, scoped by `left%`/`width%`) is `pointer-events-auto`. Only the bar's real extent captures events; empty row space falls through to the lane's paint-to-create handlers. No JS / geometry / layout change.

## Test plan
- New `tests/unit/timelineLanePointerEvents.test.tsx` — renders two abutting bars on one row and asserts the structural invariant (wrapper `pointer-events-none`, rect `pointer-events-auto`). Fails on the unfixed code (TDD RED verified). Fixtures use fictional names.
- Existing `timelineLanePaint.test.tsx` (17) + `timelineBarDrag.test.tsx` (25) stay green — empty-space paint and bar drag/resize unaffected.
- Full local gate: `typecheck` ✓, `eslint` ✓, 214 timeline unit tests ✓, `build` ✓, CodeRabbit ✓ (no findings).

## Review notes
- Codex + CodeRabbit flagged employee PII in the design doc; redacted from doc, plan, tests, and commit messages (fictional fixtures) and history rewritten so no names reach `main`.

Design: `docs/superpowers/specs/2026-07-07-timeline-bar-pointer-events-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)