### PR TITLE
test(payroll): restore Gusto export nitpick fixes dropped by PR #591 merge

### DIFF
--- a/docs/superpowers/specs/2026-07-07-payroll-provider-export-design.md
+++ b/docs/superpowers/specs/2026-07-07-payroll-provider-export-design.md
@@ -94,9 +94,11 @@ once and reports the cash portion for taxes — no employee is paid twice.
 - **All employees included** (roster parity with the template), even
   zero-activity ones.
 - **CSV-injection safe.** Free-text cells (`last_name`, `first_name`, `title`)
-  pass through a formula-neutralizing escaper: prefix a leading `= + - @` with
-  `'` and RFC-4180 quote/double-quote as needed. Numeric cells are emitted
-  unquoted. (Reuses the existing `escapeCsvCell` pattern; an employee named
+  pass through a formula-neutralizing escaper: prefix any leading formula trigger
+  character (`= + - @`) — **including when preceded by spaces or tabs** (e.g.
+  `"\t=HYPERLINK(...)"`) — with `'`, and RFC-4180 quote/double-quote as needed.
+  Numeric cells are emitted unquoted. (Reuses the existing `escapeCsvCell`
+  pattern, whose neutralization matches `^\s*[=+\-@]`; an employee named
   `=cmd|...` must not become a live formula in Excel/Sheets.)
 - **No BOM.** A UTF-8 BOM can corrupt Gusto's header parse (`﻿last_name`).
   Matches the current internal export's blob (which also omits the BOM).

--- a/tests/unit/payrollGustoExport.test.ts
+++ b/tests/unit/payrollGustoExport.test.ts
@@ -136,6 +136,18 @@ describe('buildGustoCSV', () => {
     expect(cols[12]).toBe('0.00'); // cash_tips
   });
 
+  it('formats negative computed values (payroll corrections) rather than blanking them', () => {
+    const csv = buildGustoCSV(period([
+      employee({ employeeName: 'Ann Lee', regularHours: -4.5, overtimeHours: -1.25, tipsOwed: -750, tipsPaidOut: -200 }),
+    ]));
+    const [, row] = csv.split('\n');
+    const cols = row.split(',');
+    expect(cols[4]).toBe('-4.50');   // regular_hours
+    expect(cols[5]).toBe('-1.25');   // overtime_hours
+    expect(cols[11]).toBe('-7.50');  // paycheck_tips
+    expect(cols[12]).toBe('-2.00');  // cash_tips
+  });
+
   it('keeps untracked columns blank even when adjacent computed columns are 0.00 (no-op, never clobbers Gusto-managed values)', () => {
     // The columns we never populate (owners_draw, bonus, reimbursement, …) stay
     // blank so a re-import does NOT overwrite values the user manages in Gusto.


### PR DESCRIPTION
## Summary
- Restores two CodeRabbit nitpick fixes that were acknowledged on #591 but never reached `main`: the PR's head pointer lagged behind the branch tip during a GitHub sync delay, so the merge merged the stale head and dropped the last-pushed commit.
- Adds the negative-value unit test for `buildGustoCSV` (payroll corrections format as `-4.50` / `-7.50` rather than blanking), per the repo's edge-case testing guideline.
- Updates the export design doc's CSV-injection rule to state that leading `= + - @` triggers are neutralized *including when preceded by spaces/tabs* — documenting the `^\s*[=+\-@]` hardening that already shipped in #591.

No source/behavior change — this is a cherry-pick of the dropped commit (`66dc33fd`): one test + one doc-wording line.

## Test plan
- `npx vitest run tests/unit/payrollGustoExport.test.ts` → 20 passed (incl. the new negative-value case).
- `tsc -p tsconfig.app.json --noEmit` clean.

Design doc: docs/superpowers/specs/2026-07-07-payroll-provider-export-design.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSV export safety by neutralizing formula-like values even when they begin after leading spaces or tabs, reducing the risk of spreadsheet injection.
  * Fixed payroll correction exports so negative hour and tip values are written as properly formatted negative numbers instead of blank cells.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->