### PR TITLE
fix(reviews): stop rendering an outage as a paused review page

### DIFF
--- a/docs/superpowers/plans/2026-08-05-review-page-load-states.md
+++ b/docs/superpowers/plans/2026-08-05-review-page-load-states.md
@@ -1,0 +1,618 @@
+# Review Page Load States Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop the public review page from reporting an edge-function failure as "This link isn't active", and give the failure its own retryable screen.
+
+**Architecture:** A pure classifier in `src/lib/reviews/reviewPageLoad.ts` turns the `{ data, error }` pair from `supabase.functions.invoke('review-public')` into one of three outcomes — `ready` / `inactive` / `error`. `ReviewPage` replaces its `page` + `loading` + `inactive` state trio with a single discriminated union and grows a third early-return screen. No server-side change.
+
+**Tech Stack:** React 18, TypeScript, Vite, Vitest, Playwright, Tailwind + semantic tokens.
+
+**Design doc:** `docs/superpowers/specs/2026-08-05-review-page-load-states-design.md` (commit `a86fa485`, revised after Phase 2.5 review).
+
+## Global Constraints
+
+- Semantic tokens only — no `bg-white`, `text-black`, or any literal colour. Existing screens use `text-foreground`, `text-muted-foreground`, `border-border`, `bg-card`, `bg-primary`, `text-primary-foreground`.
+- The paused screen's copy must not change: heading `This link isn't active`, body `Ask the restaurant for a current one.` It is the regression guard for the half of the behaviour that stays.
+- The error screen's copy is exactly: heading `Something went wrong`; body `That's on us, not you.` on the first failure and `Still not working. Give it a minute and try again.` on the second and later; button label `Try again`.
+- `restaurant_name: ''` must classify as `ready`. A validator that rejects it would render a live page as an error.
+- The `rate` and `comment` code paths (`src/pages/ReviewPage.tsx:97-160`) are untouched, including `committedRef`.
+- No new dependency, no change to `supabase/functions/review-public/`.
+- Pure logic lives in `src/lib`, not in `src/pages` — SonarCloud measures coverage on new code and the page is not a coverage-measured surface.
+
+---
+
+### Task 1: The load classifier
+
+**Files:**
+- Create: `src/lib/reviews/reviewPageLoad.ts`
+- Test: `tests/unit/reviewPageLoad.test.ts`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `PublicReviewPage` (interface), `ReviewPageLoad` (union type), `classifyReviewPageResponse(data: unknown, error: unknown): ReviewPageLoad`. Task 2 imports all three.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/reviewPageLoad.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { classifyReviewPageResponse } from '@/lib/reviews/reviewPageLoad';
+
+const VALID = {
+  restaurant_name: 'Test Diner',
+  headline: 'How was everything?',
+  subheadline: null,
+  logo_url: null,
+  threshold: 4,
+};
+
+describe('classifyReviewPageResponse', () => {
+  it('classifies a resolved error as error, whatever the data says', () => {
+    expect(classifyReviewPageResponse(VALID, { message: 'boom' })).toEqual({ kind: 'error' });
+    expect(classifyReviewPageResponse(null, { message: 'boom' })).toEqual({ kind: 'error' });
+  });
+
+  it('classifies a missing or non-object payload as error', () => {
+    expect(classifyReviewPageResponse(null, null)).toEqual({ kind: 'error' });
+    expect(classifyReviewPageResponse(undefined, null)).toEqual({ kind: 'error' });
+    expect(classifyReviewPageResponse('nope', null)).toEqual({ kind: 'error' });
+    expect(classifyReviewPageResponse([VALID], null)).toEqual({ kind: 'error' });
+  });
+
+  it('classifies the paused payload as inactive', () => {
+    expect(classifyReviewPageResponse({ inactive: true }, null)).toEqual({ kind: 'inactive' });
+  });
+
+  it('classifies a valid payload as ready and carries it through', () => {
+    expect(classifyReviewPageResponse(VALID, null)).toEqual({ kind: 'ready', page: VALID });
+  });
+
+  it('accepts an empty restaurant_name', () => {
+    // The function emits `?? ''` when the restaurant join is null
+    // (review-public/index.ts:141). Unreachable under the current NOT NULL
+    // schema, but a validator that rejected it would render a live page as an
+    // error — the exact failure this whole change exists to prevent.
+    const page = { ...VALID, restaurant_name: '' };
+    expect(classifyReviewPageResponse(page, null)).toEqual({ kind: 'ready', page });
+  });
+
+  it('accepts a populated subheadline and logo_url', () => {
+    const page = { ...VALID, subheadline: 'It takes 10 seconds', logo_url: 'https://x/y.png' };
+    expect(classifyReviewPageResponse(page, null)).toEqual({ kind: 'ready', page });
+  });
+
+  it('classifies a payload the page cannot render as error', () => {
+    expect(classifyReviewPageResponse({ ...VALID, headline: undefined }, null)).toEqual({ kind: 'error' });
+    expect(classifyReviewPageResponse({ ...VALID, restaurant_name: 7 }, null)).toEqual({ kind: 'error' });
+    expect(classifyReviewPageResponse({ ...VALID, threshold: 'four' }, null)).toEqual({ kind: 'error' });
+    expect(classifyReviewPageResponse({ ...VALID, threshold: 2.5 }, null)).toEqual({ kind: 'error' });
+    expect(classifyReviewPageResponse({ ...VALID, threshold: 0 }, null)).toEqual({ kind: 'error' });
+    expect(classifyReviewPageResponse({ ...VALID, threshold: 6 }, null)).toEqual({ kind: 'error' });
+    expect(classifyReviewPageResponse({ ...VALID, subheadline: 12 }, null)).toEqual({ kind: 'error' });
+  });
+
+  it('ignores inactive when it is not exactly true', () => {
+    // A payload carrying `inactive: false` alongside a real page is still a
+    // page; a payload carrying only `inactive: false` is unreadable.
+    expect(classifyReviewPageResponse({ ...VALID, inactive: false }, null)).toEqual({
+      kind: 'ready',
+      page: { ...VALID, inactive: false },
+    });
+    expect(classifyReviewPageResponse({ inactive: false }, null)).toEqual({ kind: 'error' });
+  });
+});
+```
+
+Note on the `inactive: false` + valid-page case: `classifyReviewPageResponse` returns the payload object it was handed, extra keys and all — it validates, it does not strip. The assertion spells that out so a later change to cloning behaviour is a deliberate decision, not a surprise.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+npx vitest run tests/unit/reviewPageLoad.test.ts
+```
+
+Expected: FAIL — `Failed to resolve import "@/lib/reviews/reviewPageLoad"`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/lib/reviews/reviewPageLoad.ts`:
+
+```ts
+/**
+ * What `review-public`'s `page` action can tell the client, and how the client
+ * should read it.
+ *
+ * These three outcomes used to be two. `ReviewPage` collapsed a resolved
+ * `error`, a null payload and a genuinely paused page into one "this link
+ * isn't active" screen, so when the function started failing on every call —
+ * `REVIEW_TOKEN_SECRET` was never set in production — the page told the owner
+ * the one thing that was demonstrably fine, and they spent the outage toggling
+ * `is_active`. An infrastructure failure is not a domain state.
+ */
+
+export interface PublicReviewPage {
+  restaurant_name: string;
+  headline: string;
+  subheadline: string | null;
+  logo_url: string | null;
+  threshold: number;
+}
+
+export type ReviewPageLoad =
+  | { kind: 'ready'; page: PublicReviewPage }
+  | { kind: 'inactive' }
+  | { kind: 'error' };
+
+function isNullableString(value: unknown): boolean {
+  return value === null || typeof value === 'string';
+}
+
+/**
+ * The payload has to be checked, not cast. The old code did `data as PublicPage`
+ * and trusted it, so a 200 carrying something else rendered a card with
+ * `undefined` in it and a star control wired to a threshold of `undefined`.
+ * A response the client cannot read is a failure and should look like one.
+ *
+ * `restaurant_name` may be the empty string: the function emits `?? ''` when the
+ * restaurant join comes back null (review-public/index.ts:141).
+ */
+function isPublicReviewPage(value: Record<string, unknown>): value is Record<string, unknown> &
+  PublicReviewPage {
+  return (
+    typeof value.restaurant_name === 'string' &&
+    typeof value.headline === 'string' &&
+    isNullableString(value.subheadline) &&
+    isNullableString(value.logo_url) &&
+    typeof value.threshold === 'number' &&
+    Number.isInteger(value.threshold) &&
+    value.threshold >= 1 &&
+    value.threshold <= 5
+  );
+}
+
+/**
+ * `supabase.functions.invoke()` resolves with `{ data, error }` in every failure
+ * mode — under the pinned functions-js the whole call body, including the fetch
+ * rejection path, sits inside one try/catch. So a 500 and a dropped connection
+ * both arrive here as a truthy `error`, never as a throw.
+ */
+export function classifyReviewPageResponse(data: unknown, error: unknown): ReviewPageLoad {
+  if (error) return { kind: 'error' };
+  if (typeof data !== 'object' || data === null || Array.isArray(data)) return { kind: 'error' };
+
+  const payload = data as Record<string, unknown>;
+  if (payload.inactive === true) return { kind: 'inactive' };
+  if (isPublicReviewPage(payload)) return { kind: 'ready', page: payload };
+  return { kind: 'error' };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+npx vitest run tests/unit/reviewPageLoad.test.ts
+```
+
+Expected: PASS, 8 tests.
+
+- [ ] **Step 5: Typecheck and lint**
+
+```bash
+npm run typecheck && npx eslint src/lib/reviews/reviewPageLoad.ts tests/unit/reviewPageLoad.test.ts
+```
+
+Expected: both clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/reviews/reviewPageLoad.ts tests/unit/reviewPageLoad.test.ts
+git commit -m "feat(reviews): classify the public page load into ready/inactive/error"
+```
+
+---
+
+### Task 2: Rewire ReviewPage onto the union
+
+**Files:**
+- Modify: `src/pages/ReviewPage.tsx` (lines 20-26, 39-90, 162-189)
+- Test: covered end-to-end by Task 3; no unit test — the page is not a coverage-measured surface and the logic it now holds is wiring.
+
+**Interfaces:**
+- Consumes: `PublicReviewPage`, `ReviewPageLoad`, `classifyReviewPageResponse` from Task 1.
+- Produces: the DOM contract Task 3 asserts against — an `<h1>` reading `Something went wrong`, a button named `Try again`, and the unchanged `<h1>` reading `This link isn't active`.
+
+- [ ] **Step 1: Replace the local payload interface with the shared one**
+
+In `src/pages/ReviewPage.tsx`, delete the `PublicPage` interface at lines 20-26 and add to the import block (after the `supabase` import at line 13, per the project's import order — types come after hooks):
+
+```tsx
+import {
+  classifyReviewPageResponse,
+  type PublicReviewPage,
+  type ReviewPageLoad,
+} from '@/lib/reviews/reviewPageLoad';
+```
+
+The file imports named hooks from `react` with no default import, so `React.ReactNode` is not in scope. Widen line 1 to bring the type in:
+
+```tsx
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
+```
+
+- [ ] **Step 2: Replace the three state slots with one union**
+
+Replace lines 42-44:
+
+```tsx
+  const [page, setPage] = useState<PublicPage | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [inactive, setInactive] = useState(false);
+```
+
+with:
+
+```tsx
+  // One state, not three booleans. Four real outcomes across three booleans
+  // left five representable combinations, and the render read two of them
+  // together (`inactive || !page`) to recover the fourth.
+  const [load, setLoad] = useState<{ kind: 'loading' } | ReviewPageLoad>({ kind: 'loading' });
+  const [attempt, setAttempt] = useState(0);
+  const [failures, setFailures] = useState(0);
+```
+
+- [ ] **Step 3: Rewrite the load effect**
+
+Replace lines 69-86:
+
+```tsx
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const { data, error } = await supabase.functions.invoke('review-public', {
+        body: { action: 'page', slug },
+      });
+      if (cancelled) return;
+      if (error || !data || data.inactive) {
+        setInactive(true);
+      } else {
+        setPage(data as PublicPage);
+      }
+      setLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [slug]);
+```
+
+with:
+
+```tsx
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const { data, error } = await supabase.functions.invoke('review-public', {
+        body: { action: 'page', slug },
+      });
+      if (cancelled) return;
+      const result = classifyReviewPageResponse(data, error);
+      setLoad(result);
+      if (result.kind === 'error') setFailures((count) => count + 1);
+      // The polite region is the only thing a screen-reader guest gets when a
+      // skeleton resolves — none of these screens takes focus on its own except
+      // the error one, and a silent swap reads as nothing having happened.
+      setAnnouncement(
+        result.kind === 'ready'
+          ? result.page.headline
+          : result.kind === 'inactive'
+            ? "This link isn't active."
+            : 'Something went wrong loading this page.'
+      );
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [slug, attempt]);
+```
+
+- [ ] **Step 4: Add the retry handler and the error-heading ref**
+
+After the `committedRef` declaration at line 67, add:
+
+```tsx
+  const errorHeadingRef = useRef<HTMLHeadingElement | null>(null);
+```
+
+After the `handlePreview` callback (line 92-95), add:
+
+```tsx
+  const handleRetry = useCallback(() => {
+    setLoad({ kind: 'loading' });
+    setAttempt((count) => count + 1);
+  }, []);
+```
+
+And after the `stage` focus effect at lines 88-90, add:
+
+```tsx
+  // Without this, focus sits on <body> the moment the retry button unmounts,
+  // dropping the guest to the top of the document mid-interaction.
+  useEffect(() => {
+    if (load.kind === 'error') errorHeadingRef.current?.focus();
+  }, [load.kind, attempt]);
+```
+
+- [ ] **Step 5: Rewrite the early-return screens**
+
+Replace lines 164-189 (the `if (loading)` and `if (inactive || !page)` blocks) with:
+
+```tsx
+  // The live region has to be mounted in every state, not just the loaded one,
+  // or the transition into a state is exactly what never gets announced.
+  const shell = (children: ReactNode) => (
+    <main className="theme-counter min-h-screen bg-background flex items-center justify-center p-4">
+      <p aria-live="polite" className="sr-only">
+        {announcement}
+      </p>
+      <div className={card}>{children}</div>
+    </main>
+  );
+
+  if (load.kind === 'loading') {
+    return shell(
+      <>
+        <Skeleton className="mx-auto h-14 w-14 rounded-full" />
+        <Skeleton className="mx-auto mt-4 h-5 w-40" />
+        <Skeleton className="mx-auto mt-6 h-10 w-56" />
+      </>
+    );
+  }
+
+  if (load.kind === 'inactive') {
+    return shell(
+      <>
+        <h1 className="counter-display text-[22px] font-semibold text-foreground text-center">
+          This link isn&apos;t active
+        </h1>
+        <p className="counter-micro mt-3 text-[12px] text-muted-foreground text-center">
+          Ask the restaurant for a current one.
+        </p>
+      </>
+    );
+  }
+
+  if (load.kind === 'error') {
+    return shell(
+      <>
+        <h1
+          ref={errorHeadingRef}
+          tabIndex={-1}
+          className="counter-display text-[22px] font-semibold text-foreground text-center focus:outline-none"
+        >
+          Something went wrong
+        </h1>
+        <p className="counter-micro mt-3 text-[12px] text-muted-foreground text-center">
+          {failures > 1
+            ? 'Still not working. Give it a minute and try again.'
+            : "That's on us, not you."}
+        </p>
+        <Button
+          type="button"
+          onClick={handleRetry}
+          className="mt-6 h-11 w-full rounded-lg bg-primary text-[15px] font-medium text-primary-foreground"
+        >
+          Try again
+        </Button>
+      </>
+    );
+  }
+
+  const page: PublicReviewPage = load.page;
+```
+
+- [ ] **Step 6: Wrap the loaded state in the same shell**
+
+At line 191-193 the loaded state opens with its own `<div className="theme-counter …"><div className={card}>`. Change the outer `<div>` to `<main>` (and its closing tag at line 395), and delete the now-duplicated `aria-live` paragraph at lines 216-218 — `shell` does not wrap this branch, so the region must be moved into the `<main>` here rather than dropped:
+
+```tsx
+  return (
+    <main className="theme-counter min-h-screen bg-background flex items-center justify-center p-4">
+      <p aria-live="polite" className="sr-only">
+        {announcement}
+      </p>
+      <div className={card}>
+```
+
+The `<p aria-live>` previously sat between the logo block and the stage content; moving it to the top of `<main>` changes nothing visually (it is `sr-only`) and makes it present in all four states.
+
+- [ ] **Step 7: Verify no reference to the removed state survives**
+
+```bash
+grep -n "setInactive\|setPage\|setLoading\|PublicPage\b" src/pages/ReviewPage.tsx
+```
+
+Expected: no output.
+
+- [ ] **Step 8: Typecheck, lint, and run the existing review unit tests**
+
+```bash
+npm run typecheck && npx eslint src/pages/ReviewPage.tsx && npx vitest run tests/unit/reviewPageLoad.test.ts tests/unit/useReviewPages.test.ts tests/unit/useReviewResponses.test.ts
+```
+
+Expected: all clean and passing.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/pages/ReviewPage.tsx
+git commit -m "fix(reviews): stop reporting a load failure as a paused page"
+```
+
+---
+
+### Task 3: E2E coverage for the three load outcomes
+
+**Files:**
+- Create: `tests/e2e/review-page-load.spec.ts`
+
+**Interfaces:**
+- Consumes: the DOM contract from Task 2 (headings `Something went wrong` / `This link isn't active`, button `Try again`).
+- Produces: nothing downstream.
+
+This is the Phase 8 E2E hard-gate for a user-facing page change. `review-public` is not served in the e2e stack, so every case stubs the route — the pattern at `tests/e2e/review-stars.spec.ts:26-52`. No auth: the page is public.
+
+- [ ] **Step 1: Write the spec**
+
+Create `tests/e2e/review-page-load.spec.ts`:
+
+```ts
+import { test, expect } from '@playwright/test';
+
+/**
+ * E2E: what the public review page says when it cannot load.
+ *
+ * The page used to render "This link isn't active" for an edge-function
+ * failure as well as for a genuinely paused page. When `review-public` started
+ * returning 500 on every call in production, that message sent the restaurant
+ * owner to the `is_active` toggle on a page that was already live. The first
+ * test here is that outage: it fails on the old code and passes on the new.
+ *
+ * The edge function is not served in the e2e stack, so `review-public` is
+ * stubbed at the route.
+ */
+
+const FN_GLOB = '**/functions/v1/review-public';
+
+const LIVE_PAGE = {
+  restaurant_name: 'Test Diner',
+  headline: 'How was everything?',
+  subheadline: null,
+  logo_url: null,
+  threshold: 4,
+};
+
+test.describe('public review page load states', () => {
+  test('a 500 shows the error screen, not the paused screen, and Try again recovers', async ({
+    page,
+  }) => {
+    let failNext = true;
+
+    await page.route(FN_GLOB, async (route) => {
+      if (failNext) {
+        return route.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'Something went wrong.' }),
+        });
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(LIVE_PAGE),
+      });
+    });
+
+    await page.goto('/r/table-tents');
+
+    await expect(page.getByRole('heading', { name: 'Something went wrong' })).toBeVisible({
+      timeout: 10000,
+    });
+    // The whole point: an infrastructure failure must not claim the page is paused.
+    await expect(page.getByText("This link isn't active")).toHaveCount(0);
+
+    failNext = false;
+    await page.getByRole('button', { name: 'Try again' }).click();
+
+    await expect(page.getByRole('heading', { name: 'How was everything?' })).toBeVisible();
+    await expect(page.getByRole('radiogroup', { name: /rate your visit/i })).toBeVisible();
+  });
+
+  test('a second failure escalates the copy', async ({ page }) => {
+    await page.route(FN_GLOB, async (route) =>
+      route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'Something went wrong.' }),
+      })
+    );
+
+    await page.goto('/r/table-tents');
+
+    await expect(page.getByText("That's on us, not you.")).toBeVisible({ timeout: 10000 });
+
+    await page.getByRole('button', { name: 'Try again' }).click();
+
+    await expect(page.getByText('Still not working. Give it a minute and try again.')).toBeVisible();
+  });
+
+  test('a paused page still shows the paused screen', async ({ page }) => {
+    await page.route(FN_GLOB, async (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ inactive: true }),
+      })
+    );
+
+    await page.goto('/r/table-tents');
+
+    // The regression guard for the half of the behaviour that must not change.
+    await expect(page.getByRole('heading', { name: "This link isn't active" })).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.getByText('Something went wrong')).toHaveCount(0);
+  });
+
+  test('a 200 the client cannot read shows the error screen', async ({ page }) => {
+    await page.route(FN_GLOB, async (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ restaurant_name: 'Test Diner' }),
+      })
+    );
+
+    await page.goto('/r/table-tents');
+
+    await expect(page.getByRole('heading', { name: 'Something went wrong' })).toBeVisible({
+      timeout: 10000,
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the new spec**
+
+```bash
+npx playwright test tests/e2e/review-page-load.spec.ts --reporter=line
+```
+
+Expected: 4 passed. Run in the foreground and let the Bash tool's `timeout` bound it — no poll loop.
+
+- [ ] **Step 3: Run the sibling review specs for regressions**
+
+```bash
+npx playwright test tests/e2e/review-stars.spec.ts tests/e2e/review-funnel.spec.ts --reporter=line
+```
+
+Expected: all passing. `review-stars.spec.ts` exercises the same page through the loaded state and is the check that the `shell`/`<main>` restructure did not move anything the star control depends on.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/e2e/review-page-load.spec.ts
+git commit -m "test(reviews): cover the public page's three load outcomes end to end"
+```
+
+---
+
+## Verification
+
+- [ ] `npm run typecheck`
+- [ ] `npm run lint`
+- [ ] `npm run test` — full unit suite
+- [ ] `npx playwright test tests/e2e/review-page-load.spec.ts tests/e2e/review-stars.spec.ts tests/e2e/review-funnel.spec.ts --reporter=line`
+- [ ] Manual: `npm run dev`, visit `/r/<a real local slug>` with the local edge function stopped — expect the error screen and a working *Try again*, not the paused screen.

--- a/docs/superpowers/specs/2026-08-05-review-page-load-states-design.md
+++ b/docs/superpowers/specs/2026-08-05-review-page-load-states-design.md
@@ -99,9 +99,18 @@ Rules, in order:
 2. `data` is not a non-null object → `error`
 3. `data.inactive === true` → `inactive`
 4. the payload validates (`restaurant_name` and `headline` are strings,
-   `threshold` is an integer 1–5, `subheadline` and `logo_url` are string-or-null)
+   `subheadline` and `logo_url` are string-or-null, `threshold` is a number)
    → `ready`
 5. otherwise → `error`
+
+The validator checks that the page is *renderable*, not that it is
+well-formed by the server's rules. `threshold` is the line where those two
+differ: the client never reads it — routing is decided server-side and
+arrives as `routed_to` (`src/pages/ReviewPage.tsx:125`) — so an integer-1-to-5
+bound here would encode a schema constraint the page does not depend on, and
+a future server-side widening of `promoter_threshold` would turn every live
+page into an error screen. That is the failure this whole change exists to
+prevent, so the bound stays off and the type check stays on.
 
 Rule 4 is a change in behaviour beyond the reported bug, and it is intentional:
 today `data as PublicPage` (`src/pages/ReviewPage.tsx:79`) is an unchecked cast,

--- a/docs/superpowers/specs/2026-08-05-review-page-load-states-design.md
+++ b/docs/superpowers/specs/2026-08-05-review-page-load-states-design.md
@@ -155,13 +155,16 @@ the load effect, and resets the state to `loading` so the skeleton shows while
 it retries. No page reload — a reload would be a heavier hammer and would lose
 nothing but also gain nothing.
 
-**Retry mechanics.** The button disables itself for the duration of the in-flight
-attempt. The existing `cancelled` flag (`src/pages/ReviewPage.tsx:70`, `:75`,
-`:83-85`) already makes a double-fire harmless at the data layer, but a button
-that still looks pressable while a fetch is running is a UI gap on exactly the
-flaky mobile connections this page is built for. A fast repeat failure would
-otherwise flash skeleton → error → skeleton → error; the disabled state removes
-the ability to drive that flicker, so no artificial minimum skeleton duration is
+**Retry mechanics.** No `disabled` prop is needed, because the button is not on
+screen during the retry: the click resets the state to `loading`, which swaps the
+whole card for the skeleton and unmounts the button with it. A second tap has
+nothing to hit. That is stronger than disabling it, and it is why the escalated
+copy — not a spinner on the button — is what tells a guest the retry ran. The
+existing `cancelled` flag (`src/pages/ReviewPage.tsx:70`, `:75`, `:83-85`) covers
+the in-flight response of a superseded attempt at the data layer.
+
+A fast repeat failure therefore reads as error → skeleton → error rather than a
+flicker the guest can drive, so no artificial minimum skeleton duration is
 needed.
 
 **Accessibility.** The load effect currently announces nothing: the `aria-live`
@@ -242,7 +245,6 @@ cases, no auth needed:
 2. Function returns `{inactive: true}` → the paused screen still renders. This
    is the regression guard for the half of the behaviour that must not change.
 3. Function returns a malformed 200 → the error screen renders.
-4. Function returns 500 twice → the second render carries the escalated copy,
-   and the retry button is disabled while the retry is in flight.
+4. Function returns 500 twice → the second render carries the escalated copy.
 
 Case 1 is the outage, reproduced: it fails on `main` and passes after the fix.

--- a/docs/superpowers/specs/2026-08-05-review-page-load-states-design.md
+++ b/docs/superpowers/specs/2026-08-05-review-page-load-states-design.md
@@ -1,0 +1,173 @@
+# Review page load states — design
+
+**Date:** 2026-08-05
+**Branch:** `fix/review-page-error-state`
+
+## The problem, from the outage that exposed it
+
+`REVIEW_TOKEN_SECRET` and `REVIEW_IP_PEPPER` were never set as production
+edge-function secrets. The env guard in `review-public` runs before the body is
+even parsed and returns a bare 500
+(`supabase/functions/review-public/index.ts:71-73`), so **every** call to the
+public review page failed.
+
+What the guest and the owner saw was: *"This link isn't active — ask the
+restaurant for a current one."*
+
+That message is a lie about a specific, checkable thing. The owner spent the
+outage toggling `is_active` on a page that was already live, because the UI told
+them the page was paused. The infrastructure failure was invisible; the one
+domain state the UI named was the one thing that was fine.
+
+The cause is a single line. `src/pages/ReviewPage.tsx:76` collapses three
+distinct outcomes into one:
+
+```tsx
+if (error || !data || data.inactive) {
+  setInactive(true);
+}
+```
+
+`error` (transport failure or any non-2xx from the function), `!data` (nothing
+came back), and `data.inactive` (the page really is paused) all set the same
+flag, and `src/pages/ReviewPage.tsx:176` renders the same paused screen for all
+three.
+
+## What the function actually returns
+
+Three shapes, and the client currently distinguishes only one of them:
+
+| Situation | Response |
+|---|---|
+| Page found and live | 200, the payload at `supabase/functions/review-public/index.ts:140-146` |
+| Slug unknown **or** page paused | 200 `{ inactive: true }` (`index.ts:134`) |
+| Missing config, DB error, bad request | 4xx/5xx `{ error: <generic string> }` (`index.ts:24-25`) |
+
+Merging unknown-slug with paused is deliberate at the function — it stops a
+public endpoint from confirming which slugs exist (`index.ts:128`, the comment
+above the branch says so). That merge is correct and stays. The merge this
+design undoes is the client-side one, between *the function answered* and *the
+function did not*.
+
+Two premises worth pinning, because the fix depends on them:
+
+- `supabase.functions.invoke()` **resolves** with `{ data, error }` on HTTP
+  failures and only rejects on transport failures. So a 500 arrives as a
+  resolved `error`, not a throw — which is why the current code catches it at
+  all, and why the fix belongs in the same branch rather than in a `try`.
+  (Confirmed for this codebase in `memory/lessons.md`, entry 2026-05-16.)
+- `restaurant_name` can legitimately be the empty string: the payload uses
+  `?? ''` when the restaurant join comes back null
+  (`supabase/functions/review-public/index.ts:141`). Any validation must accept
+  `''`, or a live page with an odd join renders as an error.
+
+## The fix
+
+**Split the outcome into three, and let only `data.inactive` mean paused.**
+
+### 1. A pure classifier, in `src/lib`
+
+`src/lib/reviews/reviewPageLoad.ts` (new) exports the payload type and one
+function:
+
+```ts
+export type ReviewPageLoad =
+  | { kind: 'ready'; page: PublicReviewPage }
+  | { kind: 'inactive' }
+  | { kind: 'error' };
+
+export function classifyReviewPageResponse(data: unknown, error: unknown): ReviewPageLoad;
+```
+
+Rules, in order:
+
+1. `error` truthy → `error`
+2. `data` is not a non-null object → `error`
+3. `data.inactive === true` → `inactive`
+4. the payload validates (`restaurant_name` and `headline` are strings,
+   `threshold` is an integer 1–5, `subheadline` and `logo_url` are string-or-null)
+   → `ready`
+5. otherwise → `error`
+
+Rule 4 is a change in behaviour beyond the reported bug, and it is intentional:
+today `data as PublicPage` (`src/pages/ReviewPage.tsx:79`) is an unchecked cast,
+so a malformed 200 renders a card with `undefined` in it and a star control
+wired to a threshold of `undefined`. A response the client cannot read is a
+failure, and should look like one.
+
+This lives in `src/lib` rather than in the page for two reasons: it is pure
+logic, which this codebase keeps out of `src/pages` so it lands in the
+coverage-measured surface; and the classification is the part with edge cases
+worth testing directly, without mounting a page.
+
+### 2. One state, not three booleans
+
+`ReviewPage` currently holds `page` and `inactive` as separate `useState`
+(`src/pages/ReviewPage.tsx:42-44`) and reads them together at line 176
+(`inactive || !page`). Adding a third boolean for the error case would make five
+combinations for four real states.
+
+Replace both with a single `ReviewPageLoad`-plus-loading union:
+
+```tsx
+const [load, setLoad] = useState<{ kind: 'loading' } | ReviewPageLoad>({ kind: 'loading' });
+```
+
+The impossible states (ready-without-a-page, inactive-and-error) stop being
+representable.
+
+### 3. An error screen that offers the retry
+
+The paused screen keeps its exact copy — it is correct, it is just no longer
+shown for failures. The new screen sits beside it, in the same card:
+
+> **Something went wrong**
+> That's on us, not you.
+> [ Try again ]
+
+Retry re-runs the fetch by bumping an `attempt` counter that is a dependency of
+the load effect, and resets the state to `loading` so the skeleton shows while
+it retries. No page reload — a reload would be a heavier hammer and would lose
+nothing but also gain nothing.
+
+The button carries visible text, so it needs no `aria-label`. The heading is the
+card's `<h1>`, matching the paused and land screens.
+
+This is the same shape as the two error affordances already in the file, which
+both name the failure and leave the action in reach: `rateError` at
+`src/pages/ReviewPage.tsx:238-246` and `submitError` at
+`src/pages/ReviewPage.tsx:360-364`. The load path is the only one of the three
+that lacked it.
+
+## What is deliberately not in scope
+
+- **The paused/unknown-slug merge in the function.** Correct as designed; see
+  above.
+- **Making the missing-config 500 loud at deploy time.** The outage's other
+  half — nothing in CI asserts that `REVIEW_TOKEN_SECRET` and
+  `REVIEW_IP_PEPPER` exist in a given environment — is real and worth fixing,
+  but it is a separate change to a separate surface (CI / deploy checks), and
+  bundling it here would make this diff two unrelated things.
+- **The `rate` and `comment` paths.** They already distinguish failure from
+  outcome (`src/pages/ReviewPage.tsx:115`, `:155`) and are untouched.
+
+## Testing
+
+**Unit — `tests/unit/reviewPageLoad.test.ts` (new).** The classifier's table:
+resolved `error` → `error`; `data: null` → `error`; `{inactive: true}` →
+`inactive`; a valid payload → `ready` with the page; `restaurant_name: ''` →
+`ready` (the `?? ''` case, guarding against an over-strict validator); a payload
+missing `headline`, and one with a non-numeric `threshold` → `error`.
+
+**E2E — `tests/e2e/review-page-load.spec.ts` (new).** `review-public` is not
+served in the e2e stack, so the page fetch is stubbed at the route, following
+the pattern already established at `tests/e2e/review-stars.spec.ts:26-52`. Three
+cases, no auth needed:
+
+1. Function returns 500 → the error screen renders, **not** the paused screen;
+   clicking *Try again* with the stub flipped to a good payload loads the page.
+2. Function returns `{inactive: true}` → the paused screen still renders. This
+   is the regression guard for the half of the behaviour that must not change.
+3. Function returns a malformed 200 → the error screen renders.
+
+Case 1 is the outage, reproduced: it fails on `main` and passes after the fix.

--- a/docs/superpowers/specs/2026-08-05-review-page-load-states-design.md
+++ b/docs/superpowers/specs/2026-08-05-review-page-load-states-design.md
@@ -44,22 +44,36 @@ Three shapes, and the client currently distinguishes only one of them:
 | Missing config, DB error, bad request | 4xx/5xx `{ error: <generic string> }` (`index.ts:24-25`) |
 
 Merging unknown-slug with paused is deliberate at the function — it stops a
-public endpoint from confirming which slugs exist (`index.ts:128`, the comment
+public endpoint from confirming which slugs exist (`index.ts:129`, the comment
 above the branch says so). That merge is correct and stays. The merge this
 design undoes is the client-side one, between *the function answered* and *the
 function did not*.
 
+Splitting error from inactive on the client leaks nothing the function hides:
+an unknown slug and a paused page both stay on the 200 `{inactive: true}` path
+(`index.ts:129-134`), and the new `error` classification is reachable only via a
+4xx/5xx or an unreadable 200 — none of which vary with whether a slug exists.
+
 Two premises worth pinning, because the fix depends on them:
 
-- `supabase.functions.invoke()` **resolves** with `{ data, error }` on HTTP
-  failures and only rejects on transport failures. So a 500 arrives as a
-  resolved `error`, not a throw — which is why the current code catches it at
-  all, and why the fix belongs in the same branch rather than in a `try`.
-  (Confirmed for this codebase in `memory/lessons.md`, entry 2026-05-16.)
-- `restaurant_name` can legitimately be the empty string: the payload uses
-  `?? ''` when the restaurant join comes back null
-  (`supabase/functions/review-public/index.ts:141`). Any validation must accept
-  `''`, or a live page with an odd join renders as an error.
+- `supabase.functions.invoke()` **resolves** with `{ data, error }` in every
+  failure mode. A 500 arrives as a resolved `error`, not a throw — which is why
+  the current code catches it at all, and why the fix belongs in the same branch
+  rather than in a `try`. Under the pinned SDK (`@supabase/functions-js` 2.4.6,
+  via `@supabase/supabase-js@^2.57.4` at `package.json:89`) the whole `invoke()`
+  body — including the `fetch` rejection path — sits inside one `try/catch` that
+  returns `{ data: null, error }`, so transport failures resolve too. The entry
+  in `memory/lessons.md` 2026-05-16 says `invoke()` "only rejects on transport
+  failures"; that half is stale for this SDK version and should be corrected
+  there separately.
+- `restaurant_name` can be the empty string: the payload uses `?? ''` when the
+  restaurant join comes back null
+  (`supabase/functions/review-public/index.ts:141`). Under the current schema
+  that fallback is unreachable — `review_pages.restaurant_id` is `NOT NULL` with
+  `ON DELETE CASCADE` and `restaurants.name` is `NOT NULL` — so accepting `''`
+  is defensive, not a live scenario. It stays in the validator and in the test
+  table anyway: the cost is one line, and the failure it prevents is a live page
+  rendering as an error.
 
 ## The fix
 
@@ -122,22 +136,72 @@ The paused screen keeps its exact copy — it is correct, it is just no longer
 shown for failures. The new screen sits beside it, in the same card:
 
 > **Something went wrong**
-> That's on us, not you.
+> That's on us, not you. — *first failure*
+> Still not working. Give it a minute and try again. — *second and later*
 > [ Try again ]
+
+Two audiences hit this screen: a guest at a table, who needs to know the tap
+failed and it wasn't their fault, and the owner testing their own QR, who needs
+to know this is **not** a page-configuration problem. Naming the failure as ours
+serves both; the escalated line on repeat serves the owner during an outage like
+the one that prompted this, where the same static copy on the fourth attempt
+reads as a dead end. The register matches the page's existing voice
+(`src/pages/ReviewPage.tsx:244`, `:388`) — the file's other error strings are
+purely instructional (`:240`, `:362`), so this is a departure in shape, not in
+tone, and is worth a second look at UI review.
 
 Retry re-runs the fetch by bumping an `attempt` counter that is a dependency of
 the load effect, and resets the state to `loading` so the skeleton shows while
 it retries. No page reload — a reload would be a heavier hammer and would lose
 nothing but also gain nothing.
 
-The button carries visible text, so it needs no `aria-label`. The heading is the
-card's `<h1>`, matching the paused and land screens.
+**Retry mechanics.** The button disables itself for the duration of the in-flight
+attempt. The existing `cancelled` flag (`src/pages/ReviewPage.tsx:70`, `:75`,
+`:83-85`) already makes a double-fire harmless at the data layer, but a button
+that still looks pressable while a fetch is running is a UI gap on exactly the
+flaky mobile connections this page is built for. A fast repeat failure would
+otherwise flash skeleton → error → skeleton → error; the disabled state removes
+the ability to drive that flicker, so no artificial minimum skeleton duration is
+needed.
+
+**Accessibility.** The load effect currently announces nothing: the `aria-live`
+region at `src/pages/ReviewPage.tsx:216-218` lives inside the loaded state, and
+the focus effect at `:88-90` deliberately skips `'land'` and never runs for the
+early-return screens. A screen-reader guest who lands mid-fetch therefore hears
+nothing when the skeleton resolves, and hears nothing again after tapping *Try
+again*. This change fixes that for the screens it owns:
+
+- Each terminal load screen (ready, inactive, error) sets the existing
+  `announcement` state, so the polite region carries the outcome. The region
+  moves out of the loaded-state JSX to the outermost wrapper so it is mounted in
+  every state and a transition into it is actually announced.
+- The error screen's `<h1>` takes `tabIndex={-1}` and receives focus on entry,
+  the same idiom as `branchHeadingRef` at `:252-256`. Without it, focus lands on
+  `<body>` when the retry button unmounts and the guest is dropped to the top of
+  the document.
+- The card gets a `<main>` wrapper. `/r/:slug` is a standalone route outside the
+  authenticated layout's `<main>` (`src/App.tsx:112`, route at `:319-339`), so
+  this page has never had a landmark in any state. It is one element on a render
+  path this change is already rewriting.
+
+**Styling.** *Try again* is the sole path forward, so it takes the primary-CTA
+treatment already in the file (`src/pages/ReviewPage.tsx:366-373`:
+`h-11 w-full rounded-lg bg-primary text-[15px] font-medium text-primary-foreground`),
+not the ghost/underline idiom used for the opt-out at `:272-278`. Semantic tokens
+throughout; the card reuses the `card` class at `:162` and the
+`counter-display`/`counter-micro` typography. The button carries visible text, so
+it needs no `aria-label`.
 
 This is the same shape as the two error affordances already in the file, which
 both name the failure and leave the action in reach: `rateError` at
 `src/pages/ReviewPage.tsx:238-246` and `submitError` at
 `src/pages/ReviewPage.tsx:360-364`. The load path is the only one of the three
 that lacked it.
+
+No interaction with the star write guard: the error and loading screens are
+early returns that gate before any `stage`-based rendering, so a retry can only
+happen before a rating has been committed and `committedRef` (`:67`) is
+untouched.
 
 ## What is deliberately not in scope
 
@@ -150,6 +214,15 @@ that lacked it.
   bundling it here would make this diff two unrelated things.
 - **The `rate` and `comment` paths.** They already distinguish failure from
   outcome (`src/pages/ReviewPage.tsx:115`, `:155`) and are untouched.
+- **Offering the feedback form and contact capture to promoters too.** Raised
+  while this design was in review: today a 4★+ tap goes straight to the Google
+  hand-off (`src/pages/ReviewPage.tsx:125-128`) with no way to say anything or
+  leave contact details. That is a change to the funnel's branching and to the
+  `rate`/`comment` contract, not to load-state handling — its own cycle.
+- **Silent ratings being invisible in the inbox.** The inbox lists only rows
+  with a comment (`src/hooks/useReviewResponses.ts:67`), so a 5★ tap with no
+  written feedback appears in the header counters but never in the list. Also
+  raised in review, also a separate surface.
 
 ## Testing
 
@@ -169,5 +242,7 @@ cases, no auth needed:
 2. Function returns `{inactive: true}` → the paused screen still renders. This
    is the regression guard for the half of the behaviour that must not change.
 3. Function returns a malformed 200 → the error screen renders.
+4. Function returns 500 twice → the second render carries the escalated copy,
+   and the retry button is disabled while the retry is in flight.
 
 Case 1 is the outage, reproduced: it fails on `main` and passes after the fix.

--- a/src/lib/reviews/reviewPageLoad.ts
+++ b/src/lib/reviews/reviewPageLoad.ts
@@ -1,0 +1,59 @@
+/**
+ * Classifies what came back from `review-public`'s `page` action.
+ *
+ * This exists because the page used to collapse three outcomes into one. A
+ * failed invoke, an empty response, and a genuinely paused page all rendered
+ * "This link isn't active", so when `REVIEW_TOKEN_SECRET` was missing in
+ * production and every call 500'd, the owner spent the outage toggling
+ * `is_active` on a page that was already live.
+ *
+ * The payload is validated rather than cast: `supabase.functions.invoke()`
+ * returns `unknown`, and a 200 the client cannot render is a failure that
+ * should look like one — not a card with `undefined` in it.
+ */
+
+export interface PublicReviewPage {
+  restaurant_name: string;
+  headline: string;
+  subheadline: string | null;
+  logo_url: string | null;
+  threshold: number;
+}
+
+export type ReviewPageLoad =
+  | { kind: 'ready'; page: PublicReviewPage }
+  | { kind: 'inactive' }
+  | { kind: 'error' };
+
+function isNullableString(value: unknown): boolean {
+  return value === null || typeof value === 'string';
+}
+
+function isPublicReviewPage(
+  value: Record<string, unknown>
+): value is Record<string, unknown> & PublicReviewPage {
+  return (
+    // `restaurant_name` may be '': the function emits `?? ''` when the
+    // restaurant join is null (review-public/index.ts:141).
+    typeof value.restaurant_name === 'string' &&
+    typeof value.headline === 'string' &&
+    isNullableString(value.subheadline) &&
+    isNullableString(value.logo_url) &&
+    typeof value.threshold === 'number' &&
+    Number.isInteger(value.threshold) &&
+    value.threshold >= 1 &&
+    value.threshold <= 5
+  );
+}
+
+export function classifyReviewPageResponse(data: unknown, error: unknown): ReviewPageLoad {
+  if (error) return { kind: 'error' };
+  if (typeof data !== 'object' || data === null || Array.isArray(data)) return { kind: 'error' };
+
+  const payload = data as Record<string, unknown>;
+  // Only this branch means paused — an unknown slug lands here too, on purpose
+  // (review-public/index.ts:129-134).
+  if (payload.inactive === true) return { kind: 'inactive' };
+  if (isPublicReviewPage(payload)) return { kind: 'ready', page: payload };
+  return { kind: 'error' };
+}

--- a/src/lib/reviews/reviewPageLoad.ts
+++ b/src/lib/reviews/reviewPageLoad.ts
@@ -25,6 +25,9 @@ export type ReviewPageLoad =
   | { kind: 'inactive' }
   | { kind: 'error' };
 
+/** What the page holds while the fetch is still out, plus every settled outcome. */
+export type ReviewPageLoadState = { kind: 'loading' } | ReviewPageLoad;
+
 function isNullableString(value: unknown): boolean {
   return value === null || typeof value === 'string';
 }
@@ -39,10 +42,11 @@ function isPublicReviewPage(
     typeof value.headline === 'string' &&
     isNullableString(value.subheadline) &&
     isNullableString(value.logo_url) &&
-    typeof value.threshold === 'number' &&
-    Number.isInteger(value.threshold) &&
-    value.threshold >= 1 &&
-    value.threshold <= 5
+    // Type only, no range: the page never reads `threshold` — routing is
+    // decided server-side and arrives as `routed_to`. Bounding it here would
+    // encode a schema rule the render does not depend on, so a future widening
+    // of `promoter_threshold` would turn every live page into an error screen.
+    typeof value.threshold === 'number'
   );
 }
 

--- a/src/pages/ReviewPage.tsx
+++ b/src/pages/ReviewPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { Button } from '@/components/ui/button';
@@ -10,20 +10,18 @@ import { Textarea } from '@/components/ui/textarea';
 
 import { StarRating } from '@/components/reviews/StarRating';
 
+import {
+  classifyReviewPageResponse,
+  type PublicReviewPage,
+  type ReviewPageLoad,
+} from '@/lib/reviews/reviewPageLoad';
+
 import { supabase } from '@/integrations/supabase/client';
 
 import '@fontsource/zilla-slab/400.css';
 import '@fontsource/zilla-slab/600.css';
 import '@fontsource/ibm-plex-mono/400.css';
 import '@/styles/counter-theme.css';
-
-interface PublicPage {
-  restaurant_name: string;
-  headline: string;
-  subheadline: string | null;
-  logo_url: string | null;
-  threshold: number;
-}
 
 type Stage = 'land' | 'promoter' | 'feedback' | 'thanks';
 
@@ -39,9 +37,9 @@ function initials(name: string): string {
 export default function ReviewPage() {
   const { slug = '' } = useParams<{ slug: string }>();
 
-  const [page, setPage] = useState<PublicPage | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [inactive, setInactive] = useState(false);
+  const [load, setLoad] = useState<{ kind: 'loading' } | ReviewPageLoad>({ kind: 'loading' });
+  const [attempt, setAttempt] = useState(0);
+  const [failures, setFailures] = useState(0);
 
   const [preview, setPreview] = useState(0);
   const [committed, setCommitted] = useState(0);
@@ -65,6 +63,7 @@ export default function ReviewPage() {
   // would see `committed === 0` twice and file two ratings. The state is what
   // renders; the ref is what decides.
   const committedRef = useRef(0);
+  const errorHeadingRef = useRef<HTMLHeadingElement | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -73,25 +72,38 @@ export default function ReviewPage() {
         body: { action: 'page', slug },
       });
       if (cancelled) return;
-      if (error || !data || data.inactive) {
-        setInactive(true);
+      const result = classifyReviewPageResponse(data, error);
+      setLoad(result);
+      if (result.kind === 'error') {
+        setFailures((count) => count + 1);
+        setAnnouncement('Something went wrong loading this page.');
+      } else if (result.kind === 'inactive') {
+        setAnnouncement("This link isn't active.");
       } else {
-        setPage(data as PublicPage);
+        setAnnouncement(`${result.page.restaurant_name}. ${result.page.headline}`);
       }
-      setLoading(false);
     })();
     return () => {
       cancelled = true;
     };
-  }, [slug]);
+  }, [slug, attempt]);
 
   useEffect(() => {
     if (stage !== 'land') branchHeadingRef.current?.focus();
   }, [stage]);
 
