### PR TITLE
fix(routing): resolve the role before the route guard runs, and stop re-booting the SPA in permissions E2E

### DIFF
--- a/src/contexts/RestaurantContext.tsx
+++ b/src/contexts/RestaurantContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useEffect, useMemo, ReactNode } from 'react';
+import React, { createContext, useContext, useState, useEffect, useMemo, useCallback, ReactNode } from 'react';
 import { useRestaurants, UserRestaurant } from '@/hooks/useRestaurants';
 import { useAuth } from '@/hooks/useAuth';
 import { canUserCreateRestaurant } from '@/lib/restaurantPermissions';
@@ -35,32 +35,44 @@ interface RestaurantProviderProps {
 export const RestaurantProvider: React.FC<RestaurantProviderProps> = ({ children }) => {
   const { user } = useAuth();
   const { restaurants, loading, createRestaurant } = useRestaurants();
-  const [selectedRestaurant, setSelectedRestaurant] = useState<UserRestaurant | null>(null);
+  // Only an *explicit* pick lives in state. The automatic pick (a saved choice,
+  // or the sole membership) is derived during render below.
+  const [chosenRestaurantId, setChosenRestaurantId] = useState<string | null>(null);
 
-  // Load selected restaurant from localStorage on mount
-  useEffect(() => {
-    if (user) {
-      const savedRestaurantId = localStorage.getItem(`selectedRestaurant_${user.id}`);
-      if (savedRestaurantId && restaurants.length > 0) {
-        const savedRestaurant = restaurants.find(r => r.restaurant_id === savedRestaurantId);
-        if (savedRestaurant) {
-          setSelectedRestaurant(savedRestaurant);
-        }
-      }
-    }
-  }, [user, restaurants]);
+  const storageKey = user ? `selectedRestaurant_${user.id}` : null;
 
-  // Auto-select first restaurant if only one exists and none is selected
-  useEffect(() => {
-    if (restaurants.length === 1 && !selectedRestaurant) {
-      setSelectedRestaurant(restaurants[0]);
-    }
-  }, [restaurants, selectedRestaurant]);
+  // Derived, not stored in an effect, for two reasons:
+  //
+  // 1. `StaffRoleChecker` (src/App.tsx) holds every protected route until
+  //    `loading` clears, then reads `selectedRestaurant?.role` to decide whether
+  //    a kiosk / staff / collaborator user belongs on the current path. Setting
+  //    the selection from an effect left one commit where `loading` was already
+  //    false but the selection was still null — `role` came back `undefined`,
+  //    every guard evaluated falsy, and the page those guards exist to block
+  //    rendered and fired its queries before the redirect landed.
+  // 2. Re-resolving against the freshest `restaurants` keeps the role current.
+  //    The old code stored a snapshot object, so an auto-selected membership
+  //    kept the role it was fetched with: a demotion picked up by a refetch
+  //    never reached the guards without a full reload.
+  const selectedRestaurant = useMemo(() => {
+    if (!storageKey || restaurants.length === 0) return null;
+    const byId = (id: string | null) =>
+      (id ? restaurants.find(r => r.restaurant_id === id) : undefined) ?? null;
+
+    return (
+      byId(chosenRestaurantId) ??
+      byId(localStorage.getItem(storageKey)) ??
+      // With several memberships and nothing saved, there is no right answer to
+      // guess — Index.tsx renders a "Select or create a restaurant" screen for
+      // exactly this state.
+      (restaurants.length === 1 ? restaurants[0] : null)
+    );
+  }, [storageKey, restaurants, chosenRestaurantId]);
 
   // Clear selection when user changes
   useEffect(() => {
     if (!user) {
-      setSelectedRestaurant(null);
+      setChosenRestaurantId(null);
       // Clear all localStorage entries for restaurant selection
       Object.keys(localStorage).forEach(key => {
         if (key.startsWith('selectedRestaurant_')) {
@@ -71,14 +83,14 @@ export const RestaurantProvider: React.FC<RestaurantProviderProps> = ({ children
   }, [user]);
 
   // Enhanced setSelectedRestaurant that persists to localStorage
-  const handleSetSelectedRestaurant = (restaurant: UserRestaurant | null) => {
-    setSelectedRestaurant(restaurant);
-    if (user && restaurant) {
-      localStorage.setItem(`selectedRestaurant_${user.id}`, restaurant.restaurant_id);
-    } else if (user) {
-      localStorage.removeItem(`selectedRestaurant_${user.id}`);
+  const handleSetSelectedRestaurant = useCallback((restaurant: UserRestaurant | null) => {
+    setChosenRestaurantId(restaurant?.restaurant_id ?? null);
+    if (storageKey && restaurant) {
+      localStorage.setItem(storageKey, restaurant.restaurant_id);
+    } else if (storageKey) {
+      localStorage.removeItem(storageKey);
     }
-  };
+  }, [storageKey]);
 
   // Centralized logic: Allow creation if user has no restaurants (first-time) OR is an owner
   const canCreateRestaurant = canUserCreateRestaurant(restaurants);
@@ -91,7 +103,7 @@ export const RestaurantProvider: React.FC<RestaurantProviderProps> = ({ children
     loading,
     canCreateRestaurant,
     createRestaurant,
-  }), [selectedRestaurant, restaurants, loading, canCreateRestaurant, createRestaurant]);
+  }), [selectedRestaurant, handleSetSelectedRestaurant, restaurants, loading, canCreateRestaurant, createRestaurant]);
 
   return (
     <RestaurantContext.Provider value={value}>

--- a/tests/e2e/navigate-in-app.spec.ts
+++ b/tests/e2e/navigate-in-app.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+import { navigateInApp } from '../helpers/e2e-navigation';
+
+/**
+ * Self-test for `navigateInApp`, the helper the route sweeps in
+ * permissions-roles.spec.ts use instead of a full `page.goto`.
+ *
+ * Without this, the helper has a silent false-green mode: if react-router ever
+ * stops listening for `popstate`, every sweep would still "pass" because the
+ * helper sets `window.location` itself — the assertions would be checking the
+ * URL the test just wrote, not a routing decision.
+ *
+ * These cases run signed out, so they need no database: `ProtectedRoute`
+ * redirecting an anonymous visitor to /auth is the same `<Navigate replace>`
+ * mechanism the role guards use.
+ */
+test.describe('navigateInApp', () => {
+  test('routes client-side and lets a redirect guard settle the URL', async ({ page }) => {
+    await page.goto('/auth');
+    await expect(page.getByRole('tab', { name: /sign up/i })).toBeVisible();
+
+    // Survives a client-side navigation; a full page load would wipe it.
+    await page.evaluate(() => {
+      (window as unknown as { __noReload?: true }).__noReload = true;
+    });
+
+    // A public route: the router should swap the view without a reload.
+    await navigateInApp(page, '/forgot-password');
+    await expect(page).toHaveURL('/forgot-password');
+    await expect(page.getByRole('tab', { name: /sign up/i })).toBeHidden();
+
+    // A guarded route: ProtectedRoute sends an anonymous visitor to /auth.
+    // This is what proves the helper drives real routing rather than just
+    // rewriting the address bar.
+    await navigateInApp(page, '/team');
+    await expect(page).toHaveURL('/auth');
+
+    expect(
+      await page.evaluate(() => (window as unknown as { __noReload?: true }).__noReload)
+    ).toBe(true);
+  });
+
+  test('refuses to run before the SPA has booted, instead of silently passing', async ({ page }) => {
+    await page.goto('about:blank');
+    await expect(navigateInApp(page, '/team')).rejects.toThrow(/booted SPA/);
+  });
+});

--- a/tests/e2e/permissions-roles.spec.ts
+++ b/tests/e2e/permissions-roles.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, Page } from '@playwright/test';
 import { generateTestUser, signUpAndCreateRestaurant, exposeSupabaseHelpers } from '../helpers/e2e-supabase';
+import { navigateInApp } from '../helpers/e2e-navigation';
 
 // Helper to update a user's role via the database and reload
 async function setUserRole(page: Page, role: string): Promise<void> {
@@ -63,14 +64,16 @@ const collaboratorRoles = [
   },
 ];
 
-// Every `page.goto` below is a real browser navigation, so the SPA re-boots
-// from scratch each time: Vite re-serves the module graph, auth restores the
-// session, and the membership query re-runs. On CI (four shards, unbundled dev
-// server) one navigation costs 4-6s, and a signup costs ~35s — so a sweep over
-// a dozen routes runs past the project's 90s budget and dies mid-loop, with the
-// URL sitting on whatever route was still booting. `test.slow()` triples the
-// budget; it does not slow a passing run down, it only stops the clock from
-// running out on work that was always going to take this long.
+// The route sweeps below use `navigateInApp`, not `page.goto`: a real browser
+// navigation re-boots the whole SPA (4-6s per hop on CI's unbundled dev server)
+// to re-prove a boot sequence the test already proved, and a dozen of them ran
+// the specs past their time budget. Cold-boot-into-a-guarded-route is still
+// covered — `setUserRole` reloads onto a forbidden path before every sweep, and
+// the single-route tests at the bottom of this file navigate for real.
+//
+// A signup still costs ~35s, so `test.slow()` stays on the tests that do one.
+// It does not slow a passing run down; it only stops the clock from running out
+// on work that was always going to take this long.
 
 test.describe('Collaborator Role Routing and Access', () => {
   test.describe.configure({ mode: 'serial' });
@@ -86,27 +89,16 @@ test.describe('Collaborator Role Routing and Access', () => {
       // Should redirect to landing page from dashboard
       await expect(page).toHaveURL(landing, { timeout: 10000 });
 
-      // Allowed paths should be accessible.
-      // We deliberately don't use 'networkidle' here — pages often have
-      // background queries (realtime, refetch intervals) that prevent
-      // networkidle from ever settling. 'domcontentloaded' is sufficient
-      // to verify the route resolved without a redirect.
+      // Allowed paths should be accessible — the guard leaves them alone.
       for (const path of allowed) {
-        await page.goto(path, { waitUntil: 'domcontentloaded' });
-        await expect(page).toHaveURL(path, { timeout: 5000 });
+        await navigateInApp(page, path);
+        await expect(page).toHaveURL(path);
       }
 
       // Forbidden paths should redirect to landing.
-      // The SPA aborts the original navigation when the protected-route
-      // guard redirects, which surfaces as net::ERR_ABORTED. That's the
-      // correct behavior — we only care about the *final* URL, so use
-      // 'commit' (waits for nav to commit) and tolerate an abort.
-      // Timeout is generous (15s) because forbidden=['/'] hits Index.tsx,
-      // which fires several useQuery hooks before the collaborator redirect
-      // runs — under CI load those queries can take >5s to resolve.
       for (const path of forbidden) {
-        await page.goto(path, { waitUntil: 'commit' }).catch(() => {});
-        await expect(page).toHaveURL(landing, { timeout: 15000 });
+        await navigateInApp(page, path);
+        await expect(page).toHaveURL(landing);
       }
     });
   }
@@ -144,8 +136,7 @@ test.describe('Existing Role Routing - Regression Prevention', () => {
     ];
 
     for (const route of ownerRoutes) {
-      await page.goto(route, { waitUntil: 'networkidle' });
-      await expect(page).not.toHaveURL('/auth');
+      await navigateInApp(page, route);
       // Owner should stay on the requested route (has full access)
       await expect(page).toHaveURL(route);
     }
@@ -165,7 +156,7 @@ test.describe('Existing Role Routing - Regression Prevention', () => {
     const managerRoutes = ['/', '/team', '/employees', '/transactions', '/inventory', '/recipes', '/scheduling'];
 
     for (const route of managerRoutes) {
-      await page.goto(route, { waitUntil: 'networkidle' });
+      await navigateInApp(page, route);
       await expect(page).not.toHaveURL('/auth');
     }
   });
@@ -184,7 +175,7 @@ test.describe('Existing Role Routing - Regression Prevention', () => {
     const chefRoutes = ['/', '/recipes', '/prep-recipes', '/batches', '/inventory'];
 
     for (const route of chefRoutes) {
-      await page.goto(route, { waitUntil: 'networkidle' });
+      await navigateInApp(page, route);
       await expect(page).not.toHaveURL('/auth');
     }
   });
@@ -212,7 +203,7 @@ test.describe('Existing Role Routing - Regression Prevention', () => {
     ];
 
     for (const route of staffAllowed) {
-      await page.goto(route, { waitUntil: 'networkidle' });
+      await navigateInApp(page, route);
       await expect(page).not.toHaveURL('/auth');
     }
 
@@ -220,12 +211,8 @@ test.describe('Existing Role Routing - Regression Prevention', () => {
     const staffForbidden = ['/', '/team', '/payroll', '/banking', '/transactions'];
 
     for (const route of staffForbidden) {
-      // Same redirect-abort race as the collaborator loops above — see
-      // those comments. 'commit' + tolerate abort, then assert final URL.
-      // 15s timeout: forbidden=['/'] hits Index.tsx whose hooks may take
-      // multiple seconds to resolve under CI load before the redirect.
-      await page.goto(route, { waitUntil: 'commit' }).catch(() => {});
-      await expect(page).toHaveURL('/employee/schedule', { timeout: 15000 });
+      await navigateInApp(page, route);
+      await expect(page).toHaveURL('/employee/schedule');
     }
   });
 
@@ -243,12 +230,8 @@ test.describe('Existing Role Routing - Regression Prevention', () => {
     const kioskForbidden = ['/', '/team', '/employee/clock', '/settings'];
 
     for (const route of kioskForbidden) {
-      // Same redirect-abort race as the collaborator loops above — see
-      // those comments. 'commit' + tolerate abort, then assert final URL.
-      // 15s timeout: forbidden=['/'] hits Index.tsx whose hooks may take
-      // multiple seconds to resolve under CI load before the redirect.
-      await page.goto(route, { waitUntil: 'commit' }).catch(() => {});
-      await expect(page).toHaveURL('/kiosk', { timeout: 15000 });
+      await navigateInApp(page, route);
+      await expect(page).toHaveURL('/kiosk');
     }
   });
 });

--- a/tests/helpers/e2e-navigation.ts
+++ b/tests/helpers/e2e-navigation.ts
@@ -1,0 +1,61 @@
+import { Page, expect } from '@playwright/test';
+
+/**
+ * Navigate inside the already-booted SPA, the way a real user does.
+ *
+ * `page.goto` is a full browser navigation: Vite re-serves the module graph,
+ * auth restores the session, and the membership query re-runs — 4-6s per hop on
+ * CI's unbundled dev server. A sweep over a dozen routes spends all of that
+ * re-proving the boot sequence the test already proved on its first navigation,
+ * and it is what pushed these specs past their time budget.
+ *
+ * Pushing the path through the History API exercises the same router and the
+ * same `StaffRoleChecker` guard for ~100ms instead. Cold-boot-into-a-guarded-
+ * route stays covered by the real navigations each spec still does (the
+ * `page.reload()` in `setUserRole`, and the dedicated single-route tests).
+ *
+ * Resolves once the URL has stopped moving, so the caller asserts on a settled
+ * location rather than one a guard is about to change.
+ */
+export async function navigateInApp(page: Page, path: string): Promise<void> {
+  const mounted = await page.evaluate(() =>
+    Boolean(document.getElementById('root')?.firstElementChild)
+  );
+  if (!mounted) {
+    throw new Error(
+      `navigateInApp('${path}') needs a booted SPA, but #root is empty. ` +
+        'Load the app with a real page.goto (or page.reload) first.'
+    );
+  }
+
+  await page.evaluate((target) => {
+    // Mirror the state shape react-router writes so its internal history index
+    // keeps counting — a guard's own <Navigate replace> reads it on the way out.
+    const idx = ((window.history.state as { idx?: number } | null)?.idx ?? 0) + 1;
+    window.history.pushState({ usr: null, key: String(idx), idx }, '', target);
+    // pushState is silent by design; the router only wakes up on popstate.
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  }, path);
+
+  await waitForUrlToSettle(page, path);
+}
+
+/** Wait until the pathname holds still across two consecutive polls. */
+async function waitForUrlToSettle(page: Page, requested: string): Promise<void> {
+  let previous: string | null = null;
+  await expect
+    .poll(
+      () => {
+        const current = new URL(page.url()).pathname;
+        const held = current === previous;
+        previous = current;
+        return held;
+      },
+      {
+        message: `URL never settled after navigating to '${requested}' — the app kept redirecting.`,
+        timeout: 10_000,
+        intervals: [100, 100, 200, 400, 1000],
+      }
+    )
+    .toBe(true);
+}

--- a/tests/unit/RestaurantContext.roleResolution.test.tsx
+++ b/tests/unit/RestaurantContext.roleResolution.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * RestaurantContext — the role must be resolved before `loading` clears.
+ *
+ * `StaffRoleChecker` (src/App.tsx:253) holds every protected route behind
+ * `useRestaurantContext().loading`, then reads `selectedRestaurant?.role` to
+ * decide whether a kiosk / staff / collaborator user is allowed on the current
+ * path. That gate is only sound if `loading === false` implies "the role is
+ * known".
+ *
+ * It did not. `loading` came straight from the memberships query, but the
+ * selection was made in a `useEffect` — one commit later. In between there was
+ * a render with `loading === false` and `selectedRestaurant === null`, so
+ * `role` was `undefined`, every guard in StaffRoleChecker evaluated falsy, and
+ * the forbidden page rendered (and fired its queries) before the redirect.
+ *
+ * These tests pin the contract at the context seam that StaffRoleChecker
+ * depends on, which is the layer where the defect lives. Driving it through
+ * the router in E2E cannot pin it: the window is a single commit, so a browser
+ * test observes it only as an unreproducible flash.
+ */
+import React, { ReactNode } from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { RestaurantProvider, useRestaurantContext } from '@/contexts/RestaurantContext';
+
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+vi.mock('@/lib/chartOfAccountsUtils', () => ({
+  createDefaultChartOfAccounts: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockSupabase = vi.hoisted(() => ({ from: vi.fn(), rpc: vi.fn() }));
+vi.mock('@/integrations/supabase/client', () => ({ supabase: mockSupabase }));
+
+const mockAuth = vi.hoisted(() => ({ user: { id: 'user-123' } as { id: string } | null }));
+vi.mock('@/hooks/useAuth', () => ({ useAuth: () => mockAuth }));
+
+function membershipRow(restaurantId: string, role: string) {
+  return {
+    id: `membership-${restaurantId}`,
+    user_id: 'user-123',
+    restaurant_id: restaurantId,
+    role,
+    created_at: '2026-01-01T00:00:00Z',
+    restaurant: { id: restaurantId, name: `Restaurant ${restaurantId}` },
+    roleRecord: null,
+  };
+}
+
+/** Chainable `.select().eq()` stub; `eq` resolves with the queued values in order. */
+function stubMemberships(...results: Array<{ data: unknown; error: unknown }>) {
+  const builder: Record<string, ReturnType<typeof vi.fn>> = {};
+  builder.select = vi.fn().mockReturnValue(builder);
+  builder.eq = vi.fn();
+  for (const result of results) builder.eq.mockResolvedValueOnce(result);
+  // Any further refetch repeats the last queued result.
+  builder.eq.mockResolvedValue(results[results.length - 1]);
+  mockSupabase.from.mockReturnValue(builder);
+  return builder;
+}
+
+type Sample = { loading: boolean; role: string | undefined };
+
+/** Records the context on every render, so we can inspect intermediate commits. */
+function Probe({ samples }: { samples: Sample[] }) {
+  const { selectedRestaurant, loading } = useRestaurantContext();
+  samples.push({ loading, role: selectedRestaurant?.role });
+  return null;
+}
+
+function renderProvider() {
+  const samples: Sample[] = [];
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <RestaurantProvider>{children}</RestaurantProvider>
+    </QueryClientProvider>
+  );
+  const utils = render(<Probe samples={samples} />, { wrapper });
+  return { samples, queryClient, ...utils };
+}
+
+describe('RestaurantContext — role resolution vs. the loading flag', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.user = { id: 'user-123' };
+    localStorage.clear();
+  });
+
+  it('never reports loading:false with an unresolved role when the user has a sole membership', async () => {
+    stubMemberships({ data: [membershipRow('restaurant-1', 'collaborator_accountant')], error: null });
+
+    const { samples } = renderProvider();
+
+    await waitFor(() => expect(samples.at(-1)?.role).toBe('collaborator_accountant'));
+
+    // The window StaffRoleChecker falls through: not loading, but no role yet.
+    const failOpen = samples.filter((s) => !s.loading && s.role === undefined);
+    expect(failOpen).toEqual([]);
+  });
+
+  it('never reports loading:false with an unresolved role when a saved selection is restored', async () => {
+    localStorage.setItem('selectedRestaurant_user-123', 'restaurant-2');
+    stubMemberships({
+      data: [
+        membershipRow('restaurant-1', 'owner'),
+        membershipRow('restaurant-2', 'kiosk'),
+      ],
+      error: null,
+    });
+
+    const { samples } = renderProvider();
+
+    await waitFor(() => expect(samples.at(-1)?.role).toBe('kiosk'));
+
+    const failOpen = samples.filter((s) => !s.loading && s.role === undefined);
+    expect(failOpen).toEqual([]);
+  });
+
+  it('picks up a role change on refetch instead of holding the role from the first fetch', async () => {
+    stubMemberships(
+      { data: [membershipRow('restaurant-1', 'owner')], error: null },
+      { data: [membershipRow('restaurant-1', 'staff')], error: null },
+    );
+
+    const { samples, queryClient } = renderProvider();
+
+    await waitFor(() => expect(samples.at(-1)?.role).toBe('owner'));
+
+    await queryClient.invalidateQueries({ queryKey: ['restaurants', 'user-123'] });
+
+    // The auto-selected membership was stored as a snapshot object, so a
+    // demotion to `staff` never reached StaffRoleChecker without a reload.
+    await waitFor(() => expect(samples.at(-1)?.role).toBe('staff'));
+  });
+
+  it('leaves the selection empty for a multi-restaurant user with no saved choice', async () => {
+    stubMemberships({
+      data: [membershipRow('restaurant-1', 'owner'), membershipRow('restaurant-2', 'owner')],
+      error: null,
+    });
+
+    const { samples } = renderProvider();
+
+    // Index.tsx renders a "Select or create a restaurant" screen for this
+    // state, so the provider must not block or auto-pick on the user's behalf.
+    await waitFor(() => expect(samples.at(-1)?.loading).toBe(false));
+    expect(samples.at(-1)?.role).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Started from the flake in `tests/e2e/permissions-roles.spec.ts` reported in [run 30673063063](https://github.com/toyiyo/nimble-pnl/actions/runs/30673063063). Two separate problems came out of it.

## 1. The app really could fail open, one commit wide

`StaffRoleChecker` holds every protected route until `useRestaurantContext().loading` clears, then reads `selectedRestaurant?.role` to decide whether a kiosk / staff / collaborator user belongs on the current path. Its own comment says the gate exists so those users never "briefly render the very page these redirects exist to keep them out of (and fires its queries)."

It didn't achieve that. `loading` came straight from the memberships query, but the selection was made in a `useEffect` — one commit later. In between there was a render with `loading === false` and `selectedRestaurant === null`, so `role` was `undefined`, all three guards evaluated falsy, and the forbidden page rendered.

`RestaurantContext` now derives the selection during render, which closes the window rather than adding another spinner. A spinner wasn't an option: `Index.tsx` renders a "Select or create a restaurant" screen for multi-restaurant users with no saved choice, and blocking on `!selectedRestaurant` would hang it.

The same change fixes a second defect that fell out of the same design — the selection was stored as a snapshot object, so an auto-selected membership kept the role it was *first* fetched with. A demotion picked up by a refetch never reached the guards without a full reload.

`tests/unit/RestaurantContext.roleResolution.test.tsx` pins both at the context seam. It went red on all three defects before the fix:

```
✗ loading:false with unresolved role (sole membership)   → [{loading:false, role:undefined}]
✗ loading:false with unresolved role (saved selection)   → [{loading:false, role:undefined}]
✗ role change on refetch                                 → expected 'staff', got 'owner'
✓ multi-restaurant with no saved choice stays unselected  (guards against over-fixing)
```

It lives there and not in E2E because the window is a single commit — a browser test can only see it as an unreproducible flash.

## 2. The cited CI failure was budget exhaustion, not that race

Worth stating plainly, because it changes what needed fixing: all three attempts in that run ended with `Test timeout of 90000ms exceeded`, and the `toHaveURL` mismatch is the secondary report — it only got 8–9 polls before the test itself was killed. Every failure settled on a path from that test's own forbidden list, which is what you see when a test dies mid-loop, not a routing race. (The `/banking` destination came from the *staff* test, a separate failure block.) The run predates its own mitigation: it ran 2026-07-31, and c6728958 added `test.slow()` to these tests on 2026-08-03.

But `test.slow()` was load-bearing rather than curative. Each spec does ~16 full SPA boots at 4-6s plus a ~35s signup, so the sweeps drift back toward the wall as routes get added.

`navigateInApp` pushes the path through the History API instead — same router, same `StaffRoleChecker` guard, ~100ms instead of 4-6s. It returns only once the URL has held still across two polls, so callers assert on a settled location rather than one a guard is about to change. That replaces the `waitUntil: 'commit'` + swallowed-abort + 15s-timeout pattern that was racing the initial navigation.

Cold-boot-into-a-guarded-route stays covered: `setUserRole` reloads onto a forbidden path before every sweep, and the single-route tests at the bottom of the file still navigate for real.

The helper has a false-green mode worth guarding — if react-router ever stops listening for `popstate`, every sweep would still pass, because the helper sets the URL itself and the assertions would read it back. `navigate-in-app.spec.ts` pins that. It runs signed out (no database) using `ProtectedRoute` bouncing an anonymous visitor to `/auth`, the same `<Navigate replace>` mechanism the role guards use.

## Verification

- ✅ `npm run typecheck` clean; new test files typecheck clean under an explicit `tsc` pass (the root tsconfig doesn't cover `tests/`)
- ✅ `RestaurantContext.roleResolution` + `useRestaurants` unit tests: 10 passed
- ✅ The pushState→router→guard mechanism pinned in jsdom against the installed react-router 6.30 (allowed route renders and holds; guard redirect settles; history index stays finite across four consecutive redirects)
- ✅ eslint: no new findings, and the change removes a pre-existing `exhaustive-deps` warning
- ⚠️ **The full E2E suite could not run locally.** The dev machine was saturated by parallel work — load average peaked at 272 on 10 cores, a concurrent worktree was running a 158-file pgTAP suite against the shared local Supabase, and that stack was then torn down mid-session. Under that load the unbundled dev server took 20s to serve `index.html` alone, so `page.goto('/auth')` timed out at 90s in *untouched* helper code (`e2e-supabase.ts:756`) as well. An earlier run in this same session, before the contention, passed 15/15 against the app fix. **CI is the real verification for the E2E change here.**

## Known gap, not addressed

A kiosk / staff / collaborator user with 2+ memberships and no saved selection still has `role === undefined`, so the guards fall through. It's pre-existing and can't be fixed by blocking — that user genuinely needs the picker to render. It needs a different design, e.g. deriving the guard from the union of memberships when none is selected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved restaurant selection reliability by resolving selections from current memberships, saved preferences, or the sole available restaurant.
  - Prevented transient loading and unselected states during route checks.
  - Ensured restaurant role changes are reflected after data refreshes.

- **Tests**
  - Added coverage for restaurant selection and role resolution.
  - Added end-to-end coverage for in-app navigation, protected-route redirects, and permission-based routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->