### PR TITLE
feat(focus): preserve voids as auditable negative offsets (net-out + countable)

### DIFF
--- a/docs/superpowers/plans/2026-07-12-focus-preserve-voids-plan.md
+++ b/docs/superpowers/plans/2026-07-12-focus-preserve-voids-plan.md
@@ -1,0 +1,53 @@
+# Plan: preserve Focus voids as auditable negative offsets
+
+Design: `docs/superpowers/specs/2026-07-12-focus-preserve-voids-design.md`
+Branch: `fix/focus-preserve-voids`
+
+## Task 1 — Handler: soft-delete on DeleteRecord (unit-tested)
+- **RED** (`tests/unit/focusTransactionSyncHandler.test.ts`): a datafeed with a
+  `<DeleteRecord>` for check X drives `focus_orders.update({ is_voided:true,
+  voided_at:<iso> })` scoped to restaurant+business_date+focus_check_id — assert
+  `.update` called with those args and **`.delete` NOT called**.
+- **GREEN** (`focusTransactionSyncHandler.ts`): replace the DeleteRecord
+  `.delete()` loop with the `.update({is_voided,voided_at})` version (keep the
+  `voidMarkFailed`→don't-record-fingerprint retry semantics; rename var).
+- **Files:** handler + its test. **Dep:** none.
+
+## Task 2 — Migration: focus_orders columns + RPC void branch (pgTAP)
+- **Pre-flight:** re-pull `pg_get_functiondef` of `_impl`; assert it contains
+  `apply_rules_to_pos_sales_internal` and not `auth.uid()`; re-check the newest
+  migration timestamp (use `20260713020000`, after `20260713010000_harden_…`).
+- **RED** (`supabase/tests/47_focus_transactions_unified_sales.sql`, plan +N):
+  seed order C (priced item → sale + payment tip + item discount + tax_amount)
+  and a **user split row** under it; sync → assert its 4 row kinds exist. Set
+  `focus_orders.is_voided=true` for C; re-run
+  `sync_focus_transactions_to_unified_sales(r,d,d)`; assert:
+  - C's `sale`/`tip`/`discount`/`tax` rows (parent_sale_id IS NULL) are **gone**;
+  - exactly **one** `adjustment_type='void'` row for C with `total_price =
+    -SUM(priced items)`;
+  - the **split row survives**; a **sibling order untouched**;
+  - `revenue` (`item_type='sale' AND adjustment_type IS NULL`) dropped by C's
+    amount; `SUM(total_price) WHERE adjustment_type='void'` = negated revenue.
+  Run against pre-migration state → confirm FAIL.
+- **GREEN** (`supabase/migrations/20260713020000_focus_preserve_voids.sql`):
+  1. `ALTER TABLE focus_orders ADD is_voided boolean NOT NULL DEFAULT false,
+     ADD voided_at timestamptz;`
+  2. `CREATE OR REPLACE _impl(...)` = live body + `fo.is_voided` in the loop
+     SELECT + the `IF v_order.is_voided THEN <delete revenue rows + upsert one
+     _void offset> ELSE <existing Steps 1–6 + parent_sale_id-guarded stale-void
+     cleanup> END IF;`
+  3. `REVOKE ALL … FROM PUBLIC; GRANT EXECUTE … TO service_role;`
+  Apply locally; re-run test 47 → all GREEN.
+- **Dep:** Task 1 (semantics), but migration is independent to author.
+
+## Task 3 — Verify + follow-ups
+- `npm run test` (handler unit), `npm run test:db` (fresh `db:reset`),
+  `typecheck`, lint.
+- File follow-up chips: legacy hard-deleted-orphan cleanup; tighten the
+  permissive `adjustment_type` CHECK; focus_order_items/payments retention;
+  (Voids report UI already a chip via earlier scope Q).
+
+## Notes
+- No UI changes → Phase 5 skipped.
+- Read layer verified: `void` excluded from revenue/discount/pass-through — no
+  consumer changes.

--- a/docs/superpowers/plans/2026-07-12-focus-preserve-voids-plan.md
+++ b/docs/superpowers/plans/2026-07-12-focus-preserve-voids-plan.md
@@ -25,7 +25,8 @@ Branch: `fix/focus-preserve-voids`
   - C's `sale`/`tip`/`discount`/`tax` rows (parent_sale_id IS NULL) are **gone**;
   - exactly **one** `adjustment_type='void'` row for C with `total_price =
     -SUM(priced items)`;
-  - the **split row survives**; a **sibling order untouched**;
+  - the **split child is also removed** (whole check gone); a **sibling order
+    untouched**;
   - `revenue` (`item_type='sale' AND adjustment_type IS NULL`) dropped by C's
     amount; `SUM(total_price) WHERE adjustment_type='void'` = negated revenue.
   Run against pre-migration state → confirm FAIL.

--- a/docs/superpowers/specs/2026-07-12-focus-preserve-voids-design.md
+++ b/docs/superpowers/specs/2026-07-12-focus-preserve-voids-design.md
@@ -87,10 +87,13 @@ Final aggregate: unchanged two-source UNION already re-aggregates every
 processed date (voided orders still appear in the `focus_orders` date-range
 branch), so daily totals reflect the removed revenue.
 
-### 4. Void representation (Toast-consistent, verified safe)
-`item_type='discount'`, `adjustment_type='void'`, `total_price` negative. Safe
-because revenue keys on `item_type='sale'`, discounts/pass-through on
-`adjustment_type` — none of which match `void`. Counting voids:
+### 4. Void representation (verified safe)
+`item_type='other'`, `adjustment_type='void'`, `total_price` negative. The
+meaningful, Toast-consistent identifier is `adjustment_type='void'`; `item_type`
+is `'other'` (not Toast's `'discount'`) because a void is not a discount and
+`'discount'` collides with `item_type='discount'` consumers. Safe because
+revenue keys on `item_type='sale'`, discounts/pass-through on `adjustment_type`
+— none of which match `void`/`other`. Counting voids:
 `SELECT count(*), SUM(-total_price) FROM unified_sales WHERE adjustment_type='void'`
 or `SELECT count(*), SUM(total) FROM focus_orders WHERE is_voided`.
 
@@ -100,8 +103,11 @@ or `SELECT count(*), SUM(total) FROM focus_orders WHERE is_voided`.
   countable void marker).
 - Re-sync of a voided order → idempotent (revenue rows already gone, void row
   UPSERTed).
-- User split rows (`parent_sale_id NOT NULL`) preserved by the `parent_sale_id
-  IS NULL` guard on every delete, as elsewhere.
+- **User split rows are removed** when their order is voided — a void removes
+  the whole check. The `parent_sale_id IS NULL` guard still protects splits in
+  the **non-void** Steps 2/4/5/6 (routine re-sync must not clobber user splits),
+  but the void branch deliberately omits it (whole-check removal, FK-safe single
+  delete). The routine-sync split-preservation guard is covered by its own test.
 
 ## Migration & safety
 - New `supabase/migrations/20260713020000_focus_preserve_voids.sql` — timestamp
@@ -116,12 +122,13 @@ or `SELECT count(*), SUM(total) FROM focus_orders WHERE is_voided`.
 
 ## Testing
 - **pgTAP** (`supabase/tests/47_focus_transactions_unified_sales.sql`): seed
-  order C (sale+tip+discount+tax) + a user split row; sync → rows exist. Set
-  `focus_orders.is_voided=true`; re-sync → C's sale/tip/discount/tax rows gone,
-  **one `adjustment_type='void'` row present with negative `total_price`**, the
-  **split row survives**, a **sibling order untouched**; assert
-  `SUM(total_price) WHERE adjustment_type='void'` equals the negated revenue and
-  revenue (`item_type='sale' AND adjustment_type IS NULL`) drops accordingly.
+  order C (sale+tip+discount+tax) + a user split row under it; sync → rows
+  exist. Set `focus_orders.is_voided=true`; re-sync → C's sale/tip/discount/tax
+  rows gone, **its split child also gone** (whole check removed), **one
+  `adjustment_type='void'` row present with negative `total_price`**, a **sibling
+  order untouched**; assert `SUM(total_price) WHERE adjustment_type='void'`
+  equals the negated revenue and revenue (`item_type='sale' AND adjustment_type
+  IS NULL`) drops accordingly.
 - **Unit** (`tests/unit/focusTransactionSyncHandler.test.ts`): a `<DeleteRecord>`
   drives an `update({is_voided:true})` on focus_orders, **not** a `.delete()`.
 

--- a/docs/superpowers/specs/2026-07-12-focus-preserve-voids-design.md
+++ b/docs/superpowers/specs/2026-07-12-focus-preserve-voids-design.md
@@ -1,0 +1,115 @@
+# Design: preserve Focus voids as auditable negative offsets
+
+**Date:** 2026-07-12
+**Branch:** `fix/focus-preserve-voids`
+
+## Problem
+
+Focus voids arrive as check-level `<DeleteRecord>` entries. Today
+`focusTransactionSyncHandler.ts:357` **hard-deletes** the check from
+`focus_orders` (CASCADE removes items/payments), and the sync RPC leaves the
+check's `unified_sales` rows **orphaned** (they inflate revenue/tax forever —
+Codex, PR #600). Net effect: voided sales silently vanish from the source data,
+there is **no void audit trail** (you can't count voids or their $), and
+existing rows orphan.
+
+**Decision (user):** preserve voids with the **full, Toast-consistent** model —
+soft-delete + a negative `void` offset row in `unified_sales` so voids net out
+of revenue *and* stay countable/reportable.
+
+## Read-layer facts (verified)
+- **Revenue** sums `item_type='sale' AND adjustment_type IS NULL`
+  (`20260501120000`, `20260501130100`).
+- **Discounts** sum `adjustment_type='discount'`; **pass-through** sums an
+  enumerated `adjustment_type IN ('tax','tip','service_charge','discount','fee')`
+  (`KNOWN_PASS_THROUGH_TYPES`, `20260501130000`).
+- ⇒ A row with **`adjustment_type='void'`** is excluded from revenue,
+  discounts, and pass-through automatically. No read-layer change required.
+
+## Design
+
+### 1. Schema (migration)
+- `ALTER TABLE public.focus_orders ADD COLUMN IF NOT EXISTS is_voided boolean
+  NOT NULL DEFAULT false, ADD COLUMN IF NOT EXISTS voided_at timestamptz;`
+- Extend `unified_sales_adjustment_type_check` to add `'void'` (drop + re-add
+  with `('tax','tip','service_charge','discount','fee','void',NULL)`). This also
+  **un-breaks Toast's own void path** (`20260211300000` already writes
+  `adjustment_type='void'`, which the current constraint would reject).
+
+### 2. Handler — soft-delete instead of hard-delete
+`focusTransactionSyncHandler.ts` DeleteRecord loop: replace `.delete()` with
+`.update({ is_voided: true, voided_at: <nowIso> })`, same scoping
+(`restaurant_id + business_date + focus_check_id`). Preserves the check + its
+items/payments/tax so the void amount is knowable. The existing
+`voidDeleteFailed`→don't-record-fingerprint retry logic is kept (now
+`voidMarkFailed`). A void for a never-synced check updates 0 rows (no error) →
+simply not recorded (we have no amount); the authoritative day-level count still
+lives on the Focus report's `Voids N / $X` line.
+
+### 3. RPC — branch the per-check loop on `is_voided`
+Rebuild `_sync_focus_transactions_to_unified_sales_impl` from the **live prod
+body** (verified ungated). Add `fo.is_voided` to the loop `SELECT`. Inside the
+loop:
+
+- **`is_voided = true`:**
+  - DELETE this order's revenue rows: `item_type IN ('sale','tip','discount',
+    'tax') AND external_order_id = v_order_id AND parent_sale_id IS NULL`.
+  - UPSERT **one** negative void offset row:
+    `external_item_id = v_order_id || '_void'`, `item_name = 'Void'`,
+    `total_price = -(SELECT COALESCE(SUM(price),0) FROM focus_order_items WHERE …
+    AND price != 0)` (the voided net revenue), `item_type='discount'`,
+    `adjustment_type='void'`, `sale_time = v_sale_time`. `ON CONFLICT … WHERE
+    parent_sale_id IS NULL DO UPDATE`.
+  - Because the order row now still exists, the loop visits it — **this replaces
+    the orphan-sweep** (no separate pre-loop sweep needed) and fixes the bug.
+- **`is_voided = false`:** existing Steps 1–6 (sale/discount/tip/tax), plus a
+  cleanup DELETE of any stale `…_void` row for this order (idempotent un-void).
+
+Final aggregate: unchanged two-source UNION already re-aggregates every
+processed date (voided orders still appear in the `focus_orders` date-range
+branch), so daily totals reflect the removed revenue.
+
+### 4. Void representation (Toast-consistent, verified safe)
+`item_type='discount'`, `adjustment_type='void'`, `total_price` negative. Safe
+because revenue keys on `item_type='sale'`, discounts/pass-through on
+`adjustment_type` — none of which match `void`. Counting voids:
+`SELECT count(*), SUM(-total_price) FROM unified_sales WHERE adjustment_type='void'`
+or `SELECT count(*), SUM(total) FROM focus_orders WHERE is_voided`.
+
+## Edge cases / idempotency
+- Never-synced-then-voided check → 0-row UPDATE, no void row (can't value it).
+- Voided check with no priced items → void offset `total_price = 0` (still a
+  countable void marker).
+- Re-sync of a voided order → idempotent (revenue rows already gone, void row
+  UPSERTed).
+- User split rows (`parent_sale_id NOT NULL`) preserved by the `parent_sale_id
+  IS NULL` guard on every delete, as elsewhere.
+
+## Migration & safety
+- New `supabase/migrations/20260713010000_focus_preserve_voids.sql` (timestamp
+  sorts after latest `20260713000000`; re-checked for collision before PR).
+- `CREATE OR REPLACE` from live def (pre-flight assert: contains
+  `apply_rules_to_pos_sales_internal`, no `auth.uid()`); re-apply `REVOKE ALL …
+  FROM PUBLIC; GRANT EXECUTE … TO service_role` (live ACL `{postgres,
+  service_role}`).
+- Add partial index `idx_unified_sales_focus_active (restaurant_id, sale_date)
+  WHERE pos_system='focus' AND parent_sale_id IS NULL` (speeds the per-check
+  deletes; non-CONCURRENTLY — migrations are transactional — partial predicate
+  keeps the build small).
+
+## Testing
+- **pgTAP** (`supabase/tests/47_focus_transactions_unified_sales.sql`): seed
+  order C (sale+tip+discount+tax) + a user split row; sync → rows exist. Set
+  `focus_orders.is_voided=true`; re-sync → C's sale/tip/discount/tax rows gone,
+  **one `adjustment_type='void'` row present with negative `total_price`**, the
+  **split row survives**, a **sibling order untouched**; assert
+  `SUM(total_price) WHERE adjustment_type='void'` equals the negated revenue and
+  revenue (`item_type='sale' AND adjustment_type IS NULL`) drops accordingly.
+- **Unit** (`tests/unit/focusTransactionSyncHandler.test.ts`): a `<DeleteRecord>`
+  drives an `update({is_voided:true})` on focus_orders, **not** a `.delete()`.
+
+## Follow-ups (filed as chips)
+- One-time cleanup of **legacy hard-deleted orphans** (rows left by the old
+  hard-delete path before this change) — the new sweep-by-soft-delete only
+  covers checks voided going forward.
+- Optional **Voids report UI** (count/$ surface) — deferred.

--- a/docs/superpowers/specs/2026-07-12-focus-preserve-voids-design.md
+++ b/docs/superpowers/specs/2026-07-12-focus-preserve-voids-design.md
@@ -31,10 +31,21 @@ of revenue *and* stay countable/reportable.
 ### 1. Schema (migration)
 - `ALTER TABLE public.focus_orders ADD COLUMN IF NOT EXISTS is_voided boolean
   NOT NULL DEFAULT false, ADD COLUMN IF NOT EXISTS voided_at timestamptz;`
-- Extend `unified_sales_adjustment_type_check` to add `'void'` (drop + re-add
-  with `('tax','tip','service_charge','discount','fee','void',NULL)`). This also
-  **un-breaks Toast's own void path** (`20260211300000` already writes
-  `adjustment_type='void'`, which the current constraint would reject).
+- **No `unified_sales` constraint change needed.** Verified in prod: 2,658
+  `adjustment_type='void'` rows already exist (all Toast). The constraint
+  `CHECK (adjustment_type IN ('tax','tip','service_charge','discount','fee',NULL))`
+  has `NULL` in the list, so for any unlisted value `x IN (…,NULL)` evaluates to
+  **NULL**, and a CHECK passes on NULL — i.e. the constraint already permits
+  `'void'` (and, as a side effect, any value). Focus `'void'` inserts pass
+  as-is; the earlier review's "un-breaks Toast / P&L backlog" concern is moot.
+  (That the constraint is a permissive no-op is a real but separate data-
+  integrity smell — filed as a follow-up, not fixed here.)
+- **No new index.** The void DELETE/UPSERT keys off `external_order_id`, already
+  covered by the existing partial unique index `unified_sales_unique_square
+  (restaurant_id, pos_system, external_order_id, external_item_id) WHERE
+  parent_sale_id IS NULL` (which also backs the void `ON CONFLICT`). Dropped the
+  previously-proposed `idx_unified_sales_focus_active` (unsafe non-CONCURRENTLY
+  build + wrong key for the query shape).
 
 ### 2. Handler — soft-delete instead of hard-delete
 `focusTransactionSyncHandler.ts` DeleteRecord loop: replace `.delete()` with
@@ -64,6 +75,13 @@ loop:
     the orphan-sweep** (no separate pre-loop sweep needed) and fixes the bug.
 - **`is_voided = false`:** existing Steps 1–6 (sale/discount/tip/tax), plus a
   cleanup DELETE of any stale `…_void` row for this order (idempotent un-void).
+  This cleanup DELETE **must** include `AND parent_sale_id IS NULL`, matching
+  every other delete in the function.
+
+**Voiding removes the whole check** — its tax/tip/discount rows are deleted, not
+netted to a line. This is intended: a void means the transaction didn't happen,
+so nothing from it survives except the single audit `void` offset (the negated
+net revenue). Confirmed as the desired reporting behaviour.
 
 Final aggregate: unchanged two-source UNION already re-aggregates every
 processed date (voided orders still appear in the `focus_orders` date-range
@@ -86,16 +104,15 @@ or `SELECT count(*), SUM(total) FROM focus_orders WHERE is_voided`.
   IS NULL` guard on every delete, as elsewhere.
 
 ## Migration & safety
