### PR TITLE
fix(banking): persist payee/supplier/notes on no-op-category categorize

### DIFF
--- a/docs/superpowers/plans/2026-07-09-categorize-noop-metadata-plan.md
+++ b/docs/superpowers/plans/2026-07-09-categorize-noop-metadata-plan.md
@@ -1,0 +1,52 @@
+# Plan: Persist payee/supplier/notes on no-op-category categorize
+
+**Design:** `docs/superpowers/specs/2026-07-09-categorize-noop-metadata-design.md`
+**Branch:** `fix/categorize-noop-metadata`
+
+## Tasks
+
+### Task 1 — Write failing pgTAP test (RED)
+- Create `supabase/tests/categorize_noop_preserves_metadata.sql`.
+- Model on `supabase/tests/categorize_transfer_account.sql` (fixture pattern,
+  `SET LOCAL role`, `request.jwt.claims`, ON CONFLICT DO UPDATE).
+- Fixtures: auth user, restaurant, `user_restaurants` (owner), chart_of_accounts
+  (1000 Cash + one expense category), connected_bank, one bank_transaction
+  (uncategorized, negative amount). Dates relative to `CURRENT_DATE`.
+- Steps/assertions:
+  1. Initial categorize to expense category A → succeeds.
+  2. Re-call with **same** category A + `p_supplier_id` + `p_normalized_payee`
+     → assert `supplier_id` and `normalized_payee` now persisted.
+  3. Assert the no-op call returned `is_reclassification = false` and
+     `journal_entry_id IS NULL` (short-circuit still skips ledger).
+  4. Assert `notes` preserved when `p_description` is NULL on the no-op call
+     (set a note first via the initial categorize's description, then confirm
+     it survives the metadata-only call).
+  5. Regression: assert the journal-entries count for the txn did not increase
+     on the no-op call (no spurious reclassification entry).
+- Dependency: none. Expected to FAIL against current function.
+
+### Task 2 — Migration: replace function with metadata-preserving short-circuit (GREEN)
+- Create `supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql`
+  (bump timestamp if a newer migration has landed; must sort last).
+- `CREATE OR REPLACE FUNCTION public.categorize_bank_transaction(...)` copying
+  the full latest body from `20251021204739_...sql` verbatim, inserting only the
+  metadata `UPDATE ... COALESCE(...)` block inside the short-circuit `IF` before
+  its `RETURN` (per design doc).
+- Preserve signature, `SECURITY DEFINER`, `SET search_path TO 'public'`, the
+  membership auth check, and all journal-entry logic unchanged.
+- Header comment explaining the fix + pointer to the design doc.
+- Verify test from Task 1 now passes.
+
+### Task 3 — Verify & regression sweep
+- `npm run test:db` (pgTAP) — new test green, existing
+  `categorize_transfer_account.sql` + `categorization_background_rules.test.sql`
+  still green.
+- `npm run typecheck`, `npm run lint`, `npm run build` (no TS change expected,
+  but run to be safe).
+- No frontend change — confirm supplier join + invalidation already present.
+
+## Notes / risks
+- Migration-timestamp collision: pick a timestamp strictly greater than the
+  latest existing migration.
+- No `is_transfer` change; no read-path change; scope is the write path only.
+- Fold any Phase 2.5 supabase-design-reviewer concerns before Task 2.

