### PR TITLE
feat(reviews): print a table tent, a counter card, or a sticker sheet from the QR dialog

### DIFF
--- a/docs/superpowers/plans/2026-08-07-review-qr-printable-plan.md
+++ b/docs/superpowers/plans/2026-08-07-review-qr-printable-plan.md
@@ -1,0 +1,273 @@
+# Printable review QR — implementation plan
+
+Date: 2026-08-07
+Branch: `feature/review-qr-printable`
+Design: [2026-08-07-review-qr-printable-design.md](../specs/2026-08-07-review-qr-printable-design.md)
+
+Build order follows TDD. Write the test first. See it fail. Write the code.
+
+## Step 1 — Extract the branding helpers
+
+Create `src/lib/reviews/reviewBranding.ts`.
+
+```ts
+export function initials(name: string): string;
+export function logoPublicUrl(path: string | null): string | null;
+```
+
+Move `initials` out of `ReviewPage.tsx:31`. Keep the body identical.
+`logoPublicUrl` returns `null` for a null path. Otherwise it returns
+`supabase.storage.from('review-page-logos').getPublicUrl(path).data.publicUrl`.
+This mirrors the edge function at `review-public/index.ts:137-138`.
+
+Change `ReviewPage.tsx`: import `initials`, delete the private copy.
+
+**Test** `tests/unit/reviewBranding.test.ts`:
+- `initials('Blue Fin')` returns `BF`.
+- `initials('Nobu')` returns `N`.
+- `initials('')` returns an empty string.
+- `initials('Café Ñoño')` handles the accents.
+- `logoPublicUrl(null)` returns `null`.
+- `logoPublicUrl('a/b/c.png')` returns a string that ends with the path.
+
+## Step 2 — The size record and the ready gate
+
+Create `src/lib/reviews/printSheet.ts`.
+
+```ts
+export type SheetSizeKey = 'tent' | 'card' | 'stickers';
+
+export interface SheetSize {
+  key: SheetSizeKey;
+  label: string;      // "4 x 6 tent"
+  widthIn: number;
+  heightIn: number;
+  pageSize: string;   // "4in 6in"
+  qrIn: number;
+  previewScale: number;
+  tiles: number;      // 1, or 6 for stickers
+}
+
+export const SHEET_SIZES: Readonly<Record<SheetSizeKey, SheetSize>>;
+export const MAX_MESSAGE_LENGTH = 120;
+export async function waitForPrintReady(root: HTMLElement | null, budgetMs?: number): Promise<void>;
+```
+
+Values: `tent` 4×6 in, QR 2.6 in, 1 tile. `card` 5.5×8.5 in, QR 3.2 in, 1 tile.
+`stickers` 8.5×11 in, QR 1.9 in, 6 tiles.
+
+`waitForPrintReady` races two promises:
+1. `Promise.all([document.fonts.ready, ...images.map(decode)])`, where every
+    `decode()` rejection resolves instead.
+2. A timer of `budgetMs`, default 4000.
+
+The race never rejects. A dead Print button is worse than a late font.
+
+**Test** `tests/unit/printSheet.test.ts`:
+- `SHEET_SIZES` holds exactly three keys.
+- Every `pageSize` string matches its own `widthIn` and `heightIn`.
+- `waitForPrintReady` resolves when fonts and images resolve.
+- It resolves when an image `decode()` rejects.
+- It resolves on the budget when `document.fonts.ready` never settles.
+  Use fake timers.
+
+## Step 3 — The print CSS
+
+Create `src/styles/print-sheet.css`.
+
+```css
+#review-print-root { position: absolute; left: -100000px; top: 0; }
+
+@media print {
+  body > *:not(#review-print-root) { display: none !important; }
+  #review-print-root { position: static; left: auto; }
+}
+
+@media print {
+  .sheet-tent     { /* @page rule via a size-specific class on <html> */ }
+}
+```
+
+The three `@page` rules need a size selector. CSS cannot read a class inside
+`@page`. Use three named pages instead:
+
+```css
+@page tent     { size: 4in 6in;    margin: 0; }
+@page card     { size: 5.5in 8.5in; margin: 0; }
+@page stickers { size: 8.5in 11in;  margin: 0; }
+
+#review-print-root[data-size='tent']     { page: tent; }
+#review-print-root[data-size='card']     { page: card; }
+#review-print-root[data-size='stickers'] { page: stickers; }
+```
+
+Add `break-inside: avoid` to each sticker tile. Add
+`print-color-adjust: exact` to the logo image and the QR block only.
+
+Do not use `display: none` on the print root. A `display: none` image may reject
+`decode()`.
+
+## Step 4 — The sheet component
+
+Create `src/components/reviews/ReviewTentSheet.tsx`.
+
+```tsx
+interface ReviewTentSheetProps {
+  size: SheetSizeKey;
+  restaurantName: string;
+  logoUrl: string | null;
+  message: string;
+  qrSvg: string | null;
+  publicUrl: string;
+}
+```
+
+Rules:
+- No hooks. No data fetch. Props only.
+- Root element carries `theme-counter` and `aria-hidden="true"`.
+- Import the four `@fontsource` CSS files, `@/styles/counter-theme.css`, and
+  `@/styles/print-sheet.css`.
+- Stack: logo or initials circle, restaurant name in `counter-micro` uppercase,
+  `counter-rule`, message in `counter-display`, QR block, `publicUrl` in
+  `counter-micro`.
+- Size the type in `pt`, not `px`.
+- The logo `<img>` carries `crossOrigin="anonymous"` and `alt=""`.
+- On a logo load error, switch to the initials circle. Use local state on a
+  small inner component, or an `onError` handler that sets a flag on the
+  element. Keep the sheet itself hook-free.
+- `stickers` renders `SHEET_SIZES.stickers.tiles` copies of the tile in a 2 × 3
+  grid.
+- Inject `qrSvg` with `dangerouslySetInnerHTML`. Carry the existing safety
+  comment from `ReviewQrDialog.tsx:109-113`.
+- Draw a dashed cut line around the trim area. Risk 1 in the design needs it.
+
+**Test** `tests/unit/ReviewTentSheet.test.tsx`:
+- Renders the restaurant name, the message, and the URL.
+- Shows the initials circle when `logoUrl` is `null`.
+- Shows the `<img>` when `logoUrl` is a string.
+- Renders 6 tiles for `stickers` and 1 for `tent`.
+- The root carries `aria-hidden="true"` and `data-size`.
+
+## Step 5 — Rewire the dialog
+
+Change `src/components/reviews/ReviewQrDialog.tsx`.
+
+New props: `restaurantName: string`, `logoPath: string | null`,
+`defaultMessage: string`.
+
+State: `size` (default `'tent'`), `message` (default `defaultMessage`),
+`printSvg`, `printing`, `printAttempt`.
+
+Reset `message` to `defaultMessage` whenever `open` turns false, or whenever
+`defaultMessage` changes.
+
+Generate a third SVG with `margin: 4` for the sheet. Keep `margin: 1` for the
+preview square and the two downloads. Add it to the existing `Promise.all` at
+`ReviewQrDialog.tsx:50-53`, so one dynamic import serves all three.
+
+Build `sheetProps` once. Render two mounts:
+
+```tsx
+const sheetProps = { size, restaurantName, logoUrl, message, qrSvg: printSvg, publicUrl };
+
+// inside DialogContent
+<div className="tent-preview rounded-xl border border-border/40 bg-muted/30 …">
+  <ReviewTentSheet {...sheetProps} />
+</div>
+
+// portal
+{createPortal(
+  <div id="review-print-root" data-size={size} ref={printRootRef}>
+    <ReviewTentSheet {...sheetProps} />
+  </div>,
+  document.body
+)}
+```
+
+Mount the portal only while `open` is true.
+
+Print handler:
+
+```ts
+const attempt = printAttempt + 1;
+setPrintAttempt(attempt);
+setPrinting(true);
+await waitForPrintReady(printRootRef.current, 4000);
+setPrinting(false);
+window.print();
+```
+
+Extend the live region. Every string carries the attempt number, so a second
+click announces a change:
+
+- `Preparing the sheet… (attempt ${attempt})`
+- `Sheet ready. The print dialog is open. (attempt ${attempt})`
+
+Controls, with the classes from the design section 6:
+- A `RadioGroup` for the three sizes, with a visible `<Label>`.
+- An `<Input>` for the message, with a `<Label>` and a character counter.
+  `maxLength={MAX_MESSAGE_LENGTH}`.
+- A Print button with visible text and no `aria-label`. Disable it until
+  `printSvg` is ready.
+- Keep both download buttons unchanged.
+
+Widen `DialogContent` from `max-w-md` to `max-w-2xl`, because the preview needs
+the room.
+
+**Test** `tests/unit/ReviewQrDialog.print.test.tsx`:
+- The message field starts at `defaultMessage`.
+- Close and reopen resets the message.
+- `window.print` runs only after the ready promise settles.
+- A second print announces a different live-region string.
+- Both mounts show the same message text.
+- The size radio changes `data-size` on the print root.
+
+## Step 6 — Thread the props
+
+`ReviewPageBuilder.tsx`:
+- Add `restaurantName: string` to the props interface.
+- Pass `restaurantName`, `logoPath={page.logo_path}`,
+  `defaultMessage={page.headline}` to `ReviewQrDialog`.
+
+`Reviews.tsx`:
+- Pass `restaurantName={selectedRestaurant.restaurant.name}` to the builder.
+  The nested path matters. `UserRestaurant` has no top-level `name`
+  (`useRestaurants.tsx:60-78`).
+
+## Step 7 — The e2e test
+
+Create `tests/e2e/review-qr-print.spec.ts`.
+
+- Sign in, open a review page, open the QR dialog.
+- Stub `window.print` with `page.addInitScript`.
+- Check the preview shows the restaurant name.
+- Change the size to `card`. Check `#review-print-root` carries
+  `data-size="card"`.
+- Type in the message field. Check the sheet text changes.
+- Click Print. Check the stub ran once.
+
+Use `page.getByRole` and `page.getByLabel`. Import helpers from
+`'../helpers/e2e-supabase'`.
+
+Run it in the foreground with `--reporter=line`. Bound it with the Bash tool's
+`timeout` parameter. Start no poll loop.
+
+## Step 8 — Verify
+
+```bash
+npm run typecheck && npm run lint && npm run test
+```
+
+Then the e2e run. Then a manual print check in Chrome **and** Safari, per design
+risk 2. Use the browser print preview. Check three things: the paper size, the
+QR quiet zone, and that the dialog chrome does not appear on the sheet.
+
+## Order and dependencies
+
+Steps 1, 2, and 3 are independent. Step 4 needs 2 and 3. Step 5 needs 1, 2,
+and 4. Step 6 needs 5. Step 7 needs 6.
+
+## Out of scope
+
+The design section 10 lists it. No migration. No new column. No RLS change. No
+change to what the QR encodes.

--- a/docs/superpowers/specs/2026-08-07-review-qr-printable-design.md
+++ b/docs/superpowers/specs/2026-08-07-review-qr-printable-design.md
@@ -1,0 +1,346 @@
+# Printable review QR — design
+
+Date: 2026-08-07
+Branch: `feature/review-qr-printable`
+Status: design
+
+## 1. The problem
+
+A restaurant manager opens the QR dialog and gets a bare black square with two
+download buttons ([ReviewQrDialog.tsx:121-148](../../../src/components/reviews/ReviewQrDialog.tsx)).
+The manager must then place that square in Word or Canva, add the logo, add a
+message, and set the paper size. Most managers do not do this. They tape the
+raw square to the counter, or they print nothing.
+
+Give the manager a finished sheet instead. One click prints a card that carries
+the logo, the QR code, and a short message, in the same visual language as the
+page the guest lands on after the scan.
+
+## 2. What exists today
+
+### 2.1 The dialog
+
+`ReviewQrDialog` takes `slug` and `publicUrl` and nothing else
+([ReviewQrDialog.tsx:15-20](../../../src/components/reviews/ReviewQrDialog.tsx)).
+It imports the `qrcode` package on demand, because the encoder is about 50 KB
+and only a manager who opens this dialog needs it
+([ReviewQrDialog.tsx:45-53](../../../src/components/reviews/ReviewQrDialog.tsx)).
+It builds two artefacts from one options object:
+
+```ts
+const options = { margin: 1, width: 512, errorCorrectionLevel: 'M' as const };
+```
+
+([ReviewQrDialog.tsx:49](../../../src/components/reviews/ReviewQrDialog.tsx))
+
+It injects the SVG string with `dangerouslySetInnerHTML`. The existing comment
+records why this is safe: the string is the `qrcode` package's own output, and
+it encodes `publicUrl`, which is built from `slug`, which `SLUG_PATTERN` limits
+to `[a-z0-9-]`
+([ReviewQrDialog.tsx:105-114](../../../src/components/reviews/ReviewQrDialog.tsx)).
+
+An `aria-live="polite"` region reports three states: generating, ready, failed
+([ReviewQrDialog.tsx:92-98](../../../src/components/reviews/ReviewQrDialog.tsx)).
+
+### 2.2 The parent
+
+`ReviewPageBuilder` mounts the dialog with the saved slug
+([ReviewPageBuilder.tsx:354-361](../../../src/components/reviews/ReviewPageBuilder.tsx)).
+Its props are `page`, `restaurantId`, `canManage`, and `onCreated`
+([ReviewPageBuilder.tsx:33-38](../../../src/components/reviews/ReviewPageBuilder.tsx)).
+The QR button sits outside the `canManage` guard on purpose. The comment states
+the rule: printing the tent is a read, not a write
+([ReviewPageBuilder.tsx:317-327](../../../src/components/reviews/ReviewPageBuilder.tsx)).
+
+`Reviews.tsx` renders the builder and holds `selectedRestaurant` from
+`useRestaurantContext()` ([Reviews.tsx:28-30](../../../src/pages/Reviews.tsx),
+[Reviews.tsx:430-437](../../../src/pages/Reviews.tsx)). The context type carries
+a `name` field ([RestaurantContext.tsx:13](../../../src/contexts/RestaurantContext.tsx)).
+The builder does not receive that name today.
+
+### 2.3 The Counter theme
+
+`.theme-counter` pins a warm paper palette and two font variables
+([counter-theme.css:19-52](../../../src/styles/counter-theme.css)):
+
+```css
+--font-display: 'Zilla Slab', Georgia, serif;
+--font-mono-micro: 'IBM Plex Mono', ui-monospace, monospace;
+```
+
+([counter-theme.css:50-51](../../../src/styles/counter-theme.css))
+
+Three helper classes apply them: `.counter-display`, `.counter-micro`, and
+`.counter-rule` ([counter-theme.css:54-67](../../../src/styles/counter-theme.css)).
+
+**Neither font loads today.** `index.html` fetches only Roboto from Google Fonts
+([index.html:26](../../../index.html)). No `@font-face` rule for Zilla Slab or
+IBM Plex Mono exists anywhere in `src/`. The theme therefore renders its
+Georgia and `ui-monospace` fallbacks on every guest device.
+
+### 2.4 The logo
+
+`uploadLogo` writes the object and stores the storage path on the row
+([useReviewPages.ts:208-238](../../../src/hooks/useReviewPages.ts)):
+
+```ts
+const path = `${restaurantId}/${pageId}/${crypto.randomUUID()}.${extension}`;
+```
+
+([useReviewPages.ts:213](../../../src/hooks/useReviewPages.ts))
+
+The manager-side type carries `logo_path`, not a URL
+([useReviewPages.ts:14](../../../src/hooks/useReviewPages.ts)). The hook returns
+no public-URL helper ([useReviewPages.ts:240-248](../../../src/hooks/useReviewPages.ts)).
+The bucket is public, so no signature is necessary:
+
+```sql
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES ('review-page-logos', 'review-page-logos', true, 2097152, ...);
+```
+
+([20260804100100_review_funnel_tables.sql:202-206](../../../supabase/migrations/20260804100100_review_funnel_tables.sql))
+
+A public read policy also exists
+([20260804100100_review_funnel_tables.sql:213-215](../../../supabase/migrations/20260804100100_review_funnel_tables.sql)).
+
+### 2.5 The guest surface the print must match
+
+`ReviewPage` stacks the logo, the restaurant name, a dashed rule, and the
+headline ([ReviewPage.tsx:290-317](../../../src/pages/ReviewPage.tsx)):
+
+- logo in `h-14 w-14 rounded-full object-cover`, or initials in the same circle
+- restaurant name in `counter-micro`, 12 px, uppercase, wide tracking
+- `counter-rule` divider
+- headline in `counter-display`, 26 px, semibold, centred
+
+The initials fallback uses a private helper, `initials`, declared inside the
+page file ([ReviewPage.tsx:31](../../../src/pages/ReviewPage.tsx)). It is not
+exported and no other file can reach it.
+
+### 2.6 No print CSS exists
+
+A search of `src/` finds no `@media print` block and no `@page` rule. This
+feature adds the first one in the codebase.
+
+## 3. Decisions the user confirmed
+
+| Question | Decision |
+| --- | --- |
+| Fonts | Self-host Zilla Slab and IBM Plex Mono. Scope them to the Counter theme. The print step waits on `document.fonts.ready`. This also changes the live guest page: it starts to render the slab serif it was designed for. |
+| Message | One-off. Do not store it. The field starts at the page headline and resets when the dialog closes. No migration, no RLS change, no pgTAP test. |
+| Sizes | Ship all three: 4×6 in tent, 5.5×8.5 in counter card, 6-up sticker sheet on US Letter. |
+
+## 4. Architecture
+
+### 4.1 The one-instance rule
+
+`memory/lessons.md` records a failure from 2026-06-28: a print surface and a
+screen surface that each build their own markup drift apart. The lesson demands
+one tested helper at the prop boundary.
+
+This design goes further. **The sheet exists exactly once in the DOM.** The
+dialog renders one `<ReviewTentSheet>`. On screen a wrapper scales it down with
+a CSS `transform`. In print, a `@media print` block removes the transform and
+hides every other element on the page. There is no second copy to drift, and
+no `window.open` document to re-derive.
+
+```text
+ReviewQrDialog
+├── controls (size radio, message input, Print, Download SVG, Download PNG)
+└── <div class="tent-preview">        ← transform: scale(k); screen only
+    └── <ReviewTentSheet …props />    ← the single instance, real print size
+```
+
+`window.open` was rejected. A popup blocker kills it, the new document loses
+Tailwind, and it loses the Supabase session that the logo request may need.
+
+### 4.2 New files
+
+| File | Purpose |
+| --- | --- |
+| `src/lib/reviews/reviewBranding.ts` | `initials(name)`, moved out of `ReviewPage.tsx` and exported. `logoPublicUrl(path)` wraps `supabase.storage.from('review-page-logos').getPublicUrl(path)`. Both are pure enough to unit test. |
+| `src/lib/reviews/printSheet.ts` | `SHEET_SIZES`, a frozen record of the three sizes with their inch dimensions, `@page` size string, QR side length, and preview scale. Also `waitForPrintReady(root)`, which awaits `document.fonts.ready` and every `img.decode()` inside `root`. |
+| `src/components/reviews/ReviewTentSheet.tsx` | Presentational. Props only, no hooks, no data fetch. Renders the paper: logo or initials, restaurant name, rule, message, QR, and the URL in micro type. |
+| `src/styles/print-sheet.css` | The `@media print` block and the three `@page` rules. Imported by `ReviewTentSheet.tsx`. |
+| `src/styles/counter-fonts.css` | The four `@font-face` rules. Imported by `counter-theme.css`. |
+| `src/assets/fonts/*.woff2` | Zilla Slab 400 and 600, IBM Plex Mono 400 and 500. Latin subset only. |
+
+### 4.3 Changed files
+
+| File | Change |
+| --- | --- |
+| `ReviewQrDialog.tsx` | Widen the props: add `restaurantName`, `logoPath`, `defaultMessage`. Add the size radio, the message input, and the Print button. Keep both download buttons. Keep the dynamic import. Keep the live region and extend it. |
+| `ReviewPageBuilder.tsx` | Pass `restaurantName`, `page.logo_path`, and `page.headline` down to the dialog. |
+| `Reviews.tsx` | Pass `selectedRestaurant.name` into the builder as `restaurantName`. |
+| `ReviewPage.tsx` | Import `initials` from `reviewBranding.ts`. Delete the private copy. |
+| `counter-theme.css` | Add `@import './counter-fonts.css';` at the top. |
+
+### 4.4 The three sizes
+
+| Key | Paper | QR side | Layout |
+| --- | --- | --- | --- |
+| `tent` | 4 × 6 in portrait | 2.6 in | Full sheet. Logo, name, rule, message, QR, URL. |
+| `card` | 5.5 × 8.5 in portrait | 3.2 in | Same stack, larger type, more air. |
+| `stickers` | 8.5 × 11 in Letter | 1.9 in | A 2 × 3 grid of six identical small tiles, each with logo, QR, and one short line. |
+
+`SHEET_SIZES` holds these values once. The `@page` rule and the sheet element
+both read from the same record, so a size can never disagree with its paper.
+
+### 4.5 Print correctness
+
+The current options produce a 512 px raster
+([ReviewQrDialog.tsx:49](../../../src/components/reviews/ReviewQrDialog.tsx)).
+At a 2.6 in QR that is about 197 dpi, and at 3.2 in about 160 dpi. A phone
+camera reads that, but the edges soften. The sheet therefore embeds the **SVG**,
+which is resolution independent. The PNG download stays for managers who paste
+the code into other software.
+
+Three further rules:
+
+1. **Quiet zone.** `margin: 1` gives one module of white border. The QR
+   specification requires four. Generate a second SVG for the sheet with
+   `margin: 4`. Keep `margin: 1` for the on-screen preview square and the two
+   downloads, so the existing downloads do not change shape.
+2. **Error correction.** Keep level `M`. The sheet places no logo over the code,
+   so the higher levels only add modules and shrink each one.
+3. **Ink.** Pure black on pure white inside the QR block. Apply
+   `print-color-adjust: exact` to the logo image and the QR block only. Do not
+   apply it to the paper, and do not print a full-bleed warm background: a
+   restaurant printer would drain a colour cartridge on every sheet.
+
+### 4.6 The print sequence
+
+```text
+click Print
+  → generate the margin-4 SVG if it is not ready yet
+  → announce "Preparing the sheet…" in the live region
+  → await waitForPrintReady(sheetRef.current)
+        · document.fonts.ready
+        · every <img> in the sheet: decode()
+  → announce "Sheet ready. The print dialog is open."
+  → window.print()
+```
+
+The wait matters. Without it the browser prints Georgia while Zilla Slab is
+still in flight, and prints an empty box where the logo will be.
+
+The logo is a cross-origin image from Supabase Storage. Set
+`crossOrigin="anonymous"` so `decode()` resolves and a future canvas step is not
+blocked. If the logo fails to load, fall back to the initials circle and print
+anyway. A missing logo must never block the print.
+
+### 4.7 Fonts
+
+Self-host four files under `src/assets/fonts/`. This follows the MICR
+precedent, which already stores a font in that directory and imports it with
+Vite's `?url` suffix ([micr-e13b.ts:3](../../../src/assets/fonts/micr-e13b.ts)).
+
+Each `@font-face` uses `font-display: swap` and a `unicode-range` limited to
+Latin. The rules live in `counter-fonts.css`, which `counter-theme.css` imports,
+so a page that never mounts the Counter theme never requests the files.
+
+Record the licence. Both families are SIL Open Font License 1.1. Add
+`src/assets/fonts/ZillaSlab-LICENSE.txt` and
+`src/assets/fonts/IBMPlexMono-LICENSE.txt`, next to the existing
+`MICR-E13B-LICENSE.txt`.
+
+**Known side effect.** The guest review page changes appearance the moment this
+merges. Georgia becomes Zilla Slab and the system mono becomes IBM Plex Mono.
+This is intended: the theme already asks for these families
+([counter-theme.css:50-51](../../../src/styles/counter-theme.css)). Re-check the
+contrast gate that the theme header records — 8.1:1 for `--muted-foreground` on
+`--background`. Contrast does not depend on the font, so the gate holds, but the
+new faces have different stroke weights. Confirm the 12 px micro copy stays
+legible.
+
+## 5. Access and security
+
+The QR button stays open to a viewer
+([ReviewPageBuilder.tsx:317-318](../../../src/components/reviews/ReviewPageBuilder.tsx)).
+The printable adds no write, so this rule does not change. The message field is
+local state and never reaches the database.
+
+The logo URL comes from `getPublicUrl` on a bucket that is already public
+([20260804100100_review_funnel_tables.sql:206](../../../supabase/migrations/20260804100100_review_funnel_tables.sql)),
+so no signed URL and no service-role key is involved.
+
+The message text renders as a React text node, never through
+`dangerouslySetInnerHTML`. Only the QR SVG uses that path, and the existing
+comment already justifies it
+([ReviewQrDialog.tsx:109-113](../../../src/components/reviews/ReviewQrDialog.tsx)).
+Cap the message at 120 characters, because a longer string overflows the sheet
+and pushes the QR off the paper.
+
+## 6. Accessibility
+
+The existing live region reports three states
+([ReviewQrDialog.tsx:92-98](../../../src/components/reviews/ReviewQrDialog.tsx)).
+Extend it to report the print sequence.
+
+Warning: an `aria-live` region announces a **change**. Two identical consecutive
+strings announce nothing. A second Print click must therefore announce a
+distinct string, or the screen reader user hears silence and believes the button
+is dead. Include an attempt counter in the announced string, or clear the region
+before the next message.
+
+Other rules:
+
+- The size control is a `RadioGroup` with a visible `<Label>`, not three buttons.
+- The message input has an associated `<Label>`.
+- The Print button carries `aria-label="Print the review sheet"`.
+- The sheet itself is `aria-hidden="true"` on screen. It is a preview of paper,
+  and its text already appears in the controls above it.
+- The QR image inside the sheet keeps `role="img"` and an `aria-label` that
+  names the destination URL.
+
+## 7. Testing
+
+| Test | Location | Covers |
+| --- | --- | --- |
+| `reviewBranding.test.ts` | `tests/unit/` | `initials` for one word, two words, empty, and accented input. `logoPublicUrl` returns null for a null path. |
+| `printSheet.test.ts` | `tests/unit/` | `SHEET_SIZES` holds three keys. Each `@page` size string matches its inch dimensions. `waitForPrintReady` resolves when fonts and images resolve, and still resolves when an image rejects. |
+| `ReviewTentSheet.test.tsx` | `tests/unit/` | Renders the restaurant name, the message, and the URL. Falls back to initials when `logoUrl` is null. Applies the size class for each of the three keys. |
+| `ReviewQrDialog.print.test.tsx` | `tests/unit/` | The message field starts at `defaultMessage` and resets on close. `window.print` is called only after the ready promise settles. A second print announces a different string. |
+| `review-qr-print.spec.ts` | `tests/e2e/` | Open the dialog, switch size, confirm the preview element carries the new size class, confirm the message input drives the sheet text. Stub `window.print`. |
+
+Playwright cannot read a rendered PDF. The e2e test therefore asserts the DOM
+and the stubbed call, not the paper.
+
+Follow the repository rule on unbounded waits. Run Playwright in the foreground
+with `--reporter=line` and let the Bash tool's own `timeout` bound it.
+
+## 8. Rejected alternatives
+
+| Option | Why not |
+| --- | --- |
+| `window.open` and write a document | A popup blocker kills it. The new document has no Tailwind and no session. |
+| Render the sheet to canvas and download a PDF | Adds a PDF dependency for a job the browser already does. Rasterises the QR, which is the one element that must stay vector. |
+| Store the message on `review_pages` | Needs a migration, an RLS review, and a pgTAP test for a string the manager types once and prints. The user chose the one-off field. |
+| Two components, one for preview and one for print | This is the exact drift the 2026-06-28 lesson records. One instance, one transform. |
+| Load the fonts from Google Fonts | A third-party request on the guest page. Self-hosting removes it and keeps the print deterministic. |
+
+## 9. Risks
+
+1. **Browser print differences.** Safari and Chrome disagree on `@page size`.
+   Chrome honours it. Safari often falls back to the user's paper choice. Print
+   a visible cut line on the sheet so a Safari user on Letter still gets a
+   correct trim.
+2. **Font weight of the print.** A 12 px `counter-micro` line at 4 in wide is
+   small on paper. Set the sheet's type in `pt`, not `px`, and verify the URL
+   line stays readable.
+3. **The guest page changes look.** Section 4.7 records this. It is intended and
+   it needs a visual check before the PR.
+4. **`node_modules` in this worktree.** A 2026-08-05 lesson records that a
+   worktree whose `node_modules` predates the `qrcode` dependency fails this
+   exact file's tests with a Vite import-analysis overlay. `npm install` already
+   ran in this worktree and `qrcode` is present.
+
+## 10. Out of scope
+
+- Any change to the public review page beyond the font swap and the `initials`
+  import.
+- Any new database column, RPC, RLS policy, or edge function.
+- Any change to what the QR encodes. The URL stays `${origin}/r/${slug}`
+  ([ReviewPageBuilder.tsx:359](../../../src/components/reviews/ReviewPageBuilder.tsx)).
+- Batch print across several review pages at once.

