### PR TITLE
feat(reviews): offer the follow-up form to a promoter, show silent ratings in the inbox

### DIFF
--- a/docs/superpowers/plans/2026-08-06-review-funnel-followups.md
+++ b/docs/superpowers/plans/2026-08-06-review-funnel-followups.md
@@ -1095,7 +1095,7 @@ Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
 **Interfaces:**
 - Consumes: nothing.
 - Produces:
-  - `export type ReviewResponseFilter = 'all' | 'commented' | 'silent'`
+  - `export type ReviewResponseFilter = 'all' | 'needsReply' | 'silent'`
   - `export function useReviewResponses(restaurantId?: string, filter: ReviewResponseFilter = 'all')`
   - `export function isActionableResponse(response: ReviewResponse): boolean`
 
@@ -1241,7 +1241,7 @@ In `src/hooks/useReviewResponses.ts`, add the type and the predicate after the `
 
 ```ts
 /** Which rows the inbox list asks for. The predicate runs server-side. */
-export type ReviewResponseFilter = 'all' | 'commented' | 'silent';
+export type ReviewResponseFilter = 'all' | 'needsReply' | 'silent';
 
 /**
  * A row a manager can act on: a comment to read, or a guest who asked to hear
@@ -1281,8 +1281,8 @@ export function useReviewResponses(
       // inbox — the complaint dropped off the end of a window it was never in.
       //
       // Known limit: in `all` mode a heavy run of silent taps can push an old
-      // comment past the 500-row cap. `With comments` is the mode that
-      // guarantees the full comment list.
+      // comment past the 500-row cap. `Needs a reply` is the mode that
+      // guarantees the full actionable list.
       //
       // Capped at 500 for the inbox *list* only. The header metrics below do
       // NOT come from this capped array; they're a separate, uncapped
@@ -1297,8 +1297,11 @@ export function useReviewResponses(
 
       // `all` adds no predicate, so it reads the base query unchanged.
       let scoped = base;
-      if (filter === 'commented') scoped = base.not('comment', 'is', null);
-      else if (filter === 'silent') scoped = base.is('comment', null);
+      if (filter === 'needsReply') {
+        scoped = base.or('comment.not.is.null,contact_consent.is.true');
+      } else if (filter === 'silent') {
+        scoped = base.is('comment', null).eq('contact_consent', false);
+      }
 
       const { data, error } = await scoped
         .order('submitted_at', { ascending: false })
@@ -1375,7 +1378,7 @@ After `STATUS_LABELS` (`Reviews.tsx:74-78`), add:
 ```tsx
 const FILTER_LABELS: Array<[ReviewResponseFilter, string]> = [
   ['all', 'All'],
-  ['commented', 'With comments'],
+  ['needsReply', 'Needs a reply'],
   ['silent', 'Silent'],
 ];
 
@@ -1384,13 +1387,13 @@ const EMPTY_STATES: Record<ReviewResponseFilter, { title: string; body: string }
     title: 'No ratings yet',
     body: 'Put a review page QR code on the table. Every tap lands here.',
   },
-  commented: {
-    title: 'No written feedback yet',
-    body: 'Every guest can leave a note, at any star count. Their notes land here.',
+  needsReply: {
+    title: 'Nothing needs a reply yet',
+    body: 'A comment or a request to hear back lands here.',
   },
   silent: {
-    title: 'Every rating here has a comment',
-    body: 'A silent rating is a star tap with no note.',
+    title: 'No silent ratings',
+    body: 'A silent rating has no comment and no request to hear back.',
   },
 };
 ```

--- a/docs/superpowers/plans/2026-08-06-review-funnel-followups.md
+++ b/docs/superpowers/plans/2026-08-06-review-funnel-followups.md
@@ -1497,7 +1497,7 @@ Replace `Reviews.tsx:165-171` (the empty-state branch). The filter group sits **
       <ToggleGroup
         type="single"
         value={filter}
-        // Radix sends an empty string when the guest taps the active item.
+        // Radix sends an empty string when the manager taps the active item.
         // Keep the mode; a list with no filter at all is not a state.
         onValueChange={(value) => value && setFilter(value as ReviewResponseFilter)}
         aria-label="Filter feedback"

--- a/docs/superpowers/plans/2026-08-06-review-funnel-followups.md
+++ b/docs/superpowers/plans/2026-08-06-review-funnel-followups.md
@@ -421,10 +421,10 @@ After the `announcement` state (`ReviewPage.tsx:66`), add:
 
 ```tsx
   // The server's branch decision, derived. `routeRating` returns
-  // `'destination'` only when a URL exists, and `handleRate` releases the URL
-  // only on that branch, so this is the same test with no second state to
-  // keep in step. The form copy follows it: `What happened?` in front of a
-  // five-star guest reads as an accusation.
+  // `'destination'` only when a URL exists. `handleRate` releases the URL only
+  // on that branch. This test is the same one, with no second state to keep in
+  // step. The form copy follows it. `What happened?` in front of a five-star
+  // guest reads as an accusation.
   const isPromoterBranch = destinationUrl !== null;
 ```
 
@@ -437,8 +437,8 @@ After the `announcement` state (`ReviewPage.tsx:66`), add:
 After `handleCommit` (`ReviewPage.tsx:155`), add:
 
 ```tsx
-  // Every stage move clears the error banner first. `That didn't send.` over
-  // a form the guest has not sent yet reads as a new failure.
+  // Every stage move clears the error banner first. The guest did not send the
+  // new form yet. `That didn't send.` above it reads as a new failure.
   const goToStage = useCallback((next: Stage, message: string) => {
     setSubmitError(false);
     setStage(next);

--- a/docs/superpowers/plans/2026-08-06-review-funnel-followups.md
+++ b/docs/superpowers/plans/2026-08-06-review-funnel-followups.md
@@ -762,8 +762,9 @@ import { test, expect } from '@playwright/test';
  * three paths that hand-off must not close.
  *
  * The edge function is not served in the e2e stack, so `review-public` is
- * stubbed. Its token and routing logic are covered elsewhere; what this
- * proves is the wiring — which controls appear, and what the client sends.
+ * stubbed. Other tests cover its token logic and its routing logic. This spec
+ * proves the wiring. It shows which controls appear. It shows what the client
+ * sends.
  */
 
 const FN_GLOB = '**/functions/v1/review-public';
@@ -780,7 +781,7 @@ const RATE_BODY = {
   destination_url: 'https://example.com/google-review',
 };
 
