### PR TITLE
fix(security): self-scope employee shift/payroll reads (client + RLS)

### DIFF
--- a/docs/superpowers/plans/2026-08-05-employee-self-scoped-data-plan.md
+++ b/docs/superpowers/plans/2026-08-05-employee-self-scoped-data-plan.md
@@ -135,8 +135,16 @@ user_has_capability(restaurant_id,'view:payroll')` policy, plus the `shift_trade
 `shifts` (design §4.3). Policy bodies are transcribed from the production `pg_policies` output
 in design §1.3, not re-derived.
 
-The two legacy `owner`/`manager` role-string policies on `time_punches` and `employee_tips`
-are left untouched.
+Every new policy is `TO authenticated` and spells the own-row check `(select auth.uid())`, not
+bare `auth.uid()` — per-query InitPlan instead of a per-row call (design §4.1). Also create
+`idx_shift_trades_requested_shift ON shift_trades (requested_shift_id)`: production has no
+index on that column and the new `shifts` clause filters on it (design §4.6).
+
+On `time_punches` and `employee_tips`, additionally drop the **pre-existing** own-row policies
+(`Employees can view own time punches`, `Employees can view own tips`) so the uniform policy
+replaces rather than stacks on them, and collapse each table's two byte-identical
+`Managers can view …` policies to one. Both are justified in design §4.2.1 — verified
+behaviour-preserving, and they keep two redundant per-row subqueries off the hottest tables.
 
 Then: `npm run db:reset && npm run test:db` — **never** `test:db` without a reset, or the old
 migration state is what gets tested.
@@ -175,6 +183,9 @@ Run from the worktree, printing `pwd` in the same invocation as each command:
 4. `npm run db:reset && npm run test:db`
 5. Manual RLS spot-check against **local** Supabase: authenticate as a staff user and confirm
    a direct `supabase.from('shifts').select()` returns only that employee's rows.
+6. `EXPLAIN ANALYZE` a payroll-window `time_punches` select as a `manager`, before and after the
+   migration, and record both in the PR. The `user_has_capability` arm is correlated to the row
+   and cannot be hoisted (design §4.6); the fallback if it regresses materially is noted there.
 
 No E2E is added: the pages' observable behaviour is unchanged by design, and what changed is
 what crosses the wire — which the unit tests assert directly and Playwright cannot.
