### PR TITLE
fix(time-clock): count overnight shifts in the Manual timeline view

### DIFF
--- a/docs/superpowers/plans/2026-07-11-manual-timeline-overnight.md
+++ b/docs/superpowers/plans/2026-07-11-manual-timeline-overnight.md
@@ -1,0 +1,291 @@
+# Manual Timeline Overnight-Shift Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** The Time Clock **Manual** view must count an overnight shift (clock out next day) on its clock-in day and render it correctly, matching the Cards view and the page header total.
+
+**Architecture:** Extract the timeline block-building into a pure, tested `buildTimelineBlocks(punches, date)` that pairs across midnight and attributes by clock-in day (reusing `isWithinWindow`); feed `ManualTimelineEditor` the buffered punch set; clip + tag the cross-midnight bar and make it view-only on the canvas.
+
+**Tech Stack:** React + TS, date-fns, Vitest, Playwright. Design: `docs/superpowers/specs/2026-07-11-manual-timeline-overnight-design.md`.
+
+**Scope:** `src/components/time-tracking/ManualTimelineEditor.tsx`, one prop in `src/pages/TimePunchesManager.tsx`, new `src/utils/manualTimelineBlocks.ts`. No other surface (page total/Cards/payroll already correct via #599).
+
+---
+
+## Task 1: Extract `buildTimelineBlocks` pure util + tests
+
+**Files:**
+- Create: `src/utils/manualTimelineBlocks.ts`
+- Test: `tests/unit/manualTimelineBlocks.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/unit/manualTimelineBlocks.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest';
+import { buildTimelineBlocks } from '@/utils/manualTimelineBlocks';
+import type { TimePunch } from '@/types/timeTracking';
+
+const p = (type: string, iso: string, id = `${type}-${iso}`): TimePunch => ({
+  id, employee_id: 'e1', restaurant_id: 'r1',
+  punch_type: type as TimePunch['punch_type'], punch_time: iso,
+  created_at: iso, updated_at: iso,
+} as TimePunch);
+
+// Local calendar day under test: Jul 10 2026 (constructed local to be TZ-portable)
+const day = new Date(2026, 6, 10);
+
+describe('buildTimelineBlocks', () => {
+  it('pairs a cross-midnight shift into ONE block on the clock-in day', () => {
+    const punches = [
+      p('clock_in', new Date(2026, 6, 10, 16, 45).toISOString()),
+      p('clock_out', new Date(2026, 6, 11, 0, 37).toISOString()),
+    ];
+    const blocks = buildTimelineBlocks(punches, day);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].startTime.getTime()).toBe(new Date(2026, 6, 10, 16, 45).getTime());
+    expect(blocks[0].endTime.getTime()).toBe(new Date(2026, 6, 11, 0, 37).getTime());
+    expect(blocks[0].hasClockInTime).toBe(true);
+    expect(blocks[0].hasClockOutTime).toBe(true);
+  });
+
+  it('excludes the prior night tail (clock-out lands on this day, clock-in was yesterday)', () => {
+    const punches = [
+      p('clock_in', new Date(2026, 6, 9, 20, 0).toISOString()),   // Jul 9 clock-in
+      p('clock_out', new Date(2026, 6, 10, 0, 7).toISOString()),  // Jul 10 00:07 → belongs to Jul 9
+    ];
+    expect(buildTimelineBlocks(punches, day)).toHaveLength(0);
+  });
+
+  it('keeps normal same-day shifts and split shifts unchanged', () => {
+    const punches = [
+      p('clock_in', new Date(2026, 6, 10, 9, 0).toISOString()),
+      p('clock_out', new Date(2026, 6, 10, 13, 0).toISOString()),
+      p('clock_in', new Date(2026, 6, 10, 17, 0).toISOString()),
+      p('clock_out', new Date(2026, 6, 10, 22, 0).toISOString()),
+    ];
+    const blocks = buildTimelineBlocks(punches, day);
+    expect(blocks).toHaveLength(2);
+  });
+
+  it('ignores a shift that starts the NEXT day (pulled in by the buffer)', () => {
+    const punches = [
+      p('clock_in', new Date(2026, 6, 11, 10, 0).toISOString()),
+      p('clock_out', new Date(2026, 6, 11, 18, 0).toISOString()),
+    ];
+    expect(buildTimelineBlocks(punches, day)).toHaveLength(0);
+  });
+
+  it('drops an unpaired lone clock-in (no block)', () => {
+    const punches = [p('clock_in', new Date(2026, 6, 10, 16, 0).toISOString())];
+    expect(buildTimelineBlocks(punches, day)).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect RED** (`@/utils/manualTimelineBlocks` unresolved).
+
+Run: `npx vitest run tests/unit/manualTimelineBlocks.test.ts`
+
+- [ ] **Step 3: Implement the util**
+
+Create `src/utils/manualTimelineBlocks.ts` — move `TimeBlock` and `getImportSource` here (verbatim from `ManualTimelineEditor.tsx` L17-31 and L55-... ) and add `buildTimelineBlocks`:
+```ts
+import { startOfDay, endOfDay } from 'date-fns';
+import { TimePunch } from '@/types/timeTracking';
+import { isWithinWindow } from '@/utils/punchWindow';
+
+export interface TimeBlock {
+  id: string;
+  startTime: Date;
+  endTime: Date;
+  breakMinutes?: number;
+  notes?: string;
+  clockInPunchId?: string;
+  clockOutPunchId?: string;
+  hasClockInTime?: boolean;
+  hasClockOutTime?: boolean;
+  isNew?: boolean;
+  isSaving?: boolean;
+  isImported?: boolean;
+  importSource?: string;
+}
+
+// Moved verbatim from ManualTimelineEditor (same logic that read source_type/notes).
+export function getImportSource(punch: TimePunch | undefined): string | null {
+  // ... exact body copied from the component ...
+}
+
+/**
+ * Pair an employee's punches into clock_in→clock_out blocks WITHOUT a per-day
+ * pre-filter (so a shift crossing midnight pairs whole), then keep only blocks
+ * whose clock-in (startTime) falls on `date` — attributing each shift to the day
+ * it began. Pass the ±18h buffered punch set so the next-day clock-out is present.
+ */
+export function buildTimelineBlocks(punches: TimePunch[], date: Date): TimeBlock[] {
+  const sorted = [...punches].sort(
+    (a, b) => new Date(a.punch_time).getTime() - new Date(b.punch_time).getTime()
+  );
+  const blocks: TimeBlock[] = [];
+  for (let i = 0; i < sorted.length; i++) {
+    const punch = sorted[i];
+    if (punch.punch_type !== 'clock_in') continue;
+    const next = sorted[i + 1];
+    if (next?.punch_type === 'clock_out') {
+      const importSource = getImportSource(punch) || getImportSource(next);
+      blocks.push({
+        id: `${punch.id}-${next.id}`,
+        startTime: new Date(punch.punch_time),
+        endTime: new Date(next.punch_time),
+        clockInPunchId: punch.id,
+        clockOutPunchId: next.id,
+        notes: punch.notes || next.notes || undefined,
+        hasClockInTime: true,
+        hasClockOutTime: true,
+        isImported: Boolean(importSource),
+        importSource: importSource || undefined,
+      });
+      i++;
+    }
+  }
+  // Attribute by clock-in day (reuse the centralized window rule).
+  const s = startOfDay(date);
+  const e = endOfDay(date);
+  return blocks.filter((b) => isWithinWindow(b.startTime, s, e));
+}
+```
+(Copy `getImportSource`'s real body from the component so behaviour is identical.)
+
+- [ ] **Step 4: Run — expect GREEN** (5 tests).
+
+- [ ] **Step 5: Commit** — `git add src/utils/manualTimelineBlocks.ts tests/unit/manualTimelineBlocks.test.ts && git commit -m "feat(time-clock): buildTimelineBlocks — clock-in-day attribution for the Manual view"`
+
+---
+
+## Task 2: Wire `ManualTimelineEditor` to the util + buffered punches
+
+**Files:**
+- Modify: `src/components/time-tracking/ManualTimelineEditor.tsx`
+- Modify: `src/pages/TimePunchesManager.tsx`
+
+- [ ] **Step 1: Feed buffered punches**
+
+In `src/pages/TimePunchesManager.tsx`, the `<ManualTimelineEditor>` render (~L733): change
+`existingPunches={windowPunches}` → `existingPunches={filteredPunches}` (the ±18h buffered set; the component now attributes to the clock-in day itself). Leave the other consumers on `windowPunches`.
+
+- [ ] **Step 2: Replace local defs + init pairing**
+
+In `ManualTimelineEditor.tsx`:
+- Remove the local `TimeBlock` interface (L17-31) and `getImportSource` (L55-...); import both from `@/utils/manualTimelineBlocks`. Keep the `EmployeeDay` interface.
+- In the init `useEffect` (L91-147), replace the per-employee body that filtered by `isSameDay` and inline-paired with:
+```ts
+    employees.forEach(employee => {
+      const employeePunches = existingPunches.filter(p => p.employee_id === employee.id);
+      const blocks = buildTimelineBlocks(employeePunches, date);
+      const totalHours = blocks.reduce((sum, b) => sum + getBlockDurationMinutes(b) / 60, 0);
+      const hasWarning = totalHours > 12;
+      dayMap.set(employee.id, {
+        employee, date, blocks, totalHours, hasWarning,
+        warningText: hasWarning ? 'Over 12 hours' : undefined, expanded: false,
+      });
+    });
+```
+Import: `import { TimeBlock, getImportSource, buildTimelineBlocks } from '@/utils/manualTimelineBlocks';` (drop `getImportSource` from the import if unused elsewhere — check; it's only used in the extracted code).
+
+- [ ] **Step 3: Verify** — `npx vitest run tests/unit/manualTimelineBlocks.test.ts && npx tsc --noEmit -p tsconfig.app.json 2>&1 | head`
+Expected: green, no type errors (confirms the local defs are fully removed and imports resolve).
+
+- [ ] **Step 4: Commit** — `git commit -am "fix(time-clock): Manual view pairs overnight shifts via buildTimelineBlocks + buffered punches"`
+
+---
+
+## Task 3: Cross-midnight render — clip, min-width, "+1d" tag, view-only
+
+**Files:** Modify: `src/components/time-tracking/ManualTimelineEditor.tsx`
+
+- [ ] **Step 1: Add a helper + constant near the render**
+```ts
+const MIN_CROSS_MIDNIGHT_WIDTH_PCT = 4;
+// A block crosses midnight when its clock-out is not on the viewed day.
+const crossesMidnight = (block: TimeBlock) => !isSameDay(block.endTime, date);
+```
+(`isSameDay` is already imported.)
+
+- [ ] **Step 2: Clamp position + min width in the block map (L711-714)**
+```ts
+{employeeDay.blocks.map((block) => {
+  const startPos = getPositionFromTime(block.startTime);
+  const overnight = crossesMidnight(block);
+  const endPos = overnight ? 100 : getPositionFromTime(block.endTime);
+  const width = overnight
+    ? Math.max(endPos - startPos, MIN_CROSS_MIDNIGHT_WIDTH_PCT)
+    : endPos - startPos;
+  // ...
+```
+
+- [ ] **Step 3: Block body swallows clicks + gate the right handle for overnight blocks**
+
+On the block wrapper `<div>` (L717), add for overnight blocks:
+```ts
+  onPointerDown={overnight ? (e) => e.stopPropagation() : undefined}
+```
+For the right-edge handle (L748-754): when `overnight`, render it non-interactive — `cursor-not-allowed`, no `onPointerDown` (or a no-op), and `title="Ends next day — edit the clock-out in the Punch List"`. Keep the left-edge (clock-in) handle active. When not overnight, unchanged.
+
+- [ ] **Step 4: "+1d" end marker inside the bar (semantic tokens, a11y)**
+
+Inside the block `<div>`, when `overnight`, add an absolutely-positioned marker anchored to the right edge, above siblings, that can't overflow into the Hours column:
+```tsx
+{overnight && (
+  <span
+    className="absolute right-1 top-0 bottom-0 flex items-center text-[10px] px-1 rounded bg-muted text-muted-foreground pointer-events-none z-20"
+    aria-label={`Ends ${format(block.endTime, 'h:mm a')} the next day`}
+  >
+    ↳ {format(block.endTime, 'h:mm a')} +1d
+  </span>
+)}
+```
+
+- [ ] **Step 5: Verify build + typecheck** — `npx tsc --noEmit -p tsconfig.app.json 2>&1 | head && npm run build 2>&1 | tail -3`
+
+- [ ] **Step 6: Commit** — `git commit -am "fix(time-clock): render cross-midnight blocks clipped with +1d tag, view-only on canvas"`
+
+---
+
+## Task 4: Expanded Block List — date-qualify cross-midnight end time
+
+**Files:** Modify: `src/components/time-tracking/ManualTimelineEditor.tsx`
+
+- [ ] **Step 1: Date-qualify the end time (L862-869 region)**
+
+Where the block list renders `format(block.startTime,'h:mm a') → format(block.endTime,'h:mm a')`, append a `+1d` suffix when `crossesMidnight(block)`:
+```tsx
+{format(block.endTime, 'h:mm a')}{crossesMidnight(block) ? ' +1d' : ''}
+```
+Delete stays enabled (removing a whole shift is legitimate).
+
+- [ ] **Step 2: Verify** — `npx tsc --noEmit -p tsconfig.app.json 2>&1 | head`
+
+- [ ] **Step 3: Commit** — `git commit -am "fix(time-clock): +1d suffix on cross-midnight rows in the block list"`
+
+---
+
+## Task 5: E2E — Manual view counts the overnight shift
+
+**Files:** Modify: `tests/e2e/overnight-shift-hours.spec.ts`
+
+- [ ] **Step 1: Add a test** seeding Rakiyah's pattern (clock-in yesterday 16:45, clock-out today 00:37) + a same-day contrast employee, navigate `/time-punches` (default Day + Manual), click "Previous" to yesterday, and assert:
+  - the Manual footer "Total hours for <day>" is NOT the same-day-only total — it includes the overnight hours (e.g. contains the sum of both, ~15.9h);
+  - the overnight employee's row is not `0h` (assert their row shows ~7–8h, not `/^0h$/`).
+  (Model on the existing tests in this file + the throwaway repro used during design.)
+
+- [ ] **Step 2: Run** — `npx playwright test --project=e2e tests/e2e/overnight-shift-hours.spec.ts` (kill any stale server on 4173 first). Expected: all pass.
+
+- [ ] **Step 3: Commit** — `git commit -am "test(e2e): Manual view counts overnight shift on its clock-in day"`
+
+---
+
+## Final verification (Phase 8)
+- `npm run test` (unit incl. new `manualTimelineBlocks`), `npm run typecheck`, `npm run lint` (changed files), `npm run build`, e2e spec — all green.
+
+## Spec coverage
+Design §1 (buffered punches) → Task 2. §2 (buildTimelineBlocks) → Task 1. §3 (clip+tag+view-only) → Task 3. §4 (drag safety) → Task 3. Review resolutions: body-click → T3S3; sliver/min-width → T3S2; block-list "+1d" → Task 4; getImportSource move + isWithinWindow → Task 1; disabled-handle affordance → T3S3. Tests → Tasks 1 & 5.

--- a/docs/superpowers/specs/2026-07-11-manual-timeline-overnight-design.md
+++ b/docs/superpowers/specs/2026-07-11-manual-timeline-overnight-design.md
@@ -106,6 +106,35 @@ real next-day punch.
   page header total (no more 15.9h vs 8h1m split).
 - Existing suite stays green.
 
+## Design-review resolutions (Phase 2.5, folded in)
+
+- **Block body swallows clicks (major).** Only the 2px edge handles
+  `stopPropagation`; a click on a block's *body* bubbles to the timeline
+  container's create-new-block handler (L696). For cross-midnight blocks the
+  clipped bar is a large target, so add `onPointerDown={e => e.stopPropagation()}`
+  to cross-midnight block bodies AND gate the right-edge handle's *handler* out
+  entirely (no-op) when the block crosses midnight — not just visually.
+- **Sliver + marker overlap (major).** A late-night start (11:50 PM) clamps to
+  ~0.7% width. Enforce a `MIN_CROSS_MIDNIGHT_WIDTH_PCT` floor for clipped blocks,
+  and position the "+1d" marker inside the bar with a z-index/max-right offset so
+  it never overlaps the trailing `w-32` Hours column (container has no
+  `overflow-hidden`).
+- **Expanded Block List (major).** L850-910 also lists these blocks as
+  `h:mm a → h:mm a` with no date qualifier and an enabled Delete. Add a "+1d"
+  suffix to the end time there for cross-midnight rows. **Delete stays enabled** —
+  removing a whole shift (both punches) is a legitimate action and is not the
+  "wrong same-day clock-out" corruption the canvas rail guards against.
+- **Minors:** move `getImportSource` into `manualTimelineBlocks.ts` (keep the
+  dependency direction util→types, never util→component); use
+  `isWithinWindow(startTime, startOfDay(date), endOfDay(date))` from
+  `punchWindow.ts` for the clock-in-day filter (reuse the centralized attribution
+  rule, not a fresh `isSameDay`); give the disabled right handle
+  `cursor-not-allowed` + a `title` pointing to the Punch List; the "+1d" marker
+  uses semantic tokens (`text-muted-foreground`/`bg-muted`) and an
+  `aria-label="Ends h:mm a the next day"`.
+- **Noted, not fixed (pre-existing, out of scope):** the component has no
+  `error` state (only `loading`).
+
 ## Decided trade-offs
 - **Clip + tag** display (not an extended "business-day" canvas): correct total
   immediately, minimal risk to the drag editor. Extended canvas is a follow-up.

--- a/docs/superpowers/specs/2026-07-11-manual-timeline-overnight-design.md
+++ b/docs/superpowers/specs/2026-07-11-manual-timeline-overnight-design.md
@@ -1,0 +1,114 @@
+# Design: Manual Timeline Editor — overnight shift hours & display
+
+**Date:** 2026-07-11
+**Branch:** `fix/manual-timeline-overnight-hours`
+**Type:** Bug fix (time-clock display + hours accuracy)
+
+## Problem
+
+On the Time Clock **Manual** view (Day mode), an employee who clocks out the
+next day shows **0h** and is omitted from the view's "Total hours for <day>."
+Concrete case (Rakiyah James, Jul 10): clock in 4:45 PM → clock out 12:37 AM
+(Jul 11) → shows **0h** in Manual, while the same page's header reads
+**"Today: 15.9 hours"** and the **Cards** view correctly shows
+`4:45 PM → 12:37 AM, Total 7.85h`. The page contradicts itself.
+
+This is the last surface not covered by PR #599: payroll, open-sessions,
+timecard, dashboard, tips, and the page-level total / Cards / Stream / Receipt
+all attribute overnight shifts to the clock-in day correctly. Only
+`ManualTimelineEditor` computes its own hours per calendar day.
+
+## Root cause
+
+`src/components/time-tracking/ManualTimelineEditor.tsx`:
+
+1. **Data:** it receives `existingPunches={windowPunches}` (TimePunchesManager
+   L736) — the **day-windowed** set. The next-day clock-out is never passed in.
+2. **Pairing:** its init effect pre-filters punches with
+   `isSameDay(new Date(p.punch_time), date)` (L95-96) then pairs `clock_in`→next
+   `clock_out` within that day. An overnight shift's clock-in is left unpaired
+   (its clock-out is on the next calendar day), and the prior night's clock-out
+   orphans into the current day.
+3. **Render:** `getPositionFromTime` uses `time.getHours()` (L151), so a
+   next-day clock-out (00:37 → ~0.6%) sits at the far left; block
+   `width = endPos − startPos` (L714) goes **negative** → the block can't be
+   drawn. (`getBlockDurationMinutes` uses `differenceInMinutes(end, start)`
+   (L168), so the numeric duration is already correct once the block exists.)
+
+## Approach
+
+Attribute a shift to its **clock-in day** — consistent with the rest of the app
+(and the Cards view the user confirmed is correct). Three coordinated changes,
+all scoped to this component + one prop in TimePunchesManager.
+
+### 1. Feed buffered punches
+`TimePunchesManager` passes `existingPunches={filteredPunches}` (the ±18h
+**buffered**, search-filtered set) to `ManualTimelineEditor` instead of
+`windowPunches`. This makes the next-day clock-out available for pairing. (The
+buffered fetch already exists from #599; `filteredPunches` is that set,
+search-filtered.)
+
+### 2. Pair across midnight, keep clock-in-day blocks (pure + testable)
+Extract the block-building from the init effect into a pure function
+`buildTimelineBlocks(employeePunches, date)` in a new
+`src/utils/manualTimelineBlocks.ts`:
+- Sort the employee's (buffered) punches; pair `clock_in`→next `clock_out`
+  sequentially — **no `isSameDay` pre-filter** — so a clock-in pairs with its
+  clock-out even across midnight.
+- Keep only blocks whose **clock-in** (`startTime`) is on `date`
+  (`isSameDay(startTime, date)`). This drops the prior night's tail (its
+  clock-in was the previous day) and next-day shifts, attributing each shift
+  once to the day it began.
+- Returns the existing `TimeBlock[]` shape (unchanged: `startTime`, `endTime`,
+  `clockInPunchId`, `clockOutPunchId`, `isImported`, …), so downstream render /
+  drag / save code is untouched.
+
+The init effect calls this helper; `totalHours` (already
+`Σ getBlockDurationMinutes/60`) then includes the full cross-midnight shift.
+Rakiyah → 7.85h; the Manual footer now matches the header.
+
+### 3. Render the cross-midnight block (clip + tag)
+In the block render (L712-734):
+- `endPos`: when `!isSameDay(block.endTime, date)` (block crosses midnight),
+  clamp the end position to `100` (right edge) so `width = 100 − startPos`
+  (never negative). Non-crossing blocks are unchanged.
+- Add a small end-of-bar marker/label `↳ h:mm a +1d` (e.g. "↳ 12:37 AM +1d")
+  so the manager sees where it actually ends. The bar's duration label / total
+  keeps using the real times (correct 7h52m).
+
+### 4. Drag-edit safety
+The drag handlers (`getTimeFromPosition`, resize/move) map canvas position →
+same-day time and cannot represent a next-day boundary. For a cross-midnight
+block:
+- Disable the **right-edge (clock-out) resize handle** and whole-block drag;
+  keep it visually distinct (the clipped bar + tag). Editing its clock-out is
+  done via the **Punch List** (or the next day's view). Creating/editing
+  same-day blocks is unchanged.
+This prevents the editor from writing an incorrect same-day clock-out over a
+real next-day punch.
+
+## Not changing
+- The page-level total / Open-Sessions / Cards / Stream / Receipt (already
+  correct via #599's `windowSessions`).
+- Drag-to-create for same-day blocks; the save/mutation path.
+- The 24h canvas extent (a "business-day" extended canvas — showing the full
+  overnight bar past midnight — is a deliberate follow-up, not this fix).
+
+## Testing
+- **Unit** (`tests/unit/manualTimelineBlocks.test.ts`): `buildTimelineBlocks`
+  - overnight shift (clock-in `date`, clock-out next day) → one block, full
+    duration, attributed to `date`;
+  - prior-night tail (clock-out on `date`, clock-in previous day) → excluded;
+  - normal same-day shifts, breaks/split shifts → unchanged vs current output;
+  - a shift that starts next day → excluded.
+- **E2E** (extend `tests/e2e/overnight-shift-hours.spec.ts`): reuse the Rakiyah
+  repro — Manual view shows her block ~7.85h and the Manual footer equals the
+  page header total (no more 15.9h vs 8h1m split).
+- Existing suite stays green.
+
+## Decided trade-offs
+- **Clip + tag** display (not an extended "business-day" canvas): correct total
+  immediately, minimal risk to the drag editor. Extended canvas is a follow-up.
+- **Cross-midnight blocks are view-only on the canvas** (edit clock-out via the
+  Punch List): avoids the drag math producing wrong next-day times. A full
+  cross-midnight drag editor is out of scope.

--- a/src/components/time-tracking/ManualTimelineEditor.tsx
+++ b/src/components/time-tracking/ManualTimelineEditor.tsx
@@ -13,22 +13,7 @@ import { useCreateTimePunch, useUpdateTimePunch, useDeleteTimePunch } from '@/ho
 import { useToast } from '@/hooks/use-toast';
 import { TimePunch } from '@/types/timeTracking';
 import { Employee } from '@/types/scheduling';
-
-interface TimeBlock {
-  id: string; // Unique ID for UI, maps to punch pair
-  startTime: Date;
-  endTime: Date;
-  breakMinutes?: number; // Optional break duration
-  notes?: string; // Optional notes
-  clockInPunchId?: string;
-  clockOutPunchId?: string;
-  hasClockInTime?: boolean;
-  hasClockOutTime?: boolean;
-  isNew?: boolean; // Track if this is unsaved
-  isSaving?: boolean;
-  isImported?: boolean;
-  importSource?: string;
-}
+import { TimeBlock, buildTimelineBlocks } from '@/utils/manualTimelineBlocks';
 
 interface EmployeeDay {
   employee: Employee;
@@ -51,14 +36,11 @@ interface ManualTimelineEditorProps {
 const HOURS_START = 0; // Midnight (12am)
 const HOURS_END = 24; // Midnight (12am next day)
 const TOTAL_HOURS = HOURS_END - HOURS_START;
+// Minimum rendered width (% of the 24h track) for a clipped cross-midnight bar,
+// so a shift that starts just before midnight is still visible/clickable.
+const MIN_CROSS_MIDNIGHT_WIDTH_PCT = 4;
 
-const getImportSource = (punch: TimePunch | undefined) => {
-  if (!punch?.device_info) return null;
-  if (!punch.device_info.startsWith('import:')) return null;
-  return punch.device_info.replace('import:', '').trim() || 'Uploaded';
-};
-
-export const ManualTimelineEditor = ({ 
+export const ManualTimelineEditor = ({
   employees, 
   date, 
   existingPunches, 
@@ -92,46 +74,19 @@ export const ManualTimelineEditor = ({
     const dayMap = new Map<string, EmployeeDay>();
     
     employees.forEach(employee => {
-      const employeePunches = existingPunches.filter(
-        p => p.employee_id === employee.id && isSameDay(new Date(p.punch_time), date)
-      );
-      
-      // Group punches into clock_in/clock_out pairs
-      const blocks: TimeBlock[] = [];
-      const sortedPunches = [...employeePunches].sort(
-        (a, b) => new Date(a.punch_time).getTime() - new Date(b.punch_time).getTime()
-      );
-      
-      for (let i = 0; i < sortedPunches.length; i++) {
-        const punch = sortedPunches[i];
-        if (punch.punch_type === 'clock_in') {
-          const nextPunch = sortedPunches[i + 1];
-          if (nextPunch?.punch_type === 'clock_out') {
-            const importSource = getImportSource(punch) || getImportSource(nextPunch);
-            blocks.push({
-              id: `${punch.id}-${nextPunch.id}`,
-              startTime: new Date(punch.punch_time),
-              endTime: new Date(nextPunch.punch_time),
-              clockInPunchId: punch.id,
-              clockOutPunchId: nextPunch.id,
-              notes: punch.notes || nextPunch.notes,
-              hasClockInTime: true,
-              hasClockOutTime: true,
-              isImported: Boolean(importSource),
-              importSource: importSource || undefined,
-            });
-            i++; // Skip the clock_out - required for loop control
-          }
-        }
-      }
-      
-      const totalHours = blocks.reduce((sum, block) => 
+      // Pair across midnight and attribute each shift to its clock-in day.
+      // `existingPunches` is the ±18h buffered set, so an overnight shift's
+      // next-day clock-out is present to pair.
+      const employeePunches = existingPunches.filter(p => p.employee_id === employee.id);
+      const blocks = buildTimelineBlocks(employeePunches, date);
+
+      const totalHours = blocks.reduce((sum, block) =>
         sum + getBlockDurationMinutes(block) / 60, 0
       );
-      
+
       const hasWarning = totalHours > 12;
       const warningText = hasWarning ? 'Over 12 hours' : undefined;
-      
+
       dayMap.set(employee.id, {
         employee,
         date,
@@ -152,6 +107,11 @@ export const ManualTimelineEditor = ({
     const relativeHour = hour - HOURS_START;
     return (relativeHour / TOTAL_HOURS) * 100;
   };
+
+  // A block crosses midnight when its clock-out is not on the viewed day.
+  // Such blocks are clipped at the right edge, tagged "+1d", and view-only on
+  // the canvas (edit the clock-out via the Punch List).
+  const crossesMidnight = (block: TimeBlock) => !isSameDay(block.endTime, date);
 
   // Calculate time from position
 const getTimeFromPosition = (positionPercent: number): Date => {
@@ -709,26 +669,38 @@ const getBlockDurationMinutes = (block: TimeBlock) => {
                 
                 {/* Time blocks */}
                 {employeeDay.blocks.map((block) => {
+                  const overnight = crossesMidnight(block);
                   const startPos = getPositionFromTime(block.startTime);
-                  const endPos = getPositionFromTime(block.endTime);
-                  const width = endPos - startPos;
-                  
+                  // Cross-midnight: clip the bar to the right edge (never negative
+                  // width) and shift-left just enough to guarantee a visible/
+                  // clickable min width without overflowing the track.
+                  const left = overnight
+                    ? Math.min(startPos, 100 - MIN_CROSS_MIDNIGHT_WIDTH_PCT)
+                    : startPos;
+                  const width = overnight
+                    ? 100 - left
+                    : getPositionFromTime(block.endTime) - startPos;
+
                   return (
                     <div
                       key={block.id}
                       className={cn(
                         "absolute top-1 bottom-1 rounded-md flex items-center justify-center px-2 text-xs font-medium text-primary-foreground touch-none select-none",
                         !isDragging && "transition-all duration-150", // Only transition when NOT dragging
-                        block.isSaving 
-                          ? "bg-primary/50 animate-pulse" 
+                        block.isSaving
+                          ? "bg-primary/50 animate-pulse"
                           : block.isImported
                           ? "bg-primary/60 hover:bg-primary/70 border border-primary/30"
                           : "bg-primary hover:bg-primary/90"
                       )}
                       style={{
-                        left: `${startPos}%`,
+                        left: `${left}%`,
                         width: `${width}%`,
                       }}
+                      // Cross-midnight blocks are view-only on the canvas: swallow
+                      // body pointer events so a click can't spawn a stray same-day
+                      // block over a real next-day punch.
+                      onPointerDown={overnight ? (e) => e.stopPropagation() : undefined}
                     >
                       {/* Time label inside block */}
                       {width > 8 && (
@@ -736,7 +708,17 @@ const getBlockDurationMinutes = (block: TimeBlock) => {
                           {format(block.startTime, 'HH:mm')} - {format(block.endTime, 'HH:mm')}
                         </span>
                       )}
-                      
+
+                      {/* Cross-midnight end marker (right-anchored, extends left) */}
+                      {overnight && (
+                        <span
+                          className="absolute right-1 top-0 bottom-0 flex items-center whitespace-nowrap text-[10px] px-1 rounded bg-muted text-muted-foreground pointer-events-none z-20"
+                          aria-label={`Ends ${format(block.endTime, 'h:mm a')} the next day`}
+                        >
+                          ↳ {format(block.endTime, 'h:mm a')} +1d
+                        </span>
+                      )}
+
                       {/* Drag handles */}
                       <div
                         className="absolute left-0 top-0 bottom-0 w-2 cursor-ew-resize hover:bg-primary-foreground/20 z-10"
@@ -745,13 +727,21 @@ const getBlockDurationMinutes = (block: TimeBlock) => {
                           handlePointerDown(e, employeeDay.employee.id, block.id, 'start');
                         }}
                       />
-                      <div
-                        className="absolute right-0 top-0 bottom-0 w-2 cursor-ew-resize hover:bg-primary-foreground/20 z-10"
-                        onPointerDown={(e) => {
-                          e.stopPropagation();
-                          handlePointerDown(e, employeeDay.employee.id, block.id, 'end');
-                        }}
-                      />
+                      {overnight ? (
+                        <div
+                          className="absolute right-0 top-0 bottom-0 w-2 cursor-not-allowed z-10"
+                          title="Ends next day — edit the clock-out in the Punch List"
+                          onPointerDown={(e) => e.stopPropagation()}
+                        />
+                      ) : (
+                        <div
+                          className="absolute right-0 top-0 bottom-0 w-2 cursor-ew-resize hover:bg-primary-foreground/20 z-10"
+                          onPointerDown={(e) => {
+                            e.stopPropagation();
+                            handlePointerDown(e, employeeDay.employee.id, block.id, 'end');
+                          }}
+                        />
+                      )}
                     </div>
                   );
                 })}
@@ -866,6 +856,9 @@ const getBlockDurationMinutes = (block: TimeBlock) => {
                               <span className="text-muted-foreground">→</span>
                               <span className="text-sm font-medium">
                                 {format(block.endTime, 'h:mm a')}
+                                {crossesMidnight(block) && (
+                                  <span className="ml-1 text-xs text-muted-foreground">+1d</span>
+                                )}
                               </span>
                               <span className="text-xs text-muted-foreground">
                                 ({formatDuration(workMinutes)})

--- a/src/pages/TimePunchesManager.tsx
+++ b/src/pages/TimePunchesManager.tsx
@@ -730,10 +730,13 @@ const TimePunchesManager = () => {
           {viewMode === 'day' ? (
             <>
               <div className="hidden md:block">
+                {/* Buffered (±18h) filteredPunches: the editor attributes each
+                    shift to its clock-in day itself, so an overnight shift's
+                    next-day clock-out is available to pair. */}
                 <ManualTimelineEditor
                   employees={employees}
                   date={currentDate}
-                  existingPunches={windowPunches}
+                  existingPunches={filteredPunches}
                   loading={loading}
                   restaurantId={restaurantId || ''}
                 />

--- a/src/utils/manualTimelineBlocks.ts
+++ b/src/utils/manualTimelineBlocks.ts
@@ -1,0 +1,74 @@
+import { startOfDay, endOfDay } from 'date-fns';
+import { TimePunch } from '@/types/timeTracking';
+import { isWithinWindow } from '@/utils/punchWindow';
+
+/**
+ * A clock_in→clock_out pair rendered as one editable bar on the Manual timeline.
+ * Extracted from ManualTimelineEditor so the pairing/attribution logic is pure
+ * and unit-testable.
+ */
+export interface TimeBlock {
+  id: string; // Unique ID for UI, maps to punch pair
+  startTime: Date;
+  endTime: Date;
+  breakMinutes?: number; // Optional break duration
+  notes?: string; // Optional notes
+  clockInPunchId?: string;
+  clockOutPunchId?: string;
+  hasClockInTime?: boolean;
+  hasClockOutTime?: boolean;
+  isNew?: boolean; // Track if this is unsaved
+  isSaving?: boolean;
+  isImported?: boolean;
+  importSource?: string;
+}
+
+/** Read the import source from a punch's device_info (`import:<source>`). */
+export const getImportSource = (punch: TimePunch | undefined): string | null => {
+  if (!punch?.device_info) return null;
+  if (!punch.device_info.startsWith('import:')) return null;
+  return punch.device_info.replace('import:', '').trim() || 'Uploaded';
+};
+
+/**
+ * Pair one employee's punches into clock_in→clock_out blocks WITHOUT a per-day
+ * pre-filter (so a shift crossing midnight pairs whole), then keep only blocks
+ * whose clock-in (startTime) falls on `date` — attributing each shift to the day
+ * it began. Pass the ±18h buffered punch set so the next-day clock-out is present.
+ *
+ * Reuses `isWithinWindow` (the app-wide clock-in-day attribution rule from #599)
+ * so overnight handling stays consistent with payroll/timecard/dashboard.
+ */
+export function buildTimelineBlocks(punches: TimePunch[], date: Date): TimeBlock[] {
+  const sorted = [...punches].sort(
+    (a, b) => new Date(a.punch_time).getTime() - new Date(b.punch_time).getTime()
+  );
+
+  const blocks: TimeBlock[] = [];
+  for (let i = 0; i < sorted.length; i++) {
+    const punch = sorted[i];
+    if (punch.punch_type !== 'clock_in') continue;
+    const next = sorted[i + 1];
+    if (next?.punch_type === 'clock_out') {
+      const importSource = getImportSource(punch) || getImportSource(next);
+      blocks.push({
+        id: `${punch.id}-${next.id}`,
+        startTime: new Date(punch.punch_time),
+        endTime: new Date(next.punch_time),
+        clockInPunchId: punch.id,
+        clockOutPunchId: next.id,
+        notes: punch.notes || next.notes || undefined,
+        hasClockInTime: true,
+        hasClockOutTime: true,
+        isImported: Boolean(importSource),
+        importSource: importSource || undefined,
+      });
+      i++; // Skip the paired clock_out
+    }
+  }
+
+  // Attribute each block to its clock-in day.
+  const start = startOfDay(date);
+  const end = endOfDay(date);
+  return blocks.filter((block) => isWithinWindow(block.startTime, start, end));
+}

--- a/src/utils/manualTimelineBlocks.ts
+++ b/src/utils/manualTimelineBlocks.ts
@@ -1,6 +1,7 @@
 import { startOfDay, endOfDay } from 'date-fns';
 import { TimePunch } from '@/types/timeTracking';
 import { isWithinWindow } from '@/utils/punchWindow';
+import { MAX_SHIFT_GAP_HOURS } from '@/utils/payrollCalculations';
 
 /**
  * A clock_in→clock_out pair rendered as one editable bar on the Manual timeline.
@@ -50,6 +51,15 @@ export function buildTimelineBlocks(punches: TimePunch[], date: Date): TimeBlock
     if (punch.punch_type !== 'clock_in') continue;
     const next = sorted[i + 1];
     if (next?.punch_type === 'clock_out') {
+      i++; // Consume the clock_out regardless (matches parseWorkPeriods).
+      // Cap the pairable gap the same way payroll/timecard do: a clock_out more
+      // than MAX_SHIFT_GAP_HOURS after the clock_in is a missing-punch artifact
+      // (e.g. a forgotten clock-out force-closed hours later), not a real shift —
+      // don't fabricate a multi-day block from it.
+      const gapHours =
+        (new Date(next.punch_time).getTime() - new Date(punch.punch_time).getTime()) / (1000 * 60 * 60);
+      if (gapHours > MAX_SHIFT_GAP_HOURS) continue;
+
       const importSource = getImportSource(punch) || getImportSource(next);
       blocks.push({
         id: `${punch.id}-${next.id}`,
@@ -63,7 +73,6 @@ export function buildTimelineBlocks(punches: TimePunch[], date: Date): TimeBlock
         isImported: Boolean(importSource),
         importSource: importSource || undefined,
       });
-      i++; // Skip the paired clock_out
     }
   }
 

--- a/tests/e2e/overnight-shift-hours.spec.ts
+++ b/tests/e2e/overnight-shift-hours.spec.ts
@@ -241,9 +241,9 @@ test.describe('Overnight shift hours (punch windowing fix)', () => {
     await page.getByRole('heading', { name: /time clock/i }).first().waitFor({ state: 'visible', timeout: 25000 });
     // Default view is Day + Manual; step back one day to the shift day.
     await page.getByRole('button', { name: /^previous$/i }).click();
-    await page.waitForTimeout(1500);
 
-    // The Manual view footer is present for the shift day.
+    // Deterministic wait: the value-bearing assertions below poll until the
+    // previous day's buffered punches load and the Manual view recomputes.
     await expect(page.getByText(/Total hours for/i)).toBeVisible({ timeout: 10000 });
     // Overnight shift counts its full 8h 30m on the clock-in day (was 0h before).
     await expect(page.getByText('8h 30m').first()).toBeVisible({ timeout: 10000 });

--- a/tests/e2e/overnight-shift-hours.spec.ts
+++ b/tests/e2e/overnight-shift-hours.spec.ts
@@ -192,4 +192,66 @@ test.describe('Overnight shift hours (punch windowing fix)', () => {
     await expect(hoursInput).toBeVisible({ timeout: 5000 });
     await expect(hoursInput).toHaveValue('5');
   });
+
+  test('Time Clock Manual view counts a cross-midnight shift on its clock-in day', async ({ page }) => {
+    const user = generateTestUser();
+    await signUpAndCreateRestaurant(page, user);
+    await exposeSupabaseHelpers(page);
+
+    const restaurantId = await page.evaluate(async () => {
+      const fn = (window as any).__getRestaurantId;
+      return fn ? await fn() : null;
+    });
+    expect(restaurantId).toBeTruthy();
+
+    // Shift day = yesterday (view it by stepping back one day from "Today").
+    const now = new Date();
+    const todayMidnight = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const yest = new Date(todayMidnight); yest.setDate(yest.getDate() - 1);
+    const at = (base: Date, h: number, m: number) => {
+      const d = new Date(base); d.setHours(h, m, 0, 0); return d.toISOString();
+    };
+
+    const overnightId = randomUUID(); // 4:00 PM yest -> 12:30 AM today = 8h 30m
+    const sameDayId = randomUUID();   // 2:00 PM -> 8:00 PM yest = 6h
+
+    await page.evaluate(
+      async ({ restaurantId, overnightId, sameDayId, punches }) => {
+        const insertEmployees = (window as any).__insertEmployees;
+        const insertTimePunches = (window as any).__insertTimePunches;
+        await insertEmployees([
+          { id: overnightId, name: 'Rana Overnight', position: 'Server', compensation_type: 'hourly', hourly_rate: 1500, status: 'active', is_active: true, tip_eligible: true, requires_time_punch: true, hire_date: '2026-01-01' },
+          { id: sameDayId, name: 'Sam Sameday', position: 'Mixer', compensation_type: 'hourly', hourly_rate: 1500, status: 'active', is_active: true, tip_eligible: true, requires_time_punch: true, hire_date: '2026-01-01' },
+        ], restaurantId);
+        await insertTimePunches(punches, restaurantId);
+      },
+      {
+        restaurantId, overnightId, sameDayId,
+        punches: [
+          { employee_id: overnightId, punch_type: 'clock_in', punch_time: at(yest, 16, 0) },
+          { employee_id: overnightId, punch_type: 'clock_out', punch_time: at(todayMidnight, 0, 30) },
+          { employee_id: sameDayId, punch_type: 'clock_in', punch_time: at(yest, 14, 0) },
+          { employee_id: sameDayId, punch_type: 'clock_out', punch_time: at(yest, 20, 0) },
+        ],
+      }
+    );
+
+    await page.setViewportSize({ width: 1280, height: 1400 });
+    await page.goto('/time-punches');
+    await page.getByRole('heading', { name: /time clock/i }).first().waitFor({ state: 'visible', timeout: 25000 });
+    // Default view is Day + Manual; step back one day to the shift day.
+    await page.getByRole('button', { name: /^previous$/i }).click();
+    await page.waitForTimeout(1500);
+
+    // The Manual view footer is present for the shift day.
+    await expect(page.getByText(/Total hours for/i)).toBeVisible({ timeout: 10000 });
+    // Overnight shift counts its full 8h 30m on the clock-in day (was 0h before).
+    await expect(page.getByText('8h 30m').first()).toBeVisible({ timeout: 10000 });
+    // Same-day contrast shift.
+    await expect(page.getByText('6h', { exact: true }).first()).toBeVisible();
+    // Manual footer total includes BOTH (8h30m + 6h = 14h 30m), not same-day-only;
+    // pre-fix this read 6h (overnight shift dropped). Distinctive value, so a plain
+    // text match is unambiguous.
+    await expect(page.getByText('14h 30m').first()).toBeVisible();
+  });
 });

--- a/tests/unit/manualTimelineBlocks.test.ts
+++ b/tests/unit/manualTimelineBlocks.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { buildTimelineBlocks, getImportSource } from '@/utils/manualTimelineBlocks';
+import type { TimePunch } from '@/types/timeTracking';
+
+const p = (type: string, iso: string, extra: Partial<TimePunch> = {}): TimePunch => ({
+  id: `${type}-${iso}`,
+  employee_id: 'e1',
+  restaurant_id: 'r1',
+  punch_type: type as TimePunch['punch_type'],
+  punch_time: iso,
+  created_at: iso,
+  updated_at: iso,
+  ...extra,
+} as TimePunch);
+
+// Local calendar day under test: Jul 10 2026 (constructed local → TZ-portable).
+const day = new Date(2026, 6, 10);
+
+describe('buildTimelineBlocks', () => {
+  it('pairs a cross-midnight shift into ONE block on the clock-in day', () => {
+    const punches = [
+      p('clock_in', new Date(2026, 6, 10, 16, 45).toISOString()),
+      p('clock_out', new Date(2026, 6, 11, 0, 37).toISOString()),
+    ];
+    const blocks = buildTimelineBlocks(punches, day);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].startTime.getTime()).toBe(new Date(2026, 6, 10, 16, 45).getTime());
+    expect(blocks[0].endTime.getTime()).toBe(new Date(2026, 6, 11, 0, 37).getTime());
+    expect(blocks[0].hasClockInTime).toBe(true);
+    expect(blocks[0].hasClockOutTime).toBe(true);
+    expect(blocks[0].clockInPunchId).toBeTruthy();
+    expect(blocks[0].clockOutPunchId).toBeTruthy();
+  });
+
+  it('excludes the prior-night tail (clock-out lands on this day, clock-in was yesterday)', () => {
+    const punches = [
+      p('clock_in', new Date(2026, 6, 9, 20, 0).toISOString()),   // Jul 9 clock-in
+      p('clock_out', new Date(2026, 6, 10, 0, 7).toISOString()),  // Jul 10 00:07 → belongs to Jul 9
+    ];
+    expect(buildTimelineBlocks(punches, day)).toHaveLength(0);
+  });
+
+  it('keeps normal same-day shifts and split shifts unchanged', () => {
+    const punches = [
+      p('clock_in', new Date(2026, 6, 10, 9, 0).toISOString()),
+      p('clock_out', new Date(2026, 6, 10, 13, 0).toISOString()),
+      p('clock_in', new Date(2026, 6, 10, 17, 0).toISOString()),
+      p('clock_out', new Date(2026, 6, 10, 22, 0).toISOString()),
+    ];
+    const blocks = buildTimelineBlocks(punches, day);
+    expect(blocks).toHaveLength(2);
+  });
+
+  it('ignores a shift that starts the NEXT day (pulled in by the buffer)', () => {
+    const punches = [
+      p('clock_in', new Date(2026, 6, 11, 10, 0).toISOString()),
+      p('clock_out', new Date(2026, 6, 11, 18, 0).toISOString()),
+    ];
+    expect(buildTimelineBlocks(punches, day)).toHaveLength(0);
+  });
+
+  it('drops an unpaired lone clock-in (no block)', () => {
+    const punches = [p('clock_in', new Date(2026, 6, 10, 16, 0).toISOString())];
+    expect(buildTimelineBlocks(punches, day)).toHaveLength(0);
+  });
+
+  it('flags an imported block from device_info', () => {
+    const punches = [
+      p('clock_in', new Date(2026, 6, 10, 9, 0).toISOString(), { device_info: 'import:Toast' }),
+      p('clock_out', new Date(2026, 6, 10, 17, 0).toISOString()),
+    ];
+    const blocks = buildTimelineBlocks(punches, day);
+    expect(blocks[0].isImported).toBe(true);
+    expect(blocks[0].importSource).toBe('Toast');
+  });
+});
+
+describe('getImportSource', () => {
+  it('parses the import source, or null when not imported', () => {
+    expect(getImportSource(p('clock_in', '2026-07-10T09:00:00Z', { device_info: 'import:Sling' }))).toBe('Sling');
+    expect(getImportSource(p('clock_in', '2026-07-10T09:00:00Z', { device_info: 'kiosk' }))).toBeNull();
+    expect(getImportSource(undefined)).toBeNull();
+  });
+});

--- a/tests/unit/manualTimelineBlocks.test.ts
+++ b/tests/unit/manualTimelineBlocks.test.ts
@@ -64,6 +64,24 @@ describe('buildTimelineBlocks', () => {
     expect(buildTimelineBlocks(punches, day)).toHaveLength(0);
   });
 
+  it('excludes a pair whose gap exceeds MAX_SHIFT_GAP_HOURS (missing-punch artifact)', () => {
+    // Jul 10 10:00 clock-in, clock-out 40h later (Jul 11 whole day open, forgot to
+    // clock out, force-closed Jul 12 02:00). Payroll/timecard exclude this; so must we.
+    const punches = [
+      p('clock_in', new Date(2026, 6, 10, 10, 0).toISOString()),
+      p('clock_out', new Date(2026, 6, 12, 2, 0).toISOString()),
+    ];
+    expect(buildTimelineBlocks(punches, day)).toHaveLength(0);
+  });
+
+  it('keeps a genuine overnight shift within the gap cap', () => {
+    const punches = [
+      p('clock_in', new Date(2026, 6, 10, 20, 0).toISOString()),
+      p('clock_out', new Date(2026, 6, 11, 6, 0).toISOString()), // 10h
+    ];
+    expect(buildTimelineBlocks(punches, day)).toHaveLength(1);
+  });
+
   it('flags an imported block from device_info', () => {
     const punches = [
       p('clock_in', new Date(2026, 6, 10, 9, 0).toISOString(), { device_info: 'import:Toast' }),

--- a/tests/unit/manualTimelineBlocks.test.ts
+++ b/tests/unit/manualTimelineBlocks.test.ts
@@ -17,7 +17,7 @@ const p = (type: string, iso: string, extra: Partial<TimePunch> = {}): TimePunch
 const day = new Date(2026, 6, 10);
 
 describe('buildTimelineBlocks', () => {
-  it('pairs a cross-midnight shift into ONE block on the clock-in day', () => {
+  it('CRITICAL: pairs a cross-midnight shift into ONE block on the clock-in day', () => {
     const punches = [
       p('clock_in', new Date(2026, 6, 10, 16, 45).toISOString()),
       p('clock_out', new Date(2026, 6, 11, 0, 37).toISOString()),
@@ -32,7 +32,7 @@ describe('buildTimelineBlocks', () => {
     expect(blocks[0].clockOutPunchId).toBeTruthy();
   });
 
-  it('excludes the prior-night tail (clock-out lands on this day, clock-in was yesterday)', () => {
+  it('CRITICAL: excludes the prior-night tail (clock-out lands on this day, clock-in was yesterday)', () => {
     const punches = [
       p('clock_in', new Date(2026, 6, 9, 20, 0).toISOString()),   // Jul 9 clock-in
       p('clock_out', new Date(2026, 6, 10, 0, 7).toISOString()),  // Jul 10 00:07 → belongs to Jul 9
@@ -64,7 +64,7 @@ describe('buildTimelineBlocks', () => {
     expect(buildTimelineBlocks(punches, day)).toHaveLength(0);
   });
 
-  it('excludes a pair whose gap exceeds MAX_SHIFT_GAP_HOURS (missing-punch artifact)', () => {
+  it('CRITICAL: excludes a pair whose gap exceeds MAX_SHIFT_GAP_HOURS (missing-punch artifact)', () => {
     // Jul 10 10:00 clock-in, clock-out 40h later (Jul 11 whole day open, forgot to
     // clock out, force-closed Jul 12 02:00). Payroll/timecard exclude this; so must we.
     const punches = [


### PR DESCRIPTION
## Summary
Follow-up to #599. The Time Clock **Manual** view (`ManualTimelineEditor`) still showed **0h** for an overnight shift (clock out next day) — e.g. Rakiyah, clock in 4:45 PM → clock out 12:37 AM shows 0h in Manual while the same page header reads "Today: 15.9h" and the **Cards** view correctly shows `4:45 PM → 12:37 AM, 7.85h`. It was the last surface computing its own hours **per calendar day** (`isSameDay` pre-filter + same-day pairing), and its render math made a cross-midnight block's width negative.

**Fix** (scoped to the Manual view + one prop):
- New pure, tested `buildTimelineBlocks(punches, date)` — pairs punches across midnight and keeps blocks whose **clock-in** falls on the viewed day (reuses `isWithinWindow` from #599), with the same `MAX_SHIFT_GAP_HOURS = 18` cap the other engines use so a forgotten/force-closed punch can't fabricate a multi-day block.
- `TimePunchesManager` feeds the editor the ±18h **buffered** punch set so the next-day clock-out is available.
- Cross-midnight bars render **clipped to the right edge** (never negative width) with a min-width floor and a **"↳ 12:37 AM +1d"** tag; they're **view-only on the canvas** (body + right handle swallow pointer events) so drag-editing can't overwrite a real next-day punch — the clock-in edge stays editable. A "+1d" suffix is added to cross-midnight rows in the expanded block list.

**Result:** the overnight shift shows its full hours on the clock-in day, the Manual footer matches the page header, and the past-midnight tail is shown clearly and safely. Correctness is guaranteed by `getBlockDurationMinutes` (real timestamps) once the block exists.

## Test plan
- Unit: `manualTimelineBlocks.test.ts` (9) — cross-midnight → one block on clock-in day; prior-night tail excluded; same-day/split unchanged; next-day excluded; lone clock-in dropped; **>18h gap excluded**; imported flag.
- Full unit suite green (6252). Typecheck, build, lint (no new issues — my util is lint-clean).
- E2E (`overnight-shift-hours.spec.ts`): Manual view shows 8h30m (not 0h) and footer totals 14h30m. *Note: the local signup helper is env-flaky today (the pre-existing #599 tests in this file fail identically at signup locally); validated in CI.*

## Review
- Phase 2.5 frontend design review + Phase 7 sound-logic review folded in (the gap-cap major was caught and fixed here).

Design: `docs/superpowers/specs/2026-07-11-manual-timeline-overnight-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Manual time entries now correctly include overnight shifts on the day they begin.
  * Overnight timeline blocks display accurate durations instead of 0 hours or being omitted.
  * Cross-midnight blocks are clearly marked with a “+1d” indicator.

* **Usability**
  * Overnight blocks are protected from edits that could create invalid same-day entries; adjustments can be made through the Punch List.

* **Tests**
  * Added coverage for overnight shift calculations and displayed totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->