### PR TITLE
feat(tips): Distribution view — per-employee tips + payout status (replaces broken History tab)

### DIFF
--- a/docs/superpowers/plans/2026-07-12-tips-distribution-view-plan.md
+++ b/docs/superpowers/plans/2026-07-12-tips-distribution-view-plan.md
@@ -1,0 +1,79 @@
+# Plan: Tips "Distribution" view
+
+**Design:** docs/superpowers/specs/2026-07-12-tips-distribution-view-design.md
+**Branch:** `feature/tips-distribution-view`
+
+Tasks are ordered by dependency; each is 2–5 min, TDD (RED → GREEN →
+REFACTOR → COMMIT).
+
+## Task 1 — Aggregation util (pure, tested)
+
+**File:** `src/utils/tipDistribution.ts` + `tests/unit/tipDistribution.test.ts`
+
+- Export `EmployeeDistribution`, `TipDistributionResult` interfaces.
+- Export `aggregateTipDistribution(splits, payouts): TipDistributionResult`:
+  - include only `status ∈ {approved, archived}` splits.
+  - group items by `employee_id`; sum `amount`, `hours_worked` (null→0).
+  - name/role from item's joined `employee` (fallback "Unknown"/null).
+  - `paidCents` = sum of `payouts` by `employee_id`.
+  - `unpaidCents = max(0, earnedCents - paidCents)`.
+  - `sharePct` = earned / totalEarned * 100 (0 when total 0).
+  - sort earned desc, tie-break name asc.
+- Export `paymentStatus(d): 'paid' | 'partial' | 'unpaid'`.
+- **Tests (RED first):** exclude drafts; multi-day sum; paid/partial/unpaid
+  boundaries; over-payment clamp (unpaid ≥ 0); divide-by-zero → 0; empty
+  input → zeroed; sort determinism; null hours + missing employee join.
+
+**Deps:** none. Depends on types from `useTipSplits`/`useTipPayouts`.
+
+## Task 2 — `TipDistribution` component
+
+**File:** `src/components/tips/TipDistribution.tsx`
+
+- Props per design (`splits`, `payouts`, `isLoading`, `isError`,
+  `onNavigateToOverview`).
+- `useMemo` over `aggregateTipDistribution(splits ?? [], payouts)`.
+- Three states in order: row-shaped skeleton (isLoading) → error (isError)
+  → empty (CTA button → `onNavigateToOverview`) → data.
+- Summary metric row (total distributed, employees, paid, unpaid).
+- Semantic `<ul>`/`<li>` rows with per-row `aria-label`; avatar initials,
+  name, role, share bar (`aria-hidden`) + `sharePct` text, hours, earned,
+  three-way status badge (tint + icon + label — color not sole signal).
+- Responsive: two-line stack below `sm:`, single-row grid at `sm:+`; bar
+  hidden below `sm:`. No horizontal scroll.
+- Apple/Notion pinned classes per CLAUDE.md; semantic tokens only.
+
+**Deps:** Task 1.
+
+## Task 3 — Wire the tab into Tips.tsx
+
+**File:** `src/pages/Tips.tsx`
+
+- `ViewMode`: rename `'history'` → `'distribution'`.
+- Fix the bug at the `splits` binding:
+  `const splits = viewMode === 'daily' ? dailySplits : periodSplits;`
+- Destructure `error: periodSplitsError` from the `periodSplits` query and
+  `isLoading: payoutsLoading, error: payoutsError` from `useTipPayouts`.
+- Tab label map → `{ overview, daily, distribution: 'Distribution' }`.
+- Replace the `viewMode === 'history'` locked-periods card block with
+  `<TipDistribution splits={periodSplits} payouts={payouts}
+  isLoading={periodSplitsLoading || payoutsLoading}
+  isError={!!periodSplitsError || !!payoutsError}
+  onNavigateToOverview={() => setViewMode('overview')} />`.
+- Remove now-dead imports (`Lock` if unused, `format` usage in old block).
+
+**Deps:** Task 2.
+
+## Task 4 — Verify no stale references
+
+- Grep for `'history'`, `Tip History`, `Locked periods` — ensure no
+  dangling references (e.g. E2E specs, other components).
+- Check `tests/e2e/*tip*` for a History-tab assertion that must update.
+
+**Deps:** Task 3.
+
+## Non-goals (explicit)
+
+- No Overview top-earners strip (fast-follow).
+- No "mark as paid" mutation here.
+- No CSV export, no all-time ledger.

--- a/docs/superpowers/specs/2026-07-12-tips-distribution-view-design.md
+++ b/docs/superpowers/specs/2026-07-12-tips-distribution-view-design.md
@@ -124,6 +124,20 @@ Rules:
 - `sharePct` guarded against divide-by-zero (0 when total is 0).
 - Deterministic sort: `earnedCents` desc, tie-break by `name` asc.
 
+### Payment status (three-way, not binary) — folds review major #2
+
+`unpaidCents`/`paidCents` are continuous, so the badge is **three-way**,
+derived by a pure helper `paymentStatus(d): 'paid' | 'partial' | 'unpaid'`:
+
+- `paid` — `earnedCents > 0 && unpaidCents === 0`.
+- `partial` — `paidCents > 0 && unpaidCents > 0` (e.g. $10 of $50 paid).
+- `unpaid` — `paidCents === 0 && earnedCents > 0`.
+
+Rendered with distinct semantic tints + **text label + icon** (color is
+never the sole signal — a11y): paid = success tint + `Check`, partial =
+warning tint + `Clock` + "Partial", unpaid = muted/amber tint + `Clock`.
+Partial rows also show `$paid / $earned` so a manager sees what's left.
+
 ### Component
 
 New `src/components/tips/TipDistribution.tsx`:
@@ -132,30 +146,64 @@ New `src/components/tips/TipDistribution.tsx`:
 interface TipDistributionProps {
   splits: TipSplitWithItems[] | undefined;
   payouts: TipPayout[];
-  isLoading: boolean;
-  isError: boolean;
-  periodLabel: string;
+  isLoading: boolean;   // periodSplitsLoading || payoutsLoading
+  isError: boolean;     // !!periodSplitsError || !!payoutsError
+  onNavigateToOverview: () => void; // for the empty-state CTA
 }
 ```
 
-Renders (Apple/Notion tokens per CLAUDE.md):
-- Summary metric row: total distributed, employee count, paid, unpaid.
-- Per-employee rows: avatar initials, name, role, a share-of-pool bar,
-  hours, earned amount, and a Paid/Unpaid badge (green/amber semantic
-  tint). Matches the approved mockup.
+The aggregation runs inside a `useMemo(() => aggregateTipDistribution(
+splits ?? [], payouts), [splits, payouts])` (review minor).
 
-### Three-state rendering (lesson 2026-xx line 160)
+Renders (Apple/Notion tokens per CLAUDE.md — pinned classes so
+implementation doesn't drift, mirroring `TipPeriodSummary.tsx`):
+- Summary metric row: total distributed, employee count, paid, unpaid.
+  Values `text-[22px] font-semibold`; labels
+  `text-[12px] font-medium text-muted-foreground uppercase tracking-wider`.
+- Per-employee rows rendered as a **semantic list** (`<ul>`/`<li>`), each
+  `<li>` carrying an `aria-label` that reads as one coherent sentence
+  (e.g. "Maria Santos, Server, earned $812, 19% of pool, paid") so a
+  screen reader doesn't announce fragmented spans. Row contents: avatar
+  initials, name (`text-[14px] font-medium text-foreground`), role
+  (`text-[13px] text-muted-foreground`), a share-of-pool bar, hours,
+  earned amount, and the three-way status badge. Matches the approved
+  mockup.
+- **Share-of-pool bar** (review major #3): the numeric `sharePct` renders
+  as visible text next to the bar (e.g. "19.3%"); the bar `<div>` itself
+  is `aria-hidden="true"` since the number already conveys the value. Bar
+  fill uses a semantic token (`bg-foreground`/`bg-primary`), not a raw
+  color. WCAG 1.1.1 satisfied via the text, not the bar.
+
+### Responsive / mobile (review major #4)
+
+Restaurant managers hit this on-shift on a phone, so the row must degrade
+at 375px. Strategy: below `sm:` (640px) the row becomes two lines — line 1
+is avatar + name + earned amount + status badge; line 2 (indented under
+the name) is role · hours · sharePct. The share bar is hidden below `sm:`
+(the `sharePct` text remains, so no information is lost). At `sm:` and up,
+the single-row grid layout from the mockup applies. No horizontal scroll
+at any width.
+
+### Three-state rendering (lesson line 160) — folds review major #1
 
 The view MUST distinguish, in order:
-1. `isLoading` → skeleton.
+1. `isLoading` → **row-shaped** skeleton (placeholder rows matching the
+   final layout, not a single block — avoids the `TipPeriodSummary`
+   single-`h-24`-blob anti-pattern).
 2. `isError` → error message (do NOT render "$0 / nobody" on error).
-3. empty (no finalized allocations in period) → empty state inviting the
-   user to approve/lock tips in Overview.
+3. empty (no finalized allocations in period) → empty state whose CTA is
+   an actionable button that calls `onNavigateToOverview()` (keyboard
+   operable), not just prose.
 4. data → the table.
 
-`Tips.tsx` will additionally destructure `error: periodSplitsError` from
-the `periodSplits` query (currently only `isLoading` is taken) and pass
-`isError={!!periodSplitsError}`.
+**Both** data sources feed the loading/error props. `Tips.tsx` already
+takes `payouts` from `useTipPayouts`; it will additionally destructure
+`isLoading: payoutsLoading, error: payoutsError` there and
+`error: periodSplitsError` from the `periodSplits` query (currently only
+`isLoading` is taken), then pass the combined booleans:
+`isLoading={periodSplitsLoading || payoutsLoading}` and
+`isError={!!periodSplitsError || !!payoutsError}`. This closes the
+"payout fetch slow/failed → everyone shows Unpaid" gap.
 
 ## Tab wiring
 
@@ -176,7 +224,18 @@ the `periodSplits` query (currently only `isLoading` is taken) and pass
   - empty input → zeroed result, empty array.
   - deterministic sort (earned desc, name tie-break).
   - null `hours_worked` and missing `employee` join handled.
+- `paymentStatus(d)` helper: `paid` / `partial` / `unpaid` boundaries,
+  including the partial case ($10 of $50) and the earned-but-nothing-paid
+  case.
 - Component tests optional per CLAUDE.md (util carries the logic).
+
+### Virtualization note
+
+Per-restaurant per-week distribution is typically <30 rows, below
+CLAUDE.md's 100-item virtualization threshold, so a plain mapped list is
+correct here. If a future multi-outlet pool routinely exceeds ~100 rows,
+revisit with `@tanstack/react-virtual` — noted so it isn't silently
+forgotten.
 
 ## Risks / trade-offs
 

--- a/docs/superpowers/specs/2026-07-12-tips-distribution-view-design.md
+++ b/docs/superpowers/specs/2026-07-12-tips-distribution-view-design.md
@@ -118,7 +118,10 @@ Rules:
 - Employee display name/role from the item's joined `employee` (fallback
   to "Unknown" / null when the join is missing).
 - `paidCents` sums `payouts` by `employee_id` (payouts already period-scoped
-  by the hook's date filter).
+  by the hook's date filter), **but only counts a payout whose
+  `tip_split_id` is `null` (ad-hoc payment) or references a split in the
+  finalized set built above.** A payout linked to a non-finalized split is
+  skipped — see the reopen-masking hazard below.
 - `unpaidCents = max(0, earnedCents - paidCents)` — clamp so an
   over-payment (manual correction) never renders negative.
 - `sharePct` guarded against divide-by-zero (0 when total is 0).
@@ -248,4 +251,22 @@ forgotten.
   React-Query-ref bugs (Effect 2 hours overwrite). This change only
   *reads* `periodSplits` in a `useMemo`; it introduces no effects and no
   writes, so it can't reintroduce that class of bug.
+
+## Decided trade-off: reopen-after-payout masking (Codex/Phase-7 finding)
+
+`reopenSplit()` (`useTipSplits.tsx`) reverts an `approved` split to
+`draft` (manager corrects an error) but leaves any `tip_payouts` already
+recorded against that split's `tip_split_id` in place. If `paidCents`
+summed *all* an employee's period payouts blindly, that stale payout would
+count toward a *different* still-finalized split for the same employee —
+masking a genuinely-unpaid day behind a "Paid" badge. In a payroll-adjacent
+view that is a wage-accuracy defect, not a cosmetic one.
+
+**Resolution (chosen over deferring):** `paidCents` only counts payouts
+whose `tip_split_id` is `null` or references a split in the finalized set.
+A payout tied to a reopened/draft split is excluded, so the finalized
+split correctly reads as unpaid. Ad-hoc (`null`-linked) payouts still count
+as real money paid. Locked in by regression tests in
+`tests/unit/tipDistribution.test.ts` (reopened-split masking + the
+finalized/null happy path).
 ```

