### PR TITLE
fix(focus): capture Focus POS tax as per-order unified_sales rows

### DIFF
--- a/docs/superpowers/plans/2026-07-10-focus-tax-capture-plan.md
+++ b/docs/superpowers/plans/2026-07-10-focus-tax-capture-plan.md
@@ -1,0 +1,74 @@
+# Plan: Capture Focus POS tax into unified_sales
+
+Design: `docs/superpowers/specs/2026-07-10-focus-tax-capture-design.md`
+Branch: `fix/focus-tax-capture`
+
+Each task = RED → GREEN → REFACTOR → COMMIT.
+
+## Task 1 — Parser: sum SeatRecord.TaxTotal1..5 into FocusCheck.taxAmount
+- **RED:** In `tests/unit/focusDatafeedParser.test.ts`, add cases:
+  - fixture check 1 → `taxAmount === 3.46` (3.30 + 0.16); check 2 → `0.33`
+  - multi-seat check → sum of both seats' `TaxTotal*`
+  - check with no `SeatRecord` / no `TaxTotal*` → `0`
+  - negative `TaxTotal` → negative sum (refund case)
+- **GREEN:** `focusDatafeedParser.ts`:
+  - add `taxAmount: number` to `FocusCheck`
+  - in `parseCheck`, accumulate `TaxTotal1..5` across `toArray(seat.SeatRecord)`
+    for every seat, round once (`Math.round(sum*100)/100`), assign `taxAmount`
+- **Files:** `supabase/functions/_shared/focusDatafeedParser.ts`,
+  `tests/unit/focusDatafeedParser.test.ts`
+- **Dep:** none
+
+## Task 2 — Persist tax_amount on focus_orders upsert
+- **RED:** In `tests/unit/focusTransactionSyncHandler.test.ts`, assert the
+  `focus_orders` upsert payload includes `tax_amount` from `check.taxAmount`.
+- **GREEN:** `focusTransactionSyncHandler.ts` `upsertOrder`: add
+  `tax_amount: check.taxAmount` to the upsert object.
+- **Files:** `supabase/functions/_shared/focusTransactionSyncHandler.ts`,
+  `tests/unit/focusTransactionSyncHandler.test.ts`
+- **Dep:** Task 1 (FocusCheck.taxAmount)
+
+## Task 3 — Migration A: add focus_orders.tax_amount
+- New file `supabase/migrations/20260710HHMMSS_focus_orders_tax_amount.sql`
+  (generate timestamp at creation; verify no prefix collision):
+  `ALTER TABLE public.focus_orders ADD COLUMN IF NOT EXISTS tax_amount numeric
+  NOT NULL DEFAULT 0;` + `COMMENT ON COLUMN`.
+- Own file, no other DDL.
+- **Dep:** none (but ordered before Task 4)
+
+## Task 4 — Migration B: Step 6 tax row in the impl RPC
+- **Pre-flight:** re-pull `pg_get_functiondef` of
+  `_sync_focus_transactions_to_unified_sales_impl(uuid,date,date)`; assert it
+  contains `apply_rules_to_pos_sales_internal` and NOT `auth.uid()`.
+- New file `supabase/migrations/20260710HHMMSS_focus_tax_unified_sales.sql`
+  (timestamp strictly after Task 3's):
+  - `CREATE OR REPLACE FUNCTION …_impl(...)` = live body + `fo.tax_amount` in
+    the loop `SELECT` + **Step 6** tax INSERT/DELETE block (per design Layer 3;
+    `sale_time` in INSERT and `DO UPDATE SET`; single-row conditional delete
+    with an explanatory comment).
+  - Re-apply `REVOKE ALL … FROM PUBLIC; GRANT EXECUTE … TO service_role;`
+- **Dep:** Task 3
+
+## Task 5 — pgTAP test for the RPC tax row
+- New/extended test under `supabase/tests/` (mirror
+  `47_focus_transactions_unified_sales.sql`):
+  - seed `focus_connections` + a `focus_orders` row with `tax_amount = 5.55`
+    (+ a priced `focus_order_items` row), run
+    `sync_focus_transactions_to_unified_sales(restaurant, d, d)`
+  - assert exactly one row `item_type='tax'`, `adjustment_type='tax'`,
+    `external_item_id = <order>_tax`, `total_price = 5.55`
+  - set `tax_amount = 0`, re-run → tax row deleted
+  - order with `tax_amount = 0` from the start → no tax row
+- **Dep:** Task 4
+
+## Task 6 — Verify (Phase 8) + backfill note
+- Local: `npm run test` (parser + handler), `npm run typecheck`,
+  `npm run lint`, `npm run build`; `npm run test:db` for pgTAP.
+- **Backfill (post-merge/deploy, documented in PR):** run custom-range Focus
+  syncs (≤14 days each) for `7c0c76e3-…`: Jun 24–Jul 7 and Jul 8–present
+  (custom-range path re-parses; not delta-skipped — safe to re-run). Then
+  verify Cold Stone RC June `item_type='tax'` total ≈ **$555.55**.
+
+## Notes
+- No UI/component changes → Phase 5 (UI review) skipped.
+- Read side already counts `item_type='tax'` — no consumer changes.

--- a/docs/superpowers/specs/2026-07-10-focus-tax-capture-design.md
+++ b/docs/superpowers/specs/2026-07-10-focus-tax-capture-design.md
@@ -124,15 +124,23 @@ Both overloads share the impl, so both the manual and cron paths pick up tax.
    repo/prod drift (lesson PR #579/#581); splice Step 6 in with the loop
    `SELECT` extended by `fo.tax_amount`.
 
-### Backfill (post-deploy, manual)
+### Backfill
 Tax lives only in the raw datafeed, which is not stored — so existing
-`focus_orders` rows must be **re-fetched + re-parsed** to populate
-`tax_amount`. The custom-range / backfill sync paths do **not** wire the
-delta-skip `stateStore`, so a re-run re-parses fresh.
+`focus_orders` rows must be **re-fetched + re-parsed** to populate `tax_amount`.
 
-Plan: after merge + deploy, run two custom-range Focus syncs (≤14-day cap):
-June 24–Jul 7 and Jul 8–present, for `7c0c76e3-…`. Then verify Cold Stone RC
-June tax ≈ **$555.55**.
+**Automatic (all restaurants), via fingerprint invalidation.** The bulk-cron
+sync delta-skips days whose `<Checks>` XML is unchanged (fingerprint match in
+`focus_datafeed_state`) *before* parsing — so already-fingerprinted closed days
+would keep `tax_amount = 0` forever (Codex P1, PR #600). Migration
+`20260710140000` **clears `focus_datafeed_state`**, so the next cron ticks
+recompute fingerprints, re-parse each day (idempotent upserts), and populate
+tax for **every** Focus restaurant over subsequent runs (bounded by each run's
+per-restaurant day cap; self-healing).
+
+**Manual (faster reconciliation of the target).** The custom-range sync path
+does not wire the delta-skip `stateStore`, so it re-parses immediately. After
+deploy, run two custom-range Focus syncs (≤14-day cap) for `7c0c76e3-…`: June
+24–Jul 7 and Jul 8–present, then verify Cold Stone RC June tax ≈ **$555.55**.
 
 ## Idempotency & edge cases
 - Tax row is one-per-order, fixed key `…_tax`; re-sync UPSERTs, preserving

--- a/docs/superpowers/specs/2026-07-10-focus-tax-capture-design.md
+++ b/docs/superpowers/specs/2026-07-10-focus-tax-capture-design.md
@@ -73,7 +73,14 @@ changes are needed** — only production of the rows.
 ### Layer 2 — Schema + persistence
 - Migration: `ALTER TABLE focus_orders ADD COLUMN tax_amount numeric NOT NULL
   DEFAULT 0`. (Tiny table; metadata-only default in PG11+. Existing 1,484 rows
-  get 0 until re-synced — correct, tax was never captured.)
+  get 0 until re-synced — correct, tax was never captured.) Keep this ALTER in
+  its **own** migration file (not batched with other/larger-table DDL) so the
+  fast-path default is not lost.
+- Migration filenames: timestamps must sort **after** the latest existing
+  migration (`20260708193107_…`) and be repo-wide unique — use
+  `20260710HHMMSS_…` generated at file-creation time; `git ls-tree
+  origin/main supabase/migrations/` immediately before the PR to re-check for
+  collisions (lesson PR #571/#576).
 - `focusTransactionSyncHandler.upsertOrder`: persist
   `tax_amount: check.taxAmount`.
 
@@ -83,16 +90,39 @@ and the report RPC's tax block:
 - Add `fo.tax_amount` to the per-check `FOR` loop `SELECT`.
 - `INSERT … SELECT` one row where `tax_amount != 0`:
   `external_item_id = v_order_id || '_tax'`, `item_name = 'Sales Tax'`,
-  `total_price = tax_amount`, `item_type='tax'`, `adjustment_type='tax'`,
-  `sale_time = v_sale_time`, same `ON CONFLICT … WHERE parent_sale_id IS NULL
-  DO UPDATE` shape.
-- Delete the stale `_tax` row when tax becomes 0 (mirror the tip/discount
-  delete-orphan guard: delete the `_tax` row for this order when the order no
-  longer has non-zero tax). `parent_sale_id IS NULL` guards user split rows.
+  `total_price = tax_amount`, `item_type='tax'`, `adjustment_type='tax'`.
+  **`sale_time = v_sale_time` MUST appear in both the INSERT column list AND
+  the `DO UPDATE SET`** (same as tip/discount — omitting it from `DO UPDATE`
+  leaves the busy-time signal stale on re-sync; this is the exact bug
+  `20260703120000` fixed for the other row kinds). Same `ON CONFLICT …
+  WHERE parent_sale_id IS NULL DO UPDATE` shape; `category_id`/`is_categorized`
+  omitted from `DO UPDATE` to preserve user categorization.
+- **Delete-orphan is simpler than Step 4/5** because tax is **one row per
+  order** (one-to-one), not one-per-item/payment. Use a plain conditional
+  delete keyed off the order having zero tax — delete `external_item_id =
+  v_order_id || '_tax'` when `v_order.tax_amount = 0` (or the guarded INSERT's
+  WHERE excludes it) — **not** a `NOT IN (subquery)` pattern. Add a migration
+  comment explaining *why* the shape differs so a future reader doesn't
+  "normalise" it to the multi-row form. `parent_sale_id IS NULL` still guards
+  user split rows.
 
 Both overloads share the impl, so both the manual and cron paths pick up tax.
-The function is re-created from the **live prod definition** (pulled via
-`pg_get_functiondef`) to avoid repo/prod drift (lesson PR #579/#581).
+
+**Implementation guards (from Phase 2.5 review):**
+1. **Pre-flight, before authoring the migration:** re-pull the live body via
+   `pg_get_functiondef` and assert it is the *ungated* form — contains
+   `apply_rules_to_pos_sales_internal` and does **not** contain an
+   `auth.uid()` gate (the PR #565/#567/#573 regression class). Verified at
+   design time: `ok=true, has_authuid_gate=false`. Re-verify at build time.
+2. **Preserve grants on `CREATE OR REPLACE`** (Postgres resets ACL). Live ACL
+   is `{postgres, service_role}`. Re-apply:
+   `REVOKE ALL ON FUNCTION …_impl(uuid,date,date) FROM PUBLIC;`
+   `GRANT EXECUTE ON FUNCTION …_impl(uuid,date,date) TO service_role;`
+   Do **not** grant the impl to `authenticated` (only the public wrappers are,
+   and they are unchanged — the migration re-creates the impl only).
+3. The function is re-created from the **live prod definition** to avoid
+   repo/prod drift (lesson PR #579/#581); splice Step 6 in with the loop
+   `SELECT` extended by `fo.tax_amount`.
 
 ### Backfill (post-deploy, manual)
 Tax lives only in the raw datafeed, which is not stored — so existing

--- a/docs/superpowers/specs/2026-07-10-focus-tax-capture-design.md
+++ b/docs/superpowers/specs/2026-07-10-focus-tax-capture-design.md
@@ -1,0 +1,145 @@
+# Design: Capture Focus POS tax into unified_sales
+
+**Date:** 2026-07-10
+**Branch:** `fix/focus-tax-capture`
+**Author:** Claude (with Jose)
+
+## Problem
+
+Focus POS sales flow through the Lynk transaction feed
+(`focusDatafeedParser` → `focus_orders`/`focus_order_items`/`focus_payments`
+→ `sync_focus_transactions_to_unified_sales` → `unified_sales`). This path
+emits `sale`, `discount`, and `tip` rows but **never emits tax**. As a
+result P&L and the POS Sales page show **$0 tax** for Focus restaurants.
+
+Concrete gap (Wetzel's – Cold Stone – Alamo Ranch, `7c0c76e3-…`, June): the
+Focus daily report shows **Total Tax $555.55** for the Cold Stone revenue
+center, but `unified_sales` has zero `item_type='tax'` rows for the store.
+
+### Root cause
+
+Two layers:
+1. **Parser** (`focusDatafeedParser.ts`) reads `CheckRecord.TaxableSales1..5`
+   (the taxable *base*) but never the tax *collected*.
+2. **`focus_orders`** has a `taxable_sales` column but **no tax amount
+   column**, so `_sync_focus_transactions_to_unified_sales_impl` has nothing
+   to emit.
+
+The tax capability *does* exist in the older report-based RPC
+(`sync_focus_to_unified_sales`, sourced from `focus_daily_reports.total_tax`),
+but that path is unused for this store (`focus_daily_reports` = 0 rows). Tax
+was silently dropped in the migration from the report path to the
+transaction-feed path (documented in
+`20260701130000_focus_transactions_unified_sales.sql`:31).
+
+## How the other integrations do it (the target convention)
+
+Square, Toast, and Clover all store tax as a **per-order adjustment row** in
+`unified_sales`, not a daily total:
+
+| field | value |
+|---|---|
+| `external_item_id` | `<external_order_id>_tax` |
+| `item_name` | `Sales Tax` |
+| `item_type` | `tax` |
+| `adjustment_type` | `tax` |
+| `total_price` | the order's tax amount |
+
+Revenue line items are stored pre-tax. The read side already counts this:
+`KNOWN_PASS_THROUGH_TYPES = {tax, tip, service_charge, discount, fee}` in
+`useRevenueBreakdown` + `get_pass_through_totals` (lessons 2026-05, PR #485),
+and the `unified_sales_item_type_check` / `unified_sales_adjustment_type_check`
+constraints already permit `'tax'`. **No read-side or schema-constraint
+changes are needed** — only production of the rows.
+
+## Data model (verified against `tests/fixtures/focus-datafeed-sample.xml`)
+
+- Tax is on the **`SeatRecord`**, not the `CheckRecord`:
+  `SeatRecord.TaxTotal1..5` (tax collected per bucket), parallel to the
+  `CheckRecord.TaxableSales1..5` base already parsed.
+- A check can have multiple seats → **sum `TaxTotal1..5` across all seats**.
+- Verified reconciliation on a real check: seat `Subtotal` 44.97 +
+  `TaxTotal1` 3.30 + `TaxTotal2` 0.16 = `Total` **48.43**. ✓
+- Up to 5 buckets (Cold Stone report shows 4: Food/Beverage/Soda/Tax5).
+
+## Design — three layers + backfill
+
+### Layer 1 — Parser (`focusDatafeedParser.ts`)
+- Add `taxAmount: number` to `FocusCheck`.
+- In `parseCheck`, while looping seats, read `seat.SeatRecord` and sum
+  `TaxTotal1..5` across all seats, rounding once at the end (same
+  binary-float-safe idiom already used for `taxableSales`).
+
+### Layer 2 — Schema + persistence
+- Migration: `ALTER TABLE focus_orders ADD COLUMN tax_amount numeric NOT NULL
+  DEFAULT 0`. (Tiny table; metadata-only default in PG11+. Existing 1,484 rows
+  get 0 until re-synced — correct, tax was never captured.)
+- `focusTransactionSyncHandler.upsertOrder`: persist
+  `tax_amount: check.taxAmount`.
+
+### Layer 3 — RPC (`_sync_focus_transactions_to_unified_sales_impl`)
+Add **Step 6: tax offset row**, mirroring the existing tip/discount blocks
+and the report RPC's tax block:
+- Add `fo.tax_amount` to the per-check `FOR` loop `SELECT`.
+- `INSERT … SELECT` one row where `tax_amount != 0`:
+  `external_item_id = v_order_id || '_tax'`, `item_name = 'Sales Tax'`,
+  `total_price = tax_amount`, `item_type='tax'`, `adjustment_type='tax'`,
+  `sale_time = v_sale_time`, same `ON CONFLICT … WHERE parent_sale_id IS NULL
+  DO UPDATE` shape.
+- Delete the stale `_tax` row when tax becomes 0 (mirror the tip/discount
+  delete-orphan guard: delete the `_tax` row for this order when the order no
+  longer has non-zero tax). `parent_sale_id IS NULL` guards user split rows.
+
+Both overloads share the impl, so both the manual and cron paths pick up tax.
+The function is re-created from the **live prod definition** (pulled via
+`pg_get_functiondef`) to avoid repo/prod drift (lesson PR #579/#581).
+
+### Backfill (post-deploy, manual)
+Tax lives only in the raw datafeed, which is not stored — so existing
+`focus_orders` rows must be **re-fetched + re-parsed** to populate
+`tax_amount`. The custom-range / backfill sync paths do **not** wire the
+delta-skip `stateStore`, so a re-run re-parses fresh.
+
+Plan: after merge + deploy, run two custom-range Focus syncs (≤14-day cap):
+June 24–Jul 7 and Jul 8–present, for `7c0c76e3-…`. Then verify Cold Stone RC
+June tax ≈ **$555.55**.
+
+## Idempotency & edge cases
+- Tax row is one-per-order, fixed key `…_tax`; re-sync UPSERTs, preserving
+  user categorization (category_id omitted from `DO UPDATE`), exactly like the
+  sale/tip/discount blocks.
+- Negative tax (refund checks) flows through unchanged (sum may be negative) —
+  consistent with how discounts are handled.
+- Voids/deleted checks: tax row behaves identically to the existing sale/tip
+  rows for that order (no new void semantics introduced).
+
+## Alternatives considered
+1. **Per-bucket tax columns/rows (Tax1..5 separately).** Rejected: diverges
+   from the single-`Sales Tax`-row convention used by Square/Toast/Clover;
+   `unified_sales` has no bucket concept; P&L wants the total. We still *sum*
+   all five buckets, so no data is lost — only the split is not persisted.
+2. **Revive the report path (`focus_daily_reports`).** Rejected: that path is
+   unused, would double-source sales, and its parser has a separate
+   inclusive-vs-exclusive tax bug. The transaction feed is the live source of
+   truth.
+3. **New `tax` column on `unified_sales`.** Rejected: the established pattern
+   is an adjustment *row*; a column would require read-side changes and
+   diverge from every other POS.
+
+## Testing
+- **Unit** (`focusDatafeedParser.test.ts`): the fixture check reconciles —
+  `taxAmount` = 3.46 (3.30 + 0.16) for check 1, 0.33 for check 2; multi-seat
+  sum; missing SeatRecord → 0.
+- **Unit** (`focusTransactionSyncHandler.test.ts`): `upsertOrder` persists
+  `tax_amount`.
+- **pgTAP** (`supabase/tests/`): after inserting a `focus_orders` row with
+  `tax_amount`, the RPC emits exactly one `item_type='tax'` /
+  `adjustment_type='tax'` row with matching `total_price` and external key;
+  setting tax_amount to 0 and re-running deletes it; zero-tax orders emit none.
+- **Reconciliation (post-deploy):** Cold Stone RC June tax ≈ $555.55.
+
+## Decided trade-offs
+- Existing focus_orders rows default `tax_amount=0` until re-synced; the
+  backfill re-populates. Acceptable — no historical tax existed to lose.
+- Per-bucket tax breakdown is summed away; the report's Food/Bev/Soda split is
+  not reproduced in `unified_sales`. Acceptable per the cross-POS convention.

--- a/supabase/functions/_shared/focusDatafeedParser.ts
+++ b/supabase/functions/_shared/focusDatafeedParser.ts
@@ -62,6 +62,8 @@ export interface FocusCheck {
   total: number;
   discountTotal: number;
   taxableSales: number;
+  /** Sum of SeatRecord.TaxTotal1..5 across all seats (tax collected). */
+  taxAmount: number;
   items: FocusItem[];
   payments: FocusPayment[];
 }
@@ -150,9 +152,15 @@ function parseCheck(check: any): FocusCheck {
   const cr = check.CheckRecord ?? {};
   const items: FocusItem[] = [];
   const payments: FocusPayment[] = [];
+  let taxAmountRaw = 0;
   for (const seat of toArray(check.Seats?.Seat)) {
     for (const cir of toArray(seat.CheckItemRecord)) items.push(parseItem(cir));
     for (const pr of toArray(seat.PaymentRecord)) payments.push(parsePayment(pr));
+    // Tax collected lives on SeatRecord (parallel to CheckRecord.TaxableSales1..5),
+    // summed across every seat on the check.
+    const sr = seat.SeatRecord ?? {};
+    taxAmountRaw +=
+      num(sr.TaxTotal1) + num(sr.TaxTotal2) + num(sr.TaxTotal3) + num(sr.TaxTotal4) + num(sr.TaxTotal5);
   }
   // Round to 2 decimal places after summing to avoid binary float drift
   // (e.g. 0.1 + 0.2 !== 0.3). Math.round * 100 / 100 is the standard JS idiom.
@@ -165,6 +173,7 @@ function parseCheck(check: any): FocusCheck {
         num(cr.TaxableSales5)) *
         100,
     ) / 100;
+  const taxAmount = Math.round(taxAmountRaw * 100) / 100;
   return {
     checkId: str(cr.ID) ?? '',
     openedAt: str(cr.TimeOpened),
@@ -175,6 +184,7 @@ function parseCheck(check: any): FocusCheck {
     total: num(cr.Total),
     discountTotal: num(cr.DiscountTotalAmount),
     taxableSales,
+    taxAmount,
     items,
     payments,
   };

--- a/supabase/functions/_shared/focusTransactionSyncHandler.ts
+++ b/supabase/functions/_shared/focusTransactionSyncHandler.ts
@@ -181,6 +181,7 @@ async function upsertOrder(
         total: check.total,
         discount_total: check.discountTotal,
         taxable_sales: check.taxableSales,
+        tax_amount: check.taxAmount,
       },
       { onConflict: 'restaurant_id,business_date,focus_check_id' },
     )

--- a/supabase/migrations/20260710120000_focus_orders_tax_amount.sql
+++ b/supabase/migrations/20260710120000_focus_orders_tax_amount.sql
@@ -1,0 +1,18 @@
+-- Add tax_amount to focus_orders — sum of SeatRecord.TaxTotal1..5 across all
+-- seats on the check, captured by the parser (focusDatafeedParser.ts) and
+-- persisted by focusTransactionSyncHandler.upsertOrder.
+--
+-- Tiny table; metadata-only default in PG11+ (no table rewrite). Existing
+-- rows get 0 until re-synced — correct, since tax was never captured before
+-- this migration.
+--
+-- Design ref: docs/superpowers/specs/2026-07-10-focus-tax-capture-design.md §"Layer 2"
+
+ALTER TABLE public.focus_orders
+ADD COLUMN IF NOT EXISTS tax_amount numeric NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN public.focus_orders.tax_amount IS
+  'Sum of SeatRecord.TaxTotal1..5 across all seats on the check (Focus POS '
+  'datafeed). Feeds the item_type=''tax'' unified_sales row emitted by '
+  '_sync_focus_transactions_to_unified_sales_impl. Existing rows default to '
+  '0 until re-synced.';

--- a/supabase/migrations/20260710130000_focus_tax_unified_sales.sql
+++ b/supabase/migrations/20260710130000_focus_tax_unified_sales.sql
@@ -310,7 +310,13 @@ BEGIN
   -- service-role callers defer to the apply-categorization-rules edge function)
   PERFORM apply_rules_to_pos_sales_internal(p_restaurant_id, 10000);
 
-  -- Batch-aggregate daily totals for all dates touched in this sync
+  -- Batch-aggregate daily totals for all dates touched in this sync.
+  -- Union two sources so DELETE-only dates are still re-aggregated: synced_at
+  -- only advances on INSERT/UPDATE, so a date whose only change was a removed
+  -- offset row (e.g. a tax row deleted when tax_amount is zeroed, with no
+  -- sale/tip/discount row re-upserted) would otherwise keep stale daily
+  -- totals. The focus_orders business_date range covers every check processed
+  -- this run, including those pure-delete dates (the order row still exists).
   PERFORM public.aggregate_unified_sales_to_daily(p_restaurant_id, d.sale_date)
   FROM (
     SELECT DISTINCT sale_date
@@ -318,6 +324,12 @@ BEGIN
     WHERE restaurant_id = p_restaurant_id
       AND pos_system    = 'focus'
       AND synced_at    >= v_sync_start
+    UNION
+    SELECT DISTINCT fo.business_date
+    FROM public.focus_orders fo
+    WHERE fo.restaurant_id = p_restaurant_id
+      AND (p_start_date IS NULL OR fo.business_date >= p_start_date)
+      AND (p_end_date   IS NULL OR fo.business_date <= p_end_date)
   ) d;
 
   RETURN v_count;

--- a/supabase/migrations/20260710130000_focus_tax_unified_sales.sql
+++ b/supabase/migrations/20260710130000_focus_tax_unified_sales.sql
@@ -1,0 +1,329 @@
+-- ============================================================
+-- §  Add Step 6 (tax offset row) to
+--    _sync_focus_transactions_to_unified_sales_impl
+--
+-- Focus's transaction feed never emitted a tax row (see design doc). Now
+-- that focus_orders.tax_amount is captured (20260710120000), this migration
+-- re-creates the impl with one new block: for each order with a non-zero
+-- tax_amount, upsert a single item_type='tax' / adjustment_type='tax' row —
+-- external_item_id = <order_id>_tax — mirroring the existing tip/discount
+-- offset blocks (Steps 4-5) and the convention used by Square/Toast/Clover.
+--
+-- Function body re-created from the LIVE definition (pg_get_functiondef),
+-- not from a hand-maintained copy, to avoid repo/prod drift (lesson
+-- PR #579/#581). Pre-flight verified at build time: the live body contains
+-- apply_rules_to_pos_sales_internal and does NOT contain an auth.uid() gate
+-- (the PR #565/#567/#573 regression class) — confirmed via:
+--   SELECT pg_get_functiondef(
+--     '_sync_focus_transactions_to_unified_sales_impl(uuid,date,date)'::regprocedure
+--   ) LIKE '%apply_rules_to_pos_sales_internal%'  -- true
+--   ... LIKE '%auth.uid()%'                        -- false
+--
+-- Tax delete shape is intentionally simpler than Steps 4/5: tax is exactly
+-- ONE row per order (not one-per-item/payment), so a plain conditional
+-- delete keyed off "this order currently has zero tax" is correct and
+-- clearer than the NOT IN (subquery) pattern used for discount/tip. Do not
+-- "normalise" this to the multi-row form — there is no per-tax-bucket row to
+-- enumerate; SeatRecord.TaxTotal1..5 are already summed into one
+-- focus_orders.tax_amount by the parser.
+--
+-- CREATE OR REPLACE resets function ACLs in Postgres, so grants are
+-- re-applied at the end to match production: {postgres, service_role} only
+-- (never `authenticated` — only the public wrapper functions are granted to
+-- authenticated callers, and those wrappers are unchanged by this
+-- migration).
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public._sync_focus_transactions_to_unified_sales_impl(p_restaurant_id uuid, p_start_date date, p_end_date date)
+ RETURNS integer
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+ SET statement_timeout TO '120s'
+AS $function$
+DECLARE
+  v_count          integer := 0;
+  v_row_count      integer;
+  v_sync_start     timestamptz := clock_timestamp();
+  v_store_id       text;
+  v_order          record;
+  v_order_id       text;
+  v_sale_time      time;
+  v_current_ids    text[];
+BEGIN
+  -- Fetch the store_id from the most-recently-created active connection.
+  -- Filtering by is_active prevents stale/deleted connections from being used.
+  -- ORDER BY + LIMIT 1 makes the query deterministic when multiple rows exist.
+  SELECT fc.store_id INTO v_store_id
+  FROM public.focus_connections fc
+  WHERE fc.restaurant_id = p_restaurant_id
+    AND fc.is_active = true
+  ORDER BY fc.created_at DESC
+  LIMIT 1;
+
+  -- If no active connection found, there is nothing to key external_order_id on.
+  -- Proceeding with a NULL store_id would produce orphan unified_sales rows
+  -- (pattern: focus-unknown-YYYYMMDD-{check_id}) that can never be re-synced.
+  IF v_store_id IS NULL THEN
+    RAISE EXCEPTION
+      'sync_focus_transactions_to_unified_sales: no active focus_connections row '
+      'found for restaurant %', p_restaurant_id;
+  END IF;
+
+  -- GUC flag: skip per-row triggers during bulk sync (transaction-local).
+  PERFORM set_config('app.skip_unified_sales_triggers', 'true', true);
+
+  -- ── Iterate per check (focus_order) ────────────────────────────────────
+  FOR v_order IN
+    SELECT fo.business_date, fo.focus_check_id,
+           fo.opened_at_local, fo.closed_at_local, fo.tax_amount
+    FROM public.focus_orders fo
+    WHERE fo.restaurant_id = p_restaurant_id
+      AND (p_start_date IS NULL OR fo.business_date >= p_start_date)
+      AND (p_end_date   IS NULL OR fo.business_date <= p_end_date)
+    ORDER BY fo.business_date, fo.focus_check_id
+  LOOP
+    v_order_id := 'focus-' || COALESCE(v_store_id, 'unknown')
+                  || '-' || to_char(v_order.business_date, 'YYYYMMDD')
+                  || '-' || v_order.focus_check_id;
+
+    -- Time-of-day for this check: prefer TimeOpened (when the customer
+    -- transacted — the busy-time signal), fall back to TimeClosed.
+    v_sale_time := COALESCE(
+      public._focus_parse_local_time(v_order.opened_at_local),
+      public._focus_parse_local_time(v_order.closed_at_local)
+    );
+
+    -- ── Step 1: Collect current external_item_ids (sale rows) ──────────────
+    SELECT ARRAY(
+      SELECT v_order_id || '__' || foi.item_key
+      FROM public.focus_order_items foi
+      WHERE foi.restaurant_id  = p_restaurant_id
+        AND foi.business_date  = v_order.business_date
+        AND foi.focus_check_id = v_order.focus_check_id
+        AND foi.price IS NOT NULL
+        AND foi.price != 0
+    ) INTO v_current_ids;
+
+    -- ── Step 2: DELETE orphan sale rows no longer in focus_order_items ─────
+    -- Only delete base (un-split) rows; parent_sale_id IS NULL guards user-
+    -- managed split/child rows from being silently removed on every sync.
+    DELETE FROM public.unified_sales us
+    WHERE us.restaurant_id     = p_restaurant_id
+      AND us.pos_system        = 'focus'
+      AND us.item_type         = 'sale'
+      AND us.sale_date         = v_order.business_date
+      AND us.external_order_id = v_order_id
+      AND us.parent_sale_id IS NULL
+      AND NOT (us.external_item_id = ANY(v_current_ids));
+
+    -- ── Step 3: UPSERT sale rows (one per priced item) ────────────────────
+    INSERT INTO public.unified_sales (
+      restaurant_id, pos_system,
+      external_order_id, external_item_id,
+      item_name, quantity, unit_price, total_price,
+      sale_date, sale_time, pos_category, item_type, synced_at
+    )
+    SELECT
+      foi.restaurant_id, 'focus',
+      v_order_id, v_order_id || '__' || foi.item_key,
+      foi.name, 1, foi.price, foi.price,
+      foi.business_date, v_sale_time, foi.report_group_id, 'sale', now()
+    FROM public.focus_order_items foi
+    WHERE foi.restaurant_id  = p_restaurant_id
+      AND foi.business_date  = v_order.business_date
+      AND foi.focus_check_id = v_order.focus_check_id
+      AND foi.price IS NOT NULL
+      AND foi.price != 0
+    ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
+      WHERE parent_sale_id IS NULL
+    DO UPDATE SET
+      item_name    = EXCLUDED.item_name,
+      unit_price   = EXCLUDED.unit_price,
+      total_price  = EXCLUDED.total_price,
+      sale_date    = EXCLUDED.sale_date,
+      sale_time    = EXCLUDED.sale_time,
+      pos_category = EXCLUDED.pos_category,
+      synced_at    = EXCLUDED.synced_at
+      -- category_id + is_categorized intentionally omitted →
+      -- preserves user-managed categorization on re-sync (design §4)
+    ;
+
+    GET DIAGNOSTICS v_row_count = ROW_COUNT;
+    v_count := v_count + v_row_count;
+
+    -- ── Step 4: UPSERT / DELETE discount offset rows ───────────────────────
+    -- Upsert items that have a non-zero discount.
+    -- Focus XML stores DiscountAmount as a negative value (e.g. -3.01).
+    -- Use != 0 (not > 0) so that negative amounts are also captured.
+    -- -ABS() normalises to negative regardless of stored sign.
+    INSERT INTO public.unified_sales (
+      restaurant_id, pos_system,
+      external_order_id, external_item_id,
+      item_name, quantity, unit_price, total_price,
+      sale_date, sale_time, item_type, adjustment_type, synced_at
+    )
+    SELECT
+      foi.restaurant_id, 'focus',
+      v_order_id, v_order_id || '__' || foi.item_key || '_discount',
+      'Discount - ' || COALESCE(foi.name, 'Item'), 1,
+      -ABS(foi.discount_amount), -ABS(foi.discount_amount),
+      foi.business_date, v_sale_time, 'discount', 'discount', now()
+    FROM public.focus_order_items foi
+    WHERE foi.restaurant_id  = p_restaurant_id
+      AND foi.business_date  = v_order.business_date
+      AND foi.focus_check_id = v_order.focus_check_id
+      AND foi.discount_amount != 0
+    ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
+      WHERE parent_sale_id IS NULL
+    DO UPDATE SET
+      item_name   = EXCLUDED.item_name,
+      unit_price  = EXCLUDED.unit_price,
+      total_price = EXCLUDED.total_price,
+      sale_date   = EXCLUDED.sale_date,
+      sale_time   = EXCLUDED.sale_time,
+      synced_at   = EXCLUDED.synced_at;
+
+    GET DIAGNOSTICS v_row_count = ROW_COUNT;
+    v_count := v_count + v_row_count;
+
+    -- Delete stale discount rows for items that no longer have a discount.
+    -- parent_sale_id IS NULL guards user-managed split rows.
+    DELETE FROM public.unified_sales us
+    WHERE us.restaurant_id     = p_restaurant_id
+      AND us.pos_system        = 'focus'
+      AND us.item_type         = 'discount'
+      AND us.sale_date         = v_order.business_date
+      AND us.external_order_id = v_order_id
+      AND us.parent_sale_id IS NULL
+      AND us.external_item_id NOT IN (
+        SELECT v_order_id || '__' || foi.item_key || '_discount'
+        FROM public.focus_order_items foi
+        WHERE foi.restaurant_id  = p_restaurant_id
+          AND foi.business_date  = v_order.business_date
+          AND foi.focus_check_id = v_order.focus_check_id
+          AND foi.discount_amount != 0
+      );
+
+    -- ── Step 5: UPSERT / DELETE tip offset rows ────────────────────────────
+    -- Upsert payments with a non-zero tip
+    INSERT INTO public.unified_sales (
+      restaurant_id, pos_system,
+      external_order_id, external_item_id,
+      item_name, quantity, unit_price, total_price,
+      sale_date, sale_time, item_type, adjustment_type, synced_at
+    )
+    SELECT
+      fp.restaurant_id, 'focus',
+      v_order_id, v_order_id || '_' || fp.payment_key || '_tip',
+      'Tip - ' || COALESCE(fp.name, 'Payment'), 1,
+      fp.tip, fp.tip,
+      fp.business_date, v_sale_time, 'tip', 'tip', now()
+    FROM public.focus_payments fp
+    WHERE fp.restaurant_id  = p_restaurant_id
+      AND fp.business_date  = v_order.business_date
+      AND fp.focus_check_id = v_order.focus_check_id
+      AND fp.tip != 0
+    ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
+      WHERE parent_sale_id IS NULL
+    DO UPDATE SET
+      item_name   = EXCLUDED.item_name,
+      unit_price  = EXCLUDED.unit_price,
+      total_price = EXCLUDED.total_price,
+      sale_date   = EXCLUDED.sale_date,
+      sale_time   = EXCLUDED.sale_time,
+      synced_at   = EXCLUDED.synced_at;
+
+    GET DIAGNOSTICS v_row_count = ROW_COUNT;
+    v_count := v_count + v_row_count;
+
+    -- Delete stale tip rows for payments that no longer have a tip.
+    -- parent_sale_id IS NULL guards user-managed split rows.
+    DELETE FROM public.unified_sales us
+    WHERE us.restaurant_id     = p_restaurant_id
+      AND us.pos_system        = 'focus'
+      AND us.item_type         = 'tip'
+      AND us.sale_date         = v_order.business_date
+      AND us.external_order_id = v_order_id
+      AND us.parent_sale_id IS NULL
+      AND us.external_item_id NOT IN (
+        SELECT v_order_id || '_' || fp.payment_key || '_tip'
+        FROM public.focus_payments fp
+        WHERE fp.restaurant_id  = p_restaurant_id
+          AND fp.business_date  = v_order.business_date
+          AND fp.focus_check_id = v_order.focus_check_id
+          AND fp.tip != 0
+      );
+
+    -- ── Step 6: UPSERT / DELETE tax offset row ─────────────────────────────
+    -- Tax is one row per order (SeatRecord.TaxTotal1..5 summed by the parser
+    -- into focus_orders.tax_amount) — NOT one row per item/payment like
+    -- discount/tip — so the delete below is a plain conditional delete keyed
+    -- off "this order's tax_amount is currently 0", not a NOT IN (subquery)
+    -- over a per-row source table. Do not change this to the multi-row
+    -- pattern; there is nothing to enumerate.
+    INSERT INTO public.unified_sales (
+      restaurant_id, pos_system,
+      external_order_id, external_item_id,
+      item_name, quantity, unit_price, total_price,
+      sale_date, sale_time, item_type, adjustment_type, synced_at
+    )
+    SELECT
+      p_restaurant_id, 'focus',
+      v_order_id, v_order_id || '_tax',
+      'Sales Tax', 1,
+      v_order.tax_amount, v_order.tax_amount,
+      v_order.business_date, v_sale_time, 'tax', 'tax', now()
+    WHERE v_order.tax_amount != 0
+    ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
+      WHERE parent_sale_id IS NULL
+    DO UPDATE SET
+      item_name   = EXCLUDED.item_name,
+      unit_price  = EXCLUDED.unit_price,
+      total_price = EXCLUDED.total_price,
+      sale_date   = EXCLUDED.sale_date,
+      sale_time   = EXCLUDED.sale_time,
+      synced_at   = EXCLUDED.synced_at;
+
+    GET DIAGNOSTICS v_row_count = ROW_COUNT;
+    v_count := v_count + v_row_count;
+
+    -- Delete the tax row for this order when it no longer has any tax.
+    -- parent_sale_id IS NULL guards user-managed split rows.
+    IF v_order.tax_amount = 0 THEN
+      DELETE FROM public.unified_sales us
+      WHERE us.restaurant_id     = p_restaurant_id
+        AND us.pos_system        = 'focus'
+        AND us.item_type         = 'tax'
+        AND us.sale_date         = v_order.business_date
+        AND us.external_order_id = v_order_id
+        AND us.external_item_id  = v_order_id || '_tax'
+        AND us.parent_sale_id IS NULL;
+    END IF;
+
+  END LOOP;  -- end per-check loop
+
+  -- Reset GUC flag to re-enable per-row triggers
+  PERFORM set_config('app.skip_unified_sales_triggers', 'false', true);
+
+  -- Batch-categorize uncategorized sale rows (authenticated callers only;
+  -- service-role callers defer to the apply-categorization-rules edge function)
+  PERFORM apply_rules_to_pos_sales_internal(p_restaurant_id, 10000);
+
+  -- Batch-aggregate daily totals for all dates touched in this sync
+  PERFORM public.aggregate_unified_sales_to_daily(p_restaurant_id, d.sale_date)
+  FROM (
+    SELECT DISTINCT sale_date
+    FROM public.unified_sales
+    WHERE restaurant_id = p_restaurant_id
+      AND pos_system    = 'focus'
+      AND synced_at    >= v_sync_start
+  ) d;
+
+  RETURN v_count;
+END;
+$function$;
+
+-- Re-apply grants (CREATE OR REPLACE resets ACLs in Postgres).
+REVOKE ALL ON FUNCTION public._sync_focus_transactions_to_unified_sales_impl(uuid, date, date) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public._sync_focus_transactions_to_unified_sales_impl(uuid, date, date) TO service_role;

--- a/supabase/migrations/20260710140000_focus_invalidate_datafeed_state_for_tax.sql
+++ b/supabase/migrations/20260710140000_focus_invalidate_datafeed_state_for_tax.sql
@@ -1,0 +1,26 @@
+-- Invalidate Focus datafeed fingerprints so historical tax backfills automatically.
+--
+-- Context: 20260710120000 added focus_orders.tax_amount and 20260710130000 made
+-- the sync RPC emit per-order tax rows. Tax is derived from SeatRecord.TaxTotal*
+-- during parse. But the bulk-cron sync (focusBulkSyncHandler) delta-skips days
+-- whose <Checks> XML is unchanged: computeChecksFingerprint matches the row in
+-- focus_datafeed_state and processDayTransactions returns `unchanged` BEFORE
+-- parsing or upserting. Because the raw feed for a closed day never changes, its
+-- fingerprint already matches — so those already-fingerprinted days would keep
+-- tax_amount = 0 and never emit tax rows on the normal production path.
+--
+-- The fingerprint's invariant ("same XML ⇒ same derived rows ⇒ safe to skip") is
+-- broken by this schema/logic change: the same XML now yields an additional tax
+-- row. Clearing the fingerprints re-establishes the invariant: the next bulk-cron
+-- ticks recompute fingerprints, re-parse each day (idempotent upserts), populate
+-- tax_amount, and emit tax rows — for every Focus restaurant, not just the ones
+-- reprocessed manually via a custom-range sync.
+--
+-- Safe + self-healing: the state store fails open (a missing row ⇒ reprocess), so
+-- deletion only triggers re-parsing. Cost is one-time and bounded by each cron
+-- run's per-restaurant day cap; fetched_at bookkeeping is re-established as days
+-- are reprocessed. The table is small (one row per restaurant/business_date).
+--
+-- Codex P1 (PR #600): "Invalidate fingerprints before depending on tax_amount."
+
+DELETE FROM public.focus_datafeed_state;

--- a/supabase/tests/46_focus_transactions_schema.sql
+++ b/supabase/tests/46_focus_transactions_schema.sql
@@ -19,10 +19,11 @@
 --   36:    order-level ON DELETE CASCADE (focus_order_items removed when parent order deleted)
 --   39:    focus_orders.tax_amount column exists
 --   40:    focus_orders.tax_amount defaults to 0 when omitted on INSERT
+--   41:    focus_orders.tax_amount rejects NULL (NOT NULL invariant)
 -- Migration: 20260710120000_focus_orders_tax_amount.sql
 
 BEGIN;
-SELECT plan(40);
+SELECT plan(41);
 
 -- ─────────────────────────────────────────────────────────────────────
 -- Setup
@@ -353,6 +354,17 @@ SELECT is(
       AND focus_check_id = 'CHK-TAX-DEFAULT'),
   0::numeric,
   'focus_orders.tax_amount defaults to 0 when omitted on INSERT'
+);
+
+-- 41: NOT NULL invariant — an explicit NULL must be rejected (a regression to
+-- nullable would otherwise pass the existence + default checks above).
+SELECT throws_ok(
+  $$INSERT INTO public.focus_orders
+      (restaurant_id, business_date, focus_check_id, total, tax_amount)
+    VALUES ('00000000-0000-0000-0001-f0c0aa000001', '2026-07-01', 'CHK-TAX-NULL', 10.00, NULL)$$,
+  '23502',
+  NULL,
+  'focus_orders.tax_amount is NOT NULL'
 );
 
 SELECT * FROM finish();

--- a/supabase/tests/46_focus_transactions_schema.sql
+++ b/supabase/tests/46_focus_transactions_schema.sql
@@ -17,9 +17,12 @@
 --   34:    focus_payments.payment_key not null
 --   35:    focus_payments.card_last4 CHECK rejects non-4-digit values (PCI boundary)
 --   36:    order-level ON DELETE CASCADE (focus_order_items removed when parent order deleted)
+--   39:    focus_orders.tax_amount column exists
+--   40:    focus_orders.tax_amount defaults to 0 when omitted on INSERT
+-- Migration: 20260710120000_focus_orders_tax_amount.sql
 
 BEGIN;
-SELECT plan(38);
+SELECT plan(40);
 
 -- ─────────────────────────────────────────────────────────────────────
 -- Setup
@@ -332,6 +335,24 @@ SELECT is(
       AND focus_check_id = 'CHK-FK-CASCADE'),
   0,
   'focus_order_items cascade-deleted when parent focus_order is deleted'
+);
+
+-- ─────────────────────────────────────────────────────────────────────
+-- 39-40: focus_orders.tax_amount column
+-- Migration: 20260710120000_focus_orders_tax_amount.sql
+-- ─────────────────────────────────────────────────────────────────────
+SELECT has_column('public', 'focus_orders', 'tax_amount', 'focus_orders.tax_amount exists');
+
+INSERT INTO public.focus_orders (restaurant_id, business_date, focus_check_id, total)
+VALUES ('00000000-0000-0000-0001-f0c0aa000001', '2026-07-01', 'CHK-TAX-DEFAULT', 10.00);
+
+SELECT is(
+  (SELECT tax_amount FROM public.focus_orders
+    WHERE restaurant_id = '00000000-0000-0000-0001-f0c0aa000001'
+      AND business_date = '2026-07-01'
+      AND focus_check_id = 'CHK-TAX-DEFAULT'),
+  0::numeric,
+  'focus_orders.tax_amount defaults to 0 when omitted on INSERT'
 );
 
 SELECT * FROM finish();

--- a/supabase/tests/47_focus_transactions_unified_sales.sql
+++ b/supabase/tests/47_focus_transactions_unified_sales.sql
@@ -4,13 +4,13 @@
 -- This RPC syncs focus_orders / focus_order_items / focus_payments →
 -- unified_sales, mirroring sync_toast_to_unified_sales.
 --
--- Note: focus_orders does NOT store an explicit tax_amount — the XML only
--- provides taxableSales (subtotal), not the computed tax. Tax offsets are
--- therefore omitted from this RPC (zero-value skipped per design §4).
--- Tip and discount offsets ARE available from focus_payments and
--- focus_order_items respectively.
+-- focus_orders.tax_amount (added by 20260710120000_focus_orders_tax_amount.sql)
+-- is the sum of SeatRecord.TaxTotal1..5 across all seats on the check,
+-- captured by the parser + persisted on upsert. Step 6 of this RPC (added by
+-- 20260710130000_focus_tax_unified_sales.sql) emits ONE tax offset row per
+-- order when tax_amount != 0, mirroring the tip/discount offset blocks.
 --
--- Test plan (21 tests):
+-- Test plan (24 tests):
 --
 --  1  sync_focus_transactions_to_unified_sales(uuid) exists
 --  2  sync_focus_transactions_to_unified_sales(uuid,date,date) exists
@@ -33,9 +33,12 @@
 -- 19  Service-role (auth.uid() NULL) can call impl without auth check
 -- 20  sync_all_focus_transactions_to_unified_sales() returns a row for the active connection
 -- 21  Date-range overload only syncs rows within the given dates
+-- 22  Tax offset row created for order with tax_amount=5.55 (check 42)
+-- 23  Tax row external_item_id = <order_id>_tax
+-- 24  Tax row adjustment_type = 'tax'
 
 BEGIN;
-SELECT plan(21);
+SELECT plan(24);
 
 -- ─────────────────────────────────────────────────────────────────────
 -- Setup: disable RLS so we can insert test rows freely
@@ -94,20 +97,21 @@ ON CONFLICT (restaurant_id) DO UPDATE SET store_id = 'GUID-TEST-STORE';
 -- ── focus_orders: one check on 2026-06-15 ─────────────────────────────
 -- Check 42 with $12.00 total, $1.20 taxable_sales proxy (we'll use
 -- focus_order_items prices for sale rows; focus_orders.total for tax proxy)
+-- tax_amount=5.55 exercises the Step 6 tax offset row (tests 22-23).
 INSERT INTO public.focus_orders (
   id, restaurant_id, business_date, focus_check_id,
   opened_at_local, closed_at_local,
   order_type_id, revenue_center_id, guests,
-  total, discount_total, taxable_sales
+  total, discount_total, taxable_sales, tax_amount
 ) VALUES (
   '00000000-0000-0000-0000-f0c100000031',
   '00000000-0000-0000-0000-f0c100000011',
   '2026-06-15', '42',
   '2026-06-15T10:00:00', '2026-06-15T10:15:00',
   '1', 'RC1', 2,
-  12.00, 0.50, 11.00
+  12.00, 0.50, 11.00, 5.55
 )
-ON CONFLICT ON CONSTRAINT focus_orders_unique DO UPDATE SET total = 12.00;
+ON CONFLICT ON CONSTRAINT focus_orders_unique DO UPDATE SET total = 12.00, tax_amount = 5.55;
 
 -- ── focus_order_items: 3 rows ──────────────────────────────────────────
 -- Item A: priced, category 'Waffle'
@@ -457,6 +461,42 @@ SELECT ok(
      AND item_type = 'sale'
      AND sale_date = '2026-06-14') >= 1,
   'Date-range overload creates rows only for 2026-06-14'
+);
+
+-- ─────────────────────────────────────────────────────────────────────
+-- Test 22-23: Step 6 tax offset row (check 42, tax_amount = 5.55)
+-- ─────────────────────────────────────────────────────────────────────
+SELECT is(
+  (SELECT total_price FROM public.unified_sales
+   WHERE restaurant_id = '00000000-0000-0000-0000-f0c100000011'
+     AND pos_system = 'focus'
+     AND item_type = 'tax'
+     AND external_order_id = 'focus-GUID-TEST-STORE-20260615-42'
+     AND sale_date = '2026-06-15'),
+  5.55::numeric,
+  'Tax offset row created with tax_amount=5.55 for check 42'
+);
+
+SELECT is(
+  (SELECT external_item_id FROM public.unified_sales
+   WHERE restaurant_id = '00000000-0000-0000-0000-f0c100000011'
+     AND pos_system = 'focus'
+     AND item_type = 'tax'
+     AND external_order_id = 'focus-GUID-TEST-STORE-20260615-42'
+     AND sale_date = '2026-06-15'),
+  'focus-GUID-TEST-STORE-20260615-42_tax',
+  'Tax row external_item_id = <order_id>_tax'
+);
+
+SELECT is(
+  (SELECT adjustment_type FROM public.unified_sales
+   WHERE restaurant_id = '00000000-0000-0000-0000-f0c100000011'
+     AND pos_system = 'focus'
+     AND item_type = 'tax'
+     AND external_order_id = 'focus-GUID-TEST-STORE-20260615-42'
+     AND sale_date = '2026-06-15'),
+  'tax',
+  'Tax row adjustment_type = ''tax'''
 );
 
 SELECT * FROM finish();

--- a/supabase/tests/47_focus_transactions_unified_sales.sql
+++ b/supabase/tests/47_focus_transactions_unified_sales.sql
@@ -10,7 +10,7 @@
 -- 20260710130000_focus_tax_unified_sales.sql) emits ONE tax offset row per
 -- order when tax_amount != 0, mirroring the tip/discount offset blocks.
 --
--- Test plan (24 tests):
+-- Test plan (28 tests):
 --
 --  1  sync_focus_transactions_to_unified_sales(uuid) exists
 --  2  sync_focus_transactions_to_unified_sales(uuid,date,date) exists
@@ -37,11 +37,12 @@
 -- 23  Tax row external_item_id = <order_id>_tax
 -- 24  Tax row adjustment_type = 'tax'
 -- 25  Order with tax_amount=0 from the start emits no tax row (check 10)
--- 26  Re-sync after tax_amount is zeroed out deletes the previously-created tax row (check 42)
--- 27  Zeroed-tax re-sync leaves the order's other rows (sale/tip/discount) untouched
+-- 26  Check 10's persisted focus_orders.tax_amount is 0 (default, guards test 25)
+-- 27  Re-sync after tax_amount is zeroed out deletes the previously-created tax row (check 42)
+-- 28  Zeroed-tax re-sync leaves the order's 5 non-tax rows intact by identity
 
 BEGIN;
-SELECT plan(27);
+SELECT plan(28);
 
 -- ─────────────────────────────────────────────────────────────────────
 -- Setup: disable RLS so we can insert test rows freely
@@ -517,8 +518,21 @@ SELECT is(
   'Order with tax_amount=0 from the start (check 10) emits no tax row'
 );
 
+-- Test 26: guard for Test 25 — prove check 10's persisted tax_amount is
+-- literally 0 (the column DEFAULT), not NULL. Without this, a regression that
+-- made tax_amount nullable would still satisfy Test 25 (RPC emits rows only
+-- when tax_amount != 0, and NULL != 0 is NULL/false), masking the change.
+SELECT is(
+  (SELECT tax_amount FROM public.focus_orders
+    WHERE restaurant_id = '00000000-0000-0000-0000-f0c100000011'
+      AND business_date = '2026-06-14'
+      AND focus_check_id = '10'),
+  0::numeric,
+  'Check 10 persisted focus_orders.tax_amount is 0 (default, not NULL)'
+);
+
 -- ─────────────────────────────────────────────────────────────────────
--- Test 26-27: Zeroing out tax_amount on re-sync deletes the previously
+-- Test 27-28: Zeroing out tax_amount on re-sync deletes the previously
 -- created tax row for check 42, and leaves its other row kinds untouched.
 -- ─────────────────────────────────────────────────────────────────────
 UPDATE public.focus_orders
@@ -544,14 +558,22 @@ SELECT is(
   'Re-sync after tax_amount zeroed out deletes the previously-created tax row (check 42)'
 );
 
-SELECT is(
-  (SELECT COUNT(*)::integer FROM public.unified_sales
-   WHERE restaurant_id = '00000000-0000-0000-0000-f0c100000011'
-     AND pos_system = 'focus'
-     AND external_order_id = 'focus-GUID-TEST-STORE-20260615-42'
-     AND item_type IN ('sale', 'tip', 'discount')),
-  5,
-  'Zeroed-tax re-sync leaves the order''s other rows (3 sale + 1 tip + 1 discount) untouched'
+-- Assert by identity (not just count): the exact set of non-tax rows must be
+-- unchanged. A bare count would still pass if the re-sync deleted one row and
+-- recreated a different one; bag_eq pins each external_item_id + item_type.
+SELECT bag_eq(
+  $$SELECT external_item_id, item_type FROM public.unified_sales
+     WHERE restaurant_id = '00000000-0000-0000-0000-f0c100000011'
+       AND pos_system = 'focus'
+       AND external_order_id = 'focus-GUID-TEST-STORE-20260615-42'
+       AND item_type IN ('sale', 'tip', 'discount')$$,
+  $$VALUES
+     ('focus-GUID-TEST-STORE-20260615-42__IK-A',          'sale'),
+     ('focus-GUID-TEST-STORE-20260615-42__IK-B',          'sale'),
+     ('focus-GUID-TEST-STORE-20260615-42__IK-D',          'sale'),
+     ('focus-GUID-TEST-STORE-20260615-42__IK-D_discount', 'discount'),
+     ('focus-GUID-TEST-STORE-20260615-42_PK-1_tip',       'tip')$$,
+  'Zeroed-tax re-sync leaves the order''s 5 non-tax rows intact by identity (3 sale + 1 tip + 1 discount)'
 );
 
 SELECT * FROM finish();

--- a/supabase/tests/47_focus_transactions_unified_sales.sql
+++ b/supabase/tests/47_focus_transactions_unified_sales.sql
@@ -36,9 +36,12 @@
 -- 22  Tax offset row created for order with tax_amount=5.55 (check 42)
 -- 23  Tax row external_item_id = <order_id>_tax
 -- 24  Tax row adjustment_type = 'tax'
+-- 25  Order with tax_amount=0 from the start emits no tax row (check 10)
+-- 26  Re-sync after tax_amount is zeroed out deletes the previously-created tax row (check 42)
+-- 27  Zeroed-tax re-sync leaves the order's other rows (sale/tip/discount) untouched
 
 BEGIN;
-SELECT plan(24);
+SELECT plan(27);
 
 -- ─────────────────────────────────────────────────────────────────────
 -- Setup: disable RLS so we can insert test rows freely
@@ -497,6 +500,58 @@ SELECT is(
      AND sale_date = '2026-06-15'),
   'tax',
   'Tax row adjustment_type = ''tax'''
+);
+
+-- ─────────────────────────────────────────────────────────────────────
+-- Test 25: Order with tax_amount=0 from the start emits no tax row.
+-- Check 10 (2026-06-14, synced above in Test 21) was inserted without a
+-- tax_amount, so it defaults to the column's DEFAULT 0.
+-- ─────────────────────────────────────────────────────────────────────
+SELECT is(
+  (SELECT COUNT(*)::integer FROM public.unified_sales
+   WHERE restaurant_id = '00000000-0000-0000-0000-f0c100000011'
+     AND pos_system = 'focus'
+     AND item_type = 'tax'
+     AND external_order_id = 'focus-GUID-TEST-STORE-20260614-10'),
+  0,
+  'Order with tax_amount=0 from the start (check 10) emits no tax row'
+);
+
+-- ─────────────────────────────────────────────────────────────────────
+-- Test 26-27: Zeroing out tax_amount on re-sync deletes the previously
+-- created tax row for check 42, and leaves its other row kinds untouched.
+-- ─────────────────────────────────────────────────────────────────────
+UPDATE public.focus_orders
+SET tax_amount = 0
+WHERE restaurant_id = '00000000-0000-0000-0000-f0c100000011'
+  AND business_date = '2026-06-15'
+  AND focus_check_id = '42';
+
+SET LOCAL "request.jwt.claims" TO '{"sub": "00000000-0000-0000-0000-f0c100000001"}';
+SELECT sync_focus_transactions_to_unified_sales(
+  '00000000-0000-0000-0000-f0c100000011'::uuid,
+  '2026-06-15'::date,
+  '2026-06-15'::date
+);
+
+SELECT is(
+  (SELECT COUNT(*)::integer FROM public.unified_sales
+   WHERE restaurant_id = '00000000-0000-0000-0000-f0c100000011'
+     AND pos_system = 'focus'
+     AND item_type = 'tax'
+     AND external_order_id = 'focus-GUID-TEST-STORE-20260615-42'),
+  0,
+  'Re-sync after tax_amount zeroed out deletes the previously-created tax row (check 42)'
+);
+
+SELECT is(
+  (SELECT COUNT(*)::integer FROM public.unified_sales
+   WHERE restaurant_id = '00000000-0000-0000-0000-f0c100000011'
+     AND pos_system = 'focus'
+     AND external_order_id = 'focus-GUID-TEST-STORE-20260615-42'
+     AND item_type IN ('sale', 'tip', 'discount')),
+  5,
+  'Zeroed-tax re-sync leaves the order''s other rows (3 sale + 1 tip + 1 discount) untouched'
 );
 
 SELECT * FROM finish();

--- a/tests/unit/focusDatafeedParser.test.ts
+++ b/tests/unit/focusDatafeedParser.test.ts
@@ -35,6 +35,43 @@ describe('parseFocusDatafeed', () => {
     expect(c.openedAt).toContain('06/27/2026');
   });
 
+  it('sums SeatRecord.TaxTotal1..5 across all seats into taxAmount', () => {
+    const checks = parseFocusDatafeed(xml).checks;
+    const c1 = checks.find((c) => c.checkId === '1')!;
+    const c2 = checks.find((c) => c.checkId === '2')!;
+    // check 1: TaxTotal1 3.30 + TaxTotal2 0.16
+    expect(c1.taxAmount).toBe(3.46);
+    // check 2: TaxTotal1 0.33
+    expect(c2.taxAmount).toBe(0.33);
+  });
+
+  it('sums TaxTotal1..5 across multiple seats on the same check', () => {
+    const x =
+      '<DailyData><Checks><Check><CheckRecord><ID>10</ID><Total>10.00</Total></CheckRecord>' +
+      '<Seats>' +
+      '<Seat><SeatRecord><TaxTotal1>1.00</TaxTotal1><TaxTotal2>0.50</TaxTotal2></SeatRecord></Seat>' +
+      '<Seat><SeatRecord><TaxTotal1>2.25</TaxTotal1></SeatRecord></Seat>' +
+      '</Seats></Check></Checks></DailyData>';
+    const c = parseFocusDatafeed(x).checks[0];
+    expect(c.taxAmount).toBe(3.75);
+  });
+
+  it('defaults taxAmount to 0 when SeatRecord/TaxTotal fields are absent', () => {
+    const x =
+      '<DailyData><Checks><Check><CheckRecord><ID>11</ID><Total>5.00</Total></CheckRecord>' +
+      '<Seats><Seat><CheckItemRecord><Key>1</Key></CheckItemRecord></Seat></Seats></Check></Checks></DailyData>';
+    const c = parseFocusDatafeed(x).checks[0];
+    expect(c.taxAmount).toBe(0);
+  });
+
+  it('sums negative TaxTotal values for refund checks', () => {
+    const x =
+      '<DailyData><Checks><Check><CheckRecord><ID>12</ID><Total>-5.00</Total></CheckRecord>' +
+      '<Seats><Seat><SeatRecord><TaxTotal1>-0.33</TaxTotal1></SeatRecord></Seat></Seats></Check></Checks></DailyData>';
+    const c = parseFocusDatafeed(x).checks[0];
+    expect(c.taxAmount).toBe(-0.33);
+  });
+
   it('extracts priced line items and their category', () => {
     const c = parseFocusDatafeed(xml).checks.find((c) => c.checkId === '1')!;
     const priced = c.items.filter((i) => i.price != null);

--- a/tests/unit/focusTransactionSyncHandler.test.ts
+++ b/tests/unit/focusTransactionSyncHandler.test.ts
@@ -50,7 +50,7 @@ const SAMPLE_XML_ONE_CHECK = `<DailyData><Checks><Check>
 <RevenueCenterID>1</RevenueCenterID><Guests>2</Guests><Total>12.50</Total>
 <DiscountTotalAmount>0</DiscountTotalAmount><TaxableSales1>11.37</TaxableSales1>
 </CheckRecord><Seats><Seat>
-<SeatRecord><Key>5</Key></SeatRecord>
+<SeatRecord><Key>5</Key><TaxTotal1>1.13</TaxTotal1></SeatRecord>
 <CheckItemRecord>
   <SeatKey>5</SeatKey><Key>3</Key><RecordNumber>100</RecordNumber>
   <ID>Scoop</ID><GuestCheckName>Scoop Single</GuestCheckName>
@@ -223,6 +223,14 @@ describe('processDayTransactions', () => {
     await processDayTransactions(deps, MOCK_CONFIG, BUSINESS_DATE);
     const row = mocks.ordersUpsert.mock.calls[0][0];
     expect(row.total).toBe(12.50);
+  });
+
+  it('includes tax_amount (from check.taxAmount) in the focus_orders upsert payload', async () => {
+    const { deps, mocks } = makeDeps({});
+    await processDayTransactions(deps, MOCK_CONFIG, BUSINESS_DATE);
+    const row = mocks.ordersUpsert.mock.calls[0][0];
+    // SAMPLE_XML_ONE_CHECK seat TaxTotal1 = 1.13 → FocusCheck.taxAmount = 1.13
+    expect(row.tax_amount).toBe(1.13);
   });
 
   it('uses ON CONFLICT on the correct columns for focus_orders', async () => {


### PR DESCRIPTION
## Summary
- **Captures Focus POS tax**, which the transaction-feed path silently dropped. Focus sales previously produced `sale`/`discount`/`tip` rows in `unified_sales` but **no tax**, so P&L showed $0 tax for Focus restaurants.
- Tax now lands as a **per-order `Sales Tax` adjustment row** (`item_type='tax'`, `adjustment_type='tax'`, `external_item_id=<order>_tax`), matching the Square/Toast/Clover convention. The read side already counts `item_type='tax'` (`KNOWN_PASS_THROUGH_TYPES`), so P&L picks it up with no consumer changes.

### Three layers
1. **Parser** (`focusDatafeedParser.ts`): sum `SeatRecord.TaxTotal1..5` across a check's seats into new `FocusCheck.taxAmount` (verified against `focus-datafeed-sample.xml`: seat `Subtotal` + `TaxTotal*` = `Total`).
2. **Schema**: `focus_orders.tax_amount numeric NOT NULL DEFAULT 0`, persisted in `focusTransactionSyncHandler.upsertOrder`.
3. **RPC**: Step 6 tax offset row in `_sync_focus_transactions_to_unified_sales_impl` (rebuilt from the live prod body to avoid drift; grants preserved; verified ungated). Also fixes a latent bug where the daily-aggregate step keyed off `synced_at` skipped DELETE-only dates → stale daily totals; it now unions with the processed `focus_orders` date range.

Design doc: `docs/superpowers/specs/2026-07-10-focus-tax-capture-design.md`

## Test plan
- **Unit** (`focusDatafeedParser.test.ts`): TaxTotal sum, multi-seat, missing SeatRecord→0, negative (refund).
- **Unit** (`focusTransactionSyncHandler.test.ts`): `tax_amount` persisted on upsert.
- **pgTAP** `46_` (41 tests): column exists, defaults to 0, NOT NULL rejects NULL.
- **pgTAP** `47_` (28 tests): tax row emitted with correct amount/key/type; deleted when tax→0; never created for zero-tax orders; non-tax rows preserved by identity on re-sync.
- Local: `npm run test:db` → **1662/1662**; `npm run typecheck` clean. Full unit suite + build verified green during build (only 1 pre-existing unrelated failure, `AvailableShiftsPage.tradeCard.test.tsx`).

## Post-merge backfill (manual)
Tax exists only in the live datafeed (not persisted), so existing `focus_orders` rows have `tax_amount=0` until re-synced. After deploy, run two custom-range Focus syncs (≤14-day cap) for Wetzel's–Cold Stone–Alamo Ranch (`7c0c76e3-…`): Jun 24–Jul 7 and Jul 8–present, then verify Cold Stone RC June tax ≈ **$555.55**. Custom-range syncs don't wire the delta-skip `stateStore`, so re-runs safely re-parse.

## Known limitation (pre-existing, out of scope — follow-up filed)
Fully-voided checks (deleted from `focus_orders`) leave orphaned `unified_sales` rows because the sync RPC only iterates existing orders. This predates this PR and affects `sale`/`tip`/`discount` identically; tax behaves consistently. A pre-loop orphan sweep across all row types is tracked as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
