### PR TITLE
fix(focus): classify delivery fee items as pass-through (drop out of revenue)

### DIFF
--- a/docs/focus-followups.md
+++ b/docs/focus-followups.md
@@ -1,0 +1,63 @@
+# Focus POS — open follow-ups
+
+Handoff notes. Context: Focus tax capture shipped (#600), void preservation shipped
+(#618, merged), `collected_at_pos` void-exclusion fix in review (#619, CI running).
+The three items below are the remaining "fix 1–4" tasks. Each should go through the
+`development-workflow` skill (brainstorm → plan → worktree → TDD → review → PR).
+
+## 1. Phantom $0 orders + service-fee-item revenue classification — DONE
+- **Status:** Fixed on `fix/focus-fee-item-classification`
+  (`docs/superpowers/specs/2026-07-19-focus-fee-classification-design.md`).
+  Fee items (`Dispatch Fee`, `Dispatch Service Fee`, `RailsUpcharge`, etc., matched
+  by name via the new `_focus_is_fee_item` SQL helper) are now reclassified as
+  `item_type='other'`, `adjustment_type='fee'` in
+  `_sync_focus_transactions_to_unified_sales_impl`, so they drop out of `revenue`
+  while staying in `pass_through_amount` and `collected_at_pos`. Phantom $0
+  fee-only checks resolve for free once the fee row is no longer counted as a
+  sale — no separate suppression logic was needed. Covered end-to-end by
+  `supabase/tests/55_focus_fee_classification.sql` (mixed check, fee-only
+  "phantom" check, voided fee, discounted fee, split-child backfill cleanup,
+  idempotency).
+- **Symptom (original):** some Focus orders (originally reported as "delivery
+  orders") import as `$0`. Root cause is understood to be **phantom / fee-only
+  checks**, not a parser bug.
+- **Two sub-parts (original):**
+  - Phantom $0 orders — decide whether to skip/suppress them or surface differently.
+  - Fee items like **RailsUpcharge** / **Dispatch Fee** are being counted as `sale`
+    revenue; they should be classified as non-sales (pass-through / fee), i.e.
+    `adjustment_type` set so they drop out of `revenue`.
+- **Files:** `supabase/migrations/20260719154500_focus_fee_classification.sql`,
+  `supabase/tests/55_focus_fee_classification.sql`.
+- **Later nice-to-have:** the fee-item name matching (`_focus_is_fee_item`) is
+  currently pattern-based, validated against the sample fixture
+  (`tests/fixtures/focus-datafeed-sample.xml`) rather than a captured real feed
+  containing a `RailsUpcharge` line. Capture a real Focus datafeed payload with a
+  `RailsUpcharge` item (report_group_id, exact name/price shape) and add it as a
+  fixture to lock in the pattern match against a real-world example — same spirit
+  as follow-up item 2 below.
+
+## 2. Harden Focus tax parser tests with a real-feed fixture
+- Current tax parser tests are synthetic. Add a **real datafeed XML fixture** (a
+  captured `blob_url` payload) and assert the parser sums `SeatRecord.TaxTotal1..5`
+  into `FocusCheck.taxAmount` correctly end-to-end.
+- Sanitize the fixture (no secrets/PII) before committing.
+- **Files:** parser + a new fixture under the test dir; parser unit tests.
+
+## 3. 14-day custom-range sync UX
+- The custom-range sync is capped at 14 days (a deliberate guard, **not** a bug —
+  verified). The UX is confusing: users don't know why a wider range silently
+  truncates.
+- **Goal:** surface the 14-day limit in the UI (helper text / disabled state / clear
+  message) so the cap is understood, or chunk longer ranges into sequential 14-day
+  syncs. Decide during brainstorm.
+- **Files:** Focus sync UI (setup wizard / sync trigger component) + the edge function
+  that enforces the cap.
+
+## Reference — void model recap (for context)
+- Focus voids arrive as check-level `<DeleteRecord>`. Handler soft-deletes
+  (`focus_orders.is_voided=true`) instead of hard-deleting; the sync RPC deletes the
+  check's revenue rows and inserts one negative `adjustment_type='void'` marker
+  (`item_type='other'`, `external_item_id = <order>_void`).
+- Read layer: `revenue` keys on `item_type='sale' AND adjustment_type IS NULL`;
+  `void`/`discount`/`tip`/`tax` all excluded from revenue via `adjustment_type`.
+  `collected_at_pos` now also excludes `void` (#619).

--- a/docs/superpowers/plans/2026-07-19-focus-fee-classification-plan.md
+++ b/docs/superpowers/plans/2026-07-19-focus-fee-classification-plan.md
@@ -1,0 +1,68 @@
+# Plan: Focus fee-item revenue classification
+
+**Design:** `docs/superpowers/specs/2026-07-19-focus-fee-classification-design.md`
+**Branch:** `fix/focus-fee-item-classification`
+
+TDD, one commit per task. All server-side; pure SQL/pgTAP (no TS change).
+
+## Task 1 — pgTAP: `_focus_is_fee_item` predicate (RED→GREEN)
+- New file `supabase/tests/55_focus_fee_classification.sql`, `plan()` section 1.
+- Assert `_focus_is_fee_item` is TRUE for `'Dispatch Fee'`, `'Dispatch Service Fee'`,
+  `'Dispatch Fee2'`, `'RailsUpcharge'`, `'Rails Upcharge'`; FALSE for
+  `'CLYellow Cake'`, `'Dispatch Tip'`, `NULL`, `''`.
+- GREEN: add the `IMMUTABLE` helper to the migration
+  `supabase/migrations/20260719154500_focus_fee_classification.sql`.
+- Commit: `test(focus): _focus_is_fee_item predicate` + `feat(focus): add _focus_is_fee_item helper`.
+
+## Task 2 — Migration: rewrite the impl RPC
+- In `20260719154500_focus_fee_classification.sql`, after the helper:
+  1. **Pre-flight DO guard**: `RAISE EXCEPTION` unless `pg_get_functiondef(
+     '_sync_focus_transactions_to_unified_sales_impl(uuid,date,date)'::regprocedure)`
+     contains the literal `foi.name, 1, foi.price, foi.price` (drift trip-wire).
+  2. Full `CREATE OR REPLACE FUNCTION _sync_focus_transactions_to_unified_sales_impl`
+     — copy the current body from `20260713020000_focus_preserve_voids.sql` verbatim,
+     preserving `SECURITY DEFINER`, `SET search_path='public'`,
+     `SET statement_timeout='120s'`, and apply the non-voided-branch edits:
+     - Step 1 `v_current_ids`: `AND NOT public._focus_is_fee_item(foi.name)`.
+     - New **Step 2b** fee-reclassification cleanup (base + split children in one
+       DELETE, per design).
+     - Step 3 sale insert: `AND NOT public._focus_is_fee_item(foi.name)`.
+     - New **Step 3b** fee-offset INSERT (`..._fee` id, `item_type='other'`,
+       `adjustment_type='fee'`) + stale-fee DELETE (`parent_sale_id IS NULL`).
+     - Step 4 discount insert + stale-delete subquery:
+       `AND NOT public._focus_is_fee_item(foi.name)`.
+     - Void branch: unchanged.
+  3. Re-apply grants: `REVOKE ALL ... FROM PUBLIC; GRANT EXECUTE ... TO service_role;`.
+- Commit: `feat(focus): classify delivery fee items as adjustment_type='fee' (drop out of revenue)`.
+
+## Task 3 — pgTAP: end-to-end classification (RED→GREEN against Task 2)
+- Extend `55_focus_fee_classification.sql` (bump `plan()`), seed one active
+  `focus_connections` + focus_orders/items:
+  - **Mixed check**: real dessert (sale) + Dispatch Fee 1.99.
+  - **Fee-only phantom check**: only Dispatch Service Fee 2.99.
+  - **Voided fee check**: fee on `is_voided=true` order.
+  - **Discounted-fee check**: fee item with `discount_amount != 0`.
+- Call `_sync_focus_transactions_to_unified_sales_impl`; assert cases 2–9 from the
+  design (sale row NULL adjustment_type; fee row `item_type='other'`/`'fee'`/`_fee`
+  id; totals: revenue excludes fees, pass_through + collected_at_pos include them;
+  phantom $0 revenue; split-child backfill deletes parent+child no FK abort;
+  idempotency on double-run; voided → one `void` marker no `_fee`; discounted fee →
+  no discount row).
+- Commit: `test(focus): end-to-end fee classification, phantom $0, backfill, idempotency`.
+
+## Task 4 — Docs
+- Update `docs/focus-followups.md`: mark item 1 done; note RailsUpcharge RG fixture
+  capture as a later nice-to-have.
+- Commit: `docs(focus): mark fee-classification follow-up done`.
+
+## Verify (Phase 8)
+- `npm run test:db` (pgTAP) — primary gate.
+- `npm run typecheck && npm run lint && npm run build` (no TS change, but keep green).
+- Symlink `.env.local` into the worktree for db tests; `npm ci` if node_modules is
+  Vite-cache-only (lesson #1165).
+
+## Risks / watch-items
+- Drift trip-wire must match the live body exactly (guard RAISEs otherwise).
+- Migration prefix `20260719154500` — re-verify free at push time.
+- Keep the `ON CONFLICT ... WHERE parent_sale_id IS NULL` arbiter on every upsert
+  (matches `unified_sales_unique_square` partial index).

--- a/docs/superpowers/specs/2026-07-19-focus-fee-classification-design.md
+++ b/docs/superpowers/specs/2026-07-19-focus-fee-classification-design.md
@@ -137,8 +137,18 @@ is index/planner-friendly and callable from the SET-returning inserts.
 5. **Step 3b — fee offset rows** (mirrors the discount step):
    - INSERT from `focus_order_items` where `price != 0 AND _focus_is_fee_item(name)`,
      `external_item_id = v_order_id || '__' || item_key || '_fee'`,
-     `item_name = name`, `unit_price = total_price = price`,
-     `item_type = 'other'`, `adjustment_type = 'fee'`.
+     `item_name = name`, **`unit_price = total_price = price - ABS(discount_amount)`
+     (NET of any discount on the fee line)**, `item_type = 'other'`,
+     `adjustment_type = 'fee'`.
+     - **Amendment (Phase 7b, Codex major, user-approved):** the fee row is NET,
+       not gross. A discounted fee means the POS collected less; since Step 4
+       deliberately does NOT emit a separate `adjustment_type='discount'` row for
+       fees (that would misfile a pass-through discount as a *sales* discount),
+       the discount is folded into this single `'fee'` row. Keeps
+       `pass_through_amount` / `collected_at_pos` (bare SUMs of `total_price`)
+       matching what was actually collected. (Earlier draft said
+       `unit_price = total_price = price`, which overstated collected for
+       discounted fees.)
      `ON CONFLICT (... ) WHERE parent_sale_id IS NULL DO UPDATE` the mutable cols.
    - DELETE stale fee rows for this order whose `external_item_id` is no longer in
      the current fee set (item un-priced or renamed), guarded by

--- a/docs/superpowers/specs/2026-07-19-focus-fee-classification-design.md
+++ b/docs/superpowers/specs/2026-07-19-focus-fee-classification-design.md
@@ -88,12 +88,53 @@ is index/planner-friendly and callable from the SET-returning inserts.
 
 1. **Step 1** (`v_current_ids`, the set of sale external_item_ids): add
    `AND NOT public._focus_is_fee_item(foi.name)`. Fee items are no longer
-   "current sale rows", so **Step 2's orphan-delete removes any pre-migration
-   sale row that was actually a fee** — automatic backfill cleanup on first
-   re-sync.
-2. **Step 3** (sale insert): add the same `AND NOT public._focus_is_fee_item(foi.name)`
+   "current sale rows".
+2. **Step 2** (orphan sale delete): **unchanged, and deliberately NOT relied on
+   for fee backfill cleanup** — see the dedicated cleanup below.
+3. **New Step 2b — fee-reclassification cleanup (drift/backfill-safe; addresses
+   design-review MAJOR).** A pre-migration fee item currently has an
+   `item_type='sale'` base row under the un-suffixed id
+   `v_order_id || '__' || item_key`. Its new fee row uses a distinct `..._fee`
+   id, so the old sale row must be removed. **A user may have split-categorized
+   that legacy fee-as-sale row** (`split_pos_sale` → child rows with
+   `parent_sale_id` set), and `unified_sales` carries a redundant NO-ACTION
+   `parent_sale_id` FK (`unified_sales_parent_sale_id_fkey`, `20251031000146`)
+   alongside the `ON DELETE CASCADE` `fk_parent_sale` (`20251031003130`) — the
+   NO-ACTION FK blocks deleting a parent that still has a child, which would
+   abort the entire restaurant's sync. So this cleanup deletes the stale fee-as-
+   sale **base row AND any split children in ONE statement** (exactly the void
+   branch's technique, `20260713020000:118-125`):
+
+   ```sql
+   WITH fee_ids AS (
+     SELECT v_order_id || '__' || foi.item_key AS ext_id
+     FROM public.focus_order_items foi
+     WHERE foi.restaurant_id  = p_restaurant_id
+       AND foi.business_date  = v_order.business_date
+       AND foi.focus_check_id = v_order.focus_check_id
+       AND foi.price IS NOT NULL AND foi.price != 0
+       AND public._focus_is_fee_item(foi.name)
+   )
+   DELETE FROM public.unified_sales us
+   WHERE us.restaurant_id    = p_restaurant_id
+     AND us.pos_system       = 'focus'
+     AND us.external_order_id = v_order_id
+     AND ( us.external_item_id IN (SELECT ext_id FROM fee_ids)
+        OR us.parent_sale_id IN (
+             SELECT p.id FROM public.unified_sales p
+             WHERE p.restaurant_id = p_restaurant_id
+               AND p.pos_system = 'focus'
+               AND p.external_order_id = v_order_id
+               AND p.external_item_id IN (SELECT ext_id FROM fee_ids)) );
+   ```
+
+   Because fee item_keys are excluded from `v_current_ids` (Step 1) *and* already
+   removed here, Step 2 is a no-op for them (no double-delete, no FK abort). This
+   is idempotent — after the first re-sync there is no stale sale row and the
+   statement deletes nothing.
+4. **Step 3** (sale insert): add `AND NOT public._focus_is_fee_item(foi.name)`
    so fees are never inserted as `'sale'`.
-3. **New Step 3b — fee offset rows** (mirrors the discount step):
+5. **Step 3b — fee offset rows** (mirrors the discount step):
    - INSERT from `focus_order_items` where `price != 0 AND _focus_is_fee_item(name)`,
      `external_item_id = v_order_id || '__' || item_key || '_fee'`,
      `item_name = name`, `unit_price = total_price = price`,
@@ -102,6 +143,12 @@ is index/planner-friendly and callable from the SET-returning inserts.
    - DELETE stale fee rows for this order whose `external_item_id` is no longer in
      the current fee set (item un-priced or renamed), guarded by
      `parent_sale_id IS NULL` (matches every other delete in the function).
+6. **Step 4 (discount offsets): exclude fee items** — add
+   `AND NOT public._focus_is_fee_item(foi.name)` to both the discount INSERT and
+   its stale-delete subquery. A discounted fee is pass-through, not a revenue
+   discount; without this a discounted fee item would emit BOTH a `'fee'` row and
+   a spurious `adjustment_type='discount'` row for the same item_key
+   (design-review MINOR).
 
 The **voided branch is unchanged**: a void already deletes the check's entire
 footprint (sale + fee + tip + discount + tax) and writes one `adjustment_type='void'`
@@ -112,16 +159,22 @@ voided check are removed with everything else (audit-preserved via the marker).
 
 Full `CREATE OR REPLACE` of the impl with the new body (matches how
 `20260713020000_focus_preserve_voids.sql` was authored), plus a **pre-flight DO
-guard** that `RAISE EXCEPTION`s if the current live body does not contain the
-Step-3 sale-insert anchor (`item_name, 1, foi.price, foi.price`) — so if prod has
-drifted from the repo copy we fail loudly instead of clobbering (the #579/#581
-"diff, don't believe" lesson). Re-apply grants after (`CREATE OR REPLACE` resets
-ACLs): `service_role` only.
+guard** that `RAISE EXCEPTION`s if the current live body (via
+`pg_get_functiondef`) does not contain the Step-3 sale-insert anchor —
+the ACTUAL text is **`foi.name, 1, foi.price, foi.price`**
+(`20260713020000:213`), not `item_name, ...` — so if prod has drifted from the
+repo copy we fail loudly instead of clobbering (the #579/#581 "diff, don't
+believe" lesson). Author the guard against the real `pg_get_functiondef` output.
+Re-apply grants after (`CREATE OR REPLACE` resets ACLs): `service_role` only.
 
-Migration filename: pick a `20260719HHMMSS_*` prefix verified collision-free
-against every worktree's `supabase/migrations/` (the #571 14-digit-prefix lesson).
+Migration filename: **`20260719154500_focus_fee_classification.sql`** — verified
+collision-free across every worktree's `supabase/migrations/` (avoids the taken
+`20260719120000_notification_channel_settings.sql`; the #571 14-digit-prefix
+lesson).
 
-## Testing (pgTAP — `supabase/tests/53_focus_fee_classification.sql`)
+## Testing (pgTAP — `supabase/tests/55_focus_fee_classification.sql`)
+
+*(53 and 54 are taken — `53_directed_shift_trade_rls.sql`, `54_accept_shift_trade_authz.sql`.)*
 
 Setup: one active `focus_connections`, then focus_orders/items covering:
 - **Mixed check**: 1 real dessert (sale) + 1 Dispatch Fee (1.99).
@@ -140,10 +193,16 @@ Assertions:
 5. **Phantom $0**: fee-only check → its order's revenue contribution is 0, fee in
    pass-through. (No suppression; row exists.)
 6. **Backfill cleanup**: pre-seed a stale `item_type='sale'` row for the fee's
-   item_key, run RPC, assert it is deleted (Step 2) and replaced by the `_fee` row.
+   item_key, run RPC, assert it is deleted (Step 2b) and replaced by the `_fee` row.
+6b. **Split-child backfill (design-review MAJOR)**: pre-seed a legacy fee-as-sale
+   base row PLUS a `parent_sale_id` split child on it, run RPC, assert BOTH are
+   deleted in one shot (no FK-violation abort) and the `_fee` row exists; revenue
+   excludes it.
 7. **Idempotency**: run RPC twice → identical row counts, no duplicates.
 8. Voided fee check → single `adjustment_type='void'` marker, no leftover `_fee`
    row.
+9. **Discounted fee (design-review MINOR)**: a fee item with `discount_amount != 0`
+   → emits the `'fee'` row only, NOT a spurious `adjustment_type='discount'` row.
 
 ## Files
 

--- a/docs/superpowers/specs/2026-07-19-focus-fee-classification-design.md
+++ b/docs/superpowers/specs/2026-07-19-focus-fee-classification-design.md
@@ -1,0 +1,162 @@
+# Design: Focus fee-item revenue classification (+ phantom $0 orders)
+
+**Date:** 2026-07-19
+**Branch:** `fix/focus-fee-item-classification`
+**Follow-up item:** #1 of the Focus POS open follow-ups (`docs/focus-followups.md`)
+
+## Problem
+
+Some Focus orders (reported as "delivery orders") import with $0 revenue, and
+third-party delivery **fee** line items (Dispatch Fee, Dispatch Service Fee,
+RailsUpcharge) are being counted as **sales revenue**. Both stem from one root
+cause: fee line items are priced `CheckItemRecord`s that the sync RPC classifies
+as `item_type='sale'`, so they inflate revenue on checks that carry them and — on
+a fee-only "phantom" delivery check — are the *only* thing on the check.
+
+### Grounded evidence (real fixture `tests/fixtures/focus-datafeed-sample.xml`, from #563)
+
+| Item name | ReportGroupID | `<Price>` | Current classification | Correct |
+|---|---|---|---|---|
+| Dispatch Fee | 94 | 1.99 | `item_type='sale'` (in revenue) ❌ | pass-through fee |
+| Dispatch Service Fee | 94 | 2.99 | `item_type='sale'` (in revenue) ❌ | pass-through fee |
+| Dispatch Tip - Driver | 95 | *(none)* | already excluded (null price) | n/a |
+| Real desserts (CLYellow Cake, …) | 20/22/25/29 | present | `item_type='sale'` ✓ | sale |
+
+## Root-cause location
+
+`public._sync_focus_transactions_to_unified_sales_impl(uuid, date, date)`
+(latest definition: `20260713020000_focus_preserve_voids.sql`), **Step 3** —
+the sale upsert — inserts every `focus_order_items` row with
+`price IS NOT NULL AND price != 0` as `item_type='sale'`. Fee items match that
+predicate and leak into revenue.
+
+Confirmed single seam: the legacy `sync_all_focus_to_unified_sales()` aggregator
+does **not** read `focus_order_items` (it iterates `focus_connections` only), and
+`sync_all_focus_transactions_to_unified_sales()` delegates to the impl. All
+item-level classification lives in the impl RPC — no duplicate logic to patch
+(unlike the #579 legacy-function trap).
+
+## Read-layer contract (no change needed)
+
+`get_unified_sales_totals` (latest: `20260714000000_fix_collected_at_pos_exclude_void.sql`):
+
+- **revenue**: `adjustment_type IS NOT NULL → 0`, else `item_type='sale' → total_price`.
+  → a `adjustment_type='fee'` row is **excluded from revenue**. ✓
+- **pass_through_amount**: `adjustment_type IS NOT NULL AND NOT IN ('discount','void') → total_price`.
+  → a `'fee'` row is **included in pass-through**. ✓
+- **collected_at_pos**: `SUM(total_price) FILTER (adjustment_type IS DISTINCT FROM 'void')`.
+  → a `'fee'` row **stays counted** (POS did collect it). ✓
+
+`adjustment_type='fee'` already exists in the taxonomy (KNOWN_PASS_THROUGH_TYPES =
+`('tax','tip','service_charge','discount','fee')`). **No read-layer migration, no
+new enum value.**
+
+## Decisions (approved in brainstorm)
+
+1. **Fee identification: item-name pattern** (case-insensitive), not
+   ReportGroupID (per-tenant configurable in Focus). Centralized in one
+   `IMMUTABLE` SQL predicate so the list is trivial to extend.
+2. **Implementation seam: SQL RPC only.** Fee classification joins the existing
+   void/discount/tip/tax classification inside the impl. One function-rewrite
+   migration + pgTAP. No parser/handler/column change.
+3. **Phantom $0 orders: leave as $0 revenue.** No suppression. Once fees are
+   pass-through, a fee-only check correctly shows $0 sales with the fee captured
+   in pass_through / collected_at_pos. The paired food check carries the revenue.
+
+## Fee-identification predicate
+
+New helper:
+
+```sql
+CREATE OR REPLACE FUNCTION public._focus_is_fee_item(p_name text)
+RETURNS boolean
+LANGUAGE sql IMMUTABLE
+AS $$
+  SELECT p_name IS NOT NULL AND (
+       lower(p_name) LIKE '%dispatch%fee%'   -- Dispatch Fee, Dispatch Service Fee, Dispatch Fee2
+    OR lower(p_name) LIKE '%rails%upcharge%'  -- RailsUpcharge, Rails Upcharge
+  );
+$$;
+```
+
+Conservative: matches only known third-party delivery pass-through fees. It does
+**not** broadly match `%fee%` (a real "Corkage"/"Split-Plate" charge stays a sale
+until we learn otherwise). Extending is a one-line `OR`. Marked `IMMUTABLE` so it
+is index/planner-friendly and callable from the SET-returning inserts.
+
+## RPC changes (non-voided branch of the per-check loop)
+
+1. **Step 1** (`v_current_ids`, the set of sale external_item_ids): add
+   `AND NOT public._focus_is_fee_item(foi.name)`. Fee items are no longer
+   "current sale rows", so **Step 2's orphan-delete removes any pre-migration
+   sale row that was actually a fee** — automatic backfill cleanup on first
+   re-sync.
+2. **Step 3** (sale insert): add the same `AND NOT public._focus_is_fee_item(foi.name)`
+   so fees are never inserted as `'sale'`.
+3. **New Step 3b — fee offset rows** (mirrors the discount step):
+   - INSERT from `focus_order_items` where `price != 0 AND _focus_is_fee_item(name)`,
+     `external_item_id = v_order_id || '__' || item_key || '_fee'`,
+     `item_name = name`, `unit_price = total_price = price`,
+     `item_type = 'other'`, `adjustment_type = 'fee'`.
+     `ON CONFLICT (... ) WHERE parent_sale_id IS NULL DO UPDATE` the mutable cols.
+   - DELETE stale fee rows for this order whose `external_item_id` is no longer in
+     the current fee set (item un-priced or renamed), guarded by
+     `parent_sale_id IS NULL` (matches every other delete in the function).
+
+The **voided branch is unchanged**: a void already deletes the check's entire
+footprint (sale + fee + tip + discount + tax) and writes one `adjustment_type='void'`
+marker. `v_void_amount = SUM(price)` still nets the whole check; fees inside a
+voided check are removed with everything else (audit-preserved via the marker).
+
+### Migration authoring (drift-safe)
+
+Full `CREATE OR REPLACE` of the impl with the new body (matches how
+`20260713020000_focus_preserve_voids.sql` was authored), plus a **pre-flight DO
+guard** that `RAISE EXCEPTION`s if the current live body does not contain the
+Step-3 sale-insert anchor (`item_name, 1, foi.price, foi.price`) — so if prod has
+drifted from the repo copy we fail loudly instead of clobbering (the #579/#581
+"diff, don't believe" lesson). Re-apply grants after (`CREATE OR REPLACE` resets
+ACLs): `service_role` only.
+
+Migration filename: pick a `20260719HHMMSS_*` prefix verified collision-free
+against every worktree's `supabase/migrations/` (the #571 14-digit-prefix lesson).
+
+## Testing (pgTAP — `supabase/tests/53_focus_fee_classification.sql`)
+
+Setup: one active `focus_connections`, then focus_orders/items covering:
+- **Mixed check**: 1 real dessert (sale) + 1 Dispatch Fee (1.99).
+- **Fee-only "phantom" check**: only a Dispatch Service Fee (2.99).
+- **Voided fee check**: fee item on an `is_voided=true` order.
+
+Assertions:
+1. `_focus_is_fee_item` true for `'Dispatch Fee'`, `'Dispatch Service Fee'`,
+   `'RailsUpcharge'`, `'Rails Upcharge'`; false for `'CLYellow Cake'`, `NULL`,
+   `'Dispatch Tip'`.
+2. After RPC: dessert → `unified_sales` `item_type='sale'`, `adjustment_type IS NULL`.
+3. After RPC: Dispatch Fee → `item_type='other'`, `adjustment_type='fee'`,
+   `total_price=1.99`, `external_item_id LIKE '%_fee'`.
+4. `get_unified_sales_totals`: revenue excludes both fees; `pass_through_amount`
+   and `collected_at_pos` include them.
+5. **Phantom $0**: fee-only check → its order's revenue contribution is 0, fee in
+   pass-through. (No suppression; row exists.)
+6. **Backfill cleanup**: pre-seed a stale `item_type='sale'` row for the fee's
+   item_key, run RPC, assert it is deleted (Step 2) and replaced by the `_fee` row.
+7. **Idempotency**: run RPC twice → identical row counts, no duplicates.
+8. Voided fee check → single `adjustment_type='void'` marker, no leftover `_fee`
+   row.
+
+## Files
+
+- `supabase/migrations/20260719HHMMSS_focus_fee_classification.sql` (new) — helper
+  + impl rewrite + grants.
+- `supabase/tests/53_focus_fee_classification.sql` (new) — pgTAP.
+- `docs/focus-followups.md` — mark item 1 done (or note remaining RailsUpcharge RG
+  confirmation).
+
+## Out of scope / follow-ups
+
+- Confirming RailsUpcharge's ReportGroupID against a real Rails feed (we match by
+  name, so not required for correctness, but worth capturing a fixture later).
+- Per-restaurant configurable fee lists (hardcoded predicate is enough today).
+- The voided-check `v_void_amount` including fee prices (accepted trade-off:
+  the void marker is an audit offset, item_type='other', not revenue).

--- a/supabase/migrations/20260719154500_focus_fee_classification.sql
+++ b/supabase/migrations/20260719154500_focus_fee_classification.sql
@@ -26,3 +26,565 @@ $$;
 
 REVOKE ALL ON FUNCTION public._focus_is_fee_item(text) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public._focus_is_fee_item(text) TO service_role;
+
+-- ============================================================
+-- §  Rewrite _sync_focus_transactions_to_unified_sales_impl:
+--    reclassify fee items out of revenue
+--
+-- Non-voided branch changes only (voided branch already removes a check's
+-- entire footprint, fees included, and is unchanged here):
+--   - Step 1 (v_current_ids): excludes fee items — they are no longer
+--     "current sale rows".
+--   - New Step 2b: fee-reclassification cleanup. A pre-migration fee item has
+--     a legacy item_type='sale' base row under the un-suffixed id; its new
+--     fee row (Step 3b) uses a distinct '..._fee' id, so the old sale row
+--     (and any user split children on it — unified_sales carries a redundant
+--     NO-ACTION FK, unified_sales_parent_sale_id_fkey, 20251031000146,
+--     alongside the ON DELETE CASCADE fk_parent_sale, 20251031003130, which
+--     would abort the sync if a parent with a live child were deleted alone)
+--     is deleted in ONE statement — same technique as the void branch.
+--   - Step 3 (sale upsert): excludes fee items.
+--   - New Step 3b: fee offset upsert/delete, mirroring the Step 4 discount
+--     pattern — item_type='other', adjustment_type='fee',
+--     external_item_id suffixed '_fee'.
+--   - Step 4 (discount upsert/delete): excludes fee items, so a discounted
+--     fee item emits only the Step 3b 'fee' row, not a spurious 'discount'
+--     row for the same item_key.
+--
+-- Function body copied verbatim from the live definition
+-- (20260713020000_focus_preserve_voids.sql) — preserves SECURITY DEFINER,
+-- search_path, statement_timeout — with only the edits above applied.
+-- CREATE OR REPLACE resets function ACLs in Postgres, so grants are
+-- re-applied at the end (service_role only, matching production).
+--
+-- Pre-flight drift trip-wire below verifies the live body still contains the
+-- exact Step-3 sale-insert anchor before this migration replaces it wholesale
+-- (lesson #579/#581 — "diff, don't believe"; fail loudly on drift instead of
+-- silently clobbering an out-of-band prod change).
+-- ============================================================
+
+DO $$
+BEGIN
+  IF pg_get_functiondef('public._sync_focus_transactions_to_unified_sales_impl(uuid,date,date)'::regprocedure)
+     NOT LIKE '%foi.name, 1, foi.price, foi.price%'
+  THEN
+    RAISE EXCEPTION
+      '_sync_focus_transactions_to_unified_sales_impl has drifted from the '
+      'expected base (20260713020000_focus_preserve_voids.sql) — the Step-3 '
+      'sale-insert anchor "foi.name, 1, foi.price, foi.price" was not found '
+      'in the live function body. Refusing to CREATE OR REPLACE; reconcile '
+      'this migration with the live definition before proceeding.';
+  END IF;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public._sync_focus_transactions_to_unified_sales_impl(p_restaurant_id uuid, p_start_date date, p_end_date date)
+ RETURNS integer
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+ SET statement_timeout TO '120s'
+AS $function$
+DECLARE
+  v_count          integer := 0;
+  v_row_count      integer;
+  v_sync_start     timestamptz := clock_timestamp();
+  v_store_id       text;
+  v_order          record;
+  v_order_id       text;
+  v_sale_time      time;
+  v_current_ids    text[];
+  v_void_amount    numeric;
+BEGIN
+  -- Fetch the store_id from the most-recently-created active connection.
+  -- Filtering by is_active prevents stale/deleted connections from being used.
+  -- ORDER BY + LIMIT 1 makes the query deterministic when multiple rows exist.
+  SELECT fc.store_id INTO v_store_id
+  FROM public.focus_connections fc
+  WHERE fc.restaurant_id = p_restaurant_id
+    AND fc.is_active = true
+  ORDER BY fc.created_at DESC
+  LIMIT 1;
+
+  -- If no active connection found, there is nothing to key external_order_id on.
+  -- Proceeding with a NULL store_id would produce orphan unified_sales rows
+  -- (pattern: focus-unknown-YYYYMMDD-{check_id}) that can never be re-synced.
+  IF v_store_id IS NULL THEN
+    RAISE EXCEPTION
+      'sync_focus_transactions_to_unified_sales: no active focus_connections row '
+      'found for restaurant %', p_restaurant_id;
+  END IF;
+
+  -- GUC flag: skip per-row triggers during bulk sync (transaction-local).
+  PERFORM set_config('app.skip_unified_sales_triggers', 'true', true);
+
+  -- ── Iterate per check (focus_order) ────────────────────────────────────
+  FOR v_order IN
+    SELECT fo.business_date, fo.focus_check_id,
+           fo.opened_at_local, fo.closed_at_local, fo.tax_amount,
+           fo.is_voided
+    FROM public.focus_orders fo
+    WHERE fo.restaurant_id = p_restaurant_id
+      AND (p_start_date IS NULL OR fo.business_date >= p_start_date)
+      AND (p_end_date   IS NULL OR fo.business_date <= p_end_date)
+    ORDER BY fo.business_date, fo.focus_check_id
+  LOOP
+    v_order_id := 'focus-' || COALESCE(v_store_id, 'unknown')
+                  || '-' || to_char(v_order.business_date, 'YYYYMMDD')
+                  || '-' || v_order.focus_check_id;
+
+    -- Time-of-day for this check: prefer TimeOpened (when the customer
+    -- transacted — the busy-time signal), fall back to TimeClosed.
+    v_sale_time := COALESCE(
+      public._focus_parse_local_time(v_order.opened_at_local),
+      public._focus_parse_local_time(v_order.closed_at_local)
+    );
+
+    IF v_order.is_voided THEN
+      -- ── Voided check: remove the check's ENTIRE unified_sales footprint —
+      -- base sale rows, their user split children (which share this order's
+      -- external_order_id per split_pos_sale), and tip/discount/tax offsets —
+      -- and replace it with one negative void offset row. A void means the
+      -- transaction didn't happen, so nothing from it survives except the
+      -- single audit marker.
+      --
+      -- NOT guarded by parent_sale_id IS NULL (unlike Steps 2/4/5/6): a void
+      -- removes the whole check INCLUDING user splits. Deleting a split-parent
+      -- together with its child in ONE statement satisfies the parent_sale_id
+      -- FK — the redundant NO-ACTION FK (unified_sales_parent_sale_id_fkey,
+      -- a pre-existing duplicate of the ON DELETE CASCADE fk_parent_sale) would
+      -- otherwise block deleting a base row that still has a split child.
+      -- The void marker itself is excluded so its ON CONFLICT upsert (below)
+      -- keeps a stable identity across re-syncs.
+      DELETE FROM public.unified_sales us
+      WHERE us.restaurant_id     = p_restaurant_id
+        AND us.pos_system        = 'focus'
+        AND us.external_order_id  = v_order_id
+        AND us.external_item_id  <> v_order_id || '_void';
+
+      -- Voided net revenue = SUM of this check's priced items (raw price,
+      -- discount not netted in — per design). No priced items → 0 (still a
+      -- countable void marker).
+      SELECT COALESCE(SUM(foi.price), 0) INTO v_void_amount
+      FROM public.focus_order_items foi
+      WHERE foi.restaurant_id  = p_restaurant_id
+        AND foi.business_date  = v_order.business_date
+        AND foi.focus_check_id = v_order.focus_check_id
+        AND foi.price != 0;
+
+      INSERT INTO public.unified_sales (
+        restaurant_id, pos_system,
+        external_order_id, external_item_id,
+        item_name, quantity, unit_price, total_price,
+        sale_date, sale_time, item_type, adjustment_type, synced_at
+      )
+      VALUES (
+        p_restaurant_id, 'focus',
+        v_order_id, v_order_id || '_void',
+        'Void', 1, -v_void_amount, -v_void_amount,
+        -- item_type='other' (not Toast's 'discount'): the meaningful, Toast-
+        -- consistent identifier is adjustment_type='void'; 'other' avoids a
+        -- collision with item_type='discount' consumers/tests since a void is
+        -- not a discount. Excluded from revenue (not item_type='sale'),
+        -- discounts (adjustment_type != 'discount') and pass-through (not in
+        -- KNOWN_PASS_THROUGH_TYPES).
+        v_order.business_date, v_sale_time, 'other', 'void', now()
+      )
+      ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
+        WHERE parent_sale_id IS NULL
+      DO UPDATE SET
+        item_name   = EXCLUDED.item_name,
+        unit_price  = EXCLUDED.unit_price,
+        total_price = EXCLUDED.total_price,
+        sale_date   = EXCLUDED.sale_date,
+        sale_time   = EXCLUDED.sale_time,
+        synced_at   = EXCLUDED.synced_at;
+
+      GET DIAGNOSTICS v_row_count = ROW_COUNT;
+      v_count := v_count + v_row_count;
+
+      -- Because the focus_orders row still exists (soft-deleted, not
+      -- CASCADE-removed), this loop keeps visiting it on every re-sync —
+      -- this replaces the old orphan-sweep and fixes the bug where a
+      -- hard-deleted check's unified_sales rows were left orphaned forever.
+    ELSE
+      -- ── Step 1: Collect current external_item_ids (sale rows) ──────────────
+      -- Fee items (Dispatch Fee, RailsUpcharge, ...) are excluded: they are
+      -- reclassified as pass-through (Step 3b), not "current sale rows".
+      SELECT ARRAY(
+        SELECT v_order_id || '__' || foi.item_key
+        FROM public.focus_order_items foi
+        WHERE foi.restaurant_id  = p_restaurant_id
+          AND foi.business_date  = v_order.business_date
+          AND foi.focus_check_id = v_order.focus_check_id
+          AND foi.price IS NOT NULL
+          AND foi.price != 0
+          AND NOT public._focus_is_fee_item(foi.name)
+      ) INTO v_current_ids;
+
+      -- ── Step 2b: Fee-reclassification cleanup (backfill-safe) ──────────────
+      -- MUST run BEFORE Step 2 below. A pre-migration fee item currently has
+      -- a legacy item_type='sale' base row under the un-suffixed id
+      -- (v_order_id || '__' || item_key). Its new fee row (Step 3b, below)
+      -- uses a distinct '..._fee' id, so the old sale row must be removed. A
+      -- user may have split-categorized that legacy fee-as-sale row
+      -- (split_pos_sale → child rows with parent_sale_id set), and
+      -- unified_sales carries a redundant NO-ACTION FK
+      -- (unified_sales_parent_sale_id_fkey, 20251031000146) alongside the
+      -- ON DELETE CASCADE fk_parent_sale (20251031003130) — the NO-ACTION FK
+      -- blocks deleting a parent that still has a child, which would abort
+      -- the entire restaurant's sync. So this cleanup deletes the stale
+      -- fee-as-sale base row AND any split children in ONE statement — the
+      -- same technique the void branch (above) uses.
+      --
+      -- Ordering is load-bearing: fee item_keys are excluded from
+      -- v_current_ids (Step 1, above), so Step 2's unchanged
+      -- "NOT IN v_current_ids" orphan-delete would ALSO match a legacy
+      -- fee-as-sale base row — and Step 2 is scoped to parent_sale_id IS NULL
+      -- only, so on its own it would try to delete a base row that still has
+      -- a live split child, hitting the same NO-ACTION FK abort this cleanup
+      -- exists to avoid. Running this DELETE first removes the base row AND
+      -- its children together, so by the time Step 2 runs there is nothing
+      -- left for it to touch for this item_key — a true no-op, not a race.
+      WITH fee_ids AS (
+        SELECT v_order_id || '__' || foi.item_key AS ext_id
+        FROM public.focus_order_items foi
+        WHERE foi.restaurant_id  = p_restaurant_id
+          AND foi.business_date  = v_order.business_date
+          AND foi.focus_check_id = v_order.focus_check_id
+          AND foi.price IS NOT NULL AND foi.price != 0
+          AND public._focus_is_fee_item(foi.name)
+      )
+      DELETE FROM public.unified_sales us
+      WHERE us.restaurant_id    = p_restaurant_id
+        AND us.pos_system       = 'focus'
+        AND us.external_order_id = v_order_id
+        AND ( us.external_item_id IN (SELECT ext_id FROM fee_ids)
+           OR us.parent_sale_id IN (
+                SELECT p.id FROM public.unified_sales p
+                WHERE p.restaurant_id = p_restaurant_id
+                  AND p.pos_system = 'focus'
+                  AND p.external_order_id = v_order_id
+                  AND p.external_item_id IN (SELECT ext_id FROM fee_ids)) );
+
+      -- ── Step 2: DELETE orphan sale rows no longer in focus_order_items ─────
+      -- Only delete base (un-split) rows; parent_sale_id IS NULL guards user-
+      -- managed split/child rows from being silently removed on every sync.
+      -- No-op for fee items: Step 2b (above) already removed their legacy
+      -- sale rows (base + children) in one statement.
+      DELETE FROM public.unified_sales us
+      WHERE us.restaurant_id     = p_restaurant_id
+        AND us.pos_system        = 'focus'
+        AND us.item_type         = 'sale'
+        AND us.sale_date         = v_order.business_date
+        AND us.external_order_id = v_order_id
+        AND us.parent_sale_id IS NULL
+        AND NOT (us.external_item_id = ANY(v_current_ids));
+
+      -- ── Step 3: UPSERT sale rows (one per priced item) ────────────────────
+      -- Fee items are excluded: reclassified as pass-through in Step 3b below,
+      -- never inserted as item_type='sale'.
+      INSERT INTO public.unified_sales (
+        restaurant_id, pos_system,
+        external_order_id, external_item_id,
+        item_name, quantity, unit_price, total_price,
+        sale_date, sale_time, pos_category, item_type, synced_at
+      )
+      SELECT
+        foi.restaurant_id, 'focus',
+        v_order_id, v_order_id || '__' || foi.item_key,
+        foi.name, 1, foi.price, foi.price,
+        foi.business_date, v_sale_time, foi.report_group_id, 'sale', now()
+      FROM public.focus_order_items foi
+      WHERE foi.restaurant_id  = p_restaurant_id
+        AND foi.business_date  = v_order.business_date
+        AND foi.focus_check_id = v_order.focus_check_id
+        AND foi.price IS NOT NULL
+        AND foi.price != 0
+        AND NOT public._focus_is_fee_item(foi.name)
+      ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
+        WHERE parent_sale_id IS NULL
+      DO UPDATE SET
+        item_name    = EXCLUDED.item_name,
+        unit_price   = EXCLUDED.unit_price,
+        total_price  = EXCLUDED.total_price,
+        sale_date    = EXCLUDED.sale_date,
+        sale_time    = EXCLUDED.sale_time,
+        pos_category = EXCLUDED.pos_category,
+        synced_at    = EXCLUDED.synced_at
+        -- category_id + is_categorized intentionally omitted →
+        -- preserves user-managed categorization on re-sync (design §4)
+      ;
+
+      GET DIAGNOSTICS v_row_count = ROW_COUNT;
+      v_count := v_count + v_row_count;
+
+      -- ── Step 3b: UPSERT / DELETE fee offset rows ────────────────────────────
+      -- Third-party delivery fee line items (Dispatch Fee, Dispatch Service
+      -- Fee, RailsUpcharge, ...) are priced CheckItemRecords but are
+      -- pass-through, not revenue. Excluded from Step 3's sale insert above;
+      -- reclassified here as adjustment_type='fee' (item_type='other', mirrors
+      -- the void row's use of 'other' to avoid colliding with a real
+      -- item_type value). external_item_id is suffixed '_fee' — distinct from
+      -- the legacy un-suffixed sale id Step 2b just cleaned up — so this
+      -- upsert has a stable identity across re-syncs.
+      INSERT INTO public.unified_sales (
+        restaurant_id, pos_system,
+        external_order_id, external_item_id,
+        item_name, quantity, unit_price, total_price,
+        sale_date, sale_time, item_type, adjustment_type, synced_at
+      )
+      SELECT
+        foi.restaurant_id, 'focus',
+        v_order_id, v_order_id || '__' || foi.item_key || '_fee',
+        foi.name, 1, foi.price, foi.price,
+        foi.business_date, v_sale_time, 'other', 'fee', now()
+      FROM public.focus_order_items foi
+      WHERE foi.restaurant_id  = p_restaurant_id
+        AND foi.business_date  = v_order.business_date
+        AND foi.focus_check_id = v_order.focus_check_id
+        AND foi.price != 0
+        AND public._focus_is_fee_item(foi.name)
+      ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
+        WHERE parent_sale_id IS NULL
+      DO UPDATE SET
+        item_name   = EXCLUDED.item_name,
+        unit_price  = EXCLUDED.unit_price,
+        total_price = EXCLUDED.total_price,
+        sale_date   = EXCLUDED.sale_date,
+        sale_time   = EXCLUDED.sale_time,
+        synced_at   = EXCLUDED.synced_at;
+
+      GET DIAGNOSTICS v_row_count = ROW_COUNT;
+      v_count := v_count + v_row_count;
+
+      -- Delete stale fee rows for items that are no longer priced fee items
+      -- (item un-priced or renamed away from the fee pattern).
+      -- parent_sale_id IS NULL guards user-managed split rows.
+      DELETE FROM public.unified_sales us
+      WHERE us.restaurant_id     = p_restaurant_id
+        AND us.pos_system        = 'focus'
+        AND us.adjustment_type   = 'fee'
+        AND us.sale_date         = v_order.business_date
+        AND us.external_order_id = v_order_id
+        AND us.parent_sale_id IS NULL
+        AND us.external_item_id NOT IN (
+          SELECT v_order_id || '__' || foi.item_key || '_fee'
+          FROM public.focus_order_items foi
+          WHERE foi.restaurant_id  = p_restaurant_id
+            AND foi.business_date  = v_order.business_date
+            AND foi.focus_check_id = v_order.focus_check_id
+            AND foi.price != 0
+            AND public._focus_is_fee_item(foi.name)
+        );
+
+      -- ── Step 4: UPSERT / DELETE discount offset rows ───────────────────────
+      -- Fee items are excluded from both the insert and the stale-delete
+      -- subquery below: a discounted fee is pass-through, not a revenue
+      -- discount. Without this exclusion, a discounted fee item would emit
+      -- BOTH a Step 3b 'fee' row and a spurious 'discount' row for the same
+      -- item_key.
+      -- Upsert items that have a non-zero discount.
+      -- Focus XML stores DiscountAmount as a negative value (e.g. -3.01).
+      -- Use != 0 (not > 0) so that negative amounts are also captured.
+      -- -ABS() normalises to negative regardless of stored sign.
+      INSERT INTO public.unified_sales (
+        restaurant_id, pos_system,
+        external_order_id, external_item_id,
+        item_name, quantity, unit_price, total_price,
+        sale_date, sale_time, item_type, adjustment_type, synced_at
+      )
+      SELECT
+        foi.restaurant_id, 'focus',
+        v_order_id, v_order_id || '__' || foi.item_key || '_discount',
+        'Discount - ' || COALESCE(foi.name, 'Item'), 1,
+        -ABS(foi.discount_amount), -ABS(foi.discount_amount),
+        foi.business_date, v_sale_time, 'discount', 'discount', now()
+      FROM public.focus_order_items foi
+      WHERE foi.restaurant_id  = p_restaurant_id
+        AND foi.business_date  = v_order.business_date
+        AND foi.focus_check_id = v_order.focus_check_id
+        AND foi.discount_amount != 0
+        AND NOT public._focus_is_fee_item(foi.name)
+      ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
+        WHERE parent_sale_id IS NULL
+      DO UPDATE SET
+        item_name   = EXCLUDED.item_name,
+        unit_price  = EXCLUDED.unit_price,
+        total_price = EXCLUDED.total_price,
+        sale_date   = EXCLUDED.sale_date,
+        sale_time   = EXCLUDED.sale_time,
+        synced_at   = EXCLUDED.synced_at;
+
+      GET DIAGNOSTICS v_row_count = ROW_COUNT;
+      v_count := v_count + v_row_count;
+
+      -- Delete stale discount rows for items that no longer have a discount.
+      -- parent_sale_id IS NULL guards user-managed split rows.
+      DELETE FROM public.unified_sales us
+      WHERE us.restaurant_id     = p_restaurant_id
+        AND us.pos_system        = 'focus'
+        AND us.item_type         = 'discount'
+        AND us.sale_date         = v_order.business_date
+        AND us.external_order_id = v_order_id
+        AND us.parent_sale_id IS NULL
+        AND us.external_item_id NOT IN (
+          SELECT v_order_id || '__' || foi.item_key || '_discount'
+          FROM public.focus_order_items foi
+          WHERE foi.restaurant_id  = p_restaurant_id
+            AND foi.business_date  = v_order.business_date
+            AND foi.focus_check_id = v_order.focus_check_id
+            AND foi.discount_amount != 0
+            AND NOT public._focus_is_fee_item(foi.name)
+        );
+
+      -- ── Step 5: UPSERT / DELETE tip offset rows ────────────────────────────
+      -- Upsert payments with a non-zero tip
+      INSERT INTO public.unified_sales (
+        restaurant_id, pos_system,
+        external_order_id, external_item_id,
+        item_name, quantity, unit_price, total_price,
+        sale_date, sale_time, item_type, adjustment_type, synced_at
+      )
+      SELECT
+        fp.restaurant_id, 'focus',
+        v_order_id, v_order_id || '_' || fp.payment_key || '_tip',
+        'Tip - ' || COALESCE(fp.name, 'Payment'), 1,
+        fp.tip, fp.tip,
+        fp.business_date, v_sale_time, 'tip', 'tip', now()
+      FROM public.focus_payments fp
+      WHERE fp.restaurant_id  = p_restaurant_id
+        AND fp.business_date  = v_order.business_date
+        AND fp.focus_check_id = v_order.focus_check_id
+        AND fp.tip != 0
+      ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
+        WHERE parent_sale_id IS NULL
+      DO UPDATE SET
+        item_name   = EXCLUDED.item_name,
+        unit_price  = EXCLUDED.unit_price,
+        total_price = EXCLUDED.total_price,
+        sale_date   = EXCLUDED.sale_date,
+        sale_time   = EXCLUDED.sale_time,
+        synced_at   = EXCLUDED.synced_at;
+
+      GET DIAGNOSTICS v_row_count = ROW_COUNT;
+      v_count := v_count + v_row_count;
+
+      -- Delete stale tip rows for payments that no longer have a tip.
+      -- parent_sale_id IS NULL guards user-managed split rows.
+      DELETE FROM public.unified_sales us
+      WHERE us.restaurant_id     = p_restaurant_id
+        AND us.pos_system        = 'focus'
+        AND us.item_type         = 'tip'
+        AND us.sale_date         = v_order.business_date
+        AND us.external_order_id = v_order_id
+        AND us.parent_sale_id IS NULL
+        AND us.external_item_id NOT IN (
+          SELECT v_order_id || '_' || fp.payment_key || '_tip'
+          FROM public.focus_payments fp
+          WHERE fp.restaurant_id  = p_restaurant_id
+            AND fp.business_date  = v_order.business_date
+            AND fp.focus_check_id = v_order.focus_check_id
+            AND fp.tip != 0
+        );
+
+      -- ── Step 6: UPSERT / DELETE tax offset row ─────────────────────────────
+      -- Tax is one row per order (SeatRecord.TaxTotal1..5 summed by the parser
+      -- into focus_orders.tax_amount) — NOT one row per item/payment like
+      -- discount/tip — so the delete below is a plain conditional delete keyed
+      -- off "this order's tax_amount is currently 0", not a NOT IN (subquery)
+      -- over a per-row source table. Do not change this to the multi-row
+      -- pattern; there is nothing to enumerate.
+      INSERT INTO public.unified_sales (
+        restaurant_id, pos_system,
+        external_order_id, external_item_id,
+        item_name, quantity, unit_price, total_price,
+        sale_date, sale_time, item_type, adjustment_type, synced_at
+      )
+      SELECT
+        p_restaurant_id, 'focus',
+        v_order_id, v_order_id || '_tax',
+        'Sales Tax', 1,
+        v_order.tax_amount, v_order.tax_amount,
+        v_order.business_date, v_sale_time, 'tax', 'tax', now()
+      WHERE v_order.tax_amount != 0
+      ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
+        WHERE parent_sale_id IS NULL
+      DO UPDATE SET
+        item_name   = EXCLUDED.item_name,
+        unit_price  = EXCLUDED.unit_price,
+        total_price = EXCLUDED.total_price,
+        sale_date   = EXCLUDED.sale_date,
+        sale_time   = EXCLUDED.sale_time,
+        synced_at   = EXCLUDED.synced_at;
+
+      GET DIAGNOSTICS v_row_count = ROW_COUNT;
+      v_count := v_count + v_row_count;
+
+      -- Delete the tax row for this order when it no longer has any tax.
+      -- parent_sale_id IS NULL guards user-managed split rows.
+      IF v_order.tax_amount = 0 THEN
+        DELETE FROM public.unified_sales us
+        WHERE us.restaurant_id     = p_restaurant_id
+          AND us.pos_system        = 'focus'
+          AND us.item_type         = 'tax'
+          AND us.sale_date         = v_order.business_date
+          AND us.external_order_id = v_order_id
+          AND us.external_item_id  = v_order_id || '_tax'
+          AND us.parent_sale_id IS NULL;
+      END IF;
+
+      -- Stale-void cleanup: idempotent un-void. If this check was voided in
+      -- the past (leaving a "<order_id>_void" row) and is_voided has since
+      -- flipped back to false, remove the stale void marker so it doesn't
+      -- linger alongside the freshly-restored sale/tip/discount/tax rows.
+      -- parent_sale_id IS NULL guards user-managed split rows, matching
+      -- every other delete in this function.
+      DELETE FROM public.unified_sales us
+      WHERE us.restaurant_id     = p_restaurant_id
+        AND us.pos_system        = 'focus'
+        AND us.adjustment_type   = 'void'
+        AND us.sale_date         = v_order.business_date
+        AND us.external_order_id = v_order_id
+        AND us.external_item_id  = v_order_id || '_void'
+        AND us.parent_sale_id IS NULL;
+    END IF;
+
+  END LOOP;  -- end per-check loop
+
+  -- Reset GUC flag to re-enable per-row triggers
+  PERFORM set_config('app.skip_unified_sales_triggers', 'false', true);
+
+  -- Batch-categorize uncategorized sale rows (authenticated callers only;
+  -- service-role callers defer to the apply-categorization-rules edge function)
+  PERFORM apply_rules_to_pos_sales_internal(p_restaurant_id, 10000);
+
+  -- Batch-aggregate daily totals for all dates touched in this sync.
+  -- Union two sources so DELETE-only dates are still re-aggregated: synced_at
+  -- only advances on INSERT/UPDATE, so a date whose only change was a removed
+  -- offset row (e.g. a tax row deleted when tax_amount is zeroed, with no
+  -- sale/tip/discount row re-upserted) would otherwise keep stale daily
+  -- totals. The focus_orders business_date range covers every check processed
+  -- this run, including those pure-delete dates (the order row still exists).
+  PERFORM public.aggregate_unified_sales_to_daily(p_restaurant_id, d.sale_date)
+  FROM (
+    SELECT DISTINCT sale_date
+    FROM public.unified_sales
+    WHERE restaurant_id = p_restaurant_id
+      AND pos_system    = 'focus'
+      AND synced_at    >= v_sync_start
+    UNION
+    SELECT DISTINCT fo.business_date
+    FROM public.focus_orders fo
+    WHERE fo.restaurant_id = p_restaurant_id
+      AND (p_start_date IS NULL OR fo.business_date >= p_start_date)
+      AND (p_end_date   IS NULL OR fo.business_date <= p_end_date)
+  ) d;
+
+  RETURN v_count;
+END;
+$function$;
+
+-- Re-apply grants (CREATE OR REPLACE resets ACLs in Postgres).
+REVOKE ALL ON FUNCTION public._sync_focus_transactions_to_unified_sales_impl(uuid, date, date) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public._sync_focus_transactions_to_unified_sales_impl(uuid, date, date) TO service_role;

--- a/supabase/migrations/20260719154500_focus_fee_classification.sql
+++ b/supabase/migrations/20260719154500_focus_fee_classification.sql
@@ -1,0 +1,28 @@
+-- Focus fee-item revenue classification
+--
+-- Design: docs/superpowers/specs/2026-07-19-focus-fee-classification-design.md
+--
+-- Third-party delivery fee line items (Dispatch Fee, Dispatch Service Fee,
+-- RailsUpcharge, ...) are priced CheckItemRecords that the Focus sync RPC
+-- currently classifies as item_type='sale', inflating revenue. This
+-- migration adds an IMMUTABLE helper predicate to identify them by
+-- case-insensitive item-name pattern so the sync RPC can reclassify them
+-- as adjustment_type='fee' (pass-through, excluded from revenue).
+--
+-- Conservative: matches only known third-party delivery pass-through fees.
+-- Does NOT broadly match '%fee%' (a real "Corkage"/"Split-Plate" charge
+-- stays a sale until we learn otherwise). Extending is a one-line OR.
+
+CREATE OR REPLACE FUNCTION public._focus_is_fee_item(p_name text)
+RETURNS boolean
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT p_name IS NOT NULL AND (
+       lower(p_name) LIKE '%dispatch%fee%'   -- Dispatch Fee, Dispatch Service Fee, Dispatch Fee2
+    OR lower(p_name) LIKE '%rails%upcharge%'  -- RailsUpcharge, Rails Upcharge
+  );
+$$;
+
+REVOKE ALL ON FUNCTION public._focus_is_fee_item(text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public._focus_is_fee_item(text) TO service_role;

--- a/supabase/migrations/20260719154500_focus_fee_classification.sql
+++ b/supabase/migrations/20260719154500_focus_fee_classification.sql
@@ -334,10 +334,18 @@ BEGIN
         item_name, quantity, unit_price, total_price,
         sale_date, sale_time, item_type, adjustment_type, synced_at
       )
+      -- total_price / unit_price are NET of any discount on the fee line
+      -- (price - |discount_amount|): a discounted fee means the POS collected
+      -- less, so pass_through_amount / collected_at_pos (both bare SUMs of
+      -- total_price) must reflect the net. We do NOT emit a separate
+      -- adjustment_type='discount' row for fees (Step 4 excludes them) — that
+      -- would misfile a pass-through fee discount as a sales discount — so the
+      -- discount is folded into this single 'fee' row instead.
       SELECT
         foi.restaurant_id, 'focus',
         v_order_id, v_order_id || '__' || foi.item_key || '_fee',
-        foi.name, 1, foi.price, foi.price,
+        foi.name, 1,
+        foi.price - ABS(foi.discount_amount), foi.price - ABS(foi.discount_amount),
         foi.business_date, v_sale_time, 'other', 'fee', now()
       FROM public.focus_order_items foi
       WHERE foi.restaurant_id  = p_restaurant_id

--- a/supabase/tests/55_focus_fee_classification.sql
+++ b/supabase/tests/55_focus_fee_classification.sql
@@ -7,9 +7,16 @@
 --   Third-party delivery fee line items (Dispatch Fee, Dispatch Service Fee,
 --   RailsUpcharge, ...) should be identified as pass-through fees by
 --   case-insensitive name pattern, NOT counted as real sale items.
+--
+-- Section 2: end-to-end classification via
+--   _sync_focus_transactions_to_unified_sales_impl (design cases 2-9):
+--   mixed check (dessert sale + Dispatch Fee), fee-only phantom check
+--   (Dispatch Service Fee only), fee-as-sale backfill cleanup (with and
+--   without a user split child), voided fee check, discounted-fee check,
+--   idempotency, and the get_unified_sales_totals read-layer contract.
 
 BEGIN;
-SELECT plan(9);
+SELECT plan(33);
 
 -- ─────────────────────────────────────────────────────────────────────────────
 -- Section 1: _focus_is_fee_item predicate
@@ -58,6 +65,551 @@ SELECT ok(
 SELECT ok(
   NOT public._focus_is_fee_item(''),
   '_focus_is_fee_item: FALSE for empty string'
+);
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Section 2: end-to-end classification via
+-- _sync_focus_transactions_to_unified_sales_impl
+-- ─────────────────────────────────────────────────────────────────────────────
+--
+-- Setup: one active focus_connections + focus_orders/focus_order_items
+-- covering:
+--   Check 100 (2026-07-16): mixed  — CLYellow Cake (dessert, sale) +
+--                            Dispatch Fee (1.99, fee).
+--   Check 101 (2026-07-16): fee-only "phantom" — Dispatch Service Fee (2.99).
+--   Check 104 (2026-07-17): backfill cleanup — Dispatch Fee (1.99), with a
+--                            pre-seeded legacy item_type='sale' base row
+--                            under the un-suffixed external_item_id.
+--   Check 105 (2026-07-17): split-child backfill cleanup — RailsUpcharge
+--                            (3.25), with a pre-seeded legacy sale base row
+--                            PLUS a user split child (parent_sale_id set).
+--   Check 102 (2026-07-18): voided fee check — Dispatch Fee (1.99), synced
+--                            once while NOT voided (to prove the fee row
+--                            existed), then voided and re-synced.
+--   Check 103 (2026-07-19): discounted fee — Dispatch Service Fee (3.50)
+--                            with discount_amount = -0.50.
+
+SET LOCAL role TO postgres;
+ALTER TABLE public.restaurants           DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_restaurants      DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.focus_connections     DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.focus_orders          DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.focus_order_items     DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.focus_payments        DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.unified_sales         DISABLE ROW LEVEL SECURITY;
+
+-- Auth user (owner) — needed for get_unified_sales_totals, which gates on
+-- user_restaurants membership via auth.uid().
+INSERT INTO auth.users (
+  id, instance_id, aud, role, email, encrypted_password,
+  email_confirmed_at, created_at, updated_at,
+  confirmation_token, recovery_token, email_change_token_new, email_change
+) VALUES (
+  '00000000-0000-0000-0000-f0c200000001',
+  '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated',
+  'ffee-owner@test.com', crypt('pw', gen_salt('bf')),
+  now(), now(), now(), '', '', '', ''
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- Restaurant
+INSERT INTO public.restaurants (id, name, address, phone)
+VALUES ('00000000-0000-0000-0000-f0c200000011', 'Focus Fee Test Kitchen', '1 Dispatch Way', '555-0094')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.user_restaurants (user_id, restaurant_id, role)
+VALUES ('00000000-0000-0000-0000-f0c200000001', '00000000-0000-0000-0000-f0c200000011', 'owner')
+ON CONFLICT (user_id, restaurant_id) DO UPDATE SET role = 'owner';
+
+-- focus_connections (store_id = 'GUID-FEE-STORE')
+INSERT INTO public.focus_connections (
+  id, restaurant_id, store_id,
+  api_key, api_secret_encrypted, environment,
+  is_active, connection_status, initial_sync_done, last_sync_time
+) VALUES (
+  '00000000-0000-0000-0000-f0c200000021',
+  '00000000-0000-0000-0000-f0c200000011',
+  'GUID-FEE-STORE',
+  'test-api-key', 'enc-placeholder', 'production',
+  true, 'connected', true,
+  now() - interval '3 days'
+)
+ON CONFLICT (restaurant_id) DO UPDATE SET store_id = 'GUID-FEE-STORE';
+
+-- ── Check 100 (2026-07-16): mixed — dessert + Dispatch Fee ────────────────
+INSERT INTO public.focus_orders (
+  id, restaurant_id, business_date, focus_check_id,
+  opened_at_local, closed_at_local, total, discount_total, taxable_sales
+) VALUES (
+  '00000000-0000-0000-0000-f0c200000031',
+  '00000000-0000-0000-0000-f0c200000011',
+  '2026-07-16', '100',
+  '2026-07-16T10:00:00', '2026-07-16T10:15:00',
+  8.49, 0.00, 6.50
+)
+ON CONFLICT ON CONSTRAINT focus_orders_unique DO UPDATE SET total = 8.49;
+
+INSERT INTO public.focus_order_items (
+  id, restaurant_id, business_date, focus_check_id, item_key,
+  record_number, item_code, name, report_group_id,
+  price, parent_key, is_modifier, discount_amount
+) VALUES
+  ('00000000-0000-0000-0000-f0c200000041',
+   '00000000-0000-0000-0000-f0c200000011',
+   '2026-07-16', '100', 'IK-DESSERT',
+   'RN-101', 'IC-101', 'CLYellow Cake', '20',
+   6.50, NULL, false, 0.00),
+  ('00000000-0000-0000-0000-f0c200000042',
+   '00000000-0000-0000-0000-f0c200000011',
+   '2026-07-16', '100', 'IK-FEE1',
+   'RN-102', 'IC-102', 'Dispatch Fee', '94',
+   1.99, NULL, false, 0.00)
+ON CONFLICT ON CONSTRAINT focus_order_items_unique DO NOTHING;
+
+-- ── Check 101 (2026-07-16): fee-only "phantom" — Dispatch Service Fee ─────
+INSERT INTO public.focus_orders (
+  id, restaurant_id, business_date, focus_check_id,
+  opened_at_local, closed_at_local, total, discount_total, taxable_sales
+) VALUES (
+  '00000000-0000-0000-0000-f0c200000032',
+  '00000000-0000-0000-0000-f0c200000011',
+  '2026-07-16', '101',
+  '2026-07-16T11:00:00', '2026-07-16T11:05:00',
+  2.99, 0.00, 0.00
+)
+ON CONFLICT ON CONSTRAINT focus_orders_unique DO UPDATE SET total = 2.99;
+
+INSERT INTO public.focus_order_items (
+  id, restaurant_id, business_date, focus_check_id, item_key,
+  record_number, item_code, name, report_group_id,
+  price, parent_key, is_modifier, discount_amount
+) VALUES
+  ('00000000-0000-0000-0000-f0c200000043',
+   '00000000-0000-0000-0000-f0c200000011',
+   '2026-07-16', '101', 'IK-FEE2',
+   'RN-103', 'IC-102', 'Dispatch Service Fee', '94',
+   2.99, NULL, false, 0.00)
+ON CONFLICT ON CONSTRAINT focus_order_items_unique DO NOTHING;
+
+-- ── Check 104 (2026-07-17): backfill cleanup — Dispatch Fee, pre-seeded ───
+-- with a legacy item_type='sale' base row under the un-suffixed id (as a
+-- pre-migration sync would have left it).
+INSERT INTO public.focus_orders (
+  id, restaurant_id, business_date, focus_check_id,
+  opened_at_local, closed_at_local, total, discount_total, taxable_sales
+) VALUES (
+  '00000000-0000-0000-0000-f0c200000033',
+  '00000000-0000-0000-0000-f0c200000011',
+  '2026-07-17', '104',
+  '2026-07-17T12:00:00', '2026-07-17T12:05:00',
+  1.99, 0.00, 0.00
+)
+ON CONFLICT ON CONSTRAINT focus_orders_unique DO UPDATE SET total = 1.99;
+
+INSERT INTO public.focus_order_items (
+  id, restaurant_id, business_date, focus_check_id, item_key,
+  record_number, item_code, name, report_group_id,
+  price, parent_key, is_modifier, discount_amount
+) VALUES
+  ('00000000-0000-0000-0000-f0c200000044',
+   '00000000-0000-0000-0000-f0c200000011',
+   '2026-07-17', '104', 'IK-FEE3',
+   'RN-104', 'IC-102', 'Dispatch Fee', '94',
+   1.99, NULL, false, 0.00)
+ON CONFLICT ON CONSTRAINT focus_order_items_unique DO NOTHING;
+
+INSERT INTO public.unified_sales (
+  restaurant_id, pos_system,
+  external_order_id, external_item_id,
+  item_name, quantity, unit_price, total_price,
+  sale_date, item_type, synced_at
+) VALUES (
+  '00000000-0000-0000-0000-f0c200000011', 'focus',
+  'focus-GUID-FEE-STORE-20260717-104', 'focus-GUID-FEE-STORE-20260717-104__IK-FEE3',
+  'Dispatch Fee', 1, 1.99, 1.99,
+  '2026-07-17', 'sale', now() - interval '1 hour'
+)
+ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
+  WHERE parent_sale_id IS NULL
+DO NOTHING;
+
+-- ── Check 105 (2026-07-17): split-child backfill cleanup — RailsUpcharge ──
+-- Legacy fee-as-sale base row PLUS a user split child (parent_sale_id set).
+-- unified_sales carries a redundant NO-ACTION parent_sale_id FK alongside
+-- the ON DELETE CASCADE fk_parent_sale — deleting the base row alone would
+-- abort the whole sync unless the cleanup deletes base + child together.
+INSERT INTO public.focus_orders (
+  id, restaurant_id, business_date, focus_check_id,
+  opened_at_local, closed_at_local, total, discount_total, taxable_sales
+) VALUES (
+  '00000000-0000-0000-0000-f0c200000034',
+  '00000000-0000-0000-0000-f0c200000011',
+  '2026-07-17', '105',
+  '2026-07-17T13:00:00', '2026-07-17T13:05:00',
+  3.25, 0.00, 0.00
+)
+ON CONFLICT ON CONSTRAINT focus_orders_unique DO UPDATE SET total = 3.25;
+
+INSERT INTO public.focus_order_items (
+  id, restaurant_id, business_date, focus_check_id, item_key,
+  record_number, item_code, name, report_group_id,
+  price, parent_key, is_modifier, discount_amount
+) VALUES
+  ('00000000-0000-0000-0000-f0c200000045',
+   '00000000-0000-0000-0000-f0c200000011',
+   '2026-07-17', '105', 'IK-FEE4',
+   'RN-105', 'IC-102', 'RailsUpcharge', '94',
+   3.25, NULL, false, 0.00)
+ON CONFLICT ON CONSTRAINT focus_order_items_unique DO NOTHING;
+
+INSERT INTO public.unified_sales (
+  id, restaurant_id, pos_system,
+  external_order_id, external_item_id,
+  item_name, quantity, unit_price, total_price,
+  sale_date, item_type, synced_at
+) VALUES (
+  '00000000-0000-0000-0000-f0c200000055',
+  '00000000-0000-0000-0000-f0c200000011', 'focus',
+  'focus-GUID-FEE-STORE-20260717-105', 'focus-GUID-FEE-STORE-20260717-105__IK-FEE4',
+  'RailsUpcharge', 1, 3.25, 3.25,
+  '2026-07-17', 'sale', now() - interval '1 hour'
+)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.unified_sales (
+  id, restaurant_id, pos_system,
+  external_order_id, external_item_id,
+  item_name, quantity, unit_price, total_price,
+  sale_date, item_type, parent_sale_id, synced_at
+) VALUES (
+  '00000000-0000-0000-0000-f0c200000056',
+  '00000000-0000-0000-0000-f0c200000011', 'focus',
+  'focus-GUID-FEE-STORE-20260717-105', 'focus-GUID-FEE-STORE-20260717-105__IK-FEE4-split',
+  'RailsUpcharge (split)', 1, 1.00, 1.00,
+  '2026-07-17', 'sale', '00000000-0000-0000-0000-f0c200000055', now() - interval '1 hour'
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- ── Check 102 (2026-07-18): voided fee check — Dispatch Fee ────────────────
+-- Starts NOT voided so the first sync actually creates its fee row; voided
+-- and re-synced later (case 8).
+INSERT INTO public.focus_orders (
+  id, restaurant_id, business_date, focus_check_id,
+  opened_at_local, closed_at_local, total, discount_total, taxable_sales
+) VALUES (
+  '00000000-0000-0000-0000-f0c200000035',
+  '00000000-0000-0000-0000-f0c200000011',
+  '2026-07-18', '102',
+  '2026-07-18T14:00:00', '2026-07-18T14:05:00',
+  1.99, 0.00, 0.00
+)
+ON CONFLICT ON CONSTRAINT focus_orders_unique DO UPDATE SET total = 1.99, is_voided = false, voided_at = NULL;
+
+INSERT INTO public.focus_order_items (
+  id, restaurant_id, business_date, focus_check_id, item_key,
+  record_number, item_code, name, report_group_id,
+  price, parent_key, is_modifier, discount_amount
+) VALUES
+  ('00000000-0000-0000-0000-f0c200000046',
+   '00000000-0000-0000-0000-f0c200000011',
+   '2026-07-18', '102', 'IK-FEE5',
+   'RN-106', 'IC-102', 'Dispatch Fee', '94',
+   1.99, NULL, false, 0.00)
+ON CONFLICT ON CONSTRAINT focus_order_items_unique DO NOTHING;
+
+-- ── Check 103 (2026-07-19): discounted fee — Dispatch Service Fee ─────────
+-- Focus XML stores DiscountAmount as negative.
+INSERT INTO public.focus_orders (
+  id, restaurant_id, business_date, focus_check_id,
+  opened_at_local, closed_at_local, total, discount_total, taxable_sales
+) VALUES (
+  '00000000-0000-0000-0000-f0c200000036',
+  '00000000-0000-0000-0000-f0c200000011',
+  '2026-07-19', '103',
+  '2026-07-19T15:00:00', '2026-07-19T15:05:00',
+  3.00, 0.50, 0.00
+)
+ON CONFLICT ON CONSTRAINT focus_orders_unique DO UPDATE SET total = 3.00;
+
+INSERT INTO public.focus_order_items (
+  id, restaurant_id, business_date, focus_check_id, item_key,
+  record_number, item_code, name, report_group_id,
+  price, parent_key, is_modifier, discount_amount
+) VALUES
+  ('00000000-0000-0000-0000-f0c200000047',
+   '00000000-0000-0000-0000-f0c200000011',
+   '2026-07-19', '103', 'IK-FEE6',
+   'RN-107', 'IC-102', 'Dispatch Service Fee', '94',
+   3.50, NULL, false, -0.50)
+ON CONFLICT ON CONSTRAINT focus_order_items_unique DO NOTHING;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- First sync: covers 2026-07-16..2026-07-19 (check 102 still NOT voided).
+-- ─────────────────────────────────────────────────────────────────────────
+SELECT _sync_focus_transactions_to_unified_sales_impl(
+  '00000000-0000-0000-0000-f0c200000011'::uuid,
+  '2026-07-16'::date, '2026-07-19'::date
+);
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- Case 2: mixed check (100) — dessert row is a plain sale, NULL adjustment
+-- ─────────────────────────────────────────────────────────────────────────
+SELECT is(
+  (SELECT item_type FROM public.unified_sales
+   WHERE external_order_id = 'focus-GUID-FEE-STORE-20260716-100'
+     AND external_item_id = 'focus-GUID-FEE-STORE-20260716-100__IK-DESSERT'),
+  'sale',
+  'Mixed check: dessert row item_type=''sale'''
+);
+
+SELECT ok(
+  (SELECT adjustment_type FROM public.unified_sales
+   WHERE external_order_id = 'focus-GUID-FEE-STORE-20260716-100'
+     AND external_item_id = 'focus-GUID-FEE-STORE-20260716-100__IK-DESSERT') IS NULL,
+  'Mixed check: dessert row adjustment_type IS NULL'
+);
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- Case 3: mixed check (100) — Dispatch Fee row is a pass-through fee
+-- ─────────────────────────────────────────────────────────────────────────
+SELECT is(
+  (SELECT item_type FROM public.unified_sales
+   WHERE external_order_id = 'focus-GUID-FEE-STORE-20260716-100'
+     AND external_item_id = 'focus-GUID-FEE-STORE-20260716-100__IK-FEE1_fee'),
+  'other',
+  'Mixed check: Dispatch Fee row item_type=''other'''
+);
+
+SELECT is(
+  (SELECT adjustment_type FROM public.unified_sales
+   WHERE external_order_id = 'focus-GUID-FEE-STORE-20260716-100'
+     AND external_item_id = 'focus-GUID-FEE-STORE-20260716-100__IK-FEE1_fee'),
+  'fee',
+  'Mixed check: Dispatch Fee row adjustment_type=''fee'''
+);
+
+SELECT is(
+  (SELECT total_price FROM public.unified_sales
+   WHERE external_order_id = 'focus-GUID-FEE-STORE-20260716-100'
+     AND external_item_id = 'focus-GUID-FEE-STORE-20260716-100__IK-FEE1_fee'),
+  1.99::numeric,
+  'Mixed check: Dispatch Fee row total_price=1.99'
+);
+
+SELECT ok(
+  right(
+    (SELECT external_item_id FROM public.unified_sales
+     WHERE external_order_id = 'focus-GUID-FEE-STORE-20260716-100'
+       AND adjustment_type = 'fee'),
+    4
+  ) = '_fee',
+  'Mixed check: fee row external_item_id ends in ''_fee'' (literal suffix)'
+);
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- Case 4: get_unified_sales_totals — revenue excludes fees; pass_through
+-- and collected_at_pos include them (date range = 2026-07-16 only, so the
+-- totals cover exactly checks 100 + 101).
+-- ─────────────────────────────────────────────────────────────────────────
+SET LOCAL "request.jwt.claims" TO '{"sub": "00000000-0000-0000-0000-f0c200000001"}';
+
+SELECT is(
+  (SELECT revenue FROM public.get_unified_sales_totals(
+     '00000000-0000-0000-0000-f0c200000011'::uuid, '2026-07-16'::date, '2026-07-16'::date)),
+  6.50::numeric,
+  'get_unified_sales_totals: revenue excludes both fee rows (only the 6.50 dessert counts)'
+);
+
+SELECT is(
+  (SELECT pass_through_amount FROM public.get_unified_sales_totals(
+     '00000000-0000-0000-0000-f0c200000011'::uuid, '2026-07-16'::date, '2026-07-16'::date)),
+  4.98::numeric,
+  'get_unified_sales_totals: pass_through_amount includes both fees (1.99 + 2.99 = 4.98)'
+);
+
+SELECT is(
+  (SELECT collected_at_pos FROM public.get_unified_sales_totals(
+     '00000000-0000-0000-0000-f0c200000011'::uuid, '2026-07-16'::date, '2026-07-16'::date)),
+  11.48::numeric,
+  'get_unified_sales_totals: collected_at_pos includes fees (6.50 + 1.99 + 2.99 = 11.48)'
+);
+
+SET LOCAL role TO postgres;
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- Case 5: fee-only "phantom" check (101) — $0 revenue, fee still pass-through
+-- ─────────────────────────────────────────────────────────────────────────
+SELECT is(
+  (SELECT COUNT(*)::integer FROM public.unified_sales
+   WHERE external_order_id = 'focus-GUID-FEE-STORE-20260716-101'
+     AND item_type = 'sale'),
+  0,
+  'Phantom check: no item_type=''sale'' row (fee is the only line item)'
+);
+
+SELECT is(
+  (SELECT total_price FROM public.unified_sales
+   WHERE external_order_id = 'focus-GUID-FEE-STORE-20260716-101'
+     AND adjustment_type = 'fee'),
+  2.99::numeric,
+  'Phantom check: Dispatch Service Fee row total_price=2.99'
+);
+
+SELECT is(
+  (SELECT COALESCE(SUM(total_price), 0)::numeric FROM public.unified_sales
+   WHERE external_order_id = 'focus-GUID-FEE-STORE-20260716-101'
+     AND item_type = 'sale'
+     AND adjustment_type IS NULL),
+  0::numeric,
+  'Phantom check: revenue contribution is 0 (not suppressed — row exists, just excluded)'
+);
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- Case 6: backfill cleanup (check 104) — legacy fee-as-sale row is deleted
+-- and replaced by the '_fee' row.
+-- ─────────────────────────────────────────────────────────────────────────
+SELECT is(
+  (SELECT COUNT(*)::integer FROM public.unified_sales
+   WHERE external_order_id = 'focus-GUID-FEE-STORE-20260717-104'
+     AND external_item_id = 'focus-GUID-FEE-STORE-20260717-104__IK-FEE3'),
+  0,
+  'Backfill cleanup: legacy fee-as-sale base row (un-suffixed id) is deleted'
+);
+
+SELECT is(
+  (SELECT total_price FROM public.unified_sales
+   WHERE external_order_id = 'focus-GUID-FEE-STORE-20260717-104'
+     AND external_item_id = 'focus-GUID-FEE-STORE-20260717-104__IK-FEE3_fee'
+     AND adjustment_type = 'fee'),
+  1.99::numeric,
+  'Backfill cleanup: replaced by a ''_fee'' row with total_price=1.99'
+);
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- Case 6b: split-child backfill cleanup (check 105) — base row AND its
+-- split child are BOTH deleted in one shot (no FK-violation abort).
+-- ─────────────────────────────────────────────────────────────────────────
+SELECT is(
+  (SELECT COUNT(*)::integer FROM public.unified_sales
+   WHERE external_order_id = 'focus-GUID-FEE-STORE-20260717-105'
+     AND external_item_id IN (
+       'focus-GUID-FEE-STORE-20260717-105__IK-FEE4',
+       'focus-GUID-FEE-STORE-20260717-105__IK-FEE4-split'
+     )),
+  0,
+  'Split-child backfill cleanup: legacy base row AND its split child are both deleted'
+);
+
+SELECT is(
+  (SELECT total_price FROM public.unified_sales
+   WHERE external_order_id = 'focus-GUID-FEE-STORE-20260717-105'
+     AND external_item_id = 'focus-GUID-FEE-STORE-20260717-105__IK-FEE4_fee'
+     AND adjustment_type = 'fee'),
+  3.25::numeric,
+  'Split-child backfill cleanup: replaced by a ''_fee'' row with total_price=3.25 (no FK abort)'
+);
+
+SELECT is(
+  (SELECT COALESCE(SUM(total_price), 0)::numeric FROM public.unified_sales
+   WHERE external_order_id = 'focus-GUID-FEE-STORE-20260717-105'
+     AND item_type = 'sale'
+     AND adjustment_type IS NULL),
+  0::numeric,
+  'Split-child backfill cleanup: revenue excludes the reclassified fee (no sale row survives)'
+);
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- Precondition for case 8: check 102's fee row exists BEFORE it is voided,
+-- so "no leftover _fee row after voiding" below is a meaningful assertion.
+-- ─────────────────────────────────────────────────────────────────────────
+SELECT is(
+  (SELECT total_price FROM public.unified_sales
+   WHERE external_order_id = 'focus-GUID-FEE-STORE-20260718-102'
+     AND adjustment_type = 'fee'),
+  1.99::numeric,
+  'Voided-check precondition: Dispatch Fee row (1.99) exists before voiding'
+);
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- Case 9: discounted fee (check 103) — emits the 'fee' row only, NOT a
+-- spurious 'discount' row for the same item_key.
+-- ─────────────────────────────────────────────────────────────────────────
+SELECT is(
+  (SELECT total_price FROM public.unified_sales
+   WHERE external_order_id = 'focus-GUID-FEE-STORE-20260719-103'
+     AND external_item_id = 'focus-GUID-FEE-STORE-20260719-103__IK-FEE6_fee'
+     AND adjustment_type = 'fee'),
+  3.50::numeric,
+  'Discounted fee: ''fee'' row created with total_price=3.50 (undiscounted price)'
+);
+
+SELECT is(
+  (SELECT COUNT(*)::integer FROM public.unified_sales
+   WHERE external_order_id = 'focus-GUID-FEE-STORE-20260719-103'
+     AND item_type = 'discount'),
+  0,
+  'Discounted fee: no spurious adjustment_type=''discount'' row for the fee item'
+);
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- Case 7: idempotency — re-run the same sync; row counts and identities are
+-- unchanged (no duplicates from re-inserting fee/backfill/discount rows).
+-- ─────────────────────────────────────────────────────────────────────────
+CREATE TEMP TABLE pre_second_sync_snapshot AS
+SELECT COUNT(*)::integer AS row_count
+FROM public.unified_sales
+WHERE restaurant_id = '00000000-0000-0000-0000-f0c200000011';
+
+SELECT _sync_focus_transactions_to_unified_sales_impl(
+  '00000000-0000-0000-0000-f0c200000011'::uuid,
+  '2026-07-16'::date, '2026-07-19'::date
+);
+
+SELECT is(
+  (SELECT COUNT(*)::integer FROM public.unified_sales
+   WHERE restaurant_id = '00000000-0000-0000-0000-f0c200000011'),
+  (SELECT row_count FROM pre_second_sync_snapshot),
+  'Idempotency: re-running the sync leaves the total row count unchanged'
+);
+
+SELECT is(
+  (SELECT COUNT(*)::integer FROM public.unified_sales
+   WHERE external_order_id = 'focus-GUID-FEE-STORE-20260716-100'
+     AND adjustment_type = 'fee'),
+  1,
+  'Idempotency: exactly one fee row for check 100''s Dispatch Fee (no duplicate)'
+);
+
+-- ─────────────────────────────────────────────────────────────────────────
+-- Case 8: voided fee check (102) — flip is_voided and re-sync just that
+-- date. The whole check's footprint (including the fee row) collapses into
+-- a single adjustment_type='void' marker.
+-- ─────────────────────────────────────────────────────────────────────────
+UPDATE public.focus_orders
+SET is_voided = true, voided_at = now()
+WHERE restaurant_id = '00000000-0000-0000-0000-f0c200000011'
+  AND business_date = '2026-07-18'
+  AND focus_check_id = '102';
+
+SELECT _sync_focus_transactions_to_unified_sales_impl(
+  '00000000-0000-0000-0000-f0c200000011'::uuid,
+  '2026-07-18'::date, '2026-07-18'::date
+);
+
+SELECT is(
+  (SELECT COUNT(*)::integer FROM public.unified_sales
+   WHERE external_order_id = 'focus-GUID-FEE-STORE-20260718-102'
+     AND adjustment_type = 'void'),
+  1,
+  'Voided fee check: exactly one adjustment_type=''void'' marker'
+);
+
+SELECT is(
+  (SELECT COUNT(*)::integer FROM public.unified_sales
+   WHERE external_order_id = 'focus-GUID-FEE-STORE-20260718-102'
+     AND adjustment_type = 'fee'),
+  0,
+  'Voided fee check: no leftover ''_fee'' row after voiding'
 );
 
 SELECT * FROM finish();

--- a/supabase/tests/55_focus_fee_classification.sql
+++ b/supabase/tests/55_focus_fee_classification.sql
@@ -16,7 +16,7 @@
 --   idempotency, and the get_unified_sales_totals read-layer contract.
 
 BEGIN;
-SELECT plan(33);
+SELECT plan(35);
 
 -- ─────────────────────────────────────────────────────────────────────────────
 -- Section 1: _focus_is_fee_item predicate
@@ -531,16 +531,27 @@ SELECT is(
 );
 
 -- ─────────────────────────────────────────────────────────────────────────
--- Case 9: discounted fee (check 103) — emits the 'fee' row only, NOT a
--- spurious 'discount' row for the same item_key.
+-- Case 9: discounted fee (check 103, price 3.50, discount -0.50) — emits ONE
+-- 'fee' row NET of the discount (total_price = 3.00), NOT a gross 3.50 row and
+-- NOT a spurious 'discount' row. Netting keeps pass_through_amount /
+-- collected_at_pos (bare SUMs of total_price) matching what the POS collected.
 -- ─────────────────────────────────────────────────────────────────────────
 SELECT is(
   (SELECT total_price FROM public.unified_sales
    WHERE external_order_id = 'focus-GUID-FEE-STORE-20260719-103'
      AND external_item_id = 'focus-GUID-FEE-STORE-20260719-103__IK-FEE6_fee'
      AND adjustment_type = 'fee'),
-  3.50::numeric,
-  'Discounted fee: ''fee'' row created with total_price=3.50 (undiscounted price)'
+  3.00::numeric,
+  'Discounted fee: ''fee'' row total_price is NET of discount (3.50 - 0.50 = 3.00)'
+);
+
+SELECT is(
+  (SELECT unit_price FROM public.unified_sales
+   WHERE external_order_id = 'focus-GUID-FEE-STORE-20260719-103'
+     AND external_item_id = 'focus-GUID-FEE-STORE-20260719-103__IK-FEE6_fee'
+     AND adjustment_type = 'fee'),
+  3.00::numeric,
+  'Discounted fee: ''fee'' row unit_price is NET of discount (quantity=1)'
 );
 
 SELECT is(
@@ -549,6 +560,17 @@ SELECT is(
      AND item_type = 'discount'),
   0,
   'Discounted fee: no spurious adjustment_type=''discount'' row for the fee item'
+);
+
+-- collected-side proof: the order's entire unified_sales footprint (all
+-- non-void rows) sums to the net 3.00 the POS actually collected — no
+-- overstatement from the discounted fee.
+SELECT is(
+  (SELECT COALESCE(SUM(total_price), 0) FROM public.unified_sales
+   WHERE external_order_id = 'focus-GUID-FEE-STORE-20260719-103'
+     AND adjustment_type IS DISTINCT FROM 'void'),
+  3.00::numeric,
+  'Discounted fee: collected-side SUM(total_price) = net 3.00 (no overstatement)'
 );
 
 -- ─────────────────────────────────────────────────────────────────────────

--- a/supabase/tests/55_focus_fee_classification.sql
+++ b/supabase/tests/55_focus_fee_classification.sql
@@ -1,0 +1,64 @@
+-- Tests for focus fee-item revenue classification
+-- Migration: 20260719154500_focus_fee_classification.sql
+--
+-- Design: docs/superpowers/specs/2026-07-19-focus-fee-classification-design.md
+--
+-- Section 1: _focus_is_fee_item predicate
+--   Third-party delivery fee line items (Dispatch Fee, Dispatch Service Fee,
+--   RailsUpcharge, ...) should be identified as pass-through fees by
+--   case-insensitive name pattern, NOT counted as real sale items.
+
+BEGIN;
+SELECT plan(9);
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Section 1: _focus_is_fee_item predicate
+-- ─────────────────────────────────────────────────────────────────────────────
+
+SELECT ok(
+  public._focus_is_fee_item('Dispatch Fee'),
+  '_focus_is_fee_item: TRUE for ''Dispatch Fee'''
+);
+
+SELECT ok(
+  public._focus_is_fee_item('Dispatch Service Fee'),
+  '_focus_is_fee_item: TRUE for ''Dispatch Service Fee'''
+);
+
+SELECT ok(
+  public._focus_is_fee_item('Dispatch Fee2'),
+  '_focus_is_fee_item: TRUE for ''Dispatch Fee2'''
+);
+
+SELECT ok(
+  public._focus_is_fee_item('RailsUpcharge'),
+  '_focus_is_fee_item: TRUE for ''RailsUpcharge'''
+);
+
+SELECT ok(
+  public._focus_is_fee_item('Rails Upcharge'),
+  '_focus_is_fee_item: TRUE for ''Rails Upcharge'''
+);
+
+SELECT ok(
+  NOT public._focus_is_fee_item('CLYellow Cake'),
+  '_focus_is_fee_item: FALSE for ''CLYellow Cake'' (real sale item)'
+);
+
+SELECT ok(
+  NOT public._focus_is_fee_item('Dispatch Tip'),
+  '_focus_is_fee_item: FALSE for ''Dispatch Tip'' (tip, not fee)'
+);
+
+SELECT ok(
+  NOT public._focus_is_fee_item(NULL),
+  '_focus_is_fee_item: FALSE for NULL'
+);
+
+SELECT ok(
+  NOT public._focus_is_fee_item(''),
+  '_focus_is_fee_item: FALSE for empty string'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Summary
- Third-party delivery **fee** line items (`Dispatch Fee`, `Dispatch Service Fee`, `RailsUpcharge`) were imported as `item_type='sale'` and **inflated revenue**. This reclassifies them to `adjustment_type='fee'` inside `_sync_focus_transactions_to_unified_sales_impl`, so they drop out of `revenue` while staying in `pass_through_amount` and `collected_at_pos` (the existing read-layer contract — no read-layer change, no new enum value).
- The **"$0 delivery order"** symptom resolves for free: a fee-only check correctly nets to $0 sales with the fee captured as pass-through. No suppression.
- Identification is by **item-name pattern** (`%dispatch%fee%`, `%rails%upcharge%`) via a new `IMMUTABLE` `_focus_is_fee_item()` helper — portable across tenants (Focus ReportGroupIDs are per-restaurant configurable).
- **FK-safe backfill**: a dedicated Step 2b deletes any pre-existing fee-as-sale row *and its split children in one statement*, so a restaurant that split-categorized a legacy fee row can't trip the redundant NO-ACTION `parent_sale_id` FK and abort its whole sync.
- **Discounted fees are netted** into the single fee row (`total_price = price − |discount|`) so `collected_at_pos`/`pass_through` match what the POS actually collected (Codex Phase-7b finding, resolved with an approved design amendment).

## Test plan
- New pgTAP `supabase/tests/55_focus_fee_classification.sql` — **35 assertions**: predicate truth table; sale-vs-fee classification; totals (revenue excludes fees, pass-through + collected include them); phantom $0; backfill (with & without split child, no FK abort); idempotency; voided fee → single `void` marker; discounted fee netted to 3.00 with no spurious discount row.
- Local: 35/35 pass; typecheck ✅; build ✅. (One unrelated suite failure locally is shared-dev-DB contamination from another branch's migration — passes on CI's clean reset.)

## Design & plan
- Design: `docs/superpowers/specs/2026-07-19-focus-fee-classification-design.md`
- Plan: `docs/superpowers/plans/2026-07-19-focus-fee-classification-plan.md`
- Reviewed in Phase 2.5 (Supabase design review: 1 major + 4 minor, all folded) and Phase 7a (5 Claude reviewers + Codex; Codex major on discounted-fee netting fixed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)