--- a/docs/superpowers/specs/2026-07-09-categorize-noop-metadata-design.md
+++ b/docs/superpowers/specs/2026-07-09-categorize-noop-metadata-design.md
@@ -1,0 +1,121 @@
+# Design: Persist payee/supplier/notes on no-op-category categorize
+
+**Date:** 2026-07-09
+**Type:** Bug fix (database RPC)
+**Branch:** `fix/categorize-noop-metadata`
+
+## Problem
+
+On `/banking`, setting a **payee/supplier** on a transaction that is *already
+categorized* shows a success toast ("Transaction categorized") but the value
+never displays after refetch.
+
+Reproduction (deterministic):
+1. Open a bank transaction that already has a category (e.g. a Shift4 POS
+   processing fee already categorized as "POS processing fees").
+2. In the detail sheet, set Payee/Supplier to a supplier (e.g. "Cold Stone
+   Creamery"), keeping the same category. Save.
+3. Toast says saved; the supplier/payee is not shown on the row or on reopen.
+
+## Root cause
+
+`categorize_bank_transaction` (latest definition:
+`supabase/migrations/20251021204739_73ec6be4-...sql`, lines 118-126) has a
+short-circuit that returns early **when the category does not change**:
+
+```sql
+IF v_is_reclassification AND v_original_category_id = p_category_id THEN
+  RETURN jsonb_build_object('success', true, ...);   -- returns HERE
+END IF;
+```
+
+This short-circuit was added intentionally to avoid emitting a spurious
+*reclassification* journal entry for a no-op category change. But it returns
+**before** the `UPDATE bank_transactions` (lines 248-256) that persists
+`normalized_payee`, `supplier_id`, and `notes`. So a metadata-only edit that
+keeps the same category is silently dropped:
+
+- RPC returns `success: true` → `onSuccess` fires → toast shows "saved".
+- `supplier_id` / `normalized_payee` were never written → React Query refetch
+  shows the old row → "it doesn't display it".
+
+The **display path is correct** — `useBankTransactions` already joins
+`supplier:suppliers(id, name)` and selects `normalized_payee`. The defect is
+entirely in the write path.
+
+### Who can reach the short-circuit
+
+Only UI callers. The rules engine
+(`apply_matching_rules_to_bank_transactions_batch`, migration
+`20251127120000`) selects `is_categorized = false OR category_id IS NULL`
+only (line 156), so it can never satisfy the short-circuit's
+`v_is_reclassification` precondition (`is_categorized = true AND category_id
+IS NOT NULL`). Confirmed for all `PERFORM categorize_bank_transaction` call
+sites. UI callers: `TransactionDetailSheet.handleSave` (passes
+description/payee/supplier) and `Transactions.tsx.handleCategorize` (passes
+neither description, payee, nor supplier).
+
+## Fix
+
+Add a metadata-preserving `UPDATE` inside the short-circuit branch, before the
+early `RETURN`. Keep the journal-entry skip (that part is correct — no ledger
+movement for a no-op category).
+
+```sql
+IF v_is_reclassification AND v_original_category_id = p_category_id THEN
+  -- Category unchanged: no journal entry needed, but still persist metadata
+  -- edits (payee / supplier / notes) so a UI "Save" is not a silent no-op.
+  UPDATE bank_transactions
+  SET
+    normalized_payee = COALESCE(p_normalized_payee, normalized_payee),
+    supplier_id      = COALESCE(p_supplier_id, supplier_id),
+    notes            = COALESCE(p_description, notes),
+    updated_at       = now()
+  WHERE id = p_transaction_id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'journal_entry_id', NULL,
+    'is_reclassification', false,
+    'transaction_id', p_transaction_id
+  );
+END IF;
+```
+
+Delivered as a new migration that `CREATE OR REPLACE`s the whole function
+(copying the latest body verbatim and inserting only this block). `CREATE OR
+REPLACE` preserves existing GRANTs.
+
+### Decided trade-offs
+
+- **`notes` uses `COALESCE(p_description, notes)`** (preserve-on-null), not the
+  unconditional `notes = p_description` used by the main path. Rationale:
+  `Transactions.tsx` calls the RPC with `p_description = NULL`; if it ever
+  targets an already-categorized txn at the same category, an unconditional
+  overwrite would wipe a user's manual note. Preserve-on-null is also
+  consistent with how `normalized_payee`/`supplier_id` are already handled here
+  ("preserve … with COALESCE"). Consequence: a user cannot *clear* notes to
+  empty via a no-op-category edit — acceptable, and moot in practice because
+  the detail sheet already sends `description || undefined` (empty string never
+  reaches the RPC as a value).
+- **Clearing a supplier is still not supported** (`COALESCE` keeps the existing
+  value when `NULL` is passed). Unchanged from current behavior; out of scope.
+- **No frontend change.** The React Query invalidation and supplier join
+  already exist; once the write persists, the refetch displays it.
+
+## Test plan
+
+New pgTAP test `supabase/tests/categorize_noop_preserves_metadata.sql`
+(modeled on `categorize_transfer_account.sql`):
+
+1. Categorize a txn to category A (initial categorization creates the row +
+   journal entry).
+2. Re-call `categorize_bank_transaction` with the **same** category A plus a
+   `supplier_id` and `normalized_payee` → assert both are persisted and
+   `journal_entry_id` is NULL / `is_reclassification` false (short-circuit
+   still skips the ledger).
+3. Assert `notes` is preserved when `p_description` is NULL on a no-op call.
+4. Regression: assert no extra reclassification journal entry was created for
+   the no-op call.
+
+Dates computed relative to `CURRENT_DATE` (no hardcoded future dates).

--- a/docs/superpowers/specs/2026-07-09-categorize-noop-metadata-design.md
+++ b/docs/superpowers/specs/2026-07-09-categorize-noop-metadata-design.md
@@ -63,12 +63,17 @@ movement for a no-op category).
 
 ```sql
 IF v_is_reclassification AND v_original_category_id = p_category_id THEN
-  -- Category unchanged: no journal entry needed, but still persist metadata
-  -- edits (payee / supplier / notes) so a UI "Save" is not a silent no-op.
+  -- Category unchanged: no journal entry needed (skipping rebuild_account_balances
+  -- is correct — no ledger movement), but still persist metadata edits
+  -- (payee / supplier / notes) so a UI "Save" is not a silent no-op.
   UPDATE bank_transactions
   SET
     normalized_payee = COALESCE(p_normalized_payee, normalized_payee),
     supplier_id      = COALESCE(p_supplier_id, supplier_id),
+    -- COALESCE (preserve-on-null), NOT the main path's unconditional
+    -- `notes = p_description`: Transactions.tsx calls this RPC with
+    -- p_description = NULL, so an unconditional write here would wipe a user's
+    -- note on a same-category call. Intentional asymmetry — do not "fix".
     notes            = COALESCE(p_description, notes),
     updated_at       = now()
   WHERE id = p_transaction_id;
@@ -84,7 +89,9 @@ END IF;
 
 Delivered as a new migration that `CREATE OR REPLACE`s the whole function
 (copying the latest body verbatim and inserting only this block). `CREATE OR
-REPLACE` preserves existing GRANTs.
+REPLACE` preserves existing GRANTs. **The inline `notes` comment above must
+appear verbatim in the migration** (Phase 2.5 review) so a future reader does
+not collapse the intentional asymmetry.
 
 ### Decided trade-offs
 

--- a/docs/superpowers/specs/2026-07-09-categorize-noop-metadata-design.md
+++ b/docs/superpowers/specs/2026-07-09-categorize-noop-metadata-design.md
@@ -109,6 +109,21 @@ not collapse the intentional asymmetry.
   value when `NULL` is passed). Unchanged from current behavior; out of scope.
 - **No frontend change.** The React Query invalidation and supplier join
   already exist; once the write persists, the refetch displays it.
