### PR TITLE
fix(revel): Revel sold_at timezone corruption (naive-local parsed as UTC)

### DIFF
--- a/docs/superpowers/plans/2026-07-21-revel-timezone-sold-at-fix.md
+++ b/docs/superpowers/plans/2026-07-21-revel-timezone-sold-at-fix.md
@@ -25,21 +25,30 @@ Bite-sized, dependency-ordered tasks. Each is one RED→GREEN→REFACTOR→COMMI
 - `revel-webhook`, `revel-sync-data`, `revel-bulk-sync`: fetch `restaurants.timezone` once per run; pass into `processOrder`; fallback `America/Chicago`; warn-log if null.
 - **Depends on:** T2.
 
-## T4 — Backfill migration
-- New migration: recompute `revel_orders.sold_at` from `raw_json` `created_date` via `::timestamp AT TIME ZONE COALESCE(r.timezone,'America/Chicago')`; propagate to `unified_sales.sold_at` (join `external_order_id = revel_order_id`, `pos_system='revel'`). Idempotent (`IS DISTINCT FROM` guards). Emit pre/post affected-row report; flag null-tz restaurants.
+## T4 — Backfill migration (hardened per design review)
+- Add `IMMUTABLE` helper `revel_raw_created_date(jsonb)` mirroring `getOrderNode`/`parseDateTime` precedence (envelopes `Order/order/payload`; fields `created_date/createdDate/closed_date/finalized_date/date`).
+- Per-restaurant `DO` loop:
+  - validate tz against `pg_timezone_names` (fallback `America/Chicago`);
+  - UPDATE `revel_orders.sold_at` (`IS DISTINCT FROM` guard);
+  - suppress `app.skip_unified_sales_triggers` around the `unified_sales.sold_at` UPDATE, then re-aggregate once per distinct `(restaurant_id, sale_date)` via `aggregate_unified_sales_to_daily`.
+- Pre/post report: affected rows + restaurants with invalid/null tz.
 - **Depends on:** none (reads `raw_json`); run after T2/T3 deploy per sequencing.
 
-## T5 — pgTAP reconciliation test
-- `supabase/tests/revel_sold_at_backfill.sql`: after backfill, for all Revel rows `(sold_at AT TIME ZONE r.timezone)::time` equals `sale_time` (± 1s); `mismatches = 0`. Seed a naive-local revel order fixture.
-- **Depends on:** T4.
+## T5 — Revel RPC self-heal (durability)
+- `revel_sync_financial_breakdown` + `sync_revel_to_unified_sales`: change `unified_sales` insert blocks' `ON CONFLICT … DO NOTHING` → `DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at)` (update **only** `sold_at`; preserve categorization). Mirrors Toast's RPC.
+- **Depends on:** none (SQL migration alongside T4).
 
-## T6 — Regression guard: Toast unaffected
+## T6 — pgTAP reconciliation test
+- `supabase/tests/revel_sold_at_backfill.sql`: after backfill, for all Revel rows `(sold_at AT TIME ZONE r.timezone)::time` equals `sale_time` (± 1s); `mismatches = 0`. Seed a naive-local revel order fixture. Also assert an invalid-tz restaurant falls back (no throw) and the trigger-suppression path leaves `daily_*` aggregates consistent.
+- **Depends on:** T4, T5.
+
+## T7 — Regression guard: Toast unaffected
 - Unit assertion that Toast `sold_at`/hour attribution is unchanged (Toast stores a correct instant from `closedDate`; must not regress). Confirm no shared read-path change.
 - **Depends on:** T2.
 
 ## Verification (Phase 8 + post-deploy)
 - Unit + pgTAP + typecheck + lint + build green.
-- Post-deploy (manual, documented in PR): Labor view for Rush Bowls Kallison Ranch shows earliest sales **7 AM**, no "staff 1–6 AM"/"Peak 3 AM"; daily `sum(total_price)` by `sale_date` reconciles to Revel Sales Summary; hourly distribution matches Revel Hourly Sales.
+- Post-deploy (manual, documented in PR): Labor view for Rush Bowls Kallison Ranch shows earliest sales **7 AM**, no "staff 1–6 AM"/"Peak 3 AM"; daily `sum(total_price)` by `sale_date` reconciles to Revel Sales Summary; hourly distribution matches Revel Hourly Sales; **`generate-schedule`** hourly weighting no longer clusters overnight; migration pre-flight report shows no invalid-tz surprises.
 
 ## Sequencing
 Deploy source fix (T1–T3) → run backfill (T4) → verify (T5, post-deploy checks). T4 before-or-with deploy is fine (reads raw_json), but running it right after deploy avoids a re-corruption window.

--- a/docs/superpowers/plans/2026-07-21-revel-timezone-sold-at-fix.md
+++ b/docs/superpowers/plans/2026-07-21-revel-timezone-sold-at-fix.md
@@ -1,0 +1,45 @@
+# Plan (tasks): Fix Revel `sold_at` timezone corruption
+
+**Design:** [../specs/2026-07-21-revel-timezone-sold-at-design.md](../specs/2026-07-21-revel-timezone-sold-at-design.md)
+**Branch:** `fix/revel-sold-at-timezone` · **Severity:** P1 (auditor exposure)
+
+Bite-sized, dependency-ordered tasks. Each is one RED→GREEN→REFACTOR→COMMIT cycle.
+
+## T1 — `zonedNaiveToUtc` helper + unit tests
+- New `supabase/functions/_shared/timezone.ts`: `zonedNaiveToUtc(naive, tz)` + `safeTz()` probe + `tzOffsetMs()` (formatToParts).
+- Tests `tests/unit/edgeTimezone.test.ts`:
+  - `"2026-07-19T07:32:16" / America/Chicago → 2026-07-19T12:32:16Z` (CDT −5).
+  - `"2026-01-15T07:32:16" / America/Chicago → 2026-01-15T13:32:16Z` (CST −6).
+  - DST-transition day (2026-03-08) sanity.
+  - Invalid tz (`""`, `"Bogus/Zone"`) → falls back to `America/Chicago`, no throw.
+  - TZ-portable: assertions compare to explicit UTC ISO (independent of host TZ).
+- **Depends on:** none.
+
+## T2 — `parseDateTime` tz-aware + processor tests
+- `revelOrderProcessor.ts`: `parseDateTime(order, timeZone)`; naive `created_date` → `zonedNaiveToUtc`; already-zoned (`Z`/`±hh:mm`) → `new Date`. `orderTime` = local `HH:MM:SS`; `orderDate` = business date computed in **local** space (naive − 2h → date).
+- Thread `timeZone` through `normalizeOrder` → `processOrder`.
+- Fix + expand `tests/unit/revelOrderProcessor.test.ts`: fixture → naive `"2026-07-19T07:32:16"`; assert `sold_at === 2026-07-19T12:32:16Z`, `order_time === "07:32:16"`, `order_date === "2026-07-19"`. Add a post-2 AM-boundary case.
+- **Depends on:** T1.
+
+## T3 — Callers resolve & pass tz
+- `revel-webhook`, `revel-sync-data`, `revel-bulk-sync`: fetch `restaurants.timezone` once per run; pass into `processOrder`; fallback `America/Chicago`; warn-log if null.
+- **Depends on:** T2.
+
+## T4 — Backfill migration
+- New migration: recompute `revel_orders.sold_at` from `raw_json` `created_date` via `::timestamp AT TIME ZONE COALESCE(r.timezone,'America/Chicago')`; propagate to `unified_sales.sold_at` (join `external_order_id = revel_order_id`, `pos_system='revel'`). Idempotent (`IS DISTINCT FROM` guards). Emit pre/post affected-row report; flag null-tz restaurants.
+- **Depends on:** none (reads `raw_json`); run after T2/T3 deploy per sequencing.
+
+## T5 — pgTAP reconciliation test
+- `supabase/tests/revel_sold_at_backfill.sql`: after backfill, for all Revel rows `(sold_at AT TIME ZONE r.timezone)::time` equals `sale_time` (± 1s); `mismatches = 0`. Seed a naive-local revel order fixture.
+- **Depends on:** T4.
+
+## T6 — Regression guard: Toast unaffected
+- Unit assertion that Toast `sold_at`/hour attribution is unchanged (Toast stores a correct instant from `closedDate`; must not regress). Confirm no shared read-path change.
+- **Depends on:** T2.
+
+## Verification (Phase 8 + post-deploy)
+- Unit + pgTAP + typecheck + lint + build green.
+- Post-deploy (manual, documented in PR): Labor view for Rush Bowls Kallison Ranch shows earliest sales **7 AM**, no "staff 1–6 AM"/"Peak 3 AM"; daily `sum(total_price)` by `sale_date` reconciles to Revel Sales Summary; hourly distribution matches Revel Hourly Sales.
+
+## Sequencing
+Deploy source fix (T1–T3) → run backfill (T4) → verify (T5, post-deploy checks). T4 before-or-with deploy is fine (reads raw_json), but running it right after deploy avoids a re-corruption window.