@@ -187,5 +198,7 @@ what crosses the wire — which the unit tests assert directly and Playwright ca
   ([TradeRequestDialog.tsx:53](../../../src/components/schedule/TradeRequestDialog.tsx#L53)) and
   the correct fix is column-level. **File a follow-up issue** and state the residual risk in the
   PR description: a `staff` user can still enumerate coworker `employees` rows.
-- Consolidating the duplicate legacy `owner`/`manager` policies on `time_punches` / `employee_tips`.
+- ~~Consolidating the duplicate legacy `owner`/`manager` policies on `time_punches` /
+  `employee_tips`~~ — pulled **in** scope (Step 8, design §4.2.1): the migration rewrites these
+  exact policies anyway and the duplicates cost a per-row subquery for nothing.
 - Narrowing `chef`'s access to pay rates — a product decision, not a security fix.

--- a/docs/superpowers/plans/2026-08-05-employee-self-scoped-data-plan.md
+++ b/docs/superpowers/plans/2026-08-05-employee-self-scoped-data-plan.md
@@ -1,0 +1,191 @@
+# Plan: employee self-scoped data reads
+
+- **Design:** `docs/superpowers/specs/2026-08-05-employee-self-scoped-data-design.md` (commit `3b58fdf9`)
+- **Branch:** `fix/employee-self-scoped-data`
+- **Approach:** C — self-scoped hooks + RLS tightening on six tables; `employees` deferred.
+
+Steps are TDD-ordered: each test step must fail for the right reason before its
+implementation step runs.
+
+---
+
+## Step 0 — Baseline
+
+1. `npm run typecheck && npm run lint`
+2. `npm run test -- --run`
+3. `npm run db:reset` then `npm run test:db`
+
+Record the baseline pass counts. Any pre-existing failure is noted, not fixed.
+
+---
+
+## Step 1 (RED) — `useMyShifts` unit tests
+
+New `tests/unit/useMyShifts.test.ts`, mocking the `supabase` client so the **recorded
+query-builder calls** are asserted (not the returned rows — a row-based assertion would pass
+vacuously if the filter were applied client-side):
+
+- `useMyShifts(rid, 'emp-1', start, end)` records `.eq('employee_id', 'emp-1')`.
+- `useMyShifts(rid, null, start, end)` records **zero** queries against `shifts`.
+- `useShifts(rid, start, end)` records exactly the calls it records today —
+  `.eq('restaurant_id', rid)`, the `start_time` bounds, `.order('start_time')`, and the
+  `'*, employee:employees(*)'` select — and **no** `employee_id` predicate.
+- The `employeeId` appears in the query key so admin and self caches cannot collide.
+
+## Step 2 (GREEN) — refactor `src/hooks/useShifts.tsx`
+
+Extract the body of `useShifts` ([:48-90](../../../src/hooks/useShifts.tsx#L48)) into an
+internal `useShiftsQuery(restaurantId, startDate, endDate, employeeId?)`:
+
+- append `employeeId ?? 'all'` to the query key;
+- apply `.eq('employee_id', employeeId)` only when set;
+- `enabled: !!restaurantId && (employeeId === undefined || !!employeeId)`.
+
+Export `useShifts` with its current signature unchanged (admin callers
+[useShiftPlanner.ts:539](../../../src/hooks/useShiftPlanner.ts#L539),
+[Scheduling.tsx:291](../../../src/pages/Scheduling.tsx#L291) must not be touched) and a new
+`useMyShifts(restaurantId, employeeId: string | null, startDate?, endDate?)`.
+
+## Step 3 — swap the two shift pages
+
+- [EmployeeSchedule.tsx:70-79](../../../src/pages/EmployeeSchedule.tsx#L70) → `useMyShifts`;
+  delete the `myShifts` filter `useMemo`; **keep** `|| employeeLoading` in the loading gate and
+  rewrite the now-stale comment at [:92-94](../../../src/pages/EmployeeSchedule.tsx#L92) to
+  state the real reason (a disabled query reports `isLoading: false`).
+- [AvailableShiftsPage.tsx:250-254](../../../src/pages/AvailableShiftsPage.tsx#L250) →
+  `useMyShifts`; drop the `employee_id` predicate from the `useMemo` but **keep**
+  `status !== 'cancelled'`; fold the hook's loading into
+  [:327](../../../src/pages/AvailableShiftsPage.tsx#L327)'s `const loading = feedLoading;` so
+  conflict badges are not silently omitted while shifts load.
+
+Verify: `npm run test -- --run` and `npm run typecheck`.
+
+---
+
+## Step 4 (RED) — `useMyPayroll` unit tests
+
+New `tests/unit/useMyPayroll.test.ts`:
+
+- `.eq('employee_id', id)` is recorded on all seven per-employee tables — `time_punches`,
+  `tip_split_items`, `daily_labor_allocations`, `employee_tips`, `tip_payouts`,
+  `overtime_adjustments` — and `.eq('id', id)` on `employees`.
+- `tip_splits` and `overtime_rules` stay restaurant-scoped (design §3.2).
+- `useMyPayroll(rid, null, …)` records zero queries.
+- `loading` is `true` while the inner `useEmployees` query is in flight — the disabled-query
+  window from design §3.2. This test must fail against today's `usePayroll` before the fix.
+- `usePayroll` (admin) records today's queries unchanged.
+
+## Step 5 (GREEN) — `useEmployees` + `usePayroll`
+
+- `src/hooks/useEmployees.tsx`: add `employeeId?: string` to `UseEmployeesOptions`, apply
+  `.eq('id', employeeId)`, add it to the query key. **Preserve the module-level
+  `EMPTY_EMPLOYEES` stable reference** — it guards an infinite render loop in
+  [Tips.tsx](../../../src/pages/Tips.tsx).
+- `src/hooks/usePayroll.tsx`: internal implementation takes `employeeId?: string` and threads
+  the predicate into the seven queries; destructure `loading: employeesLoading` at
+  [:116](../../../src/hooks/usePayroll.tsx#L116) and return
+  `loading: isLoading || employeesLoading` at [:484](../../../src/hooks/usePayroll.tsx#L484);
+  add `employeeId` to the query key; export `usePayroll` (unchanged signature) and
+  `useMyPayroll`.
+
+Confirm [usePayroll.pagination.test.ts](../../../tests/unit/usePayroll.pagination.test.ts) and
+[usePayroll.fetchRange.test.ts](../../../tests/unit/usePayroll.fetchRange.test.ts) stay green.
+
+## Step 6 — swap `EmployeePay`
+
+[EmployeePay.tsx:58](../../../src/pages/EmployeePay.tsx#L58) → `useMyPayroll(restaurantId,
+currentEmployee?.id ?? null, startDate, endDate)`. The `.find(...)` at
+[:61-64](../../../src/pages/EmployeePay.tsx#L61) still resolves against the one-element array.
+
+---
+
+## Step 7 (RED) — pgTAP RLS tests
+
+New `supabase/tests/rls_employee_self_scope.sql`. Fixtures: one restaurant; a `staff`
+employee with a linked `auth.users` row; a coworker employee; a `chef` member; a
+`collaborator_accountant` member; a `manager` member. Switch identity with
+`set_config('request.jwt.claims', …)`.
+
+For each of the six tables — `shifts`, `employee_compensation_history`, `time_punches`,
+`employee_tips`, `overtime_adjustments`, `daily_labor_allocations`:
+
+| Subject | Expectation | Arm isolated |
+|---|---|---|
+| staff | own row visible | own-row clause |
+| staff | coworker row **not** visible | the fix |
+| chef | both visible | `view:scheduling` only |
+| collaborator_accountant | both visible | `view:payroll` only |
+
+Plus, for `shifts` specifically:
+
+- staff sees a coworker's shift referenced by a `shift_trades.offered_shift_id` row;
+- staff sees a coworker's shift referenced by a `shift_trades.requested_shift_id` row
+  (inert in production — fixtures insert it directly);
+- staff does **not** see a coworker's shift with no trade referencing it.
+
+A `manager` fixture is deliberately **not** used to isolate either capability arm: it holds
+both, so it cannot distinguish a working clause from an unreached one.
+
+## Step 8 (GREEN) — the migration
+
+`supabase/migrations/<ts>_self_scope_employee_reads.sql`. For each of the six tables:
+`DROP POLICY IF EXISTS "<exact name from design §1.3>"`, then create the own-row policy and
+the `user_has_capability(restaurant_id,'view:scheduling') OR
+user_has_capability(restaurant_id,'view:payroll')` policy, plus the `shift_trades` clause on
+`shifts` (design §4.3). Policy bodies are transcribed from the production `pg_policies` output
+in design §1.3, not re-derived.
+
+The two legacy `owner`/`manager` role-string policies on `time_punches` and `employee_tips`
+are left untouched.
+
+Then: `npm run db:reset && npm run test:db` — **never** `test:db` without a reset, or the old
+migration state is what gets tested.
+
+## Step 9 — existing pgTAP sweep
+
+`grep -rln` `supabase/tests/` for each of the six table names. Narrowing a SELECT predicate can
+make an unrelated assertion **vacuous** rather than failing it, so every hit is read and
+re-checked, not just re-run. Update anything that now passes for the wrong reason.
+
+---
+
+## Step 10 — AI tool gating (design §4.4)
+
+`ai-execute-tool` applies RLS (anon key + forwarded JWT,
+[index.ts:3615-3618](../../../supabase/functions/ai-execute-tool/index.ts#L3615)):
+
+- Move `get_labor_costs` and `get_schedule_overview` out of `basicTools`
+  ([tools-registry.ts:889-899](../../../supabase/functions/_shared/tools-registry.ts#L889)) and
+  gate them on `view:scheduling OR view:payroll`, resolved via the `user_has_capability` RPC
+  rather than a second hard-coded role list.
+- Leave `get_kpis` basic, but have its labor component omit the labor fields with an explicit
+  reason when the caller lacks the capability — never a total computed from a truncated set.
+- Sweep the remaining `supabase/functions/` for forwarded-JWT clients touching the six tables.
+  `generate-schedule` and `notify-schedule-published` are already confirmed `owner`/`manager`-gated.
+
+---
+
+## Step 11 — Verification
+
+Run from the worktree, printing `pwd` in the same invocation as each command:
+
+1. `npm run typecheck`
+2. `npm run lint`
+3. `npm run test -- --run`
+4. `npm run db:reset && npm run test:db`
+5. Manual RLS spot-check against **local** Supabase: authenticate as a staff user and confirm
+   a direct `supabase.from('shifts').select()` returns only that employee's rows.
+
+No E2E is added: the pages' observable behaviour is unchanged by design, and what changed is
+what crosses the wire — which the unit tests assert directly and Playwright cannot.
+
+---
+
+## Out of scope
+
+- Tightening `employees` (design §6) — a staff-facing surface legitimately needs coworker rows
+  ([TradeRequestDialog.tsx:53](../../../src/components/schedule/TradeRequestDialog.tsx#L53)) and
+  the correct fix is column-level. **File a follow-up issue** and state the residual risk in the
+  PR description: a `staff` user can still enumerate coworker `employees` rows.
+- Consolidating the duplicate legacy `owner`/`manager` policies on `time_punches` / `employee_tips`.
+- Narrowing `chef`'s access to pay rates — a product decision, not a security fix.

--- a/docs/superpowers/specs/2026-08-05-employee-self-scoped-data-design.md
+++ b/docs/superpowers/specs/2026-08-05-employee-self-scoped-data-design.md
@@ -245,19 +245,30 @@ permissive policies:
 
 ```sql
 -- own row
+TO authenticated
 USING (EXISTS (
   SELECT 1 FROM employees e
   WHERE e.id = <table>.employee_id
-    AND e.user_id = auth.uid()
+    AND e.user_id = (select auth.uid())
     AND e.restaurant_id = <table>.restaurant_id
 ))
 
 -- privileged restaurant-wide
+TO authenticated
 USING (
   user_has_capability(restaurant_id, 'view:scheduling')
   OR user_has_capability(restaurant_id, 'view:payroll')
 )
 ```
+
+`(select auth.uid())` rather than bare `auth.uid()` is deliberate: an unwrapped call is
+evaluated **per row**, whereas the subquery form is hoisted to an InitPlan and evaluated once
+per query. These are the hot tables — a payroll window over `time_punches` paginates through
+thousands of rows — so this is the difference between one `auth.uid()` call and thousands.
+
+`TO authenticated` keeps the predicate from being evaluated for the `anon` role at all. Both
+are additions relative to the surrounding policies, which use the unwrapped form; they are
+applied to the new policies only, not retrofitted across the schema.
 
 **Why `view:scheduling OR view:payroll`, and not `view:payroll` alone.** The legacy-role
 capability sets are declared in [src/lib/permissions/definitions.ts](../../../src/lib/permissions/definitions.ts):
@@ -287,11 +298,43 @@ and is deliberately out of scope.
 | Table | Policy replaced | Notes |
 |---|---|---|
 | `employee_compensation_history` | Users can view compensation history for their restaurants | Own row joins via `employee_id`; also read as the embedded `compensation_history:` join in `useEmployees`. |
-| `time_punches` | Users can view time punches for their restaurants | Own-row policy already exists — the new own-row policy is redundant but harmless; the two legacy `owner`/`manager` policies are left untouched (out of scope to consolidate). |
-| `employee_tips` | Users can view tips for their restaurants | Same as above. |
+| `time_punches` | Users can view time punches for their restaurants **+ `Employees can view own time punches`** | See §4.2.1 — the pre-existing own-row policy is replaced, not supplemented. |
+| `employee_tips` | Users can view tips for their restaurants **+ `Employees can view own tips`** | Same as above. |
 | `overtime_adjustments` | Users can view their restaurant overtime adjustments | Sole SELECT policy today. |
 | `daily_labor_allocations` | Users can view allocations for their restaurants | Sole SELECT policy today. |
 | `shifts` | Users can view shifts for their restaurants | Needs a third clause — see §4.3. |
+
+#### 4.2.1 `time_punches` / `employee_tips`: replace the existing own-row policy, don't stack on it
+
+These two tables already carry an own-row SELECT policy from the tips migration. Verified in
+production, both read:
+
+```sql
+employee_id IN (SELECT employees.id FROM employees WHERE employees.user_id = auth.uid())
+```
+
+Creating §4.1's own-row policy *alongside* it would leave two permissive own-row clauses on the
+two highest-volume tables in the change — both evaluated, then OR'd, on every row of a payroll
+window. That directly undoes the per-row cost §4.1 and §4.6 exist to control. So the migration
+**drops these two by name as well** and lets the uniform policy replace them.
+
+The replacement is not merely a reformat. It differs in two ways, both improvements:
+
+- **`(select auth.uid())` instead of bare `auth.uid()`** — the existing form is evaluated per
+  row, which is exactly the anti-pattern on exactly the wrong table.
+- **It adds `e.restaurant_id = <table>.restaurant_id`**, which the existing form omits. For a
+  user employed at two restaurants the old predicate resolves *both* their employee ids; the
+  row's own `employee_id` still pins it transitively, so this is a tightening with no practical
+  effect. Confirmed against production: `time_punches`, `employee_tips`, `shifts` and
+  `employee_compensation_history` have **zero** rows whose `restaurant_id` disagrees with their
+  employee's, so no row is stranded by adding the join.
+
+The duplicated legacy `owner`/`manager` policies (`Managers can view all …` and `Managers can
+view restaurant …` are byte-identical predicates on both tables) are dropped down to one each
+in the same migration. `A OR A ≡ A`, so this is provably behaviour-preserving, and it halves a
+per-row `user_restaurants` subquery on the hot path this change is already rewriting. This was
+previously listed as out of scope; it is pulled in because the migration is touching these
+exact policies anyway, and it is called out in the PR description.
 
 ### 4.3 `shifts` needs a shift-trade clause
 
@@ -320,6 +363,11 @@ USING (EXISTS (
 `requested_shift_id`, `offered_by_employee_id`, `target_employee_id`, `status`. This subquery
 is itself evaluated under the caller's RLS on `shift_trades`; the pgTAP suite must assert that
 a staff user actually reaches an offered shift through it rather than assuming it.
+
+**This clause needs an index that does not exist.** Production has
+`idx_shift_trades_offered_shift (offered_shift_id)` but **nothing on `requested_shift_id`**, so
+the second half of the `OR` would sequentially scan `shift_trades` for every `shifts` row a
+staff user fails the first two clauses on. The migration must create it (§4.6).
 
 Note that `useShiftTrades`'s own conflict-detection read of `shifts` is already self-scoped
 (`.eq('employee_id', currentEmployeeId)` at [:616-620](../../../src/hooks/useShiftTrades.ts#L616))
@@ -379,6 +427,44 @@ touch `shifts` but are hard-gated to `owner`/`manager`, so they are unaffected.
 - Because a `SELECT` predicate changes on tables that also have `INSERT/UPDATE/DELETE`
   policies with `USING`/`WITH CHECK` clauses, the plan must re-run the full pgTAP suite after
   a `db:reset` (editing a migration and running `test:db` without a reset tests the *old* state).
+
+### 4.6 Index coverage and evaluation cost
+
+Every column the new predicates touch was checked against production `pg_indexes`. One gap:
+
+| Column | Index | Status |
+|---|---|---|
+| `shifts.employee_id` | `idx_shifts_employee_id` | ✅ |
+| `time_punches.employee_id` | `idx_time_punches_employee` (+ a duplicate `…_employee_id`) | ✅ |
+| `employee_tips.employee_id` | `idx_employee_tips_employee` (+ a duplicate `…_employee_id`) | ✅ |
+| `employee_compensation_history.employee_id` | `idx_employee_comp_history_employee` | ✅ |
+| `overtime_adjustments.employee_id` | `idx_overtime_adjustments_employee_date` (leading col) | ✅ |
+| `daily_labor_allocations.employee_id` | `idx_daily_labor_allocations_employee` | ✅ |
+| `employees.user_id` | `idx_employees_user_id`, `idx_employees_user_restaurant_active` | ✅ |
+| `shift_trades.offered_shift_id` | `idx_shift_trades_offered_shift` | ✅ |
+| `shift_trades.requested_shift_id` | — | ❌ **create it** |
+
+So the migration also carries:
+
+```sql
+CREATE INDEX IF NOT EXISTS idx_shift_trades_requested_shift
+  ON shift_trades (requested_shift_id);
+```
+
+The duplicated `employee_id` indexes on `time_punches` and `employee_tips` are pre-existing
+write-amplification, not caused by this change; dropping them is a separate cleanup and stays
+out of scope.
+
+**The `user_has_capability` arm cannot be hoisted.** Unlike `auth.uid()`, it takes the row's
+own `restaurant_id`, so it is correlated and Postgres will call the `SECURITY DEFINER` function
+once per candidate row for privileged readers on the largest tables. The same pattern already
+runs in production on `employees`, so this is a known cost rather than a new class of risk, and
+the function is `STABLE` (so repeated calls within a statement are at least cacheable by the
+planner). Verification step for the plan: `EXPLAIN ANALYZE` a representative payroll-window
+`time_punches` select as a `manager` before and after the migration, and record both. If it
+regresses materially, the fallback is a `restaurant_id`-only capability check hoisted into a
+`WITH`-style InitPlan — deliberately *not* done pre-emptively, because the two-clause form is
+simpler and the cost is unmeasured.
 
 ---
 

--- a/docs/superpowers/specs/2026-08-05-employee-self-scoped-data-design.md
+++ b/docs/superpowers/specs/2026-08-05-employee-self-scoped-data-design.md
@@ -369,6 +369,56 @@ a staff user actually reaches an offered shift through it rather than assuming i
 the second half of the `OR` would sequentially scan `shift_trades` for every `shifts` row a
 staff user fails the first two clauses on. The migration must create it (§4.6).
 
+#### 4.3.1 Accepted residual risk: resolved trades keep their shift visible
+
+Raised by the Phase 7 adversarial reviewer. The clause carries **no status or participant
+filter**, and the pre-existing `shift_trades` SELECT policy (verified in production) admits any
+active employee to every *open-marketplace* trade — `target_employee_id IS NULL` — regardless of
+`status` and with no expiry:
+
+```sql
+EXISTS (SELECT 1 FROM employees me
+  WHERE me.user_id = auth.uid() AND me.restaurant_id = shift_trades.restaurant_id
+    AND me.is_active = true
+    AND (shift_trades.target_employee_id IS NULL
+         OR me.id = ANY (ARRAY[target_employee_id, offered_by_employee_id, accepted_by_employee_id])))
+```
+
+So a `staff` user can still read a coworker's shift row if that shift was *ever* posted to the
+open marketplace — including via a trade since `cancelled`, `rejected`, or `approved`.
+
+**The clause is nonetheless internally coherent.** The subquery runs under the caller's own RLS
+on `shift_trades`, so the rule it implements is exactly *"you may see a shift iff you may see a
+trade referencing it."* The over-breadth lives entirely in the upstream `shift_trades` policy,
+not here. Measured against production:
+
+| | |
+|---|---|
+| Total `shifts` rows | 8,195 |
+| Reachable by a non-owner via this clause | **37 (0.45%)** |
+| Restaurants affected | 2 |
+| Rows where `requested_shift_id IS NOT NULL` | **0** (the column is inert, as §4.3 states) |
+
+Open-marketplace trades by status: 26 `approved`, 11 `cancelled`, 2 `open`, 1 `rejected`.
+
+**Decision: accept and document.** Rationale:
+
+1. Every one of the 37 is a shift its owner **deliberately broadcast to all colleagues** via the
+   marketplace. That is the feature working, not a confidentiality boundary being crossed.
+2. This is `shifts` only — schedule data. The compensation and payroll leak, the more sensitive
+   half of the original report, is closed unconditionally by §4.1.
+3. Adding a status filter *here* would desynchronize the two policies: 26 existing `approved`
+   open trades would still render in the trade-history UI while their embedded
+   `offered_shift:shifts!offered_shift_id(...)` came back `null`. That is a UI regression traded
+   for a 0.45%→~0.02% change in a restaurant-internal exposure.
+4. Tightening `shift_trades` itself is the correct root-cause fix, but it changes what the
+   marketplace shows every employee — a **product decision about trade history**, not a security
+   fix, and outside this change's mandate.
+
+Follow-up issue to file alongside the `employees` one from §6: *"Scope `shift_trades` SELECT to
+active trades"* — decide a retention/status rule for open-marketplace trade visibility, then the
+`shifts` clause inherits it for free with no further change here.
+
 Note that `useShiftTrades`'s own conflict-detection read of `shifts` is already self-scoped
 (`.eq('employee_id', currentEmployeeId)` at [:616-620](../../../src/hooks/useShiftTrades.ts#L616))
 and is unaffected.

--- a/docs/superpowers/specs/2026-08-05-employee-self-scoped-data-design.md
+++ b/docs/superpowers/specs/2026-08-05-employee-self-scoped-data-design.md
@@ -1,0 +1,368 @@
+# Employee self-service pages must be self-scoped (design)
+
+- **Date:** 2026-08-05
+- **Branch:** `fix/employee-self-scoped-data`
+- **Origin:** security follow-up filed from PR #701 (`fix/collaborator-work-view`). This is a
+  live issue on `main`; PR #701 surfaced it but did not introduce it.
+- **Related:** `docs/superpowers/specs/2026-08-02-collaborator-work-view-design.md`
+
+---
+
+## 1. Problem
+
+Employee self-service pages fetch **restaurant-wide** data and filter it to the current
+employee **in the browser**. The RLS policies behind those tables are membership-only, so the
+filtering is cosmetic — every coworker's row genuinely arrives over the wire.
+
+`staffAllowedPaths` has included these routes since before PR #701
+([src/App.tsx:333](../../../src/App.tsx#L333), building on `EMPLOYEE_SELF_SERVICE_PATHS` at
+[src/App.tsx:186-196](../../../src/App.tsx#L186)), so the exposure applies to every user
+holding the `staff` role today.
+
+### 1.1 Leak sites (client)
+
+Three pages, not two. The third was found during this design's caller sweep.
+
+| Page | Call | Client-side filter |
+|---|---|---|
+| `EmployeeSchedule` | `useShifts(restaurantId, currentWeekStart, weekEnd)` — [src/pages/EmployeeSchedule.tsx:70-73](../../../src/pages/EmployeeSchedule.tsx#L70) | `shifts.filter(s => s.employee_id === currentEmployee.id)` — [:76-79](../../../src/pages/EmployeeSchedule.tsx#L76) |
+| `AvailableShiftsPage` | `useShifts(restaurantId, weekStart, weekEnd)` — [src/pages/AvailableShiftsPage.tsx:250](../../../src/pages/AvailableShiftsPage.tsx#L250) | `myShifts.filter(s => s.employee_id === currentEmployee.id && s.status !== 'cancelled')` — [:251-254](../../../src/pages/AvailableShiftsPage.tsx#L251) |
+| `EmployeePay` | `usePayroll(restaurantId, startDate, endDate)` — [src/pages/EmployeePay.tsx:58](../../../src/pages/EmployeePay.tsx#L58) | `payrollPeriod.employees.find(e => e.employeeId === currentEmployee.id)` — [:61-64](../../../src/pages/EmployeePay.tsx#L61) |
+
+`useShifts` also embeds the employee record: `.select('*, employee:employees(*)')`
+([src/hooks/useShifts.tsx:59-61](../../../src/hooks/useShifts.tsx#L59)), so the schedule page
+ships every coworker's full `employees` row too, not just their shift times.
+
+### 1.2 The payroll leak is nine tables, not one
+
+The brief named `useEmployees` + `employee_compensation_history`. The `usePayroll` `queryFn`
+actually issues restaurant-wide reads against **eight** more tables, all keyed on
+`restaurant_id` + a date range with no employee predicate:
+
+| Table | Line | Selected |
+|---|---|---|
+| `employees` (+ `employee_compensation_history(*)`) | [usePayroll.tsx:116](../../../src/hooks/usePayroll.tsx#L116) → [useEmployees.tsx](../../../src/hooks/useEmployees.tsx) | `*` plus embedded compensation history |
+| `time_punches` | [:150-160](../../../src/hooks/usePayroll.tsx#L150) | `*` (paginated via `fetchAllRows`) |
+| `tip_splits` | [:171-177](../../../src/hooks/usePayroll.tsx#L171) | `id, total_amount` |
+| `tip_split_items` | [:184-189](../../../src/hooks/usePayroll.tsx#L184) | `employee_id, amount, tip_split_id` |
+| `daily_labor_allocations` | [:194-200](../../../src/hooks/usePayroll.tsx#L194) | `*` where `source = 'per-job'` |
+| `employee_tips` | [:221-226](../../../src/hooks/usePayroll.tsx#L221) | `employee_id, tip_amount, tip_date` |
+| `tip_payouts` | [:231-236](../../../src/hooks/usePayroll.tsx#L231) | `employee_id, amount` |
+| `overtime_rules` | [:281-285](../../../src/hooks/usePayroll.tsx#L281) | restaurant config — **not** per-employee |
+| `overtime_adjustments` | [:292-297](../../../src/hooks/usePayroll.tsx#L292) | `employee_id, punch_date, adjustment_type, hours, reason` |
+
+Every one of these except `overtime_rules` carries an `employee_id` column, so all are
+mechanically self-scopable.
+
+### 1.3 RLS state (verified against production `pg_policies`, read-only)
+
+Four of the six target tables have **exactly one** SELECT policy, and it is membership-only:
+
+| Table | Policy | `qual` |
+|---|---|---|
+| `shifts` | Users can view shifts for their restaurants | `EXISTS (SELECT 1 FROM user_restaurants WHERE restaurant_id = shifts.restaurant_id AND user_id = auth.uid())` |
+| `employee_compensation_history` | Users can view compensation history for their restaurants | same shape |
+| `overtime_adjustments` | Users can view their restaurant overtime adjustments | same shape |
+| `daily_labor_allocations` | Users can view allocations for their restaurants | same shape |
+
+`time_punches` and `employee_tips` each carry **four** SELECT policies: an own-row policy
+(`employee_id IN (SELECT id FROM employees WHERE user_id = auth.uid())`), two duplicate
+manager policies whose predicate is the **legacy role string** `role = ANY (ARRAY['owner','manager'])`,
+and the same membership-only policy. Because permissive policies are ORed, the membership
+policy defeats the other three.
+
+> **Consequence for the fix:** the manager policies on those two tables are role-string based
+> and cover only `owner`/`manager`. Simply *dropping* the redundant membership policy would
+> revoke `operations_manager`, `chef`, and `collaborator_operations_manager` — so the
+> membership policy must be **replaced**, not deleted.
+
+Prerequisite already in place: `employees` carries `Employees can view their own record` with
+`qual = (user_id = auth.uid())`, added by
+[supabase/migrations/20260220000000_add_staff_tip_read_policies.sql:13-16](../../../supabase/migrations/20260220000000_add_staff_tip_read_policies.sql#L13).
+That migration's header ([:6-12](../../../supabase/migrations/20260220000000_add_staff_tip_read_policies.sql#L6))
+documents why it matters: Postgres evaluates an RLS subquery against `employees` under the
+*caller's* RLS permissions, so every `EXISTS (… FROM employees WHERE user_id = auth.uid())`
+clause in this design depends on it.
+
+### 1.4 The correct pattern already exists in-repo
+
+`tip_payouts` and `tip_split_items` already use **own-row OR capability**:
+`tip_payouts` has `Employees can view their own tip payouts` (own row via `employees.user_id`)
+ORed with a `user_has_capability(restaurant_id, 'view:tips')` manager policy. This design
+copies that shape.
+
+---
+
+## 2. Goals / non-goals
+
+**Goals**
+1. Employee self-service pages must request only the signed-in employee's rows.
+2. RLS must stop restaurant-wide reads for roles that have no scheduling/payroll capability,
+   so the boundary holds even against a hand-rolled `supabase-js` call from devtools.
+3. No behaviour change for any role that legitimately reads restaurant-wide data today.
+
+**Non-goals**
+- Tightening `employees` (§6 — deferred with evidence).
+- Changing which routes `staff` may reach; `staffAllowedPaths` is unchanged.
+- Any write-path/RPC change.
+
+---
+
+## 3. Design — client layer
+
+### 3.1 The `undefined` footgun (why an optional param is not enough)
+
+`useCurrentEmployee` is itself an async React Query
+([src/hooks/useCurrentEmployee.tsx:10-40](../../../src/hooks/useCurrentEmployee.tsx#L10)), so
+`currentEmployee` is `null` on first render and stays null until the query settles. An
+*optional* `{ employeeId }` filter that falls back to "no filter" when the value is missing
+would therefore issue a full restaurant-wide fetch on **every page load** — re-opening the
+exact hole this change closes.
+
+**Rule:** the self-scoped entry point is a separate exported hook whose `enabled` gate
+requires the id. There is no code path in which "self-scoped" degrades to "everything".
+
+### 3.2 Shared implementation, two public entry points
+
+Both hook families keep one internal implementation so the employee's own numbers cannot
+drift from what the admin page shows for the same employee.
+
+**`src/hooks/useShifts.tsx`**
+
+```ts
+// internal
+function useShiftsQuery(restaurantId, startDate, endDate, employeeId?: string | null)
+//   queryKey: ['shifts', restaurantId, start, end, employeeId ?? 'all']
+//   applies .eq('employee_id', employeeId) when employeeId is set
+
+// public — unchanged signature, admin callers untouched
+export function useShifts(restaurantId, startDate?, endDate?)
+
+// public — self-scoped; enabled: !!restaurantId && !!employeeId
+export function useMyShifts(restaurantId, employeeId: string | null, startDate?, endDate?)
+```
+
+`useShifts`'s current signature and behaviour ([src/hooks/useShifts.tsx:48-90](../../../src/hooks/useShifts.tsx#L48))
+are preserved verbatim for its admin callers: [src/hooks/useShiftPlanner.ts:539](../../../src/hooks/useShiftPlanner.ts#L539)
+and [src/pages/Scheduling.tsx:291](../../../src/pages/Scheduling.tsx#L291).
+
+**`src/hooks/useEmployees.tsx`** — add `employeeId?: string` to `UseEmployeesOptions`,
+applying `.eq('id', employeeId)` and joining it into the query key. Note the existing
+module-level `EMPTY_EMPLOYEES` stable reference must be preserved — it deliberately guards an
+infinite render loop in [src/pages/Tips.tsx](../../../src/pages/Tips.tsx).
+
+**`src/hooks/usePayroll.tsx`** — internal implementation takes `employeeId?: string` and
+threads `.eq('employee_id', employeeId)` into the seven per-employee queries listed in §1.2
+(`time_punches`, `tip_split_items`, `daily_labor_allocations`, `employee_tips`, `tip_payouts`,
+`overtime_adjustments`, plus `useEmployees({ status: 'all', employeeId })`). `tip_splits` and
+`overtime_rules` stay restaurant-scoped: `tip_splits` is only read for `id, total_amount` to
+resolve child items ([:171-181](../../../src/hooks/usePayroll.tsx#L171)) and `overtime_rules`
+is restaurant configuration, not per-employee data.
+
+```ts
+export function usePayroll(restaurantId, startDate, endDate)                       // admin
+export function useMyPayroll(restaurantId, employeeId: string | null, startDate, endDate)
+```
+
+The `enabled` gate at [usePayroll.tsx:342](../../../src/hooks/usePayroll.tsx#L342) is
+`!!restaurantId && !!employees.length`; the self-scoped variant additionally requires
+`!!employeeId`. The query key must include `employeeId` so an employee's cache entry can
+never be served to the admin page (or vice versa).
+
+Downstream aggregation is unchanged: `calculatePayrollPeriod`
+([:329-340](../../../src/hooks/usePayroll.tsx#L329)) simply receives a one-element
+`eligibleEmployees` array, and `EmployeePay`'s existing `.find(...)` still resolves.
+
+### 3.3 Page changes
+
+- [EmployeeSchedule.tsx:70-79](../../../src/pages/EmployeeSchedule.tsx#L70) → `useMyShifts(restaurantId, currentEmployee?.id ?? null, currentWeekStart, weekEnd)`; the `myShifts` `useMemo` filter is removed (`shifts` is already the employee's).
+- [AvailableShiftsPage.tsx:250-254](../../../src/pages/AvailableShiftsPage.tsx#L250) → `useMyShifts(...)`; the `employee_id` predicate is dropped from the `useMemo` but **`status !== 'cancelled'` is kept** — it is a display rule, not a scoping rule.
+- [EmployeePay.tsx:58](../../../src/pages/EmployeePay.tsx#L58) → `useMyPayroll(restaurantId, currentEmployee?.id ?? null, startDate, endDate)`.
+
+Loading states already gate on `employeeLoading` on all three pages, so the extra
+"disabled until `currentEmployee` resolves" tick renders as the existing skeleton rather than
+an empty state.
+
+---
+
+## 4. Design — RLS layer (defense in depth)
+
+### 4.1 The uniform predicate
+
+For each of the six tables, the single membership-only policy is **replaced** by two
+permissive policies:
+
+```sql
+-- own row
+USING (EXISTS (
+  SELECT 1 FROM employees e
+  WHERE e.id = <table>.employee_id
+    AND e.user_id = auth.uid()
+    AND e.restaurant_id = <table>.restaurant_id
+))
+
+-- privileged restaurant-wide
+USING (
+  user_has_capability(restaurant_id, 'view:scheduling')
+  OR user_has_capability(restaurant_id, 'view:payroll')
+)
+```
+
+**Why `view:scheduling OR view:payroll`, and not `view:payroll` alone.** The legacy-role
+capability sets are declared in [src/lib/permissions/definitions.ts](../../../src/lib/permissions/definitions.ts):
+`chef` holds `view:scheduling` and `view:dashboard` but **not** `view:payroll`
+([:182-205](../../../src/lib/permissions/definitions.ts#L182)), and `staff` holds only
+`view:settings` ([:207-210](../../../src/lib/permissions/definitions.ts#L207)). A
+`view:payroll`-only predicate would silently zero out chef's labor-cost figures on the
+scheduling and dashboard surfaces fed by
+[useScheduledLaborCosts](../../../src/hooks/useScheduledLaborCosts.tsx) and
+[useLaborCostsFromTimeTracking](../../../src/hooks/useLaborCostsFromTimeTracking.tsx) — the
+same silent-zero failure mode the tips migration was written to repair. The OR'd predicate
+admits exactly `owner`, `manager`, `operations_manager`, `chef`, `collaborator_accountant`,
+`collaborator_operations_manager`, and excludes `staff`, `kiosk`, `collaborator_inventory`,
+`collaborator_chef`.
+
+`user_has_capability(uuid, text)` is `SECURITY DEFINER`, `STABLE`, `SET search_path TO 'public'`,
+and resolves either the legacy `user_restaurants.role` string or `role_areas`/`role_flags`
+keyed on `role_id`. `view:costs` / `view:pay_rates` / `view:employee_pii` are **not** usable
+here: they resolve only from `role_flags` and do not appear in the legacy role CASE, so they
+would evaluate false for legacy roles including `owner`.
+
+Tightening chef's access to pay rates further is a **product decision, not a security fix**,
+and is deliberately out of scope.
+
+### 4.2 Per-table notes
+
+| Table | Policy replaced | Notes |
+|---|---|---|
+| `employee_compensation_history` | Users can view compensation history for their restaurants | Own row joins via `employee_id`; also read as the embedded `compensation_history:` join in `useEmployees`. |
+| `time_punches` | Users can view time punches for their restaurants | Own-row policy already exists — the new own-row policy is redundant but harmless; the two legacy `owner`/`manager` policies are left untouched (out of scope to consolidate). |
+| `employee_tips` | Users can view tips for their restaurants | Same as above. |
+| `overtime_adjustments` | Users can view their restaurant overtime adjustments | Sole SELECT policy today. |
+| `daily_labor_allocations` | Users can view allocations for their restaurants | Sole SELECT policy today. |
+| `shifts` | Users can view shifts for their restaurants | Needs a third clause — see §4.3. |
+
+### 4.3 `shifts` needs a shift-trade clause
+
+`shifts.employee_id` is `NOT NULL` in production, so there are no unassigned rows to
+special-case. But the shift-trade marketplace reads **other** employees' shift rows through an
+embedded PostgREST join — `offered_shift:shifts!offered_shift_id(...)` at
+[src/hooks/useShiftTrades.ts:139](../../../src/hooks/useShiftTrades.ts#L139),
+[:245](../../../src/hooks/useShiftTrades.ts#L245),
+[:317](../../../src/hooks/useShiftTrades.ts#L317) and
+[:580](../../../src/hooks/useShiftTrades.ts#L580) — and the app deliberately shows
+marketplace trades to employees who are not the target
+([:600-603](../../../src/hooks/useShiftTrades.ts#L600)). An own-row-only policy would break
+accepting a trade.
+
+Third permissive policy on `shifts`:
+
+```sql
+USING (EXISTS (
+  SELECT 1 FROM shift_trades st
+  WHERE st.restaurant_id = shifts.restaurant_id
+    AND (st.offered_shift_id = shifts.id OR st.requested_shift_id = shifts.id)
+))
+```
+
+`shift_trades` columns confirmed in production: `restaurant_id`, `offered_shift_id`,
+`requested_shift_id`, `offered_by_employee_id`, `target_employee_id`, `status`. This subquery
+is itself evaluated under the caller's RLS on `shift_trades`; the pgTAP suite must assert that
+a staff user actually reaches an offered shift through it rather than assuming it.
+
+Note that `useShiftTrades`'s own conflict-detection read of `shifts` is already self-scoped
+(`.eq('employee_id', currentEmployeeId)` at [:616-620](../../../src/hooks/useShiftTrades.ts#L616))
+and is unaffected.
+
+### 4.4 Migration mechanics
+
+- One migration file, `supabase/migrations/2026080512xxxx_self_scope_employee_reads.sql`.
+- `DROP POLICY IF EXISTS` by exact name, then `CREATE POLICY`. Permissive policies OR, so the
+  membership policy **must** be dropped — adding a narrower policy alongside it changes nothing.
+- Policy bodies are transcribed from the production `pg_policies` output quoted in §1.3, not
+  re-derived from an assumed schema.
+- Because a `SELECT` predicate changes on tables that also have `INSERT/UPDATE/DELETE`
+  policies with `USING`/`WITH CHECK` clauses, the plan must re-run the full pgTAP suite after
+  a `db:reset` (editing a migration and running `test:db` without a reset tests the *old* state).
+
+---
+
+## 5. Testing
+
+### 5.1 Unit (Vitest)
+
+New `tests/unit/useMyShifts.test.ts` and `tests/unit/useMyPayroll.test.ts` asserting, against a
+mocked `supabase` client, that:
+
+1. `useMyShifts` issues `.eq('employee_id', <id>)` — the assertion inspects the recorded
+   query-builder calls, not the returned rows, so it cannot pass vacuously via client filtering.
+2. `useMyShifts` issues **no query at all** when `employeeId` is `null` (the §3.1 footgun).
+3. `useMyPayroll` applies `.eq('employee_id', <id>)` to each of the seven per-employee tables
+   and `.eq('id', <id>)` to `employees`.
+4. `useShifts` / `usePayroll` (admin) still issue exactly the query they issue today — a
+   regression guard for the shared implementation.
+
+Existing suites that must stay green: [tests/unit/usePayroll.pagination.test.ts](../../../tests/unit/usePayroll.pagination.test.ts)
+and [tests/unit/usePayroll.fetchRange.test.ts](../../../tests/unit/usePayroll.fetchRange.test.ts).
+
+### 5.2 pgTAP
+
+New `supabase/tests/rls_employee_self_scope.sql`. For each of the six tables, with fixtures for
+one `staff` employee, one coworker, and one `manager`:
+
+- staff sees own row; staff does **not** see the coworker's row (the actual fix);
+- manager/`view:payroll` holder sees both;
+- a `chef` sees both — the §4.1 regression guard, and the clause only `view:scheduling` grants;
+- for `shifts`, a staff user reaches a coworker's shift **only** when it is referenced by a
+  `shift_trades` row — exercising §4.3's clause with a row no other clause grants, so the test
+  is not vacuous.
+
+Every existing pgTAP test touching these tables must be re-checked: narrowing a SELECT
+predicate can make an unrelated assertion vacuous rather than failing it. The plan budgets a
+`grep -rln` sweep of `supabase/tests/` for each table name.
+
+### 5.3 Manual / E2E
+
+Not adding E2E here. The observable behaviour of all three pages is unchanged by design; the
+change is what crosses the wire, which the unit tests assert directly and Playwright cannot.
+
+---
+
+## 6. Deferred: `employees`
+
+`employees` carries the membership-only `Team members can view coworkers in their restaurant`
+(`restaurant_id IN (SELECT ur.restaurant_id FROM user_restaurants ur WHERE ur.user_id = auth.uid())`),
+which ORs open the narrower `user_has_capability(restaurant_id, 'view:employees')` policy that
+sits beside it. It is **not** tightened in this change, for two evidenced reasons:
+
+1. **A staff-facing surface legitimately needs coworker rows.** The shift-trade dialog calls
+   `useEmployees(restaurantId)` to list coworkers as trade targets —
+   [src/components/schedule/TradeRequestDialog.tsx:53](../../../src/components/schedule/TradeRequestDialog.tsx#L53).
+   Own-row-only would empty that picker and break staff-initiated trades.
+2. **The right fix is column-level, which RLS cannot express.** Staff need a coworker's `id`
+   and `name`; they do not need the rest of the row. That requires a restricted view or an
+   RPC, i.e. its own design.
+
+Blast radius also argues for separating it: `useEmployees` has roughly twenty call sites,
+including [EmployeeList.tsx:42](../../../src/components/EmployeeList.tsx#L42),
+[ShiftDialog.tsx:69](../../../src/components/ShiftDialog.tsx#L69),
+[Payroll.tsx:177](../../../src/pages/Payroll.tsx#L177), and
+[useSplhCore.ts:37](../../../src/hooks/useSplhCore.ts#L37).
+
+**Residual risk, stated plainly:** after this change a `staff` user can still enumerate
+coworker `employees` rows. Their shifts, punches, tips, pay rates, labor allocations, and
+overtime adjustments are closed at both layers; their employee record is not. A follow-up
+issue will be filed.
+
+---
+
+## 7. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Silent-zero regression for `chef`/`operations_manager` on labor-cost surfaces | `view:scheduling OR view:payroll` predicate (§4.1) + an explicit chef pgTAP case (§5.2) |
+| Self-scoped hook degrades to restaurant-wide while `currentEmployee` loads | Separate hook with a mandatory `employeeId` in `enabled` (§3.1) + a unit test asserting zero queries when null (§5.1) |
+| React Query cache collision between admin and self views | `employeeId` in the query key (§3.2) |
+| Shift-trade marketplace breaks under the new `shifts` policy | Dedicated trade clause (§4.3) + non-vacuous pgTAP case (§5.2) |
+| Existing pgTAP assertions become vacuous rather than failing | `grep -rln` sweep of `supabase/tests/` per table; full `db:reset` before `test:db` (§4.4) |
+| Employee pay figure drifts from the admin Payroll page | One shared implementation, two entry points — not a duplicate calculation (§3.2) |

--- a/docs/superpowers/specs/2026-08-05-employee-self-scoped-data-design.md
+++ b/docs/superpowers/specs/2026-08-05-employee-self-scoped-data-design.md
@@ -100,6 +100,8 @@ copies that shape.
 2. RLS must stop restaurant-wide reads for roles that have no scheduling/payroll capability,
    so the boundary holds even against a hand-rolled `supabase-js` call from devtools.
 3. No behaviour change for any role that legitimately reads restaurant-wide data today.
+4. Where a role *does* lose a restaurant-wide read, it must fail loudly. No surface may
+   silently report a truncated aggregate as if it were complete (§4.4).
 
 **Non-goals**
 - Tightening `employees` (§6 — deferred with evidence).
@@ -167,7 +169,23 @@ export function useMyPayroll(restaurantId, employeeId: string | null, startDate,
 The `enabled` gate at [usePayroll.tsx:342](../../../src/hooks/usePayroll.tsx#L342) is
 `!!restaurantId && !!employees.length`; the self-scoped variant additionally requires
 `!!employeeId`. The query key must include `employeeId` so an employee's cache entry can
-never be served to the admin page (or vice versa).
+never be served to the admin page (or vice versa). Cache invalidation is unaffected: every
+`invalidateQueries` call touching these families uses a 1- or 2-element key prefix with no
+`exact: true`, so appending `employeeId` at the end of the key still prefix-matches.
+
+**`usePayroll` must also report the inner employees query's loading state.** The `enabled`
+gate depends on `employees.length`, but `usePayroll` destructures only `{ employees }` from
+`useEmployees` at [usePayroll.tsx:116](../../../src/hooks/usePayroll.tsx#L116) and discards
+its `loading` ([useEmployees.tsx:66](../../../src/hooks/useEmployees.tsx#L66) returns it).
+While that inner query is in flight, `employees.length === 0`, so the payroll query stays
+*disabled* — and a disabled query reports `isFetching: false`, hence `isLoading: false`, with
+`data: undefined`. `usePayroll` returns that unmodified at
+[usePayroll.tsx:484](../../../src/hooks/usePayroll.tsx#L484), so `EmployeePay` currently
+renders its "No Pay Data" empty-state card during that window instead of a skeleton. Under
+`useMyPayroll` the inner `useEmployees` cannot start until `employeeId` resolves, which
+*widens* the window. Both entry points must therefore return
+`loading: isLoading || employeesLoading`. This is a pre-existing bug that this change would
+otherwise make worse, so it is fixed here rather than deferred.
 
 Downstream aggregation is unchanged: `calculatePayrollPeriod`
 ([:329-340](../../../src/hooks/usePayroll.tsx#L329)) simply receives a one-element
@@ -179,9 +197,42 @@ Downstream aggregation is unchanged: `calculatePayrollPeriod`
 - [AvailableShiftsPage.tsx:250-254](../../../src/pages/AvailableShiftsPage.tsx#L250) → `useMyShifts(...)`; the `employee_id` predicate is dropped from the `useMemo` but **`status !== 'cancelled'` is kept** — it is a display rule, not a scoping rule.
 - [EmployeePay.tsx:58](../../../src/pages/EmployeePay.tsx#L58) → `useMyPayroll(restaurantId, currentEmployee?.id ?? null, startDate, endDate)`.
 
-Loading states already gate on `employeeLoading` on all three pages, so the extra
-"disabled until `currentEmployee` resolves" tick renders as the existing skeleton rather than
-an empty state.
+**Loading states.** On `EmployeeSchedule` and at the top-level gate of `AvailableShiftsPage`,
+the "disabled until `currentEmployee` resolves" tick renders as the existing skeleton:
+`currentEmployee` and `employeeLoading` come from the same `useQuery` result and update
+atomically, and React Query optimistically reports `isLoading: true` in the same render where
+a never-fetched query first becomes enabled. Two exceptions must be fixed as part of this
+change:
+
+- **`EmployeePay`** would render its empty state instead of a skeleton — see the
+  `loading: isLoading || employeesLoading` fix in §3.2.
+- **`AvailableShiftsPage`** computes its page `loading` as `const loading = feedLoading;`
+  ([AvailableShiftsPage.tsx:327](../../../src/pages/AvailableShiftsPage.tsx#L327)), which never
+  includes the shifts hook that feeds conflict detection. If the open-shifts feed resolves
+  first, `hasScheduleConflict(...)` runs against an empty `employeeShifts` array and silently
+  omits conflict badges — an employee could claim an open shift that overlaps one they are
+  already scheduled for. This gap pre-exists, but since this change reroutes that exact call
+  site to an `employeeId`-gated hook, `useMyShifts`'s loading state is folded into `loading`
+  here.
+
+Also update the comment at
+[EmployeeSchedule.tsx:92-94](../../../src/pages/EmployeeSchedule.tsx#L92), which justifies
+`shiftsLoading || employeeLoading` by reference to the client-side filter this change removes.
+The `|| employeeLoading` term must **stay** — a disabled-but-not-yet-enabled `useMyShifts`
+reports `isLoading: false` — but the stated reason changes.
+
+**Downstream consumers on these pages are unaffected**, verified rather than assumed:
+`useWeekRetractionReason` reads `schedule_retractions`, which is restaurant/week-scoped with no
+shift dependency ([useSchedulePublish.tsx:445-474](../../../src/hooks/useSchedulePublish.tsx#L445));
+`useWeekScheduleStatus` derives its counts from whatever array it is handed
+([:378-434](../../../src/hooks/useSchedulePublish.tsx#L378)), which is content-identical before
+and after; `MyShiftTradesCard` runs off `useMyTradeActivity(restaurantId, employeeId)` and is
+independent of the `useShifts` family; and the fingerprint pill
+([src/lib/scheduleSeenFingerprint.ts](../../../src/lib/scheduleSeenFingerprint.ts), consumed at
+[EmployeeSchedule.tsx:109-116](../../../src/pages/EmployeeSchedule.tsx#L109)) hashes fields off
+an array whose select shape is unchanged. `hasScheduleConflict`
+([src/lib/openShiftHelpers.ts:36-59](../../../src/lib/openShiftHelpers.ts#L36)) has no
+restaurant-wide dependency.
 
 ---
 
@@ -274,7 +325,51 @@ Note that `useShiftTrades`'s own conflict-detection read of `shifts` is already 
 (`.eq('employee_id', currentEmployeeId)` at [:616-620](../../../src/hooks/useShiftTrades.ts#L616))
 and is unaffected.
 
-### 4.4 Migration mechanics
+### 4.4 Edge-function callers (the sweep must leave `src/`)
+
+Most edge functions use the service-role key and bypass RLS entirely, but
+`ai-execute-tool` does **not**: it builds its client from `SUPABASE_ANON_KEY` plus the
+caller's forwarded `Authorization` header
+([supabase/functions/ai-execute-tool/index.ts:3615-3618](../../../supabase/functions/ai-execute-tool/index.ts#L3615)),
+so RLS applies in full to every query it issues. Three of its tools read the tables this
+change tightens:
+
+| Tool | Reads | Line |
+|---|---|---|
+| `get_kpis` | `time_punches` (+ `employees`) restaurant-wide | [:236-249](../../../supabase/functions/ai-execute-tool/index.ts#L236) |
+| `get_labor_costs` | `time_punches` via `fetchLaborData` | [:1955-1957](../../../supabase/functions/ai-execute-tool/index.ts#L1955) |
+| `get_schedule_overview` | `shifts` restaurant-wide | [:2164-2170](../../../supabase/functions/ai-execute-tool/index.ts#L2164) |
+
+All three sit in `canUseTool`'s `basicTools` list
+([supabase/functions/_shared/tools-registry.ts:889-899](../../../supabase/functions/_shared/tools-registry.ts#L889),
+whose comment reads "Labor costs visible to all (aggregate data)"), so they are reachable by
+every role — including `collaborator_inventory` and `collaborator_chef`, which are **not**
+theoretical: the AI chat bubble is hidden only for `staff` and `kiosk`
+([src/components/ai-chat/AiChatBubble.tsx:90](../../../src/components/ai-chat/AiChatBubble.tsx#L90)).
+
+Without action, after this migration those roles would receive an RLS-truncated punch set and
+the assistant would report a near-$0 labor cost and an inflated margin — silently, as a
+plausible number rather than an error. That is the same silent-zero failure mode §4.1 exists
+to prevent, recurring because the original sweep never left `src/`. Required as part of this
+change:
+
+- Move `get_labor_costs` and `get_schedule_overview` out of `basicTools` and gate them on
+  `view:scheduling OR view:payroll`, so an unentitled caller gets a clean permission error.
+- Leave `get_kpis` basic (its sales KPIs are legitimately available to those roles) but make
+  its **labor component degrade explicitly** — omit the labor fields with a stated reason
+  rather than computing a total from a truncated punch set.
+
+Prefer resolving the gate through the `user_has_capability` RPC rather than a hard-coded role
+list in `tools-registry.ts`: `canUseTool` currently branches on a `userRole` string, and a
+second hard-coded copy of the capability set would drift from the RLS predicate and would not
+resolve custom roles keyed on `role_id`.
+
+The plan must also confirm the remaining forwarded-JWT edge functions. Spot-checked already:
+`generate-schedule` ([index.ts:116](../../../supabase/functions/generate-schedule/index.ts#L116))
+and `notify-schedule-published` ([index.ts:65](../../../supabase/functions/notify-schedule-published/index.ts#L65))
+touch `shifts` but are hard-gated to `owner`/`manager`, so they are unaffected.
+
+### 4.5 Migration mechanics
 
 - One migration file, `supabase/migrations/2026080512xxxx_self_scope_employee_reads.sql`.
 - `DROP POLICY IF EXISTS` by exact name, then `CREATE POLICY`. Permissive policies OR, so the
@@ -301,6 +396,9 @@ mocked `supabase` client, that:
    and `.eq('id', <id>)` to `employees`.
 4. `useShifts` / `usePayroll` (admin) still issue exactly the query they issue today — a
    regression guard for the shared implementation.
+5. `useMyPayroll` reports `loading: true` while its inner `useEmployees` query is in flight
+   (the §3.2 disabled-query window), so `EmployeePay` cannot render an empty state before the
+   payroll query has had a chance to run.
 
 Existing suites that must stay green: [tests/unit/usePayroll.pagination.test.ts](../../../tests/unit/usePayroll.pagination.test.ts)
 and [tests/unit/usePayroll.fetchRange.test.ts](../../../tests/unit/usePayroll.fetchRange.test.ts).
@@ -311,11 +409,18 @@ New `supabase/tests/rls_employee_self_scope.sql`. For each of the six tables, wi
 one `staff` employee, one coworker, and one `manager`:
 
 - staff sees own row; staff does **not** see the coworker's row (the actual fix);
-- manager/`view:payroll` holder sees both;
-- a `chef` sees both — the §4.1 regression guard, and the clause only `view:scheduling` grants;
+- a `chef` sees both — isolates the `view:scheduling` arm, since `chef` holds no `view:payroll`;
+- a `collaborator_accountant` sees both — isolates the `view:payroll` arm. A `manager`
+  fixture cannot do this: `manager` holds **both** capabilities, so "manager sees both" cannot
+  distinguish a working `view:payroll` clause from one that is never reached. Each arm of the
+  OR must be exercised by a role that satisfies only that arm;
 - for `shifts`, a staff user reaches a coworker's shift **only** when it is referenced by a
   `shift_trades` row — exercising §4.3's clause with a row no other clause grants, so the test
-  is not vacuous.
+  is not vacuous. Cover the `requested_shift_id` arm with its own case: no application code
+  writes that column today (`useCreateShiftTrade`'s insert at
+  [src/hooks/useShiftTrades.ts:304-311](../../../src/hooks/useShiftTrades.ts#L304) never sets
+  it), so it is inert in production and would otherwise ship as an unverified clause that a
+  future direct-swap feature inherits. pgTAP fixtures can insert it directly.
 
 Every existing pgTAP test touching these tables must be re-checked: narrowing a SELECT
 predicate can make an unrelated assertion vacuous rather than failing it. The plan budgets a
@@ -364,5 +469,9 @@ issue will be filed.
 | Self-scoped hook degrades to restaurant-wide while `currentEmployee` loads | Separate hook with a mandatory `employeeId` in `enabled` (§3.1) + a unit test asserting zero queries when null (§5.1) |
 | React Query cache collision between admin and self views | `employeeId` in the query key (§3.2) |
 | Shift-trade marketplace breaks under the new `shifts` policy | Dedicated trade clause (§4.3) + non-vacuous pgTAP case (§5.2) |
-| Existing pgTAP assertions become vacuous rather than failing | `grep -rln` sweep of `supabase/tests/` per table; full `db:reset` before `test:db` (§4.4) |
+| Existing pgTAP assertions become vacuous rather than failing | `grep -rln` sweep of `supabase/tests/` per table; full `db:reset` before `test:db` (§4.5) |
+| AI assistant silently reports near-$0 labor cost for roles that lose restaurant-wide reads | Gate `get_labor_costs`/`get_schedule_overview` on capability; make `get_kpis`'s labor component degrade explicitly (§4.4) |
+| `EmployeePay` flashes an empty state instead of a skeleton | `loading: isLoading \|\| employeesLoading` (§3.2) + a unit test for the disabled-query window (§5.1) |
+| `AvailableShiftsPage` silently omits conflict badges while shifts load | Fold `useMyShifts` loading into the page's `loading` (§3.3) |
+| One arm of the RLS OR predicate never actually exercised | Separate `chef` and `collaborator_accountant` fixtures, one per arm (§5.2) |
 | Employee pay figure drifts from the admin Payroll page | One shared implementation, two entry points — not a duplicate calculation (§3.2) |

--- a/src/hooks/useEmployees.tsx
+++ b/src/hooks/useEmployees.tsx
@@ -7,6 +7,7 @@ export type EmployeeStatusFilter = 'active' | 'inactive' | 'all';
 
 interface UseEmployeesOptions {
   status?: EmployeeStatusFilter;
+  employeeId?: string;
 }
 
 const defaultOptions: UseEmployeesOptions = { status: 'active' };
@@ -23,10 +24,10 @@ export const useEmployees = (
   restaurantId: string | null,
   options: UseEmployeesOptions = defaultOptions
 ) => {
-  const { status = 'active' } = options;
+  const { status = 'active', employeeId } = options;
 
   const { data, isLoading, error } = useQuery({
-    queryKey: ['employees', restaurantId, status],
+    queryKey: ['employees', restaurantId, status, employeeId],
     queryFn: async () => {
       if (!restaurantId) return [];
 
@@ -45,6 +46,10 @@ export const useEmployees = (
         query = query.eq('is_active', false);
       }
       // 'all' = no filter
+
+      if (employeeId) {
+        query = query.eq('id', employeeId);
+      }
 
       query = query
         .order('name')

--- a/src/hooks/usePayroll.tsx
+++ b/src/hooks/usePayroll.tsx
@@ -41,6 +41,21 @@ export function aggregateTips(
   return tipsPerEmployee;
 }
 
+/**
+ * Narrows a Supabase query to `employee_id = employeeId` in self-scoped mode;
+ * a no-op pass-through in admin mode (`employeeId` falsy). Centralizes the
+ * per-employee predicate applied to each of the seven per-employee queries
+ * below so the self-scoping rule lives in one place, not six near-identical
+ * copies of it. `.eq()` returns `this` in supabase-js, so this stays
+ * type-safe across differently-shaped queries.
+ */
+function scopeToEmployee<Query extends { eq(column: string, value: string): Query }>(
+  query: Query,
+  employeeId: string | null | undefined,
+): Query {
+  return employeeId ? query.eq('employee_id', employeeId) : query;
+}
+
 type TipSplitForFallback = { id: string; total_amount: number };
 
 /**
@@ -160,21 +175,20 @@ function usePayrollInternal(
         timezone,
       );
       const { fetchStart, fetchEnd } = bufferPunchFetchRange(dayStart, dayEnd);
-      const { rows: punches, capped } = await fetchAllRows<DBTimePunch>((from, to) => {
-        let query = supabase
-          .from('time_punches')
-          .select('*')
-          .eq('restaurant_id', restaurantId)
-          .gte('punch_time', fetchStart.toISOString())
-          .lte('punch_time', fetchEnd.toISOString());
-        if (employeeId) {
-          query = query.eq('employee_id', employeeId);
-        }
-        return query
+      const { rows: punches, capped } = await fetchAllRows<DBTimePunch>((from, to) =>
+        scopeToEmployee(
+          supabase
+            .from('time_punches')
+            .select('*')
+            .eq('restaurant_id', restaurantId)
+            .gte('punch_time', fetchStart.toISOString())
+            .lte('punch_time', fetchEnd.toISOString()),
+          employeeId,
+        )
           .order('punch_time', { ascending: true })
           .order('id')
-          .range(from, to);
-      });
+          .range(from, to),
+      );
 
       if (capped) {
         console.warn(
@@ -201,29 +215,27 @@ function usePayrollInternal(
       // Always issued (even with an empty splitIds list) so this stays one of the seven
       // per-employee queries the self-scoped predicate threads into; `.in(..., [])` resolves
       // to no rows without a client-side short-circuit.
-      let tipSplitItemsQuery = supabase
-        .from('tip_split_items')
-        .select('employee_id, amount, tip_split_id, tip_splits(split_date)')
-        .in('tip_split_id', splitIds);
-      if (employeeId) {
-        tipSplitItemsQuery = tipSplitItemsQuery.eq('employee_id', employeeId);
-      }
-      const { data: tips, error: tipsError } = await tipSplitItemsQuery;
+      const { data: tips, error: tipsError } = await scopeToEmployee(
+        supabase
+          .from('tip_split_items')
+          .select('employee_id, amount, tip_split_id, tip_splits(split_date)')
+          .in('tip_split_id', splitIds),
+        employeeId,
+      );
 
       if (tipsError) throw tipsError;
 
       // Fetch manual payments (per-job contractor payments) for the period
-      let manualPaymentsQuery = supabase
-        .from('daily_labor_allocations')
-        .select('*')
-        .eq('restaurant_id', restaurantId)
-        .eq('source', 'per-job')
-        .gte('date', toDateOnlyString(startDate))
-        .lte('date', toDateOnlyString(endDate));
-      if (employeeId) {
-        manualPaymentsQuery = manualPaymentsQuery.eq('employee_id', employeeId);
-      }
-      const { data: manualPaymentsData, error: manualPaymentsError } = await manualPaymentsQuery;
+      const { data: manualPaymentsData, error: manualPaymentsError } = await scopeToEmployee(
+        supabase
+          .from('daily_labor_allocations')
+          .select('*')
+          .eq('restaurant_id', restaurantId)
+          .eq('source', 'per-job')
+          .gte('date', toDateOnlyString(startDate))
+          .lte('date', toDateOnlyString(endDate)),
+        employeeId,
+      );
 
       if (manualPaymentsError) throw manualPaymentsError;
 
@@ -244,30 +256,28 @@ function usePayrollInternal(
       });
 
       // Fetch tips from tip_split_items and employee_tips for the period
-      let employeeTipsQuery = supabase
-        .from('employee_tips')
-        .select('employee_id, tip_amount, tip_date')
-        .eq('restaurant_id', restaurantId)
-        .gte('tip_date', toDateOnlyString(startDate))
-        .lte('tip_date', toDateOnlyString(endDate));
-      if (employeeId) {
-        employeeTipsQuery = employeeTipsQuery.eq('employee_id', employeeId);
-      }
-      const { data: employeeTips, error: employeeTipsError } = await employeeTipsQuery;
+      const { data: employeeTips, error: employeeTipsError } = await scopeToEmployee(
+        supabase
+          .from('employee_tips')
+          .select('employee_id, tip_amount, tip_date')
+          .eq('restaurant_id', restaurantId)
+          .gte('tip_date', toDateOnlyString(startDate))
+          .lte('tip_date', toDateOnlyString(endDate)),
+        employeeId,
+      );
 
       if (employeeTipsError) throw employeeTipsError;
 
       // Fetch tip payouts (cash already paid out) for the period
-      let tipPayoutsQuery = supabase
-        .from('tip_payouts')
-        .select('employee_id, amount')
-        .eq('restaurant_id', restaurantId)
-        .gte('payout_date', toDateOnlyString(startDate))
-        .lte('payout_date', toDateOnlyString(endDate));
-      if (employeeId) {
-        tipPayoutsQuery = tipPayoutsQuery.eq('employee_id', employeeId);
-      }
-      const { data: tipPayoutsData, error: tipPayoutsError } = await tipPayoutsQuery;
+      const { data: tipPayoutsData, error: tipPayoutsError } = await scopeToEmployee(
+        supabase
+          .from('tip_payouts')
+          .select('employee_id, amount')
+          .eq('restaurant_id', restaurantId)
+          .gte('payout_date', toDateOnlyString(startDate))
+          .lte('payout_date', toDateOnlyString(endDate)),
+        employeeId,
+      );
 
       if (tipPayoutsError) throw tipPayoutsError;
 
@@ -323,16 +333,15 @@ function usePayrollInternal(
       }
 
       // Fetch overtime adjustments for the period
-      let otAdjQuery = supabase
-        .from('overtime_adjustments')
-        .select('employee_id, punch_date, adjustment_type, hours, reason')
-        .eq('restaurant_id', restaurantId)
-        .gte('punch_date', toDateOnlyString(startDate))
-        .lte('punch_date', toDateOnlyString(endDate));
-      if (employeeId) {
-        otAdjQuery = otAdjQuery.eq('employee_id', employeeId);
-      }
-      const { data: otAdjData, error: otAdjError } = await otAdjQuery;
+      const { data: otAdjData, error: otAdjError } = await scopeToEmployee(
+        supabase
+          .from('overtime_adjustments')
+          .select('employee_id, punch_date, adjustment_type, hours, reason')
+          .eq('restaurant_id', restaurantId)
+          .gte('punch_date', toDateOnlyString(startDate))
+          .lte('punch_date', toDateOnlyString(endDate)),
+        employeeId,
+      );
 
       if (otAdjError) {
         console.error('Error fetching overtime adjustments:', otAdjError);

--- a/src/hooks/usePayroll.tsx
+++ b/src/hooks/usePayroll.tsx
@@ -48,12 +48,23 @@ export function aggregateTips(
  * below so the self-scoping rule lives in one place, not six near-identical
  * copies of it. `.eq()` returns `this` in supabase-js, so this stays
  * type-safe across differently-shaped queries.
+ *
+ * `Query` is intentionally left unconstrained (no `extends { eq(...): Query }`
+ * structural bound): constraining a generic against a Supabase
+ * PostgrestFilterBuilder shape forces the compiler to fully expand that
+ * (deeply nested, self-referential) type at every call site to check the
+ * constraint, which trips `TS2589: Type instantiation is excessively deep and
+ * possibly infinite` on some of the six differently-shaped queries below. The
+ * inline cast on the `.eq()` call keeps the same runtime behavior and the
+ * same `Query` return type without asking the compiler to prove the
+ * constraint structurally.
  */
-function scopeToEmployee<Query extends { eq(column: string, value: string): Query }>(
+function scopeToEmployee<Query>(
   query: Query,
   employeeId: string | null | undefined,
 ): Query {
-  return employeeId ? query.eq('employee_id', employeeId) : query;
+  if (!employeeId) return query;
+  return (query as { eq: (column: string, value: string) => Query }).eq('employee_id', employeeId);
 }
 
 type TipSplitForFallback = { id: string; total_amount: number };

--- a/src/hooks/usePayroll.tsx
+++ b/src/hooks/usePayroll.tsx
@@ -157,9 +157,11 @@ function usePayrollInternal(
   const queryClient = useQueryClient();
   const { tz: timezone } = useRestaurantClock();
 
-  // `isSelfScoped` (i.e. `employeeId !== undefined`) is admin mode; a plain
-  // `employeeId ?? null` fallback would map BOTH admin mode (undefined) and
-  // self-scoped-but-unresolved mode (null) to the same `null` key segment.
+  // `isSelfScoped` (i.e. `employeeId !== undefined`) is self-scoped mode
+  // (resolved or still-pending); `!isSelfScoped` (employeeId undefined) is
+  // admin mode. A plain `employeeId ?? null` fallback would map BOTH admin
+  // mode (undefined) and self-scoped-but-unresolved mode (null) to the same
+  // `null` key segment.
   // `enabled: false` only suppresses a new fetch, not a cache read, so a
   // disabled self-scoped query mounted while `employeeId` is still resolving
   // could otherwise read back an admin query's already-cached restaurant-wide

--- a/src/hooks/usePayroll.tsx
+++ b/src/hooks/usePayroll.tsx
@@ -146,8 +146,19 @@ function usePayrollInternal(
   const queryClient = useQueryClient();
   const { tz: timezone } = useRestaurantClock();
 
+  // `isSelfScoped` (i.e. `employeeId !== undefined`) is admin mode; a plain
+  // `employeeId ?? null` fallback would map BOTH admin mode (undefined) and
+  // self-scoped-but-unresolved mode (null) to the same `null` key segment.
+  // `enabled: false` only suppresses a new fetch, not a cache read, so a
+  // disabled self-scoped query mounted while `employeeId` is still resolving
+  // could otherwise read back an admin query's already-cached restaurant-wide
+  // payroll under the identical key — reopening the leak this hook exists to
+  // close for a dual-role viewer. Admin and self-scoped-unresolved must use
+  // distinct segments.
+  const queryKeyEmployeeId = isSelfScoped ? employeeId ?? 'pending' : 'admin';
+
   const { data: payrollPeriod, isLoading, error, refetch } = useQuery({
-    queryKey: ['payroll', restaurantId, startDate.toISOString(), endDate.toISOString(), timezone, employeeId ?? null],
+    queryKey: ['payroll', restaurantId, startDate.toISOString(), endDate.toISOString(), timezone, queryKeyEmployeeId],
     queryFn: async (): Promise<PayrollPeriod | null> => {
       if (!restaurantId) return null;
 
@@ -212,16 +223,21 @@ function usePayrollInternal(
       const splitIds = (approvedSplits || []).map(s => s.id);
 
       // Then fetch the tip split items for those splits, including split_date from tip_splits.
-      // Always issued (even with an empty splitIds list) so this stays one of the seven
-      // per-employee queries the self-scoped predicate threads into; `.in(..., [])` resolves
-      // to no rows without a client-side short-circuit.
-      const { data: tips, error: tipsError } = await scopeToEmployee(
-        supabase
-          .from('tip_split_items')
-          .select('employee_id, amount, tip_split_id, tip_splits(split_date)')
-          .in('tip_split_id', splitIds),
-        employeeId,
-      );
+      // Short-circuited locally when splitIds is empty: PostgREST's `.in()` has no
+      // client-side empty-array guard — it sends `tip_split_id=in.()` literally, which
+      // PostgREST rejects on a typed uuid column (postgrest/postgrest#641) rather than
+      // returning zero rows. Any payroll period with no approved/archived tip splits
+      // (the common case) would otherwise fail the entire payroll query. Same guard
+      // pattern as the identical query in src/pages/EmployeeTips.tsx.
+      const { data: tips, error: tipsError } = splitIds.length === 0
+        ? { data: [] as DBTipSplitItem[], error: null }
+        : await scopeToEmployee(
+            supabase
+              .from('tip_split_items')
+              .select('employee_id, amount, tip_split_id, tip_splits(split_date)')
+              .in('tip_split_id', splitIds),
+            employeeId,
+          );
 
       if (tipsError) throw tipsError;
 
@@ -386,6 +402,12 @@ function usePayrollInternal(
         overtimeAdjustments,
       );
     },
+    // The `!isSelfScoped || !!employeeId` clause is belt-and-suspenders: when
+    // self-scoped and employeeId is null, `restaurantId` was already forced
+    // to null for the inner `useEmployees` call above, so `employees.length`
+    // is already 0 and this query is already disabled without it. Kept for
+    // clarity — it states the invariant directly rather than relying on a
+    // reader re-deriving it from useEmployees' own gate.
     enabled: !!restaurantId && !!employees.length && (!isSelfScoped || !!employeeId),
     staleTime: 30000, // 30 seconds
     refetchOnWindowFocus: true,

--- a/src/hooks/usePayroll.tsx
+++ b/src/hooks/usePayroll.tsx
@@ -104,22 +104,35 @@ interface DBOvertimeAdjustment {
 }
 
 /**
- * Hook to fetch and calculate payroll for a given period
+ * Internal implementation shared by `usePayroll` (admin) and `useMyPayroll`
+ * (self-scoped) so an employee's own numbers can never drift from what the
+ * admin page shows for the same employee. `employeeId === undefined` means
+ * admin mode (no per-employee predicate, all employees fetched);
+ * `employeeId === null` means self-scoped mode with no id resolved yet
+ * (everything stays disabled); a string means self-scoped mode, filtered.
  */
-export function usePayroll(
+function usePayrollInternal(
   restaurantId: string | null,
   startDate: Date,
-  endDate: Date
+  endDate: Date,
+  employeeId?: string | null,
 ) {
+  const isSelfScoped = employeeId !== undefined;
+
   // Fetch ALL employees (including inactive) for historical payroll accuracy
-  // An employee deactivated today should still show their past work/salary
-  const { employees } = useEmployees(restaurantId, { status: 'all' });
+  // An employee deactivated today should still show their past work/salary.
+  // In self-scoped mode with no employeeId yet, pass restaurantId as null so
+  // useEmployees' own `enabled: !!restaurantId` gate stays closed too.
+  const { employees, loading: employeesLoading } = useEmployees(
+    isSelfScoped && !employeeId ? null : restaurantId,
+    { status: 'all', employeeId: employeeId ?? undefined },
+  );
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const { tz: timezone } = useRestaurantClock();
 
   const { data: payrollPeriod, isLoading, error, refetch } = useQuery({
-    queryKey: ['payroll', restaurantId, startDate.toISOString(), endDate.toISOString(), timezone],
+    queryKey: ['payroll', restaurantId, startDate.toISOString(), endDate.toISOString(), timezone, employeeId ?? null],
     queryFn: async (): Promise<PayrollPeriod | null> => {
       if (!restaurantId) return null;
 
@@ -147,17 +160,21 @@ export function usePayroll(
         timezone,
       );
       const { fetchStart, fetchEnd } = bufferPunchFetchRange(dayStart, dayEnd);
-      const { rows: punches, capped } = await fetchAllRows<DBTimePunch>((from, to) =>
-        supabase
+      const { rows: punches, capped } = await fetchAllRows<DBTimePunch>((from, to) => {
+        let query = supabase
           .from('time_punches')
           .select('*')
           .eq('restaurant_id', restaurantId)
           .gte('punch_time', fetchStart.toISOString())
-          .lte('punch_time', fetchEnd.toISOString())
+          .lte('punch_time', fetchEnd.toISOString());
+        if (employeeId) {
+          query = query.eq('employee_id', employeeId);
+        }
+        return query
           .order('punch_time', { ascending: true })
           .order('id')
-          .range(from, to),
-      );
+          .range(from, to);
+      });
 
       if (capped) {
         console.warn(
@@ -179,25 +196,34 @@ export function usePayroll(
       if (splitsError) throw splitsError;
 
       const splitIds = (approvedSplits || []).map(s => s.id);
-      
-      // Then fetch the tip split items for those splits, including split_date from tip_splits
-      const { data: tips, error: tipsError } = splitIds.length > 0
-        ? await supabase
-            .from('tip_split_items')
-            .select('employee_id, amount, tip_split_id, tip_splits(split_date)')
-            .in('tip_split_id', splitIds)
-        : { data: [], error: null };
+
+      // Then fetch the tip split items for those splits, including split_date from tip_splits.
+      // Always issued (even with an empty splitIds list) so this stays one of the seven
+      // per-employee queries the self-scoped predicate threads into; `.in(..., [])` resolves
+      // to no rows without a client-side short-circuit.
+      let tipSplitItemsQuery = supabase
+        .from('tip_split_items')
+        .select('employee_id, amount, tip_split_id, tip_splits(split_date)')
+        .in('tip_split_id', splitIds);
+      if (employeeId) {
+        tipSplitItemsQuery = tipSplitItemsQuery.eq('employee_id', employeeId);
+      }
+      const { data: tips, error: tipsError } = await tipSplitItemsQuery;
 
       if (tipsError) throw tipsError;
 
       // Fetch manual payments (per-job contractor payments) for the period
-      const { data: manualPaymentsData, error: manualPaymentsError } = await supabase
+      let manualPaymentsQuery = supabase
         .from('daily_labor_allocations')
         .select('*')
         .eq('restaurant_id', restaurantId)
         .eq('source', 'per-job')
         .gte('date', toDateOnlyString(startDate))
         .lte('date', toDateOnlyString(endDate));
+      if (employeeId) {
+        manualPaymentsQuery = manualPaymentsQuery.eq('employee_id', employeeId);
+      }
+      const { data: manualPaymentsData, error: manualPaymentsError } = await manualPaymentsQuery;
 
       if (manualPaymentsError) throw manualPaymentsError;
 
@@ -218,22 +244,30 @@ export function usePayroll(
       });
 
       // Fetch tips from tip_split_items and employee_tips for the period
-      const { data: employeeTips, error: employeeTipsError } = await supabase
+      let employeeTipsQuery = supabase
         .from('employee_tips')
         .select('employee_id, tip_amount, tip_date')
         .eq('restaurant_id', restaurantId)
         .gte('tip_date', toDateOnlyString(startDate))
         .lte('tip_date', toDateOnlyString(endDate));
+      if (employeeId) {
+        employeeTipsQuery = employeeTipsQuery.eq('employee_id', employeeId);
+      }
+      const { data: employeeTips, error: employeeTipsError } = await employeeTipsQuery;
 
       if (employeeTipsError) throw employeeTipsError;
 
       // Fetch tip payouts (cash already paid out) for the period
-      const { data: tipPayoutsData, error: tipPayoutsError } = await supabase
+      let tipPayoutsQuery = supabase
         .from('tip_payouts')
         .select('employee_id, amount')
         .eq('restaurant_id', restaurantId)
         .gte('payout_date', toDateOnlyString(startDate))
         .lte('payout_date', toDateOnlyString(endDate));
+      if (employeeId) {
+        tipPayoutsQuery = tipPayoutsQuery.eq('employee_id', employeeId);
+      }
+      const { data: tipPayoutsData, error: tipPayoutsError } = await tipPayoutsQuery;
 
       if (tipPayoutsError) throw tipPayoutsError;
 
@@ -289,12 +323,16 @@ export function usePayroll(
       }
 
       // Fetch overtime adjustments for the period
-      const { data: otAdjData, error: otAdjError } = await supabase
+      let otAdjQuery = supabase
         .from('overtime_adjustments')
         .select('employee_id, punch_date, adjustment_type, hours, reason')
         .eq('restaurant_id', restaurantId)
         .gte('punch_date', toDateOnlyString(startDate))
         .lte('punch_date', toDateOnlyString(endDate));
+      if (employeeId) {
+        otAdjQuery = otAdjQuery.eq('employee_id', employeeId);
+      }
+      const { data: otAdjData, error: otAdjError } = await otAdjQuery;
 
       if (otAdjError) {
         console.error('Error fetching overtime adjustments:', otAdjError);
@@ -339,7 +377,7 @@ export function usePayroll(
         overtimeAdjustments,
       );
     },
-    enabled: !!restaurantId && !!employees.length,
+    enabled: !!restaurantId && !!employees.length && (!isSelfScoped || !!employeeId),
     staleTime: 30000, // 30 seconds
     refetchOnWindowFocus: true,
   });
@@ -481,7 +519,7 @@ export function usePayroll(
 
   return {
     payrollPeriod,
-    loading: isLoading,
+    loading: isLoading || employeesLoading,
     error,
     refetch,
     addManualPayment: addManualPaymentMutation.mutate,
@@ -491,4 +529,29 @@ export function usePayroll(
     adjustOvertime: adjustOvertimeMutation.mutate,
     isAdjustingOvertime: adjustOvertimeMutation.isPending,
   };
+}
+
+/**
+ * Hook to fetch and calculate payroll for a given period (admin — all employees).
+ */
+export function usePayroll(
+  restaurantId: string | null,
+  startDate: Date,
+  endDate: Date
+) {
+  return usePayrollInternal(restaurantId, startDate, endDate);
+}
+
+/**
+ * Self-scoped payroll for a single employee. `employeeId: null` means the
+ * caller's own employee id hasn't resolved yet — the hook stays fully
+ * disabled (no queries issued) until it does.
+ */
+export function useMyPayroll(
+  restaurantId: string | null,
+  employeeId: string | null,
+  startDate: Date,
+  endDate: Date
+) {
+  return usePayrollInternal(restaurantId, startDate, endDate, employeeId);
 }

--- a/src/hooks/useShifts.tsx
+++ b/src/hooks/useShifts.tsx
@@ -45,13 +45,20 @@ export function buildShiftChangeDescription(
   return description;
 }
 
-export function useShifts(
+function useShiftsQuery(
   restaurantId: string | null,
   startDate?: Date,
-  endDate?: Date
+  endDate?: Date,
+  employeeId?: string | null
 ): { shifts: Shift[]; loading: boolean; error: Error | null; refetch: () => void } {
   const { data, isLoading, error, refetch } = useQuery({
-    queryKey: ['shifts', restaurantId, startDate?.toISOString(), endDate?.toISOString()],
+    queryKey: [
+      'shifts',
+      restaurantId,
+      startDate?.toISOString(),
+      endDate?.toISOString(),
+      employeeId ?? 'all',
+    ],
     queryFn: async () => {
       if (!restaurantId) return [];
 
@@ -59,6 +66,10 @@ export function useShifts(
         .from('shifts')
         .select('*, employee:employees(*)')
         .eq('restaurant_id', restaurantId);
+
+      if (employeeId) {
+        query = query.eq('employee_id', employeeId);
+      }
 
       if (startDate) {
         query = query.gte('start_time', startDate.toISOString());
@@ -73,7 +84,7 @@ export function useShifts(
 
       return data.map(toTypedShift);
     },
-    enabled: !!restaurantId,
+    enabled: !!restaurantId && (employeeId === undefined || !!employeeId),
     staleTime: 30000,
     refetchOnWindowFocus: true,
     refetchOnMount: true,
@@ -87,6 +98,30 @@ export function useShifts(
     // reads as "you are not working this week".
     refetch,
   };
+}
+
+export function useShifts(
+  restaurantId: string | null,
+  startDate?: Date,
+  endDate?: Date
+): { shifts: Shift[]; loading: boolean; error: Error | null; refetch: () => void } {
+  return useShiftsQuery(restaurantId, startDate, endDate);
+}
+
+/**
+ * Self-scoped variant of `useShifts` for employee-facing pages. Applies
+ * `.eq('employee_id', employeeId)` server-side and stays disabled until
+ * `employeeId` is resolved (non-null) — an optional filter that silently
+ * degrades to "no filter" while the caller is still resolving the current
+ * employee would re-open the restaurant-wide read this hook exists to close.
+ */
+export function useMyShifts(
+  restaurantId: string | null,
+  employeeId: string | null,
+  startDate?: Date,
+  endDate?: Date
+): { shifts: Shift[]; loading: boolean; error: Error | null; refetch: () => void } {
+  return useShiftsQuery(restaurantId, startDate, endDate, employeeId);
 }
 
 type ShiftInput = Omit<Shift, 'id' | 'created_at' | 'updated_at' | 'employee'>;

--- a/src/hooks/useShifts.tsx
+++ b/src/hooks/useShifts.tsx
@@ -45,19 +45,36 @@ export function buildShiftChangeDescription(
   return description;
 }
 
+interface UseShiftsResult {
+  shifts: Shift[];
+  loading: boolean;
+  error: Error | null;
+  refetch: () => void;
+}
+
 function useShiftsQuery(
   restaurantId: string | null,
   startDate?: Date,
   endDate?: Date,
   employeeId?: string | null
-): { shifts: Shift[]; loading: boolean; error: Error | null; refetch: () => void } {
+): UseShiftsResult {
+  // `employeeId === undefined` is admin mode (useShifts); `null` is
+  // self-scoped mode with the id not yet resolved (useMyShifts, disabled
+  // below). These must map to DIFFERENT key segments — collapsing both
+  // through a single `?? 'all'` fallback would let a self-scoped query,
+  // while still disabled and waiting on `employeeId`, read back whatever an
+  // admin query already cached under the same key (`enabled: false` only
+  // suppresses a new fetch, not a cache read), briefly serving
+  // restaurant-wide shifts to a dual-role viewer's self-scoped page.
+  const queryKeyEmployeeId = employeeId === undefined ? 'all' : employeeId ?? 'pending';
+
   const { data, isLoading, error, refetch } = useQuery({
     queryKey: [
       'shifts',
       restaurantId,
       startDate?.toISOString(),
       endDate?.toISOString(),
-      employeeId ?? 'all',
+      queryKeyEmployeeId,
     ],
     queryFn: async () => {
       if (!restaurantId) return [];
@@ -104,7 +121,7 @@ export function useShifts(
   restaurantId: string | null,
   startDate?: Date,
   endDate?: Date
-): { shifts: Shift[]; loading: boolean; error: Error | null; refetch: () => void } {
+): UseShiftsResult {
   return useShiftsQuery(restaurantId, startDate, endDate);
 }
 
@@ -120,7 +137,7 @@ export function useMyShifts(
   employeeId: string | null,
   startDate?: Date,
   endDate?: Date
-): { shifts: Shift[]; loading: boolean; error: Error | null; refetch: () => void } {
+): UseShiftsResult {
   return useShiftsQuery(restaurantId, startDate, endDate, employeeId);
 }
 

--- a/src/pages/AvailableShiftsPage.tsx
+++ b/src/pages/AvailableShiftsPage.tsx
@@ -28,7 +28,7 @@ import { useRestaurantClock } from '@/hooks/useRestaurantClock';
 import { useCurrentEmployee } from '@/hooks/useCurrentEmployee';
 import { useAvailableShifts, AvailableShiftItem } from '@/hooks/useAvailableShifts';
 import { useOpenShiftClaims, useClaimOpenShift } from '@/hooks/useOpenShiftClaims';
-import { useShifts } from '@/hooks/useShifts';
+import { useMyShifts } from '@/hooks/useShifts';
 import { useAcceptShiftTrade } from '@/hooks/useShiftTrades';
 import { useToast } from '@/hooks/use-toast';
 import { getAreaMismatch, type AreaMismatch } from '@/lib/shiftTradeArea';
@@ -247,11 +247,15 @@ export default function AvailableShiftsPage() {
   const { mutate: acceptTrade, isPending: isAcceptingTrade } = useAcceptShiftTrade();
 
   // Employee's existing shifts for conflict detection
-  const { shifts: myShifts } = useShifts(restaurantId, weekStart, weekEnd);
+  const { shifts: myShifts, loading: myShiftsLoading } = useMyShifts(
+    restaurantId,
+    currentEmployee?.id ?? null,
+    weekStart,
+    weekEnd,
+  );
   const employeeShifts = useMemo(() => {
-    if (!currentEmployee) return [];
-    return myShifts.filter((s) => s.employee_id === currentEmployee.id && s.status !== 'cancelled');
-  }, [myShifts, currentEmployee]);
+    return myShifts.filter((s) => s.status !== 'cancelled');
+  }, [myShifts]);
 
   // Conflict map: template_id-date -> boolean
   const conflictMap = useMemo(() => {
@@ -324,7 +328,7 @@ export default function AvailableShiftsPage() {
   if (empLoading) return <EmployeePageSkeleton />;
   if (!currentEmployee) return <EmployeeNotLinkedState />;
 
-  const loading = feedLoading;
+  const loading = feedLoading || myShiftsLoading;
 
   return (
     <div className="space-y-6">

--- a/src/pages/EmployeePay.tsx
+++ b/src/pages/EmployeePay.tsx
@@ -5,7 +5,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { useRestaurantContext } from '@/contexts/RestaurantContext';
 import { useCurrentEmployee } from '@/hooks/useCurrentEmployee';
-import { usePayroll } from '@/hooks/usePayroll';
+import { useMyPayroll } from '@/hooks/usePayroll';
 import { usePeriodNavigation } from '@/hooks/usePeriodNavigation';
 import { formatCurrency, formatHours } from '@/utils/payrollCalculations';
 import {
@@ -55,7 +55,12 @@ const EmployeePay = () => {
   } = usePeriodNavigation({ includeLast2Weeks: true });
 
   const { currentEmployee, loading: employeeLoading } = useCurrentEmployee(restaurantId);
-  const { payrollPeriod, loading: payrollLoading, error } = usePayroll(restaurantId, startDate, endDate);
+  const { payrollPeriod, loading: payrollLoading, error } = useMyPayroll(
+    restaurantId,
+    currentEmployee?.id ?? null,
+    startDate,
+    endDate,
+  );
 
   // Find current employee's payroll data
   const myPayroll = useMemo(() => {

--- a/src/pages/EmployeeSchedule.tsx
+++ b/src/pages/EmployeeSchedule.tsx
@@ -6,7 +6,7 @@ import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useRestaurantContext } from '@/contexts/RestaurantContext';
 import { useCurrentEmployee } from '@/hooks/useCurrentEmployee';
-import { useShifts } from '@/hooks/useShifts';
+import { useMyShifts } from '@/hooks/useShifts';
 import { useWeekScheduleStatus, useWeekRetractionReason } from '@/hooks/useSchedulePublish';
 import { TradeRequestDialog } from '@/components/schedule/TradeRequestDialog';
 import { MyShiftTradesCard } from '@/components/schedule/MyShiftTradesCard';
@@ -66,17 +66,11 @@ const EmployeeSchedule = () => {
 
   const { currentEmployee, loading: employeeLoading } = useCurrentEmployee(restaurantId);
   const {
-    shifts,
+    shifts: myShifts,
     loading: shiftsLoading,
     error: shiftsError,
     refetch: refetchShifts,
-  } = useShifts(restaurantId, currentWeekStart, weekEnd);
-
-  // Filter shifts to only show current employee's shifts
-  const myShifts = useMemo(() => {
-    if (!currentEmployee) return [];
-    return shifts.filter((shift) => shift.employee_id === currentEmployee.id);
-  }, [shifts, currentEmployee]);
+  } = useMyShifts(restaurantId, currentEmployee?.id ?? null, currentWeekStart, weekEnd);
 
   const restaurantTimezone = safeTz(selectedRestaurant?.restaurant?.timezone);
 
@@ -89,9 +83,10 @@ const EmployeeSchedule = () => {
     publishedCount,
     draftCount,
     loading: statusLoading,
-    // `employeeLoading` too, not just `shiftsLoading`: myShifts is filtered by
-    // `currentEmployee`, so it is empty until that resolves regardless of
-    // whether the shifts themselves have landed.
+    // `employeeLoading` too, not just `shiftsLoading`: `useMyShifts` stays
+    // disabled until `employeeId` resolves, and a disabled query reports
+    // `isLoading: false` — so `shiftsLoading` alone would race ahead of
+    // `currentEmployee` instead of waiting for it.
   } = useWeekScheduleStatus(
     restaurantId,
     currentWeekStart,

--- a/supabase/functions/_shared/periodMetrics.ts
+++ b/supabase/functions/_shared/periodMetrics.ts
@@ -328,3 +328,55 @@ export function calculatePeriodMetrics(
     benchmarks,
   };
 }
+
+// ===== LABOR-COMPONENT REDACTION =====
+
+/**
+ * Result of redactLaborFields — costs/benchmarks narrowed to food-only, and
+ * profitability dropped entirely, when the caller lacks labor access.
+ */
+export interface RedactedLaborFields {
+  costs: CostBreakdown | Pick<CostBreakdown, 'food_cost' | 'food_cost_percentage'>;
+  profitability?: ProfitabilityMetrics;
+  benchmarks: BenchmarkStatus | Pick<BenchmarkStatus, 'food_cost_status' | 'target_food_cost'>;
+  laborOmittedReason?: string;
+}
+
+/**
+ * Strips labor-derived fields out of a PeriodMetricsResult for a caller who
+ * lacks view:scheduling/view:payroll access. Used by get_kpis
+ * (ai-execute-tool), which runs under the caller's forwarded JWT — without
+ * that capability, RLS truncates time_punches to own-row, so labor_cost
+ * (and everything downstream of it: prime_cost, profit_margin, the
+ * labor/prime benchmark statuses) would otherwise silently read as if it
+ * were a complete restaurant-wide figure instead of one person's punches.
+ *
+ * food_cost is unaffected by that truncation (it doesn't come from
+ * time_punches), so it — and only it — passes through when access is
+ * missing.
+ */
+export function redactLaborFields(
+  metrics: Pick<PeriodMetricsResult, 'costs' | 'profitability' | 'benchmarks'>,
+  hasLaborAccess: boolean
+): RedactedLaborFields {
+  if (hasLaborAccess) {
+    return {
+      costs: metrics.costs,
+      profitability: metrics.profitability,
+      benchmarks: metrics.benchmarks,
+    };
+  }
+
+  return {
+    costs: {
+      food_cost: metrics.costs.food_cost,
+      food_cost_percentage: metrics.costs.food_cost_percentage,
+    },
+    benchmarks: {
+      food_cost_status: metrics.benchmarks.food_cost_status,
+      target_food_cost: metrics.benchmarks.target_food_cost,
+    },
+    laborOmittedReason:
+      'Labor cost, prime cost, and profitability figures require view:scheduling or view:payroll access.',
+  };
+}

--- a/supabase/functions/_shared/tools-registry.ts
+++ b/supabase/functions/_shared/tools-registry.ts
@@ -994,6 +994,25 @@ export async function hasSchedulingOrPayrollCapability(
     }),
   ]);
 
+  // An RPC failure here must not disappear silently: without logging it, a
+  // genuine infra failure (e.g. the RPC unreachable) is indistinguishable
+  // from a legitimate denial once it coerces to `false` below, and the
+  // caller reports a plain permission-denied error with no trace of the
+  // real cause. Fail closed (deny) either way — this gates security-
+  // sensitive tools/RLS-adjacent reads, so an infra error must not fail open.
+  if (scheduling.error) {
+    console.error('hasSchedulingOrPayrollCapability: view:scheduling RPC failed', {
+      restaurantId,
+      error: scheduling.error,
+    });
+  }
+  if (payroll.error) {
+    console.error('hasSchedulingOrPayrollCapability: view:payroll RPC failed', {
+      restaurantId,
+      error: payroll.error,
+    });
+  }
+
   return Boolean(scheduling.data) || Boolean(payroll.data);
 }
 

--- a/supabase/functions/_shared/tools-registry.ts
+++ b/supabase/functions/_shared/tools-registry.ts
@@ -964,7 +964,7 @@ export function requiredRoleFor(toolName: string): 'staff' | 'manager' | 'owner'
  */
 export const CAPABILITY_GATED_TOOLS = ['get_labor_costs', 'get_schedule_overview'] as const;
 
-interface CapabilityCheckClient {
+export interface CapabilityCheckClient {
   rpc: (
     fn: string,
     args: { p_restaurant_id: string; p_capability: string }
@@ -983,15 +983,24 @@ export async function hasSchedulingOrPayrollCapability(
   restaurantId: string,
   supabase: CapabilityCheckClient
 ): Promise<boolean> {
+  // `.catch()` on each call (rather than letting Promise.all reject) so a
+  // rejected RPC promise — e.g. a client that throws instead of resolving
+  // with an `error` field — still lands in the logged deny path below
+  // instead of escaping as an unhandled rejection that would bypass it.
+  const toResult = (err: unknown) => ({ data: null, error: err });
   const [scheduling, payroll] = await Promise.all([
-    supabase.rpc('user_has_capability', {
-      p_restaurant_id: restaurantId,
-      p_capability: 'view:scheduling',
-    }),
-    supabase.rpc('user_has_capability', {
-      p_restaurant_id: restaurantId,
-      p_capability: 'view:payroll',
-    }),
+    supabase
+      .rpc('user_has_capability', {
+        p_restaurant_id: restaurantId,
+        p_capability: 'view:scheduling',
+      })
+      .catch(toResult),
+    supabase
+      .rpc('user_has_capability', {
+        p_restaurant_id: restaurantId,
+        p_capability: 'view:payroll',
+      })
+      .catch(toResult),
   ]);
 
   // An RPC failure here must not disappear silently: without logging it, a

--- a/supabase/functions/_shared/tools-registry.ts
+++ b/supabase/functions/_shared/tools-registry.ts
@@ -998,6 +998,16 @@ export async function hasSchedulingOrPayrollCapability(
 }
 
 /**
+ * Type guard for CAPABILITY_GATED_TOOLS membership. Shared by
+ * canUseCapabilityGatedTool and by the ai-execute-tool dispatcher, which
+ * needs the same check to decide whether to call canUseTool or this file's
+ * capability path at all — kept in one place so the two never drift.
+ */
+export function isCapabilityGatedTool(toolName: string): toolName is (typeof CAPABILITY_GATED_TOOLS)[number] {
+  return (CAPABILITY_GATED_TOOLS as readonly string[]).includes(toolName);
+}
+
+/**
  * Resolves access for a CAPABILITY_GATED_TOOLS entry. Returns false
  * immediately — with no RPC call — for any tool not in that list.
  */
@@ -1006,7 +1016,7 @@ export async function canUseCapabilityGatedTool(
   restaurantId: string,
   supabase: CapabilityCheckClient
 ): Promise<boolean> {
-  if (!(CAPABILITY_GATED_TOOLS as readonly string[]).includes(toolName)) {
+  if (!isCapabilityGatedTool(toolName)) {
     return false;
   }
 

--- a/supabase/functions/_shared/tools-registry.ts
+++ b/supabase/functions/_shared/tools-registry.ts
@@ -885,6 +885,14 @@ export function canUseTool(toolName: string, userRole: string): boolean {
     return false;
   }
 
+  // get_labor_costs / get_schedule_overview are NOT in basicTools: they read
+  // restaurant-wide labor/schedule data, gated on view:scheduling OR
+  // view:payroll (see CAPABILITY_GATED_TOOLS / canUseCapabilityGatedTool
+  // below). That capability set doesn't collapse to a static role list —
+  // e.g. chef holds view:scheduling but not manager/owner — so canUseTool
+  // always denies them here; the dispatcher must call
+  // canUseCapabilityGatedTool for these two instead.
+
   // Navigation and basic query tools available to all users
   const basicTools = [
     'navigate',
@@ -893,8 +901,6 @@ export function canUseTool(toolName: string, userRole: string): boolean {
     'get_recipe_analytics',
     'get_sales_summary',
     'get_inventory_transactions',
-    'get_labor_costs',           // Labor costs visible to all (aggregate data)
-    'get_schedule_overview',     // Schedule overview visible to all
     'get_proactive_insights',    // Proactive insights for all users
     'get_daily_sales_totals'     // Daily revenue totals visible to all
   ];
@@ -944,4 +950,52 @@ export function requiredRoleFor(toolName: string): 'staff' | 'manager' | 'owner'
   if (canUseTool(toolName, 'staff')) return 'staff';
   if (canUseTool(toolName, 'manager')) return 'manager';
   return 'owner';
+}
+
+/**
+ * Tools whose access is determined by the view:scheduling / view:payroll
+ * capability (resolved per-restaurant via the `user_has_capability` RPC)
+ * rather than by role. These read the same restaurant-wide labor/schedule
+ * data as the RLS-protected tables behind them (shifts, time_punches,
+ * employee_compensation_history, etc.) — see
+ * supabase/migrations/20260805130000_self_scope_employee_reads.sql — so the
+ * dispatcher gate must match that RLS predicate instead of a second,
+ * independently-maintained role list.
+ */
+export const CAPABILITY_GATED_TOOLS = ['get_labor_costs', 'get_schedule_overview'] as const;
+
+interface CapabilityCheckClient {
+  rpc: (
+    fn: string,
+    args: { p_restaurant_id: string; p_capability: string }
+  ) => Promise<{ data: boolean | null; error: unknown }>;
+}
+
+/**
+ * Resolves access for a CAPABILITY_GATED_TOOLS entry via the
+ * `user_has_capability` RPC (same function the RLS policies call), OR'ing
+ * view:scheduling and view:payroll. Returns false immediately — with no RPC
+ * call — for any tool not in CAPABILITY_GATED_TOOLS.
+ */
+export async function canUseCapabilityGatedTool(
+  toolName: string,
+  restaurantId: string,
+  supabase: CapabilityCheckClient
+): Promise<boolean> {
+  if (!(CAPABILITY_GATED_TOOLS as readonly string[]).includes(toolName)) {
+    return false;
+  }
+
+  const [scheduling, payroll] = await Promise.all([
+    supabase.rpc('user_has_capability', {
+      p_restaurant_id: restaurantId,
+      p_capability: 'view:scheduling',
+    }),
+    supabase.rpc('user_has_capability', {
+      p_restaurant_id: restaurantId,
+      p_capability: 'view:payroll',
+    }),
+  ]);
+
+  return Boolean(scheduling.data) || Boolean(payroll.data);
 }

--- a/supabase/functions/_shared/tools-registry.ts
+++ b/supabase/functions/_shared/tools-registry.ts
@@ -972,20 +972,17 @@ interface CapabilityCheckClient {
 }
 
 /**
- * Resolves access for a CAPABILITY_GATED_TOOLS entry via the
- * `user_has_capability` RPC (same function the RLS policies call), OR'ing
- * view:scheduling and view:payroll. Returns false immediately — with no RPC
- * call — for any tool not in CAPABILITY_GATED_TOOLS.
+ * Resolves view:scheduling OR view:payroll for the calling user via the
+ * `user_has_capability` RPC — the same function the RLS policies behind
+ * shifts/time_punches/employee_compensation_history/etc. call. Shared by
+ * canUseCapabilityGatedTool and by get_kpis's labor-component gate (get_kpis
+ * itself stays a basic tool, but its labor/prime-cost fields must not be
+ * computed from an RLS-truncated data set for a caller who lacks this).
  */
-export async function canUseCapabilityGatedTool(
-  toolName: string,
+export async function hasSchedulingOrPayrollCapability(
   restaurantId: string,
   supabase: CapabilityCheckClient
 ): Promise<boolean> {
-  if (!(CAPABILITY_GATED_TOOLS as readonly string[]).includes(toolName)) {
-    return false;
-  }
-
   const [scheduling, payroll] = await Promise.all([
     supabase.rpc('user_has_capability', {
       p_restaurant_id: restaurantId,
@@ -998,4 +995,20 @@ export async function canUseCapabilityGatedTool(
   ]);
 
   return Boolean(scheduling.data) || Boolean(payroll.data);
+}
+
+/**
+ * Resolves access for a CAPABILITY_GATED_TOOLS entry. Returns false
+ * immediately — with no RPC call — for any tool not in that list.
+ */
+export async function canUseCapabilityGatedTool(
+  toolName: string,
+  restaurantId: string,
+  supabase: CapabilityCheckClient
+): Promise<boolean> {
+  if (!(CAPABILITY_GATED_TOOLS as readonly string[]).includes(toolName)) {
+    return false;
+  }
+
+  return hasSchedulingOrPayrollCapability(restaurantId, supabase);
 }

--- a/supabase/functions/ai-execute-tool/index.ts
+++ b/supabase/functions/ai-execute-tool/index.ts
@@ -3674,6 +3674,13 @@ serve(async (req) => {
     // tables (20260805130000_self_scope_employee_reads.sql), resolved via the
     // user_has_capability RPC rather than a hard-coded role — canUseTool
     // always denies these two, so they get their own branch here.
+    //
+    // Sweep of the other forwarded-JWT (anon key + Authorization header)
+    // consumers of the six self-scoped tables in supabase/functions/:
+    // generate-schedule and notify-schedule-published already require
+    // owner/manager via their own role checks; send-shift-notification reads
+    // `shifts` through a SUPABASE_SERVICE_ROLE_KEY client (RLS bypassed
+    // entirely, not forwarded-JWT), so it's unaffected by this change.
     if ((CAPABILITY_GATED_TOOLS as readonly string[]).includes(tool_name)) {
       const allowed = await canUseCapabilityGatedTool(tool_name, restaurant_id, supabase);
       if (!allowed) {

--- a/supabase/functions/ai-execute-tool/index.ts
+++ b/supabase/functions/ai-execute-tool/index.ts
@@ -2,7 +2,7 @@ import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { corsHeaders } from "../_shared/cors.ts";
-import { canUseTool, requiredRoleFor, CAPABILITY_GATED_TOOLS, canUseCapabilityGatedTool } from "../_shared/tools-registry.ts";
+import { canUseTool, requiredRoleFor, isCapabilityGatedTool, canUseCapabilityGatedTool } from "../_shared/tools-registry.ts";
 import { MODELS } from "../_shared/model-router.ts";
 import { 
   fetchInventoryTransactions,
@@ -3681,7 +3681,7 @@ serve(async (req) => {
     // owner/manager via their own role checks; send-shift-notification reads
     // `shifts` through a SUPABASE_SERVICE_ROLE_KEY client (RLS bypassed
     // entirely, not forwarded-JWT), so it's unaffected by this change.
-    if ((CAPABILITY_GATED_TOOLS as readonly string[]).includes(tool_name)) {
+    if (isCapabilityGatedTool(tool_name)) {
       const allowed = await canUseCapabilityGatedTool(tool_name, restaurant_id, supabase);
       if (!allowed) {
         return new Response(

--- a/supabase/functions/ai-execute-tool/index.ts
+++ b/supabase/functions/ai-execute-tool/index.ts
@@ -191,44 +191,52 @@ async function executeGetKpis(
   // A caller without that capability would otherwise silently get a
   // labor total computed from only their own punches — check up front so the
   // labor/prime-cost fields can be omitted instead of misreported below.
-  const hasLaborAccess = await hasSchedulingOrPayrollCapability(restaurantId, supabase);
-
+  //
+  // Run this alongside the sales/adjustments/food-cost fetches (none of which
+  // depend on it — only the labor block further down does) rather than
+  // awaiting it first, so it doesn't add a full extra round trip onto the
+  // front of an already-sequential fetch chain in a CPU-limited edge function.
   // ====== FETCH DATA FROM DATABASE ======
-  
-  // Fetch sales (excluding adjustments)
-  const { data: sales, error: salesError } = await supabase
-    .from('unified_sales')
-    .select('id, total_price, item_type, parent_sale_id, is_categorized, chart_account:chart_of_accounts!category_id(account_type, account_subtype)')
-    .eq('restaurant_id', restaurantId)
-    .gte('sale_date', startDateStr)
-    .lte('sale_date', endDateStr)
-    .is('adjustment_type', null);
 
+  const [hasLaborAccess, salesResult, adjustmentsResult, foodCostResult] = await Promise.all([
+    hasSchedulingOrPayrollCapability(restaurantId, supabase),
+    // Fetch sales (excluding adjustments)
+    supabase
+      .from('unified_sales')
+      .select('id, total_price, item_type, parent_sale_id, is_categorized, chart_account:chart_of_accounts!category_id(account_type, account_subtype)')
+      .eq('restaurant_id', restaurantId)
+      .gte('sale_date', startDateStr)
+      .lte('sale_date', endDateStr)
+      .is('adjustment_type', null),
+    // Fetch adjustments separately
+    supabase
+      .from('unified_sales')
+      .select('adjustment_type, total_price')
+      .eq('restaurant_id', restaurantId)
+      .gte('sale_date', startDateStr)
+      .lte('sale_date', endDateStr)
+      .not('adjustment_type', 'is', null),
+    // Fetch food costs (COGS)
+    supabase
+      .from('inventory_transactions')
+      .select('total_cost')
+      .eq('restaurant_id', restaurantId)
+      .eq('transaction_type', 'usage')
+      .gte('created_at', startDateStr)
+      .lte('created_at', endDateStr + 'T23:59:59.999Z'),
+  ]);
+
+  const { data: sales, error: salesError } = salesResult;
   if (salesError) {
     throw new Error(`Failed to fetch sales: ${salesError.message}`);
   }
 
-  // Fetch adjustments separately
-  const { data: adjustments, error: adjustmentsError } = await supabase
-    .from('unified_sales')
-    .select('adjustment_type, total_price')
-    .eq('restaurant_id', restaurantId)
-    .gte('sale_date', startDateStr)
-    .lte('sale_date', endDateStr)
-    .not('adjustment_type', 'is', null);
-
+  const { data: adjustments, error: adjustmentsError } = adjustmentsResult;
   if (adjustmentsError) {
     throw new Error(`Failed to fetch adjustments: ${adjustmentsError.message}`);
   }
 
-  // Fetch food costs (COGS)
-  const { data: foodCostData, error: foodCostError } = await supabase
-    .from('inventory_transactions')
-    .select('total_cost')
-    .eq('restaurant_id', restaurantId)
-    .eq('transaction_type', 'usage')
-    .gte('created_at', startDateStr)
-    .lte('created_at', endDateStr + 'T23:59:59.999Z');
+  const { data: foodCostData, error: foodCostError } = foodCostResult;
 
   if (foodCostError) {
     throw new Error(`Failed to fetch food costs: ${foodCostError.message}`);

--- a/supabase/functions/ai-execute-tool/index.ts
+++ b/supabase/functions/ai-execute-tool/index.ts
@@ -2,7 +2,7 @@ import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { corsHeaders } from "../_shared/cors.ts";
-import { canUseTool, requiredRoleFor } from "../_shared/tools-registry.ts";
+import { canUseTool, requiredRoleFor, CAPABILITY_GATED_TOOLS, canUseCapabilityGatedTool } from "../_shared/tools-registry.ts";
 import { MODELS } from "../_shared/model-router.ts";
 import { 
   fetchInventoryTransactions,
@@ -180,9 +180,18 @@ async function executeGetKpis(
   const { period = 'month', start_date, end_date } = args;
 
   // Import shared calculation module
-  const { calculatePeriodMetrics } = await import('../_shared/periodMetrics.ts');
+  const { calculatePeriodMetrics, redactLaborFields } = await import('../_shared/periodMetrics.ts');
+  const { hasSchedulingOrPayrollCapability } = await import('../_shared/tools-registry.ts');
 
   const { startDate, endDate, startDateStr, endDateStr } = calculateDateRange(period, start_date, end_date);
+
+  // This function runs under the caller's forwarded JWT (RLS applies), and
+  // time_punches is now self-scoped to own-row unless the caller holds
+  // view:scheduling or view:payroll (20260805130000_self_scope_employee_reads.sql).
+  // A caller without that capability would otherwise silently get a
+  // labor total computed from only their own punches — check up front so the
+  // labor/prime-cost fields can be omitted instead of misreported below.
+  const hasLaborAccess = await hasSchedulingOrPayrollCapability(restaurantId, supabase);
 
   // ====== FETCH DATA FROM DATABASE ======
   
@@ -225,47 +234,53 @@ async function executeGetKpis(
     throw new Error(`Failed to fetch food costs: ${foodCostError.message}`);
   }
 
-  // Fetch labor costs using time_punches + employees (same as Dashboard)
-  // Import labor calculation module
-  const { calculateActualLaborCost, LABOR_FETCH_LOOKAHEAD_HOURS } = await import('../_shared/laborCalculations.ts');
+  // Fetch labor costs using time_punches + employees (same as Dashboard) —
+  // only when the caller can actually see restaurant-wide punches. Skipping
+  // the fetch entirely (rather than fetching and computing anyway) avoids
+  // ever deriving a labor total from an RLS-truncated own-row-only result.
+  let laborCostData: { total_labor_cost: number }[] = [];
+  if (hasLaborAccess) {
+    // Import labor calculation module
+    const { calculateActualLaborCost, LABOR_FETCH_LOOKAHEAD_HOURS } = await import('../_shared/laborCalculations.ts');
 
-  // Fetch time punches for the period, widened by an overnight look-ahead so a
-  // shift whose clock_out lands just after endDate still pairs whole.
-  // calculateActualLaborCost attributes hours by clock-in day and drops
-  // out-of-window periods, so this never double-counts.
-  const { data: timePunches, error: punchesError } = await supabase
-    .from('time_punches')
-    .select('id, employee_id, restaurant_id, punch_time, punch_type')
-    .eq('restaurant_id', restaurantId)
-    .gte('punch_time', startDate.toISOString())
-    .lte('punch_time', new Date(endDate.getTime() + LABOR_FETCH_LOOKAHEAD_HOURS * 3600 * 1000).toISOString())
-    .order('punch_time', { ascending: true });
+    // Fetch time punches for the period, widened by an overnight look-ahead so a
+    // shift whose clock_out lands just after endDate still pairs whole.
+    // calculateActualLaborCost attributes hours by clock-in day and drops
+    // out-of-window periods, so this never double-counts.
+    const { data: timePunches, error: punchesError } = await supabase
+      .from('time_punches')
+      .select('id, employee_id, restaurant_id, punch_time, punch_type')
+      .eq('restaurant_id', restaurantId)
+      .gte('punch_time', startDate.toISOString())
+      .lte('punch_time', new Date(endDate.getTime() + LABOR_FETCH_LOOKAHEAD_HOURS * 3600 * 1000).toISOString())
+      .order('punch_time', { ascending: true });
 
-  if (punchesError) {
-    throw new Error(`Failed to fetch time punches: ${punchesError.message}`);
+    if (punchesError) {
+      throw new Error(`Failed to fetch time punches: ${punchesError.message}`);
+    }
+
+    // Fetch all employees (including inactive for historical accuracy)
+    const { data: employees, error: employeesError } = await supabase
+      .from('employees')
+      .select('*')
+      .eq('restaurant_id', restaurantId);
+
+    if (employeesError) {
+      throw new Error(`Failed to fetch employees: ${employeesError.message}`);
+    }
+
+    // Calculate labor costs using shared module (same logic as Dashboard)
+    const { breakdown: laborBreakdown } = calculateActualLaborCost(
+      employees || [],
+      timePunches || [],
+      startDate,
+      endDate
+    );
+
+    // Convert to format expected by calculatePeriodMetrics
+    // Labor total is in dollars, convert to cents for consistency
+    laborCostData = [{ total_labor_cost: Math.round(laborBreakdown.total * 100) / 100 }];
   }
-
-  // Fetch all employees (including inactive for historical accuracy)
-  const { data: employees, error: employeesError } = await supabase
-    .from('employees')
-    .select('*')
-    .eq('restaurant_id', restaurantId);
-
-  if (employeesError) {
-    throw new Error(`Failed to fetch employees: ${employeesError.message}`);
-  }
-
-  // Calculate labor costs using shared module (same logic as Dashboard)
-  const { breakdown: laborBreakdown } = calculateActualLaborCost(
-    employees || [],
-    timePunches || [],
-    startDate,
-    endDate
-  );
-
-  // Convert to format expected by calculatePeriodMetrics
-  // Labor total is in dollars, convert to cents for consistency
-  const laborCostData = [{ total_labor_cost: Math.round(laborBreakdown.total * 100) / 100 }];
 
   // Fetch inventory value
   const { data: inventory, error: invError } = await supabase
@@ -297,6 +312,13 @@ async function executeGetKpis(
     laborCostData || []
   );
 
+  // laborCostData is [] when !hasLaborAccess, so metrics.costs/profitability/
+  // benchmarks were computed with labor_cost = 0. redactLaborFields strips
+  // everything downstream of that (prime_cost, profit_margin, the
+  // labor/prime benchmark statuses) rather than let it read as a complete
+  // restaurant-wide figure — food-cost-only fields are unaffected and stay in.
+  const { costs, profitability, benchmarks, laborOmittedReason } = redactLaborFields(metrics, hasLaborAccess);
+
   return {
     ok: true,
     data: {
@@ -306,10 +328,11 @@ async function executeGetKpis(
 
       // All metrics from shared calculation module
       revenue: metrics.revenue,
-      costs: metrics.costs,
-      profitability: metrics.profitability,
+      costs,
+      profitability,
       liabilities: metrics.liabilities,
-      benchmarks: metrics.benchmarks,
+      benchmarks,
+      labor_omitted: laborOmittedReason ? { reason: laborOmittedReason } : undefined,
 
       // Additional metrics not in shared module
       inventory_value: inventoryValue,
@@ -318,7 +341,10 @@ async function executeGetKpis(
     evidence: [
       { table: 'unified_sales', date: startDateStr, summary: `Sales data ${startDateStr} to ${endDateStr}` },
       { table: 'inventory_transactions', date: startDateStr, summary: `Food cost (usage) ${startDateStr} to ${endDateStr}` },
-      { table: 'time_punches', date: startDateStr, summary: `Labor from time punches ${startDateStr} to ${endDateStr}` },
+      // Omitted when !hasLaborAccess — time_punches was never fetched in that case.
+      ...(hasLaborAccess
+        ? [{ table: 'time_punches', date: startDateStr, summary: `Labor from time punches ${startDateStr} to ${endDateStr}` }]
+        : []),
       { table: 'products', summary: `Current inventory snapshot (${inventory?.length || 0} items)` },
     ],
   };
@@ -3642,8 +3668,35 @@ serve(async (req) => {
       throw new Error('Access denied to this restaurant');
     }
 
-    // Check if user can use this tool
-    if (!canUseTool(tool_name, userRestaurant.role)) {
+    // Check if user can use this tool. get_labor_costs / get_schedule_overview
+    // read restaurant-wide labor/schedule data gated on the same
+    // view:scheduling OR view:payroll capability as the RLS behind those
+    // tables (20260805130000_self_scope_employee_reads.sql), resolved via the
+    // user_has_capability RPC rather than a hard-coded role — canUseTool
+    // always denies these two, so they get their own branch here.
+    if ((CAPABILITY_GATED_TOOLS as readonly string[]).includes(tool_name)) {
+      const allowed = await canUseCapabilityGatedTool(tool_name, restaurant_id, supabase);
+      if (!allowed) {
+        return new Response(
+          JSON.stringify({
+            ok: false,
+            error: {
+              code: 'TOOL_PERMISSION_DENIED',
+              message: `You don't have permission to use ${tool_name}.`,
+              tool: tool_name,
+              required_capability: 'view:scheduling or view:payroll',
+            },
+          }),
+          {
+            status: 403,
+            headers: {
+              ...corsHeaders,
+              'Content-Type': 'application/json',
+            },
+          }
+        );
+      }
+    } else if (!canUseTool(tool_name, userRestaurant.role)) {
       const requiredRole = requiredRoleFor(tool_name);
       return new Response(
         JSON.stringify({

--- a/supabase/functions/ai-execute-tool/index.ts
+++ b/supabase/functions/ai-execute-tool/index.ts
@@ -285,8 +285,11 @@ async function executeGetKpis(
       endDate
     );
 
-    // Convert to format expected by calculatePeriodMetrics
-    // Labor total is in dollars, convert to cents for consistency
+    // Convert to format expected by calculatePeriodMetrics.
+    // laborBreakdown.total is already in dollars (calculateActualLaborCost divides its
+    // internal cent-based per-employee costs by 100 before summing) — this only rounds to
+    // the nearest cent, it does NOT convert units. calculatePeriodMetrics expects dollars
+    // here to match the dollar-denominated sales/food-cost figures it's combined with.
     laborCostData = [{ total_labor_cost: Math.round(laborBreakdown.total * 100) / 100 }];
   }
 

--- a/supabase/migrations/20260805130000_self_scope_employee_reads.sql
+++ b/supabase/migrations/20260805130000_self_scope_employee_reads.sql
@@ -47,6 +47,16 @@ CREATE POLICY "Scheduling or payroll capability view shifts"
     OR user_has_capability(restaurant_id, 'view:payroll')
   );
 
+-- Deliberately carries no status/participant filter. The subquery is itself evaluated under
+-- the caller's RLS on shift_trades, so this implements exactly "you may see a shift iff you
+-- may see a trade referencing it" — the two policies stay in lockstep by construction.
+--
+-- Accepted residual risk (design §4.3.1): shift_trades' own SELECT policy admits any active
+-- employee to every open-marketplace trade (target_employee_id IS NULL) regardless of status,
+-- so a resolved trade keeps its shift readable by coworkers. Measured at 37 of 8,195 shifts
+-- (0.45%) across 2 restaurants, all of them shifts their owner broadcast to the marketplace.
+-- The root-cause fix belongs in the shift_trades policy — a product decision about trade
+-- history — and is filed as a follow-up. When it lands, this clause inherits it unchanged.
 CREATE POLICY "Employees can view shift-trade-referenced shifts"
   ON shifts
   FOR SELECT

--- a/supabase/migrations/20260805130000_self_scope_employee_reads.sql
+++ b/supabase/migrations/20260805130000_self_scope_employee_reads.sql
@@ -38,7 +38,7 @@ CREATE POLICY "Employees can view own shifts"
       AND e.restaurant_id = shifts.restaurant_id
   ));
 
-CREATE POLICY "Users with scheduling or payroll access can view restaurant shifts"
+CREATE POLICY "Scheduling or payroll capability view shifts"
   ON shifts
   FOR SELECT
   TO authenticated
@@ -79,7 +79,7 @@ CREATE POLICY "Employees can view own compensation history"
       AND e.restaurant_id = employee_compensation_history.restaurant_id
   ));
 
-CREATE POLICY "Users with scheduling or payroll access can view restaurant compensation history"
+CREATE POLICY "Scheduling or payroll capability view comp history"
   ON employee_compensation_history
   FOR SELECT
   TO authenticated
@@ -105,7 +105,7 @@ CREATE POLICY "Employees can view own overtime adjustments"
       AND e.restaurant_id = overtime_adjustments.restaurant_id
   ));
 
-CREATE POLICY "Users with scheduling or payroll access can view restaurant overtime adjustments"
+CREATE POLICY "Scheduling or payroll capability view overtime adjustments"
   ON overtime_adjustments
   FOR SELECT
   TO authenticated
@@ -131,7 +131,7 @@ CREATE POLICY "Employees can view own daily labor allocations"
       AND e.restaurant_id = daily_labor_allocations.restaurant_id
   ));
 
-CREATE POLICY "Users with scheduling or payroll access can view restaurant daily labor allocations"
+CREATE POLICY "Scheduling or payroll capability view daily labor allocations"
   ON daily_labor_allocations
   FOR SELECT
   TO authenticated
@@ -160,7 +160,7 @@ CREATE POLICY "Employees can view own time punches"
       AND e.restaurant_id = time_punches.restaurant_id
   ));
 
