### PR TITLE
fix(scheduling): SPLH↔labor-% guard on settings + planner, gate fabricated wage

### DIFF
--- a/docs/superpowers/plans/2026-07-24-splh-labor-pct-consistency.md
+++ b/docs/superpowers/plans/2026-07-24-splh-labor-pct-consistency.md
@@ -1,0 +1,726 @@
+# SPLH ↔ Labor-% Consistency Guard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend PR #650's SPLH↔labor-% guard to the Settings Labor-Planning tab and the Planner's inline staffing panel, and stop all surfaces from computing an implied labor % off the fabricated $15/hr fallback wage.
+
+**Architecture:** `impliedLabor` / `laborConsistentSplh` move from `coverageChartModel.ts` to `staffingCalculator.ts` (the staffing-domain home, beside `computeAvgHourlyRateCents` which feeds them). A new `hasHourlyWageData` predicate gates every implied-% readout. No new math is written.
+
+**Tech Stack:** React 18 + TypeScript, Vitest, TailwindCSS, shadcn/ui.
+
+**Spec:** `docs/superpowers/specs/2026-07-24-splh-labor-pct-consistency-design.md`
+
+## Global Constraints
+
+- **Do not change** `impliedLabor` / `laborConsistentSplh` behavior: tolerance stays `0.05` percentage points, `wage` stays in **dollars**. Only their file location changes.
+- Over-target emphasis on new inline text uses the semantic token **`text-warning`** — never raw `text-amber-*`. `SplhSlider`'s existing pill keeps `bg-destructive/15 text-destructive` (untouched).
+- Typography: Planner hint `text-[11px]`; Settings hint `text-[13px]`; slider fallback `text-[13px] text-muted-foreground`.
+- Every hint renders inside an `aria-live="polite"` container.
+- Gate on `Number.isFinite(x) && x > 0` for both SPLH and labor-%, not a bare `> 0` — a cleared field parses to `NaN` and `NaN <= 0` is `false`.
+- Warn only — never disable or block a save.
+- `computeAvgHourlyRateCents` returns **cents**; call sites divide by 100 for the dollar `wage` these helpers take.
+
+---
+
+### Task 1: Move the shared math + add the roster predicate
+
+**Files:**
+- Modify: `src/lib/coverageChartModel.ts` (remove lines 54-92: `ImpliedLaborResult`, `impliedLabor`, `laborConsistentSplh`)
+- Modify: `src/lib/staffingCalculator.ts` (receive them + add `hasHourlyWageData`)
+- Modify: `src/components/scheduling/ShiftTimeline/SplhSlider.tsx:5` (import path)
+- Modify: `tests/unit/coverageChartModel.test.ts` (remove the two moved describe blocks + their imports)
+- Modify: `tests/unit/staffingCalculator.test.ts` (receive those blocks + new tests)
+
+**Interfaces:**
+- Produces (all from `@/lib/staffingCalculator`):
+  - `interface ImpliedLaborResult { pct: number; overTarget: boolean }`
+  - `impliedLabor(params: { wage: number; splh: number; targetLaborPct: number }): ImpliedLaborResult`
+  - `laborConsistentSplh(params: { wage: number; targetLaborPct: number }): number`
+  - `hasHourlyWageData(employees: Employee[] | undefined): boolean`
+
+- [ ] **Step 1: Write the failing tests for the new predicate**
+
+Append to `tests/unit/staffingCalculator.test.ts`. Extend its existing import from `@/lib/staffingCalculator` to add `hasHourlyWageData`, `impliedLabor`, and `laborConsistentSplh`, and add `import type { Employee } from '@/types/scheduling';` if absent.
+
+```typescript
+function emp(overrides: Partial<Employee> = {}): Employee {
+  return {
+    compensation_type: 'hourly',
+    is_active: true,
+    hourly_rate: 1000,
+    ...overrides,
+  } as Employee;
+}
+
+describe('hasHourlyWageData', () => {
+  it('should be false when the roster is undefined or empty', () => {
+    expect(hasHourlyWageData(undefined)).toBe(false);
+    expect(hasHourlyWageData([])).toBe(false);
+  });
+
+  it('should be false when every employee is salaried', () => {
+    expect(hasHourlyWageData([emp({ compensation_type: 'salary' })])).toBe(false);
+  });
+
+  it('should be false when the only hourly employee is inactive', () => {
+    expect(hasHourlyWageData([emp({ is_active: false })])).toBe(false);
+  });
+
+  it('should be true when at least one active hourly employee exists', () => {
+    expect(hasHourlyWageData([emp({ compensation_type: 'salary' }), emp()])).toBe(true);
+  });
+
+  it('should agree with computeAvgHourlyRateCents about when the wage is real', () => {
+    // Salaried-only → predicate false AND the wage is the $15 default, not derived.
+    const salaried = [emp({ compensation_type: 'salary', hourly_rate: 9999 })];
+    expect(hasHourlyWageData(salaried)).toBe(false);
+    expect(computeAvgHourlyRateCents(salaried)).toBe(1500);
+  });
+});
+
+describe('SPLH ↔ labor % identity (real-world case)', () => {
+  it('should flag $30 SPLH at $10/hr against a 25% target and name $40 as consistent', () => {
+    const { pct, overTarget } = impliedLabor({ wage: 10, splh: 30, targetLaborPct: 25 });
+    expect(pct).toBeCloseTo(33.33, 1);
+    expect(overTarget).toBe(true);
+    expect(laborConsistentSplh({ wage: 10, targetLaborPct: 25 })).toBe(40);
+  });
+
+  it('should not flag the labor-consistent SPLH when fed back through', () => {
+    for (const [wage, target] of [[10, 25], [10.37, 30], [18.75, 18], [22, 33]] as const) {
+      const consistent = laborConsistentSplh({ wage, targetLaborPct: target });
+      const { pct, overTarget } = impliedLabor({ wage, splh: consistent, targetLaborPct: target });
+      expect(pct).toBeCloseTo(target, 6);
+      expect(overTarget).toBe(false);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run tests/unit/staffingCalculator.test.ts`
+Expected: FAIL — `hasHourlyWageData is not a function` (and `impliedLabor` / `laborConsistentSplh` not exported from this module yet).
+
+- [ ] **Step 3: Move the two functions and add the predicate**
+
+In `src/lib/coverageChartModel.ts`, **delete** lines 54-92 — the `ImpliedLaborResult` interface, the `impliedLabor` function, and the `laborConsistentSplh` function, along with their JSDoc blocks. Leave `classifyHour` above and the `// ── Receipt ──` banner below untouched.
+
+In `src/lib/staffingCalculator.ts`, paste them verbatim (JSDoc included) directly after `computeAvgHourlyRateCents` (which ends at line 15), then add the predicate:
+
+```typescript
+/**
+ * True when the roster has at least one active hourly employee — i.e. the wage
+ * from computeAvgHourlyRateCents is real, not the DEFAULT_HOURLY_RATE_CENTS
+ * ($15/hr) fallback. Mirrors that function's own filter so the two can never
+ * disagree. Surfaces use this to suppress an implied-labor readout that would
+ * otherwise be derived from a wage nobody is paid.
+ */
+export function hasHourlyWageData(employees: Employee[] | undefined): boolean {
+  return !!employees?.some((e) => e.compensation_type === 'hourly' && e.is_active);
+}
+```
+
+- [ ] **Step 4: Update the import in SplhSlider**
+
+`src/components/scheduling/ShiftTimeline/SplhSlider.tsx:5` — change:
+
+```typescript
+import { impliedLabor, laborConsistentSplh } from '@/lib/coverageChartModel';
+```
+
+to:
+
+```typescript
+import { impliedLabor, laborConsistentSplh } from '@/lib/staffingCalculator';
+```
+
+Also update the JSDoc on line 63 that says "math from `coverageChartModel`" to say "math from `staffingCalculator`".
+
+- [ ] **Step 5: Move the existing test blocks**
+
+In `tests/unit/coverageChartModel.test.ts`, delete the `describe('impliedLabor', …)` and `describe('laborConsistentSplh', …)` blocks (lines 87-145) and remove `impliedLabor` / `laborConsistentSplh` from its import at lines 4-5. Paste both describe blocks **verbatim** into `tests/unit/staffingCalculator.test.ts`.
+
+- [ ] **Step 6: Run all affected suites**
+
+Run: `npx vitest run tests/unit/staffingCalculator.test.ts tests/unit/coverageChartModel.test.ts tests/unit/splhSlider.test.tsx tests/unit/coverageReceipt.test.tsx`
+Expected: PASS. The moved blocks must pass unchanged — behavior did not change.
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/lib/staffingCalculator.ts src/lib/coverageChartModel.ts src/components/scheduling/ShiftTimeline/SplhSlider.tsx tests/unit/staffingCalculator.test.ts tests/unit/coverageChartModel.test.ts
+git commit -m "refactor(staffing): move implied-labor math to staffingCalculator, add wage-data predicate"
+```
+
+---
+
+### Task 2: Gate the slider's readout, pill, notch, and aria-valuetext
+
+**Files:**
+- Modify: `src/components/scheduling/ShiftTimeline/SplhSlider.tsx`
+- Modify: `src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx`
+- Test: `tests/unit/splhSlider.test.tsx`
+
+**Interfaces:**
+- Consumes: `hasHourlyWageData` (Task 1).
+- Produces: new required prop `hasWageData: boolean` on `SplhSlider`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/unit/splhSlider.test.tsx`. Match the existing render-helper style in that file; if it has a `renderSlider(props)` helper, pass `hasWageData` through it, otherwise render `<SplhSlider … hasWageData={false} />` directly with the same props the existing tests use.
+
+```typescript
+describe('SplhSlider without wage data', () => {
+  it('should hide the pill and notch and show a prompt instead of a fabricated labor %', () => {
+    render(
+      <SplhSlider
+        value={60}
+        wage={15}
+        targetLaborPct={22}
+        hasWageData={false}
+        canSave
+        isSaving={false}
+        onChange={() => {}}
+        onSave={() => {}}
+        onReset={() => {}}
+      />,
+    );
+    expect(screen.queryByTestId('splh-slider-pill')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('splh-slider-notch')).not.toBeInTheDocument();
+    expect(screen.getByText('Add hourly rates')).toBeInTheDocument();
+    expect(screen.queryByText(/% labor at/)).not.toBeInTheDocument();
+  });
+
+  it('should keep the fabricated percentage out of aria-valuetext', () => {
+    render(
+      <SplhSlider
+        value={60}
+        wage={15}
+        targetLaborPct={22}
+        hasWageData={false}
+        canSave
+        isSaving={false}
+        onChange={() => {}}
+        onSave={() => {}}
+        onReset={() => {}}
+      />,
+    );
+    expect(screen.getByRole('slider')).toHaveAttribute('aria-valuetext', '$60/hr');
+  });
+});
+```
+
+Also add `hasWageData={true}` to every existing `SplhSlider` render in this file so the current assertions keep exercising the populated path.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run tests/unit/splhSlider.test.tsx`
+Expected: FAIL — the pill/notch still render and `aria-valuetext` still contains `% labor`.
+
+- [ ] **Step 3: Add the prop and gate the four outputs**
+
+In `SplhSlider.tsx`, add to `SplhSliderProps` after the `wage` field:
+
+```typescript
+  /**
+   * Whether `wage` reflects real roster data (`hasHourlyWageData`). When false,
+   * `computeAvgHourlyRateCents` returned its $15/hr fallback, so every
+   * implied-labor output is suppressed rather than presented as fact.
+   */
+  readonly hasWageData: boolean;
+```
+
+Add `hasWageData,` to the destructured params. Then:
+
+Replace the readout span (currently `→ {pctLabel}% labor at ${wage.toFixed(2)}/hr`) and the pill with a conditional:
+
+```tsx
+          {hasWageData ? (
+            <>
+              <span className="text-[13px] text-muted-foreground tabular-nums">
+                → {pctLabel}% labor at ${wage.toFixed(2)}/hr
+              </span>
+              <span
+                data-testid="splh-slider-pill"
+                className={cn(
+                  'text-[11px] font-medium px-1.5 py-0.5 rounded-md',
+                  overTarget ? 'bg-destructive/15 text-destructive' : 'bg-success/15 text-success',
+                )}
+              >
+                {overTarget ? 'Over target' : 'On target'}
+              </span>
+            </>
+          ) : (
+            <span className="text-[13px] text-muted-foreground">Add hourly rates</span>
+          )}
+```
+
+Wrap the notch `<div data-testid="splh-slider-notch" …>…</div>` in `{hasWageData && ( … )}`.
+
+Change `aria-valuetext` (line 141) to:
+
+```tsx
+          aria-valuetext={hasWageData ? `$${value}/hr → ${pctLabel}% labor` : `$${value}/hr`}
+```
+
+- [ ] **Step 4: Pass the prop from ShiftTimelineTab**
+
+In `ShiftTimelineTab.tsx`, add `hasHourlyWageData` to the existing `@/lib/staffingCalculator` import, then next to `avgWage` (line 505) add:
+
+```typescript
+  // Whether `avgWage` is real roster data or computeAvgHourlyRateCents's $15/hr
+  // fallback — gates every implied-labor readout (design §4a).
+  const hasWageData = hasHourlyWageData(employees);
+```
+
+Add `hasWageData={hasWageData}` to the `<SplhSlider>` props (after `wage={avgWage}`).
+
+- [ ] **Step 5: Run tests**
+
+Run: `npx vitest run tests/unit/splhSlider.test.tsx tests/unit/shiftTimelineTab.test.tsx`
+Expected: PASS.
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/scheduling/ShiftTimeline/SplhSlider.tsx src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx tests/unit/splhSlider.test.tsx
+git commit -m "fix(scheduling): suppress slider implied-labor readout without real wage data"
+```
+
+---
+
+### Task 3: Gate the receipt's implied-SPLH aside
+
+**Files:**
+- Modify: `src/lib/coverageChartModel.ts` (`buildReceipt`)
+- Modify: `src/components/scheduling/ShiftTimeline/CoverageReceipt.tsx`
+- Modify: `src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx`
+- Test: `tests/unit/coverageReceipt.test.tsx`
+
+**Interfaces:**
+- Consumes: `impliedLabor` from `@/lib/staffingCalculator` (Task 1); `hasWageData` from `ShiftTimelineTab` (Task 2).
+- Produces: `buildReceipt(h, { minStaff, weekdayKey, wage, lookbackWeeks, hasWageData })`; `CoverageReceipt` gains a `hasWageData: boolean` prop.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/coverageReceipt.test.tsx`, following that file's existing render helper and fixture style (it renders `<CoverageReceipt>` with a `CoverageHour`). Use a fixture whose `scheduled > 0` so the aside would otherwise appear:
+
+```typescript
+it('should omit the implied-SPLH aside when there is no real wage data', () => {
+  renderReceipt({ hasWageData: false });
+  expect(screen.queryByText(/implied SPLH is/)).not.toBeInTheDocument();
+});
+
+it('should still show the implied-SPLH aside when wage data is real', () => {
+  renderReceipt({ hasWageData: true });
+  expect(screen.getByText(/implied SPLH is/)).toBeInTheDocument();
+});
+```
+
+Add `hasWageData: true` to the existing render helper's defaults so current assertions keep passing.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run tests/unit/coverageReceipt.test.tsx`
+Expected: FAIL — the aside renders regardless.
+
+- [ ] **Step 3: Thread the flag and reuse `impliedLabor`**
+
+In `coverageChartModel.ts`, add `impliedLabor` to the existing `@/lib/staffingCalculator` import (create the import if the file has none), extend the `buildReceipt` params type (line 131) to
+`{ minStaff: number; weekdayKey: string; wage: number; lookbackWeeks: number; hasWageData: boolean }`,
+add `hasWageData` to the destructure on line 133, and replace the aside block (lines 188-192):
+
+```typescript
+  // Implied SPLH at the scheduled count — only meaningful when someone is
+  // actually scheduled (avoids a divide-by-zero and a nonsensical "$Infinity/hr"),
+  // and only honest when `wage` is real roster data rather than the $15/hr
+  // fallback (design §4a2).
+  if (scheduled > 0 && hasWageData) {
+    const splhAt = projectedSales / scheduled;
+    const laborPctAt = Math.round(impliedLabor({ wage, splh: splhAt, targetLaborPct: 0 }).pct);
+    asides.push(`At ${scheduled} scheduled, implied SPLH is ${fmtUsd(Math.round(splhAt))}/hr → ${laborPctAt}% labor.`);
+  }
+```
+
+(`targetLaborPct: 0` is passed because only `pct` is consumed here — the aside states a fact and carries no over/under-target judgement.)
+
+- [ ] **Step 4: Pass it through the component**
+
+In `CoverageReceipt.tsx`, add to `CoverageReceiptProps` after `wage`:
+
+```typescript
+  /** Whether `wage` is real roster data — gates the implied-SPLH aside. */
+  readonly hasWageData: boolean;
+```
+
+Add `hasWageData` to the destructured props and to the `buildReceipt` call on line 78:
+
+```typescript
+  const receipt = buildReceipt(hour, { minStaff, weekdayKey, wage, lookbackWeeks, hasWageData });
+```
+
+In `ShiftTimelineTab.tsx`, add `hasWageData={hasWageData}` to the `<CoverageReceipt>` props (after `wage={avgWage}`).
+
+- [ ] **Step 5: Run tests**
+
+Run: `npx vitest run tests/unit/coverageReceipt.test.tsx tests/unit/coverageChartModel.test.ts tests/unit/shiftTimelineTab.test.tsx`
+Expected: PASS.
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/coverageChartModel.ts src/components/scheduling/ShiftTimeline/CoverageReceipt.tsx src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx tests/unit/coverageReceipt.test.tsx
+git commit -m "fix(scheduling): gate receipt implied-SPLH aside on real wage data"
+```
+
+---
+
+### Task 4: Expose wage + flag from `useWeekStaffingSuggestions`
+
+**Files:**
+- Modify: `src/hooks/useWeekStaffingSuggestions.ts`
+- Test: `tests/unit/useWeekStaffingSuggestions.wageData.test.tsx` (create)
+
+**Interfaces:**
+- Consumes: `hasHourlyWageData` (Task 1).
+- Produces: two new fields on the hook's return object — `avgHourlyRateCents: number`, `hasWageData: boolean`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/useWeekStaffingSuggestions.wageData.test.tsx`. Mirror the mocking setup in the existing `tests/unit/useWeekStaffingSuggestions.actualSplh.test.ts` (it already mocks `useStaffingSettings`, `useEmployees`, `RestaurantContext`, and the supabase client) and use `renderHook`:
+
+```typescript
+it('should expose the blended wage and flag it as real for an hourly roster', () => {
+  mockEmployees([
+    { compensation_type: 'hourly', is_active: true, hourly_rate: 1000 },
+    { compensation_type: 'hourly', is_active: true, hourly_rate: 2000 },
+  ]);
+  const { result } = renderHook(() => useWeekStaffingSuggestions('r1', ['2026-07-27'], null), { wrapper });
+  expect(result.current.avgHourlyRateCents).toBe(1500);
+  expect(result.current.hasWageData).toBe(true);
+});
+
+it('should flag the fallback wage as not real for an empty roster', () => {
+  mockEmployees([]);
+  const { result } = renderHook(() => useWeekStaffingSuggestions('r1', ['2026-07-27'], null), { wrapper });
+  expect(result.current.avgHourlyRateCents).toBe(1500); // the $15 default
+  expect(result.current.hasWageData).toBe(false);       // …but not real data
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run tests/unit/useWeekStaffingSuggestions.wageData.test.tsx`
+Expected: FAIL — `expected undefined to be 1500`.
+
+- [ ] **Step 3: Derive and return the fields**
+
+In `src/hooks/useWeekStaffingSuggestions.ts`, add `hasHourlyWageData` to the existing `@/lib/staffingCalculator` import. After the `avgHourlyRateCents` useMemo (ends ~line 80), add:
+
+```typescript
+  const hasWageData = useMemo(() => hasHourlyWageData(employees), [employees]);
+```
+
+In the returned object, after `actualSplh,`, add:
+
+```typescript
+    avgHourlyRateCents,
+    hasWageData,
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `npx vitest run tests/unit/useWeekStaffingSuggestions.wageData.test.tsx tests/unit/useWeekStaffingSuggestions.actualSplh.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useWeekStaffingSuggestions.ts tests/unit/useWeekStaffingSuggestions.wageData.test.tsx
+git commit -m "feat(staffing): expose avg wage + hasWageData from week suggestions"
+```
+
+---
+
+### Task 5: Render the hint in the Planner panel
+
+**Files:**
+- Modify: `src/components/scheduling/ShiftPlanner/StaffingConfigPanel.tsx`
+- Modify: `src/components/scheduling/ShiftPlanner/StaffingOverlay.tsx`
+- Test: `tests/unit/StaffingConfigPanel.splhConsistency.test.tsx` (create)
+- Test: `tests/unit/StaffingOverlay.wiring.test.tsx` (extend)
+
+**Interfaces:**
+- Consumes: `impliedLabor`, `laborConsistentSplh` (Task 1); hook fields `avgHourlyRateCents`, `hasWageData` (Task 4).
+- Produces: `StaffingConfigPanel` props `avgHourlyRateCents: number`, `hasWageData: boolean`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/unit/StaffingConfigPanel.splhConsistency.test.tsx`, following the render style of the existing `tests/unit/StaffingConfigPanel.saveGating.test.tsx` (same required props; add the two new ones).
+
+```typescript
+const baseSettings = {
+  target_splh: 30,
+  target_labor_pct: 25,
+  min_staff: 1,
+  min_crew: null,
+};
+
+it('should hide the hint when there is no real wage data', () => {
+  renderPanel({ settings: baseSettings, avgHourlyRateCents: 1500, hasWageData: false });
+  expect(screen.queryByText(/labor at current wage/)).not.toBeInTheDocument();
+});
+
+it('should hide the hint when the SPLH target is not a finite positive number', () => {
+  renderPanel({ settings: { ...baseSettings, target_splh: Number.NaN }, avgHourlyRateCents: 1000, hasWageData: true });
+  expect(screen.queryByText(/labor at current wage/)).not.toBeInTheDocument();
+});
+
+it('should warn with the labor-consistent SPLH for the $10/hr, $30, 25% case', () => {
+  renderPanel({ settings: baseSettings, avgHourlyRateCents: 1000, hasWageData: true });
+  const line = screen.getByText(/33% labor at current wage/);
+  expect(line).toHaveClass('text-warning');
+  expect(line).toHaveTextContent('above your 25% target, try $40');
+});
+
+it('should render the implied line muted when within target', () => {
+  renderPanel({ settings: { ...baseSettings, target_splh: 40 }, avgHourlyRateCents: 1000, hasWageData: true });
+  const line = screen.getByText(/25% labor at current wage/);
+  expect(line).not.toHaveClass('text-warning');
+  expect(line).not.toHaveTextContent('above your');
+});
+
+it('should always show the directional helper line when the hint renders', () => {
+  renderPanel({ settings: baseSettings, avgHourlyRateCents: 1000, hasWageData: true });
+  expect(screen.getByText('Lower SPLH → more staff recommended.')).toBeInTheDocument();
+});
+
+it('should announce the hint politely', () => {
+  const { container } = renderPanel({ settings: baseSettings, avgHourlyRateCents: 1000, hasWageData: true });
+  expect(container.querySelector('[aria-live="polite"]')).not.toBeNull();
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run tests/unit/StaffingConfigPanel.splhConsistency.test.tsx`
+Expected: FAIL — nothing renders.
+
+- [ ] **Step 3: Add props and derive the values**
+
+In `StaffingConfigPanel.tsx`, add the import:
+
+```typescript
+import { impliedLabor, laborConsistentSplh } from '@/lib/staffingCalculator';
+```
+
+Add to `StaffingConfigPanelProps` (after `lookbackWeeks: number;`):
+
+```typescript
+  /** Blended hourly wage in cents (`computeAvgHourlyRateCents`). */
+  avgHourlyRateCents: number;
+  /** Whether that wage is real roster data — gates the implied-labor hint. */
+  hasWageData: boolean;
+```
+
+Add `avgHourlyRateCents,` and `hasWageData,` to the destructured params. After `const [newPosition, setNewPosition] = useState('');`, add:
+
+```typescript
+  // Implied labor % of the current SPLH target at the blended wage. Null when
+  // there is no real wage, or when either input is non-finite/non-positive —
+  // a cleared field parses to NaN, and `NaN <= 0` is false (design §4).
+  const splhHint = useMemo(() => {
+    const splh = settings.target_splh;
+    const target = settings.target_labor_pct;
+    const positive = (n: number) => Number.isFinite(n) && n > 0;
+    if (!hasWageData || !positive(splh) || !positive(target)) return null;
+    const wage = avgHourlyRateCents / 100;
+    const { pct, overTarget } = impliedLabor({ wage, splh, targetLaborPct: target });
+    return { pct, overTarget, consistent: laborConsistentSplh({ wage, targetLaborPct: target }) };
+  }, [avgHourlyRateCents, hasWageData, settings.target_splh, settings.target_labor_pct]);
+```
+
+- [ ] **Step 4: Render the hint**
+
+Directly after the existing `{actualSplh !== null && ( … )}` block in the SPLH column, add:
+
+```tsx
+          {splhHint && (
+            <div aria-live="polite" className="flex flex-col gap-0.5 max-w-[220px]">
+              <span className={`text-[11px] ${splhHint.overTarget ? 'text-warning' : 'text-muted-foreground/80'}`}>
+                ≈ {splhHint.pct.toFixed(0)}% labor at current wage
+                {splhHint.overTarget && (
+                  <> — above your {settings.target_labor_pct}% target, try ${Math.round(splhHint.consistent)}</>
+                )}
+              </span>
+              <span className="text-[11px] text-muted-foreground/70">
+                Lower SPLH → more staff recommended.
+              </span>
+            </div>
+          )}
+```
+
+- [ ] **Step 5: Wire from StaffingOverlay**
+
+In `StaffingOverlay.tsx`, add `avgHourlyRateCents,` and `hasWageData,` to the `useWeekStaffingSuggestions` destructure, and add these props to `<StaffingConfigPanel>`:
+
+```tsx
+                avgHourlyRateCents={avgHourlyRateCents}
+                hasWageData={hasWageData}
+```
+
+Then extend `tests/unit/StaffingOverlay.wiring.test.tsx` with an assertion that both values reach the panel (that file already mocks `StaffingConfigPanel`; capture its props and assert `avgHourlyRateCents` and `hasWageData` are present).
+
+- [ ] **Step 6: Run tests**
+
+Run: `npx vitest run tests/unit/StaffingConfigPanel.splhConsistency.test.tsx tests/unit/StaffingConfigPanel.saveGating.test.tsx tests/unit/StaffingOverlay.wiring.test.tsx tests/unit/StaffingOverlay.deadends.test.tsx tests/unit/StaffingOverlay.tz.test.tsx`
+Expected: PASS. If `StaffingConfigPanel.saveGating.test.tsx` fails on the two new required props, add `avgHourlyRateCents={1000} hasWageData={false}` to its render and commit that with this task.
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/scheduling/ShiftPlanner/StaffingConfigPanel.tsx src/components/scheduling/ShiftPlanner/StaffingOverlay.tsx tests/unit/StaffingConfigPanel.splhConsistency.test.tsx tests/unit/StaffingConfigPanel.saveGating.test.tsx tests/unit/StaffingOverlay.wiring.test.tsx
+git commit -m "feat(staffing): SPLH consistency hint in planner panel"
+```
+
+---
+
+### Task 6: Render the hint in the Settings Labor-Planning tab
+
+**Files:**
+- Modify: `src/pages/RestaurantSettings.tsx`
+- Test: `tests/unit/restaurantSettings.splhConsistency.test.tsx` (create)
+
+**Interfaces:**
+- Consumes: `useEmployees`; `computeAvgHourlyRateCents`, `hasHourlyWageData`, `impliedLabor`, `laborConsistentSplh` (Task 1).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/unit/restaurantSettings.splhConsistency.test.tsx`. Because `RestaurantSettings` is a large page with many providers, extract the smallest viable render: mock `useRestaurantContext`, `useAuth`, `useRestaurants`, `useStaffingSettings` (returning `effectiveSettings` with `target_splh: 30, target_labor_pct: 25`), and `useEmployees` (returning two active hourly employees at `hourly_rate: 1000`), then render the page and select the `labor-planning` tab. Follow the provider/mocking pattern already used by `tests/unit/StaffingOverlay.wiring.test.tsx`.
+
+```typescript
+it('should warn under both the SPLH and the labor % fields', async () => {
+  renderLaborPlanningTab();
+  const warnings = await screen.findAllByText(/33% labor at your current average wage/);
+  expect(warnings).toHaveLength(2);
+  warnings.forEach((w) => {
+    expect(w).toHaveClass('text-warning');
+    expect(w).toHaveTextContent('Try $40 to hit it.');
+  });
+});
+
+it('should hide the hint when the roster has no hourly employees', async () => {
+  renderLaborPlanningTab({ employees: [] });
+  expect(screen.queryByText(/labor at your current average wage/)).not.toBeInTheDocument();
+});
+
+it('should hide the hint when the SPLH field is cleared', async () => {
+  renderLaborPlanningTab();
+  await userEvent.clear(screen.getByLabelText(/Target SPLH/i));
+  expect(screen.queryByText(/labor at your current average wage/)).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run tests/unit/restaurantSettings.splhConsistency.test.tsx`
+Expected: FAIL — no hint rendered.
+
+- [ ] **Step 3: Add imports and derive the hint**
+
+In `src/pages/RestaurantSettings.tsx` add (grouped with the other hook/lib imports near line 32):
+
+```typescript
+import { useEmployees } from '@/hooks/useEmployees';
+import {
+  computeAvgHourlyRateCents,
+  hasHourlyWageData,
+  impliedLabor,
+  laborConsistentSplh,
+} from '@/lib/staffingCalculator';
+```
+
+`useMemo` is already imported on line 1. After the `useStaffingSettings` line (85), add:
+
+```typescript
+  const { employees: staffEmployees } = useEmployees(selectedRestaurant?.restaurant_id ?? null);
+  // Implied labor % of the SPLH currently typed into the form. Null when the
+  // roster has no real hourly wage, or when either field is blank/non-numeric
+  // (Number.parseFloat('') is NaN, and `NaN <= 0` is false — design §4).
+  const splhHint = useMemo(() => {
+    const splh = Number.parseFloat(lpTargetSplh);
+    const target = Number.parseFloat(lpTargetLaborPct);
+    const positive = (n: number) => Number.isFinite(n) && n > 0;
+    if (!hasHourlyWageData(staffEmployees) || !positive(splh) || !positive(target)) return null;
+    const wage = computeAvgHourlyRateCents(staffEmployees) / 100;
+    const { pct, overTarget } = impliedLabor({ wage, splh, targetLaborPct: target });
+    return { pct, overTarget, consistent: laborConsistentSplh({ wage, targetLaborPct: target }) };
+  }, [staffEmployees, lpTargetSplh, lpTargetLaborPct]);
+```
+
+- [ ] **Step 4: Extract the hint markup once, render it twice**
+
+Still inside the component (after `splhHint`), define:
+
+```tsx
+  const splhHintBlock = splhHint && (
+    <div aria-live="polite" className="flex flex-col gap-0.5">
+      <p className={`text-[13px] ${splhHint.overTarget ? 'text-warning' : 'text-muted-foreground'}`}>
+        ≈ {splhHint.pct.toFixed(0)}% labor at your current average wage
+        {splhHint.overTarget && (
+          <> — above your {lpTargetLaborPct}% target. Try ${Math.round(splhHint.consistent)} to hit it.</>
+        )}
+      </p>
+      <p className="text-[13px] text-muted-foreground/70">
+        Lowering this target increases recommended headcount.
+      </p>
+    </div>
+  );
+```
+
+Render `{splhHintBlock}` in two places: immediately after the closing `</p>` of `lpTargetSplh-help` (line 1147), and immediately after the closing `</p>` of `lpTargetLaborPct-help` (line ~1198). The two fields live in separate cards, and the grid is single-column at 375px, so a manager editing either one sees the warning without scrolling (design §4c).
+
+- [ ] **Step 5: Run tests**
+
+Run: `npx vitest run tests/unit/restaurantSettings.splhConsistency.test.tsx`
+Expected: PASS.
+
+Run: `npm run typecheck && npm run lint`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/pages/RestaurantSettings.tsx tests/unit/restaurantSettings.splhConsistency.test.tsx
+git commit -m "feat(staffing): SPLH consistency hint in labor planning settings"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Gap 1 (Settings tab) → Task 6, hint under both fields. ✓
+- Gap 2 (Planner panel) → Tasks 4 + 5. ✓
+- Gap 3 (fabricated wage) → Task 2 (slider readout, pill, notch, `aria-valuetext`) + Task 3 (receipt aside). ✓
+- Goal 2 (directional helper line) → Tasks 5 and 6. ✓
+- Relocation of shared math → Task 1, with the moved test blocks and the single production import. ✓
+- `buildReceipt` reusing `impliedLabor` (review minor) → Task 3 Step 3. ✓
+- Non-goals honored: tolerance stays `0.05`, `wage` stays dollars, no schema change, save never blocked. ✓
+
+**Placeholder scan:** No TBD/TODO. Every code step shows full code. The two places that defer to an existing file's conventions (Task 5 Step 1's `renderPanel`, Task 6 Step 1's provider mocks) name the specific existing test file to copy from. ✓
+
+**Type consistency:** `impliedLabor({wage, splh, targetLaborPct})` and `laborConsistentSplh({wage, targetLaborPct})` keep #650's exact signatures in Tasks 1, 3, 5, 6. `hasHourlyWageData(employees)` identical in Tasks 1, 2, 4, 6. `hasWageData: boolean` is the prop name on `SplhSlider` (Task 2), `CoverageReceipt` (Task 3), and `StaffingConfigPanel` (Task 5), and the hook field name (Task 4). `avgHourlyRateCents` is cents everywhere; every `wage` is dollars, converted at the call site. ✓

