### PR TITLE
fix(ci): red job = gate broken; red check = findings await replies

### DIFF
--- a/.github/workflows/pr-comment-response.yml
+++ b/.github/workflows/pr-comment-response.yml
@@ -100,14 +100,18 @@ jobs:
           PRS: ${{ steps.select.outputs.prs }}
         run: |
           set -uo pipefail
-          FAILED=0
+          # BROKEN means the audit could not do its job — that is a red JOB.
+          # Unanswered findings are NOT a broken job: they are a red CHECK RUN,
+          # which is what branch protection reads. Failing the job for them made
+          # a normal triage backlog look like a broken pipeline in the Actions tab.
+          BROKEN=0
           for PR in $PRS; do
             # Snapshot the head BEFORE auditing. If the PR advances mid-audit the
             # result describes a commit that is no longer current, and publishing
             # it would mark the NEW head green on stale evidence.
             if ! BEFORE=$(gh api "repos/$REPO/pulls/$PR" --jq .head.sha) || [ -z "$BEFORE" ]; then
               echo "::error::Could not read the head SHA for PR #$PR before auditing; failing closed."
-              FAILED=1
+              BROKEN=1
               continue
             fi
 
@@ -119,7 +123,7 @@ jobs:
 
             if ! AFTER=$(gh api "repos/$REPO/pulls/$PR" --jq .head.sha) || [ -z "$AFTER" ]; then
               echo "::error::Could not re-read the head SHA for PR #$PR after auditing; failing closed."
-              FAILED=1
+              BROKEN=1
               continue
             fi
             if [ "$BEFORE" != "$AFTER" ]; then
@@ -133,7 +137,16 @@ jobs:
               # Exit 2 means the audit could not read the PR. Never a pass.
               *) CONCLUSION=failure; TITLE="Audit could not complete — treating as unanswered" ;;
             esac
-            [ "$CODE" = "0" ] || FAILED=1
+            # Exit 2 = the audit could not read the PR: broken, so fail the job.
+            # Exit 1 = findings are unanswered: expected, so the check run alone
+            # carries it.
+            # `set -e` is active here, so use if/fi rather than `[ ] && x=1` —
+            # a false test would make the compound return 1 and abort the job.
+            if [ "$CODE" = "2" ]; then
+              BROKEN=1
+            elif [ "$CODE" != "0" ]; then
+              echo "::notice::PR #$PR has review findings awaiting a verdict reply — see the pr-comment-response check."
+            fi
 
             jq -n \
               --arg name "pr-comment-response" \
@@ -152,8 +165,8 @@ jobs:
             fi
           done
 
-          if [ "$FAILED" = "1" ]; then
-            echo "::error::Some review findings have no verdict reply. See the pr-comment-response check."
+          if [ "$BROKEN" = "1" ]; then
+            echo "::error::The audit could not complete for at least one PR. The check run is red and this job failed because the gate itself is broken, not because findings are unanswered."
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

The `pr-comment-response` audit job exited 1 whenever findings were unanswered, so a routine triage backlog rendered as a **failed workflow** in the Actions tab. That reads as infrastructure breakage — it was reported as "an error in CI" on PR #663 when the gate was in fact working correctly.

Two signals, now separated:

- **Findings await a reply** (audit exit 1) → the `pr-comment-response` **check run** goes red; the job stays green. Branch protection reads the check run, so blocking behaviour is unchanged, and the PR's own check list still shows a red ✗ where reviewers look.
- **The audit could not run** (exit 2, unreadable head SHA, publish failure) → check red **and** job red, because the gate itself is broken.

## Note on a latent bug fixed here

The first draft used `[ "$CODE" = "2" ] && BROKEN=1`. `set -e` is active at that point, so a false test makes the compound return 1 and **aborts the job**. Rewritten as `if/fi`, and all three exit paths were verified under `set -e` before committing.

## Test plan

- YAML parses; the `run` block passes `bash -n`.
- All three audit exit codes exercised under `set -uo pipefail; set -e`:
  - `0` → BROKEN=0, script survives
  - `1` → notice emitted, BROKEN=0, script survives
  - `2` → BROKEN=1, script survives
- No JS changed, so `dev-tools/pr-triage.js` and its 77 unit tests are untouched.

## Context worth acting on separately

PR #663 merged at `04:05:14` with **7 unanswered findings**, 8 minutes after this gate correctly turned red at `03:57`. `required_status_checks.contexts` on `main` is currently `[]` — no required checks at all — so nothing stopped it. The gate is advisory until `pr-comment-response` is added to branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)