### PR TITLE
feat(scheduling): shift-trade poster tracker + shift-email timezone

### DIFF
--- a/docs/superpowers/plans/2026-07-04-trade-poster-tracker-plan.md
+++ b/docs/superpowers/plans/2026-07-04-trade-poster-tracker-plan.md
@@ -1,0 +1,53 @@
+# Plan: Trade poster status-tracker + shift-email timezone fix
+
+Design: `docs/superpowers/specs/2026-07-04-trade-poster-tracker-design.md`
+Branch: `feature/trade-poster-tracker`
+
+RED → GREEN → REFACTOR → COMMIT per task. No migration.
+
+## Task 1 — Pure progress helper
+- **RED:** `tests/unit/tradeStatusProgress.test.ts` — all four status mappings
+  (steps + states + labels + summary), ghost `accepted_by` → "a teammate",
+  rejected step-state handling.
+- **GREEN:** `src/lib/tradeStatusProgress.ts` (`getPosterTradeProgress`,
+  `TradeStep`, `PosterTradeProgress`).
+- **Commit:** `feat(scheduling): getPosterTradeProgress helper`
+
+## Task 2 — `useMyTradeActivity` hook + shared invalidation helper
+- **RED:** `tests/unit/useMyTradeActivity.test.ts` — mock builder: TWO separate
+  sibling `.or()` groups (AND-ed; comment at call site), status IN, order,
+  cutoff computed in queryFn (stable key), disabled without ids. Plus a test
+  that `invalidateShiftTradeQueries` hits all three keys.
+- **GREEN:** in `src/hooks/useShiftTrades.ts`: export
+  `type ShiftTradeStatus = ShiftTrade['status']`; add module-level
+  `invalidateShiftTradeQueries(queryClient)` (invalidates `['shift_trades']`,
+  `['marketplace_trades']`, `['my_trade_activity']`) and call it from all six
+  mutations' onSuccess (replacing the repeated per-key calls; `['shifts']`
+  extras stay); add `useMyTradeActivity`. Code comments: non-user-controlled
+  interpolation (UUID + ISO), intentional AND-of-two-`.or()`.
+- **Commit:** `feat(scheduling): useMyTradeActivity hook + shared invalidation`
+
+## Task 3 — "My shift trades" card on EmployeeSchedule
+- Replace "Pending Trade Requests" card: partition activity into postedByMe /
+  claimedByMe; poster rows get stepper (`role="img"` + aria-label summary;
+  labels hidden below `sm` with visible summary line instead) + manager_note on
+  rejected (neutral `bg-muted/30` block, "Manager note:" prefix) + Withdraw
+  (open only; single confirm dialog via useCancelShiftTrade; focus restored to
+  a stable section-header ref on close — success unmounts the trigger);
+  claimant rows get status line + manager_note.
+- **Verify:** targeted unit tests + `npm run typecheck && npm run lint`.
+- **Commit:** `feat(scheduling): poster status-tracker on EmployeeSchedule`
+
+## Task 4 — Shift-email timezone
+- **RED:** `tests/unit/notificationHelpers.getRestaurantInfo.test.ts` — happy
+  path, error fallbacks, null timezone → 'America/Chicago'.
+- **GREEN:** add `getRestaurantInfo` to `_shared/notificationHelpers.ts`; use in
+  `send-shift-notification/index.ts`; pass tz to all four `formatDateTime` calls.
+- **Commit:** `fix(scheduling): shift emails use restaurant timezone`
+
+## Dependencies
+1 → 3, 2 → 3. Task 4 independent. 1, 2, 4 parallelizable.
+
+## Verification gate (Phase 8)
+`npm run test && npm run typecheck && npm run lint && npm run build` green.
+No supabase/ SQL diff → test:db unaffected (CI covers).

