### PR TITLE
fix(pos-sales): server-side Status filter + pagination so the list matches the badge

### DIFF
--- a/docs/superpowers/plans/2026-07-08-uncategorized-list-server-filter-plan.md
+++ b/docs/superpowers/plans/2026-07-08-uncategorized-list-server-filter-plan.md
@@ -1,0 +1,80 @@
+# Plan: Server-side Status filter for the POS Sales list
+
+Design: docs/superpowers/specs/2026-07-08-uncategorized-list-server-filter-design.md
+Branch: `fix/uncategorized-list-server-filter` (stacked on `fix/unified-sales-pagination-offset`)
+
+Tasks are ordered; each is a small RED→GREEN→REFACTOR→COMMIT unit.
+
+## Task 1 — Failing test: server-side categorization filters (RED)
+`tests/unit/useUnifiedSales.categorization.test.ts`, extending the existing
+`useUnifiedSales.pagination.test.ts` mock-builder harness (add `is` to the mocked
+builder methods; capture `.not`/`.is` calls as `[column, operator, value]`).
+Assert, per option:
+- `uncategorized` → `.not('is_categorized','is',true)` AND `.is('suggested_category_id', null)`.
+- `pending-review` → `.not('is_categorized','is',true)` AND `.not('suggested_category_id','is',null)`.
+- `categorized` → `.is('is_categorized', true)` (and no `suggested_category_id` predicate).
+- `all` / omitted → none of the above filter calls emitted.
+Depends on: nothing. (Test fails until Task 2.)
+
+## Task 2 — Hook: add `categorizationFilter` option + filter chain (GREEN)
+`src/hooks/useUnifiedSales.tsx`:
+- Extend `UseUnifiedSalesOptions` with
+  `categorizationFilter?: 'all' | 'uncategorized' | 'pending-review' | 'categorized'`.
+- Normalise + add to `queryKey`.
+- In `fetchUnifiedSalesPage`, apply the chain from the design's parity table
+  before `.order(...)`. Add a code comment cross-referencing the RPC migration.
+Depends on: Task 1.
+
+## Task 3 — Hook: `keepPreviousData` for tab-switch UX (GREEN)
+`src/hooks/useUnifiedSales.tsx`:
+- Import `keepPreviousData` from `@tanstack/react-query`; set
+  `placeholderData: keepPreviousData` on the `useInfiniteQuery`.
+- Test: switching the `categorizationFilter` arg keeps `result.current.sales`
+  non-empty (previous rows) during the pending refetch rather than dropping to
+  `loading`/empty.
+Depends on: Task 2.
+
+## Task 4 — Wire the page (GREEN)
+`src/pages/POSSales.tsx`:
+- Pass `categorizationFilter` into the `useUnifiedSales(...)` options (lines
+  ~131-135). Leave the existing client-side filter intact.
+Depends on: Task 2.
+
+## Task 5 — Tab-aware empty state + results header (GREEN)
+`src/pages/POSSales.tsx`:
+- Empty state (lines ~1209-1216): when `categorizationFilter !== 'all'` and no
+  search term, show success-oriented copy ("No {label} sales" / "Everything in
+  this date range has been reviewed."); keep generic copy otherwise.
+- Results header (lines ~1163-1170): when `categorizationFilter !== 'all'`,
+  include the status label in the count text.
+Depends on: Task 4.
+
+## Task 6 — Migration: partial index for the uncategorized feed
+`supabase/migrations/<ts>_idx_unified_sales_uncategorized_feed.sql`:
+```sql
+-- Serves the POS Sales "Uncategorized" tab feed (server-side filter in
+-- useUnifiedSales): WHERE is_categorized IS NOT TRUE AND suggested_category_id
+-- IS NULL, ORDER BY sale_date DESC, created_at DESC, id DESC, LIMIT 500.
+-- Uncategorized rows are the oldest, so a newest-first scan of
+-- idx_unified_sales_restaurant_date reads the whole restaurant partition
+-- (measured: 6.6k rows filtered, ~28ms) — this partial index makes it a bounded
+-- scan of just the matching rows. Mirrors the get_unified_sales_totals predicate
+-- (20260523000000). CONCURRENTLY cannot run inside a transaction, so this lives
+-- in its own migration file.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_unified_sales_uncategorized_feed
+  ON public.unified_sales (restaurant_id, sale_date DESC, created_at DESC, id DESC)
+  WHERE is_categorized IS NOT TRUE AND suggested_category_id IS NULL;
+```
+Depends on: nothing (independent; can land any time). No pgTAP needed (index
+only, no function/logic); correctness is covered by the hook tests + the
+existing totals tests.
+
+## Task 7 — Verify
+- `npm run test -- useUnifiedSales` (unit), `npm run typecheck`, `npm run lint`.
+- Manual/preview: POS Sales → Uncategorized tab shows rows matching the badge.
+- Post-merge (noted for retrospective): re-run the prod `EXPLAIN ANALYZE` to
+  confirm the new index is used and buffers/time drop.
+
+## Out of scope / follow-ups
+- Pruning redundant pre-existing `unified_sales` indexes.
+- Exposing `isFetching` for a dedicated "refreshing" indicator.

--- a/docs/superpowers/specs/2026-07-08-uncategorized-list-server-filter-design.md
+++ b/docs/superpowers/specs/2026-07-08-uncategorized-list-server-filter-design.md
@@ -180,6 +180,12 @@ written by Toast sync.
   previous tab's rows (further narrowed by the new client-side filter) for the
   ~30 ms until the server responds. Acceptable, and strictly better than a blank
   full-page spinner.
+- **keepPreviousData across tenants**: `restaurantId` is part of the same
+  queryKey, so a naive `placeholderData: keepPreviousData` would briefly show
+  the *previous restaurant's* sales on a restaurant switch — a multi-tenant
+  isolation break. `placeholderData` is therefore a guard function returning
+  `undefined` (drop to loading) when `previousQuery.queryKey[1] !== restaurantId`,
+  keeping rows only for same-restaurant filter changes. Pinned by a test.
 
 ## Decided trade-offs
 

--- a/docs/superpowers/specs/2026-07-08-uncategorized-list-server-filter-design.md
+++ b/docs/superpowers/specs/2026-07-08-uncategorized-list-server-filter-design.md
@@ -1,0 +1,197 @@
+# Design: Server-side Status filter for the POS Sales list
+
+Date: 2026-07-08
+Branch: `fix/uncategorized-list-server-filter` (stacked on `fix/unified-sales-pagination-offset`)
+
+## Problem
+
+On the POS Sales page, the "Status" segmented control (All / Uncategorized /
+Pending Review / Categorized) shows badge counts sourced from the SQL aggregate
+RPC `get_unified_sales_totals` (full-table, correct), but the **list itself**
+filters `categorizationFilter` **client-side over only the rows already loaded**
+into memory (`useUnifiedSales`, `PAGE_SIZE = 500`, ordered `sale_date DESC`).
+
+When the uncategorized rows are older than the most-recent page, the badge says
+"200+" while the list shows ~0 — the reported bug.
+
+### Confirmed against production
+
+Restaurant `Wetzel's - Cold Stone - Alamo Ranch` (`7c0c76e3-…`):
+
+| Metric | Value |
+|---|---|
+| Parent rows | 6,551 |
+| Uncategorized (SQL) | 203 |
+| Uncategorized within first 500-row page | **3** |
+| Position range of uncategorized rows | 261 → 6,539 |
+
+So ~200 uncategorized rows are unreachable in the loaded window. The sibling
+branch `fix/unified-sales-pagination-offset` already repaired the broken
+`getNextPageParam` cursor, but paginating through 6.5k rows client-side to reach
+203 uncategorized ones is the wrong UX and still diverges from the badge until
+everything is loaded.
+
+## Goal
+
+Selecting a Status tab must query the DB for exactly that set, so the list
+matches the badge immediately. For "Uncategorized" (203 rows) this fits in the
+first page — no pagination needed.
+
+## Approach (chosen)
+
+Push `categorizationFilter` into the `useUnifiedSales` PostgREST query as
+additional chained filters, alongside the existing `ilike`/`gte`/`lte`.
+
+### Predicate parity (the correctness contract)
+
+The SQL RPC defines the source of truth. The nullable `is_categorized` column
+means `IS NOT TRUE` = `false OR null`. The client JS uses `!sale.is_categorized`
+(null → falsy). The PostgREST filters must match both. We use
+`.not('is_categorized', 'is', true)` — which serialises to
+`is_categorized=not.is.true` = `is_categorized IS NOT TRUE` — for **exact**
+parity with the RPC in a single filter (handles `false` and `null` together),
+rather than an `.or(...)` construction:
+
+| Tab | RPC predicate | PostgREST filter |
+|---|---|---|
+| `uncategorized` | `is_categorized IS NOT TRUE AND suggested_category_id IS NULL` | `.not('is_categorized','is',true).is('suggested_category_id', null)` |
+| `pending-review` | `is_categorized IS NOT TRUE AND suggested_category_id IS NOT NULL` | `.not('is_categorized','is',true).not('suggested_category_id','is',null)` |
+| `categorized` | `is_categorized IS TRUE` | `.is('is_categorized', true)` |
+| `all` | (no filter) | (no filter) |
+
+Each chained top-level filter becomes its own query-string parameter and
+PostgREST ANDs across them — the same composition the codebase already relies on
+(`src/hooks/useConsumptionIntelligence.tsx:106-107`,
+`src/hooks/useMonthlyMetrics.tsx:239-240`). RPC source:
+`supabase/migrations/20260523000000_unified_sales_totals_categorization_counts.sql:91,95`.
+
+### Performance / indexing (measured, in scope)
+
+`EXPLAIN (ANALYZE, BUFFERS)` on the confirmed prod restaurant for the
+`uncategorized` feed (`ORDER BY sale_date DESC, created_at DESC, id DESC LIMIT
+500`) shows an **Index Scan Backward on `idx_unified_sales_restaurant_date`**
+with **6,630 Rows Removed by Filter, 3,591 buffer hits, 28.5 ms** — effectively a
+full per-restaurant partition scan, because uncategorized rows are the *oldest*
+while the sort wants newest-first. Table is **145k rows / 535 MB** and actively
+written by Toast sync.
+
+- `categorized` and `all` feeds are fine as-is: the newest rows are categorized,
+  so `LIMIT 500` short-circuits on `idx_unified_sales_restaurant_date`.
+- `pending-review` is tiny (single/double-digit rows) and already has a partial
+  index on its `WHERE` (`idx_unified_sales_ai_suggestions`).
+- Only the **uncategorized** feed needs a new index. Add one partial index that
+  mirrors the predicate exactly and carries the sort keys, built
+  `CONCURRENTLY` in its own migration file (repo precedent:
+  `20260626120100_idx_shifts_coverage.sql`):
+
+  ```sql
+  CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_unified_sales_uncategorized_feed
+    ON public.unified_sales (restaurant_id, sale_date DESC, created_at DESC, id DESC)
+    WHERE is_categorized IS NOT TRUE AND suggested_category_id IS NULL;
+  ```
+
+### Changes
+
+1. `src/hooks/useUnifiedSales.tsx`
+   - Add `categorizationFilter?: 'all' | 'uncategorized' | 'pending-review' | 'categorized'`
+     to `UseUnifiedSalesOptions`.
+   - Include it in `queryKey` so switching tabs uses a distinct cache entry.
+   - Apply the filter chain in `fetchUnifiedSalesPage` (default `'all'` → no-op).
+   - Add `placeholderData: keepPreviousData` to the `useInfiniteQuery` so
+     switching tabs keeps the prior rows visible during the refetch instead of
+     blanking to the full-page "Loading sales…" spinner (addresses the
+     tab-switch latency regression from moving the filter server-side).
+
+2. `src/pages/POSSales.tsx`
+   - Pass `categorizationFilter` into the `useUnifiedSales(...)` options object.
+   - Keep the existing client-side filter (lines 292-298) untouched — it becomes
+     a redundant, harmless pass (mirrors how `searchTerm` is already both a
+     server `ilike` and a client filter). This preserves combined
+     recipe/search filtering and avoids destabilizing the render path.
+   - **Empty state:** make the copy tab-aware. When a Status tab legitimately
+     returns 0 rows, "No uncategorized sales" / "Everything in this date range
+     has been reviewed." is a success state, not a "loosen your filters" state
+     (current copy at lines 1213-1215 is misleading for this case).
+   - **Results header:** when `categorizationFilter !== 'all'`, name the active
+     status in the count text (e.g. "203 uncategorized sales") so the header
+     still signals that a filter is narrowing the view (lines 1163-1170).
+
+3. New migration `supabase/migrations/<ts>_idx_unified_sales_uncategorized_feed.sql`
+   (see SQL above).
+
+4. Tests (`tests/unit/useUnifiedSales.categorization.test.ts`)
+   - Assert the exact PostgREST filter calls emitted per tab value (pin the
+     `(column, operator, value)` args, not just that the method was called).
+   - Assert `all` emits none of them (backward-compatible for the other three
+     consumers — `POSSaleDialog`, `Index`, `Recipes` — which never pass it).
+   - Assert `queryKey` distinguishes filter values.
+
+## Non-goals
+
+- No RLS or RPC changes. `get_unified_sales_totals` is already correct and stays
+  the badge source. RLS confirmed unaffected: the added filters only narrow the
+  client-requested set; the `restaurant_id` RLS `USING` clause is ANDed
+  independently and cannot be widened.
+- Not removing the client-side filter (deliberate — see above).
+- Recipe filter stays client-side (unchanged); out of scope.
+- Not pruning the pre-existing redundant `unified_sales` indexes
+  (`idx_unified_sales_restaurant_id`, the duplicate `..._restaurant_date`) —
+  noted for a follow-up, out of scope here.
+- `dashboardMetrics` / badge counts (`useUnifiedSalesTotals`) are verified
+  decoupled: their `queryKey` excludes `categorizationFilter`, so they neither
+  refetch nor flicker on tab switch.
+
+## Risks / edge cases
+
+- **Predicate drift**: if the RPC predicate ever changes, these filters must
+  change in lockstep. Mitigated by a test table mirroring the RPC and a code
+  comment cross-referencing the RPC migration.
+- **`child` splits**: the query does not filter `parent_sale_id`; children are
+  excluded client-side (line 273) and the RPC counts only `parent_sale_id IS
+  NULL`. A child split is never uncategorized-relevant in the badge. Left as-is;
+  the redundant client filter still drops children from the visible list.
+
+  **Categorized-tab angle (reviewed 2026-07-08, decision: keep as-is).** A
+  Phase-7 reviewer (Codex) noted that on the `categorized` tab,
+  `is_categorized=true` child-split rows are returned by the server query and
+  consume page slots before the client filter drops them, so the *visible* row
+  count can trail the badge for split-heavy restaurants. We deliberately do
+  **not** add `.is('parent_sale_id', null)` to the categorization filter,
+  because it would be a **net regression**: `split_pos_sale`
+  (`supabase/migrations/20251122170000_fix_split_pos_sale_cleanup.sql:79-122`)
+  marks the split **parent** `is_split=true, is_categorized=true`, and
+  `useUnifiedSales` builds each parent's `child_splits` from the children present
+  **in the same fetched page** (`src/hooks/useUnifiedSales.tsx:162-166,207-218`).
+  Excluding children server-side would therefore leave categorized split parents
+  with empty `child_splits`, so they'd render as plain cards instead of
+  `SplitSaleView` — losing the split breakdown. The count divergence is (a)
+  pre-existing (children always consumed page slots when the filter was
+  client-side), (b) cosmetic (visible-count parity, not data correctness), and
+  (c) bounded to split-heavy restaurants on one tab. A fully-correct fix
+  (exclude children from slot accounting while still co-loading them for visible
+  parents) is a separate refactor, filed as a follow-up. **Accepted as-is.**
+- **Filter-value injection**: values are static literals, no user input
+  interpolated — safe.
+- **Cache footprint**: `categorizationFilter` in `queryKey` multiplies cache
+  entries (up to 4 tabs × date × search). With 500-row pages and `gcTime` 5 min,
+  a user auditing all four tabs holds ~4 page-1 payloads resident — within
+  budget, but noted.
+- **keepPreviousData flicker**: on tab switch the placeholder briefly shows the
+  previous tab's rows (further narrowed by the new client-side filter) for the
+  ~30 ms until the server responds. Acceptable, and strictly better than a blank
+  full-page spinner.
+
+## Decided trade-offs
+
+- Keeping the client-side categorization filter is intentional redundancy for
+  safety and minimal churn, accepted despite the theoretical risk that it could
+  mask a server/client predicate mismatch. The parity test table is the guard
+  against that.
+- Tab switch now costs a network refetch (first visit per tab per session)
+  instead of an instant client recompute. Accepted: correctness (list matches
+  badge) over false-instant UX. `keepPreviousData` removes the jarring blank so
+  the perceived cost is minimal; subsequent visits within `staleTime` (60 s) are
+  instant cache hits.
+- Only the uncategorized feed gets a new index; pending-review/categorized/all
+  are already served acceptably (measured). Keeps write-amplification on the hot
+  table minimal.

--- a/src/hooks/useUnifiedSales.tsx
+++ b/src/hooks/useUnifiedSales.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useCallback, useMemo } from 'react';
-import { useInfiniteQuery, useQuery, useQueryClient, keepPreviousData } from '@tanstack/react-query';
+import { useInfiniteQuery, useQuery, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from './useAuth';
 import { useToast } from '@/hooks/use-toast';
@@ -201,7 +201,14 @@ export const useUnifiedSales = (restaurantId: string | null, options: UseUnified
     // Keep the previous tab's rows visible while the new categorizationFilter
     // (part of queryKey) refetches, instead of dropping to the full-page
     // loading/empty state. See design doc's "keepPreviousData flicker" note.
-    placeholderData: keepPreviousData,
+    // BUT never reuse rows across a restaurant switch — queryKey[1] is the
+    // restaurantId, and showing another tenant's sales (even briefly) would
+    // break multi-tenant isolation. On a restaurant change, drop the
+    // placeholder so the list shows its loading state instead.
+    placeholderData: (previousData, previousQuery) =>
+      previousQuery && previousQuery.queryKey[1] !== restaurantId
+        ? undefined
+        : previousData,
   });
 
   const flatSales = useMemo(() => {

--- a/src/hooks/useUnifiedSales.tsx
+++ b/src/hooks/useUnifiedSales.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useCallback, useMemo } from 'react';
-import { useInfiniteQuery, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useInfiniteQuery, useQuery, useQueryClient, keepPreviousData } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from './useAuth';
 import { useToast } from '@/hooks/use-toast';
@@ -14,6 +14,7 @@ type UseUnifiedSalesOptions = {
   searchTerm?: string;
   startDate?: string;
   endDate?: string;
+  categorizationFilter?: 'all' | 'uncategorized' | 'pending-review' | 'categorized';
 };
 
 type UnifiedSalesPage = {
@@ -29,9 +30,17 @@ export const useUnifiedSales = (restaurantId: string | null, options: UseUnified
   const normalizedSearchTerm = options.searchTerm?.trim();
   const normalizedStartDate = options.startDate?.trim();
   const normalizedEndDate = options.endDate?.trim();
+  const normalizedCategorizationFilter = options.categorizationFilter || 'all';
   const queryKey = useMemo(
-    () => ['unified-sales', restaurantId, normalizedSearchTerm || '', normalizedStartDate || '', normalizedEndDate || ''],
-    [restaurantId, normalizedSearchTerm, normalizedStartDate, normalizedEndDate]
+    () => [
+      'unified-sales',
+      restaurantId,
+      normalizedSearchTerm || '',
+      normalizedStartDate || '',
+      normalizedEndDate || '',
+      normalizedCategorizationFilter,
+    ],
+    [restaurantId, normalizedSearchTerm, normalizedStartDate, normalizedEndDate, normalizedCategorizationFilter]
   );
 
   const fetchUnifiedSalesPage = useCallback(
@@ -98,6 +107,22 @@ export const useUnifiedSales = (restaurantId: string | null, options: UseUnified
         query = query.lte('sale_date', normalizedEndDate);
       }
 
+      // Predicate parity with the SQL RPC `get_unified_sales_totals`
+      // (supabase/migrations/20260523000000_unified_sales_totals_categorization_counts.sql:91,95).
+      // `is_categorized` is nullable, so "not categorized" must be
+      // `IS NOT TRUE` (false OR null) — `.not('is_categorized', 'is', true)` —
+      // to match the RPC and the client's `!sale.is_categorized` check.
+      // See docs/superpowers/specs/2026-07-08-uncategorized-list-server-filter-design.md
+      // for the full parity table. Keep these predicates in lockstep with the
+      // RPC if it ever changes.
+      if (normalizedCategorizationFilter === 'uncategorized') {
+        query = query.not('is_categorized', 'is', true).is('suggested_category_id', null);
+      } else if (normalizedCategorizationFilter === 'pending-review') {
+        query = query.not('is_categorized', 'is', true).not('suggested_category_id', 'is', null);
+      } else if (normalizedCategorizationFilter === 'categorized') {
+        query = query.is('is_categorized', true);
+      }
+
       query = query
         .order('sale_date', { ascending: false })
         .order('created_at', { ascending: false })
@@ -150,13 +175,14 @@ export const useUnifiedSales = (restaurantId: string | null, options: UseUnified
 
       return { sales: salesWithSplits, hasMore: (data?.length ?? 0) === PAGE_SIZE };
     },
-    [restaurantId, user, normalizedSearchTerm, normalizedStartDate, normalizedEndDate]
+    [restaurantId, user, normalizedSearchTerm, normalizedStartDate, normalizedEndDate, normalizedCategorizationFilter]
   );
 
   const {
     data,
     isLoading: loading,
     isFetchingNextPage: loadingMore,
+    isFetching,
     error,
     fetchNextPage,
     hasNextPage,
@@ -172,6 +198,10 @@ export const useUnifiedSales = (restaurantId: string | null, options: UseUnified
     refetchOnWindowFocus: false,
     refetchOnMount: false,
     refetchOnReconnect: false,
+    // Keep the previous tab's rows visible while the new categorizationFilter
+    // (part of queryKey) refetches, instead of dropping to the full-page
+    // loading/empty state. See design doc's "keepPreviousData flicker" note.
+    placeholderData: keepPreviousData,
   });
 
   const flatSales = useMemo(() => {
@@ -301,11 +331,20 @@ export const useUnifiedSales = (restaurantId: string | null, options: UseUnified
     queryClient.invalidateQueries({ queryKey });
   }, [queryClient, queryKey]);
 
+  // Suppress "Load more" while a non-next-page fetch (e.g. the initial fetch for
+  // a newly selected categorizationFilter tab) is in flight. With
+  // placeholderData: keepPreviousData, hasNextPage/getNextPageParam can still
+  // reflect the *previous* tab's placeholder pages for the brief window before
+  // the new tab's first page resolves — so both the exposed hasMore flag AND
+  // loadMoreSales must share this guard, or a caller could fetch the new filter
+  // at an offset computed from the stale placeholder page count.
+  const canLoadMore = !!hasNextPage && !(isFetching && !loadingMore);
+
   const loadMoreSales = useCallback(() => {
-    if (hasNextPage) {
+    if (canLoadMore) {
       fetchNextPage();
     }
-  }, [fetchNextPage, hasNextPage]);
+  }, [fetchNextPage, canLoadMore]);
 
   const createManualSale = async (saleData: {
     itemName: string;
@@ -582,7 +621,9 @@ export const useUnifiedSales = (restaurantId: string | null, options: UseUnified
     sales: flatSales,
     loading,
     loadingMore,
-    hasMore: !!hasNextPage,
+    // Guarded so the "Load more" affordance and loadMoreSales stay consistent
+    // (see canLoadMore above).
+    hasMore: canLoadMore,
     loadMoreSales,
     unmappedItems,
     fetchUnifiedSales: refetchSales,

--- a/src/pages/POSSales.tsx
+++ b/src/pages/POSSales.tsx
@@ -47,6 +47,25 @@ import { useBulkCategorizePosSales } from "@/hooks/useBulkPosSaleActions";
 import { isMultiSelectKey } from "@/utils/bulkEditUtils";
 import { Checkbox } from "@/components/ui/checkbox";
 
+// Lowercase, singular-tab labels for the active Status filter — used to make
+// the results header and empty state name the active tab (e.g. "203
+// uncategorized sales", "No uncategorized sales"). Keep in sync with the
+// Status segmented control's `option.label` values below.
+const CATEGORIZATION_FILTER_LABELS: Record<'uncategorized' | 'pending-review' | 'categorized', string> = {
+  uncategorized: 'uncategorized',
+  'pending-review': 'pending review',
+  categorized: 'categorized',
+};
+
+// Empty-state sub-copy per Status tab. An empty "uncategorized"/"pending review"
+// tab is a done state ("everything reviewed"); an empty "categorized" tab means
+// nothing has been categorized yet — the opposite, so its copy must differ.
+const CATEGORIZATION_EMPTY_SUBCOPY: Record<'uncategorized' | 'pending-review' | 'categorized', string> = {
+  uncategorized: 'Everything in this date range has been reviewed.',
+  'pending-review': 'No AI suggestions are waiting for review.',
+  categorized: 'Nothing has been categorized in this date range yet.',
+};
+
 export default function POSSales() {
   const {
     selectedRestaurant,
@@ -132,6 +151,7 @@ export default function POSSales() {
     searchTerm,
     startDate: startDate || undefined,
     endDate: endDate || undefined,
+    categorizationFilter,
   });
 
   // Server-side aggregated totals for dashboard metrics (independent of pagination).
@@ -1162,11 +1182,16 @@ export default function POSSales() {
               {/* Results header bar */}
               <div className="flex items-center justify-between">
                 <p className="text-[13px] text-muted-foreground">
-                  {filteredSales.length === sales.length ? (
-                    <>{sales.length.toLocaleString()} sales</>
-                  ) : (
-                    <>{filteredSales.length.toLocaleString()} of {sales.length.toLocaleString()} sales</>
-                  )}
+                  {(() => {
+                    const statusLabel = categorizationFilter !== 'all'
+                      ? `${CATEGORIZATION_FILTER_LABELS[categorizationFilter]} `
+                      : '';
+                    return filteredSales.length === sales.length ? (
+                      <>{sales.length.toLocaleString()} {statusLabel}sales</>
+                    ) : (
+                      <>{filteredSales.length.toLocaleString()} of {sales.length.toLocaleString()} {statusLabel}sales</>
+                    );
+                  })()}
                 </p>
                 <div className="flex items-center gap-2">
                   {hasMore && (
@@ -1211,8 +1236,17 @@ export default function POSSales() {
                   <div className="w-12 h-12 rounded-full bg-muted/50 flex items-center justify-center mb-4">
                     <Search className="w-6 h-6 text-muted-foreground/50" />
                   </div>
-                  <p className="text-[15px] font-medium text-foreground mb-1">No sales found</p>
-                  <p className="text-[13px] text-muted-foreground">Try adjusting your filters or date range.</p>
+                  {categorizationFilter !== 'all' && !searchTerm && recipeFilter === 'all' ? (
+                    <>
+                      <p className="text-[15px] font-medium text-foreground mb-1">No {CATEGORIZATION_FILTER_LABELS[categorizationFilter]} sales</p>
+                      <p className="text-[13px] text-muted-foreground">{CATEGORIZATION_EMPTY_SUBCOPY[categorizationFilter]}</p>
+                    </>
+                  ) : (
+                    <>
+                      <p className="text-[15px] font-medium text-foreground mb-1">No sales found</p>
+                      <p className="text-[13px] text-muted-foreground">Try adjusting your filters or date range.</p>
+                    </>
+                  )}
                 </div>
               ) : (
                 <div className="space-y-0">

--- a/supabase/migrations/20260708193107_idx_unified_sales_uncategorized_feed.sql
+++ b/supabase/migrations/20260708193107_idx_unified_sales_uncategorized_feed.sql
@@ -1,0 +1,12 @@
+-- Serves the POS Sales "Uncategorized" tab feed (server-side filter in
+-- useUnifiedSales): WHERE is_categorized IS NOT TRUE AND suggested_category_id
+-- IS NULL, ORDER BY sale_date DESC, created_at DESC, id DESC, LIMIT 500.
+-- Uncategorized rows are the oldest, so a newest-first scan of
+-- idx_unified_sales_restaurant_date reads the whole restaurant partition
+-- (measured: 6.6k rows filtered, ~28ms) — this partial index makes it a bounded
+-- scan of just the matching rows. Mirrors the get_unified_sales_totals predicate
+-- (20260523000000). CONCURRENTLY cannot run inside a transaction, so this lives
+-- in its own migration file.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_unified_sales_uncategorized_feed
+  ON public.unified_sales (restaurant_id, sale_date DESC, created_at DESC, id DESC)
+  WHERE is_categorized IS NOT TRUE AND suggested_category_id IS NULL;

--- a/tests/unit/posSalesTabAwareEmptyStateAndHeader.test.ts
+++ b/tests/unit/posSalesTabAwareEmptyStateAndHeader.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const SOURCE = readFileSync(
+  resolve(__dirname, '../../src/pages/POSSales.tsx'),
+  'utf8',
+);
+
+// Regression guard: when a Status tab (Uncategorized/Pending Review/Categorized)
+// legitimately returns 0 rows, that is a success state (everything reviewed),
+// not a "loosen your filters" state. And the results header should name the
+// active status so it's clear the count is scoped to that tab. See design doc
+// docs/superpowers/specs/2026-07-08-uncategorized-list-server-filter-design.md.
+describe('POSSales — tab-aware empty state + results header', () => {
+  it('shows tab-specific empty-state sub-copy when a Status tab is active and no search term', () => {
+    // Sub-copy is per-tab: an empty "categorized" tab means nothing categorized
+    // yet (NOT "everything reviewed"), so the copy must differ by tab.
+    expect(SOURCE).toMatch(/Everything in this date range has been reviewed\./);
+    expect(SOURCE).toMatch(/Nothing has been categorized in this date range yet\./);
+    expect(SOURCE).toMatch(/CATEGORIZATION_EMPTY_SUBCOPY\[categorizationFilter\]/);
+    // The success-state heading should be conditioned on categorizationFilter,
+    // not always "No sales found".
+    expect(SOURCE).toMatch(/No \{CATEGORIZATION_FILTER_LABELS\[categorizationFilter\]\} sales/);
+  });
+
+  it('still shows the generic "no sales found" copy when categorizationFilter is "all"', () => {
+    expect(SOURCE).toMatch(/No sales found/);
+    expect(SOURCE).toMatch(/Try adjusting your filters or date range\./);
+  });
+
+  it('conditions the empty-state branch on an active Status tab with no other narrowing filter', () => {
+    // Must also require recipeFilter === 'all' and no search term, so the
+    // reassurance copy isn't shown when a different filter caused the 0 rows.
+    expect(SOURCE).toMatch(/categorizationFilter !== 'all' && !searchTerm && recipeFilter === 'all'/);
+  });
+
+  it('includes the active status label in the results header count when a tab is active', () => {
+    // e.g. "203 uncategorized sales" — the header text should reference the
+    // active tab's label when categorizationFilter !== 'all'.
+    const markerIndex = SOURCE.indexOf('Results header bar');
+    expect(markerIndex).toBeGreaterThan(-1);
+    const resultsHeaderSection = SOURCE.slice(markerIndex, markerIndex + 1200);
+    expect(resultsHeaderSection).toMatch(/categorizationFilter !== 'all'/);
+  });
+});

--- a/tests/unit/posSalesWiresCategorizationFilter.test.ts
+++ b/tests/unit/posSalesWiresCategorizationFilter.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const SOURCE = readFileSync(
+  resolve(__dirname, '../../src/pages/POSSales.tsx'),
+  'utf8',
+);
+
+// Regression guard: the "Uncategorized"/"Pending Review"/"Categorized" Status
+// tabs must query the DB directly (useUnifiedSales) instead of only filtering
+// whatever page of rows happens to already be loaded client-side. See design
+// doc docs/superpowers/specs/2026-07-08-uncategorized-list-server-filter-design.md.
+describe('POSSales — categorizationFilter is wired into useUnifiedSales', () => {
+  it('passes categorizationFilter into the useUnifiedSales(...) options object', () => {
+    const useUnifiedSalesCallMatch = SOURCE.match(
+      /=\s*useUnifiedSales\(selectedRestaurant\?\.restaurant_id \|\| null,\s*\{([\s\S]*?)\}\);/,
+    );
+    expect(useUnifiedSalesCallMatch).not.toBeNull();
+    const optionsBody = useUnifiedSalesCallMatch![1];
+    expect(optionsBody).toMatch(/categorizationFilter/);
+  });
+
+  it('keeps the existing client-side categorization filter intact (redundant, not removed)', () => {
+    // Design doc: client-side filter stays as a harmless redundant pass,
+    // mirroring how searchTerm is both server ilike + client filter.
+    expect(SOURCE).toMatch(/if \(categorizationFilter === 'uncategorized'\)/);
+    expect(SOURCE).toMatch(/if \(categorizationFilter === 'categorized'\)/);
+  });
+});

--- a/tests/unit/useUnifiedSales.categorization.test.ts
+++ b/tests/unit/useUnifiedSales.categorization.test.ts
@@ -1,0 +1,148 @@
+import React, { ReactNode } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// --- Mock auth + toast (hook calls useAuth() and useToast()) ---
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { id: 'user-1' } }),
+}));
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+// --- Mock the Supabase client query builder ---
+const { mockSupabase } = vi.hoisted(() => ({
+  mockSupabase: { from: vi.fn() },
+}));
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: mockSupabase,
+}));
+
+import { useUnifiedSales } from '@/hooks/useUnifiedSales';
+
+// Records every .not() / .is() call the hook makes against unified_sales.
+// `kind` distinguishes which PostgREST builder method produced the call
+// (.not(col, op, value) vs .is(col, value)) since 'uncategorized' and
+// 'pending-review' touch the same two columns but with opposite methods
+// per the design's parity table — collapsing them to the same tuple shape
+// would make the two tabs indistinguishable to this test.
+type FilterCall = { kind: 'not' | 'is'; column: string; operator?: string; value: unknown };
+let filterCalls: FilterCall[];
+
+// Chainable builder: every method returns the builder; awaiting it resolves
+// with an empty page. When `capture` is true, `.not`/`.is` calls are recorded
+// into `filterCalls` — only the `unified_sales` builder captures, so the
+// unrelated `.not('pos_item_name', 'is', null)` call the hook's separate
+// `recipes` query issues doesn't leak into these assertions.
+function makeBuilder(capture: boolean) {
+  const builder: any = {};
+  for (const m of ['select', 'eq', 'ilike', 'gte', 'lte', 'order', 'range']) {
+    builder[m] = vi.fn(() => builder);
+  }
+  builder.not = vi.fn((column: string, operator: string, value: unknown) => {
+    if (capture) filterCalls.push({ kind: 'not', column, operator, value });
+    return builder;
+  });
+  builder.is = vi.fn((column: string, value: unknown) => {
+    if (capture) filterCalls.push({ kind: 'is', column, value });
+    return builder;
+  });
+  builder.then = (onFulfilled: any, onRejected: any) =>
+    Promise.resolve({ data: [], error: null }).then(onFulfilled, onRejected);
+  return builder;
+}
+
+function setup() {
+  filterCalls = [];
+  mockSupabase.from.mockImplementation((table: string) => {
+    if (table === 'recipes') {
+      return makeBuilder(false);
+    }
+    return makeBuilder(true);
+  });
+}
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+};
+
+describe('useUnifiedSales categorization filter (server-side)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uncategorized: .not('is_categorized','is',true) AND .is('suggested_category_id', null)", async () => {
+    setup();
+
+    const { result } = renderHook(
+      () => useUnifiedSales('rest-1', { categorizationFilter: 'uncategorized' }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(filterCalls).toEqual([
+      { kind: 'not', column: 'is_categorized', operator: 'is', value: true },
+      { kind: 'is', column: 'suggested_category_id', value: null },
+    ]);
+  });
+
+  it("pending-review: .not('is_categorized','is',true) AND .not('suggested_category_id','is',null)", async () => {
+    setup();
+
+    const { result } = renderHook(
+      () => useUnifiedSales('rest-1', { categorizationFilter: 'pending-review' }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(filterCalls).toEqual([
+      { kind: 'not', column: 'is_categorized', operator: 'is', value: true },
+      { kind: 'not', column: 'suggested_category_id', operator: 'is', value: null },
+    ]);
+  });
+
+  it("categorized: .is('is_categorized', true) only (no suggested_category_id predicate)", async () => {
+    setup();
+
+    const { result } = renderHook(
+      () => useUnifiedSales('rest-1', { categorizationFilter: 'categorized' }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(filterCalls).toEqual([{ kind: 'is', column: 'is_categorized', value: true }]);
+  });
+
+  it('all: emits no categorization filter calls', async () => {
+    setup();
+
+    const { result } = renderHook(
+      () => useUnifiedSales('rest-1', { categorizationFilter: 'all' }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(filterCalls).toEqual([]);
+  });
+
+  it('omitted: emits no categorization filter calls (backward compatible)', async () => {
+    setup();
+
+    const { result } = renderHook(() => useUnifiedSales('rest-1'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(filterCalls).toEqual([]);
+  });
+});

--- a/tests/unit/useUnifiedSales.keepPreviousData.test.ts
+++ b/tests/unit/useUnifiedSales.keepPreviousData.test.ts
@@ -1,0 +1,139 @@
+import React, { ReactNode } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// --- Mock auth + toast (hook calls useAuth() and useToast()) ---
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { id: 'user-1' } }),
+}));
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+// --- Mock the Supabase client query builder ---
+const { mockSupabase } = vi.hoisted(() => ({
+  mockSupabase: { from: vi.fn() },
+}));
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: mockSupabase,
+}));
+
+import { useUnifiedSales } from '@/hooks/useUnifiedSales';
+
+// Build a single distinct row per categorizationFilter value so we can tell,
+// by id, which tab's data is currently rendered.
+function rowFor(filterValue: string) {
+  return {
+    id: `row-${filterValue}`,
+    restaurant_id: 'rest-1',
+    pos_system: 'toast',
+    external_order_id: `ord-${filterValue}`,
+    external_item_id: `item-${filterValue}`,
+    item_name: `Item ${filterValue}`,
+    quantity: 1,
+    unit_price: 1,
+    total_price: 1,
+    sale_date: '2026-07-01',
+    sale_time: '10:00:00',
+    pos_category: null,
+    synced_at: null,
+    created_at: '2026-07-01T10:00:00Z',
+    category_id: null,
+    suggested_category_id: filterValue === 'pending-review' ? 'chart-1' : null,
+    ai_confidence: null,
+    ai_reasoning: null,
+    item_type: 'sale',
+    adjustment_type: null,
+    is_categorized: filterValue === 'categorized',
+    is_split: false,
+    parent_sale_id: null,
+    suggested_chart_account: null,
+    approved_chart_account: null,
+  };
+}
+
+// Chainable builder: every method returns the builder. Resolution of the
+// `unified_sales` query is gated by a manually-controlled deferred promise
+// so the test can hold a refetch "in flight" and observe hook output while
+// pending. The row returned encodes which `.is('suggested_category_id', ...)`
+// / `.is('is_categorized', ...)` filter was applied, standing in for the
+// server actually filtering by categorizationFilter.
+function makeBuilder(resolvePage: () => Promise<{ data: any; error: any }>) {
+  const builder: any = {};
+  for (const m of ['select', 'eq', 'ilike', 'gte', 'lte', 'not', 'is', 'order', 'range']) {
+    builder[m] = vi.fn(() => builder);
+  }
+  builder.then = (onFulfilled: any, onRejected: any) =>
+    resolvePage().then(onFulfilled, onRejected);
+  return builder;
+}
+
+type Deferred<T> = { promise: Promise<T>; resolve: (v: T) => void };
+function defer<T>(): Deferred<T> {
+  let resolve!: (v: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 300000, staleTime: 60000 } },
+  });
+  return ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+};
+
+describe('useUnifiedSales keepPreviousData (tab-switch UX)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('keeps previous rows visible (non-empty) while refetching after categorizationFilter changes', async () => {
+    // First tab ('uncategorized') resolves immediately.
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === 'recipes') {
+        return makeBuilder(() => Promise.resolve({ data: [], error: null }));
+      }
+      return makeBuilder(() => Promise.resolve({ data: [rowFor('uncategorized')], error: null }));
+    });
+
+    const wrapper = createWrapper();
+    const { result, rerender } = renderHook(
+      ({ categorizationFilter }: { categorizationFilter: 'uncategorized' | 'pending-review' }) =>
+        useUnifiedSales('rest-1', { categorizationFilter }),
+      { wrapper, initialProps: { categorizationFilter: 'uncategorized' } }
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.sales).toHaveLength(1);
+    expect(result.current.sales[0].id).toBe('row-uncategorized');
+
+    // Now switch tabs to 'pending-review'. Gate the new query's resolution
+    // behind a deferred promise so we can inspect hook state mid-flight.
+    const gate = defer<{ data: any; error: any }>();
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === 'recipes') {
+        return makeBuilder(() => Promise.resolve({ data: [], error: null }));
+      }
+      return makeBuilder(() => gate.promise);
+    });
+
+    rerender({ categorizationFilter: 'pending-review' });
+
+    // While the new tab's fetch is still pending, the hook must not drop to
+    // an empty/loading state — placeholderData: keepPreviousData should keep
+    // the previous tab's row visible.
+    await waitFor(() => {
+      expect(result.current.sales.length).toBeGreaterThan(0);
+    });
+    expect(result.current.sales[0].id).toBe('row-uncategorized');
+
+    // Resolve the pending-review fetch and confirm it eventually swaps in.
+    gate.resolve({ data: [rowFor('pending-review')], error: null });
+
+    await waitFor(() => expect(result.current.sales[0].id).toBe('row-pending-review'));
+  });
+});

