### PR TITLE
ci(unit-tests): give the Unit Tests job headroom over its real runtime

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,7 +16,10 @@ jobs:
   test:
     name: Unit Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # The suite plus coverage and the Sonar upload cost ~9m30s on a warm
+    # runner, so a 10-minute cap left no room for runner variance and kept
+    # cancelling the job with every test green. Keep headroom for growth.
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code

--- a/tests/unit/unitTestsWorkflowBudget.test.ts
+++ b/tests/unit/unitTestsWorkflowBudget.test.ts
@@ -1,0 +1,35 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+/**
+ * The unit-test job costs ~9m30s on a warm runner: ~30s install, ~7m50s
+ * `test:coverage`, ~10s `test:tz`, ~1m45s SonarCloud. It shipped with
+ * `timeout-minutes: 10`, so ordinary runner variance was enough to push it
+ * over and have GitHub cancel the job mid-Sonar-upload with all 8017 tests
+ * green (runs 30472141373 and 30480912925 both died at exactly 10m0x).
+ *
+ * The timeout is a hang detector, not a performance budget — it needs room
+ * for the suite to keep growing.
+ */
+const MIN_TIMEOUT_MINUTES = 20;
+
+const WORKFLOW = resolve(__dirname, '../../.github/workflows/unit-tests.yml');
+
+/** Body of a top-level job block, up to the next 2-space-indented key. */
+function jobBody(src: string, job: string): string {
+  const afterHeader = src.split(new RegExp(`^ {2}${job}:$`, 'm'))[1];
+  expect(afterHeader, `job "${job}" not found in unit-tests.yml`).toBeDefined();
+  return afterHeader.split(/^ {2}\S/m)[0];
+}
+
+describe('unit-tests workflow budget', () => {
+  const src = readFileSync(WORKFLOW, 'utf8');
+
+  it('gives the unit-test job headroom over its real runtime', () => {
+    const timeout = jobBody(src, 'test').match(/^\s+timeout-minutes:\s*(\d+)\s*$/m);
+
+    expect(timeout, 'the unit-test job must declare timeout-minutes').not.toBeNull();
+    expect(Number(timeout![1])).toBeGreaterThanOrEqual(MIN_TIMEOUT_MINUTES);
+  });
+});


### PR DESCRIPTION
## Problem

The **Unit Tests** check has been failing intermittently with `Error: The operation was canceled.` in the SonarCloud step — while every test passes.

It is a job timeout, not a test failure. `unit-tests.yml` set `timeout-minutes: 10`, but the job actually costs **~9m30s** on a warm 2-core runner:

| Step | Cost |
|---|---|
| checkout + node + `npm ci` | ~30s |
| `npm run test:coverage` | **7m50s** |
| `npm run test:tz` | ~10s |
| coverage artifact upload | ~3s |
| SonarCloud Scan | **1m45s** |

That leaves 10–45 seconds of slack, so ordinary runner variance blows the budget and GitHub cancels the job mid-Sonar-upload.

## Evidence

Last eleven runs of the job:

| Duration | Result |
|---|---|
| 10:17 | **cancelled** (run 30480912925) |
| 10:04 | **cancelled** (run 30472141373) |
| 10:00 / 9:49 / 9:44 / 9:37 | success (bare escapes) |
| 9:15 / 9:10 / 9:01 / 8:58 | success |

Run 30480912925 was cancelled at exactly 10m00s after reporting `Test Files 653 passed | 1 skipped`, `Tests 8015 passed | 2 skipped`. Nothing was broken.

The gap hides on dev machines: the same suite runs in **143s** locally on a many-core box versus **467s** on GitHub's 2-core runners, so the 10-minute cap looked generous to anyone checking locally.

## Change

- Raise the `test` job cap to **20 minutes**. A timeout is a hang detector, not a performance budget, and the suite (654 files, 8017 tests) keeps growing. Consistent with the neighbouring jobs (`db-tests: 15`, `e2e-tests: 25`).
- Add `tests/unit/unitTestsWorkflowBudget.test.ts` so the cap cannot be tightened back under the measured cost without a failing test.

## Verification

- Guard test fails before the fix (`expected 10 to be greater than or equal to 20`), passes after.
- Full suite green with the change: **654 files passed / 1 skipped, 8016 tests passed / 2 skipped**, exit 0.
- `tsc --noEmit` clean; `eslint` clean on the new file.
- Workflow YAML parses: `test=20 db-tests=15 e2e-tests=25 e2e-report=5`.

## Follow-up (not in this PR)

The Sonar scan lives inside the `test` job, so Sonar slowness surfaces as "Unit Tests: fail" even with a green suite — which is what made this confusing to diagnose. Splitting it into its own `needs: [test]` job is tracked separately; it needs its own verification for the coverage artifact path and Sonar's `fetch-depth: 0` requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)