### PR TITLE
fix(dev-workflow): close three review gaps that let a real bug ship

### DIFF
--- a/.claude/agents/frontend-design-reviewer.md
+++ b/.claude/agents/frontend-design-reviewer.md
@@ -9,6 +9,33 @@ subagent_type: general-purpose
 You are reviewing a **design document**, not code. Catch UX, accessibility,
 and performance mistakes BEFORE TDD locks them in.
 
+## STEP 0 — Premise check (do this FIRST, non-skippable)
+
+Before reviewing your own domain, verify the design's claims about
+**existing** code. This step is not optional and applies even if the rest of
+the design falls outside your specialty.
+
+1. Extract every statement the doc makes about how the current codebase
+   already behaves (e.g. "the dialog already lets the user switch modes",
+   "this RPC already checks `auth.uid()`", "the hook already debounces").
+2. **Uncited claim** — no `path/to/file.ts:123` reference → report
+   `critical`. The author must cite it or delete it.
+3. **Cited claim** — open the cited file and confirm the code actually does
+   what the doc says. Contradicted by the code → report `critical`, quoting
+   the relevant lines.
+
+Never accept a claim because it sounds plausible, or because the rest of the
+design depends on it being true. That dependency is precisely the risk: a
+design resting on a false premise passes every downstream check, because
+tests verify the build matches the spec and nobody writes a test for
+behaviour they believe already exists.
+
+Real incident this prevents: a design asserted a dialog "still lets the user
+switch to reconcile". It did not — the prop was read-only and the alternate
+mode was unreachable dead code. Five specialist reviewers, a Codex
+adversarial pass and two CodeRabbit runs all checked the diff against that
+document, found it conformant, and shipped the bug to the PR.
+
 ## Skill loadout
 
 Invoke these via the `Skill` tool before you start, in order:

--- a/.claude/agents/supabase-design-reviewer.md
+++ b/.claude/agents/supabase-design-reviewer.md
@@ -10,6 +10,33 @@ You are reviewing a **design document**, not code. Your job is to catch
 architectural mistakes BEFORE they propagate into TDD and reviewable diffs —
 fixes here are 10× cheaper than fixes in PR review.
 
+## STEP 0 — Premise check (do this FIRST, non-skippable)
+
+Before reviewing your own domain, verify the design's claims about
+**existing** code. This step is not optional and applies even if the rest of
+the design falls outside your specialty.
+
+1. Extract every statement the doc makes about how the current codebase
+   already behaves (e.g. "the dialog already lets the user switch modes",
+   "this RPC already checks `auth.uid()`", "the hook already debounces").
+2. **Uncited claim** — no `path/to/file.ts:123` reference → report
+   `critical`. The author must cite it or delete it.
+3. **Cited claim** — open the cited file and confirm the code actually does
+   what the doc says. Contradicted by the code → report `critical`, quoting
+   the relevant lines.
+
+Never accept a claim because it sounds plausible, or because the rest of the
+design depends on it being true. That dependency is precisely the risk: a
+design resting on a false premise passes every downstream check, because
+tests verify the build matches the spec and nobody writes a test for
+behaviour they believe already exists.
+
+Real incident this prevents: a design asserted a dialog "still lets the user
+switch to reconcile". It did not — the prop was read-only and the alternate
+mode was unreachable dead code. Five specialist reviewers, a Codex
+adversarial pass and two CodeRabbit runs all checked the diff against that
+document, found it conformant, and shipped the bug to the PR.
+
 ## Skill loadout
 
 Invoke these via the `Skill` tool before you start, in order:

--- a/.claude/skills/development-workflow.md
+++ b/.claude/skills/development-workflow.md
@@ -151,6 +151,31 @@ If `git stash push` reports "No local changes to save," skip step 3's `git stash
 
 **Skip condition:** None. Every task gets at least a brief design pass.
 