--- a/tests/unit/useUnifiedSales.keepPreviousData.test.ts
+++ b/tests/unit/useUnifiedSales.keepPreviousData.test.ts
@@ -136,4 +136,41 @@ describe('useUnifiedSales keepPreviousData (tab-switch UX)', () => {
 
     await waitFor(() => expect(result.current.sales[0].id).toBe('row-pending-review'));
   });
+
+  it('does NOT reuse the previous restaurant\'s rows across a restaurant switch (multi-tenant isolation)', async () => {
+    // A row tagged by restaurant so we can detect any cross-tenant bleed by id.
+    const rowForRestaurant = (rid: string) => ({ ...rowFor('uncategorized'), id: `row-${rid}`, restaurant_id: rid });
+
+    // rest-1 resolves immediately.
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === 'recipes') return makeBuilder(() => Promise.resolve({ data: [], error: null }));
+      return makeBuilder(() => Promise.resolve({ data: [rowForRestaurant('rest-1')], error: null }));
+    });
+
+    const wrapper = createWrapper();
+    const { result, rerender } = renderHook(
+      ({ restaurantId }: { restaurantId: string }) =>
+        useUnifiedSales(restaurantId, { categorizationFilter: 'uncategorized' }),
+      { wrapper, initialProps: { restaurantId: 'rest-1' } }
+    );
+
+    await waitFor(() => expect(result.current.sales[0]?.id).toBe('row-rest-1'));
+
+    // Switch restaurants; gate rest-2's fetch so we can inspect mid-flight.
+    const gate = defer<{ data: any; error: any }>();
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === 'recipes') return makeBuilder(() => Promise.resolve({ data: [], error: null }));
+      return makeBuilder(() => gate.promise);
+    });
+
+    rerender({ restaurantId: 'rest-2' });
+
+    // While rest-2's fetch is pending, the hook must NOT keep showing rest-1's
+    // row — the restaurant-scoped placeholder guard drops it (loading state).
+    await waitFor(() => expect(result.current.loading).toBe(true));
+    expect(result.current.sales.find((s) => s.id === 'row-rest-1')).toBeUndefined();
+
+    gate.resolve({ data: [rowForRestaurant('rest-2')], error: null });
+    await waitFor(() => expect(result.current.sales[0]?.id).toBe('row-rest-2'));
+  });
 });


