### PR TITLE
fix(payroll): band OT + prorate tips by clock-in day for break-after-midnight shifts

### DIFF
--- a/docs/superpowers/specs/2026-07-11-payroll-ot-clockin-banding.md
+++ b/docs/superpowers/specs/2026-07-11-payroll-ot-clockin-banding.md
@@ -1,0 +1,26 @@
+# Design + Plan: Payroll OT banding by clock-in day
+
+**Date:** 2026-07-11 · **Branch:** `fix/payroll-ot-clockin-banding` · Type: bug fix (payroll wage accuracy)
+
+## Problem
+`calculateEmployeePay` (the shared engine behind `usePayroll` — **actual paychecks** — and the monthly labor calc) buckets hours for OT banding by `period.startTime` (`payrollCalculations.ts:489`). Because `handleBreakEnd` advances a shift's clock-in anchor, a **break-after-midnight** segment's `startTime` is the next calendar day. So a shift that clocks in Sunday, takes a break past midnight, and crosses the Mon/Sun ISO-week boundary has its post-break hours banded into a *different week* (and different day) — under-counting weekly OT, daily OT, and mis-prorating tips for that shift. This is the `// KNOWN GAP` deferred from #612 (sound-logic-reproduced: 40h week + Sun→Mon break shift → $618.23 vs correct $970.00).
+
+## Fix (one line + test)
+`payrollCalculations.ts:489`: `period.startTime` → `period.clockIn ?? period.startTime`, and remove the now-resolved `// KNOWN GAP` comment (#612 added it here). `period.clockIn` was added in #599 (the shift's true clock-in, unmoved by breaks).
+
+## Blast radius (verified narrow)
+`dateKey` feeds `hoursByDate` → weekly OT (`hoursByWeek`), daily OT (`dailyHours`), and tip proration. But `clockIn` day == `startTime` day for **every** case except a break-after-midnight segment:
+- No-break shift (even overnight): one period, `startTime == clockIn`. No change.
+- Same-day shift with break: both segments on the clock-in day. No change.
+- **Break-after-midnight shift:** post-break segment's `startTime` is a later day → the ONLY case changed, moving its hours to the clock-in day/week (correct, consistent with the app-wide clock-in-day attribution).
+
+So all existing payroll tests (no such fixtures) stay green; the change only corrects the target case, in the correct direction, for weekly OT, daily OT, and tip proration together.
+
+## Not changing
+- `overtimeAdjustments` still key on `punchDate` (manual manager overrides) — a rare adjustment recorded against the post-break day would no longer match the shift's (now clock-in) day; acceptable, manual, out of scope.
+
+## Test plan (TDD)
+`tests/unit/payrollCalculations.test.ts` — new `describe`: a break-after-midnight overnight shift (Sun 20:00 → Mon 02:00, break 00:00–00:30 = 5.5h) crossing the Mon/Sun week with a weekly OT threshold of 4h → assert `regularHours=4, overtimeHours=1.5` (was `5.5 / 0` — split across two weeks). Verify under `TZ=UTC` and `TZ=America/Chicago`. Full suite + the #612 monthly acceptance case stay green.
+
+## Steps
+1. RED: add the test. 2. GREEN: apply the one-line fix + drop the KNOWN GAP comment. 3. Verify payroll + monthly + full suite (UTC + Chicago). 4. Phase 7 sound-logic review on the diff. 5. Verify (typecheck/lint/build) → PR.

--- a/src/utils/payrollCalculations.ts
+++ b/src/utils/payrollCalculations.ts
@@ -487,8 +487,9 @@ export function calculateEmployeePay(
       // midnight segment's startTime is the next day/week; keying off clockIn
       // keeps the whole shift's hours in its clock-in day/week for daily+weekly
       // OT and tip proration. Same day as startTime for all non-break-crossing
-      // shifts, so only the overnight break case changes.
-      const dateKey = format(new Date(period.clockIn ?? period.startTime), 'yyyy-MM-dd');
+      // shifts, so only the overnight break case changes. clockIn is a required
+      // WorkPeriod field (set on every parseWorkPeriods push site).
+      const dateKey = format(new Date(period.clockIn), 'yyyy-MM-dd');
       hoursByDate.set(dateKey, (hoursByDate.get(dateKey) ?? 0) + period.hours);
     }
 

--- a/src/utils/payrollCalculations.ts
+++ b/src/utils/payrollCalculations.ts
@@ -482,11 +482,13 @@ export function calculateEmployeePay(
 
     for (const period of parsed.periods) {
       if (period.isBreak) continue;
-      // KNOWN GAP: OT weekly banding keys off period.startTime, not period.clockIn,
-      // so a break-after-midnight shift crossing an ISO-week boundary bands its
-      // pre/post-midnight hours into two weeks. Pre-existing, shared with the
-      // monthly labor calc. See docs/superpowers/specs/2026-07-11-monthly-labor-overnight-design.md
-      const dateKey = format(new Date(period.startTime), 'yyyy-MM-dd');
+      // Band OT (and prorate tips) by the shift's clock-in day, not the segment
+      // start. handleBreakEnd advances the clock-in anchor, so a break-after-
+      // midnight segment's startTime is the next day/week; keying off clockIn
+      // keeps the whole shift's hours in its clock-in day/week for daily+weekly
+      // OT and tip proration. Same day as startTime for all non-break-crossing
+      // shifts, so only the overnight break case changes.
+      const dateKey = format(new Date(period.clockIn ?? period.startTime), 'yyyy-MM-dd');
       hoursByDate.set(dateKey, (hoursByDate.get(dateKey) ?? 0) + period.hours);
     }
 

--- a/tests/unit/payrollCalculations.test.ts
+++ b/tests/unit/payrollCalculations.test.ts
@@ -963,3 +963,39 @@ describe('calculateEmployeePay overnight window attribution', () => {
     expect(payB.regularHours + payB.overtimeHours).toBeCloseTo(0, 5);
   });
 });
