### PR TITLE
feat(notify): admin per-type × per-channel notification matrix

### DIFF
--- a/docs/superpowers/plans/2026-07-13-notification-channel-matrix-plan.md
+++ b/docs/superpowers/plans/2026-07-13-notification-channel-matrix-plan.md
@@ -1,0 +1,90 @@
+# Plan — Notification channel matrix (B1 + B2 combined)
+
+**Design:** docs/superpowers/specs/2026-07-13-notification-channel-matrix-design.md
+**Branch:** `feature/notification-channel-matrix`
+**Approved:** B1+B2 in one PR; **default = ON for both channels** (fail-open preserved).
+
+Reminder: after any migration add/edit, `npm run db:reset` before `npm run test:db`.
+
+---
+
+## B1 — Data model + resolver + one retrofit
+
+### Task 1 — migration: table + RLS + data-migration
+- **File** `supabase/migrations/<ts-after-20260713010000>_notification_channel_settings.sql`:
+  - `CREATE TABLE notification_channel_settings (id, restaurant_id FK, notification_type TEXT,
+    email_enabled BOOL DEFAULT true, push_enabled BOOL DEFAULT true, created_at, updated_at,
+    UNIQUE(restaurant_id, notification_type))`; index on restaurant_id; `ENABLE ROW LEVEL SECURITY`.
+  - RLS **copied verbatim from `20251123100500_create_notification_settings.sql`** (change only the
+    table name): SELECT for any `user_restaurants` member; `FOR ALL` (manage) for `role IN
+    ('owner','manager')`.
+  - **Data-migration** (preserve existing choices): for each `notification_settings` row, INSERT
+    channel rows for the 8 gated types mapping the old single boolean → BOTH email_enabled and
+    push_enabled: `shift_created←notify_shift_created`, `shift_modified←notify_shift_modified`,
+    `shift_deleted←notify_shift_deleted`, `time_off_requested←notify_time_off_request`,
+    `time_off_approved←notify_time_off_approved`, `time_off_rejected←notify_time_off_rejected`.
+    `ON CONFLICT (restaurant_id, notification_type) DO NOTHING`. Untracked types left absent (→ ON).
+- **Test** `supabase/tests/<nn>_notification_channel_settings_rls.sql` (pattern:
+  `33_tip_splits_employee_rls.sql`; ENABLE RLS before impersonating): a staff member can SELECT but
+  NOT insert/update; an owner/manager can; cross-restaurant isolation; and a data-migration
+  assertion (a restaurant with `notify_shift_created=false` gets a seeded row with
+  email_enabled=false AND push_enabled=false).
+- Dep: none.
+
+### Task 2 — `_shared/resolveChannels.ts` resolver + unit test
+- **Test** `tests/unit/resolveChannels.test.ts` (inject a mock supabase): row present → returns its
+  {email,push}; no row (PGRST116) → {email:true,push:true}; query error → {email:true,push:true}
+  (fail-open); email off / push off variants.
+- **Code** `supabase/functions/_shared/resolveChannels.ts` per design (union type of the 17 types;
+  `ChannelDecision`; fail-open).
+- Dep: 1.
+
+### Task 3 — retrofit `send-shift-notification/index.ts`
+- Replace the single `shouldSendNotification(..., settingKey)` gate (deleted branch ~154, created/
+  modified ~261) with `const ch = await resolveChannels(supabase, restaurantId, <type>)`; gate the
+  Resend email send by `ch.email` and the `sendWebPushToUser` call by `ch.push` **independently**
+  (today they share one boolean). Map action→type: created→`shift_created`, modified→`shift_modified`,
+  deleted→`shift_deleted`. Keep the "no email / no user_id" short-circuits.
+- **Verify**: `deno check`; the existing `send-shift-notification` behavior for a fully-on restaurant
+  is unchanged (default ON).
+- Dep: 2.
+
+## B2 — Admin matrix UI
+
+### Task 4 — `useNotificationChannelSettings` hook + types + test
+- **Code** `src/hooks/useNotificationChannelSettings.tsx`: React Query fetch of all rows for the
+  restaurant (`select('*').eq('restaurant_id', …)`), returning a `Map<type,{email,push}>` merged
+  over the default-ON baseline for the 17 known types; an upsert mutation
+  (`.upsert(rows, { onConflict: 'restaurant_id,notification_type' })`) invalidating the query.
+- **Types**: add `NotificationChannelSetting` + the `NOTIFICATION_TYPES` catalog (type key + human
+  label + group) in `src/types/` (or a `src/lib/notificationTypes.ts`). Run `sync-types` if needed.
+- **Test** `tests/unit/useNotificationChannelSettings.test.ts`: default-ON merge for absent types;
+  upsert payload shape; both invoke-error shapes swallowed (per the 2026-05-16 lesson).
+- Dep: 1.
+
+### Task 5 — matrix UI in Settings → Notifications
+- **Code** extend `src/components/NotificationSettings.tsx` (or a new
+  `NotificationChannelMatrix.tsx` rendered in the same tab): a grouped table — rows = the 17 types
+  (grouped Scheduling / Trades / Time-off / Access / Open shifts), columns = **Email** / **Push**
+  `Switch` cells; local-state-then-**Save** pattern (mirror the existing component: `localSettings`
+  diffed for `hasChanges`, Save/Reset buttons). Follow CLAUDE.md styling (semantic tokens, typography
+  scale, `Switch` `data-[state=checked]:bg-foreground`). Handle loading/empty/error states. a11y:
+  each Switch labelled by its row+column. Owner/manager-gated (tab already is).
+- **Test** `tests/unit/NotificationChannelMatrix.test.tsx`: renders rows/columns; toggling a cell +
+  Save calls the upsert with the right payload; disabled/read-only for non-managers if applicable.
+- Dep: 4.
+
+---
+
+## Phase 5 UI review: REQUIRED (Task 5 adds real UI) — run frontend-design review.
+## Phase 8 verify
+`npm run db:reset` + `npm run test:db` (RLS + data-migration), `npm run test` (resolver, hook,
+component), `npm run typecheck`, `npm run lint`, `npm run build`, `deno check` on the retrofit.
+
+## Task order
+1 → 2 → 3 (B1) ; 1 → 4 → 5 (B2). 3 and 4/5 independent after their deps.
+
+## Out of scope (B3 + follow-ups)
+- B3: retrofit notify-schedule-published, send-shift-trade-notification, send-time-off-notification,
+  broadcast-open-shifts, notify-pin-changed onto `resolveChannels` (next PR).
+- Per-employee overrides; unifying web-push vs legacy FCM; dropping legacy notification_settings cols.

--- a/docs/superpowers/plans/2026-07-13-notification-channel-matrix-plan.md
+++ b/docs/superpowers/plans/2026-07-13-notification-channel-matrix-plan.md
@@ -1,90 +1,96 @@
-# Plan — Notification channel matrix (B1 + B2 combined)
+# Plan — Notification channel matrix (FULL, all rows live, one PR)
 
 **Design:** docs/superpowers/specs/2026-07-13-notification-channel-matrix-design.md
 **Branch:** `feature/notification-channel-matrix`
-**Approved:** B1+B2 in one PR; **default = ON for both channels** (fail-open preserved).
+**User decision:** full retrofit + full matrix, every visible toggle live; retire old time-off toggles.
 
-Reminder: after any migration add/edit, `npm run db:reset` before `npm run test:db`.
+Reminder (lesson): after any migration add/edit, `npm run db:reset` before `npm run test:db`.
+
+## The 16 notification types (matrix rows) + channels each actually sends
+| key | group | email | push |
+|---|---|---|---|
+| schedule_published | Scheduling | ✅ | ✅ |
+| shift_created / shift_modified / shift_deleted | Scheduling | ✅ | ✅ |
+| open_shifts_broadcast | Scheduling | ✅ | ✅ |
+| shift_trade_created / _accepted / _approved / _rejected / _cancelled | Trades | ✅ | ✅ |
+| time_off_requested | Time off | ✅ | — |
+| time_off_approved / time_off_rejected | Time off | ✅ | ✅ |
+| pin_reset | Access | ✅ | ✅ |
+| team_invite | Access | ✅ | — |
+| availability_reminder | Scheduling | ✅ | — |
+(weekly_brief stays on per-user `notification_preferences` — NOT a matrix row.)
 
 ---
 
-## B1 — Data model + resolver + one retrofit
-
-### Task 1 — migration: table + RLS + data-migration
-- **File** `supabase/migrations/<ts-after-20260713010000>_notification_channel_settings.sql`:
-  - `CREATE TABLE notification_channel_settings (id, restaurant_id FK, notification_type TEXT,
-    email_enabled BOOL DEFAULT true, push_enabled BOOL DEFAULT true, created_at, updated_at,
-    UNIQUE(restaurant_id, notification_type))`; index on restaurant_id; `ENABLE ROW LEVEL SECURITY`.
-  - RLS **copied verbatim from `20251123100500_create_notification_settings.sql`** (change only the
-    table name): SELECT for any `user_restaurants` member; `FOR ALL` (manage) for `role IN
-    ('owner','manager')`.
-  - **Data-migration** (preserve existing choices): for each `notification_settings` row, INSERT
-    channel rows for the 8 gated types mapping the old single boolean → BOTH email_enabled and
-    push_enabled: `shift_created←notify_shift_created`, `shift_modified←notify_shift_modified`,
-    `shift_deleted←notify_shift_deleted`, `time_off_requested←notify_time_off_request`,
-    `time_off_approved←notify_time_off_approved`, `time_off_rejected←notify_time_off_rejected`.
-    `ON CONFLICT (restaurant_id, notification_type) DO NOTHING`. Untracked types left absent (→ ON).
-- **Test** `supabase/tests/<nn>_notification_channel_settings_rls.sql` (pattern:
-  `33_tip_splits_employee_rls.sql`; ENABLE RLS before impersonating): a staff member can SELECT but
-  NOT insert/update; an owner/manager can; cross-restaurant isolation; and a data-migration
-  assertion (a restaurant with `notify_shift_created=false` gets a seeded row with
-  email_enabled=false AND push_enabled=false).
+### Task 1 — catalog + resolver + tests (single source of truth)
+- **`src/lib/notificationTypes.ts`**: `NOTIFICATION_TYPES` array of `{ key, label, group, channels }`
+  (channels = subset of `['email','push']` per the table above); export `NotificationType` union of keys.
+- **`supabase/functions/_shared/resolveChannels.ts`**: `resolveChannels(supabase, restaurantId, type)
+  → { email, push }`; single-row lookup by `(restaurant_id, notification_type)`; **fail-open** (missing
+  row/error → both true). Type union kept in sync with the catalog.
+- **Tests** `tests/unit/resolveChannels.test.ts` (mock supabase: present row, missing→open, error→open,
+  each channel off) + `tests/unit/notificationTypes.test.ts` (catalog keys ⊆/= resolver union; a type's
+  `push` channel ⇒ its function actually sends push — guards catalog/CHECK/union drift).
 - Dep: none.
 
-### Task 2 — `_shared/resolveChannels.ts` resolver + unit test
-- **Test** `tests/unit/resolveChannels.test.ts` (inject a mock supabase): row present → returns its
-  {email,push}; no row (PGRST116) → {email:true,push:true}; query error → {email:true,push:true}
-  (fail-open); email off / push off variants.
-- **Code** `supabase/functions/_shared/resolveChannels.ts` per design (union type of the 17 types;
-  `ChannelDecision`; fail-open).
-- Dep: 1.
+### Task 2 — migration: table + RLS + trigger + CHECK + data-migration + pgTAP
+- **Migration** `supabase/migrations/<ts-after-20260713010000>_notification_channel_settings.sql`:
+  - `CREATE TABLE notification_channel_settings(id, restaurant_id FK ON DELETE CASCADE,
+    notification_type TEXT, email_enabled BOOL NOT NULL DEFAULT true, push_enabled BOOL NOT NULL
+    DEFAULT true, created_at, updated_at, UNIQUE(restaurant_id, notification_type),
+    CHECK (notification_type IN (<16 keys>)))`.
+  - `ENABLE ROW LEVEL SECURITY`; RLS **verbatim from `20251123100500`** (view = member; `FOR ALL` =
+    owner/manager).
+  - `BEFORE UPDATE` trigger → `update_scheduling_updated_at()`.
+  - Data-migration: `INSERT..SELECT` from `notification_settings` for the 6 legacy-gated types,
+    `email_enabled = COALESCE(<bool>, true)`, `push_enabled = COALESCE(<bool>, true)`,
+    `ON CONFLICT (restaurant_id, notification_type) DO NOTHING`.
+- **Test** `supabase/tests/<nn>_notification_channel_settings_rls.sql` (pattern `33_tip_splits...`;
+  ENABLE RLS before impersonating): staff can SELECT not write; owner/manager can write; cross-restaurant
+  isolation; data-migration preserves a `false` legacy toggle into both channels; CHECK rejects a bad type.
+- Dep: 1 (type list).
 
-### Task 3 — retrofit `send-shift-notification/index.ts`
-- Replace the single `shouldSendNotification(..., settingKey)` gate (deleted branch ~154, created/
-  modified ~261) with `const ch = await resolveChannels(supabase, restaurantId, <type>)`; gate the
-  Resend email send by `ch.email` and the `sendWebPushToUser` call by `ch.push` **independently**
-  (today they share one boolean). Map action→type: created→`shift_created`, modified→`shift_modified`,
-  deleted→`shift_deleted`. Keep the "no email / no user_id" short-circuits.
-- **Verify**: `deno check`; the existing `send-shift-notification` behavior for a fully-on restaurant
-  is unchanged (default ON).
-- Dep: 2.
+### Task 3 — retrofit ALL firing functions (split email/push gating)
+Each: `const ch = await resolveChannels(<service client>, restaurantId, <type>)`; gate email send by
+`ch.email`, push send by `ch.push`, independently. Replace legacy gates.
+- **3a `send-shift-notification`**: replace the single `shouldSendNotification` (deleted + created/modified
+  branches) with `resolveChannels`; action→type map.
+- **3b `notify-schedule-published`**: add gating (currently none) — `schedule_published`.
+- **3c `send-shift-trade-notification`**: `shift_trade_<action>`; gate the email + the web-push/FCM sends.
+- **3d `send-time-off-notification`**: replace the hand-rolled `notification_settings` gate with
+  `resolveChannels` for `time_off_<action>`; keep the `time_off_notify_managers/employee` **recipient**
+  flags (those are recipient-routing, not channel gates — leave in `notification_settings` for now).
+- **3e `broadcast-open-shifts`**: `open_shifts_broadcast`.
+- **3f `notify-pin-changed`**: `pin_reset` (gate email + FCM). **3g `send-team-invitation`**: `team_invite`
+  (email only). **3h `notify-availability-reminder`**: `availability_reminder` (email only).
+- Use each function's existing service-role/admin client for the resolver read. `deno check` each.
+- Dep: 1, 2.
 
-## B2 — Admin matrix UI
-
-### Task 4 — `useNotificationChannelSettings` hook + types + test
-- **Code** `src/hooks/useNotificationChannelSettings.tsx`: React Query fetch of all rows for the
-  restaurant (`select('*').eq('restaurant_id', …)`), returning a `Map<type,{email,push}>` merged
-  over the default-ON baseline for the 17 known types; an upsert mutation
-  (`.upsert(rows, { onConflict: 'restaurant_id,notification_type' })`) invalidating the query.
-- **Types**: add `NotificationChannelSetting` + the `NOTIFICATION_TYPES` catalog (type key + human
-  label + group) in `src/types/` (or a `src/lib/notificationTypes.ts`). Run `sync-types` if needed.
-- **Test** `tests/unit/useNotificationChannelSettings.test.ts`: default-ON merge for absent types;
-  upsert payload shape; both invoke-error shapes swallowed (per the 2026-05-16 lesson).
-- Dep: 1.
-
-### Task 5 — matrix UI in Settings → Notifications
-- **Code** extend `src/components/NotificationSettings.tsx` (or a new
-  `NotificationChannelMatrix.tsx` rendered in the same tab): a grouped table — rows = the 17 types
-  (grouped Scheduling / Trades / Time-off / Access / Open shifts), columns = **Email** / **Push**
-  `Switch` cells; local-state-then-**Save** pattern (mirror the existing component: `localSettings`
-  diffed for `hasChanges`, Save/Reset buttons). Follow CLAUDE.md styling (semantic tokens, typography
-  scale, `Switch` `data-[state=checked]:bg-foreground`). Handle loading/empty/error states. a11y:
-  each Switch labelled by its row+column. Owner/manager-gated (tab already is).
-- **Test** `tests/unit/NotificationChannelMatrix.test.tsx`: renders rows/columns; toggling a cell +
-  Save calls the upsert with the right payload; disabled/read-only for non-managers if applicable.
-- Dep: 4.
+### Task 4 — admin matrix UI + hook (retire old toggles)
+- **`src/hooks/useNotificationChannelSettings.tsx`**: React Query `select('id, notification_type,
+  email_enabled, push_enabled').eq('restaurant_id',…)` (`staleTime: 60000`); merge over default-ON
+  baseline for the 16 types → `Map`. Mutation = **diff-based upsert** (only rows changed vs snapshot),
+  `onConflict: 'restaurant_id,notification_type'`, invalidate. Handle both invoke-error shapes.
+- **`src/components/NotificationChannelMatrix.tsx`**: grouped `<table>` per domain (mirror
+  `AvailabilityGrid.tsx` a11y — `sr-only` `<th scope=col>`, `scope=row` labels, composed `aria-label`
+  per `Switch` e.g. `"Shift deleted — Push"`); a channel a type doesn't support renders `—` (no toggle,
+  no dead switch). Local-state-then-Save; `hasChanges` by **value comparison**; **sync-guard** so a
+  refetch doesn't clobber edits while dirty; loading→skeleton, error→retry banner (never silent all-ON).
+  CLAUDE.md styling; sticky Save/Reset footer; verify at 375px. Owner/manager-gated (tab already is).
+- **Retire old toggles**: remove the 5 time-off event switches from `NotificationSettings.tsx`
+  (now governed by the matrix); keep the Weekly Brief card (still per-user). Render the matrix in the
+  Notifications tab.
+- **Tests** `tests/unit/useNotificationChannelSettings.test.ts` (default-ON merge, diff-upsert payload,
+  error swallow) + `tests/unit/NotificationChannelMatrix.test.tsx` (renders grouped rows; unsupported
+  channel shows `—`; toggle+Save calls diff-upsert; hasChanges value-based; loading/error states).
+- Dep: 1, 2.
 
 ---
 
-## Phase 5 UI review: REQUIRED (Task 5 adds real UI) — run frontend-design review.
-## Phase 8 verify
-`npm run db:reset` + `npm run test:db` (RLS + data-migration), `npm run test` (resolver, hook,
-component), `npm run typecheck`, `npm run lint`, `npm run build`, `deno check` on the retrofit.
+## Phase 5 UI review: REQUIRED. ## Phase 8 verify: `db:reset`+`test:db`, `test`, `typecheck`, `lint`,
+`build`, `deno check` on retrofits, and the shift-trade-accept-style flows unaffected.
 
-## Task order
-1 → 2 → 3 (B1) ; 1 → 4 → 5 (B2). 3 and 4/5 independent after their deps.
+## Task order: 1 → 2 ; 1,2 → 3 ; 1,2 → 4. (3 and 4 independent.)
 
-## Out of scope (B3 + follow-ups)
-- B3: retrofit notify-schedule-published, send-shift-trade-notification, send-time-off-notification,
-  broadcast-open-shifts, notify-pin-changed onto `resolveChannels` (next PR).
-- Per-employee overrides; unifying web-push vs legacy FCM; dropping legacy notification_settings cols.
+## Out of scope: per-employee overrides; unify web-push vs FCM; drop legacy notification_settings
+columns after a soak; weekly_brief admin control.