-CREATE POLICY "Users with scheduling or payroll access can view restaurant time punches"
+CREATE POLICY "Scheduling or payroll capability view time punches"
   ON time_punches
   FOR SELECT
   TO authenticated
@@ -189,7 +189,7 @@ CREATE POLICY "Employees can view own tips"
       AND e.restaurant_id = employee_tips.restaurant_id
   ));
 
-CREATE POLICY "Users with scheduling or payroll access can view restaurant tips"
+CREATE POLICY "Scheduling or payroll capability view tips"
   ON employee_tips
   FOR SELECT
   TO authenticated

--- a/supabase/migrations/20260805130000_self_scope_employee_reads.sql
+++ b/supabase/migrations/20260805130000_self_scope_employee_reads.sql
@@ -11,12 +11,18 @@
 -- employees' offered/requested shift rows via an embedded join) keeps working.
 --
 -- `time_punches` and `employee_tips` already carry a legacy own-row policy and two
--- byte-identical legacy manager policies from the tips migration
--- (20260220000000_add_staff_tip_read_policies.sql). The legacy own-row policy is dropped in
--- favor of the uniform one (stacking both would double-evaluate an own-row subquery on the two
--- highest-volume tables in this change), and the two duplicate manager policies are collapsed
--- to one (A OR A ≡ A, so this is behaviour-preserving and removes a redundant per-row
--- user_restaurants subquery).
+-- byte-identical legacy manager policies: one created by
+-- 20251114100100_create_time_tracking_tables.sql ("Managers can view all time punches for
+-- their restaurants" / "Managers can view all employee tips for their restaurants") and a
+-- same-logic twin created under a different name by
+-- 20251115165031_3275bc7c-bc33-4b20-b42c-fd1a9c022d07.sql ("Managers can view restaurant
+-- time punches" / "Managers can view restaurant tips") — the latter migration's own
+-- `DROP POLICY IF EXISTS` only ever targeted its own name idempotently, so it never removed
+-- the older-named twin. The legacy own-row policy is dropped in favor of the uniform one
+-- (stacking both would double-evaluate an own-row subquery on the two highest-volume tables
+-- in this change), and BOTH duplicate manager policies (both names) are dropped so only the
+-- new capability-gated policy remains (A OR A ≡ A, so this is behaviour-preserving and
+-- removes a redundant per-row user_restaurants subquery).
 --
 -- See docs/superpowers/specs/2026-08-05-employee-self-scoped-data-design.md §4 for the full
 -- rationale; policy bodies below are transcribed from production pg_policies, not re-derived.
@@ -158,6 +164,13 @@ CREATE POLICY "Scheduling or payroll capability view daily labor allocations"
 DROP POLICY IF EXISTS "Users can view time punches for their restaurants" ON time_punches;
 DROP POLICY IF EXISTS "Employees can view own time punches" ON time_punches;
 DROP POLICY IF EXISTS "Managers can view restaurant time punches" ON time_punches;
+-- Byte-identical duplicate left behind by 20251114100100_create_time_tracking_tables.sql;
+-- 20251115165031 only ever dropped-and-recreated the "...restaurant time punches" name
+-- above under its own idempotent DROP IF EXISTS, so this older-named twin was never
+-- actually removed. Must be dropped here too or it stays ORed against the new
+-- capability-gated policy below, silently keeping restaurant-wide access for any
+-- owner/manager regardless of view:scheduling/view:payroll capability.
+DROP POLICY IF EXISTS "Managers can view all time punches for their restaurants" ON time_punches;
 
 CREATE POLICY "Employees can view own time punches"
   ON time_punches
@@ -187,6 +200,9 @@ CREATE POLICY "Scheduling or payroll capability view time punches"
 DROP POLICY IF EXISTS "Users can view tips for their restaurants" ON employee_tips;
 DROP POLICY IF EXISTS "Employees can view own tips" ON employee_tips;
 DROP POLICY IF EXISTS "Managers can view restaurant tips" ON employee_tips;
+-- Byte-identical duplicate left behind by the original tips migration, same
+-- as the time_punches twin above — never dropped by any later migration.
+DROP POLICY IF EXISTS "Managers can view all employee tips for their restaurants" ON employee_tips;
 
 CREATE POLICY "Employees can view own tips"
   ON employee_tips

--- a/supabase/migrations/20260805130000_self_scope_employee_reads.sql
+++ b/supabase/migrations/20260805130000_self_scope_employee_reads.sql
@@ -1,0 +1,199 @@
+-- Self-scope employee reads on six tables so a staff/kiosk-tier caller can only read their own
+-- rows via RLS (defense in depth for the client-side scoping added in this change).
+--
+-- For each table, the single membership-only SELECT policy is replaced by:
+--   1. an own-row policy (employee_id resolves to the caller via employees.user_id)
+--   2. a privileged restaurant-wide policy gated on
+--      user_has_capability(restaurant_id, 'view:scheduling') OR
+--      user_has_capability(restaurant_id, 'view:payroll')
+--
+-- `shifts` additionally needs a third clause so the shift-trade marketplace (which reads other
+-- employees' offered/requested shift rows via an embedded join) keeps working.
+--
+-- `time_punches` and `employee_tips` already carry a legacy own-row policy and two
+-- byte-identical legacy manager policies from the tips migration
+-- (20260220000000_add_staff_tip_read_policies.sql). The legacy own-row policy is dropped in
+-- favor of the uniform one (stacking both would double-evaluate an own-row subquery on the two
+-- highest-volume tables in this change), and the two duplicate manager policies are collapsed
+-- to one (A OR A ≡ A, so this is behaviour-preserving and removes a redundant per-row
+-- user_restaurants subquery).
+--
+-- See docs/superpowers/specs/2026-08-05-employee-self-scoped-data-design.md §4 for the full
+-- rationale; policy bodies below are transcribed from production pg_policies, not re-derived.
+
+-- ---------------------------------------------------------------------------
+-- shifts
+-- ---------------------------------------------------------------------------
+
+DROP POLICY IF EXISTS "Users can view shifts for their restaurants" ON shifts;
+
+CREATE POLICY "Employees can view own shifts"
+  ON shifts
+  FOR SELECT
+  TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM employees e
+    WHERE e.id = shifts.employee_id
+      AND e.user_id = (select auth.uid())
+      AND e.restaurant_id = shifts.restaurant_id
+  ));
+
+CREATE POLICY "Users with scheduling or payroll access can view restaurant shifts"
+  ON shifts
+  FOR SELECT
+  TO authenticated
+  USING (
+    user_has_capability(restaurant_id, 'view:scheduling')
+    OR user_has_capability(restaurant_id, 'view:payroll')
+  );
+
+CREATE POLICY "Employees can view shift-trade-referenced shifts"
+  ON shifts
+  FOR SELECT
+  TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM shift_trades st
+    WHERE st.restaurant_id = shifts.restaurant_id
+      AND (st.offered_shift_id = shifts.id OR st.requested_shift_id = shifts.id)
+  ));
+
+-- §4.6: the new shifts clause filters shift_trades on requested_shift_id, which has no index
+-- in production today (only offered_shift_id is indexed).
+CREATE INDEX IF NOT EXISTS idx_shift_trades_requested_shift
+  ON shift_trades (requested_shift_id);
+
+-- ---------------------------------------------------------------------------
+-- employee_compensation_history
+-- ---------------------------------------------------------------------------
+
+DROP POLICY IF EXISTS "Users can view compensation history for their restaurants" ON employee_compensation_history;
+
+CREATE POLICY "Employees can view own compensation history"
+  ON employee_compensation_history
+  FOR SELECT
+  TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM employees e
+    WHERE e.id = employee_compensation_history.employee_id
+      AND e.user_id = (select auth.uid())
+      AND e.restaurant_id = employee_compensation_history.restaurant_id
+  ));
+
+CREATE POLICY "Users with scheduling or payroll access can view restaurant compensation history"
+  ON employee_compensation_history
+  FOR SELECT
+  TO authenticated
+  USING (
+    user_has_capability(restaurant_id, 'view:scheduling')
+    OR user_has_capability(restaurant_id, 'view:payroll')
+  );
+
+-- ---------------------------------------------------------------------------
+-- overtime_adjustments
+-- ---------------------------------------------------------------------------
+
+DROP POLICY IF EXISTS "Users can view their restaurant overtime adjustments" ON overtime_adjustments;
+
+CREATE POLICY "Employees can view own overtime adjustments"
+  ON overtime_adjustments
+  FOR SELECT
+  TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM employees e
+    WHERE e.id = overtime_adjustments.employee_id
+      AND e.user_id = (select auth.uid())
+      AND e.restaurant_id = overtime_adjustments.restaurant_id
+  ));
+
+CREATE POLICY "Users with scheduling or payroll access can view restaurant overtime adjustments"
+  ON overtime_adjustments
+  FOR SELECT
+  TO authenticated
+  USING (
+    user_has_capability(restaurant_id, 'view:scheduling')
+    OR user_has_capability(restaurant_id, 'view:payroll')
+  );
+
+-- ---------------------------------------------------------------------------
+-- daily_labor_allocations
+-- ---------------------------------------------------------------------------
+
+DROP POLICY IF EXISTS "Users can view allocations for their restaurants" ON daily_labor_allocations;
+
+CREATE POLICY "Employees can view own daily labor allocations"
+  ON daily_labor_allocations
+  FOR SELECT
+  TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM employees e
+    WHERE e.id = daily_labor_allocations.employee_id
+      AND e.user_id = (select auth.uid())
+      AND e.restaurant_id = daily_labor_allocations.restaurant_id
+  ));
+
+CREATE POLICY "Users with scheduling or payroll access can view restaurant daily labor allocations"
+  ON daily_labor_allocations
+  FOR SELECT
+  TO authenticated
+  USING (
+    user_has_capability(restaurant_id, 'view:scheduling')
+    OR user_has_capability(restaurant_id, 'view:payroll')
+  );
+
+-- ---------------------------------------------------------------------------
+-- time_punches (§4.2.1: replace legacy own-row policy + membership policy;
+-- collapse the two duplicate legacy manager policies to one)
+-- ---------------------------------------------------------------------------
+
+DROP POLICY IF EXISTS "Users can view time punches for their restaurants" ON time_punches;
+DROP POLICY IF EXISTS "Employees can view own time punches" ON time_punches;
+DROP POLICY IF EXISTS "Managers can view restaurant time punches" ON time_punches;
+
+CREATE POLICY "Employees can view own time punches"
+  ON time_punches
+  FOR SELECT
+  TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM employees e
+    WHERE e.id = time_punches.employee_id
+      AND e.user_id = (select auth.uid())
+      AND e.restaurant_id = time_punches.restaurant_id
+  ));
+
+CREATE POLICY "Users with scheduling or payroll access can view restaurant time punches"
+  ON time_punches
+  FOR SELECT
+  TO authenticated
+  USING (
+    user_has_capability(restaurant_id, 'view:scheduling')
+    OR user_has_capability(restaurant_id, 'view:payroll')
+  );
+
+-- ---------------------------------------------------------------------------
+-- employee_tips (§4.2.1: replace legacy own-row policy + membership policy;
+-- collapse the two duplicate legacy manager policies to one)
+-- ---------------------------------------------------------------------------
+
+DROP POLICY IF EXISTS "Users can view tips for their restaurants" ON employee_tips;
+DROP POLICY IF EXISTS "Employees can view own tips" ON employee_tips;
+DROP POLICY IF EXISTS "Managers can view restaurant tips" ON employee_tips;
+
+CREATE POLICY "Employees can view own tips"
+  ON employee_tips
+  FOR SELECT
+  TO authenticated
+  USING (EXISTS (
+    SELECT 1 FROM employees e
+    WHERE e.id = employee_tips.employee_id
+      AND e.user_id = (select auth.uid())
+      AND e.restaurant_id = employee_tips.restaurant_id
+  ));
+
+CREATE POLICY "Users with scheduling or payroll access can view restaurant tips"
+  ON employee_tips
+  FOR SELECT
+  TO authenticated
+  USING (
+    user_has_capability(restaurant_id, 'view:scheduling')
+    OR user_has_capability(restaurant_id, 'view:payroll')
+  );