+- **Tenant-scope guard hoisted (scope expansion, post-review).** Codex (Phase
+  7b) and CodeRabbit (PR review) both flagged that `p_supplier_id` is written
+  without verifying it belongs to the transaction's restaurant — a cross-tenant
+  supplier-link gap on a `SECURITY DEFINER` function whose `supplier_id` column
+  has only a plain FK to `suppliers(id)`. The gap existed in both the new no-op
+  branch and the pre-existing main path. Rather than guard only the new branch,
+  the guard is **hoisted** to run once right after the membership auth check, so
+  it sanitizes `p_supplier_id` (reset to `NULL` when not visible to the
+  restaurant) for both the short-circuit and the main categorize/reclassify
+  UPDATE. Silently dropping (not raising) matches the metadata-preserving intent
+  and the COALESCE-preserve semantics. Justification for expanding beyond the
+  original "only the new block" scope: two independent reviewers flagged the same
+  defensive gap in the exact function being replaced, and a sibling guard already
+  existed — per `memory/lessons.md`, consistency + security outrank the
+  minimal-diff default here.
 
 ## Test plan
 
@@ -124,5 +139,11 @@ New pgTAP test `supabase/tests/categorize_noop_preserves_metadata.sql`
 3. Assert `notes` is preserved when `p_description` is NULL on a no-op call.
 4. Regression: assert no extra reclassification journal entry was created for
    the no-op call.
+5. Cross-tenant guard (no-op branch): passing a foreign-restaurant supplier UUID
+   on a no-op call leaves the own-tenant `supplier_id` intact.
+6. Cross-tenant guard (main path): reclassifying to a different category while
+   passing a foreign-restaurant supplier UUID also preserves the own-tenant
+   `supplier_id` (proves the hoisted guard covers the main path).
 
 Dates computed relative to `CURRENT_DATE` (no hardcoded future dates).
+12 assertions total.

