### PR TITLE
fix(tests): scope date-picker day lookups to in-month calendar cells

### DIFF
--- a/docs/superpowers/plans/2026-08-02-datepicker-test-outside-days-plan.md
+++ b/docs/superpowers/plans/2026-08-02-datepicker-test-outside-days-plan.md
@@ -27,10 +27,10 @@ Design: `docs/superpowers/specs/2026-08-02-datepicker-test-outside-days-design.m
       add `vi.useFakeTimers({ shouldAdvanceTime: true })` +
       `vi.setSystemTime(new Date('2027-02-10T12:00:00'))` to a scratch copy of
       the file and run it. Feb 2027 starts on a Monday, so its grid runs
-      Feb 1 – Mar 14 and the trailing outside days cover 1–14 — both `'5'` and
-      `'10'` collide. If the suite passes there too, the fix is month-independent
-      rather than month-lucky. Revert the scratch edit afterwards; the committed
-      file keeps no fake timers (`memory/lessons.md:42`).
+      Jan 31 – Mar 6 and the outside Mar 5 collides with Feb 5. If the suite
+      passes there too, the fix is month-independent rather than month-lucky.
+      Revert the scratch edit afterwards; the committed file keeps no fake
+      timers (`memory/lessons.md:42`).
 
 - [ ] **T6 — Commit.** `fix(tests): scope date-picker day lookups to in-month
       cells`.

--- a/docs/superpowers/plans/2026-08-02-datepicker-test-outside-days-plan.md
+++ b/docs/superpowers/plans/2026-08-02-datepicker-test-outside-days-plan.md
@@ -1,0 +1,59 @@
+# Plan: make the BulkInventoryDeductionDialog date-picker test clock-independent
+
+Design: `docs/superpowers/specs/2026-08-02-datepicker-test-outside-days-design.md`
+
+## Tasks
+
+- [ ] **T1 — Reproduce (RED).** Run
+      `npx vitest run tests/unit/BulkInventoryDeductionDialog.datePicker.test.tsx`
+      on the unmodified file and capture the "found multiple elements" failure
+      at `:120`. *(Done before planning; re-confirmed in the commit message.)*
+
+- [ ] **T2 — Add the `getDayCell` helper.** Insert it above the `describe`
+      block in `tests/unit/BulkInventoryDeductionDialog.datePicker.test.tsx`.
+      Filters `getAllByRole('gridcell', { name })` down to cells without the
+      `day-outside` class and asserts exactly one survivor.
+
+- [ ] **T3 — Route all four day lookups through the helper.**
+      `'10'` (start-date close-on-select), `'20'` (end-date close-on-select),
+      `'5'` and `'20'` (end-date disabled guard). No other changes to the
+      assertions.
+
+- [ ] **T4 — GREEN with the real clock.** Re-run the file. All 5 tests pass with
+      the host clock untouched (today is 2026-08-02, i.e. the month that
+      reproduces the bug).
+
+- [ ] **T5 — Hostile-month cross-check (throwaway, not committed).** Temporarily
+      add `vi.useFakeTimers({ shouldAdvanceTime: true })` +
+      `vi.setSystemTime(new Date('2027-02-10T12:00:00'))` to a scratch copy of
+      the file and run it. Feb 2027 starts on a Monday, so its grid runs
+      Feb 1 – Mar 14 and the trailing outside days cover 1–14 — both `'5'` and
+      `'10'` collide. If the suite passes there too, the fix is month-independent
+      rather than month-lucky. Revert the scratch edit afterwards; the committed
+      file keeps no fake timers (`memory/lessons.md:42`).
+
+- [ ] **T6 — Commit.** `fix(tests): scope date-picker day lookups to in-month
+      cells`.
+
+- [ ] **T7 — CodeRabbit local review** (`coderabbit review --plain --type
+      committed`), fix any actionable findings.
+
+- [ ] **T8 — Verify (Phase 8).** Full `npm run test`, `npm run typecheck`,
+      `npm run lint`, `npm run build`.
+      **E2E gate:** justified exception — this is a test-only change with no
+      user-facing behaviour change and no cross-layer seam touched. No
+      `tests/e2e/` spec is applicable.
+
+- [ ] **T9 — Ship (Phase 9).** Push, open PR, watch CI, triage every review
+      comment, then report.
+
+## Dependencies
+
+T1 → T2 → T3 → T4 → T5 → T6 → T7 → T8 → T9 (strictly sequential; the change is
+a single file).
+
+## Out of scope
+
+- Any change to `DatePicker`, `Calendar`, or `BulkInventoryDeductionDialog`.
+- Auditing other test files for the same outside-day hazard. Worth a follow-up
+  sweep, but it is not what is turning CI red today.

--- a/docs/superpowers/specs/2026-08-02-datepicker-test-outside-days-design.md
+++ b/docs/superpowers/specs/2026-08-02-datepicker-test-outside-days-design.md
@@ -1,0 +1,120 @@
+# Design: make the BulkInventoryDeductionDialog date-picker test clock-independent
+
+- **Date:** 2026-08-02
+- **Type:** fix (test-only)
+- **Files touched:** `tests/unit/BulkInventoryDeductionDialog.datePicker.test.tsx`
+
+## Problem
+
+`tests/unit/BulkInventoryDeductionDialog.datePicker.test.tsx` fails on `main`
+(commit `2bafd868`), turning the "Unit Tests" workflow red on `main` and on
+every open PR.
+
+The failing assertion is in *"end-date: days before the selected start date are
+disabled"*:
+
+```ts
+const day5Cell = within(grid).getByRole('gridcell', { name: '5' });
+```
+`tests/unit/BulkInventoryDeductionDialog.datePicker.test.tsx:120`
+
+`getByRole` throws *"found multiple elements"*. The calendar renders outside
+days from the adjacent months, so in a month whose grid runs past the 1st of the
+next month at a low enough day number, two `gridcell`s carry the same accessible
+name.
+
+### Why the duplicate exists
+
+- The dialog renders both pickers with the shared `DatePicker` primitive
+  (`src/components/BulkInventoryDeductionDialog.tsx:109` and `:118`), which
+  mounts `<Calendar mode="single" …>` (`src/components/ui/date-picker.tsx:86`).
+- `Calendar` is react-day-picker **v8.10.1** and defaults `showOutsideDays` to
+  `true` (`src/components/ui/calendar.tsx:10`, forwarded at `:13`), so the
+  6-week grid is padded with days from the previous and next month.
+- Neither picker passes `defaultMonth`, and neither has a value when the
+  calendar first opens (`src/components/ui/date-picker.tsx:89` falls back to
+  `value`, i.e. `undefined`), so react-day-picker displays **the current
+  month** — whatever the host clock says.
+
+In August 2026 the last grid row is Aug 30 – Sep 5, so `5` matches both Aug 5
+and the outside Sep 5. The same hazard applies to the `'10'` lookup at
+`:79`; trailing outside days can reach into the low teens (a 28-day February
+starting on a Monday pads out to Mar 13). `'15'` and `'20'` happen to be safe
+today, but only by arithmetic accident.
+
+## Options considered
+
+### A. Pin the clock with fake timers
+
+`vi.setSystemTime(new Date('2026-06-15T12:00:00'))` in `beforeEach`, restored in
+`afterEach`. June 2026's grid spans May 31 – Jul 4, so nothing collides.
+
+- **Pro:** two lines, no query changes.
+- **Con:** it fixes the symptom by choosing a lucky month. Any future test in
+  this file that reaches for a different day number re-opens the same trap. It
+  also drags `vi.useFakeTimers()` into a file that has no need for timer
+  control; `memory/lessons.md:42` already records fake timers leaking across
+  files when `useRealTimers` is missed.
+
+### B. Scope the queries to non-outside days (chosen)
+
+Query all matching gridcells and keep the one that is *not* an outside day.
+react-day-picker v8 tags outside days via `classNames.day_outside`, which our
+`Calendar` sets to a string beginning with the literal `day-outside`
+(`src/components/ui/calendar.tsx:37-38`). That class is not decorative — the
+cell selector in the same file keys off it
+(`[&:has([aria-selected].day-outside)]:bg-accent/50`,
+`src/components/ui/calendar.tsx:31`), so it is load-bearing and will not be
+dropped silently.
+
+- **Pro:** correct in every month, so the test is clock-independent by
+  construction rather than by choice of month. It also expresses the intent —
+  *the 5th of the displayed month* — instead of *"the only cell labelled 5"*.
+- **Con:** couples the test to a class name. Mitigated by asserting exactly one
+  in-month match, so a rename fails loudly instead of silently selecting the
+  wrong cell.
+
+**Chosen: B.** A is a smaller diff but leaves the trap armed.
+
+## Design
+
+Add one helper at the top of the test file and route all four day lookups
+through it:
+
+```ts
+/**
+ * react-day-picker pads the 6-week grid with outside days from the adjacent
+ * months (`showOutsideDays` defaults to true), so a label like "5" can match
+ * both the 5th of the displayed month and an outside 5th of the next one.
+ * Keep only the in-month cell — outside days carry the `day-outside` class
+ * from `Calendar`'s `classNames.day_outside`.
+ */
+function getDayCell(grid: HTMLElement, day: string): HTMLElement {
+  const cells = within(grid)
+    .getAllByRole('gridcell', { name: day })
+    .filter((cell) => !cell.classList.contains('day-outside'));
+  expect(cells).toHaveLength(1);
+  return cells[0];
+}
+```
+
+Call sites replaced: `:79` (`'10'`), `:93` (`'20'`), `:120` (`'5'`),
+`:124` (`'20'`).
+
+## Non-goals
+
+- No change to `DatePicker`, `Calendar`, or `BulkInventoryDeductionDialog`.
+  The duplicate-name situation is normal react-day-picker output, not an
+  accessibility defect to fix in the component.
+- No fake timers. The fix removes the clock dependency rather than freezing it.
+
+## Verification
+
+- `npx vitest run tests/unit/BulkInventoryDeductionDialog.datePicker.test.tsx`
+  passes with the host clock untouched (currently August 2026 — the month that
+  reproduces the bug).
+- The same run under a simulated February-starting-Monday month (via `TZ`- and
+  `--` free re-run with a temporarily faked system date) confirms the query no
+  longer depends on the displayed month. Documented in the plan as a manual
+  cross-check, not committed as a permanent test.
+- Full unit suite, typecheck, lint, build.

--- a/docs/superpowers/specs/2026-08-02-datepicker-test-outside-days-design.md
+++ b/docs/superpowers/specs/2026-08-02-datepicker-test-outside-days-design.md
@@ -37,10 +37,16 @@ name.
   month** — whatever the host clock says.
 
 In August 2026 the last grid row is Aug 30 – Sep 5, so `5` matches both Aug 5
-and the outside Sep 5. The same hazard applies to the `'10'` lookup at
-`:79`; trailing outside days can reach into the low teens (a 28-day February
-starting on a Monday pads out to Mar 13). `'15'` and `'20'` happen to be safe
-today, but only by arithmetic accident.
+and the outside Sep 5.
+
+Enumerating every month from 2020–2040 bounds the exposure: leading outside days
+always fall in **23–31** and trailing outside days in **1–6** (react-day-picker
+v8 does not pad to a fixed six weeks unless asked, so a trailing run never
+exceeds 6). Days **7–22** are therefore unambiguous in every month. That makes
+`'10'`, `'15'` and `'20'` safe as written, and `'5'` the only lookup in this
+file that can collide — but the safety is a property of those particular
+numbers, not of the query. Any future assertion on a day ≤ 6 or ≥ 23 walks into
+the same failure.
 
 ## Options considered
 
@@ -113,8 +119,7 @@ Call sites replaced: `:79` (`'10'`), `:93` (`'20'`), `:120` (`'5'`),
 - `npx vitest run tests/unit/BulkInventoryDeductionDialog.datePicker.test.tsx`
   passes with the host clock untouched (currently August 2026 — the month that
   reproduces the bug).
-- The same run under a simulated February-starting-Monday month (via `TZ`- and
-  `--` free re-run with a temporarily faked system date) confirms the query no
-  longer depends on the displayed month. Documented in the plan as a manual
-  cross-check, not committed as a permanent test.
+- A throwaway re-run with the clock faked to February 2027 (grid Jan 31 – Mar 6,
+  so the outside Mar 5 collides with Feb 5) confirms the query holds in a month
+  other than today's. Manual cross-check only — no fake timers are committed.
 - Full unit suite, typecheck, lint, build.

--- a/tests/unit/BulkInventoryDeductionDialog.datePicker.test.tsx
+++ b/tests/unit/BulkInventoryDeductionDialog.datePicker.test.tsx
@@ -32,6 +32,27 @@ vi.mock('@/contexts/RestaurantContext', () => ({
 
 // Alert uses ui primitives — no supabase dependency; no stub needed.
 
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve a day cell by its label, ignoring outside days.
+ *
+ * react-day-picker pads the six-week grid with days from the adjacent months
+ * (`showOutsideDays` defaults to true in our Calendar), so a label like "5" can
+ * match both the 5th of the displayed month and an outside 5th of the next one
+ * — which month it happens to be decides whether the query is ambiguous.
+ * Outside days carry the `day-outside` class from `Calendar`'s
+ * `classNames.day_outside`; dropping them leaves exactly one in-month cell in
+ * any month, so these queries do not depend on the system clock.
+ */
+function getDayCell(grid: HTMLElement, day: string): HTMLElement {
+  const inMonth = within(grid)
+    .getAllByRole('gridcell', { name: day })
+    .filter((cell) => !cell.classList.contains('day-outside'));
+  expect(inMonth).toHaveLength(1);
+  return inMonth[0];
+}
+
 // ── Tests ────────────────────────────────────────────────────────────────────
 describe('BulkInventoryDeductionDialog — date pickers (BUG-001 regression)', () => {
   beforeEach(() => {
@@ -76,7 +97,7 @@ describe('BulkInventoryDeductionDialog — date pickers (BUG-001 regression)', (
     const startTrigger = screen.getByRole('button', { name: /select start date/i });
     await user.click(startTrigger);
     const grid = await screen.findByRole('grid');
-    await user.click(within(grid).getByRole('gridcell', { name: '10' }));
+    await user.click(getDayCell(grid, '10'));
 
     // After migration: controlled DatePicker closes on a real pick.
     expect(startTrigger).toHaveAttribute('aria-expanded', 'false');
@@ -90,7 +111,7 @@ describe('BulkInventoryDeductionDialog — date pickers (BUG-001 regression)', (
     const endTrigger = screen.getByRole('button', { name: /select end date/i });
     await user.click(endTrigger);
     const grid = await screen.findByRole('grid');
-    await user.click(within(grid).getByRole('gridcell', { name: '20' }));
+    await user.click(getDayCell(grid, '20'));
 
     // After migration: controlled DatePicker closes on a real pick.
     expect(endTrigger).toHaveAttribute('aria-expanded', 'false');
@@ -105,7 +126,7 @@ describe('BulkInventoryDeductionDialog — date pickers (BUG-001 regression)', (
     const startTrigger = screen.getByRole('button', { name: /select start date/i });
     await user.click(startTrigger);
     let grid = await screen.findByRole('grid');
-    await user.click(within(grid).getByRole('gridcell', { name: '15' }));
+    await user.click(getDayCell(grid, '15'));
     // Start picker closes after selection.
     expect(startTrigger).toHaveAttribute('aria-expanded', 'false');
 
@@ -117,11 +138,9 @@ describe('BulkInventoryDeductionDialog — date pickers (BUG-001 regression)', (
     // Day 5 is before the start (day 15) → it must be disabled.
     // react-day-picker renders each day as a <button role="gridcell">;
     // disabled days carry the HTML `disabled` attribute directly on the button.
-    const day5Cell = within(grid).getByRole('gridcell', { name: '5' });
-    expect(day5Cell).toBeDisabled();
+    expect(getDayCell(grid, '5')).toBeDisabled();
 
     // Day 20 is after the start (day 15) → it must NOT be disabled.
-    const day20Cell = within(grid).getByRole('gridcell', { name: '20' });
-    expect(day20Cell).not.toBeDisabled();
+    expect(getDayCell(grid, '20')).not.toBeDisabled();
   });
 });


### PR DESCRIPTION
## Summary

- `tests/unit/BulkInventoryDeductionDialog.datePicker.test.tsx` was resolving calendar days by accessible name. react-day-picker pads the grid with outside days from the adjacent months, so in August 2026 `getByRole('gridcell', { name: '5' })` matched both Aug 5 and the outside Sep 5 and threw *"found multiple elements"* — turning the **Unit Tests** workflow red on `main` (2bafd868) and on every open PR.
- Adds a `getDayCell(grid, day)` helper that drops cells carrying react-day-picker's `day-outside` class and asserts exactly one in-month survivor, then routes all four day lookups (`'5'`, `'10'`, `'15'`, `'20'`) through it.
- Fixes the clock dependency outright rather than pinning the system time. Enumerating 2020–2040 shows leading outside days always fall in **23–31** and trailing ones in **1–6**, so `'10'`/`'15'`/`'20'` were safe only by arithmetic accident — any future assertion on a day ≤ 6 or ≥ 23 would have hit the same wall.

No production code changed.

## Test plan

- `npx vitest run tests/unit/BulkInventoryDeductionDialog.datePicker.test.tsx` — 5/5 pass with the host clock untouched (today is 2026-08-02, the month that reproduces the failure).
- Same file re-run under a throwaway faked Feb 2027 clock (grid Jan 31 – Mar 6, outside Mar 5 collides with Feb 5): passes with the helper, and still fails with `found multiple elements` when the old query is restored — so the cross-check is load-bearing, not vacuous. No fake timers are committed.
- Full unit suite: **8330 passed**, 2 skipped, 0 failed.
- `npm run typecheck` clean; `npm run build` clean; `npx eslint` on the changed file exits 0.
- **E2E gate — justified exception:** test-only change with no user-facing behaviour change and no cross-layer seam touched, so no `tests/e2e/` spec is applicable.

## Design doc

`docs/superpowers/specs/2026-08-02-datepicker-test-outside-days-design.md`

## Known deferred review findings

Local CodeRabbit raised one `major` claiming `day-outside` sits on a descendant of the `gridcell` and suggesting `cell.querySelector('.day-outside')` instead. **Declined — the premise is false for react-day-picker 8.10.1.** A DOM probe against `Calendar` shows `role="gridcell"` is on the `<button>` itself and `day-outside` is on that same button (`selfHasDayOutside=true`, `descendantHasDayOutside=false`); the `<td>` is `role="presentation"`. The suggested change would make the filter a no-op and fail `toHaveLength(1)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)