### PR TITLE
test(inventory): disambiguate day-cell lookups in the bulk-deduction date picker test

### DIFF
--- a/tests/unit/BulkInventoryDeductionDialog.datePicker.test.tsx
+++ b/tests/unit/BulkInventoryDeductionDialog.datePicker.test.tsx
@@ -46,6 +46,23 @@ describe('BulkInventoryDeductionDialog — date pickers (BUG-001 regression)', (
     await user.click(trigger);
   }
 
+  /**
+   * Return the day cell for `day` in the *displayed* month.
+   *
+   * The shadcn Calendar sets `showOutsideDays`, so react-day-picker renders the
+   * adjacent months' spill-over days in the same grid. A day number near either
+   * end of the month therefore matches twice — e.g. a grid whose last row is
+   * Aug 30 → Sep 5 contains both "5" cells. Outside days carry the
+   * `day-outside` class, so drop them and assert the match is unambiguous.
+   */
+  function getDayCell(grid: HTMLElement, day: string): HTMLElement {
+    const cells = within(grid)
+      .getAllByRole('gridcell', { name: day })
+      .filter((cell) => !cell.classList.contains('day-outside'));
+    expect(cells).toHaveLength(1);
+    return cells[0];
+  }
+
   it('shows "Select start date" and "Select end date" trigger buttons', async () => {
     const user = userEvent.setup();
     render(<BulkInventoryDeductionDialog />);
@@ -76,7 +93,7 @@ describe('BulkInventoryDeductionDialog — date pickers (BUG-001 regression)', (
     const startTrigger = screen.getByRole('button', { name: /select start date/i });
     await user.click(startTrigger);
     const grid = await screen.findByRole('grid');
-    await user.click(within(grid).getByRole('gridcell', { name: '10' }));
+    await user.click(getDayCell(grid, '10'));
 
     // After migration: controlled DatePicker closes on a real pick.
     expect(startTrigger).toHaveAttribute('aria-expanded', 'false');
@@ -90,7 +107,7 @@ describe('BulkInventoryDeductionDialog — date pickers (BUG-001 regression)', (
     const endTrigger = screen.getByRole('button', { name: /select end date/i });
     await user.click(endTrigger);
     const grid = await screen.findByRole('grid');
-    await user.click(within(grid).getByRole('gridcell', { name: '20' }));
+    await user.click(getDayCell(grid, '20'));
 
     // After migration: controlled DatePicker closes on a real pick.
     expect(endTrigger).toHaveAttribute('aria-expanded', 'false');
@@ -105,7 +122,7 @@ describe('BulkInventoryDeductionDialog — date pickers (BUG-001 regression)', (
     const startTrigger = screen.getByRole('button', { name: /select start date/i });
     await user.click(startTrigger);
     let grid = await screen.findByRole('grid');
-    await user.click(within(grid).getByRole('gridcell', { name: '15' }));
+    await user.click(getDayCell(grid, '15'));
     // Start picker closes after selection.
     expect(startTrigger).toHaveAttribute('aria-expanded', 'false');
 
@@ -117,11 +134,9 @@ describe('BulkInventoryDeductionDialog — date pickers (BUG-001 regression)', (
     // Day 5 is before the start (day 15) → it must be disabled.
     // react-day-picker renders each day as a <button role="gridcell">;
     // disabled days carry the HTML `disabled` attribute directly on the button.
-    const day5Cell = within(grid).getByRole('gridcell', { name: '5' });
-    expect(day5Cell).toBeDisabled();
+    expect(getDayCell(grid, '5')).toBeDisabled();
 
     // Day 20 is after the start (day 15) → it must NOT be disabled.
-    const day20Cell = within(grid).getByRole('gridcell', { name: '20' });
-    expect(day20Cell).not.toBeDisabled();
+    expect(getDayCell(grid, '20')).not.toBeDisabled();
   });
 });


### PR DESCRIPTION
## Problem

`tests/unit/BulkInventoryDeductionDialog.datePicker.test.tsx` failed at line 120 with a "multiple elements found" error:

```
within(grid).getByRole('gridcell', { name: '5' })
```

## Root cause

Not a production bug, and not a multi-month picker — `numberOfMonths` is 1, so there is a single grid.

The shadcn `Calendar` sets `showOutsideDays = true` (`src/components/ui/calendar.tsx:10`), so react-day-picker renders the adjacent months' spill-over days **inside that same grid**. With the grid's last row running Aug 30 → Sep 5, `gridcell` named `"5"` matched two buttons: Aug 5 (disabled, before the Aug 15 start date — the one the test wanted) and Sep 5 (enabled, an outside day).

## Fix

Test-only. All four day lookups now go through a `getDayCell` helper that drops cells carrying the `day-outside` class and asserts a single match remains.

Filtering outside days is what makes this date-proof rather than merely today-proof: within any displayed month each day number appears exactly once, and outside days are the only source of duplicates. Days 1–7 and 24–31 were all latent collisions depending on the month's layout — `5` is just the one that happened to land. The `toHaveLength(1)` check means any future ambiguity fails at the selector instead of silently asserting against the wrong cell.

## Verification

- 5/5 tests pass in the file
- `npx eslint` clean on the changed file
- Full unit suite green: 670 files / 8330 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)