+### MANDATORY: cite `file:line` for every claim about existing code
+
+Any statement the design doc makes about how the **current** codebase
+behaves — "the dialog already lets the user switch modes", "this hook
+already debounces", "the RPC already checks `auth.uid()`" — MUST carry a
+`path/to/file.ts:123` citation.
+
+**Why:** claims about code you are *not* changing are invisible to every
+downstream check. Tests verify that what you built matches the spec; they
+cannot tell you the spec's premises were false, and nobody writes a test
+for behaviour they believe already exists. A false premise therefore
+passes build, review, unit tests and E2E untouched.
+
+This happened: a design asserted a dialog "still lets the user switch to
+reconcile". It did not — the prop was read-only and the alternate mode was
+unreachable dead code. Five specialist reviewers, a Codex adversarial pass
+and two CodeRabbit runs all validated the diff *against that document* and
+found nothing. The bug reached the PR.
+
+The rule is cheap because **the act of looking up the line number is what
+exposes the falsehood.** Write the claim, go find its line, and either cite
+it or discover you were wrong.
+
+Uncited claims about existing behaviour are a Phase 2.5 blocker.
+
 ## Phase 2.5: Design Review
 
 **Trigger:** Runs immediately after the design doc is committed (end of
@@ -194,10 +219,29 @@ passing the design doc path. Prompts live at:
   performance (virtualization, memoization, single-dialog pattern,
   React Query staleTime), shadcn idioms, routing, form ergonomics.
 
+#### Premise check (BOTH reviewers, non-skippable)
+
+Before reviewing anything else, each reviewer verifies the design's claims
+about **existing** code:
+
+1. Extract every statement the doc makes about how the current codebase
+   behaves.
+2. **Uncited claim** (no `file:line`) → report as `critical`. The author
+   must cite it or remove it.
+3. **Cited claim** → open the cited file and confirm it actually says that.
+   A claim contradicted by the code is `critical`.
+
+Do not accept a claim because it is plausible or because the rest of the
+design depends on it — a design whose foundation is false is exactly the
+case this check exists to catch. This runs even when the reviewer would
+otherwise be skipped for its domain.
+
 ### Skip conditions
 
 - **Supabase reviewer:** Skipped only when the design touches no
   DB/edge-function/SQL surface (keyword-based). When ambiguous, run it.
+- **Premise check:** Never skipped. If both domain reviewers are skipped,
+  still run one of them for the premise check alone.
 - **Frontend reviewer:** Skipped only when no UI/component surface is
   touched. When ambiguous, run it.
 - **Both skipped** when the task is a workflow- or doc-only change
@@ -396,12 +440,37 @@ npm i -g @openai/codex && codex login
 3. Classify each:
    - **Actionable bug / security / correctness** → Fix it. Commit:
      `fix(review): <area> — addresses <reviewer> finding`.
-   - **Style / nit** → Skip (CodeRabbit Phase 7c catches these).
-   - **False positive** → Note in retrospective; skip.
+   - **Trivially safe minor** (one-line, mechanical, no behaviour change)
+     → Fix it in the same commit.
+   - **Everything else not fixed** → Return it in `deferred[]` with a
+     reason. It gets listed in the PR body under
+     "Known deferred review findings".
 4. After fixes commit, **re-invoke any reviewer that flagged a fixed
    issue** to confirm the fix resolved it.
 
-`minor` findings are deferred to CodeRabbit and/or the retrospective.
+**Never discard a finding silently.** "CodeRabbit will catch it in 7c" is
+not a valid reason to drop one — 7c reviews a different surface and misses
+them regularly. This is not hypothetical: three `minor` ocr-rules findings
+were dropped here on that assumption, local CodeRabbit never saw them, and
+the CodeRabbit *GitHub bot* re-flagged the identical lines after the PR was
+already open. Anything absent from both the fixes and `deferred[]` is lost.
+
+### 7d — Re-review of post-snapshot code
+
+The Phase 7a diff is captured **once**, so 7b/7c fixes and any later edits
+would otherwise ship having never been reviewed by anyone.
+
+1. Diff `<7a snapshot SHA>..HEAD`. If empty, skip this step.
+2. Re-run the five reviewers against **only** that diff.
+3. Fold the results with the same rules as 7b (fix critical/major, fix
+   trivially-safe minors, `deferred[]` for the rest).
+
+Exactly **one** extra pass — it is a safety net, not a loop.
+
+Why it exists: on the tap-to-count PR the single riskiest change (a mode
+toggle altering inventory-write semantics in a dialog shared by four call
+sites) was written after the snapshot. No reviewer ever saw it; reviewing it
+after the fact found a real major a11y defect and a real minor logic bug.
 
 ### 7c — CodeRabbit local CLI (final gate)
 

--- a/.claude/workflows/dev-build-and-ship.js
+++ b/.claude/workflows/dev-build-and-ship.js
@@ -190,10 +190,10 @@ phase('Review')
 // can't reliably re-derive them).
 const snap = await agent(
   envelope(
-    'PHASE 7 setup. In the worktree, capture and RETURN as strings: (1) git diff origin/main...HEAD ; (2) git log origin/main..HEAD --oneline ; (3) the full contents of the design doc at ' + ctx.designDocPath + '. ' +
+    'PHASE 7 setup. In the worktree, capture and RETURN as strings: (1) git diff origin/main...HEAD ; (2) git log origin/main..HEAD --oneline ; (3) the full contents of the design doc at ' + ctx.designDocPath + ' ; (4) headSha = `git rev-parse HEAD` (used later to re-review anything committed after this snapshot). ' +
       'If the diff exceeds ~60000 chars, set diffTruncated=true, return it truncated, and ALSO write the full patch to dev-tools/phase7-diff.patch in the worktree.',
   ),
-  { label: 'review-snapshot', phase: 'Review', schema: statusSchema({ diff: { type: 'string' }, gitLog: { type: 'string' }, designDoc: { type: 'string' }, diffTruncated: { type: 'boolean' } }, ['diff', 'gitLog', 'designDoc']) },
+  { label: 'review-snapshot', phase: 'Review', schema: statusSchema({ diff: { type: 'string' }, gitLog: { type: 'string' }, designDoc: { type: 'string' }, headSha: { type: 'string' }, diffTruncated: { type: 'boolean' } }, ['diff', 'gitLog', 'designDoc', 'headSha']) },
 )
 { const g = gate(snap, 'Review'); if (g.halt) return g.out }
 
@@ -261,6 +261,23 @@ REVIEWERS.forEach((d, i) => {
   if (!reviewResults[i]) log(`⚠️ Phase 7a reviewer "${d.key}" returned no result (both attempts failed) — findings absent this run`)
 })
 
+// Shared return shape for the fold steps: every finding a fold agent chooses NOT
+// to fix must come back in `deferred[]`, so nothing is dropped on the floor.
+const DEFERRED = statusSchema(
+  {
+    deferred: {
+      type: 'array',
+      items: {
+        type: 'object',
+        additionalProperties: false,
+        properties: { file: { type: 'string' }, line: { type: 'number' }, severity: { type: 'string' }, message: { type: 'string' }, reason: { type: 'string' } },
+        required: ['severity', 'message', 'reason'],
+      },
+    },
+  },
+  ['deferred'],
+)
+
 // 7b: fold findings (single agent holds all results) -> fix actionable critical/major.
 const reviewerNames = [...REVIEWERS.map((d) => d.key), 'codex']
 const foldInput = JSON.stringify(
@@ -270,13 +287,20 @@ const foldInput = JSON.stringify(
 )
 const fold = await agent(
   envelope(
-    'PHASE 7b (Fold findings). Below is JSON with findings from all reviewers (5 Claude — security, performance, maintainability, sound-logic, ocr-rules — plus Codex). Deduplicate by file:line (keep highest severity, merge messages). For each critical/major finding that is an actionable bug/security/correctness issue: FIX it and commit ("fix(review): <area> — addresses <reviewer>"). Style/nits -> skip (CodeRabbit catches them in 7c). ' +
+    'PHASE 7b (Fold findings). Below is JSON with findings from all reviewers (5 Claude — security, performance, maintainability, sound-logic, ocr-rules — plus Codex). Deduplicate by file:line (keep highest severity, merge messages). For each critical/major finding that is an actionable bug/security/correctness issue: FIX it and commit ("fix(review): <area> — addresses <reviewer>"). ' +
+      'MINOR/INFO findings: fix any that are trivially safe (one-line, mechanical, no behaviour change) in the same commit. For every minor/info finding you do NOT fix, you MUST return it in `deferred[]` with file, line, severity, message and a one-line reason. ' +
+      'NEVER discard a finding silently — "CodeRabbit will catch it in 7c" is NOT a valid reason to drop one, because 7c reviews a different surface and regularly misses them. Anything omitted from both your fixes and `deferred[]` is lost.\n' +
       'If a critical/major fix would require changing the approved design (' + ctx.designDocPath + '), return status=needs_human with details — do NOT improvise. After fixing, re-verify critical/security findings only. Also read dev-tools/codex-review-output.md if it exists.\n\n' +
       '=== findings JSON ===\n' + foldInput,
   ),
-  { label: 'fold-findings', phase: 'Review', schema: statusSchema() },
+  { label: 'fold-findings', phase: 'Review', schema: DEFERRED },
 )
 { const g = gate(fold, 'Review'); if (g.halt) return g.out }
+
+// Carry unfixed findings forward so Phase 9 can surface them in the PR body.
+// Silent drops are how minor findings reached a PR unaddressed in the past.
+const deferredFindings = fold.deferred || []
+if (deferredFindings.length) log(`Phase 7b deferred ${deferredFindings.length} minor/info finding(s) — will be listed in the PR body`)
 
 // 7c: CodeRabbit loop (script-level counter, max 3).
 let crClean = false
@@ -292,6 +316,52 @@ for (let it = 1; it <= 3 && !crClean; it++) {
   const g = gate(cr, 'Review'); if (g.halt) return g.out
   crClean = cr.clean
   log(`CodeRabbit ${it}/3: ${crClean ? 'clean' : 'fixed findings, re-running'}`)
+}
+
+// 7d: bounded re-review of code committed AFTER the 7a snapshot.
+// The 7a diff is frozen, so 7b/7c fixes — and any late edits — otherwise ship
+// completely unreviewed. Exactly one extra pass; skipped when nothing changed.
+const postSnap = await agent(
+  envelope(
+    'PHASE 7d setup. In the worktree, return as strings: (1) newCommits = output of `git log ' + snap.headSha + '..HEAD --oneline` (empty string if there are none); ' +
+      '(2) diff = output of `git diff ' + snap.headSha + '..HEAD -- . ":(exclude)dev-tools" ":(exclude)progress.md"` (empty string if empty). Truncate diff to ~60000 chars if larger. Do NOT modify anything.',
+  ),
+  { label: 're-review-snapshot', phase: 'Review', schema: statusSchema({ newCommits: { type: 'string' }, diff: { type: 'string' } }, ['newCommits', 'diff']) },
+)
+{ const g = gate(postSnap, 'Review'); if (g.halt) return g.out }
+
+if (postSnap.diff && postSnap.diff.trim()) {
+  log('Phase 7d: re-reviewing code committed after the 7a snapshot')
+  const reResults = await parallel(
+    REVIEWERS.map((d) => () =>
+      agent(
+        envelope(
+          `PHASE 7d — ${d.key} re-review. Read your reviewer instructions at ${ctx.worktreePath}/${d.promptFile} and load the skills it names. ` +
+            'The changes below were committed AFTER the main review pass (Phase 7b/7c fixes and any late edits) and have NEVER been reviewed. Review ONLY this diff. Report findings with severity. DO NOT fix anything.\n\n' +
+            '=== new commits ===\n' + postSnap.newCommits + '\n\n=== diff ===\n' + postSnap.diff,
+        ),
+        { label: `re-review:${d.key}`, phase: 'Review', agentType: d.key === 'ocr-rules' ? 'general-purpose' : 'feature-dev:code-reviewer', schema: FINDINGS },
+      ),
+    ),
+  )
+  const reFindings = reResults.map((r, i) => (r ? { reviewer: REVIEWERS[i].key, findings: r.findings || [] } : null)).filter(Boolean)
+  if (reFindings.some((r) => r.findings.length)) {
+    const reFold = await agent(
+      envelope(
+        'PHASE 7d (fold re-review). The findings below come from re-reviewing code committed AFTER the main review pass. Deduplicate by file:line. FIX actionable critical/major findings and commit ("fix(review): <area> — addresses <reviewer> re-review"). ' +
+          'Fix trivially-safe minors too; return EVERY unfixed minor/info in `deferred[]` with a reason. Never discard a finding silently. ' +
+          'If a fix would require changing the approved design (' + ctx.designDocPath + '), return status=needs_human — do NOT improvise.\n\n' +
+          '=== findings JSON ===\n' + JSON.stringify(reFindings),
+      ),
+      { label: 're-review-fold', phase: 'Review', schema: DEFERRED },
+    )
+    const g = gate(reFold, 'Review'); if (g.halt) return g.out
+    deferredFindings.push(...(reFold.deferred || []))
+  } else {
+    log('Phase 7d: re-review found nothing in post-snapshot code')
+  }
+} else {
+  log('Phase 7d: no new commits since the 7a snapshot — re-review skipped')
 }
 
 // ===========================================================================
@@ -315,6 +385,10 @@ phase('Ship')
 const ship = await agent(
   envelope(
     'PHASE 9a (Ship). Push the branch: git push -u origin ' + ctx.branch + '. Open a PR with gh pr create: concise title (<70 chars), body with ## Summary (bullets from the plan), ## Test plan, and a link to the design doc. ' +
+      (deferredFindings.length
+        ? 'ALSO add a "## Known deferred review findings" section listing each item below verbatim (file:line — severity — message — why deferred), so reviewers see what was consciously not fixed rather than it being silently dropped:\n' +
+          JSON.stringify(deferredFindings, null, 2) + '\n'
+        : '') +
       'Return the PR number as prNumber. Update progress.md with it.',
   ),
   { label: 'ship', phase: 'Ship', schema: statusSchema({ prNumber: { type: 'number' } }, ['prNumber']) },


### PR DESCRIPTION
## Why

On [#658](https://github.com/toyiyo/nimble-pnl/pull/658) — five specialist reviewers, a local Codex adversarial pass, and two CodeRabbit runs all returned clean or trivia. An inventory-inflation bug still reached the PR, caught only by the GitHub Codex bot: a "Count" button that silently did `currentStock + quantity`, so a user entering a physical on-hand total would inflate stock.

Eight automated reviews missed it. These are the three mechanisms that let it through.

## 1. Design docs asserted unverified facts about existing code

The design claimed *"the dialog still lets the user switch to reconcile."* It didn't — `mode` was a read-only prop and `reconcile` was unreachable dead code.

Reviewers are handed the design as ground truth (`envelope()`: *"the approved design — do NOT deviate from it"*), so every one of them checked **"does the diff match the design?"** — it did, perfectly — and nobody checked whether the design's claims about *pre-existing* code were true.

**E2E tests cannot catch this class.** The false claim concerned code the change never touched. Nobody writes a test for behaviour they believe already exists, and the test that would have caught it only gets written by someone who already knows the truth — which is the premise check itself. All 8 e2e shards passed with the bug live.

**Fix:** every design-doc claim about existing code must cite `file:line`, enforced as a non-skippable **STEP 0 premise check** in both Phase 2.5 design reviewers — uncited claims are `critical`, cited claims get the file opened and verified. Deliberately cheaper than adding another reviewer agent: *the act of looking up the line number is what exposes the falsehood.*

## 2. Minor findings were discarded by instruction

Phase 7b read: *"Style/nits -> skip (CodeRabbit catches them in 7c)."* It doesn't — 7c reviews a different surface. Three `ocr-rules` findings were dropped on that assumption, local CodeRabbit went clean, and the CodeRabbit **GitHub bot** re-flagged the identical lines after the PR was open.

**Fix:** the fold now fixes trivially-safe minors and **must** return every unfixed finding in `deferred[]` with a reason. Those are surfaced in the PR body under "Known deferred review findings". Anything absent from both is explicitly called out as lost.

## 3. Post-snapshot code was never reviewed

The 7a diff is captured once, then 7b/7c commit fixes and Phase 8 commits more — none of it re-reviewed. On #658 the single riskiest change (a mode toggle altering inventory-write semantics in a dialog shared by four call sites) was written *after* the snapshot and had never been seen by any reviewer. Reviewing it after the fact found a real major a11y defect (hand-rolled `role="radiogroup"` with no roving tabindex or arrow keys) and a real minor logic bug.

**Fix:** new bounded **7d** pass re-reviews `<snapshot SHA>..HEAD` with the same five reviewers and the same fold rules. Exactly one iteration; skipped entirely when no new commits landed.

## Changes

| File | Change |
|---|---|
| `.claude/workflows/dev-build-and-ship.js` | `headSha` in snapshot; `DEFERRED` schema; 7b no longer discards minors; new 7d re-review; deferred list injected into PR body |
| `.claude/skills/development-workflow.md` | citation rule (Phase 2), premise check (Phase 2.5), 7b/7d prose synced to script |
| `.claude/agents/{supabase,frontend}-design-reviewer.md` | STEP 0 premise check |

## Test plan

Tooling-only — no product code, no `src/`, no tests, no DB surface.

- Script parses under the runtime's wrapper (top-level `await`/`return`): `PARSE OK`
- All declarations verified to precede their uses (`DEFERRED`, `deferredFindings`, `FINDINGS`, `snap.headSha`)
- `meta.phases` unchanged — 7d runs inside the existing `Review` phase
- Real validation is the next `/dev` run exercising it

Deliberately **not** run through `dev-build-and-ship` itself: using the orchestrator to fix the orchestrator is circular, and a mid-run edit to the script would apply inconsistently.

Note: PR #532 previously hardened this file and was closed unmerged; this is a fresh branch off current `main` and does not revive it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)