--- a/supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql
+++ b/supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql
@@ -1,0 +1,233 @@
+-- Fix: preserve payee/supplier/notes edits on a no-op-category categorize call
+--
+-- Bug: categorize_bank_transaction's short-circuit for a no-op category change
+-- (same category re-selected) returned early BEFORE the UPDATE that persists
+-- normalized_payee / supplier_id / notes. A metadata-only edit on an already-
+-- categorized transaction (e.g. setting a Payee/Supplier while keeping the
+-- same category) reported success but silently dropped the write.
+--
+-- Fix: add a metadata-preserving UPDATE inside the short-circuit branch,
+-- before its RETURN. The journal-entry skip in that branch is intentional
+-- and unchanged (no ledger movement for a no-op category).
+--
+-- See docs/superpowers/specs/2026-07-09-categorize-noop-metadata-design.md
+-- for full root-cause analysis and rationale.
+--
+-- This migration is a verbatim CREATE OR REPLACE of the function body from
+-- supabase/migrations/20251021204739_73ec6be4-bfd6-4f6a-98cc-574c76967421.sql,
+-- with only the new UPDATE block added inside the short-circuit IF.
+
+CREATE OR REPLACE FUNCTION public.categorize_bank_transaction(
+  p_transaction_id uuid,
+  p_category_id uuid,
+  p_description text DEFAULT NULL,
+  p_normalized_payee text DEFAULT NULL,
+  p_supplier_id uuid DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_transaction RECORD;
+  v_category RECORD;
+  v_is_reclassification boolean := false;
+  v_original_category_id uuid;
+  v_journal_entry_id uuid;
+  v_cash_account RECORD;
+  v_fiscal_period RECORD;
+  v_existing_journal_entry uuid;
+  v_reclass_reference_id uuid;
+BEGIN
+  -- Get transaction details
+  SELECT * INTO v_transaction
+  FROM bank_transactions
+  WHERE id = p_transaction_id;
+
+  IF v_transaction.id IS NULL THEN
+    RAISE EXCEPTION 'Transaction not found';
+  END IF;
+
+  -- Verify user has access to this restaurant
+  IF NOT EXISTS (
+    SELECT 1
+    FROM user_restaurants
+    WHERE restaurant_id = v_transaction.restaurant_id
+      AND user_id = auth.uid()
+  ) THEN
+    RAISE EXCEPTION 'Unauthorized: user does not have access to this restaurant';
+  END IF;
+
+  -- Check if this is a reclassification
+  IF v_transaction.is_categorized AND v_transaction.category_id IS NOT NULL THEN
+    v_is_reclassification := true;
+    v_original_category_id := v_transaction.category_id;
+  END IF;
+
+  -- Short-circuit when category doesn't actually change (avoid no-op reclassifications)
+  IF v_is_reclassification AND v_original_category_id = p_category_id THEN
+    -- Category unchanged: no journal entry needed (skipping rebuild_account_balances
+    -- is correct — no ledger movement), but still persist metadata edits
+    -- (payee / supplier / notes) so a UI "Save" is not a silent no-op.
+    UPDATE bank_transactions
+    SET
+      normalized_payee = COALESCE(p_normalized_payee, normalized_payee),
+      supplier_id      = COALESCE(p_supplier_id, supplier_id),
+      -- COALESCE (preserve-on-null), NOT the main path's unconditional
+      -- `notes = p_description`: Transactions.tsx calls this RPC with
+      -- p_description = NULL, so an unconditional write here would wipe a user's
+      -- note on a same-category call. Intentional asymmetry — do not "fix".
+      notes            = COALESCE(p_description, notes),
+      updated_at       = now()
+    WHERE id = p_transaction_id;
+
+    RETURN jsonb_build_object(
+      'success', true,
+      'journal_entry_id', NULL,
+      'is_reclassification', false,
+      'transaction_id', p_transaction_id
+    );
+  END IF;
+
+  -- Block initial categorization of reconciled transactions
+  IF v_transaction.is_reconciled AND NOT v_is_reclassification THEN
+    RAISE EXCEPTION 'Cannot categorize a reconciled transaction. Use reclassification instead by updating the category of an already categorized transaction.';
+  END IF;
+
+  -- Get category details
+  SELECT * INTO v_category
+  FROM chart_of_accounts
+  WHERE id = p_category_id
+    AND restaurant_id = v_transaction.restaurant_id
+    AND is_active = true;
+
+  IF v_category.id IS NULL THEN
+    RAISE EXCEPTION 'Category not found or inactive';
+  END IF;
+
+  -- Check if transaction falls in a closed fiscal period
+  SELECT * INTO v_fiscal_period
+  FROM fiscal_periods
+  WHERE restaurant_id = v_transaction.restaurant_id
+    AND v_transaction.transaction_date >= period_start
+    AND v_transaction.transaction_date <= period_end
+    AND is_closed = true
+  LIMIT 1;
+
+  IF v_fiscal_period.id IS NOT NULL THEN
+    RAISE EXCEPTION 'Cannot categorize transaction in closed fiscal period. Period closed on %', v_fiscal_period.closed_at;
+  END IF;
+
+  -- Get cash account
+  SELECT * INTO v_cash_account
+  FROM chart_of_accounts
+  WHERE restaurant_id = v_transaction.restaurant_id
+    AND account_code = '1000'
+  LIMIT 1;
+
+  IF v_cash_account.id IS NULL THEN
+    RAISE EXCEPTION 'Cash account (1000) not found';
+  END IF;
+
+  -- Check if a journal entry already exists
+  SELECT id INTO v_existing_journal_entry
+  FROM journal_entries
+  WHERE reference_type = 'bank_transaction'
+    AND reference_id = v_transaction.id
+    AND restaurant_id = v_transaction.restaurant_id
+  LIMIT 1;
+
+  -- Handle reclassification
+  IF v_is_reclassification THEN
+    -- Generate a unique reference_id for this reclassification
+    v_reclass_reference_id := gen_random_uuid();
+
+    INSERT INTO journal_entries (
+      restaurant_id, entry_date, entry_number, description,
+      reference_type, reference_id, total_debit, total_credit, created_by
+    ) VALUES (
+      v_transaction.restaurant_id, v_transaction.transaction_date,
+      'RECLASS-' || v_transaction.id::text || '-' || TO_CHAR(now(), 'YYYYMMDD-HH24MISS-US'),
+      COALESCE(p_description, 'Reclassification: ' || v_transaction.description),
+      'reclassification', v_reclass_reference_id,  -- Use unique reference_id
+      ABS(v_transaction.amount), ABS(v_transaction.amount), auth.uid()
+    ) RETURNING id INTO v_journal_entry_id;
+
+    IF v_transaction.amount < 0 THEN
+      INSERT INTO journal_entry_lines (journal_entry_id, account_id, debit_amount, credit_amount, description)
+      VALUES
+        (v_journal_entry_id, p_category_id, ABS(v_transaction.amount), 0, 'Reclassify to ' || v_category.account_name),
+        (v_journal_entry_id, v_original_category_id, 0, ABS(v_transaction.amount), 'Reclassify from previous category');
+    ELSE
+      INSERT INTO journal_entry_lines (journal_entry_id, account_id, debit_amount, credit_amount, description)
+      VALUES
+        (v_journal_entry_id, v_original_category_id, ABS(v_transaction.amount), 0, 'Reclassify from previous category'),
+        (v_journal_entry_id, p_category_id, 0, ABS(v_transaction.amount), 'Reclassify to ' || v_category.account_name);
+    END IF;
+
+    INSERT INTO transaction_reclassifications (
+      restaurant_id, bank_transaction_id, original_category_id,
+      new_category_id, reclass_journal_entry_id, reason, created_by
+    ) VALUES (
+      v_transaction.restaurant_id, v_transaction.id, v_original_category_id,
+      p_category_id, v_journal_entry_id, p_description, auth.uid()
+    );
+  ELSE
+    IF v_existing_journal_entry IS NOT NULL THEN
+      v_journal_entry_id := v_existing_journal_entry;
+      DELETE FROM journal_entry_lines WHERE journal_entry_id = v_existing_journal_entry;
+      UPDATE journal_entries
+      SET description = COALESCE(p_description, v_transaction.description),
+          total_debit = ABS(v_transaction.amount),
+          total_credit = ABS(v_transaction.amount),
+          updated_at = now()
+      WHERE id = v_existing_journal_entry;
+    ELSE
+      INSERT INTO journal_entries (
+        restaurant_id, entry_date, entry_number, description,
+        reference_type, reference_id, total_debit, total_credit, created_by
+      ) VALUES (
+        v_transaction.restaurant_id, v_transaction.transaction_date,
+        'BANK-' || COALESCE(v_transaction.stripe_transaction_id, v_transaction.id::text) || '-' || TO_CHAR(now(), 'YYYYMMDD-HH24MISS-US'),
+        COALESCE(p_description, v_transaction.description),
+        'bank_transaction', v_transaction.id,
+        ABS(v_transaction.amount), ABS(v_transaction.amount), auth.uid()
+      ) RETURNING id INTO v_journal_entry_id;
+    END IF;
+
+    IF v_transaction.amount < 0 THEN
+      INSERT INTO journal_entry_lines (journal_entry_id, account_id, debit_amount, credit_amount, description)
+      VALUES
+        (v_journal_entry_id, p_category_id, ABS(v_transaction.amount), 0, v_category.account_name),
+        (v_journal_entry_id, v_cash_account.id, 0, ABS(v_transaction.amount), 'Cash payment');
+    ELSE
+      INSERT INTO journal_entry_lines (journal_entry_id, account_id, debit_amount, credit_amount, description)
+      VALUES
+        (v_journal_entry_id, v_cash_account.id, ABS(v_transaction.amount), 0, 'Cash received'),
+        (v_journal_entry_id, p_category_id, 0, ABS(v_transaction.amount), v_category.account_name);
+    END IF;
+  END IF;
+
+  -- Update transaction with notes, payee, and supplier (preserve supplier_id with COALESCE)
+  UPDATE bank_transactions
+  SET
+    category_id = p_category_id,
+    is_categorized = true,
+    notes = p_description,
+    normalized_payee = COALESCE(p_normalized_payee, normalized_payee),
+    supplier_id = COALESCE(p_supplier_id, supplier_id),
+    updated_at = now()
+  WHERE id = p_transaction_id;
+
+  -- Rebuild account balances
+  PERFORM rebuild_account_balances(v_transaction.restaurant_id);
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'journal_entry_id', v_journal_entry_id,
+    'is_reclassification', v_is_reclassification,
+    'transaction_id', p_transaction_id
+  );
+END;
+$function$;