--- a/docs/superpowers/specs/2026-07-24-splh-labor-pct-consistency-design.md
+++ b/docs/superpowers/specs/2026-07-24-splh-labor-pct-consistency-design.md
@@ -1,0 +1,212 @@
+# SPLH ↔ Labor-% Consistency Guard (Settings + Planner)
+
+**Date:** 2026-07-24 (revised 2026-07-27 after PR #650 landed)
+**Status:** Approved
+**Author:** Claude (with Jose Delgado)
+
+## Problem
+
+Three staffing settings are bound by a hard identity:
+
+```
+labor% = avg_hourly_wage / target_splh
+```
+
+`target_splh` and `target_labor_pct` are entered independently, and the blended
+average hourly wage comes from the employee roster. Where nothing ties them
+together, a manager can save a self-contradictory pair with no warning.
+
+### Real case
+
+Restaurant `7c0c76e3-e770-401b-a2a9-c1edd407efed` saved `target_splh = $30` with
+`target_labor_pct = 25%` and every hourly employee at `$10.00/hr`. That implies
+`10 / 30 = 33.3%` labor — not 25%. Because demand is
+`ceil(avgSales / target_splh)`, the too-low SPLH target inflated the Planner
+coverage chart to **17 staff for a $503 hour**, which reads as a broken chart
+rather than a misconfiguration.
+
+Users read "SPLH" as *"what I currently get per hour"* and enter their blended
+actual — a figure dominated by slow hours — which as a *target* over-staffs the
+peak. The relationship is also counter-intuitive: **lowering** SPLH **increases**
+recommended headcount.
+
+## What already exists (PR #650)
+
+PR #650 ("coverage chart explainer") shipped this guard for **one** surface — the
+ShiftTimeline coverage chart — via `src/lib/coverageChartModel.ts`:
+
+- `impliedLabor({wage, splh, targetLaborPct}) → {pct, overTarget}`, tolerance
+  `0.05` percentage points, `wage` in **dollars**.
+- `laborConsistentSplh({wage, targetLaborPct}) → number` — the consistent SPLH.
+- `SplhSlider.tsx` renders a live `→ X% labor at $W/hr` readout, an
+  On/Over-target pill, a track notch at the consistent value, and the
+  directional line *"a lower target schedules more staff."*
+
+**This design does not re-invent that math.** It reuses it and extends coverage
+to the surfaces #650 did not touch.
+
+## Gaps this design closes
+
+| Gap | Where |
+|---|---|
+| 1. Settings Labor Planning tab has no implied %, warning, suggestion, or directional line | `src/pages/RestaurantSettings.tsx` |
+| 2. Planner's inline staffing overrides have the same absence (`SplhSlider` is rendered only by `ShiftTimelineTab`, not `ShiftPlannerTab`) | `src/components/scheduling/ShiftPlanner/StaffingConfigPanel.tsx` |
+| 3. The readout is computed off a **fabricated wage** for rosters with no active hourly employees | `SplhSlider` via `ShiftTimelineTab.tsx:505` |
+
+Gap 3 is a real correctness bug in shipped code:
+`computeAvgHourlyRateCents` (`staffingCalculator.ts:6-15`) falls back to
+`DEFAULT_HOURLY_RATE_CENTS = 1500` ($15/hr) when the roster has no active hourly
+employees, and `ShiftTimelineTab` divides that by 100 with no guard. An empty or
+salaried-only restaurant is shown an implied labor % presented as fact, derived
+from a wage nobody is paid.
+
+## Goals
+
+1. Show the implied labor % live next to the SPLH input on the Settings tab and
+   the Planner's inline panel, warning when it exceeds `target_labor_pct` and
+   naming the consistent SPLH.
+2. Add a short helper line on both, clarifying that lowering SPLH increases
+   recommended headcount.
+3. Suppress the implied-% readout on **all three** surfaces when there is no real
+   hourly wage to reason about.
+
+## Non-goals
+
+- Do **not** block saving. Warn only — a manager may knowingly run above target.
+- No schema/DB change.
+- No change to the demand math (`buildHourlyRecommendations`) or to `impliedLabor`
+  / `laborConsistentSplh` semantics (tolerance stays `0.05`, `wage` stays dollars).
+
+## Design
+
+### 1. Relocate the shared math to the staffing-domain lib
+
+`impliedLabor`, `laborConsistentSplh`, and `ImpliedLaborResult` move from
+`src/lib/coverageChartModel.ts` to `src/lib/staffingCalculator.ts`, unchanged in
+behavior and signature. Rationale: three surfaces across settings, planner, and
+timeline now depend on the identity, and none of them is "the coverage chart";
+`staffingCalculator.ts` already owns `computeAvgHourlyRateCents`, which produces
+the `wage` these functions consume. This is a mechanical move — one production
+import (`SplhSlider.tsx`) and one test block (`coverageChartModel.test.ts`
+lines 87-144) follow it. No re-export shim; the imports are updated directly.
+
+### 2. New roster predicate
+
+```ts
+/**
+ * True when the roster has at least one active hourly employee — i.e. the wage
+ * from computeAvgHourlyRateCents is real, not the DEFAULT_HOURLY_RATE_CENTS
+ * ($15/hr) fallback.
+ */
+export function hasHourlyWageData(employees: Employee[] | undefined): boolean;
+```
+
+Mirrors `computeAvgHourlyRateCents`'s own filter
+(`compensation_type === 'hourly' && is_active`) so the two never disagree. Lives
+in `staffingCalculator.ts` beside it.
+
+### 3. Expose wage + flag from the week-suggestions hook
+
+`useWeekStaffingSuggestions` already computes `avgHourlyRateCents` internally
+(line 77) but does not return it. Add `avgHourlyRateCents` and `hasWageData`
+(from `hasHourlyWageData(employees)`) to its return object. Both new fields are
+additive.
+
+### 4. Surface changes
+
+**Non-finite guard, all surfaces.** Callers must not pass `NaN`. The Settings
+form holds SPLH/labor-% as raw strings with no coercion, and
+`Number.parseFloat('')` is `NaN` while `NaN <= 0` is `false` — so a bare `> 0`
+check lets `NaN` through into the arithmetic. Each surface gates on
+`Number.isFinite(x) && x > 0` for both inputs before rendering.
+
+**(a) `SplhSlider.tsx`** — new required prop `hasWageData: boolean`, passed from
+`ShiftTimelineTab` as `hasHourlyWageData(employees)`. When `false`: hide the
+On/Over-target pill and the labor-consistent notch, and replace the
+`→ X% labor at $W/hr` readout with a muted *"Add hourly rates to see implied
+labor %"*. The `$value` figure and the slider itself are unaffected.
+
+**(b) `StaffingConfigPanel.tsx`** — new props `avgHourlyRateCents: number` and
+`hasWageData: boolean`, threaded from the hook through `StaffingOverlay`. Under
+the SPLH input, in an `aria-live="polite"` container at `text-[11px]`,
+`max-w-[220px]` (so it wraps inside its flex column rather than displacing the
+Labor% / Min Staff columns at 375px):
+
+- Implied line: `≈ {pct}% labor at current wage`, coloured
+  `text-amber-600 dark:text-amber-400` when `overTarget`, else
+  `text-muted-foreground/80`.
+- When `overTarget`, append: `— above your {target}% target, try ${Math.round(consistent)}`.
+- A persistent directional line at `text-[11px] text-muted-foreground/70`:
+  *"Lower SPLH → more staff recommended."*
+
+**(c) `RestaurantSettings.tsx`** (Labor Planning tab) — add
+`useEmployees(restaurantId)`, derive wage + flag, and parse the live form
+strings. Same three lines under the Target SPLH help text, at `text-[13px]` to
+match sibling captions, in an `aria-live="polite"` container. Gating on
+`hasWageData` also means no `$15`-default flash while `useEmployees` loads.
+
+### Data flow
+
+```
+useEmployees ─┬─► computeAvgHourlyRateCents ──► wage (dollars, ÷100 at the call site)
+              └─► hasHourlyWageData ──────────► hasWageData
+                                                    │
+target_splh, target_labor_pct ──────────────────────┤
+                                                    ▼
+                    impliedLabor() / laborConsistentSplh()   [staffingCalculator.ts]
+                                                    ▼
+              readout + warning + directional line  (Settings · Planner · Slider)
+```
+
+## Testing
+
+**Moved tests** — the `impliedLabor` / `laborConsistentSplh` blocks move from
+`tests/unit/coverageChartModel.test.ts` to `tests/unit/staffingCalculator.test.ts`
+verbatim (behavior is unchanged; they must keep passing as-is).
+
+**New in `tests/unit/staffingCalculator.test.ts`:**
+
+- `hasHourlyWageData`: `undefined`, `[]`, and salaried-only rosters → `false`; an
+  inactive hourly employee alone → `false`; ≥1 active hourly employee → `true`.
+- Real-case integration of the identity: at `wage = 10`, `splh = 30`,
+  `targetLaborPct = 25` → `pct ≈ 33.33`, `overTarget === true`, and
+  `laborConsistentSplh` → `40`.
+- Round-trip: feeding `laborConsistentSplh` back through `impliedLabor` yields
+  `pct ≈ targetLaborPct` with `overTarget === false`.
+
+**Component tests:**
+
+- `StaffingConfigPanel`: hint hidden when `hasWageData` is false; hidden on a
+  non-finite `target_splh`; muted line within tolerance; amber line + suggested
+  value when over target; directional line always present when shown;
+  `aria-live="polite"` wrapper.
+- `RestaurantSettings` Labor Planning: same visibility matrix driven by the form
+  strings, including the cleared-field (`NaN`) case.
+- `splhSlider.test.tsx`: extend with `hasWageData={false}` → no pill, no notch,
+  fallback copy; existing `hasWageData={true}` assertions unchanged.
+- `StaffingOverlay` wiring: `avgHourlyRateCents` / `hasWageData` reach the panel.
+
+## Decided trade-offs
+
+- **Move the helpers rather than import `coverageChartModel` from Settings.**
+  A settings page importing a "coverage chart model" is a semantic wart; the
+  move costs one import line and one test-block relocation.
+- **Keep #650's `0.05` tolerance and dollar units.** Shipped, tested, and the
+  difference from the originally-planned `0.1` is immaterial.
+- **Warn, don't block** — a manager may knowingly run above target.
+- **Directional helper is a visible line, not a tooltip** on the two new
+  surfaces. The whole failure mode is that users never open the tooltip before
+  mis-entering the value.
+- **Inline per surface, shared math.** The three surfaces have different type
+  scales and layouts; copy is kept consistent by convention rather than by a
+  component that must flex across all three.
+
+## Superseded approach
+
+The first revision of this design added a self-contained
+`evaluateSplhConsistency(avgHourlyRateCents, targetSplh, targetLaborPct, hasWageData)`
+to `staffingCalculator.ts` with a `0.1` tolerance and cents units. PR #650 landed
+equivalent math first, so that helper is dropped in favor of reusing
+`impliedLabor` / `laborConsistentSplh`. Only the `hasHourlyWageData` predicate
+survives from that revision. Prior implementation preserved on the local branch
+`backup/splh-pre-rebase` (commit `29a19faf`).

--- a/docs/superpowers/specs/2026-07-24-splh-labor-pct-consistency-design.md
+++ b/docs/superpowers/specs/2026-07-24-splh-labor-pct-consistency-design.md
@@ -51,14 +51,19 @@ to the surfaces #650 did not touch.
 |---|---|
 | 1. Settings Labor Planning tab has no implied %, warning, suggestion, or directional line | `src/pages/RestaurantSettings.tsx` |
 | 2. Planner's inline staffing overrides have the same absence (`SplhSlider` is rendered only by `ShiftTimelineTab`, not `ShiftPlannerTab`) | `src/components/scheduling/ShiftPlanner/StaffingConfigPanel.tsx` |
-| 3. The readout is computed off a **fabricated wage** for rosters with no active hourly employees | `SplhSlider` via `ShiftTimelineTab.tsx:505` |
+| 3. The readout is computed off a **fabricated wage** for rosters with no active hourly employees | `SplhSlider` (visible readout + `aria-valuetext`) and `buildReceipt`'s implied-SPLH aside, both fed from `ShiftTimelineTab.tsx:505` |
 
 Gap 3 is a real correctness bug in shipped code:
 `computeAvgHourlyRateCents` (`staffingCalculator.ts:6-15`) falls back to
 `DEFAULT_HOURLY_RATE_CENTS = 1500` ($15/hr) when the roster has no active hourly
 employees, and `ShiftTimelineTab` divides that by 100 with no guard. An empty or
 salaried-only restaurant is shown an implied labor % presented as fact, derived
-from a wage nobody is paid.
+from a wage nobody is paid. It surfaces in **three** places off that one value:
+the slider's visible readout, the slider's `aria-valuetext`
+(`SplhSlider.tsx:141` — otherwise screen-reader users still hear the fabricated
+percentage after the visible readout is suppressed), and `buildReceipt`'s
+`laborPctAt` aside (`coverageChartModel.ts:190`), which renders in the pinned
+receipt column beside the slider on the same tab. All three are gated.
 
 ## Goals
 
@@ -120,11 +125,33 @@ form holds SPLH/labor-% as raw strings with no coercion, and
 check lets `NaN` through into the arithmetic. Each surface gates on
 `Number.isFinite(x) && x > 0` for both inputs before rendering.
 
+**Colour token.** The over-target emphasis uses the semantic `text-warning`
+token (`tailwind.config.ts:47-49`, `src/index.css:35-36`) — **not** raw
+`text-amber-600 dark:text-amber-400`. CLAUDE.md forbids direct colours, and
+`CoverageVerdict.tsx:70-71` already documents `text-warning` as this codebase's
+convention for exactly this amber "over target" emphasis.
+
 **(a) `SplhSlider.tsx`** — new required prop `hasWageData: boolean`, passed from
-`ShiftTimelineTab` as `hasHourlyWageData(employees)`. When `false`: hide the
-On/Over-target pill and the labor-consistent notch, and replace the
-`→ X% labor at $W/hr` readout with a muted *"Add hourly rates to see implied
-labor %"*. The `$value` figure and the slider itself are unaffected.
+`ShiftTimelineTab` as `hasHourlyWageData(employees)`. When `false`:
+
+- Hide the On/Over-target pill and the labor-consistent notch.
+- Replace the `→ X% labor at $W/hr` readout with `Add hourly rates`, at
+  `text-[13px] text-muted-foreground` (the same classes as the span it
+  replaces). The copy is kept this short deliberately: it sits in a
+  `whitespace-nowrap` flex row (`SplhSlider.tsx:99`) alongside the `$value`
+  figure, so a longer sentence would overflow at 375px.
+- Drop the labor % from `aria-valuetext` (`SplhSlider.tsx:141`), leaving
+  `` `$${value}/hr` ``. Without this, screen-reader users still hear the
+  fabricated percentage the visible change just suppressed.
+
+The `$value` figure and the slider control itself are unaffected.
+
+**(a2) `buildReceipt` (`coverageChartModel.ts`)** — takes a `hasWageData:
+boolean` param (threaded from `ShiftTimelineTab.tsx:1045`). When `false`, omit
+the `implied SPLH is $X/hr → Y% labor` aside (line 190-191) entirely, keeping the
+rest of the receipt intact. While this call site is open, replace the aside's
+hand-inlined `Math.round((wage / splhAt) * 100)` with a call to the relocated
+`impliedLabor`, so the identity has one implementation rather than two.
 
 **(b) `StaffingConfigPanel.tsx`** — new props `avgHourlyRateCents: number` and
 `hasWageData: boolean`, threaded from the hook through `StaffingOverlay`. Under
@@ -132,9 +159,8 @@ the SPLH input, in an `aria-live="polite"` container at `text-[11px]`,
 `max-w-[220px]` (so it wraps inside its flex column rather than displacing the
 Labor% / Min Staff columns at 375px):
 
-- Implied line: `≈ {pct}% labor at current wage`, coloured
-  `text-amber-600 dark:text-amber-400` when `overTarget`, else
-  `text-muted-foreground/80`.
+- Implied line: `≈ {pct}% labor at current wage`, coloured `text-warning` when
+  `overTarget`, else `text-muted-foreground/80`.
 - When `overTarget`, append: `— above your {target}% target, try ${Math.round(consistent)}`.
 - A persistent directional line at `text-[11px] text-muted-foreground/70`:
   *"Lower SPLH → more staff recommended."*
@@ -144,6 +170,14 @@ Labor% / Min Staff columns at 375px):
 strings. Same three lines under the Target SPLH help text, at `text-[13px]` to
 match sibling captions, in an `aria-live="polite"` container. Gating on
 `hasWageData` also means no `$15`-default flash while `useEmployees` loads.
