### PR TITLE
feat(payroll): Gusto-format provider export dropdown

### DIFF
--- a/docs/superpowers/plans/2026-07-07-payroll-provider-export-plan.md
+++ b/docs/superpowers/plans/2026-07-07-payroll-provider-export-plan.md
@@ -1,0 +1,732 @@
+# Payroll Provider-Specific Export (Gusto) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Gusto-format payroll CSV export alongside the existing internal CSV, selectable from an "Export ▾" dropdown on the Payroll page.
+
+**Architecture:** Two new pure util modules (`payrollGustoExport.ts` = the Gusto mapper; `payrollExportFormats.ts` = a small format registry) and one small presentational component (`PayrollExportMenu.tsx`) that renders a shadcn `DropdownMenu` and performs the blob download. `Payroll.tsx` swaps its single Export button for this component. No DB / edge-function / network surface — a pure client-side transform of data already on the page.
+
+**Tech Stack:** React 18 + TypeScript, shadcn/ui (`DropdownMenu`), lucide icons, date-fns, Vitest + @testing-library/react + user-event.
+
+**Design doc:** `docs/superpowers/specs/2026-07-07-payroll-provider-export-design.md`
+
+**Source types (already exist, do not modify):** `EmployeePayroll` and `PayrollPeriod` in `src/utils/payrollCalculations.ts`. Money fields are in **cents**; hours are decimal. Relevant fields: `employeeName: string`, `position: string`, `regularHours`, `overtimeHours`, `doubleTimeHours`, `tipsOwed` (cents), `tipsPaidOut` (cents). `PayrollPeriod` has `{ startDate, endDate, employees, ... }`. `exportPayrollToCSV(period): string` is already exported (the internal format).
+
+---
+
+## Task 1: Gusto CSV headers + `splitEmployeeName`
+
+**Files:**
+- Create: `src/utils/payrollGustoExport.ts`
+- Test: `tests/unit/payrollGustoExport.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/payrollGustoExport.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { GUSTO_CSV_HEADERS, splitEmployeeName } from '@/utils/payrollGustoExport';
+
+describe('GUSTO_CSV_HEADERS', () => {
+  it('matches the Gusto import template exactly (16 columns, in order)', () => {
+    expect(GUSTO_CSV_HEADERS.join(',')).toBe(
+      'last_name,first_name,title,gusto_employee_id,regular_hours,overtime_hours,double_overtime_hours,missed_break_hours,owners_draw,bonus,commission,paycheck_tips,cash_tips,correction_payment,reimbursement,personal_note',
+    );
+  });
+});
+
+describe('splitEmployeeName', () => {
+  it('splits "First Last" into first + last', () => {
+    expect(splitEmployeeName('Jose Delgado')).toEqual({ firstName: 'Jose', lastName: 'Delgado' });
+  });
+  it('treats the last token as the last name and the rest as the first name', () => {
+    expect(splitEmployeeName('Ana Maria Cruz')).toEqual({ firstName: 'Ana Maria', lastName: 'Cruz' });
+  });
+  it('preserves accented characters', () => {
+    expect(splitEmployeeName('Javier Gutiérrez')).toEqual({ firstName: 'Javier', lastName: 'Gutiérrez' });
+  });
+  it('keeps original casing (does not normalize)', () => {
+    expect(splitEmployeeName('Shy harrison')).toEqual({ firstName: 'Shy', lastName: 'harrison' });
+  });
+  it('collapses extra internal/leading/trailing whitespace', () => {
+    expect(splitEmployeeName('  Colby   Mullaley  ')).toEqual({ firstName: 'Colby', lastName: 'Mullaley' });
+  });
+  it('puts a single token in firstName with a blank lastName', () => {
+    expect(splitEmployeeName('Cher')).toEqual({ firstName: 'Cher', lastName: '' });
+  });
+  it('returns two blanks for empty/whitespace input', () => {
+    expect(splitEmployeeName('   ')).toEqual({ firstName: '', lastName: '' });
+    expect(splitEmployeeName('')).toEqual({ firstName: '', lastName: '' });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/payrollGustoExport.test.ts`
+Expected: FAIL — cannot resolve `@/utils/payrollGustoExport`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/utils/payrollGustoExport.ts`:
+
+```ts
+import type { PayrollPeriod } from '@/utils/payrollCalculations';
+
+/**
+ * Gusto timesheet-import column headers, in the exact order Gusto expects.
+ * Pinned by test — do not reorder or rename without a matching Gusto template.
+ */
+export const GUSTO_CSV_HEADERS = [
+  'last_name',
+  'first_name',
+  'title',
+  'gusto_employee_id',
+  'regular_hours',
+  'overtime_hours',
+  'double_overtime_hours',
+  'missed_break_hours',
+  'owners_draw',
+  'bonus',
+  'commission',
+  'paycheck_tips',
+  'cash_tips',
+  'correction_payment',
+  'reimbursement',
+  'personal_note',
+] as const;
+
+/**
+ * Split our single `employeeName` ("First Last") into Gusto's separate
+ * last_name / first_name columns. Heuristic: the last whitespace-delimited
+ * token is the last name; everything before it is the first name. A lone token
+ * is treated as a first name (Gusto still name-matches). Empty → two blanks.
+ */
+export function splitEmployeeName(full: string): { firstName: string; lastName: string } {
+  const tokens = (full ?? '').trim().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return { firstName: '', lastName: '' };
+  if (tokens.length === 1) return { firstName: tokens[0], lastName: '' };
+  return {
+    firstName: tokens.slice(0, -1).join(' '),
+    lastName: tokens[tokens.length - 1],
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/payrollGustoExport.test.ts`
+Expected: PASS (all 9 assertions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/payrollGustoExport.ts tests/unit/payrollGustoExport.test.ts
+git commit -m "feat(payroll): Gusto CSV headers + employee name split"
+```
+
+---
+
+## Task 2: `buildGustoCSV` mapper
+
+**Files:**
+- Modify: `src/utils/payrollGustoExport.ts`
+- Test: `tests/unit/payrollGustoExport.test.ts` (add a describe block)
+
+Helper context: values are formatted as **plain numbers** (no `$`, no separators).
+Money = `cents / 100` to 2 decimals; hours to 2 decimals. Any zero value → **blank
+cell** (mirrors Gusto's template). Free-text cells are formula-injection-safe and
+quoted only when necessary.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/payrollGustoExport.test.ts`:
+
+```ts
+import { buildGustoCSV } from '@/utils/payrollGustoExport';
+import type { EmployeePayroll, PayrollPeriod } from '@/utils/payrollCalculations';
+
+function employee(overrides: Partial<EmployeePayroll> = {}): EmployeePayroll {
+  return {
+    employeeId: 'e1',
+    employeeName: 'Oscar Estrada',
+    position: 'Server',
+    area: null,
+    compensationType: 'hourly',
+    hourlyRate: 1000,
+    regularHours: 0,
+    overtimeHours: 0,
+    doubleTimeHours: 0,
+    doubleTimePay: 0,
+    dailyOvertimeHours: 0,
+    weeklyOvertimeHours: 0,
+    regularPay: 0,
+    overtimePay: 0,
+    salaryPay: 0,
+    contractorPay: 0,
+    dailyRatePay: 0,
+    manualPayments: [],
+    manualPaymentsTotal: 0,
+    grossPay: 0,
+    totalTips: 0,
+    tipsPaidOut: 0,
+    tipsOwed: 0,
+    totalPay: 0,
+    ...overrides,
+  };
+}
+
+function period(employees: EmployeePayroll[]): PayrollPeriod {
+  return {
+    startDate: new Date(2026, 5, 8),
+    endDate: new Date(2026, 5, 14),
+    employees,
+    totalRegularHours: 0,
+    totalOvertimeHours: 0,
+    totalDoubleTimeHours: 0,
+    totalGrossPay: 0,
+    totalTips: 0,
+    totalTipsPaidOut: 0,
+    totalTipsOwed: 0,
+  };
+}
+
+describe('buildGustoCSV', () => {
+  it('emits the exact Gusto header as the first line', () => {
+    const csv = buildGustoCSV(period([]));
+    expect(csv).toBe(GUSTO_CSV_HEADERS.join(','));
+  });
+
+  it('maps name, title, hours and leaves gusto_employee_id blank', () => {
+    const csv = buildGustoCSV(period([employee({
+      employeeName: 'Oscar Estrada',
+      position: 'Server',
+      regularHours: 2.23,
+      overtimeHours: 1.5,
+      doubleTimeHours: 0,
+    })]));
+    const row = csv.split('\n')[1];
+    // last_name,first_name,title,gusto_employee_id,regular,ot,double,missed,draw,bonus,comm,paycheck_tips,cash_tips,corr,reimb,note
+    expect(row).toBe('Estrada,Oscar,Server,,2.23,1.50,,,,,,,,,,');
+  });
+
+  it('routes owed tips to paycheck_tips and paid-out tips to cash_tips (cents -> dollars)', () => {
+    const csv = buildGustoCSV(period([employee({
+      employeeName: 'Aleah Holderread',
+      position: 'Server',
+      tipsOwed: 1250,     // $12.50 owed -> paycheck_tips
+      tipsPaidOut: 500,   // $5.00 already cash -> cash_tips
+    })]));
+    const cols = csv.split('\n')[1].split(',');
+    expect(cols[11]).toBe('12.50'); // paycheck_tips
+    expect(cols[12]).toBe('5.00');  // cash_tips
+  });
+
+  it('renders zero numeric values as blank cells', () => {
+    const csv = buildGustoCSV(period([employee({ employeeName: 'Jodi Montes', position: 'Server' })]));
+    expect(csv.split('\n')[1]).toBe('Montes,Jodi,Server,,,,,,,,,,,,,');
+  });
+
+  it('has no TOTAL row and no blank separator line', () => {
+    const csv = buildGustoCSV(period([employee(), employee({ employeeName: 'Jose Delgado' })]));
+    const lines = csv.split('\n');
+    expect(lines).toHaveLength(3); // header + 2 employees
+    expect(lines.some((l) => l.startsWith('TOTAL') || l.startsWith('"TOTAL"'))).toBe(false);
+    expect(lines.some((l) => l.trim() === '')).toBe(false);
+  });
+
+  it('neutralizes CSV/formula injection in free-text cells', () => {
+    const csv = buildGustoCSV(period([employee({ employeeName: '=cmd|calc Regular', position: '@SUM(A1)' })]));
+    const row = csv.split('\n')[1];
+    // Leading formula chars are prefixed with a single quote; a comma-free value stays unquoted.
+    expect(row.startsWith("Regular,'=cmd|calc,'@SUM(A1),")).toBe(true);
+  });
+
+  it('quotes and escapes values containing commas or double-quotes', () => {
+    const csv = buildGustoCSV(period([employee({ employeeName: 'John Doe', position: 'Cook, "Line"' })]));
+    const row = csv.split('\n')[1];
+    expect(row).toBe('Doe,John,"Cook, ""Line""",,,,,,,,,,,,,');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/payrollGustoExport.test.ts`
+Expected: FAIL — `buildGustoCSV` is not exported.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `src/utils/payrollGustoExport.ts`:
+
+```ts
+/**
+ * Format cents as a plain dollar amount ("1250" -> "12.50"), or blank when zero.
+ * No currency symbol / thousands separator — Gusto parses these as numbers.
+ * Blank-when-zero also neutralizes negative-zero ("-0.00").
+ */
+function gustoMoney(cents: number): string {
+  const s = (cents / 100).toFixed(2);
+  return s === '0.00' || s === '-0.00' ? '' : s;
+}
+
+/** Format decimal hours to 2 places, or blank when zero. */
+function gustoHours(hours: number): string {
+  const s = hours.toFixed(2);
+  return s === '0.00' || s === '-0.00' ? '' : s;
+}
+
+/**
+ * CSV-safe rendering of a free-text cell for the Gusto file.
+ * Distinct from `escapeCsvCell` in payrollCalculations.ts (which quotes every
+ * cell for the internal format): Gusto's template uses bare, unquoted values, so
+ * we quote ONLY when a comma / double-quote is present, keeping the file visually
+ * identical to Gusto's own export. Still guards against spreadsheet formula
+ * injection by prefixing a leading = + - @ with a single quote, and strips
+ * newlines so a value can't split a row.
+ */
+function gustoText(value: string | null | undefined): string {
+  const noNewlines = (value ?? '').replace(/\r?\n/g, ' ');
+  const neutralized = /^[=+\-@]/.test(noNewlines) ? `'${noNewlines}` : noNewlines;
+  if (neutralized === '') return '';
+  if (/[",]/.test(neutralized)) {
+    return `"${neutralized.replace(/"/g, '""')}"`;
+  }
+  return neutralized;
+}
+
+/**
+ * Build a Gusto timesheet-import CSV from a payroll period.
+ * Header + one row per employee — no TOTAL row, no blank lines, no BOM.
+ * Columns we don't track (missed_break_hours, owners_draw, bonus, commission,
+ * correction_payment, reimbursement, personal_note) and gusto_employee_id are
+ * left blank; Gusto name-matches employees.
+ */
+export function buildGustoCSV(period: PayrollPeriod): string {
+  const rows = period.employees.map((ep) => {
+    const { firstName, lastName } = splitEmployeeName(ep.employeeName);
+    return [
+      gustoText(lastName),              // last_name
+      gustoText(firstName),             // first_name
+      gustoText(ep.position),           // title
+      '',                               // gusto_employee_id
+      gustoHours(ep.regularHours),      // regular_hours
+      gustoHours(ep.overtimeHours),     // overtime_hours
+      gustoHours(ep.doubleTimeHours),   // double_overtime_hours
+      '',                               // missed_break_hours
+      '',                               // owners_draw
+      '',                               // bonus
+      '',                               // commission
+      gustoMoney(ep.tipsOwed),          // paycheck_tips (owed -> paid via paycheck)
+      gustoMoney(ep.tipsPaidOut),       // cash_tips (already received in cash)
+      '',                               // correction_payment
+      '',                               // reimbursement
+      '',                               // personal_note
+    ].join(',');
+  });
+
+  return [GUSTO_CSV_HEADERS.join(','), ...rows].join('\n');
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/payrollGustoExport.test.ts`
+Expected: PASS (all buildGustoCSV + Task 1 assertions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/payrollGustoExport.ts tests/unit/payrollGustoExport.test.ts
+git commit -m "feat(payroll): buildGustoCSV mapper (tips split, zero->blank, injection-safe)"
+```
+
+---
+
+## Task 3: Export-format registry
+
+**Files:**
+- Create: `src/utils/payrollExportFormats.ts`
+- Test: `tests/unit/payrollExportFormats.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/payrollExportFormats.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { PAYROLL_EXPORT_FORMATS } from '@/utils/payrollExportFormats';
+import { GUSTO_CSV_HEADERS } from '@/utils/payrollGustoExport';
+import type { PayrollPeriod } from '@/utils/payrollCalculations';
+
+function emptyPeriod(): PayrollPeriod {
+  return {
+    startDate: new Date(2026, 5, 8),
+    endDate: new Date(2026, 5, 14),
+    employees: [],
+    totalRegularHours: 0,
+    totalOvertimeHours: 0,
+    totalDoubleTimeHours: 0,
+    totalGrossPay: 0,
+    totalTips: 0,
+    totalTipsPaidOut: 0,
+    totalTipsOwed: 0,
+  };
+}
+
+describe('PAYROLL_EXPORT_FORMATS', () => {
+  it('exposes the internal and gusto formats in order', () => {
+    expect(PAYROLL_EXPORT_FORMATS.map((f) => f.id)).toEqual(['internal', 'gusto']);
+  });
+
+  it('labels are human-readable', () => {
+    const byId = Object.fromEntries(PAYROLL_EXPORT_FORMATS.map((f) => [f.id, f.label]));
+    expect(byId.internal).toBe('Standard CSV');
+    expect(byId.gusto).toBe('Gusto CSV');
+  });
+
+  it('builds filenames from the period date range', () => {
+    const start = new Date(2026, 5, 8);
+    const end = new Date(2026, 5, 14);
+    const byId = Object.fromEntries(PAYROLL_EXPORT_FORMATS.map((f) => [f.id, f]));
+    expect(byId.internal.filename(start, end)).toBe('payroll_2026-06-08_to_2026-06-14.csv');
+    expect(byId.gusto.filename(start, end)).toBe('payroll_gusto_2026-06-08_to_2026-06-14.csv');
+  });
+
+  it('gusto.build produces the Gusto header; internal.build produces the internal header', () => {
+    const byId = Object.fromEntries(PAYROLL_EXPORT_FORMATS.map((f) => [f.id, f]));
+    expect(byId.gusto.build(emptyPeriod()).split('\n')[0]).toBe(GUSTO_CSV_HEADERS.join(','));
+    expect(byId.internal.build(emptyPeriod()).split('\n')[0]).toContain('Employee Name');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/payrollExportFormats.test.ts`
+Expected: FAIL — cannot resolve `@/utils/payrollExportFormats`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/utils/payrollExportFormats.ts`:
+
+```ts
+import { format } from 'date-fns';
+
+import type { PayrollPeriod } from '@/utils/payrollCalculations';
+import { exportPayrollToCSV } from '@/utils/payrollCalculations';
+import { buildGustoCSV } from '@/utils/payrollGustoExport';
+
+/** A selectable payroll export format (internal or a payroll provider). */
+export interface PayrollExportFormat {
+  id: 'internal' | 'gusto';
+  /** Menu label shown in the Export dropdown. */
+  label: string;
+  /** Serialize a payroll period to CSV text for this format. */
+  build: (period: PayrollPeriod) => string;
+  /** Download filename for a given period date range. */
+  filename: (start: Date, end: Date) => string;
+}
+
+/** Shared so the internal and provider filenames can't drift in date formatting. */
+function formatDateRange(start: Date, end: Date): string {
+  return `${format(start, 'yyyy-MM-dd')}_to_${format(end, 'yyyy-MM-dd')}`;
+}
+
+export const PAYROLL_EXPORT_FORMATS: readonly PayrollExportFormat[] = [
+  {
+    id: 'internal',
+    label: 'Standard CSV',
+    build: exportPayrollToCSV,
+    filename: (start, end) => `payroll_${formatDateRange(start, end)}.csv`,
+  },
+  {
+    id: 'gusto',
+    label: 'Gusto CSV',
+    build: buildGustoCSV,
+    filename: (start, end) => `payroll_gusto_${formatDateRange(start, end)}.csv`,
+  },
+];
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/payrollExportFormats.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/payrollExportFormats.ts tests/unit/payrollExportFormats.test.ts
+git commit -m "feat(payroll): export-format registry (internal + gusto)"
+```
+
+---
+
+## Task 4: `PayrollExportMenu` component
+
+**Files:**
+- Create: `src/components/payroll/PayrollExportMenu.tsx`
+- Test: `tests/unit/PayrollExportMenu.test.tsx`
+
+Note: `src/components/**` is excluded from coverage (see `vitest.config.ts`), so this
+test is for correctness, not coverage. `tests/setup.ts` already shims
+`hasPointerCapture`/`scrollIntoView`, so Radix menus open under jsdom.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/PayrollExportMenu.test.tsx`:
+
+```tsx
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { PayrollExportMenu } from '@/components/payroll/PayrollExportMenu';
+import { GUSTO_CSV_HEADERS } from '@/utils/payrollGustoExport';
+import type { EmployeePayroll, PayrollPeriod } from '@/utils/payrollCalculations';
+
+function employee(overrides: Partial<EmployeePayroll> = {}): EmployeePayroll {
+  return {
+    employeeId: 'e1', employeeName: 'Oscar Estrada', position: 'Server', area: null,
+    compensationType: 'hourly', hourlyRate: 1000, regularHours: 2.23, overtimeHours: 0,
+    doubleTimeHours: 0, doubleTimePay: 0, dailyOvertimeHours: 0, weeklyOvertimeHours: 0,
+    regularPay: 2227, overtimePay: 0, salaryPay: 0, contractorPay: 0, dailyRatePay: 0,
+    manualPayments: [], manualPaymentsTotal: 0, grossPay: 2227, totalTips: 0,
+    tipsPaidOut: 0, tipsOwed: 0, totalPay: 2227, ...overrides,
+  };
+}
+
+function period(): PayrollPeriod {
+  return {
+    startDate: new Date(2026, 5, 8), endDate: new Date(2026, 5, 14),
+    employees: [employee()], totalRegularHours: 2.23, totalOvertimeHours: 0,
+    totalDoubleTimeHours: 0, totalGrossPay: 2227, totalTips: 0, totalTipsPaidOut: 0,
+    totalTipsOwed: 0,
+  };
+}
+
+/** Capture the downloaded blob + filename by stubbing URL + anchor.click. */
+function stubDownload() {
+  let blob: Blob | undefined;
+  let download = '';
+  vi.spyOn(URL, 'createObjectURL').mockImplementation((b) => { blob = b as Blob; return 'blob:mock'; });
+  vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+  vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (this: HTMLAnchorElement) {
+    download = this.download;
+  });
+  return { getBlob: () => blob, getDownload: () => download };
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('PayrollExportMenu', () => {
+  it('exports the Gusto format with the gusto filename and header', async () => {
+    const dl = stubDownload();
+    const user = userEvent.setup();
+    render(<PayrollExportMenu period={period()} start={new Date(2026, 5, 8)} end={new Date(2026, 5, 14)} />);
+
+    await user.click(screen.getByRole('button', { name: /export/i }));
+    await user.click(await screen.findByText('Gusto CSV'));
+
+    expect(dl.getDownload()).toBe('payroll_gusto_2026-06-08_to_2026-06-14.csv');
+    const text = await dl.getBlob()!.text();
+    expect(text.split('\n')[0]).toBe(GUSTO_CSV_HEADERS.join(','));
+  });
+
+  it('exports the Standard format with the standard filename and header', async () => {
+    const dl = stubDownload();
+    const user = userEvent.setup();
+    render(<PayrollExportMenu period={period()} start={new Date(2026, 5, 8)} end={new Date(2026, 5, 14)} />);
+
+    await user.click(screen.getByRole('button', { name: /export/i }));
+    await user.click(await screen.findByText('Standard CSV'));
+
+    expect(dl.getDownload()).toBe('payroll_2026-06-08_to_2026-06-14.csv');
+    const text = await dl.getBlob()!.text();
+    expect(text.split('\n')[0]).toContain('Employee Name');
+  });
+
+  it('disables the trigger when there are no employees to export', () => {
+    render(<PayrollExportMenu period={null} start={new Date(2026, 5, 8)} end={new Date(2026, 5, 14)} disabled />);
+    expect(screen.getByRole('button', { name: /export/i })).toBeDisabled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/PayrollExportMenu.test.tsx`
+Expected: FAIL — cannot resolve `@/components/payroll/PayrollExportMenu`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/components/payroll/PayrollExportMenu.tsx`:
+
+```tsx
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { ChevronDown, Download } from 'lucide-react';
+
+import type { PayrollPeriod } from '@/utils/payrollCalculations';
+import type { PayrollExportFormat } from '@/utils/payrollExportFormats';
+import { PAYROLL_EXPORT_FORMATS } from '@/utils/payrollExportFormats';
+
+interface PayrollExportMenuProps {
+  /** The ordered/grouped period to export, or null while loading/empty. */
+  period: PayrollPeriod | null;
+  start: Date;
+  end: Date;
+  disabled?: boolean;
+}
+
+/**
+ * "Export ▾" dropdown offering each registered payroll export format.
+ * Mirrors the export-picker precedent in src/pages/Inventory.tsx.
+ */
+export function PayrollExportMenu({ period, start, end, disabled }: PayrollExportMenuProps) {
+  const handleExport = (format: PayrollExportFormat) => {
+    if (!period) return;
+    const csv = format.build(period);
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = format.filename(start, end);
+    a.click();
+    // Revoke after a tick so the browser can schedule the download first.
+    setTimeout(() => window.URL.revokeObjectURL(url), 100);
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button disabled={disabled}>
+          <Download className="h-4 w-4 mr-2" aria-hidden="true" />
+          Export
+          <ChevronDown className="h-4 w-4 ml-2" aria-hidden="true" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="bg-background z-50">
+        {PAYROLL_EXPORT_FORMATS.map((format) => (
+          <DropdownMenuItem
+            key={format.id}
+            className="cursor-pointer"
+            onClick={() => handleExport(format)}
+          >
+            {format.label}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/PayrollExportMenu.test.tsx`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/payroll/PayrollExportMenu.tsx tests/unit/PayrollExportMenu.test.tsx
+git commit -m "feat(payroll): PayrollExportMenu dropdown (Standard + Gusto)"
+```
+
+---
+
+## Task 5: Wire `PayrollExportMenu` into the Payroll page
+
+**Files:**
+- Modify: `src/pages/Payroll.tsx`
+
+Removes the single Export button + `handleExportCSV`, replacing them with
+`<PayrollExportMenu>`. `src/pages/**` is coverage-excluded; correctness is covered
+by Tasks 1–4 plus typecheck/lint/build in Phase 8.
+
+- [ ] **Step 1: Add the import**
+
+In the "custom hooks / utils" import area of `src/pages/Payroll.tsx`, add:
+
+```tsx
+import { PayrollExportMenu } from '@/components/payroll/PayrollExportMenu';
+```
+
+- [ ] **Step 2: Remove the now-unused internal-export import**
+
+Delete `exportPayrollToCSV` from the existing import of `@/utils/payrollCalculations` (line ~20). Leave the rest of that import intact. (The registry now owns that call.)
+
+- [ ] **Step 3: Add an ordered-period memo**
+
+Immediately after the existing `payrollGroups` `useMemo` (around line 439-442), add:
+
+```tsx
+  const orderedPeriod = useMemo(
+    () => (payrollPeriod ? { ...payrollPeriod, employees: payrollGroups.flatMap((g) => g.rows) } : null),
+    [payrollPeriod, payrollGroups],
+  );
+```
+
+- [ ] **Step 4: Delete the old `handleExportCSV` handler**
+
+Remove the entire `handleExportCSV` function (lines ~425-437). It is replaced by `PayrollExportMenu`'s internal handler.
+
+- [ ] **Step 5: Replace the Export button with the menu**
+
+Replace the `<Button onClick={handleExportCSV} ...>...Export CSV</Button>` block (lines ~749-755) with:
+
+```tsx
+              <PayrollExportMenu
+                period={orderedPeriod}
+                start={start}
+                end={end}
+                disabled={!payrollPeriod || payrollPeriod.employees.length === 0}
+              />
+```
+
+- [ ] **Step 6: Drop the now-unused `Download` import if unreferenced**
+
+Check whether `Download` (from `lucide-react`) is still used elsewhere in `src/pages/Payroll.tsx`:
+
+Run: `grep -n "Download" src/pages/Payroll.tsx`
+If the only remaining reference is the import line, remove `Download` from that lucide import. (The icon now lives in `PayrollExportMenu`.)
+
+- [ ] **Step 7: Typecheck, lint, build**
+
+Run: `npm run typecheck && npm run lint && npm run build`
+Expected: all pass. Fix any unused-import / type errors surfaced (e.g. a stray `Download` or `exportPayrollToCSV` reference).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/pages/Payroll.tsx
+git commit -m "feat(payroll): swap Export button for provider-format dropdown"
+```
+
+---
+
+## Final verification (Phase 8 preview)
+
+- [ ] Run the full new-test set: `npx vitest run tests/unit/payrollGustoExport.test.ts tests/unit/payrollExportFormats.test.ts tests/unit/PayrollExportMenu.test.tsx`
+- [ ] Run `npm run typecheck`, `npm run lint`, `npm run build` — all green.
+- [ ] Preview: on the Payroll page, "Export ▾" opens a menu with **Standard CSV** and **Gusto CSV**; each downloads a correctly-named file; the Gusto file's first line matches the template header and tips land in `paycheck_tips`/`cash_tips`.
+
+## Spec coverage self-check
+
+- Gusto header (exact 16 cols) → Task 1 (pinned) + Task 2 (emitted).
+- Name split → Task 1.
+- Column mapping incl. tips split, title=position, blank id/untracked → Task 2.
+- Plain numbers, zero→blank, no `$`, no TOTAL/blank lines, injection-safe, no BOM → Task 2.
+- Registry shape (internal + gusto, shared date formatter) → Task 3.
+- DropdownMenu UI (align=end, decorative chevron, disabled guard, Inventory precedent) → Task 4.
+- UI-wiring test (menu → correct format → correct filename/header) → Task 4.
+- Page integration → Task 5.

--- a/docs/superpowers/specs/2026-07-07-payroll-provider-export-design.md
+++ b/docs/superpowers/specs/2026-07-07-payroll-provider-export-design.md
@@ -127,12 +127,34 @@ export const PAYROLL_EXPORT_FORMATS: readonly PayrollExportFormat[];
 - `gusto` uses `buildGustoCSV`; filename `payroll_gusto_<start>_to_<end>.csv`.
 
 ### `src/pages/Payroll.tsx`
-- Replace the single `Export CSV` button with a shadcn `DropdownMenu`
-  ("Export ▾") whose items come from `PAYROLL_EXPORT_FORMATS`.
-- One shared handler: build via the selected format against the
-  page's grouped/ordered employees (same `orderedEmployees` the current handler
-  uses), blob-download with the format's filename. Keep the existing
-  disabled-when-no-employees guard.
+- Replace the single `Export CSV` button with a shadcn `DropdownMenu`, following
+  the **existing precedent in `src/pages/Inventory.tsx`** (Export ▾ → CSV/PDF
+  picker) so this stays consistent with the codebase rather than inventing a new
+  pattern.
+- Trigger: `DropdownMenuTrigger asChild` wrapping the existing `<Button>`, with
+  visible text `Export` + a decorative `ChevronDown` icon (`aria-hidden`, matching
+  the current `Download` icon usage). The button text self-labels it — no extra
+  `aria-label`. Keep the existing `disabled={!payrollPeriod || employees.length === 0}`
+  guard on the trigger.
+- Content: `DropdownMenuContent align="end" className="bg-background z-50"`
+  (matches Inventory exactly; prevents overflow past the right edge of the header
+  row) with one `DropdownMenuItem` per entry in `PAYROLL_EXPORT_FORMATS`, labelled
+  by `format.label` (items placed directly under the content, mirroring the
+  Inventory precedent — no `DropdownMenuGroup` wrapper for a flat two-item menu).
+- One shared handler `handleExport(format: PayrollExportFormat)`: build via the
+  selected format against the page's grouped/ordered employees (same
+  `orderedEmployees` the current handler uses), blob-download with
+  `format.filename(start, end)`.
+- **Interaction tradeoff (accepted):** today `Enter`/`Space` on the button exports
+  immediately; after this change the same keystroke opens the menu and a second
+  action (arrow + Enter, or type-ahead) performs the export. Radix
+  `DropdownMenu` provides Escape-to-close, arrow-key navigation, type-ahead, and
+  focus-return-to-trigger for free. The extra step is the deliberate cost of
+  supporting multiple formats.
+- **Filename date formatting** is centralized: both formats' `filename` functions
+  call one shared `formatDateRange(start, end)` helper (or the same
+  `format(d, 'yyyy-MM-dd')` call site) so the internal and Gusto filenames can't
+  drift in date formatting if one is later edited.
 
 ## Data flow
 
@@ -157,8 +179,19 @@ Unit (Vitest):
   line; injection escaping of a malicious name; hours formatting.
 - `PAYROLL_EXPORT_FORMATS`: contains `internal` + `gusto`, filenames well-formed.
 
-No DB / edge-function / RLS surface, so no pgTAP. UI wiring covered by the
-existing Payroll page E2E path (button → dropdown is a minor structural change).
+- `PAYROLL_EXPORT_FORMATS`: contains `internal` + `gusto`, filenames well-formed.
+
+**UI wiring (RTL component test, `tests/unit`):** because `handleExportCSV` is
+being forked into two `build` functions with two filenames, a wrong-wiring
+regression (Gusto item calling the internal builder, or a filename collision)
+would ship silently on payroll data. Add a test that renders the export
+dropdown, opens the menu, clicks the **Gusto CSV** item, and asserts (a) the
+triggered download's `download` attribute matches `payroll_gusto_<start>_to_<end>.csv`
+and (b) the produced blob text starts with the exact Gusto header line. Do the
+same for the Standard item. Mock the anchor click / `URL.createObjectURL` as
+needed. This replaces the earlier vague "existing E2E covers it" deferral.
+
+No DB / edge-function / RLS surface, so no pgTAP.
 
 ## Decided trade-offs
 

--- a/docs/superpowers/specs/2026-07-07-payroll-provider-export-design.md
+++ b/docs/superpowers/specs/2026-07-07-payroll-provider-export-design.md
@@ -74,8 +74,21 @@ once and reports the cash portion for taxes — no employee is paid twice.
 - **Plain numbers only** — no `$`, no thousands separators. Gusto parses these
   as numbers. Money: `cents / 100` to 2 decimals (`1250 → "12.50"`). Hours: up to
   2 decimals (`2.23`).
-- **Zero → blank cell.** Mirrors Gusto's own template (all-blank) and avoids
-  filling the sheet with `0.00` for employees who didn't work in the period.
+- **Zero handling — differs by column ownership (revised after CodeRabbit P1):**
+  Gusto's Smart Import treats a **blank cell as "leave unchanged"** and an
+  **explicit `0` as "set to 0"**.
+  - **Columns we compute** (`regular_hours`, `overtime_hours`,
+    `double_overtime_hours`, `paycheck_tips`, `cash_tips`) emit an explicit
+    `0.00` even when zero, so that correcting a value down to zero and
+    re-exporting **overwrites** the prior (stale) amount in Gusto rather than
+    silently leaving it.
+  - **Columns we never populate** (`gusto_employee_id`, `missed_break_hours`,
+    `owners_draw`, `bonus`, `commission`, `correction_payment`, `reimbursement`,
+    `personal_note`) stay **blank** (no-op) so a re-import never clobbers values
+    the user manages directly in Gusto.
+  - This split is robust under either interpretation of blank semantics, and
+    supersedes the original "zero → blank everywhere" decision (which optimized
+    for template-matching readability but risked stale values on re-import).
 - **No TOTAL row, no blank lines.** A total row would import as a phantom
   employee. Output is header + exactly one row per employee.
 - **All employees included** (roster parity with the template), even
@@ -175,10 +188,9 @@ Unit (Vitest):
   spaces, empty.
 - `buildGustoCSV`: exact header line; tips split (`paycheck_tips=tipsOwed`,
   `cash_tips=tipsPaidOut`); `title` = position; `gusto_employee_id` blank;
-  cents→dollars formatting; zero→blank; **no** TOTAL row / no trailing blank
-  line; injection escaping of a malicious name; hours formatting.
-- `PAYROLL_EXPORT_FORMATS`: contains `internal` + `gusto`, filenames well-formed.
-
+  cents→dollars formatting; computed columns emit explicit `0.00` while untracked
+  columns stay blank; **no** TOTAL row / no trailing blank line; injection
+  escaping of a malicious name; hours formatting.
 - `PAYROLL_EXPORT_FORMATS`: contains `internal` + `gusto`, filenames well-formed.
 
 **UI wiring (RTL component test, `tests/unit`):** because `handleExportCSV` is

--- a/docs/superpowers/specs/2026-07-07-payroll-provider-export-design.md
+++ b/docs/superpowers/specs/2026-07-07-payroll-provider-export-design.md
@@ -1,0 +1,172 @@
+# Design: Provider-specific payroll export (Gusto first)
+
+**Date:** 2026-07-07
+**Branch:** `feature/payroll-provider-export`
+**Status:** Approved
+
+## Problem
+
+The Payroll page (`src/pages/Payroll.tsx`) has a single "Export CSV" button that
+emits our **internal** payroll format (`exportPayrollToCSV` in
+`src/utils/payrollCalculations.ts`). Customers who run payroll through a provider
+(starting with **Gusto**) need a CSV whose columns match the provider's import
+template, so they can upload it directly instead of hand-transcribing hours and
+tips.
+
+This adds a **Gusto-format** export alongside the existing internal one, behind a
+small format registry so additional providers (ADP, etc.) can be added later
+without reworking the UI.
+
+## Scope
+
+- **In scope:** a pure client-side transform of the payroll data already loaded
+  on the page into Gusto's CSV import layout; a format registry; a format
+  picker in the Payroll page UI.
+- **Out of scope:** any Gusto API / OAuth integration (a separate, much larger
+  effort lives on `feature/gustopayroll`); storing a Gusto employee-id mapping;
+  additional providers beyond Gusto.
+
+## Gusto CSV template (target)
+
+Header, exactly (16 columns), taken from a real Gusto timesheet import template:
+
+```
+last_name,first_name,title,gusto_employee_id,regular_hours,overtime_hours,double_overtime_hours,missed_break_hours,owners_draw,bonus,commission,paycheck_tips,cash_tips,correction_payment,reimbursement,personal_note
+```
+
+One row per employee. No total row, no blank lines.
+
+## Column mapping
+
+Source type is `EmployeePayroll` (`src/utils/payrollCalculations.ts`). Money
+fields on that type are in **cents**; hours are decimal hours.
+
+| Gusto column | Source | Notes |
+|---|---|---|
+| `last_name` | split from `employeeName` | last whitespace token |
+| `first_name` | split from `employeeName` | everything before the last token |
+| `title` | `position` | informational; not a Gusto match key |
+| `gusto_employee_id` | **blank** | we have no mapping; Gusto name-matches |
+| `regular_hours` | `regularHours` | decimal hours |
+| `overtime_hours` | `overtimeHours` | decimal hours |
+| `double_overtime_hours` | `doubleTimeHours` | decimal hours |
+| `missed_break_hours` | **blank** | not tracked |
+| `owners_draw` | **blank** | not tracked |
+| `bonus` | **blank** | not tracked |
+| `commission` | **blank** | not tracked |
+| `paycheck_tips` | `tipsOwed` (cents → dollars) | tips still owed → paid via paycheck |
+| `cash_tips` | `tipsPaidOut` (cents → dollars) | already handed out in cash; reported for tax, not re-paid |
+| `correction_payment` | **blank** | not tracked |
+| `reimbursement` | **blank** | not tracked |
+| `personal_note` | **blank** | not tracked |
+
+### Tips rationale (avoids double-pay)
+
+Our model stores three figures: `totalTips` (earned), `tipsPaidOut` (already
+handed to the employee in cash), and `tipsOwed = max(0, totalTips - tipsPaidOut)`
+(still owed). Gusto's `paycheck_tips` is **added to net pay**; `cash_tips` is
+**already received** (reported so tax is withheld, but not paid again). Mapping
+`paycheck_tips ← tipsOwed` and `cash_tips ← tipsPaidOut` pays the unpaid portion
+once and reports the cash portion for taxes — no employee is paid twice.
+
+## Format rules (differ from the internal export)
+
+- **Plain numbers only** — no `$`, no thousands separators. Gusto parses these
+  as numbers. Money: `cents / 100` to 2 decimals (`1250 → "12.50"`). Hours: up to
+  2 decimals (`2.23`).
+- **Zero → blank cell.** Mirrors Gusto's own template (all-blank) and avoids
+  filling the sheet with `0.00` for employees who didn't work in the period.
+- **No TOTAL row, no blank lines.** A total row would import as a phantom
+  employee. Output is header + exactly one row per employee.
+- **All employees included** (roster parity with the template), even
+  zero-activity ones.
+- **CSV-injection safe.** Free-text cells (`last_name`, `first_name`, `title`)
+  pass through a formula-neutralizing escaper: prefix a leading `= + - @` with
+  `'` and RFC-4180 quote/double-quote as needed. Numeric cells are emitted
+  unquoted. (Reuses the existing `escapeCsvCell` pattern; an employee named
+  `=cmd|...` must not become a live formula in Excel/Sheets.)
+- **No BOM.** A UTF-8 BOM can corrupt Gusto's header parse (`﻿last_name`).
+  Matches the current internal export's blob (which also omits the BOM).
+- **Line endings:** `\n`.
+
+## Name split
+
+`splitEmployeeName(full): { firstName, lastName }`
+
+- Trim, collapse internal whitespace runs to single spaces.
+- 2+ tokens → `lastName` = last token, `firstName` = the rest joined by space
+  (e.g. `"Javier Gutiérrez" → {first: "Javier", last: "Gutiérrez"}`;
+  `"Ana Maria Cruz" → {first: "Ana Maria", last: "Cruz"}`).
+- 1 token → `firstName` = the token, `lastName` = `''` (a lone word is most
+  likely a given name; edge case, unlikely in real data).
+- Empty/whitespace → both `''`.
+
+## Architecture
+
+Two small new modules; no change to `payrollCalculations.ts` other than possibly
+exporting a helper.
+
+### `src/utils/payrollGustoExport.ts`
+- `GUSTO_CSV_HEADERS: readonly string[]` — the 16 column names above.
+- `splitEmployeeName(full: string)` — as specified.
+- `buildGustoCSV(period: PayrollPeriod): string` — the mapper. Reuses the
+  cents/number formatting and the injection-safe text escaper.
+
+### `src/utils/payrollExportFormats.ts`
+```ts
+export interface PayrollExportFormat {
+  id: 'internal' | 'gusto';
+  label: string;                                   // menu label
+  build: (period: PayrollPeriod) => string;        // CSV text
+  filename: (start: Date, end: Date) => string;    // download name
+}
+export const PAYROLL_EXPORT_FORMATS: readonly PayrollExportFormat[];
+```
+- `internal` wraps the existing `exportPayrollToCSV`; filename
+  `payroll_<start>_to_<end>.csv` (unchanged).
+- `gusto` uses `buildGustoCSV`; filename `payroll_gusto_<start>_to_<end>.csv`.
+
+### `src/pages/Payroll.tsx`
+- Replace the single `Export CSV` button with a shadcn `DropdownMenu`
+  ("Export ▾") whose items come from `PAYROLL_EXPORT_FORMATS`.
+- One shared handler: build via the selected format against the
+  page's grouped/ordered employees (same `orderedEmployees` the current handler
+  uses), blob-download with the format's filename. Keep the existing
+  disabled-when-no-employees guard.
+
+## Data flow
+
+Page state (`payrollPeriod` + sort/group) → `orderedEmployees` (already computed)
+→ `format.build({ ...payrollPeriod, employees: orderedEmployees })` → CSV string
+→ `Blob` → anchor download. No network, no persistence.
+
+## Error handling
+
+- Guarded by the existing `disabled={!payrollPeriod || employees.length === 0}`.
+- `build` is total over any `EmployeePayroll[]` (empty → header only for Gusto;
+  header + empty + TOTAL for internal, unchanged). No throw paths introduced.
+
+## Testing
+
+Unit (Vitest):
+- `splitEmployeeName`: multi-token, single-token, accented, lowercase, extra
+  spaces, empty.
+- `buildGustoCSV`: exact header line; tips split (`paycheck_tips=tipsOwed`,
+  `cash_tips=tipsPaidOut`); `title` = position; `gusto_employee_id` blank;
+  cents→dollars formatting; zero→blank; **no** TOTAL row / no trailing blank
+  line; injection escaping of a malicious name; hours formatting.
+- `PAYROLL_EXPORT_FORMATS`: contains `internal` + `gusto`, filenames well-formed.
+
+No DB / edge-function / RLS surface, so no pgTAP. UI wiring covered by the
+existing Payroll page E2E path (button → dropdown is a minor structural change).
+
+## Decided trade-offs
+
+- **`gusto_employee_id` left blank** (per product owner): Gusto falls back to
+  name matching. Accepted risk: employees whose name differs between systems (or
+  duplicates) won't auto-match and need manual resolution in Gusto. A stored
+  mapping is deferred to the API-integration effort.
+- **`title = position`** (per product owner): our labels won't equal Gusto's
+  titles, but `title` is informational only, so a mismatch is harmless.
+- **Registry kept to two entries**: no speculative ADP/Paychex builders — the
+  seam exists; providers are added when actually needed.

--- a/src/components/payroll/PayrollExportMenu.tsx
+++ b/src/components/payroll/PayrollExportMenu.tsx
@@ -1,0 +1,62 @@
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { ChevronDown, Download } from 'lucide-react';
+
+import type { PayrollPeriod } from '@/utils/payrollCalculations';
+import type { PayrollExportFormat } from '@/utils/payrollExportFormats';
+import { PAYROLL_EXPORT_FORMATS } from '@/utils/payrollExportFormats';
+
+interface PayrollExportMenuProps {
+  /** The ordered/grouped period to export, or null while loading/empty. */
+  period: PayrollPeriod | null;
+  start: Date;
+  end: Date;
+  disabled?: boolean;
+}
+
+/**
+ * "Export ▾" dropdown offering each registered payroll export format.
+ * Mirrors the export-picker precedent in src/pages/Inventory.tsx.
+ */
+export function PayrollExportMenu({ period, start, end, disabled }: PayrollExportMenuProps) {
+  const handleExport = (format: PayrollExportFormat) => {
+    if (!period) return;
+    const csv = format.build(period);
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = format.filename(start, end);
+    a.click();
+    // Revoke after a tick so the browser can schedule the download first.
+    setTimeout(() => window.URL.revokeObjectURL(url), 100);
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button disabled={disabled}>
+          <Download className="h-4 w-4 mr-2" aria-hidden="true" />
+          Export
+          <ChevronDown className="h-4 w-4 ml-2" aria-hidden="true" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="bg-background z-50">
+        {PAYROLL_EXPORT_FORMATS.map((format) => (
+          <DropdownMenuItem
+            key={format.id}
+            className="cursor-pointer"
+            onClick={() => handleExport(format)}
+          >
+            {format.label}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/payroll/PayrollExportMenu.tsx
+++ b/src/components/payroll/PayrollExportMenu.tsx
@@ -24,14 +24,14 @@ interface PayrollExportMenuProps {
  * Mirrors the export-picker precedent in src/pages/Inventory.tsx.
  */
 export function PayrollExportMenu({ period, start, end, disabled }: PayrollExportMenuProps) {
-  const handleExport = (format: PayrollExportFormat) => {
+  const handleExport = (exportFormat: PayrollExportFormat) => {
     if (!period) return;
-    const csv = format.build(period);
+    const csv = exportFormat.build(period);
     const blob = new Blob([csv], { type: 'text/csv' });
     const url = window.URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = format.filename(start, end);
+    a.download = exportFormat.filename(start, end);
     a.click();
     // Revoke after a tick so the browser can schedule the download first.
     setTimeout(() => window.URL.revokeObjectURL(url), 100);
@@ -47,13 +47,13 @@ export function PayrollExportMenu({ period, start, end, disabled }: PayrollExpor
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="bg-background z-50">
-        {PAYROLL_EXPORT_FORMATS.map((format) => (
+        {PAYROLL_EXPORT_FORMATS.map((exportFormat) => (
           <DropdownMenuItem
-            key={format.id}
+            key={exportFormat.id}
             className="cursor-pointer"
-            onClick={() => handleExport(format)}
+            onClick={() => handleExport(exportFormat)}
           >
-            {format.label}
+            {exportFormat.label}
           </DropdownMenuItem>
         ))}
       </DropdownMenuContent>

--- a/src/components/payroll/PayrollExportMenu.tsx
+++ b/src/components/payroll/PayrollExportMenu.tsx
@@ -15,10 +15,10 @@ import { PAYROLL_EXPORT_FORMATS } from '@/utils/payrollExportFormats';
 
 interface PayrollExportMenuProps {
   /** The ordered/grouped period to export, or null while loading/empty. */
-  period: PayrollPeriod | null;
-  start: Date;
-  end: Date;
-  disabled?: boolean;
+  readonly period: PayrollPeriod | null;
+  readonly start: Date;
+  readonly end: Date;
+  readonly disabled?: boolean;
 }
 
 /**

--- a/src/components/payroll/PayrollExportMenu.tsx
+++ b/src/components/payroll/PayrollExportMenu.tsx
@@ -7,6 +7,8 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { ChevronDown, Download } from 'lucide-react';
 
+import { useToast } from '@/hooks/use-toast';
+
 import type { PayrollPeriod } from '@/utils/payrollCalculations';
 import type { PayrollExportFormat } from '@/utils/payrollExportFormats';
 import { PAYROLL_EXPORT_FORMATS } from '@/utils/payrollExportFormats';
@@ -24,9 +26,21 @@ interface PayrollExportMenuProps {
  * Mirrors the export-picker precedent in src/pages/Inventory.tsx.
  */
 export function PayrollExportMenu({ period, start, end, disabled }: PayrollExportMenuProps) {
+  const { toast } = useToast();
+
   const handleExport = (exportFormat: PayrollExportFormat) => {
-    if (!period) return;
-    const csv = exportFormat.build(period);
+    if (!period) {
+      toast({ title: 'Nothing to export', description: 'There is no payroll data for this period yet.', variant: 'destructive' });
+      return;
+    }
+    let csv: string;
+    try {
+      csv = exportFormat.build(period);
+    } catch (err) {
+      console.error('Payroll export failed', err);
+      toast({ title: 'Export failed', description: 'Could not build the export file. Please try again.', variant: 'destructive' });
+      return;
+    }
     const blob = new Blob([csv], { type: 'text/csv' });
     const url = window.URL.createObjectURL(blob);
     const a = document.createElement('a');

--- a/src/pages/Payroll.tsx
+++ b/src/pages/Payroll.tsx
@@ -17,17 +17,16 @@ import { FeatureGate } from '@/components/subscription';
 import {
   formatCurrency,
   formatHours,
-  exportPayrollToCSV,
   EmployeePayroll,
 } from '@/utils/payrollCalculations';
 import { sortPayrollRows, groupPayrollRows, computePayrollTotals, regularPayDisplayValue, type PayrollSortKey, type SortDirection, type PayrollGroupMode } from '@/utils/payrollTableView';
 import { isPerJobContractor } from '@/utils/compensationCalculations';
 import { AddManualPaymentDialog } from '@/components/payroll/AddManualPaymentDialog';
 import { AdjustOvertimeDialog } from '@/components/payroll/AdjustOvertimeDialog';
+import { PayrollExportMenu } from '@/components/payroll/PayrollExportMenu';
 import {
   DollarSign,
   Clock,
-  Download,
   Calendar,
   RefreshCw,
   TrendingUp,
@@ -422,23 +421,14 @@ const Payroll = () => {
     setOtSelectedEmployee(null);
   };
 
-  const handleExportCSV = () => {
-    if (!payrollPeriod) return;
-    const orderedEmployees = payrollGroups.flatMap((g) => g.rows);
-    const csv = exportPayrollToCSV({ ...payrollPeriod, employees: orderedEmployees });
-    const blob = new Blob([csv], { type: 'text/csv' });
-    const url = window.URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `payroll_${format(start, 'yyyy-MM-dd')}_to_${format(end, 'yyyy-MM-dd')}.csv`;
-    a.click();
-    // Revoke after a tick so the browser can schedule the download first.
-    setTimeout(() => window.URL.revokeObjectURL(url), 100);
-  };
-
   const payrollGroups = useMemo(
     () => (payrollPeriod ? groupPayrollRows(sortPayrollRows(payrollPeriod.employees, sortKey, sortDir), groupBy) : []),
     [payrollPeriod, sortKey, sortDir, groupBy],
+  );
+
+  const orderedPeriod = useMemo(
+    () => (payrollPeriod ? { ...payrollPeriod, employees: payrollGroups.flatMap((g) => g.rows) } : null),
+    [payrollPeriod, payrollGroups],
   );
 
   const grandTotals = useMemo(
@@ -746,13 +736,12 @@ const Payroll = () => {
                   </SelectContent>
                 </Select>
               </div>
-              <Button
-                onClick={handleExportCSV}
+              <PayrollExportMenu
+                period={orderedPeriod}
+                start={start}
+                end={end}
                 disabled={!payrollPeriod || payrollPeriod.employees.length === 0}
-              >
-                <Download className="h-4 w-4 mr-2" />
-                Export CSV
-              </Button>
+              />
             </div>
           </div>
         </CardHeader>

--- a/src/utils/payrollCalculations.ts
+++ b/src/utils/payrollCalculations.ts
@@ -648,14 +648,19 @@ export function calculatePayrollPeriod(
  * - Doubles embedded quotes per RFC 4180
  * - Strips carriage returns and newlines to prevent row splitting
  * - Prefixes formula-triggering characters (=, +, -, @) with a single quote
- *   to block spreadsheet formula injection
+ *   to block spreadsheet formula injection. Leading whitespace/tab characters
+ *   before a trigger char are also neutralized, since Excel/Sheets can still
+ *   parse `\t=cmd(...)` or ` =cmd(...)` as a live formula.
  * Returns the value wrapped in double quotes.
+ *
+ * Exported for reuse by other export formats (e.g. `payrollGustoExport.ts`)
+ * so the injection-safety fix stays in one place.
  */
-function escapeCsvCell(value: string | null | undefined): string {
+export function escapeCsvCell(value: string | null | undefined): string {
   const raw = value ?? '';
   const noNewlines = raw.replace(/\r?\n/g, ' ');
   const escapedQuotes = noNewlines.replace(/"/g, '""');
-  const neutralized = /^[=+\-@]/.test(escapedQuotes) ? `'${escapedQuotes}` : escapedQuotes;
+  const neutralized = /^\s*[=+\-@]/.test(escapedQuotes) ? `'${escapedQuotes}` : escapedQuotes;
   return `"${neutralized}"`;
 }
 

--- a/src/utils/payrollExportFormats.ts
+++ b/src/utils/payrollExportFormats.ts
@@ -1,0 +1,36 @@
+import { format } from 'date-fns';
+
+import type { PayrollPeriod } from '@/utils/payrollCalculations';
+import { exportPayrollToCSV } from '@/utils/payrollCalculations';
+import { buildGustoCSV } from '@/utils/payrollGustoExport';
+
+/** A selectable payroll export format (internal or a payroll provider). */
+export interface PayrollExportFormat {
+  id: 'internal' | 'gusto';
+  /** Menu label shown in the Export dropdown. */
+  label: string;
+  /** Serialize a payroll period to CSV text for this format. */
+  build: (period: PayrollPeriod) => string;
+  /** Download filename for a given period date range. */
+  filename: (start: Date, end: Date) => string;
+}
+
+/** Shared so the internal and provider filenames can't drift in date formatting. */
+function formatDateRange(start: Date, end: Date): string {
+  return `${format(start, 'yyyy-MM-dd')}_to_${format(end, 'yyyy-MM-dd')}`;
+}
+
+export const PAYROLL_EXPORT_FORMATS: readonly PayrollExportFormat[] = [
+  {
+    id: 'internal',
+    label: 'Standard CSV',
+    build: exportPayrollToCSV,
+    filename: (start, end) => `payroll_${formatDateRange(start, end)}.csv`,
+  },
+  {
+    id: 'gusto',
+    label: 'Gusto CSV',
+    build: buildGustoCSV,
+    filename: (start, end) => `payroll_gusto_${formatDateRange(start, end)}.csv`,
+  },
+];

--- a/src/utils/payrollGustoExport.ts
+++ b/src/utils/payrollGustoExport.ts
@@ -1,3 +1,5 @@
+import type { EmployeePayroll, PayrollPeriod } from '@/utils/payrollCalculations';
+
 /**
  * Gusto timesheet-import column headers, in the exact order Gusto expects.
  * Pinned by test — do not reorder or rename without a matching Gusto template.
@@ -35,4 +37,63 @@ export function splitEmployeeName(full: string): { firstName: string; lastName: 
     firstName: tokens.slice(0, -1).join(' '),
     lastName: tokens[tokens.length - 1],
   };
+}
+
+/**
+ * Escape a free-text CSV cell, Gusto-safe: RFC-4180 quote/double-quote and
+ * neutralize a leading `= + - @` (formula injection) with a leading `'`.
+ * Mirrors the internal export's `escapeCsvCell` (always quotes) but is
+ * duplicated locally so this module has no coupling to
+ * `payrollCalculations.ts` formatting.
+ */
+function escapeGustoCsvCell(value: string | null | undefined): string {
+  const raw = value ?? '';
+  const noNewlines = raw.replace(/\r?\n/g, ' ');
+  const escapedQuotes = noNewlines.replace(/"/g, '""');
+  const neutralized = /^[=+\-@]/.test(escapedQuotes) ? `'${escapedQuotes}` : escapedQuotes;
+  return `"${neutralized}"`;
+}
+
+/** Format cents as a plain dollar string with 2 decimals; zero → blank. */
+function formatGustoMoney(cents: number): string {
+  if (!cents) return '';
+  return (cents / 100).toFixed(2);
+}
+
+/** Format decimal hours to up to 2 decimals; zero → blank. */
+function formatGustoHours(hours: number): string {
+  if (!hours) return '';
+  return hours.toFixed(2);
+}
+
+/**
+ * Build the Gusto timesheet-import CSV for a payroll period: header + exactly
+ * one row per employee (no TOTAL row, no trailing blank line). See
+ * docs/superpowers/specs/2026-07-07-payroll-provider-export-design.md for the
+ * full column mapping and tips rationale.
+ */
+export function buildGustoCSV(period: PayrollPeriod): string {
+  const rows = period.employees.map((ep: EmployeePayroll) => {
+    const { firstName, lastName } = splitEmployeeName(ep.employeeName);
+    return [
+      escapeGustoCsvCell(lastName),
+      escapeGustoCsvCell(firstName),
+      escapeGustoCsvCell(ep.position),
+      '', // gusto_employee_id — no mapping; Gusto name-matches
+      formatGustoHours(ep.regularHours),
+      formatGustoHours(ep.overtimeHours),
+      formatGustoHours(ep.doubleTimeHours),
+      '', // missed_break_hours — not tracked
+      '', // owners_draw — not tracked
+      '', // bonus — not tracked
+      '', // commission — not tracked
+      formatGustoMoney(ep.tipsOwed),
+      formatGustoMoney(ep.tipsPaidOut),
+      '', // correction_payment — not tracked
+      '', // reimbursement — not tracked
+      '', // personal_note — not tracked
+    ].join(',');
+  });
+
+  return [GUSTO_CSV_HEADERS.join(','), ...rows].join('\n');
 }

--- a/src/utils/payrollGustoExport.ts
+++ b/src/utils/payrollGustoExport.ts
@@ -1,3 +1,4 @@
+import { escapeCsvCell } from '@/utils/payrollCalculations';
 import type { EmployeePayroll, PayrollPeriod } from '@/utils/payrollCalculations';
 
 /**
@@ -39,21 +40,6 @@ export function splitEmployeeName(full: string): { firstName: string; lastName: 
   };
 }
 
-/**
- * Escape a free-text CSV cell, Gusto-safe: RFC-4180 quote/double-quote and
- * neutralize a leading `= + - @` (formula injection) with a leading `'`.
- * Mirrors the internal export's `escapeCsvCell` (always quotes) but is
- * duplicated locally so this module has no coupling to
- * `payrollCalculations.ts` formatting.
- */
-function escapeGustoCsvCell(value: string | null | undefined): string {
-  const raw = value ?? '';
-  const noNewlines = raw.replace(/\r?\n/g, ' ');
-  const escapedQuotes = noNewlines.replace(/"/g, '""');
-  const neutralized = /^[=+\-@]/.test(escapedQuotes) ? `'${escapedQuotes}` : escapedQuotes;
-  return `"${neutralized}"`;
-}
-
 /** Format cents as a plain dollar string with 2 decimals; zero → blank. */
 function formatGustoMoney(cents: number): string {
   if (!cents) return '';
@@ -76,9 +62,9 @@ export function buildGustoCSV(period: PayrollPeriod): string {
   const rows = period.employees.map((ep: EmployeePayroll) => {
     const { firstName, lastName } = splitEmployeeName(ep.employeeName);
     return [
-      escapeGustoCsvCell(lastName),
-      escapeGustoCsvCell(firstName),
-      escapeGustoCsvCell(ep.position),
+      escapeCsvCell(lastName),
+      escapeCsvCell(firstName),
+      escapeCsvCell(ep.position),
       '', // gusto_employee_id — no mapping; Gusto name-matches
       formatGustoHours(ep.regularHours),
       formatGustoHours(ep.overtimeHours),

--- a/src/utils/payrollGustoExport.ts
+++ b/src/utils/payrollGustoExport.ts
@@ -1,0 +1,38 @@
+/**
+ * Gusto timesheet-import column headers, in the exact order Gusto expects.
+ * Pinned by test — do not reorder or rename without a matching Gusto template.
+ */
+export const GUSTO_CSV_HEADERS = [
+  'last_name',
+  'first_name',
+  'title',
+  'gusto_employee_id',
+  'regular_hours',
+  'overtime_hours',
+  'double_overtime_hours',
+  'missed_break_hours',
+  'owners_draw',
+  'bonus',
+  'commission',
+  'paycheck_tips',
+  'cash_tips',
+  'correction_payment',
+  'reimbursement',
+  'personal_note',
+] as const;
+
+/**
+ * Split our single `employeeName` ("First Last") into Gusto's separate
+ * last_name / first_name columns. Heuristic: the last whitespace-delimited
+ * token is the last name; everything before it is the first name. A lone token
+ * is treated as a first name (Gusto still name-matches). Empty → two blanks.
+ */
+export function splitEmployeeName(full: string): { firstName: string; lastName: string } {
+  const tokens = (full ?? '').trim().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return { firstName: '', lastName: '' };
+  if (tokens.length === 1) return { firstName: tokens[0], lastName: '' };
+  return {
+    firstName: tokens.slice(0, -1).join(' '),
+    lastName: tokens[tokens.length - 1],
+  };
+}

--- a/src/utils/payrollGustoExport.ts
+++ b/src/utils/payrollGustoExport.ts
@@ -40,15 +40,23 @@ export function splitEmployeeName(full: string): { firstName: string; lastName: 
   };
 }
 
-/** Format cents as a plain dollar string with 2 decimals; zero → blank. */
+/**
+ * Format cents as a plain dollar string with 2 decimals (no `$`/separators).
+ * Emits an explicit "0.00" for zero — NOT blank — so that correcting a value
+ * down to zero and re-exporting overwrites the prior amount in Gusto. Gusto's
+ * Smart Import treats a blank cell as "leave unchanged" and an explicit 0 as
+ * "set to 0". Only used for columns we compute (tips); columns we don't manage
+ * stay blank in buildGustoCSV so we never clobber values kept in Gusto.
+ */
 function formatGustoMoney(cents: number): string {
-  if (!cents) return '';
   return (cents / 100).toFixed(2);
 }
 
-/** Format decimal hours to up to 2 decimals; zero → blank. */
+/**
+ * Format decimal hours to 2 decimals. Emits an explicit "0.00" for zero — NOT
+ * blank — for the same overwrite-on-re-import reason as formatGustoMoney.
+ */
 function formatGustoHours(hours: number): string {
-  if (!hours) return '';
   return hours.toFixed(2);
 }
 

--- a/tests/e2e/employee-payroll.spec.ts
+++ b/tests/e2e/employee-payroll.spec.ts
@@ -456,8 +456,9 @@ test.describe('Payroll Page Functionality', () => {
     await page.goto('/payroll');
     await expect(page.getByRole('heading', { name: 'Payroll', exact: true })).toBeVisible({ timeout: 10000 });
 
-    // Export button should exist (may be disabled without data)
-    const exportButton = page.getByRole('button', { name: /export csv/i });
+    // Export dropdown trigger should exist (disabled here since this fresh
+    // account has no payroll data yet — see PayrollExportMenu's disabled prop).
+    const exportButton = page.getByRole('button', { name: /^export$/i });
     await expect(exportButton).toBeVisible();
   });
 });

--- a/tests/unit/PayrollExportMenu.test.tsx
+++ b/tests/unit/PayrollExportMenu.test.tsx
@@ -6,6 +6,12 @@ import userEvent from '@testing-library/user-event';
 import { PayrollExportMenu } from '@/components/payroll/PayrollExportMenu';
 import { GUSTO_CSV_HEADERS } from '@/utils/payrollGustoExport';
 import type { EmployeePayroll, PayrollPeriod } from '@/utils/payrollCalculations';
+import * as payrollExportFormats from '@/utils/payrollExportFormats';
+
+const toastMock = vi.fn();
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
 
 function employee(overrides: Partial<EmployeePayroll> = {}): EmployeePayroll {
   return {
@@ -39,7 +45,10 @@ function stubDownload() {
   return { getBlob: () => blob, getDownload: () => download };
 }
 
-afterEach(() => vi.restoreAllMocks());
+afterEach(() => {
+  vi.restoreAllMocks();
+  toastMock.mockClear();
+});
 
 /** jsdom's Blob has no .text(); read via the arrayBuffer() polyfill in tests/setup.ts. */
 async function readBlobText(blob: Blob): Promise<string> {
@@ -77,5 +86,34 @@ describe('PayrollExportMenu', () => {
   it('disables the trigger when there are no employees to export', () => {
     render(<PayrollExportMenu period={null} start={new Date(2026, 5, 8)} end={new Date(2026, 5, 14)} disabled />);
     expect(screen.getByRole('button', { name: /export/i })).toBeDisabled();
+  });
+
+  it('surfaces a toast instead of silently no-oping when period is null and the caller forgot disabled', async () => {
+    const user = userEvent.setup();
+    // Intentionally omit `disabled` even though period is null, to exercise the guard clause directly.
+    render(<PayrollExportMenu period={null} start={new Date(2026, 5, 8)} end={new Date(2026, 5, 14)} />);
+
+    await user.click(screen.getByRole('button', { name: /export/i }));
+    await user.click(await screen.findByText('Gusto CSV'));
+
+    expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({ variant: 'destructive' }));
+  });
+
+  it('surfaces a toast instead of throwing when the export format builder throws', async () => {
+    const dl = stubDownload();
+    const user = userEvent.setup();
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(payrollExportFormats.PAYROLL_EXPORT_FORMATS[0], 'build').mockImplementation(() => {
+      throw new Error('boom');
+    });
+
+    render(<PayrollExportMenu period={period()} start={new Date(2026, 5, 8)} end={new Date(2026, 5, 14)} />);
+
+    await user.click(screen.getByRole('button', { name: /export/i }));
+    await user.click(await screen.findByText(payrollExportFormats.PAYROLL_EXPORT_FORMATS[0].label));
+
+    expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({ variant: 'destructive' }));
+    expect(dl.getDownload()).toBe('');
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/tests/unit/PayrollExportMenu.test.tsx
+++ b/tests/unit/PayrollExportMenu.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { PayrollExportMenu } from '@/components/payroll/PayrollExportMenu';
+import { GUSTO_CSV_HEADERS } from '@/utils/payrollGustoExport';
+import type { EmployeePayroll, PayrollPeriod } from '@/utils/payrollCalculations';
+
+function employee(overrides: Partial<EmployeePayroll> = {}): EmployeePayroll {
+  return {
+    employeeId: 'e1', employeeName: 'Oscar Estrada', position: 'Server', area: null,
+    compensationType: 'hourly', hourlyRate: 1000, regularHours: 2.23, overtimeHours: 0,
+    doubleTimeHours: 0, doubleTimePay: 0, dailyOvertimeHours: 0, weeklyOvertimeHours: 0,
+    regularPay: 2227, overtimePay: 0, salaryPay: 0, contractorPay: 0, dailyRatePay: 0,
+    manualPayments: [], manualPaymentsTotal: 0, grossPay: 2227, totalTips: 0,
+    tipsPaidOut: 0, tipsOwed: 0, totalPay: 2227, ...overrides,
+  };
+}
+
+function period(): PayrollPeriod {
+  return {
+    startDate: new Date(2026, 5, 8), endDate: new Date(2026, 5, 14),
+    employees: [employee()], totalRegularHours: 2.23, totalOvertimeHours: 0,
+    totalDoubleTimeHours: 0, totalGrossPay: 2227, totalTips: 0, totalTipsPaidOut: 0,
+    totalTipsOwed: 0,
+  };
+}
+
+/** Capture the downloaded blob + filename by stubbing URL + anchor.click. */
+function stubDownload() {
+  let blob: Blob | undefined;
+  let download = '';
+  vi.spyOn(URL, 'createObjectURL').mockImplementation((b) => { blob = b as Blob; return 'blob:mock'; });
+  vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+  vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (this: HTMLAnchorElement) {
+    download = this.download;
+  });
+  return { getBlob: () => blob, getDownload: () => download };
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+/** jsdom's Blob has no .text(); read via the arrayBuffer() polyfill in tests/setup.ts. */
+async function readBlobText(blob: Blob): Promise<string> {
+  const buffer = await blob.arrayBuffer();
+  return new TextDecoder().decode(buffer);
+}
+
+describe('PayrollExportMenu', () => {
+  it('exports the Gusto format with the gusto filename and header', async () => {
+    const dl = stubDownload();
+    const user = userEvent.setup();
+    render(<PayrollExportMenu period={period()} start={new Date(2026, 5, 8)} end={new Date(2026, 5, 14)} />);
+
+    await user.click(screen.getByRole('button', { name: /export/i }));
+    await user.click(await screen.findByText('Gusto CSV'));
+
+    expect(dl.getDownload()).toBe('payroll_gusto_2026-06-08_to_2026-06-14.csv');
+    const text = await readBlobText(dl.getBlob()!);
+    expect(text.split('\n')[0]).toBe(GUSTO_CSV_HEADERS.join(','));
+  });
+
+  it('exports the Standard format with the standard filename and header', async () => {
+    const dl = stubDownload();
+    const user = userEvent.setup();
+    render(<PayrollExportMenu period={period()} start={new Date(2026, 5, 8)} end={new Date(2026, 5, 14)} />);
+
+    await user.click(screen.getByRole('button', { name: /export/i }));
+    await user.click(await screen.findByText('Standard CSV'));
+
+    expect(dl.getDownload()).toBe('payroll_2026-06-08_to_2026-06-14.csv');
+    const text = await readBlobText(dl.getBlob()!);
+    expect(text.split('\n')[0]).toContain('Employee Name');
+  });
+
+  it('disables the trigger when there are no employees to export', () => {
+    render(<PayrollExportMenu period={null} start={new Date(2026, 5, 8)} end={new Date(2026, 5, 14)} disabled />);
+    expect(screen.getByRole('button', { name: /export/i })).toBeDisabled();
+  });
+});

--- a/tests/unit/payrollCalculations.test.ts
+++ b/tests/unit/payrollCalculations.test.ts
@@ -7,6 +7,7 @@ import {
   calculateEmployeePay,
   calculatePayrollPeriod,
   exportPayrollToCSV,
+  escapeCsvCell,
   type ManualPayment,
   type WorkPeriod,
 } from '@/utils/payrollCalculations';
@@ -594,6 +595,29 @@ describe('payrollCalculations - Additional Coverage', () => {
       expect(result.totalTips).toBe(50000);
       expect(result.totalTipsPaidOut).toBe(0);
       expect(result.totalTipsOwed).toBe(50000);
+    });
+  });
+
+  describe('escapeCsvCell — CSV injection safety', () => {
+    it('neutralizes a leading formula-trigger character', () => {
+      expect(escapeCsvCell('=cmd')).toBe('"\'=cmd"');
+      expect(escapeCsvCell('+1+1')).toBe('"\'+1+1"');
+      expect(escapeCsvCell('-1-1')).toBe('"\'-1-1"');
+      expect(escapeCsvCell('@SUM(A1)')).toBe('"\'@SUM(A1)"');
+    });
+
+    it('neutralizes a formula-trigger character preceded by leading whitespace/tab', () => {
+      // Excel/Sheets can still parse a leading tab or space before "=" as a live formula.
+      expect(escapeCsvCell('\t=HYPERLINK("https://evil")')).toBe(
+        '"\'\t=HYPERLINK(""https://evil"")"'
+      );
+      expect(escapeCsvCell('  =cmd')).toBe('"\'  =cmd"');
+    });
+
+    it('leaves non-formula text untouched aside from quoting', () => {
+      expect(escapeCsvCell('Alice')).toBe('"Alice"');
+      expect(escapeCsvCell(null)).toBe('""');
+      expect(escapeCsvCell(undefined)).toBe('""');
     });
   });
 

--- a/tests/unit/payrollExportFormats.test.ts
+++ b/tests/unit/payrollExportFormats.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { PAYROLL_EXPORT_FORMATS } from '@/utils/payrollExportFormats';
+import { GUSTO_CSV_HEADERS } from '@/utils/payrollGustoExport';
+import type { PayrollPeriod } from '@/utils/payrollCalculations';
+
+function emptyPeriod(): PayrollPeriod {
+  return {
+    startDate: new Date(2026, 5, 8),
+    endDate: new Date(2026, 5, 14),
+    employees: [],
+    totalRegularHours: 0,
+    totalOvertimeHours: 0,
+    totalDoubleTimeHours: 0,
+    totalGrossPay: 0,
+    totalTips: 0,
+    totalTipsPaidOut: 0,
+    totalTipsOwed: 0,
+  };
+}
+
+describe('PAYROLL_EXPORT_FORMATS', () => {
+  it('exposes the internal and gusto formats in order', () => {
+    expect(PAYROLL_EXPORT_FORMATS.map((f) => f.id)).toEqual(['internal', 'gusto']);
+  });
+
+  it('labels are human-readable', () => {
+    const byId = Object.fromEntries(PAYROLL_EXPORT_FORMATS.map((f) => [f.id, f.label]));
+    expect(byId.internal).toBe('Standard CSV');
+    expect(byId.gusto).toBe('Gusto CSV');
+  });
+
+  it('builds filenames from the period date range', () => {
+    const start = new Date(2026, 5, 8);
+    const end = new Date(2026, 5, 14);
+    const byId = Object.fromEntries(PAYROLL_EXPORT_FORMATS.map((f) => [f.id, f]));
+    expect(byId.internal.filename(start, end)).toBe('payroll_2026-06-08_to_2026-06-14.csv');
+    expect(byId.gusto.filename(start, end)).toBe('payroll_gusto_2026-06-08_to_2026-06-14.csv');
+  });
+
+  it('gusto.build produces the Gusto header; internal.build produces the internal header', () => {
+    const byId = Object.fromEntries(PAYROLL_EXPORT_FORMATS.map((f) => [f.id, f]));
+    expect(byId.gusto.build(emptyPeriod()).split('\n')[0]).toBe(GUSTO_CSV_HEADERS.join(','));
+    expect(byId.internal.build(emptyPeriod()).split('\n')[0]).toContain('Employee Name');
+  });
+});

--- a/tests/unit/payrollGustoExport.test.ts
+++ b/tests/unit/payrollGustoExport.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { GUSTO_CSV_HEADERS, splitEmployeeName } from '@/utils/payrollGustoExport';
+
+describe('GUSTO_CSV_HEADERS', () => {
+  it('matches the Gusto import template exactly (16 columns, in order)', () => {
+    expect(GUSTO_CSV_HEADERS.join(',')).toBe(
+      'last_name,first_name,title,gusto_employee_id,regular_hours,overtime_hours,double_overtime_hours,missed_break_hours,owners_draw,bonus,commission,paycheck_tips,cash_tips,correction_payment,reimbursement,personal_note',
+    );
+  });
+});
+
+describe('splitEmployeeName', () => {
+  it('splits "First Last" into first + last', () => {
+    expect(splitEmployeeName('Jose Delgado')).toEqual({ firstName: 'Jose', lastName: 'Delgado' });
+  });
+  it('treats the last token as the last name and the rest as the first name', () => {
+    expect(splitEmployeeName('Ana Maria Cruz')).toEqual({ firstName: 'Ana Maria', lastName: 'Cruz' });
+  });
+  it('preserves accented characters', () => {
+    expect(splitEmployeeName('Javier Gutiérrez')).toEqual({ firstName: 'Javier', lastName: 'Gutiérrez' });
+  });
+  it('keeps original casing (does not normalize)', () => {
+    expect(splitEmployeeName('Shy harrison')).toEqual({ firstName: 'Shy', lastName: 'harrison' });
+  });
+  it('collapses extra internal/leading/trailing whitespace', () => {
+    expect(splitEmployeeName('  Colby   Mullaley  ')).toEqual({ firstName: 'Colby', lastName: 'Mullaley' });
+  });
+  it('puts a single token in firstName with a blank lastName', () => {
+    expect(splitEmployeeName('Cher')).toEqual({ firstName: 'Cher', lastName: '' });
+  });
+  it('returns two blanks for empty/whitespace input', () => {
+    expect(splitEmployeeName('   ')).toEqual({ firstName: '', lastName: '' });
+    expect(splitEmployeeName('')).toEqual({ firstName: '', lastName: '' });
+  });
+});

--- a/tests/unit/payrollGustoExport.test.ts
+++ b/tests/unit/payrollGustoExport.test.ts
@@ -155,4 +155,14 @@ describe('buildGustoCSV', () => {
     // single token → lastName blank, firstName carries the neutralized formula; title has an embedded comma + quotes
     expect(row).toBe('"","\'=cmd","Line, ""Cook""",,,,,,,,,,,,,');
   });
+
+  it('is CSV-injection safe against a leading-whitespace/tab formula bypass', () => {
+    // `position` is not trimmed by a name-splitting heuristic, so the leading
+    // tab survives into the escaper and must still be neutralized there.
+    const csv = buildGustoCSV(period([
+      employee({ employeeName: 'Ann Lee', position: '\t=HYPERLINK("https://evil")' }),
+    ]));
+    const [, row] = csv.split('\n');
+    expect(row).toBe('"Lee","Ann","\'\t=HYPERLINK(""https://evil"")",,,,,,,,,,,,,');
+  });
 });

--- a/tests/unit/payrollGustoExport.test.ts
+++ b/tests/unit/payrollGustoExport.test.ts
@@ -82,7 +82,7 @@ describe('buildGustoCSV', () => {
       employee({ employeeName: 'Jose Delgado', position: 'Server' }),
     ]));
     const [, row] = csv.split('\n');
-    expect(row).toBe('"Delgado","Jose","Server",,,,,,,,,,,,,');
+    expect(row).toBe('"Delgado","Jose","Server",,0.00,0.00,0.00,,,,,0.00,0.00,,,');
   });
 
   it('splits tips: paycheck_tips = tipsOwed, cash_tips = tipsPaidOut (cents → dollars)', () => {
@@ -120,19 +120,28 @@ describe('buildGustoCSV', () => {
     expect(cols[6]).toBe('1.10');
   });
 
-  it('renders zero money/hours values as blank cells, not "0" or "0.00"', () => {
+  it('renders zero for the columns we compute as an explicit "0.00" (overwrites on re-import), never blank', () => {
+    // Gusto Smart Import treats a blank cell as "leave unchanged" and an
+    // explicit 0 as "set to 0". Columns we compute must therefore emit 0.00 so
+    // that correcting a value down to zero clears the prior amount in Gusto.
     const csv = buildGustoCSV(period([
       employee({ employeeName: 'Ann Lee', regularHours: 0, overtimeHours: 0, doubleTimeHours: 0, tipsOwed: 0, tipsPaidOut: 0 }),
     ]));
     const [, row] = csv.split('\n');
-    expect(row).toBe('"Lee","Ann","",,,,,,,,,,,,,');
+    const cols = row.split(',');
+    expect(cols[4]).toBe('0.00');  // regular_hours
+    expect(cols[5]).toBe('0.00');  // overtime_hours
+    expect(cols[6]).toBe('0.00');  // double_overtime_hours
+    expect(cols[11]).toBe('0.00'); // paycheck_tips
+    expect(cols[12]).toBe('0.00'); // cash_tips
   });
 
-  it('leaves missed_break_hours, owners_draw, bonus, commission, correction_payment, reimbursement, personal_note blank', () => {
+  it('keeps untracked columns blank even when adjacent computed columns are 0.00 (no-op, never clobbers Gusto-managed values)', () => {
+    // The columns we never populate (owners_draw, bonus, reimbursement, …) stay
+    // blank so a re-import does NOT overwrite values the user manages in Gusto.
     const csv = buildGustoCSV(period([employee({ employeeName: 'Ann Lee' })]));
     const [, row] = csv.split('\n');
     const cols = row.split(',');
-    // indices: 7 missed_break_hours, 8 owners_draw, 9 bonus, 10 commission, 13 correction_payment, 14 reimbursement, 15 personal_note
     expect([cols[7], cols[8], cols[9], cols[10], cols[13], cols[14], cols[15]]).toEqual(['', '', '', '', '', '', '']);
   });
 
@@ -153,7 +162,7 @@ describe('buildGustoCSV', () => {
     ]));
     const [, row] = csv.split('\n');
     // single token → lastName blank, firstName carries the neutralized formula; title has an embedded comma + quotes
-    expect(row).toBe('"","\'=cmd","Line, ""Cook""",,,,,,,,,,,,,');
+    expect(row).toBe('"","\'=cmd","Line, ""Cook""",,0.00,0.00,0.00,,,,,0.00,0.00,,,');
   });
 
   it('is CSV-injection safe against a leading-whitespace/tab formula bypass', () => {
@@ -163,6 +172,6 @@ describe('buildGustoCSV', () => {
       employee({ employeeName: 'Ann Lee', position: '\t=HYPERLINK("https://evil")' }),
     ]));
     const [, row] = csv.split('\n');
-    expect(row).toBe('"Lee","Ann","\'\t=HYPERLINK(""https://evil"")",,,,,,,,,,,,,');
+    expect(row).toBe('"Lee","Ann","\'\t=HYPERLINK(""https://evil"")",,0.00,0.00,0.00,,,,,0.00,0.00,,,');
   });
 });

--- a/tests/unit/payrollGustoExport.test.ts
+++ b/tests/unit/payrollGustoExport.test.ts
@@ -1,5 +1,35 @@
 import { describe, it, expect } from 'vitest';
-import { GUSTO_CSV_HEADERS, splitEmployeeName } from '@/utils/payrollGustoExport';
+import { GUSTO_CSV_HEADERS, splitEmployeeName, buildGustoCSV } from '@/utils/payrollGustoExport';
+import type { EmployeePayroll, PayrollPeriod } from '@/utils/payrollCalculations';
+
+// Minimal builder — only fields buildGustoCSV reads matter; rest are zeroed.
+function employee(overrides: Partial<EmployeePayroll>): EmployeePayroll {
+  return {
+    employeeId: 'e', employeeName: '', position: '', area: null,
+    compensationType: 'hourly', hourlyRate: 0,
+    regularHours: 0, overtimeHours: 0, doubleTimeHours: 0, doubleTimePay: 0,
+    dailyOvertimeHours: 0, weeklyOvertimeHours: 0,
+    regularPay: 0, overtimePay: 0, salaryPay: 0, contractorPay: 0, dailyRatePay: 0,
+    manualPayments: [], manualPaymentsTotal: 0,
+    grossPay: 0, totalTips: 0, tipsPaidOut: 0, tipsOwed: 0, totalPay: 0,
+    ...overrides,
+  };
+}
+
+function period(employees: EmployeePayroll[]): PayrollPeriod {
+  return {
+    startDate: new Date('2026-06-01'),
+    endDate: new Date('2026-06-07'),
+    employees,
+    totalRegularHours: 0,
+    totalOvertimeHours: 0,
+    totalDoubleTimeHours: 0,
+    totalGrossPay: 0,
+    totalTips: 0,
+    totalTipsPaidOut: 0,
+    totalTipsOwed: 0,
+  };
+}
 
 describe('GUSTO_CSV_HEADERS', () => {
   it('matches the Gusto import template exactly (16 columns, in order)', () => {
@@ -31,5 +61,98 @@ describe('splitEmployeeName', () => {
   it('returns two blanks for empty/whitespace input', () => {
     expect(splitEmployeeName('   ')).toEqual({ firstName: '', lastName: '' });
     expect(splitEmployeeName('')).toEqual({ firstName: '', lastName: '' });
+  });
+});
+
+describe('buildGustoCSV', () => {
+  it('emits the exact Gusto header line as the first row', () => {
+    const csv = buildGustoCSV(period([]));
+    const [headerLine] = csv.split('\n');
+    expect(headerLine).toBe(GUSTO_CSV_HEADERS.join(','));
+  });
+
+  it('emits header only (no rows) for an empty employee list — no TOTAL row', () => {
+    const csv = buildGustoCSV(period([]));
+    expect(csv).toBe(GUSTO_CSV_HEADERS.join(','));
+    expect(csv.split('\n')).toHaveLength(1);
+  });
+
+  it('maps name split, title=position, and leaves gusto_employee_id blank', () => {
+    const csv = buildGustoCSV(period([
+      employee({ employeeName: 'Jose Delgado', position: 'Server' }),
+    ]));
+    const [, row] = csv.split('\n');
+    expect(row).toBe('"Delgado","Jose","Server",,,,,,,,,,,,,');
+  });
+
+  it('splits tips: paycheck_tips = tipsOwed, cash_tips = tipsPaidOut (cents → dollars)', () => {
+    const csv = buildGustoCSV(period([
+      employee({ employeeName: 'Ann Lee', tipsOwed: 1250, tipsPaidOut: 500 }),
+    ]));
+    const [, row] = csv.split('\n');
+    const cols = row.split(',');
+    // header order: ...,paycheck_tips(11),cash_tips(12),...
+    expect(cols[11]).toBe('12.50');
+    expect(cols[12]).toBe('5.00');
+  });
+
+  it('quotes only the free-text cells (last_name, first_name, title); numeric/blank cells are unquoted', () => {
+    const csv = buildGustoCSV(period([
+      employee({ employeeName: 'Jose Delgado', position: 'Server', regularHours: 40 }),
+    ]));
+    const [, row] = csv.split('\n');
+    const cols = row.split(',');
+    expect(cols[0]).toBe('"Delgado"');
+    expect(cols[1]).toBe('"Jose"');
+    expect(cols[2]).toBe('"Server"');
+    expect(cols[4]).toBe('40.00');
+    expect(cols[3]).toBe('');
+  });
+
+  it('formats hours to up to 2 decimals for regular/overtime/double_overtime', () => {
+    const csv = buildGustoCSV(period([
+      employee({ employeeName: 'Ann Lee', regularHours: 40, overtimeHours: 2.234, doubleTimeHours: 1.1 }),
+    ]));
+    const [, row] = csv.split('\n');
+    const cols = row.split(',');
+    expect(cols[4]).toBe('40.00');
+    expect(cols[5]).toBe('2.23');
+    expect(cols[6]).toBe('1.10');
+  });
+
+  it('renders zero money/hours values as blank cells, not "0" or "0.00"', () => {
+    const csv = buildGustoCSV(period([
+      employee({ employeeName: 'Ann Lee', regularHours: 0, overtimeHours: 0, doubleTimeHours: 0, tipsOwed: 0, tipsPaidOut: 0 }),
+    ]));
+    const [, row] = csv.split('\n');
+    expect(row).toBe('"Lee","Ann","",,,,,,,,,,,,,');
+  });
+
+  it('leaves missed_break_hours, owners_draw, bonus, commission, correction_payment, reimbursement, personal_note blank', () => {
+    const csv = buildGustoCSV(period([employee({ employeeName: 'Ann Lee' })]));
+    const [, row] = csv.split('\n');
+    const cols = row.split(',');
+    // indices: 7 missed_break_hours, 8 owners_draw, 9 bonus, 10 commission, 13 correction_payment, 14 reimbursement, 15 personal_note
+    expect([cols[7], cols[8], cols[9], cols[10], cols[13], cols[14], cols[15]]).toEqual(['', '', '', '', '', '', '']);
+  });
+
+  it('produces exactly header + one row per employee — no TOTAL row, no trailing blank line', () => {
+    const csv = buildGustoCSV(period([
+      employee({ employeeName: 'Ann Lee' }),
+      employee({ employeeName: 'Bob Cruz' }),
+    ]));
+    const lines = csv.split('\n');
+    expect(lines).toHaveLength(3);
+    expect(lines[2]).not.toBe('');
+    expect(csv.toUpperCase()).not.toContain('TOTAL');
+  });
+
+  it('is CSV-injection safe: neutralizes a formula-triggering name and RFC-4180 quotes commas/quotes', () => {
+    const csv = buildGustoCSV(period([
+      employee({ employeeName: '=cmd', position: 'Line, "Cook"' }),
+    ]));
+    const [, row] = csv.split('\n');
+    // single token → lastName blank, firstName carries the neutralized formula; title has an embedded comma + quotes
+    expect(row).toBe('"","\'=cmd","Line, ""Cook""",,,,,,,,,,,,,');
   });
 });


### PR DESCRIPTION
## Summary
- Adds a Gusto timesheet-import CSV export alongside the existing internal CSV export on the Payroll page, selectable via an "Export ▾" dropdown (shadcn `DropdownMenu`, mirrors the `Inventory.tsx` precedent).
- New `src/utils/payrollGustoExport.ts`: `GUSTO_CSV_HEADERS` (16-column Gusto timesheet-import template) + `splitEmployeeName` + `buildGustoCSV` mapper. Money fields converted from cents; `paycheck_tips` = tipsOwed, `cash_tips` = tipsPaidOut (no double-pay); `title` = position (informational); `gusto_employee_id` left blank (Gusto name-matches).
- New `src/utils/payrollExportFormats.ts`: a small format registry (`PAYROLL_EXPORT_FORMATS`) wrapping both the existing internal CSV builder and the new Gusto builder behind a shared filename/date-range helper.
- New `src/components/payroll/PayrollExportMenu.tsx`: presentational dropdown component that performs the blob download, with destructive-toast error handling (null period, builder throwing) and a `disabled` guard for empty payroll periods.
- `src/pages/Payroll.tsx` swapped its single "Export CSV" button for `<PayrollExportMenu>`.
- Security hardening carried over to shared code: broadened `escapeCsvCell` (in `src/utils/payrollCalculations.ts`, now exported) to neutralize CSV-formula-injection payloads with leading whitespace/tabs before `=`/`+`/`-`/`@`, closing a bypass found in adversarial review; `payrollGustoExport.ts` now reuses this exported helper instead of maintaining a duplicate.
- Pure client-side transform of data already on the page — no DB migrations, no edge functions, no new network surface.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean on all touched files (repo-wide pre-existing baseline unchanged)
- [x] `npm run test` — 5718 passed / 2 skipped (25 new tests across `payrollGustoExport.test.ts`, `payrollExportFormats.test.ts`, `PayrollExportMenu.test.tsx`, plus CSV-injection regression tests in `payrollCalculations.test.ts`)
- [x] `npm run test:db` — 1641/1641 pgTAP tests passed (no SQL changes; ran for completeness)
- [x] `npm run build` — succeeds
- [x] `npm run test:e2e` — 143 passed; fixed one stale selector (`employee-payroll.spec.ts`) for the new dropdown trigger; 3 pre-existing/flaky failures confirmed unrelated (reproduce identically on `main` / under worker-isolation)
- [x] Manual/UI review against CLAUDE.md Apple/Notion styling guidelines — matches `Inventory.tsx` DropdownMenu precedent
- [x] Codex adversarial review + CodeRabbit review — all findings addressed or triaged as out-of-scope/accepted risk (see design doc + progress notes)

Design doc: `docs/superpowers/specs/2026-07-07-payroll-provider-export-design.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a payroll export dropdown with multiple formats, including a provider-specific (Gusto) CSV export.
  * Exports now download via the payroll page with consistent, date-range-based filenames.
* **Bug Fixes**
  * Improved CSV safety by neutralizing formula-like inputs (including when preceded by whitespace).
  * More consistent handling of names, zeros, and empty fields in exported CSV content.
* **Documentation**
  * Added design and implementation planning docs for provider-specific payroll export.
* **Tests**
  * Added/updated unit and end-to-end coverage for format selection, download behavior, and CSV escaping rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->