--- a/supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql
+++ b/supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql
@@ -13,9 +13,14 @@
 -- See docs/superpowers/specs/2026-07-09-categorize-noop-metadata-design.md
 -- for full root-cause analysis and rationale.
 --
--- This migration is a verbatim CREATE OR REPLACE of the function body from
+-- This migration is a CREATE OR REPLACE of the function body from
 -- supabase/migrations/20251021204739_73ec6be4-bfd6-4f6a-98cc-574c76967421.sql,
--- with only the new UPDATE block added inside the short-circuit IF.
+-- adding: (1) the metadata-preserving UPDATE inside the short-circuit IF, and
+-- (2) a hoisted tenant-scope guard on p_supplier_id (after the membership auth
+-- check) that covers BOTH the no-op short-circuit and the pre-existing main
+-- categorize/reclassify UPDATE — closing the cross-tenant supplier-link gap the
+-- SECURITY DEFINER function had on the plain suppliers(id) FK (codex + CodeRabbit
+-- review finding).
 
 CREATE OR REPLACE FUNCTION public.categorize_bank_transaction(
   p_transaction_id uuid,
@@ -59,6 +64,22 @@ BEGIN
     RAISE EXCEPTION 'Unauthorized: user does not have access to this restaurant';
   END IF;
 
+  -- Tenant-scope p_supplier_id before ANY write path uses it. This function is
+  -- SECURITY DEFINER (bypasses RLS) and bank_transactions.supplier_id only has a
+  -- plain FK to suppliers(id), so an unscoped write would let a user with access
+  -- to this restaurant link the transaction to another tenant's supplier by UUID.
+  -- If the supplier isn't visible to this restaurant, silently drop it (fall back
+  -- to preserving the existing supplier_id via COALESCE downstream) rather than
+  -- raising. Hoisted here so BOTH the no-op short-circuit and the main
+  -- categorize/reclassify UPDATE below are covered by a single guard.
+  IF p_supplier_id IS NOT NULL AND NOT EXISTS (
+    SELECT 1 FROM suppliers
+    WHERE id = p_supplier_id
+      AND restaurant_id = v_transaction.restaurant_id
+  ) THEN
+    p_supplier_id := NULL;
+  END IF;
+
   -- Check if this is a reclassification
   IF v_transaction.is_categorized AND v_transaction.category_id IS NOT NULL THEN
     v_is_reclassification := true;
@@ -70,22 +91,7 @@ BEGIN
     -- Category unchanged: no journal entry needed (skipping rebuild_account_balances
     -- is correct — no ledger movement), but still persist metadata edits
     -- (payee / supplier / notes) so a UI "Save" is not a silent no-op.
-    -- Tenant-scope p_supplier_id before writing it: this function is
-    -- SECURITY DEFINER (bypasses RLS) and bank_transactions.supplier_id only
-    -- has a plain FK to suppliers(id), so an unscoped write would let a user
-    -- with access to this restaurant link the transaction to another
-    -- tenant's supplier row by UUID. If the supplier isn't visible to this
-    -- restaurant, silently ignore it (fall back to existing supplier_id)
-    -- rather than raising, matching the metadata-preserving intent of this
-    -- branch.
-    IF p_supplier_id IS NOT NULL AND NOT EXISTS (
-      SELECT 1 FROM suppliers
-      WHERE id = p_supplier_id
-        AND restaurant_id = v_transaction.restaurant_id
-    ) THEN
-      p_supplier_id := NULL;
-    END IF;
-
+    -- p_supplier_id was already tenant-scoped above (hoisted guard).
     UPDATE bank_transactions
     SET
       normalized_payee = COALESCE(p_normalized_payee, normalized_payee),

--- a/supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql
+++ b/supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql
@@ -70,6 +70,22 @@ BEGIN
     -- Category unchanged: no journal entry needed (skipping rebuild_account_balances
     -- is correct — no ledger movement), but still persist metadata edits
     -- (payee / supplier / notes) so a UI "Save" is not a silent no-op.
+    -- Tenant-scope p_supplier_id before writing it: this function is
+    -- SECURITY DEFINER (bypasses RLS) and bank_transactions.supplier_id only
+    -- has a plain FK to suppliers(id), so an unscoped write would let a user
+    -- with access to this restaurant link the transaction to another
+    -- tenant's supplier row by UUID. If the supplier isn't visible to this
+    -- restaurant, silently ignore it (fall back to existing supplier_id)
+    -- rather than raising, matching the metadata-preserving intent of this
+    -- branch.
+    IF p_supplier_id IS NOT NULL AND NOT EXISTS (
+      SELECT 1 FROM suppliers
+      WHERE id = p_supplier_id
+        AND restaurant_id = v_transaction.restaurant_id
+    ) THEN
+      p_supplier_id := NULL;
+    END IF;
+
     UPDATE bank_transactions
     SET
       normalized_payee = COALESCE(p_normalized_payee, normalized_payee),

