### PR TITLE
fix(payroll/time-clock): stop per-day fetch windows from splitting overnight shifts

### DIFF
--- a/docs/superpowers/plans/2026-07-09-overnight-shift-punch-windowing.md
+++ b/docs/superpowers/plans/2026-07-09-overnight-shift-punch-windowing.md
@@ -1,0 +1,758 @@
+# Overnight-Shift Punch Windowing — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop overnight shifts (clock-in one day, clock-out after midnight) from being split by per-day/per-period punch fetch windows, which causes dropped payroll hours and false "open session" / "no matching clock-in" warnings.
+
+**Architecture:** The pairing engines are already overnight-aware; the bug is unbuffered fetches. Fetch a symmetric ±18h buffer, pair across the full set, then attribute each shift to its clock-in day and drop shifts whose clock-in is outside the target window. A new `src/utils/punchWindow.ts` centralizes the buffer + attribution filters; each fetch site is a small, consistent change.
+
+**Tech Stack:** React 18 + TypeScript, React Query, Supabase JS client, date-fns, Vitest. Design doc: `docs/superpowers/specs/2026-07-09-overnight-shift-punch-windowing-design.md`.
+
+**Data-lineage rule (applies throughout):** *Buffered* punches feed **pairing only**; *window-filtered* data feeds **every display and every total**. A period/session is "in window" iff its clock-in ∈ `[start, end]` inclusive.
+
+---
+
+## Task 1: `punchWindow.ts` shared util
+
+**Files:**
+- Create: `src/utils/punchWindow.ts`
+- Modify: `src/utils/payrollCalculations.ts` (export `MAX_SHIFT_GAP_HOURS`)
+- Test: `tests/unit/punchWindow.test.ts`
+
+- [ ] **Step 1: Export the existing gap constant**
+
+In `src/utils/payrollCalculations.ts`, change line 21 from:
+```ts
+const MAX_SHIFT_GAP_HOURS = 18;
+```
+to:
+```ts
+export const MAX_SHIFT_GAP_HOURS = 18;
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/unit/punchWindow.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  OVERNIGHT_BUFFER_HOURS,
+  bufferPunchFetchRange,
+  isWithinWindow,
+  periodsInWindow,
+  incompleteShiftsInWindow,
+  sessionsWithClockInInWindow,
+} from '@/utils/punchWindow';
+import { MAX_SHIFT_GAP_HOURS } from '@/utils/payrollCalculations';
+
+const start = new Date('2026-07-06T00:00:00Z'); // Mon
+const end = new Date('2026-07-12T23:59:59.999Z'); // Sun
+
+describe('punchWindow', () => {
+  it('buffer constant never drifts below the pairing gap cap', () => {
+    expect(OVERNIGHT_BUFFER_HOURS).toBeGreaterThanOrEqual(MAX_SHIFT_GAP_HOURS);
+  });
+
+  it('bufferPunchFetchRange widens by ±18h in epoch ms', () => {
+    const { fetchStart, fetchEnd } = bufferPunchFetchRange(start, end);
+    expect(start.getTime() - fetchStart.getTime()).toBe(18 * 3600 * 1000);
+    expect(fetchEnd.getTime() - end.getTime()).toBe(18 * 3600 * 1000);
+  });
+
+  it('isWithinWindow is inclusive on both boundaries', () => {
+    expect(isWithinWindow(start, start, end)).toBe(true);
+    expect(isWithinWindow(end, start, end)).toBe(true);
+    expect(isWithinWindow(new Date(start.getTime() - 1), start, end)).toBe(false);
+    expect(isWithinWindow(new Date(end.getTime() + 1), start, end)).toBe(false);
+  });
+
+  it('periodsInWindow keeps by startTime, drops out-of-window', () => {
+    const periods = [
+      { startTime: new Date('2026-07-05T20:00:00Z') }, // before start → drop
+      { startTime: new Date('2026-07-07T09:00:00Z') }, // in → keep
+      { startTime: new Date('2026-07-13T01:00:00Z') }, // after end → drop
+    ];
+    expect(periodsInWindow(periods, start, end)).toHaveLength(1);
+  });
+
+  it('incompleteShiftsInWindow keeps by punchTime', () => {
+    const shifts = [
+      { punchTime: new Date('2026-07-05T23:00:00Z') }, // drop
+      { punchTime: new Date('2026-07-08T02:00:00Z') }, // keep
+    ];
+    expect(incompleteShiftsInWindow(shifts, start, end)).toHaveLength(1);
+  });
+
+  it('sessionsWithClockInInWindow keeps by clock_in', () => {
+    const sessions = [
+      { clock_in: new Date('2026-07-07T18:00:00Z') }, // keep
+      { clock_in: new Date('2026-07-13T00:30:00Z') }, // drop (next period)
+    ];
+    expect(sessionsWithClockInInWindow(sessions, start, end)).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/punchWindow.test.ts`
+Expected: FAIL — cannot resolve `@/utils/punchWindow`.
+
+- [ ] **Step 4: Write the implementation**
+
+Create `src/utils/punchWindow.ts`:
+```ts
+/**
+ * Overnight-shift fetch windowing helpers.
+ *
+ * Punch fetches must be widened by this buffer so a shift whose clock_in and
+ * clock_out straddle the [start, end] boundary is fetched whole; the pairing
+ * engine then pairs it and callers attribute it to its clock-in day, dropping
+ * shifts whose clock-in falls outside [start, end].
+ *
+ * OVERNIGHT_BUFFER_HOURS MUST stay >= MAX_SHIFT_GAP_HOURS (payrollCalculations)
+ * — the buffer has to be at least as wide as the largest gap the pairing engine
+ * will pair, or a boundary-crossing shift's far punch is never fetched. The
+ * drift guard test in punchWindow.test.ts enforces this.
+ */
+export const OVERNIGHT_BUFFER_HOURS = 18;
+
+/** Expand [start, end] by the overnight buffer on both ends for the DB fetch. */
+export function bufferPunchFetchRange(
+  start: Date,
+  end: Date,
+  hours: number = OVERNIGHT_BUFFER_HOURS,
+): { fetchStart: Date; fetchEnd: Date } {
+  const ms = hours * 60 * 60 * 1000;
+  return {
+    fetchStart: new Date(start.getTime() - ms),
+    fetchEnd: new Date(end.getTime() + ms),
+  };
+}
+
+/** Inclusive on both boundaries, matching Supabase .gte/.lte semantics. */
+export function isWithinWindow(time: Date | string, start: Date, end: Date): boolean {
+  const t = time instanceof Date ? time.getTime() : new Date(time).getTime();
+  return t >= start.getTime() && t <= end.getTime();
+}
+
+/** Keep work periods whose clock-in (startTime) is in [start, end]. */
+export function periodsInWindow<T extends { startTime: Date }>(periods: T[], start: Date, end: Date): T[] {
+  return periods.filter((p) => isWithinWindow(p.startTime, start, end));
+}
+
+/** Keep incomplete shifts whose anchor punch (punchTime) is in [start, end]. */
+export function incompleteShiftsInWindow<T extends { punchTime: Date }>(shifts: T[], start: Date, end: Date): T[] {
+  return shifts.filter((s) => isWithinWindow(s.punchTime, start, end));
+}
+
+/** Keep work sessions whose clock_in is in [start, end]. */
+export function sessionsWithClockInInWindow<T extends { clock_in: Date }>(sessions: T[], start: Date, end: Date): T[] {
+  return sessions.filter((s) => isWithinWindow(s.clock_in, start, end));
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/punchWindow.test.ts`
+Expected: PASS (7 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/utils/punchWindow.ts src/utils/payrollCalculations.ts tests/unit/punchWindow.test.ts
+git commit -m "feat(time-punch): add punchWindow buffer + attribution helpers"
+```
+
+---
+
+## Task 2: Window-filter periods in `calculateEmployeePay`
+
+**Files:**
+- Modify: `src/utils/payrollCalculations.ts:429-486` (hourly branch)
+- Test: `tests/unit/payrollCalculations.test.ts`
+
+Background: `calculateEmployeePay(employee, punches, tips, periodStartDate, periodEndDate, …)` already receives the period bounds. The hourly branch calls `parseWorkPeriods(punches)` at :430 then loops `parsed.periods` at :433. We insert the window filter between them so buffered-but-out-of-window shifts don't count and don't warn.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/unit/payrollCalculations.test.ts` (a `TimePunch`-shaped factory already exists in this file; reuse it — otherwise build objects with `{ id, employee_id, restaurant_id, punch_type, punch_time }`):
+```ts
+import { periodsInWindow } from '@/utils/punchWindow'; // ensure import resolves
+
+describe('calculateEmployeePay overnight window attribution', () => {
+  const employee = {
+    id: 'e1', name: 'Night Owl', position: 'Cook', area: null,
+    compensation_type: 'hourly', hourly_rate: 1500, is_active: true,
+  } as any;
+
+  // Payroll week Mon 2026-07-06 .. Sun 2026-07-12 (WEEK_STARTS_ON = Mon)
+  const weekStart = new Date('2026-07-06T00:00:00');
+  const weekEnd = new Date('2026-07-12T23:59:59.999');
+
+  const punch = (type: string, iso: string) => ({
+    id: `${type}-${iso}`, employee_id: 'e1', restaurant_id: 'r1',
+    punch_type: type, punch_time: iso,
+  }) as any;
+
+  it('counts a Sun->Mon overnight shift once, attributed to the Sunday week', () => {
+    // Buffered fetch for the Sun-ending week would include Mon 02:00 clock_out.
+    const punches = [
+      punch('clock_in', '2026-07-12T20:00:00'),  // Sun 8pm (in window)
+      punch('clock_out', '2026-07-13T02:00:00'),  // Mon 2am (lookahead)
+    ];
+    const pay = calculateEmployeePay(employee, punches, 0, weekStart, weekEnd);
+    expect(pay.regularHours + pay.overtimeHours).toBeCloseTo(6, 5);
+    expect(pay.incompleteShifts ?? []).toHaveLength(0);
+  });
+
+  it('does NOT double-count the same shift in the following week, no false orphan', () => {
+    const nextStart = new Date('2026-07-13T00:00:00'); // Mon
+    const nextEnd = new Date('2026-07-19T23:59:59.999');
+    // Buffered fetch for the next week includes the Sun 20:00 clock_in (lookback).
+    const punches = [
+      punch('clock_in', '2026-07-12T20:00:00'),  // before nextStart → drop
+      punch('clock_out', '2026-07-13T02:00:00'),  // in next window, but clock-in owns it
+    ];
+    const pay = calculateEmployeePay(employee, punches, 0, nextStart, nextEnd);
+    expect(pay.regularHours + pay.overtimeHours).toBeCloseTo(0, 5);
+    // The paired clock-in suppresses the "no matching clock-in" warning:
+    expect(pay.incompleteShifts ?? []).toHaveLength(0);
+  });
+
+  it('still flags a genuine missing clock-out when the clock-in is in-window', () => {
+    const punches = [punch('clock_in', '2026-07-08T09:00:00')]; // Wed, never clocked out
+    const pay = calculateEmployeePay(employee, punches, 0, weekStart, weekEnd);
+    expect(pay.incompleteShifts?.some((s) => s.type === 'missing_clock_out')).toBe(true);
+  });
+
+  it('OT/tip base rate ignores a buffered out-of-window neighbour shift', () => {
+    // 42h in-window (Mon-Sat 7h each) → 40 reg + 2 OT; plus an out-of-window
+    // Sunday-of-PRIOR-week shift present in the buffered input must not shift OT.
+    const inWindow = [
+      ['2026-07-06', '2026-07-07'], ['2026-07-07', '2026-07-08'],
+      ['2026-07-08', '2026-07-09'], ['2026-07-09', '2026-07-10'],
+      ['2026-07-10', '2026-07-11'], ['2026-07-11', '2026-07-12'],
+    ].flatMap(([d]) => [
+      punch('clock_in', `${d}T08:00:00`), punch('clock_out', `${d}T15:00:00`),
+    ]);
+    const neighbour = [
+      punch('clock_in', '2026-07-05T08:00:00'), // Sun of prior week → drop
+      punch('clock_out', '2026-07-05T15:00:00'),
+    ];
+    const pay = calculateEmployeePay(employee, [...neighbour, ...inWindow], 0, weekStart, weekEnd);
+    expect(pay.regularHours).toBeCloseTo(40, 5);
+    expect(pay.overtimeHours).toBeCloseTo(2, 5);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run tests/unit/payrollCalculations.test.ts -t "overnight window attribution"`
+Expected: FAIL — out-of-window shifts currently counted / false orphan emitted.
+
+- [ ] **Step 3: Implement the filter**
+
+In `src/utils/payrollCalculations.ts`, add the import near the top (after the existing imports):
+```ts
+import { periodsInWindow, incompleteShiftsInWindow } from '@/utils/punchWindow';
+```
+In the hourly branch, replace:
+```ts
+  if (compensationType === 'hourly') {
+    const parsed = parseWorkPeriods(punches);
+    const hoursByDate = new Map<string, number>();
+```
+with:
+```ts
+  if (compensationType === 'hourly') {
+    const parsed = parseWorkPeriods(punches);
+    // Attribute each shift to its clock-in day: keep only periods/incomplete
+    // shifts whose anchor punch falls in the pay period. Callers fetch a ±18h
+    // buffer so boundary-crossing shifts pair whole before this filter runs.
+    if (periodStartDate && periodEndDate) {
+      parsed.periods = periodsInWindow(parsed.periods, periodStartDate, periodEndDate);
+      parsed.incompleteShifts = incompleteShiftsInWindow(parsed.incompleteShifts, periodStartDate, periodEndDate);
+    }
+    const hoursByDate = new Map<string, number>();
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx vitest run tests/unit/payrollCalculations.test.ts`
+Expected: PASS (all existing + 4 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/payrollCalculations.ts tests/unit/payrollCalculations.test.ts
+git commit -m "fix(payroll): attribute overnight shifts to clock-in day, drop out-of-window"
+```
+
+---
+
+## Task 3: Buffer the payroll punch fetch (`usePayroll`)
+
+**Files:**
+- Modify: `src/hooks/usePayroll.tsx:140-146`
+
+- [ ] **Step 1: Add the import**
+
+In `src/hooks/usePayroll.tsx`, after the existing imports add:
+```ts
+import { bufferPunchFetchRange } from '@/utils/punchWindow';
+```
+
+- [ ] **Step 2: Widen the fetch range**
+
+Replace:
+```ts
+      // Fetch all time punches for the period
+      const { data: punches, error: punchesError } = await supabase
+        .from('time_punches')
+        .select('*')
+        .eq('restaurant_id', restaurantId)
+        .gte('punch_time', startDate.toISOString())
+        .lte('punch_time', endDate.toISOString())
+        .order('punch_time', { ascending: true });
+```
+with:
+```ts
+      // Fetch time punches for the period, widened by ±18h so overnight shifts
+      // that straddle the period boundary are paired whole. calculateEmployeePay
+      // then filters periods back to [startDate, endDate] by clock-in day.
+      const { fetchStart, fetchEnd } = bufferPunchFetchRange(startDate, endDate);
+      const { data: punches, error: punchesError } = await supabase
+        .from('time_punches')
+        .select('*')
+        .eq('restaurant_id', restaurantId)
+        .gte('punch_time', fetchStart.toISOString())
+        .lte('punch_time', fetchEnd.toISOString())
+        .order('punch_time', { ascending: true });
+```
+Note: the React Query key stays keyed on the logical `startDate`/`endDate` (line 135) — do NOT change it.
+
+- [ ] **Step 3: Verify**
+
+Run: `npx vitest run tests/unit/payrollCalculations.test.ts && npx tsc --noEmit -p tsconfig.app.json 2>&1 | head`
+Expected: tests PASS, no new type errors. (Correctness proven by Task 2 tests; this step wires the buffered input in.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/hooks/usePayroll.tsx
+git commit -m "fix(payroll): fetch ±18h buffer so overnight shifts pair across period edges"
+```
+
+---
+
+## Task 4: `hoursByClockInDay` + Employee Timecard rewire
+
+**Files:**
+- Create: `src/utils/timecardHours.ts`
+- Test: `tests/unit/timecardHours.test.ts`
+- Modify: `src/pages/EmployeeTimecard.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/timecardHours.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest';
+import { hoursByClockInDay } from '@/utils/timecardHours';
+
+const punch = (type: string, iso: string) => ({
+  id: `${type}-${iso}`, employee_id: 'e1', restaurant_id: 'r1',
+  punch_type: type, punch_time: iso,
+}) as any;
+
+describe('hoursByClockInDay', () => {
+  it('attributes an overnight shift entirely to the clock-in local day', () => {
+    // Thu 23:00 -> Fri 07:00 (8h). Buffered punches may include neighbours.
+    const days = [new Date(2026, 6, 9), new Date(2026, 6, 10)]; // Thu, Fri (local)
+    const punches = [
+      punch('clock_in', new Date(2026, 6, 9, 23, 0).toISOString()),
+      punch('clock_out', new Date(2026, 6, 10, 7, 0).toISOString()),
+    ];
+    const map = hoursByClockInDay(punches, days);
+    expect(map.get('2026-07-09')!.netHours).toBeCloseTo(8, 5);
+    expect(map.get('2026-07-10')!.netHours).toBeCloseTo(0, 5);
+  });
+
+  it('subtracts breaks from the same clock-in day', () => {
+    const days = [new Date(2026, 6, 9)];
+    const punches = [
+      punch('clock_in', new Date(2026, 6, 9, 9, 0).toISOString()),
+      punch('break_start', new Date(2026, 6, 9, 12, 0).toISOString()),
+      punch('break_end', new Date(2026, 6, 9, 12, 30).toISOString()),
+      punch('clock_out', new Date(2026, 6, 9, 17, 0).toISOString()),
+    ];
+    const d = hoursByClockInDay(punches, days).get('2026-07-09')!;
+    expect(d.totalHours).toBeCloseTo(8, 5);
+    expect(d.breakHours).toBeCloseTo(0.5, 5);
+    expect(d.netHours).toBeCloseTo(7.5, 5);
+  });
+
+  it('ignores shifts whose clock-in day is outside the displayed range', () => {
+    const days = [new Date(2026, 6, 10)];
+    const punches = [
+      punch('clock_in', new Date(2026, 6, 9, 9, 0).toISOString()),
+      punch('clock_out', new Date(2026, 6, 9, 17, 0).toISOString()),
+    ];
+    expect(hoursByClockInDay(punches, days).get('2026-07-10')!.netHours).toBeCloseTo(0, 5);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run tests/unit/timecardHours.test.ts`
+Expected: FAIL — cannot resolve `@/utils/timecardHours`.
+
+- [ ] **Step 3: Implement the pure function**
+
+Create `src/utils/timecardHours.ts`:
+```ts
+import { format } from 'date-fns';
+import { TimePunch } from '@/types/timeTracking';
+import { processPunchesForPeriod } from '@/utils/timePunchProcessing';
+
+export interface DayHours {
+  totalHours: number;
+  breakHours: number;
+  netHours: number;
+}
+
+/**
+ * Pair `punches` into work sessions and bucket each COMPLETE session's hours
+ * into its clock-in LOCAL calendar day. Only days present in `days` are kept.
+ * Pass BUFFERED punches (±18h) so overnight shifts pair whole; attribution by
+ * clock-in day keeps each shift on a single calendar day.
+ */
+export function hoursByClockInDay(punches: TimePunch[], days: Date[]): Map<string, DayHours> {
+  const result = new Map<string, DayHours>();
+  for (const day of days) {
+    result.set(format(day, 'yyyy-MM-dd'), { totalHours: 0, breakHours: 0, netHours: 0 });
+  }
+
+  const { sessions } = processPunchesForPeriod(punches);
+  for (const session of sessions) {
+    if (!session.is_complete) continue; // open shift contributes no hours yet
+    const key = format(new Date(session.clock_in), 'yyyy-MM-dd');
+    const bucket = result.get(key);
+    if (!bucket) continue; // clock-in day outside the displayed range
+    bucket.totalHours += session.total_minutes / 60;
+    bucket.breakHours += session.break_minutes / 60;
+    bucket.netHours += session.worked_minutes / 60;
+  }
+  return result;
+}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx vitest run tests/unit/timecardHours.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Rewire EmployeeTimecard to buffered fetch + `hoursByClockInDay`**
+
+In `src/pages/EmployeeTimecard.tsx`:
+
+(a) Add imports:
+```ts
+import { bufferPunchFetchRange } from '@/utils/punchWindow';
+import { hoursByClockInDay } from '@/utils/timecardHours';
+```
+
+(b) Replace the punch fetch (lines 117-121) to pass a buffered start AND end:
+```ts
+  const { fetchStart, fetchEnd } = bufferPunchFetchRange(startDate, endDate);
+  const { punches, loading: punchesLoading } = useTimePunches(
+    restaurantId,
+    currentEmployee?.id,
+    fetchStart,
+    fetchEnd
+  );
+```
+
+(c) Add a memoized day-hours map (buffered punches → attributed), placed after `punchesByDay`:
+```ts
+  const dayHours = useMemo(() => hoursByClockInDay(punches, weekDays), [punches, weekDays]);
+```
+
+(d) Replace the `weeklyTotals` reducer (currently iterates `punchesByDay` and calls `calculateDayHours`) so it sums `dayHours`:
+```ts
+  const weeklyTotals = useMemo(() => {
+    let totalHours = 0;
+    let breakHours = 0;
+    let netHours = 0;
+    dayHours.forEach((d) => {
+      totalHours += d.totalHours;
+      breakHours += d.breakHours;
+      netHours += d.netHours;
+    });
+    const regularHours = Math.min(netHours, 40);
+    const overtimeHours = Math.max(netHours - 40, 0);
+    return { totalHours, breakHours, netHours, regularHours, overtimeHours };
+  }, [dayHours]);
+```
+
+(e) Find the per-day render that calls `calculateDayHours(dayPunches)` (the day cards, below the summary) and replace each call with a lookup:
+```ts
+  const dayStats = dayHours.get(dayKey) ?? { totalHours: 0, breakHours: 0, netHours: 0 };
+```
+Keep `punchesByDay` and the visual per-punch list unchanged (they still render `periodPunches`).
+
+(f) Delete the now-unused `calculateDayHours` function (lines 34-76) once no references remain.
+
+- [ ] **Step 6: Verify build + tests**
+
+Run: `npx vitest run tests/unit/timecardHours.test.ts && npx tsc --noEmit -p tsconfig.app.json 2>&1 | head`
+Expected: tests PASS, no unused-symbol / type errors (confirms `calculateDayHours` fully removed).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/utils/timecardHours.ts tests/unit/timecardHours.test.ts src/pages/EmployeeTimecard.tsx
+git commit -m "fix(timecard): pair overnight shifts across days, attribute hours to clock-in day"
+```
+
+---
+
+## Task 5: `TimePunchesManager` buffered fetch + window/buffer split
+
+**Files:**
+- Modify: `src/pages/TimePunchesManager.tsx`
+- Test: `tests/unit/timePunchProcessing.test.ts` (open-session completeness assertion)
+
+- [ ] **Step 1: Write the failing test (open-session completeness)**
+
+Add to `tests/unit/timePunchProcessing.test.ts`:
+```ts
+import { processPunchesForPeriod } from '@/utils/timePunchProcessing';
+import { sessionsWithClockInInWindow } from '@/utils/punchWindow';
+
+const p = (type: string, iso: string, emp = 'e1') => ({
+  id: `${type}-${iso}`, employee_id: emp, restaurant_id: 'r1',
+  punch_type: type, punch_time: iso, employee: { name: 'A' },
+}) as any;
+
+describe('open-session windowing (buffered pairing)', () => {
+  it('a clock-out just after the day end makes the session complete, not open', () => {
+    const dayStart = new Date('2026-07-04T00:00:00');
+    const dayEnd = new Date('2026-07-04T23:59:59.999');
+    // Buffered fetch would include the Jul-5 00:06 clock-out.
+    const punches = [
+      p('clock_in', '2026-07-04T21:14:00'),
+      p('clock_out', '2026-07-05T00:06:00'),
+    ];
+    const { sessions } = processPunchesForPeriod(punches);
+    const windowSessions = sessionsWithClockInInWindow(sessions, dayStart, dayEnd);
+    expect(windowSessions).toHaveLength(1);
+    expect(windowSessions[0].is_complete).toBe(true);
+    const open = windowSessions.filter((s) => !s.is_complete);
+    expect(open).toHaveLength(0);
+    // And the hours count toward the day total:
+    expect(windowSessions[0].worked_minutes / 60).toBeCloseTo(2.87, 1);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify pass-or-fail baseline**
+
+Run: `npx vitest run tests/unit/timePunchProcessing.test.ts -t "open-session windowing"`
+Expected: PASS already (this asserts the helper contract the page relies on; it guards against regressions when the page wiring lands). If the import path fails, that is the expected RED until Task 1 is merged (it is).
+
+- [ ] **Step 3: Buffer the fetch + derive window sets**
+
+In `src/pages/TimePunchesManager.tsx`:
+
+(a) Add imports:
+```ts
+import { bufferPunchFetchRange, isWithinWindow, sessionsWithClockInInWindow } from '@/utils/punchWindow';
+```
+
+(b) At the `useTimePunches` call (around :295-300) pass a buffered range built from `dateRange`:
+```ts
+  const { fetchStart, fetchEnd } = useMemo(
+    () => bufferPunchFetchRange(dateRange.start, dateRange.end),
+    [dateRange.start, dateRange.end],
+  );
+  const { punches, loading } = useTimePunches(
+    restaurantId,
+    undefined,
+    fetchStart,
+    fetchEnd,
+  );
+```
+(Match the existing argument list for `useTimePunches` — keep whatever employee arg the current call passes; only the date args become buffered.)
+
+(c) `filteredPunches` stays the buffered, search-filtered set feeding pairing (unchanged). Immediately after it, add the window subset:
+```ts
+  // Punches actually inside the viewed window — for tables, export, editor, photos.
+  const windowPunches = useMemo(
+    () => filteredPunches.filter((punch) => isWithinWindow(punch.punch_time, dateRange.start, dateRange.end)),
+    [filteredPunches, dateRange.start, dateRange.end],
+  );
+```
+
+(d) Window-filter the sessions for all viewModes and derive window processed-punches:
+```ts
+  const windowSessions = useMemo(
+    () => sessionsWithClockInInWindow(processedData.sessions, dateRange.start, dateRange.end),
+    [processedData.sessions, dateRange.start, dateRange.end],
+  );
+  const windowProcessedPunches = useMemo(
+    () => processedData.processedPunches.filter((pp) => isWithinWindow(pp.punch_time, dateRange.start, dateRange.end)),
+    [processedData.processedPunches, dateRange.start, dateRange.end],
+  );
+```
+
+(e) Rewire consumers:
+- `incompleteSessions` (:322) → `windowSessions.filter((s) => !s.is_complete)`.
+- `todaySessions` (:325-330) → for `day` viewMode return `sessionsWithClockInInWindow(windowSessions, startOfDay(currentDate), endOfDay(currentDate))`; otherwise return `windowSessions`. (Uses the helper for consistent inclusive semantics; removes the `isSameDay` variant.)
+- `totalWeekHours` (:564) — already `todaySessions.reduce(...)`, so it now reflects window sessions; no change needed beyond (e) above.
+- Punch List table, `handleExportCSV` (`filteredPunches` at :560 count + rows), and `ManualTimelineEditor existingPunches` (:705) → change their source from `filteredPunches` to `windowPunches`.
+- Photo-thumbnail effect (:333, `punches.filter(...)` with dep `[punches]`) → change to `windowPunches.filter(...)` with dep `[windowPunches]`.
+- `PunchStreamView` (:747) → pass `windowProcessedPunches` instead of `processedData.processedPunches`.
+
+- [ ] **Step 4: Verify build + tests**
+
+Run: `npx vitest run tests/unit/timePunchProcessing.test.ts && npx tsc --noEmit -p tsconfig.app.json 2>&1 | head`
+Expected: tests PASS, no type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pages/TimePunchesManager.tsx tests/unit/timePunchProcessing.test.ts
+git commit -m "fix(time-clock): stop false open sessions from per-day fetch windowing"
+```
+
+---
+
+## Task 6: Buffer the Dashboard labor-cost fetch
+
+**Files:**
+- Modify: `src/hooks/useLaborCostsFromTimeTracking.tsx:84-90`
+
+- [ ] **Step 1: Add import + widen fetch**
+
+Add:
+```ts
+import { bufferPunchFetchRange } from '@/utils/punchWindow';
+```
+Replace:
+```ts
+      const { data: punches, error: punchesError } = await supabase
+        .from('time_punches')
+        .select('*')
+        .eq('restaurant_id', restaurantId)
+        .gte('punch_time', dateFrom.toISOString())
+        .lte('punch_time', dateTo.toISOString())
+        .order('punch_time', { ascending: true });
+```
+with:
+```ts
+      // ±18h buffer so overnight shifts pair whole; calculateActualLaborCost
+      // attributes hours by clock-in day and drops out-of-window periods.
+      const { fetchStart, fetchEnd } = bufferPunchFetchRange(dateFrom, dateTo);
+      const { data: punches, error: punchesError } = await supabase
+        .from('time_punches')
+        .select('*')
+        .eq('restaurant_id', restaurantId)
+        .gte('punch_time', fetchStart.toISOString())
+        .lte('punch_time', fetchEnd.toISOString())
+        .order('punch_time', { ascending: true });
+```
+Query key (line 77) stays on `dateFrom`/`dateTo` — do not change.
+
+- [ ] **Step 2: Verify**
+
+Run: `npx tsc --noEmit -p tsconfig.app.json 2>&1 | head`
+Expected: no new type errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/hooks/useLaborCostsFromTimeTracking.tsx
+git commit -m "fix(dashboard): fetch ±18h buffer for overnight-safe labor costs"
+```
+
+---
+
+## Task 7: Buffer the two AI edge-tool fetches
+
+**Files:**
+- Modify: `supabase/functions/_shared/laborCalculations.ts` (add constant)
+- Modify: `supabase/functions/ai-execute-tool/index.ts` (~L231, ~L2242)
+
+- [ ] **Step 1: Add the Deno-side constant**
+
+At the top of `supabase/functions/_shared/laborCalculations.ts`, add:
+```ts
+/**
+ * Hours past endDate to widen a time_punches fetch so a shift whose clock_out
+ * lands just after the window end still pairs. calculateActualLaborCost /
+ * calculateHoursPerEmployee already drop periods whose clock-in is outside
+ * [startDate, endDate], so this look-ahead never double-counts.
+ * MUST stay in parity with src/utils/punchWindow.ts OVERNIGHT_BUFFER_HOURS.
+ */
+export const LABOR_FETCH_LOOKAHEAD_HOURS = 18;
+```
+
+- [ ] **Step 2: Widen the P&L labor fetch (~L231)**
+
+In `supabase/functions/ai-execute-tool/index.ts`, at the handler importing `calculateActualLaborCost` (~L227), import the constant alongside it:
+```ts
+  const { calculateActualLaborCost, LABOR_FETCH_LOOKAHEAD_HOURS } = await import('../_shared/laborCalculations.ts');
+```
+Replace that fetch's upper bound:
+```ts
+    .gte('punch_time', startDate.toISOString())
+    .lte('punch_time', endDate.toISOString())
+```
+with:
+```ts
+    .gte('punch_time', startDate.toISOString())
+    .lte('punch_time', new Date(endDate.getTime() + LABOR_FETCH_LOOKAHEAD_HOURS * 3600 * 1000).toISOString())
+```
+
+- [ ] **Step 3: Widen the payroll-summary fetch (~L2242)**
+
+In `executeGetPayrollSummary`, update its import (~L2236):
+```ts
+  const { calculateActualLaborCost, LABOR_FETCH_LOOKAHEAD_HOURS } = await import('../_shared/laborCalculations.ts');
+```
+and the `time_punches` query inside the `Promise.all` from:
+```ts
+      .gte('punch_time', startDate.toISOString())
+      .lte('punch_time', endDate.toISOString())
+```
+to:
+```ts
+      .gte('punch_time', startDate.toISOString())
+      .lte('punch_time', new Date(endDate.getTime() + LABOR_FETCH_LOOKAHEAD_HOURS * 3600 * 1000).toISOString())
+```
+
+- [ ] **Step 4: Verify (Deno type check if available, else lint)**
+
+Run: `npx tsc --noEmit -p tsconfig.app.json 2>&1 | head` (edge fn is Deno; front-end tsc won't cover it — rely on `deno check` in CI). Confirm the two edits compile logically (constant imported where used).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/functions/_shared/laborCalculations.ts supabase/functions/ai-execute-tool/index.ts
+git commit -m "fix(ai-tools): look-ahead buffer for overnight-safe labor + payroll summary"
+```
+
+---
+
+## Final verification (Phase 8 handles this, listed for completeness)
+
+- `npm run test` — all unit tests green (existing 58 + new punchWindow/timecard/payroll/open-session cases).
+- Run the timecard/attribution suite under `TZ=America/Chicago` as well as UTC.
+- `npm run typecheck`, `npm run lint`, `npm run build` — clean.
+
+## Spec coverage check
+
+- Design §"punchWindow.ts" → Task 1. §2 Payroll → Tasks 2, 3. §3 Open Sessions → Task 5. §4 Timecard → Task 4. §5 Dashboard → Task 6. §6 AI edge tools → Task 7. Testing §1-4 → distributed across tasks. Timezone discipline → Task 4 DST-portable test + local-day bucketing. All design sections have an owning task.

--- a/docs/superpowers/plans/2026-07-09-overnight-shift-punch-windowing.md
+++ b/docs/superpowers/plans/2026-07-09-overnight-shift-punch-windowing.md
@@ -172,7 +172,11 @@ git commit -m "feat(time-punch): add punchWindow buffer + attribution helpers"
 - Modify: `src/utils/payrollCalculations.ts:429-486` (hourly branch)
 - Test: `tests/unit/payrollCalculations.test.ts`
 
-Background: `calculateEmployeePay(employee, punches, tips, periodStartDate, periodEndDate, …)` already receives the period bounds. The hourly branch calls `parseWorkPeriods(punches)` at :430 then loops `parsed.periods` at :433. We insert the window filter between them so buffered-but-out-of-window shifts don't count and don't warn.
+Background: `calculateEmployeePay` has **three** production callers — `calculatePayrollPeriod` (payroll, fetches buffered punches, wants attribution), and TWO callers inside `src/services/laborCalculations.ts` (`calculateActualLaborCostForMonth`): a salary/contractor call (:884, non-hourly — unaffected) and an **hourly per-ISO-week** call (:913) that pre-buckets punches by unbuffered `startOfWeek` and passes **noon-anchored** week bounds (`weekKey + 'T12:00:00'`) as a deliberate DST workaround (see lessons.md PR #485). A window filter that keys off `periodStartDate`/`periodEndDate` being present would wrongly drop that caller's 09:00 clock-ins (09:00 < the noon anchor).
+
+Therefore the filter is **explicit opt-in** via a new `attributeToWindow` flag (default `false`). Only `calculatePayrollPeriod` passes `true`. The noon-anchored monthly caller stays untouched. (Its own latent overnight bug — bucketing by unbuffered `startOfWeek` splits a Sun→Mon shift across weeks — is real but DST-sensitive and out of scope; tracked as a separate follow-up.)
+
+The hourly branch calls `parseWorkPeriods(punches)` at :430 then loops `parsed.periods` at :433. We insert the flag-guarded window filter between them so buffered-but-out-of-window shifts don't count and don't warn.
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -247,16 +251,51 @@ describe('calculateEmployeePay overnight window attribution', () => {
 });
 ```
 
-- [ ] **Step 2: Run to verify failure**
+The 4 overnight tests committed in Task 2.1 call `calculateEmployeePay(employee, punches, 0, weekStart, weekEnd)` — they must opt into the new flag. Update them in this step.
+
+- [ ] **Step 2: Update the 4 overnight tests to opt into `attributeToWindow`**
+
+In `tests/unit/payrollCalculations.test.ts`, in the `describe('calculateEmployeePay overnight window attribution')` block, change each of the 4 `calculateEmployeePay(...)` calls to pass the intermediate defaults and the flag as the final arg. E.g.:
+```ts
+// before:
+const pay = calculateEmployeePay(employee, punches, 0, weekStart, weekEnd);
+// after:
+const pay = calculateEmployeePay(employee, punches, 0, weekStart, weekEnd, [], 0, undefined, [], true);
+```
+Apply the same `, [], 0, undefined, [], true` tail to all 4 calls (the two `weekStart/weekEnd` calls, the `nextStart/nextEnd` call, and the OT/tip-neighbour call at the end of the block).
+
+- [ ] **Step 3: Run to verify failure**
 
 Run: `npx vitest run tests/unit/payrollCalculations.test.ts -t "overnight window attribution"`
-Expected: FAIL — out-of-window shifts currently counted / false orphan emitted.
+Expected: FAIL — 2/4 fail (double-count + OT/tip-neighbour) because the flag param and filter don't exist yet (TS may error on the extra arg — that is also an acceptable RED).
 
-- [ ] **Step 3: Implement the filter**
+- [ ] **Step 4: Implement the opt-in filter**
 
 In `src/utils/payrollCalculations.ts`, add the import near the top (after the existing imports):
 ```ts
 import { periodsInWindow, incompleteShiftsInWindow } from '@/utils/punchWindow';
+```
+Add the `attributeToWindow` parameter to the signature (after `overtimeAdjustments`):
+```ts
+export function calculateEmployeePay(
+  employee: Employee,
+  punches: TimePunch[],
+  tips: number, // In cents
+  periodStartDate?: Date,
+  periodEndDate?: Date,
+  manualPayments: ManualPayment[] = [],
+  tipsPaidOut: number = 0,
+  overtimeRules?: OTRules,
+  overtimeAdjustments: OvertimeAdjustment[] = [],
+  // When true, attribute each shift to its clock-in day and drop periods/
+  // incomplete shifts whose anchor punch falls outside [periodStartDate,
+  // periodEndDate]. ONLY the payroll path (calculatePayrollPeriod) opts in —
+  // it fetches a ±18h buffer so boundary-crossing shifts pair whole first.
+  // calculateActualLaborCostForMonth intentionally leaves this false: it
+  // pre-buckets by ISO week and passes NOON-anchored bounds that this filter
+  // would misinterpret.
+  attributeToWindow: boolean = false,
+): EmployeePayroll {
 ```
 In the hourly branch, replace:
 ```ts
@@ -268,26 +307,31 @@ with:
 ```ts
   if (compensationType === 'hourly') {
     const parsed = parseWorkPeriods(punches);
-    // Attribute each shift to its clock-in day: keep only periods/incomplete
-    // shifts whose anchor punch falls in the pay period. Callers fetch a ±18h
-    // buffer so boundary-crossing shifts pair whole before this filter runs.
-    if (periodStartDate && periodEndDate) {
+    if (attributeToWindow && periodStartDate && periodEndDate) {
       parsed.periods = periodsInWindow(parsed.periods, periodStartDate, periodEndDate);
       parsed.incompleteShifts = incompleteShiftsInWindow(parsed.incompleteShifts, periodStartDate, periodEndDate);
     }
     const hoursByDate = new Map<string, number>();
 ```
 
-- [ ] **Step 4: Run to verify pass**
+- [ ] **Step 5: Opt the payroll path in**
 
-Run: `npx vitest run tests/unit/payrollCalculations.test.ts`
-Expected: PASS (all existing + 4 new).
+In the same file, update `calculatePayrollPeriod`'s call (line ~629) to pass `true` as the final argument:
+```ts
+    return calculateEmployeePay(employee, punches, tips, startDate, endDate, manualPayments, tipsPaidOut, overtimeRules, overtimeAdjustments, true);
+```
+Do NOT modify the two `calculateEmployeePay` calls in `src/services/laborCalculations.ts` — they intentionally keep the default `false`.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Run the FULL suite to verify no regression**
+
+Run: `npx vitest run tests/unit/payrollCalculations.test.ts tests/unit/laborCalculations.calculateActualLaborCostForMonth.test.ts`
+Expected: PASS — all payroll tests (existing + 4 new overnight) green, AND the month-boundary OT test stays green (proves the noon-anchored caller is unaffected). Then `npx vitest run` for the whole suite before committing.
+
+- [ ] **Step 7: Commit**
 
 ```bash
 git add src/utils/payrollCalculations.ts tests/unit/payrollCalculations.test.ts
-git commit -m "fix(payroll): attribute overnight shifts to clock-in day, drop out-of-window"
+git commit -m "fix(payroll): opt-in window filter attributes overnight shifts to clock-in day"
 ```
 
 ---

--- a/docs/superpowers/specs/2026-07-09-overnight-shift-punch-windowing-design.md
+++ b/docs/superpowers/specs/2026-07-09-overnight-shift-punch-windowing-design.md
@@ -127,14 +127,26 @@ dropped. A period/session is "in window" iff its clock-in ∈ `[start, end]`
   `endDate`** (buffering is encapsulated in `queryFn`) — no cache-key change.
 - `calculateEmployeePay`, hourly branch: immediately after
   `parseWorkPeriods(punches)` (payrollCalculations.ts:430), and **before** the
-  `hoursByDate` loop at :433, reassign `parsed.periods = periodsInWindow(parsed.periods,
-  periodStartDate, periodEndDate)` and `parsed.incompleteShifts =
-  incompleteShiftsInWindow(parsed.incompleteShifts, …)` — but only when both
-  window bounds are provided (they always are from `calculatePayrollPeriod`).
-  All downstream OT-bucketing and tip-proration then operate on in-window
-  periods unchanged. This is a real logic change inside the 55-line hourly
-  block, **not** mere range-widening — it gets dedicated OT/tip-proration test
-  coverage (see Testing).
+  `hoursByDate` loop at :433, reassign `parsed.periods = periodsInWindow(...)`
+  and `parsed.incompleteShifts = incompleteShiftsInWindow(...)`. This is gated
+  behind an **explicit opt-in flag** `attributeToWindow` (default `false`), NOT
+  merely the presence of `periodStartDate`/`periodEndDate`. Only
+  `calculatePayrollPeriod` (the payroll path, which fetches buffered punches)
+  passes `true`. All downstream OT-bucketing and tip-proration then operate on
+  in-window periods unchanged. This is a real logic change inside the 55-line
+  hourly block, **not** mere range-widening — it gets dedicated OT/tip-proration
+  test coverage (see Testing).
+
+  **Why opt-in (third caller):** `calculateEmployeePay` has a third production
+  caller beyond payroll — `calculateActualLaborCostForMonth`
+  (`src/services/laborCalculations.ts:913`) buckets punches by unbuffered ISO
+  week and passes **noon-anchored** week bounds (`weekKey + 'T12:00:00'`) as a
+  deliberate DST workaround (lessons.md PR #485). Keying the filter on the mere
+  presence of period bounds would wrongly drop that caller's 09:00 clock-ins
+  (09:00 < the noon anchor), shorting a full day of wages. The opt-in flag keeps
+  that caller's behaviour byte-for-byte unchanged. Its own latent overnight bug
+  (a Sun→Mon shift is split across ISO-week buckets) is real but DST-sensitive
+  and out of scope — see Decided trade-offs.
 - Daily-rate branch already guards `punchDate` within
   `[periodStartDate, periodEndDate]` (payrollCalculations.ts:496–508); buffered
   punches are safe there with no change.
@@ -319,6 +331,15 @@ near local midnight in offset zones land on the wrong day (see `memory/lessons.m
 - **No historical data cleanup** in this PR: the fix prevents *future* false
   warnings and dropped pay. Cleaning the already-created duplicate/force-out
   punches is a separate, data-only follow-up.
+- **Monthly labor-cost overnight bug deferred:** `calculateActualLaborCostForMonth`
+  (`src/services/laborCalculations.ts`) buckets punches by unbuffered
+  `startOfWeek` before pairing, so a Sun→Mon shift is split across ISO-week
+  buckets — the same bug class. Fixing it needs buffered re-bucketing AND a
+  decision on the noon-anchor-vs-midnight DST workaround (lessons.md PR #485
+  documents a $2,246 TZ swing in this exact code), so it warrants its own design
+  pass and DST-portable tests. Discovered during Phase 4; tracked as a follow-up
+  rather than improvised into this PR. The opt-in flag ensures this PR does not
+  regress that function.
 - **Attribute to clock-in day** (vs splitting hours across two calendar days):
   matches existing conventions and keeps a shift's OT in a single week bucket.
 - **Deferred follow-ups** (flagged by design review, intentionally out of scope

--- a/docs/superpowers/specs/2026-07-09-overnight-shift-punch-windowing-design.md
+++ b/docs/superpowers/specs/2026-07-09-overnight-shift-punch-windowing-design.md
@@ -1,0 +1,208 @@
+# Design: Overnight-Shift Punch Windowing Fix
+
+**Date:** 2026-07-09
+**Branch:** `fix/overnight-shift-punch-windowing`
+**Type:** Bug fix (payroll correctness + data-integrity)
+
+## Problem
+
+Employees who clock in one day and clock out after midnight the next day
+("overnight" shifts — e.g. clock in Thu 5 PM, clock out Fri 12:06 AM after
+cleaning) trigger two wrong behaviours:
+
+1. **False warnings.** The clock view shows "Open Sessions … Force Out" and
+   the Payroll page shows "Incomplete Time Punches Detected … Clock-out at
+   Jul 4, 12:06 AM has no matching clock-in." Managers, trusting the warning,
+   manually add clock-in/clock-out punches — corrupting otherwise-clean data
+   (observed live: duplicate clock-ins and stray 11:59 PM "force-out" punches).
+2. **Dropped pay (latent).** Any shift whose clock-in and clock-out fall on
+   opposite sides of a fetch-window boundary loses its hours from *both*
+   periods. Confirmed live on the platform: two Sunday-night→Monday-morning
+   shifts (~22.7 h) at another restaurant sit exactly on the Mon–Sun payroll
+   week boundary and would be dropped from a standard weekly run.
+
+### Root cause
+
+The pairing engines (`parseWorkPeriods` in
+`src/utils/payrollCalculations.ts`, `identifyWorkSessions` in
+`src/utils/timePunchProcessing.ts`) are overnight-aware — they pair
+clock-in→clock-out sequentially with an 18 h max-gap and do **not** group by
+calendar day. They are correct *in isolation*.
+
+The bug is in the **fetch layer**: every query loads punches with a hard
+`punch_time >= start AND punch_time <= end` and **no buffer**. A shift is a
+*pair*; when the window boundary falls between the two punches, the pair is
+split before the pairing engine ever sees it:
+
+- View day N → clock-in present, clock-out (day N+1) missing → "open session".
+- View day N+1 → clock-out present, clock-in (day N) missing → "no matching
+  clock-in" and the hours are not counted.
+
+### Affected fetch sites
+
+| Site | File | Symptom |
+|---|---|---|
+| Payroll | `src/hooks/usePayroll.tsx` | Dropped pay at period boundary + false banner |
+| Open Sessions | `src/pages/TimePunchesManager.tsx` | False "open session" → Force-Out corruption |
+| Employee Timecard | `src/pages/EmployeeTimecard.tsx` | **Per-day bucketing**; silently halves overnight hours, no warning |
+| Dashboard labor cost | `src/hooks/useLaborCostsFromTimeTracking.tsx` | Overnight hours dropped at range edges |
+
+The one path that already does it right is `fetchLaborData` in
+`supabase/functions/ai-execute-tool/index.ts` (`endLookaheadHours: 18`) →
+`calculateHoursPerEmployee` filters periods by `startTime` in
+`[startDate, endDate]`. This design generalizes that proven pattern.
+
+## Approach
+
+**Fetch a buffered window, pair across the full set, then attribute each
+shift to its clock-in day and drop shifts whose clock-in falls outside the
+target window.** This yields exactly-once counting and eliminates false
+orphans.
+
+- **Buffer:** symmetric ±18 h around `[start, end]`.
+  - *Look-ahead* (`end + 18h`): so the owning period sees the clock-out of a
+    shift that started in-window and crossed the end boundary.
+  - *Look-back* (`start − 18h`): so a period pairs (rather than orphans) a
+    clock-out whose clock-in was in the previous period; the completed shift
+    is then dropped as belonging to the prior period — suppressing the false
+    "no matching clock-in" warning.
+- **Attribution rule:** a shift belongs to the period containing its
+  **clock-in** (`startTime`). This matches the existing daily-rate and
+  labor-cost conventions (`docs/DAILY_RATE_PAYROLL_LOGIC.md`,
+  `calculateHoursPerEmployee`).
+- **Constant:** buffer = 18 h, equal to `MAX_SHIFT_GAP_HOURS` (the max gap the
+  pairing engine will pair). A shift with a larger gap is already flagged, not
+  counted, so 18 h captures every pairable shift.
+
+### Why symmetric buffer everywhere
+
+Some sites strictly need only look-ahead (dashboard, open-sessions) while
+payroll also needs look-back to suppress the start-boundary warning. A single
+symmetric helper is simpler to reason about and safe everywhere, because each
+site applies an attribution filter that drops out-of-window shifts. The pairing
+engine's 18 h gap cap prevents mispairing across the wider fetch.
+
+## Components
+
+### New: `src/utils/punchWindow.ts`
+
+Pure, dependency-light helpers (unit-tested):
+
+- `OVERNIGHT_BUFFER_HOURS = 18` — with a test asserting
+  `OVERNIGHT_BUFFER_HOURS >= MAX_SHIFT_GAP_HOURS` to prevent drift.
+- `bufferPunchFetchRange(start: Date, end: Date, hours?): { fetchStart: Date; fetchEnd: Date }`
+- `periodsInWindow(periods, start, end)` — keep periods whose `startTime` ∈ window.
+- `incompleteShiftsInWindow(shifts, start, end)` — keep shifts whose `punchTime` ∈ window.
+- `sessionsWithClockInInWindow(sessions, start, end)` — keep sessions whose `clock_in` ∈ window.
+
+Window bounds are inclusive on both ends (`>= start && <= end`), matching the
+existing `.gte/.lte` query semantics.
+
+### 2. Payroll — `usePayroll.tsx` + `calculateEmployeePay`
+
+- `usePayroll` fetches `bufferPunchFetchRange(startDate, endDate)` instead of
+  the raw window.
+- `calculateEmployeePay`: after `parseWorkPeriods(punches)`, when
+  `periodStartDate`/`periodEndDate` are present (they already are — passed by
+  `calculatePayrollPeriod`), filter `parsed.periods` via `periodsInWindow` and
+  `parsed.incompleteShifts` via `incompleteShiftsInWindow` before the OT/hours
+  computation. The daily-rate branch already guards `punchDate` within the
+  period, so buffered punches are safe there.
+
+Result: a Sun 20:00→Mon 02:00 shift is counted once in the Sunday week; the
+Monday-week run fetches the Sunday clock-in via look-back, pairs it, and drops
+it (clock-in < Monday start) — no double count, no false warning.
+
+### 3. Open Sessions — `TimePunchesManager.tsx`
+
+- Fetch the buffered range via `useTimePunches`.
+- Derive `windowPunches = punches.filter(inWindow)` for the raw punch table /
+  photo / display logic; pair sessions on the full buffered `punches`.
+- `incompleteSessions` (and `todaySessions` open detection) = sessions with
+  `clock_in` in the viewed `[dateRange.start, dateRange.end]` **and**
+  `!is_complete`, via `sessionsWithClockInInWindow`.
+
+Result: a Jul-4 shift whose clock-out lands 12:06 AM Jul 5 is now paired →
+`is_complete` → not surfaced as an open session; "Force Out" is only offered
+for genuinely open shifts.
+
+### 4. Employee Timecard — `EmployeeTimecard.tsx`
+
+- Replace the per-day `calculateDayHours` + `punchesByDay` **hours** path with
+  `parseWorkPeriods` over buffered punches, attributed to clock-in day.
+- Extract a pure `hoursByClockInDay(periods, days)` (or reuse period grouping)
+  returning `{ totalHours, breakHours, netHours }` per calendar day — unit
+  tested for overnight attribution.
+- Keep the visual per-day punch *list* (`punchesByDay`) unchanged; only the
+  hours numbers now come from paired periods. `useTimePunches` is called with a
+  buffered `startDate`/`endDate`.
+
+### 5. Dashboard — `useLaborCostsFromTimeTracking.tsx`
+
+- Fetch `bufferPunchFetchRange(dateFrom, dateTo)`.
+  `calculateActualLaborCost` already keys costs by clock-in day and ignores
+  out-of-window periods (date-map membership), so no further change needed.
+
+### Not touched
+
+- `get_employee_punch_status` RPC — already unbounded (last punch), correct.
+- The pairing engines (`parseWorkPeriods`, `identifyWorkSessions`) — correct in
+  isolation; no change to pairing logic.
+
+## Data flow (payroll example)
+
+```
+usePayroll(start, end)
+  → bufferPunchFetchRange → fetch time_punches in [start−18h, end+18h]
+  → group by employee
+  → calculateEmployeePay(employee, bufferedPunches, …, start, end)
+       → parseWorkPeriods(bufferedPunches)          // pairs across boundaries
+       → periodsInWindow(periods, start, end)       // attribute to clock-in day
+       → incompleteShiftsInWindow(shifts, start, end)
+       → OT / hours / pay on in-window periods only
+```
+
+## Error / edge handling
+
+- **Genuine missing clock-out** (no clock-out anywhere within 18 h): still
+  surfaces as an incomplete shift whose clock-in `punchTime` is in-window →
+  correctly flagged.
+- **Genuine orphan clock-out** (no clock-in within 18 h look-back): still
+  surfaces as "no matching clock-in" → correctly flagged.
+- **Duplicate / manual noise punches** (already present in live data): pairing
+  and dedup behaviour is unchanged; this fix does not clean historical data
+  (a separate data-hygiene pass, out of scope here).
+- **DST boundaries:** buffer math is in absolute epoch ms (`Date.getTime()`),
+  independent of local wall-clock, so DST transitions do not distort the ±18 h.
+- **Performance:** ±18 h widening adds at most ~1.5 days of punches per query —
+  negligible; existing `(restaurant_id, punch_time)` index still serves it.
+
+## Testing
+
+Pure-function unit tests carry the correctness weight (hook changes are
+mechanical range widening):
+
+1. `punchWindow.test.ts` — `bufferPunchFetchRange` offsets; each filter keeps
+   in-window / drops out-of-window (boundary-inclusive); `OVERNIGHT_BUFFER_HOURS
+   >= MAX_SHIFT_GAP_HOURS` drift guard.
+2. `payrollCalculations.test.ts` — new cases:
+   - Sun 20:00→Mon 02:00 shift counted once in the Sunday-week run.
+   - Monday-week run with look-back Sunday clock-in → shift dropped, **no**
+     double count, **no** "no matching clock-in" incomplete shift.
+   - Genuine missing clock-out still flagged when clock-in is in-window.
+3. `timePunchProcessing.test.ts` / timecard hours — a clock-out just after the
+   window end reads `is_complete` (not open) once buffered; `hoursByClockInDay`
+   attributes a Thu 23:00→Fri 07:00 shift entirely to Thursday.
+
+Existing 58 tests in the target area must stay green.
+
+## Decided trade-offs
+
+- **Symmetric buffer** (vs look-ahead-only like `fetchLaborData`): chosen for
+  uniform reasoning and to suppress the payroll start-boundary warning; the
+  attribution filters make the extra look-back harmless.
+- **No historical data cleanup** in this PR: the fix prevents *future* false
+  warnings and dropped pay. Cleaning the already-created duplicate/force-out
+  punches is a separate, data-only follow-up.
+- **Attribute to clock-in day** (vs splitting hours across two calendar days):
+  matches existing conventions and keeps a shift's OT in a single week bucket.

--- a/docs/superpowers/specs/2026-07-09-overnight-shift-punch-windowing-design.md
+++ b/docs/superpowers/specs/2026-07-09-overnight-shift-punch-windowing-design.md
@@ -46,11 +46,16 @@ split before the pairing engine ever sees it:
 | Open Sessions | `src/pages/TimePunchesManager.tsx` | False "open session" → Force-Out corruption |
 | Employee Timecard | `src/pages/EmployeeTimecard.tsx` | **Per-day bucketing**; silently halves overnight hours, no warning |
 | Dashboard labor cost | `src/hooks/useLaborCostsFromTimeTracking.tsx` | Overnight hours dropped at range edges |
+| AI tool: P&L labor | `supabase/functions/ai-execute-tool/index.ts` (~L231) | Split-shift hours in AI "profit & loss" labor line |
+| AI tool: payroll summary | `supabase/functions/ai-execute-tool/index.ts` (~L2242) | Split-shift hours in AI "payroll summary" |
 
-The one path that already does it right is `fetchLaborData` in
-`supabase/functions/ai-execute-tool/index.ts` (`endLookaheadHours: 18`) →
-`calculateHoursPerEmployee` filters periods by `startTime` in
-`[startDate, endDate]`. This design generalizes that proven pattern.
+The one path that already does it right is `fetchLaborData` in the **same**
+edge file (`endLookaheadHours: 18`) → `calculateHoursPerEmployee`/
+`calculateActualLaborCost` filter periods by clock-in day within
+`[startDate, endDate]`. This design generalizes that proven pattern; the two
+sibling handlers above (`executeGetProfitLoss`-family L231 and
+`executeGetPayrollSummary` L2242) were added without going through
+`fetchLaborData` and so still fetch unbuffered.
 
 ## Approach
 
@@ -98,16 +103,41 @@ Pure, dependency-light helpers (unit-tested):
 Window bounds are inclusive on both ends (`>= start && <= end`), matching the
 existing `.gte/.lte` query semantics.
 
+### Data-lineage rule (applies to every site)
+
+Two derived data sets, never conflated:
+
+- **Buffered set** — punches fetched across `[start−18h, end+18h]`. Feeds
+  **pairing only** (`parseWorkPeriods` / `processPunchesForPeriod`). Pairing
+  needs both punches of a boundary-crossing shift.
+- **Window set** — data filtered back to the caller's logical `[start, end]`.
+  Feeds **every display and every total**: raw punch tables, CSV export,
+  manual-editor overlap checks, photo-thumbnail loads, per-employee hour
+  summaries, and the "hours" headline metrics.
+
+The pairing output (periods / sessions) is then attributed to the window by
+**clock-in day** and everything with a clock-in outside `[start, end]` is
+dropped. A period/session is "in window" iff its clock-in ∈ `[start, end]`
+(inclusive both ends, matching `.gte/.lte`).
+
 ### 2. Payroll — `usePayroll.tsx` + `calculateEmployeePay`
 
-- `usePayroll` fetches `bufferPunchFetchRange(startDate, endDate)` instead of
-  the raw window.
-- `calculateEmployeePay`: after `parseWorkPeriods(punches)`, when
-  `periodStartDate`/`periodEndDate` are present (they already are — passed by
-  `calculatePayrollPeriod`), filter `parsed.periods` via `periodsInWindow` and
-  `parsed.incompleteShifts` via `incompleteShiftsInWindow` before the OT/hours
-  computation. The daily-rate branch already guards `punchDate` within the
-  period, so buffered punches are safe there.
+- `usePayroll` widens the inline `.gte/.lte` to `bufferPunchFetchRange(startDate,
+  endDate)`. The React Query **key stays keyed on the logical `startDate`/
+  `endDate`** (buffering is encapsulated in `queryFn`) — no cache-key change.
+- `calculateEmployeePay`, hourly branch: immediately after
+  `parseWorkPeriods(punches)` (payrollCalculations.ts:430), and **before** the
+  `hoursByDate` loop at :433, reassign `parsed.periods = periodsInWindow(parsed.periods,
+  periodStartDate, periodEndDate)` and `parsed.incompleteShifts =
+  incompleteShiftsInWindow(parsed.incompleteShifts, …)` — but only when both
+  window bounds are provided (they always are from `calculatePayrollPeriod`).
+  All downstream OT-bucketing and tip-proration then operate on in-window
+  periods unchanged. This is a real logic change inside the 55-line hourly
+  block, **not** mere range-widening — it gets dedicated OT/tip-proration test
+  coverage (see Testing).
+- Daily-rate branch already guards `punchDate` within
+  `[periodStartDate, periodEndDate]` (payrollCalculations.ts:496–508); buffered
+  punches are safe there with no change.
 
 Result: a Sun 20:00→Mon 02:00 shift is counted once in the Sunday week; the
 Monday-week run fetches the Sunday clock-in via look-back, pairs it, and drops
@@ -115,39 +145,88 @@ it (clock-in < Monday start) — no double count, no false warning.
 
 ### 3. Open Sessions — `TimePunchesManager.tsx`
 
-- Fetch the buffered range via `useTimePunches`.
-- Derive `windowPunches = punches.filter(inWindow)` for the raw punch table /
-  photo / display logic; pair sessions on the full buffered `punches`.
-- `incompleteSessions` (and `todaySessions` open detection) = sessions with
-  `clock_in` in the viewed `[dateRange.start, dateRange.end]` **and**
-  `!is_complete`, via `sessionsWithClockInInWindow`.
+Current lineage: `filteredPunches = punches.filter(searchMatch)` (:308) →
+feeds `processPunchesForPeriod` (:317), the Punch List table (:800), CSV export
+(:517), `ManualTimelineEditor existingPunches` (:705), and the photo effect
+(:333). `processedData.sessions`/`.processedPunches` feed the visualization
+views and `todaySessions`/`totalWeekHours`/`incompleteSessions`.
 
-Result: a Jul-4 shift whose clock-out lands 12:06 AM Jul 5 is now paired →
-`is_complete` → not surfaced as an open session; "Force Out" is only offered
-for genuinely open shifts.
+Changes:
+- Fetch the buffered range via `useTimePunches(restaurantId, empId,
+  bufferedStart, bufferedEnd)`. `punches` is now the buffered set.
+- `filteredPunches = punches.filter(searchMatch)` stays the **buffered**
+  search-filtered set and feeds `processPunchesForPeriod` (pairing needs
+  buffer).
+- Add `windowPunches = filteredPunches.filter(p => inWindow(p.punch_time,
+  rangeStart, rangeEnd))`. **Repoint all display consumers to `windowPunches`**:
+  the Punch List table, `handleExportCSV`, `ManualTimelineEditor existingPunches`,
+  and the photo-thumbnail effect (:333). This keeps buffer-period punches out of
+  tables, exported files, overlap checks, and Storage signed-URL calls.
+- Add `windowProcessedPunches = processedData.processedPunches.filter(p =>
+  inWindow(p.punch_time, …))` for `PunchStreamView` (:747).
+- Add `windowSessions = sessionsWithClockInInWindow(processedData.sessions,
+  rangeStart, rangeEnd)`. Use it for **all** viewModes as the source for
+  `EmployeeCardView`/`BarcodeStripeView`/`ReceiptStyleView`, `todaySessions`,
+  `totalWeekHours` (:564), and `incompleteSessions` (:322). `incompleteSessions
+  = windowSessions.filter(s => !s.is_complete)`. The day-view `todaySessions`
+  filter switches from `isSameDay(...)` to the same `sessionsWithClockInInWindow`
+  helper for consistent inclusive-boundary semantics.
+
+Result: a Jul-4 shift whose clock-out lands 12:06 AM Jul 5 is paired →
+`is_complete` → not surfaced as an open session, and its hours count in the
+Jul-4 window total; "Force Out" is only offered for genuinely open shifts.
+Week/month `totalWeekHours` no longer leaks neighbouring-period hours.
 
 ### 4. Employee Timecard — `EmployeeTimecard.tsx`
 
-- Replace the per-day `calculateDayHours` + `punchesByDay` **hours** path with
-  `parseWorkPeriods` over buffered punches, attributed to clock-in day.
-- Extract a pure `hoursByClockInDay(periods, days)` (or reuse period grouping)
-  returning `{ totalHours, breakHours, netHours }` per calendar day — unit
-  tested for overnight attribution.
-- Keep the visual per-day punch *list* (`punchesByDay`) unchanged; only the
-  hours numbers now come from paired periods. `useTimePunches` is called with a
-  buffered `startDate`/`endDate`.
+Explicit dual-source split:
+- Call `useTimePunches(restaurantId, empId, bufferedStart, bufferedEnd)` where
+  `{bufferedStart, bufferedEnd} = bufferPunchFetchRange(startDate, endDate)`.
+  This **adds an `endDate` bound** (today only `startDate` is passed, so the
+  fetch is unbounded-after-start) — a deliberate change that also *reduces*
+  over-fetch for far-past periods.
+- **Display list (window):** keep `periodPunches` (:124, `punchDate` in
+  `[startDate, endDate]`) → `punchesByDay` → the visual per-punch timeline,
+  unchanged.
+- **Hours (buffered → attributed):** add pure
+  `hoursByClockInDay(periods, weekDays)` where `periods = parseWorkPeriods(punches)`
+  runs on the **buffered** hook `punches` (NOT `periodPunches` — feeding it the
+  filtered set would reintroduce the split bug). It buckets each period by its
+  clock-in **local** calendar day (`format(startTime, 'yyyy-MM-dd')`, matching
+  the existing local-day list grouping) into the `weekDays` set, returning
+  `{ totalHours, breakHours, netHours }` per day; days outside the period are
+  ignored. Per-day rows and `weeklyTotals` read from this.
+- Delete the now-dead `calculateDayHours`.
 
 ### 5. Dashboard — `useLaborCostsFromTimeTracking.tsx`
 
-- Fetch `bufferPunchFetchRange(dateFrom, dateTo)`.
-  `calculateActualLaborCost` already keys costs by clock-in day and ignores
-  out-of-window periods (date-map membership), so no further change needed.
+- Widen the inline fetch to `bufferPunchFetchRange(dateFrom, dateTo)`; query key
+  stays on the logical `dateFrom`/`dateTo`. `calculateActualLaborCost` already
+  keys costs by clock-in day and ignores out-of-window periods (date-map
+  membership), so no further change.
+
+### 6. AI edge tools — `ai-execute-tool/index.ts` (Deno)
+
+- Two handlers fetch `time_punches` unbuffered and feed `calculateActualLaborCost`:
+  L231 (P&L labor) and L2242 (`executeGetPayrollSummary`).
+- Add `LABOR_FETCH_LOOKAHEAD_HOURS = 18` to
+  `supabase/functions/_shared/laborCalculations.ts` and widen each fetch's
+  upper bound to `endDate + LABOR_FETCH_LOOKAHEAD_HOURS` (look-ahead only, in
+  parity with the sibling `fetchLaborData`; `calculateActualLaborCost` already
+  drops out-of-window periods by clock-in-day date-map, so a shift starting
+  before the window is not double-counted and no user-facing "orphan" warning
+  is produced by these read-only aggregation tools). This is a Deno module, so
+  the constant is defined Deno-side, mirroring the TS `OVERNIGHT_BUFFER_HOURS`;
+  a drift-guard note lives beside both constants.
 
 ### Not touched
 
 - `get_employee_punch_status` RPC — already unbounded (last punch), correct.
 - The pairing engines (`parseWorkPeriods`, `identifyWorkSessions`) — correct in
   isolation; no change to pairing logic.
+- `select('*')` on `time_punches` in `usePayroll`/`useLaborCostsFromTimeTracking`
+  and Punch-List virtualization — pre-existing, left as documented follow-ups
+  (see Decided trade-offs) to keep this fix focused.
 
 ## Data flow (payroll example)
 
@@ -179,30 +258,71 @@ usePayroll(start, end)
 
 ## Testing
 
-Pure-function unit tests carry the correctness weight (hook changes are
-mechanical range widening):
+Pure-function unit tests carry the correctness weight. The `calculateEmployeePay`
+and `hoursByClockInDay` changes are genuine logic changes (not mere range
+widening) and get dedicated coverage.
 
-1. `punchWindow.test.ts` — `bufferPunchFetchRange` offsets; each filter keeps
-   in-window / drops out-of-window (boundary-inclusive); `OVERNIGHT_BUFFER_HOURS
-   >= MAX_SHIFT_GAP_HOURS` drift guard.
+1. `punchWindow.test.ts` — `bufferPunchFetchRange` offsets (±18h, epoch-ms);
+   each filter keeps in-window / drops out-of-window with **inclusive**
+   boundaries (a period whose clock-in == `start` or == `end` is kept);
+   `OVERNIGHT_BUFFER_HOURS >= MAX_SHIFT_GAP_HOURS` drift guard.
 2. `payrollCalculations.test.ts` — new cases:
-   - Sun 20:00→Mon 02:00 shift counted once in the Sunday-week run.
+   - Sun 20:00→Mon 02:00 shift counted **once** in the Sunday-week run (full
+     hours, attributed to Sunday).
    - Monday-week run with look-back Sunday clock-in → shift dropped, **no**
-     double count, **no** "no matching clock-in" incomplete shift.
-   - Genuine missing clock-out still flagged when clock-in is in-window.
-3. `timePunchProcessing.test.ts` / timecard hours — a clock-out just after the
-   window end reads `is_complete` (not open) once buffered; `hoursByClockInDay`
-   attributes a Thu 23:00→Fri 07:00 shift entirely to Thursday.
+     double count, **no** "no matching clock-in" incomplete shift emitted.
+   - **OT/tip-proration path**: a week whose in-window periods push past 40h,
+     with a buffered-but-out-of-window neighbouring shift present in the input,
+     yields the same OT split and tip-prorated base rate as if the neighbour
+     were never fetched (proves the window filter sits correctly ahead of the
+     OT/tip math).
+   - Genuine missing clock-out still flagged when the clock-in is in-window.
+3. `timePunchProcessing` / open-sessions — a clock-out just after the window end:
+   (a) the session reads `is_complete` (not open), **and** (b) once paired, its
+   hours count toward the window's `totalWeekHours` (the two consumers —
+   `incompleteSessions` and `windowSessions` totals — are asserted separately).
+4. `hoursByClockInDay` — a Thu 23:00→Fri 07:00 shift attributes **entirely to
+   Thursday** (local day); a **DST-transition** case (clock-in at a local
+   midnight on a spring-forward/fall-back day, constructed via
+   `new Date(year, month, day, …)` for TZ-portability per lessons.md) asserts
+   attribution lands on the correct local calendar day regardless of process TZ.
 
-Existing 58 tests in the target area must stay green.
+Existing 58 tests in the target area must stay green. Run in UTC and at least
+one offset TZ (e.g. `TZ=America/Chicago`) for the timecard/attribution suite,
+per the DST lessons in `memory/lessons.md`.
+
+## Timezone discipline
+
+Fetch bounds use `Date.toISOString()` (UTC) and the ±18h buffer is epoch-ms, so
+fetch widening is TZ-invariant. **Attribution/day-bucketing is local**: the
+window `Date` boundaries (`startDate`/`endDate`) are constructed from local
+calendar days upstream, and `hoursByClockInDay` buckets by the punch's *local*
+calendar day — the two are compared consistently. This must be preserved: never
+bucket attribution by the UTC date portion of `punch_time`, or overnight shifts
+near local midnight in offset zones land on the wrong day (see `memory/lessons.md`
+`parseDateOnly`/`getUTC*` entries).
 
 ## Decided trade-offs
 
-- **Symmetric buffer** (vs look-ahead-only like `fetchLaborData`): chosen for
-  uniform reasoning and to suppress the payroll start-boundary warning; the
-  attribution filters make the extra look-back harmless.
+- **Symmetric buffer** on the UI/payroll sites (vs look-ahead-only like
+  `fetchLaborData`): chosen for uniform reasoning and to suppress the payroll
+  start-boundary "no matching clock-in" warning; the attribution filters make
+  the extra look-back harmless. The AI edge tools (read-only aggregation, no
+  user-facing orphan warning) use **look-ahead only**, matching their sibling
+  `fetchLaborData`.
+- **Fetch-volume increase (accepted):** buffering widens each query by ~1.5 days
+  *on top of* the queried span (a 1-day view fetches ~2.5 days), and the shifting
+  buffered boundary reduces cross-navigation cache overlap. Correctness outweighs
+  this; the `(restaurant_id, punch_time)` index keeps the scan cheap and payload
+  stays small at restaurant scale. The React Query key stays on the *logical*
+  window so cache identity is unaffected.
 - **No historical data cleanup** in this PR: the fix prevents *future* false
   warnings and dropped pay. Cleaning the already-created duplicate/force-out
   punches is a separate, data-only follow-up.
 - **Attribute to clock-in day** (vs splitting hours across two calendar days):
   matches existing conventions and keeps a shift's OT in a single week bucket.
+- **Deferred follow-ups** (flagged by design review, intentionally out of scope
+  to keep the fix focused): narrow `select('*')` → explicit columns in
+  `usePayroll`/`useLaborCostsFromTimeTracking`; virtualize the `TimePunchesManager`
+  Punch List table (CLAUDE.md 100+-item rule). Neither is newly triggered by
+  this change once `windowPunches` wiring keeps row counts at pre-buffer size.

--- a/docs/superpowers/specs/2026-07-09-overnight-shift-punch-windowing-design.md
+++ b/docs/superpowers/specs/2026-07-09-overnight-shift-punch-windowing-design.md
@@ -48,6 +48,24 @@ split before the pairing engine ever sees it:
 | Dashboard labor cost | `src/hooks/useLaborCostsFromTimeTracking.tsx` | Overnight hours dropped at range edges |
 | AI tool: P&L labor | `supabase/functions/ai-execute-tool/index.ts` (~L231) | Split-shift hours in AI "profit & loss" labor line |
 | AI tool: payroll summary | `supabase/functions/ai-execute-tool/index.ts` (~L2242) | Split-shift hours in AI "payroll summary" |
+| Tips "Calculate from hours" | `src/pages/Tips.tsx` (L106 fetch → L277/L655 calc) | **Zero** tip hours for overnight shifts (single-day fetch → lone punch → no pair) |
+
+### Caller audit (added after user request)
+
+Audited every caller of the punch→hours functions (`calculateWorkedHours`,
+`parseWorkPeriods`, `processPunchesForPeriod`, `calculateActualLaborCost*`):
+
+- **Fixed money surfaces:** payroll, open-sessions, timecard, dashboard, AI
+  tools, and **Tips** (both `calculateWorkedHours` call sites share the one
+  L106 day-window fetch).
+- **Safe — not windowed:** `timePunchImport.ts` parses the *entire uploaded*
+  dataset (bulk-import preview), so overnight shifts pair fine.
+- **Display-only — no hours math:** `EmployeeClock.tsx` renders today's punch
+  *list*; status comes from the unbounded `get_employee_punch_status` RPC.
+- **Deferred (own follow-ups):** `calculateActualLaborCostForMonth`
+  (noon-anchored, DST-sensitive — see trade-offs) and
+  `useWeekStaffingSuggestions` SPLH (a non-payroll *suggestion heuristic*, uses
+  legacy `in`/`out` punch types, `hours<24` guard — not money owed).
 
 The one path that already does it right is `fetchLaborData` in the **same**
 edge file (`endLookaheadHours: 18`) → `calculateHoursPerEmployee`/

--- a/src/hooks/useLaborCostsFromTimeTracking.tsx
+++ b/src/hooks/useLaborCostsFromTimeTracking.tsx
@@ -4,7 +4,7 @@ import { useEmployees } from './useEmployees';
 import { TimePunch } from '@/types/timeTracking';
 import { format } from 'date-fns';
 import { calculateActualLaborCost } from '@/services/laborCalculations';
-import { bufferPunchFetchRange } from '@/utils/punchWindow';
+import { lookaheadPunchFetchRange } from '@/utils/punchWindow';
 
 export interface LaborCostData {
   date: string;
@@ -81,10 +81,13 @@ export function useLaborCostsFromTimeTracking(
         return { dailyCosts: [], totalCost: 0 };
       }
 
-      // 1. Fetch time punches for the period
-      // ±18h buffer so overnight shifts pair whole; calculateActualLaborCost
-      // attributes hours by clock-in day and drops out-of-window periods.
-      const { fetchStart, fetchEnd } = bufferPunchFetchRange(dateFrom, dateTo);
+      // 1. Fetch time punches for the period.
+      // Look-AHEAD only (not symmetric): calculateActualLaborCost attributes
+      // hours/active-days to every day a shift touches and does NOT drop shifts
+      // whose clock-in precedes dateFrom. A look-back would pull a prior-period
+      // Sunday-night shift into Monday and overstate labor; the look-ahead still
+      // completes an in-range shift whose clock_out lands just after dateTo.
+      const { fetchStart, fetchEnd } = lookaheadPunchFetchRange(dateFrom, dateTo);
       const { data: punches, error: punchesError } = await supabase
         .from('time_punches')
         .select('*')

--- a/src/hooks/useLaborCostsFromTimeTracking.tsx
+++ b/src/hooks/useLaborCostsFromTimeTracking.tsx
@@ -4,6 +4,7 @@ import { useEmployees } from './useEmployees';
 import { TimePunch } from '@/types/timeTracking';
 import { format } from 'date-fns';
 import { calculateActualLaborCost } from '@/services/laborCalculations';
+import { bufferPunchFetchRange } from '@/utils/punchWindow';
 
 export interface LaborCostData {
   date: string;
@@ -81,12 +82,15 @@ export function useLaborCostsFromTimeTracking(
       }
 
       // 1. Fetch time punches for the period
+      // ±18h buffer so overnight shifts pair whole; calculateActualLaborCost
+      // attributes hours by clock-in day and drops out-of-window periods.
+      const { fetchStart, fetchEnd } = bufferPunchFetchRange(dateFrom, dateTo);
       const { data: punches, error: punchesError } = await supabase
         .from('time_punches')
         .select('*')
         .eq('restaurant_id', restaurantId)
-        .gte('punch_time', dateFrom.toISOString())
-        .lte('punch_time', dateTo.toISOString())
+        .gte('punch_time', fetchStart.toISOString())
+        .lte('punch_time', fetchEnd.toISOString())
         .order('punch_time', { ascending: true });
 
       if (punchesError) throw punchesError;

--- a/src/hooks/usePayroll.tsx
+++ b/src/hooks/usePayroll.tsx
@@ -16,6 +16,7 @@ import {
   type TipSplitItem as TipSplitItemForAggregation,
   type EmployeeTip as EmployeeTipForAggregation,
 } from '@/utils/tipAggregation';
+import { bufferPunchFetchRange } from '@/utils/punchWindow';
 
 // Combine tips from tip_split_items and legacy employee_tips (both in cents) into a Map of cents.
 export function aggregateTips(

--- a/src/hooks/usePayroll.tsx
+++ b/src/hooks/usePayroll.tsx
@@ -137,13 +137,16 @@ export function usePayroll(
     queryFn: async (): Promise<PayrollPeriod | null> => {
       if (!restaurantId) return null;
 
-      // Fetch all time punches for the period
+      // Fetch time punches for the period, widened by ±18h so overnight shifts
+      // that straddle the period boundary are paired whole. calculateEmployeePay
+      // then filters periods back to [startDate, endDate] by clock-in day.
+      const { fetchStart, fetchEnd } = bufferPunchFetchRange(startDate, endDate);
       const { data: punches, error: punchesError } = await supabase
         .from('time_punches')
         .select('*')
         .eq('restaurant_id', restaurantId)
-        .gte('punch_time', startDate.toISOString())
-        .lte('punch_time', endDate.toISOString())
+        .gte('punch_time', fetchStart.toISOString())
+        .lte('punch_time', fetchEnd.toISOString())
         .order('punch_time', { ascending: true });
 
       if (punchesError) throw punchesError;

--- a/src/pages/EmployeeTimecard.tsx
+++ b/src/pages/EmployeeTimecard.tsx
@@ -29,51 +29,9 @@ import {
   isSameDay,
   parseISO,
 } from 'date-fns';
+import { bufferPunchFetchRange } from '@/utils/punchWindow';
+import { hoursByClockInDay } from '@/utils/timecardHours';
 import { TimePunch } from '@/types/timeTracking';
-
-// Calculate worked hours for a single day's punches
-const calculateDayHours = (punches: TimePunch[]) => {
-  let totalMinutes = 0;
-  let breakMinutes = 0;
-  let clockInTime: Date | null = null;
-  let breakStartTime: Date | null = null;
-
-  const sortedPunches = [...punches].sort(
-    (a, b) => new Date(a.punch_time).getTime() - new Date(b.punch_time).getTime()
-  );
-
-  for (const punch of sortedPunches) {
-    const punchTime = new Date(punch.punch_time);
-
-    switch (punch.punch_type) {
-      case 'clock_in':
-        clockInTime = punchTime;
-        break;
-      case 'clock_out':
-        if (clockInTime) {
-          totalMinutes += (punchTime.getTime() - clockInTime.getTime()) / (1000 * 60);
-          clockInTime = null;
-        }
-        break;
-      case 'break_start':
-        breakStartTime = punchTime;
-        break;
-      case 'break_end':
-        if (breakStartTime) {
-          breakMinutes += (punchTime.getTime() - breakStartTime.getTime()) / (1000 * 60);
-          breakStartTime = null;
-        }
-        break;
-    }
-  }
-
-  const netMinutes = Math.max(totalMinutes - breakMinutes, 0);
-  return {
-    totalHours: totalMinutes / 60,
-    breakHours: breakMinutes / 60,
-    netHours: netMinutes / 60,
-  };
-};
 
 const formatHoursMinutes = (hours: number) => {
   const h = Math.floor(hours);
@@ -114,13 +72,20 @@ const EmployeeTimecard = () => {
 
   const weekDays = eachDayOfInterval({ start: startDate, end: endDate });
 
+  // Fetch punches widened by ±18h so overnight shifts that straddle the
+  // period boundary are paired whole. hoursByClockInDay then attributes
+  // each shift back to [startDate, endDate] by clock-in day.
+  const { fetchStart, fetchEnd } = bufferPunchFetchRange(startDate, endDate);
   const { punches, loading: punchesLoading } = useTimePunches(
     restaurantId,
     currentEmployee?.id,
-    startDate
+    fetchStart,
+    fetchEnd
   );
 
-  // Filter punches to the current period
+  // Filter punches to the current period (display list only — visual
+  // per-punch timeline). Hours are computed separately from the buffered
+  // `punches` via `dayHours` below so overnight shifts aren't split.
   const periodPunches = useMemo(() => {
     return punches.filter((punch) => {
       const punchDate = new Date(punch.punch_time);
@@ -147,17 +112,20 @@ const EmployeeTimecard = () => {
     return grouped;
   }, [periodPunches, weekDays]);
 
+  // Hours attributed by clock-in day, computed from the BUFFERED punches so
+  // overnight shifts pair whole before being bucketed to their clock-in day.
+  const dayHours = useMemo(() => hoursByClockInDay(punches, weekDays), [punches, weekDays]);
+
   // Calculate weekly totals
   const weeklyTotals = useMemo(() => {
     let totalHours = 0;
     let breakHours = 0;
     let netHours = 0;
 
-    punchesByDay.forEach((dayPunches) => {
-      const dayStats = calculateDayHours(dayPunches);
-      totalHours += dayStats.totalHours;
-      breakHours += dayStats.breakHours;
-      netHours += dayStats.netHours;
+    dayHours.forEach((d) => {
+      totalHours += d.totalHours;
+      breakHours += d.breakHours;
+      netHours += d.netHours;
     });
 
     // Calculate overtime (over 40 hours)
@@ -165,7 +133,7 @@ const EmployeeTimecard = () => {
     const overtimeHours = Math.max(netHours - 40, 0);
 
     return { totalHours, breakHours, netHours, regularHours, overtimeHours };
-  }, [punchesByDay]);
+  }, [dayHours]);
 
   if (!restaurantId) {
     return <NoRestaurantState />;
@@ -278,7 +246,7 @@ const EmployeeTimecard = () => {
               {weekDays.map((day) => {
                 const dayKey = format(day, 'yyyy-MM-dd');
                 const dayPunches = punchesByDay.get(dayKey) || [];
-                const dayStats = calculateDayHours(dayPunches);
+                const dayStats = dayHours.get(dayKey) ?? { totalHours: 0, breakHours: 0, netHours: 0 };
                 const isToday = isSameDay(day, new Date());
 
                 return (

--- a/src/pages/TimePunchesManager.tsx
+++ b/src/pages/TimePunchesManager.tsx
@@ -344,6 +344,13 @@ const TimePunchesManager = () => {
     [processedData.processedPunches, dateRange.start, dateRange.end],
   );
 
+  // Anomaly count for the viewed window only (processedData.totalAnomalies
+  // spans the ±18h buffer and would over-count neighbouring-period noise).
+  const windowAnomalies = useMemo(
+    () => windowSessions.filter((s) => s.has_anomalies).length,
+    [windowSessions],
+  );
+
   // Incomplete sessions (window-filtered)
   const incompleteSessions = useMemo(() => windowSessions.filter(s => !s.is_complete), [windowSessions]);
 
@@ -604,7 +611,7 @@ const TimePunchesManager = () => {
         employeesWithPins={pinLookup.size}
         totalEmployees={employees.length}
         date={getDateRangeLabel()}
-        anomalies={processedData.totalAnomalies}
+        anomalies={windowAnomalies}
         incompleteSessions={incompleteSessions.length}
       />
 

--- a/src/pages/TimePunchesManager.tsx
+++ b/src/pages/TimePunchesManager.tsx
@@ -21,7 +21,7 @@ import {
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { 
   format, startOfWeek, endOfWeek, startOfMonth, endOfMonth, 
-  addDays, addWeeks, addMonths, isSameDay, differenceInMinutes,
+  addDays, addWeeks, addMonths, differenceInMinutes,
   startOfDay, endOfDay
 } from 'date-fns';
 import { WEEK_STARTS_ON } from '@/lib/dateConfig';
@@ -41,6 +41,7 @@ import { Switch } from '@/components/ui/switch';
 import { TimePunch } from '@/types/timeTracking';
 import { cn } from '@/lib/utils';
 import { processPunchesForPeriod } from '@/utils/timePunchProcessing';
+import { bufferPunchFetchRange, isWithinWindow, sessionsWithClockInInWindow } from '@/utils/punchWindow';
 import { useAuth } from '@/hooks/useAuth';
 import { useToast } from '@/hooks/use-toast';
 import { useKioskSession } from '@/hooks/useKioskSession';
@@ -292,11 +293,18 @@ const TimePunchesManager = () => {
   }, [viewMode, currentDate]);
 
   const { employees } = useEmployees(restaurantId);
+  // Widen the fetch by ±18h so overnight shifts that straddle the viewed
+  // window's boundary are paired whole; window-filtered sets below re-narrow
+  // to [dateRange.start, dateRange.end] for display/export/editing.
+  const { fetchStart, fetchEnd } = useMemo(
+    () => bufferPunchFetchRange(dateRange.start, dateRange.end),
+    [dateRange.start, dateRange.end],
+  );
   const { punches, loading } = useTimePunches(
     restaurantId,
     selectedEmployee !== 'all' ? selectedEmployee : undefined,
-    dateRange.start,
-    dateRange.end
+    fetchStart,
+    fetchEnd
   );
   const deletePunch = useDeleteTimePunch();
   const updatePunch = useUpdateTimePunch();
@@ -304,7 +312,7 @@ const TimePunchesManager = () => {
   const [forceSessionToClose, setForceSessionToClose] = useState<any | null>(null);
   const [forceOutTime, setForceOutTime] = useState<string>(() => format(new Date(), "yyyy-MM-dd'T'HH:mm"));
 
-  // Filter punches by search term
+  // Filter punches (buffered) by search term — feeds pairing only.
   const filteredPunches = useMemo(() => {
     return punches.filter((punch) => {
       if (!searchTerm) return true;
@@ -313,27 +321,43 @@ const TimePunchesManager = () => {
     });
   }, [punches, searchTerm]);
 
-  // Process punches
+  // Punches actually inside the viewed window — for tables, export, editor, photos.
+  const windowPunches = useMemo(
+    () => filteredPunches.filter((punch) => isWithinWindow(punch.punch_time, dateRange.start, dateRange.end)),
+    [filteredPunches, dateRange.start, dateRange.end],
+  );
+
+  // Process punches (buffered set, so overnight shifts pair whole)
   const processedData = useMemo(() => {
     return processPunchesForPeriod(filteredPunches);
   }, [filteredPunches]);
 
-  // Incomplete sessions
-  const incompleteSessions = useMemo(() => processedData.sessions.filter(s => !s.is_complete), [processedData.sessions]);
+  // Sessions attributed to the viewed window by clock-in day
+  const windowSessions = useMemo(
+    () => sessionsWithClockInInWindow(processedData.sessions, dateRange.start, dateRange.end),
+    [processedData.sessions, dateRange.start, dateRange.end],
+  );
+
+  // Processed punches attributed to the viewed window
+  const windowProcessedPunches = useMemo(
+    () => processedData.processedPunches.filter((pp) => isWithinWindow(pp.punch_time, dateRange.start, dateRange.end)),
+    [processedData.processedPunches, dateRange.start, dateRange.end],
+  );
+
+  // Incomplete sessions (window-filtered)
+  const incompleteSessions = useMemo(() => windowSessions.filter(s => !s.is_complete), [windowSessions]);
 
   // Filter sessions for current day
   const todaySessions = useMemo(() => {
-    if (viewMode !== 'day') return processedData.sessions;
-    return processedData.sessions.filter(session => 
-      isSameDay(session.clock_in, currentDate)
-    );
-  }, [processedData.sessions, viewMode, currentDate]);
+    if (viewMode !== 'day') return windowSessions;
+    return sessionsWithClockInInWindow(windowSessions, startOfDay(currentDate), endOfDay(currentDate));
+  }, [windowSessions, viewMode, currentDate]);
 
-  // Load photo thumbnails
+  // Load photo thumbnails (window-filtered — only punches actually shown)
   useEffect(() => {
     const loadThumbnails = async () => {
       const now = Date.now();
-      const punchesWithPhotos = punches.filter((punch) => {
+      const punchesWithPhotos = windowPunches.filter((punch) => {
         if (!punch.photo_path) return false;
         const cacheKey = `thumb:${punch.photo_path}`;
         const cached = signedUrlCache[cacheKey];
@@ -378,7 +402,7 @@ const TimePunchesManager = () => {
     };
 
     loadThumbnails();
-  }, [punches]);
+  }, [windowPunches]);
 
   // Fetch photo URL when viewing
   useEffect(() => {
@@ -515,7 +539,7 @@ const TimePunchesManager = () => {
   };
 
   const handleExportCSV = () => {
-    if (filteredPunches.length === 0) {
+    if (windowPunches.length === 0) {
       toast({
         title: 'Nothing to export',
         description: 'No time punches found for the selected period.',
@@ -525,7 +549,7 @@ const TimePunchesManager = () => {
     }
 
     const headers = ['Employee', 'Position', 'Punch Type', 'Date', 'Time', 'Notes', 'Location'];
-    const rows = filteredPunches.map((punch) => {
+    const rows = windowPunches.map((punch) => {
       const punchDate = new Date(punch.punch_time);
       return [
         punch.employee?.name || 'Unknown',
@@ -557,7 +581,7 @@ const TimePunchesManager = () => {
 
     toast({
       title: 'Export complete',
-      description: `Exported ${filteredPunches.length} time punch${filteredPunches.length === 1 ? '' : 'es'}.`,
+      description: `Exported ${windowPunches.length} time punch${windowPunches.length === 1 ? '' : 'es'}.`,
     });
   };
 
@@ -702,7 +726,7 @@ const TimePunchesManager = () => {
                 <ManualTimelineEditor
                   employees={employees}
                   date={currentDate}
-                  existingPunches={filteredPunches}
+                  existingPunches={windowPunches}
                   loading={loading}
                   restaurantId={restaurantId || ''}
                 />
@@ -744,7 +768,7 @@ const TimePunchesManager = () => {
 
         <TabsContent value="stream" className="mt-0">
           <PunchStreamView
-            processedPunches={processedData.processedPunches}
+            processedPunches={windowProcessedPunches}
             loading={loading}
             employeeId={selectedEmployee !== 'all' ? selectedEmployee : undefined}
           />
@@ -779,7 +803,7 @@ const TimePunchesManager = () => {
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2">
                   <TableIcon className="h-5 w-5 text-muted-foreground" />
-                  <CardTitle className="text-base">Punch List ({filteredPunches.length})</CardTitle>
+                  <CardTitle className="text-base">Punch List ({windowPunches.length})</CardTitle>
                 </div>
                 {tableOpen ? <ChevronUp className="h-5 w-5" /> : <ChevronDown className="h-5 w-5" />}
               </div>
@@ -793,11 +817,11 @@ const TimePunchesManager = () => {
                   <Skeleton className="h-16 w-full" />
                   <Skeleton className="h-16 w-full" />
                 </div>
-              ) : filteredPunches.length === 0 ? (
+              ) : windowPunches.length === 0 ? (
                 <p className="text-center text-muted-foreground py-8">No time punches found</p>
               ) : (
                 <div className="space-y-2">
-                  {filteredPunches.map((punch) => (
+                  {windowPunches.map((punch) => (
                     <div
                       key={punch.id}
                       className="flex items-center justify-between p-4 rounded-lg border bg-card hover:bg-muted/30 transition-colors"

--- a/src/pages/Tips.tsx
+++ b/src/pages/Tips.tsx
@@ -33,7 +33,8 @@ import { TipPeriodSummary } from '@/components/tips/TipPeriodSummary';
 import { TipPayoutSheet } from '@/components/tips/TipPayoutSheet';
 import { LockPeriodDialog } from '@/components/tips/LockPeriodDialog';
 import { TipPoolSettingsDialog } from '@/components/tips/TipPoolSettingsDialog';
-import { calculateWorkedHours } from '@/utils/payrollCalculations';
+import { calculateWorkedHoursForClockInDay } from '@/utils/payrollCalculations';
+import { bufferPunchFetchRange } from '@/utils/punchWindow';
 import { Info, Settings, RefreshCw, Clock, DollarSign, Lock } from 'lucide-react';
 import { supabase } from '@/integrations/supabase/client';
 
@@ -103,7 +104,14 @@ export function Tips() {
     deletePool,
     totalContributionPercentage,
   } = useTipContributionPools(restaurantId, settings?.id ?? null);
-  const { punches } = useTimePunches(restaurantId, undefined, todayStart, todayEnd);
+  // Fetch punches for the selected service day, widened by the overnight buffer
+  // so a shift that clocks out after midnight is paired whole. Hours are then
+  // attributed to the clock-in day via calculateWorkedHoursForClockInDay.
+  const { fetchStart: punchFetchStart, fetchEnd: punchFetchEnd } = useMemo(
+    () => bufferPunchFetchRange(todayStart, todayEnd),
+    [todayStart, todayEnd],
+  );
+  const { punches } = useTimePunches(restaurantId, undefined, punchFetchStart, punchFetchEnd);
 
   // Query for Daily Entry mode - single day
   const { saveTipSplit, isSaving, splits: dailySplits } = useTipSplits(restaurantId, today, today);
@@ -274,7 +282,7 @@ export function Tips() {
       const employeePunches = punches.filter(p => p.employee_id === emp.id);
       
       if (employeePunches.length > 0) {
-        const hours = calculateWorkedHours(employeePunches);
+        const hours = calculateWorkedHoursForClockInDay(employeePunches, todayStart, todayEnd);
         const roundedHours = Math.round(hours * 10) / 10; // Round to 1 decimal
         
         calculatedHours[emp.id] = roundedHours.toString();
@@ -652,7 +660,7 @@ export function Tips() {
                     participants.forEach(emp => {
                       const employeePunches = punches?.filter(p => p.employee_id === emp.id) || [];
                       if (employeePunches.length > 0) {
-                        const hours = calculateWorkedHours(employeePunches);
+                        const hours = calculateWorkedHoursForClockInDay(employeePunches, todayStart, todayEnd);
                         const roundedHours = Math.round(hours * 10) / 10;
                         calculatedHours[emp.id] = roundedHours.toString();
                         autoFlags[emp.id] = true;

--- a/src/utils/payrollCalculations.ts
+++ b/src/utils/payrollCalculations.ts
@@ -385,6 +385,28 @@ export function calculateWorkedHoursWithAnomalies(punches: TimePunch[]): {
 }
 
 /**
+ * Worked hours (excluding breaks) for shifts whose CLOCK-IN falls within
+ * [dayStart, dayEnd] — i.e. attributed to the clock-in day, not split at
+ * midnight. Callers pass a ±overnight-buffered punch set (so a shift that
+ * crosses midnight is paired whole) and the day's local bounds; a shift that
+ * started the night before or the next morning is dropped by clock-in
+ * attribution, so it is counted exactly once, on the night it began.
+ *
+ * Used by the Tips "calculate from hours" flow, which is scoped to a single
+ * service day. Mirrors calculateWorkedHours but with clock-in-day windowing.
+ */
+export function calculateWorkedHoursForClockInDay(
+  punches: TimePunch[],
+  dayStart: Date,
+  dayEnd: Date,
+): number {
+  const { periods } = parseWorkPeriods(punches);
+  return periodsInWindow(periods, dayStart, dayEnd)
+    .filter(p => !p.isBreak)
+    .reduce((sum, p) => sum + p.hours, 0);
+}
+
+/**
  * Calculate regular and overtime hours per week
  * Overtime is hours worked beyond 40 in a calendar week at 1.5x rate
  */

--- a/src/utils/payrollCalculations.ts
+++ b/src/utils/payrollCalculations.ts
@@ -12,6 +12,7 @@ import {
   type OvertimeRules as OTRules,
   type OvertimeAdjustment,
 } from '@/lib/overtimeCalculations';
+import { periodsInWindow, incompleteShiftsInWindow } from '@/utils/punchWindow';
 
 // Maximum shift length in hours (shifts longer than this are flagged as incomplete)
 const MAX_SHIFT_HOURS = 16;
@@ -407,7 +408,15 @@ export function calculateEmployeePay(
   manualPayments: ManualPayment[] = [],
   tipsPaidOut: number = 0,
   overtimeRules?: OTRules,
-  overtimeAdjustments: OvertimeAdjustment[] = []
+  overtimeAdjustments: OvertimeAdjustment[] = [],
+  // When true, attribute each shift to its clock-in day and drop periods/
+  // incomplete shifts whose anchor punch falls outside [periodStartDate,
+  // periodEndDate]. ONLY the payroll path (calculatePayrollPeriod) opts in — it
+  // fetches a ±18h buffer so boundary-crossing shifts pair whole first.
+  // calculateActualLaborCostForMonth intentionally leaves this false: it
+  // pre-buckets by ISO week and passes NOON-anchored bounds this filter would
+  // misinterpret.
+  attributeToWindow: boolean = false
 ): EmployeePayroll {
   const compensationType = employee.compensation_type || 'hourly';
 
@@ -428,6 +437,10 @@ export function calculateEmployeePay(
   // Calculate based on compensation type
   if (compensationType === 'hourly') {
     const parsed = parseWorkPeriods(punches);
+    if (attributeToWindow && periodStartDate && periodEndDate) {
+      parsed.periods = periodsInWindow(parsed.periods, periodStartDate, periodEndDate);
+      parsed.incompleteShifts = incompleteShiftsInWindow(parsed.incompleteShifts, periodStartDate, periodEndDate);
+    }
     const hoursByDate = new Map<string, number>();
 
     for (const period of parsed.periods) {
@@ -618,7 +631,7 @@ export function calculatePayrollPeriod(
     const manualPayments = manualPaymentsPerEmployee.get(employee.id) || [];
     const tipsPaidOut = tipPayoutsPerEmployee.get(employee.id) || 0;
     // Pass period dates for salary/contractor calculations
-    return calculateEmployeePay(employee, punches, tips, startDate, endDate, manualPayments, tipsPaidOut, overtimeRules, overtimeAdjustments);
+    return calculateEmployeePay(employee, punches, tips, startDate, endDate, manualPayments, tipsPaidOut, overtimeRules, overtimeAdjustments, true);
   });
 
   const totalRegularHours = employeePayrolls.reduce((sum, ep) => sum + ep.regularHours, 0);

--- a/src/utils/payrollCalculations.ts
+++ b/src/utils/payrollCalculations.ts
@@ -26,6 +26,12 @@ export interface WorkPeriod {
   endTime: Date;
   hours: number;
   isBreak: boolean;
+  // The originating shift's clock-in time. Unlike startTime — which for a
+  // post-break work segment is the break-end (handleBreakEnd advances the
+  // clock-in anchor) — clockIn stays pinned to the shift's first clock_in.
+  // Window attribution filters by this so a break-after-midnight overnight
+  // shift is attributed whole to its clock-in period, never split.
+  clockIn: Date;
 }
 
 export interface IncompleteShift {
@@ -92,6 +98,8 @@ interface ShiftParsingState {
   incompleteShifts: IncompleteShift[];
   currentClockIn: TimePunch | null;
   currentBreakStart: TimePunch | null;
+  // The current shift's original clock-in time, NOT advanced by breaks.
+  shiftClockIn: Date | null;
 }
 
 /**
@@ -125,6 +133,7 @@ function handleClockIn(
     }
   }
   state.currentClockIn = punch;
+  state.shiftClockIn = punchTime; // Pin the shift's clock-in; breaks won't move it
   state.currentBreakStart = null; // Reset break state
 }
 
@@ -163,6 +172,7 @@ function handleClockOut(
         endTime,
         hours,
         isBreak: false,
+        clockIn: state.shiftClockIn ?? startTime,
       });
     } else {
       // Normal valid shift
@@ -171,9 +181,11 @@ function handleClockOut(
         endTime,
         hours,
         isBreak: false,
+        clockIn: state.shiftClockIn ?? startTime,
       });
     }
     state.currentClockIn = null;
+    state.shiftClockIn = null;
     state.currentBreakStart = null;
   } else {
     // Clock out without a clock in - orphan punch
@@ -205,6 +217,7 @@ function handleBreakStart(
         endTime: punchTime,
         hours,
         isBreak: false,
+        clockIn: state.shiftClockIn ?? startTime,
       });
     }
     state.currentBreakStart = punch;
@@ -229,6 +242,7 @@ function handleBreakEnd(
       endTime: punchTime,
       hours: breakHours,
       isBreak: true,
+      clockIn: state.shiftClockIn ?? breakStartTime,
     });
 
     // Update clock_in to after break for next work period calculation
@@ -274,6 +288,7 @@ export function parseWorkPeriods(punches: TimePunch[]): {
     incompleteShifts: [],
     currentClockIn: null,
     currentBreakStart: null,
+    shiftClockIn: null,
   };
 
   for (const punch of dedupedPunches) {

--- a/src/utils/payrollCalculations.ts
+++ b/src/utils/payrollCalculations.ts
@@ -18,7 +18,7 @@ const MAX_SHIFT_HOURS = 16;
 
 // Maximum gap between clock_in and clock_out to be considered a valid shift
 // This prevents pairing Monday's clock_in with Wednesday's clock_out when there's missing punches
-const MAX_SHIFT_GAP_HOURS = 18;
+export const MAX_SHIFT_GAP_HOURS = 18;
 
 export interface WorkPeriod {
   startTime: Date;

--- a/src/utils/punchWindow.ts
+++ b/src/utils/punchWindow.ts
@@ -26,15 +26,40 @@ export function bufferPunchFetchRange(
   };
 }
 
+/**
+ * Look-AHEAD-only variant: widen only the end, keep the start unchanged.
+ *
+ * For consumers whose downstream calc attributes hours/active-days to EVERY day
+ * a shift touches and does NOT drop shifts whose clock-in precedes the window
+ * (e.g. the dashboard's `calculateActualLaborCost`). A symmetric look-back there
+ * would pull a prior-period Sunday-night shift into the first in-range day and
+ * overstate labor (double-counting daily-rate and post-midnight-break hours).
+ * Use the symmetric `bufferPunchFetchRange` only where callers apply a clock-in
+ * attribution filter (payroll, open-sessions) that drops the look-back shifts.
+ */
+export function lookaheadPunchFetchRange(
+  start: Date,
+  end: Date,
+  hours: number = OVERNIGHT_BUFFER_HOURS,
+): { fetchStart: Date; fetchEnd: Date } {
+  return { fetchStart: start, fetchEnd: new Date(end.getTime() + hours * 60 * 60 * 1000) };
+}
+
 /** Inclusive on both boundaries, matching Supabase .gte/.lte semantics. */
 export function isWithinWindow(time: Date | string, start: Date, end: Date): boolean {
   const t = time instanceof Date ? time.getTime() : new Date(time).getTime();
   return t >= start.getTime() && t <= end.getTime();
 }
 
-/** Keep work periods whose clock-in (startTime) is in [start, end]. */
-export function periodsInWindow<T extends { startTime: Date }>(periods: T[], start: Date, end: Date): T[] {
-  return periods.filter((p) => isWithinWindow(p.startTime, start, end));
+/**
+ * Keep work periods whose originating shift clock-in is in [start, end].
+ * Filters by `clockIn` when present (the shift's first clock_in, which stays
+ * fixed across breaks) and falls back to `startTime` otherwise — so a post-break
+ * work segment of an overnight shift is attributed to the shift's clock-in
+ * period, not the period its (break-advanced) startTime happens to land in.
+ */
+export function periodsInWindow<T extends { startTime: Date; clockIn?: Date }>(periods: T[], start: Date, end: Date): T[] {
+  return periods.filter((p) => isWithinWindow(p.clockIn ?? p.startTime, start, end));
 }
 
 /** Keep incomplete shifts whose anchor punch (punchTime) is in [start, end]. */

--- a/src/utils/punchWindow.ts
+++ b/src/utils/punchWindow.ts
@@ -1,0 +1,48 @@
+/**
+ * Overnight-shift fetch windowing helpers.
+ *
+ * Punch fetches must be widened by this buffer so a shift whose clock_in and
+ * clock_out straddle the [start, end] boundary is fetched whole; the pairing
+ * engine then pairs it and callers attribute it to its clock-in day, dropping
+ * shifts whose clock-in falls outside [start, end].
+ *
+ * OVERNIGHT_BUFFER_HOURS MUST stay >= MAX_SHIFT_GAP_HOURS (payrollCalculations)
+ * — the buffer has to be at least as wide as the largest gap the pairing engine
+ * will pair, or a boundary-crossing shift's far punch is never fetched. The
+ * drift guard test in punchWindow.test.ts enforces this.
+ */
+export const OVERNIGHT_BUFFER_HOURS = 18;
+
+/** Expand [start, end] by the overnight buffer on both ends for the DB fetch. */
+export function bufferPunchFetchRange(
+  start: Date,
+  end: Date,
+  hours: number = OVERNIGHT_BUFFER_HOURS,
+): { fetchStart: Date; fetchEnd: Date } {
+  const ms = hours * 60 * 60 * 1000;
+  return {
+    fetchStart: new Date(start.getTime() - ms),
+    fetchEnd: new Date(end.getTime() + ms),
+  };
+}
+
+/** Inclusive on both boundaries, matching Supabase .gte/.lte semantics. */
+export function isWithinWindow(time: Date | string, start: Date, end: Date): boolean {
+  const t = time instanceof Date ? time.getTime() : new Date(time).getTime();
+  return t >= start.getTime() && t <= end.getTime();
+}
+
+/** Keep work periods whose clock-in (startTime) is in [start, end]. */
+export function periodsInWindow<T extends { startTime: Date }>(periods: T[], start: Date, end: Date): T[] {
+  return periods.filter((p) => isWithinWindow(p.startTime, start, end));
+}
+
+/** Keep incomplete shifts whose anchor punch (punchTime) is in [start, end]. */
+export function incompleteShiftsInWindow<T extends { punchTime: Date }>(shifts: T[], start: Date, end: Date): T[] {
+  return shifts.filter((s) => isWithinWindow(s.punchTime, start, end));
+}
+
+/** Keep work sessions whose clock_in is in [start, end]. */
+export function sessionsWithClockInInWindow<T extends { clock_in: Date }>(sessions: T[], start: Date, end: Date): T[] {
+  return sessions.filter((s) => isWithinWindow(s.clock_in, start, end));
+}

--- a/src/utils/timecardHours.ts
+++ b/src/utils/timecardHours.ts
@@ -1,0 +1,34 @@
+import { format } from 'date-fns';
+import { TimePunch } from '@/types/timeTracking';
+import { processPunchesForPeriod } from '@/utils/timePunchProcessing';
+
+export interface DayHours {
+  totalHours: number;
+  breakHours: number;
+  netHours: number;
+}
+
+/**
+ * Pair `punches` into work sessions and bucket each COMPLETE session's hours
+ * into its clock-in LOCAL calendar day. Only days present in `days` are kept.
+ * Pass BUFFERED punches (±18h) so overnight shifts pair whole; attribution by
+ * clock-in day keeps each shift on a single calendar day.
+ */
+export function hoursByClockInDay(punches: TimePunch[], days: Date[]): Map<string, DayHours> {
+  const result = new Map<string, DayHours>();
+  for (const day of days) {
+    result.set(format(day, 'yyyy-MM-dd'), { totalHours: 0, breakHours: 0, netHours: 0 });
+  }
+
+  const { sessions } = processPunchesForPeriod(punches);
+  for (const session of sessions) {
+    if (!session.is_complete) continue; // open shift contributes no hours yet
+    const key = format(new Date(session.clock_in), 'yyyy-MM-dd');
+    const bucket = result.get(key);
+    if (!bucket) continue; // clock-in day outside the displayed range
+    bucket.totalHours += session.total_minutes / 60;
+    bucket.breakHours += session.break_minutes / 60;
+    bucket.netHours += session.worked_minutes / 60;
+  }
+  return result;
+}

--- a/supabase/functions/_shared/laborCalculations.ts
+++ b/supabase/functions/_shared/laborCalculations.ts
@@ -12,6 +12,16 @@
  * - supabase/functions/_shared/recipeAnalytics.ts
  */
 
+/**
+ * Hours past endDate to widen a time_punches fetch so a shift whose clock_out
+ * lands just after the window end still pairs into a complete period.
+ * calculateActualLaborCost / calculateHoursPerEmployee already drop periods
+ * whose clock-in is outside [startDate, endDate], so this look-ahead never
+ * double-counts a shift that started before the window.
+ * MUST stay in parity with src/utils/punchWindow.ts OVERNIGHT_BUFFER_HOURS.
+ */
+export const LABOR_FETCH_LOOKAHEAD_HOURS = 18;
+
 // ============================================================================
 // Type Definitions
 // ============================================================================

--- a/supabase/functions/ai-execute-tool/index.ts
+++ b/supabase/functions/ai-execute-tool/index.ts
@@ -224,15 +224,18 @@ async function executeGetKpis(
 
   // Fetch labor costs using time_punches + employees (same as Dashboard)
   // Import labor calculation module
-  const { calculateActualLaborCost } = await import('../_shared/laborCalculations.ts');
+  const { calculateActualLaborCost, LABOR_FETCH_LOOKAHEAD_HOURS } = await import('../_shared/laborCalculations.ts');
 
-  // Fetch time punches for the period
+  // Fetch time punches for the period, widened by an overnight look-ahead so a
+  // shift whose clock_out lands just after endDate still pairs whole.
+  // calculateActualLaborCost attributes hours by clock-in day and drops
+  // out-of-window periods, so this never double-counts.
   const { data: timePunches, error: punchesError } = await supabase
     .from('time_punches')
     .select('id, employee_id, restaurant_id, punch_time, punch_type')
     .eq('restaurant_id', restaurantId)
     .gte('punch_time', startDate.toISOString())
-    .lte('punch_time', endDate.toISOString())
+    .lte('punch_time', new Date(endDate.getTime() + LABOR_FETCH_LOOKAHEAD_HOURS * 3600 * 1000).toISOString())
     .order('punch_time', { ascending: true });
 
   if (punchesError) {
@@ -2233,17 +2236,19 @@ async function executeGetPayrollSummary(
   supabase: any
 ): Promise<any> {
   const { period, start_date, end_date, include_employee_details = true } = args;
-  const { calculateActualLaborCost } = await import('../_shared/laborCalculations.ts');
+  const { calculateActualLaborCost, LABOR_FETCH_LOOKAHEAD_HOURS } = await import('../_shared/laborCalculations.ts');
   const { startDate, endDate, startDateStr, endDateStr } = calculateDateRange(period, start_date, end_date);
 
-  // Fetch all required data in parallel
+  // Fetch all required data in parallel. time_punches upper bound is widened by
+  // an overnight look-ahead so a shift crossing endDate still pairs whole;
+  // calculateActualLaborCost drops periods whose clock-in is out of window.
   const [punchesResult, employeesResult, tipsResult, manualResult] = await Promise.all([
     supabase
       .from('time_punches')
       .select('*')
       .eq('restaurant_id', restaurantId)
       .gte('punch_time', startDate.toISOString())
-      .lte('punch_time', endDate.toISOString())
+      .lte('punch_time', new Date(endDate.getTime() + LABOR_FETCH_LOOKAHEAD_HOURS * 3600 * 1000).toISOString())
       .order('punch_time', { ascending: true }),
     supabase
       .from('employees')

--- a/tests/e2e/overnight-shift-hours.spec.ts
+++ b/tests/e2e/overnight-shift-hours.spec.ts
@@ -1,0 +1,195 @@
+import { test, expect } from '@playwright/test';
+import { randomUUID } from 'crypto';
+import { signUpAndCreateRestaurant, generateTestUser, exposeSupabaseHelpers } from '../helpers/e2e-supabase';
+
+/**
+ * E2E validation for the overnight-shift punch-windowing fix.
+ *
+ * Seeds a single hourly employee with ONE overnight shift — clock in the
+ * evening of day D, clock out early morning of D+1 (crosses midnight). Before
+ * the fix, the per-period/per-day punch fetch split the pair, so Payroll and
+ * the Tips "calculate from hours" flow reported ZERO hours and a false
+ * "Incomplete Time Punches / no matching clock-in" warning. After the fix
+ * (±18h buffered fetch + clock-in-day attribution) the whole shift is counted
+ * once, on the night it began.
+ */
+
+const formatDate = (date: Date) => {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+};
+const parseCurrency = (value: string) => Number(value.replace(/[^0-9.-]/g, ''));
+
+test.describe('Overnight shift hours (punch windowing fix)', () => {
+  test('Payroll counts a cross-midnight shift on its clock-in day with no false warning', async ({ page }) => {
+    const user = generateTestUser();
+    await signUpAndCreateRestaurant(page, user);
+    await exposeSupabaseHelpers(page);
+
+    const restaurantId = await page.evaluate(async () => {
+      const fn = (window as any).__getRestaurantId;
+      return fn ? await fn() : null;
+    });
+    expect(restaurantId).toBeTruthy();
+
+    // Shift 3 days ago so it's safely in the past and away from "today near midnight".
+    const shiftDay = new Date();
+    shiftDay.setDate(shiftDay.getDate() - 3);
+    const shiftDayMidnight = new Date(shiftDay.getFullYear(), shiftDay.getMonth(), shiftDay.getDate());
+
+    // Clock in 8:00 PM, clock out 1:00 AM next day → 5.0 worked hours, crossing midnight.
+    const clockIn = new Date(shiftDayMidnight);
+    clockIn.setHours(20, 0, 0, 0);
+    const clockOut = new Date(shiftDayMidnight);
+    clockOut.setDate(clockOut.getDate() + 1);
+    clockOut.setHours(1, 0, 0, 0);
+
+    const hourlyId = randomUUID();
+    const hourlyRateCents = 2000; // $20/hr
+    const workedHours = 5;
+    const expectedGross = (hourlyRateCents / 100) * workedHours; // $100
+    const hireDateStr = formatDate(new Date(shiftDayMidnight.getFullYear(), shiftDayMidnight.getMonth(), 1));
+
+    await page.evaluate(
+      async ({ restaurantId, hourlyId, hourlyRateCents, hireDateStr, clockIn, clockOut }) => {
+        const insertEmployees = (window as any).__insertEmployees;
+        const insertTimePunches = (window as any).__insertTimePunches;
+        if (!insertEmployees || !insertTimePunches) throw new Error('Supabase helpers not available');
+
+        await insertEmployees(
+          [
+            {
+              id: hourlyId,
+              name: 'Overnight Closer',
+              position: 'Server',
+              compensation_type: 'hourly',
+              hourly_rate: hourlyRateCents,
+              status: 'active',
+              is_active: true,
+              tip_eligible: true,
+              requires_time_punch: true,
+              hire_date: hireDateStr,
+            },
+          ],
+          restaurantId
+        );
+
+        await insertTimePunches(
+          [
+            { employee_id: hourlyId, punch_type: 'clock_in', punch_time: clockIn },
+            { employee_id: hourlyId, punch_type: 'clock_out', punch_time: clockOut },
+          ],
+          restaurantId
+        );
+      },
+      {
+        restaurantId,
+        hourlyId,
+        hourlyRateCents,
+        hireDateStr,
+        clockIn: clockIn.toISOString(),
+        clockOut: clockOut.toISOString(),
+      }
+    );
+
+    await page.goto('/payroll');
+    await expect(page.getByRole('heading', { name: 'Payroll', exact: true })).toBeVisible({ timeout: 20000 });
+    await expect(page.getByText('Employee Payroll Details')).toBeVisible({ timeout: 15000 });
+
+    // Custom range = exactly the clock-in DAY. Before the fix this window excluded
+    // the next-day clock-out, so the shift computed 0h; after the fix the buffered
+    // fetch pairs it and attributes the full 5h to this day.
+    const payPeriodSelect = page.locator('button[role="combobox"]').nth(1);
+    await expect(payPeriodSelect).toBeEnabled();
+    await payPeriodSelect.click();
+    await page.waitForTimeout(300);
+    await page.locator('[role="option"]').filter({ hasText: 'Custom Range' }).click();
+
+    const dateInputs = page.locator('input[type="date"]');
+    await expect(dateInputs.first()).toBeVisible({ timeout: 5000 });
+    await dateInputs.first().fill(formatDate(shiftDayMidnight));
+    await dateInputs.nth(1).fill(formatDate(shiftDayMidnight));
+    await page.waitForTimeout(2000);
+
+    // The false "no matching clock-in" / incomplete banner must NOT appear.
+    await expect(page.getByText('Incomplete Time Punches Detected')).toHaveCount(0);
+
+    // Gross Wages must reflect the full 5h (≈ $100), not $0.
+    const grossWagesCard = page
+      .getByText('Gross Wages')
+      .locator('xpath=ancestor::div[contains(@class,"rounded-lg")][1]');
+    const grossWagesText = await grossWagesCard.locator('.text-2xl').first().innerText();
+    const gross = parseCurrency(grossWagesText);
+    expect(gross).toBeGreaterThan(0);
+    expect(gross).toBeCloseTo(expectedGross, 0);
+  });
+
+  test('Tips "calculate from hours" counts a cross-midnight shift instead of zero', async ({ page }) => {
+    const user = generateTestUser();
+    await signUpAndCreateRestaurant(page, user);
+    await exposeSupabaseHelpers(page);
+
+    const restaurantId = await page.evaluate(async () => {
+      const fn = (window as any).__getRestaurantId;
+      return fn ? await fn() : null;
+    });
+    expect(restaurantId).toBeTruthy();
+
+    // Overnight shift on TODAY (the Tips daily-entry default date): clock in
+    // 8:00 PM today, clock out 1:00 AM tomorrow → 5.0 worked hours across midnight.
+    const now = new Date();
+    const todayMidnight = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const clockIn = new Date(todayMidnight);
+    clockIn.setHours(20, 0, 0, 0);
+    const clockOut = new Date(todayMidnight);
+    clockOut.setDate(clockOut.getDate() + 1);
+    clockOut.setHours(1, 0, 0, 0);
+
+    const empId = randomUUID();
+    const hireDateStr = formatDate(new Date(todayMidnight.getFullYear(), todayMidnight.getMonth(), 1));
+
+    await page.evaluate(
+      async ({ restaurantId, empId, hireDateStr, clockIn, clockOut }) => {
+        const insertEmployees = (window as any).__insertEmployees;
+        const insertTimePunches = (window as any).__insertTimePunches;
+        if (!insertEmployees || !insertTimePunches) throw new Error('Supabase helpers not available');
+        await insertEmployees(
+          [{
+            id: empId, name: 'Nova Overnight', position: 'Server',
+            compensation_type: 'hourly', hourly_rate: 1500,
+            status: 'active', is_active: true, tip_eligible: true,
+            requires_time_punch: true, hire_date: hireDateStr,
+          }],
+          restaurantId
+        );
+        await insertTimePunches(
+          [
+            { employee_id: empId, punch_type: 'clock_in', punch_time: clockIn },
+            { employee_id: empId, punch_type: 'clock_out', punch_time: clockOut },
+          ],
+          restaurantId
+        );
+      },
+      { restaurantId, empId, hireDateStr, clockIn: clockIn.toISOString(), clockOut: clockOut.toISOString() }
+    );
+
+    // Tips → Daily Entry → enter a tip pool → review (where hours-from-punches show).
+    await page.goto('/tips');
+    await page.getByRole('heading', { name: /^tips$/i }).first().waitFor({ state: 'visible', timeout: 25000 });
+    await page.getByRole('button', { name: /daily entry/i }).click();
+    await page.getByRole('button', { name: /enter.*tips/i }).first().click();
+    await page.locator('#tip-amount').fill('100');
+    await page.getByRole('button', { name: /continue/i }).click();
+
+    // Force hours to (re)derive from punches, then assert the overnight shift is
+    // counted (~5h), not zero as the old single-day fetch produced.
+    await expect(page.getByRole('button', { name: /recalculate from punches/i })).toBeVisible({ timeout: 15000 });
+    await page.getByRole('button', { name: /recalculate from punches/i }).click();
+
+    const hoursInput = page.getByRole('spinbutton', { name: /Nova Overnight/i });
+    await expect(hoursInput).toBeVisible({ timeout: 5000 });
+    await expect(hoursInput).toHaveValue('5');
+  });
+});

--- a/tests/unit/EmployeeTimecard.test.tsx
+++ b/tests/unit/EmployeeTimecard.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Behavioral tests for src/pages/EmployeeTimecard.tsx
+ *
+ * Design spec: docs/superpowers/specs/2026-07-09-overnight-shift-punch-windowing-design.md (§4)
+ * Plan: docs/superpowers/plans/2026-07-09-overnight-shift-punch-windowing.md (Task 4, Step 5)
+ *
+ * Pins the overnight-shift windowing fix at the component level:
+ *   - `useTimePunches` is called with a BUFFERED range (bufferPunchFetchRange),
+ *     not the raw startDate/endDate, and now includes an endDate bound.
+ *   - The "Net Hours" summary (weeklyTotals, sourced from hoursByClockInDay)
+ *     attributes an overnight shift's hours ENTIRELY to its clock-in day, even
+ *     though the clock-out punch is only present because of the buffer.
+ *   - The per-day card for the clock-in day shows the full shift hours; the
+ *     next day's card shows none of it (no double count, no split).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import EmployeeTimecard from '@/pages/EmployeeTimecard';
+import { bufferPunchFetchRange } from '@/utils/punchWindow';
+import type { TimePunch } from '@/types/timeTracking';
+
+const { useTimePunchesMock, useCurrentEmployeeMock, usePeriodNavigationMock } = vi.hoisted(() => ({
+  useTimePunchesMock: vi.fn(),
+  useCurrentEmployeeMock: vi.fn(),
+  usePeriodNavigationMock: vi.fn(),
+}));
+
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => ({
+    selectedRestaurant: { restaurant_id: 'r1', restaurant: { name: 'Test Cafe' } },
+  }),
+}));
+
+vi.mock('@/hooks/useCurrentEmployee', () => ({
+  useCurrentEmployee: (...args: unknown[]) => useCurrentEmployeeMock(...args),
+}));
+
+vi.mock('@/hooks/useTimePunches', () => ({
+  useTimePunches: (...args: unknown[]) => useTimePunchesMock(...args),
+}));
+
+vi.mock('@/hooks/usePeriodNavigation', () => ({
+  usePeriodNavigation: (...args: unknown[]) => usePeriodNavigationMock(...args),
+}));
+
+// Mon 2026-07-06 .. Sun 2026-07-12 (matches WEEK_STARTS_ON = Mon)
+const startDate = new Date(2026, 6, 6, 0, 0, 0, 0);
+const endDate = new Date(2026, 6, 12, 23, 59, 59, 999);
+
+const punch = (id: string, type: TimePunch['punch_type'], date: Date): TimePunch =>
+  ({
+    id,
+    employee_id: 'e1',
+    restaurant_id: 'r1',
+    punch_type: type,
+    punch_time: date.toISOString(),
+  }) as TimePunch;
+
+describe('EmployeeTimecard overnight windowing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useCurrentEmployeeMock.mockReturnValue({
+      currentEmployee: { id: 'e1', name: 'Night Owl', position: 'Cook' },
+      loading: false,
+    });
+    usePeriodNavigationMock.mockReturnValue({
+      periodType: 'current_week',
+      setPeriodType: vi.fn(),
+      startDate,
+      endDate,
+      handlePreviousWeek: vi.fn(),
+      handleNextWeek: vi.fn(),
+      handleToday: vi.fn(),
+    });
+  });
+
+  it('fetches time punches with the ±18h buffered range, not the raw period', () => {
+    useTimePunchesMock.mockReturnValue({ punches: [], loading: false });
+
+    render(<EmployeeTimecard />);
+
+    expect(useTimePunchesMock).toHaveBeenCalledTimes(1);
+    const [restaurantId, employeeId, fetchStartArg, fetchEndArg] = useTimePunchesMock.mock.calls[0];
+    const { fetchStart, fetchEnd } = bufferPunchFetchRange(startDate, endDate);
+
+    expect(restaurantId).toBe('r1');
+    expect(employeeId).toBe('e1');
+    expect((fetchStartArg as Date).getTime()).toBe(fetchStart.getTime());
+    expect((fetchEndArg as Date).getTime()).toBe(fetchEnd.getTime());
+  });
+
+  it('attributes an overnight shift entirely to the clock-in day (no drop, no split)', () => {
+    // Sat 2026-07-11 23:00 -> Sun 2026-07-12 07:00 (8h). The clock-out punch is
+    // only fetched because of the look-ahead buffer past `endDate`.
+    const clockIn = new Date(2026, 6, 11, 23, 0, 0, 0);
+    const clockOut = new Date(2026, 6, 12, 7, 0, 0, 0);
+    useTimePunchesMock.mockReturnValue({
+      punches: [punch('in', 'clock_in', clockIn), punch('out', 'clock_out', clockOut)],
+      loading: false,
+    });
+
+    render(<EmployeeTimecard />);
+
+    // Weekly Net Hours summary reflects the full 8h shift exactly once.
+    expect(screen.getAllByText('8h 0m').length).toBeGreaterThan(0);
+
+    // Saturday's day card shows the full 8h; Sunday's shows none.
+    const satHeading = screen.getByText('Jul 11');
+    const satCard = satHeading.closest('div.p-4');
+    expect(satCard).not.toBeNull();
+    expect(satCard!.textContent).toContain('8h 0m');
+
+    const sunHeading = screen.getByText('Jul 12');
+    const sunCard = sunHeading.closest('div.p-4');
+    expect(sunCard).not.toBeNull();
+    expect(sunCard!.textContent).toContain('0h 0m');
+  });
+});

--- a/tests/unit/payrollCalculations.test.ts
+++ b/tests/unit/payrollCalculations.test.ts
@@ -941,4 +941,25 @@ describe('calculateEmployeePay overnight window attribution', () => {
     expect(pay.regularHours).toBeCloseTo(40, 5);
     expect(pay.overtimeHours).toBeCloseTo(2, 5);
   });
+
+  it('keeps a break-after-midnight overnight shift whole in the clock-in week (Codex P1)', () => {
+    // Sun 20:00 clock-in, break 00:30-01:00 Mon, clock-out 02:00 Mon → 5.5h worked.
+    // handleBreakEnd advances the clock-in anchor, so the post-break work segment
+    // starts Mon 01:00; without clock-in attribution it would be dropped from the
+    // Sunday week and re-counted in the Monday week (split pay/OT).
+    const punches = [
+      punch('clock_in', '2026-07-12T20:00:00'),    // Sun (last day of Mon-Sun week)
+      punch('break_start', '2026-07-13T00:30:00'),  // Mon 00:30
+      punch('break_end', '2026-07-13T01:00:00'),    // Mon 01:00
+      punch('clock_out', '2026-07-13T02:00:00'),    // Mon 02:00
+    ];
+    // Whole shift (5.5h) attributed to the Sunday-containing week.
+    const payA = calculateEmployeePay(employee, punches, 0, weekStart, weekEnd, [], 0, undefined, [], true);
+    expect(payA.regularHours + payA.overtimeHours).toBeCloseTo(5.5, 5);
+    // The following week must not re-count any of it (no double-count).
+    const nextStart = new Date('2026-07-13T00:00:00');
+    const nextEnd = new Date('2026-07-19T23:59:59.999');
+    const payB = calculateEmployeePay(employee, punches, 0, nextStart, nextEnd, [], 0, undefined, [], true);
+    expect(payB.regularHours + payB.overtimeHours).toBeCloseTo(0, 5);
+  });
 });

--- a/tests/unit/payrollCalculations.test.ts
+++ b/tests/unit/payrollCalculations.test.ts
@@ -898,7 +898,7 @@ describe('calculateEmployeePay overnight window attribution', () => {
       punch('clock_in', '2026-07-12T20:00:00'),  // Sun 8pm (in window)
       punch('clock_out', '2026-07-13T02:00:00'),  // Mon 2am (lookahead)
     ];
-    const pay = calculateEmployeePay(employee, punches, 0, weekStart, weekEnd);
+    const pay = calculateEmployeePay(employee, punches, 0, weekStart, weekEnd, [], 0, undefined, [], true);
     expect(pay.regularHours + pay.overtimeHours).toBeCloseTo(6, 5);
     expect(pay.incompleteShifts ?? []).toHaveLength(0);
   });
@@ -911,7 +911,7 @@ describe('calculateEmployeePay overnight window attribution', () => {
       punch('clock_in', '2026-07-12T20:00:00'),  // before nextStart → drop
       punch('clock_out', '2026-07-13T02:00:00'),  // in next window, but clock-in owns it
     ];
-    const pay = calculateEmployeePay(employee, punches, 0, nextStart, nextEnd);
+    const pay = calculateEmployeePay(employee, punches, 0, nextStart, nextEnd, [], 0, undefined, [], true);
     expect(pay.regularHours + pay.overtimeHours).toBeCloseTo(0, 5);
     // The paired clock-in suppresses the "no matching clock-in" warning:
     expect(pay.incompleteShifts ?? []).toHaveLength(0);
@@ -919,7 +919,7 @@ describe('calculateEmployeePay overnight window attribution', () => {
 
   it('still flags a genuine missing clock-out when the clock-in is in-window', () => {
     const punches = [punch('clock_in', '2026-07-08T09:00:00')]; // Wed, never clocked out
-    const pay = calculateEmployeePay(employee, punches, 0, weekStart, weekEnd);
+    const pay = calculateEmployeePay(employee, punches, 0, weekStart, weekEnd, [], 0, undefined, [], true);
     expect(pay.incompleteShifts?.some((s) => s.type === 'missing_clock_out')).toBe(true);
   });
 
@@ -937,7 +937,7 @@ describe('calculateEmployeePay overnight window attribution', () => {
       punch('clock_in', '2026-07-05T08:00:00'), // Sun of prior week → drop
       punch('clock_out', '2026-07-05T15:00:00'),
     ];
-    const pay = calculateEmployeePay(employee, [...neighbour, ...inWindow], 0, weekStart, weekEnd);
+    const pay = calculateEmployeePay(employee, [...neighbour, ...inWindow], 0, weekStart, weekEnd, [], 0, undefined, [], true);
     expect(pay.regularHours).toBeCloseTo(40, 5);
     expect(pay.overtimeHours).toBeCloseTo(2, 5);
   });

--- a/tests/unit/payrollCalculations.test.ts
+++ b/tests/unit/payrollCalculations.test.ts
@@ -876,3 +876,69 @@ describe('payrollCalculations - Additional Coverage', () => {
     });
   });
 });
+
+describe('calculateEmployeePay overnight window attribution', () => {
+  const employee = {
+    id: 'e1', name: 'Night Owl', position: 'Cook', area: null,
+    compensation_type: 'hourly', hourly_rate: 1500, is_active: true,
+  } as unknown as Employee;
+
+  // Payroll week Mon 2026-07-06 .. Sun 2026-07-12 (WEEK_STARTS_ON = Mon)
+  const weekStart = new Date('2026-07-06T00:00:00');
+  const weekEnd = new Date('2026-07-12T23:59:59.999');
+
+  const punch = (type: string, iso: string) => ({
+    id: `${type}-${iso}`, employee_id: 'e1', restaurant_id: 'r1',
+    punch_type: type, punch_time: iso,
+  }) as unknown as TimePunch;
+
+  it('counts a Sun->Mon overnight shift once, attributed to the Sunday week', () => {
+    // Buffered fetch for the Sun-ending week would include Mon 02:00 clock_out.
+    const punches = [
+      punch('clock_in', '2026-07-12T20:00:00'),  // Sun 8pm (in window)
+      punch('clock_out', '2026-07-13T02:00:00'),  // Mon 2am (lookahead)
+    ];
+    const pay = calculateEmployeePay(employee, punches, 0, weekStart, weekEnd);
+    expect(pay.regularHours + pay.overtimeHours).toBeCloseTo(6, 5);
+    expect(pay.incompleteShifts ?? []).toHaveLength(0);
+  });
+
+  it('does NOT double-count the same shift in the following week, no false orphan', () => {
+    const nextStart = new Date('2026-07-13T00:00:00'); // Mon
+    const nextEnd = new Date('2026-07-19T23:59:59.999');
+    // Buffered fetch for the next week includes the Sun 20:00 clock_in (lookback).
+    const punches = [
+      punch('clock_in', '2026-07-12T20:00:00'),  // before nextStart → drop
+      punch('clock_out', '2026-07-13T02:00:00'),  // in next window, but clock-in owns it
+    ];
+    const pay = calculateEmployeePay(employee, punches, 0, nextStart, nextEnd);
+    expect(pay.regularHours + pay.overtimeHours).toBeCloseTo(0, 5);
+    // The paired clock-in suppresses the "no matching clock-in" warning:
+    expect(pay.incompleteShifts ?? []).toHaveLength(0);
+  });
+
+  it('still flags a genuine missing clock-out when the clock-in is in-window', () => {
+    const punches = [punch('clock_in', '2026-07-08T09:00:00')]; // Wed, never clocked out
+    const pay = calculateEmployeePay(employee, punches, 0, weekStart, weekEnd);
+    expect(pay.incompleteShifts?.some((s) => s.type === 'missing_clock_out')).toBe(true);
+  });
+
+  it('OT/tip base rate ignores a buffered out-of-window neighbour shift', () => {
+    // 42h in-window (Mon-Sat 7h each) → 40 reg + 2 OT; plus an out-of-window
+    // Sunday-of-PRIOR-week shift present in the buffered input must not shift OT.
+    const inWindow = [
+      ['2026-07-06', '2026-07-07'], ['2026-07-07', '2026-07-08'],
+      ['2026-07-08', '2026-07-09'], ['2026-07-09', '2026-07-10'],
+      ['2026-07-10', '2026-07-11'], ['2026-07-11', '2026-07-12'],
+    ].flatMap(([d]) => [
+      punch('clock_in', `${d}T08:00:00`), punch('clock_out', `${d}T15:00:00`),
+    ]);
+    const neighbour = [
+      punch('clock_in', '2026-07-05T08:00:00'), // Sun of prior week → drop
+      punch('clock_out', '2026-07-05T15:00:00'),
+    ];
+    const pay = calculateEmployeePay(employee, [...neighbour, ...inWindow], 0, weekStart, weekEnd);
+    expect(pay.regularHours).toBeCloseTo(40, 5);
+    expect(pay.overtimeHours).toBeCloseTo(2, 5);
+  });
+});

--- a/tests/unit/payrollCalculations.test.ts
+++ b/tests/unit/payrollCalculations.test.ts
@@ -8,6 +8,7 @@ import {
   calculatePayrollPeriod,
   exportPayrollToCSV,
   escapeCsvCell,
+  MAX_SHIFT_GAP_HOURS,
   type ManualPayment,
   type WorkPeriod,
 } from '@/utils/payrollCalculations';
@@ -866,6 +867,12 @@ describe('payrollCalculations - Additional Coverage', () => {
 
       expect(breakPeriods.length).toBe(2);
       expect(workPeriods.length).toBe(3); // Before first break, between breaks, after second break
+    });
+  });
+
+  describe('MAX_SHIFT_GAP_HOURS', () => {
+    it('is exported as a public constant equal to 18', () => {
+      expect(MAX_SHIFT_GAP_HOURS).toBe(18);
     });
   });
 });

--- a/tests/unit/punchWindow.test.ts
+++ b/tests/unit/punchWindow.test.ts
@@ -1,7 +1,10 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
 import { describe, it, expect } from 'vitest';
 import {
   OVERNIGHT_BUFFER_HOURS,
   bufferPunchFetchRange,
+  lookaheadPunchFetchRange,
   isWithinWindow,
   periodsInWindow,
   incompleteShiftsInWindow,
@@ -21,6 +24,36 @@ describe('punchWindow', () => {
     const { fetchStart, fetchEnd } = bufferPunchFetchRange(start, end);
     expect(start.getTime() - fetchStart.getTime()).toBe(18 * 3600 * 1000);
     expect(fetchEnd.getTime() - end.getTime()).toBe(18 * 3600 * 1000);
+  });
+
+  it('lookaheadPunchFetchRange widens only the end, keeps the start', () => {
+    const { fetchStart, fetchEnd } = lookaheadPunchFetchRange(start, end);
+    expect(fetchStart.getTime()).toBe(start.getTime()); // NO look-back
+    expect(fetchEnd.getTime() - end.getTime()).toBe(18 * 3600 * 1000);
+  });
+
+  it('periodsInWindow filters by clockIn when present (falls back to startTime)', () => {
+    // A post-break work segment whose startTime is out-of-window but whose
+    // shift clockIn is in-window must be KEPT (attributed to the clock-in period).
+    const periods = [
+      { startTime: new Date('2026-07-13T01:00:00Z'), clockIn: new Date('2026-07-12T20:00:00Z') }, // keep
+      { startTime: new Date('2026-07-07T09:00:00Z'), clockIn: new Date('2026-07-13T01:00:00Z') }, // drop
+    ];
+    const kept = periodsInWindow(periods, start, end);
+    expect(kept).toHaveLength(1);
+    expect(kept[0].clockIn.toISOString()).toBe('2026-07-12T20:00:00.000Z');
+  });
+
+  it('Deno LABOR_FETCH_LOOKAHEAD_HOURS stays in parity with OVERNIGHT_BUFFER_HOURS', () => {
+    // The Deno edge module can't import the TS client constant, so guard the
+    // two independent literals against silent drift.
+    const denoSrc = readFileSync(
+      resolve(process.cwd(), 'supabase/functions/_shared/laborCalculations.ts'),
+      'utf8',
+    );
+    const m = denoSrc.match(/LABOR_FETCH_LOOKAHEAD_HOURS\s*=\s*(\d+)/);
+    expect(m, 'LABOR_FETCH_LOOKAHEAD_HOURS declaration not found').not.toBeNull();
+    expect(Number(m![1])).toBe(OVERNIGHT_BUFFER_HOURS);
   });
 
   it('isWithinWindow is inclusive on both boundaries', () => {

--- a/tests/unit/punchWindow.test.ts
+++ b/tests/unit/punchWindow.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import {
+  OVERNIGHT_BUFFER_HOURS,
+  bufferPunchFetchRange,
+  isWithinWindow,
+  periodsInWindow,
+  incompleteShiftsInWindow,
+  sessionsWithClockInInWindow,
+} from '@/utils/punchWindow';
+import { MAX_SHIFT_GAP_HOURS } from '@/utils/payrollCalculations';
+
+const start = new Date('2026-07-06T00:00:00Z'); // Mon
+const end = new Date('2026-07-12T23:59:59.999Z'); // Sun
+
+describe('punchWindow', () => {
+  it('buffer constant never drifts below the pairing gap cap', () => {
+    expect(OVERNIGHT_BUFFER_HOURS).toBeGreaterThanOrEqual(MAX_SHIFT_GAP_HOURS);
+  });
+
+  it('bufferPunchFetchRange widens by ±18h in epoch ms', () => {
+    const { fetchStart, fetchEnd } = bufferPunchFetchRange(start, end);
+    expect(start.getTime() - fetchStart.getTime()).toBe(18 * 3600 * 1000);
+    expect(fetchEnd.getTime() - end.getTime()).toBe(18 * 3600 * 1000);
+  });
+
+  it('isWithinWindow is inclusive on both boundaries', () => {
+    expect(isWithinWindow(start, start, end)).toBe(true);
+    expect(isWithinWindow(end, start, end)).toBe(true);
+    expect(isWithinWindow(new Date(start.getTime() - 1), start, end)).toBe(false);
+    expect(isWithinWindow(new Date(end.getTime() + 1), start, end)).toBe(false);
+  });
+
+  it('periodsInWindow keeps by startTime, drops out-of-window', () => {
+    const periods = [
+      { startTime: new Date('2026-07-05T20:00:00Z') }, // before start → drop
+      { startTime: new Date('2026-07-07T09:00:00Z') }, // in → keep
+      { startTime: new Date('2026-07-13T01:00:00Z') }, // after end → drop
+    ];
+    expect(periodsInWindow(periods, start, end)).toHaveLength(1);
+  });
+
+  it('incompleteShiftsInWindow keeps by punchTime', () => {
+    const shifts = [
+      { punchTime: new Date('2026-07-05T23:00:00Z') }, // drop
+      { punchTime: new Date('2026-07-08T02:00:00Z') }, // keep
+    ];
+    expect(incompleteShiftsInWindow(shifts, start, end)).toHaveLength(1);
+  });
+
+  it('sessionsWithClockInInWindow keeps by clock_in', () => {
+    const sessions = [
+      { clock_in: new Date('2026-07-07T18:00:00Z') }, // keep
+      { clock_in: new Date('2026-07-13T00:30:00Z') }, // drop (next period)
+    ];
+    expect(sessionsWithClockInInWindow(sessions, start, end)).toHaveLength(1);
+  });
+});

--- a/tests/unit/timePunchProcessing.test.ts
+++ b/tests/unit/timePunchProcessing.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { processPunchesForPeriod } from '@/utils/timePunchProcessing';
+import { sessionsWithClockInInWindow } from '@/utils/punchWindow';
 import type { TimePunch } from '@/types/timeTracking';
 
 const mk = (
@@ -171,5 +172,25 @@ describe('identifyWorkSessions — does not skip the next clock-in', () => {
     const { sessions } = processPunchesForPeriod(punches);
     expect(sessions).toHaveLength(2);
     expect(sessions.filter((s) => s.is_complete)).toHaveLength(2);
+  });
+});
+
+describe('open-session windowing (buffered pairing)', () => {
+  it('a clock-out just after the day end makes the session complete, not open', () => {
+    const dayStart = new Date('2026-07-04T00:00:00');
+    const dayEnd = new Date('2026-07-04T23:59:59.999');
+    // Buffered fetch would include the Jul-5 00:06 clock-out.
+    const punches = [
+      mk('in', 'empA', 'clock_in', '2026-07-04T21:14:00'),
+      mk('out', 'empA', 'clock_out', '2026-07-05T00:06:00'),
+    ];
+    const { sessions } = processPunchesForPeriod(punches);
+    const windowSessions = sessionsWithClockInInWindow(sessions, dayStart, dayEnd);
+    expect(windowSessions).toHaveLength(1);
+    expect(windowSessions[0].is_complete).toBe(true);
+    const openSessions = windowSessions.filter((s) => !s.is_complete);
+    expect(openSessions).toHaveLength(0);
+    // And the hours count toward the day total:
+    expect(windowSessions[0].worked_minutes / 60).toBeCloseTo(2.87, 1);
   });
 });

--- a/tests/unit/timecardHours.test.ts
+++ b/tests/unit/timecardHours.test.ts
@@ -41,4 +41,19 @@ describe('hoursByClockInDay', () => {
     ];
     expect(hoursByClockInDay(punches, days).get('2026-07-10')!.netHours).toBeCloseTo(0, 5);
   });
+
+  it('attributes an overnight shift across US spring-forward DST to the clock-in local day', () => {
+    // US DST spring-forward: Sun 2026-03-08 02:00 → 03:00. Shift clock-in the
+    // evening before (Sat Mar 7 23:00 local) → Sun Mar 8 07:00 local crosses the
+    // transition. `new Date(y, m, d, h)` pins to local time in any process TZ, so
+    // this asserts attribution lands on the clock-in local day regardless of TZ.
+    const days = [new Date(2026, 2, 7), new Date(2026, 2, 8)]; // Sat, Sun (local)
+    const punches = [
+      punch('clock_in', new Date(2026, 2, 7, 23, 0).toISOString()),
+      punch('clock_out', new Date(2026, 2, 8, 7, 0).toISOString()),
+    ];
+    const map = hoursByClockInDay(punches, days);
+    expect(map.get('2026-03-07')!.netHours).toBeGreaterThan(0); // whole shift on Mar 7
+    expect(map.get('2026-03-08')!.netHours).toBeCloseTo(0, 5);   // nothing bled to Mar 8
+  });
 });

--- a/tests/unit/timecardHours.test.ts
+++ b/tests/unit/timecardHours.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import { hoursByClockInDay } from '@/utils/timecardHours';
+
+const punch = (type: string, iso: string) => ({
+  id: `${type}-${iso}`, employee_id: 'e1', restaurant_id: 'r1',
+  punch_type: type, punch_time: iso,
+}) as any;
+
+describe('hoursByClockInDay', () => {
+  it('attributes an overnight shift entirely to the clock-in local day', () => {
+    // Thu 23:00 -> Fri 07:00 (8h). Buffered punches may include neighbours.
+    const days = [new Date(2026, 6, 9), new Date(2026, 6, 10)]; // Thu, Fri (local)
+    const punches = [
+      punch('clock_in', new Date(2026, 6, 9, 23, 0).toISOString()),
+      punch('clock_out', new Date(2026, 6, 10, 7, 0).toISOString()),
+    ];
+    const map = hoursByClockInDay(punches, days);
+    expect(map.get('2026-07-09')!.netHours).toBeCloseTo(8, 5);
+    expect(map.get('2026-07-10')!.netHours).toBeCloseTo(0, 5);
+  });
+
+  it('subtracts breaks from the same clock-in day', () => {
+    const days = [new Date(2026, 6, 9)];
+    const punches = [
+      punch('clock_in', new Date(2026, 6, 9, 9, 0).toISOString()),
+      punch('break_start', new Date(2026, 6, 9, 12, 0).toISOString()),
+      punch('break_end', new Date(2026, 6, 9, 12, 30).toISOString()),
+      punch('clock_out', new Date(2026, 6, 9, 17, 0).toISOString()),
+    ];
+    const d = hoursByClockInDay(punches, days).get('2026-07-09')!;
+    expect(d.totalHours).toBeCloseTo(8, 5);
+    expect(d.breakHours).toBeCloseTo(0.5, 5);
+    expect(d.netHours).toBeCloseTo(7.5, 5);
+  });
+
+  it('ignores shifts whose clock-in day is outside the displayed range', () => {
+    const days = [new Date(2026, 6, 10)];
+    const punches = [
+      punch('clock_in', new Date(2026, 6, 9, 9, 0).toISOString()),
+      punch('clock_out', new Date(2026, 6, 9, 17, 0).toISOString()),
+    ];
+    expect(hoursByClockInDay(punches, days).get('2026-07-10')!.netHours).toBeCloseTo(0, 5);
+  });
+});

--- a/tests/unit/tips-hours-auto-calculation.test.ts
+++ b/tests/unit/tips-hours-auto-calculation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { calculateWorkedHours } from '@/utils/payrollCalculations';
+import { calculateWorkedHours, calculateWorkedHoursForClockInDay } from '@/utils/payrollCalculations';
 import type { TimePunch } from '@/types/timeTracking';
 
 describe('Tips: Auto-calculate hours from time punches', () => {
@@ -273,5 +273,59 @@ describe('Tips: Auto-calculate hours from time punches', () => {
 
     // Both employees worked 8 hours each
     expect(emp1Hours).toBe(emp2Hours);
+  });
+});
+
+describe('Tips: overnight-safe hours via calculateWorkedHoursForClockInDay', () => {
+  // Service day = 2025-12-17 (UTC bounds for deterministic, TZ-independent test).
+  const dayStart = new Date('2025-12-17T00:00:00.000Z');
+  const dayEnd = new Date('2025-12-17T23:59:59.999Z');
+  const p = (type: string, iso: string, emp = 'emp1'): TimePunch => ({
+    id: `${type}-${iso}`, employee_id: emp, restaurant_id: 'rest1',
+    punch_type: type as TimePunch['punch_type'], punch_time: iso,
+    created_at: iso, updated_at: iso,
+  });
+
+  it('counts an overnight shift (clock-out after midnight) on its clock-in day', () => {
+    // Wed 8pm -> Thu 1am. Buffered fetch supplies both punches; hours land on Wed.
+    const punches = [
+      p('clock_in', '2025-12-17T20:00:00Z'),
+      p('clock_out', '2025-12-18T01:00:00Z'),
+    ];
+    expect(calculateWorkedHoursForClockInDay(punches, dayStart, dayEnd)).toBeCloseTo(5, 5);
+  });
+
+  it('excludes a shift that clocked in the PREVIOUS night (pulled in by the buffer)', () => {
+    const punches = [
+      p('clock_in', '2025-12-16T20:00:00Z'),  // Tue night
+      p('clock_out', '2025-12-17T01:00:00Z'),  // Wed 1am → belongs to Tue
+    ];
+    expect(calculateWorkedHoursForClockInDay(punches, dayStart, dayEnd)).toBeCloseTo(0, 5);
+  });
+
+  it('keeps the whole break-after-midnight shift on the clock-in day, minus breaks', () => {
+    const punches = [
+      p('clock_in', '2025-12-17T18:00:00Z'),
+      p('break_start', '2025-12-18T00:00:00Z'),
+      p('break_end', '2025-12-18T00:30:00Z'),
+      p('clock_out', '2025-12-18T02:00:00Z'),
+    ];
+    // 8h span - 0.5h break = 7.5h, all on 2025-12-17.
+    expect(calculateWorkedHoursForClockInDay(punches, dayStart, dayEnd)).toBeCloseTo(7.5, 5);
+  });
+
+  it('regression: the old per-day-window path returned 0 for these overnight hours', () => {
+    // What Tips.tsx did before: filter punches to the calendar day, then
+    // calculateWorkedHours. The clock-out lands next day, so only a lone
+    // clock-in remained in-window → 0 hours (the reported bug).
+    const punches = [
+      p('clock_in', '2025-12-17T20:00:00Z'),
+      p('clock_out', '2025-12-18T01:00:00Z'),
+    ];
+    const dayOnly = punches.filter(
+      (x) => x.punch_time >= dayStart.toISOString() && x.punch_time <= dayEnd.toISOString(),
+    );
+    expect(calculateWorkedHours(dayOnly)).toBe(0); // old behaviour (bug)
+    expect(calculateWorkedHoursForClockInDay(punches, dayStart, dayEnd)).toBeCloseTo(5, 5); // fixed
   });
 });

--- a/tests/unit/useLaborCostsFromTimeTracking.fetchRange.test.ts
+++ b/tests/unit/useLaborCostsFromTimeTracking.fetchRange.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Regression: useLaborCostsFromTimeTracking's time_punches fetch must be
+ * widened by the overnight buffer (±18h, via bufferPunchFetchRange) so a
+ * shift whose clock-in and clock-out straddle the period boundary is
+ * fetched whole. calculateActualLaborCost then attributes each shift back
+ * to its clock-in day within [dateFrom, dateTo] and drops out-of-window
+ * periods.
+ *
+ * The React Query cache key must stay keyed on the *logical* dateFrom/
+ * dateTo (not the buffered range) so cache identity is unaffected by the
+ * buffer.
+ */
+import React, { type ReactNode } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { bufferPunchFetchRange } from '@/utils/punchWindow';
+
+// Generic chainable Supabase query-builder mock: every method returns
+// `this` so any chain shape resolves, and the builder is thenable so
+// `await supabase.from(...).select()...` resolves to { data: [], error: null }.
+type SupabaseChain = Record<string, unknown> & {
+  then: (resolve: (v: { data: unknown[]; error: null }) => void) => void;
+};
+
+function makeChainable(): SupabaseChain {
+  const chain = {} as SupabaseChain;
+  const methods = [
+    'select', 'eq', 'in', 'order', 'maybeSingle',
+  ];
+  methods.forEach((m) => {
+    chain[m] = vi.fn(() => chain);
+  });
+  // gte/lte are spied separately per-table so tests can assert on them.
+  chain.gte = vi.fn(() => chain);
+  chain.lte = vi.fn(() => chain);
+  chain.then = (resolve: (v: { data: unknown[]; error: null }) => void) =>
+    resolve({ data: [], error: null });
+  return chain;
+}
+
+const timePunchesChain = makeChainable();
+const fromMock = vi.fn((table: string) => {
+  if (table === 'time_punches') return timePunchesChain;
+  return makeChainable();
+});
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: (...args: [string]) => fromMock(...args),
+  },
+}));
+
+// useEmployees pulls from the same mocked supabase client; stub it directly
+// to keep this test focused on the time_punches fetch bounds. The hook's
+// query is `enabled: !!restaurantId && !!employees.length`, so at least one
+// employee is required for the time_punches query to actually run.
+vi.mock('@/hooks/useEmployees', () => ({
+  useEmployees: () => ({ employees: [{ id: 'emp-1', status: 'active' }], loading: false }),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+};
+
+describe('useLaborCostsFromTimeTracking time_punches fetch range', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches time_punches widened by the overnight buffer, not the raw logical bounds', async () => {
+    const { useLaborCostsFromTimeTracking } = await import('@/hooks/useLaborCostsFromTimeTracking');
+
+    const dateFrom = new Date('2026-03-02T00:00:00.000Z');
+    const dateTo = new Date('2026-03-08T23:59:59.999Z');
+    const { fetchStart, fetchEnd } = bufferPunchFetchRange(dateFrom, dateTo);
+
+    const { result } = renderHook(
+      () => useLaborCostsFromTimeTracking('rest-1', dateFrom, dateTo),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(fromMock).toHaveBeenCalledWith('time_punches');
+    // The fetch bounds must be the BUFFERED range, not the raw logical dates.
+    expect(timePunchesChain.gte).toHaveBeenCalledWith('punch_time', fetchStart.toISOString());
+    expect(timePunchesChain.lte).toHaveBeenCalledWith('punch_time', fetchEnd.toISOString());
+    // Sanity: the buffered bounds actually differ from the logical bounds.
+    expect(fetchStart.toISOString()).not.toBe(dateFrom.toISOString());
+    expect(fetchEnd.toISOString()).not.toBe(dateTo.toISOString());
+  });
+});

--- a/tests/unit/useLaborCostsFromTimeTracking.fetchRange.test.ts
+++ b/tests/unit/useLaborCostsFromTimeTracking.fetchRange.test.ts
@@ -1,20 +1,20 @@
 /**
  * Regression: useLaborCostsFromTimeTracking's time_punches fetch must be
- * widened by the overnight buffer (±18h, via bufferPunchFetchRange) so a
- * shift whose clock-in and clock-out straddle the period boundary is
- * fetched whole. calculateActualLaborCost then attributes each shift back
- * to its clock-in day within [dateFrom, dateTo] and drops out-of-window
- * periods.
+ * widened by a LOOK-AHEAD ONLY (via lookaheadPunchFetchRange) so a shift
+ * whose clock_out lands just after dateTo is fetched whole, WITHOUT a
+ * look-back. calculateActualLaborCost attributes hours/active-days to every
+ * day a shift touches and does NOT drop shifts whose clock-in precedes the
+ * window, so a symmetric look-back would pull a prior-period Sunday-night
+ * shift into the first in-range day and overstate labor (Codex P2).
  *
  * The React Query cache key must stay keyed on the *logical* dateFrom/
- * dateTo (not the buffered range) so cache identity is unaffected by the
- * buffer.
+ * dateTo (not the buffered range) so cache identity is unaffected.
  */
 import React, { type ReactNode } from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { bufferPunchFetchRange } from '@/utils/punchWindow';
+import { lookaheadPunchFetchRange } from '@/utils/punchWindow';
 
 // Generic chainable Supabase query-builder mock: every method returns
 // `this` so any chain shape resolves, and the builder is thenable so
@@ -73,12 +73,12 @@ describe('useLaborCostsFromTimeTracking time_punches fetch range', () => {
     vi.clearAllMocks();
   });
 
-  it('fetches time_punches widened by the overnight buffer, not the raw logical bounds', async () => {
+  it('fetches time_punches with a look-ahead only (start unchanged, end +18h)', async () => {
     const { useLaborCostsFromTimeTracking } = await import('@/hooks/useLaborCostsFromTimeTracking');
 
     const dateFrom = new Date('2026-03-02T00:00:00.000Z');
     const dateTo = new Date('2026-03-08T23:59:59.999Z');
-    const { fetchStart, fetchEnd } = bufferPunchFetchRange(dateFrom, dateTo);
+    const { fetchStart, fetchEnd } = lookaheadPunchFetchRange(dateFrom, dateTo);
 
     const { result } = renderHook(
       () => useLaborCostsFromTimeTracking('rest-1', dateFrom, dateTo),
@@ -88,11 +88,10 @@ describe('useLaborCostsFromTimeTracking time_punches fetch range', () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     expect(fromMock).toHaveBeenCalledWith('time_punches');
-    // The fetch bounds must be the BUFFERED range, not the raw logical dates.
     expect(timePunchesChain.gte).toHaveBeenCalledWith('punch_time', fetchStart.toISOString());
     expect(timePunchesChain.lte).toHaveBeenCalledWith('punch_time', fetchEnd.toISOString());
-    // Sanity: the buffered bounds actually differ from the logical bounds.
-    expect(fetchStart.toISOString()).not.toBe(dateFrom.toISOString());
-    expect(fetchEnd.toISOString()).not.toBe(dateTo.toISOString());
+    // Look-ahead only: start is the raw dateFrom (NO look-back), end is +18h.
+    expect(fetchStart.toISOString()).toBe(dateFrom.toISOString());
+    expect(fetchEnd.getTime() - dateTo.getTime()).toBe(18 * 3600 * 1000);
   });
 });

--- a/tests/unit/usePayroll.fetchRange.test.ts
+++ b/tests/unit/usePayroll.fetchRange.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Regression: usePayroll's time_punches fetch must be widened by the
+ * overnight buffer (±18h, via bufferPunchFetchRange) so a shift whose
+ * clock-in and clock-out straddle the period boundary is fetched whole.
+ * calculateEmployeePay then attributes each shift back to its clock-in day
+ * within [startDate, endDate].
+ *
+ * The React Query cache key must stay keyed on the *logical* startDate/
+ * endDate (not the buffered range) so cache identity is unaffected by the
+ * buffer.
+ */
+import React, { type ReactNode } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { bufferPunchFetchRange } from '@/utils/punchWindow';
+
+// Generic chainable Supabase query-builder mock: every method returns
+// `this` so any chain shape resolves, and the builder is thenable so
+// `await supabase.from(...).select()...` resolves to { data: [], error: null }.
+type SupabaseChain = Record<string, unknown> & {
+  then: (resolve: (v: { data: unknown[]; error: null }) => void) => void;
+};
+
+function makeChainable(): SupabaseChain {
+  const chain = {} as SupabaseChain;
+  const methods = [
+    'select', 'eq', 'in', 'order', 'maybeSingle',
+  ];
+  methods.forEach((m) => {
+    chain[m] = vi.fn(() => chain);
+  });
+  // gte/lte are spied separately per-table so tests can assert on them.
+  chain.gte = vi.fn(() => chain);
+  chain.lte = vi.fn(() => chain);
+  chain.then = (resolve: (v: { data: unknown[]; error: null }) => void) =>
+    resolve({ data: [], error: null });
+  return chain;
+}
+
+const timePunchesChain = makeChainable();
+const fromMock = vi.fn((table: string) => {
+  if (table === 'time_punches') return timePunchesChain;
+  return makeChainable();
+});
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: (...args: [string]) => fromMock(...args),
+  },
+}));
+
+// useEmployees pulls from the same mocked supabase client; stub it directly
+// to keep this test focused on the time_punches fetch bounds. usePayroll's
+// query is `enabled: !!restaurantId && !!employees.length`, so at least one
+// employee is required for the time_punches query to actually run.
+vi.mock('@/hooks/useEmployees', () => ({
+  useEmployees: () => ({ employees: [{ id: 'emp-1', status: 'active' }], loading: false }),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+};
+
+describe('usePayroll time_punches fetch range', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches time_punches widened by the overnight buffer, not the raw logical bounds', async () => {
+    const { usePayroll } = await import('@/hooks/usePayroll');
+
+    const startDate = new Date('2026-03-02T00:00:00.000Z');
+    const endDate = new Date('2026-03-08T23:59:59.999Z');
+    const { fetchStart, fetchEnd } = bufferPunchFetchRange(startDate, endDate);
+
+    const { result } = renderHook(
+      () => usePayroll('rest-1', startDate, endDate),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(fromMock).toHaveBeenCalledWith('time_punches');
+    // The fetch bounds must be the BUFFERED range, not the raw logical dates.
+    expect(timePunchesChain.gte).toHaveBeenCalledWith('punch_time', fetchStart.toISOString());
+    expect(timePunchesChain.lte).toHaveBeenCalledWith('punch_time', fetchEnd.toISOString());
+    // Sanity: the buffered bounds actually differ from the logical bounds.
+    expect(fetchStart.toISOString()).not.toBe(startDate.toISOString());
+    expect(fetchEnd.toISOString()).not.toBe(endDate.toISOString());
+  });
+});


### PR DESCRIPTION
## Summary
Fixes overnight shifts (clock in one day, clock out after midnight) being split by per-day/per-period punch **fetch windows** — the pairing engines were already overnight-correct, but every fetch used a hard `punch_time BETWEEN start AND end` with no buffer, so a shift's two punches landed on opposite sides of a boundary. This caused:
- **Dropped payroll hours** at pay-period boundaries (a Sun-night→Mon-morning shift counted in neither week).
- **False "open session" / "no matching clock-in" warnings** that led managers to hand-edit good punches into duplicates.

**Approach** (generalizes the existing `fetchLaborData` pattern): fetch a symmetric ±18h buffer, pair across the full set, then attribute each shift to its **clock-in day** and drop shifts whose clock-in is outside the target window.

- New `src/utils/punchWindow.ts` — buffer + attribution helpers, with a drift-guard test tying `OVERNIGHT_BUFFER_HOURS` to `MAX_SHIFT_GAP_HOURS`.
- `calculateEmployeePay` gains an **opt-in** `attributeToWindow` flag (only the payroll path enables it) so the noon-anchored `calculateActualLaborCostForMonth` caller is unaffected.
- Wired into: payroll (`usePayroll`), open-sessions (`TimePunchesManager`, buffered pairing + window-scoped display/totals), employee timecard (`EmployeeTimecard` + new `hoursByClockInDay`, replaces broken per-day bucketing), dashboard (`useLaborCostsFromTimeTracking`), and the two unbuffered AI edge tools (`ai-execute-tool`).

## Test plan
- New unit tests: `punchWindow`, `timecardHours`, overnight-attribution cases in `payrollCalculations` (Sun→Mon counted once, no double-count, no false orphan, OT/tip-proration ignores buffered neighbours), open-session completeness, and hook fetch-range tests.
- Full suite green (6190 passing); the one unrelated failure (`AvailableShiftsPage.tradeCard`) is **pre-existing on `main`** — a timing-sensitive shift-trade test this PR does not touch.
- `npm run build` clean; typecheck clean.

## Notes
- **Deferred (out of scope, tracked separately):** `calculateActualLaborCostForMonth` has its own latent overnight bug (buckets by unbuffered `startOfWeek`); it's DST-sensitive (see lessons.md PR #485) and needs its own design pass. The opt-in flag ensures this PR does not regress it.
- Historical data cleanup (duplicate/force-out punches already created by managers reacting to the false warnings) is a separate data-only follow-up.

Design doc: `docs/superpowers/specs/2026-07-09-overnight-shift-punch-windowing-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added overnight punch “windowing” with buffered (±18h) fetch ranges and inclusive window attribution to the clock-in day across payroll, timecards, labor costs, tips, and punch management/export views.
* **Bug Fixes**
  * Prevented false open-session/anomaly warnings near period boundaries and eliminated split/double-counting for overnight shifts crossing fetch limits; improved DST handling.
* **Documentation**
  * Added design + full implementation plan for overnight-shift punch windowing.
* **Tests**
  * Added/expanded unit tests for buffered fetch bounds, window attribution, open-session behavior, DST, and hourly/payroll/tips calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->