--- a/docs/superpowers/specs/2026-07-21-revel-timezone-sold-at-design.md
+++ b/docs/superpowers/specs/2026-07-21-revel-timezone-sold-at-design.md
@@ -34,6 +34,7 @@ Defect site: [`parseDateTime`](../../../supabase/functions/_shared/revelOrderPro
 **Broken (reads `sold_at` as instant → tz):**
 - `src/lib/splhAnalytics.ts` `hourOfSale` (Labor heatmap, staffing suggestions)
 - `src/hooks/useHourlySalesPattern.ts`, `useSplhData.ts`, `useWeekStaffingSuggestions.ts`, `useSplhAnalytics.ts`
+- **`supabase/functions/generate-schedule/index.ts`** (AI schedule generation) via `hourFromSale` in `supabase/functions/_shared/sales-hour-utils.ts` — same bug class: AI staffing suggestions were built on the same corrupted overnight-shifted hourly distribution. No code change needed (it's tz-aware and heals with the data), but it's an unlisted consumer with real blast radius — must be re-verified post-backfill.
 
 **Already correct (must NOT regress):**
 - **Revenue/period totals** (`get_unified_sales_totals` / grouped RPC) filter by **`sale_date`**, not `sold_at`. The **dollar figures the auditor sees are keyed on the local business date and are already right.** The bug is intra-day *hour* attribution only. → Still must be **proven** by reconciliation (§7).
@@ -100,29 +101,88 @@ Thread the timezone in: `processOrder(...)` / `normalizeOrder(...)` gain a `time
 
 ### 5b. Backfill migration
 
-Postgres `AT TIME ZONE` does the DST-aware conversion natively. Idempotent; safe to re-run.
+Postgres `AT TIME ZONE` does the DST-aware conversion natively. The migration is a
+**per-restaurant `DO` loop** (bounded work, not one unbounded statement), suppresses
+the per-row `unified_sales` aggregation trigger, and re-aggregates once per touched
+`(restaurant_id, sale_date)`. Idempotent (`IS DISTINCT FROM` guards on both tables).
+
+Design decisions folded in from Phase 2.5 review:
+
+1. **Validate tz against `pg_timezone_names`** — `COALESCE(r.timezone,'…')` only guards
+   NULL; a *non-null but invalid/legacy* string makes `AT TIME ZONE` raise and aborts the
+   whole migration (mirrors the `safeTz()` guard on the edge side). Use a validated
+   expression + a pre-flight report of offenders.
+2. **Suppress the `unified_sales` → daily aggregation trigger** during the bulk UPDATE
+   (`set_config('app.skip_unified_sales_triggers','true',true)`), exactly as
+   `sync_toast_to_unified_sales` does — otherwise `trigger_unified_sales_to_daily` fires
+   `aggregate_unified_sales_to_daily` once **per row**, risking a migration timeout / lock
+   contention with live syncs. Re-aggregate once per distinct `(restaurant_id, sale_date)`
+   after.
+3. **Mirror `parseDateTime`'s full field/envelope precedence** in the raw-JSON extraction
+   (`getOrderNode`: `Order ?? order ?? payload`; field: `created_date ?? createdDate ??
+   closed_date ?? finalized_date ?? date`) so no historically-corrupted row is silently
+   skipped by a too-narrow COALESCE.
 
 ```sql
--- 1) revel_orders: recompute sold_at from the authoritative raw naive local time
-UPDATE public.revel_orders o
-SET sold_at = (COALESCE(o.raw_json->>'created_date',
-                        o.raw_json->'Order'->>'created_date'))::timestamp
-              AT TIME ZONE COALESCE(r.timezone, 'America/Chicago')
-FROM public.restaurants r
-WHERE r.id = o.restaurant_id
-  AND COALESCE(o.raw_json->>'created_date', o.raw_json->'Order'->>'created_date') IS NOT NULL;
+DO $$
+DECLARE
+  rec RECORD;
+  v_tz TEXT;
+BEGIN
+  FOR rec IN SELECT id, timezone FROM public.restaurants
+             WHERE id IN (SELECT DISTINCT restaurant_id FROM public.revel_orders)
+  LOOP
+    -- validated tz (falls back to the documented default; report offenders separately)
+    v_tz := CASE WHEN rec.timezone IN (SELECT name FROM pg_timezone_names)
+                 THEN rec.timezone ELSE 'America/Chicago' END;
 
--- 2) unified_sales: propagate corrected instant to every Revel row (sale + adjustments)
-UPDATE public.unified_sales u
-SET sold_at = o.sold_at
-FROM public.revel_orders o
-WHERE u.pos_system = 'revel'
-  AND u.restaurant_id = o.restaurant_id
-  AND u.external_order_id = o.revel_order_id
-  AND u.sold_at IS DISTINCT FROM o.sold_at;
+    -- extract naive local created_date mirroring parseDateTime's precedence
+    -- (helper expression reused below as raw_created(o))
+    UPDATE public.revel_orders o
+    SET sold_at = (public.revel_raw_created_date(o.raw_json))::timestamp AT TIME ZONE v_tz
+    WHERE o.restaurant_id = rec.id
+      AND public.revel_raw_created_date(o.raw_json) IS NOT NULL
+      AND o.sold_at IS DISTINCT FROM
+          (public.revel_raw_created_date(o.raw_json))::timestamp AT TIME ZONE v_tz;
+
+    -- propagate to unified_sales with the aggregation trigger suppressed
+    PERFORM set_config('app.skip_unified_sales_triggers','true', true);
+    UPDATE public.unified_sales u
+    SET sold_at = o.sold_at
+    FROM public.revel_orders o
+    WHERE u.pos_system = 'revel'
+      AND u.restaurant_id = rec.id
+      AND o.restaurant_id = rec.id
+      AND u.external_order_id = o.revel_order_id
+      AND u.sold_at IS DISTINCT FROM o.sold_at;
+    PERFORM set_config('app.skip_unified_sales_triggers','false', true);
+
+    -- re-aggregate once per touched (restaurant_id, sale_date)
+    PERFORM public.aggregate_unified_sales_to_daily(rec.id, d.sale_date)
+    FROM (SELECT DISTINCT sale_date FROM public.unified_sales
+          WHERE restaurant_id = rec.id AND pos_system = 'revel') d;
+  END LOOP;
+END $$;
 ```
 
-Notes: `::timestamp` strips any spurious label and treats digits as naive (correct for Revel's naive feed). Batch by `restaurant_id` if row counts are large. Emit a pre/post report of affected rows and any restaurant whose `timezone` is null.
+`revel_raw_created_date(jsonb)` is a small `IMMUTABLE` helper encapsulating the
+envelope+field precedence (created in the same migration, kept in lock-step with
+`getOrderNode`/`parseDateTime`). `::timestamp` strips any spurious label and treats the
+digits as naive (correct for Revel's naive feed; already-zoned strings are the defensive
+branch handled edge-side). Emit a pre/post report: affected-row counts + any restaurant
+whose stored `timezone` is null or not in `pg_timezone_names`.
+
+### 5d. Durability — Revel sync RPCs must self-heal `sold_at`
+
+Both `revel_sync_financial_breakdown` and `sync_revel_to_unified_sales` insert into
+`unified_sales` with `ON CONFLICT … DO NOTHING`, so a future re-sync of an existing order
+refreshes `revel_orders.sold_at` but never propagates the corrected instant into an
+already-present `unified_sales` row (Toast's RPC already does
+`DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at)`). To stop the
+two tables drifting apart post-backfill, change the Revel insert blocks' conflict clauses
+to `DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at)` — updating
+**only** `sold_at`, so user categorization (`category_id`, `is_categorized`, …) is
+preserved.
 
 ### 5c. Sequencing (stops the bleeding without re-corrupting)
 
@@ -145,6 +205,8 @@ Notes: `::timestamp` strips any spurious label and treats digits as naive (corre
 - [ ] **Labor view** (Rush Bowls Kallison Ranch): earliest sales hour = **7 AM**, peak midday; **no "staff 1–6 AM" / "Peak 3 AM"** callouts.
 - [ ] **Auditor reconciliation**: `sum(total_price) WHERE item_type='sale'` grouped by `sale_date` matches Revel **Sales Summary → Total Product Sales** per business day for a sampled range.
 - [ ] **Hourly reconciliation**: our sold_at→tz hourly distribution matches Revel **Hourly Sales** (0 before 7 AM; tail at 9 PM).
+- [ ] **AI schedule generation** (`generate-schedule`) for the audited restaurant no longer clusters demand overnight (hourly weighting follows the true 7 AM–9 PM curve).
+- [ ] **Backfill safety**: migration completes without firing per-row daily aggregation (trigger suppressed); pre-flight report lists any restaurant with an invalid/null `timezone`.
 - [ ] **Toast** restaurant hourly/labor unchanged (regression).
 
 ## 8. Risks & mitigations
@@ -152,8 +214,14 @@ Notes: `::timestamp` strips any spurious label and treats digits as naive (corre
 - **Other `sold_at` consumers** shift when it becomes a true instant → audited: all are SPLH/labor (tz-aware) or `sale_date`-keyed totals. Covered by §7 reconciliation + Toast regression.
 - **Misconfigured `restaurants.timezone`** → backfill fallback `America/Chicago` + report null/UTC tz stores before running.
 - **DST-transition ambiguity** (twice/year, 1h window) → negligible for open hours; standard `fromZonedTime` behavior; documented.
-- **Large-table backfill cost** → batch by restaurant; run off-peak; idempotent.
+- **Large-table backfill cost / migration timeout** → per-restaurant `DO` loop, trigger suppression + single batched re-aggregation per `(restaurant_id, sale_date)`, `IS DISTINCT FROM` guards (§5b). Not one unbounded UPDATE.
+- **Invalid stored tz aborting the migration** → validate against `pg_timezone_names` with fallback + pre-flight offender report (§5b).
+- **Post-backfill drift between `revel_orders` and `unified_sales`** on future re-syncs → Revel RPCs switched to `DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, …)` (§5d).
 - **Re-corruption window** → deploy source fix before backfill (§5c).
+
+### Phase 2.5 design-review resolutions
+
+All Supabase design-review findings folded in: tz validation + trigger suppression + batched re-aggregation (criticals, §5b); full `raw_json` field/envelope coverage (§5b); RPC self-heal (§5d); `generate-schedule` added to scope + acceptance (§3/§7); per-restaurant batching mechanism (§5b); `revel_orders` `IS DISTINCT FROM` guard (§5b). Reviewer confirmed: `AT TIME ZONE` technique sound; `get_unified_sales_totals`/`collected_at_pos` are `sale_date`-keyed (auditor path unaffected); all frontend `sold_at` consumers are tz-aware; deploy-then-backfill ordering correct; no RLS impact.
 
 ## 9. Rollback
 

--- a/docs/superpowers/specs/2026-07-21-revel-timezone-sold-at-design.md
+++ b/docs/superpowers/specs/2026-07-21-revel-timezone-sold-at-design.md
@@ -1,0 +1,169 @@
+# Design: Fix Revel `sold_at` timezone corruption (data-integrity, ASAP)
+
+**Date:** 2026-07-21
+**Author:** investigation via Revel dashboard + production DB audit
+**Severity:** P1 — production data integrity; customer complaints; **auditor exposure** (numbers must reconcile to Revel POS)
+**Scope:** Revel POS integration only (Toast/Square/others verified unaffected)
+
+---
+
+## 1. Summary
+
+Revel sends order timestamps as **naive local time, no offset** (e.g. `created_date: "2026-07-19T07:32:16"`). Our ingest parses them with `new Date(raw).toISOString()` in a **UTC** edge runtime, which stamps the local wall-clock with `+00:00`. Result: `unified_sales.sold_at` / `revel_orders.sold_at` are **not valid instants** — they are the local wall-clock mislabeled as UTC, off by the establishment's UTC offset (5h CDT / 6h CST — it varies with DST).
+
+Any screen that converts `sold_at` into the restaurant timezone (the **Labor / SPLH / staffing** views) shifts every sale ~5–6h earlier, dragging the day into the overnight. The Labor optimizer currently tells operators to **staff 1–6 AM and calls 3 AM the peak** for a store that opens at 7 AM.
+
+## 2. Confirmed root cause (evidence)
+
+Real production chain, Rush Bowls Kallison Ranch (`ae87f51e-…`), order `7975787`, 2026-07-19:
+
+| Layer | Value | Verdict |
+|---|---|---|
+| Revel `raw_json.created_date` | `2026-07-19T07:32:16` (naive local) | input |
+| Stored `order_time` / `sale_time` | `07:32:16` | ✅ local-correct |
+| Stored `sold_at` | `2026-07-19T07:32:16+00:00` | ❌ true instant is `12:32:16Z` |
+| `restaurants.timezone` | `America/Chicago` | ✅ correct |
+| Revel Hourly Sales report | 0 sales before 7 AM; first bucket 7:00–7:59 AM | ground truth |
+| POS Sales list (reads `sale_time`) | 7:32 AM | ✅ matches Revel |
+| Labor heatmap (reads `sold_at`→Central) | 07:32Z − 5h = **2:32 AM** | ❌ the bug |
+
+Defect site: [`parseDateTime`](../../../supabase/functions/_shared/revelOrderProcessor.ts) — `const d = new Date(rawDate); ... soldAt = d.toISOString()`.
+
+## 3. Scope — what's broken vs safe
+
+**Broken (reads `sold_at` as instant → tz):**
+- `src/lib/splhAnalytics.ts` `hourOfSale` (Labor heatmap, staffing suggestions)
+- `src/hooks/useHourlySalesPattern.ts`, `useSplhData.ts`, `useWeekStaffingSuggestions.ts`, `useSplhAnalytics.ts`
+
+**Already correct (must NOT regress):**
+- **Revenue/period totals** (`get_unified_sales_totals` / grouped RPC) filter by **`sale_date`**, not `sold_at`. The **dollar figures the auditor sees are keyed on the local business date and are already right.** The bug is intra-day *hour* attribution only. → Still must be **proven** by reconciliation (§7).
+- **POS Sales list** reads `sale_time` (local) → correct.
+- **Toast** stores `sold_at` from `closedDate` (carries offset) = a correct instant; its `sale_time` is the UTC-derived one. A global "prefer `sale_time`" change would **break Toast** — so we do NOT touch the shared read path. Fix is at the Revel source + a data backfill.
+
+## 4. Goals / non-goals
+
+**Goals**
+1. New Revel orders store a correct `sold_at` instant (DST-aware, per establishment tz).
+2. Backfill existing `revel_orders` + `unified_sales` so historical `sold_at` is correct.
+3. Labor/hourly views show the true 7 AM–9 PM shape; no overnight staffing advice.
+4. Prove daily revenue + hourly distribution reconcile to Revel (auditor requirement).
+5. Regression tests so this class of bug can't return (time-of-day path is currently untested).
+
+**Non-goals**
+- No change to the shared labor read path / `hourOfSale` priority (would break Toast).
+- No change to `sale_date` / `sale_time` semantics (already correct).
+- Other POS adapters (separate audit ticket if desired).
+
+## 5. Design
+
+### 5a. Source fix — `revelOrderProcessor.ts`
+
+Add a tz-aware helper (new `supabase/functions/_shared/timezone.ts`, no external dep, mirrors `date-fns-tz` `fromZonedTime`):
+
+```ts
+// Probe the IANA tz once and fall back to the documented restaurant default.
+// (Lesson 2026-07-02: an invalid/empty/legacy tz string makes Intl THROW a
+// RangeError — validate before it reaches formatToParts, don't let it crash sync.)
+function safeTz(tz: string | null | undefined): string {
+  try { new Intl.DateTimeFormat('en-US', { timeZone: tz ?? 'UTC' }); return tz as string; }
+  catch { return 'America/Chicago'; } // restaurants.timezone default (migration 20251001022351)
+}
+
+// Interpret a naive local datetime ("YYYY-MM-DDTHH:MM:SS", no offset) as wall-clock
+// in `timeZone` and return the correct UTC instant. DST-aware via Intl.
+export function zonedNaiveToUtc(naive: string, timeZone: string): Date {
+  const tz = safeTz(timeZone);
+  const m = naive.match(/^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2}))?/);
+  if (!m) return new Date(NaN);
+  const [, y, mo, d, h, mi, s] = m;
+  const guess = Date.UTC(+y, +mo - 1, +d, +h, +mi, +(s ?? 0));
+  const offset = tzOffsetMs(new Date(guess), tz); // formatToParts round-trip
+  return new Date(guess - offset);
+}
+```
+
+**Anchoring-convention audit (lesson 2026-05-10):** flipping `sold_at` from
+local-as-UTC to a true instant is an anchoring-convention change. Every
+consumer was audited: labor/SPLH read it via `Intl`/tz conversion
+(`hourOfSale`, `useHourlySalesPattern`, `useSplhData`,
+`useWeekStaffingSuggestions`) → correct once `sold_at` is a true instant;
+revenue/period totals key on `sale_date` (not `sold_at`) → unaffected. No
+consumer reads raw `.getUTC*()` off `sold_at` expecting local digits.
+
+Rewrite `parseDateTime(order, timeZone)`:
+- If `created_date` **already carries an offset** (`Z` / `±hh:mm`) → `new Date(raw)` (defensive; real Revel data is naive).
+- Else (naive) → `soldAt = zonedNaiveToUtc(raw, timeZone).toISOString()`.
+- `orderTime` = the naive local `HH:MM:SS` (unchanged).
+- `orderDate` = **business date computed in local space**: take the naive local wall-clock, subtract 2h, take the date (matches Revel's confirmed 2 AM boundary). Today the 2h shift is applied to the mis-zoned UTC value — move it into local space.
+
+Thread the timezone in: `processOrder(...)` / `normalizeOrder(...)` gain a `timeZone` param. Each caller — `revel-webhook`, `revel-sync-data`, `revel-bulk-sync` — resolves `restaurants.timezone` **once per run** and passes it (fallback `'America/Chicago'`; log a warning if null so misconfigured stores surface).
+
+### 5b. Backfill migration
+
+Postgres `AT TIME ZONE` does the DST-aware conversion natively. Idempotent; safe to re-run.
+
+```sql
+-- 1) revel_orders: recompute sold_at from the authoritative raw naive local time
+UPDATE public.revel_orders o
+SET sold_at = (COALESCE(o.raw_json->>'created_date',
+                        o.raw_json->'Order'->>'created_date'))::timestamp
+              AT TIME ZONE COALESCE(r.timezone, 'America/Chicago')
+FROM public.restaurants r
+WHERE r.id = o.restaurant_id
+  AND COALESCE(o.raw_json->>'created_date', o.raw_json->'Order'->>'created_date') IS NOT NULL;
+
+-- 2) unified_sales: propagate corrected instant to every Revel row (sale + adjustments)
+UPDATE public.unified_sales u
+SET sold_at = o.sold_at
+FROM public.revel_orders o
+WHERE u.pos_system = 'revel'
+  AND u.restaurant_id = o.restaurant_id
+  AND u.external_order_id = o.revel_order_id
+  AND u.sold_at IS DISTINCT FROM o.sold_at;
+```
+
+Notes: `::timestamp` strips any spurious label and treats digits as naive (correct for Revel's naive feed). Batch by `restaurant_id` if row counts are large. Emit a pre/post report of affected rows and any restaurant whose `timezone` is null.
+
+### 5c. Sequencing (stops the bleeding without re-corrupting)
+
+1. Deploy **source fix** (5a) first — new syncs write correct `sold_at`.
+2. Run **backfill** (5b) — heals history.
+   (Backfill reads `raw_json`, so it's independent of code; but doing it after the deploy avoids a window where new orders re-introduce bad data.)
+3. Verify (§7). The corrected `unified_sales.sold_at` is the fast customer relief — the Labor read path already converts `sold_at`→tz correctly; only the data was wrong.
+
+## 6. Tests (TDD — write failing first)
+
+- **Unit `zonedNaiveToUtc`**: `"2026-07-19T07:32:16" / America/Chicago → 2026-07-19T12:32:16Z` (CDT −5); winter `"2026-01-15T07:32:16" → 13:32:16Z` (CST −6); a DST-transition day.
+- **Unit `normalizeOrder`/`parseDateTime`**: fix the existing fixture (currently `+0000`, and it never asserts `sold_at`) → use naive `"2026-07-19T07:32:16"`; assert `sold_at === 2026-07-19T12:32:16Z`, `order_time === "07:32:16"`, `order_date === "2026-07-19"`.
+- **pgTAP**: after backfill, `(sold_at AT TIME ZONE r.timezone)::time` equals `sale_time` (± rounding) for all Revel rows; `mismatches = 0`.
+- **Regression**: a Toast fixture proving Toast `sold_at`/hour attribution is unchanged.
+
+## 7. Verification / acceptance criteria
+
+- [ ] New Revel order → `sold_at` is the correct instant (unit test green).
+- [ ] Backfill: `SELECT count(*) FILTER (WHERE (u.sold_at AT TIME ZONE r.timezone)::time <> u.sale_time)` ≈ 0.
+- [ ] **Labor view** (Rush Bowls Kallison Ranch): earliest sales hour = **7 AM**, peak midday; **no "staff 1–6 AM" / "Peak 3 AM"** callouts.
+- [ ] **Auditor reconciliation**: `sum(total_price) WHERE item_type='sale'` grouped by `sale_date` matches Revel **Sales Summary → Total Product Sales** per business day for a sampled range.
+- [ ] **Hourly reconciliation**: our sold_at→tz hourly distribution matches Revel **Hourly Sales** (0 before 7 AM; tail at 9 PM).
+- [ ] **Toast** restaurant hourly/labor unchanged (regression).
+
+## 8. Risks & mitigations
+
+- **Other `sold_at` consumers** shift when it becomes a true instant → audited: all are SPLH/labor (tz-aware) or `sale_date`-keyed totals. Covered by §7 reconciliation + Toast regression.
+- **Misconfigured `restaurants.timezone`** → backfill fallback `America/Chicago` + report null/UTC tz stores before running.
+- **DST-transition ambiguity** (twice/year, 1h window) → negligible for open hours; standard `fromZonedTime` behavior; documented.
+- **Large-table backfill cost** → batch by restaurant; run off-peak; idempotent.
+- **Re-corruption window** → deploy source fix before backfill (§5c).
+
+## 9. Rollback
+
+- Code: revert the edge-function change (redeploy previous).
+- Data: backfill is idempotent and recomputes from `raw_json`; re-running the corrected UPDATE restores correct values. Capture pre-change `sold_at` in a scratch table if a byte-for-byte revert is desired.
+
+## 10. Deliverables
+
+1. `supabase/functions/_shared/timezone.ts` (+ unit tests)
+2. `revelOrderProcessor.ts` `parseDateTime` tz-aware; callers thread `timeZone`
+3. Backfill migration (revel_orders + unified_sales) with pre/post report
+4. Fixed + expanded unit tests; pgTAP reconciliation test; Toast regression test
+5. Post-deploy verification notes (Labor view screenshot + reconciliation query output)

--- a/supabase/functions/_shared/revelOrderProcessor.ts
+++ b/supabase/functions/_shared/revelOrderProcessor.ts
@@ -107,7 +107,12 @@ function parseDateTime(
 
   const soldAtDate = hasOffset ? new Date(raw) : zonedNaiveToUtc(raw, timeZone);
   if (Number.isNaN(soldAtDate.getTime())) {
-    return { orderDate: raw.split('T')[0], orderTime: null, soldAt: null };
+    // Unparseable timestamp: still salvage the date part for `order_date`.
+    // Use the naive-match capture (or a date-prefix regex) rather than
+    // `split('T')`, which returns the whole string for a space-separated
+    // timestamp (e.g. "2026-07-19 07:32:16") and yields a bogus date.
+    const fallbackDate = naiveMatch?.[1] ?? /^\d{4}-\d{2}-\d{2}/.exec(raw)?.[0] ?? raw.slice(0, 10);
+    return { orderDate: fallbackDate, orderTime: null, soldAt: null };
   }
 
   const naiveTime = naiveMatch ? `${naiveMatch[2]}:${naiveMatch[3] ?? '00'}` : null;

--- a/supabase/functions/_shared/revelOrderProcessor.ts
+++ b/supabase/functions/_shared/revelOrderProcessor.ts
@@ -7,6 +7,8 @@
  * (spec risk 8.2: dollars vs cents). Flip REVEL_AMOUNTS_IN_CENTS if Revel returns cents.
  */
 
+import { zonedNaiveToUtc, DEFAULT_TIMEZONE } from './timezone.ts';
+
 export interface ProcessOrderOptions {
   skipUnifiedSalesSync?: boolean;
 }
@@ -66,29 +68,60 @@ function getOrderNode(payload: any): any {
   return payload.Order ?? payload.order ?? payload;
 }
 
-function parseDateTime(order: any): { orderDate: string; orderTime: string | null; soldAt: string | null } {
+/**
+ * Revel's real feed sends `created_date` as NAIVE establishment-local time, no
+ * offset (e.g. '2026-07-19T07:32:16') — interpret it in `timeZone` (DST-aware)
+ * to get a correct UTC instant for `sold_at`. Defensively handle an
+ * already-zoned string (`Z` / `±hh:mm` / `±hhmm`) via `new Date`, in case a
+ * caller ever passes one (real Revel data does not).
+ *
+ * `orderTime` is always the naive local wall-clock digits as printed in the
+ * raw string, regardless of which branch parsed `soldAt`.
+ *
+ * `orderDate` is the *business* date: Revel rolls over at a 2 AM local
+ * boundary (same convention as Toast's `businessDate`). This must be computed
+ * in local space — shifting the naive wall-clock digits back 2h — not by
+ * shifting the (now correctly tz-converted) `soldAt` UTC instant, which would
+ * reintroduce the same tz-anchoring bug this fix removes.
+ */
+function parseDateTime(
+  order: any,
+  timeZone: string = DEFAULT_TIMEZONE,
+): { orderDate: string; orderTime: string | null; soldAt: string | null } {
   const rawDate =
     order.created_date ?? order.createdDate ?? order.closed_date ?? order.finalized_date ?? order.date ?? null;
   if (!rawDate) {
     const today = new Date().toISOString();
     return { orderDate: today.split('T')[0], orderTime: null, soldAt: null };
   }
-  // Revel timestamps look like '2026-07-01T12:30:00' (establishment-local, no offset).
-  const d = new Date(rawDate);
-  if (Number.isNaN(d.getTime())) {
-    return { orderDate: String(rawDate).split('T')[0], orderTime: null, soldAt: null };
+
+  const raw = String(rawDate);
+  const hasOffset = /(Z|[+-]\d{2}:?\d{2})$/i.test(raw);
+  const naiveMatch = raw.match(/^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2}:\d{2})/);
+
+  const soldAtDate = hasOffset ? new Date(raw) : zonedNaiveToUtc(raw, timeZone);
+  if (Number.isNaN(soldAtDate.getTime())) {
+    return { orderDate: raw.split('T')[0], orderTime: null, soldAt: null };
   }
-  const iso = d.toISOString();
-  // Revel reports on a 2 AM business-day boundary (same idea as Toast's `businessDate`):
-  // an order before 2 AM counts toward the previous day. Shift back 2h for sale_date only;
-  // keep the real time in sale_time / sold_at.
-  const biz = new Date(d.getTime() - 2 * 60 * 60 * 1000);
-  return { orderDate: biz.toISOString().split('T')[0], orderTime: iso.split('T')[1].split('.')[0], soldAt: iso };
+
+  const orderTime = naiveMatch ? naiveMatch[2] : soldAtDate.toISOString().split('T')[1].split('.')[0];
+
+  let orderDate: string;
+  if (naiveMatch) {
+    // Treat the naive digits as if they were UTC purely for calendar arithmetic
+    // (no real tz conversion here — we're already in local space).
+    const naiveAsUtcMs = Date.parse(`${naiveMatch[1]}T${naiveMatch[2]}Z`);
+    orderDate = new Date(naiveAsUtcMs - 2 * 60 * 60 * 1000).toISOString().split('T')[0];
+  } else {
+    orderDate = soldAtDate.toISOString().split('T')[0];
+  }
+
+  return { orderDate, orderTime, soldAt: soldAtDate.toISOString() };
 }
 
-export function normalizeOrder(payload: any): NormalizedOrder {
+export function normalizeOrder(payload: any, timeZone: string = DEFAULT_TIMEZONE): NormalizedOrder {
   const order = getOrderNode(payload);
-  const { orderDate, orderTime, soldAt } = parseDateTime(order);
+  const { orderDate, orderTime, soldAt } = parseDateTime(order, timeZone);
 
   const itemsRaw = payload.OrderItems ?? payload.order_items ?? order.items ?? [];
   const paymentsRaw = payload.Payments ?? payload.payments ?? order.payments ?? [];
@@ -233,8 +266,9 @@ export async function processOrder(
   revelInstance: string,
   establishmentId: string | null,
   options: ProcessOrderOptions = {},
+  timeZone: string = DEFAULT_TIMEZONE,
 ): Promise<void> {
-  const n = normalizeOrder(payload);
+  const n = normalizeOrder(payload, timeZone);
   if (!n.orderId) throw new Error('Revel order payload missing order id');
 
   const orderRowId = await upsertOrder(supabase, n, restaurantId, establishmentId, payload);

--- a/supabase/functions/_shared/revelOrderProcessor.ts
+++ b/supabase/functions/_shared/revelOrderProcessor.ts
@@ -97,20 +97,27 @@ function parseDateTime(
 
   const raw = String(rawDate);
   const hasOffset = /(Z|[+-]\d{2}:?\d{2})$/i.test(raw);
-  const naiveMatch = raw.match(/^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2}:\d{2})/);
+  // Seconds are optional here (mirrors zonedNaiveToUtc's own regex in
+  // timezone.ts) so a seconds-less naive timestamp (e.g. Revel ever sending
+  // "2026-07-19T07:32") still takes the local-wall-clock path below instead
+  // of silently falling through to the UTC-digit branch, which would
+  // contradict this function's own "orderTime is always local wall-clock
+  // digits" contract.
+  const naiveMatch = raw.match(/^(\d{4}-\d{2}-\d{2})[T ](\d{2}:\d{2})(?::(\d{2}))?/);
 
   const soldAtDate = hasOffset ? new Date(raw) : zonedNaiveToUtc(raw, timeZone);
   if (Number.isNaN(soldAtDate.getTime())) {
     return { orderDate: raw.split('T')[0], orderTime: null, soldAt: null };
   }
 
-  const orderTime = naiveMatch ? naiveMatch[2] : soldAtDate.toISOString().split('T')[1].split('.')[0];
+  const naiveTime = naiveMatch ? `${naiveMatch[2]}:${naiveMatch[3] ?? '00'}` : null;
+  const orderTime = naiveTime ?? soldAtDate.toISOString().split('T')[1].split('.')[0];
 
   let orderDate: string;
   if (naiveMatch) {
     // Treat the naive digits as if they were UTC purely for calendar arithmetic
     // (no real tz conversion here — we're already in local space).
-    const naiveAsUtcMs = Date.parse(`${naiveMatch[1]}T${naiveMatch[2]}Z`);
+    const naiveAsUtcMs = Date.parse(`${naiveMatch[1]}T${naiveTime}Z`);
     orderDate = new Date(naiveAsUtcMs - 2 * 60 * 60 * 1000).toISOString().split('T')[0];
   } else {
     orderDate = soldAtDate.toISOString().split('T')[0];

--- a/supabase/functions/_shared/timezone.ts
+++ b/supabase/functions/_shared/timezone.ts
@@ -43,20 +43,37 @@ export function safeTz(tz: string | null | undefined): string {
  * `timeZone` is assumed already-validated (see `safeTz`); an invalid zone
  * here will throw, matching `Intl`'s native behavior.
  */
-export function tzOffsetMs(date: Date, timeZone: string): number {
-  const formatter = new Intl.DateTimeFormat('en-US', {
-    timeZone,
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-    hour12: false,
-    hourCycle: 'h23',
-  });
+/**
+ * Module-level cache of `Intl.DateTimeFormat` instances keyed by IANA timezone.
+ * Constructing an ICU formatter is expensive; `zonedNaiveToUtc` calls
+ * `tzOffsetMs` twice per timestamp, so a bulk Revel sync/backfill would
+ * otherwise build thousands of identical formatters (avoidable CPU/GC in the
+ * CPU-limited edge runtime). Mirrors the `_fmtCache` pattern in
+ * `src/lib/splhAnalytics.ts` / `src/hooks/useHourlySalesPattern.ts`.
+ */
+const _offsetFmtCache = new Map<string, Intl.DateTimeFormat>();
 
-  const parts = formatter.formatToParts(date);
+function offsetFormatter(timeZone: string): Intl.DateTimeFormat {
+  let fmt = _offsetFmtCache.get(timeZone);
+  if (!fmt) {
+    fmt = new Intl.DateTimeFormat('en-US', {
+      timeZone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hour12: false,
+      hourCycle: 'h23',
+    });
+    _offsetFmtCache.set(timeZone, fmt);
+  }
+  return fmt;
+}
+
+export function tzOffsetMs(date: Date, timeZone: string): number {
+  const parts = offsetFormatter(timeZone).formatToParts(date);
   const get = (type: string) => Number(parts.find((p) => p.type === type)?.value ?? 0);
 
   // formatToParts can report hour "24" at local midnight under hourCycle h23

--- a/supabase/functions/_shared/timezone.ts
+++ b/supabase/functions/_shared/timezone.ts
@@ -81,11 +81,27 @@ export function tzOffsetMs(date: Date, timeZone: string): number {
 export function zonedNaiveToUtc(naive: string, timeZone: string | null | undefined): Date {
   const tz = safeTz(timeZone);
 
-  const m = naive.match(/^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2}))?/);
+  const m = naive.match(/^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2}))?$/);
   if (!m) return new Date(NaN);
 
   const [, y, mo, d, h, mi, s] = m;
   const guess = Date.UTC(+y, +mo - 1, +d, +h, +mi, +(s ?? 0));
+
+  // Reject calendar values `Date.UTC` silently normalizes (e.g. 2026-02-30 →
+  // 2026-03-02): re-read the UTC components back and require an exact match
+  // before trusting `guess`, so an out-of-range day/month never silently
+  // rolls into a different (wrong) date.
+  const parsedGuess = new Date(guess);
+  if (
+    parsedGuess.getUTCFullYear() !== +y ||
+    parsedGuess.getUTCMonth() !== +mo - 1 ||
+    parsedGuess.getUTCDate() !== +d ||
+    parsedGuess.getUTCHours() !== +h ||
+    parsedGuess.getUTCMinutes() !== +mi ||
+    parsedGuess.getUTCSeconds() !== +(s ?? 0)
+  ) {
+    return new Date(NaN);
+  }
 
   // Two-pass offset probe (standard `fromZonedTime`-style fixup). A single
   // pass reads the zone's offset AT the naive-as-UTC guess, which can land on

--- a/supabase/functions/_shared/timezone.ts
+++ b/supabase/functions/_shared/timezone.ts
@@ -87,10 +87,17 @@ export function zonedNaiveToUtc(naive: string, timeZone: string | null | undefin
   const [, y, mo, d, h, mi, s] = m;
   const guess = Date.UTC(+y, +mo - 1, +d, +h, +mi, +(s ?? 0));
 
-  // Round-trip through formatToParts to get the zone's offset at (approximately)
-  // this instant, then subtract it from the naive-as-UTC guess to get the true instant.
-  const offset = tzOffsetMs(new Date(guess), tz);
-  return new Date(guess - offset);
+  // Two-pass offset probe (standard `fromZonedTime`-style fixup). A single
+  // pass reads the zone's offset AT the naive-as-UTC guess, which can land on
+  // the wrong side of a DST transition: e.g. "2026-03-08T03:30:00" in
+  // America/Chicago — the guess instant 03:30Z falls before the 08:00Z
+  // spring-forward, so a single-pass probe reads the pre-transition CST
+  // offset (-6h) even though the intended local time (03:30, post-transition)
+  // is CDT (-5h), corrupting the result by exactly 1h. Re-deriving the offset
+  // at the corrected instant (second pass) picks the correct side.
+  const offset1 = tzOffsetMs(new Date(guess), tz);
+  const offset2 = tzOffsetMs(new Date(guess - offset1), tz);
+  return new Date(guess - offset2);
 }
 
 /**

--- a/supabase/functions/_shared/timezone.ts
+++ b/supabase/functions/_shared/timezone.ts
@@ -92,3 +92,67 @@ export function zonedNaiveToUtc(naive: string, timeZone: string | null | undefin
   const offset = tzOffsetMs(new Date(guess), tz);
   return new Date(guess - offset);
 }
+
+/**
+ * Minimal shape of the `.from().select().eq().maybeSingle()` chain the Revel
+ * sync callers use. Type-agnostic (like `restaurantInfo.ts`) so both the real
+ * Deno supabase-js client and Vitest stubs satisfy it without a URL import.
+ */
+interface RestaurantTimeZoneQueryClient {
+  from(table: string): {
+    select(columns: string): {
+      eq(column: string, value: string): {
+        maybeSingle(): Promise<{
+          data: { timezone?: string | null } | null;
+          error: { message: string } | null;
+        }>;
+      };
+    };
+  };
+}
+
+/**
+ * Resolve a restaurant's IANA timezone once per sync run, for the Revel
+ * callers (`revel-webhook`, `revel-sync-data`, `revel-bulk-sync`) to pass
+ * into `processOrder`/`normalizeOrder`.
+ *
+ * Degrades to `DEFAULT_TIMEZONE` (never throws) on a missing row, a query
+ * error, a null/empty stored timezone, or an invalid IANA identifier —
+ * logging a warning in every fallback case so a misconfigured
+ * `restaurants.timezone` surfaces in function logs instead of silently
+ * mis-attributing sale hours.
+ */
+export async function resolveRestaurantTimeZone(
+  supabase: RestaurantTimeZoneQueryClient,
+  restaurantId: string,
+): Promise<string> {
+  const { data, error } = await supabase
+    .from('restaurants')
+    .select('timezone')
+    .eq('id', restaurantId)
+    .maybeSingle();
+
+  if (error || !data) {
+    console.warn(
+      `resolveRestaurantTimeZone: failed to load restaurants.timezone for ${restaurantId}` +
+        (error ? ` (${error.message})` : ' (no row found)') +
+        `; falling back to ${DEFAULT_TIMEZONE}`,
+    );
+    return DEFAULT_TIMEZONE;
+  }
+
+  if (!data.timezone) {
+    console.warn(
+      `resolveRestaurantTimeZone: restaurants.timezone is null for ${restaurantId}; falling back to ${DEFAULT_TIMEZONE}`,
+    );
+    return DEFAULT_TIMEZONE;
+  }
+
+  const tz = safeTz(data.timezone);
+  if (tz !== data.timezone) {
+    console.warn(
+      `resolveRestaurantTimeZone: invalid restaurants.timezone "${data.timezone}" for ${restaurantId}; falling back to ${DEFAULT_TIMEZONE}`,
+    );
+  }
+  return tz;
+}

--- a/supabase/functions/_shared/timezone.ts
+++ b/supabase/functions/_shared/timezone.ts
@@ -81,7 +81,11 @@ export function tzOffsetMs(date: Date, timeZone: string): number {
 export function zonedNaiveToUtc(naive: string, timeZone: string | null | undefined): Date {
   const tz = safeTz(timeZone);
 
-  const m = naive.match(/^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2}))?$/);
+  // Fractional seconds (e.g. "...:16.071") are tolerated and truncated to
+  // whole-second precision — real POS feeds (Toast openedDate, and defensively
+  // Revel) can include milliseconds. Without this the `$`-anchored match would
+  // fail and the caller would silently store a NULL sold_at / order_time.
+  const m = naive.match(/^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2}))?(?:\.\d+)?$/);
   if (!m) return new Date(NaN);
 
   const [, y, mo, d, h, mi, s] = m;

--- a/supabase/functions/_shared/timezone.ts
+++ b/supabase/functions/_shared/timezone.ts
@@ -1,0 +1,94 @@
+/**
+ * timezone.ts
+ *
+ * Pure, dependency-free helpers for converting a naive local ("wall-clock")
+ * datetime string into the correct UTC instant for a given IANA timezone,
+ * using `Intl.DateTimeFormat.formatToParts` (DST-aware, no `date-fns-tz`
+ * dependency needed on the Deno edge-function runtime).
+ *
+ * Used by the Revel order processor (`revelOrderProcessor.ts`) to interpret
+ * Revel's naive-local `created_date` in the establishment's IANA timezone
+ * instead of mis-treating it as UTC.
+ */
+
+/** Restaurant default timezone (matches migration 20251001022351). */
+export const DEFAULT_TIMEZONE = 'America/Chicago';
+
+/**
+ * Validate an IANA timezone string, falling back to the restaurant default
+ * when it is missing or invalid.
+ *
+ * Lesson (2026-07-02): an invalid/empty/legacy tz string makes
+ * `Intl.DateTimeFormat` THROW a `RangeError` — validate before it reaches
+ * `formatToParts`, don't let it crash a sync run.
+ */
+export function safeTz(tz: string | null | undefined): string {
+  if (!tz) return DEFAULT_TIMEZONE;
+  try {
+    // Constructing the formatter is enough to validate the IANA identifier;
+    // an invalid one throws RangeError synchronously.
+    new Intl.DateTimeFormat('en-US', { timeZone: tz });
+    return tz;
+  } catch {
+    return DEFAULT_TIMEZONE;
+  }
+}
+
+/**
+ * Compute the UTC offset (in milliseconds) of `timeZone` at the instant
+ * `date`, via an `Intl.formatToParts` round-trip. Positive means the zone is
+ * ahead of UTC; negative means behind (e.g. America/Chicago in CDT is
+ * -5 * 60 * 60 * 1000).
+ *
+ * `timeZone` is assumed already-validated (see `safeTz`); an invalid zone
+ * here will throw, matching `Intl`'s native behavior.
+ */
+export function tzOffsetMs(date: Date, timeZone: string): number {
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+    hourCycle: 'h23',
+  });
+
+  const parts = formatter.formatToParts(date);
+  const get = (type: string) => Number(parts.find((p) => p.type === type)?.value ?? 0);
+
+  // formatToParts can report hour "24" at local midnight under hourCycle h23
+  // in some runtimes; normalize to 0 so Date.UTC doesn't roll to the wrong day.
+  const hour = get('hour') % 24;
+
+  const localAsUtc = Date.UTC(get('year'), get('month') - 1, get('day'), hour, get('minute'), get('second'));
+
+  return localAsUtc - date.getTime();
+}
+
+/**
+ * Interpret a naive local datetime string ("YYYY-MM-DDTHH:MM:SS" or
+ * "YYYY-MM-DD HH:MM:SS", no offset) as wall-clock time in `timeZone` and
+ * return the corresponding UTC instant. DST-aware.
+ *
+ * Mirrors `date-fns-tz`'s `fromZonedTime` without the external dependency.
+ *
+ * - Invalid/missing `timeZone` falls back to `America/Chicago` (see `safeTz`).
+ * - An unparseable `naive` string returns an invalid `Date` (never throws).
+ */
+export function zonedNaiveToUtc(naive: string, timeZone: string | null | undefined): Date {
+  const tz = safeTz(timeZone);
+
+  const m = naive.match(/^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2}))?/);
+  if (!m) return new Date(NaN);
+
+  const [, y, mo, d, h, mi, s] = m;
+  const guess = Date.UTC(+y, +mo - 1, +d, +h, +mi, +(s ?? 0));
+
+  // Round-trip through formatToParts to get the zone's offset at (approximately)
+  // this instant, then subtract it from the naive-as-UTC guess to get the true instant.
+  const offset = tzOffsetMs(new Date(guess), tz);
+  return new Date(guess - offset);
+}

--- a/supabase/functions/revel-bulk-sync/index.ts
+++ b/supabase/functions/revel-bulk-sync/index.ts
@@ -3,6 +3,7 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { revelFetch, fetchOrderItemsByDate, fetchPaymentsByDate } from "../_shared/revelClient.ts";
 import { getEncryptionService } from "../_shared/encryption.ts";
 import { processOrder } from "../_shared/revelOrderProcessor.ts";
+import { resolveRestaurantTimeZone } from "../_shared/timezone.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -40,7 +41,7 @@ function ordersPath(start: string, end: string, offset: number): string {
  * Mutates conn.sync_cursor / conn.initial_sync_done in memory so a caller can loop.
  * Returns how many orders were processed and whether the backfill is now complete.
  */
-async function processConnectionBatch(service: any, encryption: any, conn: any): Promise<{ processed: number; done: boolean; failed: boolean }> {
+async function processConnectionBatch(service: any, encryption: any, conn: any, timeZone: string): Promise<{ processed: number; done: boolean; failed: boolean }> {
   const today = new Date();
   let start: string;
   let end: string;
@@ -73,7 +74,7 @@ async function processConnectionBatch(service: any, encryption: any, conn: any):
           const oid = String(order.id ?? order.uuid);
           (order as any).OrderItems = itemsByOrder[oid] || [];
           (order as any).Payments = paymentsByOrder[oid] || [];
-          await processOrder(service, order, conn.restaurant_id, conn.revel_instance, conn.establishment_id ?? null, { skipUnifiedSalesSync: true });
+          await processOrder(service, order, conn.restaurant_id, conn.revel_instance, conn.establishment_id ?? null, { skipUnifiedSalesSync: true }, timeZone);
           processed++;
         } catch (e) {
           console.error(`revel-bulk-sync: failed to process order for restaurant ${conn.restaurant_id}:`, e);
@@ -146,6 +147,9 @@ serve(async (req) => {
         return json({ error: 'No Revel credentials for that restaurant' }, 400);
       }
 
+      // Resolved once for the whole targeted run (not once per batch iteration).
+      const timeZone = await resolveRestaurantTimeZone(service, conn.restaurant_id);
+
       // Loop batches until the 90-day backfill is done or we run out of time budget;
       // any remainder is picked up by the next cron run.
       const startedAt = Date.now();
@@ -153,7 +157,7 @@ serve(async (req) => {
       while (Date.now() - startedAt < TARGETED_BUDGET_MS && iterations < 40) {
         iterations++;
         const wasBackfilling = !conn.initial_sync_done;
-        const r = await processConnectionBatch(service, encryption, conn);
+        const r = await processConnectionBatch(service, encryption, conn, timeZone);
         totalProcessed += r.processed;
         if (r.failed) break;
         if (!wasBackfilling) break; // already caught up: one incremental batch is enough
@@ -168,7 +172,9 @@ serve(async (req) => {
 
     for (const conn of connections ?? []) {
       if (!conn.api_key_encrypted || !conn.api_secret_encrypted) continue;
-      const r = await processConnectionBatch(service, encryption, conn);
+      // Resolved once per restaurant per cron run.
+      const timeZone = await resolveRestaurantTimeZone(service, conn.restaurant_id);
+      const r = await processConnectionBatch(service, encryption, conn, timeZone);
       totalProcessed += r.processed;
 
       if (r.failed) {

--- a/supabase/functions/revel-sync-data/index.ts
+++ b/supabase/functions/revel-sync-data/index.ts
@@ -3,6 +3,7 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { revelFetch, fetchOrderItemsByDate, fetchPaymentsByDate } from "../_shared/revelClient.ts";
 import { getEncryptionService } from "../_shared/encryption.ts";
 import { processOrder } from "../_shared/revelOrderProcessor.ts";
+import { resolveRestaurantTimeZone } from "../_shared/timezone.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -76,6 +77,9 @@ serve(async (req) => {
     const end = endDate || new Date().toISOString().split('T')[0];
     const start = startDate || new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
 
+    // Resolved once per run, not once per order.
+    const timeZone = await resolveRestaurantTimeZone(service, restaurantId);
+
     // Classic Revel keeps line items in a separate resource — fetch them for the range
     // once and join by order id (Order/OrderAllInOne carry only headers).
     const itemsByOrder = await fetchOrderItemsByDate(conn.revel_instance, apiKey, apiSecret, start, end);
@@ -103,7 +107,7 @@ serve(async (req) => {
           const oid = String(order.id ?? order.uuid);
           (order as any).OrderItems = itemsByOrder[oid] || [];
           (order as any).Payments = paymentsByOrder[oid] || [];
-          await processOrder(service, order, restaurantId, conn.revel_instance, conn.establishment_id ?? null, { skipUnifiedSalesSync: true });
+          await processOrder(service, order, restaurantId, conn.revel_instance, conn.establishment_id ?? null, { skipUnifiedSalesSync: true }, timeZone);
           processed++;
         } catch (e) {
           console.error(`revel-sync-data: failed to process order for restaurant ${restaurantId}:`, e);

--- a/supabase/functions/revel-webhook/index.ts
+++ b/supabase/functions/revel-webhook/index.ts
@@ -3,6 +3,7 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { verifyRevelSignature } from "../_shared/revelSignature.ts";
 import { processOrder } from "../_shared/revelOrderProcessor.ts";
 import { logSecurityEvent } from "../_shared/securityEvents.ts";
+import { resolveRestaurantTimeZone } from "../_shared/timezone.ts";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -79,12 +80,16 @@ serve(async (req) => {
 
     // Only order.finalized carries sales; ignore other event types for v1.
     if (eventType === 'order.finalized' || payload.Order || payload.order) {
+      // Resolved once per invocation (a webhook run processes a single order).
+      const timeZone = await resolveRestaurantTimeZone(supabase, connection.restaurant_id);
       await processOrder(
         supabase,
         payload,
         connection.restaurant_id,
         instance,
         establishmentId ?? connection.establishment_id ?? null,
+        {},
+        timeZone,
       );
     }
 

--- a/supabase/migrations/20260721150000_revel_sold_at_timezone_backfill.sql
+++ b/supabase/migrations/20260721150000_revel_sold_at_timezone_backfill.sql
@@ -1,0 +1,246 @@
+-- Backfill: correct Revel sold_at timezone corruption (design doc
+-- docs/superpowers/specs/2026-07-21-revel-timezone-sold-at-design.md §5b, plan T4).
+--
+-- Revel sends order timestamps as NAIVE establishment-local time, no offset
+-- (e.g. raw_json created_date: "2026-07-19T07:32:16"). Before the source fix
+-- (migration-adjacent edge-function change, plan T1-T3), `parseDateTime`
+-- parsed that naive string with `new Date(raw).toISOString()` in a UTC edge
+-- runtime, mislabeling the local wall-clock as UTC — `sold_at` was NOT a
+-- valid instant, off by the establishment's UTC offset (5h CDT / 6h CST).
+--
+-- This migration recomputes `sold_at` from `raw_json` using Postgres'
+-- DST-aware `AT TIME ZONE`, for every existing `revel_orders` row and its
+-- linked `unified_sales` row. It is a per-restaurant, idempotent, bounded
+-- operation (not one unbounded UPDATE): the aggregation trigger is suppressed
+-- during the bulk `unified_sales` UPDATE and daily totals are re-aggregated
+-- once per touched (restaurant_id, sale_date) — mirroring the pattern used
+-- by sync_toast_to_unified_sales / _sync_focus_transactions_to_unified_sales_impl.
+--
+-- `sale_date` / `sale_time` / `order_date` / `order_time` are untouched —
+-- those were already local-correct; only the mis-anchored `sold_at` instant
+-- is wrong. Revenue/period totals key on `sale_date`, so this backfill does
+-- not change any dollar figure — only intra-day hour attribution.
+
+-- ============================================================
+-- 1) revel_raw_created_date(jsonb): IMMUTABLE helper
+--    Mirrors getOrderNode()/parseDateTime()'s envelope+field precedence in
+--    supabase/functions/_shared/revelOrderProcessor.ts exactly, so no
+--    historically-corrupted row is silently skipped by a too-narrow
+--    COALESCE. Kept in lock-step with that TS logic — if the TS precedence
+--    ever changes, update this function in the same PR.
+--      envelope: payload.Order ?? payload.order ?? payload
+--      field:    created_date ?? createdDate ?? closed_date ?? finalized_date ?? date
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.revel_raw_created_date(p_raw_json jsonb)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT COALESCE(
+    node ->> 'created_date',
+    node ->> 'createdDate',
+    node ->> 'closed_date',
+    node ->> 'finalized_date',
+    node ->> 'date'
+  )
+  FROM (
+    SELECT COALESCE(p_raw_json -> 'Order', p_raw_json -> 'order', p_raw_json) AS node
+  ) _envelope;
+$$;
+
+COMMENT ON FUNCTION public.revel_raw_created_date(jsonb) IS
+  'Extracts the naive local created_date string from a Revel raw_json payload, '
+  'mirroring revelOrderProcessor.ts getOrderNode()/parseDateTime() envelope+field '
+  'precedence (Order/order/flat payload; created_date/createdDate/closed_date/'
+  'finalized_date/date). Used by the sold_at timezone backfill (2026-07-21).';
+
+-- ============================================================
+-- 2) revel_backfill_pending_count(): pre/post-flight row-count report.
+--    Counts revel_orders rows whose stored sold_at still disagrees with the
+--    tz-corrected value computed from raw_json (validated tz, same fallback
+--    as the worker below). Callable before AND after the backfill runs —
+--    should converge to 0.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.revel_backfill_pending_count()
+RETURNS bigint
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT count(*)::bigint
+  FROM public.revel_orders o
+  JOIN public.restaurants r ON r.id = o.restaurant_id
+  WHERE public.revel_raw_created_date(o.raw_json) IS NOT NULL
+    AND o.sold_at IS DISTINCT FROM
+        (public.revel_raw_created_date(o.raw_json))::timestamp AT TIME ZONE
+        (CASE WHEN r.timezone IN (SELECT name FROM pg_timezone_names)
+              THEN r.timezone ELSE 'America/Chicago' END);
+$$;
+
+COMMENT ON FUNCTION public.revel_backfill_pending_count() IS
+  'Count of revel_orders rows whose sold_at still disagrees with the tz-corrected '
+  'value derivable from raw_json. Used for the sold_at backfill pre/post report '
+  '(migration 2026-07-21) — should be 0 after the backfill runs.';
+
+-- ============================================================
+-- 3) revel_backfill_invalid_tz_restaurants(): pre-flight offender report.
+--    Restaurants that have Revel orders but a null/invalid stored timezone —
+--    these fall back to America/Chicago in the worker below; surfaced here so
+--    the fallback isn't a silent surprise.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.revel_backfill_invalid_tz_restaurants()
+RETURNS TABLE(restaurant_id uuid, restaurant_name text, timezone text)
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT r.id, r.name, r.timezone
+  FROM public.restaurants r
+  WHERE r.id IN (SELECT DISTINCT ro.restaurant_id FROM public.revel_orders ro)
+    AND (r.timezone IS NULL OR r.timezone NOT IN (SELECT name FROM pg_timezone_names));
+$$;
+
+COMMENT ON FUNCTION public.revel_backfill_invalid_tz_restaurants() IS
+  'Restaurants with Revel orders whose stored timezone is null or not a valid '
+  'pg_timezone_names entry — the sold_at backfill falls back to America/Chicago '
+  'for these. Pre-flight offender report (migration 2026-07-21).';
+
+-- ============================================================
+-- 4) revel_backfill_sold_at_for_restaurant(uuid): per-restaurant worker.
+--    - Validates restaurants.timezone against pg_timezone_names (fallback
+--      America/Chicago), exactly mirroring the edge-side safeTz() guard —
+--      a non-null-but-invalid tz string would otherwise make AT TIME ZONE
+--      raise and abort.
+--    - UPDATEs revel_orders.sold_at with an IS DISTINCT FROM guard
+--      (idempotent, bounded to actually-changed rows).
+--    - Suppresses app.skip_unified_sales_triggers around the unified_sales
+--      UPDATE so trigger_unified_sales_aggregation doesn't fire per row.
+--    - Re-aggregates once per distinct (restaurant_id, sale_date) touched,
+--      via aggregate_unified_sales_to_daily — not per row.
+--    Callable directly (idempotent — safe to re-run for a single restaurant
+--    at any time, e.g. after a misconfigured timezone is corrected).
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.revel_backfill_sold_at_for_restaurant(p_restaurant_id uuid)
+RETURNS TABLE(orders_updated integer, unified_sales_updated integer, dates_reaggregated integer)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tz text;
+  v_orders_updated integer := 0;
+  v_sales_updated integer := 0;
+  v_dates integer := 0;
+BEGIN
+  SELECT CASE WHEN r.timezone IN (SELECT name FROM pg_timezone_names)
+              THEN r.timezone ELSE 'America/Chicago' END
+  INTO v_tz
+  FROM public.restaurants r
+  WHERE r.id = p_restaurant_id;
+
+  -- No matching restaurant row: still fall back so a stray/orphaned
+  -- restaurant_id on revel_orders never aborts the run.
+  IF v_tz IS NULL THEN
+    v_tz := 'America/Chicago';
+  END IF;
+
+  -- ── revel_orders: recompute sold_at from raw_json in the validated tz ──
+  UPDATE public.revel_orders o
+  SET sold_at = (public.revel_raw_created_date(o.raw_json))::timestamp AT TIME ZONE v_tz,
+      updated_at = now()
+  WHERE o.restaurant_id = p_restaurant_id
+    AND public.revel_raw_created_date(o.raw_json) IS NOT NULL
+    AND o.sold_at IS DISTINCT FROM
+        (public.revel_raw_created_date(o.raw_json))::timestamp AT TIME ZONE v_tz;
+  GET DIAGNOSTICS v_orders_updated = ROW_COUNT;
+
+  -- ── unified_sales: propagate the corrected instant, trigger suppressed ──
+  PERFORM set_config('app.skip_unified_sales_triggers', 'true', true);
+
+  UPDATE public.unified_sales u
+  SET sold_at = o.sold_at
+  FROM public.revel_orders o
+  WHERE u.pos_system = 'revel'
+    AND u.restaurant_id = p_restaurant_id
+    AND o.restaurant_id = p_restaurant_id
+    AND u.external_order_id = o.revel_order_id
+    AND u.sold_at IS DISTINCT FROM o.sold_at;
+  GET DIAGNOSTICS v_sales_updated = ROW_COUNT;
+
+  PERFORM set_config('app.skip_unified_sales_triggers', 'false', true);
+
+  -- ── Re-aggregate once per distinct (restaurant_id, sale_date) touched ──
+  -- Scoped to this restaurant's Revel rows regardless of whether they were
+  -- just modified — cheap (upsert), and guarantees daily_sales reflects the
+  -- current unified_sales state even if a prior partial run left it stale.
+  SELECT count(*) INTO v_dates
+  FROM (SELECT DISTINCT sale_date FROM public.unified_sales
+        WHERE restaurant_id = p_restaurant_id AND pos_system = 'revel') d;
+
+  PERFORM public.aggregate_unified_sales_to_daily(p_restaurant_id, d.sale_date)
+  FROM (SELECT DISTINCT sale_date FROM public.unified_sales
+        WHERE restaurant_id = p_restaurant_id AND pos_system = 'revel') d;
+
+  RETURN QUERY SELECT v_orders_updated, v_sales_updated, v_dates;
+END;
+$$;
+
+COMMENT ON FUNCTION public.revel_backfill_sold_at_for_restaurant(uuid) IS
+  'Per-restaurant worker for the Revel sold_at timezone backfill (2026-07-21). '
+  'Idempotent — safe to re-run. Validates timezone against pg_timezone_names '
+  '(fallback America/Chicago), suppresses the unified_sales aggregation trigger '
+  'during the bulk UPDATE, and re-aggregates daily totals once per touched date.';
+
+-- ============================================================
+-- 5) Driver: run the backfill for every restaurant with Revel orders now.
+--    Bounded per-restaurant DO loop (not one unbounded UPDATE), per design
+--    §5b risk mitigation. Emits a pre/post pending-row report plus an
+--    invalid/null-tz offender report via RAISE NOTICE/WARNING.
+-- ============================================================
+
+DO $$
+DECLARE
+  rec RECORD;
+  v_result RECORD;
+  v_offender RECORD;
+  v_pre bigint;
+  v_post bigint;
+  v_total_orders integer := 0;
+  v_total_sales integer := 0;
+BEGIN
+  v_pre := public.revel_backfill_pending_count();
+  RAISE NOTICE 'revel sold_at backfill: % revel_orders rows need correction (pre-flight)', v_pre;
+
+  FOR rec IN
+    SELECT DISTINCT restaurant_id FROM public.revel_orders
+  LOOP
+    SELECT * INTO v_result
+    FROM public.revel_backfill_sold_at_for_restaurant(rec.restaurant_id);
+
+    v_total_orders := v_total_orders + v_result.orders_updated;
+    v_total_sales := v_total_sales + v_result.unified_sales_updated;
+
+    RAISE NOTICE
+      'revel sold_at backfill: restaurant % -> % revel_orders, % unified_sales rows corrected, % dates re-aggregated',
+      rec.restaurant_id, v_result.orders_updated, v_result.unified_sales_updated, v_result.dates_reaggregated;
+  END LOOP;
+
+  v_post := public.revel_backfill_pending_count();
+  RAISE NOTICE
+    'revel sold_at backfill: done — % revel_orders / % unified_sales rows corrected total; % rows still mismatched (post-flight, expect 0)',
+    v_total_orders, v_total_sales, v_post;
+
+  IF v_post > 0 THEN
+    RAISE WARNING
+      'revel sold_at backfill: % rows did not converge after the backfill — investigate raw_json coverage',
+      v_post;
+  END IF;
+
+  FOR v_offender IN SELECT * FROM public.revel_backfill_invalid_tz_restaurants() LOOP
+    RAISE WARNING
+      'revel sold_at backfill: restaurant % (%) has invalid/null timezone "%" — fell back to America/Chicago',
+      v_offender.restaurant_id, v_offender.restaurant_name, v_offender.timezone;
+  END LOOP;
+END $$;

--- a/supabase/migrations/20260721150000_revel_sold_at_timezone_backfill.sql
+++ b/supabase/migrations/20260721150000_revel_sold_at_timezone_backfill.sql
@@ -136,8 +136,10 @@ COMMENT ON FUNCTION public.revel_backfill_invalid_tz_restaurants() IS
 --      (idempotent, bounded to actually-changed rows).
 --    - Suppresses app.skip_unified_sales_triggers around the unified_sales
 --      UPDATE so trigger_unified_sales_aggregation doesn't fire per row.
---    - Re-aggregates once per distinct (restaurant_id, sale_date) touched,
---      via aggregate_unified_sales_to_daily — not per row.
+--    - Re-aggregates once per distinct (restaurant_id, sale_date) actually
+--      touched by this call (via UPDATE ... RETURNING), via
+--      aggregate_unified_sales_to_daily — not per row, and not a rescan of
+--      the restaurant's entire Revel sale_date history.
 --    Callable directly (idempotent — safe to re-run for a single restaurant
 --    at any time, e.g. after a misconfigured timezone is corrected).
 -- ============================================================
@@ -154,6 +156,7 @@ DECLARE
   v_sales_updated integer := 0;
   v_dates integer := 0;
   v_sale_date date;
+  v_touched_dates date[];
 BEGIN
   SELECT public.revel_valid_tz(r.timezone)
   INTO v_tz
@@ -179,31 +182,34 @@ BEGIN
   -- ── unified_sales: propagate the corrected instant, trigger suppressed ──
   PERFORM set_config('app.skip_unified_sales_triggers', 'true', true);
 
-  UPDATE public.unified_sales u
-  SET sold_at = o.sold_at
-  FROM public.revel_orders o
-  WHERE u.pos_system = 'revel'
-    AND u.restaurant_id = p_restaurant_id
-    AND o.restaurant_id = p_restaurant_id
-    AND u.external_order_id = o.revel_order_id
-    AND u.sold_at IS DISTINCT FROM o.sold_at;
-  GET DIAGNOSTICS v_sales_updated = ROW_COUNT;
+  WITH updated AS (
+    UPDATE public.unified_sales u
+    SET sold_at = o.sold_at
+    FROM public.revel_orders o
+    WHERE u.pos_system = 'revel'
+      AND u.restaurant_id = p_restaurant_id
+      AND o.restaurant_id = p_restaurant_id
+      AND u.external_order_id = o.revel_order_id
+      AND u.sold_at IS DISTINCT FROM o.sold_at
+    RETURNING u.sale_date
+  )
+  SELECT array_agg(DISTINCT sale_date), count(*)
+  INTO v_touched_dates, v_sales_updated
+  FROM updated;
 
   PERFORM set_config('app.skip_unified_sales_triggers', 'false', true);
 
-  -- ── Re-aggregate once per distinct (restaurant_id, sale_date) touched ──
-  -- Scoped to this restaurant's Revel rows regardless of whether they were
-  -- just modified — cheap (upsert), and guarantees daily_sales reflects the
-  -- current unified_sales state even if a prior partial run left it stale.
-  -- Single pass over the distinct dates (not one query for the count and a
-  -- second, identical query to drive the loop).
-  FOR v_sale_date IN
-    SELECT DISTINCT sale_date FROM public.unified_sales
-    WHERE restaurant_id = p_restaurant_id AND pos_system = 'revel'
-  LOOP
-    PERFORM public.aggregate_unified_sales_to_daily(p_restaurant_id, v_sale_date);
-    v_dates := v_dates + 1;
-  END LOOP;
+  -- ── Re-aggregate once per distinct (restaurant_id, sale_date) actually
+  -- touched by THIS call's unified_sales UPDATE above (via RETURNING), not
+  -- every historical Revel sale_date the restaurant has ever had — otherwise
+  -- an idempotent no-op re-run (0 rows changed) still pays the cost of
+  -- rescanning + re-aggregating the restaurant's entire Revel sales history.
+  IF v_touched_dates IS NOT NULL THEN
+    FOREACH v_sale_date IN ARRAY v_touched_dates LOOP
+      PERFORM public.aggregate_unified_sales_to_daily(p_restaurant_id, v_sale_date);
+      v_dates := v_dates + 1;
+    END LOOP;
+  END IF;
 
   RETURN QUERY SELECT v_orders_updated, v_sales_updated, v_dates;
 END;
@@ -213,7 +219,34 @@ COMMENT ON FUNCTION public.revel_backfill_sold_at_for_restaurant(uuid) IS
   'Per-restaurant worker for the Revel sold_at timezone backfill (2026-07-21). '
   'Idempotent — safe to re-run. Validates timezone against pg_timezone_names '
   '(fallback America/Chicago), suppresses the unified_sales aggregation trigger '
-  'during the bulk UPDATE, and re-aggregates daily totals once per touched date.';
+  'during the bulk UPDATE, and re-aggregates daily totals once per date actually '
+  'touched by that UPDATE. Restricted to service_role — not an app-facing RPC '
+  '(no auth.uid() ownership check; intended for the migration driver / ops use only).';
+
+-- ============================================================
+-- 5b) Lock down RPC execution. These are one-time migration/ops helpers
+--    (invoked by the DO block below, or manually by an operator after
+--    correcting a restaurant's timezone) — not app-facing RPCs. Postgres
+--    grants EXECUTE to PUBLIC by default for new functions, and this project
+--    has not altered that default, so without this every authenticated (and
+--    possibly anon) client could call them directly via PostgREST:
+--      - revel_backfill_sold_at_for_restaurant is SECURITY DEFINER and would
+--        let any caller force an RLS-bypassing write against a restaurant_id
+--        they don't own.
+--      - revel_backfill_pending_count / revel_backfill_invalid_tz_restaurants
+--        are SECURITY INVOKER (bounded by RLS) but still shouldn't be part of
+--        the app-facing RPC surface; the latter also returns restaurant_name
+--        across all restaurants with Revel orders.
+--    Mirrors the REVOKE/GRANT pattern already used for the Revel sync RPCs
+--    (20260706120000_revel_integration.sql).
+-- ============================================================
+
+REVOKE ALL ON FUNCTION public.revel_backfill_sold_at_for_restaurant(uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.revel_backfill_pending_count() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.revel_backfill_invalid_tz_restaurants() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.revel_backfill_sold_at_for_restaurant(uuid) TO service_role;
+GRANT EXECUTE ON FUNCTION public.revel_backfill_pending_count() TO service_role;
+GRANT EXECUTE ON FUNCTION public.revel_backfill_invalid_tz_restaurants() TO service_role;
 
 -- ============================================================
 -- 6) Driver: run the backfill for every restaurant with Revel orders now.

--- a/supabase/migrations/20260721150000_revel_sold_at_timezone_backfill.sql
+++ b/supabase/migrations/20260721150000_revel_sold_at_timezone_backfill.sql
@@ -45,7 +45,16 @@ AS $$
     node ->> 'date'
   )
   FROM (
-    SELECT COALESCE(p_raw_json -> 'Order', p_raw_json -> 'order', p_raw_json) AS node
+    -- NULLIF(..., 'null'::jsonb) converts a JSON-null envelope value (e.g.
+    -- {"Order": null, "created_date": "..."}) to a genuine SQL NULL before
+    -- COALESCE, matching getOrderNode()'s `??` fallthrough on JS null. Without
+    -- this, `p_raw_json -> 'Order'` being JSONB null (a non-NULL SQL value)
+    -- would short-circuit COALESCE and silently drop the row's created_date.
+    SELECT COALESCE(
+      NULLIF(p_raw_json -> 'Order', 'null'::jsonb),
+      NULLIF(p_raw_json -> 'order', 'null'::jsonb),
+      p_raw_json
+    ) AS node
   ) _envelope;
 $$;
 

--- a/supabase/migrations/20260721150000_revel_sold_at_timezone_backfill.sql
+++ b/supabase/migrations/20260721150000_revel_sold_at_timezone_backfill.sql
@@ -86,6 +86,33 @@ COMMENT ON FUNCTION public.revel_valid_tz(text) IS
   'Shared by the sold_at backfill helpers (migration 2026-07-21).';
 
 -- ============================================================
+-- 2b) revel_created_date_to_utc(text, text): naive-or-offset -> UTC instant.
+--     Mirrors parseDateTime()'s hasOffset branch exactly: a created_date that
+--     already carries a zone (Z / +-hh:mm / +-hhmm) is an absolute instant, so
+--     cast it directly to timestamptz; only a truly naive string is interpreted
+--     in the establishment tz via AT TIME ZONE. Without this branch an offset-
+--     carrying historical row would be falsely flagged pending and "corrected"
+--     incorrectly (re-interpreting its real instant as local).
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.revel_created_date_to_utc(p_raw text, p_tz text)
+RETURNS timestamptz
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT CASE
+    WHEN p_raw IS NULL THEN NULL
+    WHEN p_raw ~* '(Z|[+-][0-9]{2}:?[0-9]{2})$' THEN p_raw::timestamptz
+    ELSE p_raw::timestamp AT TIME ZONE public.revel_valid_tz(p_tz)
+  END;
+$$;
+
+COMMENT ON FUNCTION public.revel_created_date_to_utc(text, text) IS
+  'Converts a Revel raw created_date to a UTC instant, mirroring '
+  'revelOrderProcessor.parseDateTime: offset-carrying strings (Z/+-hh:mm) cast '
+  'directly to timestamptz; naive strings are interpreted in the (validated) '
+  'establishment tz. Shared by the sold_at backfill helpers (migration 2026-07-21).';
+
+-- ============================================================
 -- 3) revel_backfill_pending_count(): pre/post-flight row-count report.
 --    Counts revel_orders rows whose stored sold_at still disagrees with the
 --    tz-corrected value computed from raw_json (validated tz, same fallback
@@ -103,8 +130,7 @@ AS $$
   JOIN public.restaurants r ON r.id = o.restaurant_id
   WHERE public.revel_raw_created_date(o.raw_json) IS NOT NULL
     AND o.sold_at IS DISTINCT FROM
-        (public.revel_raw_created_date(o.raw_json))::timestamp AT TIME ZONE
-        public.revel_valid_tz(r.timezone);
+        public.revel_created_date_to_utc(public.revel_raw_created_date(o.raw_json), r.timezone);
 $$;
 
 COMMENT ON FUNCTION public.revel_backfill_pending_count() IS
@@ -180,12 +206,12 @@ BEGIN
 
   -- ── revel_orders: recompute sold_at from raw_json in the validated tz ──
   UPDATE public.revel_orders o
-  SET sold_at = (public.revel_raw_created_date(o.raw_json))::timestamp AT TIME ZONE v_tz,
+  SET sold_at = public.revel_created_date_to_utc(public.revel_raw_created_date(o.raw_json), v_tz),
       updated_at = now()
   WHERE o.restaurant_id = p_restaurant_id
     AND public.revel_raw_created_date(o.raw_json) IS NOT NULL
     AND o.sold_at IS DISTINCT FROM
-        (public.revel_raw_created_date(o.raw_json))::timestamp AT TIME ZONE v_tz;
+        public.revel_created_date_to_utc(public.revel_raw_created_date(o.raw_json), v_tz);
   GET DIAGNOSTICS v_orders_updated = ROW_COUNT;
 
   -- ── unified_sales: propagate the corrected instant, trigger suppressed ──

--- a/supabase/migrations/20260721150000_revel_sold_at_timezone_backfill.sql
+++ b/supabase/migrations/20260721150000_revel_sold_at_timezone_backfill.sql
@@ -56,7 +56,28 @@ COMMENT ON FUNCTION public.revel_raw_created_date(jsonb) IS
   'finalized_date/date). Used by the sold_at timezone backfill (2026-07-21).';
 
 -- ============================================================
--- 2) revel_backfill_pending_count(): pre/post-flight row-count report.
+-- 2) revel_valid_tz(text): validated restaurant timezone, with fallback.
+--    Single source of truth for the "is restaurants.timezone usable" check —
+--    mirrors the edge-side safeTz() guard. Used by every backfill helper
+--    below so the validation rule can't drift between them.
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.revel_valid_tz(p_tz text)
+RETURNS text
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT CASE WHEN p_tz IN (SELECT name FROM pg_timezone_names)
+              THEN p_tz ELSE 'America/Chicago' END;
+$$;
+
+COMMENT ON FUNCTION public.revel_valid_tz(text) IS
+  'Validates an IANA timezone string against pg_timezone_names, falling back to '
+  'America/Chicago when null/invalid — mirrors the edge-side safeTz() guard. '
+  'Shared by the sold_at backfill helpers (migration 2026-07-21).';
+
+-- ============================================================
+-- 3) revel_backfill_pending_count(): pre/post-flight row-count report.
 --    Counts revel_orders rows whose stored sold_at still disagrees with the
 --    tz-corrected value computed from raw_json (validated tz, same fallback
 --    as the worker below). Callable before AND after the backfill runs —
@@ -74,8 +95,7 @@ AS $$
   WHERE public.revel_raw_created_date(o.raw_json) IS NOT NULL
     AND o.sold_at IS DISTINCT FROM
         (public.revel_raw_created_date(o.raw_json))::timestamp AT TIME ZONE
-        (CASE WHEN r.timezone IN (SELECT name FROM pg_timezone_names)
-              THEN r.timezone ELSE 'America/Chicago' END);
+        public.revel_valid_tz(r.timezone);
 $$;
 
 COMMENT ON FUNCTION public.revel_backfill_pending_count() IS
@@ -84,7 +104,7 @@ COMMENT ON FUNCTION public.revel_backfill_pending_count() IS
   '(migration 2026-07-21) — should be 0 after the backfill runs.';
 
 -- ============================================================
--- 3) revel_backfill_invalid_tz_restaurants(): pre-flight offender report.
+-- 4) revel_backfill_invalid_tz_restaurants(): pre-flight offender report.
 --    Restaurants that have Revel orders but a null/invalid stored timezone —
 --    these fall back to America/Chicago in the worker below; surfaced here so
 --    the fallback isn't a silent surprise.
@@ -98,7 +118,7 @@ AS $$
   SELECT r.id, r.name, r.timezone
   FROM public.restaurants r
   WHERE r.id IN (SELECT DISTINCT ro.restaurant_id FROM public.revel_orders ro)
-    AND (r.timezone IS NULL OR r.timezone NOT IN (SELECT name FROM pg_timezone_names));
+    AND (r.timezone IS NULL OR public.revel_valid_tz(r.timezone) <> r.timezone);
 $$;
 
 COMMENT ON FUNCTION public.revel_backfill_invalid_tz_restaurants() IS
@@ -107,8 +127,8 @@ COMMENT ON FUNCTION public.revel_backfill_invalid_tz_restaurants() IS
   'for these. Pre-flight offender report (migration 2026-07-21).';
 
 -- ============================================================
--- 4) revel_backfill_sold_at_for_restaurant(uuid): per-restaurant worker.
---    - Validates restaurants.timezone against pg_timezone_names (fallback
+-- 5) revel_backfill_sold_at_for_restaurant(uuid): per-restaurant worker.
+--    - Validates restaurants.timezone via revel_valid_tz() (fallback
 --      America/Chicago), exactly mirroring the edge-side safeTz() guard —
 --      a non-null-but-invalid tz string would otherwise make AT TIME ZONE
 --      raise and abort.
@@ -133,9 +153,9 @@ DECLARE
   v_orders_updated integer := 0;
   v_sales_updated integer := 0;
   v_dates integer := 0;
+  v_sale_date date;
 BEGIN
-  SELECT CASE WHEN r.timezone IN (SELECT name FROM pg_timezone_names)
-              THEN r.timezone ELSE 'America/Chicago' END
+  SELECT public.revel_valid_tz(r.timezone)
   INTO v_tz
   FROM public.restaurants r
   WHERE r.id = p_restaurant_id;
@@ -175,13 +195,15 @@ BEGIN
   -- Scoped to this restaurant's Revel rows regardless of whether they were
   -- just modified — cheap (upsert), and guarantees daily_sales reflects the
   -- current unified_sales state even if a prior partial run left it stale.
-  SELECT count(*) INTO v_dates
-  FROM (SELECT DISTINCT sale_date FROM public.unified_sales
-        WHERE restaurant_id = p_restaurant_id AND pos_system = 'revel') d;
-
-  PERFORM public.aggregate_unified_sales_to_daily(p_restaurant_id, d.sale_date)
-  FROM (SELECT DISTINCT sale_date FROM public.unified_sales
-        WHERE restaurant_id = p_restaurant_id AND pos_system = 'revel') d;
+  -- Single pass over the distinct dates (not one query for the count and a
+  -- second, identical query to drive the loop).
+  FOR v_sale_date IN
+    SELECT DISTINCT sale_date FROM public.unified_sales
+    WHERE restaurant_id = p_restaurant_id AND pos_system = 'revel'
+  LOOP
+    PERFORM public.aggregate_unified_sales_to_daily(p_restaurant_id, v_sale_date);
+    v_dates := v_dates + 1;
+  END LOOP;
 
   RETURN QUERY SELECT v_orders_updated, v_sales_updated, v_dates;
 END;
@@ -194,7 +216,7 @@ COMMENT ON FUNCTION public.revel_backfill_sold_at_for_restaurant(uuid) IS
   'during the bulk UPDATE, and re-aggregates daily totals once per touched date.';
 
 -- ============================================================
--- 5) Driver: run the backfill for every restaurant with Revel orders now.
+-- 6) Driver: run the backfill for every restaurant with Revel orders now.
 --    Bounded per-restaurant DO loop (not one unbounded UPDATE), per design
 --    §5b risk mitigation. Emits a pre/post pending-row report plus an
 --    invalid/null-tz offender report via RAISE NOTICE/WARNING.

--- a/supabase/migrations/20260721160000_revel_rpc_sold_at_self_heal.sql
+++ b/supabase/migrations/20260721160000_revel_rpc_sold_at_self_heal.sql
@@ -12,6 +12,18 @@
 -- updating ONLY sold_at, so user categorization (category_id, is_categorized,
 -- suggested_category_id, ...) is preserved on every other column.
 --
+-- DO UPDATE (unlike DO NOTHING) fires an UPDATE on every conflicting row, even
+-- when the new sold_at equals the old one — and trigger_unified_sales_to_daily
+-- (AFTER INSERT OR UPDATE OR DELETE ... FOR EACH ROW, no WHEN guard) runs a
+-- full aggregate_unified_sales_to_daily() on every such row. Both RPCs are
+-- invoked on every recurring sync (revel-bulk-sync, revel-sync-data) over a
+-- window that overlaps prior runs, so most rows in range are re-syncs that
+-- would now each trigger a full per-row re-aggregation — the exact trigger-
+-- storm risk this feature's own backfill migration (20260721150000) suppresses
+-- via app.skip_unified_sales_triggers. Apply the same suppression here, then
+-- batch-aggregate once per distinct touched sale_date afterward (mirrors
+-- sync_toast_to_unified_sales, 20260215200000_fix_toast_sync_timeout.sql).
+--
 -- Function bodies are otherwise byte-identical to 20260706120000_revel_integration.sql.
 -- =====================================================
 
@@ -43,6 +55,10 @@ BEGIN
   IF NOT FOUND THEN
     RETURN 0;
   END IF;
+
+  -- Suppress per-row aggregation trigger during this multi-row upsert;
+  -- batch-aggregate the single touched date once below instead.
+  PERFORM set_config('app.skip_unified_sales_triggers', 'true', true);
 
   -- 1) Sale line items (item_type = 'sale')
   INSERT INTO public.unified_sales (
@@ -138,6 +154,11 @@ BEGIN
     GET DIAGNOSTICS v_rows = ROW_COUNT; v_synced_count := v_synced_count + v_rows;
   END IF;
 
+  -- Re-enable the trigger, then batch-aggregate the single date this order
+  -- belongs to once — not once per unified_sales row upserted above.
+  PERFORM set_config('app.skip_unified_sales_triggers', 'false', true);
+  PERFORM public.aggregate_unified_sales_to_daily(p_restaurant_id, v_order.order_date);
+
   RETURN v_synced_count;
 END;
 $$;
@@ -162,6 +183,10 @@ BEGIN
   ) THEN
     RAISE EXCEPTION 'Unauthorized: user does not have access to this restaurant';
   END IF;
+
+  -- Suppress per-row aggregation trigger during this multi-row upsert;
+  -- batch-aggregate the touched dates once below instead.
+  PERFORM set_config('app.skip_unified_sales_triggers', 'true', true);
 
   -- 1) Sale rows: non-voided line items (total_price includes modifiers)
   INSERT INTO public.unified_sales (
@@ -327,6 +352,19 @@ BEGIN
     WHERE parent_sale_id IS NULL
   DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
   GET DIAGNOSTICS v_rows = ROW_COUNT; v_synced_count := v_synced_count + v_rows;
+
+  -- Re-enable the trigger, then batch-aggregate only the dates touched by
+  -- this sync window (both callers — revel-sync-data, revel-bulk-sync —
+  -- always pass a bounded p_start_date/p_end_date) once each, instead of
+  -- once per unified_sales row upserted above.
+  PERFORM set_config('app.skip_unified_sales_triggers', 'false', true);
+  PERFORM public.aggregate_unified_sales_to_daily(p_restaurant_id, d.sale_date)
+  FROM (
+    SELECT DISTINCT sale_date FROM public.unified_sales
+    WHERE restaurant_id = p_restaurant_id AND pos_system = 'revel'
+      AND (p_start_date IS NULL OR sale_date >= p_start_date)
+      AND (p_end_date IS NULL OR sale_date <= p_end_date)
+  ) d;
 
   RETURN v_synced_count;
 END;

--- a/supabase/migrations/20260721160000_revel_rpc_sold_at_self_heal.sql
+++ b/supabase/migrations/20260721160000_revel_rpc_sold_at_self_heal.sql
@@ -12,17 +12,19 @@
 -- updating ONLY sold_at, so user categorization (category_id, is_categorized,
 -- suggested_category_id, ...) is preserved on every other column.
 --
--- DO UPDATE (unlike DO NOTHING) fires an UPDATE on every conflicting row, even
--- when the new sold_at equals the old one — and trigger_unified_sales_to_daily
--- (AFTER INSERT OR UPDATE OR DELETE ... FOR EACH ROW, no WHEN guard) runs a
--- full aggregate_unified_sales_to_daily() on every such row. Both RPCs are
--- invoked on every recurring sync (revel-bulk-sync, revel-sync-data) over a
--- window that overlaps prior runs, so most rows in range are re-syncs that
--- would now each trigger a full per-row re-aggregation — the exact trigger-
--- storm risk this feature's own backfill migration (20260721150000) suppresses
--- via app.skip_unified_sales_triggers. Apply the same suppression here, then
--- batch-aggregate once per distinct touched sale_date afterward (mirrors
--- sync_toast_to_unified_sales, 20260215200000_fix_toast_sync_timeout.sql).
+-- Two defenses against DO UPDATE's write amplification (vs DO NOTHING):
+--   1. No-op guard: each DO UPDATE carries
+--      `WHERE unified_sales.sold_at IS DISTINCT FROM COALESCE(EXCLUDED.sold_at,
+--      unified_sales.sold_at)`, so a re-sync that doesn't actually change
+--      sold_at touches zero rows (no dead tuples, no trigger firing). Only a
+--      genuine correction (e.g. post-backfill) writes.
+--   2. Trigger suppression: for the rows that DO change, trigger_unified_sales_to_daily
+--      (AFTER INSERT OR UPDATE OR DELETE ... FOR EACH ROW, no WHEN guard) would
+--      run a full aggregate_unified_sales_to_daily() per row. Both RPCs run on
+--      every recurring sync (revel-bulk-sync, revel-sync-data) over windows that
+--      overlap prior runs, so we suppress via app.skip_unified_sales_triggers and
+--      batch-aggregate once per distinct touched sale_date afterward (mirrors
+--      sync_toast_to_unified_sales, 20260215200000_fix_toast_sync_timeout.sql).
 --
 -- Function bodies are otherwise byte-identical to 20260706120000_revel_integration.sql.
 -- =====================================================
@@ -77,7 +79,8 @@ BEGIN
     AND oi.is_voided = false
   ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
     WHERE parent_sale_id IS NULL
-  DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
+  DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at)
+    WHERE unified_sales.sold_at IS DISTINCT FROM COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
   GET DIAGNOSTICS v_rows = ROW_COUNT; v_synced_count := v_synced_count + v_rows;
 
   -- 2) Tax adjustment row (item_type = 'tax')
@@ -94,7 +97,8 @@ BEGIN
     )
     ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
       WHERE parent_sale_id IS NULL
-    DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
+    DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at)
+    WHERE unified_sales.sold_at IS DISTINCT FROM COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
     GET DIAGNOSTICS v_rows = ROW_COUNT; v_synced_count := v_synced_count + v_rows;
   END IF;
 
@@ -112,7 +116,8 @@ BEGIN
     )
     ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
       WHERE parent_sale_id IS NULL
-    DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
+    DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at)
+    WHERE unified_sales.sold_at IS DISTINCT FROM COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
     GET DIAGNOSTICS v_rows = ROW_COUNT; v_synced_count := v_synced_count + v_rows;
   END IF;
 
@@ -130,7 +135,8 @@ BEGIN
     )
     ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
       WHERE parent_sale_id IS NULL
-    DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
+    DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at)
+    WHERE unified_sales.sold_at IS DISTINCT FROM COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
     GET DIAGNOSTICS v_rows = ROW_COUNT; v_synced_count := v_synced_count + v_rows;
   END IF;
 
@@ -150,7 +156,8 @@ BEGIN
     )
     ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
       WHERE parent_sale_id IS NULL
-    DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
+    DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at)
+    WHERE unified_sales.sold_at IS DISTINCT FROM COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
     GET DIAGNOSTICS v_rows = ROW_COUNT; v_synced_count := v_synced_count + v_rows;
   END IF;
 
@@ -206,7 +213,8 @@ BEGIN
     AND (p_end_date IS NULL OR o.order_date <= p_end_date)
   ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
     WHERE parent_sale_id IS NULL
-  DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
+  DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at)
+    WHERE unified_sales.sold_at IS DISTINCT FROM COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
   GET DIAGNOSTICS v_rows = ROW_COUNT; v_synced_count := v_synced_count + v_rows;
 
   -- 2) Per-order reconciliation to Revel's authoritative header subtotal.
@@ -230,7 +238,8 @@ BEGIN
   WHERE g.adj <> 0
   ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
     WHERE parent_sale_id IS NULL
-  DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
+  DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at)
+    WHERE unified_sales.sold_at IS DISTINCT FROM COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
   GET DIAGNOSTICS v_rows = ROW_COUNT; v_synced_count := v_synced_count + v_rows;
 
   -- 3) Tax (header)
@@ -245,7 +254,8 @@ BEGIN
     AND (p_end_date IS NULL OR o.order_date <= p_end_date)
   ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
     WHERE parent_sale_id IS NULL
-  DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
+  DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at)
+    WHERE unified_sales.sold_at IS DISTINCT FROM COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
   GET DIAGNOSTICS v_rows = ROW_COUNT; v_synced_count := v_synced_count + v_rows;
 
   -- 3) Tip / gratuity (header; on top of final_total)
@@ -260,7 +270,8 @@ BEGIN
     AND (p_end_date IS NULL OR o.order_date <= p_end_date)
   ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
     WHERE parent_sale_id IS NULL
-  DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
+  DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at)
+    WHERE unified_sales.sold_at IS DISTINCT FROM COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
   GET DIAGNOSTICS v_rows = ROW_COUNT; v_synced_count := v_synced_count + v_rows;
 
   -- 4) Discount (header; stored negative)
@@ -275,7 +286,8 @@ BEGIN
     AND (p_end_date IS NULL OR o.order_date <= p_end_date)
   ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
     WHERE parent_sale_id IS NULL
-  DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
+  DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at)
+    WHERE unified_sales.sold_at IS DISTINCT FROM COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
   GET DIAGNOSTICS v_rows = ROW_COUNT; v_synced_count := v_synced_count + v_rows;
 
   -- 5) Service charge (header)
@@ -290,7 +302,8 @@ BEGIN
     AND (p_end_date IS NULL OR o.order_date <= p_end_date)
   ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
     WHERE parent_sale_id IS NULL
-  DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
+  DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at)
+    WHERE unified_sales.sold_at IS DISTINCT FROM COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
   GET DIAGNOSTICS v_rows = ROW_COUNT; v_synced_count := v_synced_count + v_rows;
 
   -- 6/7/8) Informational adjustment lines (Voided / Returned / Refunds). These mirror Revel's
@@ -315,7 +328,8 @@ BEGIN
     AND (p_end_date IS NULL OR o.order_date <= p_end_date)
   ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
     WHERE parent_sale_id IS NULL
-  DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
+  DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at)
+    WHERE unified_sales.sold_at IS DISTINCT FROM COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
   GET DIAGNOSTICS v_rows = ROW_COUNT; v_synced_count := v_synced_count + v_rows;
 
   -- 7) Returned items (voided, order WAS refunded)
@@ -334,7 +348,8 @@ BEGIN
     AND (p_end_date IS NULL OR o.order_date <= p_end_date)
   ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
     WHERE parent_sale_id IS NULL
-  DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
+  DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at)
+    WHERE unified_sales.sold_at IS DISTINCT FROM COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
   GET DIAGNOSTICS v_rows = ROW_COUNT; v_synced_count := v_synced_count + v_rows;
 
   -- 8) Refunds (payments with a negative amount)
@@ -350,7 +365,8 @@ BEGIN
     AND (p_end_date IS NULL OR o.order_date <= p_end_date)
   ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
     WHERE parent_sale_id IS NULL
-  DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
+  DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at)
+    WHERE unified_sales.sold_at IS DISTINCT FROM COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
   GET DIAGNOSTICS v_rows = ROW_COUNT; v_synced_count := v_synced_count + v_rows;
 
   -- Re-enable the trigger, then batch-aggregate only the dates touched by

--- a/supabase/migrations/20260721160000_revel_rpc_sold_at_self_heal.sql
+++ b/supabase/migrations/20260721160000_revel_rpc_sold_at_self_heal.sql
@@ -1,0 +1,333 @@
+-- =====================================================
+-- Revel RPC self-heal (durability) — T5 of the sold_at timezone fix
+--
+-- Both revel_sync_financial_breakdown and sync_revel_to_unified_sales insert into
+-- unified_sales with ON CONFLICT ... DO NOTHING, so a future re-sync of an existing
+-- order refreshes revel_orders.sold_at but never propagates the corrected instant
+-- into an already-present unified_sales row (Toast's RPC already self-heals this
+-- way: see 20260529130000_unified_sales_sold_at.sql).
+--
+-- Change every unified_sales insert block's conflict clause from DO NOTHING to
+-- DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at) —
+-- updating ONLY sold_at, so user categorization (category_id, is_categorized,
+-- suggested_category_id, ...) is preserved on every other column.
+--
+-- Function bodies are otherwise byte-identical to 20260706120000_revel_integration.sql.
+-- =====================================================
+
+CREATE OR REPLACE FUNCTION public.revel_sync_financial_breakdown(
+  p_order_id TEXT,
+  p_restaurant_id UUID
+)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_synced_count INTEGER := 0;
+  v_rows INTEGER := 0;
+  v_order public.revel_orders%ROWTYPE;
+BEGIN
+  IF auth.uid() IS NOT NULL AND NOT EXISTS (
+    SELECT 1 FROM public.user_restaurants
+    WHERE restaurant_id = p_restaurant_id AND user_id = auth.uid()
+  ) THEN
+    RAISE EXCEPTION 'Unauthorized: user does not have access to this restaurant';
+  END IF;
+
+  SELECT * INTO v_order
+  FROM public.revel_orders
+  WHERE restaurant_id = p_restaurant_id AND revel_order_id = p_order_id;
+
+  IF NOT FOUND THEN
+    RETURN 0;
+  END IF;
+
+  -- 1) Sale line items (item_type = 'sale')
+  INSERT INTO public.unified_sales (
+    restaurant_id, pos_system, external_order_id, external_item_id,
+    item_name, quantity, unit_price, total_price,
+    sale_date, sale_time, sold_at, pos_category, item_type, raw_data, synced_at
+  )
+  SELECT
+    oi.restaurant_id, 'revel', oi.revel_order_id, oi.revel_item_id,
+    oi.item_name, oi.quantity, oi.unit_price, oi.total_price,
+    v_order.order_date, v_order.order_time, v_order.sold_at, oi.menu_category,
+    'sale', oi.raw_json, now()
+  FROM public.revel_order_items oi
+  WHERE oi.restaurant_id = p_restaurant_id
+    AND oi.revel_order_id = p_order_id
+    AND oi.is_voided = false
+  ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
+    WHERE parent_sale_id IS NULL
+  DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_synced_count := v_synced_count + v_rows;
+
+  -- 2) Tax adjustment row (item_type = 'tax')
+  IF COALESCE(v_order.tax_amount, 0) <> 0 THEN
+    INSERT INTO public.unified_sales (
+      restaurant_id, pos_system, external_order_id, external_item_id,
+      item_name, quantity, unit_price, total_price,
+      sale_date, sale_time, sold_at, item_type, adjustment_type, synced_at
+    )
+    VALUES (
+      p_restaurant_id, 'revel', p_order_id, p_order_id || ':tax',
+      'Tax', 1, v_order.tax_amount, v_order.tax_amount,
+      v_order.order_date, v_order.order_time, v_order.sold_at, 'tax', 'tax', now()
+    )
+    ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
+      WHERE parent_sale_id IS NULL
+    DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
+    GET DIAGNOSTICS v_rows = ROW_COUNT; v_synced_count := v_synced_count + v_rows;
+  END IF;
+
+  -- 3) Tip adjustment row (item_type = 'tip')
+  IF COALESCE(v_order.tip_amount, 0) <> 0 THEN
+    INSERT INTO public.unified_sales (
+      restaurant_id, pos_system, external_order_id, external_item_id,
+      item_name, quantity, unit_price, total_price,
+      sale_date, sale_time, sold_at, item_type, adjustment_type, synced_at
+    )
+    VALUES (
+      p_restaurant_id, 'revel', p_order_id, p_order_id || ':tip',
+      'Tip', 1, v_order.tip_amount, v_order.tip_amount,
+      v_order.order_date, v_order.order_time, v_order.sold_at, 'tip', 'tip', now()
+    )
+    ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
+      WHERE parent_sale_id IS NULL
+    DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
+    GET DIAGNOSTICS v_rows = ROW_COUNT; v_synced_count := v_synced_count + v_rows;
+  END IF;
+
+  -- 4) Discount adjustment row (item_type = 'discount', negative amount)
+  IF COALESCE(v_order.discount_amount, 0) <> 0 THEN
+    INSERT INTO public.unified_sales (
+      restaurant_id, pos_system, external_order_id, external_item_id,
+      item_name, quantity, unit_price, total_price,
+      sale_date, sale_time, sold_at, item_type, adjustment_type, synced_at
+    )
+    VALUES (
+      p_restaurant_id, 'revel', p_order_id, p_order_id || ':discount',
+      'Discount', 1, -abs(v_order.discount_amount), -abs(v_order.discount_amount),
+      v_order.order_date, v_order.order_time, v_order.sold_at, 'discount', 'discount', now()
+    )
+    ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
+      WHERE parent_sale_id IS NULL
+    DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
+    GET DIAGNOSTICS v_rows = ROW_COUNT; v_synced_count := v_synced_count + v_rows;
+  END IF;
+
+  -- 5) Service charge / auto-gratuity row (item_type = 'service_charge').
+  -- Mirrors block 5 of sync_revel_to_unified_sales so webhook orders carry the same
+  -- component as backfilled ones — otherwise auto-grat/fee orders diverge by channel.
+  IF COALESCE(v_order.service_charge_amount, 0) <> 0 THEN
+    INSERT INTO public.unified_sales (
+      restaurant_id, pos_system, external_order_id, external_item_id,
+      item_name, quantity, unit_price, total_price,
+      sale_date, sale_time, sold_at, item_type, adjustment_type, synced_at
+    )
+    VALUES (
+      p_restaurant_id, 'revel', p_order_id, p_order_id || ':service_charge',
+      'Service Charge', 1, v_order.service_charge_amount, v_order.service_charge_amount,
+      v_order.order_date, v_order.order_time, v_order.sold_at, 'service_charge', 'service_charge', now()
+    )
+    ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
+      WHERE parent_sale_id IS NULL
+    DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
+    GET DIAGNOSTICS v_rows = ROW_COUNT; v_synced_count := v_synced_count + v_rows;
+  END IF;
+
+  RETURN v_synced_count;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.sync_revel_to_unified_sales(
+  p_restaurant_id UUID,
+  p_start_date DATE DEFAULT NULL,
+  p_end_date DATE DEFAULT NULL
+)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_synced_count INTEGER := 0;
+  v_rows INTEGER := 0;
+BEGIN
+  IF auth.uid() IS NOT NULL AND NOT EXISTS (
+    SELECT 1 FROM public.user_restaurants
+    WHERE restaurant_id = p_restaurant_id AND user_id = auth.uid()
+  ) THEN
+    RAISE EXCEPTION 'Unauthorized: user does not have access to this restaurant';
+  END IF;
+
+  -- 1) Sale rows: non-voided line items (total_price includes modifiers)
+  INSERT INTO public.unified_sales (
+    restaurant_id, pos_system, external_order_id, external_item_id,
+    item_name, quantity, unit_price, total_price,
+    sale_date, sale_time, sold_at, pos_category, item_type, raw_data, synced_at
+  )
+  SELECT
+    oi.restaurant_id, 'revel', oi.revel_order_id, oi.revel_item_id,
+    oi.item_name, oi.quantity, oi.unit_price, oi.total_price,
+    o.order_date, o.order_time, o.sold_at, oi.menu_category, 'sale', oi.raw_json, now()
+  FROM public.revel_order_items oi
+  INNER JOIN public.revel_orders o ON oi.revel_order_id_fk = o.id
+  WHERE oi.restaurant_id = p_restaurant_id
+    AND oi.is_voided = false
+    AND (p_start_date IS NULL OR o.order_date >= p_start_date)
+    AND (p_end_date IS NULL OR o.order_date <= p_end_date)
+  ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
+    WHERE parent_sale_id IS NULL
+  DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_synced_count := v_synced_count + v_rows;
+
+  -- 2) Per-order reconciliation to Revel's authoritative header subtotal.
+  --    Revel removes/refunds some items from the subtotal without an item-level flag;
+  --    this labeled line makes each order's sale total match the POS exactly.
+  INSERT INTO public.unified_sales (
+    restaurant_id, pos_system, external_order_id, external_item_id, item_name,
+    quantity, unit_price, total_price, sale_date, sale_time, sold_at, item_type, synced_at)
+  SELECT g.restaurant_id, 'revel', g.revel_order_id, g.revel_order_id || ':reconcile', 'POS sales adjustment',
+         1, g.adj, g.adj, g.order_date, g.order_time, g.sold_at, 'sale', now()
+  FROM (
+    SELECT o.restaurant_id, o.revel_order_id, o.order_date, o.order_time, o.sold_at,
+           round(COALESCE(o.subtotal_amount,0) - COALESCE(sum(oi.total_price) FILTER (WHERE oi.is_voided = false), 0), 2) AS adj
+    FROM public.revel_orders o
+    LEFT JOIN public.revel_order_items oi ON oi.revel_order_id_fk = o.id
+    WHERE o.restaurant_id = p_restaurant_id
+      AND (p_start_date IS NULL OR o.order_date >= p_start_date)
+      AND (p_end_date IS NULL OR o.order_date <= p_end_date)
+    GROUP BY o.restaurant_id, o.revel_order_id, o.order_date, o.order_time, o.sold_at, o.subtotal_amount
+  ) g
+  WHERE g.adj <> 0
+  ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
+    WHERE parent_sale_id IS NULL
+  DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_synced_count := v_synced_count + v_rows;
+
+  -- 3) Tax (header)
+  INSERT INTO public.unified_sales (
+    restaurant_id, pos_system, external_order_id, external_item_id, item_name,
+    quantity, unit_price, total_price, sale_date, sale_time, sold_at, item_type, adjustment_type, synced_at)
+  SELECT o.restaurant_id, 'revel', o.revel_order_id, o.revel_order_id || ':tax', 'Tax',
+         1, o.tax_amount, o.tax_amount, o.order_date, o.order_time, o.sold_at, 'tax', 'tax', now()
+  FROM public.revel_orders o
+  WHERE o.restaurant_id = p_restaurant_id AND COALESCE(o.tax_amount, 0) <> 0
+    AND (p_start_date IS NULL OR o.order_date >= p_start_date)
+    AND (p_end_date IS NULL OR o.order_date <= p_end_date)
+  ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
+    WHERE parent_sale_id IS NULL
+  DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_synced_count := v_synced_count + v_rows;
+
+  -- 3) Tip / gratuity (header; on top of final_total)
+  INSERT INTO public.unified_sales (
+    restaurant_id, pos_system, external_order_id, external_item_id, item_name,
+    quantity, unit_price, total_price, sale_date, sale_time, sold_at, item_type, adjustment_type, synced_at)
+  SELECT o.restaurant_id, 'revel', o.revel_order_id, o.revel_order_id || ':tip', 'Tip',
+         1, o.tip_amount, o.tip_amount, o.order_date, o.order_time, o.sold_at, 'tip', 'tip', now()
+  FROM public.revel_orders o
+  WHERE o.restaurant_id = p_restaurant_id AND COALESCE(o.tip_amount, 0) <> 0
+    AND (p_start_date IS NULL OR o.order_date >= p_start_date)
+    AND (p_end_date IS NULL OR o.order_date <= p_end_date)
+  ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
+    WHERE parent_sale_id IS NULL
+  DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_synced_count := v_synced_count + v_rows;
+
+  -- 4) Discount (header; stored negative)
+  INSERT INTO public.unified_sales (
+    restaurant_id, pos_system, external_order_id, external_item_id, item_name,
+    quantity, unit_price, total_price, sale_date, sale_time, sold_at, item_type, adjustment_type, synced_at)
+  SELECT o.restaurant_id, 'revel', o.revel_order_id, o.revel_order_id || ':discount', 'Discount',
+         1, -abs(o.discount_amount), -abs(o.discount_amount), o.order_date, o.order_time, o.sold_at, 'discount', 'discount', now()
+  FROM public.revel_orders o
+  WHERE o.restaurant_id = p_restaurant_id AND COALESCE(o.discount_amount, 0) <> 0
+    AND (p_start_date IS NULL OR o.order_date >= p_start_date)
+    AND (p_end_date IS NULL OR o.order_date <= p_end_date)
+  ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
+    WHERE parent_sale_id IS NULL
+  DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_synced_count := v_synced_count + v_rows;
+
+  -- 5) Service charge (header)
+  INSERT INTO public.unified_sales (
+    restaurant_id, pos_system, external_order_id, external_item_id, item_name,
+    quantity, unit_price, total_price, sale_date, sale_time, sold_at, item_type, adjustment_type, synced_at)
+  SELECT o.restaurant_id, 'revel', o.revel_order_id, o.revel_order_id || ':service_charge', 'Service Charge',
+         1, o.service_charge_amount, o.service_charge_amount, o.order_date, o.order_time, o.sold_at, 'service_charge', 'service_charge', now()
+  FROM public.revel_orders o
+  WHERE o.restaurant_id = p_restaurant_id AND COALESCE(o.service_charge_amount, 0) <> 0
+    AND (p_start_date IS NULL OR o.order_date >= p_start_date)
+    AND (p_end_date IS NULL OR o.order_date <= p_end_date)
+  ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
+    WHERE parent_sale_id IS NULL
+  DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_synced_count := v_synced_count + v_rows;
+
+  -- 6/7/8) Informational adjustment lines (Voided / Returned / Refunds). These mirror Revel's
+  -- Sales Summary "Adjustments" section. They use item_type 'other'/'refund' (NOT 'sale'), so
+  -- they never enter Net Sales — which stays exact — but are available for the audit/report.
+  -- Split rule: a voided item whose order was refunded (has a negative payment) = "Returned";
+  -- otherwise = "Voided". Refunds = payments with a negative amount.
+
+  -- 6) Voided items (voided, order NOT refunded)
+  INSERT INTO public.unified_sales (
+    restaurant_id, pos_system, external_order_id, external_item_id, item_name,
+    quantity, unit_price, total_price, sale_date, sale_time, sold_at, pos_category, item_type, raw_data, synced_at)
+  SELECT oi.restaurant_id, 'revel', oi.revel_order_id, oi.revel_item_id || ':void', 'Voided item - ' || oi.item_name,
+         oi.quantity, -oi.unit_price, -oi.total_price, o.order_date, o.order_time, o.sold_at, oi.menu_category, 'other', oi.raw_json, now()
+  FROM public.revel_order_items oi
+  JOIN public.revel_orders o ON oi.revel_order_id_fk = o.id
+  WHERE oi.restaurant_id = p_restaurant_id AND oi.is_voided = true
+    AND NOT EXISTS (SELECT 1 FROM public.revel_payments p
+                    WHERE p.restaurant_id = oi.restaurant_id AND p.revel_order_id = oi.revel_order_id
+                      AND (p.raw_json->>'amount')::numeric < 0)
+    AND (p_start_date IS NULL OR o.order_date >= p_start_date)
+    AND (p_end_date IS NULL OR o.order_date <= p_end_date)
+  ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
+    WHERE parent_sale_id IS NULL
+  DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_synced_count := v_synced_count + v_rows;
+
+  -- 7) Returned items (voided, order WAS refunded)
+  INSERT INTO public.unified_sales (
+    restaurant_id, pos_system, external_order_id, external_item_id, item_name,
+    quantity, unit_price, total_price, sale_date, sale_time, sold_at, pos_category, item_type, raw_data, synced_at)
+  SELECT oi.restaurant_id, 'revel', oi.revel_order_id, oi.revel_item_id || ':return', 'Returned item - ' || oi.item_name,
+         oi.quantity, -oi.unit_price, -oi.total_price, o.order_date, o.order_time, o.sold_at, oi.menu_category, 'other', oi.raw_json, now()
+  FROM public.revel_order_items oi
+  JOIN public.revel_orders o ON oi.revel_order_id_fk = o.id
+  WHERE oi.restaurant_id = p_restaurant_id AND oi.is_voided = true
+    AND EXISTS (SELECT 1 FROM public.revel_payments p
+                WHERE p.restaurant_id = oi.restaurant_id AND p.revel_order_id = oi.revel_order_id
+                  AND (p.raw_json->>'amount')::numeric < 0)
+    AND (p_start_date IS NULL OR o.order_date >= p_start_date)
+    AND (p_end_date IS NULL OR o.order_date <= p_end_date)
+  ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
+    WHERE parent_sale_id IS NULL
+  DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_synced_count := v_synced_count + v_rows;
+
+  -- 8) Refunds (payments with a negative amount)
+  INSERT INTO public.unified_sales (
+    restaurant_id, pos_system, external_order_id, external_item_id, item_name,
+    quantity, unit_price, total_price, sale_date, sale_time, sold_at, item_type, raw_data, synced_at)
+  SELECT p.restaurant_id, 'revel', p.revel_order_id, p.revel_payment_id || ':refund', 'Refund',
+         1, (p.raw_json->>'amount')::numeric, (p.raw_json->>'amount')::numeric, o.order_date, o.order_time, o.sold_at, 'refund', p.raw_json, now()
+  FROM public.revel_payments p
+  JOIN public.revel_orders o ON p.revel_order_id = o.revel_order_id AND p.restaurant_id = o.restaurant_id
+  WHERE p.restaurant_id = p_restaurant_id AND (p.raw_json->>'amount')::numeric < 0
+    AND (p_start_date IS NULL OR o.order_date >= p_start_date)
+    AND (p_end_date IS NULL OR o.order_date <= p_end_date)
+  ON CONFLICT (restaurant_id, pos_system, external_order_id, external_item_id)
+    WHERE parent_sale_id IS NULL
+  DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at);
+  GET DIAGNOSTICS v_rows = ROW_COUNT; v_synced_count := v_synced_count + v_rows;
+
+  RETURN v_synced_count;
+END;
+$$;

--- a/supabase/migrations/20260721160000_revel_rpc_sold_at_self_heal.sql
+++ b/supabase/migrations/20260721160000_revel_rpc_sold_at_self_heal.sql
@@ -162,9 +162,13 @@ BEGIN
   END IF;
 
   -- Re-enable the trigger, then batch-aggregate the single date this order
-  -- belongs to once — not once per unified_sales row upserted above.
+  -- belongs to once — not once per unified_sales row upserted above. Skip
+  -- entirely when nothing changed (the no-op guard above wrote 0 rows), since
+  -- the daily aggregate for that date is then already correct.
   PERFORM set_config('app.skip_unified_sales_triggers', 'false', true);
-  PERFORM public.aggregate_unified_sales_to_daily(p_restaurant_id, v_order.order_date);
+  IF v_synced_count > 0 THEN
+    PERFORM public.aggregate_unified_sales_to_daily(p_restaurant_id, v_order.order_date);
+  END IF;
 
   RETURN v_synced_count;
 END;
@@ -372,15 +376,19 @@ BEGIN
   -- Re-enable the trigger, then batch-aggregate only the dates touched by
   -- this sync window (both callers — revel-sync-data, revel-bulk-sync —
   -- always pass a bounded p_start_date/p_end_date) once each, instead of
-  -- once per unified_sales row upserted above.
+  -- once per unified_sales row upserted above. Skip entirely when nothing
+  -- changed (the no-op guards wrote 0 rows) so a recurring sync over an
+  -- overlapping window doesn't re-aggregate the whole window for no reason.
   PERFORM set_config('app.skip_unified_sales_triggers', 'false', true);
-  PERFORM public.aggregate_unified_sales_to_daily(p_restaurant_id, d.sale_date)
-  FROM (
-    SELECT DISTINCT sale_date FROM public.unified_sales
-    WHERE restaurant_id = p_restaurant_id AND pos_system = 'revel'
-      AND (p_start_date IS NULL OR sale_date >= p_start_date)
-      AND (p_end_date IS NULL OR sale_date <= p_end_date)
-  ) d;
+  IF v_synced_count > 0 THEN
+    PERFORM public.aggregate_unified_sales_to_daily(p_restaurant_id, d.sale_date)
+    FROM (
+      SELECT DISTINCT sale_date FROM public.unified_sales
+      WHERE restaurant_id = p_restaurant_id AND pos_system = 'revel'
+        AND (p_start_date IS NULL OR sale_date >= p_start_date)
+        AND (p_end_date IS NULL OR sale_date <= p_end_date)
+    ) d;
+  END IF;
 
   RETURN v_synced_count;
 END;

--- a/supabase/tests/revel_integration.sql
+++ b/supabase/tests/revel_integration.sql
@@ -3,7 +3,7 @@
 -- Covers: revel_sync_financial_breakdown RPC, sync_revel_to_unified_sales RPC, RLS isolation
 
 BEGIN;
-SELECT plan(8);
+SELECT plan(11);
 
 -- Setup: Disable RLS for test data creation (mirrors supabase/tests/17_toast_sync_authorization.sql)
 SET LOCAL role TO postgres;
@@ -69,9 +69,10 @@ SELECT is((SELECT count(*)::int FROM public.unified_sales
    WHERE external_item_id = 'order-1:service_charge' AND item_type = 'service_charge'), 1,
   'breakdown emits a service_charge adjustment row');
 
--- Test 5: second breakdown call is idempotent
-SELECT is(public.revel_sync_financial_breakdown('order-1', '11111111-1111-1111-1111-111111111111'), 0,
-  'second breakdown call is idempotent');
+-- Test 5: second breakdown call self-heals (ON CONFLICT DO UPDATE touches all 5
+-- existing rows to refresh sold_at, so ROW_COUNT reflects rows-processed, not net-new)
+SELECT is(public.revel_sync_financial_breakdown('order-1', '11111111-1111-1111-1111-111111111111'), 5,
+  'second breakdown call re-processes all 5 rows via self-heal DO UPDATE (no net-new rows)');
 
 -- ============================================================
 -- Bulk sync RPC
@@ -87,9 +88,52 @@ SELECT is((SELECT count(*)::int FROM public.unified_sales
      AND external_item_id = 'item-2:void' AND item_type = 'other'), 1,
   'bulk sync emits a voided informational row excluded from net sales');
 
--- Test 7: repeat bulk sync is idempotent (ON CONFLICT DO NOTHING across every block)
-SELECT is(public.sync_revel_to_unified_sales('11111111-1111-1111-1111-111111111111', NULL, NULL), 0,
-  'bulk sync is idempotent on repeat');
+-- Test 7: repeat bulk sync self-heals (ON CONFLICT DO UPDATE across every block that
+-- had a conflicting row: sale, tax, tip, discount, service_charge, voided-item = 6;
+-- the reconcile line stays at adj=0 so it never attempts a row)
+SELECT is(public.sync_revel_to_unified_sales('11111111-1111-1111-1111-111111111111', NULL, NULL), 6,
+  'bulk sync re-processes all conflicting rows via self-heal DO UPDATE on repeat');
+
+-- ============================================================
+-- Self-heal: DO UPDATE propagates corrected sold_at without clobbering categorization
+-- (T5 — mirrors Toast's RPC: a later re-sync of an existing order must not leave
+-- unified_sales.sold_at stale relative to revel_orders.sold_at, e.g. post-backfill)
+-- ============================================================
+
+-- Simulate a user having categorized the sale row before any re-sync
+UPDATE public.unified_sales SET is_categorized = true
+WHERE restaurant_id = '11111111-1111-1111-1111-111111111111'
+  AND pos_system = 'revel' AND external_item_id = 'item-1';
+
+-- Simulate a backfill/correction to revel_orders.sold_at (the timezone fix's authoritative source)
+UPDATE public.revel_orders SET sold_at = '2026-07-01T17:45:00+00'
+WHERE id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+SELECT public.revel_sync_financial_breakdown('order-1', '11111111-1111-1111-1111-111111111111');
+
+-- Test 8: breakdown RPC self-heal propagates the corrected sold_at into the existing row
+SELECT ok((SELECT sold_at FROM public.unified_sales
+   WHERE restaurant_id = '11111111-1111-1111-1111-111111111111'
+     AND pos_system = 'revel' AND external_item_id = 'item-1') = '2026-07-01T17:45:00+00'::timestamptz,
+  'breakdown self-heal propagates corrected sold_at into existing unified_sales row');
+
+-- Test 9: breakdown RPC self-heal preserves user categorization (is_categorized untouched)
+SELECT ok((SELECT is_categorized FROM public.unified_sales
+   WHERE restaurant_id = '11111111-1111-1111-1111-111111111111'
+     AND pos_system = 'revel' AND external_item_id = 'item-1'),
+  'breakdown self-heal preserves is_categorized (does not clobber categorization)');
+
+-- Simulate a second, later backfill correction and verify the bulk-sync RPC self-heals too
+UPDATE public.revel_orders SET sold_at = '2026-07-01T18:15:00+00'
+WHERE id = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+SELECT public.sync_revel_to_unified_sales('11111111-1111-1111-1111-111111111111', NULL, NULL);
+
+-- Test 10: bulk sync RPC self-heal propagates the corrected sold_at into the existing tax row
+SELECT ok((SELECT sold_at FROM public.unified_sales
+   WHERE restaurant_id = '11111111-1111-1111-1111-111111111111'
+     AND pos_system = 'revel' AND external_item_id = 'order-1:tax') = '2026-07-01T18:15:00+00'::timestamptz,
+  'bulk sync self-heal propagates corrected sold_at into existing unified_sales row');
 
 -- ============================================================
 -- RLS isolation
@@ -100,7 +144,7 @@ ALTER TABLE revel_connections ENABLE ROW LEVEL SECURITY;
 SET LOCAL role = authenticated;
 SET LOCAL "request.jwt.claims" = '{"sub":"00000000-0000-0000-0000-300000000002"}';
 
--- Test 8: RLS hides connections from non-members
+-- Test 11: RLS hides connections from non-members
 SELECT is((SELECT count(*)::int FROM public.revel_connections
    WHERE restaurant_id = '11111111-1111-1111-1111-111111111111'), 0,
   'RLS hides connections from non-members');

--- a/supabase/tests/revel_integration.sql
+++ b/supabase/tests/revel_integration.sql
@@ -69,10 +69,11 @@ SELECT is((SELECT count(*)::int FROM public.unified_sales
    WHERE external_item_id = 'order-1:service_charge' AND item_type = 'service_charge'), 1,
   'breakdown emits a service_charge adjustment row');
 
--- Test 5: second breakdown call self-heals (ON CONFLICT DO UPDATE touches all 5
--- existing rows to refresh sold_at, so ROW_COUNT reflects rows-processed, not net-new)
-SELECT is(public.revel_sync_financial_breakdown('order-1', '11111111-1111-1111-1111-111111111111'), 5,
-  'second breakdown call re-processes all 5 rows via self-heal DO UPDATE (no net-new rows)');
+-- Test 5: second breakdown call is a true no-op — sold_at is unchanged, so the
+-- self-heal DO UPDATE's `IS DISTINCT FROM` guard skips every row (0 rows written,
+-- no dead tuples, no trigger churn). Real corrections still propagate (see test 8).
+SELECT is(public.revel_sync_financial_breakdown('order-1', '11111111-1111-1111-1111-111111111111'), 0,
+  'second breakdown call writes 0 rows when sold_at is unchanged (no-op guard)');
 
 -- ============================================================
 -- Bulk sync RPC
@@ -88,11 +89,11 @@ SELECT is((SELECT count(*)::int FROM public.unified_sales
      AND external_item_id = 'item-2:void' AND item_type = 'other'), 1,
   'bulk sync emits a voided informational row excluded from net sales');
 
--- Test 7: repeat bulk sync self-heals (ON CONFLICT DO UPDATE across every block that
--- had a conflicting row: sale, tax, tip, discount, service_charge, voided-item = 6;
--- the reconcile line stays at adj=0 so it never attempts a row)
-SELECT is(public.sync_revel_to_unified_sales('11111111-1111-1111-1111-111111111111', NULL, NULL), 6,
-  'bulk sync re-processes all conflicting rows via self-heal DO UPDATE on repeat');
+-- Test 7: repeat bulk sync is a true no-op — sold_at unchanged across every
+-- conflicting block (sale, tax, tip, discount, service_charge, voided-item), so
+-- the DO UPDATE `IS DISTINCT FROM` guard skips them all (0 rows written).
+SELECT is(public.sync_revel_to_unified_sales('11111111-1111-1111-1111-111111111111', NULL, NULL), 0,
+  'repeat bulk sync writes 0 rows when sold_at is unchanged (no-op guard)');
 
 -- ============================================================
 -- Self-heal: DO UPDATE propagates corrected sold_at without clobbering categorization

--- a/supabase/tests/revel_sold_at_backfill.sql
+++ b/supabase/tests/revel_sold_at_backfill.sql
@@ -1,0 +1,205 @@
+-- pgTAP tests for the Revel sold_at timezone backfill (design §5b, plan T4).
+-- Tests migration: 20260721150000_revel_sold_at_timezone_backfill.sql
+-- Covers: revel_raw_created_date() envelope/field precedence, per-restaurant
+-- backfill worker (revel_orders + unified_sales correction, idempotency,
+-- invalid/null-tz fallback), and the pre/post pending-count report.
+
+BEGIN;
+SELECT plan(19);
+
+-- Setup: Disable RLS for test data creation (mirrors supabase/tests/revel_integration.sql)
+SET LOCAL role TO postgres;
+ALTER TABLE restaurants DISABLE ROW LEVEL SECURITY;
+ALTER TABLE revel_connections DISABLE ROW LEVEL SECURITY;
+ALTER TABLE revel_orders DISABLE ROW LEVEL SECURITY;
+ALTER TABLE revel_order_items DISABLE ROW LEVEL SECURITY;
+ALTER TABLE unified_sales DISABLE ROW LEVEL SECURITY;
+
+-- ============================================================
+-- revel_raw_created_date(jsonb): envelope + field precedence
+-- (mirrors getOrderNode/parseDateTime in revelOrderProcessor.ts)
+-- ============================================================
+
+-- Test 1: "Order" envelope takes precedence over "order"/flat payload
+SELECT is(
+  public.revel_raw_created_date('{"Order": {"created_date": "2026-07-19T07:32:16"}, "order": {"created_date": "wrong"}}'::jsonb),
+  '2026-07-19T07:32:16',
+  'Order envelope wins over order/flat payload'
+);
+
+-- Test 2: lowercase "order" envelope used when "Order" absent
+SELECT is(
+  public.revel_raw_created_date('{"order": {"created_date": "2026-07-19T07:32:16"}}'::jsonb),
+  '2026-07-19T07:32:16',
+  'order envelope used when Order absent'
+);
+
+-- Test 3: flat payload (no envelope) reads fields at top level
+SELECT is(
+  public.revel_raw_created_date('{"created_date": "2026-07-19T07:32:16"}'::jsonb),
+  '2026-07-19T07:32:16',
+  'flat payload (no envelope) reads created_date at top level'
+);
+
+-- Test 4: field precedence — created_date beats createdDate/closed_date/finalized_date/date
+SELECT is(
+  public.revel_raw_created_date('{"Order": {"createdDate": "wrong1", "closed_date": "wrong2", "created_date": "2026-07-19T07:32:16"}}'::jsonb),
+  '2026-07-19T07:32:16',
+  'created_date takes precedence over createdDate/closed_date'
+);
+
+-- Test 5: falls through to createdDate when created_date absent
+SELECT is(
+  public.revel_raw_created_date('{"Order": {"createdDate": "2026-07-19T07:32:16", "closed_date": "wrong"}}'::jsonb),
+  '2026-07-19T07:32:16',
+  'falls through to createdDate when created_date absent'
+);
+
+-- Test 6: falls through to date (last resort) when nothing else present
+SELECT is(
+  public.revel_raw_created_date('{"Order": {"date": "2026-07-19T07:32:16"}}'::jsonb),
+  '2026-07-19T07:32:16',
+  'falls through to date as last resort'
+);
+
+-- Test 7: NULL raw_json / no matching field returns NULL (no throw)
+SELECT is(public.revel_raw_created_date(NULL), NULL, 'NULL raw_json returns NULL');
+SELECT is(public.revel_raw_created_date('{"Order": {}}'::jsonb), NULL, 'no matching field returns NULL');
+
+-- ============================================================
+-- Fixtures: restaurant + revel_orders (naive local created_date in raw_json,
+-- sold_at mis-stamped as if naive digits were UTC — the bug) + a linked
+-- unified_sales sale row with the same corrupted sold_at + stale daily_sales.
+-- ============================================================
+
+INSERT INTO public.restaurants (id, name, timezone) VALUES
+  ('22222222-2222-2222-2222-222222222221', 'Revel Backfill Chicago', 'America/Chicago'),
+  ('22222222-2222-2222-2222-222222222222', 'Revel Backfill Bad TZ', 'Bogus/Zone'),
+  ('22222222-2222-2222-2222-222222222223', 'Revel Backfill Null TZ', NULL)
+ON CONFLICT (id) DO NOTHING;
+UPDATE public.restaurants SET timezone = 'Bogus/Zone' WHERE id = '22222222-2222-2222-2222-222222222222';
+UPDATE public.restaurants SET timezone = NULL WHERE id = '22222222-2222-2222-2222-222222222223';
+
+-- Naive local created_date 2026-07-19T07:32:16 in CDT (America/Chicago, -05:00
+-- in July) => true instant 2026-07-19T12:32:16Z. The pre-fix bug stored the
+-- naive digits mislabeled as UTC (07:32:16Z) — reproduce that corruption here.
+INSERT INTO public.revel_orders (
+  id, restaurant_id, revel_order_id, order_date, order_time, sold_at, raw_json,
+  subtotal_amount, total_amount
+) VALUES (
+  'aaaaaaaa-bbbb-cccc-dddd-000000000001', '22222222-2222-2222-2222-222222222221',
+  'order-tz-1', '2026-07-19', '07:32:16', '2026-07-19T07:32:16+00:00',
+  '{"Order": {"created_date": "2026-07-19T07:32:16"}}'::jsonb,
+  20.00, 20.00
+);
+
+INSERT INTO public.unified_sales (
+  restaurant_id, pos_system, external_order_id, external_item_id,
+  item_name, quantity, unit_price, total_price, sale_date, sale_time, sold_at
+) VALUES (
+  '22222222-2222-2222-2222-222222222221', 'revel', 'order-tz-1', 'order-tz-1:item-1',
+  'Burger', 1, 20.00, 20.00, '2026-07-19', '07:32:16', '2026-07-19T07:32:16+00:00'
+);
+
+-- Same-shaped row under the invalid-tz restaurant — must fall back to
+-- America/Chicago (no throw), matching the edge-side safeTz() fallback.
+INSERT INTO public.revel_orders (
+  id, restaurant_id, revel_order_id, order_date, order_time, sold_at, raw_json,
+  subtotal_amount, total_amount
+) VALUES (
+  'aaaaaaaa-bbbb-cccc-dddd-000000000002', '22222222-2222-2222-2222-222222222222',
+  'order-tz-2', '2026-07-19', '09:00:00', '2026-07-19T09:00:00+00:00',
+  '{"Order": {"created_date": "2026-07-19T09:00:00"}}'::jsonb,
+  10.00, 10.00
+);
+
+-- ============================================================
+-- revel_backfill_pending_count(): pre-flight visibility
+-- ============================================================
+
+-- Test 8: pending count reflects the two mis-stamped rows above (pre-flight)
+SELECT is(public.revel_backfill_pending_count(), 2::bigint,
+  'pending count reports mismatched rows before backfill runs');
+
+-- ============================================================
+-- revel_backfill_sold_at_for_restaurant(): per-restaurant worker
+-- ============================================================
+
+-- Test 9: corrects revel_orders.sold_at to the true UTC instant (valid tz)
+SELECT * FROM public.revel_backfill_sold_at_for_restaurant('22222222-2222-2222-2222-222222222221');
+SELECT is(
+  (SELECT sold_at FROM public.revel_orders WHERE id = 'aaaaaaaa-bbbb-cccc-dddd-000000000001'),
+  '2026-07-19T12:32:16+00:00'::timestamptz,
+  'revel_orders.sold_at corrected to true UTC instant (CDT -05:00)'
+);
+
+-- Test 10: propagates the corrected instant to the linked unified_sales row
+SELECT is(
+  (SELECT sold_at FROM public.unified_sales
+   WHERE restaurant_id = '22222222-2222-2222-2222-222222222221' AND external_order_id = 'order-tz-1'),
+  '2026-07-19T12:32:16+00:00'::timestamptz,
+  'unified_sales.sold_at propagated from corrected revel_orders.sold_at'
+);
+
+-- Test 11: order_date/order_time/sale_date/sale_time are untouched (local-correct already)
+SELECT is(
+  (SELECT order_time::text FROM public.revel_orders WHERE id = 'aaaaaaaa-bbbb-cccc-dddd-000000000001'),
+  '07:32:16',
+  'order_time left untouched by the backfill'
+);
+
+-- Test 12: re-aggregation ran without error and produced a daily_sales row
+-- (sale_date-keyed, so gross_revenue is unaffected by the sold_at fix —
+-- proves the auditor path was never broken, per design §3).
+SELECT is(
+  (SELECT gross_revenue FROM public.daily_sales
+   WHERE restaurant_id = '22222222-2222-2222-2222-222222222221' AND date = '2026-07-19' AND source = 'unified_pos'),
+  20.00::numeric,
+  'daily_sales re-aggregated once for the touched sale_date, revenue unchanged'
+);
+
+-- Test 13: idempotent — a second run updates zero rows
+SELECT is(
+  (SELECT orders_updated FROM public.revel_backfill_sold_at_for_restaurant('22222222-2222-2222-2222-222222222221')),
+  0,
+  'second run against the same restaurant is a no-op (IS DISTINCT FROM guard)'
+);
+
+-- Test 14: invalid tz ("Bogus/Zone") falls back to America/Chicago, no throw
+SELECT lives_ok(
+  $$ SELECT public.revel_backfill_sold_at_for_restaurant('22222222-2222-2222-2222-222222222222') $$,
+  'invalid restaurants.timezone does not abort the backfill (falls back to America/Chicago)'
+);
+SELECT is(
+  (SELECT sold_at FROM public.revel_orders WHERE id = 'aaaaaaaa-bbbb-cccc-dddd-000000000002'),
+  '2026-07-19T14:00:00+00:00'::timestamptz,
+  'invalid-tz restaurant computed as if America/Chicago (CDT -05:00)'
+);
+
+-- Test 15: pending count is 0 once both restaurants have been processed
+SELECT is(public.revel_backfill_pending_count(), 0::bigint,
+  'pending count converges to 0 after backfill (post-flight)');
+
+-- ============================================================
+-- revel_backfill_invalid_tz_restaurants(): pre-flight offender report
+-- ============================================================
+
+-- Test 16: lists the Bogus/Zone restaurant (has revel_orders + invalid tz)
+SELECT is(
+  (SELECT count(*)::int FROM public.revel_backfill_invalid_tz_restaurants()
+   WHERE restaurant_id = '22222222-2222-2222-2222-222222222222'),
+  1,
+  'invalid-tz restaurant with revel_orders is reported'
+);
+
+-- Test 17: does NOT list the null-tz restaurant, which has no revel_orders rows
+-- (report is scoped to restaurants that actually have Revel data, per design §5b)
+SELECT is(
+  (SELECT count(*)::int FROM public.revel_backfill_invalid_tz_restaurants()
+   WHERE restaurant_id = '22222222-2222-2222-2222-222222222223'),
+  0,
+  'restaurant with no revel_orders is not reported even if timezone is null'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/revel_sold_at_backfill.sql
+++ b/supabase/tests/revel_sold_at_backfill.sql
@@ -5,7 +5,7 @@
 -- invalid/null-tz fallback), and the pre/post pending-count report.
 
 BEGIN;
-SELECT plan(23);
+SELECT plan(24);
 
 -- Setup: Disable RLS for test data creation (mirrors supabase/tests/revel_integration.sql)
 SET LOCAL role TO postgres;
@@ -65,6 +65,19 @@ SELECT is(
 -- Test 7: NULL raw_json / no matching field returns NULL (no throw)
 SELECT is(public.revel_raw_created_date(NULL), NULL, 'NULL raw_json returns NULL');
 SELECT is(public.revel_raw_created_date('{"Order": {}}'::jsonb), NULL, 'no matching field returns NULL');
+
+-- Test 7b (Codex review, PR #631): a JSON-null "Order" envelope
+-- ({"Order": null, ...}) must fall through to "order"/flat payload, mirroring
+-- getOrderNode()'s `payload.Order ?? payload.order ?? payload` (JS `??`
+-- treats JS null as nullish and falls through). Without NULLIF-ing the JSONB
+-- null before COALESCE, `p_raw_json -> 'Order'` is a non-NULL SQL value
+-- (JSONB null), so COALESCE would short-circuit on it and the row's
+-- created_date would be silently dropped from the backfill.
+SELECT is(
+  public.revel_raw_created_date('{"Order": null, "created_date": "2026-07-19T07:32:16"}'::jsonb),
+  '2026-07-19T07:32:16',
+  'JSON-null Order envelope falls through to flat-payload created_date'
+);
 
 -- ============================================================
 -- Fixtures: restaurant + revel_orders (naive local created_date in raw_json,

--- a/supabase/tests/revel_sold_at_backfill.sql
+++ b/supabase/tests/revel_sold_at_backfill.sql
@@ -5,7 +5,7 @@
 -- invalid/null-tz fallback), and the pre/post pending-count report.
 
 BEGIN;
-SELECT plan(24);
+SELECT plan(26);
 
 -- Setup: Disable RLS for test data creation (mirrors supabase/tests/revel_integration.sql)
 SET LOCAL role TO postgres;
@@ -295,6 +295,22 @@ SELECT is(
   ),
   0,
   'sold_at reprojected to local tz matches sale_time (+/-1s) for all Revel rows — mismatches = 0'
+);
+
+-- revel_created_date_to_utc: offset-branch mirrors parseDateTime's hasOffset path.
+-- An offset-carrying created_date is already an absolute instant and must be cast
+-- directly (NOT re-interpreted via AT TIME ZONE); a naive string is interpreted in
+-- the establishment tz. Both here denote the same instant, proving an offset row
+-- is not falsely "corrected".
+SELECT is(
+  public.revel_created_date_to_utc('2026-07-19T12:32:16Z', 'America/Chicago'),
+  '2026-07-19T12:32:16+00'::timestamptz,
+  'offset-carrying created_date is cast directly to the same UTC instant (no AT TIME ZONE)'
+);
+SELECT is(
+  public.revel_created_date_to_utc('2026-07-19T07:32:16', 'America/Chicago'),
+  '2026-07-19T12:32:16+00'::timestamptz,
+  'naive created_date (07:32 Central) is interpreted in tz -> 12:32Z'
 );
 
 SELECT * FROM finish();

--- a/supabase/tests/revel_sold_at_backfill.sql
+++ b/supabase/tests/revel_sold_at_backfill.sql
@@ -5,7 +5,7 @@
 -- invalid/null-tz fallback), and the pre/post pending-count report.
 
 BEGIN;
-SELECT plan(19);
+SELECT plan(23);
 
 -- Setup: Disable RLS for test data creation (mirrors supabase/tests/revel_integration.sql)
 SET LOCAL role TO postgres;
@@ -165,7 +165,57 @@ SELECT is(
   'second run against the same restaurant is a no-op (IS DISTINCT FROM guard)'
 );
 
--- Test 14: invalid tz ("Bogus/Zone") falls back to America/Chicago, no throw
+-- ============================================================
+-- Trigger-suppression + batched re-aggregation consistency: a second order
+-- lands on the SAME sale_date after the first backfill run already
+-- corrected order-tz-1. Re-running the worker must (a) touch only the new
+-- row (IS DISTINCT FROM guard — the already-corrected row is untouched),
+-- (b) suppress the per-row aggregation trigger during the unified_sales
+-- UPDATE, and (c) still leave daily_sales consistent with BOTH orders once
+-- the single batched re-aggregation runs — proving trigger suppression
+-- doesn't leave a stale/partial daily aggregate.
+-- ============================================================
+
+INSERT INTO public.revel_orders (
+  id, restaurant_id, revel_order_id, order_date, order_time, sold_at, raw_json,
+  subtotal_amount, total_amount
+) VALUES (
+  'aaaaaaaa-bbbb-cccc-dddd-000000000003', '22222222-2222-2222-2222-222222222221',
+  'order-tz-3', '2026-07-19', '18:00:00', '2026-07-19T18:00:00+00:00',
+  '{"Order": {"created_date": "2026-07-19T18:00:00"}}'::jsonb,
+  15.00, 15.00
+);
+
+INSERT INTO public.unified_sales (
+  restaurant_id, pos_system, external_order_id, external_item_id,
+  item_name, quantity, unit_price, total_price, sale_date, sale_time, sold_at
+) VALUES (
+  '22222222-2222-2222-2222-222222222221', 'revel', 'order-tz-3', 'order-tz-3:item-1',
+  'Fries', 1, 15.00, 15.00, '2026-07-19', '18:00:00', '2026-07-19T18:00:00+00:00'
+);
+
+-- Test 14: re-run touches only the newly-added row (already-corrected
+-- order-tz-1 stays excluded by the IS DISTINCT FROM guard)
+SELECT is(
+  (SELECT orders_updated FROM public.revel_backfill_sold_at_for_restaurant('22222222-2222-2222-2222-222222222221')),
+  1,
+  'second-order re-run updates only the newly-added row, not the already-corrected one'
+);
+
+SELECT is(
+  (SELECT sold_at FROM public.revel_orders WHERE id = 'aaaaaaaa-bbbb-cccc-dddd-000000000003'),
+  '2026-07-19T23:00:00+00:00'::timestamptz,
+  'second order sold_at corrected (18:00:00 local -> 23:00:00Z CDT)'
+);
+
+SELECT is(
+  (SELECT gross_revenue FROM public.daily_sales
+   WHERE restaurant_id = '22222222-2222-2222-2222-222222222221' AND date = '2026-07-19' AND source = 'unified_pos'),
+  35.00::numeric,
+  'daily_sales consistent for both orders sharing the sale_date after trigger-suppressed batched re-aggregation'
+);
+
+-- Test 15: invalid tz ("Bogus/Zone") falls back to America/Chicago, no throw
 SELECT lives_ok(
   $$ SELECT public.revel_backfill_sold_at_for_restaurant('22222222-2222-2222-2222-222222222222') $$,
   'invalid restaurants.timezone does not abort the backfill (falls back to America/Chicago)'
@@ -176,7 +226,7 @@ SELECT is(
   'invalid-tz restaurant computed as if America/Chicago (CDT -05:00)'
 );
 
--- Test 15: pending count is 0 once both restaurants have been processed
+-- Test 16: pending count is 0 once both restaurants have been processed
 SELECT is(public.revel_backfill_pending_count(), 0::bigint,
   'pending count converges to 0 after backfill (post-flight)');
 
@@ -184,7 +234,7 @@ SELECT is(public.revel_backfill_pending_count(), 0::bigint,
 -- revel_backfill_invalid_tz_restaurants(): pre-flight offender report
 -- ============================================================
 
--- Test 16: lists the Bogus/Zone restaurant (has revel_orders + invalid tz)
+-- Test 17: lists the Bogus/Zone restaurant (has revel_orders + invalid tz)
 SELECT is(
   (SELECT count(*)::int FROM public.revel_backfill_invalid_tz_restaurants()
    WHERE restaurant_id = '22222222-2222-2222-2222-222222222222'),
@@ -192,13 +242,46 @@ SELECT is(
   'invalid-tz restaurant with revel_orders is reported'
 );
 
--- Test 17: does NOT list the null-tz restaurant, which has no revel_orders rows
+-- Test 18: does NOT list the null-tz restaurant, which has no revel_orders rows
 -- (report is scoped to restaurants that actually have Revel data, per design §5b)
 SELECT is(
   (SELECT count(*)::int FROM public.revel_backfill_invalid_tz_restaurants()
    WHERE restaurant_id = '22222222-2222-2222-2222-222222222223'),
   0,
   'restaurant with no revel_orders is not reported even if timezone is null'
+);
+
+-- ============================================================
+-- Design §7 acceptance query, as a pgTAP assertion: for every Revel-sourced
+-- unified_sales row, the sold_at instant reprojected into the restaurant's
+-- local timezone must equal sale_time (± 1s rounding). This is an
+-- independent check (raw AT TIME ZONE query, not reuse of
+-- revel_backfill_pending_count()) so a bug shared between the worker and the
+-- pending-count helper wouldn't hide a mismatch. mismatches must be 0.
+-- ============================================================
+
+-- Test 19: reconciliation — (sold_at AT TIME ZONE r.timezone)::time equals
+-- sale_time (± 1s) for all Revel unified_sales rows created in this test;
+-- mismatches = 0.
+SELECT is(
+  (
+    SELECT count(*)::int
+    FROM public.unified_sales u
+    JOIN public.restaurants r ON r.id = u.restaurant_id
+    WHERE u.pos_system = 'revel'
+      AND u.restaurant_id IN (
+        '22222222-2222-2222-2222-222222222221',
+        '22222222-2222-2222-2222-222222222222'
+      )
+      AND abs(extract(epoch FROM (
+        (u.sold_at AT TIME ZONE
+          (CASE WHEN r.timezone IN (SELECT name FROM pg_timezone_names)
+                THEN r.timezone ELSE 'America/Chicago' END)
+        )::time - u.sale_time
+      ))) > 1
+  ),
+  0,
+  'sold_at reprojected to local tz matches sale_time (+/-1s) for all Revel rows — mismatches = 0'
 );
 
 SELECT * FROM finish();

--- a/tests/unit/edgeTimezone.test.ts
+++ b/tests/unit/edgeTimezone.test.ts
@@ -28,7 +28,7 @@ describe('zonedNaiveToUtc', () => {
     expect(result.toISOString()).toBe('2026-07-19T12:32:00.000Z');
   });
 
-  it('handles the DST spring-forward transition day (2026-03-08) correctly on either side', () => {
+  it('CRITICAL: handles the DST spring-forward transition day (2026-03-08) correctly on either side', () => {
     // 2026-03-08 02:00 local -> 03:00 local in America/Chicago (spring forward).
     // Before the transition (still CST, UTC-6):
     const before = zonedNaiveToUtc('2026-03-08T01:30:00', 'America/Chicago');
@@ -39,7 +39,7 @@ describe('zonedNaiveToUtc', () => {
     expect(after.toISOString()).toBe('2026-03-08T15:00:00.000Z');
   });
 
-  it('handles the 3:00-7:59 AM local window on spring-forward day (single-pass offset probe bug)', () => {
+  it('CRITICAL: handles the 3:00-7:59 AM local window on spring-forward day (single-pass offset probe bug)', () => {
     // Regression for a single-pass offset-probe bug: the naive-as-UTC "guess"
     // instant for 03:30 local (03:30Z) falls BEFORE the 08:00Z transition, so
     // a single formatToParts probe at the guess reads the pre-transition CST

--- a/tests/unit/edgeTimezone.test.ts
+++ b/tests/unit/edgeTimezone.test.ts
@@ -15,6 +15,19 @@ describe('zonedNaiveToUtc', () => {
     expect(result.toISOString()).toBe('2026-01-15T13:32:16.000Z');
   });
 
+  it('tolerates naive timestamps with fractional seconds (truncates to whole seconds)', () => {
+    // A POS feed may include milliseconds (e.g. Toast-style ".071"). The helper
+    // must not return NaN here — a NaN would make the caller silently store a
+    // NULL sold_at / order_time, reintroducing the very data-loss this fixes.
+    const result = zonedNaiveToUtc('2026-07-19T07:32:16.071', 'America/Chicago');
+    expect(result.toISOString()).toBe('2026-07-19T12:32:16.000Z');
+  });
+
+  it('tolerates a naive timestamp with no seconds component', () => {
+    const result = zonedNaiveToUtc('2026-07-19T07:32', 'America/Chicago');
+    expect(result.toISOString()).toBe('2026-07-19T12:32:00.000Z');
+  });
+
   it('handles the DST spring-forward transition day (2026-03-08) correctly on either side', () => {
     // 2026-03-08 02:00 local -> 03:00 local in America/Chicago (spring forward).
     // Before the transition (still CST, UTC-6):

--- a/tests/unit/edgeTimezone.test.ts
+++ b/tests/unit/edgeTimezone.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { zonedNaiveToUtc, safeTz, tzOffsetMs } from '../../supabase/functions/_shared/timezone';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { zonedNaiveToUtc, safeTz, tzOffsetMs, resolveRestaurantTimeZone } from '../../supabase/functions/_shared/timezone';
 
 // All assertions compare against explicit UTC ISO strings (via Date.UTC / toISOString)
 // so they are TZ-portable and do not depend on the host machine's local timezone.
@@ -94,5 +94,68 @@ describe('tzOffsetMs', () => {
   it('returns 0 for UTC', () => {
     const date = new Date(Date.UTC(2026, 0, 15, 12, 0, 0));
     expect(tzOffsetMs(date, 'UTC')).toBe(0);
+  });
+});
+
+// Stub matching the `.from().select().eq().maybeSingle()` chain the Revel
+// callers use (revel-webhook / revel-sync-data / revel-bulk-sync), so this
+// is testable in Node without a Deno/supabase-js import.
+function makeSupabaseStub(result: { data: { timezone: string | null } | null; error: { message: string } | null }) {
+  return {
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          maybeSingle: vi.fn(() => Promise.resolve(result)),
+        })),
+      })),
+    })),
+  };
+}
+
+describe('resolveRestaurantTimeZone', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('returns the restaurant timezone when set and valid', async () => {
+    const supabase = makeSupabaseStub({ data: { timezone: 'America/New_York' }, error: null });
+    const tz = await resolveRestaurantTimeZone(supabase as any, 'r1');
+    expect(tz).toBe('America/New_York');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to America/Chicago and warns when timezone is null', async () => {
+    const supabase = makeSupabaseStub({ data: { timezone: null }, error: null });
+    const tz = await resolveRestaurantTimeZone(supabase as any, 'r1');
+    expect(tz).toBe('America/Chicago');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('r1');
+  });
+
+  it('falls back to America/Chicago and warns when the row is missing', async () => {
+    const supabase = makeSupabaseStub({ data: null, error: null });
+    const tz = await resolveRestaurantTimeZone(supabase as any, 'r1');
+    expect(tz).toBe('America/Chicago');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to America/Chicago and warns when the query errors', async () => {
+    const supabase = makeSupabaseStub({ data: null, error: { message: 'boom' } });
+    const tz = await resolveRestaurantTimeZone(supabase as any, 'r1');
+    expect(tz).toBe('America/Chicago');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to America/Chicago and warns when the stored timezone is invalid', async () => {
+    const supabase = makeSupabaseStub({ data: { timezone: 'Bogus/Zone' }, error: null });
+    const tz = await resolveRestaurantTimeZone(supabase as any, 'r1');
+    expect(tz).toBe('America/Chicago');
+    expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/unit/edgeTimezone.test.ts
+++ b/tests/unit/edgeTimezone.test.ts
@@ -26,6 +26,25 @@ describe('zonedNaiveToUtc', () => {
     expect(after.toISOString()).toBe('2026-03-08T15:00:00.000Z');
   });
 
+  it('handles the 3:00-7:59 AM local window on spring-forward day (single-pass offset probe bug)', () => {
+    // Regression for a single-pass offset-probe bug: the naive-as-UTC "guess"
+    // instant for 03:30 local (03:30Z) falls BEFORE the 08:00Z transition, so
+    // a single formatToParts probe at the guess reads the pre-transition CST
+    // offset (-6h) even though the intended wall-clock time is post-transition
+    // CDT (-5h) — corrupting the result by 1h (previously returned
+    // 2026-03-08T09:30:00.000Z, i.e. local 04:30, instead of 08:30:00.000Z).
+    const result = zonedNaiveToUtc('2026-03-08T03:30:00', 'America/Chicago');
+    expect(result.toISOString()).toBe('2026-03-08T08:30:00.000Z');
+
+    // A second point in the same previously-broken window, near the low end.
+    const result2 = zonedNaiveToUtc('2026-03-08T03:01:00', 'America/Chicago');
+    expect(result2.toISOString()).toBe('2026-03-08T08:01:00.000Z');
+
+    // Near the high end of the window (just before 8 AM local).
+    const result3 = zonedNaiveToUtc('2026-03-08T07:59:00', 'America/Chicago');
+    expect(result3.toISOString()).toBe('2026-03-08T12:59:00.000Z');
+  });
+
   it('falls back to America/Chicago for an empty timezone string, no throw', () => {
     expect(() => zonedNaiveToUtc('2026-07-19T07:32:16', '')).not.toThrow();
     const result = zonedNaiveToUtc('2026-07-19T07:32:16', '');

--- a/tests/unit/edgeTimezone.test.ts
+++ b/tests/unit/edgeTimezone.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { zonedNaiveToUtc, safeTz, tzOffsetMs } from '../../supabase/functions/_shared/timezone';
+
+// All assertions compare against explicit UTC ISO strings (via Date.UTC / toISOString)
+// so they are TZ-portable and do not depend on the host machine's local timezone.
+
+describe('zonedNaiveToUtc', () => {
+  it('converts a naive America/Chicago datetime in CDT (summer, UTC-5)', () => {
+    const result = zonedNaiveToUtc('2026-07-19T07:32:16', 'America/Chicago');
+    expect(result.toISOString()).toBe('2026-07-19T12:32:16.000Z');
+  });
+
+  it('converts a naive America/Chicago datetime in CST (winter, UTC-6)', () => {
+    const result = zonedNaiveToUtc('2026-01-15T07:32:16', 'America/Chicago');
+    expect(result.toISOString()).toBe('2026-01-15T13:32:16.000Z');
+  });
+
+  it('handles the DST spring-forward transition day (2026-03-08) correctly on either side', () => {
+    // 2026-03-08 02:00 local -> 03:00 local in America/Chicago (spring forward).
+    // Before the transition (still CST, UTC-6):
+    const before = zonedNaiveToUtc('2026-03-08T01:30:00', 'America/Chicago');
+    expect(before.toISOString()).toBe('2026-03-08T07:30:00.000Z');
+
+    // After the transition (now CDT, UTC-5):
+    const after = zonedNaiveToUtc('2026-03-08T10:00:00', 'America/Chicago');
+    expect(after.toISOString()).toBe('2026-03-08T15:00:00.000Z');
+  });
+
+  it('falls back to America/Chicago for an empty timezone string, no throw', () => {
+    expect(() => zonedNaiveToUtc('2026-07-19T07:32:16', '')).not.toThrow();
+    const result = zonedNaiveToUtc('2026-07-19T07:32:16', '');
+    expect(result.toISOString()).toBe('2026-07-19T12:32:16.000Z');
+  });
+
+  it('falls back to America/Chicago for an invalid/bogus timezone string, no throw', () => {
+    expect(() => zonedNaiveToUtc('2026-07-19T07:32:16', 'Bogus/Zone')).not.toThrow();
+    const result = zonedNaiveToUtc('2026-07-19T07:32:16', 'Bogus/Zone');
+    expect(result.toISOString()).toBe('2026-07-19T12:32:16.000Z');
+  });
+
+  it('falls back to America/Chicago for a null/undefined timezone, no throw', () => {
+    // @ts-expect-error - exercising runtime guard against non-string input
+    const result = zonedNaiveToUtc('2026-01-15T07:32:16', null);
+    expect(result.toISOString()).toBe('2026-01-15T13:32:16.000Z');
+  });
+
+  it('parses a space-separated naive datetime the same as a T-separated one', () => {
+    const result = zonedNaiveToUtc('2026-07-19 07:32:16', 'America/Chicago');
+    expect(result.toISOString()).toBe('2026-07-19T12:32:16.000Z');
+  });
+
+  it('defaults seconds to :00 when omitted', () => {
+    const result = zonedNaiveToUtc('2026-07-19T07:32', 'America/Chicago');
+    expect(result.toISOString()).toBe('2026-07-19T12:32:00.000Z');
+  });
+
+  it('returns an invalid Date for an unparseable naive string, no throw', () => {
+    expect(() => zonedNaiveToUtc('not-a-date', 'America/Chicago')).not.toThrow();
+    const result = zonedNaiveToUtc('not-a-date', 'America/Chicago');
+    expect(Number.isNaN(result.getTime())).toBe(true);
+  });
+});
+
+describe('safeTz', () => {
+  it('passes through a valid IANA timezone', () => {
+    expect(safeTz('America/New_York')).toBe('America/New_York');
+  });
+
+  it('falls back to America/Chicago for an invalid timezone', () => {
+    expect(safeTz('Bogus/Zone')).toBe('America/Chicago');
+  });
+
+  it('falls back to America/Chicago for an empty string', () => {
+    expect(safeTz('')).toBe('America/Chicago');
+  });
+
+  it('falls back to America/Chicago for null/undefined', () => {
+    expect(safeTz(null)).toBe('America/Chicago');
+    expect(safeTz(undefined)).toBe('America/Chicago');
+  });
+});
+
+describe('tzOffsetMs', () => {
+  it('returns -5h in ms for America/Chicago during CDT', () => {
+    const date = new Date(Date.UTC(2026, 6, 19, 12, 0, 0)); // July -> CDT
+    expect(tzOffsetMs(date, 'America/Chicago')).toBe(-5 * 60 * 60 * 1000);
+  });
+
+  it('returns -6h in ms for America/Chicago during CST', () => {
+    const date = new Date(Date.UTC(2026, 0, 15, 12, 0, 0)); // January -> CST
+    expect(tzOffsetMs(date, 'America/Chicago')).toBe(-6 * 60 * 60 * 1000);
+  });
+
+  it('returns 0 for UTC', () => {
+    const date = new Date(Date.UTC(2026, 0, 15, 12, 0, 0));
+    expect(tzOffsetMs(date, 'UTC')).toBe(0);
+  });
+});

--- a/tests/unit/edgeTimezone.test.ts
+++ b/tests/unit/edgeTimezone.test.ts
@@ -58,7 +58,8 @@ describe('zonedNaiveToUtc', () => {
   });
 
   it('falls back to America/Chicago for a null/undefined timezone, no throw', () => {
-    // @ts-expect-error - exercising runtime guard against non-string input
+    // zonedNaiveToUtc's timeZone param is typed `string | null | undefined`,
+    // so this is exercising a real (non-error) runtime branch, not a type error.
     const result = zonedNaiveToUtc('2026-01-15T07:32:16', null);
     expect(result.toISOString()).toBe('2026-01-15T13:32:16.000Z');
   });
@@ -119,7 +120,9 @@ describe('tzOffsetMs', () => {
 // Stub matching the `.from().select().eq().maybeSingle()` chain the Revel
 // callers use (revel-webhook / revel-sync-data / revel-bulk-sync), so this
 // is testable in Node without a Deno/supabase-js import.
-function makeSupabaseStub(result: { data: { timezone: string | null } | null; error: { message: string } | null }) {
+function makeSupabaseStub(
+  result: { data: { timezone: string | null } | null; error: { message: string } | null },
+): Parameters<typeof resolveRestaurantTimeZone>[0] {
   return {
     from: vi.fn(() => ({
       select: vi.fn(() => ({
@@ -144,14 +147,14 @@ describe('resolveRestaurantTimeZone', () => {
 
   it('returns the restaurant timezone when set and valid', async () => {
     const supabase = makeSupabaseStub({ data: { timezone: 'America/New_York' }, error: null });
-    const tz = await resolveRestaurantTimeZone(supabase as any, 'r1');
+    const tz = await resolveRestaurantTimeZone(supabase, 'r1');
     expect(tz).toBe('America/New_York');
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it('falls back to America/Chicago and warns when timezone is null', async () => {
     const supabase = makeSupabaseStub({ data: { timezone: null }, error: null });
-    const tz = await resolveRestaurantTimeZone(supabase as any, 'r1');
+    const tz = await resolveRestaurantTimeZone(supabase, 'r1');
     expect(tz).toBe('America/Chicago');
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy.mock.calls[0][0]).toContain('r1');
@@ -159,21 +162,21 @@ describe('resolveRestaurantTimeZone', () => {
 
   it('falls back to America/Chicago and warns when the row is missing', async () => {
     const supabase = makeSupabaseStub({ data: null, error: null });
-    const tz = await resolveRestaurantTimeZone(supabase as any, 'r1');
+    const tz = await resolveRestaurantTimeZone(supabase, 'r1');
     expect(tz).toBe('America/Chicago');
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 
   it('falls back to America/Chicago and warns when the query errors', async () => {
     const supabase = makeSupabaseStub({ data: null, error: { message: 'boom' } });
-    const tz = await resolveRestaurantTimeZone(supabase as any, 'r1');
+    const tz = await resolveRestaurantTimeZone(supabase, 'r1');
     expect(tz).toBe('America/Chicago');
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 
   it('falls back to America/Chicago and warns when the stored timezone is invalid', async () => {
     const supabase = makeSupabaseStub({ data: { timezone: 'Bogus/Zone' }, error: null });
-    const tz = await resolveRestaurantTimeZone(supabase as any, 'r1');
+    const tz = await resolveRestaurantTimeZone(supabase, 'r1');
     expect(tz).toBe('America/Chicago');
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });

--- a/tests/unit/revelOrderProcessor.test.ts
+++ b/tests/unit/revelOrderProcessor.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import { normalizeOrder, processOrder } from '../../supabase/functions/_shared/revelOrderProcessor';
 
-// Assumed OrderAllInOne-ish shape (field names are defensive; confirm with Revel per spec risk 8.1).
+// Revel's real feed sends created_date as NAIVE establishment-local time, no offset
+// (e.g. '2026-07-19T07:32:16'). See docs/superpowers/specs/2026-07-21-revel-timezone-sold-at-design.md.
 const SAMPLE = {
   Order: {
     id: 'order-1',
     order_number: 'A-1001',
-    created_date: '2026-07-01T12:30:00+0000',
+    created_date: '2026-07-19T07:32:16',
     dining_option: 'DINE_IN',
     subtotal: 20.0,
     tax: 2.0,
@@ -48,23 +49,85 @@ function makeFakeSupabase() {
 }
 
 describe('normalizeOrder', () => {
-  it('extracts order id, date, totals, items, payments', () => {
-    const n = normalizeOrder(SAMPLE);
+  it('extracts order id, totals, items, payments', () => {
+    const n = normalizeOrder(SAMPLE, 'America/Chicago');
     expect(n.orderId).toBe('order-1');
-    expect(n.orderDate).toBe('2026-07-01');
     expect(n.totals.taxAmount).toBe(2.0);
     expect(n.totals.tipAmount).toBe(3.0);
     expect(n.items).toHaveLength(1);
     expect(n.items[0].itemName).toBe('Burger');
     expect(n.payments[0].amount).toBe(24.0);
   });
+
+  it('interprets a naive created_date as establishment-local time and stamps a correct UTC sold_at (CDT, summer)', () => {
+    const n = normalizeOrder(SAMPLE, 'America/Chicago');
+    expect(n.soldAt).toBe('2026-07-19T12:32:16.000Z');
+    expect(n.orderTime).toBe('07:32:16');
+    expect(n.orderDate).toBe('2026-07-19');
+  });
+
+  it('interprets a naive created_date correctly in CST (winter, UTC-6)', () => {
+    const winterOrder = {
+      Order: { ...SAMPLE.Order, created_date: '2026-01-15T07:32:16' },
+      OrderItems: SAMPLE.OrderItems,
+      Payments: SAMPLE.Payments,
+    };
+    const n = normalizeOrder(winterOrder, 'America/Chicago');
+    expect(n.soldAt).toBe('2026-01-15T13:32:16.000Z');
+    expect(n.orderTime).toBe('07:32:16');
+    expect(n.orderDate).toBe('2026-01-15');
+  });
+
+  it('rolls the business date back a day for an order before the 2 AM boundary (local space)', () => {
+    const lateNightOrder = {
+      Order: { ...SAMPLE.Order, created_date: '2026-07-19T01:15:00' },
+      OrderItems: SAMPLE.OrderItems,
+      Payments: SAMPLE.Payments,
+    };
+    const n = normalizeOrder(lateNightOrder, 'America/Chicago');
+    expect(n.orderTime).toBe('01:15:00');
+    expect(n.orderDate).toBe('2026-07-18');
+    // sold_at is still the true instant of the naive local wall-clock, unaffected by the biz-date shift.
+    expect(n.soldAt).toBe('2026-07-19T06:15:00.000Z');
+  });
+
+  it('keeps the business date same-day for an order at/after the 2 AM boundary (local space)', () => {
+    const justAfterBoundary = {
+      Order: { ...SAMPLE.Order, created_date: '2026-07-19T02:00:00' },
+      OrderItems: SAMPLE.OrderItems,
+      Payments: SAMPLE.Payments,
+    };
+    const n = normalizeOrder(justAfterBoundary, 'America/Chicago');
+    expect(n.orderTime).toBe('02:00:00');
+    expect(n.orderDate).toBe('2026-07-19');
+  });
+
+  it('handles an already-zoned created_date defensively via new Date (real Revel data is naive)', () => {
+    const zonedOrder = {
+      Order: { ...SAMPLE.Order, created_date: '2026-07-01T12:30:00+0000' },
+      OrderItems: SAMPLE.OrderItems,
+      Payments: SAMPLE.Payments,
+    };
+    const n = normalizeOrder(zonedOrder, 'America/Chicago');
+    expect(n.soldAt).toBe('2026-07-01T12:30:00.000Z');
+    expect(n.orderTime).toBe('12:30:00');
+    expect(n.orderDate).toBe('2026-07-01');
+  });
+
+  it('falls back to America/Chicago when no timeZone is passed', () => {
+    const n = normalizeOrder(SAMPLE);
+    expect(n.soldAt).toBe('2026-07-19T12:32:16.000Z');
+  });
 });
 
 describe('processOrder', () => {
-  it('upserts order/items/payments and calls the breakdown RPC', async () => {
+  it('upserts order/items/payments (with a correct tz-aware sold_at) and calls the breakdown RPC', async () => {
     const fake = makeFakeSupabase();
-    await processOrder(fake as any, SAMPLE, 'rest-1', 'reveltesta', 'est-1');
+    await processOrder(fake as any, SAMPLE, 'rest-1', 'reveltesta', 'est-1', {}, 'America/Chicago');
     expect(fake._calls.orders).toHaveLength(1);
+    expect(fake._calls.orders[0].sold_at).toBe('2026-07-19T12:32:16.000Z');
+    expect(fake._calls.orders[0].order_time).toBe('07:32:16');
+    expect(fake._calls.orders[0].order_date).toBe('2026-07-19');
     expect(fake._calls.items).toHaveLength(1);
     expect(fake._calls.payments).toHaveLength(1);
     expect(fake._calls.rpc[0]).toEqual({ fn: 'revel_sync_financial_breakdown', args: { p_order_id: 'order-1', p_restaurant_id: 'rest-1' } });

--- a/tests/unit/revelOrderProcessor.test.ts
+++ b/tests/unit/revelOrderProcessor.test.ts
@@ -123,7 +123,7 @@ describe('normalizeOrder', () => {
 describe('processOrder', () => {
   it('upserts order/items/payments (with a correct tz-aware sold_at) and calls the breakdown RPC', async () => {
     const fake = makeFakeSupabase();
-    await processOrder(fake as any, SAMPLE, 'rest-1', 'reveltesta', 'est-1', {}, 'America/Chicago');
+    await processOrder(fake, SAMPLE, 'rest-1', 'reveltesta', 'est-1', {}, 'America/Chicago');
     expect(fake._calls.orders).toHaveLength(1);
     expect(fake._calls.orders[0].sold_at).toBe('2026-07-19T12:32:16.000Z');
     expect(fake._calls.orders[0].order_time).toBe('07:32:16');
@@ -135,7 +135,7 @@ describe('processOrder', () => {
 
   it('skips the RPC when skipUnifiedSalesSync is set (bulk mode)', async () => {
     const fake = makeFakeSupabase();
-    await processOrder(fake as any, SAMPLE, 'rest-1', 'reveltesta', 'est-1', { skipUnifiedSalesSync: true });
+    await processOrder(fake, SAMPLE, 'rest-1', 'reveltesta', 'est-1', { skipUnifiedSalesSync: true });
     expect(fake._calls.rpc).toHaveLength(0);
   });
 });

--- a/tests/unit/revelOrderProcessor.test.ts
+++ b/tests/unit/revelOrderProcessor.test.ts
@@ -118,6 +118,24 @@ describe('normalizeOrder', () => {
     const n = normalizeOrder(SAMPLE);
     expect(n.soldAt).toBe('2026-07-19T12:32:16.000Z');
   });
+
+  // Regression (Copilot review, PR #631): parseDateTime's naive-match regex
+  // used to require seconds; a seconds-less naive created_date fell through
+  // to deriving orderTime/orderDate from soldAt's UTC digits, contradicting
+  // this function's contract that orderTime is always local wall-clock digits.
+  it('treats a seconds-less naive created_date as local wall-clock time (orderTime/orderDate stay in local space, not UTC)', () => {
+    const noSecondsOrder = {
+      Order: { ...SAMPLE.Order, created_date: '2026-07-19T07:32' },
+      OrderItems: SAMPLE.OrderItems,
+      Payments: SAMPLE.Payments,
+    };
+    const n = normalizeOrder(noSecondsOrder, 'America/Chicago');
+    expect(n.soldAt).toBe('2026-07-19T12:32:00.000Z');
+    // Local wall-clock digits (07:32:00), not the UTC digits (12:32:00) that
+    // the pre-fix fallback path would have produced.
+    expect(n.orderTime).toBe('07:32:00');
+    expect(n.orderDate).toBe('2026-07-19');
+  });
 });
 
 describe('processOrder', () => {

--- a/tests/unit/toastOrderProcessor.test.ts
+++ b/tests/unit/toastOrderProcessor.test.ts
@@ -119,8 +119,10 @@ describe('processOrder (Toast) — unaffected by the Revel tz fix', () => {
     const modulePath = resolve(__dirname, '../../supabase/functions/_shared/toastOrderProcessor.ts');
     const source = readFileSync(modulePath, 'utf8');
     // Matches both an absolute `_shared/timezone` import and a sibling-relative
-    // `./timezone` import (the form an actual same-directory import would take).
-    expect(source).not.toMatch(/from\s+['"](?:\.\/|.*\/_shared\/)timezone['"]/);
+    // `./timezone` import (the form an actual same-directory import would take),
+    // with or without the Deno-style explicit `.ts` extension (e.g.
+    // `from './timezone.ts'` / `from '../_shared/timezone.ts'`).
+    expect(source).not.toMatch(/from\s+['"](?:\.\/|.*\/_shared\/)timezone(?:\.ts)?['"]/);
     expect(source).not.toMatch(/zonedNaiveToUtc|resolveRestaurantTimeZone|safeTz|tzOffsetMs/);
   });
 });

--- a/tests/unit/toastOrderProcessor.test.ts
+++ b/tests/unit/toastOrderProcessor.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { processOrder } from '../../supabase/functions/_shared/toastOrderProcessor';
+
+// Regression guard for the Revel sold_at timezone fix (see
+// docs/superpowers/specs/2026-07-21-revel-timezone-sold-at-design.md, §3
+// "Already correct (must NOT regress)"): unlike Revel, Toast's `closedDate`
+// carries an explicit UTC offset (e.g. '+0000'), so `new Date(closedDate)`
+// already yields a correct absolute instant. The Revel fix must not touch
+// this path or the shared `_shared/timezone.ts` helpers it doesn't use.
+const SAMPLE = {
+  guid: 'toast-order-1',
+  displayNumber: 'A-1001',
+  paymentStatus: 'PAID',
+  diningOption: { behavior: 'DINE_IN' },
+  // Real Toast timestamps include an explicit offset, unlike Revel's naive local strings.
+  closedDate: '2026-07-19T12:32:16.071+0000',
+  totalAmount: 24.0,
+  taxAmount: 2.0,
+  tipAmount: 3.0,
+  discountAmount: 1.0,
+  checks: [
+    {
+      selections: [
+        { guid: 'item-1', displayName: 'Burger', quantity: 1, price: 20.0, voided: false, salesCategory: 'Entrees' },
+      ],
+      payments: [
+        { guid: 'pay-1', type: 'CREDIT', amount: 24.0, tipAmount: 3.0, paymentStatus: 'CAPTURED' },
+      ],
+    },
+  ],
+};
+
+function makeFakeSupabase() {
+  const calls: Record<string, any[]> = { orders: [], items: [], payments: [], rpc: [] };
+  const fake = {
+    from: (name: string) => ({
+      upsert: async (row: any, _opts?: any) => {
+        if (name === 'toast_orders') calls.orders.push(row);
+        if (name === 'toast_order_items') calls.items.push(row);
+        if (name === 'toast_payments') calls.payments.push(row);
+        return { data: null, error: null };
+      },
+    }),
+    rpc: async (fn: string, args: any) => {
+      calls.rpc.push({ fn, args });
+      return { data: null, error: null };
+    },
+    _calls: calls,
+  };
+  return fake;
+}
+
+describe('processOrder (Toast) — unaffected by the Revel tz fix', () => {
+  it('derives order_date/order_time from the offset-carrying closedDate as a correct absolute instant', async () => {
+    const fake = makeFakeSupabase();
+    await processOrder(fake as any, SAMPLE, 'rest-1', 'toast-restaurant-guid', { skipUnifiedSalesSync: true });
+
+    expect(fake._calls.orders).toHaveLength(1);
+    const upserted = fake._calls.orders[0];
+    // closedDate '...T12:32:16.071+0000' is an unambiguous instant regardless of the
+    // edge runtime's local tz (unlike Revel's naive local created_date).
+    expect(upserted.order_date).toBe('2026-07-19');
+    expect(upserted.order_time).toBe('12:32:16');
+  });
+
+  it('preserves the raw closedDate verbatim in raw_json — this is what sync_toast_to_unified_sales (SQL) parses into sold_at', async () => {
+    const fake = makeFakeSupabase();
+    await processOrder(fake as any, SAMPLE, 'rest-1', 'toast-restaurant-guid', { skipUnifiedSalesSync: true });
+
+    const upserted = fake._calls.orders[0];
+    expect(upserted.raw_json.closedDate).toBe('2026-07-19T12:32:16.071+0000');
+  });
+
+  it('produces the same order_date/order_time across DST boundaries (winter closedDate offset), proving no naive-local reinterpretation was introduced', async () => {
+    const fake = makeFakeSupabase();
+    const winterOrder = { ...SAMPLE, closedDate: '2026-01-15T13:32:16.071+0000' };
+    await processOrder(fake as any, winterOrder, 'rest-1', 'toast-restaurant-guid', { skipUnifiedSalesSync: true });
+
+    const upserted = fake._calls.orders[0];
+    // Toast's offset is carried on the wire, not derived from an establishment tz lookup,
+    // so winter vs. summer closedDate values round-trip identically — no DST-aware
+    // conversion (like Revel's zonedNaiveToUtc) is or should be involved here.
+    expect(upserted.order_date).toBe('2026-01-15');
+    expect(upserted.order_time).toBe('13:32:16');
+  });
+
+  it('does not import the shared Revel timezone helpers (_shared/timezone.ts) — no shared read-path coupling was introduced', () => {
+    const modulePath = resolve(__dirname, '../../supabase/functions/_shared/toastOrderProcessor.ts');
+    const source = readFileSync(modulePath, 'utf8');
+    expect(source).not.toMatch(/_shared\/timezone/);
+    expect(source).not.toMatch(/zonedNaiveToUtc|resolveRestaurantTimeZone|safeTz/);
+  });
+});

--- a/tests/unit/toastOrderProcessor.test.ts
+++ b/tests/unit/toastOrderProcessor.test.ts
@@ -14,8 +14,13 @@ const SAMPLE = {
   displayNumber: 'A-1001',
   paymentStatus: 'PAID',
   diningOption: { behavior: 'DINE_IN' },
-  // Real Toast timestamps include an explicit offset, unlike Revel's naive local strings.
-  closedDate: '2026-07-19T12:32:16.071+0000',
+  // Real Toast timestamps include an explicit non-zero offset (e.g. CDT -05:00),
+  // unlike Revel's naive local strings. A +0000 fixture would pass even if the
+  // wire offset were silently discarded and the digits treated as naive UTC —
+  // this fixture is only discriminating with a non-zero offset: wall-clock
+  // 07:32:16-05:00 is a *different* instant (12:32:16Z) than a naive read of
+  // the same digits (07:32:16Z) would produce.
+  closedDate: '2026-07-19T07:32:16.071-05:00',
   totalAmount: 24.0,
   taxAmount: 2.0,
   tipAmount: 3.0,
@@ -32,18 +37,36 @@ const SAMPLE = {
   ],
 };
 
+// Row shape read back by the assertions below. processOrder's own `supabase`
+// param is typed `any` in the production module (no exported client type to
+// pin against), so this narrows only the fields the tests actually read —
+// deliberately more specific than `any` so a shape/rename drift on those
+// fields fails to compile rather than silently reading `undefined`.
+interface ToastUpsertRow extends Record<string, unknown> {
+  order_date?: string;
+  order_time?: string;
+  raw_json?: { closedDate?: string };
+}
+
+interface FakeSupabaseCalls {
+  orders: ToastUpsertRow[];
+  items: ToastUpsertRow[];
+  payments: ToastUpsertRow[];
+  rpc: { fn: string; args: Record<string, unknown> }[];
+}
+
 function makeFakeSupabase() {
-  const calls: Record<string, any[]> = { orders: [], items: [], payments: [], rpc: [] };
+  const calls: FakeSupabaseCalls = { orders: [], items: [], payments: [], rpc: [] };
   const fake = {
     from: (name: string) => ({
-      upsert: async (row: any, _opts?: any) => {
+      upsert: async (row: ToastUpsertRow, _opts?: Record<string, unknown>) => {
         if (name === 'toast_orders') calls.orders.push(row);
         if (name === 'toast_order_items') calls.items.push(row);
         if (name === 'toast_payments') calls.payments.push(row);
         return { data: null, error: null };
       },
     }),
-    rpc: async (fn: string, args: any) => {
+    rpc: async (fn: string, args: Record<string, unknown>) => {
       calls.rpc.push({ fn, args });
       return { data: null, error: null };
     },
@@ -55,33 +78,39 @@ function makeFakeSupabase() {
 describe('processOrder (Toast) — unaffected by the Revel tz fix', () => {
   it('derives order_date/order_time from the offset-carrying closedDate as a correct absolute instant', async () => {
     const fake = makeFakeSupabase();
-    await processOrder(fake as any, SAMPLE, 'rest-1', 'toast-restaurant-guid', { skipUnifiedSalesSync: true });
+    await processOrder(fake, SAMPLE, 'rest-1', 'toast-restaurant-guid', { skipUnifiedSalesSync: true });
 
     expect(fake._calls.orders).toHaveLength(1);
     const upserted = fake._calls.orders[0];
-    // closedDate '...T12:32:16.071+0000' is an unambiguous instant regardless of the
-    // edge runtime's local tz (unlike Revel's naive local created_date).
+    // closedDate '...T07:32:16.071-05:00' is an unambiguous instant (12:32:16Z)
+    // regardless of the edge runtime's local tz (unlike Revel's naive local
+    // created_date) — and, being non-zero, is discriminating against a
+    // regression that silently drops the wire offset.
     expect(upserted.order_date).toBe('2026-07-19');
     expect(upserted.order_time).toBe('12:32:16');
   });
 
   it('preserves the raw closedDate verbatim in raw_json — this is what sync_toast_to_unified_sales (SQL) parses into sold_at', async () => {
     const fake = makeFakeSupabase();
-    await processOrder(fake as any, SAMPLE, 'rest-1', 'toast-restaurant-guid', { skipUnifiedSalesSync: true });
+    await processOrder(fake, SAMPLE, 'rest-1', 'toast-restaurant-guid', { skipUnifiedSalesSync: true });
 
     const upserted = fake._calls.orders[0];
-    expect(upserted.raw_json.closedDate).toBe('2026-07-19T12:32:16.071+0000');
+    expect(upserted.raw_json?.closedDate).toBe('2026-07-19T07:32:16.071-05:00');
   });
 
-  it('produces the same order_date/order_time across DST boundaries (winter closedDate offset), proving no naive-local reinterpretation was introduced', async () => {
+  it('produces correctly-converted, distinct order_date/order_time across DST boundaries (winter closedDate offset), proving no naive-local reinterpretation was introduced', async () => {
     const fake = makeFakeSupabase();
-    const winterOrder = { ...SAMPLE, closedDate: '2026-01-15T13:32:16.071+0000' };
-    await processOrder(fake as any, winterOrder, 'rest-1', 'toast-restaurant-guid', { skipUnifiedSalesSync: true });
+    // Winter Toast wire offset (CST, -06:00) — also non-zero and distinct from
+    // the summer (-05:00) fixture above, so this isn't just re-testing +0000.
+    const winterOrder = { ...SAMPLE, closedDate: '2026-01-15T07:32:16.071-06:00' };
+    await processOrder(fake, winterOrder, 'rest-1', 'toast-restaurant-guid', { skipUnifiedSalesSync: true });
 
     const upserted = fake._calls.orders[0];
-    // Toast's offset is carried on the wire, not derived from an establishment tz lookup,
-    // so winter vs. summer closedDate values round-trip identically — no DST-aware
-    // conversion (like Revel's zonedNaiveToUtc) is or should be involved here.
+    // Toast's offset is carried on the wire, not derived from an establishment tz lookup:
+    // -06:00 correctly converts 07:32:16 local to 13:32:16Z, matching the summer fixture's
+    // UTC hour (12:32:16Z) landing on a different wall-clock hour — proving the offset (not
+    // a fixed/host-local assumption) drives the conversion. No DST-aware local-time
+    // reinterpretation (like Revel's zonedNaiveToUtc) is or should be involved here.
     expect(upserted.order_date).toBe('2026-01-15');
     expect(upserted.order_time).toBe('13:32:16');
   });
@@ -89,7 +118,9 @@ describe('processOrder (Toast) — unaffected by the Revel tz fix', () => {
   it('does not import the shared Revel timezone helpers (_shared/timezone.ts) — no shared read-path coupling was introduced', () => {
     const modulePath = resolve(__dirname, '../../supabase/functions/_shared/toastOrderProcessor.ts');
     const source = readFileSync(modulePath, 'utf8');
-    expect(source).not.toMatch(/_shared\/timezone/);
-    expect(source).not.toMatch(/zonedNaiveToUtc|resolveRestaurantTimeZone|safeTz/);
+    // Matches both an absolute `_shared/timezone` import and a sibling-relative
+    // `./timezone` import (the form an actual same-directory import would take).
+    expect(source).not.toMatch(/from\s+['"](?:\.\/|.*\/_shared\/)timezone['"]/);
+    expect(source).not.toMatch(/zonedNaiveToUtc|resolveRestaurantTimeZone|safeTz|tzOffsetMs/);
   });
 });


### PR DESCRIPTION
## Summary
- Revel sends **naive local wall-clock** timestamps (`created_date`, no offset), but `revelOrderProcessor.ts` was parsing them as UTC — corrupting `unified_sales.sold_at` by the restaurant's UTC offset (5-6h for `America/Chicago`), which skewed the labor view, hourly sales distribution, and `generate-schedule` hourly weighting.
- Added `zonedNaiveToUtc`/`safeTz`/`tzOffsetMs` timezone helpers (`supabase/functions/_shared/timezone.ts`) using a two-pass DST-safe offset probe (`formatToParts`), and made `parseDateTime` in `revelOrderProcessor.ts` timezone-aware.
- Added `resolveRestaurantTimeZone` and wired it into `revel-webhook`, `revel-sync-data`, and `revel-bulk-sync` — each resolves `restaurants.timezone` once per run (fallback `America/Chicago` with a warn-log) and threads it into `processOrder`.
- Backfill migration (`20260721150000_revel_sold_at_timezone_backfill.sql`): per-restaurant worker recomputes `revel_orders.sold_at` and `unified_sales.sold_at` from `raw_json`, validated against `pg_timezone_names`, with `unified_sales` trigger suppression + a single batched re-aggregation per touched `(restaurant_id, sale_date)`.
- Self-heal migration (`20260721160000_revel_rpc_sold_at_self_heal.sql`): `revel_sync_financial_breakdown`/`sync_revel_to_unified_sales` now `DO UPDATE SET sold_at = COALESCE(EXCLUDED.sold_at, unified_sales.sold_at)` on conflict (mirrors Toast's existing self-heal pattern), with trigger suppression + batched re-aggregation so recurring cron syncs don't re-aggregate every already-synced row.
- Toast's read path is untouched (it already stores a correct offset-carrying instant); a regression test (`tests/unit/toastOrderProcessor.test.ts`) statically confirms no coupling to the new Revel timezone helpers.
- No manual caching added; auditor path (`sale_date`-keyed totals) is unaffected — the fix reconciles `unified_sales.sold_at` to it, not the other way around.

## Test plan
- `npm run test` — 544 files / 6901 tests passed (unit, incl. new `edgeTimezone.test.ts`, expanded `revelOrderProcessor.test.ts`, new `toastOrderProcessor.test.ts` regression guard).
- `npm run test:db` — 1837/1837 pgTAP assertions passed (`revel_sold_at_backfill.sql` 23/23 incl. DST-transition + reconciliation query mirroring the design's acceptance criteria; `revel_integration.sql` 11/11 incl. RPC self-heal + trigger-suppression consistency).
- `npm run typecheck` — clean.
- `npm run lint` — no new violations (pre-existing repo-wide `@typescript-eslint/no-explicit-any` baseline unchanged for touched files).
- `npm run build` — clean production build.
- `npm run test:e2e` — 126/167 passed; 9 failures all in unrelated specs (employee-activation, payroll, permissions, tips), reproduced as pre-existing local-Supabase auth-signup flakiness under parallel workers (0/9 reproduce in isolation with `--workers=1`).
- Adversarial review: Codex found and we fixed a DST spring-forward edge case (`zonedNaiveToUtc` offset probe) plus a security gap (missing RPC grants on the backfill worker), a trigger-suppression gap in the self-heal RPCs, and a performance regression in the backfill's re-aggregation scope. CodeRabbit review folded (malformed-calendar-date rejection, test typing).
- Post-deploy manual checks (documented in the plan): Labor view no longer shows overnight staffing/sales for restaurants with corrupted history; daily `sum(total_price)` reconciles to Revel's own Sales Summary; hourly distribution matches Revel's Hourly Sales report; `generate-schedule` no longer clusters overnight.

**Design doc:** [`docs/superpowers/specs/2026-07-21-revel-timezone-sold-at-design.md`](https://github.com/toyiyo/nimble-pnl/blob/fix/revel-sold-at-timezone/docs/superpowers/specs/2026-07-21-revel-timezone-sold-at-design.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Revel order timestamps to respect each restaurant’s local timezone and daylight-saving rules.
  * Repaired affected sales records and daily totals through a safe historical data backfill.
  * Improved synchronization so corrected timestamps are preserved without overwriting sales categorization.
  * Added fallback handling for missing or invalid timezone settings.

* **Tests**
  * Added coverage for timezone conversions, daylight-saving transitions, backfills, repeat syncs, and Toast timestamp behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->