### PR TITLE
fix(receipt-import): sync barcode (gtin) between receipts and products

### DIFF
--- a/dev-tools/9d-triage-fix/receipt-import-barcode-sync.md
+++ b/dev-tools/9d-triage-fix/receipt-import-barcode-sync.md
@@ -1,0 +1,50 @@
+# Phase 9d — Review-comment triage — PR #657 (fix/receipt-import-barcode-sync)
+
+Base commit at start of this phase: `d02c68d5103aaf2468559b9a203e4279542ad464`
+
+## Sources checked (per instructions, all three, full contents)
+
+1. `gh api repos/toyiyo/nimble-pnl/pulls/657/comments --paginate` — inline review comments: **3 rows**
+2. `gh api repos/toyiyo/nimble-pnl/issues/657/comments --paginate` — PR conversation: **5 rows**, all bot status noise (netlify deploy-failed notice — already diagnosed in Phase 9b as a platform-wide Netlify outage unrelated to this PR's code; supabase[bot] "ignored, no changes in supabase/"; vercel[bot] ready; coderabbit walkthrough summary; sonarqubecloud quality-gate-passed summary). No actionable content beyond what's captured from the inline comments and the Sonar issue list below.
+3. `gh pr view 657 --json reviews` — **3 reviews**: Codex ("Codex Review" — see finding 1 below), Copilot ("Pull request overview" — see finding 2 below), CodeRabbit (1 actionable comment — see finding 3 below; 1 nitpick — see item 5 below).
+
+Also polled the 2 new SonarCloud issues flagged on the quality-gate-passed comment (`sonarcloud.io/api/issues/search?...pullRequest=657`) since the gate comment named them explicitly — findings 4 and 6 below.
+
+## Classified findings
+
+### 1. [BUG — FIXED] Codex (P1), `src/components/ReceiptMappingReview.tsx:286`
+**"Retain failed writes until import checks them."** The `pendingUpdatesRef` Set removed every settled promise (success *or* failure) via a bare `.finally()`. If a write failed and settled *before* the user clicked Import, its promise had already vanished from the set by click time — `Promise.allSettled(pendingUpdatesRef.current)` saw nothing, so `handleBulkImport` proceeded on the stale DB value the guard exists to prevent. Confirmed real by tracing `handleItemUpdate` / `handleBulkImport`.
+**Fix:** switched `pendingUpdatesRef` from `Set<Promise<unknown>>` to `Map<string, Promise<boolean>>` keyed by `itemId`. An entry is only deleted on a *successful* write (and only if no newer write for that item has since been queued, to avoid a slow stale write clobbering a newer one); a failed write's entry survives — already-settled — until overwritten by a later successful retry for the same item. `handleBulkImport` now does `Promise.allSettled(pendingUpdatesRef.current.values())`.
+Also extracted the state-update side effect into a standalone `applyLineItemUpdate` function (see finding 4 — this incidentally fixes the Sonar nesting-depth issue too).
+New regression test: `tests/unit/ReceiptMappingReview.pendingWrites.test.tsx` (renders the full component, fails a write via a mocked `updateLineItemMapping` resolving `false`, lets it settle, *then* clicks Import — asserts the "Unsaved changes" toast fires and `bulkImportLineItems` is never called).
+
+### 2. [BUG — FIXED] Copilot, `src/components/receipt/ReceiptItemRow.tsx:301`
+The SKU/Barcode blur-commit guard (`skuCommittedRef`) advanced optimistically at blur time regardless of whether the async write actually succeeded. If `updateLineItemMapping` returned `false`, `item.parsed_sku` (the source of truth) never advanced, but the ref did — so a plain re-blur of the same value (no retyping) would silently no-op forever, permanently blocking the retry Copilot's own comment traces through to a stuck bulk-import abort.
+**Fix (as Copilot suggested):** reset `skuCommittedRef.current = item.parsed_sku || ''` `onFocus`, so a focus+blur cycle re-baselines against the actual current prop rather than the last (possibly-failed) attempt. Verified this doesn't reintroduce the Phase 7b "untouched auto-filled field" bug — a focus+blur with no edit still resolves to the same value on both sides of the comparison.
+New regression test added to `tests/unit/ReceiptItemRow.skuBlur.test.tsx`: "re-commits on a focus + blur cycle when the prior commit never landed (retry after a failed write)".
+
+### 3. [MAJOR / QUICK WIN — FIXED] CodeRabbit, `src/hooks/useReceiptImport.tsx:660-711`
+**"Import completion toast doesn't reflect per-item write failures."** The two new restaurant_id-scoped `continue` paths this PR introduced (no row on scoped read; no row on scoped update) were only logged via `console.error`, never surfaced to the user — the closing toast always said "Successfully imported N items" regardless of skips, and this PR made the skip path meaningfully more likely to trigger (previously-unscoped reads/updates rarely failed this way).
+**Fix:** implemented CodeRabbit's suggested diff essentially as given — added a `skippedCount` counter incremented at the two new `continue` sites, and made the closing toast conditional: `"Partial Import"` / destructive variant with a skip count when `skippedCount > 0`, unchanged `"Success"` message otherwise.
+Updated two pre-existing tests in `tests/unit/useReceiptImport.barcodeWriteBack.test.ts` that had asserted the old always-"0 items"-worded message for these exact skip scenarios (they were testing the very continue paths that now change wording) — updated to assert the new `"Partial Import"` / destructive-variant toast.
+
+### 4. [MINOR — FIXED] SonarCloud `typescript:S2004` (CRITICAL severity per Sonar's own rule severity, but a style/refactor finding, not a behavior bug), `src/components/ReceiptMappingReview.tsx:279`
+"Refactor this code to not nest functions more than 4 levels deep." Phase 7b's `.then()`-wrapping of the previously-synchronous `handleItemUpdate` pushed `prev.map(item => ...)` to 4 nested arrow functions (`handleItemUpdate` → `.then` callback → `setLineItems` callback → `.map` callback).
+**Fix:** extracted the state-update body into a standalone `applyLineItemUpdate(itemId, updates)` function declared alongside `handleItemUpdate` (not nested inside it), dropping the `.map` callback back to 3 levels. This fix was folded into finding 1's edit since both touch the same function.
+
+### 5. [OUT OF SCOPE — DECLINED, no reply needed (nitpick, not actionable)] CodeRabbit nitpick, `src/hooks/useReceiptImport.tsx:660`
+"The `new_item` duplicate-product branch is still unscoped [by restaurant_id]." CodeRabbit itself flags this as pre-existing and explicitly says "not raising as a defect here" — it's the same gap Phase 7c already logged as out-of-scope (requires touching an unrelated branch this PR's design doc didn't scope in, no migration boundary issue but a separate defect surface). No PR reply posted since CodeRabbit's own comment already states it's not asking for a fix in this PR; nothing to decline.
+
+### 6. [MINOR — FIXED] SonarCloud `typescript:S6644`, `src/utils/receiptImportUtils.ts:185`
+"Unnecessary use of conditional expression for default assignment" — `return trimmed ? trimmed : null;` in `resolveBarcodeWriteBack`.
+**Fix:** simplified to `return trimmed || null;` (behaviorally identical: `trimmed` is `string | undefined`, both empty-string and undefined are falsy).
+
+## Verification after fixes
+- `npx vitest run` (targeted): all 9 receipt-import-scoped test files green — 82 tests (including the 2 new regression tests).
+- `npm run test` (full suite): **605 files passed / 1 skipped, 7513 tests passed / 2 skipped** — no regressions.
+- `npm run typecheck`: clean.
+- `npx eslint` on the 7 touched files: only pre-existing `no-explicit-any` / `ban-ts-comment` errors on the same pre-existing pattern (`Record<string, any>` update-payload signature, already present before this phase) — no new lint *rule violations* introduced, though extracting `applyLineItemUpdate` duplicates one existing `any` occurrence into a second function signature of the same pre-existing type.
+
+## Not classified as findings (informational only)
+- netlify[bot] deploy-failure comment, supabase[bot] "ignored" comment, vercel[bot] ready comment — bot status noise, no action.
+- SonarCloud quality-gate-passed summary comment itself — informational; its 2 referenced *issues* are findings 4 and 6 above, both fixed.

--- a/docs/superpowers/plans/2026-07-24-receipt-import-barcode-sync-plan.md
+++ b/docs/superpowers/plans/2026-07-24-receipt-import-barcode-sync-plan.md
@@ -1,0 +1,54 @@
+# Plan: Receipt-import barcode sync
+
+Design: docs/superpowers/specs/2026-07-24-receipt-import-barcode-sync-design.md
+
+Small, dependency-ordered tasks. Each is TDD (RED → GREEN → REFACTOR → COMMIT) where a test seam exists.
+
+## Task 1 — Pure helpers + unit tests (TDD)
+**Files:** `src/utils/receiptImportUtils.ts`, `tests/unit/receiptImportUtils.test.ts` (or the existing test file for this util)
+- RED: write failing tests for:
+  - `resolveLineItemBarcode(parsedSku, product)`:
+    - returns `null` when `parsedSku` is a non-empty string (don't overwrite user/existing value)
+    - returns `product.gtin` when `parsedSku` is null/empty and gtin present
+    - falls back to `product.sku` when gtin null/empty but sku present
+    - returns `null` when both gtin and sku are null/empty
+    - treats whitespace-only `parsedSku` as empty (fills)
+  - `resolveBarcodeWriteBack(parsedSku)`:
+    - returns trimmed value for a non-empty string
+    - returns `null` for null, `''`, and whitespace-only
+- GREEN: implement both pure helpers.
+- COMMIT: `feat(receipt-import): add barcode resolve helpers`
+
+## Task 2 — Auto-fill parsed_sku from matched product (Expectation A)
+**File:** `src/hooks/useReceiptImport.tsx` (`enrichLineItemsWithProductData`)
+- Add `gtin, sku` to the `products` SELECT (line ~475).
+- After the existing `suggested_*` enrichment, set
+  `enrichedItem.parsed_sku = resolveLineItemBarcode(item.parsed_sku, matchedProduct) ?? item.parsed_sku`.
+- Verify no regression to existing size/package enrichment.
+- COMMIT: `feat(receipt-import): auto-fill SKU/Barcode from matched product gtin`
+
+## Task 3 — Write barcode back to matched product + hardening (Expectation B)
+**File:** `src/hooks/useReceiptImport.tsx` (`bulkImportLineItems`, mapped branch ~654-737)
+- Replace the two `id`-only SELECTs (`current_stock`, `receipt_item_names`) with one
+  `restaurant_id`-scoped `.select('current_stock, receipt_item_names').maybeSingle()`; treat null/error as skip.
+- Compute `const barcode = resolveBarcodeWriteBack(item.parsed_sku)`; when truthy, add `gtin: barcode` to the
+  update object.
+- Scope the UPDATE by `.eq('restaurant_id', restaurantId)` in addition to `id`; chain `.select('id').maybeSingle()`;
+  treat null/error as a logged failure (`continue`) — no silent no-op.
+- COMMIT: `fix(receipt-import): write edited barcode back to matched product gtin`
+
+## Task 4 — Commit SKU field on blur, not per keystroke (Change 3)
+**File:** `src/components/receipt/ReceiptItemRow.tsx` (SKU Input ~292-299)
+- Change `onChange={(e) => onSkuChange(item.id, e.target.value)}` to
+  `onBlur={(e) => onSkuChange(item.id, e.target.value)}`. Keep `defaultValue` (uncontrolled).
+- No other input changes.
+- COMMIT: `fix(receipt-import): commit SKU/Barcode field on blur to avoid write race`
+
+## Notes / guards
+- No DB migration (gtin/sku exist on products; verified against prod).
+- Confirm `useProducts`/enrichment SELECT actually returns gtin (enrichment does its own query — controlled here).
+- Deferred (documented in design): `handleSkuChange` gtin reverse-lookup, `SearchableProductSelector` gtin search key,
+  collapsed-row Space-key a11y.
+
+## Sequencing
+Task 1 → (Task 2, Task 3 both depend on Task 1's helpers) → Task 4 independent (can go any time after Task 1).

--- a/docs/superpowers/specs/2026-07-24-receipt-import-barcode-sync-design.md
+++ b/docs/superpowers/specs/2026-07-24-receipt-import-barcode-sync-design.md
@@ -1,0 +1,112 @@
+# Design: Connect the receipt-import "SKU / Barcode" field to matched products
+
+**Date:** 2026-07-24
+**Branch:** `fix/receipt-import-barcode-sync`
+**Area:** Receipt/Invoice import → Review & Map step
+
+## Problem
+
+In the receipt-import mapping step ([ReceiptMappingReview.tsx](../../../src/components/ReceiptMappingReview.tsx) /
+[ReceiptItemRow.tsx](../../../src/components/receipt/ReceiptItemRow.tsx)), each parsed line has a field labeled
+**"SKU / Barcode"**, backed by a single column `parsed_sku` on `receipt_line_items`. Two user expectations are unmet:
+
+- **(A) Fill on match.** When a line item is auto-matched to an existing product that already has a barcode, the
+  SKU/Barcode field stays empty. Root cause: `enrichLineItemsWithProductData`
+  ([useReceiptImport.tsx:461](../../../src/hooks/useReceiptImport.tsx)) is the only path that copies data from a
+  matched product into the row, and it selects only `id, size_value, size_unit, uom_purchase` — it never reads the
+  product's `gtin`/`sku` and never populates `parsed_sku`.
+
+- **(B) Write-back on edit.** Editing the field and importing does not update the matched product's barcode. The edit
+  persists to `receipt_line_items.parsed_sku` fine, but `bulkImportLineItems`' **mapped** branch
+  ([useReceiptImport.tsx:654–737](../../../src/hooks/useReceiptImport.tsx)) updates only
+  `current_stock / cost_per_unit / receipt_item_names / supplier_id / updated_at` and drops `parsed_sku`. `parsed_sku`
+  only reaches a product in the **new_item** branch (as `sku`).
+
+Both failures share one cause: the barcode field is wired only for *creating* products, disconnected from *matched
+existing* products in both directions.
+
+## Decisions (from the user)
+
+- **Barcode column = `gtin`, with `sku` as fallback.**
+  - **Read/fill (A):** fill from `product.gtin || product.sku`.
+  - **Write (B):** write the edited value to `product.gtin`. We do **not** overwrite `product.sku` — `sku` is a
+    distinct stock-keeping identifier and clobbering it risks breaking sku-based lookups. "Fallback to sku" applies to
+    the *read* direction. (Decided trade-off, see below.)
+- **Fill behavior = auto-fill** (not an "Apply" suggestion chip).
+
+## Approach
+
+### Change 1 — Auto-fill `parsed_sku` from the matched product (Expectation A)
+
+In `enrichLineItemsWithProductData`:
+1. Add `gtin, sku` to the `products` SELECT.
+2. When `item.parsed_sku` is empty and the product has `gtin || sku`, set `enrichedItem.parsed_sku` to that value.
+
+This is **in-memory enrichment only** (not persisted to `receipt_line_items`), mirroring how `suggested_*` values
+already work. Since `loadData` sets `lineItems` once *after* enrichment completes, and rows mount only after that,
+the existing **uncontrolled** `defaultValue={item.parsed_sku || ''}` in `ReceiptItemRow` will display the filled value
+on first render.
+
+**The SKU input stays uncontrolled.** Making it controlled would force every keystroke through an awaited DB write in
+`handleItemUpdate` before the displayed value updates — a typing-lag / cursor-jump regression. No `ReceiptItemRow`
+change is needed.
+
+### Change 2 — Write the edited barcode back to the matched product (Expectation B)
+
+In `bulkImportLineItems`' mapped branch, fold `gtin` into the existing single `products` UPDATE when
+`item.parsed_sku` is a non-empty trimmed string:
+
+```ts
+const productUpdate = {
+  current_stock: newStock,
+  cost_per_unit: unitPrice,
+  receipt_item_names: updatedMappings,
+  supplier_id: supplierId,
+  updated_at: new Date().toISOString(),
+  ...(resolveBarcodeWriteBack(item.parsed_sku) ? { gtin: resolveBarcodeWriteBack(item.parsed_sku) } : {}),
+};
+await supabase.from('products').update(productUpdate)
+  .eq('id', item.matched_product_id)
+  .eq('restaurant_id', selectedRestaurant.restaurant_id);   // L717: scope products UPDATE by restaurant_id
+```
+
+Per lessons.md L717 (an unscoped `products` UPDATE was a real bug on PR #545), the write-back UPDATE is scoped by
+`restaurant_id` in addition to `id`.
+
+### Testable seam — pure helpers in `receiptImportUtils.ts`
+
+The affected logic lives inside a Supabase-calling hook, which is awkward to unit-test. Extract two pure helpers into
+[src/utils/receiptImportUtils.ts](../../../src/utils/receiptImportUtils.ts) (which already holds pure helpers like
+`calculateUnitPrice`) and have the hook call them:
+
+- `resolveLineItemBarcode(parsedSku: string | null, product: { gtin?: string | null; sku?: string | null }): string | null`
+  — returns the value to auto-fill: `null` when `parsedSku` is already non-empty; otherwise `gtin || sku || null`.
+- `resolveBarcodeWriteBack(parsedSku: string | null): string | null` — returns the trimmed non-empty `parsedSku`,
+  else `null`.
+
+Unit tests cover these directly (TDD RED first).
+
+## Scope boundaries (explicitly out)
+
+- **`handleSkuChange` reverse lookup** ([ReceiptMappingReview.tsx:365](../../../src/components/ReceiptMappingReview.tsx))
+  matches typed input against `p.sku` only. Extending it to also match `gtin` would make a written barcode
+  re-findable, but it's a separate "type-a-barcode-to-map" feature, not one of the two stated expectations. **Deferred**
+  (noted here so it isn't silently forgotten).
+- **`SearchableProductSelector` Fuse keys** (`['name','sku','brand']`) — not adding `gtin` to search. Out of scope.
+- **No DB migration** — `gtin` and `sku` already exist on `products`.
+
+## Decided trade-offs
+
+- **Write to `gtin` only, not `sku`.** Reading falls back to `sku`, but writing never overwrites an existing `sku`.
+  Rationale: `sku` is a distinct identifier used by other lookups; the barcode's canonical home is `gtin` (the column
+  the scanner's `findProductByGtin` queries). A product whose barcode currently lives in `sku` (from an older import)
+  will, after an edit, have the new value in `gtin` and the stale value in `sku`; fill prefers `gtin`, so the UI stays
+  correct.
+- **Auto-fill is display-only (not persisted).** Untouched auto-filled rows write nothing back on import (the product
+  keeps its own barcode — a no-op). Only user edits persist and write back.
+
+## Verification
+
+- Unit tests for `resolveLineItemBarcode` / `resolveBarcodeWriteBack`.
+- Manual/preview: import a receipt where a line matches a product with a `gtin` → field shows it; edit the field →
+  after import the product's `gtin` reflects the edit; matched product's `restaurant_id` scoping enforced.

--- a/docs/superpowers/specs/2026-07-24-receipt-import-barcode-sync-design.md
+++ b/docs/superpowers/specs/2026-07-24-receipt-import-barcode-sync-design.md
@@ -144,7 +144,12 @@ Unit tests cover these directly (TDD RED first).
   will, after an edit, have the new value in `gtin` and the stale value in `sku`; fill prefers `gtin`, so the UI stays
   correct.
 - **Auto-fill is display-only (not persisted).** Untouched auto-filled rows write nothing back on import (the product
-  keeps its own barcode — a no-op). Only user edits persist and write back.
+  keeps its own barcode — a no-op). Only user edits persist and write back. **Implementation note (Phase 7b):** the
+  auto-filled value lands in `item.parsed_sku` (Change 1) and `resolveBarcodeWriteBack` derives the write-back
+  candidate from that same field (Change 2), so an unguarded `onBlur` commit would copy an untouched auto-fill into
+  `gtin`. `ReceiptItemRow` closes this gap with a `skuCommittedRef` seeded from the auto-filled value: a blur only
+  calls `onSkuChange` when the field's value differs from what's already committed, so tabbing/clicking through an
+  untouched field is a no-op, matching this trade-off.
 
 ## Design review feedback folded in (Phase 2.5)
 

--- a/docs/superpowers/specs/2026-07-24-receipt-import-barcode-sync-design.md
+++ b/docs/superpowers/specs/2026-07-24-receipt-import-barcode-sync-design.md
@@ -48,30 +48,71 @@ the existing **uncontrolled** `defaultValue={item.parsed_sku || ''}` in `Receipt
 on first render.
 
 **The SKU input stays uncontrolled.** Making it controlled would force every keystroke through an awaited DB write in
-`handleItemUpdate` before the displayed value updates — a typing-lag / cursor-jump regression. No `ReceiptItemRow`
-change is needed.
+`handleItemUpdate` before the displayed value updates — a typing-lag / cursor-jump regression. The one `ReceiptItemRow`
+change (Change 3 below) moves the commit trigger from `onChange` to `onBlur` while keeping the input uncontrolled.
 
 ### Change 2 — Write the edited barcode back to the matched product (Expectation B)
 
-In `bulkImportLineItems`' mapped branch, fold `gtin` into the existing single `products` UPDATE when
-`item.parsed_sku` is a non-empty trimmed string:
+In `bulkImportLineItems`' mapped branch, fold `gtin` into the `products` UPDATE when `item.parsed_sku` is a non-empty
+trimmed string. Per lessons.md L717 (an unscoped `products` UPDATE was a real bug on PR #545), scope the UPDATE by
+`restaurant_id` in addition to `id`.
+
+Two Supabase design-review majors are folded in here:
+
+1. **Combine the two preceding reads.** The mapped branch currently does two separate `id`-only SELECTs on the same
+   product row (`current_stock`, then `receipt_item_names`). Combine into one `restaurant_id`-scoped read, closing the
+   same scoping gap and removing a duplicate round-trip.
+2. **No silent no-op.** With `restaurant_id` scoping, a 0-row UPDATE returns success (PostgREST does not error). Chain
+   `.select('id').maybeSingle()` and treat an empty result as a failure, so a stale-tenant mismatch surfaces instead
+   of silently dropping the write.
 
 ```ts
+const restaurantId = selectedRestaurant.restaurant_id;
+
+// One scoped read replaces the two id-only SELECTs
+const { data: current, error: fetchError } = await supabase
+  .from('products')
+  .select('current_stock, receipt_item_names')
+  .eq('id', item.matched_product_id)
+  .eq('restaurant_id', restaurantId)
+  .maybeSingle();
+if (fetchError || !current) { console.error(...); continue; }
+
+const barcode = resolveBarcodeWriteBack(item.parsed_sku);   // trimmed non-empty, else null
 const productUpdate = {
   current_stock: newStock,
   cost_per_unit: unitPrice,
   receipt_item_names: updatedMappings,
   supplier_id: supplierId,
   updated_at: new Date().toISOString(),
-  ...(resolveBarcodeWriteBack(item.parsed_sku) ? { gtin: resolveBarcodeWriteBack(item.parsed_sku) } : {}),
+  ...(barcode ? { gtin: barcode } : {}),
 };
-await supabase.from('products').update(productUpdate)
+const { data: updated, error: stockError } = await supabase
+  .from('products')
+  .update(productUpdate)
   .eq('id', item.matched_product_id)
-  .eq('restaurant_id', selectedRestaurant.restaurant_id);   // L717: scope products UPDATE by restaurant_id
+  .eq('restaurant_id', restaurantId)   // L717
+  .select('id')
+  .maybeSingle();
+if (stockError || !updated) { console.error(...); continue; }   // no silent no-op
 ```
 
-Per lessons.md L717 (an unscoped `products` UPDATE was a real bug on PR #545), the write-back UPDATE is scoped by
-`restaurant_id` in addition to `id`.
+### Change 3 — Commit the SKU/Barcode field on blur, not per keystroke (Frontend review majors)
+
+The frontend design review flagged that `ReceiptItemRow`'s SKU input commits on **every keystroke**
+(`onChange → handleSkuChange → await updateLineItemMapping`), with no debounce or cancellation. Two consequences,
+both **escalated by Change 2** (a stale `parsed_sku` now graduates into a real product's `gtin`, a shared record):
+
+- **Write race:** out-of-order resolution of per-keystroke writes can leave `receipt_line_items.parsed_sku` holding a
+  stale value that differs from what's on screen; `bulkImportLineItems` re-reads it fresh and writes it to `gtin`.
+- **Row vanishes mid-edit:** `handleSkuChange`'s live reverse-lookup (`sku.length >= 3`) re-tiers a matched row to
+  `auto-approved`, which collapses it into the collapsed-by-default "Ready" section — yanking the focused input away
+  mid-type. Change 1 makes `parsed_sku` pre-populated more often, widening this trigger.
+
+**Fix:** switch the SKU input to commit on `onBlur` instead of `onChange`. The input stays **uncontrolled**
+(`defaultValue` retained → no typing lag, no display glitch), a single write fires with the final value (no race), and
+the reverse-lookup auto-map runs only after the user leaves the field (no mid-type vanish). This is the one
+`ReceiptItemRow` change; it does not reintroduce the controlled-input problem (Claim 3), since `defaultValue` stays.
 
 ### Testable seam — pure helpers in `receiptImportUtils.ts`
 
@@ -105,8 +146,19 @@ Unit tests cover these directly (TDD RED first).
 - **Auto-fill is display-only (not persisted).** Untouched auto-filled rows write nothing back on import (the product
   keeps its own barcode — a no-op). Only user edits persist and write back.
 
+## Design review feedback folded in (Phase 2.5)
+
+- **Supabase (major):** combined the two `id`-only reads into one `restaurant_id`-scoped read; added `.select('id')`
+  to the write-back UPDATE to reject silent 0-row no-ops. (Change 2.)
+- **Supabase (major):** `restaurant_id` scoping on the UPDATE — kept. **(minor)** no unique constraint on
+  `gtin`/`sku` confirmed against prod → no conflict risk; N+1 in the mapped loop is pre-existing, out of scope.
+- **Frontend (major ×2):** per-keystroke write race + mid-edit row-vanish → fixed by committing on `onBlur`.
+  (Change 3.) **(minor)** avoid double-calling `resolveBarcodeWriteBack` → use a local `const barcode`. **(minor)**
+  `role="button"` Space-key handling on the collapsed row is pre-existing, out of scope.
+
 ## Verification
 
-- Unit tests for `resolveLineItemBarcode` / `resolveBarcodeWriteBack`.
-- Manual/preview: import a receipt where a line matches a product with a `gtin` → field shows it; edit the field →
-  after import the product's `gtin` reflects the edit; matched product's `restaurant_id` scoping enforced.
+- Unit tests (TDD RED first) for `resolveLineItemBarcode` / `resolveBarcodeWriteBack`.
+- Manual/preview: import a receipt where a line matches a product with a `gtin` → field shows it; edit the field then
+  blur → after import the product's `gtin` reflects the edit; confirm typing no longer collapses the row mid-edit; a
+  cross-tenant/stale mismatch logs an error instead of silently dropping.

--- a/src/components/ReceiptMappingReview.tsx
+++ b/src/components/ReceiptMappingReview.tsx
@@ -138,10 +138,15 @@ export const ReceiptMappingReview: React.FC<ReceiptMappingReviewProps> = ({
   const [isNewSupplier, setIsNewSupplier] = useState(false);
   const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
   const needsAttentionRef = React.useRef<HTMLDivElement>(null);
-  // In-flight handleItemUpdate writes (e.g. the SKU field's onBlur commit). bulkImportLineItems
-  // re-reads receipt_line_items fresh from the DB, so importing before these land would use
-  // stale values and silently drop the user's edit. Tracked so handleBulkImport can await them.
-  const pendingUpdatesRef = React.useRef<Set<Promise<unknown>>>(new Set());
+  // In-flight (and most-recently-settled) handleItemUpdate writes, keyed by itemId, e.g. the SKU
+  // field's onBlur commit. bulkImportLineItems re-reads receipt_line_items fresh from the DB, so
+  // importing before these land would use stale values and silently drop the user's edit. Tracked
+  // so handleBulkImport can await them.
+  // Keyed by itemId (not a bare Set of promises) so a *failed* write's entry survives until a
+  // later successful retry for the same item overwrites it — otherwise, once a write settles
+  // (success or failure) before Import is clicked, a Set-based approach would already have
+  // forgotten it, letting handleBulkImport proceed on a stale value despite the earlier failure.
+  const pendingUpdatesRef = React.useRef<Map<string, Promise<boolean>>>(new Map());
 
   const { selectedRestaurant } = useRestaurantContext();
   const { getReceiptDetails, getReceiptLineItems, updateLineItemMapping, bulkImportLineItems, findSemanticDuplicate } = useReceiptImport();
@@ -273,17 +278,31 @@ export const ReceiptMappingReview: React.FC<ReceiptMappingReviewProps> = ({
   }, [lineItems]);
 
   // Handlers
-  const handleItemUpdate = async (itemId: string, updates: Record<string, any>) => {
+  // Applies a successful write's updates to local state. Extracted to a standalone function
+  // (rather than inlined in handleItemUpdate's .then callback) to keep handleItemUpdate's nesting
+  // shallow: inlining `setLineItems(prev => prev.map(...))` inside `.then((success) => {...})`
+  // inside `handleItemUpdate` put the `.map` callback 4 arrow-functions deep.
+  const applyLineItemUpdate = (itemId: string, updates: Record<string, any>) => {
+    setLineItems(prev => prev.map(item =>
+      item.id === itemId ? { ...item, ...updates } : item
+    ));
+  };
+
+  const handleItemUpdate = (itemId: string, updates: Record<string, any>): Promise<boolean> => {
     const writePromise = updateLineItemMapping(itemId, updates).then((success) => {
       if (success) {
-        setLineItems(prev => prev.map(item =>
-          item.id === itemId ? { ...item, ...updates } : item
-        ));
+        applyLineItemUpdate(itemId, updates);
+        // Only clear this item's tracked entry if no newer write has since been queued for it
+        // (a slower earlier write resolving after a newer one was issued must not clobber it).
+        if (pendingUpdatesRef.current.get(itemId) === writePromise) {
+          pendingUpdatesRef.current.delete(itemId);
+        }
       }
+      // On failure, deliberately leave the (already-settled) entry in the map — see the
+      // pendingUpdatesRef declaration comment above for why.
       return success;
     });
-    pendingUpdatesRef.current.add(writePromise);
-    writePromise.finally(() => pendingUpdatesRef.current.delete(writePromise));
+    pendingUpdatesRef.current.set(itemId, writePromise);
     return writePromise;
   };
 
@@ -497,7 +516,7 @@ export const ReceiptMappingReview: React.FC<ReceiptMappingReviewProps> = ({
       // can't race the import into using a stale value. A failed write must abort the import —
       // otherwise the re-read falls back to the stale DB value, the exact race this guard exists
       // to prevent.
-      const results = await Promise.allSettled(pendingUpdatesRef.current);
+      const results = await Promise.allSettled(pendingUpdatesRef.current.values());
       const hasFailedUpdate = results.some(
         (r) => r.status === 'rejected' || (r.status === 'fulfilled' && r.value === false),
       );

--- a/src/components/ReceiptMappingReview.tsx
+++ b/src/components/ReceiptMappingReview.tsx
@@ -491,15 +491,32 @@ export const ReceiptMappingReview: React.FC<ReceiptMappingReviewProps> = ({
 
   const handleBulkImport = async () => {
     setImporting(true);
-    // Wait for any in-flight field edits (e.g. a SKU/Barcode onBlur commit) to land before
-    // bulkImportLineItems re-reads receipt_line_items from the DB, so a click-right-after-blur
-    // can't race the import into using a stale value.
-    await Promise.all(pendingUpdatesRef.current);
-    const success = await bulkImportLineItems(receiptId);
-    if (success) {
-      onImportComplete();
+    try {
+      // Wait for any in-flight field edits (e.g. a SKU/Barcode onBlur commit) to land before
+      // bulkImportLineItems re-reads receipt_line_items from the DB, so a click-right-after-blur
+      // can't race the import into using a stale value. A failed write must abort the import —
+      // otherwise the re-read falls back to the stale DB value, the exact race this guard exists
+      // to prevent.
+      const results = await Promise.allSettled(pendingUpdatesRef.current);
+      const hasFailedUpdate = results.some(
+        (r) => r.status === 'rejected' || (r.status === 'fulfilled' && r.value === false),
+      );
+      if (hasFailedUpdate) {
+        toast({
+          title: "Unsaved changes",
+          description: "Fix the failed item update before importing.",
+          variant: "destructive",
+        });
+        return;
+      }
+
+      const success = await bulkImportLineItems(receiptId);
+      if (success) {
+        onImportComplete();
+      }
+    } finally {
+      setImporting(false);
     }
-    setImporting(false);
   };
 
   const handleBatchAcceptAll = (itemIds: string[]) => {

--- a/src/components/ReceiptMappingReview.tsx
+++ b/src/components/ReceiptMappingReview.tsx
@@ -138,7 +138,11 @@ export const ReceiptMappingReview: React.FC<ReceiptMappingReviewProps> = ({
   const [isNewSupplier, setIsNewSupplier] = useState(false);
   const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
   const needsAttentionRef = React.useRef<HTMLDivElement>(null);
-  
+  // In-flight handleItemUpdate writes (e.g. the SKU field's onBlur commit). bulkImportLineItems
+  // re-reads receipt_line_items fresh from the DB, so importing before these land would use
+  // stale values and silently drop the user's edit. Tracked so handleBulkImport can await them.
+  const pendingUpdatesRef = React.useRef<Set<Promise<unknown>>>(new Set());
+
   const { selectedRestaurant } = useRestaurantContext();
   const { getReceiptDetails, getReceiptLineItems, updateLineItemMapping, bulkImportLineItems, findSemanticDuplicate } = useReceiptImport();
   const { products } = useProducts(selectedRestaurant?.restaurant_id || null);
@@ -270,12 +274,17 @@ export const ReceiptMappingReview: React.FC<ReceiptMappingReviewProps> = ({
 
   // Handlers
   const handleItemUpdate = async (itemId: string, updates: Record<string, any>) => {
-    const success = await updateLineItemMapping(itemId, updates);
-    if (success) {
-      setLineItems(prev => prev.map(item => 
-        item.id === itemId ? { ...item, ...updates } : item
-      ));
-    }
+    const writePromise = updateLineItemMapping(itemId, updates).then((success) => {
+      if (success) {
+        setLineItems(prev => prev.map(item =>
+          item.id === itemId ? { ...item, ...updates } : item
+        ));
+      }
+      return success;
+    });
+    pendingUpdatesRef.current.add(writePromise);
+    writePromise.finally(() => pendingUpdatesRef.current.delete(writePromise));
+    return writePromise;
   };
 
   const handleMappingChange = (itemId: string, productId: string | null) => {
@@ -482,6 +491,10 @@ export const ReceiptMappingReview: React.FC<ReceiptMappingReviewProps> = ({
 
   const handleBulkImport = async () => {
     setImporting(true);
+    // Wait for any in-flight field edits (e.g. a SKU/Barcode onBlur commit) to land before
+    // bulkImportLineItems re-reads receipt_line_items from the DB, so a click-right-after-blur
+    // can't race the import into using a stale value.
+    await Promise.all(pendingUpdatesRef.current);
     const success = await bulkImportLineItems(receiptId);
     if (success) {
       onImportComplete();

--- a/src/components/receipt/ReceiptItemRow.tsx
+++ b/src/components/receipt/ReceiptItemRow.tsx
@@ -298,6 +298,14 @@ export const ReceiptItemRow: React.FC<ReceiptItemRowProps> = ({
                     <Input
                       id={`sku-${item.id}`}
                       defaultValue={item.parsed_sku || ''}
+                      onFocus={() => {
+                        // Re-baseline against the current source-of-truth value on every focus.
+                        // If the last commit attempt failed (updateLineItemMapping resolved
+                        // false), `item.parsed_sku` was never advanced, so this lets a plain
+                        // focus + blur (no retyping needed) retry the same value instead of
+                        // being silently swallowed by the "no intervening edit" guard below.
+                        skuCommittedRef.current = item.parsed_sku || '';
+                      }}
                       onBlur={(e) => {
                         if (e.target.value !== skuCommittedRef.current) {
                           skuCommittedRef.current = e.target.value;

--- a/src/components/receipt/ReceiptItemRow.tsx
+++ b/src/components/receipt/ReceiptItemRow.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
@@ -88,6 +88,12 @@ export const ReceiptItemRow: React.FC<ReceiptItemRowProps> = ({
 }) => {
   // Auto-approved items start collapsed, others start expanded
   const [isOpen, setIsOpen] = useState(tier !== 'auto-approved');
+
+  // The SKU/Barcode input is uncontrolled and commits on blur (see onSkuChange below).
+  // Track the last value we actually committed so a blur on an unedited (or already
+  // re-blurred) field is a no-op: auto-filled values must only write back when the user
+  // genuinely changes them, never merely by tabbing/clicking through the field.
+  const skuCommittedRef = useRef(item.parsed_sku || '');
 
   const hasSuggestions = !!(item.suggested_size_value || item.suggested_package_type);
   const needsSizeInfo = !item.size_value && !item.size_unit && tier !== 'auto-approved';
@@ -292,7 +298,12 @@ export const ReceiptItemRow: React.FC<ReceiptItemRowProps> = ({
                     <Input
                       id={`sku-${item.id}`}
                       defaultValue={item.parsed_sku || ''}
-                      onBlur={(e) => onSkuChange(item.id, e.target.value)}
+                      onBlur={(e) => {
+                        if (e.target.value !== skuCommittedRef.current) {
+                          skuCommittedRef.current = e.target.value;
+                          onSkuChange(item.id, e.target.value);
+                        }
+                      }}
                       placeholder="Scan or type"
                       disabled={isImported}
                       className="h-9"

--- a/src/components/receipt/ReceiptItemRow.tsx
+++ b/src/components/receipt/ReceiptItemRow.tsx
@@ -292,7 +292,7 @@ export const ReceiptItemRow: React.FC<ReceiptItemRowProps> = ({
                     <Input
                       id={`sku-${item.id}`}
                       defaultValue={item.parsed_sku || ''}
-                      onChange={(e) => onSkuChange(item.id, e.target.value)}
+                      onBlur={(e) => onSkuChange(item.id, e.target.value)}
                       placeholder="Scan or type"
                       disabled={isImported}
                       className="h-9"

--- a/src/hooks/useReceiptImport.tsx
+++ b/src/hooks/useReceiptImport.tsx
@@ -470,10 +470,13 @@ export const useReceiptImport = () => {
     if (matchedProductIds.length === 0) return lineItems;
 
     // Fetch matched products with size info (uom_purchase = package type)
+    // Scoped by restaurant_id (L717): a stale/cross-tenant matched_product_id must not
+    // enrich this receipt with another restaurant's size/barcode data.
     const { data: matchedProducts, error } = await supabase
       .from('products')
       .select('id, size_value, size_unit, uom_purchase, gtin, sku')
-      .in('id', matchedProductIds);
+      .in('id', matchedProductIds)
+      .eq('restaurant_id', selectedRestaurant.restaurant_id);
 
     if (error) {
       console.error('Error fetching matched products for enrichment:', error);

--- a/src/hooks/useReceiptImport.tsx
+++ b/src/hooks/useReceiptImport.tsx
@@ -3,7 +3,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 import { useRestaurantContext } from '@/contexts/RestaurantContext';
 import { WEIGHT_UNITS, VOLUME_UNITS } from '@/lib/enhancedUnitConversion';
-import { calculateImportedTotal, calculateUnitPrice, resolveLineItemBarcode } from '@/utils/receiptImportUtils';
+import { calculateImportedTotal, calculateUnitPrice, resolveLineItemBarcode, resolveBarcodeWriteBack } from '@/utils/receiptImportUtils';
 import { sha256Hex } from '@/lib/fileHash';
 import { describeStorageError, UPLOAD_ERROR_TOAST_DURATION } from '@/lib/storageError';
 
@@ -654,56 +654,55 @@ export const useReceiptImport = () => {
       // Track created products by parsed_name to reuse for duplicates
       const createdProducts = new Map<string, string>(); // parsed_name (lowercase) -> product_id
 
+      const restaurantId = selectedRestaurant.restaurant_id;
+
       for (const item of lineItems) {
         if (item.mapping_status === 'mapped' && item.matched_product_id) {
-          // First get current stock
-          const { data: currentProduct, error: fetchError } = await supabase
+          // One restaurant_id-scoped read replaces the two id-only SELECTs
+          // (L717: an unscoped products UPDATE was a real bug on PR #545 —
+          // scope reads too, since a stale/cross-tenant matched_product_id
+          // should fail loudly rather than silently reading someone else's row).
+          const { data: current, error: fetchError } = await supabase
             .from('products')
-            .select('current_stock')
+            .select('current_stock, receipt_item_names')
             .eq('id', item.matched_product_id)
-            .single();
+            .eq('restaurant_id', restaurantId)
+            .maybeSingle();
 
-          if (fetchError) {
+          if (fetchError || !current) {
             console.error('Error fetching current product:', fetchError);
             continue;
           }
 
           // Update existing product stock and store receipt item mapping
-          const newStock = (currentProduct.current_stock || 0) + (item.parsed_quantity || 0);
-          
-          // Get current receipt_item_names to add the new mapping
-          const { data: currentProductData, error: currentProductError } = await supabase
-            .from('products')
-            .select('receipt_item_names')
-            .eq('id', item.matched_product_id)
-            .single();
-
-          if (currentProductError) {
-            console.error('Error fetching current product data:', currentProductError);
-            continue;
-          }
+          const newStock = (current.current_stock || 0) + (item.parsed_quantity || 0);
 
           // Add the receipt item name to the product's mapping list if not already present
-          const currentMappings = currentProductData.receipt_item_names || [];
+          const currentMappings = current.receipt_item_names || [];
           const receiptItemName = item.parsed_name || item.raw_text;
-          const updatedMappings = currentMappings.includes(receiptItemName) 
-            ? currentMappings 
+          const updatedMappings = currentMappings.includes(receiptItemName)
+            ? currentMappings
             : [...currentMappings, receiptItemName];
 
           const unitPrice = calculateUnitPrice(item);
+          const barcode = resolveBarcodeWriteBack(item.parsed_sku);
 
-          const { error: stockError } = await supabase
+          const { data: updated, error: stockError } = await supabase
             .from('products')
             .update({
               current_stock: newStock,
               cost_per_unit: unitPrice,
               receipt_item_names: updatedMappings,
               supplier_id: supplierId,
-              updated_at: new Date().toISOString()
+              updated_at: new Date().toISOString(),
+              ...(barcode ? { gtin: barcode } : {}),
             })
-            .eq('id', item.matched_product_id);
+            .eq('id', item.matched_product_id)
+            .eq('restaurant_id', restaurantId)
+            .select('id')
+            .maybeSingle();
 
-          if (stockError) {
+          if (stockError || !updated) {
             console.error('Error updating product stock:', stockError);
             continue;
           }

--- a/src/hooks/useReceiptImport.tsx
+++ b/src/hooks/useReceiptImport.tsx
@@ -654,6 +654,10 @@ export const useReceiptImport = () => {
       const purchaseDate = receiptResult.data?.purchase_date || null;
 
       let importedCount = 0;
+      // Items skipped due to a failed/missing restaurant-scoped read or write (see the two new
+      // `continue` sites below) — surfaced in the closing toast so a silent partial import
+      // doesn't read as a full "Success".
+      let skippedCount = 0;
       // Track created products by parsed_name to reuse for duplicates
       const createdProducts = new Map<string, string>(); // parsed_name (lowercase) -> product_id
 
@@ -674,6 +678,7 @@ export const useReceiptImport = () => {
 
           if (fetchError || !current) {
             console.error('Error fetching current product:', fetchError);
+            skippedCount++;
             continue;
           }
 
@@ -707,6 +712,7 @@ export const useReceiptImport = () => {
 
           if (stockError || !updated) {
             console.error('Error updating product stock:', stockError);
+            skippedCount++;
             continue;
           }
 
@@ -912,8 +918,11 @@ export const useReceiptImport = () => {
       }
 
       toast({
-        title: "Success",
-        description: `Successfully imported ${importedCount} items to inventory`,
+        title: skippedCount > 0 ? "Partial Import" : "Success",
+        description: skippedCount > 0
+          ? `Imported ${importedCount} item(s); ${skippedCount} item(s) failed and were skipped.`
+          : `Successfully imported ${importedCount} items to inventory`,
+        variant: skippedCount > 0 ? "destructive" : "default",
       });
 
       return true;

--- a/src/hooks/useReceiptImport.tsx
+++ b/src/hooks/useReceiptImport.tsx
@@ -3,7 +3,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 import { useRestaurantContext } from '@/contexts/RestaurantContext';
 import { WEIGHT_UNITS, VOLUME_UNITS } from '@/lib/enhancedUnitConversion';
-import { calculateImportedTotal, calculateUnitPrice } from '@/utils/receiptImportUtils';
+import { calculateImportedTotal, calculateUnitPrice, resolveLineItemBarcode } from '@/utils/receiptImportUtils';
 import { sha256Hex } from '@/lib/fileHash';
 import { describeStorageError, UPLOAD_ERROR_TOAST_DURATION } from '@/lib/storageError';
 
@@ -472,7 +472,7 @@ export const useReceiptImport = () => {
     // Fetch matched products with size info (uom_purchase = package type)
     const { data: matchedProducts, error } = await supabase
       .from('products')
-      .select('id, size_value, size_unit, uom_purchase')
+      .select('id, size_value, size_unit, uom_purchase, gtin, sku')
       .in('id', matchedProductIds);
 
     if (error) {
@@ -503,6 +503,10 @@ export const useReceiptImport = () => {
       if (!item.package_type && matchedProduct.uom_purchase) {
         enrichedItem.suggested_package_type = matchedProduct.uom_purchase;
       }
+
+      // Auto-fill SKU/Barcode from the matched product's gtin (fallback to sku)
+      // when the line item doesn't already have one.
+      enrichedItem.parsed_sku = resolveLineItemBarcode(item.parsed_sku, matchedProduct) ?? item.parsed_sku;
 
       return enrichedItem;
     });

--- a/src/utils/receiptImportUtils.ts
+++ b/src/utils/receiptImportUtils.ts
@@ -182,7 +182,7 @@ export function resolveLineItemBarcode(
  */
 export function resolveBarcodeWriteBack(parsedSku: string | null): string | null {
   const trimmed = parsedSku?.trim();
-  return trimmed ? trimmed : null;
+  return trimmed || null;
 }
 
 /**

--- a/src/utils/receiptImportUtils.ts
+++ b/src/utils/receiptImportUtils.ts
@@ -140,13 +140,6 @@ export interface ParsedLineItemInput {
   confidenceScore: number;
 }
 
-/**
- * Build a receipt_line_items DB insert row from a parsed AI line item.
- *
- * - pack_quantity maps from item.unitsPerPack (the distributor pack count).
- * - line_sequence is 1-based (index + 1).
- * - pack_quantity is null when unitsPerPack is absent or not provided.
- */
 export interface BarcodeSourceProduct {
   gtin?: string | null;
   sku?: string | null;
@@ -192,6 +185,13 @@ export function resolveBarcodeWriteBack(parsedSku: string | null): string | null
   return trimmed ? trimmed : null;
 }
 
+/**
+ * Build a receipt_line_items DB insert row from a parsed AI line item.
+ *
+ * - pack_quantity maps from item.unitsPerPack (the distributor pack count).
+ * - line_sequence is 1-based (index + 1).
+ * - pack_quantity is null when unitsPerPack is absent or not provided.
+ */
 export function buildLineItemInsert(receiptId: string, item: ParsedLineItemInput, index: number) {
   return {
     receipt_id: receiptId,

--- a/src/utils/receiptImportUtils.ts
+++ b/src/utils/receiptImportUtils.ts
@@ -147,6 +147,51 @@ export interface ParsedLineItemInput {
  * - line_sequence is 1-based (index + 1).
  * - pack_quantity is null when unitsPerPack is absent or not provided.
  */
+export interface BarcodeSourceProduct {
+  gtin?: string | null;
+  sku?: string | null;
+}
+
+/**
+ * Resolve the value to auto-fill into the SKU/Barcode field when a line item
+ * is matched to an existing product.
+ *
+ * - Never overwrites an already-populated (non-whitespace) parsedSku.
+ * - Otherwise prefers product.gtin, falling back to product.sku.
+ * - Returns null when there's nothing to fill.
+ */
+export function resolveLineItemBarcode(
+  parsedSku: string | null,
+  product: BarcodeSourceProduct,
+): string | null {
+  if (parsedSku && parsedSku.trim().length > 0) {
+    return null;
+  }
+
+  const gtin = product.gtin?.trim();
+  if (gtin) {
+    return gtin;
+  }
+
+  const sku = product.sku?.trim();
+  if (sku) {
+    return sku;
+  }
+
+  return null;
+}
+
+/**
+ * Resolve the value to write back to a matched product's `gtin` column when
+ * the SKU/Barcode field was edited.
+ *
+ * Returns the trimmed, non-empty parsedSku, or null when there's nothing to write.
+ */
+export function resolveBarcodeWriteBack(parsedSku: string | null): string | null {
+  const trimmed = parsedSku?.trim();
+  return trimmed ? trimmed : null;
+}
+
 export function buildLineItemInsert(receiptId: string, item: ParsedLineItemInput, index: number) {
   return {
     receipt_id: receiptId,

--- a/tests/unit/ReceiptItemRow.skuBlur.test.tsx
+++ b/tests/unit/ReceiptItemRow.skuBlur.test.tsx
@@ -117,6 +117,27 @@ describe('ReceiptItemRow — SKU/Barcode input commits on blur', () => {
     expect(onSkuChange).not.toHaveBeenCalled();
   });
 
+  it('re-commits on a focus + blur cycle when the prior commit never landed (retry after a failed write)', () => {
+    // Regression: if updateLineItemMapping resolved false, item.parsed_sku (the source of truth)
+    // never advances past its pre-edit value, but the old code's skuCommittedRef advanced
+    // optimistically at blur time regardless of write outcome — permanently blocking a retry of
+    // the same value. onFocus now re-baselines the ref from item.parsed_sku, so a focus + blur
+    // with no intervening edit still re-fires the commit.
+    const onSkuChange = vi.fn();
+    renderRow(onSkuChange, { parsed_sku: null });
+    const skuInput = screen.getByLabelText(/SKU \/ Barcode/i);
+    fireEvent.change(skuInput, { target: { value: '999' } });
+    fireEvent.blur(skuInput);
+    expect(onSkuChange).toHaveBeenCalledTimes(1);
+
+    // Simulate the parent's write having failed: item.parsed_sku prop is unchanged (still null),
+    // so the next focus resets the baseline back to it, not to the failed attempt's '999'.
+    fireEvent.focus(skuInput);
+    fireEvent.blur(skuInput);
+    expect(onSkuChange).toHaveBeenCalledTimes(2);
+    expect(onSkuChange).toHaveBeenNthCalledWith(2, 'item-1', '999');
+  });
+
   it('stays uncontrolled: uses defaultValue seeded from parsed_sku, not a controlled value prop', () => {
     const onSkuChange = vi.fn();
     renderRow(onSkuChange, { parsed_sku: 'ABC-123' });

--- a/tests/unit/ReceiptItemRow.skuBlur.test.tsx
+++ b/tests/unit/ReceiptItemRow.skuBlur.test.tsx
@@ -1,11 +1,12 @@
 /**
- * Task 4 (Phase 4, task 4/4): Commit SKU field on blur, not per keystroke (Change 3)
+ * Commit SKU field on blur, not per keystroke.
  *
- * RED: Written before the ReceiptItemRow change — the SKU input currently calls
- *   onSkuChange on every keystroke (onChange), which races per-keystroke writes
- *   and can re-tier a matched row out from under the user mid-type.
- * GREEN: Pass once the SKU input commits via onBlur instead, while remaining
- *   uncontrolled (defaultValue, not value).
+ * The SKU input calls onSkuChange on blur, but only when the value actually
+ * changed from the last-committed one. Since parsed_sku can arrive pre-filled
+ * from a matched product's gtin/sku (auto-fill, display-only), a blur on an
+ * untouched field — or a repeat blur with no intervening edit — must be a
+ * no-op: it must not re-commit the auto-filled value as if the user had typed
+ * it, and it must not re-tier a matched row out from under the user mid-type.
  */
 import { describe, it, expect, vi } from 'vitest';
 import React from 'react';
@@ -102,9 +103,18 @@ describe('ReceiptItemRow — SKU/Barcode input commits on blur', () => {
     fireEvent.change(skuInput, { target: { value: '999' } });
     fireEvent.blur(skuInput);
     fireEvent.blur(skuInput);
-    expect(onSkuChange).toHaveBeenCalledTimes(2);
-    expect(onSkuChange).toHaveBeenNthCalledWith(1, 'item-1', '999');
-    expect(onSkuChange).toHaveBeenNthCalledWith(2, 'item-1', '999');
+    expect(onSkuChange).toHaveBeenCalledTimes(1);
+    expect(onSkuChange).toHaveBeenCalledWith('item-1', '999');
+  });
+
+  it('does not call onSkuChange on blur when the field was never edited (auto-filled value)', () => {
+    // Regression: an auto-filled parsed_sku (from the matched product's gtin/sku) must not be
+    // re-committed just because the user tabbed/clicked through the field without changing it.
+    const onSkuChange = vi.fn();
+    renderRow(onSkuChange, { parsed_sku: 'ABC-123' });
+    const skuInput = screen.getByLabelText(/SKU \/ Barcode/i);
+    fireEvent.blur(skuInput);
+    expect(onSkuChange).not.toHaveBeenCalled();
   });
 
   it('stays uncontrolled: uses defaultValue seeded from parsed_sku, not a controlled value prop', () => {

--- a/tests/unit/ReceiptItemRow.skuBlur.test.tsx
+++ b/tests/unit/ReceiptItemRow.skuBlur.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Task 4 (Phase 4, task 4/4): Commit SKU field on blur, not per keystroke (Change 3)
+ *
+ * RED: Written before the ReceiptItemRow change — the SKU input currently calls
+ *   onSkuChange on every keystroke (onChange), which races per-keystroke writes
+ *   and can re-tier a matched row out from under the user mid-type.
+ * GREEN: Pass once the SKU input commits via onBlur instead, while remaining
+ *   uncontrolled (defaultValue, not value).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ReceiptItemRow } from '@/components/receipt/ReceiptItemRow';
+import type { ReceiptLineItem } from '@/hooks/useReceiptImport';
+
+// ── Minimal stubs for heavy deps ─────────────────────────────────────────────
+vi.mock('@/components/SearchableProductSelector', () => ({
+  SearchableProductSelector: () => <div data-testid="product-selector" />,
+}));
+vi.mock('@/components/GroupedUnitSelector', () => ({
+  GroupedUnitSelector: ({ value, placeholder }: { value?: string; placeholder?: string }) => (
+    <select aria-label="Unit" defaultValue={value || ''}>
+      <option value="">{placeholder ?? ''}</option>
+    </select>
+  ),
+}));
+
+function makeItem(overrides: Partial<ReceiptLineItem> = {}): ReceiptLineItem {
+  return {
+    id: 'item-1',
+    receipt_id: 'receipt-1',
+    raw_text: 'GULDENS MUSTARD PACKET',
+    parsed_name: 'Guldens Mustard Packet',
+    parsed_quantity: 500,
+    parsed_unit: 'each',
+    parsed_price: 29.96,
+    parsed_sku: null,
+    unit_price: 0.0599,
+    package_type: 'packet',
+    size_value: 0.32,
+    size_unit: 'oz',
+    pack_quantity: 500,
+    matched_product_id: null,
+    confidence_score: 0.9,
+    mapping_status: 'pending',
+    created_at: '2026-07-02T00:00:00Z',
+    updated_at: '2026-07-02T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function renderRow(onSkuChange: (itemId: string, sku: string) => void, itemOverrides: Partial<ReceiptLineItem> = {}) {
+  const item = makeItem(itemOverrides);
+  const defaultProps = {
+    index: 0,
+    tier: 'quick-review' as const,
+    linkedCount: 1,
+    products: [],
+    isImported: false,
+    onMappingChange: vi.fn(),
+    onQuantityChange: vi.fn(),
+    onPriceChange: vi.fn(),
+    onNameChange: vi.fn(),
+    onPackageTypeChange: vi.fn(),
+    onSizeValueChange: vi.fn(),
+    onSizeUnitChange: vi.fn(),
+    onSkuChange,
+    onApplySuggestion: vi.fn(),
+    onQuickFill: vi.fn(),
+    categoryQuickFills: [],
+  };
+  return render(<ReceiptItemRow item={item} {...defaultProps} />);
+}
+
+describe('ReceiptItemRow — SKU/Barcode input commits on blur', () => {
+  it('does NOT call onSkuChange while typing (per-keystroke)', () => {
+    const onSkuChange = vi.fn();
+    renderRow(onSkuChange);
+    const skuInput = screen.getByLabelText(/SKU \/ Barcode/i);
+    fireEvent.change(skuInput, { target: { value: '1' } });
+    fireEvent.change(skuInput, { target: { value: '12' } });
+    fireEvent.change(skuInput, { target: { value: '123' } });
+    expect(onSkuChange).not.toHaveBeenCalled();
+  });
+
+  it('calls onSkuChange exactly once, with the final value, on blur', () => {
+    const onSkuChange = vi.fn();
+    renderRow(onSkuChange);
+    const skuInput = screen.getByLabelText(/SKU \/ Barcode/i);
+    fireEvent.change(skuInput, { target: { value: '1' } });
+    fireEvent.change(skuInput, { target: { value: '12' } });
+    fireEvent.change(skuInput, { target: { value: '123456789' } });
+    fireEvent.blur(skuInput);
+    expect(onSkuChange).toHaveBeenCalledTimes(1);
+    expect(onSkuChange).toHaveBeenCalledWith('item-1', '123456789');
+  });
+
+  it('does not call onSkuChange again on a second blur with no intervening edits', () => {
+    const onSkuChange = vi.fn();
+    renderRow(onSkuChange);
+    const skuInput = screen.getByLabelText(/SKU \/ Barcode/i);
+    fireEvent.change(skuInput, { target: { value: '999' } });
+    fireEvent.blur(skuInput);
+    fireEvent.blur(skuInput);
+    expect(onSkuChange).toHaveBeenCalledTimes(2);
+    expect(onSkuChange).toHaveBeenNthCalledWith(1, 'item-1', '999');
+    expect(onSkuChange).toHaveBeenNthCalledWith(2, 'item-1', '999');
+  });
+
+  it('stays uncontrolled: uses defaultValue seeded from parsed_sku, not a controlled value prop', () => {
+    const onSkuChange = vi.fn();
+    renderRow(onSkuChange, { parsed_sku: 'ABC-123' });
+    const skuInput = screen.getByLabelText(/SKU \/ Barcode/i) as HTMLInputElement;
+    expect(skuInput.value).toBe('ABC-123');
+    // Typing should update the DOM value locally without needing a re-render from a `value` prop.
+    fireEvent.change(skuInput, { target: { value: 'ABC-124' } });
+    expect(skuInput.value).toBe('ABC-124');
+  });
+});

--- a/tests/unit/ReceiptMappingReview.pendingWrites.test.tsx
+++ b/tests/unit/ReceiptMappingReview.pendingWrites.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * Regression: a failed field-edit write (e.g. the SKU/Barcode onBlur commit) must still block
+ * bulk import even after it has already settled by the time the user clicks Import.
+ *
+ * handleBulkImport awaits `pendingUpdatesRef` before re-reading `receipt_line_items` fresh from
+ * the DB (see ReceiptMappingReview.tsx). The original Set<Promise>-based implementation removed
+ * every settled promise — success OR failure — via a bare `.finally()`, so a write that failed
+ * and settled *before* Import was clicked left no trace: `Promise.allSettled` over the
+ * (now-empty-of-that-entry) set would see no failure, and the import would proceed on the stale
+ * DB value the guard exists to prevent. The fix keys tracking by itemId and only clears an
+ * entry on success, so a failed write's outcome survives until a later successful retry.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import { ReceiptMappingReview } from '@/components/ReceiptMappingReview';
+
+const updateLineItemMapping = vi.fn();
+const bulkImportLineItems = vi.fn();
+const toastSpy = vi.fn();
+
+const baseItem = {
+  id: 'item-1',
+  receipt_id: 'r-1',
+  raw_text: 'GULDENS MUSTARD PACKET',
+  parsed_name: 'Guldens Mustard Packet',
+  parsed_quantity: 1,
+  parsed_unit: 'each',
+  parsed_price: 29.96,
+  parsed_sku: 'OLD-SKU',
+  unit_price: 29.96,
+  package_type: 'packet',
+  size_value: 0.32,
+  size_unit: 'oz',
+  pack_quantity: 1,
+  matched_product_id: 'product-1',
+  confidence_score: 0.95,
+  mapping_status: 'mapped',
+  created_at: '2026-07-02T00:00:00Z',
+  updated_at: '2026-07-02T00:00:00Z',
+};
+
+vi.mock('@/hooks/useReceiptImport', () => ({
+  useReceiptImport: () => ({
+    findSemanticDuplicate: vi.fn().mockResolvedValue(null),
+    findDuplicateByHash: vi.fn().mockResolvedValue(null),
+    getReceiptDetails: vi.fn().mockResolvedValue({
+      id: 'r-1',
+      restaurant_id: 'rest-123',
+      vendor_name: 'Sysco',
+      total_amount: 29.96,
+      purchase_date: '2026-05-10',
+      file_hash: 'abc',
+      created_at: '2026-05-10T00:00:00Z',
+      file_name: 'r.pdf',
+      status: 'mapped',
+    }),
+    getReceiptLineItems: vi.fn().mockResolvedValue([{ ...baseItem }]),
+    updateLineItemMapping,
+    bulkImportLineItems,
+    isUploading: false,
+    isProcessing: false,
+  }),
+}));
+
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => ({
+    selectedRestaurant: { restaurant_id: 'rest-123' },
+  }),
+}));
+
+vi.mock('@/hooks/useProducts', () => ({
+  useProducts: () => ({ products: [{ id: 'product-1', name: 'Guldens Mustard Packet' }], isLoading: false }),
+}));
+
+vi.mock('@/hooks/useSuppliers', () => ({
+  useSuppliers: () => ({ suppliers: [], createSupplier: vi.fn() }),
+}));
+
+vi.mock('@/components/ui/use-toast', () => ({
+  useToast: () => ({ toast: toastSpy }),
+}));
+
+function renderReview() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <ReceiptMappingReview receiptId="r-1" onImportComplete={vi.fn()} />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe('ReceiptMappingReview — pending write tracking survives settlement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('blocks bulk import when a field-edit write already failed before Import was clicked', async () => {
+    updateLineItemMapping.mockResolvedValue(false); // every write in this test fails
+
+    renderReview();
+
+    // The single 'mapped' item lands in the collapsed "Ready to Import" (auto-approved) section.
+    // Find its toggle by the section heading text (there's more than one "Show" button on
+    // screen — the status bar has its own toggle too).
+    const sectionHeading = await screen.findByText('Ready to Import');
+    const showToggle = sectionHeading.closest('button');
+    if (!showToggle) throw new Error('Ready to Import toggle button not found');
+    fireEvent.click(showToggle);
+
+    // Rows in the auto-approved tier also start collapsed individually — expand this one too.
+    const rowToggle = await screen.findByLabelText(/click to expand/i);
+    fireEvent.click(rowToggle);
+
+    const skuInput = await screen.findByLabelText(/SKU \/ Barcode/i);
+    fireEvent.change(skuInput, { target: { value: 'NEW-SKU' } });
+    fireEvent.blur(skuInput);
+
+    // Let the failed write settle (and, under the old bug, remove itself from tracking)
+    // *before* the user clicks Import.
+    await waitFor(() => expect(updateLineItemMapping).toHaveBeenCalledTimes(1));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const importButton = await screen.findByRole('button', { name: /import 1 item/i });
+    fireEvent.click(importButton);
+
+    await waitFor(() => {
+      expect(toastSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Unsaved changes',
+          variant: 'destructive',
+        }),
+      );
+    });
+    expect(bulkImportLineItems).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/receiptImportUtils.test.ts
+++ b/tests/unit/receiptImportUtils.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { parsePackSizeToken, computeImportedQuantity, buildLineItemInsert } from '@/utils/receiptImportUtils';
+import {
+  parsePackSizeToken,
+  computeImportedQuantity,
+  buildLineItemInsert,
+  resolveLineItemBarcode,
+  resolveBarcodeWriteBack,
+} from '@/utils/receiptImportUtils';
 
 describe('computeImportedQuantity', () => {
   it('multiplies cases by pack (butter: 2 × 4 = 8)', () => {
@@ -80,5 +86,58 @@ describe('buildLineItemInsert (DB insert mapping for process-receipt)', () => {
     const row = buildLineItemInsert('receipt-xyz', butterItem, 0);
     expect(row.pack_quantity).toBe(4);
     expect(row.parsed_quantity).toBe(8);
+  });
+});
+
+describe('resolveLineItemBarcode (auto-fill SKU/Barcode from matched product)', () => {
+  it('returns null when parsedSku is already a non-empty string (does not overwrite)', () => {
+    expect(resolveLineItemBarcode('123456', { gtin: '999999', sku: 'SKU-1' })).toBeNull();
+  });
+
+  it('returns product.gtin when parsedSku is null and gtin present', () => {
+    expect(resolveLineItemBarcode(null, { gtin: '111', sku: 'SKU-1' })).toBe('111');
+  });
+
+  it('returns product.gtin when parsedSku is empty string and gtin present', () => {
+    expect(resolveLineItemBarcode('', { gtin: '111', sku: 'SKU-1' })).toBe('111');
+  });
+
+  it('falls back to product.sku when gtin is null but sku present', () => {
+    expect(resolveLineItemBarcode(null, { gtin: null, sku: 'SKU-1' })).toBe('SKU-1');
+  });
+
+  it('falls back to product.sku when gtin is empty string but sku present', () => {
+    expect(resolveLineItemBarcode(null, { gtin: '', sku: 'SKU-1' })).toBe('SKU-1');
+  });
+
+  it('returns null when both gtin and sku are null/empty', () => {
+    expect(resolveLineItemBarcode(null, { gtin: null, sku: null })).toBeNull();
+    expect(resolveLineItemBarcode('', { gtin: '', sku: '' })).toBeNull();
+  });
+
+  it('treats a whitespace-only parsedSku as empty (fills from product)', () => {
+    expect(resolveLineItemBarcode('   ', { gtin: '111', sku: null })).toBe('111');
+  });
+});
+
+describe('resolveBarcodeWriteBack (write edited barcode back to product.gtin)', () => {
+  it('returns the trimmed value for a non-empty string', () => {
+    expect(resolveBarcodeWriteBack('  123456  ')).toBe('123456');
+  });
+
+  it('returns the value unchanged when already trimmed', () => {
+    expect(resolveBarcodeWriteBack('ABC123')).toBe('ABC123');
+  });
+
+  it('returns null for null', () => {
+    expect(resolveBarcodeWriteBack(null)).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(resolveBarcodeWriteBack('')).toBeNull();
+  });
+
+  it('returns null for a whitespace-only string', () => {
+    expect(resolveBarcodeWriteBack('   ')).toBeNull();
   });
 });

--- a/tests/unit/useReceiptImport.barcodeWriteBack.test.ts
+++ b/tests/unit/useReceiptImport.barcodeWriteBack.test.ts
@@ -145,17 +145,20 @@ describe('useReceiptImport — bulkImportLineItems mapped-branch barcode write-b
     );
   });
 
-  it('omits gtin from the update when parsed_sku is null/empty/whitespace-only', async () => {
-    const { productUpdateBuilder } = setupMocks({
-      lineItems: [{ ...baseLineItem, parsed_sku: '   ' }],
-    });
+  it.each([null, '', '   '])(
+    'omits gtin from the update when parsed_sku is %p',
+    async (parsedSku) => {
+      const { productUpdateBuilder } = setupMocks({
+        lineItems: [{ ...baseLineItem, parsed_sku: parsedSku }],
+      });
 
-    const { result } = renderHook(() => useReceiptImport());
-    await result.current.bulkImportLineItems('r-1');
+      const { result } = renderHook(() => useReceiptImport());
+      await result.current.bulkImportLineItems('r-1');
 
-    const updateCall = productUpdateBuilder.update.mock.calls[0][0] as Record<string, unknown>;
-    expect(updateCall).not.toHaveProperty('gtin');
-  });
+      const updateCall = productUpdateBuilder.update.mock.calls[0][0] as Record<string, unknown>;
+      expect(updateCall).not.toHaveProperty('gtin');
+    },
+  );
 
   it('never includes a sku key in the update payload (write-back targets gtin only)', async () => {
     const { productUpdateBuilder } = setupMocks({

--- a/tests/unit/useReceiptImport.barcodeWriteBack.test.ts
+++ b/tests/unit/useReceiptImport.barcodeWriteBack.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useReceiptImport } from '@/hooks/useReceiptImport';
+
+const mockSupabase = vi.hoisted(() => ({
+  from: vi.fn(),
+  storage: { from: vi.fn() },
+  functions: { invoke: vi.fn() },
+  rpc: vi.fn(),
+}));
+
+const toastSpy = vi.fn();
+
+vi.mock('@/integrations/supabase/client', () => ({ supabase: mockSupabase }));
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: toastSpy }) }));
+vi.mock('@/components/ui/use-toast', () => ({ useToast: () => ({ toast: toastSpy }) }));
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => ({
+    selectedRestaurant: { restaurant_id: 'rest-123' },
+  }),
+}));
+
+// A thenable, chainable Postgrest-like builder: every filter/modifier method
+// returns itself (for chaining), and awaiting the builder directly (no
+// terminal .single()/.maybeSingle() call) resolves to `result` — matching how
+// supabase-js query builders are both chainable and awaitable.
+function makeThenableBuilder(result: { data?: unknown; error?: unknown } = { data: null, error: null }) {
+  const builder: Record<string, unknown> = {};
+  ['select', 'eq', 'in', 'order', 'update', 'insert', 'upsert'].forEach((method) => {
+    builder[method] = vi.fn(() => builder);
+  });
+  builder.single = vi.fn().mockResolvedValue(result);
+  builder.maybeSingle = vi.fn().mockResolvedValue(result);
+  (builder as { then: unknown }).then = (
+    onFulfilled?: (value: typeof result) => unknown,
+    onRejected?: (reason: unknown) => unknown,
+  ) => Promise.resolve(result).then(onFulfilled, onRejected);
+  return builder as Record<string, ReturnType<typeof vi.fn>> & PromiseLike<typeof result>;
+}
+
+const baseLineItem = {
+  id: 'li-1',
+  receipt_id: 'r-1',
+  raw_text: 'WIDGET 12CT',
+  parsed_name: 'Widget',
+  parsed_quantity: 2,
+  parsed_unit: 'each',
+  parsed_price: 20,
+  unit_price: null,
+  matched_product_id: 'prod-1',
+  confidence_score: 0.9,
+  mapping_status: 'mapped',
+  parsed_sku: null as string | null,
+};
+
+interface Setup {
+  lineItems?: Array<Record<string, unknown>>;
+  productSelectResult?: { data: unknown; error: unknown };
+  productUpdateResult?: { data: unknown; error: unknown };
+}
+
+function setupMocks({
+  lineItems = [baseLineItem],
+  productSelectResult = { data: { current_stock: 5, receipt_item_names: [] }, error: null },
+  productUpdateResult = { data: { id: 'prod-1' }, error: null },
+}: Setup = {}) {
+  const lineItemsBuilder = makeThenableBuilder({ data: lineItems, error: null });
+  const receiptImportsReadBuilder = makeThenableBuilder({
+    data: { vendor_name: 'Sysco', supplier_id: null, purchase_date: '2026-01-01' },
+    error: null,
+  });
+  const receiptImportsUpdateBuilder = makeThenableBuilder({ data: null, error: null });
+
+  const productSelectBuilder = makeThenableBuilder(productSelectResult);
+  const productUpdateBuilder = makeThenableBuilder(productUpdateResult);
+
+  const inventoryTransactionsBuilder = makeThenableBuilder({ data: null, error: null });
+
+  let receiptImportsCallCount = 0;
+  let productsCallCount = 0;
+
+  mockSupabase.from.mockImplementation((table: string) => {
+    if (table === 'receipt_line_items') return lineItemsBuilder;
+    if (table === 'receipt_imports') {
+      receiptImportsCallCount += 1;
+      return receiptImportsCallCount === 1 ? receiptImportsReadBuilder : receiptImportsUpdateBuilder;
+    }
+    if (table === 'products') {
+      productsCallCount += 1;
+      return productsCallCount === 1 ? productSelectBuilder : productUpdateBuilder;
+    }
+    if (table === 'inventory_transactions') return inventoryTransactionsBuilder;
+    throw new Error(`unexpected table: ${table}`);
+  });
+
+  return { productSelectBuilder, productUpdateBuilder, lineItemsBuilder };
+}
+
+describe('useReceiptImport — bulkImportLineItems mapped-branch barcode write-back (Expectation B)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reads current_stock and receipt_item_names in a single restaurant_id-scoped select', async () => {
+    const { productSelectBuilder } = setupMocks();
+
+    const { result } = renderHook(() => useReceiptImport());
+    await result.current.bulkImportLineItems('r-1');
+
+    expect(productSelectBuilder.select).toHaveBeenCalledTimes(1);
+    expect(productSelectBuilder.select).toHaveBeenCalledWith(expect.stringContaining('current_stock'));
+    expect(productSelectBuilder.select).toHaveBeenCalledWith(expect.stringContaining('receipt_item_names'));
+    expect(productSelectBuilder.eq).toHaveBeenCalledWith('id', 'prod-1');
+    expect(productSelectBuilder.eq).toHaveBeenCalledWith('restaurant_id', 'rest-123');
+    expect(productSelectBuilder.maybeSingle).toHaveBeenCalled();
+  });
+
+  it('writes the edited parsed_sku to product.gtin on the scoped update', async () => {
+    const { productUpdateBuilder } = setupMocks({
+      lineItems: [{ ...baseLineItem, parsed_sku: '012345678905' }],
+    });
+
+    const { result } = renderHook(() => useReceiptImport());
+    await result.current.bulkImportLineItems('r-1');
+
+    expect(productUpdateBuilder.update).toHaveBeenCalledWith(
+      expect.objectContaining({ gtin: '012345678905' }),
+    );
+    expect(productUpdateBuilder.eq).toHaveBeenCalledWith('id', 'prod-1');
+    expect(productUpdateBuilder.eq).toHaveBeenCalledWith('restaurant_id', 'rest-123');
+    expect(productUpdateBuilder.select).toHaveBeenCalledWith('id');
+    expect(productUpdateBuilder.maybeSingle).toHaveBeenCalled();
+  });
+
+  it('trims whitespace before writing the barcode back', async () => {
+    const { productUpdateBuilder } = setupMocks({
+      lineItems: [{ ...baseLineItem, parsed_sku: '  012345678905  ' }],
+    });
+
+    const { result } = renderHook(() => useReceiptImport());
+    await result.current.bulkImportLineItems('r-1');
+
+    expect(productUpdateBuilder.update).toHaveBeenCalledWith(
+      expect.objectContaining({ gtin: '012345678905' }),
+    );
+  });
+
+  it('omits gtin from the update when parsed_sku is null/empty/whitespace-only', async () => {
+    const { productUpdateBuilder } = setupMocks({
+      lineItems: [{ ...baseLineItem, parsed_sku: '   ' }],
+    });
+
+    const { result } = renderHook(() => useReceiptImport());
+    await result.current.bulkImportLineItems('r-1');
+
+    const updateCall = productUpdateBuilder.update.mock.calls[0][0] as Record<string, unknown>;
+    expect(updateCall).not.toHaveProperty('gtin');
+  });
+
+  it('never includes a sku key in the update payload (write-back targets gtin only)', async () => {
+    const { productUpdateBuilder } = setupMocks({
+      lineItems: [{ ...baseLineItem, parsed_sku: 'ABC-123' }],
+    });
+
+    const { result } = renderHook(() => useReceiptImport());
+    await result.current.bulkImportLineItems('r-1');
+
+    const updateCall = productUpdateBuilder.update.mock.calls[0][0] as Record<string, unknown>;
+    expect(updateCall).not.toHaveProperty('sku');
+  });
+
+  it('skips the item without throwing when the scoped read returns no row (stale/cross-tenant match)', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { productUpdateBuilder } = setupMocks({
+      productSelectResult: { data: null, error: null },
+    });
+
+    const { result } = renderHook(() => useReceiptImport());
+    const ok = await result.current.bulkImportLineItems('r-1');
+
+    expect(ok).toBe(true);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    expect(productUpdateBuilder.update).not.toHaveBeenCalled();
+    expect(toastSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ description: expect.stringContaining('0 items') }),
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('treats a 0-row (silent no-op) update result as a logged failure, not a success', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    setupMocks({
+      productUpdateResult: { data: null, error: null },
+    });
+
+    const { result } = renderHook(() => useReceiptImport());
+    const ok = await result.current.bulkImportLineItems('r-1');
+
+    expect(ok).toBe(true);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    expect(toastSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ description: expect.stringContaining('0 items') }),
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/tests/unit/useReceiptImport.barcodeWriteBack.test.ts
+++ b/tests/unit/useReceiptImport.barcodeWriteBack.test.ts
@@ -184,8 +184,13 @@ describe('useReceiptImport — bulkImportLineItems mapped-branch barcode write-b
     expect(ok).toBe(true);
     expect(consoleErrorSpy).toHaveBeenCalled();
     expect(productUpdateBuilder.update).not.toHaveBeenCalled();
+    // A skipped item must surface as a partial import, not a silent "Success".
     expect(toastSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ description: expect.stringContaining('0 items') }),
+      expect.objectContaining({
+        title: 'Partial Import',
+        description: expect.stringContaining('1 item(s) failed'),
+        variant: 'destructive',
+      }),
     );
 
     consoleErrorSpy.mockRestore();
@@ -203,7 +208,11 @@ describe('useReceiptImport — bulkImportLineItems mapped-branch barcode write-b
     expect(ok).toBe(true);
     expect(consoleErrorSpy).toHaveBeenCalled();
     expect(toastSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ description: expect.stringContaining('0 items') }),
+      expect.objectContaining({
+        title: 'Partial Import',
+        description: expect.stringContaining('1 item(s) failed'),
+        variant: 'destructive',
+      }),
     );
 
     consoleErrorSpy.mockRestore();

--- a/tests/unit/useReceiptImport.skuEnrichment.test.ts
+++ b/tests/unit/useReceiptImport.skuEnrichment.test.ts
@@ -38,7 +38,8 @@ function makeLineItemsBuilder(rows: unknown[]) {
 function makeProductsBuilder(rows: unknown[]) {
   const builder: Record<string, ReturnType<typeof vi.fn>> = {};
   builder.select = vi.fn(() => builder);
-  builder.in = vi.fn().mockResolvedValue({ data: rows, error: null });
+  builder.in = vi.fn(() => builder);
+  builder.eq = vi.fn().mockResolvedValue({ data: rows, error: null });
   return builder;
 }
 
@@ -89,6 +90,20 @@ describe('useReceiptImport — getReceiptLineItems SKU/Barcode auto-fill (Expect
     expect(productsBuilder.select).toHaveBeenCalledWith(expect.stringContaining('sku'));
   });
 
+  it('scopes the enrichment query to the selected restaurant', async () => {
+    const row = { ...baseRow, parsed_sku: null };
+    const product = { id: 'prod-1', size_value: null, size_unit: null, uom_purchase: null, gtin: '012345678905', sku: 'SKU-1' };
+
+    const lineItemsBuilder = makeLineItemsBuilder([row]);
+    const productsBuilder = makeProductsBuilder([product]);
+    mockFromByTable(lineItemsBuilder, productsBuilder);
+
+    const { result } = renderHook(() => useReceiptImport());
+    await result.current.getReceiptLineItems('r-1');
+
+    expect(productsBuilder.eq).toHaveBeenCalledWith('restaurant_id', 'rest-123');
+  });
+
   it('auto-fills parsed_sku from the matched product gtin when the line item has none', async () => {
     const row = { ...baseRow, parsed_sku: null };
     const product = { id: 'prod-1', size_value: null, size_unit: null, uom_purchase: null, gtin: '012345678905', sku: 'SKU-1' };
@@ -103,9 +118,23 @@ describe('useReceiptImport — getReceiptLineItems SKU/Barcode auto-fill (Expect
     expect(items[0].parsed_sku).toBe('012345678905');
   });
 
-  it('falls back to the matched product sku when gtin is empty', async () => {
+  it('falls back to the matched product sku when gtin is null', async () => {
     const row = { ...baseRow, parsed_sku: null };
     const product = { id: 'prod-1', size_value: null, size_unit: null, uom_purchase: null, gtin: null, sku: 'SKU-1' };
+
+    const lineItemsBuilder = makeLineItemsBuilder([row]);
+    const productsBuilder = makeProductsBuilder([product]);
+    mockFromByTable(lineItemsBuilder, productsBuilder);
+
+    const { result } = renderHook(() => useReceiptImport());
+    const items = await result.current.getReceiptLineItems('r-1');
+
+    expect(items[0].parsed_sku).toBe('SKU-1');
+  });
+
+  it('falls back to the matched product sku when gtin is an empty string', async () => {
+    const row = { ...baseRow, parsed_sku: null };
+    const product = { id: 'prod-1', size_value: null, size_unit: null, uom_purchase: null, gtin: '', sku: 'SKU-1' };
 
     const lineItemsBuilder = makeLineItemsBuilder([row]);
     const productsBuilder = makeProductsBuilder([product]);

--- a/tests/unit/useReceiptImport.skuEnrichment.test.ts
+++ b/tests/unit/useReceiptImport.skuEnrichment.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useReceiptImport } from '@/hooks/useReceiptImport';
+
+const mockSupabase = vi.hoisted(() => ({
+  from: vi.fn(),
+  storage: { from: vi.fn() },
+  functions: { invoke: vi.fn() },
+  rpc: vi.fn(),
+}));
+
+const toastSpy = vi.fn();
+
+vi.mock('@/integrations/supabase/client', () => ({ supabase: mockSupabase }));
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: toastSpy }) }));
+vi.mock('@/components/ui/use-toast', () => ({ useToast: () => ({ toast: toastSpy }) }));
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => ({
+    selectedRestaurant: { restaurant_id: 'rest-123' },
+  }),
+}));
+vi.mock('@/services/receiptTextNormalizer', () => ({
+  ReceiptTextNormalizer: {
+    loadCustomMappings: vi.fn().mockResolvedValue(undefined),
+    generateSearchVariants: vi.fn().mockReturnValue([]),
+    learnFromCorrection: vi.fn().mockResolvedValue(undefined),
+  },
+}));
+
+function makeLineItemsBuilder(rows: unknown[]) {
+  const builder: Record<string, ReturnType<typeof vi.fn>> = {};
+  builder.select = vi.fn(() => builder);
+  builder.eq = vi.fn(() => builder);
+  builder.order = vi.fn().mockResolvedValue({ data: rows, error: null });
+  return builder;
+}
+
+function makeProductsBuilder(rows: unknown[]) {
+  const builder: Record<string, ReturnType<typeof vi.fn>> = {};
+  builder.select = vi.fn(() => builder);
+  builder.in = vi.fn().mockResolvedValue({ data: rows, error: null });
+  return builder;
+}
+
+function mockFromByTable(lineItemsBuilder: ReturnType<typeof makeLineItemsBuilder>, productsBuilder: ReturnType<typeof makeProductsBuilder>) {
+  mockSupabase.from.mockImplementation((table: string) => {
+    if (table === 'receipt_line_items') return lineItemsBuilder;
+    if (table === 'products') return productsBuilder;
+    throw new Error(`unexpected table: ${table}`);
+  });
+}
+
+const baseRow = {
+  id: 'li-1',
+  receipt_id: 'r-1',
+  raw_text: 'WIDGET 12CT',
+  parsed_name: 'Widget',
+  parsed_quantity: 1,
+  parsed_unit: 'each',
+  parsed_price: 10,
+  matched_product_id: 'prod-1',
+  confidence_score: 0.9,
+  mapping_status: 'mapped',
+  package_type: null,
+  size_value: null,
+  size_unit: null,
+  pack_quantity: null,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+describe('useReceiptImport — getReceiptLineItems SKU/Barcode auto-fill (Expectation A)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('selects gtin and sku on the products enrichment query', async () => {
+    const row = { ...baseRow, parsed_sku: null };
+    const product = { id: 'prod-1', size_value: null, size_unit: null, uom_purchase: null, gtin: '012345678905', sku: 'SKU-1' };
+
+    const lineItemsBuilder = makeLineItemsBuilder([row]);
+    const productsBuilder = makeProductsBuilder([product]);
+    mockFromByTable(lineItemsBuilder, productsBuilder);
+
+    const { result } = renderHook(() => useReceiptImport());
+    await result.current.getReceiptLineItems('r-1');
+
+    expect(productsBuilder.select).toHaveBeenCalledWith(expect.stringContaining('gtin'));
+    expect(productsBuilder.select).toHaveBeenCalledWith(expect.stringContaining('sku'));
+  });
+
+  it('auto-fills parsed_sku from the matched product gtin when the line item has none', async () => {
+    const row = { ...baseRow, parsed_sku: null };
+    const product = { id: 'prod-1', size_value: null, size_unit: null, uom_purchase: null, gtin: '012345678905', sku: 'SKU-1' };
+
+    const lineItemsBuilder = makeLineItemsBuilder([row]);
+    const productsBuilder = makeProductsBuilder([product]);
+    mockFromByTable(lineItemsBuilder, productsBuilder);
+
+    const { result } = renderHook(() => useReceiptImport());
+    const items = await result.current.getReceiptLineItems('r-1');
+
+    expect(items[0].parsed_sku).toBe('012345678905');
+  });
+
+  it('falls back to the matched product sku when gtin is empty', async () => {
+    const row = { ...baseRow, parsed_sku: null };
+    const product = { id: 'prod-1', size_value: null, size_unit: null, uom_purchase: null, gtin: null, sku: 'SKU-1' };
+
+    const lineItemsBuilder = makeLineItemsBuilder([row]);
+    const productsBuilder = makeProductsBuilder([product]);
+    mockFromByTable(lineItemsBuilder, productsBuilder);
+
+    const { result } = renderHook(() => useReceiptImport());
+    const items = await result.current.getReceiptLineItems('r-1');
+
+    expect(items[0].parsed_sku).toBe('SKU-1');
+  });
+
+  it('does not overwrite an existing (non-empty) parsed_sku', async () => {
+    const row = { ...baseRow, parsed_sku: 'EXISTING-SKU' };
+    const product = { id: 'prod-1', size_value: null, size_unit: null, uom_purchase: null, gtin: '012345678905', sku: 'SKU-1' };
+
+    const lineItemsBuilder = makeLineItemsBuilder([row]);
+    const productsBuilder = makeProductsBuilder([product]);
+    mockFromByTable(lineItemsBuilder, productsBuilder);
+
+    const { result } = renderHook(() => useReceiptImport());
+    const items = await result.current.getReceiptLineItems('r-1');
+
+    expect(items[0].parsed_sku).toBe('EXISTING-SKU');
+  });
+
+  it('leaves parsed_sku null when the matched product has neither gtin nor sku', async () => {
+    const row = { ...baseRow, parsed_sku: null };
+    const product = { id: 'prod-1', size_value: null, size_unit: null, uom_purchase: null, gtin: null, sku: null };
+
+    const lineItemsBuilder = makeLineItemsBuilder([row]);
+    const productsBuilder = makeProductsBuilder([product]);
+    mockFromByTable(lineItemsBuilder, productsBuilder);
+
+    const { result } = renderHook(() => useReceiptImport());
+    const items = await result.current.getReceiptLineItems('r-1');
+
+    expect(items[0].parsed_sku).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Auto-fill the SKU/Barcode field in the receipt mapping review from the matched product's `gtin` (falling back to `sku`), without overwriting a value already parsed from the receipt.
- Write an edited SKU/Barcode value back to the matched product's `gtin` column during bulk import, scoped by `restaurant_id`, so barcode corrections made during receipt import persist to the product record.
- Commit the SKU/Barcode field on blur instead of on every keystroke, and only when the value actually changed, to avoid a write race and unnecessary writes on untouched auto-filled fields.
- Await all pending per-row field-edit writes (aborting the import with a toast if any failed) before `bulkImportLineItems` re-reads `receipt_line_items`, so a blur-then-immediately-click-Import can't import a stale value.
- Scope the mapped-branch product read/update by `restaurant_id` throughout (enrichment SELECT and the bulk-import UPDATE), closing a cross-tenant read gap flagged in review.
- No DB migration — `gtin`/`sku`/`restaurant_id` already exist on `products` in production; no unique constraint added.

## Test plan
- [x] New/updated unit tests: `tests/unit/receiptImportUtils.test.ts` (pure helpers), `tests/unit/useReceiptImport.skuEnrichment.test.ts`, `tests/unit/useReceiptImport.barcodeWriteBack.test.ts`, `tests/unit/ReceiptItemRow.skuBlur.test.tsx`
- [x] `npm run test` — full suite green (7511 passed / 2 skipped)
- [x] `npm run test:db` — pgTAP suite green after a clean `db:reset` (2055/2055)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — no new errors introduced (diffed against merge-base; only pre-existing repo-wide debt on unchanged lines)
- [x] `npm run test:e2e` — 157 passed / 12 skipped; the 2 failures are in specs unrelated to receipt-import (POS manual-sale-tip, overnight-shift-hours), confirmed pre-existing/unrelated to this diff
- [x] `npm run build` — succeeds
- [x] CodeRabbit review (`coderabbit review --committed`) run to convergence — actionable findings fixed across two iterations (restaurant scoping, abort-on-failed-write, test edge cases), final iteration clean

Design doc: [`docs/superpowers/specs/2026-07-24-receipt-import-barcode-sync-design.md`](https://github.com/toyiyo/nimble-pnl/blob/fix/receipt-import-barcode-sync/docs/superpowers/specs/2026-07-24-receipt-import-barcode-sync-design.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically fills receipt item SKU/barcode fields from matched product data.
  * Saves edited SKU/barcode values to the matched product.
  * Commits barcode edits when the field loses focus, reducing update conflicts.
  * Prevents bulk imports from proceeding while item updates are pending.

* **Bug Fixes**
  * Improved data scoping and error handling during receipt imports.
  * Prevents stale updates and handles failed product updates safely.

* **Tests**
  * Added coverage for barcode autofill, editing, persistence, and import synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->