-/** Stubs the three actions and collects every `comment` body the page sends. */
+/** Stubs the three actions. Collects every `comment` body the page sends. */
 async function stubReviewPublic(page: any, commentBodies: any[]) {
   await page.route(FN_GLOB, async (route: any) => {
     const body = route.request().postDataJSON();

--- a/docs/superpowers/plans/2026-08-06-review-funnel-followups.md
+++ b/docs/superpowers/plans/2026-08-06-review-funnel-followups.md
@@ -19,7 +19,8 @@
 - No manual caching. React Query only, `staleTime: 30000`.
 - Every button without visible text needs `aria-label`. Every input needs a label.
 - Handle the loading state, the error state and the empty state.
-- The email shape check is duplicated: `src/lib/reviews/reviewSubmission.ts` (TypeScript) and `supabase/functions/_shared/reviewContact.ts` (Deno). The edge function cannot import from `src/`. The server copy is authoritative. Each copy names the other in a comment.
+- The submit rule is duplicated: `src/lib/reviews/reviewSubmission.ts` (TypeScript) and `supabase/functions/_shared/reviewContact.ts` (Deno). The edge function cannot import from `src/`. The server copy is authoritative. Each copy names the other in a comment.
+- The actionable-row rule is duplicated too: SQL in the migration, TypeScript in `isActionableResponse`. Each copy names the other in a comment.
 - The migration must use `CREATE OR REPLACE FUNCTION`. A `DROP FUNCTION` resets the grants and breaks the Feedback tab header with `permission denied for function`.
 - Every early exit in `handleComment` after the 400 check returns `{ ok: true }`. A caller must not tell a bot trip from a replay from a real write.
 - Run Playwright with `--reporter=line`. Never the default `html` reporter.
@@ -144,10 +145,12 @@ Create `src/lib/reviews/reviewSubmission.ts`:
  * comment and no email. A form that holds neither writes nothing, so the
  * Send control stays disabled.
  *
- * The email shape check is a copy. `supabase/functions/_shared/reviewContact.ts`
+ * This whole module is a copy. `supabase/functions/_shared/reviewContact.ts`
  * holds the Deno original, which an edge function can import and this file
- * cannot. That copy is authoritative: this one only enables a button. Change
- * both together.
+ * cannot: `isPlausibleEmail` and `hasFollowUpPayload` there answer to
+ * `isPlausibleEmail` and `canSubmitFollowUp` here. That copy is
+ * authoritative: this one only enables a button. Change both together, or
+ * the button sends a request the server answers with a 400.
  */
 
 /** The longest email `handleComment` accepts. It slices at this length. */
@@ -183,7 +186,7 @@ export function canSubmitFollowUp(input: {
 cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/review-funnel-followups && npx vitest run tests/unit/reviewSubmission.test.ts --reporter=verbose
 ```
 
-Expected: PASS, 16 tests.
+Expected: PASS, 15 tests.
 
 - [ ] **Step 5: Run the type check**
 
@@ -214,7 +217,10 @@ Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
 
 **Interfaces:**
 - Consumes: the rule from Task 1, restated in Deno. No import across the boundary.
-- Produces: `export function isPlausibleEmail(value: string): boolean` and `export const MAX_EMAIL_LENGTH = 320` from `../_shared/reviewContact.ts`.
+- Produces, from `../_shared/reviewContact.ts`:
+  - `export const MAX_EMAIL_LENGTH = 320`
+  - `export function isPlausibleEmail(value: string): boolean`
+  - `export function hasFollowUpPayload(input: { comment: string; consent: boolean; email: string }): boolean`
 
 **Context:** `handleComment` has no test harness in this repo. The edge function is stubbed in the E2E specs. Task 4 covers the client contract; the pgTAP test in Task 5 covers the aggregate. Verify this task with `npm run typecheck` and a careful read.
 
@@ -224,11 +230,14 @@ Create `supabase/functions/_shared/reviewContact.ts`:
 
 ```ts
 /**
- * The email shape check `handleComment` uses.
+ * The submit rule `handleComment` uses.
  *
  * `src/lib/reviews/reviewSubmission.ts` holds the client copy, which enables
- * the Send control. This copy is authoritative: it decides what the server
- * writes. An edge function cannot import from `src/`. Change both together.
+ * the Send control: `isPlausibleEmail` and `canSubmitFollowUp` there answer
+ * to `isPlausibleEmail` and `hasFollowUpPayload` here. This copy is
+ * authoritative: it decides what the server writes. An edge function cannot
+ * import from `src/`. Change both together, or the button sends a request
+ * the server answers with a 400.
  */
 
 /** The longest email `handleComment` accepts. It slices at this length. */
@@ -245,6 +254,17 @@ export function isPlausibleEmail(value: string): boolean {
   if (trimmed.length === 0 || trimmed.length > MAX_EMAIL_LENGTH) return false;
   return EMAIL_PATTERN.test(trimmed);
 }
+
+export function hasFollowUpPayload(input: {
+  comment: string;
+  consent: boolean;
+  email: string;
+}): boolean {
+  if (input.comment.trim().length > 0) return true;
+  // Consent false means the server discards the name and the email. Without
+  // consent an address is not a payload.
+  return input.consent && isPlausibleEmail(input.email);
+}
 ```
 
 - [ ] **Step 2: Import the module in the edge function**
@@ -253,7 +273,7 @@ In `supabase/functions/review-public/index.ts`, add one import after line 16:
 
 ```ts
 import { hashIp, isOverLimit, REVIEW_RATE_WINDOW_MS } from '../_shared/reviewRateLimit.ts';
-import { isPlausibleEmail, MAX_EMAIL_LENGTH } from '../_shared/reviewContact.ts';
+import { hasFollowUpPayload, MAX_EMAIL_LENGTH } from '../_shared/reviewContact.ts';
 ```
 
 - [ ] **Step 3: Delete the duplicate constant**
@@ -288,7 +308,7 @@ Replace `index.ts:274-276`:
 
   // The comment is optional, the payload is not. A request with neither a
   // comment nor a usable email writes nothing, so it stays a 400.
-  if (!comment && !(consent && isPlausibleEmail(email))) return fail(400);
+  if (!hasFollowUpPayload({ comment, consent, email })) return fail(400);
 ```
 
 - [ ] **Step 5: Move the single-use guard to `commented_at` and store NULL for an empty comment**
@@ -371,6 +391,13 @@ Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
 - Consumes: `canSubmitFollowUp` from `@/lib/reviews/reviewSubmission` (Task 1).
 - Produces: the DOM contract Task 4 asserts against — a `Tell us something directly` button, a `Back` button, a `Your feedback (optional)` label, and a `Leave a Google review` link on the `thanks` stage.
 
+**Note on the branch test:** the design doc keys the copy on `routed_to`. Do
+not hold `routed_to` in state. `routeRating` in
+`supabase/functions/_shared/reviewRouting.ts:22` returns `'destination'` only
+when a `destinationUrl` exists, and `handleRate` releases the URL only on that
+branch. So `destinationUrl !== null` is the same test, and it cannot fall out
+of step with a second state value.
+
 - [ ] **Step 1: Add the imports**
 
 In `src/pages/ReviewPage.tsx`, add the icon import and the module import. Follow the project import order: icons after the UI components, libraries last.
@@ -388,64 +415,34 @@ import {
 } from '@/lib/reviews/reviewPageLoad';
 ```
 
-- [ ] **Step 2: Add the `routedTo` state**
+- [ ] **Step 2: Derive the branch from `destinationUrl`**
 
-After the `destinationUrl` state (`ReviewPage.tsx:48`), add:
-
-```tsx
-  const [destinationUrl, setDestinationUrl] = useState<string | null>(null);
-  // The server's branch decision. The form copy follows it: `What happened?`
-  // in front of a five-star guest reads as an accusation.
-  const [routedTo, setRoutedTo] = useState<'destination' | 'feedback' | null>(null);
-```
-
-- [ ] **Step 3: Record the branch in `handleCommit`**
-
-Replace `ReviewPage.tsx:144-152`:
+After the `announcement` state (`ReviewPage.tsx:66`), add:
 
 ```tsx
-// before
-      setToken(data.token as string);
-      if (data.routed_to === 'destination') {
-        setDestinationUrl((data.destination_url as string) ?? null);
-        setStage('promoter');
-        setAnnouncement('Thanks. You can share this on Google.');
-      } else {
-        setStage('feedback');
-        setAnnouncement('Tell us what happened. This goes straight to the owner.');
-      }
-
-// after
-      setToken(data.token as string);
-      if (data.routed_to === 'destination') {
-        setDestinationUrl((data.destination_url as string) ?? null);
-        setRoutedTo('destination');
-        setStage('promoter');
-        setAnnouncement('Thanks. You can share this on Google.');
-      } else {
-        setRoutedTo('feedback');
-        setStage('feedback');
-        setAnnouncement('Tell us what happened. This goes straight to the owner.');
-      }
+  // The server's branch decision, derived. `routeRating` returns
+  // `'destination'` only when a URL exists, and `handleRate` releases the URL
+  // only on that branch, so this is the same test with no second state to
+  // keep in step. The form copy follows it: `What happened?` in front of a
+  // five-star guest reads as an accusation.
+  const isPromoterBranch = destinationUrl !== null;
 ```
 
-- [ ] **Step 4: Add the two stage-move callbacks**
+- [ ] **Step 3: Leave `handleCommit` as it is**
+
+`ReviewPage.tsx:144-152` already sets `destinationUrl` on the promoter branch and leaves it null on the other. Step 2 reads that value. No change here.
+
+- [ ] **Step 4: Add the stage-move callback**
 
 After `handleCommit` (`ReviewPage.tsx:155`), add:
 
 ```tsx
-  // Both moves clear the error banner first. `That didn't send.` over a form
-  // the guest has not sent yet reads as a new failure.
-  const handleOpenFeedback = useCallback(() => {
+  // Every stage move clears the error banner first. `That didn't send.` over
+  // a form the guest has not sent yet reads as a new failure.
+  const goToStage = useCallback((next: Stage, message: string) => {
     setSubmitError(false);
-    setStage('feedback');
-    setAnnouncement('Tell us more. This goes straight to the owner.');
-  }, []);
-
-  const handleBackToPromoter = useCallback(() => {
-    setSubmitError(false);
-    setStage('promoter');
-    setAnnouncement('Back to the Google link.');
+    setStage(next);
+    setAnnouncement(message);
   }, []);
 ```
 
@@ -509,14 +506,17 @@ Replace `ReviewPage.tsx:157-180`:
       setSubmitError(true);
       return;
     }
-    setStage('thanks');
-    setAnnouncement(
+    goToStage(
+      'thanks',
       destinationUrl
         ? 'Thanks. You can also share this on Google.'
         : 'Thanks. The owner has your note.'
     );
-  }, [comment, consent, destinationUrl, email, honeypot, name, token]);
+  }, [comment, consent, destinationUrl, email, goToStage, honeypot, name, token]);
 ```
+
+`goToStage` is declared in Step 4, above `handleSubmitComment`. Keep that
+order, or the `const` is read before its declaration.
 
 - [ ] **Step 6: Add the `Tell us something directly` control to the promoter stage**
 
@@ -535,7 +535,7 @@ Replace `ReviewPage.tsx:323-329` (the `No thanks` button) with two controls:
 // after
           <button
             type="button"
-            onClick={handleOpenFeedback}
+            onClick={() => goToStage('feedback', 'Tell us more. This goes straight to the owner.')}
             className="counter-micro mt-4 w-full text-center text-[12px] text-muted-foreground underline"
           >
             Tell us something directly
@@ -571,11 +571,11 @@ Replace `ReviewPage.tsx:333-344` (the heading block of the `feedback` stage):
 // after
       {stage === 'feedback' && (
         <>
-          {routedTo === 'destination' && (
+          {isPromoterBranch && (
             <Button
               type="button"
               variant="ghost"
-              onClick={handleBackToPromoter}
+              onClick={() => goToStage('promoter', 'Back to the Google link.')}
               className="mb-2 h-9 px-2 rounded-lg text-[13px] font-medium text-muted-foreground hover:text-foreground"
             >
               <ChevronLeft className="mr-1 h-4 w-4" />
@@ -587,7 +587,7 @@ Replace `ReviewPage.tsx:333-344` (the heading block of the `feedback` stage):
             tabIndex={-1}
             className="counter-display text-center text-[26px] font-semibold text-foreground focus:outline-none"
           >
-            {routedTo === 'destination' ? 'Tell us more' : 'What happened?'}
+            {isPromoterBranch ? 'Tell us more' : 'What happened?'}
           </h1>
           <p className="counter-micro mt-2 text-center text-[12px] text-muted-foreground">
             this goes straight to the owner — not public
@@ -1033,6 +1033,9 @@ AS $$
     -- guest who asked to hear back. A silent star tap is also born with
     -- status 'new' and needs no triage, so counting it would leave a badge
     -- the manager has no way to open or clear.
+    -- `isActionableResponse` in src/hooks/useReviewResponses.ts holds the same
+    -- rule for the client. Change both together, or the badge count and the
+    -- rows that show a status chip disagree.
     count(*) FILTER (
       WHERE rr.status = 'new'
         AND (rr.comment IS NOT NULL OR rr.contact_consent)
@@ -1243,6 +1246,10 @@ export type ReviewResponseFilter = 'all' | 'commented' | 'silent';
  * A row a manager can act on: a comment to read, or a guest who asked to hear
  * back. A silent five-star tap is neither, so it carries no status and no
  * contact card.
+ *
+ * The `unread_count` FILTER in `review_response_metrics` holds the same rule
+ * in SQL (supabase/migrations/20260806120000_review_metrics_actionable.sql).
+ * Change both together, or the header badge and the rows disagree.
  */
 export function isActionableResponse(response: ReviewResponse): boolean {
   return response.comment !== null || response.contact_consent;
@@ -1287,12 +1294,10 @@ export function useReviewResponses(
         )
         .eq('restaurant_id', restaurantId!);
 
-      const scoped =
-        filter === 'commented'
-          ? base.not('comment', 'is', null)
-          : filter === 'silent'
-            ? base.is('comment', null)
-            : base;
+      // `all` adds no predicate, so it reads the base query unchanged.
+      let scoped = base;
+      if (filter === 'commented') scoped = base.not('comment', 'is', null);
+      else if (filter === 'silent') scoped = base.is('comment', null);
 
       const { data, error } = await scoped
         .order('submitted_at', { ascending: false })
@@ -1312,7 +1317,7 @@ The `updateStatus` mutation invalidates `['review-responses', restaurantId]`. Re
 cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/review-funnel-followups && npx vitest run tests/unit/useReviewResponses.test.ts --reporter=verbose && npm run typecheck
 ```
 
-Expected: PASS, 16 tests. No type error.
+Expected: PASS, 17 tests. No type error.
 
 - [ ] **Step 5: Commit**
 
@@ -1380,7 +1385,7 @@ const EMPTY_STATES: Record<ReviewResponseFilter, { title: string; body: string }
   },
   commented: {
     title: 'No written feedback yet',
-    body: 'Guests who rate below your threshold get the private form. Their notes land here.',
+    body: 'Every guest can leave a note, at any star count. Their notes land here.',
   },
   silent: {
     title: 'Every rating here has a comment',
@@ -1445,14 +1450,23 @@ Replace `Reviews.tsx:114-123`:
   // status chip land most rows near 118px, and `measureElement` corrects the
   // rest. The cap the hook enforces is 500 rows, which is exactly the range
   // where mounting every row starts costing a manager real scroll latency.
+  // Both callbacks stay memoized. The virtualizer compares them by reference
+  // to decide if it must re-measure every row. A fresh arrow function per
+  // render breaks that check, so a plain row click re-measures all 500 rows.
+  // A silent row drops the two-line clamp and the status chip.
+  const estimateSize = useCallback(
+    (index: number) => (responses[index]?.comment ? 118 : 76),
+    [responses]
+  );
+  // Without a stable key the measurement cache is keyed by index. A filter
+  // change then applies the old row's height to the new row at that index.
+  const getItemKey = useCallback((index: number) => responses[index].id, [responses]);
+
   const virtualizer = useVirtualizer({
     count: responses.length,
     getScrollElement: () => listRef.current,
-    // A silent row drops the two-line clamp and the status chip.
-    estimateSize: (index) => (responses[index]?.comment ? 118 : 76),
-    // Without a stable key the measurement cache is keyed by index. A filter
-    // change then applies the old row's height to the new row at that index.
-    getItemKey: (index) => responses[index].id,
+    estimateSize,
+    getItemKey,
     overscan: 10,
   });
 

--- a/docs/superpowers/plans/2026-08-06-review-funnel-followups.md
+++ b/docs/superpowers/plans/2026-08-06-review-funnel-followups.md
@@ -1,0 +1,1738 @@
+# Review Funnel Follow-Ups Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a promoter leave a comment and contact details, and show every rating in the admin inbox.
+
+**Architecture:** The public page keeps the server's routing decision in state, then offers the follow-up form on both branches. The submit rule moves out of the JSX into a pure module, duplicated in Deno for the edge function. The admin hook takes a filter parameter that is applied server-side, before the 500-row cap. One `CREATE OR REPLACE` migration changes the unread rule to match.
+
+**Tech Stack:** React 18, TypeScript, Vite, TailwindCSS, shadcn/ui, React Query, Supabase (PostgreSQL + Deno edge functions), Vitest, Playwright, pgTAP.
+
+**Design doc:** `docs/superpowers/specs/2026-08-06-review-funnel-followups-design.md` (commit `4fe0175b`).
+
+## Global Constraints
+
+- Worktree: `/Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/review-funnel-followups`. Branch: `feature/review-funnel-followups`. Every Bash call starts with `cd <worktree> &&`.
+- Never `git add -A`, `git add .`, or `git commit -a`. Stage explicit paths only.
+- Write every comment, commit message and document in ASD-STE100. See `docs/STE100_STYLE.md`. Maximum 20 words for an instruction, 25 for a description. Active voice. No `-ing` word as a noun. No hedges.
+- No direct colors. Use semantic tokens (`text-foreground`, `bg-muted/30`, `border-border/40`).
+- No manual caching. React Query only, `staleTime: 30000`.
+- Every button without visible text needs `aria-label`. Every input needs a label.
+- Handle the loading state, the error state and the empty state.
+- The email shape check is duplicated: `src/lib/reviews/reviewSubmission.ts` (TypeScript) and `supabase/functions/_shared/reviewContact.ts` (Deno). The edge function cannot import from `src/`. The server copy is authoritative. Each copy names the other in a comment.
+- The migration must use `CREATE OR REPLACE FUNCTION`. A `DROP FUNCTION` resets the grants and breaks the Feedback tab header with `permission denied for function`.
+- Every early exit in `handleComment` after the 400 check returns `{ ok: true }`. A caller must not tell a bot trip from a replay from a real write.
+- Run Playwright with `--reporter=line`. Never the default `html` reporter.
+- Bound every wait with the Bash tool `timeout` parameter. No poll loop.
+
+---
+
+### Task 1: The submit rule module
+
+**Files:**
+- Create: `src/lib/reviews/reviewSubmission.ts`
+- Test: `tests/unit/reviewSubmission.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `export function isPlausibleEmail(value: string): boolean`
+  - `export function canSubmitFollowUp(input: { comment: string; consent: boolean; email: string }): boolean`
+  - `export const MAX_EMAIL_LENGTH = 320`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/reviewSubmission.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+
+import { canSubmitFollowUp, isPlausibleEmail } from '@/lib/reviews/reviewSubmission';
+
+describe('isPlausibleEmail', () => {
+  it('accepts an ordinary address', () => {
+    expect(isPlausibleEmail('ada@example.com')).toBe(true);
+  });
+
+  it('accepts a subdomain and a plus tag', () => {
+    expect(isPlausibleEmail('ada+tag@mail.example.co.uk')).toBe(true);
+  });
+
+  it('trims before it checks', () => {
+    expect(isPlausibleEmail('  ada@example.com  ')).toBe(true);
+  });
+
+  it('rejects an address with no domain', () => {
+    expect(isPlausibleEmail('ada@')).toBe(false);
+  });
+
+  it('rejects an address with no dot in the domain', () => {
+    expect(isPlausibleEmail('ada@localhost')).toBe(false);
+  });
+
+  it('rejects an address with a space', () => {
+    expect(isPlausibleEmail('ada example.com')).toBe(false);
+  });
+
+  it('rejects an empty value', () => {
+    expect(isPlausibleEmail('   ')).toBe(false);
+  });
+
+  it('rejects a value past the 320-character server limit', () => {
+    // The server slices at 320. A longer value would arrive truncated, so a
+    // client that calls it valid enables a button the server then rejects.
+    expect(isPlausibleEmail(`${'a'.repeat(320)}@example.com`)).toBe(false);
+  });
+});
+
+describe('canSubmitFollowUp', () => {
+  it('allows a comment on its own', () => {
+    expect(canSubmitFollowUp({ comment: 'The soup was cold', consent: false, email: '' })).toBe(
+      true
+    );
+  });
+
+  it('allows an email on its own when the guest consents', () => {
+    expect(canSubmitFollowUp({ comment: '', consent: true, email: 'ada@example.com' })).toBe(true);
+  });
+
+  it('refuses an email without consent', () => {
+    // Consent false means the server discards the value. A button that sends
+    // it promises the guest a reply the restaurant never gets.
+    expect(canSubmitFollowUp({ comment: '', consent: false, email: 'ada@example.com' })).toBe(
+      false
+    );
+  });
+
+  it('refuses a malformed email with no comment', () => {
+    expect(canSubmitFollowUp({ comment: '', consent: true, email: 'ada@' })).toBe(false);
+  });
+
+  it('refuses an empty form', () => {
+    expect(canSubmitFollowUp({ comment: '', consent: false, email: '' })).toBe(false);
+  });
+
+  it('refuses a whitespace-only comment with no email', () => {
+    expect(canSubmitFollowUp({ comment: '   \n  ', consent: false, email: '' })).toBe(false);
+  });
+
+  it('allows a malformed email when the guest also writes a comment', () => {
+    // The comment alone is enough. A typo in an optional field must not block
+    // the note the guest came to leave.
+    expect(canSubmitFollowUp({ comment: 'Great night', consent: true, email: 'ada@' })).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to check that it fails**
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/review-funnel-followups && npx vitest run tests/unit/reviewSubmission.test.ts --reporter=verbose
+```
+
+Expected: FAIL. The message names the missing module `@/lib/reviews/reviewSubmission`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/lib/reviews/reviewSubmission.ts`:
+
+```ts
+/**
+ * The rule that decides when the guest follow-up form may be sent.
+ *
+ * The comment is optional. A guest may give an email and no comment, or a
+ * comment and no email. A form that holds neither writes nothing, so the
+ * Send control stays disabled.
+ *
+ * The email shape check is a copy. `supabase/functions/_shared/reviewContact.ts`
+ * holds the Deno original, which an edge function can import and this file
+ * cannot. That copy is authoritative: this one only enables a button. Change
+ * both together.
+ */
+
+/** The longest email `handleComment` accepts. It slices at this length. */
+export const MAX_EMAIL_LENGTH = 320;
+
+/**
+ * One local part, one `@`, and a domain with at least one dot. Only a sent
+ * mail proves an address works. This check catches the typo a guest can see.
+ */
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@.]+(\.[^\s@.]+)+$/;
+
+export function isPlausibleEmail(value: string): boolean {
+  const trimmed = value.trim();
+  if (trimmed.length === 0 || trimmed.length > MAX_EMAIL_LENGTH) return false;
+  return EMAIL_PATTERN.test(trimmed);
+}
+
+export function canSubmitFollowUp(input: {
+  comment: string;
+  consent: boolean;
+  email: string;
+}): boolean {
+  if (input.comment.trim().length > 0) return true;
+  // Consent false means the server discards the name and the email. Without
+  // consent an address is not a payload.
+  return input.consent && isPlausibleEmail(input.email);
+}
+```
+
+- [ ] **Step 4: Run the test to check that it passes**
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/review-funnel-followups && npx vitest run tests/unit/reviewSubmission.test.ts --reporter=verbose
+```
+
+Expected: PASS, 16 tests.
+
+- [ ] **Step 5: Run the type check**
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/review-funnel-followups && npm run typecheck
+```
+
+Expected: no error.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/review-funnel-followups && git add src/lib/reviews/reviewSubmission.ts tests/unit/reviewSubmission.test.ts && git -c commit.gpgsign=false commit -m "feat(reviews): add the follow-up submit rule
+
+The comment becomes optional. A guest may give an email and no comment.
+The rule is pure, so a unit test covers it.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: The server accepts a contact-only submit
+
+**Files:**
+- Create: `supabase/functions/_shared/reviewContact.ts`
+- Modify: `supabase/functions/review-public/index.ts:257-330`
+
+**Interfaces:**
+- Consumes: the rule from Task 1, restated in Deno. No import across the boundary.
+- Produces: `export function isPlausibleEmail(value: string): boolean` and `export const MAX_EMAIL_LENGTH = 320` from `../_shared/reviewContact.ts`.
+
+**Context:** `handleComment` has no test harness in this repo. The edge function is stubbed in the E2E specs. Task 4 covers the client contract; the pgTAP test in Task 5 covers the aggregate. Verify this task with `npm run typecheck` and a careful read.
+
+- [ ] **Step 1: Create the shared Deno module**
+
+Create `supabase/functions/_shared/reviewContact.ts`:
+
+```ts
+/**
+ * The email shape check `handleComment` uses.
+ *
+ * `src/lib/reviews/reviewSubmission.ts` holds the client copy, which enables
+ * the Send control. This copy is authoritative: it decides what the server
+ * writes. An edge function cannot import from `src/`. Change both together.
+ */
+
+/** The longest email `handleComment` accepts. It slices at this length. */
+export const MAX_EMAIL_LENGTH = 320;
+
+/**
+ * One local part, one `@`, and a domain with at least one dot. Only a sent
+ * mail proves an address works. This check catches the typo a guest can see.
+ */
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@.]+(\.[^\s@.]+)+$/;
+
+export function isPlausibleEmail(value: string): boolean {
+  const trimmed = value.trim();
+  if (trimmed.length === 0 || trimmed.length > MAX_EMAIL_LENGTH) return false;
+  return EMAIL_PATTERN.test(trimmed);
+}
+```
+
+- [ ] **Step 2: Import the module in the edge function**
+
+In `supabase/functions/review-public/index.ts`, add one import after line 16:
+
+```ts
+import { hashIp, isOverLimit, REVIEW_RATE_WINDOW_MS } from '../_shared/reviewRateLimit.ts';
+import { isPlausibleEmail, MAX_EMAIL_LENGTH } from '../_shared/reviewContact.ts';
+```
+
+- [ ] **Step 3: Delete the duplicate constant**
+
+`index.ts:257-259` declares three constants. Delete the `MAX_EMAIL_LENGTH` line, which the import now supplies. Keep the other two.
+
+```ts
+// before
+const MAX_COMMENT_LENGTH = 4000;
+const MAX_NAME_LENGTH = 200;
+const MAX_EMAIL_LENGTH = 320;
+
+// after
+const MAX_COMMENT_LENGTH = 4000;
+const MAX_NAME_LENGTH = 200;
+```
+
+- [ ] **Step 4: Change the required-comment rule to a required-payload rule**
+
+Replace `index.ts:274-276`:
+
+```ts
+// before
+  // A malformed request is answered honestly with a 400 — that tells an
+  // attacker nothing they did not already know about their own payload.
+  if (!token || !comment || comment.length > MAX_COMMENT_LENGTH) return fail(400);
+
+// after
+  // A malformed request is answered honestly with a 400 — that tells an
+  // attacker nothing they did not already know about their own payload.
+  if (!token || comment.length > MAX_COMMENT_LENGTH) return fail(400);
+
+  // The comment is optional, the payload is not. A request with neither a
+  // comment nor a usable email writes nothing, so it stays a 400.
+  if (!comment && !(consent && isPlausibleEmail(email))) return fail(400);
+```
+
+- [ ] **Step 5: Move the single-use guard to `commented_at` and store NULL for an empty comment**
+
+Replace `index.ts:313-324`:
+
+```ts
+// before
+  // `comment IS NULL` is what makes the token single-use: a replay updates
+  // zero rows and still answers ok.
+  const { data: updated, error: updateError } = await supabase
+    .from('review_responses')
+    .update({
+      comment,
+      contact_consent: consent,
+      commented_at: new Date().toISOString(),
+    })
+    .eq('id', payload.rid)
+    .is('comment', null)
+    .select('id');
+
+// after
+  // `commented_at IS NULL` is what makes the token single-use: a replay
+  // updates zero rows and still answers ok. `comment IS NULL` cannot do that
+  // job now — a contact-only submit leaves the comment NULL, so a replay
+  // would match again, re-run the UPDATE, and hit the primary key on
+  // review_response_contacts. `handleComment` is the only writer of
+  // `commented_at`, so the new guard rejects every replay the old one did.
+  //
+  // An empty comment stores as NULL, not as an empty string.
+  // `review_response_metrics` counts `comment IS NOT NULL`, so an empty
+  // string would inflate the comment count and put a blank row in the inbox.
+  const { data: updated, error: updateError } = await supabase
+    .from('review_responses')
+    .update({
+      comment: comment || null,
+      contact_consent: consent,
+      commented_at: new Date().toISOString(),
+    })
+    .eq('id', payload.rid)
+    .is('commented_at', null)
+    .select('id');
+```
+
+- [ ] **Step 6: Run the type check and the lint**
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/review-funnel-followups && npm run typecheck && npm run lint
+```
+
+Expected: no error. `npm run typecheck` skips `supabase/functions`; the lint covers it.
+
+- [ ] **Step 7: Read the changed handler once, end to end**
+
+Read `supabase/functions/review-public/index.ts:261-349`. Check three rules:
+1. Every exit after the two 400 lines returns `ok()`, which is `{ ok: true }`.
+2. The honeypot path and the rate limit path do not change.
+3. The contact insert still runs on `consent && (name || email)`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/review-funnel-followups && git add supabase/functions/_shared/reviewContact.ts supabase/functions/review-public/index.ts && git -c commit.gpgsign=false commit -m "feat(reviews): accept a contact-only follow-up submit
+
+The comment becomes optional on the server. The single-use guard moves to
+commented_at, which stays the only column handleComment writes for that
+job. An empty comment stores as NULL.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: The promoter screen offers the form
+
+**Files:**
+- Modify: `src/pages/ReviewPage.tsx`
+
+**Interfaces:**
+- Consumes: `canSubmitFollowUp` from `@/lib/reviews/reviewSubmission` (Task 1).
+- Produces: the DOM contract Task 4 asserts against — a `Tell us something directly` button, a `Back` button, a `Your feedback (optional)` label, and a `Leave a Google review` link on the `thanks` stage.
+
+- [ ] **Step 1: Add the imports**
+
+In `src/pages/ReviewPage.tsx`, add the icon import and the module import. Follow the project import order: icons after the UI components, libraries last.
+
+```tsx
+import { StarRating } from '@/components/reviews/StarRating';
+
+import { ChevronLeft } from 'lucide-react';
+
+import { canSubmitFollowUp } from '@/lib/reviews/reviewSubmission';
+import {
+  classifyReviewPageResponse,
+  type PublicReviewPage,
+  type ReviewPageLoadState,
+} from '@/lib/reviews/reviewPageLoad';
+```
+
+- [ ] **Step 2: Add the `routedTo` state**
+
+After the `destinationUrl` state (`ReviewPage.tsx:48`), add:
+
+```tsx
+  const [destinationUrl, setDestinationUrl] = useState<string | null>(null);
+  // The server's branch decision. The form copy follows it: `What happened?`
+  // in front of a five-star guest reads as an accusation.
+  const [routedTo, setRoutedTo] = useState<'destination' | 'feedback' | null>(null);
+```
+
+- [ ] **Step 3: Record the branch in `handleCommit`**
+
+Replace `ReviewPage.tsx:144-152`:
+
+```tsx
+// before
+      setToken(data.token as string);
+      if (data.routed_to === 'destination') {
+        setDestinationUrl((data.destination_url as string) ?? null);
+        setStage('promoter');
+        setAnnouncement('Thanks. You can share this on Google.');
+      } else {
+        setStage('feedback');
+        setAnnouncement('Tell us what happened. This goes straight to the owner.');
+      }
+
+// after
+      setToken(data.token as string);
+      if (data.routed_to === 'destination') {
+        setDestinationUrl((data.destination_url as string) ?? null);
+        setRoutedTo('destination');
+        setStage('promoter');
+        setAnnouncement('Thanks. You can share this on Google.');
+      } else {
+        setRoutedTo('feedback');
+        setStage('feedback');
+        setAnnouncement('Tell us what happened. This goes straight to the owner.');
+      }
+```
+
+- [ ] **Step 4: Add the two stage-move callbacks**
+
+After `handleCommit` (`ReviewPage.tsx:155`), add:
+
+```tsx
+  // Both moves clear the error banner first. `That didn't send.` over a form
+  // the guest has not sent yet reads as a new failure.
+  const handleOpenFeedback = useCallback(() => {
+    setSubmitError(false);
+    setStage('feedback');
+    setAnnouncement('Tell us more. This goes straight to the owner.');
+  }, []);
+
+  const handleBackToPromoter = useCallback(() => {
+    setSubmitError(false);
+    setStage('promoter');
+    setAnnouncement('Back to the Google link.');
+  }, []);
+```
+
+The comment text, the consent tick, the name and the email are not cleared. A guest who taps `Back` and returns keeps what they typed.
+
+- [ ] **Step 5: Change the submit guard, the payload and the announcement**
+
+Replace `ReviewPage.tsx:157-180`:
+
+```tsx
+// before
+  const handleSubmitComment = useCallback(async () => {
+    if (!token || !comment.trim()) return;
+    setSubmitting(true);
+    setSubmitError(false);
+
+    const { error } = await supabase.functions.invoke('review-public', {
+      body: {
+        action: 'comment',
+        token,
+        comment: comment.trim(),
+        consent,
+        name: consent ? name : undefined,
+        email: consent ? email : undefined,
+        hp: honeypot,
+      },
+    });
+
+    setSubmitting(false);
+    if (error) {
+      setSubmitError(true);
+      return;
+    }
+    setStage('thanks');
+  }, [comment, consent, email, honeypot, name, token]);
+
+// after
+  const handleSubmitComment = useCallback(async () => {
+    // The `disabled` prop is not the only gate. This guard must hold the same
+    // rule, or a tap that gets past the button answers with nothing: no
+    // request, no error, no new stage.
+    if (!token || !canSubmitFollowUp({ comment, consent, email })) return;
+    setSubmitting(true);
+    setSubmitError(false);
+
+    const { error } = await supabase.functions.invoke('review-public', {
+      body: {
+        action: 'comment',
+        token,
+        // An empty string would store as a blank comment. Send nothing.
+        comment: comment.trim() || undefined,
+        consent,
+        name: consent ? name : undefined,
+        email: consent ? email : undefined,
+        hp: honeypot,
+      },
+    });
+
+    setSubmitting(false);
+    if (error) {
+      setSubmitError(true);
+      return;
+    }
+    setStage('thanks');
+    setAnnouncement(
+      destinationUrl
+        ? 'Thanks. You can also share this on Google.'
+        : 'Thanks. The owner has your note.'
+    );
+  }, [comment, consent, destinationUrl, email, honeypot, name, token]);
+```
+
+- [ ] **Step 6: Add the `Tell us something directly` control to the promoter stage**
+
+Replace `ReviewPage.tsx:323-329` (the `No thanks` button) with two controls:
+
+```tsx
+// before
+          <button
+            type="button"
+            onClick={() => setStage('thanks')}
+            className="counter-micro mt-4 w-full text-center text-[12px] text-muted-foreground underline"
+          >
+            No thanks
+          </button>
+
+// after
+          <button
+            type="button"
+            onClick={handleOpenFeedback}
+            className="counter-micro mt-4 w-full text-center text-[12px] text-muted-foreground underline"
+          >
+            Tell us something directly
+          </button>
+          <button
+            type="button"
+            onClick={() => setStage('thanks')}
+            className="counter-micro mt-2 w-full text-center text-[12px] text-muted-foreground underline"
+          >
+            No thanks
+          </button>
+```
+
+- [ ] **Step 7: Add the `Back` control and the branch copy to the feedback stage**
+
+Replace `ReviewPage.tsx:333-344` (the heading block of the `feedback` stage):
+
+```tsx
+// before
+      {stage === 'feedback' && (
+        <>
+          <h1
+            ref={branchHeadingRef}
+            tabIndex={-1}
+            className="counter-display text-center text-[26px] font-semibold text-foreground focus:outline-none"
+          >
+            What happened?
+          </h1>
+          <p className="counter-micro mt-2 text-center text-[12px] text-muted-foreground">
+            this goes straight to the owner — not public
+          </p>
+
+// after
+      {stage === 'feedback' && (
+        <>
+          {routedTo === 'destination' && (
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={handleBackToPromoter}
+              className="mb-2 h-9 px-2 rounded-lg text-[13px] font-medium text-muted-foreground hover:text-foreground"
+            >
+              <ChevronLeft className="mr-1 h-4 w-4" />
+              Back
+            </Button>
+          )}
+          <h1
+            ref={branchHeadingRef}
+            tabIndex={-1}
+            className="counter-display text-center text-[26px] font-semibold text-foreground focus:outline-none"
+          >
+            {routedTo === 'destination' ? 'Tell us more' : 'What happened?'}
+          </h1>
+          <p className="counter-micro mt-2 text-center text-[12px] text-muted-foreground">
+            this goes straight to the owner — not public
+          </p>
+```
+
+The `Back` control renders on the promoter branch only. A detractor never saw the `promoter` stage, so `Back` would move them to a screen they have not seen.
+
+- [ ] **Step 8: Change the field label and add the help line**
+
+Replace `ReviewPage.tsx:347-358` (the comment field block):
+
+```tsx
+// before
+            <div>
+              <Label htmlFor="review-comment" className="text-[13px] text-foreground">
+                Your feedback
+              </Label>
+              <Textarea
+                id="review-comment"
+                value={comment}
+                onChange={(event) => setComment(event.target.value)}
+                rows={4}
+                className="mt-1.5 bg-background border-border"
+              />
+            </div>
+
+// after
+            <div>
+              <Label htmlFor="review-comment" className="text-[13px] text-foreground">
+                Your feedback (optional)
+              </Label>
+              <Textarea
+                id="review-comment"
+                value={comment}
+                onChange={(event) => setComment(event.target.value)}
+                rows={4}
+                className="mt-1.5 bg-background border-border"
+              />
+              {/* Without this line a guest who wants no comment sees a dead
+                  Send control and no reason for it. */}
+              <p className="counter-micro mt-1.5 text-[12px] text-muted-foreground">
+                Write a note, give your email, or both.
+              </p>
+            </div>
+```
+
+- [ ] **Step 9: Change the Send control rule**
+
+Replace `ReviewPage.tsx:417-424`:
+
+```tsx
+// before
+            <Button
+              type="button"
+              onClick={handleSubmitComment}
+              disabled={submitting || comment.trim().length === 0}
+              className="h-11 w-full rounded-lg bg-primary text-[15px] font-medium text-primary-foreground"
+            >
+              {submitting ? 'Sending…' : 'Send to the owner'}
+            </Button>
+
+// after
+            <Button
+              type="button"
+              onClick={handleSubmitComment}
+              disabled={submitting || !canSubmitFollowUp({ comment, consent, email })}
+              className="h-11 w-full rounded-lg bg-primary text-[15px] font-medium text-primary-foreground"
+            >
+              {submitting ? 'Sending…' : 'Send to the owner'}
+            </Button>
+```
+
+- [ ] **Step 10: Add the Google button to the thanks stage**
+
+Replace `ReviewPage.tsx:429-442`:
+
+```tsx
+// before
+      {stage === 'thanks' && (
+        <>
+          <h1
+            ref={branchHeadingRef}
+            tabIndex={-1}
+            className="counter-display text-center text-[26px] font-semibold text-foreground focus:outline-none"
+          >
+            Thanks for telling us
+          </h1>
+          <p className="counter-micro mt-3 text-center text-[12px] text-muted-foreground">
+            have a good one
+          </p>
+        </>
+      )}
+
+// after
+      {stage === 'thanks' && (
+        <>
+          <h1
+            ref={branchHeadingRef}
+            tabIndex={-1}
+            className="counter-display text-center text-[26px] font-semibold text-foreground focus:outline-none"
+          >
+            Thanks for telling us
+          </h1>
+          {/* A sign-off above a call to action reads as an end. Say what the
+              button below is for, or say goodbye — never both. */}
+          <p className="counter-micro mt-3 text-center text-[12px] text-muted-foreground">
+            {destinationUrl ? 'You can also share this on Google.' : 'have a good one'}
+          </p>
+          {/* A comment must not cost the restaurant a Google review. */}
+          {destinationUrl && (
+            <a
+              href={destinationUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-6 flex h-11 w-full items-center justify-center rounded-lg bg-primary text-[15px] font-medium text-primary-foreground"
+            >
+              Leave a Google review
+            </a>
+          )}
+        </>
+      )}
+```
+
+- [ ] **Step 11: Run the type check, the lint and the whole unit suite**
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/review-funnel-followups && npm run typecheck && npm run lint && npx vitest run --reporter=dot
+```
+
+Expected: no type error, no lint error, and the unit suite stays green.
+
+- [ ] **Step 12: Commit**
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/review-funnel-followups && git add src/pages/ReviewPage.tsx && git -c commit.gpgsign=false commit -m "feat(reviews): offer the follow-up form to a promoter
+
+The promoter screen gains a Tell us something directly control. The form
+gains a Back control and branch copy. The comment becomes optional. The
+thanks screen keeps the Google button.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: The promoter path, end to end
+
+**Files:**
+- Create: `tests/e2e/review-promoter-followup.spec.ts`
+
+**Interfaces:**
+- Consumes: the DOM contract from Task 3.
+- Produces: nothing.
+
+**Context:** `tests/e2e/review-stars.spec.ts` is the model. The edge function does not run in the E2E stack, so `review-public` is stubbed with `page.route`. What the spec proves is the client wiring: which controls appear, and what the client sends.
+
+- [ ] **Step 1: Write the failing spec**
+
+Create `tests/e2e/review-promoter-followup.spec.ts`:
+
+```ts
+import { test, expect } from '@playwright/test';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * E2E: a promoter can leave a comment, an email, or both.
+ *
+ * Slice 1 sent a four-star or five-star guest straight to the Google
+ * hand-off, with no way back. This spec is the regression guard for the
+ * three paths that hand-off must not close.
+ *
+ * The edge function is not served in the e2e stack, so `review-public` is
+ * stubbed. Its token and routing logic are covered elsewhere; what this
+ * proves is the wiring — which controls appear, and what the client sends.
+ */
+
+const FN_GLOB = '**/functions/v1/review-public';
+const PAGE_BODY = {
+  restaurant_name: 'Test Diner',
+  headline: 'How was everything?',
+  subheadline: null,
+  logo_url: null,
+  threshold: 4,
+};
+const RATE_BODY = {
+  token: 'stub-token',
+  routed_to: 'destination',
+  destination_url: 'https://example.com/google-review',
+};
+
+/** Stubs the three actions and collects every `comment` body the page sends. */
+async function stubReviewPublic(page: any, commentBodies: any[]) {
+  await page.route(FN_GLOB, async (route: any) => {
+    const body = route.request().postDataJSON();
+    if (body.action === 'page') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(PAGE_BODY),
+      });
+    }
+    if (body.action === 'rate') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(RATE_BODY),
+      });
+    }
+    commentBodies.push(body);
+    return route.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' });
+  });
+}
+
+test.describe('public review page promoter follow-up', () => {
+  test('a promoter reaches the form and returns with the text kept', async ({ page }) => {
+    await stubReviewPublic(page, []);
+    await page.goto('/r/table-tents');
+
+    await page.getByRole('radio', { name: '5 out of 5 stars' }).click();
+    await expect(page.getByRole('heading', { name: /thank you/i })).toBeVisible();
+
+    await page.getByRole('button', { name: /tell us something directly/i }).click();
+
+    // The heading follows the branch: `What happened?` reads as an
+    // accusation in front of a five-star guest.
+    await expect(page.getByRole('heading', { name: /tell us more/i })).toBeVisible();
+    const field = page.getByLabel(/your feedback \(optional\)/i);
+    await field.fill('The bread was excellent');
+
+    await page.getByRole('button', { name: /^back$/i }).click();
+    await expect(page.getByRole('link', { name: /leave a google review/i })).toBeVisible();
+
+    await page.getByRole('button', { name: /tell us something directly/i }).click();
+    await expect(page.getByLabel(/your feedback \(optional\)/i)).toHaveValue(
+      'The bread was excellent'
+    );
+  });
+
+  test('a promoter sends a comment and still sees the Google button', async ({ page }) => {
+    const commentBodies: any[] = [];
+    await stubReviewPublic(page, commentBodies);
+    await page.goto('/r/table-tents');
+
+    await page.getByRole('radio', { name: '5 out of 5 stars' }).click();
+    await page.getByRole('button', { name: /tell us something directly/i }).click();
+    await page.getByLabel(/your feedback \(optional\)/i).fill('The bread was excellent');
+    await page.getByRole('button', { name: /send to the owner/i }).click();
+
+    await expect(page.getByRole('heading', { name: /thanks for telling us/i })).toBeVisible();
+    expect(commentBodies).toHaveLength(1);
+    expect(commentBodies[0]).toMatchObject({
+      action: 'comment',
+      token: 'stub-token',
+      comment: 'The bread was excellent',
+    });
+
+    // A comment must not cost the restaurant a Google review.
+    const link = page.getByRole('link', { name: /leave a google review/i });
+    await expect(link).toHaveAttribute('href', 'https://example.com/google-review');
+  });
+
+  test('a promoter sends an email with no comment', async ({ page }) => {
+    const commentBodies: any[] = [];
+    await stubReviewPublic(page, commentBodies);
+    await page.goto('/r/table-tents');
+
+    await page.getByRole('radio', { name: '5 out of 5 stars' }).click();
+    await page.getByRole('button', { name: /tell us something directly/i }).click();
+
+    const send = page.getByRole('button', { name: /send to the owner/i });
+    // An empty form writes nothing, so the control stays disabled.
+    await expect(send).toBeDisabled();
+
+    await page.getByLabel(/it's ok to contact me about this/i).check();
+    await page.getByLabel(/^email$/i).fill('ada@example.com');
+    await expect(send).toBeEnabled();
+    await send.click();
+
+    await expect(page.getByRole('heading', { name: /thanks for telling us/i })).toBeVisible();
+    expect(commentBodies).toHaveLength(1);
+    // No empty string. An empty comment would store as a blank inbox row.
+    expect(commentBodies[0].comment).toBeUndefined();
+    expect(commentBodies[0]).toMatchObject({ consent: true, email: 'ada@example.com' });
+  });
+});
+```
+
+- [ ] **Step 2: Run the spec**
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/review-funnel-followups && npx playwright test tests/e2e/review-promoter-followup.spec.ts --reporter=line
+```
+
+Expected: PASS, 3 tests. Task 3 already ships the behaviour.
+
+If a selector fails, fix the selector — not the page. The page is the approved design. If the page is genuinely wrong, report it and stop.
+
+If the run fails to start because the local Supabase auth database returns `500 "Database error finding user"`, that is a known environment fault. Run `npm run db:reset` first. This spec signs in nobody, so only the dev server must be up.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/review-funnel-followups && git add tests/e2e/review-promoter-followup.spec.ts && git -c commit.gpgsign=false commit -m "test(reviews): cover the promoter follow-up path end to end
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: The unread metric follows the actionable rule
+
+**Files:**
+- Create: `supabase/migrations/20260806120000_review_metrics_actionable.sql`
+- Modify: `supabase/tests/review_response_aggregates_test.sql`
+
+**Interfaces:**
+- Consumes: `public.review_response_metrics(p_restaurant_id UUID)` from `20260804110000_review_response_aggregates.sql:46`.
+- Produces: the same four columns, with a new `unread_count` rule. Task 7 shows the number; the shape does not change.
+
+- [ ] **Step 1: Write the failing pgTAP test**
+
+Edit `supabase/tests/review_response_aggregates_test.sql`. Add a fourth fixture row and change the four expectations the row moves.
+
+Replace the fixture comment and the response INSERT (lines 4-6 and 24-35):
+
+```sql
+-- Fixture: one page in restaurant A with four responses — one commented, one
+-- contact-only, two silent — plus an owner (manage:reviews) and an outsider
+-- with no restaurant at all.
+```
+
+```sql
+INSERT INTO public.review_responses
+  (id, restaurant_id, review_page_id, rating, routed_to, comment, contact_consent, status)
+VALUES
+  ('33333333-0000-0000-0000-000000000001',
+   '11111111-0000-0000-0000-000000000001',
+   '22222222-0000-0000-0000-000000000001', 5, 'destination', NULL, false, 'new'),
+  ('33333333-0000-0000-0000-000000000002',
+   '11111111-0000-0000-0000-000000000001',
+   '22222222-0000-0000-0000-000000000001', 2, 'feedback', 'The soup was cold', false, 'new'),
+  ('33333333-0000-0000-0000-000000000003',
+   '11111111-0000-0000-0000-000000000001',
+   '22222222-0000-0000-0000-000000000001', 4, 'destination', NULL, false, 'resolved'),
+  -- A promoter who left an email and no comment. The guest asked to hear
+  -- back, so the row is actionable and must reach the Unread badge.
+  ('33333333-0000-0000-0000-000000000004',
+   '11111111-0000-0000-0000-000000000001',
+   '22222222-0000-0000-0000-000000000001', 5, 'destination', NULL, true, 'new');
+```
+
+Change the four expectations:
+
+```sql
+SELECT is(
+  (SELECT average_rating FROM public.review_response_metrics('11111111-0000-0000-0000-000000000001')),
+  4.0::numeric,
+  'review_response_metrics averages every rating, not just commented ones ((5+2+4+5)/4 = 4.0)'
+);
+
+SELECT is(
+  (SELECT total_ratings FROM public.review_response_metrics('11111111-0000-0000-0000-000000000001')),
+  4::bigint,
+  'review_response_metrics counts all four responses, unbounded by any row cap'
+);
+```
+
+`comment_count` stays `1::bigint`. Replace its neighbour, the unread assertion (lines 60-67):
+
+```sql
+-- Three rows are status 'new': a comment, a contact-only submit, and a
+-- silent five-star tap. The first two need a reply. The third needs no
+-- triage, so counting it would put a badge on the tab that the manager has
+-- no row to act on and no way to clear.
+SELECT is(
+  (SELECT unread_count FROM public.review_response_metrics('11111111-0000-0000-0000-000000000001')),
+  2::bigint,
+  'review_response_metrics counts a new comment and a new contact-only row, not a silent tap'
+);
+```
+
+Change the `review_page_stats` assertion (lines 69-74):
+
+```sql
+SELECT is(
+  (SELECT rating_count FROM public.review_page_stats('11111111-0000-0000-0000-000000000001')
+   WHERE review_page_id = '22222222-0000-0000-0000-000000000001'),
+  4::bigint,
+  'review_page_stats aggregates per page via GROUP BY, not per-card round trips'
+);
+```
+
+`SELECT plan(6);` does not change. The count of assertions is the same.
+
+- [ ] **Step 2: Run the test to check that it fails**
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/review-funnel-followups && npm run test:db
+```
+
+Expected: FAIL on the unread assertion. It reports `have: 1` and `want: 2`. The old rule counts the comment row alone.
+
+If the local Supabase stack is not up, run `npm run db:start` first.
+
+- [ ] **Step 3: Write the migration**
+
+Create `supabase/migrations/20260806120000_review_metrics_actionable.sql`:
+
+```sql
+-- ============================================================================
+-- Review funnel follow-ups: the unread badge follows the actionable rule.
+--
+-- A guest can now finish the follow-up form with contact details and no
+-- comment. That guest asked to hear back, so the row needs a reply and must
+-- reach the Unread badge. The old rule counted `comment IS NOT NULL` alone
+-- and under-counts it.
+--
+-- Warning: a DROP FUNCTION here breaks the page for every user. A DROP resets
+-- the grants, `authenticated` loses EXECUTE, and the Feedback tab header
+-- fails with `permission denied for function`. Use CREATE OR REPLACE, keep
+-- the same signature and the same attributes, and restate the two grant
+-- lines below.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.review_response_metrics(p_restaurant_id UUID)
+RETURNS TABLE (
+  average_rating NUMERIC,
+  total_ratings BIGINT,
+  comment_count BIGINT,
+  unread_count BIGINT
+)
+LANGUAGE sql
+STABLE
+SET search_path = public, pg_temp
+AS $$
+  SELECT
+    round(avg(rr.rating)::numeric, 1) AS average_rating,
+    count(*) AS total_ratings,
+    count(*) FILTER (WHERE rr.comment IS NOT NULL) AS comment_count,
+    -- Unread counts the rows a manager can act on: a comment to read, or a
+    -- guest who asked to hear back. A silent star tap is also born with
+    -- status 'new' and needs no triage, so counting it would leave a badge
+    -- the manager has no way to open or clear.
+    count(*) FILTER (
+      WHERE rr.status = 'new'
+        AND (rr.comment IS NOT NULL OR rr.contact_consent)
+    ) AS unread_count
+  FROM public.review_responses rr
+  WHERE rr.restaurant_id = p_restaurant_id;
+$$;
+
+REVOKE ALL ON FUNCTION public.review_response_metrics(UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.review_response_metrics(UUID) TO authenticated;
+
+COMMENT ON FUNCTION public.review_response_metrics(UUID) IS
+'Restaurant-wide average rating / total ratings / comment count / unread actionable count for the Feedback tab header. Unread counts a new row that holds a comment or contact consent. Not capped at any row count, unlike the list query that backs the inbox rows themselves.';
+
+COMMENT ON COLUMN public.review_responses.commented_at IS
+'When the guest finished the follow-up form. Does NOT imply a comment: a contact-only submit sets this and leaves comment NULL. Use comment IS NOT NULL to test for a comment.';
+```
+
+- [ ] **Step 4: Apply the migration and run the test to check that it passes**
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/review-funnel-followups && npm run db:reset && npm run test:db
+```
+
+Expected: PASS. The file reports 6 of 6.
+
+- [ ] **Step 5: Check that the grant survived**
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/review-funnel-followups && npx supabase db execute --local "SELECT has_function_privilege('authenticated', 'public.review_response_metrics(uuid)', 'EXECUTE') AS granted;"
+```
+
+Expected: `granted` is `t`. A `f` means the migration dropped the function. Fix the migration; do not add a second grant migration.
+
+If that CLI command is not available in this environment, use `mcp__supabase__execute_sql` against the local server with the same SELECT.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/review-funnel-followups && git add supabase/migrations/20260806120000_review_metrics_actionable.sql supabase/tests/review_response_aggregates_test.sql && git -c commit.gpgsign=false commit -m "feat(reviews): count a contact-only row as unread
+
+A guest who leaves an email and no comment asked to hear back. The unread
+metric now counts a new row that holds a comment or contact consent.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: The inbox filter parameter
+
+**Files:**
+- Modify: `src/hooks/useReviewResponses.ts:41-74`
+- Test: `tests/unit/useReviewResponses.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `export type ReviewResponseFilter = 'all' | 'commented' | 'silent'`
+  - `export function useReviewResponses(restaurantId?: string, filter: ReviewResponseFilter = 'all')`
+  - `export function isActionableResponse(response: ReviewResponse): boolean`
+
+`isActionableResponse` lives here, beside the `ReviewResponse` type. Task 7 and Task 8 both consume it, and both already import the type from this module. One predicate, one place.
+
+- [ ] **Step 1: Change the list stub and write the failing tests**
+
+In `tests/unit/useReviewResponses.test.ts`, replace `makeListStub` (lines 26-34). The `all` mode calls neither `.not()` nor `.is()`, so `.eq()` must return `order` as well.
+
+```ts
+/**
+ * `.select(...).eq(...)` then, per filter, `.not(...)` / `.is(...)` / neither,
+ * then `.order(...).limit(...)`. The `all` mode adds no predicate, so `eq`
+ * carries `order` directly.
+ */
+function makeListStub(data: unknown, error: unknown = null) {
+  const limit = vi.fn(async () => ({ data, error }));
+  const order = vi.fn(() => ({ limit }));
+  const not = vi.fn(() => ({ order }));
+  const is = vi.fn(() => ({ order }));
+  const eq = vi.fn(() => ({ not, is, order }));
+  const select = vi.fn(() => ({ eq }));
+  return { stub: { select }, select, eq, not, is, order, limit };
+}
+```
+
+Add the type import beside the hook import (line 15):
+
+```ts
+import { useReviewResponses, type ReviewResponseFilter } from '@/hooks/useReviewResponses';
+```
+
+Replace the test at line 99 (`filters to commented rows server-side…`) with four tests:
+
+```ts
+  it('adds no comment predicate by default, then caps at 500, newest first', async () => {
+    const list = makeListStub([RESPONSE_ROW]);
+    mockSupabase.from.mockReturnValue(list.stub);
+    mockSupabase.rpc.mockResolvedValue({ data: [METRICS_ROW], error: null });
+
+    const { result } = renderHook(() => useReviewResponses('rest-1'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.responses).toHaveLength(1));
+    expect(mockSupabase.from).toHaveBeenCalledWith('review_responses');
+    expect(list.eq).toHaveBeenCalledWith('restaurant_id', 'rest-1');
+    // A silent rating is a rating. The default mode hides nothing.
+    expect(list.not).not.toHaveBeenCalled();
+    expect(list.is).not.toHaveBeenCalled();
+    expect(list.order).toHaveBeenCalledWith('submitted_at', { ascending: false });
+    expect(list.limit).toHaveBeenCalledWith(500);
+  });
+
+  it('filters to commented rows server-side, before the cap', async () => {
+    const list = makeListStub([RESPONSE_ROW]);
+    mockSupabase.from.mockReturnValue(list.stub);
+    mockSupabase.rpc.mockResolvedValue({ data: [METRICS_ROW], error: null });
+
+    const { result } = renderHook(() => useReviewResponses('rest-1', 'commented'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.responses).toHaveLength(1));
+    // The predicate must precede the cap. A client-side filter after a
+    // 500-row fetch loses a written complaint behind 500 newer silent taps.
+    expect(list.not).toHaveBeenCalledWith('comment', 'is', null);
+    expect(list.limit).toHaveBeenCalledWith(500);
+  });
+
+  it('filters to silent rows server-side, before the cap', async () => {
+    const list = makeListStub([RESPONSE_ROW]);
+    mockSupabase.from.mockReturnValue(list.stub);
+    mockSupabase.rpc.mockResolvedValue({ data: [METRICS_ROW], error: null });
+
+    const { result } = renderHook(() => useReviewResponses('rest-1', 'silent'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.responses).toHaveLength(1));
+    expect(list.is).toHaveBeenCalledWith('comment', null);
+    expect(list.limit).toHaveBeenCalledWith(500);
+  });
+
+  it('caches each filter on its own key, so a filter change refetches', async () => {
+    const list = makeListStub([RESPONSE_ROW]);
+    mockSupabase.from.mockReturnValue(list.stub);
+    mockSupabase.rpc.mockResolvedValue({ data: [METRICS_ROW], error: null });
+
+    const { rerender } = renderHook(
+      ({ filter }: { filter: ReviewResponseFilter }) => useReviewResponses('rest-1', filter),
+      { wrapper: createWrapper(), initialProps: { filter: 'all' as ReviewResponseFilter } }
+    );
+    await waitFor(() => expect(list.limit).toHaveBeenCalledTimes(1));
+
+    // A shared query key would answer `silent` from the `all` cache and show
+    // commented rows under a filter that excludes them.
+    rerender({ filter: 'silent' });
+    await waitFor(() => expect(list.limit).toHaveBeenCalledTimes(2));
+    expect(list.is).toHaveBeenCalledWith('comment', null);
+  });
+```
+
+Add one test for the predicate, at the end of the `describe` block:
+
+```ts
+  it('calls a row actionable when it holds a comment or contact consent', () => {
+    expect(isActionableResponse({ ...RESPONSE_ROW, comment: 'x', contact_consent: false })).toBe(
+      true
+    );
+    // The guest asked to hear back. That is a chore, comment or not.
+    expect(isActionableResponse({ ...RESPONSE_ROW, comment: null, contact_consent: true })).toBe(
+      true
+    );
+    // A silent five-star tap needs no triage.
+    expect(isActionableResponse({ ...RESPONSE_ROW, comment: null, contact_consent: false })).toBe(
+      false
+    );
+  });
+```
+
+Extend the hook import to carry it:
+
+```ts
+import {
+  isActionableResponse,
+  useReviewResponses,
+  type ReviewResponseFilter,
+} from '@/hooks/useReviewResponses';
+```
+
+- [ ] **Step 2: Run the tests to check that they fail**
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/review-funnel-followups && npx vitest run tests/unit/useReviewResponses.test.ts --reporter=verbose
+```
+
+Expected: FAIL. `isActionableResponse` is not exported, and the default mode still calls `.not()`.
+
+- [ ] **Step 3: Change the hook**
+
+In `src/hooks/useReviewResponses.ts`, add the type and the predicate after the `ReviewResponse` interface (line 21):
+
+```ts
+/** Which rows the inbox list asks for. The predicate runs server-side. */
+export type ReviewResponseFilter = 'all' | 'commented' | 'silent';
+
+/**
+ * A row a manager can act on: a comment to read, or a guest who asked to hear
+ * back. A silent five-star tap is neither, so it carries no status and no
+ * contact card.
+ */
+export function isActionableResponse(response: ReviewResponse): boolean {
+  return response.comment !== null || response.contact_consent;
+}
+```
+
+Replace the signature and the list query (lines 41-74):
+
+```ts
+export function useReviewResponses(
+  restaurantId?: string,
+  filter: ReviewResponseFilter = 'all'
+) {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  const query = useQuery({
+    // The filter joins the key, so each mode caches on its own. A shared key
+    // would answer `silent` from the `all` cache.
+    queryKey: ['review-responses', restaurantId, filter],
+    enabled: Boolean(restaurantId),
+    staleTime: 30000,
+    refetchOnWindowFocus: true,
+    queryFn: async (): Promise<ReviewResponse[]> => {
+      // The filter is applied SERVER-side, before the cap. A filter after a
+      // `.limit(500)` would mean a location that takes 500 silent star taps
+      // after a written complaint fetches 500 silent rows and shows an empty
+      // inbox — the complaint dropped off the end of a window it was never in.
+      //
+      // Known limit: in `all` mode a heavy run of silent taps can push an old
+      // comment past the 500-row cap. `With comments` is the mode that
+      // guarantees the full comment list.
+      //
+      // Capped at 500 for the inbox *list* only. The header metrics below do
+      // NOT come from this capped array; they're a separate, uncapped
+      // server-side aggregate, so a restaurant past 500 comments still sees a
+      // correct average/total/unread count.
+      const base = supabase
+        .from('review_responses' as any)
+        .select(
+          'id, restaurant_id, review_page_id, rating, routed_to, comment, contact_consent, status, submitted_at, commented_at'
+        )
+        .eq('restaurant_id', restaurantId!);
+
+      const scoped =
+        filter === 'commented'
+          ? base.not('comment', 'is', null)
+          : filter === 'silent'
+            ? base.is('comment', null)
+            : base;
+
+      const { data, error } = await scoped
+        .order('submitted_at', { ascending: false })
+        .limit(500);
+
+      if (error) throw error;
+      return (data ?? []) as unknown as ReviewResponse[];
+    },
+  });
+```
+
+The `updateStatus` mutation invalidates `['review-responses', restaurantId]`. React Query matches a key prefix, so every filter's cache still clears. Leave it as it is.
+
+- [ ] **Step 4: Run the tests to check that they pass**
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/review-funnel-followups && npx vitest run tests/unit/useReviewResponses.test.ts --reporter=verbose && npm run typecheck
+```
+
+Expected: PASS, 16 tests. No type error.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/review-funnel-followups && git add src/hooks/useReviewResponses.ts tests/unit/useReviewResponses.test.ts && git -c commit.gpgsign=false commit -m "feat(reviews): give useReviewResponses a server-side filter
+
+The default mode shows every rating. The commented and silent modes add
+one predicate each, before the 500-row cap. The filter joins the query key.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: The inbox list shows every response
+
+**Files:**
+- Modify: `src/pages/Reviews.tsx:80-258`
+
+**Interfaces:**
+- Consumes: `useReviewResponses(restaurantId, filter)`, `ReviewResponseFilter` and `isActionableResponse` from Task 6.
+- Produces: nothing.
+
+- [ ] **Step 1: Add the imports**
+
+In `src/pages/Reviews.tsx`, add the ToggleGroup import and extend the hook import:
+
+```tsx
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+```
+
+```tsx
+import {
+  isActionableResponse,
+  useReviewResponses,
+  type ReviewResponse,
+  type ReviewResponseFilter,
+  type ReviewResponseStatus,
+} from '@/hooks/useReviewResponses';
+```
+
+Add `useEffect` to the React import on line 1:
+
+```tsx
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+```
+
+- [ ] **Step 2: Add the empty-state table**
+
+After `STATUS_LABELS` (`Reviews.tsx:74-78`), add:
+
+```tsx
+const FILTER_LABELS: Array<[ReviewResponseFilter, string]> = [
+  ['all', 'All'],
+  ['commented', 'With comments'],
+  ['silent', 'Silent'],
+];
+
+const EMPTY_STATES: Record<ReviewResponseFilter, { title: string; body: string }> = {
+  all: {
+    title: 'No ratings yet',
+    body: 'Put a review page QR code on the table. Every tap lands here.',
+  },
+  commented: {
+    title: 'No written feedback yet',
+    body: 'Guests who rate below your threshold get the private form. Their notes land here.',
+  },
+  silent: {
+    title: 'Every rating here has a comment',
+    body: 'A silent rating is a star tap with no note.',
+  },
+};
+```
+
+- [ ] **Step 3: Hold the filter and pass it to the hook**
+
+Replace `Reviews.tsx:80-92`:
+
+```tsx
+// before
+function FeedbackTab({ restaurantId, canManage }: { restaurantId?: string; canManage: boolean }) {
+  const { responses, metrics, isLoading, error, updateStatus, fetchContact } =
+    useReviewResponses(restaurantId);
+  const { pages } = useReviewPages(restaurantId);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // `responses` is already the commented rows only — the hook filters them
+  // server-side, before its 500-row cap. Ratings without a comment are a
+  // number, not a message: they count toward the header metrics and stay out
+  // of the list, because an inbox of 300 silent five-star taps is an inbox
+  // nobody opens.
+  const selected = responses.find((row) => row.id === selectedId) ?? null;
+
+// after
+function FeedbackTab({ restaurantId, canManage }: { restaurantId?: string; canManage: boolean }) {
+  const [filter, setFilter] = useState<ReviewResponseFilter>('all');
+  const { responses, metrics, isLoading, error, updateStatus, fetchContact } =
+    useReviewResponses(restaurantId, filter);
+  const { pages } = useReviewPages(restaurantId);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // The hook applies the filter server-side, before its 500-row cap. A row
+  // the new mode excludes leaves `selected` null, and the detail pane closes.
+  const selected = responses.find((row) => row.id === selectedId) ?? null;
+```
+
+- [ ] **Step 4: Change the virtualizer and reset the scroll on a filter change**
+
+Replace `Reviews.tsx:114-123`:
+
+```tsx
+// before
+  // Comments are free text: a two-line clamp, a one-line meta row and a
+  // status chip land most rows near 118px, and `measureElement` corrects the
+  // rest. The cap the hook enforces is 500 rows, which is exactly the range
+  // where mounting every row starts costing a manager real scroll latency.
+  const virtualizer = useVirtualizer({
+    count: responses.length,
+    getScrollElement: () => listRef.current,
+    estimateSize: () => 118,
+    overscan: 10,
+  });
+
+// after
+  // Comments are free text: a two-line clamp, a one-line meta row and a
+  // status chip land most rows near 118px, and `measureElement` corrects the
+  // rest. The cap the hook enforces is 500 rows, which is exactly the range
+  // where mounting every row starts costing a manager real scroll latency.
+  const virtualizer = useVirtualizer({
+    count: responses.length,
+    getScrollElement: () => listRef.current,
+    // A silent row drops the two-line clamp and the status chip.
+    estimateSize: (index) => (responses[index]?.comment ? 118 : 76),
+    // Without a stable key the measurement cache is keyed by index. A filter
+    // change then applies the old row's height to the new row at that index.
+    getItemKey: (index) => responses[index].id,
+    overscan: 10,
+  });
+
+  // A manager deep inside `All` who taps `Silent` must not land in the middle
+  // of a shorter list.
+  useEffect(() => {
+    if (listRef.current) listRef.current.scrollTop = 0;
+  }, [filter]);
+```
+
+- [ ] **Step 5: Render the filter group above the list, and the new empty states**
+
+Replace `Reviews.tsx:165-171` (the empty-state branch). The filter group sits **above** the branch: a manager stuck in `Silent` with zero rows must still reach `All`.
+
+```tsx
+// before
+      {responses.length === 0 ? (
+        <div className="mt-6 rounded-xl border border-border/40 p-10 text-center">
+          <h2 className="text-[15px] font-semibold text-foreground">No written feedback yet</h2>
+          <p className="mt-1 text-[13px] text-muted-foreground">
+            Guests who rate below your threshold get the private form. Their notes land here.
+          </p>
+        </div>
+      ) : (
+
+// after
+      <ToggleGroup
+        type="single"
+        value={filter}
+        // Radix sends an empty string when the guest taps the active item.
+        // Keep the mode; a list with no filter at all is not a state.
+        onValueChange={(value) => value && setFilter(value as ReviewResponseFilter)}
+        aria-label="Filter feedback"
+        className="mt-6 justify-start"
+      >
+        {FILTER_LABELS.map(([key, label]) => (
+          <ToggleGroupItem key={key} value={key} className="h-9 px-3 text-[13px]">
+            {label}
+          </ToggleGroupItem>
+        ))}
+      </ToggleGroup>
+
+      {responses.length === 0 ? (
+        <div className="mt-4 rounded-xl border border-border/40 p-10 text-center">
+          <h2 className="text-[15px] font-semibold text-foreground">
+            {EMPTY_STATES[filter].title}
+          </h2>
+          <p className="mt-1 text-[13px] text-muted-foreground">{EMPTY_STATES[filter].body}</p>
+        </div>
+      ) : (
+```
+
+Change the wrapper below the branch from `mt-6` to `mt-4`, so the list keeps the same gap the empty state has:
+
+```tsx
+// before
+        <div className="mt-6 md:grid md:grid-cols-[340px_1fr] md:gap-6">
+
+// after
+        <div className="mt-4 md:grid md:grid-cols-[340px_1fr] md:gap-6">
+```
+
+- [ ] **Step 6: Change the row**
+
+Replace the body of `FeedbackRow` (`Reviews.tsx:248-255`):
+
+```tsx
+// before
+      <div className="flex items-center justify-between gap-2">
+        <StarDisplay rating={response.rating} className="text-[14px] text-foreground" />
+        <span className="text-[11px] px-1.5 py-0.5 rounded-md bg-muted text-muted-foreground">
+          {STATUS_LABELS[response.status]}
+        </span>
+      </div>
+      <p className="mt-1 text-[12px] text-muted-foreground truncate">{meta}</p>
+      <p className="mt-2 text-[13px] text-foreground line-clamp-2">{response.comment}</p>
+
+// after
+      <div className="flex items-center justify-between gap-2">
+        <StarDisplay rating={response.rating} className="text-[14px] text-foreground" />
+        {/* Two rules, and they are not the same rule. A contact-only row has
+            no comment and is actionable: it shows the placeholder AND the
+            chip. A silent tap needs no triage, so it carries no status. */}
+        {isActionableResponse(response) && (
+          <span className="text-[11px] px-1.5 py-0.5 rounded-md bg-muted text-muted-foreground">
+            {STATUS_LABELS[response.status]}
+          </span>
+        )}
+      </div>
+      <p className="mt-1 text-[12px] text-muted-foreground truncate">{meta}</p>
+      {response.comment === null ? (
+        <p className="mt-2 text-[13px] text-muted-foreground">No comment left</p>
+      ) : (
+        <p className="mt-2 text-[13px] text-foreground line-clamp-2">{response.comment}</p>
+      )}
+```
+
+- [ ] **Step 7: Run the type check, the lint and the unit suite**
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/review-funnel-followups && npm run typecheck && npm run lint && npx vitest run --reporter=dot
+```
+
+Expected: no error, suite green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/review-funnel-followups && git add src/pages/Reviews.tsx && git -c commit.gpgsign=false commit -m "feat(reviews): show every rating in the inbox
+
+A filter group holds All, With comments and Silent. A silent row shows a
+placeholder and no status chip. The virtualizer takes a per-row estimate
+and a stable key.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: The detail pane follows the actionable rule
+
+**Files:**
+- Modify: `src/components/reviews/ReviewFeedbackDetail.tsx:93-143`
+
+**Interfaces:**
+- Consumes: `isActionableResponse` from Task 6.
+- Produces: nothing.
+
+- [ ] **Step 1: Extend the import**
+
+In `src/components/reviews/ReviewFeedbackDetail.tsx`, change the type import (lines 17-21) into a value import plus the types:
+
+```tsx
+import {
+  isActionableResponse,
+  type ReviewResponse,
+  type ReviewResponseContact,
+  type ReviewResponseStatus,
+} from '@/hooks/useReviewResponses';
+```
+
+- [ ] **Step 2: Compute the rule once**
+
+After the `contactLoading` state (line 46), add:
+
+```tsx
+  // A comment to read, or a guest who asked to hear back. A silent five-star
+  // tap is neither: a status control on it offers a chore that means nothing.
+  const isActionable = isActionableResponse(response);
+```
+
+- [ ] **Step 3: Gate the status control**
+
+Replace `ReviewFeedbackDetail.tsx:93`:
+
+```tsx
+// before
+        {canManage && (
+
+// after
+        {canManage && isActionable && (
+```
+
+- [ ] **Step 4: Replace the comment body with a branch**
+
+Replace `ReviewFeedbackDetail.tsx:113`:
+
+```tsx
+// before
+      <p className="mt-5 text-[14px] text-foreground whitespace-pre-wrap">{response.comment}</p>
+
+// after
+      {response.comment === null ? (
+        <p className="mt-5 text-[14px] text-muted-foreground">This guest left a rating only.</p>
+      ) : (
+        <p className="mt-5 text-[14px] text-foreground whitespace-pre-wrap">{response.comment}</p>
+      )}
+```
+
+The test here is `comment === null`, not `isActionable`. A contact-only row has no comment and still shows this line.
+
+- [ ] **Step 5: Gate the contact card**
+
+Replace `ReviewFeedbackDetail.tsx:115`:
+
+```tsx
+// before
+      {canManage && (
+
+// after
+      {canManage && isActionable && (
+```
+
+On a non-actionable row the card always reads `This guest didn't leave contact details.` It costs a manager a read and gives nothing back.
+
+- [ ] **Step 6: Run the type check, the lint and the unit suite**
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/review-funnel-followups && npm run typecheck && npm run lint && npx vitest run --reporter=dot
+```
+
+Expected: no error, suite green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/review-funnel-followups && git add src/components/reviews/ReviewFeedbackDetail.tsx && git -c commit.gpgsign=false commit -m "feat(reviews): hide the status control on a silent rating
+
+A silent star tap carries no comment and no contact consent. It needs no
+triage, so the detail pane drops the status control and the contact card.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: Whole-branch verification
+
+**Files:** none.
+
+**Interfaces:**
+- Consumes: every task above.
+- Produces: the evidence for the PR body.
+
+- [ ] **Step 1: Run the type check, the lint and the build**
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/review-funnel-followups && npm run typecheck && npm run lint && npm run build
+```
+
+Expected: no error.
+
+- [ ] **Step 2: Run the unit suite**
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/review-funnel-followups && npx vitest run --reporter=dot
+```
+
+Expected: PASS. Record the totals.
+
+- [ ] **Step 3: Run the database tests**
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/review-funnel-followups && npm run test:db
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run the review E2E specs**
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/review-funnel-followups && npx playwright test tests/e2e/review-promoter-followup.spec.ts tests/e2e/review-stars.spec.ts tests/e2e/review-funnel.spec.ts tests/e2e/review-page-load.spec.ts --reporter=line
+```
+
+Expected: PASS. Report any failure with its output. Do not report a skipped run as a pass.
+
+- [ ] **Step 5: Read the whole branch diff once**
+
+```bash
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/review-funnel-followups && git diff $(git merge-base origin/main HEAD)..HEAD --stat
+```
+
+Check that the changed files match the plan file list, and that no extra file appears.
+
+---
+
+## Spec coverage
+
+| Spec section | Task |
+|---|---|
+| 1a — the promoter screen offers the form | 3 (steps 4, 6, 7, 10) |
+| 1b — the form copy follows the branch | 3 (steps 2, 3, 7, 8) |
+| 1c — the comment becomes optional | 1, 3 (steps 5, 9) |
+| 1d — the server accepts a contact-only submit | 2 |
+| 1e — the live region | 3 (steps 4, 5) |
+| 2a — the inbox filter | 6 |
+| 2b — the list shows every response | 7 |
+| 2c — status applies to an actionable row only | 6 (predicate), 7 (list), 8 (detail) |
+| 2d — the unread metric follows the same rule | 5 |
+| Testing — unit `reviewSubmission` | 1 |
+| Testing — unit `useReviewResponses` | 6 |
+| Testing — pgTAP | 5 |
+| Testing — E2E | 4 |

--- a/docs/superpowers/plans/2026-08-06-review-funnel-followups.md
+++ b/docs/superpowers/plans/2026-08-06-review-funnel-followups.md
@@ -1009,9 +1009,9 @@ Create `supabase/migrations/20260806120000_review_metrics_actionable.sql`:
 -- and under-counts it.
 --
 -- Warning: a DROP FUNCTION here breaks the page for every user. A DROP resets
--- the grants, `authenticated` loses EXECUTE, and the Feedback tab header
--- fails with `permission denied for function`. Use CREATE OR REPLACE, keep
--- the same signature and the same attributes, and restate the two grant
+-- the grants. `authenticated` then loses EXECUTE. The Feedback tab header
+-- then fails with `permission denied for function`. Use CREATE OR REPLACE.
+-- Keep the same signature and the same attributes. Restate the two grant
 -- lines below.
 -- ============================================================================
 
@@ -1066,7 +1066,7 @@ Expected: PASS. The file reports 6 of 6.
 - [ ] **Step 5: Check that the grant survived**
 
 ```bash
-cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/review-funnel-followups && npx supabase db execute --local "SELECT has_function_privilege('authenticated', 'public.review_response_metrics(uuid)', 'EXECUTE') AS granted;"
+cd /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/review-funnel-followups && npx supabase db query --local "SELECT has_function_privilege('authenticated', 'public.review_response_metrics(uuid)', 'EXECUTE') AS granted;"
 ```
 
 Expected: `granted` is `t`. A `f` means the migration dropped the function. Fix the migration; do not add a second grant migration.

--- a/docs/superpowers/specs/2026-08-06-review-funnel-followups-design.md
+++ b/docs/superpowers/specs/2026-08-06-review-funnel-followups-design.md
@@ -68,9 +68,40 @@ Would you share that on Google?
 `Back` control that returns to `promoter`, so a guest who changes their mind
 does not lose the Google link.
 
+`Back` sits above the heading, as a ghost button with a `ChevronLeft` icon.
+`Reviews.tsx:75-82` and `Reviews.tsx:346-357` already use that pattern. The
+control is secondary in weight; `Send to the owner` stays the primary action.
+
+**Warning: a stale error banner reads as a new failure.** Both stage controls
+clear the error state before they change the stage.
+
+```ts
+// on `Tell us something directly` and on `Back`
+setSubmitError(false);
+```
+
+`ReviewPage.tsx:411-415` renders the banner `That didn't send. Your rating is
+already saved — try once more.` on `submitError`. Without the reset a guest
+sees that banner over a form they did not send yet.
+
+The comment text, the consent tick, the name and the email stay. A guest who
+taps `Back` and returns must not lose what they typed.
+
 After the guest sends the form, the `thanks` stage shows the Google button
 again when `destinationUrl` is set. A comment must not cost the restaurant a
 Google review.
+
+```text
+Thanks for telling us
+You can also share this on Google.
+
+[ Leave a Google review ]     ← only when destinationUrl is set
+```
+
+The sub-line `have a good one` (`ReviewPage.tsx:437-439`) becomes `You can also
+share this on Google.` when a Google button follows it. A sign-off above a call
+to action reads as an end. Without a `destinationUrl` the sub-line does not
+change. The button uses the same style the `promoter` stage uses.
 
 ### Part 1b — the form copy follows the branch
 
@@ -83,6 +114,18 @@ Google review.
 
 `What happened?` in front of a five-star guest reads as an accusation. The
 sub-line is correct for both branches and does not change.
+
+The comment field label states the new rule. `ReviewPage.tsx:348-350` reads
+`Your feedback` today.
+
+| Element | Copy |
+|---|---|
+| `Label` for `review-comment` | `Your feedback (optional)` |
+| Help line under the field | `Write a note, give your email, or both.` |
+
+The name and the email fields sit behind the consent tick
+(`ReviewPage.tsx:371-397`). Without the help line a guest who wants no comment
+sees a dead `Send` control and no reason for it.
 
 ### Part 1c — the comment becomes optional
 
@@ -106,6 +149,47 @@ export function canSubmitFollowUp(input: {
 
 The module is pure, so a unit test covers the rule. The rule must not live
 inside the JSX, where only an E2E test can reach it.
+
+**Warning: the button rule is not the only gate.** `handleSubmitComment`
+(`ReviewPage.tsx:156`) holds a second, independent guard.
+
+```ts
+// before
+if (!token || !comment.trim()) return;
+
+// after
+if (!token || !canSubmitFollowUp({ comment, consent, email })) return;
+```
+
+A change to the `disabled` rule alone leaves this guard in place. The button
+then answers a tap with nothing: no request, no error, no new stage.
+
+The request body sends no empty string.
+
+```ts
+comment: comment.trim() || undefined,
+```
+
+### Part 1e — the live region
+
+`ReviewPage` holds one `aria-live` region through `setAnnouncement`. The region
+is a diff channel: two identical strings announce once. Each new stage move
+sets its own string.
+
+| Move | Announcement |
+|---|---|
+| `promoter` → `feedback` (`Tell us something directly`) | `Tell us more. This goes straight to the owner.` |
+| `feedback` → `promoter` (`Back`) | `Back to the Google link.` |
+| `feedback` → `thanks`, `destinationUrl` set | `Thanks. You can also share this on Google.` |
+| `feedback` → `thanks`, no `destinationUrl` | `Thanks. The owner has your note.` |
+
+The `thanks` move sets no announcement today (`ReviewPage.tsx:157-180`). A
+screen-reader guest hears nothing after a send, and hears nothing about the new
+Google button. A guest who taps `Tell us something directly` and `Back` more
+than once hears two different strings, so each move stays audible.
+
+The heading focus effect (`ReviewPage.tsx:91-93`) stays. It moves focus; it
+does not replace the announcement.
 
 ### Part 1d — the server accepts a contact-only submit
 
@@ -184,8 +268,11 @@ guarantees the full comment list. A code comment records this trade.
 
 ### Part 2b — the list shows every response
 
-A three-button filter group sits above the rows: `All`, `With comments`,
-`Silent`. Each button carries `aria-pressed`.
+A `ToggleGroup` with `type="single"` sits above the rows. It holds three
+`ToggleGroupItem` controls: `All`, `With comments`, `Silent`. Six components
+already use this primitive, for example `src/components/roles/RoleEditor.tsx`.
+Radix gives the group one tab stop and arrow-key movement. Three plain buttons
+with `aria-pressed` give three tab stops and no arrow keys.
 
 A row with no comment shows `No comment left` in muted text, in place of the
 two-line comment clamp.
@@ -196,7 +283,33 @@ Empty-state copy follows the mode:
 |---|---|
 | `all` | `No ratings yet` |
 | `commented` | `No written feedback yet` |
-| `silent` | `Every rating here came with a comment` |
+| `silent` | `Every rating here has a comment` |
+
+**The virtualizer needs three changes.** `Reviews.tsx:118-123` sets
+`estimateSize: () => 118`, a constant tuned for a two-line comment clamp, a
+meta row and a status chip. A silent row holds none of the clamp and no chip.
+
+```ts
+const virtualizer = useVirtualizer({
+  count: responses.length,
+  getScrollElement: () => listRef.current,
+  // A silent row drops the two-line clamp and the status chip.
+  estimateSize: (index) => (responses[index]?.comment ? 118 : 76),
+  // Without a stable key the measurement cache is keyed by index. A filter
+  // change then applies the old row's height to the new row at that index.
+  getItemKey: (index) => responses[index].id,
+  overscan: 10,
+});
+```
+
+The list scrolls to the top on every filter change. A manager deep inside
+`All` who taps `Silent` must not land in the middle of a shorter list.
+
+```ts
+useEffect(() => {
+  if (listRef.current) listRef.current.scrollTop = 0;
+}, [filter]);
+```
 
 ### Part 2c — status applies to an actionable row only
 
@@ -213,8 +326,25 @@ would offer a manager a chore that means nothing.
 
 A contact-only row **is** actionable. The guest asked to hear back.
 
-The detail pane shows `This guest left a rating only.` in place of the comment
-body when the comment is null.
+**Warning: two rules apply here, and they are not the same rule.** A
+contact-only row has no comment and is actionable. It shows the placeholder
+text **and** it keeps the status chip.
+
+| Element | Rule |
+|---|---|
+| `No comment left` in the list row | `comment === null` |
+| `This guest left a rating only.` in the detail pane | `comment === null` |
+| Status chip in the list row | `isActionable` |
+| Status `Select` in the detail pane | `isActionable && canManage` |
+| `Contact` card in the detail pane | `isActionable && canManage` |
+
+A single `comment === null` test on all five elements hides the status chip on
+a contact-only row. That result contradicts the rule above.
+
+`ReviewFeedbackDetail.tsx:115-143` renders the `Contact` card on `canManage`
+alone. On a non-actionable row that card always reads `This guest didn't leave
+contact details`. The card then costs a manager a read and gives nothing back,
+for the same reason the status control does.
 
 ### Part 2d — the unread metric follows the same rule
 
@@ -223,6 +353,22 @@ One migration replaces `review_response_metrics`.
 ```sql
 count(*) FILTER (WHERE rr.status = 'new'
   AND (rr.comment IS NOT NULL OR rr.contact_consent)) AS unread_count
+```
+
+**Warning: a `DROP FUNCTION` here breaks the page for every user.** The
+migration must use `CREATE OR REPLACE FUNCTION`, with the same signature
+`public.review_response_metrics(p_restaurant_id UUID)` and the same attributes
+`LANGUAGE sql STABLE SET search_path = public, pg_temp`. A `DROP` resets the
+grants. `authenticated` then loses EXECUTE, and the Feedback tab header fails
+with `permission denied for function`.
+
+The migration also repeats the two grant lines, as
+`20260803100000_assign_membership_role_custom_role_flavor_check.sql:187-193`
+does.
+
+```sql
+REVOKE ALL ON FUNCTION public.review_response_metrics(UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.review_response_metrics(UUID) TO authenticated;
 ```
 
 The old rule counted `comment IS NOT NULL` alone. That rule now under-counts: a
@@ -286,9 +432,19 @@ exactly the rows `comment IS NULL` was true for, plus no others, because
 `handleComment` is the only writer of both columns.
 
 **No new PII column.** A contact-only submit writes to
-`review_response_contacts`, which slice 1 already holds to `manage:reviews`
-through RLS. The primary key on `review_response_id` still allows one contact
-row per response.
+`review_response_contacts`. Slice 1 already holds that table to
+`manage:reviews` through the `review_response_contacts_select` policy
+(`supabase/migrations/20260804100100_review_funnel_tables.sql:194-196`). The
+primary key on `review_response_id`
+(`supabase/migrations/20260804100100_review_funnel_tables.sql:78`) still allows
+one contact row per response.
+
+**No new grant.** `service_role` already holds `GRANT INSERT` on
+`review_response_contacts`
+(`supabase/migrations/20260804120000_review_funnel_service_role_grants.sql:46`)
+and `GRANT UPDATE (comment, contact_consent, commented_at)` on
+`review_responses` (line 44 of the same file). The widened write path uses the
+grants slice 1 gave it.
 
 **No enumeration oracle.** Every widened path keeps the existing answer shape.
 A contact-only submit returns the same `{ ok: true }` a comment returns.

--- a/docs/superpowers/specs/2026-08-06-review-funnel-followups-design.md
+++ b/docs/superpowers/specs/2026-08-06-review-funnel-followups-design.md
@@ -1,0 +1,294 @@
+# Review Funnel Follow-Ups — Design
+
+**Date:** 2026-08-06
+**Branch:** `feature/review-funnel-followups`
+**Depends on:** `docs/superpowers/specs/2026-08-04-review-funnel-design.md` (slice 1, shipped)
+
+## Goal
+
+Fix two gaps that slice 1 left in the review funnel.
+
+1. A promoter cannot leave a comment or contact details. A 4-star or 5-star tap
+   goes straight to the Google hand-off.
+2. The admin inbox hides a rating that carries no comment. A 5-star tap exists
+   in `review_responses` but never appears in the list.
+
+## Problem 1 — the promoter branch is a dead end
+
+`src/pages/ReviewPage.tsx:145` routes on the server's decision:
+
+```tsx
+if (data.routed_to === 'destination') {
+  setDestinationUrl((data.destination_url as string) ?? null);
+  setStage('promoter');
+```
+
+The `promoter` stage (`src/pages/ReviewPage.tsx:301-331`) shows a Google link and
+a `No thanks` control. It offers no comment box and no contact fields. A guest
+who loves the restaurant, and who wants a coupon or a reply, has no way to give
+an email address.
+
+The server does not cause this. `handleComment`
+(`supabase/functions/review-public/index.ts:261`) never reads `routed_to`. It
+accepts any valid token whose row has no comment yet. A promoter's token already
+works today. The gap is in the client alone.
+
+## Problem 2 — the inbox filters out silent ratings
+
+`src/hooks/useReviewResponses.ts:67` adds one predicate:
+
+```ts
+.not('comment', 'is', null)
+```
+
+The header metrics do not come from that query. `review_response_metrics`
+(`supabase/migrations/20260804110000_review_response_aggregates.sql:47`) is a
+separate, uncapped aggregate over every row, so the average and the counts are
+correct. Only the list is wrong.
+
+---
+
+## Design
+
+### Part 1a — the promoter screen offers the form
+
+The Google link stays the primary action. Two secondary controls sit under it:
+
+```text
+Thank you
+Would you share that on Google?
+
+[ Leave a Google review ]
+
+  Tell us something directly
+  No thanks
+```
+
+`Tell us something directly` moves the stage to `feedback`. The form gains a
+`Back` control that returns to `promoter`, so a guest who changes their mind
+does not lose the Google link.
+
+After the guest sends the form, the `thanks` stage shows the Google button
+again when `destinationUrl` is set. A comment must not cost the restaurant a
+Google review.
+
+### Part 1b — the form copy follows the branch
+
+`ReviewPage` keeps the server's decision in a new `routedTo` state value.
+
+| Branch | Heading | Sub-line |
+|---|---|---|
+| `feedback` | `What happened?` | `this goes straight to the owner — not public` |
+| `destination` | `Tell us more` | `this goes straight to the owner — not public` |
+
+`What happened?` in front of a five-star guest reads as an accusation. The
+sub-line is correct for both branches and does not change.
+
+### Part 1c — the comment becomes optional
+
+The `Send` control enables when either condition is true:
+
+- the guest writes a comment, or
+- the guest ticks consent and gives an email that passes a shape check.
+
+A new pure module holds that rule.
+
+**File:** `src/lib/reviews/reviewSubmission.ts`
+
+```ts
+export function isPlausibleEmail(value: string): boolean;
+export function canSubmitFollowUp(input: {
+  comment: string;
+  consent: boolean;
+  email: string;
+}): boolean;
+```
+
+The module is pure, so a unit test covers the rule. The rule must not live
+inside the JSX, where only an E2E test can reach it.
+
+### Part 1d — the server accepts a contact-only submit
+
+Three changes in `handleComment`
+(`supabase/functions/review-public/index.ts:261`).
+
+**1. The required-comment rule becomes a required-payload rule.**
+
+```ts
+// before
+if (!token || !comment || comment.length > MAX_COMMENT_LENGTH) return fail(400);
+
+// after
+if (!token || comment.length > MAX_COMMENT_LENGTH) return fail(400);
+if (!comment && !(consent && isPlausibleEmail(email))) return fail(400);
+```
+
+A request with neither a comment nor a usable email writes nothing. It stays a
+400, the same honest answer the handler gives today for a malformed body.
+
+**2. The single-use guard moves to `commented_at`.**
+
+```ts
+// before
+.is('comment', null)
+
+// after
+.is('commented_at', null)
+```
+
+`handleComment` is the only writer of `commented_at`. Every row that holds a
+comment also holds a `commented_at` value, so the new guard rejects exactly the
+replays the old one rejected. Unlike the old guard, it also works when the
+comment is null.
+
+**3. An empty comment stores as NULL, not as an empty string.**
+
+```ts
+comment: comment || null,
+```
+
+`review_response_metrics` counts `comment IS NOT NULL`. An empty string would
+inflate the comment count and would put a blank row in the inbox.
+
+The honeypot path, the rate limit path and the generic-error discipline do not
+change. Every early exit still answers `{ ok: true }`.
+
+The email shape check is duplicated: TypeScript in `src/lib/reviews/`, Deno in
+`supabase/functions/_shared/`. The edge function cannot import from `src/`. Each
+copy carries a comment that names the other. The server copy is authoritative.
+
+### Part 2a — the inbox filter
+
+`useReviewResponses` takes a second parameter.
+
+```ts
+export type ReviewResponseFilter = 'all' | 'commented' | 'silent';
+export function useReviewResponses(
+  restaurantId?: string,
+  filter: ReviewResponseFilter = 'all'
+);
+```
+
+| Filter | Predicate |
+|---|---|
+| `all` | none |
+| `commented` | `.not('comment', 'is', null)` |
+| `silent` | `.is('comment', null)` |
+
+The predicate stays server-side, before the `.limit(500)` cap. The filter joins
+the React Query key, so each mode caches on its own.
+
+**Known limit, stated on purpose.** In `all` mode a heavy run of silent taps can
+push an old comment past the 500-row cap. `With comments` is the mode that
+guarantees the full comment list. A code comment records this trade.
+
+### Part 2b — the list shows every response
+
+A three-button filter group sits above the rows: `All`, `With comments`,
+`Silent`. Each button carries `aria-pressed`.
+
+A row with no comment shows `No comment left` in muted text, in place of the
+two-line comment clamp.
+
+Empty-state copy follows the mode:
+
+| Mode | Copy |
+|---|---|
+| `all` | `No ratings yet` |
+| `commented` | `No written feedback yet` |
+| `silent` | `Every rating here came with a comment` |
+
+### Part 2c — status applies to an actionable row only
+
+A response is **actionable** when it holds a comment, or when the guest gave
+contact consent.
+
+```ts
+const isActionable = response.comment !== null || response.contact_consent;
+```
+
+A non-actionable row shows no status chip in the list and no status control in
+the detail pane. A silent five-star tap needs no triage. A status control on it
+would offer a manager a chore that means nothing.
+
+A contact-only row **is** actionable. The guest asked to hear back.
+
+The detail pane shows `This guest left a rating only.` in place of the comment
+body when the comment is null.
+
+### Part 2d — the unread metric follows the same rule
+
+One migration replaces `review_response_metrics`.
+
+```sql
+count(*) FILTER (WHERE rr.status = 'new'
+  AND (rr.comment IS NOT NULL OR rr.contact_consent)) AS unread_count
+```
+
+The old rule counted `comment IS NOT NULL` alone. That rule now under-counts: a
+contact-only row is actionable and must reach the badge.
+
+The same migration documents the changed column meaning.
+
+```sql
+COMMENT ON COLUMN public.review_responses.commented_at IS
+'When the guest finished the follow-up form. Does NOT imply a comment: a contact-only submit sets this and leaves comment NULL. Use comment IS NOT NULL to test for a comment.';
+```
+
+The other three aggregate columns do not change. `average_rating` and
+`total_ratings` already count every row. `comment_count` correctly counts
+comments only.
+
+---
+
+## Files
+
+| Action | Path | Responsibility |
+|---|---|---|
+| Create | `src/lib/reviews/reviewSubmission.ts` | Submit-enable rule, email shape check |
+| Create | `supabase/functions/_shared/reviewContact.ts` | Server-side email shape check |
+| Create | `supabase/migrations/20260806120000_review_metrics_actionable.sql` | Unread rule, column comment |
+| Create | `tests/unit/reviewSubmission.test.ts` | The submit rule |
+| Create | `tests/e2e/review-promoter-followup.spec.ts` | The promoter path, end to end |
+| Modify | `src/pages/ReviewPage.tsx` | Promoter controls, branch copy, optional comment |
+| Modify | `supabase/functions/review-public/index.ts` | `handleComment` payload rule and guard |
+| Modify | `src/hooks/useReviewResponses.ts` | The filter parameter |
+| Modify | `src/pages/Reviews.tsx` | Filter group, silent row, empty states |
+| Modify | `src/components/reviews/ReviewFeedbackDetail.tsx` | Actionable rule |
+| Modify | `tests/unit/useReviewResponses.test.ts` | The three filter modes |
+| Modify | `supabase/tests/review_response_aggregates_test.sql` | The new unread rule |
+
+## Testing
+
+| Layer | Cases |
+|---|---|
+| Unit — `reviewSubmission` | comment only; email only with consent; email only without consent; malformed email; both empty; whitespace-only comment |
+| Unit — `useReviewResponses` | each filter builds the right predicate; the filter joins the query key |
+| pgTAP | unread counts a new comment row; unread counts a new contact-only row; unread skips a new silent row; `comment_count` still counts comments only |
+| E2E | a promoter reaches the form and returns; a promoter sends a comment and still sees the Google button; a promoter sends an email with no comment |
+
+## Out of scope
+
+These items stay in the slice 2 backlog.
+
+- The coupon or incentive message above a second threshold.
+- An `ai-caller` summary over a period's comments.
+- A reply by email through `_shared/emailQueue.ts`.
+
+## Security review
+
+**No new public write path.** `handleComment` accepts the same HMAC token it
+accepted before. The change widens what a valid token may write, not who holds
+one.
+
+**The single-use guard does not weaken.** `commented_at IS NULL` is true for
+exactly the rows `comment IS NULL` was true for, plus no others, because
+`handleComment` is the only writer of both columns.
+
+**No new PII column.** A contact-only submit writes to
+`review_response_contacts`, which slice 1 already holds to `manage:reviews`
+through RLS. The primary key on `review_response_id` still allows one contact
+row per response.
+
+**No enumeration oracle.** Every widened path keeps the existing answer shape.
+A contact-only submit returns the same `{ ok: true }` a comment returns.

--- a/docs/superpowers/specs/2026-08-06-review-funnel-followups-design.md
+++ b/docs/superpowers/specs/2026-08-06-review-funnel-followups-design.md
@@ -246,7 +246,7 @@ copy carries a comment that names the other. The server copy is authoritative.
 `useReviewResponses` takes a second parameter.
 
 ```ts
-export type ReviewResponseFilter = 'all' | 'commented' | 'silent';
+export type ReviewResponseFilter = 'all' | 'needsReply' | 'silent';
 export function useReviewResponses(
   restaurantId?: string,
   filter: ReviewResponseFilter = 'all'
@@ -256,20 +256,20 @@ export function useReviewResponses(
 | Filter | Predicate |
 |---|---|
 | `all` | none |
-| `commented` | `.not('comment', 'is', null)` |
-| `silent` | `.is('comment', null)` |
+| `needsReply` | `.or('comment.not.is.null,contact_consent.is.true')` |
+| `silent` | `.is('comment', null).eq('contact_consent', false)` |
 
 The predicate stays server-side, before the `.limit(500)` cap. The filter joins
 the React Query key, so each mode caches on its own.
 
 **Known limit, stated on purpose.** In `all` mode a heavy run of silent taps can
-push an old comment past the 500-row cap. `With comments` is the mode that
-guarantees the full comment list. A code comment records this trade.
+push an old comment past the 500-row cap. `Needs a reply` is the mode that
+guarantees the full actionable list. A code comment records this trade.
 
 ### Part 2b — the list shows every response
 
 A `ToggleGroup` with `type="single"` sits above the rows. It holds three
-`ToggleGroupItem` controls: `All`, `With comments`, `Silent`. Six components
+`ToggleGroupItem` controls: `All`, `Needs a reply`, `Silent`. Six components
 already use this primitive, for example `src/components/roles/RoleEditor.tsx`.
 Radix gives the group one tab stop and arrow-key movement. Three plain buttons
 with `aria-pressed` give three tab stops and no arrow keys.
@@ -282,8 +282,8 @@ Empty-state copy follows the mode:
 | Mode | Copy |
 |---|---|
 | `all` | `No ratings yet` |
-| `commented` | `No written feedback yet` |
-| `silent` | `Every rating here has a comment` |
+| `needsReply` | `Nothing needs a reply yet` |
+| `silent` | `No silent ratings` |
 
 **The virtualizer needs three changes.** `Reviews.tsx:118-123` sets
 `estimateSize: () => 118`, a constant tuned for a two-line comment clamp, a

--- a/src/components/reviews/ReviewFeedbackDetail.tsx
+++ b/src/components/reviews/ReviewFeedbackDetail.tsx
@@ -116,7 +116,7 @@ export function ReviewFeedbackDetail({
       </div>
 
       {response.comment === null ? (
-        <p className="mt-5 text-[14px] text-muted-foreground">This guest left a rating only.</p>
+        <p className="mt-5 text-[14px] text-muted-foreground">This guest left no comment.</p>
       ) : (
         <p className="mt-5 text-[14px] text-foreground whitespace-pre-wrap">{response.comment}</p>
       )}

--- a/src/components/reviews/ReviewFeedbackDetail.tsx
+++ b/src/components/reviews/ReviewFeedbackDetail.tsx
@@ -14,10 +14,11 @@ import { ChevronLeft } from 'lucide-react';
 
 import { useRestaurantClock } from '@/hooks/useRestaurantClock';
 import { StarDisplay } from '@/components/reviews/StarDisplay';
-import type {
-  ReviewResponse,
-  ReviewResponseContact,
-  ReviewResponseStatus,
+import {
+  isActionableResponse,
+  type ReviewResponse,
+  type ReviewResponseContact,
+  type ReviewResponseStatus,
 } from '@/hooks/useReviewResponses';
 
 interface ReviewFeedbackDetailProps {
@@ -44,6 +45,10 @@ export function ReviewFeedbackDetail({
   // first tells a manager the guest declined contact, moments before an email
   // address appears where that sentence was.
   const [contactLoading, setContactLoading] = useState(false);
+
+  // A comment to read, or a guest who asked to hear back. A silent five-star
+  // tap is neither: a status control on it offers a chore that means nothing.
+  const isActionable = isActionableResponse(response);
 
   useEffect(() => {
     // The contact row is a separate fetch on a separate table, so a viewer
@@ -90,7 +95,7 @@ export function ReviewFeedbackDetail({
           </p>
         </div>
 
-        {canManage && (
+        {canManage && isActionable && (
           <Select
             value={response.status}
             onValueChange={(value) => onStatusChange(value as ReviewResponseStatus)}
@@ -110,9 +115,13 @@ export function ReviewFeedbackDetail({
         )}
       </div>
 
-      <p className="mt-5 text-[14px] text-foreground whitespace-pre-wrap">{response.comment}</p>
+      {response.comment === null ? (
+        <p className="mt-5 text-[14px] text-muted-foreground">This guest left a rating only.</p>
+      ) : (
+        <p className="mt-5 text-[14px] text-foreground whitespace-pre-wrap">{response.comment}</p>
+      )}
 
-      {canManage && (
+      {canManage && isActionable && (
         <div className="mt-6 rounded-xl border border-border/40 bg-muted/30 p-4">
           <h3 className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider">
             Contact

--- a/src/hooks/useReviewResponses.ts
+++ b/src/hooks/useReviewResponses.ts
@@ -25,6 +25,22 @@ export interface ReviewResponseContact {
   contact_email: string | null;
 }
 
+/** Which rows the inbox list asks for. The predicate runs server-side. */
+export type ReviewResponseFilter = 'all' | 'commented' | 'silent';
+
+/**
+ * A row a manager can act on: a comment to read, or a guest who asked to hear
+ * back. A silent five-star tap is neither, so it carries no status and no
+ * contact card.
+ *
+ * The `unread_count` FILTER in `review_response_metrics` holds the same rule
+ * in SQL (supabase/migrations/20260806120000_review_metrics_actionable.sql).
+ * Change both together, or the header badge and the rows disagree.
+ */
+export function isActionableResponse(response: ReviewResponse): boolean {
+  return response.comment !== null || response.contact_consent;
+}
+
 interface ReviewResponseMetricsRow {
   average_rating: number | null;
   total_ratings: number;
@@ -38,33 +54,47 @@ interface ReviewResponseMetricsRow {
 // `.rpc('review_response_metrics' as any)` cast in this file is for that
 // gap; the real shapes are the interfaces above.
 
-export function useReviewResponses(restaurantId?: string) {
+export function useReviewResponses(
+  restaurantId?: string,
+  filter: ReviewResponseFilter = 'all'
+) {
   const queryClient = useQueryClient();
   const { toast } = useToast();
 
   const query = useQuery({
-    queryKey: ['review-responses', restaurantId],
+    // The filter joins the key, so each mode caches on its own. A shared key
+    // would answer `silent` from the `all` cache.
+    queryKey: ['review-responses', restaurantId, filter],
     enabled: Boolean(restaurantId),
     staleTime: 30000,
     refetchOnWindowFocus: true,
     queryFn: async (): Promise<ReviewResponse[]> => {
-      // Commented rows only, and the filter is applied SERVER-side, before
-      // the cap. Filtering after a `.limit(500)` would mean a location that
-      // takes 500 silent star taps after a written complaint fetches 500
-      // silent rows and shows an empty inbox — the complaint dropped off the
-      // end of a window it was never in.
+      // The filter is applied SERVER-side, before the cap. A filter after a
+      // `.limit(500)` would mean a location that takes 500 silent star taps
+      // after a written complaint fetches 500 silent rows and shows an empty
+      // inbox — the complaint dropped off the end of a window it was never in.
+      //
+      // Known limit: in `all` mode a heavy run of silent taps can push an old
+      // comment past the 500-row cap. `With comments` is the mode that
+      // guarantees the full comment list.
       //
       // Capped at 500 for the inbox *list* only. The header metrics below do
       // NOT come from this capped array; they're a separate, uncapped
       // server-side aggregate, so a restaurant past 500 comments still sees a
       // correct average/total/unread count.
-      const { data, error } = await supabase
+      const base = supabase
         .from('review_responses' as any)
         .select(
           'id, restaurant_id, review_page_id, rating, routed_to, comment, contact_consent, status, submitted_at, commented_at'
         )
-        .eq('restaurant_id', restaurantId!)
-        .not('comment', 'is', null)
+        .eq('restaurant_id', restaurantId!);
+
+      // `all` adds no predicate, so it reads the base query unchanged.
+      let scoped = base;
+      if (filter === 'commented') scoped = base.not('comment', 'is', null);
+      else if (filter === 'silent') scoped = base.is('comment', null);
+
+      const { data, error } = await scoped
         .order('submitted_at', { ascending: false })
         .limit(500);
 

--- a/src/hooks/useReviewResponses.ts
+++ b/src/hooks/useReviewResponses.ts
@@ -33,9 +33,11 @@ export type ReviewResponseFilter = 'all' | 'commented' | 'silent';
  * back. A silent five-star tap is neither, so it carries no status and no
  * contact card.
  *
- * The `unread_count` FILTER in `review_response_metrics` holds the same rule
- * in SQL (supabase/migrations/20260806120000_review_metrics_actionable.sql).
- * Change both together, or the header badge and the rows disagree.
+ * Warning: a change to one copy of this rule alone makes the header badge and
+ * the rows disagree. The `unread_count` FILTER in `review_response_metrics`
+ * holds the same rule in SQL
+ * (supabase/migrations/20260806120000_review_metrics_actionable.sql).
+ * Change both together.
  */
 export function isActionableResponse(response: ReviewResponse): boolean {
   return response.comment !== null || response.contact_consent;

--- a/src/hooks/useReviewResponses.ts
+++ b/src/hooks/useReviewResponses.ts
@@ -26,18 +26,19 @@ export interface ReviewResponseContact {
 }
 
 /** Which rows the inbox list asks for. The predicate runs server-side. */
-export type ReviewResponseFilter = 'all' | 'commented' | 'silent';
+export type ReviewResponseFilter = 'all' | 'needsReply' | 'silent';
 
 /**
  * A row a manager can act on: a comment to read, or a guest who asked to hear
  * back. A silent five-star tap is neither, so it carries no status and no
  * contact card.
  *
- * Warning: a change to one copy of this rule alone makes the header badge and
- * the rows disagree. The `unread_count` FILTER in `review_response_metrics`
- * holds the same rule in SQL
- * (supabase/migrations/20260806120000_review_metrics_actionable.sql).
- * Change both together.
+ * Warning: this rule has three copies. Change all three together, or the
+ * header badge, the `needsReply` filter, and the status chip disagree.
+ * 1. This function.
+ * 2. The `unread_count` FILTER in `review_response_metrics`
+ *    (supabase/migrations/20260806120000_review_metrics_actionable.sql).
+ * 3. The `needsReply` predicate below, in this file's queryFn.
  */
 export function isActionableResponse(response: ReviewResponse): boolean {
   return response.comment !== null || response.contact_consent;
@@ -49,12 +50,6 @@ interface ReviewResponseMetricsRow {
   comment_count: number;
   unread_count: number;
 }
-
-// review_responses / review_response_contacts / review_response_metrics
-// aren't in the generated Supabase types yet (added by migrations after the
-// last `npm run sync-types`) — every `.from('table' as any)` /
-// `.rpc('review_response_metrics' as any)` cast in this file is for that
-// gap; the real shapes are the interfaces above.
 
 export function useReviewResponses(
   restaurantId?: string,
@@ -77,31 +72,44 @@ export function useReviewResponses(
       // inbox — the complaint dropped off the end of a window it was never in.
       //
       // Known limit: in `all` mode a heavy run of silent taps can push an old
-      // comment past the 500-row cap. `With comments` is the mode that
-      // guarantees the full comment list.
+      // comment past the 500-row cap. `needsReply` is the mode that
+      // guarantees the full actionable list.
       //
       // Capped at 500 for the inbox *list* only. The header metrics below do
       // NOT come from this capped array; they're a separate, uncapped
       // server-side aggregate, so a restaurant past 500 comments still sees a
       // correct average/total/unread count.
       const base = supabase
-        .from('review_responses' as any)
+        .from('review_responses')
         .select(
           'id, restaurant_id, review_page_id, rating, routed_to, comment, contact_consent, status, submitted_at, commented_at'
         )
         .eq('restaurant_id', restaurantId!);
 
       // `all` adds no predicate, so it reads the base query unchanged.
+      // `needsReply` holds the same rule as isActionableResponse — see the
+      // warning on that function.
       let scoped = base;
-      if (filter === 'commented') scoped = base.not('comment', 'is', null);
-      else if (filter === 'silent') scoped = base.is('comment', null);
+      if (filter === 'needsReply') {
+        scoped = base.or('comment.not.is.null,contact_consent.is.true');
+      } else if (filter === 'silent') {
+        scoped = base.is('comment', null).eq('contact_consent', false);
+      }
 
+      // The list shows commented_at ?? submitted_at (Reviews.tsx,
+      // ReviewFeedbackDetail.tsx). Order by the same key, or a late follow-up
+      // reads as new but sits far down the list. NULLS LAST keeps a
+      // comment-less row under its own submitted_at.
       const { data, error } = await scoped
+        .order('commented_at', { ascending: false, nullsFirst: false })
         .order('submitted_at', { ascending: false })
         .limit(500);
 
       if (error) throw error;
-      return (data ?? []) as unknown as ReviewResponse[];
+      // review_responses.status and .routed_to are typed as plain `string`
+      // in the generated schema; ReviewResponse narrows them to the exact
+      // values this app writes and reads.
+      return (data ?? []) as ReviewResponse[];
     },
   });
 
@@ -111,14 +119,11 @@ export function useReviewResponses(
     staleTime: 30000,
     refetchOnWindowFocus: true,
     queryFn: async (): Promise<ReviewMetrics> => {
-      // review_response_metrics isn't in the generated Supabase types yet
-      // (added by 20260804110000_review_response_aggregates.sql, after the
-      // last `npm run sync-types`) — hence the `as any` cast.
-      const { data, error } = await supabase.rpc('review_response_metrics' as any, {
+      const { data, error } = await supabase.rpc('review_response_metrics', {
         p_restaurant_id: restaurantId!,
       });
       if (error) throw error;
-      const row = ((data ?? []) as unknown as ReviewResponseMetricsRow[])[0];
+      const row: ReviewResponseMetricsRow | undefined = (data ?? [])[0];
       return {
         averageRating: row?.average_rating ?? null,
         totalRatings: row?.total_ratings ?? 0,
@@ -141,7 +146,7 @@ export function useReviewResponses(
       // the status control would settle on the new value, and the next
       // refetch would silently snap it back with no explanation.
       const { data, error } = await supabase
-        .from('review_responses' as any)
+        .from('review_responses')
         .update({ status })
         .eq('id', id)
         .eq('restaurant_id', restaurantId)
@@ -177,7 +182,7 @@ export function useReviewResponses(
     async (responseId: string): Promise<ReviewResponseContact | null> => {
       if (!restaurantId) throw new Error('No restaurant selected');
       const { data, error } = await supabase
-        .from('review_response_contacts' as any)
+        .from('review_response_contacts')
         .select('contact_name, contact_email')
         .eq('review_response_id', responseId)
         .eq('restaurant_id', restaurantId)
@@ -198,7 +203,7 @@ export function useReviewResponses(
         });
         return null;
       }
-      return (data as unknown as ReviewResponseContact) ?? null;
+      return data ?? null;
     },
     [restaurantId, toast]
   );

--- a/src/lib/reviews/reviewSubmission.ts
+++ b/src/lib/reviews/reviewSubmission.ts
@@ -2,8 +2,8 @@
  * The rule that decides when the guest follow-up form may be sent.
  *
  * The comment is optional. A guest may give an email and no comment, or a
- * comment and no email. A form that holds neither writes nothing, so the
- * Send control stays disabled.
+ * comment and no email. A form that holds neither writes nothing. The Send
+ * control stays disabled in that case.
  *
  * This whole module is a copy. `supabase/functions/_shared/reviewContact.ts`
  * holds the Deno original, which an edge function can import and this file

--- a/src/lib/reviews/reviewSubmission.ts
+++ b/src/lib/reviews/reviewSubmission.ts
@@ -1,0 +1,40 @@
+/**
+ * The rule that decides when the guest follow-up form may be sent.
+ *
+ * The comment is optional. A guest may give an email and no comment, or a
+ * comment and no email. A form that holds neither writes nothing, so the
+ * Send control stays disabled.
+ *
+ * This whole module is a copy. `supabase/functions/_shared/reviewContact.ts`
+ * holds the Deno original, which an edge function can import and this file
+ * cannot: `isPlausibleEmail` and `hasFollowUpPayload` there answer to
+ * `isPlausibleEmail` and `canSubmitFollowUp` here. That copy is
+ * authoritative: this one only enables a button. Change both together, or
+ * the button sends a request the server answers with a 400.
+ */
+
+/** The longest email `handleComment` accepts. It slices at this length. */
+export const MAX_EMAIL_LENGTH = 320;
+
+/**
+ * One local part, one `@`, and a domain with at least one dot. Only a sent
+ * mail proves an address works. This check catches the typo a guest can see.
+ */
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@.]+(\.[^\s@.]+)+$/;
+
+export function isPlausibleEmail(value: string): boolean {
+  const trimmed = value.trim();
+  if (trimmed.length === 0 || trimmed.length > MAX_EMAIL_LENGTH) return false;
+  return EMAIL_PATTERN.test(trimmed);
+}
+
+export function canSubmitFollowUp(input: {
+  comment: string;
+  consent: boolean;
+  email: string;
+}): boolean {
+  if (input.comment.trim().length > 0) return true;
+  // Consent false means the server discards the name and the email. Without
+  // consent an address is not a payload.
+  return input.consent && isPlausibleEmail(input.email);
+}

--- a/src/pages/ReviewPage.tsx
+++ b/src/pages/ReviewPage.tsx
@@ -37,6 +37,20 @@ function initials(name: string): string {
     .join('');
 }
 
+/** The Google review hand-off. The promoter stage and the thanks stage both render it. */
+function GoogleReviewLink({ href }: { href: string }) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="mt-6 flex h-11 w-full items-center justify-center rounded-lg bg-primary text-[15px] font-medium text-primary-foreground"
+    >
+      Leave a Google review
+    </a>
+  );
+}
+
 export default function ReviewPage() {
   const { slug = '' } = useParams<{ slug: string }>();
 
@@ -338,16 +352,7 @@ export default function ReviewPage() {
           <p className="mt-2 text-center text-[14px] text-muted-foreground">
             Would you share that on Google? It takes about a minute.
           </p>
-          {destinationUrl && (
-            <a
-              href={destinationUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="mt-6 flex h-11 w-full items-center justify-center rounded-lg bg-primary text-[15px] font-medium text-primary-foreground"
-            >
-              Leave a Google review
-            </a>
-          )}
+          {destinationUrl && <GoogleReviewLink href={destinationUrl} />}
           <button
             type="button"
             onClick={() => goToStage('feedback', 'Tell us more. This goes straight to the owner.')}
@@ -357,7 +362,7 @@ export default function ReviewPage() {
           </button>
           <button
             type="button"
-            onClick={() => setStage('thanks')}
+            onClick={() => goToStage('thanks', 'Thanks. You can also share this on Google.')}
             className="counter-micro mt-2 w-full text-center text-[12px] text-muted-foreground underline"
           >
             No thanks
@@ -497,16 +502,7 @@ export default function ReviewPage() {
             {destinationUrl ? 'You can also share this on Google.' : 'have a good one'}
           </p>
           {/* A comment must not cost the restaurant a Google review. */}
-          {destinationUrl && (
-            <a
-              href={destinationUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="mt-6 flex h-11 w-full items-center justify-center rounded-lg bg-primary text-[15px] font-medium text-primary-foreground"
-            >
-              Leave a Google review
-            </a>
-          )}
+          {destinationUrl && <GoogleReviewLink href={destinationUrl} />}
         </>
       )}
 

--- a/src/pages/ReviewPage.tsx
+++ b/src/pages/ReviewPage.tsx
@@ -10,6 +10,9 @@ import { Textarea } from '@/components/ui/textarea';
 
 import { StarRating } from '@/components/reviews/StarRating';
 
+import { ChevronLeft } from 'lucide-react';
+
+import { canSubmitFollowUp } from '@/lib/reviews/reviewSubmission';
 import {
   classifyReviewPageResponse,
   type PublicReviewPage,
@@ -57,6 +60,14 @@ export default function ReviewPage() {
   const [rateError, setRateError] = useState(false);
 
   const [announcement, setAnnouncement] = useState('');
+
+  // The server's branch decision, derived. `routeRating` returns
+  // `'destination'` only when a URL exists, and `handleRate` releases the URL
+  // only on that branch, so this is the same test with no second state to
+  // keep in step. The form copy follows it: `What happened?` in front of a
+  // five-star guest reads as an accusation.
+  const isPromoterBranch = destinationUrl !== null;
+
   const branchHeadingRef = useRef<HTMLHeadingElement | null>(null);
   // The write guard is a ref, not the `committed` state: React batches state
   // updates, so a double-tap or a click landing on the same frame as an Enter
@@ -154,8 +165,19 @@ export default function ReviewPage() {
     [honeypot, slug]
   );
 
+  // Every stage move clears the error banner first. `That didn't send.` over
+  // a form the guest has not sent yet reads as a new failure.
+  const goToStage = useCallback((next: Stage, message: string) => {
+    setSubmitError(false);
+    setStage(next);
+    setAnnouncement(message);
+  }, []);
+
   const handleSubmitComment = useCallback(async () => {
-    if (!token || !comment.trim()) return;
+    // The `disabled` prop is not the only gate. This guard must hold the same
+    // rule, or a tap that gets past the button answers with nothing: no
+    // request, no error, no new stage.
+    if (!token || !canSubmitFollowUp({ comment, consent, email })) return;
     setSubmitting(true);
     setSubmitError(false);
 
@@ -163,7 +185,8 @@ export default function ReviewPage() {
       body: {
         action: 'comment',
         token,
-        comment: comment.trim(),
+        // An empty string would store as a blank comment. Send nothing.
+        comment: comment.trim() || undefined,
         consent,
         name: consent ? name : undefined,
         email: consent ? email : undefined,
@@ -176,8 +199,13 @@ export default function ReviewPage() {
       setSubmitError(true);
       return;
     }
-    setStage('thanks');
-  }, [comment, consent, email, honeypot, name, token]);
+    goToStage(
+      'thanks',
+      destinationUrl
+        ? 'Thanks. You can also share this on Google.'
+        : 'Thanks. The owner has your note.'
+    );
+  }, [comment, consent, destinationUrl, email, goToStage, honeypot, name, token]);
 
   const card = 'w-full max-w-md rounded-lg border border-border bg-card px-6 py-8 shadow-sm';
 
@@ -322,8 +350,15 @@ export default function ReviewPage() {
           )}
           <button
             type="button"
-            onClick={() => setStage('thanks')}
+            onClick={() => goToStage('feedback', 'Tell us more. This goes straight to the owner.')}
             className="counter-micro mt-4 w-full text-center text-[12px] text-muted-foreground underline"
+          >
+            Tell us something directly
+          </button>
+          <button
+            type="button"
+            onClick={() => setStage('thanks')}
+            className="counter-micro mt-2 w-full text-center text-[12px] text-muted-foreground underline"
           >
             No thanks
           </button>
@@ -332,12 +367,23 @@ export default function ReviewPage() {
 
       {stage === 'feedback' && (
         <>
+          {isPromoterBranch && (
+            <Button
+              type="button"
+              variant="ghost"
+              onClick={() => goToStage('promoter', 'Back to the Google link.')}
+              className="mb-2 h-9 px-2 rounded-lg text-[13px] font-medium text-muted-foreground hover:text-foreground"
+            >
+              <ChevronLeft className="mr-1 h-4 w-4" />
+              Back
+            </Button>
+          )}
           <h1
             ref={branchHeadingRef}
             tabIndex={-1}
             className="counter-display text-center text-[26px] font-semibold text-foreground focus:outline-none"
           >
-            What happened?
+            {isPromoterBranch ? 'Tell us more' : 'What happened?'}
           </h1>
           <p className="counter-micro mt-2 text-center text-[12px] text-muted-foreground">
             this goes straight to the owner — not public
@@ -346,7 +392,7 @@ export default function ReviewPage() {
           <div className="mt-5 space-y-4">
             <div>
               <Label htmlFor="review-comment" className="text-[13px] text-foreground">
-                Your feedback
+                Your feedback (optional)
               </Label>
               <Textarea
                 id="review-comment"
@@ -355,6 +401,11 @@ export default function ReviewPage() {
                 rows={4}
                 className="mt-1.5 bg-background border-border"
               />
+              {/* Without this line a guest who wants no comment sees a dead
+                  Send control and no reason for it. */}
+              <p className="counter-micro mt-1.5 text-[12px] text-muted-foreground">
+                Write a note, give your email, or both.
+              </p>
             </div>
 
             <div className="flex items-start gap-2">
@@ -417,7 +468,7 @@ export default function ReviewPage() {
             <Button
               type="button"
               onClick={handleSubmitComment}
-              disabled={submitting || comment.trim().length === 0}
+              disabled={submitting || !canSubmitFollowUp({ comment, consent, email })}
               className="h-11 w-full rounded-lg bg-primary text-[15px] font-medium text-primary-foreground"
             >
               {submitting ? 'Sending…' : 'Send to the owner'}
@@ -435,9 +486,22 @@ export default function ReviewPage() {
           >
             Thanks for telling us
           </h1>
+          {/* A sign-off above a call to action reads as an end. Say what the
+              button below is for, or say goodbye — never both. */}
           <p className="counter-micro mt-3 text-center text-[12px] text-muted-foreground">
-            have a good one
+            {destinationUrl ? 'You can also share this on Google.' : 'have a good one'}
           </p>
+          {/* A comment must not cost the restaurant a Google review. */}
+          {destinationUrl && (
+            <a
+              href={destinationUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-6 flex h-11 w-full items-center justify-center rounded-lg bg-primary text-[15px] font-medium text-primary-foreground"
+            >
+              Leave a Google review
+            </a>
+          )}
         </>
       )}
 

--- a/src/pages/ReviewPage.tsx
+++ b/src/pages/ReviewPage.tsx
@@ -62,10 +62,10 @@ export default function ReviewPage() {
   const [announcement, setAnnouncement] = useState('');
 
   // The server's branch decision, derived. `routeRating` returns
-  // `'destination'` only when a URL exists, and `handleRate` releases the URL
-  // only on that branch, so this is the same test with no second state to
-  // keep in step. The form copy follows it: `What happened?` in front of a
-  // five-star guest reads as an accusation.
+  // `'destination'` only when a URL exists. `handleRate` releases the URL only
+  // on that branch. This test is the same one, with no second state to keep in
+  // step. The form copy follows it. `What happened?` in front of a five-star
+  // guest reads as an accusation.
   const isPromoterBranch = destinationUrl !== null;
 
   const branchHeadingRef = useRef<HTMLHeadingElement | null>(null);
@@ -165,8 +165,8 @@ export default function ReviewPage() {
     [honeypot, slug]
   );
 
-  // Every stage move clears the error banner first. `That didn't send.` over
-  // a form the guest has not sent yet reads as a new failure.
+  // Every stage move clears the error banner first. The guest did not send the
+  // new form yet. `That didn't send.` above it reads as a new failure.
   const goToStage = useCallback((next: Stage, message: string) => {
     setSubmitError(false);
     setStage(next);
@@ -374,7 +374,7 @@ export default function ReviewPage() {
               onClick={() => goToStage('promoter', 'Back to the Google link.')}
               className="mb-2 h-9 px-2 rounded-lg text-[13px] font-medium text-muted-foreground hover:text-foreground"
             >
-              <ChevronLeft className="mr-1 h-4 w-4" />
+              <ChevronLeft aria-hidden="true" className="mr-1 h-4 w-4" />
               Back
             </Button>
           )}
@@ -396,14 +396,19 @@ export default function ReviewPage() {
               </Label>
               <Textarea
                 id="review-comment"
+                aria-describedby="review-comment-hint"
                 value={comment}
                 onChange={(event) => setComment(event.target.value)}
                 rows={4}
                 className="mt-1.5 bg-background border-border"
               />
               {/* Without this line a guest who wants no comment sees a dead
-                  Send control and no reason for it. */}
-              <p className="counter-micro mt-1.5 text-[12px] text-muted-foreground">
+                  Send control and no reason for it. `aria-describedby` reads it
+                  out to a guest who tabs straight into the field. */}
+              <p
+                id="review-comment-hint"
+                className="counter-micro mt-1.5 text-[12px] text-muted-foreground"
+              >
                 Write a note, give your email, or both.
               </p>
             </div>

--- a/src/pages/Reviews.tsx
+++ b/src/pages/Reviews.tsx
@@ -86,7 +86,7 @@ const STATUS_LABELS: Record<ReviewResponseStatus, string> = {
 
 const FILTER_LABELS: Array<[ReviewResponseFilter, string]> = [
   ['all', 'All'],
-  ['commented', 'With comments'],
+  ['needsReply', 'Needs a reply'],
   ['silent', 'Silent'],
 ];
 
@@ -95,13 +95,13 @@ const EMPTY_STATES: Record<ReviewResponseFilter, { title: string; body: string }
     title: 'No ratings yet',
     body: 'Put a review page QR code on the table. Every tap lands here.',
   },
-  commented: {
-    title: 'No written feedback yet',
-    body: 'Every guest can leave a note, at any star count. Their notes land here.',
+  needsReply: {
+    title: 'Nothing needs a reply yet',
+    body: 'A comment or a request to hear back lands here.',
   },
   silent: {
-    title: 'Every rating here has a comment',
-    body: 'A silent rating is a star tap with no note.',
+    title: 'No silent ratings',
+    body: 'A silent rating has no comment and no request to hear back.',
   },
 };
 

--- a/src/pages/Reviews.tsx
+++ b/src/pages/Reviews.tsx
@@ -1,15 +1,22 @@
-import { memo, useCallback, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 
 import { ChevronLeft, Plus, Star } from 'lucide-react';
 
 import { useRestaurantContext } from '@/contexts/RestaurantContext';
 import { usePermissions } from '@/hooks/usePermissions';
 import { useReviewPages, type ReviewPageWithStats } from '@/hooks/useReviewPages';
-import { useReviewResponses, type ReviewResponse, type ReviewResponseStatus } from '@/hooks/useReviewResponses';
+import {
+  isActionableResponse,
+  useReviewResponses,
+  type ReviewResponse,
+  type ReviewResponseFilter,
+  type ReviewResponseStatus,
+} from '@/hooks/useReviewResponses';
 import { ReviewPageBuilder } from '@/components/reviews/ReviewPageBuilder';
 import { ReviewFeedbackDetail } from '@/components/reviews/ReviewFeedbackDetail';
 import { StarDisplay } from '@/components/reviews/StarDisplay';
@@ -77,18 +84,37 @@ const STATUS_LABELS: Record<ReviewResponseStatus, string> = {
   resolved: 'Resolved',
 };
 
+const FILTER_LABELS: Array<[ReviewResponseFilter, string]> = [
+  ['all', 'All'],
+  ['commented', 'With comments'],
+  ['silent', 'Silent'],
+];
+
+const EMPTY_STATES: Record<ReviewResponseFilter, { title: string; body: string }> = {
+  all: {
+    title: 'No ratings yet',
+    body: 'Put a review page QR code on the table. Every tap lands here.',
+  },
+  commented: {
+    title: 'No written feedback yet',
+    body: 'Every guest can leave a note, at any star count. Their notes land here.',
+  },
+  silent: {
+    title: 'Every rating here has a comment',
+    body: 'A silent rating is a star tap with no note.',
+  },
+};
+
 function FeedbackTab({ restaurantId, canManage }: { restaurantId?: string; canManage: boolean }) {
+  const [filter, setFilter] = useState<ReviewResponseFilter>('all');
   const { responses, metrics, isLoading, error, updateStatus, fetchContact } =
-    useReviewResponses(restaurantId);
+    useReviewResponses(restaurantId, filter);
   const { pages } = useReviewPages(restaurantId);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const listRef = useRef<HTMLDivElement>(null);
 
-  // `responses` is already the commented rows only — the hook filters them
-  // server-side, before its 500-row cap. Ratings without a comment are a
-  // number, not a message: they count toward the header metrics and stay out
-  // of the list, because an inbox of 300 silent five-star taps is an inbox
-  // nobody opens.
+  // The hook applies the filter server-side, before its 500-row cap. A row
+  // the new mode excludes leaves `selected` null, and the detail pane closes.
   const selected = responses.find((row) => row.id === selectedId) ?? null;
   const pageNames = useMemo(
     () => new Map(pages.map((page) => [page.id, page.name])),
@@ -115,12 +141,31 @@ function FeedbackTab({ restaurantId, canManage }: { restaurantId?: string; canMa
   // status chip land most rows near 118px, and `measureElement` corrects the
   // rest. The cap the hook enforces is 500 rows, which is exactly the range
   // where mounting every row starts costing a manager real scroll latency.
+  // Both callbacks stay memoized. The virtualizer compares them by reference
+  // to decide if it must re-measure every row. A fresh arrow function per
+  // render breaks that check, so a plain row click re-measures all 500 rows.
+  // A silent row drops the two-line clamp and the status chip.
+  const estimateSize = useCallback(
+    (index: number) => (responses[index]?.comment ? 118 : 76),
+    [responses]
+  );
+  // Without a stable key the measurement cache is keyed by index. A filter
+  // change then applies the old row's height to the new row at that index.
+  const getItemKey = useCallback((index: number) => responses[index].id, [responses]);
+
   const virtualizer = useVirtualizer({
     count: responses.length,
     getScrollElement: () => listRef.current,
-    estimateSize: () => 118,
+    estimateSize,
+    getItemKey,
     overscan: 10,
   });
+
+  // A manager deep inside `All` who taps `Silent` must not land in the middle
+  // of a shorter list.
+  useEffect(() => {
+    if (listRef.current) listRef.current.scrollTop = 0;
+  }, [filter]);
 
   // A fresh arrow per row would defeat the memo on FeedbackRow — every parent
   // render would hand all 500 rows a new prop.
@@ -162,15 +207,31 @@ function FeedbackTab({ restaurantId, canManage }: { restaurantId?: string; canMa
         ))}
       </div>
 
+      <ToggleGroup
+        type="single"
+        value={filter}
+        // Radix sends an empty string when the guest taps the active item.
+        // Keep the mode; a list with no filter at all is not a state.
+        onValueChange={(value) => value && setFilter(value as ReviewResponseFilter)}
+        aria-label="Filter feedback"
+        className="mt-6 justify-start"
+      >
+        {FILTER_LABELS.map(([key, label]) => (
+          <ToggleGroupItem key={key} value={key} className="h-9 px-3 text-[13px]">
+            {label}
+          </ToggleGroupItem>
+        ))}
+      </ToggleGroup>
+
       {responses.length === 0 ? (
-        <div className="mt-6 rounded-xl border border-border/40 p-10 text-center">
-          <h2 className="text-[15px] font-semibold text-foreground">No written feedback yet</h2>
-          <p className="mt-1 text-[13px] text-muted-foreground">
-            Guests who rate below your threshold get the private form. Their notes land here.
-          </p>
+        <div className="mt-4 rounded-xl border border-border/40 p-10 text-center">
+          <h2 className="text-[15px] font-semibold text-foreground">
+            {EMPTY_STATES[filter].title}
+          </h2>
+          <p className="mt-1 text-[13px] text-muted-foreground">{EMPTY_STATES[filter].body}</p>
         </div>
       ) : (
-        <div className="mt-6 md:grid md:grid-cols-[340px_1fr] md:gap-6">
+        <div className="mt-4 md:grid md:grid-cols-[340px_1fr] md:gap-6">
           <div className={selected ? 'hidden md:block' : 'block'}>
             <div
               ref={listRef}
@@ -247,12 +308,21 @@ const FeedbackRow = memo(function FeedbackRow({
     >
       <div className="flex items-center justify-between gap-2">
         <StarDisplay rating={response.rating} className="text-[14px] text-foreground" />
-        <span className="text-[11px] px-1.5 py-0.5 rounded-md bg-muted text-muted-foreground">
-          {STATUS_LABELS[response.status]}
-        </span>
+        {/* Two rules, and they are not the same rule. A contact-only row has
+            no comment and is actionable: it shows the placeholder AND the
+            chip. A silent tap needs no triage, so it carries no status. */}
+        {isActionableResponse(response) && (
+          <span className="text-[11px] px-1.5 py-0.5 rounded-md bg-muted text-muted-foreground">
+            {STATUS_LABELS[response.status]}
+          </span>
+        )}
       </div>
       <p className="mt-1 text-[12px] text-muted-foreground truncate">{meta}</p>
-      <p className="mt-2 text-[13px] text-foreground line-clamp-2">{response.comment}</p>
+      {response.comment === null ? (
+        <p className="mt-2 text-[13px] text-muted-foreground">No comment left</p>
+      ) : (
+        <p className="mt-2 text-[13px] text-foreground line-clamp-2">{response.comment}</p>
+      )}
     </button>
   );
 });

--- a/src/pages/Reviews.tsx
+++ b/src/pages/Reviews.tsx
@@ -210,7 +210,7 @@ function FeedbackTab({ restaurantId, canManage }: { restaurantId?: string; canMa
       <ToggleGroup
         type="single"
         value={filter}
-        // Radix sends an empty string when the guest taps the active item.
+        // Radix sends an empty string when the manager taps the active item.
         // Keep the mode; a list with no filter at all is not a state.
         onValueChange={(value) => value && setFilter(value as ReviewResponseFilter)}
         aria-label="Filter feedback"

--- a/supabase/functions/_shared/reviewContact.ts
+++ b/supabase/functions/_shared/reviewContact.ts
@@ -1,0 +1,36 @@
+/**
+ * The submit rule `handleComment` uses.
+ *
+ * `src/lib/reviews/reviewSubmission.ts` holds the client copy, which enables
+ * the Send control: `isPlausibleEmail` and `canSubmitFollowUp` there answer
+ * to `isPlausibleEmail` and `hasFollowUpPayload` here. This copy is
+ * authoritative: it decides what the server writes. An edge function cannot
+ * import from `src/`. Change both together, or the button sends a request
+ * the server answers with a 400.
+ */
+
+/** The longest email `handleComment` accepts. It slices at this length. */
+export const MAX_EMAIL_LENGTH = 320;
+
+/**
+ * One local part, one `@`, and a domain with at least one dot. Only a sent
+ * mail proves an address works. This check catches the typo a guest can see.
+ */
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@.]+(\.[^\s@.]+)+$/;
+
+export function isPlausibleEmail(value: string): boolean {
+  const trimmed = value.trim();
+  if (trimmed.length === 0 || trimmed.length > MAX_EMAIL_LENGTH) return false;
+  return EMAIL_PATTERN.test(trimmed);
+}
+
+export function hasFollowUpPayload(input: {
+  comment: string;
+  consent: boolean;
+  email: string;
+}): boolean {
+  if (input.comment.trim().length > 0) return true;
+  // Consent false means the server discards the name and the email. Without
+  // consent an address is not a payload.
+  return input.consent && isPlausibleEmail(input.email);
+}

--- a/supabase/functions/review-public/index.ts
+++ b/supabase/functions/review-public/index.ts
@@ -14,7 +14,7 @@ import { corsHeaders } from '../_shared/cors.ts';
 import { signReviewToken, verifyReviewToken, REVIEW_TOKEN_TTL_SECONDS } from '../_shared/reviewToken.ts';
 import { routeRating } from '../_shared/reviewRouting.ts';
 import { hashIp, isOverLimit, REVIEW_RATE_WINDOW_MS } from '../_shared/reviewRateLimit.ts';
-import { hasFollowUpPayload, MAX_EMAIL_LENGTH } from '../_shared/reviewContact.ts';
+import { hasFollowUpPayload, isPlausibleEmail, MAX_EMAIL_LENGTH } from '../_shared/reviewContact.ts';
 
 const JSON_HEADERS = { ...corsHeaders, 'Content-Type': 'application/json' };
 
@@ -269,7 +269,23 @@ async function handleComment(
   const honeypot = typeof body.hp === 'string' ? body.hp : '';
   const consent = body.consent === true;
   const name = typeof body.name === 'string' ? body.name.trim().slice(0, MAX_NAME_LENGTH) : '';
-  const email = typeof body.email === 'string' ? body.email.trim().slice(0, MAX_EMAIL_LENGTH) : '';
+
+  // Validate the raw, untruncated email before any slice. A slice-then-check
+  // order let a caller send a 400-character string, watch the server cut it
+  // to MAX_EMAIL_LENGTH, and have the server store an address the guest
+  // never typed.
+  const rawEmail = typeof body.email === 'string' ? body.email.trim() : '';
+
+  // A comment carries the payload on its own, so an email-only request has
+  // no fallback: an over-length email must fail loud here, not fall through
+  // to the generic hasFollowUpPayload 400 below as if it were merely
+  // malformed.
+  if (!comment && rawEmail.length > MAX_EMAIL_LENGTH) return fail(400);
+
+  // A comment-bearing request drops an invalid or over-length email and
+  // keeps the comment. Truncation happens only now, after the raw value has
+  // passed every check.
+  const email = comment && !isPlausibleEmail(rawEmail) ? '' : rawEmail.slice(0, MAX_EMAIL_LENGTH);
 
   // A malformed request is answered honestly with a 400 — that tells an
   // attacker nothing they did not already know about their own payload.
@@ -314,48 +330,33 @@ async function handleComment(
     return ok();
   }
 
-  // `commented_at IS NULL` is what makes the token single-use: a replay
-  // updates zero rows and still answers ok. `comment IS NULL` cannot do that
-  // job now — a contact-only submit leaves the comment NULL, so a replay
-  // would match again, re-run the UPDATE, and hit the primary key on
-  // review_response_contacts. `handleComment` is the only writer of
-  // `commented_at`, so the new guard rejects every replay the old one did.
+  // review_response_submit_followup runs the guarded UPDATE and, on
+  // consent, the review_response_contacts INSERT inside one implicit
+  // transaction. `commented_at IS NULL` is what makes the token single-use:
+  // a replay updates zero rows and still answers ok. `comment IS NULL`
+  // cannot do that job — a contact-only submit leaves the comment NULL, so
+  // a replay would match again and hit the primary key on
+  // review_response_contacts. The RPC is the only writer of `commented_at`,
+  // so the guard rejects every replay. A failed contact insert now rolls
+  // the UPDATE back too, so `commented_at` stays NULL and a retry works.
   //
   // An empty comment stores as NULL, not as an empty string.
   // `review_response_metrics` counts `comment IS NOT NULL`, so an empty
   // string would inflate the comment count and put a blank row in the inbox.
-  const { data: updated, error: updateError } = await supabase
-    .from('review_responses')
-    .update({
-      comment: comment || null,
-      contact_consent: consent,
-      commented_at: new Date().toISOString(),
-    })
-    .eq('id', payload.rid)
-    .is('commented_at', null)
-    .select('id');
+  const { error: writeError } = await supabase.rpc('review_response_submit_followup', {
+    p_response_id: payload.rid,
+    p_comment: comment || null,
+    p_consent: consent,
+    p_name: name || null,
+    p_email: email || null,
+  });
 
-  if (updateError) {
-    console.error('review-public: comment update failed', updateError);
+  // The RPC returns false on a replay (zero rows updated) and true on a
+  // real write. The caller answers ok() either way, so it cannot tell them
+  // apart.
+  if (writeError) {
+    console.error('review-public: comment write failed', writeError);
     return fail(500);
   }
-  if (!updated || updated.length === 0) return ok();
-
-  // Consent false means the values are discarded, not stored and hidden.
-  if (consent && (name || email)) {
-    const { error: contactError } = await supabase
-      .from('review_response_contacts')
-      .insert({
-        review_response_id: payload.rid,
-        restaurant_id: '00000000-0000-0000-0000-000000000000', // overwritten by the trigger
-        contact_name: name || null,
-        contact_email: email || null,
-      });
-    if (contactError) {
-      console.error('review-public: contact insert failed', contactError);
-      // The comment itself is saved; the guest does not need to know.
-    }
-  }
-
   return ok();
 }

--- a/supabase/functions/review-public/index.ts
+++ b/supabase/functions/review-public/index.ts
@@ -14,6 +14,7 @@ import { corsHeaders } from '../_shared/cors.ts';
 import { signReviewToken, verifyReviewToken, REVIEW_TOKEN_TTL_SECONDS } from '../_shared/reviewToken.ts';
 import { routeRating } from '../_shared/reviewRouting.ts';
 import { hashIp, isOverLimit, REVIEW_RATE_WINDOW_MS } from '../_shared/reviewRateLimit.ts';
+import { hasFollowUpPayload, MAX_EMAIL_LENGTH } from '../_shared/reviewContact.ts';
 
 const JSON_HEADERS = { ...corsHeaders, 'Content-Type': 'application/json' };
 
@@ -256,7 +257,6 @@ async function countRecentResponses(
 
 const MAX_COMMENT_LENGTH = 4000;
 const MAX_NAME_LENGTH = 200;
-const MAX_EMAIL_LENGTH = 320;
 
 async function handleComment(
   supabase: Supabase,
@@ -273,7 +273,11 @@ async function handleComment(
 
   // A malformed request is answered honestly with a 400 — that tells an
   // attacker nothing they did not already know about their own payload.
-  if (!token || !comment || comment.length > MAX_COMMENT_LENGTH) return fail(400);
+  if (!token || comment.length > MAX_COMMENT_LENGTH) return fail(400);
+
+  // The comment is optional, the payload is not. A request with neither a
+  // comment nor a usable email writes nothing, so it stays a 400.
+  if (!hasFollowUpPayload({ comment, consent, email })) return fail(400);
 
   // Past this point every early exit returns the same shape, so a caller
   // holding a well-formed request cannot distinguish a bot trip, a replay, an
@@ -310,17 +314,25 @@ async function handleComment(
     return ok();
   }
 
-  // `comment IS NULL` is what makes the token single-use: a replay updates
-  // zero rows and still answers ok.
+  // `commented_at IS NULL` is what makes the token single-use: a replay
+  // updates zero rows and still answers ok. `comment IS NULL` cannot do that
+  // job now — a contact-only submit leaves the comment NULL, so a replay
+  // would match again, re-run the UPDATE, and hit the primary key on
+  // review_response_contacts. `handleComment` is the only writer of
+  // `commented_at`, so the new guard rejects every replay the old one did.
+  //
+  // An empty comment stores as NULL, not as an empty string.
+  // `review_response_metrics` counts `comment IS NOT NULL`, so an empty
+  // string would inflate the comment count and put a blank row in the inbox.
   const { data: updated, error: updateError } = await supabase
     .from('review_responses')
     .update({
-      comment,
+      comment: comment || null,
       contact_consent: consent,
       commented_at: new Date().toISOString(),
     })
     .eq('id', payload.rid)
-    .is('comment', null)
+    .is('commented_at', null)
     .select('id');
 
   if (updateError) {

--- a/supabase/migrations/20260806120000_review_metrics_actionable.sql
+++ b/supabase/migrations/20260806120000_review_metrics_actionable.sql
@@ -7,9 +7,9 @@
 -- and under-counts it.
 --
 -- Warning: a DROP FUNCTION here breaks the page for every user. A DROP resets
--- the grants, `authenticated` loses EXECUTE, and the Feedback tab header
--- fails with `permission denied for function`. Use CREATE OR REPLACE, keep
--- the same signature and the same attributes, and restate the two grant
+-- the grants. `authenticated` then loses EXECUTE. The Feedback tab header
+-- then fails with `permission denied for function`. Use CREATE OR REPLACE.
+-- Keep the same signature and the same attributes. Restate the two grant
 -- lines below.
 -- ============================================================================
 

--- a/supabase/migrations/20260806120000_review_metrics_actionable.sql
+++ b/supabase/migrations/20260806120000_review_metrics_actionable.sql
@@ -1,0 +1,53 @@
+-- ============================================================================
+-- Review funnel follow-ups: the unread badge follows the actionable rule.
+--
+-- A guest can now finish the follow-up form with contact details and no
+-- comment. That guest asked to hear back, so the row needs a reply and must
+-- reach the Unread badge. The old rule counted `comment IS NOT NULL` alone
+-- and under-counts it.
+--
+-- Warning: a DROP FUNCTION here breaks the page for every user. A DROP resets
+-- the grants, `authenticated` loses EXECUTE, and the Feedback tab header
+-- fails with `permission denied for function`. Use CREATE OR REPLACE, keep
+-- the same signature and the same attributes, and restate the two grant
+-- lines below.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.review_response_metrics(p_restaurant_id UUID)
+RETURNS TABLE (
+  average_rating NUMERIC,
+  total_ratings BIGINT,
+  comment_count BIGINT,
+  unread_count BIGINT
+)
+LANGUAGE sql
+STABLE
+SET search_path = public, pg_temp
+AS $$
+  SELECT
+    round(avg(rr.rating)::numeric, 1) AS average_rating,
+    count(*) AS total_ratings,
+    count(*) FILTER (WHERE rr.comment IS NOT NULL) AS comment_count,
+    -- Unread counts the rows a manager can act on: a comment to read, or a
+    -- guest who asked to hear back. A silent star tap is also born with
+    -- status 'new' and needs no triage, so counting it would leave a badge
+    -- the manager has no way to open or clear.
+    -- `isActionableResponse` in src/hooks/useReviewResponses.ts holds the same
+    -- rule for the client. Change both together, or the badge count and the
+    -- rows that show a status chip disagree.
+    count(*) FILTER (
+      WHERE rr.status = 'new'
+        AND (rr.comment IS NOT NULL OR rr.contact_consent)
+    ) AS unread_count
+  FROM public.review_responses rr
+  WHERE rr.restaurant_id = p_restaurant_id;
+$$;
+
+REVOKE ALL ON FUNCTION public.review_response_metrics(UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.review_response_metrics(UUID) TO authenticated;
+
+COMMENT ON FUNCTION public.review_response_metrics(UUID) IS
+'Restaurant-wide average rating / total ratings / comment count / unread actionable count for the Feedback tab header. Unread counts a new row that holds a comment or contact consent. Not capped at any row count, unlike the list query that backs the inbox rows themselves.';
+
+COMMENT ON COLUMN public.review_responses.commented_at IS
+'When the guest finished the follow-up form. Does NOT imply a comment: a contact-only submit sets this and leaves comment NULL. Use comment IS NOT NULL to test for a comment.';

--- a/supabase/migrations/20260806130000_review_response_followup_rpc.sql
+++ b/supabase/migrations/20260806130000_review_response_followup_rpc.sql
@@ -1,0 +1,76 @@
+-- ============================================================================
+-- review_response_submit_followup: one RPC for the guest follow-up write.
+--
+-- handleComment in supabase/functions/review-public/index.ts used to run two
+-- separate writes: an UPDATE on review_responses, then an INSERT on
+-- review_response_contacts. The INSERT's error was logged and swallowed --
+-- correct for a comment-only submit, where the comment already saved. Wrong
+-- for a contact-only submit: the UPDATE stores nothing but the
+-- commented_at stamp, the failed INSERT drops the guest's email on the
+-- floor, and the single-use guard below now rejects a retry. The guest has
+-- no way to repair it.
+--
+-- This function puts both writes inside one call, so one failure rolls back
+-- the other. A caller does not need an explicit transaction: a single
+-- SECURITY DEFINER function body is one implicit transaction, and an
+-- unhandled exception in the INSERT unwinds the UPDATE with it. A failed
+-- contact insert now leaves commented_at NULL, so a retry works.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.review_response_submit_followup(
+  p_response_id UUID,
+  p_comment     TEXT,
+  p_consent     BOOLEAN,
+  p_name        TEXT,
+  p_email       TEXT
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_updated_id UUID;
+BEGIN
+  -- `commented_at IS NULL` makes the token single-use: a replay updates
+  -- zero rows and the caller still answers ok. `comment IS NULL` cannot do
+  -- that job -- a contact-only submit leaves comment NULL, so a replay would
+  -- match again and hit the primary key on review_response_contacts. This
+  -- function is the only writer of commented_at, so this guard rejects
+  -- every replay.
+  UPDATE public.review_responses
+  SET comment = p_comment,
+      contact_consent = p_consent,
+      commented_at = now()
+  WHERE id = p_response_id
+    AND commented_at IS NULL
+  RETURNING id INTO v_updated_id;
+
+  IF v_updated_id IS NULL THEN
+    RETURN false;
+  END IF;
+
+  -- Consent false means the values are discarded, not stored and hidden.
+  IF p_consent AND (p_name IS NOT NULL OR p_email IS NOT NULL) THEN
+    INSERT INTO public.review_response_contacts (
+      review_response_id, restaurant_id, contact_name, contact_email
+    ) VALUES (
+      v_updated_id,
+      '00000000-0000-0000-0000-000000000000', -- overwritten by the trigger
+      p_name,
+      p_email
+    );
+  END IF;
+
+  RETURN true;
+END;
+$$;
+
+-- Least privilege: only review-public (service_role) may call this. A
+-- signed-in user edits a response through `status` and RLS, never through
+-- this path.
+REVOKE ALL ON FUNCTION public.review_response_submit_followup(UUID, TEXT, BOOLEAN, TEXT, TEXT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.review_response_submit_followup(UUID, TEXT, BOOLEAN, TEXT, TEXT) TO service_role;
+
+COMMENT ON FUNCTION public.review_response_submit_followup IS
+'Guest follow-up write for review-public''s handleComment. Runs the guarded UPDATE (commented_at IS NULL makes the token single-use) and, on a real write with consent and a name or an email, the review_response_contacts INSERT -- in one implicit transaction, so a failed INSERT rolls back the UPDATE and commented_at stays NULL for a retry. Returns true on a real write, false on a replay (zero rows updated). SECURITY DEFINER, service_role only.';

--- a/supabase/tests/review_response_aggregates_test.sql
+++ b/supabase/tests/review_response_aggregates_test.sql
@@ -1,9 +1,9 @@
 BEGIN;
 SELECT plan(6);
 
--- Fixture: one page in restaurant A with three responses (one commented, two
--- not), plus an owner (manage:reviews) and an outsider with no restaurant at
--- all.
+-- Fixture: one page in restaurant A with four responses — one commented, one
+-- contact-only, two silent — plus an owner (manage:reviews) and an outsider
+-- with no restaurant at all.
 INSERT INTO auth.users (id, email) VALUES
   ('aaaaaaaa-0000-0000-0000-000000000001', 'owner-a@test.local'),
   ('aaaaaaaa-0000-0000-0000-000000000099', 'outsider@test.local');
@@ -22,17 +22,22 @@ VALUES ('22222222-0000-0000-0000-000000000001',
         '11111111-0000-0000-0000-000000000001', 'counter-a', 'Table tents');
 
 INSERT INTO public.review_responses
-  (id, restaurant_id, review_page_id, rating, routed_to, comment, status)
+  (id, restaurant_id, review_page_id, rating, routed_to, comment, contact_consent, status)
 VALUES
   ('33333333-0000-0000-0000-000000000001',
    '11111111-0000-0000-0000-000000000001',
-   '22222222-0000-0000-0000-000000000001', 5, 'destination', NULL, 'new'),
+   '22222222-0000-0000-0000-000000000001', 5, 'destination', NULL, false, 'new'),
   ('33333333-0000-0000-0000-000000000002',
    '11111111-0000-0000-0000-000000000001',
-   '22222222-0000-0000-0000-000000000001', 2, 'feedback', 'The soup was cold', 'new'),
+   '22222222-0000-0000-0000-000000000001', 2, 'feedback', 'The soup was cold', false, 'new'),
   ('33333333-0000-0000-0000-000000000003',
    '11111111-0000-0000-0000-000000000001',
-   '22222222-0000-0000-0000-000000000001', 4, 'destination', NULL, 'resolved');
+   '22222222-0000-0000-0000-000000000001', 4, 'destination', NULL, false, 'resolved'),
+  -- A promoter who left an email and no comment. The guest asked to hear
+  -- back, so the row is actionable and must reach the Unread badge.
+  ('33333333-0000-0000-0000-000000000004',
+   '11111111-0000-0000-0000-000000000001',
+   '22222222-0000-0000-0000-000000000001', 5, 'destination', NULL, true, 'new');
 
 SET LOCAL role TO authenticated;
 SELECT set_config('request.jwt.claims', '{"sub":"aaaaaaaa-0000-0000-0000-000000000001","role":"authenticated"}', true);
@@ -41,14 +46,14 @@ SELECT set_config('request.jwt.claim.role', 'authenticated', true);
 
 SELECT is(
   (SELECT average_rating FROM public.review_response_metrics('11111111-0000-0000-0000-000000000001')),
-  3.7::numeric,
-  'review_response_metrics averages every rating, not just commented ones ((5+2+4)/3 = 3.7)'
+  4.0::numeric,
+  'review_response_metrics averages every rating, not just commented ones ((5+2+4+5)/4 = 4.0)'
 );
 
 SELECT is(
   (SELECT total_ratings FROM public.review_response_metrics('11111111-0000-0000-0000-000000000001')),
-  3::bigint,
-  'review_response_metrics counts all three responses, unbounded by any row cap'
+  4::bigint,
+  'review_response_metrics counts all four responses, unbounded by any row cap'
 );
 
 SELECT is(
@@ -57,19 +62,20 @@ SELECT is(
   'review_response_metrics counts only the one commented response'
 );
 
--- Two rows are status 'new', but one of them is a silent five-star tap that
--- never reaches the Feedback list. Counting it would put a badge on the tab
--- that the manager has no row to open and no way to clear.
+-- Three rows are status 'new': a comment, a contact-only submit, and a
+-- silent five-star tap. The first two need a reply. The third needs no
+-- triage, so counting it would put a badge on the tab that the manager has
+-- no row to act on and no way to clear.
 SELECT is(
   (SELECT unread_count FROM public.review_response_metrics('11111111-0000-0000-0000-000000000001')),
-  1::bigint,
-  'review_response_metrics counts only the new response that carries a comment'
+  2::bigint,
+  'review_response_metrics counts a new comment and a new contact-only row, not a silent tap'
 );
 
 SELECT is(
   (SELECT rating_count FROM public.review_page_stats('11111111-0000-0000-0000-000000000001')
    WHERE review_page_id = '22222222-0000-0000-0000-000000000001'),
-  3::bigint,
+  4::bigint,
   'review_page_stats aggregates per page via GROUP BY, not per-card round trips'
 );
 

--- a/supabase/tests/review_response_submit_followup_test.sql
+++ b/supabase/tests/review_response_submit_followup_test.sql
@@ -1,0 +1,137 @@
+-- pgTAP tests for review_response_submit_followup, the service-role-only RPC
+-- that review-public's handleComment calls to write the guest follow-up.
+--
+-- Coverage:
+--   1-3. a contact-only write (no comment, consent, name + email) reports
+--      true, stamps commented_at, and stores the guest email
+--   4. the trigger still derives review_response_contacts.restaurant_id
+--   5-6. a replay (commented_at already set) updates zero rows, returns
+--      false, and leaves the first contact row untouched
+--   7-8. a failed contact insert (forced primary-key collision) raises
+--      instead of swallowing the error, and rolls the UPDATE back too, so
+--      commented_at stays NULL and a retry can work
+--   9-10. authenticated has no EXECUTE privilege (service_role only)
+
+BEGIN;
+SELECT plan(10);
+
+-- Fixture: one page in restaurant A, three responses ready for a follow-up.
+INSERT INTO public.restaurants (id, name) VALUES
+  ('11111111-0000-0000-0000-000000000001', 'Restaurant A');
+
+SET LOCAL role TO postgres;
+
+INSERT INTO public.review_pages (id, restaurant_id, slug, name)
+VALUES ('22222222-0000-0000-0000-000000000001',
+        '11111111-0000-0000-0000-000000000001', 'counter-a', 'Table tents');
+
+INSERT INTO public.review_responses
+  (id, restaurant_id, review_page_id, rating, routed_to)
+VALUES
+  ('33333333-0000-0000-0000-000000000001',
+   '11111111-0000-0000-0000-000000000001',
+   '22222222-0000-0000-0000-000000000001', 5, 'destination'),
+  ('33333333-0000-0000-0000-000000000002',
+   '11111111-0000-0000-0000-000000000001',
+   '22222222-0000-0000-0000-000000000001', 4, 'destination'),
+  ('33333333-0000-0000-0000-000000000003',
+   '11111111-0000-0000-0000-000000000001',
+   '22222222-0000-0000-0000-000000000001', 3, 'feedback');
+
+-- ---------- 1-3. contact-only write stores both rows ----------
+SELECT is(
+  public.review_response_submit_followup(
+    '33333333-0000-0000-0000-000000000001'::uuid,
+    NULL, TRUE, 'Dana Guest', 'dana@example.test'
+  ),
+  TRUE,
+  'a contact-only write reports true'
+);
+
+SELECT is(
+  (SELECT commented_at IS NOT NULL FROM public.review_responses
+   WHERE id = '33333333-0000-0000-0000-000000000001'),
+  TRUE,
+  'the response is stamped commented_at even with no comment text'
+);
+
+SELECT is(
+  (SELECT contact_email FROM public.review_response_contacts
+   WHERE review_response_id = '33333333-0000-0000-0000-000000000001'),
+  'dana@example.test',
+  'the guest email is stored, not lost'
+);
+
+-- ---------- 4. the trigger still derives restaurant_id ----------
+SELECT is(
+  (SELECT restaurant_id FROM public.review_response_contacts
+   WHERE review_response_id = '33333333-0000-0000-0000-000000000001'),
+  '11111111-0000-0000-0000-000000000001'::uuid,
+  'the contacts trigger still derives restaurant_id from the response'
+);
+
+-- ---------- 5-6. a replay updates zero rows and leaves the row alone ----------
+SELECT is(
+  public.review_response_submit_followup(
+    '33333333-0000-0000-0000-000000000001'::uuid,
+    NULL, TRUE, 'Someone Else', 'someone-else@example.test'
+  ),
+  FALSE,
+  'a replay against an already-commented row reports false'
+);
+
+SELECT is(
+  (SELECT contact_email FROM public.review_response_contacts
+   WHERE review_response_id = '33333333-0000-0000-0000-000000000001'),
+  'dana@example.test',
+  'the replay does not overwrite the first guest email'
+);
+
+-- ---------- 7-8. a failed contact insert rolls back the UPDATE too ----------
+-- Pre-seed the target contact row so the RPC's own INSERT hits the primary
+-- key. review_response_id is the primary key, so the collision is
+-- guaranteed regardless of any other constraint on the table.
+INSERT INTO public.review_response_contacts
+  (review_response_id, restaurant_id, contact_name, contact_email)
+VALUES
+  ('33333333-0000-0000-0000-000000000002',
+   '00000000-0000-0000-0000-000000000000', -- trigger overwrites
+   'Existing Row', 'existing@example.test');
+
+SELECT throws_like(
+  $$SELECT public.review_response_submit_followup(
+      '33333333-0000-0000-0000-000000000002'::uuid,
+      NULL, TRUE, 'Second Attempt', 'second@example.test'
+    )$$,
+  '%duplicate key%',
+  'a contact insert that collides raises, rather than swallowing the error'
+);
+
+SELECT is(
+  (SELECT commented_at FROM public.review_responses
+   WHERE id = '33333333-0000-0000-0000-000000000002'),
+  NULL::timestamptz,
+  'the failed insert rolls the UPDATE back too, so commented_at stays NULL for a retry'
+);
+
+-- ---------- 9-10. authenticated has no EXECUTE (service_role only) ----------
+SELECT ok(
+  has_function_privilege(
+    'service_role',
+    'public.review_response_submit_followup(uuid,text,boolean,text,text)',
+    'EXECUTE'
+  ),
+  'service_role can execute review_response_submit_followup'
+);
+
+SELECT ok(
+  NOT has_function_privilege(
+    'authenticated',
+    'public.review_response_submit_followup(uuid,text,boolean,text,text)',
+    'EXECUTE'
+  ),
+  'authenticated cannot execute review_response_submit_followup'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/tests/e2e/review-promoter-followup.spec.ts
+++ b/tests/e2e/review-promoter-followup.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -10,8 +10,9 @@ import { test, expect } from '@playwright/test';
  * three paths that hand-off must not close.
  *
  * The edge function is not served in the e2e stack, so `review-public` is
- * stubbed. Its token and routing logic are covered elsewhere; what this
- * proves is the wiring — which controls appear, and what the client sends.
+ * stubbed. Other tests cover its token logic and its routing logic. This spec
+ * proves the wiring. It shows which controls appear. It shows what the client
+ * sends.
  */
 
 const FN_GLOB = '**/functions/v1/review-public';
@@ -28,8 +29,8 @@ const RATE_BODY = {
   destination_url: 'https://example.com/google-review',
 };
 
-/** Stubs the three actions and collects every `comment` body the page sends. */
-async function stubReviewPublic(page: any, commentBodies: any[]) {
+/** Stubs the three actions. Collects every `comment` body the page sends. */
+async function stubReviewPublic(page: Page, commentBodies: any[]) {
   await page.route(FN_GLOB, async (route: any) => {
     const body = route.request().postDataJSON();
     if (body.action === 'page') {
@@ -112,6 +113,9 @@ test.describe('public review page promoter follow-up', () => {
     await expect(send).toBeDisabled();
 
     await page.getByLabel(/it's ok to contact me about this/i).check();
+    // Consent alone is not a payload. The owner gets no way to answer.
+    await expect(send).toBeDisabled();
+
     await page.getByLabel(/^email$/i).fill('ada@example.com');
     await expect(send).toBeEnabled();
     await send.click();

--- a/tests/e2e/review-promoter-followup.spec.ts
+++ b/tests/e2e/review-promoter-followup.spec.ts
@@ -1,0 +1,125 @@
+import { test, expect } from '@playwright/test';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * E2E: a promoter can leave a comment, an email, or both.
+ *
+ * Slice 1 sent a four-star or five-star guest straight to the Google
+ * hand-off, with no way back. This spec is the regression guard for the
+ * three paths that hand-off must not close.
+ *
+ * The edge function is not served in the e2e stack, so `review-public` is
+ * stubbed. Its token and routing logic are covered elsewhere; what this
+ * proves is the wiring — which controls appear, and what the client sends.
+ */
+
+const FN_GLOB = '**/functions/v1/review-public';
+const PAGE_BODY = {
+  restaurant_name: 'Test Diner',
+  headline: 'How was everything?',
+  subheadline: null,
+  logo_url: null,
+  threshold: 4,
+};
+const RATE_BODY = {
+  token: 'stub-token',
+  routed_to: 'destination',
+  destination_url: 'https://example.com/google-review',
+};
+
+/** Stubs the three actions and collects every `comment` body the page sends. */
+async function stubReviewPublic(page: any, commentBodies: any[]) {
+  await page.route(FN_GLOB, async (route: any) => {
+    const body = route.request().postDataJSON();
+    if (body.action === 'page') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(PAGE_BODY),
+      });
+    }
+    if (body.action === 'rate') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(RATE_BODY),
+      });
+    }
+    commentBodies.push(body);
+    return route.fulfill({ status: 200, contentType: 'application/json', body: '{"ok":true}' });
+  });
+}
+
+test.describe('public review page promoter follow-up', () => {
+  test('a promoter reaches the form and returns with the text kept', async ({ page }) => {
+    await stubReviewPublic(page, []);
+    await page.goto('/r/table-tents');
+
+    await page.getByRole('radio', { name: '5 out of 5 stars' }).click();
+    await expect(page.getByRole('heading', { name: /thank you/i })).toBeVisible();
+
+    await page.getByRole('button', { name: /tell us something directly/i }).click();
+
+    // The heading follows the branch: `What happened?` reads as an
+    // accusation in front of a five-star guest.
+    await expect(page.getByRole('heading', { name: /tell us more/i })).toBeVisible();
+    const field = page.getByLabel(/your feedback \(optional\)/i);
+    await field.fill('The bread was excellent');
+
+    await page.getByRole('button', { name: /^back$/i }).click();
+    await expect(page.getByRole('link', { name: /leave a google review/i })).toBeVisible();
+
+    await page.getByRole('button', { name: /tell us something directly/i }).click();
+    await expect(page.getByLabel(/your feedback \(optional\)/i)).toHaveValue(
+      'The bread was excellent'
+    );
+  });
+
+  test('a promoter sends a comment and still sees the Google button', async ({ page }) => {
+    const commentBodies: any[] = [];
+    await stubReviewPublic(page, commentBodies);
+    await page.goto('/r/table-tents');
+
+    await page.getByRole('radio', { name: '5 out of 5 stars' }).click();
+    await page.getByRole('button', { name: /tell us something directly/i }).click();
+    await page.getByLabel(/your feedback \(optional\)/i).fill('The bread was excellent');
+    await page.getByRole('button', { name: /send to the owner/i }).click();
+
+    await expect(page.getByRole('heading', { name: /thanks for telling us/i })).toBeVisible();
+    expect(commentBodies).toHaveLength(1);
+    expect(commentBodies[0]).toMatchObject({
+      action: 'comment',
+      token: 'stub-token',
+      comment: 'The bread was excellent',
+    });
+
+    // A comment must not cost the restaurant a Google review.
+    const link = page.getByRole('link', { name: /leave a google review/i });
+    await expect(link).toHaveAttribute('href', 'https://example.com/google-review');
+  });
+
+  test('a promoter sends an email with no comment', async ({ page }) => {
+    const commentBodies: any[] = [];
+    await stubReviewPublic(page, commentBodies);
+    await page.goto('/r/table-tents');
+
+    await page.getByRole('radio', { name: '5 out of 5 stars' }).click();
+    await page.getByRole('button', { name: /tell us something directly/i }).click();
+
+    const send = page.getByRole('button', { name: /send to the owner/i });
+    // An empty form writes nothing, so the control stays disabled.
+    await expect(send).toBeDisabled();
+
+    await page.getByLabel(/it's ok to contact me about this/i).check();
+    await page.getByLabel(/^email$/i).fill('ada@example.com');
+    await expect(send).toBeEnabled();
+    await send.click();
+
+    await expect(page.getByRole('heading', { name: /thanks for telling us/i })).toBeVisible();
+    expect(commentBodies).toHaveLength(1);
+    // No empty string. An empty comment would store as a blank inbox row.
+    expect(commentBodies[0].comment).toBeUndefined();
+    expect(commentBodies[0]).toMatchObject({ consent: true, email: 'ada@example.com' });
+  });
+});

--- a/tests/unit/reviewContact.test.ts
+++ b/tests/unit/reviewContact.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  hasFollowUpPayload,
+  isPlausibleEmail,
+  MAX_EMAIL_LENGTH,
+} from '../../supabase/functions/_shared/reviewContact';
+import {
+  canSubmitFollowUp,
+  isPlausibleEmail as isPlausibleEmailClient,
+} from '@/lib/reviews/reviewSubmission';
+
+describe('isPlausibleEmail (server)', () => {
+  it('accepts an ordinary address', () => {
+    expect(isPlausibleEmail('ada@example.com')).toBe(true);
+  });
+
+  it('rejects an address with no dot in the domain', () => {
+    expect(isPlausibleEmail('ada@localhost')).toBe(false);
+  });
+
+  it('rejects an empty value', () => {
+    expect(isPlausibleEmail('   ')).toBe(false);
+  });
+
+  it('rejects a value past MAX_EMAIL_LENGTH', () => {
+    expect(isPlausibleEmail(`${'a'.repeat(MAX_EMAIL_LENGTH)}@example.com`)).toBe(false);
+  });
+});
+
+describe('hasFollowUpPayload', () => {
+  it('allows a comment on its own', () => {
+    expect(hasFollowUpPayload({ comment: 'The soup was cold', consent: false, email: '' })).toBe(
+      true
+    );
+  });
+
+  it('refuses a whitespace-only comment with no email', () => {
+    expect(hasFollowUpPayload({ comment: '   \n  ', consent: false, email: '' })).toBe(false);
+  });
+
+  it('allows an email on its own when the guest consents', () => {
+    expect(hasFollowUpPayload({ comment: '', consent: true, email: 'ada@example.com' })).toBe(
+      true
+    );
+  });
+
+  it('refuses a plausible email without consent', () => {
+    expect(hasFollowUpPayload({ comment: '', consent: false, email: 'ada@example.com' })).toBe(
+      false
+    );
+  });
+
+  it('refuses consent with a malformed email and no comment', () => {
+    expect(hasFollowUpPayload({ comment: '', consent: true, email: 'ada@' })).toBe(false);
+  });
+
+  it('refuses an email over MAX_EMAIL_LENGTH even with consent', () => {
+    const longEmail = `${'a'.repeat(MAX_EMAIL_LENGTH)}@example.com`;
+    expect(hasFollowUpPayload({ comment: '', consent: true, email: longEmail })).toBe(false);
+  });
+});
+
+// This group guards the drift the module docs warn about: the client copy
+// enables a button, and the server copy decides what the server writes. A
+// gap between the two lets the client enable a submit the server answers
+// with a 400.
+describe('parity between the client and server copies', () => {
+  const emails = [
+    'ada@example.com',
+    'ada+tag@mail.example.co.uk',
+    '  ada@example.com  ',
+    'ada@',
+    'ada@localhost',
+    'ada example.com',
+    '   ',
+    `${'a'.repeat(MAX_EMAIL_LENGTH)}@example.com`,
+  ];
+
+  it('isPlausibleEmail agrees on every email string', () => {
+    for (const email of emails) {
+      expect(isPlausibleEmail(email)).toBe(isPlausibleEmailClient(email));
+    }
+  });
+
+  const inputs = [
+    { comment: 'The soup was cold', consent: false, email: '' },
+    { comment: '', consent: true, email: 'ada@example.com' },
+    { comment: '', consent: false, email: 'ada@example.com' },
+    { comment: '', consent: true, email: 'ada@' },
+    { comment: '', consent: false, email: '' },
+    { comment: '   \n  ', consent: false, email: '' },
+    { comment: 'Great night', consent: true, email: 'ada@' },
+    { comment: '', consent: true, email: `${'a'.repeat(MAX_EMAIL_LENGTH)}@example.com` },
+  ];
+
+  it('hasFollowUpPayload and canSubmitFollowUp agree on every input', () => {
+    for (const input of inputs) {
+      expect(hasFollowUpPayload(input)).toBe(canSubmitFollowUp(input));
+    }
+  });
+});

--- a/tests/unit/reviewContact.test.ts
+++ b/tests/unit/reviewContact.test.ts
@@ -26,6 +26,20 @@ describe('isPlausibleEmail (server)', () => {
   it('rejects a value past MAX_EMAIL_LENGTH', () => {
     expect(isPlausibleEmail(`${'a'.repeat(MAX_EMAIL_LENGTH)}@example.com`)).toBe(false);
   });
+
+  it('accepts an email exactly MAX_EMAIL_LENGTH characters long', () => {
+    const domain = '@example.com';
+    const email = `${'a'.repeat(MAX_EMAIL_LENGTH - domain.length)}${domain}`;
+    expect(email.length).toBe(MAX_EMAIL_LENGTH);
+    expect(isPlausibleEmail(email)).toBe(true);
+  });
+
+  it('rejects an email one character past MAX_EMAIL_LENGTH', () => {
+    const domain = '@example.com';
+    const email = `${'a'.repeat(MAX_EMAIL_LENGTH + 1 - domain.length)}${domain}`;
+    expect(email.length).toBe(MAX_EMAIL_LENGTH + 1);
+    expect(isPlausibleEmail(email)).toBe(false);
+  });
 });
 
 describe('hasFollowUpPayload', () => {

--- a/tests/unit/reviewSubmission.test.ts
+++ b/tests/unit/reviewSubmission.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest';
 
-import { canSubmitFollowUp, isPlausibleEmail } from '@/lib/reviews/reviewSubmission';
+import {
+  canSubmitFollowUp,
+  isPlausibleEmail,
+  MAX_EMAIL_LENGTH,
+} from '@/lib/reviews/reviewSubmission';
 
 describe('isPlausibleEmail', () => {
   it('accepts an ordinary address', () => {
@@ -35,6 +39,20 @@ describe('isPlausibleEmail', () => {
     // The server slices at 320. A longer value would arrive truncated, so a
     // client that calls it valid enables a button the server then rejects.
     expect(isPlausibleEmail(`${'a'.repeat(320)}@example.com`)).toBe(false);
+  });
+
+  it('accepts an email exactly MAX_EMAIL_LENGTH characters long', () => {
+    const domain = '@example.com';
+    const email = `${'a'.repeat(MAX_EMAIL_LENGTH - domain.length)}${domain}`;
+    expect(email.length).toBe(MAX_EMAIL_LENGTH);
+    expect(isPlausibleEmail(email)).toBe(true);
+  });
+
+  it('rejects an email one character past MAX_EMAIL_LENGTH', () => {
+    const domain = '@example.com';
+    const email = `${'a'.repeat(MAX_EMAIL_LENGTH + 1 - domain.length)}${domain}`;
+    expect(email.length).toBe(MAX_EMAIL_LENGTH + 1);
+    expect(isPlausibleEmail(email)).toBe(false);
   });
 });
 

--- a/tests/unit/reviewSubmission.test.ts
+++ b/tests/unit/reviewSubmission.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+
+import { canSubmitFollowUp, isPlausibleEmail } from '@/lib/reviews/reviewSubmission';
+
+describe('isPlausibleEmail', () => {
+  it('accepts an ordinary address', () => {
+    expect(isPlausibleEmail('ada@example.com')).toBe(true);
+  });
+
+  it('accepts a subdomain and a plus tag', () => {
+    expect(isPlausibleEmail('ada+tag@mail.example.co.uk')).toBe(true);
+  });
+
+  it('trims before it checks', () => {
+    expect(isPlausibleEmail('  ada@example.com  ')).toBe(true);
+  });
+
+  it('rejects an address with no domain', () => {
+    expect(isPlausibleEmail('ada@')).toBe(false);
+  });
+
+  it('rejects an address with no dot in the domain', () => {
+    expect(isPlausibleEmail('ada@localhost')).toBe(false);
+  });
+
+  it('rejects an address with a space', () => {
+    expect(isPlausibleEmail('ada example.com')).toBe(false);
+  });
+
+  it('rejects an empty value', () => {
+    expect(isPlausibleEmail('   ')).toBe(false);
+  });
+
+  it('rejects a value past the 320-character server limit', () => {
+    // The server slices at 320. A longer value would arrive truncated, so a
+    // client that calls it valid enables a button the server then rejects.
+    expect(isPlausibleEmail(`${'a'.repeat(320)}@example.com`)).toBe(false);
+  });
+});
+
+describe('canSubmitFollowUp', () => {
+  it('allows a comment on its own', () => {
+    expect(canSubmitFollowUp({ comment: 'The soup was cold', consent: false, email: '' })).toBe(
+      true
+    );
+  });
+
+  it('allows an email on its own when the guest consents', () => {
+    expect(canSubmitFollowUp({ comment: '', consent: true, email: 'ada@example.com' })).toBe(true);
+  });
+
+  it('refuses an email without consent', () => {
+    // Consent false means the server discards the value. A button that sends
+    // it promises the guest a reply the restaurant never gets.
+    expect(canSubmitFollowUp({ comment: '', consent: false, email: 'ada@example.com' })).toBe(
+      false
+    );
+  });
+
+  it('refuses a malformed email with no comment', () => {
+    expect(canSubmitFollowUp({ comment: '', consent: true, email: 'ada@' })).toBe(false);
+  });
+
+  it('refuses an empty form', () => {
+    expect(canSubmitFollowUp({ comment: '', consent: false, email: '' })).toBe(false);
+  });
+
+  it('refuses a whitespace-only comment with no email', () => {
+    expect(canSubmitFollowUp({ comment: '   \n  ', consent: false, email: '' })).toBe(false);
+  });
+
+  it('allows a malformed email when the guest also writes a comment', () => {
+    // The comment alone is enough. A typo in an optional field must not block
+    // the note the guest came to leave.
+    expect(canSubmitFollowUp({ comment: 'Great night', consent: true, email: 'ada@' })).toBe(true);
+  });
+});

--- a/tests/unit/useReviewResponses.test.ts
+++ b/tests/unit/useReviewResponses.test.ts
@@ -137,6 +137,9 @@ describe('useReviewResponses', () => {
     // The predicate must precede the cap. A client-side filter after a
     // 500-row fetch loses a written complaint behind 500 newer silent taps.
     expect(list.not).toHaveBeenCalledWith('comment', 'is', null);
+    // The two arms exclude each other. Both predicates together return zero
+    // rows, and the inbox looks empty under a filter that has rows.
+    expect(list.is).not.toHaveBeenCalled();
     expect(list.limit).toHaveBeenCalledWith(500);
   });
 
@@ -151,6 +154,7 @@ describe('useReviewResponses', () => {
 
     await waitFor(() => expect(result.current.responses).toHaveLength(1));
     expect(list.is).toHaveBeenCalledWith('comment', null);
+    expect(list.not).not.toHaveBeenCalled();
     expect(list.limit).toHaveBeenCalledWith(500);
   });
 

--- a/tests/unit/useReviewResponses.test.ts
+++ b/tests/unit/useReviewResponses.test.ts
@@ -12,7 +12,11 @@ const mockToast = vi.hoisted(() => vi.fn());
 vi.mock('@/integrations/supabase/client', () => ({ supabase: mockSupabase }));
 vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: mockToast }) }));
 
-import { useReviewResponses } from '@/hooks/useReviewResponses';
+import {
+  isActionableResponse,
+  useReviewResponses,
+  type ReviewResponseFilter,
+} from '@/hooks/useReviewResponses';
 
 function createWrapper() {
   const client = new QueryClient({
@@ -23,14 +27,19 @@ function createWrapper() {
   };
 }
 
-/** `.select(...).eq(...).not(...).order(...).limit(...)` → a Supabase result. */
+/**
+ * `.select(...).eq(...)` then, per filter, `.not(...)` / `.is(...)` / neither,
+ * then `.order(...).limit(...)`. The `all` mode adds no predicate, so `eq`
+ * carries `order` directly.
+ */
 function makeListStub(data: unknown, error: unknown = null) {
   const limit = vi.fn(async () => ({ data, error }));
   const order = vi.fn(() => ({ limit }));
   const not = vi.fn(() => ({ order }));
-  const eq = vi.fn(() => ({ not }));
+  const is = vi.fn(() => ({ order }));
+  const eq = vi.fn(() => ({ not, is, order }));
   const select = vi.fn(() => ({ eq }));
-  return { stub: { select }, select, eq, not, order, limit };
+  return { stub: { select }, select, eq, not, is, order, limit };
 }
 
 /**
@@ -96,7 +105,7 @@ describe('useReviewResponses', () => {
     expect(mockSupabase.rpc).not.toHaveBeenCalled();
   });
 
-  it('filters to commented rows server-side, then caps at 500, newest first', async () => {
+  it('adds no comment predicate by default, then caps at 500, newest first', async () => {
     const list = makeListStub([RESPONSE_ROW]);
     mockSupabase.from.mockReturnValue(list.stub);
     mockSupabase.rpc.mockResolvedValue({ data: [METRICS_ROW], error: null });
@@ -108,11 +117,59 @@ describe('useReviewResponses', () => {
     await waitFor(() => expect(result.current.responses).toHaveLength(1));
     expect(mockSupabase.from).toHaveBeenCalledWith('review_responses');
     expect(list.eq).toHaveBeenCalledWith('restaurant_id', 'rest-1');
-    // The comment filter must precede the cap. Filtering client-side after a
-    // 500-row fetch loses a written complaint behind 500 newer silent taps.
-    expect(list.not).toHaveBeenCalledWith('comment', 'is', null);
+    // A silent rating is a rating. The default mode hides nothing.
+    expect(list.not).not.toHaveBeenCalled();
+    expect(list.is).not.toHaveBeenCalled();
     expect(list.order).toHaveBeenCalledWith('submitted_at', { ascending: false });
     expect(list.limit).toHaveBeenCalledWith(500);
+  });
+
+  it('filters to commented rows server-side, before the cap', async () => {
+    const list = makeListStub([RESPONSE_ROW]);
+    mockSupabase.from.mockReturnValue(list.stub);
+    mockSupabase.rpc.mockResolvedValue({ data: [METRICS_ROW], error: null });
+
+    const { result } = renderHook(() => useReviewResponses('rest-1', 'commented'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.responses).toHaveLength(1));
+    // The predicate must precede the cap. A client-side filter after a
+    // 500-row fetch loses a written complaint behind 500 newer silent taps.
+    expect(list.not).toHaveBeenCalledWith('comment', 'is', null);
+    expect(list.limit).toHaveBeenCalledWith(500);
+  });
+
+  it('filters to silent rows server-side, before the cap', async () => {
+    const list = makeListStub([RESPONSE_ROW]);
+    mockSupabase.from.mockReturnValue(list.stub);
+    mockSupabase.rpc.mockResolvedValue({ data: [METRICS_ROW], error: null });
+
+    const { result } = renderHook(() => useReviewResponses('rest-1', 'silent'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.responses).toHaveLength(1));
+    expect(list.is).toHaveBeenCalledWith('comment', null);
+    expect(list.limit).toHaveBeenCalledWith(500);
+  });
+
+  it('caches each filter on its own key, so a filter change refetches', async () => {
+    const list = makeListStub([RESPONSE_ROW]);
+    mockSupabase.from.mockReturnValue(list.stub);
+    mockSupabase.rpc.mockResolvedValue({ data: [METRICS_ROW], error: null });
+
+    const { rerender } = renderHook(
+      ({ filter }: { filter: ReviewResponseFilter }) => useReviewResponses('rest-1', filter),
+      { wrapper: createWrapper(), initialProps: { filter: 'all' as ReviewResponseFilter } }
+    );
+    await waitFor(() => expect(list.limit).toHaveBeenCalledTimes(1));
+
+    // A shared query key would answer `silent` from the `all` cache and show
+    // commented rows under a filter that excludes them.
+    rerender({ filter: 'silent' });
+    await waitFor(() => expect(list.limit).toHaveBeenCalledTimes(2));
+    expect(list.is).toHaveBeenCalledWith('comment', null);
   });
 
   it('takes metrics from the uncapped aggregate, not the capped list', async () => {
@@ -305,6 +362,20 @@ describe('useReviewResponses', () => {
         title: 'Could not load contact details',
         variant: 'destructive',
       })
+    );
+  });
+
+  it('calls a row actionable when it holds a comment or contact consent', () => {
+    expect(isActionableResponse({ ...RESPONSE_ROW, comment: 'x', contact_consent: false })).toBe(
+      true
+    );
+    // The guest asked to hear back. That is a chore, comment or not.
+    expect(isActionableResponse({ ...RESPONSE_ROW, comment: null, contact_consent: true })).toBe(
+      true
+    );
+    // A silent five-star tap needs no triage.
+    expect(isActionableResponse({ ...RESPONSE_ROW, comment: null, contact_consent: false })).toBe(
+      false
     );
   });
 });

--- a/tests/unit/useReviewResponses.test.ts
+++ b/tests/unit/useReviewResponses.test.ts
@@ -28,18 +28,29 @@ function createWrapper() {
 }
 
 /**
- * `.select(...).eq(...)` then, per filter, `.not(...)` / `.is(...)` / neither,
- * then `.order(...).limit(...)`. The `all` mode adds no predicate, so `eq`
- * carries `order` directly.
+ * `.select(...).eq(...)` then, per filter, `.or(...)` / `.is(...).eq(...)` /
+ * neither, then two chained `.order(...)` calls and `.limit(...)`. The `all`
+ * mode adds no predicate, so `eq` carries `order` directly. Both `.order()`
+ * calls resolve to the same chain object, so `order` records both calls in
+ * sequence and `limit` is reachable no matter which branch ran.
  */
 function makeListStub(data: unknown, error: unknown = null) {
   const limit = vi.fn(async () => ({ data, error }));
-  const order = vi.fn(() => ({ limit }));
-  const not = vi.fn(() => ({ order }));
-  const is = vi.fn(() => ({ order }));
-  const eq = vi.fn(() => ({ not, is, order }));
+  interface OrderChain {
+    order: (...args: unknown[]) => OrderChain;
+    limit: typeof limit;
+  }
+  const orderChain = {} as OrderChain;
+  const order = vi.fn(() => orderChain);
+  orderChain.order = order;
+  orderChain.limit = limit;
+
+  const or = vi.fn(() => orderChain);
+  const eqContactConsent = vi.fn(() => orderChain);
+  const is = vi.fn(() => ({ eq: eqContactConsent }));
+  const eq = vi.fn(() => ({ or, is, order }));
   const select = vi.fn(() => ({ eq }));
-  return { stub: { select }, select, eq, not, is, order, limit };
+  return { stub: { select }, select, eq, or, is, eqContactConsent, order, limit };
 }
 
 /**
@@ -118,28 +129,36 @@ describe('useReviewResponses', () => {
     expect(mockSupabase.from).toHaveBeenCalledWith('review_responses');
     expect(list.eq).toHaveBeenCalledWith('restaurant_id', 'rest-1');
     // A silent rating is a rating. The default mode hides nothing.
-    expect(list.not).not.toHaveBeenCalled();
+    expect(list.or).not.toHaveBeenCalled();
     expect(list.is).not.toHaveBeenCalled();
-    expect(list.order).toHaveBeenCalledWith('submitted_at', { ascending: false });
+    // The list shows commented_at ?? submitted_at, so it must order by the
+    // same key first, with submitted_at as the tiebreaker.
+    expect(list.order).toHaveBeenNthCalledWith(1, 'commented_at', {
+      ascending: false,
+      nullsFirst: false,
+    });
+    expect(list.order).toHaveBeenNthCalledWith(2, 'submitted_at', { ascending: false });
     expect(list.limit).toHaveBeenCalledWith(500);
   });
 
-  it('filters to commented rows server-side, before the cap', async () => {
+  it('filters to rows that need a reply server-side, before the cap', async () => {
     const list = makeListStub([RESPONSE_ROW]);
     mockSupabase.from.mockReturnValue(list.stub);
     mockSupabase.rpc.mockResolvedValue({ data: [METRICS_ROW], error: null });
 
-    const { result } = renderHook(() => useReviewResponses('rest-1', 'commented'), {
+    const { result } = renderHook(() => useReviewResponses('rest-1', 'needsReply'), {
       wrapper: createWrapper(),
     });
 
     await waitFor(() => expect(result.current.responses).toHaveLength(1));
     // The predicate must precede the cap. A client-side filter after a
     // 500-row fetch loses a written complaint behind 500 newer silent taps.
-    expect(list.not).toHaveBeenCalledWith('comment', 'is', null);
-    // The two arms exclude each other. Both predicates together return zero
-    // rows, and the inbox looks empty under a filter that has rows.
+    // This is the same rule as isActionableResponse — see the warning there.
+    expect(list.or).toHaveBeenCalledWith('comment.not.is.null,contact_consent.is.true');
+    // The two arms exclude each other. A stub that ran the silent branch too
+    // would call is/eqContactConsent here, and this assertion would catch it.
     expect(list.is).not.toHaveBeenCalled();
+    expect(list.eqContactConsent).not.toHaveBeenCalled();
     expect(list.limit).toHaveBeenCalledWith(500);
   });
 
@@ -154,8 +173,33 @@ describe('useReviewResponses', () => {
 
     await waitFor(() => expect(result.current.responses).toHaveLength(1));
     expect(list.is).toHaveBeenCalledWith('comment', null);
-    expect(list.not).not.toHaveBeenCalled();
+    expect(list.eqContactConsent).toHaveBeenCalledWith('contact_consent', false);
+    // The two arms exclude each other. A stub that ran the needsReply branch
+    // too would call or here, and this assertion would catch it.
+    expect(list.or).not.toHaveBeenCalled();
     expect(list.limit).toHaveBeenCalledWith(500);
+  });
+
+  it('never lets a single fetch match both the needsReply and the silent rule', () => {
+    // Mirrors the two query-builder branches as plain predicates. A future
+    // edit that lets the branches overlap — so a stub applying both filters
+    // could still return a row — fails this test before it reaches the UI.
+    const matchesNeedsReply = (row: { comment: string | null; contact_consent: boolean }) =>
+      row.comment !== null || row.contact_consent;
+    const matchesSilent = (row: { comment: string | null; contact_consent: boolean }) =>
+      row.comment === null && row.contact_consent === false;
+
+    const rowShapes = [
+      { comment: 'hi', contact_consent: false },
+      { comment: 'hi', contact_consent: true },
+      { comment: null, contact_consent: true },
+      { comment: null, contact_consent: false },
+    ];
+
+    for (const row of rowShapes) {
+      expect(matchesNeedsReply(row) && matchesSilent(row)).toBe(false);
+      expect(matchesNeedsReply(row) !== matchesSilent(row)).toBe(true);
+    }
   });
 
   it('caches each filter on its own key, so a filter change refetches', async () => {


### PR DESCRIPTION
## What this does

Two follow-ups to the review funnel.

**Part 1 — a promoter can now leave a comment and contact details.**
Before this branch a 4-star or 5-star tap went straight to the Google hand-off.
A promoter could not leave a comment or an email address. The promoter stage now
offers the same follow-up form as the detractor stage. The Google link stays the
primary control, and it also shows on the thanks stage. A comment must not cost
the restaurant a Google review.

**Part 2 — the admin inbox now shows a silent rating.**
`useReviewResponses` filtered with `.not('comment','is',null)`. A 5-star row with
no comment existed in `review_responses` but never appeared in the list. The
inbox now carries a filter: `All`, `With comments`, `Silent`. The predicate runs
server-side, before the 500-row cap.

## Design notes

- `routedTo` is derivable. `routeRating` returns `destination_url` only on the
  promoter branch, so `destinationUrl !== null` means promoter.
- The submit rule is duplicated: `src/lib/reviews/reviewSubmission.ts` and
  `supabase/functions/_shared/reviewContact.ts`. The edge function cannot import
  from `src/`. The server copy is authoritative. Each copy names the other.
- The actionable-row rule is duplicated too: the `unread_count` FILTER in SQL and
  `isActionableResponse` in TypeScript. Each copy names the other.
- The single-use guard moved from `comment IS NULL` to `commented_at IS NULL`.
  Warning: under the old guard a contact-only write left `comment` NULL, so a
  replay matched again and hit a primary key violation on
  `review_response_contacts`. The new guard closes that hole.
- The migration uses `CREATE OR REPLACE FUNCTION`. A `DROP FUNCTION` resets the
  grants and breaks the Feedback tab header.
- The header metrics come from a separate uncapped aggregate, not from the capped
  list. A restaurant past 500 comments still sees a correct average.

## Tests

- Unit: 8924 passed, 2 skipped (722 files).
- pgTAP: 2692 passed, 0 failed. `review_response_aggregates_test.sql` adds 6.
- Playwright: the 4 review specs, 10 passed. A new spec covers the promoter
  follow-up path end to end.
- `npm run build`: OK.
- `npm run typecheck`: one error, `src/hooks/useReviewPages.ts:198` TS2352. It is
  pre-existing on `main`. This branch adds no new type error.
- `npm run lint`: this branch adds no new lint error.

## Review

Every task passed a per-task review. The final whole-branch review returned zero
Critical and zero Important findings, and the verdict "Ready to merge". Commit
`ed88822e` fixes the four Minor findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Changes after the first review round

Three review bots — Codex, CodeRabbit and Copilot — raised findings on the first
push. Every finding was checked against the code. These are the fixes.

**Validate the raw email, then truncate** (`review-public/index.ts`).
The handler sliced the email to `MAX_EMAIL_LENGTH` before it validated. A caller
sent 400 characters, the server cut them to 320, accepted the result, and stored
an address the guest never typed. The client rejected the same input. The raw
trimmed value is now validated first.

**Write the response and the contact in one transaction** (new RPC).
The handler stamped `commented_at`, then ran a separate contact INSERT and
swallowed its error. That is correct for a comment-only submit. Warning: for a
contact-only submit it lost the guest email, answered `{ ok: true }`, and the
single-use guard then rejected every retry. A new `SECURITY DEFINER` RPC,
`review_response_submit_followup`, runs both writes in one call. A failed INSERT
rolls back the UPDATE, so `commented_at` stays NULL and a retry works. EXECUTE is
revoked from `PUBLIC`, `anon` and `authenticated`, and granted to `service_role`
only.

**Align the inbox filter to the actionable rule.**
A contact-only row counted toward the unread badge but filed under "Silent".
Past 500 newer silent rows it also fell off the cap in every mode, so a manager
saw an unread request they could not open. The middle filter is now
**Needs a reply** = `comment IS NOT NULL OR contact_consent`. "Silent" is now
`comment IS NULL AND contact_consent = false`. The list axis and the header badge
now use one rule. The design doc and the plan are updated to match.

**Order by the time the list shows.**
The list shows `commented_at ?? submitted_at` but ordered by `submitted_at`
alone, so a late follow-up read as new and still sat far down. The order is now
`commented_at DESC` with `submitted_at` as the tiebreaker.

**Drop the stale `as any` casts.**
`review_responses`, `review_response_contacts` and `review_response_metrics` are
all in `src/integrations/supabase/types.ts`. The comment that said otherwise was
stale. These four casts were the only ESLint errors this branch added. The branch
now adds zero.

**Correct the no-comment text.**
"This guest left a rating only." read wrong beside a visible contact card. It now
reads "This guest left no comment."

### Tests after the fixes

- Unit: 8925 passed, 2 skipped (722 files).
- pgTAP: 2702 passed, 0 failed. A new suite covers the RPC, including a forced
  INSERT failure that proves `commented_at` stays NULL.
- Playwright: the review specs pass.
- `npm run build`: OK.
- `npm run lint` on the branch files: zero errors.
- `npm run typecheck`: only the pre-existing `useReviewPages.ts:198` TS2352. This
  branch does not touch that file.