-- New `supabase/migrations/20260713010000_focus_preserve_voids.sql` (timestamp
-  sorts after latest `20260713000000`; re-checked for collision before PR).
+- New `supabase/migrations/20260713020000_focus_preserve_voids.sql` — timestamp
+  sorts after the current latest `20260713010000_harden_accept_shift_trade.sql`;
+  re-check for collision immediately before PR (`git ls-tree origin/main`).
+- Two statements only: the `focus_orders` `ALTER` and the `CREATE OR REPLACE`
+  of the RPC. No constraint change, no index (see §1).
 - `CREATE OR REPLACE` from live def (pre-flight assert: contains
   `apply_rules_to_pos_sales_internal`, no `auth.uid()`); re-apply `REVOKE ALL …
   FROM PUBLIC; GRANT EXECUTE … TO service_role` (live ACL `{postgres,
   service_role}`).
-- Add partial index `idx_unified_sales_focus_active (restaurant_id, sale_date)
-  WHERE pos_system='focus' AND parent_sale_id IS NULL` (speeds the per-check
-  deletes; non-CONCURRENTLY — migrations are transactional — partial predicate
-  keeps the build small).
 
 ## Testing
 - **pgTAP** (`supabase/tests/47_focus_transactions_unified_sales.sql`): seed
