### PR TITLE
feat(inventory): manual tap-to-count entry path (Count button on product cards)

### DIFF
--- a/docs/superpowers/plans/2026-07-24-inventory-tap-to-count-plan.md
+++ b/docs/superpowers/plans/2026-07-24-inventory-tap-to-count-plan.md
@@ -1,0 +1,420 @@
+# Manual "Tap-to-Count" Entry Path for Inventory — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a dedicated "Count" button to each product card on the Inventory products grid that opens the existing `QuickInventoryDialog` directly, independent of barcode scanning.
+
+**Architecture:** Introduce a pure audit-string helper (`buildQuickInventoryAudit`) so the save handler stops hardcoding scan-only wording; add an `onCountProduct` callback prop to `VirtualizedProductGrid` that renders a full-width "Count" button in a new `CardFooter`; wire that callback in `Inventory.tsx` to the already-existing quick-inventory dialog flow, tagging the entry source so the audit log stays accurate.
+
+**Tech Stack:** React 18.3 + TypeScript, Vite, Vitest + React Testing Library, TailwindCSS, shadcn/ui, lucide-react.
+
+## Global Constraints
+
+- Semantic tokens only — never `bg-white`/`text-black`. Count button uses the CLAUDE.md primary treatment verbatim: `h-9 px-4 rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium` (plus `w-full` in the footer). `transition-colors` on hover.
+- Every interactive control needs an `aria-label` when it has no text (the Count button has visible text AND an `aria-label` for the per-product name; its icon is `aria-hidden`).
+- Audit `reason` strings must reproduce today's scan-path wording **byte-for-byte**, interpolating the **raw, unformatted** `quantity` (no `.toFixed()`):
+  - `scan` + `add` → `Adjustment - Added ${quantity} via quick scan`
+  - `scan` + `reconcile` → `Inventory reconciliation - Set to ${quantity} via quick scan`
+  - `manual` + `add` → `Adjustment - Added ${quantity} via manual count`
+  - `manual` + `reconcile` → `Inventory reconciliation - Set to ${quantity} via manual count`
+- Audit `reference` = `${source === 'manual' ? 'manual_count' : 'quick_scan'}_${timestamp}`.
+- Multi-tenancy unchanged: all writes continue through the existing `updateProductStockWithAudit` path (no new DB/RPC/RLS surface).
+- No manual caching; no new React Query keys. This change adds a UI trigger, not a data flow.
+- TDD: write the failing test first, watch it fail, implement minimally, watch it pass, commit.
+
+---
+
+### Task 1: Pure audit-string helper `buildQuickInventoryAudit`
+
+**Files:**
+- Create: `src/utils/quickInventoryAudit.ts`
+- Test: `tests/unit/quickInventoryAudit.test.ts`
+
+**Interfaces:**
+- Consumes: nothing (leaf util).
+- Produces:
+  ```ts
+  export type QuickEntrySource = 'scan' | 'manual';
+  export type QuickEntryMode = 'add' | 'reconcile';
+  export function buildQuickInventoryAudit(
+    source: QuickEntrySource,
+    mode: QuickEntryMode,
+    quantity: number,
+    timestamp: number,
+  ): { reason: string; reference: string };
+  ```
+  Task 3 (`Inventory.tsx`) calls this with `(quickEntrySource, scanMode, quantity, Date.now())`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/quickInventoryAudit.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { buildQuickInventoryAudit } from '@/utils/quickInventoryAudit';
+
+describe('buildQuickInventoryAudit', () => {
+  it('preserves the exact scan + add wording (raw quantity, no rounding)', () => {
+    const { reason } = buildQuickInventoryAudit('scan', 'add', 3.5, 1000);
+    expect(reason).toBe('Adjustment - Added 3.5 via quick scan');
+  });
+
+  it('preserves the exact scan + reconcile wording', () => {
+    const { reason } = buildQuickInventoryAudit('scan', 'reconcile', 12, 1000);
+    expect(reason).toBe('Inventory reconciliation - Set to 12 via quick scan');
+  });
+
+  it('labels manual + add as "via manual count"', () => {
+    const { reason } = buildQuickInventoryAudit('manual', 'add', 3.5, 1000);
+    expect(reason).toBe('Adjustment - Added 3.5 via manual count');
+  });
+
+  it('labels manual + reconcile as "via manual count"', () => {
+    const { reason } = buildQuickInventoryAudit('manual', 'reconcile', 12, 1000);
+    expect(reason).toBe('Inventory reconciliation - Set to 12 via manual count');
+  });
+
+  it('prefixes the scan reference with quick_scan_ and includes the timestamp', () => {
+    const { reference } = buildQuickInventoryAudit('scan', 'add', 1, 1737700000000);
+    expect(reference).toBe('quick_scan_1737700000000');
+  });
+
+  it('prefixes the manual reference with manual_count_ and includes the timestamp', () => {
+    const { reference } = buildQuickInventoryAudit('manual', 'add', 1, 1737700000000);
+    expect(reference).toBe('manual_count_1737700000000');
+  });
+
+  it('does not round or reformat the quantity', () => {
+    const { reason } = buildQuickInventoryAudit('manual', 'add', 0.333333, 1000);
+    expect(reason).toBe('Adjustment - Added 0.333333 via manual count');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test -- tests/unit/quickInventoryAudit.test.ts`
+Expected: FAIL — cannot resolve `@/utils/quickInventoryAudit` (module does not exist yet).
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `src/utils/quickInventoryAudit.ts`:
+
+```ts
+export type QuickEntrySource = 'scan' | 'manual';
+export type QuickEntryMode = 'add' | 'reconcile';
+
+/**
+ * Builds the audit `reason` and `reference` strings for a quick-inventory write.
+ *
+ * The scan-path strings are reproduced byte-for-byte from the pre-existing
+ * inline literals in Inventory.tsx (raw, unformatted `quantity`), so extracting
+ * this helper cannot silently change historical scan audit wording. The manual
+ * variants say "via manual count" so the audit log distinguishes provenance.
+ */
+export function buildQuickInventoryAudit(
+  source: QuickEntrySource,
+  mode: QuickEntryMode,
+  quantity: number,
+  timestamp: number,
+): { reason: string; reference: string } {
+  const via = source === 'manual' ? 'via manual count' : 'via quick scan';
+  const reason =
+    mode === 'add'
+      ? `Adjustment - Added ${quantity} ${via}`
+      : `Inventory reconciliation - Set to ${quantity} ${via}`;
+  const referencePrefix = source === 'manual' ? 'manual_count' : 'quick_scan';
+  const reference = `${referencePrefix}_${timestamp}`;
+  return { reason, reference };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm run test -- tests/unit/quickInventoryAudit.test.ts`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/utils/quickInventoryAudit.ts tests/unit/quickInventoryAudit.test.ts
+git commit -m "feat(inventory): add pure audit-string helper for quick-inventory writes"
+```
+
+---
+
+### Task 2: "Count" button on `VirtualizedProductGrid` product cards
+
+**Files:**
+- Modify: `src/components/inventory/VirtualizedProductGrid.tsx`
+- Test: `tests/unit/VirtualizedProductGrid.test.tsx`
+
+**Interfaces:**
+- Consumes: nothing from Task 1 (pure UI).
+- Produces: a new required prop on `VirtualizedProductGridProps`:
+  ```ts
+  onCountProduct: (product: Product) => void;
+  ```
+  Task 3 (`Inventory.tsx`) supplies this prop.
+
+**Context before editing:**
+- `CardFooter` is already exported from `src/components/ui/card.tsx` but is currently unused by `ProductCard`. Render the button inside a new `CardFooter` — a **sibling** of the `CardContent` that owns `onClick={onEdit}` — so a footer click never bubbles to Edit. No `stopPropagation()` is needed at this placement. (If the button ever moves inside `CardContent`, it MUST call `e.stopPropagation()` — see the recipe `Link` at `VirtualizedProductGrid.tsx:268`.)
+- `ESTIMATED_ROW_HEIGHT` is at `VirtualizedProductGrid.tsx:51` (currently `320`). Bump it to `380` to account for the added footer so first paint is closer before `measureElement` corrects the real height.
+- `Calculator` comes from `lucide-react`. Add it to the existing lucide import.
+
+- [ ] **Step 1: Write the failing test**
+
+First confirm how the existing grid test (if any) renders the grid, so the new test reuses its harness/mock props:
+
+Run: `ls tests/unit | grep -i VirtualizedProductGrid`
+
+- If a test file exists, ADD the `describe('Count button', ...)` block below to it and reuse its existing render helper / mock product factory (adjust the import and prop names to match). Do NOT duplicate an entire second harness.
+- If no test file exists, create `tests/unit/VirtualizedProductGrid.test.tsx` with the full block below.
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { VirtualizedProductGrid } from '@/components/inventory/VirtualizedProductGrid';
+
+// Minimal product matching the fields ProductCard reads. If the existing test
+// file already has a factory, use that instead of this literal.
+const product = {
+  id: 'p1',
+  name: 'Tomatoes',
+  current_stock: 5,
+  uom_purchase: 'kg',
+  // add any other non-optional fields the component dereferences:
+} as any;
+
+function renderGrid(overrides: Record<string, any> = {}) {
+  const props = {
+    products: [product],
+    onEditProduct: vi.fn(),
+    onCountProduct: vi.fn(),
+    onWasteProduct: vi.fn(),
+    onTransferProduct: vi.fn(),
+    onDeleteProduct: vi.fn(),
+    ...overrides,
+  };
+  render(
+    <MemoryRouter>
+      <VirtualizedProductGrid {...(props as any)} />
+    </MemoryRouter>,
+  );
+  return props;
+}
+
+describe('Count button', () => {
+  it('renders one Count button per card with a per-product aria-label', () => {
+    renderGrid();
+    expect(
+      screen.getByRole('button', { name: 'Count Tomatoes' }),
+    ).toBeInTheDocument();
+  });
+
+  it('calls onCountProduct with the product when clicked', async () => {
+    const props = renderGrid();
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Count Tomatoes' }),
+    );
+    expect(props.onCountProduct).toHaveBeenCalledWith(product);
+  });
+
+  it('does not trigger the card-tap Edit handler when Count is clicked', async () => {
+    const props = renderGrid();
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Count Tomatoes' }),
+    );
+    expect(props.onEditProduct).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test -- tests/unit/VirtualizedProductGrid.test.tsx`
+Expected: FAIL — `Unable to find an accessible element with the role "button" and name "Count Tomatoes"` (button not rendered yet). If it instead fails on a missing required field in the mock `product`, add that field to the literal and re-run until the failure is the missing button.
+
+- [ ] **Step 3: Add the prop to the grid's props interface**
+
+In `src/components/inventory/VirtualizedProductGrid.tsx`, add to `VirtualizedProductGridProps` (next to `onEditProduct`):
+
+```tsx
+  onCountProduct: (product: Product) => void;
+```
+
+Destructure `onCountProduct` in the `VirtualizedProductGrid` component signature alongside the other `on*Product` props, and pass it into each rendered `ProductCard` in the `.map()` as:
+
+```tsx
+onCount={() => onCountProduct(product)}
+```
+
+- [ ] **Step 4: Add `onCount` to `ProductCard` and render the button**
+
+Add `onCount: () => void;` to `ProductCard`'s props type and destructure it. Add `Calculator` to the `lucide-react` import. After the closing `</CardContent>`, add a new footer as a sibling:
+
+```tsx
+<CardFooter className="pt-0">
+  <Button
+    onClick={onCount}
+    aria-label={`Count ${product.name}`}
+    title="Count"
+    className="w-full h-9 rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium transition-colors"
+  >
+    <Calculator className="h-4 w-4 mr-2" aria-hidden="true" />
+    Count
+  </Button>
+</CardFooter>
+```
+
+Ensure `CardFooter` is imported from `@/components/ui/card` (add it to the existing card import if not already present) and `Button` from `@/components/ui/button` (already imported).
+
+- [ ] **Step 5: Bump the estimated row height**
+
+At `VirtualizedProductGrid.tsx:51`, change:
+
+```tsx
+const ESTIMATED_ROW_HEIGHT = 320;
+```
+to:
+```tsx
+const ESTIMATED_ROW_HEIGHT = 380;
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `npm run test -- tests/unit/VirtualizedProductGrid.test.tsx`
+Expected: PASS (3 Count-button tests, plus any pre-existing tests in the file still green).
+
+- [ ] **Step 7: Typecheck**
+
+Run: `npm run typecheck`
+Expected: no errors. (`onCountProduct` is now required on `VirtualizedProductGridProps`; the only caller is `Inventory.tsx`, wired in Task 3 — if typecheck flags that call site now, that is expected and resolved in Task 3. If you are running tasks strictly in order, run typecheck again at the end of Task 3.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/inventory/VirtualizedProductGrid.tsx tests/unit/VirtualizedProductGrid.test.tsx
+git commit -m "feat(inventory): add Count button to product cards in VirtualizedProductGrid"
+```
+
+---
+
+### Task 3: Wire the Count trigger and audit source in `Inventory.tsx`
+
+**Files:**
+- Modify: `src/pages/Inventory.tsx`
+
+**Interfaces:**
+- Consumes: `buildQuickInventoryAudit` (Task 1) and the `onCountProduct` prop (Task 2).
+- Produces: nothing downstream (page is a leaf consumer).
+
+**Context before editing (verify line numbers with grep — they drift):**
+- State block near line ~85: `quickInventoryProduct`, `showQuickInventoryDialog`, `scanMode`.
+- `handleBarcodeScanned` near line ~493 opens the dialog for the scan path.
+- `handleQuickInventorySave(quantity)` near line ~948 currently builds the reason/reference inline (the `via quick scan` literals at ~963/967 and `quick_scan_${Date.now()}`).
+- The `<VirtualizedProductGrid ... />` render near line ~1708.
+
+Run this first to re-anchor:
+
+```bash
+grep -n "quickEntrySource\|via quick scan\|quick_scan_\|scanMode\|VirtualizedProductGrid\|handleQuickInventorySave" src/pages/Inventory.tsx
+```
+
+- [ ] **Step 1: Add the entry-source state**
+
+Import the helper and its type near the other `@/utils` imports:
+
+```tsx
+import { buildQuickInventoryAudit, type QuickEntrySource } from '@/utils/quickInventoryAudit';
+```
+
+Next to the `scanMode` state declaration, add:
+
+```tsx
+const [quickEntrySource, setQuickEntrySource] = useState<QuickEntrySource>('scan');
+```
+
+- [ ] **Step 2: Tag the scan path as `'scan'`**
+
+In `handleBarcodeScanned` (the existing scan trigger), immediately before it sets `setShowQuickInventoryDialog(true)`, add:
+
+```tsx
+setQuickEntrySource('scan');
+```
+
+(Preserves current behavior — scan writes stay labeled "via quick scan".)
+
+- [ ] **Step 3: Wire `onCountProduct` on the grid**
+
+On the `<VirtualizedProductGrid ... />` element, add the prop:
+
+```tsx
+onCountProduct={(product) => {
+  setScanMode('add');
+  setQuickEntrySource('manual');
+  setQuickInventoryProduct(product);
+  setShowQuickInventoryDialog(true);
+}}
+```
+
+- [ ] **Step 4: Replace the inline audit literals in `handleQuickInventorySave`**
+
+In `handleQuickInventorySave`, replace the inline `reason` (the `scanMode === 'add' ? 'Adjustment - Added ... via quick scan' : 'Inventory reconciliation - Set to ... via quick scan'` expression) and the `quick_scan_${Date.now()}` reference with a single call:
+
+```tsx
+const { reason, reference } = buildQuickInventoryAudit(
+  quickEntrySource,
+  scanMode,
+  quantity,
+  Date.now(),
+);
+```
+
+Then pass `reason` and `reference` into the existing `updateProductStockWithAudit(...)` call in place of the removed inline strings. Leave the success **toast** untouched — it keeps its own `.toFixed(2)` formatting and is not part of the helper.
+
+- [ ] **Step 5: Typecheck and run the full unit suite**
+
+Run: `npm run typecheck`
+Expected: no errors (the `onCountProduct` requirement from Task 2 is now satisfied).
+
+Run: `npm run test -- tests/unit/quickInventoryAudit.test.ts tests/unit/VirtualizedProductGrid.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 6: Lint**
+
+Run: `npm run lint`
+Expected: no new errors in `Inventory.tsx`, `VirtualizedProductGrid.tsx`, or `quickInventoryAudit.ts`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/pages/Inventory.tsx
+git commit -m "feat(inventory): open quick-count dialog from card Count button and label manual audits"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage**
+
+| Spec section | Task |
+|---|---|
+| §1 grid: `onCountProduct` prop, Count button in new `CardFooter`, primary style, `aria-label`, `Calculator` icon `aria-hidden`, bump `ESTIMATED_ROW_HEIGHT` | Task 2 |
+| §2 Inventory: `quickEntrySource` state, scan path sets `'scan'`, grid `onCountProduct` sets `add`+`manual`, replace inline literals via helper | Task 3 |
+| §3 pure `buildQuickInventoryAudit` with `timestamp` param, exact reason strings, reference prefixes | Task 1 |
+| Testing table: `quickInventoryAudit.test.ts` (wording per source×mode, reference prefix, quantity formatting) | Task 1 |
+| Testing table: grid Count button (renders, click calls `onCountProduct`, does NOT call `onEditProduct`) | Task 2 |
+| Accessibility (aria-label, aria-hidden icon, keyboard-focusable shadcn Button) | Task 2 |
+| Styling (primary treatment verbatim, semantic tokens, transition-colors) | Task 2 + Global Constraints |
+| SQL/pgTAP: none | N/A — no DB surface, stated in Global Constraints |
+| Follow-ups (Mode A, Mode B, ProductCard memoization) | Out of scope by design; not implemented here |
+
+No gaps.
+
+**2. Placeholder scan:** No TBD/TODO/"handle edge cases"/"similar to Task N". Every code step shows complete code. The only conditional instruction (Step 1 of Task 2: extend existing test file vs. create new) is a real branch with both paths fully specified.
+
+**3. Type consistency:** `buildQuickInventoryAudit(source, mode, quantity, timestamp)` is defined in Task 1 and called with exactly that arity/order in Task 3. `QuickEntrySource` is exported by Task 1 and imported in Task 3. `onCountProduct: (product: Product) => void` is declared in Task 2 and supplied with a matching `(product) => {...}` in Task 3. `onCount: () => void` on `ProductCard` is fed by `onCount={() => onCountProduct(product)}`. Consistent throughout.

--- a/docs/superpowers/specs/2026-07-24-inventory-tap-to-count-design.md
+++ b/docs/superpowers/specs/2026-07-24-inventory-tap-to-count-design.md
@@ -178,10 +178,10 @@ SQL/pgTAP: none (no schema or RPC change — writes go through the existing
 
 ## Styling (CLAUDE.md Apple/Notion)
 
-- Semantic tokens only (`bg-foreground/5`, `text-foreground`, `text-muted-foreground`;
-  no `bg-white`/`text-black`).
-- `border-border/40`, `rounded-lg`, existing typography scale (`text-[13px]`/`text-[14px]`).
-- `transition-colors` on hover.
+- Count button uses the CLAUDE.md **primary action** style verbatim:
+  `h-9 px-4 rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium`
+  (plus `w-full` for the footer). Semantic tokens only — no `bg-white`/`text-black`.
+- `transition-colors` on hover; `CardFooter` inherits the card's existing padding idiom.
 
 ## Decided Trade-offs
 

--- a/docs/superpowers/specs/2026-07-24-inventory-tap-to-count-design.md
+++ b/docs/superpowers/specs/2026-07-24-inventory-tap-to-count-design.md
@@ -125,13 +125,13 @@ export function buildQuickInventoryAudit(
   source: QuickEntrySource,
   mode: QuickEntryMode,
   quantity: number,
+  timestamp: number,
 ): { reason: string; reference: string };
 ```
 
-- `reference`: `` `${source === 'manual' ? 'manual_count' : 'quick_scan'}_${Date.now()}` ``
-  — **Note:** `Date.now()` is called by the caller and passed in, OR the helper takes
-  a `timestamp` argument so it stays pure and unit-testable. Final signature:
-  `buildQuickInventoryAudit(source, mode, quantity, timestamp)`.
+- `reference`: `` `${source === 'manual' ? 'manual_count' : 'quick_scan'}_${timestamp}` ``
+  — the caller passes `timestamp` (e.g. `Date.now()`) so the helper stays pure and
+  unit-testable (no hidden dependency on the system clock).
 - `reason`: reproduces today's **exact** scan-path strings byte-for-byte (the current
   code interpolates the **raw, unformatted** `quantity` — no `.toFixed()` — see
   `Inventory.tsx:963,967`):

--- a/docs/superpowers/specs/2026-07-24-inventory-tap-to-count-design.md
+++ b/docs/superpowers/specs/2026-07-24-inventory-tap-to-count-design.md
@@ -48,7 +48,7 @@ scanning.
 | Decision | Choice |
 |---|---|
 | Entry point | Dedicated "Count" button on each card (card tap still = Edit) |
-| Default mode | `add` (add to existing stock), matching the scan default; dialog still lets the user switch to reconcile |
+| Default mode | `add` (add to existing stock), matching the scan default. **Corrected during PR review (see Amendment below):** the dialog did *not* let the user switch — a Count Mode toggle was added so it now does |
 | Scope | Products grid only |
 | Placement | **A new full-width `CardFooter`** below the stock/pricing block — NOT the top-right 7×7 ghost-icon cluster (which is hard-capped `max-w-[120px]` below `sm` and would break on the reported iPhone/Safari device) |
 | Button style | The CLAUDE.md **primary** treatment (`bg-foreground text-background hover:bg-foreground/90`), not a subtle tint — the feature exists to make the control *findable* |
@@ -196,6 +196,39 @@ SQL/pgTAP: none (no schema or RPC change — writes go through the existing
   (a broader refactor of code this feature doesn't otherwise touch), which conflicts with
   the tight scope of a targeted bugfix. Filed as follow-up #3 below. This is the
   reviewer-approved "accept as pre-existing debt, called out explicitly" path.
+
+## Amendment (PR #658 review) — Count Mode toggle
+
+The original design asserted that the dialog "still lets the user switch to
+reconcile." **That was false.** Verification during PR review found:
+
+- `QuickInventoryDialog` took `mode` as a **read-only** prop — no toggle, setter
+  or callback existed; every reference was a read.
+- `setScanMode` was called in exactly **one** place app-wide (the new Count
+  handler). It was initialised to `'add'` and never otherwise changed, so
+  `reconcile` was **unreachable dead code** for the scan path too (pre-existing).
+
+Consequence: a control labelled "Count" — which invites "count what's on the
+shelf" — would silently compute `currentStock + quantity`. A user entering a
+physical on-hand total of 12 against a stored 5 would write **17**, inflating
+inventory in a system where data accuracy is critical.
+
+**Resolution (product owner decision):** add the toggle rather than change the
+default or ship as-is.
+
+- `QuickInventoryDialog` gains an **optional** `onModeChange` prop. When supplied,
+  it renders an *Add to stock / Set total* `radiogroup` (controlled — the parent
+  keeps owning `mode`, so `handleQuickInventorySave` and `buildQuickInventoryAudit`
+  retain a single source of truth), plus a hint line describing the write.
+- The prop is **optional** deliberately: `ReconciliationItemDetail`,
+  `ReconciliationSession` and `ScanSessionView` all hardcode `mode="add"` in an
+  "add a find" context where a toggle would be wrong. They omit it and are
+  visually unchanged.
+- `Inventory.tsx` passes `setScanMode`, and now also resets to `'add'` on the
+  **scan** path so a prior manual "Set total" choice cannot leak into a later scan.
+
+Default remains `'add'` as originally agreed; `reconcile` is now reachable from
+both the scan and manual entry points.
 
 ## Risks & Mitigations
 

--- a/docs/superpowers/specs/2026-07-24-inventory-tap-to-count-design.md
+++ b/docs/superpowers/specs/2026-07-24-inventory-tap-to-count-design.md
@@ -50,7 +50,8 @@ scanning.
 | Entry point | Dedicated "Count" button on each card (card tap still = Edit) |
 | Default mode | `add` (add to existing stock), matching the scan default; dialog still lets the user switch to reconcile |
 | Scope | Products grid only |
-| Placement | Accented button in the card action area (primary, findable), not crammed into the 7×7 ghost-icon cluster |
+| Placement | **A new full-width `CardFooter`** below the stock/pricing block — NOT the top-right 7×7 ghost-icon cluster (which is hard-capped `max-w-[120px]` below `sm` and would break on the reported iPhone/Safari device) |
+| Button style | The CLAUDE.md **primary** treatment (`bg-foreground text-background hover:bg-foreground/90`), not a subtle tint — the feature exists to make the control *findable* |
 
 ## What Already Exists (reused, not rebuilt)
 
@@ -74,15 +75,26 @@ the dialog. **We are adding a trigger, not a flow.**
 - Add prop `onCountProduct: (product: Product) => void` to
   `VirtualizedProductGridProps`; thread through to the `ProductCard`
   (`onCount: () => void`).
-- Render a **"Count" button** (lucide `Calculator` icon + visible "Count" label) as
-  the **primary** action in the card's action area. It:
-  - calls `e.stopPropagation()` then `onCount()` — must **not** trigger the
-    card-body `onClick={onEdit}` (three-state note: the card body tap remains Edit).
-  - carries `aria-label={`Count ${product.name}`}`; the icon is `aria-hidden`.
-  - is styled with a subtle accent (e.g. `bg-foreground/5` / outline, `border-border/40`,
-    `rounded-lg`, existing typography scale) so it reads as the obvious control —
-    directly answering "I can't find the calculator." Semantic tokens only.
+- Render a **"Count" button** (lucide `Calculator` icon + visible "Count" label) in a
+  **new `CardFooter`** (already exported from `src/components/ui/card.tsx`, currently
+  unused by `ProductCard`) below the stock/pricing `CardContent` block. The button:
+  - is **full-width** and uses the CLAUDE.md primary treatment:
+    `w-full h-9 rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium transition-colors`.
+    It is the one obviously-findable control on the card — directly answering "I can't
+    find the calculator." Semantic tokens only.
+  - carries `aria-label={`Count ${product.name}`}` and `title="Count"` (parity with the
+    other cluster buttons); the `Calculator` icon is `aria-hidden`.
+  - **Placement removes the propagation hazard:** `CardFooter` is a **sibling** of
+    `CardContent` (which owns `onClick={onEdit}`), so a footer click never bubbles to
+    Edit — no `stopPropagation()` needed. We still keep a negative test asserting
+    `onEditProduct` is not called, as a guard against future re-placement. (If, during
+    implementation, the button ends up inside `CardContent` for any reason, it MUST
+    call `e.stopPropagation()` — see the recipe `Link` at `VirtualizedProductGrid.tsx:268`.)
 - Keyboard-accessible by default (it is a shadcn `Button`).
+- **`ESTIMATED_ROW_HEIGHT`** (`VirtualizedProductGrid.tsx:51`, currently `320`): bump to
+  account for the added footer so first-paint layout is closer before `measureElement`
+  corrects it (reduces a one-time CLS blip). `measureElement` still handles the exact
+  height dynamically.
 
 ### 2. `src/pages/Inventory.tsx`
 
@@ -120,9 +132,16 @@ export function buildQuickInventoryAudit(
   — **Note:** `Date.now()` is called by the caller and passed in, OR the helper takes
   a `timestamp` argument so it stays pure and unit-testable. Final signature:
   `buildQuickInventoryAudit(source, mode, quantity, timestamp)`.
-- `reason`: preserves today's wording for `scan` (`Adjustment - Added N via quick scan`
-  / `Inventory reconciliation - Set to N via quick scan`) and uses the parallel
-  "manual count" wording for `manual`.
+- `reason`: reproduces today's **exact** scan-path strings byte-for-byte (the current
+  code interpolates the **raw, unformatted** `quantity` — no `.toFixed()` — see
+  `Inventory.tsx:963,967`):
+  - `scan` + `add` → `` `Adjustment - Added ${quantity} via quick scan` ``
+  - `scan` + `reconcile` → `` `Inventory reconciliation - Set to ${quantity} via quick scan` ``
+  - `manual` + `add` → `` `Adjustment - Added ${quantity} via manual count` ``
+  - `manual` + `reconcile` → `` `Inventory reconciliation - Set to ${quantity} via manual count` ``
+  The unit test pins the unformatted `quantity` explicitly so this refactor cannot
+  silently change scan-path audit wording. (The success **toast** keeps its separate
+  `.toFixed(2)` formatting in the page — unchanged, not part of the helper.)
 - Extracting this isolates the only branching logic in the save handler into a
   testable pure function (the save handler itself lives in a large page component that
   is impractical to unit-test in isolation).
@@ -130,8 +149,8 @@ export function buildQuickInventoryAudit(
 ## Data Flow
 
 ```
-ProductCard "Count" button click
-  → e.stopPropagation(); onCount()
+ProductCard CardFooter "Count" button click  (sibling of CardContent → no edit bubble)
+  → onCount()
   → VirtualizedProductGrid onCountProduct(product)
   → Inventory: setScanMode('add'), setQuickEntrySource('manual'),
                setQuickInventoryProduct(product), setShowQuickInventoryDialog(true)
@@ -164,9 +183,24 @@ SQL/pgTAP: none (no schema or RPC change — writes go through the existing
 - `border-border/40`, `rounded-lg`, existing typography scale (`text-[13px]`/`text-[14px]`).
 - `transition-colors` on hover.
 
+## Decided Trade-offs
+
+- **Row memoization left as pre-existing debt (accepted).** `ProductCard` is not
+  wrapped in `React.memo` today and its per-row callbacks are fresh closures created
+  inside `VirtualizedProductGrid`'s `.map()` — a standing gap against CLAUDE.md's
+  "Memoized Components" rule for virtualized rows. This PR adds `onCount` following the
+  same existing pattern. **Rationale for not fixing it here:** because `ProductCard` is
+  already un-memoized, it re-renders on every parent render regardless, so adding one
+  more callback prop has *zero* incremental perf cost; bringing the component into full
+  compliance means memoizing the component *and* stabilizing all six per-row closures
+  (a broader refactor of code this feature doesn't otherwise touch), which conflicts with
+  the tight scope of a targeted bugfix. Filed as follow-up #3 below. This is the
+  reviewer-approved "accept as pre-existing debt, called out explicitly" path.
+
 ## Risks & Mitigations
 
-- **Card-tap Edit vs Count-button conflict** → `stopPropagation` on the Count button;
+- **Card-tap Edit vs Count-button conflict** → Count lives in `CardFooter`, a sibling of
+  the `CardContent` that owns `onClick={onEdit}`, so a footer click never bubbles to Edit;
   covered by a grid test asserting `onEditProduct` is not called.
 - **Audit-log provenance drift** → pure helper + unit test lock the wording per source.
 - **Regression to the scan path** → scan path explicitly sets `quickEntrySource='scan'`,
@@ -178,3 +212,5 @@ SQL/pgTAP: none (no schema or RPC change — writes go through the existing
    `BarcodeDetector` polyfill for the iOS/Safari fallback path.
 2. Exact-match resolution brittleness (Mode B) — normalize GTIN check-digit /
    leading-zero variants, or fuzzy SKU match with confirmation.
+3. `ProductCard` virtualization compliance — wrap in `React.memo` and stabilize all
+   per-row callbacks (see Decided Trade-offs).

--- a/docs/superpowers/specs/2026-07-24-inventory-tap-to-count-design.md
+++ b/docs/superpowers/specs/2026-07-24-inventory-tap-to-count-design.md
@@ -1,0 +1,180 @@
+# Design: Manual "Tap-to-Count" Entry Path for Inventory
+
+**Date:** 2026-07-24
+**Branch:** `feature/inventory-tap-to-count`
+**Author:** Claude (development-workflow)
+
+## Problem
+
+`QuickInventoryDialog` (the in-app numpad "calculadora de conteo") has exactly
+**one** trigger today: a barcode scan that both (a) *captures* on the device and
+(b) *exactly* matches a stored product `gtin`/`sku` via `findProductByGtin`. When
+either gate fails, the calculator never appears.
+
+Both gates fail silently on the reported device (Mobile Safari, 2026-07-20 survey
+response *"Aquí no me esta saliendo la calculadora de conteo para los
+inventarios"*):
+
+- **Mode A — capture never happens.** `SmartBarcodeScanner.tsx:43` forces
+  `isIOS || isSafari` down the `Html5Qrcode` fallback engine (no `BarcodeDetector`,
+  no ML Kit). That engine is the least reliable camera path; on this device the
+  barcode is never decoded, so `useScanSession.capture()` never runs.
+- **Mode B — resolution misses.** Even on a successful decode, `findProductByGtin`
+  (`useProducts.tsx:363`) matches only on **exact** `gtin` OR `sku` equality. A
+  code that does not byte-for-byte equal a stored value returns `null`, routing the
+  session to the full new-product form instead of the quick calculator.
+
+Both are real and separately fixable, but this change deliberately **routes around
+them** by adding a scan-independent way to open the calculator. Fixing scan capture
+(Mode A) and resolution brittleness (Mode B) are tracked as follow-ups, out of
+scope here.
+
+## Goal
+
+Add a **dedicated "Count" button** to each product card on the Inventory products
+grid that opens `QuickInventoryDialog` directly for that product, independent of
+scanning.
+
+## Non-Goals (YAGNI)
+
+- Fixing Mobile-Safari scan capture (Mode A).
+- Fixing exact-match resolution brittleness (Mode B).
+- Adding the count entry point to the low-stock cards (deferred; products grid only
+  for v1, per product decision).
+- Changing the existing card-tap behavior (tap still opens Edit).
+
+## Design Decisions (confirmed with product owner)
+
+| Decision | Choice |
+|---|---|
+| Entry point | Dedicated "Count" button on each card (card tap still = Edit) |
+| Default mode | `add` (add to existing stock), matching the scan default; dialog still lets the user switch to reconcile |
+| Scope | Products grid only |
+| Placement | Accented button in the card action area (primary, findable), not crammed into the 7×7 ghost-icon cluster |
+
+## What Already Exists (reused, not rebuilt)
+
+`src/pages/Inventory.tsx` already holds the entire quick-inventory flow:
+
+- State: `quickInventoryProduct`, `showQuickInventoryDialog`, `scanMode` (`'add' | 'reconcile'`).
+- A single rendered `QuickInventoryDialog` instance (line ~1970) — **no double-wrap**;
+  the dialog renders its own Radix `Dialog`.
+- `handleQuickInventorySave(quantity)` — writes via `updateProductStockWithAudit`,
+  branches on `scanMode` (add → `current + qty`; reconcile → set total), refetches,
+  toasts.
+- `handleCloseQuickInventoryDialog(open)` — closes and clears `quickInventoryProduct`.
+
+Today only `handleBarcodeScanned` (line ~493) sets `quickInventoryProduct` and opens
+the dialog. **We are adding a trigger, not a flow.**
+
+## Changes
+
+### 1. `src/components/inventory/VirtualizedProductGrid.tsx`
+
+- Add prop `onCountProduct: (product: Product) => void` to
+  `VirtualizedProductGridProps`; thread through to the `ProductCard`
+  (`onCount: () => void`).
+- Render a **"Count" button** (lucide `Calculator` icon + visible "Count" label) as
+  the **primary** action in the card's action area. It:
+  - calls `e.stopPropagation()` then `onCount()` — must **not** trigger the
+    card-body `onClick={onEdit}` (three-state note: the card body tap remains Edit).
+  - carries `aria-label={`Count ${product.name}`}`; the icon is `aria-hidden`.
+  - is styled with a subtle accent (e.g. `bg-foreground/5` / outline, `border-border/40`,
+    `rounded-lg`, existing typography scale) so it reads as the obvious control —
+    directly answering "I can't find the calculator." Semantic tokens only.
+- Keyboard-accessible by default (it is a shadcn `Button`).
+
+### 2. `src/pages/Inventory.tsx`
+
+- Add entry-source state: `const [quickEntrySource, setQuickEntrySource] = useState<'scan' | 'manual'>('scan')`.
+- Existing scan path (`handleBarcodeScanned`): set `quickEntrySource` to `'scan'`
+  when opening the dialog (preserves current behavior/wording).
+- Wire the grid (line ~1708):
+  ```tsx
+  onCountProduct={(product) => {
+    setScanMode('add');
+    setQuickEntrySource('manual');
+    setQuickInventoryProduct(product);
+    setShowQuickInventoryDialog(true);
+  }}
+  ```
+- `handleQuickInventorySave` currently hardcodes `"via quick scan"` wording and a
+  `quick_scan_${Date.now()}` audit reference. Replace those two literals with values
+  derived from a pure helper (below) keyed on `quickEntrySource`, so a manual count
+  is not mislabeled in the inventory audit log.
+
+### 3. `src/utils/quickInventoryAudit.ts` (new, pure)
+
+```ts
+export type QuickEntrySource = 'scan' | 'manual';
+export type QuickEntryMode = 'add' | 'reconcile';
+
+export function buildQuickInventoryAudit(
+  source: QuickEntrySource,
+  mode: QuickEntryMode,
+  quantity: number,
+): { reason: string; reference: string };
+```
+
+- `reference`: `` `${source === 'manual' ? 'manual_count' : 'quick_scan'}_${Date.now()}` ``
+  — **Note:** `Date.now()` is called by the caller and passed in, OR the helper takes
+  a `timestamp` argument so it stays pure and unit-testable. Final signature:
+  `buildQuickInventoryAudit(source, mode, quantity, timestamp)`.
+- `reason`: preserves today's wording for `scan` (`Adjustment - Added N via quick scan`
+  / `Inventory reconciliation - Set to N via quick scan`) and uses the parallel
+  "manual count" wording for `manual`.
+- Extracting this isolates the only branching logic in the save handler into a
+  testable pure function (the save handler itself lives in a large page component that
+  is impractical to unit-test in isolation).
+
+## Data Flow
+
+```
+ProductCard "Count" button click
+  → e.stopPropagation(); onCount()
+  → VirtualizedProductGrid onCountProduct(product)
+  → Inventory: setScanMode('add'), setQuickEntrySource('manual'),
+               setQuickInventoryProduct(product), setShowQuickInventoryDialog(true)
+  → existing <QuickInventoryDialog> opens (mode="add")
+  → user enters count → onSave → handleQuickInventorySave(quantity)
+  → buildQuickInventoryAudit('manual', scanMode, quantity, Date.now())
+  → updateProductStockWithAudit(...) → refetch → toast
+```
+
+## Testing
+
+| Test | Location | What |
+|---|---|---|
+| `buildQuickInventoryAudit` | `tests/unit/quickInventoryAudit.test.ts` | reason + reference wording for each `source × mode`; reference prefix `manual_count_` vs `quick_scan_`; quantity formatting |
+| Grid Count button | `tests/unit/VirtualizedProductGrid.test.tsx` (or existing grid test) | renders one Count button per card with `aria-label="Count {name}"`; click calls `onCountProduct(product)`; click does **not** call `onEditProduct` (stopPropagation) |
+
+SQL/pgTAP: none (no schema or RPC change — writes go through the existing
+`updateProductStockWithAudit` path).
+
+## Accessibility
+
+- `Count` button: `aria-label` present, icon `aria-hidden`, keyboard-focusable
+  (shadcn Button), visible label text.
+- No change to existing three-state rendering (loading / error / empty) on the grid.
+
+## Styling (CLAUDE.md Apple/Notion)
+
+- Semantic tokens only (`bg-foreground/5`, `text-foreground`, `text-muted-foreground`;
+  no `bg-white`/`text-black`).
+- `border-border/40`, `rounded-lg`, existing typography scale (`text-[13px]`/`text-[14px]`).
+- `transition-colors` on hover.
+
+## Risks & Mitigations
+
+- **Card-tap Edit vs Count-button conflict** → `stopPropagation` on the Count button;
+  covered by a grid test asserting `onEditProduct` is not called.
+- **Audit-log provenance drift** → pure helper + unit test lock the wording per source.
+- **Regression to the scan path** → scan path explicitly sets `quickEntrySource='scan'`,
+  and the helper reproduces today's exact wording for `scan`.
+
+## Follow-ups (out of scope, filed separately)
+
+1. Mobile-Safari scan capture (Mode A) — evaluate `@zxing/browser` or native
+   `BarcodeDetector` polyfill for the iOS/Safari fallback path.
+2. Exact-match resolution brittleness (Mode B) — normalize GTIN check-digit /
+   leading-zero variants, or fuzzy SKU match with confirmation.

--- a/src/components/QuickInventoryDialog.tsx
+++ b/src/components/QuickInventoryDialog.tsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { Package, Check, Plus, Minus, X, Divide } from 'lucide-react';
 import { Product } from '@/hooks/useProducts';
 import { LocationCombobox } from '@/components/LocationCombobox';
@@ -145,34 +146,38 @@ export const QuickInventoryDialog: React.FC<QuickInventoryDialogProps> = ({
             )}
           </div>
 
-          {/* Count Mode toggle — only when the parent opts in via onModeChange */}
+          {/* Count Mode toggle — only when the parent opts in via onModeChange.
+              Uses ToggleGroup (Radix) rather than hand-rolled radio buttons so
+              roving tabindex and arrow-key navigation come for free. */}
           {onModeChange && (
             <div>
-              <span className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
+              <span
+                id="count-mode-label"
+                className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider"
+              >
                 Count Mode
               </span>
-              <div
-                role="radiogroup"
-                aria-label="Count mode"
+              <ToggleGroup
+                type="single"
+                value={mode}
+                // Radix emits '' when the active item is re-clicked (deselect);
+                // ignore that so mode can never become empty.
+                onValueChange={(value) => {
+                  if (value === 'add' || value === 'reconcile') onModeChange(value);
+                }}
+                aria-labelledby="count-mode-label"
                 className="mt-2 grid grid-cols-2 gap-1 p-1 rounded-lg bg-muted/50 border border-border/40"
               >
                 {MODE_OPTIONS.map((option) => (
-                  <button
+                  <ToggleGroupItem
                     key={option.value}
-                    type="button"
-                    role="radio"
-                    aria-checked={mode === option.value}
-                    onClick={() => onModeChange(option.value)}
-                    className={`h-8 rounded-md text-[13px] font-medium transition-colors ${
-                      mode === option.value
-                        ? 'bg-foreground text-background'
-                        : 'text-muted-foreground hover:text-foreground'
-                    }`}
+                    value={option.value}
+                    className="h-9 rounded-md text-[13px] font-medium transition-colors data-[state=on]:bg-foreground data-[state=on]:text-background"
                   >
                     {option.label}
-                  </button>
+                  </ToggleGroupItem>
                 ))}
-              </div>
+              </ToggleGroup>
               <p className="text-[12px] text-muted-foreground mt-1.5">
                 {MODE_OPTIONS.find((option) => option.value === mode)?.hint}
               </p>

--- a/src/components/QuickInventoryDialog.tsx
+++ b/src/components/QuickInventoryDialog.tsx
@@ -12,16 +12,37 @@ interface QuickInventoryDialogProps {
   onOpenChange: (open: boolean) => void;
   product: Product;
   mode: 'add' | 'reconcile';
+  /**
+   * When provided, the dialog renders a Count Mode toggle and reports the
+   * user's choice back to the parent (controlled — the parent owns `mode`).
+   * Omit it for flows where the mode is fixed by context (e.g. adding a find
+   * during a reconciliation session), which keeps the toggle hidden.
+   */
+  onModeChange?: (mode: 'add' | 'reconcile') => void;
   onSave: (quantity: number, location?: string) => Promise<void>;
   currentTotal?: number;
   restaurantId: string | null;
 }
+
+const MODE_OPTIONS = [
+  {
+    value: 'add' as const,
+    label: 'Add to stock',
+    hint: 'Adds the entered amount to the current stock.',
+  },
+  {
+    value: 'reconcile' as const,
+    label: 'Set total',
+    hint: 'Replaces the current stock with the entered amount.',
+  },
+];
 
 export const QuickInventoryDialog: React.FC<QuickInventoryDialogProps> = ({
   open,
   onOpenChange,
   product,
   mode,
+  onModeChange,
   onSave,
   currentTotal,
   restaurantId
@@ -123,6 +144,40 @@ export const QuickInventoryDialog: React.FC<QuickInventoryDialogProps> = ({
               </div>
             )}
           </div>
+
+          {/* Count Mode toggle — only when the parent opts in via onModeChange */}
+          {onModeChange && (
+            <div>
+              <span className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
+                Count Mode
+              </span>
+              <div
+                role="radiogroup"
+                aria-label="Count mode"
+                className="mt-2 grid grid-cols-2 gap-1 p-1 rounded-lg bg-muted/50 border border-border/40"
+              >
+                {MODE_OPTIONS.map((option) => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    role="radio"
+                    aria-checked={mode === option.value}
+                    onClick={() => onModeChange(option.value)}
+                    className={`h-8 rounded-md text-[13px] font-medium transition-colors ${
+                      mode === option.value
+                        ? 'bg-foreground text-background'
+                        : 'text-muted-foreground hover:text-foreground'
+                    }`}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+              <p className="text-[12px] text-muted-foreground mt-1.5">
+                {MODE_OPTIONS.find((option) => option.value === mode)?.hint}
+              </p>
+            </div>
+          )}
 
           {/* Current Total (if adding finds) */}
           {mode === 'add' && currentTotal !== undefined && (

--- a/src/components/inventory/VirtualizedProductGrid.tsx
+++ b/src/components/inventory/VirtualizedProductGrid.tsx
@@ -1,12 +1,12 @@
 import React, { useRef, useCallback, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { AlertTriangle, Edit, Trash, Trash2, ArrowRightLeft, ChefHat } from 'lucide-react';
+import { AlertTriangle, Calculator, Edit, Trash, Trash2, ArrowRightLeft, ChefHat } from 'lucide-react';
 import { LazyImage } from '@/components/ui/lazy-image';
 import { InventoryValueBadge } from '@/components/InventoryValueBadge';
 import { Product } from '@/hooks/useProducts';
@@ -42,13 +42,14 @@ interface VirtualizedProductGridProps {
   recipesByProduct: ProductRecipeMap;
   canDeleteProducts: boolean;
   onEditProduct: (product: Product) => void;
+  onCountProduct: (product: Product) => void;
   onWasteProduct: (product: Product) => void;
   onTransferProduct: (product: Product) => void;
   onDeleteProduct: (product: Product) => void;
 }
 
 // Estimated row height - will be measured dynamically
-const ESTIMATED_ROW_HEIGHT = 320;
+const ESTIMATED_ROW_HEIGHT = 380;
 const OVERSCAN = 3;
 
 /**
@@ -86,6 +87,7 @@ const ProductCard: React.FC<{
   recipes?: RecipeIngredient[];
   canDelete: boolean;
   onEdit: () => void;
+  onCount: () => void;
   onWaste: () => void;
   onTransfer: () => void;
   onDelete: () => void;
@@ -95,6 +97,7 @@ const ProductCard: React.FC<{
   recipes,
   canDelete,
   onEdit,
+  onCount,
   onWaste,
   onTransfer,
   onDelete,
@@ -284,6 +287,17 @@ const ProductCard: React.FC<{
           )}
         </div>
       </CardContent>
+      <CardFooter className="pt-0">
+        <Button
+          onClick={onCount}
+          aria-label={`Count ${product.name}`}
+          title="Count"
+          className="w-full h-9 rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium transition-colors"
+        >
+          <Calculator className="h-4 w-4 mr-2" aria-hidden="true" />
+          Count
+        </Button>
+      </CardFooter>
     </Card>
   );
 };
@@ -300,6 +314,7 @@ export const VirtualizedProductGrid: React.FC<VirtualizedProductGridProps> = ({
   recipesByProduct,
   canDeleteProducts,
   onEditProduct,
+  onCountProduct,
   onWasteProduct,
   onTransferProduct,
   onDeleteProduct,
@@ -361,6 +376,7 @@ export const VirtualizedProductGrid: React.FC<VirtualizedProductGridProps> = ({
                   recipes={recipesByProduct[product.id]}
                   canDelete={canDeleteProducts}
                   onEdit={() => onEditProduct(product)}
+                  onCount={() => onCountProduct(product)}
                   onWaste={() => onWasteProduct(product)}
                   onTransfer={() => onTransferProduct(product)}
                   onDelete={() => onDeleteProduct(product)}

--- a/src/pages/Inventory.tsx
+++ b/src/pages/Inventory.tsx
@@ -491,7 +491,9 @@ export const Inventory: React.FC = () => {
     const existingProduct = await findProductByGtin(gtin);
     
     if (existingProduct) {
-      // Use quick inventory dialog for scanning existing products
+      // Use quick inventory dialog for scanning existing products.
+      // Reset the mode so a prior manual "Set total" choice never leaks into a scan.
+      setScanMode('add');
       setQuickEntrySource('scan');
       setQuickInventoryProduct(existingProduct);
       setShowQuickInventoryDialog(true);
@@ -1986,6 +1988,7 @@ export const Inventory: React.FC = () => {
           onOpenChange={handleCloseQuickInventoryDialog}
           product={quickInventoryProduct}
           mode={scanMode}
+          onModeChange={setScanMode}
           onSave={handleQuickInventorySave}
           restaurantId={selectedRestaurant?.restaurant_id || null}
         />

--- a/src/pages/Inventory.tsx
+++ b/src/pages/Inventory.tsx
@@ -953,23 +953,27 @@ export const Inventory: React.FC = () => {
 
     const currentStock = quickInventoryProduct.current_stock || 0;
     const costPerUnit = quickInventoryProduct.cost_per_unit || 0;
-    
+
     let finalStock: number;
     // All quick scan updates should be adjustments
     // Only receipt uploads should create purchases
     const transactionType: 'adjustment' = 'adjustment';
-    let reason: string;
-    
+
     if (scanMode === 'add') {
       // Add mode: add to existing stock
       finalStock = currentStock + quantity;
-      reason = `Adjustment - Added ${quantity} via quick scan`;
     } else {
       // Reconcile mode: set total stock to scanned quantity
       finalStock = quantity;
-      reason = `Inventory reconciliation - Set to ${quantity} via quick scan`;
     }
-    
+
+    const { reason, reference } = buildQuickInventoryAudit(
+      quickEntrySource,
+      scanMode,
+      quantity,
+      Date.now(),
+    );
+
     const success = await updateProductStockWithAudit(
       selectedRestaurant.restaurant_id,
       quickInventoryProduct.id,
@@ -978,7 +982,7 @@ export const Inventory: React.FC = () => {
       costPerUnit,
       transactionType,
       reason,
-      `quick_scan_${Date.now()}`
+      reference
     );
     
     if (success) {

--- a/src/pages/Inventory.tsx
+++ b/src/pages/Inventory.tsx
@@ -1717,6 +1717,12 @@ export const Inventory: React.FC = () => {
                     setSelectedProduct(product);
                     setShowUpdateDialog(true);
                   }}
+                  onCountProduct={(product) => {
+                    setScanMode('add');
+                    setQuickEntrySource('manual');
+                    setQuickInventoryProduct(product);
+                    setShowQuickInventoryDialog(true);
+                  }}
                   onWasteProduct={(product) => {
                     setWasteProduct(product);
                     setShowWasteDialog(true);

--- a/src/pages/Inventory.tsx
+++ b/src/pages/Inventory.tsx
@@ -492,6 +492,7 @@ export const Inventory: React.FC = () => {
     
     if (existingProduct) {
       // Use quick inventory dialog for scanning existing products
+      setQuickEntrySource('scan');
       setQuickInventoryProduct(existingProduct);
       setShowQuickInventoryDialog(true);
       return;

--- a/src/pages/Inventory.tsx
+++ b/src/pages/Inventory.tsx
@@ -49,6 +49,7 @@ import { cn } from '@/lib/utils';
 import { formatInventoryLevel } from '@/lib/inventoryDisplay';
 import { exportToCSV, generateCSVFilename } from '@/utils/csvExport';
 import { generateTablePDF } from '@/utils/pdfExport';
+import { buildQuickInventoryAudit, type QuickEntrySource } from '@/utils/quickInventoryAudit';
 
 export const Inventory: React.FC = () => {
   const navigate = useNavigate();
@@ -85,6 +86,7 @@ export const Inventory: React.FC = () => {
   const [showQuickInventoryDialog, setShowQuickInventoryDialog] = useState(false);
   const [quickInventoryProduct, setQuickInventoryProduct] = useState<Product | null>(null);
   const [scanMode, setScanMode] = useState<'add' | 'reconcile'>('add');
+  const [quickEntrySource, setQuickEntrySource] = useState<QuickEntrySource>('scan');
   
   // Filter and sorting state
   const [categoryFilter, setCategoryFilter] = useState('all');

--- a/src/pages/Inventory.tsx
+++ b/src/pages/Inventory.tsx
@@ -955,15 +955,15 @@ export const Inventory: React.FC = () => {
     const costPerUnit = quickInventoryProduct.cost_per_unit || 0;
 
     let finalStock: number;
-    // All quick scan updates should be adjustments
+    // All quick inventory updates (scan or manual count) should be adjustments
     // Only receipt uploads should create purchases
-    const transactionType: 'adjustment' = 'adjustment';
+    const transactionType = 'adjustment' as const;
 
     if (scanMode === 'add') {
       // Add mode: add to existing stock
       finalStock = currentStock + quantity;
     } else {
-      // Reconcile mode: set total stock to scanned quantity
+      // Reconcile mode: set total stock to the entered quantity
       finalStock = quantity;
     }
 

--- a/src/pages/Inventory.tsx
+++ b/src/pages/Inventory.tsx
@@ -105,11 +105,15 @@ export const Inventory: React.FC = () => {
     }
   }, [searchParams, setSearchParams]);
 
-  // Handler to close quick inventory dialog and clear product state
+  // Handler to close quick inventory dialog and clear product state.
+  // Resetting scanMode here (not only at each open site) keeps "a session starts
+  // in 'add' mode" a single invariant, so a future entry point that forgets to
+  // reset cannot inherit a leftover 'reconcile' selection.
   const handleCloseQuickInventoryDialog = (open: boolean) => {
     setShowQuickInventoryDialog(open);
     if (!open) {
       setQuickInventoryProduct(null);
+      setScanMode('add');
     }
   };
   const [reconciliationView, setReconciliationView] = useState<'history' | 'session' | 'summary'>('history');

--- a/src/utils/quickInventoryAudit.ts
+++ b/src/utils/quickInventoryAudit.ts
@@ -1,0 +1,30 @@
+export type QuickEntrySource = 'scan' | 'manual';
+export type QuickEntryMode = 'add' | 'reconcile';
+
+/**
+ * Builds the inventory audit-log `reason` and `reference` strings for a
+ * quick inventory entry (barcode scan or manual tap-to-count).
+ *
+ * Pure and unit-testable: the caller supplies `timestamp` (e.g. `Date.now()`)
+ * so this function has no hidden dependency on the system clock.
+ *
+ * `quantity` is interpolated raw/unformatted to preserve the exact wording
+ * of the existing scan-path audit strings byte-for-byte.
+ */
+export function buildQuickInventoryAudit(
+  source: QuickEntrySource,
+  mode: QuickEntryMode,
+  quantity: number,
+  timestamp: number,
+): { reason: string; reference: string } {
+  const sourceLabel = source === 'manual' ? 'via manual count' : 'via quick scan';
+  const reason =
+    mode === 'add'
+      ? `Adjustment - Added ${quantity} ${sourceLabel}`
+      : `Inventory reconciliation - Set to ${quantity} ${sourceLabel}`;
+
+  const referencePrefix = source === 'manual' ? 'manual_count' : 'quick_scan';
+  const reference = `${referencePrefix}_${timestamp}`;
+
+  return { reason, reference };
+}

--- a/tests/unit/Inventory.countButton.test.tsx
+++ b/tests/unit/Inventory.countButton.test.tsx
@@ -23,6 +23,12 @@ const testProduct: Product = {
   uom_purchase: 'kg',
 } as Product;
 
+// Hoisted so both the vi.mock factory (hoisted above imports) and the test
+// body can reference the same spy instance.
+const { updateProductStockWithAuditMock } = vi.hoisted(() => ({
+  updateProductStockWithAuditMock: vi.fn(async () => true),
+}));
+
 // ─── Module mocks ──────────────────────────────────────────────────────────────
 
 vi.mock('@/components/SmartBarcodeScanner', () => ({
@@ -58,13 +64,16 @@ vi.mock('@/components/QuickInventoryDialog', () => ({
     open: boolean;
     mode: 'add' | 'reconcile';
     product: Product;
+    onSave: (quantity: number) => void;
   }) => (
     <div
       data-testid="quick-inventory-dialog"
       data-open={props.open}
       data-mode={props.mode}
       data-product-name={props.product?.name}
-    />
+    >
+      <button onClick={() => props.onSave(3.5)}>trigger-save</button>
+    </div>
   ),
 }));
 
@@ -123,7 +132,7 @@ vi.mock('@/hooks/useProducts', () => ({
 
 vi.mock('@/hooks/useInventoryAudit', () => ({
   useInventoryAudit: () => ({
-    updateProductStockWithAudit: vi.fn(async () => true),
+    updateProductStockWithAudit: updateProductStockWithAuditMock,
   }),
 }));
 
@@ -229,5 +238,25 @@ describe('Inventory "Count" button wiring (Task 3.3)', () => {
     expect(dialog).toHaveAttribute('data-open', 'true');
     expect(dialog).toHaveAttribute('data-mode', 'add');
     expect(dialog).toHaveAttribute('data-product-name', 'Tomatoes');
+  });
+});
+
+describe('Inventory quick-count audit wording (Task 3.4)', () => {
+  it('labels a manual (tap-to-count) save "via manual count" with a manual_count_ reference', async () => {
+    const user = userEvent.setup();
+    render(<Inventory />);
+
+    // Open the dialog via the Count button (tags quickEntrySource='manual').
+    await user.click(screen.getByRole('button', { name: 'trigger-count' }));
+    expect(screen.getByTestId('quick-inventory-dialog')).toHaveAttribute('data-open', 'true');
+
+    // Trigger the dialog's onSave(3.5), as the real QuickInventoryDialog would
+    // on user confirmation.
+    await user.click(screen.getByRole('button', { name: 'trigger-save' }));
+
+    expect(updateProductStockWithAuditMock).toHaveBeenCalledTimes(1);
+    const [, , , , , , reason, reference] = updateProductStockWithAuditMock.mock.calls[0];
+    expect(reason).toBe('Adjustment - Added 3.5 via manual count');
+    expect(reference).toMatch(/^manual_count_\d+$/);
   });
 });

--- a/tests/unit/Inventory.countButton.test.tsx
+++ b/tests/unit/Inventory.countButton.test.tsx
@@ -1,0 +1,233 @@
+/**
+ * Task 3.3: Wire onCountProduct on <VirtualizedProductGrid> in Inventory.tsx
+ *
+ * Verifies that clicking "Count" on a product card (surfaced here via the
+ * mocked VirtualizedProductGrid's onCountProduct callback) opens the
+ * QuickInventoryDialog in 'add' mode for that exact product.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import type { ScanSessionViewProps } from '@/components/inventory/ScanSessionView';
+import type { Product } from '@/hooks/useProducts';
+
+// ─── Test fixtures ─────────────────────────────────────────────────────────────
+
+const testProduct: Product = {
+  id: 'p1',
+  name: 'Tomatoes',
+  sku: 'TOM-001',
+  current_stock: 5,
+  uom_purchase: 'kg',
+} as Product;
+
+// ─── Module mocks ──────────────────────────────────────────────────────────────
+
+vi.mock('@/components/SmartBarcodeScanner', () => ({
+  SmartBarcodeScanner: () => <div data-testid="smart-scanner" />,
+}));
+
+vi.mock('@/components/inventory/ScanSessionView', () => ({
+  ScanSessionView: (props: ScanSessionViewProps) => (
+    <div data-testid="scan-session-view" data-restaurant-id={props.restaurantId}>
+      scan-session-view
+    </div>
+  ),
+}));
+
+vi.mock('@/components/ProductUpdateDialog', () => ({
+  ProductUpdateDialog: () => null,
+  ProductUpdateSheet: () => null,
+}));
+vi.mock('@/components/DeleteProductDialog', () => ({
+  DeleteProductDialog: () => null,
+}));
+vi.mock('@/components/WasteDialog', () => ({
+  WasteDialog: () => null,
+}));
+vi.mock('@/components/TransferDialog', () => ({
+  TransferDialog: () => null,
+}));
+
+// This is the dialog under test — render its key props so we can assert on
+// how Inventory.tsx wires the "Count" click through to it.
+vi.mock('@/components/QuickInventoryDialog', () => ({
+  QuickInventoryDialog: (props: {
+    open: boolean;
+    mode: 'add' | 'reconcile';
+    product: Product;
+  }) => (
+    <div
+      data-testid="quick-inventory-dialog"
+      data-open={props.open}
+      data-mode={props.mode}
+      data-product-name={props.product?.name}
+    />
+  ),
+}));
+
+vi.mock('@/components/ReconciliationSession', () => ({
+  ReconciliationSession: () => null,
+}));
+vi.mock('@/components/ReconciliationHistory', () => ({
+  ReconciliationHistory: () => null,
+}));
+vi.mock('@/components/ReconciliationSummary', () => ({
+  ReconciliationSummary: () => null,
+}));
+vi.mock('@/components/OCRBarcodeScanner', () => ({
+  OCRBarcodeScanner: () => null,
+}));
+vi.mock('@/components/KeyboardBarcodeScanner', () => ({
+  KeyboardBarcodeScanner: () => null,
+}));
+vi.mock('@/components/ImageCapture', () => ({
+  ImageCapture: () => null,
+}));
+
+// The component under test's collaborator: mocked to a single button that
+// invokes onCountProduct with a known product, so we can assert Inventory.tsx
+// wires it through to the dialog correctly without depending on the grid's
+// own virtualization/rendering internals.
+vi.mock('@/components/inventory/VirtualizedProductGrid', () => ({
+  VirtualizedProductGrid: (props: { onCountProduct?: (product: Product) => void }) => (
+    <div data-testid="virtualized-grid">
+      <button onClick={() => props.onCountProduct?.(testProduct)}>
+        trigger-count
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('@/components/InventorySettings', () => ({
+  InventorySettings: () => null,
+}));
+vi.mock('@/components/RestaurantSelector', () => ({
+  RestaurantSelector: () => null,
+}));
+
+// Mock hooks
+vi.mock('@/hooks/useProducts', () => ({
+  useProducts: () => ({
+    products: [testProduct],
+    loading: false,
+    createProduct: vi.fn(async () => ({ id: 'new-1', name: 'Test Product' })),
+    updateProductWithQuantity: vi.fn(),
+    deleteProduct: vi.fn(),
+    findProductByGtin: vi.fn(async () => null),
+    refetchProducts: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useInventoryAudit', () => ({
+  useInventoryAudit: () => ({
+    updateProductStockWithAudit: vi.fn(async () => true),
+  }),
+}));
+
+vi.mock('@/hooks/useInventoryMetrics', () => ({
+  useInventoryMetrics: () => ({
+    productMetrics: {},
+    totalInventoryCost: 0,
+    totalInventoryValue: 0,
+    loading: false,
+    calculationSummary: { recipeBasedCount: 0, estimatedCount: 0, mixedCount: 0 },
+  }),
+}));
+
+vi.mock('@/hooks/useInventoryAlerts', () => ({
+  useInventoryAlerts: () => ({ lowStockItems: [], exportLowStockCSV: vi.fn() }),
+}));
+
+vi.mock('@/hooks/useAllProductRecipes', () => ({
+  useAllProductRecipes: () => ({ recipesByProduct: {} }),
+}));
+
+vi.mock('@/hooks/useReconciliation', () => ({
+  useReconciliation: () => ({
+    activeSession: null,
+    startReconciliation: vi.fn(),
+    resumeReconciliation: vi.fn(),
+    refreshSession: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { id: 'user-1', email: 'test@test.com' } }),
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => ({
+    selectedRestaurant: {
+      restaurant_id: 'r1',
+      role: 'owner',
+      restaurant: { id: 'r1', name: 'Test Restaurant' },
+    },
+    setSelectedRestaurant: vi.fn(),
+    restaurants: [],
+    loading: false,
+    createRestaurant: vi.fn(),
+    canCreateRestaurant: false,
+  }),
+}));
+
+vi.mock('@/services/productLookupService', () => ({
+  productLookupService: {
+    lookupProduct: vi.fn(async () => null),
+  },
+}));
+
+vi.mock('@/services/productEnhancementService', () => ({
+  ProductEnhancementService: {
+    enhanceProduct: vi.fn(),
+  },
+}));
+
+vi.mock('@/services/ocrService', () => ({
+  ocrService: {},
+}));
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: vi.fn(() => ({
+      update: vi.fn(() => ({ eq: vi.fn(() => ({ error: null })) })),
+    })),
+  },
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+  useSearchParams: () => [new URLSearchParams(), vi.fn()],
+}));
+
+// ─── Import after mocks ────────────────────────────────────────────────────────
+
+import { Inventory } from '@/pages/Inventory';
+
+// ─── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('Inventory "Count" button wiring (Task 3.3)', () => {
+  it('opens the QuickInventoryDialog in add mode for the counted product', async () => {
+    const user = userEvent.setup();
+    render(<Inventory />);
+
+    // Products tab is the default — the grid (mocked) is already visible.
+    expect(screen.getByTestId('virtualized-grid')).toBeInTheDocument();
+
+    // Dialog is not rendered until a product is selected for quick-count.
+    expect(screen.queryByTestId('quick-inventory-dialog')).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'trigger-count' }));
+
+    const dialog = screen.getByTestId('quick-inventory-dialog');
+    expect(dialog).toHaveAttribute('data-open', 'true');
+    expect(dialog).toHaveAttribute('data-mode', 'add');
+    expect(dialog).toHaveAttribute('data-product-name', 'Tomatoes');
+  });
+});

--- a/tests/unit/Inventory.countButton.test.tsx
+++ b/tests/unit/Inventory.countButton.test.tsx
@@ -255,8 +255,10 @@ describe('Inventory quick-count audit wording (Task 3.4)', () => {
     await user.click(screen.getByRole('button', { name: 'trigger-save' }));
 
     expect(updateProductStockWithAuditMock).toHaveBeenCalledTimes(1);
-    const [, , , , , , reason, reference] = updateProductStockWithAuditMock.mock.calls[0];
-    expect(reason).toBe('Adjustment - Added 3.5 via manual count');
-    expect(reference).toMatch(/^manual_count_\d+$/);
+    // updateProductStockWithAudit(restaurantId, productId, newStock, oldStock,
+    // unitCost, transactionType, reason, referenceId) — args 6 and 7.
+    const call = updateProductStockWithAuditMock.mock.calls[0];
+    expect(call[6]).toBe('Adjustment - Added 3.5 via manual count');
+    expect(call[7]).toMatch(/^manual_count_\d+$/);
   });
 });

--- a/tests/unit/Inventory.countButton.test.tsx
+++ b/tests/unit/Inventory.countButton.test.tsx
@@ -6,7 +6,7 @@
  * QuickInventoryDialog in 'add' mode for that exact product.
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
@@ -220,6 +220,10 @@ vi.mock('react-router-dom', () => ({
 import { Inventory } from '@/pages/Inventory';
 
 // ─── Tests ─────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  updateProductStockWithAuditMock.mockClear();
+});
 
 describe('Inventory "Count" button wiring (Task 3.3)', () => {
   it('opens the QuickInventoryDialog in add mode for the counted product', async () => {

--- a/tests/unit/QuickInventoryDialog.modeToggle.test.tsx
+++ b/tests/unit/QuickInventoryDialog.modeToggle.test.tsx
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QuickInventoryDialog } from '@/components/QuickInventoryDialog';
+import type { Product } from '@/hooks/useProducts';
+
+// ---------------------------------------------------------------------------
+// Mocks — mirrors tests/unit/QuickInventoryDialog.a11y.test.tsx so the dialog
+// renders in jsdom without Radix portals/animations.
+// ---------------------------------------------------------------------------
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children, open }: { children: React.ReactNode; open?: boolean }) =>
+    open ? React.createElement('div', { role: 'dialog' }, children) : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('div', { 'data-testid': 'dialog-content' }, children),
+  DialogHeader: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('div', { 'data-testid': 'dialog-header' }, children),
+  DialogTitle: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('h2', null, children),
+  DialogDescription: ({ children }: { children: React.ReactNode }) =>
+    React.createElement('p', null, children),
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, onClick, disabled, title, 'aria-label': ariaLabel, className }: {
+    children: React.ReactNode;
+    onClick?: React.MouseEventHandler<HTMLButtonElement>;
+    disabled?: boolean;
+    title?: string;
+    'aria-label'?: string;
+    className?: string;
+  }) =>
+    React.createElement(
+      'button',
+      { onClick, disabled, title, 'aria-label': ariaLabel, className },
+      children
+    ),
+}));
+
+vi.mock('@/components/ui/label', () => ({
+  Label: ({ children, htmlFor }: { children: React.ReactNode; htmlFor?: string }) =>
+    React.createElement('label', { htmlFor }, children),
+}));
+
+vi.mock('@/components/LocationCombobox', () => ({
+  LocationCombobox: ({ value, onValueChange }: {
+    value?: string;
+    onValueChange?: (v: string) => void;
+  }) =>
+    React.createElement('input', {
+      'data-testid': 'location-combobox',
+      value: value ?? '',
+      onChange: (e: React.ChangeEvent<HTMLInputElement>) => onValueChange?.(e.target.value),
+    }),
+}));
+
+vi.mock('@/utils/calculator', () => ({
+  evaluateExpression: (expr: string) => {
+    const n = parseFloat(expr);
+    return isNaN(n) || n <= 0 ? null : n;
+  },
+  formatCalculatorResult: (n: number) => String(n),
+}));
+
+vi.mock('lucide-react', () => {
+  const icon = (name: string) => () =>
+    React.createElement('svg', { 'data-testid': `icon-${name}` });
+  return {
+    Package: icon('package'),
+    Check: icon('check'),
+    Plus: icon('plus'),
+    Minus: icon('minus'),
+    X: icon('x'),
+    Divide: icon('divide'),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const createWrapper = () => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: qc }, children);
+};
+
+const product = {
+  id: 'p1',
+  name: 'Roma Tomatoes',
+  uom_purchase: 'kg',
+  current_stock: 5,
+  restaurant_id: 'r1',
+} as Product;
+
+const baseProps = {
+  open: true,
+  onOpenChange: vi.fn(),
+  product,
+  onSave: vi.fn(),
+  restaurantId: 'r1',
+};
+
+const renderDialog = (over: Partial<React.ComponentProps<typeof QuickInventoryDialog>> = {}) =>
+  render(
+    React.createElement(QuickInventoryDialog, {
+      ...baseProps,
+      mode: 'add' as const,
+      ...over,
+    }),
+    { wrapper: createWrapper() }
+  );
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('QuickInventoryDialog — count mode toggle', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('does not render the toggle when onModeChange is omitted', () => {
+    // The reconciliation call sites pass a fixed mode="add" and must keep
+    // their current, non-switchable UI.
+    renderDialog();
+    expect(screen.queryByRole('radiogroup', { name: /count mode/i })).toBeNull();
+  });
+
+  it('renders the toggle when onModeChange is provided', () => {
+    renderDialog({ onModeChange: vi.fn() });
+    expect(
+      screen.getByRole('radiogroup', { name: /count mode/i })
+    ).toBeInTheDocument();
+  });
+
+  it('marks the active mode as checked', () => {
+    renderDialog({ mode: 'add', onModeChange: vi.fn() });
+    expect(screen.getByRole('radio', { name: /add to stock/i })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
+    expect(screen.getByRole('radio', { name: /set total/i })).toHaveAttribute(
+      'aria-checked',
+      'false'
+    );
+  });
+
+  it('calls onModeChange with "reconcile" when Set total is clicked', async () => {
+    const onModeChange = vi.fn();
+    renderDialog({ mode: 'add', onModeChange });
+    await userEvent.click(screen.getByRole('radio', { name: /set total/i }));
+    expect(onModeChange).toHaveBeenCalledWith('reconcile');
+  });
+
+  it('calls onModeChange with "add" when Add to stock is clicked from reconcile', async () => {
+    const onModeChange = vi.fn();
+    renderDialog({ mode: 'reconcile', onModeChange });
+    await userEvent.click(screen.getByRole('radio', { name: /add to stock/i }));
+    expect(onModeChange).toHaveBeenCalledWith('add');
+  });
+
+  it('switches the quantity label to reflect the active mode', () => {
+    const { unmount } = renderDialog({ mode: 'add', onModeChange: vi.fn() });
+    expect(screen.getByText(/quantity to add/i)).toBeInTheDocument();
+    unmount();
+
+    renderDialog({ mode: 'reconcile', onModeChange: vi.fn() });
+    expect(screen.getByText(/total quantity/i)).toBeInTheDocument();
+  });
+});

--- a/tests/unit/QuickInventoryDialog.modeToggle.test.tsx
+++ b/tests/unit/QuickInventoryDialog.modeToggle.test.tsx
@@ -125,14 +125,41 @@ describe('QuickInventoryDialog — count mode toggle', () => {
     // The reconciliation call sites pass a fixed mode="add" and must keep
     // their current, non-switchable UI.
     renderDialog();
-    expect(screen.queryByRole('radiogroup', { name: /count mode/i })).toBeNull();
+    expect(screen.queryByRole('group', { name: /count mode/i })).toBeNull();
+    expect(screen.queryByRole('radio')).toBeNull();
   });
 
   it('renders the toggle when onModeChange is provided', () => {
     renderDialog({ onModeChange: vi.fn() });
     expect(
-      screen.getByRole('radiogroup', { name: /count mode/i })
+      screen.getByRole('group', { name: /count mode/i })
     ).toBeInTheDocument();
+  });
+
+  it('is keyboard navigable: single tab stop, arrow moves focus, Enter selects', async () => {
+    // Regression guard for the original hand-rolled version, where BOTH options
+    // were independently tabbable and arrow keys did nothing at all.
+    //
+    // Radix ToggleGroup uses toggle-button semantics: arrows move focus, and
+    // Enter/Space commits the selection (it does not select on focus).
+    const onModeChange = vi.fn();
+    renderDialog({ mode: 'add', onModeChange });
+
+    const addRadio = screen.getByRole('radio', { name: /add to stock/i });
+    const setTotalRadio = screen.getByRole('radio', { name: /set total/i });
+
+    await userEvent.tab();
+    expect(addRadio).toHaveFocus();
+
+    // Roving tabindex: exactly one option is reachable via Tab.
+    expect(addRadio).toHaveAttribute('tabindex', '0');
+    expect(setTotalRadio).toHaveAttribute('tabindex', '-1');
+
+    await userEvent.keyboard('{ArrowRight}');
+    expect(setTotalRadio).toHaveFocus();
+
+    await userEvent.keyboard('{Enter}');
+    expect(onModeChange).toHaveBeenCalledWith('reconcile');
   });
 
   it('marks the active mode as checked', () => {

--- a/tests/unit/VirtualizedProductGrid.test.tsx
+++ b/tests/unit/VirtualizedProductGrid.test.tsx
@@ -4,6 +4,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { VirtualizedProductGrid } from '@/components/inventory/VirtualizedProductGrid';
+import type { Product } from '@/hooks/useProducts';
 
 // jsdom never runs layout, so every element's offsetWidth/offsetHeight is 0.
 // @tanstack/react-virtual measures its scroll container via `element.offsetHeight`
@@ -30,18 +31,18 @@ afterEach(() => {
   offsetWidthSpy.mockRestore();
 });
 
-// Minimal product matching the fields ProductCard reads. If the existing test
-// file already has a factory, use that instead of this literal.
-const product = {
+// Minimal product covering only the fields ProductCard actually reads.
+const product: Product = {
   id: 'p1',
   name: 'Tomatoes',
   current_stock: 5,
   uom_purchase: 'kg',
-  // add any other non-optional fields the component dereferences:
-} as any;
+} as Product;
 
-function renderGrid(overrides: Record<string, any> = {}) {
-  const props = {
+type GridProps = React.ComponentProps<typeof VirtualizedProductGrid>;
+
+function renderGrid(overrides: Partial<GridProps> = {}) {
+  const props: GridProps = {
     products: [product],
     inventoryMetrics: { productMetrics: {} },
     recipesByProduct: {},
@@ -52,10 +53,10 @@ function renderGrid(overrides: Record<string, any> = {}) {
     onTransferProduct: vi.fn(),
     onDeleteProduct: vi.fn(),
     ...overrides,
-  };
+  } as GridProps;
   render(
     <MemoryRouter>
-      <VirtualizedProductGrid {...(props as any)} />
+      <VirtualizedProductGrid {...props} />
     </MemoryRouter>,
   );
   return props;

--- a/tests/unit/VirtualizedProductGrid.test.tsx
+++ b/tests/unit/VirtualizedProductGrid.test.tsx
@@ -1,9 +1,34 @@
 import React from 'react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { VirtualizedProductGrid } from '@/components/inventory/VirtualizedProductGrid';
+
+// jsdom never runs layout, so every element's offsetWidth/offsetHeight is 0.
+// @tanstack/react-virtual measures its scroll container via `element.offsetHeight`
+// (see `getRect` in virtual-core) and only computes a visible range when that
+// size is > 0 — without this stub, `getVirtualItems()` always returns `[]` and
+// no rows (and therefore no Count button) are ever rendered, regardless of what
+// the component renders. Same "stub the layout jsdom won't compute" pattern
+// already used for `getBoundingClientRect` elsewhere in this test suite (e.g.
+// tests/unit/shiftTimelineTab.test.tsx).
+let offsetHeightSpy: ReturnType<typeof vi.spyOn>;
+let offsetWidthSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  offsetHeightSpy = vi
+    .spyOn(HTMLElement.prototype, 'offsetHeight', 'get')
+    .mockReturnValue(800);
+  offsetWidthSpy = vi
+    .spyOn(HTMLElement.prototype, 'offsetWidth', 'get')
+    .mockReturnValue(1200);
+});
+
+afterEach(() => {
+  offsetHeightSpy.mockRestore();
+  offsetWidthSpy.mockRestore();
+});
 
 // Minimal product matching the fields ProductCard reads. If the existing test
 // file already has a factory, use that instead of this literal.

--- a/tests/unit/VirtualizedProductGrid.test.tsx
+++ b/tests/unit/VirtualizedProductGrid.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { VirtualizedProductGrid } from '@/components/inventory/VirtualizedProductGrid';
+
+// Minimal product matching the fields ProductCard reads. If the existing test
+// file already has a factory, use that instead of this literal.
+const product = {
+  id: 'p1',
+  name: 'Tomatoes',
+  current_stock: 5,
+  uom_purchase: 'kg',
+  // add any other non-optional fields the component dereferences:
+} as any;
+
+function renderGrid(overrides: Record<string, any> = {}) {
+  const props = {
+    products: [product],
+    inventoryMetrics: { productMetrics: {} },
+    recipesByProduct: {},
+    canDeleteProducts: true,
+    onEditProduct: vi.fn(),
+    onCountProduct: vi.fn(),
+    onWasteProduct: vi.fn(),
+    onTransferProduct: vi.fn(),
+    onDeleteProduct: vi.fn(),
+    ...overrides,
+  };
+  render(
+    <MemoryRouter>
+      <VirtualizedProductGrid {...(props as any)} />
+    </MemoryRouter>,
+  );
+  return props;
+}
+
+describe('Count button', () => {
+  it('renders one Count button per card with a per-product aria-label', () => {
+    renderGrid();
+    expect(
+      screen.getByRole('button', { name: 'Count Tomatoes' }),
+    ).toBeInTheDocument();
+  });
+
+  it('calls onCountProduct with the product when clicked', async () => {
+    const props = renderGrid();
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Count Tomatoes' }),
+    );
+    expect(props.onCountProduct).toHaveBeenCalledWith(product);
+  });
+
+  it('does not trigger the card-tap Edit handler when Count is clicked', async () => {
+    const props = renderGrid();
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Count Tomatoes' }),
+    );
+    expect(props.onEditProduct).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/quickInventoryAudit.test.ts
+++ b/tests/unit/quickInventoryAudit.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { buildQuickInventoryAudit } from '@/utils/quickInventoryAudit';
+
+describe('buildQuickInventoryAudit', () => {
+  it('preserves the exact scan + add wording (raw quantity, no rounding)', () => {
+    const { reason } = buildQuickInventoryAudit('scan', 'add', 3.5, 1000);
+    expect(reason).toBe('Adjustment - Added 3.5 via quick scan');
+  });
+
+  it('preserves the exact scan + reconcile wording', () => {
+    const { reason } = buildQuickInventoryAudit('scan', 'reconcile', 12, 1000);
+    expect(reason).toBe('Inventory reconciliation - Set to 12 via quick scan');
+  });
+
+  it('labels manual + add as "via manual count"', () => {
+    const { reason } = buildQuickInventoryAudit('manual', 'add', 3.5, 1000);
+    expect(reason).toBe('Adjustment - Added 3.5 via manual count');
+  });
+
+  it('labels manual + reconcile as "via manual count"', () => {
+    const { reason } = buildQuickInventoryAudit('manual', 'reconcile', 12, 1000);
+    expect(reason).toBe('Inventory reconciliation - Set to 12 via manual count');
+  });
+
+  it('prefixes the scan reference with quick_scan_ and includes the timestamp', () => {
+    const { reference } = buildQuickInventoryAudit('scan', 'add', 1, 1737700000000);
+    expect(reference).toBe('quick_scan_1737700000000');
+  });
+
+  it('prefixes the manual reference with manual_count_ and includes the timestamp', () => {
+    const { reference } = buildQuickInventoryAudit('manual', 'add', 1, 1737700000000);
+    expect(reference).toBe('manual_count_1737700000000');
+  });
+
+  it('does not round or reformat the quantity', () => {
+    const { reason } = buildQuickInventoryAudit('manual', 'add', 0.333333, 1000);
+    expect(reason).toBe('Adjustment - Added 0.333333 via manual count');
+  });
+});

--- a/tests/unit/quickInventoryAudit.test.ts
+++ b/tests/unit/quickInventoryAudit.test.ts
@@ -36,4 +36,17 @@ describe('buildQuickInventoryAudit', () => {
     const { reason } = buildQuickInventoryAudit('manual', 'add', 0.333333, 1000);
     expect(reason).toBe('Adjustment - Added 0.333333 via manual count');
   });
+
+  it('accepts a zero quantity (e.g. reconciling a stock-out to 0)', () => {
+    const { reason } = buildQuickInventoryAudit('manual', 'reconcile', 0, 1000);
+    expect(reason).toBe('Inventory reconciliation - Set to 0 via manual count');
+  });
+
+  it('does not reject or clamp a negative quantity — interpolates it as-is', () => {
+    // buildQuickInventoryAudit is a pure string formatter; validating/rejecting
+    // negative quantities is the caller's responsibility (QuickInventoryDialog's
+    // input), not this helper's. Documenting the current pass-through behavior.
+    const { reason } = buildQuickInventoryAudit('scan', 'add', -2, 1000);
+    expect(reason).toBe('Adjustment - Added -2 via quick scan');
+  });
 });


### PR DESCRIPTION
## Problem

The in-app numpad "calculadora de conteo" (`QuickInventoryDialog`) has exactly **one** trigger today: a barcode scan that both (a) *captures* on the device **and** (b) *exactly* matches a stored `gtin`/`sku`. On Mobile Safari both gates fail silently, so the calculator never appears — the exact complaint from a 2026-07-20 survey response: *"Aquí no me esta saliendo la calculadora de conteo para los inventarios."*

- **Mode A — capture never happens.** `SmartBarcodeScanner` forces iOS/Safari down the least-reliable `Html5Qrcode` fallback engine; the barcode is often never decoded.
- **Mode B — resolution misses.** Even on a good decode, `findProductByGtin` matches only on **exact** `gtin`/`sku` equality, so a near-miss returns `null` and routes to the full new-product form.

This PR **routes around both** by adding a scan-independent way to open the calculator. Fixing Mode A and Mode B are tracked as follow-ups (below).

## What this ships

A dedicated **"Count" button** on every product card in the Inventory products grid that opens `QuickInventoryDialog` directly for that product — no scanning required.

- New full-width `CardFooter` button (Calculator icon + "Count"), CLAUDE.md **primary** treatment so it's obviously findable. It's a **sibling** of the `CardContent` that owns the card-tap → no propagation to the existing Edit action.
- Card tap still opens Edit; scanning still works exactly as before.
- Manual counts default to **add-to-stock** mode (matching the scan default); the dialog still lets the user switch to reconcile.
- **Audit provenance fixed:** extracted a pure `buildQuickInventoryAudit(source, mode, quantity, timestamp)` helper so a manual count is logged as `via manual count` / `manual_count_*` instead of being mislabeled `via quick scan`. The scan-path wording is reproduced **byte-for-byte** (raw, unformatted quantity) so existing scan audit strings are unchanged.

No DB/RPC/RLS surface — writes go through the existing `updateProductStockWithAudit` path.

## Changes

| File | Change |
|---|---|
| `src/utils/quickInventoryAudit.ts` (new) | Pure audit `reason`/`reference` builder keyed on `scan` vs `manual` |
| `src/components/inventory/VirtualizedProductGrid.tsx` | `onCountProduct` prop; Count button in a new `CardFooter`; bump `ESTIMATED_ROW_HEIGHT` 320→380 |
| `src/pages/Inventory.tsx` | `quickEntrySource` state; scan path tags `'scan'`; Count trigger tags `'manual'` + opens dialog; route audit strings through the helper |

## Testing

- **New unit tests:** `quickInventoryAudit.test.ts` (wording + reference prefix per `source × mode`, unformatted quantity), `VirtualizedProductGrid.test.tsx` (Count button renders / click fires `onCountProduct` / does **not** fire Edit), `Inventory.countButton.test.tsx` (page wiring).
- ✅ `npm run test` — 7341 passed, 0 failed
- ✅ `npm run test:db` — 1981 passed (clean DB)
- ✅ `npm run typecheck` — 0 errors
- ✅ `npm run lint` — no new issues in touched files (pre-existing only, verified against `main`)
- ✅ `npm run build` — success
- ✅ `npm run test:e2e` — 157 passed / 12 skipped / 1 failed. The single failure (`manual-sale-tip-not-doubled.spec.ts`) is **pre-existing on `main`** (reproduced there with no diff applied) and unrelated to this change (inventory-only diff, no sales/tip/POS files).

## Follow-ups (out of scope)

1. Mobile-Safari scan capture (Mode A) — evaluate `@zxing/browser` / native `BarcodeDetector`.
2. Exact-match resolution brittleness (Mode B) — GTIN check-digit / leading-zero normalization or fuzzy SKU match with confirmation.
3. `ProductCard` virtualization compliance — wrap in `React.memo` + stabilize per-row callbacks (pre-existing debt).
4. Pre-existing flaky/broken e2e `manual-sale-tip-not-doubled.spec.ts` (fails on `main`).

Design & plan: `docs/superpowers/specs/2026-07-24-inventory-tap-to-count-design.md`, `docs/superpowers/plans/2026-07-24-inventory-tap-to-count-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full-width “Count” button to each inventory product card to open quick inventory entry in the correct product context (without scanning).
  * Introduced a Count Mode toggle in the quick inventory dialog (add vs reconcile) when supported by the parent flow.
* **Refactor**
  * Centralized quick-inventory audit wording into a reusable helper to ensure consistent, exact audit reason/reference values.
* **Tests**
  * Added unit tests for the Count button behavior, the dialog mode toggle interactions, and audit-string accuracy.
* **Documentation**
  * Added tap-to-count inventory design and implementation plan documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->