### PR TITLE
feat(roles): a role card's member count becomes a door (Move 2)

### DIFF
--- a/docs/superpowers/plans/2026-08-03-role-roster.md
+++ b/docs/superpowers/plans/2026-08-03-role-roster.md
@@ -1,0 +1,187 @@
+# Role Roster (Move 2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn a role card's member count into a door — face pile → "Who's in this role" roster, "Assign people" at zero — and give the role editor `Areas | People` tabs.
+
+**Architecture:** Frontend only. Membership is resolved client-side through `roles.legacy_role`, which mirrors `role_member_counts`' `COALESCE(role_id, builtin_role_id_for(role))` without copying the mapping. Every write goes through Move 1's `assign_membership_role` RPC via the existing `useAssignRole` and `RolePicker`.
+
+**Tech Stack:** React 18 + TypeScript, React Query, shadcn/ui (Tabs, Dialog, Checkbox, Skeleton), Tailwind semantic tokens, Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-08-03-role-roster-design.md`
+
+## Global Constraints
+
+- No migration, no pgTAP, no edge function — this PR contains zero SQL.
+- Semantic color tokens only. No `bg-white` / `text-black` / raw hex.
+- React Query only for server state; `staleTime: 30000`. No `localStorage`.
+- Every data surface handles loading / error / empty explicitly.
+- Buttons without visible text need `aria-label`. Interactive elements keyboard-reachable.
+- Reuse `RolePicker` and `useAssignRole`. Do not create a second assignment path.
+- Apple/Notion type scale from CLAUDE.md: `text-[14px] font-medium` body, `text-[13px] text-muted-foreground` secondary, `text-[12px] … uppercase tracking-wider` labels, `border-border/40`, `bg-muted/30`, `rounded-lg` controls / `rounded-xl` cards.
+- Card count on a role card is always `role.memberCount` (server), never the roster's length.
+
+---
+
+### Task 1: `roleMembership.ts` — resolution mirroring `role_member_counts`
+
+**Files:**
+- Create: `src/lib/permissions/roleMembership.ts`
+- Test: `tests/unit/roleMembership.test.ts`
+
+**Interfaces:**
+- Consumes: `RestaurantMember` (`src/hooks/useRestaurantMembers.ts`), `RoleWithGrants` (`src/hooks/useRoles.ts`).
+- Produces: `legacyRoleIndex(roles): Map<string,string>`, `resolveMembershipRoleId(member, byLegacy): string | null`, `membersInRole(members, roleId, byLegacy): RestaurantMember[]`, `groupMembersByRole(members, byLegacy): Map<string, RestaurantMember[]>`.
+
+- [ ] **Step 1: Write the failing test** — `tests/unit/roleMembership.test.ts` covering: `roleId` wins over the legacy string; null `roleId` resolves through `legacy_role`; `collaborator_custom` + null `roleId` → `null`; unknown role string → `null`; `groupMembersByRole` totals match per-role counts on a mixed fixture.
+- [ ] **Step 2: Run `npx vitest run tests/unit/roleMembership.test.ts`** — expect FAIL (module not found).
+- [ ] **Step 3: Implement** the four functions. `resolveMembershipRoleId` is exactly `member.roleId ?? byLegacy.get(member.role) ?? null`, with a header comment citing `20260730200000_role_member_counts.sql:38`.
+- [ ] **Step 4: Run the test** — expect PASS.
+- [ ] **Step 5: Commit.**
+
+---
+
+### Task 2: `canAssignAnyRole` — derive the gate instead of copying it
+
+**Files:**
+- Modify: `src/lib/permissions/invitations.ts` (after `canInviteCustomRole`, line 92)
+- Modify: `src/lib/permissions/index.ts` (export it)
+- Modify: `src/components/TeamMembers.tsx:38-39`
+- Test: `tests/unit/invitationMatrix.test.ts`
+
+**Interfaces:**
+- Produces: `canAssignAnyRole(inviter: Role): boolean`.
+
+```ts
+/**
+ * Whether this role can change anyone's role at all — the gate that decides
+ * if a role-assignment control is offered. Derived from INVITABLE_ROLES
+ * rather than re-listing owner/manager/operations_manager, so it cannot
+ * disagree with the matrix the RPC enforces.
+ */
+export function canAssignAnyRole(inviter: Role): boolean {
+  return getInvitableRoles(inviter).length > 0 || canInviteCustomRole(inviter);
+}
+```
+
+- [ ] **Step 1: Add the failing test** to `tests/unit/invitationMatrix.test.ts`: true for exactly `owner`/`manager`/`operations_manager`, false for every other `Role`.
+- [ ] **Step 2: Run it** — expect FAIL.
+- [ ] **Step 3: Implement** and export from `index.ts`.
+- [ ] **Step 4: Run it** — expect PASS.
+- [ ] **Step 5: Swap `TeamMembers.tsx:38-39`** to `const canManageMembers = canAssignAnyRole(userRole);` and delete the literal list + its stale comment.
+- [ ] **Step 6: `npm run typecheck`, commit.**
+
+---
+
+### Task 3: hook plumbing — `membershipId` and the missing invalidation
+
+**Files:**
+- Modify: `src/hooks/useRestaurantMembers.ts:6-22,38-63`
+- Modify: `src/hooks/useAssignRole.ts:57-66`
+
+**Interfaces:**
+- Produces: `RestaurantMember.membershipId: string` (the `user_restaurants.id` the RPC takes).
+
+- [ ] **Step 1:** Add `membershipId: string` to `RestaurantMember` with a doc comment saying it is `user_restaurants.id`, the `p_membership_id` argument of `assign_membership_role`.
+- [ ] **Step 2:** Change the select at line 40 to `'id, user_id, role, role_id'` and map `membershipId: m.id`.
+- [ ] **Step 3:** In `useAssignRole`'s `onSuccess`, add `queryClient.invalidateQueries({ queryKey: ['restaurant-members', restaurantId] })` with a comment: the roster and the assign dialog's candidate list both read this key, and both go stale the moment an assignment lands.
+- [ ] **Step 4:** `npm run typecheck` — the three existing consumers (`EmployeeDialog.tsx:65`, `TeamInvitations.tsx:55`, `CollaboratorInvitations.tsx:192`) must still compile; an added field breaks nothing.
+- [ ] **Step 5: Commit.**
+
+---
+
+### Task 4: member display helpers + face pile
+
+**Files:**
+- Create: `src/components/roles/memberDisplay.ts`
+- Create: `src/components/roles/RoleFacePile.tsx`
+
+**Interfaces:**
+- Produces: `memberDisplayName(member): string` (full name → email → `'Unnamed member'`), `memberInitials(member): string` (up to 2 chars, falls back to the email's first letter, then `'?'`), `<RoleFacePile members max={3} />`.
+
+- [ ] **Step 1:** Write `memberDisplay.ts`. A comment records why this is not reusing `getInitials` in `src/utils/tipDistribution.ts:169` — those take a name string and have no email fallback, and a member with an unreadable `profiles` row has only an email or nothing.
+- [ ] **Step 2:** Write `RoleFacePile.tsx`: `aria-hidden="true"` wrapper, overlapping `-space-x-1.5` circles, `h-[22px] w-[22px] rounded-full bg-muted text-[10px] font-medium text-muted-foreground ring-2 ring-card`. Renders nothing when `members` is empty.
+- [ ] **Step 3:** `npm run typecheck`, commit.
+
+---
+
+### Task 5: the role card becomes two doors
+
+**Files:**
+- Modify: `src/components/roles/RolesList.tsx:31-37,72-106,127-163`
+
+**Interfaces:**
+- Consumes: Task 1 (`legacyRoleIndex`, `groupMembersByRole`), Task 4 (`RoleFacePile`), Task 3 (`useRestaurantMembers`).
+- Produces: `RolesListProps` gains `onOpenPeople: (role: RoleWithGrants) => void`.
+
+- [ ] **Step 1:** Restructure `RoleCard`. `<article>` carries the chrome and the flex column — `group flex flex-col gap-3 p-[18px] rounded-xl border border-border/40 bg-card shadow-sm hover:border-border transition-colors`. Hit button: `flex items-start gap-[11px] text-left rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring`. `RoleAreaChips` becomes a sibling (fixes the `<div>`-inside-`<button>` validity bug). Footer keeps `mt-auto pt-[11px] border-t border-border/40`.
+- [ ] **Step 2:** Footer left slot:
+  - `memberCount > 0` → button with `<RoleFacePile members={roster.slice(0,3)} />`, `memberCountLabel(n)`, `<ChevronRight className="h-3 w-3" aria-hidden="true" />`, `aria-label={`${memberCountLabel(n)} in ${role.name}. Manage who's in this role`}`.
+  - `memberCount === 0` → button with `<UserPlus className="h-3.5 w-3.5" aria-hidden="true" />` + `Assign people`, `aria-label={`Nobody is in ${role.name} yet. Assign people`}`, `text-foreground font-medium` so it reads as an action.
+- [ ] **Step 3:** In `RolesList`, call `useRestaurantMembers(restaurantId)` **once** and build `groupMembersByRole` in a `useMemo`. Pass each card `roster={byRole.get(role.id) ?? []}`. A members error or pending state yields an empty roster — faces vanish, counts and doors keep working.
+- [ ] **Step 4:** Verify `RoleCardSkeleton` (lines 50-70) still matches the loaded card's padding, gap, border and footer rule.
+- [ ] **Step 5:** `npm run typecheck && npm run lint`, commit.
+
+---
+
+### Task 6: `AssignPeopleDialog`
+
+**Files:**
+- Create: `src/components/roles/AssignPeopleDialog.tsx`
+
+**Interfaces:**
+- Consumes: `useRestaurantMembers`, `useAssignRole`, `assignRoleErrorMessage`, `CUSTOM_ROLE`, Task 1.
+- Produces: `<AssignPeopleDialog role restaurantId callerRole open onOpenChange />`.
+
+- [ ] **Step 1:** Candidate filter — exclude anyone already resolving to `role.id`, self (`useAuth`), `role === 'kiosk'`, and `role === 'owner'` when `callerRole !== 'owner'`. Each exclusion carries a comment naming the RPC rule it mirrors (rules 2, 4, 5a).
+- [ ] **Step 2:** Dialog per CLAUDE.md structure — `DialogTitle` `Assign to {name}`, `DialogDescription` *"Everyone you pick leaves the role they're in now."* Rows are `<label>` + shadcn `Checkbox` + name/email. Empty: *"Everyone already holds this role."*
+- [ ] **Step 3:** Footer — `Nobody selected` / `1 person selected` / `N people selected`; button `Assign` → `Assign N`, disabled at zero and while submitting.
+- [ ] **Step 4:** Submit sequentially in a `for…of` loop (comment: rule 5b takes `FOR UPDATE` on owner rows before counting, so parallel calls contend; and one-at-a-time keeps each failure attributable). Payload: `role.legacy_role ? { role: role.legacy_role, roleId: null } : { role: CUSTOM_ROLE, roleId: role.id }`, mirroring `RolePicker.tsx:133-141`.
+- [ ] **Step 5:** On full success — toast + close. On partial failure — keep the dialog open with failed rows still selected, toast naming each failure via `assignRoleErrorMessage`.
+- [ ] **Step 6:** `npm run typecheck && npm run lint`, commit.
+
+---
+
+### Task 7: `RoleRoster`
+
+**Files:**
+- Create: `src/components/roles/RoleRoster.tsx`
+
+**Interfaces:**
+- Consumes: Tasks 1, 2, 4, 6; `RolePicker`, `useRoles`, `useRestaurantMembers`, `useAuth`.
+- Produces: `<RoleRoster role restaurantId callerRole />`.
+
+- [ ] **Step 1:** Header — `Who's in this role` (`text-[15px] font-semibold`) and, when `canAssignAnyRole(callerRole)`, an `Assign people` button.
+- [ ] **Step 2:** States — loading: three skeleton rows; error: `role="alert"` with the message, "Assign people" still usable; empty: the spec's verbatim copy (*"Nobody is in {name} yet"* / *"A role does nothing until someone holds it…"*) with `Assign people` as the primary action.
+- [ ] **Step 3:** Rows — initials avatar (`aria-hidden`), `memberDisplayName`, email, and `RolePicker` with `disabled={!canAssign || isSelf || member.role === 'kiosk' || (member.role === 'owner' && callerRole !== 'owner')}`. No `onAssigned`: this surface is React Query and Task 3 added the invalidation.
+- [ ] **Step 4:** `npm run typecheck && npm run lint`, commit.
+
+---
+
+### Task 8: editor tabs and the wiring above them
+
+**Files:**
+- Modify: `src/components/roles/RoleEditor.tsx:105-110,386,530-541`
+- Modify: `src/components/roles/RolesTab.tsx:27-33`
+- Modify: `src/pages/Team.tsx:172`
+
+**Interfaces:**
+- `RoleEditorProps` gains `callerRole: Role`, `activeTab: 'areas' | 'people'`, `onTabChange: (t) => void`.
+- `RolesTabProps` gains `userRole: Role`.
+
+- [ ] **Step 1:** In `RoleEditor`, wrap the body below the back link in shadcn `Tabs` (controlled). `TabsList` styled to the Apple underline look. Areas panel = the existing `grid gap-5 lg:grid-cols-[minmax(0,1fr)_320px]` block moved verbatim. People panel = `<RoleRoster …/>`.
+- [ ] **Step 2:** When `role === null` (`isNewDraft`, line 390) render the Areas content with **no** tablist — an unsaved role has no members and no id.
+- [ ] **Step 3:** `RolesTab` gains `userRole` and `initialTab` state; `RolesList` gets both `onSelectRole` (→ `'areas'`) and `onOpenPeople` (→ `'people'`).
+- [ ] **Step 4:** `Team.tsx:172` → `<RolesTab restaurantId={…} userRole={selectedRestaurant.role} />`.
+- [ ] **Step 5:** `npm run typecheck && npm run lint`, commit.
+
+---
+
+### Task 9: verify
+
+- [ ] `npm run typecheck`
+- [ ] `npm run lint`
+- [ ] `npm run test`
+- [ ] `npm run build`
+- [ ] Browser pass on `/team` → Roles & areas: card face pile, zero-member "Assign people", both doors, tab switch, roster picker, assign dialog, dark mode.
+- [ ] Commit any fixes, open the PR.