+
+The tab splits the two inputs across separate cards — `target_splh` in "Revenue
+Targets" (~line 1122) and `target_labor_pct` in "Labor Constraints" (~line 1172)
+— and at 375px the grid is single-column, so a manager editing Target Labor %
+cannot see a hint anchored to the SPLH field. The same `aria-live` hint block is
+therefore rendered under **both** fields, so the warning is present at whichever
+field is being edited. Both render from the one derived value; the copy is
+identical.
 
 ### Data flow
 
@@ -181,10 +215,20 @@ verbatim (behavior is unchanged; they must keep passing as-is).
   value when over target; directional line always present when shown;
   `aria-live="polite"` wrapper.
 - `RestaurantSettings` Labor Planning: same visibility matrix driven by the form
-  strings, including the cleared-field (`NaN`) case.
+  strings, including the cleared-field (`NaN`) case, asserted under **both** the
+  Target SPLH and Target Labor % fields.
 - `splhSlider.test.tsx`: extend with `hasWageData={false}` → no pill, no notch,
-  fallback copy; existing `hasWageData={true}` assertions unchanged.
+  `Add hourly rates` copy, and `aria-valuetext` carrying no percentage; existing
+  `hasWageData={true}` assertions unchanged.
+- `coverageReceipt` / `buildReceipt`: with `hasWageData: false` the implied-SPLH
+  aside is absent; with `true` it is byte-identical to today's output (guards the
+  `impliedLabor` swap against rounding drift).
 - `StaffingOverlay` wiring: `avgHourlyRateCents` / `hasWageData` reach the panel.
+
+**Existing suites that must stay green unmodified:** the moved `impliedLabor` /
+`laborConsistentSplh` blocks, and `tests/e2e/coverage-chart-explainer.spec.ts`
+(its fixture seeds one active hourly employee, so `hasWageData` is `true` there
+and its pill/notch assertions are unaffected by the new prop).
 
 ## Decided trade-offs
 
@@ -200,6 +244,16 @@ verbatim (behavior is unchanged; they must keep passing as-is).
 - **Inline per surface, shared math.** The three surfaces have different type
   scales and layouts; copy is kept consistent by convention rather than by a
   component that must flex across all three.