+  useEffect(() => {
+    if (load.kind === 'error') errorHeadingRef.current?.focus();
+  }, [load.kind, attempt]);
+
   const handlePreview = useCallback((rating: number) => {
     setPreview(rating);
     setAnnouncement(`${rating} out of 5 stars`);
+  }, []);
+
+  const handleRetry = useCallback(() => {
+    setLoad({ kind: 'loading' });
+    setAttempt((count) => count + 1);
   }, []);
 
   const handleCommit = useCallback(
@@ -161,35 +173,74 @@ export default function ReviewPage() {
 
   const card = 'w-full max-w-md rounded-lg border border-border bg-card px-6 py-8 shadow-sm';
 
-  if (loading) {
-    return (
-      <div className="theme-counter min-h-screen bg-background flex items-center justify-center p-4">
-        <div className={card}>
-          <Skeleton className="mx-auto h-14 w-14 rounded-full" />
-          <Skeleton className="mx-auto mt-4 h-5 w-40" />
-          <Skeleton className="mx-auto mt-6 h-10 w-56" />
-        </div>
-      </div>
+  // Every load state renders through the same shell so the polite region is
+  // mounted throughout — a region that appears with its own text is not
+  // announced, which is what used to happen on this page.
+  const shell = (children: ReactNode) => (
+    <main className="theme-counter min-h-screen bg-background flex items-center justify-center p-4">
+      <p aria-live="polite" className="sr-only">
+        {announcement}
+      </p>
+      <div className={card}>{children}</div>
+    </main>
+  );
+
+  if (load.kind === 'loading') {
+    return shell(
+      <>
+        <Skeleton className="mx-auto h-14 w-14 rounded-full" />
+        <Skeleton className="mx-auto mt-4 h-5 w-40" />
+        <Skeleton className="mx-auto mt-6 h-10 w-56" />
+      </>
     );
   }
 
-  if (inactive || !page) {
-    return (
-      <div className="theme-counter min-h-screen bg-background flex items-center justify-center p-4">
-        <div className={card}>
-          <h1 className="counter-display text-[22px] font-semibold text-foreground text-center">
-            This link isn&apos;t active
-          </h1>
-          <p className="counter-micro mt-3 text-[12px] text-muted-foreground text-center">
-            Ask the restaurant for a current one.
-          </p>
-        </div>
-      </div>
+  if (load.kind === 'inactive') {
+    return shell(
+      <>
+        <h1 className="counter-display text-[22px] font-semibold text-foreground text-center">
+          This link isn&apos;t active
+        </h1>
+        <p className="counter-micro mt-3 text-[12px] text-muted-foreground text-center">
+          Ask the restaurant for a current one.
+        </p>
+      </>
     );
   }
+
+  if (load.kind === 'error') {
+    return shell(
+      <>
+        <h1
+          ref={errorHeadingRef}
+          tabIndex={-1}
+          className="counter-display text-[22px] font-semibold text-foreground text-center focus:outline-none"
+        >
+          Something went wrong
+        </h1>
+        <p className="counter-micro mt-3 text-[12px] text-muted-foreground text-center">
+          {failures > 1
+            ? 'Still not working. Give it a minute and try again.'
+            : "That's on us, not you."}
+        </p>
+        <Button
+          type="button"
+          onClick={handleRetry}
+          className="mt-6 h-11 w-full rounded-lg bg-primary text-[15px] font-medium text-primary-foreground"
+        >
+          Try again
+        </Button>
+      </>
+    );
+  }
+
+  const page: PublicReviewPage = load.page;
 
   return (
-    <div className="theme-counter min-h-screen bg-background flex items-center justify-center p-4">
+    <main className="theme-counter min-h-screen bg-background flex items-center justify-center p-4">
+      <p aria-live="polite" className="sr-only">
+        {announcement}
+      </p>
       <div className={card}>
         <div className="flex flex-col items-center">
           {page.logo_url ? (
@@ -212,10 +263,6 @@ export default function ReviewPage() {
         </div>
 
         <div className="counter-rule my-6" />
-
-        <p aria-live="polite" className="sr-only">
-          {announcement}
-        </p>
 
         {stage === 'land' && (
           <>
@@ -392,6 +439,6 @@ export default function ReviewPage() {
 
         <div className="counter-rule mt-8" />
       </div>
-    </div>
+    </main>
   );
 }

--- a/src/pages/ReviewPage.tsx
+++ b/src/pages/ReviewPage.tsx
@@ -105,6 +105,11 @@ export default function ReviewPage() {
   }, []);
 
   const handleRetry = useCallback(() => {
+    // Announcing the retry is what makes a repeat failure audible. Without it
+    // the settle below writes the same error string it wrote last time, React
+    // bails out on the identical state, the live region's text never changes,
+    // and a screen-reader guest hears silence in response to their tap.
+    setAnnouncement('Retrying.');
     setLoad({ kind: 'loading' });
     setAttempt((count) => count + 1);
   }, []);

--- a/src/pages/ReviewPage.tsx
+++ b/src/pages/ReviewPage.tsx
@@ -13,7 +13,7 @@ import { StarRating } from '@/components/reviews/StarRating';
 import {
   classifyReviewPageResponse,
   type PublicReviewPage,
-  type ReviewPageLoad,
+  type ReviewPageLoadState,
 } from '@/lib/reviews/reviewPageLoad';
 
 import { supabase } from '@/integrations/supabase/client';
@@ -37,7 +37,7 @@ function initials(name: string): string {
 export default function ReviewPage() {
   const { slug = '' } = useParams<{ slug: string }>();
 
-  const [load, setLoad] = useState<{ kind: 'loading' } | ReviewPageLoad>({ kind: 'loading' });
+  const [load, setLoad] = useState<ReviewPageLoadState>({ kind: 'loading' });
   const [attempt, setAttempt] = useState(0);
   const [failures, setFailures] = useState(0);
 
@@ -92,6 +92,9 @@ export default function ReviewPage() {
     if (stage !== 'land') branchHeadingRef.current?.focus();
   }, [stage]);
 
+  // `attempt` is in the deps because `load.kind` alone does not change between
+  // two consecutive failures — without it, a retry that fails again would leave
+  // focus wherever the unmounted button dropped it.
   useEffect(() => {
     if (load.kind === 'error') errorHeadingRef.current?.focus();
   }, [load.kind, attempt]);
@@ -236,209 +239,204 @@ export default function ReviewPage() {
 
   const page: PublicReviewPage = load.page;
 
-  return (
-    <main className="theme-counter min-h-screen bg-background flex items-center justify-center p-4">
-      <p aria-live="polite" className="sr-only">
-        {announcement}
-      </p>
-      <div className={card}>
-        <div className="flex flex-col items-center">
-          {page.logo_url ? (
-            <img
-              src={page.logo_url}
-              alt=""
-              className="h-14 w-14 rounded-full object-cover"
-            />
-          ) : (
-            <div
-              aria-hidden="true"
-              className="counter-display flex h-14 w-14 items-center justify-center rounded-full bg-muted text-[18px] font-semibold text-foreground"
-            >
-              {initials(page.restaurant_name)}
-            </div>
-          )}
-          <p className="counter-micro mt-3 text-[12px] uppercase tracking-wider text-muted-foreground">
-            {page.restaurant_name}
-          </p>
-        </div>
-
-        <div className="counter-rule my-6" />
-
-        {stage === 'land' && (
-          <>
-            <h1 className="counter-display text-center text-[26px] font-semibold text-foreground">
-              {page.headline}
-            </h1>
-            {page.subheadline && (
-              <p className="mt-2 text-center text-[14px] text-muted-foreground">
-                {page.subheadline}
-              </p>
-            )}
-            <div className="mt-6">
-              <StarRating
-                value={preview}
-                onPreview={handlePreview}
-                onCommit={handleCommit}
-                disabled={committed > 0}
-              />
-            </div>
-            {rateError ? (
-              <div className="mt-6 rounded-lg border border-border px-3 py-2 text-center text-[13px] text-foreground">
-                That didn&apos;t send. Tap a star to try again.
-              </div>
-            ) : (
-              <p className="counter-micro mt-6 text-center text-[12px] text-muted-foreground">
-                tap a star — 10 seconds, no account
-              </p>
-            )}
-          </>
+  return shell(
+    <>
+      <div className="flex flex-col items-center">
+        {page.logo_url ? (
+          <img
+            src={page.logo_url}
+            alt=""
+            className="h-14 w-14 rounded-full object-cover"
+          />
+        ) : (
+          <div
+            aria-hidden="true"
+            className="counter-display flex h-14 w-14 items-center justify-center rounded-full bg-muted text-[18px] font-semibold text-foreground"
+          >
+            {initials(page.restaurant_name)}
+          </div>
         )}
-
-        {stage === 'promoter' && (
-          <>
-            <h1
-              ref={branchHeadingRef}
-              tabIndex={-1}
-              className="counter-display text-center text-[26px] font-semibold text-foreground focus:outline-none"
-            >
-              Thank you
-            </h1>
-            <p className="mt-2 text-center text-[14px] text-muted-foreground">
-              Would you share that on Google? It takes about a minute.
-            </p>
-            {destinationUrl && (
-              <a
-                href={destinationUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="mt-6 flex h-11 w-full items-center justify-center rounded-lg bg-primary text-[15px] font-medium text-primary-foreground"
-              >
-                Leave a Google review
-              </a>
-            )}
-            <button
-              type="button"
-              onClick={() => setStage('thanks')}
-              className="counter-micro mt-4 w-full text-center text-[12px] text-muted-foreground underline"
-            >
-              No thanks
-            </button>
-          </>
-        )}
-
-        {stage === 'feedback' && (
-          <>
-            <h1
-              ref={branchHeadingRef}
-              tabIndex={-1}
-              className="counter-display text-center text-[26px] font-semibold text-foreground focus:outline-none"
-            >
-              What happened?
-            </h1>
-            <p className="counter-micro mt-2 text-center text-[12px] text-muted-foreground">
-              this goes straight to the owner — not public
-            </p>
-
-            <div className="mt-5 space-y-4">
-              <div>
-                <Label htmlFor="review-comment" className="text-[13px] text-foreground">
-                  Your feedback
-                </Label>
-                <Textarea
-                  id="review-comment"
-                  value={comment}
-                  onChange={(event) => setComment(event.target.value)}
-                  rows={4}
-                  className="mt-1.5 bg-background border-border"
-                />
-              </div>
-
-              <div className="flex items-start gap-2">
-                <Checkbox
-                  id="review-consent"
-                  checked={consent}
-                  onCheckedChange={(checked) => setConsent(checked === true)}
-                />
-                <Label htmlFor="review-consent" className="text-[13px] text-muted-foreground">
-                  It&apos;s OK to contact me about this
-                </Label>
-              </div>
-
-              {consent && (
-                <div className="space-y-3">
-                  <div>
-                    <Label htmlFor="review-name" className="text-[13px] text-foreground">
-                      Name
-                    </Label>
-                    <Input
-                      id="review-name"
-                      value={name}
-                      onChange={(event) => setName(event.target.value)}
-                      className="mt-1.5 bg-background border-border"
-                    />
-                  </div>
-                  <div>
-                    <Label htmlFor="review-email" className="text-[13px] text-foreground">
-                      Email
-                    </Label>
-                    <Input
-                      id="review-email"
-                      type="email"
-                      value={email}
-                      onChange={(event) => setEmail(event.target.value)}
-                      className="mt-1.5 bg-background border-border"
-                    />
-                  </div>
-                </div>
-              )}
-
-              {/* Honeypot: aria-hidden and untabbable so assistive tech never offers it. */}
-              <input
-                type="text"
-                name="hp"
-                value={honeypot}
-                onChange={(event) => setHoneypot(event.target.value)}
-                tabIndex={-1}
-                aria-hidden="true"
-                autoComplete="off"
-                className="absolute left-[-9999px] h-px w-px opacity-0"
-              />
-
-              {submitError && (
-                <div className="rounded-lg border border-border px-3 py-2 text-[13px] text-foreground">
-                  That didn&apos;t send. Your rating is already saved — try once more.
-                </div>
-              )}
-
-              <Button
-                type="button"
-                onClick={handleSubmitComment}
-                disabled={submitting || comment.trim().length === 0}
-                className="h-11 w-full rounded-lg bg-primary text-[15px] font-medium text-primary-foreground"
-              >
-                {submitting ? 'Sending…' : 'Send to the owner'}
-              </Button>
-            </div>
-          </>
-        )}
-
-        {stage === 'thanks' && (
-          <>
-            <h1
-              ref={branchHeadingRef}
-              tabIndex={-1}
-              className="counter-display text-center text-[26px] font-semibold text-foreground focus:outline-none"
-            >
-              Thanks for telling us
-            </h1>
-            <p className="counter-micro mt-3 text-center text-[12px] text-muted-foreground">
-              have a good one
-            </p>
-          </>
-        )}
-
-        <div className="counter-rule mt-8" />
+        <p className="counter-micro mt-3 text-[12px] uppercase tracking-wider text-muted-foreground">
+          {page.restaurant_name}
+        </p>
       </div>
-    </main>
+
+      <div className="counter-rule my-6" />
+
+      {stage === 'land' && (
+        <>
+          <h1 className="counter-display text-center text-[26px] font-semibold text-foreground">
+            {page.headline}
+          </h1>
+          {page.subheadline && (
+            <p className="mt-2 text-center text-[14px] text-muted-foreground">
+              {page.subheadline}
+            </p>
+          )}
+          <div className="mt-6">
+            <StarRating
+              value={preview}
+              onPreview={handlePreview}
+              onCommit={handleCommit}
+              disabled={committed > 0}
+            />
+          </div>
+          {rateError ? (
+            <div className="mt-6 rounded-lg border border-border px-3 py-2 text-center text-[13px] text-foreground">
+              That didn&apos;t send. Tap a star to try again.
+            </div>
+          ) : (
+            <p className="counter-micro mt-6 text-center text-[12px] text-muted-foreground">
+              tap a star — 10 seconds, no account
+            </p>
+          )}
+        </>
+      )}
+
+      {stage === 'promoter' && (
+        <>
+          <h1
+            ref={branchHeadingRef}
+            tabIndex={-1}
+            className="counter-display text-center text-[26px] font-semibold text-foreground focus:outline-none"
+          >
+            Thank you
+          </h1>
+          <p className="mt-2 text-center text-[14px] text-muted-foreground">
+            Would you share that on Google? It takes about a minute.
+          </p>
+          {destinationUrl && (
+            <a
+              href={destinationUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-6 flex h-11 w-full items-center justify-center rounded-lg bg-primary text-[15px] font-medium text-primary-foreground"
+            >
+              Leave a Google review
+            </a>
+          )}
+          <button
+            type="button"
+            onClick={() => setStage('thanks')}
+            className="counter-micro mt-4 w-full text-center text-[12px] text-muted-foreground underline"
+          >
+            No thanks
+          </button>
+        </>
+      )}
+
+      {stage === 'feedback' && (
+        <>
+          <h1
+            ref={branchHeadingRef}
+            tabIndex={-1}
+            className="counter-display text-center text-[26px] font-semibold text-foreground focus:outline-none"
+          >
+            What happened?
+          </h1>
+          <p className="counter-micro mt-2 text-center text-[12px] text-muted-foreground">
+            this goes straight to the owner — not public
+          </p>
+
+          <div className="mt-5 space-y-4">
+            <div>
+              <Label htmlFor="review-comment" className="text-[13px] text-foreground">
+                Your feedback
+              </Label>
+              <Textarea
+                id="review-comment"
+                value={comment}
+                onChange={(event) => setComment(event.target.value)}
+                rows={4}
+                className="mt-1.5 bg-background border-border"
+              />
+            </div>
+
+            <div className="flex items-start gap-2">
+              <Checkbox
+                id="review-consent"
+                checked={consent}
+                onCheckedChange={(checked) => setConsent(checked === true)}
+              />
+              <Label htmlFor="review-consent" className="text-[13px] text-muted-foreground">
+                It&apos;s OK to contact me about this
+              </Label>
+            </div>
+
+            {consent && (
+              <div className="space-y-3">
+                <div>
+                  <Label htmlFor="review-name" className="text-[13px] text-foreground">
+                    Name
+                  </Label>
+                  <Input
+                    id="review-name"
+                    value={name}
+                    onChange={(event) => setName(event.target.value)}
+                    className="mt-1.5 bg-background border-border"
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="review-email" className="text-[13px] text-foreground">
+                    Email
+                  </Label>
+                  <Input
+                    id="review-email"
+                    type="email"
+                    value={email}
+                    onChange={(event) => setEmail(event.target.value)}
+                    className="mt-1.5 bg-background border-border"
+                  />
+                </div>
+              </div>
+            )}
+
+            {/* Honeypot: aria-hidden and untabbable so assistive tech never offers it. */}
+            <input
+              type="text"
+              name="hp"
+              value={honeypot}
+              onChange={(event) => setHoneypot(event.target.value)}
+              tabIndex={-1}
+              aria-hidden="true"
+              autoComplete="off"
+              className="absolute left-[-9999px] h-px w-px opacity-0"
+            />
+
+            {submitError && (
+              <div className="rounded-lg border border-border px-3 py-2 text-[13px] text-foreground">
+                That didn&apos;t send. Your rating is already saved — try once more.
+              </div>
+            )}
+
+            <Button
+              type="button"
+              onClick={handleSubmitComment}
+              disabled={submitting || comment.trim().length === 0}
+              className="h-11 w-full rounded-lg bg-primary text-[15px] font-medium text-primary-foreground"
+            >
+              {submitting ? 'Sending…' : 'Send to the owner'}
+            </Button>
+          </div>
+        </>
+      )}
+
+      {stage === 'thanks' && (
+        <>
+          <h1
+            ref={branchHeadingRef}
+            tabIndex={-1}
+            className="counter-display text-center text-[26px] font-semibold text-foreground focus:outline-none"
+          >
+            Thanks for telling us
+          </h1>
+          <p className="counter-micro mt-3 text-center text-[12px] text-muted-foreground">
+            have a good one
+          </p>
+        </>
+      )}
+
+      <div className="counter-rule mt-8" />
+    </>
   );
 }

--- a/tests/e2e/review-page-load.spec.ts
+++ b/tests/e2e/review-page-load.spec.ts
@@ -13,6 +13,7 @@ import { test, expect, type Page } from '@playwright/test';
  */
 
 const FN_GLOB = '**/functions/v1/review-public';
+const PAGE_URL = '/r/table-tents';
 
 const GOOD_PAGE = {
   restaurant_name: 'Test Diner',
@@ -45,7 +46,7 @@ test.describe('public review page load states', () => {
         : { status: 200, body: GOOD_PAGE }
     );
 
-    await page.goto('/r/table-tents');
+    await page.goto(PAGE_URL);
 
     await expect(page.getByRole('heading', { name: /something went wrong/i })).toBeVisible({
       timeout: 10000,
@@ -63,7 +64,7 @@ test.describe('public review page load states', () => {
   test('a second failure escalates the copy', async ({ page }) => {
     await stubPage(page, () => ({ status: 500, body: { error: 'Server error' } }));
 
-    await page.goto('/r/table-tents');
+    await page.goto(PAGE_URL);
     await expect(page.getByText(/that's on us, not you/i)).toBeVisible({ timeout: 10000 });
 
     await page.getByRole('button', { name: /try again/i }).click();
@@ -75,7 +76,7 @@ test.describe('public review page load states', () => {
   test('a genuinely paused page still shows the paused screen', async ({ page }) => {
     await stubPage(page, () => ({ status: 200, body: { inactive: true } }));
 
-    await page.goto('/r/table-tents');
+    await page.goto(PAGE_URL);
 
     await expect(page.getByRole('heading', { name: /isn't active/i })).toBeVisible({
       timeout: 10000,
@@ -91,7 +92,7 @@ test.describe('public review page load states', () => {
       body: { restaurant_name: 'Test Diner', threshold: 'four' },
     }));
 
-    await page.goto('/r/table-tents');
+    await page.goto(PAGE_URL);
 
     await expect(page.getByRole('heading', { name: /something went wrong/i })).toBeVisible({
       timeout: 10000,

--- a/tests/e2e/review-page-load.spec.ts
+++ b/tests/e2e/review-page-load.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * E2E: the public review page tells the truth about why it didn't load.
+ *
+ * A missing edge-function secret once made `review-public` 500 on every call,
+ * and the page rendered "This link isn't active" — so the owner spent the
+ * outage toggling `is_active` on a page that was already live. These specs
+ * pin the two answers apart.
+ *
+ * `review-public` is not served in the e2e stack, so the route is stubbed,
+ * following the pattern in `review-stars.spec.ts`.
+ */
+
+const FN_GLOB = '**/functions/v1/review-public';
+
+const GOOD_PAGE = {
+  restaurant_name: 'Test Diner',
+  headline: 'How was everything?',
+  subheadline: null,
+  logo_url: null,
+  threshold: 4,
+};
+
+/** Stubs `review-public` with a body the caller controls per request. */
+async function stubPage(page: Page, respond: (call: number) => { status: number; body: unknown }) {
+  let calls = 0;
+  await page.route(FN_GLOB, async (route) => {
+    const request = route.request().postDataJSON();
+    if (request.action !== 'page') {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' });
+    }
+    const { status, body } = respond(++calls);
+    return route.fulfill({ status, contentType: 'application/json', body: JSON.stringify(body) });
+  });
+}
+
+test.describe('public review page load states', () => {
+  test('a 500 shows the error screen, not the paused screen, and retry recovers', async ({
+    page,
+  }) => {
+    await stubPage(page, (call) =>
+      call === 1
+        ? { status: 500, body: { error: 'Server error' } }
+        : { status: 200, body: GOOD_PAGE }
+    );
+
+    await page.goto('/r/table-tents');
+
+    await expect(page.getByRole('heading', { name: /something went wrong/i })).toBeVisible({
+      timeout: 10000,
+    });
+    // The lie this whole change exists to prevent.
+    await expect(page.getByText(/isn't active/i)).toHaveCount(0);
+    await expect(page.getByText(/that's on us, not you/i)).toBeVisible();
+
+    await page.getByRole('button', { name: /try again/i }).click();
+
+    await expect(page.getByRole('radiogroup', { name: /rate your visit/i })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /how was everything/i })).toBeVisible();
+  });
+
+  test('a second failure escalates the copy', async ({ page }) => {
+    await stubPage(page, () => ({ status: 500, body: { error: 'Server error' } }));
+
+    await page.goto('/r/table-tents');
+    await expect(page.getByText(/that's on us, not you/i)).toBeVisible({ timeout: 10000 });
+
+    await page.getByRole('button', { name: /try again/i }).click();
+
+    await expect(page.getByText(/still not working/i)).toBeVisible();
+    await expect(page.getByText(/that's on us, not you/i)).toHaveCount(0);
+  });
+
+  test('a genuinely paused page still shows the paused screen', async ({ page }) => {
+    await stubPage(page, () => ({ status: 200, body: { inactive: true } }));
+
+    await page.goto('/r/table-tents');
+
+    await expect(page.getByRole('heading', { name: /isn't active/i })).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.getByText(/ask the restaurant for a current one/i)).toBeVisible();
+    // No retry here: retrying a paused page would just pause again.
+    await expect(page.getByRole('button', { name: /try again/i })).toHaveCount(0);
+  });
+
+  test('a 200 the page cannot render is an error, not a half-drawn card', async ({ page }) => {
+    await stubPage(page, () => ({
+      status: 200,
+      body: { restaurant_name: 'Test Diner', threshold: 'four' },
+    }));
+
+    await page.goto('/r/table-tents');
+
+    await expect(page.getByRole('heading', { name: /something went wrong/i })).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.getByRole('radiogroup')).toHaveCount(0);
+  });
+});

--- a/tests/unit/reviewPageLoad.test.ts
+++ b/tests/unit/reviewPageLoad.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { classifyReviewPageResponse } from '@/lib/reviews/reviewPageLoad';
+
+const VALID = {
+  restaurant_name: 'Test Diner',
+  headline: 'How was everything?',
+  subheadline: null,
+  logo_url: null,
+  threshold: 4,
+};
+
+describe('classifyReviewPageResponse', () => {
+  it('classifies a resolved error as error, whatever the data says', () => {
+    expect(classifyReviewPageResponse(VALID, { message: 'boom' })).toEqual({ kind: 'error' });
+    expect(classifyReviewPageResponse(null, { message: 'boom' })).toEqual({ kind: 'error' });
+  });
+
+  it('classifies a missing or non-object payload as error', () => {
+    expect(classifyReviewPageResponse(null, null)).toEqual({ kind: 'error' });
+    expect(classifyReviewPageResponse(undefined, null)).toEqual({ kind: 'error' });
+    expect(classifyReviewPageResponse('nope', null)).toEqual({ kind: 'error' });
+    expect(classifyReviewPageResponse([VALID], null)).toEqual({ kind: 'error' });
+  });
+
+  it('classifies the paused payload as inactive', () => {
+    expect(classifyReviewPageResponse({ inactive: true }, null)).toEqual({ kind: 'inactive' });
+  });
+
+  it('classifies a valid payload as ready and carries it through', () => {
+    expect(classifyReviewPageResponse(VALID, null)).toEqual({ kind: 'ready', page: VALID });
+  });
+
+  it('accepts an empty restaurant_name', () => {
+    // The function emits `?? ''` when the restaurant join is null
+    // (review-public/index.ts:141). Unreachable under the current NOT NULL
+    // schema, but a validator that rejected it would render a live page as an
+    // error — the exact failure this whole change exists to prevent.
+    const page = { ...VALID, restaurant_name: '' };
+    expect(classifyReviewPageResponse(page, null)).toEqual({ kind: 'ready', page });
+  });
+
+  it('accepts a populated subheadline and logo_url', () => {
+    const page = { ...VALID, subheadline: 'It takes 10 seconds', logo_url: 'https://x/y.png' };
+    expect(classifyReviewPageResponse(page, null)).toEqual({ kind: 'ready', page });
+  });
+
+  it('classifies a payload the page cannot render as error', () => {
+    expect(classifyReviewPageResponse({ ...VALID, headline: undefined }, null)).toEqual({
+      kind: 'error',
+    });
+    expect(classifyReviewPageResponse({ ...VALID, restaurant_name: 7 }, null)).toEqual({
+      kind: 'error',
+    });
+    expect(classifyReviewPageResponse({ ...VALID, threshold: 'four' }, null)).toEqual({
+      kind: 'error',
+    });
+    expect(classifyReviewPageResponse({ ...VALID, threshold: 2.5 }, null)).toEqual({
+      kind: 'error',
+    });
+    expect(classifyReviewPageResponse({ ...VALID, threshold: 0 }, null)).toEqual({ kind: 'error' });
+    expect(classifyReviewPageResponse({ ...VALID, threshold: 6 }, null)).toEqual({ kind: 'error' });
+    expect(classifyReviewPageResponse({ ...VALID, subheadline: 12 }, null)).toEqual({
+      kind: 'error',
+    });
+  });
+
+  it('ignores inactive when it is not exactly true', () => {
+    // A payload carrying `inactive: false` alongside a real page is still a
+    // page; a payload carrying only `inactive: false` is unreadable.
+    expect(classifyReviewPageResponse({ ...VALID, inactive: false }, null)).toEqual({
+      kind: 'ready',
+      page: { ...VALID, inactive: false },
+    });
+    expect(classifyReviewPageResponse({ inactive: false }, null)).toEqual({ kind: 'error' });
+  });
+});

--- a/tests/unit/reviewPageLoad.test.ts
+++ b/tests/unit/reviewPageLoad.test.ts
@@ -54,14 +54,19 @@ describe('classifyReviewPageResponse', () => {
     expect(classifyReviewPageResponse({ ...VALID, threshold: 'four' }, null)).toEqual({
       kind: 'error',
     });
-    expect(classifyReviewPageResponse({ ...VALID, threshold: 2.5 }, null)).toEqual({
-      kind: 'error',
-    });
-    expect(classifyReviewPageResponse({ ...VALID, threshold: 0 }, null)).toEqual({ kind: 'error' });
-    expect(classifyReviewPageResponse({ ...VALID, threshold: 6 }, null)).toEqual({ kind: 'error' });
     expect(classifyReviewPageResponse({ ...VALID, subheadline: 12 }, null)).toEqual({
       kind: 'error',
     });
+  });
+
+  it('accepts a threshold outside the range the page knows about', () => {
+    // The page never reads `threshold`; routing arrives as `routed_to`. A
+    // server-side widening of `promoter_threshold` must not turn a live page
+    // into an error screen.
+    for (const threshold of [0, 6, 2.5]) {
+      const page = { ...VALID, threshold };
+      expect(classifyReviewPageResponse(page, null)).toEqual({ kind: 'ready', page });
+    }
   });
 
   it('ignores inactive when it is not exactly true', () => {


### PR DESCRIPTION
## The bug, from the outage that exposed it

`REVIEW_TOKEN_SECRET` and `REVIEW_IP_PEPPER` were never set as production
edge-function secrets. The env guard in `review-public` runs before the body is
even parsed and returns a bare 500, so **every** call to the public review page
failed.

What the guest and the owner saw was: *"This link isn't active — ask the
restaurant for a current one."*

That message is a lie about a specific, checkable thing. The owner spent the
outage toggling `is_active` on a page that was already live, because the UI told
them the page was paused. The infrastructure failure was invisible; the one
domain state the UI named was the one thing that was fine.

The cause was a single line — `src/pages/ReviewPage.tsx:76` collapsed three
distinct outcomes into one:

```tsx
if (error || !data || data.inactive) {
  setInactive(true);
}
```

## The fix

**Only `data.inactive` may mean paused.** Everything else that isn't a
renderable page is an error, and gets its own retryable screen.

- **`src/lib/reviews/reviewPageLoad.ts` (new)** — a pure classifier returning a
  discriminated union: `ready` / `inactive` / `error`. It validates the payload
  rather than casting it, because a 200 the client cannot render is a failure
  and should look like one, not a card with `undefined` in it.
- **`ReviewPage`** replaces the `page` + `inactive` boolean pair with one
  `ReviewPageLoadState`, so ready-without-a-page and inactive-and-error stop
  being representable.
- **New error screen** — "Something went wrong / That's on us, not you." with a
  primary *Try again*, escalating to "Still not working. Give it a minute and
  try again." on the second failure. Two audiences hit it: a guest at a table
  who needs to know the tap failed and it wasn't their fault, and the owner
  testing their own QR, who needs to know this is **not** a page-configuration
  problem.
- **Accessibility** — the polite live region moves to the outermost wrapper so
  it is mounted in every state, each outcome announces itself, the retry
  announces itself (otherwise a repeat failure writes the same string, React
  bails out on identical state, and the guest hears silence), the error `<h1>`
  takes focus so the unmounting button doesn't drop focus to `<body>`, and the
  card finally gets a `<main>` landmark — this standalone route never had one.

## What is deliberately unchanged

The function still merges unknown-slug with paused into one 200
`{inactive: true}` — that is what stops a public endpoint from confirming which
slugs exist. The client-side split reintroduces no oracle: `inactive === true`
short-circuits before validation, and the new `error` classification is
reachable only via a 4xx/5xx or an unreadable 200, none of which vary with
whether a slug exists.

`threshold` gets a type check but no range bound. The page never reads it —
routing is decided server-side and arrives as `routed_to` — so bounding it would
let a future widening of `promoter_threshold` turn every live page into an error
screen: the exact failure class this change exists to prevent.

## Evidence

The new E2E spec was run against the **pre-fix** `ReviewPage.tsx`: **3 failed, 1
passed** — the three new-behaviour cases fail on the old code, and the
paused-screen regression guard passes on both, which is what makes it a guard.

- `tests/unit/reviewPageLoad.test.ts` — 9 cases over the classifier's table.
- `tests/e2e/review-page-load.spec.ts` — 500 → error screen (asserting the
  "isn't active" copy is *absent*) then retry recovers; second failure escalates;
  `{inactive: true}` still shows the paused screen with no retry button; a
  malformed 200 is an error, not a half-drawn card.

## Out of scope, tracked

- Making the missing-config 500 loud at deploy time (a CI check for the two
  secrets) — separate surface.
- Offering the feedback form and contact capture to promoters, and silent
  ratings being invisible in the inbox — both raised during review, both changes
  to the funnel's branching rather than to load-state handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Public review pages now clearly distinguish ready, inactive, and error states.
  * Added accessible, retryable error screens with improved messaging for repeated failures.
  * Inactive pages retain their existing paused-page messaging without offering retry.

* **Bug Fixes**
  * Malformed, incomplete, or failed responses no longer render partial review content.

* **Tests**
  * Added unit and end-to-end coverage for loading states, retries, inactive pages, malformed responses, and successful recovery.

* **Documentation**
  * Added design and implementation planning documentation for review-page loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->