--- a/docs/superpowers/specs/2026-07-12-tips-distribution-view-design.md
+++ b/docs/superpowers/specs/2026-07-12-tips-distribution-view-design.md
@@ -1,0 +1,192 @@
+# Design: Tips "Distribution" view (replaces broken "History" tab)
+
+**Date:** 2026-07-12
+**Branch:** `feature/tips-distribution-view`
+**Author:** Claude (with Jose)
+
+## Problem
+
+Two problems, one fix.
+
+1. **The "History" tab is broken.** On `/tips`, the History view renders
+   from `splits`, which is bound to `dailySplits` for any non-`overview`
+   mode (`Tips.tsx:127`: `viewMode === 'overview' ? periodSplits : dailySplits`).
+   `dailySplits = useTipSplits(restaurantId, today, today)` is scoped to
+   **today only** (`useTipSplits` filters `gte/lte split_date`). So the
+   History tab can only ever surface archived splits whose `split_date`
+   is today — the entire point of a "history" (locked periods from prior
+   days) is silently filtered out. Result: it shows "No locked periods
+   yet" almost always.
+
+2. **We can't see how tips are distributed.** The per-employee allocation
+   data (`tip_split_items`: employee, amount, hours, role) and the actual
+   disbursements (`tip_payouts`: employee, date, amount) are computed,
+   stored, and fed to payroll — but **no screen ever shows a human "who
+   got what, and were they paid."** The Overview summary shows only a
+   headcount and a period total.
+
+"Locked periods" is an internal state-machine concept
+(`draft → approved → archived`) that leaked into the UI. Nobody manages a
+restaurant wanting to see "locked periods." They want to answer: *how much
+did each person earn this week, is the split fair, and who's still owed?*
+
+## Decision
+
+**Replace the "History" tab with a "Distribution" tab** — a per-employee
+breakdown of tips for the selected period, including payout status. This
+kills the broken screen and fills the visibility gap in one change.
+
+### Scope (first cut)
+
+- **Read-only.** Surface earnings + payout status from existing data. Do
+  NOT add a "mark as paid" mutation here — recording payouts already lives
+  in the Overview timeline (`TipPeriodTimeline` → `handleRecordPayout`).
+- **Same period navigation as Overview.** The Distribution tab reads the
+  currently-selected week (`periodStart`/`periodEnd`) — the same
+  Previous/Next navigation the Overview already has. This is what fixes
+  the today-only bug: the tab uses `periodSplits`, not `dailySplits`.
+- **Finalized allocations only.** Aggregate splits with
+  `status ∈ {approved, archived}`. Drafts are work-in-progress (visible in
+  Daily Entry / drafts list) and would mislead a "distribution" view.
+
+### Out of scope (fast-follow, not this PR)
+
+- Enhancing the Overview `TipPeriodSummary` with an inline top-earners
+  strip. The aggregation util below makes this ~free later, but folding
+  it in now widens the diff and the review surface (see lessons on scope
+  creep). Ship Distribution first.
+- Cross-period / all-time ledger. Period-scoped is the right first cut and
+  reuses existing data with zero new queries.
+- CSV export of the distribution.
+
+## Data flow
+
+No new queries. Both data sources are **already fetched** in `Tips.tsx`
+for the selected period:
+
+- `periodSplits = useTipSplits(restaurantId, periodStartStr, periodEndStr)`
+  — includes `items` (per-employee allocations, joined with employee
+  name/position).
+- `payouts = useTipPayouts(restaurantId, periodStartStr, periodEndStr)`.
+
+### The bug fix
+
+`Tips.tsx:127` changes so the non-daily branch uses period data:
+
+```ts
+// before: overview → periodSplits, everything else (incl. history) → dailySplits
+const splits = viewMode === 'overview' ? periodSplits : dailySplits;
+// after: only Daily Entry uses today-scoped data
+const splits = viewMode === 'daily' ? dailySplits : periodSplits;
+```
+
+Daily Entry keeps `dailySplits`. Overview keeps `periodSplits`.
+Distribution now also gets `periodSplits`.
+
+### Aggregation (pure, testable)
+
+New util `src/utils/tipDistribution.ts`:
+
+```ts
+export interface EmployeeDistribution {
+  employeeId: string;
+  name: string;
+  role: string | null;
+  hoursWorked: number;      // summed across the period's finalized splits
+  earnedCents: number;      // summed tip_split_items.amount
+  paidCents: number;        // summed tip_payouts.amount for this employee/period
+  unpaidCents: number;      // max(0, earned - paid)
+  sharePct: number;         // earnedCents / totalEarnedCents * 100
+}
+
+export interface TipDistributionResult {
+  employees: EmployeeDistribution[]; // sorted earnedCents desc
+  totalEarnedCents: number;
+  totalPaidCents: number;
+  totalUnpaidCents: number;
+}
+
+export function aggregateTipDistribution(
+  splits: TipSplitWithItems[],
+  payouts: TipPayout[],
+): TipDistributionResult;
+```
+
+Rules:
+- Only splits with `status ∈ {approved, archived}` contribute items.
+- Group items by `employee_id`; sum `amount` and `hours_worked` (null → 0).
+- Employee display name/role from the item's joined `employee` (fallback
+  to "Unknown" / null when the join is missing).
+- `paidCents` sums `payouts` by `employee_id` (payouts already period-scoped
+  by the hook's date filter).
+- `unpaidCents = max(0, earnedCents - paidCents)` — clamp so an
+  over-payment (manual correction) never renders negative.
+- `sharePct` guarded against divide-by-zero (0 when total is 0).
+- Deterministic sort: `earnedCents` desc, tie-break by `name` asc.
+
+### Component
+
+New `src/components/tips/TipDistribution.tsx`:
+
+```tsx
+interface TipDistributionProps {
+  splits: TipSplitWithItems[] | undefined;
+  payouts: TipPayout[];
+  isLoading: boolean;
+  isError: boolean;
+  periodLabel: string;
+}
+```
+
+Renders (Apple/Notion tokens per CLAUDE.md):
+- Summary metric row: total distributed, employee count, paid, unpaid.
+- Per-employee rows: avatar initials, name, role, a share-of-pool bar,
+  hours, earned amount, and a Paid/Unpaid badge (green/amber semantic
+  tint). Matches the approved mockup.
+
+### Three-state rendering (lesson 2026-xx line 160)
+
+The view MUST distinguish, in order:
+1. `isLoading` → skeleton.
+2. `isError` → error message (do NOT render "$0 / nobody" on error).
+3. empty (no finalized allocations in period) → empty state inviting the
+   user to approve/lock tips in Overview.
+4. data → the table.
+
+`Tips.tsx` will additionally destructure `error: periodSplitsError` from
+the `periodSplits` query (currently only `isLoading` is taken) and pass
+`isError={!!periodSplitsError}`.
+
+## Tab wiring
+
+- `ViewMode` type: rename the `'history'` member to `'distribution'`.
+- Tab label map: `{ overview: 'Overview', daily: 'Daily Entry',
+  distribution: 'Distribution' }`.
+- Replace the `viewMode === 'history'` block (the broken locked-periods
+  card) with `<TipDistribution … />`.
+- Default `viewMode` stays `'overview'`.
+
+## Testing
+
+- `tests/unit/tipDistribution.test.ts` — the aggregation util:
+  - excludes `draft` splits; includes `approved` + `archived`.
+  - sums amounts + hours per employee across multiple days.
+  - paid/unpaid math, including the over-payment clamp (unpaid ≥ 0).
+  - share percentages sum to ~100 (rounding tolerant); divide-by-zero → 0.
+  - empty input → zeroed result, empty array.
+  - deterministic sort (earned desc, name tie-break).
+  - null `hours_worked` and missing `employee` join handled.
+- Component tests optional per CLAUDE.md (util carries the logic).
+
+## Risks / trade-offs
+
+- **Period-scoped, not all-time.** A manager wanting last month steps back
+  with Previous. Accepted: matches Overview's mental model, zero new
+  queries, and the today-only bug is what we're actually fixing.
+- **Read-only.** No "mark as paid" here yet; that flow stays in the
+  timeline. Accepted to keep the first cut tight; can add later.
+- **Reusing `periodSplits` reference.** Tips.tsx has a history of
+  React-Query-ref bugs (Effect 2 hours overwrite). This change only
+  *reads* `periodSplits` in a `useMemo`; it introduces no effects and no
+  writes, so it can't reintroduce that class of bug.
+```

--- a/src/components/tips/TipDistribution.tsx
+++ b/src/components/tips/TipDistribution.tsx
@@ -21,11 +21,11 @@ import { formatCurrencyFromCents } from '@/utils/tipPooling';
 
 // Types
 import type { TipSplitWithItems } from '@/hooks/useTipSplits';
-import type { TipPayout } from '@/hooks/useTipPayouts';
+import type { TipPayoutWithEmployee } from '@/hooks/useTipPayouts';
 
 interface TipDistributionProps {
   splits: TipSplitWithItems[] | undefined;
-  payouts: TipPayout[];
+  payouts: TipPayoutWithEmployee[];
   /** periodSplitsLoading || payoutsLoading */
   isLoading: boolean;
   /** !!periodSplitsError || !!payoutsError */
@@ -55,7 +55,12 @@ export function TipDistribution({
 
   if (isLoading) {
     return (
-      <div className="space-y-3" data-testid="tip-distribution-loading">
+      <div
+        className="space-y-3"
+        data-testid="tip-distribution-loading"
+        role="status"
+        aria-live="polite"
+      >
         <Card className="rounded-xl border-border/40">
           <CardContent className="pt-6">
             <Skeleton className="h-16 w-full" />
@@ -220,7 +225,7 @@ function EmployeeRow({ employee }: { employee: EmployeeDistribution }) {
 function StatusBadge({ status, employee }: { status: PaymentStatus; employee: EmployeeDistribution }) {
   if (status === 'paid') {
     return (
-      <Badge className="bg-green-500/10 text-green-700 border-green-500/20">
+      <Badge className="bg-success/10 text-success border-success/20">
         <Check className="mr-1 h-3 w-3" aria-hidden="true" />
         Paid
       </Badge>
@@ -229,7 +234,7 @@ function StatusBadge({ status, employee }: { status: PaymentStatus; employee: Em
 
   if (status === 'partial') {
     return (
-      <Badge className="bg-yellow-500/10 text-yellow-700 border-yellow-500/20">
+      <Badge className="bg-warning/10 text-warning border-warning/20">
         <Clock className="mr-1 h-3 w-3" aria-hidden="true" />
         {formatCurrencyFromCents(employee.paidCents)} / {formatCurrencyFromCents(employee.earnedCents)}
       </Badge>
@@ -237,7 +242,7 @@ function StatusBadge({ status, employee }: { status: PaymentStatus; employee: Em
   }
 
   return (
-    <Badge className="bg-amber-500/10 text-amber-700 border-amber-500/20">
+    <Badge className="bg-muted text-muted-foreground border-border/40">
       <Clock className="mr-1 h-3 w-3" aria-hidden="true" />
       Unpaid
     </Badge>

--- a/src/components/tips/TipDistribution.tsx
+++ b/src/components/tips/TipDistribution.tsx
@@ -1,0 +1,270 @@
+import { useMemo } from 'react';
+
+// UI components (shadcn)
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+
+// Icons
+import { AlertTriangle, Check, Clock, Users } from 'lucide-react';
+
+// Utils
+import {
+  aggregateTipDistribution,
+  paymentStatus,
+  type EmployeeDistribution,
+  type PaymentStatus,
+} from '@/utils/tipDistribution';
+import { formatCurrencyFromCents } from '@/utils/tipPooling';
+
+// Types
+import type { TipSplitWithItems } from '@/hooks/useTipSplits';
+import type { TipPayout } from '@/hooks/useTipPayouts';
+
+interface TipDistributionProps {
+  splits: TipSplitWithItems[] | undefined;
+  payouts: TipPayout[];
+  /** periodSplitsLoading || payoutsLoading */
+  isLoading: boolean;
+  /** !!periodSplitsError || !!payoutsError */
+  isError: boolean;
+  /** CTA target when there's nothing finalized to show yet */
+  onNavigateToOverview: () => void;
+}
+
+/**
+ * TipDistribution — read-only per-employee breakdown of finalized tips for
+ * the selected period, including payout status.
+ *
+ * Aggregation logic lives in `src/utils/tipDistribution.ts`; this component
+ * is purely presentational over that result.
+ */
+export function TipDistribution({
+  splits,
+  payouts,
+  isLoading,
+  isError,
+  onNavigateToOverview,
+}: TipDistributionProps) {
+  const result = useMemo(
+    () => aggregateTipDistribution(splits ?? [], payouts),
+    [splits, payouts],
+  );
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3" data-testid="tip-distribution-loading">
+        <Card className="rounded-xl border-border/40">
+          <CardContent className="pt-6">
+            <Skeleton className="h-16 w-full" />
+          </CardContent>
+        </Card>
+        <div className="space-y-2">
+          <Skeleton className="h-16 w-full rounded-xl" />
+          <Skeleton className="h-16 w-full rounded-xl" />
+          <Skeleton className="h-16 w-full rounded-xl" />
+        </div>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Alert className="border-destructive/50 bg-destructive/10" data-testid="tip-distribution-error">
+        <AlertTriangle className="h-4 w-4 text-destructive" />
+        <AlertDescription className="text-sm">
+          Couldn&apos;t load the tip distribution. Try again in a moment.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (result.employees.length === 0) {
+    return (
+      <Card className="rounded-xl border-border/40">
+        <CardContent className="pt-8 pb-8 flex flex-col items-center gap-3 text-center">
+          <div className="h-10 w-10 rounded-xl bg-muted/50 flex items-center justify-center">
+            <Users className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
+          </div>
+          <div>
+            <p className="text-[14px] font-medium text-foreground">No finalized tips for this period</p>
+            <p className="text-[13px] text-muted-foreground mt-0.5 max-w-sm">
+              Approve or archive a day&apos;s split in Overview to see the distribution here.
+            </p>
+          </div>
+          <Button
+            onClick={onNavigateToOverview}
+            className="h-9 px-4 rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium"
+          >
+            Go to Overview
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card className="rounded-xl border-border/40" data-testid="tip-distribution-summary">
+        <CardContent className="pt-6">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <div className="space-y-1">
+              <p className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
+                Total distributed
+              </p>
+              <p className="text-[22px] font-semibold text-foreground">
+                {formatCurrencyFromCents(result.totalEarnedCents)}
+              </p>
+            </div>
+            <div className="space-y-1">
+              <p className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
+                Employees
+              </p>
+              <p className="text-[22px] font-semibold text-foreground">{result.employees.length}</p>
+            </div>
+            <div className="space-y-1">
+              <p className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
+                Paid
+              </p>
+              <p className="text-[22px] font-semibold text-foreground">
+                {formatCurrencyFromCents(result.totalPaidCents)}
+              </p>
+            </div>
+            <div className="space-y-1">
+              <p className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
+                Unpaid
+              </p>
+              <p className="text-[22px] font-semibold text-foreground">
+                {formatCurrencyFromCents(result.totalUnpaidCents)}
+              </p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <ul className="space-y-2" aria-label="Tip distribution by employee">
+        {result.employees.map((employee) => (
+          <EmployeeRow key={employee.employeeId} employee={employee} />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function EmployeeRow({ employee }: { employee: EmployeeDistribution }) {
+  const status = paymentStatus(employee);
+  const initials = getInitials(employee.name);
+  const sharePctLabel = formatSharePct(employee.sharePct);
+  const roleLabel = employee.role ?? 'No role';
+
+  const ariaLabel = `${employee.name}, ${roleLabel}, earned ${formatCurrencyFromCents(
+    employee.earnedCents,
+  )}, ${sharePctLabel} of pool, ${statusAriaText(status, employee)}`;
+
+  return (
+    <li aria-label={ariaLabel} className="rounded-xl border border-border/40 bg-background p-4">
+      <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-3">
+        {/* Avatar + name + role (role hidden on the same line below sm:) */}
+        <div className="flex min-w-0 flex-1 items-center gap-3">
+          <div
+            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-muted text-[13px] font-medium text-foreground"
+            aria-hidden="true"
+          >
+            {initials}
+          </div>
+          <div className="min-w-0">
+            <p className="truncate text-[14px] font-medium text-foreground">{employee.name}</p>
+            {employee.role && (
+              <p className="hidden truncate text-[13px] text-muted-foreground sm:block">
+                {employee.role}
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* Mobile-only second line: role · hours · share (bar hidden below sm:) */}
+        <p className="pl-12 text-[13px] text-muted-foreground sm:hidden">
+          {roleLabel} &middot; {formatHours(employee.hoursWorked)} &middot; {sharePctLabel}
+        </p>
+
+        {/* Share-of-pool bar — number is the a11y signal; bar is decorative */}
+        <div className="hidden shrink-0 items-center gap-2 sm:flex sm:w-32">
+          <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-muted" aria-hidden="true">
+            <div
+              className="h-full rounded-full bg-foreground"
+              style={{ width: `${Math.min(100, employee.sharePct)}%` }}
+            />
+          </div>
+          <span className="w-12 shrink-0 text-right text-[12px] tabular-nums text-muted-foreground">
+            {sharePctLabel}
+          </span>
+        </div>
+
+        <div className="hidden shrink-0 text-right text-[13px] tabular-nums text-muted-foreground sm:block sm:w-14">
+          {formatHours(employee.hoursWorked)}
+        </div>
+
+        <div className="flex shrink-0 items-center justify-between gap-2 sm:justify-end">
+          <span className="text-[14px] font-medium tabular-nums text-foreground sm:w-20 sm:text-right">
+            {formatCurrencyFromCents(employee.earnedCents)}
+          </span>
+          <StatusBadge status={status} employee={employee} />
+        </div>
+      </div>
+    </li>
+  );
+}
+
+function StatusBadge({ status, employee }: { status: PaymentStatus; employee: EmployeeDistribution }) {
+  if (status === 'paid') {
+    return (
+      <Badge className="bg-green-500/10 text-green-700 border-green-500/20">
+        <Check className="mr-1 h-3 w-3" aria-hidden="true" />
+        Paid
+      </Badge>
+    );
+  }
+
+  if (status === 'partial') {
+    return (
+      <Badge className="bg-yellow-500/10 text-yellow-700 border-yellow-500/20">
+        <Clock className="mr-1 h-3 w-3" aria-hidden="true" />
+        {formatCurrencyFromCents(employee.paidCents)} / {formatCurrencyFromCents(employee.earnedCents)}
+      </Badge>
+    );
+  }
+
+  return (
+    <Badge className="bg-amber-500/10 text-amber-700 border-amber-500/20">
+      <Clock className="mr-1 h-3 w-3" aria-hidden="true" />
+      Unpaid
+    </Badge>
+  );
+}
+
+function statusAriaText(status: PaymentStatus, employee: EmployeeDistribution): string {
+  if (status === 'paid') return 'paid';
+  if (status === 'partial') {
+    return `partially paid, ${formatCurrencyFromCents(employee.paidCents)} of ${formatCurrencyFromCents(
+      employee.earnedCents,
+    )}`;
+  }
+  return 'unpaid';
+}
+
+function formatSharePct(pct: number): string {
+  return `${pct.toFixed(1)}%`;
+}
+
+function formatHours(hours: number): string {
+  return `${hours.toFixed(1)}h`;
+}
+
+function getInitials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return '?';
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+}

--- a/src/pages/Tips.tsx
+++ b/src/pages/Tips.tsx
@@ -33,9 +33,10 @@ import { TipPeriodSummary } from '@/components/tips/TipPeriodSummary';
 import { TipPayoutSheet } from '@/components/tips/TipPayoutSheet';
 import { LockPeriodDialog } from '@/components/tips/LockPeriodDialog';
 import { TipPoolSettingsDialog } from '@/components/tips/TipPoolSettingsDialog';
+import { TipDistribution } from '@/components/tips/TipDistribution';
 import { calculateWorkedHoursForClockInDay } from '@/utils/payrollCalculations';
 import { bufferPunchFetchRange } from '@/utils/punchWindow';
-import { Info, Settings, RefreshCw, Clock, DollarSign, Lock } from 'lucide-react';
+import { Info, Settings, RefreshCw, Clock, DollarSign } from 'lucide-react';
 import { supabase } from '@/integrations/supabase/client';
 
 const defaultWeights: Record<string, number> = {
@@ -45,7 +46,7 @@ const defaultWeights: Record<string, number> = {
   'Host': 1,
 };
 
-type ViewMode = 'overview' | 'daily' | 'history';
+type ViewMode = 'overview' | 'daily' | 'distribution';
 
 export function Tips() {
   // ============ Context Hooks ============
@@ -117,11 +118,11 @@ export function Tips() {
   const { saveTipSplit, isSaving, splits: dailySplits } = useTipSplits(restaurantId, today, today);
 
   // Query for Overview mode - full period range
-  const { splits: periodSplits, isLoading: periodSplitsLoading } = useTipSplits(
-    restaurantId,
-    periodStartStr,
-    periodEndStr
-  );
+  const {
+    splits: periodSplits,
+    isLoading: periodSplitsLoading,
+    error: periodSplitsError,
+  } = useTipSplits(restaurantId, periodStartStr, periodEndStr);
 
   // Payouts for the current period
   const {
@@ -129,10 +130,14 @@ export function Tips() {
     createPayouts,
     isCreating: isCreatingPayouts,
     deletePayout,
+    isLoading: payoutsLoading,
+    error: payoutsError,
   } = useTipPayouts(restaurantId, periodStartStr, periodEndStr);
 
-  // Use appropriate splits based on view mode
-  const splits = viewMode === 'overview' ? periodSplits : dailySplits;
+  // Use appropriate splits based on view mode. Daily Entry is the only mode
+  // scoped to a single day (today); Overview and Distribution both operate
+  // on the full period.
+  const splits = viewMode === 'daily' ? dailySplits : periodSplits;
 
   // Get existing split ID for current day (used for saving server earnings)
   const currentDaySplitId = useMemo(() => {
@@ -803,8 +808,8 @@ export function Tips() {
 
       {/* Apple-style underline tabs */}
       <div className="flex border-b border-border/40">
-        {(['overview', 'daily', 'history'] as const).map((mode) => {
-          const labels: Record<ViewMode, string> = { overview: 'Overview', daily: 'Daily Entry', history: 'History' };
+        {(['overview', 'daily', 'distribution'] as const).map((mode) => {
+          const labels: Record<ViewMode, string> = { overview: 'Overview', daily: 'Daily Entry', distribution: 'Distribution' };
           return (
             <button
               key={mode}
@@ -1080,47 +1085,14 @@ export function Tips() {
         </>
       )}
 
-      {viewMode === 'history' && (
-        <div className="space-y-6">
-          <Card className="rounded-xl border-border/40">
-            <CardHeader className="pb-3">
-              <div className="flex items-center gap-3">
-                <div className="h-10 w-10 rounded-xl bg-muted/50 flex items-center justify-center">
-                  <Lock className="h-5 w-5 text-foreground" />
-                </div>
-                <div>
-                  <CardTitle className="text-[17px] font-semibold text-foreground">Tip History</CardTitle>
-                  <CardDescription className="text-[13px]">Locked periods and payroll reference</CardDescription>
-                </div>
-              </div>
-            </CardHeader>
-            <CardContent>
-              {splits?.filter(s => s.status === 'archived').length ? (
-                <div className="space-y-2">
-                  {splits.filter(s => s.status === 'archived').map(s => (
-                    <div key={s.id} className="flex items-center justify-between p-4 rounded-xl border border-border/40 bg-background hover:border-border transition-colors">
-                      <div className="space-y-0.5">
-                        <span className="text-[14px] font-medium text-foreground">{format(new Date(s.split_date + 'T00:00:00'), 'MMM d, yyyy')}</span>
-                        <p className="text-[13px] text-muted-foreground">
-                          Payroll snapshot: {s.approved_at ? format(new Date(s.approved_at), 'MMM d, yyyy, h:mm a') : 'N/A'}
-                        </p>
-                      </div>
-                      <span className="text-[14px] font-semibold text-foreground">${(s.total_amount / 100).toFixed(2)}</span>
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <div className="py-12 text-center">
-                  <div className="h-10 w-10 rounded-xl bg-muted/50 flex items-center justify-center mx-auto">
-                    <Lock className="h-5 w-5 text-muted-foreground/50" />
-                  </div>
-                  <p className="text-[14px] font-medium text-foreground mt-4">No locked periods yet</p>
-                  <p className="text-[13px] text-muted-foreground mt-1">Locked periods will appear here after you lock tips for payroll.</p>
-                </div>
-              )}
-            </CardContent>
-          </Card>
-        </div>
+      {viewMode === 'distribution' && (
+        <TipDistribution
+          splits={periodSplits}
+          payouts={payouts}
+          isLoading={periodSplitsLoading || payoutsLoading}
+          isError={!!periodSplitsError || !!payoutsError}
+          onNavigateToOverview={() => setViewMode('overview')}
+        />
       )}
 
       {/* Tip Payout Sheet */}

--- a/src/pages/Tips.tsx
+++ b/src/pages/Tips.tsx
@@ -759,6 +759,22 @@ export function Tips() {
     );
   }
 
+  // Shared period navigation for the period-scoped tabs (Overview + Distribution),
+  // so a manager can page through weeks without switching back to Overview.
+  const periodNav = (
+    <div className="flex items-center justify-between pb-2">
+      <Button variant="ghost" aria-label="Previous period" onClick={() => setPeriodOffset(o => o - 1)} className="h-9 rounded-lg text-[13px] font-medium">
+        ← Previous
+      </Button>
+      <span className="text-[14px] font-semibold text-foreground">
+        {`Week of ${periodStart.toLocaleDateString()} - ${periodEnd.toLocaleDateString()}`}
+      </span>
+      <Button variant="ghost" aria-label="Next period" onClick={() => setPeriodOffset(o => o + 1)} disabled={periodOffset >= 0} className="h-9 rounded-lg text-[13px] font-medium">
+        Next →
+      </Button>
+    </div>
+  );
+
   return (
     <div className="space-y-6">
       <header className="flex items-center justify-between">
@@ -831,17 +847,7 @@ export function Tips() {
       {viewMode === 'overview' && (
         <div className="space-y-6">
           {/* Period navigation controls */}
-          <div className="flex items-center justify-between pb-2">
-            <Button variant="ghost" aria-label="Previous period" onClick={() => setPeriodOffset(o => o - 1)} className="h-9 rounded-lg text-[13px] font-medium">
-              ← Previous
-            </Button>
-            <span className="text-[14px] font-semibold text-foreground">
-              {`Week of ${periodStart.toLocaleDateString()} - ${periodEnd.toLocaleDateString()}`}
-            </span>
-            <Button variant="ghost" aria-label="Next period" onClick={() => setPeriodOffset(o => o + 1)} disabled={periodOffset >= 0} className="h-9 rounded-lg text-[13px] font-medium">
-              Next →
-            </Button>
-          </div>
+          {periodNav}
 
           {/* Payroll integration guidance */}
           <Alert>
@@ -1086,13 +1092,18 @@ export function Tips() {
       )}
 
       {viewMode === 'distribution' && (
-        <TipDistribution
-          splits={periodSplits}
-          payouts={payouts}
-          isLoading={periodSplitsLoading || payoutsLoading}
-          isError={!!periodSplitsError || !!payoutsError}
-          onNavigateToOverview={() => setViewMode('overview')}
-        />
+        <div className="space-y-6">
+          {/* Period navigation controls (shared with Overview) */}
+          {periodNav}
+
+          <TipDistribution
+            splits={periodSplits}
+            payouts={payouts}
+            isLoading={periodSplitsLoading || payoutsLoading}
+            isError={!!periodSplitsError || !!payoutsError}
+            onNavigateToOverview={() => setViewMode('overview')}
+          />
+        </div>
       )}
 
       {/* Tip Payout Sheet */}

--- a/src/utils/tipDistribution.ts
+++ b/src/utils/tipDistribution.ts
@@ -9,7 +9,7 @@
  */
 
 import type { TipSplitWithItems } from '@/hooks/useTipSplits';
-import type { TipPayout } from '@/hooks/useTipPayouts';
+import type { TipPayoutWithEmployee } from '@/hooks/useTipPayouts';
 
 /** Splits contribute to the distribution once they're no longer a draft. */
 const FINALIZED_STATUSES = new Set<TipSplitWithItems['status']>(['approved', 'archived']);
@@ -51,7 +51,7 @@ interface EmployeeAccumulator {
  */
 export function aggregateTipDistribution(
   splits: TipSplitWithItems[],
-  payouts: TipPayout[],
+  payouts: TipPayoutWithEmployee[],
 ): TipDistributionResult {
   const accumulators = new Map<string, EmployeeAccumulator>();
   // IDs of the splits that actually contribute earnings this period. A
@@ -93,6 +93,19 @@ export function aggregateTipDistribution(
       payout.employee_id,
       (paidByEmployee.get(payout.employee_id) ?? 0) + payout.amount,
     );
+
+    // A payout can reference an employee with no finalized split item this
+    // period (e.g. an ad-hoc payment). Without this, their paid amount
+    // would be silently dropped from `employees` and the totals below.
+    if (!accumulators.has(payout.employee_id)) {
+      accumulators.set(payout.employee_id, {
+        employeeId: payout.employee_id,
+        name: payout.employee?.name ?? 'Unknown',
+        role: payout.employee?.position ?? null,
+        hoursWorked: 0,
+        earnedCents: 0,
+      });
+    }
   }
 
   const totalEarnedCents = Array.from(accumulators.values()).reduce(

--- a/src/utils/tipDistribution.ts
+++ b/src/utils/tipDistribution.ts
@@ -1,0 +1,136 @@
+/**
+ * Tip Distribution Aggregation
+ *
+ * Pure, testable aggregation of finalized tip splits + payouts into a
+ * per-employee "who got what, and were they paid" breakdown for the
+ * Distribution view.
+ *
+ * @module tipDistribution
+ */
+
+import type { TipSplitWithItems } from '@/hooks/useTipSplits';
+import type { TipPayout } from '@/hooks/useTipPayouts';
+
+/** Splits contribute to the distribution once they're no longer a draft. */
+const FINALIZED_STATUSES = new Set<TipSplitWithItems['status']>(['approved', 'archived']);
+
+export interface EmployeeDistribution {
+  employeeId: string;
+  name: string;
+  role: string | null;
+  hoursWorked: number; // summed across the period's finalized splits
+  earnedCents: number; // summed tip_split_items.amount
+  paidCents: number; // summed tip_payouts.amount for this employee/period
+  unpaidCents: number; // max(0, earned - paid)
+  sharePct: number; // earnedCents / totalEarnedCents * 100
+}
+
+export interface TipDistributionResult {
+  employees: EmployeeDistribution[]; // sorted earnedCents desc, name asc tie-break
+  totalEarnedCents: number;
+  totalPaidCents: number;
+  totalUnpaidCents: number;
+}
+
+export type PaymentStatus = 'paid' | 'partial' | 'unpaid';
+
+interface EmployeeAccumulator {
+  employeeId: string;
+  name: string;
+  role: string | null;
+  hoursWorked: number;
+  earnedCents: number;
+}
+
+/**
+ * Aggregate finalized tip splits and payouts into a per-employee
+ * distribution for the selected period.
+ *
+ * Only splits with `status` of `approved` or `archived` contribute —
+ * drafts are work-in-progress and would mislead a "distribution" view.
+ */
+export function aggregateTipDistribution(
+  splits: TipSplitWithItems[],
+  payouts: TipPayout[],
+): TipDistributionResult {
+  const accumulators = new Map<string, EmployeeAccumulator>();
+
+  for (const split of splits) {
+    if (!FINALIZED_STATUSES.has(split.status)) continue;
+
+    for (const item of split.items) {
+      const existing = accumulators.get(item.employee_id) ?? {
+        employeeId: item.employee_id,
+        name: item.employee?.name ?? 'Unknown',
+        role: item.employee?.position ?? null,
+        hoursWorked: 0,
+        earnedCents: 0,
+      };
+
+      existing.hoursWorked += item.hours_worked ?? 0;
+      existing.earnedCents += item.amount;
+      accumulators.set(item.employee_id, existing);
+    }
+  }
+
+  const paidByEmployee = new Map<string, number>();
+  for (const payout of payouts) {
+    paidByEmployee.set(
+      payout.employee_id,
+      (paidByEmployee.get(payout.employee_id) ?? 0) + payout.amount,
+    );
+  }
+
+  const totalEarnedCents = Array.from(accumulators.values()).reduce(
+    (sum, e) => sum + e.earnedCents,
+    0,
+  );
+
+  const employees: EmployeeDistribution[] = Array.from(accumulators.values()).map((e) => {
+    const paidCents = paidByEmployee.get(e.employeeId) ?? 0;
+    const unpaidCents = Math.max(0, e.earnedCents - paidCents);
+    const sharePct = totalEarnedCents > 0 ? (e.earnedCents / totalEarnedCents) * 100 : 0;
+
+    return {
+      employeeId: e.employeeId,
+      name: e.name,
+      role: e.role,
+      hoursWorked: e.hoursWorked,
+      earnedCents: e.earnedCents,
+      paidCents,
+      unpaidCents,
+      sharePct,
+    };
+  });
+
+  employees.sort((a, b) => {
+    if (b.earnedCents !== a.earnedCents) return b.earnedCents - a.earnedCents;
+    return a.name.localeCompare(b.name);
+  });
+
+  const totalPaidCents = employees.reduce((sum, e) => sum + e.paidCents, 0);
+  const totalUnpaidCents = employees.reduce((sum, e) => sum + e.unpaidCents, 0);
+
+  return {
+    employees,
+    totalEarnedCents,
+    totalPaidCents,
+    totalUnpaidCents,
+  };
+}
+
+/**
+ * Derive a three-way payment status for an employee's distribution row.
+ *
+ * - `paid` — fully paid (or nothing was earned, so nothing is owed).
+ * - `partial` — some paid, but a balance remains.
+ * - `unpaid` — earned something but nothing has been paid yet.
+ */
+export function paymentStatus(distribution: EmployeeDistribution): PaymentStatus {
+  const { earnedCents, paidCents, unpaidCents } = distribution;
+
+  if (unpaidCents === 0) return 'paid';
+  if (paidCents > 0 && unpaidCents > 0) return 'partial';
+  if (paidCents === 0 && earnedCents > 0) return 'unpaid';
+  return 'paid';
+}

--- a/src/utils/tipDistribution.ts
+++ b/src/utils/tipDistribution.ts
@@ -54,9 +54,14 @@ export function aggregateTipDistribution(
   payouts: TipPayout[],
 ): TipDistributionResult {
   const accumulators = new Map<string, EmployeeAccumulator>();
+  // IDs of the splits that actually contribute earnings this period. A
+  // payout only counts as "paid" if it links to one of these (or to no
+  // split at all) — see the payout loop below.
+  const finalizedSplitIds = new Set<string>();
 
   for (const split of splits) {
     if (!FINALIZED_STATUSES.has(split.status)) continue;
+    finalizedSplitIds.add(split.id);
 
     for (const item of split.items) {
       const existing = accumulators.get(item.employee_id) ?? {
@@ -75,6 +80,15 @@ export function aggregateTipDistribution(
 
   const paidByEmployee = new Map<string, number>();
   for (const payout of payouts) {
+    // Skip payouts linked to a split that is NOT part of this period's
+    // finalized set — e.g. a split reopened to draft after being paid
+    // (`reopenSplit`) leaves its payout behind. Counting it would mask a
+    // genuinely-unpaid finalized split for the same employee as "paid".
+    // Ad-hoc payouts with no split link (`tip_split_id === null`) still
+    // count, since they represent money actually paid to the employee.
+    if (payout.tip_split_id !== null && !finalizedSplitIds.has(payout.tip_split_id)) {
+      continue;
+    }
     paidByEmployee.set(
       payout.employee_id,
       (paidByEmployee.get(payout.employee_id) ?? 0) + payout.amount,

--- a/src/utils/tipDistribution.ts
+++ b/src/utils/tipDistribution.ts
@@ -127,10 +127,8 @@ export function aggregateTipDistribution(
  * - `unpaid` — earned something but nothing has been paid yet.
  */
 export function paymentStatus(distribution: EmployeeDistribution): PaymentStatus {
-  const { earnedCents, paidCents, unpaidCents } = distribution;
+  const { paidCents, unpaidCents } = distribution;
 
   if (unpaidCents === 0) return 'paid';
-  if (paidCents > 0 && unpaidCents > 0) return 'partial';
-  if (paidCents === 0 && earnedCents > 0) return 'unpaid';
-  return 'paid';
+  return paidCents > 0 ? 'partial' : 'unpaid';
 }

--- a/tests/unit/TipDistribution.test.tsx
+++ b/tests/unit/TipDistribution.test.tsx
@@ -4,7 +4,7 @@ import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { TipDistribution } from '../../src/components/tips/TipDistribution';
 import type { TipSplitWithItems } from '../../src/hooks/useTipSplits';
-import type { TipPayout } from '../../src/hooks/useTipPayouts';
+import type { TipPayoutWithEmployee } from '../../src/hooks/useTipPayouts';
 
 const employee1 = '11111111-1111-1111-1111-111111111111';
 const employee2 = '22222222-2222-2222-2222-222222222222';
@@ -30,7 +30,7 @@ function makeSplit(overrides: Partial<TipSplitWithItems>): TipSplitWithItems {
   };
 }
 
-function makePayout(overrides: Partial<TipPayout>): TipPayout {
+function makePayout(overrides: Partial<TipPayoutWithEmployee>): TipPayoutWithEmployee {
   return {
     id: 'payout-1',
     restaurant_id: 'restaurant-1',
@@ -152,7 +152,7 @@ describe('TipDistribution', () => {
         ],
       }),
     ];
-    const payouts: TipPayout[] = [makePayout({ employee_id: employee1, amount: 8000 })];
+    const payouts: TipPayoutWithEmployee[] = [makePayout({ employee_id: employee1, amount: 8000 })];
 
     render(
       <TipDistribution
@@ -207,7 +207,7 @@ describe('TipDistribution', () => {
         ],
       }),
     ];
-    const payouts: TipPayout[] = [makePayout({ employee_id: employee1, amount: 1000 })];
+    const payouts: TipPayoutWithEmployee[] = [makePayout({ employee_id: employee1, amount: 1000 })];
 
     render(
       <TipDistribution

--- a/tests/unit/TipDistribution.test.tsx
+++ b/tests/unit/TipDistribution.test.tsx
@@ -1,0 +1,224 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TipDistribution } from '../../src/components/tips/TipDistribution';
+import type { TipSplitWithItems } from '../../src/hooks/useTipSplits';
+import type { TipPayout } from '../../src/hooks/useTipPayouts';
+
+const employee1 = '11111111-1111-1111-1111-111111111111';
+const employee2 = '22222222-2222-2222-2222-222222222222';
+
+/** Minimal split builder — only the fields the component/aggregation read. */
+function makeSplit(overrides: Partial<TipSplitWithItems>): TipSplitWithItems {
+  return {
+    id: 'split-1',
+    restaurant_id: 'restaurant-1',
+    split_date: '2026-07-06',
+    total_amount: 0,
+    status: 'approved',
+    share_method: null,
+    tip_source: null,
+    notes: null,
+    created_by: null,
+    approved_by: null,
+    approved_at: null,
+    created_at: '2026-07-06T00:00:00Z',
+    updated_at: '2026-07-06T00:00:00Z',
+    items: [],
+    ...overrides,
+  };
+}
+
+function makePayout(overrides: Partial<TipPayout>): TipPayout {
+  return {
+    id: 'payout-1',
+    restaurant_id: 'restaurant-1',
+    employee_id: employee1,
+    payout_date: '2026-07-06',
+    amount: 0,
+    tip_split_id: null,
+    notes: null,
+    paid_by: null,
+    created_at: '2026-07-06T00:00:00Z',
+    updated_at: '2026-07-06T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('TipDistribution', () => {
+  it('renders row-shaped skeletons while loading, not the table', () => {
+    render(
+      <TipDistribution
+        splits={undefined}
+        payouts={[]}
+        isLoading
+        isError={false}
+        onNavigateToOverview={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('tip-distribution-loading')).toBeInTheDocument();
+    expect(screen.queryByRole('list', { name: /tip distribution/i })).not.toBeInTheDocument();
+  });
+
+  it('shows an error message and does not render $0/nobody data on error', () => {
+    render(
+      <TipDistribution
+        splits={undefined}
+        payouts={[]}
+        isLoading={false}
+        isError
+        onNavigateToOverview={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId('tip-distribution-error')).toBeInTheDocument();
+    expect(screen.queryByText('$0.00')).not.toBeInTheDocument();
+    expect(screen.queryByRole('list', { name: /tip distribution/i })).not.toBeInTheDocument();
+  });
+
+  it('shows an empty state with a keyboard-operable CTA when there are no finalized allocations', async () => {
+    const user = userEvent.setup();
+    const onNavigateToOverview = vi.fn();
+    render(
+      <TipDistribution
+        splits={[]}
+        payouts={[]}
+        isLoading={false}
+        isError={false}
+        onNavigateToOverview={onNavigateToOverview}
+      />,
+    );
+    expect(screen.getByText(/no finalized tips/i)).toBeInTheDocument();
+    const cta = screen.getByRole('button', { name: /overview/i });
+    await user.click(cta);
+    expect(onNavigateToOverview).toHaveBeenCalledTimes(1);
+  });
+
+  it('excludes draft splits from the empty-state check', () => {
+    render(
+      <TipDistribution
+        splits={[
+          makeSplit({
+            status: 'draft',
+            items: [
+              {
+                id: 'item-1',
+                tip_split_id: 'split-1',
+                employee_id: employee1,
+                amount: 5000,
+                hours_worked: 5,
+                role: 'Server',
+                role_weight: null,
+                employee: { name: 'Maria Santos', position: 'Server' },
+              } as TipSplitWithItems['items'][number],
+            ],
+          }),
+        ]}
+        payouts={[]}
+        isLoading={false}
+        isError={false}
+        onNavigateToOverview={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/no finalized tips/i)).toBeInTheDocument();
+  });
+
+  it('renders the summary row and per-employee rows with share bar + status badge for finalized data', () => {
+    const splits: TipSplitWithItems[] = [
+      makeSplit({
+        id: 'split-1',
+        status: 'approved',
+        items: [
+          {
+            id: 'item-1',
+            tip_split_id: 'split-1',
+            employee_id: employee1,
+            amount: 8000,
+            hours_worked: 10,
+            role: 'Server',
+            role_weight: null,
+            employee: { name: 'Maria Santos', position: 'Server' },
+          } as TipSplitWithItems['items'][number],
+          {
+            id: 'item-2',
+            tip_split_id: 'split-1',
+            employee_id: employee2,
+            amount: 2000,
+            hours_worked: 4,
+            role: 'Busser',
+            role_weight: null,
+            employee: { name: 'Alex Kim', position: 'Busser' },
+          } as TipSplitWithItems['items'][number],
+        ],
+      }),
+    ];
+    const payouts: TipPayout[] = [makePayout({ employee_id: employee1, amount: 8000 })];
+
+    render(
+      <TipDistribution
+        splits={splits}
+        payouts={payouts}
+        isLoading={false}
+        isError={false}
+        onNavigateToOverview={vi.fn()}
+      />,
+    );
+
+    // Summary row (scoped — an individual row can coincidentally show the
+    // same formatted amount as a summary total).
+    const summary = screen.getByTestId('tip-distribution-summary');
+    expect(within(summary).getByText('$100.00')).toBeInTheDocument(); // total distributed
+    expect(within(summary).getByText('$80.00')).toBeInTheDocument(); // total paid
+
+    // Per-employee list is a semantic list
+    const list = screen.getByRole('list', { name: /tip distribution/i });
+    expect(list).toBeInTheDocument();
+
+    // Maria: paid in full, 80% share
+    const mariaRow = screen.getByLabelText(
+      /Maria Santos, Server, earned \$80\.00, 80(\.0)?% of pool, paid/i,
+    );
+    expect(mariaRow).toBeInTheDocument();
+
+    // Alex: nothing paid yet -> unpaid badge
+    const alexRow = screen.getByLabelText(
+      /Alex Kim, Busser, earned \$20\.00, 20(\.0)?% of pool, unpaid/i,
+    );
+    expect(alexRow).toBeInTheDocument();
+    expect(within(alexRow).getByText(/^unpaid$/i)).toBeInTheDocument();
+  });
+
+  it('shows a partial badge with paid/earned amounts when only part of the balance is paid', () => {
+    const splits: TipSplitWithItems[] = [
+      makeSplit({
+        id: 'split-1',
+        status: 'archived',
+        items: [
+          {
+            id: 'item-1',
+            tip_split_id: 'split-1',
+            employee_id: employee1,
+            amount: 5000,
+            hours_worked: 6,
+            role: 'Server',
+            role_weight: null,
+            employee: { name: 'Maria Santos', position: 'Server' },
+          } as TipSplitWithItems['items'][number],
+        ],
+      }),
+    ];
+    const payouts: TipPayout[] = [makePayout({ employee_id: employee1, amount: 1000 })];
+
+    render(
+      <TipDistribution
+        splits={splits}
+        payouts={payouts}
+        isLoading={false}
+        isError={false}
+        onNavigateToOverview={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('$10.00 / $50.00')).toBeInTheDocument();
+  });
+});

--- a/tests/unit/Tips.distributionTab.test.tsx
+++ b/tests/unit/Tips.distributionTab.test.tsx
@@ -222,6 +222,19 @@ describe('Tips page — Distribution tab wiring', () => {
     expect(ids).not.toContain(DAILY_ONLY_SPLIT_ID);
   });
 
+  it('renders period navigation on the Distribution tab so managers can page weeks without leaving it', async () => {
+    const user = userEvent.setup();
+    render(<Tips />);
+
+    await user.click(screen.getByRole('button', { name: 'Distribution' }));
+
+    // The Previous/Next period controls (shared with Overview) must be present
+    // here — the view is period-scoped, so without them Distribution is locked
+    // to whatever week Overview last selected (Codex PR #608 finding).
+    expect(screen.getByRole('button', { name: 'Previous period' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Next period' })).toBeInTheDocument();
+  });
+
   it('combines isLoading from periodSplits and payouts queries', async () => {
     const user = userEvent.setup();
     periodSplitsState.isLoading = false;

--- a/tests/unit/Tips.distributionTab.test.tsx
+++ b/tests/unit/Tips.distributionTab.test.tsx
@@ -1,0 +1,248 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// ---------------------------------------------------------------------------
+// This test locks in the Phase 4 task 3 wiring:
+//   1. The "History" tab is renamed to "Distribution" (and the broken
+//      "locked periods" copy is gone).
+//   2. The `splits` binding bug is fixed: only Daily Entry uses
+//      today-scoped `dailySplits`; Distribution (like Overview) uses the
+//      period-scoped `periodSplits`.
+//   3. `TipDistribution` receives combined loading/error state from BOTH
+//      `useTipSplits` (period) and `useTipPayouts`.
+// ---------------------------------------------------------------------------
+
+// A day inside the current period but NOT today — this is what proves the
+// splits binding bug fix: if Distribution were still wired to `dailySplits`
+// (today-only), this split would never appear.
+const PERIOD_ONLY_SPLIT_ID = 'period-only-split-not-today';
+const DAILY_ONLY_SPLIT_ID = 'daily-only-split-today';
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ loading: false }),
+}));
+
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => ({
+    selectedRestaurant: { restaurant_id: 'restaurant-1' },
+  }),
+}));
+
+// Stable (module-level) empty arrays — Tips.tsx has an effect that recomputes
+// hours from `punches`/`eligibleEmployees` and unconditionally calls
+// setState (see memory/lessons.md 2026-xx "Effect 2" ref-instability note).
+// Returning a fresh `[]` literal from a mock on every render would give that
+// effect a new dependency reference every render and spin it into an
+// infinite loop — so these must be single shared instances.
+const EMPTY_EMPLOYEES: never[] = [];
+const EMPTY_PUNCHES: never[] = [];
+
+vi.mock('@/hooks/useEmployees', () => ({
+  useEmployees: () => ({ employees: EMPTY_EMPLOYEES, loading: false }),
+}));
+
+vi.mock('@/hooks/useTimePunches', () => ({
+  useTimePunches: () => ({ punches: EMPTY_PUNCHES, loading: false }),
+}));
+
+vi.mock('@/hooks/useTipPoolSettings', () => ({
+  useTipPoolSettings: () => ({
+    settings: null,
+    updateSettings: vi.fn(),
+    isLoading: false,
+  }),
+}));
+
+vi.mock('@/hooks/useTipContributionPools', () => ({
+  useTipContributionPools: () => ({
+    pools: [],
+    createPool: vi.fn(),
+    updatePool: vi.fn(),
+    deletePool: vi.fn(),
+    totalContributionPercentage: 0,
+  }),
+}));
+
+// Track the isLoading/error the test wants each `useTipSplits` invocation to
+// report — set per-test via the mutable objects below so we can assert the
+// combined isLoading/isError props passed into TipDistribution.
+const periodSplitsState = { isLoading: false, error: null as Error | null };
+
+vi.mock('@/hooks/useTipSplits', () => ({
+  useTipSplits: (_restaurantId: string | null, startDate?: string, endDate?: string) => {
+    // Daily Entry mode calls useTipSplits(restaurantId, today, today) — same
+    // start/end. Overview + Distribution call it with a period range.
+    const isDailyCall = !!startDate && startDate === endDate;
+
+    if (isDailyCall) {
+      return {
+        splits: [
+          {
+            id: DAILY_ONLY_SPLIT_ID,
+            restaurant_id: 'restaurant-1',
+            split_date: startDate,
+            total_amount: 1000,
+            status: 'archived',
+            share_method: 'hours',
+            tip_source: 'manual',
+            notes: null,
+            created_by: null,
+            approved_by: null,
+            approved_at: null,
+            created_at: '2026-07-06T00:00:00Z',
+            updated_at: '2026-07-06T00:00:00Z',
+            items: [],
+          },
+        ],
+        isLoading: false,
+        error: null,
+        saveTipSplit: vi.fn(),
+        isSaving: false,
+      };
+    }
+
+    // Period call (Overview + Distribution)
+    return {
+      splits: [
+        {
+          id: PERIOD_ONLY_SPLIT_ID,
+          restaurant_id: 'restaurant-1',
+          split_date: startDate,
+          total_amount: 2000,
+          status: 'archived',
+          share_method: 'hours',
+          tip_source: 'manual',
+          notes: null,
+          created_by: null,
+          approved_by: null,
+          approved_at: null,
+          created_at: '2026-07-01T00:00:00Z',
+          updated_at: '2026-07-01T00:00:00Z',
+          items: [],
+        },
+      ],
+      isLoading: periodSplitsState.isLoading,
+      error: periodSplitsState.error,
+      saveTipSplit: vi.fn(),
+      isSaving: false,
+    };
+  },
+}));
+
+const payoutsState = { isLoading: false, error: null as Error | null };
+
+vi.mock('@/hooks/useTipPayouts', () => ({
+  useTipPayouts: () => ({
+    payouts: [],
+    createPayouts: vi.fn(),
+    isCreating: false,
+    deletePayout: vi.fn(),
+    isLoading: payoutsState.isLoading,
+    error: payoutsState.error,
+  }),
+}));
+
+vi.mock('@/hooks/usePOSTips', () => ({
+  usePOSTipsForDate: () => ({ tipData: null, hasTips: false }),
+}));
+
+vi.mock('@/hooks/useAutoSaveTipSettings', () => ({
+  useAutoSaveTipSettings: () => undefined,
+}));
+
+vi.mock('@/hooks/useTipServerEarnings', () => ({
+  useTipServerEarnings: () => ({ saveServerEarnings: vi.fn() }),
+}));
+
+vi.mock('@/components/tips/DisputeManager', () => ({
+  DisputeManager: () => null,
+}));
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: vi.fn(() => ({
+      select: vi.fn().mockReturnThis(),
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+    })),
+    auth: { getUser: vi.fn().mockResolvedValue({ data: { user: null } }) },
+  },
+}));
+
+const tipDistributionSpy = vi.fn();
+vi.mock('@/components/tips/TipDistribution', () => ({
+  TipDistribution: (props: {
+    splits: Array<{ id: string }> | undefined;
+    isLoading: boolean;
+    isError: boolean;
+  }) => {
+    tipDistributionSpy(props);
+    return <div data-testid="tip-distribution-stub" />;
+  },
+}));
+
+// Imported AFTER the mocks above so Tips.tsx picks up the mocked modules.
+import { Tips } from '../../src/pages/Tips';
+
+describe('Tips page — Distribution tab wiring', () => {
+  beforeEach(() => {
+    tipDistributionSpy.mockClear();
+    periodSplitsState.isLoading = false;
+    periodSplitsState.error = null;
+    payoutsState.isLoading = false;
+    payoutsState.error = null;
+  });
+
+  it('renders a "Distribution" tab, not "History", and no locked-periods copy anywhere', async () => {
+    const user = userEvent.setup();
+    render(<Tips />);
+
+    expect(screen.getByRole('button', { name: 'Distribution' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'History' })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Distribution' }));
+
+    expect(screen.queryByText(/tip history/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/locked periods/i)).not.toBeInTheDocument();
+  });
+
+  it('passes period-scoped splits to TipDistribution, not the today-only daily splits (bug fix)', async () => {
+    const user = userEvent.setup();
+    render(<Tips />);
+
+    await user.click(screen.getByRole('button', { name: 'Distribution' }));
+
+    expect(tipDistributionSpy).toHaveBeenCalled();
+    const props = tipDistributionSpy.mock.calls.at(-1)![0];
+    const ids = (props.splits ?? []).map((s: { id: string }) => s.id);
+
+    expect(ids).toContain(PERIOD_ONLY_SPLIT_ID);
+    expect(ids).not.toContain(DAILY_ONLY_SPLIT_ID);
+  });
+
+  it('combines isLoading from periodSplits and payouts queries', async () => {
+    const user = userEvent.setup();
+    periodSplitsState.isLoading = false;
+    payoutsState.isLoading = true;
+
+    render(<Tips />);
+    await user.click(screen.getByRole('button', { name: 'Distribution' }));
+
+    const props = tipDistributionSpy.mock.calls.at(-1)![0];
+    expect(props.isLoading).toBe(true);
+  });
+
+  it('combines isError from periodSplits and payouts queries', async () => {
+    const user = userEvent.setup();
+    periodSplitsState.error = new Error('boom');
+    payoutsState.error = null;
+
+    render(<Tips />);
+    await user.click(screen.getByRole('button', { name: 'Distribution' }));
+
+    const props = tipDistributionSpy.mock.calls.at(-1)![0];
+    expect(props.isError).toBe(true);
+  });
+});

--- a/tests/unit/tipDistribution.test.ts
+++ b/tests/unit/tipDistribution.test.ts
@@ -254,6 +254,96 @@ describe('aggregateTipDistribution', () => {
     expect(result.totalUnpaidCents).toBe(5000);
   });
 
+  it('ignores payouts linked to a non-finalized (reopened) split, so a stale payout cannot mask an unpaid finalized split', () => {
+    // Regression: a manager reopens an already-paid split (reopenSplit
+    // reverts status to draft but leaves the tip_payout in place). That
+    // stale payout must NOT count toward a *different* finalized split
+    // for the same employee, or a genuinely-unpaid day reads as "paid".
+    const splits: TipSplitWithItems[] = [
+      makeSplit({
+        id: 'split-reopened',
+        status: 'draft', // was approved+paid, then reopened to fix an error
+        items: [
+          {
+            id: 'item-reopened',
+            tip_split_id: 'split-reopened',
+            employee_id: employee1,
+            amount: 5000,
+            hours_worked: 5,
+            role: 'Server',
+            role_weight: null,
+            manually_edited: false,
+            created_at: '2026-07-06T00:00:00Z',
+            employee: { name: 'Maria Santos', position: 'Server' },
+          },
+        ],
+      }),
+      makeSplit({
+        id: 'split-finalized',
+        split_date: '2026-07-07',
+        status: 'approved',
+        items: [
+          {
+            id: 'item-finalized',
+            tip_split_id: 'split-finalized',
+            employee_id: employee1,
+            amount: 4000,
+            hours_worked: 4,
+            role: 'Server',
+            role_weight: null,
+            manually_edited: false,
+            created_at: '2026-07-07T00:00:00Z',
+            employee: { name: 'Maria Santos', position: 'Server' },
+          },
+        ],
+      }),
+    ];
+    // The stale payout still points at the now-draft split.
+    const payouts: TipPayout[] = [
+      makePayout({ employee_id: employee1, amount: 5000, tip_split_id: 'split-reopened' }),
+    ];
+
+    const result = aggregateTipDistribution(splits, payouts);
+    const maria = result.employees[0];
+    expect(maria.earnedCents).toBe(4000); // only the finalized split
+    expect(maria.paidCents).toBe(0); // stale payout is not counted
+    expect(maria.unpaidCents).toBe(4000); // correctly surfaced as unpaid
+    expect(paymentStatus(maria)).toBe('unpaid');
+  });
+
+  it('counts payouts linked to a finalized split and unlinked (null) payouts', () => {
+    const splits: TipSplitWithItems[] = [
+      makeSplit({
+        id: 'split-finalized',
+        status: 'approved',
+        items: [
+          {
+            id: 'item-1',
+            tip_split_id: 'split-finalized',
+            employee_id: employee1,
+            amount: 10000,
+            hours_worked: 5,
+            role: 'Server',
+            role_weight: null,
+            manually_edited: false,
+            created_at: '2026-07-06T00:00:00Z',
+            employee: { name: 'Maria Santos', position: 'Server' },
+          },
+        ],
+      }),
+    ];
+    const payouts: TipPayout[] = [
+      makePayout({ employee_id: employee1, amount: 3000, tip_split_id: 'split-finalized' }),
+      makePayout({ employee_id: employee1, amount: 2000, tip_split_id: null }),
+    ];
+
+    const result = aggregateTipDistribution(splits, payouts);
+    const maria = result.employees[0];
+    expect(maria.paidCents).toBe(5000); // both counted
+    expect(maria.unpaidCents).toBe(5000);
+    expect(paymentStatus(maria)).toBe('partial');
+  });
+
   it('computes sharePct against the total, guarding divide-by-zero', () => {
     const splits: TipSplitWithItems[] = [
       makeSplit({

--- a/tests/unit/tipDistribution.test.ts
+++ b/tests/unit/tipDistribution.test.ts
@@ -5,7 +5,7 @@ import {
   type EmployeeDistribution,
 } from '@/utils/tipDistribution';
 import type { TipSplitWithItems } from '@/hooks/useTipSplits';
-import type { TipPayout } from '@/hooks/useTipPayouts';
+import type { TipPayoutWithEmployee } from '@/hooks/useTipPayouts';
 
 const employee1 = '11111111-1111-1111-1111-111111111111';
 const employee2 = '22222222-2222-2222-2222-222222222222';
@@ -32,7 +32,7 @@ function makeSplit(overrides: Partial<TipSplitWithItems>): TipSplitWithItems {
   };
 }
 
-function makePayout(overrides: Partial<TipPayout>): TipPayout {
+function makePayout(overrides: Partial<TipPayoutWithEmployee>): TipPayoutWithEmployee {
   return {
     id: 'payout-1',
     restaurant_id: 'restaurant-1',
@@ -210,7 +210,7 @@ describe('aggregateTipDistribution', () => {
       }),
     ];
     // Overpayment: paid more than earned.
-    const payouts: TipPayout[] = [
+    const payouts: TipPayoutWithEmployee[] = [
       makePayout({ employee_id: employee1, amount: 7000 }),
     ];
 
@@ -241,7 +241,7 @@ describe('aggregateTipDistribution', () => {
         ],
       }),
     ];
-    const payouts: TipPayout[] = [
+    const payouts: TipPayoutWithEmployee[] = [
       makePayout({ employee_id: employee1, amount: 3000 }),
       makePayout({ employee_id: employee1, amount: 2000 }),
     ];
@@ -299,7 +299,7 @@ describe('aggregateTipDistribution', () => {
       }),
     ];
     // The stale payout still points at the now-draft split.
-    const payouts: TipPayout[] = [
+    const payouts: TipPayoutWithEmployee[] = [
       makePayout({ employee_id: employee1, amount: 5000, tip_split_id: 'split-reopened' }),
     ];
 
@@ -332,7 +332,7 @@ describe('aggregateTipDistribution', () => {
         ],
       }),
     ];
-    const payouts: TipPayout[] = [
+    const payouts: TipPayoutWithEmployee[] = [
       makePayout({ employee_id: employee1, amount: 3000, tip_split_id: 'split-finalized' }),
       makePayout({ employee_id: employee1, amount: 2000, tip_split_id: null }),
     ];
@@ -342,6 +342,52 @@ describe('aggregateTipDistribution', () => {
     expect(maria.paidCents).toBe(5000); // both counted
     expect(maria.unpaidCents).toBe(5000);
     expect(paymentStatus(maria)).toBe('partial');
+  });
+
+  it('includes an employee whose only record this period is a payout (no finalized split item)', () => {
+    // Regression: an ad-hoc payout (tip_split_id: null) for an employee who
+    // wasn't part of any finalized split this period must not be silently
+    // dropped from `employees`/totals — they were still paid something.
+    const splits: TipSplitWithItems[] = [
+      makeSplit({
+        items: [
+          {
+            id: 'item-1',
+            tip_split_id: 'split-1',
+            employee_id: employee1,
+            amount: 5000,
+            hours_worked: 5,
+            role: 'Server',
+            role_weight: null,
+            manually_edited: false,
+            created_at: '2026-07-06T00:00:00Z',
+            employee: { name: 'Maria Santos', position: 'Server' },
+          },
+        ],
+      }),
+    ];
+    const payouts: TipPayoutWithEmployee[] = [
+      makePayout({ employee_id: employee1, amount: 5000 }),
+      makePayout({
+        employee_id: employee2,
+        amount: 1500,
+        employee: { name: 'Jordan Lee', position: 'Host' },
+      }),
+    ];
+
+    const result = aggregateTipDistribution(splits, payouts);
+
+    const jordan = result.employees.find((e) => e.employeeId === employee2);
+    expect(jordan).toBeDefined();
+    expect(jordan!.name).toBe('Jordan Lee');
+    expect(jordan!.role).toBe('Host');
+    expect(jordan!.earnedCents).toBe(0);
+    expect(jordan!.paidCents).toBe(1500);
+    expect(jordan!.unpaidCents).toBe(0); // nothing owed, so not "unpaid"
+    expect(paymentStatus(jordan!)).toBe('paid');
+
+    // Their paid amount folds into the totals, not just Maria's.
+    expect(result.totalPaidCents).toBe(6500);
   });
 
   it('computes sharePct against the total, guarding divide-by-zero', () => {
@@ -541,7 +587,7 @@ describe('aggregateTipDistribution', () => {
         ],
       }),
     ];
-    const payouts: TipPayout[] = [
+    const payouts: TipPayoutWithEmployee[] = [
       makePayout({ employee_id: employee1, amount: 10000 }), // fully paid
       makePayout({ employee_id: employee2, amount: 1000 }), // partially paid
     ];

--- a/tests/unit/tipDistribution.test.ts
+++ b/tests/unit/tipDistribution.test.ts
@@ -1,0 +1,502 @@
+import { describe, it, expect } from 'vitest';
+import {
+  aggregateTipDistribution,
+  paymentStatus,
+  type EmployeeDistribution,
+} from '@/utils/tipDistribution';
+import type { TipSplitWithItems } from '@/hooks/useTipSplits';
+import type { TipPayout } from '@/hooks/useTipPayouts';
+
+const employee1 = '11111111-1111-1111-1111-111111111111';
+const employee2 = '22222222-2222-2222-2222-222222222222';
+const employee3 = '33333333-3333-3333-3333-333333333333';
+
+/** Minimal split builder — only the fields aggregateTipDistribution reads. */
+function makeSplit(overrides: Partial<TipSplitWithItems>): TipSplitWithItems {
+  return {
+    id: 'split-1',
+    restaurant_id: 'restaurant-1',
+    split_date: '2026-07-06',
+    total_amount: 0,
+    status: 'approved',
+    share_method: null,
+    tip_source: null,
+    notes: null,
+    created_by: null,
+    approved_by: null,
+    approved_at: null,
+    created_at: '2026-07-06T00:00:00Z',
+    updated_at: '2026-07-06T00:00:00Z',
+    items: [],
+    ...overrides,
+  };
+}
+
+function makePayout(overrides: Partial<TipPayout>): TipPayout {
+  return {
+    id: 'payout-1',
+    restaurant_id: 'restaurant-1',
+    employee_id: employee1,
+    payout_date: '2026-07-06',
+    amount: 0,
+    tip_split_id: null,
+    notes: null,
+    paid_by: null,
+    created_at: '2026-07-06T00:00:00Z',
+    updated_at: '2026-07-06T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('aggregateTipDistribution', () => {
+  it('returns a zeroed result for empty input', () => {
+    const result = aggregateTipDistribution([], []);
+    expect(result.employees).toEqual([]);
+    expect(result.totalEarnedCents).toBe(0);
+    expect(result.totalPaidCents).toBe(0);
+    expect(result.totalUnpaidCents).toBe(0);
+  });
+
+  it('excludes draft splits, includes approved and archived', () => {
+    const splits: TipSplitWithItems[] = [
+      makeSplit({
+        id: 'draft-split',
+        status: 'draft',
+        items: [
+          {
+            id: 'item-draft',
+            tip_split_id: 'draft-split',
+            employee_id: employee1,
+            amount: 5000,
+            hours_worked: 5,
+            role: 'Server',
+            role_weight: null,
+            manually_edited: false,
+            created_at: '2026-07-06T00:00:00Z',
+            employee: { name: 'Maria Santos', position: 'Server' },
+          },
+        ],
+      }),
+      makeSplit({
+        id: 'approved-split',
+        status: 'approved',
+        items: [
+          {
+            id: 'item-approved',
+            tip_split_id: 'approved-split',
+            employee_id: employee1,
+            amount: 8000,
+            hours_worked: 6,
+            role: 'Server',
+            role_weight: null,
+            manually_edited: false,
+            created_at: '2026-07-06T00:00:00Z',
+            employee: { name: 'Maria Santos', position: 'Server' },
+          },
+        ],
+      }),
+      makeSplit({
+        id: 'archived-split',
+        status: 'archived',
+        items: [
+          {
+            id: 'item-archived',
+            tip_split_id: 'archived-split',
+            employee_id: employee1,
+            amount: 2000,
+            hours_worked: 2,
+            role: 'Server',
+            role_weight: null,
+            manually_edited: false,
+            created_at: '2026-07-06T00:00:00Z',
+            employee: { name: 'Maria Santos', position: 'Server' },
+          },
+        ],
+      }),
+    ];
+
+    const result = aggregateTipDistribution(splits, []);
+
+    expect(result.employees).toHaveLength(1);
+    // draft's 5000 must NOT be included; only approved (8000) + archived (2000)
+    expect(result.employees[0].earnedCents).toBe(10000);
+    expect(result.totalEarnedCents).toBe(10000);
+  });
+
+  it('sums amounts and hours per employee across multiple days/splits', () => {
+    const splits: TipSplitWithItems[] = [
+      makeSplit({
+        id: 'split-day-1',
+        split_date: '2026-07-06',
+        items: [
+          {
+            id: 'item-1',
+            tip_split_id: 'split-day-1',
+            employee_id: employee1,
+            amount: 4000,
+            hours_worked: 4,
+            role: 'Server',
+            role_weight: null,
+            manually_edited: false,
+            created_at: '2026-07-06T00:00:00Z',
+            employee: { name: 'Maria Santos', position: 'Server' },
+          },
+          {
+            id: 'item-2',
+            tip_split_id: 'split-day-1',
+            employee_id: employee2,
+            amount: 3000,
+            hours_worked: 3,
+            role: 'Cook',
+            role_weight: null,
+            manually_edited: false,
+            created_at: '2026-07-06T00:00:00Z',
+            employee: { name: 'Alex Kim', position: 'Cook' },
+          },
+        ],
+      }),
+      makeSplit({
+        id: 'split-day-2',
+        split_date: '2026-07-07',
+        items: [
+          {
+            id: 'item-3',
+            tip_split_id: 'split-day-2',
+            employee_id: employee1,
+            amount: 5000,
+            hours_worked: 5,
+            role: 'Server',
+            role_weight: null,
+            manually_edited: false,
+            created_at: '2026-07-07T00:00:00Z',
+            employee: { name: 'Maria Santos', position: 'Server' },
+          },
+        ],
+      }),
+    ];
+
+    const result = aggregateTipDistribution(splits, []);
+
+    const maria = result.employees.find((e) => e.employeeId === employee1);
+    expect(maria).toBeDefined();
+    expect(maria!.earnedCents).toBe(9000); // 4000 + 5000
+    expect(maria!.hoursWorked).toBe(9); // 4 + 5
+
+    const alex = result.employees.find((e) => e.employeeId === employee2);
+    expect(alex).toBeDefined();
+    expect(alex!.earnedCents).toBe(3000);
+    expect(alex!.hoursWorked).toBe(3);
+
+    expect(result.totalEarnedCents).toBe(12000);
+  });
+
+  it('computes paidCents from payouts and clamps unpaidCents at zero on overpayment', () => {
+    const splits: TipSplitWithItems[] = [
+      makeSplit({
+        items: [
+          {
+            id: 'item-1',
+            tip_split_id: 'split-1',
+            employee_id: employee1,
+            amount: 5000,
+            hours_worked: 5,
+            role: 'Server',
+            role_weight: null,
+            manually_edited: false,
+            created_at: '2026-07-06T00:00:00Z',
+            employee: { name: 'Maria Santos', position: 'Server' },
+          },
+        ],
+      }),
+    ];
+    // Overpayment: paid more than earned.
+    const payouts: TipPayout[] = [
+      makePayout({ employee_id: employee1, amount: 7000 }),
+    ];
+
+    const result = aggregateTipDistribution(splits, payouts);
+    const maria = result.employees[0];
+    expect(maria.earnedCents).toBe(5000);
+    expect(maria.paidCents).toBe(7000);
+    expect(maria.unpaidCents).toBe(0); // clamped, never negative
+    expect(result.totalUnpaidCents).toBe(0);
+  });
+
+  it('sums multiple payouts for the same employee within the period', () => {
+    const splits: TipSplitWithItems[] = [
+      makeSplit({
+        items: [
+          {
+            id: 'item-1',
+            tip_split_id: 'split-1',
+            employee_id: employee1,
+            amount: 10000,
+            hours_worked: 5,
+            role: 'Server',
+            role_weight: null,
+            manually_edited: false,
+            created_at: '2026-07-06T00:00:00Z',
+            employee: { name: 'Maria Santos', position: 'Server' },
+          },
+        ],
+      }),
+    ];
+    const payouts: TipPayout[] = [
+      makePayout({ employee_id: employee1, amount: 3000 }),
+      makePayout({ employee_id: employee1, amount: 2000 }),
+    ];
+
+    const result = aggregateTipDistribution(splits, payouts);
+    const maria = result.employees[0];
+    expect(maria.paidCents).toBe(5000);
+    expect(maria.unpaidCents).toBe(5000);
+    expect(result.totalPaidCents).toBe(5000);
+    expect(result.totalUnpaidCents).toBe(5000);
+  });
+
+  it('computes sharePct against the total, guarding divide-by-zero', () => {
+    const splits: TipSplitWithItems[] = [
+      makeSplit({
+        items: [
+          {
+            id: 'item-1',
+            tip_split_id: 'split-1',
+            employee_id: employee1,
+            amount: 7500,
+            hours_worked: 5,
+            role: 'Server',
+            role_weight: null,
+            manually_edited: false,
+            created_at: '2026-07-06T00:00:00Z',
+            employee: { name: 'Maria Santos', position: 'Server' },
+          },
+          {
+            id: 'item-2',
+            tip_split_id: 'split-1',
+            employee_id: employee2,
+            amount: 2500,
+            hours_worked: 3,
+            role: 'Cook',
+            role_weight: null,
+            manually_edited: false,
+            created_at: '2026-07-06T00:00:00Z',
+            employee: { name: 'Alex Kim', position: 'Cook' },
+          },
+        ],
+      }),
+    ];
+
+    const result = aggregateTipDistribution(splits, []);
+    const maria = result.employees.find((e) => e.employeeId === employee1)!;
+    const alex = result.employees.find((e) => e.employeeId === employee2)!;
+    expect(maria.sharePct).toBeCloseTo(75, 5);
+    expect(alex.sharePct).toBeCloseTo(25, 5);
+    // Shares sum to ~100 (rounding tolerant).
+    expect(maria.sharePct + alex.sharePct).toBeCloseTo(100, 5);
+  });
+
+  it('returns sharePct of 0 for all employees when total earned is zero', () => {
+    const splits: TipSplitWithItems[] = [
+      makeSplit({
+        items: [
+          {
+            id: 'item-1',
+            tip_split_id: 'split-1',
+            employee_id: employee1,
+            amount: 0,
+            hours_worked: 2,
+            role: 'Server',
+            role_weight: null,
+            manually_edited: false,
+            created_at: '2026-07-06T00:00:00Z',
+            employee: { name: 'Maria Santos', position: 'Server' },
+          },
+        ],
+      }),
+    ];
+
+    const result = aggregateTipDistribution(splits, []);
+    expect(result.employees[0].sharePct).toBe(0);
+  });
+
+  it('sorts by earnedCents desc, tie-breaking by name asc', () => {
+    const splits: TipSplitWithItems[] = [
+      makeSplit({
+        items: [
+          {
+            id: 'item-1',
+            tip_split_id: 'split-1',
+            employee_id: employee1,
+            amount: 3000,
+            hours_worked: 3,
+            role: 'Server',
+            role_weight: null,
+            manually_edited: false,
+            created_at: '2026-07-06T00:00:00Z',
+            employee: { name: 'Zed Adams', position: 'Server' },
+          },
+          {
+            id: 'item-2',
+            tip_split_id: 'split-1',
+            employee_id: employee2,
+            amount: 3000,
+            hours_worked: 3,
+            role: 'Cook',
+            role_weight: null,
+            manually_edited: false,
+            created_at: '2026-07-06T00:00:00Z',
+            employee: { name: 'Alex Kim', position: 'Cook' },
+          },
+          {
+            id: 'item-3',
+            tip_split_id: 'split-1',
+            employee_id: employee3,
+            amount: 9000,
+            hours_worked: 6,
+            role: 'Bartender',
+            role_weight: null,
+            manually_edited: false,
+            created_at: '2026-07-06T00:00:00Z',
+            employee: { name: 'Sam Lee', position: 'Bartender' },
+          },
+        ],
+      }),
+    ];
+
+    const result = aggregateTipDistribution(splits, []);
+    expect(result.employees.map((e) => e.name)).toEqual([
+      'Sam Lee', // 9000, highest earner
+      'Alex Kim', // tie at 3000, name asc
+      'Zed Adams', // tie at 3000
+    ]);
+  });
+
+  it('handles null hours_worked as zero', () => {
+    const splits: TipSplitWithItems[] = [
+      makeSplit({
+        items: [
+          {
+            id: 'item-1',
+            tip_split_id: 'split-1',
+            employee_id: employee1,
+            amount: 1000,
+            hours_worked: null,
+            role: 'Server',
+            role_weight: null,
+            manually_edited: false,
+            created_at: '2026-07-06T00:00:00Z',
+            employee: { name: 'Maria Santos', position: 'Server' },
+          },
+        ],
+      }),
+    ];
+
+    const result = aggregateTipDistribution(splits, []);
+    expect(result.employees[0].hoursWorked).toBe(0);
+  });
+
+  it('falls back to "Unknown" name and null role when the employee join is missing', () => {
+    const splits: TipSplitWithItems[] = [
+      makeSplit({
+        items: [
+          {
+            id: 'item-1',
+            tip_split_id: 'split-1',
+            employee_id: employee1,
+            amount: 1000,
+            hours_worked: 1,
+            role: null,
+            role_weight: null,
+            manually_edited: false,
+            created_at: '2026-07-06T00:00:00Z',
+            // no `employee` field — join missing
+          },
+        ],
+      }),
+    ];
+
+    const result = aggregateTipDistribution(splits, []);
+    expect(result.employees[0].name).toBe('Unknown');
+    expect(result.employees[0].role).toBeNull();
+  });
+
+  it('sets totalPaidCents/totalUnpaidCents as sums across all employees', () => {
+    const splits: TipSplitWithItems[] = [
+      makeSplit({
+        items: [
+          {
+            id: 'item-1',
+            tip_split_id: 'split-1',
+            employee_id: employee1,
+            amount: 10000,
+            hours_worked: 5,
+            role: 'Server',
+            role_weight: null,
+            manually_edited: false,
+            created_at: '2026-07-06T00:00:00Z',
+            employee: { name: 'Maria Santos', position: 'Server' },
+          },
+          {
+            id: 'item-2',
+            tip_split_id: 'split-1',
+            employee_id: employee2,
+            amount: 5000,
+            hours_worked: 3,
+            role: 'Cook',
+            role_weight: null,
+            manually_edited: false,
+            created_at: '2026-07-06T00:00:00Z',
+            employee: { name: 'Alex Kim', position: 'Cook' },
+          },
+        ],
+      }),
+    ];
+    const payouts: TipPayout[] = [
+      makePayout({ employee_id: employee1, amount: 10000 }), // fully paid
+      makePayout({ employee_id: employee2, amount: 1000 }), // partially paid
+    ];
+
+    const result = aggregateTipDistribution(splits, payouts);
+    expect(result.totalEarnedCents).toBe(15000);
+    expect(result.totalPaidCents).toBe(11000);
+    expect(result.totalUnpaidCents).toBe(4000); // (5000-1000) + (10000-10000)
+  });
+});
+
+describe('paymentStatus', () => {
+  function makeDistribution(
+    overrides: Partial<EmployeeDistribution>,
+  ): EmployeeDistribution {
+    return {
+      employeeId: employee1,
+      name: 'Maria Santos',
+      role: 'Server',
+      hoursWorked: 5,
+      earnedCents: 5000,
+      paidCents: 0,
+      unpaidCents: 5000,
+      sharePct: 100,
+      ...overrides,
+    };
+  }
+
+  it('returns "paid" when earned > 0 and unpaid is 0', () => {
+    const d = makeDistribution({ earnedCents: 5000, paidCents: 5000, unpaidCents: 0 });
+    expect(paymentStatus(d)).toBe('paid');
+  });
+
+  it('returns "partial" when some paid but unpaid remains (e.g. $10 of $50)', () => {
+    const d = makeDistribution({ earnedCents: 5000, paidCents: 1000, unpaidCents: 4000 });
+    expect(paymentStatus(d)).toBe('partial');
+  });
+
+  it('returns "unpaid" when nothing paid but something earned', () => {
+    const d = makeDistribution({ earnedCents: 5000, paidCents: 0, unpaidCents: 5000 });
+    expect(paymentStatus(d)).toBe('unpaid');
+  });
+
+  it('returns "paid" for the zero-earned edge case (nothing owed, nothing unpaid)', () => {
+    const d = makeDistribution({ earnedCents: 0, paidCents: 0, unpaidCents: 0 });
+    expect(paymentStatus(d)).toBe('paid');
+  });
+});

--- a/tests/unit/tipsDistribution-staleRefs-guard.test.ts
+++ b/tests/unit/tipsDistribution-staleRefs-guard.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tips "Distribution" tab — stale-reference regression guard.
+ *
+ * Phase 4 task 4 of the Tips Distribution View plan: the manager-facing
+ * "History" tab (with its broken "locked periods" placeholder copy) was
+ * renamed/replaced by the "Distribution" tab (see src/pages/Tips.tsx and
+ * tests/unit/Tips.distributionTab.test.tsx for the behavioral coverage).
+ *
+ * These tests read the relevant source/spec files as raw strings and assert
+ * that no dangling references to the removed tab survive:
+ *   - the literal ViewMode value `'history'`
+ *   - the label/copy `"Tip History"` (case-insensitive)
+ *   - the placeholder copy `"Locked periods"` (case-insensitive)
+ *   - an E2E assertion that still expects a "History" tab button on the
+ *     Tips page
+ *
+ * They will FAIL immediately if a future edit reintroduces any of these.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const repoRoot = path.resolve(__dirname, '../..');
+
+function read(relPath: string): string {
+  return fs.readFileSync(path.join(repoRoot, relPath), 'utf-8');
+}
+
+describe('Tips Distribution tab guard: no residual "History"/"Locked periods" references', () => {
+  it('src/pages/Tips.tsx has no history-tab ViewMode literal', () => {
+    const src = read('src/pages/Tips.tsx');
+    // The ViewMode union and switch statements must not reintroduce the old
+    // 'history' mode value (as a quoted string literal).
+    expect(src).not.toMatch(/['"]history['"]/i);
+  });
+
+  it('src/pages/Tips.tsx has no "Tip History" or "Locked periods" copy', () => {
+    const src = read('src/pages/Tips.tsx');
+    expect(src).not.toMatch(/tip history/i);
+    expect(src).not.toMatch(/locked periods/i);
+  });
+
+  const e2eTipsSpecs = [
+    'tests/e2e/tips-flow.spec.ts',
+    'tests/e2e/tips-complete-flow.spec.ts',
+    'tests/e2e/tip-sharing.spec.ts',
+    'tests/e2e/tip-double-counting-prevention.spec.ts',
+    'tests/e2e/tip-split-reopen.spec.ts',
+    'tests/e2e/tip-payouts.spec.ts',
+  ];
+
+  for (const relPath of e2eTipsSpecs) {
+    it(`${relPath} does not assert a "History" tab button on the Tips page`, () => {
+      const src = read(relPath);
+      // Guard against the specific pattern that would break if the tab
+      // were ever renamed back / a stale spec still clicked "History".
+      expect(src).not.toMatch(/name:\s*['"]History['"]/);
+      expect(src).not.toMatch(/name:\s*\/history\/i/);
+      expect(src).not.toMatch(/locked periods/i);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Replaces the broken **History** tab on `/tips` with a read-only **Distribution** tab showing per-employee tip earnings, share-of-pool, hours, and paid/partial/unpaid status for the selected week.
- **Fixes a latent bug:** the History view read `dailySplits` (today-only) for every non-Overview mode (`Tips.tsx` `viewMode === 'overview' ? periodSplits : dailySplits`), so "locked periods" from any prior day were silently filtered out — it showed "No locked periods yet" almost always. The Distribution tab uses period-scoped data, and the binding is corrected to `viewMode === 'daily' ? dailySplits : periodSplits`.
- **Fills the visibility gap:** per-employee allocations (`tip_split_items`) and payouts (`tip_payouts`) were computed, stored, and fed to payroll but never surfaced to a human. Now they are.
- Zero new queries — reuses already-fetched `periodSplits` + `payouts`. Aggregation is a pure, unit-tested util.

## Correctness note (payout linkage)
`aggregateTipDistribution` only counts a payout toward "paid" when its `tip_split_id` is `null` (ad-hoc) or references a split in the finalized set. This prevents a payout left behind by `reopenSplit()` (approved→draft) from masking a genuinely-unpaid finalized split behind a "Paid" badge. Regression tests cover the reopen-masking scenario and the finalized/null happy path.

## Test plan
- `tests/unit/tipDistribution.test.ts` — aggregation util (drafts excluded; multi-day sums; paid/partial/unpaid boundaries; overpayment clamp; divide-by-zero; reopen-masking regression; payout-only employees).
- `tests/unit/TipDistribution.test.tsx` — component loading/error/empty/data states.
- `tests/unit/Tips.distributionTab.test.tsx` — tab wiring + corrected splits binding.
- Local: typecheck clean, lint 0 errors, build OK, unit 6290 pass, pgTAP 1674 pass. Full e2e runs in CI.

## Design
See `docs/superpowers/specs/2026-07-12-tips-distribution-view-design.md` (design-reviewed; payout-state, three-way badge, a11y, responsive, and reopen-masking trade-off folded in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)