@@ -110,6 +127,13 @@ or `SELECT count(*), SUM(total) FROM focus_orders WHERE is_voided`.
 
 ## Follow-ups (filed as chips)
 - One-time cleanup of **legacy hard-deleted orphans** (rows left by the old
-  hard-delete path before this change) — the new sweep-by-soft-delete only
-  covers checks voided going forward.
+  hard-delete path before this change) — the new soft-delete only covers checks
+  voided going forward.
+- **`unified_sales_adjustment_type_check` is a permissive no-op** (NULL-in-list
+  makes it accept any value) — tighten it separately (carefully: it currently
+  "allows" whatever historical rows exist).
+- **`focus_order_items`/`focus_payments` retention:** soft-delete now preserves
+  these for voided checks (previously CASCADE-removed). Only the sync RPC +
+  handler read them, so no correctness risk, but there's now no cleanup path —
+  revisit if Focus volume grows.
 - Optional **Voids report UI** (count/$ surface) — deferred.

--- a/docs/superpowers/specs/2026-07-12-focus-preserve-voids-design.md
+++ b/docs/superpowers/specs/2026-07-12-focus-preserve-voids-design.md
@@ -68,7 +68,7 @@ loop:
   - UPSERT **one** negative void offset row:
     `external_item_id = v_order_id || '_void'`, `item_name = 'Void'`,
     `total_price = -(SELECT COALESCE(SUM(price),0) FROM focus_order_items WHERE …
-    AND price != 0)` (the voided net revenue), `item_type='discount'`,
+    AND price != 0)` (the voided net revenue), `item_type='other'`,
     `adjustment_type='void'`, `sale_time = v_sale_time`. `ON CONFLICT … WHERE
     parent_sale_id IS NULL DO UPDATE`.
   - Because the order row now still exists, the loop visits it — **this replaces

--- a/supabase/functions/_shared/focusTransactionSyncHandler.ts
+++ b/supabase/functions/_shared/focusTransactionSyncHandler.ts
@@ -80,7 +80,9 @@ export interface TransactionSupabaseDeps {
     ): {
       select(): Promise<{ data: unknown; error: { message: string } | null }>;
     };
-    delete(): {
+    update(
+      data: Record<string, unknown>,
+    ): {
       eq(col: string, val: string): {
         eq(col: string, val: string): {
           eq(col: string, val: string): Promise<{ error: { message: string } | null }>;
@@ -348,28 +350,31 @@ export async function processDayTransactions(
       return { status: 'empty' };
     }
 
-    // ── 4. Delete voided checks (DeleteRecord entries) ────────────────────────
-    // Voided checks are removed from focus_orders; ON DELETE CASCADE cleans up
-    // focus_order_items and focus_payments automatically.
-    // unified_sales orphan-delete is handled by _sync_focus_transactions_to_unified_sales_impl.
+    // ── 4. Soft-delete voided checks (DeleteRecord entries) ───────────────────
+    // Voided checks are marked is_voided/voided_at on focus_orders instead of
+    // being hard-deleted — this preserves the check + its items/payments so
+    // the void amount stays knowable, and gives sync_focus_transactions_to_
+    // unified_sales_impl an auditable negative offset row to emit (rather than
+    // an orphaned/vanished unified_sales row).
 
-    let voidDeleteFailed = false;
+    let voidMarkFailed = false;
+    const voidedAt = new Date().toISOString();
     for (const voidedCheckId of deletedCheckIds) {
-      const { error: delError } = await deps.supabase
+      const { error: updateError } = await deps.supabase
         .from('focus_orders')
-        .delete()
+        .update({ is_voided: true, voided_at: voidedAt })
         .eq('restaurant_id', config.restaurantId)
         .eq('business_date', businessDate)
         .eq('focus_check_id', voidedCheckId);
-      if (delError) {
+      if (updateError) {
         // Non-fatal for THIS run: log and continue — the check may not exist
         // locally yet. But remember the failure: recording the fingerprint
         // below would make the next tick delta-skip this identical feed and
-        // never retry the void, leaving the voided check in focus_orders /
+        // never retry the void, leaving the check un-voided in focus_orders /
         // unified_sales indefinitely (codex review).
-        voidDeleteFailed = true;
+        voidMarkFailed = true;
         console.warn(
-          `focus_orders delete (voided check ${voidedCheckId}): ${delError.message}`,
+          `focus_orders void-mark (voided check ${voidedCheckId}): ${updateError.message}`,
         );
       }
     }
@@ -406,12 +411,12 @@ export async function processDayTransactions(
 
     // Record the fingerprint only once the day is fully synced (voids applied,
     // data written, AND unified_sales caught up). If the RPC or any void
-    // delete failed above, deliberately skip the record so the next tick
+    // mark failed above, deliberately skip the record so the next tick
     // re-fetches, re-parses, and retries instead of matching a
     // "stale-success" fingerprint and delta-skipping forever (codex review:
     // prevents unified_sales — a P&L-critical table — and voided checks from
     // silently drifting stale after a transient failure).
-    if (deps.stateStore && fingerprint && !unifiedSalesSyncFailed && !voidDeleteFailed) {
+    if (deps.stateStore && fingerprint && !unifiedSalesSyncFailed && !voidMarkFailed) {
       const stateStore = deps.stateStore;
       const fp = fingerprint;
       await safeStateStoreCall(

--- a/supabase/functions/_shared/focusTransactionSyncHandler.ts
+++ b/supabase/functions/_shared/focusTransactionSyncHandler.ts
@@ -184,6 +184,12 @@ async function upsertOrder(
         discount_total: check.discountTotal,
         taxable_sales: check.taxableSales,
         tax_amount: check.taxAmount,
+        // A check present in the <Checks> section is active. Clear any prior
+        // void state so a previously-voided check that reappears (un-void) is
+        // treated as active again — the sync RPC then drops its stale _void
+        // offset. Voided checks arrive via <DeleteRecord>, not here.
+        is_voided: false,
+        voided_at: null,
       },
       { onConflict: 'restaurant_id,business_date,focus_check_id' },
     )

--- a/supabase/migrations/20260713020000_focus_preserve_voids.sql
+++ b/supabase/migrations/20260713020000_focus_preserve_voids.sql
@@ -1,0 +1,440 @@
+-- ============================================================
+-- §  Preserve Focus voids as auditable negative offsets
+--
+-- Problem: Focus voids arrive as check-level <DeleteRecord> entries. The
+-- handler used to hard-DELETE the focus_orders row (CASCADE removed
+-- items/payments), leaving the check's unified_sales rows orphaned
+-- (they inflated revenue/tax forever — PR #600) and no audit trail of
+-- voids (count/$ was unrecoverable).
+--
+-- Fix: soft-delete (focus_orders.is_voided/voided_at, set by the handler —
+-- see focusTransactionSyncHandler.ts) + branch the sync RPC's per-check
+-- loop on is_voided:
+--   - voided:     delete this check's sale/tip/discount/tax rows, upsert
+--                 ONE negative adjustment_type='void' offset row
+--                 (Toast-consistent: item_type='discount', adjustment_type
+--                 ='void', total_price = -SUM(focus_order_items.price)).
+--                 Because the focus_orders row still exists, the loop keeps
+--                 visiting it on every re-sync — this *replaces* the old
+--                 orphan-sweep and fixes the bug (no separate pre-loop
+--                 sweep needed).
+--   - not voided: existing Steps 1-6 (sale/discount/tip/tax), plus a new
+--                 cleanup DELETE of any stale "<order_id>_void" row, so an
+--                 idempotent un-void (is_voided flips back to false) removes
+--                 the stale void marker. Guarded by parent_sale_id IS NULL,
+--                 matching every other delete in this function.
+--
+-- Read-layer note (no read-layer change required): revenue sums
+-- item_type='sale' AND adjustment_type IS NULL; discounts sum
+-- adjustment_type='discount'; pass-through sums an enumerated adjustment_type
+-- list. A row with adjustment_type='void' is excluded from all three
+-- automatically.
+--
+-- Function body re-created from the LIVE definition (pg_get_functiondef),
+-- not from a hand-maintained copy, to avoid repo/prod drift (lesson
+-- PR #579/#581). Pre-flight verified at build time: the live body contains
+-- apply_rules_to_pos_sales_internal and does NOT contain an auth.uid() gate
+-- (the PR #565/#567/#573 regression class).
+--
+-- CREATE OR REPLACE resets function ACLs in Postgres, so grants are
+-- re-applied at the end to match production: {postgres, service_role} only
+-- (never `authenticated` — only the public wrapper functions are granted to
+-- authenticated callers, and those wrappers are unchanged by this
+-- migration).
+-- ============================================================
+
+ALTER TABLE public.focus_orders
+  ADD COLUMN IF NOT EXISTS is_voided boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS voided_at timestamptz;
+
+CREATE OR REPLACE FUNCTION public._sync_focus_transactions_to_unified_sales_impl(p_restaurant_id uuid, p_start_date date, p_end_date date)
+ RETURNS integer
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+ SET statement_timeout TO '120s'
+AS $function$
+DECLARE
+  v_count          integer := 0;
+  v_row_count      integer;
+  v_sync_start     timestamptz := clock_timestamp();
+  v_store_id       text;
+  v_order          record;
+  v_order_id       text;
+  v_sale_time      time;
+  v_current_ids    text[];
+  v_void_amount    numeric;
+BEGIN
+  -- Fetch the store_id from the most-recently-created active connection.
+  -- Filtering by is_active prevents stale/deleted connections from being used.
+  -- ORDER BY + LIMIT 1 makes the query deterministic when multiple rows exist.
+  SELECT fc.store_id INTO v_store_id
+  FROM public.focus_connections fc
+  WHERE fc.restaurant_id = p_restaurant_id
+    AND fc.is_active = true
+  ORDER BY fc.created_at DESC
+  LIMIT 1;
+
+  -- If no active connection found, there is nothing to key external_order_id on.
+  -- Proceeding with a NULL store_id would produce orphan unified_sales rows
+  -- (pattern: focus-unknown-YYYYMMDD-{check_id}) that can never be re-synced.
+  IF v_store_id IS NULL THEN
+    RAISE EXCEPTION
+      'sync_focus_transactions_to_unified_sales: no active focus_connections row '
+      'found for restaurant %', p_restaurant_id;
+  END IF;
+
+  -- GUC flag: skip per-row triggers during bulk sync (transaction-local).
+  PERFORM set_config('app.skip_unified_sales_triggers', 'true', true);
+
+  -- ── Iterate per check (focus_order) ────────────────────────────────────
+  FOR v_order IN
+    SELECT fo.business_date, fo.focus_check_id,
+           fo.opened_at_local, fo.closed_at_local, fo.tax_amount,
+           fo.is_voided
+    FROM public.focus_orders fo
+    WHERE fo.restaurant_id = p_restaurant_id
+      AND (p_start_date IS NULL OR fo.business_date >= p_start_date)
+      AND (p_end_date   IS NULL OR fo.business_date <= p_end_date)
+    ORDER BY fo.business_date, fo.focus_check_id
+  LOOP
+    v_order_id := 'focus-' || COALESCE(v_store_id, 'unknown')
+                  || '-' || to_char(v_order.business_date, 'YYYYMMDD')
+                  || '-' || v_order.focus_check_id;
+
+    -- Time-of-day for this check: prefer TimeOpened (when the customer
+    -- transacted — the busy-time signal), fall back to TimeClosed.
+    v_sale_time := COALESCE(
+      public._focus_parse_local_time(v_order.opened_at_local),
+      public._focus_parse_local_time(v_order.closed_at_local)
+    );
+
+    IF v_order.is_voided THEN
+      -- ── Voided check: remove the check's ENTIRE unified_sales footprint —
+      -- base sale rows, their user split children (which share this order's
+      -- external_order_id per split_pos_sale), and tip/discount/tax offsets —
+      -- and replace it with one negative void offset row. A void means the
+      -- transaction didn't happen, so nothing from it survives except the
+      -- single audit marker.
+      --
+      -- NOT guarded by parent_sale_id IS NULL (unlike Steps 2/4/5/6): a void
+      -- removes the whole check INCLUDING user splits. Deleting a split-parent
+      -- together with its child in ONE statement satisfies the parent_sale_id
+      -- FK — the redundant NO-ACTION FK (unified_sales_parent_sale_id_fkey,
+      -- a pre-existing duplicate of the ON DELETE CASCADE fk_parent_sale) would
+      -- otherwise block deleting a base row that still has a split child.
+      -- The void marker itself is excluded so its ON CONFLICT upsert (below)
+      -- keeps a stable identity across re-syncs.
+      DELETE FROM public.unified_sales us
+      WHERE us.restaurant_id     = p_restaurant_id
+        AND us.pos_system        = 'focus'
+        AND us.external_order_id  = v_order_id
+        AND us.external_item_id  <> v_order_id || '_void';
+
+      -- Voided net revenue = SUM of this check's priced items (raw price,
+      -- discount not netted in — per design). No priced items → 0 (still a
+      -- countable void marker).
+      SELECT COALESCE(SUM(foi.price), 0) INTO v_void_amount
+      FROM public.focus_order_items foi
+      WHERE foi.restaurant_id  = p_restaurant_id
+        AND foi.business_date  = v_order.business_date
+        AND foi.focus_check_id = v_order.focus_check_id
+        AND foi.price != 0;
+
+      INSERT INTO public.unified_sales (
+        restaurant_id, pos_system,
+        external_order_id, external_item_id,
+        item_name, quantity, unit_price, total_price,
+        sale_date, sale_time, item_type, adjustment_type, synced_at
+      )
+      VALUES (
+        p_restaurant_id, 'focus',
+        v_order_id, v_order_id || '_void',
+        'Void', 1, -v_void_amount, -v_void_amount,
+        -- item_type='other' (not Toast's 'discount'): the meaningful, Toast-
+        -- consistent identifier is adjustment_type='void'; 'other' avoids a
+        -- collision with item_type='discount' consumers/tests since a void is
+        -- not a discount. Excluded from revenue (not item_type='sale'),
+        -- discounts (adjustment_type != 'discount') and pass-through (not in
+        -- KNOWN_PASS_THROUGH_TYPES).
+        v_order.business_date, v_sale_time, 'other', 'void', now()
+      )
+      ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
+        WHERE parent_sale_id IS NULL
+      DO UPDATE SET
+        item_name   = EXCLUDED.item_name,
+        unit_price  = EXCLUDED.unit_price,
+        total_price = EXCLUDED.total_price,
+        sale_date   = EXCLUDED.sale_date,
+        sale_time   = EXCLUDED.sale_time,
+        synced_at   = EXCLUDED.synced_at;
+
+      GET DIAGNOSTICS v_row_count = ROW_COUNT;
+      v_count := v_count + v_row_count;
+
+      -- Because the focus_orders row still exists (soft-deleted, not
+      -- CASCADE-removed), this loop keeps visiting it on every re-sync —
+      -- this replaces the old orphan-sweep and fixes the bug where a
+      -- hard-deleted check's unified_sales rows were left orphaned forever.
+    ELSE
+      -- ── Step 1: Collect current external_item_ids (sale rows) ──────────────
+      SELECT ARRAY(
+        SELECT v_order_id || '__' || foi.item_key
+        FROM public.focus_order_items foi
+        WHERE foi.restaurant_id  = p_restaurant_id
+          AND foi.business_date  = v_order.business_date
+          AND foi.focus_check_id = v_order.focus_check_id
+          AND foi.price IS NOT NULL
+          AND foi.price != 0
+      ) INTO v_current_ids;
+
+      -- ── Step 2: DELETE orphan sale rows no longer in focus_order_items ─────
+      -- Only delete base (un-split) rows; parent_sale_id IS NULL guards user-
+      -- managed split/child rows from being silently removed on every sync.
+      DELETE FROM public.unified_sales us
+      WHERE us.restaurant_id     = p_restaurant_id
+        AND us.pos_system        = 'focus'
+        AND us.item_type         = 'sale'
+        AND us.sale_date         = v_order.business_date
+        AND us.external_order_id = v_order_id
+        AND us.parent_sale_id IS NULL
+        AND NOT (us.external_item_id = ANY(v_current_ids));
+
+      -- ── Step 3: UPSERT sale rows (one per priced item) ────────────────────
+      INSERT INTO public.unified_sales (
+        restaurant_id, pos_system,
+        external_order_id, external_item_id,
+        item_name, quantity, unit_price, total_price,
+        sale_date, sale_time, pos_category, item_type, synced_at
+      )
+      SELECT
+        foi.restaurant_id, 'focus',
+        v_order_id, v_order_id || '__' || foi.item_key,
+        foi.name, 1, foi.price, foi.price,
+        foi.business_date, v_sale_time, foi.report_group_id, 'sale', now()
+      FROM public.focus_order_items foi
+      WHERE foi.restaurant_id  = p_restaurant_id
+        AND foi.business_date  = v_order.business_date
+        AND foi.focus_check_id = v_order.focus_check_id
+        AND foi.price IS NOT NULL
+        AND foi.price != 0
+      ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
+        WHERE parent_sale_id IS NULL
+      DO UPDATE SET
+        item_name    = EXCLUDED.item_name,
+        unit_price   = EXCLUDED.unit_price,
+        total_price  = EXCLUDED.total_price,
+        sale_date    = EXCLUDED.sale_date,
+        sale_time    = EXCLUDED.sale_time,
+        pos_category = EXCLUDED.pos_category,
+        synced_at    = EXCLUDED.synced_at
+        -- category_id + is_categorized intentionally omitted →
+        -- preserves user-managed categorization on re-sync (design §4)
+      ;
+
+      GET DIAGNOSTICS v_row_count = ROW_COUNT;
+      v_count := v_count + v_row_count;
+
+      -- ── Step 4: UPSERT / DELETE discount offset rows ───────────────────────
+      -- Upsert items that have a non-zero discount.
+      -- Focus XML stores DiscountAmount as a negative value (e.g. -3.01).
+      -- Use != 0 (not > 0) so that negative amounts are also captured.
+      -- -ABS() normalises to negative regardless of stored sign.
+      INSERT INTO public.unified_sales (
+        restaurant_id, pos_system,
+        external_order_id, external_item_id,
+        item_name, quantity, unit_price, total_price,
+        sale_date, sale_time, item_type, adjustment_type, synced_at
+      )
+      SELECT
+        foi.restaurant_id, 'focus',
+        v_order_id, v_order_id || '__' || foi.item_key || '_discount',
+        'Discount - ' || COALESCE(foi.name, 'Item'), 1,
+        -ABS(foi.discount_amount), -ABS(foi.discount_amount),
+        foi.business_date, v_sale_time, 'discount', 'discount', now()
+      FROM public.focus_order_items foi
+      WHERE foi.restaurant_id  = p_restaurant_id
+        AND foi.business_date  = v_order.business_date
+        AND foi.focus_check_id = v_order.focus_check_id
+        AND foi.discount_amount != 0
+      ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
+        WHERE parent_sale_id IS NULL
+      DO UPDATE SET
+        item_name   = EXCLUDED.item_name,
+        unit_price  = EXCLUDED.unit_price,
+        total_price = EXCLUDED.total_price,
+        sale_date   = EXCLUDED.sale_date,
+        sale_time   = EXCLUDED.sale_time,
+        synced_at   = EXCLUDED.synced_at;
+
+      GET DIAGNOSTICS v_row_count = ROW_COUNT;
+      v_count := v_count + v_row_count;
+
+      -- Delete stale discount rows for items that no longer have a discount.
+      -- parent_sale_id IS NULL guards user-managed split rows.
+      DELETE FROM public.unified_sales us
+      WHERE us.restaurant_id     = p_restaurant_id
+        AND us.pos_system        = 'focus'
+        AND us.item_type         = 'discount'
+        AND us.sale_date         = v_order.business_date
+        AND us.external_order_id = v_order_id
+        AND us.parent_sale_id IS NULL
+        AND us.external_item_id NOT IN (
+          SELECT v_order_id || '__' || foi.item_key || '_discount'
+          FROM public.focus_order_items foi
+          WHERE foi.restaurant_id  = p_restaurant_id
+            AND foi.business_date  = v_order.business_date
+            AND foi.focus_check_id = v_order.focus_check_id
+            AND foi.discount_amount != 0
+        );
+
+      -- ── Step 5: UPSERT / DELETE tip offset rows ────────────────────────────
+      -- Upsert payments with a non-zero tip
+      INSERT INTO public.unified_sales (
+        restaurant_id, pos_system,
+        external_order_id, external_item_id,
+        item_name, quantity, unit_price, total_price,
+        sale_date, sale_time, item_type, adjustment_type, synced_at
+      )
+      SELECT
+        fp.restaurant_id, 'focus',
+        v_order_id, v_order_id || '_' || fp.payment_key || '_tip',
+        'Tip - ' || COALESCE(fp.name, 'Payment'), 1,
+        fp.tip, fp.tip,
+        fp.business_date, v_sale_time, 'tip', 'tip', now()
+      FROM public.focus_payments fp
+      WHERE fp.restaurant_id  = p_restaurant_id
+        AND fp.business_date  = v_order.business_date
+        AND fp.focus_check_id = v_order.focus_check_id
+        AND fp.tip != 0
+      ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
+        WHERE parent_sale_id IS NULL
+      DO UPDATE SET
+        item_name   = EXCLUDED.item_name,
+        unit_price  = EXCLUDED.unit_price,
+        total_price = EXCLUDED.total_price,
+        sale_date   = EXCLUDED.sale_date,
+        sale_time   = EXCLUDED.sale_time,
+        synced_at   = EXCLUDED.synced_at;
+
+      GET DIAGNOSTICS v_row_count = ROW_COUNT;
+      v_count := v_count + v_row_count;
+
+      -- Delete stale tip rows for payments that no longer have a tip.
+      -- parent_sale_id IS NULL guards user-managed split rows.
+      DELETE FROM public.unified_sales us
+      WHERE us.restaurant_id     = p_restaurant_id
+        AND us.pos_system        = 'focus'
+        AND us.item_type         = 'tip'
+        AND us.sale_date         = v_order.business_date
+        AND us.external_order_id = v_order_id
+        AND us.parent_sale_id IS NULL
+        AND us.external_item_id NOT IN (
+          SELECT v_order_id || '_' || fp.payment_key || '_tip'
+          FROM public.focus_payments fp
+          WHERE fp.restaurant_id  = p_restaurant_id
+            AND fp.business_date  = v_order.business_date
+            AND fp.focus_check_id = v_order.focus_check_id
+            AND fp.tip != 0
+        );
+
+      -- ── Step 6: UPSERT / DELETE tax offset row ─────────────────────────────
+      -- Tax is one row per order (SeatRecord.TaxTotal1..5 summed by the parser
+      -- into focus_orders.tax_amount) — NOT one row per item/payment like
+      -- discount/tip — so the delete below is a plain conditional delete keyed
+      -- off "this order's tax_amount is currently 0", not a NOT IN (subquery)
+      -- over a per-row source table. Do not change this to the multi-row
+      -- pattern; there is nothing to enumerate.
+      INSERT INTO public.unified_sales (
+        restaurant_id, pos_system,
+        external_order_id, external_item_id,
+        item_name, quantity, unit_price, total_price,
+        sale_date, sale_time, item_type, adjustment_type, synced_at
+      )
+      SELECT
+        p_restaurant_id, 'focus',
+        v_order_id, v_order_id || '_tax',
+        'Sales Tax', 1,
+        v_order.tax_amount, v_order.tax_amount,
+        v_order.business_date, v_sale_time, 'tax', 'tax', now()
+      WHERE v_order.tax_amount != 0
+      ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
+        WHERE parent_sale_id IS NULL
+      DO UPDATE SET
+        item_name   = EXCLUDED.item_name,
+        unit_price  = EXCLUDED.unit_price,
+        total_price = EXCLUDED.total_price,
+        sale_date   = EXCLUDED.sale_date,
+        sale_time   = EXCLUDED.sale_time,
+        synced_at   = EXCLUDED.synced_at;
+
+      GET DIAGNOSTICS v_row_count = ROW_COUNT;
+      v_count := v_count + v_row_count;
+
+      -- Delete the tax row for this order when it no longer has any tax.
+      -- parent_sale_id IS NULL guards user-managed split rows.
+      IF v_order.tax_amount = 0 THEN
+        DELETE FROM public.unified_sales us
+        WHERE us.restaurant_id     = p_restaurant_id
+          AND us.pos_system        = 'focus'
+          AND us.item_type         = 'tax'
+          AND us.sale_date         = v_order.business_date
+          AND us.external_order_id = v_order_id
+          AND us.external_item_id  = v_order_id || '_tax'
+          AND us.parent_sale_id IS NULL;
+      END IF;
+
+      -- Stale-void cleanup: idempotent un-void. If this check was voided in
+      -- the past (leaving a "<order_id>_void" row) and is_voided has since
+      -- flipped back to false, remove the stale void marker so it doesn't
+      -- linger alongside the freshly-restored sale/tip/discount/tax rows.
+      -- parent_sale_id IS NULL guards user-managed split rows, matching
+      -- every other delete in this function.
+      DELETE FROM public.unified_sales us
+      WHERE us.restaurant_id     = p_restaurant_id
+        AND us.pos_system        = 'focus'
+        AND us.adjustment_type   = 'void'
+        AND us.sale_date         = v_order.business_date
+        AND us.external_order_id = v_order_id
+        AND us.external_item_id  = v_order_id || '_void'
+        AND us.parent_sale_id IS NULL;
+    END IF;
+
+  END LOOP;  -- end per-check loop
+
+  -- Reset GUC flag to re-enable per-row triggers
+  PERFORM set_config('app.skip_unified_sales_triggers', 'false', true);
+
+  -- Batch-categorize uncategorized sale rows (authenticated callers only;
+  -- service-role callers defer to the apply-categorization-rules edge function)
+  PERFORM apply_rules_to_pos_sales_internal(p_restaurant_id, 10000);
+
+  -- Batch-aggregate daily totals for all dates touched in this sync.
+  -- Union two sources so DELETE-only dates are still re-aggregated: synced_at
+  -- only advances on INSERT/UPDATE, so a date whose only change was a removed
+  -- offset row (e.g. a tax row deleted when tax_amount is zeroed, with no
+  -- sale/tip/discount row re-upserted) would otherwise keep stale daily
+  -- totals. The focus_orders business_date range covers every check processed
+  -- this run, including those pure-delete dates (the order row still exists).
+  PERFORM public.aggregate_unified_sales_to_daily(p_restaurant_id, d.sale_date)
+  FROM (
+    SELECT DISTINCT sale_date
+    FROM public.unified_sales
+    WHERE restaurant_id = p_restaurant_id
+      AND pos_system    = 'focus'
+      AND synced_at    >= v_sync_start
+    UNION
+    SELECT DISTINCT fo.business_date
+    FROM public.focus_orders fo
+    WHERE fo.restaurant_id = p_restaurant_id
+      AND (p_start_date IS NULL OR fo.business_date >= p_start_date)
+      AND (p_end_date   IS NULL OR fo.business_date <= p_end_date)
+  ) d;
+
+  RETURN v_count;
+END;
+$function$;
+
+-- Re-apply grants (CREATE OR REPLACE resets ACLs in Postgres).
+REVOKE ALL ON FUNCTION public._sync_focus_transactions_to_unified_sales_impl(uuid, date, date) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public._sync_focus_transactions_to_unified_sales_impl(uuid, date, date) TO service_role;

--- a/supabase/tests/47_focus_transactions_unified_sales.sql
+++ b/supabase/tests/47_focus_transactions_unified_sales.sql
@@ -40,9 +40,30 @@
 -- 26  Check 10's persisted focus_orders.tax_amount is 0 (default, guards test 25)
 -- 27  Re-sync after tax_amount is zeroed out deletes the previously-created tax row (check 42)
 -- 28  Zeroed-tax re-sync leaves the order's 5 non-tax rows intact by identity
+--
+-- Void tests (check 43, "order C"): a priced item -> sale + payment tip +
+-- item discount + tax_amount, plus a user-managed split row under its sale
+-- row. focus_orders.is_voided/voided_at are added by
+-- 20260713020000_focus_preserve_voids.sql; until that migration lands these
+-- tests fail (undefined column / no void branch) -- this is the RED half of
+-- the TDD cycle for that migration.
+--
+-- 29  Order C: sale row created for item IK-E (6.00)
+-- 30  Order C: tip offset row created (1.25) from payment PK-2
+-- 31  Order C: discount offset row created (-0.60) for item IK-E
+-- 32  Order C: tax offset row created (0.42)
+-- 33  Order C: split row (parent_sale_id = C's sale row id) exists before voiding
+-- 34  After voiding C: sale/tip/discount/tax rows (parent_sale_id IS NULL) are gone
+-- 35  After voiding C: exactly one adjustment_type='void' row exists for order C
+-- 36  After voiding C: void row total_price = -SUM(priced items) = -6.00
+-- 37  After voiding C: the split row (child) survives
+-- 38  After voiding C: sibling order 42's sale-row count is untouched (still 3)
+-- 39  After voiding C: sibling order 42's IK-A sale row identity/amount is untouched
+-- 40  After voiding C: revenue (item_type='sale' AND adjustment_type IS NULL) dropped by exactly C's amount (6.00)
+-- 41  After voiding C: SUM(total_price) WHERE adjustment_type='void' equals negated revenue lost
 
 BEGIN;
-SELECT plan(28);
+SELECT plan(41);
 
 -- ─────────────────────────────────────────────────────────────────────
 -- Setup: disable RLS so we can insert test rows freely
@@ -574,6 +595,259 @@ SELECT bag_eq(
      ('focus-GUID-TEST-STORE-20260615-42__IK-D_discount', 'discount'),
      ('focus-GUID-TEST-STORE-20260615-42_PK-1_tip',       'tip')$$,
   'Zeroed-tax re-sync leaves the order''s 5 non-tax rows intact by identity (3 sale + 1 tip + 1 discount)'
+);
+
+-- ─────────────────────────────────────────────────────────────────────
+-- Void tests: order C (check 43) — a priced item that produces all 4
+-- offset row kinds (sale/tip/discount/tax), plus a user-managed split row
+-- under its sale row. focus_orders.is_voided/voided_at and the RPC's void
+-- branch are added by 20260713020000_focus_preserve_voids.sql — until that
+-- migration lands, this block fails (undefined column, or no void row
+-- created). That's the RED half of this TDD cycle.
+-- ─────────────────────────────────────────────────────────────────────
+INSERT INTO public.focus_orders (
+  id, restaurant_id, business_date, focus_check_id,
+  opened_at_local, closed_at_local,
+  order_type_id, revenue_center_id, guests,
+  total, discount_total, taxable_sales, tax_amount
+) VALUES (
+  '00000000-0000-0000-0000-f0c100000033',
+  '00000000-0000-0000-0000-f0c100000011',
+  '2026-06-15', '43',
+  '2026-06-15T12:00:00', '2026-06-15T12:10:00',
+  '1', 'RC1', 1,
+  6.22, 0.60, 5.40, 0.42
+)
+ON CONFLICT ON CONSTRAINT focus_orders_unique DO UPDATE SET total = 6.22, tax_amount = 0.42;
+
+-- One priced item -> sale row + discount row
+INSERT INTO public.focus_order_items (
+  id, restaurant_id, business_date, focus_check_id, item_key,
+  record_number, item_code, name, report_group_id,
+  price, parent_key, is_modifier, discount_amount
+) VALUES (
+  '00000000-0000-0000-0000-f0c100000046',
+  '00000000-0000-0000-0000-f0c100000011',
+  '2026-06-15', '43', 'IK-E',
+  'RN-005', 'IC-005', 'Order C Entree', 'Entrees',
+  6.00, NULL, false, 0.60
+)
+ON CONFLICT ON CONSTRAINT focus_order_items_unique DO NOTHING;
+
+-- One payment with a tip -> tip row
+INSERT INTO public.focus_payments (
+  id, restaurant_id, business_date, focus_check_id, payment_key,
+  payment_id, name, amount, tip, card_last4
+) VALUES (
+  '00000000-0000-0000-0000-f0c100000053',
+  '00000000-0000-0000-0000-f0c100000011',
+  '2026-06-15', '43', 'PK-2',
+  'PAY-002', 'MASTERCARD', 6.22, 1.25, '5678'
+)
+ON CONFLICT ON CONSTRAINT focus_payments_unique DO NOTHING;
+
+-- Sync so order C's 4 offset row kinds are created
+SET LOCAL "request.jwt.claims" TO '{"sub": "00000000-0000-0000-0000-f0c100000001"}';
+SELECT sync_focus_transactions_to_unified_sales(
+  '00000000-0000-0000-0000-f0c100000011'::uuid,
+  '2026-06-15'::date,
+  '2026-06-15'::date
+);
+
+-- Test 29: sale row for item IK-E (order C)
+SELECT is(
+  (SELECT total_price FROM public.unified_sales
+   WHERE restaurant_id = '00000000-0000-0000-0000-f0c100000011'
+     AND pos_system = 'focus'
+     AND external_item_id = 'focus-GUID-TEST-STORE-20260615-43__IK-E'
+     AND item_type = 'sale'),
+  6.00::numeric,
+  'Order C: sale row created for item IK-E (6.00)'
+);
+
+-- Test 30: tip offset row (payment PK-2, tip=1.25)
+SELECT is(
+  (SELECT total_price FROM public.unified_sales
+   WHERE restaurant_id = '00000000-0000-0000-0000-f0c100000011'
+     AND pos_system = 'focus'
+     AND item_type = 'tip'
+     AND external_order_id = 'focus-GUID-TEST-STORE-20260615-43'),
+  1.25::numeric,
+  'Order C: tip offset row created (1.25) from payment PK-2'
+);
+
+-- Test 31: discount offset row (-0.60) for item IK-E
+SELECT is(
+  (SELECT total_price FROM public.unified_sales
+   WHERE restaurant_id = '00000000-0000-0000-0000-f0c100000011'
+     AND pos_system = 'focus'
+     AND item_type = 'discount'
+     AND external_item_id = 'focus-GUID-TEST-STORE-20260615-43__IK-E_discount'),
+  (-0.60)::numeric,
+  'Order C: discount offset row created (-0.60) for item IK-E'
+);
+
+-- Test 32: tax offset row (0.42)
+SELECT is(
+  (SELECT total_price FROM public.unified_sales
+   WHERE restaurant_id = '00000000-0000-0000-0000-f0c100000011'
+     AND pos_system = 'focus'
+     AND item_type = 'tax'
+     AND external_order_id = 'focus-GUID-TEST-STORE-20260615-43'),
+  0.42::numeric,
+  'Order C: tax offset row created (0.42)'
+);
+
+-- User-managed split row under C's sale row (parent_sale_id = that row's id).
+-- Mirrors the manual-split pattern used elsewhere (e.g.
+-- 27_get_daily_sales_totals.sql) -- a real unified_sales child row, not
+-- something the sync RPC itself creates.
+INSERT INTO public.unified_sales (
+  id, restaurant_id, pos_system,
+  external_order_id, external_item_id,
+  item_name, quantity, unit_price, total_price,
+  sale_date, item_type, parent_sale_id, synced_at
+)
+SELECT
+  '00000000-0000-0000-0000-f0c100000054'::uuid,
+  '00000000-0000-0000-0000-f0c100000011', 'focus',
+  'focus-GUID-TEST-STORE-20260615-43', 'focus-GUID-TEST-STORE-20260615-43__IK-E-split',
+  'Order C Entree (split)', 1, 3.00, 3.00,
+  '2026-06-15', 'sale', us.id, now() - interval '5 minutes'
+FROM public.unified_sales us
+WHERE us.restaurant_id = '00000000-0000-0000-0000-f0c100000011'
+  AND us.pos_system = 'focus'
+  AND us.external_item_id = 'focus-GUID-TEST-STORE-20260615-43__IK-E'
+  AND us.item_type = 'sale'
+ON CONFLICT (id) DO NOTHING;
+
+-- Test 33: split row exists before voiding
+SELECT ok(
+  EXISTS(
+    SELECT 1 FROM public.unified_sales
+    WHERE id = '00000000-0000-0000-0000-f0c100000054'
+      AND parent_sale_id IS NOT NULL
+  ),
+  'Order C: split row (parent_sale_id set) exists before voiding'
+);
+
+-- Snapshot restaurant-wide revenue before voiding, for the delta assertion
+-- in test 40 below.
+CREATE TEMP TABLE pre_void_revenue AS
+SELECT COALESCE(SUM(total_price), 0)::numeric AS revenue
+FROM public.unified_sales
+WHERE restaurant_id = '00000000-0000-0000-0000-f0c100000011'
+  AND item_type = 'sale'
+  AND adjustment_type IS NULL;
+
+-- ─────────────────────────────────────────────────────────────────────
+-- Void order C and re-sync.
+-- ─────────────────────────────────────────────────────────────────────
+SET LOCAL role TO postgres;
+UPDATE public.focus_orders
+SET is_voided = true, voided_at = now()
+WHERE restaurant_id = '00000000-0000-0000-0000-f0c100000011'
+  AND business_date = '2026-06-15'
+  AND focus_check_id = '43';
+
+SET LOCAL "request.jwt.claims" TO '{"sub": "00000000-0000-0000-0000-f0c100000001"}';
+SELECT sync_focus_transactions_to_unified_sales(
+  '00000000-0000-0000-0000-f0c100000011'::uuid,
+  '2026-06-15'::date,
+  '2026-06-15'::date
+);
+
+-- Test 34: C's sale/tip/discount/tax rows (parent_sale_id IS NULL) are gone
+SELECT is(
+  (SELECT COUNT(*)::integer FROM public.unified_sales
+   WHERE restaurant_id = '00000000-0000-0000-0000-f0c100000011'
+     AND pos_system = 'focus'
+     AND external_order_id = 'focus-GUID-TEST-STORE-20260615-43'
+     AND parent_sale_id IS NULL
+     AND item_type IN ('sale', 'tip', 'discount', 'tax')),
+  0,
+  'After voiding C: sale/tip/discount/tax rows (parent_sale_id IS NULL) are gone'
+);
+
+-- Test 35: exactly one adjustment_type='void' row for order C
+SELECT is(
+  (SELECT COUNT(*)::integer FROM public.unified_sales
+   WHERE restaurant_id = '00000000-0000-0000-0000-f0c100000011'
+     AND pos_system = 'focus'
+     AND external_order_id = 'focus-GUID-TEST-STORE-20260615-43'
+     AND adjustment_type = 'void'),
+  1,
+  'After voiding C: exactly one adjustment_type=''void'' row exists'
+);
+
+-- Test 36: void row total_price = -SUM(priced items) = -6.00
+-- (IK-E's raw price only -- the discount is not netted into this figure,
+-- per the design's "voided net revenue" = -SUM(focus_order_items.price)).
+SELECT is(
+  (SELECT total_price FROM public.unified_sales
+   WHERE restaurant_id = '00000000-0000-0000-0000-f0c100000011'
+     AND pos_system = 'focus'
+     AND external_order_id = 'focus-GUID-TEST-STORE-20260615-43'
+     AND adjustment_type = 'void'),
+  (-6.00)::numeric,
+  'After voiding C: void row total_price = -SUM(priced items) = -6.00'
+);
+
+-- Test 37: the split row (child) survives voiding
+SELECT ok(
+  EXISTS(
+    SELECT 1 FROM public.unified_sales
+    WHERE id = '00000000-0000-0000-0000-f0c100000054'
+      AND parent_sale_id IS NOT NULL
+  ),
+  'After voiding C: the split row (child) survives'
+);
+
+-- Test 38: sibling order 42's sale-row count is untouched (still 3)
+SELECT is(
+  (SELECT COUNT(*)::integer FROM public.unified_sales
+   WHERE restaurant_id = '00000000-0000-0000-0000-f0c100000011'
+     AND pos_system = 'focus'
+     AND external_order_id = 'focus-GUID-TEST-STORE-20260615-42'
+     AND item_type = 'sale'),
+  3,
+  'After voiding C: sibling order 42''s sale-row count is untouched (still 3)'
+);
+
+-- Test 39: sibling order 42's item A sale row amount is untouched
+SELECT is(
+  (SELECT total_price FROM public.unified_sales
+   WHERE restaurant_id = '00000000-0000-0000-0000-f0c100000011'
+     AND pos_system = 'focus'
+     AND external_item_id = 'focus-GUID-TEST-STORE-20260615-42__IK-A'
+     AND item_type = 'sale'),
+  5.84::numeric,
+  'After voiding C: sibling order 42''s IK-A sale row is untouched'
+);
+
+-- Test 40: revenue (item_type='sale' AND adjustment_type IS NULL) dropped
+-- by exactly C's amount (6.00). Only C's own sale row is removed between
+-- the snapshot and this comparison -- the split row (item_type='sale' too)
+-- is untouched by the void and so contributes equally to both sides,
+-- cancelling out of the delta.
+SELECT is(
+  (SELECT revenue FROM pre_void_revenue) -
+  (SELECT COALESCE(SUM(total_price), 0)::numeric FROM public.unified_sales
+   WHERE restaurant_id = '00000000-0000-0000-0000-f0c100000011'
+     AND item_type = 'sale'
+     AND adjustment_type IS NULL),
+  6.00::numeric,
+  'After voiding C: revenue dropped by exactly 6.00'
+);
+
+-- Test 41: SUM(total_price) WHERE adjustment_type='void' equals the negated
+-- revenue lost (only order C has ever been voided in this test).
+SELECT is(
+  (SELECT SUM(total_price) FROM public.unified_sales
+   WHERE restaurant_id = '00000000-0000-0000-0000-f0c100000011'
+     AND adjustment_type = 'void'),
+  (-6.00)::numeric,
+  'After voiding C: SUM(total_price) WHERE adjustment_type=''void'' equals negated revenue lost'
 );
 
 SELECT * FROM finish();

--- a/supabase/tests/47_focus_transactions_unified_sales.sql
+++ b/supabase/tests/47_focus_transactions_unified_sales.sql
@@ -56,7 +56,7 @@
 -- 34  After voiding C: sale/tip/discount/tax rows (parent_sale_id IS NULL) are gone
 -- 35  After voiding C: exactly one adjustment_type='void' row exists for order C
 -- 36  After voiding C: void row total_price = -SUM(priced items) = -6.00
--- 37  After voiding C: the split row (child) survives
+-- 37  After voiding C: the split row (child) is removed too (whole check gone)
 -- 38  After voiding C: sibling order 42's sale-row count is untouched (still 3)
 -- 39  After voiding C: sibling order 42's IK-A sale row identity/amount is untouched
 -- 40  After voiding C: revenue (item_type='sale' AND adjustment_type IS NULL) dropped by exactly C's amount (6.00)
@@ -793,14 +793,15 @@ SELECT is(
   'After voiding C: void row total_price = -SUM(priced items) = -6.00'
 );
 
--- Test 37: the split row (child) survives voiding
+-- Test 37: the split row (child) is removed too — a void removes the WHOLE
+-- check, including user splits (they share the order's external_order_id, so
+-- the single void DELETE removes parent + child together, FK-safe).
 SELECT ok(
-  EXISTS(
+  NOT EXISTS(
     SELECT 1 FROM public.unified_sales
     WHERE id = '00000000-0000-0000-0000-f0c100000054'
-      AND parent_sale_id IS NOT NULL
   ),
-  'After voiding C: the split row (child) survives'
+  'After voiding C: the split row (child) is removed with the rest of the check'
 );
 
 -- Test 38: sibling order 42's sale-row count is untouched (still 3)
@@ -825,19 +826,17 @@ SELECT is(
   'After voiding C: sibling order 42''s IK-A sale row is untouched'
 );
 
--- Test 40: revenue (item_type='sale' AND adjustment_type IS NULL) dropped
--- by exactly C's amount (6.00). Only C's own sale row is removed between
--- the snapshot and this comparison -- the split row (item_type='sale' too)
--- is untouched by the void and so contributes equally to both sides,
--- cancelling out of the delta.
+-- Test 40: revenue (item_type='sale' AND adjustment_type IS NULL) dropped by
+-- exactly 9.00 = C's base sale row (6.00, IK-E) + its user split child (3.00,
+-- also item_type='sale'), BOTH removed by the void (the whole check is gone).
 SELECT is(
   (SELECT revenue FROM pre_void_revenue) -
   (SELECT COALESCE(SUM(total_price), 0)::numeric FROM public.unified_sales
    WHERE restaurant_id = '00000000-0000-0000-0000-f0c100000011'
      AND item_type = 'sale'
      AND adjustment_type IS NULL),
-  6.00::numeric,
-  'After voiding C: revenue dropped by exactly 6.00'
+  9.00::numeric,
+  'After voiding C: revenue dropped by 9.00 (C''s 6.00 sale + 3.00 split, both removed)'
 );
 
 -- Test 41: SUM(total_price) WHERE adjustment_type='void' equals the negated

--- a/tests/unit/focusTransactionSyncHandler.test.ts
+++ b/tests/unit/focusTransactionSyncHandler.test.ts
@@ -236,6 +236,15 @@ describe('processDayTransactions', () => {
     expect(row.tax_amount).toBe(1.13);
   });
 
+  it('clears void state (is_voided:false, voided_at:null) on active-check upsert', async () => {
+    const { deps, mocks } = makeDeps({});
+    await processDayTransactions(deps, MOCK_CONFIG, BUSINESS_DATE);
+    const row = mocks.ordersUpsert.mock.calls[0][0];
+    // A check in <Checks> is active — un-void a previously-voided reappearance.
+    expect(row.is_voided).toBe(false);
+    expect(row.voided_at).toBeNull();
+  });
+
   it('uses ON CONFLICT on the correct columns for focus_orders', async () => {
     const { deps, mocks } = makeDeps({});
     await processDayTransactions(deps, MOCK_CONFIG, BUSINESS_DATE);

--- a/tests/unit/focusTransactionSyncHandler.test.ts
+++ b/tests/unit/focusTransactionSyncHandler.test.ts
@@ -102,24 +102,27 @@ function makeRpcMock() {
   return vi.fn().mockResolvedValue({ data: null, error: null });
 }
 
-function makeDeleteMock() {
-  // Three-level eq chain: .delete().eq(restaurant_id).eq(business_date).eq(focus_check_id)
+function makeUpdateMock() {
+  // Three-level eq chain: .update({...}).eq(restaurant_id).eq(business_date).eq(focus_check_id)
   const eqInnermost = vi.fn().mockResolvedValue({ error: null });
   const eqInner = vi.fn().mockReturnValue({ eq: eqInnermost });
   const eqOuter = vi.fn().mockReturnValue({ eq: eqInner });
-  const deleteFn = vi.fn().mockReturnValue({ eq: eqOuter });
-  return { deleteFn, eqOuter, eqInner, eqInnermost };
+  const updateFn = vi.fn().mockReturnValue({ eq: eqOuter });
+  return { updateFn, eqOuter, eqInner, eqInnermost };
 }
 
 function makeSupabaseMock() {
   const { upsertFn: ordersUpsert, selectFn: ordersSelect } = makeUpsertMock();
   const { upsertFn: itemsUpsert, selectFn: itemsSelect } = makeUpsertMock();
   const { upsertFn: paymentsUpsert, selectFn: paymentsSelect } = makeUpsertMock();
-  const { deleteFn: ordersDelete, eqOuter: deleteEqOuter, eqInner: deleteEqInner, eqInnermost: deleteEqInnermost } = makeDeleteMock();
+  const { updateFn: ordersUpdate, eqOuter: updateEqOuter, eqInner: updateEqInner, eqInnermost: updateEqInnermost } = makeUpdateMock();
+  // Voided checks are now soft-deleted via .update() — .delete() on focus_orders
+  // must never be called. Kept as a bare spy so tests can assert that.
+  const ordersDelete = vi.fn();
   const rpcFn = makeRpcMock();
 
   const fromFn = vi.fn().mockImplementation((table: string) => {
-    if (table === 'focus_orders') return { upsert: ordersUpsert, delete: ordersDelete };
+    if (table === 'focus_orders') return { upsert: ordersUpsert, update: ordersUpdate, delete: ordersDelete };
     if (table === 'focus_order_items') return { upsert: itemsUpsert };
     if (table === 'focus_payments') return { upsert: paymentsUpsert };
     return { upsert: vi.fn().mockReturnValue({ select: vi.fn().mockResolvedValue({ data: [], error: null }) }) };
@@ -127,7 +130,7 @@ function makeSupabaseMock() {
 
   return {
     client: { from: fromFn, rpc: rpcFn },
-    mocks: { fromFn, ordersUpsert, ordersSelect, itemsUpsert, itemsSelect, paymentsUpsert, paymentsSelect, ordersDelete, deleteEqOuter, deleteEqInner, deleteEqInnermost, rpcFn },
+    mocks: { fromFn, ordersUpsert, ordersSelect, itemsUpsert, itemsSelect, paymentsUpsert, paymentsSelect, ordersUpdate, updateEqOuter, updateEqInner, updateEqInnermost, ordersDelete, rpcFn },
   };
 }
 
@@ -444,7 +447,7 @@ describe('processDayTransactions', () => {
 
   // ── Voided checks (DeleteRecord) ─────────────────────────────────────────────
 
-  it('deletes voided checks from focus_orders when DeleteRecord entries are present', async () => {
+  it('soft-deletes voided checks via focus_orders.update({is_voided,voided_at}), not .delete()', async () => {
     const XML_WITH_DELETE = `<DailyData><Checks>
 <Check><CheckRecord><ID>10</ID><Total>12.50</Total></CheckRecord>
 <Seats><Seat><SeatRecord><Key>1</Key></SeatRecord>
