### PR TITLE
feat(notify): push team when a shift is offered for trade + fix cross-user trade pushes

### DIFF
--- a/docs/superpowers/plans/2026-07-11-shift-available-push-plan.md
+++ b/docs/superpowers/plans/2026-07-11-shift-available-push-plan.md
@@ -1,0 +1,62 @@
+# Plan — Shift-available broadcast push (Phase A)
+
+**Design:** docs/superpowers/specs/2026-07-11-shift-available-push-design.md
+**Branch:** `feature/shift-available-push`
+
+TDD: RED → GREEN → REFACTOR → COMMIT per task. `sonar.sources=src` → edge-function files aren't
+coverage-gated, but pure logic still gets unit tests for correctness.
+
+---
+
+### Task 1 — `_shared/webPushFanout.ts` (pure primitives) + test
+- **Test** `tests/unit/webPushFanout.test.ts`:
+  - `selectBroadcastPushUserIds`: drops null/undefined user_ids; excludes `excludeUserId`; dedupes;
+    excludeUserId null/undefined keeps all; empty input → `[]`.
+  - `runBounded`: runs worker once per item; `maxInFlight ≤ concurrency` (timing probe like the
+    schedulePublishedPush test); non-throw when a worker rejects (Promise.allSettled); non-positive
+    concurrency clamps to ≥1 and still completes (no hang).
+- **Code** `supabase/functions/_shared/webPushFanout.ts`: `selectBroadcastPushUserIds` +
+  `runBounded<T>` per design (no Deno-only imports — vitest-importable).
+- Dep: none.
+
+### Task 2 — `sendWebPushToUsers` bulk helper in `_shared/webPushHelper.ts`
+- **Code**: add `sendWebPushToUsers(supabase, userIds, restaurantId, payload, opts?)`:
+  one `web_push_subscriptions` select `.in('user_id', userIds).eq('restaurant_id', restaurantId)`;
+  `maxTargets` ceiling (default 500, log+cap, return `skipped`); `setVapidDetails` once (skip if
+  VAPID unset); `runBounded` over subscription rows calling `webpush.sendNotification`; batch-delete
+  410/404 stale; return `{ sent, cleaned, skipped }`. Reuses the `runBounded` primitive from Task 1.
+- **Verify**: `deno check`; no vitest target (Deno-only glue, same status as existing
+  `sendWebPushToUser`). Pure decision logic lives in Task 1's tested helpers.
+- Dep: 1.
+
+### Task 3 — wire `send-shift-trade-notification/index.ts`
+- **Code**:
+  1. Add bare `admin = createClient(supabaseUrl, supabaseServiceKey)` (no Authorization). Keep the
+     JWT-scoped `supabase` for `auth.getUser()` only.
+  2. After the trade fetch, caller-authz: `admin.from('user_restaurants').select('role')
+     .eq('user_id', user.id).eq('restaurant_id', trade.restaurant_id).maybeSingle()` → 403 if none.
+  3. Repoint the existing targeted `sendWebPushToUser(...)` calls from `supabase` → `admin`
+     (fixes the latent cross-user silent no-op). The broadcast `employees` query also uses `admin`.
+  4. Replace the `created` push-skip with: fetch active employees' user_ids via `admin`,
+     `selectBroadcastPushUserIds(rows, trade.offered_by?.user_id)`, then
+     `sendWebPushToUsers(admin, targets, trade.restaurant_id, { title: content.heading,
+     body: 'A teammate offered a shift for trade. Tap to view.', url: '/employee/shifts',
+     tag: `trade-created-${tradeId}` })`, wrapped in try/catch.
+- **Verify**: `deno check --config supabase/functions/deno.json`, `eslint`, `typecheck`.
+- Dep: 1, 2.
+
+---
+
+## Phase 8 verify
+Full `npx vitest run` (not just the new file — lesson from #601), `typecheck`, `lint`, `build`,
+`deno check` on the edited functions. No migration, no pgTAP (no schema change).
+
+## Task order
+1 → 2 → 3 (strictly sequential; 2 and 3 depend on 1's `runBounded`/`selectBroadcastPushUserIds`).
+
+## Out of scope (follow-ups)
+- Admin-only per-type × per-channel resolver (Phase B) — the `created` block is the seam.
+- Migrate notify-schedule-published + retire `schedulePublishedPush.ts` onto `sendWebPushToUsers`.
+- `notifications_sent` idempotency record for the trade broadcast (email already lacks one).
+- Excluding the poster from the broadcast *email*.
+- Surfacing the push opt-in banner in help docs (separate doc gap).

--- a/docs/superpowers/specs/2026-07-11-shift-available-push-design.md
+++ b/docs/superpowers/specs/2026-07-11-shift-available-push-design.md
@@ -1,0 +1,109 @@
+# Design — Shift-available push notification (Phase A)
+
+**Date:** 2026-07-11
+**Branch:** `feature/shift-available-push`
+
+## Problem
+
+When an employee offers a shift for trade (`shift_trades` insert → `send-shift-trade-notification`
+with `action: 'created'`), the whole team gets an **email** but **no push**. The push section
+explicitly skips it:
+
+```js
+if (action === 'created') {
+  // No targeted push for broadcast — skip (would notify all employees)
+}
+```
+
+Managers want the team notified on their phones when a shift becomes available. Push reaches
+only employees who opted in via the "Enable" banner, so a broadcast push pings *opted-in*
+teammates — not literally everyone — and email is unchanged.
+
+## Scope (approved)
+
+- **In:** Add a bounded-concurrency web-push fan-out to the `created` branch → active employees
+  with a push subscription, **excluding the poster** (`trade.offered_by.user_id`). Email untouched.
+- **Out (Phase B, separate):** admin-only per-type × per-channel resolver. Not built now; the
+  channel decision is kept isolated (a single call site) so it can later be gated by a resolver.
+- **Out:** changing the targeted actions (accepted/approved/rejected/cancelled) — they already push.
+- **Out:** excluding the poster from the *email* (pre-existing behavior; the poster currently gets
+  the broadcast email too — left as-is per "email unchanged").
+
+## Approach
+
+### New tested helper — `supabase/functions/_shared/webPushFanout.ts` (pure, vitest-importable)
+
+```ts
+export type WebPushSend = (userId: string) => Promise<unknown>;
+
+/** Filter employee rows to the distinct set of push targets, dropping null user_ids
+ *  and the excluded user (e.g. the poster / actor who caused the event). */
+export function selectBroadcastPushUserIds(
+  employees: Array<{ user_id?: string | null }>,
+  excludeUserId?: string | null,
+): string[];
+
+/** Fan `send` out over userIds in bounded-concurrency chunks (clamped >= 1) so a
+ *  100+-employee broadcast doesn't open 100+ simultaneous push round-trips in one
+ *  edge-function invocation. Promise.allSettled per chunk — a rejecting send never throws. */
+export async function fanOutWebPush(
+  userIds: string[],
+  send: WebPushSend,
+  concurrency?: number, // default 20
+): Promise<{ attempted: number }>;
+```
+
+`fanOutWebPush` is the generalized form of the bounded loop already shipped in
+`_shared/schedulePublishedPush.ts` (PR #601). **Refactor** `notifySchedulePublishedPush` to map
+its `employees` → user_ids via `selectBroadcastPushUserIds` and delegate to `fanOutWebPush` —
+one implementation, no duplication. Its existing test (`schedulePublishedPush.test.ts`) guards the
+identical behavior (including the concurrency-clamp guard).
+
+### Edge function — `send-shift-trade-notification/index.ts`, `created` branch only
+
+Replace the skip with:
+1. Fetch active employees' user_ids for the restaurant (service-role client already in scope):
+   `employees.select('user_id').eq('restaurant_id', restaurantId).eq('is_active', true).not('user_id','is',null)`.
+2. `const targets = selectBroadcastPushUserIds(rows, trade.offered_by?.user_id)`.
+3. `await fanOutWebPush(targets, (uid) => sendWebPushToUser(supabase, uid, trade.restaurant_id, {
+     title: content.heading,                 // "New Shift Available for Trade"
+     body: 'A teammate offered a shift for trade. Tap to view.',
+     url: '/employee/shifts',
+     tag: `shift-trade-created-${tradeId}`,  // on-device dedupe per trade
+   }))`.
+
+Notes:
+- **Web push only** for the broadcast (no legacy FCM `send-push-notification` fan-out) — FCM is
+  disabled and 100 FCM POSTs would be wasteful; consistent with PR #601's schedule-published fix.
+  The targeted actions keep their existing dual FCM+web-push loop, untouched.
+- Wrapped in try/catch → push failure never blocks the (already-sent) email response.
+- The `created` branch sits in the existing push section; the DB fetch + two helper calls are the
+  only new index.ts lines (thin — new logic is unit-tested in the helper).
+
+### Phase-B seam
+
+The channel decision for `created` is a single, isolated block. When Phase B lands the admin-only
+resolver, this becomes `if (channels.push) { …fanOutWebPush… }` where
+`channels = resolveChannels('shift_trade_created', restaurantId)`. No structural rework needed.
+
+## Testing
+
+- `tests/unit/webPushFanout.test.ts`:
+  - `selectBroadcastPushUserIds`: drops null/undefined user_ids; excludes `excludeUserId`; dedupes;
+    returns [] for empty; excludeUserId null/undefined keeps everyone.
+  - `fanOutWebPush`: sends once per id; bounded concurrency (maxInFlight ≤ n); non-throw on a
+    rejecting send; non-positive concurrency clamps to ≥1 (no hang); `{ attempted }` count.
+- `tests/unit/schedulePublishedPush.test.ts`: unchanged, must stay green after the delegation refactor
+  (regression guard that the generalization preserved behavior).
+- Edge-function `index.ts` broadcast wiring: covered indirectly via the pure helpers; Deno lines stay
+  thin. Verified with `deno check`, `eslint`, `typecheck`, full `vitest run`, `build`.
+
+## Decided trade-offs
+
+- **Broadcast parity with email:** push goes to the same audience as the email (all active
+  employees, minus the poster). No position/availability targeting — that would diverge from the
+  existing email broadcast and is out of scope.
+- **Reach depends on push opt-in.** Only employees who tapped "Enable" receive it. (Separate doc
+  gap — surfacing the opt-in — tracked outside this PR.)
+- **Poster still gets the broadcast email** (unchanged); excluded only from push. Aligning email is
+  a separate, deliberate choice left for later to honor "email unchanged."

--- a/docs/superpowers/specs/2026-07-11-shift-available-push-design.md
+++ b/docs/superpowers/specs/2026-07-11-shift-available-push-design.md
@@ -6,104 +6,144 @@
 ## Problem
 
 When an employee offers a shift for trade (`shift_trades` insert → `send-shift-trade-notification`
-with `action: 'created'`), the whole team gets an **email** but **no push**. The push section
-explicitly skips it:
+with `action: 'created'`), the whole team gets an **email** but **no push** — the push section
+explicitly skips it (`if (action === 'created') { /* No targeted push for broadcast — skip */ }`).
+Managers want the team notified on their phones when a shift becomes available.
 
-```js
-if (action === 'created') {
-  // No targeted push for broadcast — skip (would notify all employees)
-}
+## Critical constraint found in design review
+
+The function builds its Supabase client by **forwarding the caller's JWT**:
+
+```ts
+const supabase = createClient(supabaseUrl, supabaseServiceKey, {
+  global: { headers: { Authorization: authHeader } }   // ← poster's JWT
+});
 ```
 
-Managers want the team notified on their phones when a shift becomes available. Push reaches
-only employees who opted in via the "Enable" banner, so a broadcast push pings *opted-in*
-teammates — not literally everyone — and email is unchanged.
+PostgREST derives the RLS role from that `Authorization` header, so every `.from()` runs as the
+**poster (`authenticated`)**, not `service_role`. `web_push_subscriptions` RLS is strictly
+`USING (auth.uid() = user_id)` with no restaurant-broadening policy, so
+`sendWebPushToUser(supabase, otherUserId, …)` reads **zero rows and no-ops silently** for anyone
+but the caller. Consequence: the new broadcast would ship returning `200 { attempted: N }` while
+delivering **zero pushes** — and the *existing* targeted pushes (accepted/approved/rejected/
+cancelled) to the *other* party are already silently broken for the same reason.
 
 ## Scope (approved)
 
-- **In:** Add a bounded-concurrency web-push fan-out to the `created` branch → active employees
-  with a push subscription, **excluding the poster** (`trade.offered_by.user_id`). Email untouched.
-- **Out (Phase B, separate):** admin-only per-type × per-channel resolver. Not built now; the
-  channel decision is kept isolated (a single call site) so it can later be gated by a resolver.
-- **Out:** changing the targeted actions (accepted/approved/rejected/cancelled) — they already push.
-- **Out:** excluding the poster from the *email* (pre-existing behavior; the poster currently gets
-  the broadcast email too — left as-is per "email unchanged").
+- **In:** broadcast web-push on `created` to active employees with a subscription, **excluding the
+  poster**, bounded/bulk so a big team stays within the edge budget. Fix the client so pushes
+  actually deliver (this repairs the existing targeted branches too). Add the missing caller
+  authorization check. Email unchanged.
+- **Out (Phase B, separate):** admin-only per-type × per-channel resolver. The channel decision is
+  a single isolated block so it can later be gated by `resolveChannels(...)`.
+- **Out:** migrating `notify-schedule-published` / `schedulePublishedPush.ts` onto the new bulk
+  helper (works today via a *bare* service client). Noted as a Phase-B consolidation follow-up.
+- **Out:** excluding the poster from the *email* (pre-existing; left as-is per "email unchanged").
 
 ## Approach
 
-### New tested helper — `supabase/functions/_shared/webPushFanout.ts` (pure, vitest-importable)
+### 1. Fix the client (critical) — `send-shift-trade-notification/index.ts`
+
+Keep the JWT-scoped `supabase` **only** for `supabase.auth.getUser()`. Add a genuine bypass client
+for all data/notification reads (mirrors `proxy-receipt-file/index.ts`):
 
 ```ts
-export type WebPushSend = (userId: string) => Promise<unknown>;
-
-/** Filter employee rows to the distinct set of push targets, dropping null user_ids
- *  and the excluded user (e.g. the poster / actor who caused the event). */
-export function selectBroadcastPushUserIds(
-  employees: Array<{ user_id?: string | null }>,
-  excludeUserId?: string | null,
-): string[];
-
-/** Fan `send` out over userIds in bounded-concurrency chunks (clamped >= 1) so a
- *  100+-employee broadcast doesn't open 100+ simultaneous push round-trips in one
- *  edge-function invocation. Promise.allSettled per chunk — a rejecting send never throws. */
-export async function fanOutWebPush(
-  userIds: string[],
-  send: WebPushSend,
-  concurrency?: number, // default 20
-): Promise<{ attempted: number }>;
+const admin = createClient(supabaseUrl, supabaseServiceKey);  // no Authorization override
 ```
 
-`fanOutWebPush` is the generalized form of the bounded loop already shipped in
-`_shared/schedulePublishedPush.ts` (PR #601). **Refactor** `notifySchedulePublishedPush` to map
-its `employees` → user_ids via `selectBroadcastPushUserIds` and delegate to `fanOutWebPush` —
-one implementation, no duplication. Its existing test (`schedulePublishedPush.test.ts`) guards the
-identical behavior (including the concurrency-clamp guard).
+Route the broadcast `employees` query, the caller-membership lookup, and **all** `sendWebPushTo*`
+calls through `admin`. This makes the new feature work and fixes the latent cross-user targeted-push
+bug in the same change (documented in the PR).
 
-### Edge function — `send-shift-trade-notification/index.ts`, `created` branch only
+### 2. Caller authorization (major)
 
-Replace the skip with:
-1. Fetch active employees' user_ids for the restaurant (service-role client already in scope):
-   `employees.select('user_id').eq('restaurant_id', restaurantId).eq('is_active', true).not('user_id','is',null)`.
-2. `const targets = selectBroadcastPushUserIds(rows, trade.offered_by?.user_id)`.
-3. `await fanOutWebPush(targets, (uid) => sendWebPushToUser(supabase, uid, trade.restaurant_id, {
-     title: content.heading,                 // "New Shift Available for Trade"
-     body: 'A teammate offered a shift for trade. Tap to view.',
-     url: '/employee/shifts',
-     tag: `shift-trade-created-${tradeId}`,  // on-device dedupe per trade
-   }))`.
+Today the function only checks that `authHeader` resolves to *some* user — any authenticated user
+can POST an arbitrary `tradeId` and (now) trigger a mass broadcast to another restaurant's staff.
+After fetching the trade, verify membership:
 
-Notes:
-- **Web push only** for the broadcast (no legacy FCM `send-push-notification` fan-out) — FCM is
-  disabled and 100 FCM POSTs would be wasteful; consistent with PR #601's schedule-published fix.
-  The targeted actions keep their existing dual FCM+web-push loop, untouched.
-- Wrapped in try/catch → push failure never blocks the (already-sent) email response.
-- The `created` branch sits in the existing push section; the DB fetch + two helper calls are the
-  only new index.ts lines (thin — new logic is unit-tested in the helper).
+```ts
+const { data: membership } = await admin.from('user_restaurants')
+  .select('role').eq('user_id', user.id).eq('restaurant_id', trade.restaurant_id).maybeSingle();
+if (!membership) return 403;
+```
+
+### 3. Bulk web-push helper (major — avoid N+1 + repeated VAPID signing)
+
+`sendWebPushToUser` does a `web_push_subscriptions` SELECT **and** `webpush.setVapidDetails()` per
+call — 100 targets = 100 SELECTs + 100 ECDSA VAPID setups (real CPU) in one invocation. Add a bulk
+variant to `_shared/webPushHelper.ts`:
+
+```ts
+export async function sendWebPushToUsers(
+  supabase, userIds: string[], restaurantId: string, payload: WebPushPayload,
+  opts?: { concurrency?: number; maxTargets?: number },
+): Promise<{ sent: number; cleaned: number; skipped: number }>;
+```
+- One `select('id, user_id, endpoint, p256dh, auth').eq('restaurant_id', restaurantId).in('user_id', userIds)`.
+- `setVapidDetails(...)` **once**; no-op (skip) if VAPID unset.
+- Hard **ceiling** `maxTargets` (default 500): if `userIds` exceeds it, log and process the first N,
+  returning `skipped` — matches the codebase's "max N per run" pattern; keeps the ~10s CPU budget safe.
+- Fan `webpush.sendNotification` out over subscription rows with **bounded concurrency** via the
+  tested `runBounded` primitive; collect 410/404 and delete stale in one batch.
+
+### 4. Pure, tested primitives — `_shared/webPushFanout.ts` (vitest-importable)
+
+```ts
+export function selectBroadcastPushUserIds(
+  employees: Array<{ user_id?: string | null }>, excludeUserId?: string | null,
+): string[];  // drop null user_ids, exclude the actor, dedupe
+
+export async function runBounded<T>(
+  items: T[], worker: (item: T) => Promise<unknown>, concurrency?: number, // default 20
+): Promise<void>;  // Promise.allSettled per chunk; concurrency clamped >= 1 (no hang)
+```
+
+### 5. The `created` branch
+
+```ts
+if (action === 'created') {
+  const { data: rows } = await admin.from('employees')
+    .select('user_id').eq('restaurant_id', trade.restaurant_id)
+    .eq('is_active', true).not('user_id', 'is', null);
+  const targets = selectBroadcastPushUserIds(rows ?? [], trade.offered_by?.user_id);
+  try {
+    await sendWebPushToUsers(admin, targets, trade.restaurant_id, {
+      title: content.heading,                          // "New Shift Available for Trade"
+      body: 'A teammate offered a shift for trade. Tap to view.',
+      url: '/employee/shifts',
+      tag: `trade-created-${tradeId}`,                 // aligns with existing `trade-${action}-${tradeId}`
+    });
+  } catch (e) { console.error('Broadcast web push failed:', e); }
+}
+```
+Web-push only (no legacy FCM) for the broadcast, consistent with PR #601. Push failure never blocks
+the already-sent email.
 
 ### Phase-B seam
 
-The channel decision for `created` is a single, isolated block. When Phase B lands the admin-only
-resolver, this becomes `if (channels.push) { …fanOutWebPush… }` where
-`channels = resolveChannels('shift_trade_created', restaurantId)`. No structural rework needed.
+The `created` channel decision is one isolated block; Phase B wraps it as
+`if (channels.push) { … }` with `channels = resolveChannels('shift_trade_created', restaurantId)`.
 
 ## Testing
 
 - `tests/unit/webPushFanout.test.ts`:
-  - `selectBroadcastPushUserIds`: drops null/undefined user_ids; excludes `excludeUserId`; dedupes;
-    returns [] for empty; excludeUserId null/undefined keeps everyone.
-  - `fanOutWebPush`: sends once per id; bounded concurrency (maxInFlight ≤ n); non-throw on a
-    rejecting send; non-positive concurrency clamps to ≥1 (no hang); `{ attempted }` count.
-- `tests/unit/schedulePublishedPush.test.ts`: unchanged, must stay green after the delegation refactor
-  (regression guard that the generalization preserved behavior).
-- Edge-function `index.ts` broadcast wiring: covered indirectly via the pure helpers; Deno lines stay
-  thin. Verified with `deno check`, `eslint`, `typecheck`, full `vitest run`, `build`.
+  - `selectBroadcastPushUserIds`: drops null/undefined; excludes `excludeUserId`; **dedupes**
+    duplicate user_ids; excludeUserId null → keeps all; empty → `[]`.
+  - `runBounded`: runs every item; `maxInFlight ≤ concurrency`; non-throw on a rejecting worker;
+    non-positive concurrency clamps to ≥1 (no hang).
+- `tests/unit/schedulePublishedPush.test.ts`: **unchanged and untouched** (that helper is not
+  modified — the reviewer's refactor-risk finding is avoided entirely).
+- Edge-function `index.ts` + `sendWebPushToUsers` glue are Deno-only (not in `sonar.sources=src`,
+  so not coverage-gated); verified via `deno check`, `eslint`, `typecheck`, full `vitest run`, `build`.
 
 ## Decided trade-offs
 
-- **Broadcast parity with email:** push goes to the same audience as the email (all active
-  employees, minus the poster). No position/availability targeting — that would diverge from the
-  existing email broadcast and is out of scope.
-- **Reach depends on push opt-in.** Only employees who tapped "Enable" receive it. (Separate doc
-  gap — surfacing the opt-in — tracked outside this PR.)
-- **Poster still gets the broadcast email** (unchanged); excluded only from push. Aligning email is
-  a separate, deliberate choice left for later to honor "email unchanged."
+- **Broadcast parity with email:** push targets = active employees minus the poster (same audience
+  as the email). No position/availability targeting (out of scope; would diverge from the email).
+- **Reach depends on push opt-in** (the "Enable" banner). Separate doc gap, tracked outside this PR.
+- **Poster still receives the broadcast email** (unchanged); excluded only from push.
+- **No `notifications_sent` idempotency record:** a client retry of `sendShiftTradeNotification`
+  would re-broadcast. Pre-existing (email already has this); the on-device `tag` collapses duplicate
+  *pushes* per trade. Full idempotency deferred.
+- **notify-schedule-published not migrated** to the bulk helper this round (works via a bare service
+  client); consolidation deferred to Phase B.

--- a/supabase/functions/_shared/webPushFanout.ts
+++ b/supabase/functions/_shared/webPushFanout.ts
@@ -1,0 +1,50 @@
+export interface PushEligibleEmployee {
+  user_id?: string | null;
+}
+
+const RUN_BOUNDED_CONCURRENCY = 20; // bounded fan-out — see design doc "CPU/timeout" note
+
+/**
+ * Reduce a list of employees down to the deduped set of user_ids eligible for a
+ * broadcast push, excluding a given actor (e.g. the poster of a shift trade).
+ * Pure filter — no I/O — so it stays vitest-importable and independent of the
+ * Deno-only web-push send path.
+ */
+export function selectBroadcastPushUserIds(
+  employees: PushEligibleEmployee[],
+  excludeUserId?: string | null,
+): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const employee of employees) {
+    const userId = employee.user_id;
+    if (!userId) continue;
+    if (excludeUserId && userId === excludeUserId) continue;
+    if (seen.has(userId)) continue;
+    seen.add(userId);
+    result.push(userId);
+  }
+  return result;
+}
+
+/**
+ * Run `worker` once per item in bounded-concurrency chunks, so a large fan-out
+ * (e.g. pushing to every active employee) doesn't open hundreds of simultaneous
+ * async calls inside one edge-function invocation. A worker rejection never
+ * aborts the run (Promise.allSettled semantics) — callers that need per-item
+ * failure detail should capture it inside `worker` itself.
+ */
+export async function runBounded<T>(
+  items: T[],
+  worker: (item: T) => Promise<unknown>,
+  concurrency = RUN_BOUNDED_CONCURRENCY,
+): Promise<void> {
+  // Clamp to a positive integer step — a caller-supplied 0/negative concurrency
+  // would otherwise never advance `i`, spinning the loop until the edge function
+  // times out.
+  const step = Math.max(1, Math.floor(concurrency));
+  for (let i = 0; i < items.length; i += step) {
+    const chunk = items.slice(i, i + step);
+    await Promise.allSettled(chunk.map((item) => worker(item)));
+  }
+}

--- a/supabase/functions/_shared/webPushHelper.ts
+++ b/supabase/functions/_shared/webPushHelper.ts
@@ -25,6 +25,62 @@ interface BulkWebPushSubscription extends WebPushSubscription {
 // (see e.g. Toast bulk sync's "max 200 orders per restaurant per run").
 const DEFAULT_MAX_TARGETS = 500;
 
+interface VapidConfig {
+  publicKey: string;
+  privateKey: string;
+  subject: string;
+}
+
+// Minimal shape of the `npm:web-push` module's default export used here — narrower than
+// `any` so lint stays clean while avoiding a hard dependency on the npm package's own types.
+interface WebPushClient {
+  sendNotification(
+    subscription: { endpoint: string; keys: { p256dh: string; auth: string } },
+    payload: string,
+    options?: { TTL?: number }
+  ): Promise<unknown>;
+}
+
+/** Reads the three VAPID env vars; returns null if any are unset (caller should skip/no-op). */
+function getVapidConfig(): VapidConfig | null {
+  const publicKey = Deno.env.get('VAPID_PUBLIC_KEY');
+  const privateKey = Deno.env.get('VAPID_PRIVATE_KEY');
+  const subject = Deno.env.get('VAPID_SUBJECT');
+  if (!publicKey || !privateKey || !subject) {
+    return null;
+  }
+  return { publicKey, privateKey, subject };
+}
+
+/**
+ * Sends one payload to one subscription. Classifies 410 Gone / 404 Not Found as a stale
+ * subscription (caller should batch-delete it) rather than an error worth logging.
+ */
+async function sendToSubscription(
+  webpush: WebPushClient,
+  sub: WebPushSubscription,
+  payload: WebPushPayload
+): Promise<{ sent: boolean; stale: boolean }> {
+  try {
+    await webpush.sendNotification(
+      {
+        endpoint: sub.endpoint,
+        keys: { p256dh: sub.p256dh, auth: sub.auth },
+      },
+      JSON.stringify(payload),
+      { TTL: 86400 } // 24 hour TTL
+    );
+    return { sent: true, stale: false };
+  } catch (err: unknown) {
+    const statusCode = (err as { statusCode?: number })?.statusCode;
+    if (statusCode === 410 || statusCode === 404) {
+      return { sent: false, stale: true };
+    }
+    console.error(`Web push failed for subscription ${sub.id}:`, err);
+    return { sent: false, stale: false };
+  }
+}
+
 /**
  * Send Web Push notifications to all subscriptions for a user at a restaurant.
  * Silently skips if VAPID keys are not configured.
@@ -36,11 +92,8 @@ export async function sendWebPushToUser(
   restaurantId: string,
   payload: WebPushPayload
 ): Promise<{ sent: number; cleaned: number }> {
-  const vapidPublicKey = Deno.env.get('VAPID_PUBLIC_KEY');
-  const vapidPrivateKey = Deno.env.get('VAPID_PRIVATE_KEY');
-  const vapidSubject = Deno.env.get('VAPID_SUBJECT');
-
-  if (!vapidPublicKey || !vapidPrivateKey || !vapidSubject) {
+  const vapidConfig = getVapidConfig();
+  if (!vapidConfig) {
     console.log('Web push: VAPID keys not configured, skipping');
     return { sent: 0, cleaned: 0 };
   }
@@ -58,30 +111,15 @@ export async function sendWebPushToUser(
 
   // Import web-push library
   const webpush = await import('npm:web-push@3.6.7');
-  webpush.setVapidDetails(vapidSubject, vapidPublicKey, vapidPrivateKey);
+  webpush.setVapidDetails(vapidConfig.subject, vapidConfig.publicKey, vapidConfig.privateKey);
 
   let sent = 0;
   const staleIds: string[] = [];
 
   for (const sub of subscriptions as WebPushSubscription[]) {
-    try {
-      await webpush.sendNotification(
-        {
-          endpoint: sub.endpoint,
-          keys: { p256dh: sub.p256dh, auth: sub.auth },
-        },
-        JSON.stringify(payload),
-        { TTL: 86400 } // 24 hour TTL
-      );
-      sent++;
-    } catch (err: unknown) {
-      const statusCode = (err as { statusCode?: number })?.statusCode;
-      if (statusCode === 410 || statusCode === 404) {
-        staleIds.push(sub.id);
-      } else {
-        console.error(`Web push failed for subscription ${sub.id}:`, err);
-      }
-    }
+    const result = await sendToSubscription(webpush, sub, payload);
+    if (result.sent) sent++;
+    if (result.stale) staleIds.push(sub.id);
   }
 
   // Clean up stale subscriptions
@@ -125,11 +163,8 @@ export async function sendWebPushToUsers(
     );
   }
 
-  const vapidPublicKey = Deno.env.get('VAPID_PUBLIC_KEY');
-  const vapidPrivateKey = Deno.env.get('VAPID_PRIVATE_KEY');
-  const vapidSubject = Deno.env.get('VAPID_SUBJECT');
-
-  if (!vapidPublicKey || !vapidPrivateKey || !vapidSubject) {
+  const vapidConfig = getVapidConfig();
+  if (!vapidConfig) {
     console.log('Web push: VAPID keys not configured, skipping');
     return { sent: 0, cleaned: 0, skipped };
   }
@@ -147,7 +182,7 @@ export async function sendWebPushToUsers(
 
   // Import web-push library and configure VAPID once for the whole batch.
   const webpush = await import('npm:web-push@3.6.7');
-  webpush.setVapidDetails(vapidSubject, vapidPublicKey, vapidPrivateKey);
+  webpush.setVapidDetails(vapidConfig.subject, vapidConfig.publicKey, vapidConfig.privateKey);
 
   let sent = 0;
   const staleIds: string[] = [];
@@ -155,24 +190,9 @@ export async function sendWebPushToUsers(
   await runBounded(
     subscriptions as BulkWebPushSubscription[],
     async (sub) => {
-      try {
-        await webpush.sendNotification(
-          {
-            endpoint: sub.endpoint,
-            keys: { p256dh: sub.p256dh, auth: sub.auth },
-          },
-          JSON.stringify(payload),
-          { TTL: 86400 } // 24 hour TTL
-        );
-        sent++;
-      } catch (err: unknown) {
-        const statusCode = (err as { statusCode?: number })?.statusCode;
-        if (statusCode === 410 || statusCode === 404) {
-          staleIds.push(sub.id);
-        } else {
-          console.error(`Web push failed for subscription ${sub.id} (user ${sub.user_id}):`, err);
-        }
-      }
+      const result = await sendToSubscription(webpush, sub, payload);
+      if (result.sent) sent++;
+      if (result.stale) staleIds.push(sub.id);
     },
     opts?.concurrency
   );

--- a/supabase/functions/_shared/webPushHelper.ts
+++ b/supabase/functions/_shared/webPushHelper.ts
@@ -37,9 +37,18 @@ interface WebPushClient {
   sendNotification(
     subscription: { endpoint: string; keys: { p256dh: string; auth: string } },
     payload: string,
-    options?: { TTL?: number }
+    options?: { TTL?: number; timeout?: number }
   ): Promise<unknown>;
 }
+
+/**
+ * Per-request socket timeout (ms) for web-push. Unset, `timeout` defaults to
+ * undefined, so a slow/unresponsive push endpoint would hang the promise
+ * indefinitely and could stall a whole `runBounded` chunk — risking the
+ * edge-function wall-clock limit. 10s bounds each send; a timeout rejects
+ * (handled like any other non-410/404 failure).
+ */
+const PUSH_REQUEST_TIMEOUT_MS = 10_000;
 
 /** Reads the three VAPID env vars; returns null if any are unset (caller should skip/no-op). */
 function getVapidConfig(): VapidConfig | null {
@@ -68,7 +77,7 @@ async function sendToSubscription(
         keys: { p256dh: sub.p256dh, auth: sub.auth },
       },
       JSON.stringify(payload),
-      { TTL: 86400 } // 24 hour TTL
+      { TTL: 86400, timeout: PUSH_REQUEST_TIMEOUT_MS } // 24h TTL; bounded socket timeout
     );
     return { sent: true, stale: false };
   } catch (err: unknown) {

--- a/supabase/functions/_shared/webPushHelper.ts
+++ b/supabase/functions/_shared/webPushHelper.ts
@@ -1,4 +1,5 @@
 import { SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2';
+import { runBounded } from './webPushFanout.ts';
 
 interface WebPushPayload {
   title: string;
@@ -14,6 +15,16 @@ interface WebPushSubscription {
   p256dh: string;
   auth: string;
 }
+
+interface BulkWebPushSubscription extends WebPushSubscription {
+  user_id: string;
+}
+
+// Hard ceiling on how many user_ids a single bulk send will process — keeps the
+// ~10s edge-function CPU budget safe. Matches the codebase's "max N per run" pattern
+// (see e.g. Toast bulk sync's "max 200 orders per restaurant per run").
+const DEFAULT_MAX_TARGETS = 500;
+const BULK_SEND_CONCURRENCY = 20;
 
 /**
  * Send Web Push notifications to all subscriptions for a user at a restaurant.
@@ -82,4 +93,97 @@ export async function sendWebPushToUser(
 
   console.log(`Web push: sent ${sent}/${subscriptions.length} to user ${userId}`);
   return { sent, cleaned: staleIds.length };
+}
+
+/**
+ * Send Web Push notifications to many users' subscriptions in a restaurant with a
+ * single subscription lookup and a single VAPID setup — avoids the N+1 SELECT +
+ * repeated ECDSA VAPID signing that calling `sendWebPushToUser` per target would
+ * cost (see design doc "avoid N+1 + repeated VAPID signing").
+ *
+ * `userIds` beyond `opts.maxTargets` (default 500) are dropped and counted in
+ * `skipped`, so one oversized broadcast can't blow the edge function's CPU budget.
+ * Silently skips (0 sent) if VAPID keys are not configured. Cleans up stale
+ * subscriptions (410 Gone, 404 Not Found) in one batched delete.
+ */
+export async function sendWebPushToUsers(
+  supabase: SupabaseClient,
+  userIds: string[],
+  restaurantId: string,
+  payload: WebPushPayload,
+  opts?: { concurrency?: number; maxTargets?: number }
+): Promise<{ sent: number; cleaned: number; skipped: number }> {
+  if (!userIds.length) {
+    return { sent: 0, cleaned: 0, skipped: 0 };
+  }
+
+  const maxTargets = opts?.maxTargets ?? DEFAULT_MAX_TARGETS;
+  const targetIds = userIds.slice(0, maxTargets);
+  const skipped = userIds.length - targetIds.length;
+  if (skipped > 0) {
+    console.log(
+      `Web push: ${userIds.length} target(s) exceed maxTargets=${maxTargets}, processing first ${targetIds.length} and skipping ${skipped}`
+    );
+  }
+
+  const vapidPublicKey = Deno.env.get('VAPID_PUBLIC_KEY');
+  const vapidPrivateKey = Deno.env.get('VAPID_PRIVATE_KEY');
+  const vapidSubject = Deno.env.get('VAPID_SUBJECT');
+
+  if (!vapidPublicKey || !vapidPrivateKey || !vapidSubject) {
+    console.log('Web push: VAPID keys not configured, skipping');
+    return { sent: 0, cleaned: 0, skipped };
+  }
+
+  // Single lookup for every target's subscriptions, instead of one SELECT per user.
+  const { data: subscriptions, error } = await supabase
+    .from('web_push_subscriptions')
+    .select('id, user_id, endpoint, p256dh, auth')
+    .eq('restaurant_id', restaurantId)
+    .in('user_id', targetIds);
+
+  if (error || !subscriptions?.length) {
+    return { sent: 0, cleaned: 0, skipped };
+  }
+
+  // Import web-push library and configure VAPID once for the whole batch.
+  const webpush = await import('npm:web-push@3.6.7');
+  webpush.setVapidDetails(vapidSubject, vapidPublicKey, vapidPrivateKey);
+
+  let sent = 0;
+  const staleIds: string[] = [];
+
+  await runBounded(
+    subscriptions as BulkWebPushSubscription[],
+    async (sub) => {
+      try {
+        await webpush.sendNotification(
+          {
+            endpoint: sub.endpoint,
+            keys: { p256dh: sub.p256dh, auth: sub.auth },
+          },
+          JSON.stringify(payload),
+          { TTL: 86400 } // 24 hour TTL
+        );
+        sent++;
+      } catch (err: unknown) {
+        const statusCode = (err as { statusCode?: number })?.statusCode;
+        if (statusCode === 410 || statusCode === 404) {
+          staleIds.push(sub.id);
+        } else {
+          console.error(`Web push failed for subscription ${sub.id} (user ${sub.user_id}):`, err);
+        }
+      }
+    },
+    opts?.concurrency ?? BULK_SEND_CONCURRENCY
+  );
+
+  // Clean up stale subscriptions in one batch.
+  if (staleIds.length > 0) {
+    await supabase.from('web_push_subscriptions').delete().in('id', staleIds);
+    console.log(`Cleaned ${staleIds.length} stale web push subscriptions`);
+  }
+
+  console.log(`Web push: sent ${sent}/${subscriptions.length} to ${targetIds.length} target user(s)`);
+  return { sent, cleaned: staleIds.length, skipped };
 }

--- a/supabase/functions/_shared/webPushHelper.ts
+++ b/supabase/functions/_shared/webPushHelper.ts
@@ -24,7 +24,6 @@ interface BulkWebPushSubscription extends WebPushSubscription {
 // ~10s edge-function CPU budget safe. Matches the codebase's "max N per run" pattern
 // (see e.g. Toast bulk sync's "max 200 orders per restaurant per run").
 const DEFAULT_MAX_TARGETS = 500;
-const BULK_SEND_CONCURRENCY = 20;
 
 /**
  * Send Web Push notifications to all subscriptions for a user at a restaurant.
@@ -175,7 +174,7 @@ export async function sendWebPushToUsers(
         }
       }
     },
-    opts?.concurrency ?? BULK_SEND_CONCURRENCY
+    opts?.concurrency
   );
 
   // Clean up stale subscriptions in one batch.

--- a/supabase/functions/send-shift-trade-notification/index.ts
+++ b/supabase/functions/send-shift-trade-notification/index.ts
@@ -10,6 +10,10 @@ const corsHeaders = {
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 };
 
+// Single source of truth for the in-app deep link every shift-trade notification (email
+// button, FCM data.route, and both web-push payloads) points at.
+const EMPLOYEE_SHIFTS_ROUTE = '/employee/shifts';
+
 interface RequestBody {
   tradeId: string;
   action: 'created' | 'accepted' | 'approved' | 'rejected' | 'cancelled';
@@ -338,12 +342,18 @@ const handler = async (req: Request): Promise<Response> => {
     // Caller authorization: any authenticated user could otherwise POST an arbitrary
     // tradeId and trigger notifications (including the broadcast) for a restaurant
     // they have no membership in. Verify the caller belongs to this trade's restaurant.
-    const { data: membership } = await admin
+    const { data: membership, error: membershipError } = await admin
       .from('user_restaurants')
       .select('role')
       .eq('user_id', user.id)
       .eq('restaurant_id', trade.restaurant_id)
       .maybeSingle();
+    if (membershipError) {
+      // Distinguish a transient DB failure from a genuine "not a member" so auth
+      // failures caused by an infra hiccup are auditable, not silently indistinguishable
+      // from a real 403.
+      console.error('Error checking caller membership:', membershipError);
+    }
     if (!membership) {
       return new Response(
         JSON.stringify({ error: 'Forbidden' }),
@@ -425,18 +435,24 @@ const handler = async (req: Request): Promise<Response> => {
       // poster — bulk fan-out (single subscription lookup + bounded concurrency)
       // instead of per-employee sendWebPushToUser calls. Email recipients above are
       // unaffected; this only adds the push channel.
-      const { data: activeEmployees } = await admin
-        .from('employees')
-        .select('user_id')
-        .eq('restaurant_id', trade.restaurant_id)
-        .eq('is_active', true)
-        .not('user_id', 'is', null);
-      const broadcastTargets = selectBroadcastPushUserIds(activeEmployees ?? [], trade.offered_by?.user_id);
+      // Both the target lookup and the send are wrapped together so a failure at either
+      // step degrades to a logged, skipped broadcast instead of ever turning the
+      // already-sent email into a false 500.
       try {
+        const { data: activeEmployees, error: employeesError } = await admin
+          .from('employees')
+          .select('user_id')
+          .eq('restaurant_id', trade.restaurant_id)
+          .eq('is_active', true)
+          .not('user_id', 'is', null);
+        if (employeesError) {
+          console.error('Error fetching active employees for broadcast push:', employeesError);
+        }
+        const broadcastTargets = selectBroadcastPushUserIds(activeEmployees ?? [], trade.offered_by?.user_id);
         await sendWebPushToUsers(admin, broadcastTargets, trade.restaurant_id, {
           title: content.heading,
           body: 'A teammate offered a shift for trade. Tap to view.',
-          url: '/employee/shifts',
+          url: EMPLOYEE_SHIFTS_ROUTE,
           tag: `trade-created-${tradeId}`,
         });
       } catch (e) {
@@ -466,7 +482,7 @@ const handler = async (req: Request): Promise<Response> => {
             user_id: userId,
             title: 'Shift Trade Request',
             body: 'Someone wants to trade a shift with you',
-            data: { route: '/employee/shifts' },
+            data: { route: EMPLOYEE_SHIFTS_ROUTE },
           }),
         });
       } catch (e) {
@@ -477,7 +493,7 @@ const handler = async (req: Request): Promise<Response> => {
         await sendWebPushToUser(admin, userId, trade.restaurant_id, {
           title: 'Shift Trade Update',
           body: content.subject(employeeName),
-          url: '/employee/shifts',
+          url: EMPLOYEE_SHIFTS_ROUTE,
           tag: `trade-${action}-${tradeId}`,
         });
       } catch (e) {

--- a/supabase/functions/send-shift-trade-notification/index.ts
+++ b/supabase/functions/send-shift-trade-notification/index.ts
@@ -2,7 +2,8 @@ import { generateHeader, formatDateTime } from '../_shared/emailTemplates.ts';
 import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
 import { createClient, type SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { Resend } from "https://esm.sh/resend@4.0.0";
-import { sendWebPushToUser } from '../_shared/webPushHelper.ts';
+import { sendWebPushToUser, sendWebPushToUsers } from '../_shared/webPushHelper.ts';
+import { selectBroadcastPushUserIds } from '../_shared/webPushFanout.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -270,6 +271,12 @@ const handler = async (req: Request): Promise<Response> => {
     const supabase = createClient(supabaseUrl, supabaseServiceKey, {
       global: { headers: { Authorization: authHeader } }
     });
+    // Bare service-role client (no Authorization override) for data/notification reads —
+    // the JWT-scoped `supabase` client above runs every `.from()` as the caller
+    // (`authenticated`), which silently no-ops against `web_push_subscriptions` RLS
+    // (`USING (auth.uid() = user_id)`) for anyone but the caller. `admin` is used for
+    // all data access after auth; `supabase` stays limited to `auth.getUser()`.
+    const admin = createClient(supabaseUrl, supabaseServiceKey);
 
     // Verify user authentication
     const { data: { user }, error: userError } = await supabase.auth.getUser();
@@ -325,6 +332,22 @@ const handler = async (req: Request): Promise<Response> => {
       return new Response(
         JSON.stringify({ error: 'Trade not found' }),
         { status: 404, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+
+    // Caller authorization: any authenticated user could otherwise POST an arbitrary
+    // tradeId and trigger notifications (including the broadcast) for a restaurant
+    // they have no membership in. Verify the caller belongs to this trade's restaurant.
+    const { data: membership } = await admin
+      .from('user_restaurants')
+      .select('role')
+      .eq('user_id', user.id)
+      .eq('restaurant_id', trade.restaurant_id)
+      .maybeSingle();
+    if (!membership) {
+      return new Response(
+        JSON.stringify({ error: 'Forbidden' }),
+        { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
       );
     }
 
@@ -398,7 +421,27 @@ const handler = async (req: Request): Promise<Response> => {
     const pushUserIds: string[] = [];
 
     if (action === 'created') {
-      // No targeted push for broadcast — skip (would notify all employees)
+      // Broadcast web push to active employees with a subscription, excluding the
+      // poster — bulk fan-out (single subscription lookup + bounded concurrency)
+      // instead of per-employee sendWebPushToUser calls. Email recipients above are
+      // unaffected; this only adds the push channel.
+      const { data: activeEmployees } = await admin
+        .from('employees')
+        .select('user_id')
+        .eq('restaurant_id', trade.restaurant_id)
+        .eq('is_active', true)
+        .not('user_id', 'is', null);
+      const broadcastTargets = selectBroadcastPushUserIds(activeEmployees ?? [], trade.offered_by?.user_id);
+      try {
+        await sendWebPushToUsers(admin, broadcastTargets, trade.restaurant_id, {
+          title: content.heading,
+          body: 'A teammate offered a shift for trade. Tap to view.',
+          url: '/employee/shifts',
+          tag: `trade-created-${tradeId}`,
+        });
+      } catch (e) {
+        console.error('Broadcast web push failed:', e);
+      }
     } else if (action === 'accepted') {
       // Notify the employee who offered the shift
       if (trade.offered_by?.user_id) pushUserIds.push(trade.offered_by.user_id);
@@ -431,7 +474,7 @@ const handler = async (req: Request): Promise<Response> => {
       }
 
       try {
-        await sendWebPushToUser(supabase, userId, trade.restaurant_id, {
+        await sendWebPushToUser(admin, userId, trade.restaurant_id, {
           title: 'Shift Trade Update',
           body: content.subject(employeeName),
           url: '/employee/shifts',

--- a/supabase/functions/send-shift-trade-notification/index.ts
+++ b/supabase/functions/send-shift-trade-notification/index.ts
@@ -431,24 +431,43 @@ const handler = async (req: Request): Promise<Response> => {
     const pushUserIds: string[] = [];
 
     if (action === 'created') {
-      // Broadcast web push to active employees with a subscription, excluding the
-      // poster — bulk fan-out (single subscription lookup + bounded concurrency)
-      // instead of per-employee sendWebPushToUser calls. Email recipients above are
-      // unaffected; this only adds the push channel.
-      // Both the target lookup and the send are wrapped together so a failure at either
-      // step degrades to a logged, skipped broadcast instead of ever turning the
-      // already-sent email into a false 500.
+      // Push on a newly-offered trade. A DIRECTED trade ("Specific Coworker",
+      // target_employee_id set) is visible only to its target under RLS + the
+      // marketplace filter — so it must push ONLY that employee, never the whole
+      // team, or we'd leak/noise a private offer. An OPEN marketplace trade
+      // (target_employee_id null) broadcasts to active employees, minus the poster.
+      // Bulk fan-out (single subscription lookup + bounded concurrency). Email
+      // recipients above are unaffected; this only adds the push channel. The
+      // whole block is wrapped so a failure at any step degrades to a logged,
+      // skipped push instead of turning the already-sent email into a false 500.
       try {
-        const { data: activeEmployees, error: employeesError } = await admin
-          .from('employees')
-          .select('user_id')
-          .eq('restaurant_id', trade.restaurant_id)
-          .eq('is_active', true)
-          .not('user_id', 'is', null);
-        if (employeesError) {
-          console.error('Error fetching active employees for broadcast push:', employeesError);
+        let broadcastTargets: string[];
+        if (trade.target_employee_id) {
+          const { data: targetEmployee, error: targetError } = await admin
+            .from('employees')
+            .select('user_id')
+            .eq('id', trade.target_employee_id)
+            .eq('restaurant_id', trade.restaurant_id)
+            .maybeSingle();
+          if (targetError) {
+            console.error('Error fetching directed-trade target for push:', targetError);
+          }
+          broadcastTargets = selectBroadcastPushUserIds(
+            targetEmployee ? [targetEmployee] : [],
+            trade.offered_by?.user_id,
+          );
+        } else {
+          const { data: activeEmployees, error: employeesError } = await admin
+            .from('employees')
+            .select('user_id')
+            .eq('restaurant_id', trade.restaurant_id)
+            .eq('is_active', true)
+            .not('user_id', 'is', null);
+          if (employeesError) {
+            console.error('Error fetching active employees for broadcast push:', employeesError);
+          }
+          broadcastTargets = selectBroadcastPushUserIds(activeEmployees ?? [], trade.offered_by?.user_id);
         }
-        const broadcastTargets = selectBroadcastPushUserIds(activeEmployees ?? [], trade.offered_by?.user_id);
         await sendWebPushToUsers(admin, broadcastTargets, trade.restaurant_id, {
           title: content.heading,
           body: 'A teammate offered a shift for trade. Tap to view.',

--- a/tests/unit/webPushFanout.test.ts
+++ b/tests/unit/webPushFanout.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  selectBroadcastPushUserIds,
+  runBounded,
+} from '../../supabase/functions/_shared/webPushFanout';
+
+describe('selectBroadcastPushUserIds', () => {
+  it('drops employees with null or undefined user_id', () => {
+    const employees = [
+      { user_id: 'user-1' },
+      { user_id: null },
+      { user_id: undefined },
+      {},
+    ];
+
+    expect(selectBroadcastPushUserIds(employees)).toEqual(['user-1']);
+  });
+
+  it('excludes the given excludeUserId', () => {
+    const employees = [{ user_id: 'user-1' }, { user_id: 'user-2' }, { user_id: 'user-3' }];
+
+    expect(selectBroadcastPushUserIds(employees, 'user-2')).toEqual(['user-1', 'user-3']);
+  });
+
+  it('dedupes duplicate user_ids', () => {
+    const employees = [
+      { user_id: 'user-1' },
+      { user_id: 'user-1' },
+      { user_id: 'user-2' },
+    ];
+
+    expect(selectBroadcastPushUserIds(employees)).toEqual(['user-1', 'user-2']);
+  });
+
+  it('keeps all users when excludeUserId is null or undefined', () => {
+    const employees = [{ user_id: 'user-1' }, { user_id: 'user-2' }];
+
+    expect(selectBroadcastPushUserIds(employees, null)).toEqual(['user-1', 'user-2']);
+    expect(selectBroadcastPushUserIds(employees, undefined)).toEqual(['user-1', 'user-2']);
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(selectBroadcastPushUserIds([])).toEqual([]);
+  });
+});
+
+describe('runBounded', () => {
+  it('runs the worker exactly once per item', async () => {
+    const items = ['a', 'b', 'c'];
+    const worker = vi.fn().mockResolvedValue(undefined);
+
+    await runBounded(items, worker);
+
+    expect(worker).toHaveBeenCalledTimes(3);
+    expect(worker).toHaveBeenCalledWith('a');
+    expect(worker).toHaveBeenCalledWith('b');
+    expect(worker).toHaveBeenCalledWith('c');
+  });
+
+  it('keeps maxInFlight <= concurrency', async () => {
+    const items = Array.from({ length: 5 }, (_, i) => `item-${i}`);
+
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const worker = vi.fn().mockImplementation(async (item: string) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      inFlight -= 1;
+      return item;
+    });
+
+    await runBounded(items, worker, 2);
+
+    expect(worker).toHaveBeenCalledTimes(5);
+    expect(maxInFlight).toBeLessThanOrEqual(2);
+  });
+
+  it('does not throw when a worker rejects (Promise.allSettled semantics)', async () => {
+    const items = ['a', 'b'];
+    const worker = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('worker failed'))
+      .mockResolvedValueOnce(undefined);
+
+    await expect(runBounded(items, worker)).resolves.toBeUndefined();
+    expect(worker).toHaveBeenCalledTimes(2);
+  });
+
+  it('clamps non-positive concurrency to >= 1 and still completes (no hang)', async () => {
+    const items = ['a', 'b'];
+    const worker = vi.fn().mockResolvedValue(undefined);
+
+    for (const concurrency of [0, -5]) {
+      worker.mockClear();
+      await runBounded(items, worker, concurrency);
+      expect(worker).toHaveBeenCalledTimes(2);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- **Shift-available push:** when an employee offers a shift for trade (`action:'created'`), the team now gets a **push** (previously email-only — push was explicitly skipped). Broadcasts to active employees who opted into push, **excluding the poster**, via a single bulk query + bounded-concurrency fan-out with a safety ceiling.
- **Critical fix (found in design review):** the function built its Supabase client by forwarding the caller's JWT, so it ran under the poster's RLS and read **zero** rows from `web_push_subscriptions` (RLS: `auth.uid() = user_id`). This silently broke **all** cross-user trade pushes (accepted/approved/rejected/cancelled), not just the new broadcast. Now uses a genuine service-role client for subscription/employee reads; JWT client is used only for `auth.getUser()`.
- **Authorization fix:** added the missing caller-membership check — the function previously let any authenticated user trigger notifications for an arbitrary trade at any restaurant.

## Scope
Edge-function only (no migration, no UI). Email behavior unchanged. Web-push only for the broadcast (no legacy FCM). The `created` channel decision is isolated as the seam for **Phase B** (admin-only per-type × per-channel resolver).

## Test plan
- New `tests/unit/webPushFanout.test.ts` (9 tests): `selectBroadcastPushUserIds` (drop null, exclude poster, dedupe) + `runBounded` (bounded concurrency, non-throw on reject, non-positive clamp).
- Verified: full `vitest` **6263 passed / 0 failed**, `typecheck` ✅, `lint` ✅, `deno check` (3 edge files) ✅, `build` ✅, CodeRabbit **no findings**.

## Follow-ups (spawned as tasks)
- `buildEmails` uses the caller-scoped client for `accepted` (pre-existing manager-email drop).
- Dedupe the employees query between email recipients and push targets.
- Phase B: admin-only per-type × per-channel resolver; migrate schedule-published onto the bulk helper.

## Design
docs/superpowers/specs/2026-07-11-shift-available-push-design.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added web push notifications for newly created shift trades, sent to eligible active employees with subscriptions.
  - Excludes the employee who posted the trade from broadcast notifications.
  - Added bulk delivery support with target limits, controlled processing, and stale subscription cleanup.
  - Improved targeted shift-trade notification delivery and consistent navigation links.

- **Bug Fixes**
  - Prevented unauthorized users from triggering notifications for trades outside their restaurant.
  - Push delivery failures no longer interrupt email notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->