### PR TITLE
fix(scheduling): default staffing suggestions panel to collapsed

### DIFF
--- a/src/components/scheduling/ShiftPlanner/StaffingOverlay.tsx
+++ b/src/components/scheduling/ShiftPlanner/StaffingOverlay.tsx
@@ -27,7 +27,7 @@ export function StaffingOverlay({
   restaurantId,
   weekDays,
 }: Readonly<StaffingOverlayProps>) {
-  const [isExpanded, setIsExpanded] = useState(true);
+  const [isExpanded, setIsExpanded] = useState(false);
   const { toast } = useToast();
   const [localSettings, setLocalSettings] = useState<Partial<StaffingSettings> | null>(null);
 


### PR DESCRIPTION
## Summary

Staffing suggestions isn't ready for prime time, so the overlay panel now defaults to **collapsed** instead of expanded.

- `StaffingOverlay` initializes `isExpanded` to `false` — the `Collapsible` renders closed on first load.
- Users can still expand it anytime via the existing chevron toggle; the collapsed summary line (peak staff) still shows when sales data is available.

## Changes

- `src/components/scheduling/ShiftPlanner/StaffingOverlay.tsx` — flip initial state `useState(true)` → `useState(false)`.

This is a one-line initial-state change with no data or behavioral impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)