--- a/supabase/tests/rls_employee_self_scope.sql
+++ b/supabase/tests/rls_employee_self_scope.sql
@@ -1,0 +1,423 @@
+-- ============================================================================
+-- Test: employee self-scoped reads on the six per-employee payroll/scheduling
+-- tables (RLS)
+--
+-- Today each of these six tables carries a single SELECT policy that checks
+-- restaurant *membership* only, so ANY active employee (including staff) can
+-- read every other employee's row. This test proves that gap (RED) for a
+-- staff subject and locks in correct visibility once the follow-up migration
+-- replaces the membership-only policy with an own-row clause plus a
+-- `view:scheduling OR view:payroll` privileged clause (GREEN).
+--
+-- Design: docs/superpowers/specs/2026-08-05-employee-self-scoped-data-design.md
+-- Plan:   docs/superpowers/plans/2026-08-05-employee-self-scoped-data-plan.md
+--
+-- Fixture namespace: UUIDs starting with 70000000-...
+-- Seeds: restaurant R1; staff S and coworker CW (both `employees` rows +
+--        `user_restaurants` role='staff'); a `chef` member C (no employees
+--        row — isolates the view:scheduling arm); a collaborator_accountant
+--        member A (no employees row — isolates the view:payroll arm); a
+--        manager member M (holds BOTH capabilities, so per the plan it is
+--        NOT used to isolate either arm — included only because the plan
+--        lists it as a required fixture).
+--
+-- Six tables, one row owned by S and one by CW each: shifts,
+-- employee_compensation_history, time_punches, employee_tips,
+-- overtime_adjustments, daily_labor_allocations.
+--
+-- shifts also gets a dedicated shift-trade case: a staff user must reach a
+-- coworker's shift ONLY when a shift_trades row references it (via
+-- offered_shift_id or requested_shift_id) — exercising the third "shifts
+-- needs a shift-trade clause" policy this design adds. The baseline CW shift
+-- (no trade referencing it) doubles as the "no trade -> not visible" case.
+-- ============================================================================
+
+BEGIN;
+SELECT plan(26);
+
+-- ============================================================================
+-- Setup (as postgres/superuser — bypasses RLS regardless of enable state)
+-- ============================================================================
+SET LOCAL role TO postgres;
+
+ALTER TABLE restaurants DISABLE ROW LEVEL SECURITY;
+ALTER TABLE user_restaurants DISABLE ROW LEVEL SECURITY;
+ALTER TABLE employees DISABLE ROW LEVEL SECURITY;
+ALTER TABLE shifts DISABLE ROW LEVEL SECURITY;
+ALTER TABLE shift_trades DISABLE ROW LEVEL SECURITY;
+ALTER TABLE employee_compensation_history DISABLE ROW LEVEL SECURITY;
+ALTER TABLE time_punches DISABLE ROW LEVEL SECURITY;
+ALTER TABLE employee_tips DISABLE ROW LEVEL SECURITY;
+ALTER TABLE overtime_adjustments DISABLE ROW LEVEL SECURITY;
+ALTER TABLE daily_labor_allocations DISABLE ROW LEVEL SECURITY;
+
+-- Restaurant
+INSERT INTO restaurants (id, name) VALUES
+  ('70000000-0000-0000-0000-000000000001', 'Employee Self-Scope RLS Restaurant')
+ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name;
+
+-- Auth users: S(staff), CW(coworker/staff), C(chef), A(collaborator_accountant), M(manager)
+INSERT INTO auth.users (id, instance_id, aud, role, email, encrypted_password, email_confirmed_at, created_at, updated_at, confirmation_token, recovery_token, email_change_token_new, email_change)
+VALUES
+  ('70000000-0000-0000-0000-000000000011', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'ess-staff-70@test.com', crypt('password123', gen_salt('bf')), now(), now(), now(), '', '', '', ''),
+  ('70000000-0000-0000-0000-000000000012', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'ess-coworker-70@test.com', crypt('password123', gen_salt('bf')), now(), now(), now(), '', '', '', ''),
+  ('70000000-0000-0000-0000-000000000013', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'ess-chef-70@test.com', crypt('password123', gen_salt('bf')), now(), now(), now(), '', '', '', ''),
+  ('70000000-0000-0000-0000-000000000014', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'ess-accountant-70@test.com', crypt('password123', gen_salt('bf')), now(), now(), now(), '', '', '', ''),
+  ('70000000-0000-0000-0000-000000000015', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'ess-manager-70@test.com', crypt('password123', gen_salt('bf')), now(), now(), now(), '', '', '', '')
+ON CONFLICT (id) DO NOTHING;
+
+-- Employees: only S and CW need employees rows. Chef/accountant/manager are
+-- pure user_restaurants members here — the six tables' own-row clause joins
+-- through `employees`, so a subject with no employees row can only ever
+-- reach a row via the privileged clause, which is exactly what isolates the
+-- capability arms.
+INSERT INTO employees (id, restaurant_id, user_id, name, email, position, is_active) VALUES
+  ('70000000-0000-0000-0000-000000000021', '70000000-0000-0000-0000-000000000001', '70000000-0000-0000-0000-000000000011', 'Staff S', 'ess-staff-70@test.com', 'Server', true),
+  ('70000000-0000-0000-0000-000000000022', '70000000-0000-0000-0000-000000000001', '70000000-0000-0000-0000-000000000012', 'Coworker CW', 'ess-coworker-70@test.com', 'Server', true)
+ON CONFLICT (id) DO UPDATE SET is_active = true;
+
+-- Memberships: S and CW are legacy-role 'staff' (also required for the
+-- shifts/other membership-only policy and for user_has_capability's legacy
+-- CASE fallback); C is 'chef' (view:scheduling, NOT view:payroll); A is
+-- 'collaborator_accountant' (view:payroll, NOT view:scheduling); M is
+-- 'manager' (holds both — included as a fixture only, unused for isolation).
+INSERT INTO user_restaurants (id, user_id, restaurant_id, role) VALUES
+  ('70000000-0000-0000-0000-000000000031', '70000000-0000-0000-0000-000000000011', '70000000-0000-0000-0000-000000000001', 'staff'),
+  ('70000000-0000-0000-0000-000000000032', '70000000-0000-0000-0000-000000000012', '70000000-0000-0000-0000-000000000001', 'staff'),
+  ('70000000-0000-0000-0000-000000000033', '70000000-0000-0000-0000-000000000013', '70000000-0000-0000-0000-000000000001', 'chef'),
+  ('70000000-0000-0000-0000-000000000034', '70000000-0000-0000-0000-000000000014', '70000000-0000-0000-0000-000000000001', 'collaborator_accountant'),
+  ('70000000-0000-0000-0000-000000000035', '70000000-0000-0000-0000-000000000015', '70000000-0000-0000-0000-000000000001', 'manager')
+ON CONFLICT (user_id, restaurant_id) DO UPDATE SET role = EXCLUDED.role;
+
+-- ----------------------------------------------------------------------------
+-- shifts: S's own shift, CW's baseline shift (no trade referencing it), plus
+-- two more CW shifts that are ONLY reachable through a shift_trades row.
+-- ----------------------------------------------------------------------------
+INSERT INTO shifts (id, restaurant_id, employee_id, start_time, end_time, position, break_duration) VALUES
+  ('70000000-0000-0000-0000-000000000041', '70000000-0000-0000-0000-000000000001', '70000000-0000-0000-0000-000000000021', '2026-08-10 09:00:00+00', '2026-08-10 17:00:00+00', 'Server', 30),
+  ('70000000-0000-0000-0000-000000000042', '70000000-0000-0000-0000-000000000001', '70000000-0000-0000-0000-000000000022', '2026-08-11 09:00:00+00', '2026-08-11 17:00:00+00', 'Server', 30),
+  ('70000000-0000-0000-0000-000000000043', '70000000-0000-0000-0000-000000000001', '70000000-0000-0000-0000-000000000022', '2026-08-12 09:00:00+00', '2026-08-12 17:00:00+00', 'Server', 30),
+  ('70000000-0000-0000-0000-000000000044', '70000000-0000-0000-0000-000000000001', '70000000-0000-0000-0000-000000000022', '2026-08-13 09:00:00+00', '2026-08-13 17:00:00+00', 'Server', 30)
+ON CONFLICT (id) DO UPDATE SET position = 'Server';
+
+DELETE FROM shift_trades WHERE restaurant_id = '70000000-0000-0000-0000-000000000001';
+
+-- OPEN trade (target NULL): CW offers shift ...043 to the marketplace.
+-- Visible to S via shift_trades' own "active employee, open trade" policy,
+-- so it isolates the shifts.offered_shift_id clause rather than assuming it.
+INSERT INTO shift_trades (id, restaurant_id, offered_shift_id, offered_by_employee_id, requested_shift_id, target_employee_id, status) VALUES
+  ('70000000-0000-0000-0000-000000000051', '70000000-0000-0000-0000-000000000001', '70000000-0000-0000-0000-000000000043', '70000000-0000-0000-0000-000000000022', NULL, NULL, 'open');
+
+-- OPEN trade (target NULL): S offers their own shift ...041 and directly
+-- requests CW's shift ...044 in return. `requested_shift_id` is never
+-- written by application code today (design §5.2) — inserted directly here
+-- to exercise that arm of the shifts policy.
+INSERT INTO shift_trades (id, restaurant_id, offered_shift_id, offered_by_employee_id, requested_shift_id, target_employee_id, status) VALUES
+  ('70000000-0000-0000-0000-000000000052', '70000000-0000-0000-0000-000000000001', '70000000-0000-0000-0000-000000000041', '70000000-0000-0000-0000-000000000021', '70000000-0000-0000-0000-000000000044', NULL, 'open');
+
+-- ----------------------------------------------------------------------------
+-- employee_compensation_history
+-- ----------------------------------------------------------------------------
+INSERT INTO employee_compensation_history (id, employee_id, restaurant_id, compensation_type, amount_cents, effective_date) VALUES
+  ('70000000-0000-0000-0000-000000000061', '70000000-0000-0000-0000-000000000021', '70000000-0000-0000-0000-000000000001', 'hourly', 2000, '2026-08-01'),
+  ('70000000-0000-0000-0000-000000000062', '70000000-0000-0000-0000-000000000022', '70000000-0000-0000-0000-000000000001', 'hourly', 2200, '2026-08-01')
+ON CONFLICT (id) DO UPDATE SET amount_cents = EXCLUDED.amount_cents;
+
+-- ----------------------------------------------------------------------------
+-- time_punches
+-- ----------------------------------------------------------------------------
+INSERT INTO time_punches (id, restaurant_id, employee_id, punch_type, punch_time) VALUES
+  ('70000000-0000-0000-0000-000000000071', '70000000-0000-0000-0000-000000000001', '70000000-0000-0000-0000-000000000021', 'clock_in', '2026-08-10 09:00:00+00'),
+  ('70000000-0000-0000-0000-000000000072', '70000000-0000-0000-0000-000000000001', '70000000-0000-0000-0000-000000000022', 'clock_in', '2026-08-11 09:00:00+00')
+ON CONFLICT (id) DO UPDATE SET punch_time = EXCLUDED.punch_time;
+
+-- ----------------------------------------------------------------------------
+-- employee_tips
+-- ----------------------------------------------------------------------------
+INSERT INTO employee_tips (id, restaurant_id, employee_id, tip_amount, tip_source, recorded_at) VALUES
+  ('70000000-0000-0000-0000-000000000081', '70000000-0000-0000-0000-000000000001', '70000000-0000-0000-0000-000000000021', 1000, 'cash', '2026-08-10 20:00:00+00'),
+  ('70000000-0000-0000-0000-000000000082', '70000000-0000-0000-0000-000000000001', '70000000-0000-0000-0000-000000000022', 1500, 'cash', '2026-08-11 20:00:00+00')
+ON CONFLICT (id) DO UPDATE SET tip_amount = EXCLUDED.tip_amount;
+
+-- ----------------------------------------------------------------------------
+-- overtime_adjustments
+-- ----------------------------------------------------------------------------
+INSERT INTO overtime_adjustments (id, restaurant_id, employee_id, punch_date, adjustment_type, hours, adjusted_by) VALUES
+  ('70000000-0000-0000-0000-000000000091', '70000000-0000-0000-0000-000000000001', '70000000-0000-0000-0000-000000000021', '2026-08-10', 'regular_to_overtime', 2.0, '70000000-0000-0000-0000-000000000015'),
+  ('70000000-0000-0000-0000-000000000092', '70000000-0000-0000-0000-000000000001', '70000000-0000-0000-0000-000000000022', '2026-08-11', 'regular_to_overtime', 2.5, '70000000-0000-0000-0000-000000000015')
+ON CONFLICT (id) DO UPDATE SET hours = EXCLUDED.hours;
+
+-- ----------------------------------------------------------------------------
+-- daily_labor_allocations
+-- ----------------------------------------------------------------------------
+INSERT INTO daily_labor_allocations (id, restaurant_id, employee_id, date, allocated_cost, compensation_type, source) VALUES
+  ('70000000-0000-0000-0000-000000000101', '70000000-0000-0000-0000-000000000001', '70000000-0000-0000-0000-000000000021', '2026-08-10', 5000, 'salary', 'per-job'),
+  ('70000000-0000-0000-0000-000000000102', '70000000-0000-0000-0000-000000000001', '70000000-0000-0000-0000-000000000022', '2026-08-11', 5500, 'salary', 'per-job')
+ON CONFLICT (id) DO UPDATE SET allocated_cost = EXCLUDED.allocated_cost;
+
+-- CRITICAL: re-enable RLS on every table we disabled above before switching
+-- to the authenticated role (see 53_directed_shift_trade_rls.sql's own
+-- warning about the sibling test that forgot this and passed vacuously).
+ALTER TABLE restaurants ENABLE ROW LEVEL SECURITY;
+ALTER TABLE user_restaurants ENABLE ROW LEVEL SECURITY;
+ALTER TABLE employees ENABLE ROW LEVEL SECURITY;
+ALTER TABLE shifts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE shift_trades ENABLE ROW LEVEL SECURITY;
+ALTER TABLE employee_compensation_history ENABLE ROW LEVEL SECURITY;
+ALTER TABLE time_punches ENABLE ROW LEVEL SECURITY;
+ALTER TABLE employee_tips ENABLE ROW LEVEL SECURITY;
+ALTER TABLE overtime_adjustments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE daily_labor_allocations ENABLE ROW LEVEL SECURITY;
+
+RESET ROLE;
+
+-- ============================================================================
+-- shifts (6 assertions: the generic 4 + the two shift-trade-only arms)
+-- ============================================================================
+SET LOCAL role = 'authenticated';
+SELECT set_config('request.jwt.claims', '{"sub":"70000000-0000-0000-0000-000000000011","role":"authenticated"}', true);
+
+SELECT is(
+  (SELECT COUNT(*) FROM shifts WHERE id = '70000000-0000-0000-0000-000000000041'),
+  1::bigint,
+  'shifts: staff S sees own shift'
+);
+
+SELECT is(
+  (SELECT COUNT(*) FROM shifts WHERE id = '70000000-0000-0000-0000-000000000042'),
+  0::bigint,
+  'shifts: staff S does NOT see coworker CW''s untraded shift (the fix)'
+);
+
+SELECT is(
+  (SELECT COUNT(*) FROM shifts WHERE id = '70000000-0000-0000-0000-000000000043'),
+  1::bigint,
+  'shifts: staff S sees CW''s shift referenced by shift_trades.offered_shift_id'
+);
+
+SELECT is(
+  (SELECT COUNT(*) FROM shifts WHERE id = '70000000-0000-0000-0000-000000000044'),
+  1::bigint,
+  'shifts: staff S sees CW''s shift referenced by shift_trades.requested_shift_id'
+);
+
+RESET ROLE;
+SET LOCAL role = 'authenticated';
+SELECT set_config('request.jwt.claims', '{"sub":"70000000-0000-0000-0000-000000000013","role":"authenticated"}', true);
+
+SELECT is(
+  (SELECT COUNT(*) FROM shifts WHERE id IN ('70000000-0000-0000-0000-000000000041', '70000000-0000-0000-0000-000000000042')),
+  2::bigint,
+  'shifts: chef (view:scheduling only) sees both S and CW rows'
+);
+
+RESET ROLE;
+SET LOCAL role = 'authenticated';
+SELECT set_config('request.jwt.claims', '{"sub":"70000000-0000-0000-0000-000000000014","role":"authenticated"}', true);
+
+SELECT is(
+  (SELECT COUNT(*) FROM shifts WHERE id IN ('70000000-0000-0000-0000-000000000041', '70000000-0000-0000-0000-000000000042')),
+  2::bigint,
+  'shifts: collaborator_accountant (view:payroll only) sees both S and CW rows'
+);
+
+-- ============================================================================
+-- employee_compensation_history
+-- ============================================================================
+RESET ROLE;
+SET LOCAL role = 'authenticated';
+SELECT set_config('request.jwt.claims', '{"sub":"70000000-0000-0000-0000-000000000011","role":"authenticated"}', true);
+
+SELECT is(
+  (SELECT COUNT(*) FROM employee_compensation_history WHERE id = '70000000-0000-0000-0000-000000000061'),
+  1::bigint,
+  'employee_compensation_history: staff S sees own row'
+);
+
+SELECT is(
+  (SELECT COUNT(*) FROM employee_compensation_history WHERE id = '70000000-0000-0000-0000-000000000062'),
+  0::bigint,
+  'employee_compensation_history: staff S does NOT see coworker CW''s row (the fix)'
+);
+
+RESET ROLE;
+SET LOCAL role = 'authenticated';
+SELECT set_config('request.jwt.claims', '{"sub":"70000000-0000-0000-0000-000000000013","role":"authenticated"}', true);
+
+SELECT is(
+  (SELECT COUNT(*) FROM employee_compensation_history WHERE id IN ('70000000-0000-0000-0000-000000000061', '70000000-0000-0000-0000-000000000062')),
+  2::bigint,
+  'employee_compensation_history: chef (view:scheduling only) sees both rows'
+);
+
+RESET ROLE;
+SET LOCAL role = 'authenticated';
+SELECT set_config('request.jwt.claims', '{"sub":"70000000-0000-0000-0000-000000000014","role":"authenticated"}', true);
+
+SELECT is(
+  (SELECT COUNT(*) FROM employee_compensation_history WHERE id IN ('70000000-0000-0000-0000-000000000061', '70000000-0000-0000-0000-000000000062')),
+  2::bigint,
+  'employee_compensation_history: collaborator_accountant (view:payroll only) sees both rows'
+);
+
+-- ============================================================================
+-- time_punches
+-- ============================================================================
+RESET ROLE;
+SET LOCAL role = 'authenticated';
+SELECT set_config('request.jwt.claims', '{"sub":"70000000-0000-0000-0000-000000000011","role":"authenticated"}', true);
+
+SELECT is(
+  (SELECT COUNT(*) FROM time_punches WHERE id = '70000000-0000-0000-0000-000000000071'),
+  1::bigint,
+  'time_punches: staff S sees own row'
+);
+
+SELECT is(
+  (SELECT COUNT(*) FROM time_punches WHERE id = '70000000-0000-0000-0000-000000000072'),
+  0::bigint,
+  'time_punches: staff S does NOT see coworker CW''s row (the fix)'
+);
+
+RESET ROLE;
+SET LOCAL role = 'authenticated';
+SELECT set_config('request.jwt.claims', '{"sub":"70000000-0000-0000-0000-000000000013","role":"authenticated"}', true);
+
+SELECT is(
+  (SELECT COUNT(*) FROM time_punches WHERE id IN ('70000000-0000-0000-0000-000000000071', '70000000-0000-0000-0000-000000000072')),
+  2::bigint,
+  'time_punches: chef (view:scheduling only) sees both rows'
+);
+
+RESET ROLE;
+SET LOCAL role = 'authenticated';
+SELECT set_config('request.jwt.claims', '{"sub":"70000000-0000-0000-0000-000000000014","role":"authenticated"}', true);
+
+SELECT is(
+  (SELECT COUNT(*) FROM time_punches WHERE id IN ('70000000-0000-0000-0000-000000000071', '70000000-0000-0000-0000-000000000072')),
+  2::bigint,
+  'time_punches: collaborator_accountant (view:payroll only) sees both rows'
+);
+
+-- ============================================================================
+-- employee_tips
+-- ============================================================================
+RESET ROLE;
+SET LOCAL role = 'authenticated';
+SELECT set_config('request.jwt.claims', '{"sub":"70000000-0000-0000-0000-000000000011","role":"authenticated"}', true);
+
+SELECT is(
+  (SELECT COUNT(*) FROM employee_tips WHERE id = '70000000-0000-0000-0000-000000000081'),
+  1::bigint,
+  'employee_tips: staff S sees own row'
+);
+
+SELECT is(
+  (SELECT COUNT(*) FROM employee_tips WHERE id = '70000000-0000-0000-0000-000000000082'),
+  0::bigint,
+  'employee_tips: staff S does NOT see coworker CW''s row (the fix)'
+);
+
+RESET ROLE;
+SET LOCAL role = 'authenticated';
+SELECT set_config('request.jwt.claims', '{"sub":"70000000-0000-0000-0000-000000000013","role":"authenticated"}', true);
+
+SELECT is(
+  (SELECT COUNT(*) FROM employee_tips WHERE id IN ('70000000-0000-0000-0000-000000000081', '70000000-0000-0000-0000-000000000082')),
+  2::bigint,
+  'employee_tips: chef (view:scheduling only) sees both rows'
+);
+
+RESET ROLE;
+SET LOCAL role = 'authenticated';
+SELECT set_config('request.jwt.claims', '{"sub":"70000000-0000-0000-0000-000000000014","role":"authenticated"}', true);
+
+SELECT is(
+  (SELECT COUNT(*) FROM employee_tips WHERE id IN ('70000000-0000-0000-0000-000000000081', '70000000-0000-0000-0000-000000000082')),
+  2::bigint,
+  'employee_tips: collaborator_accountant (view:payroll only) sees both rows'
+);
+
+-- ============================================================================
+-- overtime_adjustments
+-- ============================================================================
+RESET ROLE;
+SET LOCAL role = 'authenticated';
+SELECT set_config('request.jwt.claims', '{"sub":"70000000-0000-0000-0000-000000000011","role":"authenticated"}', true);
+
+SELECT is(
+  (SELECT COUNT(*) FROM overtime_adjustments WHERE id = '70000000-0000-0000-0000-000000000091'),
+  1::bigint,
+  'overtime_adjustments: staff S sees own row'
+);
+
+SELECT is(
+  (SELECT COUNT(*) FROM overtime_adjustments WHERE id = '70000000-0000-0000-0000-000000000092'),
+  0::bigint,
+  'overtime_adjustments: staff S does NOT see coworker CW''s row (the fix)'
+);
+
+RESET ROLE;
+SET LOCAL role = 'authenticated';
+SELECT set_config('request.jwt.claims', '{"sub":"70000000-0000-0000-0000-000000000013","role":"authenticated"}', true);
+
+SELECT is(
+  (SELECT COUNT(*) FROM overtime_adjustments WHERE id IN ('70000000-0000-0000-0000-000000000091', '70000000-0000-0000-0000-000000000092')),
+  2::bigint,
+  'overtime_adjustments: chef (view:scheduling only) sees both rows'
+);
+
+RESET ROLE;
+SET LOCAL role = 'authenticated';
+SELECT set_config('request.jwt.claims', '{"sub":"70000000-0000-0000-0000-000000000014","role":"authenticated"}', true);
+
+SELECT is(
+  (SELECT COUNT(*) FROM overtime_adjustments WHERE id IN ('70000000-0000-0000-0000-000000000091', '70000000-0000-0000-0000-000000000092')),
+  2::bigint,
+  'overtime_adjustments: collaborator_accountant (view:payroll only) sees both rows'
+);
+
+-- ============================================================================
+-- daily_labor_allocations
+-- ============================================================================
+RESET ROLE;
+SET LOCAL role = 'authenticated';
+SELECT set_config('request.jwt.claims', '{"sub":"70000000-0000-0000-0000-000000000011","role":"authenticated"}', true);
+
+SELECT is(
+  (SELECT COUNT(*) FROM daily_labor_allocations WHERE id = '70000000-0000-0000-0000-000000000101'),
+  1::bigint,
+  'daily_labor_allocations: staff S sees own row'
+);
+
+SELECT is(
+  (SELECT COUNT(*) FROM daily_labor_allocations WHERE id = '70000000-0000-0000-0000-000000000102'),
+  0::bigint,
+  'daily_labor_allocations: staff S does NOT see coworker CW''s row (the fix)'
+);
+
+RESET ROLE;
+SET LOCAL role = 'authenticated';
+SELECT set_config('request.jwt.claims', '{"sub":"70000000-0000-0000-0000-000000000013","role":"authenticated"}', true);
+
+SELECT is(
+  (SELECT COUNT(*) FROM daily_labor_allocations WHERE id IN ('70000000-0000-0000-0000-000000000101', '70000000-0000-0000-0000-000000000102')),
+  2::bigint,
+  'daily_labor_allocations: chef (view:scheduling only) sees both rows'
+);
+
+RESET ROLE;
+SET LOCAL role = 'authenticated';
+SELECT set_config('request.jwt.claims', '{"sub":"70000000-0000-0000-0000-000000000014","role":"authenticated"}', true);
+
+SELECT is(
+  (SELECT COUNT(*) FROM daily_labor_allocations WHERE id IN ('70000000-0000-0000-0000-000000000101', '70000000-0000-0000-0000-000000000102')),
+  2::bigint,
+  'daily_labor_allocations: collaborator_accountant (view:payroll only) sees both rows'
+);
+
+-- ============================================================================
+-- Cleanup
+-- ============================================================================
+SELECT * FROM finish();
+ROLLBACK;