--- a/supabase/tests/categorize_noop_preserves_metadata.sql
+++ b/supabase/tests/categorize_noop_preserves_metadata.sql
@@ -1,0 +1,139 @@
+-- File: supabase/tests/categorize_noop_preserves_metadata.sql
+-- Description: Pins the fix for a bug where re-calling categorize_bank_transaction
+-- with the SAME category (a no-op reclassification) silently dropped payee/
+-- supplier/notes edits because the short-circuit branch returned before the
+-- metadata UPDATE. See docs/superpowers/specs/2026-07-09-categorize-noop-metadata-design.md.
+
+BEGIN;
+SELECT plan(8);
+
+SET LOCAL role TO postgres;
+SET LOCAL "request.jwt.claims" TO '{"sub": "00000000-0000-0000-0000-000000000301"}';
+
+-- Fixture: user, restaurant, membership
+INSERT INTO auth.users (id, email) VALUES
+  ('00000000-0000-0000-0000-000000000301'::uuid, 'noop-metadata-test@example.com')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO restaurants (id, name) VALUES
+  ('00000000-0000-0000-0000-000000000399'::uuid, 'Noop Metadata Test Restaurant')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO user_restaurants (user_id, restaurant_id, role) VALUES
+  ('00000000-0000-0000-0000-000000000301'::uuid, '00000000-0000-0000-0000-000000000399'::uuid, 'owner')
+ON CONFLICT (user_id, restaurant_id) DO UPDATE SET role = 'owner';
+
+-- Chart of accounts:
+--   1000 = Cash (required by categorize_bank_transaction as the offsetting account)
+--   6000 = Supplies Expense (the category under test)
+INSERT INTO chart_of_accounts (id, restaurant_id, account_code, account_name, account_type, account_subtype, normal_balance) VALUES
+  ('00000000-0000-0000-0000-000000000350'::uuid, '00000000-0000-0000-0000-000000000399'::uuid, '1000', 'Cash', 'asset', 'cash', 'debit'),
+  ('00000000-0000-0000-0000-000000000352'::uuid, '00000000-0000-0000-0000-000000000399'::uuid, '6000', 'Supplies Expense', 'expense', 'operating_expenses', 'debit')
+ON CONFLICT (id) DO UPDATE SET account_name = EXCLUDED.account_name;
+
+-- Supplier fixture
+INSERT INTO suppliers (id, restaurant_id, name, is_active) VALUES
+  ('00000000-0000-0000-0000-000000000360'::uuid, '00000000-0000-0000-0000-000000000399'::uuid, 'Cold Stone Creamery', true)
+ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name;
+
+-- Connected bank + bank transaction fixture (starts uncategorized)
+INSERT INTO connected_banks (id, restaurant_id, stripe_financial_account_id, institution_name, status) VALUES
+  ('00000000-0000-0000-0000-000000000361'::uuid, '00000000-0000-0000-0000-000000000399'::uuid, 'fa_test_noop_001', 'Test Bank', 'connected')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO bank_transactions (
+  id, restaurant_id, connected_bank_id, stripe_transaction_id,
+  transaction_date, amount, description, status, is_categorized, is_transfer
+) VALUES (
+  '00000000-0000-0000-0000-000000000371'::uuid,
+  '00000000-0000-0000-0000-000000000399'::uuid,
+  '00000000-0000-0000-0000-000000000361'::uuid,
+  'txn-noop-metadata-test-1',
+  CURRENT_DATE, -42.50, 'POS processing fee', 'posted', false, false
+)
+ON CONFLICT (id) DO UPDATE SET
+  is_categorized = false,
+  is_transfer = false,
+  category_id = NULL,
+  notes = NULL,
+  normalized_payee = NULL,
+  supplier_id = NULL;
+
+-- STEP 1: Initial categorization to category A ("Supplies Expense"), with a note.
+-- This creates the bank_transaction's journal entry (reference_type = 'bank_transaction').
+SELECT lives_ok(
+  $$ SELECT categorize_bank_transaction(
+       '00000000-0000-0000-0000-000000000371'::uuid,
+       '00000000-0000-0000-0000-000000000352'::uuid,
+       'Original note', NULL, NULL
+     ) $$,
+  'Initial categorization to Supplies Expense succeeds'
+);
+
+-- Capture journal-entry count for this transaction after initial categorization.
+-- (One row expected: the bank_transaction entry created above.)
+SELECT is(
+  (SELECT COUNT(*)::int FROM journal_entries
+     WHERE reference_type = 'bank_transaction'
+       AND reference_id = '00000000-0000-0000-0000-000000000371'::uuid),
+  1,
+  'Initial categorization creates exactly one journal entry'
+);
+
+-- STEP 2: Re-call categorize_bank_transaction with the SAME category (no-op),
+-- plus a supplier_id and normalized_payee. p_description is NULL (mirrors
+-- Transactions.tsx / a metadata-only save that should not clobber notes).
+SELECT lives_ok(
+  $$ SELECT categorize_bank_transaction(
+       '00000000-0000-0000-0000-000000000371'::uuid,
+       '00000000-0000-0000-0000-000000000352'::uuid,
+       NULL,
+       'Cold Stone Creamery',
+       '00000000-0000-0000-0000-000000000360'::uuid
+     ) $$,
+  'No-op-category re-categorize call (with supplier/payee) succeeds'
+);
+
+-- TEST: supplier_id is now persisted
+SELECT is(
+  (SELECT supplier_id FROM bank_transactions WHERE id = '00000000-0000-0000-0000-000000000371'::uuid),
+  '00000000-0000-0000-0000-000000000360'::uuid,
+  'supplier_id is persisted by the no-op-category call'
+);
+
+-- TEST: normalized_payee is now persisted
+SELECT is(
+  (SELECT normalized_payee FROM bank_transactions WHERE id = '00000000-0000-0000-0000-000000000371'::uuid),
+  'Cold Stone Creamery',
+  'normalized_payee is persisted by the no-op-category call'
+);
+
+-- TEST: notes preserved (p_description was NULL on the no-op call; must not wipe the original note)
+SELECT is(
+  (SELECT notes FROM bank_transactions WHERE id = '00000000-0000-0000-0000-000000000371'::uuid),
+  'Original note',
+  'notes preserved (not wiped) when p_description is NULL on a no-op-category call'
+);
+
+-- TEST: no extra journal entry created for the no-op call (short-circuit still skips the ledger)
+SELECT is(
+  (SELECT COUNT(*)::int FROM journal_entries
+     WHERE reference_type = 'bank_transaction'
+       AND reference_id = '00000000-0000-0000-0000-000000000371'::uuid),
+  1,
+  'No extra journal entry created by the no-op-category call'
+);
+
+-- TEST: the no-op call's return value reports success with no reclassification / journal entry
+SELECT is(
+  (SELECT categorize_bank_transaction(
+       '00000000-0000-0000-0000-000000000371'::uuid,
+       '00000000-0000-0000-0000-000000000352'::uuid,
+       NULL, 'Cold Stone Creamery', '00000000-0000-0000-0000-000000000360'::uuid
+     ) - 'transaction_id'),
+  '{"success": true, "journal_entry_id": null, "is_reclassification": false}'::jsonb,
+  'No-op-category call returns success=true, is_reclassification=false, journal_entry_id=NULL'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/categorize_noop_preserves_metadata.sql
+++ b/supabase/tests/categorize_noop_preserves_metadata.sql
@@ -5,7 +5,7 @@
 -- metadata UPDATE. See docs/superpowers/specs/2026-07-09-categorize-noop-metadata-design.md.
 
 BEGIN;
-SELECT plan(10);
+SELECT plan(12);
 
 SET LOCAL role TO postgres;
 SET LOCAL "request.jwt.claims" TO '{"sub": "00000000-0000-0000-0000-000000000301"}';
@@ -28,7 +28,8 @@ ON CONFLICT (user_id, restaurant_id) DO UPDATE SET role = 'owner';
 --   6000 = Supplies Expense (the category under test)
 INSERT INTO chart_of_accounts (id, restaurant_id, account_code, account_name, account_type, account_subtype, normal_balance) VALUES
   ('00000000-0000-0000-0000-000000000350'::uuid, '00000000-0000-0000-0000-000000000399'::uuid, '1000', 'Cash', 'asset', 'cash', 'debit'),
-  ('00000000-0000-0000-0000-000000000352'::uuid, '00000000-0000-0000-0000-000000000399'::uuid, '6000', 'Supplies Expense', 'expense', 'operating_expenses', 'debit')
+  ('00000000-0000-0000-0000-000000000352'::uuid, '00000000-0000-0000-0000-000000000399'::uuid, '6000', 'Supplies Expense', 'expense', 'operating_expenses', 'debit'),
+  ('00000000-0000-0000-0000-000000000353'::uuid, '00000000-0000-0000-0000-000000000399'::uuid, '6010', 'Repairs Expense', 'expense', 'operating_expenses', 'debit')
 ON CONFLICT (id) DO UPDATE SET account_name = EXCLUDED.account_name;
 
 -- Supplier fixture
@@ -165,6 +166,28 @@ SELECT is(
   (SELECT supplier_id FROM bank_transactions WHERE id = '00000000-0000-0000-0000-000000000371'::uuid),
   '00000000-0000-0000-0000-000000000360'::uuid,
   'foreign-tenant supplier_id is rejected; existing (own-tenant) supplier_id is preserved'
+);
+
+-- STEP 4 (main-path cross-tenant guard, added for the CodeRabbit finding):
+-- The tenant guard is hoisted to cover the MAIN categorize/reclassify path too,
+-- not just the no-op branch. Reclassify to a DIFFERENT category (6010) while
+-- passing a foreign-tenant supplier UUID (...460). The reclassification succeeds
+-- (category changes) but the foreign supplier must be rejected, leaving the
+-- own-tenant supplier_id (...360) intact.
+SELECT lives_ok(
+  $$ SELECT categorize_bank_transaction(
+       '00000000-0000-0000-0000-000000000371'::uuid,
+       '00000000-0000-0000-0000-000000000353'::uuid,
+       NULL, NULL,
+       '00000000-0000-0000-0000-000000000460'::uuid
+     ) $$,
+  'Reclassify (main path) passing a foreign-tenant supplier_id succeeds'
+);
+
+SELECT is(
+  (SELECT supplier_id FROM bank_transactions WHERE id = '00000000-0000-0000-0000-000000000371'::uuid),
+  '00000000-0000-0000-0000-000000000360'::uuid,
+  'main path also rejects foreign-tenant supplier_id; own-tenant supplier_id preserved'
 );
 
 SELECT * FROM finish();

--- a/supabase/tests/categorize_noop_preserves_metadata.sql
+++ b/supabase/tests/categorize_noop_preserves_metadata.sql
@@ -5,7 +5,7 @@
 -- metadata UPDATE. See docs/superpowers/specs/2026-07-09-categorize-noop-metadata-design.md.
 
 BEGIN;
-SELECT plan(8);
+SELECT plan(10);
 
 SET LOCAL role TO postgres;
 SET LOCAL "request.jwt.claims" TO '{"sub": "00000000-0000-0000-0000-000000000301"}';
@@ -34,6 +34,17 @@ ON CONFLICT (id) DO UPDATE SET account_name = EXCLUDED.account_name;
 -- Supplier fixture
 INSERT INTO suppliers (id, restaurant_id, name, is_active) VALUES
   ('00000000-0000-0000-0000-000000000360'::uuid, '00000000-0000-0000-0000-000000000399'::uuid, 'Cold Stone Creamery', true)
+ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name;
+
+-- Cross-tenant fixture: a DIFFERENT restaurant with its OWN supplier. The test
+-- user (301) is NOT a member of this restaurant. Used to prove the short-circuit
+-- branch's tenant guard rejects a supplier UUID that belongs to another tenant.
+INSERT INTO restaurants (id, name) VALUES
+  ('00000000-0000-0000-0000-000000000499'::uuid, 'Other Tenant Restaurant')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO suppliers (id, restaurant_id, name, is_active) VALUES
+  ('00000000-0000-0000-0000-000000000460'::uuid, '00000000-0000-0000-0000-000000000499'::uuid, 'Foreign Tenant Supplier', true)
 ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name;
 
 -- Connected bank + bank transaction fixture (starts uncategorized)
@@ -133,6 +144,27 @@ SELECT is(
      ) - 'transaction_id'),
   '{"success": true, "journal_entry_id": null, "is_reclassification": false}'::jsonb,
   'No-op-category call returns success=true, is_reclassification=false, journal_entry_id=NULL'