--- a/docs/superpowers/specs/2026-08-03-role-roster-design.md
+++ b/docs/superpowers/specs/2026-08-03-role-roster-design.md
@@ -1,0 +1,449 @@
+# Move 2 — the member count becomes a door
+
+**Date:** 2026-08-03
+**Branch:** `feature/role-roster`
+**Builds on:** `docs/superpowers/specs/2026-08-02-role-assignment-design.md` (Move 1, shipped in #688 / `713a41cc`)
+**Prototype:** `docs/design-reference/role-assignment.html`
+
+---
+
+## Problem
+
+Move 1 made it possible to change an existing member's role, from the two
+screens that list *people*: Team Members and Collaborators. The screen that
+lists *roles* still cannot reach a person.
+
+Two dead ends survive on `Roles & areas`:
+
+1. **The member count is a label, not a link.** `RolesList.tsx:99` renders
+   `{memberCountLabel(role.memberCount)}` as a bare `<span>`. An owner who
+   wants to know *who* holds "Bartender" cannot find out from the role. They
+   have to go to Team Members and read every row.
+
+2. **A brand-new custom role reads "0 people" and offers nothing.** That is
+   the exact state a role is in one second after it is created — the moment
+   the owner most wants to put someone in it. The card says the role is empty
+   and then stops talking.
+
+The role editor has the same shape of gap: it warns *"N people have this role.
+Saving changes what they can reach the next time they load a page."*
+(`RoleEditor.tsx:591`) without ever naming those N people.
+
+## What this ships
+
+- A role card's member count becomes a **door**: a face pile plus the count,
+  which opens the role on a **Who's in this role** roster. At zero members the
+  same slot becomes an **Assign people** action instead of a dead label.
+- The role editor gains **Areas | People** tabs. Areas is everything the editor
+  does today, unchanged. People is the roster.
+- The roster's per-person control is the **existing `RolePicker`**, and bulk
+  assignment goes through the **existing `useAssignRole`**. No second
+  assignment path, no new SQL.
+
+**Out of scope:** Move 3 (`EmployeeDialog` gains an "App access" row, replacing
+the hardcoded `role: 'staff'` at `EmployeeDialog.tsx:412`). Separate PR.
+
+---
+
+## Why this needs no migration
+
+This is the load-bearing finding, so it is argued rather than asserted.
+
+The role card's count comes from `role_member_counts`
+(`supabase/migrations/20260730200000_role_member_counts.sql:36-46`), which
+resolves membership as:
+
+```sql
+COALESCE(ur.role_id, public.builtin_role_id_for(ur.role))
+```
+
+…and drops rows where that is NULL (line 45). A roster that resolves
+membership *differently* would show a list whose length disagrees with the
+count printed on the card that opened it. So the roster must mirror that
+expression exactly.
+
+The same migration warns, at lines 18-21, that resolving the legacy string
+client-side would be "a third copy in TypeScript… the copy that drifts."
+
+That warning is already answered. `roles.legacy_role`
+(`supabase/migrations/20260802100000_roles_legacy_role.sql`) is that mapping
+*exposed as data*, and it cannot disagree with the function because the
+backfill runs **through** it — `WHERE r.id = public.builtin_role_id_for(m.legacy_role)`
+(line 44) — under a unique partial index (line 51) and a builtin-only CHECK
+(lines 54-55). `RolePicker.tsx:113` already reads it this way:
+
+```tsx
+const isCurrent = (r: RoleWithGrants) =>
+  currentRoleId ? r.id === currentRoleId : r.legacy_role === currentRole;
+```
+
+So the client predicate
+
+```ts
+member.roleId ?? rolesByLegacy.get(member.role)?.id ?? null
+```
+
+is a *read of the mapping*, not a copy of it. `collaborator_custom` has no
+`legacy_role` row (it is absent from the backfill list at lines 39-43), so a
+membership carrying `role = 'collaborator_custom'` with `role_id IS NULL`
+resolves to `null` and is dropped — matching `builtin_role_id_for` returning
+NULL for that same string, which the migration comment at lines 42-44 calls
+out explicitly.
+
+**Consequence:** this PR is frontend-only. No migration, no pgTAP, no RLS
+change, no edge function. The permission model is entirely Move 1's
+`assign_membership_role`
+(`supabase/migrations/20260802110000_assign_membership_role.sql`), which is
+already SECURITY DEFINER and already raises 42501 on every denial rather than
+filtering.
+
+### The two queries see the same rows
+
+The card count comes from `role_member_counts`, which is `SECURITY INVOKER`
+(migration line 33) over `user_restaurants`. The roster comes from
+`useRestaurantMembers`, which SELECTs `user_restaurants` directly
+(`useRestaurantMembers.ts:38-41`) under the same RLS. Same rows, same
+predicate, same total.
+
+`useRestaurantMembers` maps over `memberships`, not over `profiles`
+(`useRestaurantMembers.ts:54`), so a member whose `profiles` row is unreadable
+still appears — with `fullName` and `email` null. It does not silently shrink
+the roster below the count. Such a row renders as "Unnamed member".
+
+---
+
+## Architecture
+
+### New
+
+| File | Responsibility |
+|---|---|
+| `src/lib/permissions/roleMembership.ts` | Pure resolution: `resolveMembershipRoleId`, `membersInRole`. Mirrors `role_member_counts`. Unit-tested. |
+| `src/components/roles/memberDisplay.ts` | `memberDisplayName(member)`, `memberInitials(member)`. |
+| `src/components/roles/RoleFacePile.tsx` | Up to three stacked initial avatars. Decorative (`aria-hidden`). |
+| `src/components/roles/RoleRoster.tsx` | The "Who's in this role" panel: rows, empty state, "Assign people" trigger. |
+| `src/components/roles/AssignPeopleDialog.tsx` | Multi-select over candidates → sequential `useAssignRole` calls → per-person result report. |
+| `tests/unit/roleMembership.test.ts` | Resolution + grouping tests. |
+
+### Modified
+
+| File | Change |
+|---|---|
+| `src/hooks/useRestaurantMembers.ts:40,54-62` | Select `id` too; add `membershipId` to `RestaurantMember`. |
+| `src/hooks/useAssignRole.ts:59-65` | Also invalidate `['restaurant-members', restaurantId]`. |
+| `src/components/roles/RolesList.tsx:72-106` | `<button>` card → `<article>` + hit button + footer people button. |
+| `src/components/roles/RoleEditor.tsx:386,538-541` | Areas \| People tabs; `callerRole` prop; controlled initial tab. |
+| `src/components/roles/RolesTab.tsx:27-33` | Gains `userRole`; owns which tab the editor opens on. |
+| `src/pages/Team.tsx:172` | Pass `userRole={selectedRestaurant.role}`. |
+
+`Team.tsx:172` is currently the only tab on that page not receiving
+`userRole` — the other three do (lines 167, 178, 185).
+
+### `roleMembership.ts`
+
+```ts
+/** Mirrors COALESCE(ur.role_id, builtin_role_id_for(ur.role)) — see
+ *  20260730200000_role_member_counts.sql:38. */
+export function resolveMembershipRoleId(
+  member: Pick<RestaurantMember, 'role' | 'roleId'>,
+  rolesByLegacy: ReadonlyMap<string, string>
+): string | null;
+
+/** Everyone in `members` whose membership resolves to `roleId`. */
+export function membersInRole(
+  members: readonly RestaurantMember[],
+  roleId: string,
+  roles: readonly RoleWithGrants[]
+): RestaurantMember[];
+```
+
+`rolesByLegacy` is built once from `roles.filter(r => r.legacy_role !== null)`.
+`membersInRole` builds it internally; both are exported so the grid can build
+the map once for all cards.
+
+---
+
+## The role card
+
+`RolesList.tsx:72-106` is today a single `<button>` wrapping icon, name,
+description, `RoleAreaChips`, and the footer. A people button cannot go inside
+it — nested `<button>` is invalid HTML. The approved prototype already solves
+this, so the change is transcription, not invention:
+
+```html
+<article class="rolecard">
+  <button class="rolecard__hit" data-role-open="…">glyph · name · description</button>
+  <div class="rolecard__chips">…</div>
+  <div class="rolecard__foot">
+    <button class="peoplelink" data-people="…">…</button>
+    <span class="chip chip--stamp">Built-in | Custom</span>
+  </div>
+</article>
+```
+
+Ours becomes:
+
+```tsx
+<article className={CARD_CHROME}>              {/* border, bg-card, hover, shadow */}
+  <button type="button" onClick={onOpen} className={HIT}>
+    <span className={GLYPH}><Icon aria-hidden="true" /></span>
+    <span className="min-w-0">
+      <span className="block text-[14px] font-semibold text-foreground">{role.name}</span>
+      {role.description && <span className="block text-[13px] text-muted-foreground mt-0.5">…</span>}
+    </span>
+  </button>
+
+  <RoleAreaChips areas={role.role_areas} />
+
+  <div className={FOOT}>
+    {role.memberCount > 0 ? <PeopleButton … /> : <AssignPeopleButton … />}
+    <span className={STAMP}>{role.builtin ? 'Built-in' : 'Custom'}</span>
+  </div>
+</article>
+```
+
+Moving `RoleAreaChips` out of the hit button is not cosmetic: it renders a
+`<div>` (`RoleAreaChips.tsx:27`), and `<div>` inside `<button>` violates the
+button content model. The prototype's structure fixes an existing validity bug
+as a side effect.
+
+Focus is per-button, not per-card: the hit button and the people button each
+carry `focus-visible:ring-2 focus-visible:ring-ring`, so tabbing through the
+grid stops at both doors. The card's `hover:border-border` moves to the
+`<article>` via `group-hover`, so hovering either child still lights the whole
+card as it does today.
+
+### The two footer states
+
+| `memberCount` | Renders | Accessible name |
+|---|---|---|
+| `> 0` | face pile (≤3) + `memberCountLabel(n)` + chevron | `3 people in Bartender. Manage who's in this role` |
+| `0` | user-plus icon + `Assign people` | `Nobody is in Bartender yet. Assign people` |
+
+Both are the same destination: the role editor's People tab.
+
+**The count stays `role.memberCount`.** The roster query supplies *faces only*.
+Two reasons: `role.memberCount` is the server's answer and the same number the
+editor's save warning uses (`RoleEditor.tsx:591`), so card and banner cannot
+disagree; and if the members query is slow or fails, the grid still renders
+correct counts with no avatars rather than flashing wrong numbers. The face
+pile degrades to nothing; the door still works.
+
+The grid runs **one** `useRestaurantMembers` query for all cards and groups
+once with `membersInRole` — not one query per card.
+
+---
+
+## The role editor
+
+Under the existing "← All roles" back link (`RoleEditor.tsx:538`):
+
+```
+← All roles
+┌──────────────────────────────
+│ Areas   People
+│ ───────
+└──────────────────────────────
+```
+
+- **Areas** — the existing `grid gap-5 lg:grid-cols-[minmax(0,1fr)_320px]`
+  (`RoleEditor.tsx:541`) verbatim: identity card, member-count banner, the
+  three bands, sensitive flags, copy-to-restaurants, save row, and the sticky
+  `RolePreviewPanel`. Nothing inside it changes.
+- **People** — `<RoleRoster role={role} restaurantId={…} callerRole={…} />`,
+  full width.
+
+Implemented with shadcn `Tabs`/`TabsList`/`TabsTrigger`/`TabsContent` styled to
+the Apple underline look from CLAUDE.md, rather than hand-rolled buttons —
+Radix supplies `role="tablist"`, roving tabindex and arrow-key navigation, and
+`Team.tsx:118` already uses shadcn `Tabs` on this same page.
+
+`value` is controlled so `RolesTab` can open the editor directly on People when
+the card's people button was the door.
+
+**Tabs are omitted entirely when `role === null`.** That is the new-role draft
+(`RolesTab.tsx:15-19`); an unsaved role has no members and no id to assign
+against. The draft renders exactly what it renders today.
+
+### Wiring
+
+`RolesList` gains two callbacks rather than one overloaded one:
+
+```ts
+onSelectRole: (role: RoleWithGrants) => void;   // hit button  → Areas
+onOpenPeople: (role: RoleWithGrants) => void;   // people button → People
+```
+
+`RolesTab` holds `initialTab: 'areas' | 'people'` alongside its existing
+`isEditing` / `selectedRole`, and takes `userRole: Role` to pass down as
+`callerRole`.
+
+---
+
+## The roster
+
+```
+Who's in this role                                    [ Assign people ]
+
+ ( JD )  Jose Delgado                         [ Bartender ▾ ]
+         jose@example.com
+
+ ( MR )  Maria Reyes                          [ Bartender ▾ ]
+         maria@example.com
+```
+
+Each row's role control **is `RolePicker`** — the same component Move 1 put on
+Team Members (`TeamMembers.tsx:184-193`) and Collaborators. Changing the value
+moves that person out of this role and into another, which is the roster's only
+mutation. Props mirror the Team Members wiring:
+
+```tsx
+<RolePicker
+  membershipId={member.membershipId}
+  restaurantId={restaurantId}
+  personName={memberDisplayName(member)}
+  currentRole={member.role}
+  currentRoleId={member.roleId}
+  callerRole={callerRole}
+  disabled={isSelf || member.role === 'kiosk' || (member.role === 'owner' && callerRole !== 'owner')}
+/>
+```
+
+`isSelf` comes from `useAuth()`, as at `TeamMembers.tsx:152`. No `onAssigned`
+callback is needed here: unlike `TeamMembers`, this surface is React Query, and
+`useAssignRole` already invalidates `['roles']` (line 59) — plus
+`['restaurant-members']`, which this PR adds.
+
+`RolePicker` calls `useInsideScrollLock()` (`RolePicker.tsx:77`), which reads a
+context provided by `DialogContent`/`SheetContent`. In the roster it is on a
+plain page, outside any dialog, so the hook returns its default `false` and the
+popover is non-modal — correct for a page. The constraint only bites inside
+`AssignPeopleDialog`, which does not render a `RolePicker`.
+
+### States
+
+- **Loading** — three skeleton rows.
+- **Error** — `role="alert"` with the message; the "Assign people" button stays
+  usable, since assignment does not depend on reading the roster.
+- **Empty** — the prototype's copy, verbatim:
+
+  > **Nobody is in {name} yet**
+  > A role does nothing until someone holds it. Assign the people who do this
+  > job — they'll see the areas above the next time they load a page.
+
+  with **Assign people** as the primary action.
+
+---
+
+## Assigning people
+
+Trigger: "Assign people" from the empty state, the roster header, or the card's
+zero-member button (which routes here via the People tab).
+
+A shadcn `Dialog` titled **Assign to {name}**, subtitled *"Everyone you pick
+leaves the role they're in now."* — the prototype's copy.
+
+**Candidates** = every restaurant member, minus:
+
+| Excluded | Why |
+|---|---|
+| already resolves to this role | nothing to do |
+| self | `assign_membership_role` rule 2 (migration lines 99-104) |
+| `role === 'kiosk'` | rule 4 (lines 120-126) — a shared device credential |
+| `role === 'owner'` when caller is not an owner | rule 5a (lines 128-134) |
+
+These mirror server rules that would raise 42501 anyway. The dialog hides what
+the server would reject rather than offering it and reporting failure; the
+server remains the authority.
+
+Rows are shadcn `Checkbox` inside a `<label>` — a real labelled checkbox rather
+than the prototype's `role="checkbox" tabindex="0"` div, because we have the
+primitive and it gets keyboard and screen-reader behaviour right for free.
+Footer reads `Nobody selected` / `1 person selected` / `N people selected`,
+with the button label `Assign` → `Assign N`. When there are no candidates:
+*"Everyone already holds this role."*
+
+### Submission
+
+`assign_membership_role` takes one membership per call. Rather than add a bulk
+RPC — which would pull SQL, RLS review and pgTAP into a frontend PR — the
+dialog issues the calls **sequentially** through `useAssignRole`:
+
+```ts
+const payload = role.legacy_role
+  ? { role: role.legacy_role as Role, roleId: null }
+  : { role: CUSTOM_ROLE, roleId: role.id };
+```
+
+mirroring `RolePicker.tsx:133-141`.
+
+Sequential, not `Promise.all`: rule 5b takes `FOR UPDATE` on the restaurant's
+owner rows before counting (migration lines 143-150), so concurrent calls
+touching an owner contend on that lock; and one-at-a-time keeps each failure
+attributable to a named person.
+
+Partial failure is reported, not swallowed: successes are counted, and each
+failure is named with `assignRoleErrorMessage(error)`
+(`useAssignRole.ts:36`) — which checks `'message' in error` before
+`instanceof Error`, because PostgREST rejections are plain objects. The dialog
+stays open when anything failed, with the failed rows still selected.
+
+---
+
+## Deliberate deviations from the prototype
+
+1. **Roster rows use `RolePicker`, not a "Move out" button.** The prototype's
+   `data-remove` handler reassigns to a fixed fallback role ("falls back to
+   Employee, never to nothing"). A silent demotion to Employee is a worse
+   outcome than an explicit choice, and a second write path would need its own
+   copy of the permission gating that `RolePicker` already has. Standing
+   instruction from Move 1: reuse `RolePicker`/`useAssignRole`.
+
+2. **No read-only display header above the tabs.** The prototype shows the
+   role's name and description as static text above `Areas | People`. Ours is a
+   live editable `<Input>` inside the Areas panel, so a second rendering of the
+   same name would either duplicate it or go stale mid-edit.
+
+3. **"Assign people" appears on any zero-member role, not only custom ones.**
+   A built-in role with nobody in it is the same dead end. The card is pure
+   navigation; whether the viewer *may* assign is decided in the People panel
+   and, finally, by the RPC.
+
+4. **The card's count is the server's, not the roster's length.** Argued above.
+
+---
+
+## Testing
+
+**Unit** — `tests/unit/roleMembership.test.ts`:
+
+- `role_id` wins over the legacy string when both are set (mirrors `COALESCE`).
+- A membership with `role_id IS NULL` resolves through `legacy_role`.
+- `role = 'collaborator_custom'`, `role_id IS NULL` → dropped.
+- An unrecognised role string → dropped.
+- Grouping totals equal the per-role counts for a mixed fixture.
+
+**Not added, and why:** no pgTAP — this PR contains no SQL. No new Playwright
+spec — the flow needs two seeded members holding different roles in one
+restaurant, which `tests/helpers/e2e-supabase` does not currently provide;
+building that seeding is its own change and would dominate the PR.
+
+**Existing gates:** `npm run typecheck`, `npm run lint`, `npm run test`,
+`npm run build`, plus the existing roles-and-areas E2E spec, which selects the
+roles tab by its visible text (`Team.tsx:129-135`) and must keep passing
+through the card restructure.
+
+## Accessibility
+
+- Both card doors are `<button type="button">` with explicit `aria-label`s
+  naming the role.
+- The face pile is `aria-hidden="true"`; the count text carries the meaning.
+- Tabs come from Radix: real `tablist`/`tab`/`tabpanel`, arrow-key navigation.
+- Roster avatars are `aria-hidden`; the visible name is the row's label.
+- Dialog checkboxes are wrapped in `<label>`; the dialog uses
+  `DialogDescription` so Radix wires `aria-describedby` (CLAUDE.md).
+- Loading uses `Skeleton`; errors use `role="alert"`; the empty state is real
+  text, not an icon.
+
+All colour via semantic tokens; no `localStorage`; every query is React Query
+with `staleTime: 30000`.

--- a/docs/superpowers/specs/2026-08-03-role-roster-design.md
+++ b/docs/superpowers/specs/2026-08-03-role-roster-design.md
@@ -119,6 +119,7 @@ the roster below the count. Such a row renders as "Unnamed member".
 | File | Responsibility |
 |---|---|
 | `src/lib/permissions/roleMembership.ts` | Pure resolution: `resolveMembershipRoleId`, `membersInRole`. Mirrors `role_member_counts`. Unit-tested. |
+| — | `canAssignAnyRole(role)` is added to the existing `src/lib/permissions/invitations.ts`, not to a new file (see "Who may assign" below). |
 | `src/components/roles/memberDisplay.ts` | `memberDisplayName(member)`, `memberInitials(member)`. |
 | `src/components/roles/RoleFacePile.tsx` | Up to three stacked initial avatars. Decorative (`aria-hidden`). |
 | `src/components/roles/RoleRoster.tsx` | The "Who's in this role" panel: rows, empty state, "Assign people" trigger. |
@@ -129,6 +130,8 @@ the roster below the count. Such a row renders as "Unnamed member".
 
 | File | Change |
 |---|---|
+| `src/lib/permissions/invitations.ts:79-94` | Add `canAssignAnyRole(role)`, derived from the matrix. |
+| `src/components/TeamMembers.tsx:38-39` | Replace the hardcoded `canManageMembers` list with `canAssignAnyRole(userRole)`. |
 | `src/hooks/useRestaurantMembers.ts:40,54-62` | Select `id` too; add `membershipId` to `RestaurantMember`. |
 | `src/hooks/useAssignRole.ts:59-65` | Also invalidate `['restaurant-members', restaurantId]`. |
 | `src/components/roles/RolesList.tsx:72-106` | `<button>` card → `<article>` + hit button + footer people button. |
@@ -201,6 +204,24 @@ Ours becomes:
   </div>
 </article>
 ```
+
+**`CARD_CHROME` must carry `flex flex-col`.** Today the footer pins to the
+bottom of a short card because `mt-auto` (`RolesList.tsx:98`) sits on a direct
+child of the single flex-column button, which stretches to the grid row height.
+Once the card is an `<article>` with three children, that column context has to
+move to the `<article>` or every card's footer floats up to hug its
+description and the grid stops looking like a grid. The prototype's CSS says
+the same thing (`display:flex; flex-direction:column` on `.rolecard`,
+`margin-top:auto` on `.rolecard__foot`). Concretely: `CARD_CHROME` =
+`group flex flex-col gap-3 p-[18px] rounded-xl border border-border/40 bg-card shadow-sm hover:border-border transition-colors`,
+`FOOT` keeps `mt-auto pt-[11px] border-t border-border/40`, and `HIT` drops the
+card chrome it no longer owns, keeping `flex items-start gap-[11px] text-left
+rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring`.
+
+`RoleCardSkeleton` (`RolesList.tsx:50-70`) already mirrors this shape as a
+plain `<div>` with the same padding, gap, border and footer rule, so it needs
+no structural change — but its values must keep matching `CARD_CHROME`, which
+is the reason the two are worth reading side by side when this lands.
 
 Moving `RoleAreaChips` out of the hit button is not cosmetic: it renders a
 `<div>` (`RoleAreaChips.tsx:27`), and `<div>` inside `<button>` violates the
@@ -305,7 +326,12 @@ mutation. Props mirror the Team Members wiring:
   currentRole={member.role}
   currentRoleId={member.roleId}
   callerRole={callerRole}
-  disabled={isSelf || member.role === 'kiosk' || (member.role === 'owner' && callerRole !== 'owner')}
+  disabled={
+    !canAssign ||
+    isSelf ||
+    member.role === 'kiosk' ||
+    (member.role === 'owner' && callerRole !== 'owner')
+  }
 />
 ```
 
@@ -319,6 +345,45 @@ context provided by `DialogContent`/`SheetContent`. In the roster it is on a
 plain page, outside any dialog, so the hook returns its default `false` and the
 popover is non-modal — correct for a page. The constraint only bites inside
 `AssignPeopleDialog`, which does not render a `RolePicker`.
+
+### Who may assign
+
+`chef` is not blocked from `/team` — `App.tsx`'s `StaffRoleChecker` (lines
+237-295) turns away only `staff`, `kiosk` and the `collaborator_*` roles — and
+`RolesTab` applies no gate of its own. So the roster must carry the same
+permission gate the Team Members list does, or a chef would see pickers that
+look live and fail with a 42501 from `invitable_roles()`, which has no `chef`
+row (`assign_membership_role.sql:32-48`).
+
+`TeamMembers.tsx:39` spells that gate out as a literal list:
+
+```ts
+const canManageMembers = userRole === 'owner' || userRole === 'manager' || userRole === 'operations_manager';
+```
+
+Copying that list into the roster would make three copies of the same fact
+(here, `TeamMembers`, and the SQL matrix). Instead it is **derived** from the
+matrix that already exists, in `src/lib/permissions/invitations.ts` beside
+`getInvitableRoles` (line 79) and `canInviteCustomRole` (line 92):
+
+```ts
+/** Whether this role can change anyone's role at all. Derived from
+ *  INVITABLE_ROLES rather than re-listed, so it cannot disagree with it. */
+export function canAssignAnyRole(inviter: Role): boolean {
+  return getInvitableRoles(inviter).length > 0 || canInviteCustomRole(inviter);
+}
+```
+
+`INVITABLE_ROLES` (`invitations.ts:10`) has rows only for `owner`, `manager`
+and `operations_manager`, so this returns exactly the set `canManageMembers`
+hardcodes today — and `TeamMembers.tsx:38-39` is switched to it in this PR,
+deleting the literal list rather than adding a second one.
+
+When `canAssignAnyRole(callerRole)` is false the roster still renders — reading
+who holds a role is not a privileged act, and these users can already read the
+same memberships on Team Members — but every `RolePicker` is disabled and the
+"Assign people" action is not rendered at all. The final authority remains the
+RPC.
 
 ### States
 
@@ -423,6 +488,11 @@ stays open when anything failed, with the failed rows still selected.
 - An unrecognised role string → dropped.
 - Grouping totals equal the per-role counts for a mixed fixture.
 
+Plus, in `tests/unit/invitationMatrix.test.ts`:
+`canAssignAnyRole` is true for exactly `owner`, `manager`,
+`operations_manager` and false for every other `Role` — the assertion that
+catches it silently widening if a future matrix row is added.
+
 **Not added, and why:** no pgTAP — this PR contains no SQL. No new Playwright
 spec — the flow needs two seeded members holding different roles in one
 restaurant, which `tests/helpers/e2e-supabase` does not currently provide;
@@ -430,7 +500,8 @@ building that seeding is its own change and would dominate the PR.
 
 **Existing gates:** `npm run typecheck`, `npm run lint`, `npm run test`,
 `npm run build`, plus the existing roles-and-areas E2E spec, which selects the
-roles tab by its visible text (`Team.tsx:129-135`) and must keep passing
+roles tab by its visible text (`Team.tsx:136-143`, deliberately unlabelled —
+see the comment at lines 129-135) and must keep passing
 through the card restructure.
 
 ## Accessibility

--- a/docs/superpowers/specs/2026-08-03-role-roster-design.md
+++ b/docs/superpowers/specs/2026-08-03-role-roster-design.md
@@ -118,7 +118,7 @@ the roster below the count. Such a row renders as "Unnamed member".
 
 | File | Responsibility |
 |---|---|
-| `src/lib/permissions/roleMembership.ts` | Pure resolution: `resolveMembershipRoleId`, `membersInRole`. Mirrors `role_member_counts`. Unit-tested. |
+| `src/lib/permissions/roleMembership.ts` | Pure resolution: `legacyRoleIndex`, `resolveMembershipRoleId`, `membersInRole`, `groupMembersByRole`. Mirrors `role_member_counts`. Unit-tested. |
 | — | `canAssignAnyRole(role)` is added to the existing `src/lib/permissions/invitations.ts`, not to a new file (see "Who may assign" below). |
 | `src/components/roles/memberDisplay.ts` | `memberDisplayName(member)`, `memberInitials(member)`. |
 | `src/components/roles/RoleFacePile.tsx` | Up to three stacked initial avatars. Decorative (`aria-hidden`). |
@@ -152,17 +152,28 @@ export function resolveMembershipRoleId(
   rolesByLegacy: ReadonlyMap<string, string>
 ): string | null;
 
+/** The legacy-role → role-id map both functions below resolve through. */
+export function legacyRoleIndex(
+  roles: readonly RoleWithGrants[]
+): Map<string, string>;
+
 /** Everyone in `members` whose membership resolves to `roleId`. */
 export function membersInRole(
   members: readonly RestaurantMember[],
   roleId: string,
-  roles: readonly RoleWithGrants[]
+  byLegacy: ReadonlyMap<string, string>
 ): RestaurantMember[];
+
+/** Every member bucketed by resolved role id, for the whole grid at once. */
+export function groupMembersByRole(
+  members: readonly RestaurantMember[],
+  byLegacy: ReadonlyMap<string, string>
+): Map<string, RestaurantMember[]>;
 ```
 
-`rolesByLegacy` is built once from `roles.filter(r => r.legacy_role !== null)`.
-`membersInRole` builds it internally; both are exported so the grid can build
-the map once for all cards.
+Every function takes the map rather than building it — the grid builds it once
+via `legacyRoleIndex` and buckets all cards in a single `groupMembersByRole`
+pass, instead of re-deriving it per card.
 
 ---
 
@@ -251,7 +262,7 @@ correct counts with no avatars rather than flashing wrong numbers. The face
 pile degrades to nothing; the door still works.
 
 The grid runs **one** `useRestaurantMembers` query for all cards and groups
-once with `membersInRole` — not one query per card.
+once with `groupMembersByRole` — not one query, or one filter pass, per card.
 
 ---
 

--- a/src/components/TeamMembers.tsx
+++ b/src/components/TeamMembers.tsx
@@ -10,6 +10,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { MoreHorizontal, Trash2 } from 'lucide-react';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { RolePicker } from '@/components/roles/RolePicker';
+import { canAssignAnyRole } from '@/lib/permissions/invitations';
 import type { Role } from '@/lib/permissions/types';
 
 interface TeamMember {
@@ -35,8 +36,10 @@ export const TeamMembers = ({ restaurantId, userRole }: TeamMembersProps) => {
   const { toast } = useToast();
   const { user } = useAuth();
 
-  // Derive from capability system — consistent with ROLE_CAPABILITIES['manage:team']
-  const canManageMembers = userRole === 'owner' || userRole === 'manager' || userRole === 'operations_manager';
+  // Derived from the invite matrix, which is what assign_membership_role
+  // actually enforces — a role with nowhere to assign gets a label, not a
+  // picker that returns 42501 for every choice.
+  const canManageMembers = canAssignAnyRole(userRole);
 
   useEffect(() => {
     fetchTeamMembers();

--- a/src/components/roles/AssignPeopleDialog.tsx
+++ b/src/components/roles/AssignPeopleDialog.tsx
@@ -54,6 +54,18 @@ function submitLabel(submitting: boolean, count: number): string {
   return `Assign ${count}`;
 }
 
+/**
+ * The members query refetches in the background while the dialog sits open, so
+ * someone ticked a moment ago may no longer be a candidate — another admin put
+ * them in this role, or made them an owner. The button promised a number; say
+ * when we assigned fewer rather than letting the toast quietly disagree.
+ */
+function droppedNoteText(dropped: number): string | undefined {
+  if (dropped <= 0) return undefined;
+  if (dropped === 1) return 'One person was already handled elsewhere and was skipped.';
+  return `${dropped} people were already handled elsewhere and were skipped.`;
+}
+
 export function AssignPeopleDialog({
   role,
   restaurantId,
@@ -108,16 +120,18 @@ export function AssignPeopleDialog({
 
   const submit = async () => {
     const chosen = candidates.filter((m) => selected.has(m.membershipId));
-    if (chosen.length === 0) return;
+    const droppedNote = droppedNoteText(selected.size - chosen.length);
 
-    // The members query can refetch in the background while the dialog sits
-    // open, so someone ticked a moment ago may no longer be a candidate —
-    // another admin put them in this role, or made them an owner. The button
-    // promised a number; say when we assigned fewer rather than letting the
-    // toast quietly disagree with it.
-    const dropped = selected.size - chosen.length;
-    const droppedNote =
-      dropped > 0 ? `${dropped} were already handled elsewhere and were skipped.` : undefined;
+    if (chosen.length === 0) {
+      // Everyone ticked has since left the candidate list, so `renderCandidates`
+      // no longer draws a row for any of them — there is nothing left to untick.
+      // Clearing the selection is the only way back to a button that means what
+      // it says; returning without it leaves an enabled "Assign N" that can
+      // never do anything.
+      setSelected(new Set());
+      if (droppedNote) toast({ title: 'Nothing left to assign', description: droppedNote });
+      return;
+    }
 
     // Mirrors RolePicker.tsx:133-141 — a builtin role names itself and carries
     // no role_id; a custom role is the bare literal plus its id.
@@ -134,14 +148,22 @@ export function AssignPeopleDialog({
     // The bare RPC rather than `useAssignRole`, so the four query invalidations
     // fire once below instead of once per person — the queries behind this
     // dialog are all mounted and would refetch on every iteration.
-    for (const member of chosen) {
-      try {
-        await assignMembershipRole({ membershipId: member.membershipId, ...payload });
-      } catch (err) {
-        failures.push({ member, message: assignRoleErrorMessage(err) });
+    //
+    // try/finally, not a bare loop: `close()` refuses every dismissal path
+    // while `submitting` is true, so a throw that skipped `setSubmitting(false)`
+    // would seal the dialog shut. Nothing in the loop throws today; the finally
+    // is what keeps that from being a future edit's problem.
+    try {
+      for (const member of chosen) {
+        try {
+          await assignMembershipRole({ membershipId: member.membershipId, ...payload });
+        } catch (err) {
+          failures.push({ member, message: assignRoleErrorMessage(err) });
+        }
       }
+    } finally {
+      setSubmitting(false);
     }
-    setSubmitting(false);
     // Even a fully failed run refreshes: rule 5b's owner count and the invite
     // matrix are both read from data this dialog is showing, so a denial can
     // mean the screen is stale.

--- a/src/components/roles/AssignPeopleDialog.tsx
+++ b/src/components/roles/AssignPeopleDialog.tsx
@@ -1,0 +1,225 @@
+import { useMemo, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Skeleton } from '@/components/ui/skeleton';
+import { UserPlus } from 'lucide-react';
+import { useAuth } from '@/hooks/useAuth';
+import { useAssignRole, assignRoleErrorMessage } from '@/hooks/useAssignRole';
+import { useRestaurantMembers, type RestaurantMember } from '@/hooks/useRestaurantMembers';
+import { useToast } from '@/hooks/use-toast';
+import { memberDisplayName, memberInitials } from '@/components/roles/memberDisplay';
+import { CUSTOM_ROLE } from '@/lib/permissions/invitations';
+import { legacyRoleIndex, resolveMembershipRoleId } from '@/lib/permissions/roleMembership';
+import type { RoleWithGrants } from '@/hooks/useRoles';
+import type { Role } from '@/lib/permissions/types';
+
+/**
+ * AssignPeopleDialog — put existing members into a role, several at a time.
+ *
+ * The reverse of `RolePicker`, which starts from a person and picks their role.
+ * This starts from the role, which is the direction an empty custom role leaves
+ * you facing. Both write through the same `assign_membership_role` RPC.
+ */
+
+export interface AssignPeopleDialogProps {
+  role: RoleWithGrants;
+  restaurantId: string;
+  /** The signed-in user's role in this restaurant. */
+  callerRole: Role;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function selectionLabel(count: number): string {
+  if (count === 0) return 'Nobody selected';
+  return count === 1 ? '1 person selected' : `${count} people selected`;
+}
+
+export function AssignPeopleDialog({
+  role,
+  restaurantId,
+  callerRole,
+  open,
+  onOpenChange,
+}: AssignPeopleDialogProps) {
+  const { user } = useAuth();
+  const { toast } = useToast();
+  const { data: members, isLoading, error } = useRestaurantMembers(restaurantId);
+  const assign = useAssignRole(restaurantId);
+  const [selected, setSelected] = useState<ReadonlySet<string>>(new Set());
+  const [submitting, setSubmitting] = useState(false);
+
+  const candidates = useMemo(() => {
+    if (!members) return [];
+    const byLegacy = legacyRoleIndex([role]);
+    return members.filter((m) => {
+      // Already here. Resolved the way role_member_counts resolves it, so this
+      // list and the card's count agree on who is already in.
+      if (resolveMembershipRoleId(m, byLegacy) === role.id) return false;
+      // RPC rule 2: never self-target.
+      if (user && m.userId === user.id) return false;
+      // RPC rule 4: a kiosk is a shared device credential, not a person.
+      if (m.role === 'kiosk') return false;
+      // RPC rule 5a: only an owner may change an owner.
+      if (m.role === 'owner' && callerRole !== 'owner') return false;
+      return true;
+    });
+  }, [members, role, user, callerRole]);
+
+  const toggle = (membershipId: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(membershipId)) next.delete(membershipId);
+      else next.add(membershipId);
+      return next;
+    });
+  };
+
+  const close = (nextOpen: boolean) => {
+    if (!nextOpen) setSelected(new Set());
+    onOpenChange(nextOpen);
+  };
+
+  const submit = async () => {
+    const chosen = candidates.filter((m) => selected.has(m.membershipId));
+    if (chosen.length === 0) return;
+
+    // Mirrors RolePicker.tsx:133-141 — a builtin role names itself and carries
+    // no role_id; a custom role is the bare literal plus its id.
+    const payload = role.legacy_role
+      ? { role: role.legacy_role as Role, roleId: undefined }
+      : { role: CUSTOM_ROLE, roleId: role.id };
+
+    setSubmitting(true);
+    const failures: { member: RestaurantMember; message: string }[] = [];
+    // Sequential, not Promise.all: rule 5b takes FOR UPDATE on the restaurant's
+    // owner rows before counting them, so concurrent calls contend on the same
+    // lock. One at a time also keeps every failure attributable to a person.
+    for (const member of chosen) {
+      try {
+        await assign.mutateAsync({ membershipId: member.membershipId, ...payload });
+      } catch (err) {
+        failures.push({ member, message: assignRoleErrorMessage(err) });
+      }
+    }
+    setSubmitting(false);
+
+    const landed = chosen.length - failures.length;
+    if (failures.length === 0) {
+      toast({
+        title:
+          landed === 1
+            ? `${memberDisplayName(chosen[0])} is now ${role.name}`
+            : `${landed} people are now ${role.name}`,
+      });
+      close(false);
+      return;
+    }
+
+    // Partial failure keeps the dialog open with the failed rows still ticked,
+    // so a retry does not re-assign the ones that already landed.
+    setSelected(new Set(failures.map((f) => f.member.membershipId)));
+    toast({
+      title: landed > 0 ? `${landed} assigned, ${failures.length} failed` : "Couldn't assign",
+      description: failures
+        .map((f) => `${memberDisplayName(f.member)}: ${f.message}`)
+        .join('\n'),
+      variant: 'destructive',
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={close}>
+      <DialogContent className="max-w-lg max-h-[80vh] overflow-y-auto p-0 gap-0 border-border/40">
+        <DialogHeader className="px-6 pt-6 pb-4 border-b border-border/40">
+          <div className="flex items-center gap-3">
+            <div className="h-10 w-10 rounded-xl bg-muted/50 flex items-center justify-center">
+              <UserPlus className="h-5 w-5 text-foreground" aria-hidden="true" />
+            </div>
+            <div>
+              <DialogTitle className="text-[17px] font-semibold text-foreground">
+                Assign to {role.name}
+              </DialogTitle>
+              <DialogDescription className="text-[13px] text-muted-foreground mt-0.5">
+                Everyone you pick leaves the role they&apos;re in now.
+              </DialogDescription>
+            </div>
+          </div>
+        </DialogHeader>
+
+        <div className="px-6 py-5">
+          {isLoading ? (
+            <div className="space-y-2" data-testid="assign-people-loading">
+              {[1, 2, 3].map((i) => (
+                <Skeleton key={i} className="h-12 w-full rounded-lg" />
+              ))}
+            </div>
+          ) : error ? (
+            <p role="alert" className="text-[13px] text-destructive">
+              Couldn&apos;t load your team. Please try again.
+            </p>
+          ) : candidates.length === 0 ? (
+            <p className="text-[13px] text-muted-foreground">Everyone already holds this role.</p>
+          ) : (
+            <div className="space-y-1">
+              {candidates.map((member) => (
+                <label
+                  key={member.membershipId}
+                  className="flex items-center gap-3 p-2.5 rounded-lg hover:bg-muted/50 transition-colors cursor-pointer"
+                >
+                  <Checkbox
+                    checked={selected.has(member.membershipId)}
+                    onCheckedChange={() => toggle(member.membershipId)}
+                    disabled={submitting}
+                  />
+                  <span className="h-8 w-8 flex-shrink-0 rounded-full bg-muted flex items-center justify-center text-[11px] font-medium text-muted-foreground" aria-hidden="true">
+                    {memberInitials(member)}
+                  </span>
+                  <span className="min-w-0">
+                    <span className="block text-[14px] font-medium text-foreground truncate">
+                      {memberDisplayName(member)}
+                    </span>
+                    {member.email && (
+                      <span className="block text-[12px] text-muted-foreground truncate">
+                        {member.email}
+                      </span>
+                    )}
+                  </span>
+                </label>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <DialogFooter className="px-6 py-4 border-t border-border/40 sm:justify-between items-center gap-3">
+          <span className="text-[13px] text-muted-foreground">{selectionLabel(selected.size)}</span>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              onClick={() => close(false)}
+              disabled={submitting}
+              className="h-9 px-4 rounded-lg text-[13px] font-medium text-muted-foreground hover:text-foreground"
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={submit}
+              disabled={selected.size === 0 || submitting}
+              className="h-9 px-4 rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium"
+            >
+              {submitting ? 'Assigning…' : selected.size > 0 ? `Assign ${selected.size}` : 'Assign'}
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/roles/AssignPeopleDialog.tsx
+++ b/src/components/roles/AssignPeopleDialog.tsx
@@ -12,10 +12,15 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Skeleton } from '@/components/ui/skeleton';
 import { UserPlus } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
-import { useAssignRole, assignRoleErrorMessage } from '@/hooks/useAssignRole';
+import {
+  assignMembershipRole,
+  assignRoleErrorMessage,
+  useRefreshAfterAssign,
+} from '@/hooks/useAssignRole';
 import { useRestaurantMembers, type RestaurantMember } from '@/hooks/useRestaurantMembers';
 import { useToast } from '@/hooks/use-toast';
-import { memberDisplayName, memberInitials } from '@/components/roles/memberDisplay';
+import { MemberIdentity } from '@/components/roles/MemberIdentity';
+import { memberDisplayName } from '@/components/roles/memberDisplay';
 import { CUSTOM_ROLE } from '@/lib/permissions/invitations';
 import { legacyRoleIndex, resolveMembershipRoleId } from '@/lib/permissions/roleMembership';
 import type { RoleWithGrants } from '@/hooks/useRoles';
@@ -43,6 +48,12 @@ function selectionLabel(count: number): string {
   return count === 1 ? '1 person selected' : `${count} people selected`;
 }
 
+function submitLabel(submitting: boolean, count: number): string {
+  if (submitting) return 'Assigning…';
+  if (count === 0) return 'Assign';
+  return `Assign ${count}`;
+}
+
 export function AssignPeopleDialog({
   role,
   restaurantId,
@@ -53,7 +64,7 @@ export function AssignPeopleDialog({
   const { user } = useAuth();
   const { toast } = useToast();
   const { data: members, isLoading, error } = useRestaurantMembers(restaurantId);
-  const assign = useAssignRole(restaurantId);
+  const refresh = useRefreshAfterAssign(restaurantId);
   const [selected, setSelected] = useState<ReadonlySet<string>>(new Set());
   const [submitting, setSubmitting] = useState(false);
 
@@ -84,6 +95,13 @@ export function AssignPeopleDialog({
   };
 
   const close = (nextOpen: boolean) => {
+    // Every dismissal funnels through Radix's onOpenChange — Escape, the
+    // overlay, and the X button alike — so one guard covers all three. Closing
+    // mid-run would clear `selected` while the loop is still writing, so a
+    // partial failure would have nothing left to re-tick, and the failure toast
+    // would name rows the user can no longer see. Cancel is already disabled
+    // while submitting; this makes the other exits agree with it.
+    if (!nextOpen && submitting) return;
     if (!nextOpen) setSelected(new Set());
     onOpenChange(nextOpen);
   };
@@ -91,6 +109,15 @@ export function AssignPeopleDialog({
   const submit = async () => {
     const chosen = candidates.filter((m) => selected.has(m.membershipId));
     if (chosen.length === 0) return;
+
+    // The members query can refetch in the background while the dialog sits
+    // open, so someone ticked a moment ago may no longer be a candidate —
+    // another admin put them in this role, or made them an owner. The button
+    // promised a number; say when we assigned fewer rather than letting the
+    // toast quietly disagree with it.
+    const dropped = selected.size - chosen.length;
+    const droppedNote =
+      dropped > 0 ? `${dropped} were already handled elsewhere and were skipped.` : undefined;
 
     // Mirrors RolePicker.tsx:133-141 — a builtin role names itself and carries
     // no role_id; a custom role is the bare literal plus its id.
@@ -103,14 +130,22 @@ export function AssignPeopleDialog({
     // Sequential, not Promise.all: rule 5b takes FOR UPDATE on the restaurant's
     // owner rows before counting them, so concurrent calls contend on the same
     // lock. One at a time also keeps every failure attributable to a person.
+    //
+    // The bare RPC rather than `useAssignRole`, so the four query invalidations
+    // fire once below instead of once per person — the queries behind this
+    // dialog are all mounted and would refetch on every iteration.
     for (const member of chosen) {
       try {
-        await assign.mutateAsync({ membershipId: member.membershipId, ...payload });
+        await assignMembershipRole({ membershipId: member.membershipId, ...payload });
       } catch (err) {
         failures.push({ member, message: assignRoleErrorMessage(err) });
       }
     }
     setSubmitting(false);
+    // Even a fully failed run refreshes: rule 5b's owner count and the invite
+    // matrix are both read from data this dialog is showing, so a denial can
+    // mean the screen is stale.
+    refresh();
 
     const landed = chosen.length - failures.length;
     if (failures.length === 0) {
@@ -119,6 +154,7 @@ export function AssignPeopleDialog({
           landed === 1
             ? `${memberDisplayName(chosen[0])} is now ${role.name}`
             : `${landed} people are now ${role.name}`,
+        description: droppedNote,
       });
       close(false);
       return;
@@ -129,11 +165,54 @@ export function AssignPeopleDialog({
     setSelected(new Set(failures.map((f) => f.member.membershipId)));
     toast({
       title: landed > 0 ? `${landed} assigned, ${failures.length} failed` : "Couldn't assign",
-      description: failures
-        .map((f) => `${memberDisplayName(f.member)}: ${f.message}`)
-        .join('\n'),
+      description: [
+        ...failures.map((f) => `${memberDisplayName(f.member)}: ${f.message}`),
+        ...(droppedNote ? [droppedNote] : []),
+      ].join('\n'),
       variant: 'destructive',
     });
+  };
+
+  // One state per branch, as sequential returns rather than a ternary chain.
+  // A plain function, not a component: it closes over the six values below, and
+  // it is called — not mounted — so React never remounts the list.
+  const renderCandidates = () => {
+    if (isLoading) {
+      return (
+        <div className="space-y-2" data-testid="assign-people-loading">
+          {[1, 2, 3].map((i) => (
+            <Skeleton key={i} className="h-12 w-full rounded-lg" />
+          ))}
+        </div>
+      );
+    }
+    if (error) {
+      return (
+        <p role="alert" className="text-[13px] text-destructive">
+          Couldn&apos;t load your team. Please try again.
+        </p>
+      );
+    }
+    if (candidates.length === 0) {
+      return <p className="text-[13px] text-muted-foreground">Everyone already holds this role.</p>;
+    }
+    return (
+      <div className="space-y-1">
+        {candidates.map((member) => (
+          <label
+            key={member.membershipId}
+            className="flex items-center gap-3 p-2.5 rounded-lg hover:bg-muted/50 transition-colors cursor-pointer"
+          >
+            <Checkbox
+              checked={selected.has(member.membershipId)}
+              onCheckedChange={() => toggle(member.membershipId)}
+              disabled={submitting}
+            />
+            <MemberIdentity member={member} size="md" />
+          </label>
+        ))}
+      </div>
+    );
   };
 
   return (
@@ -155,49 +234,7 @@ export function AssignPeopleDialog({
           </div>
         </DialogHeader>
 
-        <div className="px-6 py-5">
-          {isLoading ? (
-            <div className="space-y-2" data-testid="assign-people-loading">
-              {[1, 2, 3].map((i) => (
-                <Skeleton key={i} className="h-12 w-full rounded-lg" />
-              ))}
-            </div>
-          ) : error ? (
-            <p role="alert" className="text-[13px] text-destructive">
-              Couldn&apos;t load your team. Please try again.
-            </p>
-          ) : candidates.length === 0 ? (
-            <p className="text-[13px] text-muted-foreground">Everyone already holds this role.</p>
-          ) : (
-            <div className="space-y-1">
-              {candidates.map((member) => (
-                <label
-                  key={member.membershipId}
-                  className="flex items-center gap-3 p-2.5 rounded-lg hover:bg-muted/50 transition-colors cursor-pointer"
-                >
-                  <Checkbox
-                    checked={selected.has(member.membershipId)}
-                    onCheckedChange={() => toggle(member.membershipId)}
-                    disabled={submitting}
-                  />
-                  <span className="h-8 w-8 flex-shrink-0 rounded-full bg-muted flex items-center justify-center text-[11px] font-medium text-muted-foreground" aria-hidden="true">
-                    {memberInitials(member)}
-                  </span>
-                  <span className="min-w-0">
-                    <span className="block text-[14px] font-medium text-foreground truncate">
-                      {memberDisplayName(member)}
-                    </span>
-                    {member.email && (
-                      <span className="block text-[12px] text-muted-foreground truncate">
-                        {member.email}
-                      </span>
-                    )}
-                  </span>
-                </label>
-              ))}
-            </div>
-          )}
-        </div>
+        <div className="px-6 py-5">{renderCandidates()}</div>
 
         <DialogFooter className="px-6 py-4 border-t border-border/40 sm:justify-between items-center gap-3">
           <span className="text-[13px] text-muted-foreground">{selectionLabel(selected.size)}</span>
@@ -215,7 +252,7 @@ export function AssignPeopleDialog({
               disabled={selected.size === 0 || submitting}
               className="h-9 px-4 rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium"
             >
-              {submitting ? 'Assigning…' : selected.size > 0 ? `Assign ${selected.size}` : 'Assign'}
+              {submitLabel(submitting, selected.size)}
             </Button>
           </div>
         </DialogFooter>

--- a/src/components/roles/AssignPeopleDialog.tsx
+++ b/src/components/roles/AssignPeopleDialog.tsx
@@ -12,12 +12,8 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Skeleton } from '@/components/ui/skeleton';
 import { UserPlus } from 'lucide-react';
 import { useAuth } from '@/hooks/useAuth';
-import {
-  assignMembershipRole,
-  assignRoleErrorMessage,
-  useRefreshAfterAssign,
-} from '@/hooks/useAssignRole';
-import { useRestaurantMembers, type RestaurantMember } from '@/hooks/useRestaurantMembers';
+import { useAssignPeopleToRole } from '@/hooks/useAssignRole';
+import { useRestaurantMembers } from '@/hooks/useRestaurantMembers';
 import { useToast } from '@/hooks/use-toast';
 import { MemberIdentity } from '@/components/roles/MemberIdentity';
 import { memberDisplayName } from '@/components/roles/memberDisplay';
@@ -76,9 +72,8 @@ export function AssignPeopleDialog({
   const { user } = useAuth();
   const { toast } = useToast();
   const { data: members, isLoading, error } = useRestaurantMembers(restaurantId);
-  const refresh = useRefreshAfterAssign(restaurantId);
+  const { mutateAsync: assignPeople, isPending: submitting } = useAssignPeopleToRole(restaurantId);
   const [selected, setSelected] = useState<ReadonlySet<string>>(new Set());
-  const [submitting, setSubmitting] = useState(false);
 
   const candidates = useMemo(() => {
     if (!members) return [];
@@ -139,37 +134,12 @@ export function AssignPeopleDialog({
       ? { role: role.legacy_role as Role, roleId: undefined }
       : { role: CUSTOM_ROLE, roleId: role.id };
 
-    setSubmitting(true);
-    const failures: { member: RestaurantMember; message: string }[] = [];
-    // Sequential, not Promise.all: rule 5b takes FOR UPDATE on the restaurant's
-    // owner rows before counting them, so concurrent calls contend on the same
-    // lock. One at a time also keeps every failure attributable to a person.
-    //
-    // The bare RPC rather than `useAssignRole`, so the four query invalidations
-    // fire once below instead of once per person — the queries behind this
-    // dialog are all mounted and would refetch on every iteration.
-    //
-    // try/finally, not a bare loop: `close()` refuses every dismissal path
-    // while `submitting` is true, so a throw that skipped `setSubmitting(false)`
-    // would seal the dialog shut. Nothing in the loop throws today; the finally
-    // is what keeps that from being a future edit's problem.
-    try {
-      for (const member of chosen) {
-        try {
-          await assignMembershipRole({ membershipId: member.membershipId, ...payload });
-        } catch (err) {
-          failures.push({ member, message: assignRoleErrorMessage(err) });
-        }
-      }
-    } finally {
-      setSubmitting(false);
-    }
-    // Even a fully failed run refreshes: rule 5b's owner count and the invite
-    // matrix are both read from data this dialog is showing, so a denial can
-    // mean the screen is stale.
-    refresh();
+    // The mutation owns the sequential loop, the per-person failure capture and
+    // the single batch invalidation; it resolves rather than throwing, because a
+    // partial failure is a result to report, not an exception. See
+    // useAssignRole.ts for why none of that is optimistic.
+    const { landed, failures } = await assignPeople({ members: chosen, ...payload });
 
-    const landed = chosen.length - failures.length;
     if (failures.length === 0) {
       toast({
         title:

--- a/src/components/roles/MemberAvatar.tsx
+++ b/src/components/roles/MemberAvatar.tsx
@@ -1,0 +1,45 @@
+import { memberInitials } from '@/components/roles/memberDisplay';
+import type { RestaurantMember } from '@/hooks/useRestaurantMembers';
+import { cn } from '@/lib/utils';
+
+/**
+ * A member's initials in a circle — the same face in the three places this
+ * feature shows one: the card's face pile, the roster row, and the assign
+ * dialog's candidate list.
+ *
+ * Always `aria-hidden`. Initials are a visual shorthand for a name that is
+ * already announced beside them (or, in the face pile's case, for a count that
+ * is); reading "DC" aloud tells a screen reader user nothing they can act on.
+ */
+
+const SIZES = {
+  /** Face pile, where three overlap inside a card footer. */
+  sm: 'h-[22px] w-[22px] text-[10px]',
+  /** Assign-dialog rows. */
+  md: 'h-8 w-8 text-[11px]',
+  /** Roster rows, beside a name and an email. */
+  lg: 'h-9 w-9 text-[12px]',
+} as const;
+
+export function MemberAvatar({
+  member,
+  size = 'lg',
+  className,
+}: {
+  member: RestaurantMember;
+  size?: keyof typeof SIZES;
+  className?: string;
+}) {
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        'flex-shrink-0 rounded-full bg-muted flex items-center justify-center font-medium text-muted-foreground',
+        SIZES[size],
+        className
+      )}
+    >
+      {memberInitials(member)}
+    </span>
+  );
+}

--- a/src/components/roles/MemberIdentity.tsx
+++ b/src/components/roles/MemberIdentity.tsx
@@ -1,0 +1,36 @@
+import { MemberAvatar } from '@/components/roles/MemberAvatar';
+import { memberDisplayName } from '@/components/roles/memberDisplay';
+import type { RestaurantMember } from '@/hooks/useRestaurantMembers';
+import { cn } from '@/lib/utils';
+
+/**
+ * Who a row is about: initials, name, and email if we have one.
+ *
+ * Shared by the roster and the assign dialog so truncation and spacing cannot
+ * drift between the two lists showing the same people. All spans, no divs — one
+ * of the two hosts is a `<label>`, and block elements inside a label are as
+ * wrong as a button inside a button.
+ */
+export function MemberIdentity({
+  member,
+  size = 'lg',
+  className,
+}: {
+  member: RestaurantMember;
+  size?: 'md' | 'lg';
+  className?: string;
+}) {
+  return (
+    <span className={cn('flex items-center gap-3 min-w-0', className)}>
+      <MemberAvatar member={member} size={size} />
+      <span className="min-w-0">
+        <span className="block text-[14px] font-medium text-foreground truncate">
+          {memberDisplayName(member)}
+        </span>
+        {member.email && (
+          <span className="block text-[12px] text-muted-foreground truncate">{member.email}</span>
+        )}
+      </span>
+    </span>
+  );
+}

--- a/src/components/roles/RoleEditor.tsx
+++ b/src/components/roles/RoleEditor.tsx
@@ -186,6 +186,20 @@ function memberNoticeText(count: number): string {
 }
 
 /**
+ * The one amber banner under the name and description, or nothing.
+ *
+ * Read-only wins over the member notice: if you cannot save, how many people
+ * would be affected by saving is not the thing to say.
+ */
+function editorNoticeText(builtinReadOnly: boolean, role: RoleWithGrants | null): string | null {
+  if (builtinReadOnly) {
+    return 'Built-in role. Read-only — keeps getting new areas as we ship features. Duplicate it to make a version you control.';
+  }
+  if (role && role.memberCount > 0) return memberNoticeText(role.memberCount);
+  return null;
+}
+
+/**
  * A band's tinted full-bleed header strip, with the column legend on the right.
  *
  * Full-bleed (no horizontal padding on the parent) is what separates one band
@@ -409,6 +423,7 @@ export function RoleEditor({
 
   const isNewDraft = role === null;
   const builtinReadOnly = role?.builtin ?? false;
+  const editorNotice = editorNoticeText(builtinReadOnly, role);
   const { toast } = useToast();
 
   const [name, setName] = useState(role?.name ?? '');
@@ -622,20 +637,12 @@ export function RoleEditor({
 
               {/* Banner sits under the two fields, as in the approved design — the
                   name is what identifies the card, so it reads first. */}
-              {builtinReadOnly ? (
+              {editorNotice && (
                 <div className="flex items-start gap-3 p-2.5 rounded-lg bg-amber-500/10 border border-amber-500/20">
                   <AlertTriangle className="h-4 w-4 flex-shrink-0 mt-0.5 text-amber-600 dark:text-amber-500" aria-hidden="true" />
-                  <p className="text-[13px] text-foreground">
-                    Built-in role. Read-only — keeps getting new areas as we ship features. Duplicate it to make a
-                    version you control.
-                  </p>
+                  <p className="text-[13px] text-foreground">{editorNotice}</p>
                 </div>
-              ) : role && role.memberCount > 0 ? (
-                <div className="flex items-start gap-3 p-2.5 rounded-lg bg-amber-500/10 border border-amber-500/20">
-                  <AlertTriangle className="h-4 w-4 flex-shrink-0 mt-0.5 text-amber-600 dark:text-amber-500" aria-hidden="true" />
-                  <p className="text-[13px] text-foreground">{memberNoticeText(role.memberCount)}</p>
-                </div>
-              ) : null}
+              )}
             </div>
 
             {/* Area bands */}

--- a/src/components/roles/RoleEditor.tsx
+++ b/src/components/roles/RoleEditor.tsx
@@ -5,7 +5,9 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { RolePreviewPanel } from '@/components/roles/RolePreviewPanel';
+import { RoleRoster } from '@/components/roles/RoleRoster';
 import { useToast } from '@/hooks/use-toast';
 import { useRoles, type RoleWithGrants } from '@/hooks/useRoles';
 import { useRestaurants } from '@/hooks/useRestaurants';
@@ -102,11 +104,22 @@ function describeRoleWriteError(err: unknown): string {
  * without inventing bespoke listbox keyboard handling.
  */
 
+/** The two things a role has: what it can reach, and who holds it. */
+export type RoleEditorTab = 'areas' | 'people';
+
 export interface RoleEditorProps {
   restaurantId: string;
   /** `null` means a brand-new, unsaved draft. */
   role: RoleWithGrants | null;
   onBack: () => void;
+  /** The signed-in user's role in this restaurant — gates the People tab. */
+  callerRole: Role;
+  /**
+   * Controlled: a card's face pile opens straight to People, its name to
+   * Areas, so the caller that knows which door was used owns this.
+   */
+  activeTab: RoleEditorTab;
+  onTabChange: (tab: RoleEditorTab) => void;
 }
 
 type Grants = Partial<Record<AreaKey, AreaLevel>>;
@@ -383,7 +396,14 @@ function AreaRow({
   );
 }
 
-export function RoleEditor({ restaurantId, role, onBack }: RoleEditorProps) {
+export function RoleEditor({
+  restaurantId,
+  role,
+  onBack,
+  callerRole,
+  activeTab,
+  onTabChange,
+}: RoleEditorProps) {
   const { createRole, updateRole, copyRole, isMutating } = useRoles(restaurantId);
   const { restaurants } = useRestaurants();
 
@@ -538,6 +558,31 @@ export function RoleEditor({ restaurantId, role, onBack }: RoleEditorProps) {
         All roles
       </button>
 
+      {/* A saved role has two things to look at; an unsaved draft has one, so
+          it gets the Areas body with no tablist above it — an unsaved role has
+          no id to build a roster from and nobody in it either way. */}
+      <Tabs
+        value={isNewDraft ? 'areas' : activeTab}
+        onValueChange={(value) => onTabChange(value as RoleEditorTab)}
+      >
+        {!isNewDraft && (
+          <TabsList className="h-auto p-0 mb-5 bg-transparent border-b border-border/40 rounded-none w-full justify-start gap-6">
+            <TabsTrigger
+              value="areas"
+              className="relative px-0 py-3 rounded-none bg-transparent shadow-none text-[14px] font-medium text-muted-foreground data-[state=active]:bg-transparent data-[state=active]:shadow-none data-[state=active]:text-foreground data-[state=active]:after:absolute data-[state=active]:after:bottom-[-1px] data-[state=active]:after:left-0 data-[state=active]:after:right-0 data-[state=active]:after:h-[2px] data-[state=active]:after:bg-foreground"
+            >
+              Areas
+            </TabsTrigger>
+            <TabsTrigger
+              value="people"
+              className="relative px-0 py-3 rounded-none bg-transparent shadow-none text-[14px] font-medium text-muted-foreground data-[state=active]:bg-transparent data-[state=active]:shadow-none data-[state=active]:text-foreground data-[state=active]:after:absolute data-[state=active]:after:bottom-[-1px] data-[state=active]:after:left-0 data-[state=active]:after:right-0 data-[state=active]:after:h-[2px] data-[state=active]:after:bg-foreground"
+            >
+              People
+            </TabsTrigger>
+          </TabsList>
+        )}
+
+        <TabsContent value="areas" className="mt-0">
       <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_320px]">
         <div className="space-y-5 min-w-0">
           {/* Identity card */}
@@ -767,6 +812,14 @@ export function RoleEditor({ restaurantId, role, onBack }: RoleEditorProps) {
         {/* Live preview */}
         <RolePreviewPanel grants={grants} flags={effectiveFlags} roleName={name.trim() || 'This role'} />
       </div>
+        </TabsContent>
+
+        {role && (
+          <TabsContent value="people" className="mt-0">
+            <RoleRoster role={role} restaurantId={restaurantId} callerRole={callerRole} />
+          </TabsContent>
+        )}
+      </Tabs>
     </div>
   );
 }

--- a/src/components/roles/RoleEditor.tsx
+++ b/src/components/roles/RoleEditor.tsx
@@ -583,235 +583,235 @@ export function RoleEditor({
         )}
 
         <TabsContent value="areas" className="mt-0">
-      <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_320px]">
-        <div className="space-y-5 min-w-0">
-          {/* Identity card */}
-          <div className="rounded-xl border border-border/40 bg-card p-5 space-y-4">
-            <div className="grid gap-4 sm:grid-cols-2">
-              <div>
-                <Label
-                  htmlFor="role-name"
-                  className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider"
-                >
-                  Role name
-                </Label>
-                <Input
-                  id="role-name"
-                  value={name}
-                  disabled={builtinReadOnly}
-                  onChange={(e) => setName(e.target.value)}
-                  className="mt-1.5 h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
-                />
-              </div>
-              <div>
-                <Label
-                  htmlFor="role-description"
-                  className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider"
-                >
-                  What this person does
-                </Label>
-                <Input
-                  id="role-description"
-                  value={description}
-                  disabled={builtinReadOnly}
-                  onChange={(e) => setDescription(e.target.value)}
-                  className="mt-1.5 h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
-                />
-              </div>
-            </div>
-
-            {/* Banner sits under the two fields, as in the approved design — the
-                name is what identifies the card, so it reads first. */}
-            {builtinReadOnly ? (
-              <div className="flex items-start gap-3 p-2.5 rounded-lg bg-amber-500/10 border border-amber-500/20">
-                <AlertTriangle className="h-4 w-4 flex-shrink-0 mt-0.5 text-amber-600 dark:text-amber-500" aria-hidden="true" />
-                <p className="text-[13px] text-foreground">
-                  Built-in role. Read-only — keeps getting new areas as we ship features. Duplicate it to make a
-                  version you control.
-                </p>
-              </div>
-            ) : role && role.memberCount > 0 ? (
-              <div className="flex items-start gap-3 p-2.5 rounded-lg bg-amber-500/10 border border-amber-500/20">
-                <AlertTriangle className="h-4 w-4 flex-shrink-0 mt-0.5 text-amber-600 dark:text-amber-500" aria-hidden="true" />
-                <p className="text-[13px] text-foreground">{memberNoticeText(role.memberCount)}</p>
-              </div>
-            ) : null}
-          </div>
-
-          {/* Area bands */}
-          <div className="rounded-xl border border-border/40 bg-card overflow-hidden">
-            {BAND_ORDER.map((band, bandIndex) => (
-              <div key={band}>
-                <BandHeader
-                  label={band}
-                  legend={bandIndex === 0 ? 'No access · View · Manage' : undefined}
-                  first={bandIndex === 0}
-                />
-                <div className="px-5">
-                  {(rowsByBand.get(band) ?? []).map((row) => (
-                    <AreaRow
-                      key={row.key}
-                      row={row}
-                      grants={grants}
-                      builtinReadOnly={builtinReadOnly}
-                      onChange={handleAreaChange}
-                    />
-                  ))}
-                </div>
-              </div>
-            ))}
-
-            {/* Sensitive data closes the same card, as its own band — the flags
-                are cross-cutting, but they are read as one more thing this role
-                either can or cannot see. */}
-            <BandHeader label="Sensitive data" legend="Off · On" />
-            <div className="p-5 pt-4 space-y-1">
-              {/* Say plainly what these switches do today. They are stored on
-                  the role and resolvable through user_has_capability(), but no
-                  screen and no RLS policy reads them yet, so leaving one off
-                  hides nothing. Advertising them as protection they don't yet
-                  provide is worse than admitting the gap (Phase 7a security
-                  review); the copy comes out when the fields are gated. */}
-              <p className="text-[12px] text-muted-foreground pb-2">
-                Recorded on the role, but not enforced yet — these fields still follow area access
-                everywhere in the app. Set them for the role you want; they take effect when
-                per-field gating ships.
-              </p>
-              {SENSITIVE_FLAGS.map((s) => {
-                const available = flagAvailable(s, grants, builtinReadOnly);
-                const checked = effectiveFlagSet.has(s.flag);
-                const requiredLabels = s.requires.map(areaKeyLabel).join(', ');
-                return (
-                  <div
-                    key={s.flag}
-                    data-testid={`flag-row-${s.flag}`}
-                    className={cn(
-                      'flex items-center justify-between gap-3 p-2.5 rounded-lg border border-border/40',
-                      // The amber wash means "this role can see sensitive data",
-                      // so it appears only when the switch is actually on —
-                      // never merely because the flag is available.
-                      checked && 'bg-amber-500/10 border-amber-500/20',
-                      !available && 'bg-muted/40 opacity-70'
-                    )}
+        <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_320px]">
+          <div className="space-y-5 min-w-0">
+            {/* Identity card */}
+            <div className="rounded-xl border border-border/40 bg-card p-5 space-y-4">
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div>
+                  <Label
+                    htmlFor="role-name"
+                    className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider"
                   >
-                    <div className="min-w-0">
-                      <Label htmlFor={`flag-${s.flag}`} className="text-[13px] font-medium text-foreground">
-                        {s.name}
-                      </Label>
-                      <p className="text-[12px] text-muted-foreground">
-                        {available ? s.hint : `Needs access to ${requiredLabels}`}
-                      </p>
-                    </div>
-                    <Switch
-                      id={`flag-${s.flag}`}
-                      aria-label={s.name}
-                      checked={checked}
-                      disabled={builtinReadOnly || !available}
-                      onCheckedChange={(v) => toggleFlag(s.flag, v)}
-                      // Amber when on, matching the row's caution wash — these
-                      // switches grant sensitive data, not an ordinary setting.
-                      className="data-[state=checked]:bg-amber-600 dark:data-[state=checked]:bg-amber-500"
-                    />
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-
-          {/* Copy to other restaurants — only meaningful for an already-saved
-              custom role, and only when there is somewhere to copy it to: a
-              single-restaurant operator would otherwise get an empty picker. */}
-          {role && !role.builtin && otherRestaurants.length > 0 && (
-            <div className="rounded-xl border border-border/40 bg-card p-5 space-y-3">
-              <div>
-                <Label
-                  htmlFor="copy-targets"
-                  className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider"
-                >
-                  Copy to other restaurants
-                </Label>
-                <p className="text-[13px] text-muted-foreground mt-0.5">
-                  Clone this role's areas and sensitive-data flags into other restaurants you manage.
-                </p>
-              </div>
-              <select
-                id="copy-targets"
-                multiple
-                value={copyTargetIds}
-                onChange={(e) =>
-                  setCopyTargetIds(Array.from(e.target.selectedOptions).map((option) => option.value))
-                }
-                className="w-full min-h-[92px] rounded-lg border border-border/40 bg-muted/30 text-[14px] p-2"
-              >
-                {otherRestaurants.map((r) => (
-                  <option key={r.id} value={r.id}>
-                    {r.name}
-                  </option>
-                ))}
-              </select>
-              <Button
-                type="button"
-                variant="outline"
-                disabled={copyTargetIds.length === 0 || isMutating}
-                onClick={handleCopy}
-                className="h-9 px-4 rounded-lg text-[13px] font-medium"
-              >
-                Copy role
-              </Button>
-              {copyReport && (
-                <div className="text-[12px] space-y-1">
-                  {copyReport.copied.length > 0 && (
-                    <p className="text-muted-foreground">
-                      Copied to {copyReport.copied.length} restaurant{copyReport.copied.length === 1 ? '' : 's'}.
-                    </p>
-                  )}
-                  {copyReport.nameCollisions.length > 0 && (
-                    <p className="text-destructive">
-                      A role named "{name}" already exists at {copyReport.nameCollisions.length} restaurant
-                      {copyReport.nameCollisions.length === 1 ? '' : 's'} — those copies were skipped.
-                    </p>
-                  )}
+                    Role name
+                  </Label>
+                  <Input
+                    id="role-name"
+                    value={name}
+                    disabled={builtinReadOnly}
+                    onChange={(e) => setName(e.target.value)}
+                    className="mt-1.5 h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
+                  />
                 </div>
-              )}
-            </div>
-          )}
+                <div>
+                  <Label
+                    htmlFor="role-description"
+                    className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider"
+                  >
+                    What this person does
+                  </Label>
+                  <Input
+                    id="role-description"
+                    value={description}
+                    disabled={builtinReadOnly}
+                    onChange={(e) => setDescription(e.target.value)}
+                    className="mt-1.5 h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
+                  />
+                </div>
+              </div>
 
-          <div className="flex items-center justify-between pt-1">
-            <div>
-              {saveHint && (
-                <p id="save-hint" className="text-[12px] text-muted-foreground">
-                  {saveHint}
-                </p>
-              )}
+              {/* Banner sits under the two fields, as in the approved design — the
+                  name is what identifies the card, so it reads first. */}
+              {builtinReadOnly ? (
+                <div className="flex items-start gap-3 p-2.5 rounded-lg bg-amber-500/10 border border-amber-500/20">
+                  <AlertTriangle className="h-4 w-4 flex-shrink-0 mt-0.5 text-amber-600 dark:text-amber-500" aria-hidden="true" />
+                  <p className="text-[13px] text-foreground">
+                    Built-in role. Read-only — keeps getting new areas as we ship features. Duplicate it to make a
+                    version you control.
+                  </p>
+                </div>
+              ) : role && role.memberCount > 0 ? (
+                <div className="flex items-start gap-3 p-2.5 rounded-lg bg-amber-500/10 border border-amber-500/20">
+                  <AlertTriangle className="h-4 w-4 flex-shrink-0 mt-0.5 text-amber-600 dark:text-amber-500" aria-hidden="true" />
+                  <p className="text-[13px] text-foreground">{memberNoticeText(role.memberCount)}</p>
+                </div>
+              ) : null}
             </div>
-            <div className="flex items-center gap-2">
-              <Button
-                type="button"
-                variant="ghost"
-                onClick={onBack}
-                className="h-9 px-4 rounded-lg text-[13px] font-medium text-muted-foreground hover:text-foreground"
-              >
-                Cancel
-              </Button>
-              <Button
-                type="button"
-                disabled={saveDisabled}
-                aria-describedby={saveHint ? 'save-hint' : undefined}
-                onClick={handleSave}
-                // Accent-filled, not the usual near-black primary: the approved
-                // design ties the save action to the same accent the selected
-                // "Manage" segment uses.
-                className="h-9 px-4 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 text-[13px] font-medium disabled:opacity-45"
-              >
-                Save role
-              </Button>
+
+            {/* Area bands */}
+            <div className="rounded-xl border border-border/40 bg-card overflow-hidden">
+              {BAND_ORDER.map((band, bandIndex) => (
+                <div key={band}>
+                  <BandHeader
+                    label={band}
+                    legend={bandIndex === 0 ? 'No access · View · Manage' : undefined}
+                    first={bandIndex === 0}
+                  />
+                  <div className="px-5">
+                    {(rowsByBand.get(band) ?? []).map((row) => (
+                      <AreaRow
+                        key={row.key}
+                        row={row}
+                        grants={grants}
+                        builtinReadOnly={builtinReadOnly}
+                        onChange={handleAreaChange}
+                      />
+                    ))}
+                  </div>
+                </div>
+              ))}
+
+              {/* Sensitive data closes the same card, as its own band — the flags
+                  are cross-cutting, but they are read as one more thing this role
+                  either can or cannot see. */}
+              <BandHeader label="Sensitive data" legend="Off · On" />
+              <div className="p-5 pt-4 space-y-1">
+                {/* Say plainly what these switches do today. They are stored on
+                    the role and resolvable through user_has_capability(), but no
+                    screen and no RLS policy reads them yet, so leaving one off
+                    hides nothing. Advertising them as protection they don't yet
+                    provide is worse than admitting the gap (Phase 7a security
+                    review); the copy comes out when the fields are gated. */}
+                <p className="text-[12px] text-muted-foreground pb-2">
+                  Recorded on the role, but not enforced yet — these fields still follow area access
+                  everywhere in the app. Set them for the role you want; they take effect when
+                  per-field gating ships.
+                </p>
+                {SENSITIVE_FLAGS.map((s) => {
+                  const available = flagAvailable(s, grants, builtinReadOnly);
+                  const checked = effectiveFlagSet.has(s.flag);
+                  const requiredLabels = s.requires.map(areaKeyLabel).join(', ');
+                  return (
+                    <div
+                      key={s.flag}
+                      data-testid={`flag-row-${s.flag}`}
+                      className={cn(
+                        'flex items-center justify-between gap-3 p-2.5 rounded-lg border border-border/40',
+                        // The amber wash means "this role can see sensitive data",
+                        // so it appears only when the switch is actually on —
+                        // never merely because the flag is available.
+                        checked && 'bg-amber-500/10 border-amber-500/20',
+                        !available && 'bg-muted/40 opacity-70'
+                      )}
+                    >
+                      <div className="min-w-0">
+                        <Label htmlFor={`flag-${s.flag}`} className="text-[13px] font-medium text-foreground">
+                          {s.name}
+                        </Label>
+                        <p className="text-[12px] text-muted-foreground">
+                          {available ? s.hint : `Needs access to ${requiredLabels}`}
+                        </p>
+                      </div>
+                      <Switch
+                        id={`flag-${s.flag}`}
+                        aria-label={s.name}
+                        checked={checked}
+                        disabled={builtinReadOnly || !available}
+                        onCheckedChange={(v) => toggleFlag(s.flag, v)}
+                        // Amber when on, matching the row's caution wash — these
+                        // switches grant sensitive data, not an ordinary setting.
+                        className="data-[state=checked]:bg-amber-600 dark:data-[state=checked]:bg-amber-500"
+                      />
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+
+            {/* Copy to other restaurants — only meaningful for an already-saved
+                custom role, and only when there is somewhere to copy it to: a
+                single-restaurant operator would otherwise get an empty picker. */}
+            {role && !role.builtin && otherRestaurants.length > 0 && (
+              <div className="rounded-xl border border-border/40 bg-card p-5 space-y-3">
+                <div>
+                  <Label
+                    htmlFor="copy-targets"
+                    className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider"
+                  >
+                    Copy to other restaurants
+                  </Label>
+                  <p className="text-[13px] text-muted-foreground mt-0.5">
+                    Clone this role's areas and sensitive-data flags into other restaurants you manage.
+                  </p>
+                </div>
+                <select
+                  id="copy-targets"
+                  multiple
+                  value={copyTargetIds}
+                  onChange={(e) =>
+                    setCopyTargetIds(Array.from(e.target.selectedOptions).map((option) => option.value))
+                  }
+                  className="w-full min-h-[92px] rounded-lg border border-border/40 bg-muted/30 text-[14px] p-2"
+                >
+                  {otherRestaurants.map((r) => (
+                    <option key={r.id} value={r.id}>
+                      {r.name}
+                    </option>
+                  ))}
+                </select>
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={copyTargetIds.length === 0 || isMutating}
+                  onClick={handleCopy}
+                  className="h-9 px-4 rounded-lg text-[13px] font-medium"
+                >
+                  Copy role
+                </Button>
+                {copyReport && (
+                  <div className="text-[12px] space-y-1">
+                    {copyReport.copied.length > 0 && (
+                      <p className="text-muted-foreground">
+                        Copied to {copyReport.copied.length} restaurant{copyReport.copied.length === 1 ? '' : 's'}.
+                      </p>
+                    )}
+                    {copyReport.nameCollisions.length > 0 && (
+                      <p className="text-destructive">
+                        A role named "{name}" already exists at {copyReport.nameCollisions.length} restaurant
+                        {copyReport.nameCollisions.length === 1 ? '' : 's'} — those copies were skipped.
+                      </p>
+                    )}
+                  </div>
+                )}
+              </div>
+            )}
+
+            <div className="flex items-center justify-between pt-1">
+              <div>
+                {saveHint && (
+                  <p id="save-hint" className="text-[12px] text-muted-foreground">
+                    {saveHint}
+                  </p>
+                )}
+              </div>
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={onBack}
+                  className="h-9 px-4 rounded-lg text-[13px] font-medium text-muted-foreground hover:text-foreground"
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="button"
+                  disabled={saveDisabled}
+                  aria-describedby={saveHint ? 'save-hint' : undefined}
+                  onClick={handleSave}
+                  // Accent-filled, not the usual near-black primary: the approved
+                  // design ties the save action to the same accent the selected
+                  // "Manage" segment uses.
+                  className="h-9 px-4 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 text-[13px] font-medium disabled:opacity-45"
+                >
+                  Save role
+                </Button>
+              </div>
             </div>
           </div>
-        </div>
 
-        {/* Live preview */}
-        <RolePreviewPanel grants={grants} flags={effectiveFlags} roleName={name.trim() || 'This role'} />
-      </div>
+          {/* Live preview */}
+          <RolePreviewPanel grants={grants} flags={effectiveFlags} roleName={name.trim() || 'This role'} />
+        </div>
         </TabsContent>
 
         {role && (

--- a/src/components/roles/RoleFacePile.tsx
+++ b/src/components/roles/RoleFacePile.tsx
@@ -1,0 +1,43 @@
+import { memberInitials } from '@/components/roles/memberDisplay';
+import type { RestaurantMember } from '@/hooks/useRestaurantMembers';
+import { cn } from '@/lib/utils';
+
+/**
+ * The overlapping initials next to a role card's member count.
+ *
+ * Purely decorative: the count beside it already says how many people are in
+ * the role, and the button's aria-label says whose role it is, so announcing
+ * three sets of initials would add nothing a screen reader user could act on.
+ * Hence `aria-hidden` on the wrapper rather than per-avatar labels.
+ *
+ * Renders nothing when `members` is empty — including while the roster query is
+ * still in flight. The count comes from the server (`role.memberCount`), so a
+ * slow or failed members query costs faces, never correctness.
+ *
+ * `ring-card` (not `ring-background`): these sit on the card's surface, and the
+ * ring exists to cut the overlap.
+ */
+export function RoleFacePile({
+  members,
+  max = 3,
+  className,
+}: {
+  members: readonly RestaurantMember[];
+  max?: number;
+  className?: string;
+}) {
+  if (members.length === 0) return null;
+
+  return (
+    <span className={cn('flex -space-x-1.5', className)} aria-hidden="true">
+      {members.slice(0, max).map((member) => (
+        <span
+          key={member.membershipId}
+          className="h-[22px] w-[22px] flex-shrink-0 rounded-full bg-muted ring-2 ring-card flex items-center justify-center text-[10px] font-medium text-muted-foreground"
+        >
+          {memberInitials(member)}
+        </span>
+      ))}
+    </span>
+  );
+}

--- a/src/components/roles/RoleFacePile.tsx
+++ b/src/components/roles/RoleFacePile.tsx
@@ -1,4 +1,4 @@
-import { memberInitials } from '@/components/roles/memberDisplay';
+import { MemberAvatar } from '@/components/roles/MemberAvatar';
 import type { RestaurantMember } from '@/hooks/useRestaurantMembers';
 import { cn } from '@/lib/utils';
 
@@ -31,12 +31,7 @@ export function RoleFacePile({
   return (
     <span className={cn('flex -space-x-1.5', className)} aria-hidden="true">
       {members.slice(0, max).map((member) => (
-        <span
-          key={member.membershipId}
-          className="h-[22px] w-[22px] flex-shrink-0 rounded-full bg-muted ring-2 ring-card flex items-center justify-center text-[10px] font-medium text-muted-foreground"
-        >
-          {memberInitials(member)}
-        </span>
+        <MemberAvatar key={member.membershipId} member={member} size="sm" className="ring-2 ring-card" />
       ))}
     </span>
   );

--- a/src/components/roles/RolePicker.tsx
+++ b/src/components/roles/RolePicker.tsx
@@ -19,6 +19,7 @@ import {
   CUSTOM_ROLE,
   canInviteCustomRole,
   getInvitableRoles,
+  isAssignableCustomRole,
 } from '@/lib/permissions/invitations';
 import { roleDelta, type RoleGrantSet } from '@/lib/permissions/roleDelta';
 import type { Role } from '@/lib/permissions/types';
@@ -88,20 +89,12 @@ export function RolePicker({
   const searchQuery = search.trim().toLowerCase();
   const matches = (name: string) => name.toLowerCase().includes(searchQuery);
 
-  // Mirrors what `assign_membership_role` will actually accept for
-  // `collaborator_custom`: restaurant-scoped, non-builtin, collaborator-flavored.
-  // `restaurant_id` alone is not enough — `copy_role_to_restaurants`
-  // (20260730160000:114-115) copies the source row's `flavor` verbatim, so a
-  // restaurant can own a non-builtin *platform*-flavored role. Offering one here
-  // would fail at commit time with a 42501 that reads as a permissions problem
-  // rather than "this role was never assignable".
-  const customRoles = roles.filter(
-    (r) =>
-      r.restaurant_id === restaurantId &&
-      !r.builtin &&
-      r.flavor === 'collaborator' &&
-      matches(r.name)
-  );
+  // Only roles `assign_membership_role` will actually accept for
+  // `collaborator_custom` — see `isAssignableCustomRole` for why the three
+  // checks are all needed. Shared with `canAssignTargetRole`, which gates the
+  // "Assign people" entry points, so the options here and the door that leads to
+  // them agree.
+  const customRoles = roles.filter((r) => isAssignableCustomRole(r, restaurantId) && matches(r.name));
   const builtinRoles = roles.filter(
     (r) =>
       r.legacy_role !== null &&

--- a/src/components/roles/RoleRoster.tsx
+++ b/src/components/roles/RoleRoster.tsx
@@ -44,7 +44,7 @@ export function RoleRoster({ role, restaurantId, callerRole }: RoleRosterProps) 
   // assign only staff) gets the button on a custom role, and a manager gets it
   // on Owner, and every person they pick comes back 42501.
   const canAssign = canAssignAnyRole(callerRole);
-  const canAssignIntoRole = canAssignTargetRole(callerRole, role.legacy_role);
+  const canAssignIntoRole = canAssignTargetRole(callerRole, role, restaurantId);
 
   const roster = useMemo(
     () => membersInRole(members ?? [], role.id, legacyRoleIndex(roles)),

--- a/src/components/roles/RoleRoster.tsx
+++ b/src/components/roles/RoleRoster.tsx
@@ -7,8 +7,9 @@ import { useRestaurantMembers } from '@/hooks/useRestaurantMembers';
 import { useRoles, type RoleWithGrants } from '@/hooks/useRoles';
 import { AssignPeopleDialog } from '@/components/roles/AssignPeopleDialog';
 import { RolePicker } from '@/components/roles/RolePicker';
-import { memberDisplayName, memberInitials } from '@/components/roles/memberDisplay';
-import { canAssignAnyRole } from '@/lib/permissions/invitations';
+import { MemberIdentity } from '@/components/roles/MemberIdentity';
+import { memberDisplayName } from '@/components/roles/memberDisplay';
+import { canAssignAnyRole, canAssignTargetRole } from '@/lib/permissions/invitations';
 import { legacyRoleIndex, membersInRole } from '@/lib/permissions/roleMembership';
 import type { Role } from '@/lib/permissions/types';
 
@@ -37,7 +38,13 @@ export function RoleRoster({ role, restaurantId, callerRole }: RoleRosterProps) 
   const { data: members, isLoading, error } = useRestaurantMembers(restaurantId);
   const [assignOpen, setAssignOpen] = useState(false);
 
+  // Two different questions. A row's picker offers every role the caller may
+  // assign, so it only needs "any at all". "Assign people" names THIS role up
+  // front, so it needs "this one" — otherwise an operations_manager (who may
+  // assign only staff) gets the button on a custom role, and a manager gets it
+  // on Owner, and every person they pick comes back 42501.
   const canAssign = canAssignAnyRole(callerRole);
+  const canAssignIntoRole = canAssignTargetRole(callerRole, role.legacy_role);
 
   const roster = useMemo(
     () => membersInRole(members ?? [], role.id, legacyRoleIndex(roles)),
@@ -48,7 +55,7 @@ export function RoleRoster({ role, restaurantId, callerRole }: RoleRosterProps) 
   // showing it in the header too would put the same button on screen twice.
   const showEmptyState = !isLoading && !error && roster.length === 0;
 
-  const assignButton = canAssign ? (
+  const assignButton = canAssignIntoRole ? (
     <Button
       onClick={() => setAssignOpen(true)}
       className="h-9 px-4 rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium"
@@ -57,6 +64,71 @@ export function RoleRoster({ role, restaurantId, callerRole }: RoleRosterProps) 
       Assign people
     </Button>
   ) : null;
+
+  // One state per branch, as sequential returns rather than a ternary chain.
+  // A plain function, not a component: it closes over the values above, and it
+  // is called — not mounted — so React never remounts the list.
+  const renderRoster = () => {
+    if (isLoading) {
+      return (
+        <div className="space-y-2" data-testid="role-roster-loading">
+          {[1, 2, 3].map((i) => (
+            <Skeleton key={i} className="h-14 w-full rounded-xl" />
+          ))}
+        </div>
+      );
+    }
+    if (error) {
+      // The assign button above stays usable: it reads the same query, but a
+      // failed roster is no reason to block the action that fixes an empty one.
+      return (
+        <p role="alert" className="text-[13px] text-destructive">
+          Couldn&apos;t load who&apos;s in this role. Please try again.
+        </p>
+      );
+    }
+    if (roster.length === 0) {
+      return (
+        <div className="flex flex-col items-center gap-2 py-10 px-6 rounded-xl border border-dashed border-border/40 text-center">
+          <p className="text-[14px] font-medium text-foreground">Nobody is in {role.name} yet</p>
+          <p className="text-[13px] text-muted-foreground max-w-sm">
+            A role does nothing until someone holds it. Assign people to put this role to work.
+          </p>
+          {assignButton && <div className="mt-2">{assignButton}</div>}
+        </div>
+      );
+    }
+    return (
+      <div className="space-y-1.5">
+        {roster.map((member) => (
+          <div
+            key={member.membershipId}
+            className="flex items-center justify-between gap-3 p-3 rounded-xl border border-border/40 bg-background"
+          >
+            <MemberIdentity member={member} />
+            <RolePicker
+              membershipId={member.membershipId}
+              restaurantId={restaurantId}
+              personName={memberDisplayName(member)}
+              currentRole={member.role}
+              currentRoleId={member.roleId}
+              callerRole={callerRole}
+              // Each condition mirrors a rule assign_membership_role would
+              // otherwise raise 42501 on: no assign rights at all, self
+              // (rule 2), kiosk (rule 4), an owner changed by a non-owner
+              // (rule 5a).
+              disabled={
+                !canAssign ||
+                (!!user && member.userId === user.id) ||
+                member.role === 'kiosk' ||
+                (member.role === 'owner' && callerRole !== 'owner')
+              }
+            />
+          </div>
+        ))}
+      </div>
+    );
+  };
 
   return (
     <div className="space-y-4">
@@ -70,76 +142,9 @@ export function RoleRoster({ role, restaurantId, callerRole }: RoleRosterProps) 
         {!showEmptyState && assignButton}
       </div>
 
-      {isLoading ? (
-        <div className="space-y-2" data-testid="role-roster-loading">
-          {[1, 2, 3].map((i) => (
-            <Skeleton key={i} className="h-14 w-full rounded-xl" />
-          ))}
-        </div>
-      ) : error ? (
-        // The assign button above stays usable: it reads the same query, but a
-        // failed roster is no reason to block the action that fixes an empty one.
-        <p role="alert" className="text-[13px] text-destructive">
-          Couldn&apos;t load who&apos;s in this role. Please try again.
-        </p>
-      ) : roster.length === 0 ? (
-        <div className="flex flex-col items-center gap-2 py-10 px-6 rounded-xl border border-dashed border-border/40 text-center">
-          <p className="text-[14px] font-medium text-foreground">Nobody is in {role.name} yet</p>
-          <p className="text-[13px] text-muted-foreground max-w-sm">
-            A role does nothing until someone holds it. Assign people to put this role to work.
-          </p>
-          {canAssign && <div className="mt-2">{assignButton}</div>}
-        </div>
-      ) : (
-        <div className="space-y-1.5">
-          {roster.map((member) => {
-            const isSelf = !!user && member.userId === user.id;
-            return (
-              <div
-                key={member.membershipId}
-                className="flex items-center justify-between gap-3 p-3 rounded-xl border border-border/40 bg-background"
-              >
-                <div className="flex items-center gap-3 min-w-0">
-                  <span
-                    className="h-9 w-9 flex-shrink-0 rounded-full bg-muted flex items-center justify-center text-[12px] font-medium text-muted-foreground"
-                    aria-hidden="true"
-                  >
-                    {memberInitials(member)}
-                  </span>
-                  <div className="min-w-0">
-                    <p className="text-[14px] font-medium text-foreground truncate">
-                      {memberDisplayName(member)}
-                    </p>
-                    {member.email && (
-                      <p className="text-[12px] text-muted-foreground truncate">{member.email}</p>
-                    )}
-                  </div>
-                </div>
-                <RolePicker
-                  membershipId={member.membershipId}
-                  restaurantId={restaurantId}
-                  personName={memberDisplayName(member)}
-                  currentRole={member.role}
-                  currentRoleId={member.roleId}
-                  callerRole={callerRole}
-                  // Each condition mirrors a rule assign_membership_role would
-                  // otherwise raise 42501 on: no assign rights at all, self
-                  // (rule 2), kiosk (rule 4), an owner changed by a non-owner
-                  // (rule 5a).
-                  disabled={
-                    !canAssign ||
-                    isSelf ||
-                    member.role === 'kiosk' ||
-                    (member.role === 'owner' && callerRole !== 'owner')
-                  }
-                />
-              </div>
-            );
-          })}
-        </div>
-      )}
+      {renderRoster()}
 
-      {canAssign && (
+      {canAssignIntoRole && (
         <AssignPeopleDialog
           role={role}
           restaurantId={restaurantId}

--- a/src/components/roles/RoleRoster.tsx
+++ b/src/components/roles/RoleRoster.tsx
@@ -1,0 +1,153 @@
+import { useMemo, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { UserPlus } from 'lucide-react';
+import { useAuth } from '@/hooks/useAuth';
+import { useRestaurantMembers } from '@/hooks/useRestaurantMembers';
+import { useRoles, type RoleWithGrants } from '@/hooks/useRoles';
+import { AssignPeopleDialog } from '@/components/roles/AssignPeopleDialog';
+import { RolePicker } from '@/components/roles/RolePicker';
+import { memberDisplayName, memberInitials } from '@/components/roles/memberDisplay';
+import { canAssignAnyRole } from '@/lib/permissions/invitations';
+import { legacyRoleIndex, membersInRole } from '@/lib/permissions/roleMembership';
+import type { Role } from '@/lib/permissions/types';
+
+/**
+ * RoleRoster — "Who's in this role", the People tab of the role editor.
+ *
+ * Each row's role chip is a live `RolePicker`, so moving someone out of this
+ * role means naming where they go. The prototype had a bare "Move out" button;
+ * that would silently demote to Employee, which is a decision the person
+ * clicking it never made.
+ *
+ * No `onAssigned` callback: this surface reads `useRestaurantMembers`, which
+ * `useAssignRole` invalidates directly.
+ */
+
+export interface RoleRosterProps {
+  role: RoleWithGrants;
+  restaurantId: string;
+  /** The signed-in user's role in this restaurant. */
+  callerRole: Role;
+}
+
+export function RoleRoster({ role, restaurantId, callerRole }: RoleRosterProps) {
+  const { user } = useAuth();
+  const { roles } = useRoles(restaurantId);
+  const { data: members, isLoading, error } = useRestaurantMembers(restaurantId);
+  const [assignOpen, setAssignOpen] = useState(false);
+
+  const canAssign = canAssignAnyRole(callerRole);
+
+  const roster = useMemo(
+    () => membersInRole(members ?? [], role.id, legacyRoleIndex(roles)),
+    [members, role.id, roles]
+  );
+
+  // The empty state owns the action when there is nothing else on the panel;
+  // showing it in the header too would put the same button on screen twice.
+  const showEmptyState = !isLoading && !error && roster.length === 0;
+
+  const assignButton = canAssign ? (
+    <Button
+      onClick={() => setAssignOpen(true)}
+      className="h-9 px-4 rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium"
+    >
+      <UserPlus className="h-4 w-4 mr-1.5" aria-hidden="true" />
+      Assign people
+    </Button>
+  ) : null;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h3 className="text-[15px] font-semibold text-foreground">Who&apos;s in this role</h3>
+          <p className="text-[13px] text-muted-foreground mt-0.5">
+            Changing someone&apos;s role here changes what they see everywhere.
+          </p>
+        </div>
+        {!showEmptyState && assignButton}
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-2" data-testid="role-roster-loading">
+          {[1, 2, 3].map((i) => (
+            <Skeleton key={i} className="h-14 w-full rounded-xl" />
+          ))}
+        </div>
+      ) : error ? (
+        // The assign button above stays usable: it reads the same query, but a
+        // failed roster is no reason to block the action that fixes an empty one.
+        <p role="alert" className="text-[13px] text-destructive">
+          Couldn&apos;t load who&apos;s in this role. Please try again.
+        </p>
+      ) : roster.length === 0 ? (
+        <div className="flex flex-col items-center gap-2 py-10 px-6 rounded-xl border border-dashed border-border/40 text-center">
+          <p className="text-[14px] font-medium text-foreground">Nobody is in {role.name} yet</p>
+          <p className="text-[13px] text-muted-foreground max-w-sm">
+            A role does nothing until someone holds it. Assign people to put this role to work.
+          </p>
+          {canAssign && <div className="mt-2">{assignButton}</div>}
+        </div>
+      ) : (
+        <div className="space-y-1.5">
+          {roster.map((member) => {
+            const isSelf = !!user && member.userId === user.id;
+            return (
+              <div
+                key={member.membershipId}
+                className="flex items-center justify-between gap-3 p-3 rounded-xl border border-border/40 bg-background"
+              >
+                <div className="flex items-center gap-3 min-w-0">
+                  <span
+                    className="h-9 w-9 flex-shrink-0 rounded-full bg-muted flex items-center justify-center text-[12px] font-medium text-muted-foreground"
+                    aria-hidden="true"
+                  >
+                    {memberInitials(member)}
+                  </span>
+                  <div className="min-w-0">
+                    <p className="text-[14px] font-medium text-foreground truncate">
+                      {memberDisplayName(member)}
+                    </p>
+                    {member.email && (
+                      <p className="text-[12px] text-muted-foreground truncate">{member.email}</p>
+                    )}
+                  </div>
+                </div>
+                <RolePicker
+                  membershipId={member.membershipId}
+                  restaurantId={restaurantId}
+                  personName={memberDisplayName(member)}
+                  currentRole={member.role}
+                  currentRoleId={member.roleId}
+                  callerRole={callerRole}
+                  // Each condition mirrors a rule assign_membership_role would
+                  // otherwise raise 42501 on: no assign rights at all, self
+                  // (rule 2), kiosk (rule 4), an owner changed by a non-owner
+                  // (rule 5a).
+                  disabled={
+                    !canAssign ||
+                    isSelf ||
+                    member.role === 'kiosk' ||
+                    (member.role === 'owner' && callerRole !== 'owner')
+                  }
+                />
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {canAssign && (
+        <AssignPeopleDialog
+          role={role}
+          restaurantId={restaurantId}
+          callerRole={callerRole}
+          open={assignOpen}
+          onOpenChange={setAssignOpen}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/roles/RolesList.tsx
+++ b/src/components/roles/RolesList.tsx
@@ -98,21 +98,30 @@ function RoleCardPeople({
   role,
   roster,
   count,
+  restaurantId,
   callerRole,
   onOpenPeople,
 }: {
   role: RoleWithGrants;
   roster: readonly RestaurantMember[];
   count: number;
+  restaurantId: string;
   callerRole: Role;
   onOpenPeople: () => void;
 }) {
+  const canAssign = canAssignTargetRole(callerRole, role, restaurantId);
+
   if (count > 0) {
+    // The same door, named for what is behind it. A caller who cannot assign
+    // into this role — a manager opening Owner — gets a roster whose every
+    // picker is disabled and no assign action; promising "Manage" would be a
+    // label the panel cannot honor.
+    const verb = canAssign ? 'Manage' : 'See';
     return (
       <button
         type="button"
         onClick={onOpenPeople}
-        aria-label={`${memberCountLabel(count)} in ${role.name}. Manage who's in this role`}
+        aria-label={`${memberCountLabel(count)} in ${role.name}. ${verb} who's in this role`}
         className={cn(
           'group/people inline-flex items-center gap-[7px] rounded-lg -mx-1 px-1 py-0.5',
           'hover:bg-muted hover:text-foreground transition-colors',
@@ -129,7 +138,7 @@ function RoleCardPeople({
     );
   }
 
-  if (canAssignTargetRole(callerRole, role.legacy_role)) {
+  if (canAssign) {
     // The case the user actually hit: an empty custom role used to show a dead
     // "0 members". Make it the loudest thing on the card.
     return (
@@ -150,8 +159,9 @@ function RoleCardPeople({
   }
 
   // Empty, and this caller cannot fill it — Kiosk for everyone (it is in no
-  // inviter's row), Owner for a manager. Offering the action here would only
-  // walk them to a panel that cannot offer it either.
+  // inviter's row), Owner for a manager, or a role `assign_membership_role`
+  // itself refuses. Offering the action here would only walk them to a panel
+  // that cannot offer it either.
   return <span>Nobody yet</span>;
 }
 
@@ -167,12 +177,14 @@ function RoleCardPeople({
 function RoleCard({
   role,
   roster,
+  restaurantId,
   callerRole,
   onClick,
   onOpenPeople,
 }: {
   role: RoleWithGrants;
   roster: readonly RestaurantMember[];
+  restaurantId: string;
   callerRole: Role;
   onClick: () => void;
   onOpenPeople: () => void;
@@ -219,6 +231,7 @@ function RoleCard({
           role={role}
           roster={roster}
           count={count}
+          restaurantId={restaurantId}
           callerRole={callerRole}
           onOpenPeople={onOpenPeople}
         />
@@ -297,6 +310,7 @@ export function RolesList({
           key={role.id}
           role={role}
           roster={rostersByRole.get(role.id) ?? EMPTY_ROSTER}
+          restaurantId={restaurantId}
           callerRole={callerRole}
           onClick={() => onSelectRole(role)}
           onOpenPeople={() => onOpenPeople(role)}

--- a/src/components/roles/RolesList.tsx
+++ b/src/components/roles/RolesList.tsx
@@ -1,7 +1,11 @@
-import { AlertCircle, LayoutGrid, Plus, Users } from 'lucide-react';
+import { useMemo } from 'react';
+import { AlertCircle, ChevronRight, LayoutGrid, Plus, UserPlus, Users } from 'lucide-react';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useRoles, type RoleWithGrants } from '@/hooks/useRoles';
+import { useRestaurantMembers, type RestaurantMember } from '@/hooks/useRestaurantMembers';
 import { RoleAreaChips } from '@/components/roles/RoleAreaChips';
+import { RoleFacePile } from '@/components/roles/RoleFacePile';
+import { groupMembersByRole, legacyRoleIndex } from '@/lib/permissions/roleMembership';
 import { cn } from '@/lib/utils';
 
 /**
@@ -19,10 +23,11 @@ import { cn } from '@/lib/utils';
  * (e.g. "Scheduling & Labor" vs. this file's "Scheduling").
  *
  * This component only fetches and renders. Deciding what happens on click —
- * navigating to the (read-only, for a builtin) role editor, or to a blank
- * draft — belongs to the caller via `onSelectRole`/`onNewRole`; that keeps
- * this component usable from wherever the "Roles & areas" tab ends up living
- * (a later task), without this file needing to know about routing.
+ * navigating to the (read-only, for a builtin) role editor, to a blank draft,
+ * or to the role's roster — belongs to the caller via `onSelectRole`,
+ * `onNewRole` and `onOpenPeople`; that keeps this component usable from
+ * wherever the "Roles & areas" tab ends up living (a later task), without this
+ * file needing to know about routing.
  *
  * "Read-only open for builtins" (this task's own description) means exactly
  * that a builtin role's card stays clickable, calling `onSelectRole` like any
@@ -34,6 +39,12 @@ export interface RolesListProps {
   restaurantId: string;
   onSelectRole: (role: RoleWithGrants) => void;
   onNewRole: () => void;
+  /**
+   * The card's second door: who is in this role. Separate from `onSelectRole`
+   * because the two go to different places — the role's definition, and the
+   * people holding it.
+   */
+  onOpenPeople: (role: RoleWithGrants) => void;
 }
 
 /**
@@ -69,19 +80,46 @@ function RoleCardSkeleton() {
   );
 }
 
-function RoleCard({ role, onClick }: { role: RoleWithGrants; onClick: () => void }) {
+/**
+ * A card is two doors, not one.
+ *
+ * The chrome moved from a single `<button>` onto an `<article>` so the footer
+ * can hold its own control: a button inside a button is invalid HTML, and so
+ * was the `RoleAreaChips` `<div>` that used to sit inside the outer button. The
+ * hit area for "open this role's definition" is now the name block alone, which
+ * is also what the prototype does (`.rolecard__hit`).
+ */
+function RoleCard({
+  role,
+  roster,
+  onClick,
+  onOpenPeople,
+}: {
+  role: RoleWithGrants;
+  roster: readonly RestaurantMember[];
+  onClick: () => void;
+  onOpenPeople: () => void;
+}) {
   const Icon = role.builtin ? LayoutGrid : Users;
+  // The server's count, not `roster.length`: it is the number the editor's save
+  // banner quotes, and it survives a members query that is slow or denied.
+  const count = role.memberCount;
 
   return (
-    <button
-      type="button"
-      onClick={onClick}
+    <article
       className={cn(
-        'group flex flex-col gap-3 p-[18px] text-left rounded-xl border border-border/40 bg-card shadow-sm',
-        'hover:border-border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+        'group flex flex-col gap-3 p-[18px] rounded-xl border border-border/40 bg-card shadow-sm',
+        'hover:border-border transition-colors'
       )}
     >
-      <div className="flex items-start gap-[11px]">
+      <button
+        type="button"
+        onClick={onClick}
+        className={cn(
+          'flex items-start gap-[11px] text-left rounded-lg',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+        )}
+      >
         <span className="h-[34px] w-[34px] flex-shrink-0 rounded-lg bg-muted/50 flex items-center justify-center text-muted-foreground">
           <Icon className="h-4 w-4" aria-hidden="true" />
         </span>
@@ -91,17 +129,51 @@ function RoleCard({ role, onClick }: { role: RoleWithGrants; onClick: () => void
             <span className="block text-[13px] text-muted-foreground mt-0.5">{role.description}</span>
           )}
         </span>
-      </div>
+      </button>
 
       <RoleAreaChips areas={role.role_areas} />
 
-      <div className="flex items-center justify-between mt-auto pt-[11px] border-t border-border/40 text-[12px] text-muted-foreground">
-        <span>{memberCountLabel(role.memberCount)}</span>
+      <div className="flex items-center justify-between gap-2.5 mt-auto pt-[11px] border-t border-border/40 text-[12px] text-muted-foreground">
+        {count > 0 ? (
+          <button
+            type="button"
+            onClick={onOpenPeople}
+            aria-label={`${memberCountLabel(count)} in ${role.name}. Manage who's in this role`}
+            className={cn(
+              'group/people inline-flex items-center gap-[7px] rounded-lg -mx-1 px-1 py-0.5',
+              'hover:bg-muted hover:text-foreground transition-colors',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+            )}
+          >
+            <RoleFacePile members={roster} />
+            <span>{memberCountLabel(count)}</span>
+            <ChevronRight
+              className="h-3 w-3 opacity-0 group-hover/people:opacity-70 transition-opacity"
+              aria-hidden="true"
+            />
+          </button>
+        ) : (
+          // The case the user actually hit: an empty custom role used to show a
+          // dead "0 people". Make it the loudest thing on the card.
+          <button
+            type="button"
+            onClick={onOpenPeople}
+            aria-label={`Nobody is in ${role.name} yet. Assign people`}
+            className={cn(
+              'inline-flex items-center gap-[7px] rounded-lg -mx-1 px-1 py-0.5 font-medium text-foreground',
+              'hover:bg-muted transition-colors',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+            )}
+          >
+            <UserPlus className="h-3.5 w-3.5" aria-hidden="true" />
+            <span>Assign people</span>
+          </button>
+        )}
         <span className="text-[10px] px-1.5 py-0.5 rounded-md border border-border/40 font-mono uppercase tracking-wider text-muted-foreground">
           {role.builtin ? 'Built-in' : 'Custom'}
         </span>
       </div>
-    </button>
+    </article>
   );
 }
 
@@ -124,8 +196,20 @@ function NewRoleCard({ onClick }: { onClick: () => void }) {
   );
 }
 
-export function RolesList({ restaurantId, onSelectRole, onNewRole }: RolesListProps) {
+export function RolesList({
+  restaurantId,
+  onSelectRole,
+  onNewRole,
+  onOpenPeople,
+}: RolesListProps) {
   const { roles, isLoading, error } = useRoles(restaurantId);
+  // One members query for the whole grid, bucketed once — not one per card.
+  const { data: members } = useRestaurantMembers(restaurantId);
+
+  const rostersByRole = useMemo(
+    () => groupMembersByRole(members ?? [], legacyRoleIndex(roles)),
+    [members, roles]
+  );
 
   if (isLoading) {
     return (
@@ -155,7 +239,13 @@ export function RolesList({ restaurantId, onSelectRole, onNewRole }: RolesListPr
   return (
     <div className={ROLE_GRID_CLASS}>
       {roles.map((role) => (
-        <RoleCard key={role.id} role={role} onClick={() => onSelectRole(role)} />
+        <RoleCard
+          key={role.id}
+          role={role}
+          roster={rostersByRole.get(role.id) ?? []}
+          onClick={() => onSelectRole(role)}
+          onOpenPeople={() => onOpenPeople(role)}
+        />
       ))}
       <NewRoleCard onClick={onNewRole} />
     </div>

--- a/src/components/roles/RolesList.tsx
+++ b/src/components/roles/RolesList.tsx
@@ -107,6 +107,10 @@ function RoleCard({
 
   return (
     <article
+      // Named so the card is one addressable unit: it now holds two controls
+      // plus a badge, and a screen reader jumping between articles should hear
+      // which role it landed on.
+      aria-label={role.name}
       className={cn(
         'group flex flex-col gap-3 p-[18px] rounded-xl border border-border/40 bg-card shadow-sm',
         'hover:border-border transition-colors'

--- a/src/components/roles/RolesList.tsx
+++ b/src/components/roles/RolesList.tsx
@@ -6,6 +6,8 @@ import { useRestaurantMembers, type RestaurantMember } from '@/hooks/useRestaura
 import { RoleAreaChips } from '@/components/roles/RoleAreaChips';
 import { RoleFacePile } from '@/components/roles/RoleFacePile';
 import { groupMembersByRole, legacyRoleIndex } from '@/lib/permissions/roleMembership';
+import { canAssignTargetRole } from '@/lib/permissions/invitations';
+import type { Role } from '@/lib/permissions/types';
 import { cn } from '@/lib/utils';
 
 /**
@@ -37,6 +39,8 @@ import { cn } from '@/lib/utils';
 
 export interface RolesListProps {
   restaurantId: string;
+  /** The signed-in user's role in this restaurant. */
+  callerRole: Role;
   onSelectRole: (role: RoleWithGrants) => void;
   onNewRole: () => void;
   /**
@@ -53,6 +57,9 @@ export interface RolesListProps {
  * responsive without a breakpoint ladder.
  */
 const ROLE_GRID_CLASS = 'grid gap-3.5 grid-cols-[repeat(auto-fill,minmax(292px,1fr))]';
+
+/** Shared so an empty role's `roster` prop is the same reference every render. */
+const EMPTY_ROSTER: readonly RestaurantMember[] = [];
 
 function memberCountLabel(count: number): string {
   return count === 1 ? '1 person' : `${count} people`;
@@ -81,6 +88,74 @@ function RoleCardSkeleton() {
 }
 
 /**
+ * The card footer's left half — the count, and what it opens.
+ *
+ * Three states, as sequential returns rather than a ternary chain: people are
+ * in the role, the role is empty and this caller can fill it, or the role is
+ * empty and they cannot.
+ */
+function RoleCardPeople({
+  role,
+  roster,
+  count,
+  callerRole,
+  onOpenPeople,
+}: {
+  role: RoleWithGrants;
+  roster: readonly RestaurantMember[];
+  count: number;
+  callerRole: Role;
+  onOpenPeople: () => void;
+}) {
+  if (count > 0) {
+    return (
+      <button
+        type="button"
+        onClick={onOpenPeople}
+        aria-label={`${memberCountLabel(count)} in ${role.name}. Manage who's in this role`}
+        className={cn(
+          'group/people inline-flex items-center gap-[7px] rounded-lg -mx-1 px-1 py-0.5',
+          'hover:bg-muted hover:text-foreground transition-colors',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+        )}
+      >
+        <RoleFacePile members={roster} />
+        <span>{memberCountLabel(count)}</span>
+        <ChevronRight
+          className="h-3 w-3 opacity-0 group-hover/people:opacity-70 transition-opacity"
+          aria-hidden="true"
+        />
+      </button>
+    );
+  }
+
+  if (canAssignTargetRole(callerRole, role.legacy_role)) {
+    // The case the user actually hit: an empty custom role used to show a dead
+    // "0 members". Make it the loudest thing on the card.
+    return (
+      <button
+        type="button"
+        onClick={onOpenPeople}
+        aria-label={`Nobody is in ${role.name} yet. Assign people`}
+        className={cn(
+          'inline-flex items-center gap-[7px] rounded-lg -mx-1 px-1 py-0.5 font-medium text-foreground',
+          'hover:bg-muted transition-colors',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+        )}
+      >
+        <UserPlus className="h-3.5 w-3.5" aria-hidden="true" />
+        <span>Assign people</span>
+      </button>
+    );
+  }
+
+  // Empty, and this caller cannot fill it — Kiosk for everyone (it is in no
+  // inviter's row), Owner for a manager. Offering the action here would only
+  // walk them to a panel that cannot offer it either.
+  return <span>Nobody yet</span>;
+}
+
+/**
  * A card is two doors, not one.
  *
  * The chrome moved from a single `<button>` onto an `<article>` so the footer
@@ -92,11 +167,13 @@ function RoleCardSkeleton() {
 function RoleCard({
   role,
   roster,
+  callerRole,
   onClick,
   onOpenPeople,
 }: {
   role: RoleWithGrants;
   roster: readonly RestaurantMember[];
+  callerRole: Role;
   onClick: () => void;
   onOpenPeople: () => void;
 }) {
@@ -138,41 +215,13 @@ function RoleCard({
       <RoleAreaChips areas={role.role_areas} />
 
       <div className="flex items-center justify-between gap-2.5 mt-auto pt-[11px] border-t border-border/40 text-[12px] text-muted-foreground">
-        {count > 0 ? (
-          <button
-            type="button"
-            onClick={onOpenPeople}
-            aria-label={`${memberCountLabel(count)} in ${role.name}. Manage who's in this role`}
-            className={cn(
-              'group/people inline-flex items-center gap-[7px] rounded-lg -mx-1 px-1 py-0.5',
-              'hover:bg-muted hover:text-foreground transition-colors',
-              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
-            )}
-          >
-            <RoleFacePile members={roster} />
-            <span>{memberCountLabel(count)}</span>
-            <ChevronRight
-              className="h-3 w-3 opacity-0 group-hover/people:opacity-70 transition-opacity"
-              aria-hidden="true"
-            />
-          </button>
-        ) : (
-          // The case the user actually hit: an empty custom role used to show a
-          // dead "0 people". Make it the loudest thing on the card.
-          <button
-            type="button"
-            onClick={onOpenPeople}
-            aria-label={`Nobody is in ${role.name} yet. Assign people`}
-            className={cn(
-              'inline-flex items-center gap-[7px] rounded-lg -mx-1 px-1 py-0.5 font-medium text-foreground',
-              'hover:bg-muted transition-colors',
-              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
-            )}
-          >
-            <UserPlus className="h-3.5 w-3.5" aria-hidden="true" />
-            <span>Assign people</span>
-          </button>
-        )}
+        <RoleCardPeople
+          role={role}
+          roster={roster}
+          count={count}
+          callerRole={callerRole}
+          onOpenPeople={onOpenPeople}
+        />
         <span className="text-[10px] px-1.5 py-0.5 rounded-md border border-border/40 font-mono uppercase tracking-wider text-muted-foreground">
           {role.builtin ? 'Built-in' : 'Custom'}
         </span>
@@ -202,6 +251,7 @@ function NewRoleCard({ onClick }: { onClick: () => void }) {
 
 export function RolesList({
   restaurantId,
+  callerRole,
   onSelectRole,
   onNewRole,
   onOpenPeople,
@@ -246,7 +296,8 @@ export function RolesList({
         <RoleCard
           key={role.id}
           role={role}
-          roster={rostersByRole.get(role.id) ?? []}
+          roster={rostersByRole.get(role.id) ?? EMPTY_ROSTER}
+          callerRole={callerRole}
           onClick={() => onSelectRole(role)}
           onOpenPeople={() => onOpenPeople(role)}
         />

--- a/src/components/roles/RolesTab.tsx
+++ b/src/components/roles/RolesTab.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import { RolesList } from '@/components/roles/RolesList';
-import { RoleEditor } from '@/components/roles/RoleEditor';
+import { RoleEditor, type RoleEditorTab } from '@/components/roles/RoleEditor';
 import type { RoleWithGrants } from '@/hooks/useRoles';
+import type { Role } from '@/lib/permissions/types';
 
 /**
  * RolesTab — the "Roles & areas" tab body on Team Management.
@@ -26,20 +27,36 @@ import type { RoleWithGrants } from '@/hooks/useRoles';
 
 export interface RolesTabProps {
   restaurantId: string;
+  /** The signed-in user's role in this restaurant. */
+  userRole: Role;
 }
 
-export function RolesTab({ restaurantId }: RolesTabProps) {
+export function RolesTab({ restaurantId, userRole }: RolesTabProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [selectedRole, setSelectedRole] = useState<RoleWithGrants | null>(null);
+  // Which door the card was opened by. Lives here rather than in the editor so
+  // the editor stays controlled and a second click on the other door of the
+  // same card still switches tabs.
+  const [activeTab, setActiveTab] = useState<RoleEditorTab>('areas');
+
+  const openRole = (role: RoleWithGrants | null, tab: RoleEditorTab) => {
+    setSelectedRole(role);
+    setActiveTab(tab);
+    setIsEditing(true);
+  };
 
   if (isEditing) {
     return (
       <RoleEditor
         restaurantId={restaurantId}
         role={selectedRole}
+        callerRole={userRole}
+        activeTab={activeTab}
+        onTabChange={setActiveTab}
         onBack={() => {
           setIsEditing(false);
           setSelectedRole(null);
+          setActiveTab('areas');
         }}
       />
     );
@@ -71,14 +88,9 @@ export function RolesTab({ restaurantId }: RolesTabProps) {
         </div>
         <RolesList
           restaurantId={restaurantId}
-          onSelectRole={(role) => {
-            setSelectedRole(role);
-            setIsEditing(true);
-          }}
-          onNewRole={() => {
-            setSelectedRole(null);
-            setIsEditing(true);
-          }}
+          onSelectRole={(role) => openRole(role, 'areas')}
+          onOpenPeople={(role) => openRole(role, 'people')}
+          onNewRole={() => openRole(null, 'areas')}
         />
       </div>
     </div>

--- a/src/components/roles/RolesTab.tsx
+++ b/src/components/roles/RolesTab.tsx
@@ -88,6 +88,7 @@ export function RolesTab({ restaurantId, userRole }: RolesTabProps) {
         </div>
         <RolesList
           restaurantId={restaurantId}
+          callerRole={userRole}
           onSelectRole={(role) => openRole(role, 'areas')}
           onOpenPeople={(role) => openRole(role, 'people')}
           onNewRole={() => openRole(null, 'areas')}

--- a/src/components/roles/memberDisplay.ts
+++ b/src/components/roles/memberDisplay.ts
@@ -1,0 +1,42 @@
+import type { RestaurantMember } from '@/hooks/useRestaurantMembers';
+
+/**
+ * How to name and abbreviate a member in the roster UI.
+ *
+ * Not `getInitials` from `src/utils/tipDistribution.ts:169`: that takes a name
+ * string and assumes there is one. `useRestaurantMembers` maps over the
+ * memberships, not the profiles (useRestaurantMembers.ts:54), so a member whose
+ * `profiles` row RLS hides returns with a null name *and* a null email — a case
+ * a name-only helper cannot express. Both functions here take the member and
+ * degrade through the same ladder, so the pile and the row that names it never
+ * disagree about who someone is.
+ */
+
+const UNNAMED = 'Unnamed member';
+
+/** Full name, then email, then a stable placeholder. Never empty. */
+export function memberDisplayName(member: Pick<RestaurantMember, 'fullName' | 'email'>): string {
+  return member.fullName?.trim() || member.email?.trim() || UNNAMED;
+}
+
+/**
+ * Up to two uppercase letters for an avatar.
+ *
+ * Takes the first and last word of a name, which reads better than the first
+ * two for "Maria de la Cruz". An email has no words to split, so it
+ * contributes its first character only — 'JO' from 'jose@…' would look like a
+ * surname that isn't there.
+ */
+export function memberInitials(member: Pick<RestaurantMember, 'fullName' | 'email'>): string {
+  const name = member.fullName?.trim();
+  if (name) {
+    const parts = name.split(/\s+/).filter(Boolean);
+    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+    if (parts.length > 1) return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+  }
+
+  const email = member.email?.trim();
+  if (email) return email[0].toUpperCase();
+
+  return '?';
+}

--- a/src/hooks/useAssignRole.ts
+++ b/src/hooks/useAssignRole.ts
@@ -58,6 +58,10 @@ export function useAssignRole(restaurantId: string | undefined) {
       // ['roles'] — member counts moved.
       queryClient.invalidateQueries({ queryKey: ['roles', restaurantId] });
       queryClient.invalidateQueries({ queryKey: ['collaborators', restaurantId] });
+      // ['restaurant-members'] — the roster behind a role card reads it, and a
+      // reassignment moves someone from one card's list to another's. Without
+      // this the count (from ['roles']) updates and the faces do not.
+      queryClient.invalidateQueries({ queryKey: ['restaurant-members', restaurantId] });
       // ['restaurants'] is not belt-and-braces: useRestaurants embeds the
       // signed-in user's own roleRecord, so a role change they can see must
       // refresh their resolved capabilities — the same reasoning useRoles.ts

--- a/src/hooks/useAssignRole.ts
+++ b/src/hooks/useAssignRole.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
+import type { RestaurantMember } from '@/hooks/useRestaurantMembers';
 import type { MembershipRoleLiteral } from '@/lib/permissions/invitations';
 
 /**
@@ -94,5 +95,59 @@ export function useAssignRole(restaurantId: string | undefined) {
   return useMutation({
     mutationFn: assignMembershipRole,
     onSuccess: refresh,
+  });
+}
+
+export interface AssignPeopleParams extends Omit<AssignRoleParams, 'membershipId'> {
+  /** Everyone to move into the role, in the order they should be attempted. */
+  members: readonly RestaurantMember[];
+}
+
+export interface AssignPeopleResult {
+  /** How many the RPC accepted. */
+  landed: number;
+  /** The rest, each paired with the sentence the RPC wrote for it. */
+  failures: { member: RestaurantMember; message: string }[];
+}
+
+/**
+ * Move several people into one role.
+ *
+ * A partial failure is the normal case, not an exception: `assign_membership_role`
+ * decides person by person, so one 42501 among five must not discard the four
+ * that landed. So the loop swallows each rejection into `failures` and the
+ * mutation itself resolves — the caller reads the result rather than catching.
+ *
+ * Sequential, not `Promise.all`: rule 5b of
+ * 20260802110000_assign_membership_role.sql takes FOR UPDATE on the restaurant's
+ * owner rows before counting them, so concurrent calls contend on one lock. One
+ * at a time also keeps every failure attributable to a person.
+ *
+ * `onSettled`, not `onSuccess`: even a run where every call was denied refreshes,
+ * because rule 5b's owner count and the invite matrix are both read from data the
+ * caller is showing — a denial can mean the screen is stale. It fires once for
+ * the batch, not once per person, which is the whole reason `assignMembershipRole`
+ * is separate from `useAssignRole`.
+ *
+ * No optimistic update: the write is a *reassignment*, so rolling one back means
+ * restoring each person's previous role individually, and the failures arrive
+ * interleaved with successes. The honest cache here is the server's.
+ */
+export function useAssignPeopleToRole(restaurantId: string | undefined) {
+  const refresh = useRefreshAfterAssign(restaurantId);
+
+  return useMutation({
+    mutationFn: async ({ members, role, roleId }: AssignPeopleParams): Promise<AssignPeopleResult> => {
+      const failures: AssignPeopleResult['failures'] = [];
+      for (const member of members) {
+        try {
+          await assignMembershipRole({ membershipId: member.membershipId, role, roleId });
+        } catch (err) {
+          failures.push({ member, message: assignRoleErrorMessage(err) });
+        }
+      }
+      return { landed: members.length - failures.length, failures };
+    },
+    onSettled: refresh,
   });
 }

--- a/src/hooks/useAssignRole.ts
+++ b/src/hooks/useAssignRole.ts
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import type { MembershipRoleLiteral } from '@/lib/permissions/invitations';
@@ -42,31 +43,56 @@ export function assignRoleErrorMessage(error: unknown): string {
   return FALLBACK;
 }
 
-export function useAssignRole(restaurantId: string | undefined) {
+/**
+ * The RPC call alone, with no cache side effects.
+ *
+ * Separate from the mutation so a caller assigning several people in a row can
+ * refresh ONCE at the end. Through the mutation, each `mutateAsync` fires the
+ * four invalidations below, and the queries behind the open dialog are all
+ * active — so assigning K people means 4K refetches for one net change.
+ */
+export async function assignMembershipRole({
+  membershipId,
+  role,
+  roleId,
+}: AssignRoleParams): Promise<void> {
+  const { error } = await supabase.rpc('assign_membership_role', {
+    p_membership_id: membershipId,
+    p_role: role,
+    p_role_id: roleId ?? null,
+  });
+  if (error) throw error;
+}
+
+/**
+ * Everything a role change moves, refreshed together. Returned as a callback so
+ * both the single-assignment mutation and a batch can fire it — the batch after
+ * its whole loop rather than inside it.
+ */
+export function useRefreshAfterAssign(restaurantId: string | undefined) {
   const queryClient = useQueryClient();
 
+  return useCallback(() => {
+    // ['roles'] — member counts moved.
+    queryClient.invalidateQueries({ queryKey: ['roles', restaurantId] });
+    queryClient.invalidateQueries({ queryKey: ['collaborators', restaurantId] });
+    // ['restaurant-members'] — the roster behind a role card reads it, and a
+    // reassignment moves someone from one card's list to another's. Without
+    // this the count (from ['roles']) updates and the faces do not.
+    queryClient.invalidateQueries({ queryKey: ['restaurant-members', restaurantId] });
+    // ['restaurants'] is not belt-and-braces: useRestaurants embeds the
+    // signed-in user's own roleRecord, so a role change they can see must
+    // refresh their resolved capabilities — the same reasoning useRoles.ts
+    // documents at :15-19.
+    queryClient.invalidateQueries({ queryKey: ['restaurants'] });
+  }, [queryClient, restaurantId]);
+}
+
+export function useAssignRole(restaurantId: string | undefined) {
+  const refresh = useRefreshAfterAssign(restaurantId);
+
   return useMutation({
-    mutationFn: async ({ membershipId, role, roleId }: AssignRoleParams) => {
-      const { error } = await supabase.rpc('assign_membership_role', {
-        p_membership_id: membershipId,
-        p_role: role,
-        p_role_id: roleId ?? null,
-      });
-      if (error) throw error;
-    },
-    onSuccess: () => {
-      // ['roles'] — member counts moved.
-      queryClient.invalidateQueries({ queryKey: ['roles', restaurantId] });
-      queryClient.invalidateQueries({ queryKey: ['collaborators', restaurantId] });
-      // ['restaurant-members'] — the roster behind a role card reads it, and a
-      // reassignment moves someone from one card's list to another's. Without
-      // this the count (from ['roles']) updates and the faces do not.
-      queryClient.invalidateQueries({ queryKey: ['restaurant-members', restaurantId] });
-      // ['restaurants'] is not belt-and-braces: useRestaurants embeds the
-      // signed-in user's own roleRecord, so a role change they can see must
-      // refresh their resolved capabilities — the same reasoning useRoles.ts
-      // documents at :15-19.
-      queryClient.invalidateQueries({ queryKey: ['restaurants'] });
-    },
+    mutationFn: assignMembershipRole,
+    onSuccess: refresh,
   });
 }

--- a/src/hooks/useRestaurantMembers.ts
+++ b/src/hooks/useRestaurantMembers.ts
@@ -4,6 +4,12 @@ import { supabase } from '@/integrations/supabase/client';
 import type { MembershipRoleLiteral } from '@/lib/permissions';
 
 export interface RestaurantMember {
+  /**
+   * The `user_restaurants` row id — what `assign_membership_role` takes, and
+   * what `RolePicker` needs to change this person's role. Not the user id: a
+   * user may hold a membership in more than one restaurant.
+   */
+  membershipId: string;
   userId: string;
   email: string | null;
   fullName: string | null;
@@ -37,7 +43,7 @@ export function useRestaurantMembers(restaurantId: string | undefined) {
     queryFn: async (): Promise<RestaurantMember[]> => {
       const { data: memberships, error: membershipError } = await supabase
         .from('user_restaurants')
-        .select('user_id, role, role_id')
+        .select('id, user_id, role, role_id')
         .eq('restaurant_id', restaurantId);
 
       if (membershipError) throw membershipError;
@@ -54,6 +60,7 @@ export function useRestaurantMembers(restaurantId: string | undefined) {
       return memberships.map((m) => {
         const profile = byUserId.get(m.user_id);
         return {
+          membershipId: m.id,
           userId: m.user_id,
           email: profile?.email ?? null,
           fullName: profile?.full_name ?? null,

--- a/src/lib/permissions/index.ts
+++ b/src/lib/permissions/index.ts
@@ -33,6 +33,7 @@ export {
 // Invitations
 export {
   canAssignAnyRole,
+  canAssignTargetRole,
   canInviteRole,
   canInviteCustomRole,
   getInvitableRoles,

--- a/src/lib/permissions/index.ts
+++ b/src/lib/permissions/index.ts
@@ -37,6 +37,11 @@ export {
   canInviteRole,
   canInviteCustomRole,
   getInvitableRoles,
+  isAssignableCustomRole,
   CUSTOM_ROLE,
 } from './invitations';
-export type { InviteRoleLiteral, MembershipRoleLiteral } from './invitations';
+export type {
+  AssignableRoleRow,
+  InviteRoleLiteral,
+  MembershipRoleLiteral,
+} from './invitations';

--- a/src/lib/permissions/index.ts
+++ b/src/lib/permissions/index.ts
@@ -31,5 +31,11 @@ export {
 } from './definitions';
 
 // Invitations
-export { canInviteRole, canInviteCustomRole, getInvitableRoles, CUSTOM_ROLE } from './invitations';
+export {
+  canAssignAnyRole,
+  canInviteRole,
+  canInviteCustomRole,
+  getInvitableRoles,
+  CUSTOM_ROLE,
+} from './invitations';
 export type { InviteRoleLiteral, MembershipRoleLiteral } from './invitations';

--- a/src/lib/permissions/invitations.ts
+++ b/src/lib/permissions/invitations.ts
@@ -112,6 +112,44 @@ export function canAssignAnyRole(inviter: Role): boolean {
 }
 
 /**
+ * The columns of a `roles` row that decide whether it can be assigned to.
+ *
+ * Declared structurally rather than importing the hook's `Role`/`RoleWithGrants`
+ * type: this module is the permission matrix, and the data layer already
+ * depends on it. Naming the four fields it reads keeps the arrow pointing one
+ * way and lets a caller pass any row shape that carries them.
+ */
+export interface AssignableRoleRow {
+  /** Builtin role string for a builtin row, NULL for a custom one. */
+  legacy_role: string | null;
+  /** Owning restaurant; NULL for the platform's own builtin rows. */
+  restaurant_id: string | null;
+  builtin: boolean;
+  flavor: string;
+}
+
+/**
+ * Whether `role` is a custom role that `assign_membership_role` would actually
+ * accept for this restaurant — restaurant-scoped, non-builtin, and
+ * collaborator-flavored, the three predicates the RPC checks together
+ * (20260803100000_assign_membership_role_custom_role_flavor_check.sql:150-161).
+ *
+ * `restaurant_id` alone is not enough, and neither is a null `legacy_role`.
+ * `copy_role_to_restaurants` (20260730160000:114-115) inserts the copy with the
+ * source row's `flavor` verbatim, `builtin = false` and no `legacy_role` — so
+ * copying a platform-flavored role hands a restaurant a non-builtin row that
+ * looks exactly like a custom role from the `legacy_role` column alone. Offering
+ * it as an assignment target fails at commit time with a 42501 that reads as a
+ * permissions problem rather than "this role was never assignable".
+ *
+ * Shared with `RolePicker`'s custom-role list so the two cannot drift: the
+ * picker's options and this gate must answer the same question.
+ */
+export function isAssignableCustomRole(role: AssignableRoleRow, restaurantId: string): boolean {
+  return role.restaurant_id === restaurantId && !role.builtin && role.flavor === 'collaborator';
+}
+
+/**
  * Whether `inviter` may put someone into ONE specific role — the gate for an
  * "Assign people to this role" action, which names its target up front.
  *
@@ -120,19 +158,25 @@ export function canAssignAnyRole(inviter: Role): boolean {
  * `staff`) standing in front of a custom role, and to a manager standing in
  * front of Owner. Both would get a 42501 on every person they picked.
  *
- * `targetLegacyRole` is the `roles.legacy_role` column: the builtin role string
- * for a builtin row, NULL for a custom one — the same discriminator
- * `RolePicker` uses to decide what to send. The two branches mirror
- * `assign_membership_role`'s rule 6 exactly
- * (20260802110000_assign_membership_role.sql:158-190): custom roles are gated
- * by `can_invite_custom_role`, builtins by membership in `invitable_roles`.
+ * The branch is on `roles.legacy_role` — the same discriminator `RolePicker`
+ * uses to decide what to send — and the two arms mirror
+ * `assign_membership_role`'s rule 6: builtins by membership in
+ * `invitable_roles`, custom roles by `can_invite_custom_role` AND the role's own
+ * restaurant / builtin / flavor (see `isAssignableCustomRole`). Both halves of
+ * the custom arm are required; the caller's privilege does not make an
+ * unassignable role assignable.
  *
  * A consequence worth stating: nobody can assign `kiosk`, because it is in no
  * inviter's row. That is the server's answer too — a kiosk is provisioned from
  * device setup, not handed to a person.
  */
-export function canAssignTargetRole(inviter: Role, targetLegacyRole: string | null): boolean {
-  return targetLegacyRole === null
-    ? canInviteCustomRole(inviter)
-    : canInviteRole(inviter, targetLegacyRole as Role);
+export function canAssignTargetRole(
+  inviter: Role,
+  role: AssignableRoleRow,
+  restaurantId: string
+): boolean {
+  if (role.legacy_role !== null) {
+    return canInviteRole(inviter, role.legacy_role as Role);
+  }
+  return canInviteCustomRole(inviter) && isAssignableCustomRole(role, restaurantId);
 }

--- a/src/lib/permissions/invitations.ts
+++ b/src/lib/permissions/invitations.ts
@@ -92,3 +92,21 @@ export function canInviteRole(inviter: Role, target: Role): boolean {
 export function canInviteCustomRole(inviter: Role): boolean {
   return CUSTOM_ROLE_INVITERS.includes(inviter);
 }
+
+/**
+ * Whether `inviter` may change anyone's role at all — the gate for showing a
+ * role picker rather than a plain label.
+ *
+ * Derived from the two structures above rather than re-listing the roles that
+ * can assign, so it cannot drift from them: a role with nowhere to assign is a
+ * role that `assign_membership_role` would refuse for every target it was
+ * offered (rule 6, 20260802110000_assign_membership_role.sql:188). Showing that
+ * caller a live picker buys them a 42501 for every choice.
+ *
+ * This is a reachable state, not a hypothetical one: `App.tsx`'s
+ * `StaffRoleChecker` keeps staff, kiosk and collaborators off /team, but a chef
+ * walks straight in.
+ */
+export function canAssignAnyRole(inviter: Role): boolean {
+  return getInvitableRoles(inviter).length > 0 || canInviteCustomRole(inviter);
+}

--- a/src/lib/permissions/invitations.ts
+++ b/src/lib/permissions/invitations.ts
@@ -110,3 +110,29 @@ export function canInviteCustomRole(inviter: Role): boolean {
 export function canAssignAnyRole(inviter: Role): boolean {
   return getInvitableRoles(inviter).length > 0 || canInviteCustomRole(inviter);
 }
+
+/**
+ * Whether `inviter` may put someone into ONE specific role — the gate for an
+ * "Assign people to this role" action, which names its target up front.
+ *
+ * `canAssignAnyRole` cannot answer this: it asks whether the caller has any
+ * target at all, so it says yes to an operations_manager (who may assign only
+ * `staff`) standing in front of a custom role, and to a manager standing in
+ * front of Owner. Both would get a 42501 on every person they picked.
+ *
+ * `targetLegacyRole` is the `roles.legacy_role` column: the builtin role string
+ * for a builtin row, NULL for a custom one — the same discriminator
+ * `RolePicker` uses to decide what to send. The two branches mirror
+ * `assign_membership_role`'s rule 6 exactly
+ * (20260802110000_assign_membership_role.sql:158-190): custom roles are gated
+ * by `can_invite_custom_role`, builtins by membership in `invitable_roles`.
+ *
+ * A consequence worth stating: nobody can assign `kiosk`, because it is in no
+ * inviter's row. That is the server's answer too — a kiosk is provisioned from
+ * device setup, not handed to a person.
+ */
+export function canAssignTargetRole(inviter: Role, targetLegacyRole: string | null): boolean {
+  return targetLegacyRole === null
+    ? canInviteCustomRole(inviter)
+    : canInviteRole(inviter, targetLegacyRole as Role);
+}

--- a/src/lib/permissions/roleMembership.ts
+++ b/src/lib/permissions/roleMembership.ts
@@ -1,0 +1,84 @@
+import type { RestaurantMember } from '@/hooks/useRestaurantMembers';
+import type { RoleWithGrants } from '@/hooks/useRoles';
+
+/**
+ * Which role a membership belongs to, resolved the way the database resolves
+ * it.
+ *
+ * `role_member_counts` (20260730200000_role_member_counts.sql:36-46) buckets a
+ * membership by `COALESCE(ur.role_id, builtin_role_id_for(ur.role))` and drops
+ * the row when that is NULL. A role card prints the count that RPC returns and
+ * opens a roster built here, so any disagreement between the two shows up as a
+ * card that says "3 people" above a list of two.
+ *
+ * That migration also warns (lines 18-21) that resolving the legacy string in
+ * TypeScript "would be the copy that drifts". This is not that copy.
+ * `roles.legacy_role` (20260802100000_roles_legacy_role.sql) is the mapping
+ * itself, exposed as a column: it was backfilled *through* `builtin_role_id_for`
+ * (line 44), so it cannot hold a pair the function disagrees with, and a unique
+ * partial index (line 51) plus a builtin-only CHECK (lines 54-55) keep it that
+ * way. `RolePicker.tsx:113` already reads it the same way. What follows is a
+ * lookup in that data, not a second listing of the pairs.
+ */
+
+/**
+ * Builtin role string -> roles row id.
+ *
+ * Only builtin rows appear: `legacy_role` is NULL for every custom role, which
+ * has no legacy string to be found by — every custom role shares the bare
+ * 'collaborator_custom' literal and is told apart by id alone.
+ *
+ * Built once per render and passed down, rather than rebuilt per card.
+ */
+export function legacyRoleIndex(roles: readonly RoleWithGrants[]): Map<string, string> {
+  const index = new Map<string, string>();
+  for (const role of roles) {
+    if (role.legacy_role !== null) index.set(role.legacy_role, role.id);
+  }
+  return index;
+}
+
+/**
+ * The roles row this membership counts towards, or null when it counts towards
+ * none — the client-side twin of the COALESCE above.
+ *
+ * Null is the ordinary answer for a `collaborator_custom` membership whose
+ * `role_id` was never written: no roles row carries that legacy string, just as
+ * `builtin_role_id_for` returns NULL for it. Such a row has no card to sit on.
+ */
+export function resolveMembershipRoleId(
+  member: Pick<RestaurantMember, 'role' | 'roleId'>,
+  byLegacy: ReadonlyMap<string, string>
+): string | null {
+  return member.roleId ?? byLegacy.get(member.role) ?? null;
+}
+
+/** Everyone in `members` whose membership resolves to `roleId`. */
+export function membersInRole(
+  members: readonly RestaurantMember[],
+  roleId: string,
+  byLegacy: ReadonlyMap<string, string>
+): RestaurantMember[] {
+  return members.filter((m) => resolveMembershipRoleId(m, byLegacy) === roleId);
+}
+
+/**
+ * Every member bucketed by resolved role, in one pass.
+ *
+ * The roles grid needs a roster per card; calling `membersInRole` once per card
+ * would walk the membership list once per role for no reason.
+ */
+export function groupMembersByRole(
+  members: readonly RestaurantMember[],
+  byLegacy: ReadonlyMap<string, string>
+): Map<string, RestaurantMember[]> {
+  const grouped = new Map<string, RestaurantMember[]>();
+  for (const member of members) {
+    const roleId = resolveMembershipRoleId(member, byLegacy);
+    if (roleId === null) continue;
+    const list = grouped.get(roleId);
+    if (list) list.push(member);
+    else grouped.set(roleId, [member]);
+  }
+  return grouped;
+}

--- a/src/pages/Team.tsx
+++ b/src/pages/Team.tsx
@@ -169,7 +169,10 @@ const Team = () => {
           </TabsContent>
 
           <TabsContent value="roles" role="tabpanel" aria-labelledby="roles-tab">
-            <RolesTab restaurantId={selectedRestaurant.restaurant_id} />
+            <RolesTab
+              restaurantId={selectedRestaurant.restaurant_id}
+              userRole={selectedRestaurant.role}
+            />
           </TabsContent>
 
           <TabsContent value="collaborators" role="tabpanel" aria-labelledby="collaborators-tab">

--- a/tests/e2e/role-roster.spec.ts
+++ b/tests/e2e/role-roster.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect } from '@playwright/test';
+import { generateTestUser, signUpAndCreateRestaurant, exposeSupabaseHelpers } from '../helpers/e2e-supabase';
+
+/**
+ * Move 2 of the role-assignment design: a role card's member count is a door.
+ *
+ * The bug this closes is the one the user reported — you make a custom role,
+ * and the card says "0 members" with nothing to click. So this walks the path
+ * from the dead end to the fix: empty card → "Assign people" → the People tab
+ * → the dialog → the count on the card, all without touching the Team members
+ * tab that Move 1 already covers (role-assignment.spec.ts).
+ *
+ * The reload at the end is the same guard Move 1's spec keeps: the code this
+ * feature replaced showed success over a write that never landed.
+ */
+test('an owner fills an empty custom role from the role card, and the count follows', async ({ page }) => {
+  const member = generateTestUser('member');
+  const owner = generateTestUser('owner');
+
+  // Sign the member up first, purely to mint a real auth.users row — the
+  // membership row's user_id is a foreign key, so it cannot be faked.
+  await page.goto('/auth');
+  await exposeSupabaseHelpers(page);
+  await page.getByRole('tab', { name: /sign up/i }).click();
+  await page.getByLabel(/email/i).first().fill(member.email);
+  await page.getByLabel(/full name/i).fill(member.fullName);
+  await page.getByLabel(/password/i).first().fill(member.password);
+  await page.getByRole('button', { name: /sign up|create account/i }).click();
+  await page.waitForURL('/', { timeout: 15000 });
+
+  const memberUserId = await page.evaluate(async () => {
+    // `any`: test-only global attached by exposeSupabaseHelpers, no typed surface.
+    const user = await (window as any).__getAuthUser();
+    return user?.id as string;
+  });
+  expect(memberUserId).toBeTruthy();
+
+  await page.evaluate(async () => {
+    // `any`: test-only global attached by exposeSupabaseHelpers, no typed surface.
+    await (window as any).__supabase.auth.signOut();
+  });
+
+  await signUpAndCreateRestaurant(page, owner);
+  await exposeSupabaseHelpers(page);
+
+  // Seed the empty custom role and the member's staff membership. Both writes
+  // are ones the owner can legitimately make through the UI; doing them here
+  // keeps the spec on the behaviour under test rather than re-walking the role
+  // builder, which roles-and-areas.spec.ts already covers end to end.
+  const roleName = `Weekend Lead ${Date.now()}`;
+  await page.evaluate(
+    async ({ memberUserId, roleName }) => {
+      // `any`: both are test-only globals attached by exposeSupabaseHelpers.
+      const supabase = (window as any).__supabase;
+      const restaurantId = await (window as any).__getRestaurantId();
+
+      const { data: role, error: roleError } = await supabase
+        .from('roles')
+        .insert({ restaurant_id: restaurantId, name: roleName, flavor: 'collaborator', builtin: false })
+        .select('id')
+        .single();
+      if (roleError) throw new Error(`role insert failed: ${roleError.message}`);
+
+      const { error: grantError } = await supabase
+        .from('role_areas')
+        .insert({ role_id: role.id, area_key: 'recipes', level: 'manage' });
+      if (grantError) throw new Error(`grant insert failed: ${grantError.message}`);
+
+      const { error: memberError } = await supabase
+        .from('user_restaurants')
+        .insert({ user_id: memberUserId, restaurant_id: restaurantId, role: 'staff' });
+      if (memberError) throw new Error(`membership insert failed: ${memberError.message}`);
+    },
+    { memberUserId, roleName }
+  );
+
+  await page.goto('/team');
+  await page.getByRole('tab', { name: /roles & areas/i }).click();
+
+  // ---- The dead end, now a door ----
+  const assignFromCard = page.getByRole('button', {
+    name: new RegExp(`Nobody is in ${roleName} yet\\. Assign people`),
+  });
+  await expect(assignFromCard).toBeVisible({ timeout: 10000 });
+  await assignFromCard.click();
+
+  // It opens the editor on the People tab, not the Areas tab — the two doors
+  // on a card go to different places.
+  await expect(page.getByRole('tab', { name: 'People', selected: true })).toBeVisible();
+  await expect(page.getByRole('heading', { name: /who's in this role/i })).toBeVisible();
+
+  // ---- Assign, from the role's side rather than the person's ----
+  await page.getByRole('button', { name: /^assign people$/i }).click();
+  await expect(page.getByRole('dialog')).toBeVisible();
+
+  const dialog = page.getByRole('dialog');
+  await dialog.getByText(member.fullName).click();
+  await dialog.getByRole('button', { name: /^assign 1$/i }).click();
+
+  // ---- The roster now holds them ----
+  await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 10000 });
+  await expect(
+    page.getByRole('combobox', { name: new RegExp(`${member.fullName}.*role is ${roleName}`) })
+  ).toBeVisible({ timeout: 10000 });
+
+  // ---- And the card's count followed ----
+  await page.getByRole('button', { name: /all roles/i }).click();
+  const countDoor = page.getByRole('button', {
+    name: new RegExp(`1 person in ${roleName}`),
+  });
+  await expect(countDoor).toBeVisible({ timeout: 10000 });
+
+  await page.reload();
+  await page.getByRole('tab', { name: /roles & areas/i }).click();
+  await expect(countDoor).toBeVisible({ timeout: 10000 });
+});

--- a/tests/e2e/roles-and-areas.spec.ts
+++ b/tests/e2e/roles-and-areas.spec.ts
@@ -218,7 +218,10 @@ test.describe('Roles & Areas', () => {
     await page.getByRole('button', { name: /^save role$/i }).click();
 
     // ---- Back on the roles list: the new card shows exactly what was granted ----
-    const roleCard = page.getByRole('button', { name: new RegExp(roleName) });
+    // The card is an <article>, not a button: it holds two doors (the name
+    // block opens the definition, the footer opens who holds the role), and a
+    // button inside a button is invalid HTML.
+    const roleCard = page.getByRole('article', { name: new RegExp(roleName) });
     await expect(roleCard).toBeVisible();
     await expect(roleCard).toContainText(/inventory & purchasing/i);
     await expect(roleCard).toContainText(/· manage/i); // manage-level chip suffix

--- a/tests/unit/AssignPeopleDialog.test.tsx
+++ b/tests/unit/AssignPeopleDialog.test.tsx
@@ -187,8 +187,13 @@ describe('AssignPeopleDialog', () => {
         expect.objectContaining({ title: '1 assigned, 1 failed', variant: 'destructive' })
       )
     );
-    // Only the failure stays ticked, so a retry cannot re-assign the one that landed.
+    // Only the failure stays ticked, so a retry cannot re-assign the one that
+    // landed. Named by position, in candidate order: the row's accessible name
+    // lives on the label text, not on the Radix checkbox itself.
     expect(screen.getByText('1 person selected')).toBeInTheDocument();
+    const [danaBox, samBox] = screen.getAllByRole('checkbox');
+    expect(danaBox).not.toBeChecked();
+    expect(samBox).toBeChecked();
     expect(props.onOpenChange).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/AssignPeopleDialog.test.tsx
+++ b/tests/unit/AssignPeopleDialog.test.tsx
@@ -11,15 +11,15 @@ vi.mock('@/hooks/useRestaurantMembers', () => ({
   useRestaurantMembers: (...a: unknown[]) => mockUseRestaurantMembers(...a),
 }));
 
-const assignMembershipRole = vi.fn();
-const refresh = vi.fn();
+// The batch mutation is mocked at the hook boundary; useAssignRole.test.ts
+// covers the loop, the failure capture and the single onSettled refresh.
+const assignPeople = vi.fn();
 vi.mock('@/hooks/useAssignRole', async () => {
   const actual =
     await vi.importActual<typeof import('@/hooks/useAssignRole')>('@/hooks/useAssignRole');
   return {
     ...actual,
-    assignMembershipRole: (...a: unknown[]) => assignMembershipRole(...a),
-    useRefreshAfterAssign: () => refresh,
+    useAssignPeopleToRole: () => ({ mutateAsync: assignPeople, isPending: false }),
   };
 });
 
@@ -65,11 +65,10 @@ const loaded = (members: RestaurantMember[]) => ({ data: members, isLoading: fal
 describe('AssignPeopleDialog', () => {
   beforeEach(() => {
     mockUseRestaurantMembers.mockReset();
-    assignMembershipRole.mockReset();
-    refresh.mockReset();
+    assignPeople.mockReset();
     toast.mockReset();
     props.onOpenChange.mockReset();
-    assignMembershipRole.mockResolvedValue(undefined);
+    assignPeople.mockResolvedValue({ landed: 0, failures: [] });
   });
 
   // The row is a <label> wrapping a Radix Checkbox, which renders a <button
@@ -89,29 +88,53 @@ describe('AssignPeopleDialog', () => {
     expect(screen.getByRole('button', { name: 'Assign 1' })).toBeEnabled();
   });
 
-  it('assigns the ticked people, refreshes once, and closes', async () => {
-    mockUseRestaurantMembers.mockReturnValue(
-      loaded([member({}), member({ membershipId: 'm2', userId: 'u2', fullName: 'Sam Ortiz' })])
-    );
+  it('hands the whole selection to the batch mutation in one call, and closes', async () => {
+    const dana = member({});
+    const sam = member({ membershipId: 'm2', userId: 'u2', fullName: 'Sam Ortiz' });
+    mockUseRestaurantMembers.mockReturnValue(loaded([dana, sam]));
+    assignPeople.mockResolvedValue({ landed: 2, failures: [] });
     render(<AssignPeopleDialog {...props} />);
 
     await userEvent.click(screen.getByText('Dana Reyes'));
     await userEvent.click(screen.getByText('Sam Ortiz'));
     await userEvent.click(screen.getByRole('button', { name: 'Assign 2' }));
 
-    await waitFor(() => expect(assignMembershipRole).toHaveBeenCalledTimes(2));
+    // One call for the batch, not one per person — the invalidation storm this
+    // dialog would otherwise cause is the reason the mutation takes a list.
+    await waitFor(() => expect(assignPeople).toHaveBeenCalledTimes(1));
     // A custom role sends the bare literal plus its id, never its own name.
-    expect(assignMembershipRole).toHaveBeenCalledWith({
-      membershipId: 'm1',
+    expect(assignPeople).toHaveBeenCalledWith({
+      members: [dana, sam],
       role: 'collaborator_custom',
       roleId: 'role-weekend',
     });
-    // Once for the batch, not once per person.
-    expect(refresh).toHaveBeenCalledTimes(1);
     expect(toast).toHaveBeenCalledWith(
       expect.objectContaining({ title: '2 people are now Weekend Lead' })
     );
     expect(props.onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('sends a builtin role by name with no role id', async () => {
+    const dana = member({});
+    mockUseRestaurantMembers.mockReturnValue(loaded([dana]));
+    assignPeople.mockResolvedValue({ landed: 1, failures: [] });
+    render(
+      <AssignPeopleDialog
+        {...props}
+        role={{ ...role, id: 'role-manager', name: 'Manager', legacy_role: 'manager' }}
+      />
+    );
+
+    await userEvent.click(screen.getByText('Dana Reyes'));
+    await userEvent.click(screen.getByRole('button', { name: 'Assign 1' }));
+
+    await waitFor(() =>
+      expect(assignPeople).toHaveBeenCalledWith({
+        members: [dana],
+        role: 'manager',
+        roleId: undefined,
+      })
+    );
   });
 
   // The boundary the batch path gets wrong if the drop check sits after the
@@ -134,7 +157,7 @@ describe('AssignPeopleDialog', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'Assign 1' }));
 
-    expect(assignMembershipRole).not.toHaveBeenCalled();
+    expect(assignPeople).not.toHaveBeenCalled();
     expect(toast).toHaveBeenCalledWith({
       title: 'Nothing left to assign',
       description: 'One person was already handled elsewhere and was skipped.',
@@ -147,12 +170,12 @@ describe('AssignPeopleDialog', () => {
   });
 
   it('keeps the failed rows ticked and the dialog open on a partial failure', async () => {
-    mockUseRestaurantMembers.mockReturnValue(
-      loaded([member({}), member({ membershipId: 'm2', userId: 'u2', fullName: 'Sam Ortiz' })])
-    );
-    assignMembershipRole.mockImplementation(({ membershipId }: { membershipId: string }) =>
-      membershipId === 'm2' ? Promise.reject(new Error('nope')) : Promise.resolve(undefined)
-    );
+    const sam = member({ membershipId: 'm2', userId: 'u2', fullName: 'Sam Ortiz' });
+    mockUseRestaurantMembers.mockReturnValue(loaded([member({}), sam]));
+    assignPeople.mockResolvedValue({
+      landed: 1,
+      failures: [{ member: sam, message: 'Only an owner can change an owner.' }],
+    });
     render(<AssignPeopleDialog {...props} />);
 
     await userEvent.click(screen.getByText('Dana Reyes'));

--- a/tests/unit/AssignPeopleDialog.test.tsx
+++ b/tests/unit/AssignPeopleDialog.test.tsx
@@ -1,0 +1,171 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AssignPeopleDialog } from '@/components/roles/AssignPeopleDialog';
+import type { RestaurantMember } from '@/hooks/useRestaurantMembers';
+import type { RoleWithGrants } from '@/hooks/useRoles';
+
+const mockUseRestaurantMembers = vi.fn();
+vi.mock('@/hooks/useRestaurantMembers', () => ({
+  useRestaurantMembers: (...a: unknown[]) => mockUseRestaurantMembers(...a),
+}));
+
+const assignMembershipRole = vi.fn();
+const refresh = vi.fn();
+vi.mock('@/hooks/useAssignRole', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/hooks/useAssignRole')>('@/hooks/useAssignRole');
+  return {
+    ...actual,
+    assignMembershipRole: (...a: unknown[]) => assignMembershipRole(...a),
+    useRefreshAfterAssign: () => refresh,
+  };
+});
+
+vi.mock('@/hooks/useAuth', () => ({ useAuth: () => ({ user: { id: 'u-caller' } }) }));
+
+const toast = vi.fn();
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast }) }));
+
+const role: RoleWithGrants = {
+  id: 'role-weekend',
+  restaurant_id: 'r1',
+  name: 'Weekend Lead',
+  description: null,
+  flavor: 'collaborator',
+  builtin: false,
+  legacy_role: null,
+  created_at: '',
+  role_areas: [],
+  role_flags: [],
+  memberCount: 0,
+} as unknown as RoleWithGrants;
+
+const member = (over: Partial<RestaurantMember>): RestaurantMember => ({
+  membershipId: 'm1',
+  userId: 'u1',
+  email: 'dana@example.com',
+  fullName: 'Dana Reyes',
+  role: 'staff',
+  roleId: null,
+  ...over,
+});
+
+const props = {
+  role,
+  restaurantId: 'r1',
+  callerRole: 'owner' as const,
+  open: true,
+  onOpenChange: vi.fn(),
+};
+
+const loaded = (members: RestaurantMember[]) => ({ data: members, isLoading: false, error: null });
+
+describe('AssignPeopleDialog', () => {
+  beforeEach(() => {
+    mockUseRestaurantMembers.mockReset();
+    assignMembershipRole.mockReset();
+    refresh.mockReset();
+    toast.mockReset();
+    props.onOpenChange.mockReset();
+    assignMembershipRole.mockResolvedValue(undefined);
+  });
+
+  // The row is a <label> wrapping a Radix Checkbox, which renders a <button
+  // role="checkbox"> rather than a native input. A review flagged that as
+  // possibly inert. <button> is a labelable element, so the label's activation
+  // behaviour forwards the click — this pins it, because if it ever stops
+  // being true the row text goes dead and nothing else would notice.
+  it('ticks the row when you click the person, not just the checkbox', async () => {
+    mockUseRestaurantMembers.mockReturnValue(loaded([member({})]));
+    render(<AssignPeopleDialog {...props} />);
+
+    expect(screen.getByText('Nobody selected')).toBeInTheDocument();
+    await userEvent.click(screen.getByText('Dana Reyes'));
+
+    expect(screen.getByRole('checkbox')).toBeChecked();
+    expect(screen.getByText('1 person selected')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Assign 1' })).toBeEnabled();
+  });
+
+  it('assigns the ticked people, refreshes once, and closes', async () => {
+    mockUseRestaurantMembers.mockReturnValue(
+      loaded([member({}), member({ membershipId: 'm2', userId: 'u2', fullName: 'Sam Ortiz' })])
+    );
+    render(<AssignPeopleDialog {...props} />);
+
+    await userEvent.click(screen.getByText('Dana Reyes'));
+    await userEvent.click(screen.getByText('Sam Ortiz'));
+    await userEvent.click(screen.getByRole('button', { name: 'Assign 2' }));
+
+    await waitFor(() => expect(assignMembershipRole).toHaveBeenCalledTimes(2));
+    // A custom role sends the bare literal plus its id, never its own name.
+    expect(assignMembershipRole).toHaveBeenCalledWith({
+      membershipId: 'm1',
+      role: 'collaborator_custom',
+      roleId: 'role-weekend',
+    });
+    // Once for the batch, not once per person.
+    expect(refresh).toHaveBeenCalledTimes(1);
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: '2 people are now Weekend Lead' })
+    );
+    expect(props.onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  // The boundary the batch path gets wrong if the drop check sits after the
+  // early return: everyone ticked leaves the candidate list, so no row is left
+  // to untick, and a stale `selected` keeps "Assign 1" enabled forever.
+  it('recovers when everyone ticked was assigned elsewhere first', async () => {
+    mockUseRestaurantMembers.mockReturnValue(loaded([member({})]));
+    const { rerender } = render(<AssignPeopleDialog {...props} />);
+
+    await userEvent.click(screen.getByText('Dana Reyes'));
+    expect(screen.getByRole('button', { name: 'Assign 1' })).toBeEnabled();
+
+    // Another admin put Dana in this role while the dialog sat open, so the
+    // background refetch drops her from the candidates.
+    mockUseRestaurantMembers.mockReturnValue(
+      loaded([member({ role: 'collaborator_custom', roleId: 'role-weekend' })])
+    );
+    rerender(<AssignPeopleDialog {...props} />);
+    expect(screen.getByText('Everyone already holds this role.')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Assign 1' }));
+
+    expect(assignMembershipRole).not.toHaveBeenCalled();
+    expect(toast).toHaveBeenCalledWith({
+      title: 'Nothing left to assign',
+      description: 'One person was already handled elsewhere and was skipped.',
+    });
+    // Back to a button that means what it says, rather than a permanent no-op.
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Assign' })).toBeDisabled()
+    );
+    expect(props.onOpenChange).not.toHaveBeenCalled();
+  });
+
+  it('keeps the failed rows ticked and the dialog open on a partial failure', async () => {
+    mockUseRestaurantMembers.mockReturnValue(
+      loaded([member({}), member({ membershipId: 'm2', userId: 'u2', fullName: 'Sam Ortiz' })])
+    );
+    assignMembershipRole.mockImplementation(({ membershipId }: { membershipId: string }) =>
+      membershipId === 'm2' ? Promise.reject(new Error('nope')) : Promise.resolve(undefined)
+    );
+    render(<AssignPeopleDialog {...props} />);
+
+    await userEvent.click(screen.getByText('Dana Reyes'));
+    await userEvent.click(screen.getByText('Sam Ortiz'));
+    await userEvent.click(screen.getByRole('button', { name: 'Assign 2' }));
+
+    await waitFor(() =>
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({ title: '1 assigned, 1 failed', variant: 'destructive' })
+      )
+    );
+    // Only the failure stays ticked, so a retry cannot re-assign the one that landed.
+    expect(screen.getByText('1 person selected')).toBeInTheDocument();
+    expect(props.onOpenChange).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/RoleEditor.test.tsx
+++ b/tests/unit/RoleEditor.test.tsx
@@ -3,9 +3,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { RoleEditor } from '../../src/components/roles/RoleEditor';
+import { RoleEditor, type RoleEditorTab } from '../../src/components/roles/RoleEditor';
 import type { RoleWithGrants } from '../../src/hooks/useRoles';
 import type { UserRestaurant } from '../../src/hooks/useRestaurants';
+import type { Role } from '../../src/lib/permissions/types';
 
 /**
  * Phase 4 task 9d (roles-and-areas plan, 2026-07-29): RoleEditor.tsx — the
@@ -43,6 +44,18 @@ import { useRestaurants } from '../../src/hooks/useRestaurants';
 const wrapper = ({ children }: { children: React.ReactNode }) => (
   <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>
 );
+
+/**
+ * The Areas|People tab props, spread into every render below. Every assertion
+ * in this file is about the Areas tab, so it is pinned open rather than left to
+ * whatever the editor would default to — the People tab is `RoleRoster`'s own
+ * test surface. `callerRole` is what the People tab hands to `RolePicker`.
+ */
+const editorProps = {
+  callerRole: 'owner' as Role,
+  activeTab: 'areas' as RoleEditorTab,
+  onTabChange: vi.fn(),
+};
 
 function makeRole(overrides: Partial<RoleWithGrants> = {}): RoleWithGrants {
   return {
@@ -112,7 +125,7 @@ describe('RoleEditor', () => {
   it('renders a "All roles" back button and calls onBack when clicked', async () => {
     const user = userEvent.setup();
     const onBack = vi.fn();
-    render(<RoleEditor restaurantId="rest-1" role={null} onBack={onBack} />, { wrapper });
+    render(<RoleEditor {...editorProps} restaurantId="rest-1" role={null} onBack={onBack} />, { wrapper });
 
     const back = screen.getByRole('button', { name: /all roles/i });
     await user.click(back);
@@ -121,7 +134,7 @@ describe('RoleEditor', () => {
 
   it('renders labeled Role name / What this person does inputs, pre-filled when editing', () => {
     const role = makeRole({ name: 'Weekend Supervisor', description: 'Covers weekend shifts' });
-    render(<RoleEditor restaurantId="rest-1" role={role} onBack={vi.fn()} />, { wrapper });
+    render(<RoleEditor {...editorProps} restaurantId="rest-1" role={role} onBack={vi.fn()} />, { wrapper });
 
     expect(screen.getByLabelText(/role name/i)).toHaveValue('Weekend Supervisor');
     expect(screen.getByLabelText(/what this person does/i)).toHaveValue('Covers weekend shifts');
@@ -129,7 +142,7 @@ describe('RoleEditor', () => {
 
   it('shows the member-count warning banner with the exact copy for an existing role with members', () => {
     const role = makeRole({ memberCount: 2 });
-    render(<RoleEditor restaurantId="rest-1" role={role} onBack={vi.fn()} />, { wrapper });
+    render(<RoleEditor {...editorProps} restaurantId="rest-1" role={role} onBack={vi.fn()} />, { wrapper });
     expect(
       screen.getByText(/2 people have this role\. saving changes what they can reach the next time they load a page\./i)
     ).toBeInTheDocument();
@@ -137,25 +150,25 @@ describe('RoleEditor', () => {
 
   it('uses singular phrasing for a one-person member count', () => {
     const role = makeRole({ memberCount: 1 });
-    render(<RoleEditor restaurantId="rest-1" role={role} onBack={vi.fn()} />, { wrapper });
+    render(<RoleEditor {...editorProps} restaurantId="rest-1" role={role} onBack={vi.fn()} />, { wrapper });
     expect(screen.getByText(/1 person has this role\./i)).toBeInTheDocument();
   });
 
   it('shows no member-count banner for a brand-new draft', () => {
-    render(<RoleEditor restaurantId="rest-1" role={null} onBack={vi.fn()} />, { wrapper });
+    render(<RoleEditor {...editorProps} restaurantId="rest-1" role={null} onBack={vi.fn()} />, { wrapper });
     expect(screen.queryByText(/people have this role/i)).not.toBeInTheDocument();
   });
 
   it('shows no member-count banner for an existing role with zero members', () => {
     const role = makeRole({ memberCount: 0 });
-    render(<RoleEditor restaurantId="rest-1" role={role} onBack={vi.fn()} />, { wrapper });
+    render(<RoleEditor {...editorProps} restaurantId="rest-1" role={role} onBack={vi.fn()} />, { wrapper });
     expect(screen.queryByText(/people have this role/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/person has this role/i)).not.toBeInTheDocument();
   });
 
   it('shows the built-in notice and disables Save with a describing hint for a builtin role', () => {
     const role = makeRole({ builtin: true, name: 'Accountant', memberCount: 3 });
-    render(<RoleEditor restaurantId="rest-1" role={role} onBack={vi.fn()} />, { wrapper });
+    render(<RoleEditor {...editorProps} restaurantId="rest-1" role={role} onBack={vi.fn()} />, { wrapper });
 
     expect(screen.getByText(/built-in role/i)).toBeInTheDocument();
     expect(screen.getByText(/duplicate it to make a version you control/i)).toBeInTheDocument();
@@ -171,7 +184,7 @@ describe('RoleEditor', () => {
   });
 
   it('renders all ten area rows as RadioGroups with the "{Area} access" aria-label', () => {
-    render(<RoleEditor restaurantId="rest-1" role={null} onBack={vi.fn()} />, { wrapper });
+    render(<RoleEditor {...editorProps} restaurantId="rest-1" role={null} onBack={vi.fn()} />, { wrapper });
 
     for (const label of [
       'Dashboard & Reports',
@@ -190,7 +203,7 @@ describe('RoleEditor', () => {
   });
 
   it('caps Payroll at View: Manage is disabled with an aria-describedby reason mentioning owners and managers', () => {
-    render(<RoleEditor restaurantId="rest-1" role={null} onBack={vi.fn()} />, { wrapper });
+    render(<RoleEditor {...editorProps} restaurantId="rest-1" role={null} onBack={vi.fn()} />, { wrapper });
 
     const payrollGroup = screen.getByRole('radiogroup', { name: /^payroll access$/i });
     const manage = within(payrollGroup).getByRole('radio', { name: /^manage$/i });
@@ -205,7 +218,7 @@ describe('RoleEditor', () => {
   });
 
   it('makes Team & Access fully ungrantable: both View and Manage disabled with the same reason', () => {
-    render(<RoleEditor restaurantId="rest-1" role={null} onBack={vi.fn()} />, { wrapper });
+    render(<RoleEditor {...editorProps} restaurantId="rest-1" role={null} onBack={vi.fn()} />, { wrapper });
 
     const teamGroup = screen.getByRole('radiogroup', { name: /^team & access access$/i });
     const view = within(teamGroup).getByRole('radio', { name: /^view$/i });
@@ -227,7 +240,7 @@ describe('RoleEditor', () => {
   });
 
   it('does not cap Inventory & Purchasing or Scheduling at all', () => {
-    render(<RoleEditor restaurantId="rest-1" role={null} onBack={vi.fn()} />, { wrapper });
+    render(<RoleEditor {...editorProps} restaurantId="rest-1" role={null} onBack={vi.fn()} />, { wrapper });
 
     const inventoryGroup = screen.getByRole('radiogroup', { name: /^inventory & purchasing access$/i });
     expect(within(inventoryGroup).getByRole('radio', { name: /^manage$/i })).not.toBeDisabled();
@@ -238,7 +251,7 @@ describe('RoleEditor', () => {
 
   it('starts the grant counter at "0 granted" and updates it as areas are toggled', async () => {
     const user = userEvent.setup();
-    render(<RoleEditor restaurantId="rest-1" role={null} onBack={vi.fn()} />, { wrapper });
+    render(<RoleEditor {...editorProps} restaurantId="rest-1" role={null} onBack={vi.fn()} />, { wrapper });
 
     const counter = screen.getByText(/^\d+\s+granted$/i);
     expect(counter).toHaveTextContent(/^0 granted$/i);
@@ -250,7 +263,7 @@ describe('RoleEditor', () => {
   });
 
   it('renders the three sensitive-data Switches with accessible names for costs and pay rates', () => {
-    render(<RoleEditor restaurantId="rest-1" role={null} onBack={vi.fn()} />, { wrapper });
+    render(<RoleEditor {...editorProps} restaurantId="rest-1" role={null} onBack={vi.fn()} />, { wrapper });
     expect(screen.getByRole('switch', { name: /costs/i })).toBeInTheDocument();
     expect(screen.getByRole('switch', { name: /pay rates/i })).toBeInTheDocument();
     expect(screen.getAllByRole('switch')).toHaveLength(3);
@@ -258,7 +271,7 @@ describe('RoleEditor', () => {
 
   it('disables a sensitive-data switch with a "Needs access to" hint until a requiring area is granted', async () => {
     const user = userEvent.setup();
-    render(<RoleEditor restaurantId="rest-1" role={null} onBack={vi.fn()} />, { wrapper });
+    render(<RoleEditor {...editorProps} restaurantId="rest-1" role={null} onBack={vi.fn()} />, { wrapper });
 
     const payRatesSwitch = screen.getByRole('switch', { name: /pay rates/i });
     expect(payRatesSwitch).toBeDisabled();
@@ -280,7 +293,7 @@ describe('RoleEditor', () => {
     const onBack = vi.fn();
     const createRole = vi.fn().mockResolvedValue('new-role-id');
     mockUseRoles({ createRole });
-    render(<RoleEditor restaurantId="rest-1" role={null} onBack={onBack} />, { wrapper });
+    render(<RoleEditor {...editorProps} restaurantId="rest-1" role={null} onBack={onBack} />, { wrapper });
 
     await user.type(screen.getByLabelText(/role name/i), 'Weekend Supervisor');
     const inventoryGroup = screen.getByRole('radiogroup', { name: /^inventory & purchasing access$/i });
@@ -305,7 +318,7 @@ describe('RoleEditor', () => {
     const updateRole = vi.fn().mockResolvedValue('role-1');
     mockUseRoles({ updateRole });
     const role = makeRole({ id: 'role-1' });
-    render(<RoleEditor restaurantId="rest-1" role={role} onBack={vi.fn()} />, { wrapper });
+    render(<RoleEditor {...editorProps} restaurantId="rest-1" role={role} onBack={vi.fn()} />, { wrapper });
 
     await user.click(screen.getByRole('button', { name: /^save role$/i }));
 
@@ -315,7 +328,7 @@ describe('RoleEditor', () => {
 
   it('disables Save with a describing hint when the role name is empty', () => {
     const role = makeRole({ name: '' });
-    render(<RoleEditor restaurantId="rest-1" role={role} onBack={vi.fn()} />, { wrapper });
+    render(<RoleEditor {...editorProps} restaurantId="rest-1" role={role} onBack={vi.fn()} />, { wrapper });
 
     const save = screen.getByRole('button', { name: /^save role$/i });
     expect(save).toBeDisabled();
@@ -330,7 +343,7 @@ describe('RoleEditor', () => {
       name: 'Operations Manager',
       role_areas: [{ area_key: 'settings', level: 'view' }],
     });
-    render(<RoleEditor restaurantId="rest-1" role={role} onBack={vi.fn()} />, { wrapper });
+    render(<RoleEditor {...editorProps} restaurantId="rest-1" role={role} onBack={vi.fn()} />, { wrapper });
 
     expect(screen.queryByRole('radiogroup', { name: /^settings & integrations access$/i })).not.toBeInTheDocument();
     expect(screen.getByText(/partial/i)).toBeInTheDocument();
@@ -342,7 +355,7 @@ describe('RoleEditor', () => {
       name: 'Accountant',
       role_areas: [{ area_key: 'books', level: 'manage' }, { area_key: 'chart_of_accounts', level: 'manage' }],
     });
-    render(<RoleEditor restaurantId="rest-1" role={role} onBack={vi.fn()} />, { wrapper });
+    render(<RoleEditor {...editorProps} restaurantId="rest-1" role={role} onBack={vi.fn()} />, { wrapper });
 
     const booksGroup = screen.getByRole('radiogroup', { name: /^money & books access$/i });
     expect(within(booksGroup).getByRole('radio', { name: /^manage$/i })).toBeDisabled();
@@ -357,13 +370,13 @@ describe('RoleEditor', () => {
       ],
     });
 
-    const { rerender } = render(<RoleEditor restaurantId="rest-1" role={null} onBack={vi.fn()} />, { wrapper });
+    const { rerender } = render(<RoleEditor {...editorProps} restaurantId="rest-1" role={null} onBack={vi.fn()} />, { wrapper });
     expect(screen.queryByRole('listbox', { name: /other restaurants/i })).not.toBeInTheDocument();
 
-    rerender(<RoleEditor restaurantId="rest-1" role={makeRole({ builtin: true })} onBack={vi.fn()} />);
+    rerender(<RoleEditor {...editorProps} restaurantId="rest-1" role={makeRole({ builtin: true })} onBack={vi.fn()} />);
     expect(screen.queryByRole('listbox', { name: /other restaurants/i })).not.toBeInTheDocument();
 
-    rerender(<RoleEditor restaurantId="rest-1" role={makeRole({ builtin: false })} onBack={vi.fn()} />);
+    rerender(<RoleEditor {...editorProps} restaurantId="rest-1" role={makeRole({ builtin: false })} onBack={vi.fn()} />);
     const listbox = screen.getByRole('listbox', { name: /other restaurants/i });
     expect(within(listbox).getByRole('option', { name: /cold stone/i })).toBeInTheDocument();
     // The currently-selected restaurant is not offered as a copy target.
@@ -398,7 +411,7 @@ describe('RoleEditor', () => {
       ],
     });
 
-    render(<RoleEditor restaurantId="rest-1" role={makeRole({ builtin: false })} onBack={vi.fn()} />, { wrapper });
+    render(<RoleEditor {...editorProps} restaurantId="rest-1" role={makeRole({ builtin: false })} onBack={vi.fn()} />, { wrapper });
 
     const listbox = screen.getByRole('listbox', { name: /other restaurants/i });
     expect(within(listbox).getByRole('option', { name: /owned/i })).toBeInTheDocument();
@@ -417,7 +430,7 @@ describe('RoleEditor', () => {
       ],
     });
 
-    render(<RoleEditor restaurantId="rest-1" role={makeRole({ id: 'role-1' })} onBack={vi.fn()} />, { wrapper });
+    render(<RoleEditor {...editorProps} restaurantId="rest-1" role={makeRole({ id: 'role-1' })} onBack={vi.fn()} />, { wrapper });
 
     const listbox = screen.getByRole('listbox', { name: /other restaurants/i });
     await user.selectOptions(listbox, ['rest-2']);
@@ -438,7 +451,7 @@ describe('RoleEditor', () => {
     const user = userEvent.setup();
     const createRole = vi.fn().mockResolvedValue('new-role-id');
     mockUseRoles({ createRole });
-    render(<RoleEditor restaurantId="rest-1" role={null} onBack={vi.fn()} />, { wrapper });
+    render(<RoleEditor {...editorProps} restaurantId="rest-1" role={null} onBack={vi.fn()} />, { wrapper });
 
     await user.type(screen.getByLabelText(/role name/i), 'Weekend Supervisor');
 
@@ -467,7 +480,7 @@ describe('RoleEditor', () => {
     const user = userEvent.setup();
     const createRole = vi.fn().mockResolvedValue('new-role-id');
     mockUseRoles({ createRole });
-    render(<RoleEditor restaurantId="rest-1" role={null} onBack={vi.fn()} />, { wrapper });
+    render(<RoleEditor {...editorProps} restaurantId="rest-1" role={null} onBack={vi.fn()} />, { wrapper });
 
     await user.type(screen.getByLabelText(/role name/i), 'Weekend Supervisor');
     const employeesGroup = screen.getByRole('radiogroup', { name: /^employees access$/i });
@@ -490,7 +503,7 @@ describe('RoleEditor', () => {
     const onBack = vi.fn();
     const createRole = vi.fn().mockRejectedValue(new Error('new row violates row-level security policy'));
     mockUseRoles({ createRole });
-    render(<RoleEditor restaurantId="rest-1" role={null} onBack={onBack} />, { wrapper });
+    render(<RoleEditor {...editorProps} restaurantId="rest-1" role={null} onBack={onBack} />, { wrapper });
 
     await user.type(screen.getByLabelText(/role name/i), 'Weekend Supervisor');
     await user.click(screen.getByRole('button', { name: /^save role$/i }));

--- a/tests/unit/RolesList.test.tsx
+++ b/tests/unit/RolesList.test.tsx
@@ -105,20 +105,20 @@ describe('RolesList', () => {
 
   it('shows a loading skeleton while roles are loading', () => {
     mockUseRoles({ isLoading: true });
-    render(<RolesList restaurantId="rest-1" onSelectRole={vi.fn()} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />, { wrapper });
+    render(<RolesList restaurantId="rest-1" callerRole="owner" onSelectRole={vi.fn()} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />, { wrapper });
     expect(screen.getByTestId('roles-list-loading')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /new role/i })).not.toBeInTheDocument();
   });
 
   it('shows an error message when the roles query fails', () => {
     mockUseRoles({ error: new Error('boom') });
-    render(<RolesList restaurantId="rest-1" onSelectRole={vi.fn()} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />, { wrapper });
+    render(<RolesList restaurantId="rest-1" callerRole="owner" onSelectRole={vi.fn()} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />, { wrapper });
     expect(screen.getByText(/failed to load roles/i)).toBeInTheDocument();
   });
 
   it('always renders the dashed "New role" card, even with zero roles', () => {
     mockUseRoles({ roles: [] });
-    render(<RolesList restaurantId="rest-1" onSelectRole={vi.fn()} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />, { wrapper });
+    render(<RolesList restaurantId="rest-1" callerRole="owner" onSelectRole={vi.fn()} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />, { wrapper });
     expect(screen.getByRole('button', { name: /new role/i })).toBeInTheDocument();
   });
 
@@ -126,7 +126,7 @@ describe('RolesList', () => {
     const user = userEvent.setup();
     const onNewRole = vi.fn();
     mockUseRoles({ roles: [] });
-    render(<RolesList restaurantId="rest-1" onSelectRole={vi.fn()} onNewRole={onNewRole} onOpenPeople={vi.fn()} />, { wrapper });
+    render(<RolesList restaurantId="rest-1" callerRole="owner" onSelectRole={vi.fn()} onNewRole={onNewRole} onOpenPeople={vi.fn()} />, { wrapper });
     await user.click(screen.getByRole('button', { name: /new role/i }));
     expect(onNewRole).toHaveBeenCalledTimes(1);
   });
@@ -138,7 +138,7 @@ describe('RolesList', () => {
         makeRole({ id: 'r-custom', name: 'Weekend Supervisor', builtin: false }),
       ],
     });
-    render(<RolesList restaurantId="rest-1" onSelectRole={vi.fn()} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />, { wrapper });
+    render(<RolesList restaurantId="rest-1" callerRole="owner" onSelectRole={vi.fn()} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />, { wrapper });
 
     expect(card(/accountant/i)).toHaveTextContent(/built-in/i);
     expect(card(/accountant/i)).not.toHaveTextContent(/custom/i);
@@ -147,7 +147,7 @@ describe('RolesList', () => {
 
   it('shows "No areas yet" when a role has zero area grants', () => {
     mockUseRoles({ roles: [makeRole({ name: 'Empty Role', role_areas: [] })] });
-    render(<RolesList restaurantId="rest-1" onSelectRole={vi.fn()} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />, { wrapper });
+    render(<RolesList restaurantId="rest-1" callerRole="owner" onSelectRole={vi.fn()} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />, { wrapper });
     expect(card(/empty role/i)).toHaveTextContent(/no areas yet/i);
   });
 
@@ -163,7 +163,7 @@ describe('RolesList', () => {
         }),
       ],
     });
-    render(<RolesList restaurantId="rest-1" onSelectRole={vi.fn()} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />, { wrapper });
+    render(<RolesList restaurantId="rest-1" callerRole="owner" onSelectRole={vi.fn()} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />, { wrapper });
     const opsCard = card(/operations manager/i);
 
     expect(opsCard).toHaveTextContent(/inventory & purchasing\s*·\s*manage/i);
@@ -180,7 +180,7 @@ describe('RolesList', () => {
         makeRole({ id: 'r3', name: 'Three People', memberCount: 3 }),
       ],
     });
-    render(<RolesList restaurantId="rest-1" onSelectRole={vi.fn()} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />, { wrapper });
+    render(<RolesList restaurantId="rest-1" callerRole="owner" onSelectRole={vi.fn()} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />, { wrapper });
 
     expect(card(/one person/i)).toHaveTextContent('1 person');
     expect(card(/three people/i)).toHaveTextContent('3 people');
@@ -195,7 +195,7 @@ describe('RolesList', () => {
     // quotes role.memberCount, the same number the editor's save banner uses.
     mockUseRestaurantMembers([]);
     mockUseRoles({ roles: [makeRole({ id: 'r3', name: 'Three People', memberCount: 3 })] });
-    render(<RolesList restaurantId="rest-1" onSelectRole={vi.fn()} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />, { wrapper });
+    render(<RolesList restaurantId="rest-1" callerRole="owner" onSelectRole={vi.fn()} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />, { wrapper });
 
     expect(card(/three people/i)).toHaveTextContent('3 people');
   });
@@ -204,7 +204,7 @@ describe('RolesList', () => {
     const role = makeRole({ id: 'r-chef', name: 'Chef', legacy_role: 'chef', memberCount: 1 });
     mockUseRestaurantMembers([makeMember({ role: 'chef', fullName: 'Dana Chef' })]);
     mockUseRoles({ roles: [role] });
-    render(<RolesList restaurantId="rest-1" onSelectRole={vi.fn()} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />, { wrapper });
+    render(<RolesList restaurantId="rest-1" callerRole="owner" onSelectRole={vi.fn()} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />, { wrapper });
 
     // Decoration beside a count that already says the same thing, so the face
     // pile is aria-hidden — the button's own label carries the meaning.
@@ -219,7 +219,7 @@ describe('RolesList', () => {
     const onSelectRole = vi.fn();
     const builtin = makeRole({ id: 'r-builtin', name: 'Accountant', builtin: true });
     mockUseRoles({ roles: [builtin] });
-    render(<RolesList restaurantId="rest-1" onSelectRole={onSelectRole} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />, { wrapper });
+    render(<RolesList restaurantId="rest-1" callerRole="owner" onSelectRole={onSelectRole} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />, { wrapper });
 
     await user.click(nameDoor('Accountant'));
     expect(onSelectRole).toHaveBeenCalledTimes(1);
@@ -235,6 +235,7 @@ describe('RolesList', () => {
     render(
       <RolesList
         restaurantId="rest-1"
+        callerRole="owner"
         onSelectRole={onSelectRole}
         onNewRole={vi.fn()}
         onOpenPeople={onOpenPeople}
@@ -255,6 +256,7 @@ describe('RolesList', () => {
     render(
       <RolesList
         restaurantId="rest-1"
+        callerRole="owner"
         onSelectRole={vi.fn()}
         onNewRole={vi.fn()}
         onOpenPeople={onOpenPeople}
@@ -268,9 +270,33 @@ describe('RolesList', () => {
     expect(onOpenPeople).toHaveBeenCalledWith(role);
   });
 
+  it('offers no action on an empty role this caller cannot assign into', () => {
+    // Kiosk is in no inviter's row — not even an owner's — because a kiosk is
+    // provisioned from device setup, never handed to a person. Offering
+    // "Assign people" here would open a panel that could not offer it either.
+    mockUseRoles({
+      roles: [makeRole({ id: 'rk', name: 'Kiosk', legacy_role: 'kiosk', memberCount: 0 })],
+    });
+    render(
+      <RolesList
+        restaurantId="rest-1"
+        callerRole="owner"
+        onSelectRole={vi.fn()}
+        onNewRole={vi.fn()}
+        onOpenPeople={vi.fn()}
+      />,
+      { wrapper }
+    );
+
+    expect(within(card('Kiosk')).getByText('Nobody yet')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /nobody is in kiosk yet\. assign people/i })
+    ).not.toBeInTheDocument();
+  });
+
   it('renders role cards before the "New role" card, in query order', () => {
     mockUseRoles({ roles: [makeRole({ id: 'r1', name: 'Accountant' })] });
-    render(<RolesList restaurantId="rest-1" onSelectRole={vi.fn()} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />, { wrapper });
+    render(<RolesList restaurantId="rest-1" callerRole="owner" onSelectRole={vi.fn()} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />, { wrapper });
     const buttons = screen.getAllByRole('button');
     expect(buttons[buttons.length - 1]).toHaveAccessibleName(/new role/i);
   });

--- a/tests/unit/RolesList.test.tsx
+++ b/tests/unit/RolesList.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { RolesList } from '../../src/components/roles/RolesList';
@@ -21,12 +21,41 @@ import type { RoleWithGrants } from '../../src/hooks/useRoles';
  */
 
 vi.mock('../../src/hooks/useRoles');
+vi.mock('../../src/hooks/useRestaurantMembers');
 
 import { useRoles } from '../../src/hooks/useRoles';
+import { useRestaurantMembers, type RestaurantMember } from '../../src/hooks/useRestaurantMembers';
 
 const wrapper = ({ children }: { children: React.ReactNode }) => (
   <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>
 );
+
+/**
+ * A card is two doors now (role-roster plan, 2026-08-03): the name block opens
+ * the role's definition, the footer opens who holds it. So a card is addressed
+ * as its `<article>` — `getByRole('button', {name: /accountant/i})` would be
+ * ambiguous, both doors carry the role name.
+ */
+function card(name: RegExp | string) {
+  return screen.getByRole('article', { name });
+}
+
+/** The definition door. Anchored so it never matches the people door's label. */
+function nameDoor(roleName: string) {
+  return within(card(roleName)).getByRole('button', { name: new RegExp(`^${roleName}`, 'i') });
+}
+
+function makeMember(overrides: Partial<RestaurantMember> = {}): RestaurantMember {
+  return {
+    membershipId: 'm-1',
+    userId: 'u-1',
+    role: 'chef',
+    roleId: null,
+    fullName: 'Dana Chef',
+    email: 'dana@example.com',
+    ...overrides,
+  };
+}
 
 function makeRole(overrides: Partial<RoleWithGrants> = {}): RoleWithGrants {
   return {
@@ -36,6 +65,9 @@ function makeRole(overrides: Partial<RoleWithGrants> = {}): RoleWithGrants {
     description: 'Keeps the books and closes the month',
     flavor: 'collaborator',
     builtin: true,
+    // Null unless a test needs the builtin-role mapping the roster resolves
+    // membership through (see lib/permissions/roleMembership.ts).
+    legacy_role: null,
     created_at: '2026-07-01T00:00:00Z',
     role_areas: [],
     role_flags: [],
@@ -57,27 +89,36 @@ function mockUseRoles(partial: Partial<ReturnType<typeof useRoles>>) {
   });
 }
 
+function mockUseRestaurantMembers(members: RestaurantMember[] = []) {
+  (useRestaurantMembers as ReturnType<typeof vi.fn>).mockReturnValue({
+    data: members,
+    isLoading: false,
+    error: null,
+  });
+}
+
 describe('RolesList', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockUseRestaurantMembers();
   });
 
   it('shows a loading skeleton while roles are loading', () => {
     mockUseRoles({ isLoading: true });
-    render(<RolesList restaurantId="rest-1" onSelectRole={vi.fn()} onNewRole={vi.fn()} />, { wrapper });
+    render(<RolesList restaurantId="rest-1" onSelectRole={vi.fn()} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />, { wrapper });
     expect(screen.getByTestId('roles-list-loading')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /new role/i })).not.toBeInTheDocument();
   });
 
   it('shows an error message when the roles query fails', () => {
     mockUseRoles({ error: new Error('boom') });
-    render(<RolesList restaurantId="rest-1" onSelectRole={vi.fn()} onNewRole={vi.fn()} />, { wrapper });
+    render(<RolesList restaurantId="rest-1" onSelectRole={vi.fn()} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />, { wrapper });
     expect(screen.getByText(/failed to load roles/i)).toBeInTheDocument();
   });
 
   it('always renders the dashed "New role" card, even with zero roles', () => {
     mockUseRoles({ roles: [] });
-    render(<RolesList restaurantId="rest-1" onSelectRole={vi.fn()} onNewRole={vi.fn()} />, { wrapper });
+    render(<RolesList restaurantId="rest-1" onSelectRole={vi.fn()} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />, { wrapper });
     expect(screen.getByRole('button', { name: /new role/i })).toBeInTheDocument();
   });
 
@@ -85,7 +126,7 @@ describe('RolesList', () => {
     const user = userEvent.setup();
     const onNewRole = vi.fn();
     mockUseRoles({ roles: [] });
-    render(<RolesList restaurantId="rest-1" onSelectRole={vi.fn()} onNewRole={onNewRole} />, { wrapper });
+    render(<RolesList restaurantId="rest-1" onSelectRole={vi.fn()} onNewRole={onNewRole} onOpenPeople={vi.fn()} />, { wrapper });
     await user.click(screen.getByRole('button', { name: /new role/i }));
     expect(onNewRole).toHaveBeenCalledTimes(1);
   });
@@ -97,21 +138,17 @@ describe('RolesList', () => {
         makeRole({ id: 'r-custom', name: 'Weekend Supervisor', builtin: false }),
       ],
     });
-    render(<RolesList restaurantId="rest-1" onSelectRole={vi.fn()} onNewRole={vi.fn()} />, { wrapper });
+    render(<RolesList restaurantId="rest-1" onSelectRole={vi.fn()} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />, { wrapper });
 
-    const builtinCard = screen.getByRole('button', { name: /accountant/i });
-    expect(builtinCard).toHaveTextContent(/built-in/i);
-    expect(builtinCard).not.toHaveTextContent(/custom/i);
-
-    const customCard = screen.getByRole('button', { name: /weekend supervisor/i });
-    expect(customCard).toHaveTextContent(/custom/i);
+    expect(card(/accountant/i)).toHaveTextContent(/built-in/i);
+    expect(card(/accountant/i)).not.toHaveTextContent(/custom/i);
+    expect(card(/weekend supervisor/i)).toHaveTextContent(/custom/i);
   });
 
   it('shows "No areas yet" when a role has zero area grants', () => {
     mockUseRoles({ roles: [makeRole({ name: 'Empty Role', role_areas: [] })] });
-    render(<RolesList restaurantId="rest-1" onSelectRole={vi.fn()} onNewRole={vi.fn()} />, { wrapper });
-    const card = screen.getByRole('button', { name: /empty role/i });
-    expect(card).toHaveTextContent(/no areas yet/i);
+    render(<RolesList restaurantId="rest-1" onSelectRole={vi.fn()} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />, { wrapper });
+    expect(card(/empty role/i)).toHaveTextContent(/no areas yet/i);
   });
 
   it('renders a manage-level chip with the " · manage" suffix, and a view-level chip without it', () => {
@@ -126,16 +163,16 @@ describe('RolesList', () => {
         }),
       ],
     });
-    render(<RolesList restaurantId="rest-1" onSelectRole={vi.fn()} onNewRole={vi.fn()} />, { wrapper });
-    const card = screen.getByRole('button', { name: /operations manager/i });
+    render(<RolesList restaurantId="rest-1" onSelectRole={vi.fn()} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />, { wrapper });
+    const opsCard = card(/operations manager/i);
 
-    expect(card).toHaveTextContent(/inventory & purchasing\s*·\s*manage/i);
+    expect(opsCard).toHaveTextContent(/inventory & purchasing\s*·\s*manage/i);
     // The view-level chip carries the area label but never the "· manage" suffix.
-    expect(card).toHaveTextContent(/dashboard & reports/i);
-    expect(card).not.toHaveTextContent(/dashboard & reports\s*·\s*manage/i);
+    expect(opsCard).toHaveTextContent(/dashboard & reports/i);
+    expect(opsCard).not.toHaveTextContent(/dashboard & reports\s*·\s*manage/i);
   });
 
-  it('shows singular/plural member counts correctly, including zero', () => {
+  it('shows singular/plural member counts, and an action instead of a dead zero', () => {
     mockUseRoles({
       roles: [
         makeRole({ id: 'r0', name: 'Zero People', memberCount: 0 }),
@@ -143,11 +180,38 @@ describe('RolesList', () => {
         makeRole({ id: 'r3', name: 'Three People', memberCount: 3 }),
       ],
     });
-    render(<RolesList restaurantId="rest-1" onSelectRole={vi.fn()} onNewRole={vi.fn()} />, { wrapper });
+    render(<RolesList restaurantId="rest-1" onSelectRole={vi.fn()} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />, { wrapper });
 
-    expect(screen.getByRole('button', { name: /zero people/i })).toHaveTextContent('0 people');
-    expect(screen.getByRole('button', { name: /one person/i })).toHaveTextContent('1 person');
-    expect(screen.getByRole('button', { name: /three people/i })).toHaveTextContent('3 people');
+    expect(card(/one person/i)).toHaveTextContent('1 person');
+    expect(card(/three people/i)).toHaveTextContent('3 people');
+    // The bug this move exists to fix: an empty role used to read "0 people"
+    // and go nowhere.
+    expect(card(/zero people/i)).not.toHaveTextContent('0 people');
+    expect(card(/zero people/i)).toHaveTextContent(/assign people/i);
+  });
+
+  it('counts from the server, not from the members it managed to load', () => {
+    // A slow or denied members query costs avatars, not the count: the card
+    // quotes role.memberCount, the same number the editor's save banner uses.
+    mockUseRestaurantMembers([]);
+    mockUseRoles({ roles: [makeRole({ id: 'r3', name: 'Three People', memberCount: 3 })] });
+    render(<RolesList restaurantId="rest-1" onSelectRole={vi.fn()} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />, { wrapper });
+
+    expect(card(/three people/i)).toHaveTextContent('3 people');
+  });
+
+  it('shows initials for the people in a role, hidden from screen readers', () => {
+    const role = makeRole({ id: 'r-chef', name: 'Chef', legacy_role: 'chef', memberCount: 1 });
+    mockUseRestaurantMembers([makeMember({ role: 'chef', fullName: 'Dana Chef' })]);
+    mockUseRoles({ roles: [role] });
+    render(<RolesList restaurantId="rest-1" onSelectRole={vi.fn()} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />, { wrapper });
+
+    // Decoration beside a count that already says the same thing, so the face
+    // pile is aria-hidden — the button's own label carries the meaning.
+    expect(card(/^chef$/i)).toHaveTextContent('DC');
+    expect(
+      within(card(/^chef$/i)).getByRole('button', { name: /1 person in chef/i })
+    ).toBeInTheDocument();
   });
 
   it('calls onSelectRole with the role when a card is clicked, including builtin roles (read-only open)', async () => {
@@ -155,16 +219,58 @@ describe('RolesList', () => {
     const onSelectRole = vi.fn();
     const builtin = makeRole({ id: 'r-builtin', name: 'Accountant', builtin: true });
     mockUseRoles({ roles: [builtin] });
-    render(<RolesList restaurantId="rest-1" onSelectRole={onSelectRole} onNewRole={vi.fn()} />, { wrapper });
+    render(<RolesList restaurantId="rest-1" onSelectRole={onSelectRole} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />, { wrapper });
 
-    await user.click(screen.getByRole('button', { name: /accountant/i }));
+    await user.click(nameDoor('Accountant'));
     expect(onSelectRole).toHaveBeenCalledTimes(1);
     expect(onSelectRole).toHaveBeenCalledWith(builtin);
   });
 
+  it('calls onOpenPeople — not onSelectRole — when a populated role\'s count is clicked', async () => {
+    const user = userEvent.setup();
+    const onOpenPeople = vi.fn();
+    const onSelectRole = vi.fn();
+    const role = makeRole({ id: 'r3', name: 'Three People', memberCount: 3 });
+    mockUseRoles({ roles: [role] });
+    render(
+      <RolesList
+        restaurantId="rest-1"
+        onSelectRole={onSelectRole}
+        onNewRole={vi.fn()}
+        onOpenPeople={onOpenPeople}
+      />,
+      { wrapper }
+    );
+
+    await user.click(screen.getByRole('button', { name: /3 people in three people/i }));
+    expect(onOpenPeople).toHaveBeenCalledWith(role);
+    expect(onSelectRole).not.toHaveBeenCalled();
+  });
+
+  it('calls onOpenPeople when an empty role\'s "Assign people" action is clicked', async () => {
+    const user = userEvent.setup();
+    const onOpenPeople = vi.fn();
+    const role = makeRole({ id: 'r0', name: 'Weekend Supervisor', builtin: false, memberCount: 0 });
+    mockUseRoles({ roles: [role] });
+    render(
+      <RolesList
+        restaurantId="rest-1"
+        onSelectRole={vi.fn()}
+        onNewRole={vi.fn()}
+        onOpenPeople={onOpenPeople}
+      />,
+      { wrapper }
+    );
+
+    await user.click(
+      screen.getByRole('button', { name: /nobody is in weekend supervisor yet\. assign people/i })
+    );
+    expect(onOpenPeople).toHaveBeenCalledWith(role);
+  });
+
   it('renders role cards before the "New role" card, in query order', () => {
     mockUseRoles({ roles: [makeRole({ id: 'r1', name: 'Accountant' })] });
-    render(<RolesList restaurantId="rest-1" onSelectRole={vi.fn()} onNewRole={vi.fn()} />, { wrapper });
+    render(<RolesList restaurantId="rest-1" onSelectRole={vi.fn()} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />, { wrapper });
     const buttons = screen.getAllByRole('button');
     expect(buttons[buttons.length - 1]).toHaveAccessibleName(/new role/i);
   });

--- a/tests/unit/RolesList.test.tsx
+++ b/tests/unit/RolesList.test.tsx
@@ -57,6 +57,19 @@ function makeMember(overrides: Partial<RestaurantMember> = {}): RestaurantMember
   };
 }
 
+/**
+ * What makes a role assignable as `collaborator_custom`: owned by *this*
+ * restaurant, non-builtin, collaborator-flavored. All three are required — see
+ * `isAssignableCustomRole` — so spreading them together keeps a fixture from
+ * accidentally testing a row the server would reject.
+ */
+const CUSTOM_ROLE_FIELDS = {
+  restaurant_id: 'rest-1',
+  builtin: false,
+  flavor: 'collaborator',
+  legacy_role: null,
+} satisfies Partial<RoleWithGrants>;
+
 function makeRole(overrides: Partial<RoleWithGrants> = {}): RoleWithGrants {
   return {
     id: 'role-1',
@@ -175,7 +188,7 @@ describe('RolesList', () => {
   it('shows singular/plural member counts, and an action instead of a dead zero', () => {
     mockUseRoles({
       roles: [
-        makeRole({ id: 'r0', name: 'Zero People', memberCount: 0 }),
+        makeRole({ id: 'r0', name: 'Zero People', ...CUSTOM_ROLE_FIELDS, memberCount: 0 }),
         makeRole({ id: 'r1', name: 'One Person', memberCount: 1 }),
         makeRole({ id: 'r3', name: 'Three People', memberCount: 3 }),
       ],
@@ -251,7 +264,7 @@ describe('RolesList', () => {
   it('calls onOpenPeople when an empty role\'s "Assign people" action is clicked', async () => {
     const user = userEvent.setup();
     const onOpenPeople = vi.fn();
-    const role = makeRole({ id: 'r0', name: 'Weekend Supervisor', builtin: false, memberCount: 0 });
+    const role = makeRole({ id: 'r0', name: 'Weekend Supervisor', ...CUSTOM_ROLE_FIELDS, memberCount: 0 });
     mockUseRoles({ roles: [role] });
     render(
       <RolesList
@@ -292,6 +305,64 @@ describe('RolesList', () => {
     expect(
       screen.queryByRole('button', { name: /nobody is in kiosk yet\. assign people/i })
     ).not.toBeInTheDocument();
+  });
+
+  it('offers no action on a platform-flavored role the restaurant happens to own', () => {
+    // `copy_role_to_restaurants` copies the source row's flavor verbatim and
+    // inserts with builtin = false and no legacy_role, so this row is
+    // indistinguishable from a custom role by legacy_role alone — and
+    // `assign_membership_role` still refuses it. Offering "Assign people" here
+    // buys a 42501 for every person picked.
+    mockUseRoles({
+      roles: [
+        makeRole({
+          id: 'rp',
+          name: 'Regional Ops',
+          ...CUSTOM_ROLE_FIELDS,
+          flavor: 'platform',
+          memberCount: 0,
+        }),
+      ],
+    });
+    render(
+      <RolesList
+        restaurantId="rest-1"
+        callerRole="owner"
+        onSelectRole={vi.fn()}
+        onNewRole={vi.fn()}
+        onOpenPeople={vi.fn()}
+      />,
+      { wrapper }
+    );
+
+    expect(within(card('Regional Ops')).getByText('Nobody yet')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /assign people/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it('names the people door for what the caller can do there', () => {
+    // A manager may not assign anyone to Owner, so the Owner roster is a
+    // read-only list for them: every picker in it is disabled and there is no
+    // assign action. Promising "Manage" would be a label the panel cannot honor.
+    const owners = makeRole({ id: 'ro', name: 'Owner', legacy_role: 'owner', memberCount: 2 });
+    mockUseRoles({ roles: [owners] });
+
+    const { rerender } = render(
+      <RolesList restaurantId="rest-1" callerRole="manager" onSelectRole={vi.fn()} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />,
+      { wrapper }
+    );
+    expect(
+      within(card('Owner')).getByRole('button', { name: /2 people in owner\. see who's in this role/i })
+    ).toBeInTheDocument();
+
+    // Same card, a caller who can act on it.
+    rerender(
+      <RolesList restaurantId="rest-1" callerRole="owner" onSelectRole={vi.fn()} onNewRole={vi.fn()} onOpenPeople={vi.fn()} />
+    );
+    expect(
+      within(card('Owner')).getByRole('button', { name: /2 people in owner\. manage who's in this role/i })
+    ).toBeInTheDocument();
   });
 
   it('renders role cards before the "New role" card, in query order', () => {

--- a/tests/unit/invitationMatrix.test.ts
+++ b/tests/unit/invitationMatrix.test.ts
@@ -5,7 +5,9 @@ import {
   canInviteRole,
   canInviteCustomRole,
   getInvitableRoles,
+  isAssignableCustomRole,
 } from '@/lib/permissions/invitations';
+import type { AssignableRoleRow } from '@/lib/permissions/invitations';
 import type { Role } from '@/lib/permissions/types';
 
 describe('invite matrix', () => {
@@ -104,48 +106,108 @@ describe('canAssignAnyRole', () => {
   });
 });
 
+const RESTAURANT = 'rest-1';
+
+/** A role this restaurant owns that `assign_membership_role` would accept. */
+const customRole = (over: Partial<AssignableRoleRow> = {}): AssignableRoleRow => ({
+  legacy_role: null,
+  restaurant_id: RESTAURANT,
+  builtin: false,
+  flavor: 'collaborator',
+  ...over,
+});
+
+/** A builtin row: platform-owned, and named by `legacy_role`. */
+const builtinRole = (legacy_role: string): AssignableRoleRow => ({
+  legacy_role,
+  restaurant_id: null,
+  builtin: true,
+  flavor: legacy_role.startsWith('collaborator') ? 'collaborator' : 'platform',
+});
+
+describe('isAssignableCustomRole', () => {
+  // The three predicates `assign_membership_role` checks before it will accept a
+  // `collaborator_custom` target
+  // (20260803100000_assign_membership_role_custom_role_flavor_check.sql:150-161).
+
+  it('accepts a restaurant-owned, non-builtin, collaborator-flavored role', () => {
+    expect(isAssignableCustomRole(customRole(), RESTAURANT)).toBe(true);
+  });
+
+  it('rejects a role belonging to another restaurant', () => {
+    expect(isAssignableCustomRole(customRole({ restaurant_id: 'rest-2' }), RESTAURANT)).toBe(false);
+    expect(isAssignableCustomRole(customRole({ restaurant_id: null }), RESTAURANT)).toBe(false);
+  });
+
+  it('rejects a builtin row', () => {
+    expect(isAssignableCustomRole(customRole({ builtin: true }), RESTAURANT)).toBe(false);
+  });
+
+  it('rejects a platform-flavored role the restaurant nonetheless owns', () => {
+    // Reachable, not hypothetical: `copy_role_to_restaurants` copies the source
+    // row's `flavor` verbatim and inserts with `builtin = false` and no
+    // `legacy_role` (20260730160000:114-115), so copying a platform-flavored
+    // role hands a restaurant a non-builtin row whose `legacy_role` is NULL.
+    expect(isAssignableCustomRole(customRole({ flavor: 'platform' }), RESTAURANT)).toBe(false);
+  });
+});
+
 describe('canAssignTargetRole', () => {
-  // The argument is `roles.legacy_role`: the builtin role string for a builtin
-  // row, null for a custom one — the same discriminator RolePicker sends on.
+  // Branches on `roles.legacy_role`: the builtin role string for a builtin row,
+  // null for a custom one — the same discriminator RolePicker sends on.
 
   it('sends a custom role through the custom-role gate', () => {
-    expect(canAssignTargetRole('owner', null)).toBe(true);
-    expect(canAssignTargetRole('manager', null)).toBe(true);
+    expect(canAssignTargetRole('owner', customRole(), RESTAURANT)).toBe(true);
+    expect(canAssignTargetRole('manager', customRole(), RESTAURANT)).toBe(true);
     // The finding this function exists to fix: an operations_manager may assign
     // staff, so canAssignAnyRole says yes — but a custom role is not staff.
     expect(canAssignAnyRole('operations_manager')).toBe(true);
-    expect(canAssignTargetRole('operations_manager', null)).toBe(false);
+    expect(canAssignTargetRole('operations_manager', customRole(), RESTAURANT)).toBe(false);
+  });
+
+  it('refuses a custom-looking role the server would reject anyway', () => {
+    // Every one of these carries `legacy_role: null`, so a gate that branched on
+    // that alone would offer "Assign people" and then collect a 42501 for every
+    // person picked.
+    for (const row of [
+      customRole({ flavor: 'platform' }),
+      customRole({ builtin: true }),
+      customRole({ restaurant_id: 'rest-2' }),
+    ]) {
+      expect(canAssignTargetRole('owner', row, RESTAURANT)).toBe(false);
+      expect(canAssignTargetRole('manager', row, RESTAURANT)).toBe(false);
+    }
   });
 
   it('sends a builtin role through the per-role invite gate', () => {
-    expect(canAssignTargetRole('owner', 'owner')).toBe(true);
+    expect(canAssignTargetRole('owner', builtinRole('owner'), RESTAURANT)).toBe(true);
     // The other half of the same finding: a manager may assign plenty, just
     // never an owner.
-    expect(canAssignTargetRole('manager', 'owner')).toBe(false);
-    expect(canAssignTargetRole('operations_manager', 'staff')).toBe(true);
-    expect(canAssignTargetRole('operations_manager', 'manager')).toBe(false);
+    expect(canAssignTargetRole('manager', builtinRole('owner'), RESTAURANT)).toBe(false);
+    expect(canAssignTargetRole('operations_manager', builtinRole('staff'), RESTAURANT)).toBe(true);
+    expect(canAssignTargetRole('operations_manager', builtinRole('manager'), RESTAURANT)).toBe(false);
   });
 
   it('is false for kiosk from every caller', () => {
     // Kiosk is in no inviter's row. A kiosk is provisioned from device setup,
     // not handed to a person — so nobody can assign someone into it.
     for (const r of [...ASSIGNERS, ...NON_ASSIGNERS]) {
-      expect(canAssignTargetRole(r, 'kiosk')).toBe(false);
+      expect(canAssignTargetRole(r, builtinRole('kiosk'), RESTAURANT)).toBe(false);
     }
   });
 
   it('is false for every target when the caller cannot assign at all', () => {
     for (const r of NON_ASSIGNERS) {
-      expect(canAssignTargetRole(r, null)).toBe(false);
-      expect(canAssignTargetRole(r, 'staff')).toBe(false);
+      expect(canAssignTargetRole(r, customRole(), RESTAURANT)).toBe(false);
+      expect(canAssignTargetRole(r, builtinRole('staff'), RESTAURANT)).toBe(false);
     }
   });
 
   it('agrees with the two gates it delegates to, caller by caller', () => {
     for (const r of [...ASSIGNERS, ...NON_ASSIGNERS]) {
-      expect(canAssignTargetRole(r, null)).toBe(canInviteCustomRole(r));
+      expect(canAssignTargetRole(r, customRole(), RESTAURANT)).toBe(canInviteCustomRole(r));
       for (const target of BUILTIN_TARGETS) {
-        expect(canAssignTargetRole(r, target)).toBe(canInviteRole(r, target));
+        expect(canAssignTargetRole(r, builtinRole(target), RESTAURANT)).toBe(canInviteRole(r, target));
       }
     }
   });

--- a/tests/unit/invitationMatrix.test.ts
+++ b/tests/unit/invitationMatrix.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { canInviteRole, getInvitableRoles } from '@/lib/permissions/invitations';
+import {
+  canAssignAnyRole,
+  canInviteRole,
+  canInviteCustomRole,
+  getInvitableRoles,
+} from '@/lib/permissions/invitations';
+import type { Role } from '@/lib/permissions/types';
 
 describe('invite matrix', () => {
   it('operations_manager can invite only staff', () => {
@@ -58,5 +64,38 @@ describe('invite matrix', () => {
 
   it('operations manager collaborator can invite nobody', () => {
     expect(getInvitableRoles('collaborator_operations_manager')).toEqual([]);
+  });
+});
+
+describe('canAssignAnyRole', () => {
+  const ASSIGNERS: readonly Role[] = ['owner', 'manager', 'operations_manager'];
+  const NON_ASSIGNERS: readonly Role[] = [
+    'chef',
+    'staff',
+    'kiosk',
+    'collaborator_accountant',
+    'collaborator_inventory',
+    'collaborator_chef',
+    'collaborator_operations_manager',
+  ];
+
+  it('is true for exactly the roles with somewhere to assign', () => {
+    for (const r of ASSIGNERS) expect(canAssignAnyRole(r)).toBe(true);
+    for (const r of NON_ASSIGNERS) expect(canAssignAnyRole(r)).toBe(false);
+  });
+
+  it('agrees with the matrix it is derived from, role by role', () => {
+    // The point of deriving rather than re-listing: no role may be shown a
+    // live role picker that assign_membership_role would then refuse. A chef
+    // reaches /team (App.tsx gates only staff, kiosk and collaborators), so
+    // this is a reachable state, not a hypothetical one.
+    for (const r of [...ASSIGNERS, ...NON_ASSIGNERS]) {
+      const hasSomeTarget = getInvitableRoles(r).length > 0 || canInviteCustomRole(r);
+      expect(canAssignAnyRole(r)).toBe(hasSomeTarget);
+    }
+  });
+
+  it('is false for an unrecognised role', () => {
+    expect(canAssignAnyRole('unknown_role' as unknown as Role)).toBe(false);
   });
 });

--- a/tests/unit/invitationMatrix.test.ts
+++ b/tests/unit/invitationMatrix.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   canAssignAnyRole,
+  canAssignTargetRole,
   canInviteRole,
   canInviteCustomRole,
   getInvitableRoles,
@@ -67,18 +68,21 @@ describe('invite matrix', () => {
   });
 });
 
-describe('canAssignAnyRole', () => {
-  const ASSIGNERS: readonly Role[] = ['owner', 'manager', 'operations_manager'];
-  const NON_ASSIGNERS: readonly Role[] = [
-    'chef',
-    'staff',
-    'kiosk',
-    'collaborator_accountant',
-    'collaborator_inventory',
-    'collaborator_chef',
-    'collaborator_operations_manager',
-  ];
+const ASSIGNERS: readonly Role[] = ['owner', 'manager', 'operations_manager'];
+const NON_ASSIGNERS: readonly Role[] = [
+  'chef',
+  'staff',
+  'kiosk',
+  'collaborator_accountant',
+  'collaborator_inventory',
+  'collaborator_chef',
+  'collaborator_operations_manager',
+];
 
+/** Every builtin role a `roles.legacy_role` column can hold. */
+const BUILTIN_TARGETS: readonly Role[] = [...ASSIGNERS, ...NON_ASSIGNERS];
+
+describe('canAssignAnyRole', () => {
   it('is true for exactly the roles with somewhere to assign', () => {
     for (const r of ASSIGNERS) expect(canAssignAnyRole(r)).toBe(true);
     for (const r of NON_ASSIGNERS) expect(canAssignAnyRole(r)).toBe(false);
@@ -97,5 +101,52 @@ describe('canAssignAnyRole', () => {
 
   it('is false for an unrecognised role', () => {
     expect(canAssignAnyRole('unknown_role' as unknown as Role)).toBe(false);
+  });
+});
+
+describe('canAssignTargetRole', () => {
+  // The argument is `roles.legacy_role`: the builtin role string for a builtin
+  // row, null for a custom one — the same discriminator RolePicker sends on.
+
+  it('sends a custom role through the custom-role gate', () => {
+    expect(canAssignTargetRole('owner', null)).toBe(true);
+    expect(canAssignTargetRole('manager', null)).toBe(true);
+    // The finding this function exists to fix: an operations_manager may assign
+    // staff, so canAssignAnyRole says yes — but a custom role is not staff.
+    expect(canAssignAnyRole('operations_manager')).toBe(true);
+    expect(canAssignTargetRole('operations_manager', null)).toBe(false);
+  });
+
+  it('sends a builtin role through the per-role invite gate', () => {
+    expect(canAssignTargetRole('owner', 'owner')).toBe(true);
+    // The other half of the same finding: a manager may assign plenty, just
+    // never an owner.
+    expect(canAssignTargetRole('manager', 'owner')).toBe(false);
+    expect(canAssignTargetRole('operations_manager', 'staff')).toBe(true);
+    expect(canAssignTargetRole('operations_manager', 'manager')).toBe(false);
+  });
+
+  it('is false for kiosk from every caller', () => {
+    // Kiosk is in no inviter's row. A kiosk is provisioned from device setup,
+    // not handed to a person — so nobody can assign someone into it.
+    for (const r of [...ASSIGNERS, ...NON_ASSIGNERS]) {
+      expect(canAssignTargetRole(r, 'kiosk')).toBe(false);
+    }
+  });
+
+  it('is false for every target when the caller cannot assign at all', () => {
+    for (const r of NON_ASSIGNERS) {
+      expect(canAssignTargetRole(r, null)).toBe(false);
+      expect(canAssignTargetRole(r, 'staff')).toBe(false);
+    }
+  });
+
+  it('agrees with the two gates it delegates to, caller by caller', () => {
+    for (const r of [...ASSIGNERS, ...NON_ASSIGNERS]) {
+      expect(canAssignTargetRole(r, null)).toBe(canInviteCustomRole(r));
+      for (const target of BUILTIN_TARGETS) {
+        expect(canAssignTargetRole(r, target)).toBe(canInviteRole(r, target));
+      }
+    }
   });
 });

--- a/tests/unit/memberDisplay.test.ts
+++ b/tests/unit/memberDisplay.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+
+import { memberDisplayName, memberInitials } from '@/components/roles/memberDisplay';
+
+describe('memberDisplayName', () => {
+  it('prefers the full name', () => {
+    expect(memberDisplayName({ fullName: 'Ada Lovelace', email: 'ada@example.com' })).toBe(
+      'Ada Lovelace'
+    );
+  });
+
+  it('falls back to the email, then to a placeholder', () => {
+    expect(memberDisplayName({ fullName: null, email: 'ada@example.com' })).toBe('ada@example.com');
+    // Both null is reachable: useRestaurantMembers maps over memberships, so a
+    // member whose profiles row RLS hides still appears in the roster.
+    expect(memberDisplayName({ fullName: null, email: null })).toBe('Unnamed member');
+  });
+
+  it('treats a whitespace-only name as absent', () => {
+    expect(memberDisplayName({ fullName: '   ', email: 'ada@example.com' })).toBe(
+      'ada@example.com'
+    );
+  });
+});
+
+describe('memberInitials', () => {
+  it('takes the first and last word of a name', () => {
+    expect(memberInitials({ fullName: 'Ada Lovelace', email: null })).toBe('AL');
+    expect(memberInitials({ fullName: 'Maria de la Cruz', email: null })).toBe('MC');
+  });
+
+  it('takes two letters from a single-word name', () => {
+    expect(memberInitials({ fullName: 'Prince', email: null })).toBe('PR');
+  });
+
+  it('takes only one letter from an email', () => {
+    // 'JO' from 'jose@...' would read as a surname that does not exist.
+    expect(memberInitials({ fullName: null, email: 'jose@example.com' })).toBe('J');
+  });
+
+  it('never returns an empty string', () => {
+    expect(memberInitials({ fullName: null, email: null })).toBe('?');
+    expect(memberInitials({ fullName: '  ', email: '  ' })).toBe('?');
+  });
+});

--- a/tests/unit/roleMembership.test.ts
+++ b/tests/unit/roleMembership.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  legacyRoleIndex,
+  resolveMembershipRoleId,
+  membersInRole,
+  groupMembersByRole,
+} from '@/lib/permissions/roleMembership';
+import type { RestaurantMember } from '@/hooks/useRestaurantMembers';
+import type { RoleWithGrants } from '@/hooks/useRoles';
+
+/**
+ * These tests pin the client resolution to `role_member_counts`
+ * (supabase/migrations/20260730200000_role_member_counts.sql:36-46). If the
+ * two ever disagree, a role card's count and the roster that card opens show
+ * different numbers for the same role.
+ */
+
+const OWNER_ROLE_ID = '11111111-1111-1111-1111-111111111111';
+const CHEF_ROLE_ID = '22222222-2222-2222-2222-222222222222';
+const BARTENDER_ROLE_ID = '33333333-3333-3333-3333-333333333333';
+
+function role(id: string, name: string, legacy: string | null): RoleWithGrants {
+  return {
+    id,
+    restaurant_id: legacy === null ? 'rest-1' : null,
+    name,
+    description: null,
+    flavor: 'collaborator',
+    builtin: legacy !== null,
+    legacy_role: legacy,
+    created_at: '2026-08-03T00:00:00Z',
+    role_areas: [],
+    role_flags: [],
+    memberCount: 0,
+  };
+}
+
+const ROLES: RoleWithGrants[] = [
+  role(OWNER_ROLE_ID, 'Owner', 'owner'),
+  role(CHEF_ROLE_ID, 'Chef', 'chef'),
+  role(BARTENDER_ROLE_ID, 'Bartender', null),
+];
+
+function member(
+  userId: string,
+  roleLiteral: RestaurantMember['role'],
+  roleId: string | null
+): RestaurantMember {
+  return {
+    membershipId: `m-${userId}`,
+    userId,
+    email: `${userId}@example.com`,
+    fullName: userId,
+    role: roleLiteral,
+    roleId,
+  };
+}
+
+describe('legacyRoleIndex', () => {
+  it('indexes only builtin roles, which are the only ones with a legacy string', () => {
+    const index = legacyRoleIndex(ROLES);
+    expect(index.get('owner')).toBe(OWNER_ROLE_ID);
+    expect(index.get('chef')).toBe(CHEF_ROLE_ID);
+    expect(index.size).toBe(2);
+  });
+});
+
+describe('resolveMembershipRoleId', () => {
+  const index = legacyRoleIndex(ROLES);
+
+  it('prefers role_id over the legacy string, as COALESCE does', () => {
+    // A row whose columns disagree: COALESCE takes role_id first, so the
+    // client must too, or the roster would place this member on the Chef card
+    // while the count places them on Bartender.
+    const m = member('u1', 'chef', BARTENDER_ROLE_ID);
+    expect(resolveMembershipRoleId(m, index)).toBe(BARTENDER_ROLE_ID);
+  });
+
+  it('falls back to the legacy string when role_id is null', () => {
+    // The pre-backfill shape: 20260730170000 states an INSERT that omits
+    // role_id must keep leaving it NULL, so this is not a legacy edge case.
+    expect(resolveMembershipRoleId(member('u2', 'chef', null), index)).toBe(CHEF_ROLE_ID);
+  });
+
+  it('drops a custom-role membership that never got its role_id', () => {
+    // builtin_role_id_for('collaborator_custom') is NULL and no roles row
+    // carries that legacy string, so the count drops the row and so do we.
+    expect(resolveMembershipRoleId(member('u3', 'collaborator_custom', null), index)).toBeNull();
+  });
+
+  it('drops an unrecognised role string', () => {
+    const m = { ...member('u4', 'staff', null), role: 'not_a_role' as RestaurantMember['role'] };
+    expect(resolveMembershipRoleId(m, index)).toBeNull();
+  });
+});
+
+describe('membersInRole and groupMembersByRole', () => {
+  const members: RestaurantMember[] = [
+    member('owner1', 'owner', null),
+    member('chef1', 'chef', CHEF_ROLE_ID),
+    member('chef2', 'chef', null),
+    member('bar1', 'collaborator_custom', BARTENDER_ROLE_ID),
+    member('ghost', 'collaborator_custom', null),
+  ];
+  const index = legacyRoleIndex(ROLES);
+
+  it('collects everyone whose membership resolves to the role', () => {
+    expect(membersInRole(members, CHEF_ROLE_ID, index).map((m) => m.userId)).toEqual([
+      'chef1',
+      'chef2',
+    ]);
+    expect(membersInRole(members, BARTENDER_ROLE_ID, index).map((m) => m.userId)).toEqual(['bar1']);
+  });
+
+  it('groups every resolvable member exactly once and drops the rest', () => {
+    const grouped = groupMembersByRole(members, index);
+    expect(grouped.get(OWNER_ROLE_ID)?.length).toBe(1);
+    expect(grouped.get(CHEF_ROLE_ID)?.length).toBe(2);
+    expect(grouped.get(BARTENDER_ROLE_ID)?.length).toBe(1);
+
+    const totalGrouped = [...grouped.values()].reduce((sum, list) => sum + list.length, 0);
+    expect(totalGrouped).toBe(members.length - 1); // 'ghost' resolves to nothing
+  });
+
+  it('returns an empty list for a role nobody holds, not undefined', () => {
+    expect(membersInRole(members, 'no-such-role', index)).toEqual([]);
+  });
+});

--- a/tests/unit/useAssignRole.test.ts
+++ b/tests/unit/useAssignRole.test.ts
@@ -9,7 +9,17 @@ vi.mock('@/integrations/supabase/client', () => ({
   supabase: { rpc: (...args: unknown[]) => rpc(...args) },
 }));
 
-import { useAssignRole, assignRoleErrorMessage } from '@/hooks/useAssignRole';
+/** The membership id an `assign_membership_role` call carries. */
+function calledMembershipId(params: unknown): string | undefined {
+  return (params as { p_membership_id?: string } | undefined)?.p_membership_id;
+}
+
+import {
+  useAssignRole,
+  useAssignPeopleToRole,
+  assignRoleErrorMessage,
+} from '@/hooks/useAssignRole';
+import type { RestaurantMember } from '@/hooks/useRestaurantMembers';
 
 function wrapper(client: QueryClient) {
   return ({ children }: { children: ReactNode }) =>
@@ -68,6 +78,88 @@ describe('useAssignRole', () => {
     result.current.mutate({ membershipId: 'm1', role: 'staff' });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+const person = (id: string): RestaurantMember => ({
+  membershipId: id,
+  userId: `u-${id}`,
+  email: `${id}@example.com`,
+  fullName: id.toUpperCase(),
+  role: 'staff',
+  roleId: null,
+});
+
+describe('useAssignPeopleToRole', () => {
+  beforeEach(() => rpc.mockReset());
+
+  it('walks the list one at a time, in order', async () => {
+    // Sequential, not Promise.all: rule 5b of assign_membership_role takes
+    // FOR UPDATE on the restaurant's owner rows, so concurrent calls contend.
+    const seen: string[] = [];
+    let inFlight = 0;
+    let overlapped = false;
+    rpc.mockImplementation(async (_fn: unknown, params: unknown) => {
+      inFlight += 1;
+      if (inFlight > 1) overlapped = true;
+      seen.push(calledMembershipId(params) ?? '?');
+      await Promise.resolve();
+      inFlight -= 1;
+      return { error: null };
+    });
+    const client = new QueryClient();
+    const { result } = renderHook(() => useAssignPeopleToRole('r1'), { wrapper: wrapper(client) });
+
+    const outcome = await result.current.mutateAsync({
+      members: [person('m1'), person('m2'), person('m3')],
+      role: 'collaborator_custom',
+      roleId: 'x1',
+    });
+
+    expect(seen).toEqual(['m1', 'm2', 'm3']);
+    expect(overlapped).toBe(false);
+    expect(outcome).toEqual({ landed: 3, failures: [] });
+  });
+
+  it('resolves with the failures rather than throwing them', async () => {
+    // A partial failure is a result to report, not an exception: one 42501
+    // among three must not discard the two that landed.
+    rpc.mockImplementation(async (_fn: unknown, params: unknown) =>
+      calledMembershipId(params) === 'm2'
+        ? { error: { code: '42501', message: 'Only an owner can change an owner' } }
+        : { error: null }
+    );
+    const client = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const { result } = renderHook(() => useAssignPeopleToRole('r1'), { wrapper: wrapper(client) });
+
+    const outcome = await result.current.mutateAsync({
+      members: [person('m1'), person('m2'), person('m3')],
+      role: 'staff',
+    });
+
+    expect(outcome.landed).toBe(2);
+    expect(outcome.failures).toHaveLength(1);
+    expect(outcome.failures[0].member.membershipId).toBe('m2');
+    // The sentence the RPC wrote, not a generic fallback.
+    expect(outcome.failures[0].message).toBe('Only an owner can change an owner');
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  it('invalidates once for the batch, even when every call was denied', async () => {
+    // onSettled, not onSuccess: rule 5b's owner count and the invite matrix are
+    // both read from data the caller is showing, so a denial can mean the
+    // screen is stale.
+    rpc.mockResolvedValue({ error: { code: '42501', message: 'nope' } });
+    const client = new QueryClient();
+    const spy = vi.spyOn(client, 'invalidateQueries');
+    const { result } = renderHook(() => useAssignPeopleToRole('r1'), { wrapper: wrapper(client) });
+
+    await result.current.mutateAsync({ members: [person('m1'), person('m2')], role: 'staff' });
+
+    const keys = spy.mock.calls.map((c) => JSON.stringify((c[0] as { queryKey: unknown }).queryKey));
+    // Four invalidations for a two-person batch, not eight.
+    expect(keys).toHaveLength(4);
+    expect(keys).toContain(JSON.stringify(['restaurant-members', 'r1']));
   });
 });
 


### PR DESCRIPTION
Move 2 of the role-assignment design (`docs/superpowers/specs/2026-08-02-role-assignment-design.md`, shipped alongside Move 1 in #688).

## The dead end this closes

You create a custom role on `/team` → **Roles & areas**. The card says **0 members**. Nothing on it is clickable. The role you just built does nothing, and there is no path from the role to a person — only from a person to a role, on a different tab.

## What changes

**The member count becomes a door.**
- A populated card renders a face pile that opens the role editor on a new **People** tab — "Who's in this role", with a live `RolePicker` on every row.
- An empty card renders an **Assign people** action instead of a dead label — but only when this caller may actually assign *into that role*. Kiosk (which is in no inviter's row) and Owner-viewed-by-a-manager fall through to a plain "Nobody yet".

**The role editor gains Areas | People tabs.** The two doors on a card go to different places: the name opens Areas, the count opens People.

**`AssignPeopleDialog`** works from the role's side: pick several members, one `assign_membership_role` call each. Its candidate list applies the same four rules the RPC enforces (never self-target, never a kiosk, only an owner may change an owner, already-in-this-role), so a row that is offered is a row the server will accept.

No migration. The roster resolves membership exactly as `role_member_counts` does — `COALESCE(role_id, builtin_role_id_for(role))`, read off `roles.legacy_role` — so the card's count and the list under it cannot disagree. `src/lib/permissions/roleMembership.ts` is that lookup, not a second copy of the mapping.

**`canAssignTargetRole(caller, targetLegacyRole)`** is the new gate: `canAssignAnyRole` answers "may this caller assign *anything*" (right for a row's picker, which offers every role they may reach) and was wrong as a per-role gate — it would have shown an `operations_manager` an Assign button on a custom role, and a manager one on Owner, with every pick coming back 42501.

## Verification

- `npm run typecheck`, `npx eslint`, `npm run build` — clean
- `npm run test` — 682 files / 8464 tests passed, 1 file / 2 skipped
- `npx playwright test` on `role-roster`, `role-assignment`, `roles-and-areas` — 3 passed
- `tests/e2e/role-roster.spec.ts` is new and walks the exact reported dead end: empty card → Assign people → People tab → dialog → count on the card → reload → still there. The reload matters: the code this replaced showed a success toast over a write that never landed.

Live browser verification of `/team` was not possible — the dev server redirects to sign-in and entering credentials is out of scope for an agent. The E2E spec is the browser pass.

## Review findings folded in

- **Per-role assign gate** (`major`) — `canAssignTargetRole`, above.
- **Invalidation storm** (`major`) — assigning K people fired 4K refetches. The batch now lives in `useAssignPeopleToRole`, one invalidation set for the whole run.
- **A fully-dropped selection wedged the button** (`major`) — the "some of your picks were handled elsewhere" note was computed *after* the `chosen.length === 0` early return, so when *everyone* ticked had dropped out, the return fired first: no toast, no refresh, and a `selected` set holding ids that no longer have a row to untick. "Assign 1" stayed enabled and permanently inert. Now the note precedes the return and the zero case clears the selection and says why.
- **Radix checkbox inside a wrapping `<label>`** (`major`) — flagged as possibly inert. It is not: `<button>` is a labelable element, so the label's activation behaviour forwards the click. Refuted by the E2E (which clicks the row text in a real browser) and now pinned by a unit test, because if it ever stops holding, the row text goes dead silently.
- **Partial-failure assertion was direction-blind** (`minor`) — it counted the surviving selection without naming it, so it would have passed on the inversion that re-assigns someone twice on retry.
- **Duplicated markup** — `MemberAvatar` (three sizes) and `MemberIdentity` (spans-only, so it is valid inside a `<label>`) replace three hand-rolled copies.

## Declined, with reasons

- **Optimistic updates on the assign mutations** (`major`, raised twice). Declined deliberately, and argued in `useAssignRole.ts`'s doc comment. This is a *reassignment*: rolling one back means restoring each person's previous role individually, with failures interleaved among successes. The four keys it would have to patch include `roles` (whose `memberCount` is computed by a server RPC) and `restaurants` (which embeds the signed-in user's *resolved capabilities*) — recomputing either client-side is the "copy that drifts" that `20260730200000_role_member_counts.sql:18-21` warns against. And denial is not a rare path: `assign_membership_role` raises 42501 on five distinct rules, so an optimistic move would routinely show a change the server then rejects. `onSettled` (not `onSuccess`) keeps the refresh on the all-denied path, which is where staleness actually matters. Note the finding also names `useAssignRole` at :92-99, which shipped in #688 and is untouched here.

## Known, not fixed here

- `logic:minor` — the count and the face pile settle from two independent `invalidateQueries`, so they can disagree for one frame after an assignment.
- `security:minor` — the members query exposes name and email to any non-blocked role. Pre-existing and identical to `TeamMembers.tsx`; not widened by this PR.
- `performance:minor` — `RoleCard` is not memoized. Partly addressed via a module-level `EMPTY_ROSTER` so an empty role's `roster` prop is reference-stable.
- `maintainability:minor` — `callerRole` is prop-drilled four hops. The reviewer recommended leaving it rather than adding a context for one value.

## Not in this PR

Move 3 — `EmployeeDialog` gains an "App access" row, replacing the hardcoded `role: 'staff'` at `src/components/EmployeeDialog.tsx:412`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added People tabs for roles, with member rosters, avatars, counts, and role-management controls.
  * Added bulk member assignment with eligibility filtering, progress states, retry support, and partial-failure reporting.
  * Added accessible role cards with “Assign people,” “Manage,” and “See” actions.
  * Added clearer member names, initials, and identity displays.

* **Permissions**
  * Role assignment controls now follow the applicable assignment permissions.

* **Tests**
  * Added unit and end-to-end coverage for rosters, assignments, permissions, and member displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->