### PR TITLE
test(scheduling): fix pre-existing red Unit/E2E tests on main (StaffingOverlay #598 + tradeCard date-rot)

### DIFF
--- a/tests/e2e/staffing-suggestions.spec.ts
+++ b/tests/e2e/staffing-suggestions.spec.ts
@@ -1,7 +1,18 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import { signUpAndCreateRestaurant, exposeSupabaseHelpers, generateTestUser } from '../helpers/e2e-supabase';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Since #598 ("default staffing suggestions panel to collapsed"), the Staffing
+ * Suggestions panel starts collapsed and its content (empty-state CTA, suggested
+ * shifts, apply dialog) is unmounted until opened. Expand it before asserting.
+ */
+async function expandStaffingPanel(page: Page): Promise<void> {
+  await page
+    .getByRole('button', { name: /expand staffing suggestions/i })
+    .click({ timeout: 10000 });
+}
 
 /**
  * E2E: Staffing suggestions — empty state + seeded-sales → apply flow.
@@ -47,8 +58,9 @@ test.describe('Staffing suggestions', () => {
     await page.getByRole('tab', { name: /planner/i }).click();
     await expect(page.getByText('Ana Costa')).toBeVisible({ timeout: 10000 });
 
-    // The Staffing Overlay is default-expanded (Task 7).
-    // With no sales data, the empty-state CTA should be visible.
+    // The Staffing Overlay defaults to collapsed since #598 — expand it first.
+    // With no sales data, the empty-state CTA should then be visible.
+    await expandStaffingPanel(page);
     await expect(
       page.getByRole('link', { name: /connect your pos/i }),
     ).toBeVisible({ timeout: 10000 });
@@ -120,6 +132,7 @@ test.describe('Staffing suggestions', () => {
 
     await page.getByRole('tab', { name: /planner/i }).click();
     await expect(page.getByText('Marco Rivera')).toBeVisible({ timeout: 10000 });
+    await expandStaffingPanel(page);
 
     // Wait for the staffing overlay to compute shift blocks and show the Suggested shifts section.
     // This proves the sales data was picked up and consolidated into at least one block.
@@ -215,6 +228,7 @@ test.describe('Staffing suggestions', () => {
 
     await page.getByRole('tab', { name: /planner/i }).click();
     await expect(page.getByText('Kim Park')).toBeVisible({ timeout: 10000 });
+    await expandStaffingPanel(page);
 
     await expect(page.getByText('Suggested shifts', { exact: true })).toBeVisible({ timeout: 15000 });
     await page.getByRole('button', { name: /apply suggested shifts/i }).click();

--- a/tests/unit/AvailableShiftsPage.tradeCard.test.tsx
+++ b/tests/unit/AvailableShiftsPage.tradeCard.test.tsx
@@ -92,20 +92,31 @@ vi.mock('@/hooks/useCurrentEmployee', () => ({
   })),
 }));
 
+// Future-relative fixture dates so the accept/claim buttons aren't disabled by
+// the isPast guard (shiftStart < now). Hardcoded calendar dates silently disable
+// the button once the date passes, which broke the in-flight-label test (8) the
+// day the calendar rolled past 2026-07-10. vi.hoisted so the values exist when
+// the hoisted vi.mock factory below runs.
+const { DAY_A, DAY_B } = vi.hoisted(() => {
+  const iso = (offsetDays: number) =>
+    new Date(Date.now() + offsetDays * 86_400_000).toISOString().slice(0, 10);
+  return { DAY_A: iso(7), DAY_B: iso(8) };
+});
+
 vi.mock('@/hooks/useAvailableShifts', () => ({
   useAvailableShifts: vi.fn(() => ({
     items: [
       {
         key: 'trade-mismatch',
         type: 'trade',
-        date: new Date('2026-07-10'),
+        date: new Date(DAY_A),
         trade: {
           id: 'trade-mismatch',
           status: 'open',
           offered_shift: {
             id: 'shift-1',
-            start_time: '2026-07-10T14:00:00Z',
-            end_time: '2026-07-10T20:00:00Z',
+            start_time: `${DAY_A}T14:00:00Z`,
+            end_time: `${DAY_A}T20:00:00Z`,
             position: 'Bartender',
             break_duration: 0,
           },
@@ -123,14 +134,14 @@ vi.mock('@/hooks/useAvailableShifts', () => ({
       {
         key: 'trade-same-area',
         type: 'trade',
-        date: new Date('2026-07-11'),
+        date: new Date(DAY_B),
         trade: {
           id: 'trade-same-area',
           status: 'open',
           offered_shift: {
             id: 'shift-2',
-            start_time: '2026-07-11T14:00:00Z',
-            end_time: '2026-07-11T20:00:00Z',
+            start_time: `${DAY_B}T14:00:00Z`,
+            end_time: `${DAY_B}T20:00:00Z`,
             position: 'Server',
             break_duration: 0,
           },

--- a/tests/unit/StaffingOverlay.deadends.test.tsx
+++ b/tests/unit/StaffingOverlay.deadends.test.tsx
@@ -92,6 +92,12 @@ const wrapper = ({ children }: { children: React.ReactNode }) => {
   );
 };
 
+// Since #598 the panel defaults to collapsed (isExpanded=false); its
+// CollapsibleContent (empty state, explainer, retry, legend) is unmounted until
+// opened. Expand it first by clicking the trigger (aria-label "Expand …").
+const expandPanel = () =>
+  fireEvent.click(screen.getByRole('button', { name: /expand staffing suggestions/i }));
+
 describe('<StaffingOverlay> dead-end fixes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -118,6 +124,7 @@ describe('<StaffingOverlay> dead-end fixes', () => {
     });
 
     render(<StaffingOverlay restaurantId="r1" weekDays={WEEK_DAYS} />, { wrapper });
+    expandPanel();
 
     expect(
       screen.getByText(/staffing suggestions need sales history/i),
@@ -134,6 +141,7 @@ describe('<StaffingOverlay> dead-end fixes', () => {
     });
 
     render(<StaffingOverlay restaurantId="r1" weekDays={WEEK_DAYS} />, { wrapper });
+    expandPanel();
 
     const link = screen.getByRole('link', { name: /connect your pos/i });
     expect(link).toBeTruthy();
@@ -150,6 +158,7 @@ describe('<StaffingOverlay> dead-end fixes', () => {
     });
 
     render(<StaffingOverlay restaurantId="r1" weekDays={WEEK_DAYS} />, { wrapper });
+    expandPanel();
 
     expect(screen.getByText(/how this works/i)).toBeTruthy();
   });
@@ -157,6 +166,7 @@ describe('<StaffingOverlay> dead-end fixes', () => {
   // ── Test 4: "How it works" explainer also renders with sales data ────────────
   it('renders the "How it works" explainer when hasSalesData is true', () => {
     render(<StaffingOverlay restaurantId="r1" weekDays={WEEK_DAYS} />, { wrapper });
+    expandPanel();
 
     expect(screen.getByText(/how this works/i)).toBeTruthy();
   });
@@ -176,6 +186,7 @@ describe('<StaffingOverlay> dead-end fixes', () => {
     });
 
     render(<StaffingOverlay restaurantId="r1" weekDays={WEEK_DAYS} />, { wrapper });
+    expandPanel();
 
     expect(screen.getByRole('button', { name: /retry/i })).toBeTruthy();
   });
@@ -196,6 +207,7 @@ describe('<StaffingOverlay> dead-end fixes', () => {
     });
 
     render(<StaffingOverlay restaurantId="r1" weekDays={WEEK_DAYS} />, { wrapper });
+    expandPanel();
 
     fireEvent.click(screen.getByRole('button', { name: /retry/i }));
     expect(refetchMock).toHaveBeenCalledOnce();
@@ -204,6 +216,7 @@ describe('<StaffingOverlay> dead-end fixes', () => {
   // ── Test 7: Legend renders on mobile (no hidden md:flex class) ───────────────
   it('renders the On-target/Over-budget legend without hiding it on mobile', () => {
     render(<StaffingOverlay restaurantId="r1" weekDays={WEEK_DAYS} />, { wrapper });
+    expandPanel();
 
     // The legend container should NOT have "hidden" in its className
     const onTargetText = screen.getByText('On target');

--- a/tests/unit/StaffingOverlay.wiring.test.tsx
+++ b/tests/unit/StaffingOverlay.wiring.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
@@ -107,6 +107,12 @@ const FAKE_SALES = Array.from({ length: 10 }, (_, i) => ({
   total_price: '500',
 }));
 
+// Since #598 the panel defaults to collapsed (isExpanded=false), so its
+// CollapsibleContent is unmounted until opened. Tests that assert inner content
+// must expand it first by clicking the trigger (aria-label "Expand …").
+const expandPanel = () =>
+  fireEvent.click(screen.getByRole('button', { name: /expand staffing suggestions/i }));
+
 describe('<StaffingOverlay> wiring', () => {
   beforeEach(() => {
     suggestedShiftsProps.length = 0;
@@ -125,16 +131,16 @@ describe('<StaffingOverlay> wiring', () => {
     });
   });
 
-  it('renders with the CollapsibleContent open by default (isExpanded = true)', () => {
+  it('renders collapsed by default (isExpanded = false) — #598', () => {
     render(
       <StaffingOverlay restaurantId="r1" weekDays={WEEK_DAYS} />,
       { wrapper },
     );
-    // CollapsibleTrigger button shows "Collapse" aria-label when expanded
-    const trigger = screen.getByRole('button', { name: /collapse staffing suggestions/i });
+    // Since #598 the panel defaults to collapsed: the trigger shows the
+    // "Expand" aria-label and aria-expanded is false until the user opens it.
+    const trigger = screen.getByRole('button', { name: /expand staffing suggestions/i });
     expect(trigger).toBeTruthy();
-    // The collapsible container should be open
-    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
   });
 
   it('renders SuggestedShifts when hasSalesData is true', () => {
@@ -142,6 +148,7 @@ describe('<StaffingOverlay> wiring', () => {
       <StaffingOverlay restaurantId="r1" weekDays={WEEK_DAYS} />,
       { wrapper },
     );
+    expandPanel();
     // With hasSalesData=true, SuggestedShifts stub should mount
     expect(screen.getByTestId('suggested-shifts')).toBeTruthy();
   });
@@ -151,6 +158,7 @@ describe('<StaffingOverlay> wiring', () => {
       <StaffingOverlay restaurantId="r1" weekDays={WEEK_DAYS} />,
       { wrapper },
     );
+    expandPanel();
     // SuggestedShifts is rendered and received a blocks prop (array, possibly empty
     // since FAKE_SALES are all the same DOW but the mechanism is wired)
     const el = screen.getByTestId('suggested-shifts');
@@ -174,6 +182,8 @@ describe('<StaffingOverlay> wiring', () => {
       <StaffingOverlay restaurantId="r1" weekDays={WEEK_DAYS} />,
       { wrapper },
     );
+    // Expand first so this asserts the hasSalesData gating, not the collapse.
+    expandPanel();
     expect(screen.queryByTestId('suggested-shifts')).toBeNull();
   });
 
@@ -182,6 +192,7 @@ describe('<StaffingOverlay> wiring', () => {
       <StaffingOverlay restaurantId="my-restaurant-id" weekDays={WEEK_DAYS} />,
       { wrapper },
     );
+    expandPanel();
     expect(suggestedShiftsProps.some((p) => p.restaurantId === 'my-restaurant-id')).toBe(true);
   });
 
@@ -190,6 +201,7 @@ describe('<StaffingOverlay> wiring', () => {
       <StaffingOverlay restaurantId="r1" weekDays={WEEK_DAYS} />,
       { wrapper },
     );
+    expandPanel();
     expect(screen.getByTestId('config-panel')).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary
Fixes the `main` regression from **#598** ("default staffing suggestions panel to collapsed") that turned **Unit Tests** and **E2E Shard 4** red on every open PR.

#598 flipped `StaffingOverlay`'s `useState(true)` → `useState(false)`, so the panel now defaults to **collapsed** and Radix unmounts its `CollapsibleContent` until opened. But the tests from #525/#529 still assert the panel is expanded and its content (empty-state CTA, "How this works", Retry, "On target" legend, suggested shifts) is visible — so they fail.

**This PR fixes the tests only** — the collapsed-by-default behavior from #598 is intended and unchanged.

## Changes
- `StaffingOverlay.deadends` + `wiring` unit tests: expand the panel (click the "Expand staffing suggestions" trigger) before asserting inner content. The wiring "default state" test now asserts **collapsed** (`aria-expanded='false'`).
- `staffing-suggestions` E2E: expand the panel before asserting the empty-state CTA / suggested shifts, via a shared `expandStaffingPanel()` helper.

## Why separate PR
It's a `main` regression that blocks **all** open PRs (#600, #601, #599, #597) via the CI merge-with-main. Landing it here unblocks everyone; keeps it out of unrelated feature PRs.

## Test plan
- `npm run typecheck` clean; eslint clean on changed files.
- `TZ=UTC npx vitest run` StaffingOverlay unit suite → **23/23 pass** (reproduced the CI failure locally against #598 first: 12 failed → now green).
- E2E verified by CI (needs full stack + browsers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Experience**
  * Staffing Suggestions now opens in a collapsed state, keeping the interface more compact by default.
  * Users can expand the panel to view suggested shifts, empty-state guidance, explanations, retry actions, and related settings.
* **Tests**
  * Updated coverage to verify expanded and collapsed states, mobile behavior, trade actions, and accessibility labels remain consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->