--- a/tests/unit/AvailableShiftsPage.tradeCard.test.tsx
+++ b/tests/unit/AvailableShiftsPage.tradeCard.test.tsx
@@ -171,6 +171,7 @@ vi.mock('@/hooks/useOpenShiftClaims', () => ({
 
 vi.mock('@/hooks/useShifts', () => ({
   useShifts: vi.fn(() => ({ shifts: [] })),
+  useMyShifts: vi.fn(() => ({ shifts: [], loading: false })),
 }));
 
 vi.mock('@/hooks/useShiftTrades', () => ({

--- a/tests/unit/periodMetrics.test.ts
+++ b/tests/unit/periodMetrics.test.ts
@@ -19,6 +19,7 @@ import {
   calculateProfitability,
   calculateBenchmarks,
   calculatePeriodMetrics,
+  redactLaborFields,
   type SaleRecord,
   type AdjustmentRecord,
   type InventoryTransactionRecord,
@@ -586,5 +587,57 @@ describe('calculatePeriodMetrics', () => {
     expect(result.costs.labor_cost).toBe(0);
     expect(result.profitability.gross_profit).toBe(0);
     expect(result.profitability.profit_margin).toBe(0);
+  });
+});
+
+describe('redactLaborFields', () => {
+  // get_kpis (ai-execute-tool) runs under the caller's forwarded JWT, so
+  // time_punches is RLS-truncated to own-row for a caller without
+  // view:scheduling/view:payroll. Its labor total, and everything computed
+  // from it (prime_cost, profitability, labor/prime benchmark statuses),
+  // must never reach that caller looking like a complete figure.
+  const sales: SaleRecord[] = [
+    createSale({ total_price: 1000, chart_account: { account_type: 'revenue', account_subtype: 'sales' } }),
+  ];
+  const foodCosts: InventoryTransactionRecord[] = [{ total_cost: -300 }];
+  const laborCosts: LaborCostRecord[] = [{ total_labor_cost: 250 }];
+  const metrics = calculatePeriodMetrics(sales, [], foodCosts, laborCosts);
+
+  it('passes every field through unchanged when the caller has labor access', () => {
+    const result = redactLaborFields(metrics, true);
+    expect(result.costs).toEqual(metrics.costs);
+    expect(result.profitability).toEqual(metrics.profitability);
+    expect(result.benchmarks).toEqual(metrics.benchmarks);
+    expect(result.laborOmittedReason).toBeUndefined();
+  });
+
+  it('keeps only food-cost fields in costs when labor access is missing', () => {
+    const result = redactLaborFields(metrics, false);
+    expect(result.costs).toEqual({
+      food_cost: metrics.costs.food_cost,
+      food_cost_percentage: metrics.costs.food_cost_percentage,
+    });
+    expect(result.costs).not.toHaveProperty('labor_cost');
+    expect(result.costs).not.toHaveProperty('prime_cost');
+  });
+
+  it('drops profitability entirely when labor access is missing (it derives from prime_cost)', () => {
+    const result = redactLaborFields(metrics, false);
+    expect(result.profitability).toBeUndefined();
+  });
+
+  it('keeps only the food benchmark when labor access is missing', () => {
+    const result = redactLaborFields(metrics, false);
+    expect(result.benchmarks).toEqual({
+      food_cost_status: metrics.benchmarks.food_cost_status,
+      target_food_cost: metrics.benchmarks.target_food_cost,
+    });
+    expect(result.benchmarks).not.toHaveProperty('labor_cost_status');
+    expect(result.benchmarks).not.toHaveProperty('prime_cost_status');
+  });
+
+  it('supplies an explicit reason when labor access is missing', () => {
+    const result = redactLaborFields(metrics, false);
+    expect(result.laborOmittedReason).toMatch(/view:scheduling|view:payroll/);
   });
 });

--- a/tests/unit/tools-registry.test.ts
+++ b/tests/unit/tools-registry.test.ts
@@ -6,6 +6,7 @@ import {
   CAPABILITY_GATED_TOOLS,
   canUseCapabilityGatedTool,
   hasSchedulingOrPayrollCapability,
+  type CapabilityCheckClient,
 } from '../../supabase/functions/_shared/tools-registry';
 
 /**
@@ -196,13 +197,12 @@ describe('tools-registry: get_labor_costs / get_schedule_overview are capability
   );
 
   // Deliberately a minimal `{ rpc }` shape, not a full Supabase client — the
-  // functions under test only ever call `.rpc(...)`. The `as any` casts below
-  // at each call site accept that mismatch against `CapabilityCheckClient`'s
-  // real (wider) type; same minimal-mock-plus-cast pattern used throughout
-  // this test suite for Supabase client mocks.
-  function mockSupabase(responses: Record<string, boolean | null>) {
+  // functions under test only ever call `.rpc(...)`. Typed directly against
+  // `CapabilityCheckClient` (the real parameter type) so no cast is needed
+  // at any call site below.
+  function mockSupabase(responses: Record<string, boolean | null>): CapabilityCheckClient {
     return {
-      rpc: vi.fn((_fn: string, args: { p_capability: string }) =>
+      rpc: vi.fn((_fn: string, args: { p_restaurant_id: string; p_capability: string }) =>
         Promise.resolve({ data: responses[args.p_capability] ?? false, error: null }),
       ),
     };
@@ -210,25 +210,25 @@ describe('tools-registry: get_labor_costs / get_schedule_overview are capability
 
   it('grants access when the caller has view:scheduling', async () => {
     const supabase = mockSupabase({ 'view:scheduling': true, 'view:payroll': false });
-    const result = await canUseCapabilityGatedTool('get_labor_costs', 'rest-1', supabase as any);
+    const result = await canUseCapabilityGatedTool('get_labor_costs', 'rest-1', supabase);
     expect(result).toBe(true);
   });
 
   it('grants access when the caller has view:payroll', async () => {
     const supabase = mockSupabase({ 'view:scheduling': false, 'view:payroll': true });
-    const result = await canUseCapabilityGatedTool('get_schedule_overview', 'rest-1', supabase as any);
+    const result = await canUseCapabilityGatedTool('get_schedule_overview', 'rest-1', supabase);
     expect(result).toBe(true);
   });
 
   it('denies access when the caller has neither capability', async () => {
     const supabase = mockSupabase({ 'view:scheduling': false, 'view:payroll': false });
-    const result = await canUseCapabilityGatedTool('get_labor_costs', 'rest-1', supabase as any);
+    const result = await canUseCapabilityGatedTool('get_labor_costs', 'rest-1', supabase);
     expect(result).toBe(false);
   });
 
   it('denies access for a tool that is not capability-gated', async () => {
     const supabase = mockSupabase({ 'view:scheduling': true, 'view:payroll': true });
-    const result = await canUseCapabilityGatedTool('get_kpis', 'rest-1', supabase as any);
+    const result = await canUseCapabilityGatedTool('get_kpis', 'rest-1', supabase);
     expect(result).toBe(false);
     expect(supabase.rpc).not.toHaveBeenCalled();
   });
@@ -238,18 +238,18 @@ describe('tools-registry: get_labor_costs / get_schedule_overview are capability
   // just must not compute prime cost from an RLS-truncated labor set).
   it('hasSchedulingOrPayrollCapability: true when only scheduling is granted', async () => {
     const supabase = mockSupabase({ 'view:scheduling': true, 'view:payroll': false });
-    expect(await hasSchedulingOrPayrollCapability('rest-1', supabase as any)).toBe(true);
+    expect(await hasSchedulingOrPayrollCapability('rest-1', supabase)).toBe(true);
   });
 
   it('hasSchedulingOrPayrollCapability: false when neither is granted', async () => {
     const supabase = mockSupabase({ 'view:scheduling': false, 'view:payroll': false });
-    expect(await hasSchedulingOrPayrollCapability('rest-1', supabase as any)).toBe(false);
+    expect(await hasSchedulingOrPayrollCapability('rest-1', supabase)).toBe(false);
   });
 
   it('hasSchedulingOrPayrollCapability: fails closed AND logs when an RPC errors, instead of silently reporting a plain denial', async () => {
     const rpcError = new Error('connection reset');
-    const supabase = {
-      rpc: vi.fn((_fn: string, args: { p_capability: string }) =>
+    const supabase: CapabilityCheckClient = {
+      rpc: vi.fn((_fn: string, args: { p_restaurant_id: string; p_capability: string }) =>
         args.p_capability === 'view:scheduling'
           ? Promise.resolve({ data: null, error: rpcError })
           : Promise.resolve({ data: false, error: null }),
@@ -258,12 +258,39 @@ describe('tools-registry: get_labor_costs / get_schedule_overview are capability
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     try {
-      const result = await hasSchedulingOrPayrollCapability('rest-1', supabase as any);
+      const result = await hasSchedulingOrPayrollCapability('rest-1', supabase);
 
       // Fail closed: an infra error must not grant access.
       expect(result).toBe(false);
       // But the real cause must be logged, not swallowed — otherwise an infra
       // failure is indistinguishable from a legitimate permission denial.
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('view:scheduling'),
+        expect.objectContaining({ restaurantId: 'rest-1', error: rpcError }),
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it('hasSchedulingOrPayrollCapability: fails closed AND logs when an RPC promise rejects (not just resolves with an error field)', async () => {
+    const rpcError = new Error('network unreachable');
+    const supabase: CapabilityCheckClient = {
+      rpc: vi.fn((_fn: string, args: { p_restaurant_id: string; p_capability: string }) =>
+        args.p_capability === 'view:scheduling'
+          ? Promise.reject(rpcError)
+          : Promise.resolve({ data: false, error: null }),
+      ),
+    };
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      // A rejected RPC promise must not escape as an unhandled rejection —
+      // it has to land in the same fail-closed/logged path as a resolved
+      // `{ data: null, error }` response.
+      const result = await hasSchedulingOrPayrollCapability('rest-1', supabase);
+
+      expect(result).toBe(false);
       expect(consoleErrorSpy).toHaveBeenCalledWith(
         expect.stringContaining('view:scheduling'),
         expect.objectContaining({ restaurantId: 'rest-1', error: rpcError }),

--- a/tests/unit/tools-registry.test.ts
+++ b/tests/unit/tools-registry.test.ts
@@ -5,6 +5,7 @@ import {
   requiredRoleFor,
   CAPABILITY_GATED_TOOLS,
   canUseCapabilityGatedTool,
+  hasSchedulingOrPayrollCapability,
 } from '../../supabase/functions/_shared/tools-registry';
 
 /**
@@ -225,5 +226,18 @@ describe('tools-registry: get_labor_costs / get_schedule_overview are capability
     const result = await canUseCapabilityGatedTool('get_kpis', 'rest-1', supabase as any);
     expect(result).toBe(false);
     expect(supabase.rpc).not.toHaveBeenCalled();
+  });
+
+  // hasSchedulingOrPayrollCapability is the underlying OR-check, reused by
+  // get_kpis's labor-component gate (get_kpis itself stays a basic tool; it
+  // just must not compute prime cost from an RLS-truncated labor set).
+  it('hasSchedulingOrPayrollCapability: true when only scheduling is granted', async () => {
+    const supabase = mockSupabase({ 'view:scheduling': true, 'view:payroll': false });
+    expect(await hasSchedulingOrPayrollCapability('rest-1', supabase as any)).toBe(true);
+  });
+
+  it('hasSchedulingOrPayrollCapability: false when neither is granted', async () => {
+    const supabase = mockSupabase({ 'view:scheduling': false, 'view:payroll': false });
+    expect(await hasSchedulingOrPayrollCapability('rest-1', supabase as any)).toBe(false);
   });
 });

--- a/tests/unit/tools-registry.test.ts
+++ b/tests/unit/tools-registry.test.ts
@@ -195,6 +195,11 @@ describe('tools-registry: get_labor_costs / get_schedule_overview are capability
     },
   );
 
+  // Deliberately a minimal `{ rpc }` shape, not a full Supabase client — the
+  // functions under test only ever call `.rpc(...)`. The `as any` casts below
+  // at each call site accept that mismatch against `CapabilityCheckClient`'s
+  // real (wider) type; same minimal-mock-plus-cast pattern used throughout
+  // this test suite for Supabase client mocks.
   function mockSupabase(responses: Record<string, boolean | null>) {
     return {
       rpc: vi.fn((_fn: string, args: { p_capability: string }) =>
@@ -239,5 +244,32 @@ describe('tools-registry: get_labor_costs / get_schedule_overview are capability
   it('hasSchedulingOrPayrollCapability: false when neither is granted', async () => {
     const supabase = mockSupabase({ 'view:scheduling': false, 'view:payroll': false });
     expect(await hasSchedulingOrPayrollCapability('rest-1', supabase as any)).toBe(false);
+  });
+
+  it('hasSchedulingOrPayrollCapability: fails closed AND logs when an RPC errors, instead of silently reporting a plain denial', async () => {
+    const rpcError = new Error('connection reset');
+    const supabase = {
+      rpc: vi.fn((_fn: string, args: { p_capability: string }) =>
+        args.p_capability === 'view:scheduling'
+          ? Promise.resolve({ data: null, error: rpcError })
+          : Promise.resolve({ data: false, error: null }),
+      ),
+    };
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      const result = await hasSchedulingOrPayrollCapability('rest-1', supabase as any);
+
+      // Fail closed: an infra error must not grant access.
+      expect(result).toBe(false);
+      // But the real cause must be logged, not swallowed — otherwise an infra
+      // failure is indistinguishable from a legitimate permission denial.
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('view:scheduling'),
+        expect.objectContaining({ restaurantId: 'rest-1', error: rpcError }),
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
   });
 });

--- a/tests/unit/tools-registry.test.ts
+++ b/tests/unit/tools-registry.test.ts
@@ -1,8 +1,10 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   getTools,
   canUseTool,
   requiredRoleFor,
+  CAPABILITY_GATED_TOOLS,
+  canUseCapabilityGatedTool,
 } from '../../supabase/functions/_shared/tools-registry';
 
 /**
@@ -131,10 +133,12 @@ describe('tools-registry: requiredRoleFor / canUseTool invariant', () => {
   // and false for the role one tier below it. This guards the dispatcher's
   // "what should I tell the user they need?" message against drifting from the
   // actual permission check.
+  // get_labor_costs / get_schedule_overview are excluded here: they are no
+  // longer role-gated (see the capability-gating describe block below), so
+  // the "required role" concept does not apply to them.
   const tools = [
     'get_kpis',
     'get_inventory_status',
-    'get_labor_costs',
     'get_time_punches',
     'get_payroll_summary',
     'get_financial_intelligence',
@@ -166,5 +170,60 @@ describe('tools-registry: requiredRoleFor / canUseTool invariant', () => {
     if (required === 'owner') {
       expect(canUseTool(toolName, 'manager')).toBe(false);
     }
+  });
+});
+
+describe('tools-registry: get_labor_costs / get_schedule_overview are capability-gated, not role-gated', () => {
+  // These two tools expose restaurant-wide labor/schedule data. The RLS
+  // behind the tables they read is `own-row OR view:scheduling OR
+  // view:payroll` (see the self-scoped-employee-data migration), so the
+  // dispatcher must gate the tools on the same capability rather than a
+  // second hard-coded role list that could drift from RLS.
+  it('lists exactly get_labor_costs and get_schedule_overview as capability-gated', () => {
+    expect([...CAPABILITY_GATED_TOOLS].sort()).toEqual(
+      ['get_labor_costs', 'get_schedule_overview'].sort(),
+    );
+  });
+
+  it.each(CAPABILITY_GATED_TOOLS)(
+    'canUseTool never grants %s by role alone (enforcement moved to canUseCapabilityGatedTool)',
+    (toolName) => {
+      for (const role of ALL_ROLES) {
+        expect(canUseTool(toolName, role)).toBe(false);
+      }
+    },
+  );
+
+  function mockSupabase(responses: Record<string, boolean | null>) {
+    return {
+      rpc: vi.fn((_fn: string, args: { p_capability: string }) =>
+        Promise.resolve({ data: responses[args.p_capability] ?? false, error: null }),
+      ),
+    };
+  }
+
+  it('grants access when the caller has view:scheduling', async () => {
+    const supabase = mockSupabase({ 'view:scheduling': true, 'view:payroll': false });
+    const result = await canUseCapabilityGatedTool('get_labor_costs', 'rest-1', supabase as any);
+    expect(result).toBe(true);
+  });
+
+  it('grants access when the caller has view:payroll', async () => {
+    const supabase = mockSupabase({ 'view:scheduling': false, 'view:payroll': true });
+    const result = await canUseCapabilityGatedTool('get_schedule_overview', 'rest-1', supabase as any);
+    expect(result).toBe(true);
+  });
+
+  it('denies access when the caller has neither capability', async () => {
+    const supabase = mockSupabase({ 'view:scheduling': false, 'view:payroll': false });
+    const result = await canUseCapabilityGatedTool('get_labor_costs', 'rest-1', supabase as any);
+    expect(result).toBe(false);
+  });
+
+  it('denies access for a tool that is not capability-gated', async () => {
+    const supabase = mockSupabase({ 'view:scheduling': true, 'view:payroll': true });
+    const result = await canUseCapabilityGatedTool('get_kpis', 'rest-1', supabase as any);
+    expect(result).toBe(false);
+    expect(supabase.rpc).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/useMyPayroll.test.ts
+++ b/tests/unit/useMyPayroll.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Unit Tests: `useMyPayroll` (self-scoped) and `usePayroll` (admin) regression guard
+ *
+ * Per docs/superpowers/specs/2026-08-05-employee-self-scoped-data-design.md §3.2, both
+ * hooks share one internal implementation with two public entry points. The internal
+ * implementation threads `.eq('employee_id', employeeId)` into the seven per-employee
+ * queries — `time_punches`, `tip_split_items`, `daily_labor_allocations`, `employee_tips`,
+ * `tip_payouts`, `overtime_adjustments`, and `employees` (via `useEmployees({ status: 'all',
+ * employeeId })`, which applies `.eq('id', employeeId)`) — while `tip_splits` and
+ * `overtime_rules` stay restaurant-scoped.
+ *
+ * These assertions inspect the recorded query-builder calls, not the returned rows — a
+ * row-based assertion would pass vacuously if the filter were applied client-side instead
+ * of pushed into the query.
+ */
+import React, { type ReactNode } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+type RecordedCall = { method: string; args: unknown[] };
+
+// Generic chainable Supabase query-builder mock: every method returns `this`
+// so any chain shape resolves, and the builder is thenable so
+// `await supabase.from(...).select()...` resolves to { data: [], error: null }.
+// One instance is created per table so calls can be inspected per table.
+function makeChainable(): Record<string, unknown> & {
+  calls: RecordedCall[];
+  then: (resolve: (v: { data: unknown[]; error: null }) => void) => void;
+} {
+  const calls: RecordedCall[] = [];
+  const chain = { calls } as Record<string, unknown> & {
+    calls: RecordedCall[];
+    then: (resolve: (v: { data: unknown[]; error: null }) => void) => void;
+  };
+  (['select', 'eq', 'in', 'gte', 'lte', 'order', 'maybeSingle', 'range'] as const).forEach(
+    (method) => {
+      chain[method] = vi.fn((...args: unknown[]) => {
+        calls.push({ method, args });
+        return chain;
+      });
+    },
+  );
+  chain.then = (resolve: (v: { data: unknown[]; error: null }) => void) =>
+    resolve({ data: [], error: null });
+  return chain;
+}
+
+const employeesChain = makeChainable();
+// Return at least one employee so the outer payroll query's
+// `enabled: !!restaurantId && !!employees.length` gate actually opens.
+employeesChain.then = (resolve: (v: { data: unknown[]; error: null }) => void) =>
+  resolve({ data: [{ id: 'emp-1', name: 'Emp One', status: 'active' }], error: null });
+
+const perEmployeeTableChains: Record<string, ReturnType<typeof makeChainable>> = {
+  time_punches: makeChainable(),
+  tip_split_items: makeChainable(),
+  daily_labor_allocations: makeChainable(),
+  employee_tips: makeChainable(),
+  tip_payouts: makeChainable(),
+  overtime_adjustments: makeChainable(),
+};
+const restaurantScopedChains: Record<string, ReturnType<typeof makeChainable>> = {
+  tip_splits: makeChainable(),
+  overtime_rules: makeChainable(),
+};
+
+const allChains: Record<string, ReturnType<typeof makeChainable>> = {
+  employees: employeesChain,
+  ...perEmployeeTableChains,
+  ...restaurantScopedChains,
+};
+
+const fromMock = vi.fn((table: string) => {
+  if (allChains[table]) return allChains[table];
+  return makeChainable();
+});
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: (...args: [string]) => fromMock(...args),
+  },
+}));
+
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => ({
+    selectedRestaurant: { restaurant: { timezone: 'America/Chicago' } },
+  }),
+}));
+
+const createWrapper = (queryClient: QueryClient) => {
+  const Wrapper = ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+  return Wrapper;
+};
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+}
+
+const restaurantId = 'rest-123';
+const startDate = new Date(2026, 2, 2); // Mon 2026-03-02
+const endDate = new Date(2026, 2, 8); // Sun 2026-03-08
+
+describe('useMyPayroll (self-scoped)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.values(allChains).forEach((chain) => {
+      chain.calls.length = 0;
+    });
+  });
+
+  it("applies .eq('employee_id', <id>) on all seven per-employee tables and .eq('id', <id>) on employees", async () => {
+    const { useMyPayroll } = await import('@/hooks/usePayroll');
+
+    const { result } = renderHook(
+      () => useMyPayroll(restaurantId, 'emp-1', startDate, endDate),
+      { wrapper: createWrapper(createQueryClient()) },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    Object.entries(perEmployeeTableChains).forEach(([table, chain]) => {
+      expect(fromMock).toHaveBeenCalledWith(table);
+      expect(chain.calls).toContainEqual({ method: 'eq', args: ['employee_id', 'emp-1'] });
+    });
+    expect(fromMock).toHaveBeenCalledWith('employees');
+    expect(employeesChain.calls).toContainEqual({ method: 'eq', args: ['id', 'emp-1'] });
+  });
+
+  it('leaves tip_splits and overtime_rules restaurant-scoped, with no employee_id predicate', async () => {
+    const { useMyPayroll } = await import('@/hooks/usePayroll');
+
+    const { result } = renderHook(
+      () => useMyPayroll(restaurantId, 'emp-1', startDate, endDate),
+      { wrapper: createWrapper(createQueryClient()) },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    Object.entries(restaurantScopedChains).forEach(([table, chain]) => {
+      expect(fromMock).toHaveBeenCalledWith(table);
+      expect(chain.calls).toContainEqual({
+        method: 'eq',
+        args: ['restaurant_id', restaurantId],
+      });
+      const employeeIdCalls = chain.calls.filter(
+        (call) => call.method === 'eq' && call.args[0] === 'employee_id',
+      );
+      expect(employeeIdCalls).toHaveLength(0);
+    });
+  });
+
+  it('issues no queries at all when employeeId is null', async () => {
+    const { useMyPayroll } = await import('@/hooks/usePayroll');
+
+    const { result } = renderHook(() => useMyPayroll(restaurantId, null, startDate, endDate), {
+      wrapper: createWrapper(createQueryClient()),
+    });
+
+    // Disabled query: React Query never runs the queryFn, so loading never
+    // transitions to true and settles immediately as not-loading.
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(fromMock).not.toHaveBeenCalled();
+  });
+
+  it('reports loading: true while the inner useEmployees query is in flight (the disabled-query window)', async () => {
+    // A never-resolving employees fetch keeps `useEmployees`'s inner query
+    // "in flight" for the lifetime of the test, so `employees.length` never
+    // reaches nonzero and the outer payroll query stays disabled. Per design
+    // §3.2, `loading` must still report `true` during this window — a
+    // disabled query alone reports `isLoading: false`, which would make
+    // `EmployeePay` render its "No Pay Data" empty state instead of a
+    // skeleton while the employee's own record is still resolving.
+    employeesChain.then = () => new Promise<never>(() => {});
+
+    const { useMyPayroll } = await import('@/hooks/usePayroll');
+
+    const { result } = renderHook(
+      () => useMyPayroll(restaurantId, 'emp-1', startDate, endDate),
+      { wrapper: createWrapper(createQueryClient()) },
+    );
+
+    expect(result.current.loading).toBe(true);
+  });
+});
+
+describe('usePayroll (admin) — regression guard for the shared implementation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.values(allChains).forEach((chain) => {
+      chain.calls.length = 0;
+    });
+    employeesChain.then = (resolve: (v: { data: unknown[]; error: null }) => void) =>
+      resolve({ data: [{ id: 'emp-1', name: 'Emp One', status: 'active' }], error: null });
+  });
+
+  it('issues exactly the queries it issues today, with no employee_id predicate anywhere', async () => {
+    const { usePayroll } = await import('@/hooks/usePayroll');
+
+    const { result } = renderHook(() => usePayroll(restaurantId, startDate, endDate), {
+      wrapper: createWrapper(createQueryClient()),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    Object.entries(allChains).forEach(([, chain]) => {
+      const employeeIdCalls = chain.calls.filter(
+        (call) => call.method === 'eq' && call.args[0] === 'employee_id',
+      );
+      expect(employeeIdCalls).toHaveLength(0);
+    });
+    const employeesIdCalls = employeesChain.calls.filter(
+      (call) => call.method === 'eq' && call.args[0] === 'id',
+    );
+    expect(employeesIdCalls).toHaveLength(0);
+  });
+});

