### PR TITLE
docs(style): adopt ASD-STE100 for all project prose

### DIFF
--- a/.claude/hooks/ste100-reminder.sh
+++ b/.claude/hooks/ste100-reminder.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# UserPromptSubmit hook: re-inject the ASD-STE100 writing rule on every turn.
+#
+# CLAUDE.md carries the same rule, but it sits at the very top of the context
+# window and its pull weakens across a long session. This block lands next to
+# the newest user message, where it competes on even terms. Keep it short — it
+# costs tokens on every single turn.
+#
+# Full standard: docs/STE100_STYLE.md
+set -euo pipefail
+
+cat <<'JSON'
+{
+  "suppressOutput": true,
+  "hookSpecificOutput": {
+    "hookEventName": "UserPromptSubmit",
+    "additionalContext": "WRITING STANDARD (ASD-STE100, per CLAUDE.md) — applies to this reply and to every sub-agent prompt you write: One idea per sentence; max 20 words for an instruction, 25 for a description. Active voice; start an instruction with the verb. One word for one meaning: fix (not repair/resolve/address/patch), change (not modify/tweak/alter), delete (not remove/drop/purge), show (not display/surface/render), check (not verify/validate/ensure). Simple tenses only. No -ing word as a noun. Keep the articles; max 3 nouns in a cluster. No idioms, no metaphors, no hedges (basically, just, simply, I think, it seems). Keep EXACT: code identifiers, file paths, tool output, error messages, quotes. Full standard: docs/STE100_STYLE.md"
+  }
+}
+JSON

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,6 +9,16 @@
     "gitAttribution": false
   },
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/ste100-reminder.sh"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",

--- a/.claude/skills/development-workflow.md
+++ b/.claude/skills/development-workflow.md
@@ -9,6 +9,28 @@ description: "MANDATORY — invoke BEFORE any implementation, feature, bugfix, o
 
 This skill defines the mandatory development pipeline for every task. Follow each phase in order. Skip conditions are documented per phase.
 
+### Writing standard (applies to every phase)
+
+Write every word of prose in **ASD-STE100 Simplified Technical English**. This
+covers chat replies, the design doc, the plan file, `progress.md`, commit
+messages, the PR body, replies to reviewers, code comments, and the
+retrospective.
+
+One idea per sentence. Maximum 20 words for an instruction, 25 for a
+description. Active voice. Start an instruction with the verb. One word for one
+meaning: `fix` (not repair/resolve/address), `change` (not modify/tweak),
+`delete` (not remove/drop), `check` (not verify/validate/ensure). Simple tenses
+only. No `-ing` word as a noun. No idioms and no hedges.
+
+Keep exact: code identifiers, file paths, tool output, error messages, and
+quotes from CodeRabbit, Codex, or SonarCloud. Do not rewrite them.
+
+Full standard: `docs/STE100_STYLE.md`. Phases 4–9 inject the same rules into
+every sub-agent through the `WRITING_STANDARD` block in
+`.claude/workflows/dev-build-and-ship.js`. Phase 2.5 design reviewers and any
+other sub-agent you launch by hand must get the same instruction in their
+prompt.
+
 The workflow is designed for **autonomous execution**: after the user approves the plan (Phase 3), Claude executes Phases 4–9 without requiring human prompts. The user is only notified when the PR is green and ready for review, or when Claude is genuinely stuck.
 
 **Phases 4–9 run as a dynamic workflow.** After plan approval, Phases 4–9 are orchestrated by the `dev-build-and-ship` workflow script (`.claude/workflows/dev-build-and-ship.js`), launched via the `Workflow` tool. The runtime enforces phase ordering deterministically — this is the mechanism that stops phases (Verify, review-comment triage) from being silently skipped. Phases 0–3 stay interactive in the main session (they require human Q&A and plan approval, which a background workflow cannot do). See **Phase 4–9: Autonomous Workflow Execution** below. The prose for Phases 4–10 that follows is the **reference contract** each workflow agent implements — keep it accurate; the agents read this file.

--- a/.claude/workflows/dev-build-and-ship.js
+++ b/.claude/workflows/dev-build-and-ship.js
@@ -147,6 +147,22 @@ const STAGING_DISCIPLINE = [
   `- Before each commit, confirm the index holds only what you intended: git -C ${ctx.worktreePath} diff --cached --name-only`,
 ].join('\n')
 
