### PR TITLE
fix(banking): re-key bank balances to connected_bank_id (reconnect duplicate + reauth loop)

### DIFF
--- a/supabase/functions/stripe-financial-connections-webhook/index.ts
+++ b/supabase/functions/stripe-financial-connections-webhook/index.ts
@@ -204,7 +204,12 @@ serve(async (req) => {
             is_active: true,
             as_of_date: new Date().toISOString(),
           }, {
-            onConflict: "stripe_financial_account_id",
+            // Key on connected_bank_id, the 1:1 identity of the account.
+            // Stripe rotates fca_ ids on reconnect, so keying on
+            // stripe_financial_account_id would INSERT a duplicate row for the
+            // new id and orphan the old one (incident 2026-07-24). Keying on
+            // connected_bank_id rotates the fca_ in place instead.
+            onConflict: "connected_bank_id",
             ignoreDuplicates: false, // Update existing record
           });
 

--- a/supabase/functions/stripe-financial-connections-webhook/index.ts
+++ b/supabase/functions/stripe-financial-connections-webhook/index.ts
@@ -190,27 +190,25 @@ serve(async (req) => {
         const availableBalance = balanceData?.available?.usd;
         const hasBalanceData = currentBalance !== undefined || availableBalance !== undefined;
 
+        // Identity-safe Stripe balance upsert via RPC. The balance identity is
+        // the partial unique index (one Stripe row per bank); Stripe rotates
+        // fca_ ids on reconnect, so a plain upsert keyed on the fca_ INSERTED a
+        // duplicate row and orphaned the old one (incident 2026-07-24). The RPC
+        // rotates the fca_ in place on the single existing Stripe row instead.
+        // PostgREST cannot express the partial index's WHERE predicate, so this
+        // must be an RPC rather than a REST upsert.
         const { error: balanceError } = await supabaseClient
-          .from("bank_account_balances")
-          .upsert({
-            connected_bank_id: bankData.id,
-            stripe_financial_account_id: account.id,
-            account_name: account.display_name || account.institution_name,
-            account_type: account.subcategory,
-            account_mask: account.last4,
-            current_balance: currentBalance ? currentBalance / 100 : 0,
-            available_balance: availableBalance ? availableBalance / 100 : null,
-            currency: "USD",
-            is_active: true,
-            as_of_date: new Date().toISOString(),
-          }, {
-            // Key on connected_bank_id, the 1:1 identity of the account.
-            // Stripe rotates fca_ ids on reconnect, so keying on
-            // stripe_financial_account_id would INSERT a duplicate row for the
-            // new id and orphan the old one (incident 2026-07-24). Keying on
-            // connected_bank_id rotates the fca_ in place instead.
-            onConflict: "connected_bank_id",
-            ignoreDuplicates: false, // Update existing record
+          .rpc("upsert_stripe_bank_balance", {
+            p_connected_bank_id: bankData.id,
+            p_stripe_financial_account_id: account.id,
+            p_account_name: account.display_name || account.institution_name,
+            p_account_type: account.subcategory,
+            p_account_mask: account.last4,
+            p_current_balance: currentBalance ? currentBalance / 100 : 0,
+            p_available_balance: availableBalance ? availableBalance / 100 : null,
+            p_currency: "USD",
+            p_is_active: true,
+            p_as_of_date: new Date().toISOString(),
           });
 
         if (balanceError) {

--- a/supabase/functions/stripe-refresh-balance/index.ts
+++ b/supabase/functions/stripe-refresh-balance/index.ts
@@ -103,22 +103,14 @@ serve(async (req) => {
       apiVersion: "2025-08-27.basil" as any
     });
 
-    // Get all Stripe account IDs for this bank connection from balances table
-    const { data: balanceRecords } = await supabaseAdmin
-      .from("bank_account_balances")
-      .select("stripe_financial_account_id, account_name")
-      .eq("connected_bank_id", bankId)
-      .not("stripe_financial_account_id", "is", null);
-
-    // Extract unique account IDs
-    const accountIds = [...new Set(
-      balanceRecords?.map(b => b.stripe_financial_account_id).filter(Boolean) || []
-    )];
-
-    // If no account IDs found in balances, fall back to primary one from connected_banks
-    if (accountIds.length === 0 && bank.stripe_financial_account_id) {
-      accountIds.push(bank.stripe_financial_account_id);
-    }
+    // Enumerate the account to refresh from connected_banks' CURRENT fca_ —
+    // the single source of truth for which Stripe account is live. Deriving
+    // this from bank_account_balances instead used to pick up a stale old-fca_
+    // row left by a reconnect (incident 2026-07-24). A connected_banks row is
+    // 1:1 with a real account, so there is exactly one live account id here.
+    const accountIds = bank.stripe_financial_account_id
+      ? [bank.stripe_financial_account_id]
+      : [];
 
     console.log(`[REFRESH-BALANCE] Found ${accountIds.length} account(s) to refresh:`, accountIds);
 
@@ -186,7 +178,10 @@ serve(async (req) => {
             connected_bank_id: bankId,
             ...balanceData
           }, {
-            onConflict: 'stripe_financial_account_id'
+            // 1:1 identity is connected_bank_id; Stripe rotates fca_ ids on
+            // reconnect. Keying on the fca_ would orphan the pre-reconnect
+            // balance row (incident 2026-07-24).
+            onConflict: 'connected_bank_id'
           });
 
         if (upsertError) {

--- a/supabase/functions/stripe-refresh-balance/index.ts
+++ b/supabase/functions/stripe-refresh-balance/index.ts
@@ -171,17 +171,23 @@ serve(async (req) => {
           stripe_financial_account_id: accountId,
         };
 
-        // Update balance record for this specific account
+        // Update balance record for this specific account via the identity-safe
+        // RPC. One Stripe row per bank; Stripe rotates fca_ ids on reconnect, so
+        // a plain upsert keyed on the fca_ would orphan the pre-reconnect row
+        // (incident 2026-07-24). The RPC rotates the fca_ in place. as_of_date
+        // is omitted when Stripe gave no balance.as_of (null => keep persisted).
         const { error: upsertError } = await supabaseAdmin
-          .from("bank_account_balances")
-          .upsert({
-            connected_bank_id: bankId,
-            ...balanceData
-          }, {
-            // 1:1 identity is connected_bank_id; Stripe rotates fca_ ids on
-            // reconnect. Keying on the fca_ would orphan the pre-reconnect
-            // balance row (incident 2026-07-24).
-            onConflict: 'connected_bank_id'
+          .rpc("upsert_stripe_bank_balance", {
+            p_connected_bank_id: bankId,
+            p_stripe_financial_account_id: accountId,
+            p_account_name: balanceData.account_name,
+            p_account_type: balanceData.account_type,
+            p_account_mask: balanceData.account_mask,
+            p_current_balance: balanceData.current_balance,
+            p_available_balance: balanceData.available_balance,
+            p_currency: balanceData.currency,
+            p_is_active: balanceData.is_active,
+            p_as_of_date: asOfDate ?? null,
           });
 
         if (upsertError) {

--- a/supabase/functions/stripe-sync-transactions/index.ts
+++ b/supabase/functions/stripe-sync-transactions/index.ts
@@ -107,22 +107,16 @@ serve(async (req) => {
       apiVersion: "2025-08-27.basil" as any
     });
 
-    // Get all Stripe account IDs for this bank connection from balances table
-    const { data: balanceRecords } = await supabaseAdmin
-      .from("bank_account_balances")
-      .select("stripe_financial_account_id, account_name")
-      .eq("connected_bank_id", bankId)
-      .not("stripe_financial_account_id", "is", null);
-
-    // Extract unique account IDs
-    const accountIds = [...new Set(
-      balanceRecords?.map(b => b.stripe_financial_account_id).filter(Boolean) || []
-    )];
-
-    // If no account IDs found in balances, fall back to primary one from connected_banks
-    if (accountIds.length === 0 && bank.stripe_financial_account_id) {
-      accountIds.push(bank.stripe_financial_account_id);
-    }
+    // Enumerate the account to sync from connected_banks' CURRENT fca_ — the
+    // single source of truth for which Stripe account is live. Deriving this
+    // from bank_account_balances instead used to pick up a stale old-fca_ row
+    // left by a reconnect, retrieve that dead account, see it inactive, and
+    // re-flag the whole bank requires_reauth seconds after the user finished
+    // reconnecting (incident 2026-07-24). A connected_banks row is 1:1 with a
+    // real account, so there is exactly one live account id here.
+    const accountIds = bank.stripe_financial_account_id
+      ? [bank.stripe_financial_account_id]
+      : [];
 
     console.log(`[SYNC-TRANSACTIONS] Found ${accountIds.length} account(s) to sync:`, accountIds);
 

--- a/supabase/functions/stripe-verify-connection-session/index.ts
+++ b/supabase/functions/stripe-verify-connection-session/index.ts
@@ -133,6 +133,11 @@ serve(async (req) => {
               status: 'connected',
               connected_at: new Date().toISOString(),
               disconnected_at: null,
+              // Clear the reauth escalation clock: a completed reconnect makes
+              // this account live again. Omitting this left deactivated_at set
+              // after reconnect, which the sync path then preserved via
+              // COALESCE and kept the bank stuck requires_reauth (2026-07-24).
+              deactivated_at: null,
               sync_error: null,
               institution_name: account.institution_name,
               institution_logo_url: institutionLogoUrl,
@@ -188,7 +193,10 @@ serve(async (req) => {
               as_of_date: new Date(account.balance.as_of * 1000).toISOString(),
               is_active: true,
             }, {
-              onConflict: 'stripe_financial_account_id',
+              // 1:1 identity is connected_bank_id; Stripe rotates fca_ ids on
+              // reconnect. Keying on the fca_ would orphan the pre-reconnect
+              // balance row (incident 2026-07-24).
+              onConflict: 'connected_bank_id',
             });
 
           if (balanceError) {

--- a/supabase/functions/stripe-verify-connection-session/index.ts
+++ b/supabase/functions/stripe-verify-connection-session/index.ts
@@ -108,95 +108,62 @@ serve(async (req) => {
             ? `https://financialconnections.stripe.com/v1/institution/${account.institution_name.toLowerCase().replace(/\s+/g, '-')}/logo`
             : null);
 
-        // Check if this account already exists (reconnection case)
-        const { data: existingBank, error: checkError } = await supabaseAdmin
-          .from('connected_banks')
-          .select('id, status')
-          .eq('restaurant_id', restaurantId)
-          .eq('stripe_financial_account_id', account.id)
-          .maybeSingle();
+        // Identity-safe reconnect matching (design §4.2), identical to the
+        // account.created webhook path: relink the connected_banks row matching
+        // (restaurant, institution, account_mask) if one exists in a
+        // reconnectable state, else insert a new row — conflict-aware for
+        // double-submitted Link flows. This converges on the same row and
+        // clears deactivated_at regardless of whether this function or the
+        // webhook runs first. The previous lookup here keyed on
+        // stripe_financial_account_id = account.id, but Stripe ROTATES the fca_
+        // on reconnect, so it missed the pre-reconnect row, fell through to an
+        // INSERT, and left the old row's deactivated_at set — keeping the bank
+        // stuck requires_reauth after a completed reconnect (incident 2026-07-24).
+        const { data: reconnectData, error: reconnectError } = await supabaseAdmin
+          .rpc('reconnect_connected_bank', {
+            p_restaurant_id: restaurantId,
+            p_stripe_financial_account_id: account.id,
+            p_institution_name: account.institution_name,
+            p_institution_logo_url: institutionLogoUrl,
+            p_account_mask: account.last4 ?? null,
+          })
+          .single();
 
-        if (checkError && checkError.code !== 'PGRST116') { // PGRST116 = no rows returned
-          console.error(`[VERIFY-SESSION] Error checking existing bank:`, checkError);
-          throw checkError;
+        if (reconnectError || !reconnectData) {
+          console.error(`[VERIFY-SESSION] Error reconnecting bank:`, reconnectError);
+          throw reconnectError ?? new Error('reconnect_connected_bank returned no row');
         }
 
-        let bankId: string;
+        const reconnectRow = reconnectData as { id: string; created_at: string; connected_at: string };
+        const bankId: string = reconnectRow.id;
+        // Best-effort telemetry flag for the response only (not used for logic):
+        // a fresh insert stamps created_at == connected_at, a relink keeps the
+        // original (older) created_at while connected_at is now().
+        const isReconnection =
+          new Date(reconnectRow.connected_at).getTime() -
+            new Date(reconnectRow.created_at).getTime() > 2000;
+        console.log(`[VERIFY-SESSION] ${isReconnection ? 'Reconnected' : 'Connected'} bank ${bankId}`);
 
-        if (existingBank) {
-          // Reconnection - update existing record
-          console.log(`[VERIFY-SESSION] Reconnecting existing bank: ${existingBank.id}`);
-          
-          const { error: updateError } = await supabaseAdmin
-            .from('connected_banks')
-            .update({
-              status: 'connected',
-              connected_at: new Date().toISOString(),
-              disconnected_at: null,
-              // Clear the reauth escalation clock: a completed reconnect makes
-              // this account live again. Omitting this left deactivated_at set
-              // after reconnect, which the sync path then preserved via
-              // COALESCE and kept the bank stuck requires_reauth (2026-07-24).
-              deactivated_at: null,
-              sync_error: null,
-              institution_name: account.institution_name,
-              institution_logo_url: institutionLogoUrl,
-            })
-            .eq('id', existingBank.id);
-
-          if (updateError) {
-            console.error(`[VERIFY-SESSION] Error updating bank:`, updateError);
-            throw updateError;
-          }
-
-          bankId = existingBank.id;
-        } else {
-          // New connection - create new record
-          console.log(`[VERIFY-SESSION] Creating new bank connection`);
-          
-          const { data: newBank, error: insertError } = await supabaseAdmin
-            .from('connected_banks')
-            .insert({
-              restaurant_id: restaurantId,
-              stripe_financial_account_id: account.id,
-              institution_name: account.institution_name,
-              institution_logo_url: institutionLogoUrl,
-              status: 'connected',
-              connected_at: new Date().toISOString(),
-            })
-            .select('id')
-            .single();
-
-          if (insertError) {
-            console.error(`[VERIFY-SESSION] Error creating bank:`, insertError);
-            throw insertError;
-          }
-
-          bankId = newBank.id;
-        }
-
-        // Store balance information if available
+        // Store balance information if available, via the identity-safe RPC.
+        // One Stripe balance row per bank (partial unique index); the RPC rotates
+        // the fca_ in place on reconnect instead of inserting a duplicate
+        // (incident 2026-07-24). PostgREST cannot express the partial index's
+        // WHERE predicate, so this must be an RPC rather than a REST upsert.
         if (account.balance) {
           console.log(`[VERIFY-SESSION] Storing balance for bank ${bankId}`);
-          
+
           const { error: balanceError } = await supabaseAdmin
-            .from('bank_account_balances')
-            .upsert({
-              connected_bank_id: bankId,
-              stripe_financial_account_id: account.id,
-              account_name: account.display_name,
-              account_type: account.subcategory || account.category,
-              account_mask: account.last4,
-              current_balance: account.balance.current?.[Object.keys(account.balance.current)[0]] || 0,
-              available_balance: account.balance.cash?.available?.[Object.keys(account.balance.cash.available)[0]] || null,
-              currency: Object.keys(account.balance.current || {})[0]?.toUpperCase() || 'USD',
-              as_of_date: new Date(account.balance.as_of * 1000).toISOString(),
-              is_active: true,
-            }, {
-              // 1:1 identity is connected_bank_id; Stripe rotates fca_ ids on
-              // reconnect. Keying on the fca_ would orphan the pre-reconnect
-              // balance row (incident 2026-07-24).
-              onConflict: 'connected_bank_id',
+            .rpc('upsert_stripe_bank_balance', {
+              p_connected_bank_id: bankId,
+              p_stripe_financial_account_id: account.id,
+              p_account_name: account.display_name,
+              p_account_type: account.subcategory || account.category,
+              p_account_mask: account.last4,
+              p_current_balance: account.balance.current?.[Object.keys(account.balance.current)[0]] || 0,
+              p_available_balance: account.balance.cash?.available?.[Object.keys(account.balance.cash.available)[0]] ?? null,
+              p_currency: Object.keys(account.balance.current || {})[0]?.toUpperCase() || 'USD',
+              p_is_active: true,
+              p_as_of_date: new Date(account.balance.as_of * 1000).toISOString(),
             });
 
           if (balanceError) {
@@ -242,7 +209,7 @@ serve(async (req) => {
           accountId: account.id,
           displayName: account.display_name,
           status: 'success',
-          isReconnection: !!existingBank,
+          isReconnection,
         });
 
       } catch (accountError) {

--- a/supabase/migrations/20260724180200_bank_balances_rekey_connected_bank.sql
+++ b/supabase/migrations/20260724180200_bank_balances_rekey_connected_bank.sql
@@ -1,32 +1,44 @@
--- Bank re-authentication flow — balance-row identity fix.
+-- Bank re-authentication flow — Stripe balance-row identity fix.
 --
 -- ROOT CAUSE (production incident 2026-07-24, Huntington reconnect):
---   bank_account_balances' only unique key was stripe_financial_account_id
---   (bank_account_balances_stripe_account_unique). Stripe Financial
---   Connections mints a NEW fca_ id for every account on each reconnect, so
---   the fca-keyed upserts in stripe-financial-connections-webhook,
---   stripe-verify-connection-session, and stripe-refresh-balance MISS the
---   pre-reconnect row and INSERT a second one. The old-fca row is never
---   retired. Two real accounts became four balance rows ("4 accounts instead
---   of two"), and the orphaned old-fca row then made stripe-sync-transactions
---   retrieve a dead account, see it inactive, and re-flag the whole bank
---   requires_reauth seconds after the user finished reconnecting (the loop).
+--   The Stripe balance upserts in stripe-financial-connections-webhook,
+--   stripe-verify-connection-session, and stripe-refresh-balance keyed
+--   ON CONFLICT on stripe_financial_account_id. Stripe Financial Connections
+--   mints a NEW fca_ id for every account on each reconnect, so the upsert of
+--   the reconnected account did not match the pre-reconnect row (old fca_) and
+--   INSERTED a second row instead. Two real accounts became four balance rows
+--   ("4 accounts instead of two"), the dashboard summed all four, and the
+--   orphaned old-fca_ row then made stripe-sync-transactions retrieve a dead
+--   account, see it inactive, and re-flag the whole bank requires_reauth
+--   seconds after the user finished reconnecting (the reauth loop).
 --
--- The real identity of a balance row is its connected_banks row: the
--- invariant is 1 connected_banks row <-> 1 account <-> 1 balance row (verified
--- 1:1 across every institution in production). fca_ is a MUTABLE attribute of
--- that row, not its key. This migration makes the schema say so.
+-- INVARIANT (corrected): bank_account_balances is NOT one-row-per-bank. It also
+-- holds non-Stripe rows: CSV/statement-import balances and the historical
+-- reconciliation snapshots that useReconcileTransactions APPENDS
+-- (stripe_financial_account_id IS NULL). The true invariant is narrower:
+--   at most ONE Stripe-origin balance row (fca_ NOT NULL) per connected bank.
+-- fca_ is a mutable attribute of that single Stripe row, not its key; the key
+-- is connected_bank_id, scoped to Stripe-origin rows. This migration makes the
+-- schema enforce exactly that, and nothing wider — non-Stripe snapshot rows are
+-- left completely alone.
+--
+-- The pre-existing UNIQUE(stripe_financial_account_id) constraint is KEPT: each
+-- Stripe account id still maps to one row, it permits multiple NULLs (so
+-- snapshots coexist), and the reconnect duplicate never violated it (the
+-- duplicate carried a new, distinct fca_). It is orthogonal to this fix.
 --
 -- Idempotent: guarded so a re-run (or a partially-applied deploy) is a no-op.
 
 -- ============================================================
--- Step 1 — retire duplicate balance rows created by fca-keyed upserts.
--- For each connected_bank_id keep exactly one row: prefer the one whose fca
--- matches the connected bank's CURRENT fca (the live account after reconnect);
--- otherwise keep the freshest by as_of_date, then created_at, then id. This
--- must run before the unique index below or its creation would fail.
--- Measured on production 2026-07-24: deletes exactly 2 rows (the Huntington
--- orphans), touches 0 current-fca rows.
+-- Step 1 — retire duplicate STRIPE-origin balance rows created by the
+-- fca-keyed upserts. Scope strictly to stripe_financial_account_id IS NOT NULL
+-- so CSV/statement/reconciliation snapshot rows (fca_ NULL) are NEVER touched.
+-- For each connected_bank_id keep exactly one Stripe row: prefer the one whose
+-- fca_ matches the connected bank's CURRENT fca_ (the live account after
+-- reconnect); otherwise keep the freshest by as_of_date, then created_at, then
+-- id. Must run before the partial unique index below or its creation would
+-- fail. Measured on production 2026-07-24: deletes exactly 2 rows (the
+-- Huntington orphans), touches 0 current-fca rows and 0 snapshot rows.
 -- ============================================================
 
 WITH ranked AS (
@@ -41,6 +53,7 @@ WITH ranked AS (
          ) AS rn
     FROM public.bank_account_balances bab
     JOIN public.connected_banks cb ON cb.id = bab.connected_bank_id
+   WHERE bab.stripe_financial_account_id IS NOT NULL   -- Stripe-origin rows only
 )
 DELETE FROM public.bank_account_balances b
  USING ranked r
@@ -48,24 +61,33 @@ DELETE FROM public.bank_account_balances b
    AND r.rn > 1;
 
 -- ============================================================
--- Step 2 — swap the identity key.
--- Drop the fca uniqueness (fca is now a mutable attribute). It is a UNIQUE
--- CONSTRAINT (not a bare index), so DROP CONSTRAINT is required — DROP INDEX
--- is rejected while the constraint depends on it. Keep a plain, non-unique
--- index on stripe_financial_account_id for lookups (created defensively in
--- case dropping the constraint removed the only index on the column). Then add
--- uniqueness on connected_bank_id, the true 1:1 key; connected_bank_id is
--- NOT NULL, so this fully enforces one balance row per connected bank.
+-- Step 2 — add the identity key as a PARTIAL unique index.
+-- Uniqueness applies only to Stripe-origin rows (stripe_financial_account_id
+-- IS NOT NULL), so a reconnect can never spawn a second Stripe row for a bank,
+-- while reconciliation/CSV/manual snapshot rows (fca_ NULL) remain unconstrained
+-- and may coexist freely. PostgREST's upsert on_conflict cannot attach the WHERE
+-- predicate a partial index needs, so the Stripe balance writes go through the
+-- upsert_stripe_bank_balance() SECURITY DEFINER RPC (next migration), whose
+-- ON CONFLICT clause repeats this predicate verbatim — the same pattern
+-- connected_banks_identity_uniq / reconnect_connected_bank already use.
+--
+-- Plain (non-unique) index idx_bank_account_balances_stripe_account and the
+-- UNIQUE(stripe_financial_account_id) constraint both already exist from
+-- 20251019221101 and are intentionally left in place.
+--
+-- Note on locking: a plain CREATE UNIQUE INDEX briefly blocks writes to this
+-- table during the build. bank_account_balances is tiny (~1 row per account,
+-- low-tens of rows in production) and its writers are infrequent bank webhooks,
+-- so the window is sub-millisecond; CONCURRENTLY is intentionally not used here
+-- because it cannot run inside the migration's transaction and the table's
+-- scale makes it unnecessary. If a duplicate raced in between Step 1 and this
+-- build, the unique build fails and the whole migration rolls back (fails
+-- closed) rather than committing a bad state.
 -- ============================================================
 
-ALTER TABLE public.bank_account_balances
-  DROP CONSTRAINT IF EXISTS bank_account_balances_stripe_account_unique;
+CREATE UNIQUE INDEX IF NOT EXISTS bank_account_balances_stripe_bank_uniq
+    ON public.bank_account_balances (connected_bank_id)
+    WHERE stripe_financial_account_id IS NOT NULL;
 
-CREATE INDEX IF NOT EXISTS idx_bank_account_balances_stripe_account
-    ON public.bank_account_balances (stripe_financial_account_id);
-
-CREATE UNIQUE INDEX IF NOT EXISTS bank_account_balances_connected_bank_uniq
-    ON public.bank_account_balances (connected_bank_id);
-
-COMMENT ON INDEX public.bank_account_balances_connected_bank_uniq IS
-  'One balance row per connected bank (1:1 invariant). Reconnect upserts key on connected_bank_id and rotate stripe_financial_account_id in place, so a new fca_ can never spawn a duplicate row. Incident: 2026-07-24 Huntington reconnect.';
+COMMENT ON INDEX public.bank_account_balances_stripe_bank_uniq IS
+  'At most one Stripe-origin balance row (fca_ NOT NULL) per connected bank (design invariant). Reconnect upserts go through upsert_stripe_bank_balance() and rotate stripe_financial_account_id in place, so a new fca_ can never spawn a duplicate Stripe row. Partial so reconciliation/CSV snapshot rows (fca_ NULL) coexist freely. Incident: 2026-07-24 Huntington reconnect.';

--- a/supabase/migrations/20260724180200_bank_balances_rekey_connected_bank.sql
+++ b/supabase/migrations/20260724180200_bank_balances_rekey_connected_bank.sql
@@ -1,0 +1,71 @@
+-- Bank re-authentication flow — balance-row identity fix.
+--
+-- ROOT CAUSE (production incident 2026-07-24, Huntington reconnect):
+--   bank_account_balances' only unique key was stripe_financial_account_id
+--   (bank_account_balances_stripe_account_unique). Stripe Financial
+--   Connections mints a NEW fca_ id for every account on each reconnect, so
+--   the fca-keyed upserts in stripe-financial-connections-webhook,
+--   stripe-verify-connection-session, and stripe-refresh-balance MISS the
+--   pre-reconnect row and INSERT a second one. The old-fca row is never
+--   retired. Two real accounts became four balance rows ("4 accounts instead
+--   of two"), and the orphaned old-fca row then made stripe-sync-transactions
+--   retrieve a dead account, see it inactive, and re-flag the whole bank
+--   requires_reauth seconds after the user finished reconnecting (the loop).
+--
+-- The real identity of a balance row is its connected_banks row: the
+-- invariant is 1 connected_banks row <-> 1 account <-> 1 balance row (verified
+-- 1:1 across every institution in production). fca_ is a MUTABLE attribute of
+-- that row, not its key. This migration makes the schema say so.
+--
+-- Idempotent: guarded so a re-run (or a partially-applied deploy) is a no-op.
+
+-- ============================================================
+-- Step 1 — retire duplicate balance rows created by fca-keyed upserts.
+-- For each connected_bank_id keep exactly one row: prefer the one whose fca
+-- matches the connected bank's CURRENT fca (the live account after reconnect);
+-- otherwise keep the freshest by as_of_date, then created_at, then id. This
+-- must run before the unique index below or its creation would fail.
+-- Measured on production 2026-07-24: deletes exactly 2 rows (the Huntington
+-- orphans), touches 0 current-fca rows.
+-- ============================================================
+
+WITH ranked AS (
+  SELECT bab.id,
+         row_number() OVER (
+           PARTITION BY bab.connected_bank_id
+           ORDER BY (bab.stripe_financial_account_id
+                       IS NOT DISTINCT FROM cb.stripe_financial_account_id) DESC,
+                    bab.as_of_date  DESC NULLS LAST,
+                    bab.created_at  DESC NULLS LAST,
+                    bab.id          DESC
+         ) AS rn
+    FROM public.bank_account_balances bab
+    JOIN public.connected_banks cb ON cb.id = bab.connected_bank_id
+)
+DELETE FROM public.bank_account_balances b
+ USING ranked r
+ WHERE b.id = r.id
+   AND r.rn > 1;
+
+-- ============================================================
+-- Step 2 — swap the identity key.
+-- Drop the fca uniqueness (fca is now a mutable attribute). It is a UNIQUE
+-- CONSTRAINT (not a bare index), so DROP CONSTRAINT is required — DROP INDEX
+-- is rejected while the constraint depends on it. Keep a plain, non-unique
+-- index on stripe_financial_account_id for lookups (created defensively in
+-- case dropping the constraint removed the only index on the column). Then add
+-- uniqueness on connected_bank_id, the true 1:1 key; connected_bank_id is
+-- NOT NULL, so this fully enforces one balance row per connected bank.
+-- ============================================================
+
+ALTER TABLE public.bank_account_balances
+  DROP CONSTRAINT IF EXISTS bank_account_balances_stripe_account_unique;
+
+CREATE INDEX IF NOT EXISTS idx_bank_account_balances_stripe_account
+    ON public.bank_account_balances (stripe_financial_account_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS bank_account_balances_connected_bank_uniq
+    ON public.bank_account_balances (connected_bank_id);
+
+COMMENT ON INDEX public.bank_account_balances_connected_bank_uniq IS
+  'One balance row per connected bank (1:1 invariant). Reconnect upserts key on connected_bank_id and rotate stripe_financial_account_id in place, so a new fca_ can never spawn a duplicate row. Incident: 2026-07-24 Huntington reconnect.';

--- a/supabase/migrations/20260724180300_upsert_stripe_bank_balance.sql
+++ b/supabase/migrations/20260724180300_upsert_stripe_bank_balance.sql
@@ -1,0 +1,81 @@
+-- upsert_stripe_bank_balance — identity-safe Stripe balance upsert.
+--
+-- Exists for the same reason reconnect_connected_bank does: the balance
+-- identity key is the PARTIAL unique index bank_account_balances_stripe_bank_uniq
+-- (UNIQUE(connected_bank_id) WHERE stripe_financial_account_id IS NOT NULL), and
+-- PostgREST's upsert on_conflict parameter accepts only a column list — it
+-- cannot attach the index's WHERE predicate. Postgres will not infer a partial
+-- index as the ON CONFLICT arbiter unless the conflict clause repeats that
+-- predicate verbatim, which is only reachable from a database function, not a
+-- REST upsert. So all three Stripe balance writers (webhook, verify-session,
+-- refresh-balance) call this function instead of upserting on connected_bank_id.
+--
+-- Behaviour: insert a Stripe-origin balance row for the bank, or — if one
+-- already exists — rotate its stripe_financial_account_id to the new fca_ and
+-- refresh its fields in place. A reconnect therefore updates the single existing
+-- Stripe row rather than inserting a duplicate (incident 2026-07-24). Non-Stripe
+-- snapshot rows (fca_ NULL) are outside the partial index and never collide.
+--
+-- Caller: service role only (edge functions).
+
+CREATE OR REPLACE FUNCTION public.upsert_stripe_bank_balance(
+  p_connected_bank_id           uuid,
+  p_stripe_financial_account_id text,
+  p_account_name                text,
+  p_account_type                text,
+  p_account_mask                text,
+  p_current_balance             numeric,
+  p_available_balance           numeric,
+  p_currency                    text,
+  p_is_active                   boolean,
+  p_as_of_date                  timestamptz DEFAULT NULL
+)
+RETURNS public.bank_account_balances
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_row public.bank_account_balances;
+BEGIN
+  -- The partial unique index only covers rows with a non-null fca_; a null
+  -- here would silently bypass the identity guard and could append duplicates.
+  IF p_stripe_financial_account_id IS NULL THEN
+    RAISE EXCEPTION
+      'upsert_stripe_bank_balance requires a non-null stripe_financial_account_id';
+  END IF;
+
+  INSERT INTO public.bank_account_balances (
+    connected_bank_id, stripe_financial_account_id, account_name, account_type,
+    account_mask, current_balance, available_balance, currency, is_active, as_of_date
+  )
+  VALUES (
+    p_connected_bank_id, p_stripe_financial_account_id, p_account_name, p_account_type,
+    p_account_mask, p_current_balance, p_available_balance, p_currency, p_is_active, p_as_of_date
+  )
+  ON CONFLICT (connected_bank_id) WHERE stripe_financial_account_id IS NOT NULL
+  DO UPDATE SET
+    stripe_financial_account_id = EXCLUDED.stripe_financial_account_id,
+    account_name      = EXCLUDED.account_name,
+    account_type      = EXCLUDED.account_type,
+    account_mask      = EXCLUDED.account_mask,
+    current_balance   = EXCLUDED.current_balance,
+    available_balance = EXCLUDED.available_balance,
+    currency          = EXCLUDED.currency,
+    is_active         = EXCLUDED.is_active,
+    -- Never invent a date: only overwrite as_of_date when the caller supplied
+    -- one (they pass NULL when Stripe gave no balance.as_of), else keep the
+    -- persisted value.
+    as_of_date        = COALESCE(EXCLUDED.as_of_date, public.bank_account_balances.as_of_date)
+  RETURNING * INTO v_row;
+
+  RETURN v_row;
+END;
+$$;
+
+COMMENT ON FUNCTION public.upsert_stripe_bank_balance(uuid, text, text, text, text, numeric, numeric, text, boolean, timestamptz) IS
+  'Identity-safe Stripe balance upsert: inserts the single Stripe-origin balance row for a connected bank, or rotates its stripe_financial_account_id + refreshes fields in place on reconnect. Targets the partial unique index bank_account_balances_stripe_bank_uniq, whose WHERE predicate PostgREST cannot express. Caller: edge functions (service role only). Incident: 2026-07-24 Huntington reconnect.';
+
+REVOKE ALL ON FUNCTION public.upsert_stripe_bank_balance(uuid, text, text, text, text, numeric, numeric, text, boolean, timestamptz) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.upsert_stripe_bank_balance(uuid, text, text, text, text, numeric, numeric, text, boolean, timestamptz) FROM anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.upsert_stripe_bank_balance(uuid, text, text, text, text, numeric, numeric, text, boolean, timestamptz) TO service_role;

--- a/supabase/tests/bank_balances_identity.sql
+++ b/supabase/tests/bank_balances_identity.sql
@@ -1,26 +1,40 @@
--- pgTAP coverage for the bank_account_balances identity fix
--- (migration 20260724180200_bank_balances_rekey_connected_bank.sql).
+-- pgTAP coverage for the bank_account_balances Stripe-identity fix
+-- (migrations 20260724180200_bank_balances_rekey_connected_bank.sql and
+--  20260724180300_upsert_stripe_bank_balance.sql).
 --
--- ROOT CAUSE this migration fixes (production incident 2026-07-24):
---   bank_account_balances was unique on stripe_financial_account_id. Stripe
---   mints a NEW fca_ id per account on every reconnect, so the fca-keyed
---   upserts INSERTED a second row instead of updating the first. Two accounts
---   became four rows, and the orphaned old-fca row then re-flagged the bank
---   requires_reauth. The real key is connected_bank_id (1:1 with an account).
+-- ROOT CAUSE this fix addresses (production incident 2026-07-24, Huntington):
+--   The Stripe balance upserts keyed ON CONFLICT on stripe_financial_account_id.
+--   Stripe mints a NEW fca_ id per account on every reconnect, so the fca-keyed
+--   upsert of the reconnected account did not match the pre-reconnect row and
+--   INSERTED a second row. Two accounts became four rows; the orphaned old-fca_
+--   row then re-flagged the whole bank requires_reauth.
+--
+-- CORRECTED invariant: bank_account_balances is NOT one-row-per-bank. It also
+-- holds non-Stripe rows — CSV/statement-import balances and reconciliation
+-- snapshots that useReconcileTransactions APPENDS with a NULL fca_. The real
+-- invariant is narrower: at most ONE Stripe-origin row (fca_ NOT NULL) per
+-- connected bank. The schema enforces exactly that via a PARTIAL unique index,
+-- and nothing wider.
 --
 -- Covers:
---   1. The new UNIQUE index on connected_bank_id exists.
---   2. The old fca uniqueness is gone (fca is now a mutable attribute).
---   3. A second balance row for the same connected_bank_id raises 23505 —
---      the duplicate a reconnect used to create is now structurally impossible.
---   4. An upsert keyed on connected_bank_id ROTATES the fca in place across a
---      reconnect, leaving exactly one row (the fix the edge functions now use).
---   5. A plain (non-unique) index on stripe_financial_account_id survives for
---      lookups.
+--   1. The partial unique index bank_account_balances_stripe_bank_uniq exists.
+--   2. The pre-existing UNIQUE(stripe_financial_account_id) constraint is KEPT
+--      (orthogonal; permits multiple NULLs so snapshots coexist).
+--   3. The plain lookup index on stripe_financial_account_id survives.
+--   4. A first Stripe-origin balance row inserts cleanly.
+--   5. A second Stripe row for the same bank (new fca_) raises 23505 — the
+--      reconnect duplicate is now structurally impossible.
+--   6-7. NULL-fca_ snapshot rows for the same bank coexist freely, and more
+--      than one may exist (reconciliation history is preserved).
+--   8. Exactly one Stripe row coexists with the snapshots (partial scope).
+--   9-11. upsert_stripe_bank_balance() rotates the fca_ in place on reconnect,
+--      leaving one Stripe row (new fca_) and leaving snapshots untouched.
+--   12-13. The migration's Step-1 dedupe keeps the current-fca_ Stripe row,
+--      deletes the orphaned old-fca_ Stripe row, and preserves snapshots.
 
 BEGIN;
 
-SELECT plan(7);
+SELECT plan(13);
 
 SET LOCAL role TO postgres;
 
@@ -33,22 +47,23 @@ ALTER TABLE public.bank_account_balances DISABLE ROW LEVEL SECURITY;
 -- ============================================================
 
 SELECT has_index(
-  'public', 'bank_account_balances', 'bank_account_balances_connected_bank_uniq',
-  'bank_account_balances should have the connected_bank_id unique index (the 1:1 key)'
+  'public', 'bank_account_balances', 'bank_account_balances_stripe_bank_uniq',
+  'partial unique index on connected_bank_id (WHERE fca_ NOT NULL) exists — the Stripe-row identity key'
 );
 
-SELECT hasnt_index(
+SELECT has_index(
   'public', 'bank_account_balances', 'bank_account_balances_stripe_account_unique',
-  'the old fca uniqueness index should be dropped — fca is now a mutable attribute'
+  'the pre-existing UNIQUE(stripe_financial_account_id) constraint is kept (permits multiple NULLs, so snapshots coexist)'
 );
 
 SELECT has_index(
   'public', 'bank_account_balances', 'idx_bank_account_balances_stripe_account',
-  'a plain (non-unique) index on stripe_financial_account_id should survive for lookups'
+  'the plain lookup index on stripe_financial_account_id survives'
 );
 
 -- ============================================================
--- Behavioral coverage
+-- Fixture: one restaurant + one connected bank whose CURRENT fca_ is
+-- fca_bal_test_current (the live account after reconnect).
 -- ============================================================
 
 CREATE TEMP TABLE _ids AS
@@ -66,56 +81,161 @@ SELECT r_one, 'Balance Identity Test', '1 Test Way', '555-0100' FROM _ids;
 
 INSERT INTO public.connected_banks
   (restaurant_id, stripe_financial_account_id, institution_name, status, account_mask)
-SELECT r_one, 'fca_bal_test_new', 'Huntington', 'connected', '2589' FROM _ids;
+SELECT r_one, 'fca_bal_test_current', 'Huntington', 'connected', '2589' FROM _ids;
 
 CREATE TEMP TABLE _bank AS
 SELECT id AS bank_id FROM public.connected_banks
  WHERE restaurant_id = (SELECT r_one FROM _ids) AND account_mask = '2589';
 
--- First balance row inserts cleanly.
+-- ============================================================
+-- Partial-index enforcement + snapshot coexistence
+-- ============================================================
+
+-- First Stripe-origin balance row (starts on the old fca_, pre-reconnect).
 SELECT lives_ok(
   $$
     INSERT INTO public.bank_account_balances
       (connected_bank_id, account_name, stripe_financial_account_id, current_balance)
     SELECT bank_id, 'Huntington Business Checking 100', 'fca_bal_test_old', 48679.81 FROM _bank
   $$,
-  'first balance row for a connected bank inserts cleanly'
+  'first Stripe-origin balance row for a connected bank inserts cleanly'
 );
 
--- A second row for the SAME connected_bank_id with a DIFFERENT fca — exactly
--- the duplicate the pre-fix reconnect created — must now violate the unique
--- index.
+-- A second Stripe row for the SAME bank with a DIFFERENT fca_ — exactly the
+-- duplicate the pre-fix reconnect created — must violate the partial index.
 SELECT throws_ok(
   $$
     INSERT INTO public.bank_account_balances
       (connected_bank_id, account_name, stripe_financial_account_id, current_balance)
-    SELECT bank_id, 'Huntington Business Checking 100', 'fca_bal_test_new', 39218.59 FROM _bank
+    SELECT bank_id, 'Huntington Business Checking 100', 'fca_bal_test_dup', 39218.59 FROM _bank
   $$,
   '23505',
   NULL,
-  'a second balance row for the same connected bank (new fca_) raises unique_violation — the reconnect duplicate is now impossible'
+  'a second Stripe row for the same bank (new fca_) raises unique_violation — the reconnect duplicate is now impossible'
 );
 
--- The fix the edge functions use: upsert keyed on connected_bank_id rotates
--- the fca in place instead of inserting. One row survives, tracking the new
--- fca and the fresh balance.
+-- A NULL-fca_ snapshot row (reconciliation/CSV import) for the SAME bank is
+-- outside the partial index and coexists.
 SELECT lives_ok(
   $$
     INSERT INTO public.bank_account_balances
       (connected_bank_id, account_name, stripe_financial_account_id, current_balance)
-    SELECT bank_id, 'Huntington Business Checking 100', 'fca_bal_test_new', 39218.59 FROM _bank
-    ON CONFLICT (connected_bank_id) DO UPDATE
-      SET stripe_financial_account_id = EXCLUDED.stripe_financial_account_id,
-          current_balance = EXCLUDED.current_balance
+    SELECT bank_id, 'Reconcile snapshot', NULL, 100.00 FROM _bank
   $$,
-  'a reconnect upsert keyed on connected_bank_id rotates the fca in place (no 23505)'
+  'a NULL-fca_ snapshot row for the same bank coexists (partial index does not cover it)'
+);
+
+-- A SECOND NULL-fca_ snapshot must also be allowed — reconciliation appends
+-- history and must never collide.
+SELECT lives_ok(
+  $$
+    INSERT INTO public.bank_account_balances
+      (connected_bank_id, account_name, stripe_financial_account_id, current_balance)
+    SELECT bank_id, 'Reconcile snapshot 2', NULL, 200.00 FROM _bank
+  $$,
+  'a second NULL-fca_ snapshot for the same bank is allowed (reconciliation history preserved)'
+);
+
+-- Exactly one Stripe row coexists with the two snapshots.
+SELECT is(
+  (SELECT count(*)::int FROM public.bank_account_balances b
+     JOIN _bank ON b.connected_bank_id = _bank.bank_id
+    WHERE b.stripe_financial_account_id IS NOT NULL),
+  1,
+  'exactly one Stripe-origin row exists for the bank while two NULL-fca_ snapshots coexist'
+);
+
+-- ============================================================
+-- Forward guarantee: the RPC the edge functions call rotates the fca_ in place
+-- ============================================================
+
+SELECT lives_ok(
+  $$
+    SELECT public.upsert_stripe_bank_balance(
+      (SELECT bank_id FROM _bank),
+      'fca_bal_test_new', 'Huntington Business Checking 100', 'checking', '2589',
+      39218.59, NULL, 'USD', true, now()
+    )
+  $$,
+  'upsert_stripe_bank_balance rotates the fca_ in place on reconnect (no 23505)'
+);
+
+SELECT is(
+  (SELECT stripe_financial_account_id FROM public.bank_account_balances b
+     JOIN _bank ON b.connected_bank_id = _bank.bank_id
+    WHERE b.stripe_financial_account_id IS NOT NULL),
+  'fca_bal_test_new',
+  'after the RPC exactly one Stripe row remains and it carries the new fca_ (rotated in place)'
+);
+
+SELECT is(
+  (SELECT count(*)::int FROM public.bank_account_balances b
+     JOIN _bank ON b.connected_bank_id = _bank.bank_id
+    WHERE b.stripe_financial_account_id IS NULL),
+  2,
+  'the RPC left both NULL-fca_ snapshot rows untouched'
+);
+
+-- ============================================================
+-- Step-1 dedupe: reproduce the pre-fix duplicate scenario and run the exact
+-- ranked-CTE DELETE from the migration. The partial index blocks building the
+-- duplicate, so drop it inside this (rolled-back) transaction first.
+-- ============================================================
+
+DROP INDEX public.bank_account_balances_stripe_bank_uniq;
+
+-- Bank currently has one Stripe row (fca_bal_test_new) + 2 snapshots. Add the
+-- orphaned OLD-fca_ Stripe row a reconnect would have left behind. Stamp the
+-- current-fca_ row as OLDER so the dedupe cannot win it on recency alone —
+-- it must win on the "matches connected_banks.stripe_financial_account_id"
+-- tiebreak. First point the bank's current fca_ at fca_bal_test_new.
+UPDATE public.connected_banks
+   SET stripe_financial_account_id = 'fca_bal_test_new'
+ WHERE id = (SELECT bank_id FROM _bank);
+
+UPDATE public.bank_account_balances
+   SET as_of_date = '2026-01-01', created_at = '2026-01-01'
+ WHERE connected_bank_id = (SELECT bank_id FROM _bank)
+   AND stripe_financial_account_id = 'fca_bal_test_new';
+
+INSERT INTO public.bank_account_balances
+  (connected_bank_id, account_name, stripe_financial_account_id, current_balance, as_of_date, created_at)
+SELECT bank_id, 'Huntington Business Checking 100', 'fca_bal_test_orphan', 0.00, '2026-07-01', '2026-07-01'
+  FROM _bank;
+
+-- Exact Step-1 query from the migration.
+WITH ranked AS (
+  SELECT bab.id,
+         row_number() OVER (
+           PARTITION BY bab.connected_bank_id
+           ORDER BY (bab.stripe_financial_account_id
+                       IS NOT DISTINCT FROM cb.stripe_financial_account_id) DESC,
+                    bab.as_of_date  DESC NULLS LAST,
+                    bab.created_at  DESC NULLS LAST,
+                    bab.id          DESC
+         ) AS rn
+    FROM public.bank_account_balances bab
+    JOIN public.connected_banks cb ON cb.id = bab.connected_bank_id
+   WHERE bab.stripe_financial_account_id IS NOT NULL
+)
+DELETE FROM public.bank_account_balances b
+ USING ranked r
+ WHERE b.id = r.id
+   AND r.rn > 1;
+
+SELECT is(
+  (SELECT stripe_financial_account_id FROM public.bank_account_balances b
+     JOIN _bank ON b.connected_bank_id = _bank.bank_id
+    WHERE b.stripe_financial_account_id IS NOT NULL),
+  'fca_bal_test_new',
+  'dedupe keeps the Stripe row whose fca_ matches connected_banks (current), even though the orphan is more recent'
 );
 
 SELECT is(
   (SELECT count(*)::int FROM public.bank_account_balances b
      JOIN _bank ON b.connected_bank_id = _bank.bank_id),
-  1,
-  'after the reconnect upsert exactly one balance row remains for the connected bank (1:1 restored)'
+  3,
+  'dedupe deletes only the orphaned old-fca_ Stripe row: one Stripe row + two snapshots survive'
 );
 
 -- Cleanup

--- a/supabase/tests/bank_balances_identity.sql
+++ b/supabase/tests/bank_balances_identity.sql
@@ -1,0 +1,128 @@
+-- pgTAP coverage for the bank_account_balances identity fix
+-- (migration 20260724180200_bank_balances_rekey_connected_bank.sql).
+--
+-- ROOT CAUSE this migration fixes (production incident 2026-07-24):
+--   bank_account_balances was unique on stripe_financial_account_id. Stripe
+--   mints a NEW fca_ id per account on every reconnect, so the fca-keyed
+--   upserts INSERTED a second row instead of updating the first. Two accounts
+--   became four rows, and the orphaned old-fca row then re-flagged the bank
+--   requires_reauth. The real key is connected_bank_id (1:1 with an account).
+--
+-- Covers:
+--   1. The new UNIQUE index on connected_bank_id exists.
+--   2. The old fca uniqueness is gone (fca is now a mutable attribute).
+--   3. A second balance row for the same connected_bank_id raises 23505 —
+--      the duplicate a reconnect used to create is now structurally impossible.
+--   4. An upsert keyed on connected_bank_id ROTATES the fca in place across a
+--      reconnect, leaving exactly one row (the fix the edge functions now use).
+--   5. A plain (non-unique) index on stripe_financial_account_id survives for
+--      lookups.
+
+BEGIN;
+
+SELECT plan(7);
+
+SET LOCAL role TO postgres;
+
+ALTER TABLE public.restaurants DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.connected_banks DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.bank_account_balances DISABLE ROW LEVEL SECURITY;
+
+-- ============================================================
+-- Index shape
+-- ============================================================
+
+SELECT has_index(
+  'public', 'bank_account_balances', 'bank_account_balances_connected_bank_uniq',
+  'bank_account_balances should have the connected_bank_id unique index (the 1:1 key)'
+);
+
+SELECT hasnt_index(
+  'public', 'bank_account_balances', 'bank_account_balances_stripe_account_unique',
+  'the old fca uniqueness index should be dropped — fca is now a mutable attribute'
+);
+
+SELECT has_index(
+  'public', 'bank_account_balances', 'idx_bank_account_balances_stripe_account',
+  'a plain (non-unique) index on stripe_financial_account_id should survive for lookups'
+);
+
+-- ============================================================
+-- Behavioral coverage
+-- ============================================================
+
+CREATE TEMP TABLE _ids AS
+SELECT '00000000-0000-0000-0000-0000b0000001'::uuid AS r_one;
+
+DELETE FROM public.bank_account_balances
+ WHERE connected_bank_id IN (
+   SELECT id FROM public.connected_banks WHERE restaurant_id = (SELECT r_one FROM _ids)
+ );
+DELETE FROM public.connected_banks WHERE restaurant_id = (SELECT r_one FROM _ids);
+DELETE FROM public.restaurants WHERE id = (SELECT r_one FROM _ids);
+
+INSERT INTO public.restaurants (id, name, address, phone)
+SELECT r_one, 'Balance Identity Test', '1 Test Way', '555-0100' FROM _ids;
+
+INSERT INTO public.connected_banks
+  (restaurant_id, stripe_financial_account_id, institution_name, status, account_mask)
+SELECT r_one, 'fca_bal_test_new', 'Huntington', 'connected', '2589' FROM _ids;
+
+CREATE TEMP TABLE _bank AS
+SELECT id AS bank_id FROM public.connected_banks
+ WHERE restaurant_id = (SELECT r_one FROM _ids) AND account_mask = '2589';
+
+-- First balance row inserts cleanly.
+SELECT lives_ok(
+  $$
+    INSERT INTO public.bank_account_balances
+      (connected_bank_id, account_name, stripe_financial_account_id, current_balance)
+    SELECT bank_id, 'Huntington Business Checking 100', 'fca_bal_test_old', 48679.81 FROM _bank
+  $$,
+  'first balance row for a connected bank inserts cleanly'
+);
+
+-- A second row for the SAME connected_bank_id with a DIFFERENT fca — exactly
+-- the duplicate the pre-fix reconnect created — must now violate the unique
+-- index.
+SELECT throws_ok(
+  $$
+    INSERT INTO public.bank_account_balances
+      (connected_bank_id, account_name, stripe_financial_account_id, current_balance)
+    SELECT bank_id, 'Huntington Business Checking 100', 'fca_bal_test_new', 39218.59 FROM _bank
+  $$,
+  '23505',
+  NULL,
+  'a second balance row for the same connected bank (new fca_) raises unique_violation — the reconnect duplicate is now impossible'
+);
+
+-- The fix the edge functions use: upsert keyed on connected_bank_id rotates
+-- the fca in place instead of inserting. One row survives, tracking the new
+-- fca and the fresh balance.
+SELECT lives_ok(
+  $$
+    INSERT INTO public.bank_account_balances
+      (connected_bank_id, account_name, stripe_financial_account_id, current_balance)
+    SELECT bank_id, 'Huntington Business Checking 100', 'fca_bal_test_new', 39218.59 FROM _bank
+    ON CONFLICT (connected_bank_id) DO UPDATE
+      SET stripe_financial_account_id = EXCLUDED.stripe_financial_account_id,
+          current_balance = EXCLUDED.current_balance
+  $$,
+  'a reconnect upsert keyed on connected_bank_id rotates the fca in place (no 23505)'
+);
+
+SELECT is(
+  (SELECT count(*)::int FROM public.bank_account_balances b
+     JOIN _bank ON b.connected_bank_id = _bank.bank_id),
+  1,
+  'after the reconnect upsert exactly one balance row remains for the connected bank (1:1 restored)'
+);
+
+-- Cleanup
+DELETE FROM public.bank_account_balances
+ WHERE connected_bank_id IN (SELECT bank_id FROM _bank);
+DELETE FROM public.connected_banks WHERE restaurant_id = (SELECT r_one FROM _ids);
+DELETE FROM public.restaurants WHERE id = (SELECT r_one FROM _ids);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Problem

After a Stripe Financial Connections **reconnect**, a restaurant with multiple accounts at one institution saw duplicate balance rows (e.g. 4 rows for 2 real accounts) and stayed stuck on **"Needs reauthorization"** even after completing the reconnect flow.

**Root cause:** Stripe mints a **new** `fca_` id for the same real account on every reconnect. The three Stripe balance writers upserted `ON CONFLICT (stripe_financial_account_id)`, so the reconnected account's new `fca_` didn't match the pre-reconnect row and **INSERTED a duplicate**. The orphaned old-`fca_` row then made `stripe-sync-transactions` retrieve a dead account, see it inactive, and re-flag the whole bank `requires_reauth` — the reauth loop.

## Why the first approach was wrong (review feedback)

The initial commit made `bank_account_balances` globally `UNIQUE(connected_bank_id)`. Review (Codex P1, CodeRabbit, Copilot) surfaced that the table is **not** one-row-per-bank: `useReconcileTransactions` **appends** reconciliation snapshots and CSV/statement imports write rows with a **NULL** `stripe_financial_account_id`. A global unique would `23505` those writers and could delete real snapshots during dedupe.

**Corrected invariant:** at most **one Stripe-origin row** (`fca_ NOT NULL`) per connected bank; `fca_` is a mutable attribute of that single row. Non-Stripe snapshot rows are left completely alone.

## Changes

- **`20260724180200`** — dedupe scoped strictly to Stripe rows (snapshots never touched); identity key is a **partial** unique index `bank_account_balances_stripe_bank_uniq (connected_bank_id) WHERE stripe_financial_account_id IS NOT NULL`. The pre-existing `UNIQUE(stripe_financial_account_id)` constraint is kept (orthogonal; permits multiple NULLs so snapshots coexist).
- **`20260724180300`** — new `SECURITY DEFINER` `upsert_stripe_bank_balance()` RPC. PostgREST can't attach a partial index's `WHERE` predicate to `on_conflict`, so all three Stripe balance writers call the RPC, which **rotates the `fca_` in place** on reconnect instead of inserting a duplicate.
- **webhook / refresh-balance / verify-session** — balance writes go through the RPC. `verify-session` also adopts `reconnect_connected_bank` (the same identity-safe RPC the webhook uses) instead of its `fca_`-keyed lookup, which missed on reconnect and left `deactivated_at` set — keeping the bank stuck `requires_reauth` after a completed reconnect.
- **pgTAP** — rewritten for the partial index, snapshot coexistence, RPC rotate-in-place, and snapshot-safe dedupe (13 assertions, all green locally).

## Verification

- `npx supabase db reset --local` — both migrations apply cleanly.
- pgTAP `bank_balances_identity.sql` — 13/13 pass, 0 failures.
- `npm run typecheck` — clean.

## Production repair (follow-up, gated on explicit confirmation)

Applying the migration auto-deletes the orphaned Stripe balance rows. The stuck `connected_banks` rows still need `requires_reauth → connected` with `deactivated_at`/`sync_error` cleared — this will be presented with exact row counts and affected tables for confirmation **after** deploy, not in this PR.