--- a/docs/superpowers/plans/2026-07-13-notification-channel-matrix-plan.md
+++ b/docs/superpowers/plans/2026-07-13-notification-channel-matrix-plan.md
@@ -16,8 +16,9 @@ Reminder (lesson): after any migration add/edit, `npm run db:reset` before `npm 
 | time_off_requested | Time off | ✅ | — |
 | time_off_approved / time_off_rejected | Time off | ✅ | ✅ |
 | pin_reset | Access | ✅ | ✅ |
-| team_invite | Access | ✅ | — |
 | availability_reminder | Scheduling | ✅ | — |
+(15 rows. `team_invite` is **excluded** — a transactional invite email carries the only copy of the
+accept link, so it always sends and is not admin-toggleable. `send-team-invitation` is NOT retrofitted.)
 (weekly_brief stays on per-user `notification_preferences` — NOT a matrix row.)
 
 ---
@@ -61,8 +62,9 @@ Each: `const ch = await resolveChannels(<service client>, restaurantId, <type>)`
   `resolveChannels` for `time_off_<action>`; keep the `time_off_notify_managers/employee` **recipient**
   flags (those are recipient-routing, not channel gates — leave in `notification_settings` for now).
 - **3e `broadcast-open-shifts`**: `open_shifts_broadcast`.
-- **3f `notify-pin-changed`**: `pin_reset` (gate email + FCM). **3g `send-team-invitation`**: `team_invite`
-  (email only). **3h `notify-availability-reminder`**: `availability_reminder` (email only).
+- **3f `notify-pin-changed`**: `pin_reset` (gate email + FCM). **3g `send-team-invitation`**: NOT
+  retrofitted — invite email is transactional, always sends (excluded from the catalog). **3h
+  `notify-availability-reminder`**: `availability_reminder` (email only).
 - Use each function's existing service-role/admin client for the resolver read. `deno check` each.
 - Dep: 1, 2.
 

--- a/docs/superpowers/specs/2026-07-13-notification-channel-matrix-design.md
+++ b/docs/superpowers/specs/2026-07-13-notification-channel-matrix-design.md
@@ -1,0 +1,105 @@
+# Design — Admin per-type × per-channel notification matrix (Phase B)
+
+**Date:** 2026-07-13
+**Branch:** `feature/notification-channel-matrix`
+**Control model:** admin-only (restaurant-level; no per-employee override this phase)
+
+## Goal
+
+One place where a manager decides, **per notification type**, whether it goes out over **Email**
+and/or **Push**. Every notification-sending edge function consults a shared resolver before sending
+on each channel, replacing today's scattered/absent gating.
+
+## Current reality (from infra map)
+
+- `notification_settings` gates by a **single boolean per type** (`notify_shift_created` …) that
+  covers email+push together; only `send-shift-notification` (3 shift types) and
+  `send-time-off-notification` (5 time-off flags) actually consult it. 12+ other types fire with
+  **no gating**. ~21 columns are inert.
+- `shouldSendNotification()` is **fail-open** (missing row → send).
+- 17 distinct types fire across 8 functions; channels vary (email-only, email+push, +legacy FCM).
+- `notification_preferences` (weekly brief) is per-user — **out of scope**.
+
+## Data model
+
+New table (do NOT extend the 29-column `notification_settings` further):
+
+```sql
+CREATE TABLE notification_channel_settings (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  restaurant_id UUID NOT NULL REFERENCES restaurants(id) ON DELETE CASCADE,
+  notification_type TEXT NOT NULL,        -- 'schedule_published', 'shift_created', …
+  email_enabled BOOLEAN NOT NULL DEFAULT true,
+  push_enabled  BOOLEAN NOT NULL DEFAULT true,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now(),
+  UNIQUE (restaurant_id, notification_type)
+);
+```
+- **RLS** copies `notification_settings` verbatim: SELECT for any restaurant member; INSERT/UPDATE/
+  DELETE (`FOR ALL`) restricted to `role IN ('owner','manager')` — already exactly "admin-only".
+- **Absent row ⇒ both channels ON** (preserves the current fail-open behavior → zero behavior change
+  for restaurants that never configure anything).
+- **Data migration to preserve existing choices:** for every restaurant with a `notification_settings`
+  row, seed `notification_channel_settings` rows for the 8 already-gated types
+  (`shift_created/modified/deleted`, `time_off_requested/approved/rejected`) mapping the old single
+  boolean → BOTH `email_enabled` and `push_enabled` (a restaurant that turned `notify_shift_created`
+  off keeps it off on both channels). Types that were never gated are left absent (→ ON, unchanged).
+
+## Resolver (shared)
+
+`supabase/functions/_shared/resolveChannels.ts` (pure-ish; DB read injectable for tests):
+
+```ts
+export type NotificationType = 'schedule_published' | 'shift_created' | … ;   // union of the 17
+export interface ChannelDecision { email: boolean; push: boolean }
+
+/** Restaurant-level channel decision for a notification type. Fail-OPEN: no row ⇒ both true
+ *  (matches today's shouldSendNotification default — never silently drop on a missing/errored row). */
+export async function resolveChannels(
+  supabase: SupabaseClient, restaurantId: string, type: NotificationType,
+): Promise<ChannelDecision>;
+```
+- Reads the one row by `(restaurant_id, notification_type)`; missing/error → `{ email: true, push: true }`.
+- Each notify function becomes: `const ch = await resolveChannels(...); if (ch.email) {…email…} if (ch.push) {…push…}` — splitting today's single combined gate into two.
+- The "push" boolean is **channel-agnostic**: a function fans out to whatever push it already uses
+  (web push and/or legacy FCM) when `ch.push` is true. This migration does not unify the two push
+  mechanisms (separate follow-up).
+
+## Rollout — sliced into reviewable PRs
+
+**B1 — Foundation (this PR):** migration (table + RLS + data-migration from `notification_settings`)
++ `resolveChannels.ts` resolver (unit-tested) + retrofit **one** function as proof —
+`send-shift-notification` (cleanest: it already uses the single `shouldSendNotification`; replace with
+per-channel `resolveChannels`, email gated by `ch.email`, push by `ch.push`). pgTAP for table/RLS;
+vitest for the resolver; the retrofit verified by `deno check`.
+
+**B2 — Admin UI:** a matrix in the existing Settings → Notifications tab (rows = the 17 types,
+columns = Email / Push `Switch` cells; local-state-then-Save, mirroring `NotificationSettings.tsx`).
+New `useNotificationChannelSettings` hook. Regenerate/extend TS types. Human-friendly type labels +
+grouping (Scheduling / Trades / Time-off / Access / …).
+
+**B3 — Retrofit the rest:** wire `resolveChannels` into `notify-schedule-published`,
+`send-shift-trade-notification`, `send-time-off-notification`, `broadcast-open-shifts`,
+`notify-pin-changed`. Each splits email/push gating; `send-time-off-notification`'s hand-rolled gate
+is unified onto the resolver.
+
+## Out of scope / follow-ups
+
+- Per-**employee** channel overrides (a `notification_user_channel_overrides` table layered on top) —
+  explicitly deferred (user chose admin-only for now).
+- Unifying the two push mechanisms (web push vs legacy FCM `device_tokens`).
+- `weekly_brief` stays on per-user `notification_preferences`; not an admin-matrix row.
+- The ~21 inert `notification_settings` columns (payroll/tips/etc.) — those types don't fire yet, so
+  they're not matrix rows until a sender exists. The matrix covers only currently-firing types.
+
+## Decided trade-offs
+
+- **Fail-open preserved.** A restaurant with no config (or a type with no row) gets both channels —
+  matching today. Fail-closed would silently mute everyone on deploy; rejected.
+- **New table, not more `notification_settings` columns.** A normalized `(type, channel)` shape scales
+  to 17+ types × 2 channels without a 60-column table, and cleanly separates the new model from the
+  legacy per-type booleans (which the data-migration reads once, then the new table is authoritative).
+- **Legacy `notification_settings` booleans become read-once seed data**, not a live dual-source. After
+  B3, the new table is the single source of truth for the retrofitted types; the old columns are left
+  in place (harmless) and can be dropped in a later cleanup.

--- a/docs/superpowers/specs/2026-07-13-notification-channel-matrix-design.md
+++ b/docs/superpowers/specs/2026-07-13-notification-channel-matrix-design.md
@@ -84,6 +84,43 @@ grouping (Scheduling / Trades / Time-off / Access / …).
 `notify-pin-changed`. Each splits email/push gating; `send-time-off-notification`'s hand-rolled gate
 is unified onto the resolver.
 
+## Combined scope (user decision) + design-review folds
+
+**User chose "full matrix, all live, one PR":** wire **all currently-firing** notification functions
+to `resolveChannels` (B1+B3) AND ship the **full matrix UI** (B2) so **every visible row is live** —
+no dead toggles. Retire the old time-off event switches (replaced by matrix rows).
+
+### Supabase review folds
+- **COALESCE legacy booleans** in the data-migration: `COALESCE(notify_shift_created, true)` for every
+  mapped column (both channels) — nullable legacy columns would otherwise NULL-violate the NOT NULL
+  channel columns and abort the whole `INSERT..SELECT`; and NULL→true preserves fail-open semantics.
+- **Add an `updated_at` `BEFORE UPDATE` trigger** reusing `update_scheduling_updated_at()` (the source
+  table has one; without it `updated_at` never advances on toggle-saves).
+- **CHECK constraint** `notification_type IN (<17 types>)` — turns a typo (which fail-open would mask
+  as "not configured") into an insert-time error. The TS union is the single hand-maintained source;
+  the CHECK list + UI catalog are reviewed against it in this PR.
+- Drop the redundant single-column `restaurant_id` index (composite UNIQUE covers the prefix).
+- Data-migration seeds **6** types (3 shift + 3 time-off), not "8" (doc-count fix).
+
+### Frontend review folds
+- **No dead rows** (was critical): resolved by the full retrofit — every row controls a live function.
+- **Retire the old time-off toggles** in `NotificationSettings.tsx` (they wrote the legacy table);
+  once `send-time-off-notification` reads only the resolver, the matrix's time-off rows are the single
+  control. Removing avoids two contradictory controls in one tab.
+- **Diff-based Save** (was critical, lost-update race + bloat): upsert **only rows changed vs the
+  fetched snapshot**, never the full 17×2 grid.
+- **Guard the local↔server sync effect** so a background refetch (`refetchOnWindowFocus`/staleTime)
+  never clobbers in-progress edits while `hasChanges` is true.
+- **a11y:** a real `<table>` per domain group (mirror `AvailabilityGrid.tsx`), each `Switch` with a
+  composed `aria-label` (`"Shift deleted — Push"`); `sr-only` column headers, `scope="row"` labels.
+- **Mobile:** verify at 375px; sticky Save/Reset footer given the page height.
+- **Catalog single-source:** `src/lib/notificationTypes.ts` (key + label + group). A vitest asserts its
+  keys exactly match the resolver's `NotificationType` union (drift fails CI, not prod).
+- **States:** loading → table-shaped skeleton; error → explicit retry banner (NOT a silent all-ON
+  fallback, which would look identical to a real fail-open load); no empty state (17 fixed rows).
+- New `NotificationChannelMatrix.tsx` component (don't bloat `NotificationSettings.tsx`); `staleTime:
+  60000`; `hasChanges` by value-comparison; explicit `select` fields.
+
 ## Out of scope / follow-ups
 
 - Per-**employee** channel overrides (a `notification_user_channel_overrides` table layered on top) —

--- a/docs/superpowers/specs/2026-07-13-notification-channel-matrix-design.md
+++ b/docs/superpowers/specs/2026-07-13-notification-channel-matrix-design.md
@@ -121,6 +121,15 @@ no dead toggles. Retire the old time-off event switches (replaced by matrix rows
 - New `NotificationChannelMatrix.tsx` component (don't bloat `NotificationSettings.tsx`); `staleTime:
   60000`; `hasChanges` by value-comparison; explicit `select` fields.
 
+## Amendment (review): `team_invite` excluded — transactional, not a notification
+
+The multi-model review flagged that a team-invitation email is **transactional**: it carries the only
+copy of the accept link (the token is hashed/unrecoverable server-side). Making it a matrix toggle
+would let an admin turn it off and silently break every invite (reported "sent", but no link ever
+delivered, unrecoverable). Decision (user-confirmed): **exclude `team_invite` from the catalog**
+(now **15** types). `send-team-invitation` is **not** retrofitted and always sends. An "invite by
+link / copy link" affordance (so email could be optional) is a possible future feature, out of scope.
+
 ## Out of scope / follow-ups
 
 - Per-**employee** channel overrides (a `notification_user_channel_overrides` table layered on top) —

--- a/src/components/NotificationChannelMatrix.tsx
+++ b/src/components/NotificationChannelMatrix.tsx
@@ -1,0 +1,231 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import { Skeleton } from '@/components/ui/skeleton';
+import { AlertCircle, Bell } from 'lucide-react';
+
+import {
+  useNotificationChannelSettings,
+  type ChannelSettingsMap,
+} from '@/hooks/useNotificationChannelSettings';
+import { NOTIFICATION_TYPES, type NotificationGroup, type NotificationType } from '@/lib/notificationTypes';
+
+interface NotificationChannelMatrixProps {
+  restaurantId: string;
+}
+
+const GROUP_ORDER: NotificationGroup[] = ['Scheduling', 'Trades', 'Time off', 'Access'];
+
+function mapsEqual(a: ChannelSettingsMap, b: ChannelSettingsMap): boolean {
+  for (const type of NOTIFICATION_TYPES) {
+    const av = a.get(type.key);
+    const bv = b.get(type.key);
+    if (av?.email !== bv?.email || av?.push !== bv?.push) return false;
+  }
+  return true;
+}
+
+/**
+ * Admin per-type × per-channel notification matrix (Settings → Notifications).
+ * Grouped `<table>` per domain, mirroring `AvailabilityGrid.tsx`'s a11y
+ * pattern. Local-state-then-Save with a sync-guard so a background refetch
+ * never clobbers in-progress edits. See docs/superpowers/specs/2026-07-13-
+ * notification-channel-matrix-design.md.
+ */
+export function NotificationChannelMatrix({ restaurantId }: NotificationChannelMatrixProps) {
+  const { settings, isLoading, isError, refetch, saveChanges, isSaving } =
+    useNotificationChannelSettings(restaurantId);
+
+  const [local, setLocal] = useState<ChannelSettingsMap>(() => new Map(settings));
+
+  // hasChanges is derived by value-comparison (not a dirty flag) so it can
+  // never drift from what's actually on screen.
+  const hasChanges = useMemo(() => !mapsEqual(local, settings), [local, settings]);
+
+  // Sync-guard: only pull the server snapshot into local state while the form
+  // is clean. A background refetch (staleTime elapsing, window refocus, or a
+  // post-save invalidation) must never clobber edits the user hasn't saved.
+  useEffect(() => {
+    if (!hasChanges) {
+      setLocal(new Map(settings));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally omits hasChanges: it must not retrigger this sync
+  }, [settings]);
+
+  const groups = useMemo(
+    () =>
+      GROUP_ORDER.map((group) => ({
+        group,
+        types: NOTIFICATION_TYPES.filter((t) => t.group === group),
+      })).filter((g) => g.types.length > 0),
+    [],
+  );
+
+  function updateChannel(type: NotificationType, channel: 'email' | 'push', value: boolean) {
+    setLocal((prev) => {
+      const next = new Map(prev);
+      const current = next.get(type) ?? { email: true, push: true };
+      next.set(type, { ...current, [channel]: value });
+      return next;
+    });
+  }
+
+  async function handleSave() {
+    try {
+      await saveChanges(local);
+    } catch {
+      // Failure is already surfaced via toast inside the hook; keep the
+      // user's local edits in place (footer stays visible) so they can retry.
+    }
+  }
+
+  function handleReset() {
+    setLocal(new Map(settings));
+  }
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        <Skeleton
+          className="h-6 w-56"
+          role="status"
+          aria-label="Loading notification channel settings"
+        />
+        <Skeleton className="h-40 w-full rounded-xl" />
+        <Skeleton className="h-40 w-full rounded-xl" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div
+        role="alert"
+        className="flex items-center justify-between gap-3 p-4 rounded-xl border border-destructive/20 bg-destructive/10"
+      >
+        <div className="flex items-center gap-2 text-[13px] text-foreground">
+          <AlertCircle className="h-4 w-4 text-destructive" aria-hidden="true" />
+          <span>Couldn&apos;t load notification channel settings.</span>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-8 px-3 rounded-lg text-[13px] font-medium"
+          onClick={() => refetch()}
+        >
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 pb-4">
+      <div className="flex items-center gap-2">
+        <Bell className="h-5 w-5 text-primary" aria-hidden="true" />
+        <div>
+          <h2 className="text-[17px] font-semibold text-foreground">Notification channels</h2>
+          <p className="text-[13px] text-muted-foreground">
+            Choose which channels each notification type sends over.
+          </p>
+        </div>
+      </div>
+
+      {groups.map(({ group, types }) => (
+        <div key={group} className="rounded-xl border border-border/40 bg-muted/30 overflow-hidden">
+          <div className="px-4 py-3 border-b border-border/40 bg-muted/50">
+            <h3 className="text-[13px] font-semibold text-foreground">{group}</h3>
+          </div>
+          <div className="p-4 overflow-x-auto">
+            <table className="w-full border-collapse">
+              <caption className="sr-only">{group} notifications</caption>
+              <thead>
+                <tr>
+                  <th scope="col" className="sr-only">
+                    Notification type
+                  </th>
+                  <th scope="col" className="sr-only">
+                    Email
+                  </th>
+                  <th scope="col" className="sr-only">
+                    Push
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {types.map((type) => {
+                  const value = local.get(type.key) ?? { email: true, push: true };
+                  return (
+                    <tr key={type.key} className="border-b border-border/40 last:border-0">
+                      <th
+                        scope="row"
+                        className="py-3 pr-3 text-left text-[14px] font-medium text-foreground"
+                      >
+                        {type.label}
+                      </th>
+                      <td className="py-3 pr-3 text-center align-middle">
+                        {type.channels.includes('email') ? (
+                          <Switch
+                            checked={value.email}
+                            onCheckedChange={(checked) => updateChannel(type.key, 'email', checked)}
+                            aria-label={`${type.label} — Email`}
+                            className="data-[state=checked]:bg-foreground"
+                          />
+                        ) : (
+                          <>
+                            <span aria-hidden="true" className="text-muted-foreground">
+                              —
+                            </span>
+                            <span className="sr-only">Email not available for {type.label}</span>
+                          </>
+                        )}
+                      </td>
+                      <td className="py-3 text-center align-middle">
+                        {type.channels.includes('push') ? (
+                          <Switch
+                            checked={value.push}
+                            onCheckedChange={(checked) => updateChannel(type.key, 'push', checked)}
+                            aria-label={`${type.label} — Push`}
+                            className="data-[state=checked]:bg-foreground"
+                          />
+                        ) : (
+                          <>
+                            <span aria-hidden="true" className="text-muted-foreground">
+                              —
+                            </span>
+                            <span className="sr-only">Push not available for {type.label}</span>
+                          </>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      ))}
+
+      {hasChanges && (
+        <div className="sticky bottom-0 left-0 right-0 z-10 flex items-center justify-end gap-2 px-4 py-3 border-t border-border/40 bg-background/95 backdrop-blur">
+          <Button
+            variant="outline"
+            className="h-9 px-4 rounded-lg text-[13px] font-medium"
+            onClick={handleReset}
+            disabled={isSaving}
+          >
+            Reset
+          </Button>
+          <Button
+            className="h-9 px-4 rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium"
+            onClick={handleSave}
+            disabled={isSaving}
+          >
+            {isSaving ? 'Saving…' : 'Save'}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/NotificationChannelMatrix.tsx
+++ b/src/components/NotificationChannelMatrix.tsx
@@ -1,19 +1,24 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { Switch } from '@/components/ui/switch';
 import { Skeleton } from '@/components/ui/skeleton';
-import { AlertCircle, Bell } from 'lucide-react';
-
 import {
-  useNotificationChannelSettings,
-  type ChannelSettingsMap,
-} from '@/hooks/useNotificationChannelSettings';
+  AlertCircle,
+  ArrowLeftRight,
+  CalendarClock,
+  CalendarDays,
+  KeyRound,
+  Mail,
+  Smartphone,
+  type LucideIcon,
+} from 'lucide-react';
+
+import { useNotificationChannelSettings } from '@/hooks/useNotificationChannelSettings';
 import {
   NOTIFICATION_TYPES,
   type NotificationChannel,
   type NotificationGroup,
-  type NotificationType,
   type NotificationTypeDef,
 } from '@/lib/notificationTypes';
 
@@ -22,39 +27,38 @@ interface NotificationChannelMatrixProps {
 }
 
 const GROUP_ORDER: NotificationGroup[] = ['Scheduling', 'Trades', 'Time off', 'Access'];
+const GROUP_ICON: Record<NotificationGroup, LucideIcon> = {
+  Scheduling: CalendarDays,
+  Trades: ArrowLeftRight,
+  'Time off': CalendarClock,
+  Access: KeyRound,
+};
 const CHANNEL_LABEL: Record<NotificationChannel, string> = { email: 'Email', push: 'Push' };
-
-function mapsEqual(a: ChannelSettingsMap, b: ChannelSettingsMap): boolean {
-  for (const type of NOTIFICATION_TYPES) {
-    const av = a.get(type.key);
-    const bv = b.get(type.key);
-    if (av?.email !== bv?.email || av?.push !== bv?.push) return false;
-  }
-  return true;
-}
+const CHANNEL_ICON: Record<NotificationChannel, LucideIcon> = { email: Mail, push: Smartphone };
 
 /** One matrix cell: a live `Switch` if `type` supports `channel`, otherwise a
- *  disabled "—" with screen-reader-only context. Shared by the email and push
- *  columns so the toggle-or-dash logic isn't duplicated per channel. */
+ *  muted "—" with screen-reader context. */
 function ChannelCell({
   type,
   channel,
   checked,
-  onCheckedChange,
+  disabled,
+  onChange,
 }: {
   type: NotificationTypeDef;
   channel: NotificationChannel;
   checked: boolean;
-  onCheckedChange: (checked: boolean) => void;
+  disabled: boolean;
+  onChange: (checked: boolean) => void;
 }) {
   if (!type.channels.includes(channel)) {
     return (
       <>
-        <span aria-hidden="true" className="text-muted-foreground">
+        <span aria-hidden="true" className="text-muted-foreground/50">
           —
         </span>
         <span className="sr-only">
-          {CHANNEL_LABEL[channel]} not available for {type.label}
+          {CHANNEL_LABEL[channel]} is not available for {type.label}
         </span>
       </>
     );
@@ -63,7 +67,8 @@ function ChannelCell({
   return (
     <Switch
       checked={checked}
-      onCheckedChange={onCheckedChange}
+      disabled={disabled}
+      onCheckedChange={onChange}
       aria-label={`${type.label} — ${CHANNEL_LABEL[channel]}`}
       className="data-[state=checked]:bg-foreground"
     />
@@ -72,30 +77,14 @@ function ChannelCell({
 
 /**
  * Admin per-type × per-channel notification matrix (Settings → Notifications).
- * Grouped `<table>` per domain, mirroring `AvailabilityGrid.tsx`'s a11y
- * pattern. Local-state-then-Save with a sync-guard so a background refetch
- * never clobbers in-progress edits. See docs/superpowers/specs/2026-07-13-
- * notification-channel-matrix-design.md.
+ * A single `table-fixed` grid so the Email/Push columns line up across every
+ * group, with visible column headers and per-group section headers. Each toggle
+ * saves immediately (optimistic) — no Save button. See docs/superpowers/specs/
+ * 2026-07-13-notification-channel-matrix-design.md.
  */
 export function NotificationChannelMatrix({ restaurantId }: NotificationChannelMatrixProps) {
-  const { settings, isLoading, isError, refetch, saveChanges, isSaving } =
+  const { settings, isLoading, isError, refetch, setChannel, isSaving } =
     useNotificationChannelSettings(restaurantId);
-
-  const [local, setLocal] = useState<ChannelSettingsMap>(() => new Map(settings));
-
-  // hasChanges is derived by value-comparison (not a dirty flag) so it can
-  // never drift from what's actually on screen.
-  const hasChanges = useMemo(() => !mapsEqual(local, settings), [local, settings]);
-
-  // Sync-guard: only pull the server snapshot into local state while the form
-  // is clean. A background refetch (staleTime elapsing, window refocus, or a
-  // post-save invalidation) must never clobber edits the user hasn't saved.
-  useEffect(() => {
-    if (!hasChanges) {
-      setLocal(new Map(settings));
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally omits hasChanges: it must not retrigger this sync
-  }, [settings]);
 
   const groups = useMemo(
     () =>
@@ -106,38 +95,15 @@ export function NotificationChannelMatrix({ restaurantId }: NotificationChannelM
     [],
   );
 
-  function updateChannel(type: NotificationType, channel: 'email' | 'push', value: boolean) {
-    setLocal((prev) => {
-      const next = new Map(prev);
-      const current = next.get(type) ?? { email: true, push: true };
-      next.set(type, { ...current, [channel]: value });
-      return next;
-    });
-  }
-
-  async function handleSave() {
-    try {
-      await saveChanges(local);
-    } catch {
-      // Failure is already surfaced via toast inside the hook; keep the
-      // user's local edits in place (footer stays visible) so they can retry.
-    }
-  }
-
-  function handleReset() {
-    setLocal(new Map(settings));
-  }
-
   if (isLoading) {
     return (
-      <div className="space-y-3">
+      <div className="rounded-xl border border-border/40 bg-background p-4 space-y-3">
         <Skeleton
-          className="h-6 w-56"
+          className="h-5 w-48"
           role="status"
           aria-label="Loading notification channel settings"
         />
-        <Skeleton className="h-40 w-full rounded-xl" />
-        <Skeleton className="h-40 w-full rounded-xl" />
+        <Skeleton className="h-64 w-full rounded-lg" />
       </div>
     );
   }
@@ -165,93 +131,101 @@ export function NotificationChannelMatrix({ restaurantId }: NotificationChannelM
   }
 
   return (
-    <div className="space-y-6 pb-4">
-      <div className="flex items-center gap-2">
-        <Bell className="h-5 w-5 text-primary" aria-hidden="true" />
-        <div>
-          <h2 className="text-[17px] font-semibold text-foreground">Notification channels</h2>
-          <p className="text-[13px] text-muted-foreground">
-            Choose which channels each notification type sends over.
-          </p>
-        </div>
+    <div className="rounded-xl border border-border/40 bg-background overflow-hidden">
+      <div className="px-5 pt-5 pb-4">
+        <h3 className="text-[15px] font-semibold text-foreground">Notification channels</h3>
+        <p className="text-[13px] text-muted-foreground mt-0.5">
+          Turn a channel on to send that notification. Changes save automatically.
+        </p>
       </div>
 
-      {groups.map(({ group, types }) => (
-        <div key={group} className="rounded-xl border border-border/40 bg-muted/30 overflow-hidden">
-          <div className="px-4 py-3 border-b border-border/40 bg-muted/50">
-            <h3 className="text-[13px] font-semibold text-foreground">{group}</h3>
-          </div>
-          <div className="p-4 overflow-x-auto">
-            <table className="w-full border-collapse">
-              <caption className="sr-only">{group} notifications</caption>
-              <thead>
-                <tr>
-                  <th scope="col" className="sr-only">
-                    Notification type
+      <div className="overflow-x-auto">
+        <table className="w-full table-fixed border-collapse">
+          <caption className="sr-only">
+            Notification channel settings. For each notification type, toggle whether it sends over
+            email and push.
+          </caption>
+          <colgroup>
+            <col />
+            <col className="w-[104px]" />
+            <col className="w-[104px]" />
+          </colgroup>
+          <thead>
+            <tr className="border-y border-border/40 bg-muted/40">
+              <th
+                scope="col"
+                className="py-2.5 pl-5 pr-3 text-left text-[11px] font-semibold uppercase tracking-wider text-muted-foreground"
+              >
+                Notification
+              </th>
+              {(['email', 'push'] as const).map((channel) => {
+                const Icon = CHANNEL_ICON[channel];
+                return (
+                  <th key={channel} scope="col" className="py-2.5 px-3">
+                    <span className="flex flex-col items-center gap-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                      <Icon className="h-4 w-4" aria-hidden="true" />
+                      {CHANNEL_LABEL[channel]}
+                    </span>
                   </th>
-                  <th scope="col" className="sr-only">
-                    Email
-                  </th>
-                  <th scope="col" className="sr-only">
-                    Push
+                );
+              })}
+            </tr>
+          </thead>
+          {groups.map(({ group, types }) => {
+            const GroupIcon = GROUP_ICON[group];
+            return (
+              <tbody key={group}>
+                <tr className="bg-muted/20">
+                  <th
+                    scope="colgroup"
+                    colSpan={3}
+                    className="py-2 pl-5 pr-3 text-left text-[12px] font-semibold text-foreground/80 border-b border-border/40"
+                  >
+                    <span className="flex items-center gap-2">
+                      <GroupIcon className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
+                      {group}
+                    </span>
                   </th>
                 </tr>
-              </thead>
-              <tbody>
                 {types.map((type) => {
-                  const value = local.get(type.key) ?? { email: true, push: true };
+                  const value = settings.get(type.key) ?? { email: true, push: true };
                   return (
-                    <tr key={type.key} className="border-b border-border/40 last:border-0">
+                    <tr
+                      key={type.key}
+                      className="border-b border-border/30 last:border-0 hover:bg-muted/20 transition-colors"
+                    >
                       <th
                         scope="row"
-                        className="py-3 pr-3 text-left text-[14px] font-medium text-foreground"
+                        className="py-3 pl-5 pr-3 text-left text-[14px] font-normal text-foreground"
                       >
                         {type.label}
                       </th>
-                      <td className="py-3 pr-3 text-center align-middle">
+                      <td className="py-3 px-3 text-center align-middle">
                         <ChannelCell
                           type={type}
                           channel="email"
                           checked={value.email}
-                          onCheckedChange={(checked) => updateChannel(type.key, 'email', checked)}
+                          disabled={isSaving}
+                          onChange={(checked) => setChannel(type.key, 'email', checked)}
                         />
                       </td>
-                      <td className="py-3 text-center align-middle">
+                      <td className="py-3 px-3 text-center align-middle">
                         <ChannelCell
                           type={type}
                           channel="push"
                           checked={value.push}
-                          onCheckedChange={(checked) => updateChannel(type.key, 'push', checked)}
+                          disabled={isSaving}
+                          onChange={(checked) => setChannel(type.key, 'push', checked)}
                         />
                       </td>
                     </tr>
                   );
                 })}
               </tbody>
-            </table>
-          </div>
-        </div>
-      ))}
-
-      {hasChanges && (
-        <div className="sticky bottom-0 left-0 right-0 z-10 flex items-center justify-end gap-2 px-4 py-3 border-t border-border/40 bg-background/95 backdrop-blur">
-          <Button
-            variant="outline"
-            className="h-9 px-4 rounded-lg text-[13px] font-medium"
-            onClick={handleReset}
-            disabled={isSaving}
-          >
-            Reset
-          </Button>
-          <Button
-            className="h-9 px-4 rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium"
-            onClick={handleSave}
-            disabled={isSaving}
-          >
-            {isSaving ? 'Saving…' : 'Save'}
-          </Button>
-        </div>
-      )}
+            );
+          })}
+        </table>
+      </div>
     </div>
   );
 }

--- a/src/components/NotificationChannelMatrix.tsx
+++ b/src/components/NotificationChannelMatrix.tsx
@@ -9,13 +9,20 @@ import {
   useNotificationChannelSettings,
   type ChannelSettingsMap,
 } from '@/hooks/useNotificationChannelSettings';
-import { NOTIFICATION_TYPES, type NotificationGroup, type NotificationType } from '@/lib/notificationTypes';
+import {
+  NOTIFICATION_TYPES,
+  type NotificationChannel,
+  type NotificationGroup,
+  type NotificationType,
+  type NotificationTypeDef,
+} from '@/lib/notificationTypes';
 
 interface NotificationChannelMatrixProps {
   restaurantId: string;
 }
 
 const GROUP_ORDER: NotificationGroup[] = ['Scheduling', 'Trades', 'Time off', 'Access'];
+const CHANNEL_LABEL: Record<NotificationChannel, string> = { email: 'Email', push: 'Push' };
 
 function mapsEqual(a: ChannelSettingsMap, b: ChannelSettingsMap): boolean {
   for (const type of NOTIFICATION_TYPES) {
@@ -24,6 +31,43 @@ function mapsEqual(a: ChannelSettingsMap, b: ChannelSettingsMap): boolean {
     if (av?.email !== bv?.email || av?.push !== bv?.push) return false;
   }
   return true;
+}
+
+/** One matrix cell: a live `Switch` if `type` supports `channel`, otherwise a
+ *  disabled "—" with screen-reader-only context. Shared by the email and push
+ *  columns so the toggle-or-dash logic isn't duplicated per channel. */
+function ChannelCell({
+  type,
+  channel,
+  checked,
+  onCheckedChange,
+}: {
+  type: NotificationTypeDef;
+  channel: NotificationChannel;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}) {
+  if (!type.channels.includes(channel)) {
+    return (
+      <>
+        <span aria-hidden="true" className="text-muted-foreground">
+          —
+        </span>
+        <span className="sr-only">
+          {CHANNEL_LABEL[channel]} not available for {type.label}
+        </span>
+      </>
+    );
+  }
+
+  return (
+    <Switch
+      checked={checked}
+      onCheckedChange={onCheckedChange}
+      aria-label={`${type.label} — ${CHANNEL_LABEL[channel]}`}
+      className="data-[state=checked]:bg-foreground"
+    />
+  );
 }
 
 /**
@@ -165,38 +209,20 @@ export function NotificationChannelMatrix({ restaurantId }: NotificationChannelM
                         {type.label}
                       </th>
                       <td className="py-3 pr-3 text-center align-middle">
-                        {type.channels.includes('email') ? (
-                          <Switch
-                            checked={value.email}
-                            onCheckedChange={(checked) => updateChannel(type.key, 'email', checked)}
-                            aria-label={`${type.label} — Email`}
-                            className="data-[state=checked]:bg-foreground"
-                          />
-                        ) : (
-                          <>
-                            <span aria-hidden="true" className="text-muted-foreground">
-                              —
-                            </span>
-                            <span className="sr-only">Email not available for {type.label}</span>
-                          </>
-                        )}
+                        <ChannelCell
+                          type={type}
+                          channel="email"
+                          checked={value.email}
+                          onCheckedChange={(checked) => updateChannel(type.key, 'email', checked)}
+                        />
                       </td>
                       <td className="py-3 text-center align-middle">
-                        {type.channels.includes('push') ? (
-                          <Switch
-                            checked={value.push}
-                            onCheckedChange={(checked) => updateChannel(type.key, 'push', checked)}
-                            aria-label={`${type.label} — Push`}
-                            className="data-[state=checked]:bg-foreground"
-                          />
-                        ) : (
-                          <>
-                            <span aria-hidden="true" className="text-muted-foreground">
-                              —
-                            </span>
-                            <span className="sr-only">Push not available for {type.label}</span>
-                          </>
-                        )}
+                        <ChannelCell
+                          type={type}
+                          channel="push"
+                          checked={value.push}
+                          onCheckedChange={(checked) => updateChannel(type.key, 'push', checked)}
+                        />
                       </td>
                     </tr>
                   );

--- a/src/components/NotificationSettings.tsx
+++ b/src/components/NotificationSettings.tsx
@@ -1,10 +1,8 @@
-import { useState, useEffect } from 'react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Separator } from '@/components/ui/separator';
-import { Bell, Users, CheckCircle, Newspaper, AlertTriangle } from 'lucide-react';
+import { Bell, Users, Newspaper, AlertTriangle } from 'lucide-react';
 import { useNotificationSettings, useUpdateNotificationSettings } from '@/hooks/useNotificationSettings';
 import { useNotificationPreferences } from '@/hooks/useNotificationPreferences';
 import { useApproverCount } from '@/hooks/useApproverCount';
@@ -17,7 +15,8 @@ interface NotificationSettingsProps {
 export function NotificationSettings({ restaurantId }: NotificationSettingsProps) {
   const { settings, loading } = useNotificationSettings(restaurantId);
   const updateSettings = useUpdateNotificationSettings();
-  const { preferences: briefPrefs, updatePreferences: updateBriefPrefs, isUpdating: briefUpdating } = useNotificationPreferences(restaurantId);
+  const { preferences: briefPrefs, updatePreferences: updateBriefPrefs, isUpdating: briefUpdating } =
+    useNotificationPreferences(restaurantId);
   const {
     data: approverCount,
     isLoading: approverCountLoading,
@@ -28,39 +27,17 @@ export function NotificationSettings({ restaurantId }: NotificationSettingsProps
   // toggles are now governed by the NotificationChannelMatrix (per-type ×
   // per-channel). time_off_notify_managers/employee remain: they're recipient
   // routing (WHO gets notified), orthogonal to the channel matrix (WHETHER a
-  // channel fires) — see docs/superpowers/specs/2026-07-13-notification-
-  // channel-matrix-design.md.
-  const [localSettings, setLocalSettings] = useState({
-    time_off_notify_managers: true,
-    time_off_notify_employee: true,
-  });
-
-  useEffect(() => {
-    if (settings) {
-      setLocalSettings({
-        time_off_notify_managers: settings.time_off_notify_managers ?? true,
-        time_off_notify_employee: settings.time_off_notify_employee ?? true,
-      });
-    }
-  }, [settings]);
-
-  const handleSave = () => {
-    updateSettings.mutate({
-      restaurantId,
-      settings: localSettings,
-    });
-  };
-
-  const hasChanges = settings && (
-    localSettings.time_off_notify_managers !== settings.time_off_notify_managers ||
-    localSettings.time_off_notify_employee !== settings.time_off_notify_employee
-  );
+  // channel fires). Like every other control on this page, they save on toggle
+  // (no Save button) — see the design doc.
+  const notifyManagers = settings?.time_off_notify_managers ?? true;
+  const notifyEmployee = settings?.time_off_notify_employee ?? true;
+  const savingRecipients = updateSettings.isPending;
 
   const showNoApproversWarning =
     !approverCountLoading &&
     !approverCountError &&
     approverCount !== undefined &&
-    localSettings.time_off_notify_managers &&
+    notifyManagers &&
     approverCount === 0;
 
   if (loading) {
@@ -84,18 +61,12 @@ export function NotificationSettings({ restaurantId }: NotificationSettingsProps
           </div>
           <CardDescription>
             Choose which channels each notification type sends over, who receives time-off
-            emails, and your weekly performance digest
+            emails, and your weekly performance digest. Every toggle saves automatically.
           </CardDescription>
         </CardHeader>
       </Card>
 
-      {/* key=restaurantId forces a full remount (fresh local state) when the
-          active restaurant changes, since the sync-guard effect inside only
-          re-syncs `local` from `settings` while hasChanges is false — without
-          this key, switching restaurants while mid-edit (or right after) can
-          leave stale channel values on screen and, on Save, upsert the
-          previous restaurant's settings onto the new one's restaurant_id. */}
-      <NotificationChannelMatrix key={restaurantId} restaurantId={restaurantId} />
+      <NotificationChannelMatrix restaurantId={restaurantId} />
 
       <Card>
         <CardHeader>
@@ -119,10 +90,12 @@ export function NotificationSettings({ restaurantId }: NotificationSettingsProps
             </div>
             <Switch
               id="notify-managers"
-              checked={localSettings.time_off_notify_managers}
+              checked={notifyManagers}
+              disabled={savingRecipients}
               onCheckedChange={(checked) =>
-                setLocalSettings({ ...localSettings, time_off_notify_managers: checked })
+                updateSettings.mutate({ restaurantId, settings: { time_off_notify_managers: checked } })
               }
+              className="data-[state=checked]:bg-foreground"
             />
           </div>
 
@@ -158,10 +131,12 @@ export function NotificationSettings({ restaurantId }: NotificationSettingsProps
             </div>
             <Switch
               id="notify-employee"
-              checked={localSettings.time_off_notify_employee}
+              checked={notifyEmployee}
+              disabled={savingRecipients}
               onCheckedChange={(checked) =>
-                setLocalSettings({ ...localSettings, time_off_notify_employee: checked })
+                updateSettings.mutate({ restaurantId, settings: { time_off_notify_employee: checked } })
               }
+              className="data-[state=checked]:bg-foreground"
             />
           </div>
         </CardContent>
@@ -199,37 +174,6 @@ export function NotificationSettings({ restaurantId }: NotificationSettingsProps
           </div>
         </CardContent>
       </Card>
-
-      <div className="flex justify-end gap-2">
-        {hasChanges && (
-          <Button
-            variant="outline"
-            onClick={() => {
-              if (settings) {
-                setLocalSettings({
-                  time_off_notify_managers: settings.time_off_notify_managers,
-                  time_off_notify_employee: settings.time_off_notify_employee,
-                });
-              }
-            }}
-          >
-            Reset Changes
-          </Button>
-        )}
-        <Button
-          onClick={handleSave}
-          disabled={!hasChanges || updateSettings.isPending}
-        >
-          {updateSettings.isPending ? (
-            'Saving...'
-          ) : (
-            <>
-              <CheckCircle className="h-4 w-4 mr-2" />
-              Save Settings
-            </>
-          )}
-        </Button>
-      </div>
 
       <Card className="bg-muted/50">
         <CardContent className="py-4">

--- a/src/components/NotificationSettings.tsx
+++ b/src/components/NotificationSettings.tsx
@@ -89,7 +89,13 @@ export function NotificationSettings({ restaurantId }: NotificationSettingsProps
         </CardHeader>
       </Card>
 
-      <NotificationChannelMatrix restaurantId={restaurantId} />
+      {/* key=restaurantId forces a full remount (fresh local state) when the
+          active restaurant changes, since the sync-guard effect inside only
+          re-syncs `local` from `settings` while hasChanges is false — without
+          this key, switching restaurants while mid-edit (or right after) can
+          leave stale channel values on screen and, on Save, upsert the
+          previous restaurant's settings onto the new one's restaurant_id. */}
+      <NotificationChannelMatrix key={restaurantId} restaurantId={restaurantId} />
 
       <Card>
         <CardHeader>

--- a/src/components/NotificationSettings.tsx
+++ b/src/components/NotificationSettings.tsx
@@ -4,10 +4,11 @@ import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Separator } from '@/components/ui/separator';
-import { Bell, Mail, Users, CheckCircle, Newspaper, AlertTriangle } from 'lucide-react';
+import { Bell, Users, CheckCircle, Newspaper, AlertTriangle } from 'lucide-react';
 import { useNotificationSettings, useUpdateNotificationSettings } from '@/hooks/useNotificationSettings';
 import { useNotificationPreferences } from '@/hooks/useNotificationPreferences';
 import { useApproverCount } from '@/hooks/useApproverCount';
+import { NotificationChannelMatrix } from '@/components/NotificationChannelMatrix';
 
 interface NotificationSettingsProps {
   restaurantId: string;
@@ -23,10 +24,13 @@ export function NotificationSettings({ restaurantId }: NotificationSettingsProps
     isError: approverCountError,
   } = useApproverCount(restaurantId);
 
+  // notify_time_off_request/approved/rejected are retired here — those event
+  // toggles are now governed by the NotificationChannelMatrix (per-type ×
+  // per-channel). time_off_notify_managers/employee remain: they're recipient
+  // routing (WHO gets notified), orthogonal to the channel matrix (WHETHER a
+  // channel fires) — see docs/superpowers/specs/2026-07-13-notification-
+  // channel-matrix-design.md.
   const [localSettings, setLocalSettings] = useState({
-    notify_time_off_request: true,
-    notify_time_off_approved: true,
-    notify_time_off_rejected: true,
     time_off_notify_managers: true,
     time_off_notify_employee: true,
   });
@@ -34,9 +38,6 @@ export function NotificationSettings({ restaurantId }: NotificationSettingsProps
   useEffect(() => {
     if (settings) {
       setLocalSettings({
-        notify_time_off_request: settings.notify_time_off_request ?? true,
-        notify_time_off_approved: settings.notify_time_off_approved ?? true,
-        notify_time_off_rejected: settings.notify_time_off_rejected ?? true,
         time_off_notify_managers: settings.time_off_notify_managers ?? true,
         time_off_notify_employee: settings.time_off_notify_employee ?? true,
       });
@@ -51,9 +52,6 @@ export function NotificationSettings({ restaurantId }: NotificationSettingsProps
   };
 
   const hasChanges = settings && (
-    localSettings.notify_time_off_request !== settings.notify_time_off_request ||
-    localSettings.notify_time_off_approved !== settings.notify_time_off_approved ||
-    localSettings.notify_time_off_rejected !== settings.notify_time_off_rejected ||
     localSettings.time_off_notify_managers !== settings.time_off_notify_managers ||
     localSettings.time_off_notify_employee !== settings.time_off_notify_employee
   );
@@ -85,81 +83,13 @@ export function NotificationSettings({ restaurantId }: NotificationSettingsProps
             <CardTitle>Notification Settings</CardTitle>
           </div>
           <CardDescription>
-            Configure email notifications for time-off requests and other events
+            Choose which channels each notification type sends over, who receives time-off
+            emails, and your weekly performance digest
           </CardDescription>
         </CardHeader>
       </Card>
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Mail className="h-5 w-5" />
-            Time-Off Request Notifications
-          </CardTitle>
-          <CardDescription>
-            Choose which time-off events trigger email notifications
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-6">
-          <div className="flex items-center justify-between">
-            <div>
-              <Label htmlFor="notify-request" className="text-base">
-                New Request Submitted
-              </Label>
-              <p className="text-sm text-muted-foreground">
-                Send notification when a time-off request is created
-              </p>
-            </div>
-            <Switch
-              id="notify-request"
-              checked={localSettings.notify_time_off_request}
-              onCheckedChange={(checked) =>
-                setLocalSettings({ ...localSettings, notify_time_off_request: checked })
-              }
-            />
-          </div>
-
-          <Separator />
-
-          <div className="flex items-center justify-between">
-            <div>
-              <Label htmlFor="notify-approved" className="text-base">
-                Request Approved
-              </Label>
-              <p className="text-sm text-muted-foreground">
-                Send notification when a time-off request is approved
-              </p>
-            </div>
-            <Switch
-              id="notify-approved"
-              checked={localSettings.notify_time_off_approved}
-              onCheckedChange={(checked) =>
-                setLocalSettings({ ...localSettings, notify_time_off_approved: checked })
-              }
-            />
-          </div>
-
-          <Separator />
-
-          <div className="flex items-center justify-between">
-            <div>
-              <Label htmlFor="notify-rejected" className="text-base">
-                Request Rejected
-              </Label>
-              <p className="text-sm text-muted-foreground">
-                Send notification when a time-off request is rejected
-              </p>
-            </div>
-            <Switch
-              id="notify-rejected"
-              checked={localSettings.notify_time_off_rejected}
-              onCheckedChange={(checked) =>
-                setLocalSettings({ ...localSettings, notify_time_off_rejected: checked })
-              }
-            />
-          </div>
-        </CardContent>
-      </Card>
+      <NotificationChannelMatrix restaurantId={restaurantId} />
 
       <Card>
         <CardHeader>
@@ -271,9 +201,6 @@ export function NotificationSettings({ restaurantId }: NotificationSettingsProps
             onClick={() => {
               if (settings) {
                 setLocalSettings({
-                  notify_time_off_request: settings.notify_time_off_request,
-                  notify_time_off_approved: settings.notify_time_off_approved,
-                  notify_time_off_rejected: settings.notify_time_off_rejected,
                   time_off_notify_managers: settings.time_off_notify_managers,
                   time_off_notify_employee: settings.time_off_notify_employee,
                 });

--- a/src/hooks/useNotificationChannelSettings.tsx
+++ b/src/hooks/useNotificationChannelSettings.tsx
@@ -2,7 +2,11 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
-import { NOTIFICATION_TYPES, type NotificationType } from '@/lib/notificationTypes';
+import {
+  NOTIFICATION_TYPES,
+  type NotificationChannel,
+  type NotificationType,
+} from '@/lib/notificationTypes';
 
 // Per-restaurant admin control for the notification channel matrix (Settings →
 // Notifications). See docs/superpowers/specs/2026-07-13-notification-channel-
@@ -17,9 +21,9 @@ export interface ChannelDecision {
 }
 
 /** Map of every catalog notification type to its current channel decision.
- *  Always fully populated (all 16 catalog keys) — absent server rows resolve
- *  to the default-ON baseline, mirroring `resolveChannels()`'s fail-open
- *  semantics on the read side. */
+ *  Always fully populated (every key in NOTIFICATION_TYPES) — absent server
+ *  rows resolve to the default-ON baseline, mirroring `resolveChannels()`'s
+ *  fail-open semantics on the read side. */
 export type ChannelSettingsMap = Map<NotificationType, ChannelDecision>;
 
 interface ChannelSettingsRow {
@@ -42,12 +46,10 @@ function createDefaultChannelSettingsMap(): ChannelSettingsMap {
 
 /** Referentially-stable default-ON map, computed once at module load. This is
  *  what the hook returns as `settings` whenever `query.data` is undefined
- *  (disabled query, or still loading). It must stay the SAME object across
- *  renders — if it were reallocated every render (as `createDefaultChannel
- *  SettingsMap()` does), `NotificationChannelMatrix`'s sync-guard effect
- *  (`useEffect(..., [settings])`) would see a new reference on every render
- *  and re-fire forever, spinning in an unbounded render loop. Callers must
- *  treat this as read-only (clone before mutating). */
+ *  (disabled query, or still loading). Kept as a single shared instance so
+ *  `settings` has a stable identity across renders while loading — cheap
+ *  insurance against reference-identity churn in any consumer that memoizes on
+ *  it. Callers must treat this as read-only (clone before mutating). */
 const STABLE_DEFAULT_CHANNEL_SETTINGS: ChannelSettingsMap = createDefaultChannelSettingsMap();
 
 export function useNotificationChannelSettings(restaurantId: string | null) {
@@ -80,46 +82,64 @@ export function useNotificationChannelSettings(restaurantId: string | null) {
     staleTime: 60000,
   });
 
-  const mutation = useMutation({
-    mutationFn: async (next: ChannelSettingsMap) => {
+  // Immediate, optimistic per-toggle save. Each flip of an Email/Push switch
+  // persists on its own — no Save button, no local form state to drift or
+  // clobber. The cache is updated optimistically so the switch reflects the new
+  // value instantly, and rolled back with a toast if the write fails. This also
+  // makes concurrent admins safe: each toggle is an independent upsert of one
+  // (restaurant, type) row, so there is no full-grid batch to overwrite.
+  const setChannelMutation = useMutation({
+    mutationFn: async ({
+      type,
+      channel,
+      value,
+    }: {
+      type: NotificationType;
+      channel: NotificationChannel;
+      value: boolean;
+    }) => {
       if (!restaurantId) throw new Error('No restaurant selected');
 
-      // Diff against the last fetched snapshot — upsert only the rows that
-      // actually changed, never the full 16-row grid (design: "Diff-based Save").
-      const snapshot = query.data ?? STABLE_DEFAULT_CHANNEL_SETTINGS;
-      const changedRows = NOTIFICATION_TYPES.filter((type) => {
-        const before = snapshot.get(type.key);
-        const after = next.get(type.key);
-        return before?.email !== after?.email || before?.push !== after?.push;
-      }).map((type) => {
-        const value = next.get(type.key) ?? { email: true, push: true };
-        return {
-          restaurant_id: restaurantId,
-          notification_type: type.key,
-          email_enabled: value.email,
-          push_enabled: value.push,
-        };
-      });
-
-      if (changedRows.length === 0) return;
+      // Build the full row from the (optimistically-updated) cache so the
+      // untouched channel keeps its current value in the upsert.
+      const current =
+        (queryClient.getQueryData<ChannelSettingsMap>(queryKey) ??
+          STABLE_DEFAULT_CHANNEL_SETTINGS).get(type) ?? { email: true, push: true };
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- table not in generated types yet
       const { error } = await (supabase.from as any)('notification_channel_settings').upsert(
-        changedRows,
+        {
+          restaurant_id: restaurantId,
+          notification_type: type,
+          email_enabled: channel === 'email' ? value : current.email,
+          push_enabled: channel === 'push' ? value : current.push,
+        },
         { onConflict: 'restaurant_id,notification_type' },
       );
 
       if (error) throw error;
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey });
+    onMutate: async ({ type, channel, value }) => {
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData<ChannelSettingsMap>(queryKey);
+      queryClient.setQueryData<ChannelSettingsMap>(queryKey, (old) => {
+        const next = new Map(old ?? STABLE_DEFAULT_CHANNEL_SETTINGS);
+        const cur = next.get(type) ?? { email: true, push: true };
+        next.set(type, { ...cur, [channel]: value });
+        return next;
+      });
+      return { previous };
     },
-    onError: (error: Error) => {
+    onError: (error: Error, _vars, context) => {
+      if (context?.previous) queryClient.setQueryData(queryKey, context.previous);
       toast({
-        title: 'Error saving notification settings',
+        title: "Couldn't update notification setting",
         description: error.message,
         variant: 'destructive',
       });
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey });
     },
   });
 
@@ -129,7 +149,9 @@ export function useNotificationChannelSettings(restaurantId: string | null) {
     isError: query.isError,
     error: query.error,
     refetch: query.refetch,
-    saveChanges: mutation.mutateAsync,
-    isSaving: mutation.isPending,
+    /** Persist a single channel toggle immediately (optimistic). */
+    setChannel: (type: NotificationType, channel: NotificationChannel, value: boolean) =>
+      setChannelMutation.mutate({ type, channel, value }),
+    isSaving: setChannelMutation.isPending,
   };
 }

--- a/src/hooks/useNotificationChannelSettings.tsx
+++ b/src/hooks/useNotificationChannelSettings.tsx
@@ -1,0 +1,135 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { supabase } from '@/integrations/supabase/client';
+import { useToast } from '@/hooks/use-toast';
+import { NOTIFICATION_TYPES, type NotificationType } from '@/lib/notificationTypes';
+
+// Per-restaurant admin control for the notification channel matrix (Settings →
+// Notifications). See docs/superpowers/specs/2026-07-13-notification-channel-
+// matrix-design.md. `notification_channel_settings` isn't in the generated
+// Supabase types yet (new table, types not regenerated) — cast through `any`
+// at the call site, matching the existing repo convention (see
+// `useStaffingSettings.ts`).
+
+export interface ChannelDecision {
+  email: boolean;
+  push: boolean;
+}
+
+/** Map of every catalog notification type to its current channel decision.
+ *  Always fully populated (all 16 catalog keys) — absent server rows resolve
+ *  to the default-ON baseline, mirroring `resolveChannels()`'s fail-open
+ *  semantics on the read side. */
+export type ChannelSettingsMap = Map<NotificationType, ChannelDecision>;
+
+interface ChannelSettingsRow {
+  id: string;
+  notification_type: string;
+  email_enabled: boolean;
+  push_enabled: boolean;
+}
+
+/** Fresh, independently-mutable default-ON map. Used as the merge base inside
+ *  `queryFn`/the mutation's snapshot fallback, where the caller mutates the
+ *  result — never share one instance across those call sites. */
+function createDefaultChannelSettingsMap(): ChannelSettingsMap {
+  const map: ChannelSettingsMap = new Map();
+  for (const type of NOTIFICATION_TYPES) {
+    map.set(type.key, { email: true, push: true });
+  }
+  return map;
+}
+
+/** Referentially-stable default-ON map, computed once at module load. This is
+ *  what the hook returns as `settings` whenever `query.data` is undefined
+ *  (disabled query, or still loading). It must stay the SAME object across
+ *  renders — if it were reallocated every render (as `createDefaultChannel
+ *  SettingsMap()` does), `NotificationChannelMatrix`'s sync-guard effect
+ *  (`useEffect(..., [settings])`) would see a new reference on every render
+ *  and re-fire forever, spinning in an unbounded render loop. Callers must
+ *  treat this as read-only (clone before mutating). */
+const STABLE_DEFAULT_CHANNEL_SETTINGS: ChannelSettingsMap = createDefaultChannelSettingsMap();
+
+export function useNotificationChannelSettings(restaurantId: string | null) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const queryKey = ['notification-channel-settings', restaurantId];
+
+  const query = useQuery({
+    queryKey,
+    queryFn: async (): Promise<ChannelSettingsMap> => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- table not in generated types yet
+      const { data, error } = await (supabase.from as any)('notification_channel_settings')
+        .select('id, notification_type, email_enabled, push_enabled')
+        .eq('restaurant_id', restaurantId);
+
+      if (error) throw error;
+
+      const merged = createDefaultChannelSettingsMap();
+      for (const row of (data ?? []) as ChannelSettingsRow[]) {
+        if (merged.has(row.notification_type as NotificationType)) {
+          merged.set(row.notification_type as NotificationType, {
+            email: row.email_enabled,
+            push: row.push_enabled,
+          });
+        }
+      }
+      return merged;
+    },
+    enabled: !!restaurantId,
+    staleTime: 60000,
+  });
+
+  const mutation = useMutation({
+    mutationFn: async (next: ChannelSettingsMap) => {
+      if (!restaurantId) throw new Error('No restaurant selected');
+
+      // Diff against the last fetched snapshot — upsert only the rows that
+      // actually changed, never the full 16-row grid (design: "Diff-based Save").
+      const snapshot = query.data ?? STABLE_DEFAULT_CHANNEL_SETTINGS;
+      const changedRows = NOTIFICATION_TYPES.filter((type) => {
+        const before = snapshot.get(type.key);
+        const after = next.get(type.key);
+        return before?.email !== after?.email || before?.push !== after?.push;
+      }).map((type) => {
+        const value = next.get(type.key) ?? { email: true, push: true };
+        return {
+          restaurant_id: restaurantId,
+          notification_type: type.key,
+          email_enabled: value.email,
+          push_enabled: value.push,
+        };
+      });
+
+      if (changedRows.length === 0) return;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- table not in generated types yet
+      const { error } = await (supabase.from as any)('notification_channel_settings').upsert(
+        changedRows,
+        { onConflict: 'restaurant_id,notification_type' },
+      );
+
+      if (error) throw error;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey });
+    },
+    onError: (error: Error) => {
+      toast({
+        title: 'Error saving notification settings',
+        description: error.message,
+        variant: 'destructive',
+      });
+    },
+  });
+
+  return {
+    settings: query.data ?? STABLE_DEFAULT_CHANNEL_SETTINGS,
+    isLoading: query.isLoading,
+    isError: query.isError,
+    error: query.error,
+    refetch: query.refetch,
+    saveChanges: mutation.mutateAsync,
+    isSaving: mutation.isPending,
+  };
+}

--- a/src/lib/notificationTypes.ts
+++ b/src/lib/notificationTypes.ts
@@ -25,7 +25,6 @@ export type NotificationType =
   | 'time_off_approved'
   | 'time_off_rejected'
   | 'pin_reset'
-  | 'team_invite'
   | 'availability_reminder';
 
 export type NotificationChannel = 'email' | 'push';
@@ -58,5 +57,7 @@ export const NOTIFICATION_TYPES: NotificationTypeDef[] = [
   { key: 'time_off_approved', label: 'Time off approved', group: 'Time off', channels: ['email', 'push'] },
   { key: 'time_off_rejected', label: 'Time off rejected', group: 'Time off', channels: ['email', 'push'] },
   { key: 'pin_reset', label: 'PIN reset', group: 'Access', channels: ['email', 'push'] },
-  { key: 'team_invite', label: 'Team invitation', group: 'Access', channels: ['email'] },
+  // NOTE: `team_invite` is intentionally NOT a matrix row. A team-invitation email is
+  // transactional — it carries the only copy of the accept link (token is hashed and
+  // unrecoverable), so it must always send and is not admin-toggleable.
 ];

--- a/src/lib/notificationTypes.ts
+++ b/src/lib/notificationTypes.ts
@@ -1,0 +1,62 @@
+// Single source of truth for the admin notification channel matrix (Settings →
+// Notifications). Every currently-firing notification type is listed here with
+// its display metadata; `supabase/functions/_shared/resolveChannels.ts` holds an
+// independent `NotificationType` union that MUST list the same keys — a vitest
+// test in tests/unit/notificationTypes.test.ts asserts the two stay in sync, and
+// the `notification_channel_settings` table's CHECK constraint is hand-reviewed
+// against this same list. See docs/superpowers/specs/2026-07-13-notification-
+// channel-matrix-design.md for the full design.
+//
+// `weekly_brief` is intentionally NOT a row here — it stays on the per-user
+// `notification_preferences` table, out of scope for this admin matrix.
+
+export type NotificationType =
+  | 'schedule_published'
+  | 'shift_created'
+  | 'shift_modified'
+  | 'shift_deleted'
+  | 'open_shifts_broadcast'
+  | 'shift_trade_created'
+  | 'shift_trade_accepted'
+  | 'shift_trade_approved'
+  | 'shift_trade_rejected'
+  | 'shift_trade_cancelled'
+  | 'time_off_requested'
+  | 'time_off_approved'
+  | 'time_off_rejected'
+  | 'pin_reset'
+  | 'team_invite'
+  | 'availability_reminder';
+
+export type NotificationChannel = 'email' | 'push';
+
+export type NotificationGroup = 'Scheduling' | 'Trades' | 'Time off' | 'Access';
+
+export interface NotificationTypeDef {
+  key: NotificationType;
+  label: string;
+  group: NotificationGroup;
+  /** Channels this type actually sends on. A channel absent here renders as a
+   *  disabled "—" cell in the matrix UI — never a live toggle for a channel the
+   *  sending function doesn't use. */
+  channels: NotificationChannel[];
+}
+
+export const NOTIFICATION_TYPES: NotificationTypeDef[] = [
+  { key: 'schedule_published', label: 'Schedule published', group: 'Scheduling', channels: ['email', 'push'] },
+  { key: 'shift_created', label: 'Shift created', group: 'Scheduling', channels: ['email', 'push'] },
+  { key: 'shift_modified', label: 'Shift modified', group: 'Scheduling', channels: ['email', 'push'] },
+  { key: 'shift_deleted', label: 'Shift deleted', group: 'Scheduling', channels: ['email', 'push'] },
+  { key: 'open_shifts_broadcast', label: 'Open shift broadcast', group: 'Scheduling', channels: ['email', 'push'] },
+  { key: 'availability_reminder', label: 'Availability reminder', group: 'Scheduling', channels: ['email'] },
+  { key: 'shift_trade_created', label: 'Shift trade requested', group: 'Trades', channels: ['email', 'push'] },
+  { key: 'shift_trade_accepted', label: 'Shift trade accepted', group: 'Trades', channels: ['email', 'push'] },
+  { key: 'shift_trade_approved', label: 'Shift trade approved', group: 'Trades', channels: ['email', 'push'] },
+  { key: 'shift_trade_rejected', label: 'Shift trade rejected', group: 'Trades', channels: ['email', 'push'] },
+  { key: 'shift_trade_cancelled', label: 'Shift trade cancelled', group: 'Trades', channels: ['email', 'push'] },
+  { key: 'time_off_requested', label: 'Time off requested', group: 'Time off', channels: ['email'] },
+  { key: 'time_off_approved', label: 'Time off approved', group: 'Time off', channels: ['email', 'push'] },
+  { key: 'time_off_rejected', label: 'Time off rejected', group: 'Time off', channels: ['email', 'push'] },
+  { key: 'pin_reset', label: 'PIN reset', group: 'Access', channels: ['email', 'push'] },
+  { key: 'team_invite', label: 'Team invitation', group: 'Access', channels: ['email'] },
+];

--- a/supabase/functions/_shared/availabilityReminderHandler.ts
+++ b/supabase/functions/_shared/availabilityReminderHandler.ts
@@ -1,3 +1,5 @@
+import { resolveChannels, type SupabaseLike } from './resolveChannels.ts';
+
 type CreateClientFn = (authHeader: string | null) => {
   auth: { getUser: () => Promise<{ data: { user: { id: string } | null }; error: unknown }> };
   from: (table: string) => {
@@ -6,6 +8,7 @@ type CreateClientFn = (authHeader: string | null) => {
         eq?: (col: string, val: unknown) => unknown;
         in?: (col: string, vals: unknown[]) => Promise<{ data: unknown; error: unknown }>;
         single: () => Promise<{ data: unknown; error: unknown }>;
+        maybeSingle?: () => Promise<{ data: unknown; error: unknown }>;
       };
     };
   };
@@ -107,6 +110,13 @@ export async function processAvailabilityReminder(
       .single();
     if (restRes.error) return json({ error: 'Failed to load restaurant' }, 500);
     const restaurantName = (restRes.data as { name?: string } | null)?.name ?? 'Your restaurant';
+
+    // `availability_reminder` is email-only in the catalog (see
+    // src/lib/notificationTypes.ts) — there is no push variant to gate here.
+    const ch = await resolveChannels(supabase as unknown as SupabaseLike, restaurantId, 'availability_reminder');
+    if (!ch.email) {
+      return json({ sent: 0, skipped_no_email: 0, errors: 0, channel_disabled: true }, 200);
+    }
 
     const empRes = await supabase
       .from('employees')

--- a/supabase/functions/_shared/notificationActionTypes.ts
+++ b/supabase/functions/_shared/notificationActionTypes.ts
@@ -1,0 +1,35 @@
+// Single source of truth mapping each firing function's request-body `action`
+// (or, for send-team-invitation/notify-pin-changed/notify-availability-reminder,
+// their one implicit action) onto the matrix's `NotificationType` catalog key.
+// Consumed by the retrofitted edge functions in Task 3 of the notification-
+// channel-matrix feature; kept here (rather than duplicated per-function) so a
+// single vitest suite (tests/unit/notificationActionTypes.test.ts) can assert
+// every mapped value is a real catalog key with the channels the function
+// actually gates.
+//
+// See docs/superpowers/specs/2026-07-13-notification-channel-matrix-design.md.
+
+import type { NotificationType } from './resolveChannels.ts';
+
+export const SHIFT_ACTION_TYPE: Record<'created' | 'modified' | 'deleted', NotificationType> = {
+  created: 'shift_created',
+  modified: 'shift_modified',
+  deleted: 'shift_deleted',
+};
+
+export const TRADE_ACTION_TYPE: Record<
+  'created' | 'accepted' | 'approved' | 'rejected' | 'cancelled',
+  NotificationType
+> = {
+  created: 'shift_trade_created',
+  accepted: 'shift_trade_accepted',
+  approved: 'shift_trade_approved',
+  rejected: 'shift_trade_rejected',
+  cancelled: 'shift_trade_cancelled',
+};
+
+export const TIME_OFF_ACTION_TYPE: Record<'created' | 'approved' | 'rejected', NotificationType> = {
+  created: 'time_off_requested',
+  approved: 'time_off_approved',
+  rejected: 'time_off_rejected',
+};

--- a/supabase/functions/_shared/resolveChannels.ts
+++ b/supabase/functions/_shared/resolveChannels.ts
@@ -23,7 +23,6 @@ export type NotificationType =
   | 'time_off_approved'
   | 'time_off_rejected'
   | 'pin_reset'
-  | 'team_invite'
   | 'availability_reminder';
 
 export interface ChannelDecision {

--- a/supabase/functions/_shared/resolveChannels.ts
+++ b/supabase/functions/_shared/resolveChannels.ts
@@ -1,0 +1,85 @@
+// Shared per-type × per-channel notification gate. Every notification-sending
+// edge function should call this before sending on each channel, replacing the
+// old combined `shouldSendNotification` boolean.
+//
+// Keep this `NotificationType` union in sync with `src/lib/notificationTypes.ts`
+// (asserted by tests/unit/notificationTypes.test.ts) and with the
+// `notification_channel_settings` CHECK constraint in the migration.
+//
+// See docs/superpowers/specs/2026-07-13-notification-channel-matrix-design.md.
+
+export type NotificationType =
+  | 'schedule_published'
+  | 'shift_created'
+  | 'shift_modified'
+  | 'shift_deleted'
+  | 'open_shifts_broadcast'
+  | 'shift_trade_created'
+  | 'shift_trade_accepted'
+  | 'shift_trade_approved'
+  | 'shift_trade_rejected'
+  | 'shift_trade_cancelled'
+  | 'time_off_requested'
+  | 'time_off_approved'
+  | 'time_off_rejected'
+  | 'pin_reset'
+  | 'team_invite'
+  | 'availability_reminder';
+
+export interface ChannelDecision {
+  email: boolean;
+  push: boolean;
+}
+
+interface ChannelSettingsRow {
+  email_enabled: boolean;
+  push_enabled: boolean;
+}
+
+/**
+ * Minimal structural shape of the Supabase client subset `resolveChannels`
+ * needs. Deliberately NOT the real `SupabaseClient` type from
+ * `https://esm.sh/@supabase/supabase-js@2` — that import specifier can't be
+ * resolved under vitest/Node, and this file needs to be directly unit-testable
+ * (mirrors the pattern already used by `_shared/availabilityReminderHandler.ts`).
+ * Any real `SupabaseClient` (service-role or user-scoped) satisfies this shape.
+ */
+export interface SupabaseLike {
+  from: (table: string) => {
+    select: (columns: string) => {
+      eq: (column: string, value: unknown) => {
+        eq: (column: string, value: unknown) => {
+          maybeSingle: () => Promise<{ data: ChannelSettingsRow | null; error: unknown }>;
+        };
+      };
+    };
+  };
+}
+
+/**
+ * Restaurant-level channel decision for a notification type.
+ *
+ * Fail-OPEN: a missing row or a query error both resolve to `{ email: true,
+ * push: true }` — matching today's `shouldSendNotification` default. This is
+ * intentional (see design doc "Decided trade-offs"): a restaurant that never
+ * configured the matrix, or a transient DB error, must never silently drop a
+ * notification.
+ */
+export async function resolveChannels(
+  supabase: SupabaseLike,
+  restaurantId: string,
+  type: NotificationType,
+): Promise<ChannelDecision> {
+  const { data, error } = await supabase
+    .from('notification_channel_settings')
+    .select('email_enabled, push_enabled')
+    .eq('restaurant_id', restaurantId)
+    .eq('notification_type', type)
+    .maybeSingle();
+
+  if (error || !data) {
+    return { email: true, push: true };
+  }
+
+  return { email: data.email_enabled, push: data.push_enabled };
+}