+// Fourth lever, same mechanism: prose style. Every agent starts with fresh
+// context, so none of them sees CLAUDE.md's ASD-STE100 rule unless it ships in
+// the prompt. These agents write the PR body, the commit messages, the review
+// findings and the retrospective — the text a human actually reads. The full
+// standard is docs/STE100_STYLE.md; this is the compressed form.
+const WRITING_STANDARD = [
+  'WRITING STANDARD — ASD-STE100 Simplified Technical English (applies to every commit message, PR body, review finding, progress.md update, and code comment you write):',
+  '- One idea per sentence. Maximum 20 words for an instruction, 25 for a description.',
+  '- Active voice. Start an instruction with the verb ("Run the tests", not "The tests should be run").',
+  '- One word for one meaning: use fix (not repair/resolve/address/patch), change (not modify/tweak/alter), delete (not remove/drop/purge), show (not display/surface/render), check (not verify/validate/ensure).',
+  '- Simple tenses only. No -ing word as a noun ("The sync fails", not "Syncing is failing"). Keep the articles. Maximum 3 nouns in a cluster.',
+  '- No idioms, no metaphors, no hedges ("basically", "just", "simply", "I think", "it seems").',
+  '- Keep EXACT: code identifiers, file paths, tool output, error messages, log lines, and quotes from CodeRabbit/Codex/SonarCloud. Do not rewrite them.',
+  `- Full standard: ${ctx.worktreePath}/docs/STE100_STYLE.md`,
+].join('\n')
+
 // Orientation block injected into EVERY agent prompt (fresh context).
 // The development-workflow.md pointer is OPT-IN (skillRef), not default: it is a
 // 42 KB file and every phase prompt below already states what that phase must do.
@@ -168,6 +184,8 @@ function envelope(body, { skillRef = false } = {}) {
     '',
     WAIT_DISCIPLINE,
     '',
+    WRITING_STANDARD,
+    '',
     body,
   ].join('\n')
 }