--- a/tests/unit/useMyPayroll.test.ts
+++ b/tests/unit/useMyPayroll.test.ts
@@ -110,9 +110,23 @@ describe('useMyPayroll (self-scoped)', () => {
     Object.values(allChains).forEach((chain) => {
       chain.calls.length = 0;
     });
+    // Reset tip_splits back to the generic empty-response default between
+    // tests — the first test below overrides it to a non-empty response so
+    // the (short-circuited-when-empty) tip_split_items query actually fires.
+    restaurantScopedChains.tip_splits.then = (
+      resolve: (v: { data: unknown[]; error: null }) => void,
+    ) => resolve({ data: [], error: null });
   });
 
   it("applies .eq('employee_id', <id>) on all seven per-employee tables and .eq('id', <id>) on employees", async () => {
+    // tip_split_items is only queried when there's at least one approved/
+    // archived tip_splits row for the period (see the short-circuit in
+    // usePayroll.tsx — `.in('tip_split_id', [])` is never issued), so seed a
+    // split here to exercise that query's employee_id predicate.
+    restaurantScopedChains.tip_splits.then = (
+      resolve: (v: { data: unknown[]; error: null }) => void,
+    ) => resolve({ data: [{ id: 'split-1', total_amount: 500 }], error: null });
+
     const { useMyPayroll } = await import('@/hooks/usePayroll');
 
     const { result } = renderHook(
@@ -128,6 +142,24 @@ describe('useMyPayroll (self-scoped)', () => {
     });
     expect(fromMock).toHaveBeenCalledWith('employees');
     expect(employeesChain.calls).toContainEqual({ method: 'eq', args: ['id', 'emp-1'] });
+  });
+
+  it('does not query tip_split_items at all when there are no approved/archived tip splits for the period (empty splitIds short-circuit)', async () => {
+    // Regression test: `.in('tip_split_id', [])` sends `in.()` to PostgREST
+    // literally, which errors on a typed uuid column instead of returning
+    // zero rows — so the common case (no tip splits yet) must never reach
+    // the network at all.
+    const { useMyPayroll } = await import('@/hooks/usePayroll');
+
+    const { result } = renderHook(
+      () => useMyPayroll(restaurantId, 'emp-1', startDate, endDate),
+      { wrapper: createWrapper(createQueryClient()) },
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(fromMock).not.toHaveBeenCalledWith('tip_split_items');
+    expect(perEmployeeTableChains.tip_split_items.calls).toHaveLength(0);
   });
 
   it('leaves tip_splits and overtime_rules restaurant-scoped, with no employee_id predicate', async () => {
@@ -217,5 +249,34 @@ describe('usePayroll (admin) — regression guard for the shared implementation'
       (call) => call.method === 'eq' && call.args[0] === 'id',
     );
     expect(employeesIdCalls).toHaveLength(0);
+  });
+
+  it("keys the unresolved self-scoped state (employeeId: null) DIFFERENTLY from the admin key, so a disabled query cannot read back the admin query's cache", async () => {
+    // Regression test for a query-key collision: `employeeId ?? null` would
+    // map BOTH admin mode (employeeId === undefined, via usePayroll) and
+    // self-scoped-but-unresolved mode (employeeId === null, via useMyPayroll
+    // before useCurrentEmployee resolves) to the identical `null` segment.
+    // `enabled: false` only suppresses a new fetch, not a cache read, so a
+    // dual-role viewer mounting useMyPayroll after usePayroll already cached
+    // restaurant-wide payroll for the same range would transiently read that
+    // cached admin data back through the self-scoped hook.
+    const { usePayroll, useMyPayroll } = await import('@/hooks/usePayroll');
+    const queryClient = createQueryClient();
+
+    const { result: adminResult } = renderHook(
+      () => usePayroll(restaurantId, startDate, endDate),
+      { wrapper: createWrapper(queryClient) },
+    );
+    await waitFor(() => expect(adminResult.current.loading).toBe(false));
+
+    renderHook(() => useMyPayroll(restaurantId, null, startDate, endDate), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    const keys = queryClient.getQueryCache().getAll().map((query) => query.queryKey);
+    const payrollKeys = keys.filter((key) => Array.isArray(key) && key[0] === 'payroll');
+
+    expect(payrollKeys).toHaveLength(2);
+    expect(payrollKeys[0]).not.toEqual(payrollKeys[1]);
   });
 });

--- a/tests/unit/useMyShifts.test.ts
+++ b/tests/unit/useMyShifts.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Unit Tests: `useMyShifts` (self-scoped) and `useShifts` (admin) regression guard
+ *
+ * Per docs/superpowers/specs/2026-08-05-employee-self-scoped-data-design.md §3.2, both
+ * hooks share one internal implementation with two public entry points:
+ *
+ * - `useShifts(restaurantId, startDate?, endDate?)` — unchanged admin behaviour, no
+ *   `employee_id` predicate.
+ * - `useMyShifts(restaurantId, employeeId, startDate?, endDate?)` — applies
+ *   `.eq('employee_id', employeeId)` and is only enabled once `employeeId` is non-null
+ *   (§3.1: an optional filter that silently degrades to "no filter" while
+ *   `useCurrentEmployee` is still resolving would re-open the restaurant-wide read this
+ *   change closes).
+ *
+ * These assertions inspect the recorded query-builder calls, not the returned rows — a
+ * row-based assertion would pass vacuously if the filter were applied client-side instead
+ * of pushed into the query.
+ */
+import React, { ReactNode } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useShifts, useMyShifts } from '@/hooks/useShifts';
+
+const mockSupabase = vi.hoisted(() => ({
+  from: vi.fn(),
+}));
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: mockSupabase,
+}));
+
+const createWrapper = (queryClient: QueryClient) => {
+  const Wrapper = ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+  return Wrapper;
+};
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+}
+
+type RecordedCall = { method: string; args: unknown[] };
+
+/**
+ * A chainable query-builder mock that records every `select`/`eq`/`gte`/`lte`/`order`
+ * call regardless of the order the hook chains them in, then resolves on `.order()` —
+ * matching the point at which `useShifts`'s queryFn awaits the query today.
+ */
+function setupShiftsQueryChain(): { calls: RecordedCall[] } {
+  const calls: RecordedCall[] = [];
+  const builder: Record<string, ReturnType<typeof vi.fn>> = {};
+
+  (['select', 'eq', 'gte', 'lte'] as const).forEach((method) => {
+    builder[method] = vi.fn((...args: unknown[]) => {
+      calls.push({ method, args });
+      return builder;
+    });
+  });
+
+  builder.order = vi.fn((...args: unknown[]) => {
+    calls.push({ method: 'order', args });
+    return Promise.resolve({ data: [], error: null });
+  });
+
+  mockSupabase.from.mockReturnValue(builder);
+
+  return { calls };
+}
+
+const restaurantId = 'rest-123';
+const startDate = new Date('2026-07-14T00:00:00.000Z');
+const endDate = new Date('2026-07-20T23:59:59.999Z');
+
+describe('useMyShifts (self-scoped)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("applies .eq('employee_id', <id>) when given an employee id", async () => {
+    const { calls } = setupShiftsQueryChain();
+
+    const { result } = renderHook(() => useMyShifts(restaurantId, 'emp-1', startDate, endDate), {
+      wrapper: createWrapper(createQueryClient()),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(mockSupabase.from).toHaveBeenCalledWith('shifts');
+    expect(calls).toContainEqual({ method: 'eq', args: ['employee_id', 'emp-1'] });
+    expect(calls).toContainEqual({ method: 'eq', args: ['restaurant_id', restaurantId] });
+  });
+
+  it('issues no query against shifts when employeeId is null', async () => {
+    setupShiftsQueryChain();
+
+    const { result } = renderHook(() => useMyShifts(restaurantId, null, startDate, endDate), {
+      wrapper: createWrapper(createQueryClient()),
+    });
+
+    // Disabled query: React Query never runs the queryFn, so loading never
+    // transitions to true and settles immediately as not-loading.
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(mockSupabase.from).not.toHaveBeenCalled();
+  });
+
+  it('keys the query on employeeId so admin and self caches cannot collide', async () => {
+    setupShiftsQueryChain();
+    const queryClient = createQueryClient();
+
+    const { result } = renderHook(() => useMyShifts(restaurantId, 'emp-1', startDate, endDate), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const keys = queryClient.getQueryCache().getAll().map((query) => query.queryKey);
+    const matching = keys.find((key) => Array.isArray(key) && key[0] === 'shifts');
+
+    expect(matching).toBeDefined();
+    expect(matching).toContain('emp-1');
+  });
+});
+
+describe('useShifts (admin) — regression guard for the shared implementation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('issues exactly the query it issues today, with no employee_id predicate', async () => {
+    const { calls } = setupShiftsQueryChain();
+
+    const { result } = renderHook(() => useShifts(restaurantId, startDate, endDate), {
+      wrapper: createWrapper(createQueryClient()),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(mockSupabase.from).toHaveBeenCalledWith('shifts');
+    expect(calls).toContainEqual({ method: 'select', args: ['*, employee:employees(*)'] });
+    expect(calls).toContainEqual({ method: 'eq', args: ['restaurant_id', restaurantId] });
+    expect(calls).toContainEqual({ method: 'gte', args: ['start_time', startDate.toISOString()] });
+    expect(calls).toContainEqual({ method: 'lte', args: ['start_time', endDate.toISOString()] });
+    expect(calls).toContainEqual({ method: 'order', args: ['start_time'] });
+
+    const employeeIdCalls = calls.filter(
+      (call) => call.method === 'eq' && call.args[0] === 'employee_id',
+    );
+    expect(employeeIdCalls).toHaveLength(0);
+  });
+});

