### PR TITLE
feat(employees): app access on the employee dialog (Move 3)

### DIFF
--- a/docs/superpowers/plans/2026-08-04-employee-app-access.md
+++ b/docs/superpowers/plans/2026-08-04-employee-app-access.md
@@ -1,0 +1,791 @@
+# App Access on the Employee Dialog — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The employee dialog names where app access actually lives — the account, not the employee row — and the invite it sends stops hard-coding `staff`.
+
+**Architecture:** `RolePicker` splits into a controlled `RoleSelect` (option list) and the existing assignment shell that wraps it. A new `EmployeeAppAccessRow` renders in both dialog modes, resolving three states from `employee.user_id`, the restaurant roster, and the typed email. `EmployeeDialog` keeps every Supabase call; the row is presentational plus a self-contained `RolePicker`.
+
+**Tech Stack:** React 18 + TypeScript, React Query, shadcn/ui (Popover + cmdk `Command`), Vitest + Testing Library, Playwright.
+
+**Spec:** `docs/superpowers/specs/2026-08-04-employee-app-access-design.md`
+
+## Global Constraints
+
+- Semantic tokens only. Never `bg-white`, `text-black`, or any literal color. `--success` / `--destructive` for the gains/loses lines.
+- Apple/Notion type scale per CLAUDE.md: `text-[14px] font-medium` body, `text-[13px] text-muted-foreground` secondary, `border-border/40`, `bg-muted/30`, `rounded-lg` controls / `rounded-xl` cards.
+- Every async surface handles loading, error, and empty explicitly.
+- No `localStorage` caching. React Query only, `staleTime` ≤ 60s.
+- Buttons without visible text need `aria-label`. A trigger's accessible name must *contain* its visible text (WCAG 2.5.3).
+- `RolePickerProps` is public API — `TeamMembers.tsx:187`, `RoleRoster.tsx:109`, `RolesList.tsx:235`/`:314`, `CollaboratorInvitations.tsx:538` must compile and pass unchanged.
+- No migrations. No edge-function changes.
+- Never `git add -A` / `git add .` / `git commit -a`. Stage explicit paths.
+- Run `npm run typecheck` before every commit. It uses `tsconfig.app.json`, whose `include` is `["src"]` — it does **not** typecheck `tests/`. Run `npx vitest run <file>` to catch test-file type errors.
+
+---
+
+## File Structure
+
+| Path | Responsibility |
+|------|----------------|
+| `src/lib/permissions/roleMembership.ts` | + `INTERNAL_TEAM_ROLES`, `isInternalTeamRole` — TS mirror of the SQL visibility predicate |
+| `src/components/roles/RoleSelect.tsx` | **new** — controlled role option list in a Popover. No writes, no delta. |
+| `src/components/roles/RolePicker.tsx` | `RoleSelect` + delta panel + commit button. Public props unchanged. |
+| `src/components/employees/EmployeeAppAccessRow.tsx` | **new** — the three states. Presentational; all Supabase calls stay in the dialog. |
+| `src/components/EmployeeDialog.tsx` | Renders the row in both modes; invite payload takes the chosen role; new edit-mode invite call |
+
+---
+
+### Task 1: Mirror the internal-team predicate
+
+The roster query is visibility-gated by RLS, not just permission-gated. `EmployeeAppAccessRow` must not render for a caller who cannot see the roster, or it will print "No access" about people who have access. That needs a client-side copy of a SQL rule, which needs a drift test.
+
+**Files:**
+- Modify: `src/lib/permissions/roleMembership.ts`
+- Test: `tests/unit/internalTeamMirror.test.ts` (create)
+
+**Interfaces:**
+- Produces: `INTERNAL_TEAM_ROLES: readonly Role[]`, `isInternalTeamRole(role: Role | null | undefined): boolean`
+
+- [ ] **Step 1: Write the failing mirror test**
+
+Create `tests/unit/internalTeamMirror.test.ts`:
+
+```ts
+/**
+ * `user_is_internal_team` decides who can SELECT every row of
+ * user_restaurants (20260120100000_add_collaborator_roles.sql:201-212).
+ * EmployeeAppAccessRow needs the same answer client-side to know whether a
+ * miss in the roster means "no account" or "you just can't see it".
+ *
+ * That makes INTERNAL_TEAM_ROLES a second copy of a database rule, and
+ * roleMembership.ts's own header warns about exactly that. This test is the
+ * pin: add a sixth internal role in SQL without updating the constant and it
+ * fails here rather than silently blanking the row in production.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { INTERNAL_TEAM_ROLES } from '@/lib/permissions/roleMembership';
+
+const MIGRATION = 'supabase/migrations/20260702170000_add_operations_manager_role.sql';
+
+describe('INTERNAL_TEAM_ROLES mirrors user_is_internal_team', () => {
+  it('lists exactly the roles the SQL function accepts', () => {
+    const sql = readFileSync(resolve(process.cwd(), MIGRATION), 'utf8');
+
+    const fnStart = sql.indexOf('FUNCTION public.user_is_internal_team');
+    expect(fnStart, `user_is_internal_team not found in ${MIGRATION}`).toBeGreaterThan(-1);
+
+    // `AND ur.role IN ('owner', 'manager', ...)` — first IN list after the signature.
+    const inList = /ur\.role\s+IN\s*\(([^)]*)\)/.exec(sql.slice(fnStart));
+    expect(inList, 'role IN (...) list not found').not.toBeNull();
+
+    const fromSql = [...inList![1].matchAll(/'([^']+)'/g)].map((m) => m[1]);
+    expect(fromSql.length).toBeGreaterThan(0);
+    expect([...INTERNAL_TEAM_ROLES].sort()).toEqual([...fromSql].sort());
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+npx vitest run tests/unit/internalTeamMirror.test.ts
+```
+
+Expected: FAIL — `INTERNAL_TEAM_ROLES` is not exported from `roleMembership.ts`.
+
+- [ ] **Step 3: Add the constant**
+
+Append to `src/lib/permissions/roleMembership.ts` (it already imports nothing from `types`, so add the type import at the top):
+
+```ts
+import type { Role } from '@/lib/permissions/types';
+
+/**
+ * The roles that `user_is_internal_team` accepts
+ * (20260702170000_add_operations_manager_role.sql:27-43).
+ *
+ * A second copy of a database rule, which the header above warns against —
+ * but this one is unavoidable: RLS decides what `useRestaurantMembers`
+ * returns, and the UI has to distinguish "this employee has no account" from
+ * "you cannot see whether they do". Getting that backwards tells a
+ * collaborator_accountant that a fully-provisioned employee cannot sign in.
+ * `tests/unit/internalTeamMirror.test.ts` pins the two together.
+ */
+export const INTERNAL_TEAM_ROLES = [
+  'owner',
+  'manager',
+  'operations_manager',
+  'chef',
+  'staff',
+] as const satisfies readonly Role[];
+
+/** Whether this caller sees every `user_restaurants` row for the restaurant. */
+export function isInternalTeamRole(role: Role | null | undefined): boolean {
+  return !!role && (INTERNAL_TEAM_ROLES as readonly string[]).includes(role);
+}
+```
+
+- [ ] **Step 4: Run the test and the typecheck**
+
+```bash
+npx vitest run tests/unit/internalTeamMirror.test.ts && npm run typecheck
+```
+
+Expected: PASS, no type errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/permissions/roleMembership.ts tests/unit/internalTeamMirror.test.ts
+git commit -m "feat(permissions): mirror user_is_internal_team for roster visibility"
+```
+
+---
+
+### Task 2: Extract `RoleSelect` from `RolePicker`
+
+A pure refactor. `RolePicker`'s public behaviour must not move — `tests/unit/RolePicker.test.tsx` is the gate. It does not currently assert that a successful commit closes the popover, which is the exact behaviour the split endangers, so that test gets written **first**, against the un-refactored component.
+
+**Files:**
+- Create: `src/components/roles/RoleSelect.tsx`
+- Modify: `src/components/roles/RolePicker.tsx`
+- Test: `tests/unit/RolePicker.test.tsx` (extend), `tests/unit/RoleSelect.test.tsx` (create)
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces: `RoleSelect`, `RoleSelectProps` (below). `RolePickerProps` unchanged.
+
+```ts
+export interface RoleSelectProps {
+  restaurantId: string;
+  callerRole: Role;
+  /**
+   * The role id the checkmark sits on, or null for none.
+   *
+   * This is "what is true", NOT "what is highlighted". `RolePicker` passes the
+   * CURRENT role here and leaves the candidate to its footer — today's
+   * `isCurrent` check never moves when you click an option, and moving it
+   * would erase the only on-screen record of what the person has now.
+   */
+  value: string | null;
+  onSelect: (role: RoleWithGrants) => void;
+  /** Accessible name. MUST contain `triggerText` (WCAG 2.5.3). */
+  triggerLabel: string;
+  /** Visible chip text. */
+  triggerText: string;
+  disabled?: boolean;
+  /** Rendered as a sibling of CommandList, inside Command. Never inside CommandList. */
+  footer?: ReactNode;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+```
+
+- [ ] **Step 1: Pin the behaviour the split endangers — before touching the component**
+
+Add to `tests/unit/RolePicker.test.tsx`, inside the existing `describe`:
+
+```tsx
+  // RolePicker owns `open` precisely so commit's onSuccess can close it and
+  // clear the candidate. When the option list moved into RoleSelect, an
+  // uncontrolled popover would leave this dialog open on a stale candidate
+  // after a successful assignment. Written before the extraction, on purpose.
+  it('closes and clears the candidate once the assignment lands', async () => {
+    mockUseRoles.mockReturnValue({
+      roles: [roleRow({ id: 'c1', name: 'Operations Lead' })],
+      isLoading: false, error: null,
+    });
+    render(<RolePicker {...base} />, { wrapper });
+
+    await userEvent.click(screen.getByRole('combobox', { name: /Dana Reyes/i }));
+    await userEvent.click(await screen.findByRole('option', { name: /Operations Lead/ }));
+    await userEvent.click(screen.getByRole('button', { name: /change role to/i }));
+
+    const [, handlers] = mutate.mock.calls[0];
+    handlers.onSuccess();
+
+    // Popover gone, so the commit button and the option list are gone with it.
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: /change role to/i })).not.toBeInTheDocument()
+    );
+    expect(screen.queryByRole('option', { name: /Operations Lead/ })).not.toBeInTheDocument();
+
+    // Reopening starts clean — no candidate carried over, so no commit footer.
+    await userEvent.click(screen.getByRole('combobox', { name: /Dana Reyes/i }));
+    expect(screen.queryByRole('button', { name: /change role to/i })).not.toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 2: Run it against the un-refactored component**
+
+```bash
+npx vitest run tests/unit/RolePicker.test.tsx
+```
+
+Expected: PASS (all 10). If it fails, stop — the baseline is not what the plan assumes; report before refactoring.
+
+- [ ] **Step 3: Commit the pin on its own**
+
+```bash
+git add tests/unit/RolePicker.test.tsx
+git commit -m "test(roles): pin RolePicker closing on a landed assignment"
+```
+
+- [ ] **Step 4: Create `RoleSelect`**
+
+Move, verbatim, out of `RolePicker.tsx`: the `useRoles` call, `invitable`/`mayAssignCustom`, `searchQuery`/`matches`, `customRoles`/`builtinRoles`, `renderRow`, and the whole `Popover`/`PopoverTrigger`/`PopoverContent`/`Command` tree including the three list states and both `CommandGroup`s.
+
+`src/components/roles/RoleSelect.tsx`:
+
+```tsx
+import { useState, type ReactNode } from 'react';
+import { Button } from '@/components/ui/button';
+import { Command, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { useInsideScrollLock } from '@/components/ui/scroll-lock-boundary';
+import { Check, ChevronsUpDown } from 'lucide-react';
+import { useRoles, type RoleWithGrants } from '@/hooks/useRoles';
+import { RoleAreaChips } from '@/components/roles/RoleAreaChips';
+import { canInviteCustomRole, getInvitableRoles, isAssignableCustomRole } from '@/lib/permissions/invitations';
+import type { Role } from '@/lib/permissions/types';
+import { cn } from '@/lib/utils';
+
+export interface RoleSelectProps { /* as declared above */ }
+
+export function RoleSelect({
+  restaurantId, callerRole, value, onSelect,
+  triggerLabel, triggerText, disabled = false, footer,
+  open: openProp, onOpenChange,
+}: RoleSelectProps) {
+  const [openUncontrolled, setOpenUncontrolled] = useState(false);
+  const open = openProp ?? openUncontrolled;
+  const setOpen = (next: boolean) => {
+    setOpenUncontrolled(next);
+    onOpenChange?.(next);
+  };
+
+  const [search, setSearch] = useState('');
+  const modal = useInsideScrollLock();
+
+  // useRoles returns { roles, isLoading, error, ... } — NOT a raw React Query
+  // result, so there is no `data` here.
+  const { roles, isLoading, error } = useRoles(restaurantId);
+
+  const invitable = getInvitableRoles(callerRole);
+  const mayAssignCustom = canInviteCustomRole(callerRole);
+
+  const searchQuery = search.trim().toLowerCase();
+  const matches = (name: string) => name.toLowerCase().includes(searchQuery);
+
+  const customRoles = roles.filter((r) => isAssignableCustomRole(r, restaurantId) && matches(r.name));
+  const builtinRoles = roles.filter(
+    (r) => r.legacy_role !== null && (invitable as readonly string[]).includes(r.legacy_role) && matches(r.name)
+  );
+
+  const renderRow = (r: RoleWithGrants) => (
+    // value={r.name} is load-bearing: cmdk filters on the `value` prop, and with
+    // chips and a description as children its default text extraction would
+    // match the concatenated blob instead of the name.
+    <CommandItem key={r.id} value={r.name} onSelect={() => onSelect(r)} className="flex flex-col items-start gap-1.5 py-2.5">
+      <div className="flex w-full items-center gap-2">
+        <Check className={cn('h-4 w-4 shrink-0', r.id === value ? 'opacity-100' : 'opacity-0')} />
+        <span className="text-[14px] font-medium text-foreground">{r.name}</span>
+      </div>
+      {r.description && <p className="pl-6 text-[13px] text-muted-foreground">{r.description}</p>}
+      <div className="pl-6"><RoleAreaChips areas={r.role_areas} /></div>
+    </CommandItem>
+  );
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(next) => { setOpen(next); if (!next) setSearch(''); }}
+      modal={modal}
+    >
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline" role="combobox" aria-expanded={open}
+          aria-label={triggerLabel} disabled={disabled}
+          className="h-7 max-w-[220px] gap-1 rounded-full border-border/40 px-2.5 text-[13px] font-medium"
+        >
+          <span className="truncate">{triggerText}</span>
+          <ChevronsUpDown className="h-3 w-3 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+
+      <PopoverContent className="w-[340px] p-0" align="end">
+        <Command shouldFilter={false}>
+          <CommandInput placeholder="Search roles..." value={search} onValueChange={setSearch} />
+          <CommandList>
+            {/* Copy the three-state block from RolePicker.tsx:220-249 VERBATIM,
+                including its comment. Direct children of CommandList, never
+                routed through CommandEmpty. */}
+          </CommandList>
+          {/* footer is a SIBLING of CommandList, inside Command — exactly where
+              the delta panel sits today. Inside CommandList it would register
+              as a filterable cmdk item and steal the arrow keys. */}
+          {footer}
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+```
+
+Copy the two `CommandGroup` blocks (`RolePicker.tsx:251-270`) into `CommandList` verbatim, comments included.
+
+- [ ] **Step 5: Rewrite `RolePicker` on top of it**
+
+`RolePicker` keeps: `open`/`candidateId` state, `useAssignRole`, `grantSetOf`, `renderDeltaLines`, `currentLabel`, `triggerLabel`, `commit`, and the delta JSX — now passed as `footer`. It **must** pass `open` and `onOpenChange` controlled:
+
+```tsx
+  return (
+    <RoleSelect
+      restaurantId={restaurantId}
+      callerRole={callerRole}
+      {/* The CURRENT role, not the candidate — `isCurrent` at RolePicker.tsx:105
+          never moves when you click an option, and the footer is what shows
+          the pending choice. Passing `candidateId` here would erase the only
+          on-screen record of the role the person holds today. */}
+      value={currentRow?.id ?? null}
+      onSelect={(r) => setCandidateId(r.id)}
+      triggerLabel={triggerLabel}
+      triggerText={currentLabel}
+      disabled={disabled}
+      open={open}
+      onOpenChange={(next) => { setOpen(next); if (!next) setCandidateId(null); }}
+      footer={delta && candidateRow ? (
+        <div className="space-y-2 border-t border-border/40 px-3 py-3">
+          {/* delta JSX from RolePicker.tsx:275-298, unchanged */}
+        </div>
+      ) : null}
+    />
+  );
+```
+
+`RolePicker` still needs `roles` for `currentRow`/`candidateRow`/`currentLabel`, so it keeps its own `useRoles(restaurantId)` call. Both hooks hit the same React Query key — one fetch, two readers.
+
+- [ ] **Step 6: Run the gate**
+
+```bash
+npx vitest run tests/unit/RolePicker.test.tsx && npm run typecheck
+```
+
+Expected: all 10 PASS, unmodified. Any failure is a real behaviour change — fix `RolePicker`, do not edit the test.
+
+- [ ] **Step 7: Test `RoleSelect` directly**
+
+Create `tests/unit/RoleSelect.test.tsx`, mocking `@/hooks/useRoles` the same way `RolePicker.test.tsx` does. Cases:
+
+1. trigger's `aria-label` contains its visible text
+2. `isLoading` → "Loading roles…" with `role="status"`
+3. `error` → "Couldn't load roles" and **not** the empty-state copy
+4. a manager sees no `owner` option; an owner does
+5. a custom role from another restaurant never appears (`isAssignableCustomRole`)
+6. `callerRole="chef"` → custom group renders with "Only an owner or manager can assign a custom role" instead of rows, not hidden
+7. `onSelect` fires with the whole `RoleWithGrants`, and no write occurs — assert `@/hooks/useAssignRole` was never imported/called by mocking it and checking `mutate` is untouched
+8. `footer` renders inside the popover and is **not** reachable as a `role="option"`
+
+- [ ] **Step 8: Run and commit**
+
+```bash
+npx vitest run tests/unit/RoleSelect.test.tsx tests/unit/RolePicker.test.tsx && npm run typecheck && npm run lint
+git add src/components/roles/RoleSelect.tsx src/components/roles/RolePicker.tsx tests/unit/RoleSelect.test.tsx
+git commit -m "refactor(roles): split the role option list out of RolePicker"
+```
+
+---
+
+### Task 3: `EmployeeAppAccessRow` — visibility gate and the linked-account state
+
+**Files:**
+- Create: `src/components/employees/EmployeeAppAccessRow.tsx`
+- Modify: `src/components/EmployeeDialog.tsx`
+- Test: `tests/unit/EmployeeDialog.appAccess.test.tsx` (extend)
+
+**Interfaces:**
+- Consumes: `isInternalTeamRole` (Task 1); `RolePicker` (unchanged public props).
+- Produces:
+
+```ts
+export interface EmployeeAppAccessRowProps {
+  restaurantId: string;
+  /** Caller's role in THIS restaurant, or null when it can't be established. */
+  callerRole: Role | null;
+  /** Undefined in create mode. */
+  employee?: Employee;
+  /** Email currently typed in the dialog. */
+  email: string;
+  grantAppAccess: boolean;
+  onGrantAppAccessChange: (next: boolean) => void;
+  /** Chosen invite role. null means "unchosen" — the payload then defaults to staff. */
+  inviteRole: RoleWithGrants | null;
+  onInviteRoleChange: (role: RoleWithGrants) => void;
+  /** Provided in edit mode only. Sends immediately. */
+  onSendInvite?: () => void;
+  sendingInvite?: boolean;
+}
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+Extend `tests/unit/EmployeeDialog.appAccess.test.tsx`. It already mocks `useRestaurantMembers`; extend the `useRestaurantContext` mock to carry a role, since the row now reads it:
+
+```tsx
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => ({
+    selectedRestaurant: { restaurant_id: 'r1', role: 'owner', restaurant: { id: 'r1', timezone: 'UTC' } },
+  }),
+}));
+```
+
+Cases to add:
+
+```tsx
+  it('shows the linked account and its role, not a role on the employee row', async () => {
+    // employee.user_id matches a roster member -> membershipId resolves
+    // expect: /signed in as/i with the email, and a combobox naming the role
+  });
+
+  it('says nothing at all to a caller who cannot see the roster', async () => {
+    // callerRole 'collaborator_accountant': RLS returns only their own row, so a
+    // roster miss means "can't see", not "no account". Claiming "No access"
+    // would be a confident lie about someone with full access.
+    // expect: queryByText(/app access/i) is null — the row is absent entirely.
+  });
+
+  it('offers the invite when the account is linked to no membership here', async () => {
+    // employee.user_id set, roster has no matching userId -> state 3 folds into 2
+    // expect: /no access/i and an "Invite to the app" control,
+    //         and NO combobox (a RolePicker without a membershipId)
+  });
+
+  it('waits rather than guessing while the roster loads', async () => {
+    // useRestaurantMembers isLoading -> skeleton, no invite control
+    // expect: queryByRole('switch', {name: /invite/i}) is null
+  });
+
+  it('renders the role read-only when the caller role cannot be established', async () => {
+    // selectedRestaurant.restaurant_id !== restaurantId prop
+    // expect: role text present, but no combobox
+  });
+```
+
+- [ ] **Step 2: Run and watch them fail**
+
+```bash
+npx vitest run tests/unit/EmployeeDialog.appAccess.test.tsx
+```
+
+Expected: the five new cases FAIL; the existing cases still PASS.
+
+- [ ] **Step 3: Build the row's gate and state 1**
+
+```tsx
+export function EmployeeAppAccessRow({ restaurantId, callerRole, employee, /* … */ }: EmployeeAppAccessRowProps) {
+  const { data: members, isLoading, isError } = useRestaurantMembers(restaurantId);
+
+  // RLS on user_restaurants returns every row only to internal team
+  // (20260120100000:201-212). To a collaborator the roster is just their own
+  // row, so a miss means "cannot see", not "no account" — and this row would
+  // announce "No access" about someone fully provisioned. Say nothing instead.
+  if (!isInternalTeamRole(callerRole)) return null;
+
+  if (isLoading) return <AppAccessSkeleton />;
+  if (isError) {
+    return (
+      <div role="alert" className="rounded-lg border border-border/40 bg-muted/30 p-3 text-[13px] text-muted-foreground">
+        Couldn't load access details.
+      </div>
+    );
+  }
+
+  const member = employee?.user_id
+    ? members?.find((m) => m.userId === employee.user_id) ?? null
+    : null;
+
+  if (member) return <LinkedAccountState member={member} … />;
+  return <NoAccessState … />;
+}
+```
+
+State 1 stacks unconditionally — `TeamMembers.tsx:178-186` shows a label plus this chip overflows a 375px row, and this dialog is capped tighter at `sm:max-w-[500px]` (`EmployeeDialog.tsx:647`):
+
+```tsx
+<div className="rounded-lg border border-border/40 bg-muted/30 p-3 space-y-2">
+  <Label className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">App access</Label>
+  <p className="text-[13px] text-muted-foreground truncate">
+    Signed in as <span className="text-foreground">{member.email}</span>
+  </p>
+  <RolePicker
+    membershipId={member.membershipId}
+    restaurantId={restaurantId}
+    personName={employee?.name ?? member.fullName ?? 'this member'}
+    currentRole={member.role}
+    currentRoleId={member.roleId}
+    callerRole={callerRole}
+  />
+  <p className="text-[13px] text-muted-foreground">
+    Roles belong to the EasyShiftHQ account, not the employee record — the same control appears on Team members.
+  </p>
+</div>
+```
+
+`RolePicker` needs a non-null `callerRole`; the `isInternalTeamRole` gate above already guarantees it. When `callerRole` is null the gate returns `null`, which also satisfies the read-only case — except where the restaurant mismatches, handled next.
+
+- [ ] **Step 4: Wire it into `EmployeeDialog` in edit mode**
+
+Derive `callerRole` without assuming the selected restaurant is the dialog's:
+
+```tsx
+// Both call sites pass the selected restaurant (Employees.tsx:137,
+// Scheduling.tsx:1621), but a mismatch must not silently borrow another
+// restaurant's role — that would gate this row on the wrong permissions.
+const callerRole =
+  selectedRestaurant?.restaurant_id === restaurantId ? selectedRestaurant.role : null;
+```
+
+Render the row unconditionally where the `isCreateMode &&` block sits today (`:1110`), leaving that block's create-mode contents alone for now.
+
+- [ ] **Step 5: Run**
+
+```bash
+npx vitest run tests/unit/EmployeeDialog.appAccess.test.tsx && npm run typecheck
+```
+
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/employees/EmployeeAppAccessRow.tsx src/components/EmployeeDialog.tsx tests/unit/EmployeeDialog.appAccess.test.tsx
+git commit -m "feat(employees): show the linked account's role on the employee dialog"
+```
+
+---
+
+### Task 4: Unhardcode the create-mode invite
+
+**Files:**
+- Modify: `src/components/employees/EmployeeAppAccessRow.tsx`, `src/components/EmployeeDialog.tsx`
+- Test: `tests/unit/EmployeeDialog.appAccess.test.tsx` (extend)
+
+**Interfaces:**
+- Consumes: `RoleSelect` (Task 2), the row (Task 3).
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+  it('still invites as staff when nobody touches the picker', async () => {
+    // fill name + email, flip the switch, submit
+    expect(invokeMock).toHaveBeenCalledWith('send-team-invitation', {
+      body: expect.objectContaining({ role: 'staff', employeeId: 'new-emp' }),
+    });
+    expect(invokeMock.mock.calls[0][1].body).not.toHaveProperty('roleId');
+  });
+
+  it('invites as the chosen custom role, carrying its roleId', async () => {
+    // pick "Operations Lead" (a custom role) then submit
+    expect(invokeMock).toHaveBeenCalledWith('send-team-invitation', {
+      body: expect.objectContaining({ role: 'collaborator_custom', roleId: 'c1' }),
+    });
+  });
+
+  it('invites as a chosen built-in role without a roleId', async () => {
+    // pick "Chef" then submit -> { role: 'chef' }, no roleId
+  });
+
+  it('describes the role it will actually grant, not always staff', async () => {
+    // pick a custom role -> its own description shows, and the staff sentence
+    // about "will not see sales, costs, payroll" is gone
+    expect(screen.queryByText(/will not see sales, costs, payroll/i)).not.toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 2: Run and watch them fail**
+
+```bash
+npx vitest run tests/unit/EmployeeDialog.appAccess.test.tsx
+```
+
+Expected: the four new cases FAIL.
+
+- [ ] **Step 3: Move the switch into the row and add the picker**
+
+Move the existing switch block (`EmployeeDialog.tsx:1141-1166`) into `EmployeeAppAccessRow`'s no-access state **verbatim** — `aria-disabled` rather than `disabled` when the email is empty (a disabled Switch leaves the tab order and a keyboard user never hears why), the `onCheckedChange` early return, `aria-describedby="grantAppAccessHint"`, all of it.
+
+Replace only the hint's body. When `grantAppAccess` is on, render the picker and let the chosen role describe itself:
+
+```tsx
+<p id="grantAppAccessHint" className="text-[13px] text-muted-foreground">
+  {!email.trim()
+    ? 'Add an email address to enable.'
+    : inviteRole?.description ?? 'Lets them clock in, view their own schedule, and request time off from their phone.'}
+</p>
+{grantAppAccess && email.trim() && (
+  <>
+    <RoleSelect
+      restaurantId={restaurantId}
+      callerRole={callerRole}
+      value={inviteRole?.id ?? null}
+      onSelect={onInviteRoleChange}
+      triggerText={inviteLabel}
+      triggerLabel={`Invite as ${inviteLabel}. Change role`}
+    />
+    {inviteRole && <RoleAreaChips areas={inviteRole.role_areas} />}
+  </>
+)}
+```
+
+`inviteLabel` is `inviteRole?.name ?? 'Employee (self-service)'` — the staff role's display name from `ROLE_METADATA`. Leaving `inviteRole` null keeps today's payload byte-identical, so an untouched picker cannot change behaviour.
+
+- [ ] **Step 4: Take the hardcode out**
+
+`EmployeeDialog.tsx:429`:
+
+```tsx
+role: inviteRole && inviteRole.legacy_role === null ? CUSTOM_ROLE : (inviteRole?.legacy_role ?? 'staff'),
+...(inviteRole && inviteRole.legacy_role === null ? { roleId: inviteRole.id } : {}),
+```
+
+`roleId` must be **absent**, not `undefined`, for a non-custom role: `send-team-invitation/index.ts:111` rejects the pairing when `role !== CUSTOM_ROLE && roleId`.
+
+- [ ] **Step 5: Run and commit**
+
+```bash
+npx vitest run tests/unit/EmployeeDialog.appAccess.test.tsx && npm run typecheck && npm run lint
+git add src/components/employees/EmployeeAppAccessRow.tsx src/components/EmployeeDialog.tsx tests/unit/EmployeeDialog.appAccess.test.tsx
+git commit -m "feat(employees): the invite asks which role instead of assuming staff"
+```
+
+---
+
+### Task 5: The edit-mode invite
+
+A genuinely new call path — `send-team-invitation` has exactly one call site today and it is create-only.
+
+**Files:**
+- Modify: `src/components/employees/EmployeeAppAccessRow.tsx`, `src/components/EmployeeDialog.tsx`
+- Test: `tests/unit/EmployeeDialog.appAccess.test.tsx` (extend)
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+  it('sends the invite with the saved email and the chosen role', async () => {
+    // edit mode, employee.email 'sam@x.com', no user_id
+    // click "Invite to the app…", pick a custom role, click "Send invite"
+    expect(invokeMock).toHaveBeenCalledWith('send-team-invitation', {
+      body: { restaurantId: 'r1', email: 'sam@x.com', role: 'collaborator_custom', roleId: 'c1', employeeId: 'e1' },
+    });
+  });
+
+  it('refuses to invite an address the user is still typing', async () => {
+    // edit mode, saved email 'sam@x.com', user types 'other@x.com' in the field
+    // expect: "Send invite" disabled, and no call fires on click
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it('asks for an email first when the employee has none saved', async () => {
+    // edit mode, employee.email undefined
+    // expect: no "Send invite" button, prompt to add an address
+  });
+```
+
+- [ ] **Step 2: Run and watch them fail**
+
+```bash
+npx vitest run tests/unit/EmployeeDialog.appAccess.test.tsx
+```
+
+- [ ] **Step 3: Implement**
+
+In the row's no-access state, when `onSendInvite` is provided (edit mode), replace the switch with a ghost button that expands to the picker plus a `Send invite` button:
+
+```tsx
+<Button
+  variant="ghost"
+  onClick={onSendInvite}
+  disabled={sendingInvite || !savedEmail || typedEmailDiffers}
+  className="h-9 px-4 rounded-lg text-[13px] font-medium text-muted-foreground hover:text-foreground"
+>
+  {sendingInvite ? 'Sending…' : 'Send invite'}
+</Button>
+{typedEmailDiffers && (
+  <p className="text-[13px] text-muted-foreground">Save the email change before inviting.</p>
+)}
+```
+
+In `EmployeeDialog`, add the handler. It fires immediately — **not** on Save. The edit path has two exits (`:582` plain update, `:575-580` compensation detour through the effective-date modal); hanging an outward-facing email off either is three trigger sites and three ways to get it wrong.
+
+```tsx
+const handleSendInvite = async () => {
+  if (!employee?.email) return;
+  setSendingInvite(true);
+  try {
+    const { error } = await supabase.functions.invoke('send-team-invitation', {
+      body: { restaurantId, email: employee.email, ...invitePayloadFor(inviteRole), employeeId: employee.id },
+    });
+    if (error) throw error;
+    toast({ title: `Invitation sent to ${employee.email}` });
+  } catch (e) {
+    console.error('Error sending invitation:', e);
+    toast({ title: "Couldn't send the invitation", description: 'Please try again.', variant: 'destructive' });
+  } finally {
+    setSendingInvite(false);
+  }
+};
+```
+
+Extract `invitePayloadFor(role)` and use it on the create path too, so the two call sites cannot build the payload differently.
+
+- [ ] **Step 4: Run and commit**
+
+```bash
+npx vitest run tests/unit/EmployeeDialog.appAccess.test.tsx && npm run typecheck && npm run lint
+git add src/components/employees/EmployeeAppAccessRow.tsx src/components/EmployeeDialog.tsx tests/unit/EmployeeDialog.appAccess.test.tsx
+git commit -m "feat(employees): invite an existing employee to the app"
+```
+
+---
+
+### Task 6: End-to-end coverage
+
+**Files:**
+- Modify: `tests/e2e/accountless-employee-invite.spec.ts`, `tests/e2e/role-assignment.spec.ts`
+
+- [ ] **Step 1: Custom-role invite from the employee dialog**
+
+Extend `accountless-employee-invite.spec.ts`: create an employee with an email, flip the invite switch, pick a custom role, save, and assert the pending invitation carries that role. Use `page.getByRole()` / `getByLabel()`, and `generateTestUser()` for unique data.
+
+- [ ] **Step 2: The two surfaces write the same row**
+
+Extend `role-assignment.spec.ts`: change an employee's role from the employee dialog, then open Team members and assert the chip there shows the new role. This is the whole point of the design — the role lives on the account, and every surface reads the same source.
+
+- [ ] **Step 3: Run**
+
+```bash
+npx playwright test tests/e2e/accountless-employee-invite.spec.ts tests/e2e/role-assignment.spec.ts --reporter=line
+```
+
+Run in the foreground and let the Bash tool's `timeout` bound it. No poll loops; `timeout`/`gtimeout` do not exist on this machine.
+
+- [ ] **Step 4: Full suite, then commit**
+
+```bash
+npm run test && npm run typecheck && npm run lint
+git add tests/e2e/accountless-employee-invite.spec.ts tests/e2e/role-assignment.spec.ts
+git commit -m "test(e2e): custom-role invites and cross-surface role agreement"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** State 1 → Task 3. States 2/3 create → Task 4. States 2/3 edit → Task 5. `RoleSelect` split, footer placement, controlled `open` → Task 2. Internal-team gate + mirror test → Task 1. Narrow-viewport stacking → Task 3 Step 3. Copy-that-stops-lying → Task 4 Step 3. Caller gating → Task 3 Step 4. E2E → Task 6. No spec section is unclaimed.
+
+**Type consistency.** `RoleSelectProps` is declared once (Task 2) and used as declared in Tasks 2 and 4. `EmployeeAppAccessRowProps` is declared in Task 3 and extended by behaviour only — `onSendInvite`/`sendingInvite` are in the original declaration, used in Task 5. `inviteRole` is `RoleWithGrants | null` throughout. `INTERNAL_TEAM_ROLES`/`isInternalTeamRole` (Task 1) are consumed in Task 3.
+
+**Ordering.** Task 2 is independent of Task 1 and could run in parallel. Tasks 3-5 are strictly sequential on the same two files. Task 6 needs 3-5.

--- a/docs/superpowers/specs/2026-08-04-employee-app-access-design.md
+++ b/docs/superpowers/specs/2026-08-04-employee-app-access-design.md
@@ -324,7 +324,8 @@ second commit is rejected.
 | `useRestaurantMembers` errors | Same skeleton replaced by "Couldn't load access details." No control. Consistent with the fail-closed hint in `resolveAccountlessEmployeeHint`. |
 | `useRoles` loading / errors | `RoleSelect` renders its existing `:231-244` states inside the popover. |
 | Assignment rejected (42501) | `RolePicker`'s existing toast via `assignRoleErrorMessage`. Unchanged. |
-| Invite rejected | Existing `EmployeeDialog.tsx:432-446` toast path, unchanged. The employee is still created — the invite is fire-and-forget by design. |
+| Invite rejected (create mode) | Existing `EmployeeDialog.tsx:432-446` toast path, unchanged. The employee is still created and the dialog still closes — the invite is fire-and-forget by design, and losing the whole employee record over a failed email would be worse. |
+| Invite rejected (edit mode) | `handleSendInvite`'s "Couldn't send the invitation / Please try again." toast. Nothing was being saved, so the existing employee is untouched and the dialog stays open — the button is still there to retry. |
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-08-04-employee-app-access-design.md
+++ b/docs/superpowers/specs/2026-08-04-employee-app-access-design.md
@@ -85,6 +85,45 @@ comment: a global "does this email have an account" lookup would be an
 account-enumeration oracle). Matching on `userId` reads nothing the caller cannot
 already see on the Team page.
 
+### The row renders only for internal-team callers
+
+The roster is not merely permission-gated, it is **visibility**-gated, and the two
+are not the same thing. The SELECT policy on `user_restaurants`
+(`supabase/migrations/20260120100000_add_collaborator_roles.sql:201-212`) returns
+every membership row only when `user_is_internal_team(restaurant_id)` holds —
+defined at `20260702170000_add_operations_manager_role.sql:27-43` as
+`role IN ('owner','manager','operations_manager','chef','staff')`. Every
+collaborator role is excluded. The migration says so itself, in a trailing note:
+collaborators see only their own row.
+
+`collaborator_accountant` can reach `/employees` ("View for payroll context",
+`src/App.tsx:184`), as can `collaborator_chef` (`:229`). For them
+`useRestaurantMembers` returns exactly one row — their own — so
+`members.find(m => m.userId === employee.user_id)` misses for every other
+employee, and states 1 and 3 become indistinguishable from the outside. The row
+would confidently print "No access — they can't sign in yet" about someone who
+has full access. A caller-reach check does not catch this: their reach is
+correctly empty, but the falsehood is in the *reading*, not the writing.
+
+So the row renders only when the caller is internal team. For everyone else the
+dialog behaves exactly as it does today — no app-access row at all. Saying
+nothing is honest; the alternative is a confident lie.
+
+That predicate needs a TypeScript mirror, added to
+`src/lib/permissions/roleMembership.ts`:
+
+```ts
+/** Mirrors `user_is_internal_team` (20260702170000:27-43). See the drift note below. */
+export const INTERNAL_TEAM_ROLES = ['owner', 'manager', 'operations_manager', 'chef', 'staff'] as const;
+export function isInternalTeamRole(role: Role): boolean;
+```
+
+This is a second copy of a database rule, which `roleMembership.ts`'s own header
+warns against. It is pinned the same way the invite matrix is: a mirror test that
+parses the role list out of the migration and asserts equality, modelled on
+`tests/unit/inviteMatrixMirror.test.ts`. Without the pin, adding a sixth internal
+role in SQL would silently blank this row for that role.
+
 While `useRestaurantMembers` is loading or has errored, state 1 cannot be
 distinguished from state 3. The row renders a skeleton rather than guessing —
 guessing state 2 would offer an invite to someone who already has access.
@@ -170,6 +209,34 @@ two hosts word it differently, so it is a prop:
 
 Both embed the visible chip text.
 
+### The edit-mode invite is a new call path, not a reused one
+
+Worth stating plainly, because the state table makes it look like reuse: today
+`send-team-invitation` has exactly one call site, inside
+`createEmployeeWithHistory` (`EmployeeDialog.tsx:425`), which runs in create mode
+only. The edit-mode submit branch (`:567-592`) contains no invite logic at all.
+
+**Trigger: immediate, on an explicit button — not on Save.** Clicking
+`Invite to the app…` expands the row to the same role choice as create mode plus
+a `Send invite` button; that button fires the call. Two reasons over
+invite-on-Save: the edit path has *two* exits (the plain
+`updateEmployee.mutateAsync` at `:582`, and the compensation-change path that
+detours through the effective-date modal at `:575-580`), so on-Save means three
+trigger sites across the dialog and three ways to get it wrong; and sending an
+email is an outward-facing act that should be a button the user presses, not a
+side effect of saving an unrelated field.
+
+**Payload:** `{ restaurantId, email: employee.email, role, roleId?, employeeId: employee.id }`
+— the *saved* email, never the typed draft. If the two differ, `Send invite` is
+disabled with "Save the email change before inviting." If the employee has no
+saved email, the button does not appear and the row reads "Add an email address
+to invite them." This is the one guard that keeps an invite from going to an
+address the user is still typing.
+
+The create-mode invite keeps its existing shape: fired inside
+`createEmployeeWithHistory` after the insert, fire-and-forget, carrying the
+newly-created `employeeId`. Only its `role`/`roleId` change.
+
 ### Narrow viewports
 
 `TeamMembers.tsx:178-186` records what this costs on a 375px row: the role label
@@ -216,6 +283,25 @@ Within a matching restaurant, reach is whatever `getInvitableRoles` and
 design: a manager may change someone to any role they could already invite them
 to, custom roles included; owners keep full reach. No new matrix.
 
+"No new matrix" is a claim about **target-role eligibility only.** There, the SQL
+(`20260802110000_assign_membership_role.sql:32-60`), the TS
+(`invitations.ts:10-49`), and the Deno mirror are identical and pinned by
+`tests/unit/inviteMatrixMirror.test.ts`. `assign_membership_role` additionally
+enforces rules the invite path has no analog for — self-target refusal, kiosk
+memberships being immovable, and owner protection including the last-owner
+`FOR UPDATE` count (`20260803100000_assign_membership_role_custom_role_flavor_check.sql:71-128`).
+Those are additive safeguards on the *existing-membership* path; an invite has no
+membership to protect. The two RPCs are not interchangeable, and nothing here
+assumes they are.
+
+Concurrency between the two assignment surfaces is already closed at the database
+layer: `assign_membership_role` opens with `SELECT … FOR UPDATE` on the target
+membership (`20260803100000_…:60-64`, added for exactly this race). Two admins
+submitting at once serialize. The only residue is a stale gains/loses delta in
+whichever dialog rendered first, which self-heals on the next cache
+invalidation, or surfaces as the existing `assignRoleErrorMessage` toast if the
+second commit is rejected.
+
 ### What does not change
 
 - No migration. `assign_membership_role` is Move 1's and is reused as-is.
@@ -249,8 +335,20 @@ to, custom roles included; owners keep full reach. No new matrix.
 - edit mode, `user_id` matches a member → "Signed in as", chip shows the member's role
 - edit mode, no `user_id` → "No access", `Invite to the app…`
 - edit mode, `user_id` set with no membership here → state 2, not a `RolePicker` without a membership
+- edit mode, `Send invite` → `send-team-invitation` called once with the **saved**
+  email, the chosen `role`/`roleId`, and `employeeId: employee.id`. This is a new
+  call path; asserting the label renders is not enough.
+- edit mode, typed email differs from saved → `Send invite` disabled, no call fires
+- edit mode, employee has no saved email → no `Send invite`, prompt to add one
 - roster loading → skeleton, no invite control
+- caller is `collaborator_accountant` → **no app-access row at all** (not "No access")
+- caller is `owner` → row renders
 - `selectedRestaurant.restaurant_id !== restaurantId` → read-only label
+
+**Unit — `tests/unit/internalTeamMirror.test.ts` (new):** parses the role list out
+of `20260702170000_add_operations_manager_role.sql` and asserts it equals
+`INTERNAL_TEAM_ROLES`, modelled on `inviteMatrixMirror.test.ts`. This is what
+keeps a sixth internal role added in SQL from silently blanking the row.
 
 **Unit — `tests/unit/RolePicker.test.tsx`: must pass untouched.** That file is the
 regression gate on the split; if the extraction changed observable behaviour it
@@ -277,8 +375,10 @@ of rows rather than hiding the group, and the three list states.
 | `src/components/roles/RoleSelect.tsx` | new — controlled option list, extracted from `RolePicker` |
 | `src/components/roles/RolePicker.tsx` | modify — renders `RoleSelect` + delta/commit footer; props unchanged |
 | `src/components/employees/EmployeeAppAccessRow.tsx` | new — the three states |
-| `src/components/EmployeeDialog.tsx` | modify — render the row in both modes; `:429` takes the chosen role |
+| `src/lib/permissions/roleMembership.ts` | modify — add `INTERNAL_TEAM_ROLES` / `isInternalTeamRole` |
+| `src/components/EmployeeDialog.tsx` | modify — render the row in both modes; `:429` takes the chosen role; new edit-mode invite call |
 | `tests/unit/RoleSelect.test.tsx` | new |
+| `tests/unit/internalTeamMirror.test.ts` | new |
 | `tests/unit/EmployeeDialog.appAccess.test.tsx` | extend |
 | `tests/e2e/accountless-employee-invite.spec.ts` | extend |
 | `tests/e2e/role-assignment.spec.ts` | extend |

--- a/docs/superpowers/specs/2026-08-04-employee-app-access-design.md
+++ b/docs/superpowers/specs/2026-08-04-employee-app-access-design.md
@@ -124,6 +124,19 @@ export interface RoleSelectProps {
 }
 ```
 
+`open`/`onOpenChange` are optional so the invite branch can let `RoleSelect`
+manage its own popover, but **`RolePicker` must pass them controlled.** Its
+`commit()` success path closes the popover and clears `candidateId` and `search`
+(`RolePicker.tsx:138-144`), and its `onOpenChange` clears the same two on any
+close (`:189-194`). Both live in `RolePicker`, so it has to own `open` to keep
+them. Uncontrolled here would ship a picker that stays open after "Change role"
+succeeds and carries a stale candidate into the next open.
+
+`footer` renders as a **sibling of `<CommandList>`, inside `<Command>`** — the
+exact DOM position the delta panel occupies today (`RolePicker.tsx:271-300`,
+after `</CommandList>`). Nested inside `CommandList` instead, the commit button
+would register as a filterable cmdk item and the arrow keys would land on it.
+
 It keeps, unchanged, the filters that Move 1 established:
 `isAssignableCustomRole(r, restaurantId)` and
 `getInvitableRoles(callerRole)` (`RolePicker.tsx:97-103`), the "Only an owner or
@@ -157,9 +170,22 @@ two hosts word it differently, so it is a prop:
 
 Both embed the visible chip text.
 
+### Narrow viewports
+
+`TeamMembers.tsx:178-186` records what this costs on a 375px row: the role label
+plus the picker chip is wider than the content box, and keeping it on the name's
+line collapsed the name column to zero. The fix there was stacking with
+`pl-[3.25rem] sm:pl-0`.
+
+State 1 is tighter still — `EmployeeDialog`'s `DialogContent` is capped at
+`sm:max-w-[500px]` (`EmployeeDialog.tsx:647`), and "Signed in as {email}" is an
+arbitrary-length string next to a `max-w-[220px]` chip (`RolePicker.tsx:205`). So
+state 1 stacks unconditionally: the label and email on one line, the chip on its
+own line below, with the email `truncate`d. No horizontal competition to lose.
+
 ### Copy that stops lying
 
-The existing hint (`EmployeeDialog.tsx:1146-1149`) hardcodes staff's access:
+The existing hint (`EmployeeDialog.tsx:1146-1150`) hardcodes staff's access:
 
 > Lets them clock in, view their own schedule, and request time off from their
 > phone. They will not see sales, costs, payroll, or other employees.
@@ -194,10 +220,15 @@ to, custom roles included; owners keep full reach. No new matrix.
 
 - No migration. `assign_membership_role` is Move 1's and is reused as-is.
 - No edge-function change. `send-team-invitation` already accepts `roleId`.
-- The `existingMember` / `linkToExisting` branch (`EmployeeDialog.tsx:1111-1141`,
+- The `existingMember` / `linkToExisting` branch (`EmployeeDialog.tsx:1111-1139`,
   `link_employee_to_user` RPC at `:401`) is untouched. Linking an already-registered account is a
   different action from inviting a new one, and it already lands the person on a
   membership whose role state 1 then governs.
+- The invite switch itself moves into `EmployeeAppAccessRow` **verbatim**:
+  `aria-disabled` rather than `disabled` when the email is empty, because a
+  disabled Switch leaves the tab order and a keyboard user never hears why it is
+  off (`EmployeeDialog.tsx:1152-1162`), plus the `onCheckedChange` early return
+  on an empty email. Only the description it points at changes.
 
 ## Error handling
 
@@ -207,7 +238,7 @@ to, custom roles included; owners keep full reach. No new matrix.
 | `useRestaurantMembers` errors | Same skeleton replaced by "Couldn't load access details." No control. Consistent with the fail-closed hint in `resolveAccountlessEmployeeHint`. |
 | `useRoles` loading / errors | `RoleSelect` renders its existing `:231-244` states inside the popover. |
 | Assignment rejected (42501) | `RolePicker`'s existing toast via `assignRoleErrorMessage`. Unchanged. |
-| Invite rejected | Existing `EmployeeDialog.tsx:432-440` toast path, unchanged. The employee is still created — the invite is fire-and-forget by design. |
+| Invite rejected | Existing `EmployeeDialog.tsx:432-446` toast path, unchanged. The employee is still created — the invite is fire-and-forget by design. |
 
 ## Testing
 
@@ -223,7 +254,10 @@ to, custom roles included; owners keep full reach. No new matrix.
 
 **Unit — `tests/unit/RolePicker.test.tsx`: must pass untouched.** That file is the
 regression gate on the split; if the extraction changed observable behaviour it
-fails here.
+fails here. If it does not already assert that a successful commit closes the
+popover and clears the candidate, add that case first — it is the behaviour the
+controlled-`open` requirement above exists to protect, and an untested
+requirement is one an implementer can quietly drop.
 
 **Unit — `tests/unit/RoleSelect.test.tsx` (new):** the option-list filters —
 custom roles gated by `isAssignableCustomRole`, built-ins by

--- a/docs/superpowers/specs/2026-08-04-employee-app-access-design.md
+++ b/docs/superpowers/specs/2026-08-04-employee-app-access-design.md
@@ -1,0 +1,259 @@
+# Move 3 — App access on the employee dialog
+
+**Status:** approved
+**Date:** 2026-08-04
+**Parent design:** `docs/superpowers/specs/2026-08-02-role-assignment-design.md`
+**Prototype:** `docs/design-reference/role-assignment.html`, section `#v-employee`
+**Depends on:** Move 1 (#688, `assign_membership_role` + `RolePicker`), Move 2 (#691, `RoleRoster`)
+
+---
+
+## The problem
+
+Two separate defects, both in `src/components/EmployeeDialog.tsx`, both producing the
+same report: *"I created a custom role and I can't apply it to an employee."*
+
+**1. Every invite is hardcoded to `staff`.**
+
+```tsx
+// src/components/EmployeeDialog.tsx:425-431
+supabase.functions.invoke('send-team-invitation', {
+  body: {
+    restaurantId: restaurantId,
+    email: email.trim(),
+    role: 'staff',
+    employeeId: newEmployee.id, // Pass employee ID for linking
+  },
+})
+```
+
+The server has accepted a role choice since Move 1's predecessor:
+`supabase/functions/send-team-invitation/index.ts:52-59` declares `roleId?: string`
+alongside `role`, validates the pairing at `:105` and `:111`, and writes
+`invitationData.role_id` at `:262`. Only the client assumes.
+
+**2. An existing employee's dialog has no app-access row at all.**
+
+`src/components/EmployeeDialog.tsx:1110` opens the entire block with
+`{isCreateMode && (existingMember ? … : …)}`, closing at `:1167`. `isCreateMode`
+is `!employee` (`:159`). So the moment an employee exists, the dialog goes silent
+about whether they can sign in and as what — which is precisely when an owner
+goes looking for it.
+
+The parent design doc cites this hardcode as `EmployeeDialog.tsx:412`. That line
+number is stale; it is `:429` on `f2a31da8`.
+
+## The idea the UI has to carry
+
+From the prototype's annotation:
+
+> A role lives on the account, not on the employee row — which is why looking for
+> it on an employee found nothing.
+
+`employees.user_id` (`src/types/scheduling.ts:41`, nullable) is the link to an
+account. The role hangs off `user_restaurants`, one row per person per restaurant.
+The dialog should not grow a fake `role` field on the employee record; it should
+name the real relationship and give direct access to it.
+
+## Architecture
+
+One new component, `src/components/employees/EmployeeAppAccessRow.tsx`, rendered
+in **both** create and edit mode. `EmployeeDialog` keeps ownership of the invite
+side effect; the row is presentational plus a self-contained `RolePicker`.
+
+### State resolution
+
+Three inputs: `employee?.user_id`, the `useRestaurantMembers(restaurantId)` roster,
+and the typed `email`. `RestaurantMember` (`src/hooks/useRestaurantMembers.ts:6-27`)
+carries `membershipId`, `userId`, `email`, `role`, `roleId` — exactly `RolePicker`'s
+inputs. The match is `members.find(m => m.userId === employee.user_id)`.
+
+| # | Condition | Renders |
+|---|-----------|---------|
+| 1 | `employee.user_id` matches a member of this restaurant | "Signed in as {email}" + live `RolePicker` on that `membershipId` + "Roles belong to the EasyShiftHQ account, not the employee record — the same control appears on Team members." |
+| 2 | No `user_id` | Create mode: today's invite switch + a role choice. Edit mode: "No access — they can't sign in yet." + `Invite to the app…` |
+| 3 | `user_id` set, no membership in this restaurant | Same as 2 |
+
+State 3 is not in the prototype. It is reachable: the account was removed from the
+team, or `user_id` points at an account whose membership lives in another
+restaurant. Falling through to state 1 would render a `RolePicker` with no
+`membershipId` — so it is explicitly folded into state 2, which offers the invite
+that repairs it.
+
+The roster query is restaurant-scoped by design (`useRestaurantMembers.ts` header
+comment: a global "does this email have an account" lookup would be an
+account-enumeration oracle). Matching on `userId` reads nothing the caller cannot
+already see on the Team page.
+
+While `useRestaurantMembers` is loading or has errored, state 1 cannot be
+distinguished from state 3. The row renders a skeleton rather than guessing —
+guessing state 2 would offer an invite to someone who already has access.
+
+### Splitting `RolePicker`
+
+`src/components/roles/RolePicker.tsx` welds three things together: option
+selection, the gains/loses delta, and the write. `useAssignRole` at `:84`,
+`commit()` at `:124-153`, and the delta footer at `:273-300` all assume a
+`membershipId` to write to and a *current* role to diff against.
+
+An invite has neither. There is no membership yet, and diffing against "no access"
+would render every grant as a gain — noise, not information.
+
+So `RolePicker.tsx` splits in two:
+
+**`src/components/roles/RoleSelect.tsx`** — the popover, the search box, and the
+two option groups. Controlled:
+
+```ts
+export interface RoleSelectProps {
+  restaurantId: string;
+  /** The signed-in user's role in this restaurant — gates the option list. */
+  callerRole: Role;
+  /** Currently selected role id, or null for "nothing chosen yet". */
+  value: string | null;
+  onSelect: (role: RoleWithGrants) => void;
+  /** Accessible name for the trigger. Hosts differ; see WCAG note below. */
+  triggerLabel: string;
+  /** Visible text on the trigger chip. Must appear inside `triggerLabel`. */
+  triggerText: string;
+  disabled?: boolean;
+  /** Rendered below the list, inside the popover. `RolePicker` puts its delta + commit here. */
+  footer?: ReactNode;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+```
+
+It keeps, unchanged, the filters that Move 1 established:
+`isAssignableCustomRole(r, restaurantId)` and
+`getInvitableRoles(callerRole)` (`RolePicker.tsx:97-103`), the "Only an owner or
+manager can assign a custom role" in-place explanation (`:256-266` — hiding the
+group is what produced the original confusion), and the three explicit list states
+at `:231-249` rendered as direct children of `CommandList`, never through
+`CommandEmpty`.
+
+**`RolePicker.tsx`** — becomes `RoleSelect` plus the delta panel and commit button
+passed as `footer`, holding `candidateId` and the `useAssignRole` mutation. Its
+exported `RolePickerProps` is unchanged, so `TeamMembers.tsx:187`,
+`RoleRoster.tsx:109`, `RolesList.tsx:235`/`:314`, and
+`CollaboratorInvitations.tsx:538` need no edits.
+
+`footer` is a `ReactNode` slot rather than a render prop because the footer's only
+input is the candidate, which `RolePicker` already holds.
+
+The invite branch renders bare `RoleSelect`. That is what makes the prototype's
+claim — *"The invite asks which role, using the same picker"* — literally true
+rather than a lookalike that drifts.
+
+### The trigger's accessible name
+
+`RolePicker.tsx:159` computes `${personName}: role is ${currentLabel}. Change role`.
+WCAG 2.5.3 Label in Name requires the accessible name to *contain* the visible
+text, so a voice-control user saying "click Manager" still hits the control. The
+two hosts word it differently, so it is a prop:
+
+- `RolePicker`: `${personName}: role is ${currentLabel}. Change role` (unchanged)
+- invite branch: `Invite as ${selectedLabel}. Change role`
+
+Both embed the visible chip text.
+
+### Copy that stops lying
+
+The existing hint (`EmployeeDialog.tsx:1146-1149`) hardcodes staff's access:
+
+> Lets them clock in, view their own schedule, and request time off from their
+> phone. They will not see sales, costs, payroll, or other employees.
+
+True of Staff, false of anything else. Once the role is selectable it is replaced
+by the selected role's own `description` plus `<RoleAreaChips areas={role.role_areas} />`
+— the same two fields `RolePicker` already renders per option row
+(`RolePicker.tsx:177-182`). "Add an email address to enable." is unchanged.
+
+Default selection stays **Staff**: least privilege, matches today's behaviour, and
+`getInvitableRoles` returns it for every inviter who can invite at all.
+
+### Caller gating
+
+`callerRole` comes from `useRestaurantContext().selectedRestaurant.role`
+(`useRestaurants.tsx:68`, typed `Role`). `EmployeeDialog` already reads
+`selectedRestaurant` at `:71`.
+
+The dialog takes `restaurantId` as a prop. Both call sites pass the selected
+restaurant (`src/pages/Employees.tsx:137`, `src/pages/Scheduling.tsx:1621`), but
+the row does not assume it: `callerRole` is used only when
+`selectedRestaurant?.restaurant_id === restaurantId`. On a mismatch the role
+renders as a plain read-only label and the invite control is hidden — a caller
+whose reach cannot be established gets no assignment surface.
+
+Within a matching restaurant, reach is whatever `getInvitableRoles` and
+`canInviteCustomRole` already grant, per the decision recorded in the parent
+design: a manager may change someone to any role they could already invite them
+to, custom roles included; owners keep full reach. No new matrix.
+
+### What does not change
+
+- No migration. `assign_membership_role` is Move 1's and is reused as-is.
+- No edge-function change. `send-team-invitation` already accepts `roleId`.
+- The `existingMember` / `linkToExisting` branch (`EmployeeDialog.tsx:1111-1141`,
+  `link_employee_to_user` RPC at `:401`) is untouched. Linking an already-registered account is a
+  different action from inviting a new one, and it already lands the person on a
+  membership whose role state 1 then governs.
+
+## Error handling
+
+| Failure | Behaviour |
+|---------|-----------|
+| `useRestaurantMembers` loading | Skeleton in place of the row. No invite offered — it could be a duplicate. |
+| `useRestaurantMembers` errors | Same skeleton replaced by "Couldn't load access details." No control. Consistent with the fail-closed hint in `resolveAccountlessEmployeeHint`. |
+| `useRoles` loading / errors | `RoleSelect` renders its existing `:231-244` states inside the popover. |
+| Assignment rejected (42501) | `RolePicker`'s existing toast via `assignRoleErrorMessage`. Unchanged. |
+| Invite rejected | Existing `EmployeeDialog.tsx:432-440` toast path, unchanged. The employee is still created — the invite is fire-and-forget by design. |
+
+## Testing
+
+**Unit — `tests/unit/EmployeeDialog.appAccess.test.tsx` (extend):**
+- create mode, switch on, role left at default → invite body carries `role: 'staff'`, no `roleId`
+- create mode, custom role chosen → body carries `role: 'collaborator_custom'` and that role's `roleId`
+- create mode, built-in non-staff chosen → body carries that `role`, no `roleId`
+- edit mode, `user_id` matches a member → "Signed in as", chip shows the member's role
+- edit mode, no `user_id` → "No access", `Invite to the app…`
+- edit mode, `user_id` set with no membership here → state 2, not a `RolePicker` without a membership
+- roster loading → skeleton, no invite control
+- `selectedRestaurant.restaurant_id !== restaurantId` → read-only label
+
+**Unit — `tests/unit/RolePicker.test.tsx`: must pass untouched.** That file is the
+regression gate on the split; if the extraction changed observable behaviour it
+fails here.
+
+**Unit — `tests/unit/RoleSelect.test.tsx` (new):** the option-list filters —
+custom roles gated by `isAssignableCustomRole`, built-ins by
+`getInvitableRoles(callerRole)`, the owner/manager explanation rendering in place
+of rows rather than hiding the group, and the three list states.
+
+**E2E:**
+- `tests/e2e/accountless-employee-invite.spec.ts` — extend with a custom-role invite
+- `tests/e2e/role-assignment.spec.ts` — add changing an employee's role from the
+  edit dialog and confirming it on the Team page, proving both surfaces write the
+  same row
+
+## Files
+
+| Path | Change |
+|------|--------|
+| `src/components/roles/RoleSelect.tsx` | new — controlled option list, extracted from `RolePicker` |
+| `src/components/roles/RolePicker.tsx` | modify — renders `RoleSelect` + delta/commit footer; props unchanged |
+| `src/components/employees/EmployeeAppAccessRow.tsx` | new — the three states |
+| `src/components/EmployeeDialog.tsx` | modify — render the row in both modes; `:429` takes the chosen role |
+| `tests/unit/RoleSelect.test.tsx` | new |
+| `tests/unit/EmployeeDialog.appAccess.test.tsx` | extend |
+| `tests/e2e/accountless-employee-invite.spec.ts` | extend |
+| `tests/e2e/role-assignment.spec.ts` | extend |
+
+## Out of scope
+
+- Revoking app access from the employee dialog. Removing a membership is a Team-page
+  action with its own confirmation; duplicating it here would be a second path to a
+  destructive operation.
+- Changing an employee's role in bulk from the employee list. Move 2's
+  `AssignPeopleDialog` already covers role-first bulk assignment.
+- Any change to `send-team-invitation` or to `assign_membership_role`.

--- a/src/components/EmployeeDialog.tsx
+++ b/src/components/EmployeeDialog.tsx
@@ -878,7 +878,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                       <div className="flex items-start gap-2 rounded-lg bg-amber-500/10 border border-amber-500/20 p-3">
                         <AlertTriangle className="h-4 w-4 text-amber-500 mt-0.5 shrink-0" />
                         <p className="text-[13px] text-amber-700 dark:text-amber-400">
-                          { }
+                          {/* eslint-disable-next-line no-restricted-syntax -- toLocaleString here formats a NUMBER (annualizedPay), not a date; the selector matches any toLocaleString member regardless of receiver type. */}
                           This employee's annualized pay (${annualizedPay.toLocaleString('en-US', { maximumFractionDigits: 0 })}/year) is below the FLSA exempt threshold ($35,568/year). Consult labor law before classifying as exempt.
                         </p>
                       </div>

--- a/src/components/EmployeeDialog.tsx
+++ b/src/components/EmployeeDialog.tsx
@@ -44,10 +44,10 @@ import { useRestaurantContext } from '@/contexts/RestaurantContext';
 import { convertAvailabilityWindowsToUtc } from '@/lib/availabilityTimeUtils';
 import { isActiveForStatus } from '@/utils/employeeFilters';
 import { useRestaurantMembers, findMemberByEmail } from '@/hooks/useRestaurantMembers';
-import { ROLE_METADATA } from '@/lib/permissions/definitions';
-import { CUSTOM_ROLE } from '@/lib/permissions/invitations';
 import { EmployeeAppAccessRow } from '@/components/employees/EmployeeAppAccessRow';
 import type { RoleWithGrants } from '@/hooks/useRoles';
+import { ROLE_METADATA } from '@/lib/permissions/definitions';
+import { CUSTOM_ROLE } from '@/lib/permissions/invitations';
 
 interface EmployeeDialogProps {
   open: boolean;
@@ -212,6 +212,16 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
     setIsEffectiveDateModalOpen(false);
     setPendingCompChange(null);
     setSavingCompHistory(false);
+
+    // The access decision belongs to whoever is on screen right now, so it is
+    // cleared for BOTH branches below. The edit branch re-seeds every other
+    // field from `employee` but has nothing to re-seed these from -- leaving
+    // them alone would carry a role picked for the last person into the next
+    // person's invite payload, and the "Send invite" button doesn't show what
+    // role it is about to send.
+    setAppAccessGrant(false);
+    setAppAccessInviteRole(null);
+    setLinkToExisting(false);
 
     if (employee) {
       setName(employee.name);
@@ -1175,6 +1185,11 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                   showing both options. */}
               {!(isCreateMode && existingMember) && (
                 <EmployeeAppAccessRow
+                  // The row owns "is the invite panel expanded" locally, which
+                  // is per-person state the row has no other way to reset --
+                  // the dialog is reused across employees rather than
+                  // remounted. Keying on the employee remounts just this row.
+                  key={employee?.id ?? 'new'}
                   restaurantId={restaurantId}
                   callerRole={callerRole}
                   employee={employee}

--- a/src/components/EmployeeDialog.tsx
+++ b/src/components/EmployeeDialog.tsx
@@ -45,6 +45,8 @@ import { convertAvailabilityWindowsToUtc } from '@/lib/availabilityTimeUtils';
 import { isActiveForStatus } from '@/utils/employeeFilters';
 import { useRestaurantMembers, findMemberByEmail } from '@/hooks/useRestaurantMembers';
 import { ROLE_METADATA } from '@/lib/permissions/definitions';
+import { EmployeeAppAccessRow } from '@/components/employees/EmployeeAppAccessRow';
+import type { RoleWithGrants } from '@/hooks/useRoles';
 
 interface EmployeeDialogProps {
   open: boolean;
@@ -72,6 +74,15 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
   const restaurantTimezone = safeTz(selectedRestaurant?.restaurant?.timezone);
   // null while loading, on error, and for non-members — all mean "behave normally".
   const existingMember = findMemberByEmail(restaurantMembers, email);
+  // Both call sites pass the selected restaurant (Employees.tsx, Scheduling.tsx),
+  // but a mismatch must not silently borrow another restaurant's role — that
+  // would gate the app-access row on the wrong permissions.
+  const callerRole =
+    selectedRestaurant?.restaurant_id === restaurantId ? selectedRestaurant.role : null;
+  // Local to the app-access row — kept separate from `grantAppAccess` above,
+  // which drives the create-mode invite flow and is left untouched here.
+  const [appAccessGrant, setAppAccessGrant] = useState(false);
+  const [appAccessInviteRole, setAppAccessInviteRole] = useState<RoleWithGrants | null>(null);
   const [phone, setPhone] = useState('');
   const [position, setPosition] = useState('Server');
   const [area, setArea] = useState('');
@@ -816,7 +827,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                       <div className="flex items-start gap-2 rounded-lg bg-amber-500/10 border border-amber-500/20 p-3">
                         <AlertTriangle className="h-4 w-4 text-amber-500 mt-0.5 shrink-0" />
                         <p className="text-[13px] text-amber-700 dark:text-amber-400">
-                          {/* eslint-disable-next-line no-restricted-syntax -- toLocaleString here formats a NUMBER (annualizedPay), not a date; the selector matches any toLocaleString member regardless of receiver type. */}
+                          { }
                           This employee's annualized pay (${annualizedPay.toLocaleString('en-US', { maximumFractionDigits: 0 })}/year) is below the FLSA exempt threshold ($35,568/year). Consult labor law before classifying as exempt.
                         </p>
                       </div>
@@ -1106,6 +1117,17 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                   />
                 </div>
               </div>
+
+              <EmployeeAppAccessRow
+                restaurantId={restaurantId}
+                callerRole={callerRole}
+                employee={employee}
+                email={email}
+                grantAppAccess={appAccessGrant}
+                onGrantAppAccessChange={setAppAccessGrant}
+                inviteRole={appAccessInviteRole}
+                onInviteRoleChange={setAppAccessInviteRole}
+              />
 
               {isCreateMode && (existingMember ? (
                 <div className="rounded-lg border border-border/40 bg-muted/30 p-3 space-y-2">

--- a/src/components/EmployeeDialog.tsx
+++ b/src/components/EmployeeDialog.tsx
@@ -45,6 +45,7 @@ import { convertAvailabilityWindowsToUtc } from '@/lib/availabilityTimeUtils';
 import { isActiveForStatus } from '@/utils/employeeFilters';
 import { useRestaurantMembers, findMemberByEmail } from '@/hooks/useRestaurantMembers';
 import { ROLE_METADATA } from '@/lib/permissions/definitions';
+import { CUSTOM_ROLE } from '@/lib/permissions/invitations';
 import { EmployeeAppAccessRow } from '@/components/employees/EmployeeAppAccessRow';
 import type { RoleWithGrants } from '@/hooks/useRoles';
 
@@ -60,8 +61,13 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
   const [email, setEmail] = useState('');
   // Access is opt-in and separate from the email field. Typing an email used to
   // silently provision a staff login — that unlabelled side effect is the bug
-  // this switch exists to remove.
-  const [grantAppAccess, setGrantAppAccess] = useState(false);
+  // this switch exists to remove. Drives both the create-mode invite (below)
+  // and the EmployeeAppAccessRow's own switch — there is only one decision
+  // to make about a given email, not two.
+  const [appAccessGrant, setAppAccessGrant] = useState(false);
+  // The role chosen in EmployeeAppAccessRow's picker. null means "unchosen" —
+  // the invite payload then defaults to staff, same as before this picker existed.
+  const [appAccessInviteRole, setAppAccessInviteRole] = useState<RoleWithGrants | null>(null);
   // Offered instead of inviting when the typed email already belongs to a team
   // member — linking avoids double-provisioning a second account for the same person.
   const [linkToExisting, setLinkToExisting] = useState(false);
@@ -79,10 +85,6 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
   // would gate the app-access row on the wrong permissions.
   const callerRole =
     selectedRestaurant?.restaurant_id === restaurantId ? selectedRestaurant.role : null;
-  // Local to the app-access row — kept separate from `grantAppAccess` above,
-  // which drives the create-mode invite flow and is left untouched here.
-  const [appAccessGrant, setAppAccessGrant] = useState(false);
-  const [appAccessInviteRole, setAppAccessInviteRole] = useState<RoleWithGrants | null>(null);
   const [phone, setPhone] = useState('');
   const [position, setPosition] = useState('Server');
   const [area, setArea] = useState('');
@@ -237,14 +239,16 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
   // from the new value, so the correct panel re-appears on the next keystroke.
   const handleEmailChange = (value: string) => {
     setEmail(value);
-    setGrantAppAccess(false);
+    setAppAccessGrant(false);
+    setAppAccessInviteRole(null);
     setLinkToExisting(false);
   };
 
   const resetForm = () => {
     setName('');
     setEmail('');
-    setGrantAppAccess(false);
+    setAppAccessGrant(false);
+    setAppAccessInviteRole(null);
     setLinkToExisting(false);
     setPhone('');
     setPosition('Server');
@@ -432,13 +436,18 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
         } else {
           toast({ title: 'Employee created', description: `${name} was added.` });
         }
-      } else if (grantAppAccess && email?.trim()) {
+      } else if (appAccessGrant && email?.trim()) {
+        // roleId must be ABSENT (not undefined) for a non-custom role —
+        // send-team-invitation/index.ts:111 rejects the pairing when
+        // role !== CUSTOM_ROLE && roleId.
+        const isCustomRole = appAccessInviteRole && appAccessInviteRole.legacy_role === null;
         supabase.functions.invoke('send-team-invitation', {
           body: {
             restaurantId: restaurantId,
             email: email.trim(),
-            role: 'staff',
+            role: isCustomRole ? CUSTOM_ROLE : (appAccessInviteRole?.legacy_role ?? 'staff'),
             employeeId: newEmployee.id, // Pass employee ID for linking
+            ...(isCustomRole ? { roleId: appAccessInviteRole.id } : {}),
           },
         }).then(({ error }) => {
           if (error) {
@@ -1118,18 +1127,24 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                 </div>
               </div>
 
-              <EmployeeAppAccessRow
-                restaurantId={restaurantId}
-                callerRole={callerRole}
-                employee={employee}
-                email={email}
-                grantAppAccess={appAccessGrant}
-                onGrantAppAccessChange={setAppAccessGrant}
-                inviteRole={appAccessInviteRole}
-                onInviteRoleChange={setAppAccessInviteRole}
-              />
+              {/* An existing member matching the typed email offers linking
+                  instead — the invite switch below would double-provision
+                  the same person, so the row is skipped entirely rather than
+                  showing both options. */}
+              {!(isCreateMode && existingMember) && (
+                <EmployeeAppAccessRow
+                  restaurantId={restaurantId}
+                  callerRole={callerRole}
+                  employee={employee}
+                  email={email}
+                  grantAppAccess={appAccessGrant}
+                  onGrantAppAccessChange={setAppAccessGrant}
+                  inviteRole={appAccessInviteRole}
+                  onInviteRoleChange={setAppAccessInviteRole}
+                />
+              )}
 
-              {isCreateMode && (existingMember ? (
+              {isCreateMode && existingMember && (
                 <div className="rounded-lg border border-border/40 bg-muted/30 p-3 space-y-2">
                   <div className="flex items-start gap-2 rounded-lg bg-amber-500/10 border border-amber-500/20 p-2.5">
                     <AlertTriangle className="h-4 w-4 text-muted-foreground mt-0.5 shrink-0" />
@@ -1159,34 +1174,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                     />
                   </div>
                 </div>
-              ) : (
-                <div className="flex items-center justify-between rounded-lg border border-border/40 bg-muted/30 p-3">
-                  <div className="space-y-0.5 pr-4">
-                    <Label htmlFor="grantAppAccess" className="text-[14px] font-medium text-foreground cursor-pointer">
-                      Invite to the employee app
-                    </Label>
-                    <p id="grantAppAccessHint" className="text-[13px] text-muted-foreground">
-                      {email.trim()
-                        ? 'Lets them clock in, view their own schedule, and request time off from their phone. They will not see sales, costs, payroll, or other employees.'
-                        : 'Add an email address to enable.'}
-                    </p>
-                  </div>
-                  <Switch
-                    id="grantAppAccess"
-                    checked={grantAppAccess}
-                    // aria-disabled rather than disabled: a disabled Switch leaves
-                    // the tab order, so a keyboard user never hears why it is off.
-                    aria-disabled={!email.trim() ? true : undefined}
-                    aria-describedby="grantAppAccessHint"
-                    onCheckedChange={(checked) => {
-                      if (!email.trim()) return;
-                      setGrantAppAccess(checked);
-                    }}
-                    className="data-[state=checked]:bg-foreground aria-disabled:opacity-50 aria-disabled:cursor-not-allowed"
-                    aria-label="Invite to the employee app"
-                  />
-                </div>
-              ))}
+              )}
 
               <div className="grid grid-cols-3 gap-4">
                 <div className="space-y-2">

--- a/src/components/EmployeeDialog.tsx
+++ b/src/components/EmployeeDialog.tsx
@@ -56,6 +56,19 @@ interface EmployeeDialogProps {
   restaurantId: string;
 }
 
+// Shared by the create-mode invite (fired on submit) and the edit-mode invite
+// (fired immediately from the row) so the two call sites cannot build the
+// payload differently. roleId must be ABSENT (not undefined) for a non-custom
+// role — send-team-invitation/index.ts:111 rejects the pairing when
+// role !== CUSTOM_ROLE && roleId.
+function invitePayloadFor(role: RoleWithGrants | null) {
+  const isCustomRole = !!role && role.legacy_role === null;
+  return {
+    role: isCustomRole ? CUSTOM_ROLE : (role?.legacy_role ?? 'staff'),
+    ...(isCustomRole ? { roleId: role.id } : {}),
+  };
+}
+
 export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: EmployeeDialogProps) => {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
@@ -68,6 +81,9 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
   // The role chosen in EmployeeAppAccessRow's picker. null means "unchosen" —
   // the invite payload then defaults to staff, same as before this picker existed.
   const [appAccessInviteRole, setAppAccessInviteRole] = useState<RoleWithGrants | null>(null);
+  // Edit-mode invite (EmployeeAppAccessRow's "Send invite" button) fires
+  // immediately, not on Save — this tracks that in-flight request only.
+  const [sendingInvite, setSendingInvite] = useState(false);
   // Offered instead of inviting when the typed email already belongs to a team
   // member — linking avoids double-provisioning a second account for the same person.
   const [linkToExisting, setLinkToExisting] = useState(false);
@@ -437,17 +453,12 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
           toast({ title: 'Employee created', description: `${name} was added.` });
         }
       } else if (appAccessGrant && email?.trim()) {
-        // roleId must be ABSENT (not undefined) for a non-custom role —
-        // send-team-invitation/index.ts:111 rejects the pairing when
-        // role !== CUSTOM_ROLE && roleId.
-        const isCustomRole = appAccessInviteRole && appAccessInviteRole.legacy_role === null;
         supabase.functions.invoke('send-team-invitation', {
           body: {
             restaurantId: restaurantId,
             email: email.trim(),
-            role: isCustomRole ? CUSTOM_ROLE : (appAccessInviteRole?.legacy_role ?? 'staff'),
+            ...invitePayloadFor(appAccessInviteRole),
             employeeId: newEmployee.id, // Pass employee ID for linking
-            ...(isCustomRole ? { roleId: appAccessInviteRole.id } : {}),
           },
         }).then(({ error }) => {
           if (error) {
@@ -477,6 +488,37 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
       resetForm();
     } catch (error) {
       console.error('Error creating employee', error);
+    }
+  };
+
+  // Fires immediately from EmployeeAppAccessRow's "Send invite" button — not
+  // on Save. The edit path has two exits below (a plain update, and a
+  // compensation-change detour through the effective-date modal); hanging an
+  // outward-facing email off either would be three trigger sites for the same
+  // action instead of one.
+  const handleSendInvite = async () => {
+    if (!employee?.email) return;
+    setSendingInvite(true);
+    try {
+      const { error } = await supabase.functions.invoke('send-team-invitation', {
+        body: {
+          restaurantId,
+          email: employee.email,
+          ...invitePayloadFor(appAccessInviteRole),
+          employeeId: employee.id,
+        },
+      });
+      if (error) throw error;
+      toast({ title: `Invitation sent to ${employee.email}` });
+    } catch (e) {
+      console.error('Error sending invitation:', e);
+      toast({
+        title: "Couldn't send the invitation",
+        description: 'Please try again.',
+        variant: 'destructive',
+      });
+    } finally {
+      setSendingInvite(false);
     }
   };
 
@@ -1141,6 +1183,8 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                   onGrantAppAccessChange={setAppAccessGrant}
                   inviteRole={appAccessInviteRole}
                   onInviteRoleChange={setAppAccessInviteRole}
+                  onSendInvite={!isCreateMode ? handleSendInvite : undefined}
+                  sendingInvite={sendingInvite}
                 />
               )}
 

--- a/src/components/EmployeeDialog.tsx
+++ b/src/components/EmployeeDialog.tsx
@@ -207,6 +207,16 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
 
   const bulkSetAvailability = useBulkSetAvailability({ silent: true });
 
+  // The zone changing has to re-seed the effective date -- see `getToday`'s
+  // useCallback above. It gets its own effect rather than riding along in the
+  // reset below: that one re-seeds every field from `employee` and clears the
+  // access decision, so hanging it off the zone would let a settings change
+  // made anywhere else in the app silently discard what the admin has typed
+  // and the role they just picked, with the dialog open in front of them.
+  useEffect(() => {
+    setEffectiveDate(getToday());
+  }, [getToday]);
+
   useEffect(() => {
     setEffectiveDate(getToday());
     setIsEffectiveDateModalOpen(false);
@@ -255,9 +265,11 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
     } else {
       resetForm();
     }
-    // `getToday` is tz-derived, so the zone changing has to re-seed the
-    // effective date -- see its useCallback above.
-  }, [employee, open, getToday]);
+    // Deliberately NOT depending on `getToday`: this effect is "the person on
+    // screen changed", and the zone is not the person. The effect above owns
+    // the tz re-seed.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [employee, open]);
 
   // Editing the email invalidates the access decision the user made against the
   // previous address (grant a new login vs. link to whoever that email belongs

--- a/src/components/employees/EmployeeAppAccessRow.tsx
+++ b/src/components/employees/EmployeeAppAccessRow.tsx
@@ -62,6 +62,7 @@ export function EmployeeAppAccessRow({
 }: EmployeeAppAccessRowProps) {
   const { data: members, isLoading, isError } = useRestaurantMembers(restaurantId);
   const [inviteExpanded, setInviteExpanded] = useState(false);
+  const [pickerOpen, setPickerOpen] = useState(false);
 
   if (isLoading) return <AppAccessSkeleton />;
   if (isError) {
@@ -129,6 +130,29 @@ export function EmployeeAppAccessRow({
 
   const inviteLabel = inviteRole?.name ?? ROLE_METADATA.staff.label;
 
+  // Both invite branches below render the same picker, so they share one set
+  // of props — and one open state, since only one of them is ever mounted.
+  //
+  // Closing on select is the difference between this picker and RolePicker's.
+  // There, the choice is a candidate: the footer shows the access delta and a
+  // commit button, so the popover has to stay open until the assignment lands.
+  // Here the choice IS the whole action — there is no footer and nothing left
+  // to confirm — so leaving it open would just park a 340px panel over the
+  // rest of the form.
+  const invitePickerProps = {
+    restaurantId,
+    callerRole,
+    value: inviteRole?.id ?? null,
+    onSelect: (role: RoleWithGrants) => {
+      onInviteRoleChange(role);
+      setPickerOpen(false);
+    },
+    triggerText: inviteLabel,
+    triggerLabel: `Invite as ${inviteLabel}. Change role`,
+    open: pickerOpen,
+    onOpenChange: setPickerOpen,
+  };
+
   // Edit mode: `onSendInvite` is only ever passed for an existing employee
   // record, so `employee` is defined here too — its SAVED email (not
   // whatever is currently typed in the dialog's field) is what the invite
@@ -159,14 +183,7 @@ export function EmployeeAppAccessRow({
           </Button>
         ) : (
           <>
-            <RoleSelect
-              restaurantId={restaurantId}
-              callerRole={callerRole}
-              value={inviteRole?.id ?? null}
-              onSelect={onInviteRoleChange}
-              triggerText={inviteLabel}
-              triggerLabel={`Invite as ${inviteLabel}. Change role`}
-            />
+            <RoleSelect {...invitePickerProps} />
             {inviteRole && <RoleAreaChips areas={inviteRole.role_areas} />}
             <Button
               type="button"
@@ -224,14 +241,7 @@ export function EmployeeAppAccessRow({
       </p>
       {grantAppAccess && email.trim() && (
         <>
-          <RoleSelect
-            restaurantId={restaurantId}
-            callerRole={callerRole}
-            value={inviteRole?.id ?? null}
-            onSelect={onInviteRoleChange}
-            triggerText={inviteLabel}
-            triggerLabel={`Invite as ${inviteLabel}. Change role`}
-          />
+          <RoleSelect {...invitePickerProps} />
           {inviteRole && <RoleAreaChips areas={inviteRole.role_areas} />}
         </>
       )}

--- a/src/components/employees/EmployeeAppAccessRow.tsx
+++ b/src/components/employees/EmployeeAppAccessRow.tsx
@@ -4,7 +4,7 @@ import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { RolePicker } from '@/components/roles/RolePicker';
-import { RoleSelect } from '@/components/roles/RoleSelect';
+import { RoleSelect, type RoleSelectProps } from '@/components/roles/RoleSelect';
 import { RoleAreaChips } from '@/components/roles/RoleAreaChips';
 import { useRestaurantMembers } from '@/hooks/useRestaurantMembers';
 import type { RoleWithGrants } from '@/hooks/useRoles';
@@ -32,17 +32,8 @@ export interface EmployeeAppAccessRowProps {
   sendingInvite?: boolean;
 }
 
-function AppAccessSkeleton() {
-  return (
-    <div className="rounded-lg border border-border/40 bg-muted/30 p-3 space-y-2">
-      <Skeleton className="h-3 w-20" />
-      <Skeleton className="h-4 w-48" />
-    </div>
-  );
-}
-
-/** The card shell every non-loading, non-error state below shares — the "App
- * access" label plus the same border/background. Only the body differs. */
+/** The card shell every state below shares — the "App access" label plus the
+ * same border/background. Only the body differs. */
 function AppAccessCard({ children }: { children: ReactNode }) {
   return (
     <div className="rounded-lg border border-border/40 bg-muted/30 p-3 space-y-2">
@@ -54,11 +45,89 @@ function AppAccessCard({ children }: { children: ReactNode }) {
   );
 }
 
+function AppAccessSkeleton() {
+  return (
+    <AppAccessCard>
+      <Skeleton className="h-4 w-48" />
+    </AppAccessCard>
+  );
+}
+
 /** ROLE_METADATA doesn't have an entry for the bare collaborator_custom
  * literal (see CUSTOM_ROLE in invitations.ts) — mirrors the fallback
  * RolePicker.tsx uses for its own currentLabel. */
 function roleLabelFor(role: string): string {
   return ROLE_METADATA[role as Role]?.label ?? (role === CUSTOM_ROLE ? 'Custom role' : role);
+}
+
+/** Named against RoleSelect's own props so a typo lands on the object literal
+ * that builds it rather than at the spread site. */
+type InvitePickerProps = Pick<
+  RoleSelectProps,
+  'restaurantId' | 'callerRole' | 'value' | 'onSelect' | 'triggerText' | 'triggerLabel' | 'open' | 'onOpenChange'
+>;
+
+/** Edit mode: the invite fires on its own button rather than on the dialog's
+ * Save, so it lives behind a disclosure instead of sitting open next to
+ * unrelated fields. Three states, each its own early return. */
+function EditModeInvite({
+  savedEmail,
+  typedEmailDiffers,
+  expanded,
+  onExpand,
+  picker,
+  inviteRole,
+  onSendInvite,
+  sendingInvite,
+}: {
+  savedEmail: string | undefined;
+  typedEmailDiffers: boolean;
+  expanded: boolean;
+  onExpand: () => void;
+  picker: InvitePickerProps;
+  inviteRole: RoleWithGrants | null;
+  onSendInvite: () => void;
+  sendingInvite?: boolean;
+}) {
+  if (!savedEmail) {
+    return (
+      <p className="text-[13px] text-muted-foreground">
+        Add an email address and save before inviting this employee to the app.
+      </p>
+    );
+  }
+
+  if (!expanded) {
+    return (
+      <Button
+        type="button"
+        variant="ghost"
+        onClick={onExpand}
+        className="h-9 px-4 -ml-4 rounded-lg text-[13px] font-medium text-muted-foreground hover:text-foreground"
+      >
+        Invite to the app…
+      </Button>
+    );
+  }
+
+  return (
+    <>
+      <RoleSelect {...picker} />
+      {inviteRole && <RoleAreaChips areas={inviteRole.role_areas} />}
+      <Button
+        type="button"
+        variant="ghost"
+        onClick={onSendInvite}
+        disabled={sendingInvite || typedEmailDiffers}
+        className="h-9 px-4 -ml-4 rounded-lg text-[13px] font-medium text-muted-foreground hover:text-foreground"
+      >
+        {sendingInvite ? 'Sending…' : 'Send invite'}
+      </Button>
+      {typedEmailDiffers && (
+        <p className="text-[13px] text-muted-foreground">Save the email change before inviting.</p>
+      )}
+    </>
+  );
 }
 
 export function EmployeeAppAccessRow({
@@ -80,12 +149,11 @@ export function EmployeeAppAccessRow({
   if (isLoading) return <AppAccessSkeleton />;
   if (isError) {
     return (
-      <div
-        role="alert"
-        className="rounded-lg border border-border/40 bg-muted/30 p-3 text-[13px] text-muted-foreground"
-      >
-        Couldn't load access details.
-      </div>
+      <AppAccessCard>
+        <p role="alert" className="text-[13px] text-muted-foreground">
+          Couldn't load access details.
+        </p>
+      </AppAccessCard>
     );
   }
 
@@ -102,8 +170,17 @@ export function EmployeeAppAccessRow({
     // to fall back to a read-only display of the same information.
     return (
       <AppAccessCard>
+        {/* RestaurantMember.email is nullable -- the roster reads it from a
+            joined profiles row that may not have one. "Signed in as" trailing
+            off into nothing reads like a rendering bug, so name the state. */}
         <p className="text-[13px] text-muted-foreground truncate">
-          Signed in as <span className="text-foreground">{member.email}</span>
+          {member.email ? (
+            <>
+              Signed in as <span className="text-foreground">{member.email}</span>
+            </>
+          ) : (
+            'Signed in to the app'
+          )}
         </p>
         {callerRole ? (
           <RolePicker
@@ -149,7 +226,7 @@ export function EmployeeAppAccessRow({
   // Here the choice IS the whole action — there is no footer and nothing left
   // to confirm — so leaving it open would just park a 340px panel over the
   // rest of the form.
-  const invitePickerProps = {
+  const invitePickerProps: InvitePickerProps = {
     restaurantId,
     callerRole,
     value: inviteRole?.id ?? null,
@@ -170,44 +247,26 @@ export function EmployeeAppAccessRow({
   // associates with this employee record.
   if (onSendInvite) {
     const savedEmail = employee?.email?.trim();
-    const typedEmailDiffers = !!savedEmail && email.trim() !== savedEmail;
+    // Case-insensitively, for the reason findMemberByEmail documents:
+    // profiles.email is plain TEXT, not CITEXT, so the same address can come
+    // back in a different case than the user types it. Comparing strictly
+    // would block the invite over a capital letter.
+    const typedEmailDiffers =
+      !!savedEmail && email.trim().toLowerCase() !== savedEmail.toLowerCase();
 
     return (
       <AppAccessCard>
         <p className="text-[13px] text-muted-foreground">No access</p>
-        {!savedEmail ? (
-          <p className="text-[13px] text-muted-foreground">
-            Add an email address and save before inviting this employee to the app.
-          </p>
-        ) : !inviteExpanded ? (
-          <Button
-            type="button"
-            variant="ghost"
-            onClick={() => setInviteExpanded(true)}
-            className="h-9 px-4 -ml-4 rounded-lg text-[13px] font-medium text-muted-foreground hover:text-foreground"
-          >
-            Invite to the app…
-          </Button>
-        ) : (
-          <>
-            <RoleSelect {...invitePickerProps} />
-            {inviteRole && <RoleAreaChips areas={inviteRole.role_areas} />}
-            <Button
-              type="button"
-              variant="ghost"
-              onClick={onSendInvite}
-              disabled={sendingInvite || !savedEmail || typedEmailDiffers}
-              className="h-9 px-4 -ml-4 rounded-lg text-[13px] font-medium text-muted-foreground hover:text-foreground"
-            >
-              {sendingInvite ? 'Sending…' : 'Send invite'}
-            </Button>
-            {typedEmailDiffers && (
-              <p className="text-[13px] text-muted-foreground">
-                Save the email change before inviting.
-              </p>
-            )}
-          </>
-        )}
+        <EditModeInvite
+          savedEmail={savedEmail}
+          typedEmailDiffers={typedEmailDiffers}
+          expanded={inviteExpanded}
+          onExpand={() => setInviteExpanded(true)}
+          picker={invitePickerProps}
+          inviteRole={inviteRole}
+          onSendInvite={onSendInvite}
+          sendingInvite={sendingInvite}
+        />
       </AppAccessCard>
     );
   }

--- a/src/components/employees/EmployeeAppAccessRow.tsx
+++ b/src/components/employees/EmployeeAppAccessRow.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
@@ -37,6 +37,19 @@ function AppAccessSkeleton() {
     <div className="rounded-lg border border-border/40 bg-muted/30 p-3 space-y-2">
       <Skeleton className="h-3 w-20" />
       <Skeleton className="h-4 w-48" />
+    </div>
+  );
+}
+
+/** The card shell every non-loading, non-error state below shares — the "App
+ * access" label plus the same border/background. Only the body differs. */
+function AppAccessCard({ children }: { children: ReactNode }) {
+  return (
+    <div className="rounded-lg border border-border/40 bg-muted/30 p-3 space-y-2">
+      <Label className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
+        App access
+      </Label>
+      {children}
     </div>
   );
 }
@@ -88,10 +101,7 @@ export function EmployeeAppAccessRow({
     // definite role to gate its option list) is safe to render, or whether
     // to fall back to a read-only display of the same information.
     return (
-      <div className="rounded-lg border border-border/40 bg-muted/30 p-3 space-y-2">
-        <Label className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
-          App access
-        </Label>
+      <AppAccessCard>
         <p className="text-[13px] text-muted-foreground truncate">
           Signed in as <span className="text-foreground">{member.email}</span>
         </p>
@@ -111,7 +121,7 @@ export function EmployeeAppAccessRow({
           Roles belong to the EasyShiftHQ account, not the employee record — the same control
           appears on Team members.
         </p>
-      </div>
+      </AppAccessCard>
     );
   }
 
@@ -163,10 +173,7 @@ export function EmployeeAppAccessRow({
     const typedEmailDiffers = !!savedEmail && email.trim() !== savedEmail;
 
     return (
-      <div className="rounded-lg border border-border/40 bg-muted/30 p-3 space-y-2">
-        <Label className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
-          App access
-        </Label>
+      <AppAccessCard>
         <p className="text-[13px] text-muted-foreground">No access</p>
         {!savedEmail ? (
           <p className="text-[13px] text-muted-foreground">
@@ -201,15 +208,12 @@ export function EmployeeAppAccessRow({
             )}
           </>
         )}
-      </div>
+      </AppAccessCard>
     );
   }
 
   return (
-    <div className="rounded-lg border border-border/40 bg-muted/30 p-3 space-y-2">
-      <Label className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
-        App access
-      </Label>
+    <AppAccessCard>
       <p className="text-[13px] text-muted-foreground">No access</p>
       <div className="flex items-center justify-between">
         <Label
@@ -245,6 +249,6 @@ export function EmployeeAppAccessRow({
           {inviteRole && <RoleAreaChips areas={inviteRole.role_areas} />}
         </>
       )}
-    </div>
+    </AppAccessCard>
   );
 }

--- a/src/components/employees/EmployeeAppAccessRow.tsx
+++ b/src/components/employees/EmployeeAppAccessRow.tsx
@@ -2,6 +2,8 @@ import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Skeleton } from '@/components/ui/skeleton';
 import { RolePicker } from '@/components/roles/RolePicker';
+import { RoleSelect } from '@/components/roles/RoleSelect';
+import { RoleAreaChips } from '@/components/roles/RoleAreaChips';
 import { useRestaurantMembers } from '@/hooks/useRestaurantMembers';
 import type { RoleWithGrants } from '@/hooks/useRoles';
 import { isInternalTeamRole } from '@/lib/permissions/roleMembership';
@@ -48,8 +50,11 @@ export function EmployeeAppAccessRow({
   restaurantId,
   callerRole,
   employee,
+  email,
   grantAppAccess,
   onGrantAppAccessChange,
+  inviteRole,
+  onInviteRoleChange,
 }: EmployeeAppAccessRowProps) {
   const { data: members, isLoading, isError } = useRestaurantMembers(restaurantId);
 
@@ -111,7 +116,13 @@ export function EmployeeAppAccessRow({
   // confident lie about someone with full access. A null callerRole (e.g. a
   // restaurant-context mismatch) gets the same treatment: we don't know it's
   // safe to say "no account", so say nothing.
-  if (!isInternalTeamRole(callerRole)) return null;
+  //
+  // The `!callerRole ||` half narrows callerRole to non-null for the rest of
+  // this branch (isInternalTeamRole itself returns a plain boolean, not a
+  // type predicate) — RoleSelect below requires a definite Role.
+  if (!callerRole || !isInternalTeamRole(callerRole)) return null;
+
+  const inviteLabel = inviteRole?.name ?? ROLE_METADATA.staff.label;
 
   return (
     <div className="rounded-lg border border-border/40 bg-muted/30 p-3 space-y-2">
@@ -121,19 +132,45 @@ export function EmployeeAppAccessRow({
       <p className="text-[13px] text-muted-foreground">No access</p>
       <div className="flex items-center justify-between">
         <Label
-          htmlFor="employeeAppAccessInvite"
+          htmlFor="grantAppAccess"
           className="text-[14px] font-medium text-foreground cursor-pointer"
         >
-          Invite to the app
+          Invite to the employee app
         </Label>
         <Switch
-          id="employeeAppAccessInvite"
+          id="grantAppAccess"
           checked={grantAppAccess}
-          onCheckedChange={onGrantAppAccessChange}
-          className="data-[state=checked]:bg-foreground"
-          aria-label="Invite to the app"
+          // aria-disabled rather than disabled: a disabled Switch leaves
+          // the tab order, so a keyboard user never hears why it is off.
+          aria-disabled={!email.trim() ? true : undefined}
+          aria-describedby="grantAppAccessHint"
+          onCheckedChange={(checked) => {
+            if (!email.trim()) return;
+            onGrantAppAccessChange(checked);
+          }}
+          className="data-[state=checked]:bg-foreground aria-disabled:opacity-50 aria-disabled:cursor-not-allowed"
+          aria-label="Invite to the employee app"
         />
       </div>
+      <p id="grantAppAccessHint" className="text-[13px] text-muted-foreground">
+        {!email.trim()
+          ? 'Add an email address to enable.'
+          : inviteRole?.description ??
+            'Lets them clock in, view their own schedule, and request time off from their phone.'}
+      </p>
+      {grantAppAccess && email.trim() && (
+        <>
+          <RoleSelect
+            restaurantId={restaurantId}
+            callerRole={callerRole}
+            value={inviteRole?.id ?? null}
+            onSelect={onInviteRoleChange}
+            triggerText={inviteLabel}
+            triggerLabel={`Invite as ${inviteLabel}. Change role`}
+          />
+          {inviteRole && <RoleAreaChips areas={inviteRole.role_areas} />}
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/employees/EmployeeAppAccessRow.tsx
+++ b/src/components/employees/EmployeeAppAccessRow.tsx
@@ -1,0 +1,139 @@
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Skeleton } from '@/components/ui/skeleton';
+import { RolePicker } from '@/components/roles/RolePicker';
+import { useRestaurantMembers } from '@/hooks/useRestaurantMembers';
+import type { RoleWithGrants } from '@/hooks/useRoles';
+import { isInternalTeamRole } from '@/lib/permissions/roleMembership';
+import { ROLE_METADATA } from '@/lib/permissions/definitions';
+import { CUSTOM_ROLE } from '@/lib/permissions/invitations';
+import type { Role } from '@/lib/permissions/types';
+import type { Employee } from '@/types/scheduling';
+
+export interface EmployeeAppAccessRowProps {
+  restaurantId: string;
+  /** Caller's role in THIS restaurant, or null when it can't be established. */
+  callerRole: Role | null;
+  /** Undefined in create mode. */
+  employee?: Employee;
+  /** Email currently typed in the dialog. */
+  email: string;
+  grantAppAccess: boolean;
+  onGrantAppAccessChange: (next: boolean) => void;
+  /** Chosen invite role. null means "unchosen" — the payload then defaults to staff. */
+  inviteRole: RoleWithGrants | null;
+  onInviteRoleChange: (role: RoleWithGrants) => void;
+  /** Provided in edit mode only. Sends immediately. */
+  onSendInvite?: () => void;
+  sendingInvite?: boolean;
+}
+
+function AppAccessSkeleton() {
+  return (
+    <div className="rounded-lg border border-border/40 bg-muted/30 p-3 space-y-2">
+      <Skeleton className="h-3 w-20" />
+      <Skeleton className="h-4 w-48" />
+    </div>
+  );
+}
+
+/** ROLE_METADATA doesn't have an entry for the bare collaborator_custom
+ * literal (see CUSTOM_ROLE in invitations.ts) — mirrors the fallback
+ * RolePicker.tsx uses for its own currentLabel. */
+function roleLabelFor(role: string): string {
+  return ROLE_METADATA[role as Role]?.label ?? (role === CUSTOM_ROLE ? 'Custom role' : role);
+}
+
+export function EmployeeAppAccessRow({
+  restaurantId,
+  callerRole,
+  employee,
+  grantAppAccess,
+  onGrantAppAccessChange,
+}: EmployeeAppAccessRowProps) {
+  const { data: members, isLoading, isError } = useRestaurantMembers(restaurantId);
+
+  if (isLoading) return <AppAccessSkeleton />;
+  if (isError) {
+    return (
+      <div
+        role="alert"
+        className="rounded-lg border border-border/40 bg-muted/30 p-3 text-[13px] text-muted-foreground"
+      >
+        Couldn't load access details.
+      </div>
+    );
+  }
+
+  const member = employee?.user_id
+    ? members?.find((m) => m.userId === employee.user_id) ?? null
+    : null;
+
+  if (member) {
+    // The data already came back from a query RLS approved for the real
+    // caller — that alone proves this is safe to show, regardless of
+    // whether the client-side `callerRole` guess is trustworthy. What
+    // `callerRole` decides is only whether the RolePicker (which needs a
+    // definite role to gate its option list) is safe to render, or whether
+    // to fall back to a read-only display of the same information.
+    return (
+      <div className="rounded-lg border border-border/40 bg-muted/30 p-3 space-y-2">
+        <Label className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
+          App access
+        </Label>
+        <p className="text-[13px] text-muted-foreground truncate">
+          Signed in as <span className="text-foreground">{member.email}</span>
+        </p>
+        {callerRole ? (
+          <RolePicker
+            membershipId={member.membershipId}
+            restaurantId={restaurantId}
+            personName={employee?.name ?? member.fullName ?? 'this member'}
+            currentRole={member.role}
+            currentRoleId={member.roleId}
+            callerRole={callerRole}
+          />
+        ) : (
+          <p className="text-[14px] font-medium text-foreground">{roleLabelFor(member.role)}</p>
+        )}
+        <p className="text-[13px] text-muted-foreground">
+          Roles belong to the EasyShiftHQ account, not the employee record — the same control
+          appears on Team members.
+        </p>
+      </div>
+    );
+  }
+
+  // No linked account was found. RLS on user_restaurants
+  // (20260120100000:201-212) returns every row only to internal team roles —
+  // to a collaborator, the roster is just their own row, so a miss here means
+  // "cannot see", not "no account". Saying "No access" here would be a
+  // confident lie about someone with full access. A null callerRole (e.g. a
+  // restaurant-context mismatch) gets the same treatment: we don't know it's
+  // safe to say "no account", so say nothing.
+  if (!isInternalTeamRole(callerRole)) return null;
+
+  return (
+    <div className="rounded-lg border border-border/40 bg-muted/30 p-3 space-y-2">
+      <Label className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
+        App access
+      </Label>
+      <p className="text-[13px] text-muted-foreground">No access</p>
+      <div className="flex items-center justify-between">
+        <Label
+          htmlFor="employeeAppAccessInvite"
+          className="text-[14px] font-medium text-foreground cursor-pointer"
+        >
+          Invite to the app
+        </Label>
+        <Switch
+          id="employeeAppAccessInvite"
+          checked={grantAppAccess}
+          onCheckedChange={onGrantAppAccessChange}
+          className="data-[state=checked]:bg-foreground"
+          aria-label="Invite to the app"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/employees/EmployeeAppAccessRow.tsx
+++ b/src/components/employees/EmployeeAppAccessRow.tsx
@@ -6,11 +6,12 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { RolePicker } from '@/components/roles/RolePicker';
 import { RoleSelect, type RoleSelectProps } from '@/components/roles/RoleSelect';
 import { RoleAreaChips } from '@/components/roles/RoleAreaChips';
+import { useAuth } from '@/hooks/useAuth';
 import { useRestaurantMembers } from '@/hooks/useRestaurantMembers';
 import type { RoleWithGrants } from '@/hooks/useRoles';
 import { isInternalTeamRole } from '@/lib/permissions/roleMembership';
 import { ROLE_METADATA } from '@/lib/permissions/definitions';
-import { CUSTOM_ROLE } from '@/lib/permissions/invitations';
+import { canAssignAnyRole, CUSTOM_ROLE } from '@/lib/permissions/invitations';
 import type { Role } from '@/lib/permissions/types';
 import type { Employee } from '@/types/scheduling';
 
@@ -143,6 +144,7 @@ export function EmployeeAppAccessRow({
   sendingInvite,
 }: EmployeeAppAccessRowProps) {
   const { data: members, isLoading, isError } = useRestaurantMembers(restaurantId);
+  const { user } = useAuth();
   const [inviteExpanded, setInviteExpanded] = useState(false);
   const [pickerOpen, setPickerOpen] = useState(false);
 
@@ -190,6 +192,18 @@ export function EmployeeAppAccessRow({
             currentRole={member.role}
             currentRoleId={member.roleId}
             callerRole={callerRole}
+            // The same four conditions RoleRoster and TeamMembers disable on,
+            // each mirroring a rule `assign_membership_role` would otherwise
+            // raise 42501 for: no assign rights at all, self (rule 2), kiosk
+            // (rule 4), an owner changed by a non-owner (rule 5a). Without
+            // this, opening your own employee dialog offers a menu where every
+            // choice ends in an error toast.
+            disabled={
+              !canAssignAnyRole(callerRole) ||
+              (!!user && member.userId === user.id) ||
+              member.role === 'kiosk' ||
+              (member.role === 'owner' && callerRole !== 'owner')
+            }
           />
         ) : (
           <p className="text-[14px] font-medium text-foreground">{roleLabelFor(member.role)}</p>

--- a/src/components/employees/EmployeeAppAccessRow.tsx
+++ b/src/components/employees/EmployeeAppAccessRow.tsx
@@ -1,5 +1,7 @@
+import { useState } from 'react';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
+import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { RolePicker } from '@/components/roles/RolePicker';
 import { RoleSelect } from '@/components/roles/RoleSelect';
@@ -55,8 +57,11 @@ export function EmployeeAppAccessRow({
   onGrantAppAccessChange,
   inviteRole,
   onInviteRoleChange,
+  onSendInvite,
+  sendingInvite,
 }: EmployeeAppAccessRowProps) {
   const { data: members, isLoading, isError } = useRestaurantMembers(restaurantId);
+  const [inviteExpanded, setInviteExpanded] = useState(false);
 
   if (isLoading) return <AppAccessSkeleton />;
   if (isError) {
@@ -123,6 +128,65 @@ export function EmployeeAppAccessRow({
   if (!callerRole || !isInternalTeamRole(callerRole)) return null;
 
   const inviteLabel = inviteRole?.name ?? ROLE_METADATA.staff.label;
+
+  // Edit mode: `onSendInvite` is only ever passed for an existing employee
+  // record, so `employee` is defined here too — its SAVED email (not
+  // whatever is currently typed in the dialog's field) is what the invite
+  // can safely target, since that's the address the backend already
+  // associates with this employee record.
+  if (onSendInvite) {
+    const savedEmail = employee?.email?.trim();
+    const typedEmailDiffers = !!savedEmail && email.trim() !== savedEmail;
+
+    return (
+      <div className="rounded-lg border border-border/40 bg-muted/30 p-3 space-y-2">
+        <Label className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
+          App access
+        </Label>
+        <p className="text-[13px] text-muted-foreground">No access</p>
+        {!savedEmail ? (
+          <p className="text-[13px] text-muted-foreground">
+            Add an email address and save before inviting this employee to the app.
+          </p>
+        ) : !inviteExpanded ? (
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => setInviteExpanded(true)}
+            className="h-9 px-4 -ml-4 rounded-lg text-[13px] font-medium text-muted-foreground hover:text-foreground"
+          >
+            Invite to the app…
+          </Button>
+        ) : (
+          <>
+            <RoleSelect
+              restaurantId={restaurantId}
+              callerRole={callerRole}
+              value={inviteRole?.id ?? null}
+              onSelect={onInviteRoleChange}
+              triggerText={inviteLabel}
+              triggerLabel={`Invite as ${inviteLabel}. Change role`}
+            />
+            {inviteRole && <RoleAreaChips areas={inviteRole.role_areas} />}
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={onSendInvite}
+              disabled={sendingInvite || !savedEmail || typedEmailDiffers}
+              className="h-9 px-4 -ml-4 rounded-lg text-[13px] font-medium text-muted-foreground hover:text-foreground"
+            >
+              {sendingInvite ? 'Sending…' : 'Send invite'}
+            </Button>
+            {typedEmailDiffers && (
+              <p className="text-[13px] text-muted-foreground">
+                Save the email change before inviting.
+              </p>
+            )}
+          </>
+        )}
+      </div>
+    );
+  }
 
   return (
     <div className="rounded-lg border border-border/40 bg-muted/30 p-3 space-y-2">

--- a/src/components/roles/RolePicker.tsx
+++ b/src/components/roles/RolePicker.tsx
@@ -1,29 +1,14 @@
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { Button } from '@/components/ui/button';
-import {
-  Command,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from '@/components/ui/command';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
-import { useInsideScrollLock } from '@/components/ui/scroll-lock-boundary';
-import { Check, ChevronsUpDown, ArrowUp, ArrowDown } from 'lucide-react';
+import { ArrowUp, ArrowDown } from 'lucide-react';
 import { useRoles, type RoleWithGrants } from '@/hooks/useRoles';
 import { useAssignRole, assignRoleErrorMessage } from '@/hooks/useAssignRole';
 import { useToast } from '@/hooks/use-toast';
-import { RoleAreaChips } from '@/components/roles/RoleAreaChips';
+import { RoleSelect } from '@/components/roles/RoleSelect';
 import { ROLE_METADATA } from '@/lib/permissions/definitions';
-import {
-  CUSTOM_ROLE,
-  canInviteCustomRole,
-  getInvitableRoles,
-  isAssignableCustomRole,
-} from '@/lib/permissions/invitations';
+import { CUSTOM_ROLE } from '@/lib/permissions/invitations';
 import { roleDelta, type RoleGrantSet } from '@/lib/permissions/roleDelta';
 import type { Role } from '@/lib/permissions/types';
-import { cn } from '@/lib/utils';
 
 export interface RolePickerProps {
   membershipId: string;
@@ -73,34 +58,15 @@ export function RolePicker({
   onAssigned,
 }: RolePickerProps) {
   const [open, setOpen] = useState(false);
-  const [search, setSearch] = useState('');
   const [candidateId, setCandidateId] = useState<string | null>(null);
-  const modal = useInsideScrollLock();
   const { toast } = useToast();
 
   // useRoles returns { roles, isLoading, error, ... } — NOT a raw React Query
-  // result, so there is no `data` here.
-  const { roles, isLoading, error } = useRoles(restaurantId);
+  // result, so there is no `data` here. RolePicker still needs `roles` for
+  // currentRow/candidateRow/currentLabel; RoleSelect makes the same call
+  // under the same React Query key, so this is one fetch, two readers.
+  const { roles } = useRoles(restaurantId);
   const assign = useAssignRole(restaurantId);
-
-  const invitable = useMemo(() => getInvitableRoles(callerRole), [callerRole]);
-  const mayAssignCustom = canInviteCustomRole(callerRole);
-
-  const searchQuery = search.trim().toLowerCase();
-  const matches = (name: string) => name.toLowerCase().includes(searchQuery);
-
-  // Only roles `assign_membership_role` will actually accept for
-  // `collaborator_custom` — see `isAssignableCustomRole` for why the three
-  // checks are all needed. Shared with `canAssignTargetRole`, which gates the
-  // "Assign people" entry points, so the options here and the door that leads to
-  // them agree.
-  const customRoles = roles.filter((r) => isAssignableCustomRole(r, restaurantId) && matches(r.name));
-  const builtinRoles = roles.filter(
-    (r) =>
-      r.legacy_role !== null &&
-      (invitable as readonly string[]).includes(r.legacy_role) &&
-      matches(r.name)
-  );
 
   const isCurrent = (r: RoleWithGrants) =>
     currentRoleId ? r.id === currentRoleId : r.legacy_role === currentRole;
@@ -139,7 +105,6 @@ export function RolePicker({
           toast({ title: `${personName} is now ${candidateRow.name}` });
           setOpen(false);
           setCandidateId(null);
-          setSearch('');
           onAssigned?.();
         },
         onError: (err) =>
@@ -158,148 +123,54 @@ export function RolePicker({
   // hence the name is embedded rather than replaced.
   const triggerLabel = `${personName}: role is ${currentLabel}. Change role`;
 
-  const renderRow = (r: RoleWithGrants) => (
-    // value={r.name} is load-bearing: cmdk filters on the `value` prop, and
-    // with chips and a description as children its default text extraction
-    // would match the concatenated blob instead of the name.
-    <CommandItem
-      key={r.id}
-      value={r.name}
-      onSelect={() => setCandidateId(r.id)}
-      className="flex flex-col items-start gap-1.5 py-2.5"
-    >
-      <div className="flex w-full items-center gap-2">
-        <Check
-          className={cn('h-4 w-4 shrink-0', isCurrent(r) ? 'opacity-100' : 'opacity-0')}
-        />
-        <span className="text-[14px] font-medium text-foreground">{r.name}</span>
-      </div>
-      {r.description && (
-        <p className="pl-6 text-[13px] text-muted-foreground">{r.description}</p>
-      )}
-      <div className="pl-6">
-        <RoleAreaChips areas={r.role_areas} />
-      </div>
-    </CommandItem>
-  );
-
   return (
-    <Popover
+    <RoleSelect
+      restaurantId={restaurantId}
+      callerRole={callerRole}
+      // The CURRENT role, not the candidate — `isCurrent` above never moves
+      // when you click an option, and the footer is what shows the pending
+      // choice. Passing `candidateId` here would erase the only on-screen
+      // record of the role the person holds today.
+      value={currentRow?.id ?? null}
+      onSelect={(r) => setCandidateId(r.id)}
+      triggerLabel={triggerLabel}
+      triggerText={currentLabel}
+      disabled={disabled}
       open={open}
       onOpenChange={(next) => {
         setOpen(next);
-        if (!next) {
-          setCandidateId(null);
-          setSearch('');
-        }
+        if (!next) setCandidateId(null);
       }}
-      modal={modal}
-    >
-      <PopoverTrigger asChild>
-        <Button
-          variant="outline"
-          role="combobox"
-          aria-expanded={open}
-          aria-label={triggerLabel}
-          disabled={disabled}
-          className="h-7 max-w-[220px] gap-1 rounded-full border-border/40 px-2.5 text-[13px] font-medium"
-        >
-          <span className="truncate">{currentLabel}</span>
-          <ChevronsUpDown className="h-3 w-3 shrink-0 opacity-50" />
-        </Button>
-      </PopoverTrigger>
-
-      <PopoverContent className="w-[340px] p-0" align="end">
-        <Command shouldFilter={false}>
-          <CommandInput
-            placeholder="Search roles..."
-            value={search}
-            onValueChange={setSearch}
-          />
-          <CommandList>
-            {/*
-              These three states are direct children of CommandList, never
-              routed through CommandEmpty. CommandEmpty means "no rows
-              registered" — it cannot distinguish a load failure from an empty
-              restaurant, and rendering an error through it would tell the
-              admin there are no roles when in fact the request failed.
-
-              !restaurantId is checked alongside isLoading because useRoles is
-              enabled: !!restaurantId, and a disabled React Query reports
-              isLoading === false.
-            */}
-            {(!restaurantId || isLoading) && (
-              <p
-                role="status"
-                aria-live="polite"
-                className="px-3 py-6 text-center text-[13px] text-muted-foreground"
-              >
-                Loading roles…
+      footer={
+        delta && candidateRow ? (
+          <div className="space-y-2 border-t border-border/40 px-3 py-3">
+            {delta.isSame ? (
+              <p className="text-[13px] text-muted-foreground">
+                Same access — only the label changes.
               </p>
-            )}
-            {error && (
-              <p role="alert" className="px-3 py-6 text-center text-[13px] text-destructive">
-                Couldn't load roles. Please try again.
-              </p>
-            )}
-            {!isLoading && !error && customRoles.length === 0 && builtinRoles.length === 0 && (
-              <p className="px-3 py-6 text-center text-[13px] text-muted-foreground">
-                No roles match. Create one in Team → Roles.
-              </p>
-            )}
-
-            {/*
-              The custom group renders for a caller who cannot assign custom
-              roles too — visibly, with the reason. Hiding it is what produced
-              the original "I made a role and it's nowhere" confusion.
-            */}
-            {customRoles.length > 0 && (
-              <CommandGroup heading="Your custom roles">
-                {mayAssignCustom ? (
-                  customRoles.map(renderRow)
-                ) : (
-                  <p className="px-2 py-2 text-[13px] text-muted-foreground">
-                    Only an owner or manager can assign a custom role.
-                  </p>
+            ) : (
+              <div className="space-y-1">
+                {renderDeltaLines(
+                  [...delta.gains.map((g) => g.label), ...delta.flagGains.map((f) => f.label)],
+                  'gain'
                 )}
-              </CommandGroup>
+                {renderDeltaLines(
+                  [...delta.loses.map((l) => l.label), ...delta.flagLoses.map((f) => f.label)],
+                  'lose'
+                )}
+              </div>
             )}
-
-            {builtinRoles.length > 0 && (
-              <CommandGroup heading="Built-in">{builtinRoles.map(renderRow)}</CommandGroup>
-            )}
-          </CommandList>
-
-          {delta && candidateRow && (
-            <div className="space-y-2 border-t border-border/40 px-3 py-3">
-              {delta.isSame ? (
-                <p className="text-[13px] text-muted-foreground">
-                  Same access — only the label changes.
-                </p>
-              ) : (
-                <div className="space-y-1">
-                  {renderDeltaLines(
-                    [...delta.gains.map((g) => g.label), ...delta.flagGains.map((f) => f.label)],
-                    'gain'
-                  )}
-                  {renderDeltaLines(
-                    [...delta.loses.map((l) => l.label), ...delta.flagLoses.map((f) => f.label)],
-                    'lose'
-                  )}
-                </div>
-              )}
-              <Button
-                onClick={commit}
-                disabled={assign.isPending}
-                aria-label={`Change role to ${candidateRow.name}`}
-                className="h-9 w-full rounded-lg bg-foreground text-[13px] font-medium text-background hover:bg-foreground/90"
-              >
-                {assign.isPending ? 'Changing…' : `Change role to ${candidateRow.name}`}
-              </Button>
-            </div>
-          )}
-        </Command>
-      </PopoverContent>
-    </Popover>
+            <Button
+              onClick={commit}
+              disabled={assign.isPending}
+              aria-label={`Change role to ${candidateRow.name}`}
+              className="h-9 w-full rounded-lg bg-foreground text-[13px] font-medium text-background hover:bg-foreground/90"
+            >
+              {assign.isPending ? 'Changing…' : `Change role to ${candidateRow.name}`}
+            </Button>
+          </div>
+        ) : null
+      }
+    />
   );
 }

--- a/src/components/roles/RoleSelect.tsx
+++ b/src/components/roles/RoleSelect.tsx
@@ -40,6 +40,9 @@ export interface RoleSelectProps {
   disabled?: boolean;
   /** Rendered as a sibling of CommandList, inside Command. Never inside CommandList. */
   footer?: ReactNode;
+  /** Optional: control `open` only when the popover has to close on something
+   * other than a click outside — the invite pickers close on select, RolePicker
+   * closes when the assignment lands. Left off, the popover manages itself. */
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
 }
@@ -59,7 +62,10 @@ export function RoleSelect({
   const [openUncontrolled, setOpenUncontrolled] = useState(false);
   const open = openProp ?? openUncontrolled;
   const setOpen = (next: boolean) => {
-    setOpenUncontrolled(next);
+    // Only track internally while nobody else is driving `open`. Writing both
+    // would leave the two out of step for a caller that passes `open` without
+    // `onOpenChange`, and whichever one it stopped agreeing with would win.
+    if (openProp === undefined) setOpenUncontrolled(next);
     onOpenChange?.(next);
   };
 

--- a/src/components/roles/RoleSelect.tsx
+++ b/src/components/roles/RoleSelect.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import { Button } from '@/components/ui/button';
 import {
   Command,
@@ -70,6 +70,14 @@ export function RoleSelect({
   };
 
   const [search, setSearch] = useState('');
+  // Clearing on the `open` value rather than inside onOpenChange: a caller that
+  // drives `open` itself never routes through Radix's callback, so both real
+  // call sites (RolePicker closes in onSuccess, the invite pickers close on
+  // select) would reopen still filtered by the last thing typed.
+  useEffect(() => {
+    if (!open) setSearch('');
+  }, [open]);
+
   const modal = useInsideScrollLock();
 
   // useRoles returns { roles, isLoading, error, ... } — NOT a raw React Query
@@ -123,10 +131,7 @@ export function RoleSelect({
   return (
     <Popover
       open={open}
-      onOpenChange={(next) => {
-        setOpen(next);
-        if (!next) setSearch('');
-      }}
+      onOpenChange={setOpen}
       modal={modal}
     >
       <PopoverTrigger asChild>

--- a/src/components/roles/RoleSelect.tsx
+++ b/src/components/roles/RoleSelect.tsx
@@ -137,14 +137,29 @@ export function RoleSelect({
         </Button>
       </PopoverTrigger>
 
-      <PopoverContent className="w-[340px] p-0" align="end">
-        <Command shouldFilter={false}>
+      {/*
+        The height cap is load-bearing, not cosmetic. Search box + a 300px list
+        + RolePicker's delta footer is ~450px of panel; anchored to a chip
+        partway down the employee dialog on a 720px-tall screen, neither side
+        has room, so Radix picks the roomier one and the footer — which holds
+        the only button that commits the change — lands below the fold with no
+        way to scroll to it. `--radix-popover-content-available-height` is the
+        space Radix measured on the side it chose, so capping to it lets the
+        LIST absorb the shortfall (min-h-0 below) and keeps the footer on
+        screen. collisionPadding keeps the panel off the viewport edge.
+      */}
+      <PopoverContent
+        className="flex max-h-[var(--radix-popover-content-available-height)] w-[340px] flex-col p-0"
+        align="end"
+        collisionPadding={12}
+      >
+        <Command shouldFilter={false} className="min-h-0">
           <CommandInput
             placeholder="Search roles..."
             value={search}
             onValueChange={setSearch}
           />
-          <CommandList>
+          <CommandList className="min-h-0 flex-1">
             {/*
               These three states are direct children of CommandList, never
               routed through CommandEmpty. CommandEmpty means "no rows
@@ -198,7 +213,8 @@ export function RoleSelect({
             )}
           </CommandList>
 
-          {footer}
+          {/* shrink-0 so the list, not the footer, gives up the space. */}
+          {footer && <div className="shrink-0">{footer}</div>}
         </Command>
       </PopoverContent>
     </Popover>

--- a/src/components/roles/RoleSelect.tsx
+++ b/src/components/roles/RoleSelect.tsx
@@ -196,7 +196,11 @@ export function RoleSelect({
                 Couldn't load roles. Please try again.
               </p>
             )}
-            {!isLoading && !error && customRoles.length === 0 && builtinRoles.length === 0 && (
+            {/* `!!restaurantId` for the same reason the loading branch checks
+                it: with no restaurant the query is disabled, so isLoading is
+                false and the empty state would render UNDER the loading line
+                rather than instead of it. */}
+            {!!restaurantId && !isLoading && !error && customRoles.length === 0 && builtinRoles.length === 0 && (
               <p className="px-3 py-6 text-center text-[13px] text-muted-foreground">
                 No roles match. Create one in Team → Roles.
               </p>

--- a/src/components/roles/RoleSelect.tsx
+++ b/src/components/roles/RoleSelect.tsx
@@ -1,0 +1,206 @@
+import { useState, type ReactNode } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Command,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { useInsideScrollLock } from '@/components/ui/scroll-lock-boundary';
+import { Check, ChevronsUpDown } from 'lucide-react';
+import { useRoles, type RoleWithGrants } from '@/hooks/useRoles';
+import { RoleAreaChips } from '@/components/roles/RoleAreaChips';
+import {
+  canInviteCustomRole,
+  getInvitableRoles,
+  isAssignableCustomRole,
+} from '@/lib/permissions/invitations';
+import type { Role } from '@/lib/permissions/types';
+import { cn } from '@/lib/utils';
+
+export interface RoleSelectProps {
+  restaurantId: string;
+  callerRole: Role;
+  /**
+   * The role id the checkmark sits on, or null for none.
+   *
+   * This is "what is true", NOT "what is highlighted". `RolePicker` passes the
+   * CURRENT role here and leaves the candidate to its footer — today's
+   * `isCurrent` check never moves when you click an option, and moving it
+   * would erase the only on-screen record of what the person has now.
+   */
+  value: string | null;
+  onSelect: (role: RoleWithGrants) => void;
+  /** Accessible name. MUST contain `triggerText` (WCAG 2.5.3). */
+  triggerLabel: string;
+  /** Visible chip text. */
+  triggerText: string;
+  disabled?: boolean;
+  /** Rendered as a sibling of CommandList, inside Command. Never inside CommandList. */
+  footer?: ReactNode;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+}
+
+export function RoleSelect({
+  restaurantId,
+  callerRole,
+  value,
+  onSelect,
+  triggerLabel,
+  triggerText,
+  disabled = false,
+  footer,
+  open: openProp,
+  onOpenChange,
+}: RoleSelectProps) {
+  const [openUncontrolled, setOpenUncontrolled] = useState(false);
+  const open = openProp ?? openUncontrolled;
+  const setOpen = (next: boolean) => {
+    setOpenUncontrolled(next);
+    onOpenChange?.(next);
+  };
+
+  const [search, setSearch] = useState('');
+  const modal = useInsideScrollLock();
+
+  // useRoles returns { roles, isLoading, error, ... } — NOT a raw React Query
+  // result, so there is no `data` here.
+  const { roles, isLoading, error } = useRoles(restaurantId);
+
+  const invitable = getInvitableRoles(callerRole);
+  const mayAssignCustom = canInviteCustomRole(callerRole);
+
+  const searchQuery = search.trim().toLowerCase();
+  const matches = (name: string) => name.toLowerCase().includes(searchQuery);
+
+  // Only roles `assign_membership_role` will actually accept for
+  // `collaborator_custom` — see `isAssignableCustomRole` for why the three
+  // checks are all needed. Shared with `canAssignTargetRole`, which gates the
+  // "Assign people" entry points, so the options here and the door that leads to
+  // them agree.
+  const customRoles = roles.filter((r) => isAssignableCustomRole(r, restaurantId) && matches(r.name));
+  const builtinRoles = roles.filter(
+    (r) =>
+      r.legacy_role !== null &&
+      (invitable as readonly string[]).includes(r.legacy_role) &&
+      matches(r.name)
+  );
+
+  const renderRow = (r: RoleWithGrants) => (
+    // value={r.name} is load-bearing: cmdk filters on the `value` prop, and
+    // with chips and a description as children its default text extraction
+    // would match the concatenated blob instead of the name.
+    <CommandItem
+      key={r.id}
+      value={r.name}
+      onSelect={() => onSelect(r)}
+      className="flex flex-col items-start gap-1.5 py-2.5"
+    >
+      <div className="flex w-full items-center gap-2">
+        <Check
+          className={cn('h-4 w-4 shrink-0', r.id === value ? 'opacity-100' : 'opacity-0')}
+        />
+        <span className="text-[14px] font-medium text-foreground">{r.name}</span>
+      </div>
+      {r.description && (
+        <p className="pl-6 text-[13px] text-muted-foreground">{r.description}</p>
+      )}
+      <div className="pl-6">
+        <RoleAreaChips areas={r.role_areas} />
+      </div>
+    </CommandItem>
+  );
+
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) setSearch('');
+      }}
+      modal={modal}
+    >
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          aria-label={triggerLabel}
+          disabled={disabled}
+          className="h-7 max-w-[220px] gap-1 rounded-full border-border/40 px-2.5 text-[13px] font-medium"
+        >
+          <span className="truncate">{triggerText}</span>
+          <ChevronsUpDown className="h-3 w-3 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+
+      <PopoverContent className="w-[340px] p-0" align="end">
+        <Command shouldFilter={false}>
+          <CommandInput
+            placeholder="Search roles..."
+            value={search}
+            onValueChange={setSearch}
+          />
+          <CommandList>
+            {/*
+              These three states are direct children of CommandList, never
+              routed through CommandEmpty. CommandEmpty means "no rows
+              registered" — it cannot distinguish a load failure from an empty
+              restaurant, and rendering an error through it would tell the
+              admin there are no roles when in fact the request failed.
+
+              !restaurantId is checked alongside isLoading because useRoles is
+              enabled: !!restaurantId, and a disabled React Query reports
+              isLoading === false.
+            */}
+            {(!restaurantId || isLoading) && (
+              <p
+                role="status"
+                aria-live="polite"
+                className="px-3 py-6 text-center text-[13px] text-muted-foreground"
+              >
+                Loading roles…
+              </p>
+            )}
+            {error && (
+              <p role="alert" className="px-3 py-6 text-center text-[13px] text-destructive">
+                Couldn't load roles. Please try again.
+              </p>
+            )}
+            {!isLoading && !error && customRoles.length === 0 && builtinRoles.length === 0 && (
+              <p className="px-3 py-6 text-center text-[13px] text-muted-foreground">
+                No roles match. Create one in Team → Roles.
+              </p>
+            )}
+
+            {/*
+              The custom group renders for a caller who cannot assign custom
+              roles too — visibly, with the reason. Hiding it is what produced
+              the original "I made a role and it's nowhere" confusion.
+            */}
+            {customRoles.length > 0 && (
+              <CommandGroup heading="Your custom roles">
+                {mayAssignCustom ? (
+                  customRoles.map(renderRow)
+                ) : (
+                  <p className="px-2 py-2 text-[13px] text-muted-foreground">
+                    Only an owner or manager can assign a custom role.
+                  </p>
+                )}
+              </CommandGroup>
+            )}
+
+            {builtinRoles.length > 0 && (
+              <CommandGroup heading="Built-in">{builtinRoles.map(renderRow)}</CommandGroup>
+            )}
+          </CommandList>
+
+          {footer}
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/lib/permissions/roleMembership.ts
+++ b/src/lib/permissions/roleMembership.ts
@@ -1,5 +1,6 @@
 import type { RestaurantMember } from '@/hooks/useRestaurantMembers';
 import type { RoleWithGrants } from '@/hooks/useRoles';
+import type { Role } from '@/lib/permissions/types';
 
 /**
  * Which role a membership belongs to, resolved the way the database resolves
@@ -81,4 +82,28 @@ export function groupMembersByRole(
     else grouped.set(roleId, [member]);
   }
   return grouped;
+}
+
+/**
+ * The roles that `user_is_internal_team` accepts
+ * (20260702170000_add_operations_manager_role.sql:27-43).
+ *
+ * A second copy of a database rule, which the header above warns against —
+ * but this one is unavoidable: RLS decides what `useRestaurantMembers`
+ * returns, and the UI has to distinguish "this employee has no account" from
+ * "you cannot see whether they do". Getting that backwards tells a
+ * collaborator_accountant that a fully-provisioned employee cannot sign in.
+ * `tests/unit/internalTeamMirror.test.ts` pins the two together.
+ */
+export const INTERNAL_TEAM_ROLES = [
+  'owner',
+  'manager',
+  'operations_manager',
+  'chef',
+  'staff',
+] as const satisfies readonly Role[];
+
+/** Whether this caller sees every `user_restaurants` row for the restaurant. */
+export function isInternalTeamRole(role: Role | null | undefined): boolean {
+  return !!role && (INTERNAL_TEAM_ROLES as readonly string[]).includes(role);
 }

--- a/tests/e2e/accountless-employee-invite.spec.ts
+++ b/tests/e2e/accountless-employee-invite.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 import {
   signUpAndCreateRestaurant,
   generateTestUser,
+  exposeSupabaseHelpers,
 } from '../helpers/e2e-supabase';
 
 type EmployeeSeed = {
@@ -100,5 +101,107 @@ test.describe('accountless employee invite detection', () => {
 
     await collabEmail.fill(strangerEmail);
     await expect(hint).not.toBeVisible();
+  });
+});
+
+/**
+ * The third invite surface: the employee dialog itself.
+ *
+ * Before this, that dialog hardcoded `role: 'staff'` and told the admin the
+ * invite would let the person "clock in, view their own schedule, and request
+ * time off" no matter what — so a restaurant that had built a custom role had
+ * no way to reach it from the place they were actually standing.
+ *
+ * Scope note, same shape as the one above: this asserts on the picker and the
+ * employee record, NOT on a row in `invitations`. The send runs through the
+ * `send-team-invitation` edge function as `service_role`, which has no INSERT
+ * grant on `invitations` in the local/CI stack, so a "the invitation carries
+ * this role" assertion would fail here for a reason unrelated to the code
+ * under test. The payload the dialog builds — including the CUSTOM_ROLE /
+ * roleId pairing the edge function requires — is pinned instead by
+ * `tests/unit/EmployeeDialog.appAccess.test.tsx`. What only a browser can
+ * prove is what this test covers: that the custom role reaches the picker at
+ * all, through the real `roles` table under real RLS.
+ */
+test('the employee dialog invites into a custom role, and says so', async ({ page }) => {
+  const owner = generateTestUser('emp-invite-owner');
+  await signUpAndCreateRestaurant(page, owner);
+  await exposeSupabaseHelpers(page);
+
+  const roleName = `Pastry Lead ${Date.now()}`;
+  const roleDescription = 'Runs the pastry station and owns its recipes.';
+
+  await page.evaluate(
+    async ({ roleName, roleDescription }) => {
+      // `any`: both are test-only globals attached by exposeSupabaseHelpers, no typed surface.
+      const supabase = (window as any).__supabase;
+      const restaurantId = await (window as any).__getRestaurantId();
+
+      const { data: role, error: roleError } = await supabase
+        .from('roles')
+        .insert({
+          restaurant_id: restaurantId,
+          name: roleName,
+          description: roleDescription,
+          flavor: 'collaborator',
+          builtin: false,
+        })
+        .select('id')
+        .single();
+      if (roleError) throw new Error(`role insert failed: ${roleError.message}`);
+
+      const { error: grantError } = await supabase
+        .from('role_areas')
+        .insert({ role_id: role.id, area_key: 'recipes', level: 'manage' });
+      if (grantError) throw new Error(`grant insert failed: ${grantError.message}`);
+    },
+    { roleName, roleDescription },
+  );
+
+  await page.goto('/employees');
+  // Scoped by name, not a bare getByRole('dialog'): Radix portals an open
+  // Popover as its own top-level `dialog`, so while the role picker is open
+  // there are two on the page and an unnamed locator is ambiguous.
+  const dialog = page.getByRole('dialog', { name: /add new employee/i });
+
+  await page.getByRole('button', { name: 'Add Employee' }).click();
+  await expect(dialog).toBeVisible();
+
+  // Both fields carry an aria-label that overrides their visible <Label>, so
+  // the accessible names are "Employee name" / "Employee email", not "Name" /
+  // "Email".
+  await dialog.getByLabel(/employee name/i).fill('Rae Baker');
+  await dialog.getByLabel(/employee email/i).fill(generateTestUser('rae').email);
+  // Required on the default hourly compensation path — without it the browser
+  // blocks the submit and the dialog never closes.
+  await dialog.getByLabel(/hourly rate in dollars/i).fill('18');
+
+  const accessSwitch = dialog.getByRole('switch', { name: /invite to the employee app/i });
+  await accessSwitch.click();
+
+  // Unchosen still means staff — the picker changes what you CAN send, not
+  // what gets sent by default. The chip shows ROLE_METADATA.staff.label, which
+  // is the customer-facing name for that role, not the enum literal.
+  const picker = dialog.getByRole('combobox', { name: /invite as .*change role/i });
+  await expect(picker).toContainText('Employee (self-service)');
+
+  await picker.click();
+  await page.getByRole('option', { name: new RegExp(roleName) }).click();
+
+  // Unlike RolePicker's, this popover has no commit footer — the choice IS the
+  // action — so it closes instead of parking a panel over the rest of the form.
+  await expect(picker).toHaveAttribute('aria-expanded', 'false');
+  await expect(picker).toContainText(roleName);
+  // The hint used to describe staff access regardless of the role being sent.
+  await expect(dialog.getByText(roleDescription)).toBeVisible();
+
+  await dialog.getByRole('button', { name: 'Add Employee' }).click();
+
+  // The employee lands whether or not the invite email goes out — the two are
+  // deliberately not coupled, so a mail failure can't lose the record.
+  await expect(dialog).not.toBeVisible();
+  // The list row, not getByText — the success toast says the name too.
+  await expect(page.getByRole('button', { name: 'Edit Rae Baker' })).toBeVisible({
+    timeout: 10000,
   });
 });

--- a/tests/e2e/role-assignment.spec.ts
+++ b/tests/e2e/role-assignment.spec.ts
@@ -82,3 +82,109 @@ test('an owner moves a member into a custom role and it survives a reload', asyn
     page.getByRole('combobox', { name: new RegExp(`role is ${roleName}`) })
   ).toBeVisible({ timeout: 10000 });
 });
+
+/**
+ * The claim the whole design rests on: the role lives on the ACCOUNT, not on
+ * the employee row. So the employee dialog and Team members are two windows
+ * onto one value — changing it through either has to move the other.
+ *
+ * If this ever fails, the likely cause is a third assignment path having grown
+ * somewhere that writes a role the other surface doesn't read.
+ */
+test('a role changed on the employee dialog is the same role Team members shows', async ({ page }) => {
+  const member = generateTestUser('two-surface-member');
+  const owner = generateTestUser('two-surface-owner');
+
+  // Mint a real auth.users row for the member — user_restaurants.user_id and
+  // employees.user_id are both foreign keys, so neither can be faked.
+  await page.goto('/auth');
+  await exposeSupabaseHelpers(page);
+  await page.getByRole('tab', { name: /sign up/i }).click();
+  await page.getByLabel(/email/i).first().fill(member.email);
+  await page.getByLabel(/full name/i).fill(member.fullName);
+  await page.getByLabel(/password/i).first().fill(member.password);
+  await page.getByRole('button', { name: /sign up|create account/i }).click();
+  await page.waitForURL('/', { timeout: 15000 });
+
+  const memberUserId = await page.evaluate(async () => {
+    // `any`: test-only global attached by exposeSupabaseHelpers, no typed surface.
+    const user = await (window as any).__getAuthUser();
+    return user?.id as string;
+  });
+  expect(memberUserId).toBeTruthy();
+
+  await page.evaluate(async () => {
+    // `any`: test-only global attached by exposeSupabaseHelpers, no typed surface.
+    await (window as any).__supabase.auth.signOut();
+  });
+
+  await signUpAndCreateRestaurant(page, owner);
+  await exposeSupabaseHelpers(page);
+
+  // Seed the custom role, the membership, and — the piece this test needs that
+  // the one above doesn't — an employee record LINKED to the same account.
+  const roleName = `Line Captain ${Date.now()}`;
+  await page.evaluate(
+    async ({ memberUserId, memberName, memberEmail, roleName }) => {
+      // `any`: both are test-only globals attached by exposeSupabaseHelpers, no typed surface.
+      const supabase = (window as any).__supabase;
+      const restaurantId = await (window as any).__getRestaurantId();
+
+      const { data: role, error: roleError } = await supabase
+        .from('roles')
+        .insert({ restaurant_id: restaurantId, name: roleName, flavor: 'collaborator', builtin: false })
+        .select('id')
+        .single();
+      if (roleError) throw new Error(`role insert failed: ${roleError.message}`);
+
+      const { error: grantError } = await supabase
+        .from('role_areas')
+        .insert({ role_id: role.id, area_key: 'recipes', level: 'manage' });
+      if (grantError) throw new Error(`grant insert failed: ${grantError.message}`);
+
+      const { error: memberError } = await supabase
+        .from('user_restaurants')
+        .insert({ user_id: memberUserId, restaurant_id: restaurantId, role: 'staff' });
+      if (memberError) throw new Error(`membership insert failed: ${memberError.message}`);
+
+      const { error: employeeError } = await supabase.from('employees').insert({
+        restaurant_id: restaurantId,
+        user_id: memberUserId,
+        name: memberName,
+        email: memberEmail,
+        position: 'Cook',
+        status: 'active',
+      });
+      if (employeeError) throw new Error(`employee insert failed: ${employeeError.message}`);
+    },
+    { memberUserId, memberName: member.fullName, memberEmail: member.email, roleName }
+  );
+
+  // --- Surface 1: the employee dialog ---
+  await page.goto('/employees');
+  await page.getByRole('button', { name: `Edit ${member.fullName}` }).click();
+
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+  // The row reports the linked ACCOUNT, not a role stored on the employee row.
+  await expect(dialog.getByText(member.email)).toBeVisible({ timeout: 10000 });
+
+  const dialogChip = dialog.getByRole('combobox', {
+    name: new RegExp(`${member.fullName}.*Change role`),
+  });
+  await expect(dialogChip).toBeVisible({ timeout: 10000 });
+  await dialogChip.click();
+
+  await page.getByRole('option', { name: new RegExp(roleName) }).click();
+  await page.getByRole('button', { name: `Change role to ${roleName}` }).click();
+
+  await expect(
+    dialog.getByRole('combobox', { name: new RegExp(`role is ${roleName}`) })
+  ).toBeVisible({ timeout: 10000 });
+
+  // --- Surface 2: Team members, reading the same row ---
+  await page.goto('/team');
+  await expect(
+    page.getByRole('combobox', { name: new RegExp(`${member.fullName}.*role is ${roleName}`) })
+  ).toBeVisible({ timeout: 10000 });
+});

--- a/tests/unit/EmployeeDialog.appAccess.test.tsx
+++ b/tests/unit/EmployeeDialog.appAccess.test.tsx
@@ -5,6 +5,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { EmployeeDialog } from '@/components/EmployeeDialog';
+import type { Employee } from '@/types/scheduling';
 
 const createEmployeeMock = vi.fn();
 // insertCompensationHistoryEntry is a local function in EmployeeDialog that calls
@@ -49,11 +50,37 @@ vi.mock('@/hooks/use-toast', () => ({
   useToast: () => ({ toast: toastMock }),
 }));
 
-vi.mock('@/contexts/RestaurantContext', () => ({
-  useRestaurantContext: () => ({
-    selectedRestaurant: { restaurant: { id: 'r1', timezone: 'UTC' } },
-  }),
+// A controllable mock — most tests want the default (owner, matching
+// restaurant); the app-access-row tests below override it per case to
+// exercise the non-internal-role and restaurant-mismatch paths.
+const mockUseRestaurantContext = vi.fn(() => ({
+  selectedRestaurant: {
+    restaurant_id: 'r1',
+    role: 'owner' as const,
+    restaurant: { id: 'r1', timezone: 'UTC' },
+  },
 }));
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => mockUseRestaurantContext(),
+}));
+
+// EmployeeAppAccessRow renders RolePicker in the linked-account state, which
+// calls useRoles/useAssignRole directly — mocked the same way
+// RolePicker.test.tsx does, rather than deepening the supabase chain mock
+// above (which has no `.or()` and would crash useRoles' real query).
+const mockUseRoles = vi.fn(() => ({ roles: [], isLoading: false, error: null }));
+vi.mock('@/hooks/useRoles', async () => {
+  const actual = await vi.importActual<typeof import('@/hooks/useRoles')>('@/hooks/useRoles');
+  return { ...actual, useRoles: (...args: unknown[]) => mockUseRoles(...args) };
+});
+
+const assignRoleMutate = vi.fn();
+vi.mock('@/hooks/useAssignRole', async () => {
+  const actual = await vi.importActual<typeof import('@/hooks/useAssignRole')>(
+    '@/hooks/useAssignRole'
+  );
+  return { ...actual, useAssignRole: () => ({ mutate: assignRoleMutate, isPending: false }) };
+});
 
 // Mock only the useRestaurantMembers hook (the React Query call); keep
 // findMemberByEmail real since it's a pure function used by the component
@@ -113,6 +140,19 @@ function renderDialog() {
   return render(
     <QueryClientProvider client={qc}>
       <EmployeeDialog open onOpenChange={vi.fn()} restaurantId="r1" />
+    </QueryClientProvider>,
+  );
+}
+
+function renderDialogEdit(employee: Employee) {
+  const qc = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, refetchOnWindowFocus: false, staleTime: Infinity },
+    },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      <EmployeeDialog open onOpenChange={vi.fn()} restaurantId="r1" employee={employee} />
     </QueryClientProvider>,
   );
 }
@@ -312,5 +352,118 @@ describe('EmployeeDialog — link to an existing account instead of double-provi
     // link must not roll back or block employee creation.
     expect(createEmployeeMock).toHaveBeenCalled();
     expect(toastMock).toHaveBeenCalledWith(expect.objectContaining({ variant: 'destructive' }));
+  });
+});
+
+describe('EmployeeDialog — app access row: visibility gate and the linked-account state', () => {
+  const EMPLOYEE_WITH_ACCOUNT: Employee = {
+    id: 'emp-1',
+    restaurant_id: 'r1',
+    name: 'Jamie Rivera',
+    email: 'jamie@example.com',
+    position: 'Server',
+    status: 'active',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    user_id: 'u1',
+    is_active: true,
+    compensation_type: 'hourly',
+    hourly_rate: 1500,
+  };
+
+  const LINKED_MEMBER = {
+    membershipId: 'mem-1',
+    userId: 'u1',
+    email: 'jamie@example.com',
+    fullName: 'Jamie Rivera',
+    role: 'manager',
+    roleId: null,
+  };
+
+  beforeEach(() => {
+    createEmployeeMock.mockReset().mockResolvedValue({ id: 'new-emp-1' });
+    bulkMutateMock.mockReset().mockResolvedValue({ employees_updated: 1, rows_inserted: 7 });
+    toastMock.mockReset();
+    invokeMock.mockReset().mockResolvedValue({ data: null, error: null });
+    rpcMock.mockReset().mockResolvedValue({ data: null, error: null });
+    mockUseRestaurantMembers.mockReset().mockReturnValue({ data: [], isLoading: false, isError: false });
+    mockUseRoles.mockReset().mockReturnValue({ roles: [], isLoading: false, error: null });
+    assignRoleMutate.mockReset();
+    mockUseRestaurantContext.mockReset().mockReturnValue({
+      selectedRestaurant: {
+        restaurant_id: 'r1',
+        role: 'owner' as const,
+        restaurant: { id: 'r1', timezone: 'UTC' },
+      },
+    });
+  });
+
+  it('shows the linked account and its role, not a role on the employee row', async () => {
+    mockUseRestaurantMembers.mockReturnValue({ data: [LINKED_MEMBER], isLoading: false, isError: false });
+    renderDialogEdit(EMPLOYEE_WITH_ACCOUNT);
+
+    expect(await screen.findByText(/signed in as/i)).toBeInTheDocument();
+    expect(screen.getByText(/jamie@example\.com/i)).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: /jamie rivera/i })).toBeInTheDocument();
+  });
+
+  it('says nothing at all to a caller who cannot see the roster', async () => {
+    // RLS returns only the collaborator_accountant's own row, so a roster
+    // miss means "can't see", not "no account" — the row must be absent
+    // entirely, not a confident "No access" about someone fully provisioned.
+    mockUseRestaurantContext.mockReturnValue({
+      selectedRestaurant: {
+        restaurant_id: 'r1',
+        role: 'collaborator_accountant' as const,
+        restaurant: { id: 'r1', timezone: 'UTC' },
+      },
+    });
+    mockUseRestaurantMembers.mockReturnValue({ data: [], isLoading: false, isError: false });
+    renderDialogEdit(EMPLOYEE_WITH_ACCOUNT);
+
+    await screen.findByLabelText(/^name/i);
+    expect(screen.queryByText(/app access/i)).not.toBeInTheDocument();
+  });
+
+  it('offers the invite when the account is linked to no membership here', async () => {
+    // employee.user_id is set, but the roster has no matching userId — state
+    // 3 folds into 2.
+    mockUseRestaurantMembers.mockReturnValue({ data: [], isLoading: false, isError: false });
+    renderDialogEdit(EMPLOYEE_WITH_ACCOUNT);
+
+    expect(await screen.findByText(/no access/i)).toBeInTheDocument();
+    expect(screen.getByRole('switch', { name: /invite to the app/i })).toBeInTheDocument();
+    // Position/Area also render as `combobox` — scope to the RolePicker's
+    // accessible name (it never appears here) rather than any combobox.
+    expect(screen.queryByRole('combobox', { name: /jamie rivera/i })).not.toBeInTheDocument();
+  });
+
+  it('waits rather than guessing while the roster loads', async () => {
+    mockUseRestaurantMembers.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+    renderDialogEdit(EMPLOYEE_WITH_ACCOUNT);
+
+    await screen.findByLabelText(/^name/i);
+    expect(screen.queryByRole('switch', { name: /invite/i })).not.toBeInTheDocument();
+  });
+
+  it('renders the role read-only when the caller role cannot be established', async () => {
+    // selectedRestaurant.restaurant_id !== the dialog's restaurantId prop
+    // ("r1") — callerRole resolves to null. The linked-member data already
+    // came back (proof it was safe to fetch), so it's still shown, just
+    // without the RolePicker combobox that needs a definite callerRole.
+    mockUseRestaurantContext.mockReturnValue({
+      selectedRestaurant: {
+        restaurant_id: 'other-restaurant',
+        role: 'owner' as const,
+        restaurant: { id: 'other-restaurant', timezone: 'UTC' },
+      },
+    });
+    mockUseRestaurantMembers.mockReturnValue({ data: [LINKED_MEMBER], isLoading: false, isError: false });
+    renderDialogEdit(EMPLOYEE_WITH_ACCOUNT);
+
+    expect(await screen.findByText(/manager/i)).toBeInTheDocument();
+    // Position/Area also render as `combobox` — scope to the RolePicker's
+    // accessible name (it never appears here) rather than any combobox.
+    expect(screen.queryByRole('combobox', { name: /jamie rivera/i })).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/EmployeeDialog.appAccess.test.tsx
+++ b/tests/unit/EmployeeDialog.appAccess.test.tsx
@@ -86,6 +86,11 @@ vi.mock('@/hooks/useAssignRole', async () => {
 // findMemberByEmail real since it's a pure function used by the component
 // itself. Default: nobody on the roster matches — tests that need an
 // existing member override this per-test (mirrors TeamInvitations.test.tsx).
+// The signed-in caller. EmployeeAppAccessRow needs it to recognise "this is
+// me" and disable the picker — assign_membership_role rejects self-assignment.
+const mockUseAuth = vi.fn(() => ({ user: { id: 'caller-1' } as { id: string } | null }));
+vi.mock('@/hooks/useAuth', () => ({ useAuth: () => mockUseAuth() }));
+
 const mockUseRestaurantMembers = vi.fn(() => ({ data: [], isError: false }));
 vi.mock('@/hooks/useRestaurantMembers', async () => {
   const actual = await vi.importActual<typeof import('@/hooks/useRestaurantMembers')>(
@@ -389,6 +394,7 @@ describe('EmployeeDialog — app access row: visibility gate and the linked-acco
     mockUseRestaurantMembers.mockReset().mockReturnValue({ data: [], isLoading: false, isError: false });
     mockUseRoles.mockReset().mockReturnValue({ roles: [], isLoading: false, error: null });
     assignRoleMutate.mockReset();
+    mockUseAuth.mockReset().mockReturnValue({ user: { id: 'caller-1' } });
     mockUseRestaurantContext.mockReset().mockReturnValue({
       selectedRestaurant: {
         restaurant_id: 'r1',
@@ -404,7 +410,80 @@ describe('EmployeeDialog — app access row: visibility gate and the linked-acco
 
     expect(await screen.findByText(/signed in as/i)).toBeInTheDocument();
     expect(screen.getByText(/jamie@example\.com/i)).toBeInTheDocument();
-    expect(screen.getByRole('combobox', { name: /jamie rivera/i })).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: /jamie rivera/i })).toBeEnabled();
+  });
+
+  // Each case below mirrors a rule `assign_membership_role` raises 42501 for.
+  // Left enabled, the picker offers a menu where every choice ends in an error
+  // toast — the same guard RoleRoster and TeamMembers already carry.
+  it('will not let you change your own role from your own employee dialog', async () => {
+    mockUseAuth.mockReturnValue({ user: { id: 'u1' } });
+    mockUseRestaurantMembers.mockReturnValue({ data: [LINKED_MEMBER], isLoading: false, isError: false });
+    renderDialogEdit(EMPLOYEE_WITH_ACCOUNT);
+
+    expect(await screen.findByRole('combobox', { name: /jamie rivera/i })).toBeDisabled();
+  });
+
+  it('will not reassign a kiosk membership', async () => {
+    mockUseRestaurantMembers.mockReturnValue({
+      data: [{ ...LINKED_MEMBER, role: 'kiosk' }],
+      isLoading: false,
+      isError: false,
+    });
+    renderDialogEdit(EMPLOYEE_WITH_ACCOUNT);
+
+    expect(await screen.findByRole('combobox', { name: /jamie rivera/i })).toBeDisabled();
+  });
+
+  it('will not let a manager change an owner', async () => {
+    mockUseRestaurantContext.mockReturnValue({
+      selectedRestaurant: {
+        restaurant_id: 'r1',
+        role: 'manager' as const,
+        restaurant: { id: 'r1', timezone: 'UTC' },
+      },
+    });
+    mockUseRestaurantMembers.mockReturnValue({
+      data: [{ ...LINKED_MEMBER, role: 'owner' }],
+      isLoading: false,
+      isError: false,
+    });
+    renderDialogEdit(EMPLOYEE_WITH_ACCOUNT);
+
+    expect(await screen.findByRole('combobox', { name: /jamie rivera/i })).toBeDisabled();
+  });
+
+  it('still lets that manager change a non-owner', async () => {
+    // The owner guard is per-target, not a blanket "managers can't assign" —
+    // without this the previous test would pass just as well if the disable
+    // were keyed on callerRole alone.
+    mockUseRestaurantContext.mockReturnValue({
+      selectedRestaurant: {
+        restaurant_id: 'r1',
+        role: 'manager' as const,
+        restaurant: { id: 'r1', timezone: 'UTC' },
+      },
+    });
+    mockUseRestaurantMembers.mockReturnValue({ data: [LINKED_MEMBER], isLoading: false, isError: false });
+    renderDialogEdit(EMPLOYEE_WITH_ACCOUNT);
+
+    expect(await screen.findByRole('combobox', { name: /jamie rivera/i })).toBeEnabled();
+  });
+
+  it('will not offer a role menu to a caller with no assign rights', async () => {
+    // A chef can see the roster (internal team) but `assign_membership_role`
+    // accepts nothing from them.
+    mockUseRestaurantContext.mockReturnValue({
+      selectedRestaurant: {
+        restaurant_id: 'r1',
+        role: 'chef' as const,
+        restaurant: { id: 'r1', timezone: 'UTC' },
+      },
+    });
+    mockUseRestaurantMembers.mockReturnValue({ data: [LINKED_MEMBER], isLoading: false, isError: false });
+    renderDialogEdit(EMPLOYEE_WITH_ACCOUNT);
+
+    expect(await screen.findByRole('combobox', { name: /jamie rivera/i })).toBeDisabled();
   });
 
   it('says nothing at all to a caller who cannot see the roster', async () => {

--- a/tests/unit/EmployeeDialog.appAccess.test.tsx
+++ b/tests/unit/EmployeeDialog.appAccess.test.tsx
@@ -432,7 +432,9 @@ describe('EmployeeDialog — app access row: visibility gate and the linked-acco
     renderDialogEdit(EMPLOYEE_WITH_ACCOUNT);
 
     expect(await screen.findByText(/no access/i)).toBeInTheDocument();
-    expect(screen.getByRole('switch', { name: /invite to the app/i })).toBeInTheDocument();
+    // Same switch/copy as the create-mode invite (Task 4 unified the two) —
+    // "Invite to the employee app", not the pre-unification "Invite to the app".
+    expect(screen.getByRole('switch', { name: /invite to the employee app/i })).toBeInTheDocument();
     // Position/Area also render as `combobox` — scope to the RolePicker's
     // accessible name (it never appears here) rather than any combobox.
     expect(screen.queryByRole('combobox', { name: /jamie rivera/i })).not.toBeInTheDocument();
@@ -465,5 +467,124 @@ describe('EmployeeDialog — app access row: visibility gate and the linked-acco
     // Position/Area also render as `combobox` — scope to the RolePicker's
     // accessible name (it never appears here) rather than any combobox.
     expect(screen.queryByRole('combobox', { name: /jamie rivera/i })).not.toBeInTheDocument();
+  });
+});
+
+describe('EmployeeDialog — create-mode invite carries the chosen role', () => {
+  const roleRow = (over: Record<string, unknown>) => ({
+    id: 'x',
+    restaurant_id: 'r1',
+    name: 'Role',
+    description: null,
+    flavor: 'collaborator',
+    builtin: false,
+    legacy_role: null,
+    created_at: '',
+    role_areas: [],
+    role_flags: [],
+    memberCount: 0,
+    ...over,
+  });
+
+  beforeEach(() => {
+    createEmployeeMock.mockReset().mockResolvedValue({ id: 'new-emp' });
+    bulkMutateMock.mockReset().mockResolvedValue({ employees_updated: 1, rows_inserted: 7 });
+    toastMock.mockReset();
+    invokeMock.mockReset().mockResolvedValue({ data: null, error: null });
+    rpcMock.mockReset().mockResolvedValue({ data: null, error: null });
+    mockUseRestaurantMembers.mockReset().mockReturnValue({ data: [], isLoading: false, isError: false });
+    mockUseRoles.mockReset().mockReturnValue({
+      roles: [
+        roleRow({ id: 'c1', name: 'Operations Lead', description: 'Runs the floor day to day.' }),
+        roleRow({
+          id: 'chef-role',
+          name: 'Chef',
+          legacy_role: 'chef',
+          builtin: true,
+          restaurant_id: null,
+          description: 'Manage recipes and inventory',
+        }),
+      ],
+      isLoading: false,
+      error: null,
+    });
+    mockUseRestaurantContext.mockReset().mockReturnValue({
+      selectedRestaurant: {
+        restaurant_id: 'r1',
+        role: 'owner' as const,
+        restaurant: { id: 'r1', timezone: 'UTC' },
+      },
+    });
+  });
+
+  async function fillAndArm() {
+    renderDialog();
+    await userEvent.type(screen.getByLabelText(/name/i), 'New Hire');
+    await userEvent.type(screen.getByLabelText(/hourly rate/i), '15');
+    await userEvent.type(screen.getByLabelText(/email/i), 'newhire@example.com');
+    await userEvent.click(screen.getByRole('switch', { name: /invite to the employee app/i }));
+  }
+
+  it('still invites as staff when nobody touches the picker', async () => {
+    await fillAndArm();
+    await userEvent.click(screen.getByRole('button', { name: /add employee/i }));
+
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith(
+        'send-team-invitation',
+        expect.objectContaining({
+          body: expect.objectContaining({ role: 'staff', employeeId: 'new-emp' }),
+        }),
+      ),
+    );
+    expect(invokeMock.mock.calls[0][1].body).not.toHaveProperty('roleId');
+  });
+
+  it('invites as the chosen custom role, carrying its roleId', async () => {
+    await fillAndArm();
+    await userEvent.click(screen.getByRole('combobox', { name: /invite as/i }));
+    await userEvent.click(await screen.findByRole('option', { name: /Operations Lead/i }));
+    // Selecting an option commits the value but leaves the popover open (no
+    // separate confirm step here, unlike RolePicker's footer flow) — close it
+    // before reaching for controls it would otherwise cover.
+    await userEvent.keyboard('{Escape}');
+    await userEvent.click(screen.getByRole('button', { name: /add employee/i }));
+
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith(
+        'send-team-invitation',
+        expect.objectContaining({
+          body: expect.objectContaining({ role: 'collaborator_custom', roleId: 'c1' }),
+        }),
+      ),
+    );
+  });
+
+  it('invites as a chosen built-in role without a roleId', async () => {
+    await fillAndArm();
+    await userEvent.click(screen.getByRole('combobox', { name: /invite as/i }));
+    await userEvent.click(await screen.findByRole('option', { name: /Chef/i }));
+    await userEvent.keyboard('{Escape}');
+    await userEvent.click(screen.getByRole('button', { name: /add employee/i }));
+
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith(
+        'send-team-invitation',
+        expect.objectContaining({
+          body: expect.objectContaining({ role: 'chef' }),
+        }),
+      ),
+    );
+    expect(invokeMock.mock.calls[0][1].body).not.toHaveProperty('roleId');
+  });
+
+  it('describes the role it will actually grant, not always staff', async () => {
+    await fillAndArm();
+    await userEvent.click(screen.getByRole('combobox', { name: /invite as/i }));
+    await userEvent.click(await screen.findByRole('option', { name: /Operations Lead/i }));
+    await userEvent.keyboard('{Escape}');
+
+    expect(await screen.findByText(/runs the floor day to day/i)).toBeInTheDocument();
+    expect(screen.queryByText(/will not see sales, costs, payroll/i)).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/EmployeeDialog.appAccess.test.tsx
+++ b/tests/unit/EmployeeDialog.appAccess.test.tsx
@@ -718,6 +718,86 @@ describe('EmployeeDialog — the edit-mode invite', () => {
     );
   });
 
+  it('keeps the chosen role when the restaurant timezone changes underneath', async () => {
+    const qc = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, refetchOnWindowFocus: false, staleTime: Infinity },
+      },
+    });
+    // A FUNCTION, not a stored element: re-rendering the identical element
+    // object makes React bail out of the subtree entirely, and the component
+    // would never re-read the (mocked) restaurant context.
+    const tree = () => (
+      <QueryClientProvider client={qc}>
+        <EmployeeDialog open onOpenChange={vi.fn()} restaurantId="r1" employee={EMPLOYEE_NO_ACCOUNT} />
+      </QueryClientProvider>
+    );
+    const { rerender } = render(tree());
+
+    await userEvent.click(await screen.findByRole('button', { name: /invite to the app/i }));
+    await userEvent.click(screen.getByRole('combobox', { name: /invite as/i }));
+    await userEvent.click(await screen.findByRole('option', { name: /Operations Lead/i }));
+    await userEvent.keyboard('{Escape}');
+
+    // Someone else changes the restaurant's zone while this dialog sits open.
+    // It re-seeds the compensation effective date and nothing else — the admin
+    // is mid-decision about a person, and the zone is not the person.
+    mockUseRestaurantContext.mockReturnValue({
+      selectedRestaurant: {
+        restaurant_id: 'r1',
+        role: 'owner' as const,
+        restaurant: { id: 'r1', timezone: 'America/New_York' },
+      },
+    });
+    rerender(tree());
+
+    await userEvent.click(screen.getByRole('button', { name: /send invite/i }));
+
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith('send-team-invitation', {
+        body: {
+          restaurantId: 'r1',
+          email: 'sam@x.com',
+          role: 'collaborator_custom',
+          roleId: 'c1',
+          employeeId: 'e1',
+        },
+      }),
+    );
+  });
+
+  it('names the invite trigger by the role it is about to send', async () => {
+    renderDialogEdit(EMPLOYEE_NO_ACCOUNT);
+
+    await userEvent.click(await screen.findByRole('button', { name: /invite to the app/i }));
+
+    // WCAG 2.5.3: the accessible name has to contain the visible chip text, so
+    // a voice-control user can say what they see.
+    // ROLE_METADATA.staff.label, not the raw role key — the chip says what the
+    // admin sees everywhere else in the app.
+    const trigger = screen.getByRole('combobox', { name: /invite as/i });
+    expect(trigger.getAttribute('aria-label')).toBe('Invite as Employee (self-service). Change role');
+    expect(trigger).toHaveTextContent('Employee (self-service)');
+
+    await userEvent.click(trigger);
+    await userEvent.click(await screen.findByRole('option', { name: /Operations Lead/i }));
+
+    const updated = screen.getByRole('combobox', { name: /invite as/i });
+    expect(updated.getAttribute('aria-label')).toBe('Invite as Operations Lead. Change role');
+    expect(updated).toHaveTextContent('Operations Lead');
+  });
+
+  it('says the roster failed rather than claiming no access', async () => {
+    mockUseRestaurantMembers.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+    renderDialogEdit(EMPLOYEE_NO_ACCOUNT);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/couldn't load access details/i);
+    // Offering an invite off a roster we couldn't read risks double-provisioning
+    // someone who already has an account.
+    expect(screen.queryByRole('button', { name: /invite to the app/i })).not.toBeInTheDocument();
+    expect(screen.queryByText(/no access/i)).not.toBeInTheDocument();
+  });
+
   it('asks for an email first when the employee has none saved', async () => {
     renderDialogEdit({ ...EMPLOYEE_NO_ACCOUNT, email: undefined });
 

--- a/tests/unit/EmployeeDialog.appAccess.test.tsx
+++ b/tests/unit/EmployeeDialog.appAccess.test.tsx
@@ -432,9 +432,10 @@ describe('EmployeeDialog — app access row: visibility gate and the linked-acco
     renderDialogEdit(EMPLOYEE_WITH_ACCOUNT);
 
     expect(await screen.findByText(/no access/i)).toBeInTheDocument();
-    // Same switch/copy as the create-mode invite (Task 4 unified the two) —
-    // "Invite to the employee app", not the pre-unification "Invite to the app".
-    expect(screen.getByRole('switch', { name: /invite to the employee app/i })).toBeInTheDocument();
+    // Edit mode (Task 5) replaces the create-mode switch with the
+    // "Send invite" button flow — there is no `onSendInvite`-less switch
+    // once a dialog is editing an existing employee record.
+    expect(screen.getByRole('button', { name: /invite to the app/i })).toBeInTheDocument();
     // Position/Area also render as `combobox` — scope to the RolePicker's
     // accessible name (it never appears here) rather than any combobox.
     expect(screen.queryByRole('combobox', { name: /jamie rivera/i })).not.toBeInTheDocument();
@@ -586,5 +587,104 @@ describe('EmployeeDialog — create-mode invite carries the chosen role', () => 
 
     expect(await screen.findByText(/runs the floor day to day/i)).toBeInTheDocument();
     expect(screen.queryByText(/will not see sales, costs, payroll/i)).not.toBeInTheDocument();
+  });
+});
+
+describe('EmployeeDialog — the edit-mode invite', () => {
+  const roleRow = (over: Record<string, unknown>) => ({
+    id: 'x',
+    restaurant_id: 'r1',
+    name: 'Role',
+    description: null,
+    flavor: 'collaborator',
+    builtin: false,
+    legacy_role: null,
+    created_at: '',
+    role_areas: [],
+    role_flags: [],
+    memberCount: 0,
+    ...over,
+  });
+
+  const EMPLOYEE_NO_ACCOUNT: Employee = {
+    id: 'e1',
+    restaurant_id: 'r1',
+    name: 'Sam Rivera',
+    email: 'sam@x.com',
+    position: 'Server',
+    status: 'active',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    is_active: true,
+    compensation_type: 'hourly',
+    hourly_rate: 1500,
+  };
+
+  beforeEach(() => {
+    createEmployeeMock.mockReset().mockResolvedValue({ id: 'new-emp' });
+    bulkMutateMock.mockReset().mockResolvedValue({ employees_updated: 1, rows_inserted: 7 });
+    toastMock.mockReset();
+    invokeMock.mockReset().mockResolvedValue({ data: null, error: null });
+    rpcMock.mockReset().mockResolvedValue({ data: null, error: null });
+    mockUseRestaurantMembers.mockReset().mockReturnValue({ data: [], isLoading: false, isError: false });
+    mockUseRoles.mockReset().mockReturnValue({
+      roles: [
+        roleRow({ id: 'c1', name: 'Operations Lead', description: 'Runs the floor day to day.' }),
+      ],
+      isLoading: false,
+      error: null,
+    });
+    mockUseRestaurantContext.mockReset().mockReturnValue({
+      selectedRestaurant: {
+        restaurant_id: 'r1',
+        role: 'owner' as const,
+        restaurant: { id: 'r1', timezone: 'UTC' },
+      },
+    });
+  });
+
+  it('sends the invite with the saved email and the chosen role', async () => {
+    renderDialogEdit(EMPLOYEE_NO_ACCOUNT);
+
+    await userEvent.click(await screen.findByRole('button', { name: /invite to the app/i }));
+    await userEvent.click(screen.getByRole('combobox', { name: /invite as/i }));
+    await userEvent.click(await screen.findByRole('option', { name: /Operations Lead/i }));
+    await userEvent.keyboard('{Escape}');
+    await userEvent.click(screen.getByRole('button', { name: /send invite/i }));
+
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith('send-team-invitation', {
+        body: {
+          restaurantId: 'r1',
+          email: 'sam@x.com',
+          role: 'collaborator_custom',
+          roleId: 'c1',
+          employeeId: 'e1',
+        },
+      }),
+    );
+  });
+
+  it('refuses to invite an address the user is still typing', async () => {
+    renderDialogEdit(EMPLOYEE_NO_ACCOUNT);
+
+    const emailInput = await screen.findByLabelText(/email/i);
+    await userEvent.clear(emailInput);
+    await userEvent.type(emailInput, 'other@x.com');
+
+    await userEvent.click(screen.getByRole('button', { name: /invite to the app/i }));
+    const sendButton = screen.getByRole('button', { name: /send invite/i });
+    expect(sendButton).toBeDisabled();
+
+    await userEvent.click(sendButton);
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it('asks for an email first when the employee has none saved', async () => {
+    renderDialogEdit({ ...EMPLOYEE_NO_ACCOUNT, email: undefined });
+
+    await screen.findByLabelText(/^name/i);
+    expect(screen.queryByRole('button', { name: /send invite/i })).not.toBeInTheDocument();
+    expect(screen.getByText(/add an email address/i)).toBeInTheDocument();
   });
 });

--- a/tests/unit/EmployeeDialog.appAccess.test.tsx
+++ b/tests/unit/EmployeeDialog.appAccess.test.tsx
@@ -471,22 +471,24 @@ describe('EmployeeDialog — app access row: visibility gate and the linked-acco
   });
 });
 
-describe('EmployeeDialog — create-mode invite carries the chosen role', () => {
-  const roleRow = (over: Record<string, unknown>) => ({
-    id: 'x',
-    restaurant_id: 'r1',
-    name: 'Role',
-    description: null,
-    flavor: 'collaborator',
-    builtin: false,
-    legacy_role: null,
-    created_at: '',
-    role_areas: [],
-    role_flags: [],
-    memberCount: 0,
-    ...over,
-  });
+/** A custom role, overridable field by field. Shared by both invite suites so
+ * they can't drift into testing subtly different role shapes. */
+const roleRow = (over: Record<string, unknown>) => ({
+  id: 'x',
+  restaurant_id: 'r1',
+  name: 'Role',
+  description: null,
+  flavor: 'collaborator',
+  builtin: false,
+  legacy_role: null,
+  created_at: '',
+  role_areas: [],
+  role_flags: [],
+  memberCount: 0,
+  ...over,
+});
 
+describe('EmployeeDialog — create-mode invite carries the chosen role', () => {
   beforeEach(() => {
     createEmployeeMock.mockReset().mockResolvedValue({ id: 'new-emp' });
     bulkMutateMock.mockReset().mockResolvedValue({ employees_updated: 1, rows_inserted: 7 });
@@ -591,21 +593,6 @@ describe('EmployeeDialog — create-mode invite carries the chosen role', () => 
 });
 
 describe('EmployeeDialog — the edit-mode invite', () => {
-  const roleRow = (over: Record<string, unknown>) => ({
-    id: 'x',
-    restaurant_id: 'r1',
-    name: 'Role',
-    description: null,
-    flavor: 'collaborator',
-    builtin: false,
-    legacy_role: null,
-    created_at: '',
-    role_areas: [],
-    role_flags: [],
-    memberCount: 0,
-    ...over,
-  });
-
   const EMPLOYEE_NO_ACCOUNT: Employee = {
     id: 'e1',
     restaurant_id: 'r1',
@@ -678,6 +665,57 @@ describe('EmployeeDialog — the edit-mode invite', () => {
 
     await userEvent.click(sendButton);
     expect(invokeMock).not.toHaveBeenCalled();
+  });
+
+  it('starts the next employee fresh instead of carrying the last one\'s role', async () => {
+    const qc = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, refetchOnWindowFocus: false, staleTime: Infinity },
+      },
+    });
+    const { rerender } = render(
+      <QueryClientProvider client={qc}>
+        <EmployeeDialog
+          open
+          onOpenChange={vi.fn()}
+          restaurantId="r1"
+          employee={EMPLOYEE_NO_ACCOUNT}
+        />
+      </QueryClientProvider>,
+    );
+
+    await userEvent.click(await screen.findByRole('button', { name: /invite to the app/i }));
+    await userEvent.click(screen.getByRole('combobox', { name: /invite as/i }));
+    await userEvent.click(await screen.findByRole('option', { name: /Operations Lead/i }));
+    await userEvent.keyboard('{Escape}');
+
+    const OTHER: Employee = {
+      ...EMPLOYEE_NO_ACCOUNT,
+      id: 'e2',
+      name: 'Dana Cruz',
+      email: 'dana@x.com',
+    };
+    rerender(
+      <QueryClientProvider client={qc}>
+        <EmployeeDialog open onOpenChange={vi.fn()} restaurantId="r1" employee={OTHER} />
+      </QueryClientProvider>,
+    );
+
+    // The panel collapses back to its entry point, so the next person starts at
+    // the same place the first one did rather than mid-decision.
+    await userEvent.click(await screen.findByRole('button', { name: /invite to the app/i }));
+    await userEvent.click(screen.getByRole('button', { name: /send invite/i }));
+
+    await waitFor(() =>
+      expect(invokeMock).toHaveBeenCalledWith('send-team-invitation', {
+        body: {
+          restaurantId: 'r1',
+          email: 'dana@x.com',
+          role: 'staff',
+          employeeId: 'e2',
+        },
+      }),
+    );
   });
 
   it('asks for an email first when the employee has none saved', async () => {

--- a/tests/unit/EmployeeDialog.availabilitySection.test.tsx
+++ b/tests/unit/EmployeeDialog.availabilitySection.test.tsx
@@ -54,6 +54,11 @@ vi.mock('@/contexts/RestaurantContext', () => ({
   }),
 }));
 
+// EmployeeAppAccessRow (mounted by every EmployeeDialog render) calls useAuth,
+// which throws without an AuthProvider by design. Nothing here asserts on app
+// access — this just keeps the dialog mountable.
+vi.mock('@/hooks/useAuth', () => ({ useAuth: () => ({ user: { id: 'caller-1' } }) }));
+
 vi.mock('@/integrations/supabase/client', () => {
   // Build a chainable supabase query mock that resolves at any terminal call.
   function makeChain(): any {

--- a/tests/unit/EmployeeDialog.statusSync.test.tsx
+++ b/tests/unit/EmployeeDialog.statusSync.test.tsx
@@ -38,6 +38,11 @@ vi.mock('@/contexts/RestaurantContext', () => ({
   useRestaurantContext: () => ({ selectedRestaurant: { restaurant: { id: 'r1', timezone: 'UTC' } } }),
 }));
 
+// EmployeeAppAccessRow (mounted by every EmployeeDialog render) calls useAuth,
+// which throws without an AuthProvider by design. Nothing here asserts on app
+// access — this just keeps the dialog mountable.
+vi.mock('@/hooks/useAuth', () => ({ useAuth: () => ({ user: { id: 'caller-1' } }) }));
+
 vi.mock('@/integrations/supabase/client', () => {
   // Recursive fluent-builder mock — must be `any` because the chain can call
   // any subset of methods in any order; a typed interface would require an

--- a/tests/unit/RolePicker.test.tsx
+++ b/tests/unit/RolePicker.test.tsx
@@ -167,4 +167,33 @@ describe('RolePicker', () => {
     expect(screen.queryByRole('option', { name: /Copied platform role/ })).not.toBeInTheDocument();
     expect(screen.queryByRole('option', { name: /Scoped builtin/ })).not.toBeInTheDocument();
   });
+
+  // RolePicker owns `open` precisely so commit's onSuccess can close it and
+  // clear the candidate. When the option list moved into RoleSelect, an
+  // uncontrolled popover would leave this dialog open on a stale candidate
+  // after a successful assignment. Written before the extraction, on purpose.
+  it('closes and clears the candidate once the assignment lands', async () => {
+    mockUseRoles.mockReturnValue({
+      roles: [roleRow({ id: 'c1', name: 'Operations Lead' })],
+      isLoading: false, error: null,
+    });
+    render(<RolePicker {...base} />, { wrapper });
+
+    await userEvent.click(screen.getByRole('combobox', { name: /Dana Reyes/i }));
+    await userEvent.click(await screen.findByRole('option', { name: /Operations Lead/ }));
+    await userEvent.click(screen.getByRole('button', { name: /change role to/i }));
+
+    const [, handlers] = mutate.mock.calls[0];
+    handlers.onSuccess();
+
+    // Popover gone, so the commit button and the option list are gone with it.
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: /change role to/i })).not.toBeInTheDocument()
+    );
+    expect(screen.queryByRole('option', { name: /Operations Lead/ })).not.toBeInTheDocument();
+
+    // Reopening starts clean — no candidate carried over, so no commit footer.
+    await userEvent.click(screen.getByRole('combobox', { name: /Dana Reyes/i }));
+    expect(screen.queryByRole('button', { name: /change role to/i })).not.toBeInTheDocument();
+  });
 });

--- a/tests/unit/RoleSelect.test.tsx
+++ b/tests/unit/RoleSelect.test.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { RoleSelect } from '@/components/roles/RoleSelect';
+
+const mockUseRoles = vi.fn();
+vi.mock('@/hooks/useRoles', () => ({ useRoles: (...a: unknown[]) => mockUseRoles(...a) }));
+
+const mutate = vi.fn();
+vi.mock('@/hooks/useAssignRole', async () => {
+  const actual = await vi.importActual<typeof import('@/hooks/useAssignRole')>('@/hooks/useAssignRole');
+  return { ...actual, useAssignRole: () => ({ mutate, isPending: false }) };
+});
+
+const roleRow = (over: Record<string, unknown>) => ({
+  id: 'x', restaurant_id: 'r1', name: 'Role', description: null,
+  flavor: 'collaborator', builtin: false, legacy_role: null,
+  created_at: '', role_areas: [], role_flags: [], memberCount: 0, ...over,
+});
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>
+);
+
+const base = {
+  restaurantId: 'r1',
+  callerRole: 'owner' as const,
+  value: null,
+  onSelect: vi.fn(),
+  triggerLabel: 'Dana Reyes: role is Staff. Change role',
+  triggerText: 'Staff',
+};
+
+describe('RoleSelect', () => {
+  beforeEach(() => { mockUseRoles.mockReset(); mutate.mockReset(); });
+
+  it("the trigger's accessible name contains its visible text (WCAG 2.5.3)", () => {
+    mockUseRoles.mockReturnValue({ roles: [], isLoading: false, error: null });
+    render(<RoleSelect {...base} />, { wrapper });
+
+    const trigger = screen.getByRole('combobox');
+    const visible = trigger.textContent ?? '';
+    expect(visible.trim().length).toBeGreaterThan(0);
+    expect(trigger.getAttribute('aria-label')).toContain(visible.trim());
+  });
+
+  it('shows a loading state with role="status" while roles resolve', async () => {
+    mockUseRoles.mockReturnValue({ roles: [], isLoading: true, error: null });
+    render(<RoleSelect {...base} />, { wrapper });
+    await userEvent.click(screen.getByRole('combobox'));
+    const status = screen.getByRole('status');
+    expect(status).toHaveTextContent(/loading roles/i);
+  });
+
+  it("shows an error state distinctly from the empty-state copy", async () => {
+    mockUseRoles.mockReturnValue({ roles: [], isLoading: false, error: new Error('boom') });
+    render(<RoleSelect {...base} />, { wrapper });
+    await userEvent.click(screen.getByRole('combobox'));
+    expect(screen.getByText(/couldn't load roles/i)).toBeInTheDocument();
+    expect(screen.queryByText(/no roles match/i)).not.toBeInTheDocument();
+  });
+
+  it('hides owner from a manager and shows it to an owner', async () => {
+    mockUseRoles.mockReturnValue({
+      roles: [roleRow({ id: 'owner-role', name: 'Owner', legacy_role: 'owner', builtin: true, restaurant_id: null })],
+      isLoading: false, error: null,
+    });
+
+    const { unmount } = render(<RoleSelect {...base} callerRole="manager" />, { wrapper });
+    await userEvent.click(screen.getByRole('combobox'));
+    expect(screen.queryByRole('option', { name: /^Owner/ })).not.toBeInTheDocument();
+    unmount();
+
+    render(<RoleSelect {...base} callerRole="owner" />, { wrapper });
+    await userEvent.click(screen.getByRole('combobox'));
+    await waitFor(() => expect(screen.getByRole('option', { name: /Owner/ })).toBeInTheDocument());
+  });
+
+  it('never offers a custom role scoped to another restaurant', async () => {
+    mockUseRoles.mockReturnValue({
+      roles: [
+        roleRow({ id: 'ok', name: 'Operations lead', restaurant_id: 'r1' }),
+        roleRow({ id: 'other', name: 'Other Restaurant Custom', restaurant_id: 'r2' }),
+      ],
+      isLoading: false, error: null,
+    });
+    render(<RoleSelect {...base} />, { wrapper });
+    await userEvent.click(screen.getByRole('combobox'));
+
+    expect(await screen.findByRole('option', { name: /Operations lead/ })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /Other Restaurant Custom/ })).not.toBeInTheDocument();
+  });
+
+  it('shows the custom group with a reason, not hidden, when the caller may not assign one', async () => {
+    mockUseRoles.mockReturnValue({
+      roles: [roleRow({ id: 'c1', name: 'Operations Lead', restaurant_id: 'r1' })],
+      isLoading: false, error: null,
+    });
+    render(<RoleSelect {...base} callerRole="chef" />, { wrapper });
+    await userEvent.click(screen.getByRole('combobox'));
+
+    expect(await screen.findByText(/Only an owner or manager can assign a custom role/i)).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /Operations Lead/ })).not.toBeInTheDocument();
+  });
+
+  it('fires onSelect with the whole role and never touches useAssignRole', async () => {
+    const onSelect = vi.fn();
+    mockUseRoles.mockReturnValue({
+      roles: [roleRow({ id: 'c1', name: 'Operations Lead', restaurant_id: 'r1' })],
+      isLoading: false, error: null,
+    });
+    render(<RoleSelect {...base} onSelect={onSelect} />, { wrapper });
+    await userEvent.click(screen.getByRole('combobox'));
+    await userEvent.click(await screen.findByRole('option', { name: /Operations Lead/ }));
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ id: 'c1', name: 'Operations Lead' }));
+    expect(mutate).not.toHaveBeenCalled();
+  });
+
+  it('renders the footer inside the popover but not as an option', async () => {
+    mockUseRoles.mockReturnValue({ roles: [], isLoading: false, error: null });
+    render(
+      <RoleSelect {...base} footer={<div data-testid="footer-content">Footer</div>} />,
+      { wrapper }
+    );
+    await userEvent.click(screen.getByRole('combobox'));
+
+    const footer = await screen.findByTestId('footer-content');
+    expect(footer).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /Footer/ })).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/RoleSelect.test.tsx
+++ b/tests/unit/RoleSelect.test.tsx
@@ -133,4 +133,30 @@ describe('RoleSelect', () => {
     expect(footer).toBeInTheDocument();
     expect(screen.queryByRole('option', { name: /Footer/ })).not.toBeInTheDocument();
   });
+
+  it('reopens unfiltered after the caller closes it itself', async () => {
+    mockUseRoles.mockReturnValue({
+      roles: [
+        roleRow({ id: 'c1', name: 'Operations Lead', restaurant_id: 'r1' }),
+        roleRow({ id: 'c2', name: 'Pastry Lead', restaurant_id: 'r1' }),
+      ],
+      isLoading: false, error: null,
+    });
+
+    // Both real call sites drive `open` themselves — RolePicker closes in
+    // onSuccess, the invite pickers close on select — so Radix's onOpenChange
+    // never fires on the way out. Clearing there would leak the last search
+    // into the next open.
+    const { rerender } = render(
+      <RoleSelect {...base} open onOpenChange={vi.fn()} />, { wrapper }
+    );
+    await userEvent.type(await screen.findByPlaceholderText(/search roles/i), 'Pastry');
+    expect(screen.queryByRole('option', { name: /Operations Lead/ })).not.toBeInTheDocument();
+
+    rerender(<RoleSelect {...base} open={false} onOpenChange={vi.fn()} />);
+    rerender(<RoleSelect {...base} open onOpenChange={vi.fn()} />);
+
+    expect(await screen.findByPlaceholderText(/search roles/i)).toHaveValue('');
+    expect(await screen.findByRole('option', { name: /Operations Lead/ })).toBeInTheDocument();
+  });
 });

--- a/tests/unit/RoleSelect.test.tsx
+++ b/tests/unit/RoleSelect.test.tsx
@@ -63,6 +63,18 @@ describe('RoleSelect', () => {
     expect(screen.queryByText(/no roles match/i)).not.toBeInTheDocument();
   });
 
+  it('waits rather than claiming no roles exist when there is no restaurant yet', async () => {
+    // useRoles is `enabled: !!restaurantId`, and a disabled React Query reports
+    // isLoading === false — so the empty state has to check restaurantId too or
+    // it renders "No roles match" directly under "Loading roles…".
+    mockUseRoles.mockReturnValue({ roles: [], isLoading: false, error: null });
+    render(<RoleSelect {...base} restaurantId="" />, { wrapper });
+    await userEvent.click(screen.getByRole('combobox'));
+
+    expect(screen.getByRole('status')).toHaveTextContent(/loading roles/i);
+    expect(screen.queryByText(/no roles match/i)).not.toBeInTheDocument();
+  });
+
   it('hides owner from a manager and shows it to an owner', async () => {
     mockUseRoles.mockReturnValue({
       roles: [roleRow({ id: 'owner-role', name: 'Owner', legacy_role: 'owner', builtin: true, restaurant_id: null })],

--- a/tests/unit/internalTeamMirror.test.ts
+++ b/tests/unit/internalTeamMirror.test.ts
@@ -10,14 +10,35 @@
  * fails here rather than silently blanking the row in production.
  */
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { INTERNAL_TEAM_ROLES } from '@/lib/permissions/roleMembership';
+import { INTERNAL_TEAM_ROLES, isInternalTeamRole } from '@/lib/permissions/roleMembership';
+import type { Role } from '@/lib/permissions/types';
 
-const MIGRATION = 'supabase/migrations/20260702170000_add_operations_manager_role.sql';
+const MIGRATIONS_DIR = 'supabase/migrations';
+
+/**
+ * The LAST migration that defines the function wins, because that is what a
+ * migrated database ends up running. Naming one file here would quietly pin a
+ * superseded definition the day someone adds a sixth role in a new migration --
+ * which is the exact failure this test exists to catch.
+ */
+function latestMigrationDefining(fn: string): string {
+  const dir = resolve(process.cwd(), MIGRATIONS_DIR);
+  const match = readdirSync(dir)
+    .filter((f) => f.endsWith('.sql'))
+    // Timestamp-prefixed, so lexicographic order is migration order.
+    .sort()
+    .reverse()
+    .find((f) => readFileSync(resolve(dir, f), 'utf8').includes(`FUNCTION public.${fn}`));
+
+  expect(match, `no migration defines ${fn}`).toBeDefined();
+  return `${MIGRATIONS_DIR}/${match}`;
+}
 
 describe('INTERNAL_TEAM_ROLES mirrors user_is_internal_team', () => {
   it('lists exactly the roles the SQL function accepts', () => {
+    const MIGRATION = latestMigrationDefining('user_is_internal_team');
     const sql = readFileSync(resolve(process.cwd(), MIGRATION), 'utf8');
 
     const fnStart = sql.indexOf('FUNCTION public.user_is_internal_team');
@@ -30,5 +51,32 @@ describe('INTERNAL_TEAM_ROLES mirrors user_is_internal_team', () => {
     const fromSql = [...inList![1].matchAll(/'([^']+)'/g)].map((m) => m[1]);
     expect(fromSql.length).toBeGreaterThan(0);
     expect([...INTERNAL_TEAM_ROLES].sort()).toEqual([...fromSql].sort());
+  });
+});
+
+/**
+ * The mirror test above pins the LIST. This pins the PREDICATE built on it --
+ * the half EmployeeAppAccessRow actually calls, including the nullable inputs
+ * its signature accepts (a caller whose role can't be established).
+ */
+describe('isInternalTeamRole', () => {
+  it.each(INTERNAL_TEAM_ROLES)('accepts %s', (role) => {
+    expect(isInternalTeamRole(role)).toBe(true);
+  });
+
+  it.each([
+    'collaborator_accountant',
+    'collaborator_inventory',
+    'collaborator_chef',
+    'collaborator_custom',
+    'kiosk',
+    'not_a_role',
+  ])('rejects %s', (role) => {
+    expect(isInternalTeamRole(role as Role)).toBe(false);
+  });
+
+  it('rejects an unestablished caller rather than throwing', () => {
+    expect(isInternalTeamRole(null)).toBe(false);
+    expect(isInternalTeamRole(undefined)).toBe(false);
   });
 });

--- a/tests/unit/internalTeamMirror.test.ts
+++ b/tests/unit/internalTeamMirror.test.ts
@@ -1,0 +1,34 @@
+/**
+ * `user_is_internal_team` decides who can SELECT every row of
+ * user_restaurants (20260120100000_add_collaborator_roles.sql:201-212).
+ * EmployeeAppAccessRow needs the same answer client-side to know whether a
+ * miss in the roster means "no account" or "you just can't see it".
+ *
+ * That makes INTERNAL_TEAM_ROLES a second copy of a database rule, and
+ * roleMembership.ts's own header warns about exactly that. This test is the
+ * pin: add a sixth internal role in SQL without updating the constant and it
+ * fails here rather than silently blanking the row in production.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { INTERNAL_TEAM_ROLES } from '@/lib/permissions/roleMembership';
+
+const MIGRATION = 'supabase/migrations/20260702170000_add_operations_manager_role.sql';
+
+describe('INTERNAL_TEAM_ROLES mirrors user_is_internal_team', () => {
+  it('lists exactly the roles the SQL function accepts', () => {
+    const sql = readFileSync(resolve(process.cwd(), MIGRATION), 'utf8');
+
+    const fnStart = sql.indexOf('FUNCTION public.user_is_internal_team');
+    expect(fnStart, `user_is_internal_team not found in ${MIGRATION}`).toBeGreaterThan(-1);
+
+    // `AND ur.role IN ('owner', 'manager', ...)` — first IN list after the signature.
+    const inList = /ur\.role\s+IN\s*\(([^)]*)\)/.exec(sql.slice(fnStart));
+    expect(inList, 'role IN (...) list not found').not.toBeNull();
+
+    const fromSql = [...inList![1].matchAll(/'([^']+)'/g)].map((m) => m[1]);
+    expect(fromSql.length).toBeGreaterThan(0);
+    expect([...INTERNAL_TEAM_ROLES].sort()).toEqual([...fromSql].sort());
+  });
+});


### PR DESCRIPTION
Move 3 of the approved role-assignment design. Closes the loop the user opened: *"I created a new permissions role and I can't apply it to an employee."*

Design: [`docs/superpowers/specs/2026-08-04-employee-app-access-design.md`](docs/superpowers/specs/2026-08-04-employee-app-access-design.md)
Follows #688 (Move 1 — `assign_membership_role` + the role chip) and #691 (Move 2 — the role roster).

## What changes

`EmployeeDialog` gains an **App access** row, and the hardcoded `role: 'staff'` is gone.

The row reads the employee's linked account, if any, and shows one of three things:

- **Signed in** — the account's email plus a `RolePicker`, the same control Team members uses. Roles belong to the account, not the employee record, and the row says so.
- **No linked account** — an "Invite to the app…" disclosure with a role picker. The invite goes out as the role you picked, custom roles included, and the button says which one.
- **Nothing at all** — to a caller who cannot see the roster. RLS on `user_restaurants` returns every row only to internal team roles, so to a collaborator a miss means "cannot see", not "no account". Saying "No access" there would be a confident lie about someone with full access.

Create mode gets the same picker, so a new employee can be invited straight into a custom role.

## Structure

`RoleSelect` is extracted from `RolePicker` — the option list, its permission gating, and its search. `RolePicker` keeps the assignment: the delta footer, the commit button, `useAssignRole`. Three call sites now share one list instead of growing a third.

`INTERNAL_TEAM_ROLES` / `isInternalTeamRole` mirror the SQL `user_is_internal_team` predicate client-side. That is a second copy of a database rule, so `tests/unit/internalTeamMirror.test.ts` parses the migration and pins them together — add a sixth internal role in SQL without touching the constant and the test fails rather than silently blanking the row in production.

## Verification

- `npx vitest run` — 8654 passed, 0 failed (705 files)
- `npx playwright test` on both feature specs — 4 passed
- `npx tsc --noEmit` — clean
- eslint on changed files — only the 2 pre-existing `no-explicit-any` errors already on `main`

Two E2E-only defects were found and fixed during the build, both invisible to unit tests that assert on payloads: the invite popover never closed on select, and it had no height cap, so on a 720px viewport the commit button landed below the fold unreachable.

Review passes: five-reviewer panel + Codex adversarial, CodeRabbit, and a re-review of the fold diff. Both regression tests from the last round were verified to fail against the pre-fix files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added employee app-access controls for inviting, linking, and managing account access.
  * Added role selection during employee invitations, including custom roles where permitted.
  * Added role-aware access states for loading, errors, unavailable accounts, and existing links.
  * Added the ability to send edit-mode invitations directly from the employee dialog.
  * Improved role picker accessibility, filtering, search behavior, and responsive layout.

* **Bug Fixes**
  * Prevented stale access information when switching employees or changing email addresses.
  * Ensured access remains hidden when permissions or account context cannot be verified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->