### PR TITLE
fix(test): seed one connected_bank per account in bank-filtering E2E

### DIFF
--- a/tests/e2e/bank-transaction-filtering.spec.ts
+++ b/tests/e2e/bank-transaction-filtering.spec.ts
@@ -36,10 +36,12 @@ test.describe('Bank Transaction Filtering', () => {
     const { bankAccountIds } = await page.evaluate(async ({ rid }) => {
       const { supabase } = await import('/src/integrations/supabase/client');
       
-      // Generate unique IDs to avoid constraint violations
+      // Generate unique IDs to avoid constraint violations. Use crypto.randomUUID
+      // (available in the page's secure context) rather than Math.random so these
+      // synthetic Stripe ids don't trip CodeQL's js/insecure-randomness rule.
       const timestamp = Date.now();
-      const random = Math.random().toString(36).slice(2, 8);
-      
+      const random = crypto.randomUUID().slice(0, 8);
+
       // Create two connected banks — one per account — at the same institution.
       // This mirrors production: the connect flow creates one connected_banks
       // row per Stripe account (reconnect_connected_bank is keyed on

--- a/tests/e2e/bank-transaction-filtering.spec.ts
+++ b/tests/e2e/bank-transaction-filtering.spec.ts
@@ -40,26 +40,48 @@ test.describe('Bank Transaction Filtering', () => {
       const timestamp = Date.now();
       const random = Math.random().toString(36).slice(2, 8);
       
-      // Create connected bank
-      const { data: connectedBank, error: bankError } = await supabase
+      // Create two connected banks — one per account — at the same institution.
+      // This mirrors production: the connect flow creates one connected_banks
+      // row per Stripe account (reconnect_connected_bank is keyed on
+      // account_mask), so checking and savings are distinct rows. A single bank
+      // cannot hold two Stripe balance rows — the partial unique index
+      // bank_account_balances_stripe_bank_uniq forbids it.
+      const { data: checkingBank, error: checkingBankError } = await supabase
         .from('connected_banks')
         .insert({
           restaurant_id: rid,
           institution_name: 'Test Bank',
-          stripe_financial_account_id: `fca_test_${timestamp}_${random}`,
+          stripe_financial_account_id: `fca_checking_${timestamp}_${random}`,
+          account_mask: '1234',
           status: 'connected',
         })
         .select()
         .single();
 
-      if (bankError) throw new Error(`Failed to create bank: ${bankError.message}`);
+      if (checkingBankError) throw new Error(`Failed to create checking bank: ${checkingBankError.message}`);
 
-      // Create two bank accounts with different Stripe account IDs
+      const { data: savingsBank, error: savingsBankError } = await supabase
+        .from('connected_banks')
+        .insert({
+          restaurant_id: rid,
+          institution_name: 'Test Bank',
+          stripe_financial_account_id: `fca_savings_${timestamp}_${random}`,
+          account_mask: '5678',
+          status: 'connected',
+        })
+        .select()
+        .single();
+
+      if (savingsBankError) throw new Error(`Failed to create savings bank: ${savingsBankError.message}`);
+
+      // One Stripe balance row per bank (the invariant). The balance row's
+      // stripe_financial_account_id is what the account filter matches against
+      // each transaction's raw_data.account.
       const { data: accounts, error: accountsError } = await supabase
         .from('bank_account_balances')
         .insert([
           {
-            connected_bank_id: connectedBank.id,
+            connected_bank_id: checkingBank.id,
             stripe_financial_account_id: `fa_checking_${timestamp}_${random}`,
             account_name: 'Checking Account',
             account_type: 'checking',
@@ -68,7 +90,7 @@ test.describe('Bank Transaction Filtering', () => {
             as_of_date: new Date().toISOString(),
           },
           {
-            connected_bank_id: connectedBank.id,
+            connected_bank_id: savingsBank.id,
             stripe_financial_account_id: `fa_savings_${timestamp}_${random}`,
             account_name: 'Savings Account',
             account_type: 'savings',
@@ -90,7 +112,7 @@ test.describe('Bank Transaction Filtering', () => {
         // Checking account transactions
         {
           restaurant_id: rid,
-          connected_bank_id: connectedBank.id,
+          connected_bank_id: checkingBank.id,
           stripe_transaction_id: `txn_checking_1_${Date.now()}`,
           transaction_date: new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000).toISOString(), // 2 days ago
           description: 'Checking - Grocery Store',
@@ -104,7 +126,7 @@ test.describe('Bank Transaction Filtering', () => {
         },
         {
           restaurant_id: rid,
-          connected_bank_id: connectedBank.id,
+          connected_bank_id: checkingBank.id,
           stripe_transaction_id: `txn_checking_2_${Date.now()}`,
           transaction_date: new Date(now.getTime() - 1 * 24 * 60 * 60 * 1000).toISOString(), // 1 day ago
           description: 'Checking - Restaurant Supply',
@@ -119,7 +141,7 @@ test.describe('Bank Transaction Filtering', () => {
         // Savings account transactions
         {
           restaurant_id: rid,
-          connected_bank_id: connectedBank.id,
+          connected_bank_id: savingsBank.id,
           stripe_transaction_id: `txn_savings_1_${Date.now()}`,
           transaction_date: new Date(now.getTime() - 3 * 24 * 60 * 60 * 1000).toISOString(), // 3 days ago
           description: 'Savings - Interest Payment',
@@ -133,7 +155,7 @@ test.describe('Bank Transaction Filtering', () => {
         },
         {
           restaurant_id: rid,
-          connected_bank_id: connectedBank.id,
+          connected_bank_id: savingsBank.id,
           stripe_transaction_id: `txn_savings_2_${Date.now()}`,
           transaction_date: new Date(now.getTime() - 4 * 24 * 60 * 60 * 1000).toISOString(), // 4 days ago
           description: 'Savings - Transfer In',


### PR DESCRIPTION
## Problem

`E2E Tests (Shard 1/4)` is failing on `main` after #653 merged:

```
Error: page.evaluate: Error: Failed to create accounts:
duplicate key value violates unique constraint "bank_account_balances_stripe_bank_uniq"
```

#653 added a **partial unique index** — at most one Stripe-origin balance row (`stripe_financial_account_id IS NOT NULL`) per `connected_bank`. The first test in `bank-transaction-filtering.spec.ts` seeded **two** `bank_account_balances` rows (checking + savings) under a **single** `connected_banks` row, which now violates that index at insert time. Deterministic failure, not flaky.

## Fix

Split the fixture to mirror production. The real connect flow creates **one `connected_banks` row per Stripe account** (`reconnect_connected_bank` is keyed on `restaurant_id + institution_name + account_mask`), so checking (••1234) and savings (••5678) are distinct banks, each with a single balance row.

The account filter resolves the selected balance row's `stripe_financial_account_id` and matches it against each transaction's `raw_data.account` — independent of `connected_bank` grouping — so the dropdown options and every assertion (4 total rows, filter to 2 checking / 2 savings by mask, institution label) are unchanged.

The other two tests in the file already seed one bank + one balance row and are untouched.

## Verification

- [x] `npm run typecheck` clean
- [x] Fixture change scoped to the first test only; no stale `connectedBank` references
- [ ] E2E Shard 1/4 green in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)