--- a/tests/unit/useMyShifts.test.ts
+++ b/tests/unit/useMyShifts.test.ts
@@ -123,6 +123,37 @@ describe('useMyShifts (self-scoped)', () => {
     expect(matching).toBeDefined();
     expect(matching).toContain('emp-1');
   });
+
+  it('keys the unresolved self-scoped state (employeeId: null) DIFFERENTLY from the admin key, so a disabled query cannot read back an admin query\'s cache', async () => {
+    // Regression test for a query-key collision: `employeeId ?? 'all'` would
+    // map BOTH admin mode (employeeId === undefined, via useShifts) and
+    // self-scoped-but-unresolved mode (employeeId === null, via useMyShifts
+    // before useCurrentEmployee resolves) to the identical 'all' segment.
+    // `enabled: false` only suppresses a new fetch, not a cache read, so a
+    // dual-role viewer mounting useMyShifts after useShifts already cached
+    // restaurant-wide data for the same range would transiently read that
+    // cached admin data back through the self-scoped hook.
+    setupShiftsQueryChain();
+    const queryClient = createQueryClient();
+
+    const { result: adminResult } = renderHook(
+      () => useShifts(restaurantId, startDate, endDate),
+      { wrapper: createWrapper(queryClient) },
+    );
+    await waitFor(() => expect(adminResult.current.loading).toBe(false));
+
+    renderHook(() => useMyShifts(restaurantId, null, startDate, endDate), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    const keys = queryClient.getQueryCache().getAll().map((query) => query.queryKey);
+    const shiftsKeys = keys.filter((key) => Array.isArray(key) && key[0] === 'shifts');
+
+    // Two distinct cache entries must exist — admin and unresolved-self-scoped
+    // must never collide onto the same key.
+    expect(shiftsKeys).toHaveLength(2);
+    expect(shiftsKeys[0]).not.toEqual(shiftsKeys[1]);
+  });
 });
 
 describe('useShifts (admin) — regression guard for the shared implementation', () => {


### PR DESCRIPTION
## Summary

Employee self-service pages (`EmployeeSchedule`, `EmployeePay`, `AvailableShiftsPage`) fetched
restaurant-wide shift and payroll data and filtered it client-side. Because the RLS behind those
tables was membership-only, every `staff` user already received every coworker's shifts and
compensation over the wire — this closes that at both the client and the database layer
(approach C from the design doc: shared hook implementations behind two entry points, plus one
RLS migration).

- **Client layer**: extracted `useShiftsQuery`/`usePayrollInternal` from the existing
  `useShifts`/`usePayroll` hooks and added self-scoped entry points, `useMyShifts` and
  `useMyPayroll`, that require a resolved `employeeId` (a `null` employeeId disables the query
  entirely rather than falling back to restaurant-wide — the "`undefined` footgun" the design
  calls out in §3.1). `EmployeeSchedule`, `AvailableShiftsPage`, and `EmployeePay` now call the
  self-scoped hooks instead of filtering admin data client-side. Admin `useShifts`/`usePayroll`
  are unchanged. `employeeId` is part of the React Query cache key so admin and self-scoped views
  can never collide, including the case where a self-scoped query is disabled (unresolved
  `employeeId`) but the same key was already warm from an admin query on that page.
- **RLS layer (defense in depth)**: new migration tightens SELECT policies on six tables
  (`shifts`, `employee_compensation_history`, `time_punches`, `employee_tips`,
  `overtime_adjustments`, `daily_labor_allocations`) from membership-only to
  `own-row OR user_has_capability(restaurant_id, 'view:scheduling') OR
  user_has_capability(restaurant_id, 'view:payroll')`. The OR (not `view:payroll` alone) matters
  because `chef` holds only `view:scheduling` — a payroll-only predicate would silently zero out
  chef's labor-cost visibility. `shifts` carries a third clause for the shift-trade marketplace
  (a coworker's shift referenced by an open trade must stay visible to the counterparty); the
  design doc's §4.3.1 records the accepted residual risk that a *resolved* trade keeps the
  referenced shift visible, measured against production (37/8,195 shifts, 0.45%, all
  deliberately-broadcast open-marketplace trades).
- **AI tool gating**: `get_labor_costs`/`get_schedule_overview` are now capability-gated
  (`view:scheduling` or `view:payroll`) instead of role-gated, matching the new RLS predicate.
  `get_kpis` now checks the same capability before fetching `time_punches`/`employees` at all —
  since `ai-execute-tool` runs under the caller's forwarded JWT, without this the RLS tightening
  above would have made it silently report a near-$0 labor cost to any role that lost
  restaurant-wide access, rather than omitting the field. The response explicitly flags
  `labor_omitted: { reason }` instead.
- **Deferred** (design §6, not in scope for this PR): the `employees` table itself stays
  membership-only — `TradeRequestDialog` needs a restaurant-wide coworker picker for shift
  trades, and the correct fix there is column-level (a restricted view/RPC exposing only `id`/
  `name`), which RLS can't express and which has ~20 unrelated call sites. Residual risk: a
  `staff` user can still enumerate coworker `employees` rows after this PR; their shifts,
  punches, tips, pay rates, labor allocations, and overtime adjustments are closed at both
  layers, their employee record is not.

Design doc: `docs/superpowers/specs/2026-08-05-employee-self-scoped-data-design.md`

## Test plan

- [x] `tests/unit/useMyShifts.test.ts`, `tests/unit/useMyPayroll.test.ts` — recorded
      query-builder calls (not returned rows) confirm the `employee_id` predicate is applied,
      the disabled-query zero-request guard when `employeeId` is `null`, and that admin vs.
      self-scoped cache keys never collide.
- [x] `supabase/tests/rls_employee_self_scope.sql` (pgTAP, 26 assertions) — per table: staff
      sees own row, staff does not see a coworker's row, chef sees both (scheduling arm),
      collaborator_accountant sees both (payroll arm); plus the shift-trade clause's two arms
      (`offered_shift_id`, `requested_shift_id`).
- [x] `tests/unit/tools-registry.test.ts`, `tests/unit/periodMetrics.test.ts` — capability gating
      on `get_labor_costs`/`get_schedule_overview` and `get_kpis`'s labor-field redaction.
- [x] Full suite: `npx vitest run` — 716 files / 8792 tests passed (0 failed), `npm run test:db`
      — 2653/2653 pgTAP passed, `npm run typecheck`/`npm run lint` — no new errors beyond the
      pre-existing repo baseline, `npm run build` — succeeds.
- [x] Manual RLS spot-check against local PostgREST with two real auth users + real access
      tokens (not just the pgTAP harness's simulated context) — confirmed a staff user's
      `shifts` query returns exactly their own row.
- [x] `EXPLAIN ANALYZE` on the tightened `time_punches` policy at 20,000-row scale — ~3.5ms
      execution overhead, no fallback needed.
- [x] `npx playwright test --project=e2e` — 185/201 passed; the 4 flaky-under-parallel failures
      reproduced green in isolation, and the 1 failure that reproduces consistently
      (`manual-sale-tip-not-doubled.spec.ts`) has zero file overlap with this branch's diff
      (pre-existing POS-sales issue, unrelated to employee self-scoped RLS/payroll hooks).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Employees now see only their own shifts and payroll information.
  * Available shifts, schedules, and pay pages load employee-specific data securely.
  * AI scheduling and payroll insights now require the appropriate access capability.
  * Labor metrics are omitted when access is unavailable, while food-cost metrics remain visible.

* **Bug Fixes**
  * Prevented unauthorized access to coworkers’ payroll and scheduling records.
  * Preserved approved visibility for shift-trade information and authorized roles.

* **Tests**
  * Added coverage for employee data scoping, access controls, loading states, and metric redaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->