### PR TITLE
fix(dev-workflow): contain runaway token burn and unbounded waits

### DIFF
--- a/.claude/workflows/dev-build-and-ship.js
+++ b/.claude/workflows/dev-build-and-ship.js
@@ -37,6 +37,34 @@ export const meta = {
 //      (the runtime has no sleep primitive for script-level polling).
 //   3. Phase 9e "done" is verified via on-disk ARTIFACTS, not transcript
 //      visibility (which does not exist across fresh-context agents).
+//
+// RUNAWAY-BURN HARDENING (post-mortem of run wf_da8ba6ba-5bb: 1.10M subagent
+// tokens, 59 min, zero commits — 97% of it ONE build task re-run six times).
+// What the runtime does, verified against the 2.1.218 binary and that run's
+// journal.jsonl, because it constrains what this layer can and cannot fix:
+//   * The stall watchdog and its retry loop live INSIDE the runtime's agent()
+//     implementation, not here. A stalled agent is retried with a BYTE-IDENTICAL
+//     prompt up to a hardcoded 5 times (6 attempts total); the retry count and
+//     the 180000ms interval are compile-time constants with no opts passthrough.
+//     The journal proves it: six agentIds share one prompt cache key.
+//     => "cap retries at 2" and "append the prior failure to the retry prompt"
+//        are NOT implementable at the script layer. They need a runtime change.
+//   * After the last attempt agent() THROWS. That is why the run died with a
+//     raw Error instead of a structured stop. A throw IS catchable here, so the
+//     three levers this script actually owns are:
+//       (a) catch the throw and halt with a structured, actionable needs_human
+//           (runAgent below) — one dead call can no longer kill the run blind;
+//       (b) guarantee nothing further is spent after a stall, and refuse to
+//           re-run a task already known to stall unless its prompt changed;
+//       (c) cap total spend with budget.spent(), which works whether or not the
+//           operator passed a "+Nk" directive (budget.total is usually null).
+//   * The stalls did NOT follow a silent no-tool_use turn. In every transcript
+//     the 180s gap follows a tool_result: the model was generating its NEXT turn
+//     and never emitted it, in a context grown to 0.4-1.0 MB. Stall probability
+//     therefore rises with context size, which makes prompt/context slimming
+//     (inlining each task's own plan section instead of pointing nine agents at
+//     the plan + design doc + a 42 KB skill file) a stall fix, not just a token
+//     saving.
 // ---------------------------------------------------------------------------
 
 // ---- Inputs (passed via args by the /dev skill after Phase 3) ----
@@ -79,8 +107,32 @@ const statusSchema = (extraProps = {}, extraRequired = []) => ({
   required: ['status', ...extraRequired],
 })
 
+// Second runaway mode, distinct from the stall retries: a wait whose exit
+// condition is unsatisfiable by construction. Observed for real — an agent left
+// a shell spinning `until [ "$(ps aux | grep -c '[p]laywright')" -lt 2 ]`. The
+// [p] trick stops grep matching itself but not the ~30 Claude Code processes
+// that carry "playwright" inside the MCP config on their own command lines, so
+// the count sat at 31 and could never fall. It ran 4h07m, orphaned from an
+// agent that had already died, until a human noticed and killed it.
+//
+// Nothing at the script layer can see a shell an agent spawned, let alone reap
+// one that outlives it. The only lever is the prompt, so this ships in the
+// envelope every agent gets — including phases that do not obviously wait,
+// because the next phase that starts a server should inherit it for free.
+const WAIT_DISCIPLINE = [
+  'WAIT DISCIPLINE (a poll loop with an impossible exit condition once spun 4h before a human killed it):',
+  '- Before ANY wait loop, evaluate the condition ONCE and print the raw value. If it already sits on the wrong side of the exit test, do not loop — looping cannot move it.',
+  '- Never test process state with `ps aux | grep -c <name>`. Every Claude Code process carries the MCP config on its command line, so grepping a tool name ("playwright", "vitest", "supabase") matches dozens of unrelated processes and the count never drops. Wait on a PID you started (`cmd & pid=$!; wait $pid`) or use the tool\'s own blocking mode (`gh pr checks --watch`, a foreground test run).',
+  '- Every wait needs a bound: prefix `timeout <seconds>`, or cap the iterations and exit non-zero printing the last observed value. An unbounded wait is indistinguishable from a hang.',
+  "- Kill every background process you start before you return, on the failure path too (`trap 'kill $pid 2>/dev/null' EXIT`). Orphans outlive the agent that spawned them.",
+].join('\n')
+
 // Orientation block injected into EVERY agent prompt (fresh context).
-function envelope(body) {
+// The development-workflow.md pointer is OPT-IN (skillRef), not default: it is a
+// 42 KB file and every phase prompt below already states what that phase must do.
+// Nine build agents each reading it from scratch was pure context bloat, and
+// context size is what drives the 180s stall (see the runtime notes above).
+function envelope(body, { skillRef = false } = {}) {
   return [
     'WORKING CONTEXT (you have fresh context — this block is all you start with):',
     `- Worktree (cd here for every command): ${ctx.worktreePath}`,
@@ -88,26 +140,94 @@ function envelope(body) {
     `- Design doc (the approved design — do NOT deviate from it): ${ctx.designDocPath}`,
     `- Plan file: ${ctx.planPath}`,
     `- progress.md: ${ctx.worktreePath}/progress.md — read it for prior-phase state; update it when you finish your phase.`,
-    `- The authoritative phase definitions live in ${ctx.worktreePath}/.claude/skills/development-workflow.md — consult the matching phase if you need detail.`,
+    ...(skillRef
+      ? [`- The authoritative phase definitions live in ${ctx.worktreePath}/.claude/skills/development-workflow.md — consult the matching phase if you need detail.`]
+      : []),
+    '',
+    WAIT_DISCIPLINE,
     '',
     body,
   ].join('\n')
 }
 
+// ---- Spend accounting -----------------------------------------------------
+// budget.total is null unless the operator passed a "+Nk" directive, so
+// budget.remaining() is usually Infinity and cannot backstop anything. spent()
+// always works, so the ceiling here is script-owned and measured against it.
+const TOKEN_CEILING = Number(ctx.tokenCeiling) > 0 ? Number(ctx.tokenCeiling) : 2000000
+const TASK_TOKEN_CEILING = Number(ctx.taskTokenCeiling) > 0 ? Number(ctx.taskTokenCeiling) : 350000
+function spent() {
+  try {
+    return typeof budget !== 'undefined' && budget && typeof budget.spent === 'function' ? budget.spent() || 0 : 0
+  } catch {
+    return 0
+  }
+}
+
+// Agents that died rather than returned. Carried into every stop payload so the
+// operator sees the stall signature without digging through transcripts.
+const stalls = []
+
+function stop(phase, extra = {}) {
+  return { stopped: true, phase, tokensSpent: spent(), ...(stalls.length ? { stalls } : {}), ...extra }
+}
+
 // Halt helper: stop the workflow cleanly when an agent needs a human or fails.
-function gate(result, phase) {
-  if (!result) return { halt: true, out: { stopped: true, phase, reason: 'agent returned null (user skipped or it errored)' } }
+function gate(result, phase, extra = {}) {
+  if (!result) return { halt: true, out: stop(phase, { reason: 'agent returned null (user skipped or it errored)', ...extra }) }
   if (result.status !== 'completed') {
-    return { halt: true, out: { stopped: true, phase, status: result.status, reason: result.reason || `agent returned status=${result.status}` } }
+    return { halt: true, out: stop(phase, { status: result.status, reason: result.reason || `agent returned status=${result.status}`, ...extra }) }
   }
   return { halt: false }
+}
+
+// Every agent() call goes through here. A stalled-out agent THROWS (see the
+// runtime notes at the top) and that throw would otherwise kill the run with a
+// bare Error and no structured stop. Converting it to a needs_human envelope
+// lets the normal gate() path halt cleanly with the stall signature attached.
+async function runAgent(prompt, opts, { nullOnCrash = false } = {}) {
+  const before = spent()
+  try {
+    return await agent(prompt, opts)
+  } catch (e) {
+    const message = String((e && e.message) || e)
+    const cost = spent() - before
+    stalls.push({ label: (opts && opts.label) || 'unlabelled', message, tokens: cost })
+    log(`✖ agent "${(opts && opts.label) || 'unlabelled'}" produced no result after ~${cost} tokens: ${message}`)
+    if (nullOnCrash) return null
+    return {
+      status: 'needs_human',
+      crashed: true,
+      reason:
+        `Agent "${(opts && opts.label) || 'unlabelled'}" never produced a result (${message}). ` +
+        `It burned ~${cost} tokens across the runtime's internal attempts, all with the same prompt. ` +
+        'Resuming as-is will reproduce it identically — change the prompt first (fix the task in the plan, ' +
+        'or pass args.resolutionNotes for this task), and pass the task id in args.stalledTasks so this ' +
+        'script refuses to re-run it blind.',
+    }
+  }
+}
+
+// Global spend ceiling, checked between agent() calls (the only point at which
+// this layer regains control). Returns a stop payload, or null to continue.
+function budgetHalt(phaseName, extra = {}) {
+  const s = spent()
+  if (s < TOKEN_CEILING) return null
+  return stop(phaseName, {
+    status: 'needs_human',
+    reason:
+      `Token ceiling reached: ~${s} output tokens spent against a ceiling of ${TOKEN_CEILING}. ` +
+      'Halting before spending more. If this run legitimately needs a bigger budget, relaunch with ' +
+      'args.tokenCeiling raised; if it does not, this is the runaway you wanted caught.',
+    ...extra,
+  })
 }
 
 // ===========================================================================
 // PHASE: Preflight — verify the environment before any expensive work.
 // ===========================================================================
 phase('Preflight')
-const pre = await agent(
+const pre = await runAgent(
   envelope(
     'PHASE: Preflight. Verify the environment is ready for autonomous build + ship. In the worktree, check and report:\n' +
       '- gh auth status; presence of jq, node, coderabbit (run coderabbit --version); presence of codex (best-effort).\n' +
@@ -126,13 +246,25 @@ const codexAvailable = !!pre.codexAvailable
 // PHASE 4: Build (TDD). Read plan -> one sequential agent per task.
 // ===========================================================================
 phase('Build')
-const planRead = await agent(
-  envelope('PHASE 4 setup. Read the plan file at ' + ctx.planPath + '. Extract the ordered list of implementation tasks (each a 2-5 min unit). Return them in dependency order — a task may only depend on earlier ones. Do not implement anything yet.'),
+// This agent is the ONLY one that reads the whole plan. It returns each task's
+// own section verbatim so the per-task prompts can inline just that slice —
+// nine fresh agents re-parsing the full plan is the context bloat that makes
+// build agents stall.
+const planRead = await runAgent(
+  envelope(
+    'PHASE 4 setup. Read the plan file at ' + ctx.planPath + '. Extract the ordered list of implementation tasks (each a 2-5 min unit). ' +
+      'Return them in dependency order — a task may only depend on earlier ones. Do not implement anything yet.\n' +
+      'For EACH task also return `body`: that task\'s own section of the plan, VERBATIM — its steps, the files it names, and its ' +
+      'completion/acceptance criterion (including any criterion that deliberately differs from a normal red-green-refactor cycle, ' +
+      'e.g. "complete when these tests fail"). Copy the text; do not summarise or rewrite it, because the build agent will see your ' +
+      'copy INSTEAD of the plan. If a section exceeds ~4000 characters, include the first 4000 and end with ' +
+      '"…[truncated — open the plan file for the rest]".',
+  ),
   {
     label: 'plan-read',
     phase: 'Build',
     schema: statusSchema(
-      { tasks: { type: 'array', items: { type: 'object', additionalProperties: false, properties: { id: { type: 'string' }, title: { type: 'string' } }, required: ['id', 'title'] } } },
+      { tasks: { type: 'array', items: { type: 'object', additionalProperties: false, properties: { id: { type: 'string' }, title: { type: 'string' }, body: { type: 'string' } }, required: ['id', 'title'] } } },
       ['tasks'],
     ),
   },
@@ -142,26 +274,110 @@ const planRead = await agent(
 // Sequential TDD — each task commits before the next starts (shared worktree, safe).
 // FUTURE: group tasks into dependency levels and parallel() the file-disjoint ones
 // with isolation:'worktree' + a merge-back agent. Out of scope for v1.
+// Tasks a previous run already burned six identical attempts on. The runtime
+// will do exactly the same thing again — same prompt, same stall, same cost —
+// so refuse to spend on one unless its prompt has actually changed (which, for
+// this loop, means a resolutionNotes entry).
+const knownStalled = new Set(Array.isArray(ctx.stalledTasks) ? ctx.stalledTasks : [])
+
 for (let i = 0; i < planRead.tasks.length; i++) {
   const t = planRead.tasks[i]
-  const r = await agent(
+  // A prior run may have halted this task with status=needs_human. The human's
+  // decision comes back in via ctx.resolutionNotes, keyed by task id or by
+  // 1-based position. Appending it changes the prompt, which is also what makes
+  // resumeFromRunId re-run this task instead of replaying its cached halt —
+  // tasks without a note keep their cache and return instantly.
+  const note = (ctx.resolutionNotes || {})[t.id] ?? (ctx.resolutionNotes || {})[String(i + 1)]
+
+  if (knownStalled.has(t.id) && !note) {
+    return stop('Build', {
+      status: 'needs_human',
+      task: t.id,
+      taskIndex: i + 1,
+      reason:
+        `Task ${t.id} ("${t.title}") is listed in args.stalledTasks and has no args.resolutionNotes entry. ` +
+        'Its prompt would be byte-identical to the run that already stalled on it, and the runtime retries a stalled ' +
+        'agent with the same prompt six times before giving up — so re-running it now buys nothing and costs the same. ' +
+        'Fix the task in the plan, or pass a resolutionNotes entry for it, then relaunch.',
+    })
+  }
+
+  const overall = budgetHalt('Build', { task: t.id, taskIndex: i + 1, completedTasks: i })
+  if (overall) return overall
+
+  const before = spent()
+  const r = await runAgent(
     envelope(
       `PHASE 4 (Build, strict TDD) — task ${i + 1}/${planRead.tasks.length}: "${t.title}" (id ${t.id}).\n` +
-        'Cycle: RED (write a failing test) -> GREEN (minimal code to pass) -> REFACTOR (tests stay green) -> COMMIT (descriptive message). ' +
+        (t.body
+          ? 'THIS TASK\'S SECTION OF THE PLAN IS INLINED BELOW — it is authoritative. Where its completion criterion ' +
+            'differs from the generic cycle, the plan wins. Some tasks deliberately end RED (a reproduction task lands ' +
+            'failing tests and NO source change; it is complete when the tests fail, and "fixing" them defeats its ' +
+            'purpose). Do not force such a task to green. Only open the plan file itself if the section below is ' +
+            'truncated or genuinely ambiguous — do not re-read the whole plan or the design doc for context you already have.\n' +
+            '=== plan section for ' + t.id + ' ===\n' + t.body + '\n=== end plan section ===\n'
+          : 'FIRST: open the plan file and read THIS task\'s own section (the plan-read step could not extract it). The plan is ' +
+            'authoritative — where its completion criterion differs from the generic cycle below, the plan wins. Some tasks ' +
+            'deliberately end RED (a reproduction task lands failing tests and NO source change; it is complete when the tests ' +
+            'fail, and "fixing" them defeats its purpose). Do not force such a task to green.\n') +
+        'ALSO FIRST: check whether this task is already done — `git log --oneline origin/main..HEAD` plus the ' +
+        'plan/progress.md. If its commit already exists, verify it briefly and return status=completed without redoing it.\n' +
+        'Otherwise the cycle is: RED (write a failing test) -> GREEN (minimal code to pass) -> REFACTOR (tests stay green) -> COMMIT (descriptive message). ' +
         'Use the repo test stack (vitest / pgTAP / playwright as appropriate). After committing, update progress.md with the task and its commit SHA. ' +
-        'If implementing this task correctly would require changing the approved design, do NOT improvise — return status=needs_human with specifics.',
+        'If implementing this task correctly would require changing the approved design, do NOT improvise — return status=needs_human with specifics.\n' +
+        'PACING: a watchdog kills you if you go 180s without emitting a tool call, and it gets easier to trip the longer ' +
+        'your context grows — so keep the context small. Read narrow (ranged reads and targeted greps, not whole files or ' +
+        'whole directories), act, commit. Do not plan the entire task in one long silent reasoning block, and do not ' +
+        're-derive the design from source when the section above already tells you what to change.\n' +
+        'SALVAGE (the kill gives you no warning and leaves nothing behind unless you wrote it down): commit early and ' +
+        'often — every green step is a commit. Before any long-running command (the full test suite, a broad search), ' +
+        'first record where you are: either commit what you have as `wip(' + t.id + '): <state>`, or append a short ' +
+        '"### ' + t.id + ' in progress — <what is done, what is next>" note to progress.md and commit that. A kill then ' +
+        'leaves a resumable branch instead of zero. Leave those small commits in place; make the LAST commit of the task ' +
+        'the descriptive one and do NOT rewrite history to tidy them up.' +
+        (note
+          ? `\n\nRESOLUTION FROM A PRIOR HALT ON THIS TASK — this is a decision already made by the human operator; treat it as binding and do not re-litigate it:\n${note}`
+          : ''),
     ),
     { label: `build:${t.id}`, phase: 'Build', schema: statusSchema() },
   )
-  const g = gate(r, 'Build'); if (g.halt) return g.out
-  log(`Build ${i + 1}/${planRead.tasks.length}: ${t.title}`)
+
+  const used = spent() - before
+  const g = gate(r, 'Build', { task: t.id, taskIndex: i + 1, completedTasks: i, taskTokens: used })
+  if (g.halt) return g.out
+
+  log(`Build ${i + 1}/${planRead.tasks.length}: ${t.title} — ~${used} tokens (run total ~${spent()})`)
+
+  // A task that completes but costs far more than budgeted is the shape of the
+  // wf_da8ba6ba-5bb runaway. Warn always; halt only when carrying that cost
+  // across the remaining tasks would blow the ceiling anyway.
+  if (used > TASK_TOKEN_CEILING) {
+    const remaining = planRead.tasks.length - (i + 1)
+    const projected = spent() + used * remaining
+    log(`⚠️ Build task ${t.id} used ~${used} tokens (per-task ceiling ${TASK_TOKEN_CEILING}); projected run total ~${projected}`)
+    if (projected > TOKEN_CEILING) {
+      return stop('Build', {
+        status: 'needs_human',
+        task: t.id,
+        taskIndex: i + 1,
+        completedTasks: i + 1,
+        taskTokens: used,
+        reason:
+          `Task ${t.id} completed but cost ~${used} tokens (per-task ceiling ${TASK_TOKEN_CEILING}). At that rate the ` +
+          `${remaining} remaining task(s) would take the run to ~${projected}, past the ${TOKEN_CEILING} ceiling. ` +
+          'Work committed so far is on the branch. Split the oversized tasks in the plan, or relaunch with a raised ' +
+          'args.tokenCeiling if this cost is genuinely expected.',
+      })
+    }
+  }
 }
 
 // ===========================================================================
 // PHASE 5: UI Review (conditional — agent decides skip via git diff).
 // ===========================================================================
 phase('UI Review')
-const ui = await agent(
+{ const b = budgetHalt('UI Review'); if (b) return b }
+const ui = await runAgent(
   envelope(
     'PHASE 5 (UI Review). Run: git diff origin/main...HEAD --name-only. ' +
       'If NO UI/component files changed (src/components, src/pages, *.tsx UI), return status=completed, reason="skipped: no UI changes". ' +
@@ -175,7 +391,8 @@ const ui = await agent(
 // PHASE 6: Simplify.
 // ===========================================================================
 phase('Simplify')
-const simp = await agent(
+{ const b = budgetHalt('Simplify'); if (b) return b }
+const simp = await runAgent(
   envelope('PHASE 6 (Simplify). Run: git diff origin/main...HEAD --name-only to scope recently-changed files. Use the code-simplifier skill to improve clarity/consistency/maintainability WITHOUT changing behavior. Commit any simplifications.'),
   { label: 'simplify', phase: 'Simplify', schema: statusSchema() },
 )
@@ -185,10 +402,14 @@ const simp = await agent(
 // PHASE 7: Multi-model review. snapshot -> parallel reviewers -> fold -> CR loop
 // ===========================================================================
 phase('Review')
+// Last hard budget gate before the six-way fan-out — the single most expensive
+// step in the script.
+{ const b = budgetHalt('Review'); if (b) return b }
+log(`Entering Phase 7 review fan-out at ~${spent()} tokens (ceiling ${TOKEN_CEILING})`)
 
 // 7a-prep: snapshot diff/log/design as STRINGS before fan-out (fresh-context agents
 // can't reliably re-derive them).
-const snap = await agent(
+const snap = await runAgent(
   envelope(
     'PHASE 7 setup. In the worktree, capture and RETURN as strings: (1) git diff origin/main...HEAD ; (2) git log origin/main..HEAD --oneline ; (3) the full contents of the design doc at ' + ctx.designDocPath + ' ; (4) headSha = `git rev-parse HEAD` (used later to re-review anything committed after this snapshot). ' +
       'If the diff exceeds ~60000 chars, set diffTruncated=true, return it truncated, and ALSO write the full patch to dev-tools/phase7-diff.patch in the worktree.',
@@ -238,17 +459,23 @@ async function runReviewer(d) {
   // reviewer exists to catch. Use a faithful general-purpose reviewer for it;
   // the judgment-based dimensions keep the bug-hunting reviewer.
   const agentType = d.key === 'ocr-rules' ? 'general-purpose' : 'feature-dev:code-reviewer'
-  let r = await agent(reviewerPrompt(d), { label: `review:${d.key}`, phase: 'Review', agentType, schema: FINDINGS })
-  if (!r) r = await agent(reviewerPrompt(d), { label: `review:${d.key}:retry`, phase: 'Review', agentType, schema: FINDINGS })
+  // nullOnCrash: this path already treats null as "reviewer produced nothing"
+  // and retries exactly once, which is the bounded script-level retry the build
+  // loop cannot have. Don't retry into a blown budget.
+  let r = await runAgent(reviewerPrompt(d), { label: `review:${d.key}`, phase: 'Review', agentType, schema: FINDINGS }, { nullOnCrash: true })
+  if (!r && spent() < TOKEN_CEILING) {
+    r = await runAgent(reviewerPrompt(d), { label: `review:${d.key}:retry`, phase: 'Review', agentType, schema: FINDINGS }, { nullOnCrash: true })
+  }
   return r
 }
 const reviewResults = await parallel([
   ...REVIEWERS.map((d) => () => runReviewer(d)),
   () =>
     codexAvailable
-      ? agent(
+      ? runAgent(
           envelope('PHASE 7a — Codex adversarial review. Run: bash dev-tools/codex-adversarial-review.sh main (it writes dev-tools/codex-review-output.md). If the output contains ::skip:: return status=completed with findings=[] (Codex unavailable). Otherwise parse dev-tools/codex-review-output.md into findings with severity.'),
           { label: 'review:codex', phase: 'Review', schema: FINDINGS },
+          { nullOnCrash: true },
         )
       : Promise.resolve({ status: 'completed', findings: [] }),
 ])
@@ -285,7 +512,7 @@ const foldInput = JSON.stringify(
     .map((r, i) => (r ? { reviewer: reviewerNames[i] || `#${i}`, status: r.status, findings: r.findings || [] } : null))
     .filter(Boolean),
 )
-const fold = await agent(
+const fold = await runAgent(
   envelope(
     'PHASE 7b (Fold findings). Below is JSON with findings from all reviewers (5 Claude — security, performance, maintainability, sound-logic, ocr-rules — plus Codex). Deduplicate by file:line (keep highest severity, merge messages). For each critical/major finding that is an actionable bug/security/correctness issue: FIX it and commit ("fix(review): <area> — addresses <reviewer>"). ' +
       'MINOR/INFO findings: fix any that are trivially safe (one-line, mechanical, no behaviour change) in the same commit. For every minor/info finding you do NOT fix, you MUST return it in `deferred[]` with file, line, severity, message and a one-line reason. ' +
@@ -305,7 +532,7 @@ if (deferredFindings.length) log(`Phase 7b deferred ${deferredFindings.length} m
 // 7c: CodeRabbit loop (script-level counter, max 3).
 let crClean = false
 for (let it = 1; it <= 3 && !crClean; it++) {
-  const cr = await agent(
+  const cr = await runAgent(
     envelope(
       `PHASE 7c (CodeRabbit) iteration ${it}/3. Run: coderabbit review --plain --type committed (in the worktree). Fix ONLY actionable findings and commit them. ` +
         'Return clean=true if there were NO actionable findings this run; clean=false if you fixed some (we re-run). On iteration 3 with findings still remaining, return clean=false and list the remaining items in reason — the script will escalate. ' +
@@ -316,12 +543,20 @@ for (let it = 1; it <= 3 && !crClean; it++) {
   const g = gate(cr, 'Review'); if (g.halt) return g.out
   crClean = cr.clean
   log(`CodeRabbit ${it}/3: ${crClean ? 'clean' : 'fixed findings, re-running'}`)
+  // The 7c prompt promises "the script will escalate" on a still-dirty round 3.
+  // It used to just fall through, so the last observed state vanished. A capped
+  // loop must report what it saw when the cap is what ended it.
+  if (!crClean && it === 3) {
+    const remaining = cr.reason || 'CodeRabbit still reported actionable findings on iteration 3 (no detail returned)'
+    log(`⚠️ CodeRabbit still dirty after 3 iterations — carrying forward as deferred: ${remaining}`)
+    deferredFindings.push(`CodeRabbit (unresolved after 3 iterations): ${remaining}`)
+  }
 }
 
 // 7d: bounded re-review of code committed AFTER the 7a snapshot.
 // The 7a diff is frozen, so 7b/7c fixes — and any late edits — otherwise ship
 // completely unreviewed. Exactly one extra pass; skipped when nothing changed.
-const postSnap = await agent(
+const postSnap = await runAgent(
   envelope(
     'PHASE 7d setup. In the worktree, return as strings: (1) newCommits = output of `git log ' + snap.headSha + '..HEAD --oneline` (empty string if there are none); ' +
       '(2) diff = output of `git diff ' + snap.headSha + '..HEAD -- . ":(exclude)dev-tools" ":(exclude)progress.md"` (empty string if empty). Truncate diff to ~60000 chars if larger. Do NOT modify anything.',
@@ -334,19 +569,20 @@ if (postSnap.diff && postSnap.diff.trim()) {
   log('Phase 7d: re-reviewing code committed after the 7a snapshot')
   const reResults = await parallel(
     REVIEWERS.map((d) => () =>
-      agent(
+      runAgent(
         envelope(
           `PHASE 7d — ${d.key} re-review. Read your reviewer instructions at ${ctx.worktreePath}/${d.promptFile} and load the skills it names. ` +
             'The changes below were committed AFTER the main review pass (Phase 7b/7c fixes and any late edits) and have NEVER been reviewed. Review ONLY this diff. Report findings with severity. DO NOT fix anything.\n\n' +
             '=== new commits ===\n' + postSnap.newCommits + '\n\n=== diff ===\n' + postSnap.diff,
         ),
         { label: `re-review:${d.key}`, phase: 'Review', agentType: d.key === 'ocr-rules' ? 'general-purpose' : 'feature-dev:code-reviewer', schema: FINDINGS },
+        { nullOnCrash: true },
       ),
     ),
   )
   const reFindings = reResults.map((r, i) => (r ? { reviewer: REVIEWERS[i].key, findings: r.findings || [] } : null)).filter(Boolean)
   if (reFindings.some((r) => r.findings.length)) {
-    const reFold = await agent(
+    const reFold = await runAgent(
       envelope(
         'PHASE 7d (fold re-review). The findings below come from re-reviewing code committed AFTER the main review pass. Deduplicate by file:line. FIX actionable critical/major findings and commit ("fix(review): <area> — addresses <reviewer> re-review"). ' +
           'Fix trivially-safe minors too; return EVERY unfixed minor/info in `deferred[]` with a reason. Never discard a finding silently. ' +
@@ -368,7 +604,11 @@ if (postSnap.diff && postSnap.diff.trim()) {
 // PHASE 8: Verify (single agent, internal 5-iteration fix loop).
 // ===========================================================================
 phase('Verify')
-const verify = await agent(
+// Final hard budget gate. From Ship onward the ceiling is advisory only: a PR
+// exists (or is one push away) and abandoning mid-CI strands finished work in a
+// worse state than finishing it, so those phases log spend instead of halting.
+{ const b = budgetHalt('Verify'); if (b) return b }
+const verify = await runAgent(
   envelope(
     'PHASE 8 (Verify). Ensure the .env.local symlink exists in the worktree. Run the FULL suite: npm run test ; npm run test:db ; npm run test:e2e (start npm run dev:full / local Supabase as needed, then TEAR DOWN the dev server) ; npm run typecheck ; npm run lint ; npm run build. ' +
       'If anything fails, fix + commit and re-run, up to 5 iterations. Return allPass=true ONLY if every check passes with real output evidence. If still failing after 5 iterations, return status=failed listing the failing checks. Always tear down any background servers you start.',
@@ -376,13 +616,13 @@ const verify = await agent(
   { label: 'verify', phase: 'Verify', schema: statusSchema({ allPass: { type: 'boolean' } }, ['allPass']) },
 )
 { const g = gate(verify, 'Verify'); if (g.halt) return g.out }
-if (!verify.allPass) return { stopped: true, phase: 'Verify', reason: 'local verification did not pass after 5 iterations' }
+if (!verify.allPass) return stop('Verify', { reason: 'local verification did not pass after 5 iterations' })
 
 // ===========================================================================
 // PHASE 9a: Ship — push + open PR, return the PR number (load-bearing state).
 // ===========================================================================
 phase('Ship')
-const ship = await agent(
+const ship = await runAgent(
   envelope(
     'PHASE 9a (Ship). Push the branch: git push -u origin ' + ctx.branch + '. Open a PR with gh pr create: concise title (<70 chars), body with ## Summary (bullets from the plan), ## Test plan, and a link to the design doc. ' +
       (deferredFindings.length
@@ -402,7 +642,7 @@ const PR = ship.prNumber
 phase('CI Loop')
 let ciGreen = false
 for (let it = 1; it <= 5 && !ciGreen; it++) {
-  const ci = await agent(
+  const ci = await runAgent(
     envelope(
       `PHASE 9b (CI) iteration ${it}/5 for PR #${PR}. Run: gh pr checks ${PR} --watch (blocks until checks finish). Then run dev-tools/refresh-queue.sh --pr ${PR} --skip-tests and check the SonarCloud quality gate (poll up to 3x with 60s gaps if Sonar lags CI).\n` +
         '- If all checks pass AND the Sonar gate passes (or Sonar is unconfigured — note it), return ciGreen=true.\n' +
@@ -413,15 +653,15 @@ for (let it = 1; it <= 5 && !ciGreen; it++) {
   )
   const g = gate(ci, 'CI Loop'); if (g.halt) return g.out
   ciGreen = ci.ciGreen
-  log(`CI ${it}/5: ${ciGreen ? 'green' : 'fixed + pushed, re-watching'}`)
+  log(`CI ${it}/5: ${ciGreen ? 'green' : 'fixed + pushed, re-watching'} (run total ~${spent()} tokens)`)
 }
-if (!ciGreen) return { stopped: true, phase: 'CI Loop', reason: 'CI not green after 5 iterations — escalating to human' }
+if (!ciGreen) return stop('CI Loop', { reason: 'CI not green after 5 iterations — escalating to human' })
 
 // ===========================================================================
 // PHASE 9d: Review-comment triage (NON-SKIPPABLE). Writes a disk artifact.
 // ===========================================================================
 phase('Triage')
-const triage = await agent(
+const triage = await runAgent(
   envelope(
     `PHASE 9d (Review-comment triage) for PR #${PR} — NON-SKIPPABLE. CI green is NOT done.\n` +
       '1. Capture the latest commit: git rev-parse HEAD.\n' +
@@ -449,19 +689,19 @@ const triage = await agent(
 
 // If triage pushed a fix, CI must re-run before the done gate.
 if (triage.pushedFix) {
-  const reCi = await agent(
+  const reCi = await runAgent(
     envelope(`A triage fix was pushed to PR #${PR}. Run: gh pr checks ${PR} --watch, confirm all green + Sonar gate. Return ciGreen.`),
     { label: 'ci:post-triage', phase: 'Triage', schema: statusSchema({ ciGreen: { type: 'boolean' } }, ['ciGreen']) },
   )
   const g = gate(reCi, 'Triage'); if (g.halt) return g.out
-  if (!reCi.ciGreen) return { stopped: true, phase: 'Triage', reason: 'CI not green after triage fix push' }
+  if (!reCi.ciGreen) return stop('Triage', { reason: 'CI not green after triage fix push' })
 }
 
 // ===========================================================================
 // PHASE 9e: Done gate — verified against ON-DISK ARTIFACTS, not transcript.
 // ===========================================================================
 phase('Done Gate')
-const done = await agent(
+const done = await runAgent(
   envelope(
     `PHASE 9e (Done gate) for PR #${PR}. Verify against the LATEST commit (git rev-parse HEAD):\n` +
       `- node dev-tools/pr-triage.js audit --pr ${PR} exits 0 (every finding has a verdict reply on the PR).\n` +
@@ -480,6 +720,8 @@ return {
   prNumber: PR,
   done: done.donePassed,
   buildTasks: planRead.tasks.length,
+  tokensSpent: spent(),
+  ...(stalls.length ? { stalls } : {}),
   triage: {
     fixesCommitted: triage.fixesCommitted || 0,
     declinedWithReply: triage.declinedWithReply || 0,

--- a/.claude/workflows/dev-build-and-ship.js
+++ b/.claude/workflows/dev-build-and-ship.js
@@ -123,7 +123,7 @@ const WAIT_DISCIPLINE = [
   'WAIT DISCIPLINE (a poll loop with an impossible exit condition once spun 4h before a human killed it):',
   '- Before ANY wait loop, evaluate the condition ONCE and print the raw value. If it already sits on the wrong side of the exit test, do not loop — looping cannot move it.',
   '- Never test process state with `ps aux | grep -c <name>`. Every Claude Code process carries the MCP config on its command line, so grepping a tool name ("playwright", "vitest", "supabase") matches dozens of unrelated processes and the count never drops. Wait on a PID you started (`cmd & pid=$!; wait $pid`) or use the tool\'s own blocking mode (`gh pr checks --watch`, a foreground test run).',
-  '- Every wait needs a bound: prefix `timeout <seconds>`, or cap the iterations and exit non-zero printing the last observed value. An unbounded wait is indistinguishable from a hang.',
+  "- Every wait needs a bound, but `timeout` and `gtimeout` do NOT exist on this BSD/bash-3.2 machine (nor does `tail --pid`) — do not reach for them. Run the command in the FOREGROUND and let the Bash tool's own timeout parameter bound it (default 120s, max 600s). If you must iterate, cap the count and exit non-zero printing the last observed value. An unbounded wait is indistinguishable from a hang.",
   "- Kill every background process you start before you return, on the failure path too (`trap 'kill $pid 2>/dev/null' EXIT`). Orphans outlive the agent that spawned them.",
 ].join('\n')
 
@@ -167,6 +167,15 @@ function spent() {
 // Agents that died rather than returned. Carried into every stop payload so the
 // operator sees the stall signature without digging through transcripts.
 const stalls = []
+
+// True when this label already died inside the runtime's retry loop. A null
+// from a THROWN stall is not the same as a null from an agent that simply
+// returned nothing: the runtime has already spent six byte-identical attempts
+// on that prompt, so any script-level retry buys six more of exactly the burn
+// this file exists to contain.
+function didCrash(label) {
+  return stalls.some((s) => s.label === label)
+}
 
 function stop(phase, extra = {}) {
   return { stopped: true, phase, tokensSpent: spent(), ...(stalls.length ? { stalls } : {}), ...extra }
@@ -459,10 +468,19 @@ async function runReviewer(d) {
   // reviewer exists to catch. Use a faithful general-purpose reviewer for it;
   // the judgment-based dimensions keep the bug-hunting reviewer.
   const agentType = d.key === 'ocr-rules' ? 'general-purpose' : 'feature-dev:code-reviewer'
-  // nullOnCrash: this path already treats null as "reviewer produced nothing"
-  // and retries exactly once, which is the bounded script-level retry the build
-  // loop cannot have. Don't retry into a blown budget.
-  let r = await runAgent(reviewerPrompt(d), { label: `review:${d.key}`, phase: 'Review', agentType, schema: FINDINGS }, { nullOnCrash: true })
+  // nullOnCrash: this path treats null as "reviewer produced nothing" and
+  // retries exactly once, which is the bounded script-level retry the build
+  // loop cannot have. But a null that came from a THROWN stall must NOT be
+  // retried — the runtime already burned six identical attempts on that
+  // prompt, and re-dispatching it buys six more, roughly doubling the very
+  // runaway this file contains. Retry only a reviewer that came back empty
+  // without dying, and never into a blown budget.
+  const label = `review:${d.key}`
+  let r = await runAgent(reviewerPrompt(d), { label, phase: 'Review', agentType, schema: FINDINGS }, { nullOnCrash: true })
+  if (!r && didCrash(label)) {
+    log(`⚠️ Phase 7a reviewer "${d.key}" stalled out — NOT retrying (the prompt would be byte-identical); its findings are absent this run`)
+    return null
+  }
   if (!r && spent() < TOKEN_CEILING) {
     r = await runAgent(reviewerPrompt(d), { label: `review:${d.key}:retry`, phase: 'Review', agentType, schema: FINDINGS }, { nullOnCrash: true })
   }

--- a/.claude/workflows/dev-continue-verify-and-ship.js
+++ b/.claude/workflows/dev-continue-verify-and-ship.js
@@ -50,7 +50,7 @@ const WAIT_DISCIPLINE = [
   'WAIT DISCIPLINE (a poll loop with an impossible exit condition once spun 4h before a human killed it):',
   '- Before ANY wait loop, evaluate the condition ONCE and print the raw value. If it already sits on the wrong side of the exit test, do not loop — looping cannot move it.',
   '- Never test process state with `ps aux | grep -c <name>`. Every Claude Code process carries the MCP config on its command line, so grepping a tool name ("playwright", "vitest", "supabase") matches dozens of unrelated processes and the count never drops. Wait on a PID you started (`cmd & pid=$!; wait $pid`) or use the tool\'s own blocking mode (`gh pr checks --watch`, a foreground test run).',
-  '- Every wait needs a bound: prefix `timeout <seconds>`, or cap the iterations and exit non-zero printing the last observed value. An unbounded wait is indistinguishable from a hang.',
+  "- Every wait needs a bound, but `timeout` and `gtimeout` do NOT exist on this BSD/bash-3.2 machine (nor does `tail --pid`) — do not reach for them. Run the command in the FOREGROUND and let the Bash tool's own timeout parameter bound it (default 120s, max 600s). If you must iterate, cap the count and exit non-zero printing the last observed value. An unbounded wait is indistinguishable from a hang.",
   "- Kill every background process you start before you return, on the failure path too (`trap 'kill $pid 2>/dev/null' EXIT`). Orphans outlive the agent that spawned them.",
 ].join('\n')
 

--- a/.claude/workflows/dev-continue-verify-and-ship.js
+++ b/.claude/workflows/dev-continue-verify-and-ship.js
@@ -1,0 +1,283 @@
+export const meta = {
+  name: 'dev-continue-verify-and-ship',
+  description: 'Continue /dev Phases 8-9e (Verify, Ship, CI loop, Triage, Done gate) after a Review-phase needs_human gate was resolved by hand.',
+  whenToUse:
+    'When dev-build-and-ship.js halted at the Review fold gate, the human resolved the finding and committed the fix, and Phases 8 onward still need to run. Resuming the original run would replay the cached fold agent and stop at the same gate.',
+  phases: [
+    { title: 'Verify', detail: 'full suite + prod-bundle probe grep' },
+    { title: 'Ship', detail: 'push + open PR' },
+    { title: 'CI Loop', detail: 'watch checks, fix, re-push (max 5)' },
+    { title: 'Triage', detail: 'reply to every review finding, audit exit 0' },
+    { title: 'Done Gate', detail: 'verify against on-disk artifacts' },
+  ],
+}
+
+let ctx = {}
+try {
+  ctx = (typeof args === 'string' ? JSON.parse(args) : args) || {}
+} catch {
+  ctx = {}
+}
+const REQUIRED = ['worktreePath', 'branch', 'designDocPath', 'planPath']
+const missingArgs = REQUIRED.filter((k) => !ctx[k])
+if (missingArgs.length) {
+  return { stopped: true, phase: 'Preflight', reason: `Missing required args: ${missingArgs.join(', ')}` }
+}
+
+const STATUS = {
+  status: { type: 'string', enum: ['completed', 'needs_human', 'failed'] },
+  reason: {
+    type: 'string',
+    description: 'Required when status is needs_human or failed: the specific blocker, with enough context for a human to act cold.',
+  },
+  commits: { type: 'array', items: { type: 'string' }, description: 'commit SHAs created during this phase (may be empty)' },
+}
+const statusSchema = (extraProps = {}, extraRequired = []) => ({
+  type: 'object',
+  additionalProperties: false,
+  properties: { ...STATUS, ...extraProps },
+  required: ['status', ...extraRequired],
+})
+
+// skillRef is opt-in: development-workflow.md is 42 KB and every prompt below
+// already states what its phase must do. See the runaway-burn notes in
+// dev-build-and-ship.js — context size is what drives the 180s stall.
+// Unsatisfiable-wait guard — see the WAIT_DISCIPLINE comment in
+// dev-build-and-ship.js for the incident. This script matters more for it than
+// that one does: Verify starts dev servers and Playwright, and the CI loop
+// waits on GitHub, so every phase here is a place a wait can be built wrong.
+const WAIT_DISCIPLINE = [
+  'WAIT DISCIPLINE (a poll loop with an impossible exit condition once spun 4h before a human killed it):',
+  '- Before ANY wait loop, evaluate the condition ONCE and print the raw value. If it already sits on the wrong side of the exit test, do not loop — looping cannot move it.',
+  '- Never test process state with `ps aux | grep -c <name>`. Every Claude Code process carries the MCP config on its command line, so grepping a tool name ("playwright", "vitest", "supabase") matches dozens of unrelated processes and the count never drops. Wait on a PID you started (`cmd & pid=$!; wait $pid`) or use the tool\'s own blocking mode (`gh pr checks --watch`, a foreground test run).',
+  '- Every wait needs a bound: prefix `timeout <seconds>`, or cap the iterations and exit non-zero printing the last observed value. An unbounded wait is indistinguishable from a hang.',
+  "- Kill every background process you start before you return, on the failure path too (`trap 'kill $pid 2>/dev/null' EXIT`). Orphans outlive the agent that spawned them.",
+].join('\n')
+
+function envelope(body, { skillRef = false } = {}) {
+  return [
+    'WORKING CONTEXT (you have fresh context — this block is all you start with):',
+    `- Worktree (cd here for every command): ${ctx.worktreePath}`,
+    `- Branch: ${ctx.branch}`,
+    `- Design doc (the approved design — do NOT deviate from it): ${ctx.designDocPath}`,
+    `- Plan file: ${ctx.planPath}`,
+    `- progress.md: ${ctx.worktreePath}/progress.md — read it for prior-phase state; update it when you finish your phase.`,
+    ...(skillRef
+      ? [`- The authoritative phase definitions live in ${ctx.worktreePath}/.claude/skills/development-workflow.md — consult the matching phase if you need detail.`]
+      : []),
+    '',
+    WAIT_DISCIPLINE,
+    '',
+    'PRIOR STATE: Phases 4-7 are COMPLETE. All reviewers ran (security/performance/maintainability: no findings; ocr-rules + sound-logic minors fixed in c0872b91). One Codex major — tier-2 route-shell boundary had no resetKey — was escalated and has since been resolved by hand in commit ff3776c1, which adds src/components/RouteShellBoundary.tsx, amends the design doc\'s "Reset semantics" section, and adds tests/unit/RouteShellBoundary.test.tsx. Do NOT re-litigate that decision or re-run the reviewers.',
+    '',
+    body,
+  ].join('\n')
+}
+
+// ---- Spend accounting + crash containment ---------------------------------
+// Same rationale as dev-build-and-ship.js (read the RUNAWAY-BURN block there):
+// the stall watchdog, its 6 identical retries and the 180s interval all live in
+// the runtime, and a stalled-out agent() THROWS. This script has no build loop,
+// so the levers that apply here are: catch the throw into a structured halt,
+// and cap total spend with budget.spent() (budget.total is usually null).
+const TOKEN_CEILING = Number(ctx.tokenCeiling) > 0 ? Number(ctx.tokenCeiling) : 1200000
+function spent() {
+  try {
+    return typeof budget !== 'undefined' && budget && typeof budget.spent === 'function' ? budget.spent() || 0 : 0
+  } catch {
+    return 0
+  }
+}
+
+const stalls = []
+
+function stop(phase, extra = {}) {
+  return { stopped: true, phase, tokensSpent: spent(), ...(stalls.length ? { stalls } : {}), ...extra }
+}
+
+function gate(result, phase, extra = {}) {
+  if (!result) return { halt: true, out: stop(phase, { reason: 'agent returned null (user skipped or it errored)', ...extra }) }
+  if (result.status !== 'completed') {
+    return { halt: true, out: stop(phase, { status: result.status, reason: result.reason || `agent returned status=${result.status}`, ...extra }) }
+  }
+  return { halt: false }
+}
+
+async function runAgent(prompt, opts, { nullOnCrash = false } = {}) {
+  const before = spent()
+  try {
+    return await agent(prompt, opts)
+  } catch (e) {
+    const message = String((e && e.message) || e)
+    const cost = spent() - before
+    stalls.push({ label: (opts && opts.label) || 'unlabelled', message, tokens: cost })
+    log(`✖ agent "${(opts && opts.label) || 'unlabelled'}" produced no result after ~${cost} tokens: ${message}`)
+    if (nullOnCrash) return null
+    return {
+      status: 'needs_human',
+      crashed: true,
+      reason:
+        `Agent "${(opts && opts.label) || 'unlabelled'}" never produced a result (${message}). ` +
+        `It burned ~${cost} tokens across the runtime's internal attempts, all with the same prompt — ` +
+        'relaunching unchanged will reproduce it identically. Change the prompt or do this phase by hand.',
+    }
+  }
+}
+
+// Returns a stop payload once the ceiling is reached, or null to continue.
+function budgetHalt(phaseName, extra = {}) {
+  const s = spent()
+  if (s < TOKEN_CEILING) return null
+  return stop(phaseName, {
+    status: 'needs_human',
+    reason:
+      `Token ceiling reached: ~${s} output tokens spent against a ceiling of ${TOKEN_CEILING}. ` +
+      'Halting before spending more. Relaunch with args.tokenCeiling raised if this run legitimately needs it.',
+    ...extra,
+  })
+}
+
+// ===========================================================================
+// PHASE 8: Verify
+// ===========================================================================
+phase('Verify')
+// Verify is this script's first phase, so a ceiling check here only fires on a
+// resumed run that arrives with spend already on the clock. The check that
+// actually bites is the one before Ship.
+{ const b = budgetHalt('Verify'); if (b) return b }
+const verify = await runAgent(
+  envelope(
+    'PHASE 8 (Verify). Ensure the .env.local symlink exists in the worktree. Run the FULL suite: npm run test ; npm run test:db ; npm run test:e2e (start npm run dev:full / local Supabase as needed, then TEAR DOWN the dev server) ; npm run typecheck ; npm run lint ; npm run build.\n' +
+      'ADDITIONALLY — this feature has a plan-mandated production-bundle gate (Task 6 of the plan). After npm run build, run:\n' +
+      '  grep -r "__error-boundary-probe" dist/ ; echo "exit=$?"\n' +
+      'It MUST report no matches (exit=1). The dev-only diagnostic route at src/App.tsx is gated on import.meta.env.DEV so Vite eliminates the dead branch; the path string lives inside that branch, so its absence from dist/ proves the probe route cannot ship. If the string IS present, the guard shape is wrong — fix it (move the probe behind a module imported only under the DEV branch) and re-run; do NOT proceed with a deliberately-throwing route in the production bundle. Record the grep output in progress.md under a "Production bundle verification" heading and set probeAbsentFromBundle accordingly.\n' +
+      'If anything fails, fix + commit and re-run, up to 5 iterations. Return allPass=true ONLY if every check passes with real output evidence. If still failing after 5 iterations, return status=failed listing the failing checks. Always tear down any background servers you start.',
+  ),
+  {
+    label: 'verify',
+    phase: 'Verify',
+    schema: statusSchema(
+      { allPass: { type: 'boolean' }, probeAbsentFromBundle: { type: 'boolean' } },
+      ['allPass', 'probeAbsentFromBundle'],
+    ),
+  },
+)
+{ const g = gate(verify, 'Verify'); if (g.halt) return g.out }
+if (!verify.allPass) return stop('Verify', { reason: 'local verification did not pass after 5 iterations' })
+if (!verify.probeAbsentFromBundle) {
+  return stop('Verify', { reason: 'the dev-only /__error-boundary-probe path is present in the production bundle — a deliberately-throwing route must not ship' })
+}
+
+// ===========================================================================
+// PHASE 9a: Ship
+// ===========================================================================
+phase('Ship')
+// Last clean halt point: nothing has been pushed yet, so stopping here strands
+// nothing. From here on the ceiling is advisory — abandoning mid-CI with a live
+// PR leaves a worse state than finishing, so those phases log spend instead.
+{ const b = budgetHalt('Ship'); if (b) return b }
+log(`Entering Ship at ~${spent()} tokens (ceiling ${TOKEN_CEILING})`)
+const ship = await runAgent(
+  envelope(
+    'PHASE 9a (Ship). Push the branch: git push -u origin ' + ctx.branch + '. Open a PR with gh pr create: concise title (<70 chars), body with ## Summary (bullets from the plan), ## Test plan, and a link to the design doc.\n' +
+      'In ## Summary, explicitly call out the three boundary tiers and the reset-key asymmetry (tier 1 has no resetKey because it sits above BrowserRouter; tiers 2 and 3 key on pathname, tier 3 additionally on restaurant id). Also note the design doc was amended during review — link the "Reset semantics" section.\n' +
+      'Return the PR number as prNumber. Update progress.md with it.',
+  ),
+  { label: 'ship', phase: 'Ship', schema: statusSchema({ prNumber: { type: 'number' } }, ['prNumber']) },
+)
+{ const g = gate(ship, 'Ship'); if (g.halt) return g.out }
+const PR = ship.prNumber
+
+// ===========================================================================
+// PHASE 9b: CI loop (max 5)
+// ===========================================================================
+phase('CI Loop')
+let ciGreen = false
+for (let it = 1; it <= 5 && !ciGreen; it++) {
+  const ci = await runAgent(
+    envelope(
+      `PHASE 9b (CI) iteration ${it}/5 for PR #${PR}. Run: gh pr checks ${PR} --watch (blocks until checks finish). Then run dev-tools/refresh-queue.sh --pr ${PR} --skip-tests and check the SonarCloud quality gate (poll up to 3x with 60s gaps if Sonar lags CI).\n` +
+        '- If all checks pass AND the Sonar gate passes (or Sonar is unconfigured — note it), return ciGreen=true.\n' +
+        '- If checks fail, fix the actionable failures, commit, push, and return ciGreen=false (we re-run).\n' +
+        '- If a review item genuinely needs human clarification, return status=needs_human with the items.',
+    ),
+    { label: `ci:${it}`, phase: 'CI Loop', schema: statusSchema({ ciGreen: { type: 'boolean' } }, ['ciGreen']) },
+  )
+  const g = gate(ci, 'CI Loop'); if (g.halt) return g.out
+  ciGreen = ci.ciGreen
+  log(`CI ${it}/5: ${ciGreen ? 'green' : 'fixed + pushed, re-watching'} (run total ~${spent()} tokens)`)
+}
+if (!ciGreen) return stop('CI Loop', { reason: 'CI not green after 5 iterations — escalating to human' })
+
+// ===========================================================================
+// PHASE 9d: Review-comment triage (NON-SKIPPABLE)
+// ===========================================================================
+phase('Triage')
+const triage = await runAgent(
+  envelope(
+    `PHASE 9d (Review-comment triage) for PR #${PR} — NON-SKIPPABLE. CI green is NOT done.\n` +
+      '1. Capture the latest commit: git rev-parse HEAD.\n' +
+      `2. Run: dev-tools/refresh-queue.sh --pr ${PR} --skip-tests.\n` +
+      '3. Run ALL THREE and print every row (do not summarize):\n' +
+      `   - gh api repos/{owner}/{repo}/pulls/${PR}/comments --paginate   (inline review comments — Codex posts here)\n` +
+      `   - gh api repos/{owner}/{repo}/issues/${PR}/comments --paginate  (PR conversation)\n` +
+      `   - gh pr view ${PR} --json reviews                               (PR-level reviews)\n` +
+      `4. Fix first, PUSH, and only then reply. An "agreed" reply must cite a commit already on the PR — the audit verifies the SHA against the PR's commit list, so replying before pushing makes the reply fail the gate.\n` +
+      `4b. Reply to EVERY finding: node dev-tools/pr-triage.js reply --pr ${PR} --comment <id> --verdict <agreed|pushed-back|ignored> [--commit <sha>] --rationale "<why>". For a CHANGES_REQUESTED review (no thread to nest under) use --review <reviewer-login> instead of --comment. A fix is an "agreed" reply naming the commit, NOT a substitute for replying. Use \`node dev-tools/pr-triage.js list --pr ${PR}\` to enumerate unanswered findings and their comment ids.\n` +
+      `4c. Then run: node dev-tools/pr-triage.js audit --pr ${PR} — it must exit 0 before you return. Exit 1 means a finding is unanswered; exit 2 means the audit could not read the PR (fail closed — investigate, never treat as a pass).\n` +
+      `5. Write the full classified list to dev-tools/9d-triage-${ctx.branch}.md (persistent artifact for the done gate).\n` +
+      'NOTE: if a reviewer re-raises the tier-2 resetKey question, it is already resolved in ff3776c1 — reply "agreed" citing that commit and the amended "Reset semantics" section of the design doc. Do not revert it.\n' +
+      'Return counts + latestSha. If there are genuinely ambiguous comments you cannot resolve, return status=needs_human with them.',
+  ),
+  {
+    label: 'triage',
+    phase: 'Triage',
+    schema: statusSchema(
+      { latestSha: { type: 'string' }, fixesCommitted: { type: 'number' }, declinedWithReply: { type: 'number' }, informational: { type: 'number' }, openCriticalOrMajor: { type: 'number' }, pushedFix: { type: 'boolean' } },
+      ['openCriticalOrMajor'],
+    ),
+  },
+)
+{ const g = gate(triage, 'Triage'); if (g.halt) return g.out }
+
+if (triage.pushedFix) {
+  const reCi = await runAgent(
+    envelope(`A triage fix was pushed to PR #${PR}. Run: gh pr checks ${PR} --watch, confirm all green + Sonar gate. Return ciGreen.`),
+    { label: 'ci:post-triage', phase: 'Triage', schema: statusSchema({ ciGreen: { type: 'boolean' } }, ['ciGreen']) },
+  )
+  const g = gate(reCi, 'Triage'); if (g.halt) return g.out
+  if (!reCi.ciGreen) return stop('Triage', { reason: 'CI not green after triage fix push' })
+}
+
+// ===========================================================================
+// PHASE 9e: Done gate
+// ===========================================================================
+phase('Done Gate')
+const done = await runAgent(
+  envelope(
+    `PHASE 9e (Done gate) for PR #${PR}. Verify against the LATEST commit (git rev-parse HEAD):\n` +
+      `- node dev-tools/pr-triage.js audit --pr ${PR} exits 0 (every finding has a verdict reply on the PR).\n` +
+      `- gh pr checks ${PR} : all passing.\n` +
+      '- SonarCloud quality gate: PASS (or explicitly note it is unconfigured).\n' +
+      `- dev-tools/9d-triage-${ctx.branch}.md exists and every row is fixed / replied / classified-as-nit.\n` +
+      '- dev-tools/review_queue.json: zero OPEN critical or major items.\n' +
+      'Return donePassed=true ONLY if ALL hold; otherwise donePassed=false with what failed in reason. Then update progress.md: ## Status: Ready for merge (only if donePassed).',
+  ),
+  { label: 'done-gate', phase: 'Done Gate', schema: statusSchema({ donePassed: { type: 'boolean' } }, ['donePassed']) },
+)
+{ const g = gate(done, 'Done Gate'); if (g.halt) return g.out }
+
+return {
+  stopped: false,
+  prNumber: PR,
+  done: done.donePassed,
+  tokensSpent: spent(),
+  ...(stalls.length ? { stalls } : {}),
+  probeAbsentFromBundle: verify.probeAbsentFromBundle,
+  triage: {
+    fixesCommitted: triage.fixesCommitted || 0,
+    declinedWithReply: triage.declinedWithReply || 0,
+    informational: triage.informational || 0,
+    openCriticalOrMajor: triage.openCriticalOrMajor,
+  },
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,30 @@ return <div>{data.map(...)}</div>;
 - Form inputs need associated labels
 - Interactive elements must be keyboard accessible
 
+### No Unbounded Waits
+A poll loop whose exit condition is unsatisfiable by construction once spun for 4h07m, orphaned from the agent that started it, until a human killed it.
+
+```bash
+# ❌ NEVER — every Claude Code process carries the MCP config on its command line,
+# so this matches ~30 unrelated processes and the count never drops below 2.
+until [ "$(ps aux | grep -c '[p]laywright')" -lt 2 ]; do sleep 5; done
+
+# ✅ Run the thing in the FOREGROUND and let the Bash tool's own `timeout`
+# parameter bound it (default 120s, max 600s). No poll loop to get wrong.
+npx playwright test --reporter=line
+
+# ✅ When you genuinely need a server alive underneath, trap it and keep the
+# work in the foreground — the server dies with the shell, on failure too.
+npm run dev & pid=$!
+trap 'kill $pid 2>/dev/null' EXIT
+npx playwright test --reporter=line
+```
+
+- Evaluate any wait condition **once** and print the raw value before looping. If it already sits on the wrong side of the exit test, looping cannot move it.
+- Never infer process state from `ps aux | grep -c <name>` — grepping a tool name (`playwright`, `vitest`, `supabase`) hits unrelated Claude Code processes. Prefer a PID you own (`wait $pid`), or the tool's own blocking mode (`gh pr checks --watch`, a foreground test run).
+- Bound every wait with the Bash tool's `timeout` parameter, not a hand-rolled loop. This is a BSD/bash-3.2 machine: `timeout`, `gtimeout` and `tail --pid` do **not** exist, so the usual Linux idioms silently fail here. If you must iterate, cap the count and exit non-zero printing the last observed value.
+- Kill every background process you start before returning, on the failure path too. Orphans outlive the agent that spawned them.
+
 ## Testing Requirements
 
 All new code must have tests:

--- a/dev-tools/workflow-harness.mjs
+++ b/dev-tools/workflow-harness.mjs
@@ -1,0 +1,110 @@
+/**
+ * Test harness for `.claude/workflows/*.js` orchestration scripts.
+ *
+ * Those scripts are not modules — the Workflow runtime evaluates their body as
+ * an async function with `agent`/`parallel`/`pipeline`/`log`/`phase`/`args`/
+ * `budget`/`workflow` injected as globals, and a top-level `return` producing
+ * the run's result. This harness reproduces that calling convention with
+ * scripted agents, so the control flow (halt gates, budget ceilings, stall
+ * containment) can be exercised deterministically in milliseconds instead of by
+ * burning a real multi-agent run.
+ *
+ * It verifies the SCRIPT layer only. The stall watchdog, its six identical
+ * retries and the 180s interval live inside the runtime's own agent()
+ * implementation and are not reachable from here — which is exactly why the
+ * scripts model a stalled-out agent as a thrown Error (what the runtime
+ * actually does after the last attempt) rather than pretending to control it.
+ */
+
+import { readFileSync } from 'node:fs'
+
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor
+
+/**
+ * @param {string} scriptPath           path to the workflow script
+ * @param {object} options
+ * @param {any}    options.args         value exposed to the script as `args`
+ * @param {(call: {prompt: string, opts: object, index: number}) => object} options.onAgent
+ *        Returns `{ result }` to resolve, `{ error }` to throw (the runtime's
+ *        stalled-out behaviour), and optionally `{ tokens }` to charge the
+ *        budget — charged either way, as the runtime accumulates the tokens
+ *        burned by attempts that never produced a result.
+ * @param {number|null} [options.budgetTotal]  `budget.total` (null = no "+Nk" directive)
+ */
+export async function runWorkflow(scriptPath, { args, onAgent, budgetTotal = null } = {}) {
+  const source = readFileSync(scriptPath, 'utf8').replace(/^export\s+const\s+meta\s*=/m, 'const meta =')
+
+  const calls = []
+  const logs = []
+  const phases = []
+  let tokens = 0
+
+  const agent = async (prompt, opts = {}) => {
+    const index = calls.length
+    const call = { prompt, opts, index, label: opts.label }
+    calls.push(call)
+    const outcome = (await onAgent({ prompt, opts, index })) || {}
+    tokens += outcome.tokens || 0
+    call.tokens = outcome.tokens || 0
+    if (outcome.error) {
+      call.threw = outcome.error
+      throw new Error(outcome.error)
+    }
+    call.result = outcome.result
+    return outcome.result === undefined ? null : outcome.result
+  }
+
+  // Mirrors the runtime: a thunk that throws resolves to null rather than
+  // rejecting the whole call.
+  const parallel = async (thunks) => Promise.all(thunks.map((t) => Promise.resolve().then(t).catch(() => null)))
+
+  const pipeline = async (items, ...stages) =>
+    Promise.all(
+      items.map(async (item, i) => {
+        let value = item
+        try {
+          for (const stage of stages) value = await stage(value, item, i)
+          return value
+        } catch {
+          return null
+        }
+      }),
+    )
+
+  const budget = {
+    get total() {
+      return budgetTotal
+    },
+    spent: () => tokens,
+    remaining: () => (budgetTotal == null ? Infinity : Math.max(0, budgetTotal - tokens)),
+  }
+
+  const body = new AsyncFunction('agent', 'parallel', 'pipeline', 'log', 'phase', 'args', 'budget', 'workflow', source)
+
+  let result
+  let error = null
+  try {
+    result = await body(
+      agent,
+      parallel,
+      pipeline,
+      (m) => logs.push(String(m)),
+      (t) => phases.push(t),
+      args,
+      budget,
+      async () => {
+        throw new Error('nested workflow() not supported in the harness')
+      },
+    )
+  } catch (e) {
+    error = e
+  }
+
+  return { result, error, calls, logs, phases, tokensSpent: tokens }
+}
+
+/** All agent labels in call order — the cheapest assertion for "what ran". */
+export const labelsOf = (run) => run.calls.map((c) => c.label)
+
+/** The single call with this label, or undefined. */
+export const callNamed = (run, label) => run.calls.find((c) => c.label === label)

--- a/tests/unit/workflowRunawayGuards.test.ts
+++ b/tests/unit/workflowRunawayGuards.test.ts
@@ -309,6 +309,12 @@ describe('unsatisfiable waits', () => {
         expect(call.prompt, `${script} / ${call.label}`).toContain('ps aux | grep -c')
         expect(call.prompt, `${script} / ${call.label}`).toContain('evaluate the condition ONCE')
         expect(call.prompt, `${script} / ${call.label}`).toContain('trap')
+        // The bound must point at a mechanism that exists here. `timeout` and
+        // `gtimeout` are absent on this BSD/bash-3.2 box, so telling agents to
+        // prefix with them produces "command not found" instead of a bound —
+        // the first cut of this block did exactly that (caught in review).
+        expect(call.prompt, `${script} / ${call.label}`).toContain("Bash tool's own timeout parameter")
+        expect(call.prompt, `${script} / ${call.label}`).not.toMatch(/prefix `timeout/)
       }
     }
   })
@@ -340,5 +346,47 @@ describe('unsatisfiable waits', () => {
     expect(run.logs.join('\n')).toContain('2 actionable findings remain in useShifts.tsx')
     // Best-effort phase: it escalates into the PR body rather than halting.
     expect(labelsOf(run)).toContain('ship')
+  })
+})
+
+/**
+ * Phase 7a retries a reviewer that came back empty, because a silently missing
+ * review is unsafe. That retry must distinguish its two nulls: an agent that
+ * returned nothing (retry it) from an agent that THREW after the runtime's six
+ * identical attempts (retrying buys six more, roughly doubling the runaway this
+ * file exists to contain). Caught in review on #681 — the first cut treated
+ * both nulls the same.
+ */
+describe('the Phase 7a reviewer retry knows which null it got', () => {
+  it('retries a reviewer that returned nothing, but never one that stalled out', async () => {
+    const run = await runWorkflow(BUILD_SCRIPT, {
+      args: BASE_ARGS,
+      onAgent: responder({
+        'review:security': { error: STALL_ERROR, tokens: 1_100_000 },
+        'review:performance': { tokens: 1000 }, // no result -> null, without dying
+      }),
+    })
+
+    const labels = labelsOf(run)
+    // Came back empty on its own: one bounded script-level retry is correct.
+    expect(labels).toContain('review:performance')
+    expect(labels).toContain('review:performance:retry')
+    // Stalled out: the prompt would be byte-identical, so it must not re-run.
+    expect(labels).toContain('review:security')
+    expect(labels).not.toContain('review:security:retry')
+
+    expect(run.logs.join('\n')).toContain('stalled out — NOT retrying')
+    // The stall is still surfaced rather than silently dropped.
+    expect(run.logs.join('\n')).toContain('findings are absent this run')
+  })
+
+  it('does not let a stalled reviewer double the burn', async () => {
+    const run = await runWorkflow(BUILD_SCRIPT, {
+      args: BASE_ARGS,
+      onAgent: responder({ 'review:security': { error: STALL_ERROR, tokens: 1_100_000 } }),
+    })
+
+    // Exactly one dispatch of the doomed prompt, not two rounds of six.
+    expect(labelsOf(run).filter((l) => l?.startsWith('review:security'))).toEqual(['review:security'])
   })
 })

--- a/tests/unit/workflowRunawayGuards.test.ts
+++ b/tests/unit/workflowRunawayGuards.test.ts
@@ -1,0 +1,344 @@
+/**
+ * Regression tests for the runaway-token-burn guards in the /dev workflow
+ * scripts, written against the post-mortem of run wf_da8ba6ba-5bb: 1,103,050
+ * subagent tokens over 59 minutes, 279 tool calls, ZERO commits, ~97% of it a
+ * single build task the runtime re-ran six times with a byte-identical prompt
+ * before throwing `agent stalled on all 6 attempts`.
+ *
+ * The runtime owns the watchdog, the six retries and the 180s interval — none
+ * of them are reachable from the script layer (the retry loop and its
+ * hardcoded limit live inside the runtime's own agent() implementation). What
+ * the script layer owns, and what these tests pin down, is everything that
+ * happens AROUND that: a dead agent must halt the run with an actionable
+ * needs_human instead of killing it with a bare Error, must not be re-run
+ * blind, and must never be followed by more spend.
+ */
+
+import { describe, it, expect } from 'vitest'
+import path from 'node:path'
+import { runWorkflow, labelsOf, callNamed } from '../../dev-tools/workflow-harness.mjs'
+
+const BUILD_SCRIPT = path.resolve(__dirname, '../../.claude/workflows/dev-build-and-ship.js')
+const CONTINUE_SCRIPT = path.resolve(__dirname, '../../.claude/workflows/dev-continue-verify-and-ship.js')
+
+const BASE_ARGS = {
+  worktreePath: '/tmp/wt',
+  branch: 'fix/shift-create-tz',
+  designDocPath: 'docs/design.md',
+  planPath: 'docs/plan.md',
+}
+
+/** The real error the runtime throws once every attempt has stalled. */
+const STALL_ERROR = 'agent stalled on all 6 attempts (no progress for 180000ms each)'
+
+const TASKS = Array.from({ length: 9 }, (_, i) => ({
+  id: `task-${i + 1}`,
+  title: `Task ${i + 1} title`,
+  body: `Steps for task ${i + 1}. Completion criterion: the new specs fail.`,
+}))
+
+/**
+ * Default happy-path agent responses, keyed by label prefix. Individual tests
+ * override single labels to inject the failure they care about.
+ */
+function defaultResponder(label: string) {
+  if (label === 'preflight') return { result: { status: 'completed', codexAvailable: false, sonarConfigured: false } }
+  if (label === 'plan-read') return { result: { status: 'completed', tasks: TASKS } }
+  if (label.startsWith('build:')) return { result: { status: 'completed' } }
+  if (label === 'review-snapshot') return { result: { status: 'completed', diff: 'd', gitLog: 'l', designDoc: 'dd', headSha: 'abc123' } }
+  if (label.startsWith('review:')) return { result: { status: 'completed', findings: [] } }
+  if (label === 'fold-findings') return { result: { status: 'completed', deferred: [] } }
+  if (label.startsWith('coderabbit:')) return { result: { status: 'completed', clean: true } }
+  if (label === 're-review-snapshot') return { result: { status: 'completed', newCommits: '', diff: '' } }
+  if (label === 'verify') return { result: { status: 'completed', allPass: true, probeAbsentFromBundle: true } }
+  if (label === 'ship') return { result: { status: 'completed', prNumber: 42 } }
+  if (label.startsWith('ci:')) return { result: { status: 'completed', ciGreen: true } }
+  if (label === 'triage') return { result: { status: 'completed', openCriticalOrMajor: 0, pushedFix: false } }
+  if (label === 'done-gate') return { result: { status: 'completed', donePassed: true } }
+  return { result: { status: 'completed' } }
+}
+
+/** What the harness accepts back from `onAgent`. */
+type AgentOutcome = { result?: unknown; error?: string; tokens?: number }
+/** What the harness hands to `onAgent` (prompt omitted where unused). */
+type AgentCall = { prompt?: string; opts: { label?: string } }
+
+/** A CI round that fixed something and pushed, so the loop wants another turn. */
+const CI_RED: AgentOutcome = { result: { status: 'completed', ciGreen: false } }
+
+/** Build an onAgent handler: happy path everywhere, `overrides` where given. */
+function responder(overrides: Record<string, AgentOutcome> = {}, costPerCall = 1000) {
+  return ({ opts }: AgentCall): AgentOutcome => {
+    const label = String(opts.label)
+    const override = overrides[label] ?? (label.startsWith('build:') ? overrides['build:*'] : undefined)
+    const base = override ?? defaultResponder(label)
+    return { tokens: costPerCall, ...base }
+  }
+}
+
+describe('dev-build-and-ship: a stalled build agent', () => {
+  it('halts the run with an actionable needs_human instead of dying with a bare Error', async () => {
+    const run = await runWorkflow(BUILD_SCRIPT, {
+      args: BASE_ARGS,
+      onAgent: responder({ 'build:task-1': { error: STALL_ERROR, tokens: 1_100_000 } }),
+    })
+
+    // The incident killed the workflow outright. It must not any more.
+    expect(run.error).toBeNull()
+    expect(run.result.stopped).toBe(true)
+    expect(run.result.phase).toBe('Build')
+    expect(run.result.status).toBe('needs_human')
+    expect(run.result.task).toBe('task-1')
+    expect(run.result.taskIndex).toBe(1)
+
+    // The reason must be actionable cold, and must name the two levers that
+    // actually change the outcome (the prompt is what the runtime replays).
+    expect(run.result.reason).toContain('never produced a result')
+    expect(run.result.reason).toContain(STALL_ERROR)
+    expect(run.result.reason).toMatch(/resolutionNotes/)
+    expect(run.result.reason).toMatch(/stalledTasks/)
+
+    // The stall signature travels with the stop payload.
+    expect(run.result.stalls).toHaveLength(1)
+    expect(run.result.stalls[0]).toMatchObject({ label: 'build:task-1', message: STALL_ERROR })
+    expect(run.result.tokensSpent).toBeGreaterThan(1_000_000)
+  })
+
+  it('spends nothing further — the remaining 8 tasks and the six-way review fan-out never start', async () => {
+    const run = await runWorkflow(BUILD_SCRIPT, {
+      args: BASE_ARGS,
+      onAgent: responder({ 'build:task-1': { error: STALL_ERROR, tokens: 1_100_000 } }),
+    })
+
+    expect(labelsOf(run)).toEqual(['preflight', 'plan-read', 'build:task-1'])
+    expect(labelsOf(run)).not.toContain('build:task-2')
+    expect(labelsOf(run)).not.toContain('review:security')
+  })
+
+  it('refuses to re-run a task already known to stall, spending zero on it', async () => {
+    const run = await runWorkflow(BUILD_SCRIPT, {
+      args: { ...BASE_ARGS, stalledTasks: ['task-1'] },
+      onAgent: responder({ 'build:task-1': { error: STALL_ERROR, tokens: 1_100_000 } }),
+    })
+
+    // build:task-1 is never dispatched at all.
+    expect(labelsOf(run)).toEqual(['preflight', 'plan-read'])
+    expect(run.result.status).toBe('needs_human')
+    expect(run.result.task).toBe('task-1')
+    expect(run.result.reason).toContain('byte-identical')
+    expect(run.tokensSpent).toBeLessThan(10_000)
+  })
+
+  it('re-runs a known-stalled task once its prompt actually differs, and the difference is visible', async () => {
+    const prompts: Record<string, string> = {}
+    const capture = (overrides: Record<string, AgentOutcome>, runArgs: unknown) =>
+      runWorkflow(BUILD_SCRIPT, {
+        args: runArgs,
+        onAgent: ({ prompt, opts }: AgentCall) => {
+          prompts[String(opts.label)] = String(prompt)
+          return responder(overrides)({ opts })
+        },
+      })
+
+    const withoutNote = await capture({}, BASE_ARGS)
+    const baseline = prompts['build:task-1']
+
+    const RESOLUTION = 'Task 1 is a reproduction task: land the failing specs and STOP. Do not touch src/.'
+    const withNote = await capture({}, { ...BASE_ARGS, stalledTasks: ['task-1'], resolutionNotes: { 'task-1': RESOLUTION } })
+    const retried = prompts['build:task-1']
+
+    expect(withoutNote.result.stopped).toBe(false)
+    expect(withNote.result.stopped).toBe(false)
+    expect(retried).not.toEqual(baseline)
+    expect(retried).toContain(RESOLUTION)
+    expect(retried).toContain('do not re-litigate')
+  })
+})
+
+describe('dev-build-and-ship: spend ceilings', () => {
+  it('halts at the global ceiling rather than grinding through every task', async () => {
+    const run = await runWorkflow(BUILD_SCRIPT, {
+      args: { ...BASE_ARGS, tokenCeiling: 500_000, taskTokenCeiling: 1_000_000 },
+      onAgent: responder({}, 120_000),
+    })
+
+    expect(run.result.stopped).toBe(true)
+    expect(run.result.phase).toBe('Build')
+    expect(run.result.status).toBe('needs_human')
+    expect(run.result.reason).toContain('Token ceiling reached')
+    expect(run.result.reason).toContain('tokenCeiling')
+    // Stopped mid-build, not after all nine tasks.
+    expect(run.result.completedTasks).toBeLessThan(TASKS.length)
+    expect(run.tokensSpent).toBeLessThan(700_000)
+  })
+
+  it('halts when one completed task is so expensive the remaining tasks would blow the ceiling', async () => {
+    const run = await runWorkflow(BUILD_SCRIPT, {
+      args: { ...BASE_ARGS, tokenCeiling: 2_000_000, taskTokenCeiling: 100_000 },
+      onAgent: responder({ 'build:*': { result: { status: 'completed' }, tokens: 400_000 } }),
+    })
+
+    expect(run.result.stopped).toBe(true)
+    expect(run.result.task).toBe('task-1')
+    expect(run.result.completedTasks).toBe(1)
+    expect(run.result.reason).toContain('per-task ceiling')
+    expect(run.logs.join('\n')).toContain('projected run total')
+  })
+
+  it('logs spend as it goes, so a burn is visible during the run and not only in the post-mortem', async () => {
+    const run = await runWorkflow(BUILD_SCRIPT, { args: BASE_ARGS, onAgent: responder({}, 5_000) })
+    const text = run.logs.join('\n')
+    expect(text).toMatch(/Build 1\/9: .* tokens \(run total/)
+    expect(text).toContain('Entering Phase 7 review fan-out at')
+  })
+
+  it('leaves the happy path intact and reports what it spent', async () => {
+    const run = await runWorkflow(BUILD_SCRIPT, { args: BASE_ARGS, onAgent: responder({}, 5_000) })
+
+    expect(run.error).toBeNull()
+    expect(run.result.stopped).toBe(false)
+    expect(run.result.prNumber).toBe(42)
+    expect(run.result.done).toBe(true)
+    expect(run.result.buildTasks).toBe(9)
+    expect(run.result.tokensSpent).toBe(run.tokensSpent)
+    expect(run.result.stalls).toBeUndefined()
+  })
+})
+
+describe('dev-build-and-ship: per-task context is inlined, not re-derived', () => {
+  it('inlines the task section and drops the 42 KB skill-file pointer', async () => {
+    const run = await runWorkflow(BUILD_SCRIPT, { args: BASE_ARGS, onAgent: responder() })
+    const prompt = callNamed(run, 'build:task-1')!.prompt
+
+    expect(prompt).toContain('=== plan section for task-1 ===')
+    expect(prompt).toContain(TASKS[0].body)
+    expect(prompt).toContain('do not re-read the whole plan')
+    expect(prompt).toContain('SALVAGE')
+
+    // No agent gets pointed at development-workflow.md by default any more.
+    for (const call of run.calls) expect(call.prompt).not.toContain('development-workflow.md')
+  })
+
+  it('falls back to reading the plan when plan-read could not extract a section', async () => {
+    const run = await runWorkflow(BUILD_SCRIPT, {
+      args: BASE_ARGS,
+      onAgent: responder({ 'plan-read': { result: { status: 'completed', tasks: [{ id: 'task-1', title: 'Only task' }] } } }),
+    })
+    const prompt = callNamed(run, 'build:task-1')!.prompt
+
+    expect(prompt).toContain('open the plan file and read THIS task')
+    expect(prompt).not.toContain('=== plan section for')
+  })
+})
+
+describe('dev-continue-verify-and-ship: same containment', () => {
+  it('converts a stalled verify agent into a structured halt and ships nothing after it', async () => {
+    const run = await runWorkflow(CONTINUE_SCRIPT, {
+      args: BASE_ARGS,
+      onAgent: responder({ verify: { error: STALL_ERROR, tokens: 900_000 } }),
+    })
+
+    expect(run.error).toBeNull()
+    expect(run.result.stopped).toBe(true)
+    expect(run.result.phase).toBe('Verify')
+    expect(run.result.status).toBe('needs_human')
+    expect(run.result.stalls[0].message).toBe(STALL_ERROR)
+    expect(labelsOf(run)).toEqual(['verify'])
+  })
+
+  it('enforces its own token ceiling before it pushes anything', async () => {
+    const run = await runWorkflow(CONTINUE_SCRIPT, {
+      args: { ...BASE_ARGS, tokenCeiling: 300_000 },
+      onAgent: responder({ verify: { result: { status: 'completed', allPass: true, probeAbsentFromBundle: true }, tokens: 400_000 } }),
+    })
+
+    expect(run.result.stopped).toBe(true)
+    expect(run.result.phase).toBe('Ship')
+    expect(run.result.reason).toContain('Token ceiling reached')
+    // Verify ran and passed, but nothing was pushed and no PR was opened.
+    expect(labelsOf(run)).toEqual(['verify'])
+  })
+})
+
+describe('both scripts still stop cleanly on ordinary gates', () => {
+  it('missing args halts before any agent runs', async () => {
+    for (const script of [BUILD_SCRIPT, CONTINUE_SCRIPT]) {
+      const run = await runWorkflow(script, { args: {}, onAgent: responder() })
+      expect(run.error).toBeNull()
+      expect(run.result.stopped).toBe(true)
+      expect(run.result.reason).toContain('Missing required args')
+      expect(run.calls).toHaveLength(0)
+    }
+  })
+
+  it('a needs_human return from an agent still halts with its own reason', async () => {
+    const run = await runWorkflow(BUILD_SCRIPT, {
+      args: BASE_ARGS,
+      onAgent: responder({ 'build:task-3': { result: { status: 'needs_human', reason: 'the design does not cover DST fall-back' } } }),
+    })
+
+    expect(run.result.stopped).toBe(true)
+    expect(run.result.status).toBe('needs_human')
+    expect(run.result.reason).toBe('the design does not cover DST fall-back')
+    expect(run.result.task).toBe('task-3')
+    expect(labelsOf(run)).not.toContain('build:task-4')
+  })
+})
+
+/**
+ * Second runaway mode, unrelated to the token-burn retries: a wait whose exit
+ * condition can never be satisfied. Observed as a shell left spinning
+ * `until [ "$(ps aux | grep -c '[p]laywright')" -lt 2 ]` — the count sat at 31
+ * because every Claude Code process carries "playwright" in its MCP config on
+ * its own command line. 4h07m, orphaned from a dead agent, killed by hand.
+ *
+ * The script layer cannot see or reap a shell an agent spawned, so the guard is
+ * prompt-side. What IS testable: that the guidance reaches every agent, and
+ * that the script's own capped loops report the state that ended them instead
+ * of falling through silently.
+ */
+describe('unsatisfiable waits', () => {
+  it('warns every agent in both scripts, including phases that do not obviously wait', async () => {
+    for (const script of [BUILD_SCRIPT, CONTINUE_SCRIPT]) {
+      const run = await runWorkflow(script, { args: BASE_ARGS, onAgent: responder() })
+      expect(run.calls.length).toBeGreaterThan(0)
+      for (const call of run.calls) {
+        expect(call.prompt, `${script} / ${call.label}`).toContain('WAIT DISCIPLINE')
+        // The exact footgun, named — generic "be careful with loops" would not
+        // have stopped this one.
+        expect(call.prompt, `${script} / ${call.label}`).toContain('ps aux | grep -c')
+        expect(call.prompt, `${script} / ${call.label}`).toContain('evaluate the condition ONCE')
+        expect(call.prompt, `${script} / ${call.label}`).toContain('trap')
+      }
+    }
+  })
+
+  it('bounds the CI loop at 5 and escalates rather than watching forever', async () => {
+    const run = await runWorkflow(BUILD_SCRIPT, {
+      args: BASE_ARGS,
+      onAgent: responder({ 'ci:1': CI_RED, 'ci:2': CI_RED, 'ci:3': CI_RED, 'ci:4': CI_RED, 'ci:5': CI_RED }),
+    })
+
+    expect(labelsOf(run).filter((l) => l?.startsWith('ci:'))).toEqual(['ci:1', 'ci:2', 'ci:3', 'ci:4', 'ci:5'])
+    expect(run.result.stopped).toBe(true)
+    expect(run.result.phase).toBe('CI Loop')
+    expect(run.result.reason).toContain('not green after 5 iterations')
+    // It never silently proceeded to triage on a red PR.
+    expect(labelsOf(run)).not.toContain('triage')
+  })
+
+  it('bounds the CodeRabbit loop at 3 and carries the last observed state forward', async () => {
+    const dirty = { result: { status: 'completed', clean: false, reason: '2 actionable findings remain in useShifts.tsx' } }
+    const run = await runWorkflow(BUILD_SCRIPT, {
+      args: BASE_ARGS,
+      onAgent: responder({ 'coderabbit:1': dirty, 'coderabbit:2': dirty, 'coderabbit:3': dirty }),
+    })
+
+    expect(labelsOf(run).filter((l) => l?.startsWith('coderabbit:'))).toEqual(['coderabbit:1', 'coderabbit:2', 'coderabbit:3'])
+    // A capped loop must not fall through as if the condition had been met.
+    expect(run.logs.join('\n')).toContain('still dirty after 3 iterations')
+    expect(run.logs.join('\n')).toContain('2 actionable findings remain in useShifts.tsx')
+    // Best-effort phase: it escalates into the PR body rather than halting.
+    expect(labelsOf(run)).toContain('ship')
+  })
+})


### PR DESCRIPTION
Two distinct runaway modes in the `/dev` workflow scripts, both observed for real, neither previously guarded.

## 1. Token burn

Run `wf_da8ba6ba-5bb` spent **1,103,050 subagent tokens over 59 minutes across 279 tool calls and committed nothing**, ~97% of it a single build task the runtime re-ran six times with a byte-identical prompt before throwing `agent stalled on all 6 attempts (no progress for 180000ms each)`.

**The obvious fix is not available to us.** The retry loop, its hardcoded limit and the 180s interval all live inside the runtime's own `agent()` implementation:

```js
for (let Er = 1; Dt.stalled && !It && Er <= Shd; Er++) {   // Shd = 5, so 6 attempts
  Dt = await X5e(Et, () => dr(Pt, `${ee} (retry ${Er})`, Er + 1, Ur))   // same prompt Pt
}
if (Dt.stalled) throw Error(`agent stalled on all ${Er} attempts …`)
```

`agent()`'s `opts` has no passthrough for attempt count or stall interval, so the script layer cannot cap attempts, append the prior failure to the retry prompt, or lengthen the watchdog. Worth an upstream report — that loop is the amplifier. What the script layer *can* do, and now does:

- **`runAgent()`** catches the throw the runtime raises after the last attempt and converts it into a structured `needs_human` carrying the stall signature and token cost, instead of killing the run with a bare `Error`. Zero further spend follows a stall.
- **`args.stalledTasks`** — a task known to stall is refused unless `args.resolutionNotes` has actually changed its prompt. Resuming otherwise replays a byte-identical prompt into the same six retries.
- **A script-owned token ceiling** measured via `budget.spent()` (`budget.total` is null without a `+Nk` directive, so it can't backstop anything), with per-task accounting, projection-based halting and live `log()` visibility. Advisory from Ship onward, where abandoning mid-CI strands a live PR.
- **Per-task context** — `plan-read` now returns each task's section body and the build prompt inlines only that, with the blanket 42 KB `development-workflow.md` pointer made opt-in.

That last one is a stall fix, not just a token saving. The post-mortem assumed the 180s gaps followed an assistant message with no `tool_use`; the transcripts show every gap following a `tool_result`, in contexts grown to 0.4–1.0 MB. It's the next generation after a tool result that dies, so context size is the lever.

## 2. Unbounded waits

A shell left spinning `until [ "$(ps aux | grep -c '[p]laywright')" -lt 2 ]` ran **4h07m**, orphaned from an agent that had already died, until a human killed it. The `[p]` trick stops grep matching itself but not the ~30 Claude Code processes carrying `playwright` inside the MCP config on their own command lines — the count sat at 31 and could never fall.

Neither existing guard catches this: a spinning `until` loop burns no tokens, and the agent that owned it was already dead. Nothing at the script layer can see or reap a shell an agent spawned, so the guard is prompt-side — a `WAIT DISCIPLINE` block in the envelope every agent receives, naming the exact footgun rather than offering generic caution. Whoever wrote that loop had clearly thought about grep matching itself and still lost.

Also added to `CLAUDE.md`, which reaches every agent in the repo rather than only `/dev` runs. **The examples are checked against this platform** — `timeout`, `gtimeout` and `tail --pid` do not exist on BSD/bash-3.2, so the standard Linux idioms silently fail here (my own first draft used one). The rule points at the Bash tool's own `timeout` parameter instead: it always exists and leaves no loop to get wrong.

While auditing, found this script's own CodeRabbit loop capping at 3 and then falling through silently, despite its prompt telling the agent "the script will escalate." Same family — a bounded wait discarding what ended it. It now carries the last observed state into `deferredFindings` and the PR body.

## Verification

`dev-tools/workflow-harness.mjs` runs the workflow scripts with the runtime's real calling convention (`AsyncFunction` with the globals injected) and scripted agents, so control flow is exercised in milliseconds instead of by burning a real multi-agent run.

**17 tests**, covering: the incident replay halting with a structured `needs_human`; exactly 3 agent calls instead of 9 tasks plus a six-way review fan-out; the `stalledTasks` guard dispatching the bad task zero times; the retried prompt provably differing under `resolutionNotes`; both ceilings; plan-section inlining with the 42 KB pointer absent from every prompt; wait-discipline present in every dispatched prompt in both scripts; and the CI (5) and CodeRabbit (3) loop bounds.

- `npx vitest run` — 8160 passed, 2 skipped, 660 files
- `npx tsc --noEmit` — exit 0
- `npx eslint` on the new files — exit 0

One test earned its keep by catching a real gap rather than a bad assertion: `dev-continue-verify-and-ship.js`'s only ceiling check sat at Verify, its *first* phase, where `spent()` is always 0 — so the ceiling never bit on a fresh run. Fixed by adding one before Ship, the last point where nothing has been pushed.

## Two things to flag for review

- **This carries ~30 lines of previously-uncommitted work that isn't mine** — the trigger fix to the per-task build prompt (the plan's completion criterion overrides the generic `RED -> GREEN -> REFACTOR -> COMMIT` cycle, already-committed tasks short-circuit, pacing guidance). It was sitting uncommitted in the working tree and is what the incident's reproduction task tripped over, so it belongs with the amplifier fix.
- **`dev-continue-verify-and-ship.js` is a one-off** with hardcoded state from the react-error-boundaries feature (specific commit SHAs, a bundle-probe grep). It's committed because the tests import it and it was in scope for the same hardening, but it will go stale — reasonable to delete once that feature is settled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
