### PR TITLE
fix(categorization): make the backlog drain a standing */5 sweep for every POS and for bank

### DIFF
--- a/docs/superpowers/plans/2026-08-04-categorization-standing-sweep-plan.md
+++ b/docs/superpowers/plans/2026-08-04-categorization-standing-sweep-plan.md
@@ -1,0 +1,779 @@
+# Standing Categorization Sweep — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `drain_categorization_backlog()` a permanent `*/5` pg_cron job instead of one that deletes itself, so `bank_transactions` and every `pos_system` — present and future — get rule categorization without per-integration wiring.
+
+**Architecture:** One migration (`CREATE OR REPLACE` the drain with the self-retire block removed, plus an idempotent `cron.schedule`), one new pgTAP conformance file, and an inversion of the three tests in `50_categorization_backlog_drain.sql` that pin the old self-retire semantics. No schema change, no edge-function change, no UI change.
+
+**Tech Stack:** PostgreSQL 15 (Supabase), pl/pgSQL, pg_cron, pgTAP.
+
+**Design doc:** [docs/superpowers/specs/2026-08-04-categorization-standing-sweep-design.md](../specs/2026-08-04-categorization-standing-sweep-design.md)
+
+## Global Constraints
+
+- Worktree: `/Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/categorization-standing-sweep`. Every git command uses `git -C <that path>`.
+- Branch: `fix/categorization-standing-sweep`. Never commit to `main`.
+- Never `git add -A`, `git add .`, or `git commit -a`. Stage explicit paths only. `progress.md` is gitignored and must never be staged.
+- Migration filenames are strictly ordered; this migration must sort after `20260804090700_categorization_watermark_and_drain_convergence.sql`.
+- pgTAP files are auto-discovered by `supabase/tests/run_tests.sh:75` (`for test_file in "$SCRIPT_DIR"/*.sql`). No registration step exists.
+- Every pgTAP file is `BEGIN; SELECT plan(N); … SELECT * FROM finish(); ROLLBACK;`.
+- All committed artifacts use fictional placeholders. No real restaurant, person, or account identifiers.
+- Run `npm run test:db` from the repo root; it `cd`s into `supabase/tests` and runs `./run_tests.sh`.
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `supabase/migrations/20260804091000_standing_categorization_sweep.sql` | Create | Replace the drain without self-retirement; schedule the standing job |
+| `supabase/tests/51_standing_categorization_sweep.sql` | Create | Conformance: the properties that make future POS coverage automatic |
+| `supabase/tests/50_categorization_backlog_drain.sql` | Modify | Invert the three assertions that pin self-retirement |
+
+---
+
+### Task 1: Migration — the drain stops retiring itself, and gets a standing job
+
+**Files:**
+- Create: `supabase/migrations/20260804091000_standing_categorization_sweep.sql`
+
+**Interfaces:**
+- Consumes: `apply_rules_to_pos_sales_internal(uuid, integer)` and `apply_rules_to_bank_transactions_internal(uuid, integer, boolean)`, both returning `(applied_count integer, total_count integer)`; `rebuild_account_balances(uuid)`.
+- Produces: `public.drain_categorization_backlog() RETURNS integer` (signature unchanged) and a pg_cron job named `categorization-backlog-drain` on `*/5 * * * *`.
+
+Three edits to the body as it stands at
+[20260804090700_categorization_watermark_and_drain_convergence.sql:81-257](../../../supabase/migrations/20260804090700_categorization_watermark_and_drain_convergence.sql:81):
+
+1. Both restaurant loops gain a deterministic wrapper + `ORDER BY random()`. Note the wrapper is **required**: `ORDER BY random()` directly on a `SELECT DISTINCT` is a syntax error ("for SELECT DISTINCT, ORDER BY expressions must appear in select list"), so the DISTINCT goes in a subquery.
+2. The self-retire `IF … cron.unschedule … ELSE … END IF` block at
+   [:195-253](../../../supabase/migrations/20260804090700_categorization_watermark_and_drain_convergence.sql:195)
+   — comment header included — becomes an unconditional `RAISE LOG`. The `NOT EXISTS (… leftover …)` subquery goes with it; it had no other consumer.
+3. New `COMMENT ON FUNCTION` stating the standing contract.
+
+- [ ] **Step 1: Write the migration**
+
+Create `supabase/migrations/20260804091000_standing_categorization_sweep.sql`:
+
+```sql
+-- Standing categorization sweep.
+--
+-- drain_categorization_backlog() was written as a one-shot backfill: it deleted
+-- its own pg_cron job on a converged pass (20260804090700 §self-retire, and the
+-- original schedule comment at 20260703090000:1045 "The job deletes itself ...
+-- once converged"). It ran four times and retired on 2026-07-04.
+--
+-- That retirement stranded every categorization path that is not wired into a
+-- sync function. unified_sales has two mechanisms and no owner: the
+-- auto_categorize_pos_sale BEFORE INSERT trigger (one shot per row, so a rule
+-- created tomorrow never sees today's rows) and the batch sweep, which only
+-- toast/focus/focus_transactions/revel call inline. square, clover, shift4,
+-- lighthouse, manual_upload and manual have the trigger only.
+-- bank_transactions had exactly one driver -- stripe-sync-transactions, and
+-- only when that sync found new rows.
+--
+-- The fix is to stop retiring. The sweep selects candidates by restaurant_id
+-- and watermark with NO pos_system predicate (20260804090300:130-139), and this
+-- drain selects restaurants by RULE, not by connection table -- so one standing
+-- job covers every POS that exists today and every POS added later, with no
+-- per-integration wiring. Do not add a pos_system filter to either; that is the
+-- property the 51_standing_categorization_sweep.sql conformance test pins.
+--
+-- Retirement is no longer buying anything: since the rules_evaluated_at
+-- negative cache (20260804090300) a converged tick reads no candidates at all.
+
+CREATE OR REPLACE FUNCTION public.drain_categorization_backlog()
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+SET statement_timeout = '120s'
+AS $$
+DECLARE
+  r             RECORD;
+  n_applied     integer;
+  n_claimed     integer;
+  i             integer;
+  v_r_applied   integer;
+  v_total       integer     := 0;
+  v_claimed     integer     := 0;
+  v_errors      integer     := 0;
+  v_budget_hit  boolean     := false;
+  v_started     timestamptz := clock_timestamp();
+  v_budget      interval    := interval '40 seconds';
+BEGIN
+  -- ── POS backlog (a few batches per restaurant per tick) ──────────────────
+  -- ORDER BY random(): no ordering was harmless while this job retired, but a
+  -- permanent job with a fixed planner order starves whoever sorts last every
+  -- single tick once the 40s budget is exhausted mid-pass. Random order gives
+  -- every restaurant equal expected coverage. The DISTINCT is wrapped because
+  -- ORDER BY random() on a SELECT DISTINCT is a syntax error.
+  FOR r IN
+    SELECT d.restaurant_id
+    FROM (
+      SELECT DISTINCT cr.restaurant_id
+      FROM categorization_rules cr
+      WHERE cr.is_active
+        AND cr.auto_apply
+        AND cr.applies_to IN ('pos_sales', 'both')
+    ) d
+    ORDER BY random()
+  LOOP
+    IF v_budget_hit OR clock_timestamp() - v_started > v_budget THEN
+      v_budget_hit := true;
+      EXIT;
+    END IF;
+    BEGIN
+      i := 0;
+      LOOP
+        -- total_count is candidates CLAIMED, not matched. Exiting on
+        -- applied_count would stop at the first bounded batch that happened to
+        -- match nothing and leave older candidates unevaluated forever.
+        SELECT applied_count, total_count INTO n_applied, n_claimed
+        FROM apply_rules_to_pos_sales_internal(r.restaurant_id, 5000);
+        v_total   := v_total   + COALESCE(n_applied, 0);
+        v_claimed := v_claimed + COALESCE(n_claimed, 0);
+        i := i + 1;
+        EXIT WHEN COALESCE(n_claimed, 0) = 0 OR i >= 2;
+        IF clock_timestamp() - v_started > v_budget THEN
+          v_budget_hit := true;
+          EXIT;
+        END IF;
+      END LOOP;
+    EXCEPTION
+      -- WHEN OTHERS does NOT catch query_canceled (57014); name it explicitly
+      -- so a timed-out batch skips this restaurant instead of aborting the tick.
+      -- Treat it as time exhaustion so the pass is not considered complete.
+      WHEN query_canceled THEN
+        v_errors := v_errors + 1;
+        v_budget_hit := true;
+        RAISE WARNING 'categorization drain (pos) canceled for restaurant %: %',
+          r.restaurant_id, SQLERRM;
+      WHEN OTHERS THEN
+        v_errors := v_errors + 1;
+        RAISE WARNING 'categorization drain (pos) failed for restaurant %: %',
+          r.restaurant_id, SQLERRM;
+    END;
+  END LOOP;
+
+  -- ── Bank backlog (a few batches per restaurant per tick) ─────────────────
+  FOR r IN
+    SELECT d.restaurant_id
+    FROM (
+      SELECT DISTINCT cr.restaurant_id
+      FROM categorization_rules cr
+      WHERE cr.is_active
+        AND cr.auto_apply
+        AND cr.applies_to IN ('bank_transactions', 'both')
+    ) d
+    ORDER BY random()
+  LOOP
+    IF v_budget_hit OR clock_timestamp() - v_started > v_budget THEN
+      v_budget_hit := true;
+      EXIT;
+    END IF;
+    BEGIN
+      i := 0;
+      v_r_applied := 0;
+      LOOP
+        -- p_skip_rebuild=true: one rebuild per restaurant per tick (below),
+        -- not one per batch — rebuilds dominate the cost otherwise.
+        SELECT applied_count, total_count INTO n_applied, n_claimed
+        FROM apply_rules_to_bank_transactions_internal(r.restaurant_id, 1000, true);
+        v_total     := v_total     + COALESCE(n_applied, 0);
+        v_claimed   := v_claimed   + COALESCE(n_claimed, 0);
+        v_r_applied := v_r_applied + COALESCE(n_applied, 0);
+        i := i + 1;
+        EXIT WHEN COALESCE(n_claimed, 0) = 0 OR i >= 5;
+        IF clock_timestamp() - v_started > v_budget THEN
+          v_budget_hit := true;
+          EXIT;
+        END IF;
+      END LOOP;
+      -- Rebuild once per tick, only when this restaurant applied rows. Claiming
+      -- candidates that matched nothing changes no balance, so it must not
+      -- trigger a rebuild.
+      IF v_r_applied > 0 THEN
+        PERFORM rebuild_account_balances(r.restaurant_id);
+      END IF;
+    EXCEPTION
+      WHEN query_canceled THEN
+        v_errors := v_errors + 1;
+        v_budget_hit := true;
+        RAISE WARNING 'categorization drain (bank) canceled for restaurant %: %',
+          r.restaurant_id, SQLERRM;
+      WHEN OTHERS THEN
+        v_errors := v_errors + 1;
+        RAISE WARNING 'categorization drain (bank) failed for restaurant %: %',
+          r.restaurant_id, SQLERRM;
+    END;
+  END LOOP;
+
+  -- ── No self-retirement ────────────────────────────────────────────────────
+  -- This tick never unschedules its own job, whatever the outcome. A converged
+  -- backlog is not a terminal state: the next rule a user creates lowers the
+  -- watermark and makes their whole history a candidate again. The previous
+  -- version retired here and left 3,351 bank rows and 9,333 POS rows stranded
+  -- for a month with no automated driver.
+  RAISE LOG 'categorization drain: applied % rows of % claimed this tick (errors=%, budget_hit=%)',
+    v_total, v_claimed, v_errors, v_budget_hit;
+
+  RETURN v_total;
+END;
+$$;
+
+COMMENT ON FUNCTION public.drain_categorization_backlog() IS
+  'Standing bounded (~40s) sweep that applies categorization rules to the '
+  'uncategorized POS and bank backlog for every restaurant with an active '
+  'auto_apply rule. Runs permanently every 5 minutes as the '
+  'categorization-backlog-drain pg_cron job and NEVER unschedules itself -- a '
+  'converged backlog is not terminal, because the next rule a user creates '
+  'lowers the watermark and re-opens their history. POS-agnostic by '
+  'construction: restaurants are selected by rule and candidates by watermark, '
+  'with no pos_system predicate anywhere, so a POS integration added later is '
+  'covered with no wiring. Returns rows applied this tick.';
+
+-- Re-assert the 20260703090000 hardening. CREATE OR REPLACE preserves the
+-- existing ACL, but restating it keeps this file correct if it is ever replayed
+-- against a database where the function was created fresh.
+REVOKE ALL ON FUNCTION public.drain_categorization_backlog() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.drain_categorization_backlog() TO service_role;
+
+-- Schedule the standing job. Unschedule-then-schedule converges from either
+-- state: production, where the job is absent because it retired itself on
+-- 2026-07-04, and any environment where it still exists on some other schedule.
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'categorization-backlog-drain') THEN
+    PERFORM cron.unschedule('categorization-backlog-drain');
+  END IF;
+  PERFORM cron.schedule(
+    'categorization-backlog-drain',
+    '*/5 * * * *',
+    'SELECT public.drain_categorization_backlog()'
+  );
+END $$;
+```
+
+- [ ] **Step 2: Apply it and confirm the job exists**
+
+Run:
+
+```bash
+npm run db:reset
+```
+
+Expected: completes without error. Then confirm the standing job landed:
+
+```bash
+PGPASSWORD=postgres psql -h localhost -p 54322 -U postgres -d postgres -c "SELECT jobname, schedule, command FROM cron.job WHERE jobname = 'categorization-backlog-drain';"
+```
+
+Expected: exactly one row, `*/5 * * * *`, `SELECT public.drain_categorization_backlog()`.
+
+If `psql` is not on PATH, use the container the test runner falls back to:
+
+```bash
+docker exec -i "$(docker ps --format '{{.Names}}' | grep -E 'supabase_db_|supabase-db' | head -1)" psql -U postgres -d postgres -c "SELECT jobname, schedule FROM cron.job WHERE jobname = 'categorization-backlog-drain';"
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/categorization-standing-sweep add supabase/migrations/20260804091000_standing_categorization_sweep.sql
+git -C /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/categorization-standing-sweep commit -m "fix(categorization): make the backlog drain a standing */5 sweep
+
+It deleted its own cron job on a converged pass and retired on 2026-07-04,
+stranding 3,351 bank rows and 9,333 POS rows with no automated driver. A
+converged backlog is not terminal: the next rule a user creates re-opens
+their whole history.
+
+Also orders both restaurant loops randomly — a fixed planner order starves
+whoever sorts last on every budget-exhausted tick once the job is permanent.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Invert the tests that pin self-retirement
+
+**Files:**
+- Modify: `supabase/tests/50_categorization_backlog_drain.sql`
+
+Three assertions there encode the behaviour Task 1 removed. They are inverted, not deleted — an old test flipped to pin the new behaviour is the cheapest regression guard available. Test count stays at 10.
+
+- [ ] **Step 1: Run the existing suite and watch these three fail**
+
+Run:
+
+```bash
+npm run test:db
+```
+
+Expected: `50_categorization_backlog_drain.sql` fails on tests 6 and 10 (both assert the job was unscheduled; it now survives). Test 9 still passes. This confirms the old tests genuinely pinned the old behaviour.
+
+- [ ] **Step 2: Rewrite the file header**
+
+Replace lines 1-25 (from `-- Tests for the deferred categorization backlog drain` through the `-- (re)scheduled inside this rolled-back transaction ...` NOTE) with:
+
+```sql
+-- Tests for the standing categorization backlog sweep
+-- Migrations: 20260703090000 (§7, original), 20260804090700 (convergence guard),
+--             20260804091000 (standing sweep — retirement removed)
+--
+-- The original §7 drained the whole backlog synchronously inside the migration
+-- and timed out production deploys (SQLSTATE 57014). It became a bounded
+-- 5-minute pg_cron tick that unscheduled itself once converged — which stranded
+-- every categorization path not wired into a sync function. It is now a
+-- PERMANENT 5-minute tick that never retires.
+--
+-- Test plan (10 tests):
+--  1  drain_categorization_backlog() exists
+--  2  the drain job can be (re)scheduled on */5 * * * *
+--  3  anon cannot execute the SECURITY DEFINER drain (PUBLIC revoked)
+--  4  authenticated cannot execute it either
+--  5  a tick on an empty database applies 0 rows (no error)
+--  6  that converged tick leaves its own cron job scheduled
+--  7  categorization_rules_watermark returns the newest active-rule timestamp
+--  8  categorization_rules_watermark is NULL when no active rule covers the scope
+--  9  a tick with a backlog waiting leaves the job scheduled
+-- 10  a tick that exhausts the backlog still leaves the job scheduled
+--
+-- Tests 6 and 10 are the inverted forms of assertions that pinned the old
+-- self-retirement. They are the regression guard for the 2026-07-04 strand:
+-- if retirement ever returns, both fail.
+```
+
+- [ ] **Step 3: Invert test 6**
+
+Replace lines 76-80:
+
+```sql
+-- Test 6: that complete, error-free, 0-row tick retired the cron job.
+SELECT ok(
+  NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'categorization-backlog-drain'),
+  'a converged (complete + clean + 0-row) tick unschedules the drain job'
+);
+```
+
+with:
+
+```sql
+-- Test 6: a converged tick does NOT retire the job. Convergence is not a
+-- terminal state — the next rule a user creates lowers the watermark and makes
+-- their whole history a candidate again, and this job is the only driver that
+-- would notice.
+SELECT ok(
+  EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'categorization-backlog-drain'),
+  'a converged (complete + clean + 0-row) tick leaves the drain job scheduled'
+);
+```
+
+- [ ] **Step 4: Rewrite the retirement-guard comment block**
+
+Replace lines 82-89 (the `-- Retirement guard (20260804090700)` block) with:
+
+```sql
+-- ---------------------------------------------------------------------------
+-- Claim accounting (20260804090700). The sweeps claim FOR UPDATE SKIP LOCKED,
+-- so a tick can claim 0 rows while a backlog is still there — which is why
+-- total_count (claimed), not applied_count (matched), drives the drain loop.
+-- Tests 9/10 pin that the job survives both states: work waiting, and work
+-- exhausted.
+-- ---------------------------------------------------------------------------
+```
+
+- [ ] **Step 5: Delete the now-dead re-arm block**
+
+Delete lines 148-159 entirely — the comment `-- Re-arm the job that test 6 retired, ...` and the `DO $$ ... END $$;` that follows it. Test 6 no longer retires anything, so there is nothing to re-arm.
+
+- [ ] **Step 6: Keep the statement-snapshot comment verbatim, and invert test 10**
+
+Leave lines 161-165 (the `-- Each tick runs as its OWN statement ...` warning) exactly as they are. That hazard caused a real pgTAP failure and still applies to any assertion that reads `cron.job` after calling the drain.
+
+Test 9 (lines 167-173) is unchanged — still true, still meaningful.
+
+Replace lines 175-183:
+
+```sql
+-- Test 10: the previous tick stamped every candidate, so nothing claimable is
+-- left and the next tick converges. Guards against a leftover check so wide
+-- that unmatched rows keep the job scheduled forever.
+SELECT public.drain_categorization_backlog();
+
+SELECT ok(
+  NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'categorization-backlog-drain'),
+  'once every candidate is evaluated the drain still retires itself'
+);
+```
+
+with:
+
+```sql
+-- Test 10: the previous tick stamped every candidate, so this one converges —
+-- and the job still survives. Together with test 9 this pins job survival
+-- across both outcomes, which is what makes the sweep permanent.
+SELECT public.drain_categorization_backlog();
+
+SELECT ok(
+  EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'categorization-backlog-drain'),
+  'a tick that exhausts the backlog still leaves the job scheduled'
+);
+```
+
+- [ ] **Step 7: Run the suite and verify 50 passes**
+
+Run:
+
+```bash
+npm run test:db
+```
+
+Expected: `50_categorization_backlog_drain.sql` reports 10/10 passing.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git -C /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/categorization-standing-sweep add supabase/tests/50_categorization_backlog_drain.sql
+git -C /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/categorization-standing-sweep commit -m "test(categorization): invert the assertions that pinned self-retirement
+
+Tests 6 and 10 asserted the drain unschedules its own cron job. They now
+assert the opposite, so they become the regression guard for the 2026-07-04
+strand rather than a pin on the bug that caused it.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Conformance test — the properties that make future POS coverage free
+
+**Files:**
+- Create: `supabase/tests/51_standing_categorization_sweep.sql`
+
+**Interfaces:**
+- Consumes: `public.drain_categorization_backlog()`, `public.apply_rules_to_pos_sales_internal(uuid, integer)`, the `categorization-backlog-drain` cron job created in Task 1.
+- Produces: nothing. Terminal test file.
+
+Fixture namespace is `dddddddd-0000-0000-0000-…`, grep-verified unused anywhere under `supabase/` (`bbbbbbbb-0000` belongs to `50_categorization_backlog_drain.sql:91-110`, `cccccccc-0000` to `schedule_plan_templates.test.sql` and `receipt_file_hash.test.sql`).
+
+Two things this file does differently from 50, both deliberate:
+
+- It asserts the **real, migration-created** job rather than re-scheduling one inside the transaction. 50 could not do that, because the live pg_cron in the test database might legitimately have retired the job before the file ran ([50:20-25](../../../supabase/tests/50_categorization_backlog_drain.sql:20)). With retirement gone, the job's existence is deterministic — and asserting the real one is what actually proves the migration scheduled it.
+- Rows are inserted **before** their matching rules exist, so the `BEFORE INSERT` triggers (`auto_categorize_pos_sale` at [20251111000000:554-558](../../../supabase/migrations/20251111000000_enhanced_categorization_rules.sql:554), `auto_categorize_bank_transaction` at [20251111000000:611-614](../../../supabase/migrations/20251111000000_enhanced_categorization_rules.sql:611)) find nothing to apply. That needs no GUC suppression and reproduces the production bug exactly: a row that existed before its rule did. Note `auto_apply_bank_categorization_rules` honours no skip GUC, so ordering is the only way to leave a bank row uncategorized.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `supabase/tests/51_standing_categorization_sweep.sql`:
+
+```sql
+-- Conformance tests for the standing categorization sweep
+-- Migration: 20260804091000_standing_categorization_sweep.sql
+--
+-- These are the codified pattern for future POS integrations. Categorization
+-- reaches a new POS with zero wiring only while three properties hold, and each
+-- test below pins one of them:
+--
+--   * the sweep job runs permanently and never retires  (tests 1, 4)
+--   * the drain cannot reacquire the ability to retire   (test 2)
+--   * the sweep carries no pos_system predicate          (tests 3, 5)
+--
+-- If a future change breaks one of these, the failure message says which
+-- property was lost and why it mattered.
+--
+-- Test plan (7 tests):
+--  1  the migration scheduled a standing */5 categorization-backlog-drain job
+--  2  drain_categorization_backlog contains no cron.unschedule
+--  3  apply_rules_to_pos_sales_internal contains no pos_system predicate
+--  4  a converged tick leaves the standing job scheduled
+--  5  a row whose pos_system no sync function knows about is still categorized
+--  6  a bank_transactions candidate is categorized by the same mechanism
+--  7  one tick covers both tables
+
+BEGIN;
+SELECT plan(7);
+
+-- Test 1: the job the migration created is really there, on the real schedule.
+-- Unlike 50_categorization_backlog_drain.sql this does NOT re-schedule the job
+-- first: with retirement gone, the migration-time job's existence is
+-- deterministic, and asserting the real one is what proves the migration
+-- scheduled it at all.
+SELECT is(
+  (SELECT schedule FROM cron.job WHERE jobname = 'categorization-backlog-drain'),
+  '*/5 * * * *',
+  'the migration leaves a standing categorization-backlog-drain job on */5'
+);
+
+-- ---------------------------------------------------------------------------
+-- Tests 2/3 match against the function source with SQL comments stripped.
+-- Without stripping they would punish exactly the behaviour this codebase
+-- rewards: 20260804091000 carries a comment saying "do not add a pos_system
+-- filter", and an unstripped match would fail on the warning that explains the
+-- test. Strip block comments first (dot-matches-newline), then line comments.
+-- ---------------------------------------------------------------------------
+
+-- Test 2: the drain can never reacquire the ability to retire. Structural, not
+-- behavioural — test 4 proves it does not retire on a converged tick, this
+-- proves the code to do so is simply absent on every path.
+SELECT ok(
+  regexp_replace(
+    regexp_replace(pg_get_functiondef(p.oid), '/\*.*?\*/', '', 'gs'),
+    '--[^\n]*', '', 'g'
+  ) NOT ILIKE '%cron.unschedule%',
+  'drain_categorization_backlog contains no cron.unschedule'
+)
+FROM pg_proc p
+JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = 'public' AND p.proname = 'drain_categorization_backlog';
+
+-- Test 3: THE property that makes a future POS free. The sweep selects
+-- candidates by restaurant_id and watermark only. Adding "AND s.pos_system =
+-- ..." as an optimization would silently orphan every other POS, exactly as
+-- relying on per-POS sync wiring already did.
+SELECT ok(
+  regexp_replace(
+    regexp_replace(pg_get_functiondef(p.oid), '/\*.*?\*/', '', 'gs'),
+    '--[^\n]*', '', 'g'
+  ) NOT ILIKE '%pos_system%',
+  'apply_rules_to_pos_sales_internal carries no pos_system predicate'
+)
+FROM pg_proc p
+JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = 'public'
+  AND p.proname = 'apply_rules_to_pos_sales_internal';
+
+-- ---------------------------------------------------------------------------
+-- Fixtures. Rows are inserted BEFORE their rules exist, so the BEFORE INSERT
+-- triggers find nothing to apply and both rows land as genuine candidates
+-- (rules_evaluated_at defaults to '-infinity'). This reproduces the production
+-- bug directly: a row that predates the rule that would match it.
+-- auto_apply_bank_categorization_rules honours no skip GUC, so insert ordering
+-- is the only way to leave a bank row uncategorized.
+-- ---------------------------------------------------------------------------
+
+INSERT INTO restaurants (id, name) VALUES
+  ('dddddddd-0000-0000-0000-0000000000a1', 'Standing Sweep Restaurant')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO chart_of_accounts
+  (id, restaurant_id, account_name, account_code, account_type, account_subtype, normal_balance)
+VALUES
+  ('dddddddd-0000-0000-0000-0000000000c1', 'dddddddd-0000-0000-0000-0000000000a1',
+   'Food Sales', '4000', 'revenue', 'sales', 'credit')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO connected_banks
+  (id, restaurant_id, stripe_financial_account_id, institution_name)
+VALUES
+  ('dddddddd-0000-0000-0000-0000000000b1', 'dddddddd-0000-0000-0000-0000000000a1',
+   'fca_standing_sweep_fixture', 'Placeholder Bank')
+ON CONFLICT (id) DO NOTHING;
+
+-- A pos_system value no sync function, connection table, or edge function
+-- knows about. unified_sales.pos_system is a bare TEXT NOT NULL with no CHECK
+-- and no enum (20250925125415:13), which is itself part of why a new POS needs
+-- no migration — if this INSERT ever starts failing, that property is gone.
+INSERT INTO unified_sales
+  (id, restaurant_id, pos_system, external_order_id, item_name, quantity,
+   sale_date, total_price)
+VALUES
+  ('dddddddd-0000-0000-0000-0000000000d1', 'dddddddd-0000-0000-0000-0000000000a1',
+   'future_pos', 'ord-future-1', 'Future POS Item', 1, CURRENT_DATE, 12.00)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO bank_transactions
+  (id, restaurant_id, connected_bank_id, stripe_transaction_id,
+   transaction_date, description, amount)
+VALUES
+  ('dddddddd-0000-0000-0000-0000000000e1', 'dddddddd-0000-0000-0000-0000000000a1',
+   'dddddddd-0000-0000-0000-0000000000b1', 'txn_standing_sweep_fixture',
+   CURRENT_DATE, 'STANDING SWEEP VENDOR', -25.00)
+ON CONFLICT (id) DO NOTHING;
+
+-- Now the rules, after the rows. The restaurant has no POS connection row of
+-- any kind — the drain selects restaurants by RULE, so it is swept anyway.
+INSERT INTO categorization_rules
+  (id, restaurant_id, rule_name, applies_to, category_id, item_name_pattern,
+   item_name_match_type, is_active, auto_apply, priority, created_at, updated_at)
+VALUES
+  ('dddddddd-0000-0000-0000-0000000000f1', 'dddddddd-0000-0000-0000-0000000000a1',
+   'Future POS rule', 'pos_sales', 'dddddddd-0000-0000-0000-0000000000c1',
+   'Future POS Item', 'exact', true, true, 10,
+   '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO categorization_rules
+  (id, restaurant_id, rule_name, applies_to, category_id, description_pattern,
+   description_match_type, is_active, auto_apply, priority, created_at, updated_at)
+VALUES
+  ('dddddddd-0000-0000-0000-0000000000f2', 'dddddddd-0000-0000-0000-0000000000a1',
+   'Standing sweep bank rule', 'bank_transactions', 'dddddddd-0000-0000-0000-0000000000c1',
+   'STANDING SWEEP VENDOR', 'exact', true, true, 10,
+   '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')
+ON CONFLICT (id) DO NOTHING;
+
+-- One tick, captured so tests 5, 6 and 7 all describe the SAME tick.
+CREATE TEMP TABLE standing_sweep_tick AS
+SELECT public.drain_categorization_backlog() AS applied;
+
+-- Test 5: the whole point. Nothing anywhere knows what 'future_pos' is, and it
+-- is categorized regardless — because the sweep selects by restaurant and
+-- watermark, never by POS.
+SELECT ok(
+  (SELECT is_categorized AND category_id = 'dddddddd-0000-0000-0000-0000000000c1'
+   FROM unified_sales WHERE id = 'dddddddd-0000-0000-0000-0000000000d1'),
+  'a row whose pos_system no sync function knows about is still categorized'
+);
+
+-- Test 6: bank_transactions is covered by the same standing job. Before
+-- 20260804091000 its only driver was stripe-sync-transactions, and only on a
+-- sync that found new rows — so a backlog with no new activity never drained.
+SELECT ok(
+  (SELECT is_categorized AND category_id = 'dddddddd-0000-0000-0000-0000000000c1'
+   FROM bank_transactions WHERE id = 'dddddddd-0000-0000-0000-0000000000e1'),
+  'a bank_transactions candidate is categorized by a drain tick'
+);
+
+-- Test 7: both of the above came from ONE tick of ONE job. This is the
+-- "one standing job covers everything" claim, stated as an assertion.
+SELECT cmp_ok(
+  (SELECT applied FROM standing_sweep_tick),
+  '>=',
+  2,
+  'a single tick applies both the POS row and the bank row'
+);
+
+-- Test 4: the backlog is now exhausted for this restaurant, and the job still
+-- survives. Run as its OWN statement, never folded into the assertion: an outer
+-- scan of cron.job reads the snapshot taken when the statement began, so a
+-- cron.unschedule() performed by a volatile function in the same command is
+-- invisible to it — the combined form would silently test nothing.
+SELECT public.drain_categorization_backlog();
+
+SELECT ok(
+  EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'categorization-backlog-drain'),
+  'a converged tick leaves the standing job scheduled'
+);
+
+SELECT * FROM finish();
+ROLLBACK;
+```
+
+- [ ] **Step 2: Run it against the migration from Task 1**
+
+Run:
+
+```bash
+npm run test:db
+```
+
+Expected: `51_standing_categorization_sweep.sql` reports 7/7 passing.
+
+If test 5 or 6 fails with the row still uncategorized, the likely cause is the watermark: `categorization_rules_watermark` returns `max(GREATEST(created_at, updated_at))` over active rules, and the sweep only claims rows whose `rules_evaluated_at` is strictly less than it. The fixture rules are stamped `2026-01-01`, which is greater than the `-infinity` default, so this should hold; if a touch trigger has rewritten `updated_at`, read the actual watermark with:
+
+```bash
+PGPASSWORD=postgres psql -h localhost -p 54322 -U postgres -d postgres -c "SELECT public.categorization_rules_watermark('dddddddd-0000-0000-0000-0000000000a1','pos_sales');"
+```
+
+- [ ] **Step 3: Prove the conformance tests actually bite**
+
+A conformance test that cannot fail is decoration. Temporarily add `AND s.pos_system IS NOT NULL` to the batch CTE in `apply_rules_to_pos_sales_internal` (in a scratch `psql` session, not in a file), re-run `npm run test:db`, and confirm test 3 fails. Then `npm run db:reset` to discard the scratch change.
+
+Expected: test 3 fails with `apply_rules_to_pos_sales_internal carries no pos_system predicate`; after the reset, 7/7 pass again.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git -C /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/categorization-standing-sweep add supabase/tests/51_standing_categorization_sweep.sql
+git -C /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/categorization-standing-sweep commit -m "test(categorization): codify the standing-sweep contract for future POS
+
+Pins the three properties that let a new POS inherit categorization with no
+wiring: the job runs permanently, the drain cannot reacquire the ability to
+retire, and the sweep carries no pos_system predicate. Test 5 proves it
+behaviourally with a pos_system value nothing in the codebase knows about.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Full verification
+
+**Files:** none modified.
+
+- [ ] **Step 1: Full database suite**
+
+Run:
+
+```bash
+npm run test:db
+```
+
+Expected: every file passes, including 50 (10/10) and 51 (7/7).
+
+- [ ] **Step 2: Typecheck and lint**
+
+Run:
+
+```bash
+npm run typecheck && npm run lint
+```
+
+Expected: both clean. No TypeScript changed, so this is a no-regression check — `drain_categorization_backlog`'s signature is unchanged, so `src/integrations/supabase/types.ts` needs no regeneration.
+
+- [ ] **Step 3: Unit suite**
+
+Run:
+
+```bash
+npm run test
+```
+
+Expected: passes. Nothing in `src/` changed.
+
+**E2E:** none, and this is a deliberate exception to the Phase 8 coverage gate rather than an omission. The change is a pg_cron-scheduled SQL function; there is no route, dialog, form, or flow to drive, and Playwright cannot advance pg_cron. pgTAP is the only level at which this behaviour is observable.
+
+---
+
+## Post-deploy verification (not a build step — run within minutes of merge)
+
+On 2026-07-05 a scheduler change passed five reviewers, Codex, CodeRabbit, 19 pgTAP tests and full CI, and the defect was caught only by production verification minutes after deploy. "Cron ticks succeeded" says nothing about whether work is being *selected*. Against production, read-only:
+
+```sql
+-- 1. the standing job exists
+SELECT jobid, jobname, schedule, active FROM cron.job
+WHERE jobname = 'categorization-backlog-drain';
+
+-- 2. its ticks are succeeding
+SELECT status, count(*), max(end_time)
+FROM cron.job_run_details
+WHERE jobid = (SELECT jobid FROM cron.job WHERE jobname = 'categorization-backlog-drain')
+GROUP BY status;
+
+-- 3. work is actually being selected — these counts must FALL
+SELECT 'bank' AS scope, count(*) FROM bank_transactions bt
+WHERE (bt.is_categorized = false OR bt.category_id IS NULL)
+  AND bt.is_split = false AND bt.excluded_reason IS NULL
+  AND bt.rules_evaluated_at
+      < public.categorization_rules_watermark(bt.restaurant_id, 'bank_transactions')
+UNION ALL
+SELECT s.pos_system, count(*) FROM unified_sales s
+WHERE (s.is_categorized = false OR s.category_id IS NULL)
+  AND s.is_split = false
+  AND s.rules_evaluated_at
+      < public.categorization_rules_watermark(s.restaurant_id, 'pos_sales')
+GROUP BY s.pos_system;
+```
+
+Baseline to beat (production, 2026-08-04): bank 3,351; lighthouse 7,967; manual_upload 955; square 185; toast 153; clover 37; manual 36.
+
+Also confirm ticks settle to sub-second once drained, and that no restaurant is starved — if one `pos_system` stops falling while others clear, the `ORDER BY random()` rotation is not keeping up and the budget needs raising.
+
+## Self-Review
+
+**Spec coverage.** Every design section maps to a task: §1 (drain replacement) and §2 (schedule) → Task 1; §3 (conformance test) → Task 3; §4 (invert tests) → Task 2; "What this does not change" → verified by Task 4 finding no `src/` or edge-function work. The review-response items are all carried: comment-stripped regex in Task 3 Step 1, `ORDER BY random()` with the DISTINCT-wrapper syntax fix in Task 1 Step 1, the overlap note in the migration's own comments.
+
+**Placeholder scan.** No TBD, no "add error handling", no "similar to Task N". Every code step carries the literal file content.
+
+**Type consistency.** `drain_categorization_backlog()` keeps `RETURNS integer` throughout; `apply_rules_to_pos_sales_internal(uuid, integer)` and `apply_rules_to_bank_transactions_internal(uuid, integer, boolean)` are called with the same arities the existing body uses. The job name string `categorization-backlog-drain` is identical in the migration, both test files, and the verification queries.

--- a/docs/superpowers/plans/2026-08-04-categorization-standing-sweep-plan.md
+++ b/docs/superpowers/plans/2026-08-04-categorization-standing-sweep-plan.md
@@ -770,6 +770,21 @@ Baseline to beat (production, 2026-08-04): bank 3,351; lighthouse 7,967; manual_
 
 Also confirm ticks settle to sub-second once drained, and that no restaurant is starved — if one `pos_system` stops falling while others clear, the `ORDER BY random()` rotation is not keeping up and the budget needs raising.
 
+```sql
+-- 4. churn: the stamp on rules_evaluated_at can never be a HOT update, because
+-- that column is a leading key of both candidate indexes. Not new — but the
+-- standing job extends it permanently to bank_transactions and to the POS
+-- systems that previously only saw the one-shot insert trigger.
+SELECT relname, n_live_tup, n_dead_tup,
+       round(100.0*n_dead_tup/GREATEST(n_live_tup,1),2) AS dead_pct,
+       round(100.0*n_tup_hot_upd/GREATEST(n_tup_upd,1),1) AS hot_pct,
+       last_autovacuum
+FROM pg_stat_user_tables
+WHERE relname IN ('unified_sales','bank_transactions','categorization_rules');
+```
+
+Baseline (production, 2026-08-04): `unified_sales` 190,727 live / 8,745 dead (4.59%) / 72.2% HOT; `bank_transactions` 7,532 live / 561 dead (7.45%) / 2.0% HOT; `categorization_rules` 956 live / 159 dead (16.63%) / 89.6% HOT. Expect dead-tuple counts to spike while the backlog drains and then settle. If `dead_pct` on either table climbs past ~20% and stays there once the backlog is clear, lower `autovacuum_vacuum_scale_factor` on that table rather than slowing the job.
+
 ## Self-Review
 
 **Spec coverage.** Every design section maps to a task: §1 (drain replacement) and §2 (schedule) → Task 1; §3 (conformance test) → Task 3; §4 (invert tests) → Task 2; "What this does not change" → verified by Task 4 finding no `src/` or edge-function work. The review-response items are all carried: comment-stripped regex in Task 3 Step 1, `ORDER BY random()` with the DISTINCT-wrapper syntax fix in Task 1 Step 1, the overlap note in the migration's own comments.

--- a/docs/superpowers/specs/2026-08-04-categorization-standing-sweep-design.md
+++ b/docs/superpowers/specs/2026-08-04-categorization-standing-sweep-design.md
@@ -1,0 +1,294 @@
+# Standing Categorization Sweep — Design
+
+**Date:** 2026-08-04
+**Branch:** `fix/categorization-standing-sweep`
+**Status:** Proposed
+
+## Problem
+
+Categorization has two mechanisms and no owner. Neither one ever revisits a row
+after that row's single chance to be evaluated, so any row inserted before its
+matching rule existed stays uncategorized forever.
+
+### Mechanism 1 — the insert-time trigger (one shot per row)
+
+`auto_categorize_pos_sale` is a `BEFORE INSERT` trigger on `unified_sales`
+([20251111000000_enhanced_categorization_rules.sql:554-558](../../../supabase/migrations/20251111000000_enhanced_categorization_rules.sql:554))
+running `auto_apply_pos_categorization_rules()`
+([20251111000000_enhanced_categorization_rules.sql:505](../../../supabase/migrations/20251111000000_enhanced_categorization_rules.sql:505)).
+It fires exactly once, at insert. A rule created tomorrow never sees the rows
+inserted today.
+
+### Mechanism 2 — the batch sweep (only some callers invoke it)
+
+`apply_rules_to_pos_sales_internal(p_restaurant_id uuid, p_batch_limit integer)`
+([20260804090300_bounded_categorization_sweep.sql:130-139](../../../supabase/migrations/20260804090300_bounded_categorization_sweep.sql:130))
+claims a batch of candidates with `FOR UPDATE SKIP LOCKED`, evaluates them, and
+stamps `rules_evaluated_at`. Four sync functions call it inline, immediately
+after suppressing the insert trigger via `app.skip_unified_sales_triggers`:
+
+| Caller | Location |
+|---|---|
+| `sync_toast_to_unified_sales` (both overloads) | prod `pg_get_functiondef`, confirmed 2026-08-04 |
+| `sync_focus_to_unified_sales` impl | prod `pg_get_functiondef`, confirmed 2026-08-04 |
+| `sync_focus_transactions_to_unified_sales` impl | prod `pg_get_functiondef`, confirmed 2026-08-04 |
+| `sync_revel_to_unified_sales` | [20260804090400_pos_sync_failure_visibility.sql:546](../../../supabase/migrations/20260804090400_pos_sync_failure_visibility.sql:546) |
+
+Every other write path into `unified_sales` — square, clover, shift4,
+lighthouse, manual_upload, manual — relies on Mechanism 1 alone. Notably
+`sync_all_toast_to_unified_sales()`
+([20260804090400_pos_sync_failure_visibility.sql:72](../../../supabase/migrations/20260804090400_pos_sync_failure_visibility.sql:72))
+and `sync_all_shift4_to_unified_sales()`
+([20260804090400_pos_sync_failure_visibility.sql:141](../../../supabase/migrations/20260804090400_pos_sync_failure_visibility.sql:141))
+do **not** call the sweep themselves; coverage comes from the per-restaurant
+function the Toast wrapper calls, and Shift4 has no such call anywhere.
+
+### `bank_transactions` — one conditional driver, no cron
+
+`apply_rules_to_bank_transactions_internal` is invoked from exactly one place,
+[stripe-sync-transactions/index.ts:386](../../../supabase/functions/stripe-sync-transactions/index.ts:386),
+and it sits inside `if (syncedCount > 0)`
+([stripe-sync-transactions/index.ts:376](../../../supabase/functions/stripe-sync-transactions/index.ts:376)).
+A restaurant whose Stripe sync returns no new transactions never has its
+existing backlog swept. There is no pg_cron job for it.
+
+### The one universal driver retired itself
+
+`drain_categorization_backlog()`
+([20260804090700_categorization_watermark_and_drain_convergence.sql:81](../../../supabase/migrations/20260804090700_categorization_watermark_and_drain_convergence.sql:81))
+sweeps both tables for every restaurant that has an active auto-apply rule
+(POS loop [:102-144](../../../supabase/migrations/20260804090700_categorization_watermark_and_drain_convergence.sql:102),
+bank loop [:147-193](../../../supabase/migrations/20260804090700_categorization_watermark_and_drain_convergence.sql:147)).
+It is the only mechanism that is not tied to a sync path — and it deletes its
+own pg_cron job on a converged pass
+([:215-249](../../../supabase/migrations/20260804090700_categorization_watermark_and_drain_convergence.sql:215),
+`PERFORM cron.unschedule(...)` at
+[:247](../../../supabase/migrations/20260804090700_categorization_watermark_and_drain_convergence.sql:247)).
+That was deliberate: it was designed as a one-shot backfill, scheduled at
+[20260703090000_categorization_background_and_supplier_assign.sql:1056](../../../supabase/migrations/20260703090000_categorization_background_and_supplier_assign.sql:1056)
+with the comment "The job deletes itself … once converged".
+
+It ran 4 times and retired on 2026-07-04. It is absent from prod's `cron.job`
+today (verified against production 2026-08-04; the 15 remaining jobs include no
+`categorization-backlog-drain` and no clover job at all).
+
+### Measured impact (production, 2026-08-04)
+
+| Scope | Stranded candidates |
+|---|---|
+| `bank_transactions` | 3,351 across 8 restaurants, against 274 active auto-apply bank rules |
+| `unified_sales` | 9,333 unevaluated, spread over lighthouse (7,967), manual_upload (955), square (185), toast (153), clover (37), manual (36) |
+
+## Approach
+
+**Stop retiring the drain. Schedule it permanently at `*/5 * * * *`.**
+
+This is one change, and it fixes bank and every POS at once, because the sweep
+selects candidates by `restaurant_id` and watermark with **no `pos_system`
+predicate**
+([20260804090300_bounded_categorization_sweep.sql:130-139](../../../supabase/migrations/20260804090300_bounded_categorization_sweep.sql:130)),
+and the drain selects restaurants by *rule*, not by connection table
+([20260804090700:102-108](../../../supabase/migrations/20260804090700_categorization_watermark_and_drain_convergence.sql:102)).
+A POS integration added next year inherits categorization the moment its rows
+land in `unified_sales` — no per-POS wiring, no new cron job. That is the
+codified pattern.
+
+### Why retirement was worth removing
+
+Retirement bought one thing: not paying for a converged tick. That cost is now
+near zero. The negative-result cache shipped in PR #693
+(`rules_evaluated_at`, [20260804090300](../../../supabase/migrations/20260804090300_bounded_categorization_sweep.sql))
+means a converged tick reads no candidates at all — production's Toast rollup
+went from 10.992s to 0.719–0.834s after that deploy. Against that, retirement
+costs correctness permanently and silently: the moment a user creates a rule
+after the job has retired, nothing re-evaluates their history.
+
+### Decisions taken
+
+1. **Cadence `*/5 * * * *`.** Matches the four existing POS rollups (jobids 4,
+   6, 30, 38 all run `*/5`). A user who creates a rule sees their history
+   recategorized within five minutes.
+2. **Keep the four inline sweep calls.** They are not redundant with the
+   standing job — those callers suppress the insert trigger, so the inline call
+   is what categorizes their rows *in the same transaction*. Removing them
+   would introduce up to a 5-minute window where freshly synced Toast/Focus/
+   Revel rows show uncategorized. The standing job becomes the safety net, not
+   the mechanism.
+3. **Codify with a pgTAP conformance test**, not with prose. A doc telling
+   future integrators to "remember to call the sweep" is exactly the failure
+   mode we are fixing. The test asserts the structural properties that make
+   coverage automatic.
+
+## Changes
+
+### 1. Migration — `drain_categorization_backlog()` never retires
+
+`CREATE OR REPLACE FUNCTION public.drain_categorization_backlog()` restating the
+full body from
+[20260804090700:81-257](../../../supabase/migrations/20260804090700_categorization_watermark_and_drain_convergence.sql:81)
+with one edit: the `IF v_claimed = 0 AND … THEN cron.unschedule(…)` block
+([:215-249](../../../supabase/migrations/20260804090700_categorization_watermark_and_drain_convergence.sql:215))
+is replaced by an unconditional `RAISE LOG` of the tick outcome.
+
+Everything else is preserved verbatim: `SECURITY DEFINER`,
+`SET search_path = pg_catalog, public`, `SET statement_timeout = '120s'`, the
+40-second soft budget, the POS loop (2 × 5000) and bank loop (5 × 1000 with
+`p_skip_rebuild => true` plus one `rebuild_account_balances` per restaurant per
+tick), and the explicit `WHEN query_canceled` handlers — `WHEN OTHERS` does not
+catch SQLSTATE 57014.
+
+The `NOT EXISTS (… leftover …)` subquery at
+[:219-244](../../../supabase/migrations/20260804090700_categorization_watermark_and_drain_convergence.sql:219)
+existed **only** to gate retirement. With retirement gone it has no consumer, so
+it is deleted — which also removes a per-tick cross-join probe over both tables
+for every restaurant with an active rule. Net effect: a converged tick gets
+cheaper, not more expensive.
+
+The function keeps its name. Renaming would mean `DROP FUNCTION` + recreate,
+plus edits to the cron command, the pgTAP fixtures, and the generated
+`src/integrations/supabase/types.ts` — churn with no behavioural gain. "Drain
+the categorization backlog" still describes what a tick does; only its lifetime
+changes. The `COMMENT ON FUNCTION`
+([:259](../../../supabase/migrations/20260804090700_categorization_watermark_and_drain_convergence.sql:259))
+is rewritten to state the new contract explicitly: standing job, never retires,
+POS-agnostic by construction, covers `bank_transactions` too.
+
+`REVOKE ALL … FROM PUBLIC, anon, authenticated` / `GRANT EXECUTE … TO
+service_role`
+([:272-273](../../../supabase/migrations/20260804090700_categorization_watermark_and_drain_convergence.sql:272))
+are re-asserted, because `CREATE OR REPLACE` on a function that was dropped and
+recreated in some environments would otherwise inherit default ACLs.
+
+### 2. Migration — schedule the standing job
+
+```sql
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'categorization-backlog-drain') THEN
+    PERFORM cron.unschedule('categorization-backlog-drain');
+  END IF;
+  PERFORM cron.schedule(
+    'categorization-backlog-drain',
+    '*/5 * * * *',
+    'SELECT public.drain_categorization_backlog()'
+  );
+END $$;
+```
+
+Unschedule-then-schedule converges from either starting state: prod, where the
+job is absent because it retired itself, and any environment where it still
+exists on a different schedule. Same shape as the original schedule block at
+[20260703090000:1048-1060](../../../supabase/migrations/20260703090000_categorization_background_and_supplier_assign.sql:1048).
+
+No backfill `DO` block. The 12,684 stranded rows drain on the normal ticks:
+POS at 10,000/restaurant/tick and bank at 5,000/restaurant/tick clears the
+current backlog within the first one or two ticks per restaurant, inside the
+40-second budget the function already enforces.
+
+### 3. Conformance test — `supabase/tests/51_standing_categorization_sweep.sql`
+
+The codification. Four properties, each of which would have caught a real bug:
+
+1. **The standing job exists on `*/5 * * * *`.** Catches a migration that
+   replaces the function but forgets the schedule.
+2. **`pg_get_functiondef(drain_categorization_backlog)` contains no
+   `cron.unschedule`.** Structural, not behavioural — it pins that the drain can
+   never again acquire the ability to retire, whatever the tick outcome.
+3. **`pg_get_functiondef(apply_rules_to_pos_sales_internal)` contains no
+   `pos_system` reference.** This is the property that makes future POS
+   integrations free. If someone adds `AND s.pos_system = 'toast'` as an
+   optimization, this test fails and explains why.
+4. **A row with an unrecognized `pos_system` is swept.** The behavioural twin of
+   (3): insert a `unified_sales` row with `pos_system = 'future_pos'` — a value
+   no sync function, connection table, or edge function knows about — plus a
+   matching rule, run one tick, assert the row is categorized. This proves a
+   hypothetical future POS is covered with zero integration work.
+
+Plus regression coverage for the two paths that were broken:
+
+5. A converged tick leaves the job scheduled (the inverse of the 2026-07-04
+   strand).
+6. A `bank_transactions` candidate with an active auto-apply bank rule is
+   categorized by a drain tick.
+
+### 4. Invert the tests that pin the old semantics
+
+`supabase/tests/50_categorization_backlog_drain.sql` currently asserts
+retirement in three places and must be updated, not deleted — an old test that
+pins removed behaviour is the cheapest possible regression guard once inverted:
+
+| Test | Current assertion | Change |
+|---|---|---|
+| 6 ([:76-80](../../../supabase/tests/50_categorization_backlog_drain.sql:76)) | "a converged (complete + clean + 0-row) tick unschedules the drain job" | Invert: a converged tick **keeps** the job scheduled |
+| 9 ([:167-173](../../../supabase/tests/50_categorization_backlog_drain.sql:167)) | "a tick with a backlog waiting does not retire the drain job" | Unchanged — still true, still meaningful |
+| 10 ([:175-183](../../../supabase/tests/50_categorization_backlog_drain.sql:175)) | "once every candidate is evaluated the drain still retires itself" | Invert: the job survives an exhausted backlog |
+
+The re-arm block at
+[:148-159](../../../supabase/tests/50_categorization_backlog_drain.sql:148)
+becomes dead once test 6 no longer retires the job; it is removed. The file
+header ([:1-25](../../../supabase/tests/50_categorization_backlog_drain.sql:1))
+describes the self-retire lifecycle and its live-cron race caveat, and is
+rewritten to match. Tests 1–5 and 7–8 (existence, schedule, the two ACL
+assertions, the empty-database tick, and the two watermark assertions) are
+unaffected.
+
+The one comment that **must survive verbatim** is the statement-snapshot warning
+at [:161-165](../../../supabase/tests/50_categorization_backlog_drain.sql:161):
+each tick runs as its own statement, never folded into the assertion, because an
+outer scan of `cron.job` cannot see a `cron.unschedule()` performed by a
+volatile function called in the same command. That hazard caused a real pgTAP
+failure on PR #693 and still applies to any test that reads `cron.job` after
+calling the drain.
+
+## What this does not change
+
+- **No schema change.** No new column, index, or table.
+- **No edge function change.** `stripe-sync-transactions`' conditional sweep at
+  [index.ts:376](../../../supabase/functions/stripe-sync-transactions/index.ts:376)
+  stays as-is; it is now a fast path in front of the standing job rather than
+  the only path.
+- **No change to the four inline sweep calls** (decision 2).
+- **No new cron job.** The existing job name is reused.
+- **No UI, route, hook, or component change.**
+
+## Risks
+
+**A standing job that always finds work would run every 5 minutes forever.**
+Bounded by construction: the function already carries
+`SET statement_timeout = '120s'` and a 40-second soft budget that breaks out of
+both loops, so a tick cannot overlap the next one badly. Post-deploy
+verification (below) confirms ticks settle back to sub-second once the backlog
+clears.
+
+**The watermark ⊇ matcher invariant still governs correctness.** The drain's
+restaurant selection filters on `is_active AND auto_apply`, while
+`categorization_rules_watermark` deliberately filters on `is_active` +
+`applies_to` only, because the matchers ignore `auto_apply`. A watermark
+narrower than the matcher's rule set is a silent permanent missed match. This
+design touches neither predicate, and test 7 in
+[50_categorization_backlog_drain.sql:112-120](../../../supabase/tests/50_categorization_backlog_drain.sql:112)
+continues to pin it.
+
+**"Cron ticks succeeded" is not evidence.** On 2026-07-05 a scheduler change
+passed five reviewers, Codex, CodeRabbit, 19 pgTAP tests and full CI, and was
+caught only by prod verification minutes after deploy. Post-deploy we must
+confirm rows are actually being *selected*, not just that the job ran:
+`cron.job` contains the job, `cron.job_run_details` shows succeeded ticks, and
+the counts of unevaluated candidates in `bank_transactions` and `unified_sales`
+(grouped by `pos_system`) are falling toward zero.
+
+## Testing
+
+- **pgTAP:** new `supabase/tests/51_standing_categorization_sweep.sql`; updated
+  `supabase/tests/50_categorization_backlog_drain.sql`. Run via
+  `npm run test:db`.
+- **Fixtures:** the `bbbbbbbb-0000-…` namespace is already taken by
+  50's "Drain Guard Restaurant"
+  ([:91-110](../../../supabase/tests/50_categorization_backlog_drain.sql:91)).
+  51 uses a distinct namespace, grep-verified unused across `supabase/tests/`
+  before adoption.
+- **E2E:** none. The seam is a pg_cron-driven SQL function with no user-facing
+  route, dialog, or flow change; Playwright cannot drive pg_cron. pgTAP is the
+  correct level.
+- **Post-deploy prod verification:** as described under Risks, within minutes of
+  the migration landing.

--- a/docs/superpowers/specs/2026-08-04-categorization-standing-sweep-design.md
+++ b/docs/superpowers/specs/2026-08-04-categorization-standing-sweep-design.md
@@ -179,9 +179,20 @@ counts. This is a correctness fix for the state the job is being made permanent
   exactly as stated.
 - Report both flags in the closing `RAISE LOG`.
 
-Net guarantee: POS may consume at most 25s, so bank is always left at least 15s,
-and the total soft budget is still 40s. If POS finishes early, bank gets
-correspondingly more — no capacity is wasted.
+Net guarantee, for the checked/voluntary bound the two entry guards enforce:
+POS may consume at most 25s of *checked* time, so bank is left at least 15s of
+its own checked budget, and the total soft budget is still 40s. If POS
+finishes early, bank gets correspondingly more — no capacity is wasted. This is
+not an absolute wall-clock bound, though: the checks run only *between*
+batches, so a single in-flight `apply_rules_to_pos_sales_internal` call can
+still block past the 25s checkpoint for up to the full 120s
+`statement_timeout` before `query_canceled` fires. In that case bank's entry
+guard (which measures from the same `v_started` against the 40s total, not its
+own clock — see below) can already read past 40s by the time the bank loop
+starts, leaving bank nothing that tick. See *Risks* → "POS starving bank of
+the shared budget" for the full worst-case accounting; this section states the
+checked bound the guards are built to enforce, not a guarantee against an
+in-flight statement running long.
 
 The conformance test asserts this structurally, in the style of tests 2 and 3:
 split the comment-stripped function definition at the bank-loop marker and assert

--- a/docs/superpowers/specs/2026-08-04-categorization-standing-sweep-design.md
+++ b/docs/superpowers/specs/2026-08-04-categorization-standing-sweep-design.md
@@ -132,10 +132,61 @@ is replaced by an unconditional `RAISE LOG` of the tick outcome.
 
 Everything else is preserved verbatim: `SECURITY DEFINER`,
 `SET search_path = pg_catalog, public`, `SET statement_timeout = '120s'`, the
-40-second soft budget, the POS loop (2 × 5000) and bank loop (5 × 1000 with
-`p_skip_rebuild => true` plus one `rebuild_account_balances` per restaurant per
-tick), and the explicit `WHEN query_canceled` handlers — `WHEN OTHERS` does not
-catch SQLSTATE 57014.
+40-second soft budget **in total**, the POS loop (2 × 5000) and bank loop
+(5 × 1000 with `p_skip_rebuild => true` plus one `rebuild_account_balances` per
+restaurant per tick), and the explicit `WHEN query_canceled` handlers —
+`WHEN OTHERS` does not catch SQLSTATE 57014.
+
+#### 1a. The budget is split POS/bank so POS cannot starve bank
+
+**Amended 2026-08-05, after Phase 7 review.** The version above shares one
+`v_budget_hit` flag and one 40-second budget across both loops, and the POS loop
+runs first. Two consequences, both reachable only because this PR makes the job
+permanent:
+
+1. A POS pass that exhausts the 40s budget leaves `v_budget_hit = true` when the
+   bank loop's entry guard runs, so **zero** bank restaurants are swept that tick.
+2. Worse and likelier: the POS `WHEN query_canceled` handler sets
+   `v_budget_hit := true` deliberately (a cancelled batch means time is gone).
+   With one shared flag, a *single* POS statement timeout zeroes out bank for the
+   whole tick even with 39 seconds left. The Feb 2026 incident recorded 733
+   `statement_timeout` aborts, so this path is not hypothetical.
+
+Bank is the backlog this PR exists to rescue (3,351 stranded rows). A permanent
+sweep in which POS structurally outranks bank is a defect in the fix itself.
+
+Measured on production 2026-08-05, it does not bite *today* — POS has 4,948
+claimable rows against bank's 1,348, and they sit in near-disjoint restaurants
+(the one holding 4,855 POS rows has zero bank candidates). The POS loop's own cap
+(2 × 5000 per restaurant × 7 restaurants) stays well inside 40s at current rule
+counts. This is a correctness fix for the state the job is being made permanent
+*for*, not a live incident.
+
+**The fix, exactly:**
+
+- Replace the single `v_budget_hit` with `v_budget_hit_pos` and
+  `v_budget_hit_bank`. Each loop's entry guard and inner-batch guard read and
+  write **only its own** flag. The POS `query_canceled` handler sets
+  `v_budget_hit_pos` only.
+- Add `v_budget_pos interval := interval '25 seconds'`. The POS loop's guards
+  compare against `v_budget_pos`; the bank loop's guards keep comparing against
+  the full `v_budget` (40s).
+- **Both loops keep measuring from the same `v_started`.** Bank must NOT get an
+  independent clock. Giving bank its own 15s measured from its own start would
+  make the worst case `25s + 120s statement + 15s + 120s statement = 280s`,
+  against a 300s cadence — a regression on the ~160s bound established in *Risks*
+  below. Measuring bank from `v_started` against the 40s total keeps that bound
+  exactly as stated.
+- Report both flags in the closing `RAISE LOG`.
+
+Net guarantee: POS may consume at most 25s, so bank is always left at least 15s,
+and the total soft budget is still 40s. If POS finishes early, bank gets
+correspondingly more — no capacity is wasted.
+
+The conformance test asserts this structurally, in the style of tests 2 and 3:
+split the comment-stripped function definition at the bank-loop marker and assert
+the POS half references `v_budget_hit_pos` and never `v_budget_hit_bank`, and the
+bank half the reverse. Re-unifying the flags fails the test.
 
 The `NOT EXISTS (… leftover …)` subquery at
 [:219-244](../../../supabase/migrations/20260804090700_categorization_watermark_and_drain_convergence.sql:219)
@@ -261,6 +312,20 @@ Plus regression coverage for the two paths that were broken:
    strand).
 6. A `bank_transactions` candidate with an active auto-apply bank rule is
    categorized by a drain tick.
+7. **The two loops do not share a budget flag** (§1a). Split the comment-stripped
+   `drain_categorization_backlog` definition at the bank-loop marker and assert
+   the POS half references `v_budget_hit_pos` and never `v_budget_hit_bank`, and
+   the bank half the reverse. Re-unifying the flags — which is what silently
+   re-introduces POS starving bank — fails here.
+8. **A POS loop that gives up still leaves the bank loop to sweep** — the
+   behavioural twin of (7), same pairing as (3)/(4). Reached through the
+   `query_canceled` path rather than by burning 25 seconds of real POS work:
+   instant, deterministic, and the likelier of the two ways the shared flag
+   fired. `CREATE OR REPLACE` a stub `apply_rules_to_pos_sales_internal` that
+   raises SQLSTATE 57014 (reverted by the file's `ROLLBACK`), add a fresh bank
+   candidate, run one tick, assert it is categorized. Both 7 and 8 were
+   mutation-checked against a re-unified-flag build of the migration: both pass
+   on the fix and fail on the mutant.
 
 ### 4. Invert the tests that pin the old semantics
 
@@ -337,6 +402,20 @@ design exists to remove. It would also serialize the standing job against the
 inline `apply_rules_to_pos_sales_internal` calls that toast, focus,
 focus_transactions and revel still make, turning a safe concurrent path into a
 blocking one.
+
+**POS starving bank of the shared budget — fixed, see §1a.** The pre-amendment
+version ran the POS loop first against a single 40s budget and a single
+`v_budget_hit` flag, so a POS pass that ran out of time — or a *single* POS
+`query_canceled`, which sets that flag deliberately — left the bank loop with
+nothing. Production measurement on 2026-08-05 says it does not bite today: POS
+holds 4,948 claimable rows and bank 1,348, in near-disjoint restaurants, and the
+POS loop's own per-restaurant cap keeps it well inside 40s. It becomes reachable
+as POS customers grow, and this PR is what makes the job permanent, so §1a splits
+the budget: POS capped at 25s, bank guaranteed the remaining 15s, separate hit
+flags. **The ~160s worst case above is unchanged by that split** — precisely
+because bank's guard still measures from the shared `v_started` against the 40s
+total rather than starting its own clock. An independent bank clock would have
+made the worst case 25s + 120s + 15s + 120s = 280s against a 300s cadence.
 
 **Cost profile, measured on production 2026-08-04.** With 934 active auto-apply
 rules across 7 restaurants per scope, a converged tick does: 2 restaurant-

--- a/docs/superpowers/specs/2026-08-04-categorization-standing-sweep-design.md
+++ b/docs/superpowers/specs/2026-08-04-categorization-standing-sweep-design.md
@@ -105,9 +105,9 @@ after the job has retired, nothing re-evaluates their history.
 
 ### Decisions taken
 
-1. **Cadence `*/5 * * * *`.** Matches the four existing POS rollups (jobids 4,
-   6, 30, 38 all run `*/5`). A user who creates a rule sees their history
-   recategorized within five minutes.
+1. **Cadence `*/5 * * * *`.** Matches the four existing POS rollups — jobids 4,
+   6, 30 and 38 all run `*/5` (prod `cron.job`, confirmed 2026-08-04). A user
+   who creates a rule sees their history recategorized within five minutes.
 2. **Keep the four inline sweep calls.** They are not redundant with the
    standing job — those callers suppress the insert trigger, so the inline call
    is what categorizes their rows *in the same transaction*. Removing them
@@ -143,6 +143,21 @@ existed **only** to gate retirement. With retirement gone it has no consumer, so
 it is deleted — which also removes a per-tick cross-join probe over both tables
 for every restaurant with an active rule. Net effect: a converged tick gets
 cheaper, not more expensive.
+
+One addition, not a removal: both restaurant loops
+([:102-108](../../../supabase/migrations/20260804090700_categorization_watermark_and_drain_convergence.sql:102),
+[:147-152](../../../supabase/migrations/20260804090700_categorization_watermark_and_drain_convergence.sql:147))
+currently do `FOR r IN SELECT DISTINCT cr.restaurant_id … ` with no `ORDER BY`,
+so the planner's row order decides who gets swept first. That is harmless for a
+job that retires; for a permanent job it is structural starvation — if the
+40-second budget is ever exhausted mid-tick, the restaurants the planner
+happens to return last are skipped on *every* tick, forever. Both loops gain
+`ORDER BY random()`, which costs nothing on a set this small (one row per
+restaurant with an active auto-apply rule) and gives every restaurant equal
+expected coverage per tick. A deterministic round-robin would need a
+last-swept column, i.e. a schema change, for no additional guarantee. Loop
+order is not observable by any assertion, so this does not make the pgTAP tests
+non-deterministic.
 
 The function keeps its name. Renaming would mean `DROP FUNCTION` + recreate,
 plus edits to the cron command, the pgTAP fixtures, and the generated
@@ -198,6 +213,27 @@ The codification. Four properties, each of which would have caught a real bug:
    `pos_system` reference.** This is the property that makes future POS
    integrations free. If someone adds `AND s.pos_system = 'toast'` as an
    optimization, this test fails and explains why.
+
+   Both text assertions strip SQL comments before matching:
+
+   ```sql
+   regexp_replace(
+     regexp_replace(pg_get_functiondef(p.oid), '/\*.*?\*/', '', 'gs'),
+     '--[^\n]*', '', 'g')
+   ```
+
+   Without stripping, the tests punish exactly the behaviour this codebase
+   rewards. `20260804090300_bounded_categorization_sweep.sql` explains its own
+   invariants in long prose comments
+   ([:116-129](../../../supabase/migrations/20260804090300_bounded_categorization_sweep.sql:116)),
+   and the migration written for *this* design will carry a comment saying "do
+   not add a `pos_system` filter here" — which would fail an unstripped match on
+   its own warning.
+
+   Text matching also cannot see a filter expressed some other way (a join
+   against a connection table, say). Assertion 4 is the behavioural twin that
+   catches those; 3 catches the literal predicate with a message that names the
+   reason. They are kept as a pair, not as alternatives.
 4. **A row with an unrecognized `pos_system` is swept.** The behavioural twin of
    (3): insert a `unified_sales` row with `pos_system = 'future_pos'` — a value
    no sync function, connection table, or edge function knows about — plus a
@@ -259,6 +295,15 @@ Bounded by construction: the function already carries
 both loops, so a tick cannot overlap the next one badly. Post-deploy
 verification (below) confirms ticks settle back to sub-second once the backlog
 clears.
+
+**Overlapping ticks are survivable.** pg_cron does not serialize runs of the
+same job, so a 120s-timeout tick on a 300s cadence could in principle overlap a
+successor. Nothing corrupts if it does: the sweeps claim candidates with
+`FOR UPDATE SKIP LOCKED`, so two ticks partition the backlog rather than
+duplicating work, and `rebuild_account_balances` is an idempotent recompute
+(`current_balance = compute_account_balance(id)`, not an increment —
+[20251019021231_942cf575-c06d-491f-9f5f-77c57b85d1a2.sql:61-84](../../../supabase/migrations/20251019021231_942cf575-c06d-491f-9f5f-77c57b85d1a2.sql:61)).
+The cost of overlap is redundant work and brief row-lock waits.
 
 **The watermark ⊇ matcher invariant still governs correctness.** The drain's
 restaurant selection filters on `is_active AND auto_apply`, while

--- a/docs/superpowers/specs/2026-08-04-categorization-standing-sweep-design.md
+++ b/docs/superpowers/specs/2026-08-04-categorization-standing-sweep-design.md
@@ -152,12 +152,27 @@ so the planner's row order decides who gets swept first. That is harmless for a
 job that retires; for a permanent job it is structural starvation — if the
 40-second budget is ever exhausted mid-tick, the restaurants the planner
 happens to return last are skipped on *every* tick, forever. Both loops gain
-`ORDER BY random()`, which costs nothing on a set this small (one row per
-restaurant with an active auto-apply rule) and gives every restaurant equal
-expected coverage per tick. A deterministic round-robin would need a
-last-swept column, i.e. a schema change, for no additional guarantee. Loop
-order is not observable by any assertion, so this does not make the pgTAP tests
-non-deterministic.
+`ORDER BY random()`, and both remain index-backed with the sort added —
+measured on production, 2026-08-04:
+
+| Loop | Plan | Rows | Time |
+|---|---|---|---|
+| POS | `Index Only Scan using idx_cr_pos_active_auto` → `Unique` → `Sort` | 660 scanned → 7 | 0.896 ms |
+| Bank | `Index Scan using idx_categorization_rules_applies_to` → `Unique` → `Sort` | 274 scanned → 7 | 0.853 ms |
+
+`idx_cr_pos_active_auto`'s partial predicate (`is_active AND auto_apply AND
+applies_to IN ('pos_sales','both')`) is exactly the POS loop's `WHERE`, which is
+why that side gets an index-*only* scan. The sort is over 7 rows —
+`quicksort Memory: 25kB` in both plans — so the anti-starvation ordering is
+free. A deterministic round-robin would need a last-swept column, i.e. a schema
+change, for no additional guarantee. Loop order is not observable by any
+assertion, so this does not make the pgTAP tests non-deterministic.
+
+There is no partial-index twin of `idx_cr_pos_active_auto` on the bank side, so
+the bank loop scans `applies_to` as a non-leading column and filters
+`is_active AND auto_apply`. At 956 rules that costs 150 buffers and 0.85 ms, so
+adding one now would be premature. The trigger to revisit is rule count in the
+tens of thousands, or this query surfacing in `pg_stat_statements`.
 
 The function keeps its name. Renaming would mean `DROP FUNCTION` + recreate,
 plus edits to the cron command, the pgTAP fixtures, and the generated
@@ -296,14 +311,57 @@ both loops, so a tick cannot overlap the next one badly. Post-deploy
 verification (below) confirms ticks settle back to sub-second once the backlog
 clears.
 
-**Overlapping ticks are survivable.** pg_cron does not serialize runs of the
-same job, so a 120s-timeout tick on a 300s cadence could in principle overlap a
-successor. Nothing corrupts if it does: the sweeps claim candidates with
+**Overlapping ticks cannot happen from duration alone, and are survivable if
+they ever do.** pg_cron does not serialize runs of the same job, so the question
+is whether a tick can outlive the 300-second cadence. It cannot: the budget is
+checked between statements, and the longest a tick can run is the 40-second soft
+budget plus one in-flight batch, which the function's own
+`SET statement_timeout = '120s'` caps — a worst case of ~160s, comfortably under
+300s. Overlap therefore requires pg_cron scheduling drift (a delayed or missed
+invocation), not steady-state timing.
+
+If it does happen, nothing corrupts: the sweeps claim candidates with
 `FOR UPDATE SKIP LOCKED`, so two ticks partition the backlog rather than
 duplicating work, and `rebuild_account_balances` is an idempotent recompute
 (`current_balance = compute_account_balance(id)`, not an increment —
 [20251019021231_942cf575-c06d-491f-9f5f-77c57b85d1a2.sql:61-84](../../../supabase/migrations/20251019021231_942cf575-c06d-491f-9f5f-77c57b85d1a2.sql:61)).
 The cost of overlap is redundant work and brief row-lock waits.
+
+**No advisory lock.** `pg_try_advisory_lock` is the textbook guard for "skip
+this run if the previous one is still going", and it is deliberately not used
+here. `SKIP LOCKED` already makes concurrency safe, so a lock would buy nothing
+correctness-wise while introducing a new failure mode: a session-level advisory
+lock leaked by a crashed backend would silently disable the sweep, which is
+precisely the class of failure — an automated driver that quietly stops — this
+design exists to remove. It would also serialize the standing job against the
+inline `apply_rules_to_pos_sales_internal` calls that toast, focus,
+focus_transactions and revel still make, turning a safe concurrent path into a
+blocking one.
+
+**Cost profile, measured on production 2026-08-04.** With 934 active auto-apply
+rules across 7 restaurants per scope, a converged tick does: 2 restaurant-
+selection queries (0.9 ms each), then per restaurant one watermark lookup
+(0.44 ms, `Index Scan using idx_categorization_rules_applies_to`) and one
+candidate probe that returns nothing — the probe matches
+`idx_unified_sales_rule_candidates_v2` /
+`idx_bank_transactions_rule_candidates_v2` exactly, including the
+`rules_evaluated_at` range condition. Residual cost scales with restaurant
+count, not row count, which is what makes a permanent 288-ticks-per-day job
+affordable. `rebuild_account_balances` is the largest single item at ~82 ms for
+the widest restaurant (148 active accounts over 6,565 `journal_entry_lines`),
+and it is correctly gated on `v_r_applied > 0`, so a tick that applied nothing
+never pays it.
+
+**Stamping cannot be a HOT update, and that is accepted.**
+`rules_evaluated_at` is a leading key of both candidate indexes, so every stamp
+writes a new heap tuple plus index tuples. This is pre-existing behaviour from
+the negative cache, not introduced here, but the standing job extends it
+permanently to `bank_transactions` and to the POS systems that previously only
+saw the one-shot insert trigger. Production today: `unified_sales` 72.2% HOT
+with 4.59% dead tuples and autovacuum keeping up; `bank_transactions` 2.0% HOT
+but only 12,850 lifetime updates on 7,532 rows. Once the 3,351-row bank backlog
+drains, the steady-state stamp rate is the rate of genuinely new rows and rule
+edits. Dead-tuple growth on both tables is on the post-deploy checklist.
 
 **The watermark ⊇ matcher invariant still governs correctness.** The drain's
 restaurant selection filters on `is_active AND auto_apply`, while

--- a/supabase/migrations/20260804091000_standing_categorization_sweep.sql
+++ b/supabase/migrations/20260804091000_standing_categorization_sweep.sql
@@ -40,9 +40,23 @@ DECLARE
   v_total       integer     := 0;
   v_claimed     integer     := 0;
   v_errors      integer     := 0;
-  v_budget_hit  boolean     := false;
+  -- One flag per loop. A single shared flag let the POS loop -- which runs
+  -- first -- zero out the bank loop for a whole tick, and not only on genuine
+  -- time exhaustion: the POS query_canceled handler below sets its flag
+  -- deliberately, so ONE timed-out POS batch used to cancel bank with 39s of
+  -- budget left. Bank is the backlog this job exists to rescue; it must not be
+  -- structurally outranked. Keep these separate.
+  v_budget_hit_pos  boolean := false;
+  v_budget_hit_bank boolean := false;
   v_started     timestamptz := clock_timestamp();
+  -- Both loops measure from the SAME v_started. POS may take at most 25s, so
+  -- bank is guaranteed the remaining 15s of the unchanged 40s total -- and more
+  -- when POS finishes early. Do NOT give bank its own clock: 15s measured from
+  -- bank's own start would make the worst case 25s + 120s statement_timeout +
+  -- 15s + 120s = 280s against a 300s cadence, instead of the ~160s this design
+  -- is bounded at.
   v_budget      interval    := interval '40 seconds';
+  v_budget_pos  interval    := interval '25 seconds';
 BEGIN
   -- ── POS backlog (a few batches per restaurant per tick) ──────────────────
   -- ORDER BY random(): no ordering was harmless while this job retired, but a
@@ -61,8 +75,8 @@ BEGIN
     ) d
     ORDER BY random()
   LOOP
-    IF v_budget_hit OR clock_timestamp() - v_started > v_budget THEN
-      v_budget_hit := true;
+    IF v_budget_hit_pos OR clock_timestamp() - v_started > v_budget_pos THEN
+      v_budget_hit_pos := true;
       EXIT;
     END IF;
     BEGIN
@@ -77,8 +91,8 @@ BEGIN
         v_claimed := v_claimed + COALESCE(n_claimed, 0);
         i := i + 1;
         EXIT WHEN COALESCE(n_claimed, 0) = 0 OR i >= 2;
-        IF clock_timestamp() - v_started > v_budget THEN
-          v_budget_hit := true;
+        IF clock_timestamp() - v_started > v_budget_pos THEN
+          v_budget_hit_pos := true;
           EXIT;
         END IF;
       END LOOP;
@@ -88,7 +102,7 @@ BEGIN
       -- Treat it as time exhaustion so the pass is not considered complete.
       WHEN query_canceled THEN
         v_errors := v_errors + 1;
-        v_budget_hit := true;
+        v_budget_hit_pos := true;
         RAISE WARNING 'categorization drain (pos) canceled for restaurant %: %',
           r.restaurant_id, SQLERRM;
       WHEN OTHERS THEN
@@ -110,8 +124,10 @@ BEGIN
     ) d
     ORDER BY random()
   LOOP
-    IF v_budget_hit OR clock_timestamp() - v_started > v_budget THEN
-      v_budget_hit := true;
+    -- v_budget (the full 40s), not v_budget_pos, and NOT v_budget_hit_pos: a POS
+    -- pass that exhausted its 25s or hit a statement timeout leaves bank its 15s.
+    IF v_budget_hit_bank OR clock_timestamp() - v_started > v_budget THEN
+      v_budget_hit_bank := true;
       EXIT;
     END IF;
     BEGIN
@@ -128,7 +144,7 @@ BEGIN
         i := i + 1;
         EXIT WHEN COALESCE(n_claimed, 0) = 0 OR i >= 5;
         IF clock_timestamp() - v_started > v_budget THEN
-          v_budget_hit := true;
+          v_budget_hit_bank := true;
           EXIT;
         END IF;
       END LOOP;
@@ -141,7 +157,7 @@ BEGIN
     EXCEPTION
       WHEN query_canceled THEN
         v_errors := v_errors + 1;
-        v_budget_hit := true;
+        v_budget_hit_bank := true;
         RAISE WARNING 'categorization drain (bank) canceled for restaurant %: %',
           r.restaurant_id, SQLERRM;
       WHEN OTHERS THEN
@@ -157,15 +173,16 @@ BEGIN
   -- watermark and makes their whole history a candidate again. The previous
   -- version retired here and left 3,351 bank rows and 9,333 POS rows stranded
   -- for a month with no automated driver.
-  RAISE LOG 'categorization drain: applied % rows of % claimed this tick (errors=%, budget_hit=%)',
-    v_total, v_claimed, v_errors, v_budget_hit;
+  RAISE LOG 'categorization drain: applied % rows of % claimed this tick (errors=%, budget_hit_pos=%, budget_hit_bank=%)',
+    v_total, v_claimed, v_errors, v_budget_hit_pos, v_budget_hit_bank;
 
   RETURN v_total;
 END;
 $$;
 
 COMMENT ON FUNCTION public.drain_categorization_backlog() IS
-  'Standing bounded (~40s) sweep that applies categorization rules to the '
+  'Standing bounded (~40s total, of which POS may take at most 25s so the bank '
+  'sweep is never starved) sweep that applies categorization rules to the '
   'uncategorized POS and bank backlog for every restaurant with an active '
   'auto_apply rule. Runs permanently every 5 minutes as the '
   'categorization-backlog-drain pg_cron job and NEVER unschedules itself -- a '

--- a/supabase/migrations/20260804091000_standing_categorization_sweep.sql
+++ b/supabase/migrations/20260804091000_standing_categorization_sweep.sql
@@ -181,10 +181,16 @@ END;
 $$;
 
 COMMENT ON FUNCTION public.drain_categorization_backlog() IS
-  'Standing bounded (~40s total, of which POS may take at most 25s so the bank '
-  'sweep is never starved) sweep that applies categorization rules to the '
-  'uncategorized POS and bank backlog for every restaurant with an active '
-  'auto_apply rule. Runs permanently every 5 minutes as the '
+  'Standing bounded (~40s total soft budget, of which POS is checked against '
+  'at most 25s between batches so bank keeps its 15s share when both loops '
+  'stay within their checkpoints) sweep that applies categorization rules to '
+  'the uncategorized POS and bank backlog for every restaurant with an active '
+  'auto_apply rule. That 25s/15s split is a checked bound, not an absolute '
+  'wall-clock one: a single in-flight POS batch can still run past its '
+  'checkpoint for up to the 120s statement_timeout before query_canceled '
+  'fires, in which case bank''s own 40s guard (measured from the same start '
+  'time) can already be exceeded -- see the design doc Risks section for the '
+  'full worst-case accounting. Runs permanently every 5 minutes as the '
   'categorization-backlog-drain pg_cron job and NEVER unschedules itself -- a '
   'converged backlog is not terminal, because the next rule a user creates '
   'lowers the watermark and re-opens their history. POS-agnostic by '

--- a/supabase/migrations/20260804091000_standing_categorization_sweep.sql
+++ b/supabase/migrations/20260804091000_standing_categorization_sweep.sql
@@ -1,0 +1,199 @@
+-- Standing categorization sweep.
+--
+-- drain_categorization_backlog() was written as a one-shot backfill: it deleted
+-- its own pg_cron job on a converged pass (20260804090700 §self-retire, and the
+-- original schedule comment at 20260703090000:1045 "The job deletes itself ...
+-- once converged"). It ran four times and retired on 2026-07-04.
+--
+-- That retirement stranded every categorization path that is not wired into a
+-- sync function. unified_sales has two mechanisms and no owner: the
+-- auto_categorize_pos_sale BEFORE INSERT trigger (one shot per row, so a rule
+-- created tomorrow never sees today's rows) and the batch sweep, which only
+-- toast/focus/focus_transactions/revel call inline. square, clover, shift4,
+-- lighthouse, manual_upload and manual have the trigger only.
+-- bank_transactions had exactly one driver -- stripe-sync-transactions, and
+-- only when that sync found new rows.
+--
+-- The fix is to stop retiring. The sweep selects candidates by restaurant_id
+-- and watermark with NO pos_system predicate (20260804090300:130-139), and this
+-- drain selects restaurants by RULE, not by connection table -- so one standing
+-- job covers every POS that exists today and every POS added later, with no
+-- per-integration wiring. Do not add a pos_system filter to either; that is the
+-- property the 51_standing_categorization_sweep.sql conformance test pins.
+--
+-- Retirement is no longer buying anything: since the rules_evaluated_at
+-- negative cache (20260804090300) a converged tick reads no candidates at all.
+
+CREATE OR REPLACE FUNCTION public.drain_categorization_backlog()
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+SET statement_timeout = '120s'
+AS $$
+DECLARE
+  r             RECORD;
+  n_applied     integer;
+  n_claimed     integer;
+  i             integer;
+  v_r_applied   integer;
+  v_total       integer     := 0;
+  v_claimed     integer     := 0;
+  v_errors      integer     := 0;
+  v_budget_hit  boolean     := false;
+  v_started     timestamptz := clock_timestamp();
+  v_budget      interval    := interval '40 seconds';
+BEGIN
+  -- ── POS backlog (a few batches per restaurant per tick) ──────────────────
+  -- ORDER BY random(): no ordering was harmless while this job retired, but a
+  -- permanent job with a fixed planner order starves whoever sorts last every
+  -- single tick once the 40s budget is exhausted mid-pass. Random order gives
+  -- every restaurant equal expected coverage. The DISTINCT is wrapped because
+  -- ORDER BY random() on a SELECT DISTINCT is a syntax error.
+  FOR r IN
+    SELECT d.restaurant_id
+    FROM (
+      SELECT DISTINCT cr.restaurant_id
+      FROM categorization_rules cr
+      WHERE cr.is_active
+        AND cr.auto_apply
+        AND cr.applies_to IN ('pos_sales', 'both')
+    ) d
+    ORDER BY random()
+  LOOP
+    IF v_budget_hit OR clock_timestamp() - v_started > v_budget THEN
+      v_budget_hit := true;
+      EXIT;
+    END IF;
+    BEGIN
+      i := 0;
+      LOOP
+        -- total_count is candidates CLAIMED, not matched. Exiting on
+        -- applied_count would stop at the first bounded batch that happened to
+        -- match nothing and leave older candidates unevaluated forever.
+        SELECT applied_count, total_count INTO n_applied, n_claimed
+        FROM apply_rules_to_pos_sales_internal(r.restaurant_id, 5000);
+        v_total   := v_total   + COALESCE(n_applied, 0);
+        v_claimed := v_claimed + COALESCE(n_claimed, 0);
+        i := i + 1;
+        EXIT WHEN COALESCE(n_claimed, 0) = 0 OR i >= 2;
+        IF clock_timestamp() - v_started > v_budget THEN
+          v_budget_hit := true;
+          EXIT;
+        END IF;
+      END LOOP;
+    EXCEPTION
+      -- WHEN OTHERS does NOT catch query_canceled (57014); name it explicitly
+      -- so a timed-out batch skips this restaurant instead of aborting the tick.
+      -- Treat it as time exhaustion so the pass is not considered complete.
+      WHEN query_canceled THEN
+        v_errors := v_errors + 1;
+        v_budget_hit := true;
+        RAISE WARNING 'categorization drain (pos) canceled for restaurant %: %',
+          r.restaurant_id, SQLERRM;
+      WHEN OTHERS THEN
+        v_errors := v_errors + 1;
+        RAISE WARNING 'categorization drain (pos) failed for restaurant %: %',
+          r.restaurant_id, SQLERRM;
+    END;
+  END LOOP;
+
+  -- ── Bank backlog (a few batches per restaurant per tick) ─────────────────
+  FOR r IN
+    SELECT d.restaurant_id
+    FROM (
+      SELECT DISTINCT cr.restaurant_id
+      FROM categorization_rules cr
+      WHERE cr.is_active
+        AND cr.auto_apply
+        AND cr.applies_to IN ('bank_transactions', 'both')
+    ) d
+    ORDER BY random()
+  LOOP
+    IF v_budget_hit OR clock_timestamp() - v_started > v_budget THEN
+      v_budget_hit := true;
+      EXIT;
+    END IF;
+    BEGIN
+      i := 0;
+      v_r_applied := 0;
+      LOOP
+        -- p_skip_rebuild=true: one rebuild per restaurant per tick (below),
+        -- not one per batch — rebuilds dominate the cost otherwise.
+        SELECT applied_count, total_count INTO n_applied, n_claimed
+        FROM apply_rules_to_bank_transactions_internal(r.restaurant_id, 1000, true);
+        v_total     := v_total     + COALESCE(n_applied, 0);
+        v_claimed   := v_claimed   + COALESCE(n_claimed, 0);
+        v_r_applied := v_r_applied + COALESCE(n_applied, 0);
+        i := i + 1;
+        EXIT WHEN COALESCE(n_claimed, 0) = 0 OR i >= 5;
+        IF clock_timestamp() - v_started > v_budget THEN
+          v_budget_hit := true;
+          EXIT;
+        END IF;
+      END LOOP;
+      -- Rebuild once per tick, only when this restaurant applied rows. Claiming
+      -- candidates that matched nothing changes no balance, so it must not
+      -- trigger a rebuild.
+      IF v_r_applied > 0 THEN
+        PERFORM rebuild_account_balances(r.restaurant_id);
+      END IF;
+    EXCEPTION
+      WHEN query_canceled THEN
+        v_errors := v_errors + 1;
+        v_budget_hit := true;
+        RAISE WARNING 'categorization drain (bank) canceled for restaurant %: %',
+          r.restaurant_id, SQLERRM;
+      WHEN OTHERS THEN
+        v_errors := v_errors + 1;
+        RAISE WARNING 'categorization drain (bank) failed for restaurant %: %',
+          r.restaurant_id, SQLERRM;
+    END;
+  END LOOP;
+
+  -- ── No self-retirement ────────────────────────────────────────────────────
+  -- This tick never unschedules its own job, whatever the outcome. A converged
+  -- backlog is not a terminal state: the next rule a user creates lowers the
+  -- watermark and makes their whole history a candidate again. The previous
+  -- version retired here and left 3,351 bank rows and 9,333 POS rows stranded
+  -- for a month with no automated driver.
+  RAISE LOG 'categorization drain: applied % rows of % claimed this tick (errors=%, budget_hit=%)',
+    v_total, v_claimed, v_errors, v_budget_hit;
+
+  RETURN v_total;
+END;
+$$;
+
+COMMENT ON FUNCTION public.drain_categorization_backlog() IS
+  'Standing bounded (~40s) sweep that applies categorization rules to the '
+  'uncategorized POS and bank backlog for every restaurant with an active '
+  'auto_apply rule. Runs permanently every 5 minutes as the '
+  'categorization-backlog-drain pg_cron job and NEVER unschedules itself -- a '
+  'converged backlog is not terminal, because the next rule a user creates '
+  'lowers the watermark and re-opens their history. POS-agnostic by '
+  'construction: restaurants are selected by rule and candidates by watermark, '
+  'with no pos_system predicate anywhere, so a POS integration added later is '
+  'covered with no wiring. Returns rows applied this tick.';
+
+-- Re-assert the 20260703090000 hardening. CREATE OR REPLACE preserves the
+-- existing ACL, but restating it keeps this file correct if it is ever replayed
+-- against a database where the function was created fresh.
+REVOKE ALL ON FUNCTION public.drain_categorization_backlog() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.drain_categorization_backlog() TO service_role;
+
+-- Schedule the standing job. Unschedule-then-schedule converges from either
+-- state: production, where the job is absent because it retired itself on
+-- 2026-07-04, and any environment where it still exists on some other schedule.
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'categorization-backlog-drain') THEN
+    PERFORM cron.unschedule('categorization-backlog-drain');
+  END IF;
+  PERFORM cron.schedule(
+    'categorization-backlog-drain',
+    '*/5 * * * *',
+    'SELECT public.drain_categorization_backlog()'
+  );
+END $$;

--- a/supabase/tests/50_categorization_backlog_drain.sql
+++ b/supabase/tests/50_categorization_backlog_drain.sql
@@ -83,12 +83,11 @@ SELECT ok(
 );
 
 -- ---------------------------------------------------------------------------
--- Retirement guard (20260804090700). v_claimed = 0 is NOT sufficient to retire:
--- the sweeps claim FOR UPDATE SKIP LOCKED, so a concurrent sweep holding the
--- last candidates makes a tick claim 0 while the backlog is still there. The
--- drain now also proves no claimable candidate remains. Tests 9/10 pin both
--- directions — it must not retire with work left, and must still retire once
--- there is none (a guard that is too wide would never converge).
+-- Claim accounting (20260804090700). The sweeps claim FOR UPDATE SKIP LOCKED,
+-- so a tick can claim 0 rows while a backlog is still there — which is why
+-- total_count (claimed), not applied_count (matched), drives the drain loop.
+-- Tests 9/10 pin that the job survives both states: work waiting, and work
+-- exhausted.
 -- ---------------------------------------------------------------------------
 
 INSERT INTO restaurants (id, name) VALUES

--- a/supabase/tests/50_categorization_backlog_drain.sql
+++ b/supabase/tests/50_categorization_backlog_drain.sql
@@ -161,14 +161,14 @@ SELECT ok(
   'a tick with a backlog waiting does not retire the drain job'
 );
 
--- Test 10: the previous tick stamped every candidate, so nothing claimable is
--- left and the next tick converges. Guards against a leftover check so wide
--- that unmatched rows keep the job scheduled forever.
+-- Test 10: the previous tick stamped every candidate, so this one converges —
+-- and the job still survives. Together with test 9 this pins job survival
+-- across both outcomes, which is what makes the sweep permanent.
 SELECT public.drain_categorization_backlog();
 
 SELECT ok(
-  NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'categorization-backlog-drain'),
-  'once every candidate is evaluated the drain still retires itself'
+  EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'categorization-backlog-drain'),
+  'a tick that exhausts the backlog still leaves the job scheduled'
 );
 
 SELECT * FROM finish();

--- a/supabase/tests/50_categorization_backlog_drain.sql
+++ b/supabase/tests/50_categorization_backlog_drain.sql
@@ -73,10 +73,13 @@ SELECT is(
   'a drain tick on an empty database applies 0 rows'
 );
 
--- Test 6: that complete, error-free, 0-row tick retired the cron job.
+-- Test 6: a converged tick does NOT retire the job. Convergence is not a
+-- terminal state — the next rule a user creates lowers the watermark and makes
+-- their whole history a candidate again, and this job is the only driver that
+-- would notice.
 SELECT ok(
-  NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'categorization-backlog-drain'),
-  'a converged (complete + clean + 0-row) tick unschedules the drain job'
+  EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'categorization-backlog-drain'),
+  'a converged (complete + clean + 0-row) tick leaves the drain job scheduled'
 );
 
 -- ---------------------------------------------------------------------------

--- a/supabase/tests/50_categorization_backlog_drain.sql
+++ b/supabase/tests/50_categorization_backlog_drain.sql
@@ -1,9 +1,12 @@
--- Tests for the deferred categorization backlog drain
--- Migration: 20260703090000_categorization_background_and_supplier_assign.sql (§7)
+-- Tests for the standing categorization backlog sweep
+-- Migrations: 20260703090000 (§7, original), 20260804090700 (convergence guard),
+--             20260804091000 (standing sweep — retirement removed)
 --
 -- The original §7 drained the whole backlog synchronously inside the migration
--- and timed out production deploys (SQLSTATE 57014). It is now a bounded
--- 5-minute pg_cron tick that unschedules itself once converged.
+-- and timed out production deploys (SQLSTATE 57014). It became a bounded
+-- 5-minute pg_cron tick that unschedules itself once converged — which stranded
+-- every categorization path not wired into a sync function. It is now a
+-- PERMANENT 5-minute tick that never retires.
 --
 -- Test plan (10 tests):
 --  1  drain_categorization_backlog() exists
@@ -11,18 +14,15 @@
 --  3  anon cannot execute the SECURITY DEFINER drain (PUBLIC revoked)
 --  4  authenticated cannot execute it either
 --  5  a tick on an empty database applies 0 rows (no error)
---  6  the converged (complete, error-free, 0-row) tick unschedules its own cron job
+--  6  that converged tick leaves its own cron job scheduled
 --  7  categorization_rules_watermark returns the newest active-rule timestamp
 --  8  categorization_rules_watermark is NULL when no active rule covers the scope
---  9  a tick with a backlog waiting does not retire the drain job
--- 10  once every candidate is evaluated the drain still retires itself
+--  9  a tick with a backlog waiting leaves the job scheduled
+-- 10  a tick that exhausts the backlog still leaves the job scheduled
 --
--- NOTE: we do NOT assert the migration-time job still exists — the pgTAP
--- database runs a LIVE pg_cron, so on an empty database the real */5 tick may
--- already have drained 0 rows and legitimately retired the job before this
--- file runs (self-retirement working as designed). Instead the job is
--- (re)scheduled inside this rolled-back transaction and the full
--- schedule → drain → self-retire lifecycle is asserted deterministically.
+-- Tests 6 and 10 are the inverted forms of assertions that pinned the old
+-- self-retirement. They are the regression guard for the 2026-07-04 strand:
+-- if retirement ever returns, both fail.
 
 BEGIN;
 SELECT plan(10);

--- a/supabase/tests/50_categorization_backlog_drain.sql
+++ b/supabase/tests/50_categorization_backlog_drain.sql
@@ -147,19 +147,6 @@ ON CONFLICT (id) DO NOTHING;
 
 SELECT set_config('app.skip_unified_sales_triggers', 'false', true);
 
--- Re-arm the job that test 6 retired, then stamp the backlog as unevaluated so
--- a tick has real work waiting for it.
-DO $$
-BEGIN
-  IF NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'categorization-backlog-drain') THEN
-    PERFORM cron.schedule(
-      'categorization-backlog-drain',
-      '*/5 * * * *',
-      'SELECT public.drain_categorization_backlog()'
-    );
-  END IF;
-END $$;
-
 -- Each tick runs as its OWN statement, never folded into the assertion as
 -- `drain() >= 0 AND (NOT) EXISTS (...)`. The outer query scans cron.job under
 -- the snapshot taken when the statement began, so a cron.unschedule() the

--- a/supabase/tests/51_standing_categorization_sweep.sql
+++ b/supabase/tests/51_standing_categorization_sweep.sql
@@ -20,6 +20,10 @@
 --  5  a row whose pos_system no sync function knows about is still categorized
 --  6  a bank_transactions candidate is categorized by the same mechanism
 --  7  one tick covers both tables
+--
+-- NOTE: tests run out of numeric order below -- 1, 2, 3, 5, 6, 7, then 4 last.
+-- Test 4 must run after the backlog-exhausting ticks used by 5/6/7 so it
+-- asserts the job survives post-convergence; see the comment at test 4.
 
 BEGIN;
 SELECT plan(7);

--- a/supabase/tests/51_standing_categorization_sweep.sql
+++ b/supabase/tests/51_standing_categorization_sweep.sql
@@ -8,11 +8,12 @@
 --   * the sweep job runs permanently and never retires  (tests 1, 4)
 --   * the drain cannot reacquire the ability to retire   (test 2)
 --   * the sweep carries no pos_system predicate          (tests 3, 5)
+--   * neither loop can starve the other of the budget    (tests 8, 9)
 --
 -- If a future change breaks one of these, the failure message says which
 -- property was lost and why it mattered.
 --
--- Test plan (7 tests):
+-- Test plan (9 tests):
 --  1  the migration scheduled a standing */5 categorization-backlog-drain job
 --  2  drain_categorization_backlog contains no cron.unschedule
 --  3  apply_rules_to_pos_sales_internal contains no pos_system predicate
@@ -20,13 +21,16 @@
 --  5  a row whose pos_system no sync function knows about is still categorized
 --  6  a bank_transactions candidate is categorized by the same mechanism
 --  7  one tick covers both tables
+--  8  the POS and bank loops each track their own budget-hit flag
+--  9  a POS loop that hits query_canceled still leaves the bank loop to sweep
 --
--- NOTE: tests run out of numeric order below -- 1, 2, 3, 5, 6, 7, then 4 last.
--- Test 4 must run after the backlog-exhausting ticks used by 5/6/7 so it
--- asserts the job survives post-convergence; see the comment at test 4.
+-- NOTE: tests run out of numeric order below -- 1, 2, 3, 5, 6, 7, then 4, then
+-- 8 and 9. Test 4 must run after the backlog-exhausting ticks used by 5/6/7 so
+-- it asserts the job survives post-convergence; see the comment at test 4.
+-- Tests 8 and 9 are last because 9 stubs out apply_rules_to_pos_sales_internal.
 
 BEGIN;
-SELECT plan(7);
+SELECT plan(9);
 
 -- Test 1: the job the migration created is really there, on the real schedule.
 -- Unlike 50_categorization_backlog_drain.sql this does NOT re-schedule the job
@@ -200,6 +204,105 @@ SELECT public.drain_categorization_backlog();
 SELECT ok(
   EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'categorization-backlog-drain'),
   'a converged tick leaves the standing job scheduled'
+);
+
+-- Test 8: the POS and bank loops must not share a budget flag. Structural, and
+-- placed last only to avoid renumbering the tests above.
+--
+-- The pre-amendment drain ran the POS loop first against one v_budget_hit, so a
+-- POS pass that ran out of time — or a SINGLE POS query_canceled, whose handler
+-- sets the flag deliberately — left the bank loop with nothing to do for the
+-- whole tick. Bank is the backlog this job exists to rescue. Re-unifying the
+-- flags reintroduces that silently, and would pass every other test in this
+-- file, so it is pinned here.
+--
+-- Comments are stripped first (as in tests 2/3), then the definition is cut at
+-- non-comment markers: the POS half runs from the POS loop's applies_to literal
+-- to the bank loop's, and the bank half from there to the closing RAISE LOG —
+-- which names both flags legitimately and so must be excluded. The strpos
+-- ordering is asserted too: a marker that stopped matching would otherwise
+-- collapse the halves to empty strings and pass vacuously.
+WITH def AS (
+  SELECT regexp_replace(
+    regexp_replace(pg_get_functiondef(p.oid), '/\*.*?\*/', '', 'gs'),
+    '--[^\n]*', '', 'g'
+  ) AS src
+  FROM pg_proc p
+  JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public' AND p.proname = 'drain_categorization_backlog'
+), marks AS (
+  SELECT
+    src,
+    strpos(src, '''pos_sales''')         AS p_pos,
+    strpos(src, '''bank_transactions''') AS p_bank,
+    strpos(src, 'categorization drain: applied') AS p_log
+  FROM def
+), halves AS (
+  SELECT
+    p_pos > 0 AND p_bank > p_pos AND p_log > p_bank AS markers_ok,
+    substr(src, p_pos, p_bank - p_pos)  AS pos_half,
+    substr(src, p_bank, p_log - p_bank) AS bank_half
+  FROM marks
+)
+SELECT ok(
+  markers_ok
+  AND pos_half  LIKE     '%v_budget_hit_pos%'
+  AND pos_half  NOT LIKE '%v_budget_hit_bank%'
+  AND bank_half LIKE     '%v_budget_hit_bank%'
+  AND bank_half NOT LIKE '%v_budget_hit_pos%',
+  'the POS and bank loops each track their own budget-hit flag'
+)
+FROM halves;
+
+-- Test 9: the behavioural twin of test 8 — a POS loop that gives up still
+-- leaves the bank loop to run. Test 8 pins the shape; this pins the outcome.
+--
+-- Exercised through the query_canceled path rather than by burning 25s of real
+-- POS work: it is instant, deterministic, and it is the likelier of the two
+-- ways the old shared flag fired. The POS handler sets its flag deliberately on
+-- a cancel, so before the split ONE timed-out POS batch skipped bank entirely —
+-- and the Feb 2026 incident logged 733 statement_timeout aborts.
+
+-- A fresh bank candidate, created after the ticks above. The rule is
+-- deactivated across the INSERT because auto_categorize_bank_transaction is a
+-- BEFORE INSERT trigger that honours no skip GUC — with the rule live the row
+-- would arrive already categorized and prove nothing. Reactivating raises the
+-- watermark, which is what re-opens the row to the sweep.
+UPDATE categorization_rules SET is_active = false
+WHERE id = 'dddddddd-0000-0000-0000-0000000000f2';
+
+INSERT INTO bank_transactions
+  (id, restaurant_id, connected_bank_id, stripe_transaction_id,
+   transaction_date, description, amount)
+VALUES
+  ('dddddddd-0000-0000-0000-0000000000e2', 'dddddddd-0000-0000-0000-0000000000a1',
+   'dddddddd-0000-0000-0000-0000000000b1', 'txn_standing_sweep_starvation',
+   CURRENT_DATE, 'STANDING SWEEP VENDOR', -31.00);
+
+UPDATE categorization_rules SET is_active = true
+WHERE id = 'dddddddd-0000-0000-0000-0000000000f2';
+
+-- Fault injection, reverted by this file's ROLLBACK along with everything else.
+-- 57014 is query_canceled: what statement_timeout raises, and what WHEN OTHERS
+-- does not catch — which is why the drain names it explicitly.
+-- The DEFAULT must be restated: CREATE OR REPLACE refuses to drop an existing
+-- parameter default.
+CREATE OR REPLACE FUNCTION public.apply_rules_to_pos_sales_internal(
+  p_restaurant_id uuid, p_batch_limit integer DEFAULT 100
+) RETURNS TABLE(applied_count integer, total_count integer)
+LANGUAGE plpgsql
+AS $stub$
+BEGIN
+  RAISE EXCEPTION 'simulated statement timeout' USING ERRCODE = '57014';
+END;
+$stub$;
+
+SELECT public.drain_categorization_backlog();
+
+SELECT ok(
+  (SELECT is_categorized AND category_id = 'dddddddd-0000-0000-0000-0000000000c1'
+   FROM bank_transactions WHERE id = 'dddddddd-0000-0000-0000-0000000000e2'),
+  'a POS loop that hits query_canceled still leaves the bank loop to sweep'
 );
 
 SELECT * FROM finish();

--- a/supabase/tests/51_standing_categorization_sweep.sql
+++ b/supabase/tests/51_standing_categorization_sweep.sql
@@ -93,6 +93,18 @@ VALUES
    'Food Sales', '4000', 'revenue', 'sales', 'credit')
 ON CONFLICT (id) DO NOTHING;
 
+-- apply_rules_to_bank_transactions_internal posts a journal entry for each
+-- categorized row and requires a Cash account (account_code 1000) to exist for
+-- the restaurant, or it raises and the whole batch is skipped
+-- (20260703090000:519-528). Without this row test 6 fails silently: the
+-- function logs a WARNING and leaves the bank row uncategorized.
+INSERT INTO chart_of_accounts
+  (id, restaurant_id, account_name, account_code, account_type, account_subtype, normal_balance)
+VALUES
+  ('dddddddd-0000-0000-0000-0000000000c2', 'dddddddd-0000-0000-0000-0000000000a1',
+   'Cash', '1000', 'asset', 'cash', 'debit')
+ON CONFLICT (id) DO NOTHING;
+
 INSERT INTO connected_banks
   (id, restaurant_id, stripe_financial_account_id, institution_name)
 VALUES

--- a/supabase/tests/51_standing_categorization_sweep.sql
+++ b/supabase/tests/51_standing_categorization_sweep.sql
@@ -1,0 +1,190 @@
+-- Conformance tests for the standing categorization sweep
+-- Migration: 20260804091000_standing_categorization_sweep.sql
+--
+-- These are the codified pattern for future POS integrations. Categorization
+-- reaches a new POS with zero wiring only while three properties hold, and each
+-- test below pins one of them:
+--
+--   * the sweep job runs permanently and never retires  (tests 1, 4)
+--   * the drain cannot reacquire the ability to retire   (test 2)
+--   * the sweep carries no pos_system predicate          (tests 3, 5)
+--
+-- If a future change breaks one of these, the failure message says which
+-- property was lost and why it mattered.
+--
+-- Test plan (7 tests):
+--  1  the migration scheduled a standing */5 categorization-backlog-drain job
+--  2  drain_categorization_backlog contains no cron.unschedule
+--  3  apply_rules_to_pos_sales_internal contains no pos_system predicate
+--  4  a converged tick leaves the standing job scheduled
+--  5  a row whose pos_system no sync function knows about is still categorized
+--  6  a bank_transactions candidate is categorized by the same mechanism
+--  7  one tick covers both tables
+
+BEGIN;
+SELECT plan(7);
+
+-- Test 1: the job the migration created is really there, on the real schedule.
+-- Unlike 50_categorization_backlog_drain.sql this does NOT re-schedule the job
+-- first: with retirement gone, the migration-time job's existence is
+-- deterministic, and asserting the real one is what proves the migration
+-- scheduled it at all.
+SELECT is(
+  (SELECT schedule FROM cron.job WHERE jobname = 'categorization-backlog-drain'),
+  '*/5 * * * *',
+  'the migration leaves a standing categorization-backlog-drain job on */5'
+);
+
+-- ---------------------------------------------------------------------------
+-- Tests 2/3 match against the function source with SQL comments stripped.
+-- Without stripping they would punish exactly the behaviour this codebase
+-- rewards: 20260804091000 carries a comment saying "do not add a pos_system
+-- filter", and an unstripped match would fail on the warning that explains the
+-- test. Strip block comments first (dot-matches-newline), then line comments.
+-- ---------------------------------------------------------------------------
+
+-- Test 2: the drain can never reacquire the ability to retire. Structural, not
+-- behavioural — test 4 proves it does not retire on a converged tick, this
+-- proves the code to do so is simply absent on every path.
+SELECT ok(
+  regexp_replace(
+    regexp_replace(pg_get_functiondef(p.oid), '/\*.*?\*/', '', 'gs'),
+    '--[^\n]*', '', 'g'
+  ) NOT ILIKE '%cron.unschedule%',
+  'drain_categorization_backlog contains no cron.unschedule'
+)
+FROM pg_proc p
+JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = 'public' AND p.proname = 'drain_categorization_backlog';
+
+-- Test 3: THE property that makes a future POS free. The sweep selects
+-- candidates by restaurant_id and watermark only. Adding "AND s.pos_system =
+-- ..." as an optimization would silently orphan every other POS, exactly as
+-- relying on per-POS sync wiring already did.
+SELECT ok(
+  regexp_replace(
+    regexp_replace(pg_get_functiondef(p.oid), '/\*.*?\*/', '', 'gs'),
+    '--[^\n]*', '', 'g'
+  ) NOT ILIKE '%pos_system%',
+  'apply_rules_to_pos_sales_internal carries no pos_system predicate'
+)
+FROM pg_proc p
+JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = 'public'
+  AND p.proname = 'apply_rules_to_pos_sales_internal';
+
+-- ---------------------------------------------------------------------------
+-- Fixtures. Rows are inserted BEFORE their rules exist, so the BEFORE INSERT
+-- triggers find nothing to apply and both rows land as genuine candidates
+-- (rules_evaluated_at defaults to '-infinity'). This reproduces the production
+-- bug directly: a row that predates the rule that would match it.
+-- auto_apply_bank_categorization_rules honours no skip GUC, so insert ordering
+-- is the only way to leave a bank row uncategorized.
+-- ---------------------------------------------------------------------------
+
+INSERT INTO restaurants (id, name) VALUES
+  ('dddddddd-0000-0000-0000-0000000000a1', 'Standing Sweep Restaurant')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO chart_of_accounts
+  (id, restaurant_id, account_name, account_code, account_type, account_subtype, normal_balance)
+VALUES
+  ('dddddddd-0000-0000-0000-0000000000c1', 'dddddddd-0000-0000-0000-0000000000a1',
+   'Food Sales', '4000', 'revenue', 'sales', 'credit')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO connected_banks
+  (id, restaurant_id, stripe_financial_account_id, institution_name)
+VALUES
+  ('dddddddd-0000-0000-0000-0000000000b1', 'dddddddd-0000-0000-0000-0000000000a1',
+   'fca_standing_sweep_fixture', 'Placeholder Bank')
+ON CONFLICT (id) DO NOTHING;
+
+-- A pos_system value no sync function, connection table, or edge function
+-- knows about. unified_sales.pos_system is a bare TEXT NOT NULL with no CHECK
+-- and no enum (20250925125415:13), which is itself part of why a new POS needs
+-- no migration — if this INSERT ever starts failing, that property is gone.
+INSERT INTO unified_sales
+  (id, restaurant_id, pos_system, external_order_id, item_name, quantity,
+   sale_date, total_price)
+VALUES
+  ('dddddddd-0000-0000-0000-0000000000d1', 'dddddddd-0000-0000-0000-0000000000a1',
+   'future_pos', 'ord-future-1', 'Future POS Item', 1, CURRENT_DATE, 12.00)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO bank_transactions
+  (id, restaurant_id, connected_bank_id, stripe_transaction_id,
+   transaction_date, description, amount)
+VALUES
+  ('dddddddd-0000-0000-0000-0000000000e1', 'dddddddd-0000-0000-0000-0000000000a1',
+   'dddddddd-0000-0000-0000-0000000000b1', 'txn_standing_sweep_fixture',
+   CURRENT_DATE, 'STANDING SWEEP VENDOR', -25.00)
+ON CONFLICT (id) DO NOTHING;
+
+-- Now the rules, after the rows. The restaurant has no POS connection row of
+-- any kind — the drain selects restaurants by RULE, so it is swept anyway.
+INSERT INTO categorization_rules
+  (id, restaurant_id, rule_name, applies_to, category_id, item_name_pattern,
+   item_name_match_type, is_active, auto_apply, priority, created_at, updated_at)
+VALUES
+  ('dddddddd-0000-0000-0000-0000000000f1', 'dddddddd-0000-0000-0000-0000000000a1',
+   'Future POS rule', 'pos_sales', 'dddddddd-0000-0000-0000-0000000000c1',
+   'Future POS Item', 'exact', true, true, 10,
+   '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO categorization_rules
+  (id, restaurant_id, rule_name, applies_to, category_id, description_pattern,
+   description_match_type, is_active, auto_apply, priority, created_at, updated_at)
+VALUES
+  ('dddddddd-0000-0000-0000-0000000000f2', 'dddddddd-0000-0000-0000-0000000000a1',
+   'Standing sweep bank rule', 'bank_transactions', 'dddddddd-0000-0000-0000-0000000000c1',
+   'STANDING SWEEP VENDOR', 'exact', true, true, 10,
+   '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')
+ON CONFLICT (id) DO NOTHING;
+
+-- One tick, captured so tests 5, 6 and 7 all describe the SAME tick.
+CREATE TEMP TABLE standing_sweep_tick AS
+SELECT public.drain_categorization_backlog() AS applied;
+
+-- Test 5: the whole point. Nothing anywhere knows what 'future_pos' is, and it
+-- is categorized regardless — because the sweep selects by restaurant and
+-- watermark, never by POS.
+SELECT ok(
+  (SELECT is_categorized AND category_id = 'dddddddd-0000-0000-0000-0000000000c1'
+   FROM unified_sales WHERE id = 'dddddddd-0000-0000-0000-0000000000d1'),
+  'a row whose pos_system no sync function knows about is still categorized'
+);
+
+-- Test 6: bank_transactions is covered by the same standing job. Before
+-- 20260804091000 its only driver was stripe-sync-transactions, and only on a
+-- sync that found new rows — so a backlog with no new activity never drained.
+SELECT ok(
+  (SELECT is_categorized AND category_id = 'dddddddd-0000-0000-0000-0000000000c1'
+   FROM bank_transactions WHERE id = 'dddddddd-0000-0000-0000-0000000000e1'),
+  'a bank_transactions candidate is categorized by a drain tick'
+);
+
+-- Test 7: both of the above came from ONE tick of ONE job. This is the
+-- "one standing job covers everything" claim, stated as an assertion.
+SELECT cmp_ok(
+  (SELECT applied FROM standing_sweep_tick),
+  '>=',
+  2,
+  'a single tick applies both the POS row and the bank row'
+);
+
+-- Test 4: the backlog is now exhausted for this restaurant, and the job still
+-- survives. Run as its OWN statement, never folded into the assertion: an outer
+-- scan of cron.job reads the snapshot taken when the statement began, so a
+-- cron.unschedule() performed by a volatile function in the same command is
+-- invisible to it — the combined form would silently test nothing.
+SELECT public.drain_categorization_backlog();
+
+SELECT ok(
+  EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'categorization-backlog-drain'),
+  'a converged tick leaves the standing job scheduled'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Problem

Categorization had two mechanisms and no owner, so rows that no sync function happened to touch were stranded forever.

- `drain_categorization_backlog()` was written as a one-shot backfill: it deleted its own pg_cron job on a converged pass. It ran four times and **retired itself on 2026-07-04**. It is absent from prod's `cron.job` today.
- `unified_sales` has an `auto_categorize_pos_sale` BEFORE INSERT trigger (one shot per row — a rule created tomorrow never sees today's rows) **and** a batch sweep that only `toast` / `focus` / `focus_transactions` / `revel` call inline. `square`, `clover`, `shift4`, `lighthouse`, `manual_upload` and `manual` have the trigger only.
- `bank_transactions` had exactly one driver — `stripe-sync-transactions`, and only when that sync found new rows.

Measured on production: **3,351 stranded uncategorized bank candidates across 8 restaurants** against 274 active auto-apply bank rules, plus 4,948 claimable POS candidates.

## Fix

Stop retiring. Schedule `drain_categorization_backlog()` permanently at `*/5 * * * *`.

This is POS-agnostic **by construction**, which is the whole point: the sweep selects candidates by `restaurant_id` + watermark with **no `pos_system` predicate**, and the drain selects restaurants by *rule*, not by connection table. One standing job therefore covers every POS that exists today and every POS added later, with zero per-integration wiring. Retirement is no longer buying anything either — since the `rules_evaluated_at` negative cache (#693) a converged tick reads no candidates at all.

Inline sweep calls in the four sync functions are deliberately kept (they make categorization prompt after a sync; the standing job is the safety net).

## Budget split

Both loops originally shared one `v_budget_hit` flag. The POS loop runs first, and its `query_canceled` handler sets that flag *deliberately* — so **one** timed-out POS batch zeroed out the bank loop for a whole tick with 39s of budget left. Bank is the backlog this job exists to rescue; it must not be structurally outranked.

Split into `v_budget_hit_pos` / `v_budget_hit_bank`, with POS capped at 25s of the unchanged 40s total. Both loops still measure from the same `v_started` — deliberately. Giving bank its own clock would make the worst-case tick `25s + 120s statement_timeout + 15s + 120s = 280s` against a 300s cadence, regressing the ~160s bound in the design's Risks section.

**This is a checked bound, not an absolute one.** The guards run only *between* batches, so a single in-flight `apply_rules_to_pos_sales_internal` can run past its checkpoint for up to the 120s `statement_timeout`, by which point bank's own 40s guard already reads past budget and bank gets nothing that tick. That residual case is documented in the design doc's Risks section and in `COMMENT ON FUNCTION` rather than papered over.

## Tests

`supabase/tests/51_standing_categorization_sweep.sql` — 9 assertions codifying the contract for future POS integrations (the "codify the pattern" ask):

1-2. the migration leaves a standing `*/5` job; the function contains no `cron.unschedule`
3-4. `apply_rules_to_pos_sales_internal` carries **no `pos_system` predicate**, and a row whose `pos_system` no sync function knows about is still categorized
5-6. a bank candidate is categorized by a tick; one tick applies both POS and bank
7. a converged tick leaves the job scheduled
8. structural — the POS and bank halves each name only their own budget-hit flag
9. behavioural — `apply_rules_to_pos_sales_internal` stubbed to raise SQLSTATE `57014`; a fresh bank candidate is still categorized

Tests 8 and 9 were **mutation-checked**: both fail against a re-unified-flag build of the migration, so they are real guards rather than tautologies.

`supabase/tests/50_categorization_backlog_drain.sql` — the two assertions that pinned self-retirement are inverted to assert the job survives both a backlog tick and a converged tick.

## Verification

| check | result |
|---|---|
| `test:db` | 2567/2567 |
| `50_categorization_backlog_drain.sql` | 10/10 |
| `51_standing_categorization_sweep.sql` | 9/9 |
| `typecheck` | clean |
| `build` | clean |

`npm run lint` reports 1651 pre-existing errors across files this branch never touches — this branch changes **zero** `.ts`/`.tsx` files (SQL + pgTAP + markdown only), and no CI workflow runs lint. Not addressed here.

## Post-deploy check

Within minutes of deploy, confirm all three — "cron ticks succeeded" alone is not evidence:
1. the job exists in `cron.job` on `*/5 * * * *`
2. `cron.job_run_details` shows succeeded ticks
3. unevaluated-candidate counts are **falling** from the 3,351 bank / 4,948 POS baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)
