### PR TITLE
fix(db): P0 — disable statement_timeout for Revel sold_at backfill (unblocks deploy)

### DIFF
--- a/supabase/migrations/20260721150000_revel_sold_at_timezone_backfill.sql
+++ b/supabase/migrations/20260721150000_revel_sold_at_timezone_backfill.sql
@@ -288,7 +288,18 @@ GRANT EXECUTE ON FUNCTION public.revel_backfill_invalid_tz_restaurants() TO serv
 --    Bounded per-restaurant DO loop (not one unbounded UPDATE), per design
 --    §5b risk mitigation. Emits a pre/post pending-row report plus an
 --    invalid/null-tz offender report via RAISE NOTICE/WARNING.
+--
+--    A DO block is a SINGLE statement, so the whole historical backfill runs
+--    under one statement_timeout. On the first prod deploy (1345+ orders across
+--    all restaurants + per-date re-aggregation) that exceeded the default
+--    timeout and the migration was cancelled (SQLSTATE 57014) and rolled back —
+--    halting the entire migration pipeline. Disable the per-statement timeout
+--    for this one-time data backfill (standard pattern for heavy data
+--    migrations), then restore it. sold_at is not an input to any daily
+--    aggregate, so this only affects intra-day hour attribution, not totals.
 -- ============================================================
+
+SET statement_timeout = 0;
 
 DO $$
 DECLARE
@@ -334,3 +345,6 @@ BEGIN
       v_offender.restaurant_id, v_offender.restaurant_name, v_offender.timezone;
   END LOOP;
 END $$;
+
+-- Restore the default per-statement timeout for any migrations that follow.
+RESET statement_timeout;


### PR DESCRIPTION
## P0 — migration pipeline is halted
The deploy of #631 fails applying `20260721150000_revel_sold_at_timezone_backfill.sql`:
```
NOTICE: revel sold_at backfill: 1345 revel_orders rows need correction (pre-flight)
ERROR: canceling statement due to statement timeout (SQLSTATE 57014)
At statement: 18  (the driver DO block)
```
A `DO` block is a **single statement**, so the whole historical backfill (1345 orders across all restaurants + per-date re-aggregation) runs under one `statement_timeout` and gets cancelled. The migration runs in a transaction, so it **fully rolled back** — it never recorded in `schema_migrations` on prod, so **every subsequent deploy re-runs and re-fails**, halting all DB migrations.

## Fix
`SET statement_timeout = 0;` around the driver `DO` block (standard pattern for heavy one-time data migrations), `RESET` afterward. Must amend this migration file directly — a later migration can't help because prod applies in filename order and dies here first (this file never recorded on prod, so amending it is safe; it applies fresh).

- No logic/test changes. Backfill is idempotent (`IS DISTINCT FROM` guards) → applies once on prod, no-op thereafter.
- `sold_at` is **not** an input to any daily aggregate, so this only corrects intra-day hour attribution (Labor/SPLH). **Auditor-facing daily/period totals are unaffected.**

## Test plan
- `npx supabase db reset` → migration applies cleanly (backfill driver runs, 0 local rows).
- pgTAP `revel_sold_at_backfill` 26/26, `revel_integration` 11/11.

## Follow-up (not this PR)
The per-row `revel_valid_tz`→`pg_timezone_names` validation and the (redundant, since sold_at ⊥ daily) re-aggregation make the backfill slower than necessary; a follow-up can optimize to shrink the deploy lock-hold window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)