### PR TITLE
fix(scheduling): un-stick metrics ribbon so it stops hiding the tabs

### DIFF
--- a/src/components/scheduling/ScheduleMetricsRibbon.tsx
+++ b/src/components/scheduling/ScheduleMetricsRibbon.tsx
@@ -47,8 +47,6 @@ function MetricPill({ icon: Icon, value, unit, tone = 'text-foreground', childre
   );
 }
 
-// Sticky offset couples to AppHeader (h-14 / 56px, sticky top-0 z-50 in
-// src/components/AppHeader.tsx). If the header height changes, update top-14.
 export function ScheduleMetricsRibbon({
   activeEmployeeCount,
   totalScheduledHours,
@@ -155,7 +153,7 @@ export function ScheduleMetricsRibbon({
                 <TooltipTrigger asChild>
                   <button
                     type="button"
-                    className="inline-flex pointer-events-auto"
+                    className="inline-flex"
                     aria-label={warningLabel}
                   >
                     <AlertTriangle
@@ -182,13 +180,11 @@ export function ScheduleMetricsRibbon({
   }
 
   return (
-    // `pointer-events-none` on the sticky wrapper is deliberate: because the
-    // ribbon pins over content that scrolls beneath it (the tabs/toolbar sit
-    // directly below), an opaque sticky box would otherwise intercept clicks
-    // meant for those elements once they scroll under it. We re-enable
-    // `pointer-events-auto` on the ribbon's own interactive controls only, so
-    // clicks pass through the ribbon's empty area to whatever is behind it.
-    <div className="sticky top-14 z-30 -mx-4 px-4 bg-background border-b border-border/40 pointer-events-none">
+    // Intentionally NOT sticky: the tabs/toolbar sit directly below this ribbon,
+    // so a sticky ribbon pinned to the top covered them (and their nav links)
+    // as soon as the page scrolled. Keeping the ribbon in normal flow means it
+    // scrolls away with the rest of the header and never hides the tabs.
+    <div className="-mx-4 px-4 bg-background border-b border-border/40">
       <div className="flex flex-wrap items-center gap-x-4 gap-y-2 py-2.5">
         {/* Title group — folds the old hero header in, keeps the page's <h1> */}
         <div className="flex items-center gap-2.5 min-w-0">
@@ -218,7 +214,7 @@ export function ScheduleMetricsRibbon({
           onClick={() => setDetailsOpen((open) => !open)}
           aria-expanded={detailsExpanded}
           aria-controls="ribbon-details"
-          className="ml-auto h-8 px-2.5 text-[13px] font-medium text-muted-foreground hover:text-foreground transition-colors pointer-events-auto"
+          className="ml-auto h-8 px-2.5 text-[13px] font-medium text-muted-foreground hover:text-foreground transition-colors"
         >
           {detailsExpanded ? 'Hide' : 'Details'}
           {detailsExpanded ? <ChevronUp className="h-4 w-4 ml-1" /> : <ChevronDown className="h-4 w-4 ml-1" />}
@@ -227,7 +223,7 @@ export function ScheduleMetricsRibbon({
 
       {/* Collapsible detail — `group` enables LaborCostBreakdown's hover-to-edit */}
       {detailsExpanded && (
-        <div id="ribbon-details" className="group grid gap-3 pb-4 pt-1 sm:grid-cols-2 pointer-events-auto">
+        <div id="ribbon-details" className="group grid gap-3 pb-4 pt-1 sm:grid-cols-2">
           <div className="rounded-xl border border-border/40 bg-muted/30 p-3 space-y-2">
             {breakdownRows.map((row) => (
               <div key={row.key} className="flex items-center justify-between text-xs">

--- a/tests/unit/ScheduleMetricsRibbon.test.tsx
+++ b/tests/unit/ScheduleMetricsRibbon.test.tsx
@@ -123,6 +123,14 @@ describe('ScheduleMetricsRibbon', () => {
   // opaque box intercepts clicks meant for those tabs (Playwright reported
   // "subtree intercepts pointer events"). The interactive Details button must
   // re-enable pointer events so it stays clickable.
+  // Regression guard (production hotfix): the ribbon must NOT be sticky. A sticky
+  // ribbon pins to the top and covers the tabs/toolbar that sit directly below it
+  // once the page scrolls, hiding the Planner/other-area nav links.
+  it('is not sticky, so it cannot cover the tabs below it', () => {
+    const { container } = renderRibbon();
+    expect(container.querySelector('.sticky')).toBeNull();
+  });
+
   // Regression (Copilot, PR #630): the toggle label/chevron, aria-expanded, and
   // the panel must all agree. If loading/error begins while Details was open
   // (e.g. a restaurant switch), the button must fall back to the collapsed look.
@@ -149,11 +157,4 @@ describe('ScheduleMetricsRibbon', () => {
     expect(screen.queryByText('Top Earners')).not.toBeInTheDocument();
   });
 
-  it('keeps the sticky wrapper click-through while its controls stay interactive', () => {
-    renderRibbon();
-    const wrapper = screen.getByRole('heading', { level: 1, name: /staff schedule/i })
-      .closest('.sticky');
-    expect(wrapper).toHaveClass('pointer-events-none');
-    expect(screen.getByRole('button', { name: /details/i })).toHaveClass('pointer-events-auto');
-  });
 });


### PR DESCRIPTION
## Problem (production)
The sticky metrics ribbon (#630) pins to the top of the scheduling page. Because the tab bar (Schedule / Time-Off / Availability / Shift Trades / **Planner**) sits directly below it, any scroll pushed the tabs *under* the opaque ribbon — hiding and blocking the nav links. Reported on production.

## Fix (quick, low-risk)
Remove the sticky positioning from the ribbon so it scrolls in normal flow and can never cover the tabs. Also removes the `pointer-events-none/auto` workaround that only existed to let clicks pass through the sticky overlay, and the now-stale sticky-offset comment.

The primary win of the redesign is unchanged: the compact ribbon (vs. the old tall header + 3 cards) still keeps the schedule grid visible on load. We trade away "numbers stay pinned while scrolling" — the exact behavior causing the bug.

## Test plan
- Updated `ScheduleMetricsRibbon.test.tsx`: replaced the sticky/pointer-events assertions with a regression guard that the ribbon is **not** sticky (`container.querySelector('.sticky')` is null). 11/11 unit tests pass.
- `npm run typecheck`, `npm run lint` (0 errors), `npm run build` — all green locally.

## Follow-up
A proper "ribbon + tabs as one combined sticky header" (numbers *and* nav both stay visible while scrolling) is a nicer end state but a larger change — leaving it as a follow-up rather than in this hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)