+
+describe('calculateEmployeePay — OT banding for break-after-midnight overnight shifts', () => {
+  const emp = {
+    id: 'e1', name: 'Night Owl', position: 'Server', status: 'active', is_active: true,
+    compensation_type: 'hourly', hourly_rate: 2000,
+  } as unknown as Employee;
+  const p = (type: string, iso: string): TimePunch => ({
+    id: `${type}-${iso}`, employee_id: 'e1', restaurant_id: 'r1',
+    punch_type: type, punch_time: iso, created_at: iso, updated_at: iso,
+  } as unknown as TimePunch);
+  const otRules = {
+    weeklyThresholdHours: 4, weeklyOtMultiplier: 1.5,
+    dailyThresholdHours: null, dailyOtMultiplier: 1.5,
+    dailyDoubleThresholdHours: null, dailyDoubleMultiplier: 2, excludeTipsFromOtRate: false,
+  };
+
+  it('CRITICAL: bands a break-after-midnight overnight shift crossing a week boundary into ONE (clock-in) week', () => {
+    // 2026-07-12 is Sunday (last day of the ISO week; WEEK_STARTS_ON=Mon).
+    // Sun 20:00 -> Mon 02:00 with a 00:00-00:30 break = 5.5h worked. Weekly OT threshold 4h.
+    // Whole shift belongs to the clock-in week → 4h reg + 1.5h OT.
+    // Before the fix the post-break 1.5h banded into the NEXT week → 5.5h reg / 0 OT.
+    const punches = [
+      p('clock_in', '2026-07-12T20:00:00'),
+      p('break_start', '2026-07-13T00:00:00'),
+      p('break_end', '2026-07-13T00:30:00'),
+      p('clock_out', '2026-07-13T02:00:00'),
+    ];
+    const pay = calculateEmployeePay(
+      emp, punches, 0,
+      new Date('2026-07-06T00:00:00'), new Date('2026-07-12T23:59:59.999'),
+      [], 0, otRules, []
+    );
+    expect(pay.regularHours).toBeCloseTo(4, 5);
+    expect(pay.overtimeHours).toBeCloseTo(1.5, 5);
+  });
+});


### PR DESCRIPTION
## Summary
Resolves the `KNOWN GAP` deferred from #612. `calculateEmployeePay` — the **shared payroll engine behind actual paychecks** (`usePayroll`) and the monthly labor calc — banded OT and prorated tips by `period.startTime`. Because `handleBreakEnd` advances a shift's clock-in anchor, a **break-after-midnight** work segment's `startTime` is the next calendar day, so an overnight shift crossing the Mon/Sun ISO-week boundary had its post-break hours banded into a *different week and day* — under-counting **weekly OT, daily OT, and mis-prorating tips** for that shift.

**Fix:** key the OT-banding day off `period.clockIn ?? period.startTime` (the shift's true clock-in, added in #599).

## Blast radius (verified narrow — see review below)
`clockIn` day == `startTime` day for **every** shift shape except a break-after-midnight segment:
- No-break shift (even overnight): one period, `startTime == clockIn`. No change.
- Same-day shift with break, and same-day split shifts (each sub-shift gets its own `clockIn`, reset on clock-out): no change.
- **Break-after-midnight overnight shift:** the only case changed — its post-break hours move to the clock-in day/week, matching the codebase-wide clock-in-day convention (payroll periods, monthly labor, timecard display).

## Test plan
- `payrollCalculations.test.ts`: +1 — a break-after-midnight shift (Sun 20:00 → Mon 02:00, break 00:00–00:30, 5.5h) crossing the week with a 4h weekly OT threshold → `regularHours=4, overtimeHours=1.5` (was `5.5 / 0`, split across two weeks). Verified under `TZ=UTC` and `TZ=America/Chicago`.
- Full unit suite green (6510). Monthly acceptance (Russo April) **unchanged** at 1,282,985 (its fixture has no break-after-midnight week-crossing shifts). Typecheck, lint, build clean.

## Review
- **Phase 7 sound-logic review: clean — no critical/major/minor.** Traced every shift shape (split, consecutive clock-ins, multi-break, no-break overnight), confirmed `clockIn` is per-shift, tip-proration total unaffected, OT adjustments not segment-bound → no regression.

Design: `docs/superpowers/specs/2026-07-11-payroll-ot-clockin-banding.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected overtime and tip calculations for overnight shifts that cross a day or week boundary, including breaks after midnight.
  * Ensured work time remains attributed to the shift’s clock-in day for accurate regular and overtime totals.

* **Tests**
  * Added coverage for Sunday-to-Monday overnight shifts with a post-midnight break.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->