### PR TITLE
fix(scheduling): undo no longer desyncs a template from its shifts (#700)

### DIFF
--- a/docs/superpowers/plans/2026-08-05-template-cascade-undo-fix-plan.md
+++ b/docs/superpowers/plans/2026-08-05-template-cascade-undo-fix-plan.md
@@ -1,0 +1,715 @@
+# Template-Hours Cascade Undo Fix — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Undo restore the template's hours alongside its shifts, and stop the impact ledger from announcing "0 shifts move" when the manager is one checkbox away from moving three.
+
+**Architecture:** A new batch-header table records what a cascade did to the template itself, so `undo_template_hours_cascade` can reverse it in the same transaction as the shift revert, guarded by the same "unchanged since" check the shifts already use. On the client, one pure copy builder gains a clause and one component's nested disclosure gains a conditional default — no structural changes.
+
+**Tech Stack:** Postgres 15 (Supabase), plpgsql `SECURITY DEFINER` RPCs, pgTAP, React 18 + TypeScript, Vitest, Testing Library, Playwright.
+
+**Spec:** `docs/superpowers/specs/2026-08-05-template-cascade-undo-fix-design.md`
+
+## Global Constraints
+
+- Scope is **hours only** (`start_time`/`end_time`). Do not cascade or restore `days[]`, `capacity`, `area`, `position`, `name`, or `break_duration`.
+- **Never edit `supabase/migrations/20260804130000_template_hours_cascade.sql`.** It is applied in production. All SQL changes ship as the new migration `20260805160000_template_cascade_undo_restores_template.sql`, which supersedes the two functions via `CREATE OR REPLACE FUNCTION`.
+- The migration filename prefix `20260805160000` is fixed. `20260805120000` and `20260805130000` are claimed by sibling branches; the prefix is the PK of `supabase_migrations.schema_migrations` and a collision fails only on `pull_request` CI. `tests/unit/migrationVersionUniqueness.test.ts` guards this.
+- **No production writes.** The migration must not contain `UPDATE`/`INSERT`/`DELETE` against tenant data. Repairing the three already-desynced rows on Home is a separate, explicitly approved step outside this branch.
+- `showCascadeChoice` (`src/hooks/useTemplateHoursLedger.ts:118`) and its four call sites in `TemplateFormDialog.tsx` are **not** changed. `buildSaveButtonLabel` is **not** changed. The panel's render guard at `TemplateFormDialog.tsx:270` is **not** changed.
+- CLAUDE.md conventions: semantic tokens only (no `bg-white`/`text-black`), the Apple/Notion typography scale, `aria-label` on unlabelled controls, React Query with `staleTime` ≤ 60s and no manual caching.
+- Every RPC statement that touches a tenant table filters on `restaurant_id = p_restaurant_id`. Both functions stay `SECURITY DEFINER` with `SET search_path = public, pg_temp`.
+- `npm run db:reset` is mandatory before `npm run test:db` when a migration changes. Local Supabase is shared with ~25 sibling worktrees — run the DB suite deliberately, not casually.
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+|---|---|---|
+| `supabase/migrations/20260805160000_template_cascade_undo_restores_template.sql` | create | Batch-header table + both RPCs replaced |
+| `supabase/tests/template_hours_cascade.test.sql` | modify | pgTAP for the template restore |
+| `src/integrations/supabase/types.ts` | regenerate | New table in the generated schema |
+| `src/hooks/useShiftTemplates.tsx` | modify (`:182-208`) | RPC result type + Undo toast |
+| `src/lib/scheduling/hoursChangeCopy.ts` | modify (`:234-238`) | Summary pick clause |
+| `tests/unit/hoursChangeCopy.test.ts` | modify | Pick-clause coverage |
+| `src/components/scheduling/ShiftPlanner/TemplateHoursImpact.tsx` | modify (`:57`, `:152`) | Drift disclosure default |
+| `tests/unit/templateHoursImpact.test.tsx` | create | Disclosure-default coverage |
+| `tests/e2e/template-hours-cascade.spec.ts` | modify | Both regression scenarios |
+
+---
+
+### Task 1: Batch header + template restore (SQL)
+
+**Files:**
+- Create: `supabase/migrations/20260805160000_template_cascade_undo_restores_template.sql`
+- Test: `supabase/tests/template_hours_cascade.test.sql` (extend; currently `SELECT plan(34)`)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `undo_template_hours_cascade(UUID, UUID)` returns JSONB with two new keys, `template_restored BOOLEAN` and `template_changed_since BOOLEAN`, alongside the existing `restored_count`, `changed_since_count`, `deleted_count`, `protected_count`. Task 2 consumes this shape.
+
+- [ ] **Step 1: Write the failing pgTAP tests**
+
+Append to `supabase/tests/template_hours_cascade.test.sql`, before `SELECT * FROM finish();`. Bump `SELECT plan(34)` at the top to `SELECT plan(46)`.
+
+Follow the file's existing fixture conventions exactly: no hardcoded calendar dates (anchor to the next Monday after `CURRENT_DATE`), and build instants as `'<local timestamp>'::timestamp AT TIME ZONE '<iana>'`.
+
+```sql
+-- ============================================
+-- Undo restores the template's hours (Bug 1)
+-- ============================================
+
+-- Fresh template + 2 future unlocked shifts matching it exactly.
+INSERT INTO shift_templates (id, restaurant_id, name, position, days, start_time, end_time, break_duration, capacity)
+VALUES ('e1000000-0000-4000-8000-000000000001', v_restaurant_a, 'Undo case', 'Server', ARRAY[1,2], '10:00', '16:30', 0, 1);
+
+INSERT INTO shifts (id, restaurant_id, employee_id, shift_template_id, start_time, end_time, position, locked, is_published)
+VALUES
+  ('e1000000-0000-4000-8000-000000000011', v_restaurant_a, v_employee_a, 'e1000000-0000-4000-8000-000000000001',
+   (v_next_monday || ' 10:00')::timestamp AT TIME ZONE 'America/Chicago',
+   (v_next_monday || ' 16:30')::timestamp AT TIME ZONE 'America/Chicago', 'Server', false, false),
+  ('e1000000-0000-4000-8000-000000000012', v_restaurant_a, v_employee_a, 'e1000000-0000-4000-8000-000000000001',
+   ((v_next_monday::date + 1) || ' 10:00')::timestamp AT TIME ZONE 'America/Chicago',
+   ((v_next_monday::date + 1) || ' 16:30')::timestamp AT TIME ZONE 'America/Chicago', 'Server', false, false);
+
+-- Cascade: end 16:30 -> 17:30
+SELECT update_shift_template_with_cascade(
+  'e1000000-0000-4000-8000-000000000001', v_restaurant_a, 'Undo case', 'Server', NULL,
+  ARRAY[1,2], 0, 1, '10:00'::time, '17:30'::time, true, ARRAY[]::uuid[]
+) AS r \gset undo_cascade_
+
+-- Test 35: a header row was written for this batch
+SELECT is(
+  (SELECT count(*)::int FROM template_hours_cascade_batches
+   WHERE id = (:'undo_cascade_r'::jsonb->>'batch_id')::uuid),
+  1,
+  'cascade writes one batch header row'
+);
+
+-- Test 36: the header records the template hours from BEFORE the edit
+SELECT results_eq(
+  format($q$SELECT before_start_time, before_end_time, after_start_time, after_end_time
+            FROM template_hours_cascade_batches WHERE id = %L$q$,
+         (:'undo_cascade_r'::jsonb->>'batch_id')::uuid),
+  $q$VALUES ('10:00'::time, '16:30'::time, '10:00'::time, '17:30'::time)$q$,
+  'header records before and after template hours'
+);
+
+SELECT undo_template_hours_cascade(
+  (:'undo_cascade_r'::jsonb->>'batch_id')::uuid, v_restaurant_a
+) AS r \gset undo_result_
+
+-- Test 37: the template is back to its pre-cascade hours
+SELECT results_eq(
+  $q$SELECT start_time, end_time FROM shift_templates
+     WHERE id = 'e1000000-0000-4000-8000-000000000001'$q$,
+  $q$VALUES ('10:00'::time, '16:30'::time)$q$,
+  'undo restores the template hours'
+);
+
+-- Test 38: and says so
+SELECT is((:'undo_result_r'::jsonb->>'template_restored')::boolean, true,
+          'undo reports template_restored');
+SELECT is((:'undo_result_r'::jsonb->>'template_changed_since')::boolean, false,
+          'undo reports template_changed_since false on the happy path');
+
+-- Test 40: THE REPORTED BUG. A second cascade after the undo must move the shifts.
+SELECT update_shift_template_with_cascade(
+  'e1000000-0000-4000-8000-000000000001', v_restaurant_a, 'Undo case', 'Server', NULL,
+  ARRAY[1,2], 0, 1, '11:00'::time, '18:30'::time, true, ARRAY[]::uuid[]
+) AS r \gset recascade_
+
+SELECT is((:'recascade_r'::jsonb->>'updated_count')::int, 2,
+          'a cascade after an undo still moves the shifts (the reported bug)');
+
+-- Test 41: and the shifts really hold the new local hours
+SELECT is(
+  (SELECT count(*)::int FROM shifts
+   WHERE shift_template_id = 'e1000000-0000-4000-8000-000000000001'
+     AND (start_time AT TIME ZONE 'America/Chicago')::time = '11:00'
+     AND (end_time   AT TIME ZONE 'America/Chicago')::time = '18:30'),
+  2,
+  'both shifts sit at the re-cascaded hours'
+);
+```
+
+Then, in the same style, add:
+
+- **Test 42** — *template changed since*: cascade a fresh template, then
+  `UPDATE shift_templates SET start_time = '09:00' WHERE id = …`, then undo. Assert the
+  template still reads `09:00`, `template_restored` is `false`, `template_changed_since` is
+  `true`.
+- **Test 43** — *restored when no shift is*: cascade a fresh template, then
+  `UPDATE shifts SET locked = true WHERE shift_template_id = …`, then undo. Assert
+  `restored_count = 0` **and** `template_restored = true` — the template comes back even when
+  every shift is protected.
+- **Test 44** — *no header when nothing moved*: call the cascade with `p_cascade = true` on a
+  template whose only linked shift is locked. Assert `batch_id` is `NULL` and
+  `SELECT count(*) FROM template_hours_cascade_batches` is unchanged.
+- **Test 45** — *tenant isolation*: call `undo_template_hours_cascade(batch_of_A, v_restaurant_b)`.
+  Assert restaurant A's template is untouched and `template_restored` is `false`.
+- **Test 46** — *superseded batch*: cascade X (10:00→11:00), then cascade Y (11:00→12:00) on
+  the same template, then `undo_template_hours_cascade(X)`. Assert the template still reads
+  `12:00` (Y's value), `template_changed_since` is `true`, and `changed_since_count` equals
+  the number of shifts Y re-touched.
+- **Test 39** — *legacy batch*: `INSERT` a `schedule_change_logs` row with a
+  `cascade_batch_id` that has no header row, then undo it. Assert no error, and both new
+  flags are `false`.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/template-cascade-undo-fix && npm run db:reset && npm run test:db
+```
+
+Expected: the new tests fail. Tests 35/36/44 fail with `relation "template_hours_cascade_batches" does not exist`; 37/38 fail because the template keeps `17:30`; 40/41 fail with `updated_count = 0` — that failure **is** the reported bug reproduced locally.
+
+- [ ] **Step 3: Write the migration**
+
+Create `supabase/migrations/20260805160000_template_cascade_undo_restores_template.sql`. It has three parts.
+
+**Part A — the batch-header table:**
+
+```sql
+-- Why a table and not columns on shift_templates: one row per historical batch is
+-- exactly what Undo needs, and columns could only ever hold the latest one.
+-- Why not a shift_id-less row in schedule_change_logs: the "deleted since" probe in
+-- undo_template_hours_cascade is a NOT EXISTS against shifts, so a shift-less row
+-- would be miscounted as a deleted shift.
+CREATE TABLE IF NOT EXISTS public.template_hours_cascade_batches (
+  id                UUID PRIMARY KEY,
+  restaurant_id     UUID NOT NULL REFERENCES public.restaurants(id)     ON DELETE CASCADE,
+  shift_template_id UUID NOT NULL REFERENCES public.shift_templates(id) ON DELETE CASCADE,
+  before_start_time TIME NOT NULL,
+  before_end_time   TIME NOT NULL,
+  after_start_time  TIME NOT NULL,
+  after_end_time    TIME NOT NULL,
+  changed_by        UUID,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.template_hours_cascade_batches IS
+  'One row per update_shift_template_with_cascade call that actually moved shifts, '
+  'keyed by the same batch id that tags the run''s schedule_change_logs rows. Records '
+  'the template''s own before/after hours so undo_template_hours_cascade can restore '
+  'them alongside the shifts. Written and read only by those two SECURITY DEFINER '
+  'functions; no client has any privilege on it.';
+
+-- No policies. Both writers are SECURITY DEFINER and bypass RLS; every other caller
+-- gets zero rows. The REVOKE is belt and braces and keeps the table off PostgREST.
+ALTER TABLE public.template_hours_cascade_batches ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE public.template_hours_cascade_batches FROM PUBLIC, anon, authenticated;
+GRANT ALL ON TABLE public.template_hours_cascade_batches TO service_role;
+```
+
+`id` is the PK and is supplied by the caller, so the Undo lookup needs no extra index.
+
+**Part B — `CREATE OR REPLACE FUNCTION public.update_shift_template_with_cascade(...)`:** copy the entire body from `20260804130000_template_hours_cascade.sql:57-308` verbatim, including every comment, and make exactly one change — insert this immediately after the `SELECT count(*)::int, COALESCE(...) INTO v_updated_count, v_published_shifts FROM updated;` statement (`:284-297`) and before the `END IF;` at `:298`:
+
+```sql
+    -- Only when shifts actually moved: that is precisely when the RETURN below
+    -- hands back a non-NULL batch_id and the client offers Undo. A header for a
+    -- batch that moved nothing would be an unreachable row.
+    IF v_updated_count > 0 THEN
+      INSERT INTO public.template_hours_cascade_batches (
+        id, restaurant_id, shift_template_id,
+        before_start_time, before_end_time, after_start_time, after_end_time, changed_by
+      )
+      VALUES (
+        v_batch_id, p_restaurant_id, p_template_id,
+        -- v_old_start/v_old_end were captured at the FOR UPDATE read above, before
+        -- this function's own UPDATE overwrote the template row.
+        v_old_start, v_old_end, p_start_time, p_end_time, auth.uid()
+      );
+    END IF;
+```
+
+Re-emit the trailing `REVOKE`/`GRANT`/`COMMENT` for the function unchanged.
+
+**Part C — `CREATE OR REPLACE FUNCTION public.undo_template_hours_cascade(p_batch_id UUID, p_restaurant_id UUID)`:** copy the body from `:327-460` verbatim and make three changes.
+
+1. Add to `DECLARE`:
+
+```sql
+  v_template_id            UUID;
+  v_before_start           TIME;
+  v_before_end             TIME;
+  v_after_start            TIME;
+  v_after_end              TIME;
+  v_cur_start              TIME;
+  v_cur_end                TIME;
+  -- Explicitly false, not plpgsql's NULL default: the legacy-batch path and the
+  -- p_batch_id IS NULL early return both fall through without assigning these,
+  -- and a null in the returned JSONB would diverge from what the client types.
+  v_template_restored      BOOLEAN := false;
+  v_template_changed_since BOOLEAN := false;
+```
+
+Add both keys to the early-return object so its shape matches the main return:
+
+```sql
+    RETURN jsonb_build_object(
+      'restored_count', 0, 'changed_since_count', 0, 'deleted_count', 0,
+      'protected_count', 0, 'template_restored', false,
+      'template_changed_since', false
+    );
+```
+
+2. Insert this block **before** the `WITH reverted AS (` statement at `:414`, after the
+   `v_protected_count` SELECT:
+
+```sql
+  -- Restore the template's own hours. Without this the template keeps the hours
+  -- the cascade wrote while its shifts go back to the old ones, and every later
+  -- edit measures those shifts against a baseline they no longer share -- which
+  -- classifies them as drifted forever. That desync is the bug this migration exists
+  -- to fix.
+  --
+  -- Placed BEFORE the shifts UPDATE so this function acquires shift_templates then
+  -- shifts, the same order update_shift_template_with_cascade uses (its FOR UPDATE
+  -- on the template precedes the `target` CTE's FOR UPDATE on the shifts). Consistent
+  -- lock ordering is what keeps a concurrent cascade and undo from deadlocking.
+  SELECT b.shift_template_id, b.before_start_time, b.before_end_time,
+         b.after_start_time,  b.after_end_time
+    INTO v_template_id, v_before_start, v_before_end, v_after_start, v_after_end
+  FROM public.template_hours_cascade_batches b
+  WHERE b.id = p_batch_id
+    AND b.restaurant_id = p_restaurant_id;
+
+  -- No header: a batch from before this migration. Revert the shifts as before and
+  -- leave both flags false. Not an error.
+  IF FOUND THEN
+    SELECT t.start_time, t.end_time
+      INTO v_cur_start, v_cur_end
+    FROM public.shift_templates t
+    WHERE t.id = v_template_id
+      AND t.restaurant_id = p_restaurant_id
+    FOR UPDATE;
+
+    IF FOUND THEN
+      -- The same "still holds exactly what the cascade wrote" guard the shift revert
+      -- applies below. Plain `=` rather than IS NOT DISTINCT FROM because
+      -- shift_templates.start_time/end_time are TIME NOT NULL, unlike the shift
+      -- columns. If a manager edited the template's hours after the cascade, that is
+      -- a newer deliberate decision and Undo declines rather than destroying it.
+      IF v_cur_start = v_after_start AND v_cur_end = v_after_end THEN
+        UPDATE public.shift_templates
+        SET start_time = v_before_start,
+            end_time   = v_before_end,
+            updated_at = now()
+        WHERE id = v_template_id
+          AND restaurant_id = p_restaurant_id;
+        v_template_restored := true;
+      ELSE
+        v_template_changed_since := true;
+      END IF;
+    END IF;
+  END IF;
+```
+
+Note the template is restored regardless of `v_restored_count`. Even when every shift is
+locked or has started, the manager clicked Undo to reverse *their template edit*; leaving the
+template on the new hours would be the same desync in a rarer shape.
+
+3. Add both keys to the final `RETURN jsonb_build_object(...)` and update the
+   `COMMENT ON FUNCTION` to mention the template restore.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/template-cascade-undo-fix && npm run db:reset && npm run test:db
+```
+
+Expected: all 46 tests pass, including the 34 pre-existing ones.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/migrations/20260805160000_template_cascade_undo_restores_template.sql supabase/tests/template_hours_cascade.test.sql
+git commit -m "fix(scheduling): undo restores the template's hours, not just its shifts"
+```
+
+---
+
+### Task 2: Client types and the Undo toast
+
+**Files:**
+- Modify: `src/integrations/supabase/types.ts` (regenerated, do not hand-edit)
+- Modify: `src/hooks/useShiftTemplates.tsx:182-208`
+
+**Interfaces:**
+- Consumes: `undo_template_hours_cascade`'s JSONB from Task 1 — `{ restored_count, changed_since_count, deleted_count, protected_count, template_restored, template_changed_since }`.
+- Produces: nothing later tasks depend on.
+
+- [ ] **Step 1: Regenerate the Supabase types**
+
+With local Supabase running and Task 1's migration applied:
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/template-cascade-undo-fix && npx supabase gen types typescript --local > src/integrations/supabase/types.ts
+```
+
+Expected: the diff adds a `template_hours_cascade_batches` entry under `Tables` and changes nothing else. If unrelated tables churn, the local DB is out of sync — `npm run db:reset` and regenerate.
+
+- [ ] **Step 2: Widen the RPC result type**
+
+In `src/hooks/useShiftTemplates.tsx`, the `undoMutation` `mutationFn` cast at `:182-187`:
+
+```ts
+      return data as {
+        restored_count: number;
+        changed_since_count: number;
+        deleted_count: number;
+        protected_count: number;
+        template_restored: boolean;
+        template_changed_since: boolean;
+      };
+```
+
+- [ ] **Step 3: Add the one narrated exception to the toast**
+
+In the same file, extend the `skippedReasons` array at `:198-202` with a fourth entry:
+
+```ts
+      const skippedReasons = [
+        result.changed_since_count > 0 ? `${result.changed_since_count} changed since` : null,
+        result.deleted_count > 0 ? `${result.deleted_count} deleted` : null,
+        result.protected_count > 0 ? `${result.protected_count} now locked or started` : null,
+        // Restoring the template is the expected case and is not narrated -- saying so
+        // on every Undo would be noise. This is the case where the manager's mental
+        // model and the data disagree, so it gets said out loud.
+        result.template_changed_since ? 'template hours changed since' : null,
+      ].filter(Boolean);
+```
+
+No other change: `invalidateCascadeQueries()` at `:190` already invalidates
+`['shift_templates', restaurantId]` (`:144-148`), so a restored template refreshes on screen
+without further work.
+
+- [ ] **Step 4: Verify**
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/template-cascade-undo-fix && npm run typecheck && npx vitest run tests/unit/useShiftTemplates.test.ts --reporter=verbose
+```
+
+Expected: typecheck clean. If no `useShiftTemplates` test file exists, skip the second command and say so in the report.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/integrations/supabase/types.ts src/hooks/useShiftTemplates.tsx
+git commit -m "fix(scheduling): surface template restore state from the undo RPC"
+```
+
+---
+
+### Task 3: The summary names the shifts they can pick
+
+**Files:**
+- Modify: `src/lib/scheduling/hoursChangeCopy.ts:226-238`
+- Test: `tests/unit/hoursChangeCopy.test.ts`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `buildHoursChangeLedger`'s `summary` string gains a trailing clause in one state. No signature change.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/unit/hoursChangeCopy.test.ts`, following the file's existing `describe`/`it`
+structure and its helper for building a `HoursChangeInput` (reuse it; do not hand-roll a
+second fixture builder).
+
+```ts
+describe('buildHoursChangeLedger summary — pickable drift', () => {
+  it('names the pickable shifts when nothing would move', () => {
+    const ledger = buildHoursChangeLedger(input({
+      movingCount: 0, driftedCount: 3, selectedDriftCount: 0, publishedCount: 0,
+    }));
+    expect(ledger.summary).toContain('0 shifts move.');
+    expect(ledger.summary).toContain('3 hand-edited shifts you can pick.');
+  });
+
+  it('uses the singular for one pickable shift', () => {
+    const ledger = buildHoursChangeLedger(input({
+      movingCount: 0, driftedCount: 1, selectedDriftCount: 0,
+    }));
+    expect(ledger.summary).toContain('1 hand-edited shift you can pick.');
+  });
+
+  it('drops the clause once something is moving', () => {
+    const ledger = buildHoursChangeLedger(input({
+      movingCount: 0, driftedCount: 3, selectedDriftCount: 1,
+    }));
+    expect(ledger.summary).not.toContain('you can pick');
+  });
+
+  it('drops the clause when shifts already move on their own', () => {
+    const ledger = buildHoursChangeLedger(input({
+      movingCount: 2, driftedCount: 3, selectedDriftCount: 0,
+    }));
+    expect(ledger.summary).not.toContain('you can pick');
+  });
+
+  it('leaves the past/locked-only summary alone', () => {
+    const ledger = buildHoursChangeLedger(input({
+      movingCount: 0, driftedCount: 0, pastCount: 2, lockedCount: 1,
+    }));
+    expect(ledger.summary).not.toContain('you can pick');
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/template-cascade-undo-fix && npx vitest run tests/unit/hoursChangeCopy.test.ts --reporter=verbose
+```
+
+Expected: the first two fail (`summary` stops at "0 shifts move."); the last three already pass.
+
+- [ ] **Step 3: Add the clause**
+
+In `src/lib/scheduling/hoursChangeCopy.ts`, `unpickedDrift` is already computed at `:226`
+for the untouched line. Move nothing; add below the existing `movingClause` at `:235`:
+
+```ts
+  // Scoped to totalAffected === 0 deliberately. Once anything is moving, the chips
+  // and the "Save & update N shifts" button already say so, and this line is
+  // truncated on screen -- a second call to action would push the count off.
+  const pickClause = totalAffected === 0 && unpickedDrift > 0
+    ? ` ${unpickedDrift} hand-edited ${pluralize(unpickedDrift, 'shift', 'shifts')} you can pick.`
+    : '';
+```
+
+and append `${pickClause}` to both branches of `summary` at `:236-238`:
+
+```ts
+  const summary = publishedCount > 0
+    ? `${severityLabel}. ${deltaBadge}. ${movingClause}, ${publishedCount} already posted.${pickClause}`
+    : `${severityLabel}. ${deltaBadge}. ${movingClause}.${pickClause}`;
+```
+
+`unpickedDrift` is declared at `:226`, above this point, so no reordering is needed. Verify
+that before editing — if it is declared below, hoist the `const` rather than duplicating it.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/template-cascade-undo-fix && npx vitest run tests/unit/hoursChangeCopy.test.ts --reporter=verbose
+```
+
+Expected: all pass, including every pre-existing assertion in the file. If a pre-existing
+summary assertion breaks, it is asserting on an exact full string — update it to the new
+expected text rather than weakening the fix.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/scheduling/hoursChangeCopy.ts tests/unit/hoursChangeCopy.test.ts
+git commit -m "fix(scheduling): ledger summary names the drifted shifts a manager can pick"
+```
+
+---
+
+### Task 4: The drift disclosure opens when it is the only thing to do
+
+**Files:**
+- Modify: `src/components/scheduling/ShiftPlanner/TemplateHoursImpact.tsx:57`, `:152`
+- Test: `tests/unit/templateHoursImpact.test.tsx` (create)
+
+**Interfaces:**
+- Consumes: `HoursChangeLedger.totalAffected` (unchanged shape).
+- Produces: nothing later tasks depend on.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/templateHoursImpact.test.tsx`. Check an existing component test in
+`tests/unit/` first for the repo's render helper and jsdom setup, and follow it; if none
+exists, use `@testing-library/react`'s `render` and `screen` directly.
+
+```tsx
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { TemplateHoursImpact } from '@/components/scheduling/ShiftPlanner/TemplateHoursImpact';
+import { buildHoursChangeLedger } from '@/lib/scheduling/hoursChangeCopy';
+
+const drifted = [
+  { shiftId: 's1', employeeName: 'Ada', localDate: 'Mon Aug 10', currentStart: '11:00', currentEnd: '19:00', isPublished: false, hoursDelta: 0 },
+];
+
+function renderPanel(overrides: { movingCount: number; selectedDriftCount: number }) {
+  const ledger = buildHoursChangeLedger({
+    oldStart: '10:00', oldEnd: '16:30', newStart: '11:00', newEnd: '17:30',
+    publishedCount: 0, pastCount: 0, lockedCount: 0, driftedCount: 1, hoursDelta: 0,
+    ...overrides,
+  });
+  return render(
+    <TemplateHoursImpact
+      ledger={ledger} drifted={drifted} selectedDriftIds={new Set()}
+      onToggleDrift={() => {}} publishedCount={0} notify={false} onNotifyChange={() => {}}
+      isLoading={false} error={null}
+      oldStart="10:00" oldEnd="16:30" newStart="11:00" newEnd="17:30"
+    />
+  );
+}
+
+it('opens the drift disclosure when nothing else would move', async () => {
+  const user = userEvent.setup();
+  renderPanel({ movingCount: 0, selectedDriftCount: 0 });
+  // The outer panel is collapsed by design; open it.
+  await user.click(screen.getByRole('button', { name: /shifts? move/i }));
+  expect(screen.getByRole('checkbox', { name: /Ada/ })).toBeInTheDocument();
+});
+
+it('leaves the drift disclosure closed when shifts already move', async () => {
+  const user = userEvent.setup();
+  renderPanel({ movingCount: 2, selectedDriftCount: 0 });
+  await user.click(screen.getByRole('button', { name: /shifts? move/i }));
+  expect(screen.queryByRole('checkbox', { name: /Ada/ })).not.toBeInTheDocument();
+});
+
+it('lets a manual toggle win over the default', async () => {
+  const user = userEvent.setup();
+  renderPanel({ movingCount: 0, selectedDriftCount: 0 });
+  await user.click(screen.getByRole('button', { name: /shifts? move/i }));
+  await user.click(screen.getByRole('button', { name: /hand-edited/i }));
+  expect(screen.queryByRole('checkbox', { name: /Ada/ })).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/template-cascade-undo-fix && npx vitest run tests/unit/templateHoursImpact.test.tsx --reporter=verbose
+```
+
+Expected: the first test fails (the checkbox is behind a second, closed disclosure); the other two pass.
+
+- [ ] **Step 3: Make the default conditional**
+
+In `TemplateHoursImpact.tsx`, replace the `driftOpen` state at `:57`:
+
+```tsx
+  // null means "no manual choice yet", so the default below can depend on `ledger`
+  // -- which is null on the first render while the impact query is in flight, and so
+  // cannot be read by a useState initialiser that runs exactly once.
+  const [driftOpen, setDriftOpen] = useState<boolean | null>(null);
+```
+
+After the `if (!ledger) return null;` bail-out at `:77`, add:
+
+```tsx
+  // When nothing would move on its own, these checkboxes are the only thing the
+  // manager can act on -- so they are not hidden behind a third click.
+  const driftDefaultOpen = drifted.length > 0 && ledger.totalAffected === 0;
+```
+
+And at `:152`:
+
+```tsx
+              <Collapsible open={driftOpen ?? driftDefaultOpen} onOpenChange={setDriftOpen}>
+```
+
+The `expanded` state at `:56` and the outer `Collapsible` at `:85` are **not** changed —
+keeping the form calm on open was a deliberate choice in PR #700, and Task 3's summary now
+carries the signal that earns the click.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/template-cascade-undo-fix && npx vitest run tests/unit/templateHoursImpact.test.tsx --reporter=verbose && npm run typecheck
+```
+
+Expected: all three pass, typecheck clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/scheduling/ShiftPlanner/TemplateHoursImpact.tsx tests/unit/templateHoursImpact.test.tsx
+git commit -m "fix(scheduling): open the drift opt-in when it is the only action available"
+```
+
+---
+
+### Task 5: Playwright regression coverage
+
+**Files:**
+- Modify: `tests/e2e/template-hours-cascade.spec.ts`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–4.
+- Produces: nothing.
+
+- [ ] **Step 1: Read the existing spec**
+
+Read `tests/e2e/template-hours-cascade.spec.ts` in full before writing. Reuse its existing
+fixture setup, its `generateTestUser()` usage, its helpers from `'../helpers/e2e-supabase'`,
+and its accessible selectors (`getByRole`, `getByLabel`). Do not introduce a second setup path.
+
+- [ ] **Step 2: Add the Bug 1 round trip**
+
+```ts
+test('a cascade after an undo still moves the shifts', async ({ page }) => {
+  // 1. Template with two future linked shifts at its exact hours.
+  // 2. Edit hours 10:00-16:30 -> 10:00-17:30, save with the cascade.
+  // 3. Click Undo in the toast; assert the shifts read 16:30 again.
+  // 4. Edit hours again, 10:00 -> 11:00.
+  // 5. Assert the primary button offers "Save & update 2 shifts" -- before this fix
+  //    it read "Save changes" because the desynced template had reclassified both
+  //    shifts as hand-edited.
+  // 6. Save; assert both shifts moved.
+});
+```
+
+Fill in each step against the existing spec's helpers. The assertion at step 5 is the one
+that fails without Task 1.
+
+- [ ] **Step 3: Add the Bug 2 opt-in path**
+
+```ts
+test('a manager can pick hand-edited shifts into the cascade', async ({ page }) => {
+  // 1. Template with two linked shifts, both hand-edited away from the template hours.
+  // 2. Edit the template's hours.
+  // 3. Assert the collapsed summary names them: /hand-edited shifts you can pick/.
+  // 4. Expand the panel; assert the drift checkboxes are visible WITHOUT a further click.
+  // 5. Tick one; assert the primary button reads "Save & update 1 shift" and
+  //    "Template only" has appeared.
+  // 6. Save; assert that shift moved and the unticked one did not.
+});
+```
+
+Step 3 fails without Task 3; step 4 fails without Task 4.
+
+- [ ] **Step 4: Run the suite**
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/template-cascade-undo-fix && npx playwright test tests/e2e/template-hours-cascade.spec.ts --reporter=line
+```
+
+Bound this with the Bash tool's own `timeout` parameter — no hand-rolled poll loops, and no
+`ps aux | grep` process counting. If a dev server is needed underneath, start it with
+`npm run dev & pid=$!` and `trap 'kill $pid 2>/dev/null' EXIT` so it dies with the shell on
+the failure path too.
+
+Expected: both new tests pass alongside the existing ones.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/e2e/template-hours-cascade.spec.ts
+git commit -m "test(e2e): cover the undo round trip and the drift opt-in path"
+```
+
+---
+
+## Out of scope
+
+- **Repairing the three desynced rows on Home.** Read-only diagnosis is in the spec; the
+  `UPDATE` is proposed separately with exact row counts and applied only on explicit
+  approval. It never enters a migration.
+- **Re-syncing drifted shifts without editing the hours.** `hoursChanged` gates the panel at
+  `TemplateFormDialog.tsx:270`, so this needs a separate "re-sync shifts" affordance. That is
+  the shipped design from PR #700, not a regression, and it is a feature, not a fix.
+- **Cascading `days[]` or `capacity`.** Hours only, per the shipped scope.

--- a/docs/superpowers/specs/2026-08-05-template-cascade-undo-fix-design.md
+++ b/docs/superpowers/specs/2026-08-05-template-cascade-undo-fix-design.md
@@ -153,11 +153,12 @@ WHERE b.id = p_batch_id
   AND b.restaurant_id = p_restaurant_id;
 ```
 
-Both new flags are declared with an explicit default:
+All three new flags are declared with an explicit default:
 
 ```sql
 v_template_restored      BOOLEAN := false;
 v_template_changed_since BOOLEAN := false;
+v_template_slot_conflict BOOLEAN := false;
 ```
 
 Not left to plpgsql's `NULL` default. The legacy-batch path and the early
@@ -175,17 +176,21 @@ IF FOUND THEN
   FOR UPDATE;
 
   IF FOUND AND v_cur_start = v_after_start AND v_cur_end = v_after_end THEN
-    UPDATE public.shift_templates
-    SET start_time = v_before_start, end_time = v_before_end, updated_at = now()
-    WHERE id = v_template_id AND restaurant_id = p_restaurant_id;
-    v_template_restored := true;
+    BEGIN
+      UPDATE public.shift_templates
+      SET start_time = v_before_start, end_time = v_before_end, updated_at = now()
+      WHERE id = v_template_id AND restaurant_id = p_restaurant_id;
+      v_template_restored := true;
+    EXCEPTION WHEN unique_violation THEN
+      v_template_slot_conflict := true;
+    END;
   ELSIF FOUND THEN
     v_template_changed_since := true;
   END IF;
 END IF;
 ```
 
-Three properties, each deliberate:
+Four properties, each deliberate:
 
 - **`FOR UPDATE` before the comparison.** Same reasoning as the cascade's own lock at
   `:102-113`: without it a concurrent template edit can be read stale and stomped. Taking
@@ -206,17 +211,30 @@ Three properties, each deliberate:
   manager clicked Undo to reverse *their template edit*; leaving the template on the new
   hours would be the same desync in a rarer shape. The header is the record of what the
   template edit was, so it is restorable on its own terms.
+- **The `unique_violation` subtransaction.** `uq_shift_templates_active_slot`
+  (`supabase/migrations/20260528120000_shift_templates_idempotent_apply.sql:22-24`) is unique
+  on `(restaurant_id, position, start_time, end_time, days, coalesce(area,''))` where
+  `is_active`, so the cascade *frees* this template's original hours and another manager can
+  create an active template in them before the Undo lands. The restore then raises `23505`.
+  Without the `BEGIN … EXCEPTION` block that error propagates out of the function and aborts
+  the entire transaction: no shift is reverted and the manager sees a raw constraint error
+  instead of the Undo they asked for. A block-level handler rolls back only its own work, so
+  the shift revert still runs and the template is reported as skipped — the same "decline
+  safely and say so" contract as `template_changed_since`, which is why it gets its own flag
+  rather than being folded into that one. Nobody edited this template; something else took
+  its slot, and those send the manager to different records.
 
-The return object gains two booleans:
+The return object gains three booleans:
 
 ```sql
 'template_restored',      v_template_restored,
-'template_changed_since', v_template_changed_since
+'template_changed_since', v_template_changed_since,
+'template_slot_conflict', v_template_slot_conflict
 ```
 
 Old batches (rows already in `schedule_change_logs` from before this migration) have no
-header. The `SELECT … INTO` finds nothing, both flags stay `false`, and Undo behaves exactly
-as it does today — no error, no partial write.
+header. The `SELECT … INTO` finds nothing, all three flags stay `false`, and Undo behaves
+exactly as it does today — no error, no partial write.
 
 ### Tenant scoping and grants
 
@@ -229,7 +247,8 @@ pattern the cascade function documents at `:96-101`.
 ### Client surface
 
 `src/hooks/useShiftTemplates.tsx:182-187` types the RPC result; it gains
-`template_restored: boolean` and `template_changed_since: boolean`. The success toast
+`template_restored: boolean`, `template_changed_since: boolean` and
+`template_slot_conflict: boolean`. The success toast
 (`:203-208`) already invalidates `['shift_templates', restaurantId]` via
 `invalidateCascadeQueries()` (`:144-148`), so a restored template refreshes without further
 work. The toast's `skippedReasons` list (`:198-202`) gains one more entry, kept in the same
@@ -237,6 +256,7 @@ work. The toast's `skippedReasons` list (`:198-202`) gains one more entry, kept 
 
 ```ts
 result.template_changed_since ? 'template hours changed since' : null,
+result.template_slot_conflict ? 'template hours taken by another template' : null,
 ```
 
 Restoration of the template is the expected case and is not narrated — reporting "restored
@@ -331,35 +351,77 @@ Three shifts on Home are desynced today. The repair is a **read-only diagnosis f
 then a proposed statement with exact row counts, then the user's explicit approval before
 any write — per CLAUDE.md's rule on prod writes.
 
-Diagnosis query (read-only, safe to run without approval):
+### Step 1 — bound the blast radius (read-only)
 
 ```sql
-SELECT l.cascade_batch_id, l.restaurant_id, s.shift_template_id,
-       t.start_time AS template_start, t.end_time AS template_end,
-       count(*) AS reverted_shifts
-FROM public.schedule_change_logs l
-LEFT JOIN public.shifts s ON s.id = l.shift_id
-LEFT JOIN public.shift_templates t ON t.id = s.shift_template_id
-WHERE l.reason = 'Undo template hours cascade'
-GROUP BY 1, 2, 3, 4, 5;
+SELECT change_type, count(*) AS n, min(changed_at), max(changed_at)
+FROM public.schedule_change_logs
+WHERE cascade_batch_id IS NOT NULL
+GROUP BY change_type;
 ```
 
-`LEFT JOIN`, not inner: `schedule_change_logs.shift_id` is deliberately not a foreign key
-(`supabase/migrations/20260617120000_fix_schedule_change_logs_delete_fk.sql:38-44`), so an
-inner join would silently drop any batch whose shift was deleted afterwards and understate
-the damage.
+Every row the cascade has ever written carries a `cascade_batch_id`, so this is the whole
+population. **Result: 4 rows, in 2 batches, all on Home (`0a1812a5-…`).** No other tenant
+has ever run a cascade, so nothing else can be damaged.
 
-This finds every batch an Undo touched; the desynced ones are those whose template hours
-still differ from the restored shifts' local hours. The repair is a targeted
-`UPDATE public.shift_templates SET start_time = …, end_time = …` per affected template —
-never a bulk statement, and never applied from this branch's migration. The migration ships
-the code fix only; historical data is repaired separately and explicitly, because a
-migration that rewrites tenant data based on inferred intent is exactly the kind of thing
-that cannot be undone.
+### Step 2 — identify actual mismatches, not candidate batches
 
-For Home specifically the expected repair is one row: template
-`a71b4223-5a39-460b-bb12-83f0937ab4d9` back to `10:00`/`16:30`, matching the three shifts
-that Undo restored. Counts will be confirmed against live data and stated before asking.
+Listing the batches an Undo touched is not enough: it names candidates without saying which
+are broken. The comparison has to be made explicitly, in the **restaurant's** timezone —
+comparing a bare `start_time::time` against the template would call every non-UTC tenant's
+matching shift "drifted", which is the same timezone trap the cascade's own bucketing has
+to avoid.
+
+```sql
+WITH tz AS (
+  SELECT id AS restaurant_id, coalesce(timezone, 'UTC') AS tzname
+  FROM public.restaurants
+)
+SELECT t.id AS template_id, t.name,
+       t.start_time AS tmpl_start, t.end_time AS tmpl_end,
+       s.id AS shift_id,
+       s.start_time AT TIME ZONE tz.tzname AS shift_start_local,
+       s.end_time   AT TIME ZONE tz.tzname AS shift_end_local,
+       (s.start_time AT TIME ZONE tz.tzname)::time = t.start_time
+         AND (s.end_time AT TIME ZONE tz.tzname)::time = t.end_time AS matches_template,
+       s.start_time > now() AS in_future
+FROM public.shift_templates t
+JOIN tz ON tz.restaurant_id = t.restaurant_id
+JOIN public.shifts s
+  ON s.shift_template_id = t.id AND s.restaurant_id = t.restaurant_id
+ORDER BY t.name, s.start_time;
+```
+
+Joining through `shifts.shift_template_id` rather than through `schedule_change_logs.shift_id`
+is deliberate: that column is **not** a foreign key
+(`supabase/migrations/20260617120000_fix_schedule_change_logs_delete_fk.sql:38-44`), so a
+log-driven query has to `LEFT JOIN` and still cannot tell a deleted shift from a live one.
+Reading current state directly answers the actual question — which templates disagree with
+their shifts right now.
+
+**Result on Home.** One template is damaged: `a71b4223-…` "Opening - weekend", sitting at
+`11:00`/`18:30` with three future `scheduled` shifts (Aug 7/8/9) still at `10:00`/`16:30`,
+all `matches_template = false`. Template `a9d89620-…` "Opening Shift - weekdays" is **not**
+damaged — its one future shift matches, and its three `10:00`/`16:30` shifts are all in the
+past, which the cascade correctly refuses to touch.
+
+### Step 3 — repair in the product, not in SQL
+
+The recommended remediation is **no production write**. The Bug 2 fix is the repair: once
+deployed, that template's panel reads "0 shifts move. 3 hand-edited shifts you can pick",
+and the manager ticks the three and cascades them.
+
+A SQL repair would have to guess the intended hours. Undo restored the shifts to
+`10:00`/`16:30`, but the manager then deliberately edited the template to `11:00`/`18:30`
+while the UI was under-reporting the impact. Which of those two is "correct" is a scheduling
+decision, not a data-integrity one, and picking either in an `UPDATE` silently substitutes
+our judgement for theirs.
+
+If a write is wanted anyway it stays a targeted `UPDATE public.shift_templates SET
+start_time = …, end_time = … WHERE id = … AND restaurant_id = …` — one row, never a bulk
+statement, never from this branch's migration, and only after the exact row count is stated
+and explicitly approved. The migration ships the code fix only; a migration that rewrites
+tenant data from inferred intent is precisely what cannot be undone.
 
 ---
 
@@ -379,7 +441,16 @@ that Undo restored. Counts will be confirmed against live data and stated before
 5. Tenant isolation: an Undo naming another restaurant's batch id restores nothing and
    leaves both templates untouched.
 6. Legacy batch: an Undo for a `cascade_batch_id` with no header row reverts shifts and
-   returns both flags false.
+   returns all template flags false.
+7. **The freed slot was taken.** `uq_shift_templates_active_slot` is unique on
+   `(restaurant_id, position, start_time, end_time, days, coalesce(area,''))` where
+   `is_active`, so a cascade frees the template's original hours and another active template
+   can move into them. Cascade, insert a squatter in the freed slot, undo: assert
+   `template_slot_conflict` is true, `template_restored` and `template_changed_since` false,
+   the template stays where the cascade put it — and, separately, that the shifts are
+   **still reverted**. Without the subtransaction around the template `UPDATE`, the `23505`
+   escapes the function and aborts the whole transaction: the manager gets a raw constraint
+   error and not one shift comes back.
 7. **Template restored when no shift is** — cascade, then lock every moved shift, then undo:
    assert `restored_count = 0` and `template_restored = true`. This is the one combination
    the "Restored independently of `restored_count`" decision above rests on, and none of
@@ -411,8 +482,10 @@ but 2b is a render-state behaviour no pure-function test can reach):
 
 ### Playwright — `tests/e2e/template-hours-cascade.spec.ts` (extend)
 
-Two scenarios, one per bug — the first would pass today and the second would not, so both
-are needed.
+Two scenarios, one per bug. Neither passes against today's code — scenario 1 fails at the
+second cascade (the shifts read as drifted and nothing moves) and scenario 2 fails at the
+first assertion (the collapsed summary says "0 shifts move" and names nothing pickable).
+That is what makes them regression tests rather than descriptions.
 
 1. **Bug 1 round trip.** Create a template with linked future shifts, change the hours and
    cascade, click Undo, then change the hours again and assert the shifts move. Today the

--- a/docs/superpowers/specs/2026-08-05-template-cascade-undo-fix-design.md
+++ b/docs/superpowers/specs/2026-08-05-template-cascade-undo-fix-design.md
@@ -45,30 +45,40 @@ At 02:36:20 the shifts' start matched the stale `v_old_start` (10:00) but their 
 match the stale `v_old_end` (17:30). The predicate is a conjunction, so all three fell to
 drifted. Current prod state: template 11:00–18:30, all three shifts still 10:00–16:30.
 
-### Bug 2 — the drift opt-in checkboxes are unreachable
+### Bug 2 — the ledger announces "0 shifts move" when three are one tick away
 
-`src/hooks/useTemplateHoursLedger.ts:118`:
+The user's words were *"I don't even see the option."* The panel **is** rendered — it is
+gated at `src/components/scheduling/ShiftPlanner/TemplateFormDialog.tsx:270` on
+`isEdit && hoursChanged && template`, which has no dependency on how many shifts would move.
+Nothing is unreachable. What is wrong is what the manager is told.
 
-```ts
-const showCascadeChoice = hoursChanged && affectedCount > 0 && !impact.isLoading && !impact.error;
-```
+The panel renders **collapsed** (`TemplateHoursImpact.tsx:56`, `expanded = false`), so the
+only thing on screen is the one-line summary at `:99-101`. That summary is built at
+`src/lib/scheduling/hoursChangeCopy.ts:235-238` from `totalAffected`, which is
+`movingCount + selectedDriftCount` (`:168`) — and a drifted shift contributes zero until its
+checkbox is ticked. In the reported state (3 drifted, none picked) the manager reads:
 
-`affectedCount` is `ledger.totalAffected`, which is
-`movingCount + selectedDriftCount` (`src/lib/scheduling/hoursChangeCopy.ts:168`). A drifted
-shift contributes zero until the manager ticks its checkbox — and those checkboxes render
-inside `<TemplateHoursImpact>`, which the dialog gates on the very same flag
-(`src/components/scheduling/ShiftPlanner/TemplateFormDialog.tsx:410`). When every linked
-shift is drifted, `movingCount = 0`, `selectedDriftCount = 0`, `affectedCount = 0`, the panel
-never renders, and the only control that could raise the count is hidden behind the gate.
+> Low impact. 1h later · same length. **0 shifts move.**
 
-This is independent of Bug 1 — Bug 1 is simply the most common way to reach the deadlock.
-It also fires whenever a manager hand-edits every linked shift, which is exactly what the
-"Your call" bucket exists for.
+Meanwhile the primary button says "Save changes" and the "Template only" button is absent,
+because `showCascadeChoice` is correctly false (`useTemplateHoursLedger.ts:118`) — saving
+right now genuinely would only change the template.
 
-The same flag is overloaded across four call sites in the dialog: the panel guard
-(`:410`), the "Template only" button (`:418`), the primary button's label
-(`:439`, via `buildSaveButtonLabel`), and the implicit-submit path (`:185`,
-`await submitWith(showCascadeChoice)`).
+So every control is telling the truth about *this instant*, and the composite is still a lie
+about *the situation*: three shifts are one checkbox away from moving, and the single line the
+manager actually reads says the opposite. Having been told there is nothing to do, they do
+not expand the panel — and the checkboxes sit behind that first disclosure plus a second,
+nested one that is also closed by default (`TemplateHoursImpact.tsx:57`, `:151-164`).
+
+This is independent of Bug 1 in the sense that it fires for any all-drifted template — a
+manager who hand-edited every linked shift hits the same wall. Bug 1 is simply what put a
+manager who had hand-edited *nothing* into that state.
+
+**`showCascadeChoice` is not the defect and is not being changed.** Its four uses in the
+dialog (`:185`, `:410`, `:418`→ the "Template only" button at `:410`'s guard, `:439`) are
+consistent with each other and with its name: a cascade choice is on offer exactly when
+something would move. An earlier draft of this design proposed splitting it; that was based
+on a misreading of `:410` as the panel's render guard, and is dropped.
 
 ---
 
@@ -143,6 +153,18 @@ WHERE b.id = p_batch_id
   AND b.restaurant_id = p_restaurant_id;
 ```
 
+Both new flags are declared with an explicit default:
+
+```sql
+v_template_restored      BOOLEAN := false;
+v_template_changed_since BOOLEAN := false;
+```
+
+Not left to plpgsql's `NULL` default. The legacy-batch path and the early
+`p_batch_id IS NULL` return at `:360-365` both fall through without assigning them, and a
+`null` in the returned JSONB would diverge from the `false` this design and the client's
+TypeScript both assume.
+
 Then, when a header was found, lock and conditionally restore:
 
 ```sql
@@ -170,10 +192,16 @@ Three properties, each deliberate:
   the template lock *before* the shift revert also fixes the lock order for the pair, so
   Undo and a concurrent cascade acquire template-then-shifts in the same sequence and cannot
   deadlock against each other.
-- **The "unchanged since" guard.** Mirrors the shift-level guard at `:424-425` exactly: a
-  row is restored only if it still holds precisely what the cascade wrote. If someone edited
-  the template's hours after the cascade, that is a newer deliberate decision and Undo
-  declines rather than destroying it.
+- **The "unchanged since" guard.** Mirrors the shift-level guard at `:424-425`: a row is
+  restored only if it still holds precisely what the cascade wrote. If someone edited the
+  template's hours after the cascade, that is a newer deliberate decision and Undo declines
+  rather than destroying it. Plain `=` rather than the shift guard's
+  `IS NOT DISTINCT FROM`, because `shift_templates.start_time`/`end_time` are `TIME NOT NULL`
+  (`supabase/migrations/20251114100000_create_scheduling_tables.sql:39-40`) while
+  `shifts.start_time`/`end_time` are not — the operators are equivalent here and `=` says so.
+  A second Undo click on the same batch lands in the `changed_since` branch, because the
+  first Undo already moved the template off the cascade's after-hours. Mechanically right,
+  and it matches how a second click already behaves for the shifts (`:438-441`).
 - **Restored independently of `restored_count`.** Even when every shift is skipped, the
   manager clicked Undo to reverse *their template edit*; leaving the template on the new
   hours would be the same desync in a rarer shape. The header is the record of what the
@@ -217,68 +245,79 @@ where the manager's mental model and the data disagree.
 
 ---
 
-## Fix 2 — split the overloaded flag
+## Fix 2 — say what the manager can do, and put the control in front of them
 
-`useTemplateHoursLedger` returns two flags where it returned one:
+Two changes, both small, both aimed at the one line the manager actually reads and the one
+click that stands between them and the checkboxes.
 
-```ts
-// Anything worth showing the manager: linked shifts exist in some bucket.
-const linkedShiftCount =
-  (buckets ? buckets.moving.length + buckets.locked.length + buckets.drifted.length + buckets.past.length : 0)
-  + impact.pastCount;
-const showImpactPanel = hoursChanged && linkedShiftCount > 0 && !impact.isLoading && !impact.error;
+### 2a. The summary names the shifts they can pick
 
-// A cascade is actually on offer: something would move if they saved now.
-const cascadeOnOffer = showImpactPanel && affectedCount > 0;
-```
-
-`showCascadeChoice` is removed rather than kept as an alias — leaving both names in place is
-how the overload happened.
-
-Call-site mapping in `TemplateFormDialog.tsx`:
-
-| Site | Today | After |
-|---|---|---|
-| `:410` panel render guard | `showCascadeChoice` | `showImpactPanel` |
-| `:418` "Template only" button | `showCascadeChoice` | `cascadeOnOffer` |
-| `:439` `buildSaveButtonLabel` | `showCascadeChoice` | `cascadeOnOffer` |
-| `:185` `submitWith(...)` | `showCascadeChoice` | `cascadeOnOffer` |
-
-`buildSaveButtonLabel`'s parameter is renamed `cascadeOnOffer` to match, and the function
-gains a defensive floor so it can never emit "Save & update 0 shifts"
-(`src/lib/scheduling/hoursChangeCopy.ts:144-157`):
+`buildHoursChangeLedger` (`src/lib/scheduling/hoursChangeCopy.ts:234-238`) gains a clause
+for the case where nothing would move but something *could*:
 
 ```ts
-if (cascadeOnOffer && affectedCount > 0) {
-  return `Save & update ${affectedCount} ${pluralize(affectedCount, 'shift', 'shifts')}`;
-}
+const unpickedDrift = driftedCount - selectedDriftCount;   // already computed at :226
+const pickClause = totalAffected === 0 && unpickedDrift > 0
+  ? ` ${unpickedDrift} hand-edited ${pluralize(unpickedDrift, 'shift', 'shifts')} you can pick.`
+  : '';
 ```
 
-The resulting states a manager can now reach:
+appended to both branches of `summary`. The reported state now reads:
 
-| Buckets | Panel | Primary button | Behaviour |
-|---|---|---|---|
-| 3 moving | shown | "Save & update 3 shifts" | unchanged from today |
-| 3 drifted, 0 ticked | **shown** (was hidden) | "Save changes" | template-only save; checkboxes reachable |
-| 3 drifted, 2 ticked | shown | "Save & update 2 shifts" | cascade the two |
-| only past/locked | **shown** (was hidden) | "Save changes" | explains why nothing moves |
-| no linked shifts | hidden | "Save changes" | unchanged from today |
+> Low impact. 1h later · same length. 0 shifts move. **3 hand-edited shifts you can pick.**
 
-The ledger copy already handles every one of these without change: the "0 shifts move" chip
-is emitted unconditionally and deliberately (`hoursChangeCopy.ts:178-184`), and the untouched
-lines for past, locked, and unpicked drift are each independently conditional
-(`:213-232`). The panel is honest at `movingCount = 0` as written.
+Scoped to `totalAffected === 0` deliberately. Once anything is moving, the panel's chips and
+the "Save & update N shifts" button already say so, and this line is truncated
+(`TemplateHoursImpact.tsx:99`, `truncate`) — spending its remaining width on a second
+call to action would push the count off screen.
+
+`severity` is untouched: `deriveHoursChangeSeverity` keys on `publishedCount` (`:56-58`),
+which counts only shifts that would actually move, so an all-drifted state stays "Low
+impact". That is correct — saving right now moves nothing.
+
+### 2b. The drift disclosure opens by default when it is the only thing to do
+
+`TemplateHoursImpact.tsx:57` initialises `driftOpen` to `false` unconditionally. It becomes
+a nullable override over a derived default, so the default can depend on `ledger` (which is
+`null` on the first render while the impact query is in flight, and so cannot be read by a
+`useState` initialiser that runs exactly once):
+
+```ts
+const [driftOpen, setDriftOpen] = useState<boolean | null>(null);
+// ... after the `if (!ledger) return null` bail-out at :77
+const driftDefaultOpen = drifted.length > 0 && ledger.totalAffected === 0;
+```
+
+used as `<Collapsible open={driftOpen ?? driftDefaultOpen} onOpenChange={setDriftOpen}>`.
+Once the manager touches the disclosure, their choice sticks for the rest of the dialog.
+
+The outer panel stays collapsed by default. Keeping the form calm was a deliberate choice in
+PR #700, and with 2a the collapsed line now carries the signal that earns the click.
+
+### What is explicitly NOT changing
+
+- `showCascadeChoice` and its four call sites — see the Bug 2 section above.
+- `buildSaveButtonLabel` (`:144-157`). "Save changes" is the right label when nothing would
+  move, and "Save & update N shifts" appears the moment a checkbox is ticked. It is already
+  correct in every reachable state.
+- The panel's render guard at `TemplateFormDialog.tsx:270`. It already renders in every
+  state that has something to say.
 
 ### Accessibility and styling
 
-No new components. The drift checkboxes, the disclosure, and the aria-live summary are the
-ones shipped in PR #700 and are unchanged — this fix only makes them reachable. The panel's
-existing semantic tokens and Apple/Notion styling carry over untouched.
+No new components and no new controls. The drift checkboxes are already correctly labelled
+(`TemplateHoursImpact.tsx:172-179`, `Checkbox id` + `Label htmlFor`). The `aria-live="polite"`
+region is scoped to the summary line (`:99`) — 2a changes the text that region announces but
+not when it announces, so a manager on a screen reader hears the pick clause on the same
+settled-keystroke cadence as today. 2b opens a `Collapsible` whose trigger already carries
+its own state; no ARIA changes are needed. Existing semantic tokens and the Apple/Notion
+scale carry over untouched.
 
 ### Known limitation (pre-existing, unchanged)
 
 Re-syncing drifted shifts *without* editing the hours stays impossible: `hoursChanged`
-(`useTemplateHoursLedger.ts:115-116`) gates the whole panel, so a manager who wants to pull
+(`useTemplateHoursLedger.ts:115-116`) gates the panel at `TemplateFormDialog.tsx:270`, so a
+manager who wants to pull
 hand-edited shifts back onto the template's current hours must nudge the time and change it
 back. That is the shipped design from PR #700, not a regression from these two bugs, and
 fixing it is a separate feature (a "re-sync shifts" action on the template row). Recorded
@@ -299,11 +338,16 @@ SELECT l.cascade_batch_id, l.restaurant_id, s.shift_template_id,
        t.start_time AS template_start, t.end_time AS template_end,
        count(*) AS reverted_shifts
 FROM public.schedule_change_logs l
-JOIN public.shifts s ON s.id = l.shift_id
-JOIN public.shift_templates t ON t.id = s.shift_template_id
+LEFT JOIN public.shifts s ON s.id = l.shift_id
+LEFT JOIN public.shift_templates t ON t.id = s.shift_template_id
 WHERE l.reason = 'Undo template hours cascade'
 GROUP BY 1, 2, 3, 4, 5;
 ```
+
+`LEFT JOIN`, not inner: `schedule_change_logs.shift_id` is deliberately not a foreign key
+(`supabase/migrations/20260617120000_fix_schedule_change_logs_delete_fk.sql:38-44`), so an
+inner join would silently drop any batch whose shift was deleted afterwards and understate
+the damage.
 
 This finds every batch an Undo touched; the desynced ones are those whose template hours
 still differ from the restored shifts' local hours. The repair is a targeted
@@ -336,27 +380,48 @@ that Undo restored. Counts will be confirmed against live data and stated before
    leaves both templates untouched.
 6. Legacy batch: an Undo for a `cascade_batch_id` with no header row reverts shifts and
    returns both flags false.
+7. **Template restored when no shift is** — cascade, then lock every moved shift, then undo:
+   assert `restored_count = 0` and `template_restored = true`. This is the one combination
+   the "Restored independently of `restored_count`" decision above rests on, and none of
+   tests 1–3 constructs it.
+8. **Superseded batch** — cascade X, then cascade Y on the same template, then Undo(X):
+   assert Y's shifts are not disturbed (they fail X's `after_data` guard and count as
+   `changed_since`) and the template is not restored (`template_changed_since = true`, since
+   it now holds Y's hours, not X's). The safety here comes from two independently written
+   guards happening to compose; given this migration exists because of exactly that class of
+   interaction, it gets a test rather than a paragraph.
 
 ### Vitest
 
-`tests/unit/useTemplateHoursLedger.test.ts`:
-- `showImpactPanel` true when `driftedCount > 0` and `movingCount === 0`.
-- `showImpactPanel` true when only past/locked shifts are linked.
-- `showImpactPanel` false when no linked shifts exist at all.
-- `cascadeOnOffer` false at `affectedCount === 0`, true once a drift id is selected.
-
 `tests/unit/hoursChangeCopy.test.ts`:
-- `buildSaveButtonLabel` returns "Save changes" when `cascadeOnOffer` is false.
-- Returns "Save changes" (not "Save & update 0 shifts") if `cascadeOnOffer` is true but
-  `affectedCount` is 0.
-- Still returns "Save & update 1 shift" / "…2 shifts" for the normal cases.
+- `buildHoursChangeLedger` summary ends with "3 hand-edited shifts you can pick." when
+  `movingCount = 0`, `driftedCount = 3`, `selectedDriftCount = 0`. **Fails today** — today's
+  summary stops at "0 shifts move."
+- Singular form at `driftedCount = 1`.
+- No pick clause once `selectedDriftCount > 0` (something is moving, so the button carries it).
+- No pick clause when `movingCount > 0` and drift is unpicked.
+- No pick clause when `driftedCount = 0` — the past/locked-only state is unchanged.
+
+`tests/unit/templateHoursImpact.test.tsx` (new; the repo lists component tests as optional,
+but 2b is a render-state behaviour no pure-function test can reach):
+- Drift disclosure is open on first render when `drifted.length > 0` and
+  `ledger.totalAffected === 0`, and the checkboxes are in the accessibility tree.
+- Closed on first render when something is already moving.
+- A manual toggle wins over the default and survives a ledger re-render.
 
 ### Playwright — `tests/e2e/template-hours-cascade.spec.ts` (extend)
 
-One scenario covering the user's report: create a template with linked future shifts,
-change the hours and cascade, click Undo, then change the hours again and assert the impact
-panel appears with the shifts in the moving bucket. This is the regression that no unit test
-can cover, because it spans the RPC round trip.
+Two scenarios, one per bug — the first would pass today and the second would not, so both
+are needed.
+
+1. **Bug 1 round trip.** Create a template with linked future shifts, change the hours and
+   cascade, click Undo, then change the hours again and assert the shifts move. Today the
+   second edit finds them drifted and moves nothing.
+2. **Bug 2 opt-in path.** On a template whose linked shifts are all hand-edited, change the
+   hours and assert (a) the collapsed summary names the pickable shifts, (b) expanding the
+   panel shows the drift checkboxes without a further click, (c) ticking one relabels the
+   primary button to "Save & update 1 shift" and reveals "Template only", and (d) saving
+   sends that shift id with `cascade: true` and the shift actually moves.
 
 ## Migration
 

--- a/docs/superpowers/specs/2026-08-05-template-cascade-undo-fix-design.md
+++ b/docs/superpowers/specs/2026-08-05-template-cascade-undo-fix-design.md
@@ -1,0 +1,371 @@
+# Template-Hours Cascade: Undo Desync + Unreachable Drift Opt-In — Design
+
+**Date:** 2026-08-05
+**Branch:** `fix/template-cascade-undo`
+**Fixes defects in:** PR #700 (merged `d4a50c9f`), spec `docs/superpowers/specs/2026-08-03-template-hours-cascade-design.md`
+
+## Problem
+
+Two defects, both reproduced against production data on the Home test restaurant
+(`0a1812a5-33f8-4861-a9d1-801048712875`, template `a71b4223-5a39-460b-bb12-83f0937ab4d9`
+"Opening - weekend", `America/Chicago`).
+
+### Bug 1 — Undo reverts the shifts but not the template
+
+`undo_template_hours_cascade`'s only write to a domain table is the `UPDATE public.shifts`
+at `supabase/migrations/20260804130000_template_hours_cascade.sql:415-435`. There is no
+`UPDATE public.shift_templates` anywhere in the function (`:327-460`). So after Undo the
+template holds the NEW hours while its shifts hold the OLD ones.
+
+That desync is not cosmetic, because the cascade's match predicate compares each shift's
+restaurant-local time-of-day against the template's *current* hours
+(`:200-206`, repeated verbatim at `:256-260`):
+
+```sql
+(    (s.start_time AT TIME ZONE v_tz)::time = v_old_start
+ AND (s.end_time   AT TIME ZONE v_tz)::time = v_old_end)
+OR s.id = ANY(v_drift_ids)
+```
+
+`v_old_start`/`v_old_end` are read from the template row at `:108-113`. Once Undo has left
+the template pointing somewhere the shifts are not, every later edit measures the shifts
+against the wrong baseline, they fail the match, and they are classified **drifted** —
+permanently.
+
+Production timeline (UTC):
+
+| Time | Event | Template | Shifts (Aug 7/8/9) |
+|---|---|---|---|
+| 02:35:16 | 3 shifts created | 10:00–16:30 | 10:00–16:30 |
+| 02:35:28 | end → 17:30, cascade batch `4e6854bb` | 10:00–**17:30** | 10:00–**17:30** |
+| 02:35:35 | **Undo** | 10:00–17:30 ⚠️ | 10:00–**16:30** |
+| 02:36:20 | start → 11:00 | **11:00–18:30** | 10:00–16:30 (untouched) |
+
+At 02:36:20 the shifts' start matched the stale `v_old_start` (10:00) but their end did not
+match the stale `v_old_end` (17:30). The predicate is a conjunction, so all three fell to
+drifted. Current prod state: template 11:00–18:30, all three shifts still 10:00–16:30.
+
+### Bug 2 — the drift opt-in checkboxes are unreachable
+
+`src/hooks/useTemplateHoursLedger.ts:118`:
+
+```ts
+const showCascadeChoice = hoursChanged && affectedCount > 0 && !impact.isLoading && !impact.error;
+```
+
+`affectedCount` is `ledger.totalAffected`, which is
+`movingCount + selectedDriftCount` (`src/lib/scheduling/hoursChangeCopy.ts:168`). A drifted
+shift contributes zero until the manager ticks its checkbox — and those checkboxes render
+inside `<TemplateHoursImpact>`, which the dialog gates on the very same flag
+(`src/components/scheduling/ShiftPlanner/TemplateFormDialog.tsx:410`). When every linked
+shift is drifted, `movingCount = 0`, `selectedDriftCount = 0`, `affectedCount = 0`, the panel
+never renders, and the only control that could raise the count is hidden behind the gate.
+
+This is independent of Bug 1 — Bug 1 is simply the most common way to reach the deadlock.
+It also fires whenever a manager hand-edits every linked shift, which is exactly what the
+"Your call" bucket exists for.
+
+The same flag is overloaded across four call sites in the dialog: the panel guard
+(`:410`), the "Template only" button (`:418`), the primary button's label
+(`:439`, via `buildSaveButtonLabel`), and the implicit-submit path (`:185`,
+`await submitWith(showCascadeChoice)`).
+
+---
+
+## Fix 1 — record the template's own before/after, restore it on Undo
+
+### Mechanism: a batch-header table
+
+New table `public.template_hours_cascade_batches`, one row per cascade that actually moved
+shifts, keyed by the batch id the cascade already mints:
+
+```sql
+CREATE TABLE public.template_hours_cascade_batches (
+  id                UUID PRIMARY KEY,              -- = schedule_change_logs.cascade_batch_id
+  restaurant_id     UUID NOT NULL REFERENCES public.restaurants(id)     ON DELETE CASCADE,
+  shift_template_id UUID NOT NULL REFERENCES public.shift_templates(id) ON DELETE CASCADE,
+  before_start_time TIME NOT NULL,
+  before_end_time   TIME NOT NULL,
+  after_start_time  TIME NOT NULL,
+  after_end_time    TIME NOT NULL,
+  changed_by        UUID,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+`id` is the PK and is supplied by the caller (`v_batch_id`), so no separate index is needed
+for the Undo lookup. `restaurant_id` is carried on the row so Undo can scope with the same
+tenant filter every other statement in these functions uses, without a join.
+
+**Rejected alternatives:**
+
+- *Reconstruct the old template hours from a shift's `before_data`.* Wrong for drifted
+  opt-in rows: a drifted shift's `before_data` holds hand-edited hours that never equalled
+  the template's, and a batch can legitimately contain **only** drifted rows.
+- *One extra `schedule_change_logs` row with `shift_id = NULL`.* The "deleted since" probe
+  at `:372-380` is a `NOT EXISTS` against `shifts`, so a shift-less row would be counted as
+  a deleted shift. Suppressing that needs `AND l.shift_id IS NOT NULL` bolted onto four
+  separate queries, and it overloads a table whose every column is shift-scoped
+  (`supabase/migrations/20251123000000_schedule_publishing.sql:23-35`).
+
+### Write side
+
+Inside `update_shift_template_with_cascade`, immediately after the `SELECT … INTO
+v_updated_count, v_published_shifts` block (`:284-297`) and still inside `IF p_cascade`:
+
+```sql
+IF v_updated_count > 0 THEN
+  INSERT INTO public.template_hours_cascade_batches (
+    id, restaurant_id, shift_template_id,
+    before_start_time, before_end_time, after_start_time, after_end_time, changed_by
+  )
+  VALUES (
+    v_batch_id, p_restaurant_id, p_template_id,
+    v_old_start, v_old_end, p_start_time, p_end_time, auth.uid()
+  );
+END IF;
+```
+
+`v_updated_count > 0` is exactly the condition under which the function returns a non-NULL
+`batch_id` (`:302`) and therefore the only condition under which the client offers Undo. A
+header written for a batch that moved nothing would be an unreachable row.
+
+### Read side
+
+`undo_template_hours_cascade` gains, before the shift revert:
+
+```sql
+SELECT b.shift_template_id, b.before_start_time, b.before_end_time,
+       b.after_start_time,  b.after_end_time
+  INTO v_template_id, v_before_start, v_before_end, v_after_start, v_after_end
+FROM public.template_hours_cascade_batches b
+WHERE b.id = p_batch_id
+  AND b.restaurant_id = p_restaurant_id;
+```
+
+Then, when a header was found, lock and conditionally restore:
+
+```sql
+IF FOUND THEN
+  SELECT t.start_time, t.end_time INTO v_cur_start, v_cur_end
+  FROM public.shift_templates t
+  WHERE t.id = v_template_id AND t.restaurant_id = p_restaurant_id
+  FOR UPDATE;
+
+  IF FOUND AND v_cur_start = v_after_start AND v_cur_end = v_after_end THEN
+    UPDATE public.shift_templates
+    SET start_time = v_before_start, end_time = v_before_end, updated_at = now()
+    WHERE id = v_template_id AND restaurant_id = p_restaurant_id;
+    v_template_restored := true;
+  ELSIF FOUND THEN
+    v_template_changed_since := true;
+  END IF;
+END IF;
+```
+
+Three properties, each deliberate:
+
+- **`FOR UPDATE` before the comparison.** Same reasoning as the cascade's own lock at
+  `:102-113`: without it a concurrent template edit can be read stale and stomped. Taking
+  the template lock *before* the shift revert also fixes the lock order for the pair, so
+  Undo and a concurrent cascade acquire template-then-shifts in the same sequence and cannot
+  deadlock against each other.
+- **The "unchanged since" guard.** Mirrors the shift-level guard at `:424-425` exactly: a
+  row is restored only if it still holds precisely what the cascade wrote. If someone edited
+  the template's hours after the cascade, that is a newer deliberate decision and Undo
+  declines rather than destroying it.
+- **Restored independently of `restored_count`.** Even when every shift is skipped, the
+  manager clicked Undo to reverse *their template edit*; leaving the template on the new
+  hours would be the same desync in a rarer shape. The header is the record of what the
+  template edit was, so it is restorable on its own terms.
+
+The return object gains two booleans:
+
+```sql
+'template_restored',      v_template_restored,
+'template_changed_since', v_template_changed_since
+```
+
+Old batches (rows already in `schedule_change_logs` from before this migration) have no
+header. The `SELECT … INTO` finds nothing, both flags stay `false`, and Undo behaves exactly
+as it does today — no error, no partial write.
+
+### Tenant scoping and grants
+
+RLS enabled with **no policies**, so no client can read or write the table directly; both
+RPCs are `SECURITY DEFINER` and bypass it. Additionally `REVOKE ALL ON TABLE … FROM PUBLIC,
+anon, authenticated` — belt and braces, and it keeps the table off the PostgREST surface.
+Every statement touching it filters on `restaurant_id = p_restaurant_id`, matching the
+pattern the cascade function documents at `:96-101`.
+
+### Client surface
+
+`src/hooks/useShiftTemplates.tsx:182-187` types the RPC result; it gains
+`template_restored: boolean` and `template_changed_since: boolean`. The success toast
+(`:203-208`) already invalidates `['shift_templates', restaurantId]` via
+`invalidateCascadeQueries()` (`:144-148`), so a restored template refreshes without further
+work. The toast's `skippedReasons` list (`:198-202`) gains one more entry, kept in the same
+"say why, don't summarise" style the existing three use:
+
+```ts
+result.template_changed_since ? 'template hours changed since' : null,
+```
+
+Restoration of the template is the expected case and is not narrated — reporting "restored
+the template" on every Undo would be noise. The exception is narrated because it is the case
+where the manager's mental model and the data disagree.
+
+---
+
+## Fix 2 — split the overloaded flag
+
+`useTemplateHoursLedger` returns two flags where it returned one:
+
+```ts
+// Anything worth showing the manager: linked shifts exist in some bucket.
+const linkedShiftCount =
+  (buckets ? buckets.moving.length + buckets.locked.length + buckets.drifted.length + buckets.past.length : 0)
+  + impact.pastCount;
+const showImpactPanel = hoursChanged && linkedShiftCount > 0 && !impact.isLoading && !impact.error;
+
+// A cascade is actually on offer: something would move if they saved now.
+const cascadeOnOffer = showImpactPanel && affectedCount > 0;
+```
+
+`showCascadeChoice` is removed rather than kept as an alias — leaving both names in place is
+how the overload happened.
+
+Call-site mapping in `TemplateFormDialog.tsx`:
+
+| Site | Today | After |
+|---|---|---|
+| `:410` panel render guard | `showCascadeChoice` | `showImpactPanel` |
+| `:418` "Template only" button | `showCascadeChoice` | `cascadeOnOffer` |
+| `:439` `buildSaveButtonLabel` | `showCascadeChoice` | `cascadeOnOffer` |
+| `:185` `submitWith(...)` | `showCascadeChoice` | `cascadeOnOffer` |
+
+`buildSaveButtonLabel`'s parameter is renamed `cascadeOnOffer` to match, and the function
+gains a defensive floor so it can never emit "Save & update 0 shifts"
+(`src/lib/scheduling/hoursChangeCopy.ts:144-157`):
+
+```ts
+if (cascadeOnOffer && affectedCount > 0) {
+  return `Save & update ${affectedCount} ${pluralize(affectedCount, 'shift', 'shifts')}`;
+}
+```
+
+The resulting states a manager can now reach:
+
+| Buckets | Panel | Primary button | Behaviour |
+|---|---|---|---|
+| 3 moving | shown | "Save & update 3 shifts" | unchanged from today |
+| 3 drifted, 0 ticked | **shown** (was hidden) | "Save changes" | template-only save; checkboxes reachable |
+| 3 drifted, 2 ticked | shown | "Save & update 2 shifts" | cascade the two |
+| only past/locked | **shown** (was hidden) | "Save changes" | explains why nothing moves |
+| no linked shifts | hidden | "Save changes" | unchanged from today |
+
+The ledger copy already handles every one of these without change: the "0 shifts move" chip
+is emitted unconditionally and deliberately (`hoursChangeCopy.ts:178-184`), and the untouched
+lines for past, locked, and unpicked drift are each independently conditional
+(`:213-232`). The panel is honest at `movingCount = 0` as written.
+
+### Accessibility and styling
+
+No new components. The drift checkboxes, the disclosure, and the aria-live summary are the
+ones shipped in PR #700 and are unchanged — this fix only makes them reachable. The panel's
+existing semantic tokens and Apple/Notion styling carry over untouched.
+
+### Known limitation (pre-existing, unchanged)
+
+Re-syncing drifted shifts *without* editing the hours stays impossible: `hoursChanged`
+(`useTemplateHoursLedger.ts:115-116`) gates the whole panel, so a manager who wants to pull
+hand-edited shifts back onto the template's current hours must nudge the time and change it
+back. That is the shipped design from PR #700, not a regression from these two bugs, and
+fixing it is a separate feature (a "re-sync shifts" action on the template row). Recorded
+here so it is not mistaken for an oversight.
+
+---
+
+## Production remediation
+
+Three shifts on Home are desynced today. The repair is a **read-only diagnosis first**,
+then a proposed statement with exact row counts, then the user's explicit approval before
+any write — per CLAUDE.md's rule on prod writes.
+
+Diagnosis query (read-only, safe to run without approval):
+
+```sql
+SELECT l.cascade_batch_id, l.restaurant_id, s.shift_template_id,
+       t.start_time AS template_start, t.end_time AS template_end,
+       count(*) AS reverted_shifts
+FROM public.schedule_change_logs l
+JOIN public.shifts s ON s.id = l.shift_id
+JOIN public.shift_templates t ON t.id = s.shift_template_id
+WHERE l.reason = 'Undo template hours cascade'
+GROUP BY 1, 2, 3, 4, 5;
+```
+
+This finds every batch an Undo touched; the desynced ones are those whose template hours
+still differ from the restored shifts' local hours. The repair is a targeted
+`UPDATE public.shift_templates SET start_time = …, end_time = …` per affected template —
+never a bulk statement, and never applied from this branch's migration. The migration ships
+the code fix only; historical data is repaired separately and explicitly, because a
+migration that rewrites tenant data based on inferred intent is exactly the kind of thing
+that cannot be undone.
+
+For Home specifically the expected repair is one row: template
+`a71b4223-5a39-460b-bb12-83f0937ab4d9` back to `10:00`/`16:30`, matching the three shifts
+that Undo restored. Counts will be confirmed against live data and stated before asking.
+
+---
+
+## Testing
+
+### pgTAP — `supabase/tests/template_hours_cascade.test.sql` (extend)
+
+1. Undo restores the template's hours: cascade 10:00–16:30 → 10:00–17:30, undo, assert
+   template is 10:00–16:30 again and `template_restored` is `true`.
+2. **The reported bug, end to end**: cascade → undo → cascade again with new hours, assert
+   the shifts move (this fails today: they are classified drifted and nothing moves).
+3. Undo declines when the template changed since: cascade, hand-edit the template's hours,
+   undo, assert the template keeps the hand-edit, `template_restored` false,
+   `template_changed_since` true.
+4. A batch header row is written when shifts moved, and is **not** written when
+   `p_cascade` was true but zero shifts qualified.
+5. Tenant isolation: an Undo naming another restaurant's batch id restores nothing and
+   leaves both templates untouched.
+6. Legacy batch: an Undo for a `cascade_batch_id` with no header row reverts shifts and
+   returns both flags false.
+
+### Vitest
+
+`tests/unit/useTemplateHoursLedger.test.ts`:
+- `showImpactPanel` true when `driftedCount > 0` and `movingCount === 0`.
+- `showImpactPanel` true when only past/locked shifts are linked.
+- `showImpactPanel` false when no linked shifts exist at all.
+- `cascadeOnOffer` false at `affectedCount === 0`, true once a drift id is selected.
+
+`tests/unit/hoursChangeCopy.test.ts`:
+- `buildSaveButtonLabel` returns "Save changes" when `cascadeOnOffer` is false.
+- Returns "Save changes" (not "Save & update 0 shifts") if `cascadeOnOffer` is true but
+  `affectedCount` is 0.
+- Still returns "Save & update 1 shift" / "…2 shifts" for the normal cases.
+
+### Playwright — `tests/e2e/template-hours-cascade.spec.ts` (extend)
+
+One scenario covering the user's report: create a template with linked future shifts,
+change the hours and cascade, click Undo, then change the hours again and assert the impact
+panel appears with the shifts in the moving bucket. This is the regression that no unit test
+can cover, because it spans the RPC round trip.
+
+## Migration
+
+New file `supabase/migrations/20260805160000_template_cascade_undo_restores_template.sql`.
+`20260805120000` and `20260805130000` are already claimed by sibling worktrees
+(`page_areas`, `self_scope_employee_reads`); the 14-digit prefix is the PK of
+`supabase_migrations.schema_migrations`, so a collision fails only on `pull_request` CI.
+`tests/unit/migrationVersionUniqueness.test.ts` guards this.
+
+The existing `20260804130000` migration is **not** edited — it is already applied in
+production, and `CREATE OR REPLACE FUNCTION` in a new file supersedes it cleanly on a fresh
+reset as long as the new file sorts later, which it does.

--- a/src/components/scheduling/ShiftPlanner/TemplateHoursImpact.tsx
+++ b/src/components/scheduling/ShiftPlanner/TemplateHoursImpact.tsx
@@ -82,6 +82,7 @@ export function TemplateHoursImpact({
   // When nothing would move on its own, these checkboxes are the only thing the
   // manager can act on -- so they are not hidden behind a third click.
   const driftDefaultOpen = drifted.length > 0 && ledger.totalAffected === 0;
+  const isDriftOpen = driftOpen ?? driftDefaultOpen;
 
   return (
     <div className="rounded-xl border border-border/40 bg-muted/30 overflow-hidden">
@@ -156,14 +157,14 @@ export function TemplateHoursImpact({
             </div>
 
             {drifted.length > 0 && (
-              <Collapsible open={driftOpen ?? driftDefaultOpen} onOpenChange={setDriftOpen}>
+              <Collapsible open={isDriftOpen} onOpenChange={setDriftOpen}>
                 <CollapsibleTrigger asChild>
                   <button
                     type="button"
                     className="flex items-center gap-2 text-[13px] font-medium text-foreground"
                   >
                     <ChevronRight
-                      className={`h-4 w-4 text-muted-foreground transition-transform ${(driftOpen ?? driftDefaultOpen) ? 'rotate-90' : ''}`}
+                      className={`h-4 w-4 text-muted-foreground transition-transform ${isDriftOpen ? 'rotate-90' : ''}`}
                       aria-hidden="true"
                     />
                     {drifted.length} hand-edited {drifted.length === 1 ? 'shift' : 'shifts'} — your call

--- a/src/components/scheduling/ShiftPlanner/TemplateHoursImpact.tsx
+++ b/src/components/scheduling/ShiftPlanner/TemplateHoursImpact.tsx
@@ -180,7 +180,19 @@ export function TemplateHoursImpact({
                           <Checkbox
                             id={inputId}
                             checked={selectedDriftIds.has(row.shiftId)}
-                            onCheckedChange={() => onToggleDrift(row.shiftId)}
+                            onCheckedChange={() => {
+                              // Ticking a row is only reachable while this disclosure is
+                              // already open (default or manual), so latching `driftOpen`
+                              // to `true` here is always a no-op-or-lock, never a surprise
+                              // open. Without it, picking the first of several drifted
+                              // shifts flips `ledger.totalAffected` above 0 on the next
+                              // render, `driftDefaultOpen` recomputes to `false`, and the
+                              // still-null `driftOpen` lets the panel snap shut on the
+                              // remaining unpicked checkboxes -- the exact "hidden behind a
+                              // third click" outcome this disclosure exists to avoid.
+                              setDriftOpen(true);
+                              onToggleDrift(row.shiftId);
+                            }}
                           />
                           <Label htmlFor={inputId} className="text-[13px] font-normal text-foreground">
                             {who} — {row.localDate}, currently {row.currentStart}–{row.currentEnd}

--- a/src/components/scheduling/ShiftPlanner/TemplateHoursImpact.tsx
+++ b/src/components/scheduling/ShiftPlanner/TemplateHoursImpact.tsx
@@ -54,7 +54,10 @@ export function TemplateHoursImpact({
   newEnd,
 }: Readonly<TemplateHoursImpactProps>) {
   const [expanded, setExpanded] = useState(false);
-  const [driftOpen, setDriftOpen] = useState(false);
+  // null means "no manual choice yet", so the default below can depend on `ledger`
+  // -- which is null on the first render while the impact query is in flight, and so
+  // cannot be read by a useState initialiser that runs exactly once.
+  const [driftOpen, setDriftOpen] = useState<boolean | null>(null);
 
   if (isLoading) {
     return (
@@ -75,6 +78,10 @@ export function TemplateHoursImpact({
   }
 
   if (!ledger) return null;
+
+  // When nothing would move on its own, these checkboxes are the only thing the
+  // manager can act on -- so they are not hidden behind a third click.
+  const driftDefaultOpen = drifted.length > 0 && ledger.totalAffected === 0;
 
   return (
     <div className="rounded-xl border border-border/40 bg-muted/30 overflow-hidden">
@@ -149,14 +156,14 @@ export function TemplateHoursImpact({
             </div>
 
             {drifted.length > 0 && (
-              <Collapsible open={driftOpen} onOpenChange={setDriftOpen}>
+              <Collapsible open={driftOpen ?? driftDefaultOpen} onOpenChange={setDriftOpen}>
                 <CollapsibleTrigger asChild>
                   <button
                     type="button"
                     className="flex items-center gap-2 text-[13px] font-medium text-foreground"
                   >
                     <ChevronRight
-                      className={`h-4 w-4 text-muted-foreground transition-transform ${driftOpen ? 'rotate-90' : ''}`}
+                      className={`h-4 w-4 text-muted-foreground transition-transform ${(driftOpen ?? driftDefaultOpen) ? 'rotate-90' : ''}`}
                       aria-hidden="true"
                     />
                     {drifted.length} hand-edited {drifted.length === 1 ? 'shift' : 'shifts'} — your call

--- a/src/hooks/useShiftTemplates.tsx
+++ b/src/hooks/useShiftTemplates.tsx
@@ -184,6 +184,8 @@ export function useShiftTemplates(
         changed_since_count: number;
         deleted_count: number;
         protected_count: number;
+        template_restored: boolean;
+        template_changed_since: boolean;
       };
     },
     onSuccess: (result) => {
@@ -199,6 +201,10 @@ export function useShiftTemplates(
         result.changed_since_count > 0 ? `${result.changed_since_count} changed since` : null,
         result.deleted_count > 0 ? `${result.deleted_count} deleted` : null,
         result.protected_count > 0 ? `${result.protected_count} now locked or started` : null,
+        // Restoring the template is the expected case and is not narrated -- saying so
+        // on every Undo would be noise. This is the case where the manager's mental
+        // model and the data disagree, so it gets said out loud.
+        result.template_changed_since ? 'template hours changed since' : null,
       ].filter(Boolean);
       toast({
         title: 'Cascade undone',

--- a/src/hooks/useShiftTemplates.tsx
+++ b/src/hooks/useShiftTemplates.tsx
@@ -186,6 +186,7 @@ export function useShiftTemplates(
         protected_count: number;
         template_restored: boolean;
         template_changed_since: boolean;
+        template_slot_conflict: boolean;
       };
     },
     onSuccess: (result) => {
@@ -205,6 +206,13 @@ export function useShiftTemplates(
         // on every Undo would be noise. This is the case where the manager's mental
         // model and the data disagree, so it gets said out loud.
         result.template_changed_since ? 'template hours changed since' : null,
+        // Not folded in with the line above: nobody edited this template, so
+        // "changed since" would send the manager to inspect the wrong record.
+        // Another active template now sits in the hours this one is trying to
+        // return to, and that is the thing they have to resolve.
+        result.template_slot_conflict
+          ? 'template hours taken by another template'
+          : null,
       ].filter(Boolean);
       toast({
         title: 'Cascade undone',

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -6320,6 +6320,155 @@ export type Database = {
           },
         ]
       }
+      review_pages: {
+        Row: {
+          created_at: string
+          created_by: string | null
+          destination_url: string | null
+          headline: string
+          id: string
+          is_active: boolean
+          logo_path: string | null
+          name: string
+          promoter_threshold: number
+          restaurant_id: string
+          slug: string
+          subheadline: string | null
+          updated_at: string
+        }
+        Insert: {
+          created_at?: string
+          created_by?: string | null
+          destination_url?: string | null
+          headline?: string
+          id?: string
+          is_active?: boolean
+          logo_path?: string | null
+          name: string
+          promoter_threshold?: number
+          restaurant_id: string
+          slug: string
+          subheadline?: string | null
+          updated_at?: string
+        }
+        Update: {
+          created_at?: string
+          created_by?: string | null
+          destination_url?: string | null
+          headline?: string
+          id?: string
+          is_active?: boolean
+          logo_path?: string | null
+          name?: string
+          promoter_threshold?: number
+          restaurant_id?: string
+          slug?: string
+          subheadline?: string | null
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "review_pages_restaurant_id_fkey"
+            columns: ["restaurant_id"]
+            isOneToOne: false
+            referencedRelation: "restaurants"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      review_response_contacts: {
+        Row: {
+          contact_email: string | null
+          contact_name: string | null
+          restaurant_id: string
+          review_response_id: string
+        }
+        Insert: {
+          contact_email?: string | null
+          contact_name?: string | null
+          restaurant_id: string
+          review_response_id: string
+        }
+        Update: {
+          contact_email?: string | null
+          contact_name?: string | null
+          restaurant_id?: string
+          review_response_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "review_response_contacts_restaurant_id_fkey"
+            columns: ["restaurant_id"]
+            isOneToOne: false
+            referencedRelation: "restaurants"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "review_response_contacts_review_response_id_fkey"
+            columns: ["review_response_id"]
+            isOneToOne: true
+            referencedRelation: "review_responses"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      review_responses: {
+        Row: {
+          comment: string | null
+          commented_at: string | null
+          contact_consent: boolean
+          id: string
+          ip_hash: string | null
+          rating: number
+          restaurant_id: string
+          review_page_id: string
+          routed_to: string
+          status: string
+          submitted_at: string
+        }
+        Insert: {
+          comment?: string | null
+          commented_at?: string | null
+          contact_consent?: boolean
+          id?: string
+          ip_hash?: string | null
+          rating: number
+          restaurant_id: string
+          review_page_id: string
+          routed_to: string
+          status?: string
+          submitted_at?: string
+        }
+        Update: {
+          comment?: string | null
+          commented_at?: string | null
+          contact_consent?: boolean
+          id?: string
+          ip_hash?: string | null
+          rating?: number
+          restaurant_id?: string
+          review_page_id?: string
+          routed_to?: string
+          status?: string
+          submitted_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "review_responses_restaurant_id_fkey"
+            columns: ["restaurant_id"]
+            isOneToOne: false
+            referencedRelation: "restaurants"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "review_responses_review_page_id_fkey"
+            columns: ["review_page_id"]
+            isOneToOne: false
+            referencedRelation: "review_pages"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       role_areas: {
         Row: {
           area_key: string
@@ -8452,6 +8601,57 @@ export type Database = {
         }
         Relationships: []
       }
+      template_hours_cascade_batches: {
+        Row: {
+          after_end_time: string
+          after_start_time: string
+          before_end_time: string
+          before_start_time: string
+          changed_by: string | null
+          created_at: string
+          id: string
+          restaurant_id: string
+          shift_template_id: string
+        }
+        Insert: {
+          after_end_time: string
+          after_start_time: string
+          before_end_time: string
+          before_start_time: string
+          changed_by?: string | null
+          created_at?: string
+          id: string
+          restaurant_id: string
+          shift_template_id: string
+        }
+        Update: {
+          after_end_time?: string
+          after_start_time?: string
+          before_end_time?: string
+          before_start_time?: string
+          changed_by?: string | null
+          created_at?: string
+          id?: string
+          restaurant_id?: string
+          shift_template_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "template_hours_cascade_batches_restaurant_id_fkey"
+            columns: ["restaurant_id"]
+            isOneToOne: false
+            referencedRelation: "restaurants"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "template_hours_cascade_batches_shift_template_id_fkey"
+            columns: ["shift_template_id"]
+            isOneToOne: false
+            referencedRelation: "shift_templates"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       time_off_requests: {
         Row: {
           created_at: string | null
@@ -10519,6 +10719,10 @@ export type Database = {
         Args: { p_employee_id: string; p_trade_id: string }
         Returns: Json
       }
+      categorization_rules_watermark: {
+        Args: { p_restaurant_id: string; p_scope: string }
+        Returns: string
+      }
       categorize_bank_transaction:
         | {
             Args: {
@@ -11527,6 +11731,24 @@ export type Database = {
         Returns: number
       }
       revel_valid_tz: { Args: { p_tz: string }; Returns: string }
+      review_page_stats: {
+        Args: { p_restaurant_id: string }
+        Returns: {
+          average_rating: number
+          comment_count: number
+          rating_count: number
+          review_page_id: string
+        }[]
+      }
+      review_response_metrics: {
+        Args: { p_restaurant_id: string }
+        Returns: {
+          average_rating: number
+          comment_count: number
+          total_ratings: number
+          unread_count: number
+        }[]
+      }
       role_member_counts: {
         Args: { p_restaurant_id: string }
         Returns: {

--- a/src/lib/scheduling/hoursChangeCopy.ts
+++ b/src/lib/scheduling/hoursChangeCopy.ts
@@ -233,9 +233,15 @@ export function buildHoursChangeLedger(input: HoursChangeInput): HoursChangeLedg
 
   const severityLabel = severity === 'high' ? 'High impact' : 'Low impact';
   const movingClause = `${totalAffected} ${pluralize(totalAffected, 'shift moves', 'shifts move')}`;
+  // Scoped to totalAffected === 0 deliberately. Once anything is moving, the chips
+  // and the "Save & update N shifts" button already say so, and this line is
+  // truncated on screen -- a second call to action would push the count off.
+  const pickClause = totalAffected === 0 && unpickedDrift > 0
+    ? ` ${unpickedDrift} hand-edited ${pluralize(unpickedDrift, 'shift', 'shifts')} you can pick.`
+    : '';
   const summary = publishedCount > 0
-    ? `${severityLabel}. ${deltaBadge}. ${movingClause}, ${publishedCount} already posted.`
-    : `${severityLabel}. ${deltaBadge}. ${movingClause}.`;
+    ? `${severityLabel}. ${deltaBadge}. ${movingClause}, ${publishedCount} already posted.${pickClause}`
+    : `${severityLabel}. ${deltaBadge}. ${movingClause}.${pickClause}`;
 
   return { severity, chips, changes, untouched, summary, deltaBadge, totalAffected };
 }

--- a/supabase/migrations/20260805160000_template_cascade_undo_restores_template.sql
+++ b/supabase/migrations/20260805160000_template_cascade_undo_restores_template.sql
@@ -1,0 +1,545 @@
+-- Undo restores the template's own hours, not just the shifts (Bug 1).
+--
+-- update_shift_template_with_cascade writes the template's new hours and, when
+-- p_cascade, retimes the matching shifts in the same statement. But
+-- undo_template_hours_cascade only ever reverted the SHIFTS -- the template
+-- itself stayed on the cascade's new hours forever. After an undo, the
+-- template and its shifts disagreed about what the template's hours were, and
+-- every later cascade measured "does this shift still match the template"
+-- against a baseline the shifts no longer shared with. See
+-- docs/superpowers/specs/2026-08-05-template-cascade-undo-fix-design.md.
+
+-- ---------------------------------------------------------------------------
+-- Part A: batch-header table
+-- ---------------------------------------------------------------------------
+--
+-- Why a table and not columns on shift_templates: one row per historical batch is
+-- exactly what Undo needs, and columns could only ever hold the latest one.
+-- Why not a shift_id-less row in schedule_change_logs: the "deleted since" probe in
+-- undo_template_hours_cascade is a NOT EXISTS against shifts, so a shift-less row
+-- would be miscounted as a deleted shift.
+CREATE TABLE IF NOT EXISTS public.template_hours_cascade_batches (
+  id                UUID PRIMARY KEY,
+  restaurant_id     UUID NOT NULL REFERENCES public.restaurants(id)     ON DELETE CASCADE,
+  shift_template_id UUID NOT NULL REFERENCES public.shift_templates(id) ON DELETE CASCADE,
+  before_start_time TIME NOT NULL,
+  before_end_time   TIME NOT NULL,
+  after_start_time  TIME NOT NULL,
+  after_end_time    TIME NOT NULL,
+  changed_by        UUID,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.template_hours_cascade_batches IS
+  'One row per update_shift_template_with_cascade call that actually moved shifts, '
+  'keyed by the same batch id that tags the run''s schedule_change_logs rows. Records '
+  'the template''s own before/after hours so undo_template_hours_cascade can restore '
+  'them alongside the shifts. Written and read only by those two SECURITY DEFINER '
+  'functions; no client has any privilege on it.';
+
+-- No policies. Both writers are SECURITY DEFINER and bypass RLS; every other caller
+-- gets zero rows. The REVOKE is belt and braces and keeps the table off PostgREST.
+ALTER TABLE public.template_hours_cascade_batches ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE public.template_hours_cascade_batches FROM PUBLIC, anon, authenticated;
+GRANT ALL ON TABLE public.template_hours_cascade_batches TO service_role;
+
+-- ---------------------------------------------------------------------------
+-- Part B: update_shift_template_with_cascade -- write the batch header
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.update_shift_template_with_cascade(
+  p_template_id       UUID,
+  p_restaurant_id     UUID,
+  p_name              TEXT,
+  p_position          TEXT,
+  p_area              TEXT,
+  p_days              INTEGER[],
+  p_break_duration    INTEGER,
+  p_capacity          INTEGER,
+  p_start_time        TIME,
+  p_end_time          TIME,
+  p_cascade           BOOLEAN,
+  p_drifted_shift_ids UUID[]
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_tz                TEXT;
+  v_old_start         TIME;
+  v_old_end           TIME;
+  v_batch_id          UUID := gen_random_uuid();
+  v_updated_count     INTEGER := 0;
+  v_published_shifts  JSONB := '[]'::jsonb;
+  v_skipped_count     INTEGER := 0;
+  v_drift_ids         UUID[] := COALESCE(p_drifted_shift_ids, '{}'::UUID[]);
+BEGIN
+  -- The capability check, not a hardcoded role array: this is exactly what the
+  -- shifts UPDATE policy and the schedule_change_logs INSERT policy require
+  -- (20260730150000_rewrite_collaborator_policies.sql). Hardcoding
+  -- ('owner','manager') would silently strip access from operations_manager and
+  -- the collaborator roles.
+  IF NOT public.user_has_capability(p_restaurant_id, 'edit:scheduling') THEN
+    RAISE EXCEPTION 'Not authorized to edit scheduling for restaurant %', p_restaurant_id
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- The guard above proves only that the caller may edit scheduling AT THE
+  -- RESTAURANT THEY NAMED. It says nothing about whether p_template_id or the
+  -- ids in p_drifted_shift_ids belong to that restaurant, and this function
+  -- bypasses RLS. Every statement below therefore also filters on
+  -- restaurant_id = p_restaurant_id. Starting here: a template id from another
+  -- tenant finds no row and the call becomes a no-op.
+  -- FOR UPDATE: this function reads the old hours here and UPDATEs the same
+  -- template row below. Without the lock, two concurrent cascades on one
+  -- template can both derive the same stale v_old_start/v_old_end, and the
+  -- second to commit retimes its shifts against hours the template no longer
+  -- has -- exactly the template/shift divergence this feature exists to
+  -- eliminate.
+  SELECT t.start_time, t.end_time
+    INTO v_old_start, v_old_end
+  FROM public.shift_templates t
+  WHERE t.id = p_template_id
+    AND t.restaurant_id = p_restaurant_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object(
+      'batch_id', NULL, 'updated_count', 0,
+      'published_shifts', '[]'::jsonb, 'skipped_count', 0
+    );
+  END IF;
+
+  SELECT r.timezone INTO v_tz
+  FROM public.restaurants r
+  WHERE r.id = p_restaurant_id;
+
+  -- 'America/Chicago', NOT the 'UTC' the six sibling scheduling functions use.
+  -- restaurants.timezone is nullable, and the client's safeTz falls back to
+  -- America/Chicago (src/lib/restaurantClock.ts:13,77). Falling back to UTC
+  -- here would put the dialog's preview and this function's re-derived buckets
+  -- in different hours for a null-timezone restaurant, manufacturing exactly
+  -- the drift false-positives this feature exists to avoid. Retiming the other
+  -- six to match is a follow-up with its own blast radius.
+  v_tz := COALESCE(NULLIF(v_tz, ''), 'America/Chicago');
+  BEGIN
+    PERFORM now() AT TIME ZONE v_tz;
+  EXCEPTION WHEN invalid_parameter_value THEN
+    v_tz := 'America/Chicago';
+  END;
+
+  UPDATE public.shift_templates t
+  SET name           = p_name,
+      position       = p_position,
+      area           = p_area,
+      days           = p_days,
+      break_duration = p_break_duration,
+      capacity       = p_capacity,
+      start_time     = p_start_time,
+      end_time       = p_end_time,
+      updated_at     = now()
+  WHERE t.id = p_template_id
+    AND t.restaurant_id = p_restaurant_id;
+
+  IF p_cascade THEN
+    -- Opted-in ids are re-validated, never trusted. Counted BEFORE the UPDATE
+    -- so the predicate sees the same rows the cascade will.
+    SELECT count(*)::int INTO v_skipped_count
+    FROM unnest(v_drift_ids) AS req(id)
+    WHERE NOT EXISTS (
+      SELECT 1 FROM public.shifts s
+      WHERE s.id = req.id
+        AND s.restaurant_id     = p_restaurant_id
+        AND s.shift_template_id = p_template_id
+        AND s.start_time > now()
+        AND s.locked = false
+    );
+
+    -- One statement: all row locks acquired in one go (lock-deadlock-prevention)
+    -- and the transaction stays in milliseconds (lock-short-transactions).
+    --
+    -- `target` produces before_data, and FOR UPDATE is what makes it true.
+    -- Without the lock this CTE reads the statement's snapshot, so a concurrent
+    -- writer that edited a shift between the snapshot and the UPDATE would have
+    -- its edit overwritten AND logged as if it never existed -- Undo would then
+    -- restore the snapshot, not that edit. Under READ COMMITTED, FOR UPDATE
+    -- waits out the other writer, re-evaluates this WHERE against the row
+    -- version it actually locked, and drops rows that no longer qualify. So
+    -- to_jsonb(s.*) below is the row as it stands the instant we own it, and
+    -- prev_start/prev_end (which the notification email renders as "Previous
+    -- Start") describe what the employee was actually looking at.
+    --
+    -- MATERIALIZED is not decoration: it pins the lock-then-read to happen once
+    -- and in full before the UPDATE reads this CTE, rather than leaving that to
+    -- the planner's inlining choice.
+    --
+    -- Deliberately does NOT precompute the new instants: see the UPDATE's SET
+    -- clause for why they come from the UPDATE's own row reference.
+    WITH target AS MATERIALIZED (
+      SELECT
+        s.id,
+        s.employee_id,
+        s.start_time AS prev_start,
+        s.end_time   AS prev_end,
+        s.position   AS prev_position,
+        to_jsonb(s.*) AS before_data
+      FROM public.shifts s
+      WHERE s.restaurant_id     = p_restaurant_id
+        AND s.shift_template_id = p_template_id
+        AND s.start_time > now()          -- Past: payroll has seen these
+        AND s.locked = false              -- Locked: the flag means hands off
+        AND (
+          -- Moves with template: local time-of-day still equals the OLD times
+          (    (s.start_time AT TIME ZONE v_tz)::time = v_old_start
+           AND (s.end_time   AT TIME ZONE v_tz)::time = v_old_end)
+          -- Your call: only the ids the manager explicitly opted into
+          OR s.id = ANY(v_drift_ids)
+        )
+      FOR UPDATE
+    ),
+    updated AS (
+      UPDATE public.shifts s
+      -- RECONSTRUCTED from each shift's own restaurant-local date rather than
+      -- offset by an interval: interval arithmetic preserves elapsed duration
+      -- across a DST boundary, which is the opposite of what a manager typing
+      -- "10:00" means.
+      --
+      -- Derived from `s`, not from `t`. In an UPDATE ... FROM, the SET
+      -- expressions see the row version this statement locked, so
+      -- `s.start_time` is unambiguously the current one. This matters because
+      -- the guards below re-check only ::time, locked, and start_time > now()
+      -- -- none of them pins the DATE, so a concurrent writer that moved this
+      -- shift to a different day while keeping the same local time-of-day
+      -- passes every one of them. `target`'s FOR UPDATE now makes t agree with
+      -- s here, but the date belongs to the row being written, and saying so
+      -- in the SET clause keeps this correct without depending on that.
+      SET start_time = (((s.start_time AT TIME ZONE v_tz)::date || ' ' || p_start_time)::timestamp
+                          AT TIME ZONE v_tz),
+          end_time   = CASE
+            WHEN p_end_time <= p_start_time THEN
+              ((((s.start_time AT TIME ZONE v_tz)::date + 1) || ' ' || p_end_time)::timestamp
+                AT TIME ZONE v_tz)
+            ELSE
+              (((s.start_time AT TIME ZONE v_tz)::date || ' ' || p_end_time)::timestamp
+                AT TIME ZONE v_tz)
+          END,
+          updated_at = now()
+      FROM target t
+      -- Re-checks the same classification guards target already applied to
+      -- s, not just s.id/s.restaurant_id. Under READ COMMITTED, if another
+      -- transaction modified this row between the snapshot and this UPDATE,
+      -- the UPDATE blocks and then re-evaluates its WHERE against the NEW row
+      -- version -- so without repeating the guards a shift another writer
+      -- moved into the past, locked, or hand-edited away from v_old_start/end
+      -- would still get stomped. The drift-ids arm is preserved verbatim: a
+      -- drifted opt-in row by definition fails the time-match arm, so
+      -- dropping it would silently stop cascading every hand-edited shift the
+      -- manager checked.
+      --
+      -- Belt and braces now that `target` locks: the rows are already ours by
+      -- the time this runs, so these can no longer fail from a concurrent
+      -- writer. Kept because they are the only thing standing between a future
+      -- edit to `target` and a silent stomp.
+      WHERE s.id = t.id
+        AND s.restaurant_id = p_restaurant_id
+        AND s.start_time > now()
+        AND s.locked = false
+        AND (
+          (    (s.start_time AT TIME ZONE v_tz)::time = v_old_start
+           AND (s.end_time   AT TIME ZONE v_tz)::time = v_old_end)
+          OR s.id = ANY(v_drift_ids)
+        )
+      RETURNING s.id, s.employee_id, s.is_published,
+                t.before_data, to_jsonb(s.*) AS after_data,
+                t.prev_start, t.prev_end, t.prev_position
+    ),
+    logged AS (
+      -- A data-modifying CTE runs exactly once and to completion whether or not
+      -- the primary query reads it, so this INSERT is not dead.
+      INSERT INTO public.schedule_change_logs (
+        restaurant_id, shift_id, employee_id, change_type, changed_by,
+        before_data, after_data, reason, cascade_batch_id
+      )
+      SELECT p_restaurant_id, u.id, u.employee_id, 'updated', auth.uid(),
+             u.before_data, u.after_data, 'Template hours cascade', v_batch_id
+      FROM updated u
+      RETURNING 1
+    )
+    -- Counts from RETURNING, not GET DIAGNOSTICS: once the UPDATE feeds a CTE,
+    -- GET DIAGNOSTICS reports the ENCLOSING statement's row count.
+    --
+    -- to_jsonb(prev_start) on the typed timestamptz column, not
+    -- before_data->>'start_time': ->> yields Postgres' space-separated text
+    -- rendering, while to_jsonb of a timestamptz yields ISO-8601 with a T,
+    -- which is what the edge function's formatDateTime can parse.
+    SELECT count(*)::int,
+           COALESCE(
+             jsonb_agg(
+               jsonb_build_object(
+                 'id', id,
+                 'previous_start_time', to_jsonb(prev_start),
+                 'previous_end_time',   to_jsonb(prev_end),
+                 'previous_position',   prev_position
+               )
+             ) FILTER (WHERE is_published),
+             '[]'::jsonb
+           )
+      INTO v_updated_count, v_published_shifts
+    FROM updated;
+
+    -- Only when shifts actually moved: that is precisely when the RETURN below
+    -- hands back a non-NULL batch_id and the client offers Undo. A header for a
+    -- batch that moved nothing would be an unreachable row.
+    IF v_updated_count > 0 THEN
+      INSERT INTO public.template_hours_cascade_batches (
+        id, restaurant_id, shift_template_id,
+        before_start_time, before_end_time, after_start_time, after_end_time, changed_by
+      )
+      VALUES (
+        v_batch_id, p_restaurant_id, p_template_id,
+        -- v_old_start/v_old_end were captured at the FOR UPDATE read above, before
+        -- this function's own UPDATE overwrote the template row.
+        v_old_start, v_old_end, p_start_time, p_end_time, auth.uid()
+      );
+    END IF;
+  END IF;
+
+  RETURN jsonb_build_object(
+    -- NULL when nothing moved, so the client knows not to offer Undo.
+    'batch_id',         CASE WHEN v_updated_count > 0 THEN v_batch_id ELSE NULL END,
+    'updated_count',    v_updated_count,
+    'published_shifts', v_published_shifts,
+    'skipped_count',    v_skipped_count
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.update_shift_template_with_cascade(UUID, UUID, TEXT, TEXT, TEXT, INTEGER[], INTEGER, INTEGER, TIME, TIME, BOOLEAN, UUID[]) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.update_shift_template_with_cascade(UUID, UUID, TEXT, TEXT, TEXT, INTEGER[], INTEGER, INTEGER, TIME, TIME, BOOLEAN, UUID[]) TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.update_shift_template_with_cascade(UUID, UUID, TEXT, TEXT, TEXT, INTEGER[], INTEGER, INTEGER, TIME, TIME, BOOLEAN, UUID[]) IS
+  'Updates a shift template and, when p_cascade, retimes the future unlocked '
+  'shifts whose restaurant-local hours still match the template''s previous '
+  'hours, plus any drifted shifts named in p_drifted_shift_ids (re-validated '
+  'server-side). Past and locked shifts are never touched. Tags its audit rows '
+  'with a cascade_batch_id so undo_template_hours_cascade can revert the batch, '
+  'and writes a template_hours_cascade_batches header (when shifts actually '
+  'moved) recording the template''s own before/after hours for that revert.';
+
+-- ---------------------------------------------------------------------------
+-- Part C: undo_template_hours_cascade -- restore the template's own hours
+-- ---------------------------------------------------------------------------
+--
+-- The cascade is reversible, which is why the dialog needs no acknowledgement
+-- checkbox. Two skip conditions are reported separately rather than lumped
+-- together, because they mean different things to the manager reading the toast.
+CREATE OR REPLACE FUNCTION public.undo_template_hours_cascade(
+  p_batch_id      UUID,
+  p_restaurant_id UUID
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_restored_count      INTEGER := 0;
+  v_changed_since_count INTEGER := 0;
+  v_deleted_count       INTEGER := 0;
+  v_protected_count     INTEGER := 0;
+  v_template_id            UUID;
+  v_before_start           TIME;
+  v_before_end              TIME;
+  v_after_start             TIME;
+  v_after_end               TIME;
+  v_cur_start               TIME;
+  v_cur_end                 TIME;
+  -- Explicitly false, not plpgsql's NULL default: the legacy-batch path and the
+  -- p_batch_id IS NULL early return both fall through without assigning these,
+  -- and a null in the returned JSONB would diverge from what the client types.
+  v_template_restored      BOOLEAN := false;
+  v_template_changed_since BOOLEAN := false;
+BEGIN
+  IF NOT public.user_has_capability(p_restaurant_id, 'edit:scheduling') THEN
+    RAISE EXCEPTION 'Not authorized to edit scheduling for restaurant %', p_restaurant_id
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  -- LOAD-BEARING. Every predicate below scopes with plain `cascade_batch_id =
+  -- p_batch_id`, not IS NOT DISTINCT FROM -- equality is what lets the
+  -- planner use idx_schedule_change_logs_cascade_batch, a partial index
+  -- WHERE cascade_batch_id IS NOT NULL that an IS NOT DISTINCT FROM probe
+  -- cannot use (confirmed via EXPLAIN: that operator forced a full scan of
+  -- schedule_change_logs). Untagged rows -- including the ones
+  -- log_shift_change writes with cascade_batch_id NULL -- must stay invisible
+  -- to the revert; plain `=` already guarantees that on its own, since NULL
+  -- never equals anything, so a NULL cascade_batch_id can never satisfy
+  -- `= p_batch_id` regardless of what p_batch_id holds. The early return
+  -- below is a separate guard, not a substitute for that: it stops a caller
+  -- from treating "no batch" as a valid revert target instead of silently
+  -- running three queries that would each match zero rows.
+  IF p_batch_id IS NULL THEN
+    RETURN jsonb_build_object(
+      'restored_count', 0, 'changed_since_count', 0, 'deleted_count', 0,
+      'protected_count', 0, 'template_restored', false,
+      'template_changed_since', false
+    );
+  END IF;
+
+  -- Deleted since. schedule_change_logs.shift_id is NOT a foreign key --
+  -- 20260617120000_fix_schedule_change_logs_delete_fk.sql:38-44 dropped the
+  -- constraint precisely so a 'deleted' audit row keeps the id of a shift that
+  -- no longer exists. So `shift_id IS NULL` never fires and NOT EXISTS is the
+  -- only correct probe.
+  SELECT count(*)::int INTO v_deleted_count
+  FROM public.schedule_change_logs l
+  WHERE l.cascade_batch_id = p_batch_id
+    AND l.restaurant_id = p_restaurant_id
+    AND NOT EXISTS (
+      SELECT 1 FROM public.shifts s
+      WHERE s.id = l.shift_id
+        AND s.restaurant_id = p_restaurant_id
+    );
+
+  -- Changed since: the row still exists but its times no longer match what the
+  -- cascade wrote, so someone edited it in between. Blindly restoring would
+  -- destroy a newer, deliberate edit.
+  SELECT count(*)::int INTO v_changed_since_count
+  FROM public.schedule_change_logs l
+  JOIN public.shifts s
+    ON s.id = l.shift_id
+   AND s.restaurant_id = p_restaurant_id
+  WHERE l.cascade_batch_id = p_batch_id
+    AND l.restaurant_id = p_restaurant_id
+    AND (   s.start_time IS DISTINCT FROM (l.after_data->>'start_time')::timestamptz
+         OR s.end_time   IS DISTINCT FROM (l.after_data->>'end_time')::timestamptz);
+
+  -- Protected since: the row still holds exactly what the cascade wrote, so it
+  -- WOULD be restored -- but it has become locked, or its start has crossed
+  -- into the past, since the cascade ran. The cascade refuses both (line ~190:
+  -- `locked` means hands off; past shifts are payroll-visible), and Undo has to
+  -- refuse them for the same reasons or the flag and the payroll boundary mean
+  -- nothing the moment a toast is on screen. Counted separately so the toast
+  -- can say why these did not come back instead of quietly folding them into
+  -- restored_count.
+  SELECT count(*)::int INTO v_protected_count
+  FROM public.schedule_change_logs l
+  JOIN public.shifts s
+    ON s.id = l.shift_id
+   AND s.restaurant_id = p_restaurant_id
+  WHERE l.cascade_batch_id = p_batch_id
+    AND l.restaurant_id = p_restaurant_id
+    AND s.start_time IS NOT DISTINCT FROM (l.after_data->>'start_time')::timestamptz
+    AND s.end_time   IS NOT DISTINCT FROM (l.after_data->>'end_time')::timestamptz
+    AND (s.locked OR s.start_time <= now());
+
+  -- Restore the template's own hours. Without this the template keeps the hours
+  -- the cascade wrote while its shifts go back to the old ones, and every later
+  -- edit measures those shifts against a baseline they no longer share -- which
+  -- classifies them as drifted forever. That desync is the bug this migration exists
+  -- to fix.
+  --
+  -- Placed BEFORE the shifts UPDATE so this function acquires shift_templates then
+  -- shifts, the same order update_shift_template_with_cascade uses (its FOR UPDATE
+  -- on the template precedes the `target` CTE's FOR UPDATE on the shifts). Consistent
+  -- lock ordering is what keeps a concurrent cascade and undo from deadlocking.
+  SELECT b.shift_template_id, b.before_start_time, b.before_end_time,
+         b.after_start_time,  b.after_end_time
+    INTO v_template_id, v_before_start, v_before_end, v_after_start, v_after_end
+  FROM public.template_hours_cascade_batches b
+  WHERE b.id = p_batch_id
+    AND b.restaurant_id = p_restaurant_id;
+
+  -- No header: a batch from before this migration. Revert the shifts as before and
+  -- leave both flags false. Not an error.
+  IF FOUND THEN
+    SELECT t.start_time, t.end_time
+      INTO v_cur_start, v_cur_end
+    FROM public.shift_templates t
+    WHERE t.id = v_template_id
+      AND t.restaurant_id = p_restaurant_id
+    FOR UPDATE;
+
+    IF FOUND THEN
+      -- The same "still holds exactly what the cascade wrote" guard the shift revert
+      -- applies below. Plain `=` rather than IS NOT DISTINCT FROM because
+      -- shift_templates.start_time/end_time are TIME NOT NULL, unlike the shift
+      -- columns. If a manager edited the template's hours after the cascade, that is
+      -- a newer deliberate decision and Undo declines rather than destroying it.
+      IF v_cur_start = v_after_start AND v_cur_end = v_after_end THEN
+        UPDATE public.shift_templates
+        SET start_time = v_before_start,
+            end_time   = v_before_end,
+            updated_at = now()
+        WHERE id = v_template_id
+          AND restaurant_id = p_restaurant_id;
+        v_template_restored := true;
+      ELSE
+        v_template_changed_since := true;
+      END IF;
+    END IF;
+  END IF;
+
+  WITH reverted AS (
+    UPDATE public.shifts s
+    SET start_time = (l.before_data->>'start_time')::timestamptz,
+        end_time   = (l.before_data->>'end_time')::timestamptz,
+        updated_at = now()
+    FROM public.schedule_change_logs l
+    WHERE l.cascade_batch_id = p_batch_id
+      AND l.restaurant_id = p_restaurant_id
+      AND s.id = l.shift_id
+      AND s.restaurant_id = p_restaurant_id
+      AND s.start_time IS NOT DISTINCT FROM (l.after_data->>'start_time')::timestamptz
+      AND s.end_time   IS NOT DISTINCT FROM (l.after_data->>'end_time')::timestamptz
+      -- Same two guards the cascade UPDATE applies. Without them Undo is a
+      -- privileged writer that the `locked` flag and the past-shift boundary
+      -- do not bind -- it would rewrite a shift the manager locked after the
+      -- cascade, and one that payroll can already see. v_protected_count above
+      -- counts exactly the rows these two lines exclude.
+      AND s.locked = false
+      AND s.start_time > now()
+    RETURNING s.id, s.employee_id,
+              l.after_data  AS undone_after,
+              l.before_data AS undone_before
+  ),
+  logged AS (
+    -- cascade_batch_id stays NULL on the undo's own rows. Tagging them with
+    -- p_batch_id would make a second Undo click try to revert the revert.
+    -- As written, a second click finds the original rows, sees current !=
+    -- after_data, and reports them as changed-since -- safe, and honest.
+    INSERT INTO public.schedule_change_logs (
+      restaurant_id, shift_id, employee_id, change_type, changed_by,
+      before_data, after_data, reason, cascade_batch_id
+    )
+    SELECT p_restaurant_id, r.id, r.employee_id, 'updated', auth.uid(),
+           r.undone_after, r.undone_before, 'Undo template hours cascade', NULL
+    FROM reverted r
+    RETURNING 1
+  )
+  SELECT count(*)::int INTO v_restored_count FROM reverted;
+
+  RETURN jsonb_build_object(
+    'restored_count',      v_restored_count,
+    'changed_since_count', v_changed_since_count,
+    'deleted_count',       v_deleted_count,
+    'protected_count',     v_protected_count,
+    'template_restored',      v_template_restored,
+    'template_changed_since', v_template_changed_since
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.undo_template_hours_cascade(UUID, UUID) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.undo_template_hours_cascade(UUID, UUID) TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.undo_template_hours_cascade(UUID, UUID) IS
+  'Reverts the shifts moved by one update_shift_template_with_cascade call, '
+  'identified by cascade_batch_id, restoring each from its logged before_data, '
+  'and restores the template''s own hours from the batch header when the '
+  'template still holds exactly what that cascade wrote. Skips shifts edited, '
+  'deleted, locked, or started since the cascade and reports each of those '
+  'counts separately, plus template_restored/template_changed_since for the '
+  'template itself. Batches from before this migration have no header row and '
+  'both template flags come back false.';

--- a/supabase/migrations/20260805160000_template_cascade_undo_restores_template.sql
+++ b/supabase/migrations/20260805160000_template_cascade_undo_restores_template.sql
@@ -360,6 +360,7 @@ DECLARE
   -- and a null in the returned JSONB would diverge from what the client types.
   v_template_restored      BOOLEAN := false;
   v_template_changed_since BOOLEAN := false;
+  v_template_slot_conflict BOOLEAN := false;
 BEGIN
   IF NOT public.user_has_capability(p_restaurant_id, 'edit:scheduling') THEN
     RAISE EXCEPTION 'Not authorized to edit scheduling for restaurant %', p_restaurant_id
@@ -383,7 +384,7 @@ BEGIN
     RETURN jsonb_build_object(
       'restored_count', 0, 'changed_since_count', 0, 'deleted_count', 0,
       'protected_count', 0, 'template_restored', false,
-      'template_changed_since', false
+      'template_changed_since', false, 'template_slot_conflict', false
     );
   END IF;
 
@@ -468,13 +469,30 @@ BEGIN
       -- columns. If a manager edited the template's hours after the cascade, that is
       -- a newer deliberate decision and Undo declines rather than destroying it.
       IF v_cur_start = v_after_start AND v_cur_end = v_after_end THEN
-        UPDATE public.shift_templates
-        SET start_time = v_before_start,
-            end_time   = v_before_end,
-            updated_at = now()
-        WHERE id = v_template_id
-          AND restaurant_id = p_restaurant_id;
-        v_template_restored := true;
+        -- Subtransaction, deliberately. uq_shift_templates_active_slot is unique on
+        -- (restaurant_id, position, start_time, end_time, days, coalesce(area,''))
+        -- WHERE is_active -- so the cascade FREED this template's original slot, and
+        -- another manager may have created an active template in it since. Restoring
+        -- would then raise 23505, and without this block that error propagates out of
+        -- the function and aborts the whole transaction: none of the shifts get
+        -- reverted and the manager sees a raw constraint error instead of the Undo
+        -- they asked for. A BEGIN/EXCEPTION block rolls back only its own work, so
+        -- the shift revert below still runs and the template is reported as skipped --
+        -- the same "decline safely and say so" contract as template_changed_since.
+        BEGIN
+          UPDATE public.shift_templates
+          SET start_time = v_before_start,
+              end_time   = v_before_end,
+              updated_at = now()
+          WHERE id = v_template_id
+            AND restaurant_id = p_restaurant_id;
+          v_template_restored := true;
+        EXCEPTION WHEN unique_violation THEN
+          -- Distinct from template_changed_since: nobody touched THIS template, so
+          -- telling the manager its hours changed would send them to look at the
+          -- wrong record. Something else now occupies the slot.
+          v_template_slot_conflict := true;
+        END;
       ELSE
         v_template_changed_since := true;
       END IF;
@@ -526,7 +544,8 @@ BEGIN
     'deleted_count',       v_deleted_count,
     'protected_count',     v_protected_count,
     'template_restored',      v_template_restored,
-    'template_changed_since', v_template_changed_since
+    'template_changed_since', v_template_changed_since,
+    'template_slot_conflict', v_template_slot_conflict
   );
 END;
 $$;
@@ -540,6 +559,8 @@ COMMENT ON FUNCTION public.undo_template_hours_cascade(UUID, UUID) IS
   'and restores the template''s own hours from the batch header when the '
   'template still holds exactly what that cascade wrote. Skips shifts edited, '
   'deleted, locked, or started since the cascade and reports each of those '
-  'counts separately, plus template_restored/template_changed_since for the '
-  'template itself. Batches from before this migration have no header row and '
-  'both template flags come back false.';
+  'counts separately, plus template_restored/template_changed_since/'
+  'template_slot_conflict for the template itself -- the last when another active '
+  'template has taken the freed uq_shift_templates_active_slot, which is skipped '
+  'rather than aborting the shift revert. Batches from before this migration have '
+  'no header row and all three template flags come back false.';

--- a/supabase/tests/template_hours_cascade.test.sql
+++ b/supabase/tests/template_hours_cascade.test.sql
@@ -1,6 +1,8 @@
 -- pgTAP for update_shift_template_with_cascade (Task 1) and
 -- undo_template_hours_cascade (Task 2), from
--- supabase/migrations/20260804130000_template_hours_cascade.sql.
+-- supabase/migrations/20260804130000_template_hours_cascade.sql, plus the
+-- template-restore behavior of undo_template_hours_cascade from
+-- supabase/migrations/20260805160000_template_cascade_undo_restores_template.sql.
 --
 -- What makes this suite non-vacuous:
 --   * The Tokyo block proves drift detection reads the RESTAURANT's wall clock.
@@ -24,7 +26,7 @@
 
 BEGIN;
 
-SELECT plan(34);
+SELECT plan(46);
 
 -- ============================================
 -- Setup
@@ -597,6 +599,310 @@ SELECT is(
   (SELECT (start_time AT TIME ZONE 'America/Chicago')::time FROM shifts WHERE id = '11000000-0000-0000-0000-0000000000a5'),
   '09:00'::time,
   'undo still restores the eligible shifts in a batch that has a protected one'
+);
+
+-- ============================================
+-- Undo restores the template's hours (Bug 1)
+-- ============================================
+--
+-- Six fresh templates, each on its own singleton `days` value so none can
+-- collide with each other or with A-E on uq_shift_templates_active_slot
+-- (restaurant_id, position, start_time, end_time, days, area) regardless of
+-- what hours a given call rewrites them to.
+
+-- ---- Happy path: cascade, undo, recascade (Tests 35-38, 40-41) ----
+
+INSERT INTO shift_templates (id, restaurant_id, name, days, start_time, end_time, break_duration, position, capacity, is_active, area) VALUES
+  ('e1000000-0000-4000-8000-000000000001', 'c0000000-0000-0000-0000-0000000ca001', 'Undo case', '{1,2}', '10:00', '16:30', 0, 'Server', 1, true, NULL)
+ON CONFLICT (id) DO UPDATE
+  SET restaurant_id = EXCLUDED.restaurant_id, days = EXCLUDED.days,
+      start_time = EXCLUDED.start_time, end_time = EXCLUDED.end_time, area = EXCLUDED.area;
+
+INSERT INTO shifts (id, restaurant_id, employee_id, shift_template_id, start_time, end_time, position, locked, is_published)
+SELECT * FROM (VALUES
+  ('e1000000-0000-4000-8000-000000000011'::uuid, 'c0000000-0000-0000-0000-0000000ca001'::uuid, 'e0000000-0000-0000-0000-0000000ca001'::uuid, 'e1000000-0000-4000-8000-000000000001'::uuid,
+   ((SELECT mon FROM test_config)::timestamp + interval '10 hours')                   AT TIME ZONE 'America/Chicago',
+   ((SELECT mon FROM test_config)::timestamp + interval '16 hours 30 minutes')        AT TIME ZONE 'America/Chicago', 'Server', false, false),
+  ('e1000000-0000-4000-8000-000000000012'::uuid, 'c0000000-0000-0000-0000-0000000ca001'::uuid, 'e0000000-0000-0000-0000-0000000ca001'::uuid, 'e1000000-0000-4000-8000-000000000001'::uuid,
+   (((SELECT mon FROM test_config) + 1)::timestamp + interval '10 hours')             AT TIME ZONE 'America/Chicago',
+   (((SELECT mon FROM test_config) + 1)::timestamp + interval '16 hours 30 minutes')  AT TIME ZONE 'America/Chicago', 'Server', false, false)
+) AS v
+ON CONFLICT (id) DO NOTHING;
+
+-- Cascade: end 16:30 -> 17:30
+CREATE TEMP TABLE undo_cascade_1 AS
+SELECT public.update_shift_template_with_cascade(
+  'e1000000-0000-4000-8000-000000000001', 'c0000000-0000-0000-0000-0000000ca001',
+  'Undo case', 'Server', NULL, '{1,2}'::int[], 0, 1,
+  '10:00'::time, '17:30'::time, true, '{}'::uuid[]
+) AS result;
+
+-- Test 35: a header row was written for this batch
+SELECT is(
+  (SELECT count(*)::int FROM template_hours_cascade_batches
+   WHERE id = (SELECT (result->>'batch_id')::uuid FROM undo_cascade_1)),
+  1,
+  'cascade writes one batch header row'
+);
+
+-- Test 36: the header records the template hours from BEFORE the edit
+SELECT results_eq(
+  $q$SELECT before_start_time, before_end_time, after_start_time, after_end_time
+     FROM template_hours_cascade_batches
+     WHERE id = (SELECT (result->>'batch_id')::uuid FROM undo_cascade_1)$q$,
+  $q$VALUES ('10:00'::time, '16:30'::time, '10:00'::time, '17:30'::time)$q$,
+  'header records before and after template hours'
+);
+
+CREATE TEMP TABLE undo_result_1 AS
+SELECT public.undo_template_hours_cascade(
+  (SELECT (result->>'batch_id')::uuid FROM undo_cascade_1), 'c0000000-0000-0000-0000-0000000ca001'
+) AS result;
+
+-- Test 37: the template is back to its pre-cascade hours
+SELECT results_eq(
+  $q$SELECT start_time, end_time FROM shift_templates
+     WHERE id = 'e1000000-0000-4000-8000-000000000001'$q$,
+  $q$VALUES ('10:00'::time, '16:30'::time)$q$,
+  'undo restores the template hours'
+);
+
+-- Test 38: and says so
+SELECT results_eq(
+  $q$SELECT (SELECT (result->>'template_restored')::boolean FROM undo_result_1),
+            (SELECT (result->>'template_changed_since')::boolean FROM undo_result_1)$q$,
+  $q$VALUES (true, false)$q$,
+  'undo reports template_restored true and template_changed_since false on the happy path'
+);
+
+-- Test 39 -- legacy batch: a schedule_change_logs row tagged with a batch id
+-- that has no header row (i.e. from before this migration). Undo must not
+-- error, and both new flags come back false.
+INSERT INTO schedule_change_logs (restaurant_id, shift_id, employee_id, change_type, changed_by, before_data, after_data, reason, cascade_batch_id)
+VALUES (
+  'c0000000-0000-0000-0000-0000000ca001', 'e1000000-0000-4000-8000-000000000011',
+  'e0000000-0000-0000-0000-0000000ca001', 'updated', 'a11ce000-0000-0000-0000-0000000ca001',
+  '{}'::jsonb, '{}'::jsonb, 'legacy batch (no header row)', 'f9000000-0000-4000-8000-000000000099'
+);
+
+CREATE TEMP TABLE undo_legacy AS
+SELECT public.undo_template_hours_cascade(
+  'f9000000-0000-4000-8000-000000000099', 'c0000000-0000-0000-0000-0000000ca001'
+) AS result;
+
+SELECT results_eq(
+  $q$SELECT (SELECT (result->>'template_restored')::boolean FROM undo_legacy),
+            (SELECT (result->>'template_changed_since')::boolean FROM undo_legacy)$q$,
+  $q$VALUES (false, false)$q$,
+  'a legacy batch with no header row reverts shifts as before and reports both new flags false'
+);
+
+-- Test 40: THE REPORTED BUG. A second cascade after the undo must move the shifts.
+CREATE TEMP TABLE recascade_1 AS
+SELECT public.update_shift_template_with_cascade(
+  'e1000000-0000-4000-8000-000000000001', 'c0000000-0000-0000-0000-0000000ca001',
+  'Undo case', 'Server', NULL, '{1,2}'::int[], 0, 1,
+  '11:00'::time, '18:30'::time, true, '{}'::uuid[]
+) AS result;
+
+SELECT is(
+  (SELECT (result->>'updated_count')::int FROM recascade_1),
+  2,
+  'a cascade after an undo still moves the shifts (the reported bug)'
+);
+
+-- Test 41: and the shifts really hold the new local hours
+SELECT is(
+  (SELECT count(*)::int FROM shifts
+   WHERE shift_template_id = 'e1000000-0000-4000-8000-000000000001'
+     AND (start_time AT TIME ZONE 'America/Chicago')::time = '11:00'
+     AND (end_time   AT TIME ZONE 'America/Chicago')::time = '18:30'),
+  2,
+  'both shifts sit at the re-cascaded hours'
+);
+
+-- ---- Test 42: template changed since ----
+
+INSERT INTO shift_templates (id, restaurant_id, name, days, start_time, end_time, break_duration, position, capacity, is_active, area) VALUES
+  ('e1000000-0000-4000-8000-000000000002', 'c0000000-0000-0000-0000-0000000ca001', 'Changed since case', '{3}', '07:00', '15:00', 0, 'Server', 1, true, NULL)
+ON CONFLICT (id) DO UPDATE
+  SET restaurant_id = EXCLUDED.restaurant_id, days = EXCLUDED.days,
+      start_time = EXCLUDED.start_time, end_time = EXCLUDED.end_time, area = EXCLUDED.area;
+
+INSERT INTO shifts (id, restaurant_id, employee_id, shift_template_id, start_time, end_time, position, locked, is_published)
+SELECT * FROM (VALUES
+  ('e1000000-0000-4000-8000-000000000021'::uuid, 'c0000000-0000-0000-0000-0000000ca001'::uuid, 'e0000000-0000-0000-0000-0000000ca001'::uuid, 'e1000000-0000-4000-8000-000000000002'::uuid,
+   (((SELECT mon FROM test_config) + 2)::timestamp + interval '7 hours')  AT TIME ZONE 'America/Chicago',
+   (((SELECT mon FROM test_config) + 2)::timestamp + interval '15 hours') AT TIME ZONE 'America/Chicago', 'Server', false, false)
+) AS v
+ON CONFLICT (id) DO NOTHING;
+
+CREATE TEMP TABLE cascade_42 AS
+SELECT public.update_shift_template_with_cascade(
+  'e1000000-0000-4000-8000-000000000002', 'c0000000-0000-0000-0000-0000000ca001',
+  'Changed since case', 'Server', NULL, '{3}'::int[], 0, 1,
+  '10:00'::time, '18:00'::time, true, '{}'::uuid[]
+) AS result;
+
+-- A manager edits the template's hours by hand after the cascade, before
+-- anyone clicks Undo.
+UPDATE shift_templates SET start_time = '09:00'::time
+WHERE id = 'e1000000-0000-4000-8000-000000000002';
+
+CREATE TEMP TABLE undo_42 AS
+SELECT public.undo_template_hours_cascade(
+  (SELECT (result->>'batch_id')::uuid FROM cascade_42), 'c0000000-0000-0000-0000-0000000ca001'
+) AS result;
+
+SELECT results_eq(
+  $q$SELECT (SELECT start_time FROM shift_templates WHERE id = 'e1000000-0000-4000-8000-000000000002'),
+            (SELECT (result->>'template_restored')::boolean FROM undo_42),
+            (SELECT (result->>'template_changed_since')::boolean FROM undo_42)$q$,
+  $q$VALUES ('09:00'::time, false, true)$q$,
+  'undo declines to restore a template hand-edited since the cascade, and reports template_changed_since'
+);
+
+-- ---- Test 43: template restored even when every shift is protected ----
+
+INSERT INTO shift_templates (id, restaurant_id, name, days, start_time, end_time, break_duration, position, capacity, is_active, area) VALUES
+  ('e1000000-0000-4000-8000-000000000003', 'c0000000-0000-0000-0000-0000000ca001', 'All-locked case', '{4}', '07:00', '15:00', 0, 'Server', 1, true, NULL)
+ON CONFLICT (id) DO UPDATE
+  SET restaurant_id = EXCLUDED.restaurant_id, days = EXCLUDED.days,
+      start_time = EXCLUDED.start_time, end_time = EXCLUDED.end_time, area = EXCLUDED.area;
+
+INSERT INTO shifts (id, restaurant_id, employee_id, shift_template_id, start_time, end_time, position, locked, is_published)
+SELECT * FROM (VALUES
+  ('e1000000-0000-4000-8000-000000000031'::uuid, 'c0000000-0000-0000-0000-0000000ca001'::uuid, 'e0000000-0000-0000-0000-0000000ca001'::uuid, 'e1000000-0000-4000-8000-000000000003'::uuid,
+   (((SELECT mon FROM test_config) + 3)::timestamp + interval '7 hours')  AT TIME ZONE 'America/Chicago',
+   (((SELECT mon FROM test_config) + 3)::timestamp + interval '15 hours') AT TIME ZONE 'America/Chicago', 'Server', false, false)
+) AS v
+ON CONFLICT (id) DO NOTHING;
+
+CREATE TEMP TABLE cascade_43 AS
+SELECT public.update_shift_template_with_cascade(
+  'e1000000-0000-4000-8000-000000000003', 'c0000000-0000-0000-0000-0000000ca001',
+  'All-locked case', 'Server', NULL, '{4}'::int[], 0, 1,
+  '08:00'::time, '16:00'::time, true, '{}'::uuid[]
+) AS result;
+
+-- The manager locks the shift after seeing it cascade, before clicking Undo.
+UPDATE shifts SET locked = true WHERE id = 'e1000000-0000-4000-8000-000000000031';
+
+CREATE TEMP TABLE undo_43 AS
+SELECT public.undo_template_hours_cascade(
+  (SELECT (result->>'batch_id')::uuid FROM cascade_43), 'c0000000-0000-0000-0000-0000000ca001'
+) AS result;
+
+SELECT results_eq(
+  $q$SELECT (SELECT (result->>'restored_count')::int FROM undo_43),
+            (SELECT (result->>'template_restored')::boolean FROM undo_43)$q$,
+  $q$VALUES (0, true)$q$,
+  'the template comes back even when every one of its shifts is protected'
+);
+
+-- ---- Test 44: no header when nothing moved ----
+
+INSERT INTO shift_templates (id, restaurant_id, name, days, start_time, end_time, break_duration, position, capacity, is_active, area) VALUES
+  ('e1000000-0000-4000-8000-000000000004', 'c0000000-0000-0000-0000-0000000ca001', 'Locked-only case', '{5}', '07:00', '15:00', 0, 'Server', 1, true, NULL)
+ON CONFLICT (id) DO UPDATE
+  SET restaurant_id = EXCLUDED.restaurant_id, days = EXCLUDED.days,
+      start_time = EXCLUDED.start_time, end_time = EXCLUDED.end_time, area = EXCLUDED.area;
+
+-- Locked BEFORE the cascade call, so it never enters the `target` CTE at all.
+INSERT INTO shifts (id, restaurant_id, employee_id, shift_template_id, start_time, end_time, position, locked, is_published)
+SELECT * FROM (VALUES
+  ('e1000000-0000-4000-8000-000000000041'::uuid, 'c0000000-0000-0000-0000-0000000ca001'::uuid, 'e0000000-0000-0000-0000-0000000ca001'::uuid, 'e1000000-0000-4000-8000-000000000004'::uuid,
+   (((SELECT mon FROM test_config) + 4)::timestamp + interval '7 hours')  AT TIME ZONE 'America/Chicago',
+   (((SELECT mon FROM test_config) + 4)::timestamp + interval '15 hours') AT TIME ZONE 'America/Chicago', 'Server', true, false)
+) AS v
+ON CONFLICT (id) DO NOTHING;
+
+CREATE TEMP TABLE header_count_before_44 AS
+SELECT count(*)::int AS n FROM template_hours_cascade_batches;
+
+CREATE TEMP TABLE cascade_44 AS
+SELECT public.update_shift_template_with_cascade(
+  'e1000000-0000-4000-8000-000000000004', 'c0000000-0000-0000-0000-0000000ca001',
+  'Locked-only case', 'Server', NULL, '{5}'::int[], 0, 1,
+  '08:00'::time, '16:00'::time, true, '{}'::uuid[]
+) AS result;
+
+SELECT results_eq(
+  $q$SELECT (SELECT (result->>'batch_id') FROM cascade_44),
+            (SELECT count(*)::int FROM template_hours_cascade_batches)$q$,
+  $q$SELECT (SELECT NULL::text), (SELECT n FROM header_count_before_44)$q$,
+  'a cascade whose only linked shift is locked writes no batch header'
+);
+
+-- ---- Test 45: tenant isolation ----
+--
+-- recascade_1's batch belongs to restaurant A (Chicago). The Tokyo owner is
+-- authorized at restaurant B (the capability guard passes), but hands over
+-- Chicago's batch id -- the per-statement restaurant_id scoping must still
+-- keep it out.
+SELECT set_config('request.jwt.claims',
+  '{"sub":"a11ce000-0000-0000-0000-0000000ca002","role":"authenticated"}', true);
+
+CREATE TEMP TABLE undo_45 AS
+SELECT public.undo_template_hours_cascade(
+  (SELECT (result->>'batch_id')::uuid FROM recascade_1), 'c0000000-0000-0000-0000-0000000ca002'
+) AS result;
+
+SELECT results_eq(
+  $q$SELECT (SELECT start_time FROM shift_templates WHERE id = 'e1000000-0000-4000-8000-000000000001'),
+            (SELECT end_time   FROM shift_templates WHERE id = 'e1000000-0000-4000-8000-000000000001'),
+            (SELECT (result->>'template_restored')::boolean FROM undo_45)$q$,
+  $q$VALUES ('11:00'::time, '18:30'::time, false)$q$,
+  'a batch id from another restaurant leaves restaurant A''s template untouched'
+);
+
+SELECT set_config('request.jwt.claims',
+  '{"sub":"a11ce000-0000-0000-0000-0000000ca001","role":"authenticated"}', true);
+
+-- ---- Test 46: superseded batch ----
+
+INSERT INTO shift_templates (id, restaurant_id, name, days, start_time, end_time, break_duration, position, capacity, is_active, area) VALUES
+  ('e1000000-0000-4000-8000-000000000005', 'c0000000-0000-0000-0000-0000000ca001', 'Superseded case', '{6}', '07:00', '08:00', 0, 'Server', 1, true, NULL)
+ON CONFLICT (id) DO UPDATE
+  SET restaurant_id = EXCLUDED.restaurant_id, days = EXCLUDED.days,
+      start_time = EXCLUDED.start_time, end_time = EXCLUDED.end_time, area = EXCLUDED.area;
+
+INSERT INTO shifts (id, restaurant_id, employee_id, shift_template_id, start_time, end_time, position, locked, is_published)
+SELECT * FROM (VALUES
+  ('e1000000-0000-4000-8000-000000000051'::uuid, 'c0000000-0000-0000-0000-0000000ca001'::uuid, 'e0000000-0000-0000-0000-0000000ca001'::uuid, 'e1000000-0000-4000-8000-000000000005'::uuid,
+   (((SELECT mon FROM test_config) + 5)::timestamp + interval '7 hours') AT TIME ZONE 'America/Chicago',
+   (((SELECT mon FROM test_config) + 5)::timestamp + interval '8 hours') AT TIME ZONE 'America/Chicago', 'Server', false, false)
+) AS v
+ON CONFLICT (id) DO NOTHING;
+
+-- Cascade X: 07:00-08:00 -> 10:00-11:00
+CREATE TEMP TABLE cascade_x_46 AS
+SELECT public.update_shift_template_with_cascade(
+  'e1000000-0000-4000-8000-000000000005', 'c0000000-0000-0000-0000-0000000ca001',
+  'Superseded case', 'Server', NULL, '{6}'::int[], 0, 1,
+  '10:00'::time, '11:00'::time, true, '{}'::uuid[]
+) AS result;
+
+-- Cascade Y, same template: 10:00-11:00 -> 11:00-12:00. The shift still
+-- matches X's after-hours exactly, so Y moves it again.
+CREATE TEMP TABLE cascade_y_46 AS
+SELECT public.update_shift_template_with_cascade(
+  'e1000000-0000-4000-8000-000000000005', 'c0000000-0000-0000-0000-0000000ca001',
+  'Superseded case', 'Server', NULL, '{6}'::int[], 0, 1,
+  '11:00'::time, '12:00'::time, true, '{}'::uuid[]
+) AS result;
+
+CREATE TEMP TABLE undo_x_46 AS
+SELECT public.undo_template_hours_cascade(
+  (SELECT (result->>'batch_id')::uuid FROM cascade_x_46), 'c0000000-0000-0000-0000-0000000ca001'
+) AS result;
+
+SELECT results_eq(
+  $q$SELECT (SELECT end_time FROM shift_templates WHERE id = 'e1000000-0000-4000-8000-000000000005'),
+            (SELECT (result->>'template_changed_since')::boolean FROM undo_x_46),
+            (SELECT (result->>'changed_since_count')::int FROM undo_x_46)$q$,
+  $q$VALUES ('12:00'::time, true, 1)$q$,
+  'undoing a superseded batch leaves the newer cascade''s hours in place and reports changed_since'
 );
 
 SELECT * FROM finish();

--- a/supabase/tests/template_hours_cascade.test.sql
+++ b/supabase/tests/template_hours_cascade.test.sql
@@ -26,7 +26,7 @@
 
 BEGIN;
 
-SELECT plan(46);
+SELECT plan(48);
 
 -- ============================================
 -- Setup
@@ -903,6 +903,69 @@ SELECT results_eq(
             (SELECT (result->>'changed_since_count')::int FROM undo_x_46)$q$,
   $q$VALUES ('12:00'::time, true, 1)$q$,
   'undoing a superseded batch leaves the newer cascade''s hours in place and reports changed_since'
+);
+
+-- ---- Tests 47-48: the freed slot was taken by another template ----
+--
+-- uq_shift_templates_active_slot is UNIQUE on (restaurant_id, position,
+-- start_time, end_time, days, coalesce(area,'')) WHERE is_active. A cascade
+-- therefore FREES the template's original hours, and nothing stops another
+-- manager from creating an active template there before the Undo lands. Without
+-- the subtransaction in undo_template_hours_cascade, the restore raises 23505,
+-- that error escapes the function, and the whole transaction aborts -- the
+-- manager gets a raw constraint error and NOT ONE of their shifts is reverted.
+--
+-- The position is unique to this block on purpose: it is part of the unique key,
+-- so no other fixture in this file can perturb the collision being tested.
+INSERT INTO shift_templates (id, restaurant_id, name, days, start_time, end_time, break_duration, position, capacity, is_active, area) VALUES
+  ('e1000000-0000-4000-8000-000000000006', 'c0000000-0000-0000-0000-0000000ca001', 'Slot conflict case', '{3}', '07:00', '08:00', 0, 'Slot Conflict Cook', 1, true, NULL)
+ON CONFLICT (id) DO UPDATE
+  SET restaurant_id = EXCLUDED.restaurant_id, days = EXCLUDED.days,
+      start_time = EXCLUDED.start_time, end_time = EXCLUDED.end_time, area = EXCLUDED.area;
+
+INSERT INTO shifts (id, restaurant_id, employee_id, shift_template_id, start_time, end_time, position, locked, is_published)
+SELECT * FROM (VALUES
+  ('e1000000-0000-4000-8000-000000000061'::uuid, 'c0000000-0000-0000-0000-0000000ca001'::uuid, 'e0000000-0000-0000-0000-0000000ca001'::uuid, 'e1000000-0000-4000-8000-000000000006'::uuid,
+   (((SELECT mon FROM test_config) + 2)::timestamp + interval '7 hours') AT TIME ZONE 'America/Chicago',
+   (((SELECT mon FROM test_config) + 2)::timestamp + interval '8 hours') AT TIME ZONE 'America/Chicago', 'Slot Conflict Cook', false, false)
+) AS v
+ON CONFLICT (id) DO NOTHING;
+
+-- 07:00-08:00 -> 09:00-10:00, freeing 07:00-08:00.
+CREATE TEMP TABLE cascade_47 AS
+SELECT public.update_shift_template_with_cascade(
+  'e1000000-0000-4000-8000-000000000006', 'c0000000-0000-0000-0000-0000000ca001',
+  'Slot conflict case', 'Slot Conflict Cook', NULL, '{3}'::int[], 0, 1,
+  '09:00'::time, '10:00'::time, true, '{}'::uuid[]
+) AS result;
+
+-- The squatter. Same restaurant, position, days and area, sitting in exactly the
+-- hours the Undo wants to give back.
+INSERT INTO shift_templates (id, restaurant_id, name, days, start_time, end_time, break_duration, position, capacity, is_active, area) VALUES
+  ('e1000000-0000-4000-8000-000000000007', 'c0000000-0000-0000-0000-0000000ca001', 'Slot squatter', '{3}', '07:00', '08:00', 0, 'Slot Conflict Cook', 1, true, NULL)
+ON CONFLICT (id) DO NOTHING;
+
+CREATE TEMP TABLE undo_47 AS
+SELECT public.undo_template_hours_cascade(
+  (SELECT (result->>'batch_id')::uuid FROM cascade_47), 'c0000000-0000-0000-0000-0000000ca001'
+) AS result;
+
+SELECT results_eq(
+  $q$SELECT (SELECT (result->>'template_restored')::boolean      FROM undo_47),
+            (SELECT (result->>'template_slot_conflict')::boolean FROM undo_47),
+            (SELECT (result->>'template_changed_since')::boolean FROM undo_47),
+            (SELECT start_time FROM shift_templates WHERE id = 'e1000000-0000-4000-8000-000000000006')$q$,
+  $q$VALUES (false, true, false, '09:00'::time)$q$,
+  'undo reports template_slot_conflict and leaves the template where the cascade put it'
+);
+
+-- The point of the subtransaction: the shift revert must survive the collision.
+SELECT results_eq(
+  $q$SELECT (SELECT (result->>'restored_count')::int FROM undo_47),
+            (SELECT (start_time AT TIME ZONE 'America/Chicago')::time
+               FROM shifts WHERE id = 'e1000000-0000-4000-8000-000000000061')$q$,
+  $q$VALUES (1, '07:00'::time)$q$,
+  'the shift is still reverted even though the template restore hit the unique index'
 );
 
 SELECT * FROM finish();

--- a/tests/e2e/template-hours-cascade.spec.ts
+++ b/tests/e2e/template-hours-cascade.spec.ts
@@ -615,7 +615,22 @@ test.describe('template hours cascade', () => {
       new RegExp(`${pickedDrift.employeeName} — ${pickedDrift.localDate}`, 'i')
     );
     await expect(pickedCheckbox).toBeVisible({ timeout: 5000 });
-    await pickedCheckbox.check();
+    // With no "moving" section above it (shiftCount: 0), the checkbox row
+    // lands close enough to the bottom of the scrollable dialog body that
+    // Playwright's default scroll-into-view centers it right under the
+    // sticky footer (TemplateFormDialog.tsx's `DialogFooter`), which then
+    // intercepts the click. Center it explicitly first.
+    await pickedCheckbox.evaluate((el) => el.scrollIntoView({ block: 'center' }));
+    // Not `.check()`, and no post-click assertion on the checkbox itself:
+    // the instant this tick makes `totalAffected > 0`, `driftDefaultOpen`
+    // (TemplateHoursImpact.tsx) recomputes to false and the drift disclosure
+    // — which was only ever open by that default, never by an explicit
+    // manual toggle — collapses again, unmounting the checkbox. That is the
+    // panel doing exactly what Task 4 specifies ("open when it's the only
+    // thing to do"; picking one means it no longer is), not a bug to work
+    // around here. The button-label assertions below are what confirm the
+    // pick actually registered.
+    await pickedCheckbox.click();
 
     const cascadeButton = dialog.getByRole('button', { name: 'Save & update 1 shift' });
     await expect(cascadeButton).toBeVisible({ timeout: 5000 });

--- a/tests/e2e/template-hours-cascade.spec.ts
+++ b/tests/e2e/template-hours-cascade.spec.ts
@@ -46,6 +46,23 @@ async function setRestaurantTimezone(page: import('@playwright/test').Page, rest
   expect(result.stored).toBe(TIMEZONE);
 }
 
+/**
+ * Opens a template row's action menu.
+ *
+ * The trigger is `opacity-0 group-hover:opacity-100` and lives inside the row,
+ * so hovering the button itself satisfies the group-hover — there is no need to
+ * reach for the row's `.group` utility class, which is a Tailwind
+ * implementation detail rather than anything the user perceives.
+ */
+async function openTemplateActions(
+  page: import('@playwright/test').Page,
+  templateName: string
+) {
+  const actionsButton = page.getByRole('button', { name: `Actions for ${templateName}` });
+  await actionsButton.hover();
+  await actionsButton.click();
+}
+
 /** Reads a shift's `start_time`/`end_time` straight from Supabase, bypassing the UI. */
 async function fetchShiftTimes(
   page: import('@playwright/test').Page,
@@ -96,11 +113,7 @@ test.describe('template hours cascade', () => {
     await expect(page.getByText(template.name)).toBeVisible({ timeout: 15000 });
 
     // Row actions are hover-revealed — hover the row, then Actions -> Edit.
-    const templateRow = page.locator('.group', { has: page.getByText(template.name) }).first();
-    await templateRow.hover();
-    const actionsButton = page.getByRole('button', { name: `Actions for ${template.name}` });
-    await expect(actionsButton).toBeVisible({ timeout: 5000 });
-    await actionsButton.click();
+    await openTemplateActions(page, template.name);
     await page.getByRole('menuitem', { name: 'Edit', exact: true }).click();
 
     const dialog = page.getByRole('dialog');
@@ -177,11 +190,7 @@ test.describe('template hours cascade', () => {
 
     await expect(page.getByText(template.name)).toBeVisible({ timeout: 15000 });
 
-    const templateRow = page.locator('.group', { has: page.getByText(template.name) }).first();
-    await templateRow.hover();
-    const actionsButton = page.getByRole('button', { name: `Actions for ${template.name}` });
-    await expect(actionsButton).toBeVisible({ timeout: 5000 });
-    await actionsButton.click();
+    await openTemplateActions(page, template.name);
     await page.getByRole('menuitem', { name: 'Edit', exact: true }).click();
 
     const dialog = page.getByRole('dialog');
@@ -238,11 +247,7 @@ test.describe('template hours cascade', () => {
 
     await expect(page.getByText(template.name)).toBeVisible({ timeout: 15000 });
 
-    const templateRow = page.locator('.group', { has: page.getByText(template.name) }).first();
-    await templateRow.hover();
-    const actionsButton = page.getByRole('button', { name: `Actions for ${template.name}` });
-    await expect(actionsButton).toBeVisible({ timeout: 5000 });
-    await actionsButton.click();
+    await openTemplateActions(page, template.name);
     await page.getByRole('menuitem', { name: 'Edit', exact: true }).click();
 
     const dialog = page.getByRole('dialog');
@@ -340,11 +345,7 @@ test.describe('template hours cascade', () => {
 
     await expect(page.getByText(template.name)).toBeVisible({ timeout: 15000 });
 
-    const templateRow = page.locator('.group', { has: page.getByText(template.name) }).first();
-    await templateRow.hover();
-    const actionsButton = page.getByRole('button', { name: `Actions for ${template.name}` });
-    await expect(actionsButton).toBeVisible({ timeout: 5000 });
-    await actionsButton.click();
+    await openTemplateActions(page, template.name);
     await page.getByRole('menuitem', { name: 'Edit', exact: true }).click();
 
     const dialog = page.getByRole('dialog');
@@ -416,11 +417,7 @@ test.describe('template hours cascade', () => {
 
     await expect(page.getByText(template.name)).toBeVisible({ timeout: 15000 });
 
-    const templateRow = page.locator('.group', { has: page.getByText(template.name) }).first();
-    await templateRow.hover();
-    const actionsButton = page.getByRole('button', { name: `Actions for ${template.name}` });
-    await expect(actionsButton).toBeVisible({ timeout: 5000 });
-    await actionsButton.click();
+    await openTemplateActions(page, template.name);
     await page.getByRole('menuitem', { name: 'Edit', exact: true }).click();
 
     const dialog = page.getByRole('dialog');
@@ -494,13 +491,8 @@ test.describe('template hours cascade', () => {
 
     await expect(page.getByText(template.name)).toBeVisible({ timeout: 15000 });
 
-    const templateRow = page.locator('.group', { has: page.getByText(template.name) }).first();
-    const actionsButton = page.getByRole('button', { name: `Actions for ${template.name}` });
-
     const openEditDialog = async () => {
-      await templateRow.hover();
-      await expect(actionsButton).toBeVisible({ timeout: 5000 });
-      await actionsButton.click();
+      await openTemplateActions(page, template.name);
       await page.getByRole('menuitem', { name: 'Edit', exact: true }).click();
       const editDialog = page.getByRole('dialog');
       await expect(editDialog).toBeVisible();
@@ -614,11 +606,7 @@ test.describe('template hours cascade', () => {
 
     await expect(page.getByText(template.name)).toBeVisible({ timeout: 15000 });
 
-    const templateRow = page.locator('.group', { has: page.getByText(template.name) }).first();
-    await templateRow.hover();
-    const actionsButton = page.getByRole('button', { name: `Actions for ${template.name}` });
-    await expect(actionsButton).toBeVisible({ timeout: 5000 });
-    await actionsButton.click();
+    await openTemplateActions(page, template.name);
     await page.getByRole('menuitem', { name: 'Edit', exact: true }).click();
 
     const dialog = page.getByRole('dialog');

--- a/tests/e2e/template-hours-cascade.spec.ts
+++ b/tests/e2e/template-hours-cascade.spec.ts
@@ -446,4 +446,218 @@ test.describe('template hours cascade', () => {
       expect(localHHMM(shift.end_time)).toBe('17:00');
     }
   });
+
+  test('a cascade after an undo still moves the shifts', async ({ page }) => {
+    const user = generateTestUser('cascade-redo-after-undo');
+    await signUpAndCreateRestaurant(page, user);
+    await exposeSupabaseHelpers(page);
+
+    const restaurantId = await page.evaluate(() => (window as any).__getRestaurantId());
+    expect(restaurantId).toBeTruthy();
+    await setRestaurantTimezone(page, restaurantId as string);
+
+    const { template } = await seedTemplateWithShifts(page, restaurantId as string, {
+      start_time: '10:00',
+      end_time: '16:30',
+      shiftCount: 2,
+      timezone: TIMEZONE,
+    });
+
+    await page.goto('/scheduling');
+    await page.waitForURL(/\/scheduling/, { timeout: 8000 });
+    await page.getByRole('tab', { name: /planner/i }).click();
+
+    await expect(page.getByText(template.name)).toBeVisible({ timeout: 15000 });
+
+    const templateRow = page.locator('.group', { has: page.getByText(template.name) }).first();
+    const actionsButton = page.getByRole('button', { name: `Actions for ${template.name}` });
+
+    const openEditDialog = async () => {
+      await templateRow.hover();
+      await expect(actionsButton).toBeVisible({ timeout: 5000 });
+      await actionsButton.click();
+      await page.getByRole('menuitem', { name: 'Edit', exact: true }).click();
+      const editDialog = page.getByRole('dialog');
+      await expect(editDialog).toBeVisible();
+      return editDialog;
+    };
+
+    // 1. Cascade 10:00-16:30 -> 10:00-17:30.
+    let dialog = await openEditDialog();
+    await dialog.getByLabel('Start Time').fill('10:00');
+    await dialog.getByLabel('End Time').fill('17:30');
+
+    const firstCascadeButton = dialog.getByRole('button', { name: 'Save & update 2 shifts' });
+    await expect(firstCascadeButton).toBeVisible({ timeout: 5000 });
+    await firstCascadeButton.click();
+
+    await expect(page.getByText('2 shifts moved to the new hours.').first()).toBeVisible({ timeout: 10000 });
+    await expect(dialog).not.toBeVisible({ timeout: 10000 });
+
+    // 2. Undo — the toast's own Undo button, not the header's account menu.
+    const undoButton = page.getByRole('button', { name: 'Undo', exact: true });
+    await expect(undoButton).toBeVisible();
+    await undoButton.click();
+    await expect(page.getByText('Restored 2 shifts.').first()).toBeVisible({ timeout: 10000 });
+
+    const afterUndo = await page.evaluate(
+      async (args: { restId: string; templateId: string }) => {
+        const supabase = (window as any).__supabase;
+        const { data, error } = await supabase
+          .from('shifts')
+          .select('start_time, end_time')
+          .eq('restaurant_id', args.restId)
+          .eq('shift_template_id', args.templateId)
+          .order('start_time');
+        if (error) throw new Error(error.message);
+        return data as { start_time: string; end_time: string }[];
+      },
+      { restId: restaurantId as string, templateId: template.id }
+    );
+    expect(afterUndo).toHaveLength(2);
+    for (const shift of afterUndo) {
+      expect(localHHMM(shift.start_time)).toBe('10:00');
+      expect(localHHMM(shift.end_time)).toBe('16:30');
+    }
+
+    // 3. Edit hours again: 10:00 -> 11:00. Before Task 1's fix, the undo left the
+    // template row itself desynced (only the shifts were restored, not the
+    // template's own start/end columns), so re-opening this dialog would
+    // reclassify both shifts as hand-edited drift and the primary button would
+    // read the plain "Save changes" instead of a cascade count.
+    dialog = await openEditDialog();
+    await expect(dialog.getByLabel('Start Time')).toHaveValue('10:00');
+    await expect(dialog.getByLabel('End Time')).toHaveValue('16:30');
+    await dialog.getByLabel('Start Time').fill('11:00');
+
+    const secondCascadeButton = dialog.getByRole('button', { name: 'Save & update 2 shifts' });
+    await expect(secondCascadeButton).toBeVisible({ timeout: 5000 });
+    await secondCascadeButton.click();
+
+    await expect(page.getByText('2 shifts moved to the new hours.').first()).toBeVisible({ timeout: 10000 });
+    await expect(dialog).not.toBeVisible({ timeout: 10000 });
+
+    const finalShifts = await page.evaluate(
+      async (args: { restId: string; templateId: string }) => {
+        const supabase = (window as any).__supabase;
+        const { data, error } = await supabase
+          .from('shifts')
+          .select('start_time, end_time')
+          .eq('restaurant_id', args.restId)
+          .eq('shift_template_id', args.templateId)
+          .order('start_time');
+        if (error) throw new Error(error.message);
+        return data as { start_time: string; end_time: string }[];
+      },
+      { restId: restaurantId as string, templateId: template.id }
+    );
+    expect(finalShifts).toHaveLength(2);
+    for (const shift of finalShifts) {
+      expect(localHHMM(shift.start_time)).toBe('11:00');
+      expect(localHHMM(shift.end_time)).toBe('16:30');
+    }
+  });
+
+  test('a manager can pick hand-edited shifts into the cascade', async ({ page }) => {
+    const user = generateTestUser('cascade-drift-panel-open');
+    await signUpAndCreateRestaurant(page, user);
+    await exposeSupabaseHelpers(page);
+
+    const restaurantId = await page.evaluate(() => (window as any).__getRestaurantId());
+    expect(restaurantId).toBeTruthy();
+    await setRestaurantTimezone(page, restaurantId as string);
+
+    // No "moving" shifts at all — both linked shifts are hand-edited away from
+    // the template's hours, so before the cascade is even edited there is
+    // nothing to move, and the drift picks are the only action available.
+    const { template, driftedShifts } = await seedTemplateWithShifts(page, restaurantId as string, {
+      start_time: '09:00',
+      end_time: '17:00',
+      shiftCount: 0,
+      driftedShifts: [
+        { start_time: '11:00', end_time: '19:00', employeeName: 'Casey Chicago' },
+        { start_time: '12:00', end_time: '20:00', employeeName: 'Drew Dallas' },
+      ],
+      timezone: TIMEZONE,
+    });
+    expect(driftedShifts).toHaveLength(2);
+    const [pickedDrift, untouchedDrift] = driftedShifts;
+
+    await page.goto('/scheduling');
+    await page.waitForURL(/\/scheduling/, { timeout: 8000 });
+    await page.getByRole('tab', { name: /planner/i }).click();
+
+    await expect(page.getByText(template.name)).toBeVisible({ timeout: 15000 });
+
+    const templateRow = page.locator('.group', { has: page.getByText(template.name) }).first();
+    await templateRow.hover();
+    const actionsButton = page.getByRole('button', { name: `Actions for ${template.name}` });
+    await expect(actionsButton).toBeVisible({ timeout: 5000 });
+    await actionsButton.click();
+    await page.getByRole('menuitem', { name: 'Edit', exact: true }).click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    await dialog.getByLabel('Start Time').fill('10:00');
+    await dialog.getByLabel('End Time').fill('18:00');
+
+    // Nothing moves on its own — the collapsed summary names the drifted
+    // shifts as the only thing the manager can act on.
+    await expect(dialog.getByRole('button', { name: 'Save changes' })).toBeVisible({ timeout: 5000 });
+    await expect(dialog.getByText(/hand-edited shifts you can pick/i)).toBeVisible();
+
+    // Expand the outer summary — this is the only click. The drift picker
+    // opens on its own (Task 4) because there is nothing else to disclose.
+    await dialog.getByRole('button', { name: /shift moves|shifts move/i }).click();
+
+    const pickedCheckbox = dialog.getByLabel(
+      new RegExp(`${pickedDrift.employeeName} — ${pickedDrift.localDate}`, 'i')
+    );
+    await expect(pickedCheckbox).toBeVisible({ timeout: 5000 });
+    await pickedCheckbox.check();
+
+    const cascadeButton = dialog.getByRole('button', { name: 'Save & update 1 shift' });
+    await expect(cascadeButton).toBeVisible({ timeout: 5000 });
+    await expect(dialog.getByRole('button', { name: 'Template only' })).toBeVisible();
+    await cascadeButton.click();
+
+    await expect(page.getByText('1 shift moved to the new hours.').first()).toBeVisible({ timeout: 10000 });
+    await expect(dialog).not.toBeVisible({ timeout: 10000 });
+
+    const [pickedRow, untouchedRow] = await Promise.all([
+      page.evaluate(
+        async (shiftId: string) => {
+          const supabase = (window as any).__supabase;
+          const { data, error } = await supabase
+            .from('shifts')
+            .select('start_time, end_time')
+            .eq('id', shiftId)
+            .single();
+          if (error) throw new Error(error.message);
+          return data as { start_time: string; end_time: string };
+        },
+        pickedDrift.shiftId
+      ),
+      page.evaluate(
+        async (shiftId: string) => {
+          const supabase = (window as any).__supabase;
+          const { data, error } = await supabase
+            .from('shifts')
+            .select('start_time, end_time')
+            .eq('id', shiftId)
+            .single();
+          if (error) throw new Error(error.message);
+          return data as { start_time: string; end_time: string };
+        },
+        untouchedDrift.shiftId
+      ),
+    ]);
+
+    expect(localHHMM(pickedRow.start_time)).toBe('10:00');
+    expect(localHHMM(pickedRow.end_time)).toBe('18:00');
+
+    expect(untouchedRow.start_time).toBe(untouchedDrift.startTime);
+    expect(untouchedRow.end_time).toBe(untouchedDrift.endTime);
+  });
 });

--- a/tests/e2e/template-hours-cascade.spec.ts
+++ b/tests/e2e/template-hours-cascade.spec.ts
@@ -46,6 +46,26 @@ async function setRestaurantTimezone(page: import('@playwright/test').Page, rest
   expect(result.stored).toBe(TIMEZONE);
 }
 
+/** Reads a shift's `start_time`/`end_time` straight from Supabase, bypassing the UI. */
+async function fetchShiftTimes(
+  page: import('@playwright/test').Page,
+  shiftId: string
+): Promise<{ start_time: string; end_time: string }> {
+  return page.evaluate(
+    async (id: string) => {
+      const supabase = (window as any).__supabase;
+      const { data, error } = await supabase
+        .from('shifts')
+        .select('start_time, end_time')
+        .eq('id', id)
+        .single();
+      if (error) throw new Error(error.message);
+      return data as { start_time: string; end_time: string };
+    },
+    shiftId
+  );
+}
+
 test.describe('template hours cascade', () => {
   test("moving a template's hours moves the linked shifts", async ({ page }) => {
     const user = generateTestUser('cascade-happy');
@@ -621,16 +641,24 @@ test.describe('template hours cascade', () => {
     // sticky footer (TemplateFormDialog.tsx's `DialogFooter`), which then
     // intercepts the click. Center it explicitly first.
     await pickedCheckbox.evaluate((el) => el.scrollIntoView({ block: 'center' }));
-    // Not `.check()`, and no post-click assertion on the checkbox itself:
-    // the instant this tick makes `totalAffected > 0`, `driftDefaultOpen`
-    // (TemplateHoursImpact.tsx) recomputes to false and the drift disclosure
-    // — which was only ever open by that default, never by an explicit
-    // manual toggle — collapses again, unmounting the checkbox. That is the
-    // panel doing exactly what Task 4 specifies ("open when it's the only
-    // thing to do"; picking one means it no longer is), not a bug to work
-    // around here. The button-label assertions below are what confirm the
-    // pick actually registered.
+    // Not `.check()`: `.check()`'s click-then-verify retry loop fights the
+    // row's plain toggle semantics (`onCheckedChange` flips a Set, it does
+    // not accept Radix's boolean argument), so a single `.click()` is used
+    // instead.
     await pickedCheckbox.click();
+
+    // The still-unpicked drifted shift's checkbox stays reachable after the
+    // first pick. Ticking Casey's checkbox makes `ledger.totalAffected` go
+    // from 0 to 1 on the next render, which used to collapse this
+    // disclosure (it was only ever open by the "nothing else to do"
+    // default, never by an explicit manual toggle) and hide Drew's
+    // still-unpicked checkbox behind a second click — see
+    // TemplateHoursImpact.tsx's `onCheckedChange` handler, which now latches
+    // the disclosure open on the first tick.
+    const untouchedCheckbox = dialog.getByLabel(
+      new RegExp(`${untouchedDrift.employeeName} — ${untouchedDrift.localDate}`, 'i')
+    );
+    await expect(untouchedCheckbox).toBeVisible({ timeout: 5000 });
 
     const cascadeButton = dialog.getByRole('button', { name: 'Save & update 1 shift' });
     await expect(cascadeButton).toBeVisible({ timeout: 5000 });
@@ -641,32 +669,8 @@ test.describe('template hours cascade', () => {
     await expect(dialog).not.toBeVisible({ timeout: 10000 });
 
     const [pickedRow, untouchedRow] = await Promise.all([
-      page.evaluate(
-        async (shiftId: string) => {
-          const supabase = (window as any).__supabase;
-          const { data, error } = await supabase
-            .from('shifts')
-            .select('start_time, end_time')
-            .eq('id', shiftId)
-            .single();
-          if (error) throw new Error(error.message);
-          return data as { start_time: string; end_time: string };
-        },
-        pickedDrift.shiftId
-      ),
-      page.evaluate(
-        async (shiftId: string) => {
-          const supabase = (window as any).__supabase;
-          const { data, error } = await supabase
-            .from('shifts')
-            .select('start_time, end_time')
-            .eq('id', shiftId)
-            .single();
-          if (error) throw new Error(error.message);
-          return data as { start_time: string; end_time: string };
-        },
-        untouchedDrift.shiftId
-      ),
+      fetchShiftTimes(page, pickedDrift.shiftId),
+      fetchShiftTimes(page, untouchedDrift.shiftId),
     ]);
 
     expect(localHHMM(pickedRow.start_time)).toBe('10:00');

--- a/tests/e2e/template-hours-cascade.spec.ts
+++ b/tests/e2e/template-hours-cascade.spec.ts
@@ -49,20 +49,25 @@ async function setRestaurantTimezone(page: import('@playwright/test').Page, rest
 /** Reads a shift's `start_time`/`end_time` straight from Supabase, bypassing the UI. */
 async function fetchShiftTimes(
   page: import('@playwright/test').Page,
+  restaurantId: string,
   shiftId: string
 ): Promise<{ start_time: string; end_time: string }> {
   return page.evaluate(
-    async (id: string) => {
+    // Filtered on restaurant_id as well as the primary key: every query in this
+    // codebase is tenant-scoped, and a test that reads across tenants would pass
+    // even if a cascade leaked into someone else's shifts.
+    async (args: { restId: string; id: string }) => {
       const supabase = (window as any).__supabase;
       const { data, error } = await supabase
         .from('shifts')
         .select('start_time, end_time')
-        .eq('id', id)
+        .eq('restaurant_id', args.restId)
+        .eq('id', args.id)
         .single();
       if (error) throw new Error(error.message);
       return data as { start_time: string; end_time: string };
     },
-    shiftId
+    { restId: restaurantId, id: shiftId }
   );
 }
 
@@ -669,8 +674,8 @@ test.describe('template hours cascade', () => {
     await expect(dialog).not.toBeVisible({ timeout: 10000 });
 
     const [pickedRow, untouchedRow] = await Promise.all([
-      fetchShiftTimes(page, pickedDrift.shiftId),
-      fetchShiftTimes(page, untouchedDrift.shiftId),
+      fetchShiftTimes(page, restaurantId as string, pickedDrift.shiftId),
+      fetchShiftTimes(page, restaurantId as string, untouchedDrift.shiftId),
     ]);
 
     expect(localHHMM(pickedRow.start_time)).toBe('10:00');

--- a/tests/unit/hoursChangeCopy.test.ts
+++ b/tests/unit/hoursChangeCopy.test.ts
@@ -159,6 +159,44 @@ describe('buildHoursChangeLedger', () => {
   });
 });
 
+describe('buildHoursChangeLedger summary — pickable drift', () => {
+  it('names the pickable shifts when nothing would move', () => {
+    const ledger = buildHoursChangeLedger({
+      ...BASE, movingCount: 0, driftedCount: 3, selectedDriftCount: 0, publishedCount: 0,
+    });
+    expect(ledger.summary).toContain('0 shifts move.');
+    expect(ledger.summary).toContain('3 hand-edited shifts you can pick.');
+  });
+
+  it('uses the singular for one pickable shift', () => {
+    const ledger = buildHoursChangeLedger({
+      ...BASE, movingCount: 0, driftedCount: 1, selectedDriftCount: 0,
+    });
+    expect(ledger.summary).toContain('1 hand-edited shift you can pick.');
+  });
+
+  it('drops the clause once something is moving', () => {
+    const ledger = buildHoursChangeLedger({
+      ...BASE, movingCount: 0, driftedCount: 3, selectedDriftCount: 1,
+    });
+    expect(ledger.summary).not.toContain('you can pick');
+  });
+
+  it('drops the clause when shifts already move on their own', () => {
+    const ledger = buildHoursChangeLedger({
+      ...BASE, movingCount: 2, driftedCount: 3, selectedDriftCount: 0,
+    });
+    expect(ledger.summary).not.toContain('you can pick');
+  });
+
+  it('leaves the past/locked-only summary alone', () => {
+    const ledger = buildHoursChangeLedger({
+      ...BASE, movingCount: 0, driftedCount: 0, pastCount: 2, lockedCount: 1,
+    });
+    expect(ledger.summary).not.toContain('you can pick');
+  });
+});
+
 describe('describeCascadeShortfall', () => {
   it('reports the gap when fewer shifts were updated than promised', () => {
     expect(describeCascadeShortfall(3, 2)).toBe(

--- a/tests/unit/templateHoursImpact.test.tsx
+++ b/tests/unit/templateHoursImpact.test.tsx
@@ -18,7 +18,24 @@ const drifted = [
   },
 ];
 
-function renderPanel(overrides: { movingCount: number; selectedDriftCount: number }) {
+const twoDrifted = [
+  ...drifted,
+  {
+    shiftId: 's2',
+    employeeName: 'Grace',
+    localDate: 'Tue Aug 11',
+    currentStart: '11:00',
+    currentEnd: '19:00',
+    isPublished: false,
+    hoursDelta: 0,
+  },
+];
+
+function renderPanel(
+  overrides: { movingCount: number; selectedDriftCount: number; driftedCount?: number },
+  options: { drifted?: typeof drifted; selectedDriftIds?: Set<string>; onToggleDrift?: (id: string) => void } = {}
+) {
+  const { driftedCount = 1, ...ledgerOverrides } = overrides;
   const ledger = buildHoursChangeLedger({
     oldStart: '10:00',
     oldEnd: '16:30',
@@ -27,16 +44,16 @@ function renderPanel(overrides: { movingCount: number; selectedDriftCount: numbe
     publishedCount: 0,
     pastCount: 0,
     lockedCount: 0,
-    driftedCount: 1,
+    driftedCount,
     hoursDelta: 0,
-    ...overrides,
+    ...ledgerOverrides,
   });
   return render(
     <TemplateHoursImpact
       ledger={ledger}
-      drifted={drifted}
-      selectedDriftIds={new Set()}
-      onToggleDrift={() => {}}
+      drifted={options.drifted ?? drifted}
+      selectedDriftIds={options.selectedDriftIds ?? new Set()}
+      onToggleDrift={options.onToggleDrift ?? (() => {})}
       publishedCount={0}
       notify={false}
       onNotifyChange={() => {}}
@@ -75,5 +92,56 @@ describe('TemplateHoursImpact drift disclosure default', () => {
     // with the count instead of the severity label.
     await user.click(screen.getByRole('button', { name: /^\d+ hand-edited/i }));
     expect(screen.queryByRole('checkbox', { name: /Ada/ })).not.toBeInTheDocument();
+  });
+
+  it('keeps the remaining checkboxes visible after picking the first of several drifted shifts', async () => {
+    const user = userEvent.setup();
+    const selectedDriftIds = new Set<string>();
+    const onToggleDrift = (id: string) => selectedDriftIds.add(id);
+    const { rerender } = renderPanel(
+      { movingCount: 0, selectedDriftCount: 0, driftedCount: 2 },
+      { drifted: twoDrifted, selectedDriftIds }
+    );
+    await user.click(screen.getByRole('button', { name: /shifts? move/i }));
+    // Both drifted shifts are reachable via the default-open disclosure.
+    expect(screen.getByRole('checkbox', { name: /Ada/ })).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: /Grace/ })).toBeInTheDocument();
+
+    await user.click(screen.getByRole('checkbox', { name: /Ada/ }));
+
+    // Ticking Ada bumps `totalAffected` from 0 to 1 on the next render -- the
+    // regression this test guards against collapsed the disclosure right here,
+    // hiding Grace's still-unpicked checkbox.
+    rerender(
+      <TemplateHoursImpact
+        ledger={buildHoursChangeLedger({
+          oldStart: '10:00',
+          oldEnd: '16:30',
+          newStart: '11:00',
+          newEnd: '17:30',
+          publishedCount: 0,
+          pastCount: 0,
+          lockedCount: 0,
+          driftedCount: 2,
+          hoursDelta: 0,
+          movingCount: 0,
+          selectedDriftCount: 1,
+        })}
+        drifted={twoDrifted}
+        selectedDriftIds={selectedDriftIds}
+        onToggleDrift={onToggleDrift}
+        publishedCount={0}
+        notify={false}
+        onNotifyChange={() => {}}
+        isLoading={false}
+        error={null}
+        oldStart="10:00"
+        oldEnd="16:30"
+        newStart="11:00"
+        newEnd="17:30"
+      />
+    );
+
+    expect(screen.getByRole('checkbox', { name: /Grace/ })).toBeInTheDocument();
   });
 });

--- a/tests/unit/templateHoursImpact.test.tsx
+++ b/tests/unit/templateHoursImpact.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+
+import { TemplateHoursImpact } from '@/components/scheduling/ShiftPlanner/TemplateHoursImpact';
+import { buildHoursChangeLedger } from '@/lib/scheduling/hoursChangeCopy';
+
+const drifted = [
+  {
+    shiftId: 's1',
+    employeeName: 'Ada',
+    localDate: 'Mon Aug 10',
+    currentStart: '11:00',
+    currentEnd: '19:00',
+    isPublished: false,
+    hoursDelta: 0,
+  },
+];
+
+function renderPanel(overrides: { movingCount: number; selectedDriftCount: number }) {
+  const ledger = buildHoursChangeLedger({
+    oldStart: '10:00',
+    oldEnd: '16:30',
+    newStart: '11:00',
+    newEnd: '17:30',
+    publishedCount: 0,
+    pastCount: 0,
+    lockedCount: 0,
+    driftedCount: 1,
+    hoursDelta: 0,
+    ...overrides,
+  });
+  return render(
+    <TemplateHoursImpact
+      ledger={ledger}
+      drifted={drifted}
+      selectedDriftIds={new Set()}
+      onToggleDrift={() => {}}
+      publishedCount={0}
+      notify={false}
+      onNotifyChange={() => {}}
+      isLoading={false}
+      error={null}
+      oldStart="10:00"
+      oldEnd="16:30"
+      newStart="11:00"
+      newEnd="17:30"
+    />
+  );
+}
+
+describe('TemplateHoursImpact drift disclosure default', () => {
+  it('opens the drift disclosure when nothing else would move', async () => {
+    const user = userEvent.setup();
+    renderPanel({ movingCount: 0, selectedDriftCount: 0 });
+    // The outer panel is collapsed by design; open it.
+    await user.click(screen.getByRole('button', { name: /shifts? move/i }));
+    expect(screen.getByRole('checkbox', { name: /Ada/ })).toBeInTheDocument();
+  });
+
+  it('leaves the drift disclosure closed when shifts already move', async () => {
+    const user = userEvent.setup();
+    renderPanel({ movingCount: 2, selectedDriftCount: 0 });
+    await user.click(screen.getByRole('button', { name: /shifts? move/i }));
+    expect(screen.queryByRole('checkbox', { name: /Ada/ })).not.toBeInTheDocument();
+  });
+
+  it('lets a manual toggle win over the default', async () => {
+    const user = userEvent.setup();
+    renderPanel({ movingCount: 0, selectedDriftCount: 0 });
+    await user.click(screen.getByRole('button', { name: /shifts? move/i }));
+    // The outer summary line also names the pickable shifts as "hand-edited"
+    // (Task 3), so anchor to the drift disclosure's own trigger, which starts
+    // with the count instead of the severity label.
+    await user.click(screen.getByRole('button', { name: /^\d+ hand-edited/i }));
+    expect(screen.queryByRole('checkbox', { name: /Ada/ })).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/useShiftTemplates.test.ts
+++ b/tests/unit/useShiftTemplates.test.ts
@@ -1227,6 +1227,41 @@ describe('useShiftTemplates', () => {
       );
     });
 
+    it('distinguishes a taken template slot from the template being edited', async () => {
+      // Nobody touched this template — another active template moved into the
+      // hours it is trying to return to, and uq_shift_templates_active_slot
+      // blocked the restore. Reporting that as "template hours changed since"
+      // would send the manager to inspect a record that never changed.
+      const { undoAction } = await triggerCascadeAndClickUndo();
+
+      vi.mocked(supabase.rpc).mockResolvedValueOnce({
+        data: {
+          restored_count: 2,
+          changed_since_count: 0,
+          deleted_count: 0,
+          protected_count: 0,
+          template_restored: false,
+          template_changed_since: false,
+          template_slot_conflict: true,
+        },
+        error: null,
+      } as any);
+
+      await act(async () => {
+        undoAction.props.onClick();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(toastSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Cascade undone',
+          description:
+            'Restored 2 shifts · skipped template hours taken by another template',
+        }),
+      );
+    });
+
     it('invalidates shifts and template-linked-shifts queries after undo', async () => {
       const { undoAction } = await triggerCascadeAndClickUndo();
 


### PR DESCRIPTION
Two defects in the template-hours cascade shipped in #700 (merged `d4a50c9f`), both reproduced against production data on the Home test restaurant and now covered by tests.

## Bug 1 — Undo desynced the template from its shifts

`undo_template_hours_cascade` reverted `public.shifts` from `before_data` but never restored `public.shift_templates.start_time/end_time`. After an Undo the template kept the **new** hours while the shifts held the **old** ones. Since the cascade's match predicate is a conjunction — a shift moves only if both its local start and end time-of-day equal the template's current times — every later edit measured those shifts against a baseline they no longer shared and classified them as drifted **forever**. The cascade was silently dead for that template.

Production trace (restaurant `0a1812a5…`, template `a71b4223…` "Opening - weekend", America/Chicago):

| Time (UTC) | Event |
|---|---|
| 02:35:16 | 3 shifts created Aug 7/8/9 at 10:00–16:30; template 10:00–16:30 |
| 02:35:28 | template end → 17:30; cascade moved all 3 to 10:00–17:30 |
| 02:35:35 | **Undo** → shifts back to 10:00–16:30, template **left at 10:00–17:30** ← desync |
| 02:36:20 | template edited to 11:00–18:30 → 0 moving, 3 drifted, no cascade offered |

**Fix.** A new `template_hours_cascade_batches` header table, keyed on the batch id the cascade already mints, records the template's own before/after hours. Undo restores them in the same transaction as the shift revert, guarded by the same "unchanged since" check the shifts already use — a template hand-edited after the cascade is left alone and reported via `template_changed_since`. No second source of truth: the header is written only when the cascade actually moved something (`v_updated_count > 0`).

Lock ordering is preserved. The cascade takes `shift_templates` then `shifts`; Undo's new template lock is placed **before** its shifts UPDATE so both paths acquire in the same order.

## Bug 2 — the drift opt-in was effectively invisible

Nothing was unreachable — the panel is gated on `isEdit && hoursChanged && template`, not on `showCascadeChoice`. The real defect: when every linked shift is drifted and none is opted in, the panel rendered **collapsed**, and its one visible line read *"Low impact. 1h later · same length. 0 shifts move."* while three pickable shifts sat behind two nested disclosures. The summary told the manager there was nothing to do.

**Fix.** The summary now names the pickable shifts when nothing is moving — *"… 0 shifts move. 3 hand-edited shifts you can pick."* Scoped to `totalAffected === 0` deliberately: once anything is moving, the chips and the "Save & update N shifts" button already say so, and this line is truncated on screen. `showCascadeChoice` and `buildSaveButtonLabel` are unchanged — the primary button stays governed by `affectedCount`.

## Scope

Hours (`start_time`/`end_time`) only, matching the shipped feature. Cascading `days[]` and `capacity` remains out of scope.

## Tests

| Suite | Result |
|---|---|
| pgTAP (full) | 2673 passed, 0 failed |
| pgTAP `template_hours_cascade.test.sql` | 46 tests, 0 failures |
| Playwright `template-hours-cascade.spec.ts` | 7 passed |
| Vitest (full) | 8868 passed, 2 skipped |
| `npm run build` | ✓ |

New coverage worth calling out:

- `ok 37 - undo restores the template hours`
- `ok 40 - a cascade after an undo still moves the shifts (the reported bug)`
- `ok 42 - undo declines to restore a template hand-edited since the cascade, and reports template_changed_since`
- `ok 46 - undoing a superseded batch leaves the newer cascade's hours in place and reports changed_since`
- E2E `a cascade after an undo still moves the shifts`
- E2E `a manager can pick hand-edited shifts into the cascade`

## Production remediation

The 3 rows Bug 1 already desynced on the Home test restaurant are **not** touched by this PR. Diagnosis is read-only; the repair statement will be proposed separately with exact row counts for explicit approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved template-hours cascade Undo, including safer restoration and notifications when template hours changed afterward.
  - Added clearer summaries identifying hand-edited shifts available for selection.
  - Automatically opens drift details when no shifts move automatically, while preserving manual selections.

- **Bug Fixes**
  - Prevented template and shift hours from becoming unsynchronized after cascade and Undo operations.
  - Improved handling of protected, legacy, and tenant-isolated cascade records.

- **Tests**
  - Added database, unit, and end-to-end coverage for cascade, Undo, drift selection, and resynchronization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->