### PR TITLE
fix(scheduling): stop directed shift-trade emails leaking to all staff

### DIFF
--- a/docs/superpowers/plans/2026-07-13-directed-trade-email-leak-plan.md
+++ b/docs/superpowers/plans/2026-07-13-directed-trade-email-leak-plan.md
@@ -1,0 +1,54 @@
+# Plan — Directed-trade email leak fix
+
+**Design:** docs/superpowers/specs/2026-07-13-directed-trade-email-leak-design.md
+**Branch:** `fix/directed-trade-email-leak`
+
+TDD. `sonar.sources=src` → edge-function files aren't coverage-gated; pure logic still tested.
+
+---
+
+### Task 1 — `_shared/tradeEmailAudience.ts` (pure helper) + test
+- **Test** `tests/unit/tradeEmailAudience.test.ts` (RED first):
+  - directed + email → `[email]`
+  - directed + null email → `[]` (privacy: never falls back to broadcast)
+  - open (null directedTarget) → returns the broadcast list verbatim
+  - open + empty broadcast → `[]`
+- **Code** `supabase/functions/_shared/tradeEmailAudience.ts`: `DirectedTarget` +
+  `resolveCreatedTradeEmailRecipients(directedTarget, broadcastEmails)` per design.
+- Dep: none.
+
+### Task 2 — wire `buildEmails` + call site + handler flow in `send-shift-trade-notification/index.ts`
+- **Code**:
+  1. `buildEmails`: add trailing `directedTarget: DirectedTarget | null = null`. In the `created`
+     branch, only run the all-active-employees query when `!directedTarget`; then
+     `emails.push(...resolveCreatedTradeEmailRecipients(directedTarget, broadcastEmails))`.
+  2. Call site (~line 381): before calling buildEmails, for `action==='created' && trade.target_employee_id`,
+     resolve the target's email via the bare `admin` client
+     (`.from('employees').select('email').eq('id', trade.target_employee_id).eq('restaurant_id', ...).maybeSingle()`,
+     log error; `directedTarget = { email: t?.email ?? null }`). Add a comment noting the
+     intentional `is_active`-omission parity with the push target lookup. Pass `directedTarget` in.
+  3. **Handler flow (major fix):** replace the `if (recipients.length === 0) return 200` early
+     return with a conditional email send — compute `content`/`employeeName` first (both channels
+     use them), send email only when `recipients.length > 0` (genuine `emailError` still → 500),
+     else `console.warn` and fall through. The `created` push block then runs regardless, so a
+     directed target with no email still gets the push.
+  4. Correct the stale comment in the `created` **push** block ("visible only to its target under
+     RLS + the marketplace filter") → "hidden from non-targets by the marketplace filter
+     (client-side; not RLS-enforced — see task_35a15d77)".
+- **Verify**: `deno check --config supabase/functions/deno.json`, `eslint`, `typecheck`.
+- Dep: 1.
+
+---
+
+## Phase 8 verify
+Full `npx vitest run` (not just the new file), `typecheck`, `lint`, `build`, `deno check` on the
+edited function. No migration, no pgTAP.
+
+## Task order
+1 → 2.
+
+## Out of scope (follow-ups filed)
+- `task_35a15d77` — enforce directed-trade privacy in `shift_trades` RLS Policy 1 (pgTAP).
+- `task_344afce3` — buildEmails caller-scoped client for `accepted` (profiles embed).
+- `task_26513232` — dedupe the two employees queries.
+- Phase B: admin-only per-type × per-channel resolver.

--- a/docs/superpowers/plans/2026-07-13-directed-trade-email-leak-plan.md
+++ b/docs/superpowers/plans/2026-07-13-directed-trade-email-leak-plan.md
@@ -50,5 +50,4 @@ edited function. No migration, no pgTAP.
 ## Out of scope (follow-ups filed)
 - `task_35a15d77` — enforce directed-trade privacy in `shift_trades` RLS Policy 1 (pgTAP).
 - `task_344afce3` — buildEmails caller-scoped client for `accepted` (profiles embed).
-- `task_26513232` — dedupe the two employees queries.
 - Phase B: admin-only per-type × per-channel resolver.

--- a/docs/superpowers/specs/2026-07-13-directed-trade-email-leak-design.md
+++ b/docs/superpowers/specs/2026-07-13-directed-trade-email-leak-design.md
@@ -15,10 +15,20 @@ const { data: employees } = await supabase.from('employees').select('email')
 ```
 
 But shift trades can be **directed** to one coworker (`shift_trades.target_employee_id`).
-Directed trades are visible only to the target under RLS + the marketplace filter
-(`target_employee_id IS NULL OR target_employee_id = me` — migration
-`20260104120000_create_shift_trades.sql`, `useShiftTrades.ts` marketplace query). So a directed
-`created` trade currently **emails the whole team a private offer** they can't see in-app.
+Directed trades are hidden from non-targets **in the app** by the marketplace query's client-side
+filter (`useShiftTrades.ts`: `.or('target_employee_id.is.null,target_employee_id.eq.<me>')`). So a
+directed `created` trade currently **emails the whole team a private offer** they cannot see in
+the UI — the email is strictly worse than the app, actively pushing the private detail out.
+
+> **Correction (design review):** this visibility is **NOT** enforced by RLS. `shift_trades`
+> Policy 1 (`20260104120000_create_shift_trades.sql`) only checks restaurant membership — it never
+> references `target_employee_id`, so any active employee can `SELECT` a directed trade via a raw
+> query. The privacy boundary is client-side only. This email fix still stands and is a net
+> improvement (it stops the server from *broadcasting* directed offers), but it aligns email with
+> the **app-visible** audience, not an RLS-enforced one. The RLS gap is a **separate** pre-existing
+> security issue — filed as its own ticket (`task` spawned), distinct from `task_344afce3`. The
+> stale "visible only to its target under RLS" comment in the `created` **push** block (added in
+> #606) is corrected in this PR too.
 
 PR #606 already fixed the identical leak on the **push** channel (directed → notify only the
 target; open → broadcast). This applies the same gating to **email**.
@@ -71,6 +81,29 @@ const buildEmails = async (supabase, restaurantId, action,
 };
 ```
 
+### Handler flow — don't let "no email recipients" skip the push (design review, major)
+
+The handler currently early-returns `200 "No recipients"` when `buildEmails` is empty — **before**
+the push block. Today `created` recipients are always non-empty (broadcast), so it never fires; but
+after this change a directed trade whose target has **no email** returns `[]`, and the early return
+would skip the push too — so the target would get *neither* channel. Fix: replace the early return
+with a **conditional email send**, and let the push block run regardless:
+
+```ts
+const content = ACTION_CONTENT[action];
+const employeeName = action === 'accepted' ? acceptedByName : offeredByName; // used by email AND push
+
+if (recipients.length > 0) {
+  const html = generateEmailHtml(content, employeeName, shiftDetails, restaurantName, trade.manager_note);
+  const { data: emailData, error: emailError } = await resend.emails.send({ ...to: recipients... });
+  if (emailError) { console.error(...); return 500; }   // genuine send failure stays a 500 (unchanged)
+  console.log(`...emailId=${emailData?.id}`);
+} else {
+  console.warn('No email recipients; continuing to push');
+}
+// push block runs unconditionally below → the directed target still gets a push
+```
+
 ### Call site — resolve the directed target via the `admin` client
 
 The existing bare service-role `admin` client (added in #606) reliably reads the target's email
@@ -108,3 +141,9 @@ already covers a directed target with no email.
 - **Client discipline:** only the new directed-target lookup uses `admin`; the pre-existing
   open-broadcast and `accepted` queries keep their current client — the broader caller-scoped-client
   audit is `task_344afce3`, deliberately out of scope here.
+- **Target lookup omits `is_active`** (matches the merged push lookup at `index.ts:446-451`) — a
+  directed trade should still notify its target even if a race deactivated them; a one-line comment
+  notes the intentional parity so a reviewer doesn't "fix" one lookup out of sync with the other.
+- **RLS gap is out of scope, filed separately:** tightening `shift_trades` Policy 1 to enforce
+  `target_employee_id` is a distinct security ticket; this PR only fixes the server-side email
+  broadcast + corrects the stale "under RLS" comment.

--- a/docs/superpowers/specs/2026-07-13-directed-trade-email-leak-design.md
+++ b/docs/superpowers/specs/2026-07-13-directed-trade-email-leak-design.md
@@ -1,0 +1,110 @@
+# Design — Directed-trade email leak fix
+
+**Date:** 2026-07-13
+**Branch:** `fix/directed-trade-email-leak`
+**Follow-up:** task_0768d931 (from PR #606 review)
+
+## Problem
+
+`send-shift-trade-notification`'s `buildEmails`, `action === 'created'` branch, emails **all**
+active employees in the restaurant:
+
+```ts
+const { data: employees } = await supabase.from('employees').select('email')
+  .eq('restaurant_id', restaurantId).eq('is_active', true).not('email', 'is', null);
+```
+
+But shift trades can be **directed** to one coworker (`shift_trades.target_employee_id`).
+Directed trades are visible only to the target under RLS + the marketplace filter
+(`target_employee_id IS NULL OR target_employee_id = me` — migration
+`20260104120000_create_shift_trades.sql`, `useShiftTrades.ts` marketplace query). So a directed
+`created` trade currently **emails the whole team a private offer** they can't see in-app.
+
+PR #606 already fixed the identical leak on the **push** channel (directed → notify only the
+target; open → broadcast). This applies the same gating to **email**.
+
+## Scope
+
+- **In:** gate the `created` *email* audience — directed trade → the target employee only; open
+  marketplace → all active employees (unchanged).
+- **Out:** any other change to `buildEmails`. In particular the `accepted` branch's
+  `profiles` embed / caller-scoped-client concern is a **separate** follow-up (`task_344afce3`)
+  and is not touched here. Push behavior is already correct (#606) — unchanged.
+
+## Approach
+
+### Pure helper — `_shared/tradeEmailAudience.ts` (vitest-importable, tested)
+
+```ts
+export interface DirectedTarget { email: string | null }
+
+/** Recipients for a 'created' trade email.
+ *  A DIRECTED trade (non-null target) goes ONLY to the target — or nobody if the target has
+ *  no email — NEVER the broadcast list, because directed offers are private to the target.
+ *  An OPEN marketplace trade (null target) uses the full broadcast list. */
+export function resolveCreatedTradeEmailRecipients(
+  directedTarget: DirectedTarget | null,
+  broadcastEmails: string[],
+): string[] {
+  if (directedTarget) return directedTarget.email ? [directedTarget.email] : [];
+  return broadcastEmails;
+}
+```
+
+### `buildEmails` — add a trailing `directedTarget` param
+
+```ts
+const buildEmails = async (supabase, restaurantId, action,
+  offeredByEmployeeEmail?, acceptedByEmployeeEmail?,
+  directedTarget: DirectedTarget | null = null) => {
+  ...
+  if (action === 'created') {
+    let broadcastEmails: string[] = [];
+    if (!directedTarget) {                         // skip the query entirely for directed trades
+      const { data: employees } = await supabase.from('employees').select('email')
+        .eq('restaurant_id', restaurantId).eq('is_active', true).not('email', 'is', null);
+      broadcastEmails = (employees ?? []).map((e) => e.email).filter((e): e is string => !!e);
+    }
+    emails.push(...resolveCreatedTradeEmailRecipients(directedTarget, broadcastEmails));
+  } else if (...) { /* accepted/approved/rejected/cancelled unchanged */ }
+  return [...new Set(emails)];
+};
+```
+
+### Call site — resolve the directed target via the `admin` client
+
+The existing bare service-role `admin` client (added in #606) reliably reads the target's email
+under RLS (per the lesson: a JWT-scoped client can silently read zero rows for other users). The
+JWT-scoped `supabase` client stays as buildEmails's argument for the unchanged open-broadcast /
+accepted queries (scope discipline — not touching `task_344afce3`).
+
+```ts
+let directedTarget: DirectedTarget | null = null;
+if (action === 'created' && trade.target_employee_id) {
+  const { data: t, error: targetErr } = await admin.from('employees').select('email')
+    .eq('id', trade.target_employee_id).eq('restaurant_id', trade.restaurant_id).maybeSingle();
+  if (targetErr) console.error('Error resolving directed-trade email target:', targetErr);
+  directedTarget = { email: t?.email ?? null };
+}
+const recipients = await buildEmails(supabase, trade.restaurant_id, action,
+  trade.offered_by?.email, trade.accepted_by?.email, directedTarget);
+```
+
+Existing empty-recipients guard (`recipients.length === 0` → `200 { message: 'No recipients' }`)
+already covers a directed target with no email.
+
+## Testing
+
+- `tests/unit/tradeEmailAudience.test.ts`: directed + email → `[email]`; directed + null email →
+  `[]` (privacy: never falls back to broadcast); open (null target) → broadcast list; open +
+  empty broadcast → `[]`.
+- Edge-function wiring is Deno-only (`sonar.sources=src` excludes it; not coverage-gated);
+  verified via `deno check`, `eslint`, `typecheck`, full `vitest run`.
+
+## Decided trade-offs
+
+- **Directed `created` email goes only to the target** (not the poster). Mirrors the push channel
+  (#606 excludes the poster); the poster already knows they made the offer. Consistent + private.
+- **Client discipline:** only the new directed-target lookup uses `admin`; the pre-existing
+  open-broadcast and `accepted` queries keep their current client — the broader caller-scoped-client
+  audit is `task_344afce3`, deliberately out of scope here.

--- a/docs/superpowers/specs/2026-07-13-directed-trade-email-leak-design.md
+++ b/docs/superpowers/specs/2026-07-13-directed-trade-email-leak-design.md
@@ -123,8 +123,9 @@ const recipients = await buildEmails(supabase, trade.restaurant_id, action,
   trade.offered_by?.email, trade.accepted_by?.email, directedTarget);
 ```
 
-Existing empty-recipients guard (`recipients.length === 0` → `200 { message: 'No recipients' }`)
-already covers a directed target with no email.
+An empty `recipients` list (e.g. a directed target with no email) no longer short-circuits the
+handler with an early `200`; per the "Handler flow" fix above, it only skips the email send and
+falls through so the push block still runs.
 
 ## Testing
 

--- a/supabase/functions/_shared/tradeEmailAudience.ts
+++ b/supabase/functions/_shared/tradeEmailAudience.ts
@@ -1,0 +1,23 @@
+export interface DirectedTarget {
+  email: string | null;
+}
+
+/**
+ * Recipients for a 'created' trade email.
+ *
+ * A DIRECTED trade (non-null target) goes ONLY to the target — or nobody if the target has
+ * no email — NEVER the broadcast list, because directed offers are private to the target.
+ * An OPEN marketplace trade (null target) uses the full broadcast list.
+ *
+ * Pure filter — no I/O — so it stays vitest-importable and independent of the Deno-only
+ * email send path. Mirrors the push-channel gating in `webPushFanout.ts` (#606).
+ */
+export function resolveCreatedTradeEmailRecipients(
+  directedTarget: DirectedTarget | null,
+  broadcastEmails: string[],
+): string[] {
+  if (directedTarget) {
+    return directedTarget.email ? [directedTarget.email] : [];
+  }
+  return broadcastEmails;
+}

--- a/supabase/functions/send-shift-trade-notification/index.ts
+++ b/supabase/functions/send-shift-trade-notification/index.ts
@@ -4,6 +4,7 @@ import { createClient, type SupabaseClient } from "https://esm.sh/@supabase/supa
 import { Resend } from "https://esm.sh/resend@4.0.0";
 import { sendWebPushToUser, sendWebPushToUsers } from '../_shared/webPushHelper.ts';
 import { selectBroadcastPushUserIds } from '../_shared/webPushFanout.ts';
+import { resolveCreatedTradeEmailRecipients, type DirectedTarget } from '../_shared/tradeEmailAudience.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -68,25 +69,32 @@ const buildEmails = async (
   restaurantId: string,
   action: RequestBody['action'],
   offeredByEmployeeEmail?: string,
-  acceptedByEmployeeEmail?: string
+  acceptedByEmployeeEmail?: string,
+  directedTarget: DirectedTarget | null = null
 ) => {
   const emails: string[] = [];
 
   // Notify based on action
   if (action === 'created') {
-    // Notify all active employees about new marketplace trade
-    const { data: employees } = await supabase
-      .from('employees')
-      .select('email')
-      .eq('restaurant_id', restaurantId)
-      .eq('is_active', true)
-      .not('email', 'is', null);
+    // Notify all active employees about new marketplace trade — but only for OPEN trades.
+    // A DIRECTED trade (target_employee_id set) is private to its target, so skip this
+    // broadcast query entirely and resolve recipients from directedTarget instead.
+    let broadcastEmails: string[] = [];
+    if (!directedTarget) {
+      const { data: employees } = await supabase
+        .from('employees')
+        .select('email')
+        .eq('restaurant_id', restaurantId)
+        .eq('is_active', true)
+        .not('email', 'is', null);
 
-    if (employees) {
-      employees.forEach((emp: { email: string | null }) => {
-        if (emp.email) emails.push(emp.email);
-      });
+      if (employees) {
+        broadcastEmails = employees
+          .map((emp: { email: string | null }) => emp.email)
+          .filter((email: string | null): email is string => !!email);
+      }
     }
+    emails.push(...resolveCreatedTradeEmailRecipients(directedTarget, broadcastEmails));
   } else if (action === 'accepted') {
     // Notify managers about pending approval
     const { data: managers } = await supabase

--- a/supabase/functions/send-shift-trade-notification/index.ts
+++ b/supabase/functions/send-shift-trade-notification/index.ts
@@ -385,13 +385,34 @@ const handler = async (req: Request): Promise<Response> => {
     const offeredByName = trade.offered_by?.name || 'Employee';
     const acceptedByName = trade.accepted_by?.name || '';
 
+    // Resolve the directed-trade email target (if any) via `admin` — reading under RLS with
+    // the JWT-scoped `supabase` client can silently return zero rows for another employee's
+    // row. Deliberately omits `.eq('is_active', true)`: a directed trade should still notify
+    // its target even if a race deactivated them — this intentionally mirrors the directed-
+    // trade target lookup in the push block below (no `is_active` filter there either) so the
+    // two stay in parity.
+    let directedTarget: DirectedTarget | null = null;
+    if (action === 'created' && trade.target_employee_id) {
+      const { data: t, error: targetErr } = await admin
+        .from('employees')
+        .select('email')
+        .eq('id', trade.target_employee_id)
+        .eq('restaurant_id', trade.restaurant_id)
+        .maybeSingle();
+      if (targetErr) {
+        console.error('Error resolving directed-trade email target:', targetErr);
+      }
+      directedTarget = { email: t?.email ?? null };
+    }
+
     // Determine recipients based on action
     const recipients = await buildEmails(
       supabase,
       trade.restaurant_id,
       action,
       trade.offered_by?.email,
-      trade.accepted_by?.email
+      trade.accepted_by?.email,
+      directedTarget
     );
 
     if (recipients.length === 0) {

--- a/supabase/functions/send-shift-trade-notification/index.ts
+++ b/supabase/functions/send-shift-trade-notification/index.ts
@@ -385,25 +385,28 @@ const handler = async (req: Request): Promise<Response> => {
     const offeredByName = trade.offered_by?.name || 'Employee';
     const acceptedByName = trade.accepted_by?.name || '';
 
-    // Resolve the directed-trade email target (if any) via `admin` — reading under RLS with
-    // the JWT-scoped `supabase` client can silently return zero rows for another employee's
-    // row. Deliberately omits `.eq('is_active', true)`: a directed trade should still notify
-    // its target even if a race deactivated them — this intentionally mirrors the directed-
-    // trade target lookup in the push block below (no `is_active` filter there either) so the
-    // two stay in parity.
-    let directedTarget: DirectedTarget | null = null;
+    // Resolve the directed-trade target's employee row once — via `admin`, since reading
+    // under RLS with the JWT-scoped `supabase` client can silently return zero rows for
+    // another employee's row. One query serves both the email target (below) and the push
+    // target (further down), instead of two round-trips for the same row. Deliberately omits
+    // `.eq('is_active', true)`: a directed trade should still notify its target even if a
+    // race deactivated them.
+    let directedTargetEmployee: { email: string | null; user_id: string | null } | null = null;
     if (action === 'created' && trade.target_employee_id) {
       const { data: t, error: targetErr } = await admin
         .from('employees')
-        .select('email')
+        .select('email, user_id')
         .eq('id', trade.target_employee_id)
         .eq('restaurant_id', trade.restaurant_id)
         .maybeSingle();
       if (targetErr) {
-        console.error('Error resolving directed-trade email target:', targetErr);
+        console.error('Error resolving directed-trade target:', targetErr);
       }
-      directedTarget = { email: t?.email ?? null };
+      directedTargetEmployee = t ?? null;
     }
+    const directedTarget: DirectedTarget | null = action === 'created' && trade.target_employee_id
+      ? { email: directedTargetEmployee?.email ?? null }
+      : null;
 
     // Determine recipients based on action
     const recipients = await buildEmails(
@@ -477,17 +480,10 @@ const handler = async (req: Request): Promise<Response> => {
       try {
         let broadcastTargets: string[];
         if (trade.target_employee_id) {
-          const { data: targetEmployee, error: targetError } = await admin
-            .from('employees')
-            .select('user_id')
-            .eq('id', trade.target_employee_id)
-            .eq('restaurant_id', trade.restaurant_id)
-            .maybeSingle();
-          if (targetError) {
-            console.error('Error fetching directed-trade target for push:', targetError);
-          }
+          // Reuses the directed-target row resolved above (email lookup) instead of a
+          // second query for the same employee.
           broadcastTargets = selectBroadcastPushUserIds(
-            targetEmployee ? [targetEmployee] : [],
+            directedTargetEmployee ? [directedTargetEmployee] : [],
             trade.offered_by?.user_id,
           );
         } else {

--- a/supabase/functions/send-shift-trade-notification/index.ts
+++ b/supabase/functions/send-shift-trade-notification/index.ts
@@ -391,8 +391,9 @@ const handler = async (req: Request): Promise<Response> => {
     // target (further down), instead of two round-trips for the same row. Deliberately omits
     // `.eq('is_active', true)`: a directed trade should still notify its target even if a
     // race deactivated them.
+    const isDirectedCreate = action === 'created' && !!trade.target_employee_id;
     let directedTargetEmployee: { email: string | null; user_id: string | null } | null = null;
-    if (action === 'created' && trade.target_employee_id) {
+    if (isDirectedCreate) {
       const { data: t, error: targetErr } = await admin
         .from('employees')
         .select('email, user_id')
@@ -404,7 +405,7 @@ const handler = async (req: Request): Promise<Response> => {
       }
       directedTargetEmployee = t ?? null;
     }
-    const directedTarget: DirectedTarget | null = action === 'created' && trade.target_employee_id
+    const directedTarget: DirectedTarget | null = isDirectedCreate
       ? { email: directedTargetEmployee?.email ?? null }
       : null;
 

--- a/supabase/functions/send-shift-trade-notification/index.ts
+++ b/supabase/functions/send-shift-trade-notification/index.ts
@@ -465,10 +465,11 @@ const handler = async (req: Request): Promise<Response> => {
 
     if (action === 'created') {
       // Push on a newly-offered trade. A DIRECTED trade ("Specific Coworker",
-      // target_employee_id set) is visible only to its target under RLS + the
-      // marketplace filter — so it must push ONLY that employee, never the whole
-      // team, or we'd leak/noise a private offer. An OPEN marketplace trade
-      // (target_employee_id null) broadcasts to active employees, minus the poster.
+      // target_employee_id set) is hidden from non-targets by the marketplace filter
+      // (client-side; not RLS-enforced — see task_35a15d77) — so it must push ONLY
+      // that employee, never the whole team, or we'd leak/noise a private offer. An
+      // OPEN marketplace trade (target_employee_id null) broadcasts to active
+      // employees, minus the poster.
       // Bulk fan-out (single subscription lookup + bounded concurrency). Email
       // recipients above are unaffected; this only adds the push channel. The
       // whole block is wrapped so a failure at any step degrades to a logged,

--- a/supabase/functions/send-shift-trade-notification/index.ts
+++ b/supabase/functions/send-shift-trade-notification/index.ts
@@ -415,46 +415,50 @@ const handler = async (req: Request): Promise<Response> => {
       directedTarget
     );
 
-    if (recipients.length === 0) {
-      console.warn('No recipients found for notification');
-      return new Response(
-        JSON.stringify({ success: true, message: 'No recipients to notify' }),
-        { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
-      );
-    }
-
-    console.log(`Sending shift trade notification to ${recipients.length} recipients`);
-
-    // Get appropriate content for action
+    // Get appropriate content for action — used by both the email below AND the push block
+    // further down, so it's computed unconditionally (recipients being empty must not skip
+    // the push channel, e.g. a directed trade whose target has no email on file).
     const content = ACTION_CONTENT[action];
     const employeeName = action === 'accepted' ? acceptedByName : offeredByName;
 
-    // Generate email HTML
-    const html = generateEmailHtml(
-      content,
-      employeeName,
-      shiftDetails,
-      restaurantName,
-      trade.manager_note
-    );
+    let emailData: { id?: string } | undefined;
 
-    // Send emails via Resend
-    const { data: emailData, error: emailError } = await resend.emails.send({
-      from: 'EasyShiftHQ <notifications@easyshifthq.com>',
-      to: recipients,
-      subject: content.subject(employeeName),
-      html: html,
-    });
+    if (recipients.length > 0) {
+      console.log(`Sending shift trade notification to ${recipients.length} recipients`);
 
-    if (emailError) {
-      console.error('Error sending email:', emailError);
-      return new Response(
-        JSON.stringify({ error: 'Failed to send email', details: emailError }),
-        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      // Generate email HTML
+      const html = generateEmailHtml(
+        content,
+        employeeName,
+        shiftDetails,
+        restaurantName,
+        trade.manager_note
       );
-    }
 
-    console.log(`Successfully sent shift trade notification: emailId=${emailData?.id}`);
+      // Send emails via Resend
+      const { data, error: emailError } = await resend.emails.send({
+        from: 'EasyShiftHQ <notifications@easyshifthq.com>',
+        to: recipients,
+        subject: content.subject(employeeName),
+        html: html,
+      });
+
+      if (emailError) {
+        console.error('Error sending email:', emailError);
+        return new Response(
+          JSON.stringify({ error: 'Failed to send email', details: emailError }),
+          { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+        );
+      }
+
+      emailData = data ?? undefined;
+      console.log(`Successfully sent shift trade notification: emailId=${emailData?.id}`);
+    } else {
+      // No email recipients (e.g. a directed trade whose target has no email on file) — this
+      // is not an error. Fall through so the push block below still runs; it's the only
+      // channel that can reach the target.
+      console.warn('No email recipients; continuing to push');
+    }
 
     // Send push notifications to the relevant employees based on action
     const pushUserIds: string[] = [];

--- a/tests/unit/tradeEmailAudience.test.ts
+++ b/tests/unit/tradeEmailAudience.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { resolveCreatedTradeEmailRecipients } from '../../supabase/functions/_shared/tradeEmailAudience';
+
+describe('resolveCreatedTradeEmailRecipients', () => {
+  it('directed trade with a target email returns only that email', () => {
+    const result = resolveCreatedTradeEmailRecipients(
+      { email: 'target@example.com' },
+      ['broadcast1@example.com', 'broadcast2@example.com'],
+    );
+
+    expect(result).toEqual(['target@example.com']);
+  });
+
+  it('directed trade with a null target email returns [] (never falls back to broadcast)', () => {
+    const result = resolveCreatedTradeEmailRecipients(
+      { email: null },
+      ['broadcast1@example.com', 'broadcast2@example.com'],
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it('open marketplace trade (null directedTarget) returns the broadcast list verbatim', () => {
+    const broadcastEmails = ['broadcast1@example.com', 'broadcast2@example.com'];
+
+    const result = resolveCreatedTradeEmailRecipients(null, broadcastEmails);
+
+    expect(result).toEqual(broadcastEmails);
+  });
+
+  it('open marketplace trade with an empty broadcast list returns []', () => {
+    const result = resolveCreatedTradeEmailRecipients(null, []);
+
+    expect(result).toEqual([]);
+  });
+});

--- a/tests/unit/tradeEmailAudience.test.ts
+++ b/tests/unit/tradeEmailAudience.test.ts
@@ -20,6 +20,24 @@ describe('resolveCreatedTradeEmailRecipients', () => {
     expect(result).toEqual([]);
   });
 
+  it('directed trade with an undefined target email returns [] (never falls back to broadcast)', () => {
+    const result = resolveCreatedTradeEmailRecipients(
+      { email: undefined as unknown as null },
+      ['broadcast1@example.com', 'broadcast2@example.com'],
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it('directed trade with an empty-string target email returns [] (never falls back to broadcast)', () => {
+    const result = resolveCreatedTradeEmailRecipients(
+      { email: '' },
+      ['broadcast1@example.com', 'broadcast2@example.com'],
+    );
+
+    expect(result).toEqual([]);
+  });
+
   it('open marketplace trade (null directedTarget) returns the broadcast list verbatim', () => {
     const broadcastEmails = ['broadcast1@example.com', 'broadcast2@example.com'];
 

--- a/tests/unit/tradeEmailAudience.test.ts
+++ b/tests/unit/tradeEmailAudience.test.ts
@@ -11,7 +11,7 @@ describe('resolveCreatedTradeEmailRecipients', () => {
     expect(result).toEqual(['target@example.com']);
   });
 
-  it('directed trade with a null target email returns [] (never falls back to broadcast)', () => {
+  it('CRITICAL: directed trade with a null target email returns [] (never falls back to broadcast)', () => {
     const result = resolveCreatedTradeEmailRecipients(
       { email: null },
       ['broadcast1@example.com', 'broadcast2@example.com'],
@@ -20,7 +20,7 @@ describe('resolveCreatedTradeEmailRecipients', () => {
     expect(result).toEqual([]);
   });
 
-  it('directed trade with an undefined target email returns [] (never falls back to broadcast)', () => {
+  it('CRITICAL: directed trade with an undefined target email returns [] (never falls back to broadcast)', () => {
     const result = resolveCreatedTradeEmailRecipients(
       { email: undefined as unknown as null },
       ['broadcast1@example.com', 'broadcast2@example.com'],
@@ -29,7 +29,7 @@ describe('resolveCreatedTradeEmailRecipients', () => {
     expect(result).toEqual([]);
   });
 
-  it('directed trade with an empty-string target email returns [] (never falls back to broadcast)', () => {
+  it('CRITICAL: directed trade with an empty-string target email returns [] (never falls back to broadcast)', () => {
     const result = resolveCreatedTradeEmailRecipients(
       { email: '' },
       ['broadcast1@example.com', 'broadcast2@example.com'],


### PR DESCRIPTION
## Summary
- Add `resolveCreatedTradeEmailRecipients` audience helper: a directed trade (`trade.target_employee_id` set) resolves to only that employee's email (or no email recipient if they have none), never falling back to the restaurant-wide broadcast list.
- `buildEmails` in `send-shift-trade-notification/index.ts` skips the all-active-employees broadcast query entirely for directed `created` trades, and the call site resolves the target's email via the admin client before invoking `buildEmails`.
- Fix a cascading bug uncovered while wiring this in: the handler no longer early-returns 200 when `recipients.length === 0` — email is now sent conditionally on having recipients, and the `created` push notification block runs regardless, so a directed target with no email on file still gets their push notification.
- Correct a stale comment in the `created` push block that incorrectly implied RLS enforces trade-target visibility (it's a client-side marketplace filter, not RLS — tracked as a separate follow-up).
- Dedupe the directed-trade employee lookup used by both the email and push paths.

Design doc: `docs/superpowers/specs/2026-07-13-directed-trade-email-leak-design.md`

## Test plan
- [x] `tests/unit/tradeEmailAudience.test.ts` (6/6): directed+email → `[email]`; directed+null/undefined/empty email → `[]` (never falls back to broadcast); open trade → broadcast list verbatim; open+empty broadcast → `[]`.
- [x] `npm run test` — 480 files / 6318 tests passed, 0 failures (1 skipped file, 2 skipped tests, unrelated to this branch).
- [x] `npm run test:db` — 1686/1686 pgTAP tests passed.
- [x] `npm run test:e2e` — 164/164 effective (8 initial failures confirmed flaky/unrelated via isolated re-run, all outside scheduling/notification specs).
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — clean on the 3 changed files (full-repo lint has pre-existing unrelated debt, not a CI gate).
- [x] `npm run build` — clean production build.
- [x] `deno check` on the edited edge function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Directed shift-trade notifications are now emailed only to the intended recipient.
  * Open trades continue to notify all active employees.
  * Push notifications still send when the intended recipient has no email address.
  * Email failures now return an error only when an email send is attempted and fails.

* **Tests**
  * Added coverage for directed, open, and missing-recipient email scenarios.

* **Documentation**
  * Added design and implementation plans for the notification privacy fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->