+- **`SplhSlider`'s existing "Over target" pill keeps `bg-destructive/15
+  text-destructive`.** New inline hint text uses `text-warning`. A filled status
+  pill and inline body text are different affordances, and re-colouring
+  just-shipped UI from #650 is churn this change does not need. Both are semantic
+  tokens, so the CLAUDE.md rule is satisfied either way; harmonising the pill is
+  noted as a follow-up rather than done here.
+- **The Settings hint is duplicated under both inputs** rather than placed once
+  between the two cards. Restructuring the tab's card layout is a larger,
+  unrelated change; rendering the same derived block twice is the cheap fix that
+  puts the warning at the point of edit.
 
 ## Superseded approach
 

--- a/src/components/scheduling/ShiftPlanner/StaffingConfigPanel.tsx
+++ b/src/components/scheduling/ShiftPlanner/StaffingConfigPanel.tsx
@@ -12,7 +12,7 @@ import {
 
 import { HelpCircle, Plus, X } from 'lucide-react';
 
-import { impliedLabor, laborConsistentSplh } from '@/lib/staffingCalculator';
+import { deriveSplhHint } from '@/lib/staffingCalculator';
 
 import type { MinCrew, StaffingSettings } from '@/types/scheduling';
 
@@ -72,15 +72,16 @@ export const StaffingConfigPanel = memo(function StaffingConfigPanel({
   // Implied labor % of the current SPLH target at the blended wage. Null when
   // there is no real wage, or when either input is non-finite/non-positive —
   // a cleared field parses to NaN, and `NaN <= 0` is false (design §4).
-  const splhHint = useMemo(() => {
-    const splh = settings.target_splh;
-    const target = settings.target_labor_pct;
-    const positive = (n: number) => Number.isFinite(n) && n > 0;
-    if (!hasWageData || !positive(splh) || !positive(target)) return null;
-    const wage = avgHourlyRateCents / 100;
-    const { pct, overTarget } = impliedLabor({ wage, splh, targetLaborPct: target });
-    return { pct, overTarget, consistent: laborConsistentSplh({ wage, targetLaborPct: target }) };
-  }, [avgHourlyRateCents, hasWageData, settings.target_splh, settings.target_labor_pct]);
+  const splhHint = useMemo(
+    () =>
+      deriveSplhHint({
+        splh: settings.target_splh,
+        targetLaborPct: settings.target_labor_pct,
+        hasWageData,
+        wageCents: avgHourlyRateCents,
+      }),
+    [avgHourlyRateCents, hasWageData, settings.target_splh, settings.target_labor_pct],
+  );
 
   const minCrew = useMemo(() => settings.min_crew ?? {}, [settings.min_crew]);
   const crewPositions = Object.keys(minCrew);

--- a/src/components/scheduling/ShiftPlanner/StaffingConfigPanel.tsx
+++ b/src/components/scheduling/ShiftPlanner/StaffingConfigPanel.tsx
@@ -144,6 +144,19 @@ export const StaffingConfigPanel = memo(function StaffingConfigPanel({
               <span className="text-muted-foreground/50">(last {lookbackWeeks} wks)</span>
             </span>
           )}
+          {splhHint && (
+            <div aria-live="polite" className="flex flex-col gap-0.5 max-w-[220px]">
+              <span className={`text-[11px] ${splhHint.overTarget ? 'text-warning' : 'text-muted-foreground/80'}`}>
+                ≈ {splhHint.pct.toFixed(0)}% labor at current wage
+                {splhHint.overTarget && (
+                  <> — above your {settings.target_labor_pct}% target, try ${Math.round(splhHint.consistent)}</>
+                )}
+              </span>
+              <span className="text-[11px] text-muted-foreground/70">
+                Lower SPLH → more staff recommended.
+              </span>
+            </div>
+          )}
         </div>
         <div className="flex flex-col gap-1">
           <div className="flex items-center gap-1">

--- a/src/components/scheduling/ShiftPlanner/StaffingConfigPanel.tsx
+++ b/src/components/scheduling/ShiftPlanner/StaffingConfigPanel.tsx
@@ -12,6 +12,8 @@ import {
 
 import { HelpCircle, Plus, X } from 'lucide-react';
 
+import { impliedLabor, laborConsistentSplh } from '@/lib/staffingCalculator';
+
 import type { MinCrew, StaffingSettings } from '@/types/scheduling';
 
 interface StaffingConfigPanelProps {
@@ -31,6 +33,10 @@ interface StaffingConfigPanelProps {
   employeePositions: string[];
   actualSplh: number | null;
   lookbackWeeks: number;
+  /** Blended hourly wage in cents (`computeAvgHourlyRateCents`). */
+  avgHourlyRateCents: number;
+  /** Whether that wage is real roster data — gates the implied-labor hint. */
+  hasWageData: boolean;
 }
 
 function HelpTip({ text, fieldName }: Readonly<{ text: string; fieldName: string }>) {
@@ -58,8 +64,23 @@ export const StaffingConfigPanel = memo(function StaffingConfigPanel({
   employeePositions,
   actualSplh,
   lookbackWeeks,
+  avgHourlyRateCents,
+  hasWageData,
 }: Readonly<StaffingConfigPanelProps>) {
   const [newPosition, setNewPosition] = useState('');
+
+  // Implied labor % of the current SPLH target at the blended wage. Null when
+  // there is no real wage, or when either input is non-finite/non-positive —
+  // a cleared field parses to NaN, and `NaN <= 0` is false (design §4).
+  const splhHint = useMemo(() => {
+    const splh = settings.target_splh;
+    const target = settings.target_labor_pct;
+    const positive = (n: number) => Number.isFinite(n) && n > 0;
+    if (!hasWageData || !positive(splh) || !positive(target)) return null;
+    const wage = avgHourlyRateCents / 100;
+    const { pct, overTarget } = impliedLabor({ wage, splh, targetLaborPct: target });
+    return { pct, overTarget, consistent: laborConsistentSplh({ wage, targetLaborPct: target }) };
+  }, [avgHourlyRateCents, hasWageData, settings.target_splh, settings.target_labor_pct]);
 
   const minCrew = useMemo(() => settings.min_crew ?? {}, [settings.min_crew]);
   const crewPositions = Object.keys(minCrew);

--- a/src/components/scheduling/ShiftPlanner/StaffingOverlay.tsx
+++ b/src/components/scheduling/ShiftPlanner/StaffingOverlay.tsx
@@ -43,6 +43,8 @@ export function StaffingOverlay({
     isSaving,
     employeePositions,
     actualSplh,
+    avgHourlyRateCents,
+    hasWageData,
   } = useWeekStaffingSuggestions(restaurantId, weekDays, localSettings);
 
   const handleSettingsChange = useCallback((updates: Partial<StaffingSettings>) => {
@@ -160,6 +162,8 @@ export function StaffingOverlay({
                 employeePositions={employeePositions}
                 actualSplh={actualSplh}
                 lookbackWeeks={activeSettings.lookback_weeks}
+                avgHourlyRateCents={avgHourlyRateCents}
+                hasWageData={hasWageData}
               />
 
               {/* How it works explainer — always visible so it educates even with no data */}

--- a/src/components/scheduling/ShiftTimeline/CoverageReceipt.tsx
+++ b/src/components/scheduling/ShiftTimeline/CoverageReceipt.tsx
@@ -16,6 +16,8 @@ interface CoverageReceiptProps {
   readonly weekdayKey: string;
   /** Average hourly wage — drives the implied-SPLH-at-scheduled aside. */
   readonly wage: number;
+  /** Whether `wage` is real roster data — gates the implied-SPLH aside. */
+  readonly hasWageData: boolean;
   /** Lookback window (in weeks) — surfaced in the nodata aside's copy. */
   readonly lookbackWeeks: number;
   /**
@@ -72,10 +74,11 @@ export function CoverageReceipt({
   minStaff,
   weekdayKey,
   wage,
+  hasWageData,
   lookbackWeeks,
   onQuickAdd,
 }: CoverageReceiptProps) {
-  const receipt = buildReceipt(hour, { minStaff, weekdayKey, wage, lookbackWeeks });
+  const receipt = buildReceipt(hour, { minStaff, weekdayKey, wage, lookbackWeeks, hasWageData });
   const kind = classifyHour(hour, minStaff);
   const showQuickAdd = Boolean(onQuickAdd) && (kind === 'crit' || kind === 'floor');
 

--- a/src/components/scheduling/ShiftTimeline/CoverageReceipt.tsx
+++ b/src/components/scheduling/ShiftTimeline/CoverageReceipt.tsx
@@ -104,10 +104,13 @@ export function CoverageReceipt({
 
   // Selecting a different hour is independent of slider dragging and should
   // announce right away (design doc §C: "selecting updates the receipt").
+  // `hasWageData` is here for the same reason: it adds/removes the implied-SPLH
+  // aside, and it changes on a roster refetch rather than on a drag, so the
+  // live region would otherwise stay stale until the next pointer/key event.
   useEffect(() => {
     setAnnounced(announcementText(latestRef.current.receipt, latestRef.current.hour));
-     
-  }, [hour.startMin]);
+
+  }, [hour.startMin, hasWageData]);
 
   // The ledger's last row is always the verdict (Short on demand / Short on
   // floor / Covered / On target) — set it off as an emphasized "total" below a

--- a/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
+++ b/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
@@ -1047,6 +1047,7 @@ export function ShiftTimelineTab({
               minStaff={minStaff}
               weekdayKey={weekdayKey}
               wage={avgWage}
+              hasWageData={hasWageData}
               lookbackWeeks={lookbackWeeks}
               onQuickAdd={handleGapClick}
             />

--- a/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
+++ b/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
@@ -19,7 +19,7 @@ import { useValidatedShiftMutations } from '@/hooks/useValidatedShiftMutations';
 import { useCreateShift } from '@/hooks/useShifts';
 import { useToast } from '@/hooks/use-toast';
 import { useRestaurantContext } from '@/contexts/RestaurantContext';
-import { computeAvgHourlyRateCents, computeMinStaffFromCrew } from '@/lib/staffingCalculator';
+import { computeAvgHourlyRateCents, computeMinStaffFromCrew, hasHourlyWageData } from '@/lib/staffingCalculator';
 import { useTimelineModel, computeCoverage } from './useTimelineModel';
 import { CoverageVerdict } from './CoverageVerdict';
 import { CoverageChart } from './CoverageChart';
@@ -503,6 +503,9 @@ export function ShiftTimelineTab({
   // `SplhSlider`'s implied-labor readout (`pct = avgWage ÷ target_splh × 100`)
   // and its labor-consistent notch, rendered below (Stage 5.3).
   const avgWage = computeAvgHourlyRateCents(employees) / 100;
+  // Whether `avgWage` is real roster data or computeAvgHourlyRateCents's $15/hr
+  // fallback — gates every implied-labor readout (design §4a).
+  const hasWageData = hasHourlyWageData(employees);
   // Target labor % from staffing settings — drives the slider pill's
   // over/under-target threshold and its notch label. Falls back to the same
   // default `useStaffingSettings` seeds a restaurant with (DEFAULTS.target_labor_pct)
@@ -960,6 +963,7 @@ export function ShiftTimelineTab({
                   <SplhSlider
                     value={sliderTarget ?? targetSplh}
                     wage={avgWage}
+                    hasWageData={hasWageData}
                     targetLaborPct={targetLaborPct}
                     canSave={canSaveSplhTarget}
                     isSaving={isSaving}

--- a/src/components/scheduling/ShiftTimeline/SplhSlider.tsx
+++ b/src/components/scheduling/ShiftTimeline/SplhSlider.tsx
@@ -2,7 +2,7 @@ import { useId } from 'react';
 
 import { Label } from '@/components/ui/label';
 
-import { impliedLabor, laborConsistentSplh } from '@/lib/coverageChartModel';
+import { impliedLabor, laborConsistentSplh } from '@/lib/staffingCalculator';
 import { cn } from '@/lib/utils';
 
 // ── Constants ────────────────────────────────────────────────────────────────
@@ -60,7 +60,7 @@ interface SplhSliderProps {
  * A native `<input type="range">` (25–120 step 5) drives `onChange` on every
  * drag frame so the caller can re-run the whole staffing pipeline live — this
  * component holds no derived staffing state of its own, only the pure
- * `impliedLabor`/`laborConsistentSplh` math from `coverageChartModel`.
+ * `impliedLabor`/`laborConsistentSplh` math from `staffingCalculator`.
  *
  * The notch marks the SPLH value that would exactly hit `targetLaborPct` at
  * `wage` (`laborConsistentSplh`), so a manager can see at a glance where their

--- a/src/components/scheduling/ShiftTimeline/SplhSlider.tsx
+++ b/src/components/scheduling/ShiftTimeline/SplhSlider.tsx
@@ -35,6 +35,12 @@ interface SplhSliderProps {
   readonly value: number;
   /** Average hourly wage across employees — drives the implied-labor readout and notch. */
   readonly wage: number;
+  /**
+   * Whether `wage` reflects real roster data (`hasHourlyWageData`). When false,
+   * `computeAvgHourlyRateCents` returned its $15/hr fallback, so every
+   * implied-labor output is suppressed rather than presented as fact.
+   */
+  readonly hasWageData: boolean;
   /** Target labor % from staffing settings — drives the pill threshold and notch label. */
   readonly targetLaborPct: number;
   /**
@@ -69,6 +75,7 @@ interface SplhSliderProps {
 export function SplhSlider({
   value,
   wage,
+  hasWageData,
   targetLaborPct,
   canSave,
   isSaving,
@@ -100,34 +107,42 @@ export function SplhSlider({
           <span className="text-[22px] font-semibold text-foreground tabular-nums leading-none">
             ${value}
           </span>
-          <span className="text-[13px] text-muted-foreground tabular-nums">
-            → {pctLabel}% labor at ${wage.toFixed(2)}/hr
-          </span>
-          <span
-            data-testid="splh-slider-pill"
-            className={cn(
-              'text-[11px] font-medium px-1.5 py-0.5 rounded-md',
-              overTarget ? 'bg-destructive/15 text-destructive' : 'bg-success/15 text-success',
-            )}
-          >
-            {overTarget ? 'Over target' : 'On target'}
-          </span>
+          {hasWageData ? (
+            <>
+              <span className="text-[13px] text-muted-foreground tabular-nums">
+                → {pctLabel}% labor at ${wage.toFixed(2)}/hr
+              </span>
+              <span
+                data-testid="splh-slider-pill"
+                className={cn(
+                  'text-[11px] font-medium px-1.5 py-0.5 rounded-md',
+                  overTarget ? 'bg-destructive/15 text-destructive' : 'bg-success/15 text-success',
+                )}
+              >
+                {overTarget ? 'Over target' : 'On target'}
+              </span>
+            </>
+          ) : (
+            <span className="text-[13px] text-muted-foreground">Add hourly rates</span>
+          )}
         </div>
       </div>
 
       <div className="relative pt-4 pb-0.5">
         {/* Labor-consistent notch — display-clamped into the 25–120 track (never persisted) */}
-        <div
-          data-testid="splh-slider-notch"
-          className="absolute top-0 flex -translate-x-1/2 flex-col items-center"
-          style={{ left: `${notchPct}%` }}
-          aria-hidden="true"
-        >
-          <span className="whitespace-nowrap text-[10px] text-muted-foreground">
-            ${Math.round(consistent)} · {targetLaborPct}% labor
-          </span>
-          <span className="h-2 w-px bg-muted-foreground/60" />
-        </div>
+        {hasWageData && (
+          <div
+            data-testid="splh-slider-notch"
+            className="absolute top-0 flex -translate-x-1/2 flex-col items-center"
+            style={{ left: `${notchPct}%` }}
+            aria-hidden="true"
+          >
+            <span className="whitespace-nowrap text-[10px] text-muted-foreground">
+              ${Math.round(consistent)} · {targetLaborPct}% labor
+            </span>
+            <span className="h-2 w-px bg-muted-foreground/60" />
+          </div>
+        )}
 
         <input
           id={sliderId}
@@ -138,7 +153,7 @@ export function SplhSlider({
           value={value}
           onChange={(e) => onChange(Number(e.target.value))}
           aria-label="Sales per labor hour target, in dollars"
-          aria-valuetext={`$${value}/hr → ${pctLabel}% labor`}
+          aria-valuetext={hasWageData ? `$${value}/hr → ${pctLabel}% labor` : `$${value}/hr`}
           className="w-full accent-primary"
         />
 

--- a/src/hooks/useWeekStaffingSuggestions.ts
+++ b/src/hooks/useWeekStaffingSuggestions.ts
@@ -7,7 +7,7 @@ import { useStaffingSettings } from '@/hooks/useStaffingSettings';
 import { useEmployees } from '@/hooks/useEmployees';
 import { aggregateHourlySales } from '@/hooks/useHourlySalesPattern';
 import { computeStaffingSuggestions } from '@/hooks/useStaffingSuggestions';
-import { computeAvgHourlyRateCents, computeMinStaffFromCrew } from '@/lib/staffingCalculator';
+import { computeAvgHourlyRateCents, computeMinStaffFromCrew, hasHourlyWageData } from '@/lib/staffingCalculator';
 import { dayStringToDow } from '@/lib/staffingApply';
 import { supabase } from '@/integrations/supabase/client';
 import { useRestaurantContext } from '@/contexts/RestaurantContext';
@@ -76,6 +76,14 @@ export function useWeekStaffingSuggestions(
 
   const avgHourlyRateCents = useMemo(
     () => computeAvgHourlyRateCents(employees),
+    [employees],
+  );
+
+  // Gates every implied-%/implied-SPLH readout downstream (design §4a): true
+  // only when at least one active hourly employee has a real wage, false
+  // when avgHourlyRateCents is just the DEFAULT_HOURLY_RATE_CENTS fallback.
+  const hasWageData = useMemo(
+    () => hasHourlyWageData(employees),
     [employees],
   );
 
@@ -263,6 +271,8 @@ export function useWeekStaffingSuggestions(
     isSaving,
     employeePositions,
     actualSplh,
+    avgHourlyRateCents,
+    hasWageData,
   };
 }
 

--- a/src/lib/coverageChartModel.ts
+++ b/src/lib/coverageChartModel.ts
@@ -51,46 +51,6 @@ export function classifyHour(h: CoverageHour, minStaff: number): HourClassificat
   return 'ok';
 }
 
-export interface ImpliedLaborResult {
-  pct: number;
-  overTarget: boolean;
-}
-
-/**
- * Implied labor % of a given SPLH target at a given average hourly wage —
- * the on-chart slider's live readout (`→ X% labor at $W/hr`).
- *
- * `overTarget` flags the readout as "over budget" once `pct` clears
- * `targetLaborPct` by more than a 0.05-point tolerance (so a target hit to
- * within float/rounding noise doesn't flash red).
- */
-export function impliedLabor(params: {
-  wage: number;
-  splh: number;
-  targetLaborPct: number;
-}): ImpliedLaborResult {
-  const { wage, splh, targetLaborPct } = params;
-  // Guard against a 0 splh (would otherwise divide to Infinity) — the slider's
-  // own bounds keep this out of reach today, but the readout should degrade to
-  // a plain 0% rather than a nonsensical Infinity if that ever changes.
-  const pct = splh > 0 ? (wage / splh) * 100 : 0;
-  const overTarget = pct > targetLaborPct + 0.05;
-  return { pct, overTarget };
-}
-
-/**
- * The SPLH target that exactly hits `targetLaborPct` at `wage` — the value
- * the slider's track notch is drawn at, so a manager can see where their own
- * labor goal puts the knob.
- */
-export function laborConsistentSplh(params: { wage: number; targetLaborPct: number }): number {
-  const { wage, targetLaborPct } = params;
-  // Guard against a 0 targetLaborPct (would otherwise divide to Infinity) —
-  // settings-form input clamps this above 0 today, but the notch position
-  // should degrade to 0 rather than Infinity if that invariant ever slips.
-  return targetLaborPct > 0 ? wage / (targetLaborPct / 100) : 0;
-}
-
 // ── Receipt ──────────────────────────────────────────────────────────────────
 
 export type ReceiptTone = 'default' | 'critical' | 'warning' | 'positive';

--- a/src/lib/coverageChartModel.ts
+++ b/src/lib/coverageChartModel.ts
@@ -148,7 +148,11 @@ export function buildReceipt(
   // actually scheduled (avoids a divide-by-zero and a nonsensical "$Infinity/hr"),
   // and only honest when `wage` is real roster data rather than the $15/hr
   // fallback (design §4a2).
-  if (scheduled > 0 && hasWageData) {
+  // `projectedSales > 0` matters independently of `scheduled`: with staff on
+  // the clock and no sales, labor is infinitely over target, but `splhAt`
+  // collapses to 0 and impliedLabor's divide-by-zero guard returns 0% — a
+  // number that reads as the exact opposite of the truth. Say nothing instead.
+  if (scheduled > 0 && projectedSales > 0 && hasWageData) {
     const splhAt = projectedSales / scheduled;
     const laborPctAt = Math.round(impliedLabor({ wage, splh: splhAt, targetLaborPct: 0 }).pct);
     asides.push(`At ${scheduled} scheduled, implied SPLH is ${fmtUsd(Math.round(splhAt))}/hr → ${laborPctAt}% labor.`);

--- a/src/lib/coverageChartModel.ts
+++ b/src/lib/coverageChartModel.ts
@@ -12,6 +12,7 @@
 
 import type { CoverageHour } from '@/lib/coverageSummary';
 import { formatCoverageHour } from '@/lib/coverageSummary';
+import { impliedLabor } from '@/lib/staffingCalculator';
 
 export type HourClassification = 'crit' | 'floor' | 'spare' | 'ok' | 'nodata';
 
@@ -88,9 +89,9 @@ function fmtUsd(n: number): string {
  */
 export function buildReceipt(
   h: CoverageHour,
-  params: { minStaff: number; weekdayKey: string; wage: number; lookbackWeeks: number },
+  params: { minStaff: number; weekdayKey: string; wage: number; lookbackWeeks: number; hasWageData: boolean },
 ): Receipt {
-  const { minStaff, weekdayKey, wage, lookbackWeeks } = params;
+  const { minStaff, weekdayKey, wage, lookbackWeeks, hasWageData } = params;
 
   if (h.demand === null) {
     return {
@@ -144,10 +145,12 @@ export function buildReceipt(
   const asides: string[] = [];
 
   // Implied SPLH at the scheduled count — only meaningful when someone is
-  // actually scheduled (avoids a divide-by-zero and a nonsensical "$Infinity/hr").
-  if (scheduled > 0) {
+  // actually scheduled (avoids a divide-by-zero and a nonsensical "$Infinity/hr"),
+  // and only honest when `wage` is real roster data rather than the $15/hr
+  // fallback (design §4a2).
+  if (scheduled > 0 && hasWageData) {
     const splhAt = projectedSales / scheduled;
-    const laborPctAt = Math.round((wage / splhAt) * 100);
+    const laborPctAt = Math.round(impliedLabor({ wage, splh: splhAt, targetLaborPct: 0 }).pct);
     asides.push(`At ${scheduled} scheduled, implied SPLH is ${fmtUsd(Math.round(splhAt))}/hr → ${laborPctAt}% labor.`);
   }
 

--- a/src/lib/staffingCalculator.ts
+++ b/src/lib/staffingCalculator.ts
@@ -95,7 +95,7 @@ export function deriveSplhHint(params: {
 }): SplhHint | null {
   const { splh, targetLaborPct, hasWageData, wageCents } = params;
   const positive = (n: number) => Number.isFinite(n) && n > 0;
-  if (!hasWageData || !positive(splh) || !positive(targetLaborPct)) return null;
+  if (!hasWageData || !positive(wageCents) || !positive(splh) || !positive(targetLaborPct)) return null;
   const wage = wageCents / 100;
   const { pct, overTarget } = impliedLabor({ wage, splh, targetLaborPct });
   return { pct, overTarget, consistent: laborConsistentSplh({ wage, targetLaborPct }) };

--- a/src/lib/staffingCalculator.ts
+++ b/src/lib/staffingCalculator.ts
@@ -3,33 +3,41 @@ import type { Employee, HourlySalesData, HourlyStaffingRecommendation, MinCrew, 
 const MAX_SHIFT_HOURS = 8;
 const DEFAULT_HOURLY_RATE_CENTS = 1500; // $15/hr
 
+/**
+ * The employees whose wages are real: active, hourly, and actually paid a
+ * positive rate. `EmployeeDialog` stores a blank hourly-rate field as `0`
+ * cents, so an unset rate is indistinguishable from a genuine `$0/hr` and must
+ * be excluded from both the blended average and the has-real-wage predicate.
+ *
+ * Both `computeAvgHourlyRateCents` and `hasHourlyWageData` derive from this one
+ * set so they cannot disagree: if they used different filters, a roster mixing
+ * one employee at $20/hr with one unset rate would report "wage data is real"
+ * while advertising a blended $10/hr that nobody is paid, and every implied-labor
+ * readout downstream would inherit that error.
+ */
+function paidHourlyEmployees(employees: Employee[] | undefined): Employee[] {
+  return (
+    employees?.filter(
+      (e) => e.compensation_type === 'hourly' && e.is_active && e.hourly_rate > 0,
+    ) ?? []
+  );
+}
+
 export function computeAvgHourlyRateCents(employees: Employee[] | undefined): number {
-  if (!employees?.length) return DEFAULT_HOURLY_RATE_CENTS;
-  const hourlyEmployees = employees.filter(
-    (e) => e.compensation_type === 'hourly' && e.is_active,
-  );
-  if (hourlyEmployees.length === 0) return DEFAULT_HOURLY_RATE_CENTS;
-  return Math.round(
-    hourlyEmployees.reduce((sum, e) => sum + e.hourly_rate, 0) / hourlyEmployees.length,
-  );
+  const paid = paidHourlyEmployees(employees);
+  if (paid.length === 0) return DEFAULT_HOURLY_RATE_CENTS;
+  return Math.round(paid.reduce((sum, e) => sum + e.hourly_rate, 0) / paid.length);
 }
 
 /**
  * True when the roster has at least one active hourly employee with a real,
- * nonzero rate — i.e. the wage from computeAvgHourlyRateCents is real, not the
- * DEFAULT_HOURLY_RATE_CENTS ($15/hr) fallback. Mirrors that function's own
- * `compensation_type === 'hourly' && is_active` filter, plus an `hourly_rate >
- * 0` check: `EmployeeDialog` saves a blank hourly-rate field as `0` cents, and
- * a roster whose only active hourly employee has an unset rate would
- * otherwise make this predicate true while the computed average is a
- * fabricated `$0/hr` — surfacing a "0% labor" readout as if it were real.
- * Surfaces use this to suppress an implied-labor readout that would
- * otherwise be derived from a wage nobody is paid.
+ * positive rate — i.e. the wage from `computeAvgHourlyRateCents` is derived
+ * from real data rather than its `DEFAULT_HOURLY_RATE_CENTS` ($15/hr) fallback.
+ * Surfaces use this to suppress an implied-labor readout that would otherwise
+ * be presented as fact while resting on a wage nobody is paid.
  */
 export function hasHourlyWageData(employees: Employee[] | undefined): boolean {
-  return !!employees?.some(
-    (e) => e.compensation_type === 'hourly' && e.is_active && e.hourly_rate > 0,
-  );
+  return paidHourlyEmployees(employees).length > 0;
 }
 
 export interface ImpliedLaborResult {

--- a/src/lib/staffingCalculator.ts
+++ b/src/lib/staffingCalculator.ts
@@ -65,6 +65,35 @@ export function laborConsistentSplh(params: { wage: number; targetLaborPct: numb
   return targetLaborPct > 0 ? wage / (targetLaborPct / 100) : 0;
 }
 
+export interface SplhHint extends ImpliedLaborResult {
+  /** SPLH value that would exactly hit `targetLaborPct` at `wageCents`. */
+  consistent: number;
+}
+
+/**
+ * The "≈ X% labor at current wage" hint shown next to the SPLH/labor-%
+ * inputs in both the on-chart config panel (`StaffingConfigPanel`) and the
+ * Labor Planning settings page (`RestaurantSettings`) — same guard and math
+ * in both places, centralized here so they can't drift.
+ *
+ * Null when there's no real wage, or when either input is blank/non-finite/
+ * non-positive (a cleared field parses to NaN, and `NaN > 0` is false —
+ * design §4).
+ */
+export function deriveSplhHint(params: {
+  splh: number;
+  targetLaborPct: number;
+  hasWageData: boolean;
+  wageCents: number;
+}): SplhHint | null {
+  const { splh, targetLaborPct, hasWageData, wageCents } = params;
+  const positive = (n: number) => Number.isFinite(n) && n > 0;
+  if (!hasWageData || !positive(splh) || !positive(targetLaborPct)) return null;
+  const wage = wageCents / 100;
+  const { pct, overTarget } = impliedLabor({ wage, splh, targetLaborPct });
+  return { pct, overTarget, consistent: laborConsistentSplh({ wage, targetLaborPct }) };
+}
+
 /**
  * Compute the effective minimum staff from position-based min_crew.
  * Falls back to the global min_staff when min_crew is null or empty.

--- a/src/lib/staffingCalculator.ts
+++ b/src/lib/staffingCalculator.ts
@@ -15,14 +15,21 @@ export function computeAvgHourlyRateCents(employees: Employee[] | undefined): nu
 }
 
 /**
- * True when the roster has at least one active hourly employee — i.e. the wage
- * from computeAvgHourlyRateCents is real, not the DEFAULT_HOURLY_RATE_CENTS
- * ($15/hr) fallback. Mirrors that function's own filter so the two can never
- * disagree. Surfaces use this to suppress an implied-labor readout that would
+ * True when the roster has at least one active hourly employee with a real,
+ * nonzero rate — i.e. the wage from computeAvgHourlyRateCents is real, not the
+ * DEFAULT_HOURLY_RATE_CENTS ($15/hr) fallback. Mirrors that function's own
+ * `compensation_type === 'hourly' && is_active` filter, plus an `hourly_rate >
+ * 0` check: `EmployeeDialog` saves a blank hourly-rate field as `0` cents, and
+ * a roster whose only active hourly employee has an unset rate would
+ * otherwise make this predicate true while the computed average is a
+ * fabricated `$0/hr` — surfacing a "0% labor" readout as if it were real.
+ * Surfaces use this to suppress an implied-labor readout that would
  * otherwise be derived from a wage nobody is paid.
  */
 export function hasHourlyWageData(employees: Employee[] | undefined): boolean {
-  return !!employees?.some((e) => e.compensation_type === 'hourly' && e.is_active);
+  return !!employees?.some(
+    (e) => e.compensation_type === 'hourly' && e.is_active && e.hourly_rate > 0,
+  );
 }
 
 export interface ImpliedLaborResult {

--- a/src/lib/staffingCalculator.ts
+++ b/src/lib/staffingCalculator.ts
@@ -15,6 +15,57 @@ export function computeAvgHourlyRateCents(employees: Employee[] | undefined): nu
 }
 
 /**
+ * True when the roster has at least one active hourly employee — i.e. the wage
+ * from computeAvgHourlyRateCents is real, not the DEFAULT_HOURLY_RATE_CENTS
+ * ($15/hr) fallback. Mirrors that function's own filter so the two can never
+ * disagree. Surfaces use this to suppress an implied-labor readout that would
+ * otherwise be derived from a wage nobody is paid.
+ */
+export function hasHourlyWageData(employees: Employee[] | undefined): boolean {
+  return !!employees?.some((e) => e.compensation_type === 'hourly' && e.is_active);
+}
+
+export interface ImpliedLaborResult {
+  pct: number;
+  overTarget: boolean;
+}
+
+/**
+ * Implied labor % of a given SPLH target at a given average hourly wage —
+ * the on-chart slider's live readout (`→ X% labor at $W/hr`).
+ *
+ * `overTarget` flags the readout as "over budget" once `pct` clears
+ * `targetLaborPct` by more than a 0.05-point tolerance (so a target hit to
+ * within float/rounding noise doesn't flash red).
+ */
+export function impliedLabor(params: {
+  wage: number;
+  splh: number;
+  targetLaborPct: number;
+}): ImpliedLaborResult {
+  const { wage, splh, targetLaborPct } = params;
+  // Guard against a 0 splh (would otherwise divide to Infinity) — the slider's
+  // own bounds keep this out of reach today, but the readout should degrade to
+  // a plain 0% rather than a nonsensical Infinity if that ever changes.
+  const pct = splh > 0 ? (wage / splh) * 100 : 0;
+  const overTarget = pct > targetLaborPct + 0.05;
+  return { pct, overTarget };
+}
+
+/**
+ * The SPLH target that exactly hits `targetLaborPct` at `wage` — the value
+ * the slider's track notch is drawn at, so a manager can see where their own
+ * labor goal puts the knob.
+ */
+export function laborConsistentSplh(params: { wage: number; targetLaborPct: number }): number {
+  const { wage, targetLaborPct } = params;
+  // Guard against a 0 targetLaborPct (would otherwise divide to Infinity) —
+  // settings-form input clamps this above 0 today, but the notch position
+  // should degrade to 0 rather than Infinity if that invariant ever slips.
+  return targetLaborPct > 0 ? wage / (targetLaborPct / 100) : 0;
+}
+
+/**
  * Compute the effective minimum staff from position-based min_crew.
  * Falls back to the global min_staff when min_crew is null or empty.
  */

--- a/src/pages/RestaurantSettings.tsx
+++ b/src/pages/RestaurantSettings.tsx
@@ -110,6 +110,20 @@ export default function RestaurantSettings() {
     return { pct, overTarget, consistent: laborConsistentSplh({ wage, targetLaborPct: target }) };
   }, [staffEmployees, lpTargetSplh, lpTargetLaborPct]);
 
+  const splhHintBlock = splhHint && (
+    <div aria-live="polite" className="flex flex-col gap-0.5">
+      <p className={`text-[13px] ${splhHint.overTarget ? 'text-warning' : 'text-muted-foreground'}`}>
+        ≈ {splhHint.pct.toFixed(0)}% labor at your current average wage
+        {splhHint.overTarget && (
+          <> — above your {lpTargetLaborPct}% target. Try ${Math.round(splhHint.consistent)} to hit it.</>
+        )}
+      </p>
+      <p className="text-[13px] text-muted-foreground/70">
+        Lowering this target increases recommended headcount.
+      </p>
+    </div>
+  );
+
   // Sync labor planning form when staffing defaults load
   useEffect(() => {
     setLpTargetSplh(String(staffDefaults.target_splh));
@@ -1166,6 +1180,7 @@ export default function RestaurantSettings() {
                             <p id="lpTargetSplh-help" className="text-[13px] text-muted-foreground">
                               Sales Per Labor Hour — the revenue each staff member should generate per hour
                             </p>
+                            {splhHintBlock}
                           </div>
                           <div className="space-y-2">
                             <Label htmlFor="lpAvgTicket" className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
@@ -1217,6 +1232,7 @@ export default function RestaurantSettings() {
                             <p id="lpTargetLaborPct-help" className="text-[13px] text-muted-foreground">
                               Maximum percentage of revenue that should go to labor costs
                             </p>
+                            {splhHintBlock}
                           </div>
                           <div className="space-y-2">
                             <Label htmlFor="lpMinStaff" className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">

--- a/src/pages/RestaurantSettings.tsx
+++ b/src/pages/RestaurantSettings.tsx
@@ -33,9 +33,8 @@ import { useStaffingSettings } from '@/hooks/useStaffingSettings';
 import { useEmployees } from '@/hooks/useEmployees';
 import {
   computeAvgHourlyRateCents,
+  deriveSplhHint,
   hasHourlyWageData,
-  impliedLabor,
-  laborConsistentSplh,
 } from '@/lib/staffingCalculator';
 
 export default function RestaurantSettings() {
@@ -100,15 +99,16 @@ export default function RestaurantSettings() {
   // Implied labor % of the SPLH currently typed into the form. Null when the
   // roster has no real hourly wage, or when either field is blank/non-numeric
   // (Number.parseFloat('') is NaN, and `NaN <= 0` is false — design §4).
-  const splhHint = useMemo(() => {
-    const splh = Number.parseFloat(lpTargetSplh);
-    const target = Number.parseFloat(lpTargetLaborPct);
-    const positive = (n: number) => Number.isFinite(n) && n > 0;
-    if (!hasHourlyWageData(staffEmployees) || !positive(splh) || !positive(target)) return null;
-    const wage = computeAvgHourlyRateCents(staffEmployees) / 100;
-    const { pct, overTarget } = impliedLabor({ wage, splh, targetLaborPct: target });
-    return { pct, overTarget, consistent: laborConsistentSplh({ wage, targetLaborPct: target }) };
-  }, [staffEmployees, lpTargetSplh, lpTargetLaborPct]);
+  const splhHint = useMemo(
+    () =>
+      deriveSplhHint({
+        splh: Number.parseFloat(lpTargetSplh),
+        targetLaborPct: Number.parseFloat(lpTargetLaborPct),
+        hasWageData: hasHourlyWageData(staffEmployees),
+        wageCents: computeAvgHourlyRateCents(staffEmployees),
+      }),
+    [staffEmployees, lpTargetSplh, lpTargetLaborPct],
+  );
 
   const splhHintBlock = splhHint && (
     <div aria-live="polite" className="flex flex-col gap-0.5">

--- a/src/pages/RestaurantSettings.tsx
+++ b/src/pages/RestaurantSettings.tsx
@@ -30,6 +30,13 @@ import { supabase } from '@/integrations/supabase/client';
 import { COGSPreferenceSettings } from '@/components/settings/COGSPreferenceSettings';
 import { GeofenceSettings } from '@/components/settings/GeofenceSettings';
 import { useStaffingSettings } from '@/hooks/useStaffingSettings';
+import { useEmployees } from '@/hooks/useEmployees';
+import {
+  computeAvgHourlyRateCents,
+  hasHourlyWageData,
+  impliedLabor,
+  laborConsistentSplh,
+} from '@/lib/staffingCalculator';
 
 export default function RestaurantSettings() {
   const { user } = useAuth();
@@ -83,11 +90,25 @@ export default function RestaurantSettings() {
 
   // Labor planning state (staffing settings)
   const { effectiveSettings: staffDefaults, updateSettings: saveStaffingSettings, isSaving: staffingSaving, isLoading: staffingLoading } = useStaffingSettings(selectedRestaurant?.restaurant_id ?? null);
+  const { employees: staffEmployees } = useEmployees(selectedRestaurant?.restaurant_id ?? null);
   const [lpTargetSplh, setLpTargetSplh] = useState('60');
   const [lpAvgTicket, setLpAvgTicket] = useState('8');
   const [lpTargetLaborPct, setLpTargetLaborPct] = useState('22');
   const [lpMinStaff, setLpMinStaff] = useState('1');
   const [lpLookbackWeeks, setLpLookbackWeeks] = useState('4');
+
+  // Implied labor % of the SPLH currently typed into the form. Null when the
+  // roster has no real hourly wage, or when either field is blank/non-numeric
+  // (Number.parseFloat('') is NaN, and `NaN <= 0` is false — design §4).
+  const splhHint = useMemo(() => {
+    const splh = Number.parseFloat(lpTargetSplh);
+    const target = Number.parseFloat(lpTargetLaborPct);
+    const positive = (n: number) => Number.isFinite(n) && n > 0;
+    if (!hasHourlyWageData(staffEmployees) || !positive(splh) || !positive(target)) return null;
+    const wage = computeAvgHourlyRateCents(staffEmployees) / 100;
+    const { pct, overTarget } = impliedLabor({ wage, splh, targetLaborPct: target });
+    return { pct, overTarget, consistent: laborConsistentSplh({ wage, targetLaborPct: target }) };
+  }, [staffEmployees, lpTargetSplh, lpTargetLaborPct]);
 
   // Sync labor planning form when staffing defaults load
   useEffect(() => {

--- a/tests/unit/StaffingConfigPanel.splhConsistency.test.tsx
+++ b/tests/unit/StaffingConfigPanel.splhConsistency.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * Task 5: SPLH ↔ labor-% consistency hint in the Planner's inline staffing panel.
+ * Tests: hint hidden without real wage data / with non-finite-positive SPLH;
+ *        warns with the labor-consistent SPLH when over target; renders muted
+ *        when within target; directional helper line always shows alongside
+ *        the hint; hint announces via aria-live="polite".
+ */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { StaffingConfigPanel } from '@/components/scheduling/ShiftPlanner/StaffingConfigPanel';
+
+const baseSettings = {
+  target_splh: 30,
+  target_labor_pct: 25,
+  min_staff: 1,
+  min_crew: null,
+};
+
+const defaultProps = {
+  onSettingsChange: vi.fn(),
+  onImmediateSettingsChange: vi.fn(),
+  onSaveDefaults: vi.fn(),
+  isSaving: false,
+  hasPendingChanges: false,
+  employeePositions: [],
+  actualSplh: null,
+  lookbackWeeks: 8,
+};
+
+function renderPanel(overrides: Record<string, unknown> = {}) {
+  return render(
+    <StaffingConfigPanel
+      {...defaultProps}
+      settings={baseSettings}
+      avgHourlyRateCents={1500}
+      hasWageData={true}
+      {...overrides}
+    />,
+  );
+}
+
+describe('StaffingConfigPanel — SPLH ↔ labor % consistency hint', () => {
+  it('should hide the hint when there is no real wage data', () => {
+    renderPanel({ settings: baseSettings, avgHourlyRateCents: 1500, hasWageData: false });
+    expect(screen.queryByText(/labor at current wage/)).not.toBeInTheDocument();
+  });
+
+  it('should hide the hint when the SPLH target is not a finite positive number', () => {
+    renderPanel({ settings: { ...baseSettings, target_splh: Number.NaN }, avgHourlyRateCents: 1000, hasWageData: true });
+    expect(screen.queryByText(/labor at current wage/)).not.toBeInTheDocument();
+  });
+
+  it('should warn with the labor-consistent SPLH for the $10/hr, $30, 25% case', () => {
+    renderPanel({ settings: baseSettings, avgHourlyRateCents: 1000, hasWageData: true });
+    const line = screen.getByText(/33% labor at current wage/);
+    expect(line).toHaveClass('text-warning');
+    expect(line).toHaveTextContent('above your 25% target, try $40');
+  });
+
+  it('should render the implied line muted when within target', () => {
+    renderPanel({ settings: { ...baseSettings, target_splh: 40 }, avgHourlyRateCents: 1000, hasWageData: true });
+    const line = screen.getByText(/25% labor at current wage/);
+    expect(line).not.toHaveClass('text-warning');
+    expect(line).not.toHaveTextContent('above your');
+  });
+
+  it('should always show the directional helper line when the hint renders', () => {
+    renderPanel({ settings: baseSettings, avgHourlyRateCents: 1000, hasWageData: true });
+    expect(screen.getByText('Lower SPLH → more staff recommended.')).toBeInTheDocument();
+  });
+
+  it('should announce the hint politely', () => {
+    const { container } = renderPanel({ settings: baseSettings, avgHourlyRateCents: 1000, hasWageData: true });
+    expect(container.querySelector('[aria-live="polite"]')).not.toBeNull();
+  });
+});

--- a/tests/unit/StaffingOverlay.wiring.test.tsx
+++ b/tests/unit/StaffingOverlay.wiring.test.tsx
@@ -20,9 +20,13 @@ vi.mock('@/components/scheduling/ShiftPlanner/SuggestedShifts', () => ({
   },
 }));
 
-// StaffingConfigPanel: stub
+// StaffingConfigPanel: stub, capturing props to assert wiring
+const configPanelProps: Array<Record<string, unknown>> = [];
 vi.mock('@/components/scheduling/ShiftPlanner/StaffingConfigPanel', () => ({
-  StaffingConfigPanel: () => <div data-testid="config-panel" />,
+  StaffingConfigPanel: (props: Record<string, unknown>) => {
+    configPanelProps.push(props);
+    return <div data-testid="config-panel" />;
+  },
 }));
 
 // StaffingDayColumn: stub
@@ -116,6 +120,7 @@ const expandPanel = () =>
 describe('<StaffingOverlay> wiring', () => {
   beforeEach(() => {
     suggestedShiftsProps.length = 0;
+    configPanelProps.length = 0;
     vi.clearAllMocks();
 
     // Default: queries return real-looking data with no loading
@@ -203,5 +208,21 @@ describe('<StaffingOverlay> wiring', () => {
     );
     expandPanel();
     expect(screen.getByTestId('config-panel')).toBeTruthy();
+  });
+
+  it('passes avgHourlyRateCents and hasWageData through to StaffingConfigPanel', () => {
+    render(
+      <StaffingOverlay restaurantId="r1" weekDays={WEEK_DAYS} />,
+      { wrapper },
+    );
+    expandPanel();
+    expect(configPanelProps.length).toBeGreaterThan(0);
+    const lastProps = configPanelProps[configPanelProps.length - 1];
+    // useEmployees is mocked to return no employees, so the hook falls back
+    // to the DEFAULT_HOURLY_RATE_CENTS ($15/hr) with hasWageData=false —
+    // asserting these reach the panel confirms the wiring, not the math
+    // (that's staffingCalculator.test.ts's job).
+    expect(lastProps.avgHourlyRateCents).toBe(1500);
+    expect(lastProps.hasWageData).toBe(false);
   });
 });

--- a/tests/unit/coverageChartModel.test.ts
+++ b/tests/unit/coverageChartModel.test.ts
@@ -167,7 +167,7 @@ describe('buildReceipt', () => {
     ]);
   });
 
-  it('CRITICAL: ok — last row "On target" / 0, default tone throughout', () => {
+  it('ok — last row "On target" / 0, default tone throughout', () => {
     const h = receiptFixture({ demand: 5, scheduled: 5, projectedSales: 150 });
     const receipt = buildReceipt(h, { minStaff: 2, weekdayKey: 'Tuesday', wage: 15, lookbackWeeks: 6, hasWageData: true });
     const last = receipt.rows[receipt.rows.length - 1];
@@ -175,7 +175,17 @@ describe('buildReceipt', () => {
     expect(receipt.rows.every((r) => r.tone === 'default')).toBe(true);
   });
 
-  it('CRITICAL: spare — last row "Covered" / +N, positive tone', () => {
+  it('should omit the implied-SPLH aside when there are no sales to divide', () => {
+    // Staff on the clock with $0 projected sales means labor is *infinitely*
+    // over target, not 0% — `splhAt` collapses to 0 and impliedLabor's
+    // divide-by-zero guard returns 0%, which reads as the opposite of the
+    // truth. Omit the line rather than state a number that is backwards.
+    const h = receiptFixture({ demand: 0, scheduled: 3, projectedSales: 0 });
+    const receipt = buildReceipt(h, { minStaff: 1, weekdayKey: 'Monday', wage: 15, lookbackWeeks: 6, hasWageData: true });
+    expect(receipt.asides.some((a) => a.includes('implied SPLH'))).toBe(false);
+  });
+
+  it('spare — last row "Covered" / +N, positive tone', () => {
     const h = receiptFixture({ demand: 5, scheduled: 7, projectedSales: 150 });
     const receipt = buildReceipt(h, { minStaff: 2, weekdayKey: 'Tuesday', wage: 15, lookbackWeeks: 6, hasWageData: true });
     const last = receipt.rows[receipt.rows.length - 1];

--- a/tests/unit/coverageChartModel.test.ts
+++ b/tests/unit/coverageChartModel.test.ts
@@ -116,7 +116,7 @@ function receiptFixture(opts: {
 describe('buildReceipt', () => {
   it('CRITICAL: nodata — no rows, single explanatory aside using weekdayKey/lookbackWeeks/scheduled', () => {
     const h = receiptFixture({ demand: null, scheduled: 5 });
-    const receipt = buildReceipt(h, { minStaff: 2, weekdayKey: 'Monday', wage: 15, lookbackWeeks: 6 });
+    const receipt = buildReceipt(h, { minStaff: 2, weekdayKey: 'Monday', wage: 15, lookbackWeeks: 6, hasWageData: true });
     expect(receipt.rows).toEqual([]);
     expect(receipt.asides).toEqual([
       'No sales in the last 6 Mondays — no demand target to compare against. (The old chart used to show this hour as 5 / 0.)',
@@ -127,7 +127,7 @@ describe('buildReceipt', () => {
     // Avg sales $503, demand 17 (⇒ implied target round(503/17)=$30/hr), minStaff 4
     // (below demand, so needed stays 17), scheduled 14 ⇒ short on demand −3.
     const h = receiptFixture({ demand: 17, scheduled: 14, projectedSales: 503 });
-    const receipt = buildReceipt(h, { minStaff: 4, weekdayKey: 'Monday', wage: 15, lookbackWeeks: 6 });
+    const receipt = buildReceipt(h, { minStaff: 4, weekdayKey: 'Monday', wage: 15, lookbackWeeks: 6, hasWageData: true });
 
     expect(receipt.rows).toEqual([
       { label: 'Avg Monday sales', value: '$503', tone: 'default' },
@@ -148,7 +148,7 @@ describe('buildReceipt', () => {
     // demand=3 (target implied $30/hr from $90 sales), minStaff=5 pulls needed to 5;
     // scheduled=4 meets demand but misses the floor by 1.
     const h = receiptFixture({ demand: 3, scheduled: 4, projectedSales: 90 });
-    const receipt = buildReceipt(h, { minStaff: 5, weekdayKey: 'Friday', wage: 15, lookbackWeeks: 4 });
+    const receipt = buildReceipt(h, { minStaff: 5, weekdayKey: 'Friday', wage: 15, lookbackWeeks: 4, hasWageData: true });
 
     expect(receipt.rows).toEqual([
       { label: 'Avg Friday sales', value: '$90', tone: 'default' },
@@ -169,7 +169,7 @@ describe('buildReceipt', () => {
 
   it('CRITICAL: ok — last row "On target" / 0, default tone throughout', () => {
     const h = receiptFixture({ demand: 5, scheduled: 5, projectedSales: 150 });
-    const receipt = buildReceipt(h, { minStaff: 2, weekdayKey: 'Tuesday', wage: 15, lookbackWeeks: 6 });
+    const receipt = buildReceipt(h, { minStaff: 2, weekdayKey: 'Tuesday', wage: 15, lookbackWeeks: 6, hasWageData: true });
     const last = receipt.rows[receipt.rows.length - 1];
     expect(last).toEqual({ label: 'On target', value: '0', tone: 'default' });
     expect(receipt.rows.every((r) => r.tone === 'default')).toBe(true);
@@ -177,7 +177,7 @@ describe('buildReceipt', () => {
 
   it('CRITICAL: spare — last row "Covered" / +N, positive tone', () => {
     const h = receiptFixture({ demand: 5, scheduled: 7, projectedSales: 150 });
-    const receipt = buildReceipt(h, { minStaff: 2, weekdayKey: 'Tuesday', wage: 15, lookbackWeeks: 6 });
+    const receipt = buildReceipt(h, { minStaff: 2, weekdayKey: 'Tuesday', wage: 15, lookbackWeeks: 6, hasWageData: true });
     const last = receipt.rows[receipt.rows.length - 1];
     expect(last).toEqual({ label: 'Covered', value: '+2', tone: 'positive' });
   });
@@ -186,8 +186,8 @@ describe('buildReceipt', () => {
     const steady = receiptFixture({ demand: 5, scheduled: 5, scheduledMax: 5, projectedSales: 150 });
     const dips = receiptFixture({ demand: 5, scheduled: 5, scheduledMax: 8, projectedSales: 150 });
 
-    const steadyReceipt = buildReceipt(steady, { minStaff: 2, weekdayKey: 'Tuesday', wage: 15, lookbackWeeks: 6 });
-    const dipsReceipt = buildReceipt(dips, { minStaff: 2, weekdayKey: 'Tuesday', wage: 15, lookbackWeeks: 6 });
+    const steadyReceipt = buildReceipt(steady, { minStaff: 2, weekdayKey: 'Tuesday', wage: 15, lookbackWeeks: 6, hasWageData: true });
+    const dipsReceipt = buildReceipt(dips, { minStaff: 2, weekdayKey: 'Tuesday', wage: 15, lookbackWeeks: 6, hasWageData: true });
 
     expect(steadyReceipt.asides.some((a) => a.startsWith('Headcount moves'))).toBe(false);
     expect(dipsReceipt.asides).toContain(
@@ -198,7 +198,7 @@ describe('buildReceipt', () => {
   it('BOUNDARY: demand === 0 (no sales but a rec exists) — "÷ target" row omitted, no implied-SPLH aside at scheduled=0', () => {
     // demand=0, minStaff=2 ⇒ needed=2; scheduled=0 ⇒ floor (0 >= demand(0) but < needed(2)).
     const h = receiptFixture({ demand: 0, scheduled: 0, scheduledMax: 0, projectedSales: 0 });
-    const receipt = buildReceipt(h, { minStaff: 2, weekdayKey: 'Sunday', wage: 15, lookbackWeeks: 6 });
+    const receipt = buildReceipt(h, { minStaff: 2, weekdayKey: 'Sunday', wage: 15, lookbackWeeks: 6, hasWageData: true });
 
     expect(receipt.rows).toEqual([
       { label: 'Avg Sunday sales', value: '$0', tone: 'default' },

--- a/tests/unit/coverageChartModel.test.ts
+++ b/tests/unit/coverageChartModel.test.ts
@@ -1,8 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import {
   classifyHour,
-  impliedLabor,
-  laborConsistentSplh,
   buildReceipt,
   chartSummaryLabel,
 } from '@/lib/coverageChartModel';
@@ -81,66 +79,6 @@ describe('classifyHour', () => {
   it('BOUNDARY: demand === 0 with scheduled === 0 and minStaff === 0 → ok (not crit/floor)', () => {
     const h = hourFixture({ demand: 0, scheduled: 0 });
     expect(classifyHour(h, 0)).toBe('ok');
-  });
-});
-
-describe('impliedLabor', () => {
-  it('CRITICAL: pct = wage / splh * 100', () => {
-    const { pct } = impliedLabor({ wage: 20, splh: 25, targetLaborPct: 75 });
-    expect(pct).toBe(80);
-  });
-
-  it('CRITICAL: overTarget is true once pct exceeds targetLaborPct + 0.05', () => {
-    // wage/splh*100 = 75; targetLaborPct=74.94 -> threshold 74.99 -> 75 > 74.99
-    const { pct, overTarget } = impliedLabor({ wage: 15, splh: 20, targetLaborPct: 74.94 });
-    expect(pct).toBe(75);
-    expect(overTarget).toBe(true);
-  });
-
-  it('CRITICAL: overTarget is false when pct is at or below target', () => {
-    // wage/splh*100 = 30; targetLaborPct=30 (well above threshold 30.05)
-    const { pct, overTarget } = impliedLabor({ wage: 30, splh: 100, targetLaborPct: 30 });
-    expect(pct).toBe(30);
-    expect(overTarget).toBe(false);
-  });
-
-  it('BOUNDARY: pct exactly equal to targetLaborPct + 0.05 → not overTarget (strict >)', () => {
-    // wage/splh*100 = 75; targetLaborPct=74.95 -> threshold 75.0 exactly -> 75 > 75 is false
-    const { pct, overTarget } = impliedLabor({ wage: 15, splh: 20, targetLaborPct: 74.95 });
-    expect(pct).toBe(75);
-    expect(overTarget).toBe(false);
-  });
-
-  it('BOUNDARY: pct just 0.01 over threshold → overTarget true', () => {
-    // wage/splh*100 = 75; targetLaborPct=74.94 -> threshold 74.99 -> 75 > 74.99 -> true
-    const { overTarget } = impliedLabor({ wage: 15, splh: 20, targetLaborPct: 74.94 });
-    expect(overTarget).toBe(true);
-  });
-
-  it('BOUNDARY: splh === 0 degrades to pct 0 instead of Infinity', () => {
-    const { pct, overTarget } = impliedLabor({ wage: 15, splh: 0, targetLaborPct: 22 });
-    expect(pct).toBe(0);
-    expect(overTarget).toBe(false);
-  });
-});
-
-describe('laborConsistentSplh', () => {
-  it('CRITICAL: consistent = wage / (targetLaborPct / 100)', () => {
-    expect(laborConsistentSplh({ wage: 20, targetLaborPct: 25 })).toBe(80);
-  });
-
-  it('CRITICAL: a lower targetLaborPct yields a higher consistent SPLH (inverse relationship)', () => {
-    const lower = laborConsistentSplh({ wage: 20, targetLaborPct: 20 });
-    const higher = laborConsistentSplh({ wage: 20, targetLaborPct: 40 });
-    expect(lower).toBeGreaterThan(higher);
-  });
-
-  it('BOUNDARY: targetLaborPct === 100 → consistent === wage', () => {
-    expect(laborConsistentSplh({ wage: 30, targetLaborPct: 100 })).toBe(30);
-  });
-
-  it('BOUNDARY: targetLaborPct === 0 degrades to 0 instead of Infinity', () => {
-    expect(laborConsistentSplh({ wage: 30, targetLaborPct: 0 })).toBe(0);
   });
 });
 

--- a/tests/unit/coverageReceipt.test.tsx
+++ b/tests/unit/coverageReceipt.test.tsx
@@ -4,7 +4,7 @@ import { render, screen, fireEvent, within } from '@testing-library/react';
 import { CoverageReceipt } from '@/components/scheduling/ShiftTimeline/CoverageReceipt';
 import type { CoverageHour } from '@/lib/coverageSummary';
 
-const BASE_PARAMS = { minStaff: 4, weekdayKey: 'Monday', wage: 15, lookbackWeeks: 6 };
+const BASE_PARAMS = { minStaff: 4, weekdayKey: 'Monday', wage: 15, lookbackWeeks: 6, hasWageData: true };
 
 function hourFixture(opts: Partial<CoverageHour> & { demand: number | null; scheduled: number }): CoverageHour {
   const { demand, scheduled, scheduledMax = scheduled, projectedSales = demand === null ? null : 100, ...rest } = opts;
@@ -46,6 +46,16 @@ describe('CoverageReceipt', () => {
   it('renders buildReceipt asides below the ledger (implied SPLH note)', () => {
     render(<CoverageReceipt hour={critHour} {...BASE_PARAMS} minStaff={4} />);
     expect(screen.getByText(/implied SPLH is \$36\/hr/i)).toBeInTheDocument();
+  });
+
+  it('should omit the implied-SPLH aside when there is no real wage data', () => {
+    render(<CoverageReceipt hour={critHour} {...BASE_PARAMS} minStaff={4} hasWageData={false} />);
+    expect(screen.queryByText(/implied SPLH is/)).not.toBeInTheDocument();
+  });
+
+  it('should still show the implied-SPLH aside when wage data is real', () => {
+    render(<CoverageReceipt hour={critHour} {...BASE_PARAMS} minStaff={4} hasWageData={true} />);
+    expect(screen.getByText(/implied SPLH is/)).toBeInTheDocument();
   });
 
   it('CRITICAL: nodata hour renders no ledger rows, only the explanatory aside', () => {

--- a/tests/unit/restaurantSettings.splhConsistency.test.tsx
+++ b/tests/unit/restaurantSettings.splhConsistency.test.tsx
@@ -11,17 +11,26 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 // supabase client — RestaurantSettings fetches `overtime_rules` directly in a
 // useEffect on mount; a chainable no-op mock keeps that from throwing/hanging.
 vi.mock('@/integrations/supabase/client', () => {
-  function makeChain(): any {
-    const chain: any = {};
-    chain.select = () => makeChain();
-    chain.eq = () => makeChain();
-    chain.order = () => makeChain();
-    chain.maybeSingle = () => Promise.resolve({ data: null, error: null });
-    chain.single = () => Promise.resolve({ data: null, error: null });
-    chain.upsert = () => Promise.resolve({ data: null, error: null });
-    chain.then = (resolve: (v: { data: unknown; error: null }) => unknown) =>
-      Promise.resolve({ data: null, error: null }).then(resolve);
-    return chain;
+  type EmptyResult = { data: null; error: null };
+  interface QueryChain extends PromiseLike<EmptyResult> {
+    select: () => QueryChain;
+    eq: () => QueryChain;
+    order: () => QueryChain;
+    maybeSingle: () => Promise<EmptyResult>;
+    single: () => Promise<EmptyResult>;
+    upsert: () => Promise<EmptyResult>;
+  }
+  const empty = (): Promise<EmptyResult> => Promise.resolve({ data: null, error: null });
+  function makeChain(): QueryChain {
+    return {
+      select: makeChain,
+      eq: makeChain,
+      order: makeChain,
+      maybeSingle: empty,
+      single: empty,
+      upsert: empty,
+      then: (resolve, reject) => empty().then(resolve, reject),
+    };
   }
   return {
     supabase: {

--- a/tests/unit/restaurantSettings.splhConsistency.test.tsx
+++ b/tests/unit/restaurantSettings.splhConsistency.test.tsx
@@ -1,0 +1,176 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// --- Stub heavy deps before importing the component under test ---
+// Follows the provider/mocking pattern from tests/unit/StaffingOverlay.wiring.test.tsx.
+
+// supabase client — RestaurantSettings fetches `overtime_rules` directly in a
+// useEffect on mount; a chainable no-op mock keeps that from throwing/hanging.
+vi.mock('@/integrations/supabase/client', () => {
+  function makeChain(): any {
+    const chain: any = {};
+    chain.select = () => makeChain();
+    chain.eq = () => makeChain();
+    chain.order = () => makeChain();
+    chain.maybeSingle = () => Promise.resolve({ data: null, error: null });
+    chain.single = () => Promise.resolve({ data: null, error: null });
+    chain.upsert = () => Promise.resolve({ data: null, error: null });
+    chain.then = (resolve: (v: { data: unknown; error: null }) => unknown) =>
+      Promise.resolve({ data: null, error: null }).then(resolve);
+    return chain;
+  }
+  return {
+    supabase: {
+      from: () => makeChain(),
+      functions: { invoke: () => Promise.resolve({ data: null, error: null }) },
+    },
+  };
+});
+
+vi.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ user: { id: 'user-1', email: 'manager@example.com' } }),
+}));
+
+// role: 'manager' (not 'owner') keeps canEdit true while isOwner stays false —
+// isOwner also gates <TrialBanner> and the 'subscription' tab, which pull in
+// useSubscription() and its own Supabase reads we don't need for this test.
+const mockUserRestaurant = {
+  id: 'ur-1',
+  user_id: 'user-1',
+  restaurant_id: 'r1',
+  role: 'manager',
+  created_at: '2026-01-01T00:00:00Z',
+  restaurant: {
+    id: 'r1',
+    name: 'Test Restaurant',
+    timezone: 'America/Chicago',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+};
+
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => ({
+    selectedRestaurant: mockUserRestaurant,
+    restaurants: [mockUserRestaurant],
+    setSelectedRestaurant: vi.fn(),
+    loading: false,
+    createRestaurant: vi.fn(),
+    canCreateRestaurant: false,
+  }),
+}));
+
+vi.mock('@/hooks/useRestaurants', () => ({
+  useRestaurants: () => ({
+    updateRestaurant: vi.fn(),
+    restaurants: [mockUserRestaurant],
+    loading: false,
+  }),
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+// useStaffingSettings — fixed effective settings: target_splh: 30, target_labor_pct: 25.
+vi.mock('@/hooks/useStaffingSettings', () => ({
+  useStaffingSettings: () => ({
+    effectiveSettings: {
+      target_splh: 30,
+      avg_ticket_size: 8,
+      target_labor_pct: 25,
+      min_staff: 1,
+      lookback_weeks: 4,
+      manual_projections: null,
+      min_crew: null,
+      open_shifts_enabled: false,
+      require_shift_claim_approval: false,
+    },
+    updateSettings: vi.fn(),
+    isSaving: false,
+    isLoading: false,
+  }),
+}));
+
+// useEmployees — two active hourly employees at $10/hr (1000 cents) by default,
+// overridable per test via mockEmployeesReturn.
+const HOURLY_EMPLOYEES = [
+  {
+    id: 'e1',
+    restaurant_id: 'r1',
+    name: 'Alex',
+    position: 'Server',
+    status: 'active',
+    is_active: true,
+    compensation_type: 'hourly',
+    hourly_rate: 1000,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+  {
+    id: 'e2',
+    restaurant_id: 'r1',
+    name: 'Sam',
+    position: 'Cook',
+    status: 'active',
+    is_active: true,
+    compensation_type: 'hourly',
+    hourly_rate: 1000,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+];
+
+let mockEmployeesReturn: unknown[] = HOURLY_EMPLOYEES;
+vi.mock('@/hooks/useEmployees', () => ({
+  useEmployees: () => ({ employees: mockEmployeesReturn, loading: false, error: null }),
+}));
+
+import RestaurantSettings from '@/pages/RestaurantSettings';
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <MemoryRouter initialEntries={['/settings?tab=labor-planning']}>
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    </MemoryRouter>
+  );
+};
+
+const renderLaborPlanningTab = (overrides: { employees?: unknown[] } = {}) => {
+  mockEmployeesReturn = overrides.employees ?? HOURLY_EMPLOYEES;
+  return render(<RestaurantSettings />, { wrapper });
+};
+
+describe('<RestaurantSettings> Labor Planning tab — SPLH consistency hint', () => {
+  beforeEach(() => {
+    mockEmployeesReturn = HOURLY_EMPLOYEES;
+  });
+
+  it('should warn under both the SPLH and the labor % fields', async () => {
+    renderLaborPlanningTab();
+    const warnings = await screen.findAllByText(/33% labor at your current average wage/);
+    expect(warnings).toHaveLength(2);
+    warnings.forEach((w) => {
+      expect(w).toHaveClass('text-warning');
+      expect(w).toHaveTextContent('Try $40 to hit it.');
+    });
+  });
+
+  it('should hide the hint when the roster has no hourly employees', async () => {
+    renderLaborPlanningTab({ employees: [] });
+    expect(await screen.findByLabelText(/Target SPLH/i)).toBeInTheDocument();
+    expect(screen.queryByText(/labor at your current average wage/)).not.toBeInTheDocument();
+  });
+
+  it('should hide the hint when the SPLH field is cleared', async () => {
+    renderLaborPlanningTab();
+    await screen.findAllByText(/33% labor at your current average wage/);
+    await userEvent.clear(screen.getByLabelText(/Target SPLH/i));
+    expect(screen.queryByText(/labor at your current average wage/)).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/splhSlider.test.tsx
+++ b/tests/unit/splhSlider.test.tsx
@@ -9,6 +9,7 @@ const BASE_PROPS = {
   value: 50,
   wage: 15,
   targetLaborPct: 25,
+  hasWageData: true,
   canSave: true,
   isSaving: false,
   onChange: vi.fn(),
@@ -102,5 +103,23 @@ describe('SplhSlider', () => {
     renderSlider();
     const slider = screen.getByRole('slider', { name: 'Sales per labor hour target, in dollars' });
     expect(slider.getAttribute('aria-valuetext')).toMatch(/30(\.0)?%/);
+  });
+});
+
+describe('SplhSlider without wage data', () => {
+  it('should hide the pill and notch and show a prompt instead of a fabricated labor %', () => {
+    renderSlider({ value: 60, targetLaborPct: 22, hasWageData: false });
+    expect(screen.queryByTestId('splh-slider-pill')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('splh-slider-notch')).not.toBeInTheDocument();
+    expect(screen.getByText('Add hourly rates')).toBeInTheDocument();
+    expect(screen.queryByText(/% labor at/)).not.toBeInTheDocument();
+  });
+
+  it('should keep the fabricated percentage out of aria-valuetext', () => {
+    renderSlider({ value: 60, targetLaborPct: 22, hasWageData: false });
+    expect(screen.getByRole('slider', { name: 'Sales per labor hour target, in dollars' })).toHaveAttribute(
+      'aria-valuetext',
+      '$60/hr',
+    );
   });
 });

--- a/tests/unit/staffingCalculator.test.ts
+++ b/tests/unit/staffingCalculator.test.ts
@@ -4,7 +4,12 @@ import {
   consolidateIntoShiftBlocks,
   buildHourlyRecommendations,
   computeMinStaffFromCrew,
+  computeAvgHourlyRateCents,
+  hasHourlyWageData,
+  impliedLabor,
+  laborConsistentSplh,
 } from '@/lib/staffingCalculator';
+import type { Employee } from '@/types/scheduling';
 
 describe('checkLaborGuardrail', () => {
   it('returns false when labor pct is under target', () => {
@@ -185,5 +190,118 @@ describe('buildHourlyRecommendations', () => {
     });
     expect(result[0].demand).toBe(0);
     expect(result[0].recommendedStaff).toBe(1);
+  });
+});
+
+function emp(overrides: Partial<Employee> = {}): Employee {
+  return {
+    compensation_type: 'hourly',
+    is_active: true,
+    hourly_rate: 1000,
+    ...overrides,
+  } as Employee;
+}
+
+describe('hasHourlyWageData', () => {
+  it('should be false when the roster is undefined or empty', () => {
+    expect(hasHourlyWageData(undefined)).toBe(false);
+    expect(hasHourlyWageData([])).toBe(false);
+  });
+
+  it('should be false when every employee is salaried', () => {
+    expect(hasHourlyWageData([emp({ compensation_type: 'salary' })])).toBe(false);
+  });
+
+  it('should be false when the only hourly employee is inactive', () => {
+    expect(hasHourlyWageData([emp({ is_active: false })])).toBe(false);
+  });
+
+  it('should be true when at least one active hourly employee exists', () => {
+    expect(hasHourlyWageData([emp({ compensation_type: 'salary' }), emp()])).toBe(true);
+  });
+
+  it('should agree with computeAvgHourlyRateCents about when the wage is real', () => {
+    // Salaried-only → predicate false AND the wage is the $15 default, not derived.
+    const salaried = [emp({ compensation_type: 'salary', hourly_rate: 9999 })];
+    expect(hasHourlyWageData(salaried)).toBe(false);
+    expect(computeAvgHourlyRateCents(salaried)).toBe(1500);
+  });
+});
+
+describe('impliedLabor', () => {
+  it('CRITICAL: pct = wage / splh * 100', () => {
+    const { pct } = impliedLabor({ wage: 20, splh: 25, targetLaborPct: 75 });
+    expect(pct).toBe(80);
+  });
+
+  it('CRITICAL: overTarget is true once pct exceeds targetLaborPct + 0.05', () => {
+    // wage/splh*100 = 75; targetLaborPct=74.94 -> threshold 74.99 -> 75 > 74.99
+    const { pct, overTarget } = impliedLabor({ wage: 15, splh: 20, targetLaborPct: 74.94 });
+    expect(pct).toBe(75);
+    expect(overTarget).toBe(true);
+  });
+
+  it('CRITICAL: overTarget is false when pct is at or below target', () => {
+    // wage/splh*100 = 30; targetLaborPct=30 (well above threshold 30.05)
+    const { pct, overTarget } = impliedLabor({ wage: 30, splh: 100, targetLaborPct: 30 });
+    expect(pct).toBe(30);
+    expect(overTarget).toBe(false);
+  });
+
+  it('BOUNDARY: pct exactly equal to targetLaborPct + 0.05 → not overTarget (strict >)', () => {
+    // wage/splh*100 = 75; targetLaborPct=74.95 -> threshold 75.0 exactly -> 75 > 75 is false
+    const { pct, overTarget } = impliedLabor({ wage: 15, splh: 20, targetLaborPct: 74.95 });
+    expect(pct).toBe(75);
+    expect(overTarget).toBe(false);
+  });
+
+  it('BOUNDARY: pct just 0.01 over threshold → overTarget true', () => {
+    // wage/splh*100 = 75; targetLaborPct=74.94 -> threshold 74.99 -> 75 > 74.99 -> true
+    const { overTarget } = impliedLabor({ wage: 15, splh: 20, targetLaborPct: 74.94 });
+    expect(overTarget).toBe(true);
+  });
+
+  it('BOUNDARY: splh === 0 degrades to pct 0 instead of Infinity', () => {
+    const { pct, overTarget } = impliedLabor({ wage: 15, splh: 0, targetLaborPct: 22 });
+    expect(pct).toBe(0);
+    expect(overTarget).toBe(false);
+  });
+});
+
+describe('laborConsistentSplh', () => {
+  it('CRITICAL: consistent = wage / (targetLaborPct / 100)', () => {
+    expect(laborConsistentSplh({ wage: 20, targetLaborPct: 25 })).toBe(80);
+  });
+
+  it('CRITICAL: a lower targetLaborPct yields a higher consistent SPLH (inverse relationship)', () => {
+    const lower = laborConsistentSplh({ wage: 20, targetLaborPct: 20 });
+    const higher = laborConsistentSplh({ wage: 20, targetLaborPct: 40 });
+    expect(lower).toBeGreaterThan(higher);
+  });
+
+  it('BOUNDARY: targetLaborPct === 100 → consistent === wage', () => {
+    expect(laborConsistentSplh({ wage: 30, targetLaborPct: 100 })).toBe(30);
+  });
+
+  it('BOUNDARY: targetLaborPct === 0 degrades to 0 instead of Infinity', () => {
+    expect(laborConsistentSplh({ wage: 30, targetLaborPct: 0 })).toBe(0);
+  });
+});
+
+describe('SPLH ↔ labor % identity (real-world case)', () => {
+  it('should flag $30 SPLH at $10/hr against a 25% target and name $40 as consistent', () => {
+    const { pct, overTarget } = impliedLabor({ wage: 10, splh: 30, targetLaborPct: 25 });
+    expect(pct).toBeCloseTo(33.33, 1);
+    expect(overTarget).toBe(true);
+    expect(laborConsistentSplh({ wage: 10, targetLaborPct: 25 })).toBe(40);
+  });
+
+  it('should not flag the labor-consistent SPLH when fed back through', () => {
+    for (const [wage, target] of [[10, 25], [10.37, 30], [18.75, 18], [22, 33]] as const) {
+      const consistent = laborConsistentSplh({ wage, targetLaborPct: target });
+      const { pct, overTarget } = impliedLabor({ wage, splh: consistent, targetLaborPct: target });
+      expect(pct).toBeCloseTo(target, 6);
+      expect(overTarget).toBe(false);
+    }
   });
 });

--- a/tests/unit/staffingCalculator.test.ts
+++ b/tests/unit/staffingCalculator.test.ts
@@ -8,6 +8,7 @@ import {
   hasHourlyWageData,
   impliedLabor,
   laborConsistentSplh,
+  deriveSplhHint,
 } from '@/lib/staffingCalculator';
 import type { Employee } from '@/types/scheduling';
 
@@ -294,6 +295,40 @@ describe('laborConsistentSplh', () => {
 
   it('BOUNDARY: targetLaborPct === 0 degrades to 0 instead of Infinity', () => {
     expect(laborConsistentSplh({ wage: 30, targetLaborPct: 0 })).toBe(0);
+  });
+});
+
+describe('deriveSplhHint', () => {
+  it('returns the cents-to-dollars converted hint when all inputs are valid', () => {
+    const hint = deriveSplhHint({ splh: 30, targetLaborPct: 25, hasWageData: true, wageCents: 1000 });
+    expect(hint).not.toBeNull();
+    expect(hint!.pct).toBeCloseTo(33.33, 1);
+    expect(hint!.overTarget).toBe(true);
+    expect(hint!.consistent).toBe(40);
+  });
+
+  it('CRITICAL: returns null when wageCents is 0, even if hasWageData is true', () => {
+    expect(deriveSplhHint({ splh: 30, targetLaborPct: 25, hasWageData: true, wageCents: 0 })).toBeNull();
+  });
+
+  it('CRITICAL: returns null when wageCents is NaN', () => {
+    expect(deriveSplhHint({ splh: 30, targetLaborPct: 25, hasWageData: true, wageCents: NaN })).toBeNull();
+  });
+
+  it('CRITICAL: returns null when wageCents is Infinity', () => {
+    expect(deriveSplhHint({ splh: 30, targetLaborPct: 25, hasWageData: true, wageCents: Infinity })).toBeNull();
+  });
+
+  it('returns null when hasWageData is false', () => {
+    expect(deriveSplhHint({ splh: 30, targetLaborPct: 25, hasWageData: false, wageCents: 1000 })).toBeNull();
+  });
+
+  it('returns null when splh is not positive', () => {
+    expect(deriveSplhHint({ splh: 0, targetLaborPct: 25, hasWageData: true, wageCents: 1000 })).toBeNull();
+  });
+
+  it('returns null when targetLaborPct is not positive', () => {
+    expect(deriveSplhHint({ splh: 30, targetLaborPct: 0, hasWageData: true, wageCents: 1000 })).toBeNull();
   });
 });
 

--- a/tests/unit/staffingCalculator.test.ts
+++ b/tests/unit/staffingCalculator.test.ts
@@ -203,6 +203,32 @@ function emp(overrides: Partial<Employee> = {}): Employee {
   } as Employee;
 }
 
+describe('computeAvgHourlyRateCents and hasHourlyWageData agree on the paid set', () => {
+  it('should exclude unset (zero) rates from the blended average', () => {
+    // EmployeeDialog stores a blank hourly-rate field as 0 cents. Averaging a
+    // real $20/hr against that 0 advertises a $10/hr blended wage nobody is
+    // paid, and every implied-labor readout inherits the error.
+    const roster = [
+      emp({ hourly_rate: 2000 }),
+      emp({ hourly_rate: 0 }),
+    ];
+    expect(computeAvgHourlyRateCents(roster)).toBe(2000);
+    expect(hasHourlyWageData(roster)).toBe(true);
+  });
+
+  it('should fall back to the default wage when every rate is unset', () => {
+    const roster = [emp({ hourly_rate: 0 }), emp({ hourly_rate: 0 })];
+    expect(computeAvgHourlyRateCents(roster)).toBe(1500);
+    expect(hasHourlyWageData(roster)).toBe(false);
+  });
+
+  it('should ignore a negative rate in both the average and the predicate', () => {
+    const roster = [emp({ hourly_rate: -500 })];
+    expect(computeAvgHourlyRateCents(roster)).toBe(1500);
+    expect(hasHourlyWageData(roster)).toBe(false);
+  });
+});
+
 describe('hasHourlyWageData', () => {
   it('should be false when the roster is undefined or empty', () => {
     expect(hasHourlyWageData(undefined)).toBe(false);
@@ -229,12 +255,13 @@ describe('hasHourlyWageData', () => {
   });
 
   it('should be false when the only active hourly employee has an unset ($0) rate', () => {
-    // EmployeeDialog saves a blank hourly-rate field as 0 cents. Without excluding
-    // this, hasWageData would be true while computeAvgHourlyRateCents returns 0,
-    // fabricating a "0% labor" readout instead of suppressing it.
+    // EmployeeDialog saves a blank hourly-rate field as 0 cents. Both functions
+    // derive from the same paid-employee set, so the roster reduces to "no wage
+    // data": the predicate is false and the average reports its documented
+    // DEFAULT_HOURLY_RATE_CENTS sentinel rather than a fabricated $0/hr.
     const unsetRate = [emp({ hourly_rate: 0 })];
     expect(hasHourlyWageData(unsetRate)).toBe(false);
-    expect(computeAvgHourlyRateCents(unsetRate)).toBe(0);
+    expect(computeAvgHourlyRateCents(unsetRate)).toBe(1500);
   });
 });
 

--- a/tests/unit/staffingCalculator.test.ts
+++ b/tests/unit/staffingCalculator.test.ts
@@ -226,6 +226,15 @@ describe('hasHourlyWageData', () => {
     expect(hasHourlyWageData(salaried)).toBe(false);
     expect(computeAvgHourlyRateCents(salaried)).toBe(1500);
   });
+
+  it('should be false when the only active hourly employee has an unset ($0) rate', () => {
+    // EmployeeDialog saves a blank hourly-rate field as 0 cents. Without excluding
+    // this, hasWageData would be true while computeAvgHourlyRateCents returns 0,
+    // fabricating a "0% labor" readout instead of suppressing it.
+    const unsetRate = [emp({ hourly_rate: 0 })];
+    expect(hasHourlyWageData(unsetRate)).toBe(false);
+    expect(computeAvgHourlyRateCents(unsetRate)).toBe(0);
+  });
 });
 
 describe('impliedLabor', () => {

--- a/tests/unit/useWeekStaffingSuggestions.wageData.test.tsx
+++ b/tests/unit/useWeekStaffingSuggestions.wageData.test.tsx
@@ -100,4 +100,38 @@ describe('useWeekStaffingSuggestions wage data', () => {
     expect(result.current.avgHourlyRateCents).toBe(1500); // the $15 default
     expect(result.current.hasWageData).toBe(false); // …but not real data
   });
+
+  it('should treat a roster of unset ($0) rates as having no wage data', async () => {
+    mockEmployees([
+      { compensation_type: 'hourly', is_active: true, hourly_rate: 0 },
+      { compensation_type: 'hourly', is_active: true, hourly_rate: 0 },
+    ]);
+
+    const { result } = renderHook(
+      () => useWeekStaffingSuggestions('r1', ['2026-07-27'], null),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.avgHourlyRateCents).toBe(1500);
+    expect(result.current.hasWageData).toBe(false);
+  });
+
+  it('should exclude unset rates from the blended wage it advertises', async () => {
+    // A $20/hr employee alongside one whose rate was never set must not be
+    // averaged down to $10/hr and then reported as real (Codex P2 on PR #663).
+    mockEmployees([
+      { compensation_type: 'hourly', is_active: true, hourly_rate: 2000 },
+      { compensation_type: 'hourly', is_active: true, hourly_rate: 0 },
+    ]);
+
+    const { result } = renderHook(
+      () => useWeekStaffingSuggestions('r1', ['2026-07-27'], null),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.avgHourlyRateCents).toBe(2000);
+    expect(result.current.hasWageData).toBe(true);
+  });
 });

--- a/tests/unit/useWeekStaffingSuggestions.wageData.test.tsx
+++ b/tests/unit/useWeekStaffingSuggestions.wageData.test.tsx
@@ -1,0 +1,103 @@
+import React, { ReactNode } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import type { Employee } from '@/types/scheduling';
+
+// --- Mock the hook's dependencies (settings, employees, restaurant context) ---
+// Mirrors tests/unit/useWeekStaffingSuggestions.pagination.test.ts's mocking
+// scaffold, with useEmployees made per-test-controllable via mockEmployees().
+const { mockUseEmployees } = vi.hoisted(() => ({
+  mockUseEmployees: vi.fn(),
+}));
+
+vi.mock('@/hooks/useStaffingSettings', () => ({
+  useStaffingSettings: () => ({
+    effectiveSettings: {
+      lookback_weeks: 4,
+      target_splh: 200,
+      min_crew: 1,
+      min_staff: 1,
+      target_labor_pct: 25,
+    },
+    isLoading: false,
+    updateSettings: vi.fn(),
+    isSaving: false,
+  }),
+}));
+vi.mock('@/hooks/useEmployees', () => ({
+  useEmployees: () => mockUseEmployees(),
+}));
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => ({
+    selectedRestaurant: { restaurant: { timezone: 'America/Chicago' } },
+  }),
+}));
+
+// --- Mock the Supabase client query builder: every query resolves to an
+// empty page. These tests only assert on the wage-derived fields, which come
+// straight from `employees` and don't depend on sales/punch data. ---
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: vi.fn(() => {
+      const builder: Record<string, unknown> = {};
+      for (const m of ['select', 'eq', 'is', 'gte', 'lte', 'in', 'order']) {
+        builder[m] = vi.fn(() => builder);
+      }
+      builder.range = vi.fn(() => builder);
+      builder.then = (onFulfilled: (v: { data: unknown[]; error: null }) => unknown) =>
+        Promise.resolve({ data: [], error: null }).then(onFulfilled);
+      return builder;
+    }),
+  },
+}));
+
+import { useWeekStaffingSuggestions } from '@/hooks/useWeekStaffingSuggestions';
+
+function mockEmployees(employees: Partial<Employee>[]) {
+  mockUseEmployees.mockReturnValue({ employees: employees as Employee[] });
+}
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+};
+
+describe('useWeekStaffingSuggestions wage data', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should expose the blended wage and flag it as real for an hourly roster', async () => {
+    mockEmployees([
+      { compensation_type: 'hourly', is_active: true, hourly_rate: 1000 },
+      { compensation_type: 'hourly', is_active: true, hourly_rate: 2000 },
+    ]);
+
+    const { result } = renderHook(
+      () => useWeekStaffingSuggestions('r1', ['2026-07-27'], null),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.avgHourlyRateCents).toBe(1500);
+    expect(result.current.hasWageData).toBe(true);
+  });
+
+  it('should flag the fallback wage as not real for an empty roster', async () => {
+    mockEmployees([]);
+
+    const { result } = renderHook(
+      () => useWeekStaffingSuggestions('r1', ['2026-07-27'], null),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.avgHourlyRateCents).toBe(1500); // the $15 default
+    expect(result.current.hasWageData).toBe(false); // …but not real data
+  });
+});


### PR DESCRIPTION
## Summary

Extends PR #650's SPLH↔labor-% guard to the surfaces it did not reach, and fixes a wage bug it shipped with.

The identity `labor% = avg_hourly_wage / target_splh` binds three staffing settings, but nothing tied them together outside the coverage chart. Restaurant `7c0c76e3…` saved `target_splh = $30` with `target_labor_pct = 25%` and every hourly employee at `$10/hr` — that implies **33.3%** labor, not 25%. Since demand is `ceil(avgSales / target_splh)`, the too-low target drove the Planner coverage chart to demand **17 staff for a $503 hour**, which reads as a broken chart rather than a misconfiguration.

- **Settings → Labor Planning** and the **Planner's inline staffing panel** now show the implied labor % live, warn (`text-warning`) when it exceeds the target, name the consistent SPLH, and carry a directional line — users read "SPLH" as *what I currently get*, enter their blended actual, and get massive over-staffing at peak.
- **Fixes a real bug in shipped code:** `computeAvgHourlyRateCents` falls back to `$15/hr` for a roster with no active hourly employees, and four consumers presented that fabricated wage as fact — the slider's readout, its `aria-valuetext` (screen-reader-only), its notch, and `buildReceipt`'s implied-SPLH aside. A new `hasHourlyWageData` predicate gates all of them.
- **One implementation, not two:** `impliedLabor` / `laborConsistentSplh` move from `coverageChartModel.ts` to `staffingCalculator.ts` (three surfaces now depend on them, none of which is "the coverage chart"), and `buildReceipt` calls `impliedLabor` instead of re-inlining the division. Tolerance (`0.05` pt) and units (dollars) are unchanged from #650.

Warn-only by design — a manager may knowingly run above target, so nothing blocks a save.

## Test plan

- `npm run typecheck` — clean
- `npm run test` — 631 files / 7751 tests pass
- `npm run test:db` (pgTAP) — all pass
- `npm run build` — ✓ 21.18s
- E2E `coverage-chart-explainer.spec.ts` + `staffing-suggestions.spec.ts` — 5/5 pass (full suite runs here in CI)

New coverage: `hasHourlyWageData` (empty / salaried-only / inactive / unset-rate rosters), the real-world `$10`-`$30`-`25%` case, a `laborConsistentSplh` → `impliedLabor` round-trip, the slider's no-wage-data state incl. `aria-valuetext`, the receipt aside gate, hook exposure, and the hint's visibility matrix on both new surfaces (including the cleared-field `NaN` path).

## Design doc

`docs/superpowers/specs/2026-07-24-splh-labor-pct-consistency-design.md`

Two design-review rounds fed this: the first caught that the guard must key off an explicit roster predicate rather than the wage value (which can never be ≤0); the second caught the `aria-valuetext` and receipt leaks, and that raw `text-amber-*` violated CLAUDE.md where a semantic `text-warning` token already exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added labor-planning guidance connecting target SPLH and labor percentage.
  * Added wage-aware hints in Settings, the staffing planner, the SPLH slider, and coverage receipts.
  * Displays “Add hourly rates” when real wage data is unavailable.
  * Added accessible, warning-styled notices when labor is above target.

* **Bug Fixes**
  * Prevented fallback wage estimates from appearing as factual labor guidance.
  * Added validation for invalid or non-positive planning values.

* **Tests**
  * Added coverage for wage availability, consistency calculations, hints, slider behavior, receipts, and settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->