### PR DESCRIPTION
## Problem

On the **POS Sales** page, the "Status" tabs (All / Uncategorized / Pending Review / Categorized) showed badge counts from a full-table SQL aggregate, but the **list itself filtered client-side over only the ~500 rows loaded in memory**. When the uncategorized rows were older than that window, the badge said "200+" while the list showed ~0 — the reported bug ("uncategorized count is off, nothing shows on the list").

### Confirmed against production
Restaurant `Wetzel's - Cold Stone - Alamo Ranch`: **6,551 parent rows, 203 uncategorized**, of which only **3** fell inside the first 500-row page (positions 261–6,539). A compounding pagination-cursor bug made the older rows unreachable and inflated the denominator to "11,000" (22 × 500 duplicate page-0 fetches).

## Fix

This PR bundles two coupled fixes (the second stacked on the first):

**1. Pagination cursor** (`fix/unified-sales-pagination-offset`)
- `getNextPageParam` derived the next offset from `lastPage.nextPage`, which was never set → always `0`, so "Load more" refetched page 0 forever. Now derives the offset from `allPages.length * PAGE_SIZE`, plus an `id` ORDER BY tiebreaker for deterministic OFFSET paging.

**2. Server-side Status filter** (this branch)
- `useUnifiedSales` now accepts `categorizationFilter` and pushes it into the PostgREST query with **exact parity** to the `get_unified_sales_totals` RPC predicates (`.not('is_categorized','is',true)` = `IS NOT TRUE`). Selecting a tab now queries the DB directly, so the list matches the badge — the 203 uncategorized rows fit in the first page.
- `placeholderData: keepPreviousData` keeps rows visible on tab switch instead of a blank spinner; the `hasMore` / `loadMoreSales` guard is shared so no fetch happens at a stale placeholder offset.
- Tab-aware empty state + results header (per-tab sub-copy: an empty "categorized" tab means *nothing categorized yet*, not "everything reviewed").
- **Partial index** (`CONCURRENTLY`) for the uncategorized feed — the query was a measured full-partition scan (6,630 rows filtered, ~28 ms) on the 535 MB / 145k-row table because uncategorized rows are the oldest under a newest-first sort.

## Design decision (recorded)
A Phase-7 reviewer flagged that the `categorized` tab doesn't exclude child splits server-side. Adding `.is('parent_sale_id', null)` was **rejected** because `split_pos_sale` marks the split parent `is_categorized=true` and the hook builds `child_splits` from children co-loaded in the same page — excluding them would break `SplitSaleView` rendering. The divergence is pre-existing, cosmetic, and bounded; a proper fix is filed as a follow-up. See the design doc's "child splits → Categorized-tab angle" section.

## Testing
- New unit tests: server-side filter parity per tab, `keepPreviousData` on tab switch, pagination offset regression, page-wiring + tab-aware empty state/header (**18/18** in the affected suites).
- Full suite: 5,845 pass (6 files fail only on a locally-unpopulated `fast-xml-parser`, which is in `package.json` and installed fresh on CI — unrelated to this change).
- `typecheck` clean, production `build` passes, **CodeRabbit: no findings**.
- Design reviewed pre-code (Supabase + Frontend), five-model + Codex + CodeRabbit review post-code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