--- a/docs/superpowers/specs/2026-08-07-review-qr-printable-design.md
+++ b/docs/superpowers/specs/2026-08-07-review-qr-printable-design.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-07
 Branch: `feature/review-qr-printable`
-Status: design
+Status: design, revision 2 (Phase 2.5 review folded in)
 
 ## 1. The problem
 
@@ -42,7 +42,26 @@ to `[a-z0-9-]`
 An `aria-live="polite"` region reports three states: generating, ready, failed
 ([ReviewQrDialog.tsx:92-98](../../../src/components/reviews/ReviewQrDialog.tsx)).
 
-### 2.2 The parent
+### 2.2 The dialog shell
+
+`DialogContent` applies these classes
+([dialog.tsx:40](../../../src/components/ui/dialog.tsx)):
+
+```text
+fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg max-h-[85vh]
+translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto …
+```
+
+Four of those values matter for print: `fixed`, `max-h-[85vh]`,
+`overflow-y-auto`, and the two `translate` transforms. A `position: fixed`
+ancestor with a capped height and `overflow-y-auto` clips its children to the
+screen. Section 4.1 records the consequence.
+
+`DialogContent` renders inside a `DialogPortal`
+([dialog.tsx:34-36](../../../src/components/ui/dialog.tsx)), so the whole dialog
+is a direct child of `document.body`.
+
+### 2.3 The parent
 
 `ReviewPageBuilder` mounts the dialog with the saved slug
 ([ReviewPageBuilder.tsx:354-361](../../../src/components/reviews/ReviewPageBuilder.tsx)).
@@ -54,11 +73,16 @@ the rule: printing the tent is a read, not a write
 
 `Reviews.tsx` renders the builder and holds `selectedRestaurant` from
 `useRestaurantContext()` ([Reviews.tsx:28-30](../../../src/pages/Reviews.tsx),
-[Reviews.tsx:430-437](../../../src/pages/Reviews.tsx)). The context type carries
-a `name` field ([RestaurantContext.tsx:13](../../../src/contexts/RestaurantContext.tsx)).
-The builder does not receive that name today.
+[Reviews.tsx:430-437](../../../src/pages/Reviews.tsx)).
 
-### 2.3 The Counter theme
+`selectedRestaurant` has type `UserRestaurant`
+([useRestaurants.tsx:60-78](../../../src/hooks/useRestaurants.tsx)). That type
+has **no** top-level `name` field. The name sits on the nested `restaurant`
+object ([useRestaurants.tsx:10-12](../../../src/hooks/useRestaurants.tsx)). The
+correct path is `selectedRestaurant.restaurant.name`. The builder does not
+receive that name today.
+
+### 2.4 The Counter theme
 
 `.theme-counter` pins a warm paper palette and two font variables
 ([counter-theme.css:19-52](../../../src/styles/counter-theme.css)):
@@ -73,12 +97,24 @@ The builder does not receive that name today.
 Three helper classes apply them: `.counter-display`, `.counter-micro`, and
 `.counter-rule` ([counter-theme.css:54-67](../../../src/styles/counter-theme.css)).
 
-**Neither font loads today.** `index.html` fetches only Roboto from Google Fonts
-([index.html:26](../../../index.html)). No `@font-face` rule for Zilla Slab or
-IBM Plex Mono exists anywhere in `src/`. The theme therefore renders its
-Georgia and `ui-monospace` fallbacks on every guest device.
+**Both fonts already load.** `ReviewPage.tsx` imports them from `@fontsource`
+([ReviewPage.tsx:24-27](../../../src/pages/ReviewPage.tsx)):
 
-### 2.4 The logo
+```ts
+import '@fontsource/zilla-slab/400.css';
+import '@fontsource/zilla-slab/600.css';
+import '@fontsource/ibm-plex-mono/400.css';
+import '@/styles/counter-theme.css';
+```
+
+`package.json:53-54` lists both packages. The packages self-host the woff2
+files and declare the `@font-face` rules inside `node_modules`. The guest page
+renders Zilla Slab and IBM Plex Mono today.
+
+`ReviewPage.tsx:27` is the **only** import of `counter-theme.css` in `src/`. The
+manager pane therefore has neither the theme nor the fonts today.
+
+### 2.5 The logo
 
 `uploadLogo` writes the object and stores the storage path on the row
 ([useReviewPages.ts:208-238](../../../src/hooks/useReviewPages.ts)):
@@ -99,12 +135,18 @@ INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_typ
 VALUES ('review-page-logos', 'review-page-logos', true, 2097152, ...);
 ```
 
-([20260804100100_review_funnel_tables.sql:202-206](../../../supabase/migrations/20260804100100_review_funnel_tables.sql))
+([20260804100100_review_funnel_tables.sql:202-210](../../../supabase/migrations/20260804100100_review_funnel_tables.sql))
 
 A public read policy also exists
 ([20260804100100_review_funnel_tables.sql:213-215](../../../supabase/migrations/20260804100100_review_funnel_tables.sql)).
+No later migration changes the bucket or drops that policy.
 
-### 2.5 The guest surface the print must match
+The public page gets its `logo_url` from the edge function, which calls plain
+`getPublicUrl` with no signature and no transform
+([review-public/index.ts:137-138](../../../supabase/functions/review-public/index.ts)).
+The manager side cannot reach that code, because it runs on the server.
+
+### 2.6 The guest surface the print must match
 
 `ReviewPage` stacks the logo, the restaurant name, a dashed rule, and the
 headline ([ReviewPage.tsx:290-317](../../../src/pages/ReviewPage.tsx)):
@@ -118,39 +160,70 @@ The initials fallback uses a private helper, `initials`, declared inside the
 page file ([ReviewPage.tsx:31](../../../src/pages/ReviewPage.tsx)). It is not
 exported and no other file can reach it.
 
-### 2.6 No print CSS exists
+### 2.7 No print CSS exists
 
 A search of `src/` finds no `@media print` block and no `@page` rule. This
 feature adds the first one in the codebase.
 
-## 3. Decisions the user confirmed
+## 3. Decisions
 
 | Question | Decision |
 | --- | --- |
-| Fonts | Self-host Zilla Slab and IBM Plex Mono. Scope them to the Counter theme. The print step waits on `document.fonts.ready`. This also changes the live guest page: it starts to render the slab serif it was designed for. |
 | Message | One-off. Do not store it. The field starts at the page headline and resets when the dialog closes. No migration, no RLS change, no pgTAP test. |
 | Sizes | Ship all three: 4×6 in tent, 5.5×8.5 in counter card, 6-up sticker sheet on US Letter. |
+| Fonts | **Superseded.** The user chose "self-host both fonts" against a false premise. Section 2.4 shows `@fontsource` already loads both. The sheet reuses those packages. Add no font file, no `@font-face` rule, and no licence file. The guest page does not change look. |
 
 ## 4. Architecture
 
-### 4.1 The one-instance rule
+### 4.1 One component, one props object, two mounts
 
-`memory/lessons.md` records a failure from 2026-06-28: a print surface and a
+`memory/lessons.md:791` records a failure from 2026-06-28: a print surface and a
 screen surface that each build their own markup drift apart. The lesson demands
-one tested helper at the prop boundary.
+one tested helper applied at the prop boundary.
 
-This design goes further. **The sheet exists exactly once in the DOM.** The
-dialog renders one `<ReviewTentSheet>`. On screen a wrapper scales it down with
-a CSS `transform`. In print, a `@media print` block removes the transform and
-hides every other element on the page. There is no second copy to drift, and
-no `window.open` document to re-derive.
+An earlier revision tried to satisfy this with a single DOM node inside the
+dialog, scaled down by a CSS `transform`. The Phase 2.5 review rejected that.
+`DialogContent` is `position: fixed` with `max-h-[85vh]`, `overflow-y-auto`, and
+two `translate` transforms ([dialog.tsx:40](../../../src/components/ui/dialog.tsx)).
+A clipped, transformed, fixed ancestor prints the visible scroll window only, or
+prints nothing at all in Safari.
+
+This design therefore mounts `ReviewTentSheet` **twice**, from **one** props
+object built once in `ReviewQrDialog`:
 
 ```text
 ReviewQrDialog
