### PR TITLE
fix(pos-sales): stop Load more from duplicating pages (Grouped view inflation)

### DIFF
--- a/docs/superpowers/plans/2026-07-06-unified-sales-pagination-offset.md
+++ b/docs/superpowers/plans/2026-07-06-unified-sales-pagination-offset.md
@@ -1,0 +1,295 @@
+# Fix useUnifiedSales Pagination Offset Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix `useUnifiedSales` so "Load more" advances the pagination offset instead of re-fetching page 0, eliminating the duplicate-page accumulation that inflates the Grouped view's per-item totals.
+
+**Architecture:** `useUnifiedSales` uses `useInfiniteQuery` where `pageParam` is the SQL row offset passed to `.range(from, to)`. `getNextPageParam` currently reads a phantom `lastPage.nextPage` (never set → always `0`), so every page re-fetches offset 0 and gets appended as a duplicate. Fix: derive the offset from `allPages.length * PAGE_SIZE`, and add an `id` tiebreaker to the ORDER BY so OFFSET paging is fully deterministic at page boundaries.
+
+**Tech Stack:** React 18, TanStack React Query (`useInfiniteQuery`), Supabase JS client (`.from().select()...range()`), Vitest + `@testing-library/react` `renderHook`.
+
+**Design doc:** `docs/superpowers/specs/2026-07-06-unified-sales-pagination-offset-design.md`
+
+---
+
+## File Structure
+
+- **Modify:** `src/hooks/useUnifiedSales.tsx`
+  - Line ~96-99: add `.order('id', { ascending: false })` as the final ORDER BY tiebreaker.
+  - Line ~160: replace `getNextPageParam` with the `allPages`-derived offset.
+- **Create:** `tests/unit/useUnifiedSales.pagination.test.ts`
+  - Contract/regression test for offset advancement, no-duplicate-ids, short-first-page termination, and the `id` tiebreaker.
+
+---
+
+## Task 1: Pagination regression test (RED)
+
+**Files:**
+- Create: `tests/unit/useUnifiedSales.pagination.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/useUnifiedSales.pagination.test.ts` with this exact content:
+
+```ts
+import React, { ReactNode } from 'react';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// --- Mock auth + toast (hook calls useAuth() and useToast()) ---
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { id: 'user-1' } }),
+}));
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+// --- Mock the Supabase client query builder ---
+const { mockSupabase } = vi.hoisted(() => ({
+  mockSupabase: { from: vi.fn() },
+}));
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: mockSupabase,
+}));
+
+import { useUnifiedSales } from '@/hooks/useUnifiedSales';
+
+const PAGE_SIZE = 500;
+
+// Records every .range() and .order() call the hook makes against unified_sales.
+let rangeCalls: Array<[number, number]>;
+let orderCalls: Array<[string, unknown]>;
+
+// Build a distinct, non-overlapping page of rows for a given offset.
+// IDs encode the offset so any duplicate page fetch is detectable by id.
+function pageForOffset(from: number, size: number) {
+  return Array.from({ length: size }, (_, i) => ({
+    id: `row-${from + i}`,
+    restaurant_id: 'rest-1',
+    pos_system: 'toast',
+    external_order_id: `ord-${from + i}`,
+    external_item_id: `item-${from + i}`,
+    item_name: `Item ${from + i}`,
+    quantity: 1,
+    unit_price: 1,
+    total_price: 1,
+    sale_date: '2026-07-01',
+    sale_time: '10:00:00',
+    pos_category: null,
+    synced_at: null,
+    created_at: '2026-07-01T10:00:00Z',
+    category_id: null,
+    suggested_category_id: null,
+    ai_confidence: null,
+    ai_reasoning: null,
+    item_type: 'sale',
+    adjustment_type: null,
+    is_categorized: false,
+    is_split: false,
+    parent_sale_id: null,
+    suggested_chart_account: null,
+    approved_chart_account: null,
+  }));
+}
+
+// Chainable builder: every method returns the builder; awaiting it resolves
+// via `resolver`. `.range`/`.order` calls are captured for assertions.
+function makeBuilder(resolver: (b: any) => { data: any; error: any }) {
+  const builder: any = {};
+  for (const m of ['select', 'eq', 'ilike', 'gte', 'lte', 'not']) {
+    builder[m] = vi.fn(() => builder);
+  }
+  builder.order = vi.fn((col: string, opts: unknown) => {
+    orderCalls.push([col, opts]);
+    return builder;
+  });
+  builder.range = vi.fn((from: number, to: number) => {
+    builder.__range = [from, to];
+    rangeCalls.push([from, to]);
+    return builder;
+  });
+  builder.then = (onFulfilled: any, onRejected: any) =>
+    Promise.resolve(resolver(builder)).then(onFulfilled, onRejected);
+  return builder;
+}
+
+// `firstPageSize` controls whether more pages exist (=== PAGE_SIZE → hasMore).
+function setup(firstPageSize: number) {
+  rangeCalls = [];
+  orderCalls = [];
+  mockSupabase.from.mockImplementation((table: string) => {
+    if (table === 'recipes') {
+      return makeBuilder(() => ({ data: [], error: null }));
+    }
+    // unified_sales: resolve the slice for whatever offset was requested.
+    return makeBuilder((b) => {
+      const [from] = b.__range as [number, number];
+      const size = from === 0 ? firstPageSize : PAGE_SIZE;
+      return { data: pageForOffset(from, size), error: null };
+    });
+  });
+}
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+};
+
+describe('useUnifiedSales pagination', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('advances the offset on Load more and never duplicates rows', async () => {
+    setup(PAGE_SIZE); // full first page → hasMore true
+
+    const { result } = renderHook(() => useUnifiedSales('rest-1'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.sales).toHaveLength(PAGE_SIZE);
+    expect(result.current.hasMore).toBe(true);
+
+    await act(async () => {
+      result.current.loadMoreSales();
+    });
+
+    await waitFor(() => expect(result.current.sales).toHaveLength(PAGE_SIZE * 2));
+
+    // The SECOND unified_sales page must be fetched at offset PAGE_SIZE, not 0.
+    const unifiedRanges = rangeCalls;
+    expect(unifiedRanges[0]).toEqual([0, PAGE_SIZE - 1]);
+    expect(unifiedRanges[1]).toEqual([PAGE_SIZE, PAGE_SIZE * 2 - 1]);
+
+    // No duplicate ids across the two pages.
+    const ids = result.current.sales.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('stops paging when the first page is short (no dead-end Load more)', async () => {
+    setup(12); // 12 < PAGE_SIZE → hasMore false
+
+    const { result } = renderHook(() => useUnifiedSales('rest-1'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.sales).toHaveLength(12);
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it('orders by a unique id tiebreaker for deterministic OFFSET paging', async () => {
+    setup(PAGE_SIZE);
+
+    const { result } = renderHook(() => useUnifiedSales('rest-1'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // The ORDER BY chain must include an `id` ordering call.
+    expect(orderCalls.some(([col]) => col === 'id')).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test -- tests/unit/useUnifiedSales.pagination.test.ts`
+
+Expected: FAIL. Specifically:
+- "advances the offset…" fails — with the bug the second fetch is `[0, 499]` (so `unifiedRanges[1]` is `[0, 499]`, and duplicate ids collapse the Set), and `sales` length reaches `PAGE_SIZE * 2` only as duplicates, so the `new Set(ids).size === ids.length` assertion fails.
+- "orders by a unique id tiebreaker…" fails — no `id` order call exists yet.
+- "stops paging when the first page is short…" may already PASS (termination doesn't depend on the bug); that's fine — it guards the common path going forward.
+
+---
+
+## Task 2: Fix the offset + add tiebreaker (GREEN)
+
+**Files:**
+- Modify: `src/hooks/useUnifiedSales.tsx`
+
+- [ ] **Step 1: Add the `id` ORDER BY tiebreaker**
+
+In `src/hooks/useUnifiedSales.tsx`, find (around line 96-99):
+
+```ts
+      query = query
+        .order('sale_date', { ascending: false })
+        .order('created_at', { ascending: false })
+        .range(from, to);
+```
+
+Replace with:
+
+```ts
+      query = query
+        .order('sale_date', { ascending: false })
+        .order('created_at', { ascending: false })
+        .order('id', { ascending: false })
+        .range(from, to);
+```
+
+- [ ] **Step 2: Fix `getNextPageParam`**
+
+Find (around line 160):
+
+```ts
+    getNextPageParam: (lastPage: any) => (lastPage?.hasMore ? (lastPage?.nextPage || 0) : undefined),
+```
+
+Replace with:
+
+```ts
+    getNextPageParam: (lastPage: any, allPages: any[]) =>
+      lastPage?.hasMore ? allPages.length * PAGE_SIZE : undefined,
+```
+
+- [ ] **Step 3: Run the test to verify it passes**
+
+Run: `npm run test -- tests/unit/useUnifiedSales.pagination.test.ts`
+
+Expected: PASS (all three tests green).
+
+- [ ] **Step 4: Typecheck the changed files**
+
+Run: `npm run typecheck`
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useUnifiedSales.tsx tests/unit/useUnifiedSales.pagination.test.ts
+git commit -m "fix(pos-sales): advance unified-sales pagination offset + id tiebreaker
+
+getNextPageParam read a phantom lastPage.nextPage (always 0), so every
+Load more re-fetched offset 0 and useInfiniteQuery appended a duplicate
+page. flatSales accumulated N copies, inflating the client-side Grouped
+totals (revenue/qty/sale_count) in lockstep. Derive the offset from
+allPages.length * PAGE_SIZE, and add an id ORDER BY tiebreaker so OFFSET
+paging is deterministic at page boundaries. Adds a pagination contract
+test (offset advances, no duplicate ids, short-page termination).
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:**
+  - Fix `getNextPageParam` → Task 2 Step 2. ✅
+  - `id` tiebreaker → Task 2 Step 1. ✅
+  - Offset-advances + no-duplicate contract test → Task 1 test 1. ✅
+  - Short-first-page termination test → Task 1 test 2. ✅
+  - Tiebreaker verified in test → Task 1 test 3. ✅
+  - Grouped-view server RPC → explicitly out of scope (design doc). ✅
+- **Placeholder scan:** none — all code and commands are literal.
+- **Type consistency:** `getNextPageParam` signature `(lastPage, allPages)` matches TanStack `useInfiniteQuery`; `PAGE_SIZE` is the existing module constant (500). `result.current.sales`, `.loading`, `.hasMore`, `.loadMoreSales` match the hook's returned API (lines 574-590). The builder mock exposes every method the hook chains (`select/eq/ilike/gte/lte/order/range` for unified_sales, `select/eq/not` for recipes).
+```

--- a/docs/superpowers/specs/2026-07-06-unified-sales-pagination-offset-design.md
+++ b/docs/superpowers/specs/2026-07-06-unified-sales-pagination-offset-design.md
@@ -1,0 +1,100 @@
+# Design: Fix `useUnifiedSales` pagination offset (duplicate-page inflation)
+
+**Date:** 2026-07-06
+**Topic:** unified-sales-pagination-offset
+**Type:** Bugfix (correctness — financial view)
+
+## Problem
+
+On `/pos-sales`, the **Grouped** view shows per-item revenue/quantity/sale-count
+that far exceed reality. In the reported case the store's true revenue was
+~$14,315 (shown correctly in the header cards), yet individual grouped items
+displayed values like $31,458 — impossible for a single item. The inflation
+grows every time the user clicks **Load more**, and the inflated `qty` and
+`sales` numbers move in lockstep and land on round multiples of the real value.
+
+## Root cause
+
+`src/hooks/useUnifiedSales.tsx` paginates `unified_sales` with
+`useInfiniteQuery`. The page fetcher uses `pageParam` **directly as the SQL row
+offset**:
+
+```js
+const from = pageParam;
+const to = pageParam + PAGE_SIZE - 1;
+// ...
+.range(from, to);
+return { sales: salesWithSplits, hasMore: (data?.length ?? 0) === PAGE_SIZE };
+```
+
+But `getNextPageParam` reads a field the page never returns:
+
+```js
+getNextPageParam: (lastPage) => (lastPage?.hasMore ? (lastPage?.nextPage || 0) : undefined),
+```
+
+`lastPage.nextPage` is `undefined`, so `nextPage || 0` is always **`0`**. Every
+`fetchNextPage()` therefore re-requests rows `0–499` — the same first page — and
+`useInfiniteQuery` appends it as a new page. `flatSales` flattens all pages
+(`data.pages.flatMap(...)`), so after N "Load more" clicks the list holds N
+copies of the first 500 rows.
+
+The Grouped view aggregates that duplicated list client-side
+(`POSSales.tsx` `groupedSales`), summing `total_revenue`, `total_quantity`, and
+`sale_count`. Each duplicate copy inflates all three in lockstep → the observed
+symptom. The header total cards are unaffected because they come from a separate
+server-side aggregation hook (`useUnifiedSalesTotals`), which is why the header
+is correct while the grouped cards are not — the exact discrepancy reported.
+
+## Fix
+
+Derive the next offset from the number of pages already loaded, so it advances
+`PAGE_SIZE` per page and stops when a short page returns:
+
+```js
+getNextPageParam: (lastPage: any, allPages: any[]) =>
+  lastPage?.hasMore ? allPages.length * PAGE_SIZE : undefined,
+```
+
+- After page 1 (offset 0): `allPages.length === 1` → next offset `500`.
+- After page 2 (offset 500): `allPages.length === 2` → next offset `1000`.
+- `hasMore` is `data.length === PAGE_SIZE`, so a final short page ends paging.
+
+No change to the fetcher's return shape; `nextPage` is removed from the mental
+model entirely (it never existed on the object).
+
+## Testing
+
+There is no existing unit test for this hook's pagination (only
+`useUnifiedSalesTotals` is tested). This is precisely the
+[2026-05-03 lesson](../../../memory/lessons.md) trap — *"tests existed for the
+math but not for the contract."* Add a contract test
+(`tests/unit/useUnifiedSales.pagination.test.ts`):
+
+1. Mock the Supabase query builder so `.range(from, to)` returns a **distinct,
+   non-overlapping** slice of rows per offset (unique IDs per page).
+2. Render the hook via `renderHook`, wait for the first page, call
+   `loadMoreSales()`.
+3. Assert:
+   - The second fetch requested offset **`PAGE_SIZE` (500)**, not `0`.
+   - `sales` contains **no duplicate `id`s** across pages.
+   - `sales.length` equals the sum of the two distinct page sizes.
+
+The "requested offset" assertion is the regression guard: it fails on the
+current `|| 0` behavior and passes with the fix.
+
+## Scope / decided trade-offs
+
+- **In scope:** the pagination-offset fix and its regression test only.
+- **Out of scope (follow-up):** the Grouped view aggregates only the pages
+  currently loaded, so its totals are *partial* until the user pages through the
+  entire range. Making Grouped totals complete-and-accurate regardless of paging
+  would require a server-side group-by RPC (mirroring `useUnifiedSalesTotals`).
+  That is a larger enhancement and is intentionally deferred — the reported bug
+  is the duplication/inflation, which this fix resolves. Noted here so the
+  follow-up isn't lost.
+
+## Verification
+
+`npm run test` (targeted + full), `npm run typecheck`, `npm run lint`,
+`npm run build`, then the standard Phase 7–9 review/CI pipeline.

--- a/docs/superpowers/specs/2026-07-06-unified-sales-pagination-offset-design.md
+++ b/docs/superpowers/specs/2026-07-06-unified-sales-pagination-offset-design.md
@@ -58,10 +58,37 @@ getNextPageParam: (lastPage: any, allPages: any[]) =>
 
 - After page 1 (offset 0): `allPages.length === 1` → next offset `500`.
 - After page 2 (offset 500): `allPages.length === 2` → next offset `1000`.
-- `hasMore` is `data.length === PAGE_SIZE`, so a final short page ends paging.
+- `hasMore` is `data.length === PAGE_SIZE`, so a final short page (including an
+  empty page) ends paging.
 
 No change to the fetcher's return shape; `nextPage` is removed from the mental
 model entirely (it never existed on the object).
+
+**Invariant relied upon:** `allPages.length * PAGE_SIZE` is correct only because
+React Query fetches infinite-query pages **sequentially, in order** — never page
+N+1 before page N settles. This is guaranteed by TanStack Query's infinite-query
+design, and the hook already disables `refetchOnMount/WindowFocus/Reconnect`, so
+no background refetch races a `fetchNextPage()`. We depend on that invariant
+rather than an explicit server cursor.
+
+**Determinism tiebreaker (folded in from Supabase design review).** The query
+currently orders by `sale_date DESC, created_at DESC` — no unique final
+tiebreaker. Under OFFSET pagination (`.range(from, to)`), rows tying on **both**
+columns have an unspecified relative order that Postgres may return differently
+across two separate `.range()` calls, allowing a rare row skip/duplication at a
+page boundary — which would corrupt Grouped totals in the same way as the bug
+we're fixing. Add `.order('id', { ascending: false })` as a final tiebreaker to
+make the sort fully deterministic. (Full keyset/seek pagination on
+`(sale_date, created_at, id)` — which also avoids OFFSET's O(offset) re-scan cost
+when paging deep into history — is a larger change left as a future option.)
+
+**No interaction with virtualizer or child-split reconstruction.** The
+`salesVirtualizer` in `POSSales.tsx` is keyed off `dateFilteredSales.length`
+(derived from the hook's `flatSales`) with stable `key={sale.id}`; once duplicate
+pages stop appending, it simply sees a smaller `count`. The cross-page
+`childrenByParent` reduction in `flatSales` already scans the full flattened list
+regardless of page boundaries, so it is unaffected. Both are fixed transitively;
+neither needs a code change.
 
 ## Testing
 
@@ -79,20 +106,43 @@ math but not for the contract."* Add a contract test
    - The second fetch requested offset **`PAGE_SIZE` (500)**, not `0`.
    - `sales` contains **no duplicate `id`s** across pages.
    - `sales.length` equals the sum of the two distinct page sizes.
+4. **Short-first-page case (common path):** mock the first page to return fewer
+   than `PAGE_SIZE` rows (e.g. 12). Assert `hasMore` is `false`, so the
+   `POSSales.tsx` "Load more" buttons (three of them, all gated on `hasMore`)
+   never render — no dead-end button for the majority of restaurants that have
+   under 500 sales rows.
 
 The "requested offset" assertion is the regression guard: it fails on the
-current `|| 0` behavior and passes with the fix.
+current `|| 0` behavior and passes with the fix. The tiebreaker is verified
+implicitly by asserting the `.order` chain includes an `id` ordering call.
 
 ## Scope / decided trade-offs
 
-- **In scope:** the pagination-offset fix and its regression test only.
+- **In scope:** the pagination-offset fix, the `id` sort tiebreaker, and their
+  regression test.
 - **Out of scope (follow-up):** the Grouped view aggregates only the pages
   currently loaded, so its totals are *partial* until the user pages through the
   entire range. Making Grouped totals complete-and-accurate regardless of paging
   would require a server-side group-by RPC (mirroring `useUnifiedSalesTotals`).
   That is a larger enhancement and is intentionally deferred — the reported bug
   is the duplication/inflation, which this fix resolves. Noted here so the
-  follow-up isn't lost.
+  follow-up isn't lost. Constraints for that future RPC, captured now so it
+  isn't re-derived (from Supabase design review):
+  - Mirror `get_unified_sales_totals`: `SECURITY DEFINER`, `SET search_path =
+    public` pinned, marked `STABLE`.
+  - Because `SECURITY DEFINER` bypasses RLS, do an explicit `restaurant_id` +
+    caller-membership check inside the function body.
+  - `GROUP BY item_name` filtered by `restaurant_id`/`sale_date` is a `HashAgg`
+    over the restaurant's date-filtered rows — covered by
+    `idx_unified_sales_restaurant_date` for the scan, but `item_name` grouping
+    is not separately indexed; fine at current scale, not "free."
+
+## Rollout note
+
+After deploy, Grouped totals will **drop** immediately (the duplicate copies of
+page 1 vanish), then grow back as a user pages through with "Load more." A
+support report of "the numbers went down!" on day one is expected behavior, not
+a regression — call this out in the PR description / release note.
 
 ## Verification
 

--- a/src/hooks/useUnifiedSales.tsx
+++ b/src/hooks/useUnifiedSales.tsx
@@ -158,7 +158,8 @@ export const useUnifiedSales = (restaurantId: string | null, options: UseUnified
   } = useInfiniteQuery({
     queryKey,
     queryFn: ({ pageParam = 0 }) => fetchUnifiedSalesPage({ pageParam: pageParam as number }),
-    getNextPageParam: (lastPage: any) => (lastPage?.hasMore ? (lastPage?.nextPage || 0) : undefined),
+    getNextPageParam: (lastPage: any, allPages: any[]) =>
+      lastPage?.hasMore ? allPages.length * PAGE_SIZE : undefined,
     initialPageParam: 0,
     enabled: !!restaurantId && !!user,
     staleTime: 60000,

--- a/src/hooks/useUnifiedSales.tsx
+++ b/src/hooks/useUnifiedSales.tsx
@@ -16,6 +16,11 @@ type UseUnifiedSalesOptions = {
   endDate?: string;
 };
 
+type UnifiedSalesPage = {
+  sales: UnifiedSaleItem[];
+  hasMore: boolean;
+};
+
 export const useUnifiedSales = (restaurantId: string | null, options: UseUnifiedSalesOptions = {}) => {
   const { user } = useAuth();
   const { toast } = useToast();
@@ -158,7 +163,7 @@ export const useUnifiedSales = (restaurantId: string | null, options: UseUnified
   } = useInfiniteQuery({
     queryKey,
     queryFn: ({ pageParam = 0 }) => fetchUnifiedSalesPage({ pageParam: pageParam as number }),
-    getNextPageParam: (lastPage: any, allPages: any[]) =>
+    getNextPageParam: (lastPage: UnifiedSalesPage, allPages: UnifiedSalesPage[]) =>
       lastPage?.hasMore ? allPages.length * PAGE_SIZE : undefined,
     initialPageParam: 0,
     enabled: !!restaurantId && !!user,
@@ -170,7 +175,7 @@ export const useUnifiedSales = (restaurantId: string | null, options: UseUnified
   });
 
   const flatSales = useMemo(() => {
-    const salesList = data?.pages.flatMap((page: any) => page?.sales || []) ?? [];
+    const salesList = data?.pages.flatMap((page: UnifiedSalesPage) => page?.sales || []) ?? [];
     if (!salesList.length) return [];
 
     // Build child splits across pages to avoid missing links

--- a/src/hooks/useUnifiedSales.tsx
+++ b/src/hooks/useUnifiedSales.tsx
@@ -96,6 +96,7 @@ export const useUnifiedSales = (restaurantId: string | null, options: UseUnified
       query = query
         .order('sale_date', { ascending: false })
         .order('created_at', { ascending: false })
+        .order('id', { ascending: false })
         .range(from, to);
 
       const { data, error } = await query;

--- a/tests/unit/useUnifiedSales.pagination.test.ts
+++ b/tests/unit/useUnifiedSales.pagination.test.ts
@@ -59,10 +59,20 @@ function pageForOffset(from: number, size: number) {
   }));
 }
 
+type QueryResult = { data: unknown; error: unknown };
+type MockBuilder = {
+  __range?: [number, number];
+  then: (
+    onFulfilled: (value: QueryResult) => unknown,
+    onRejected?: (reason: unknown) => unknown,
+  ) => Promise<unknown>;
+  [method: string]: unknown;
+};
+
 // Chainable builder: every method returns the builder; awaiting it resolves
 // via `resolver`. `.range`/`.order` calls are captured for assertions.
-function makeBuilder(resolver: (b: any) => { data: any; error: any }) {
-  const builder: any = {};
+function makeBuilder(resolver: (b: MockBuilder) => QueryResult) {
+  const builder = {} as MockBuilder;
   for (const m of ['select', 'eq', 'ilike', 'gte', 'lte', 'not']) {
     builder[m] = vi.fn(() => builder);
   }
@@ -75,7 +85,7 @@ function makeBuilder(resolver: (b: any) => { data: any; error: any }) {
     rangeCalls.push([from, to]);
     return builder;
   });
-  builder.then = (onFulfilled: any, onRejected: any) =>
+  builder.then = (onFulfilled, onRejected) =>
     Promise.resolve(resolver(builder)).then(onFulfilled, onRejected);
   return builder;
 }

--- a/tests/unit/useUnifiedSales.pagination.test.ts
+++ b/tests/unit/useUnifiedSales.pagination.test.ts
@@ -1,0 +1,164 @@
+import React, { ReactNode } from 'react';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// --- Mock auth + toast (hook calls useAuth() and useToast()) ---
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { id: 'user-1' } }),
+}));
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+// --- Mock the Supabase client query builder ---
+const { mockSupabase } = vi.hoisted(() => ({
+  mockSupabase: { from: vi.fn() },
+}));
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: mockSupabase,
+}));
+
+import { useUnifiedSales } from '@/hooks/useUnifiedSales';
+
+const PAGE_SIZE = 500;
+
+// Records every .range() and .order() call the hook makes against unified_sales.
+let rangeCalls: Array<[number, number]>;
+let orderCalls: Array<[string, unknown]>;
+
+// Build a distinct, non-overlapping page of rows for a given offset.
+// IDs encode the offset so any duplicate page fetch is detectable by id.
+function pageForOffset(from: number, size: number) {
+  return Array.from({ length: size }, (_, i) => ({
+    id: `row-${from + i}`,
+    restaurant_id: 'rest-1',
+    pos_system: 'toast',
+    external_order_id: `ord-${from + i}`,
+    external_item_id: `item-${from + i}`,
+    item_name: `Item ${from + i}`,
+    quantity: 1,
+    unit_price: 1,
+    total_price: 1,
+    sale_date: '2026-07-01',
+    sale_time: '10:00:00',
+    pos_category: null,
+    synced_at: null,
+    created_at: '2026-07-01T10:00:00Z',
+    category_id: null,
+    suggested_category_id: null,
+    ai_confidence: null,
+    ai_reasoning: null,
+    item_type: 'sale',
+    adjustment_type: null,
+    is_categorized: false,
+    is_split: false,
+    parent_sale_id: null,
+    suggested_chart_account: null,
+    approved_chart_account: null,
+  }));
+}
+
+// Chainable builder: every method returns the builder; awaiting it resolves
+// via `resolver`. `.range`/`.order` calls are captured for assertions.
+function makeBuilder(resolver: (b: any) => { data: any; error: any }) {
+  const builder: any = {};
+  for (const m of ['select', 'eq', 'ilike', 'gte', 'lte', 'not']) {
+    builder[m] = vi.fn(() => builder);
+  }
+  builder.order = vi.fn((col: string, opts: unknown) => {
+    orderCalls.push([col, opts]);
+    return builder;
+  });
+  builder.range = vi.fn((from: number, to: number) => {
+    builder.__range = [from, to];
+    rangeCalls.push([from, to]);
+    return builder;
+  });
+  builder.then = (onFulfilled: any, onRejected: any) =>
+    Promise.resolve(resolver(builder)).then(onFulfilled, onRejected);
+  return builder;
+}
+
+// `firstPageSize` controls whether more pages exist (=== PAGE_SIZE → hasMore).
+function setup(firstPageSize: number) {
+  rangeCalls = [];
+  orderCalls = [];
+  mockSupabase.from.mockImplementation((table: string) => {
+    if (table === 'recipes') {
+      return makeBuilder(() => ({ data: [], error: null }));
+    }
+    // unified_sales: resolve the slice for whatever offset was requested.
+    return makeBuilder((b) => {
+      const [from] = b.__range as [number, number];
+      const size = from === 0 ? firstPageSize : PAGE_SIZE;
+      return { data: pageForOffset(from, size), error: null };
+    });
+  });
+}
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+};
+
+describe('useUnifiedSales pagination', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('advances the offset on Load more and never duplicates rows', async () => {
+    setup(PAGE_SIZE); // full first page → hasMore true
+
+    const { result } = renderHook(() => useUnifiedSales('rest-1'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.sales).toHaveLength(PAGE_SIZE);
+    expect(result.current.hasMore).toBe(true);
+
+    await act(async () => {
+      result.current.loadMoreSales();
+    });
+
+    await waitFor(() => expect(result.current.sales).toHaveLength(PAGE_SIZE * 2));
+
+    // The SECOND unified_sales page must be fetched at offset PAGE_SIZE, not 0.
+    const unifiedRanges = rangeCalls;
+    expect(unifiedRanges[0]).toEqual([0, PAGE_SIZE - 1]);
+    expect(unifiedRanges[1]).toEqual([PAGE_SIZE, PAGE_SIZE * 2 - 1]);
+
+    // No duplicate ids across the two pages.
+    const ids = result.current.sales.map((s) => s.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('stops paging when the first page is short (no dead-end Load more)', async () => {
+    setup(12); // 12 < PAGE_SIZE → hasMore false
+
+    const { result } = renderHook(() => useUnifiedSales('rest-1'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.sales).toHaveLength(12);
+    expect(result.current.hasMore).toBe(false);
+  });
+
+  it('orders by a unique id tiebreaker for deterministic OFFSET paging', async () => {
+    setup(PAGE_SIZE);
+
+    const { result } = renderHook(() => useUnifiedSales('rest-1'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // The ORDER BY chain must include an `id` ordering call.
+    expect(orderCalls.some(([col]) => col === 'id')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes the POS Sales **Grouped** view showing per-item revenue/qty/sale-count far above reality (single items reading $31k when the store did ~$14k), inflating further with each **Load more** click.
- Root cause: `useUnifiedSales`'s `getNextPageParam` read a phantom `lastPage.nextPage` field the fetcher never set, so it always resolved to `0`. Since `pageParam` is the SQL row offset, every "Load more" re-fetched rows 0–499 and `useInfiniteQuery` appended a duplicate page; `flatSales` accumulated N copies, and the client-side grouped aggregates summed the duplicates in lockstep. (Header total cards were unaffected — they come from the separate server-aggregated `useUnifiedSalesTotals`.)
- Fix: derive the offset from `allPages.length * PAGE_SIZE`, and add an `id` `ORDER BY` tiebreaker so OFFSET pagination is deterministic at page boundaries (rows tying on both `sale_date` and `created_at` could otherwise skip/duplicate).

## Changes
- `src/hooks/useUnifiedSales.tsx` — correct `getNextPageParam`; add `.order('id', …)` tiebreaker; add `UnifiedSalesPage` type (drops newly-introduced `any`).
- `tests/unit/useUnifiedSales.pagination.test.ts` — new contract test: offset advances to `PAGE_SIZE` (not 0), no duplicate ids across pages, short first page terminates paging (no dead-end "Load more"), and the `id` tiebreaker is present.

## Rollout note
After deploy, Grouped totals will **drop immediately** (duplicate copies of page 1 disappear), then grow back as a user pages through with "Load more". A day-one "the numbers went down!" report is expected behavior, not a regression.

## Out of scope (follow-up)
The Grouped view still aggregates only *loaded* pages, so its totals are partial until fully paged. Making them complete regardless of paging needs a server-side group-by RPC (mirroring `get_unified_sales_totals`); deferred and documented in the design doc.

## Test plan
- `npx vitest run tests/unit/useUnifiedSales.pagination.test.ts` → 3/3 pass
- `npm run test` → full suite green (6020 tests)
- `npm run typecheck`, `npm run build` → clean
- CodeRabbit committed review → No findings

Design doc: `docs/superpowers/specs/2026-07-06-unified-sales-pagination-offset-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed “Load more” paging in sales views so additional results now advance correctly instead of repeating the first page.
  * Prevented duplicate rows from accumulating during pagination and improved consistency when results are sorted.
* **Tests**
  * Added regression coverage for offset advancement, duplicate-free paging, short-page stopping, and deterministic ordering.
* **Documentation**
  * Added implementation and design notes describing the updated pagination behavior and rollout expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->