### PR TITLE
fix(schedule): make publish and unpublish actually tell employees what their schedule is

### DIFF
--- a/docs/superpowers/plans/2026-08-02-schedule-publish-notifications.md
+++ b/docs/superpowers/plans/2026-08-02-schedule-publish-notifications.md
@@ -1,0 +1,116 @@
+# Plan — Schedule Publish Notifications + Employee Schedule Clarity
+
+- **Branch:** `fix/schedule-publish-notifications`
+- **Spec:** `docs/superpowers/specs/2026-08-02-employee-schedule-clarity-design.md` (a49debfd)
+- **Scope:** the five approved items (a–e) plus the §F bucketing fix. Nothing else.
+
+## Decision needed before Phase 4
+
+**Do not add an UPDATE RLS policy to `schedule_publications`.** The approved scope said
+"use `serviceClient` **and** add the missing UPDATE RLS policy," but those are alternatives:
+`serviceClient` bypasses RLS entirely, so the policy is unnecessary for the fix, and a policy
+broad enough to satisfy the old code path would let any manager-role client forge
+`notification_sent` — and, once §D lands, the retraction audience too. The plan below ships the
+`serviceClient` fix plus a pgTAP test asserting the table stays un-UPDATE-able. Say the word if
+you want the policy anyway; the harmless documenting form is `USING (false) WITH CHECK (false)`.
+
+## Order of work
+
+Server first (steps 1–5), because the UI's 4-state model reads state the migration creates.
+Each step is a commit; tests land with the code they cover, not after.
+
+### 1. `_shared/emailQueue.ts` + `sendEmailResult` — defect C
+
+- Add `sendEmailResult()` to `_shared/notificationHelpers.ts` returning
+  `{ ok, status, error? }`; reimplement the existing `sendEmail` as
+  `(await sendEmailResult(...)).ok`. Its 6 external call sites are untouched and provably
+  unchanged.
+- New `_shared/emailQueue.ts`: paced sender (≤2/s), 429 → retry with backoff, everything else →
+  terminal. Returns per-recipient results so defect B can report them. Logs recipient count and
+  total elapsed so the wall-clock ceiling is observable before it's hit.
+- `tests/unit/emailQueue.test.ts` — pacing interval respected; 429 retried then succeeds; hard
+  failure not retried; result shape preserved.
+
+### 2. Migration — `schedule_retractions` + `unpublish_schedule` — defect D
+
+One migration, `CREATE OR REPLACE` on `unpublish_schedule` with its `RETURNS INTEGER` signature
+and `SECURITY DEFINER` / `SET search_path = public, pg_temp` re-stated (omitting either resets it).
+
+- Table + partial index per spec §D.
+- Replace `GET DIAGNOSTICS` with the CTE aggregate — this is a behavior fix, not a refactor: left
+  as-is it would return the INSERT's row count and the manager toast would read "1 shift."
+- `COALESCE(array_agg(...) FILTER (WHERE employee_id IS NOT NULL), '{}')` for the audience.
+- Guard the retraction INSERT on `v_shift_count > 0`.
+- RLS: SELECT for restaurant members; no INSERT/UPDATE/DELETE policy (writes are RPC/service-role
+  only), mirroring `schedule_publications`.
+- `supabase/tests/schedule_retractions.sql` (pgTAP): audience captured pre-flip and matches the
+  employees who had published shifts; double-unpublish inserts nothing and does not raise;
+  `authenticated` cannot UPDATE `schedule_publications` (zero affected rows, not `throws_ok`);
+  same for `schedule_retractions`.
+
+### 3. `notify-schedule-published` — defects A, B, C
+
+- `notification_sent` write moves to `serviceClient`, with `.select('id')`, and the error and row
+  count are checked and logged.
+- Fan-out goes through the step-1 queue.
+- Return a non-2xx when `failureCount > 0`, with the structured body preserved.
+- No refactor onto the shared helpers — noted as follow-up so the diff stays reviewable.
+
+### 4. `notify-schedule-unpublished` (new) — defect D
+
+Built on `_shared/notificationHelpers.ts` (not cloned from the publish function). Takes
+`{restaurantId, weekStart}` only:
+
+1. Latest unnotified retraction for the week, `ORDER BY retracted_at DESC LIMIT 1`.
+2. Null-safe `LEFT JOIN` to the publication; abort unless `notification_sent = true`.
+3. Atomic claim: `UPDATE ... SET notified_at = now() WHERE id = $1 AND notified_at IS NULL
+   RETURNING *`; zero rows → exit quietly. Reset to NULL if the send fails outright.
+4. Email + web push + native push to `employee_ids`, through the queue, §7(a) copy.
+- `_shared/schedulePublishedPush.ts` gains a sibling retraction-push helper.
+
+### 5. `useSchedulePublish.tsx` — defects B, F
+
+- `usePublishSchedule`: await the invoke, read `error.context.json()`, and surface three distinct
+  toasts (full success / partial / total failure). Publishing itself must still read as
+  successful — the RPC has already committed.
+- `useUnpublishSchedule`: same, invoking `notify-schedule-unpublished`.
+- Fix `:169-175` to bucket by the restaurant timezone instead of browser-local `toISOString()`.
+- `tests/unit/useSchedulePublish.test.ts` — the three toast branches; week bucketing at a week
+  edge in a non-UTC restaurant timezone.
+
+### 6. `useWeekScheduleStatus` (new hook) — item (e)
+
+Returns `{ state, publication, publishedCount, draftCount, loading }` for the 4-state model.
+Separate from `useWeekPublicationStatus`, which stays as-is for manager surfaces.
+`tests/unit/useWeekScheduleStatus.test.ts` covers all four states plus the incident scenario
+(publication row exists, `notification_sent: true`, `publishedCount: 0` → `retracted`).
+
+### 7. Employee UI — item (e)
+
+- `ShiftRow.tsx` (new, shared) — one row for both the day grid and the Upcoming Shifts card,
+  branching internally on `isPublished`.
+- `ScheduleStatusBanner.tsx` (new) — the four states plus state B's one-line chip, in a
+  fixed-height slot; `role="status"` in A/B/C, default `role="alert"` in D.
+- `scheduleSeenFingerprint.ts` (new) — fingerprint + localStorage, interaction-dismiss only, 8-week
+  pruning on write.
+- `EmployeeSchedule.tsx` — wire all of it; neutralize the Upcoming card's green chrome when every
+  row in it is a draft; add the missing `useShifts().error` branch.
+- Unit tests for the fingerprint, the banner, and `ShiftRow`.
+
+### 8. E2E
+
+`tests/e2e/employee-schedule-retraction.spec.ts` — publish as manager → employee sees the clean
+published state → unpublish → employee sees the retracted banner and every row in the tentative
+treatment (rows present, per Decision 1).
+
+## Then Phases 5–9
+
+code-simplify → the four parallel reviewers + CodeRabbit → `npm run typecheck && lint && test` →
+PR → CI loop until green.
+
+## Known limitation to state in the PR
+
+Every production publication row currently reads `notification_sent = false` — that *is* defect A
+— so the Decision 2 gate suppresses all retraction notifications until a week is published after
+this ships. Correct-conservative and self-healing within one publish cycle. No backfill: it would
+assert deliveries we can't verify, and it's a prod write needing separate approval.

--- a/docs/superpowers/plans/2026-08-02-schedule-publish-notifications.md
+++ b/docs/superpowers/plans/2026-08-02-schedule-publish-notifications.md
@@ -114,3 +114,10 @@ Every production publication row currently reads `notification_sent = false` —
 — so the Decision 2 gate suppresses all retraction notifications until a week is published after
 this ships. Correct-conservative and self-healing within one publish cycle. No backfill: it would
 assert deliveries we can't verify, and it's a prod write needing separate approval.
+
+---
+
+**Divergences between this plan and the shipped code are recorded in the design doc's
+"As Built" section** (`docs/superpowers/specs/2026-08-02-employee-schedule-clarity-design.md`) —
+retry bounds, the `notification_sent` and `notified_at` semantics, and the
+newest-retraction-only rule in particular.

--- a/docs/superpowers/specs/2026-08-02-employee-schedule-clarity-design.md
+++ b/docs/superpowers/specs/2026-08-02-employee-schedule-clarity-design.md
@@ -920,3 +920,57 @@ The remainder stay open and are explicitly *not* being built in this pass:
    fan-out) or requires a separate client-triggered call, matching whatever pattern the existing
    native shift-created/time-off notifications already use (not audited in this pass — worth a
    quick check before implementation).
+
+---
+
+## As Built — where the shipped code departs from this document
+
+This design was written before implementation and is kept as the record of what was intended.
+Where the build learned something the design got wrong, the code is authoritative and the
+divergence is listed here rather than edited into the sections above.
+
+1. **State D no longer fires on zero shifts (§1, §2).** The design's condition — a historical
+   publication plus zero live published shifts — classifies an employee with *no shifts at all*
+   as "retracted". Unpublishing flips shifts to draft, it never deletes them, so a real retraction
+   always leaves drafts behind. `deriveWeekScheduleState` therefore returns `published` when both
+   counts are zero: that employee simply isn't on the roster this week. Without it, every
+   part-timer would be told their schedule was withdrawn on every week they have off.
+   Pinned by a test in `tests/unit/useWeekScheduleStatus.test.ts`.
+
+2. **A failed publication query renders no banner (§4).** The design maps the error case onto
+   `not_published`, which asserts something false. `deriveWeekScheduleState` returns `null` while
+   loading or on error, and the banner's fixed-height slot stays empty. Shift rendering is
+   unaffected.
+
+3. **Paths.** The paced sender shipped as `supabase/functions/_shared/emailQueue.ts` (tests in
+   `tests/unit/emailQueue.test.ts`), not `rateLimitedSend.ts`. The pgTAP file is
+   `supabase/tests/schedule_retractions.test.sql`.
+
+4. **Retry bound (§ paced sender).** Retries are 429-only, capped at 3 after the initial attempt,
+   with 1s/2s/3s backoff; anything else — including a request aborted at the 15s per-request
+   timeout — fails terminally at status 0 rather than retrying. Covered by "gives up after
+   maxRetries and reports the last 429" and "aborts a request Resend accepts but never answers".
+
+5. **`notification_sent` means "reached somebody", not "reached everybody".** The design left this
+   ambiguous. A partial failure still marks the week announced, because the retraction gate's job
+   is to avoid announcing the withdrawal of something *nobody* heard about; the manager's failure
+   toast is what prompts a republish, and republishing writes a fresh row. Reaching nobody on
+   either channel leaves the flag false.
+
+6. **`notified_at` is a whole-retraction latch, not per-recipient.** Recipient-level delivery
+   state would need its own table. Partial failure is logged and returned in the response; the
+   latch still claims, so a retry does not re-mail the recipients who succeeded. Accepted
+   limitation, not an oversight.
+
+7. **Only the newest unnotified retraction for a week is announced.** Older unnotified rows for
+   the same week are left as an audit trail rather than mailed. They describe versions that were
+   superseded before anyone was told about them, and sending one message per revision is the
+   confusion this change set exists to remove.
+
+8. **The fingerprint keys on `published_at` plus shift fields (§3b), not `is_published`.** A
+   retraction changes the banner, which is far louder than the pill; the pill's job is to catch
+   *silent* edits inside an already-published week.
+
+9. **Open question 4 (native push) is resolved.** `notify-schedule-unpublished` calls
+   `send-push-notification` server-side with the service-role key, matching the existing
+   web-push fan-out. No client-triggered path.

--- a/docs/superpowers/specs/2026-08-02-employee-schedule-clarity-design.md
+++ b/docs/superpowers/specs/2026-08-02-employee-schedule-clarity-design.md
@@ -129,6 +129,12 @@ state B.
 
 ## 1. Draft vs Published Week States
 
+Typography is the same in every state and is stated explicitly rather than left to the primitive's
+defaults (`AlertTitle` is `font-medium leading-none tracking-tight`, `AlertDescription` is
+`text-sm` — `src/components/ui/alert.tsx:29-41`, close to but not on the project scale):
+`AlertTitle` → `text-[14px] font-semibold text-foreground`, `AlertDescription` →
+`text-[13px] text-muted-foreground`. Icons are `h-4 w-4`.
+
 ### State A — Not Yet Published
 
 The employee has no confirmed schedule for the viewed week. Per **Decision 1**, draft shifts *are*
@@ -144,17 +150,31 @@ that way.
 └─────────────────────────────────────────────────────────┘
 ```
 
-Copy: **"Schedule not published yet"** / **"Your manager hasn't finalized the week of {weekStart}
-– {weekEnd}. Check back soon."**
+Copy depends on whether anything is actually rendered below, because under Decision 1 the two
+cases look completely different to the employee:
+
+- `draftCount === 0` — **"Schedule not published yet"** / **"Your manager hasn't finalized the
+  week of {weekStart} – {weekEnd}. Check back soon."**
+- `draftCount > 0` — **"Schedule not published yet"** / **"Your manager hasn't finalized the week
+  of {weekStart} – {weekEnd}. The {M} shift{s} below {is/are} still {a draft/drafts} — nothing is
+  confirmed yet. Check back soon."**
+
+The second variant is not optional polish. With drafts visible, the first variant's "check back
+soon" sits directly above a full week of shift cards and reads as "there's nothing to see yet"
+while the employee is looking straight at what appears to be their schedule. State C already
+quantifies confirmed-vs-draft; state A must too, and for the same reason.
 
 Component: `shadcn` `Alert` with `variant="default"`, icon `Clock` (lucide), classes
 `bg-muted/30 border-border/40` (neutral — this is not an error, it's an expected pending state).
 
 ### State B — Published (Clean)
 
-No new banner. A small, persistent "Published" affordance sits in the `Weekly Schedule` card
-header next to the date range badge — see §3 for exact treatment. This is the default, quiet
-state; the redesign should not add ceremony to the common case.
+No banner. The banner slot instead holds a single quiet line — **"Published {date} at {time}"**,
+`text-[13px] text-muted-foreground` — which keeps the slot's height constant across all four
+states (§4, layout-shift note) and answers "is this final?" at the top of the page. The same
+information also appears in the `Weekly Schedule` card header next to the date-range badge, per
+§3a, which is where it belongs when the employee is looking at a specific week. This is the
+default, quiet state; the redesign should not add ceremony to the common case.
 
 ### State C — Published, Being Revised
 
@@ -244,11 +264,22 @@ Treatment:
 - Card background changes from `bg-muted/50` (current, for all shifts) to
   `bg-muted/20 border border-dashed border-border/60` — dashed border reads as "not solid/not
   final" independent of color, satisfying the accessibility no-color-alone rule in §5.
-- A `Badge variant="outline"` reading **"Draft — not confirmed"** (not just "Draft"; the copy
-  should imply "you cannot rely on this" without requiring an explicit legend) sits where
-  `getShiftStatusBadge()` normally renders its status badge — draft state takes priority over
-  the existing Completed/In Progress/Today/Upcoming badges, since "is it real" outranks "when is
-  it."
+  **The `/20` and `/60` are a deliberate departure** from CLAUDE.md's `bg-muted/30` /
+  `border-border/40` house values (which the §1 banners *do* follow): the draft row must sit
+  *below* the ambient surface level while its border sits *above* it, so the contrast between a
+  draft and a confirmed row is legible at a glance. Recorded here so a future
+  convention-cleanup pass doesn't silently normalize it back to `/30` and `/40`.
+- A badge reading **"Draft — not confirmed"** (not just "Draft"; the copy should imply "you cannot
+  rely on this" without requiring an explicit legend) sits where `getShiftStatusBadge()` normally
+  renders its status badge — draft state takes priority over the existing Completed/In
+  Progress/Today/Upcoming badges, since "is it real" outranks "when is it."
+  **It must not be `variant="outline"`.** The pre-existing "Upcoming" badge
+  (`EmployeeSchedule.tsx:99-105`) is already `variant="outline"`, so an outline draft badge would
+  be a second identical grey pill in the same slot — precisely the "just another status pill"
+  failure §2 is written to avoid. Give it a filled, warmer treatment plus a leading icon:
+  `bg-amber-500/15 text-foreground border-amber-500/30` with a `FileEdit`/`PencilLine` (lucide)
+  icon at `h-3 w-3`, matching the state-C banner's amber so "amber = not final" is one consistent
+  language across the page. The icon is supplementary, not the signal — the text carries it (§5).
 - Times and position text drop from `font-medium text-foreground` to
   `font-normal text-muted-foreground` — visually recedes relative to confirmed shifts on the same
   day.
@@ -259,6 +290,45 @@ Treatment:
 `myShifts` keeps its current, unfiltered definition (employee match only) — no `is_published`
 filter is added. `publishedCount` / `draftCount` are derived alongside it to drive the §1 banner,
 and each rendered row branches on `shift.is_published` for the treatment above.
+
+### The "Upcoming Shifts" card must get the same treatment — it is the worst offender
+
+The first draft of this section only covered the day-grid rows in the `Weekly Schedule` card, and
+that is an outright gap. `src/pages/EmployeeSchedule.tsx:241-294` renders a **second, separate
+list** — the "Upcoming Shifts" card — from `upcomingShifts`, computed at `:170-179` by filtering
+the same unfiltered `myShifts` on `startTime >= now && status !== 'cancelled'` with **no
+`is_published` check**. It sits between the proposed banner (top of page) and the day grid
+(below), and it renders each shift in a *solid* `bg-background border` card inside a green-tinted
+`Card` (`from-green-500/5 to-green-600/5 border-green-500/20`) with `getShiftStatusBadge(shift)`
+(`:287`) showing "Today"/"Upcoming".
+
+Left untouched, state D produces this: a banner saying "Nothing below is final," and two sections
+later the exact same draft shifts rendered solid, green-framed and badged "Upcoming" — reading as
+*more* confirmed than the correctly-dashed rows further down. That inverts the whole point of
+Decision 1. Two changes, both required:
+
+1. **Rows branch identically.** Each row in this card takes the same `is_published` branch as the
+   day grid — dashed border, muted type, "Draft — not confirmed" badge replacing the
+   `getShiftStatusBadge()` output. This falls out for free once the row is a shared component (see
+   the note on `ShiftRow` below).
+2. **The card's own chrome must stop asserting confidence when nothing in it is confirmed.** When
+   `upcomingShifts.every(s => !s.is_published)`, drop the green gradient and border for neutral
+   `bg-muted/20 border-border/40`, and title the card **"Upcoming (tentative)"**. Green framing is
+   itself a confirmation signal, and it is read before any badge is.
+
+The card is **not** suppressed in states A/D. Suppressing it would contradict Decision 1 in the
+same way hiding rows would, and it would make the page silently restructure itself between states.
+
+### One `ShiftRow`, not a separate `DraftShiftRow`
+
+An earlier version of this document proposed a new `DraftShiftRow.tsx` rendering only
+`is_published === false` rows, leaving confirmed rows as inline JSX in the page's day-grid `.map()`
+(`EmployeeSchedule.tsx:368-416`). That forks one conceptual row into two independently-maintained
+render paths — duration/break formatting, Trade-button gating, badge placement — that then have to
+be kept in sync by hand. **Superseded:** build a single `ShiftRow` parameterized on
+`{ shift, isPublished, onTrade? }` that branches internally, and use it in *both* the day grid and
+the Upcoming Shifts card. That is also what makes requirement 1 above a one-line change rather than
+a second copy of the treatment.
 
 ### Rejected alternative: hide unpublished shifts
 
@@ -303,21 +373,30 @@ bookkeeping, not the "manual caching of server data" CLAUDE.md prohibits, since 
 substitutes for or delays a React Query fetch; it only decides whether to show a "New" pill on
 top of data that was fetched normally.
 
-- Key: `schedule_seen_${restaurantId}_${employeeId}_${weekStartISO}` → value = a hash of
+- Key: `schedule_seen_${restaurantId}_${employeeId}_${weekStartISO}` → value = a hash of the
+  fingerprint input below. Keys accumulate one per week ever viewed, unbounded over an employee's
+  tenure, so the helper prunes on write: drop any `schedule_seen_*` key whose `weekStartISO`
+  segment is more than 8 weeks in the past. Cheap, synchronous, and keeps the namespace bounded
+  without needing a migration or a scheduled job.
+- Value: a hash of
   `{publication.published_at, myShifts.map(s => [s.id, s.start_time, s.end_time, s.position,
   s.status]).sort()}` (cheap `JSON.stringify` + a non-cryptographic hash is sufficient; this is
   a change-detection fingerprint, not a security boundary).
 - On mount/data-load, compare current fingerprint to stored value for the viewed week. Mismatch
   (or no stored value but a fingerprint now exists) → render a small **"Updated since you last
   checked"** `Badge` next to the "Published …" line, `bg-primary/10 text-primary
-  border-primary/20`. On the user dismissing it (any interaction with the week, or an explicit
-  "Got it" tap) or after N seconds of the page being visible, write the new fingerprint and clear
-  the pill.
+  border-primary/20`. The pill clears **only on interaction** — any interaction with the week, or
+  an explicit "Got it" tap — at which point the new fingerprint is written.
+- **No time-based auto-dismiss.** An earlier draft also cleared the pill after N visible seconds.
+  That is a WCAG 2.2.1 (Timing Adjustable) failure and a practical one: the pill would vanish
+  *and* permanently clear its underlying signal before a slow-reading, low-vision, or
+  motor-impaired user had processed it, with no way to bring it back. Interaction-based dismissal
+  already covers the "they've seen it" case, so the timer buys nothing.
 - This only ever adds a *pill*, never hides or alters what's rendered — it degrades to "no pill"
   silently if `localStorage` is unavailable (Capacitor native webview, private browsing), which
   is an acceptable v1 limitation, not a broken state.
 
-This is flagged as an explicit open product decision in §8 — a server-tracked "last viewed"
+This is flagged as an explicit open product decision in "Open Questions" — a server-tracked "last viewed"
 column would be more robust (works across devices, survives cache clears, and could feed manager
 analytics like "did the team see the update") but is a larger scope than this design's core fix.
 
@@ -327,7 +406,7 @@ CLAUDE.md requires all three be handled explicitly; auditing what exists today:
 
 | State | Current | Proposed |
 |---|---|---|
-| Loading | `EmployeePageSkeleton` (page-level, on `employeeLoading`) + inline `Skeleton` rows in the `Weekly Schedule` card (on `shiftsLoading`) — already present. | Unchanged, but the new publication-status query (§"State Model") must not block the shift skeleton — render the week's day grid skeleton immediately; let the publication banner pop in a beat later once its own (fast, single-row) query resolves, rather than gating the whole page on it. |
+| Loading | `EmployeePageSkeleton` (page-level, on `employeeLoading`) + inline `Skeleton` rows in the `Weekly Schedule` card (on `shiftsLoading`) — already present. | Unchanged, but the new publication-status query (§"State Model") must not block the shift skeleton — render the week's day grid skeleton immediately; let the publication banner resolve a beat later from its own (fast, single-row) query, rather than gating the whole page on it. **The banner slot must reserve its space while that query is in flight** — a fixed `min-h-[76px]` placeholder (roughly one `Alert` with a two-line description) at the top of the page. Without it the banner's arrival pushes `MyShiftTradesCard` and everything below it down on an already-painted page: a CLS regression, and on mobile a live mis-tap hazard for anyone who started interacting during that beat. Reserving space only during the fetch would just defer the jump to resolve-time (the placeholder collapsing is a shift too), so state B — the state with no banner — fills the slot with a single-line confirmation chip of the same height: **"Published {date} at {time}"**, `text-[13px] text-muted-foreground`. That makes the slot height constant across every state, and gives the common case a top-of-page answer to "is this final?" instead of nothing. |
 | Empty (genuinely zero shifts, any state) | Per-day **"No shifts scheduled"** text only — indistinguishable from "you have the week off" on a published week. | Day-level text unchanged (still correct for a genuinely published week off), but now sits underneath the state A/D banner from §1, which supplies the missing "why." Note that under Decision 1 this row is now *rare* in states A and D — a week with draft shifts renders those shifts as tentative rows rather than as an empty grid, so "empty" here means the manager truly scheduled nobody. |
 | Empty (state B/C, employee genuinely has no shifts some days) | Same "No shifts scheduled" | Unchanged — this is a legitimately different case (published week, this employee just isn't on Wednesday) and should not be confused with "not published yet." |
 | Error (`useShifts` `error`) | **Not handled at all** — `EmployeeSchedule.tsx` destructures `shifts, loading` from `useShifts` but never reads `error`; a query failure silently renders an empty week, which is actively dangerous here (looks identical to "day off"). | Add an explicit error branch: if `shiftsError`, render an `Alert variant="destructive"` — **"Couldn't load your schedule"** / **"Something went wrong loading shifts. Pull to refresh or try again in a moment."** — in place of the day grid, with a `Button` "Retry" that calls `queryClient.invalidateQueries(['shifts', ...])`. This must not silently fall through to the empty-week UI. |
@@ -346,9 +425,19 @@ CLAUDE.md requires all three be handled explicitly; auditing what exists today:
   true` / `refetchOnWindowFocus: true` on `useShifts` pulls the change in — is announced to
   screen reader users without requiring them to re-navigate. The "Updated since you last checked"
   pill from §3 is announced the same way, once, when it first appears.
+- **The `Alert` itself must carry `role="status"`, or "polite" is a lie.**
+  `src/components/ui/alert.tsx:25` hardcodes `role="alert"` on the primitive — an implicit
+  **assertive** live region. Nesting that inside the polite wrapper above does not soften it; the
+  inner assertive region is what governs AT behavior, so every banner state would interrupt the
+  user mid-sentence. Because `{...props}` is spread *after* the hardcoded attribute on that line,
+  passing `role="status"` straight to `<Alert>` overrides it cleanly. **Do that** — override on
+  the `Alert`, and drop the redundant outer wrapper for the banner (the wrapper is still the right
+  mechanism for the §3 "Updated" pill, which is not an `Alert`). The one deliberate exception is
+  state D: a retraction *is* worth interrupting for, so state D keeps the primitive's default
+  `role="alert"`.
 - **Keyboard reachability.** The banners are static content (no interactive controls beyond the
-  optional "Retry" button in the error state and a "Got it" dismiss on the "Updated" pill if that
-  affordance is interactive rather than auto-clearing) — both existing patterns in the file
+  "Retry" button in the error state and the "Got it" dismiss on the "Updated" pill, which per §3b
+  is always interactive — there is no timed auto-clear) — both existing patterns in the file
   already use `min-h-[44px]` touch/click targets and visible `aria-label`s (`Previous week`,
   `Next week`); any new interactive element in this design must match that convention.
 - **Draft status must be announced per row, not just styled.** Under Decision 1 the dashed border
@@ -466,20 +555,21 @@ the same week already had `notification_sent = true`:
 
 | File | Change |
 |---|---|
-| `src/pages/EmployeeSchedule.tsx` | Keep `myShifts` unfiltered (Decision 1); derive `publishedCount`/`draftCount` for banner copy; render each row in the tentative treatment when `!shift.is_published` (§2); suppress the Trade button on drafts; add error branch on `useShifts().error` (§4); render new `ScheduleStatusBanner` above `MyShiftTradesCard`; add "Published on …" line + "Updated" pill to the `Weekly Schedule` card header; add `role="status" aria-live="polite"` wrapper (§5). |
+| `src/pages/EmployeeSchedule.tsx` | Keep `myShifts` unfiltered (Decision 1); derive `publishedCount`/`draftCount` for banner copy; replace the inline day-grid row JSX (`:368-416`) **and** the Upcoming Shifts card's row JSX (`:252-290`) with the shared `ShiftRow`; neutralize the Upcoming card's green chrome and retitle it "Upcoming (tentative)" when every row in it is a draft (§2); suppress the Trade button on drafts; add error branch on `useShifts().error` (§4); render new `ScheduleStatusBanner` above `MyShiftTradesCard` in a fixed-height slot (§4 layout-shift note); add "Published on …" line + "Updated" pill to the `Weekly Schedule` card header. |
 | `src/hooks/useShifts.tsx` | No change — it already fetches all shifts regardless of `is_published`, which Decision 1 requires. (Note: this hook is shared with manager surfaces; adding a publish filter here would have broken them, which is a further reason the filtering lives in the page.) |
 | `src/hooks/useSchedulePublish.tsx` | New hook `useWeekScheduleStatus(restaurantId, weekStart, weekEnd)` — wraps a query for the latest `schedule_publications` row matching the week regardless of current shift state (`historicalPublication`), combined with the existing published-shift-count logic, to return the 4-state model from "State Model" above: `{ state: 'not_published' \| 'published' \| 'published_revising' \| 'retracted', publication: SchedulePublication \| null, publishedCount: number, draftCount: number, loading }`. Distinct from the existing `useWeekPublicationStatus`, which stays as-is for the manager side (its `null`-collapsing behavior may be intentional there — manager UI has other cues for "was this ever published"). |
-| `src/components/employee/ScheduleStatusBanner.tsx` (new) | Renders the 4 banner variants from §1 given the `useWeekScheduleStatus` result. Pure presentational, no data fetching. |
-| `src/components/employee/DraftShiftRow.tsx` (new) | The dashed-border / "Draft — not confirmed" badge treatment for shift rows where `is_published === false` (§2). Now the primary path, not a conditional fallback. Badge text must be real in-tree text (§5). |
+| `src/components/employee/ScheduleStatusBanner.tsx` (new) | Renders the 4 banner variants from §1 given the `useWeekScheduleStatus` result, plus state B's one-line "Published …" chip. Pure presentational, no data fetching. Passes `role="status"` to `Alert` in states A/B/C to override the primitive's hardcoded `role="alert"`; state D keeps the assertive default (§5). Owns the fixed-height slot so the height is constant while loading. |
+| `src/components/employee/ShiftRow.tsx` (new) | One row component for both the day grid and the Upcoming Shifts card, parameterized on `{ shift, isPublished, onTrade? }`. Branches internally for the §2 tentative treatment — dashed border, muted type, filled amber "Draft — not confirmed" badge, no Trade button. Badge text must be real in-tree text (§5). Replaces the earlier `DraftShiftRow` proposal, which would have forked confirmed and draft rows into two hand-synced render paths. |
 | `src/lib/scheduleSeenFingerprint.ts` (new) | Pure fingerprint + localStorage read/write helpers for the "Updated since you last checked" pill (§3b). Small, unit-testable, no React dependency. |
-| `supabase/functions/notify-schedule-unpublished/index.ts` (new) | Sends the retraction email + web push + native push from §7(a). Modeled directly on `notify-schedule-published/index.ts`'s structure (auth → permission check → restaurant lookup → employee lookup → send). |
+| `supabase/functions/notify-schedule-unpublished/index.ts` (new) | Sends the retraction email + web push + native push from §7(a). Built on `_shared/notificationHelpers.ts` — **not** modeled on `notify-schedule-published`, which hand-rolls all of it (§C). Takes `{restaurantId, weekStart}` only and derives audience and gate from `schedule_retractions` per §D; claims the `notified_at` latch before sending. |
 | `supabase/functions/notify-schedule-published/index.ts` | Add the `isRepublish` branch from §7(b) — check for a prior `notification_sent = true` publication row for the same week before composing subject/body. |
 | `supabase/functions/_shared/schedulePublishedPush.ts` | Extend or sibling with a `notifyScheduleUnpublishedPush` helper mirroring `notifySchedulePublishedPush`, for the retraction push payload. |
-| `src/hooks/useSchedulePublish.tsx` (`useUnpublishSchedule`) | Fire-and-forget invoke of `notify-schedule-unpublished` on success, mirroring how `usePublishSchedule` invokes `notify-schedule-published` today — but gated on the unpublished week's publication row having `notification_sent = true` (don't notify about retracting a schedule nobody was told about). |
+| `src/hooks/useSchedulePublish.tsx` (`useUnpublishSchedule`) | Invoke `notify-schedule-unpublished` with `{restaurantId, weekStart}` on success, **awaited** and surfaced per §B rather than fire-and-forget. The `notification_sent = true` gate lives in the edge function against persisted state (§D), not here — a client-side gate would be advisory only. Also fix the browser-local week bucketing at `:169-175` to match the RPC's restaurant-timezone bucketing (§F). |
 | `tests/unit/scheduleSeenFingerprint.test.ts` (new) | Fingerprint stability (same input → same hash), change detection (any of published_at/shift fields differing → different hash), localStorage-unavailable fallback. |
 | `tests/unit/useWeekScheduleStatus.test.ts` (new) | All 4 states derived correctly from mocked `schedule_publications` + shift rows; the specific incident scenario (row exists, `notification_sent: true`, `publishedCount: 0`) resolves to `'retracted'`. |
-| `tests/unit/ScheduleStatusBanner.test.tsx` (new) | Correct copy/component per state; retracted-state reason line shown only for a non-boilerplate manager reason. |
-| `tests/e2e/employee-schedule-retraction.spec.ts` (new) | Publish a week as a manager test user, verify employee view shows clean published state; unpublish; verify employee view (same session, on refetch) shows the retracted banner and zero visible shift rows for that employee. |
+| `tests/unit/ScheduleStatusBanner.test.tsx` (new) | Correct copy/component per state; state A's two copy variants (`draftCount === 0` vs `> 0`); retracted-state reason line shown only for a non-boilerplate manager reason; `role="status"` in A/B/C and `role="alert"` in D. |
+| `tests/unit/ShiftRow.test.tsx` (new) | Draft rows render the badge text and omit the Trade button; published rows render `getShiftStatusBadge` output and keep it. Guards the single-path invariant that replaced `DraftShiftRow`. |
+| `tests/e2e/employee-schedule-retraction.spec.ts` (new) | Publish a week as a manager test user, verify employee view shows clean published state; unpublish; verify employee view (same session, on refetch) shows the retracted banner **and** that every shift row is now in the tentative treatment — rows still present per Decision 1, each carrying the "Draft — not confirmed" badge and no Trade button. Asserting zero rows here would encode the rejected hide-drafts alternative. |
 
 ---
 
@@ -487,10 +577,16 @@ the same week already had `notification_sent = true`:
 
 Five defects found while debugging the original report ("not all my users get notifications").
 All are confirmed against production. **The originally-reported symptom was a false alarm**: the
-11 delivered emails for Jul 27 – Aug 2 were exactly the 11 distinct employees with published
-shifts that week. Nobody was missed. The employees working Aug 3–9 received nothing because that
-week *was not published* at the time — it had 0 published shifts and 8–14 drafts per day. The
-real defects are the five below, which the investigation surfaced.
+11 delivered emails the user pasted for Jul 27 – Aug 2 match, one for one, the count of distinct
+employees with published shifts for that week at
+`restaurant_id = 7c0c76e3-e770-401b-a2a9-c1edd407efed` — a production `SELECT count(DISTINCT
+employee_id)` over `shifts` for the week, bucketed in `America/Chicago`, returns 11. Nobody was
+missed. (The addresses themselves were not cross-checked against the roster row by row; the claim
+is a count match plus the absence of any failure signal, which is sufficient to rule out "some
+employees were skipped" but not to prove each specific address was the right one.) The employees
+working Aug 3–9 received nothing because that week *was not published* at the time — it had 0
+published shifts and 8–14 drafts per day. The real defects are the five below, which the
+investigation surfaced.
 
 ## A. `notification_sent` is never recorded
 
@@ -534,6 +630,21 @@ RLS by design. In place of the policy, add a pgTAP test that *asserts the absenc
 fails loudly if someone later adds a permissive policy. This satisfies the "pgTAP for the RLS
 change" testing requirement by pinning the invariant rather than by widening access.
 
+**The test must assert zero affected rows, not an exception.** RLS with no matching policy does
+not raise — it silently filters, which is the entire mechanism behind this defect. A `throws_ok`
+assertion would fail against correct behavior and pass only if someone later added a policy that
+errors. Assert the row count instead:
+
+```sql
+SET LOCAL ROLE authenticated;
+WITH attempted AS (
+  UPDATE public.schedule_publications SET notification_sent = true
+   WHERE id = <fixture id> RETURNING 1
+)
+SELECT is((SELECT count(*)::int FROM attempted), 0,
+          'authenticated role cannot UPDATE schedule_publications');
+```
+
 Flagged for the user at plan approval; if a policy is wanted anyway, the narrow form is
 `FOR UPDATE USING (false) WITH CHECK (false)`, which documents intent without granting anything.
 
@@ -568,6 +679,25 @@ will not, and the resulting 429s are invisible because of defect B.
 429 as retryable with backoff rather than as a terminal failure. Keep the per-recipient result
 shape so defect B's reporting still works. This is a shared helper — both this function and the
 new one in §D need it — so it belongs in `supabase/functions/_shared/`.
+
+**The pacing fits inside the edge-function budget; here is the actual ceiling.** CLAUDE.md warns
+that edge functions have a strict CPU limit (~10s), which at first glance looks incompatible with
+deliberately slowing a fan-out down. It isn't, for two reasons, and both were checked rather than
+assumed:
+
+- **Size.** Queried against production: the largest active roster with an email address is **25**
+  employees (p95 = 25, median = 2, across 10 restaurants; exactly one is above 20). So the worst
+  real case today is 25 emails, and 25 at 2/s is ~12.5 s of wall time.
+- **Kind of time.** That 12.5 s is `await`ed idle wall time — the isolate is parked on a timer and
+  a `fetch`, consuming no CPU. The ~10 s ceiling that CLAUDE.md's Toast notes are about is a
+  **CPU** budget, exhausted by per-row work in a tight loop, not by waiting. The relevant limit
+  for waiting is the request wall-clock timeout, which is far larger.
+
+The design is therefore safe at present scale, but the bound is worth stating because it is not
+open-ended: at ~2/s, any roster beyond roughly a few hundred would start pressing the wall-clock
+timeout, and the answer then is a queue/cron drain rather than a faster loop. The rate limiter
+should log the recipient count and total elapsed time so that ceiling is observable before it is
+hit, rather than discovered as a timeout.
 
 ### Build on the existing notification toolkit, don't clone the hand-rolled one
 
@@ -627,26 +757,89 @@ CREATE TABLE public.schedule_retractions (
   retracted_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
   notified_at     TIMESTAMPTZ                      -- idempotency latch
 );
+
+CREATE INDEX idx_schedule_retractions_lookup
+  ON public.schedule_retractions (restaurant_id, week_start_date, retracted_at DESC)
+  WHERE notified_at IS NULL;
 ```
+
+The partial index matches the §D step-1 lookup exactly (unnotified rows for a week, newest first).
 
 A separate table rather than columns on `schedule_publications`, because a week can cycle
 publish → retract → publish → retract, and each retraction needs its own audience snapshot and
 its own `notified_at` latch.
 
-`unpublish_schedule` gains, inside its existing transaction, a CTE that captures the affected
-rows' distinct `employee_id`s from the `UPDATE ... RETURNING` **before** the flip is observable,
-plus an INSERT into `schedule_retractions` linking to the latest publication row for
-`(restaurant_id, week_start_date)`. **Its `RETURNS INTEGER` signature is unchanged** — deliberately,
-since `CREATE OR REPLACE` cannot alter a return type and a `DROP`/recreate would risk the known
-hazard of a later-merged migration silently reverting it. The client therefore keeps calling it
-exactly as today.
+`unpublish_schedule` gains, inside its existing transaction, a data-modifying CTE that captures
+the affected rows' distinct `employee_id`s from the `UPDATE ... RETURNING` **before** the flip is
+externally observable. **Its `RETURNS INTEGER` signature is unchanged** — deliberately, since
+`CREATE OR REPLACE` cannot alter a return type and a `DROP`/recreate would risk the known hazard
+of a later-merged migration silently reverting it. The client therefore keeps calling it exactly
+as today.
+
+Two implementation hazards, both of which break *existing* behavior if handled naively:
+
+**(i) `GET DIAGNOSTICS` must be removed, not kept.** The current function derives `v_shift_count`
+via `GET DIAGNOSTICS v_shift_count = ROW_COUNT` immediately after the plain UPDATE
+(`20260729120000_publish_schedule_tz_bucketing.sql:182`). Once the UPDATE is wrapped in a CTE
+feeding an INSERT, `GET DIAGNOSTICS` reports the **INSERT's** row count (1), not the number of
+shifts unpublished. That value is returned to the caller and rendered directly in the manager's
+toast at `src/hooks/useSchedulePublish.tsx:141` — a 63-shift unpublish would silently report
+"1 shift". Derive both values from the CTE instead:
+
+```sql
+WITH updated_shifts AS (
+  UPDATE public.shifts s
+     SET is_published = false, locked = false, published_at = NULL, published_by = NULL
+   WHERE s.restaurant_id = p_restaurant_id
+     AND (s.start_time AT TIME ZONE v_tz)::date >= p_week_start
+     AND (s.start_time AT TIME ZONE v_tz)::date <= p_week_end
+     AND s.is_published = true
+  RETURNING s.employee_id
+)
+SELECT count(*), COALESCE(array_agg(DISTINCT employee_id) FILTER (WHERE employee_id IS NOT NULL), '{}')
+  INTO v_shift_count, v_employee_ids
+  FROM updated_shifts;
+```
+
+Note `array_agg` over zero rows yields `NULL`, not `'{}'` — hence the `COALESCE`. The
+`FILTER` guards against open shifts, whose `employee_id` is nullable.
+
+**(ii) The retraction INSERT must be guarded on `v_shift_count > 0`.** Unpublishing a week that
+has no currently-published shifts is routine — a double-click, or unpublishing an
+already-retracted week. Inserting an empty retraction row would (a) violate `NOT NULL` if the
+`COALESCE` above were omitted, aborting the entire unpublish transaction, and (b) even with the
+`COALESCE`, create a meaningless retraction with an empty audience that the edge function would
+then have to special-case. Wrap the INSERT in `IF v_shift_count > 0 THEN ... END IF;`.
+
+The publication link resolves to the latest row for `(restaurant_id, week_start_date)` —
+`ORDER BY published_at DESC LIMIT 1`, never `.single()`, per the production facts recorded in
+Part I.
 
 The edge function is invoked with `{restaurantId, weekStart}` only, and derives everything else:
 
-1. Load the latest `schedule_retractions` row for the week where `notified_at IS NULL`.
-2. Join its `publication_id`; **abort unless `notification_sent = true`** (Decision 2).
-3. Send to `employee_ids` (Decision 3), through the §C rate limiter.
-4. Stamp `notified_at` via the service client — which makes a duplicate invoke a no-op.
+1. Load the latest unnotified `schedule_retractions` row for the week —
+   `WHERE notified_at IS NULL ORDER BY retracted_at DESC LIMIT 1`. Retractions accumulate per
+   week across publish→retract cycles, so this must be ordered and limited, never `.single()`.
+2. `LEFT JOIN` its `publication_id` and **abort unless `notification_sent = true`** (Decision 2).
+   The join must be null-safe: `publication_id` is `ON DELETE SET NULL`, so a NULL publication is
+   a legitimate state and must be treated as "abort", not allowed to throw.
+3. **Atomically claim the row before sending** (see below).
+4. Send to `employee_ids` (Decision 3), through the §C rate limiter.
+
+**The latch must be claimed before the send, not stamped after it.** Load-check-send-then-stamp
+is not race-safe: two concurrent invokes (a retry after a network hiccup, a double-tap) can both
+pass the gate before either stamps, and every employee gets the retraction twice. Claim it with a
+conditional update and only proceed if a row comes back:
+
+```sql
+UPDATE public.schedule_retractions
+   SET notified_at = now()
+ WHERE id = $1 AND notified_at IS NULL
+RETURNING *;
+```
+
+Zero rows returned means another invocation already owns this retraction — exit quietly. If the
+send subsequently fails outright, reset `notified_at` back to `NULL` so a retry can still fire.
 
 **Known limitation, stated plainly:** because defect A means *every* production publication row
 currently reads `notification_sent = false`, the Decision 2 gate will suppress **all** retraction

--- a/docs/superpowers/specs/2026-08-02-employee-schedule-clarity-design.md
+++ b/docs/superpowers/specs/2026-08-02-employee-schedule-clarity-design.md
@@ -962,10 +962,13 @@ divergence is listed here rather than edited into the sections above.
    latch still claims, so a retry does not re-mail the recipients who succeeded. Accepted
    limitation, not an oversight.
 
-7. **Only the newest unnotified retraction for a week is announced.** Older unnotified rows for
-   the same week are left as an audit trail rather than mailed. They describe versions that were
-   superseded before anyone was told about them, and sending one message per revision is the
-   confusion this change set exists to remove.
+7. **Only the newest retraction for a week can ever be announced.** The notifier selects the
+   latest row for the week outright — `notified_at` is checked *after* the ordering, not folded
+   into it — so older rows are permanently audit-only whether or not they were ever mailed. The
+   ordering matters: filtering on `notified_at IS NULL` first picks the newest *unnotified* row,
+   which is a different row. Retract twice in quick succession and a retry would find the older,
+   still-unlatched row and announce a version that was superseded before anyone heard of it.
+   Sending one message per revision is the confusion this change set exists to remove.
 
 8. **The fingerprint keys on `published_at` plus shift fields (§3b), not `is_published`.** A
    retraction changes the banner, which is far louder than the pill; the pill's job is to catch
@@ -974,3 +977,32 @@ divergence is listed here rather than edited into the sections above.
 9. **Open question 4 (native push) is resolved.** `notify-schedule-unpublished` calls
    `send-push-notification` server-side with the service-role key, matching the existing
    web-push fan-out. No client-triggered path.
+
+10. **The notifier authenticates before it claims (§7a's flow sketch omits this).** The sketch
+    goes straight from request to row lookup. The shipped function runs `authenticateRequest`
+    and then `verifyRestaurantPermission` for the caller against `restaurantId` *before* it
+    touches `schedule_retractions`, so an unauthenticated or non-manager request cannot burn the
+    `notified_at` latch and silence a real retraction. It follows the repo's standard edge
+    ordering: CORS → auth → permission → business logic.
+
+11. **`employee_ids` is readable by restaurant members, and that is not new exposure.** The
+    SELECT policy scopes rows to `user_restaurants` membership, the same boundary `shifts`
+    already uses — any member can already read every shift in the restaurant, employee ids
+    included, so the snapshot column reveals nothing the roster didn't. The protections that
+    matter are the ones on writes: no INSERT/UPDATE/DELETE grant and no UPDATE policy, both
+    pinned by `supabase/tests/schedule_retractions.test.sql`, so a client cannot rewrite the
+    audience or pre-claim `notified_at`. Narrowing reads to a self-scoped function would be
+    real work with no attacker benefit until `shifts` is narrowed first.
+
+12. **`notified_at` doubles as claim and completion; the reclaim is `release()`, not a token.**
+    A crash between the claim and the send would strand the row latched. The function nulls
+    `notified_at` back on every early return it controls, which covers the paths that actually
+    occur; a hard kill mid-send still strands it. Claim tokens with expiry would fix the
+    remaining window and are deliberately out of scope — the failure mode is one missed
+    retraction notice on a function crash, and the next republish writes a fresh row.
+
+13. **Delivery is client-invoked, not a durable outbox.** `useUnpublishSchedule` invokes the
+    function after the RPC commits, so a browser closed in that beat means the retraction is
+    never announced. A transactional outbox drained by cron is the correct shape and is out of
+    scope here; the persisted `schedule_retractions` row means the work is recoverable when
+    that lands, rather than lost. The publish path has the same shape today.

--- a/docs/superpowers/specs/2026-08-02-employee-schedule-clarity-design.md
+++ b/docs/superpowers/specs/2026-08-02-employee-schedule-clarity-design.md
@@ -569,6 +569,36 @@ will not, and the resulting 429s are invisible because of defect B.
 shape so defect B's reporting still works. This is a shared helper — both this function and the
 new one in §D need it — so it belongs in `supabase/functions/_shared/`.
 
+### Build on the existing notification toolkit, don't clone the hand-rolled one
+
+`supabase/functions/_shared/notificationHelpers.ts` (308 lines) already provides
+`sendEmail` (:159), `getEmployeeEmails` (:66), `getAllActiveEmployeeEmails` (:90),
+`shouldSendNotification` (:135), `verifyRestaurantPermission` (:208), `NOTIFICATION_FROM` (:197),
+`APP_URL` (:202), `corsHeaders` (:229), `handleCorsPreflightRequest` (:237),
+`createAuthenticatedClient` (:244), `authenticateRequest` (:266), `errorResponse` (:287) and
+`successResponse` (:300).
+
+`notify-schedule-published` uses **none of them** — it hand-rolls its own client construction
+(index.ts:33-41), permission check (index.ts:57-66), Resend `fetch` (index.ts:219-226) and
+response shaping (index.ts:269-291). The first draft of this document said to model the new
+`notify-schedule-unpublished` "directly on `notify-schedule-published`'s structure," which would
+propagate that duplication. **Superseded:** the new function is built on the shared helpers.
+Refactoring the existing publish function onto them is *not* in scope — it is noted as a
+follow-up so this change stays reviewable.
+
+**One blocker for reuse.** `sendEmail` returns a bare `boolean` (:159-192) — it catches the error
+text and the HTTP status and discards both (:181-185). A 429 is therefore indistinguishable from
+a hard bounce, which is exactly the distinction §C's backoff needs, and §B needs the error detail
+to report partial failure meaningfully.
+
+It has **6 call sites outside its own module** (`bank-reauth-notices`, `broadcast-open-shifts`,
+`notify-availability-reminder`, `notify-open-shift-claim`, `_shared/availabilityReminderHandler`,
+`_shared/bankReauthNoticesHandler`), so changing its return type is a breaking change well beyond
+this task's scope. **Approach: add a sibling `sendEmailResult()` returning
+`{ ok: boolean; status: number; error?: string }`, and reimplement the existing `sendEmail` as a
+one-line wrapper (`(await sendEmailResult(...)).ok`).** Existing callers are untouched and their
+behavior is provably identical; the rate limiter consumes the structured version.
+
 ## D. Retraction notifies nobody — and the audience must be persisted
 
 There is no `notify-schedule-unpublished` function; `useUnpublishSchedule`
@@ -661,9 +691,10 @@ path rather than the write path.
 | File | Change |
 |---|---|
 | `supabase/migrations/20260802120000_schedule_retractions.sql` (new) | `schedule_retractions` table + RLS (SELECT for restaurant members; no INSERT/UPDATE policy — writes come only from the `SECURITY DEFINER` RPC and service role); `CREATE OR REPLACE unpublish_schedule` re-declared **in full** carrying forward `SECURITY DEFINER`, `SET search_path = public, pg_temp`, and the existing `user_has_restaurant_access` guard, plus the audience-capturing CTE. Signature unchanged. |
-| `supabase/functions/_shared/rateLimitedSend.ts` (new) | Paced, concurrency-limited sender with 429 backoff (§C). Shared by both notify functions. |
-| `supabase/functions/notify-schedule-published/index.ts` | §A `serviceClient` + error check; §B non-2xx on partial failure; §C route sends through the limiter. |
-| `supabase/functions/notify-schedule-unpublished/index.ts` (new) | §D. Derives audience and gate entirely from `schedule_retractions` + `schedule_publications`; idempotent via `notified_at`. |
+| `supabase/functions/_shared/rateLimitedSend.ts` (new) | Paced, concurrency-limited sender with 429 backoff (§C). Consumes `sendEmailResult`. Shared by both notify functions. |
+| `supabase/functions/_shared/notificationHelpers.ts` | Add `sendEmailResult()` returning `{ ok, status, error? }`; reimplement existing `sendEmail` as a wrapper over it. Purely additive — the 6 existing call sites keep identical behavior. |
+| `supabase/functions/notify-schedule-published/index.ts` | §A `serviceClient` + error check; §B non-2xx on partial failure; §C route sends through the limiter. (Not refactored onto the shared helpers — out of scope, noted as follow-up.) |
+| `supabase/functions/notify-schedule-unpublished/index.ts` (new) | §D. Built on `notificationHelpers`, not cloned from the publish function. Derives audience and gate entirely from `schedule_retractions` + `schedule_publications`; idempotent via `notified_at`. |
 | `src/hooks/useSchedulePublish.tsx` | §B await the invoke and surface partial/total failure; §D invoke the new function from `useUnpublishSchedule`; §F timezone-correct published-shift count. |
 | `supabase/tests/schedule_retractions.test.sql` (new) | pgTAP: audience snapshot captured correctly; `notified_at` latch; `authenticated` cannot UPDATE `schedule_publications` (§A) or write `schedule_retractions`; cross-tenant access denied. |
 | `tests/unit/rateLimitedSend.test.ts` (new) | Pacing, 429 retry/backoff, per-recipient result shape preserved. |

--- a/docs/superpowers/specs/2026-08-02-employee-schedule-clarity-design.md
+++ b/docs/superpowers/specs/2026-08-02-employee-schedule-clarity-design.md
@@ -1,0 +1,698 @@
+# Employee Schedule Clarity — Draft vs Published Design
+
+**Date:** 2026-08-02
+**Status:** Approved — product decisions recorded below; implementation scoped
+**Scope:** Two parts. **Part I** — `src/pages/EmployeeSchedule.tsx` and its data layer (mobile +
+desktop, web + Capacitor native). **Part II** — the five notification-delivery defects found while
+debugging the original incident.
+
+## Recorded Product Decisions
+
+These were open questions in the first draft. They are now settled and binding on implementation:
+
+| # | Question | Decision |
+|---|---|---|
+| 1 | Hide vs. show-marked draft shifts (§2) | **Show, marked as tentative.** The §2 *fallback* treatment is the primary path. Hiding is rejected. |
+| 2 | Retraction notification threshold (§7a) | **Only weeks whose publication row had `notification_sent = true`.** Don't announce the retraction of something nobody was told about. |
+| 3 | Retraction audience (§7a) | **Employees who had published shifts in the retracted version.** |
+
+Decision 1 overrides this document's original recommendation. The tradeoff was raised explicitly
+and accepted: because a retracted week (state D) has *no* published shifts by definition, showing
+drafts means the whole week renders as dashed "tentative" rows under the red banner rather than as
+an empty week. That is a weaker signal than an empty grid, so **the state-D banner carries
+proportionally more of the burden** and must be unmissable (§1 State D).
+
+Decision 3 has a mechanical consequence the first draft missed — see **Part II §D** — because
+`unpublish_schedule()` sets `is_published = false` on every shift in the week, so *after* it runs
+there is no way to reconstruct who "had published shifts." The audience must be captured at
+retraction time and persisted.
+
+## Problem Statement
+
+`EmployeeSchedule.tsx` fetches shifts through `useShifts()` (`src/hooks/useShifts.tsx`), which
+runs `select('*, employee:employees(*)')` against `shifts` with **no `is_published` filter**. RLS
+on `shifts` allows any restaurant member to read every row for their restaurant, published or
+not. The page never references `is_published`, `published_at`, or `locked` — every shift for the
+viewed week renders identically, whether it is a manager's locked, published commitment or a
+half-finished draft the manager is still dragging around.
+
+**Real incident:** a manager published week Aug 3–9 on Aug 1 (employees got "New Schedule
+Published" emails, sent from `notify-schedule-published`). On Aug 2 the manager unpublished the
+whole week to make edits — 63 shifts flipped from `is_published: true` back to `false` via the
+`unpublish_schedule()` Postgres function, and were unlocked. **No notification exists for this
+event** — grepping the repo confirms there is no `notify-schedule-unpublished` (or equivalent)
+edge function; `notify-schedule-published/index.ts` is the only notification function in the
+schedule-publish family. The manager then edited shifts all morning. Any employee who opened the
+app during that window saw the half-edited draft rendered with the exact same visual weight as a
+confirmed schedule, with nothing on screen to say otherwise.
+
+Two failures compound here:
+1. **No visual distinction** between draft and published shifts on the employee page.
+2. **No notification** when a published week is retracted, so employees who already saw the
+   "published" version have no signal that what they're looking at is no longer real.
+
+## What the Database Already Gives Us
+
+This matters because it changes the design from "add new tracking" to "surface what's already
+tracked":
+
+- `shifts.is_published` (bool) / `shifts.locked` (bool) / `shifts.published_at` (timestamptz) —
+  set true/true/now() by `publish_schedule()`, and set back to `false`/`false`/`NULL` by
+  `unpublish_schedule()`. **`unpublish_schedule()` does not touch the historical
+  `schedule_publications` row** — it only mutates `shifts` and inserts an audit row into
+  `schedule_change_logs`.
+- `schedule_publications` (`restaurant_id, week_start_date, week_end_date, published_at,
+  published_by, shift_count, notes, notification_sent`) — one row is INSERTed per *publish*
+  action (`20260729120000_publish_schedule_tz_bucketing.sql:113-127`, an unconditional INSERT).
+  It is never deleted or updated by unpublish. This means **a row existing for a given week is
+  durable proof that the week was published at least once**, independent of the shifts' current
+  `is_published` state. This is the exact signal needed to detect "retracted."
+
+  **Two production facts constrain how this row is looked up** (verified by direct query against
+  prod, 2026-08-02):
+
+  1. **Republishing accumulates rows.** Because the INSERT is unconditional, one week can have
+     many publication rows — prod currently holds a week with **5**. Any "the publication for
+     this week" lookup must therefore mean *latest by `published_at`*, never `.single()`, which
+     would throw.
+  2. **`week_end_date` is not a stable key.** Older rows use an 8-day Sun–Sun span
+     (`2026-07-27 → 2026-08-03`) while newer ones use the current Monday-start 7-day span
+     (`2026-08-03 → 2026-08-09`). A lookup matching on *both* dates silently misses historical
+     rows. **Match on `(restaurant_id, week_start_date)` only.**
+- `schedule_change_logs` — gets a `change_type = 'unpublished'` row (with an optional manager
+  `reason`) on every unpublish, both per-shift (via the `log_shift_change()` trigger) and one
+  aggregate row from the RPC itself. **RLS already allows any restaurant member to `SELECT` this
+  table** (`"Users can view change logs for their restaurants"`, `USING (... user_restaurants
+  ... auth.uid())` — no role restriction), so the employee page can read the manager's stated
+  reason for a retraction without any RLS change.
+- `src/hooks/useSchedulePublish.tsx` already contains `useWeekPublicationStatus(restaurantId,
+  weekStart, weekEnd)`, used today on the manager side. It returns `{ publication, isPublished,
+  loading }`, but **its `isPublished` collapses "never published" and "published-then-retracted"
+  into the same `null`** (it early-returns `null` the moment `publishedShiftCount === 0`,
+  regardless of whether a `schedule_publications` row exists). That collapse is precisely why the
+  incident was invisible — even the manager-side hook, if it were reused as-is on the employee
+  page, would show "not published" for both a fresh unedited week and a week mid-retraction.
+
+This means the required new logic is small: query `schedule_publications` for *any* row matching
+the viewed week (not gated on current shift state) to learn "has this week ever been published,"
+and cross it with the current `is_published` count to learn "is it live right now." No RLS
+changes, no new tables.
+
+## State Model
+
+Given the viewed week (`weekStart`/`weekEnd`, restaurant-local, Monday-start per
+`WEEK_STARTS_ON`), and restricted to the current employee's shifts (`myShifts` in
+`EmployeeSchedule.tsx`):
+
+```
+historicalPublication = latest-by-published_at schedule_publications row for
+                         (restaurant_id, week_start_date)   [any status]
+livePublishedCount    = count(myShifts where is_published = true)
+draftCount            = count(myShifts where is_published = false)
+```
+
+Note the lookup key and the `latest-by-published_at` ordering — both are required by the two
+production facts recorded above, not stylistic choices.
+
+| State | Condition | Meaning |
+|---|---|---|
+| **A. Not yet published** | `historicalPublication == null` | Manager hasn't published this week. Nothing to show as "your schedule" — regardless of draft shift count. |
+| **B. Published (clean)** | `historicalPublication != null` AND `livePublishedCount > 0` AND `draftCount == 0` | Every shift for this employee this week is published and locked. Normal view. |
+| **C. Published, being revised** | `historicalPublication != null` AND `livePublishedCount > 0` AND `draftCount > 0` | Manager published, then added/changed shifts without re-publishing. Employee has a confirmed subset plus unconfirmed additions. |
+| **D. Retracted** | `historicalPublication != null` AND `livePublishedCount == 0` | The exact incident: was published, is now fully unpublished. Whatever shifts exist for the week are draft-only, mid-edit. |
+
+State D is the one the app currently cannot express at all. State C is the "partially published"
+case named in the task. State A already degrades gracefully today by accident (an unpublished
+week with zero shifts looks like an empty week) — but only by accident, and only if the manager
+also has zero draft shifts scaffolded; today an all-draft week in state A renders identically to
+state B.
+
+## 1. Draft vs Published Week States
+
+### State A — Not Yet Published
+
+The employee has no confirmed schedule for the viewed week. Per **Decision 1**, draft shifts *are*
+rendered — but in the tentative treatment from §2, so every row on the page is visibly dashed and
+badged "Draft — not confirmed." The page-level banner tells the employee why the whole week looks
+that way.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ ⓘ  Schedule not published yet                            │
+│    Your manager hasn't finalized the week of Aug 3–9.    │
+│    Check back soon.                                       │
+└─────────────────────────────────────────────────────────┘
+```
+
+Copy: **"Schedule not published yet"** / **"Your manager hasn't finalized the week of {weekStart}
+– {weekEnd}. Check back soon."**
+
+Component: `shadcn` `Alert` with `variant="default"`, icon `Clock` (lucide), classes
+`bg-muted/30 border-border/40` (neutral — this is not an error, it's an expected pending state).
+
+### State B — Published (Clean)
+
+No new banner. A small, persistent "Published" affordance sits in the `Weekly Schedule` card
+header next to the date range badge — see §3 for exact treatment. This is the default, quiet
+state; the redesign should not add ceremony to the common case.
+
+### State C — Published, Being Revised
+
+The employee has a confirmed schedule AND the manager has added/edited shifts since, not yet
+re-published. This is the most nuanced state: employees should trust the published shifts and be
+clearly warned that anything else is not final.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ ⚠  Some shifts are still being finalized                 │
+│    3 of your shifts this week are confirmed. 1 more is   │
+│    a draft your manager hasn't published yet — treat it  │
+│    as tentative until it shows a "Confirmed" badge.       │
+└─────────────────────────────────────────────────────────┘
+```
+
+Copy: **"Some shifts are still being finalized"** / **"{N} of your shifts this week are
+confirmed. {M} more {is/are} a draft your manager hasn't published yet — treat {it/them} as
+tentative until {it/they} show{s} a 'Confirmed' badge."** (pluralize `is/are`, `it/them`,
+`shows/show` via a small helper, not hardcoded — see `formatShiftChangeDescription`-style helper
+already in `useShifts.tsx` for the existing singular/plural pattern to mirror.)
+
+Component: `Alert` with `variant="default"`, icon `AlertTriangle`, classes
+`bg-amber-500/10 border-amber-500/20 text-foreground` (mirrors the existing "AI suggestion panel"
+amber convention from CLAUDE.md, repurposed here for "needs attention, not an error").
+
+### State D — Retracted
+
+The incident state. A published week whose shifts are now all draft again. This must be the most
+visually distinct state on the page — it is actively correcting a wrong belief the employee may
+already hold from an earlier visit or a "New Schedule Published" email already in their inbox.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ ⚠  This schedule was pulled back for changes             │
+│    Your manager published Aug 3–9 on Aug 1, then         │
+│    unpublished it to make edits. Nothing below is final  │
+│    — check back once it's republished.                    │
+│    {optional: "Reason: fixing a coverage gap Thursday."}  │
+└─────────────────────────────────────────────────────────┘
+```
+
+Copy: **"This schedule was pulled back for changes"** / **"Your manager published {weekStart} –
+{weekEnd} on {publishedDate}, then unpublished it to make edits. Nothing below is final — check
+back once it's republished."** Optional third line if `schedule_change_logs.reason` is non-null
+and not the RPC's own auto-generated boilerplate string (`"Schedule unpublished for date range: …"`
+— filter that default out, it's not manager-authored and would read as noise): **"Reason:
+{reason}"**.
+
+Component: `Alert` with `variant="destructive"` semantics but not full destructive-red saturation
+(this isn't the employee's error) — classes `bg-destructive/10 border-destructive/30
+text-foreground`, icon `AlertTriangle` in `text-destructive`. Placed at the very top of the page,
+above `MyShiftTradesCard`, so it's the first thing seen — this is the one state where being
+unmissable matters more than visual quietness.
+
+Per **Decision 1**, the day grid below this banner shows **every shift, all in the tentative
+treatment** — because in state D, by definition, `livePublishedCount == 0`, so every row is a
+draft. The entire week renders dashed and badged.
+
+This is the case where Decision 1 costs the most, and it was accepted knowingly: an empty grid
+would have said "there is nothing real here" structurally, whereas a full grid of dashed rows
+still *looks* like a schedule to someone skimming. Two consequences follow and are binding:
+
+1. **The state-D banner is the primary signal, not a supporting one.** It must be the first
+   content on the page and visually dominant (see component spec above).
+2. **The tentative treatment must not be subtle in this state.** The dashed border and badge are
+   carrying the whole load for anyone who skips the banner.
+
+## 2. Per-Shift Treatment
+
+### Chosen treatment (Decision 1): visible, clearly marked drafts
+
+**This is the specification.** Drafts stay visible and are made impossible to mistake for
+confirmed shifts. Managers want employees to see tentative plans early so conflicts get flagged
+before publish, and that outweighed the skim-risk argument below.
+
+The rejected alternative and its rationale are preserved at the end of this section, because the
+risk it names is real and shapes how the chosen treatment must be built: a "Draft" pill alone is
+exactly the kind of secondary visual information users tune out on a fast mobile glance, which is
+the majority of how this page gets used (per §6). **Every element below is therefore
+load-bearing** — the dashed border, the badge copy, the muted type, and the removed Trade button
+each independently signal "not final." Do not drop one as redundant during implementation; they
+are redundant *on purpose*, because the banner may go unread.
+
+Treatment:
+
+- Card background changes from `bg-muted/50` (current, for all shifts) to
+  `bg-muted/20 border border-dashed border-border/60` — dashed border reads as "not solid/not
+  final" independent of color, satisfying the accessibility no-color-alone rule in §5.
+- A `Badge variant="outline"` reading **"Draft — not confirmed"** (not just "Draft"; the copy
+  should imply "you cannot rely on this" without requiring an explicit legend) sits where
+  `getShiftStatusBadge()` normally renders its status badge — draft state takes priority over
+  the existing Completed/In Progress/Today/Upcoming badges, since "is it real" outranks "when is
+  it."
+- Times and position text drop from `font-medium text-foreground` to
+  `font-normal text-muted-foreground` — visually recedes relative to confirmed shifts on the same
+  day.
+- The Trade button (`ArrowLeftRight`) is **not shown** on draft shifts — trading a shift that
+  might not exist tomorrow doesn't make sense; `isFuture(...) && shift.status !== 'cancelled'`
+  gains `&& shift.is_published`.
+
+`myShifts` keeps its current, unfiltered definition (employee match only) — no `is_published`
+filter is added. `publishedCount` / `draftCount` are derived alongside it to drive the §1 banner,
+and each rendered row branches on `shift.is_published` for the treatment above.
+
+### Rejected alternative: hide unpublished shifts
+
+Recorded for provenance, since this was the first draft's recommendation and was overridden.
+
+The argument for hiding: the cost of a false negative (employee doesn't realize a shift is a
+draft, and shows up or doesn't show up based on wrong info) is categorically worse than the cost
+of a false positive (employee doesn't see a shift that later gets published — they find out when
+it publishes, same as the pre-existing baseline). Hiding would also have fixed the incident
+structurally, since state D's shifts are all drafts and would simply not render.
+
+Why it was rejected: it withholds information managers actively want employees to have, and an
+empty week is itself ambiguous — it reads identically to "you're off this week." The chosen
+treatment keeps the information and spends its complexity budget on making the distinction
+unmissable instead.
+
+## 3. "Last Updated / Published On" Affordance
+
+Two related but distinct needs:
+
+**(a) "When was this confirmed?"** — always answerable from data already fetched. Add a small,
+persistent line in the `Weekly Schedule` card header, next to the existing date-range `Badge`:
+
+```
+Weekly Schedule                    [< Today >]  [Aug 3 – Aug 9, 2026]
+                                                  Published Aug 1 at 6:42 PM
+```
+
+Copy: **"Published {format(publication.published_at, 'MMM d')} at {format(publication.published_at, 'h:mm a')}"**,
+computed in the restaurant's timezone via the existing `formatLocalDateInTz` /
+`formatLocalHHMMInTz` helpers from `src/lib/shiftInterval.ts` (not the browser's local time —
+consistent with the recent timezone-bucketing fixes referenced in the recent commit history).
+Rendered as `text-[12px] text-muted-foreground`, directly under the date-range badge. Omitted
+entirely in state A (nothing to date).
+
+**(b) "Has this changed since I last looked?"** — there is no existing per-user "last viewed
+schedule" tracking anywhere in the schema, and adding server-tracked read-receipts is a
+meaningfully bigger feature (new table, RLS, write-on-view). For v1, propose a **client-side
+"seen" fingerprint**, the same pattern already used by `EnableNotificationsBanner`'s
+`push_banner_dismissed_at` localStorage key (per the browser-push design doc) — this is UI-state
+bookkeeping, not the "manual caching of server data" CLAUDE.md prohibits, since it never
+substitutes for or delays a React Query fetch; it only decides whether to show a "New" pill on
+top of data that was fetched normally.
+
+- Key: `schedule_seen_${restaurantId}_${employeeId}_${weekStartISO}` → value = a hash of
+  `{publication.published_at, myShifts.map(s => [s.id, s.start_time, s.end_time, s.position,
+  s.status]).sort()}` (cheap `JSON.stringify` + a non-cryptographic hash is sufficient; this is
+  a change-detection fingerprint, not a security boundary).
+- On mount/data-load, compare current fingerprint to stored value for the viewed week. Mismatch
+  (or no stored value but a fingerprint now exists) → render a small **"Updated since you last
+  checked"** `Badge` next to the "Published …" line, `bg-primary/10 text-primary
+  border-primary/20`. On the user dismissing it (any interaction with the week, or an explicit
+  "Got it" tap) or after N seconds of the page being visible, write the new fingerprint and clear
+  the pill.
+- This only ever adds a *pill*, never hides or alters what's rendered — it degrades to "no pill"
+  silently if `localStorage` is unavailable (Capacitor native webview, private browsing), which
+  is an acceptable v1 limitation, not a broken state.
+
+This is flagged as an explicit open product decision in §8 — a server-tracked "last viewed"
+column would be more robust (works across devices, survives cache clears, and could feed manager
+analytics like "did the team see the update") but is a larger scope than this design's core fix.
+
+## 4. Empty / Loading / Error States
+
+CLAUDE.md requires all three be handled explicitly; auditing what exists today:
+
+| State | Current | Proposed |
+|---|---|---|
+| Loading | `EmployeePageSkeleton` (page-level, on `employeeLoading`) + inline `Skeleton` rows in the `Weekly Schedule` card (on `shiftsLoading`) — already present. | Unchanged, but the new publication-status query (§"State Model") must not block the shift skeleton — render the week's day grid skeleton immediately; let the publication banner pop in a beat later once its own (fast, single-row) query resolves, rather than gating the whole page on it. |
+| Empty (genuinely zero shifts, any state) | Per-day **"No shifts scheduled"** text only — indistinguishable from "you have the week off" on a published week. | Day-level text unchanged (still correct for a genuinely published week off), but now sits underneath the state A/D banner from §1, which supplies the missing "why." Note that under Decision 1 this row is now *rare* in states A and D — a week with draft shifts renders those shifts as tentative rows rather than as an empty grid, so "empty" here means the manager truly scheduled nobody. |
+| Empty (state B/C, employee genuinely has no shifts some days) | Same "No shifts scheduled" | Unchanged — this is a legitimately different case (published week, this employee just isn't on Wednesday) and should not be confused with "not published yet." |
+| Error (`useShifts` `error`) | **Not handled at all** — `EmployeeSchedule.tsx` destructures `shifts, loading` from `useShifts` but never reads `error`; a query failure silently renders an empty week, which is actively dangerous here (looks identical to "day off"). | Add an explicit error branch: if `shiftsError`, render an `Alert variant="destructive"` — **"Couldn't load your schedule"** / **"Something went wrong loading shifts. Pull to refresh or try again in a moment."** — in place of the day grid, with a `Button` "Retry" that calls `queryClient.invalidateQueries(['shifts', ...])`. This must not silently fall through to the empty-week UI. |
+| Error (new publication-status query) | N/A (doesn't exist yet) | Fails soft — if the publication-status query errors, treat as state A/unknown (don't claim "not published" or "published" with false confidence) and simply omit the banner + "Published on" line, while the shift list itself still renders normally from `useShifts` (which is a separate, independently-erroring query). A silent banner is an acceptable degradation; a wrong banner is not. |
+
+## 5. Accessibility
+
+- **No color-only signaling.** Every state in §1 pairs an icon (`AlertTriangle`, `Clock`) with
+  text copy that states the status in words ("not published yet," "pulled back for changes"),
+  never relying on the alert's tint alone. The fallback draft treatment in §2 uses a **dashed
+  border** (shape, not just color) plus explicit badge text "Draft — not confirmed."
+- **aria-live announcements.** The page-level banner container (§1) is wrapped in a persistent
+  `<div role="status" aria-live="polite" aria-atomic="true">` that exists on every render (empty
+  when there's nothing to say) so that a state transition triggered by data refetch — e.g. the
+  employee has the page open when a manager retracts the week mid-session, and `refetchOnMount:
+  true` / `refetchOnWindowFocus: true` on `useShifts` pulls the change in — is announced to
+  screen reader users without requiring them to re-navigate. The "Updated since you last checked"
+  pill from §3 is announced the same way, once, when it first appears.
+- **Keyboard reachability.** The banners are static content (no interactive controls beyond the
+  optional "Retry" button in the error state and a "Got it" dismiss on the "Updated" pill if that
+  affordance is interactive rather than auto-clearing) — both existing patterns in the file
+  already use `min-h-[44px]` touch/click targets and visible `aria-label`s (`Previous week`,
+  `Next week`); any new interactive element in this design must match that convention.
+- **Draft status must be announced per row, not just styled.** Under Decision 1 the dashed border
+  and muted type are purely visual and convey nothing to a screen reader; the "Draft — not
+  confirmed" badge text is the only part of the treatment that carries into the accessibility
+  tree. Each draft row must therefore announce its status as part of the row's accessible name —
+  the badge text must be real text inside the row (not a `::before`, background image, or
+  `aria-hidden` decoration), so a user navigating row-by-row hears "Draft — not confirmed"
+  without having to reach the page banner. This is the direct accessibility cost of showing
+  drafts instead of hiding them, and it is not optional.
+- **The banner is announced first.** The page-level banner in §1 must be the first
+  focusable/announced content on the page in states A, C and D (already true structurally since
+  it's placed above `MyShiftTradesCard`), not an easily-skipped aside.
+- **Not relying on hover.** All new affordances (banner, "Published on" line, "Updated" pill) are
+  always-visible on render, never hover-revealed — consistent with mobile-first (§6) where hover
+  doesn't exist.
+
+## 6. Mobile-First Considerations
+
+This page is used primarily on phones by restaurant staff, both in mobile Safari/Chrome and
+inside the Capacitor-wrapped native app (per
+`docs/superpowers/specs/2026-03-28-capacitor-native-employee-app-design.md`).
+
+- **Banner placement survives small viewports.** The state A/C/D banners use the same
+  `EmployeeInfoAlert`-style full-width `Alert` pattern already in the file (see the existing
+  "Your schedule may change" note at the bottom of the page) — full-width, wraps naturally, no
+  fixed width assumptions. Placed above the fold on a typical phone (before the `Weekly Schedule`
+  card), so no scrolling is required to see it.
+- **"Published on" line must not crowd the week-nav row.** The existing header row
+  (`flex flex-col sm:flex-row sm:items-center sm:justify-between`) already stacks vertically
+  below `sm:`. The new "Published Aug 1 at 6:42 PM" line goes on its own row beneath the badge on
+  mobile, not inline with it — inline would force the date-range badge to wrap awkwardly on
+  narrow screens (tested widths: 375px iPhone SE class).
+- **Two notification channels, not one.** The Capacitor app has its own native push path
+  (`send-push-notification` edge function + device token table, per the Capacitor design doc),
+  separate from the existing web-push path (`send-web-push` / `sendWebPushToUser`, used by
+  `notify-schedule-published`). Any new "schedule retracted" notification (§7) must fan out
+  through **both** channels, or native-app users get silently worse coverage than web-app users —
+  this is a real gap risk since the two channels currently live in different edge functions with
+  no shared trigger point.
+- **Pull-to-refresh expectation.** Native apps train users to pull-to-refresh; the error-state
+  Retry button (§4) should not be the *only* recovery path — if the page already wires up
+  `refetchOnWindowFocus`/`refetchOnMount` (it does, via `useShifts`), returning to the app from
+  background after a manager's change already triggers a refetch, which is the more common real
+  recovery path on mobile than a manual button tap.
+- **Touch targets.** Any new interactive element (Retry button, optional "Got it" dismiss on the
+  Updated pill) must meet the file's existing `min-h-[44px]` convention.
+
+## 7. Notification Copy
+
+Two notifications are currently missing entirely. Both should reuse the existing dual-channel
+pattern from `notify-schedule-published/index.ts` (Resend email + web push via
+`sendWebPushToUser`) and additionally cover the native push channel per §6.
+
+### (a) Schedule retracted / being revised
+
+Fires when `unpublish_schedule()` runs against a week that had `notification_sent = true` on its
+latest `schedule_publications` row (Decision 2), targeting the employees who held published
+shifts in the version being retracted (Decision 3). The mechanism that makes this possible is
+specified in **Part II §D** — the audience cannot be recomputed after the fact and must be
+captured inside the RPC transaction.
+
+The edge function derives *everything* from persisted state given only
+`{restaurantId, weekStart}`: it looks up the retraction row, and from there the audience, the
+week, and the `notification_sent` gate. **No caller-supplied employee list.** This follows the
+existing lesson that notification functions must derive the send decision from the database
+rather than the request body — otherwise any authenticated user could POST an arbitrary
+recipient list to the function and use it as a mail relay.
+
+**Email**
+- Subject: `Schedule update: {weekStart} – {weekEnd} at {restaurant.name} is being revised`
+- Body (plain-language, matching the existing template's tone in
+  `notify-schedule-published/index.ts`):
+  > Hi {employee.name},
+  >
+  > Your schedule for **{weekStart} – {weekEnd}** at **{restaurant.name}** is being revised by
+  > your manager. The version you may have seen is no longer final — please don't rely on it yet.
+  >
+  > You'll get another notification as soon as the updated schedule is published. If you have
+  > questions in the meantime, contact your manager.
+
+**Push** (web + native, same payload shape as `notifySchedulePublishedPush`)
+- Title: `Schedule Being Revised`
+- Body: `{weekStart}–{weekEnd} is no longer final — your manager is making changes.`
+- `url: "/employee/schedule"`, `tag: "schedule-unpublished"` (distinct tag from
+  `"schedule-published"` so the two don't clobber each other in the notification tray if both
+  fire in a short window).
+
+### (b) Re-published after a change (schedule changed since you last saw it)
+
+This is the recovery half of (a) — when the manager finishes editing and re-publishes, the
+existing `notify-schedule-published` fires again as-is (it's not gated on "first time"), but its
+copy currently reads identically whether this is the first publish of the week or a republish
+after retraction, which undersells "this is different from what you saw before." Propose a small
+copy branch inside the existing function based on whether a prior `schedule_publications` row for
+the same week already had `notification_sent = true`:
+
+**Email** (branch: `isRepublish`)
+- Subject (first publish, unchanged): `New Schedule Published: {weekStart} - {weekEnd}`
+- Subject (republish): `Updated Schedule: {weekStart} – {weekEnd} at {restaurant.name} — changes made`
+- Body addition for republish (appended after the existing "Your schedule for … has been
+  published" paragraph):
+  > This is an updated version — some shifts changed since your manager's earlier schedule for
+  > this week. Please review your shifts below before your next scheduled shift.
+
+**Push** (branch: `isRepublish`)
+- Title (first publish, unchanged): `Schedule Updated`
+- Title (republish): `Schedule Updated Again`
+- Body (republish): `{weekStart}–{weekEnd} was revised and republished — check what changed.`
+- Same `url`/`tag` as today (`"schedule-published"`) — this is intentionally the *same* tag as a
+  first publish, so a republish notification correctly replaces/collapses with an earlier
+  published-notification still sitting in the tray rather than stacking a duplicate.
+
+## Component-by-Component Breakdown
+
+| File | Change |
+|---|---|
+| `src/pages/EmployeeSchedule.tsx` | Keep `myShifts` unfiltered (Decision 1); derive `publishedCount`/`draftCount` for banner copy; render each row in the tentative treatment when `!shift.is_published` (§2); suppress the Trade button on drafts; add error branch on `useShifts().error` (§4); render new `ScheduleStatusBanner` above `MyShiftTradesCard`; add "Published on …" line + "Updated" pill to the `Weekly Schedule` card header; add `role="status" aria-live="polite"` wrapper (§5). |
+| `src/hooks/useShifts.tsx` | No change — it already fetches all shifts regardless of `is_published`, which Decision 1 requires. (Note: this hook is shared with manager surfaces; adding a publish filter here would have broken them, which is a further reason the filtering lives in the page.) |
+| `src/hooks/useSchedulePublish.tsx` | New hook `useWeekScheduleStatus(restaurantId, weekStart, weekEnd)` — wraps a query for the latest `schedule_publications` row matching the week regardless of current shift state (`historicalPublication`), combined with the existing published-shift-count logic, to return the 4-state model from "State Model" above: `{ state: 'not_published' \| 'published' \| 'published_revising' \| 'retracted', publication: SchedulePublication \| null, publishedCount: number, draftCount: number, loading }`. Distinct from the existing `useWeekPublicationStatus`, which stays as-is for the manager side (its `null`-collapsing behavior may be intentional there — manager UI has other cues for "was this ever published"). |
+| `src/components/employee/ScheduleStatusBanner.tsx` (new) | Renders the 4 banner variants from §1 given the `useWeekScheduleStatus` result. Pure presentational, no data fetching. |
+| `src/components/employee/DraftShiftRow.tsx` (new) | The dashed-border / "Draft — not confirmed" badge treatment for shift rows where `is_published === false` (§2). Now the primary path, not a conditional fallback. Badge text must be real in-tree text (§5). |
+| `src/lib/scheduleSeenFingerprint.ts` (new) | Pure fingerprint + localStorage read/write helpers for the "Updated since you last checked" pill (§3b). Small, unit-testable, no React dependency. |
+| `supabase/functions/notify-schedule-unpublished/index.ts` (new) | Sends the retraction email + web push + native push from §7(a). Modeled directly on `notify-schedule-published/index.ts`'s structure (auth → permission check → restaurant lookup → employee lookup → send). |
+| `supabase/functions/notify-schedule-published/index.ts` | Add the `isRepublish` branch from §7(b) — check for a prior `notification_sent = true` publication row for the same week before composing subject/body. |
+| `supabase/functions/_shared/schedulePublishedPush.ts` | Extend or sibling with a `notifyScheduleUnpublishedPush` helper mirroring `notifySchedulePublishedPush`, for the retraction push payload. |
+| `src/hooks/useSchedulePublish.tsx` (`useUnpublishSchedule`) | Fire-and-forget invoke of `notify-schedule-unpublished` on success, mirroring how `usePublishSchedule` invokes `notify-schedule-published` today — but gated on the unpublished week's publication row having `notification_sent = true` (don't notify about retracting a schedule nobody was told about). |
+| `tests/unit/scheduleSeenFingerprint.test.ts` (new) | Fingerprint stability (same input → same hash), change detection (any of published_at/shift fields differing → different hash), localStorage-unavailable fallback. |
+| `tests/unit/useWeekScheduleStatus.test.ts` (new) | All 4 states derived correctly from mocked `schedule_publications` + shift rows; the specific incident scenario (row exists, `notification_sent: true`, `publishedCount: 0`) resolves to `'retracted'`. |
+| `tests/unit/ScheduleStatusBanner.test.tsx` (new) | Correct copy/component per state; retracted-state reason line shown only for a non-boilerplate manager reason. |
+| `tests/e2e/employee-schedule-retraction.spec.ts` (new) | Publish a week as a manager test user, verify employee view shows clean published state; unpublish; verify employee view (same session, on refetch) shows the retracted banner and zero visible shift rows for that employee. |
+
+---
+
+# Part II — Notification Delivery Defects
+
+Five defects found while debugging the original report ("not all my users get notifications").
+All are confirmed against production. **The originally-reported symptom was a false alarm**: the
+11 delivered emails for Jul 27 – Aug 2 were exactly the 11 distinct employees with published
+shifts that week. Nobody was missed. The employees working Aug 3–9 received nothing because that
+week *was not published* at the time — it had 0 published shifts and 8–14 drafts per day. The
+real defects are the five below, which the investigation surfaced.
+
+## A. `notification_sent` is never recorded
+
+`supabase/functions/notify-schedule-published/index.ts:259-262` performs the write with the
+**user-scoped** client (`supabase`, built from the anon key at index.ts:33-41), not the
+`serviceClient` already constructed and in scope at index.ts:81-84:
+
+```typescript
+await supabase
+  .from("schedule_publications")
+  .update({ notification_sent: true })
+  .eq("id", publicationId);
+```
+
+`schedule_publications` has exactly two RLS policies — `INSERT` (`Managers can create schedule
+publications`) and `SELECT` (`Users can view schedule publications for their restaurants`).
+**There is no `UPDATE` policy**, so under RLS this statement matches zero rows. The result is
+never destructured or error-checked, so it fails silently. Confirmed: **every** publication row
+in production reads `notification_sent = false`, including the one that demonstrably delivered
+11 emails.
+
+**Fix:** issue the update via `serviceClient`, check the returned `error`, and log it. Use
+`.select('id')` so the row count is observable rather than assumed.
+
+### Scope correction: do *not* add a broad UPDATE policy
+
+The approved scope said "use `serviceClient` **and** add the missing UPDATE RLS policy
+migration." Those two are alternatives, not complements, and only the first is correct:
+
+- `serviceClient` uses the service-role key, which **bypasses RLS entirely**. Once the write goes
+  through it, an UPDATE policy is not required for the fix to work.
+- Adding an UPDATE policy broad enough to satisfy the old code path (i.e. one that lets a manager
+  update `schedule_publications`) would let any manager-role client **forge** `notification_sent`
+  — and, once Part II §D lands, the retraction state and audience too. That is a net loss of
+  integrity for zero functional gain.
+
+**Recommendation: keep `schedule_publications` free of an UPDATE policy.** Every legitimate write
+to it comes from a service-role edge function or a `SECURITY DEFINER` RPC, both of which bypass
+RLS by design. In place of the policy, add a pgTAP test that *asserts the absence* — that an
+`authenticated` client cannot UPDATE the table — which locks in the current correct posture and
+fails loudly if someone later adds a permissive policy. This satisfies the "pgTAP for the RLS
+change" testing requirement by pinning the invariant rather than by widening access.
+
+Flagged for the user at plan approval; if a policy is wanted anyway, the narrow form is
+`FOR UPDATE USING (false) WITH CHECK (false)`, which documents intent without granting anything.
+
+## B. Send failures are invisible
+
+Two independent layers swallow failures:
+
+- `supabase/functions/notify-schedule-published/index.ts:241-244` computes `successCount` /
+  `failureCount`, then returns **HTTP 200** with them in the body (index.ts:269-280) regardless of
+  how many failed. A run where every single email failed is indistinguishable, at the HTTP layer,
+  from a fully successful one.
+- `src/hooks/useSchedulePublish.tsx:71-87` invokes the function **fire-and-forget** — the promise
+  is not awaited into the mutation result, and both branches only `console.error` / `console.log`.
+  The publishing manager sees an unconditional success toast.
+
+**Fix:** return a non-2xx status when `failureCount > 0` (partial failure included), per the
+existing lesson that edge functions should use real HTTP codes instead of a 200-with-error-body
+workaround. On the client, await the invoke and read `error.context.json()` for the structured
+body, then surface a distinct toast: full success, partial ("Published — but N of M
+notifications failed to send"), or total failure. **Publishing must still succeed** even if
+notification fails — the RPC has already committed by then, so the toast must never imply the
+schedule wasn't published.
+
+## C. The Resend fan-out is unthrottled
+
+`supabase/functions/notify-schedule-published/index.ts:154-238` builds one promise per recipient
+and fires them all at once via `Promise.allSettled` (index.ts:238). Resend's default rate limit is
+**2 requests/second**. Eleven recipients happened to get through; a 25-person roster very likely
+will not, and the resulting 429s are invisible because of defect B.
+
+**Fix:** send through a small concurrency-limited queue with a paced interval (≤2/s), and treat a
+429 as retryable with backoff rather than as a terminal failure. Keep the per-recipient result
+shape so defect B's reporting still works. This is a shared helper — both this function and the
+new one in §D need it — so it belongs in `supabase/functions/_shared/`.
+
+## D. Retraction notifies nobody — and the audience must be persisted
+
+There is no `notify-schedule-unpublished` function; `useUnpublishSchedule`
+(`src/hooks/useSchedulePublish.tsx:111-152`) invokes nothing at all. On Aug 2 a manager
+unpublished 63 live shifts for the already-announced week of Aug 3–9 and no employee was told.
+
+**The mechanical problem Decision 3 creates.** `unpublish_schedule()` sets `is_published = false`
+on every shift in the week (`20260729120000_publish_schedule_tz_bucketing.sql:170-179`). So by the
+time any edge function runs *after* the RPC, the set of "employees who had published shifts in the
+retracted version" **no longer exists anywhere**. It cannot be recomputed. And per the lesson that
+notification functions must derive their decision from persisted DB state, it must *not* be passed
+in from the client — a caller-supplied recipient list turns the function into an open mail relay.
+
+**Therefore the audience must be captured inside the RPC transaction and persisted.** New table:
+
+```sql
+CREATE TABLE public.schedule_retractions (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  restaurant_id   UUID NOT NULL REFERENCES public.restaurants(id) ON DELETE CASCADE,
+  publication_id  UUID REFERENCES public.schedule_publications(id) ON DELETE SET NULL,
+  week_start_date DATE NOT NULL,
+  week_end_date   DATE NOT NULL,
+  employee_ids    UUID[] NOT NULL DEFAULT '{}',   -- audience snapshot, captured pre-flip
+  shift_count     INTEGER NOT NULL DEFAULT 0,
+  retracted_by    UUID,
+  retracted_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  notified_at     TIMESTAMPTZ                      -- idempotency latch
+);
+```
+
+A separate table rather than columns on `schedule_publications`, because a week can cycle
+publish → retract → publish → retract, and each retraction needs its own audience snapshot and
+its own `notified_at` latch.
+
+`unpublish_schedule` gains, inside its existing transaction, a CTE that captures the affected
+rows' distinct `employee_id`s from the `UPDATE ... RETURNING` **before** the flip is observable,
+plus an INSERT into `schedule_retractions` linking to the latest publication row for
+`(restaurant_id, week_start_date)`. **Its `RETURNS INTEGER` signature is unchanged** — deliberately,
+since `CREATE OR REPLACE` cannot alter a return type and a `DROP`/recreate would risk the known
+hazard of a later-merged migration silently reverting it. The client therefore keeps calling it
+exactly as today.
+
+The edge function is invoked with `{restaurantId, weekStart}` only, and derives everything else:
+
+1. Load the latest `schedule_retractions` row for the week where `notified_at IS NULL`.
+2. Join its `publication_id`; **abort unless `notification_sent = true`** (Decision 2).
+3. Send to `employee_ids` (Decision 3), through the §C rate limiter.
+4. Stamp `notified_at` via the service client — which makes a duplicate invoke a no-op.
+
+**Known limitation, stated plainly:** because defect A means *every* production publication row
+currently reads `notification_sent = false`, the Decision 2 gate will suppress **all** retraction
+notifications until a week is published *after* this change ships. That is the correct
+conservative behavior — for those historical rows we genuinely cannot tell whether employees were
+emailed — and it self-heals on the next publish. No backfill is proposed: setting
+`notification_sent = true` retroactively would be asserting a delivery we cannot verify, and would
+be a production write requiring separate explicit approval.
+
+## E. Employees cannot distinguish draft from published
+
+`src/hooks/useShifts.tsx:48-80` selects shifts with no `is_published` predicate, and the `shifts`
+SELECT policy is plain restaurant membership (`EXISTS (SELECT 1 FROM user_restaurants WHERE
+restaurant_id = shifts.restaurant_id AND user_id = auth.uid())`) — so every employee can read
+every draft. `src/pages/EmployeeSchedule.tsx` never references `is_published`.
+
+This is **Part I** of this document. No RLS change is proposed: Decision 1 requires employees to
+*see* drafts, so restricting the read path would defeat the chosen design. The distinction is made
+in the UI, per Part I §1/§2.
+
+## F. Manager "Published" badge disagrees with what publish actually did
+
+`src/hooks/useSchedulePublish.tsx:169-175` counts published shifts using browser-local instants:
+
+```typescript
+.gte('start_time', weekStart.toISOString())
+.lte('start_time', weekEnd.toISOString())
+```
+
+while the RPC buckets by restaurant-local calendar day
+(`(s.start_time AT TIME ZONE v_tz)::date`, `20260729120000_publish_schedule_tz_bucketing.sql:101-102`).
+For a manager whose browser timezone differs from the restaurant's, the two disagree at week
+edges — the badge can read "not published" for a week that was published, or vice versa.
+
+**Fix:** bucket the count the same way the RPC does, using the restaurant's IANA timezone via the
+existing `fromZonedTime` approach already used in `notify-schedule-published/index.ts:110-116`.
+This is the same class of bug as the recently-merged `publish_schedule` timezone fix, in the read
+path rather than the write path.
+
+## Part II — Files
+
+| File | Change |
+|---|---|
+| `supabase/migrations/20260802120000_schedule_retractions.sql` (new) | `schedule_retractions` table + RLS (SELECT for restaurant members; no INSERT/UPDATE policy — writes come only from the `SECURITY DEFINER` RPC and service role); `CREATE OR REPLACE unpublish_schedule` re-declared **in full** carrying forward `SECURITY DEFINER`, `SET search_path = public, pg_temp`, and the existing `user_has_restaurant_access` guard, plus the audience-capturing CTE. Signature unchanged. |
+| `supabase/functions/_shared/rateLimitedSend.ts` (new) | Paced, concurrency-limited sender with 429 backoff (§C). Shared by both notify functions. |
+| `supabase/functions/notify-schedule-published/index.ts` | §A `serviceClient` + error check; §B non-2xx on partial failure; §C route sends through the limiter. |
+| `supabase/functions/notify-schedule-unpublished/index.ts` (new) | §D. Derives audience and gate entirely from `schedule_retractions` + `schedule_publications`; idempotent via `notified_at`. |
+| `src/hooks/useSchedulePublish.tsx` | §B await the invoke and surface partial/total failure; §D invoke the new function from `useUnpublishSchedule`; §F timezone-correct published-shift count. |
+| `supabase/tests/schedule_retractions.test.sql` (new) | pgTAP: audience snapshot captured correctly; `notified_at` latch; `authenticated` cannot UPDATE `schedule_publications` (§A) or write `schedule_retractions`; cross-tenant access denied. |
+| `tests/unit/rateLimitedSend.test.ts` (new) | Pacing, 429 retry/backoff, per-recipient result shape preserved. |
+| `tests/unit/useWeekScheduleStatus.test.ts` (new) | Part I 4-state model; plus §F timezone bucketing at week edges. |
+
+## Open Questions / Product Decisions
+
+Questions 1–3 of the original draft are **resolved** — see "Recorded Product Decisions" at the top.
+The remainder stay open and are explicitly *not* being built in this pass:
+
+1. **Server-tracked "last viewed" vs. client-side fingerprint (§3b).** The localStorage approach
+   is cheap and ships fast but is per-device and invisible to managers. Is manager-visible
+   "did the team see this" reporting a real near-term need? If yes, this should be a
+   `schedule_views` table from the start rather than a client-only stopgap that gets thrown away
+   later.
+2. **Reason surfacing in the retracted banner (§1, State D).** `schedule_change_logs.reason` is
+   optional and today defaults to an auto-generated, not-manager-authored string when the manager
+   doesn't supply one. Should the unpublish UI (manager side, out of scope for this doc but
+   adjacent) be changed to *require* a reason when unpublishing an already-notified week, so the
+   employee-facing banner always has something meaningful to show instead of silently omitting
+   the reason line?
+3. **Partial-publish threshold for state C.** Is "any draft shift alongside any published shift
+   for this employee this week" the right bar for showing the amber "being finalized" banner, or
+   should it only fire once draft shifts cross some materiality threshold (e.g., a single
+   draft note-only change vs. a genuinely new unconfirmed shift)? This design treats all drafts
+   equally for simplicity; may need refinement once real data volume is seen.
+4. **Capacitor native push wiring (§6, §7).** Native push currently has no equivalent trigger
+   point wired to the publish/unpublish mutations — confirm whether `send-push-notification`
+   (native) should be called from the same new `notify-schedule-unpublished` function (server-side
+   fan-out) or requires a separate client-triggered call, matching whatever pattern the existing
+   native shift-created/time-off notifications already use (not audited in this pass — worth a
+   quick check before implementation).

--- a/src/components/PublishScheduleDialog.tsx
+++ b/src/components/PublishScheduleDialog.tsx
@@ -186,8 +186,10 @@ export const PublishScheduleDialog = ({
             */}
             {isPublishing ? (
               <>
-                <Clock className="h-4 w-4 mr-2 animate-spin" />
-                {employeeCount > 0 ? `Notifying ${employeeCount}...` : 'Publishing...'}
+                <Clock className="h-4 w-4 mr-2 animate-spin" aria-hidden="true" />
+                <span aria-live="polite">
+                  {employeeCount > 0 ? `Notifying ${employeeCount}...` : 'Publishing...'}
+                </span>
               </>
             ) : (
               <>

--- a/src/components/PublishScheduleDialog.tsx
+++ b/src/components/PublishScheduleDialog.tsx
@@ -164,6 +164,20 @@ export const PublishScheduleDialog = ({
         </div>
 
         <DialogFooter>
+          {/*
+            Mounted unconditionally, unlike the button label below. A live
+            region has to be in the accessibility tree *before* its content
+            changes or most screen readers drop the first update — and the
+            button that carries the visible label is disabled the moment
+            publishing starts, so focus isn't sitting on it either.
+          */}
+          <span role="status" aria-live="polite" className="sr-only">
+            {isPublishing
+              ? employeeCount > 0
+                ? `Publishing. Notifying ${employeeCount} ${employeeCount === 1 ? 'employee' : 'employees'}.`
+                : 'Publishing.'
+              : ''}
+          </span>
           <Button
             type="button"
             variant="outline"
@@ -187,7 +201,8 @@ export const PublishScheduleDialog = ({
             {isPublishing ? (
               <>
                 <Clock className="h-4 w-4 mr-2 animate-spin" aria-hidden="true" />
-                <span aria-live="polite">
+                {/* Not a live region: the sr-only one above owns the announcement. */}
+                <span>
                   {employeeCount > 0 ? `Notifying ${employeeCount}...` : 'Publishing...'}
                 </span>
               </>

--- a/src/components/PublishScheduleDialog.tsx
+++ b/src/components/PublishScheduleDialog.tsx
@@ -178,10 +178,16 @@ export const PublishScheduleDialog = ({
             disabled={isPublishing}
             className="bg-gradient-to-r from-primary to-accent"
           >
+            {/*
+              The shifts publish in about a second; the rest of this wait is the
+              notification fan-out, paced to stay under Resend's rate limit, so
+              it scales with headcount. Naming that is what keeps a legitimate
+              ten-second wait from reading as a hung button.
+            */}
             {isPublishing ? (
               <>
                 <Clock className="h-4 w-4 mr-2 animate-spin" />
-                Publishing...
+                {employeeCount > 0 ? `Notifying ${employeeCount}...` : 'Publishing...'}
               </>
             ) : (
               <>

--- a/src/components/employee/ScheduleStatusBanner.tsx
+++ b/src/components/employee/ScheduleStatusBanner.tsx
@@ -92,7 +92,8 @@ export function ScheduleStatusBanner({
           Some shifts are still being finalized
         </AlertTitle>
         <AlertDescription className="text-[13px] text-muted-foreground">
-          {publishedCount} of your {pluralize(publishedCount, 'shift', 'shifts')} this week{' '}
+          {publishedCount} of your {publishedCount + draftCount}{' '}
+          {pluralize(publishedCount + draftCount, 'shift', 'shifts')} this week{' '}
           {pluralize(publishedCount, 'is', 'are')} confirmed. {draftCount} more{' '}
           {pluralize(draftCount, 'is a draft', 'are drafts')} your manager hasn't published yet —
           treat {pluralize(draftCount, 'it', 'them')} as tentative until{' '}

--- a/src/components/employee/ScheduleStatusBanner.tsx
+++ b/src/components/employee/ScheduleStatusBanner.tsx
@@ -1,0 +1,140 @@
+import { ReactNode } from 'react';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { AlertTriangle, Clock } from 'lucide-react';
+import { SchedulePublication } from '@/types/scheduling';
+import { WeekScheduleState } from '@/hooks/useSchedulePublish';
+import { formatDayLabel, formatLocalDateInTz, formatLocalHHMMInTz } from '@/lib/shiftInterval';
+
+/**
+ * The RPC writes this itself when a manager unpublishes without giving a
+ * reason. Showing it back to an employee as "Reason: …" would present machine
+ * boilerplate as if a person had written it.
+ */
+const AUTO_REASON_PREFIX = 'Schedule unpublished for date range';
+
+const plural = (n: number, one: string, many: string) => (n === 1 ? one : many);
+
+interface ScheduleStatusBannerProps {
+  state: WeekScheduleState | null;
+  publication: SchedulePublication | null;
+  publishedCount: number;
+  draftCount: number;
+  weekRange: string;
+  timezone: string;
+  /** `schedule_change_logs.reason` from the retraction, when a manager wrote one. */
+  retractionReason?: string | null;
+}
+
+/**
+ * Owns a fixed-height slot at the top of the page.
+ *
+ * The height is constant across all four states on purpose. If the slot
+ * collapsed while the publication lookup was in flight, the banner's arrival
+ * would push `MyShiftTradesCard` and everything under it down on an
+ * already-painted page — a layout shift, and on mobile a live mis-tap hazard
+ * for anyone who started tapping during that beat. State B, which has no
+ * banner, fills the slot with the same information in one quiet line.
+ */
+export function ScheduleStatusBanner({
+  state,
+  publication,
+  publishedCount,
+  draftCount,
+  weekRange,
+  timezone,
+  retractionReason,
+}: ScheduleStatusBannerProps) {
+  const slot = (children: ReactNode) => <div className="min-h-[76px]">{children}</div>;
+
+  // Loading, or the lookup failed. A wrong banner is worse than no banner:
+  // telling someone their week is "not published yet" when it is would have
+  // them ignore real shifts.
+  if (!state) return slot(null);
+
+  // Restaurant timezone, not the browser's. An employee travelling, or a
+  // manager publishing at 11pm from one zone over, must not see a date that
+  // disagrees with the week the shifts were bucketed into.
+  const publishedOn = publication?.published_at
+    ? `${formatDayLabel(formatLocalDateInTz(new Date(publication.published_at), timezone))} at ${formatLocalHHMMInTz(publication.published_at, timezone)}`
+    : null;
+
+  if (state === 'published') {
+    return slot(
+      publishedOn ? (
+        <p className="text-[13px] text-muted-foreground">Published {publishedOn}</p>
+      ) : null
+    );
+  }
+
+  if (state === 'not_published') {
+    return slot(
+      <Alert role="status" className="bg-muted/30 border-border/40">
+        <Clock className="h-4 w-4" />
+        <AlertTitle className="text-[14px] font-semibold text-foreground">
+          Schedule not published yet
+        </AlertTitle>
+        <AlertDescription className="text-[13px] text-muted-foreground">
+          Your manager hasn't finalized the week of {weekRange}.{' '}
+          {draftCount > 0 && (
+            <>
+              The {draftCount} {plural(draftCount, 'shift', 'shifts')} below{' '}
+              {plural(draftCount, 'is', 'are')} still {plural(draftCount, 'a draft', 'drafts')} —
+              nothing is confirmed yet.{' '}
+            </>
+          )}
+          Check back soon.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (state === 'published_revising') {
+    return slot(
+      <Alert role="status" className="bg-amber-500/10 border-amber-500/20 text-foreground">
+        <AlertTriangle className="h-4 w-4" />
+        <AlertTitle className="text-[14px] font-semibold text-foreground">
+          Some shifts are still being finalized
+        </AlertTitle>
+        <AlertDescription className="text-[13px] text-muted-foreground">
+          {publishedCount} of your {plural(publishedCount, 'shift', 'shifts')} this week{' '}
+          {plural(publishedCount, 'is', 'are')} confirmed. {draftCount} more{' '}
+          {plural(draftCount, 'is a draft', 'are drafts')} your manager hasn't published yet —
+          treat {plural(draftCount, 'it', 'them')} as tentative until{' '}
+          {plural(draftCount, 'it shows', 'they show')} a "Confirmed" badge.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  // Retracted. The one state where being unmissable outranks being quiet — it
+  // is actively correcting a belief the employee may already hold from a "New
+  // Schedule Published" email sitting in their inbox. Keeps the primitive's
+  // assertive role.
+  const showReason =
+    !!retractionReason?.trim() && !retractionReason.startsWith(AUTO_REASON_PREFIX);
+
+  return slot(
+    <Alert className="bg-destructive/10 border-destructive/30 text-foreground">
+      <AlertTriangle className="h-4 w-4 text-destructive" />
+      <AlertTitle className="text-[14px] font-semibold text-foreground">
+        This schedule was pulled back for changes
+      </AlertTitle>
+      <AlertDescription className="text-[13px] text-muted-foreground">
+        Your manager published {weekRange}
+        {publishedOn ? ` on ${publishedOn}` : ''}, then unpublished it to make edits. Nothing below
+        is final — check back once it's republished.
+        {showReason && <span className="block mt-1">Reason: {retractionReason}</span>}
+      </AlertDescription>
+    </Alert>
+  );
+}
+
+/** "Updated since you last checked" pill, shown beside the published-on line. */
+export function ScheduleUpdatedPill() {
+  return (
+    <Badge className="bg-primary/10 text-primary border-primary/20 hover:bg-primary/10 text-[11px]">
+      Updated since you last checked
+    </Badge>
+  );
+}

--- a/src/components/employee/ScheduleStatusBanner.tsx
+++ b/src/components/employee/ScheduleStatusBanner.tsx
@@ -13,7 +13,14 @@ import { formatDayLabel, formatLocalDateInTz, formatLocalHHMMInTz } from '@/lib/
  */
 const AUTO_REASON_PREFIX = 'Schedule unpublished for date range';
 
-const plural = (n: number, one: string, many: string) => (n === 1 ? one : many);
+function plural(n: number, one: string, many: string): string {
+  return n === 1 ? one : many;
+}
+
+/** The fixed-height slot every state renders into; see the banner's own doc comment. */
+function slot(children: ReactNode): JSX.Element {
+  return <div className="min-h-[76px]">{children}</div>;
+}
 
 interface ScheduleStatusBannerProps {
   state: WeekScheduleState | null;
@@ -44,9 +51,7 @@ export function ScheduleStatusBanner({
   weekRange,
   timezone,
   retractionReason,
-}: ScheduleStatusBannerProps) {
-  const slot = (children: ReactNode) => <div className="min-h-[76px]">{children}</div>;
-
+}: ScheduleStatusBannerProps): JSX.Element {
   // Loading, or the lookup failed. A wrong banner is worse than no banner:
   // telling someone their week is "not published yet" when it is would have
   // them ignore real shifts.
@@ -130,8 +135,8 @@ export function ScheduleStatusBanner({
   );
 }
 
-/** "Updated since you last checked" pill, shown beside the published-on line. */
-export function ScheduleUpdatedPill() {
+/** "Updated since you last checked" pill, shown beside the Weekly Schedule heading. */
+export function ScheduleUpdatedPill(): JSX.Element {
   return (
     <Badge className="bg-primary/10 text-primary border-primary/20 hover:bg-primary/10 text-[11px]">
       Updated since you last checked

--- a/src/components/employee/ScheduleStatusBanner.tsx
+++ b/src/components/employee/ScheduleStatusBanner.tsx
@@ -86,8 +86,8 @@ export function ScheduleStatusBanner({
 
   if (state === 'published_revising') {
     return slot(
-      <Alert role="status" className="bg-amber-500/10 border-amber-500/20 text-foreground">
-        <AlertTriangle className="h-4 w-4" />
+      <Alert role="status" className="bg-warning/10 border-warning/20 text-foreground">
+        <AlertTriangle className="h-4 w-4 text-warning" />
         <AlertTitle className="text-[14px] font-semibold text-foreground">
           Some shifts are still being finalized
         </AlertTitle>

--- a/src/components/employee/ScheduleStatusBanner.tsx
+++ b/src/components/employee/ScheduleStatusBanner.tsx
@@ -2,20 +2,10 @@ import { ReactNode } from 'react';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
 import { AlertTriangle, Clock } from 'lucide-react';
-import { SchedulePublication } from '@/types/scheduling';
 import { WeekScheduleState } from '@/hooks/useSchedulePublish';
+import { SchedulePublication } from '@/types/scheduling';
+import { pluralize } from '@/lib/scheduling/deletionCopy';
 import { formatDayLabel, formatLocalDateInTz, formatLocalHHMMInTz } from '@/lib/shiftInterval';
-
-/**
- * The RPC writes this itself when a manager unpublishes without giving a
- * reason. Showing it back to an employee as "Reason: …" would present machine
- * boilerplate as if a person had written it.
- */
-const AUTO_REASON_PREFIX = 'Schedule unpublished for date range';
-
-function plural(n: number, one: string, many: string): string {
-  return n === 1 ? one : many;
-}
 
 /** The fixed-height slot every state renders into; see the banner's own doc comment. */
 function slot(children: ReactNode): JSX.Element {
@@ -29,7 +19,7 @@ interface ScheduleStatusBannerProps {
   draftCount: number;
   weekRange: string;
   timezone: string;
-  /** `schedule_change_logs.reason` from the retraction, when a manager wrote one. */
+  /** `schedule_retractions.reason`, set only when a manager wrote one. */
   retractionReason?: string | null;
 }
 
@@ -83,8 +73,8 @@ export function ScheduleStatusBanner({
           Your manager hasn't finalized the week of {weekRange}.{' '}
           {draftCount > 0 && (
             <>
-              The {draftCount} {plural(draftCount, 'shift', 'shifts')} below{' '}
-              {plural(draftCount, 'is', 'are')} still {plural(draftCount, 'a draft', 'drafts')} —
+              The {draftCount} {pluralize(draftCount, 'shift', 'shifts')} below{' '}
+              {pluralize(draftCount, 'is', 'are')} still {pluralize(draftCount, 'a draft', 'drafts')} —
               nothing is confirmed yet.{' '}
             </>
           )}
@@ -102,11 +92,11 @@ export function ScheduleStatusBanner({
           Some shifts are still being finalized
         </AlertTitle>
         <AlertDescription className="text-[13px] text-muted-foreground">
-          {publishedCount} of your {plural(publishedCount, 'shift', 'shifts')} this week{' '}
-          {plural(publishedCount, 'is', 'are')} confirmed. {draftCount} more{' '}
-          {plural(draftCount, 'is a draft', 'are drafts')} your manager hasn't published yet —
-          treat {plural(draftCount, 'it', 'them')} as tentative until{' '}
-          {plural(draftCount, 'it shows', 'they show')} a "Confirmed" badge.
+          {publishedCount} of your {pluralize(publishedCount, 'shift', 'shifts')} this week{' '}
+          {pluralize(publishedCount, 'is', 'are')} confirmed. {draftCount} more{' '}
+          {pluralize(draftCount, 'is a draft', 'are drafts')} your manager hasn't published yet —
+          treat {pluralize(draftCount, 'it', 'them')} as tentative until{' '}
+          {pluralize(draftCount, 'it shows', 'they show')} a "Confirmed" badge.
         </AlertDescription>
       </Alert>
     );
@@ -116,8 +106,11 @@ export function ScheduleStatusBanner({
   // is actively correcting a belief the employee may already hold from a "New
   // Schedule Published" email sitting in their inbox. Keeps the primitive's
   // assertive role.
-  const showReason =
-    !!retractionReason?.trim() && !retractionReason.startsWith(AUTO_REASON_PREFIX);
+  // No boilerplate filter needed: `schedule_retractions.reason` stores the
+  // manager's `p_reason` verbatim and stays NULL when they gave none. The RPC's
+  // "Schedule unpublished for date range…" default is written only to
+  // `schedule_change_logs`, which this never reads.
+  const showReason = !!retractionReason?.trim();
 
   return slot(
     <Alert className="bg-destructive/10 border-destructive/30 text-foreground">

--- a/src/components/employee/ShiftRow.tsx
+++ b/src/components/employee/ShiftRow.tsx
@@ -15,20 +15,16 @@ import { format, parseISO, isToday, isFuture, isPast, differenceInMinutes } from
 import { Shift } from '@/types/scheduling';
 import { cn } from '@/lib/utils';
 
-const formatShiftDuration = (
-  startTime: string,
-  endTime: string,
-  breakMinutes: number
-) => {
+function formatShiftDuration(startTime: string, endTime: string, breakMinutes: number): string {
   const start = new Date(startTime);
   const end = new Date(endTime);
   const netMinutes = differenceInMinutes(end, start) - breakMinutes;
   const hours = Math.floor(netMinutes / 60);
   const minutes = netMinutes % 60;
   return `${hours}h ${minutes}m`;
-};
+}
 
-const getShiftStatusBadge = (shift: Shift) => {
+function getShiftStatusBadge(shift: Shift): JSX.Element | null {
   const startTime = new Date(shift.start_time);
   const endTime = new Date(shift.end_time);
   const now = new Date();
@@ -79,7 +75,7 @@ const getShiftStatusBadge = (shift: Shift) => {
   }
 
   return null;
-};
+}
 
 /**
  * Deliberately NOT variant="outline". The pre-existing "Upcoming" badge is an
@@ -89,12 +85,16 @@ const getShiftStatusBadge = (shift: Shift) => {
  * banner so "amber = not final" is one language across the page. The icon is
  * supplementary; the text carries the meaning.
  */
-const DraftBadge = () => (
-  <Badge className="flex items-center gap-1 bg-amber-500/15 text-foreground border-amber-500/30 hover:bg-amber-500/15">
-    <PencilLine className="h-3 w-3" />
-    Draft — not confirmed
-  </Badge>
-);
+function DraftBadge(): JSX.Element {
+  return (
+    <Badge className="flex items-center gap-1 bg-amber-500/15 text-foreground border-amber-500/30 hover:bg-amber-500/15">
+      <PencilLine className="h-3 w-3" />
+      Draft — not confirmed
+    </Badge>
+  );
+}
+
+type ShiftRowVariant = 'day' | 'upcoming';
 
 interface ShiftRowProps {
   shift: Shift;
@@ -103,26 +103,27 @@ interface ShiftRowProps {
    * which leads with a date block. Both take the identical draft branch — that
    * shared branch is the reason this is one component and not two.
    */
-  variant?: 'day' | 'upcoming';
+  variant?: ShiftRowVariant;
   onTrade?: (shift: Shift) => void;
 }
 
-export function ShiftRow({ shift, variant = 'day', onTrade }: ShiftRowProps) {
+/** Cancelled outranks draft, which outranks the per-variant default. */
+function getSurfaceClass(isCancelled: boolean, isDraft: boolean, variant: ShiftRowVariant): string {
+  if (isCancelled) return 'bg-destructive/10 line-through';
+  if (isDraft) return 'bg-muted/20 border border-dashed border-border/60';
+  if (variant === 'upcoming') return 'bg-background border';
+  return 'bg-muted/50';
+}
+
+export function ShiftRow({ shift, variant = 'day', onTrade }: ShiftRowProps): JSX.Element {
   const isDraft = !shift.is_published;
   const isCancelled = shift.status === 'cancelled';
 
-  // Every one of these signals is load-bearing and redundant on purpose: the
-  // dashed border, the badge copy, the muted type and the missing Trade button
-  // each say "not final" on their own, because the banner above may go unread
-  // on a fast mobile glance.
-  const surface = isCancelled
-    ? 'bg-destructive/10 line-through'
-    : isDraft
-      ? 'bg-muted/20 border border-dashed border-border/60'
-      : variant === 'upcoming'
-        ? 'bg-background border'
-        : 'bg-muted/50';
-
+  // Every draft signal below is load-bearing and redundant on purpose: the
+  // dashed surface, the badge copy, the muted type and the missing Trade
+  // button each say "not final" on their own, because the banner above may go
+  // unread on a fast mobile glance.
+  const surface = getSurfaceClass(isCancelled, isDraft, variant);
   const timeText = isDraft ? 'font-normal text-muted-foreground' : 'font-medium';
 
   const canTrade =

--- a/src/components/employee/ShiftRow.tsx
+++ b/src/components/employee/ShiftRow.tsx
@@ -1,0 +1,217 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  ArrowLeftRight,
+  Calendar,
+  CheckCircle,
+  Clock,
+  ClockIcon,
+  Coffee,
+  MapPin,
+  PencilLine,
+  XCircle,
+} from 'lucide-react';
+import { format, parseISO, isToday, isFuture, isPast, differenceInMinutes } from 'date-fns';
+import { Shift } from '@/types/scheduling';
+import { cn } from '@/lib/utils';
+
+const formatShiftDuration = (
+  startTime: string,
+  endTime: string,
+  breakMinutes: number
+) => {
+  const start = new Date(startTime);
+  const end = new Date(endTime);
+  const netMinutes = differenceInMinutes(end, start) - breakMinutes;
+  const hours = Math.floor(netMinutes / 60);
+  const minutes = netMinutes % 60;
+  return `${hours}h ${minutes}m`;
+};
+
+const getShiftStatusBadge = (shift: Shift) => {
+  const startTime = new Date(shift.start_time);
+  const endTime = new Date(shift.end_time);
+  const now = new Date();
+
+  if (shift.status === 'cancelled') {
+    return (
+      <Badge variant="destructive" className="flex items-center gap-1">
+        <XCircle className="h-3 w-3" />
+        Cancelled
+      </Badge>
+    );
+  }
+
+  if (isPast(endTime)) {
+    return (
+      <Badge variant="outline" className="flex items-center gap-1 bg-muted">
+        <CheckCircle className="h-3 w-3" />
+        Completed
+      </Badge>
+    );
+  }
+
+  if (now >= startTime && now <= endTime) {
+    return (
+      <Badge className="flex items-center gap-1 bg-green-500">
+        <ClockIcon className="h-3 w-3" />
+        In Progress
+      </Badge>
+    );
+  }
+
+  if (isToday(startTime)) {
+    return (
+      <Badge variant="default" className="flex items-center gap-1">
+        <Clock className="h-3 w-3" />
+        Today
+      </Badge>
+    );
+  }
+
+  if (isFuture(startTime)) {
+    return (
+      <Badge variant="outline" className="flex items-center gap-1">
+        <Calendar className="h-3 w-3" />
+        Upcoming
+      </Badge>
+    );
+  }
+
+  return null;
+};
+
+/**
+ * Deliberately NOT variant="outline". The pre-existing "Upcoming" badge is an
+ * outline pill in this exact slot, so an outline draft badge would be a second
+ * identical grey pill and read as just another status — the precise failure the
+ * tentative treatment exists to avoid. The amber matches the "being revised"
+ * banner so "amber = not final" is one language across the page. The icon is
+ * supplementary; the text carries the meaning.
+ */
+const DraftBadge = () => (
+  <Badge className="flex items-center gap-1 bg-amber-500/15 text-foreground border-amber-500/30 hover:bg-amber-500/15">
+    <PencilLine className="h-3 w-3" />
+    Draft — not confirmed
+  </Badge>
+);
+
+interface ShiftRowProps {
+  shift: Shift;
+  /**
+   * `'day'` is the weekly grid row; `'upcoming'` is the Upcoming Shifts card,
+   * which leads with a date block. Both take the identical draft branch — that
+   * shared branch is the reason this is one component and not two.
+   */
+  variant?: 'day' | 'upcoming';
+  onTrade?: (shift: Shift) => void;
+}
+
+export function ShiftRow({ shift, variant = 'day', onTrade }: ShiftRowProps) {
+  const isDraft = !shift.is_published;
+  const isCancelled = shift.status === 'cancelled';
+
+  // Every one of these signals is load-bearing and redundant on purpose: the
+  // dashed border, the badge copy, the muted type and the missing Trade button
+  // each say "not final" on their own, because the banner above may go unread
+  // on a fast mobile glance.
+  const surface = isCancelled
+    ? 'bg-destructive/10 line-through'
+    : isDraft
+      ? 'bg-muted/20 border border-dashed border-border/60'
+      : variant === 'upcoming'
+        ? 'bg-background border'
+        : 'bg-muted/50';
+
+  const timeText = isDraft ? 'font-normal text-muted-foreground' : 'font-medium';
+
+  const canTrade =
+    !!onTrade && shift.is_published && !isCancelled && isFuture(parseISO(shift.start_time));
+
+  const tradeButton = canTrade ? (
+    <Button
+      size="sm"
+      variant="outline"
+      onClick={() => onTrade!(shift)}
+      className="min-h-[44px]"
+    >
+      <ArrowLeftRight className="h-4 w-4 mr-1" />
+      Trade
+    </Button>
+  ) : null;
+
+  // "Is this real" outranks "when is this", so the draft badge takes the slot
+  // the status badge would otherwise occupy rather than sitting beside it.
+  const statusBadge = isDraft ? <DraftBadge /> : getShiftStatusBadge(shift);
+
+  if (variant === 'upcoming') {
+    return (
+      <div className={cn('flex items-center justify-between p-3 rounded-lg', surface)}>
+        <div className="flex items-center gap-4">
+          <div className="text-center">
+            <div className="text-sm font-medium text-muted-foreground">
+              {format(parseISO(shift.start_time), 'EEE')}
+            </div>
+            <div className={cn('text-2xl', isDraft ? 'font-normal text-muted-foreground' : 'font-bold')}>
+              {format(parseISO(shift.start_time), 'd')}
+            </div>
+            <div className="text-xs text-muted-foreground">
+              {format(parseISO(shift.start_time), 'MMM')}
+            </div>
+          </div>
+          <div>
+            <div className={timeText}>
+              {format(parseISO(shift.start_time), 'h:mm a')} -{' '}
+              {format(parseISO(shift.end_time), 'h:mm a')}
+            </div>
+            <div className="text-sm text-muted-foreground flex items-center gap-2">
+              <MapPin className="h-3 w-3" />
+              {shift.position}
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center justify-end gap-3">
+          {shift.break_duration > 0 && (
+            <div className="flex items-center gap-1 text-sm text-muted-foreground">
+              <Coffee className="h-3 w-3" />
+              {shift.break_duration}m break
+            </div>
+          )}
+          {statusBadge}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 p-3 rounded-lg',
+        surface
+      )}
+    >
+      <div className="flex items-center gap-4">
+        <div>
+          <div className={timeText}>
+            {format(parseISO(shift.start_time), 'h:mm a')} -{' '}
+            {format(parseISO(shift.end_time), 'h:mm a')}
+          </div>
+          <div className="text-sm text-muted-foreground">{shift.position}</div>
+        </div>
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="text-sm text-muted-foreground">
+          {formatShiftDuration(shift.start_time, shift.end_time, shift.break_duration)}
+        </div>
+        {shift.break_duration > 0 && (
+          <div className="flex items-center gap-1 text-xs text-muted-foreground">
+            <Coffee className="h-3 w-3" />
+            {shift.break_duration}m
+          </div>
+        )}
+        {statusBadge}
+        {tradeButton}
+      </div>
+    </div>
+  );
+}

--- a/src/components/employee/ShiftRow.tsx
+++ b/src/components/employee/ShiftRow.tsx
@@ -84,13 +84,13 @@ function getShiftStatusBadge(shift: Shift): JSX.Element | null {
  * Deliberately NOT variant="outline". The pre-existing "Upcoming" badge is an
  * outline pill in this exact slot, so an outline draft badge would be a second
  * identical grey pill and read as just another status — the precise failure the
- * tentative treatment exists to avoid. The amber matches the "being revised"
- * banner so "amber = not final" is one language across the page. The icon is
- * supplementary; the text carries the meaning.
+ * tentative treatment exists to avoid. The `warning` token matches the "being
+ * revised" banner so "amber = not final" is one language across the page. The
+ * icon is supplementary; the text carries the meaning.
  */
 function DraftBadge(): JSX.Element {
   return (
-    <Badge className="flex items-center gap-1 bg-amber-500/15 text-foreground border-amber-500/30 hover:bg-amber-500/15">
+    <Badge className="flex items-center gap-1 bg-warning/15 text-foreground border-warning/30 hover:bg-warning/15">
       <PencilLine className="h-3 w-3" />
       Draft — not confirmed
     </Badge>
@@ -146,7 +146,13 @@ export function ShiftRow({ shift, variant = 'day', onTrade }: ShiftRowProps): JS
 
   // "Is this real" outranks "when is this", so the draft badge takes the slot
   // the status badge would otherwise occupy rather than sitting beside it.
-  const statusBadge = isDraft ? <DraftBadge /> : getShiftStatusBadge(shift);
+  //
+  // Cancelled still outranks draft, matching getSurfaceClass. An unpublished
+  // cancelled shift is reachable — unpublishing flips is_published on every
+  // shift in the week, cancelled ones included — and it would otherwise wear a
+  // struck-through destructive row under a badge reading "Draft — not
+  // confirmed". "It's cancelled" is the fact the employee has to leave with.
+  const statusBadge = isDraft && !isCancelled ? <DraftBadge /> : getShiftStatusBadge(shift);
 
   if (variant === 'upcoming') {
     return (

--- a/src/components/employee/ShiftRow.tsx
+++ b/src/components/employee/ShiftRow.tsx
@@ -1,3 +1,4 @@
+import { format, parseISO, isToday, isFuture, isPast, differenceInMinutes } from 'date-fns';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -11,7 +12,6 @@ import {
   PencilLine,
   XCircle,
 } from 'lucide-react';
-import { format, parseISO, isToday, isFuture, isPast, differenceInMinutes } from 'date-fns';
 import { Shift } from '@/types/scheduling';
 import { cn } from '@/lib/utils';
 

--- a/src/components/employee/ShiftRow.tsx
+++ b/src/components/employee/ShiftRow.tsx
@@ -18,7 +18,10 @@ import { cn } from '@/lib/utils';
 function formatShiftDuration(startTime: string, endTime: string, breakMinutes: number): string {
   const start = new Date(startTime);
   const end = new Date(endTime);
-  const netMinutes = differenceInMinutes(end, start) - breakMinutes;
+  // Clamped: a break longer than the shift is a data-entry slip, and "-1h 30m"
+  // on an employee's own schedule reads as a bug in the app rather than one in
+  // the shift.
+  const netMinutes = Math.max(0, differenceInMinutes(end, start) - breakMinutes);
   const hours = Math.floor(netMinutes / 60);
   const minutes = netMinutes % 60;
   return `${hours}h ${minutes}m`;

--- a/src/components/employee/index.ts
+++ b/src/components/employee/index.ts
@@ -9,3 +9,5 @@ export { EmployeeInfoAlert } from './EmployeeInfoAlert';
 export { PeriodSelector, type PeriodType } from './PeriodSelector';
 export { MobileLayout } from './MobileLayout';
 export { MobileTabBar } from './MobileTabBar';
+export { ShiftRow } from './ShiftRow';
+export { ScheduleStatusBanner, ScheduleUpdatedPill } from './ScheduleStatusBanner';

--- a/src/hooks/useSchedulePublish.tsx
+++ b/src/hooks/useSchedulePublish.tsx
@@ -349,6 +349,46 @@ export const useWeekScheduleStatus = (
   };
 };
 
+/**
+ * The reason a manager gave when pulling a week back, if they gave one.
+ *
+ * Gated on `enabled` so the overwhelmingly common case — a published week —
+ * costs nothing. `schedule_retractions` is the right source rather than
+ * `schedule_change_logs`: it is scoped to the week, carries the SELECT policy
+ * and grant employees actually have, and stores the reason verbatim instead of
+ * the RPC's `COALESCE(...)` boilerplate.
+ */
+export const useWeekRetractionReason = (
+  restaurantId: string | null,
+  weekStart: Date,
+  enabled: boolean
+): string | null => {
+  const weekStartStr = formatLocalDate(weekStart);
+
+  const { data } = useQuery({
+    queryKey: ['week_retraction_reason', restaurantId, weekStartStr],
+    queryFn: async () => {
+      if (!restaurantId) return null;
+
+      const { data, error } = await supabase
+        .from('schedule_retractions')
+        .select('reason')
+        .eq('restaurant_id', restaurantId)
+        .eq('week_start_date', weekStartStr)
+        .order('retracted_at', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+
+      if (error) throw error;
+      return data?.reason ?? null;
+    },
+    enabled: !!restaurantId && enabled,
+    staleTime: 30000,
+  });
+
+  return data ?? null;
+};
+
 export const useWeekPublicationStatus = (
   restaurantId: string | null,
   weekStart: Date,

--- a/src/hooks/useSchedulePublish.tsx
+++ b/src/hooks/useSchedulePublish.tsx
@@ -47,10 +47,10 @@ interface InvokeError {
  * that (which is what the old fire-and-forget `.then()` did) is what let a
  * publish where every email bounced still toast "Employees will be notified".
  */
-export const invokeScheduleNotification = async (
+export async function invokeScheduleNotification(
   functionName: string,
   body: Record<string, unknown>,
-): Promise<NotificationOutcome> => {
+): Promise<NotificationOutcome> {
   try {
     const { data, error } = await supabase.functions.invoke(functionName, { body });
 
@@ -79,7 +79,18 @@ export const invokeScheduleNotification = async (
       message: error instanceof Error ? error.message : 'Unknown error',
     };
   }
-};
+}
+
+interface NotificationToastCopy {
+  title: string;
+  successDescription: string;
+}
+
+interface ToastPayload {
+  title: string;
+  description: string;
+  variant?: 'destructive';
+}
 
 /**
  * The mutation itself has already committed by the time notifications run, so
@@ -87,33 +98,33 @@ export const invokeScheduleNotification = async (
  * varies — and a manager who knows three people weren't emailed can go tell
  * them, which is the entire point.
  */
-const notificationToast = (
+function notificationToast(
   outcome: NotificationOutcome,
-  { title, successDescription }: { title: string; successDescription: string },
-) => {
+  { title, successDescription }: NotificationToastCopy,
+): ToastPayload {
   switch (outcome.status) {
     case 'sent':
-      return { title, description: successDescription } as const;
+      return { title, description: successDescription };
     case 'partial':
       return {
         title: `${title} — some employees not notified`,
         description: `${outcome.sent} notified, ${outcome.failed} could not be reached. Please contact them directly.`,
         variant: 'destructive',
-      } as const;
+      };
     case 'failed':
       return {
         title: `${title} — nobody was notified`,
         description: `All ${outcome.failed} notification${outcome.failed !== 1 ? 's' : ''} failed to send. Please tell your team directly.`,
         variant: 'destructive',
-      } as const;
+      };
     case 'unknown':
       return {
         title: `${title} — notifications unconfirmed`,
         description: `We could not confirm that employees were notified: ${outcome.message}`,
         variant: 'destructive',
-      } as const;
+      };
   }
-};
+}
 
 export const useSchedulePublications = (restaurantId: string | null) => {
   const { data, isLoading, error } = useQuery({
@@ -283,6 +294,24 @@ interface WeekScheduleStatus {
 }
 
 /**
+ * A wrong banner is worse than no banner, so an errored or in-flight lookup
+ * reports no state at all rather than guessing "not published".
+ */
+function deriveWeekScheduleState(
+  isLoading: boolean,
+  error: unknown,
+  publication: SchedulePublication | null,
+  publishedCount: number,
+  draftCount: number
+): WeekScheduleState | null {
+  if (isLoading || error) return null;
+  if (!publication) return 'not_published';
+  if (publishedCount === 0) return 'retracted';
+  if (draftCount > 0) return 'published_revising';
+  return 'published';
+}
+
+/**
  * Counts come from shifts the caller already has — `EmployeeSchedule` filters
  * the week down to `myShifts`, and the state model is defined over that
  * employee's own shifts, not the restaurant's. Passing them in also keeps this
@@ -325,19 +354,7 @@ export const useWeekScheduleStatus = (
 
   const publishedCount = shifts.filter((s) => s.is_published).length;
   const draftCount = shifts.length - publishedCount;
-
-  // A wrong banner is worse than no banner, so an errored or in-flight lookup
-  // reports no state at all rather than guessing "not published".
-  const state: WeekScheduleState | null =
-    isLoading || error
-      ? null
-      : !data
-        ? 'not_published'
-        : publishedCount === 0
-          ? 'retracted'
-          : draftCount > 0
-            ? 'published_revising'
-            : 'published';
+  const state = deriveWeekScheduleState(isLoading, error, data ?? null, publishedCount, draftCount);
 
   return {
     state,

--- a/src/hooks/useSchedulePublish.tsx
+++ b/src/hooks/useSchedulePublish.tsx
@@ -4,6 +4,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { SchedulePublication, Shift } from '@/types/scheduling';
 import { useToast } from '@/hooks/use-toast';
 import { formatLocalDate } from '@/lib/shiftInterval';
+import { safeTz } from '@/lib/restaurantClock';
 
 interface PublishScheduleParams {
   restaurantId: string;
@@ -257,7 +258,13 @@ export const useUnpublishSchedule = () => {
       toast(
         notificationToast(notification, {
           title: 'Schedule Unpublished',
-          successDescription: `${shiftCount} shift${shiftCount !== 1 ? 's' : ''} have been unlocked for editing. Affected employees have been told the week is being revised.`,
+          // Nothing was retracted means nothing was sent -- the mutation skips
+          // the invoke entirely on that path. Promising a notification anyway
+          // is how a manager ends up believing their team was told.
+          successDescription:
+            shiftCount > 0
+              ? `${shiftCount} shift${shiftCount !== 1 ? 's' : ''} have been unlocked for editing. Affected employees have been told the week is being revised.`
+              : 'Nothing was published for this week, so no shifts changed and nobody was notified.',
         }),
       );
     },
@@ -421,13 +428,21 @@ export const useWeekPublicationStatus = (
   weekEnd: Date,
   timezone: string
 ) => {
+  // `restaurants.timezone` is nullable and free-text, and callers may hand this
+  // through before the restaurant has loaded. `fromZonedTime` answers an invalid
+  // zone with an Invalid Date, whose `.toISOString()` throws — so the whole
+  // badge would disappear behind a query error rather than fall back to UTC the
+  // way publish_schedule itself does. Resolved once, before the key, so a
+  // '' -> 'UTC' correction doesn't split the cache across two entries.
+  const tz = safeTz(timezone);
+
   const { data, isLoading } = useQuery({
     queryKey: [
       'week_publication_status',
       restaurantId,
       weekStart.toISOString(),
       weekEnd.toISOString(),
-      timezone,
+      tz,
     ],
     queryFn: async () => {
       if (!restaurantId) return null;
@@ -441,8 +456,8 @@ export const useWeekPublicationStatus = (
       // zone from the restaurant — or anyone looking at a Sunday-evening shift,
       // which is already Monday in UTC — could see "Published" disagree with
       // what publish actually did at the week edges.
-      const weekStartInstant = fromZonedTime(`${weekStartStr}T00:00:00`, timezone).toISOString();
-      const weekEndInstant = fromZonedTime(`${weekEndStr}T23:59:59.999`, timezone).toISOString();
+      const weekStartInstant = fromZonedTime(`${weekStartStr}T00:00:00`, tz).toISOString();
+      const weekEndInstant = fromZonedTime(`${weekEndStr}T23:59:59.999`, tz).toISOString();
 
       const { count: publishedShiftCount, error: shiftError } = await supabase
         .from('shifts')

--- a/src/hooks/useSchedulePublish.tsx
+++ b/src/hooks/useSchedulePublish.tsx
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { fromZonedTime } from 'date-fns-tz';
 import { supabase } from '@/integrations/supabase/client';
 import { SchedulePublication } from '@/types/scheduling';
 import { useToast } from '@/hooks/use-toast';
@@ -17,6 +18,102 @@ interface UnpublishScheduleParams {
   weekEnd: Date;
   reason?: string;
 }
+
+/**
+ * What the notification edge function actually managed to do.
+ *
+ * `unknown` is a real outcome, not a fallback for tidiness: the invoke can fail
+ * before the function runs at all (offline, cold-start timeout), and claiming
+ * "everyone was notified" in that case is the behaviour this change set exists
+ * to remove.
+ */
+export type NotificationOutcome =
+  | { status: 'sent'; sent: number }
+  | { status: 'partial'; sent: number; failed: number }
+  | { status: 'failed'; failed: number }
+  | { status: 'unknown'; message: string };
+
+interface InvokeError {
+  message?: string;
+  context?: { json?: () => Promise<unknown> };
+}
+
+/**
+ * Invoke a notification function and work out what really happened.
+ *
+ * The functions answer 502 with a structured body when any recipient failed,
+ * and supabase-js turns a non-2xx into an `error` whose `context` is the raw
+ * `Response` — so the counts are only reachable by re-reading it. Swallowing
+ * that (which is what the old fire-and-forget `.then()` did) is what let a
+ * publish where every email bounced still toast "Employees will be notified".
+ */
+export const invokeScheduleNotification = async (
+  functionName: string,
+  body: Record<string, unknown>,
+): Promise<NotificationOutcome> => {
+  try {
+    const { data, error } = await supabase.functions.invoke(functionName, { body });
+
+    if (!error) {
+      const sent = typeof data?.sent === 'number' ? data.sent : 0;
+      return { status: 'sent', sent };
+    }
+
+    const payload = (await (error as InvokeError).context?.json?.()) as
+      | { sent?: number; failed?: number }
+      | undefined;
+
+    if (payload && typeof payload.failed === 'number' && payload.failed > 0) {
+      const sent = typeof payload.sent === 'number' ? payload.sent : 0;
+      return sent > 0
+        ? { status: 'partial', sent, failed: payload.failed }
+        : { status: 'failed', failed: payload.failed };
+    }
+
+    return { status: 'unknown', message: (error as InvokeError).message ?? 'Unknown error' };
+  } catch (error) {
+    // A body that was already consumed, or one that isn't JSON at all. We know
+    // something went wrong and nothing more than that.
+    return {
+      status: 'unknown',
+      message: error instanceof Error ? error.message : 'Unknown error',
+    };
+  }
+};
+
+/**
+ * The mutation itself has already committed by the time notifications run, so
+ * every branch reports the schedule change as done. Only the notification half
+ * varies — and a manager who knows three people weren't emailed can go tell
+ * them, which is the entire point.
+ */
+const notificationToast = (
+  outcome: NotificationOutcome,
+  { title, successDescription }: { title: string; successDescription: string },
+) => {
+  switch (outcome.status) {
+    case 'sent':
+      return { title, description: successDescription } as const;
+    case 'partial':
+      return {
+        title: `${title} — some employees not notified`,
+        description: `${outcome.sent} notified, ${outcome.failed} could not be reached. Please contact them directly.`,
+        variant: 'destructive',
+      } as const;
+    case 'failed':
+      return {
+        title: `${title} — nobody was notified`,
+        description: `All ${outcome.failed} notification${outcome.failed !== 1 ? 's' : ''} failed to send. Please tell your team directly.`,
+        variant: 'destructive',
+      } as const;
+    case 'unknown':
+      return {
+        title: `${title} — notifications unconfirmed`,
+        description: `We could not confirm that employees were notified: ${outcome.message}`,
+        variant: 'destructive',
+      } as const;
+  }
+};
 
 export const useSchedulePublications = (restaurantId: string | null) => {
   const { data, isLoading, error } = useQuery({
@@ -65,38 +162,33 @@ export const usePublishSchedule = () => {
       });
 
       if (error) throw error;
-      
+
       const publicationId = data;
 
-      // Send push notifications asynchronously (don't await)
-      supabase.functions
-        .invoke('notify-schedule-published', {
-          body: {
-            publicationId,
-            restaurantId,
-            weekStart: weekStartStr,
-            weekEnd: weekEndStr,
-          },
-        })
-        .then((result) => {
-          if (result.error) {
-            console.error('Failed to send notifications:', result.error);
-          } else {
-            console.log('Notifications sent:', result.data);
-          }
-        });
-      
-      return { publicationId, restaurantId };
+      // Awaited, unlike before. The old call was fire-and-forget with a
+      // console.error, so a fan-out that reached nobody still produced a
+      // "Employees will be notified" toast and the manager had no way to know.
+      const notification = await invokeScheduleNotification('notify-schedule-published', {
+        publicationId,
+        restaurantId,
+        weekStart: weekStartStr,
+        weekEnd: weekEndStr,
+      });
+
+      return { publicationId, restaurantId, notification };
     },
-    onSuccess: ({ restaurantId }) => {
+    onSuccess: ({ restaurantId, notification }) => {
       // Invalidate relevant queries
       queryClient.invalidateQueries({ queryKey: ['shifts', restaurantId] });
       queryClient.invalidateQueries({ queryKey: ['schedule_publications', restaurantId] });
-      
-      toast({
-        title: 'Schedule Published',
-        description: 'The schedule has been published and locked. Employees will be notified.',
-      });
+
+      toast(
+        notificationToast(notification, {
+          title: 'Schedule Published',
+          successDescription:
+            'The schedule has been published and locked. Employees have been notified.',
+        }),
+      );
     },
     onError: (error: Error) => {
       toast({
@@ -127,19 +219,33 @@ export const useUnpublishSchedule = () => {
       });
 
       if (error) throw error;
-      
-      return { shiftCount: data, restaurantId };
+
+      const shiftCount = data as number;
+
+      // Nothing was actually retracted, so there is nobody to tell. Skipping
+      // the invoke keeps a double-tap on Unpublish off the error path.
+      const notification: NotificationOutcome =
+        shiftCount > 0
+          ? await invokeScheduleNotification('notify-schedule-unpublished', {
+              restaurantId,
+              weekStart: weekStartStr,
+            })
+          : { status: 'sent', sent: 0 };
+
+      return { shiftCount, restaurantId, notification };
     },
-    onSuccess: ({ shiftCount, restaurantId }) => {
+    onSuccess: ({ shiftCount, restaurantId, notification }) => {
       // Invalidate relevant queries
       queryClient.invalidateQueries({ queryKey: ['shifts', restaurantId] });
       queryClient.invalidateQueries({ queryKey: ['schedule_publications', restaurantId] });
       queryClient.invalidateQueries({ queryKey: ['schedule_change_logs', restaurantId] });
-      
-      toast({
-        title: 'Schedule Unpublished',
-        description: `${shiftCount} shift${shiftCount !== 1 ? 's' : ''} have been unlocked for editing.`,
-      });
+
+      toast(
+        notificationToast(notification, {
+          title: 'Schedule Unpublished',
+          successDescription: `${shiftCount} shift${shiftCount !== 1 ? 's' : ''} have been unlocked for editing. Affected employees have been told the week is being revised.`,
+        }),
+      );
     },
     onError: (error: Error) => {
       toast({
@@ -154,24 +260,38 @@ export const useUnpublishSchedule = () => {
 export const useWeekPublicationStatus = (
   restaurantId: string | null,
   weekStart: Date,
-  weekEnd: Date
+  weekEnd: Date,
+  timezone: string
 ) => {
   const { data, isLoading } = useQuery({
-    queryKey: ['week_publication_status', restaurantId, weekStart.toISOString(), weekEnd.toISOString()],
+    queryKey: [
+      'week_publication_status',
+      restaurantId,
+      weekStart.toISOString(),
+      weekEnd.toISOString(),
+      timezone,
+    ],
     queryFn: async () => {
       if (!restaurantId) return null;
 
       const weekStartStr = formatLocalDate(weekStart);
       const weekEndStr = formatLocalDate(weekEnd);
 
-      // Check if there are actually published shifts for this week
-      // (timestamptz column -> compare against full instants, not local-day strings)
+      // Count the same shifts publish_schedule acted on. It buckets by
+      // `(start_time AT TIME ZONE restaurant_tz)::date`; this used to send the
+      // browser-local midnight instants instead, so a manager in a different
+      // zone from the restaurant — or anyone looking at a Sunday-evening shift,
+      // which is already Monday in UTC — could see "Published" disagree with
+      // what publish actually did at the week edges.
+      const weekStartInstant = fromZonedTime(`${weekStartStr}T00:00:00`, timezone).toISOString();
+      const weekEndInstant = fromZonedTime(`${weekEndStr}T23:59:59.999`, timezone).toISOString();
+
       const { count: publishedShiftCount, error: shiftError } = await supabase
         .from('shifts')
         .select('id', { count: 'exact', head: true })
         .eq('restaurant_id', restaurantId)
-        .gte('start_time', weekStart.toISOString())
-        .lte('start_time', weekEnd.toISOString())
+        .gte('start_time', weekStartInstant)
+        .lte('start_time', weekEndInstant)
         .eq('is_published', true);
 
       if (shiftError) throw shiftError;

--- a/src/hooks/useSchedulePublish.tsx
+++ b/src/hooks/useSchedulePublish.tsx
@@ -231,7 +231,10 @@ export const useUnpublishSchedule = () => {
 
       if (error) throw error;
 
-      const shiftCount = data as number;
+      // PostgREST types the RPC return as nullable. A null here would make
+      // `shiftCount > 0` false and quietly skip the notification, so it is
+      // pinned to 0 rather than asserted away.
+      const shiftCount = (data as number | null) ?? 0;
 
       // Nothing was actually retracted, so there is nobody to tell. Skipping
       // the invoke keeps a double-tap on Unpublish off the error path.

--- a/src/hooks/useSchedulePublish.tsx
+++ b/src/hooks/useSchedulePublish.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { fromZonedTime } from 'date-fns-tz';
 import { supabase } from '@/integrations/supabase/client';
-import { SchedulePublication } from '@/types/scheduling';
+import { SchedulePublication, Shift } from '@/types/scheduling';
 import { useToast } from '@/hooks/use-toast';
 import { formatLocalDate } from '@/lib/shiftInterval';
 
@@ -255,6 +255,98 @@ export const useUnpublishSchedule = () => {
       });
     },
   });
+};
+
+/**
+ * What an employee's week actually is, as opposed to what it looks like.
+ *
+ * `useWeekPublicationStatus` collapses "was published, now fully retracted" into
+ * the same `null` it returns for "never published" — fine for the manager, who
+ * has the Publish button's own state to go by, but it is exactly the distinction
+ * an employee needs. That is the incident: a week was announced, then pulled back
+ * for edits, and the employee's view was indistinguishable from a week that had
+ * simply never been published.
+ */
+export type WeekScheduleState =
+  | 'not_published'
+  | 'published'
+  | 'published_revising'
+  | 'retracted';
+
+interface WeekScheduleStatus {
+  state: WeekScheduleState | null;
+  publication: SchedulePublication | null;
+  publishedCount: number;
+  draftCount: number;
+  loading: boolean;
+  error: unknown;
+}
+
+/**
+ * Counts come from shifts the caller already has — `EmployeeSchedule` filters
+ * the week down to `myShifts`, and the state model is defined over that
+ * employee's own shifts, not the restaurant's. Passing them in also keeps this
+ * query off the critical path: the day grid renders from `useShifts` while the
+ * banner resolves a beat later from its own single-row lookup.
+ */
+export const useWeekScheduleStatus = (
+  restaurantId: string | null,
+  weekStart: Date,
+  shifts: Pick<Shift, 'is_published'>[]
+): WeekScheduleStatus => {
+  const weekStartStr = formatLocalDate(weekStart);
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['week_schedule_status', restaurantId, weekStartStr],
+    queryFn: async () => {
+      if (!restaurantId) return null;
+
+      // Keyed on week_start_date alone and ordered newest-first on purpose. A
+      // week can carry several publication rows (every republish inserts one),
+      // and unlike useWeekPublicationStatus this lookup is NOT gated on shifts
+      // still being published — a retracted week has to stay findable, or state
+      // D collapses back into state A and the whole distinction is lost.
+      const { data, error } = await supabase
+        .from('schedule_publications')
+        .select('*')
+        .eq('restaurant_id', restaurantId)
+        .eq('week_start_date', weekStartStr)
+        .order('published_at', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+
+      if (error) throw error;
+      return (data as SchedulePublication | null) ?? null;
+    },
+    enabled: !!restaurantId,
+    staleTime: 30000,
+    refetchOnWindowFocus: true,
+  });
+
+  const publishedCount = shifts.filter((s) => s.is_published).length;
+  const draftCount = shifts.length - publishedCount;
+
+  // A wrong banner is worse than no banner, so an errored or in-flight lookup
+  // reports no state at all rather than guessing "not published".
+  const state: WeekScheduleState | null =
+    isLoading || error
+      ? null
+      : !data
+        ? 'not_published'
+        : publishedCount === 0
+          ? 'retracted'
+          : draftCount > 0
+            ? 'published_revising'
+            : 'published';
+
+  return {
+    state,
+    publication: data ?? null,
+    publishedCount,
+    draftCount,
+    loading: isLoading,
+    error,
+  };
 };
 
 export const useWeekPublicationStatus = (

--- a/src/hooks/useSchedulePublish.tsx
+++ b/src/hooks/useSchedulePublish.tsx
@@ -48,7 +48,48 @@ interface InvokeError {
  * that (which is what the old fire-and-forget `.then()` did) is what let a
  * publish where every email bounced still toast "Employees will be notified".
  */
+/**
+ * How long the dialog will sit with both its buttons disabled before giving up
+ * on the fan-out.
+ *
+ * Generous on purpose: the fan-out is paced to stay under Resend's 2 req/s
+ * limit, so it grows with headcount — a 60-person roster is legitimately ~30s
+ * of sending, and cutting that short would report a failure that never
+ * happened. But it is not unbounded: an edge function that hangs used to leave
+ * Publish and Cancel disabled with no way out but a page reload.
+ */
+const NOTIFICATION_TIMEOUT_MS = 90_000;
+
 export async function invokeScheduleNotification(
+  functionName: string,
+  body: Record<string, unknown>,
+  timeoutMs: number = NOTIFICATION_TIMEOUT_MS,
+): Promise<NotificationOutcome> {
+  // A race, not an AbortSignal: this repo's `FunctionInvokeOptions` has only
+  // `headers | method | region | body`, so there is nothing to pass a signal
+  // to. The request carries on in the background after we stop waiting —
+  // acceptable, because the send may well be succeeding and the alternative is
+  // a stuck dialog. The outcome is 'unknown', which is exactly true.
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<NotificationOutcome>((resolve) => {
+    timer = setTimeout(
+      () =>
+        resolve({
+          status: 'unknown',
+          message: `Notifications did not confirm within ${Math.round(timeoutMs / 1000)}s. They may still be sending.`,
+        }),
+      timeoutMs,
+    );
+  });
+
+  try {
+    return await Promise.race([invokeAndInterpret(functionName, body), timeout]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function invokeAndInterpret(
   functionName: string,
   body: Record<string, unknown>,
 ): Promise<NotificationOutcome> {
@@ -337,7 +378,16 @@ function deriveWeekScheduleState(
 export const useWeekScheduleStatus = (
   restaurantId: string | null,
   weekStart: Date,
-  shifts: Pick<Shift, 'is_published'>[]
+  shifts: Pick<Shift, 'is_published'>[],
+  /**
+   * Whether `shifts` is still loading. Load-bearing, not cosmetic: an empty
+   * array reads identically whether the employee has no shifts or the query
+   * hasn't answered yet, and those map to opposite banners. With the
+   * publication row already in the React Query cache, `isLoading` below is
+   * false, so a retracted week would render the quiet "Published …" line and
+   * then flip to the red banner once the shifts arrived.
+   */
+  shiftsLoading = false
 ): WeekScheduleStatus => {
   const weekStartStr = formatLocalDate(weekStart);
 
@@ -370,14 +420,15 @@ export const useWeekScheduleStatus = (
 
   const publishedCount = shifts.filter((s) => s.is_published).length;
   const draftCount = shifts.length - publishedCount;
-  const state = deriveWeekScheduleState(isLoading, error, data ?? null, publishedCount, draftCount);
+  const loading = isLoading || shiftsLoading;
+  const state = deriveWeekScheduleState(loading, error, data ?? null, publishedCount, draftCount);
 
   return {
     state,
     publication: data ?? null,
     publishedCount,
     draftCount,
-    loading: isLoading,
+    loading,
     error,
   };
 };

--- a/src/hooks/useSchedulePublish.tsx
+++ b/src/hooks/useSchedulePublish.tsx
@@ -306,6 +306,12 @@ function deriveWeekScheduleState(
 ): WeekScheduleState | null {
   if (isLoading || error) return null;
   if (!publication) return 'not_published';
+  // No shifts of any kind means this employee simply isn't on the roster this
+  // week — not that anything was pulled back. Unpublishing flips shifts to
+  // draft, it never deletes them, so a real retraction always leaves drafts
+  // behind. Without this, every unscheduled employee at a published restaurant
+  // would be told their schedule was withdrawn, every week they have off.
+  if (publishedCount === 0 && draftCount === 0) return 'published';
   if (publishedCount === 0) return 'retracted';
   if (draftCount > 0) return 'published_revising';
   return 'published';

--- a/src/hooks/useShifts.tsx
+++ b/src/hooks/useShifts.tsx
@@ -49,8 +49,8 @@ export function useShifts(
   restaurantId: string | null,
   startDate?: Date,
   endDate?: Date
-): { shifts: Shift[]; loading: boolean; error: Error | null } {
-  const { data, isLoading, error } = useQuery({
+): { shifts: Shift[]; loading: boolean; error: Error | null; refetch: () => void } {
+  const { data, isLoading, error, refetch } = useQuery({
     queryKey: ['shifts', restaurantId, startDate?.toISOString(), endDate?.toISOString()],
     queryFn: async () => {
       if (!restaurantId) return [];
@@ -83,6 +83,9 @@ export function useShifts(
     shifts: data || [],
     loading: isLoading,
     error,
+    // Exposed so a failed load can offer Retry rather than an empty grid that
+    // reads as "you are not working this week".
+    refetch,
   };
 }
 

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -6634,6 +6634,63 @@ export type Database = {
           },
         ]
       }
+      schedule_retractions: {
+        Row: {
+          employee_ids: string[]
+          id: string
+          notified_at: string | null
+          publication_id: string | null
+          reason: string | null
+          restaurant_id: string
+          retracted_at: string
+          retracted_by: string | null
+          shift_count: number
+          week_end_date: string
+          week_start_date: string
+        }
+        Insert: {
+          employee_ids?: string[]
+          id?: string
+          notified_at?: string | null
+          publication_id?: string | null
+          reason?: string | null
+          restaurant_id: string
+          retracted_at?: string
+          retracted_by?: string | null
+          shift_count?: number
+          week_end_date: string
+          week_start_date: string
+        }
+        Update: {
+          employee_ids?: string[]
+          id?: string
+          notified_at?: string | null
+          publication_id?: string | null
+          reason?: string | null
+          restaurant_id?: string
+          retracted_at?: string
+          retracted_by?: string | null
+          shift_count?: number
+          week_end_date?: string
+          week_start_date?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "schedule_retractions_publication_id_fkey"
+            columns: ["publication_id"]
+            isOneToOne: false
+            referencedRelation: "schedule_publications"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "schedule_retractions_restaurant_id_fkey"
+            columns: ["restaurant_id"]
+            isOneToOne: false
+            referencedRelation: "restaurants"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       scim_group_members: {
         Row: {
           created_at: string

--- a/src/lib/scheduleSeenFingerprint.ts
+++ b/src/lib/scheduleSeenFingerprint.ts
@@ -1,0 +1,145 @@
+/**
+ * "Has my schedule changed since I last looked?"
+ *
+ * There is no server-side per-user read tracking anywhere in the schema, and
+ * adding it is a real feature (table, RLS, write-on-view). This is the v1
+ * stand-in: a client-side fingerprint of what the employee last saw, compared
+ * against what they're seeing now.
+ *
+ * This is not the manual caching of server data CLAUDE.md prohibits. Nothing
+ * here is ever read *instead of* a query — the shifts always come from React
+ * Query, and this only decides whether to draw a pill on top of them. If
+ * localStorage is unavailable (private browsing, some native webviews) every
+ * function degrades to "no pill" rather than throwing.
+ */
+
+const KEY_PREFIX = 'schedule_seen_';
+
+/** Keys accumulate one per week ever viewed, so old ones are pruned on write. */
+const RETENTION_WEEKS = 8;
+const MS_PER_WEEK = 7 * 24 * 60 * 60 * 1000;
+
+export interface FingerprintShift {
+  id: string;
+  start_time: string;
+  end_time: string;
+  position: string;
+  status: string;
+}
+
+export interface FingerprintInput {
+  publishedAt: string | null;
+  shifts: FingerprintShift[];
+}
+
+/**
+ * A change-detection fingerprint, not a security boundary — FNV-1a is plenty.
+ * Anyone who can forge this can already write the localStorage key directly.
+ */
+function hash(input: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return (h >>> 0).toString(36);
+}
+
+/**
+ * Sorted by shift id so a reordered query result is not mistaken for a change.
+ * The fields are the ones an employee would act on — a shift moving, changing
+ * position, or being cancelled all have to register.
+ */
+export function computeScheduleFingerprint({ publishedAt, shifts }: FingerprintInput): string {
+  const rows = shifts
+    .map((s) => [s.id, s.start_time, s.end_time, s.position, s.status])
+    .sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0));
+  return hash(JSON.stringify({ publishedAt, rows }));
+}
+
+export function scheduleSeenKey(
+  restaurantId: string,
+  employeeId: string,
+  weekStartISO: string
+): string {
+  return `${KEY_PREFIX}${restaurantId}_${employeeId}_${weekStartISO}`;
+}
+
+function safeStorage(): Storage | null {
+  try {
+    const storage = globalThis.localStorage;
+    // Touching the object is not enough — Safari's private mode throws on the
+    // first write, not on access.
+    const probe = `${KEY_PREFIX}probe`;
+    storage.setItem(probe, '1');
+    storage.removeItem(probe);
+    return storage;
+  } catch {
+    return null;
+  }
+}
+
+export function readSeenFingerprint(
+  restaurantId: string,
+  employeeId: string,
+  weekStartISO: string
+): string | null {
+  const storage = safeStorage();
+  if (!storage) return null;
+  try {
+    return storage.getItem(scheduleSeenKey(restaurantId, employeeId, weekStartISO));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Prunes any `schedule_seen_*` key whose week is more than eight weeks behind
+ * `now`. Cheap and synchronous, and it keeps the namespace bounded over an
+ * employee's whole tenure without a migration or a scheduled job.
+ */
+export function writeSeenFingerprint(
+  restaurantId: string,
+  employeeId: string,
+  weekStartISO: string,
+  fingerprint: string,
+  now: Date = new Date()
+): void {
+  const storage = safeStorage();
+  if (!storage) return;
+
+  try {
+    const cutoff = now.getTime() - RETENTION_WEEKS * MS_PER_WEEK;
+    const stale: string[] = [];
+
+    for (let i = 0; i < storage.length; i++) {
+      const key = storage.key(i);
+      if (!key?.startsWith(KEY_PREFIX)) continue;
+      const weekSegment = key.slice(key.lastIndexOf('_') + 1);
+      const weekTime = Date.parse(`${weekSegment}T00:00:00Z`);
+      // An unparseable segment is not ours to interpret; leaving it costs one
+      // key, whereas deleting it could drop something another feature owns.
+      if (!Number.isNaN(weekTime) && weekTime < cutoff) stale.push(key);
+    }
+
+    stale.forEach((key) => storage.removeItem(key));
+    storage.setItem(scheduleSeenKey(restaurantId, employeeId, weekStartISO), fingerprint);
+  } catch {
+    // Quota exceeded, or storage disabled mid-session. The pill is cosmetic;
+    // failing to record "seen" only means it shows once more than needed.
+  }
+}
+
+/**
+ * True when the week looks different from what this employee last acknowledged.
+ *
+ * A first-ever view is deliberately NOT "updated" — an employee opening their
+ * schedule for the first time has nothing to have missed, and a pill there
+ * would train them to ignore it.
+ */
+export function hasScheduleChangedSinceSeen(
+  stored: string | null,
+  current: string
+): boolean {
+  return stored !== null && stored !== current;
+}

--- a/src/lib/scheduleSeenFingerprint.ts
+++ b/src/lib/scheduleSeenFingerprint.ts
@@ -25,6 +25,7 @@ export interface FingerprintShift {
   end_time: string;
   position: string;
   status: string;
+  is_published: boolean;
 }
 
 export interface FingerprintInput {
@@ -49,10 +50,18 @@ function hash(input: string): string {
  * Sorted by shift id so a reordered query result is not mistaken for a change.
  * The fields are the ones an employee would act on — a shift moving, changing
  * position, or being cancelled all have to register.
+ *
+ * `is_published` is in there because a retraction is otherwise invisible to
+ * this: unpublishing changes only `is_published`, `locked` and the shift's
+ * `published_at`, while the historical publication row's `published_at` — the
+ * one this hashes — stays exactly as it was. Without it, an employee who read
+ * the published week gets a byte-identical fingerprint after it is pulled back
+ * and never sees the "Updated since you last checked" pill on the one
+ * transition that most needs it.
  */
 export function computeScheduleFingerprint({ publishedAt, shifts }: FingerprintInput): string {
   const rows = shifts
-    .map((s) => [s.id, s.start_time, s.end_time, s.position, s.status])
+    .map((s) => [s.id, s.start_time, s.end_time, s.position, s.status, String(s.is_published)])
     .sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0));
   return hash(JSON.stringify({ publishedAt, rows }));
 }

--- a/src/lib/scheduling/deletionCopy.ts
+++ b/src/lib/scheduling/deletionCopy.ts
@@ -65,7 +65,7 @@ function formatClaimantNames(names: string[]): string {
   return `${first}, ${second} +${rest.length} more`;
 }
 
-function pluralize(count: number, singular: string, plural: string): string {
+export function pluralize(count: number, singular: string, plural: string): string {
   return count === 1 ? singular : plural;
 }
 

--- a/src/pages/EmployeeSchedule.tsx
+++ b/src/pages/EmployeeSchedule.tsx
@@ -83,11 +83,13 @@ const EmployeeSchedule = () => {
   // What this week actually IS, as opposed to what the rows look like: a week
   // that was announced and then pulled back is otherwise indistinguishable
   // from one nobody ever published.
-  const { state, publication, publishedCount, draftCount } = useWeekScheduleStatus(
-    restaurantId,
-    currentWeekStart,
-    myShifts
-  );
+  const {
+    state,
+    publication,
+    publishedCount,
+    draftCount,
+    loading: statusLoading,
+  } = useWeekScheduleStatus(restaurantId, currentWeekStart, myShifts);
   const retractionReason = useWeekRetractionReason(
     restaurantId,
     currentWeekStart,
@@ -113,11 +115,18 @@ const EmployeeSchedule = () => {
   // Read on arrival, then immediately record the visit. Reading into state
   // first is what keeps the pill on screen for the whole visit -- writing
   // without it would mark the week seen and erase the pill in the same commit.
+  //
+  // Both loading flags gate this, not just `shiftsLoading`. The fingerprint
+  // covers `published_at`, which arrives from a *different* query: writing
+  // while that one is still in flight stores a fingerprint with a null
+  // published_at, and the moment it resolves the effect re-fires, reads its own
+  // stale write back, and shows "Updated since you last checked" on a week
+  // where nothing changed.
   useEffect(() => {
-    if (!restaurantId || !employeeId || shiftsLoading) return;
+    if (!restaurantId || !employeeId || shiftsLoading || statusLoading) return;
     setSeenFingerprint(readSeenFingerprint(restaurantId, employeeId, weekStartStr));
     writeSeenFingerprint(restaurantId, employeeId, weekStartStr, fingerprint);
-  }, [restaurantId, employeeId, weekStartStr, fingerprint, shiftsLoading]);
+  }, [restaurantId, employeeId, weekStartStr, fingerprint, shiftsLoading, statusLoading]);
 
   const scheduleChangedSinceSeen = hasScheduleChangedSinceSeen(seenFingerprint, fingerprint);
 

--- a/src/pages/EmployeeSchedule.tsx
+++ b/src/pages/EmployeeSchedule.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useRef } from 'react';
+import { useState, useMemo, useRef, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -7,6 +7,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { useRestaurantContext } from '@/contexts/RestaurantContext';
 import { useCurrentEmployee } from '@/hooks/useCurrentEmployee';
 import { useShifts } from '@/hooks/useShifts';
+import { useWeekScheduleStatus, useWeekRetractionReason } from '@/hooks/useSchedulePublish';
 import { TradeRequestDialog } from '@/components/schedule/TradeRequestDialog';
 import { MyShiftTradesCard } from '@/components/schedule/MyShiftTradesCard';
 import {
@@ -15,19 +16,17 @@ import {
   EmployeePageSkeleton,
   EmployeeNotLinkedState,
   EmployeeInfoAlert,
+  ScheduleStatusBanner,
+  ScheduleUpdatedPill,
+  ShiftRow,
 } from '@/components/employee';
 import {
-  Calendar,
   Clock,
   ChevronLeft,
   ChevronRight,
   CalendarDays,
-  MapPin,
-  Coffee,
-  CheckCircle,
-  XCircle,
-  ClockIcon,
   ArrowLeftRight,
+  AlertTriangle,
 } from 'lucide-react';
 import {
   format,
@@ -38,75 +37,18 @@ import {
   eachDayOfInterval,
   parseISO,
   isToday,
-  isFuture,
-  isPast,
   differenceInMinutes,
 } from 'date-fns';
 import { WEEK_STARTS_ON } from '@/lib/dateConfig';
+import { safeTz } from '@/lib/restaurantClock';
+import { formatLocalDate } from '@/lib/shiftInterval';
+import {
+  computeScheduleFingerprint,
+  hasScheduleChangedSinceSeen,
+  readSeenFingerprint,
+  writeSeenFingerprint,
+} from '@/lib/scheduleSeenFingerprint';
 import { Shift } from '@/types/scheduling';
-
-const formatShiftDuration = (startTime: string, endTime: string, breakMinutes: number) => {
-  const start = new Date(startTime);
-  const end = new Date(endTime);
-  const totalMinutes = differenceInMinutes(end, start);
-  const netMinutes = totalMinutes - breakMinutes;
-  const hours = Math.floor(netMinutes / 60);
-  const minutes = netMinutes % 60;
-  return `${hours}h ${minutes}m`;
-};
-
-const getShiftStatusBadge = (shift: Shift) => {
-  const startTime = new Date(shift.start_time);
-  const endTime = new Date(shift.end_time);
-  const now = new Date();
-
-  if (shift.status === 'cancelled') {
-    return (
-      <Badge variant="destructive" className="flex items-center gap-1">
-        <XCircle className="h-3 w-3" />
-        Cancelled
-      </Badge>
-    );
-  }
-
-  if (isPast(endTime)) {
-    return (
-      <Badge variant="outline" className="flex items-center gap-1 bg-muted">
-        <CheckCircle className="h-3 w-3" />
-        Completed
-      </Badge>
-    );
-  }
-
-  if (now >= startTime && now <= endTime) {
-    return (
-      <Badge className="flex items-center gap-1 bg-green-500">
-        <ClockIcon className="h-3 w-3" />
-        In Progress
-      </Badge>
-    );
-  }
-
-  if (isToday(startTime)) {
-    return (
-      <Badge variant="default" className="flex items-center gap-1">
-        <Clock className="h-3 w-3" />
-        Today
-      </Badge>
-    );
-  }
-
-  if (isFuture(startTime)) {
-    return (
-      <Badge variant="outline" className="flex items-center gap-1">
-        <Calendar className="h-3 w-3" />
-        Upcoming
-      </Badge>
-    );
-  }
-
-  return null;
-};
 
 const EmployeeSchedule = () => {
   const { selectedRestaurant } = useRestaurantContext();
@@ -123,13 +65,61 @@ const EmployeeSchedule = () => {
   const weekDays = eachDayOfInterval({ start: currentWeekStart, end: weekEnd });
 
   const { currentEmployee, loading: employeeLoading } = useCurrentEmployee(restaurantId);
-  const { shifts, loading: shiftsLoading } = useShifts(restaurantId, currentWeekStart, weekEnd);
+  const {
+    shifts,
+    loading: shiftsLoading,
+    error: shiftsError,
+    refetch: refetchShifts,
+  } = useShifts(restaurantId, currentWeekStart, weekEnd);
 
   // Filter shifts to only show current employee's shifts
   const myShifts = useMemo(() => {
     if (!currentEmployee) return [];
     return shifts.filter((shift) => shift.employee_id === currentEmployee.id);
   }, [shifts, currentEmployee]);
+
+  const restaurantTimezone = safeTz(selectedRestaurant?.restaurant?.timezone);
+
+  // What this week actually IS, as opposed to what the rows look like: a week
+  // that was announced and then pulled back is otherwise indistinguishable
+  // from one nobody ever published.
+  const { state, publication, publishedCount, draftCount } = useWeekScheduleStatus(
+    restaurantId,
+    currentWeekStart,
+    myShifts
+  );
+  const retractionReason = useWeekRetractionReason(
+    restaurantId,
+    currentWeekStart,
+    state === 'retracted'
+  );
+
+  // "Has anything moved since I last looked?" There is no server-side read
+  // tracking, so this compares a fingerprint of what the employee last saw.
+  const fingerprint = useMemo(
+    () =>
+      computeScheduleFingerprint({
+        publishedAt: publication?.published_at ?? null,
+        shifts: myShifts,
+      }),
+    [publication?.published_at, myShifts]
+  );
+
+  const weekStartStr = formatLocalDate(currentWeekStart);
+  const employeeId = currentEmployee?.id ?? null;
+
+  const [seenFingerprint, setSeenFingerprint] = useState<string | null>(null);
+
+  // Read on arrival, then immediately record the visit. Reading into state
+  // first is what keeps the pill on screen for the whole visit -- writing
+  // without it would mark the week seen and erase the pill in the same commit.
+  useEffect(() => {
+    if (!restaurantId || !employeeId || shiftsLoading) return;
+    setSeenFingerprint(readSeenFingerprint(restaurantId, employeeId, weekStartStr));
+    writeSeenFingerprint(restaurantId, employeeId, weekStartStr, fingerprint);
+  }, [restaurantId, employeeId, weekStartStr, fingerprint, shiftsLoading]);
+
+  const scheduleChangedSinceSeen = hasScheduleChangedSinceSeen(seenFingerprint, fingerprint);
 
   // Group shifts by day
   const shiftsByDay = useMemo(() => {
@@ -177,6 +167,9 @@ const EmployeeSchedule = () => {
       .sort((a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime())
       .slice(0, 5);
   }, [myShifts]);
+
+  const allUpcomingAreDrafts =
+    upcomingShifts.length > 0 && upcomingShifts.every((shift) => !shift.is_published);
 
   const handlePreviousWeek = () => {
     setCurrentWeekStart(subWeeks(currentWeekStart, 1));
@@ -231,6 +224,18 @@ const EmployeeSchedule = () => {
         </Link>
       </div>
 
+      {/* Is this week actually mine? Above everything, because a retracted week
+          contradicts an email the employee may already have acted on. */}
+      <ScheduleStatusBanner
+        state={state}
+        publication={publication}
+        publishedCount={publishedCount}
+        draftCount={draftCount}
+        weekRange={`${format(currentWeekStart, 'MMM d')} - ${format(weekEnd, 'MMM d, yyyy')}`}
+        timezone={restaurantTimezone}
+        retractionReason={retractionReason}
+      />
+
       {/* My shift trades — poster tracker + claimant status */}
       <MyShiftTradesCard
         restaurantId={restaurantId}
@@ -238,55 +243,28 @@ const EmployeeSchedule = () => {
         fallbackFocusRef={pageHeaderRef}
       />
 
-      {/* Upcoming Shifts */}
+      {/* Upcoming Shifts. The green celebratory chrome is a claim that these
+          are locked in, so it only survives while at least one of them is. */}
       {upcomingShifts.length > 0 && (
-        <Card className="bg-gradient-to-br from-green-500/5 to-green-600/5 border-green-500/20">
+        <Card
+          className={
+            allUpcomingAreDrafts
+              ? 'bg-muted/20 border-border/40'
+              : 'bg-gradient-to-br from-green-500/5 to-green-600/5 border-green-500/20'
+          }
+        >
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
-              <Clock className="h-5 w-5 text-green-600" />
-              Upcoming Shifts
+              <Clock
+                className={`h-5 w-5 ${allUpcomingAreDrafts ? 'text-muted-foreground' : 'text-green-600'}`}
+              />
+              {allUpcomingAreDrafts ? 'Upcoming (tentative)' : 'Upcoming Shifts'}
             </CardTitle>
           </CardHeader>
           <CardContent>
             <div className="space-y-3">
               {upcomingShifts.map((shift) => (
-                <div
-                  key={shift.id}
-                  className="flex items-center justify-between p-3 rounded-lg bg-background border"
-                >
-                  <div className="flex items-center gap-4">
-                    <div className="text-center">
-                      <div className="text-sm font-medium text-muted-foreground">
-                        {format(parseISO(shift.start_time), 'EEE')}
-                      </div>
-                      <div className="text-2xl font-bold">
-                        {format(parseISO(shift.start_time), 'd')}
-                      </div>
-                      <div className="text-xs text-muted-foreground">
-                        {format(parseISO(shift.start_time), 'MMM')}
-                      </div>
-                    </div>
-                    <div>
-                      <div className="font-medium">
-                        {format(parseISO(shift.start_time), 'h:mm a')} -{' '}
-                        {format(parseISO(shift.end_time), 'h:mm a')}
-                      </div>
-                      <div className="text-sm text-muted-foreground flex items-center gap-2">
-                        <MapPin className="h-3 w-3" />
-                        {shift.position}
-                      </div>
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-3">
-                    {shift.break_duration > 0 && (
-                      <div className="flex items-center gap-1 text-sm text-muted-foreground">
-                        <Coffee className="h-3 w-3" />
-                        {shift.break_duration}m break
-                      </div>
-                    )}
-                    {getShiftStatusBadge(shift)}
-                  </div>
-                </div>
+                <ShiftRow key={shift.id} shift={shift} variant="upcoming" />
               ))}
             </div>
           </CardContent>
@@ -297,7 +275,10 @@ const EmployeeSchedule = () => {
       <Card>
         <CardHeader>
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-            <CardTitle>Weekly Schedule</CardTitle>
+            <div className="flex flex-wrap items-center gap-2">
+              <CardTitle>Weekly Schedule</CardTitle>
+              {scheduleChangedSinceSeen && <ScheduleUpdatedPill />}
+            </div>
             <div className="flex flex-col sm:flex-row items-start sm:items-center gap-2">
               <div className="flex items-center gap-2">
                 <Button
@@ -335,6 +316,23 @@ const EmployeeSchedule = () => {
                 <Skeleton key={i} className="h-20 w-full" />
               ))}
             </div>
+          ) : shiftsError ? (
+            /* An empty grid on a failed load reads as "you are not working this
+               week" -- the most costly possible misreading on this page. */
+            <div className="flex flex-col items-center gap-3 py-8 text-center">
+              <AlertTriangle className="h-6 w-6 text-destructive" />
+              <div>
+                <p className="text-[14px] font-medium text-foreground">
+                  We couldn't load your schedule
+                </p>
+                <p className="text-[13px] text-muted-foreground">
+                  This is a loading problem, not an empty week. Your shifts are still there.
+                </p>
+              </div>
+              <Button variant="outline" size="sm" onClick={() => refetchShifts()} className="min-h-[44px]">
+                Retry
+              </Button>
+            </div>
           ) : (
             <div className="space-y-3">
               {weekDays.map((day) => {
@@ -366,53 +364,7 @@ const EmployeeSchedule = () => {
                     ) : (
                       <div className="space-y-2">
                         {dayShifts.map((shift) => (
-                          <div
-                            key={shift.id}
-                            className={`flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 p-3 rounded-lg ${
-                              shift.status === 'cancelled'
-                                ? 'bg-destructive/10 line-through'
-                                : 'bg-muted/50'
-                            }`}
-                          >
-                            <div className="flex items-center gap-4">
-                              <div>
-                                <div className="font-medium">
-                                  {format(parseISO(shift.start_time), 'h:mm a')} -{' '}
-                                  {format(parseISO(shift.end_time), 'h:mm a')}
-                                </div>
-                                <div className="text-sm text-muted-foreground">
-                                  {shift.position}
-                                </div>
-                              </div>
-                            </div>
-                            <div className="flex flex-wrap items-center gap-2">
-                              <div className="text-sm text-muted-foreground">
-                                {formatShiftDuration(
-                                  shift.start_time,
-                                  shift.end_time,
-                                  shift.break_duration
-                                )}
-                              </div>
-                              {shift.break_duration > 0 && (
-                                <div className="flex items-center gap-1 text-xs text-muted-foreground">
-                                  <Coffee className="h-3 w-3" />
-                                  {shift.break_duration}m
-                                </div>
-                              )}
-                              {getShiftStatusBadge(shift)}
-                              {isFuture(parseISO(shift.start_time)) && shift.status !== 'cancelled' && (
-                                <Button
-                                  size="sm"
-                                  variant="outline"
-                                  onClick={() => handleTradeShift(shift)}
-                                  className="min-h-[44px]"
-                                >
-                                  <ArrowLeftRight className="h-4 w-4 mr-1" />
-                                  Trade
-                                </Button>
-                              )}
-                            </div>
-                          </div>
+                          <ShiftRow key={shift.id} shift={shift} onTrade={handleTradeShift} />
                         ))}
                       </div>
                     )}

--- a/src/pages/EmployeeSchedule.tsx
+++ b/src/pages/EmployeeSchedule.tsx
@@ -89,7 +89,15 @@ const EmployeeSchedule = () => {
     publishedCount,
     draftCount,
     loading: statusLoading,
-  } = useWeekScheduleStatus(restaurantId, currentWeekStart, myShifts);
+    // `employeeLoading` too, not just `shiftsLoading`: myShifts is filtered by
+    // `currentEmployee`, so it is empty until that resolves regardless of
+    // whether the shifts themselves have landed.
+  } = useWeekScheduleStatus(
+    restaurantId,
+    currentWeekStart,
+    myShifts,
+    shiftsLoading || employeeLoading
+  );
   const retractionReason = useWeekRetractionReason(
     restaurantId,
     currentWeekStart,

--- a/src/pages/Scheduling.tsx
+++ b/src/pages/Scheduling.tsx
@@ -312,7 +312,8 @@ const Scheduling = () => {
   const { publication, isPublished, loading: publicationLoading } = useWeekPublicationStatus(
     restaurantId,
     currentWeekStart,
-    weekEnd
+    weekEnd,
+    restaurantTimezone
   );
   const { changeLogs, loading: changeLogsLoading } = useScheduleChangeLogs(
     restaurantId,

--- a/src/types/scheduling.ts
+++ b/src/types/scheduling.ts
@@ -245,6 +245,12 @@ export interface SchedulePublication {
   shift_count: number;
   open_shifts_broadcast_at: string | null;
   open_shifts_broadcast_by: string | null;
+  /**
+   * Whether notify-schedule-published actually reached anyone for this row.
+   * Gates the retraction notification: pulling back a week nobody was told
+   * about should not generate the first message they ever receive about it.
+   */
+  notification_sent: boolean;
 }
 
 // Daily labor allocation for salaried/contractor employees

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -178,6 +178,9 @@ verify_jwt = true
 [functions.notify-schedule-published]
 verify_jwt = true
 
+[functions.notify-schedule-unpublished]
+verify_jwt = true
+
 [functions.notify-availability-reminder]
 verify_jwt = true
 

--- a/supabase/functions/_shared/emailQueue.ts
+++ b/supabase/functions/_shared/emailQueue.ts
@@ -100,8 +100,15 @@ export const sendEmailResult = async (
       signal: controller.signal,
     });
 
+    // Headers are in, so the deadline has done its job. Leaving it armed would
+    // let a slow body abort mid-read and turn a retryable 429 into a terminal
+    // status 0 — the exact distinction this module exists to preserve.
+    clearTimeout(timer);
+
     if (!response.ok) {
-      const body = await response.text();
+      // The status is what decides retryability; the body is only for the log.
+      // A truncated or unreadable body must not downgrade a 429 to a 0.
+      const body = await response.text().catch(errorMessage);
       return { ok: false, status: response.status, error: body };
     }
 

--- a/supabase/functions/_shared/emailQueue.ts
+++ b/supabase/functions/_shared/emailQueue.ts
@@ -148,7 +148,11 @@ export const sendPaced = async <T>(
 
   for (const recipient of recipients) {
     let attempts = 0;
-    let outcome: EmailSendResult = { ok: false, status: 0, error: 'not attempted' };
+    // No initializer: the only way out of the loop below is the `break`, and
+    // both paths into it assign. A placeholder here would be dead on every
+    // path, and would quietly become the reported result if a future edit ever
+    // did break out early.
+    let outcome: EmailSendResult;
 
     for (;;) {
       const waitMs = nextSendAt - now();

--- a/supabase/functions/_shared/emailQueue.ts
+++ b/supabase/functions/_shared/emailQueue.ts
@@ -1,0 +1,161 @@
+/**
+ * Paced Resend sender.
+ *
+ * Resend's default rate limit is 2 requests/second. `notify-schedule-published`
+ * historically fanned every recipient out at once through `Promise.allSettled`,
+ * so any roster past a handful started collecting 429s — invisibly, because the
+ * old `sendEmail` collapsed every outcome to a bare boolean.
+ *
+ * Two pieces live here:
+ *   - `sendEmailResult` — like `notificationHelpers.sendEmail`, but keeps the
+ *     HTTP status and body so a retryable 429 is distinguishable from a hard
+ *     bounce. `sendEmail` is now a one-line wrapper over it.
+ *   - `sendPaced` — walks recipients sequentially at <= 2/s, retrying 429s with
+ *     backoff, returning one result per recipient so callers can report partial
+ *     failure.
+ *
+ * The pacing is awaited idle wall time, not CPU, so it does not press the edge
+ * runtime's CPU budget. It does consume wall-clock: at 2/s the largest roster in
+ * production today (25) takes ~12.5s. `sendPaced` logs the count and elapsed
+ * time so that ceiling is observable well before a roster is large enough to
+ * threaten the request timeout — past a few hundred recipients the answer is a
+ * queue/cron drain, not a faster loop.
+ */
+
+/** Resend's default limit is 2 req/s. */
+export const RESEND_DEFAULT_INTERVAL_MS = 500;
+
+const DEFAULT_MAX_RETRIES = 3;
+const BASE_BACKOFF_MS = 1000;
+
+export interface EmailSendResult {
+  ok: boolean;
+  status: number;
+  error?: string;
+}
+
+export interface PacedResult<T> {
+  recipient: T;
+  ok: boolean;
+  status: number;
+  error?: string;
+  attempts: number;
+}
+
+export interface PacedOptions {
+  /** Minimum gap between send starts. Defaults to 2/s. */
+  intervalMs?: number;
+  /** Retries after the initial attempt, for 429s only. */
+  maxRetries?: number;
+  /** Injectable for tests. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Injectable for tests. */
+  now?: () => number;
+  /** Labels the summary log line. */
+  label?: string;
+}
+
+const realSleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+const errorMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+/**
+ * Send one email via Resend, preserving the HTTP status.
+ */
+export const sendEmailResult = async (
+  resendApiKey: string,
+  from: string,
+  to: string | string[],
+  subject: string,
+  html: string,
+): Promise<EmailSendResult> => {
+  try {
+    const response = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${resendApiKey}`,
+      },
+      body: JSON.stringify({
+        from,
+        to: Array.isArray(to) ? to : [to],
+        subject,
+        html,
+      }),
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      return { ok: false, status: response.status, error: body };
+    }
+
+    return { ok: true, status: response.status };
+  } catch (error) {
+    // status 0 means "never reached Resend" — a transport failure, not a
+    // rejection from the API.
+    return { ok: false, status: 0, error: errorMessage(error) };
+  }
+};
+
+/**
+ * Send to each recipient in order, at most `1000 / intervalMs` per second.
+ *
+ * A failure for one recipient never aborts the rest: every recipient gets
+ * exactly one result, in input order.
+ */
+export const sendPaced = async <T>(
+  recipients: T[],
+  send: (recipient: T) => Promise<EmailSendResult>,
+  options: PacedOptions = {},
+): Promise<PacedResult<T>[]> => {
+  if (recipients.length === 0) return [];
+
+  const intervalMs = options.intervalMs ?? RESEND_DEFAULT_INTERVAL_MS;
+  const maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+  const sleep = options.sleep ?? realSleep;
+  const now = options.now ?? (() => Date.now());
+
+  const startedAt = now();
+  const results: PacedResult<T>[] = [];
+  let nextSendAt = startedAt;
+
+  for (const recipient of recipients) {
+    let attempts = 0;
+    let outcome: EmailSendResult = { ok: false, status: 0, error: 'not attempted' };
+
+    for (;;) {
+      const waitMs = nextSendAt - now();
+      if (waitMs > 0) await sleep(waitMs);
+
+      attempts++;
+      // The interval is measured from when this send *starts*, so a send that
+      // itself outlasts the interval doesn't then wait out a second one.
+      const sentAt = now();
+      try {
+        outcome = await send(recipient);
+      } catch (error) {
+        outcome = { ok: false, status: 0, error: errorMessage(error) };
+      }
+      nextSendAt = sentAt + intervalMs;
+
+      const retryable = outcome.status === 429 && attempts <= maxRetries;
+      if (!retryable) break;
+
+      // Exponential backoff on top of the normal pacing gap: 1s, 2s, 4s.
+      await sleep(BASE_BACKOFF_MS * 2 ** (attempts - 1));
+      nextSendAt = now();
+    }
+
+    results.push({ recipient, attempts, ...outcome });
+  }
+
+  const failed = results.filter((r) => !r.ok).length;
+  console.log(
+    `[emailQueue]${options.label ? ` ${options.label}:` : ''} sent ${
+      results.length - failed
+    }/${results.length} in ${now() - startedAt}ms (${failed} failed)`,
+  );
+
+  return results;
+};

--- a/supabase/functions/_shared/emailQueue.ts
+++ b/supabase/functions/_shared/emailQueue.ts
@@ -28,6 +28,17 @@ export const RESEND_DEFAULT_INTERVAL_MS = 500;
 const DEFAULT_MAX_RETRIES = 3;
 const BASE_BACKOFF_MS = 1000;
 
+/**
+ * Per-request ceiling on the Resend call.
+ *
+ * `fetch` has no timeout of its own, so a connection Resend accepts and then
+ * stops answering hangs until the whole edge invocation is killed. That used to
+ * be somebody else's problem; now that the publish dialog awaits this fan-out,
+ * it is a manager staring at a spinner that never resolves. Aborting turns the
+ * hang into a status-0 result the pacer already knows how to record.
+ */
+const REQUEST_TIMEOUT_MS = 15_000;
+
 export interface EmailSendResult {
   ok: boolean;
   status: number;
@@ -70,6 +81,9 @@ export const sendEmailResult = async (
   subject: string,
   html: string,
 ): Promise<EmailSendResult> => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
   try {
     const response = await fetch('https://api.resend.com/emails', {
       method: 'POST',
@@ -83,6 +97,7 @@ export const sendEmailResult = async (
         subject,
         html,
       }),
+      signal: controller.signal,
     });
 
     if (!response.ok) {
@@ -93,8 +108,12 @@ export const sendEmailResult = async (
     return { ok: true, status: response.status };
   } catch (error) {
     // status 0 means "never reached Resend" — a transport failure, not a
-    // rejection from the API.
+    // rejection from the API. An abort lands here too, and is deliberately not
+    // retried: 429 is the only retryable status, and a stalled connection is
+    // not evidence the next one will answer any faster.
     return { ok: false, status: 0, error: errorMessage(error) };
+  } finally {
+    clearTimeout(timer);
   }
 };
 

--- a/supabase/functions/_shared/notificationHelpers.ts
+++ b/supabase/functions/_shared/notificationHelpers.ts
@@ -5,6 +5,10 @@
  */
 
 import { createClient, type SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { sendEmailResult } from "./emailQueue.ts";
+
+export { sendEmailResult, sendPaced } from "./emailQueue.ts";
+export type { EmailSendResult, PacedResult } from "./emailQueue.ts";
 
 /**
  * Get all managers for a restaurant
@@ -155,6 +159,11 @@ export const shouldSendNotification = async (
 /**
  * Send email using Resend
  * Returns true if successful
+ *
+ * Thin wrapper over `sendEmailResult` in `./emailQueue.ts`. Prefer that one for
+ * new code — it keeps the HTTP status, so a retryable 429 is distinguishable
+ * from a hard bounce. This signature is preserved because several functions
+ * call it and only care whether it worked.
  */
 export const sendEmail = async (
   resendApiKey: string,
@@ -163,32 +172,11 @@ export const sendEmail = async (
   subject: string,
   html: string
 ): Promise<boolean> => {
-  try {
-    const response = await fetch("https://api.resend.com/emails", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${resendApiKey}`,
-      },
-      body: JSON.stringify({
-        from,
-        to: Array.isArray(to) ? to : [to],
-        subject,
-        html,
-      }),
-    });
-
-    if (!response.ok) {
-      const error = await response.text();
-      console.error('Failed to send email:', error);
-      return false;
-    }
-
-    return true;
-  } catch (error) {
-    console.error('Error sending email:', error);
-    return false;
+  const result = await sendEmailResult(resendApiKey, from, to, subject, html);
+  if (!result.ok) {
+    console.error('Failed to send email:', result.error);
   }
+  return result.ok;
 };
 
 /**

--- a/supabase/functions/notify-schedule-published/index.ts
+++ b/supabase/functions/notify-schedule-published/index.ts
@@ -3,6 +3,7 @@ import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { fromZonedTime } from "https://esm.sh/date-fns-tz@3.2.0";
 import { corsHeaders } from "../_shared/cors.ts";
+import { sendEmailResult, sendPaced } from "../_shared/emailQueue.ts";
 import { sendWebPushToUser } from "../_shared/webPushHelper.ts";
 import { notifySchedulePublishedPush } from "../_shared/schedulePublishedPush.ts";
 import { resolveChannels, type SupabaseLike } from "../_shared/resolveChannels.ts";
@@ -151,14 +152,11 @@ serve(async (req) => {
     const appUrl = "https://app.easyshifthq.com/employee/schedule";
 
     // Send email notifications using Resend
-    const emailPromises = (ch.email ? scheduledEmployees : [])
-      .filter((emp) => emp.email) // Only send to employees with email
-      .map(async (employee) => {
-        const emailPayload = {
-          from: "EasyShiftHQ <notifications@easyshifthq.com>",
-          to: employee.email,
-          subject: `New Schedule Published: ${weekStartFormatted} - ${weekEndFormatted}`,
-          html: `
+    const emailRecipients = (ch.email ? scheduledEmployees : []).filter(
+      (emp) => emp.email
+    );
+
+    const buildEmailHtml = (employeeName: string) => `
             <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; max-width: 600px; margin: 0 auto; background-color: #ffffff;">
               ${generateHeader()}
               
@@ -167,7 +165,7 @@ serve(async (req) => {
                 <h1 style="color: #1f2937; font-size: 24px; font-weight: 600; margin: 0 0 16px 0; line-height: 1.3;">New Schedule Published</h1>
                 
                 <p style="color: #4b5563; line-height: 1.6; font-size: 16px; margin: 0 0 24px 0;">
-                  Hi <strong style="color: #1f2937;">${employee.name}</strong>,
+                  Hi <strong style="color: #1f2937;">${employeeName}</strong>,
                 </p>
                 
                 <p style="color: #4b5563; line-height: 1.6; font-size: 16px; margin: 0 0 24px 0;">
@@ -213,35 +211,35 @@ serve(async (req) => {
                 </p>
               </div>
             </div>
-          `,
-        };
+          `;
 
-        const response = await fetch("https://api.resend.com/emails", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${RESEND_API_KEY}`,
-          },
-          body: JSON.stringify(emailPayload),
-        });
+    // Paced rather than fanned out. Resend allows 2 requests/second and this
+    // used to fire every recipient at once through Promise.allSettled, so any
+    // roster past a handful started collecting 429s that nothing looked at.
+    const emailResults = await sendPaced(
+      emailRecipients,
+      (employee) =>
+        sendEmailResult(
+          RESEND_API_KEY ?? "",
+          "EasyShiftHQ <notifications@easyshifthq.com>",
+          employee.email,
+          `New Schedule Published: ${weekStartFormatted} - ${weekEndFormatted}`,
+          buildEmailHtml(employee.name)
+        ),
+      { label: `schedule-published ${publicationId}` }
+    );
 
-        if (!response.ok) {
-          const error = await response.text();
-          console.error(`Failed to send email to ${employee.email}:`, error);
-          return { success: false, email: employee.email, error };
-        }
+    for (const result of emailResults) {
+      if (!result.ok) {
+        console.error(
+          `Failed to send email to ${result.recipient.email} after ${result.attempts} attempt(s) [${result.status}]:`,
+          result.error
+        );
+      }
+    }
 
-        return { success: true, email: employee.email };
-      });
-
-    // Wait for all emails to be sent
-    const results = await Promise.allSettled(emailPromises);
-
-    // Count successes and failures
-    const successCount = results.filter(
-      (r) => r.status === "fulfilled" && r.value.success
-    ).length;
-    const failureCount = results.length - successCount;
+    const successCount = emailResults.filter((r) => r.ok).length;
+    const failureCount = emailResults.length - successCount;
 
     // Send web push notifications to all scheduled employees
     if (ch.push) {
@@ -255,27 +253,55 @@ serve(async (req) => {
       );
     }
 
-    // Update the publication record to mark notifications as sent
-    await supabase
-      .from("schedule_publications")
-      .update({ notification_sent: true })
-      .eq("id", publicationId);
+    // Every attempted email failed, so nobody was actually told. Leaving the row
+    // unmarked keeps the retraction notifier from later announcing the
+    // withdrawal of a schedule its audience never heard about, and the manager's
+    // failure toast prompts a republish that writes a fresh row anyway.
+    const announced = successCount > 0 || (failureCount === 0 && ch.push);
+
+    if (announced) {
+      // serviceClient, not `supabase`. This write used to go through the
+      // user-scoped client, and schedule_publications has no UPDATE policy, so
+      // RLS filtered it to zero rows -- silently, because a filtered-out UPDATE
+      // is not an error. Every publication row in production still reads
+      // notification_sent = false as a result, including ones that demonstrably
+      // delivered. The .select() is what makes the row count observable.
+      const { data: marked, error: markError } = await serviceClient
+        .from("schedule_publications")
+        .update({ notification_sent: true })
+        .eq("id", publicationId)
+        .select("id");
+
+      if (markError) {
+        console.error(
+          `Failed to mark publication ${publicationId} as notified:`,
+          markError
+        );
+      } else if (!marked?.length) {
+        console.error(
+          `Marked 0 rows notified for publication ${publicationId} -- the id does not exist.`
+        );
+      }
+    }
 
     // Log notification activity
     console.log(
       `Sent ${successCount} notifications, ${failureCount} failed for publication ${publicationId}`
     );
 
+    // A 200 here is what hid defect B: the caller could not tell a clean
+    // fan-out from one where every recipient bounced. The body is unchanged so
+    // the client can still report exactly how many got through.
     return new Response(
       JSON.stringify({
-        success: true,
+        success: failureCount === 0,
         sent: successCount,
         failed: failureCount,
         totalEmployees: scheduledEmployees.length,
       }),
       {
         headers: { ...corsHeaders, "Content-Type": "application/json" },
-        status: 200,
+        status: failureCount > 0 ? 502 : 200,
       }
     );
   } catch (error: unknown) {

--- a/supabase/functions/notify-schedule-published/index.ts
+++ b/supabase/functions/notify-schedule-published/index.ts
@@ -273,10 +273,15 @@ serve(async (req) => {
     const successCount = emailResults.filter((r) => r.ok).length;
     const failureCount = emailResults.length - successCount;
 
-    // Send web push notifications to all scheduled employees
+    // Send web push notifications to all scheduled employees. Deliveries are
+    // counted, not just attempted: push is the only channel for a restaurant
+    // with email off, and it reaches nobody when VAPID keys are unset or no one
+    // has subscribed.
+    let pushSentCount = 0;
+
     if (ch.push) {
-      await notifySchedulePublishedPush(scheduledEmployees, (userId) =>
-        sendWebPushToUser(serviceClient, userId, restaurantId, {
+      await notifySchedulePublishedPush(scheduledEmployees, async (userId) => {
+        const result = await sendWebPushToUser(serviceClient, userId, restaurantId, {
           title: isRepublish ? "Schedule Updated Again" : "Schedule Updated",
           body: isRepublish
             ? `${weekStartFormatted}–${weekEndFormatted} was revised and republished — check what changed.`
@@ -286,15 +291,20 @@ serve(async (req) => {
           // replaces an earlier notification still sitting in the tray instead
           // of stacking a second one next to copy it contradicts.
           tag: "schedule-published",
-        })
-      );
+        });
+        pushSentCount += result.sent;
+        return result;
+      });
     }
 
-    // Every attempted email failed, so nobody was actually told. Leaving the row
-    // unmarked keeps the retraction notifier from later announcing the
-    // withdrawal of a schedule its audience never heard about, and the manager's
-    // failure toast prompts a republish that writes a fresh row anyway.
-    const announced = successCount > 0 || (failureCount === 0 && ch.push);
+    // Marked notified only if somebody was actually reached, on either channel.
+    // `ch.push` on its own is not proof of delivery — an email-disabled
+    // restaurant with no push subscriptions would otherwise record a schedule
+    // as announced to an audience that heard nothing, and the retraction
+    // notifier's gate would later mail them about withdrawing it. Leaving the
+    // row unmarked also lets the manager's failure toast prompt a republish,
+    // which writes a fresh row anyway.
+    const announced = successCount > 0 || pushSentCount > 0;
 
     if (announced) {
       // serviceClient, not `supabase`. This write used to go through the
@@ -323,7 +333,7 @@ serve(async (req) => {
 
     // Log notification activity
     console.log(
-      `Sent ${successCount} notifications, ${failureCount} failed for publication ${publicationId}`
+      `Sent ${successCount} emails and ${pushSentCount} pushes, ${failureCount} emails failed for publication ${publicationId}`
     );
 
     // A 200 here is what hid defect B: the caller could not tell a clean

--- a/supabase/functions/notify-schedule-published/index.ts
+++ b/supabase/functions/notify-schedule-published/index.ts
@@ -316,10 +316,20 @@ serve(async (req) => {
       // is not an error. Every publication row in production still reads
       // notification_sent = false as a result, including ones that demonstrably
       // delivered. The .select() is what makes the row count observable.
+      //
+      // Scoped to the restaurant and week the caller was authorized for, not to
+      // publicationId alone. The permission check upstream validates
+      // restaurantId; publicationId arrives beside it as an independent value,
+      // and this is a service-role write, so RLS is not standing behind it.
+      // Filtering on the id by itself would let a manager of one restaurant
+      // mark another's publication announced -- and that flag is the gate the
+      // retraction notifier reads before mailing anyone.
       const { data: marked, error: markError } = await serviceClient
         .from("schedule_publications")
         .update({ notification_sent: true })
         .eq("id", publicationId)
+        .eq("restaurant_id", restaurantId)
+        .eq("week_start_date", weekStart)
         .select("id");
 
       if (markError) {
@@ -329,7 +339,7 @@ serve(async (req) => {
         );
       } else if (!marked?.length) {
         console.error(
-          `Marked 0 rows notified for publication ${publicationId} -- the id does not exist.`
+          `Marked 0 rows notified for publication ${publicationId} -- no such row for restaurant ${restaurantId}, week ${weekStart}.`
         );
       }
     }
@@ -340,19 +350,34 @@ serve(async (req) => {
     );
 
     // A 200 here is what hid defect B: the caller could not tell a clean
-    // fan-out from one where every recipient bounced. The body is unchanged so
-    // the client can still report exactly how many got through.
+    // fan-out from one where every recipient bounced.
+    //
+    // `reachedNobody` is the same rule notify-schedule-unpublished applies, and
+    // it is not covered by failureCount: with email disabled, or nobody on the
+    // roster holding an email address, emailResults is empty, failureCount is 0
+    // and a push fan-out that reached zero subscribers still answered 200. That
+    // is a manager being told their team knows about a schedule nobody
+    // received. `announced` above already refuses to latch notification_sent in
+    // that case; only the response was still claiming success.
+    //
+    // When nobody was reached, `failed` reports the whole audience rather than
+    // the email failure count. The client keys its toast off `failed > 0`, so a
+    // 502 carrying `failed: 0` degrades to "notifications unconfirmed" when the
+    // truth is the far more actionable "nobody was notified".
+    const reachedNobody = !announced && scheduledEmployees.length > 0;
+    const failed = reachedNobody || failureCount > 0;
+
     return new Response(
       JSON.stringify({
-        success: failureCount === 0,
+        success: !failed,
         sent: successCount,
-        failed: failureCount,
+        failed: reachedNobody ? scheduledEmployees.length : failureCount,
         pushSent: pushSentCount,
         totalEmployees: scheduledEmployees.length,
       }),
       {
         headers: { ...corsHeaders, "Content-Type": "application/json" },
-        status: failureCount > 0 ? 502 : 200,
+        status: failed ? 502 : 200,
       }
     );
   } catch (error: unknown) {

--- a/supabase/functions/notify-schedule-published/index.ts
+++ b/supabase/functions/notify-schedule-published/index.ts
@@ -263,8 +263,11 @@ serve(async (req) => {
 
     for (const result of emailResults) {
       if (!result.ok) {
+        // Employee id, not address: function logs are readable well outside the
+        // tenant, and a bounce log is not a reason to spill a roster's email
+        // addresses into them. The id joins back to the row anyway.
         console.error(
-          `Failed to send email to ${result.recipient.email} after ${result.attempts} attempt(s) [${result.status}]:`,
+          `Failed to send email to employee ${result.recipient.id} after ${result.attempts} attempt(s) [${result.status}]:`,
           result.error
         );
       }
@@ -344,6 +347,7 @@ serve(async (req) => {
         success: failureCount === 0,
         sent: successCount,
         failed: failureCount,
+        pushSent: pushSentCount,
         totalEmployees: scheduledEmployees.length,
       }),
       {

--- a/supabase/functions/notify-schedule-published/index.ts
+++ b/supabase/functions/notify-schedule-published/index.ts
@@ -148,6 +148,24 @@ serve(async (req) => {
     const weekStartFormatted = formatDate(weekStart);
     const weekEndFormatted = formatDate(weekEnd);
 
+    // Is this the first announcement for the week, or a revision of one people
+    // have already read? Identical copy for both is what leaves an employee
+    // unsure whether the email they just got supersedes the shifts they wrote
+    // on the fridge. Excluding the current row matters: publish_schedule has
+    // already inserted it, and this function is about to mark it notified.
+    const { data: priorPublication } = await serviceClient
+      .from("schedule_publications")
+      .select("id")
+      .eq("restaurant_id", restaurantId)
+      .eq("week_start_date", weekStart)
+      .eq("week_end_date", weekEnd)
+      .eq("notification_sent", true)
+      .neq("id", publicationId)
+      .limit(1)
+      .maybeSingle();
+
+    const isRepublish = !!priorPublication;
+
     // App URL for the button
     const appUrl = "https://app.easyshifthq.com/employee/schedule";
 
@@ -162,16 +180,23 @@ serve(async (req) => {
               
               <!-- Content -->
               <div style="padding: 40px 32px; background-color: #ffffff;">
-                <h1 style="color: #1f2937; font-size: 24px; font-weight: 600; margin: 0 0 16px 0; line-height: 1.3;">New Schedule Published</h1>
-                
+                <h1 style="color: #1f2937; font-size: 24px; font-weight: 600; margin: 0 0 16px 0; line-height: 1.3;">${isRepublish ? "Updated Schedule" : "New Schedule Published"}</h1>
+
                 <p style="color: #4b5563; line-height: 1.6; font-size: 16px; margin: 0 0 24px 0;">
                   Hi <strong style="color: #1f2937;">${employeeName}</strong>,
                 </p>
-                
+
                 <p style="color: #4b5563; line-height: 1.6; font-size: 16px; margin: 0 0 24px 0;">
                   Your schedule for <strong style="color: #1f2937;">${weekStartFormatted} - ${weekEndFormatted}</strong> has been published at <strong style="color: #1f2937;">${restaurant.name}</strong>.
                 </p>
-                
+                ${
+                  isRepublish
+                    ? `<p style="color: #4b5563; line-height: 1.6; font-size: 16px; margin: 0 0 24px 0;">
+                  This is an updated version — some shifts changed since your manager's earlier schedule for this week. Please review your shifts below before your next scheduled shift.
+                </p>`
+                    : ""
+                }
+
                 <div style="background: linear-gradient(135deg, #f0fdf4 0%, #dcfce7 100%); padding: 24px; border-radius: 12px; margin: 24px 0; border-left: 4px solid #10b981;">
                   <table style="width: 100%; border-collapse: collapse;">
                     <tr>
@@ -223,7 +248,9 @@ serve(async (req) => {
           RESEND_API_KEY ?? "",
           "EasyShiftHQ <notifications@easyshifthq.com>",
           employee.email,
-          `New Schedule Published: ${weekStartFormatted} - ${weekEndFormatted}`,
+          isRepublish
+            ? `Updated Schedule: ${weekStartFormatted} - ${weekEndFormatted} at ${restaurant.name} — changes made`
+            : `New Schedule Published: ${weekStartFormatted} - ${weekEndFormatted}`,
           buildEmailHtml(employee.name)
         ),
       { label: `schedule-published ${publicationId}` }
@@ -245,9 +272,14 @@ serve(async (req) => {
     if (ch.push) {
       await notifySchedulePublishedPush(scheduledEmployees, (userId) =>
         sendWebPushToUser(serviceClient, userId, restaurantId, {
-          title: "Schedule Updated",
-          body: "A new schedule has been published",
+          title: isRepublish ? "Schedule Updated Again" : "Schedule Updated",
+          body: isRepublish
+            ? `${weekStartFormatted}–${weekEndFormatted} was revised and republished — check what changed.`
+            : "A new schedule has been published",
           url: "/employee/schedule",
+          // Deliberately the same tag as a first publish, so a republish
+          // replaces an earlier notification still sitting in the tray instead
+          // of stacking a second one next to copy it contradicts.
           tag: "schedule-published",
         })
       );

--- a/supabase/functions/notify-schedule-published/index.ts
+++ b/supabase/functions/notify-schedule-published/index.ts
@@ -153,12 +153,17 @@ serve(async (req) => {
     // unsure whether the email they just got supersedes the shifts they wrote
     // on the fridge. Excluding the current row matters: publish_schedule has
     // already inserted it, and this function is about to mark it notified.
+    //
+    // Keyed on week_start_date alone, deliberately: week_end_date is not a
+    // stable key, because older rows in production carry an 8-day Sunday-Sunday
+    // span while current ones carry a 7-day Monday-start span. Matching on it
+    // would classify a genuine republish of such a week as a first publish.
+    // unpublish_schedule()'s own lookup keys the same way.
     const { data: priorPublication } = await serviceClient
       .from("schedule_publications")
       .select("id")
       .eq("restaurant_id", restaurantId)
       .eq("week_start_date", weekStart)
-      .eq("week_end_date", weekEnd)
       .eq("notification_sent", true)
       .neq("id", publicationId)
       .limit(1)

--- a/supabase/functions/notify-schedule-unpublished/index.ts
+++ b/supabase/functions/notify-schedule-unpublished/index.ts
@@ -264,8 +264,11 @@ serve(async (req) => {
 
       for (const result of emailResults) {
         if (!result.ok) {
+          // Employee id, not address: function logs are readable well outside
+          // the tenant, and a bounce log is not a reason to spill a roster's
+          // email addresses into them. The id joins back to the row anyway.
           console.error(
-            `Failed to send retraction email to ${result.recipient.email} after ${result.attempts} attempt(s) [${result.status}]:`,
+            `Failed to send retraction email to employee ${result.recipient.id} after ${result.attempts} attempt(s) [${result.status}]:`,
             result.error,
           );
         }

--- a/supabase/functions/notify-schedule-unpublished/index.ts
+++ b/supabase/functions/notify-schedule-unpublished/index.ts
@@ -1,0 +1,343 @@
+// Announce that a published week has been pulled back for revision.
+//
+// Retracting a live schedule used to tell nobody. Employees who had already
+// been emailed "New Schedule Published" kept believing a schedule that no
+// longer existed, and only found out when they turned up for a shift that had
+// been moved -- exactly the confusion this whole change set exists to remove.
+//
+// Everything is derived from persisted state given only {restaurantId,
+// weekStart}. The caller supplies no recipient list: a notification function
+// that mails whichever employee_ids arrive in the request body is a mail relay
+// for any authenticated user. The audience comes from the schedule_retractions
+// row that `unpublish_schedule` wrote inside its own transaction, which is the
+// only place it still exists -- the unpublish itself cleared is_published on
+// every shift that would otherwise identify it.
+
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { generateHeader } from "../_shared/emailTemplates.ts";
+import {
+  APP_URL,
+  NOTIFICATION_FROM,
+  authenticateRequest,
+  corsHeaders,
+  errorResponse,
+  handleCorsPreflightRequest,
+  sendEmailResult,
+  sendPaced,
+  verifyRestaurantPermission,
+} from "../_shared/notificationHelpers.ts";
+import { resolveChannels, type SupabaseLike } from "../_shared/resolveChannels.ts";
+import { sendWebPushToUsers } from "../_shared/webPushHelper.ts";
+import { runBounded } from "../_shared/webPushFanout.ts";
+
+const RESEND_API_KEY = Deno.env.get("RESEND_API_KEY");
+
+interface UnpublishNotificationPayload {
+  restaurantId: string;
+  weekStart: string;
+}
+
+interface RetractionEmployee {
+  id: string;
+  name: string;
+  email: string | null;
+  user_id: string | null;
+}
+
+const formatDate = (dateStr: string) =>
+  new Date(`${dateStr}T00:00:00Z`).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+
+const buildEmailHtml = (
+  employeeName: string,
+  restaurantName: string,
+  weekRange: string,
+  scheduleUrl: string,
+) => `
+  <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; max-width: 600px; margin: 0 auto; background-color: #ffffff;">
+    ${generateHeader()}
+
+    <div style="padding: 40px 32px; background-color: #ffffff;">
+      <h1 style="color: #1f2937; font-size: 24px; font-weight: 600; margin: 0 0 16px 0; line-height: 1.3;">Your Schedule Is Being Revised</h1>
+
+      <p style="color: #4b5563; line-height: 1.6; font-size: 16px; margin: 0 0 24px 0;">
+        Hi <strong style="color: #1f2937;">${employeeName}</strong>,
+      </p>
+
+      <p style="color: #4b5563; line-height: 1.6; font-size: 16px; margin: 0 0 24px 0;">
+        Your schedule for <strong style="color: #1f2937;">${weekRange}</strong> at
+        <strong style="color: #1f2937;">${restaurantName}</strong> is being revised by your manager.
+        The version you may have seen is no longer final &mdash; please don't rely on it yet.
+      </p>
+
+      <div style="background: linear-gradient(135deg, #fffbeb 0%, #fef3c7 100%); padding: 24px; border-radius: 12px; margin: 24px 0; border-left: 4px solid #f59e0b;">
+        <p style="color: #92400e; line-height: 1.6; font-size: 15px; margin: 0;">
+          You'll get another notification as soon as the updated schedule is published. If you have
+          questions in the meantime, contact your manager.
+        </p>
+      </div>
+
+      <div style="text-align: center; margin: 32px 0;">
+        <a href="${scheduleUrl}"
+           style="background-color: #4b5563; color: #ffffff !important; padding: 14px 32px; text-decoration: none; border-radius: 8px; display: inline-block; font-weight: 600; font-size: 16px; mso-padding-alt: 14px 32px; border: 2px solid #4b5563;">
+          <span style="color: #ffffff !important;">View My Schedule</span>
+        </a>
+      </div>
+    </div>
+
+    <div style="background-color: #f9fafb; padding: 24px 32px; border-radius: 0 0 8px 8px; border-top: 1px solid #e5e7eb;">
+      <p style="color: #6b7280; font-size: 13px; text-align: center; margin: 0; line-height: 1.5;">
+        <strong style="color: #4b5563;">EasyShiftHQ</strong><br>
+        Restaurant Operations Management System
+      </p>
+      <p style="color: #9ca3af; font-size: 12px; text-align: center; margin: 12px 0 0 0;">
+        &copy; ${new Date().getFullYear()} EasyShiftHQ. All rights reserved.
+      </p>
+      <p style="color: #9ca3af; font-size: 12px; text-align: center; margin: 8px 0 0 0;">
+        This is an automated notification. Please do not reply to this email.
+      </p>
+    </div>
+  </div>
+`;
+
+/** Nothing to announce. A 200 keeps this off the caller's error path. */
+const noop = (reason: string) => {
+  console.log(`notify-schedule-unpublished: ${reason}`);
+  return new Response(
+    JSON.stringify({ success: true, sent: 0, failed: 0, totalEmployees: 0, skipped: reason }),
+    { headers: { ...corsHeaders, "Content-Type": "application/json" }, status: 200 },
+  );
+};
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return handleCorsPreflightRequest();
+  }
+
+  try {
+    const { user, supabase } = await authenticateRequest(req);
+
+    const { restaurantId, weekStart }: UnpublishNotificationPayload = await req.json();
+    if (!restaurantId || !weekStart) {
+      return errorResponse("restaurantId and weekStart are required", 400);
+    }
+
+    await verifyRestaurantPermission(supabase, user.id, restaurantId);
+
+    const serviceClient = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
+    );
+
+    // Newest unnotified retraction for the week. A week can be published and
+    // retracted several times, and only the most recent retraction describes
+    // the version employees are currently holding.
+    const { data: retraction, error: retractionError } = await serviceClient
+      .from("schedule_retractions")
+      .select("id, publication_id, week_start_date, week_end_date, employee_ids")
+      .eq("restaurant_id", restaurantId)
+      .eq("week_start_date", weekStart)
+      .is("notified_at", null)
+      .order("retracted_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (retractionError) {
+      throw new Error(`Failed to read retraction: ${retractionError.message}`);
+    }
+    if (!retraction) {
+      return noop(`no unnotified retraction for ${restaurantId} week ${weekStart}`);
+    }
+
+    // Decision 2: don't announce the withdrawal of something nobody was told
+    // about. A missing publication_id means the same thing as an unnotified
+    // one -- there is no announcement to walk back -- so the null is handled
+    // explicitly rather than left to a join that would quietly drop the row.
+    if (!retraction.publication_id) {
+      return noop(`retraction ${retraction.id} has no publication to walk back`);
+    }
+
+    const { data: publication, error: publicationError } = await serviceClient
+      .from("schedule_publications")
+      .select("notification_sent")
+      .eq("id", retraction.publication_id)
+      .maybeSingle();
+
+    if (publicationError) {
+      throw new Error(`Failed to read publication: ${publicationError.message}`);
+    }
+    if (!publication?.notification_sent) {
+      return noop(`publication ${retraction.publication_id} was never announced`);
+    }
+
+    // Claim before sending, not after. Two managers unpublishing in quick
+    // succession, or a client retry, would otherwise each read notified_at as
+    // NULL and mail the same roster twice. Whoever wins this UPDATE sends; the
+    // loser sees zero rows and stops.
+    const { data: claimed, error: claimError } = await serviceClient
+      .from("schedule_retractions")
+      .update({ notified_at: new Date().toISOString() })
+      .eq("id", retraction.id)
+      .is("notified_at", null)
+      .select("id");
+
+    if (claimError) {
+      throw new Error(`Failed to claim retraction: ${claimError.message}`);
+    }
+    if (!claimed?.length) {
+      return noop(`retraction ${retraction.id} was already claimed by another run`);
+    }
+
+    // From here on the latch is held, so any early return must release it.
+    const release = async () => {
+      const { error } = await serviceClient
+        .from("schedule_retractions")
+        .update({ notified_at: null })
+        .eq("id", retraction.id);
+      if (error) {
+        console.error(`Failed to release retraction ${retraction.id}:`, error);
+      }
+    };
+
+    try {
+      const { data: restaurant, error: restError } = await serviceClient
+        .from("restaurants")
+        .select("name")
+        .eq("id", restaurantId)
+        .maybeSingle();
+
+      if (restError || !restaurant) {
+        throw new Error("Restaurant not found");
+      }
+
+      const employeeIds: string[] = retraction.employee_ids ?? [];
+      if (employeeIds.length === 0) {
+        await release();
+        return noop(`retraction ${retraction.id} has an empty audience`);
+      }
+
+      const { data: employees, error: empError } = await serviceClient
+        .from("employees")
+        .select("id, name, email, user_id")
+        .in("id", employeeIds)
+        .eq("status", "active");
+
+      if (empError) {
+        throw new Error(`Failed to fetch employees: ${empError.message}`);
+      }
+
+      const audience = (employees ?? []) as RetractionEmployee[];
+      const ch = await resolveChannels(
+        serviceClient as unknown as SupabaseLike,
+        restaurantId,
+        // Retractions ride the schedule_published gate rather than a channel
+        // type of their own: a restaurant that turned schedule notifications
+        // off does not want half of the pair to keep arriving.
+        "schedule_published",
+      );
+
+      const weekRange = `${formatDate(retraction.week_start_date)} - ${formatDate(retraction.week_end_date)}`;
+      const scheduleUrl = `${APP_URL}/employee/schedule`;
+
+      const emailRecipients = (ch.email ? audience : []).filter((emp) => emp.email);
+      const emailResults = await sendPaced(
+        emailRecipients,
+        (employee) =>
+          sendEmailResult(
+            RESEND_API_KEY ?? "",
+            NOTIFICATION_FROM,
+            employee.email as string,
+            `Schedule update: ${weekRange} at ${restaurant.name} is being revised`,
+            buildEmailHtml(employee.name, restaurant.name, weekRange, scheduleUrl),
+          ),
+        { label: `schedule-unpublished ${retraction.id}` },
+      );
+
+      for (const result of emailResults) {
+        if (!result.ok) {
+          console.error(
+            `Failed to send retraction email to ${result.recipient.email} after ${result.attempts} attempt(s) [${result.status}]:`,
+            result.error,
+          );
+        }
+      }
+
+      const successCount = emailResults.filter((r) => r.ok).length;
+      const failureCount = emailResults.length - successCount;
+
+      const pushTitle = "Schedule Being Revised";
+      const pushBody = `${weekRange} is no longer final — your manager is making changes.`;
+      const pushUserIds = audience
+        .map((emp) => emp.user_id)
+        .filter((id): id is string => !!id);
+
+      if (ch.push && pushUserIds.length > 0) {
+        // A distinct tag from "schedule-published" so a retraction never
+        // silently replaces the publish notice still sitting in the tray.
+        await sendWebPushToUsers(serviceClient, pushUserIds, restaurantId, {
+          title: pushTitle,
+          body: pushBody,
+          url: "/employee/schedule",
+          tag: "schedule-unpublished",
+        });
+
+        const supabaseUrl = Deno.env.get("SUPABASE_URL") ?? "";
+        const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+        await runBounded(pushUserIds, async (userId) => {
+          try {
+            await fetch(`${supabaseUrl}/functions/v1/send-push-notification`, {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${serviceKey}`,
+              },
+              body: JSON.stringify({
+                user_id: userId,
+                title: pushTitle,
+                body: pushBody,
+                data: { route: "/employee/schedule" },
+              }),
+            });
+          } catch (e) {
+            console.error(`Native push failed for ${userId}:`, e);
+          }
+        });
+      }
+
+      // Nobody was reached, so the announcement did not happen. Release the
+      // latch rather than leaving the retraction permanently marked notified.
+      if (emailResults.length > 0 && successCount === 0) {
+        await release();
+      }
+
+      console.log(
+        `Sent ${successCount} retraction notifications, ${failureCount} failed for retraction ${retraction.id}`,
+      );
+
+      return new Response(
+        JSON.stringify({
+          success: failureCount === 0,
+          sent: successCount,
+          failed: failureCount,
+          totalEmployees: audience.length,
+        }),
+        {
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+          status: failureCount > 0 ? 502 : 200,
+        },
+      );
+    } catch (error) {
+      await release();
+      throw error;
+    }
+  } catch (error: unknown) {
+    console.error("Error in notify-schedule-unpublished:", error);
+    const message = error instanceof Error ? error.message : "An error occurred";
+    return errorResponse(message, message === "Access denied" ? 403 : 500);
+  }
+});

--- a/supabase/functions/notify-schedule-unpublished/index.ts
+++ b/supabase/functions/notify-schedule-unpublished/index.ts
@@ -345,7 +345,11 @@ serve(async (req) => {
       // happen. Release the latch rather than leaving the retraction
       // permanently marked notified — the claim is what makes a retry possible,
       // and an un-retryable false success is the worst outcome here.
-      const reachedNobody = successCount === 0 && pushSuccessCount === 0;
+      // Guarded on a nonempty audience: every employee in the snapshot having
+      // since been deactivated leaves nobody to tell, and answering 502 there
+      // would send the manager chasing a delivery that was never owed.
+      const reachedNobody =
+        audience.length > 0 && successCount === 0 && pushSuccessCount === 0;
       if (reachedNobody) {
         await release();
       }
@@ -356,13 +360,18 @@ serve(async (req) => {
 
       // Reaching nobody is a failure even with an empty email list, otherwise a
       // push-only restaurant whose pushes all bounced reports a clean 200.
+      //
+      // And when nobody was reached, `failed` has to name the whole audience.
+      // The client keys its toast off `failed > 0`, so a 502 carrying
+      // `failed: 0` degrades to "notifications unconfirmed" when the truth is
+      // the far more actionable "nobody was notified -- tell your team".
       const failed = reachedNobody || failureCount > 0;
 
       return new Response(
         JSON.stringify({
           success: !failed,
           sent: successCount,
-          failed: failureCount,
+          failed: reachedNobody ? audience.length : failureCount,
           pushSent: pushSuccessCount,
           totalEmployees: audience.length,
         }),

--- a/supabase/functions/notify-schedule-unpublished/index.ts
+++ b/supabase/functions/notify-schedule-unpublished/index.ts
@@ -33,6 +33,9 @@ import { runBounded } from "../_shared/webPushFanout.ts";
 
 const RESEND_API_KEY = Deno.env.get("RESEND_API_KEY");
 
+/** Where all three channels — email link, web push, native push — point. */
+const SCHEDULE_PATH = "/employee/schedule";
+
 interface UnpublishNotificationPayload {
   restaurantId: string;
   weekStart: string;
@@ -243,7 +246,7 @@ serve(async (req) => {
       );
 
       const weekRange = `${formatDate(retraction.week_start_date)} - ${formatDate(retraction.week_end_date)}`;
-      const scheduleUrl = `${APP_URL}/employee/schedule`;
+      const scheduleUrl = `${APP_URL}${SCHEDULE_PATH}`;
 
       const emailRecipients = (ch.email ? audience : []).filter((emp) => emp.email);
       const emailResults = await sendPaced(
@@ -288,7 +291,7 @@ serve(async (req) => {
         const webPush = await sendWebPushToUsers(serviceClient, pushUserIds, restaurantId, {
           title: pushTitle,
           body: pushBody,
-          url: "/employee/schedule",
+          url: SCHEDULE_PATH,
           tag: "schedule-unpublished",
         });
         pushSuccessCount += webPush.sent;
@@ -307,7 +310,7 @@ serve(async (req) => {
                 user_id: userId,
                 title: pushTitle,
                 body: pushBody,
-                data: { route: "/employee/schedule" },
+                data: { route: SCHEDULE_PATH },
               }),
             });
             if (res.ok) pushSuccessCount += 1;

--- a/supabase/functions/notify-schedule-unpublished/index.ts
+++ b/supabase/functions/notify-schedule-unpublished/index.ts
@@ -137,15 +137,22 @@ serve(async (req) => {
       Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
     );
 
-    // Newest unnotified retraction for the week. A week can be published and
-    // retracted several times, and only the most recent retraction describes
-    // the version employees are currently holding.
+    // The newest retraction for the week, whatever its notified_at. A week can
+    // be published and retracted several times, and only the most recent
+    // retraction describes the version employees are currently holding.
+    //
+    // Ordering has to happen before the notified_at test, not after. Filtering
+    // on `notified_at IS NULL` first picks the newest *unnotified* row, which
+    // is a different row: retract twice in quick succession and the first call
+    // latches the newer one, then a retry finds the older one still unlatched
+    // and mails everyone about a version that was superseded before anyone
+    // heard of it. Selecting the newest row outright makes older ones
+    // permanently audit-only, which is what they are.
     const { data: retraction, error: retractionError } = await serviceClient
       .from("schedule_retractions")
-      .select("id, publication_id, week_start_date, week_end_date, employee_ids")
+      .select("id, publication_id, week_start_date, week_end_date, employee_ids, notified_at")
       .eq("restaurant_id", restaurantId)
       .eq("week_start_date", weekStart)
-      .is("notified_at", null)
       .order("retracted_at", { ascending: false })
       .limit(1)
       .maybeSingle();
@@ -154,7 +161,10 @@ serve(async (req) => {
       throw new Error(`Failed to read retraction: ${retractionError.message}`);
     }
     if (!retraction) {
-      return noop(`no unnotified retraction for ${restaurantId} week ${weekStart}`);
+      return noop(`no retraction for ${restaurantId} week ${weekStart}`);
+    }
+    if (retraction.notified_at) {
+      return noop(`retraction ${retraction.id} was already announced`);
     }
 
     // Decision 2: don't announce the withdrawal of something nobody was told

--- a/supabase/functions/notify-schedule-unpublished/index.ts
+++ b/supabase/functions/notify-schedule-unpublished/index.ts
@@ -205,28 +205,29 @@ serve(async (req) => {
     };
 
     try {
-      const { data: restaurant, error: restError } = await serviceClient
-        .from("restaurants")
-        .select("name")
-        .eq("id", restaurantId)
-        .maybeSingle();
-
-      if (restError || !restaurant) {
-        throw new Error("Restaurant not found");
-      }
-
       const employeeIds: string[] = retraction.employee_ids ?? [];
       if (employeeIds.length === 0) {
         await release();
         return noop(`retraction ${retraction.id} has an empty audience`);
       }
 
-      const { data: employees, error: empError } = await serviceClient
-        .from("employees")
-        .select("id, name, email, user_id")
-        .in("id", employeeIds)
-        .eq("status", "active");
+      // Independent lookups — the audience comes from the retraction row, not
+      // from the restaurant — so they overlap rather than queue up.
+      const [
+        { data: restaurant, error: restError },
+        { data: employees, error: empError },
+      ] = await Promise.all([
+        serviceClient.from("restaurants").select("name").eq("id", restaurantId).maybeSingle(),
+        serviceClient
+          .from("employees")
+          .select("id, name, email, user_id")
+          .in("id", employeeIds)
+          .eq("status", "active"),
+      ]);
 
+      if (restError || !restaurant) {
+        throw new Error("Restaurant not found");
+      }
       if (empError) {
         throw new Error(`Failed to fetch employees: ${empError.message}`);
       }
@@ -276,21 +277,27 @@ serve(async (req) => {
         .map((emp) => emp.user_id)
         .filter((id): id is string => !!id);
 
+      // Counted, not fire-and-forget: push is the *only* channel for a
+      // restaurant with email turned off, so if it silently reaches nobody the
+      // release below has to see that.
+      let pushSuccessCount = 0;
+
       if (ch.push && pushUserIds.length > 0) {
         // A distinct tag from "schedule-published" so a retraction never
         // silently replaces the publish notice still sitting in the tray.
-        await sendWebPushToUsers(serviceClient, pushUserIds, restaurantId, {
+        const webPush = await sendWebPushToUsers(serviceClient, pushUserIds, restaurantId, {
           title: pushTitle,
           body: pushBody,
           url: "/employee/schedule",
           tag: "schedule-unpublished",
         });
+        pushSuccessCount += webPush.sent;
 
         const supabaseUrl = Deno.env.get("SUPABASE_URL") ?? "";
         const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
         await runBounded(pushUserIds, async (userId) => {
           try {
-            await fetch(`${supabaseUrl}/functions/v1/send-push-notification`, {
+            const res = await fetch(`${supabaseUrl}/functions/v1/send-push-notification`, {
               method: "POST",
               headers: {
                 "Content-Type": "application/json",
@@ -303,32 +310,42 @@ serve(async (req) => {
                 data: { route: "/employee/schedule" },
               }),
             });
+            if (res.ok) pushSuccessCount += 1;
+            else console.error(`Native push for ${userId} returned ${res.status}`);
           } catch (e) {
             console.error(`Native push failed for ${userId}:`, e);
           }
         });
       }
 
-      // Nobody was reached, so the announcement did not happen. Release the
-      // latch rather than leaving the retraction permanently marked notified.
-      if (emailResults.length > 0 && successCount === 0) {
+      // Nobody was reached through any channel, so the announcement did not
+      // happen. Release the latch rather than leaving the retraction
+      // permanently marked notified — the claim is what makes a retry possible,
+      // and an un-retryable false success is the worst outcome here.
+      const reachedNobody = successCount === 0 && pushSuccessCount === 0;
+      if (reachedNobody) {
         await release();
       }
 
       console.log(
-        `Sent ${successCount} retraction notifications, ${failureCount} failed for retraction ${retraction.id}`,
+        `Sent ${successCount} retraction emails and ${pushSuccessCount} pushes, ${failureCount} emails failed for retraction ${retraction.id}`,
       );
+
+      // Reaching nobody is a failure even with an empty email list, otherwise a
+      // push-only restaurant whose pushes all bounced reports a clean 200.
+      const failed = reachedNobody || failureCount > 0;
 
       return new Response(
         JSON.stringify({
-          success: failureCount === 0,
+          success: !failed,
           sent: successCount,
           failed: failureCount,
+          pushSent: pushSuccessCount,
           totalEmployees: audience.length,
         }),
         {
           headers: { ...corsHeaders, "Content-Type": "application/json" },
-          status: failureCount > 0 ? 502 : 200,
+          status: failed ? 502 : 200,
         },
       );
     } catch (error) {

--- a/supabase/functions/notify-schedule-unpublished/index.ts
+++ b/supabase/functions/notify-schedule-unpublished/index.ts
@@ -231,9 +231,16 @@ serve(async (req) => {
         { data: employees, error: empError },
       ] = await Promise.all([
         serviceClient.from("restaurants").select("name").eq("id", restaurantId).maybeSingle(),
+        // restaurant_id is redundant against a correctly-written retraction row
+        // and deliberately kept anyway: this client is service-role, so RLS is
+        // not standing behind it, and `employeeIds` is the one input that
+        // reaches here as data rather than as a checked parameter. A tenant
+        // filter turns "the audience column was wrong" into zero recipients
+        // instead of somebody else's roster receiving mail.
         serviceClient
           .from("employees")
           .select("id, name, email, user_id")
+          .eq("restaurant_id", restaurantId)
           .in("id", employeeIds)
           .eq("status", "active"),
       ]);

--- a/supabase/migrations/20260802120000_schedule_retractions.sql
+++ b/supabase/migrations/20260802120000_schedule_retractions.sql
@@ -1,0 +1,204 @@
+-- Retraction notifications.
+--
+-- Unpublishing a live week told nobody. Employees who had already been emailed
+-- "New Schedule Published" kept believing a schedule that no longer existed.
+--
+-- The audience cannot be reconstructed after the fact: unpublish_schedule flips
+-- is_published to false on every affected row, erasing the very thing that says
+-- who was on the published version. And it must not be passed in by the client
+-- either -- an edge function that mails whichever employee_ids the caller hands
+-- it is an open relay. So it is captured inside this transaction, from the
+-- UPDATE's own RETURNING, and the notifier derives everything from that.
+
+CREATE TABLE IF NOT EXISTS public.schedule_retractions (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  restaurant_id   UUID NOT NULL REFERENCES public.restaurants(id) ON DELETE CASCADE,
+  publication_id  UUID REFERENCES public.schedule_publications(id) ON DELETE SET NULL,
+  week_start_date DATE NOT NULL,
+  week_end_date   DATE NOT NULL,
+  -- Audience snapshot, captured before the is_published flip is observable.
+  employee_ids    UUID[] NOT NULL DEFAULT '{}',
+  shift_count     INTEGER NOT NULL DEFAULT 0,
+  reason          TEXT,
+  retracted_by    UUID REFERENCES auth.users(id),
+  retracted_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  -- Idempotency latch, claimed by the notifier before it sends.
+  notified_at     TIMESTAMPTZ
+);
+
+-- Matches the notifier's lookup exactly: unnotified rows for a week, newest
+-- first. Retractions accumulate per week across publish/retract cycles.
+CREATE INDEX IF NOT EXISTS idx_schedule_retractions_lookup
+  ON public.schedule_retractions (restaurant_id, week_start_date, retracted_at DESC)
+  WHERE notified_at IS NULL;
+
+ALTER TABLE public.schedule_retractions ENABLE ROW LEVEL SECURITY;
+
+-- SELECT only, mirroring schedule_publications. Every write comes from the
+-- SECURITY DEFINER RPC below or from the notifier's service-role client, both
+-- of which bypass RLS. There is deliberately no UPDATE policy: a client-writable
+-- notified_at or employee_ids would let a manager forge who gets mailed, or
+-- suppress a retraction notice entirely. See the pgTAP test that pins this.
+DROP POLICY IF EXISTS "Users can view schedule retractions for their restaurants"
+  ON public.schedule_retractions;
+CREATE POLICY "Users can view schedule retractions for their restaurants"
+  ON public.schedule_retractions FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.user_restaurants ur
+      WHERE ur.restaurant_id = schedule_retractions.restaurant_id
+        AND ur.user_id = auth.uid()
+    )
+  );
+
+-- Default privileges in this database grant no DML on new public tables, so the
+-- SELECT policy above is inert without this grant. The omissions are the point:
+-- no INSERT/UPDATE/DELETE for authenticated, so a client cannot rewrite the
+-- audience or pre-claim notified_at even if a policy is later added by mistake.
+-- The RPC writes as the function owner and does not need a grant; the notifier
+-- reads and claims rows with the service-role key and does.
+GRANT SELECT ON public.schedule_retractions TO authenticated;
+GRANT SELECT, INSERT, UPDATE ON public.schedule_retractions TO service_role;
+
+COMMENT ON TABLE public.schedule_retractions IS
+  'One row per unpublish of a previously-published week. employee_ids is an '
+  'audience snapshot captured inside unpublish_schedule''s transaction, before '
+  'the is_published flip erases it. notified_at is an idempotency latch the '
+  'notify-schedule-unpublished function claims before sending.';
+
+COMMENT ON COLUMN public.schedule_retractions.employee_ids IS
+  'Employees who had published shifts in the retracted version. Never supplied '
+  'by a caller -- derived from the UPDATE''s RETURNING clause.';
+
+-- Recreated with the audience capture. RETURNS INTEGER is unchanged on purpose:
+-- CREATE OR REPLACE cannot alter a return type, and a DROP/recreate risks a
+-- later-merged migration silently reverting this one. SECURITY DEFINER and
+-- search_path are restated because CREATE OR REPLACE resets them if omitted.
+CREATE OR REPLACE FUNCTION public.unpublish_schedule(
+  p_restaurant_id UUID,
+  p_week_start DATE,
+  p_week_end DATE,
+  p_reason TEXT DEFAULT NULL
+)
+RETURNS INTEGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_shift_count INTEGER;
+  v_employee_ids UUID[];
+  v_publication_id UUID;
+  v_tz TEXT;
+BEGIN
+  -- Same authorization guard as publish_schedule; see the comment there.
+  -- Unpublishing another tenant's week is the more damaging direction of the
+  -- two: it clears is_published/locked and silently retracts a live schedule.
+  IF NOT public.user_has_restaurant_access(p_restaurant_id, false) THEN
+    RAISE EXCEPTION 'Not authorized to unpublish schedules for restaurant %', p_restaurant_id
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- Same resolution as publish_schedule; see the comment there.
+  SELECT r.timezone INTO v_tz
+  FROM public.restaurants r
+  WHERE r.id = p_restaurant_id;
+
+  v_tz := COALESCE(NULLIF(v_tz, ''), 'UTC');
+
+  BEGIN
+    PERFORM now() AT TIME ZONE v_tz;
+  EXCEPTION WHEN invalid_parameter_value THEN
+    v_tz := 'UTC';
+  END;
+
+  -- The count and the audience both come from the UPDATE's RETURNING rather
+  -- than from GET DIAGNOSTICS. Once this UPDATE feeds a CTE, GET DIAGNOSTICS
+  -- would report the *enclosing* statement's row count, so a 63-shift unpublish
+  -- would return 1 and the manager's toast would read "1 shift".
+  --
+  -- array_agg over zero rows yields NULL, not '{}', hence the COALESCE.
+  -- shifts.employee_id is NOT NULL today, so the FILTER is defensive rather
+  -- than load-bearing: employee_ids is NOT NULL as an array but would happily
+  -- store a NULL *element*, and the notifier would then look up an employee
+  -- that does not exist.
+  WITH updated_shifts AS (
+    UPDATE public.shifts s
+    SET
+      is_published = false,
+      locked = false,
+      published_at = NULL,
+      published_by = NULL
+    WHERE s.restaurant_id = p_restaurant_id
+      AND (s.start_time AT TIME ZONE v_tz)::date >= p_week_start
+      AND (s.start_time AT TIME ZONE v_tz)::date <= p_week_end
+      AND s.is_published = true
+    RETURNING s.employee_id
+  )
+  SELECT
+    count(*)::int,
+    COALESCE(array_agg(DISTINCT employee_id) FILTER (WHERE employee_id IS NOT NULL), '{}')
+  INTO v_shift_count, v_employee_ids
+  FROM updated_shifts;
+
+  -- Unpublishing a week with nothing currently published is routine (a
+  -- double-tap, or a week already retracted). Recording an empty retraction
+  -- would leave the notifier a row with no audience to special-case.
+  IF v_shift_count > 0 THEN
+    -- Republishing appends, so a week can have several publication rows; the
+    -- latest one is what employees were last told about.
+    SELECT sp.id INTO v_publication_id
+    FROM public.schedule_publications sp
+    WHERE sp.restaurant_id = p_restaurant_id
+      AND sp.week_start_date = p_week_start
+    ORDER BY sp.published_at DESC
+    LIMIT 1;
+
+    INSERT INTO public.schedule_retractions (
+      restaurant_id,
+      publication_id,
+      week_start_date,
+      week_end_date,
+      employee_ids,
+      shift_count,
+      reason,
+      retracted_by
+    ) VALUES (
+      p_restaurant_id,
+      v_publication_id,
+      p_week_start,
+      p_week_end,
+      v_employee_ids,
+      v_shift_count,
+      p_reason,
+      auth.uid()
+    );
+  END IF;
+
+  -- Log the unpublish action
+  INSERT INTO public.schedule_change_logs (
+    restaurant_id,
+    change_type,
+    changed_by,
+    reason
+  ) VALUES (
+    p_restaurant_id,
+    'unpublished',
+    auth.uid(),
+    COALESCE(p_reason, 'Schedule unpublished for date range: ' || p_week_start || ' to ' || p_week_end)
+  );
+
+  RETURN v_shift_count;
+END;
+$$;
+
+-- CREATE OR REPLACE preserves the existing ACL, but restate it so the grant
+-- posture is visible in this migration rather than only in the earlier one.
+REVOKE ALL ON FUNCTION public.unpublish_schedule(UUID, DATE, DATE, TEXT) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.unpublish_schedule(UUID, DATE, DATE, TEXT) TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.unpublish_schedule(UUID, DATE, DATE, TEXT) IS
+  'Unpublishes shifts in a date range (for corrections only). Uses the same '
+  'restaurant-local date bucketing as publish_schedule, and records a '
+  'schedule_retractions row snapshotting who had published shifts, so the '
+  'retraction can be announced after the is_published flip has erased it.';

--- a/supabase/migrations/20260802120000_schedule_retractions.sql
+++ b/supabase/migrations/20260802120000_schedule_retractions.sql
@@ -26,11 +26,16 @@ CREATE TABLE IF NOT EXISTS public.schedule_retractions (
   notified_at     TIMESTAMPTZ
 );
 
--- Matches the notifier's lookup exactly: unnotified rows for a week, newest
--- first. Retractions accumulate per week across publish/retract cycles.
+-- Matches the notifier's lookup exactly: rows for a week, newest first.
+-- Retractions accumulate per week across publish/retract cycles.
+--
+-- Deliberately not partial on `notified_at IS NULL`. The notifier takes the
+-- newest row outright and *then* checks the latch, because filtering unnotified
+-- rows first selects a different row -- retract twice quickly and a retry would
+-- find the older, still-unlatched row and announce a superseded version. A
+-- partial index could not serve that query.
 CREATE INDEX IF NOT EXISTS idx_schedule_retractions_lookup
-  ON public.schedule_retractions (restaurant_id, week_start_date, retracted_at DESC)
-  WHERE notified_at IS NULL;
+  ON public.schedule_retractions (restaurant_id, week_start_date, retracted_at DESC);
 
 -- schedule_publications only carries single-column indexes on restaurant_id and
 -- week_start_date, but every lookup added here -- useWeekScheduleStatus, the

--- a/supabase/migrations/20260802120000_schedule_retractions.sql
+++ b/supabase/migrations/20260802120000_schedule_retractions.sql
@@ -63,12 +63,22 @@ CREATE POLICY "Users can view schedule retractions for their restaurants"
     )
   );
 
--- Default privileges in this database grant no DML on new public tables, so the
--- SELECT policy above is inert without this grant. The omissions are the point:
--- no INSERT/UPDATE/DELETE for authenticated, so a client cannot rewrite the
--- audience or pre-claim notified_at even if a policy is later added by mistake.
--- The RPC writes as the function owner and does not need a grant; the notifier
--- reads and claims rows with the service-role key and does.
+-- Grants, stated outright rather than inherited.
+--
+-- Default privileges on new public tables are not the same everywhere: a stock
+-- Supabase project grants ALL to anon/authenticated, while some local stacks
+-- grant nothing. Either way the SELECT policy above is only live because of an
+-- explicit grant, and either way a table's write posture must not depend on
+-- which of those a given database happens to be. So revoke first, then grant
+-- exactly what each role needs.
+--
+-- The omissions are the point: no INSERT/UPDATE/DELETE for authenticated, so a
+-- client cannot rewrite the audience or pre-claim notified_at even if an UPDATE
+-- policy is later added by mistake -- which is precisely how schedule_publications
+-- ended up with a write that silently affected zero rows for months. The RPC
+-- writes as the function owner and needs no grant; the notifier reads and claims
+-- rows with the service-role key and does.
+REVOKE ALL ON public.schedule_retractions FROM PUBLIC, anon, authenticated;
 GRANT SELECT ON public.schedule_retractions TO authenticated;
 GRANT SELECT, INSERT, UPDATE ON public.schedule_retractions TO service_role;
 

--- a/supabase/migrations/20260802120000_schedule_retractions.sql
+++ b/supabase/migrations/20260802120000_schedule_retractions.sql
@@ -32,6 +32,13 @@ CREATE INDEX IF NOT EXISTS idx_schedule_retractions_lookup
   ON public.schedule_retractions (restaurant_id, week_start_date, retracted_at DESC)
   WHERE notified_at IS NULL;
 
+-- schedule_publications only carries single-column indexes on restaurant_id and
+-- week_start_date, but every lookup added here -- useWeekScheduleStatus, the
+-- isRepublish probe, and unpublish_schedule's own -- filters on the pair and
+-- takes the newest row. One composite serves all three.
+CREATE INDEX IF NOT EXISTS idx_schedule_publications_week_lookup
+  ON public.schedule_publications (restaurant_id, week_start_date, published_at DESC);
+
 ALTER TABLE public.schedule_retractions ENABLE ROW LEVEL SECURITY;
 
 -- SELECT only, mirroring schedule_publications. Every write comes from the

--- a/supabase/tests/schedule_retractions.test.sql
+++ b/supabase/tests/schedule_retractions.test.sql
@@ -14,12 +14,17 @@
 --   * the routine double-unpublish aborts the transaction, because array_agg
 --     over zero rows is NULL rather than '{}' and the column is NOT NULL.
 --
--- The last three assertions are a different subject: neither this table nor
--- schedule_publications may be written by a client. A table with no UPDATE
--- policy does not RAISE on UPDATE — RLS silently filters it to zero rows, which
--- is exactly the mechanism that let notify-schedule-published believe it had
--- recorded notification_sent for a year. So they assert an affected-row count of
--- zero, not throws_ok.
+-- The closing assertions are a different subject: neither this table nor
+-- schedule_publications may be written by a client, and the two are blocked by
+-- different mechanisms. schedule_publications holds the table-level UPDATE grant
+-- and relies on the absent policy — and a table with no UPDATE policy does not
+-- RAISE, RLS silently filters it to zero rows, which is exactly the mechanism
+-- that let notify-schedule-published believe it had recorded notification_sent
+-- for a year. So that one asserts an affected-row count of zero, not throws_ok.
+-- schedule_retractions revokes the grant outright, so it raises 42501, and a
+-- separate assertion pins the revoke itself: default privileges on new public
+-- tables differ between a stock Supabase project and a bare local stack, and a
+-- write posture that depends on the host is not a posture.
 --
 -- Auth context follows publish_schedule_tz_bucketing.test.sql: the suite stays
 -- as postgres and drives auth.uid() through request.jwt.claims, which is
@@ -32,7 +37,7 @@
 
 BEGIN;
 
-SELECT plan(21);
+SELECT plan(22);
 
 -- ============================================
 -- Setup
@@ -426,7 +431,17 @@ SELECT set_config(
   true
 );
 
--- Test 21
+-- Test 21 -- the REVOKE the migration issues before its grants, pinned
+-- directly. Without it this table's write posture would depend on the host:
+-- a stock Supabase project grants ALL on new public tables to authenticated,
+-- a bare local stack grants nothing, and the difference is invisible until
+-- test 22 catches a client write in one environment and not the other.
+SELECT ok(
+  NOT has_table_privilege('authenticated', 'public.schedule_retractions', 'UPDATE'),
+  'authenticated holds no UPDATE grant on schedule_retractions, whatever the default privileges were'
+);
+
+-- Test 22
 SELECT throws_ok(
   $$ UPDATE schedule_retractions SET notified_at = now()
        WHERE restaurant_id = 'c0000000-0000-0000-0000-00000000a001' $$,

--- a/supabase/tests/schedule_retractions.test.sql
+++ b/supabase/tests/schedule_retractions.test.sql
@@ -1,0 +1,414 @@
+-- pgTAP tests for the retraction audience snapshot
+-- (supabase/migrations/20260802120000_schedule_retractions.sql).
+--
+-- Unpublishing a live week told nobody, because after the fact there is nothing
+-- left to tell: unpublish_schedule flips is_published to false on every affected
+-- row, erasing the only record of who was on the published version. So the
+-- audience is captured inside the function's own transaction, from the UPDATE's
+-- RETURNING clause, and these tests pin the three ways that capture can be wrong:
+--
+--   * the count regresses to the retraction INSERT's row count (the GET
+--     DIAGNOSTICS trap once the UPDATE feeds a CTE),
+--   * the audience includes people it must not — drafts, prior-week shifts — or
+--     double-counts someone who worked twice that week,
+--   * the routine double-unpublish aborts the transaction, because array_agg
+--     over zero rows is NULL rather than '{}' and the column is NOT NULL.
+--
+-- The last three assertions are a different subject: neither this table nor
+-- schedule_publications may be written by a client. A table with no UPDATE
+-- policy does not RAISE on UPDATE — RLS silently filters it to zero rows, which
+-- is exactly the mechanism that let notify-schedule-published believe it had
+-- recorded notification_sent for a year. So they assert an affected-row count of
+-- zero, not throws_ok.
+--
+-- Auth context follows publish_schedule_tz_bucketing.test.sql: the suite stays
+-- as postgres and drives auth.uid() through request.jwt.claims, which is
+-- role-independent. Only the closing RLS block switches role, after the last
+-- ALTER TABLE.
+--
+-- No hardcoded calendar dates: the week is anchored to the next Monday after
+-- CURRENT_DATE, and instants are built as `<local timestamp> AT TIME ZONE
+-- '<iana>'` so the fixtures survive the CST/CDT transition.
+
+BEGIN;
+
+SELECT plan(20);
+
+-- ============================================
+-- Setup
+-- ============================================
+
+SET LOCAL role TO postgres;
+ALTER TABLE restaurants            DISABLE ROW LEVEL SECURITY;
+ALTER TABLE employees              DISABLE ROW LEVEL SECURITY;
+ALTER TABLE shifts                 DISABLE ROW LEVEL SECURITY;
+ALTER TABLE schedule_publications  DISABLE ROW LEVEL SECURITY;
+ALTER TABLE schedule_change_logs   DISABLE ROW LEVEL SECURITY;
+ALTER TABLE user_restaurants       DISABLE ROW LEVEL SECURITY;
+
+-- Next Monday from today. ISODOW: Monday = 1 ... Sunday = 7, so 8 - ISODOW is
+-- always in [1, 7] and never resolves to today.
+CREATE TEMP TABLE retraction_config AS
+SELECT
+  (CURRENT_DATE + (8 - EXTRACT(ISODOW FROM CURRENT_DATE)::int))     AS week_start,
+  (CURRENT_DATE + (8 - EXTRACT(ISODOW FROM CURRENT_DATE)::int)) + 6 AS week_end;
+
+-- auth.uid() source for retracted_by / changed_by.
+INSERT INTO auth.users (id, instance_id, aud, role, email, encrypted_password, email_confirmed_at, created_at, updated_at, confirmation_token, recovery_token, email_change_token_new, email_change)
+VALUES (
+  'c0117000-0000-0000-0000-000000000001',
+  '00000000-0000-0000-0000-000000000000',
+  'authenticated', 'authenticated',
+  'retraction-test@example.com',
+  crypt('password123', gen_salt('bf')),
+  now(), now(), now(), '', '', '', ''
+)
+ON CONFLICT (id) DO NOTHING;
+
+SELECT set_config(
+  'request.jwt.claims',
+  '{"sub":"c0117000-0000-0000-0000-000000000001","role":"authenticated"}',
+  true
+);
+
+-- America/Chicago, so the Sunday-night closing shift below lands on the
+-- following UTC day and the restaurant-local bucketing is actually exercised.
+-- DO UPDATE, not DO NOTHING: a retained row from an earlier run carrying a
+-- different zone would silently invalidate the week-edge assertion.
+INSERT INTO restaurants (id, name, timezone) VALUES
+  ('c0000000-0000-0000-0000-00000000a001', 'Retraction Test Restaurant', 'America/Chicago')
+ON CONFLICT (id) DO UPDATE
+  SET name = EXCLUDED.name, timezone = EXCLUDED.timezone;
+
+INSERT INTO employees (id, restaurant_id, name, position) VALUES
+  ('c0000000-0000-0000-0000-0000000000e1', 'c0000000-0000-0000-0000-00000000a001', 'Two Shift Server', 'Server'),
+  ('c0000000-0000-0000-0000-0000000000e2', 'c0000000-0000-0000-0000-00000000a001', 'Closing Server',   'Server'),
+  ('c0000000-0000-0000-0000-0000000000e3', 'c0000000-0000-0000-0000-00000000a001', 'Draft Only Cook',  'Cook')
+ON CONFLICT (id) DO UPDATE
+  SET restaurant_id = EXCLUDED.restaurant_id, name = EXCLUDED.name, position = EXCLUDED.position;
+
+-- unpublish_schedule requires the caller to be a member of the target
+-- restaurant; without this every call below fails with insufficient_privilege
+-- before any audience capture is exercised.
+INSERT INTO user_restaurants (user_id, restaurant_id, role) VALUES
+  ('c0117000-0000-0000-0000-000000000001', 'c0000000-0000-0000-0000-00000000a001', 'owner')
+ON CONFLICT (user_id, restaurant_id) DO UPDATE SET role = EXCLUDED.role;
+
+-- --- Shift fixtures ---
+--
+-- Published, in-week:
+--   s1, s2  e1, two shifts    -> e1 must appear ONCE, not twice
+--   s3      e2, Sun 22:00     -> in-week only under restaurant-local bucketing
+-- Excluded:
+--   s4      e3, draft         -> never announced, so never retracted
+--   s6      e3, prior week    -> published, but belongs to the week before
+--
+-- There is deliberately no unassigned-shift fixture: shifts.employee_id is NOT
+-- NULL, so the FILTER in the RPC has nothing to catch here and a test for it
+-- would only assert the column constraint.
+
+INSERT INTO shifts (id, restaurant_id, employee_id, start_time, end_time, position, is_published, locked)
+SELECT
+  'c0000000-0000-0000-0000-00000000f001',
+  'c0000000-0000-0000-0000-00000000a001',
+  'c0000000-0000-0000-0000-0000000000e1',
+  (week_start::timestamp + interval '10 hours') AT TIME ZONE 'America/Chicago',
+  (week_start::timestamp + interval '18 hours') AT TIME ZONE 'America/Chicago',
+  'Server', true, true
+FROM retraction_config;
+
+INSERT INTO shifts (id, restaurant_id, employee_id, start_time, end_time, position, is_published, locked)
+SELECT
+  'c0000000-0000-0000-0000-00000000f002',
+  'c0000000-0000-0000-0000-00000000a001',
+  'c0000000-0000-0000-0000-0000000000e1',
+  ((week_start + 1)::timestamp + interval '10 hours') AT TIME ZONE 'America/Chicago',
+  ((week_start + 1)::timestamp + interval '18 hours') AT TIME ZONE 'America/Chicago',
+  'Server', true, true
+FROM retraction_config;
+
+-- Sunday (week_end) 22:00 local -> 03:00 UTC the following Monday.
+INSERT INTO shifts (id, restaurant_id, employee_id, start_time, end_time, position, is_published, locked)
+SELECT
+  'c0000000-0000-0000-0000-00000000f003',
+  'c0000000-0000-0000-0000-00000000a001',
+  'c0000000-0000-0000-0000-0000000000e2',
+  (week_end::timestamp + interval '22 hours') AT TIME ZONE 'America/Chicago',
+  (week_end::timestamp + interval '26 hours') AT TIME ZONE 'America/Chicago',
+  'Server', true, true
+FROM retraction_config;
+
+INSERT INTO shifts (id, restaurant_id, employee_id, start_time, end_time, position, is_published, locked)
+SELECT
+  'c0000000-0000-0000-0000-00000000f004',
+  'c0000000-0000-0000-0000-00000000a001',
+  'c0000000-0000-0000-0000-0000000000e3',
+  ((week_start + 2)::timestamp + interval '10 hours') AT TIME ZONE 'America/Chicago',
+  ((week_start + 2)::timestamp + interval '18 hours') AT TIME ZONE 'America/Chicago',
+  'Cook', false, false
+FROM retraction_config;
+
+-- Sunday (week_start - 1) 22:00 local -> 03:00 UTC on week_start: previous week.
+INSERT INTO shifts (id, restaurant_id, employee_id, start_time, end_time, position, is_published, locked)
+SELECT
+  'c0000000-0000-0000-0000-00000000f006',
+  'c0000000-0000-0000-0000-00000000a001',
+  'c0000000-0000-0000-0000-0000000000e3',
+  ((week_start - 1)::timestamp + interval '22 hours') AT TIME ZONE 'America/Chicago',
+  ((week_start - 1)::timestamp + interval '26 hours') AT TIME ZONE 'America/Chicago',
+  'Cook', true, true
+FROM retraction_config;
+
+-- Two publications for the same week: republishing appends rather than
+-- replaces, so the retraction must link the LATEST one, not an arbitrary row.
+INSERT INTO schedule_publications
+  (id, restaurant_id, week_start_date, week_end_date, published_by, published_at, shift_count, notification_sent)
+SELECT
+  'c0000000-0000-0000-0000-00000000b001',
+  'c0000000-0000-0000-0000-00000000a001',
+  week_start, week_end,
+  'c0117000-0000-0000-0000-000000000001',
+  now(), 3, true
+FROM retraction_config;
+
+INSERT INTO schedule_publications
+  (id, restaurant_id, week_start_date, week_end_date, published_by, published_at, shift_count, notification_sent)
+SELECT
+  'c0000000-0000-0000-0000-00000000b000',
+  'c0000000-0000-0000-0000-00000000a001',
+  week_start, week_end,
+  'c0117000-0000-0000-0000-000000000001',
+  now() - interval '2 days', 3, true
+FROM retraction_config;
+
+-- ============================================
+-- Structure
+-- ============================================
+
+-- Test 1
+SELECT has_table('public', 'schedule_retractions', 'schedule_retractions table exists');
+
+-- Test 2
+SELECT ok(
+  (SELECT relrowsecurity FROM pg_class c
+     JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public' AND c.relname = 'schedule_retractions'),
+  'schedule_retractions has RLS enabled'
+);
+
+-- Test 3 -- a client-writable employee_ids would let a manager choose who gets
+-- mailed; a client-writable notified_at would let one suppress the notice.
+SELECT is(
+  (SELECT count(*)::int FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'schedule_retractions'
+      AND cmd IN ('UPDATE', 'INSERT', 'DELETE', 'ALL')),
+  0,
+  'schedule_retractions has no client write policy'
+);
+
+-- Test 4 -- the shape that caused the original bug, pinned so a later migration
+-- cannot "helpfully" add the UPDATE policy the edge function seemed to want.
+SELECT is(
+  (SELECT count(*)::int FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'schedule_publications'
+      AND cmd IN ('UPDATE', 'ALL')),
+  0,
+  'schedule_publications still has no UPDATE policy'
+);
+
+-- ============================================
+-- Audience capture
+-- ============================================
+
+CREATE TEMP TABLE retraction_result AS
+SELECT unpublish_schedule(
+  'c0000000-0000-0000-0000-00000000a001',
+  (SELECT week_start FROM retraction_config),
+  (SELECT week_end   FROM retraction_config),
+  'coverage gap'
+) AS unpublished_count;
+
+-- Test 5 -- s1, s2 and s3. A 1 here means GET DIAGNOSTICS crept back in and is
+-- reporting the retraction INSERT's row count instead of the UPDATE's.
+SELECT is(
+  (SELECT unpublished_count FROM retraction_result),
+  3,
+  'unpublish_schedule returns the shift count, not the retraction INSERT count'
+);
+
+-- Test 6
+SELECT is(
+  (SELECT count(*)::int FROM schedule_retractions
+    WHERE restaurant_id = 'c0000000-0000-0000-0000-00000000a001'),
+  1,
+  'one retraction row recorded'
+);
+
+-- Test 7
+SELECT is(
+  (SELECT shift_count FROM schedule_retractions
+    WHERE restaurant_id = 'c0000000-0000-0000-0000-00000000a001'),
+  3,
+  'the retraction records the same shift count the RPC returned'
+);
+
+-- Test 8 -- e1 holds two of the three retracted shifts, so a missing DISTINCT
+-- gives 3 here.
+SELECT is(
+  (SELECT array_length(employee_ids, 1) FROM schedule_retractions
+    WHERE restaurant_id = 'c0000000-0000-0000-0000-00000000a001'),
+  2,
+  'the audience is deduped rather than one entry per retracted shift'
+);
+
+-- Test 9
+SELECT ok(
+  (SELECT employee_ids @> ARRAY[
+            'c0000000-0000-0000-0000-0000000000e1'::uuid,
+            'c0000000-0000-0000-0000-0000000000e2'::uuid]
+     FROM schedule_retractions
+    WHERE restaurant_id = 'c0000000-0000-0000-0000-00000000a001'),
+  'the audience contains both employees who had published shifts, including the week-edge closer'
+);
+
+-- Test 10 -- e3 had only a draft this week and a published shift LAST week.
+-- Mailing them "your schedule was taken down" would be the notification bug
+-- inverted: a retraction notice for a schedule they were never promised.
+SELECT ok(
+  (SELECT NOT (employee_ids @> ARRAY['c0000000-0000-0000-0000-0000000000e3'::uuid])
+     FROM schedule_retractions
+    WHERE restaurant_id = 'c0000000-0000-0000-0000-00000000a001'),
+  'the audience excludes an employee with only a draft and a prior-week shift'
+);
+
+-- Test 11
+SELECT is(
+  (SELECT publication_id FROM schedule_retractions
+    WHERE restaurant_id = 'c0000000-0000-0000-0000-00000000a001'),
+  'c0000000-0000-0000-0000-00000000b001'::uuid,
+  'the retraction links the most recent publication for the week'
+);
+
+-- Test 12
+SELECT is(
+  (SELECT retracted_by FROM schedule_retractions
+    WHERE restaurant_id = 'c0000000-0000-0000-0000-00000000a001'),
+  'c0117000-0000-0000-0000-000000000001'::uuid,
+  'the retraction records who retracted it'
+);
+
+-- Test 13 -- ok() rather than is(), since an untyped NULL comparand is ambiguous
+-- for pgTAP's polymorphic is().
+SELECT ok(
+  (SELECT notified_at IS NULL FROM schedule_retractions
+    WHERE restaurant_id = 'c0000000-0000-0000-0000-00000000a001'),
+  'the retraction starts unnotified so the notifier can claim it'
+);
+
+-- Test 14 -- the prior-week shift is untouched, so test 10 is a real exclusion
+-- rather than an employee who simply had nothing published anywhere.
+SELECT is(
+  (SELECT is_published FROM shifts WHERE id = 'c0000000-0000-0000-0000-00000000f006'),
+  true,
+  'the prior-week Sun 22:00 shift is left published'
+);
+
+-- ============================================
+-- The routine no-op
+-- ============================================
+--
+-- Unpublishing a week with nothing published is a double-tap, not an error.
+-- Without the COALESCE, array_agg over zero rows returns NULL and the NOT NULL
+-- employee_ids column aborts the whole transaction; without the count guard, an
+-- empty retraction row leaves the notifier an audience of nobody to special-case.
+
+CREATE TEMP TABLE second_retraction_result AS
+SELECT unpublish_schedule(
+  'c0000000-0000-0000-0000-00000000a001',
+  (SELECT week_start FROM retraction_config),
+  (SELECT week_end   FROM retraction_config),
+  NULL
+) AS unpublished_count;
+
+-- Test 15
+SELECT is(
+  (SELECT unpublished_count FROM second_retraction_result),
+  0,
+  'unpublishing a week with nothing published returns 0 and does not raise'
+);
+
+-- Test 16
+SELECT is(
+  (SELECT count(*)::int FROM schedule_retractions
+    WHERE restaurant_id = 'c0000000-0000-0000-0000-00000000a001'),
+  1,
+  'a no-op unpublish records no second retraction'
+);
+
+-- ============================================
+-- Neither table is client-writable
+-- ============================================
+--
+-- Re-enable RLS and drop to `authenticated` — this must be the last block in the
+-- file, since ALTER TABLE is not available to that role. The caller is a genuine
+-- member of the restaurant and can SELECT both rows, so a passing assertion here
+-- is about the write path and nothing else.
+--
+-- The two tables are blocked by different mechanisms, and the assertions differ
+-- to match. schedule_publications grants UPDATE to `authenticated` and relies on
+-- the absent policy, which silently filters to zero rows rather than raising --
+-- that silence is precisely what let the original bug run undetected in
+-- production for months. schedule_retractions grants no UPDATE at all, so it
+-- raises 42501 before RLS is consulted.
+
+ALTER TABLE schedule_publications ENABLE ROW LEVEL SECURITY;
+ALTER TABLE schedule_retractions  ENABLE ROW LEVEL SECURITY;
+
+SET LOCAL role TO authenticated;
+
+-- Test 17 -- without this, tests 18 and 19 would also pass if `authenticated`
+-- simply lacked the table grant, which is a different (and unpinned) reason.
+SELECT ok(
+  has_table_privilege('authenticated', 'public.schedule_publications', 'UPDATE'),
+  'authenticated holds the table-level UPDATE grant, so RLS is what stops the write'
+);
+
+-- Test 18 -- THE ORIGINAL BUG. notify-schedule-published issued exactly this
+-- write with a user-scoped client and never checked the result, so every
+-- publication row in production still reads notification_sent = false.
+WITH attempted AS (
+  UPDATE schedule_publications
+  SET notification_sent = true
+  WHERE id = 'c0000000-0000-0000-0000-00000000b001'
+  RETURNING 1
+)
+SELECT is(
+  (SELECT count(*)::int FROM attempted),
+  0,
+  'an authenticated client cannot UPDATE schedule_publications.notification_sent'
+);
+
+-- Test 19 -- the SELECT policy on schedule_retractions is only live because the
+-- migration grants SELECT explicitly; default privileges in this database give
+-- new public tables no DML at all. Without this the policy would be dead code
+-- and test 20 would pass for the wrong reason.
+SELECT is(
+  (SELECT count(*)::int FROM schedule_retractions
+    WHERE restaurant_id = 'c0000000-0000-0000-0000-00000000a001'),
+  1,
+  'a member of the restaurant can read its retraction'
+);
+
+-- Test 20
+SELECT throws_ok(
+  $$ UPDATE schedule_retractions SET notified_at = now()
+       WHERE restaurant_id = 'c0000000-0000-0000-0000-00000000a001' $$,
+  '42501',
+  NULL,
+  'an authenticated client cannot claim a retraction by setting notified_at'
+);
+
+SET LOCAL role TO postgres;
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/schedule_retractions.test.sql
+++ b/supabase/tests/schedule_retractions.test.sql
@@ -32,7 +32,7 @@
 
 BEGIN;
 
-SELECT plan(20);
+SELECT plan(21);
 
 -- ============================================
 -- Setup
@@ -308,7 +308,9 @@ SELECT ok(
 -- Test 14 -- the prior-week shift is untouched, so test 10 is a real exclusion
 -- rather than an employee who simply had nothing published anywhere.
 SELECT is(
-  (SELECT is_published FROM shifts WHERE id = 'c0000000-0000-0000-0000-00000000f006'),
+  (SELECT is_published FROM shifts
+    WHERE id = 'c0000000-0000-0000-0000-00000000f006'
+      AND restaurant_id = 'c0000000-0000-0000-0000-00000000a001'),
   true,
   'the prior-week Sun 22:00 shift is left published'
 );
@@ -380,6 +382,7 @@ WITH attempted AS (
   UPDATE schedule_publications
   SET notification_sent = true
   WHERE id = 'c0000000-0000-0000-0000-00000000b001'
+    AND restaurant_id = 'c0000000-0000-0000-0000-00000000a001'
   RETURNING 1
 )
 SELECT is(
@@ -399,7 +402,31 @@ SELECT is(
   'a member of the restaurant can read its retraction'
 );
 
--- Test 20
+-- Test 20 -- the other half of test 19, and the half that actually matters.
+-- "A member can read it" passes just as happily under a policy of USING (true);
+-- only a non-member coming back empty proves the tenant scope is real. The
+-- audience snapshot is a roster of employee ids, so a leak here is a leak of
+-- who works at somebody else's restaurant.
+SELECT set_config(
+  'request.jwt.claims',
+  '{"sub":"c0117000-0000-0000-0000-000000000002","role":"authenticated"}',
+  true
+);
+
+SELECT is(
+  (SELECT count(*)::int FROM schedule_retractions
+    WHERE restaurant_id = 'c0000000-0000-0000-0000-00000000a001'),
+  0,
+  'a user with no user_restaurants row cannot read the restaurant''s retractions'
+);
+
+SELECT set_config(
+  'request.jwt.claims',
+  '{"sub":"c0117000-0000-0000-0000-000000000001","role":"authenticated"}',
+  true
+);
+
+-- Test 21
 SELECT throws_ok(
   $$ UPDATE schedule_retractions SET notified_at = now()
        WHERE restaurant_id = 'c0000000-0000-0000-0000-00000000a001' $$,

--- a/tests/e2e/employee-schedule-retraction.spec.ts
+++ b/tests/e2e/employee-schedule-retraction.spec.ts
@@ -1,0 +1,148 @@
+import { test, expect, Page } from '@playwright/test';
+import { signUpAndCreateRestaurant, exposeSupabaseHelpers, generateTestUser } from '../helpers/e2e-supabase';
+
+/**
+ * The whole point of the banner is that an employee can tell a draft week from
+ * a published one, and a published week from one the manager has pulled back.
+ * That distinction only exists across a publish/unpublish sequence, so this
+ * spec walks the sequence rather than asserting any single state in isolation.
+ *
+ * Timezone is pinned for the same reason as schedule-publish-week-range.spec.ts:
+ * CI runs UTC, and week bucketing bugs are invisible there.
+ */
+test.use({ timezoneId: 'America/New_York' });
+
+/** The owner is also the employee, so one session can both publish and read the result. */
+async function seedSelfAsEmployeeWithShift(page: Page, restaurantId: string): Promise<void> {
+  await page.evaluate(async ({ restId }) => {
+    // `window` has no type declarations for the test-only Supabase client exposeSupabaseHelpers attaches.
+    const supabase = (window as any).__supabase;
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user?.id) throw new Error('No authenticated user found');
+
+    const { data: employee, error: empError } = await supabase
+      .from('employees')
+      .insert({
+        restaurant_id: restId,
+        user_id: user.id,
+        name: 'Robin Retraction',
+        position: 'Server',
+        status: 'active',
+        is_active: true,
+        compensation_type: 'hourly',
+        hourly_rate: 1500,
+      })
+      .select()
+      .single();
+    if (empError) throw new Error(`employees insert failed: ${empError.message}`);
+
+    // Wednesday of the current local week — safely inside Mon..Sun no matter
+    // which day the suite runs on.
+    const now = new Date();
+    const monday = new Date(now);
+    monday.setDate(now.getDate() - ((now.getDay() + 6) % 7));
+    const wednesday = new Date(monday);
+    wednesday.setDate(monday.getDate() + 2);
+    wednesday.setHours(10, 0, 0, 0);
+    const end = new Date(wednesday);
+    end.setHours(16, 0, 0, 0);
+
+    const { error: shiftError } = await supabase.from('shifts').insert({
+      restaurant_id: restId,
+      employee_id: employee.id,
+      start_time: wednesday.toISOString(),
+      end_time: end.toISOString(),
+      position: 'Server',
+    });
+    if (shiftError) throw new Error(`shifts insert failed: ${shiftError.message}`);
+  }, { restId: restaurantId });
+}
+
+/** Drives the manager-side Publish dialog and waits for the RPC to land. */
+async function publishCurrentWeek(page: Page): Promise<void> {
+  await page.goto('/scheduling');
+  await page.waitForLoadState('networkidle');
+
+  await expect(page.getByRole('tabpanel', { name: 'Schedule' }).getByText('Robin Retraction').first())
+    .toBeVisible({ timeout: 15000 });
+
+  const publishBtn = page.getByRole('button', { name: 'Publish', exact: true });
+  await expect(publishBtn).toBeEnabled({ timeout: 10000 });
+  await publishBtn.click();
+
+  const dialog = page.getByRole('dialog', { name: /publish schedule/i });
+  await expect(dialog).toBeVisible({ timeout: 5000 });
+
+  const responsePromise = page.waitForResponse(
+    (resp) => resp.url().includes('publish_schedule') && resp.status() === 200,
+    { timeout: 20000 },
+  );
+  await dialog.getByRole('button', { name: /publish schedule/i }).click();
+  await responsePromise;
+}
+
+/** Drives the manager-side Unpublish confirmation and waits for the RPC to land. */
+async function unpublishCurrentWeek(page: Page): Promise<void> {
+  await page.goto('/scheduling');
+  await page.waitForLoadState('networkidle');
+
+  const unpublishBtn = page.getByRole('button', { name: /^unpublish$/i });
+  await expect(unpublishBtn).toBeVisible({ timeout: 15000 });
+  await unpublishBtn.click();
+
+  const dialog = page.getByRole('alertdialog').filter({ hasText: /unpublish schedule/i });
+  await expect(dialog).toBeVisible({ timeout: 5000 });
+
+  const responsePromise = page.waitForResponse(
+    (resp) => resp.url().includes('unpublish_schedule') && resp.status() === 200,
+    { timeout: 20000 },
+  );
+  await dialog.getByRole('button', { name: /unpublish schedule/i }).click();
+  await responsePromise;
+}
+
+test.describe('Employee schedule publish states', () => {
+  test('an employee sees draft, then published, then retracted as the manager acts', async ({ page }) => {
+    const testUser = generateTestUser('retract');
+    await signUpAndCreateRestaurant(page, testUser);
+    await exposeSupabaseHelpers(page);
+
+    // `window` has no type declarations for the test-only helpers exposeSupabaseHelpers attaches.
+    const restaurantId = await page.evaluate(() => (window as any).__getRestaurantId());
+    expect(restaurantId).toBeTruthy();
+
+    await seedSelfAsEmployeeWithShift(page, restaurantId);
+
+    // --- State A: nothing published yet. The shift is visible but tentative.
+    await page.goto('/employee/schedule');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText(/schedule not published yet/i)).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText(/draft — not confirmed/i).first()).toBeVisible();
+
+    // --- State B: published. The draft badge is gone and the banner steps aside.
+    await publishCurrentWeek(page);
+
+    await page.goto('/employee/schedule');
+    await page.waitForLoadState('networkidle');
+
+    await expect(page.getByText(/^Published /)).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText(/schedule not published yet/i)).not.toBeVisible();
+    await expect(page.getByText(/draft — not confirmed/i)).not.toBeVisible();
+
+    // --- State D: pulled back. This is the state the old UI could not express
+    // at all — the employee was left reading a week nobody had told them was
+    // no longer final.
+    await unpublishCurrentWeek(page);
+
+    await page.goto('/employee/schedule');
+    await page.waitForLoadState('networkidle');
+
+    const retractedAlert = page.getByRole('alert').filter({ hasText: /pulled back for changes/i });
+    await expect(retractedAlert).toBeVisible({ timeout: 15000 });
+    await expect(retractedAlert).toContainText(/nothing below is final/i);
+
+    // The shifts themselves are drafts again, so they read as tentative too.
+    await expect(page.getByText(/draft — not confirmed/i).first()).toBeVisible();
+  });
+});

--- a/tests/unit/BulkInventoryDeductionDialog.datePicker.test.tsx
+++ b/tests/unit/BulkInventoryDeductionDialog.datePicker.test.tsx
@@ -11,7 +11,7 @@
  * <DatePicker>.
  */
 import React from 'react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BulkInventoryDeductionDialog } from '../../src/components/BulkInventoryDeductionDialog';
@@ -34,8 +34,23 @@ vi.mock('@/contexts/RestaurantContext', () => ({
 
 // ── Tests ────────────────────────────────────────────────────────────────────
 describe('BulkInventoryDeductionDialog — date pickers (BUG-001 regression)', () => {
+  // These tests address calendar days by their number ("5", "15", "20"), and the
+  // calendar renders the *current* month plus the outside days that pad the grid.
+  // On a real clock that makes the day numbers ambiguous in some months and not
+  // others: this file went red on 2026-08-01 because the August grid trails into
+  // September, so "5" matched both Aug 5 and Sep 5 and getByRole found two.
+  //
+  // Pin the clock to a month whose padding cannot collide with any number the
+  // tests reach for. July 2026 pads with Jun 28-30 and Aug 1 only. Only Date is
+  // faked -- userEvent drives its own real timers and would hang otherwise.
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date(2026, 6, 15, 12, 0, 0));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   /** Open the outer Dialog by clicking the trigger button. */

--- a/tests/unit/ScheduleStatusBanner.test.tsx
+++ b/tests/unit/ScheduleStatusBanner.test.tsx
@@ -115,15 +115,18 @@ describe('ScheduleStatusBanner', () => {
     );
   });
 
-  it('does not present the RPC’s own boilerplate as a manager’s reason', () => {
+  it('omits the reason line when the manager gave none', () => {
+    // `schedule_retractions.reason` is NULL in that case — the RPC's
+    // "Schedule unpublished for date range…" default goes to
+    // schedule_change_logs, which the banner never reads. Whitespace stands in
+    // for a manager who opened the box and typed nothing.
     renderBanner({
       state: 'retracted',
       publishedCount: 0,
       draftCount: 5,
-      retractionReason: 'Schedule unpublished for date range: 2026-08-03 to 2026-08-09',
+      retractionReason: '   ',
     });
 
-    // Machine text quoted back as if a person wrote it reads as an evasion.
     expect(screen.getByRole('alert')).not.toHaveTextContent('Reason:');
   });
 

--- a/tests/unit/ScheduleStatusBanner.test.tsx
+++ b/tests/unit/ScheduleStatusBanner.test.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { ScheduleStatusBanner } from '@/components/employee/ScheduleStatusBanner';
+import { SchedulePublication } from '@/types/scheduling';
+
+const TZ = 'America/Chicago';
+const WEEK_RANGE = 'Aug 3 - Aug 9';
+
+function publication(overrides: Partial<SchedulePublication> = {}): SchedulePublication {
+  return {
+    id: 'pub-1',
+    restaurant_id: 'r1',
+    week_start_date: '2026-08-03',
+    week_end_date: '2026-08-09',
+    // 15:00Z is 10:00 CDT -- the assertions below depend on the restaurant's
+    // zone being applied, not the runner's.
+    published_at: '2026-08-01T15:00:00Z',
+    published_by: 'u1',
+    notes: null,
+    shift_count: 12,
+    open_shifts_broadcast_at: null,
+    open_shifts_broadcast_by: null,
+    notification_sent: true,
+    ...overrides,
+  };
+}
+
+function renderBanner(props: Partial<React.ComponentProps<typeof ScheduleStatusBanner>> = {}) {
+  return render(
+    <ScheduleStatusBanner
+      state="published"
+      publication={publication()}
+      publishedCount={4}
+      draftCount={0}
+      weekRange={WEEK_RANGE}
+      timezone={TZ}
+      {...props}
+    />
+  );
+}
+
+describe('ScheduleStatusBanner', () => {
+  it('says nothing at all while the status is still unknown', () => {
+    const { container } = renderBanner({ state: null });
+
+    // A wrong banner is worse than no banner. The slot still occupies its
+    // height so the page does not jump when the answer arrives.
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(container.querySelector('.min-h-\\[76px\\]')).toBeInTheDocument();
+  });
+
+  it('reduces a fully published week to one quiet line, in the restaurant timezone', () => {
+    renderBanner({ state: 'published' });
+
+    // 2026-08-01T15:00Z is 10:00 CDT on Sat Aug 1 -- not 15:00, and not Aug 2.
+    expect(screen.getByText(/Published Sat, Aug 1 at 10:00/)).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('tells an employee a draft-only week is not theirs yet', () => {
+    renderBanner({ state: 'not_published', publication: null, publishedCount: 0, draftCount: 3 });
+
+    const banner = screen.getByRole('status');
+    expect(banner).toHaveTextContent('Schedule not published yet');
+    expect(banner).toHaveTextContent(`Your manager hasn't finalized the week of ${WEEK_RANGE}`);
+    // The count is the part that connects the banner to the rows below it.
+    expect(banner).toHaveTextContent('The 3 shifts below are still drafts');
+  });
+
+  it('omits the shift-count sentence when there is nothing on the grid to explain', () => {
+    renderBanner({ state: 'not_published', publication: null, publishedCount: 0, draftCount: 0 });
+
+    expect(screen.getByRole('status')).not.toHaveTextContent('shifts below');
+  });
+
+  it('singularizes the draft sentence for a lone shift', () => {
+    renderBanner({ state: 'not_published', publication: null, publishedCount: 0, draftCount: 1 });
+
+    expect(screen.getByRole('status')).toHaveTextContent('The 1 shift below is still a draft');
+  });
+
+  it('splits confirmed from unconfirmed while a week is being revised', () => {
+    renderBanner({ state: 'published_revising', publishedCount: 3, draftCount: 2 });
+
+    const banner = screen.getByRole('status');
+    expect(banner).toHaveTextContent('Some shifts are still being finalized');
+    expect(banner).toHaveTextContent('3 of your shifts this week are confirmed');
+    expect(banner).toHaveTextContent('2 more are drafts');
+  });
+
+  it('announces a retraction assertively, naming when the week had been published', () => {
+    renderBanner({ state: 'retracted', publishedCount: 0, draftCount: 5 });
+
+    // role="alert", not "status": this is correcting a belief the employee may
+    // already hold from a "New Schedule Published" email in their inbox.
+    const banner = screen.getByRole('alert');
+    expect(banner).toHaveTextContent('This schedule was pulled back for changes');
+    expect(banner).toHaveTextContent(`Your manager published ${WEEK_RANGE} on Sat, Aug 1 at 10:00`);
+    expect(banner).toHaveTextContent("check back once it's republished");
+  });
+
+  it('passes along a reason a manager actually wrote', () => {
+    renderBanner({
+      state: 'retracted',
+      publishedCount: 0,
+      draftCount: 5,
+      retractionReason: 'Two callouts, rebuilding the weekend',
+    });
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      'Reason: Two callouts, rebuilding the weekend'
+    );
+  });
+
+  it('does not present the RPC’s own boilerplate as a manager’s reason', () => {
+    renderBanner({
+      state: 'retracted',
+      publishedCount: 0,
+      draftCount: 5,
+      retractionReason: 'Schedule unpublished for date range: 2026-08-03 to 2026-08-09',
+    });
+
+    // Machine text quoted back as if a person wrote it reads as an evasion.
+    expect(screen.getByRole('alert')).not.toHaveTextContent('Reason:');
+  });
+
+  it('still renders the retraction when the publication row is missing', () => {
+    renderBanner({ state: 'retracted', publication: null, publishedCount: 0, draftCount: 5 });
+
+    const banner = screen.getByRole('alert');
+    expect(banner).toHaveTextContent('This schedule was pulled back for changes');
+    expect(banner).not.toHaveTextContent(' on ,');
+  });
+});

--- a/tests/unit/ScheduleStatusBanner.test.tsx
+++ b/tests/unit/ScheduleStatusBanner.test.tsx
@@ -135,6 +135,9 @@ describe('ScheduleStatusBanner', () => {
 
     const banner = screen.getByRole('alert');
     expect(banner).toHaveTextContent('This schedule was pulled back for changes');
-    expect(banner).not.toHaveTextContent(' on ,');
+    // With no publication row there is no published_at to format, so the
+    // " on {day} at {time}" clause must be absent entirely -- not rendered
+    // empty, which would read as "published  on , then unpublished it".
+    expect(banner).not.toHaveTextContent(/ on \w/);
   });
 });

--- a/tests/unit/ScheduleStatusBanner.test.tsx
+++ b/tests/unit/ScheduleStatusBanner.test.tsx
@@ -87,7 +87,10 @@ describe('ScheduleStatusBanner', () => {
 
     const banner = screen.getByRole('status');
     expect(banner).toHaveTextContent('Some shifts are still being finalized');
-    expect(banner).toHaveTextContent('3 of your shifts this week are confirmed');
+    // "3 of your shifts" leaves the denominator to the reader, and the number
+    // they reach for is the one they can see -- five rows on the page. Naming
+    // the total is what makes the sentence answer "how many are left?".
+    expect(banner).toHaveTextContent('3 of your 5 shifts this week are confirmed');
     expect(banner).toHaveTextContent('2 more are drafts');
   });
 

--- a/tests/unit/ShiftRow.test.tsx
+++ b/tests/unit/ShiftRow.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ShiftRow } from '@/components/employee/ShiftRow';
+import { Shift } from '@/types/scheduling';
+
+/** Far enough out that `isFuture` stays true whatever day the suite runs. */
+const FUTURE = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+const futureAt = (hoursOffset: number) =>
+  new Date(FUTURE.getTime() + hoursOffset * 60 * 60 * 1000).toISOString();
+
+function makeShift(overrides: Partial<Shift> = {}): Shift {
+  return {
+    id: 'shift-1',
+    restaurant_id: 'r1',
+    employee_id: 'e1',
+    start_time: futureAt(0),
+    end_time: futureAt(8),
+    position: 'Server',
+    status: 'scheduled',
+    break_duration: 30,
+    is_published: true,
+    locked: false,
+    source: 'manual',
+    created_at: futureAt(-100),
+    updated_at: futureAt(-100),
+    ...overrides,
+  };
+}
+
+describe('ShiftRow draft treatment', () => {
+  it('labels an unpublished shift as an unconfirmed draft', () => {
+    render(<ShiftRow shift={makeShift({ is_published: false })} />);
+
+    // The badge text is the signal that survives a screen reader, a
+    // colour-blind viewer and a greyscale phone -- the dashed border alone
+    // would not.
+    expect(screen.getByText('Draft — not confirmed')).toBeInTheDocument();
+  });
+
+  it('does not offer a Trade button on a draft shift', async () => {
+    const onTrade = vi.fn();
+    render(<ShiftRow shift={makeShift({ is_published: false })} onTrade={onTrade} />);
+
+    // Trading a shift that does not officially exist yet produces a request
+    // against a schedule the manager is still editing.
+    expect(screen.queryByRole('button', { name: /trade/i })).not.toBeInTheDocument();
+    expect(onTrade).not.toHaveBeenCalled();
+  });
+
+  it('shows the normal status badge and Trade button once published', async () => {
+    const onTrade = vi.fn();
+    render(<ShiftRow shift={makeShift()} onTrade={onTrade} />);
+
+    expect(screen.queryByText('Draft — not confirmed')).not.toBeInTheDocument();
+    expect(screen.getByText('Upcoming')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /trade/i }));
+    expect(onTrade).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a cancelled shift reading as cancelled, not as a draft', () => {
+    render(<ShiftRow shift={makeShift({ status: 'cancelled' })} onTrade={vi.fn()} />);
+
+    expect(screen.getByText('Cancelled')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /trade/i })).not.toBeInTheDocument();
+  });
+
+  it('takes the same draft branch in the Upcoming card as in the day grid', () => {
+    render(<ShiftRow shift={makeShift({ is_published: false })} variant="upcoming" />);
+
+    // The Upcoming card is the one an employee reads first on mobile; a draft
+    // that looked confirmed there is the exact reported confusion.
+    expect(screen.getByText('Draft — not confirmed')).toBeInTheDocument();
+  });
+});

--- a/tests/unit/emailQueue.test.ts
+++ b/tests/unit/emailQueue.test.ts
@@ -65,6 +65,33 @@ describe('sendEmailResult', () => {
     expect(result).toEqual({ ok: false, status: 0, error: 'connection reset' });
   });
 
+  it('aborts a request Resend accepts but never answers', async () => {
+    vi.useFakeTimers();
+
+    // A connection that is opened and then goes silent. `fetch` has no timeout
+    // of its own, so without the AbortController this promise -- and the
+    // manager's publish dialog awaiting it -- never settles.
+    vi.mocked(fetch).mockImplementation(
+      (_url, init) =>
+        new Promise((_resolve, reject) => {
+          (init?.signal as AbortSignal | undefined)?.addEventListener('abort', () =>
+            reject(new DOMException('The signal has been aborted', 'AbortError')),
+          );
+        }),
+    );
+
+    const pending = sendEmailResult('key', 'from@x.com', 'to@x.com', 'Subj', '<p>hi</p>');
+    await vi.advanceTimersByTimeAsync(15_000);
+    const result = await pending;
+
+    expect(result.ok).toBe(false);
+    // Status 0 is the same channel a transport failure uses, so the pacer needs
+    // no new case: it is not a 429, so it is not retried.
+    expect(result.status).toBe(0);
+
+    vi.useRealTimers();
+  });
+
   it('normalizes a single recipient into an array for the Resend payload', async () => {
     vi.mocked(fetch).mockResolvedValue(new Response('{}', { status: 200 }));
 

--- a/tests/unit/emailQueue.test.ts
+++ b/tests/unit/emailQueue.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  sendEmailResult,
+  sendPaced,
+  RESEND_DEFAULT_INTERVAL_MS,
+} from '../../supabase/functions/_shared/emailQueue';
+
+/**
+ * A fake clock + sleep so pacing/backoff are asserted deterministically
+ * instead of by actually waiting seconds in the test run.
+ */
+function makeFakeTimer() {
+  let now = 0;
+  const sleeps: number[] = [];
+  return {
+    sleeps,
+    now: () => now,
+    sleep: async (ms: number) => {
+      sleeps.push(ms);
+      now += ms;
+    },
+    advance: (ms: number) => {
+      now += ms;
+    },
+  };
+}
+
+describe('sendEmailResult', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('reports ok with the HTTP status on success', async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ id: 'abc' }), { status: 200 }),
+    );
+
+    const result = await sendEmailResult('key', 'from@x.com', 'to@x.com', 'Subj', '<p>hi</p>');
+
+    expect(result).toEqual({ ok: true, status: 200 });
+  });
+
+  it('surfaces the status and body on failure instead of collapsing to false', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response('rate limit exceeded', { status: 429 }));
+
+    const result = await sendEmailResult('key', 'from@x.com', 'to@x.com', 'Subj', '<p>hi</p>');
+
+    // This is the whole point of the sibling function: a 429 must be
+    // distinguishable from a hard bounce so the queue can retry it.
+    expect(result.ok).toBe(false);
+    expect(result.status).toBe(429);
+    expect(result.error).toContain('rate limit');
+  });
+
+  it('reports a thrown network error as status 0 rather than throwing', async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error('connection reset'));
+
+    const result = await sendEmailResult('key', 'from@x.com', 'to@x.com', 'Subj', '<p>hi</p>');
+
+    expect(result).toEqual({ ok: false, status: 0, error: 'connection reset' });
+  });
+
+  it('normalizes a single recipient into an array for the Resend payload', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response('{}', { status: 200 }));
+
+    await sendEmailResult('key', 'from@x.com', 'to@x.com', 'Subj', '<p>hi</p>');
+
+    const body = JSON.parse(vi.mocked(fetch).mock.calls[0][1]?.body as string);
+    expect(body.to).toEqual(['to@x.com']);
+  });
+});
+
+describe('sendPaced', () => {
+  it('paces sends at the Resend default of 2 per second', async () => {
+    const timer = makeFakeTimer();
+    const send = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+
+    await sendPaced(['a@x.com', 'b@x.com', 'c@x.com'], send, {
+      sleep: timer.sleep,
+      now: timer.now,
+    });
+
+    expect(send).toHaveBeenCalledTimes(3);
+    // First send is immediate; the following two each wait out the interval.
+    expect(timer.sleeps).toEqual([RESEND_DEFAULT_INTERVAL_MS, RESEND_DEFAULT_INTERVAL_MS]);
+  });
+
+  it('does not sleep before the first send', async () => {
+    const timer = makeFakeTimer();
+    const send = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+
+    await sendPaced(['only@x.com'], send, { sleep: timer.sleep, now: timer.now });
+
+    expect(timer.sleeps).toEqual([]);
+  });
+
+  it('does not sleep when the caller already burned the interval', async () => {
+    const timer = makeFakeTimer();
+    const send = vi.fn().mockImplementation(async () => {
+      // A send that itself takes longer than the pacing interval means the
+      // next one is already due — waiting again would be wasted wall time.
+      timer.advance(RESEND_DEFAULT_INTERVAL_MS + 50);
+      return { ok: true, status: 200 };
+    });
+
+    await sendPaced(['a@x.com', 'b@x.com'], send, { sleep: timer.sleep, now: timer.now });
+
+    expect(timer.sleeps).toEqual([]);
+  });
+
+  it('retries a 429 with backoff and reports the eventual success', async () => {
+    const timer = makeFakeTimer();
+    const send = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 429, error: 'too many' })
+      .mockResolvedValueOnce({ ok: true, status: 200 });
+
+    const results = await sendPaced(['a@x.com'], send, { sleep: timer.sleep, now: timer.now });
+
+    expect(send).toHaveBeenCalledTimes(2);
+    expect(results[0]).toMatchObject({ recipient: 'a@x.com', ok: true, attempts: 2 });
+    expect(timer.sleeps).toContain(1000);
+  });
+
+  it('gives up after maxRetries and reports the last 429', async () => {
+    const timer = makeFakeTimer();
+    const send = vi.fn().mockResolvedValue({ ok: false, status: 429, error: 'too many' });
+
+    const results = await sendPaced(['a@x.com'], send, {
+      sleep: timer.sleep,
+      now: timer.now,
+      maxRetries: 2,
+    });
+
+    expect(send).toHaveBeenCalledTimes(3); // initial + 2 retries
+    expect(results[0]).toMatchObject({ ok: false, status: 429, attempts: 3 });
+  });
+
+  it('does not retry a non-429 failure', async () => {
+    const timer = makeFakeTimer();
+    const send = vi.fn().mockResolvedValue({ ok: false, status: 422, error: 'invalid address' });
+
+    const results = await sendPaced(['bad@x.com'], send, { sleep: timer.sleep, now: timer.now });
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(results[0]).toMatchObject({ ok: false, status: 422, attempts: 1 });
+  });
+
+  it('keeps one result per recipient, in order, so partial failure can be reported', async () => {
+    const timer = makeFakeTimer();
+    const send = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, status: 200 })
+      .mockResolvedValueOnce({ ok: false, status: 422, error: 'invalid address' })
+      .mockResolvedValueOnce({ ok: true, status: 200 });
+
+    const results = await sendPaced(['a@x.com', 'b@x.com', 'c@x.com'], send, {
+      sleep: timer.sleep,
+      now: timer.now,
+    });
+
+    expect(results.map((r) => r.recipient)).toEqual(['a@x.com', 'b@x.com', 'c@x.com']);
+    expect(results.map((r) => r.ok)).toEqual([true, false, true]);
+  });
+
+  it('one recipient failing does not abort the rest of the fan-out', async () => {
+    const timer = makeFakeTimer();
+    const send = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('unexpected explosion'))
+      .mockResolvedValue({ ok: true, status: 200 });
+
+    const results = await sendPaced(['a@x.com', 'b@x.com'], send, {
+      sleep: timer.sleep,
+      now: timer.now,
+    });
+
+    expect(results[0]).toMatchObject({ ok: false, status: 0, error: 'unexpected explosion' });
+    expect(results[1]).toMatchObject({ ok: true });
+  });
+
+  it('returns an empty result set for an empty recipient list without sending', async () => {
+    const send = vi.fn();
+
+    const results = await sendPaced([], send, {});
+
+    expect(results).toEqual([]);
+    expect(send).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/scheduleSeenFingerprint.test.ts
+++ b/tests/unit/scheduleSeenFingerprint.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  computeScheduleFingerprint,
+  scheduleSeenKey,
+  readSeenFingerprint,
+  writeSeenFingerprint,
+  hasScheduleChangedSinceSeen,
+  type FingerprintShift,
+} from '@/lib/scheduleSeenFingerprint';
+
+const shift = (overrides: Partial<FingerprintShift> = {}): FingerprintShift => ({
+  id: 's1',
+  start_time: '2026-08-04T14:00:00Z',
+  end_time: '2026-08-04T22:00:00Z',
+  position: 'Server',
+  status: 'scheduled',
+  ...overrides,
+});
+
+const baseline = { publishedAt: '2026-08-01T23:42:00Z', shifts: [shift()] };
+
+describe('computeScheduleFingerprint', () => {
+  it('is stable for identical input', () => {
+    expect(computeScheduleFingerprint(baseline)).toBe(computeScheduleFingerprint(baseline));
+  });
+
+  it('ignores the order rows come back in', () => {
+    const a = { publishedAt: null, shifts: [shift({ id: 'a' }), shift({ id: 'b' })] };
+    const b = { publishedAt: null, shifts: [shift({ id: 'b' }), shift({ id: 'a' })] };
+
+    // Postgrest ordering is not a schedule change, and treating it as one would
+    // pop the pill on every refetch until employees stopped reading it.
+    expect(computeScheduleFingerprint(a)).toBe(computeScheduleFingerprint(b));
+  });
+
+  it.each([
+    ['a republish', { publishedAt: '2026-08-02T10:00:00Z' }],
+    ['a shift moving earlier', { shifts: [shift({ start_time: '2026-08-04T12:00:00Z' })] }],
+    ['a shift ending later', { shifts: [shift({ end_time: '2026-08-04T23:30:00Z' })] }],
+    ['a position change', { shifts: [shift({ position: 'Cook' })] }],
+    ['a cancellation', { shifts: [shift({ status: 'cancelled' })] }],
+    ['a shift being removed', { shifts: [] }],
+    ['a shift being added', { shifts: [shift(), shift({ id: 's2' })] }],
+  ])('changes on %s', (_label, overrides) => {
+    expect(computeScheduleFingerprint({ ...baseline, ...overrides })).not.toBe(
+      computeScheduleFingerprint(baseline)
+    );
+  });
+});
+
+describe('hasScheduleChangedSinceSeen', () => {
+  it('does not flag a first-ever view as updated', () => {
+    // Nothing has been missed yet; a pill here would just teach people to
+    // dismiss it reflexively.
+    expect(hasScheduleChangedSinceSeen(null, 'abc')).toBe(false);
+  });
+
+  it('flags a week that differs from what was acknowledged', () => {
+    expect(hasScheduleChangedSinceSeen('abc', 'def')).toBe(true);
+  });
+
+  it('stays quiet when nothing moved', () => {
+    expect(hasScheduleChangedSinceSeen('abc', 'abc')).toBe(false);
+  });
+});
+
+describe('seen storage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('round-trips a fingerprint for the viewed week', () => {
+    writeSeenFingerprint('r1', 'e1', '2026-08-03', 'fp1');
+    expect(readSeenFingerprint('r1', 'e1', '2026-08-03')).toBe('fp1');
+  });
+
+  it('scopes the key to restaurant, employee and week', () => {
+    writeSeenFingerprint('r1', 'e1', '2026-08-03', 'fp1');
+
+    expect(readSeenFingerprint('r2', 'e1', '2026-08-03')).toBeNull();
+    expect(readSeenFingerprint('r1', 'e2', '2026-08-03')).toBeNull();
+    expect(readSeenFingerprint('r1', 'e1', '2026-08-10')).toBeNull();
+  });
+
+  it('prunes weeks older than eight weeks on write', () => {
+    const now = new Date('2026-08-05T00:00:00Z');
+
+    localStorage.setItem(scheduleSeenKey('r1', 'e1', '2026-05-04'), 'ancient'); // ~13 weeks back
+    localStorage.setItem(scheduleSeenKey('r1', 'e1', '2026-07-06'), 'recent'); // ~4 weeks back
+
+    writeSeenFingerprint('r1', 'e1', '2026-08-03', 'fp1', now);
+
+    expect(readSeenFingerprint('r1', 'e1', '2026-05-04')).toBeNull();
+    expect(readSeenFingerprint('r1', 'e1', '2026-07-06')).toBe('recent');
+    expect(readSeenFingerprint('r1', 'e1', '2026-08-03')).toBe('fp1');
+  });
+
+  it('leaves keys belonging to other features alone', () => {
+    localStorage.setItem('push_banner_dismissed_at', '2020-01-01');
+
+    writeSeenFingerprint('r1', 'e1', '2026-08-03', 'fp1', new Date('2026-08-05T00:00:00Z'));
+
+    expect(localStorage.getItem('push_banner_dismissed_at')).toBe('2020-01-01');
+  });
+});
+
+describe('storage unavailable', () => {
+  const original = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+
+  afterEach(() => {
+    if (original) Object.defineProperty(globalThis, 'localStorage', original);
+  });
+
+  it('degrades to no pill instead of throwing', () => {
+    // Safari private mode and some native webviews throw on the first write,
+    // not on property access -- hence the probe write in safeStorage().
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      get: () => ({
+        setItem: vi.fn(() => {
+          throw new DOMException('QuotaExceededError');
+        }),
+        getItem: vi.fn(),
+        removeItem: vi.fn(),
+        key: vi.fn(),
+        length: 0,
+      }),
+    });
+
+    expect(() => writeSeenFingerprint('r1', 'e1', '2026-08-03', 'fp1')).not.toThrow();
+    expect(readSeenFingerprint('r1', 'e1', '2026-08-03')).toBeNull();
+    expect(hasScheduleChangedSinceSeen(null, 'fp1')).toBe(false);
+  });
+});

--- a/tests/unit/scheduleSeenFingerprint.test.ts
+++ b/tests/unit/scheduleSeenFingerprint.test.ts
@@ -14,6 +14,7 @@ const shift = (overrides: Partial<FingerprintShift> = {}): FingerprintShift => (
   end_time: '2026-08-04T22:00:00Z',
   position: 'Server',
   status: 'scheduled',
+  is_published: true,
   ...overrides,
 });
 
@@ -39,6 +40,9 @@ describe('computeScheduleFingerprint', () => {
     ['a shift ending later', { shifts: [shift({ end_time: '2026-08-04T23:30:00Z' })] }],
     ['a position change', { shifts: [shift({ position: 'Cook' })] }],
     ['a cancellation', { shifts: [shift({ status: 'cancelled' })] }],
+    // The retraction case, and the reason is_published is hashed at all: an
+    // unpublish leaves publishedAt and every other field here untouched.
+    ['the week being retracted', { shifts: [shift({ is_published: false })] }],
     ['a shift being removed', { shifts: [] }],
     ['a shift being added', { shifts: [shift(), shift({ id: 's2' })] }],
   ])('changes on %s', (_label, overrides) => {

--- a/tests/unit/scheduleSeenFingerprint.test.ts
+++ b/tests/unit/scheduleSeenFingerprint.test.ts
@@ -108,7 +108,14 @@ describe('storage unavailable', () => {
   const original = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
 
   afterEach(() => {
-    if (original) Object.defineProperty(globalThis, 'localStorage', original);
+    if (original) {
+      Object.defineProperty(globalThis, 'localStorage', original);
+    } else {
+      // No descriptor to put back means the environment had no localStorage at
+      // all. Restoring nothing would leave this suite's throwing stub installed
+      // for every test file that runs after it in the same worker.
+      delete (globalThis as { localStorage?: unknown }).localStorage;
+    }
   });
 
   it('degrades to no pill instead of throwing', () => {

--- a/tests/unit/scheduleWeekRange.test.ts
+++ b/tests/unit/scheduleWeekRange.test.ts
@@ -115,6 +115,7 @@ describe('week range serialization', () => {
 
   it('useUnpublishSchedule sends a Mon..Sun range, not Mon..Mon', async () => {
     mockSupabase.rpc.mockResolvedValue({ data: 3, error: null });
+    mockSupabase.functions.invoke.mockResolvedValue({ data: {}, error: null });
     const { weekStart, weekEnd } = makeWeek();
 
     const { result } = renderHook(() => useUnpublishSchedule(), { wrapper: createWrapper() });
@@ -139,13 +140,17 @@ describe('week range serialization', () => {
     );
 
     const { weekStart, weekEnd } = makeWeek();
-    renderHook(() => useWeekPublicationStatus('r1', weekStart, weekEnd), { wrapper: createWrapper() });
+    renderHook(() => useWeekPublicationStatus('r1', weekStart, weekEnd, 'America/Chicago'), {
+      wrapper: createWrapper(),
+    });
 
     await waitFor(() => expect(pubsBuilder.maybeSingle).toHaveBeenCalled());
 
-    // timestamptz column -> full instants, so no local wall-clock hours are lost.
-    expect(shiftsBuilder.gte).toHaveBeenCalledWith('start_time', weekStart.toISOString());
-    expect(shiftsBuilder.lte).toHaveBeenCalledWith('start_time', weekEnd.toISOString());
+    // timestamptz column -> full instants anchored in the RESTAURANT's zone, so
+    // the count covers exactly the shifts publish_schedule acted on. CDT is
+    // UTC-5 in July, hence 05:00Z Monday through 04:59:59.999Z the next Monday.
+    expect(shiftsBuilder.gte).toHaveBeenCalledWith('start_time', '2026-07-27T05:00:00.000Z');
+    expect(shiftsBuilder.lte).toHaveBeenCalledWith('start_time', '2026-08-03T04:59:59.999Z');
 
     // date columns -> local calendar days.
     expect(pubsBuilder.eq).toHaveBeenCalledWith('week_start_date', '2026-07-27');

--- a/tests/unit/useSchedulePublish.test.ts
+++ b/tests/unit/useSchedulePublish.test.ts
@@ -15,7 +15,11 @@ vi.mock('@/integrations/supabase/client', () => ({ supabase: mockSupabase }));
 const mockToast = vi.hoisted(() => vi.fn());
 vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: mockToast }) }));
 
-import { usePublishSchedule, useUnpublishSchedule } from '@/hooks/useSchedulePublish';
+import {
+  invokeScheduleNotification,
+  usePublishSchedule,
+  useUnpublishSchedule,
+} from '@/hooks/useSchedulePublish';
 
 function makeWeek() {
   const weekStart = new Date(2026, 6, 27);
@@ -193,5 +197,33 @@ describe('unpublish notification outcomes', () => {
     const toasted = lastToast();
     expect(toasted.variant).toBe('destructive');
     expect(toasted.title).toContain('nobody was notified');
+  });
+});
+
+describe('notification timeout', () => {
+  beforeEach(() => {
+    mockSupabase.functions.invoke.mockReset();
+  });
+
+  it('gives up on a fan-out that never answers instead of waiting forever', async () => {
+    // A hung edge function used to leave the publish dialog with both Publish
+    // and Cancel disabled, recoverable only by reloading the page.
+    mockSupabase.functions.invoke.mockReturnValue(new Promise(() => {}));
+
+    const outcome = await invokeScheduleNotification('notify-schedule-published', {}, 20);
+
+    expect(outcome.status).toBe('unknown');
+    // 'unknown', not 'failed': the request is still in flight and may well be
+    // succeeding, so the manager is told we could not confirm -- not that it
+    // went wrong.
+    expect(outcome).toMatchObject({ message: expect.stringContaining('may still be sending') });
+  });
+
+  it('does not time out a fan-out that answers in time', async () => {
+    mockSupabase.functions.invoke.mockResolvedValue({ data: { sent: 4 }, error: null });
+
+    await expect(invokeScheduleNotification('notify-schedule-published', {}, 5000)).resolves.toEqual(
+      { status: 'sent', sent: 4 }
+    );
   });
 });

--- a/tests/unit/useSchedulePublish.test.ts
+++ b/tests/unit/useSchedulePublish.test.ts
@@ -1,0 +1,197 @@
+import React, { ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { endOfWeek } from 'date-fns';
+
+const mockSupabase = vi.hoisted(() => ({
+  from: vi.fn(),
+  rpc: vi.fn(),
+  functions: { invoke: vi.fn() },
+}));
+
+vi.mock('@/integrations/supabase/client', () => ({ supabase: mockSupabase }));
+
+const mockToast = vi.hoisted(() => vi.fn());
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: mockToast }) }));
+
+import { usePublishSchedule, useUnpublishSchedule } from '@/hooks/useSchedulePublish';
+
+function makeWeek() {
+  const weekStart = new Date(2026, 6, 27);
+  return { weekStart, weekEnd: endOfWeek(weekStart, { weekStartsOn: 1 }) };
+}
+
+function createWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return React.createElement(QueryClientProvider, { client }, children);
+  };
+}
+
+/**
+ * supabase-js turns a non-2xx into an `error` carrying the raw `Response` on
+ * `error.context`, which is the only place the per-recipient counts survive.
+ * The functions answer 502 with that body whenever anyone failed.
+ */
+function invokeFailure(body: { sent?: number; failed?: number }) {
+  return {
+    data: null,
+    error: {
+      message: 'Edge Function returned a non-2xx status code',
+      context: { json: () => Promise.resolve(body) },
+    },
+  };
+}
+
+const lastToast = () => mockToast.mock.calls[mockToast.mock.calls.length - 1][0];
+
+describe('publish notification outcomes', () => {
+  beforeEach(() => {
+    mockSupabase.from.mockReset();
+    mockSupabase.rpc.mockReset();
+    mockSupabase.functions.invoke.mockReset();
+    mockToast.mockReset();
+    mockSupabase.rpc.mockResolvedValue({ data: 'pub-1', error: null });
+  });
+
+  it('reports plain success when every recipient was reached', async () => {
+    mockSupabase.functions.invoke.mockResolvedValue({ data: { sent: 11, failed: 0 }, error: null });
+    const { weekStart, weekEnd } = makeWeek();
+
+    const { result } = renderHook(() => usePublishSchedule(), { wrapper: createWrapper() });
+    await act(async () => {
+      await result.current.mutateAsync({ restaurantId: 'r1', weekStart, weekEnd });
+    });
+
+    expect(lastToast()).toEqual({
+      title: 'Schedule Published',
+      description: expect.stringContaining('Employees have been notified'),
+    });
+    expect(lastToast().variant).toBeUndefined();
+  });
+
+  it('names the shortfall when only some recipients were reached', async () => {
+    mockSupabase.functions.invoke.mockResolvedValue(invokeFailure({ sent: 8, failed: 3 }));
+    const { weekStart, weekEnd } = makeWeek();
+
+    const { result } = renderHook(() => usePublishSchedule(), { wrapper: createWrapper() });
+    await act(async () => {
+      await result.current.mutateAsync({ restaurantId: 'r1', weekStart, weekEnd });
+    });
+
+    const toasted = lastToast();
+    expect(toasted.variant).toBe('destructive');
+    expect(toasted.title).toContain('some employees not notified');
+    expect(toasted.description).toContain('8 notified, 3 could not be reached');
+  });
+
+  it('says nobody was notified when the whole fan-out failed', async () => {
+    mockSupabase.functions.invoke.mockResolvedValue(invokeFailure({ sent: 0, failed: 11 }));
+    const { weekStart, weekEnd } = makeWeek();
+
+    const { result } = renderHook(() => usePublishSchedule(), { wrapper: createWrapper() });
+    await act(async () => {
+      await result.current.mutateAsync({ restaurantId: 'r1', weekStart, weekEnd });
+    });
+
+    const toasted = lastToast();
+    expect(toasted.variant).toBe('destructive');
+    expect(toasted.title).toContain('nobody was notified');
+    expect(toasted.description).toContain('All 11 notifications failed');
+  });
+
+  it('admits it cannot confirm delivery when the invoke never reached the function', async () => {
+    mockSupabase.functions.invoke.mockResolvedValue({
+      data: null,
+      error: { message: 'Failed to fetch' },
+    });
+    const { weekStart, weekEnd } = makeWeek();
+
+    const { result } = renderHook(() => usePublishSchedule(), { wrapper: createWrapper() });
+    await act(async () => {
+      await result.current.mutateAsync({ restaurantId: 'r1', weekStart, weekEnd });
+    });
+
+    const toasted = lastToast();
+    expect(toasted.variant).toBe('destructive');
+    expect(toasted.title).toContain('notifications unconfirmed');
+    expect(toasted.description).toContain('Failed to fetch');
+  });
+
+  it('still reports the publish itself as done when notifications fail', async () => {
+    mockSupabase.functions.invoke.mockResolvedValue(invokeFailure({ sent: 0, failed: 4 }));
+    const { weekStart, weekEnd } = makeWeek();
+
+    const { result } = renderHook(() => usePublishSchedule(), { wrapper: createWrapper() });
+    await act(async () => {
+      await result.current.mutateAsync({ restaurantId: 'r1', weekStart, weekEnd });
+    });
+
+    // The RPC already committed; a failed fan-out must not read as a failed
+    // publish, or the manager will publish again and re-notify everyone who did
+    // get through.
+    expect(result.current.isError).toBe(false);
+    expect(lastToast().title).toMatch(/^Schedule Published/);
+  });
+});
+
+describe('unpublish notification outcomes', () => {
+  beforeEach(() => {
+    mockSupabase.from.mockReset();
+    mockSupabase.rpc.mockReset();
+    mockSupabase.functions.invoke.mockReset();
+    mockToast.mockReset();
+  });
+
+  it('tells the retracted employees and says so', async () => {
+    mockSupabase.rpc.mockResolvedValue({ data: 63, error: null });
+    mockSupabase.functions.invoke.mockResolvedValue({ data: { sent: 12, failed: 0 }, error: null });
+    const { weekStart, weekEnd } = makeWeek();
+
+    const { result } = renderHook(() => useUnpublishSchedule(), { wrapper: createWrapper() });
+    await act(async () => {
+      await result.current.mutateAsync({ restaurantId: 'r1', weekStart, weekEnd });
+    });
+
+    expect(mockSupabase.functions.invoke).toHaveBeenCalledWith('notify-schedule-unpublished', {
+      body: { restaurantId: 'r1', weekStart: '2026-07-27' },
+    });
+    expect(lastToast()).toEqual({
+      title: 'Schedule Unpublished',
+      description: expect.stringContaining('63 shifts have been unlocked'),
+    });
+  });
+
+  it('skips the notification entirely when nothing was actually retracted', async () => {
+    mockSupabase.rpc.mockResolvedValue({ data: 0, error: null });
+    const { weekStart, weekEnd } = makeWeek();
+
+    const { result } = renderHook(() => useUnpublishSchedule(), { wrapper: createWrapper() });
+    await act(async () => {
+      await result.current.mutateAsync({ restaurantId: 'r1', weekStart, weekEnd });
+    });
+
+    // A double-tap on Unpublish has nobody to tell, and invoking anyway would
+    // surface a scary "unconfirmed" toast for a no-op.
+    expect(mockSupabase.functions.invoke).not.toHaveBeenCalled();
+    expect(lastToast().variant).toBeUndefined();
+  });
+
+  it('warns the manager when the retracted employees were not all reached', async () => {
+    mockSupabase.rpc.mockResolvedValue({ data: 63, error: null });
+    mockSupabase.functions.invoke.mockResolvedValue(invokeFailure({ sent: 0, failed: 12 }));
+    const { weekStart, weekEnd } = makeWeek();
+
+    const { result } = renderHook(() => useUnpublishSchedule(), { wrapper: createWrapper() });
+    await act(async () => {
+      await result.current.mutateAsync({ restaurantId: 'r1', weekStart, weekEnd });
+    });
+
+    const toasted = lastToast();
+    expect(toasted.variant).toBe('destructive');
+    expect(toasted.title).toContain('nobody was notified');
+  });
+});

--- a/tests/unit/useWeekScheduleStatus.test.ts
+++ b/tests/unit/useWeekScheduleStatus.test.ts
@@ -1,0 +1,159 @@
+import React, { ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockSupabase = vi.hoisted(() => ({
+  from: vi.fn(),
+  rpc: vi.fn(),
+  functions: { invoke: vi.fn() },
+}));
+
+vi.mock('@/integrations/supabase/client', () => ({ supabase: mockSupabase }));
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+
+import { useWeekScheduleStatus } from '@/hooks/useSchedulePublish';
+
+const WEEK_START = new Date(2026, 7, 3); // Mon 2026-08-03, TZ-portable
+
+/** Postgrest-style chainable builder terminating in maybeSingle(). */
+function makeBuilder(result: { data?: unknown; error?: unknown }) {
+  const builder: Record<string, unknown> = {};
+  for (const m of ['select', 'eq', 'order', 'limit']) {
+    builder[m] = vi.fn(() => builder);
+  }
+  builder.maybeSingle = vi.fn(() => Promise.resolve(result));
+  return builder;
+}
+
+function publicationRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'pub-1',
+    restaurant_id: 'r1',
+    week_start_date: '2026-08-03',
+    week_end_date: '2026-08-09',
+    published_at: '2026-08-01T15:00:00Z',
+    notification_sent: true,
+    ...overrides,
+  };
+}
+
+function shifts(published: number, draft: number) {
+  return [
+    ...Array.from({ length: published }, () => ({ is_published: true })),
+    ...Array.from({ length: draft }, () => ({ is_published: false })),
+  ];
+}
+
+function createWrapper() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return React.createElement(QueryClientProvider, { client }, children);
+  };
+}
+
+function renderStatus(result: { data?: unknown; error?: unknown }, weekShifts: { is_published: boolean }[]) {
+  const builder = makeBuilder(result);
+  mockSupabase.from.mockReturnValue(builder);
+  const rendered = renderHook(() => useWeekScheduleStatus('r1', WEEK_START, weekShifts), {
+    wrapper: createWrapper(),
+  });
+  return { ...rendered, builder };
+}
+
+describe('useWeekScheduleStatus', () => {
+  beforeEach(() => {
+    mockSupabase.from.mockReset();
+  });
+
+  it('reports not_published when the week was never announced', async () => {
+    const { result } = renderStatus({ data: null, error: null }, shifts(0, 6));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // Six drafts on the grid and still "not published" -- a draft-only week is
+    // exactly the case employees were reading as their schedule.
+    expect(result.current.state).toBe('not_published');
+    expect(result.current.draftCount).toBe(6);
+    expect(result.current.publication).toBeNull();
+  });
+
+  it('reports published when every shift this employee has is locked in', async () => {
+    const { result } = renderStatus({ data: publicationRow(), error: null }, shifts(4, 0));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.state).toBe('published');
+    expect(result.current.publishedCount).toBe(4);
+    expect(result.current.publication?.id).toBe('pub-1');
+  });
+
+  it('reports published_revising when confirmed shifts sit next to unconfirmed ones', async () => {
+    const { result } = renderStatus({ data: publicationRow(), error: null }, shifts(3, 2));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.state).toBe('published_revising');
+    expect(result.current.publishedCount).toBe(3);
+    expect(result.current.draftCount).toBe(2);
+  });
+
+  it('reports retracted for the incident: announced week, now zero published shifts', async () => {
+    // The Aug 3-9 case exactly -- 63 shifts unpublished after the week had
+    // already been announced. useWeekPublicationStatus returns null here, which
+    // is indistinguishable from a week nobody ever published.
+    const { result } = renderStatus(
+      { data: publicationRow({ notification_sent: true }), error: null },
+      shifts(0, 5),
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.state).toBe('retracted');
+    expect(result.current.publishedCount).toBe(0);
+    expect(result.current.draftCount).toBe(5);
+    expect(result.current.publication?.notification_sent).toBe(true);
+  });
+
+  it('reports retracted even when the retracted week has no shifts left at all', async () => {
+    const { result } = renderStatus({ data: publicationRow(), error: null }, []);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // Otherwise this renders as a published week off, which is the single most
+    // dangerous misreading available here.
+    expect(result.current.state).toBe('retracted');
+  });
+
+  it('withholds a state rather than guessing when the lookup fails', async () => {
+    const { result } = renderStatus({ data: null, error: { message: 'boom' } }, shifts(2, 1));
+
+    await waitFor(() => expect(result.current.error).toBeTruthy());
+
+    // A wrong banner is worse than no banner: claiming "not published" over a
+    // week that is in fact published would tell people to ignore real shifts.
+    expect(result.current.state).toBeNull();
+    // The counts still come from shifts the caller already holds, so the grid
+    // does not degrade just because this query did.
+    expect(result.current.publishedCount).toBe(2);
+    expect(result.current.draftCount).toBe(1);
+  });
+
+  it('withholds a state while the lookup is still in flight', () => {
+    const { result } = renderStatus({ data: publicationRow(), error: null }, shifts(2, 0));
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.state).toBeNull();
+  });
+
+  it('looks up by week_start_date alone, newest publication first', async () => {
+    const { result, builder } = renderStatus({ data: publicationRow(), error: null }, shifts(1, 0));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(mockSupabase.from).toHaveBeenCalledWith('schedule_publications');
+    expect(builder.eq).toHaveBeenCalledWith('week_start_date', '2026-08-03');
+    // A republished week has several rows; the stale one must not win.
+    expect(builder.order).toHaveBeenCalledWith('published_at', { ascending: false });
+  });
+});

--- a/tests/unit/useWeekScheduleStatus.test.ts
+++ b/tests/unit/useWeekScheduleStatus.test.ts
@@ -52,12 +52,17 @@ function createWrapper() {
   };
 }
 
-function renderStatus(result: { data?: unknown; error?: unknown }, weekShifts: { is_published: boolean }[]) {
+function renderStatus(
+  result: { data?: unknown; error?: unknown },
+  weekShifts: { is_published: boolean }[],
+  shiftsLoading = false
+) {
   const builder = makeBuilder(result);
   mockSupabase.from.mockReturnValue(builder);
-  const rendered = renderHook(() => useWeekScheduleStatus('r1', WEEK_START, weekShifts), {
-    wrapper: createWrapper(),
-  });
+  const rendered = renderHook(
+    () => useWeekScheduleStatus('r1', WEEK_START, weekShifts, shiftsLoading),
+    { wrapper: createWrapper() }
+  );
   return { ...rendered, builder };
 }
 
@@ -143,6 +148,20 @@ describe('useWeekScheduleStatus', () => {
 
   it('withholds a state while the lookup is still in flight', () => {
     const { result } = renderStatus({ data: publicationRow(), error: null }, shifts(2, 0));
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.state).toBeNull();
+  });
+
+  it('withholds a state while the shifts themselves are still loading', async () => {
+    // An empty shifts array reads the same whether the employee has no shifts
+    // or the query has not answered, and those map to opposite banners. With
+    // the publication row already cached this hook's own isLoading is false, so
+    // without the flag a retracted week would render the quiet "Published ..."
+    // line and then flip to the red banner a beat later.
+    const { result } = renderStatus({ data: publicationRow(), error: null }, [], true);
+
+    await waitFor(() => expect(result.current.publication).not.toBeNull());
 
     expect(result.current.loading).toBe(true);
     expect(result.current.state).toBeNull();

--- a/tests/unit/useWeekScheduleStatus.test.ts
+++ b/tests/unit/useWeekScheduleStatus.test.ts
@@ -115,14 +115,16 @@ describe('useWeekScheduleStatus', () => {
     expect(result.current.publication?.notification_sent).toBe(true);
   });
 
-  it('reports retracted even when the retracted week has no shifts left at all', async () => {
+  it('does not cry retraction at an employee who simply has no shifts this week', async () => {
     const { result } = renderStatus({ data: publicationRow(), error: null }, []);
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    // Otherwise this renders as a published week off, which is the single most
-    // dangerous misreading available here.
-    expect(result.current.state).toBe('retracted');
+    // Unpublishing flips shifts to draft, it never deletes them, so zero shifts
+    // of any kind is "not on the roster", not "pulled back". Reading it as a
+    // retraction would tell every part-timer their schedule was withdrawn on
+    // every week they have off.
+    expect(result.current.state).toBe('published');
   });
 
   it('withholds a state rather than guessing when the lookup fails', async () => {


### PR DESCRIPTION
## Why

A manager published the week of Jul 27 – Aug 2 and 11 employees were emailed. The week of Aug 3 – 9 has more people on it, and those people got nothing. The reported symptom turned out to be a false alarm — 11 is exactly the number of distinct employees with published shifts that week at Wetzel's · Cold Stone · Alamo Ranch, and Aug 3–9 was never published — but chasing it surfaced six real defects, all of which bite the same way: **employees cannot tell what their schedule is.**

Two of them had already happened in production. On Aug 2 a manager unpublished 63 live shifts for a week that had been announced on Aug 1, and nobody was told. And every one of the 12 publication rows in production reads `notification_sent = false`, including the one that demonstrably delivered 11 emails.

## What's fixed

**A. `notification_sent` was never recorded.** `notify-schedule-published` wrote the flag with the *user-scoped* anon client instead of the `serviceClient` already in scope. `schedule_publications` has SELECT and INSERT policies but no UPDATE policy, and RLS with no UPDATE policy silently filters to zero rows — it does not raise. The result was never error-checked either. Now it writes with `serviceClient` and checks the error.

Per the product decision, **no UPDATE policy was added**: the write only ever comes from a service-role client, and a client-writable `notification_sent` would let a manager forge or suppress the retraction gate.

**B. Send failures were invisible.** `useSchedulePublish` fired the invoke without awaiting and only `console.log`'d; the function counted failures and still returned 200. The invoke is now awaited and a partial or total failure surfaces as a toast the manager can act on.

**C. The Resend fan-out was fully concurrent.** `Promise.allSettled` over the whole roster against a 2 req/s default limit. Eleven recipients squeaked through; a 25-person roster would not. Sending is now paced.

**D. Unpublishing told nobody.** New `notify-schedule-unpublished` function, invoked from `useUnpublishSchedule`.

The audience is the hard part. `unpublish_schedule` flips `is_published` to false on every affected row, which erases the only record of who was on the published version — and it must not be passed in by the caller, because a notification function that mails whichever `employee_ids` arrive in the request body is a mail relay for any authenticated user. So the audience is snapshotted inside the RPC's own transaction, from the `UPDATE`'s `RETURNING`, into a new `schedule_retractions` table. The function derives everything from `{restaurantId, weekStart}`.

**E. Employees saw draft shifts as their schedule.** `useShifts` had no `is_published` filter and RLS lets any restaurant member read every shift. Per the product decision drafts stay **visible**, marked tentative — dashed border, "Draft — not confirmed", muted, no Trade button — rather than hidden. A 4-state banner (`not_published` / `published` / `published_revising` / `retracted`) sits above the week, plus an "Updated since you last checked" hint driven by a locally-stored fingerprint.

**F. Week bucketing disagreed with the RPC.** `useSchedulePublish` counted published shifts by browser-local `toISOString()` while `publish_schedule` buckets by `(start_time AT TIME ZONE v_tz)::date`, so the manager's "Published" badge could disagree with what publish actually did at week edges. Both now bucket in the restaurant's timezone.

## Decisions worth knowing

**Retractions are gated on `notification_sent = true`.** Pulling back a week nobody was told about should not generate the first message they ever receive about it.

**"Announced" now requires real delivery, not a successful attempt.** `ch.push === true` is not proof anyone was reached: `sendWebPushToUser` returns `{ sent: 0 }` when VAPID keys or subscriptions are missing. An email-disabled restaurant with no push subscribers would otherwise record `notification_sent = true` having reached nobody — and a later unpublish would sail through the gate above and mail everyone about withdrawing a schedule they were never sent. Both notifiers now count deliveries.

**The publish dialog blocks while the fan-out runs.** That is deliberate — awaiting is what makes (B) possible — but it means the button can sit for ~10s on a 25-person roster, because (C) paces the sends. The pending copy names it (`Notifying 25...`) so a legitimate wait doesn't read as a hung button. A background job would decouple the two; it's the right long-term shape and out of scope here.

**Only the newest retraction for a week can ever be announced.** The lookup takes the latest row outright and checks the `notified_at` latch *afterward*. Ordering after the latch test instead would select the newest *unnotified* row, which is a different row: retract twice in quick succession and the first call latches the newer one, then a retry finds the older one still unlatched and mails everyone about a version that was superseded before anyone heard of it. Older rows are permanently audit-only.

**`sendPaced` degrades under a sustained 429 storm.** The retry backoff is per-recipient, so a Resend outage stretches wall clock rather than dropping mail. Documented in the module's doc comment.

## Known limitation

Every publication row in production currently reads `notification_sent = false` — that *is* defect A. So the retraction gate suppresses **all** retraction notifications until a week is published after this ships. It is correct-conservative and self-healing within one publish cycle.

No backfill: it would assert deliveries we cannot verify, and it's a production write that needs its own approval.

## One out-of-scope fix

`tests/unit/BulkInventoryDeductionDialog.datePicker.test.tsx` has been red on `main` since 2026-08-01, two runs before this branched. It addresses calendar days by number while the calendar also renders the outside days padding the grid, so `getByRole('gridcell', {name: '5'})` matches both Aug 5 and Sep 5 in the August grid. It passed only in months whose padding happened to miss 5, 10, 15 and 20. The clock is now pinned to 2026-07-15. Fixed here because it blocks this PR's merge gate, in its own commit (`64192d32`) so it can be read or reverted separately.

## Deviations from the approved plan

- `notify-schedule-unpublished` uses the existing batched `sendWebPushToUsers` plus `runBounded` for native push, rather than the planned sibling helper in `_shared/schedulePublishedPush.ts`.
- Retractions ride the existing `schedule_published` `NotificationType` gate instead of a new type — an employee who wants publish mail wants to know when it's withdrawn.
- `useWeekPublicationStatus` takes an explicit `timezone` param rather than reaching for `useRestaurantContext()`; `useWeekScheduleStatus` takes `shifts` as a parameter rather than refetching them.
- Design §7(b) (republish copy — "Schedule Updated Again") was implemented although the plan's step 3 didn't enumerate it.
- `useWeekRetractionReason` is a new hook not named in the plan.
- Reviewer-driven, not planned: the `PublishScheduleDialog` pending copy, and `idx_schedule_publications_week_lookup` (three separate lookups filter on `(restaurant_id, week_start_date)` and take the newest row; the table only carried single-column indexes).
- `src/integrations/supabase/types.ts` was hand-edited rather than regenerated — the local DB was 14 migrations behind and was brought current by hand.

## Tests

- **Unit:** 66 across 7 files — `useWeekScheduleStatus`, `ScheduleStatusBanner`, `useSchedulePublish`, `scheduleSeenFingerprint`, `scheduleWeekRange`, `ShiftRow`, `emailQueue`.
- **pgTAP:** `supabase/tests/schedule_retractions.test.sql`, 22 assertions — including one that pins the *absence* of an UPDATE policy, one that catches the trap that a SELECT policy without a matching GRANT is dead code, one that proves a non-member reads zero retractions (the member-can-read assertion alone would pass under `USING (true)`), and one that pins the table's write grants directly rather than trusting whatever default privileges the host applies.
- **E2E:** `tests/e2e/employee-schedule-retraction.spec.ts` — publish → unpublish → employee sees the retracted state.
- **Full suite:** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