-├── controls (size radio, message input, Print, Download SVG, Download PNG)
-└── <div class="tent-preview">        ← transform: scale(k); screen only
-    └── <ReviewTentSheet …props />    ← the single instance, real print size
+├── sheetProps = { size, restaurantName, logoUrl, message, qrSvg, publicUrl }
+│
+├── inside DialogContent
+│   └── <div class="tent-preview" aria-hidden="true">   ← transform: scale(k)
+│       └── <ReviewTentSheet {...sheetProps} />
+│
+└── createPortal(
+        <div id="review-print-root">
+          <ReviewTentSheet {...sheetProps} />
+        </div>,
+        document.body)
 ```
+
+The lesson forbids two **implementations**. Two mounts of one component from one
+props object cannot drift: React renders the same tree from the same input. The
+print copy hangs off `document.body`, so no Radix ancestor clips it.
+
+Screen and print behaviour of the print root:
+
+```css
+/* Off screen, not display:none — a display:none image may reject decode(). */
+#review-print-root { position: absolute; left: -100000px; top: 0; }
+
+@media print {
+  body > *:not(#review-print-root) { display: none !important; }
+  #review-print-root { position: static; left: auto; }
+}
+```
+
+`body > *` reaches the dialog, because `DialogPortal` puts it there
+([dialog.tsx:34-36](../../../src/components/ui/dialog.tsx)).
 
 `window.open` was rejected. A popup blocker kills it, the new document loses
 Tailwind, and it loses the Supabase session that the logo request may need.
@@ -159,22 +232,24 @@ Tailwind, and it loses the Supabase session that the logo request may need.
 
 | File | Purpose |
 | --- | --- |
-| `src/lib/reviews/reviewBranding.ts` | `initials(name)`, moved out of `ReviewPage.tsx` and exported. `logoPublicUrl(path)` wraps `supabase.storage.from('review-page-logos').getPublicUrl(path)`. Both are pure enough to unit test. |
-| `src/lib/reviews/printSheet.ts` | `SHEET_SIZES`, a frozen record of the three sizes with their inch dimensions, `@page` size string, QR side length, and preview scale. Also `waitForPrintReady(root)`, which awaits `document.fonts.ready` and every `img.decode()` inside `root`. |
-| `src/components/reviews/ReviewTentSheet.tsx` | Presentational. Props only, no hooks, no data fetch. Renders the paper: logo or initials, restaurant name, rule, message, QR, and the URL in micro type. |
-| `src/styles/print-sheet.css` | The `@media print` block and the three `@page` rules. Imported by `ReviewTentSheet.tsx`. |
-| `src/styles/counter-fonts.css` | The four `@font-face` rules. Imported by `counter-theme.css`. |
-| `src/assets/fonts/*.woff2` | Zilla Slab 400 and 600, IBM Plex Mono 400 and 500. Latin subset only. |
+| `src/lib/reviews/reviewBranding.ts` | `initials(name)`, moved out of `ReviewPage.tsx` and exported. `logoPublicUrl(path)` wraps `supabase.storage.from('review-page-logos').getPublicUrl(path)` and returns `null` for a null path. Both are pure enough to unit test. |
+| `src/lib/reviews/printSheet.ts` | `SHEET_SIZES`, a frozen record of the three sizes. Each entry holds the inch dimensions, the `@page` size string, the QR side length, and the preview scale. Also `waitForPrintReady(root, budgetMs)`. |
+| `src/components/reviews/ReviewTentSheet.tsx` | Presentational. Props only, no hooks, no data fetch. Renders the paper. Imports the `@fontsource` CSS and `@/styles/counter-theme.css`. |
+| `src/styles/print-sheet.css` | The `@media print` block, the `#review-print-root` rules, and the three `@page` rules. Imported by `ReviewTentSheet.tsx`. |
+
+The earlier revision also listed `src/styles/counter-fonts.css` and four
+`.woff2` files. Section 3 deletes them.
 
 ### 4.3 Changed files
 
 | File | Change |
 | --- | --- |
-| `ReviewQrDialog.tsx` | Widen the props: add `restaurantName`, `logoPath`, `defaultMessage`. Add the size radio, the message input, and the Print button. Keep both download buttons. Keep the dynamic import. Keep the live region and extend it. |
-| `ReviewPageBuilder.tsx` | Pass `restaurantName`, `page.logo_path`, and `page.headline` down to the dialog. |
-| `Reviews.tsx` | Pass `selectedRestaurant.name` into the builder as `restaurantName`. |
-| `ReviewPage.tsx` | Import `initials` from `reviewBranding.ts`. Delete the private copy. |
-| `counter-theme.css` | Add `@import './counter-fonts.css';` at the top. |
+| `ReviewQrDialog.tsx` | Widen the props: add `restaurantName`, `logoPath`, `defaultMessage`. Add the size radio, the message input, and the Print button. Add the preview mount and the portal mount. Keep both download buttons, the dynamic import, and the live region. |
+| `ReviewPageBuilder.tsx` | Add a `restaurantName` prop. Pass `restaurantName`, `page.logo_path`, and `page.headline` down to the dialog. |
+| `Reviews.tsx` | Pass `selectedRestaurant.restaurant.name` into the builder as `restaurantName`. |
+| `ReviewPage.tsx` | Import `initials` from `reviewBranding.ts`. Delete the private copy at line 31. Keep the four import lines at 24-27 exactly as they are. |
+
+`counter-theme.css` does not change.
 
 ### 4.4 The three sizes
 
@@ -187,6 +262,9 @@ Tailwind, and it loses the Supabase session that the logo request may need.
 `SHEET_SIZES` holds these values once. The `@page` rule and the sheet element
 both read from the same record, so a size can never disagree with its paper.
 
+Each sticker tile carries `break-inside: avoid`, so no tile splits across two
+sheets.
+
 ### 4.5 Print correctness
 
 The current options produce a 512 px raster
@@ -196,7 +274,7 @@ camera reads that, but the edges soften. The sheet therefore embeds the **SVG**,
 which is resolution independent. The PNG download stays for managers who paste
 the code into other software.
 
-Three further rules:
+Four further rules:
 
 1. **Quiet zone.** `margin: 1` gives one module of white border. The QR
    specification requires four. Generate a second SVG for the sheet with
@@ -204,7 +282,10 @@ Three further rules:
    downloads, so the existing downloads do not change shape.
 2. **Error correction.** Keep level `M`. The sheet places no logo over the code,
    so the higher levels only add modules and shrink each one.
-3. **Ink.** Pure black on pure white inside the QR block. Apply
+3. **Page margin.** Set `@page { size: …; margin: 0 }` for every size. A browser
+   applies about 0.5 in of default margin otherwise. That default shrinks the
+   printable area and pushes a seventh partial row of stickers onto sheet two.
+4. **Ink.** Pure black on pure white inside the QR block. Apply
    `print-color-adjust: exact` to the logo image and the QR block only. Do not
    apply it to the paper, and do not print a full-bleed warm background: a
    restaurant printer would drain a colour cartridge on every sheet.
@@ -214,45 +295,47 @@ Three further rules:
 ```text
 click Print
   → generate the margin-4 SVG if it is not ready yet
-  → announce "Preparing the sheet…" in the live region
-  → await waitForPrintReady(sheetRef.current)
+  → announce "Preparing the sheet… (attempt N)" in the live region
+  → await waitForPrintReady(printRootRef.current, 4000)
         · document.fonts.ready
-        · every <img> in the sheet: decode()
-  → announce "Sheet ready. The print dialog is open."
+        · every <img> in the root: decode()
+        · a 4 s budget wins the race and resolves anyway
+  → announce "Sheet ready. The print dialog is open. (attempt N)"
   → window.print()
 ```
 
 The wait matters. Without it the browser prints Georgia while Zilla Slab is
 still in flight, and prints an empty box where the logo will be.
 
+The wait must also never hang. A blocked font request or a stale cache can leave
+`document.fonts.ready` pending. `waitForPrintReady` therefore races the work
+against a 4 s budget and resolves either way. A late font is a cosmetic loss. A
+dead Print button is a broken feature.
+
 The logo is a cross-origin image from Supabase Storage. Set
-`crossOrigin="anonymous"` so `decode()` resolves and a future canvas step is not
-blocked. If the logo fails to load, fall back to the initials circle and print
-anyway. A missing logo must never block the print.
+`crossOrigin="anonymous"` so `decode()` resolves. If the logo fails to load,
+fall back to the initials circle and print anyway. A missing logo must never
+block the print.
 
 ### 4.7 Fonts
 
-Self-host four files under `src/assets/fonts/`. This follows the MICR
-precedent, which already stores a font in that directory and imports it with
-Vite's `?url` suffix ([micr-e13b.ts:3](../../../src/assets/fonts/micr-e13b.ts)).
+No new work. `ReviewTentSheet.tsx` imports the packages that already ship:
 
-Each `@font-face` uses `font-display: swap` and a `unicode-range` limited to
-Latin. The rules live in `counter-fonts.css`, which `counter-theme.css` imports,
-so a page that never mounts the Counter theme never requests the files.
+```ts
+import '@fontsource/zilla-slab/400.css';
+import '@fontsource/zilla-slab/600.css';
+import '@fontsource/ibm-plex-mono/400.css';
+import '@fontsource/ibm-plex-mono/500.css';
+import '@/styles/counter-theme.css';
+```
 
-Record the licence. Both families are SIL Open Font License 1.1. Add
-`src/assets/fonts/ZillaSlab-LICENSE.txt` and
-`src/assets/fonts/IBMPlexMono-LICENSE.txt`, next to the existing
-`MICR-E13B-LICENSE.txt`.
+`node_modules/@fontsource/ibm-plex-mono/500.css` and
+`node_modules/@fontsource/zilla-slab/600.css` both exist. Vite deduplicates a
+CSS module that two entry points import, so the guest page fetches no extra
+bytes.
 
-**Known side effect.** The guest review page changes appearance the moment this
-merges. Georgia becomes Zilla Slab and the system mono becomes IBM Plex Mono.
-This is intended: the theme already asks for these families
-([counter-theme.css:50-51](../../../src/styles/counter-theme.css)). Re-check the
-contrast gate that the theme header records — 8.1:1 for `--muted-foreground` on
-`--background`. Contrast does not depend on the font, so the gate holds, but the
-new faces have different stroke weights. Confirm the 12 px micro copy stays
-legible.
+`ReviewTentSheet` puts `theme-counter` on its own root element, so the manager
+pane keeps its normal palette outside the sheet.
 
 ## 5. Access and security
 
@@ -263,7 +346,9 @@ local state and never reaches the database.
 
 The logo URL comes from `getPublicUrl` on a bucket that is already public
 ([20260804100100_review_funnel_tables.sql:206](../../../supabase/migrations/20260804100100_review_funnel_tables.sql)),
-so no signed URL and no service-role key is involved.
+so no signed URL and no service-role key is involved. `logo_path` already
+travels to any user who can read the row under the existing `review_pages`
+select policy, so the print adds no new exposure.
 
 The message text renders as a React text node, never through
 `dangerouslySetInnerHTML`. Only the QR SVG uses that path, and the existing
@@ -280,32 +365,45 @@ Extend it to report the print sequence.
 
 Warning: an `aria-live` region announces a **change**. Two identical consecutive
 strings announce nothing. A second Print click must therefore announce a
-distinct string, or the screen reader user hears silence and believes the button
-is dead. Include an attempt counter in the announced string, or clear the region
-before the next message.
+distinct string. Section 4.6 puts an attempt counter in every announced string.
+
+Both sheet mounts carry `aria-hidden="true"`. The preview is a picture of paper.
+The print copy sits off screen. Neither is a control, and every value they show
+already appears in a labelled control above them. An `aria-hidden` ancestor
+removes its whole subtree, so the sheet's QR carries **no** `role="img"` and no
+`aria-label`: that markup would be unreachable. The reachable QR is the existing
+preview square in the dialog body, which keeps its `role="img"` and its label
+([ReviewQrDialog.tsx:105-114](../../../src/components/reviews/ReviewQrDialog.tsx)).
 
 Other rules:
 
 - The size control is a `RadioGroup` with a visible `<Label>`, not three buttons.
-- The message input has an associated `<Label>`.
-- The Print button carries `aria-label="Print the review sheet"`.
-- The sheet itself is `aria-hidden="true"` on screen. It is a preview of paper,
-  and its text already appears in the controls above it.
-- The QR image inside the sheet keeps `role="img"` and an `aria-label` that
-  names the destination URL.
+- The message input has an associated `<Label>` and a character counter.
+- The Print button keeps its visible text "Print". It carries no `aria-label`,
+  because a label would override the visible text with no gain.
+
+Classes follow the CLAUDE.md Apple/Notion scale:
+
+- `<Label>`: `text-[12px] font-medium text-muted-foreground uppercase tracking-wider`
+- `<Input>`: `h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border`
+- Print button: `h-9 px-4 rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium`
+- Preview frame: `rounded-xl border border-border/40 bg-muted/30`
+
+No direct colour appears. The sheet's paper colour comes from `theme-counter`'s
+`--background` token.
 
 ## 7. Testing
 
 | Test | Location | Covers |
 | --- | --- | --- |
-| `reviewBranding.test.ts` | `tests/unit/` | `initials` for one word, two words, empty, and accented input. `logoPublicUrl` returns null for a null path. |
-| `printSheet.test.ts` | `tests/unit/` | `SHEET_SIZES` holds three keys. Each `@page` size string matches its inch dimensions. `waitForPrintReady` resolves when fonts and images resolve, and still resolves when an image rejects. |
-| `ReviewTentSheet.test.tsx` | `tests/unit/` | Renders the restaurant name, the message, and the URL. Falls back to initials when `logoUrl` is null. Applies the size class for each of the three keys. |
-| `ReviewQrDialog.print.test.tsx` | `tests/unit/` | The message field starts at `defaultMessage` and resets on close. `window.print` is called only after the ready promise settles. A second print announces a different string. |
-| `review-qr-print.spec.ts` | `tests/e2e/` | Open the dialog, switch size, confirm the preview element carries the new size class, confirm the message input drives the sheet text. Stub `window.print`. |
+| `reviewBranding.test.ts` | `tests/unit/` | `initials` for one word, two words, empty, and accented input. `logoPublicUrl` returns `null` for a null path. |
+| `printSheet.test.ts` | `tests/unit/` | `SHEET_SIZES` holds three keys. Each `@page` size string matches its inch dimensions. `waitForPrintReady` resolves when fonts and images resolve. It still resolves when an image rejects. It resolves on the budget when `document.fonts.ready` never settles. |
+| `ReviewTentSheet.test.tsx` | `tests/unit/` | Renders the restaurant name, the message, and the URL. Falls back to initials when `logoUrl` is null. Applies the size class for each of the three keys. Carries `aria-hidden`. |
+| `ReviewQrDialog.print.test.tsx` | `tests/unit/` | The message field starts at `defaultMessage` and resets on close. `window.print` runs only after the ready promise settles. A second print announces a different string. Both mounts receive the same props. |
+| `review-qr-print.spec.ts` | `tests/e2e/` | Open the dialog, change the size, check the preview element carries the new size class, check the message input drives the sheet text. Stub `window.print`. |
 
-Playwright cannot read a rendered PDF. The e2e test therefore asserts the DOM
-and the stubbed call, not the paper.
+Playwright cannot read a rendered PDF. The e2e test therefore checks the DOM and
+the stubbed call, not the paper.
 
 Follow the repository rule on unbounded waits. Run Playwright in the foreground
 with `--reporter=line` and let the Bash tool's own `timeout` bound it.
@@ -315,31 +413,33 @@ with `--reporter=line` and let the Bash tool's own `timeout` bound it.
 | Option | Why not |
 | --- | --- |
 | `window.open` and write a document | A popup blocker kills it. The new document has no Tailwind and no session. |
+| One DOM node inside the dialog, scaled by `transform` | `DialogContent` is `fixed` with `max-h-[85vh]`, `overflow-y-auto`, and two translate transforms ([dialog.tsx:40](../../../src/components/ui/dialog.tsx)). It clips the print, or prints blank in Safari. |
 | Render the sheet to canvas and download a PDF | Adds a PDF dependency for a job the browser already does. Rasterises the QR, which is the one element that must stay vector. |
-| Store the message on `review_pages` | Needs a migration, an RLS review, and a pgTAP test for a string the manager types once and prints. The user chose the one-off field. |
-| Two components, one for preview and one for print | This is the exact drift the 2026-06-28 lesson records. One instance, one transform. |
-| Load the fonts from Google Fonts | A third-party request on the guest page. Self-hosting removes it and keeps the print deterministic. |
+| Store the message on `review_pages` | Needs a migration, an RLS review, and a pgTAP test for a string the manager types once and prints. |
+| Two components, one for preview and one for print | This is the exact drift the 2026-06-28 lesson records. One component, two mounts, one props object. |
+| Self-host the fonts | `@fontsource` already self-hosts them ([ReviewPage.tsx:24-26](../../../src/pages/ReviewPage.tsx)). A hand-written `@font-face` set would double the font bytes on the guest page. |
 
 ## 9. Risks
 
 1. **Browser print differences.** Safari and Chrome disagree on `@page size`.
    Chrome honours it. Safari often falls back to the user's paper choice. Print
-   a visible cut line on the sheet so a Safari user on Letter still gets a
+   a visible cut line on the sheet, so a Safari user on Letter still gets a
    correct trim.
-2. **Font weight of the print.** A 12 px `counter-micro` line at 4 in wide is
-   small on paper. Set the sheet's type in `pt`, not `px`, and verify the URL
+2. **Safari print of a portalled node.** Section 4.1 removes the `fixed` and
+   `transform` ancestors, which are the documented cause of blank Safari output.
+   The print copy still needs a manual check in real Safari before the PR. Add
+   this to the Phase 8 verify step. A Chrome check alone is not enough.
+3. **Font weight of the print.** A 12 px `counter-micro` line at 4 in wide is
+   small on paper. Set the sheet's type in `pt`, not `px`, and check the URL
    line stays readable.
-3. **The guest page changes look.** Section 4.7 records this. It is intended and
-   it needs a visual check before the PR.
-4. **`node_modules` in this worktree.** A 2026-08-05 lesson records that a
-   worktree whose `node_modules` predates the `qrcode` dependency fails this
-   exact file's tests with a Vite import-analysis overlay. `npm install` already
-   ran in this worktree and `qrcode` is present.
+4. **`node_modules` in this worktree.** A 2026-08-05 lesson (`memory/lessons.md:2325`)
+   records that a worktree whose `node_modules` predates the `qrcode` dependency
+   fails this exact file's tests with a Vite import-analysis overlay.
+   `npm install` already ran in this worktree and `qrcode` is present.
 
 ## 10. Out of scope
 
-- Any change to the public review page beyond the font swap and the `initials`
-  import.
+- Any change to the public review page beyond the `initials` import.
 - Any new database column, RPC, RLS policy, or edge function.
 - Any change to what the QR encodes. The URL stays `${origin}/r/${slug}`
   ([ReviewPageBuilder.tsx:359](../../../src/components/reviews/ReviewPageBuilder.tsx)).

--- a/src/components/reviews/BrandMark.tsx
+++ b/src/components/reviews/BrandMark.tsx
@@ -14,6 +14,9 @@ interface BrandMarkProps {
    * Lifts the broken flag to the parent. The sticker sheet draws six marks from
    * one URL, and one shared flag keeps all six the same on a single sheet.
    * Omit both props to keep the flag local.
+   *
+   * A parent that lifts the flag must key it by URL, as the local flag does.
+   * A plain boolean survives a logo change and hides the new logo.
    */
   broken?: boolean;
   onBroken?: () => void;
@@ -34,8 +37,11 @@ export function BrandMark({
   broken,
   onBroken,
 }: BrandMarkProps) {
-  const [localBroken, setLocalBroken] = useState(false);
-  const isBroken = broken ?? localBroken;
+  // Keyed by URL, not a plain boolean. `logo_path` comes from a React Query
+  // read with `refetchOnWindowFocus`. A manager who uploads a new logo gets a
+  // new URL, and a sticky boolean would show the initials circle forever.
+  const [brokenUrl, setBrokenUrl] = useState<string | null>(null);
+  const isBroken = broken ?? (logoUrl !== null && brokenUrl === logoUrl);
 
   // A logo that fails to load must never leave a blank box, on screen or on
   // paper. Fall back to the initials circle.
@@ -45,7 +51,7 @@ export function BrandMark({
         src={logoUrl}
         alt=""
         onError={() => {
-          setLocalBroken(true);
+          setBrokenUrl(logoUrl);
           onBroken?.();
         }}
         className={cn('rounded-full object-cover', className)}

--- a/src/components/reviews/BrandMark.tsx
+++ b/src/components/reviews/BrandMark.tsx
@@ -1,0 +1,69 @@
+import { useState, type CSSProperties } from 'react';
+
+import { initials } from '@/lib/reviews/reviewBranding';
+import { cn } from '@/lib/utils';
+
+interface BrandMarkProps {
+  logoUrl: string | null;
+  /** The restaurant name. Supplies the initials when there is no logo. */
+  name: string;
+  /** Applied to the logo and to the initials circle, so both get one size. */
+  className?: string;
+  style?: CSSProperties;
+  /**
+   * Lifts the broken flag to the parent. The sticker sheet draws six marks from
+   * one URL, and one shared flag keeps all six the same on a single sheet.
+   * Omit both props to keep the flag local.
+   */
+  broken?: boolean;
+  onBroken?: () => void;
+}
+
+/**
+ * The restaurant logo, or a circle of initials when there is no logo.
+ *
+ * The guest page and the printed sheet both show this mark. They held two
+ * copies of the markup before, and the copies drifted: only one of them
+ * handled a logo that fails to load.
+ */
+export function BrandMark({
+  logoUrl,
+  name,
+  className,
+  style,
+  broken,
+  onBroken,
+}: BrandMarkProps) {
+  const [localBroken, setLocalBroken] = useState(false);
+  const isBroken = broken ?? localBroken;
+
+  // A logo that fails to load must never leave a blank box, on screen or on
+  // paper. Fall back to the initials circle.
+  if (logoUrl && !isBroken) {
+    return (
+      <img
+        src={logoUrl}
+        alt=""
+        onError={() => {
+          setLocalBroken(true);
+          onBroken?.();
+        }}
+        className={cn('rounded-full object-cover', className)}
+        style={style}
+      />
+    );
+  }
+
+  return (
+    <div
+      aria-hidden="true"
+      className={cn(
+        'counter-display flex items-center justify-center rounded-full bg-muted font-semibold text-foreground',
+        className
+      )}
+      style={style}
+    >
+      {initials(name)}
+    </div>
+  );
+}

--- a/src/components/reviews/ReviewPageBuilder.tsx
+++ b/src/components/reviews/ReviewPageBuilder.tsx
@@ -17,6 +17,8 @@ import { ReviewQrDialog } from './ReviewQrDialog';
 interface ReviewPageBuilderProps {
   page: ReviewPageWithStats | null;
   restaurantId: string;
+  /** Printed on the table tent, under the logo. */
+  restaurantName: string;
   /**
    * `manage:reviews`. A chef holds `view:reviews` and legitimately reaches
    * this pane to read a page's settings and print its QR — but every control
@@ -33,6 +35,7 @@ const THRESHOLDS = [1, 2, 3, 4, 5] as const;
 export function ReviewPageBuilder({
   page,
   restaurantId,
+  restaurantName,
   canManage,
   onCreated,
 }: ReviewPageBuilderProps) {
@@ -357,6 +360,11 @@ export function ReviewPageBuilder({
           onOpenChange={setQrOpen}
           slug={page.slug}
           publicUrl={`${window.location.origin}/r/${page.slug}`}
+          restaurantName={restaurantName}
+          logoPath={page.logo_path}
+          // The saved headline, not the `headline` state. The state can hold an
+          // unsaved edit, and the paper must match the page a guest reaches.
+          defaultMessage={page.headline}
         />
       )}
     </div>

--- a/src/components/reviews/ReviewQrDialog.tsx
+++ b/src/components/reviews/ReviewQrDialog.tsx
@@ -188,62 +188,108 @@ export function ReviewQrDialog({
               The code didn&apos;t generate. Close this and try again.
             </p>
           ) : (
-            <>
-              <div className="space-y-2">
-                <Label
-                  htmlFor="review-qr-size"
-                  className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider"
-                >
-                  Paper size
-                </Label>
-                <RadioGroup
-                  id="review-qr-size"
-                  value={size}
-                  onValueChange={(value) => setSize(value as SheetSizeKey)}
-                  className="grid gap-2 sm:grid-cols-3"
-                >
-                  {SHEET_SIZE_KEYS.map((key) => (
-                    <label
-                      key={key}
-                      htmlFor={`review-qr-size-${key}`}
-                      className="flex cursor-pointer items-start gap-2.5 rounded-xl border border-border/40 bg-muted/30 p-3 transition-colors hover:border-border"
-                    >
-                      <RadioGroupItem
-                        value={key}
-                        id={`review-qr-size-${key}`}
-                        className="mt-0.5"
-                      />
-                      <span className="min-w-0">
-                        <span className="block text-[13px] font-medium text-foreground">
-                          {SHEET_SIZES[key].label}
+            // Two columns from `sm` up. In one column the preview is about
+            // 385 px tall and pushes the Print button — the point of the whole
+            // dialog — below the fold on a laptop.
+            <div className="grid gap-5 sm:grid-cols-[1fr_auto] sm:items-start">
+              <div className="space-y-5">
+                <div className="space-y-2">
+                  <Label
+                    htmlFor="review-qr-size"
+                    className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider"
+                  >
+                    Paper size
+                  </Label>
+                  <RadioGroup
+                    id="review-qr-size"
+                    value={size}
+                    onValueChange={(value) => setSize(value as SheetSizeKey)}
+                    className="grid gap-2"
+                  >
+                    {SHEET_SIZE_KEYS.map((key) => (
+                      <label
+                        key={key}
+                        htmlFor={`review-qr-size-${key}`}
+                        className="flex cursor-pointer items-start gap-2.5 rounded-xl border border-border/40 bg-muted/30 p-3 transition-colors hover:border-border"
+                      >
+                        <RadioGroupItem
+                          value={key}
+                          id={`review-qr-size-${key}`}
+                          className="mt-0.5"
+                        />
+                        <span className="min-w-0">
+                          <span className="block text-[13px] font-medium text-foreground">
+                            {SHEET_SIZES[key].label}
+                          </span>
+                          <span className="block text-[12px] text-muted-foreground">
+                            {SHEET_SIZES[key].hint}
+                          </span>
                         </span>
-                        <span className="block text-[12px] text-muted-foreground">
-                          {SHEET_SIZES[key].hint}
-                        </span>
-                      </span>
-                    </label>
-                  ))}
-                </RadioGroup>
-              </div>
+                      </label>
+                    ))}
+                  </RadioGroup>
+                </div>
 
-              <div className="space-y-2">
-                <Label
-                  htmlFor="review-qr-message"
-                  className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider"
-                >
-                  Message
-                </Label>
-                <Input
-                  id="review-qr-message"
-                  value={message}
-                  maxLength={MAX_MESSAGE_LENGTH}
-                  onChange={(event) => setMessage(event.target.value)}
-                  className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
-                />
-                <p className="text-[12px] text-muted-foreground">
-                  This sheet only. It does not change the page.{' '}
-                  {message.length}/{MAX_MESSAGE_LENGTH}
-                </p>
+                <div className="space-y-2">
+                  <Label
+                    htmlFor="review-qr-message"
+                    className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider"
+                  >
+                    Message
+                  </Label>
+                  <Input
+                    id="review-qr-message"
+                    value={message}
+                    maxLength={MAX_MESSAGE_LENGTH}
+                    onChange={(event) => setMessage(event.target.value)}
+                    className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
+                  />
+                  <p className="text-[12px] text-muted-foreground">
+                    This sheet only. It does not change the page. {message.length}/
+                    {MAX_MESSAGE_LENGTH}
+                  </p>
+                </div>
+
+                <div className="space-y-2">
+                  <Button
+                    type="button"
+                    disabled={!sheetSvg || preparing}
+                    onClick={handlePrint}
+                    className="h-9 w-full rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium"
+                  >
+                    <Printer className="mr-2 h-4 w-4" />
+                    {preparing ? 'Preparing…' : 'Print'}
+                  </Button>
+                  <div className="flex gap-2">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      disabled={!svg}
+                      aria-label="Download QR code as SVG"
+                      className="h-9 flex-1 rounded-lg text-[13px] font-medium"
+                      onClick={() =>
+                        svg &&
+                        download(
+                          `${slug}-qr.svg`,
+                          `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`
+                        )
+                      }
+                    >
+                      Download SVG
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      disabled={!png}
+                      aria-label="Download QR code as PNG"
+                      className="h-9 flex-1 rounded-lg text-[13px] font-medium"
+                      onClick={() => png && download(`${slug}-qr.png`, png)}
+                    >
+                      Download PNG
+                    </Button>
+                  </div>
+                  <p className="text-[12px] text-muted-foreground break-all">{publicUrl}</p>
+                </div>
               </div>
 
               <div className="rounded-xl border border-border/40 bg-muted/30 p-4">
@@ -268,49 +314,7 @@ export function ReviewQrDialog({
                   <Skeleton className="mx-auto h-64 w-44 rounded-lg" />
                 )}
               </div>
-
-              <p className="text-[12px] text-muted-foreground text-center break-all">
-                {publicUrl}
-              </p>
-
-              <div className="flex flex-wrap gap-2">
-                <Button
-                  type="button"
-                  disabled={!sheetSvg || preparing}
-                  onClick={handlePrint}
-                  className="h-9 flex-1 min-w-[120px] rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium"
-                >
-                  <Printer className="mr-2 h-4 w-4" />
-                  {preparing ? 'Preparing…' : 'Print'}
-                </Button>
-                <Button
-                  type="button"
-                  variant="outline"
-                  disabled={!svg}
-                  aria-label="Download QR code as SVG"
-                  className="h-9 flex-1 min-w-[120px] rounded-lg text-[13px] font-medium"
-                  onClick={() =>
-                    svg &&
-                    download(
-                      `${slug}-qr.svg`,
-                      `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`
-                    )
-                  }
-                >
-                  Download SVG
-                </Button>
-                <Button
-                  type="button"
-                  variant="outline"
-                  disabled={!png}
-                  aria-label="Download QR code as PNG"
-                  className="h-9 flex-1 min-w-[120px] rounded-lg text-[13px] font-medium"
-                  onClick={() => png && download(`${slug}-qr.png`, png)}
-                >
-                  Download PNG
-                </Button>
-              </div>
-            </>
+            </div>
           )}
         </div>
       </DialogContent>

--- a/src/components/reviews/ReviewQrDialog.tsx
+++ b/src/components/reviews/ReviewQrDialog.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 import {
   Dialog,
@@ -8,15 +9,33 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
 import { Skeleton } from '@/components/ui/skeleton';
 
-import { QrCode } from 'lucide-react';
+import { Printer, QrCode } from 'lucide-react';
+
+import { ReviewTentSheet } from './ReviewTentSheet';
+
+import { logoPublicUrl } from '@/lib/reviews/reviewBranding';
+import {
+  MAX_MESSAGE_LENGTH,
+  SHEET_SIZES,
+  SHEET_SIZE_KEYS,
+  waitForPrintReady,
+  type SheetSizeKey,
+} from '@/lib/reviews/printSheet';
 
 interface ReviewQrDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   slug: string;
   publicUrl: string;
+  restaurantName: string;
+  logoPath: string | null;
+  /** Seeds the message field. The page headline, so the paper matches the page. */
+  defaultMessage: string;
 }
 
 function download(filename: string, href: string) {
@@ -28,16 +47,44 @@ function download(filename: string, href: string) {
   link.remove();
 }
 
-export function ReviewQrDialog({ open, onOpenChange, slug, publicUrl }: ReviewQrDialogProps) {
+export function ReviewQrDialog({
+  open,
+  onOpenChange,
+  slug,
+  publicUrl,
+  restaurantName,
+  logoPath,
+  defaultMessage,
+}: ReviewQrDialogProps) {
   const [svg, setSvg] = useState<string | null>(null);
   const [png, setPng] = useState<string | null>(null);
+  // The sheet needs a four-module quiet zone, which the download codes do not
+  // have. Two SVGs, one encoder import.
+  const [sheetSvg, setSheetSvg] = useState<string | null>(null);
   const [failed, setFailed] = useState(false);
+
+  const [size, setSize] = useState<SheetSizeKey>('tent');
+  const [message, setMessage] = useState(defaultMessage);
+  const [printAttempt, setPrintAttempt] = useState(0);
+  const [preparing, setPreparing] = useState(false);
+
+  const printRootRef = useRef<HTMLDivElement | null>(null);
+
+  // The message is a one-off. It never reaches the database, so every time the
+  // dialog opens it starts from the page headline again.
+  useEffect(() => {
+    if (!open) return;
+    setMessage(defaultMessage);
+    setPrintAttempt(0);
+    setPreparing(false);
+  }, [open, defaultMessage]);
 
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
     setSvg(null);
     setPng(null);
+    setSheetSvg(null);
     setFailed(false);
 
     (async () => {
@@ -47,13 +94,18 @@ export function ReviewQrDialog({ open, onOpenChange, slug, publicUrl }: ReviewQr
         // chunk for every user on every page.
         const QRCode = await import('qrcode');
         const options = { margin: 1, width: 512, errorCorrectionLevel: 'M' as const };
-        const [svgString, dataUrl] = await Promise.all([
+        const [svgString, dataUrl, sheetString] = await Promise.all([
           QRCode.toString(publicUrl, { ...options, type: 'svg' }),
           QRCode.toDataURL(publicUrl, options),
+          // The QR specification asks for a four-module quiet zone. `margin: 1`
+          // survives a screen, but a printed code with one module of white
+          // fails against a busy tablecloth or a dark counter.
+          QRCode.toString(publicUrl, { ...options, margin: 4, type: 'svg' }),
         ]);
         if (cancelled) return;
         setSvg(svgString);
         setPng(dataUrl);
+        setSheetSvg(sheetString);
       } catch {
         if (!cancelled) setFailed(true);
       }
@@ -64,9 +116,45 @@ export function ReviewQrDialog({ open, onOpenChange, slug, publicUrl }: ReviewQr
     };
   }, [open, publicUrl]);
 
+  const logoUrl = useMemo(() => logoPublicUrl(logoPath), [logoPath]);
+
+  // One props object, two mounts. React renders the same tree from the same
+  // input, so the preview and the paper cannot drift — see memory/lessons.md,
+  // 2026-06-28, where a second print path re-derived its own data.
+  const sheetProps = {
+    size,
+    restaurantName,
+    logoUrl,
+    message,
+    qrSvg: sheetSvg,
+    publicUrl,
+  };
+
+  const handlePrint = useCallback(async () => {
+    const attempt = printAttempt + 1;
+    setPrintAttempt(attempt);
+    setPreparing(true);
+    // Never rejects, never hangs: a 4 s budget wins the race if a font stalls.
+    await waitForPrintReady(printRootRef.current);
+    setPreparing(false);
+    window.print();
+  }, [printAttempt]);
+
+  const status = failed
+    ? "The QR code didn't generate."
+    : preparing
+      ? `Preparing the sheet… (attempt ${printAttempt})`
+      : printAttempt > 0
+        ? `Sheet ready. The print dialog is open. (attempt ${printAttempt})`
+        : sheetSvg
+          ? 'QR code ready to print or download.'
+          : 'Generating the QR code…';
+
+  const sheet = SHEET_SIZES[size];
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md p-0 gap-0 border-border/40">
+      <DialogContent className="max-w-2xl max-h-[85vh] overflow-y-auto p-0 gap-0 border-border/40">
         <DialogHeader className="px-6 pt-6 pb-4 border-b border-border/40">
           <div className="flex items-center gap-3">
             <div className="h-10 w-10 rounded-xl bg-muted/50 flex items-center justify-center">
@@ -83,71 +171,163 @@ export function ReviewQrDialog({ open, onOpenChange, slug, publicUrl }: ReviewQr
           </div>
         </DialogHeader>
 
-        <div className="px-6 py-5 space-y-4">
+        <div className="px-6 py-5 space-y-5">
           {/* The encoder is a dynamic import, so on a slow connection this
-              dialog can sit on a skeleton for seconds with both download
-              buttons disabled. Sighted users see the placeholder; without a
-              live region a screen reader user gets an opened dialog and
-              silence, then two buttons that quietly become enabled. */}
+              dialog can sit on a skeleton for seconds with every button
+              disabled. Sighted users see the placeholder; without a live
+              region a screen reader user gets an opened dialog and silence.
+              Each print announcement carries its attempt number, because an
+              aria-live region reports a change: two identical strings in a row
+              announce nothing at all. */}
           <p aria-live="polite" className="sr-only">
-            {failed
-              ? "The QR code didn't generate."
-              : svg
-                ? 'QR code ready to download.'
-                : 'Generating the QR code…'}
+            {status}
           </p>
 
           {failed ? (
             <p className="text-[13px] text-muted-foreground">
               The code didn&apos;t generate. Close this and try again.
             </p>
-          ) : svg ? (
-            <div
-              className="mx-auto h-48 w-48 [&>svg]:h-full [&>svg]:w-full"
-              aria-label={`QR code linking to ${publicUrl}`}
-              role="img"
-              // `svg` is the `qrcode` package's own SVG output (not user HTML): it
-              // encodes `publicUrl`, which is built from `slug` — restricted to
-              // SLUG_PATTERN's [a-z0-9-] charset (see reviewSlug.ts) — so there is
-              // no attacker-controlled markup reaching innerHTML here.
-              dangerouslySetInnerHTML={{ __html: svg }}
-            />
           ) : (
-            <Skeleton className="mx-auto h-48 w-48 rounded-lg" />
+            <>
+              <div className="space-y-2">
+                <Label
+                  htmlFor="review-qr-size"
+                  className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider"
+                >
+                  Paper size
+                </Label>
+                <RadioGroup
+                  id="review-qr-size"
+                  value={size}
+                  onValueChange={(value) => setSize(value as SheetSizeKey)}
+                  className="grid gap-2 sm:grid-cols-3"
+                >
+                  {SHEET_SIZE_KEYS.map((key) => (
+                    <label
+                      key={key}
+                      htmlFor={`review-qr-size-${key}`}
+                      className="flex cursor-pointer items-start gap-2.5 rounded-xl border border-border/40 bg-muted/30 p-3 transition-colors hover:border-border"
+                    >
+                      <RadioGroupItem
+                        value={key}
+                        id={`review-qr-size-${key}`}
+                        className="mt-0.5"
+                      />
+                      <span className="min-w-0">
+                        <span className="block text-[13px] font-medium text-foreground">
+                          {SHEET_SIZES[key].label}
+                        </span>
+                        <span className="block text-[12px] text-muted-foreground">
+                          {SHEET_SIZES[key].hint}
+                        </span>
+                      </span>
+                    </label>
+                  ))}
+                </RadioGroup>
+              </div>
+
+              <div className="space-y-2">
+                <Label
+                  htmlFor="review-qr-message"
+                  className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider"
+                >
+                  Message
+                </Label>
+                <Input
+                  id="review-qr-message"
+                  value={message}
+                  maxLength={MAX_MESSAGE_LENGTH}
+                  onChange={(event) => setMessage(event.target.value)}
+                  className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
+                />
+                <p className="text-[12px] text-muted-foreground">
+                  This sheet only. It does not change the page.{' '}
+                  {message.length}/{MAX_MESSAGE_LENGTH}
+                </p>
+              </div>
+
+              <div className="rounded-xl border border-border/40 bg-muted/30 p-4">
+                {sheetSvg ? (
+                  <div
+                    className="mx-auto overflow-hidden"
+                    style={{
+                      width: `calc(${sheet.widthIn}in * ${sheet.previewScale})`,
+                      height: `calc(${sheet.heightIn}in * ${sheet.previewScale})`,
+                    }}
+                  >
+                    <div
+                      style={{
+                        transform: `scale(${sheet.previewScale})`,
+                        transformOrigin: 'top left',
+                      }}
+                    >
+                      <ReviewTentSheet {...sheetProps} />
+                    </div>
+                  </div>
+                ) : (
+                  <Skeleton className="mx-auto h-64 w-44 rounded-lg" />
+                )}
+              </div>
+
+              <p className="text-[12px] text-muted-foreground text-center break-all">
+                {publicUrl}
+              </p>
+
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  disabled={!sheetSvg || preparing}
+                  onClick={handlePrint}
+                  className="h-9 flex-1 min-w-[120px] rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium"
+                >
+                  <Printer className="mr-2 h-4 w-4" />
+                  {preparing ? 'Preparing…' : 'Print'}
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={!svg}
+                  aria-label="Download QR code as SVG"
+                  className="h-9 flex-1 min-w-[120px] rounded-lg text-[13px] font-medium"
+                  onClick={() =>
+                    svg &&
+                    download(
+                      `${slug}-qr.svg`,
+                      `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`
+                    )
+                  }
+                >
+                  Download SVG
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={!png}
+                  aria-label="Download QR code as PNG"
+                  className="h-9 flex-1 min-w-[120px] rounded-lg text-[13px] font-medium"
+                  onClick={() => png && download(`${slug}-qr.png`, png)}
+                >
+                  Download PNG
+                </Button>
+              </div>
+            </>
           )}
-
-          <p className="text-[12px] text-muted-foreground text-center break-all">{publicUrl}</p>
-
-          <div className="flex gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              disabled={!svg}
-              aria-label="Download QR code as SVG"
-              className="h-9 flex-1 rounded-lg text-[13px] font-medium"
-              onClick={() =>
-                svg &&
-                download(
-                  `${slug}-qr.svg`,
-                  `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`
-                )
-              }
-            >
-              Download SVG
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              disabled={!png}
-              aria-label="Download QR code as PNG"
-              className="h-9 flex-1 rounded-lg text-[13px] font-medium"
-              onClick={() => png && download(`${slug}-qr.png`, png)}
-            >
-              Download PNG
-            </Button>
-          </div>
         </div>
       </DialogContent>
+
+      {/* The print copy. It hangs off document.body, not off DialogContent,
+          which is `fixed` with `max-h-[85vh]` and `overflow-y-auto`
+          (src/components/ui/dialog.tsx:40). A clipped, transformed, fixed
+          ancestor prints the visible scroll window only, and WebKit often
+          prints nothing at all. print-sheet.css moves this off screen and
+          hides every other body child when the print starts. */}
+      {open &&
+        createPortal(
+          <div id="review-print-root" data-size={size} ref={printRootRef}>
+            <ReviewTentSheet {...sheetProps} />
+          </div>,
+          document.body
+        )}
     </Dialog>
   );
 }

--- a/src/components/reviews/ReviewQrDialog.tsx
+++ b/src/components/reviews/ReviewQrDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 
 import {
@@ -18,12 +18,13 @@ import { Printer, QrCode } from 'lucide-react';
 
 import { ReviewTentSheet } from './ReviewTentSheet';
 
+import { useReviewQrSheet } from '@/hooks/useReviewQrSheet';
+
 import { logoPublicUrl } from '@/lib/reviews/reviewBranding';
 import {
   MAX_MESSAGE_LENGTH,
   SHEET_SIZES,
   SHEET_SIZE_KEYS,
-  waitForPrintReady,
   type SheetSizeKey,
 } from '@/lib/reviews/printSheet';
 
@@ -37,6 +38,9 @@ interface ReviewQrDialogProps {
   /** Seeds the message field. The page headline, so the paper matches the page. */
   defaultMessage: string;
 }
+
+/** The print CSS hides the app behind this class. See src/styles/print-sheet.css. */
+const PRINT_ACTIVE_CLASS = 'review-print-active';
 
 function download(filename: string, href: string) {
   const link = document.createElement('a');
@@ -56,65 +60,28 @@ export function ReviewQrDialog({
   logoPath,
   defaultMessage,
 }: ReviewQrDialogProps) {
-  const [svg, setSvg] = useState<string | null>(null);
-  const [png, setPng] = useState<string | null>(null);
-  // The sheet needs a four-module quiet zone, which the download codes do not
-  // have. Two SVGs, one encoder import.
-  const [sheetSvg, setSheetSvg] = useState<string | null>(null);
-  const [failed, setFailed] = useState(false);
+  const {
+    svg,
+    png,
+    sheetSvg,
+    failed,
+    size,
+    setSize,
+    message,
+    setMessage,
+    isPreparing,
+    printRootRef,
+    handlePrint,
+    status,
+  } = useReviewQrSheet({ open, publicUrl, defaultMessage });
 
-  const [size, setSize] = useState<SheetSizeKey>('tent');
-  const [message, setMessage] = useState(defaultMessage);
-  const [printAttempt, setPrintAttempt] = useState(0);
-  const [preparing, setPreparing] = useState(false);
-
-  const printRootRef = useRef<HTMLDivElement | null>(null);
-
-  // The message is a one-off. It never reaches the database, so every time the
-  // dialog opens it starts from the page headline again.
+  // The class tracks the print portal below. The print rule hides every other
+  // body child, so it must never outlive the sheet it makes room for.
   useEffect(() => {
     if (!open) return;
-    setMessage(defaultMessage);
-    setPrintAttempt(0);
-    setPreparing(false);
-  }, [open, defaultMessage]);
-
-  useEffect(() => {
-    if (!open) return;
-    let cancelled = false;
-    setSvg(null);
-    setPng(null);
-    setSheetSvg(null);
-    setFailed(false);
-
-    (async () => {
-      try {
-        // Dynamic import: the QR encoder is ~50 KB and only a manager opening
-        // this dialog ever needs it. A static import would put it in the main
-        // chunk for every user on every page.
-        const QRCode = await import('qrcode');
-        const options = { margin: 1, width: 512, errorCorrectionLevel: 'M' as const };
-        const [svgString, dataUrl, sheetString] = await Promise.all([
-          QRCode.toString(publicUrl, { ...options, type: 'svg' }),
-          QRCode.toDataURL(publicUrl, options),
-          // The QR specification asks for a four-module quiet zone. `margin: 1`
-          // survives a screen, but a printed code with one module of white
-          // fails against a busy tablecloth or a dark counter.
-          QRCode.toString(publicUrl, { ...options, margin: 4, type: 'svg' }),
-        ]);
-        if (cancelled) return;
-        setSvg(svgString);
-        setPng(dataUrl);
-        setSheetSvg(sheetString);
-      } catch {
-        if (!cancelled) setFailed(true);
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [open, publicUrl]);
+    document.body.classList.add(PRINT_ACTIVE_CLASS);
+    return () => document.body.classList.remove(PRINT_ACTIVE_CLASS);
+  }, [open]);
 
   const logoUrl = useMemo(() => logoPublicUrl(logoPath), [logoPath]);
 
@@ -129,26 +96,6 @@ export function ReviewQrDialog({
     qrSvg: sheetSvg,
     publicUrl,
   };
-
-  const handlePrint = useCallback(async () => {
-    const attempt = printAttempt + 1;
-    setPrintAttempt(attempt);
-    setPreparing(true);
-    // Never rejects, never hangs: a 4 s budget wins the race if a font stalls.
-    await waitForPrintReady(printRootRef.current);
-    setPreparing(false);
-    window.print();
-  }, [printAttempt]);
-
-  const status = failed
-    ? "The QR code didn't generate."
-    : preparing
-      ? `Preparing the sheet… (attempt ${printAttempt})`
-      : printAttempt > 0
-        ? `Sheet ready. The print dialog is open. (attempt ${printAttempt})`
-        : sheetSvg
-          ? 'QR code ready to print or download.'
-          : 'Generating the QR code…';
 
   const sheet = SHEET_SIZES[size];
 
@@ -175,10 +122,7 @@ export function ReviewQrDialog({
           {/* The encoder is a dynamic import, so on a slow connection this
               dialog can sit on a skeleton for seconds with every button
               disabled. Sighted users see the placeholder; without a live
-              region a screen reader user gets an opened dialog and silence.
-              Each print announcement carries its attempt number, because an
-              aria-live region reports a change: two identical strings in a row
-              announce nothing at all. */}
+              region a screen reader user gets an opened dialog and silence. */}
           <p aria-live="polite" className="sr-only">
             {status}
           </p>
@@ -194,14 +138,17 @@ export function ReviewQrDialog({
             <div className="grid gap-5 sm:grid-cols-[1fr_auto] sm:items-start">
               <div className="space-y-5">
                 <div className="space-y-2">
+                  {/* `aria-labelledby`, not `htmlFor`. RadioGroup renders a
+                      div, and `label for` names labelable elements only, so
+                      the group would announce with no name. */}
                   <Label
-                    htmlFor="review-qr-size"
+                    id="review-qr-size-label"
                     className="text-[12px] font-medium text-muted-foreground uppercase tracking-wider"
                   >
                     Paper size
                   </Label>
                   <RadioGroup
-                    id="review-qr-size"
+                    aria-labelledby="review-qr-size-label"
                     value={size}
                     onValueChange={(value) => setSize(value as SheetSizeKey)}
                     className="grid gap-2"
@@ -253,12 +200,12 @@ export function ReviewQrDialog({
                 <div className="space-y-2">
                   <Button
                     type="button"
-                    disabled={!sheetSvg || preparing}
+                    disabled={!sheetSvg || isPreparing}
                     onClick={handlePrint}
                     className="h-9 w-full rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium"
                   >
                     <Printer className="mr-2 h-4 w-4" />
-                    {preparing ? 'Preparing…' : 'Print'}
+                    {isPreparing ? 'Preparing…' : 'Print'}
                   </Button>
                   <div className="flex gap-2">
                     <Button
@@ -292,7 +239,16 @@ export function ReviewQrDialog({
                 </div>
               </div>
 
-              <div className="rounded-xl border border-border/40 bg-muted/30 p-4">
+              {/* The sheet itself is `aria-hidden`: it is a picture of paper,
+                  and its inner text carries no role. This wrapper is what a
+                  screen reader reaches, so it names the restaurant and the
+                  link the code carries. `main` had that name on the plain QR
+                  preview, and the sheet must not lose it. */}
+              <div
+                role="img"
+                aria-label={`Preview of the ${sheet.label} sheet for ${restaurantName}. The QR code links to ${publicUrl}`}
+                className="rounded-xl border border-border/40 bg-muted/30 p-4"
+              >
                 {sheetSvg ? (
                   <div
                     className="mx-auto overflow-hidden"

--- a/src/components/reviews/ReviewQrDialog.tsx
+++ b/src/components/reviews/ReviewQrDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 import { createPortal } from 'react-dom';
 
 import {
@@ -83,7 +83,7 @@ export function ReviewQrDialog({
     return () => document.body.classList.remove(PRINT_ACTIVE_CLASS);
   }, [open]);
 
-  const logoUrl = useMemo(() => logoPublicUrl(logoPath), [logoPath]);
+  const logoUrl = logoPublicUrl(logoPath);
 
   // One props object, two mounts. React renders the same tree from the same
   // input, so the preview and the paper cannot drift — see memory/lessons.md,

--- a/src/components/reviews/ReviewTentSheet.tsx
+++ b/src/components/reviews/ReviewTentSheet.tsx
@@ -1,12 +1,12 @@
 import { useState } from 'react';
 
-import { initials } from '@/lib/reviews/reviewBranding';
+import { BrandMark } from './BrandMark';
+
 import { SHEET_SIZES, type SheetSizeKey } from '@/lib/reviews/printSheet';
 
 import '@fontsource/zilla-slab/400.css';
 import '@fontsource/zilla-slab/600.css';
 import '@fontsource/ibm-plex-mono/400.css';
-import '@fontsource/ibm-plex-mono/500.css';
 import '@/styles/counter-theme.css';
 import '@/styles/print-sheet.css';
 
@@ -26,7 +26,7 @@ interface ReviewTentSheetProps {
  */
 interface TypeScale {
   markIn: number;
-  nameePt: number;
+  namePt: number;
   messagePt: number;
   urlPt: number;
   padIn: number;
@@ -34,50 +34,21 @@ interface TypeScale {
 }
 
 const TYPE: Readonly<Record<SheetSizeKey, TypeScale>> = {
-  tent: { markIn: 0.62, nameePt: 8, messagePt: 17, urlPt: 7.5, padIn: 0.42, gapIn: 0.16 },
-  card: { markIn: 0.86, nameePt: 10, messagePt: 22, urlPt: 9, padIn: 0.6, gapIn: 0.22 },
-  stickers: { markIn: 0.3, nameePt: 5.5, messagePt: 8, urlPt: 5, padIn: 0.16, gapIn: 0.07 },
+  tent: { markIn: 0.62, namePt: 8, messagePt: 17, urlPt: 7.5, padIn: 0.42, gapIn: 0.16 },
+  card: { markIn: 0.86, namePt: 10, messagePt: 22, urlPt: 9, padIn: 0.6, gapIn: 0.22 },
+  stickers: { markIn: 0.3, namePt: 5.5, messagePt: 8, urlPt: 5, padIn: 0.16, gapIn: 0.07 },
 };
+
+/**
+ * Initials height against the circle diameter. One inch is 72 pt, so 34 pt per
+ * inch sets the cap height near half the circle. Two letters then fill the
+ * circle without a collision with the edge.
+ */
+const INITIALS_PT_PER_IN = 34;
 
 /** `https://app.example.com/r/slug` reads better on paper without the scheme. */
 function displayUrl(url: string): string {
   return url.replace(/^https?:\/\//, '');
-}
-
-function SheetMark({
-  logoUrl,
-  restaurantName,
-  sizeIn,
-}: {
-  logoUrl: string | null;
-  restaurantName: string;
-  sizeIn: number;
-}) {
-  const [broken, setBroken] = useState(false);
-
-  // A logo that fails to load must never block the print, and must never leave
-  // a blank box on the paper. Fall back to the same circle the guest page shows.
-  if (logoUrl && !broken) {
-    return (
-      <img
-        src={logoUrl}
-        alt=""
-        crossOrigin="anonymous"
-        onError={() => setBroken(true)}
-        className="print-ink rounded-full object-cover"
-        style={{ width: `${sizeIn}in`, height: `${sizeIn}in` }}
-      />
-    );
-  }
-
-  return (
-    <div
-      className="counter-display flex items-center justify-center rounded-full bg-muted font-semibold text-foreground"
-      style={{ width: `${sizeIn}in`, height: `${sizeIn}in`, fontSize: `${sizeIn * 34}pt` }}
-    >
-      {initials(restaurantName)}
-    </div>
-  );
 }
 
 function SheetTile({
@@ -87,7 +58,9 @@ function SheetTile({
   message,
   qrSvg,
   publicUrl,
-}: ReviewTentSheetProps) {
+  logoBroken,
+  onLogoBroken,
+}: ReviewTentSheetProps & { logoBroken: boolean; onLogoBroken: () => void }) {
   const sheet = SHEET_SIZES[size];
   const type = TYPE[size];
 
@@ -96,11 +69,25 @@ function SheetTile({
       className="print-tile flex h-full w-full flex-col items-center justify-center text-center"
       style={{ padding: `${type.padIn}in`, gap: `${type.gapIn}in` }}
     >
-      <SheetMark logoUrl={logoUrl} restaurantName={restaurantName} sizeIn={type.markIn} />
+      {/* `print-ink` on the mark, not only on the logo. A printer with
+          background graphics off drops the initials circle otherwise, and a
+          restaurant with no logo loses the one mark of identity on the page. */}
+      <BrandMark
+        logoUrl={logoUrl}
+        name={restaurantName}
+        broken={logoBroken}
+        onBroken={onLogoBroken}
+        className="print-ink"
+        style={{
+          width: `${type.markIn}in`,
+          height: `${type.markIn}in`,
+          fontSize: `${type.markIn * INITIALS_PT_PER_IN}pt`,
+        }}
+      />
 
       <p
         className="counter-micro uppercase text-muted-foreground"
-        style={{ fontSize: `${type.nameePt}pt`, letterSpacing: '0.09em' }}
+        style={{ fontSize: `${type.namePt}pt`, letterSpacing: '0.09em' }}
       >
         {restaurantName}
       </p>
@@ -120,8 +107,9 @@ function SheetTile({
           style={{ width: `${sheet.qrIn}in`, height: `${sheet.qrIn}in` }}
           // `qrSvg` is the `qrcode` package's own SVG output, not user HTML. It
           // encodes `publicUrl`, built from `slug`, which SLUG_PATTERN limits to
-          // [a-z0-9-] (see reviewSlug.ts). No attacker-controlled markup reaches
-          // innerHTML here. The same reasoning covers ReviewQrDialog.tsx:109-113.
+          // [a-z0-9-] (see reviewSlug.ts). The database holds the same pattern
+          // as a CHECK constraint. No attacker-controlled markup reaches
+          // innerHTML here.
           dangerouslySetInnerHTML={{ __html: qrSvg }}
         />
       )}
@@ -150,12 +138,15 @@ function SheetTile({
 export function ReviewTentSheet(props: ReviewTentSheetProps) {
   const sheet = SHEET_SIZES[props.size];
 
+  // One flag for the whole sheet. The sticker page draws six marks from one
+  // URL. Six local flags let one slow request print five logos and one circle.
+  const [logoBroken, setLogoBroken] = useState(false);
+
   return (
     <div
-      // The sheet is a picture of paper, not a control. Every value it shows
-      // already appears in a labelled control in the dialog, so the whole
-      // subtree leaves the accessibility tree. Nothing inside carries a role or
-      // a label: an aria-hidden ancestor makes that markup unreachable.
+      // The sheet is a picture of paper, not a control. The dialog carries the
+      // accessible name for this subtree — see the `role="img"` wrapper on the
+      // preview and the `aria-live` status line in ReviewQrDialog.
       aria-hidden="true"
       data-size={props.size}
       className="theme-counter bg-background text-foreground"
@@ -168,7 +159,12 @@ export function ReviewTentSheet(props: ReviewTentSheetProps) {
       }}
     >
       {Array.from({ length: sheet.tiles }, (_, index) => (
-        <SheetTile key={index} {...props} />
+        <SheetTile
+          key={index}
+          {...props}
+          logoBroken={logoBroken}
+          onLogoBroken={() => setLogoBroken(true)}
+        />
       ))}
     </div>
   );

--- a/src/components/reviews/ReviewTentSheet.tsx
+++ b/src/components/reviews/ReviewTentSheet.tsx
@@ -140,7 +140,11 @@ export function ReviewTentSheet(props: ReviewTentSheetProps) {
 
   // One flag for the whole sheet. The sticker page draws six marks from one
   // URL. Six local flags let one slow request print five logos and one circle.
-  const [logoBroken, setLogoBroken] = useState(false);
+  //
+  // Keyed by URL, as BrandMark keys its own flag. A manager can upload a new
+  // logo while this dialog stays open, and a plain boolean would then hide it.
+  const [brokenLogoUrl, setBrokenLogoUrl] = useState<string | null>(null);
+  const logoBroken = props.logoUrl !== null && brokenLogoUrl === props.logoUrl;
 
   return (
     <div
@@ -163,7 +167,7 @@ export function ReviewTentSheet(props: ReviewTentSheetProps) {
           key={index}
           {...props}
           logoBroken={logoBroken}
-          onLogoBroken={() => setLogoBroken(true)}
+          onLogoBroken={() => setBrokenLogoUrl(props.logoUrl)}
         />
       ))}
     </div>

--- a/src/components/reviews/ReviewTentSheet.tsx
+++ b/src/components/reviews/ReviewTentSheet.tsx
@@ -1,0 +1,175 @@
+import { useState } from 'react';
+
+import { initials } from '@/lib/reviews/reviewBranding';
+import { SHEET_SIZES, type SheetSizeKey } from '@/lib/reviews/printSheet';
+
+import '@fontsource/zilla-slab/400.css';
+import '@fontsource/zilla-slab/600.css';
+import '@fontsource/ibm-plex-mono/400.css';
+import '@fontsource/ibm-plex-mono/500.css';
+import '@/styles/counter-theme.css';
+import '@/styles/print-sheet.css';
+
+interface ReviewTentSheetProps {
+  size: SheetSizeKey;
+  restaurantName: string;
+  logoUrl: string | null;
+  message: string;
+  /** Null until the encoder finishes. The sheet renders the rest meanwhile. */
+  qrSvg: string | null;
+  publicUrl: string;
+}
+
+/**
+ * Paper type is set in points, not pixels. A 12 px line looks fine on a monitor
+ * and disappears on a 4 in card held at arm's length.
+ */
+interface TypeScale {
+  markIn: number;
+  nameePt: number;
+  messagePt: number;
+  urlPt: number;
+  padIn: number;
+  gapIn: number;
+}
+
+const TYPE: Readonly<Record<SheetSizeKey, TypeScale>> = {
+  tent: { markIn: 0.62, nameePt: 8, messagePt: 17, urlPt: 7.5, padIn: 0.42, gapIn: 0.16 },
+  card: { markIn: 0.86, nameePt: 10, messagePt: 22, urlPt: 9, padIn: 0.6, gapIn: 0.22 },
+  stickers: { markIn: 0.3, nameePt: 5.5, messagePt: 8, urlPt: 5, padIn: 0.16, gapIn: 0.07 },
+};
+
+/** `https://app.example.com/r/slug` reads better on paper without the scheme. */
+function displayUrl(url: string): string {
+  return url.replace(/^https?:\/\//, '');
+}
+
+function SheetMark({
+  logoUrl,
+  restaurantName,
+  sizeIn,
+}: {
+  logoUrl: string | null;
+  restaurantName: string;
+  sizeIn: number;
+}) {
+  const [broken, setBroken] = useState(false);
+
+  // A logo that fails to load must never block the print, and must never leave
+  // a blank box on the paper. Fall back to the same circle the guest page shows.
+  if (logoUrl && !broken) {
+    return (
+      <img
+        src={logoUrl}
+        alt=""
+        crossOrigin="anonymous"
+        onError={() => setBroken(true)}
+        className="print-ink rounded-full object-cover"
+        style={{ width: `${sizeIn}in`, height: `${sizeIn}in` }}
+      />
+    );
+  }
+
+  return (
+    <div
+      className="counter-display flex items-center justify-center rounded-full bg-muted font-semibold text-foreground"
+      style={{ width: `${sizeIn}in`, height: `${sizeIn}in`, fontSize: `${sizeIn * 34}pt` }}
+    >
+      {initials(restaurantName)}
+    </div>
+  );
+}
+
+function SheetTile({
+  size,
+  restaurantName,
+  logoUrl,
+  message,
+  qrSvg,
+  publicUrl,
+}: ReviewTentSheetProps) {
+  const sheet = SHEET_SIZES[size];
+  const type = TYPE[size];
+
+  return (
+    <div
+      className="print-tile flex h-full w-full flex-col items-center justify-center text-center"
+      style={{ padding: `${type.padIn}in`, gap: `${type.gapIn}in` }}
+    >
+      <SheetMark logoUrl={logoUrl} restaurantName={restaurantName} sizeIn={type.markIn} />
+
+      <p
+        className="counter-micro uppercase text-muted-foreground"
+        style={{ fontSize: `${type.nameePt}pt`, letterSpacing: '0.09em' }}
+      >
+        {restaurantName}
+      </p>
+
+      <div className="counter-rule w-1/2" />
+
+      <p
+        className="counter-display font-semibold text-foreground"
+        style={{ fontSize: `${type.messagePt}pt`, lineHeight: 1.25 }}
+      >
+        {message}
+      </p>
+
+      {qrSvg && (
+        <div
+          className="print-ink print-qr-paper [&>svg]:h-full [&>svg]:w-full"
+          style={{ width: `${sheet.qrIn}in`, height: `${sheet.qrIn}in` }}
+          // `qrSvg` is the `qrcode` package's own SVG output, not user HTML. It
+          // encodes `publicUrl`, built from `slug`, which SLUG_PATTERN limits to
+          // [a-z0-9-] (see reviewSlug.ts). No attacker-controlled markup reaches
+          // innerHTML here. The same reasoning covers ReviewQrDialog.tsx:109-113.
+          dangerouslySetInnerHTML={{ __html: qrSvg }}
+        />
+      )}
+
+      <p
+        className="counter-micro text-muted-foreground"
+        style={{ fontSize: `${type.urlPt}pt` }}
+      >
+        {displayUrl(publicUrl)}
+      </p>
+    </div>
+  );
+}
+
+/**
+ * The printed sheet, and the preview of it.
+ *
+ * `ReviewQrDialog` mounts this twice from one props object: once scaled down
+ * inside the dialog, once in a portal on document.body for the print. Two
+ * mounts of one component from one props object cannot drift. Two components
+ * can — see memory/lessons.md, 2026-06-28, where a print path re-derived its
+ * own roster and leaked inactive employees onto paper.
+ *
+ * Presentational only. No data fetch, no context, no query.
+ */
+export function ReviewTentSheet(props: ReviewTentSheetProps) {
+  const sheet = SHEET_SIZES[props.size];
+
+  return (
+    <div
+      // The sheet is a picture of paper, not a control. Every value it shows
+      // already appears in a labelled control in the dialog, so the whole
+      // subtree leaves the accessibility tree. Nothing inside carries a role or
+      // a label: an aria-hidden ancestor makes that markup unreachable.
+      aria-hidden="true"
+      data-size={props.size}
+      className="theme-counter bg-background text-foreground"
+      style={{
+        width: `${sheet.widthIn}in`,
+        height: `${sheet.heightIn}in`,
+        display: 'grid',
+        gridTemplateColumns: `repeat(${sheet.columns}, 1fr)`,
+        gridAutoRows: `${sheet.heightIn / (sheet.tiles / sheet.columns)}in`,
+      }}
+    >
+      {Array.from({ length: sheet.tiles }, (_, index) => (
+        <SheetTile key={index} {...props} />
+      ))}
+    </div>
+  );
+}

--- a/src/hooks/useReviewQrSheet.ts
+++ b/src/hooks/useReviewQrSheet.ts
@@ -1,6 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import { nextFrame, waitForPrintReady, type SheetSizeKey } from '@/lib/reviews/printSheet';
+import {
+  MAX_MESSAGE_LENGTH,
+  nextFrame,
+  waitForPrintReady,
+  type SheetSizeKey,
+} from '@/lib/reviews/printSheet';
 
 interface UseReviewQrSheetOptions {
   open: boolean;
@@ -59,12 +64,21 @@ export function useReviewQrSheet({ open, publicUrl, defaultMessage }: UseReviewQ
 
   const printRootRef = useRef<HTMLDivElement | null>(null);
 
-  // `handlePrint` waits before it prints, and the dialog can close during that
-  // wait. A ref carries the live value: a plain `open` in the callback would
-  // hold whatever it captured when the callback was made.
-  const openRef = useRef(open);
+  // Every open is one print session, and every close ends it.
+  //
+  // `handlePrint` waits before it prints. It captures the session id and
+  // compares the id after the wait. A live `open` flag is not enough: the
+  // manager can close the dialog and open it again inside one slow wait, which
+  // sets the flag back to true and lets the dead attempt print into the new
+  // session. The cleanup also covers an unmount, so a print cannot follow the
+  // manager to the next page.
+  const sessionRef = useRef(0);
   useEffect(() => {
-    openRef.current = open;
+    if (!open) return;
+    sessionRef.current += 1;
+    return () => {
+      sessionRef.current += 1;
+    };
   }, [open]);
 
   // Seed the message on the open transition only.
@@ -75,7 +89,12 @@ export function useReviewQrSheet({ open, publicUrl, defaultMessage }: UseReviewQ
   const wasOpen = useRef(false);
   useEffect(() => {
     if (open && !wasOpen.current) {
-      setMessage(defaultMessage);
+      // Clamp the seed. `review_pages.headline` is TEXT with no length limit,
+      // and the headline editor sets no `maxLength`. The input `maxLength`
+      // stops a manager from typing past 120, but it does not trim a value
+      // that arrives past 120. An unclamped seed prints text that pushes the
+      // QR code off the paper, under a counter that reads "500/120".
+      setMessage(defaultMessage.slice(0, MAX_MESSAGE_LENGTH));
       setPrintAttempt(0);
       setIsPreparing(false);
     }
@@ -120,6 +139,7 @@ export function useReviewQrSheet({ open, publicUrl, defaultMessage }: UseReviewQ
   }, [open, publicUrl]);
 
   const handlePrint = useCallback(async () => {
+    const session = sessionRef.current;
     setPrintAttempt((attempt) => attempt + 1);
     setIsPreparing(true);
     // Never rejects, never hangs: a 4 s budget wins the race if a font stalls.
@@ -130,10 +150,11 @@ export function useReviewQrSheet({ open, publicUrl, defaultMessage }: UseReviewQ
     // status and the live region announces it. Without the yield a screen
     // reader user hears "Preparing" and then nothing.
     await nextFrame();
-    // The manager can close the dialog during that wait. Print only what they
-    // still ask for: the print root is gone, and the system print dialog would
-    // open over a screen they already dismissed.
-    if (!openRef.current) return;
+    // The manager can close the dialog during that wait, and open it again.
+    // Print only for the session that asked. The print root of a dead session
+    // is gone, and the system print dialog would open over a screen they
+    // already dismissed.
+    if (session !== sessionRef.current) return;
     window.print();
   }, []);
 

--- a/src/hooks/useReviewQrSheet.ts
+++ b/src/hooks/useReviewQrSheet.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import { waitForPrintReady, type SheetSizeKey } from '@/lib/reviews/printSheet';
+import { nextFrame, waitForPrintReady, type SheetSizeKey } from '@/lib/reviews/printSheet';
 
 interface UseReviewQrSheetOptions {
   open: boolean;
@@ -125,6 +125,11 @@ export function useReviewQrSheet({ open, publicUrl, defaultMessage }: UseReviewQ
     // Never rejects, never hangs: a 4 s budget wins the race if a font stalls.
     await waitForPrintReady(printRootRef.current);
     setIsPreparing(false);
+    // `window.print()` blocks the main thread until the manager dismisses the
+    // system dialog. Yield one frame first, so React paints the "Sheet ready"
+    // status and the live region announces it. Without the yield a screen
+    // reader user hears "Preparing" and then nothing.
+    await nextFrame();
     // The manager can close the dialog during that wait. Print only what they
     // still ask for: the print root is gone, and the system print dialog would
     // open over a screen they already dismissed.

--- a/src/hooks/useReviewQrSheet.ts
+++ b/src/hooks/useReviewQrSheet.ts
@@ -1,0 +1,149 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { waitForPrintReady, type SheetSizeKey } from '@/lib/reviews/printSheet';
+
+interface UseReviewQrSheetOptions {
+  open: boolean;
+  publicUrl: string;
+  /** Seeds the message field when the dialog opens. */
+  defaultMessage: string;
+}
+
+interface PrintStatusInput {
+  failed: boolean;
+  isPreparing: boolean;
+  printAttempt: number;
+  ready: boolean;
+}
+
+/**
+ * The screen-reader status line.
+ *
+ * Every branch carries the attempt number, because an `aria-live` region
+ * reports a change. Two identical strings in a row announce nothing at all.
+ */
+export function printStatus({
+  failed,
+  isPreparing,
+  printAttempt,
+  ready,
+}: PrintStatusInput): string {
+  if (failed) return "The QR code didn't generate.";
+  if (isPreparing) return `Preparing the sheet… (attempt ${printAttempt})`;
+  if (printAttempt > 0) {
+    return `Sheet ready. The print dialog is open. (attempt ${printAttempt})`;
+  }
+  if (ready) return 'QR code ready to print or download.';
+  return 'Generating the QR code…';
+}
+
+/**
+ * The QR codes, the sheet options, and the print itself.
+ *
+ * `ReviewQrDialog` renders what this returns. Hooks hold the business logic in
+ * this codebase, and the print orchestration is business logic: it decides when
+ * the paper is ready and whether the print still has a reason to start.
+ */
+export function useReviewQrSheet({ open, publicUrl, defaultMessage }: UseReviewQrSheetOptions) {
+  const [svg, setSvg] = useState<string | null>(null);
+  const [png, setPng] = useState<string | null>(null);
+  // The sheet needs a four-module quiet zone, which the download codes do not
+  // have. Two SVGs, one encoder import.
+  const [sheetSvg, setSheetSvg] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  const [size, setSize] = useState<SheetSizeKey>('tent');
+  const [message, setMessage] = useState(defaultMessage);
+  const [printAttempt, setPrintAttempt] = useState(0);
+  const [isPreparing, setIsPreparing] = useState(false);
+
+  const printRootRef = useRef<HTMLDivElement | null>(null);
+
+  // `handlePrint` waits before it prints, and the dialog can close during that
+  // wait. A ref carries the live value: a plain `open` in the callback would
+  // hold whatever it captured when the callback was made.
+  const openRef = useRef(open);
+  useEffect(() => {
+    openRef.current = open;
+  }, [open]);
+
+  // Seed the message on the open transition only.
+  //
+  // The headline comes from a React Query read with `refetchOnWindowFocus`. A
+  // dependency on `defaultMessage` alone would let a second manager's save, or
+  // a tab change, delete a message the first manager is still typing.
+  const wasOpen = useRef(false);
+  useEffect(() => {
+    if (open && !wasOpen.current) {
+      setMessage(defaultMessage);
+      setPrintAttempt(0);
+      setIsPreparing(false);
+    }
+    wasOpen.current = open;
+  }, [open, defaultMessage]);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setSvg(null);
+    setPng(null);
+    setSheetSvg(null);
+    setFailed(false);
+
+    (async () => {
+      try {
+        // Dynamic import: the QR encoder is ~50 KB and only a manager opening
+        // this dialog ever needs it. A static import would put it in the main
+        // chunk for every user on every page.
+        const QRCode = await import('qrcode');
+        const options = { margin: 1, width: 512, errorCorrectionLevel: 'M' as const };
+        const [svgString, dataUrl, sheetString] = await Promise.all([
+          QRCode.toString(publicUrl, { ...options, type: 'svg' }),
+          QRCode.toDataURL(publicUrl, options),
+          // The QR specification asks for a four-module quiet zone. `margin: 1`
+          // survives a screen, but a printed code with one module of white
+          // fails against a busy tablecloth or a dark counter.
+          QRCode.toString(publicUrl, { ...options, margin: 4, type: 'svg' }),
+        ]);
+        if (cancelled) return;
+        setSvg(svgString);
+        setPng(dataUrl);
+        setSheetSvg(sheetString);
+      } catch {
+        if (!cancelled) setFailed(true);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [open, publicUrl]);
+
+  const handlePrint = useCallback(async () => {
+    setPrintAttempt((attempt) => attempt + 1);
+    setIsPreparing(true);
+    // Never rejects, never hangs: a 4 s budget wins the race if a font stalls.
+    await waitForPrintReady(printRootRef.current);
+    setIsPreparing(false);
+    // The manager can close the dialog during that wait. Print only what they
+    // still ask for: the print root is gone, and the system print dialog would
+    // open over a screen they already dismissed.
+    if (!openRef.current) return;
+    window.print();
+  }, []);
+
+  return {
+    svg,
+    png,
+    sheetSvg,
+    failed,
+    size,
+    setSize,
+    message,
+    setMessage,
+    isPreparing,
+    printRootRef,
+    handlePrint,
+    status: printStatus({ failed, isPreparing, printAttempt, ready: Boolean(sheetSvg) }),
+  };
+}

--- a/src/lib/reviews/printSheet.ts
+++ b/src/lib/reviews/printSheet.ts
@@ -29,7 +29,9 @@ export const SHEET_SIZES: Readonly<Record<SheetSizeKey, SheetSize>> = Object.fre
   tent: {
     key: 'tent',
     label: 'Table tent',
-    hint: '4 × 6 in — folds to stand on a table',
+    // Not "folds to stand": the sheet is one tile across the full 4 × 6, so a
+    // fold would put the crease through the QR code.
+    hint: '4 × 6 in — fits a countertop stand',
     widthIn: 4,
     heightIn: 6,
     pageSize: '4in 6in',

--- a/src/lib/reviews/printSheet.ts
+++ b/src/lib/reviews/printSheet.ts
@@ -85,7 +85,7 @@ const DEFAULT_PRINT_BUDGET_MS = 4000;
  * next render. Without this yield the print starts in the same task and puts
  * the broken image on the paper.
  */
-function nextFrame(): Promise<void> {
+export function nextFrame(): Promise<void> {
   return new Promise((resolve) => {
     if (typeof requestAnimationFrame === 'function') {
       requestAnimationFrame(() => resolve());
@@ -117,7 +117,13 @@ export async function waitForPrintReady(
     document.fonts?.ready ?? Promise.resolve(),
     // A failed decode is the missing-logo path. The sheet already falls back to
     // the initials circle, so swallow it rather than block the print.
-    ...images.map((img) => img.decode().catch(() => undefined)),
+    //
+    // `decode` is absent in some engines and in a plain jsdom image. A bare
+    // call would throw out of this function and kill the print, which is a
+    // worse result than a logo that arrives one frame late.
+    ...images.map((img) =>
+      typeof img.decode === 'function' ? img.decode().catch(() => undefined) : Promise.resolve()
+    ),
   ]);
 
   let timer: ReturnType<typeof setTimeout> | undefined;

--- a/src/lib/reviews/printSheet.ts
+++ b/src/lib/reviews/printSheet.ts
@@ -1,0 +1,113 @@
+export type SheetSizeKey = 'tent' | 'card' | 'stickers';
+
+export interface SheetSize {
+  key: SheetSizeKey;
+  /** Shown next to the radio button. */
+  label: string;
+  /** Shown under the label. */
+  hint: string;
+  widthIn: number;
+  heightIn: number;
+  /** Feeds the `@page { size }` rule. Never write this by hand twice. */
+  pageSize: string;
+  /** The printed side of the QR square. */
+  qrIn: number;
+  /** Screen preview scale. The sheet always renders at its real print size. */
+  previewScale: number;
+  /** How many copies the sheet carries. */
+  tiles: number;
+  /** Grid columns for those copies. */
+  columns: number;
+}
+
+/**
+ * One record for three sizes. The `@page` rule, the preview, and the printed
+ * sheet all read these numbers, so a paper size can never disagree with the
+ * element drawn on it.
+ */
+export const SHEET_SIZES: Readonly<Record<SheetSizeKey, SheetSize>> = Object.freeze({
+  tent: {
+    key: 'tent',
+    label: 'Table tent',
+    hint: '4 × 6 in — folds to stand on a table',
+    widthIn: 4,
+    heightIn: 6,
+    pageSize: '4in 6in',
+    qrIn: 2.6,
+    previewScale: 0.62,
+    tiles: 1,
+    columns: 1,
+  },
+  card: {
+    key: 'card',
+    label: 'Counter card',
+    hint: '5.5 × 8.5 in — half a letter sheet',
+    widthIn: 5.5,
+    heightIn: 8.5,
+    pageSize: '5.5in 8.5in',
+    qrIn: 3.2,
+    previewScale: 0.45,
+    tiles: 1,
+    columns: 1,
+  },
+  stickers: {
+    key: 'stickers',
+    label: 'Sticker sheet',
+    hint: '8.5 × 11 in — six to a page',
+    widthIn: 8.5,
+    heightIn: 11,
+    pageSize: '8.5in 11in',
+    qrIn: 1.9,
+    previewScale: 0.35,
+    tiles: 6,
+    columns: 2,
+  },
+});
+
+/** Radio order. `Object.keys` order is not a contract worth relying on. */
+export const SHEET_SIZE_KEYS: readonly SheetSizeKey[] = ['tent', 'card', 'stickers'];
+
+/**
+ * A longer line overflows the tent and pushes the QR off the paper. The dialog
+ * caps the input at this length, so the sheet never has to truncate.
+ */
+export const MAX_MESSAGE_LENGTH = 120;
+
+const DEFAULT_PRINT_BUDGET_MS = 4000;
+
+/**
+ * Holds the print back until the sheet can render what it promises: the slab
+ * serif rather than the Georgia fallback, and the logo rather than an empty
+ * box.
+ *
+ * This never rejects and never hangs. A blocked font request or a stale cache
+ * can leave `document.fonts.ready` pending forever, and a manager staring at a
+ * dead Print button has a broken feature. A late font is a cosmetic loss, so
+ * the budget wins the race and the print goes ahead.
+ */
+export async function waitForPrintReady(
+  root: HTMLElement | null,
+  budgetMs: number = DEFAULT_PRINT_BUDGET_MS
+): Promise<void> {
+  if (!root) return;
+
+  const images = Array.from(root.querySelectorAll('img'));
+  const work = Promise.all([
+    // `document.fonts` is absent in older engines and in some test environments.
+    document.fonts?.ready ?? Promise.resolve(),
+    // A failed decode is the missing-logo path. The sheet already falls back to
+    // the initials circle, so swallow it rather than block the print.
+    ...images.map((img) => img.decode().catch(() => undefined)),
+  ]);
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const budget = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, budgetMs);
+  });
+
+  try {
+    await Promise.race([work.then(() => undefined), budget]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}

--- a/src/lib/reviews/printSheet.ts
+++ b/src/lib/reviews/printSheet.ts
@@ -78,6 +78,24 @@ export const MAX_MESSAGE_LENGTH = 120;
 const DEFAULT_PRINT_BUDGET_MS = 4000;
 
 /**
+ * Yields once, so React can commit a state change that a settled image caused.
+ *
+ * A logo that fails to load rejects `decode()` and fires `onerror`. The error
+ * handler sets state, and the initials circle replaces the broken image on the
+ * next render. Without this yield the print starts in the same task and puts
+ * the broken image on the paper.
+ */
+function nextFrame(): Promise<void> {
+  return new Promise((resolve) => {
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(() => resolve());
+      return;
+    }
+    setTimeout(resolve, 0);
+  });
+}
+
+/**
  * Holds the print back until the sheet can render what it promises: the slab
  * serif rather than the Georgia fallback, and the logo rather than an empty
  * box.
@@ -112,4 +130,6 @@ export async function waitForPrintReady(
   } finally {
     if (timer !== undefined) clearTimeout(timer);
   }
+
+  await nextFrame();
 }

--- a/src/lib/reviews/reviewBranding.ts
+++ b/src/lib/reviews/reviewBranding.ts
@@ -9,6 +9,11 @@ const LOGO_BUCKET = 'review-page-logos';
  * The public page and the printed sheet must agree, so this lives here and not
  * inside either surface. A guest who scans the QR should see the same two
  * letters that the paper on the counter showed.
+ *
+ * Not `getInitials` from tipDistribution.ts: that one takes the first and
+ * last word ("Blue Fin Sushi" -> "BS"). A restaurant name reads better as
+ * its first two words ("Blue Fin Sushi" -> "BF"). Same reason for a plain
+ * empty string here, not tipDistribution's "?" fallback.
  */
 export function initials(name: string): string {
   return name

--- a/src/lib/reviews/reviewBranding.ts
+++ b/src/lib/reviews/reviewBranding.ts
@@ -1,0 +1,34 @@
+import { supabase } from '@/integrations/supabase/client';
+
+/** Matches the bucket created by 20260804100100_review_funnel_tables.sql. */
+const LOGO_BUCKET = 'review-page-logos';
+
+/**
+ * The circle a review page shows when a restaurant uploaded no logo.
+ *
+ * The public page and the printed sheet must agree, so this lives here and not
+ * inside either surface. A guest who scans the QR should see the same two
+ * letters that the paper on the counter showed.
+ */
+export function initials(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((word) => word[0]?.toUpperCase() ?? '')
+    .join('');
+}
+
+/**
+ * The manager side stores `logo_path`, not a URL (useReviewPages.ts:14), while
+ * the guest side receives `logo_url` already built by the edge function
+ * (supabase/functions/review-public/index.ts:137-138). The printed sheet runs
+ * in the browser and has only the path, so it repeats that derivation here.
+ *
+ * No signature is involved: the bucket carries `public = true` and a public
+ * SELECT policy (20260804100100_review_funnel_tables.sql:202-215).
+ */
+export function logoPublicUrl(path: string | null): string | null {
+  if (!path) return null;
+  return supabase.storage.from(LOGO_BUCKET).getPublicUrl(path).data.publicUrl;
+}

--- a/src/pages/ReviewPage.tsx
+++ b/src/pages/ReviewPage.tsx
@@ -12,6 +12,7 @@ import { StarRating } from '@/components/reviews/StarRating';
 
 import { ChevronLeft } from 'lucide-react';
 
+import { initials } from '@/lib/reviews/reviewBranding';
 import { canSubmitFollowUp } from '@/lib/reviews/reviewSubmission';
 import {
   classifyReviewPageResponse,
@@ -27,15 +28,6 @@ import '@fontsource/ibm-plex-mono/400.css';
 import '@/styles/counter-theme.css';
 
 type Stage = 'land' | 'promoter' | 'feedback' | 'thanks';
-
-function initials(name: string): string {
-  return name
-    .split(/\s+/)
-    .filter(Boolean)
-    .slice(0, 2)
-    .map((word) => word[0]?.toUpperCase() ?? '')
-    .join('');
-}
 
 /** The Google review hand-off. The promoter stage and the thanks stage both render it. */
 function GoogleReviewLink({ href }: { href: string }) {

--- a/src/pages/ReviewPage.tsx
+++ b/src/pages/ReviewPage.tsx
@@ -8,11 +8,11 @@ import { Label } from '@/components/ui/label';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Textarea } from '@/components/ui/textarea';
 
+import { BrandMark } from '@/components/reviews/BrandMark';
 import { StarRating } from '@/components/reviews/StarRating';
 
 import { ChevronLeft } from 'lucide-react';
 
-import { initials } from '@/lib/reviews/reviewBranding';
 import { canSubmitFollowUp } from '@/lib/reviews/reviewSubmission';
 import {
   classifyReviewPageResponse,
@@ -281,20 +281,11 @@ export default function ReviewPage() {
   return shell(
     <>
       <div className="flex flex-col items-center">
-        {page.logo_url ? (
-          <img
-            src={page.logo_url}
-            alt=""
-            className="h-14 w-14 rounded-full object-cover"
-          />
-        ) : (
-          <div
-            aria-hidden="true"
-            className="counter-display flex h-14 w-14 items-center justify-center rounded-full bg-muted text-[18px] font-semibold text-foreground"
-          >
-            {initials(page.restaurant_name)}
-          </div>
-        )}
+        <BrandMark
+          logoUrl={page.logo_url}
+          name={page.restaurant_name}
+          className="h-14 w-14 text-[18px]"
+        />
         <p className="counter-micro mt-3 text-[12px] uppercase tracking-wider text-muted-foreground">
           {page.restaurant_name}
         </p>

--- a/src/pages/Reviews.tsx
+++ b/src/pages/Reviews.tsx
@@ -69,7 +69,11 @@ export default function Reviews() {
 
       <div className="mt-6">
         {tab === 'pages' ? (
-          <PagesTab restaurantId={restaurantId} canManage={canManage} />
+          <PagesTab
+            restaurantId={restaurantId}
+            restaurantName={selectedRestaurant?.restaurant?.name ?? ''}
+            canManage={canManage}
+          />
         ) : (
           <FeedbackTab restaurantId={restaurantId} canManage={canManage} />
         )}
@@ -327,7 +331,15 @@ const FeedbackRow = memo(function FeedbackRow({
   );
 });
 
-function PagesTab({ restaurantId, canManage }: { restaurantId?: string; canManage: boolean }) {
+function PagesTab({
+  restaurantId,
+  restaurantName,
+  canManage,
+}: {
+  restaurantId?: string;
+  restaurantName: string;
+  canManage: boolean;
+}) {
   const { pages, isLoading, error } = useReviewPages(restaurantId);
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
@@ -430,6 +442,7 @@ function PagesTab({ restaurantId, canManage }: { restaurantId?: string; canManag
           <ReviewPageBuilder
             page={creating ? null : selected}
             restaurantId={restaurantId}
+            restaurantName={restaurantName}
             canManage={canManage}
             onCreated={(id) => {
               setCreating(false);

--- a/src/styles/print-sheet.css
+++ b/src/styles/print-sheet.css
@@ -1,0 +1,94 @@
+/* The printed review sheet. The first print CSS in this codebase.
+ *
+ * Why a portal on document.body and not the dialog:
+ * DialogContent carries `fixed`, `max-h-[85vh]`, `overflow-y-auto`, and two
+ * translate transforms (src/components/ui/dialog.tsx:40). A clipped,
+ * transformed, fixed ancestor prints the visible scroll window only, and
+ * WebKit often prints nothing at all. The print copy therefore hangs off
+ * document.body, where no Radix wrapper can reach it.
+ *
+ * Why `position: absolute; left: -100000px` and not `display: none`:
+ * a display:none image is not laid out, and img.decode() can reject on it.
+ * waitForPrintReady depends on that decode, so the print copy stays in the
+ * layout and moves off screen instead.
+ */
+
+#review-print-root {
+  position: absolute;
+  left: -100000px;
+  top: 0;
+}
+
+/* Named pages. `@page` cannot read a class, so each size gets its own page
+ * name and the root opts in through `page:`. Every rule zeroes the margin: a
+ * browser applies about 0.5in by default, which shrinks the printable area and
+ * pushes a seventh partial row of stickers onto a second sheet. */
+@page tent {
+  size: 4in 6in;
+  margin: 0;
+}
+
+@page card {
+  size: 5.5in 8.5in;
+  margin: 0;
+}
+
+@page stickers {
+  size: 8.5in 11in;
+  margin: 0;
+}
+
+#review-print-root[data-size='tent'] {
+  page: tent;
+}
+
+#review-print-root[data-size='card'] {
+  page: card;
+}
+
+#review-print-root[data-size='stickers'] {
+  page: stickers;
+}
+
+/* The one place in this feature that names a colour instead of a token.
+ *
+ * A QR scanner reads contrast, not theme. The Counter palette's warm paper
+ * (--background: 38 34% 96%) behind black modules drops the contrast ratio and
+ * makes a worn print harder to read at arm's length. The code therefore sits on
+ * pure white on screen and on paper. The surrounding sheet keeps the token. */
+.print-qr-paper {
+  background-color: #fff;
+}
+
+/* The trim guide. Safari often ignores `@page size` and prints on the user's
+ * chosen paper, so a manager needs to see where to cut. */
+.print-tile {
+  outline: 1px dashed hsl(var(--border));
+  outline-offset: -2px;
+}
+
+@media print {
+  /* DialogPortal makes the whole dialog a direct child of body
+   * (src/components/ui/dialog.tsx:34-36), so this reaches it. */
+  body > *:not(#review-print-root) {
+    display: none !important;
+  }
+
+  #review-print-root {
+    position: static;
+    left: auto;
+  }
+
+  /* Only the logo and the QR force their ink. A full-bleed warm background
+   * would drain a restaurant printer's colour cartridge on every sheet. */
+  .print-ink {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  /* No tile may split across two sheets. */
+  .print-tile {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+}

--- a/src/styles/print-sheet.css
+++ b/src/styles/print-sheet.css
@@ -68,9 +68,19 @@
 }
 
 @media print {
-  /* DialogPortal makes the whole dialog a direct child of body
+  /* WARNING: this rule must never apply without the print root on the page.
+   *
+   * The selector needs the `review-print-active` class, which ReviewQrDialog
+   * adds to body only while the print portal is mounted. Scoped to `body >`
+   * alone, the rule stays live for the whole session, because this stylesheet
+   * loads with the Reviews route and never unloads. A manager who opened the
+   * QR dialog once would then print a blank sheet from every other page —
+   * payroll, P&L, an invoice. tests/e2e/review-qr-print.spec.ts closes the
+   * dialog and prints again to hold this.
+   *
+   * DialogPortal makes the whole dialog a direct child of body
    * (src/components/ui/dialog.tsx:34-36), so this reaches it. */
-  body > *:not(#review-print-root) {
+  body.review-print-active > *:not(#review-print-root) {
     display: none !important;
   }
 

--- a/tests/e2e/review-qr-print.spec.ts
+++ b/tests/e2e/review-qr-print.spec.ts
@@ -101,4 +101,21 @@ test('an owner previews and prints the table tent', async ({ page }) => {
       timeout: 10000,
     })
     .toBe(1);
+
+  // Close the dialog, then print again.
+  //
+  // The hide rule is global CSS. It loads with the Reviews route and stays for
+  // the whole session. Scoped to `body >` alone it also hides the app on every
+  // other page: a manager who opens this dialog once then prints a payroll
+  // report gets a blank sheet. The rule must therefore need the print root to
+  // be mounted.
+  await page.keyboard.press('Escape');
+  await expect(printRoot).toHaveCount(0);
+
+  await page.emulateMedia({ media: 'print' });
+  const afterClose = await page.evaluate(
+    () => getComputedStyle(document.getElementById('root')!).display
+  );
+  expect(afterClose).not.toBe('none');
+  await page.emulateMedia({ media: 'screen' });
 });

--- a/tests/e2e/review-qr-print.spec.ts
+++ b/tests/e2e/review-qr-print.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect } from '@playwright/test';
+import { signUpAndCreateRestaurant, generateTestUser } from '../helpers/e2e-supabase';
+
+/**
+ * E2E: an owner prints the table tent from the QR dialog.
+ *
+ * The unit tests cover the props and the state. They cannot cover the print
+ * CSS, because jsdom has no print media and no page box. This spec is the only
+ * place `@media print` runs, so it asserts the two rules that a manager finds
+ * out about at the printer:
+ *
+ *   1. The print copy hangs off document.body, outside DialogContent. A
+ *      `fixed`, clipped, transformed ancestor prints the visible scroll
+ *      window only.
+ *   2. Print hides every other body child. Without that rule the sheet
+ *      arrives behind the app chrome and the dialog overlay.
+ *
+ * `window.print` opens a native dialog that Playwright cannot close, so the
+ * spec replaces it with a counter before the click.
+ */
+
+test('an owner previews and prints the table tent', async ({ page }) => {
+  const user = generateTestUser('qrprint');
+  await signUpAndCreateRestaurant(page, user);
+
+  await page.goto('/reviews');
+  await expect(page.getByRole('heading', { name: 'Reviews' })).toBeVisible({ timeout: 10000 });
+
+  await page.getByRole('button', { name: /new page/i }).first().click();
+  await page.getByLabel(/^name$/i).fill(`Tents ${Date.now()}`);
+  await page.getByLabel(/google review link/i).fill('https://example.com/google-review');
+  await page.getByRole('button', { name: /create page/i }).click();
+
+  await page.getByRole('button', { name: /qr code/i }).click();
+
+  const printRoot = page.locator('#review-print-root');
+  await expect(printRoot).toHaveAttribute('data-size', 'tent', { timeout: 10000 });
+
+  // The print copy is a sibling of the dialog on body, not a descendant of it.
+  // `evaluate` reads the real parent, which no CSS selector can assert.
+  const parentIsBody = await printRoot.evaluate((node) => node.parentElement === document.body);
+  expect(parentIsBody).toBe(true);
+
+  // The sheet carries the restaurant name and the seeded headline.
+  const tile = printRoot.locator('.print-tile');
+  await expect(tile).toHaveCount(1);
+  await expect(tile).toContainText(user.restaurantName);
+  await expect(tile).toContainText('How was everything?');
+
+  // A one-off message reaches both mounts: the preview and the paper.
+  await page.getByLabel(/^message$/i).fill('Tell us how we did');
+  await expect(page.locator('.print-tile', { hasText: 'Tell us how we did' })).toHaveCount(2);
+
+  // The sticker sheet is six tiles on one page, and repoints `@page`.
+  await page.getByRole('radio', { name: /sticker/i }).click();
+  await expect(printRoot).toHaveAttribute('data-size', 'stickers');
+  await expect(printRoot.locator('.print-tile')).toHaveCount(6);
+
+  await page.getByRole('radio', { name: /table tent/i }).click();
+  await expect(printRoot).toHaveAttribute('data-size', 'tent');
+
+  // Print media: the sheet is the only thing on the paper.
+  //
+  // Read the computed styles, not `toBeVisible`/`toBeHidden`. Radix marks the
+  // background `aria-hidden` while a dialog is open, so a role query behind the
+  // dialog matches nothing — and `toBeHidden()` passes for zero elements. That
+  // assertion held even after the print rule was deleted. These do not.
+  await page.emulateMedia({ media: 'print' });
+
+  const printStyles = await page.evaluate(() => {
+    const root = document.getElementById('review-print-root')!;
+    const app = document.getElementById('root')!;
+    return {
+      appDisplay: getComputedStyle(app).display,
+      sheetDisplay: getComputedStyle(root).display,
+      // The screen rule parks the sheet at left: -100000px. Print must undo it,
+      // or the paper comes out blank.
+      sheetPosition: getComputedStyle(root).position,
+      sheetLeft: getComputedStyle(root).left,
+    };
+  });
+
+  expect(printStyles.appDisplay).toBe('none');
+  expect(printStyles.sheetDisplay).not.toBe('none');
+  expect(printStyles.sheetPosition).toBe('static');
+  expect(printStyles.sheetLeft).toBe('auto');
+
+  await page.emulateMedia({ media: 'screen' });
+
+  await page.evaluate(() => {
+    (window as unknown as { __printCalls: number }).__printCalls = 0;
+    window.print = () => {
+      (window as unknown as { __printCalls: number }).__printCalls += 1;
+    };
+  });
+
+  await page.getByRole('button', { name: /^print$/i }).click();
+
+  await expect
+    .poll(() => page.evaluate(() => (window as unknown as { __printCalls: number }).__printCalls), {
+      timeout: 10000,
+    })
+    .toBe(1);
+});

--- a/tests/unit/ReviewQrDialog.print.test.tsx
+++ b/tests/unit/ReviewQrDialog.print.test.tsx
@@ -166,6 +166,34 @@ describe('ReviewQrDialog print sheet', () => {
     expect(window.print).not.toHaveBeenCalled();
   });
 
+  it('does not print for a dialog session the manager already closed', async () => {
+    // Close and open again inside one slow wait. A live `open` flag goes back
+    // to true, and the dead attempt would then print into the new session —
+    // the manager gets a print dialog they did not ask for.
+    const { rerender } = render(<ReviewQrDialog {...PROPS} />);
+    const button = await screen.findByRole('button', { name: /^print$/i });
+    await waitFor(() => expect(button).toBeEnabled());
+
+    fireEvent.click(button);
+    rerender(<ReviewQrDialog {...PROPS} open={false} />);
+    rerender(<ReviewQrDialog {...PROPS} open={true} />);
+
+    await act(async () => {
+      await new Promise((done) => setTimeout(done, 50));
+    });
+    expect(window.print).not.toHaveBeenCalled();
+  });
+
+  it('clamps a long saved headline to the message limit', async () => {
+    // `review_pages.headline` is TEXT with no length limit, and the headline
+    // editor sets no maxLength. The input maxLength stops a manager from
+    // typing past 120. It does not trim a value that arrives past 120.
+    const long = 'x'.repeat(300);
+    render(<ReviewQrDialog {...PROPS} defaultMessage={long} />);
+    const input = await screen.findByLabelText(/message/i);
+    expect((input as HTMLInputElement).value).toHaveLength(120);
+  });
+
   it('announces the ready status before it opens the print dialog', async () => {
     // `window.print()` blocks the main thread until the manager dismisses the
     // system dialog. Without a frame yield React never paints the new status,

--- a/tests/unit/ReviewQrDialog.print.test.tsx
+++ b/tests/unit/ReviewQrDialog.print.test.tsx
@@ -1,0 +1,140 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    storage: {
+      from: (bucket: string) => ({
+        getPublicUrl: (path: string) => ({
+          data: { publicUrl: `https://stub.test/${bucket}/${path}` },
+        }),
+      }),
+    },
+  },
+}));
+
+vi.mock('qrcode', () => ({
+  toString: (_text: string, options: { margin: number }) =>
+    Promise.resolve(`<svg data-margin="${options.margin}"><rect /></svg>`),
+  toDataURL: () => Promise.resolve('data:image/png;base64,stub'),
+}));
+
+import { ReviewQrDialog } from '@/components/reviews/ReviewQrDialog';
+
+const PROPS = {
+  open: true,
+  onOpenChange: () => {},
+  slug: 'blue-fin',
+  publicUrl: 'https://app.test/r/blue-fin',
+  restaurantName: 'Blue Fin Sushi',
+  logoPath: null,
+  defaultMessage: 'How was everything?',
+};
+
+/** The live region is the only sr-only paragraph in the dialog. */
+function liveText(): string {
+  return document.querySelector('[aria-live]')?.textContent ?? '';
+}
+
+describe('ReviewQrDialog print sheet', () => {
+  beforeEach(() => {
+    vi.stubGlobal('print', vi.fn());
+    Object.defineProperty(document, 'fonts', {
+      configurable: true,
+      get: () => ({ ready: Promise.resolve() }),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('starts the message at defaultMessage', async () => {
+    render(<ReviewQrDialog {...PROPS} />);
+    const input = await screen.findByLabelText(/message/i);
+    expect(input).toHaveValue('How was everything?');
+  });
+
+  it('resets the message when the dialog closes and reopens', async () => {
+    const { rerender } = render(<ReviewQrDialog {...PROPS} />);
+    const input = await screen.findByLabelText(/message/i);
+    fireEvent.change(input, { target: { value: 'Tell us how we did' } });
+    expect(input).toHaveValue('Tell us how we did');
+
+    rerender(<ReviewQrDialog {...PROPS} open={false} />);
+    rerender(<ReviewQrDialog {...PROPS} open={true} />);
+
+    expect(await screen.findByLabelText(/message/i)).toHaveValue('How was everything?');
+  });
+
+  it('shows the typed message on the sheet', async () => {
+    render(<ReviewQrDialog {...PROPS} />);
+    const input = await screen.findByLabelText(/message/i);
+    fireEvent.change(input, { target: { value: 'Tell us how we did' } });
+
+    // One props object drives both mounts, so both must show the new text.
+    await waitFor(() => {
+      const hits = Array.from(document.querySelectorAll('.print-tile')).filter((tile) =>
+        tile.textContent?.includes('Tell us how we did')
+      );
+      expect(hits).toHaveLength(2);
+    });
+  });
+
+  it('generates a wider quiet zone for the sheet than for the download', async () => {
+    render(<ReviewQrDialog {...PROPS} />);
+    await waitFor(() => {
+      expect(document.querySelector('#review-print-root svg')).toHaveAttribute('data-margin', '4');
+    });
+  });
+
+  it('calls window.print only after the sheet is ready', async () => {
+    render(<ReviewQrDialog {...PROPS} />);
+    const button = await screen.findByRole('button', { name: /^print$/i });
+    await waitFor(() => expect(button).toBeEnabled());
+
+    expect(window.print).not.toHaveBeenCalled();
+    fireEvent.click(button);
+    await waitFor(() => expect(window.print).toHaveBeenCalledTimes(1));
+  });
+
+  it('announces a different string on a second print', async () => {
+    render(<ReviewQrDialog {...PROPS} />);
+    const button = await screen.findByRole('button', { name: /^print$/i });
+    await waitFor(() => expect(button).toBeEnabled());
+
+    fireEvent.click(button);
+    await waitFor(() => expect(window.print).toHaveBeenCalledTimes(1));
+    const first = liveText();
+
+    fireEvent.click(button);
+    await waitFor(() => expect(window.print).toHaveBeenCalledTimes(2));
+    // aria-live reports a change. An identical string announces nothing, so a
+    // second print would be silent to a screen reader.
+    expect(liveText()).not.toBe(first);
+  });
+
+  it('changes data-size on the print root when the size changes', async () => {
+    render(<ReviewQrDialog {...PROPS} />);
+    await waitFor(() =>
+      expect(document.querySelector('#review-print-root')).toHaveAttribute('data-size', 'tent')
+    );
+
+    fireEvent.click(await screen.findByRole('radio', { name: /counter card/i }));
+
+    await waitFor(() =>
+      expect(document.querySelector('#review-print-root')).toHaveAttribute('data-size', 'card')
+    );
+  });
+
+  it('mounts no print root while the dialog is closed', () => {
+    render(<ReviewQrDialog {...PROPS} open={false} />);
+    expect(document.querySelector('#review-print-root')).toBeNull();
+  });
+
+  it('caps the message input at 120 characters', async () => {
+    render(<ReviewQrDialog {...PROPS} />);
+    expect(await screen.findByLabelText(/message/i)).toHaveAttribute('maxlength', '120');
+  });
+});

--- a/tests/unit/ReviewQrDialog.print.test.tsx
+++ b/tests/unit/ReviewQrDialog.print.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 
 vi.mock('@/integrations/supabase/client', () => ({
   supabase: {
@@ -136,5 +136,59 @@ describe('ReviewQrDialog print sheet', () => {
   it('caps the message input at 120 characters', async () => {
     render(<ReviewQrDialog {...PROPS} />);
     expect(await screen.findByLabelText(/message/i)).toHaveAttribute('maxlength', '120');
+  });
+
+  it('keeps a typed message when the saved headline changes underneath', async () => {
+    // useReviewPages refetches on window focus. A second manager can save a new
+    // headline while this one types a one-off message for the paper.
+    const { rerender } = render(<ReviewQrDialog {...PROPS} />);
+    const input = await screen.findByLabelText(/message/i);
+    fireEvent.change(input, { target: { value: 'Tell us how we did' } });
+
+    rerender(<ReviewQrDialog {...PROPS} defaultMessage="A brand new headline" />);
+
+    expect(await screen.findByLabelText(/message/i)).toHaveValue('Tell us how we did');
+  });
+
+  it('does not print when the dialog closes during the wait', async () => {
+    const { rerender } = render(<ReviewQrDialog {...PROPS} />);
+    const button = await screen.findByRole('button', { name: /^print$/i });
+    await waitFor(() => expect(button).toBeEnabled());
+
+    fireEvent.click(button);
+    // Close before waitForPrintReady resolves. The system print dialog would
+    // otherwise open over a screen the manager already dismissed.
+    rerender(<ReviewQrDialog {...PROPS} open={false} />);
+
+    await act(async () => {
+      await new Promise((done) => setTimeout(done, 50));
+    });
+    expect(window.print).not.toHaveBeenCalled();
+  });
+
+  it('holds the print class on body only while the dialog is open', async () => {
+    const { rerender } = render(<ReviewQrDialog {...PROPS} />);
+    await waitFor(() => expect(document.body).toHaveClass('review-print-active'));
+
+    // The print rule hides every other body child. Left behind, it makes every
+    // other page in the app print a blank sheet.
+    rerender(<ReviewQrDialog {...PROPS} open={false} />);
+    expect(document.body).not.toHaveClass('review-print-active');
+  });
+
+  it('names the preview for a screen reader', async () => {
+    render(<ReviewQrDialog {...PROPS} />);
+    // The sheet itself is aria-hidden. Without this wrapper the dialog gives a
+    // screen reader no restaurant name and no destination for the code.
+    const preview = await screen.findByRole('img', { name: /preview of the/i });
+    expect(preview).toHaveAccessibleName(/Blue Fin Sushi/);
+    expect(preview).toHaveAccessibleName(/https:\/\/app\.test\/r\/blue-fin/);
+  });
+
+  it('names the paper size radio group', async () => {
+    render(<ReviewQrDialog {...PROPS} />);
+    // `label htmlFor` names labelable elements only. RadioGroup renders a div,
+    // so the group needs aria-labelledby to announce with a name.
+    expect(await screen.findByRole('radiogroup', { name: /paper size/i })).toBeInTheDocument();
   });
 });

--- a/tests/unit/ReviewQrDialog.print.test.tsx
+++ b/tests/unit/ReviewQrDialog.print.test.tsx
@@ -166,6 +166,27 @@ describe('ReviewQrDialog print sheet', () => {
     expect(window.print).not.toHaveBeenCalled();
   });
 
+  it('announces the ready status before it opens the print dialog', async () => {
+    // `window.print()` blocks the main thread until the manager dismisses the
+    // system dialog. Without a frame yield React never paints the new status,
+    // and a screen reader user hears "Preparing" and then nothing.
+    let statusAtPrint = '';
+    vi.stubGlobal(
+      'print',
+      vi.fn(() => {
+        statusAtPrint = liveText();
+      })
+    );
+
+    render(<ReviewQrDialog {...PROPS} />);
+    const button = await screen.findByRole('button', { name: /^print$/i });
+    await waitFor(() => expect(button).toBeEnabled());
+
+    fireEvent.click(button);
+    await waitFor(() => expect(window.print).toHaveBeenCalledTimes(1));
+    expect(statusAtPrint).toMatch(/sheet ready/i);
+  });
+
   it('holds the print class on body only while the dialog is open', async () => {
     const { rerender } = render(<ReviewQrDialog {...PROPS} />);
     await waitFor(() => expect(document.body).toHaveClass('review-print-active'));

--- a/tests/unit/ReviewTentSheet.test.tsx
+++ b/tests/unit/ReviewTentSheet.test.tsx
@@ -34,8 +34,11 @@ describe('ReviewTentSheet', () => {
     const img = container.querySelector('img');
     expect(img).not.toBeNull();
     expect(img).toHaveAttribute('src', 'https://cdn.test/logo.png');
-    expect(img).toHaveAttribute('crossorigin', 'anonymous');
     expect(img).toHaveAttribute('alt', '');
+    // No `crossOrigin`. Nothing draws this logo to a canvas, so the attribute
+    // buys nothing and adds a CORS rule that can fail a logo the guest page
+    // loads. The sheet must load the logo the same way the guest page does.
+    expect(img).not.toHaveAttribute('crossorigin');
   });
 
   it('falls back to the initials when the logo fails to load', () => {
@@ -45,6 +48,20 @@ describe('ReviewTentSheet', () => {
     fireEvent.error(container.querySelector('img')!);
     expect(container.querySelector('img')).toBeNull();
     expect(screen.getByText('BF')).toBeInTheDocument();
+  });
+
+  it('turns every sticker tile to the initials when one logo fails', () => {
+    // Six tiles, one URL, one flag. Six local flags would let a slow request
+    // print five logos and one circle on the same physical sheet.
+    const { container } = render(
+      <ReviewTentSheet {...BASE} size="stickers" logoUrl="https://cdn.test/broken.png" />
+    );
+    expect(container.querySelectorAll('img')).toHaveLength(6);
+
+    fireEvent.error(container.querySelectorAll('img')[0]);
+
+    expect(container.querySelectorAll('img')).toHaveLength(0);
+    expect(screen.getAllByText('BF')).toHaveLength(6);
   });
 
   it('renders one tile for the tent and six for the sticker sheet', () => {

--- a/tests/unit/ReviewTentSheet.test.tsx
+++ b/tests/unit/ReviewTentSheet.test.tsx
@@ -64,6 +64,21 @@ describe('ReviewTentSheet', () => {
     expect(screen.getAllByText('BF')).toHaveLength(6);
   });
 
+  it('tries the logo again when the URL changes', () => {
+    // `logo_path` comes from a React Query read with `refetchOnWindowFocus`. A
+    // manager can upload a new logo while this dialog stays open. A sticky
+    // boolean flag would then show the initials circle for the new URL too.
+    const { container, rerender } = render(
+      <ReviewTentSheet {...BASE} logoUrl="https://cdn.test/old.png" />
+    );
+    fireEvent.error(container.querySelector('img')!);
+    expect(container.querySelector('img')).toBeNull();
+
+    rerender(<ReviewTentSheet {...BASE} logoUrl="https://cdn.test/new.png" />);
+
+    expect(container.querySelector('img')).toHaveAttribute('src', 'https://cdn.test/new.png');
+  });
+
   it('renders one tile for the tent and six for the sticker sheet', () => {
     const { container: tent } = render(<ReviewTentSheet {...BASE} />);
     expect(tent.querySelectorAll('.print-tile')).toHaveLength(1);

--- a/tests/unit/ReviewTentSheet.test.tsx
+++ b/tests/unit/ReviewTentSheet.test.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { ReviewTentSheet } from '@/components/reviews/ReviewTentSheet';
+
+const BASE = {
+  size: 'tent' as const,
+  restaurantName: 'Blue Fin Sushi',
+  logoUrl: null,
+  message: 'How was everything?',
+  qrSvg: '<svg role="presentation"><rect /></svg>',
+  publicUrl: 'https://app.test/r/blue-fin',
+};
+
+describe('ReviewTentSheet', () => {
+  it('shows the restaurant name, the message, and the URL', () => {
+    render(<ReviewTentSheet {...BASE} />);
+    expect(screen.getByText('Blue Fin Sushi')).toBeInTheDocument();
+    expect(screen.getByText('How was everything?')).toBeInTheDocument();
+    expect(screen.getByText('app.test/r/blue-fin')).toBeInTheDocument();
+  });
+
+  it('shows the initials circle when there is no logo', () => {
+    const { container } = render(<ReviewTentSheet {...BASE} />);
+    expect(screen.getByText('BF')).toBeInTheDocument();
+    expect(container.querySelector('img')).toBeNull();
+  });
+
+  it('shows the logo when there is one', () => {
+    const { container } = render(
+      <ReviewTentSheet {...BASE} logoUrl="https://cdn.test/logo.png" />
+    );
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img).toHaveAttribute('src', 'https://cdn.test/logo.png');
+    expect(img).toHaveAttribute('crossorigin', 'anonymous');
+    expect(img).toHaveAttribute('alt', '');
+  });
+
+  it('falls back to the initials when the logo fails to load', () => {
+    const { container } = render(
+      <ReviewTentSheet {...BASE} logoUrl="https://cdn.test/broken.png" />
+    );
+    fireEvent.error(container.querySelector('img')!);
+    expect(container.querySelector('img')).toBeNull();
+    expect(screen.getByText('BF')).toBeInTheDocument();
+  });
+
+  it('renders one tile for the tent and six for the sticker sheet', () => {
+    const { container: tent } = render(<ReviewTentSheet {...BASE} />);
+    expect(tent.querySelectorAll('.print-tile')).toHaveLength(1);
+
+    const { container: stickers } = render(<ReviewTentSheet {...BASE} size="stickers" />);
+    expect(stickers.querySelectorAll('.print-tile')).toHaveLength(6);
+  });
+
+  it('carries the theme, the size, and aria-hidden on its root', () => {
+    const { container } = render(<ReviewTentSheet {...BASE} size="card" />);
+    const root = container.firstElementChild as HTMLElement;
+    expect(root).toHaveAttribute('data-size', 'card');
+    expect(root).toHaveAttribute('aria-hidden', 'true');
+    expect(root.className).toContain('theme-counter');
+  });
+
+  it('sizes the paper from SHEET_SIZES, not from a hand-written value', () => {
+    const { container } = render(<ReviewTentSheet {...BASE} size="card" />);
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.style.width).toBe('5.5in');
+    expect(root.style.height).toBe('8.5in');
+  });
+
+  it('renders no QR block until the SVG arrives', () => {
+    const { container } = render(<ReviewTentSheet {...BASE} qrSvg={null} />);
+    expect(container.querySelector('svg')).toBeNull();
+  });
+});

--- a/tests/unit/printSheet.test.ts
+++ b/tests/unit/printSheet.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import {
+  SHEET_SIZES,
+  SHEET_SIZE_KEYS,
+  MAX_MESSAGE_LENGTH,
+  waitForPrintReady,
+} from '@/lib/reviews/printSheet';
+
+describe('SHEET_SIZES', () => {
+  it('holds exactly the three shipped sizes', () => {
+    expect(SHEET_SIZE_KEYS).toEqual(['tent', 'card', 'stickers']);
+    expect(Object.keys(SHEET_SIZES).sort()).toEqual(['card', 'stickers', 'tent']);
+  });
+
+  it('gives every pageSize string the same inches as its own dimensions', () => {
+    for (const key of SHEET_SIZE_KEYS) {
+      const size = SHEET_SIZES[key];
+      expect(size.pageSize).toBe(`${size.widthIn}in ${size.heightIn}in`);
+    }
+  });
+
+  it('keys every entry by its own key', () => {
+    for (const key of SHEET_SIZE_KEYS) {
+      expect(SHEET_SIZES[key].key).toBe(key);
+    }
+  });
+
+  it('keeps every QR at least 32 mm wide', () => {
+    // 32 mm is the practical floor for a phone camera at arm's length.
+    const MIN_QR_IN = 32 / 25.4;
+    for (const key of SHEET_SIZE_KEYS) {
+      expect(SHEET_SIZES[key].qrIn).toBeGreaterThanOrEqual(MIN_QR_IN);
+    }
+  });
+
+  it('fits the QR inside its own paper', () => {
+    for (const key of SHEET_SIZE_KEYS) {
+      const size = SHEET_SIZES[key];
+      const across = size.columns;
+      expect(size.qrIn * across).toBeLessThan(size.widthIn);
+    }
+  });
+
+  it('gives the sticker sheet a six-tile grid and the others a single tile', () => {
+    expect(SHEET_SIZES.stickers.tiles).toBe(6);
+    expect(SHEET_SIZES.stickers.columns).toBe(2);
+    expect(SHEET_SIZES.tent.tiles).toBe(1);
+    expect(SHEET_SIZES.card.tiles).toBe(1);
+  });
+
+  it('caps the message at 120 characters', () => {
+    expect(MAX_MESSAGE_LENGTH).toBe(120);
+  });
+});
+
+/** Builds a root whose images resolve or reject on demand. */
+function rootWithImages(behaviours: Array<'resolve' | 'reject'>): HTMLElement {
+  const root = document.createElement('div');
+  for (const behaviour of behaviours) {
+    const img = document.createElement('img');
+    img.decode =
+      behaviour === 'resolve'
+        ? () => Promise.resolve()
+        : () => Promise.reject(new Error('decode failed'));
+    root.appendChild(img);
+  }
+  return root;
+}
+
+describe('waitForPrintReady', () => {
+  let fontsReady: Promise<unknown>;
+
+  beforeEach(() => {
+    fontsReady = Promise.resolve();
+    Object.defineProperty(document, 'fonts', {
+      configurable: true,
+      get: () => ({ get ready() { return fontsReady; } }),
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('resolves when the fonts and every image resolve', async () => {
+    await expect(waitForPrintReady(rootWithImages(['resolve', 'resolve']))).resolves.toBeUndefined();
+  });
+
+  it('resolves when an image decode rejects', async () => {
+    // A missing logo must never block the print.
+    await expect(waitForPrintReady(rootWithImages(['resolve', 'reject']))).resolves.toBeUndefined();
+  });
+
+  it('resolves for a null root', async () => {
+    await expect(waitForPrintReady(null)).resolves.toBeUndefined();
+  });
+
+  it('resolves on the budget when the fonts promise never settles', async () => {
+    vi.useFakeTimers();
+    fontsReady = new Promise(() => {});
+
+    let settled = false;
+    const pending = waitForPrintReady(rootWithImages([]), 4000).then(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(3999);
+    expect(settled).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await pending;
+    expect(settled).toBe(true);
+  });
+
+  it('resolves without waiting for the budget when the work finishes first', async () => {
+    vi.useFakeTimers();
+
+    let settled = false;
+    const pending = waitForPrintReady(rootWithImages(['resolve']), 4000).then(() => {
+      settled = true;
+    });
+
+    await vi.advanceTimersByTimeAsync(0);
+    await pending;
+    expect(settled).toBe(true);
+  });
+});

--- a/tests/unit/printSheet.test.ts
+++ b/tests/unit/printSheet.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import {
@@ -6,6 +9,7 @@ import {
   MAX_MESSAGE_LENGTH,
   waitForPrintReady,
 } from '@/lib/reviews/printSheet';
+import { SLUG_PATTERN } from '@/lib/reviews/reviewSlug';
 
 describe('SHEET_SIZES', () => {
   it('holds exactly the three shipped sizes', () => {
@@ -108,7 +112,9 @@ describe('waitForPrintReady', () => {
     await vi.advanceTimersByTimeAsync(3999);
     expect(settled).toBe(false);
 
+    // 1 ms ends the budget, then one frame lets React commit.
     await vi.advanceTimersByTimeAsync(1);
+    await vi.advanceTimersByTimeAsync(20);
     await pending;
     expect(settled).toBe(true);
   });
@@ -121,8 +127,114 @@ describe('waitForPrintReady', () => {
       settled = true;
     });
 
-    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(20);
     await pending;
     expect(settled).toBe(true);
+  });
+
+  it('yields a frame after the images settle', async () => {
+    // A logo that fails to load rejects decode() and fires onerror. The error
+    // handler sets state, and React needs a frame to put the initials circle
+    // on the paper. Without the yield the print captures the broken image.
+    const frames: Array<() => void> = [];
+    const original = globalThis.requestAnimationFrame;
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      frames.push(() => cb(0));
+      return 1;
+    }) as typeof globalThis.requestAnimationFrame;
+
+    try {
+      let settled = false;
+      const pending = waitForPrintReady(rootWithImages(['reject'])).then(() => {
+        settled = true;
+      });
+
+      // Drain the microtask queue. The frame is the only thing left.
+      await new Promise((done) => setTimeout(done, 0));
+      expect(settled).toBe(false);
+      expect(frames).toHaveLength(1);
+
+      frames[0]();
+      await pending;
+      expect(settled).toBe(true);
+    } finally {
+      globalThis.requestAnimationFrame = original;
+    }
+  });
+});
+
+const PRINT_CSS = readFileSync(resolve(process.cwd(), 'src/styles/print-sheet.css'), 'utf8');
+
+describe('print-sheet.css against SHEET_SIZES', () => {
+  // `@page` cannot read a TypeScript object, so the paper sizes live twice: in
+  // SHEET_SIZES and in the stylesheet. This suite is what stops them drifting.
+  const pageRules = new Map<string, string>();
+  for (const match of PRINT_CSS.matchAll(/@page\s+([\w-]+)\s*\{([^}]*)\}/g)) {
+    const size = /size:\s*([^;]+);/.exec(match[2]);
+    if (size) pageRules.set(match[1], size[1].trim());
+  }
+
+  it('declares one @page rule per sheet size and no others', () => {
+    expect([...pageRules.keys()].sort()).toEqual([...SHEET_SIZE_KEYS].sort());
+  });
+
+  it('gives every @page rule the size its SHEET_SIZES entry names', () => {
+    for (const key of SHEET_SIZE_KEYS) {
+      expect(pageRules.get(key)).toBe(SHEET_SIZES[key].pageSize);
+    }
+  });
+
+  it('zeroes the margin on every @page rule', () => {
+    // A default 0.5 in margin pushes a seventh partial sticker row onto a
+    // second sheet.
+    for (const match of PRINT_CSS.matchAll(/@page\s+[\w-]+\s*\{([^}]*)\}/g)) {
+      expect(match[1]).toMatch(/margin:\s*0\s*;/);
+    }
+  });
+
+  it('opts each size into its own named page', () => {
+    for (const key of SHEET_SIZE_KEYS) {
+      expect(PRINT_CSS).toContain(`#review-print-root[data-size='${key}']`);
+    }
+  });
+
+  it('needs the review-print-active class before it hides the app', () => {
+    // The stylesheet loads with the Reviews route and never unloads. Without
+    // the class the hide rule stays live for the session and every other page
+    // in the app prints blank. tests/e2e/review-qr-print.spec.ts holds the
+    // runtime half of this.
+    expect(PRINT_CSS).toContain('body.review-print-active > *:not(#review-print-root)');
+    expect(PRINT_CSS).not.toMatch(/(?<!\.review-print-active)\s*body\s*>\s*\*:not\(/);
+  });
+});
+
+describe('QR module size on the smallest sheet', () => {
+  /** The slug pattern allows 48 characters. Pin that, then build on it. */
+  const MAX_SLUG_LENGTH = 48;
+
+  it('caps the slug at 48 characters', () => {
+    expect(SLUG_PATTERN.test('a'.repeat(MAX_SLUG_LENGTH))).toBe(true);
+    expect(SLUG_PATTERN.test('a'.repeat(MAX_SLUG_LENGTH + 1))).toBe(false);
+  });
+
+  it('keeps every module at least 0.5 mm wide for the longest URL', async () => {
+    // A longer URL needs a higher QR version, which puts more modules in the
+    // same printed square. A phone camera loses a module below about 0.4 mm.
+    const QRCode = await import('qrcode');
+    const worstCaseUrl = `https://app.easyshifthq.com/r/${'a'.repeat(MAX_SLUG_LENGTH)}`;
+    const svg = await QRCode.toString(worstCaseUrl, {
+      margin: 4,
+      type: 'svg',
+      errorCorrectionLevel: 'M',
+    });
+
+    const viewBox = /viewBox="0 0 (\d+) \1"/.exec(svg);
+    expect(viewBox).not.toBeNull();
+    const modulesAcross = Number(viewBox![1]);
+
+    for (const key of SHEET_SIZE_KEYS) {
+      const mmPerModule = (SHEET_SIZES[key].qrIn * 25.4) / modulesAcross;
+      expect(mmPerModule).toBeGreaterThanOrEqual(0.5);
+    }
   });
 });

--- a/tests/unit/reviewBranding.test.ts
+++ b/tests/unit/reviewBranding.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    storage: {
+      from: (bucket: string) => ({
+        getPublicUrl: (path: string) => ({
+          data: { publicUrl: `https://stub.supabase.co/storage/v1/object/public/${bucket}/${path}` },
+        }),
+      }),
+    },
+  },
+}));
+
+import { initials, logoPublicUrl } from '@/lib/reviews/reviewBranding';
+
+describe('initials', () => {
+  it('takes the first letter of the first two words', () => {
+    expect(initials('Blue Fin Sushi')).toBe('BF');
+  });
+
+  it('takes one letter from a single word', () => {
+    expect(initials('Nobu')).toBe('N');
+  });
+
+  it('returns an empty string for an empty name', () => {
+    expect(initials('')).toBe('');
+  });
+
+  it('returns an empty string for whitespace only', () => {
+    expect(initials('   ')).toBe('');
+  });
+
+  it('uppercases accented letters', () => {
+    expect(initials('Café Ñoño')).toBe('CÑ');
+  });
+
+  it('collapses runs of whitespace', () => {
+    expect(initials('  The   Grill  ')).toBe('TG');
+  });
+});
+
+describe('logoPublicUrl', () => {
+  it('returns null for a null path', () => {
+    expect(logoPublicUrl(null)).toBeNull();
+  });
+
+  it('returns null for an empty path', () => {
+    expect(logoPublicUrl('')).toBeNull();
+  });
+
+  it('builds a public URL from the review-page-logos bucket', () => {
+    expect(logoPublicUrl('rest-1/page-2/abc.png')).toBe(
+      'https://stub.supabase.co/storage/v1/object/public/review-page-logos/rest-1/page-2/abc.png'
+    );
+  });
+});


### PR DESCRIPTION
## What

A restaurant can now print the review QR code on paper and put it next to the
POS. The QR dialog on the Reviews page gains a paper size, a message field, a
live preview, and a Print button.

Three sizes ship:

| Size | Paper | Use |
|---|---|---|
| Table tent | 4 × 6 in | Fold it, stand it on a table |
| Counter card | 5.5 × 8.5 in | Prop it next to the POS |
| Sticker sheet | 8.5 × 11 in, 6 up | Cut them, stick them on check presenters |

The sheet carries the restaurant logo, the restaurant name, a message, the QR
code, and the plain URL under it. It uses the Counter theme, the same look the
public review page already has. The message is one-off: it seeds from the saved
headline, and it does not change the page.

## How

- `src/lib/reviews/printSheet.ts` — `SHEET_SIZES` is the single source of truth
  for every paper dimension. `waitForPrintReady` waits for the fonts and the
  images, with a 4 s budget so a stalled font never kills the Print button.
- `src/components/reviews/ReviewTentSheet.tsx` — the sheet. One props object
  drives both the preview and the paper, so the two cannot drift.
- `src/components/reviews/BrandMark.tsx` — the logo, or a circle of initials.
  The guest page and the sheet now share it. The guest page gains the
  `onError` fallback it did not have.
- `src/hooks/useReviewQrSheet.ts` — the QR encode and the print orchestration.
- `src/styles/print-sheet.css` — named `@page` rules, one per size.

The `qrcode` encoder loads with a dynamic import. The build puts it in its own
24 KB async chunk, out of the main bundle.

## Print correctness

The print copy hangs off `document.body` through a portal, not off
`DialogContent`. `DialogContent` is `fixed` with `max-h-[85vh]` and
`overflow-y-auto`, and a clipped, transformed, fixed ancestor prints the visible
scroll window only. WebKit often prints nothing at all.

The rule that hides the app during a print needs `body.review-print-active`.
`ReviewQrDialog` adds that class only while the print portal is mounted.
`print-sheet.css` loads with the Reviews route and never unloads, so a plain
`body > *` selector would stay live for the whole session. A manager who opened
this dialog once would then print a blank page from payroll or P&L.

## Tests

- `tests/unit/printSheet.test.ts` (20) — the sizes, the ready budget, and the
  stylesheet parsed and checked against `SHEET_SIZES`. Also pins the QR module
  size at 0.5 mm for the longest slug the pattern allows.
- `tests/unit/ReviewTentSheet.test.tsx` (10) — the tiles, the fallbacks, the
  six-tile flag.
- `tests/unit/ReviewQrDialog.print.test.tsx` (15) — the print path, the a11y
  names, the live region.
- `tests/e2e/review-qr-print.spec.ts` — an owner prints the tent, then closes
  the dialog and prints again to hold the CSS scope.

Every guard added in review carries a test that fails without it. Each one was
mutation-checked: break the guard, and exactly one test fails.

Full unit suite: 9035 pass. Build: OK. Lint: clean on every file this branch
touches.

## Review

Five Claude reviewers, then the CodeRabbit CLI for two iterations. The most
serious defect was the print CSS scope above. Findings that asked to move the
sheet geometry out of `SHEET_SIZES` and into CSS were rejected: CSS cannot read
the object, and a second copy of every dimension adds the drift the tests exist
to prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)