--- a/docs/superpowers/specs/2026-07-04-trade-poster-tracker-design.md
+++ b/docs/superpowers/specs/2026-07-04-trade-poster-tracker-design.md
@@ -1,0 +1,197 @@
+# Design: Poster status-tracker + send-shift-notification timezone fix
+
+**Date:** 2026-07-04
+**Branch:** `feature/trade-poster-tracker`
+**Follow-up to:** PR #562 (manager cleanup) and PR #570 (area warnings)
+
+## Part 1 — Poster status-tracker
+
+### Problem
+
+After posting a shift trade, the poster gets a toast and then silence.
+`EmployeeSchedule.tsx` fetches only `pending_approval` trades involving the
+employee, so:
+- a freshly-posted `open` trade (no claimant yet) shows **nothing**;
+- once a manager approves/rejects, the trade **vanishes** without the poster
+  ever seeing the outcome or who took the shift.
+
+The existing "Pending Trade Requests" card also conflates two roles — the
+employee as *poster* and as *claimant* — with one generic "Pending Approval"
+badge.
+
+### Decisions
+
+1. **Lifecycle coverage:** show the employee's trades in `open`,
+   `pending_approval`, and recently-resolved `approved`/`rejected`.
+   **Resolved window = 7 days from `reviewed_at`** so outcomes are seen but the
+   list doesn't grow forever. `cancelled` is excluded (the poster withdrew it
+   themselves — no news to deliver).
+2. **One card, two labeled sections** replacing "Pending Trade Requests":
+   - **"Posted by you"** — poster view with a 4-step progress stepper.
+   - **"Claimed by you"** — claimant view (preserves today's visibility and
+     adds the resolved outcome).
+   Partition rule: poster = `offered_by_employee_id === me`; claimant =
+   `accepted_by_employee_id === me && offered_by !== me`. Directed-at-me open
+   trades are NOT shown here (they live in the Available Shifts feed).
+3. **Withdraw** for the poster's own `open` trades via the existing
+   `cancel_shift_trade` RPC / `useCancelShiftTrade` hook, behind a confirm
+   dialog. On success the trade becomes `cancelled` → drops out of the query.
+
+### Data — new hook `useMyTradeActivity` (in `src/hooks/useShiftTrades.ts`)
+
+A dedicated hook rather than another optional param on `useShiftTrades` (whose
+OR-filter also matches `target_employee_id`, which we do NOT want here):
+
+```ts
+useMyTradeActivity(restaurantId, employeeId, resolvedWithinDays = 7)
+```
+
+Query (same select/joins fragment as `useShiftTrades` — `offered_shift`,
+`offered_by`, `accepted_by`):
+
+```
+.eq('restaurant_id', restaurantId)
+.or(`offered_by_employee_id.eq.${employeeId},accepted_by_employee_id.eq.${employeeId}`)
+.in('status', ['open', 'pending_approval', 'approved', 'rejected'])
+.or(`reviewed_at.is.null,reviewed_at.gte.${cutoffIso}`)
+.order('created_at', { ascending: false })
+```
+
+- Multiple `.or()` calls are AND-ed by PostgREST — unresolved trades have
+  `reviewed_at = null` (kept), resolved ones are kept only within the window.
+  The window is enforced **server-side** (bounded payload, no client growth).
+- **`cutoffIso` is computed INSIDE `queryFn`** (`new Date(Date.now() - days*864e5)`),
+  not in the query key — the key stays stable
+  (`['my_trade_activity', restaurantId, employeeId, resolvedWithinDays]`) while
+  every refetch (30s staleTime / focus) re-derives a fresh cutoff. This avoids
+  both the frozen-`now` lesson and query-key churn.
+- `enabled: !!restaurantId && !!employeeId`, `staleTime: 30000`,
+  `refetchOnWindowFocus: true` (house pattern).
+- Existing mutations already invalidate `['shift_trades']`; they must also
+  invalidate `['my_trade_activity']` — add that key to the `onSuccess`
+  invalidations of `useCreateShiftTrade`, `useCancelShiftTrade`,
+  `useAcceptShiftTrade`, `useApproveShiftTrade`, `useRejectShiftTrade`, and
+  `useDeleteShiftTrade` (all in the same file).
+
+### Pure helper — `src/lib/tradeStatusProgress.ts` (new, unit-tested)
+
+Lives in `src/lib` (measured dir, per the Sonar-coverage lesson). No React, no
+clock reads.
+
+```ts
+export type TradeStepState = 'done' | 'current' | 'upcoming' | 'rejected';
+export interface TradeStep { key: 'posted' | 'claimed' | 'review' | 'transferred'; label: string; state: TradeStepState; }
+export interface PosterTradeProgress {
+  steps: TradeStep[];              // always 4, in order
+  summary: string;                 // one-line status for aria + subtitle
+  outcome: 'active' | 'approved' | 'rejected';
+}
+export function getPosterTradeProgress(trade: {
+  status: ShiftTradeStatus;
+  accepted_by?: { name: string } | null;
+}): PosterTradeProgress
+```
+
+Mapping:
+| status | steps | summary |
+|---|---|---|
+| `open` | Posted ✓ → Claimed (current, "Waiting for a claimant") → Review → Transferred | "Posted — waiting for a claimant" |
+| `pending_approval` | Posted ✓ → Claimed ✓ ("Claimed by {name}") → Review (current) → Transferred | "Claimed by {name} — awaiting manager review" |
+| `approved` | all ✓ (Transferred done) | "Approved — shift transferred to {name}" |
+| `rejected` | Posted ✓ → Claimed ✓ → Review (rejected) → Transferred (upcoming) | "Rejected by manager" |
+
+`accepted_by` null (ghost) degrades to "a teammate" in labels — never crashes.
+
+Claimant rows don't need the stepper; a small status line suffices:
+`pending_approval` → "Awaiting manager approval"; `approved` → "Approved — this
+shift is on your schedule"; `rejected` → "Declined" (+ `manager_note` if set).
+
+### UI — `EmployeeSchedule.tsx`
+
+Replace the "Pending Trade Requests" card with a **"My shift trades"** card
+(rendered when the activity list is non-empty; keep the existing
+gradient-free Apple/Notion patterns — `rounded-xl border-border/40`,
+typography scale `text-[13px]/[14px]`, no new raw colors beyond the
+established amber pattern):
+
+- **Posted by you** section: each row keeps the existing date-block + position
+  + time layout, adds:
+  - A compact horizontal stepper (4 dots/segments with labels at
+    `text-[11px]`), colored via semantic/amber/established tokens:
+    done = `text-foreground`/filled, current = amber pattern, rejected =
+    `text-destructive`. The stepper container gets
+    `role="img"` + `aria-label={progress.summary}` (text alternative — the
+    per-step dots are decorative, `aria-hidden`).
+  - `manager_note` shown for rejected (existing blue-note pattern used in
+    TradeApprovalQueue).
+  - **Withdraw** button (`variant="outline"`, `text-destructive` accent) only
+    when `status === 'open'`, opening ONE page-level confirm dialog
+    (single-dialog pattern; `ConfirmTarget = { trade } | null`), confirming via
+    `useCancelShiftTrade({ tradeId, employeeId })`. Disable confirm+trigger
+    while `isPending`. Restore focus to the card section header on close.
+- **Claimed by you** section: existing row layout + the status line above +
+  `manager_note` when rejected.
+- Loading: existing `tradesLoading` skeleton behavior (card hidden while
+  loading, as today). Error: hook exposes `error`; on error render nothing new
+  (page already has toasts elsewhere) — but do NOT render an empty-looking
+  card on error (warning-heuristics lesson: `!isError` guard before "empty"
+  interpretations).
+- Empty: card not rendered when zero rows (matches current behavior).
+
+### Not touched
+
+`TradeRequestDialog` (posting flow), manager `TradeApprovalQueue`, marketplace
+pages, tab badges, schema/RLS (poster/claimant SELECT visibility already
+covered by the employees-can-view-trades policy).
+
+## Part 2 — `send-shift-notification` renders restaurant timezone
+
+### Problem
+
+`supabase/functions/send-shift-notification/index.ts` calls the shared
+`formatDateTime(...)` with **no `timeZone`** for Start/End/Previous Start/
+Previous End (lines ~170–181), so assigned/updated/removed-shift emails show
+UTC times. The shared helper already accepts an optional IANA `timeZone` with
+an invalid-value probe → UTC fallback (added in PR #562).
+
+### Fix (mirrors PR #562)
+
+1. `_shared/notificationHelpers.ts`: add
+   `getRestaurantInfo(supabase, restaurantId): Promise<{ name: string; timezone: string }>`
+   — selects `name, timezone`, falls back to `'Your Restaurant'` /
+   `'America/Chicago'` (column default + sibling-function convention) on
+   error/missing. Keep the existing `getRestaurantName` untouched (its other
+   consumer is only the dead `index.refactored.ts`, but no need to churn it).
+2. `send-shift-notification/index.ts`: replace the `getRestaurantName` call
+   with `getRestaurantInfo`, then pass `info.timezone` to all four
+   `formatDateTime` calls.
+
+No config/verify_jwt changes; the function's auth/settings flow is untouched.
+
+### Testing
+
+- `tests/unit/notificationHelpers.getRestaurantInfo.test.ts` — mock the
+  supabase builder: happy path returns `{name, timezone}`; error → both
+  fallbacks; row with null timezone → `'America/Chicago'`. (`_shared/**` is
+  vitest-coverage-excluded in both configs, so no gate impact — correctness
+  test only, same posture as the PR #562 email test.)
+- `tests/unit/tradeStatusProgress.test.ts` — all four status mappings, ghost
+  `accepted_by`, step states/labels, summaries.
+- `tests/unit/useMyTradeActivity.test.ts` — mock builder chain: asserts the
+  two OR filters + status IN + order; window param in query key; disabled
+  without ids.
+- Existing mutation-invalidation tests extended for the new query key where
+  such tests exist.
+
+## Decided trade-offs
+
+- **7-day resolved window, server-side:** long enough to catch a weekly
+  schedule rhythm; server-side so payload stays bounded. Not configurable —
+  YAGNI until asked.
+- **No stepper for claimant rows:** the claimant cares about one binary
+  outcome, not the pipeline; a status line is clearer and cheaper.
+- **New hook over param-extending `useShiftTrades`:** the existing OR-filter
+  includes `target_employee_id` matches, which would pollute this view;
+  a dedicated, precisely-filtered query is clearer than a flag matrix.
+- **`getRestaurantInfo` alongside `getRestaurantName`:** avoids touching the
+  dead refactored file's import; one live consumer switches over.

--- a/docs/superpowers/specs/2026-07-04-trade-poster-tracker-design.md
+++ b/docs/superpowers/specs/2026-07-04-trade-poster-tracker-design.md
@@ -60,6 +60,11 @@ Query (same select/joins fragment as `useShiftTrades` — `offered_shift`,
 - Multiple `.or()` calls are AND-ed by PostgREST — unresolved trades have
   `reviewed_at = null` (kept), resolved ones are kept only within the window.
   The window is enforced **server-side** (bounded payload, no client growth).
+  **(Frontend review, major):** this AND-of-two-OR-groups is the most fragile
+  line in the hook — a future refactor merging both into ONE `.or()` with a
+  comma would silently flip the semantics to OR. Add a code comment at the
+  call site stating that the two `.or()` calls are intentionally separate and
+  AND-ed, plus the unit test asserting both appear as sibling filters.
 - **`cutoffIso` is computed INSIDE `queryFn`** (`new Date(Date.now() - days*864e5)`),
   not in the query key — the key stays stable
   (`['my_trade_activity', restaurantId, employeeId, resolvedWithinDays]`) while
@@ -67,11 +72,20 @@ Query (same select/joins fragment as `useShiftTrades` — `offered_shift`,
   both the frozen-`now` lesson and query-key churn.
 - `enabled: !!restaurantId && !!employeeId`, `staleTime: 30000`,
   `refetchOnWindowFocus: true` (house pattern).
-- Existing mutations already invalidate `['shift_trades']`; they must also
-  invalidate `['my_trade_activity']` — add that key to the `onSuccess`
-  invalidations of `useCreateShiftTrade`, `useCancelShiftTrade`,
-  `useAcceptShiftTrade`, `useApproveShiftTrade`, `useRejectShiftTrade`, and
-  `useDeleteShiftTrade` (all in the same file).
+- **Invalidation via ONE shared helper (frontend review, major):** instead of
+  editing six `onSuccess` blocks to add a second key (drift-prone), add a
+  module-level `invalidateShiftTradeQueries(queryClient)` in
+  `useShiftTrades.ts` that invalidates `['shift_trades']`,
+  `['marketplace_trades']`, and `['my_trade_activity']`, and call it from the
+  `onSuccess` of all six mutations (`useCreateShiftTrade`,
+  `useCancelShiftTrade`, `useAcceptShiftTrade`, `useApproveShiftTrade`,
+  `useRejectShiftTrade`, `useDeleteShiftTrade`). This also de-duplicates the
+  existing repeated invalidations. Mutations that additionally invalidate
+  `['shifts']` keep that extra call.
+- **Type note (frontend review, minor):** export a named
+  `type ShiftTradeStatus = ShiftTrade['status']` from `useShiftTrades.ts`; the
+  pure helper imports the type only (type-only import of a hook module is fine
+  and keeps one source of truth).
 
 ### Pure helper — `src/lib/tradeStatusProgress.ts` (new, unit-tested)
 
@@ -101,6 +115,15 @@ Mapping:
 | `rejected` | Posted ✓ → Claimed ✓ → Review (rejected) → Transferred (upcoming) | "Rejected by manager" |
 
 `accepted_by` null (ghost) degrades to "a teammate" in labels — never crashes.
+State-machine note (confirmed in design review against the SQL): `rejected` can
+only be reached from `pending_approval`, which atomically sets `accepted_by`,
+so a rejected trade never has a null claimant — the "a teammate" fallback is
+purely defensive. Self-accept is likewise blocked at the RLS layer; the
+partition's `offered_by !== me` clause is a second, defensive guard.
+Known interaction (accepted): a **ghost** `pending_approval` trade (claimant
+employee deleted) renders to the poster as "Claimed by a teammate — awaiting
+manager review" while the manager's queue has exiled it to "Needs cleanup"; it
+resolves when the manager removes it. Acceptable — no special poster-side copy.
 
 Claimant rows don't need the stepper; a small status line suffices:
 `pending_approval` → "Awaiting manager approval"; `approved` → "Approved — this
@@ -122,13 +145,26 @@ established amber pattern):
     `text-destructive`. The stepper container gets
     `role="img"` + `aria-label={progress.summary}` (text alternative — the
     per-step dots are decorative, `aria-hidden`).
-  - `manager_note` shown for rejected (existing blue-note pattern used in
-    TradeApprovalQueue).
+  - **Narrow widths / 200% zoom (frontend review, minor):** step labels are
+    hidden below the `sm` breakpoint (dots-only) with `progress.summary`
+    rendered as an adjacent visible `text-[12px] text-muted-foreground` line —
+    so low-vision/zoomed users get the same information as screen-reader
+    users, and labels never wrap awkwardly.
+  - `manager_note` shown for rejected in a neutral `bg-muted/30 border
+    border-border/40 rounded-lg p-2.5 text-[13px]` block prefixed "Manager
+    note:" (frontend review, minor: no existing manager-note display pattern
+    exists to copy — the TradeApprovalQueue blue block is for the employee's
+    *reason*; do not invent a colored block for this).
   - **Withdraw** button (`variant="outline"`, `text-destructive` accent) only
     when `status === 'open'`, opening ONE page-level confirm dialog
     (single-dialog pattern; `ConfirmTarget = { trade } | null`), confirming via
     `useCancelShiftTrade({ tradeId, employeeId })`. Disable confirm+trigger
-    while `isPending`. Restore focus to the card section header on close.
+    while `isPending`.
+  - **Focus restore (frontend review, minor):** a successful withdraw unmounts
+    the row (and its Withdraw button), so Radix's default return-to-trigger
+    would target a removed element. Use the `TradeApprovalQueue`
+    `bulkRemoveBtnRef` pattern: a stable ref on the "Posted by you" section
+    header, explicitly focused on dialog close (both cancel and success).
 - **Claimed by you** section: existing row layout + the status line above +
   `manager_note` when rejected.
 - Loading: existing `tradesLoading` skeleton behavior (card hidden while
@@ -182,6 +218,29 @@ No config/verify_jwt changes; the function's auth/settings flow is untouched.
   without ids.
 - Existing mutation-invalidation tests extended for the new query key where
   such tests exist.
+
+## Review notes folded in
+
+- **Interpolation safety (Supabase review, minor):** both values interpolated
+  into `.or()` strings are non-user-controlled — `employeeId` is a UUID from
+  our own `employees.id`, `cutoffIso` is `Date.toISOString()` output (no
+  commas/parens). Add a code comment saying so, since PostgREST treats commas
+  and parens as syntax.
+- **`manager_note` visibility (Supabase review, minor):** the existing SELECT
+  policy is restaurant-scoped, so ANY active employee in the restaurant can
+  already read every trade's `manager_note`/`reviewed_at` via existing
+  queries. This feature changes what is *rendered*, not the exposure surface —
+  no new access decision is being made here.
+- **pgTAP for the RLS assumption (Supabase review, optional):** declined for
+  this PR — the policy is pre-existing and unchanged, and this PR has no SQL
+  diff; adding RLS tests for unchanged policies is a separate hardening pass.
+- **Composite `(restaurant_id, status)` index (Supabase review, optional):**
+  declined — `shift_trades` volume per restaurant is small; noted as a watch
+  item if scale changes.
+- **Style seam (frontend review, minor, accepted):** the new flat
+  Apple/Notion card will sit next to the page's older gradient cards
+  (Upcoming Shifts etc.), which are NOT in scope. The seam is an accepted,
+  scoped trade-off — modernizing the rest of the page is a separate task.
 
 ## Decided trade-offs
 

--- a/src/components/schedule/MyShiftTradesCard.tsx
+++ b/src/components/schedule/MyShiftTradesCard.tsx
@@ -1,0 +1,280 @@
+import { useMemo, useRef, useState } from 'react';
+import { format, parseISO } from 'date-fns';
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+
+import { ArrowRightLeft, Loader2, Undo2 } from 'lucide-react';
+
+import { useMyTradeActivity, useCancelShiftTrade } from '@/hooks/useShiftTrades';
+
+import type { ShiftTrade } from '@/hooks/useShiftTrades';
+
+import {
+  getPosterTradeProgress,
+  getClaimantTradeStatusLine,
+  type PosterTradeProgress,
+  type TradeStepState,
+} from '@/lib/tradeStatusProgress';
+import { cn } from '@/lib/utils';
+
+interface MyShiftTradesCardProps {
+  restaurantId: string;
+  employeeId: string;
+}
+
+const STEP_DOT_CLASS: Record<TradeStepState, string> = {
+  done: 'bg-foreground',
+  current: 'bg-amber-500',
+  upcoming: 'bg-muted-foreground/30',
+  rejected: 'bg-destructive',
+};
+
+const STEP_LABEL_CLASS: Record<TradeStepState, string> = {
+  done: 'text-foreground',
+  current: 'text-amber-600',
+  upcoming: 'text-muted-foreground',
+  rejected: 'text-destructive',
+};
+
+/**
+ * Visual pipeline for a posted trade. The whole stepper is one accessible
+ * unit (role="img" named by the summary); dots/labels are decorative.
+ * Step labels are hidden below `sm` — the always-visible summary line under
+ * the stepper carries the same information for narrow/zoomed viewports.
+ */
+const TradeStepper = ({ progress }: { progress: PosterTradeProgress }) => (
+  <div role="img" aria-label={progress.summary} className="flex flex-wrap items-center gap-y-1">
+    {progress.steps.map((step, i) => (
+      <div key={step.key} aria-hidden="true" className="flex items-center">
+        {i > 0 && <div className="mx-1.5 h-px w-3 sm:w-5 bg-border" />}
+        <span className={cn('h-2 w-2 rounded-full flex-shrink-0', STEP_DOT_CLASS[step.state])} />
+        <span className={cn('hidden sm:inline ml-1 text-[11px]', STEP_LABEL_CLASS[step.state])}>
+          {step.label}
+        </span>
+      </div>
+    ))}
+  </div>
+);
+
+const ShiftDateBlock = ({ trade }: { trade: ShiftTrade }) => {
+  const start = parseISO(trade.offered_shift!.start_time);
+  const end = parseISO(trade.offered_shift!.end_time);
+  return (
+    <div className="flex items-center gap-4 min-w-0">
+      <div className="text-center flex-shrink-0">
+        <div className="text-[13px] font-medium text-muted-foreground">{format(start, 'EEE')}</div>
+        <div className="text-2xl font-bold text-foreground">{format(start, 'd')}</div>
+        <div className="text-[11px] text-muted-foreground">{format(start, 'MMM')}</div>
+      </div>
+      <div className="min-w-0">
+        <div className="text-[14px] font-medium text-foreground">{trade.offered_shift!.position}</div>
+        <div className="text-[13px] text-muted-foreground">
+          {format(start, 'h:mm a')} - {format(end, 'h:mm a')}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const ManagerNote = ({ note }: { note: string }) => (
+  <div className="rounded-lg border border-border/40 bg-muted/30 p-2.5 text-[13px] text-muted-foreground">
+    <span className="font-medium text-foreground">Manager note:</span> {note}
+  </div>
+);
+
+/**
+ * "My shift trades" — the poster's view of where their posted trades went
+ * (with a lifecycle stepper and a Withdraw action while unclaimed) plus the
+ * claimant's view of trades they picked up. Resolved trades stay visible for
+ * the hook's bounded window so outcomes are seen instead of vanishing.
+ */
+export const MyShiftTradesCard = ({ restaurantId, employeeId }: MyShiftTradesCardProps) => {
+  const { trades, loading, isError } = useMyTradeActivity(restaurantId, employeeId);
+  const { mutate: cancelTrade, isPending: isWithdrawing } = useCancelShiftTrade();
+
+  const [confirmTarget, setConfirmTarget] = useState<ShiftTrade | null>(null);
+  // A successful withdraw unmounts the row (and its Withdraw button), so
+  // Radix's default return-to-trigger would focus a removed node. Focus the
+  // stable section header instead, on both cancel and success.
+  const postedHeaderRef = useRef<HTMLHeadingElement>(null);
+
+  const { postedByMe, claimedByMe } = useMemo(() => {
+    const posted: ShiftTrade[] = [];
+    const claimed: ShiftTrade[] = [];
+    for (const trade of trades) {
+      if (trade.offered_by_employee_id === employeeId) {
+        posted.push(trade);
+      } else if (trade.accepted_by_employee_id === employeeId) {
+        claimed.push(trade);
+      }
+    }
+    return { postedByMe: posted, claimedByMe: claimed };
+  }, [trades, employeeId]);
+
+  const closeConfirm = () => {
+    setConfirmTarget(null);
+    requestAnimationFrame(() => postedHeaderRef.current?.focus());
+  };
+
+  const handleConfirmWithdraw = () => {
+    if (!confirmTarget) return;
+    cancelTrade(
+      { tradeId: confirmTarget.id, employeeId },
+      { onSettled: closeConfirm }
+    );
+  };
+
+  if (loading || isError || (postedByMe.length === 0 && claimedByMe.length === 0)) {
+    return null;
+  }
+
+  return (
+    <Card className="border-border/40">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-[17px] font-semibold text-foreground">
+          <ArrowRightLeft className="h-5 w-5" aria-hidden="true" />
+          My shift trades
+        </CardTitle>
+        <CardDescription className="text-[13px] text-muted-foreground">
+          Track shifts you posted for trade and shifts you claimed.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        {postedByMe.length > 0 && (
+          <section className="space-y-2">
+            <h3
+              ref={postedHeaderRef}
+              tabIndex={-1}
+              className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider outline-none"
+            >
+              Posted by you
+            </h3>
+            {postedByMe.map((trade) => {
+              const progress = getPosterTradeProgress(trade);
+              return (
+                <div
+                  key={trade.id}
+                  className="p-4 rounded-xl border border-border/40 bg-background space-y-2.5"
+                >
+                  <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+                    <ShiftDateBlock trade={trade} />
+                    {trade.status === 'open' && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="h-8 rounded-lg text-[13px] font-medium text-destructive hover:text-destructive/80 border-border/40 self-start sm:self-center"
+                        disabled={isWithdrawing}
+                        onClick={() => setConfirmTarget(trade)}
+                      >
+                        <Undo2 className="mr-1.5 h-3.5 w-3.5" aria-hidden="true" />
+                        Withdraw post
+                      </Button>
+                    )}
+                  </div>
+                  <TradeStepper progress={progress} />
+                  <p className="text-[12px] text-muted-foreground">{progress.summary}</p>
+                  {trade.status === 'rejected' && trade.manager_note && (
+                    <ManagerNote note={trade.manager_note} />
+                  )}
+                </div>
+              );
+            })}
+          </section>
+        )}
+
+        {claimedByMe.length > 0 && (
+          <section className="space-y-2">
+            <h3 className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
+              Claimed by you
+            </h3>
+            {claimedByMe.map((trade) => (
+              <div
+                key={trade.id}
+                className="p-4 rounded-xl border border-border/40 bg-background space-y-2"
+              >
+                <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+                  <ShiftDateBlock trade={trade} />
+                  <span className="text-[13px] text-muted-foreground">
+                    From {trade.offered_by?.name ?? 'a teammate'}
+                  </span>
+                </div>
+                <p className="text-[12px] text-muted-foreground">
+                  {getClaimantTradeStatusLine(trade.status)}
+                </p>
+                {trade.status === 'rejected' && trade.manager_note && (
+                  <ManagerNote note={trade.manager_note} />
+                )}
+              </div>
+            ))}
+          </section>
+        )}
+      </CardContent>
+
+      <Dialog open={confirmTarget !== null} onOpenChange={(open) => !open && closeConfirm()}>
+        <DialogContent className="max-w-md p-0 gap-0 border-border/40">
+          <DialogHeader className="px-6 pt-6 pb-4 border-b border-border/40">
+            <div className="flex items-center gap-3">
+              <div className="h-10 w-10 rounded-xl bg-muted/50 flex items-center justify-center">
+                <Undo2 className="h-5 w-5 text-foreground" aria-hidden="true" />
+              </div>
+              <div>
+                <DialogTitle className="text-[17px] font-semibold text-foreground">
+                  Withdraw this post?
+                </DialogTitle>
+                <DialogDescription className="text-[13px] text-muted-foreground mt-0.5">
+                  Your shift stays on your schedule and leaves the marketplace.
+                </DialogDescription>
+              </div>
+            </div>
+          </DialogHeader>
+          {confirmTarget?.offered_shift && (
+            <div className="px-6 py-5">
+              <div className="rounded-xl border border-border/40 bg-muted/30 p-4 text-[13px] text-muted-foreground">
+                <span className="font-medium text-foreground">
+                  {confirmTarget.offered_shift.position}
+                </span>{' '}
+                · {format(parseISO(confirmTarget.offered_shift.start_time), 'EEE, MMM d')} ·{' '}
+                {format(parseISO(confirmTarget.offered_shift.start_time), 'h:mm a')} -{' '}
+                {format(parseISO(confirmTarget.offered_shift.end_time), 'h:mm a')}
+              </div>
+            </div>
+          )}
+          <DialogFooter className="px-6 pb-6 gap-2">
+            <Button
+              variant="outline"
+              className="h-9 px-4 rounded-lg text-[13px] font-medium"
+              onClick={closeConfirm}
+              disabled={isWithdrawing}
+            >
+              Keep post
+            </Button>
+            <Button
+              variant="destructive"
+              className="h-9 px-4 rounded-lg text-[13px] font-medium"
+              onClick={handleConfirmWithdraw}
+              disabled={isWithdrawing}
+            >
+              {isWithdrawing ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
+                  Withdrawing...
+                </>
+              ) : (
+                'Withdraw post'
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </Card>
+  );
+};

--- a/src/components/schedule/MyShiftTradesCard.tsx
+++ b/src/components/schedule/MyShiftTradesCard.tsx
@@ -29,6 +29,12 @@ import { cn } from '@/lib/utils';
 interface MyShiftTradesCardProps {
   restaurantId: string;
   employeeId: string;
+  /**
+   * Focused after a withdraw empties the "Posted by you" section — the section
+   * header (the usual focus-restore target) unmounts along with the last row,
+   * so focus needs a stable page-level anchor to land on.
+   */
+  fallbackFocusRef?: React.RefObject<HTMLElement | null>;
 }
 
 const STEP_DOT_CLASS: Record<TradeStepState, string> = {
@@ -66,8 +72,12 @@ const TradeStepper = ({ progress }: { progress: PosterTradeProgress }) => (
 );
 
 const ShiftDateBlock = ({ trade }: { trade: ShiftTrade }) => {
-  const start = parseISO(trade.offered_shift!.start_time);
-  const end = parseISO(trade.offered_shift!.end_time);
+  // The activity hook filters ghost joins upstream, but that guarantee lives
+  // in another file — guard locally instead of asserting with `!`.
+  const shift = trade.offered_shift;
+  if (!shift) return null;
+  const start = parseISO(shift.start_time);
+  const end = parseISO(shift.end_time);
   return (
     <div className="flex items-center gap-4 min-w-0">
       <div className="text-center flex-shrink-0">
@@ -76,7 +86,7 @@ const ShiftDateBlock = ({ trade }: { trade: ShiftTrade }) => {
         <div className="text-[11px] text-muted-foreground">{format(start, 'MMM')}</div>
       </div>
       <div className="min-w-0">
-        <div className="text-[14px] font-medium text-foreground">{trade.offered_shift!.position}</div>
+        <div className="text-[14px] font-medium text-foreground">{shift.position}</div>
         <div className="text-[13px] text-muted-foreground">
           {format(start, 'h:mm a')} - {format(end, 'h:mm a')}
         </div>
@@ -97,7 +107,11 @@ const ManagerNote = ({ note }: { note: string }) => (
  * claimant's view of trades they picked up. Resolved trades stay visible for
  * the hook's bounded window so outcomes are seen instead of vanishing.
  */
-export const MyShiftTradesCard = ({ restaurantId, employeeId }: MyShiftTradesCardProps) => {
+export const MyShiftTradesCard = ({
+  restaurantId,
+  employeeId,
+  fallbackFocusRef,
+}: MyShiftTradesCardProps) => {
   const { trades, loading, isError } = useMyTradeActivity(restaurantId, employeeId);
   const { mutate: cancelTrade, isPending: isWithdrawing } = useCancelShiftTrade();
 
@@ -120,16 +134,26 @@ export const MyShiftTradesCard = ({ restaurantId, employeeId }: MyShiftTradesCar
     return { postedByMe: posted, claimedByMe: claimed };
   }, [trades, employeeId]);
 
-  const closeConfirm = () => {
+  const closeConfirm = (target: 'section' | 'fallback' = 'section') => {
     setConfirmTarget(null);
-    requestAnimationFrame(() => postedHeaderRef.current?.focus());
+    requestAnimationFrame(() => {
+      const el =
+        target === 'fallback'
+          ? fallbackFocusRef?.current ?? postedHeaderRef.current
+          : postedHeaderRef.current ?? fallbackFocusRef?.current;
+      el?.focus();
+    });
   };
 
   const handleConfirmWithdraw = () => {
     if (!confirmTarget) return;
+    // Withdrawing the LAST posted trade unmounts the whole section (and its
+    // header) once the refetch lands, so the usual focus target disappears —
+    // send focus to the page-level fallback instead.
+    const focusTarget = postedByMe.length <= 1 ? 'fallback' : 'section';
     cancelTrade(
       { tradeId: confirmTarget.id, employeeId },
-      { onSettled: closeConfirm }
+      { onSettled: () => closeConfirm(focusTarget) }
     );
   };
 
@@ -252,7 +276,7 @@ export const MyShiftTradesCard = ({ restaurantId, employeeId }: MyShiftTradesCar
             <Button
               variant="outline"
               className="h-9 px-4 rounded-lg text-[13px] font-medium"
-              onClick={closeConfirm}
+              onClick={() => closeConfirm()}
               disabled={isWithdrawing}
             >
               Keep post

--- a/src/components/schedule/MyShiftTradesCard.tsx
+++ b/src/components/schedule/MyShiftTradesCard.tsx
@@ -39,14 +39,14 @@ interface MyShiftTradesCardProps {
 
 const STEP_DOT_CLASS: Record<TradeStepState, string> = {
   done: 'bg-foreground',
-  current: 'bg-amber-500',
+  current: 'bg-warning',
   upcoming: 'bg-muted-foreground/30',
   rejected: 'bg-destructive',
 };
 
 const STEP_LABEL_CLASS: Record<TradeStepState, string> = {
   done: 'text-foreground',
-  current: 'text-amber-600',
+  current: 'text-warning',
   upcoming: 'text-muted-foreground',
   rejected: 'text-destructive',
 };
@@ -148,12 +148,16 @@ export const MyShiftTradesCard = ({
   const handleConfirmWithdraw = () => {
     if (!confirmTarget) return;
     // Withdrawing the LAST posted trade unmounts the whole section (and its
-    // header) once the refetch lands, so the usual focus target disappears —
-    // send focus to the page-level fallback instead.
-    const focusTarget = postedByMe.length <= 1 ? 'fallback' : 'section';
+    // header) once the refetch lands, so on SUCCESS focus the page-level
+    // fallback. On ERROR the section stays mounted, so keep focus on its
+    // header — the outcome is only known in onSuccess/onError, not onSettled.
+    const successTarget = postedByMe.length <= 1 ? 'fallback' : 'section';
     cancelTrade(
       { tradeId: confirmTarget.id, employeeId },
-      { onSettled: () => closeConfirm(focusTarget) }
+      {
+        onSuccess: () => closeConfirm(successTarget),
+        onError: () => closeConfirm('section'),
+      }
     );
   };
 

--- a/src/hooks/useShiftTrades.ts
+++ b/src/hooks/useShiftTrades.ts
@@ -45,6 +45,8 @@ export interface ShiftTrade {
   };
 }
 
+export type ShiftTradeStatus = ShiftTrade['status'];
+
 type ShiftTradeNotificationAction =
   | 'created'
   | 'accepted'

--- a/src/hooks/useShiftTrades.ts
+++ b/src/hooks/useShiftTrades.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient, type QueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 
@@ -96,6 +96,19 @@ const executeShiftTradeAction = async ({
 };
 
 /**
+ * Invalidate every shift-trade query family in one place.
+ *
+ * All trade mutations must call this instead of hand-listing keys — a missed
+ * key silently desyncs whichever view reads it (this is how the "My shift
+ * trades" card would go stale).
+ */
+export const invalidateShiftTradeQueries = (queryClient: QueryClient) => {
+  queryClient.invalidateQueries({ queryKey: ['shift_trades'] });
+  queryClient.invalidateQueries({ queryKey: ['marketplace_trades'] });
+  queryClient.invalidateQueries({ queryKey: ['my_trade_activity'] });
+};
+
+/**
  * Hook to fetch shift trades for a restaurant
  * @param restaurantId - Restaurant ID
  * @param status - Optional status filter ('open', 'pending_approval', etc.)
@@ -177,6 +190,95 @@ export const useShiftTrades = (
   };
 };
 
+/** Statuses shown in the "My shift trades" activity view. `cancelled` is
+ * deliberately excluded — the poster withdrew it themselves. */
+const MY_TRADE_ACTIVITY_STATUSES: ShiftTradeStatus[] = [
+  'open',
+  'pending_approval',
+  'approved',
+  'rejected',
+];
+
+/**
+ * Trades the employee is a party to (poster or claimant), across the active
+ * lifecycle plus a bounded window of recently-resolved outcomes.
+ *
+ * @param resolvedWithinDays - approved/rejected trades are included only when
+ *   reviewed_at is within this many days (default 7), enforced server-side.
+ */
+export const useMyTradeActivity = (
+  restaurantId: string | null,
+  employeeId: string | null,
+  resolvedWithinDays = 7
+) => {
+  const { data, isLoading, isError, error } = useQuery({
+    // The cutoff is intentionally NOT in the key: the key stays stable while
+    // every refetch recomputes a fresh window inside queryFn.
+    queryKey: ['my_trade_activity', restaurantId, employeeId, resolvedWithinDays],
+    queryFn: async () => {
+      const cutoffIso = new Date(
+        Date.now() - resolvedWithinDays * 24 * 60 * 60 * 1000
+      ).toISOString();
+
+      const { data, error } = await supabase
+        .from('shift_trades')
+        .select(`
+          *,
+          offered_shift:shifts!offered_shift_id(
+            id,
+            start_time,
+            end_time,
+            position,
+            break_duration
+          ),
+          offered_by:employees!offered_by_employee_id(
+            id,
+            name,
+            email,
+            position,
+            area
+          ),
+          accepted_by:employees!accepted_by_employee_id(
+            id,
+            name,
+            email,
+            position
+          )
+        `)
+        .eq('restaurant_id', restaurantId!)
+        // The two .or() calls below are INTENTIONALLY separate: PostgREST ANDs
+        // sibling or= params. Merging them into one comma-joined .or() would
+        // silently flip the semantics to a single big OR. Both interpolated
+        // values are non-user-controlled (employeeId is a UUID from our own
+        // employees table; cutoffIso is Date.toISOString() output), so the
+        // comma/paren-sensitive .or() syntax cannot be broken by them.
+        .or(
+          `offered_by_employee_id.eq.${employeeId},accepted_by_employee_id.eq.${employeeId}`
+        )
+        .in('status', MY_TRADE_ACTIVITY_STATUSES)
+        .or(`reviewed_at.is.null,reviewed_at.gte.${cutoffIso}`)
+        .order('created_at', { ascending: false });
+
+      if (error) throw error;
+      // Drop rows whose joined poster/shift was deleted (same guard as useShiftTrades).
+      return (data as ShiftTrade[]).filter(
+        (t) => t.offered_by != null && t.offered_shift != null
+      );
+    },
+    enabled: !!restaurantId && !!employeeId,
+    staleTime: 30000,
+    refetchOnWindowFocus: true,
+    refetchOnMount: true,
+  });
+
+  return {
+    trades: data || [],
+    loading: isLoading,
+    isError,
+    error,
+  };
+};
+
 /**
  * Hook to create a new shift trade request
  */
@@ -210,7 +312,7 @@ export const useCreateShiftTrade = () => {
       return data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['shift_trades'] });
+      invalidateShiftTradeQueries(queryClient);
       queryClient.invalidateQueries({ queryKey: ['shifts'] });
       toast({
         title: 'Shift trade posted',
@@ -254,7 +356,7 @@ export const useAcceptShiftTrade = () => {
       });
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['shift_trades'] });
+      invalidateShiftTradeQueries(queryClient);
       toast({
         title: 'Trade request sent',
         description: 'Your request has been sent to management for approval.',
@@ -300,7 +402,7 @@ export const useApproveShiftTrade = () => {
       });
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['shift_trades'] });
+      invalidateShiftTradeQueries(queryClient);
       queryClient.invalidateQueries({ queryKey: ['shifts'] });
       toast({
         title: 'Trade approved',
@@ -347,7 +449,7 @@ export const useRejectShiftTrade = () => {
       });
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['shift_trades'] });
+      invalidateShiftTradeQueries(queryClient);
       toast({
         title: 'Trade rejected',
         description: 'The trade request has been rejected.',
@@ -384,7 +486,7 @@ export const useCancelShiftTrade = () => {
       });
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['shift_trades'] });
+      invalidateShiftTradeQueries(queryClient);
       toast({
         title: 'Trade cancelled',
         description: 'Your shift trade has been cancelled.',
@@ -433,8 +535,7 @@ export const useDeleteShiftTrade = () => {
     onSuccess: () => {
       // The shift never moved (ownership only transfers in approve_shift_trade),
       // so NO ['shifts'] invalidation is needed here.
-      queryClient.invalidateQueries({ queryKey: ['shift_trades'] });
-      queryClient.invalidateQueries({ queryKey: ['marketplace_trades'] });
+      invalidateShiftTradeQueries(queryClient);
       toast({ title: 'Trade removed', description: 'The stale trade request was removed.' });
     },
     onError: (error: Error) => {

--- a/src/hooks/useShiftTrades.ts
+++ b/src/hooks/useShiftTrades.ts
@@ -47,8 +47,13 @@ export interface ShiftTrade {
 
 export type ShiftTradeStatus = ShiftTrade['status'];
 
-/** Guard against ghost joins: drop trades whose poster or shift row was deleted. */
-const hasValidJoins = (t: ShiftTrade) => t.offered_by != null && t.offered_shift != null;
+/**
+ * Guard against ghost joins: drop trades whose poster or shift row was deleted.
+ * Structurally typed (not `ShiftTrade`) because useMarketplaceTrades filters
+ * supabase-inferred rows whose `status: string` is wider than the union.
+ */
+const hasValidJoins = (t: { offered_by?: unknown; offered_shift?: unknown }) =>
+  t.offered_by != null && t.offered_shift != null;
 
 type ShiftTradeNotificationAction =
   | 'created'
@@ -223,7 +228,20 @@ export const useMyTradeActivity = (
       const { data, error } = await supabase
         .from('shift_trades')
         .select(`
-          *,
+          id,
+          restaurant_id,
+          offered_shift_id,
+          offered_by_employee_id,
+          requested_shift_id,
+          target_employee_id,
+          accepted_by_employee_id,
+          status,
+          reason,
+          manager_note,
+          reviewed_by,
+          reviewed_at,
+          created_at,
+          updated_at,
           offered_shift:shifts!offered_shift_id(
             id,
             start_time,

--- a/src/hooks/useShiftTrades.ts
+++ b/src/hooks/useShiftTrades.ts
@@ -47,6 +47,9 @@ export interface ShiftTrade {
 
 export type ShiftTradeStatus = ShiftTrade['status'];
 
+/** Guard against ghost joins: drop trades whose poster or shift row was deleted. */
+const hasValidJoins = (t: ShiftTrade) => t.offered_by != null && t.offered_shift != null;
+
 type ShiftTradeNotificationAction =
   | 'created'
   | 'accepted'
@@ -172,10 +175,7 @@ export const useShiftTrades = (
       const { data, error } = await query.order('created_at', { ascending: false });
 
       if (error) throw error;
-      // Filter out trades with null joined data (e.g., deleted employees)
-      return (data as ShiftTrade[]).filter(
-        (t) => t.offered_by != null && t.offered_shift != null
-      );
+      return (data as ShiftTrade[]).filter(hasValidJoins);
     },
     enabled: !!restaurantId,
     staleTime: 30000, // 30 seconds
@@ -260,10 +260,7 @@ export const useMyTradeActivity = (
         .order('created_at', { ascending: false });
 
       if (error) throw error;
-      // Drop rows whose joined poster/shift was deleted (same guard as useShiftTrades).
-      return (data as ShiftTrade[]).filter(
-        (t) => t.offered_by != null && t.offered_shift != null
-      );
+      return (data as ShiftTrade[]).filter(hasValidJoins);
     },
     enabled: !!restaurantId && !!employeeId,
     staleTime: 30000,
@@ -591,10 +588,7 @@ export const useMarketplaceTrades = (
 
       if (tradesError) throw tradesError;
 
-      // Filter out trades with null joined data (e.g., deleted employees)
-      const validTrades = (trades || []).filter(
-        (t) => t.offered_by != null && t.offered_shift != null
-      );
+      const validTrades = (trades || []).filter(hasValidJoins);
 
       if (!currentEmployeeId || validTrades.length === 0) {
         return validTrades;

--- a/src/lib/tradeStatusProgress.ts
+++ b/src/lib/tradeStatusProgress.ts
@@ -33,20 +33,14 @@ export function getPosterTradeProgress(trade: {
   const claimant = trade.accepted_by?.name ?? FALLBACK_CLAIMANT;
   const claimedLabel = `Claimed by ${claimant}`;
 
-  const step = (
-    key: TradeStep['key'],
-    label: string,
-    state: TradeStepState,
-  ): TradeStep => ({ key, label, state });
-
   switch (trade.status) {
     case 'open':
       return {
         steps: [
-          step('posted', 'Posted', 'done'),
-          step('claimed', 'Waiting for a claimant', 'current'),
-          step('review', 'Manager review', 'upcoming'),
-          step('transferred', 'Transferred', 'upcoming'),
+          { key: 'posted', label: 'Posted', state: 'done' },
+          { key: 'claimed', label: 'Waiting for a claimant', state: 'current' },
+          { key: 'review', label: 'Manager review', state: 'upcoming' },
+          { key: 'transferred', label: 'Transferred', state: 'upcoming' },
         ],
         summary: 'Posted — waiting for a claimant',
         outcome: 'active',
@@ -54,10 +48,10 @@ export function getPosterTradeProgress(trade: {
     case 'pending_approval':
       return {
         steps: [
-          step('posted', 'Posted', 'done'),
-          step('claimed', claimedLabel, 'done'),
-          step('review', 'Manager review', 'current'),
-          step('transferred', 'Transferred', 'upcoming'),
+          { key: 'posted', label: 'Posted', state: 'done' },
+          { key: 'claimed', label: claimedLabel, state: 'done' },
+          { key: 'review', label: 'Manager review', state: 'current' },
+          { key: 'transferred', label: 'Transferred', state: 'upcoming' },
         ],
         summary: `${claimedLabel} — awaiting manager review`,
         outcome: 'active',
@@ -65,10 +59,10 @@ export function getPosterTradeProgress(trade: {
     case 'approved':
       return {
         steps: [
-          step('posted', 'Posted', 'done'),
-          step('claimed', claimedLabel, 'done'),
-          step('review', 'Manager review', 'done'),
-          step('transferred', 'Transferred', 'done'),
+          { key: 'posted', label: 'Posted', state: 'done' },
+          { key: 'claimed', label: claimedLabel, state: 'done' },
+          { key: 'review', label: 'Manager review', state: 'done' },
+          { key: 'transferred', label: 'Transferred', state: 'done' },
         ],
         summary: `Approved — shift transferred to ${claimant}`,
         outcome: 'approved',
@@ -76,10 +70,10 @@ export function getPosterTradeProgress(trade: {
     case 'rejected':
       return {
         steps: [
-          step('posted', 'Posted', 'done'),
-          step('claimed', claimedLabel, 'done'),
-          step('review', 'Rejected', 'rejected'),
-          step('transferred', 'Transferred', 'upcoming'),
+          { key: 'posted', label: 'Posted', state: 'done' },
+          { key: 'claimed', label: claimedLabel, state: 'done' },
+          { key: 'review', label: 'Rejected', state: 'rejected' },
+          { key: 'transferred', label: 'Transferred', state: 'upcoming' },
         ],
         summary: 'Rejected by manager',
         outcome: 'rejected',
@@ -88,10 +82,10 @@ export function getPosterTradeProgress(trade: {
       // Defensive only — the activity query excludes cancelled trades.
       return {
         steps: [
-          step('posted', 'Posted', 'done'),
-          step('claimed', 'Claimed', 'upcoming'),
-          step('review', 'Manager review', 'upcoming'),
-          step('transferred', 'Transferred', 'upcoming'),
+          { key: 'posted', label: 'Posted', state: 'done' },
+          { key: 'claimed', label: 'Claimed', state: 'upcoming' },
+          { key: 'review', label: 'Manager review', state: 'upcoming' },
+          { key: 'transferred', label: 'Transferred', state: 'upcoming' },
         ],
         summary: 'Withdrawn',
         outcome: 'withdrawn',

--- a/src/lib/tradeStatusProgress.ts
+++ b/src/lib/tradeStatusProgress.ts
@@ -1,0 +1,118 @@
+import type { ShiftTradeStatus } from '@/hooks/useShiftTrades';
+
+export type TradeStepState = 'done' | 'current' | 'upcoming' | 'rejected';
+
+export interface TradeStep {
+  key: 'posted' | 'claimed' | 'review' | 'transferred';
+  label: string;
+  state: TradeStepState;
+}
+
+export interface PosterTradeProgress {
+  /** Always four steps, in canonical order. */
+  steps: TradeStep[];
+  /** One-line status used as the stepper's accessible name and visible summary. */
+  summary: string;
+  outcome: 'active' | 'approved' | 'rejected' | 'withdrawn';
+}
+
+const FALLBACK_CLAIMANT = 'a teammate';
+
+/**
+ * Derive the poster-facing progress of a shift trade.
+ *
+ * Pure — no clock, no React. A `rejected` trade always has a claimant at the
+ * DB level (rejection is only reachable from pending_approval, which sets
+ * accepted_by atomically); the fallback name covers ghost rows where the
+ * claimant employee was later deleted (FK is ON DELETE SET NULL).
+ */
+export function getPosterTradeProgress(trade: {
+  status: ShiftTradeStatus;
+  accepted_by?: { name: string } | null;
+}): PosterTradeProgress {
+  const claimant = trade.accepted_by?.name ?? FALLBACK_CLAIMANT;
+  const claimedLabel = `Claimed by ${claimant}`;
+
+  const step = (
+    key: TradeStep['key'],
+    label: string,
+    state: TradeStepState,
+  ): TradeStep => ({ key, label, state });
+
+  switch (trade.status) {
+    case 'open':
+      return {
+        steps: [
+          step('posted', 'Posted', 'done'),
+          step('claimed', 'Waiting for a claimant', 'current'),
+          step('review', 'Manager review', 'upcoming'),
+          step('transferred', 'Transferred', 'upcoming'),
+        ],
+        summary: 'Posted — waiting for a claimant',
+        outcome: 'active',
+      };
+    case 'pending_approval':
+      return {
+        steps: [
+          step('posted', 'Posted', 'done'),
+          step('claimed', claimedLabel, 'done'),
+          step('review', 'Manager review', 'current'),
+          step('transferred', 'Transferred', 'upcoming'),
+        ],
+        summary: `${claimedLabel} — awaiting manager review`,
+        outcome: 'active',
+      };
+    case 'approved':
+      return {
+        steps: [
+          step('posted', 'Posted', 'done'),
+          step('claimed', claimedLabel, 'done'),
+          step('review', 'Manager review', 'done'),
+          step('transferred', 'Transferred', 'done'),
+        ],
+        summary: `Approved — shift transferred to ${claimant}`,
+        outcome: 'approved',
+      };
+    case 'rejected':
+      return {
+        steps: [
+          step('posted', 'Posted', 'done'),
+          step('claimed', claimedLabel, 'done'),
+          step('review', 'Rejected', 'rejected'),
+          step('transferred', 'Transferred', 'upcoming'),
+        ],
+        summary: 'Rejected by manager',
+        outcome: 'rejected',
+      };
+    case 'cancelled':
+      // Defensive only — the activity query excludes cancelled trades.
+      return {
+        steps: [
+          step('posted', 'Posted', 'done'),
+          step('claimed', 'Claimed', 'upcoming'),
+          step('review', 'Manager review', 'upcoming'),
+          step('transferred', 'Transferred', 'upcoming'),
+        ],
+        summary: 'Withdrawn',
+        outcome: 'withdrawn',
+      };
+  }
+}
+
+/**
+ * Claimant-facing one-line status. The claimant sees a binary outcome, not the
+ * pipeline, so no stepper. Unreachable statuses (a claimant row only exists
+ * from pending_approval onward) return '' so callers can render nothing.
+ */
+export function getClaimantTradeStatusLine(status: ShiftTradeStatus): string {
+  switch (status) {
+    case 'pending_approval':
+      return 'Awaiting manager approval';
+    case 'approved':
+      return 'Approved — this shift is on your schedule';
+    case 'rejected':
+      return 'Declined';
+    default:
+      return '';
+  }
+}

--- a/src/pages/EmployeeSchedule.tsx
+++ b/src/pages/EmployeeSchedule.tsx
@@ -7,8 +7,8 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { useRestaurantContext } from '@/contexts/RestaurantContext';
 import { useCurrentEmployee } from '@/hooks/useCurrentEmployee';
 import { useShifts } from '@/hooks/useShifts';
-import { useShiftTrades } from '@/hooks/useShiftTrades';
 import { TradeRequestDialog } from '@/components/schedule/TradeRequestDialog';
+import { MyShiftTradesCard } from '@/components/schedule/MyShiftTradesCard';
 import {
   EmployeePageHeader,
   NoRestaurantState,
@@ -123,11 +123,6 @@ const EmployeeSchedule = () => {
 
   const { currentEmployee, loading: employeeLoading } = useCurrentEmployee(restaurantId);
   const { shifts, loading: shiftsLoading } = useShifts(restaurantId, currentWeekStart, weekEnd);
-  const { trades: pendingTrades, loading: tradesLoading } = useShiftTrades(
-    restaurantId,
-    'pending_approval',
-    currentEmployee?.id || null
-  );
 
   // Filter shifts to only show current employee's shifts
   const myShifts = useMemo(() => {
@@ -230,55 +225,8 @@ const EmployeeSchedule = () => {
         </Link>
       </div>
 
-      {/* Pending Trade Requests */}
-      {!tradesLoading && pendingTrades && pendingTrades.length > 0 && (
-        <Card className="bg-gradient-to-br from-yellow-500/5 to-orange-500/5 border-yellow-500/20">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <ClockIcon className="h-5 w-5 text-yellow-600" />
-              Pending Trade Requests
-            </CardTitle>
-            <CardDescription>
-              These shifts are awaiting manager approval. They will appear in your schedule once approved.
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-3">
-              {pendingTrades.map((trade) => (
-                <div
-                  key={trade.id}
-                  className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 p-3 rounded-lg bg-background border border-yellow-500/20"
-                >
-                  <div className="flex items-center gap-4">
-                    <div className="text-center">
-                      <div className="text-sm font-medium text-muted-foreground">
-                        {format(parseISO(trade.offered_shift.start_time), 'EEE')}
-                      </div>
-                      <div className="text-2xl font-bold">
-                        {format(parseISO(trade.offered_shift.start_time), 'd')}
-                      </div>
-                      <div className="text-xs text-muted-foreground">
-                        {format(parseISO(trade.offered_shift.start_time), 'MMM')}
-                      </div>
-                    </div>
-                    <div>
-                      <div className="font-medium">{trade.offered_shift.position}</div>
-                      <div className="text-sm text-muted-foreground">
-                        {format(parseISO(trade.offered_shift.start_time), 'h:mm a')} -{' '}
-                        {format(parseISO(trade.offered_shift.end_time), 'h:mm a')}
-                      </div>
-                    </div>
-                  </div>
-                  <Badge className="bg-gradient-to-r from-yellow-500 to-orange-600 text-white">
-                    <ClockIcon className="w-3 h-3 mr-1" />
-                    Pending Approval
-                  </Badge>
-                </div>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
-      )}
+      {/* My shift trades — poster tracker + claimant status */}
+      <MyShiftTradesCard restaurantId={restaurantId} employeeId={currentEmployee.id} />
 
       {/* Upcoming Shifts */}
       {upcomingShifts.length > 0 && (

--- a/src/pages/EmployeeSchedule.tsx
+++ b/src/pages/EmployeeSchedule.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -116,6 +116,7 @@ const EmployeeSchedule = () => {
     startOfWeek(new Date(), { weekStartsOn: WEEK_STARTS_ON })
   );
   const [tradeDialogOpen, setTradeDialogOpen] = useState(false);
+  const pageHeaderRef = useRef<HTMLDivElement>(null);
   const [selectedShiftForTrade, setSelectedShiftForTrade] = useState<Shift | null>(null);
 
   const weekEnd = endOfWeek(currentWeekStart, { weekStartsOn: WEEK_STARTS_ON });
@@ -210,8 +211,13 @@ const EmployeeSchedule = () => {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex flex-col sm:flex-row gap-4 justify-between items-start sm:items-center">
+      {/* Header — focusable anchor: MyShiftTradesCard returns focus here when a
+          withdraw removes its last posted row (its own section header unmounts). */}
+      <div
+        ref={pageHeaderRef}
+        tabIndex={-1}
+        className="flex flex-col sm:flex-row gap-4 justify-between items-start sm:items-center outline-none"
+      >
         <EmployeePageHeader
           icon={CalendarDays}
           title="My Schedule"
@@ -226,7 +232,11 @@ const EmployeeSchedule = () => {
       </div>
 
       {/* My shift trades — poster tracker + claimant status */}
-      <MyShiftTradesCard restaurantId={restaurantId} employeeId={currentEmployee.id} />
+      <MyShiftTradesCard
+        restaurantId={restaurantId}
+        employeeId={currentEmployee.id}
+        fallbackFocusRef={pageHeaderRef}
+      />
 
       {/* Upcoming Shifts */}
       {upcomingShifts.length > 0 && (

--- a/supabase/functions/_shared/restaurantInfo.ts
+++ b/supabase/functions/_shared/restaurantInfo.ts
@@ -1,0 +1,56 @@
+/**
+ * Restaurant display info for notification emails.
+ *
+ * Type-agnostic like buildEmails.ts: accepts any object with a `.from()`
+ * chain of the expected shape, so the real Deno Supabase client and Vitest
+ * stubs satisfy the same interface — no URL imports, so this module is
+ * directly unit-testable in Node.
+ */
+
+export const DEFAULT_RESTAURANT_NAME = 'Your Restaurant';
+/** Matches the restaurants.timezone column default and sibling sync functions. */
+export const DEFAULT_RESTAURANT_TIMEZONE = 'America/Chicago';
+
+export interface RestaurantInfo {
+  name: string;
+  timezone: string;
+}
+
+interface RestaurantsQueryClient {
+  from(table: string): {
+    select(columns: string): {
+      eq(column: string, value: string): {
+        single(): Promise<{
+          data: { name?: string | null; timezone?: string | null } | null;
+          error: { message: string } | null;
+        }>;
+      };
+    };
+  };
+}
+
+/**
+ * Fetch a restaurant's name and IANA timezone, falling back per-field.
+ * The timezone value is further validated downstream by formatDateTime's
+ * Intl probe (invalid IANA → UTC), so a bad stored value cannot throw.
+ */
+export const getRestaurantInfo = async (
+  supabase: RestaurantsQueryClient,
+  restaurantId: string,
+): Promise<RestaurantInfo> => {
+  const { data, error } = await supabase
+    .from('restaurants')
+    .select('name, timezone')
+    .eq('id', restaurantId)
+    .single();
+
+  if (error || !data) {
+    console.error('Error fetching restaurant info:', error);
+    return { name: DEFAULT_RESTAURANT_NAME, timezone: DEFAULT_RESTAURANT_TIMEZONE };
+  }
+
+  return {
+    name: data.name || DEFAULT_RESTAURANT_NAME,
+    timezone: data.timezone || DEFAULT_RESTAURANT_TIMEZONE,
+  };
+};

--- a/supabase/functions/_shared/restaurantInfo.ts
+++ b/supabase/functions/_shared/restaurantInfo.ts
@@ -31,6 +31,12 @@ interface RestaurantsQueryClient {
 
 /**
  * Fetch a restaurant's name and IANA timezone, falling back per-field.
+ *
+ * Errors deliberately degrade to the defaults instead of throwing: this
+ * helper feeds notification emails, where "generic name + default timezone"
+ * is strictly better for the recipient than the whole send failing over a
+ * cosmetic lookup. The error is logged server-side for operators.
+ *
  * The timezone value is further validated downstream by formatDateTime's
  * Intl probe (invalid IANA → UTC), so a bad stored value cannot throw.
  */

--- a/supabase/functions/send-shift-notification/index.ts
+++ b/supabase/functions/send-shift-notification/index.ts
@@ -10,11 +10,11 @@ import {
   handleCorsPreflightRequest,
   errorResponse,
   successResponse,
-  getRestaurantName,
   shouldSendNotification,
   NOTIFICATION_FROM,
   APP_URL
 } from "../_shared/notificationHelpers.ts";
+import { getRestaurantInfo } from "../_shared/restaurantInfo.ts";
 import { sendWebPushToUser } from '../_shared/webPushHelper.ts';
 
 interface RequestBody {
@@ -160,15 +160,17 @@ const handler = async (req: Request): Promise<Response> => {
       return successResponse({ message: 'No employee email found' });
     }
 
-    // Get restaurant name
-    const restaurantName = await getRestaurantName(supabase, shift.restaurant_id);
+    // Get restaurant name + timezone so shift times render in the
+    // restaurant's local time, not the edge runtime's UTC.
+    const { name: restaurantName, timezone: restaurantTimezone } =
+      await getRestaurantInfo(supabase, shift.restaurant_id);
 
     // Build details card
     const detailsItems = [
       { label: 'Restaurant', value: restaurantName },
       { label: 'Position', value: shift.position },
-      { label: 'Start', value: formatDateTime(shift.start_time) },
-      { label: 'End', value: formatDateTime(shift.end_time) },
+      { label: 'Start', value: formatDateTime(shift.start_time, restaurantTimezone) },
+      { label: 'End', value: formatDateTime(shift.end_time, restaurantTimezone) },
     ];
 
     // Add previous details if modified
@@ -177,8 +179,8 @@ const handler = async (req: Request): Promise<Response> => {
       detailsItems.push(
         { label: '', value: '--- Previous ---' },
         { label: 'Previous Position', value: previousShift!.position },
-        { label: 'Previous Start', value: formatDateTime(previousShift!.start_time) },
-        { label: 'Previous End', value: formatDateTime(previousShift!.end_time) },
+        { label: 'Previous Start', value: formatDateTime(previousShift!.start_time, restaurantTimezone) },
+        { label: 'Previous End', value: formatDateTime(previousShift!.end_time, restaurantTimezone) },
       );
     }
 

--- a/tests/unit/MyShiftTradesCard.test.tsx
+++ b/tests/unit/MyShiftTradesCard.test.tsx
@@ -171,7 +171,10 @@ describe('MyShiftTradesCard', () => {
 
     expect(mockCancelMutate).toHaveBeenCalledWith(
       { tradeId: 'trade-9', employeeId: ME },
-      expect.objectContaining({ onSettled: expect.any(Function) }),
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      }),
     );
   });
 });

--- a/tests/unit/MyShiftTradesCard.test.tsx
+++ b/tests/unit/MyShiftTradesCard.test.tsx
@@ -33,6 +33,8 @@ import type { ShiftTrade } from '@/hooks/useShiftTrades';
 
 const ME = 'emp-me';
 
+// Test fixture: fully-populated defaults + per-test overrides; the `as
+// ShiftTrade` cast is safe because every required field has a default here.
 const makeTrade = (overrides: Partial<ShiftTrade>): ShiftTrade =>
   ({
     id: 'trade-1',

--- a/tests/unit/MyShiftTradesCard.test.tsx
+++ b/tests/unit/MyShiftTradesCard.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * Regression tests for the "My shift trades" card:
+ * (1) hidden while loading / on error / when empty (no empty-looking shell)
+ * (2) poster rows: stepper accessible name, Withdraw only while open
+ * (3) claimant rows: status line, no stepper
+ * (4) partition: poster rows never leak into "Claimed by you"
+ * (5) withdraw confirm dialog wires useCancelShiftTrade with tradeId+employeeId
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockUseMyTradeActivity = vi.hoisted(() => vi.fn());
+const mockCancelMutate = vi.hoisted(() => vi.fn());
+
+vi.mock('@/hooks/useShiftTrades', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/hooks/useShiftTrades')>();
+  return {
+    ...actual,
+    useMyTradeActivity: mockUseMyTradeActivity,
+    useCancelShiftTrade: () => ({ mutate: mockCancelMutate, isPending: false }),
+  };
+});
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { from: vi.fn(), rpc: vi.fn(), functions: { invoke: vi.fn() } },
+}));
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+
+import { MyShiftTradesCard } from '@/components/schedule/MyShiftTradesCard';
+import type { ShiftTrade } from '@/hooks/useShiftTrades';
+
+const ME = 'emp-me';
+
+const makeTrade = (overrides: Partial<ShiftTrade>): ShiftTrade =>
+  ({
+    id: 'trade-1',
+    restaurant_id: 'rest-1',
+    offered_shift_id: 'shift-1',
+    offered_by_employee_id: ME,
+    requested_shift_id: null,
+    target_employee_id: null,
+    accepted_by_employee_id: null,
+    status: 'open',
+    reason: null,
+    manager_note: null,
+    reviewed_by: null,
+    reviewed_at: null,
+    created_at: '2026-07-01T00:00:00Z',
+    updated_at: '2026-07-01T00:00:00Z',
+    offered_shift: {
+      id: 'shift-1',
+      start_time: '2026-07-10T17:00:00Z',
+      end_time: '2026-07-10T23:00:00Z',
+      position: 'Server',
+      break_duration: 0,
+    },
+    offered_by: { id: ME, name: 'Me', email: null, position: 'Server', area: null },
+    ...overrides,
+  }) as ShiftTrade;
+
+const setActivity = (trades: ShiftTrade[], loading = false, isError = false) => {
+  mockUseMyTradeActivity.mockReturnValue({ trades, loading, isError, error: null });
+};
+
+const renderCard = () => render(<MyShiftTradesCard restaurantId="rest-1" employeeId={ME} />);
+
+describe('MyShiftTradesCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing while loading, on error, or with no trades', () => {
+    setActivity([], true, false);
+    const { container: c1 } = renderCard();
+    expect(c1.firstChild).toBeNull();
+
+    setActivity([makeTrade({})], false, true);
+    const { container: c2 } = renderCard();
+    expect(c2.firstChild).toBeNull();
+
+    setActivity([], false, false);
+    const { container: c3 } = renderCard();
+    expect(c3.firstChild).toBeNull();
+  });
+
+  it('shows a posted open trade with the waiting stepper and a Withdraw button', () => {
+    setActivity([makeTrade({ status: 'open' })]);
+    renderCard();
+    expect(screen.getByText('Posted by you')).toBeInTheDocument();
+    expect(
+      screen.getByRole('img', { name: 'Posted — waiting for a claimant' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /withdraw post/i })).toBeInTheDocument();
+  });
+
+  it('pending_approval posted trade names the claimant and hides Withdraw', () => {
+    setActivity([
+      makeTrade({
+        status: 'pending_approval',
+        accepted_by_employee_id: 'emp-2',
+        accepted_by: { id: 'emp-2', name: 'Jordan', email: null, position: 'Cook' },
+      }),
+    ]);
+    renderCard();
+    expect(
+      screen.getByRole('img', { name: 'Claimed by Jordan — awaiting manager review' }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /withdraw post/i })).not.toBeInTheDocument();
+  });
+
+  it('rejected posted trade surfaces the manager note', () => {
+    setActivity([
+      makeTrade({
+        status: 'rejected',
+        accepted_by_employee_id: 'emp-2',
+        accepted_by: { id: 'emp-2', name: 'Jordan', email: null, position: 'Cook' },
+        manager_note: 'Need you on Friday',
+        reviewed_at: '2026-07-02T00:00:00Z',
+      }),
+    ]);
+    renderCard();
+    expect(screen.getByText(/Manager note:/)).toBeInTheDocument();
+    expect(screen.getByText(/Need you on Friday/)).toBeInTheDocument();
+  });
+
+  it('claimed trade renders in "Claimed by you" with a status line and no stepper', () => {
+    setActivity([
+      makeTrade({
+        offered_by_employee_id: 'emp-other',
+        offered_by: { id: 'emp-other', name: 'Mia', email: null, position: 'Bar', area: null },
+        accepted_by_employee_id: ME,
+        status: 'pending_approval',
+      }),
+    ]);
+    renderCard();
+    expect(screen.getByText('Claimed by you')).toBeInTheDocument();
+    expect(screen.getByText('Awaiting manager approval')).toBeInTheDocument();
+    expect(screen.getByText(/From Mia/)).toBeInTheDocument();
+    expect(screen.queryByRole('img')).not.toBeInTheDocument();
+    expect(screen.queryByText('Posted by you')).not.toBeInTheDocument();
+  });
+
+  it('a trade I posted never leaks into the claimed section (partition)', () => {
+    setActivity([
+      makeTrade({
+        status: 'pending_approval',
+        accepted_by_employee_id: 'emp-2',
+        accepted_by: { id: 'emp-2', name: 'Jordan', email: null, position: 'Cook' },
+      }),
+    ]);
+    renderCard();
+    expect(screen.getByText('Posted by you')).toBeInTheDocument();
+    expect(screen.queryByText('Claimed by you')).not.toBeInTheDocument();
+  });
+
+  it('withdraw opens the confirm dialog and confirm calls cancel with tradeId + employeeId', () => {
+    setActivity([makeTrade({ id: 'trade-9', status: 'open' })]);
+    renderCard();
+    fireEvent.click(screen.getByRole('button', { name: /withdraw post/i }));
+    expect(screen.getByText('Withdraw this post?')).toBeInTheDocument();
+
+    const confirmBtn = screen
+      .getAllByRole('button', { name: /withdraw post/i })
+      .find((b) => b.closest('[role="dialog"]'));
+    expect(confirmBtn).toBeDefined();
+    fireEvent.click(confirmBtn!);
+
+    expect(mockCancelMutate).toHaveBeenCalledWith(
+      { tradeId: 'trade-9', employeeId: ME },
+      expect.objectContaining({ onSettled: expect.any(Function) }),
+    );
+  });
+});

--- a/tests/unit/restaurantInfo.test.ts
+++ b/tests/unit/restaurantInfo.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  getRestaurantInfo,
+  DEFAULT_RESTAURANT_NAME,
+  DEFAULT_RESTAURANT_TIMEZONE,
+} from '../../supabase/functions/_shared/restaurantInfo';
+
+const makeClient = (
+  data: { name?: string | null; timezone?: string | null } | null,
+  error: { message: string } | null = null,
+) => ({
+  from: vi.fn().mockReturnValue({
+    select: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({ data, error }),
+      }),
+    }),
+  }),
+});
+
+describe('getRestaurantInfo', () => {
+  it('returns name and timezone from the restaurants row', async () => {
+    const client = makeClient({ name: "Russo's", timezone: 'America/New_York' });
+    const info = await getRestaurantInfo(client, 'rest-1');
+    expect(info).toEqual({ name: "Russo's", timezone: 'America/New_York' });
+    expect(client.from).toHaveBeenCalledWith('restaurants');
+  });
+
+  it('falls back to defaults when the query errors', async () => {
+    const client = makeClient(null, { message: 'boom' });
+    const info = await getRestaurantInfo(client, 'rest-1');
+    expect(info).toEqual({
+      name: DEFAULT_RESTAURANT_NAME,
+      timezone: DEFAULT_RESTAURANT_TIMEZONE,
+    });
+  });
+
+  it('falls back per-field when the row has null name or timezone', async () => {
+    const client = makeClient({ name: null, timezone: null });
+    const info = await getRestaurantInfo(client, 'rest-1');
+    expect(info).toEqual({
+      name: DEFAULT_RESTAURANT_NAME,
+      timezone: DEFAULT_RESTAURANT_TIMEZONE,
+    });
+  });
+
+  it('uses the America/Chicago default (matches the restaurants.timezone column default)', () => {
+    expect(DEFAULT_RESTAURANT_TIMEZONE).toBe('America/Chicago');
+  });
+});

--- a/tests/unit/tradeStatusProgress.test.ts
+++ b/tests/unit/tradeStatusProgress.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getPosterTradeProgress,
+  getClaimantTradeStatusLine,
+} from '@/lib/tradeStatusProgress';
+
+const CLAIMANT = { name: 'Jordan' };
+
+describe('getPosterTradeProgress', () => {
+  it('open: posted done, claimed current with waiting label', () => {
+    const p = getPosterTradeProgress({ status: 'open', accepted_by: null });
+    expect(p.steps.map((s) => s.key)).toEqual(['posted', 'claimed', 'review', 'transferred']);
+    expect(p.steps[0].state).toBe('done');
+    expect(p.steps[1].state).toBe('current');
+    expect(p.steps[1].label).toBe('Waiting for a claimant');
+    expect(p.steps[2].state).toBe('upcoming');
+    expect(p.steps[3].state).toBe('upcoming');
+    expect(p.summary).toBe('Posted — waiting for a claimant');
+    expect(p.outcome).toBe('active');
+  });
+
+  it('pending_approval: claimed done with claimant name, review current', () => {
+    const p = getPosterTradeProgress({ status: 'pending_approval', accepted_by: CLAIMANT });
+    expect(p.steps[0].state).toBe('done');
+    expect(p.steps[1].state).toBe('done');
+    expect(p.steps[1].label).toBe('Claimed by Jordan');
+    expect(p.steps[2].state).toBe('current');
+    expect(p.steps[3].state).toBe('upcoming');
+    expect(p.summary).toBe('Claimed by Jordan — awaiting manager review');
+    expect(p.outcome).toBe('active');
+  });
+
+  it('approved: all steps done, summary names the claimant', () => {
+    const p = getPosterTradeProgress({ status: 'approved', accepted_by: CLAIMANT });
+    expect(p.steps.every((s) => s.state === 'done')).toBe(true);
+    expect(p.summary).toBe('Approved — shift transferred to Jordan');
+    expect(p.outcome).toBe('approved');
+  });
+
+  it('rejected: review step rejected, transferred stays upcoming', () => {
+    const p = getPosterTradeProgress({ status: 'rejected', accepted_by: CLAIMANT });
+    expect(p.steps[0].state).toBe('done');
+    expect(p.steps[1].state).toBe('done');
+    expect(p.steps[2].state).toBe('rejected');
+    expect(p.steps[3].state).toBe('upcoming');
+    expect(p.summary).toBe('Rejected by manager');
+    expect(p.outcome).toBe('rejected');
+  });
+
+  it('ghost claimant (null accepted_by past open) degrades to "a teammate"', () => {
+    const p = getPosterTradeProgress({ status: 'pending_approval', accepted_by: null });
+    expect(p.steps[1].label).toBe('Claimed by a teammate');
+    expect(p.summary).toBe('Claimed by a teammate — awaiting manager review');
+  });
+
+  it('cancelled (defensive — excluded by the query): withdrawn outcome', () => {
+    const p = getPosterTradeProgress({ status: 'cancelled', accepted_by: null });
+    expect(p.outcome).toBe('withdrawn');
+    expect(p.summary).toBe('Withdrawn');
+    expect(p.steps[0].state).toBe('done');
+    expect(p.steps.slice(1).every((s) => s.state === 'upcoming')).toBe(true);
+  });
+
+  it('always returns exactly four steps in canonical order', () => {
+    for (const status of ['open', 'pending_approval', 'approved', 'rejected', 'cancelled'] as const) {
+      const p = getPosterTradeProgress({ status, accepted_by: CLAIMANT });
+      expect(p.steps.map((s) => s.key)).toEqual(['posted', 'claimed', 'review', 'transferred']);
+    }
+  });
+});
+
+describe('getClaimantTradeStatusLine', () => {
+  it('pending_approval → awaiting approval', () => {
+    expect(getClaimantTradeStatusLine('pending_approval')).toBe('Awaiting manager approval');
+  });
+  it('approved → shift on your schedule', () => {
+    expect(getClaimantTradeStatusLine('approved')).toBe('Approved — this shift is on your schedule');
+  });
+  it('rejected → declined', () => {
+    expect(getClaimantTradeStatusLine('rejected')).toBe('Declined');
+  });
+  it('unreachable statuses return empty string (defensive)', () => {
+    expect(getClaimantTradeStatusLine('open')).toBe('');
+    expect(getClaimantTradeStatusLine('cancelled')).toBe('');
+  });
+});

--- a/tests/unit/useMyTradeActivity.test.ts
+++ b/tests/unit/useMyTradeActivity.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Unit tests: useMyTradeActivity + invalidateShiftTradeQueries
+ *
+ * The activity query is the data source for the "My shift trades" card on
+ * EmployeeSchedule. Critical contracts pinned here:
+ * - TWO SEPARATE .or() groups (PostgREST ANDs sibling or= params). Merging
+ *   them into one comma-joined .or() would silently flip AND → OR.
+ * - Resolved-window cutoff is computed INSIDE queryFn (fresh per refetch),
+ *   while the query key stays stable.
+ * - invalidateShiftTradeQueries fans out to all three trade query keys.
+ */
+
+import React, { ReactNode } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  useMyTradeActivity,
+  invalidateShiftTradeQueries,
+  type ShiftTrade,
+} from '@/hooks/useShiftTrades';
+
+const mockSupabase = vi.hoisted(() => ({
+  from: vi.fn(),
+  rpc: vi.fn(),
+  functions: { invoke: vi.fn() },
+}));
+
+vi.mock('@/integrations/supabase/client', () => ({ supabase: mockSupabase }));
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+
+type QueryBuilder = {
+  select: ReturnType<typeof vi.fn>;
+  eq: ReturnType<typeof vi.fn>;
+  in: ReturnType<typeof vi.fn>;
+  or: ReturnType<typeof vi.fn>;
+  order: ReturnType<typeof vi.fn>;
+};
+
+const createSelectQueryBuilder = (
+  mockData: Partial<ShiftTrade>[] | null,
+  error: Error | null = null,
+): QueryBuilder => ({
+  select: vi.fn().mockReturnThis(),
+  eq: vi.fn().mockReturnThis(),
+  in: vi.fn().mockReturnThis(),
+  or: vi.fn().mockReturnThis(),
+  order: vi.fn().mockResolvedValue({ data: mockData, error }),
+});
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+};
+
+const makeTrade = (overrides: Partial<ShiftTrade>): Partial<ShiftTrade> => ({
+  id: 'trade-1',
+  restaurant_id: 'rest-123',
+  offered_by_employee_id: 'emp-1',
+  accepted_by_employee_id: null,
+  status: 'open',
+  reviewed_at: null,
+  created_at: '2026-07-01T00:00:00Z',
+  offered_shift: {
+    id: 'shift-1',
+    start_time: '2026-07-10T17:00:00Z',
+    end_time: '2026-07-10T23:00:00Z',
+    position: 'Server',
+    break_duration: 0,
+  },
+  offered_by: { id: 'emp-1', name: 'Mia', email: null, position: 'Server', area: null },
+  ...overrides,
+});
+
+describe('useMyTradeActivity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('builds the query with restaurant eq, TWO sibling or-groups, status IN, and created_at desc order', async () => {
+    const builder = createSelectQueryBuilder([makeTrade({})]);
+    mockSupabase.from.mockReturnValue(builder);
+
+    const { result } = renderHook(() => useMyTradeActivity('rest-123', 'emp-1'), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(mockSupabase.from).toHaveBeenCalledWith('shift_trades');
+    expect(builder.eq).toHaveBeenCalledWith('restaurant_id', 'rest-123');
+    expect(builder.in).toHaveBeenCalledWith('status', [
+      'open',
+      'pending_approval',
+      'approved',
+      'rejected',
+    ]);
+    expect(builder.order).toHaveBeenCalledWith('created_at', { ascending: false });
+
+    // The two or-groups MUST be separate sibling calls (AND-ed by PostgREST).
+    expect(builder.or).toHaveBeenCalledTimes(2);
+    const orArgs = builder.or.mock.calls.map((c) => c[0] as string);
+    expect(orArgs[0]).toBe('offered_by_employee_id.eq.emp-1,accepted_by_employee_id.eq.emp-1');
+    expect(orArgs[1]).toMatch(/^reviewed_at\.is\.null,reviewed_at\.gte\./);
+  });
+
+  it('computes the resolved-window cutoff ~7 days back, inside queryFn', async () => {
+    const builder = createSelectQueryBuilder([]);
+    mockSupabase.from.mockReturnValue(builder);
+
+    const before = Date.now();
+    const { result } = renderHook(() => useMyTradeActivity('rest-123', 'emp-1'), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    const after = Date.now();
+
+    const windowArg = builder.or.mock.calls.map((c) => c[0] as string)[1];
+    const iso = windowArg.replace('reviewed_at.is.null,reviewed_at.gte.', '');
+    const cutoff = new Date(iso).getTime();
+    const sevenDays = 7 * 24 * 60 * 60 * 1000;
+    expect(cutoff).toBeGreaterThanOrEqual(before - sevenDays - 5000);
+    expect(cutoff).toBeLessThanOrEqual(after - sevenDays + 5000);
+  });
+
+  it('filters out trades with null joined offered_by / offered_shift', async () => {
+    const builder = createSelectQueryBuilder([
+      makeTrade({ id: 'good' }),
+      makeTrade({ id: 'no-shift', offered_shift: undefined }),
+      makeTrade({ id: 'no-poster', offered_by: undefined }),
+    ]);
+    mockSupabase.from.mockReturnValue(builder);
+
+    const { result } = renderHook(() => useMyTradeActivity('rest-123', 'emp-1'), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.trades.map((t) => t.id)).toEqual(['good']);
+  });
+
+  it('is disabled (no fetch) without a restaurantId or employeeId', async () => {
+    const { result: r1 } = renderHook(() => useMyTradeActivity(null, 'emp-1'), {
+      wrapper: createWrapper(),
+    });
+    const { result: r2 } = renderHook(() => useMyTradeActivity('rest-123', null), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(r1.current.trades).toEqual([]);
+      expect(r2.current.trades).toEqual([]);
+    });
+    expect(mockSupabase.from).not.toHaveBeenCalled();
+  });
+});
+
+describe('invalidateShiftTradeQueries', () => {
+  it('invalidates all three trade query keys', () => {
+    const queryClient = { invalidateQueries: vi.fn() };
+    invalidateShiftTradeQueries(queryClient as never);
+    const keys = queryClient.invalidateQueries.mock.calls.map(
+      (c) => (c[0] as { queryKey: string[] }).queryKey[0],
+    );
+    expect(keys).toContain('shift_trades');
+    expect(keys).toContain('marketplace_trades');
+    expect(keys).toContain('my_trade_activity');
+    expect(queryClient.invalidateQueries).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
## Summary
- **Poster status-tracker.** Replaces the ambiguous "Pending Trade Requests" card on `EmployeeSchedule` with **"My shift trades"**. *Posted by you* rows get a 4-step lifecycle tracker (Posted → Claimed by {name} → Manager review → Transferred), the rejection outcome + manager note, and a **Withdraw** action while unclaimed (existing `cancel_shift_trade` RPC). *Claimed by you* rows get a status line + outcome. Resolved trades stay visible for a bounded 7-day window (server-side) instead of vanishing.
- **Shift-email timezone fix.** `send-shift-notification` rendered shift times in UTC; it now uses the restaurant's IANA timezone (new `_shared/restaurantInfo.ts`, `America/Chicago` fallback), mirroring PR #562's fix for trade emails — including the Previous Start/End fields.

Follow-up to #562 (manager cleanup) and #570 (area warnings). No schema/RLS/RPC changes.

Design: `docs/superpowers/specs/2026-07-04-trade-poster-tracker-design.md`

## Test plan
- `tradeStatusProgress.test.ts` (11) — all status mappings, ghost claimant, step states
- `useMyTradeActivity.test.ts` (6) — two AND-ed `.or()` groups, 7-day cutoff computed in queryFn, disabled without ids, shared invalidation fan-out
- `MyShiftTradesCard.test.tsx` (7) — hidden on loading/error/empty; poster stepper + Withdraw; claimant status line; partition; withdraw confirm wiring
- `restaurantInfo.test.ts` (4) — name/timezone, error + null fallbacks
- Full suite: **5,714 pass**; typecheck, lint (changed files), build all green locally

## Review notes
Multi-model + Codex review folded in: Codex caught a `tsc` break the simplify pass introduced (masked by a piped exit code); sound-logic caught the last-posted-trade focus-loss; CodeRabbit's semantic-token + success-only-focus fixes applied. CodeRabbit CLI hit its rate limit before all 7 findings could be captured locally — the GitHub CodeRabbit bot's fresh review will be triaged on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a refreshed **My shift trades** view that clearly separates trades posted by you from trades claimed by you.
  * Trade status is now shown with clearer progress and outcome labels, plus a withdraw confirmation for open posts.

* **Bug Fixes**
  * Improved trade updates so changes refresh consistently across related trade views.
  * Fixed shift notification email times to respect each restaurant’s local timezone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->