+);
+
+-- STEP 3 (cross-tenant guard, added for the Phase 7b codex finding):
+-- Re-call the no-op-category path passing a supplier UUID that belongs to
+-- ANOTHER restaurant (id ...460, restaurant ...499). The SECURITY DEFINER
+-- function must NOT cross-link it. supplier_id was ...360 from STEP 2, so it
+-- must stay ...360 (foreign supplier silently ignored, existing preserved).
+SELECT lives_ok(
+  $$ SELECT categorize_bank_transaction(
+       '00000000-0000-0000-0000-000000000371'::uuid,
+       '00000000-0000-0000-0000-000000000352'::uuid,
+       NULL, NULL,
+       '00000000-0000-0000-0000-000000000460'::uuid
+     ) $$,
+  'No-op call passing a foreign-tenant supplier_id succeeds (does not raise)'
+);
+
+SELECT is(
+  (SELECT supplier_id FROM bank_transactions WHERE id = '00000000-0000-0000-0000-000000000371'::uuid),
+  '00000000-0000-0000-0000-000000000360'::uuid,
+  'foreign-tenant supplier_id is rejected; existing (own-tenant) supplier_id is preserved'
 );
 
 SELECT * FROM finish();


### PR DESCRIPTION
## Summary
- Fixes a silent data-drop on `/banking`: setting a **Payee/Supplier** (or notes) on an **already-categorized** transaction reported "saved" but never persisted.
- Root cause: `categorize_bank_transaction`'s no-op-category short-circuit returned **before** the `UPDATE` that writes `normalized_payee` / `supplier_id` / `notes`. The metadata edit was dropped while the RPC still returned `success: true`.
- Fix (new migration `20260709120000`): add a metadata-preserving `UPDATE ... COALESCE(...)` inside the short-circuit branch, before its `RETURN`. The journal-entry skip in that branch is intentional and unchanged (no ledger movement for a no-op category).