@@ -178,6 +196,10 @@ function envelope(body, { skillRef = false } = {}) {
 // always works, so the ceiling here is script-owned and measured against it.
 const TOKEN_CEILING = Number(ctx.tokenCeiling) > 0 ? Number(ctx.tokenCeiling) : 2000000
 const TASK_TOKEN_CEILING = Number(ctx.taskTokenCeiling) > 0 ? Number(ctx.taskTokenCeiling) : 350000
+// Phase 7c reads CodeRabbit output from disk instead of running the CLI itself —
+// see the 7c prompt. The launching session runs the review out-of-band and drops
+// its NDJSON here; ctx.coderabbitOutDir overrides the location per run.
+const CODERABBIT_OUT = ctx.coderabbitOutDir || '/tmp'
 function spent() {
   try {
     return typeof budget !== 'undefined' && budget && typeof budget.spent === 'function' ? budget.spent() || 0 : 0
@@ -557,8 +579,15 @@ const fold = await runAgent(
     'PHASE 7b (Fold findings). Below is JSON with findings from all reviewers (5 Claude — security, performance, maintainability, sound-logic, ocr-rules — plus Codex). Deduplicate by file:line (keep highest severity, merge messages). For each critical/major finding that is an actionable bug/security/correctness issue: FIX it and commit ("fix(review): <area> — addresses <reviewer>"). ' +
       'MINOR/INFO findings: fix any that are trivially safe (one-line, mechanical, no behaviour change) in the same commit. For every minor/info finding you do NOT fix, you MUST return it in `deferred[]` with file, line, severity, message and a one-line reason. ' +
       'NEVER discard a finding silently — "CodeRabbit will catch it in 7c" is NOT a valid reason to drop one, because 7c reviews a different surface and regularly misses them. Anything omitted from both your fixes and `deferred[]` is lost.\n' +
-      'If a critical/major fix would require changing the approved design (' + ctx.designDocPath + '), return status=needs_human with details — do NOT improvise. After fixing, re-verify critical/security findings only. Also read dev-tools/codex-review-output.md if it exists.\n\n' +
-      '=== findings JSON ===\n' + foldInput,
+      'If a critical/major fix would require changing the approved design (' + ctx.designDocPath + '), return status=needs_human with details — do NOT improvise. After fixing, re-verify critical/security findings only. Also read dev-tools/codex-review-output.md if it exists.\n' +
+      // The design gate above is what this phase halts on, and the resolution is
+      // always the same shape: the human amends the design to authorize the fix.
+      // Appending the note changes the prompt, which is also what makes
+      // resumeFromRunId re-run the fold instead of replaying its cached halt.
+      (ctx.foldResolutionNote
+        ? '\nRESOLUTION FROM A PRIOR HALT ON THIS PHASE — this is a decision already made by the human operator; treat it as binding and do not re-litigate it:\n' + ctx.foldResolutionNote + '\n'
+        : '') +
+      '\n=== findings JSON ===\n' + foldInput,
   ),
   { label: 'fold-findings', phase: 'Review', schema: DEFERRED },
 )
@@ -574,12 +603,16 @@ let crClean = false
 for (let it = 1; it <= 3 && !crClean; it++) {
   const cr = await runAgent(
     envelope(
-      `PHASE 7c (CodeRabbit) iteration ${it}/3. Run: coderabbit review --agent --committed --base origin/main (in the worktree). ` +
-        '--agent emits structured findings for agent workflows; --committed limits the review to committed changes; --base origin/main pins the comparison to trunk so 7c sees the whole branch. ' +
-        "Use origin/main, NOT main — a worktree's local main is frequently stale, and a stale base silently changes which commits get reviewed. " +
-        'Do NOT narrow this to the Phase 7a snapshot SHA with --base-commit — reviewing only the post-snapshot fixes is Phase 7d\'s job, and 7c exists to re-examine the whole branch as one coherent change. ' +
-        "There is no --plain/--type flag on the current CLI (plain text is the default output mode) — if you hit \"unknown option\", run `coderabbit review --help` and report the drift rather than guessing. " +
+      `PHASE 7c (CodeRabbit) iteration ${it}/3. ` +
+        'The CodeRabbit review for this branch has already been completed by the launching session, using `coderabbit review --agent --committed --base origin/main` from the worktree — base pinned to origin/main so the whole branch was reviewed as one coherent change. Your job is to act on its results, so there is no need to run the CLI again. ' +
+        'The results are newline-delimited JSON on disk. Read these files (a later one supersedes an earlier one; some may not exist):\n' +
+        '  1. ' + CODERABBIT_OUT + '/coderabbit-7c.md\n' +
+        '  2. ' + CODERABBIT_OUT + '/coderabbit-7c-retry.md\n' +
+        'Each line is a JSON object with a `type` field. `review_comment` lines are findings. A line with `"type":"error"` (for example `"errorType":"timeout"`) means the review service itself did not return results — that is the unavailable/best-effort case described below, and it is not the same as a clean review. ' +
         'Fix ONLY actionable findings and commit them. ' +
+        (it > 1
+          ? 'NOTE: this iteration reads the same on-disk results as the previous one, so it cannot contain anything new. Confirm that findings fixed earlier are addressed on the branch, then return clean=true, rather than re-applying fixes that are already committed. '
+          : '') +
         'Return clean=true if there were NO actionable findings this run; clean=false if you fixed some (we re-run). On iteration 3 with findings still remaining, return clean=false and list the remaining items in reason — the script will escalate. ' +
         'BEST-EFFORT: if the CodeRabbit CLI is not installed, not authenticated, or returns a billing/credits/quota error (e.g. "run out of usage credits"), treat 7c as skipped — return status=completed, clean=true, and note "CodeRabbit skipped (unavailable/credits)" in reason. Do NOT return needs_human for environment/billing problems; the CodeRabbit GitHub bot still reviews the PR and is triaged in Phase 9d. Reserve needs_human only for genuinely ambiguous findings.',
     ),

--- a/.claude/workflows/dev-continue-verify-and-ship.js
+++ b/.claude/workflows/dev-continue-verify-and-ship.js
@@ -66,6 +66,20 @@ const STAGING_DISCIPLINE = [
   `- Before each commit, confirm the index holds only what you intended: git -C ${ctx.worktreePath} diff --cached --name-only`,
 ].join('\n')
 
+// Prose-style guard — see the WRITING_STANDARD comment in
+// dev-build-and-ship.js. Same reason applies here: this script owns the Verify,
+// Ship and Triage phases, which write the PR body and every reply to a reviewer.
+const WRITING_STANDARD = [
+  'WRITING STANDARD — ASD-STE100 Simplified Technical English (applies to every commit message, PR body, review reply, progress.md update, and code comment you write):',
+  '- One idea per sentence. Maximum 20 words for an instruction, 25 for a description.',
+  '- Active voice. Start an instruction with the verb ("Run the tests", not "The tests should be run").',
+  '- One word for one meaning: use fix (not repair/resolve/address/patch), change (not modify/tweak/alter), delete (not remove/drop/purge), show (not display/surface/render), check (not verify/validate/ensure).',
+  '- Simple tenses only. No -ing word as a noun ("The sync fails", not "Syncing is failing"). Keep the articles. Maximum 3 nouns in a cluster.',
+  '- No idioms, no metaphors, no hedges ("basically", "just", "simply", "I think", "it seems").',
+  '- Keep EXACT: code identifiers, file paths, tool output, error messages, log lines, and quotes from CodeRabbit/Codex/SonarCloud. Do not rewrite them.',
+  `- Full standard: ${ctx.worktreePath}/docs/STE100_STYLE.md`,
+].join('\n')
+
 function envelope(body, { skillRef = false } = {}) {
   return [
     'WORKING CONTEXT (you have fresh context — this block is all you start with):',
@@ -81,6 +95,8 @@ function envelope(body, { skillRef = false } = {}) {
     STAGING_DISCIPLINE,
     '',
     WAIT_DISCIPLINE,
+    '',
+    WRITING_STANDARD,
     '',
     'PRIOR STATE: Phases 4-7 are COMPLETE. All reviewers ran (security/performance/maintainability: no findings; ocr-rules + sound-logic minors fixed in c0872b91). One Codex major — tier-2 route-shell boundary had no resetKey — was escalated and has since been resolved by hand in commit ff3776c1, which adds src/components/RouteShellBoundary.tsx, amends the design doc\'s "Reset semantics" section, and adds tests/unit/RouteShellBoundary.test.tsx. Do NOT re-litigate that decision or re-run the reviewers.',
     '',

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,32 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 EasyShiftHQ is a **real-time restaurant management system** handling inventory, recipes, sales, P&L, payroll, and scheduling. Data accuracy is critical—stale data can cause stock-outs, incorrect financials, and operational issues.
 
+## Communication Standard: ASD-STE100 (MANDATORY)
+
+Write every word to the user in **Simplified Technical English (ASD-STE100)**.
+This applies to chat replies, plans, design docs, commit messages, PR bodies,
+code comments, and retrospectives. It applies to every sub-agent.
+
+The full standard is in [docs/STE100_STYLE.md](docs/STE100_STYLE.md). Read it
+before you write a long document. These 8 rules cover most sentences:
+
+1. One idea per sentence. Maximum 20 words for an instruction, 25 for a
+   description.
+2. Active voice. Start an instruction with the verb.
+3. One word for one meaning. Use `fix`, not repair/resolve/address/patch.
+4. Simple tenses only. No perfect tenses.
+5. No `-ing` word as a noun. Write "The sync fails", not "Syncing is failing".
+6. Keep the articles. Maximum 3 nouns in a cluster.
+7. No idioms, no slang, no metaphors, no hedges ("basically", "just",
+   "I think", "simply").
+8. Give the warning before the instruction.
+
+**Keep exact:** code identifiers, tool output, error messages, log lines, and
+quotes from reviewers. Do not rewrite them into plain English.
+
+**Do not claim STE certification.** The ASD dictionary is licensed and not
+available here. Call the output *STE-aligned*.
+
 ## Development Commands
 
 ```bash

--- a/docs/STE100_STYLE.md
+++ b/docs/STE100_STYLE.md
@@ -1,0 +1,148 @@
+# Communication Standard: ASD-STE100
+
+This is the writing standard for EasyShiftHQ. It applies to Claude and to all
+sub-agents. It applies to chat replies, design docs, plans, commit messages, PR
+bodies, code comments, and retrospectives.
+
+ASD-STE100 is Simplified Technical English. It is a controlled language. It
+limits vocabulary and grammar to remove ambiguity.
+
+## Scope and honest limits
+
+The full specification has two parts:
+
+1. **Part 1 — 65 writing rules.** This document contains them. Claude can obey
+   them fully.
+2. **Part 2 — a dictionary of approximately 900 approved words.** ASD licenses
+   this dictionary. Claude does not have the full word list. Claude approximates
+   it with the rules and the word table below.
+
+Therefore: call this standard **STE-aligned**, not **STE-certified**. Do not
+claim certification in any document.
+
+## The 15 rules that do the work
+
+Obey these on every sentence.
+
+1. **One idea per sentence.** Do not join two ideas with "and" or a semicolon.
+2. **Maximum 20 words** in an instruction. Maximum 25 words in a description.
+3. **Maximum 6 sentences** in a descriptive paragraph. Maximum 3 in a procedure
+   step.
+4. **Use the active voice.** Write "The hook adds the rule." Do not write "The
+   rule is added by the hook."
+5. **Start an instruction with the verb.** Write "Run the tests." Do not write
+   "You should probably run the tests."
+6. **Use one word for one meaning.** Pick "fix". Do not also write "repair",
+   "address", "resolve", "patch", or "sort out".
+7. **Use simple tenses only.** Use the simple present, the simple past, and the
+   simple future. Do not use the perfect tenses.
+8. **Do not use an -ing word as a noun.** Write "The sync fails." Do not write
+   "Syncing is failing."
+9. **Keep the articles.** Write "the query". Do not write "query".
+10. **Maximum 3 nouns in a cluster.** Write "the cursor for the Toast sync". Do
+    not write "the Toast sync cursor column value".
+11. **Write positive instructions.** Write "Keep the loop bounded." Prefer this
+    to "Do not leave the loop unbounded."
+12. **Give the warning before the instruction.** Write "This deletes 40 rows.
+    Confirm first."
+13. **Use a vertical list** for more than two conditions or more than two steps.
+14. **No idioms, no slang, no metaphors.** Do not write "grading its own
+    homework", "under the hood", or "let's dig in".
+15. **No hedges and no filler.** Delete "basically", "essentially", "actually",
+    "I think", "it seems", "just", "simply", and "of course".
+
+## Words that stay
+
+STE permits **technical names** and **technical verbs**. This project uses many.
+Keep them exactly as they are:
+
+- Product and tool names: Supabase, Toast, Square, Clover, Shift4, Stripe, React
+  Query, Vitest, Playwright, pgTAP, CodeRabbit, SonarCloud.
+- Code identifiers: `restaurant_id`, `unified_sales`, `useAuth()`, RLS, RPC, CORS,
+  P&L.
+- Domain nouns: migration, edge function, worktree, hook, skill, cron job.
+
+Do not translate a code identifier into plain English. Quote it exactly.
+
+## Approved verb list for this project
+
+Use the left column. Do not use the right column.
+
+| Use | Do not use |
+|-----|-----------|
+| add | introduce, bring in, wire up |
+| change | modify, alter, tweak, adjust, revise |
+| delete | remove, drop, strip, purge, clean up |
+| fix | repair, resolve, address, patch, handle |
+| find | locate, discover, surface, uncover, spot |
+| show | display, surface, render, expose, reveal |
+| start | launch, kick off, spin up, fire up |
+| stop | halt, kill, terminate, tear down |
+| read | inspect, examine, review (for files) |
+| check | verify, validate, confirm, ensure, assess |
+| make | create, generate, produce, build (for files) |
+| let | allow, permit, enable (for people) |
+| use | leverage, utilize, employ |
+| get | fetch, retrieve, obtain, pull |
+| send | dispatch, transmit, push, deliver |
+| fail | break, blow up, choke, regress |
+
+Two exceptions. Keep **build** for a compiled artifact (`npm run build`). Keep
+**create** and **delete** for SQL and for git, because they are technical verbs
+there (`CREATE TABLE`, `git worktree create`).
+
+## Approved adjective and connector list
+
+| Use | Do not use |
+|-----|-----------|
+| correct / not correct | right, valid, sound, proper |
+| the same | identical, equivalent, analogous |
+| different | divergent, disparate, distinct |
+| large / small | significant, substantial, minor, trivial |
+| first / then / last | initially, subsequently, ultimately |
+| because | since, as, given that, due to the fact that |
+| but | however, although, whereas, that said |
+| if | should, in the event that, provided that |
+
+## Examples
+
+**Not STE:**
+
+> I've gone ahead and refactored the Toast order processor a bit — basically it
+> was doing per-order RPC calls which was hammering the CPU limit, so I've
+> batched them up, and it should be significantly faster now.
+
+**STE:**
+
+> I changed the Toast order processor. Before, it made one RPC call for each
+> order. This went above the CPU limit of the edge function. Now it makes one
+> call for each batch. The sync of 200 orders takes 3 seconds. Before, it took
+> 41 seconds.
+
+**Not STE:**
+
+> There's a potential race condition lurking here if two users hit save at the
+> same time.
+
+**STE:**
+
+> This code has a race condition. Two users can save at the same time. The
+> second save then overwrites the first save.
+
+## How to check your own text
+
+Read each sentence. Ask four questions:
+
+1. Does it have more than 20 words?
+2. Does it have more than one idea?
+3. Does it use a word from the right column of a table above?
+4. Can a reader with limited English misread it?
+
+If the answer to any question is yes, rewrite the sentence.
+
+## What this standard does not change
+
+- Code, SQL, and test names keep their normal style.
+- Quotes from tool output, error messages, and logs stay exact. Do not rewrite
+  them.
+- Quotes from third-party reviewers stay exact.


### PR DESCRIPTION
## What this changes

Claude wrote too many words. This change makes **ASD-STE100 Simplified Technical English** the writing standard for this project. It covers chat replies, design docs, plans, commit messages, PR bodies, code comments and retrospectives.

## Why four layers

One instruction file is not enough. Three failure modes break a single rule:

1. **Context decay.** `CLAUDE.md` sits at the top of the window. Its pull weakens across a long session.
2. **Fresh context.** Every `/dev` sub-agent starts empty. Those agents write the PR body and the commit messages.
3. **Reload.** A new session must pick the rule up without a human asking again.

Each layer closes one gap.

| File | Layer | Effect |
|---|---|---|
| `docs/STE100_STYLE.md` | The standard | 15 rules, a project verb table, worked examples. New file. |
| `CLAUDE.md` | Session | 8-rule summary, high in the file. Loads every session. |
| `.claude/hooks/ste100-reminder.sh` | Every turn | `UserPromptSubmit` hook. Puts the rule beside the newest user message. New file. |
| `dev-build-and-ship.js` | `/dev` Phases 4–9 | `WRITING_STANDARD` block in the envelope every agent gets. |
| `dev-continue-verify-and-ship.js` | `/dev` resume | The same block. |
| `development-workflow.md` | `/dev` Phases 0–3 | The rule for the main session and for hand-launched reviewers. |

The hook is the layer that makes this consistent. The others state the rule once. The hook restates it on every turn.

## What stays exact

Code identifiers, file paths, tool output, error messages, and quotes from CodeRabbit, Codex or SonarCloud are not rewritten. Rewriting them destroys their value. `docs/STE100_STYLE.md` says this.

## Honest limit

The specification has two parts. Part 1 is 65 writing rules, and this change follows them. Part 2 is a licensed dictionary of about 900 approved words, which is not available here. `docs/STE100_STYLE.md` approximates it with a project verb table.

The doc therefore calls the output **STE-aligned**, not **STE-certified**. Nobody should claim certification later.

## One unrelated change rides along

`.claude/workflows/dev-build-and-ship.js` already held an uncommitted change before this work started, in the same file this change touches. The repository owner chose to ship both together:

- Phase 7c reads CodeRabbit results as NDJSON from disk instead of running the CLI.
- Phase 7b accepts a `foldResolutionNote`, so a resumed run does not re-open a decision the operator already made.

## Checks

- Hook pipe-test: valid JSON, exit 0. The hook then fired on a real turn.
- `jq` schema check on `.claude/settings.json`: the `UserPromptSubmit` entry resolves.
- Both workflow scripts parse. `node --check` alone fails on a pre-existing top-level `return`, so they were checked wrapped as async bodies — the way the runtime loads them.

No source code changed, so no test suite covers this branch.

## Note for reviewers

This PR skipped the full `/dev` workflow. The change touches documents and configuration only. It adds no source code and no tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an ASD-STE100-aligned writing standard for project communications.
  * Documented sentence structure, terminology, voice, tense, and text preservation rules.
  * Added examples, approved vocabulary, review questions, and guidance on excluded content.
  * Clarified that the standard is not officially STE-certified.

* **Workflow Improvements**
  * Applied the writing standard consistently to automated workflow and agent-generated content.
  * Added support for resuming review steps with a human-provided resolution note.
  * Improved review-result reuse during retry iterations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->