@@ -464,11 +467,21 @@ describe('processDayTransactions', () => {
     // Should succeed — the live check is processed normally
     expect(result).toMatchObject({ status: 'ok', checksWritten: 1 });
 
-    // focus_orders.delete() scoped to restaurant_id + business_date + focus_check_id
-    expect(mocks.ordersDelete).toHaveBeenCalledOnce();
-    expect(mocks.deleteEqOuter).toHaveBeenCalledWith('restaurant_id', RESTAURANT_ID);
-    expect(mocks.deleteEqInner).toHaveBeenCalledWith('business_date', BUSINESS_DATE);
-    expect(mocks.deleteEqInnermost).toHaveBeenCalledWith('focus_check_id', '99');
+    // focus_orders.update({is_voided:true, voided_at}) scoped to
+    // restaurant_id + business_date + focus_check_id (soft-delete: preserves
+    // the check + its items/payments so the void amount stays knowable).
+    expect(mocks.ordersUpdate).toHaveBeenCalledOnce();
+    const updatePayload = mocks.ordersUpdate.mock.calls[0][0] as { is_voided: boolean; voided_at: string };
+    expect(updatePayload.is_voided).toBe(true);
+    expect(typeof updatePayload.voided_at).toBe('string');
+    expect(Number.isNaN(new Date(updatePayload.voided_at).getTime())).toBe(false);
+    expect(mocks.updateEqOuter).toHaveBeenCalledWith('restaurant_id', RESTAURANT_ID);
+    expect(mocks.updateEqInner).toHaveBeenCalledWith('business_date', BUSINESS_DATE);
+    expect(mocks.updateEqInnermost).toHaveBeenCalledWith('focus_check_id', '99');
+
+    // Hard-delete must NOT be used for voids anymore (spec: preserve voids as
+    // auditable rows instead of CASCADE-removing items/payments).
+    expect(mocks.ordersDelete).not.toHaveBeenCalled();
   });
 
   it('returns ok when only voided checks are present (no active checks)', async () => {
@@ -480,9 +493,10 @@ describe('processDayTransactions', () => {
     const { deps, mocks } = makeDeps({ xml: XML_ONLY_DELETE });
     const result = await processDayTransactions(deps, MOCK_CONFIG, BUSINESS_DATE);
 
-    // Not 'empty' — there is work to do (delete the voided check)
+    // Not 'empty' — there is work to do (soft-delete/void the check)
     expect(result).toMatchObject({ status: 'ok', checksWritten: 0 });
-    expect(mocks.ordersDelete).toHaveBeenCalledOnce();
+    expect(mocks.ordersUpdate).toHaveBeenCalledOnce();
+    expect(mocks.ordersDelete).not.toHaveBeenCalled();
     expect(mocks.ordersUpsert).not.toHaveBeenCalled();
   });
 
@@ -675,11 +689,12 @@ describe('processDayTransactions', () => {
       expect(stateStore.record).toHaveBeenCalledOnce();
     });
 
-    // ── voidDeleteFailed gate (codex review) ──────────────────────────────────
-    // A feed containing a DeleteRecord (voided check) whose focus_orders delete
-    // fails must NOT record the fingerprint — otherwise the next tick sees a
-    // matching fingerprint and delta-skips, leaving the voided check stranded
-    // in focus_orders / unified_sales indefinitely.
+    // ── voidMarkFailed gate (codex review) ────────────────────────────────────
+    // A feed containing a DeleteRecord (voided check) whose focus_orders
+    // is_voided update fails must NOT record the fingerprint — otherwise the
+    // next tick sees a matching fingerprint and delta-skips, leaving the
+    // voided check stranded un-voided in focus_orders / unified_sales
+    // indefinitely.
 
     const XML_WITH_DELETE = `<DailyData><Checks>
 <Check><CheckRecord><ID>10</ID><Total>12.50</Total></CheckRecord>
@@ -694,12 +709,12 @@ describe('processDayTransactions', () => {
 <DeleteRecord><ID>99</ID></DeleteRecord>
 </Checks></DailyData>`;
 
-    it('does NOT record the fingerprint when a voided-check delete fails, so the next tick retries the void', async () => {
+    it('does NOT record the fingerprint when a voided-check update fails, so the next tick retries the void', async () => {
       const stateStore = makeStateStore(null);
       const { client, mocks } = makeSupabaseMock();
-      // Make the focus_orders delete chain resolve with an error (the check
+      // Make the focus_orders update chain resolve with an error (the check
       // "may not exist locally yet" case the handler tolerates non-fatally).
-      mocks.deleteEqInnermost.mockResolvedValue({ error: { message: 'boom' } });
+      mocks.updateEqInnermost.mockResolvedValue({ error: { message: 'boom' } });
       const fetchDatafeedMock = makeFetchDatafeedMock(XML_WITH_DELETE);
       const deps: TransactionSyncDeps = {
         supabase: client as unknown as TransactionSupabaseDeps,
@@ -712,20 +727,20 @@ describe('processDayTransactions', () => {
       // Non-fatal for this run: the live check is still processed and the
       // overall result is still 'ok', not 'error'.
       expect(result).toEqual({ status: 'ok', checksWritten: 1 });
-      expect(mocks.ordersDelete).toHaveBeenCalledOnce();
+      expect(mocks.ordersUpdate).toHaveBeenCalledOnce();
       // But the fingerprint must NOT be recorded — the next tick must re-fetch
       // and retry the void instead of delta-skipping this identical feed.
       expect(stateStore.record).not.toHaveBeenCalled();
     });
 
-    it('records the fingerprint when the voided-check delete succeeds', async () => {
+    it('records the fingerprint when the voided-check update succeeds', async () => {
       const stateStore = makeStateStore(null);
       const { deps, mocks } = makeDeps({ xml: XML_WITH_DELETE });
 
       const result = await processDayTransactions({ ...deps, stateStore }, MOCK_CONFIG, BUSINESS_DATE);
 
       expect(result).toEqual({ status: 'ok', checksWritten: 1 });
-      expect(mocks.ordersDelete).toHaveBeenCalledOnce();
+      expect(mocks.ordersUpdate).toHaveBeenCalledOnce();
       expect(stateStore.record).toHaveBeenCalledOnce();
     });
   });


### PR DESCRIPTION
## Summary
- **Preserves voided Focus checks** instead of hard-deleting them, so voids are auditable and net out of revenue (Toast-consistent model). **Absorbs the pre-existing orphan-bug fix** (Codex, PR #600).
- On a `<DeleteRecord>`, the handler now **soft-deletes** (`focus_orders.is_voided`/`voided_at`) instead of `.delete()`, preserving the check's items/payments/tax.
- The sync RPC branches on `is_voided`: a voided check has its **entire `unified_sales` footprint removed** (base sale rows + tip/discount/tax offsets + user split children, which share `external_order_id`) in one FK-safe DELETE, and gets **one negative void offset row** (`item_type='other'`, `adjustment_type='void'`, `total_price = −net revenue`).

## Behavior
- **Revenue nets out** — a void's sale rows are gone; the `void` row is excluded from revenue (`item_type='sale'`), discounts (`adjustment_type='discount'`), and pass-through (`KNOWN_PASS_THROUGH_TYPES`).
- **Voids are countable** — `SUM/COUNT WHERE adjustment_type='void'`, or `focus_orders WHERE is_voided`.
- **A void removes the whole check**, including user splits (the transaction didn't happen). The `parent_sale_id IS NULL` split-preservation guard remains on the routine (non-void) sync steps.
- **Un-void handled** — an active check upsert clears `is_voided`/`voided_at`, dropping the stale void offset.

## Notes / follow-ups (chips filed)
- Verified in prod: `adjustment_type='void'` already permitted (the constraint's `NULL`-in-list makes it a permissive no-op) — **no constraint change needed**, no Toast side-effect.
- Found + filed: **duplicate `parent_sale_id` FK** on `unified_sales` (NO ACTION + CASCADE) — the void DELETE works around it by removing parent+child together.

## Test plan
- pgTAP `47_` (41 tests): void → sale/tip/discount/tax + split child gone, one negative `void` row, sibling untouched, revenue drops correctly.
- Unit (`focusTransactionSyncHandler`, 53): `<DeleteRecord>` drives soft-delete; active upsert clears void state.
- `npm run test:db` → **1723/1723**; typecheck clean.

Design: `docs/superpowers/specs/2026-07-12-focus-preserve-voids-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