--- a/supabase/functions/broadcast-open-shifts/index.ts
+++ b/supabase/functions/broadcast-open-shifts/index.ts
@@ -4,6 +4,7 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { corsHeaders } from "../_shared/cors.ts";
 import { sendEmail, NOTIFICATION_FROM, APP_URL } from "../_shared/notificationHelpers.ts";
 import { sendWebPushToUser } from "../_shared/webPushHelper.ts";
+import { resolveChannels, type SupabaseLike } from "../_shared/resolveChannels.ts";
 
 const RESEND_API_KEY = Deno.env.get("RESEND_API_KEY");
 
@@ -157,24 +158,33 @@ serve(async (req) => {
     let emailSentCount = 0;
     let emailFailCount = 0;
 
+    // Independent per-channel gating (email/push may be toggled separately).
+    const ch = await resolveChannels(
+      serviceClient as unknown as SupabaseLike,
+      restaurant_id,
+      "open_shifts_broadcast"
+    );
+
     // Send web push notifications to employees with user_id
-    const pushEmployees = allEmployees.filter((emp) => emp.user_id);
-    for (const employee of pushEmployees) {
-      try {
-        const result = await sendWebPushToUser(serviceClient, employee.user_id!, restaurant_id, {
-          title: "Shifts Available",
-          body: notificationBody,
-          url: "/employee/shifts",
-        });
-        pushSentCount += result.sent;
-      } catch (err) {
-        pushFailCount++;
-        console.error(`Push notification failed for employee ${employee.id}:`, err);
+    if (ch.push) {
+      const pushEmployees = allEmployees.filter((emp) => emp.user_id);
+      for (const employee of pushEmployees) {
+        try {
+          const result = await sendWebPushToUser(serviceClient, employee.user_id!, restaurant_id, {
+            title: "Shifts Available",
+            body: notificationBody,
+            url: "/employee/shifts",
+          });
+          pushSentCount += result.sent;
+        } catch (err) {
+          pushFailCount++;
+          console.error(`Push notification failed for employee ${employee.id}:`, err);
+        }
       }
     }
 
     // Send email notifications to employees with email
-    if (RESEND_API_KEY) {
+    if (ch.email && RESEND_API_KEY) {
       const emailEmployees = allEmployees.filter((emp) => emp.email);
       const appUrl = `${APP_URL}/employee/shifts`;
 

--- a/supabase/functions/notify-pin-changed/index.ts
+++ b/supabase/functions/notify-pin-changed/index.ts
@@ -2,6 +2,7 @@ import { generateHeader, escapeHtml } from '../_shared/emailTemplates.ts';
 import { serve } from 'https://deno.land/std@0.208.0/http/server.ts';
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { Resend } from 'https://esm.sh/resend@4.0.0';
+import { resolveChannels, type SupabaseLike } from '../_shared/resolveChannels.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -110,11 +111,14 @@ const handler = async (req: Request): Promise<Response> => {
       .maybeSingle();
     const restaurantName = restaurant?.name ?? 'your restaurant';
 
+    // Independent per-channel gating (email/push may be toggled separately).
+    const ch = await resolveChannels(supabase as unknown as SupabaseLike, body.restaurantId, 'pin_reset');
+
     // Push notification (no-op if no device tokens; never throw).
     // send-push-notification verifies the Authorization header equals
     // "Bearer ${SUPABASE_SERVICE_ROLE_KEY}" verbatim, so supabase.functions.invoke
     // (which sends the caller's user JWT) would silently 401. Use raw fetch.
-    if (employee.user_id) {
+    if (ch.push && employee.user_id) {
       try {
         await fetch(`${supabaseUrl}/functions/v1/send-push-notification`, {
           method: 'POST',
@@ -135,7 +139,7 @@ const handler = async (req: Request): Promise<Response> => {
     }
 
     // Email — PIN value is NEVER included
-    if (employee.email) {
+    if (ch.email && employee.email) {
       const resendKey = Deno.env.get('RESEND_API_KEY');
       if (resendKey) {
         try {

--- a/supabase/functions/notify-schedule-published/index.ts
+++ b/supabase/functions/notify-schedule-published/index.ts
@@ -4,6 +4,7 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { corsHeaders } from "../_shared/cors.ts";
 import { sendWebPushToUser } from "../_shared/webPushHelper.ts";
 import { notifySchedulePublishedPush } from "../_shared/schedulePublishedPush.ts";
+import { resolveChannels, type SupabaseLike } from "../_shared/resolveChannels.ts";
 
 const RESEND_API_KEY = Deno.env.get("RESEND_API_KEY");
 
@@ -73,6 +74,18 @@ serve(async (req) => {
       throw new Error("Restaurant not found");
     }
 
+    // Service-role client for the resolver read + push sends (created here so
+    // it's available for the independent email/push gating below).
+    const serviceClient = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
+    );
+    const ch = await resolveChannels(
+      serviceClient as unknown as SupabaseLike,
+      restaurantId,
+      "schedule_published"
+    );
+
     // Get all employees for this restaurant
     const { data: employees, error: empError } = await supabase
       .from("employees")
@@ -120,7 +133,7 @@ serve(async (req) => {
     const appUrl = "https://app.easyshifthq.com/employee/schedule";
 
     // Send email notifications using Resend
-    const emailPromises = scheduledEmployees
+    const emailPromises = (ch.email ? scheduledEmployees : [])
       .filter((emp) => emp.email) // Only send to employees with email
       .map(async (employee) => {
         const emailPayload = {
@@ -213,18 +226,16 @@ serve(async (req) => {
     const failureCount = results.length - successCount;
 
     // Send web push notifications to all scheduled employees
-    const serviceClient = createClient(
-      Deno.env.get("SUPABASE_URL") ?? "",
-      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? ""
-    );
-    await notifySchedulePublishedPush(scheduledEmployees, (userId) =>
-      sendWebPushToUser(serviceClient, userId, restaurantId, {
-        title: "Schedule Updated",
-        body: "A new schedule has been published",
-        url: "/employee/schedule",
-        tag: "schedule-published",
-      })
-    );
+    if (ch.push) {
+      await notifySchedulePublishedPush(scheduledEmployees, (userId) =>
+        sendWebPushToUser(serviceClient, userId, restaurantId, {
+          title: "Schedule Updated",
+          body: "A new schedule has been published",
+          url: "/employee/schedule",
+          tag: "schedule-published",
+        })
+      );
+    }
 
     // Update the publication record to mark notifications as sent
     await supabase

--- a/supabase/functions/send-shift-notification/index.ts
+++ b/supabase/functions/send-shift-notification/index.ts
@@ -10,13 +10,14 @@ import {
   handleCorsPreflightRequest,
   errorResponse,
   successResponse,
-  shouldSendNotification,
   NOTIFICATION_FROM,
   APP_URL
 } from "../_shared/notificationHelpers.ts";
 import { getRestaurantInfo } from "../_shared/restaurantInfo.ts";
 import { sendWebPushToUser } from '../_shared/webPushHelper.ts';
 import { buildDeletedShiftNotification } from '../_shared/shiftDeletedNotification.ts';
+import { resolveChannels, type SupabaseLike } from '../_shared/resolveChannels.ts';
+import { SHIFT_ACTION_TYPE } from '../_shared/notificationActionTypes.ts';
 
 interface RequestBody {
   shiftId: string;
@@ -44,7 +45,6 @@ const ACTION_CONFIG: Record<RequestBody['action'], {
   heading: string;
   statusColor: string;
   statusText: string;
-  settingKey: string;
   message: (hasChanges: boolean) => string;
 }> = {
   created: {
@@ -52,7 +52,6 @@ const ACTION_CONFIG: Record<RequestBody['action'], {
     heading: 'You Have a New Shift',
     statusColor: '#3b82f6',
     statusText: 'New',
-    settingKey: 'notify_shift_created',
     message: () => 'A new shift has been added to your schedule.',
   },
   modified: {
@@ -60,8 +59,7 @@ const ACTION_CONFIG: Record<RequestBody['action'], {
     heading: 'Your Shift Has Been Updated',
     statusColor: '#f59e0b',
     statusText: 'Modified',
-    settingKey: 'notify_shift_modified',
-    message: (hasChanges: boolean) => hasChanges 
+    message: (hasChanges: boolean) => hasChanges
       ? 'Your shift details have been changed. Please review the updated information below.'
       : 'Your shift has been updated.',
   },
@@ -70,7 +68,6 @@ const ACTION_CONFIG: Record<RequestBody['action'], {
     heading: 'A Shift Has Been Removed',
     statusColor: '#ef4444',
     statusText: 'Removed',
-    settingKey: 'notify_shift_deleted',
     message: () => 'One of your scheduled shifts has been removed from the schedule.',
   },
 };
@@ -151,13 +148,9 @@ const handler = async (req: Request): Promise<Response> => {
         return errorResponse('Access denied', 403);
       }
 
-      const shouldNotifyDeleted = await shouldSendNotification(
-        supabase,
-        deletedShift.restaurant_id,
-        'notify_shift_deleted'
-      );
-      if (!shouldNotifyDeleted) {
-        console.log('Notification disabled for deleted');
+      const deletedCh = await resolveChannels(supabase as unknown as SupabaseLike, deletedShift.restaurant_id, 'shift_deleted');
+      if (!deletedCh.email && !deletedCh.push) {
+        console.log('Notification disabled for deleted (both channels off)');
         return successResponse({ message: 'Notification disabled by settings' });
       }
 
@@ -202,7 +195,7 @@ const handler = async (req: Request): Promise<Response> => {
       }
 
       let deletedShiftEmailId: string | undefined;
-      if (plan.email) {
+      if (plan.email && deletedCh.email) {
         const { data: emailResult, error: emailError } = await resend.emails.send({
           from: NOTIFICATION_FROM,
           to: [plan.email.to],
@@ -217,7 +210,7 @@ const handler = async (req: Request): Promise<Response> => {
         }
       }
 
-      if (plan.push) {
+      if (plan.push && deletedCh.push) {
         try {
           await sendWebPushToUser(supabase, plan.push.userId, deletedShift.restaurant_id, plan.push.payload);
         } catch (e) {
@@ -256,89 +249,88 @@ const handler = async (req: Request): Promise<Response> => {
       return errorResponse('Shift not found', 404);
     }
 
-    // Check notification settings
+    // Independent per-channel gating (email/push may be toggled separately).
     const config = ACTION_CONFIG[action];
-    const shouldNotify = await shouldSendNotification(
-      supabase, 
-      shift.restaurant_id, 
-      config.settingKey
-    );
+    const ch = await resolveChannels(supabase as unknown as SupabaseLike, shift.restaurant_id, SHIFT_ACTION_TYPE[action]);
 
-    if (!shouldNotify) {
-      console.log(`Notification disabled for ${action}`);
+    if (!ch.email && !ch.push) {
+      console.log(`Notification disabled for ${action} (both channels off)`);
       return successResponse({ message: 'Notification disabled by settings' });
     }
 
-    // Get employee email
-    const employeeEmail = shift.employee?.email;
-    if (!employeeEmail) {
-      console.log('Employee has no email address');
-      return successResponse({ message: 'No employee email found' });
-    }
-
-    // Get restaurant name + timezone so shift times render in the
-    // restaurant's local time, not the edge runtime's UTC.
-    const { name: restaurantName, timezone: restaurantTimezone } =
-      await getRestaurantInfo(supabase, shift.restaurant_id);
-
-    // Build details card
-    const detailsItems = [
-      { label: 'Restaurant', value: restaurantName },
-      { label: 'Position', value: shift.position },
-      { label: 'Start', value: formatDateTime(shift.start_time, restaurantTimezone) },
-      { label: 'End', value: formatDateTime(shift.end_time, restaurantTimezone) },
-    ];
-
-    // Add previous details if modified
     const hasChanges = action === 'modified' && previousShift;
-    if (hasChanges) {
-      detailsItems.push(
-        { label: '', value: '--- Previous ---' },
-        { label: 'Previous Position', value: previousShift!.position },
-        { label: 'Previous Start', value: formatDateTime(previousShift!.start_time, restaurantTimezone) },
-        { label: 'Previous End', value: formatDateTime(previousShift!.end_time, restaurantTimezone) },
-      );
+    let emailResult: { id?: string } | null | undefined;
+
+    if (ch.email) {
+      const employeeEmail = shift.employee?.email;
+      if (!employeeEmail) {
+        console.log('Employee has no email address');
+      } else {
+        // Get restaurant name + timezone so shift times render in the
+        // restaurant's local time, not the edge runtime's UTC.
+        const { name: restaurantName, timezone: restaurantTimezone } =
+          await getRestaurantInfo(supabase, shift.restaurant_id);
+
+        // Build details card
+        const detailsItems = [
+          { label: 'Restaurant', value: restaurantName },
+          { label: 'Position', value: shift.position },
+          { label: 'Start', value: formatDateTime(shift.start_time, restaurantTimezone) },
+          { label: 'End', value: formatDateTime(shift.end_time, restaurantTimezone) },
+        ];
+
+        // Add previous details if modified
+        if (hasChanges) {
+          detailsItems.push(
+            { label: '', value: '--- Previous ---' },
+            { label: 'Previous Position', value: previousShift!.position },
+            { label: 'Previous Start', value: formatDateTime(previousShift!.start_time, restaurantTimezone) },
+            { label: 'Previous End', value: formatDateTime(previousShift!.end_time, restaurantTimezone) },
+          );
+        }
+
+        // Generate email template
+        const emailData: EmailTemplateData = {
+          heading: config.heading,
+          statusBadge: {
+            text: config.statusText,
+            color: config.statusColor,
+          },
+          greeting: `Hi ${shift.employee?.name || 'there'},`,
+          message: config.message(!!hasChanges),
+          detailsCard: {
+            items: detailsItems,
+          },
+          ctaButton: {
+            text: 'View My Schedule',
+            url: `${APP_URL}/employee/schedule`,
+          },
+          footerNote: 'If you have any questions about your schedule, please contact your manager.',
+        };
+
+        const html = generateEmailTemplate(emailData);
+        const subject = config.subject(restaurantName);
+
+        // Send email
+        const { data: sentEmail, error: emailError } = await resend.emails.send({
+          from: NOTIFICATION_FROM,
+          to: [employeeEmail],
+          subject,
+          html,
+        });
+
+        if (emailError) {
+          console.error('Error sending email:', emailError);
+          return errorResponse('Failed to send email', 500);
+        }
+
+        emailResult = sentEmail;
+        console.log(`Successfully sent shift notification: emailId=${emailResult?.id}`);
+      }
     }
-
-    // Generate email template
-    const emailData: EmailTemplateData = {
-      heading: config.heading,
-      statusBadge: {
-        text: config.statusText,
-        color: config.statusColor,
-      },
-      greeting: `Hi ${shift.employee?.name || 'there'},`,
-      message: config.message(!!hasChanges),
-      detailsCard: {
-        items: detailsItems,
-      },
-      ctaButton: {
-        text: 'View My Schedule',
-        url: `${APP_URL}/employee/schedule`,
-      },
-      footerNote: 'If you have any questions about your schedule, please contact your manager.',
-    };
-
-    const html = generateEmailTemplate(emailData);
-    const subject = config.subject(restaurantName);
-
-    // Send email
-    const { data: emailResult, error: emailError } = await resend.emails.send({
-      from: NOTIFICATION_FROM,
-      to: [employeeEmail],
-      subject,
-      html,
-    });
-
-    if (emailError) {
-      console.error('Error sending email:', emailError);
-      return errorResponse('Failed to send email', 500);
-    }
-
-    console.log(`Successfully sent shift notification: emailId=${emailResult?.id}`);
 
     // Send web push notification to the employee
-    if (shift.employee?.user_id) {
+    if (ch.push && shift.employee?.user_id) {
       try {
         await sendWebPushToUser(supabase, shift.employee.user_id, shift.restaurant_id, {
           title: config.heading,

--- a/supabase/functions/send-shift-trade-notification/index.ts
+++ b/supabase/functions/send-shift-trade-notification/index.ts
@@ -5,6 +5,8 @@ import { Resend } from "https://esm.sh/resend@4.0.0";
 import { sendWebPushToUser, sendWebPushToUsers } from '../_shared/webPushHelper.ts';
 import { selectBroadcastPushUserIds } from '../_shared/webPushFanout.ts';
 import { resolveCreatedTradeEmailRecipients, type DirectedTarget } from '../_shared/tradeEmailAudience.ts';
+import { resolveChannels, type SupabaseLike } from '../_shared/resolveChannels.ts';
+import { TRADE_ACTION_TYPE } from '../_shared/notificationActionTypes.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -369,6 +371,13 @@ const handler = async (req: Request): Promise<Response> => {
       );
     }
 
+    // Independent per-channel gating (email/push may be toggled separately).
+    const ch = await resolveChannels(
+      admin as unknown as SupabaseLike,
+      trade.restaurant_id,
+      TRADE_ACTION_TYPE[action]
+    );
+
     // Build shift details object
     const shift = trade.offered_shift;
     // Matches the `restaurants.timezone` column default and Clover/Shift4 fallback.
@@ -427,7 +436,7 @@ const handler = async (req: Request): Promise<Response> => {
 
     let emailData: { id?: string } | undefined;
 
-    if (recipients.length > 0) {
+    if (ch.email && recipients.length > 0) {
       console.log(`Sending shift trade notification to ${recipients.length} recipients`);
 
       // Generate email HTML
@@ -467,87 +476,89 @@ const handler = async (req: Request): Promise<Response> => {
     // Send push notifications to the relevant employees based on action
     const pushUserIds: string[] = [];
 
-    if (action === 'created') {
-      // Push on a newly-offered trade. A DIRECTED trade ("Specific Coworker",
-      // target_employee_id set) is hidden from non-targets by the marketplace filter
-      // (client-side; not RLS-enforced — see task_35a15d77) — so it must push ONLY
-      // that employee, never the whole team, or we'd leak/noise a private offer. An
-      // OPEN marketplace trade (target_employee_id null) broadcasts to active
-      // employees, minus the poster.
-      // Bulk fan-out (single subscription lookup + bounded concurrency). Email
-      // recipients above are unaffected; this only adds the push channel. The
-      // whole block is wrapped so a failure at any step degrades to a logged,
-      // skipped push instead of turning the already-sent email into a false 500.
-      try {
-        let broadcastTargets: string[];
-        if (trade.target_employee_id) {
-          // Reuses the directed-target row resolved above (email lookup) instead of a
-          // second query for the same employee.
-          broadcastTargets = selectBroadcastPushUserIds(
-            directedTargetEmployee ? [directedTargetEmployee] : [],
-            trade.offered_by?.user_id,
-          );
-        } else {
-          const { data: activeEmployees, error: employeesError } = await admin
-            .from('employees')
-            .select('user_id')
-            .eq('restaurant_id', trade.restaurant_id)
-            .eq('is_active', true)
-            .not('user_id', 'is', null);
-          if (employeesError) {
-            console.error('Error fetching active employees for broadcast push:', employeesError);
+    if (ch.push) {
+      if (action === 'created') {
+        // Push on a newly-offered trade. A DIRECTED trade ("Specific Coworker",
+        // target_employee_id set) is hidden from non-targets by the marketplace filter
+        // (client-side; not RLS-enforced — see task_35a15d77) — so it must push ONLY
+        // that employee, never the whole team, or we'd leak/noise a private offer. An
+        // OPEN marketplace trade (target_employee_id null) broadcasts to active
+        // employees, minus the poster.
+        // Bulk fan-out (single subscription lookup + bounded concurrency). Email
+        // recipients above are unaffected; this only adds the push channel. The
+        // whole block is wrapped so a failure at any step degrades to a logged,
+        // skipped push instead of turning the already-sent email into a false 500.
+        try {
+          let broadcastTargets: string[];
+          if (trade.target_employee_id) {
+            // Reuses the directed-target row resolved above (email lookup) instead of a
+            // second query for the same employee.
+            broadcastTargets = selectBroadcastPushUserIds(
+              directedTargetEmployee ? [directedTargetEmployee] : [],
+              trade.offered_by?.user_id,
+            );
+          } else {
+            const { data: activeEmployees, error: employeesError } = await admin
+              .from('employees')
+              .select('user_id')
+              .eq('restaurant_id', trade.restaurant_id)
+              .eq('is_active', true)
+              .not('user_id', 'is', null);
+            if (employeesError) {
+              console.error('Error fetching active employees for broadcast push:', employeesError);
+            }
+            broadcastTargets = selectBroadcastPushUserIds(activeEmployees ?? [], trade.offered_by?.user_id);
           }
-          broadcastTargets = selectBroadcastPushUserIds(activeEmployees ?? [], trade.offered_by?.user_id);
+          await sendWebPushToUsers(admin, broadcastTargets, trade.restaurant_id, {
+            title: content.heading,
+            body: 'A teammate offered a shift for trade. Tap to view.',
+            url: EMPLOYEE_SHIFTS_ROUTE,
+            tag: `trade-created-${tradeId}`,
+          });
+        } catch (e) {
+          console.error('Broadcast web push failed:', e);
         }
-        await sendWebPushToUsers(admin, broadcastTargets, trade.restaurant_id, {
-          title: content.heading,
-          body: 'A teammate offered a shift for trade. Tap to view.',
-          url: EMPLOYEE_SHIFTS_ROUTE,
-          tag: `trade-created-${tradeId}`,
-        });
-      } catch (e) {
-        console.error('Broadcast web push failed:', e);
-      }
-    } else if (action === 'accepted') {
-      // Notify the employee who offered the shift
-      if (trade.offered_by?.user_id) pushUserIds.push(trade.offered_by.user_id);
-    } else if (action === 'approved' || action === 'rejected') {
-      // Notify both involved employees
-      if (trade.offered_by?.user_id) pushUserIds.push(trade.offered_by.user_id);
-      if (trade.accepted_by?.user_id) pushUserIds.push(trade.accepted_by.user_id);
-    } else if (action === 'cancelled') {
-      // Notify the employee who had accepted
-      if (trade.accepted_by?.user_id) pushUserIds.push(trade.accepted_by.user_id);
-    }
-
-    for (const userId of [...new Set(pushUserIds)]) {
-      try {
-        await fetch(`${supabaseUrl}/functions/v1/send-push-notification`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            'Authorization': `Bearer ${supabaseServiceKey}`,
-          },
-          body: JSON.stringify({
-            user_id: userId,
-            title: 'Shift Trade Request',
-            body: 'Someone wants to trade a shift with you',
-            data: { route: EMPLOYEE_SHIFTS_ROUTE },
-          }),
-        });
-      } catch (e) {
-        console.error('Push notification failed:', e);
+      } else if (action === 'accepted') {
+        // Notify the employee who offered the shift
+        if (trade.offered_by?.user_id) pushUserIds.push(trade.offered_by.user_id);
+      } else if (action === 'approved' || action === 'rejected') {
+        // Notify both involved employees
+        if (trade.offered_by?.user_id) pushUserIds.push(trade.offered_by.user_id);
+        if (trade.accepted_by?.user_id) pushUserIds.push(trade.accepted_by.user_id);
+      } else if (action === 'cancelled') {
+        // Notify the employee who had accepted
+        if (trade.accepted_by?.user_id) pushUserIds.push(trade.accepted_by.user_id);
       }
 
-      try {
-        await sendWebPushToUser(admin, userId, trade.restaurant_id, {
-          title: 'Shift Trade Update',
-          body: content.subject(employeeName),
-          url: EMPLOYEE_SHIFTS_ROUTE,
-          tag: `trade-${action}-${tradeId}`,
-        });
-      } catch (e) {
-        console.error('Web push failed:', e);
+      for (const userId of [...new Set(pushUserIds)]) {
+        try {
+          await fetch(`${supabaseUrl}/functions/v1/send-push-notification`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': `Bearer ${supabaseServiceKey}`,
+            },
+            body: JSON.stringify({
+              user_id: userId,
+              title: 'Shift Trade Request',
+              body: 'Someone wants to trade a shift with you',
+              data: { route: EMPLOYEE_SHIFTS_ROUTE },
+            }),
+          });
+        } catch (e) {
+          console.error('Push notification failed:', e);
+        }
+
+        try {
+          await sendWebPushToUser(admin, userId, trade.restaurant_id, {
+            title: 'Shift Trade Update',
+            body: content.subject(employeeName),
+            url: EMPLOYEE_SHIFTS_ROUTE,
+            tag: `trade-${action}-${tradeId}`,
+          });
+        } catch (e) {
+          console.error('Web push failed:', e);
+        }
       }
     }
 

--- a/supabase/functions/send-team-invitation/index.ts
+++ b/supabase/functions/send-team-invitation/index.ts
@@ -2,6 +2,7 @@ import { generateHeader } from '../_shared/emailTemplates.ts';
 import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { Resend } from "https://esm.sh/resend@4.0.0";
+import { resolveChannels, type SupabaseLike } from "../_shared/resolveChannels.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -194,73 +195,83 @@ const handler = async (req: Request): Promise<Response> => {
     const friendlyRole = roleLabels[role] || role;
     const isCollaborator = role.startsWith('collaborator_');
 
+    // `team_invite` is email-only in the catalog (see src/lib/notificationTypes.ts)
+    // — there is no push variant to gate here. The invitation row above is
+    // always created regardless of the channel setting; only the notification
+    // email is gated.
+    const ch = await resolveChannels(supabase as unknown as SupabaseLike, restaurantId, 'team_invite');
+
     // Send invitation email
-    try {
-      const emailResponse = await resend.emails.send({
-        from: "EasyShiftHQ <notifications@easyshifthq.com>",
-        to: [email],
-        subject: isCollaborator
-          ? `You're invited to collaborate with ${restaurant.name}`
-          : `You're invited to join ${restaurant.name}`,
-        html: `
-          <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; max-width: 600px; margin: 0 auto; background: #ffffff;">
-            ${generateHeader()}
+    if (!ch.email) {
+      console.log('Invitation email disabled by settings; invitation row still created');
+    } else {
+      try {
+        const emailResponse = await resend.emails.send({
+          from: "EasyShiftHQ <notifications@easyshifthq.com>",
+          to: [email],
+          subject: isCollaborator
+            ? `You're invited to collaborate with ${restaurant.name}`
+            : `You're invited to join ${restaurant.name}`,
+          html: `
+            <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; max-width: 600px; margin: 0 auto; background: #ffffff;">
+              ${generateHeader()}
 
-            <!-- Content -->
-            <div style="padding: 40px 32px; background: #ffffff;">
-              <h1 style="color: #1f2937; font-size: 24px; font-weight: 600; margin: 0 0 16px 0; line-height: 1.3;">${isCollaborator ? `You're invited to collaborate with ${restaurant.name}` : `You're invited to join ${restaurant.name}`}</h1>
+              <!-- Content -->
+              <div style="padding: 40px 32px; background: #ffffff;">
+                <h1 style="color: #1f2937; font-size: 24px; font-weight: 600; margin: 0 0 16px 0; line-height: 1.3;">${isCollaborator ? `You're invited to collaborate with ${restaurant.name}` : `You're invited to join ${restaurant.name}`}</h1>
 
-              <p style="color: #6b7280; line-height: 1.6; font-size: 16px; margin: 0 0 24px 0;">
-                You've been invited to ${isCollaborator ? 'collaborate with' : 'join'} <strong style="color: #1f2937;">${restaurant.name}</strong> as ${isCollaborator ? 'an' : 'a'} <strong style="color: #1f2937;">${friendlyRole}</strong> on EasyShiftHQ.
-              </p>
-              
-              <div style="background: linear-gradient(135deg, #f0fdf4 0%, #dcfce7 100%); padding: 24px; border-radius: 12px; margin: 24px 0; border-left: 4px solid #10b981;">
-                <table style="width: 100%; border-collapse: collapse;">
-                  <tr>
-                    <td style="padding: 6px 0; color: #6b7280; font-size: 14px; font-weight: 600;">Restaurant:</td>
-                    <td style="padding: 6px 0; color: #1f2937; font-size: 14px; text-align: right;">${restaurant.name}</td>
-                  </tr>
-                  <tr>
-                    <td style="padding: 6px 0; color: #6b7280; font-size: 14px; font-weight: 600;">Role:</td>
-                    <td style="padding: 6px 0; color: #1f2937; font-size: 14px; text-align: right;">${friendlyRole}</td>
-                  </tr>
-                  <tr>
-                    <td style="padding: 6px 0; color: #6b7280; font-size: 14px; font-weight: 600;">Expires:</td>
-                    <td style="padding: 6px 0; color: #1f2937; font-size: 14px; text-align: right;">${new Date(invitation.expires_at).toLocaleDateString()}</td>
-                  </tr>
-                </table>
+                <p style="color: #6b7280; line-height: 1.6; font-size: 16px; margin: 0 0 24px 0;">
+                  You've been invited to ${isCollaborator ? 'collaborate with' : 'join'} <strong style="color: #1f2937;">${restaurant.name}</strong> as ${isCollaborator ? 'an' : 'a'} <strong style="color: #1f2937;">${friendlyRole}</strong> on EasyShiftHQ.
+                </p>
+
+                <div style="background: linear-gradient(135deg, #f0fdf4 0%, #dcfce7 100%); padding: 24px; border-radius: 12px; margin: 24px 0; border-left: 4px solid #10b981;">
+                  <table style="width: 100%; border-collapse: collapse;">
+                    <tr>
+                      <td style="padding: 6px 0; color: #6b7280; font-size: 14px; font-weight: 600;">Restaurant:</td>
+                      <td style="padding: 6px 0; color: #1f2937; font-size: 14px; text-align: right;">${restaurant.name}</td>
+                    </tr>
+                    <tr>
+                      <td style="padding: 6px 0; color: #6b7280; font-size: 14px; font-weight: 600;">Role:</td>
+                      <td style="padding: 6px 0; color: #1f2937; font-size: 14px; text-align: right;">${friendlyRole}</td>
+                    </tr>
+                    <tr>
+                      <td style="padding: 6px 0; color: #6b7280; font-size: 14px; font-weight: 600;">Expires:</td>
+                      <td style="padding: 6px 0; color: #1f2937; font-size: 14px; text-align: right;">${new Date(invitation.expires_at).toLocaleDateString()}</td>
+                    </tr>
+                  </table>
+                </div>
+
+                <div style="text-align: center; margin: 32px 0;">
+                  <a href="${invitationUrl}"
+                     style="background-color: #059669; background: linear-gradient(135deg, #10b981 0%, #059669 100%); color: #ffffff !important; padding: 14px 32px; text-decoration: none; border-radius: 8px; display: inline-block; font-weight: 600; font-size: 16px; box-shadow: 0 4px 12px rgba(16, 185, 129, 0.3); mso-padding-alt: 14px 32px; border: 2px solid #059669;">
+                    <span style="color: #ffffff !important;">Accept Invitation</span>
+                  </a>
+                </div>
+
+                <p style="color: #9ca3af; font-size: 14px; margin: 32px 0 0 0; line-height: 1.6;">
+                  This invitation will expire in 7 days. If you didn't expect this invitation, you can safely ignore this email.
+                </p>
               </div>
-              
-              <div style="text-align: center; margin: 32px 0;">
-                <a href="${invitationUrl}" 
-                   style="background-color: #059669; background: linear-gradient(135deg, #10b981 0%, #059669 100%); color: #ffffff !important; padding: 14px 32px; text-decoration: none; border-radius: 8px; display: inline-block; font-weight: 600; font-size: 16px; box-shadow: 0 4px 12px rgba(16, 185, 129, 0.3); mso-padding-alt: 14px 32px; border: 2px solid #059669;">
-                  <span style="color: #ffffff !important;">Accept Invitation</span>
-                </a>
-              </div>
-              
-              <p style="color: #9ca3af; font-size: 14px; margin: 32px 0 0 0; line-height: 1.6;">
-                This invitation will expire in 7 days. If you didn't expect this invitation, you can safely ignore this email.
-              </p>
-            </div>
-            
-            <!-- Footer -->
-            <div style="background: #f9fafb; padding: 24px 32px; border-radius: 0 0 8px 8px; border-top: 1px solid #e5e7eb;">
-              <p style="color: #9ca3af; font-size: 13px; text-align: center; margin: 0; line-height: 1.5;">
-                <strong style="color: #6b7280;">EasyShiftHQ</strong><br>
-                Restaurant Operations Management System
-              </p>
-              <p style="color: #d1d5db; font-size: 12px; text-align: center; margin: 12px 0 0 0;">
-                © ${new Date().getFullYear()} EasyShiftHQ. All rights reserved.
-              </p>
-            </div>
-          </div>
-        `,
-      });
 
-      console.log("Invitation email sent successfully:", emailResponse);
-    } catch (emailError) {
-      console.error("Failed to send invitation email:", emailError);
-      // Don't fail the entire request if email fails - invitation is still created
+              <!-- Footer -->
+              <div style="background: #f9fafb; padding: 24px 32px; border-radius: 0 0 8px 8px; border-top: 1px solid #e5e7eb;">
+                <p style="color: #9ca3af; font-size: 13px; text-align: center; margin: 0; line-height: 1.5;">
+                  <strong style="color: #6b7280;">EasyShiftHQ</strong><br>
+                  Restaurant Operations Management System
+                </p>
+                <p style="color: #d1d5db; font-size: 12px; text-align: center; margin: 12px 0 0 0;">
+                  © ${new Date().getFullYear()} EasyShiftHQ. All rights reserved.
+                </p>
+              </div>
+            </div>
+          `,
+        });
+
+        console.log("Invitation email sent successfully:", emailResponse);
+      } catch (emailError) {
+        console.error("Failed to send invitation email:", emailError);
+        // Don't fail the entire request if email fails - invitation is still created
+      }
     }
     return new Response(
       JSON.stringify({ 

--- a/supabase/functions/send-team-invitation/index.ts
+++ b/supabase/functions/send-team-invitation/index.ts
@@ -2,7 +2,6 @@ import { generateHeader } from '../_shared/emailTemplates.ts';
 import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { Resend } from "https://esm.sh/resend@4.0.0";
-import { resolveChannels, type SupabaseLike } from "../_shared/resolveChannels.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -195,16 +194,11 @@ const handler = async (req: Request): Promise<Response> => {
     const friendlyRole = roleLabels[role] || role;
     const isCollaborator = role.startsWith('collaborator_');
 
-    // `team_invite` is email-only in the catalog (see src/lib/notificationTypes.ts)
-    // — there is no push variant to gate here. The invitation row above is
-    // always created regardless of the channel setting; only the notification
-    // email is gated.
-    const ch = await resolveChannels(supabase as unknown as SupabaseLike, restaurantId, 'team_invite');
-
-    // Send invitation email
-    if (!ch.email) {
-      console.log('Invitation email disabled by settings; invitation row still created');
-    } else {
+    // Send invitation email. A team invite is TRANSACTIONAL — the email carries the
+    // only copy of the accept link (the token is hashed/unrecoverable server-side),
+    // so it is NOT gated by the notification channel matrix (team_invite is
+    // deliberately excluded from the catalog) and always sends.
+    {
       try {
         const emailResponse = await resend.emails.send({
           from: "EasyShiftHQ <notifications@easyshifthq.com>",

--- a/supabase/functions/send-time-off-notification/index.ts
+++ b/supabase/functions/send-time-off-notification/index.ts
@@ -4,6 +4,8 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { Resend } from "https://esm.sh/resend@4.0.0";
 import { sendWebPushToUser } from '../_shared/webPushHelper.ts';
 import { buildEmails } from './buildEmails.ts';
+import { resolveChannels, type SupabaseLike } from '../_shared/resolveChannels.ts';
+import { TIME_OFF_ACTION_TYPE } from '../_shared/notificationActionTypes.ts';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -112,21 +114,25 @@ const handler = async (req: Request): Promise<Response> => {
       .eq('restaurant_id', timeOffRequest.restaurant_id)
       .single();
 
+    // `time_off_notify_managers`/`time_off_notify_employee` are WHO gets notified
+    // (recipient routing) and stay sourced from legacy `notification_settings`
+    // below — unrelated to WHETHER a channel fires, which the matrix now governs.
     const settings = notificationSettings || {
-      notify_time_off_request: true,
-      notify_time_off_approved: true,
-      notify_time_off_rejected: true,
       time_off_notify_managers: true,
       time_off_notify_employee: true,
     };
 
-    const shouldNotify =
-      (action === 'created' && settings.notify_time_off_request) ||
-      (action === 'approved' && settings.notify_time_off_approved) ||
-      (action === 'rejected' && settings.notify_time_off_rejected);
+    // Independent per-channel gating (email/push may be toggled separately).
+    // Replaces the old combined `notify_time_off_request`/`_approved`/`_rejected`
+    // booleans, which forced email and push to share a single on/off switch.
+    const ch = await resolveChannels(
+      supabase as unknown as SupabaseLike,
+      timeOffRequest.restaurant_id,
+      TIME_OFF_ACTION_TYPE[action]
+    );
 
-    if (!shouldNotify) {
-      console.log('Notification disabled for action:', action);
+    if (!ch.email && !ch.push) {
+      console.log('Notification disabled for action (both channels off):', action);
       return new Response(
         JSON.stringify({
           success: true,
@@ -195,7 +201,7 @@ const handler = async (req: Request): Promise<Response> => {
 
     // Send notification emails
     try {
-      const emailPromises = recipients.emails.map(email => 
+      const emailPromises = (ch.email ? recipients.emails : []).map(email =>
         resend.emails.send({
           from: "EasyShiftHQ <notifications@easyshifthq.com>",
           to: [email],
@@ -276,7 +282,7 @@ const handler = async (req: Request): Promise<Response> => {
       });
 
       // Send push notification to the employee for approved/rejected actions
-      if ((action === 'approved' || action === 'rejected') && timeOffRequest.employee?.user_id) {
+      if (ch.push && (action === 'approved' || action === 'rejected') && timeOffRequest.employee?.user_id) {
         try {
           await fetch(
             `${Deno.env.get('SUPABASE_URL')}/functions/v1/send-push-notification`,

--- a/supabase/migrations/20260719120000_notification_channel_settings.sql
+++ b/supabase/migrations/20260719120000_notification_channel_settings.sql
@@ -1,0 +1,123 @@
+-- Admin per-type x per-channel notification matrix: notification_channel_settings table.
+--
+-- Single source of truth for the 16 notification types lives in TWO hand-maintained
+-- lists that a vitest test (tests/unit/notificationTypes.test.ts) keeps in sync:
+--   - src/lib/notificationTypes.ts (NOTIFICATION_TYPES / NotificationType union)
+--   - supabase/functions/_shared/resolveChannels.ts (NotificationType union)
+-- The CHECK constraint below is the third hand-maintained copy of that same list —
+-- review it against those two files whenever a notification type is added/removed.
+--
+-- See docs/superpowers/specs/2026-07-13-notification-channel-matrix-design.md.
+
+CREATE TABLE IF NOT EXISTS notification_channel_settings (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  restaurant_id UUID NOT NULL REFERENCES restaurants(id) ON DELETE CASCADE,
+  notification_type TEXT NOT NULL,
+  email_enabled BOOLEAN NOT NULL DEFAULT true,
+  push_enabled BOOLEAN NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  CONSTRAINT notification_channel_settings_restaurant_type_unique
+    UNIQUE (restaurant_id, notification_type),
+
+  CONSTRAINT notification_channel_settings_type_check
+    CHECK (notification_type IN (
+      'schedule_published',
+      'shift_created',
+      'shift_modified',
+      'shift_deleted',
+      'open_shifts_broadcast',
+      'shift_trade_created',
+      'shift_trade_accepted',
+      'shift_trade_approved',
+      'shift_trade_rejected',
+      'shift_trade_cancelled',
+      'time_off_requested',
+      'time_off_approved',
+      'time_off_rejected',
+      'pin_reset',
+      'team_invite',
+      'availability_reminder'
+    ))
+);
+
+-- Note: no separate single-column index on restaurant_id — the composite UNIQUE
+-- constraint above already provides an index usable for a restaurant_id-only lookup
+-- (leftmost-column prefix), so a redundant index would just be write-amplification.
+
+-- RLS: verbatim from notification_settings (20251123100500) — any restaurant member
+-- can view; only owner/manager can write. Absent-row callers fall through to
+-- resolveChannels()'s fail-open default (both channels on), so RLS never needs to be
+-- permissive for "no row yet".
+ALTER TABLE notification_channel_settings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view notification channel settings"
+  ON notification_channel_settings FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM user_restaurants
+      WHERE user_restaurants.restaurant_id = notification_channel_settings.restaurant_id
+      AND user_restaurants.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "Owners and managers can manage notification channel settings"
+  ON notification_channel_settings FOR ALL
+  USING (
+    EXISTS (
+      SELECT 1 FROM user_restaurants
+      WHERE user_restaurants.restaurant_id = notification_channel_settings.restaurant_id
+      AND user_restaurants.user_id = auth.uid()
+      AND user_restaurants.role IN ('owner', 'manager')
+    )
+  );
+
+-- updated_at trigger: reuse the same function notification_settings uses, so
+-- updated_at actually advances on toggle-saves.
+CREATE TRIGGER update_notification_channel_settings_updated_at
+  BEFORE UPDATE ON notification_channel_settings
+  FOR EACH ROW
+  EXECUTE FUNCTION update_scheduling_updated_at();
+
+-- Table-level grants: required as of 20260628000000_grant_user_restaurants_select
+-- (local Supabase CLI runs migrations as `postgres`, whose default-privilege entry
+-- does NOT include SELECT/INSERT/UPDATE for authenticated/anon/service_role — RLS
+-- alone isn't enough, PostgreSQL checks the table ACL before evaluating policies).
+-- RLS policies above still control which rows each role can see/write.
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.notification_channel_settings TO authenticated;
+GRANT SELECT ON public.notification_channel_settings TO anon;
+GRANT ALL ON public.notification_channel_settings TO service_role;
+
+COMMENT ON TABLE notification_channel_settings IS 'Per-restaurant, per-notification-type email/push channel toggles (admin matrix). Absent row = both channels on (fail-open, see resolveChannels()).';
+COMMENT ON COLUMN notification_channel_settings.notification_type IS 'One of the 16 catalog keys in src/lib/notificationTypes.ts — kept in sync with the CHECK constraint above.';
+COMMENT ON COLUMN notification_channel_settings.email_enabled IS 'Whether this notification type sends over email for this restaurant.';
+COMMENT ON COLUMN notification_channel_settings.push_enabled IS 'Whether this notification type sends over push (web push and/or legacy FCM) for this restaurant.';
+
+-- Data migration: preserve existing choices from the legacy notification_settings
+-- single-boolean-per-type columns for the 6 types that were already gated
+-- (3 shift + 3 time-off). Types that were never gated (11 others) are left absent,
+-- which resolves to "both channels on" via resolveChannels() — unchanged behavior.
+-- COALESCE(<legacy>, true): the legacy columns are nullable; NULL must map to
+-- true (fail-open), not violate the NOT NULL channel columns.
+-- ON CONFLICT DO NOTHING: idempotent re-run safety (should never actually hit,
+-- since this table is brand new in this migration).
+INSERT INTO notification_channel_settings (restaurant_id, notification_type, email_enabled, push_enabled)
+SELECT restaurant_id, 'shift_created', COALESCE(notify_shift_created, true), COALESCE(notify_shift_created, true)
+FROM notification_settings
+UNION ALL
+SELECT restaurant_id, 'shift_modified', COALESCE(notify_shift_modified, true), COALESCE(notify_shift_modified, true)
+FROM notification_settings
+UNION ALL
+SELECT restaurant_id, 'shift_deleted', COALESCE(notify_shift_deleted, true), COALESCE(notify_shift_deleted, true)
+FROM notification_settings
+UNION ALL
+SELECT restaurant_id, 'time_off_requested', COALESCE(notify_time_off_request, true), COALESCE(notify_time_off_request, true)
+FROM notification_settings
+UNION ALL
+SELECT restaurant_id, 'time_off_approved', COALESCE(notify_time_off_approved, true), COALESCE(notify_time_off_approved, true)
+FROM notification_settings
+UNION ALL
+SELECT restaurant_id, 'time_off_rejected', COALESCE(notify_time_off_rejected, true), COALESCE(notify_time_off_rejected, true)
+FROM notification_settings
+ON CONFLICT (restaurant_id, notification_type) DO NOTHING;

--- a/supabase/migrations/20260719120000_notification_channel_settings.sql
+++ b/supabase/migrations/20260719120000_notification_channel_settings.sql
@@ -37,7 +37,6 @@ CREATE TABLE IF NOT EXISTS notification_channel_settings (
       'time_off_approved',
       'time_off_rejected',
       'pin_reset',
-      'team_invite',
       'availability_reminder'
     ))
 );
@@ -90,7 +89,7 @@ GRANT SELECT ON public.notification_channel_settings TO anon;
 GRANT ALL ON public.notification_channel_settings TO service_role;
 
 COMMENT ON TABLE notification_channel_settings IS 'Per-restaurant, per-notification-type email/push channel toggles (admin matrix). Absent row = both channels on (fail-open, see resolveChannels()).';
-COMMENT ON COLUMN notification_channel_settings.notification_type IS 'One of the 16 catalog keys in src/lib/notificationTypes.ts — kept in sync with the CHECK constraint above.';
+COMMENT ON COLUMN notification_channel_settings.notification_type IS 'One of the 15 catalog keys in src/lib/notificationTypes.ts — kept in sync with the CHECK constraint above. (team_invite is excluded: a transactional invite email is always sent, not admin-toggleable.)';
 COMMENT ON COLUMN notification_channel_settings.email_enabled IS 'Whether this notification type sends over email for this restaurant.';
 COMMENT ON COLUMN notification_channel_settings.push_enabled IS 'Whether this notification type sends over push (web push and/or legacy FCM) for this restaurant.';
 

--- a/supabase/migrations/20260719120000_notification_channel_settings.sql
+++ b/supabase/migrations/20260719120000_notification_channel_settings.sql
@@ -1,6 +1,6 @@
 -- Admin per-type x per-channel notification matrix: notification_channel_settings table.
 --
--- Single source of truth for the 16 notification types lives in TWO hand-maintained
+-- Single source of truth for the 15 notification types lives in TWO hand-maintained
 -- lists that a vitest test (tests/unit/notificationTypes.test.ts) keeps in sync:
 --   - src/lib/notificationTypes.ts (NOTIFICATION_TYPES / NotificationType union)
 --   - supabase/functions/_shared/resolveChannels.ts (NotificationType union)
@@ -95,7 +95,7 @@ COMMENT ON COLUMN notification_channel_settings.push_enabled IS 'Whether this no
 
 -- Data migration: preserve existing choices from the legacy notification_settings
 -- single-boolean-per-type columns for the 6 types that were already gated
--- (3 shift + 3 time-off). Types that were never gated (11 others) are left absent,
+-- (3 shift + 3 time-off). Types that were never gated (9 others) are left absent,
 -- which resolves to "both channels on" via resolveChannels() — unchanged behavior.
 -- COALESCE(<legacy>, true): the legacy columns are nullable; NULL must map to
 -- true (fail-open), not violate the NOT NULL channel columns.

--- a/supabase/tests/62_notification_channel_settings_rls.sql
+++ b/supabase/tests/62_notification_channel_settings_rls.sql
@@ -162,14 +162,14 @@ SELECT is(
 -- Test 14: Owner CAN INSERT for their restaurant
 SELECT lives_ok(
   $$INSERT INTO notification_channel_settings (restaurant_id, notification_type, email_enabled)
-    VALUES ('c9000000-0000-0000-0000-000000000001', 'team_invite', false)$$,
+    VALUES ('c9000000-0000-0000-0000-000000000001', 'schedule_published', false)$$,
   'Owner should be able to INSERT notification channel settings for their restaurant'
 );
 
 -- Test 15: Owner CAN UPDATE for their restaurant
 SELECT lives_ok(
   $$UPDATE notification_channel_settings SET email_enabled = true
-    WHERE restaurant_id = 'c9000000-0000-0000-0000-000000000001' AND notification_type = 'team_invite'$$,
+    WHERE restaurant_id = 'c9000000-0000-0000-0000-000000000001' AND notification_type = 'schedule_published'$$,
   'Owner should be able to UPDATE notification channel settings for their restaurant'
 );
 

--- a/supabase/tests/62_notification_channel_settings_rls.sql
+++ b/supabase/tests/62_notification_channel_settings_rls.sql
@@ -1,0 +1,279 @@
+-- ============================================================================
+-- Tests for notification_channel_settings table
+--
+-- Verifies table structure, defaults, UNIQUE/CHECK constraints, the updated_at
+-- trigger, RLS (member SELECT / owner+manager-only write), cross-restaurant
+-- isolation, and the data-migration backfill from the legacy
+-- notification_settings single-boolean-per-type columns.
+--
+-- Migration: 20260719120000_notification_channel_settings.sql
+-- ============================================================================
+
+BEGIN;
+SELECT plan(20);
+
+-- ============================================================================
+-- TEST CATEGORY 1: Table and column structure (Tests 1-4)
+-- ============================================================================
+
+SELECT has_table('public', 'notification_channel_settings', 'notification_channel_settings table should exist');
+SELECT has_column('public', 'notification_channel_settings', 'notification_type', 'should have notification_type column');
+SELECT has_column('public', 'notification_channel_settings', 'email_enabled', 'should have email_enabled column');
+SELECT has_column('public', 'notification_channel_settings', 'push_enabled', 'should have push_enabled column');
+
+-- ============================================================================
+-- TEST CATEGORY 2: Defaults, UNIQUE, CHECK, trigger (Tests 5-9)
+-- ============================================================================
+
+SET LOCAL role TO postgres;
+ALTER TABLE notification_channel_settings DISABLE ROW LEVEL SECURITY;
+ALTER TABLE notification_settings DISABLE ROW LEVEL SECURITY;
+ALTER TABLE restaurants DISABLE ROW LEVEL SECURITY;
+ALTER TABLE user_restaurants DISABLE ROW LEVEL SECURITY;
+
+INSERT INTO restaurants (id, name) VALUES
+  ('c9000000-0000-0000-0000-000000000001', 'Notif Channel Test Restaurant 1'),
+  ('c9000000-0000-0000-0000-000000000002', 'Notif Channel Test Restaurant 2'),
+  ('c9000000-0000-0000-0000-000000000003', 'Notif Channel Test Restaurant 3 (non-member)')
+ON CONFLICT (id) DO NOTHING;
+
+-- Test 5-6: Defaults are true/true
+INSERT INTO notification_channel_settings (id, restaurant_id, notification_type)
+VALUES ('c9000000-0000-0000-0000-100000000001', 'c9000000-0000-0000-0000-000000000001', 'pin_reset');
+
+SELECT is(
+  (SELECT email_enabled FROM notification_channel_settings WHERE id = 'c9000000-0000-0000-0000-100000000001'),
+  true,
+  'Default email_enabled should be true'
+);
+
+SELECT is(
+  (SELECT push_enabled FROM notification_channel_settings WHERE id = 'c9000000-0000-0000-0000-100000000001'),
+  true,
+  'Default push_enabled should be true'
+);
+
+-- Test 7: UNIQUE(restaurant_id, notification_type) rejects a duplicate
+SELECT throws_ok(
+  $$INSERT INTO notification_channel_settings (restaurant_id, notification_type)
+    VALUES ('c9000000-0000-0000-0000-000000000001', 'pin_reset')$$,
+  '23505',
+  NULL,
+  'UNIQUE constraint should prevent duplicate (restaurant_id, notification_type)'
+);
+
+-- Test 8: CHECK constraint rejects a notification_type not in the catalog
+SELECT throws_ok(
+  $$INSERT INTO notification_channel_settings (restaurant_id, notification_type)
+    VALUES ('c9000000-0000-0000-0000-000000000001', 'not_a_real_type')$$,
+  '23514',
+  NULL,
+  'CHECK constraint should reject an unknown notification_type'
+);
+
+-- Test 9: updated_at trigger advances on UPDATE. NOW() is transaction-scoped in
+-- Postgres (constant for the whole test transaction), so comparing updated_at to
+-- created_at (both defaulted via NOW() at insert time) would never show a
+-- difference. Instead, force updated_at to a sentinel past value at INSERT
+-- (bypassing the BEFORE UPDATE trigger), then verify the trigger overwrites it
+-- on UPDATE.
+INSERT INTO notification_channel_settings (id, restaurant_id, notification_type, updated_at)
+VALUES ('c9000000-0000-0000-0000-100000000009', 'c9000000-0000-0000-0000-000000000001', 'availability_reminder', '2000-01-01T00:00:00Z');
+
+UPDATE notification_channel_settings
+  SET email_enabled = false
+  WHERE id = 'c9000000-0000-0000-0000-100000000009';
+
+SELECT isnt(
+  (SELECT updated_at FROM notification_channel_settings WHERE id = 'c9000000-0000-0000-0000-100000000009'),
+  '2000-01-01T00:00:00Z'::timestamptz,
+  'updated_at trigger should overwrite the sentinel value on UPDATE'
+);
+
+-- ============================================================================
+-- TEST CATEGORY 3: RLS (Tests 10-16)
+-- ============================================================================
+
+INSERT INTO auth.users (id, instance_id, aud, role, email, encrypted_password, email_confirmed_at, created_at, updated_at, confirmation_token, recovery_token, email_change_token_new, email_change)
+VALUES
+  ('c9000000-0000-0000-0000-000000000010', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'notifchannel_owner@test.com', crypt('password123', gen_salt('bf')), now(), now(), now(), '', '', '', ''),
+  ('c9000000-0000-0000-0000-000000000020', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'notifchannel_staff@test.com', crypt('password123', gen_salt('bf')), now(), now(), now(), '', '', '', ''),
+  ('c9000000-0000-0000-0000-000000000030', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'notifchannel_nonmember@test.com', crypt('password123', gen_salt('bf')), now(), now(), now(), '', '', '', '')
+ON CONFLICT (id) DO NOTHING;
+
+-- User 10 = owner of restaurant 1
+-- User 20 = staff of restaurant 1
+-- User 30 = no memberships (non-member)
+INSERT INTO user_restaurants (user_id, restaurant_id, role) VALUES
+  ('c9000000-0000-0000-0000-000000000010', 'c9000000-0000-0000-0000-000000000001', 'owner'),
+  ('c9000000-0000-0000-0000-000000000020', 'c9000000-0000-0000-0000-000000000001', 'staff')
+ON CONFLICT (user_id, restaurant_id) DO NOTHING;
+
+-- A row on restaurant 2 that none of our test users belong to (for cross-restaurant isolation)
+INSERT INTO notification_channel_settings (id, restaurant_id, notification_type)
+VALUES ('c9000000-0000-0000-0000-100000000002', 'c9000000-0000-0000-0000-000000000002', 'pin_reset')
+ON CONFLICT (id) DO NOTHING;
+
+ALTER TABLE notification_channel_settings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE notification_settings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE restaurants ENABLE ROW LEVEL SECURITY;
+ALTER TABLE user_restaurants ENABLE ROW LEVEL SECURITY;
+
+-- Test 10: Owner CAN SELECT their restaurant's settings
+SET LOCAL role TO authenticated;
+SET LOCAL "request.jwt.claims" TO '{"sub": "c9000000-0000-0000-0000-000000000010", "role": "authenticated"}';
+
+SELECT is(
+  (SELECT COUNT(*) FROM notification_channel_settings WHERE restaurant_id = 'c9000000-0000-0000-0000-000000000001' AND notification_type = 'pin_reset'),
+  1::bigint,
+  'Owner should be able to SELECT their restaurant notification channel settings'
+);
+
+-- Test 11: Staff CAN SELECT their restaurant's settings (view-only)
+SET LOCAL role TO authenticated;
+SET LOCAL "request.jwt.claims" TO '{"sub": "c9000000-0000-0000-0000-000000000020", "role": "authenticated"}';
+
+SELECT is(
+  (SELECT COUNT(*) FROM notification_channel_settings WHERE restaurant_id = 'c9000000-0000-0000-0000-000000000001' AND notification_type = 'pin_reset'),
+  1::bigint,
+  'Staff should be able to SELECT their restaurant notification channel settings'
+);
+
+-- Test 12: Non-member CANNOT SELECT any row (cross-restaurant isolation from the outside)
+SET LOCAL role TO authenticated;
+SET LOCAL "request.jwt.claims" TO '{"sub": "c9000000-0000-0000-0000-000000000030", "role": "authenticated"}';
+
+SELECT is(
+  (SELECT COUNT(*) FROM notification_channel_settings),
+  0::bigint,
+  'Non-member should NOT be able to SELECT any notification channel settings'
+);
+
+-- Test 13: Owner of restaurant 1 does NOT see restaurant 2's row (cross-restaurant isolation)
+SET LOCAL role TO authenticated;
+SET LOCAL "request.jwt.claims" TO '{"sub": "c9000000-0000-0000-0000-000000000010", "role": "authenticated"}';
+
+SELECT is(
+  (SELECT COUNT(*) FROM notification_channel_settings WHERE restaurant_id = 'c9000000-0000-0000-0000-000000000002'),
+  0::bigint,
+  'Owner of restaurant 1 should NOT see restaurant 2 notification channel settings'
+);
+
+-- Test 14: Owner CAN INSERT for their restaurant
+SELECT lives_ok(
+  $$INSERT INTO notification_channel_settings (restaurant_id, notification_type, email_enabled)
+    VALUES ('c9000000-0000-0000-0000-000000000001', 'team_invite', false)$$,
+  'Owner should be able to INSERT notification channel settings for their restaurant'
+);
+
+-- Test 15: Owner CAN UPDATE for their restaurant
+SELECT lives_ok(
+  $$UPDATE notification_channel_settings SET email_enabled = true
+    WHERE restaurant_id = 'c9000000-0000-0000-0000-000000000001' AND notification_type = 'team_invite'$$,
+  'Owner should be able to UPDATE notification channel settings for their restaurant'
+);
+
+-- Test 16: Staff CANNOT INSERT (RLS blocks non-owner/manager writes)
+SET LOCAL role TO authenticated;
+SET LOCAL "request.jwt.claims" TO '{"sub": "c9000000-0000-0000-0000-000000000020", "role": "authenticated"}';
+
+SELECT throws_ok(
+  $$INSERT INTO notification_channel_settings (restaurant_id, notification_type)
+    VALUES ('c9000000-0000-0000-0000-000000000001', 'availability_reminder')$$,
+  '42501',
+  NULL,
+  'Staff should NOT be able to INSERT notification channel settings'
+);
+
+-- ============================================================================
+-- TEST CATEGORY 4: Data-migration backfill from legacy notification_settings
+-- (Tests 17-20)
+--
+-- The migration's real INSERT..SELECT ran once, at apply-time, against whatever
+-- notification_settings rows existed then (none, on a fresh db:reset). To verify
+-- the backfill SQL itself is correct, these tests re-run the exact same
+-- statement shape against fresh fixture rows created inside this transaction.
+-- Keep this in sync with the data-migration block in
+-- 20260719120000_notification_channel_settings.sql.
+-- ============================================================================
+
+SET LOCAL role TO postgres;
+ALTER TABLE notification_channel_settings DISABLE ROW LEVEL SECURITY;
+ALTER TABLE notification_settings DISABLE ROW LEVEL SECURITY;
+
+-- Restaurant 3: legacy row with an explicit false toggle and a NULL toggle.
+-- notify_shift_created/modified are nullable (added via a later ALTER TABLE with
+-- no NOT NULL); the time_off_* columns are NOT NULL DEFAULT true from the
+-- original table, so the NULL/COALESCE case must be exercised on a shift column.
+INSERT INTO notification_settings (restaurant_id, notify_shift_created, notify_shift_modified)
+VALUES ('c9000000-0000-0000-0000-000000000003', false, NULL)
+ON CONFLICT (restaurant_id) DO UPDATE SET notify_shift_created = false, notify_shift_modified = NULL;
+
+-- Pre-seed a channel row for restaurant 3 / time_off_rejected so ON CONFLICT DO
+-- NOTHING can be verified not to clobber it.
+INSERT INTO notification_channel_settings (restaurant_id, notification_type, email_enabled, push_enabled)
+VALUES ('c9000000-0000-0000-0000-000000000003', 'time_off_rejected', false, false)
+ON CONFLICT (restaurant_id, notification_type) DO NOTHING;
+
+-- Re-run the migration's backfill statement (6 legacy-gated types) against the
+-- fixtures above.
+INSERT INTO notification_channel_settings (restaurant_id, notification_type, email_enabled, push_enabled)
+SELECT restaurant_id, 'shift_created', COALESCE(notify_shift_created, true), COALESCE(notify_shift_created, true)
+FROM notification_settings WHERE restaurant_id = 'c9000000-0000-0000-0000-000000000003'
+UNION ALL
+SELECT restaurant_id, 'shift_modified', COALESCE(notify_shift_modified, true), COALESCE(notify_shift_modified, true)
+FROM notification_settings WHERE restaurant_id = 'c9000000-0000-0000-0000-000000000003'
+UNION ALL
+SELECT restaurant_id, 'shift_deleted', COALESCE(notify_shift_deleted, true), COALESCE(notify_shift_deleted, true)
+FROM notification_settings WHERE restaurant_id = 'c9000000-0000-0000-0000-000000000003'
+UNION ALL
+SELECT restaurant_id, 'time_off_requested', COALESCE(notify_time_off_request, true), COALESCE(notify_time_off_request, true)
+FROM notification_settings WHERE restaurant_id = 'c9000000-0000-0000-0000-000000000003'
+UNION ALL
+SELECT restaurant_id, 'time_off_approved', COALESCE(notify_time_off_approved, true), COALESCE(notify_time_off_approved, true)
+FROM notification_settings WHERE restaurant_id = 'c9000000-0000-0000-0000-000000000003'
+UNION ALL
+SELECT restaurant_id, 'time_off_rejected', COALESCE(notify_time_off_rejected, true), COALESCE(notify_time_off_rejected, true)
+FROM notification_settings WHERE restaurant_id = 'c9000000-0000-0000-0000-000000000003'
+ON CONFLICT (restaurant_id, notification_type) DO NOTHING;
+
+-- Test 17: A `false` legacy toggle (notify_shift_created) migrates to BOTH
+-- channels off.
+SELECT is(
+  ROW((SELECT email_enabled FROM notification_channel_settings WHERE restaurant_id = 'c9000000-0000-0000-0000-000000000003' AND notification_type = 'shift_created'),
+      (SELECT push_enabled FROM notification_channel_settings WHERE restaurant_id = 'c9000000-0000-0000-0000-000000000003' AND notification_type = 'shift_created')),
+  ROW(false, false),
+  'A false legacy toggle should migrate to email_enabled=false AND push_enabled=false'
+);
+
+-- Test 18: A NULL legacy toggle (notify_shift_modified) migrates to BOTH
+-- channels on (COALESCE fail-open).
+SELECT is(
+  ROW((SELECT email_enabled FROM notification_channel_settings WHERE restaurant_id = 'c9000000-0000-0000-0000-000000000003' AND notification_type = 'shift_modified'),
+      (SELECT push_enabled FROM notification_channel_settings WHERE restaurant_id = 'c9000000-0000-0000-0000-000000000003' AND notification_type = 'shift_modified')),
+  ROW(true, true),
+  'A NULL legacy toggle should COALESCE to email_enabled=true AND push_enabled=true'
+);
+
+-- Test 19: A legacy column with its default true (notify_time_off_approved,
+-- never touched) migrates to both channels on.
+SELECT is(
+  ROW((SELECT email_enabled FROM notification_channel_settings WHERE restaurant_id = 'c9000000-0000-0000-0000-000000000003' AND notification_type = 'time_off_approved'),
+      (SELECT push_enabled FROM notification_channel_settings WHERE restaurant_id = 'c9000000-0000-0000-0000-000000000003' AND notification_type = 'time_off_approved')),
+  ROW(true, true),
+  'A true (default) legacy toggle should migrate to both channels on'
+);
+
+-- Test 20: ON CONFLICT DO NOTHING does not clobber a pre-existing target row.
+SELECT is(
+  ROW((SELECT email_enabled FROM notification_channel_settings WHERE restaurant_id = 'c9000000-0000-0000-0000-000000000003' AND notification_type = 'time_off_rejected'),
+      (SELECT push_enabled FROM notification_channel_settings WHERE restaurant_id = 'c9000000-0000-0000-0000-000000000003' AND notification_type = 'time_off_rejected')),
+  ROW(false, false),
+  'ON CONFLICT DO NOTHING should not overwrite a pre-existing notification_channel_settings row'
+);
+
+-- ============================================================================
+-- Cleanup
+-- ============================================================================
+SELECT * FROM finish();
+ROLLBACK;

--- a/tests/unit/NotificationChannelMatrix.test.tsx
+++ b/tests/unit/NotificationChannelMatrix.test.tsx
@@ -19,7 +19,7 @@ function allOnMap() {
   return map;
 }
 
-const saveChangesMock = vi.fn().mockResolvedValue(undefined);
+const setChannelMock = vi.fn();
 const refetchMock = vi.fn();
 
 function mockHookReturn(overrides: Partial<ReturnType<typeof hookMock>> = {}) {
@@ -29,7 +29,7 @@ function mockHookReturn(overrides: Partial<ReturnType<typeof hookMock>> = {}) {
     isError: false,
     error: null,
     refetch: refetchMock,
-    saveChanges: saveChangesMock,
+    setChannel: setChannelMock,
     isSaving: false,
     ...overrides,
   });
@@ -38,7 +38,6 @@ function mockHookReturn(overrides: Partial<ReturnType<typeof hookMock>> = {}) {
 describe('NotificationChannelMatrix', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    saveChangesMock.mockResolvedValue(undefined);
   });
 
   it('shows a loading skeleton while the query is in flight (never a silent all-ON table)', () => {
@@ -60,16 +59,35 @@ describe('NotificationChannelMatrix', () => {
     expect(refetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it('renders every catalog type grouped into its own table, one row per type', () => {
+  it('renders a single aligned table with visible Email and Push column headers', () => {
+    mockHookReturn();
+    render(<NotificationChannelMatrix restaurantId="rest-1" />);
+
+    // One table for all groups (so the toggle columns line up across sections),
+    // not one table per group.
+    expect(screen.getAllByRole('table')).toHaveLength(1);
+
+    // The channel columns are labelled visibly (not sr-only) so an admin knows
+    // which toggle turns on which delivery method.
+    expect(screen.getByRole('columnheader', { name: /notification/i })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: /email/i })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: /push/i })).toBeInTheDocument();
+  });
+
+  it('renders a labelled section header for every catalog group, and one row per type', () => {
     mockHookReturn();
     render(<NotificationChannelMatrix restaurantId="rest-1" />);
 
     const groups = new Set(NOTIFICATION_TYPES.map((t) => t.group));
-    const tables = screen.getAllByRole('table');
-    expect(tables).toHaveLength(groups.size);
+    for (const group of groups) {
+      // Group headers span the row as a colgroup <th>.
+      expect(
+        screen.getByRole('columnheader', { name: new RegExp(`^${group}$`, 'i') }),
+      ).toBeInTheDocument();
+    }
 
     for (const type of NOTIFICATION_TYPES) {
-      expect(screen.getByText(type.label)).toBeInTheDocument();
+      expect(screen.getByRole('rowheader', { name: type.label })).toBeInTheDocument();
     }
   });
 
@@ -79,61 +97,50 @@ describe('NotificationChannelMatrix', () => {
 
     // time_off_requested is email-only per the catalog — its Push cell must
     // not expose a live switch.
-    const timeOffRow = screen.getByText('Time off requested').closest('tr')!;
+    const timeOffRow = screen.getByRole('rowheader', { name: 'Time off requested' }).closest('tr')!;
     expect(within(timeOffRow).queryByRole('switch', { name: /push/i })).not.toBeInTheDocument();
     expect(within(timeOffRow).getByRole('switch', { name: /email/i })).toBeInTheDocument();
   });
 
-  it('toggling a switch and clicking Save calls saveChanges with only the changed row (diff-based)', async () => {
+  it('toggling a switch saves that one channel immediately — no Save button in the UI', () => {
     mockHookReturn();
     render(<NotificationChannelMatrix restaurantId="rest-1" />);
 
-    const shiftDeletedRow = screen.getByText('Shift deleted').closest('tr')!;
+    // Immediate-save: there is no Save/Reset footer to click.
+    expect(screen.queryByRole('button', { name: /^save$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /reset/i })).not.toBeInTheDocument();
+
+    const shiftDeletedRow = screen.getByRole('rowheader', { name: 'Shift deleted' }).closest('tr')!;
     const pushSwitch = within(shiftDeletedRow).getByRole('switch', { name: /push/i });
     fireEvent.click(pushSwitch);
 
-    const saveButton = await screen.findByRole('button', { name: /^save$/i });
-    fireEvent.click(saveButton);
-
-    expect(saveChangesMock).toHaveBeenCalledTimes(1);
-    const [passedMap] = saveChangesMock.mock.calls[0];
-    expect(passedMap.get('shift_deleted')).toEqual({ email: true, push: false });
-    // Everything else stays untouched in the payload the component builds.
-    expect(passedMap.get('pin_reset')).toEqual({ email: true, push: true });
+    // Currently ON → the flip persists just this (type, channel) as OFF.
+    expect(setChannelMock).toHaveBeenCalledTimes(1);
+    expect(setChannelMock).toHaveBeenCalledWith('shift_deleted', 'push', false);
   });
 
-  it('hasChanges (Save/Reset footer) is driven by value comparison, not toggle-count', () => {
-    mockHookReturn();
+  it('reflects the value straight from the hook (no local edit state to drift)', () => {
+    const map = allOnMap();
+    map.set('shift_deleted', { email: true, push: false });
+    mockHookReturn({ settings: map });
     render(<NotificationChannelMatrix restaurantId="rest-1" />);
 
-    // No footer until something actually differs from the server snapshot.
-    expect(screen.queryByRole('button', { name: /^save$/i })).not.toBeInTheDocument();
-
-    const shiftDeletedRow = screen.getByText('Shift deleted').closest('tr')!;
-    const pushSwitch = within(shiftDeletedRow).getByRole('switch', { name: /push/i });
-
-    fireEvent.click(pushSwitch);
-    expect(screen.getByRole('button', { name: /^save$/i })).toBeInTheDocument();
-
-    // Flip it back — value now matches the snapshot again, footer should hide.
-    fireEvent.click(pushSwitch);
-    expect(screen.queryByRole('button', { name: /^save$/i })).not.toBeInTheDocument();
-  });
-
-  it('Reset discards local edits back to the fetched snapshot', () => {
-    mockHookReturn();
-    render(<NotificationChannelMatrix restaurantId="rest-1" />);
-
-    const shiftDeletedRow = screen.getByText('Shift deleted').closest('tr')!;
-    const pushSwitch = within(shiftDeletedRow).getByRole('switch', { name: /push/i });
-    fireEvent.click(pushSwitch);
-
-    fireEvent.click(screen.getByRole('button', { name: /reset/i }));
-
-    expect(screen.queryByRole('button', { name: /^save$/i })).not.toBeInTheDocument();
+    const shiftDeletedRow = screen.getByRole('rowheader', { name: 'Shift deleted' }).closest('tr')!;
     expect(within(shiftDeletedRow).getByRole('switch', { name: /push/i })).toHaveAttribute(
+      'data-state',
+      'unchecked',
+    );
+    expect(within(shiftDeletedRow).getByRole('switch', { name: /email/i })).toHaveAttribute(
       'data-state',
       'checked',
     );
+  });
+
+  it('disables the toggles while a save is in flight', () => {
+    mockHookReturn({ isSaving: true });
+    render(<NotificationChannelMatrix restaurantId="rest-1" />);
+
+    const shiftDeletedRow = screen.getByRole('rowheader', { name: 'Shift deleted' }).closest('tr')!;
+    expect(within(shiftDeletedRow).getByRole('switch', { name: /push/i })).toBeDisabled();
   });
 });

--- a/tests/unit/NotificationChannelMatrix.test.tsx
+++ b/tests/unit/NotificationChannelMatrix.test.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { NOTIFICATION_TYPES } from '@/lib/notificationTypes';
+
+const hookMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/hooks/useNotificationChannelSettings', () => ({
+  useNotificationChannelSettings: hookMock,
+}));
+
+import { NotificationChannelMatrix } from '@/components/NotificationChannelMatrix';
+
+function allOnMap() {
+  const map = new Map<string, { email: boolean; push: boolean }>();
+  for (const type of NOTIFICATION_TYPES) {
+    map.set(type.key, { email: true, push: true });
+  }
+  return map;
+}
+
+const saveChangesMock = vi.fn().mockResolvedValue(undefined);
+const refetchMock = vi.fn();
+
+function mockHookReturn(overrides: Partial<ReturnType<typeof hookMock>> = {}) {
+  hookMock.mockReturnValue({
+    settings: allOnMap(),
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: refetchMock,
+    saveChanges: saveChangesMock,
+    isSaving: false,
+    ...overrides,
+  });
+}
+
+describe('NotificationChannelMatrix', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    saveChangesMock.mockResolvedValue(undefined);
+  });
+
+  it('shows a loading skeleton while the query is in flight (never a silent all-ON table)', () => {
+    mockHookReturn({ isLoading: true, settings: new Map() });
+    render(<NotificationChannelMatrix restaurantId="rest-1" />);
+
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    expect(screen.getByLabelText(/loading notification channel settings/i)).toBeInTheDocument();
+  });
+
+  it('shows a retry banner on error, not a silent all-ON table', () => {
+    mockHookReturn({ isError: true, error: new Error('boom') });
+    render(<NotificationChannelMatrix restaurantId="rest-1" />);
+
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+    expect(refetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders every catalog type grouped into its own table, one row per type', () => {
+    mockHookReturn();
+    render(<NotificationChannelMatrix restaurantId="rest-1" />);
+
+    const groups = new Set(NOTIFICATION_TYPES.map((t) => t.group));
+    const tables = screen.getAllByRole('table');
+    expect(tables).toHaveLength(groups.size);
+
+    for (const type of NOTIFICATION_TYPES) {
+      expect(screen.getByText(type.label)).toBeInTheDocument();
+    }
+  });
+
+  it('renders a dash (no toggle) for a channel a type does not support', () => {
+    mockHookReturn();
+    render(<NotificationChannelMatrix restaurantId="rest-1" />);
+
+    // time_off_requested is email-only per the catalog — its Push cell must
+    // not expose a live switch.
+    const timeOffRow = screen.getByText('Time off requested').closest('tr')!;
+    expect(within(timeOffRow).queryByRole('switch', { name: /push/i })).not.toBeInTheDocument();
+    expect(within(timeOffRow).getByRole('switch', { name: /email/i })).toBeInTheDocument();
+  });
+
+  it('toggling a switch and clicking Save calls saveChanges with only the changed row (diff-based)', async () => {
+    mockHookReturn();
+    render(<NotificationChannelMatrix restaurantId="rest-1" />);
+
+    const shiftDeletedRow = screen.getByText('Shift deleted').closest('tr')!;
+    const pushSwitch = within(shiftDeletedRow).getByRole('switch', { name: /push/i });
+    fireEvent.click(pushSwitch);
+
+    const saveButton = await screen.findByRole('button', { name: /^save$/i });
+    fireEvent.click(saveButton);
+
+    expect(saveChangesMock).toHaveBeenCalledTimes(1);
+    const [passedMap] = saveChangesMock.mock.calls[0];
+    expect(passedMap.get('shift_deleted')).toEqual({ email: true, push: false });
+    // Everything else stays untouched in the payload the component builds.
+    expect(passedMap.get('pin_reset')).toEqual({ email: true, push: true });
+  });
+
+  it('hasChanges (Save/Reset footer) is driven by value comparison, not toggle-count', () => {
+    mockHookReturn();
+    render(<NotificationChannelMatrix restaurantId="rest-1" />);
+
+    // No footer until something actually differs from the server snapshot.
+    expect(screen.queryByRole('button', { name: /^save$/i })).not.toBeInTheDocument();
+
+    const shiftDeletedRow = screen.getByText('Shift deleted').closest('tr')!;
+    const pushSwitch = within(shiftDeletedRow).getByRole('switch', { name: /push/i });
+
+    fireEvent.click(pushSwitch);
+    expect(screen.getByRole('button', { name: /^save$/i })).toBeInTheDocument();
+
+    // Flip it back — value now matches the snapshot again, footer should hide.
+    fireEvent.click(pushSwitch);
+    expect(screen.queryByRole('button', { name: /^save$/i })).not.toBeInTheDocument();
+  });
+
+  it('Reset discards local edits back to the fetched snapshot', () => {
+    mockHookReturn();
+    render(<NotificationChannelMatrix restaurantId="rest-1" />);
+
+    const shiftDeletedRow = screen.getByText('Shift deleted').closest('tr')!;
+    const pushSwitch = within(shiftDeletedRow).getByRole('switch', { name: /push/i });
+    fireEvent.click(pushSwitch);
+
+    fireEvent.click(screen.getByRole('button', { name: /reset/i }));
+
+    expect(screen.queryByRole('button', { name: /^save$/i })).not.toBeInTheDocument();
+    expect(within(shiftDeletedRow).getByRole('switch', { name: /push/i })).toHaveAttribute(
+      'data-state',
+      'checked',
+    );
+  });
+});

--- a/tests/unit/NotificationSettings.test.tsx
+++ b/tests/unit/NotificationSettings.test.tsx
@@ -23,6 +23,26 @@ vi.mock('@/hooks/useNotificationPreferences', () => ({
   }),
 }));
 
+// Returns a referentially-STABLE object (computed once, not re-created per
+// call). NotificationChannelMatrix's sync-guard effect depends on `[settings]`
+// by reference — a mock that returns a fresh `{ settings: new Map(), ... }`
+// literal on every render would make that dependency "change" every render,
+// spinning the component into an infinite render loop (setLocal -> re-render
+// -> new settings reference -> effect fires -> setLocal -> ...).
+const channelSettingsMock = vi.hoisted(() => ({
+  settings: new Map(),
+  isLoading: false,
+  isError: false,
+  error: null,
+  refetch: vi.fn(),
+  saveChanges: vi.fn(),
+  isSaving: false,
+}));
+
+vi.mock('@/hooks/useNotificationChannelSettings', () => ({
+  useNotificationChannelSettings: () => channelSettingsMock,
+}));
+
 import { NotificationSettings } from '@/components/NotificationSettings';
 
 function renderWithClient(ui: React.ReactElement) {

--- a/tests/unit/NotificationSettings.test.tsx
+++ b/tests/unit/NotificationSettings.test.tsx
@@ -33,7 +33,7 @@ vi.mock('@/hooks/useNotificationPreferences', () => ({
 // matrix shows the right restaurant's data after a restaurantId change.
 const channelSettingsByRestaurant = vi.hoisted(() => ({
   'rest-1': {
-    settings: new Map([['team_invite', { email: true, push: false }]]),
+    settings: new Map([['schedule_published', { email: true, push: false }]]),
     isLoading: false,
     isError: false,
     error: null,
@@ -42,7 +42,7 @@ const channelSettingsByRestaurant = vi.hoisted(() => ({
     isSaving: false,
   },
   'rest-2': {
-    settings: new Map([['team_invite', { email: false, push: false }]]),
+    settings: new Map([['schedule_published', { email: false, push: false }]]),
     isLoading: false,
     isError: false,
     error: null,
@@ -165,8 +165,8 @@ describe('NotificationSettings channel matrix restaurant switching', () => {
       </QueryClientProvider>
     );
 
-    // rest-1's team_invite email switch is ON.
-    expect(screen.getByRole('switch', { name: /team invitation — email/i })).toBeChecked();
+    // rest-1's schedule-published email switch is ON.
+    expect(screen.getByRole('switch', { name: /schedule published — email/i })).toBeChecked();
 
     rerender(
       <QueryClientProvider client={client}>
@@ -174,10 +174,10 @@ describe('NotificationSettings channel matrix restaurant switching', () => {
       </QueryClientProvider>
     );
 
-    // rest-2's team_invite email switch is OFF — must reflect immediately,
+    // rest-2's schedule-published email switch is OFF — must reflect immediately,
     // never rest-1's stale ON value (which the missing sync on restaurantId
     // change previously allowed, risking a Save that overwrites rest-2's
     // real settings with rest-1's).
-    expect(screen.getByRole('switch', { name: /team invitation — email/i })).not.toBeChecked();
+    expect(screen.getByRole('switch', { name: /schedule published — email/i })).not.toBeChecked();
   });
 });

--- a/tests/unit/NotificationSettings.test.tsx
+++ b/tests/unit/NotificationSettings.test.tsx
@@ -23,24 +23,39 @@ vi.mock('@/hooks/useNotificationPreferences', () => ({
   }),
 }));
 
-// Returns a referentially-STABLE object (computed once, not re-created per
-// call). NotificationChannelMatrix's sync-guard effect depends on `[settings]`
-// by reference — a mock that returns a fresh `{ settings: new Map(), ... }`
-// literal on every render would make that dependency "change" every render,
-// spinning the component into an infinite render loop (setLocal -> re-render
-// -> new settings reference -> effect fires -> setLocal -> ...).
-const channelSettingsMock = vi.hoisted(() => ({
-  settings: new Map(),
-  isLoading: false,
-  isError: false,
-  error: null,
-  refetch: vi.fn(),
-  saveChanges: vi.fn(),
-  isSaving: false,
+// Returns a referentially-STABLE object per restaurantId (each computed once,
+// not re-created per call). NotificationChannelMatrix's sync-guard effect
+// depends on `[settings]` by reference — a mock that returns a fresh
+// `{ settings: new Map(), ... }` literal on every render would make that
+// dependency "change" every render, spinning the component into an infinite
+// render loop (setLocal -> re-render -> new settings reference -> effect
+// fires -> setLocal -> ...). Keyed by restaurantId so tests can assert the
+// matrix shows the right restaurant's data after a restaurantId change.
+const channelSettingsByRestaurant = vi.hoisted(() => ({
+  'rest-1': {
+    settings: new Map([['team_invite', { email: true, push: false }]]),
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+    saveChanges: vi.fn(),
+    isSaving: false,
+  },
+  'rest-2': {
+    settings: new Map([['team_invite', { email: false, push: false }]]),
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+    saveChanges: vi.fn(),
+    isSaving: false,
+  },
 }));
 
 vi.mock('@/hooks/useNotificationChannelSettings', () => ({
-  useNotificationChannelSettings: () => channelSettingsMock,
+  useNotificationChannelSettings: (restaurantId: string) =>
+    channelSettingsByRestaurant[restaurantId as keyof typeof channelSettingsByRestaurant] ??
+    channelSettingsByRestaurant['rest-1'],
 }));
 
 import { NotificationSettings } from '@/components/NotificationSettings';
@@ -131,5 +146,38 @@ describe('NotificationSettings approver warning', () => {
     renderWithClient(<NotificationSettings restaurantId="rest-1" />);
 
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});
+
+describe('NotificationSettings channel matrix restaurant switching', () => {
+  beforeEach(() => {
+    approverCountMock.mockReset();
+    notificationSettingsMock.mockReset();
+    notificationSettingsMock.mockReturnValue({ settings: baseSettings, loading: false });
+    approverCountMock.mockReturnValue({ data: 2, isLoading: false });
+  });
+
+  it('shows the new restaurant\'s channel settings (not the previous restaurant\'s stale values) when restaurantId changes', () => {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { rerender } = render(
+      <QueryClientProvider client={client}>
+        <NotificationSettings restaurantId="rest-1" />
+      </QueryClientProvider>
+    );
+
+    // rest-1's team_invite email switch is ON.
+    expect(screen.getByRole('switch', { name: /team invitation — email/i })).toBeChecked();
+
+    rerender(
+      <QueryClientProvider client={client}>
+        <NotificationSettings restaurantId="rest-2" />
+      </QueryClientProvider>
+    );
+
+    // rest-2's team_invite email switch is OFF — must reflect immediately,
+    // never rest-1's stale ON value (which the missing sync on restaurantId
+    // change previously allowed, risking a Save that overwrites rest-2's
+    // real settings with rest-1's).
+    expect(screen.getByRole('switch', { name: /team invitation — email/i })).not.toBeChecked();
   });
 });

--- a/tests/unit/NotificationSettings.test.tsx
+++ b/tests/unit/NotificationSettings.test.tsx
@@ -23,14 +23,12 @@ vi.mock('@/hooks/useNotificationPreferences', () => ({
   }),
 }));
 
-// Returns a referentially-STABLE object per restaurantId (each computed once,
-// not re-created per call). NotificationChannelMatrix's sync-guard effect
-// depends on `[settings]` by reference — a mock that returns a fresh
-// `{ settings: new Map(), ... }` literal on every render would make that
-// dependency "change" every render, spinning the component into an infinite
-// render loop (setLocal -> re-render -> new settings reference -> effect
-// fires -> setLocal -> ...). Keyed by restaurantId so tests can assert the
-// matrix shows the right restaurant's data after a restaurantId change.
+// Channel-matrix hook stub, keyed by restaurantId so tests can assert the
+// matrix shows the right restaurant's data after a restaurantId change. The
+// matrix now renders directly from `settings` (immediate optimistic save, no
+// local edit state), so there is no sync effect to loop — a fresh object per
+// call would be harmless, but keying it lets the restaurant-switch test below
+// return distinct values per id.
 const channelSettingsByRestaurant = vi.hoisted(() => ({
   'rest-1': {
     settings: new Map([['schedule_published', { email: true, push: false }]]),
@@ -38,7 +36,7 @@ const channelSettingsByRestaurant = vi.hoisted(() => ({
     isError: false,
     error: null,
     refetch: vi.fn(),
-    saveChanges: vi.fn(),
+    setChannel: vi.fn(),
     isSaving: false,
   },
   'rest-2': {
@@ -47,7 +45,7 @@ const channelSettingsByRestaurant = vi.hoisted(() => ({
     isError: false,
     error: null,
     refetch: vi.fn(),
-    saveChanges: vi.fn(),
+    setChannel: vi.fn(),
     isSaving: false,
   },
 }));
@@ -174,10 +172,9 @@ describe('NotificationSettings channel matrix restaurant switching', () => {
       </QueryClientProvider>
     );
 
-    // rest-2's schedule-published email switch is OFF — must reflect immediately,
-    // never rest-1's stale ON value (which the missing sync on restaurantId
-    // change previously allowed, risking a Save that overwrites rest-2's
-    // real settings with rest-1's).
+    // rest-2's schedule-published email switch is OFF — the matrix reads the
+    // value straight from the hook, so a restaurantId change reflects the new
+    // restaurant's settings immediately (never rest-1's stale ON value).
     expect(screen.getByRole('switch', { name: /schedule published — email/i })).not.toBeChecked();
   });
 });

--- a/tests/unit/availabilityReminderHandler.test.ts
+++ b/tests/unit/availabilityReminderHandler.test.ts
@@ -9,6 +9,18 @@ type FakeClient = {
   from: ReturnType<typeof vi.fn>;
 };
 
+// Default channel-settings response: no row for the restaurant/type, which
+// `resolveChannels` resolves fail-OPEN ({ email: true, push: true }) — matches
+// the pre-Task-3 always-send behavior for every existing test below unless a
+// test overrides this table explicitly.
+function channelSettingsBuilder(row: { email_enabled: boolean; push_enabled: boolean } | null) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue({ data: row, error: null }),
+  };
+}
+
 function makeClient(overrides: Partial<FakeClient> = {}): FakeClient {
   const builder = (rows: unknown, error: unknown = null) => ({
     select: vi.fn().mockReturnThis(),
@@ -40,6 +52,7 @@ function makeClient(overrides: Partial<FakeClient> = {}): FakeClient {
         return fluent;
       }
       if (table === 'restaurants') return builder({ name: "Wetzel's" });
+      if (table === 'notification_channel_settings') return channelSettingsBuilder(null);
       throw new Error(`unexpected table ${table}`);
     }),
     ...overrides,
@@ -246,6 +259,7 @@ describe('processAvailabilityReminder', () => {
           in: vi.fn().mockResolvedValue({ data: null, error: { message: 'db down' } }),
         };
       }
+      if (table === 'notification_channel_settings') return channelSettingsBuilder(null);
       throw new Error(`unexpected table ${table}`);
     });
     const res = await processAvailabilityReminder(
@@ -263,6 +277,86 @@ describe('processAvailabilityReminder', () => {
       },
     );
     expect(res.status).toBe(500);
+  });
+
+  it('sends no emails and reports channel_disabled when the email channel is off', async () => {
+    const client = makeClient();
+    client.from = vi.fn((table: string) => {
+      if (table === 'notification_channel_settings') {
+        return channelSettingsBuilder({ email_enabled: false, push_enabled: true });
+      }
+      return makeClient().from(table);
+    });
+    const sendEmail = vi.fn().mockResolvedValue(true);
+    const res = await processAvailabilityReminder(
+      new Request('https://x', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer x' },
+        body: JSON.stringify({ restaurant_id: 'r1', employee_ids: ['e1', 'e2'] }),
+      }),
+      {
+        createClient: () => client as never,
+        sendEmail,
+        appUrl: 'https://app',
+        resendApiKey: 'k',
+        fromEmail: 'from@x',
+      },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ sent: 0, skipped_no_email: 0, errors: 0, channel_disabled: true });
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  it('still sends when the email channel is explicitly on', async () => {
+    const client = makeClient();
+    client.from = vi.fn((table: string) => {
+      if (table === 'notification_channel_settings') {
+        return channelSettingsBuilder({ email_enabled: true, push_enabled: true });
+      }
+      return makeClient().from(table);
+    });
+    const sendEmail = vi.fn().mockResolvedValue(true);
+    const res = await processAvailabilityReminder(
+      new Request('https://x', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer x' },
+        body: JSON.stringify({ restaurant_id: 'r1', employee_ids: ['e1', 'e2'] }),
+      }),
+      {
+        createClient: () => client as never,
+        sendEmail,
+        appUrl: 'https://app',
+        resendApiKey: 'k',
+        fromEmail: 'from@x',
+      },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ sent: 1, skipped_no_email: 1, errors: 0 });
+    expect(sendEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it('still sends (fail-open) when no channel-settings row exists for the restaurant', async () => {
+    // makeClient()'s default notification_channel_settings response is a missing row.
+    const sendEmail = vi.fn().mockResolvedValue(true);
+    const res = await processAvailabilityReminder(
+      new Request('https://x', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer x' },
+        body: JSON.stringify({ restaurant_id: 'r1', employee_ids: ['e1', 'e2'] }),
+      }),
+      {
+        createClient: () => makeClient() as never,
+        sendEmail,
+        appUrl: 'https://app',
+        resendApiKey: 'k',
+        fromEmail: 'from@x',
+      },
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ sent: 1, skipped_no_email: 1, errors: 0 });
   });
 
   it('returns 500 when an unexpected exception is thrown', async () => {

--- a/tests/unit/notificationActionTypes.test.ts
+++ b/tests/unit/notificationActionTypes.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SHIFT_ACTION_TYPE,
+  TRADE_ACTION_TYPE,
+  TIME_OFF_ACTION_TYPE,
+} from '../../supabase/functions/_shared/notificationActionTypes';
+import { NOTIFICATION_TYPES, type NotificationType } from '../../src/lib/notificationTypes';
+
+const CATALOG_KEYS = new Set<NotificationType>(NOTIFICATION_TYPES.map((t) => t.key));
+const channelsFor = (key: NotificationType) =>
+  NOTIFICATION_TYPES.find((t) => t.key === key)!.channels;
+
+describe('SHIFT_ACTION_TYPE', () => {
+  it('maps all three shift actions to distinct catalog keys', () => {
+    expect(SHIFT_ACTION_TYPE).toEqual({
+      created: 'shift_created',
+      modified: 'shift_modified',
+      deleted: 'shift_deleted',
+    });
+  });
+
+  it('every mapped type is a real catalog key that gates both email and push', () => {
+    for (const type of Object.values(SHIFT_ACTION_TYPE)) {
+      expect(CATALOG_KEYS.has(type)).toBe(true);
+      expect(channelsFor(type)).toEqual(expect.arrayContaining(['email', 'push']));
+    }
+  });
+});
+
+describe('TRADE_ACTION_TYPE', () => {
+  it('maps all five trade actions to distinct catalog keys', () => {
+    expect(TRADE_ACTION_TYPE).toEqual({
+      created: 'shift_trade_created',
+      accepted: 'shift_trade_accepted',
+      approved: 'shift_trade_approved',
+      rejected: 'shift_trade_rejected',
+      cancelled: 'shift_trade_cancelled',
+    });
+  });
+
+  it('every mapped type is a real catalog key that gates both email and push', () => {
+    for (const type of Object.values(TRADE_ACTION_TYPE)) {
+      expect(CATALOG_KEYS.has(type)).toBe(true);
+      expect(channelsFor(type)).toEqual(expect.arrayContaining(['email', 'push']));
+    }
+  });
+});
+
+describe('TIME_OFF_ACTION_TYPE', () => {
+  it('maps all three time-off actions to distinct catalog keys', () => {
+    expect(TIME_OFF_ACTION_TYPE).toEqual({
+      created: 'time_off_requested',
+      approved: 'time_off_approved',
+      rejected: 'time_off_rejected',
+    });
+  });
+
+  it('the "created" (request-submitted) type is email-only, matching the catalog', () => {
+    expect(channelsFor(TIME_OFF_ACTION_TYPE.created)).toEqual(['email']);
+  });
+
+  it('the approved/rejected types gate both email and push', () => {
+    expect(channelsFor(TIME_OFF_ACTION_TYPE.approved)).toEqual(expect.arrayContaining(['email', 'push']));
+    expect(channelsFor(TIME_OFF_ACTION_TYPE.rejected)).toEqual(expect.arrayContaining(['email', 'push']));
+  });
+});

--- a/tests/unit/notificationTypes.test.ts
+++ b/tests/unit/notificationTypes.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { NOTIFICATION_TYPES, type NotificationType, type NotificationChannel } from '../../src/lib/notificationTypes';
+import type { NotificationType as ResolverNotificationType } from '../../supabase/functions/_shared/resolveChannels';
+
+// The resolver's NotificationType union isn't introspectable at runtime, so we
+// hand-maintain a mirror list here purely for the drift check below. If this
+// list and src/lib/notificationTypes.ts diverge, either this test or the
+// exhaustiveness check further down will fail — forcing both files (and the
+// migration's CHECK constraint, reviewed by hand) to be updated together.
+const RESOLVER_TYPES: ResolverNotificationType[] = [
+  'schedule_published',
+  'shift_created',
+  'shift_modified',
+  'shift_deleted',
+  'open_shifts_broadcast',
+  'shift_trade_created',
+  'shift_trade_accepted',
+  'shift_trade_approved',
+  'shift_trade_rejected',
+  'shift_trade_cancelled',
+  'time_off_requested',
+  'time_off_approved',
+  'time_off_rejected',
+  'pin_reset',
+  'team_invite',
+  'availability_reminder',
+];
+
+// Compile-time guard: every catalog key must be assignable to the resolver's
+// union (and vice versa via the mirror list above). If someone adds a key to
+// one file and not the other, this line stops compiling.
+function assertNotificationTypeAssignable(_key: NotificationType): ResolverNotificationType {
+  return _key;
+}
+void assertNotificationTypeAssignable;
+
+describe('NOTIFICATION_TYPES catalog', () => {
+  it('has exactly 16 rows', () => {
+    expect(NOTIFICATION_TYPES).toHaveLength(16);
+  });
+
+  it('has no duplicate keys', () => {
+    const keys = NOTIFICATION_TYPES.map((t) => t.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it('keys exactly match the resolver NotificationType union (drift guard)', () => {
+    const catalogKeys = new Set(NOTIFICATION_TYPES.map((t) => t.key));
+    const resolverKeys = new Set(RESOLVER_TYPES);
+    expect(catalogKeys).toEqual(resolverKeys);
+  });
+
+  it('every row has a non-empty label and a known group', () => {
+    const validGroups = new Set(['Scheduling', 'Trades', 'Time off', 'Access']);
+    for (const t of NOTIFICATION_TYPES) {
+      expect(t.label.length).toBeGreaterThan(0);
+      expect(validGroups.has(t.group)).toBe(true);
+    }
+  });
+
+  it('every row lists at least one channel, and only known channels', () => {
+    const validChannels: NotificationChannel[] = ['email', 'push'];
+    for (const t of NOTIFICATION_TYPES) {
+      expect(t.channels.length).toBeGreaterThan(0);
+      for (const ch of t.channels) {
+        expect(validChannels).toContain(ch);
+      }
+      expect(new Set(t.channels).size).toBe(t.channels.length);
+    }
+  });
+
+  it('email-only types (no push) are exactly time_off_requested, team_invite, availability_reminder', () => {
+    const emailOnly = NOTIFICATION_TYPES.filter((t) => !t.channels.includes('push')).map((t) => t.key).sort();
+    expect(emailOnly).toEqual(['availability_reminder', 'team_invite', 'time_off_requested'].sort());
+  });
+
+  it('every type supports email (no push-only types exist yet)', () => {
+    for (const t of NOTIFICATION_TYPES) {
+      expect(t.channels).toContain('email');
+    }
+  });
+
+  it('does NOT include weekly_brief (per-user preference, out of scope for the admin matrix)', () => {
+    const keys = NOTIFICATION_TYPES.map((t) => t.key);
+    expect(keys).not.toContain('weekly_brief');
+  });
+});

--- a/tests/unit/notificationTypes.test.ts
+++ b/tests/unit/notificationTypes.test.ts
@@ -22,7 +22,6 @@ const RESOLVER_TYPES: ResolverNotificationType[] = [
   'time_off_approved',
   'time_off_rejected',
   'pin_reset',
-  'team_invite',
   'availability_reminder',
 ];
 
@@ -35,8 +34,8 @@ function assertNotificationTypeAssignable(_key: NotificationType): ResolverNotif
 void assertNotificationTypeAssignable;
 
 describe('NOTIFICATION_TYPES catalog', () => {
-  it('has exactly 16 rows', () => {
-    expect(NOTIFICATION_TYPES).toHaveLength(16);
+  it('has exactly 15 rows', () => {
+    expect(NOTIFICATION_TYPES).toHaveLength(15);
   });
 
   it('has no duplicate keys', () => {
@@ -69,9 +68,9 @@ describe('NOTIFICATION_TYPES catalog', () => {
     }
   });
 
-  it('email-only types (no push) are exactly time_off_requested, team_invite, availability_reminder', () => {
+  it('email-only types (no push) are exactly time_off_requested, availability_reminder', () => {
     const emailOnly = NOTIFICATION_TYPES.filter((t) => !t.channels.includes('push')).map((t) => t.key).sort();
-    expect(emailOnly).toEqual(['availability_reminder', 'team_invite', 'time_off_requested'].sort());
+    expect(emailOnly).toEqual(['availability_reminder', 'time_off_requested'].sort());
   });
 
   it('every type supports email (no push-only types exist yet)', () => {

--- a/tests/unit/resolveChannels.test.ts
+++ b/tests/unit/resolveChannels.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+import { resolveChannels, type SupabaseLike } from '../../supabase/functions/_shared/resolveChannels';
+import { NOTIFICATION_TYPES } from '../../src/lib/notificationTypes';
+
+function makeClient(data: { email_enabled: boolean; push_enabled: boolean } | null, error: unknown = null): SupabaseLike {
+  const maybeSingle = vi.fn().mockResolvedValue({ data, error });
+  const eq2 = vi.fn().mockReturnValue({ maybeSingle });
+  const eq1 = vi.fn().mockReturnValue({ eq: eq2 });
+  const select = vi.fn().mockReturnValue({ eq: eq1 });
+  const from = vi.fn().mockReturnValue({ select });
+  return { from } as unknown as SupabaseLike;
+}
+
+describe('resolveChannels', () => {
+  it('returns the row values when a settings row exists with both channels on', async () => {
+    const client = makeClient({ email_enabled: true, push_enabled: true });
+    const result = await resolveChannels(client, 'r1', 'shift_created');
+    expect(result).toEqual({ email: true, push: true });
+  });
+
+  it('returns email off / push on when the row disables only email', async () => {
+    const client = makeClient({ email_enabled: false, push_enabled: true });
+    const result = await resolveChannels(client, 'r1', 'shift_created');
+    expect(result).toEqual({ email: false, push: true });
+  });
+
+  it('returns email on / push off when the row disables only push', async () => {
+    const client = makeClient({ email_enabled: true, push_enabled: false });
+    const result = await resolveChannels(client, 'r1', 'shift_created');
+    expect(result).toEqual({ email: true, push: false });
+  });
+
+  it('returns both off when the row disables both channels', async () => {
+    const client = makeClient({ email_enabled: false, push_enabled: false });
+    const result = await resolveChannels(client, 'r1', 'shift_created');
+    expect(result).toEqual({ email: false, push: false });
+  });
+
+  it('fails OPEN (both true) when no row exists for the restaurant/type', async () => {
+    const client = makeClient(null, null);
+    const result = await resolveChannels(client, 'r1', 'schedule_published');
+    expect(result).toEqual({ email: true, push: true });
+  });
+
+  it('fails OPEN (both true) when the query errors', async () => {
+    const client = makeClient(null, { message: 'db down' });
+    const result = await resolveChannels(client, 'r1', 'schedule_published');
+    expect(result).toEqual({ email: true, push: true });
+  });
+
+  it('queries the composite (restaurant_id, notification_type) key on notification_channel_settings', async () => {
+    const client = makeClient({ email_enabled: true, push_enabled: true });
+    await resolveChannels(client, 'restaurant-42', 'pin_reset');
+
+    expect(client.from).toHaveBeenCalledWith('notification_channel_settings');
+    const fromResult = (client.from as ReturnType<typeof vi.fn>).mock.results[0].value;
+    expect(fromResult.select).toHaveBeenCalledWith('email_enabled, push_enabled');
+    const selectResult = fromResult.select.mock.results[0].value;
+    expect(selectResult.eq).toHaveBeenCalledWith('restaurant_id', 'restaurant-42');
+    const eq1Result = selectResult.eq.mock.results[0].value;
+    expect(eq1Result.eq).toHaveBeenCalledWith('notification_type', 'pin_reset');
+  });
+
+  it('resolves for every catalog type without throwing', async () => {
+    const client = makeClient({ email_enabled: true, push_enabled: true });
+    for (const { key } of NOTIFICATION_TYPES) {
+      await expect(resolveChannels(client, 'r1', key)).resolves.toEqual({ email: true, push: true });
+    }
+  });
+});

--- a/tests/unit/useNotificationChannelSettings.test.ts
+++ b/tests/unit/useNotificationChannelSettings.test.ts
@@ -26,6 +26,16 @@ function buildSelectChain(resolvedValue: { data: unknown; error: unknown }) {
   return chain;
 }
 
+/** A `supabase.from()` return that answers both the initial `.select().eq()`
+ *  read and any `.upsert()` write, so a single `mockReturnValue` covers a
+ *  render that loads settings and then flips a toggle. */
+function buildReadWriteChain(
+  read: { data: unknown; error: unknown },
+  upsertMock: ReturnType<typeof vi.fn>,
+) {
+  return { ...buildSelectChain(read), upsert: upsertMock };
+}
+
 function createWrapper() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
@@ -40,7 +50,7 @@ describe('useNotificationChannelSettings', () => {
     vi.clearAllMocks();
   });
 
-  it('merges an empty row set into a default-ON map for all 16 catalog types', async () => {
+  it('merges an empty row set into a default-ON map for all catalog types', async () => {
     mockSupabase.from.mockReturnValue(buildSelectChain({ data: [], error: null }));
 
     const { result } = renderHook(() => useNotificationChannelSettings('rest-1'), {
@@ -92,10 +102,9 @@ describe('useNotificationChannelSettings', () => {
     expect(result.current.isError).toBe(true);
   });
 
-  it('saveChanges upserts only the rows that differ from the fetched snapshot (diff-based)', async () => {
-    const selectChain = buildSelectChain({ data: [], error: null });
+  it('setChannel upserts the full row for that one type, flipping only the touched channel', async () => {
     const upsertMock = vi.fn().mockResolvedValue({ error: null });
-    mockSupabase.from.mockReturnValue({ ...selectChain, upsert: upsertMock });
+    mockSupabase.from.mockReturnValue(buildReadWriteChain({ data: [], error: null }, upsertMock));
 
     const { result } = renderHook(() => useNotificationChannelSettings('rest-1'), {
       wrapper: createWrapper(),
@@ -103,51 +112,48 @@ describe('useNotificationChannelSettings', () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    const next = new Map(result.current.settings);
-    next.set('shift_deleted', { email: false, push: true });
-
     await act(async () => {
-      await result.current.saveChanges(next);
+      result.current.setChannel('shift_deleted', 'email', false);
     });
 
-    expect(upsertMock).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(upsertMock).toHaveBeenCalledTimes(1));
+    // The untouched `push` channel keeps its current (default-ON) value.
     expect(upsertMock).toHaveBeenCalledWith(
-      [
-        {
-          restaurant_id: 'rest-1',
-          notification_type: 'shift_deleted',
-          email_enabled: false,
-          push_enabled: true,
-        },
-      ],
+      {
+        restaurant_id: 'rest-1',
+        notification_type: 'shift_deleted',
+        email_enabled: false,
+        push_enabled: true,
+      },
       { onConflict: 'restaurant_id,notification_type' },
     );
   });
 
-  it('saveChanges is a no-op (no upsert call) when nothing actually changed', async () => {
-    const selectChain = buildSelectChain({ data: [], error: null });
-    const upsertMock = vi.fn().mockResolvedValue({ error: null });
-    mockSupabase.from.mockReturnValue({ ...selectChain, upsert: upsertMock });
+  it('setChannel updates the cache optimistically so the toggle reflects instantly (before the write resolves)', async () => {
+    // A never-resolving upsert: the optimistic cache update must be visible
+    // without waiting on the network round-trip.
+    const upsertMock = vi.fn().mockReturnValue(new Promise(() => {}));
+    mockSupabase.from.mockReturnValue(buildReadWriteChain({ data: [], error: null }, upsertMock));
 
     const { result } = renderHook(() => useNotificationChannelSettings('rest-1'), {
       wrapper: createWrapper(),
     });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.settings.get('pin_reset')).toEqual({ email: true, push: true });
 
-    const unchanged = new Map(result.current.settings);
-
-    await act(async () => {
-      await result.current.saveChanges(unchanged);
+    act(() => {
+      result.current.setChannel('pin_reset', 'push', false);
     });
 
-    expect(upsertMock).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(result.current.settings.get('pin_reset')).toEqual({ email: true, push: false }),
+    );
   });
 
-  it('a failed save rejects (caller can catch/retry) and reports via toast rather than throwing uncaught', async () => {
-    const selectChain = buildSelectChain({ data: [], error: null });
+  it('a failed setChannel rolls the cache back to its prior value and reports via toast', async () => {
     const upsertMock = vi.fn().mockResolvedValue({ error: { message: 'write failed' } });
-    mockSupabase.from.mockReturnValue({ ...selectChain, upsert: upsertMock });
+    mockSupabase.from.mockReturnValue(buildReadWriteChain({ data: [], error: null }, upsertMock));
 
     const { result } = renderHook(() => useNotificationChannelSettings('rest-1'), {
       wrapper: createWrapper(),
@@ -155,22 +161,17 @@ describe('useNotificationChannelSettings', () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    const next = new Map(result.current.settings);
-    next.set('pin_reset', { email: false, push: false });
-
-    let caught: unknown;
     await act(async () => {
-      try {
-        await result.current.saveChanges(next);
-      } catch (err) {
-        caught = err;
-      }
+      result.current.setChannel('pin_reset', 'email', false);
     });
 
-    expect(caught).toBeTruthy();
     await waitFor(() => expect(mockToast).toHaveBeenCalled());
     expect(mockToast).toHaveBeenCalledWith(
       expect.objectContaining({ variant: 'destructive' }),
+    );
+    // Rolled back to the pre-toggle default-ON value (no silent phantom change).
+    await waitFor(() =>
+      expect(result.current.settings.get('pin_reset')).toEqual({ email: true, push: true }),
     );
   });
 });

--- a/tests/unit/useNotificationChannelSettings.test.ts
+++ b/tests/unit/useNotificationChannelSettings.test.ts
@@ -1,0 +1,176 @@
+import React, { ReactNode } from 'react';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useNotificationChannelSettings } from '@/hooks/useNotificationChannelSettings';
+import { NOTIFICATION_TYPES } from '@/lib/notificationTypes';
+
+const mockSupabase = vi.hoisted(() => ({
+  from: vi.fn(),
+}));
+
+const mockToast = vi.hoisted(() => vi.fn());
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: mockSupabase,
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+function buildSelectChain(resolvedValue: { data: unknown; error: unknown }) {
+  const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+  chain.select = vi.fn().mockReturnValue(chain);
+  chain.eq = vi.fn().mockResolvedValue(resolvedValue);
+  return chain;
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+describe('useNotificationChannelSettings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('merges an empty row set into a default-ON map for all 16 catalog types', async () => {
+    mockSupabase.from.mockReturnValue(buildSelectChain({ data: [], error: null }));
+
+    const { result } = renderHook(() => useNotificationChannelSettings('rest-1'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.settings.size).toBe(NOTIFICATION_TYPES.length);
+    for (const type of NOTIFICATION_TYPES) {
+      expect(result.current.settings.get(type.key)).toEqual({ email: true, push: true });
+    }
+  });
+
+  it('overrides only the types present in the fetched rows, defaults elsewhere', async () => {
+    mockSupabase.from.mockReturnValue(
+      buildSelectChain({
+        data: [
+          { id: 'row-1', notification_type: 'shift_deleted', email_enabled: false, push_enabled: true },
+          { id: 'row-2', notification_type: 'pin_reset', email_enabled: true, push_enabled: false },
+        ],
+        error: null,
+      }),
+    );
+
+    const { result } = renderHook(() => useNotificationChannelSettings('rest-1'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.settings.get('shift_deleted')).toEqual({ email: false, push: true });
+    expect(result.current.settings.get('pin_reset')).toEqual({ email: true, push: false });
+    // Untouched type stays at the default-ON baseline.
+    expect(result.current.settings.get('schedule_published')).toEqual({ email: true, push: true });
+  });
+
+  it('exposes a query error instead of silently falling back to all-ON (never a silent fail-open UI state)', async () => {
+    mockSupabase.from.mockReturnValue(
+      buildSelectChain({ data: null, error: { message: 'DB down' } }),
+    );
+
+    const { result } = renderHook(() => useNotificationChannelSettings('rest-1'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.isError).toBe(true);
+  });
+
+  it('saveChanges upserts only the rows that differ from the fetched snapshot (diff-based)', async () => {
+    const selectChain = buildSelectChain({ data: [], error: null });
+    const upsertMock = vi.fn().mockResolvedValue({ error: null });
+    mockSupabase.from.mockReturnValue({ ...selectChain, upsert: upsertMock });
+
+    const { result } = renderHook(() => useNotificationChannelSettings('rest-1'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const next = new Map(result.current.settings);
+    next.set('shift_deleted', { email: false, push: true });
+
+    await act(async () => {
+      await result.current.saveChanges(next);
+    });
+
+    expect(upsertMock).toHaveBeenCalledTimes(1);
+    expect(upsertMock).toHaveBeenCalledWith(
+      [
+        {
+          restaurant_id: 'rest-1',
+          notification_type: 'shift_deleted',
+          email_enabled: false,
+          push_enabled: true,
+        },
+      ],
+      { onConflict: 'restaurant_id,notification_type' },
+    );
+  });
+
+  it('saveChanges is a no-op (no upsert call) when nothing actually changed', async () => {
+    const selectChain = buildSelectChain({ data: [], error: null });
+    const upsertMock = vi.fn().mockResolvedValue({ error: null });
+    mockSupabase.from.mockReturnValue({ ...selectChain, upsert: upsertMock });
+
+    const { result } = renderHook(() => useNotificationChannelSettings('rest-1'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const unchanged = new Map(result.current.settings);
+
+    await act(async () => {
+      await result.current.saveChanges(unchanged);
+    });
+
+    expect(upsertMock).not.toHaveBeenCalled();
+  });
+
+  it('a failed save rejects (caller can catch/retry) and reports via toast rather than throwing uncaught', async () => {
+    const selectChain = buildSelectChain({ data: [], error: null });
+    const upsertMock = vi.fn().mockResolvedValue({ error: { message: 'write failed' } });
+    mockSupabase.from.mockReturnValue({ ...selectChain, upsert: upsertMock });
+
+    const { result } = renderHook(() => useNotificationChannelSettings('rest-1'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const next = new Map(result.current.settings);
+    next.set('pin_reset', { email: false, push: false });
+
+    let caught: unknown;
+    await act(async () => {
+      try {
+        await result.current.saveChanges(next);
+      } catch (err) {
+        caught = err;
+      }
+    });
+
+    expect(caught).toBeTruthy();
+    await waitFor(() => expect(mockToast).toHaveBeenCalled());
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: 'destructive' }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Admin **per-notification-type × per-channel** (Email / Push) settings — one place where an owner/manager controls which notifications go out over which channel. Every visible toggle is live.

- **New table** `notification_channel_settings` (restaurant_id, notification_type, email_enabled, push_enabled) with **admin-only RLS** (owner/manager), an `updated_at` trigger, and a `CHECK` on the 15 types. **Absent row ⇒ both channels ON** (fail-open — no restaurant goes dark).
- **Data migration** seeds rows from the legacy `notification_settings` booleans (`COALESCE(..., true)`) so existing off-toggles are preserved.
- **Shared `resolveChannels()` resolver** — every notification function now gates **email and push independently** through it, replacing the old scattered single-boolean gates.
- **Retrofit** of all firing functions: schedule-published, shift created/modified/deleted, shift-trade ×5, open-shift broadcast, time-off ×3, pin-reset, availability-reminder.
- **Admin matrix UI** in Settings → Notifications (grouped accessible `<table>`, per-channel toggles, diff-based Save, edit-safe against refetch, mobile-checked). The legacy time-off toggles are **retired** (now governed by the matrix).
- **`team_invite` excluded** (design decision): a team-invitation email is transactional — it carries the only copy of the accept link (token hashed/unrecoverable), so it always sends and is not admin-toggleable.

## Notable fixes from review
- Cross-tenant guard: switching restaurants in the matrix could show/save the wrong restaurant's values — fixed with a remount-on-restaurant-change + regression test.
- `team_invite` transactional exemption (above).

## Test plan
- pgTAP `62_notification_channel_settings_rls.sql` (RLS: staff read-only, owner/manager write, cross-restaurant isolation, data-migration preserves choices, CHECK rejects bad type). **1718/1718 pgTAP pass.**
- Unit: resolver (fail-open), catalog↔resolver sync guard, hook (diff-upsert, default-ON merge), matrix component, restaurant-switch remount. **Full vitest 6395 pass.** typecheck ✅, build ✅.

## Follow-ups
- "Invite by link / copy link" affordance (if email should ever be optional for invites).
- Per-employee channel overrides; unify web-push vs legacy FCM; drop legacy notification_settings columns after a soak.

## Design
docs/superpowers/specs/2026-07-13-notification-channel-matrix-design.md