## Details
- `notes` uses `COALESCE(p_description, notes)` (preserve-on-null), **not** the main path's unconditional overwrite — `Transactions.tsx` calls the RPC with `p_description = NULL`, so an unconditional write would wipe a user's note on a same-category call. Intentional asymmetry, documented inline with a "do not fix" guard comment.
- Tenant-scoped `p_supplier_id` before the write (Phase 7b / codex finding): the function is `SECURITY DEFINER` (bypasses RLS) and `bank_transactions.supplier_id` has only a plain FK to `suppliers(id)`, so an unscoped write would let a user link the transaction to another tenant's supplier by UUID. If the supplier isn't visible to the transaction's restaurant, it's ignored (existing supplier preserved) rather than raising.
- Delivered as a verbatim `CREATE OR REPLACE` of the latest function body with only the short-circuit block added — signature, `SECURITY DEFINER`, `search_path`, membership auth check, and all journal-entry logic unchanged. No frontend change: the supplier join + query invalidation already exist, so the fix flows through on refetch.

## Test plan
- New pgTAP `supabase/tests/categorize_noop_preserves_metadata.sql` (10 assertions):
  - initial categorize creates exactly one journal entry;
  - no-op-category re-call persists `supplier_id` and `normalized_payee`;
  - `notes` preserved when `p_description` is NULL;
  - no extra journal entry on the no-op call; RPC return shape asserted;
  - **cross-tenant guard**: a foreign-restaurant supplier UUID is rejected and the own-tenant supplier is preserved.
- Local: `test:db` 1660+ pgTAP green (incl. the new file 10/10 and the sibling `categorize_transfer_account.sql`), `typecheck`, `build` clean. Lint failures are pre-existing debt on unrelated files (diff is SQL + docs only). E2E is exercised authoritatively by CI (local run was inconclusive due to known macOS Playwright flakiness; diff touches no UI code).

## Design
`docs/superpowers/specs/2026-07-09-categorize-noop-metadata-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Same-category updates now save supplier, normalized payee, and notes metadata.
  * Existing notes are preserved when no replacement description is provided.
  * Cross-tenant supplier references are safely ignored.
  * No-op categorization continues to avoid creating journal entries.

* **Tests**
  * Added coverage for metadata persistence, response values, journal-entry behavior, and tenant safeguards.

* **Documentation**
  * Added design and implementation documentation for the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->