### PR TITLE
fix(security): harden accept_shift_trade authz + fix approve/reject NULL-role fail-open

### DIFF
--- a/docs/superpowers/plans/2026-07-13-accept-trade-authz-plan.md
+++ b/docs/superpowers/plans/2026-07-13-accept-trade-authz-plan.md
@@ -1,0 +1,56 @@
+# Plan — accept_shift_trade authz + search_path hardening
+
+**Design:** docs/superpowers/specs/2026-07-13-accept-trade-authz-design.md
+**Branch:** `fix/accept-shift-trade-authz`
+
+TDD via pgTAP. **After any migration add/edit, `npm run db:reset` before `npm run test:db`** (else
+pgTAP runs against stale schema — prior-session lesson).
+
+---
+
+### Task 1 — new pgTAP authz test (RED first)
+- **File** `supabase/tests/<nn>_accept_shift_trade_authz.sql` (next free NN). Pattern:
+  `SET LOCAL ROLE authenticated` + `request.jwt.claims {sub}` per caller. Seed R1 {A offerer, B
+  target, C bystander}, R2 {X}; an OPEN trade (A, target NULL) and a DIRECTED trade (A→B). Assert
+  BOTH `jsonb->>'success'` and the resulting `accepted_by_employee_id`:
+  1. C calls `accept(open, B's id)` (not C's) → success=false, accepted_by NULL. ← RED (today true)
+  2. C calls `accept(open, C's id)` → success=true, accepted_by=C, status pending_approval.
+  3. C calls `accept(directed A→B, C's id)` → success=false, accepted_by NULL. ← RED
+  4. B calls `accept(directed A→B, B's id)` → success=true, accepted_by=B.
+  5. X (R2) calls `accept(open, X's id)` → success=false (restaurant mismatch), unchanged.
+  - `db:reset` + `test:db` → confirm 1,3,5 FAIL against current function.
+- Dep: none.
+
+### Task 2 — hardening migration (GREEN)
+- **File** `supabase/migrations/<ts-after-20260713000000>_harden_accept_shift_trade.sql`:
+  `CREATE OR REPLACE` all four functions, bodies **verbatim** from `20260105000100`, changing only:
+  - `accept_shift_trade`: add `SET search_path = public, pg_temp` to header; insert the caller-owns-
+    employee EXISTS check + the directed-target check (per design) after the `status != 'open'` check.
+  - `approve/reject/cancel_shift_trade`: add `SET search_path = public, pg_temp` to header only —
+    reproduce EXACT signatures: approve/reject `(UUID, UUID, TEXT DEFAULT NULL)`, cancel `(UUID, UUID)`.
+  - Re-`GRANT EXECUTE … TO authenticated` on all four (idempotent).
+- **Verify**: `db:reset` + `test:db` → Task 1 assertions GREEN. Then the overload guard:
+  `SELECT proname, count(*) FROM pg_proc WHERE proname LIKE '%_shift_trade' GROUP BY 1` → 1 each.
+- Dep: 1.
+
+### Task 3 — fix the existing `17_shift_trade_functions_security.sql` (major, review)
+- **Code**: before Test 1's accept happy-path, `SET LOCAL "request.jwt.claims" TO '{"sub":"…0002"}'`
+  (employee 122's user = the actual accepter); restore to `…0001` before the later offerer/cancel
+  tests. Confirm employee 122 has no schedule conflict with trade 141's shift (shifts 132/134 are
+  Jan 21/23; trade offers shift 131 = Jan 20 → no overlap). All 12 assertions must still pass.
+- **Verify**: `db:reset` + `test:db` → `17_` and the new file both green.
+- Dep: 2.
+
+---
+
+## Phase 8 verify
+`npm run db:reset` then `npm run test:db` (the proof — new file + 17_ both green, overload guard =1
+each), `npm run test` (unit, unaffected), `typecheck`, `lint`, `build`.
+
+## Task order
+1 (RED) → 2 (GREEN) → 3 (fix existing test).
+
+## Out of scope (follow-ups)
+- `cancel_shift_trade` missing `is_active` in its ownership check (minor inconsistency).
+- `task_344afce3` (buildEmails client), `task_26513232` (dedupe query).
+- Phase B — admin per-type × per-channel notification matrix (next after this).

--- a/docs/superpowers/specs/2026-07-13-accept-trade-authz-design.md
+++ b/docs/superpowers/specs/2026-07-13-accept-trade-authz-design.md
@@ -1,0 +1,101 @@
+# Design — accept_shift_trade authorization + search_path hardening
+
+**Date:** 2026-07-13
+**Branch:** `fix/accept-shift-trade-authz`
+**Ticket:** task_d9ab7984 (write-side complement to PR #609)
+
+## Problem
+
+`accept_shift_trade(p_trade_id UUID, p_accepting_employee_id UUID)` is `SECURITY DEFINER` and
+`GRANT`ed to `authenticated`, but **trusts the client-supplied `p_accepting_employee_id`**. It
+checks only that the trade is `open` and the accepting employee has no schedule conflict — never
+that the accepter belongs to the caller (`auth.uid()`), nor (for a directed trade) that it equals
+`target_employee_id`. Because it's `SECURITY DEFINER` it bypasses RLS and the UPDATE policy.
+
+Via a direct `supabase.rpc('accept_shift_trade', { p_trade_id, p_accepting_employee_id })` call
+(not the UI, which sends the caller's own id), **any authenticated user** can set a trade's
+`accepted_by` to any employee and move it to `pending_approval`. Impact is gated by the
+owner/manager-only `approve_shift_trade` before the shift actually transfers — so this is an
+integrity/griefing hole (forge "who accepted"; a non-target accepting a directed trade), not a
+silent takeover. Sibling functions get this right: `approve`/`reject` check
+`p_manager_user_id = auth.uid()` + role; `cancel` checks the caller owns the offerer employee.
+Only `accept` lacks the caller check.
+
+Separately, none of the four trade functions pin `SET search_path` (a `SECURITY DEFINER` hardening
+flagged in the #609 review / Supabase advisor).
+
+## Approach
+
+New migration `supabase/migrations/<ts-after-20260713000000>_harden_accept_shift_trade.sql` that
+`CREATE OR REPLACE`s the four functions (historical migration untouched). Bodies copied **verbatim**
+from `20260105000100_create_shift_trade_functions.sql`, changing only:
+
+### 1. `accept_shift_trade` — add caller/target checks
+
+Immediately after the `status != 'open'` check (before the conflict check), insert:
+
+```sql
+  -- The accepting employee must belong to the caller, be active, and be in the
+  -- trade's restaurant. Prevents a direct RPC call from accepting a trade on
+  -- behalf of another employee (or across restaurants). SECURITY DEFINER bypasses
+  -- RLS, so this is the authorization boundary.
+  IF NOT EXISTS (
+    SELECT 1 FROM employees e
+    WHERE e.id = p_accepting_employee_id
+      AND e.user_id = auth.uid()
+      AND e.is_active = true
+      AND e.restaurant_id = v_trade.restaurant_id
+  ) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'You can only accept a trade as yourself');
+  END IF;
+
+  -- A DIRECTED trade may be accepted only by its target.
+  IF v_trade.target_employee_id IS NOT NULL
+     AND p_accepting_employee_id <> v_trade.target_employee_id THEN
+    RETURN jsonb_build_object('success', false, 'error', 'This trade was offered to a specific employee');
+  END IF;
+```
+
+Everything else in `accept_shift_trade` (row lock, status check, conflict check, the
+`UPDATE shift_trades SET accepted_by_employee_id = …, status = 'pending_approval'`) is unchanged.
+
+### 2. `SET search_path` on all four functions
+
+Add `SET search_path = public, pg_temp` to the `CREATE OR REPLACE FUNCTION … SECURITY DEFINER`
+header of `accept_shift_trade`, `approve_shift_trade`, `reject_shift_trade`, `cancel_shift_trade`.
+(`public, pg_temp` is the hardened form already used in this codebase; dominant convention is bare
+`public`, but pinning `pg_temp` blocks temp-schema function/type shadowing.) approve/reject/cancel
+bodies are otherwise copied verbatim — no logic change.
+
+Re-`GRANT EXECUTE … TO authenticated` after the `CREATE OR REPLACE` (grants persist across replace,
+but re-granting is idempotent and explicit).
+
+## Testing (pgTAP)
+
+New `supabase/tests/<nn>_accept_shift_trade_authz.sql`, impersonating callers via
+`SET LOCAL ROLE authenticated` + `request.jwt.claims {sub}` (SECURITY DEFINER reads `auth.uid()`
+from the JWT). Seed: restaurant R1 with employees A(offerer), B(target), C(bystander); a 2nd
+restaurant R2 with employee X; an OPEN trade (A, target NULL) and a DIRECTED trade (A→B). Assert on
+both the returned `jsonb->>'success'` and the resulting `accepted_by_employee_id`:
+
+1. **Attacker**: C calls `accept_shift_trade(open_trade, B's employee_id)` (not C's) →
+   `success=false`, `accepted_by` stays NULL.
+2. **Legit self-accept (open)**: C calls with C's own employee_id on the open trade →
+   `success=true`, `accepted_by = C`, status `pending_approval`.
+3. **Non-target self-accept (directed)**: C calls with C's own id on the A→B directed trade →
+   `success=false`, `accepted_by` stays NULL.
+4. **Target self-accept (directed)**: B calls with B's own id on the A→B directed trade →
+   `success=true`, `accepted_by = B`.
+5. **Cross-restaurant**: X (R2) calls with X's own id on an R1 open trade → `success=false`
+   (restaurant mismatch), `accepted_by` unchanged.
+
+Remember: `npm run db:reset` before `npm run test:db` (a migration was added/edited).
+
+## Decided trade-offs
+
+- **Offerer self-accepting their own trade** is not explicitly blocked (out of scope) — the new
+  checks still require it be *their* employee row; a self-trade is harmless (goes to manager
+  approval) and the client never does it. Noted, not fixed.
+- **`public, pg_temp`** chosen over bare `public` for the hardened form; over `''` (empty) because
+  the bodies reference unqualified `public` objects and the codebase convention keeps `public`.
+- Read-side privacy (who can *see* directed trades) shipped in #609; this closes the write side.

--- a/docs/superpowers/specs/2026-07-13-accept-trade-authz-design.md
+++ b/docs/superpowers/specs/2026-07-13-accept-trade-authz-design.md
@@ -70,6 +70,35 @@ bodies are otherwise copied verbatim — no logic change.
 Re-`GRANT EXECUTE … TO authenticated` after the `CREATE OR REPLACE` (grants persist across replace,
 but re-granting is idempotent and explicit).
 
+### 3. Fix the EXISTING test `17_shift_trade_functions_security.sql` (design review, major)
+
+That file sets `request.jwt.claims` sub to `…0001` (employee **121**'s user) once at the top, then
+Test 1 calls `accept_shift_trade(trade141, employee 122)` — i.e. accepts **as employee 122** while
+the caller's JWT is employee 121's user. The current unguarded function lets this through; the new
+`user_id = auth.uid()` check will (correctly) return `success:false`, breaking Test 1 and the
+dependent Tests 2–3.
+
+Fix in this branch: before Test 1's accept happy-path, `SET LOCAL "request.jwt.claims" TO
+'{"sub":"…0002"}'` (employee 122's user, the actual accepter) so caller == accepting employee;
+restore to `…0001` before the later cancel/offerer tests that rely on it. Verify all 12 assertions
+still pass. (Note: `17_` runs as `SET LOCAL role TO postgres` — superuser — so it never exercised
+the `authenticated` GRANT boundary; the new dedicated file below, using `SET LOCAL ROLE
+authenticated`, is the rigorous authz test.)
+
+### 4. Signature-drift guard on `CREATE OR REPLACE` (design review, major)
+
+`CREATE OR REPLACE FUNCTION` dispatches by `(name, arg types)`. If a header doesn't reproduce the
+**exact** live signature, Postgres silently creates an *overload*, leaving the old unhardened
+function live. Reproduce verbatim:
+- `accept_shift_trade(UUID, UUID)`
+- `cancel_shift_trade(UUID, UUID)`
+- `approve_shift_trade(UUID, UUID, TEXT DEFAULT NULL)`
+- `reject_shift_trade(UUID, UUID, TEXT DEFAULT NULL)`
+
+Post-`db:reset` verification: `SELECT proname, count(*) FROM pg_proc WHERE proname IN
+('accept_shift_trade','approve_shift_trade','reject_shift_trade','cancel_shift_trade') GROUP BY 1`
+must return **1 each** (no accidental overloads).
+
 ## Testing (pgTAP)
 
 New `supabase/tests/<nn>_accept_shift_trade_authz.sql`, impersonating callers via
@@ -99,3 +128,6 @@ Remember: `npm run db:reset` before `npm run test:db` (a migration was added/edi
 - **`public, pg_temp`** chosen over bare `public` for the hardened form; over `''` (empty) because
   the bodies reference unqualified `public` objects and the codebase convention keeps `public`.
 - Read-side privacy (who can *see* directed trades) shipped in #609; this closes the write side.
+- **`cancel_shift_trade` omits `is_active`** in its ownership check (unlike the new `accept` check).
+  Not a hole (a deactivated employee cancelling their own open trade is low-risk) — left unchanged
+  to keep this migration's diff focused on the `accept` authz gap; noted for a possible follow-up.

--- a/supabase/migrations/20260713010000_harden_accept_shift_trade.sql
+++ b/supabase/migrations/20260713010000_harden_accept_shift_trade.sql
@@ -1,0 +1,304 @@
+-- Harden the four shift-trade SECURITY DEFINER functions:
+--   1. accept_shift_trade trusted the client-supplied p_accepting_employee_id
+--      with no check that the caller (auth.uid()) owns that employee row, nor
+--      (for a directed trade) that it equals target_employee_id. Add both
+--      checks. Sibling functions already get this right: approve/reject check
+--      p_manager_user_id = auth.uid() + role; cancel checks the caller owns
+--      the offerer employee.
+--   2. None of the four functions pinned SET search_path (SECURITY DEFINER
+--      hardening flagged in the #609 review / Supabase advisor). Add
+--      `SET search_path = public, pg_temp` to all four.
+--
+-- Bodies are copied verbatim from 20260105000100_create_shift_trade_functions.sql
+-- (no other migration has touched these functions since), with only the two
+-- changes above. Signatures reproduced EXACTLY so CREATE OR REPLACE replaces
+-- the existing functions rather than silently creating overloads:
+--   accept_shift_trade(UUID, UUID)
+--   approve_shift_trade(UUID, UUID, TEXT DEFAULT NULL)
+--   reject_shift_trade(UUID, UUID, TEXT DEFAULT NULL)
+--   cancel_shift_trade(UUID, UUID)
+--
+-- Design: docs/superpowers/specs/2026-07-13-accept-trade-authz-design.md
+-- Ticket: task_d9ab7984
+
+-- Function to accept a shift trade
+-- This checks for conflicts and updates the trade status to pending_approval
+CREATE OR REPLACE FUNCTION accept_shift_trade(
+  p_trade_id UUID,
+  p_accepting_employee_id UUID
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_trade shift_trades;
+  v_shift shifts;
+  v_conflict shifts;
+BEGIN
+  -- Get the trade with row lock to prevent race conditions
+  SELECT * INTO v_trade
+  FROM shift_trades
+  WHERE id = p_trade_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Trade not found');
+  END IF;
+
+  -- Check trade is still open
+  IF v_trade.status != 'open' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Trade is no longer available');
+  END IF;
+
+  -- The accepting employee must belong to the caller, be active, and be in the
+  -- trade's restaurant. Prevents a direct RPC call from accepting a trade on
+  -- behalf of another employee (or across restaurants). SECURITY DEFINER bypasses
+  -- RLS, so this is the authorization boundary.
+  IF NOT EXISTS (
+    SELECT 1 FROM employees e
+    WHERE e.id = p_accepting_employee_id
+      AND e.user_id = auth.uid()
+      AND e.is_active = true
+      AND e.restaurant_id = v_trade.restaurant_id
+  ) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'You can only accept a trade as yourself');
+  END IF;
+
+  -- A DIRECTED trade may be accepted only by its target.
+  IF v_trade.target_employee_id IS NOT NULL
+     AND p_accepting_employee_id <> v_trade.target_employee_id THEN
+    RETURN jsonb_build_object('success', false, 'error', 'This trade was offered to a specific employee');
+  END IF;
+
+  -- Get the shift details
+  SELECT * INTO v_shift
+  FROM shifts
+  WHERE id = v_trade.offered_shift_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Shift not found');
+  END IF;
+
+  -- Check for conflicts with accepting employee's existing shifts
+  SELECT * INTO v_conflict
+  FROM shifts
+  WHERE employee_id = p_accepting_employee_id
+    AND status IN ('scheduled', 'confirmed')
+    AND (
+      -- Overlapping shifts
+      (start_time, end_time) OVERLAPS (v_shift.start_time, v_shift.end_time)
+    );
+
+  IF FOUND THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'You already have a shift scheduled during this time'
+    );
+  END IF;
+
+  -- Update the trade
+  UPDATE shift_trades
+  SET
+    accepted_by_employee_id = p_accepting_employee_id,
+    status = 'pending_approval',
+    updated_at = NOW()
+  WHERE id = p_trade_id;
+
+  RETURN jsonb_build_object('success', true);
+END;
+$$;
+
+-- Function to approve a shift trade (manager)
+-- This transfers shift ownership and updates trade status
+CREATE OR REPLACE FUNCTION approve_shift_trade(
+  p_trade_id UUID,
+  p_manager_user_id UUID,
+  p_manager_note TEXT DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_trade shift_trades;
+  v_shift shifts;
+  v_user_role TEXT;
+BEGIN
+  -- Verify caller is the manager specified and has manager role
+  IF p_manager_user_id != auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Unauthorized');
+  END IF;
+
+  SELECT role INTO v_user_role
+  FROM user_restaurants
+  WHERE user_id = auth.uid()
+  AND restaurant_id = (SELECT restaurant_id FROM shift_trades WHERE id = p_trade_id)
+  LIMIT 1;
+
+  IF v_user_role NOT IN ('owner', 'manager') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Unauthorized: Manager access required');
+  END IF;
+
+  -- Get the trade with row lock
+  SELECT * INTO v_trade
+  FROM shift_trades
+  WHERE id = p_trade_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Trade not found');
+  END IF;
+
+  -- Check trade is pending approval
+  IF v_trade.status != 'pending_approval' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Trade is not pending approval');
+  END IF;
+
+  -- Check accepting employee is set
+  IF v_trade.accepted_by_employee_id IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No employee has accepted this trade');
+  END IF;
+
+  -- Transfer shift ownership
+  UPDATE shifts
+  SET
+    employee_id = v_trade.accepted_by_employee_id,
+    updated_at = NOW()
+  WHERE id = v_trade.offered_shift_id;
+
+  -- Update trade status
+  UPDATE shift_trades
+  SET
+    status = 'approved',
+    reviewed_by = p_manager_user_id,
+    reviewed_at = NOW(),
+    manager_note = p_manager_note,
+    updated_at = NOW()
+  WHERE id = p_trade_id;
+
+  RETURN jsonb_build_object('success', true);
+END;
+$$;
+
+-- Function to reject a shift trade (manager)
+CREATE OR REPLACE FUNCTION reject_shift_trade(
+  p_trade_id UUID,
+  p_manager_user_id UUID,
+  p_manager_note TEXT DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_trade shift_trades;
+  v_user_role TEXT;
+BEGIN
+  -- Verify caller is the manager specified and has manager role
+  IF p_manager_user_id != auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Unauthorized');
+  END IF;
+
+  SELECT role INTO v_user_role
+  FROM user_restaurants
+  WHERE user_id = auth.uid()
+  AND restaurant_id = (SELECT restaurant_id FROM shift_trades WHERE id = p_trade_id)
+  LIMIT 1;
+
+  IF v_user_role NOT IN ('owner', 'manager') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Unauthorized: Manager access required');
+  END IF;
+
+  -- Get the trade with row lock
+  SELECT * INTO v_trade
+  FROM shift_trades
+  WHERE id = p_trade_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Trade not found');
+  END IF;
+
+  -- Check trade is pending approval
+  IF v_trade.status != 'pending_approval' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Trade is not pending approval');
+  END IF;
+
+  -- Update trade status
+  UPDATE shift_trades
+  SET
+    status = 'rejected',
+    reviewed_by = p_manager_user_id,
+    reviewed_at = NOW(),
+    manager_note = p_manager_note,
+    updated_at = NOW()
+  WHERE id = p_trade_id;
+
+  RETURN jsonb_build_object('success', true);
+END;
+$$;
+
+-- Function to cancel a shift trade (employee who created it)
+CREATE OR REPLACE FUNCTION cancel_shift_trade(
+  p_trade_id UUID,
+  p_employee_id UUID
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_trade shift_trades;
+BEGIN
+  -- Get the trade with row lock
+  SELECT * INTO v_trade
+  FROM shift_trades
+  WHERE id = p_trade_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Trade not found');
+  END IF;
+
+  -- Verify the caller owns the employee record that created this trade
+  IF NOT EXISTS (
+    SELECT 1 FROM employees
+    WHERE id = v_trade.offered_by_employee_id
+    AND user_id = auth.uid()
+  ) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'You can only cancel your own trades');
+  END IF;
+
+  -- Check trade is still open (can't cancel after accepted)
+  IF v_trade.status != 'open' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Cannot cancel trade after it has been accepted');
+  END IF;
+
+  -- Update trade status
+  UPDATE shift_trades
+  SET
+    status = 'cancelled',
+    updated_at = NOW()
+  WHERE id = p_trade_id;
+
+  RETURN jsonb_build_object('success', true);
+END;
+$$;
+
+-- Re-grant execute permissions (grants persist across CREATE OR REPLACE, but
+-- re-granting is idempotent and keeps intent explicit).
+GRANT EXECUTE ON FUNCTION accept_shift_trade(UUID, UUID) TO authenticated;
+GRANT EXECUTE ON FUNCTION approve_shift_trade(UUID, UUID, TEXT) TO authenticated;
+GRANT EXECUTE ON FUNCTION reject_shift_trade(UUID, UUID, TEXT) TO authenticated;
+GRANT EXECUTE ON FUNCTION cancel_shift_trade(UUID, UUID) TO authenticated;
+
+-- Update comments to reflect the new authorization checks
+COMMENT ON FUNCTION accept_shift_trade(UUID, UUID) IS 'Employee accepts a shift trade as themselves (target-only for directed trades), checks for conflicts, and sets status to pending_approval';
+COMMENT ON FUNCTION approve_shift_trade(UUID, UUID, TEXT) IS 'Manager approves a shift trade and transfers ownership';
+COMMENT ON FUNCTION reject_shift_trade(UUID, UUID, TEXT) IS 'Manager rejects a shift trade';
+COMMENT ON FUNCTION cancel_shift_trade(UUID, UUID) IS 'Employee cancels their own shift trade (only if still open)';

--- a/supabase/migrations/20260713010000_harden_accept_shift_trade.sql
+++ b/supabase/migrations/20260713010000_harden_accept_shift_trade.sql
@@ -11,8 +11,14 @@
 --
 -- Bodies are copied verbatim from 20260105000100_create_shift_trade_functions.sql
 -- (no other migration has touched these functions since), with only the two
--- changes above. Signatures reproduced EXACTLY so CREATE OR REPLACE replaces
--- the existing functions rather than silently creating overloads:
+-- changes above, PLUS one pre-existing correctness bug fixed in
+-- approve_shift_trade/reject_shift_trade found during review: `v_user_role
+-- NOT IN ('owner', 'manager')` evaluates to NULL (not TRUE) in PL/pgSQL when
+-- the caller has no user_restaurants row at all, so the IF was skipped and
+-- the check failed OPEN for callers with zero restaurant membership. Changed
+-- to `v_user_role IS NULL OR v_user_role NOT IN (...)`. Signatures
+-- reproduced EXACTLY so CREATE OR REPLACE replaces the existing functions
+-- rather than silently creating overloads:
 --   accept_shift_trade(UUID, UUID)
 --   approve_shift_trade(UUID, UUID, TEXT DEFAULT NULL)
 --   reject_shift_trade(UUID, UUID, TEXT DEFAULT NULL)
@@ -138,7 +144,13 @@ BEGIN
   AND restaurant_id = (SELECT restaurant_id FROM shift_trades WHERE id = p_trade_id)
   LIMIT 1;
 
-  IF v_user_role NOT IN ('owner', 'manager') THEN
+  -- v_user_role is NULL when the caller has no user_restaurants row for this
+  -- restaurant (e.g. no membership at all). `NULL NOT IN (...)` evaluates to
+  -- NULL, not TRUE, so a plain `NOT IN` check here would fail OPEN and let
+  -- any authenticated user with zero role/restaurant membership approve a
+  -- trade by passing their own uid as p_manager_user_id. Explicitly reject
+  -- NULL first.
+  IF v_user_role IS NULL OR v_user_role NOT IN ('owner', 'manager') THEN
     RETURN jsonb_build_object('success', false, 'error', 'Unauthorized: Manager access required');
   END IF;
 
@@ -209,7 +221,13 @@ BEGIN
   AND restaurant_id = (SELECT restaurant_id FROM shift_trades WHERE id = p_trade_id)
   LIMIT 1;
 
-  IF v_user_role NOT IN ('owner', 'manager') THEN
+  -- v_user_role is NULL when the caller has no user_restaurants row for this
+  -- restaurant (e.g. no membership at all). `NULL NOT IN (...)` evaluates to
+  -- NULL, not TRUE, so a plain `NOT IN` check here would fail OPEN and let
+  -- any authenticated user with zero role/restaurant membership reject a
+  -- trade by passing their own uid as p_manager_user_id. Explicitly reject
+  -- NULL first.
+  IF v_user_role IS NULL OR v_user_role NOT IN ('owner', 'manager') THEN
     RETURN jsonb_build_object('success', false, 'error', 'Unauthorized: Manager access required');
   END IF;
 

--- a/supabase/tests/17_shift_trade_functions_security.sql
+++ b/supabase/tests/17_shift_trade_functions_security.sql
@@ -4,7 +4,7 @@
 -- Note: Full auth.uid() verification requires E2E tests, these focus on function logic
 
 BEGIN;
-SELECT plan(12);
+SELECT plan(14);
 
 -- Setup: Disable RLS for test data creation
 SET LOCAL role TO postgres;
@@ -22,11 +22,14 @@ INSERT INTO restaurants (id, name) VALUES
 ON CONFLICT (id) DO NOTHING;
 
 -- Create test users in auth.users
+-- User 4 deliberately gets NO user_restaurants row anywhere below — it's
+-- used to exercise the NULL-role fail-open regression (Test 13/14).
 INSERT INTO auth.users (id, instance_id, aud, role, email, encrypted_password, email_confirmed_at, created_at, updated_at, confirmation_token, recovery_token, email_change_token_new, email_change)
 VALUES
   ('00000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'emp1@security.test', crypt('password123', gen_salt('bf')), now(), now(), now(), '', '', '', ''),
   ('00000000-0000-0000-0000-000000000002', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'emp2@security.test', crypt('password123', gen_salt('bf')), now(), now(), now(), '', '', '', ''),
-  ('00000000-0000-0000-0000-000000000003', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'manager@security.test', crypt('password123', gen_salt('bf')), now(), now(), now(), '', '', '', '')
+  ('00000000-0000-0000-0000-000000000003', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'manager@security.test', crypt('password123', gen_salt('bf')), now(), now(), now(), '', '', '', ''),
+  ('00000000-0000-0000-0000-000000000004', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'norole@security.test', crypt('password123', gen_salt('bf')), now(), now(), now(), '', '', '', '')
 ON CONFLICT (id) DO NOTHING;
 
 -- Create employees
@@ -157,6 +160,49 @@ SELECT ok(
   (SELECT status FROM shift_trades WHERE id = '00000000-0000-0000-0000-000000000145') IN ('pending_approval', 'rejected'),
   'Trade should be rejected or remain pending (auth may not work in test context)'
 );
+
+-- ============================================================
+-- TEST CATEGORY 2b/3b: approve_shift_trade / reject_shift_trade -
+-- NULL-role fail-open regression (20260713010000_harden_accept_shift_trade.sql)
+-- `v_user_role NOT IN ('owner', 'manager')` evaluates to NULL (not TRUE) in
+-- PL/pgSQL when the caller has zero user_restaurants rows, so a bare NOT IN
+-- check would silently skip the rejection and let this caller (who owns no
+-- restaurant membership at all) approve/reject the trade. User 4 has no
+-- user_restaurants row anywhere in this fixture.
+-- ============================================================
+
+-- Test 13: approve_shift_trade must reject a caller with NULL role (fail closed)
+-- Clear any still-active trade left on shift 134 by Test 6 first (Test 6
+-- uses `lives_ok` and doesn't assert success, so trade144 may still be
+-- 'pending_approval' and the unique-active-trade-per-shift index would
+-- otherwise reject this insert).
+DELETE FROM shift_trades WHERE offered_shift_id = '00000000-0000-0000-0000-000000000134';
+INSERT INTO shift_trades (id, restaurant_id, offered_shift_id, offered_by_employee_id, accepted_by_employee_id, status)
+  VALUES ('00000000-0000-0000-0000-000000000148', '00000000-0000-0000-0000-000000000AAA', '00000000-0000-0000-0000-000000000134', '00000000-0000-0000-0000-000000000122', '00000000-0000-0000-0000-000000000121', 'pending_approval')
+ON CONFLICT (id) DO NOTHING;
+
+SET LOCAL "request.jwt.claims" TO '{"sub": "00000000-0000-0000-0000-000000000004"}';
+
+SELECT is(
+  (SELECT approve_shift_trade('00000000-0000-0000-0000-000000000148', '00000000-0000-0000-0000-000000000004')->>'success')::boolean,
+  false,
+  'approve_shift_trade should reject a caller with no user_restaurants role (NULL role fails closed, not open)'
+);
+
+-- Test 14: reject_shift_trade must reject a caller with NULL role (fail closed)
+-- Same clear-first reasoning as Test 13 above, for shift 132 / trade145.
+DELETE FROM shift_trades WHERE offered_shift_id = '00000000-0000-0000-0000-000000000132';
+INSERT INTO shift_trades (id, restaurant_id, offered_shift_id, offered_by_employee_id, accepted_by_employee_id, status)
+  VALUES ('00000000-0000-0000-0000-000000000149', '00000000-0000-0000-0000-000000000AAA', '00000000-0000-0000-0000-000000000132', '00000000-0000-0000-0000-000000000122', '00000000-0000-0000-0000-000000000121', 'pending_approval')
+ON CONFLICT (id) DO NOTHING;
+
+SELECT is(
+  (SELECT reject_shift_trade('00000000-0000-0000-0000-000000000149', '00000000-0000-0000-0000-000000000004')->>'success')::boolean,
+  false,
+  'reject_shift_trade should reject a caller with no user_restaurants role (NULL role fails closed, not open)'
+);
+
+SET LOCAL "request.jwt.claims" TO '{"sub": "00000000-0000-0000-0000-000000000001"}';
 
 -- ============================================================
 -- TEST CATEGORY 4: cancel_shift_trade - Employee Ownership

--- a/supabase/tests/17_shift_trade_functions_security.sql
+++ b/supabase/tests/17_shift_trade_functions_security.sql
@@ -63,6 +63,13 @@ INSERT INTO shift_trades (id, restaurant_id, offered_shift_id, offered_by_employ
   VALUES ('00000000-0000-0000-0000-000000000141', '00000000-0000-0000-0000-000000000AAA', '00000000-0000-0000-0000-000000000131', '00000000-0000-0000-0000-000000000121', 'open')
 ON CONFLICT (id) DO NOTHING;
 
+-- accept_shift_trade now requires the caller to own the accepting employee
+-- (20260713010000_harden_accept_shift_trade.sql), so impersonate employee
+-- 122's user for this happy-path call. Employee 122's existing shifts are
+-- Jan 21 (132) and Jan 23 (134); trade 141 offers Jan 20 (131), so there's no
+-- schedule conflict and the accept should succeed.
+SET LOCAL "request.jwt.claims" TO '{"sub": "00000000-0000-0000-0000-000000000002"}';
+
 SELECT is(
   (SELECT (accept_shift_trade('00000000-0000-0000-0000-000000000141', '00000000-0000-0000-0000-000000000122')->>'success')::boolean),
   true,
@@ -82,6 +89,10 @@ SELECT is(
   '00000000-0000-0000-0000-000000000122'::uuid,
   'Accepting employee should be recorded'
 );
+
+-- Restore the caller identity to employee 121's user for the remaining
+-- offerer/cancel tests below.
+SET LOCAL "request.jwt.claims" TO '{"sub": "00000000-0000-0000-0000-000000000001"}';
 
 -- Test 4: Should reject duplicate acceptance (trade no longer open)
 INSERT INTO shift_trades (id, restaurant_id, offered_shift_id, offered_by_employee_id, status)

--- a/supabase/tests/54_accept_shift_trade_authz.sql
+++ b/supabase/tests/54_accept_shift_trade_authz.sql
@@ -1,0 +1,272 @@
+-- ============================================================================
+-- Test: accept_shift_trade authorization (caller must own the accepting
+-- employee row; a directed trade may only be accepted by its target)
+--
+-- accept_shift_trade(p_trade_id UUID, p_accepting_employee_id UUID) is
+-- SECURITY DEFINER + GRANTed to authenticated, but today trusts the
+-- client-supplied p_accepting_employee_id: it never checks that the caller
+-- (auth.uid()) owns that employee row, nor (for a directed trade) that it
+-- equals target_employee_id. This test impersonates callers via
+-- `SET LOCAL ROLE authenticated` + request.jwt.claims so it exercises the
+-- real authenticated-role GRANT boundary (unlike 17_shift_trade_functions_
+-- security.sql, which runs as postgres/superuser throughout).
+--
+-- Each scenario asserts BOTH the returned jsonb->>'success' AND the
+-- resulting shift_trades.accepted_by_employee_id, as two separate top-level
+-- statements (a function call that writes, then a fresh SELECT to observe
+-- the write — combining both into one CTE-based statement hits a Postgres
+-- planning artifact where an uncorrelated subquery can be evaluated as an
+-- InitPlan that doesn't see the CTE's own write; verified directly against
+-- local Postgres before settling on this two-statement form). The
+-- accepted_by_employee_id follow-up SELECT always runs as `postgres`
+-- (RLS bypassed), not as the calling employee: a cross-restaurant caller
+-- (scenario 5) can be denied RLS visibility of the row even when the RPC
+-- did mutate it, which would make a caller-scoped check pass vacuously for
+-- the wrong reason (also confirmed directly before settling on this form).
+--   1. Attacker: C accepts the OPEN trade as B (not C).       -> RED today
+--   2. Legit self-accept: C accepts the OPEN trade as C.      -> already green
+--   3. Non-target self-accept: C accepts the DIRECTED trade
+--      (A->B) as C.                                            -> RED today
+--   4. Target self-accept: B accepts the DIRECTED trade
+--      (A->B) as B.                                            -> already green
+--   5. Cross-restaurant: X (R2) accepts an R1 OPEN trade as X. -> RED today
+--
+-- Migration under test (not yet applied when this test is written):
+--   supabase/migrations/<ts-after-20260713000000>_harden_accept_shift_trade.sql
+--
+-- Design: docs/superpowers/specs/2026-07-13-accept-trade-authz-design.md
+-- Ticket: task_d9ab7984
+--
+-- Fixture namespace: UUIDs starting with 54000000-...
+-- Seeds: restaurant R1 + employees A(offerer)/B(target)/C(bystander), a
+--        second restaurant R2 + employee X. Each scenario gets its OWN
+--        trade + shift, entirely independent of the others: a trade
+--        consumed (or left open) by an earlier scenario would otherwise
+--        change a later scenario's expected pre-patch outcome purely via
+--        the pre-existing status check, not the authz check under test —
+--        e.g. sharing one trade between scenarios 1 and 2 made scenario 2
+--        fail pre-patch too (for the wrong reason: "trade no longer open"),
+--        which was caught by running this file before writing it up here.
+--          - trade51 (OPEN, shift1)          -> scenario 1 (attacker)
+--          - trade54 (OPEN, shift4)          -> scenario 2 (legit self-accept)
+--          - trade52 (DIRECTED A->B, shift2) -> scenario 3 (non-target self-accept)
+--          - trade55 (DIRECTED A->B, shift5) -> scenario 4 (target self-accept)
+--          - trade53 (OPEN, shift3)          -> scenario 5 (cross-restaurant)
+-- ============================================================================
+
+BEGIN;
+SELECT plan(10);
+
+-- ============================================================================
+-- Setup (as postgres/superuser — bypasses RLS regardless of enable state)
+-- ============================================================================
+SET LOCAL role TO postgres;
+
+ALTER TABLE shift_trades DISABLE ROW LEVEL SECURITY;
+ALTER TABLE shifts DISABLE ROW LEVEL SECURITY;
+ALTER TABLE employees DISABLE ROW LEVEL SECURITY;
+ALTER TABLE restaurants DISABLE ROW LEVEL SECURITY;
+ALTER TABLE user_restaurants DISABLE ROW LEVEL SECURITY;
+
+-- Restaurants
+INSERT INTO restaurants (id, name) VALUES
+  ('54000000-0000-0000-0000-000000000001', 'Accept Trade Authz Restaurant'),
+  ('54000000-0000-0000-0000-000000000002', 'Other Restaurant (Accept Trade Authz)')
+ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name;
+
+-- Auth users: A(offerer), B(target), C(bystander), X(other restaurant)
+INSERT INTO auth.users (id, instance_id, aud, role, email, encrypted_password, email_confirmed_at, created_at, updated_at, confirmation_token, recovery_token, email_change_token_new, email_change)
+VALUES
+  ('54000000-0000-0000-0000-000000000011', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'trade-a-54@test.com', crypt('password123', gen_salt('bf')), now(), now(), now(), '', '', '', ''),
+  ('54000000-0000-0000-0000-000000000012', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'trade-b-54@test.com', crypt('password123', gen_salt('bf')), now(), now(), now(), '', '', '', ''),
+  ('54000000-0000-0000-0000-000000000013', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'trade-c-54@test.com', crypt('password123', gen_salt('bf')), now(), now(), now(), '', '', '', ''),
+  ('54000000-0000-0000-0000-000000000016', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'trade-x-54@test.com', crypt('password123', gen_salt('bf')), now(), now(), now(), '', '', '', '')
+ON CONFLICT (id) DO NOTHING;
+
+-- Employees: A, B, C on R1; X on R2
+INSERT INTO employees (id, restaurant_id, user_id, name, email, position, is_active) VALUES
+  ('54000000-0000-0000-0000-000000000021', '54000000-0000-0000-0000-000000000001', '54000000-0000-0000-0000-000000000011', 'Offerer A', 'trade-a-54@test.com', 'Server', true),
+  ('54000000-0000-0000-0000-000000000022', '54000000-0000-0000-0000-000000000001', '54000000-0000-0000-0000-000000000012', 'Target B', 'trade-b-54@test.com', 'Server', true),
+  ('54000000-0000-0000-0000-000000000023', '54000000-0000-0000-0000-000000000001', '54000000-0000-0000-0000-000000000013', 'Bystander C', 'trade-c-54@test.com', 'Server', true),
+  ('54000000-0000-0000-0000-000000000024', '54000000-0000-0000-0000-000000000002', '54000000-0000-0000-0000-000000000016', 'Other Restaurant X', 'trade-x-54@test.com', 'Server', true)
+ON CONFLICT (id) DO UPDATE SET is_active = true;
+
+-- Five shifts owned by A, on distinct days so no accepter ever has a
+-- schedule conflict with the shift being traded.
+INSERT INTO shifts (id, restaurant_id, employee_id, start_time, end_time, position, break_duration, status) VALUES
+  ('54000000-0000-0000-0000-000000000041', '54000000-0000-0000-0000-000000000001', '54000000-0000-0000-0000-000000000021', '2026-08-01 09:00:00+00', '2026-08-01 17:00:00+00', 'Server', 30, 'scheduled'),
+  ('54000000-0000-0000-0000-000000000042', '54000000-0000-0000-0000-000000000001', '54000000-0000-0000-0000-000000000021', '2026-08-02 09:00:00+00', '2026-08-02 17:00:00+00', 'Server', 30, 'scheduled'),
+  ('54000000-0000-0000-0000-000000000043', '54000000-0000-0000-0000-000000000001', '54000000-0000-0000-0000-000000000021', '2026-08-03 09:00:00+00', '2026-08-03 17:00:00+00', 'Server', 30, 'scheduled'),
+  ('54000000-0000-0000-0000-000000000044', '54000000-0000-0000-0000-000000000001', '54000000-0000-0000-0000-000000000021', '2026-08-04 09:00:00+00', '2026-08-04 17:00:00+00', 'Server', 30, 'scheduled'),
+  ('54000000-0000-0000-0000-000000000045', '54000000-0000-0000-0000-000000000001', '54000000-0000-0000-0000-000000000021', '2026-08-05 09:00:00+00', '2026-08-05 17:00:00+00', 'Server', 30, 'scheduled')
+ON CONFLICT (id) DO UPDATE SET position = 'Server';
+
+DELETE FROM shift_trades WHERE restaurant_id IN (
+  '54000000-0000-0000-0000-000000000001', '54000000-0000-0000-0000-000000000002'
+);
+
+-- trade51: OPEN (marketplace) trade on shift1 — used only by scenario 1
+INSERT INTO shift_trades (id, restaurant_id, offered_shift_id, offered_by_employee_id, target_employee_id, status)
+  VALUES ('54000000-0000-0000-0000-000000000051', '54000000-0000-0000-0000-000000000001', '54000000-0000-0000-0000-000000000041', '54000000-0000-0000-0000-000000000021', NULL, 'open');
+
+-- trade52: DIRECTED trade (A->B) on shift2 — used only by scenario 3
+INSERT INTO shift_trades (id, restaurant_id, offered_shift_id, offered_by_employee_id, target_employee_id, status)
+  VALUES ('54000000-0000-0000-0000-000000000052', '54000000-0000-0000-0000-000000000001', '54000000-0000-0000-0000-000000000042', '54000000-0000-0000-0000-000000000021', '54000000-0000-0000-0000-000000000022', 'open');
+
+-- trade53: OPEN (marketplace) trade on shift3 — used only by scenario 5
+INSERT INTO shift_trades (id, restaurant_id, offered_shift_id, offered_by_employee_id, target_employee_id, status)
+  VALUES ('54000000-0000-0000-0000-000000000053', '54000000-0000-0000-0000-000000000001', '54000000-0000-0000-0000-000000000043', '54000000-0000-0000-0000-000000000021', NULL, 'open');
+
+-- trade54: OPEN (marketplace) trade on shift4 — used only by scenario 2
+INSERT INTO shift_trades (id, restaurant_id, offered_shift_id, offered_by_employee_id, target_employee_id, status)
+  VALUES ('54000000-0000-0000-0000-000000000054', '54000000-0000-0000-0000-000000000001', '54000000-0000-0000-0000-000000000044', '54000000-0000-0000-0000-000000000021', NULL, 'open');
+
+-- trade55: DIRECTED trade (A->B) on shift5 — used only by scenario 4
+INSERT INTO shift_trades (id, restaurant_id, offered_shift_id, offered_by_employee_id, target_employee_id, status)
+  VALUES ('54000000-0000-0000-0000-000000000055', '54000000-0000-0000-0000-000000000001', '54000000-0000-0000-0000-000000000045', '54000000-0000-0000-0000-000000000021', '54000000-0000-0000-0000-000000000022', 'open');
+
+-- CRITICAL: re-enable RLS on every table we disabled above before switching
+-- to the authenticated role (see 53_directed_shift_trade_rls.sql precedent —
+-- the sibling 16_shift_trades_security.sql forgets this and its assertions
+-- pass vacuously).
+ALTER TABLE shift_trades ENABLE ROW LEVEL SECURITY;
+ALTER TABLE shifts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE employees ENABLE ROW LEVEL SECURITY;
+ALTER TABLE restaurants ENABLE ROW LEVEL SECURITY;
+ALTER TABLE user_restaurants ENABLE ROW LEVEL SECURITY;
+
+RESET ROLE;
+
+-- ============================================================================
+-- Scenario 1 (assertions 1-2): Bystander C calls
+-- accept_shift_trade(trade51 OPEN, B's employee_id) — i.e. accepting AS B
+-- while authenticated as C. Today's unguarded function lets this through
+-- (RED); the hardened function must reject it and leave
+-- accepted_by_employee_id untouched.
+-- ============================================================================
+SET LOCAL role = 'authenticated';
+SELECT set_config('request.jwt.claims', '{"sub":"54000000-0000-0000-0000-000000000013","role":"authenticated"}', true);
+
+SELECT is(
+  (SELECT (accept_shift_trade('54000000-0000-0000-0000-000000000051', '54000000-0000-0000-0000-000000000022')->>'success')::boolean),
+  false,
+  'Scenario 1: C cannot accept the open trade as B'
+);
+
+-- Checked as postgres (RLS bypassed) so this reads the RPC's actual write,
+-- not what the caller's own RLS-scoped view happens to expose — a
+-- cross-restaurant caller (scenario 5) can be denied visibility of the row
+-- by RLS even when the row itself was mutated, which would make a
+-- caller-scoped check pass vacuously.
+RESET ROLE;
+SET LOCAL role TO postgres;
+SELECT is(
+  (SELECT accepted_by_employee_id FROM shift_trades WHERE id = '54000000-0000-0000-0000-000000000051'),
+  NULL::uuid,
+  'Scenario 1: open trade accepted_by_employee_id stays NULL after the rejected impersonation'
+);
+
+-- ============================================================================
+-- Scenario 2 (assertions 3-4): Bystander C calls
+-- accept_shift_trade(trade54 OPEN, C's own employee_id) — legitimate
+-- self-accept of a marketplace trade. Must succeed and record C. Uses a
+-- dedicated trade (not trade51) so scenario 1's outcome above can never
+-- affect this scenario's starting state.
+-- ============================================================================
+RESET ROLE;
+SET LOCAL role = 'authenticated';
+SELECT set_config('request.jwt.claims', '{"sub":"54000000-0000-0000-0000-000000000013","role":"authenticated"}', true);
+
+SELECT is(
+  (SELECT (accept_shift_trade('54000000-0000-0000-0000-000000000054', '54000000-0000-0000-0000-000000000023')->>'success')::boolean),
+  true,
+  'Scenario 2: C can accept the open trade as themselves'
+);
+
+RESET ROLE;
+SET LOCAL role TO postgres;
+SELECT is(
+  (SELECT accepted_by_employee_id FROM shift_trades WHERE id = '54000000-0000-0000-0000-000000000054'),
+  '54000000-0000-0000-0000-000000000023'::uuid,
+  'Scenario 2: open trade accepted_by_employee_id is recorded as C'
+);
+
+-- ============================================================================
+-- Scenario 3 (assertions 5-6): Bystander C calls
+-- accept_shift_trade(trade52 DIRECTED A->B, C's own employee_id) — C is not
+-- the target, so this must fail even though C legitimately owns the
+-- employee row they're passing.
+-- ============================================================================
+RESET ROLE;
+SET LOCAL role = 'authenticated';
+SELECT set_config('request.jwt.claims', '{"sub":"54000000-0000-0000-0000-000000000013","role":"authenticated"}', true);
+
+SELECT is(
+  (SELECT (accept_shift_trade('54000000-0000-0000-0000-000000000052', '54000000-0000-0000-0000-000000000023')->>'success')::boolean),
+  false,
+  'Scenario 3: C (non-target) cannot accept the directed A->B trade'
+);
+
+RESET ROLE;
+SET LOCAL role TO postgres;
+SELECT is(
+  (SELECT accepted_by_employee_id FROM shift_trades WHERE id = '54000000-0000-0000-0000-000000000052'),
+  NULL::uuid,
+  'Scenario 3: directed trade accepted_by_employee_id stays NULL after C is rejected'
+);
+
+-- ============================================================================
+-- Scenario 4 (assertions 7-8): Target B calls
+-- accept_shift_trade(trade55 DIRECTED A->B, B's own employee_id) —
+-- legitimate target self-accept. Must succeed and record B. Uses a
+-- dedicated trade (not trade52) so scenario 3's outcome above can never
+-- affect this scenario's starting state.
+-- ============================================================================
+RESET ROLE;
+SET LOCAL role = 'authenticated';
+SELECT set_config('request.jwt.claims', '{"sub":"54000000-0000-0000-0000-000000000012","role":"authenticated"}', true);
+
+SELECT is(
+  (SELECT (accept_shift_trade('54000000-0000-0000-0000-000000000055', '54000000-0000-0000-0000-000000000022')->>'success')::boolean),
+  true,
+  'Scenario 4: B (the target) can accept the directed A->B trade as themselves'
+);
+
+RESET ROLE;
+SET LOCAL role TO postgres;
+SELECT is(
+  (SELECT accepted_by_employee_id FROM shift_trades WHERE id = '54000000-0000-0000-0000-000000000055'),
+  '54000000-0000-0000-0000-000000000022'::uuid,
+  'Scenario 4: directed trade accepted_by_employee_id is recorded as B'
+);
+
+-- ============================================================================
+-- Scenario 5 (assertions 9-10): Cross-restaurant — X (R2) calls
+-- accept_shift_trade(trade53 OPEN R1, X's own employee_id). X owns the
+-- employee row they're passing, but that employee is not in the trade's
+-- restaurant, so this must fail and leave accepted_by untouched.
+-- ============================================================================
+RESET ROLE;
+SET LOCAL role = 'authenticated';
+SELECT set_config('request.jwt.claims', '{"sub":"54000000-0000-0000-0000-000000000016","role":"authenticated"}', true);
+
+SELECT is(
+  (SELECT (accept_shift_trade('54000000-0000-0000-0000-000000000053', '54000000-0000-0000-0000-000000000024')->>'success')::boolean),
+  false,
+  'Scenario 5: cross-restaurant employee X cannot accept an R1 open trade as themselves'
+);
+
+RESET ROLE;
+SET LOCAL role TO postgres;
+SELECT is(
+  (SELECT accepted_by_employee_id FROM shift_trades WHERE id = '54000000-0000-0000-0000-000000000053'),
+  NULL::uuid,
+  'Scenario 5: R1 open trade accepted_by_employee_id stays NULL after X is rejected'
+);
+
+-- ============================================================================
+-- Cleanup
+-- ============================================================================
+RESET ROLE;
+SELECT * FROM finish();
+ROLLBACK;

--- a/tests/e2e/shift-trade-accept.spec.ts
+++ b/tests/e2e/shift-trade-accept.spec.ts
@@ -1,0 +1,143 @@
+import { test, expect } from '@playwright/test';
+import { signUpAndCreateRestaurant, exposeSupabaseHelpers, generateTestUser } from '../helpers/e2e-supabase';
+
+/**
+ * E2E for PR #615 (harden accept_shift_trade authz). Proves the permission change does NOT
+ * break the legitimate employee flow: employee Q logs in and accepts a COWORKER's (P's) open
+ * shift trade through the real "Accept Shift" button, and the trade moves to pending_approval
+ * with Q recorded as the accepter.
+ *
+ * The new server check requires the accepting employee row to belong to the caller
+ * (user_id = auth.uid(), active, same restaurant); the client passes currentEmployee.id
+ * (resolved by user_id = the caller). Negative paths (forged id, non-target on directed,
+ * cross-restaurant) are covered by pgTAP (supabase/tests/54_accept_shift_trade_authz.sql);
+ * this spec proves the happy path through real auth + UI + RPC.
+ *
+ * Two real users because RLS requires the trade's offerer to be the caller's own employee:
+ *   P (owner) offers P's own shift; Q (a second real user) accepts it.
+ */
+test.describe('Shift Trade Acceptance (accept_shift_trade authz)', () => {
+  test('an employee can accept a coworker\'s open shift trade', async ({ page }) => {
+    const primary = generateTestUser('trade-P');
+    const acceptor = generateTestUser('trade-Q');
+    await signUpAndCreateRestaurant(page, primary);
+    await exposeSupabaseHelpers(page);
+
+    const restaurantId = await page.evaluate(() => (window as any).__getRestaurantId());
+    expect(restaurantId).toBeTruthy();
+
+    // Seed: P (offerer) creates P's employee + future published shift + an OPEN trade
+    // (RLS-legit: offered_by is P's own employee). Then create acceptor Q (a second real
+    // user), Q's employee + staff membership — done while re-authenticated as owner P.
+    const seed = await page.evaluate(
+      async ({ restId, qEmail, qPassword, pEmail, pPassword }) => {
+        const supabase = (window as any).__supabase;
+
+        const pUserId = (await supabase.auth.getUser()).data.user?.id;
+        if (!pUserId) throw new Error('No P session');
+
+        // P's employee (offerer).
+        const { data: pEmp, error: pErr } = await supabase
+          .from('employees')
+          .insert({
+            restaurant_id: restId, user_id: pUserId, name: 'Pat Offerer', position: 'Server',
+            status: 'active', is_active: true, compensation_type: 'hourly', hourly_rate: 1500,
+          })
+          .select().single();
+        if (pErr) throw new Error(`P employee insert: ${pErr.message}`);
+
+        // P's future published shift.
+        const start = new Date();
+        start.setDate(start.getDate() + 3);
+        start.setHours(16, 0, 0, 0);
+        const end = new Date(start);
+        end.setHours(22, 0, 0, 0);
+        const { data: shift, error: sErr } = await supabase
+          .from('shifts')
+          .insert({
+            restaurant_id: restId, employee_id: pEmp.id,
+            start_time: start.toISOString(), end_time: end.toISOString(),
+            position: 'Server', status: 'scheduled', break_duration: 30,
+            is_published: true, locked: false,
+          })
+          .select().single();
+        if (sErr) throw new Error(`shift insert: ${sErr.message}`);
+
+        // OPEN marketplace trade offered by P (RLS WITH CHECK: offered_by is P's employee).
+        const { data: trade, error: tErr } = await supabase
+          .from('shift_trades')
+          .insert({
+            restaurant_id: restId, offered_shift_id: shift.id,
+            offered_by_employee_id: pEmp.id, target_employee_id: null, status: 'open',
+          })
+          .select().single();
+        if (tErr) throw new Error(`trade insert: ${tErr.message}`);
+
+        // Create acceptor Q as a real auth user (signUp switches the session to Q).
+        const { data: qAuth, error: qErr } = await supabase.auth.signUp({ email: qEmail, password: qPassword });
+        if (qErr) throw new Error(`Q signUp: ${qErr.message}`);
+        const qUserId = qAuth?.user?.id;
+        if (!qUserId) throw new Error('Q signUp returned no user id');
+
+        // Re-authenticate as owner P to create Q's employee + membership.
+        const { error: pSignIn } = await supabase.auth.signInWithPassword({ email: pEmail, password: pPassword });
+        if (pSignIn) throw new Error(`P re-signin: ${pSignIn.message}`);
+
+        const { data: qEmp, error: qEmpErr } = await supabase
+          .from('employees')
+          .insert({
+            restaurant_id: restId, user_id: qUserId, name: 'Quinn Acceptor', position: 'Server',
+            status: 'active', is_active: true, compensation_type: 'hourly', hourly_rate: 1500,
+          })
+          .select().single();
+        if (qEmpErr) throw new Error(`Q employee insert: ${qEmpErr.message}`);
+
+        const { error: memErr } = await supabase
+          .from('user_restaurants')
+          .upsert({ user_id: qUserId, restaurant_id: restId, role: 'staff' }, { onConflict: 'user_id,restaurant_id' });
+        if (memErr) throw new Error(`Q membership: ${memErr.message}`);
+
+        return { tradeId: trade.id as string, qEmpId: qEmp.id as string };
+      },
+      { restId: restaurantId as string, qEmail: acceptor.email, qPassword: acceptor.password, pEmail: primary.email, pPassword: primary.password },
+    );
+
+    // Log in as Q (the acceptor) and reload so the app runs under Q's session.
+    await page.evaluate(async ({ qEmail, qPassword }) => {
+      const supabase = (window as any).__supabase;
+      const { error } = await supabase.auth.signInWithPassword({ email: qEmail, password: qPassword });
+      if (error) throw new Error(`Q signin: ${error.message}`);
+    }, { qEmail: acceptor.email, qPassword: acceptor.password });
+
+    await page.goto('/employee/shifts');
+    await page.waitForURL(/\/employee\/shifts/, { timeout: 15000 });
+
+    // Q sees P's open trade and accepts it via the real button. The trade card's
+    // accept control is labelled "Accept trade from <offerer> on <date>".
+    const acceptButton = page.getByRole('button', { name: /accept trade from/i }).first();
+    await expect(acceptButton).toBeVisible({ timeout: 20000 });
+
+    const acceptResponse = page
+      .waitForResponse((r) => r.url().includes('accept_shift_trade'), { timeout: 15000 })
+      .catch(() => null);
+    await acceptButton.click();
+    await acceptResponse;
+
+    // Authoritative: the trade is now pending_approval with Q recorded as accepter.
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(async (tradeId: string) => {
+            const supabase = (window as any).__supabase;
+            const { data } = await supabase
+              .from('shift_trades')
+              .select('status, accepted_by_employee_id')
+              .eq('id', tradeId)
+              .single();
+            return data ? `${data.status}:${data.accepted_by_employee_id}` : null;
+          }, seed.tradeId),
+        { timeout: 15000 },
+      )
+      .toBe(`pending_approval:${seed.qEmpId}`);
+  });
+});


### PR DESCRIPTION
## Summary
- **Closes the `accept_shift_trade` authorization gap.** The `SECURITY DEFINER` RPC (GRANTed to `authenticated`) trusted the client-supplied `p_accepting_employee_id`, so a direct `supabase.rpc` call could set a trade's `accepted_by` to **any** employee and move it to `pending_approval` (bypassing the UI, which sends the caller's own id). Now it requires the accepting employee to belong to the caller (`user_id = auth.uid()`, active, same restaurant) and, for a **directed** trade, to be the target.
- **Bonus (Codex-caught, worse) fix:** `approve_shift_trade`/`reject_shift_trade` used `v_user_role NOT IN ('owner','manager')`, which is `NULL` (not `TRUE`) when the caller has no membership — so the manager check **failed open**, letting a non-member approve/reject. Fixed to `v_user_role IS NULL OR …`.
- **Hardening:** pinned `SET search_path = public, pg_temp` on all four SECURITY DEFINER trade functions.

## Scope
New migration `CREATE OR REPLACE`s the four functions (bodies verbatim; exact signatures preserved — verified no accidental overloads via `pg_proc`). No app/UI change (the client already passes the caller's own id). Write-side complement to #609 (directed-trade read RLS).

## Test plan
- New `supabase/tests/54_accept_shift_trade_authz.sql` (5 scenarios): attacker-as-someone-else rejected; legit self-accept succeeds; non-target self-accepting a directed trade rejected; target succeeds; cross-restaurant rejected.
- `17_shift_trade_functions_security.sql`: fixed the accept happy-path caller identity + added non-member approve/reject rejection tests.
- **pgTAP 1710/1710 pass** (fresh `db:reset`); typecheck ✅, build ✅, CodeRabbit no findings.

## Follow-ups
- `cancel_shift_trade` omits `is_active` in its ownership check (minor inconsistency, noted).

## Design
docs/superpowers/specs/2026-07-13-accept-trade-authz-design.md
