### PR TITLE
docs(security): account-creation audit and remediation plan

### DIFF
--- a/docs/SECURITY_AUDIT_ACCOUNT_CREATION_2026-08.md
+++ b/docs/SECURITY_AUDIT_ACCOUNT_CREATION_2026-08.md
@@ -1,0 +1,433 @@
+# Security Audit — User Account Creation (August 2026)
+
+**Scope:** self-service registration, the identity layer, tenant bootstrap, and
+every path a new account reaches.
+**Target:** production project `ncdujvdgqtaunuyigflp`.
+**Date:** 2026-08-07.
+**Method:** 4 parallel finders over the codebase, then 10 parallel adversarial
+verifiers. Every finding below survived a live production check or a
+line-by-line re-read. Findings that failed verification are in
+[Refuted](#refuted--do-not-re-investigate).
+
+**Remediation plan:** `docs/plans/2026-08-08-account-creation-security-plan.md`
+**Dashboard work:** `docs/SUPABASE_AUTH_HARDENING_CHECKLIST.md`
+
+---
+
+## Trigger for this audit
+
+The user saw a live card-testing attack at another company. Bots made thousands
+of accounts and used the product as a free card-validation oracle. The user
+asked four questions. Here are the measured answers.
+
+| Question | Verified answer |
+|---|---|
+| Can bots make thousands of accounts? | **Yes.** No CAPTCHA, no invite gate, no bot defense. |
+| Can they authorize many cards without a purchase? | **No.** This codebase has no card-tokenizing endpoint. See [Refuted](#refuted--do-not-re-investigate). |
+| Is there IP throttling? | **No** application-layer throttle exists. |
+| Is there email validation? | **No.** Auto-confirm is ON in production. |
+
+### Measured production state, 2026-08-07
+
+Of 72 real (non-`test.com`) email signups, 71 show `email_confirmed_at` set.
+Only **3** ever had a confirmation email queued. 53 confirmed within 2 seconds
+of `created_at`. A human cannot open an inbox in 2 seconds.
+**Email verification does not gate account creation today.**
+
+Other measurements:
+
+- 154 of 280 accounts use `test.com` (RFC 2606 reserved, non-deliverable), all
+  unconfirmed. They account for every signup burst window found. This looks
+  like the E2E suite. Confirm before you delete them.
+- 169 of 280 accounts (60%) never joined a restaurant.
+- 226 accounts use the `email` provider. 54 use `google`.
+- One user owns 19 restaurants. One owns 15. This is **legitimate** —
+  `stripe-subscription-checkout/index.ts:168-176` has a volume-discount ladder
+  at 3, 6, and 11+ locations.
+
+---
+
+## Findings
+
+| # | Severity | Title | Location | Confidence |
+|---|---|---|---|---|
+| 1 | CRITICAL | Any user can self-grant `owner` on any restaurant | `user_restaurants` RLS | 10/10 |
+| 2 | HIGH | An owner can self-upgrade their subscription tier | `restaurants` RLS | 9/10 |
+| 3 | HIGH | Unauthenticated cross-tenant POS hijack (Square) | `square-oauth` | 9/10 |
+| 4 | HIGH | Unauthenticated cross-tenant POS hijack (Clover) | `clover-oauth` | 9/10 |
+| 5 | HIGH | Auth bypass on a missing header | `shift4-sync-data` | 9/10 |
+| 6 | HIGH | Raw invitation token in the logs | `validate-invitation` | 9/10 |
+| 7 | HIGH | No email verification, no bot defense | `Auth.tsx` / Auth settings | 9/10 |
+| 8 | MEDIUM | `get_users_by_ids` returns any email to `anon` | RPC grant | 8/10 |
+| 9 | MEDIUM | Unbounded tenant and trial creation | `create_restaurant_with_owner` | 9/10 |
+| 10 | MEDIUM | Cross-tenant notification trigger (IDOR) | 2 edge functions | 8/10 |
+| 11 | MEDIUM | AI-cost functions have no subscription check | 10 edge functions | 8/10 |
+| 12 | LOW | No password policy at signup | `Auth.tsx` | 8/10 |
+
+---
+
+### Vuln 1 — CRITICAL — Any user can self-grant `owner` on any restaurant
+
+**Location:** `supabase/migrations/20250915210020_774bc2c1-abb6-4f03-b10f-5cfc85e9b772.sql:61-64`
+**Category:** `rls_privilege_escalation`
+
+`public.user_restaurants` has two permissive INSERT policies. Their effective OR
+reduces to `with_check: (user_id = auth.uid())`. Neither checks `role` or
+`restaurant_id`. The RESTRICTIVE guard `"Prevent self-escalation to privileged
+roles"` has `cmd = 'UPDATE'`, so it never applies to INSERT.
+
+Live production evidence:
+
+```
+policyname: "Owners can manage restaurant associations"
+  permissive: PERMISSIVE  cmd: ALL
+  with_check: ((user_id = auth.uid()) OR is_restaurant_owner(restaurant_id, auth.uid()))
+policyname: "Users can insert their own restaurant associations"
+  permissive: PERMISSIVE  cmd: INSERT
+  with_check: (user_id = auth.uid())
+policyname: "Prevent self-escalation to privileged roles"
+  permissive: RESTRICTIVE  cmd: UPDATE      <-- UPDATE only
+  with_check: (is_restaurant_owner(restaurant_id, auth.uid())
+               OR ((role = ANY (ARRAY['staff','kiosk']))
+                   AND ((role_id IS NULL) OR (role_id = builtin_role_id_for(role)))))
+```
+
+`pg_trigger` shows one trigger, `user_restaurants_sync_role_id`, `BEFORE UPDATE`
+only. `has_table_privilege('authenticated','public.user_restaurants','INSERT')`
+returns `true`.
+
+**Exploit:** Any signed-up user runs this through PostgREST.
+
+```sql
+INSERT INTO user_restaurants (user_id, restaurant_id, role)
+VALUES (auth.uid(), '<victim restaurant_id>', 'owner');
+```
+
+The forged row satisfies `is_restaurant_owner()`. **113 policy definitions**
+across the migration history depend on that function. The attacker gains owner
+access to the victim's P&L, payroll, bank connections, and inventory. They then
+pass the `FOR ALL` policy on `user_restaurants` and can delete the real owner's
+membership row.
+
+**Known:** `supabase/migrations/20260730180000_close_role_id_self_escalation.sql:37-40`
+documents this exact gap and says the team deferred it. It is still open.
+
+---
+
+### Vuln 2 — HIGH — An owner can self-upgrade their subscription tier
+
+**Location:** `supabase/migrations/20250916223011_7793a7c0-1807-4a7e-b125-c458b98bd032.sql:56-65`
+**Category:** `broken_access_control`
+
+The policy `"Owners and managers can update their restaurants"` is `FOR UPDATE`
+with `with_check: null`. Postgres then reuses `USING` for the new row. `USING`
+tests only membership and role, keyed on `restaurants.id`, which an UPDATE never
+changes. So the policy validates *who* writes, never *which columns*.
+
+`public.restaurants` holds `subscription_tier`, `subscription_status`,
+`subscription_period`, `subscription_ends_at`, `subscription_cancel_at`,
+`trial_ends_at`, `stripe_customer_id`, `stripe_subscription_id`,
+`stripe_subscription_customer_id`.
+
+The only trigger is `update_restaurants_updated_at`, a timestamp stamper.
+
+**Exploit:** Every self-serve signup becomes owner of its own restaurant.
+
+```js
+supabase.from('restaurants')
+  .update({ subscription_tier: 'pro', subscription_status: 'active' })
+  .eq('id', restaurantId)
+```
+
+The live definition of `has_subscription_feature()` reads these columns
+directly. The write unlocks `ai_assistant`, `ops_inbox`, `weekly_brief`,
+`financial_intelligence`, `inventory_automation`, `scheduling`, and
+`multi_location_dashboard`.
+
+For any restaurant with `stripe_subscription_id IS NULL`, no webhook ever
+reconciles it. The free upgrade persists forever.
+
+---
+
+### Vuln 3 — HIGH — Unauthenticated cross-tenant POS hijack (Square)
+
+**Location:** `supabase/functions/square-oauth/index.ts:34-47, 162, 288-294`
+**Category:** `broken_authz`
+
+`verify_jwt = false` (`supabase/config.toml:61-62`). The handler calls
+`supabase.auth.getUser(token)` only when `action === 'authorize'`. The
+`callback` branch has no guard.
+
+Line 162 reads `const restaurantId = state`. `state` is the raw restaurant id,
+not a server-issued nonce. No pending-state table exists in any migration.
+Line 288 upserts `square_connections` with the service-role client, which
+bypasses RLS.
+
+**Exploit:** An attacker with no EasyShiftHQ account completes Square consent
+with their own merchant account. They POST straight to the function URL.
+
+```json
+{"action":"callback","code":"<their code>","state":"<victim restaurant_id>"}
+```
+
+Lines 362-364 then fire `square-sync-data` with `action: initial_sync`. The
+attacker's sales data flows into the victim's `unified_sales` table and P&L. The
+rogue connection stays in the sync rotation.
+
+This is integrity poison, not data theft. The victim's real connection survives,
+because the unique key is `(restaurant_id, merchant_id)`.
+
+---
+
+### Vuln 4 — HIGH — Unauthenticated cross-tenant POS hijack (Clover)
+
+**Location:** `supabase/functions/clover-oauth/index.ts:34-45, 195-196, 343-349`
+**Category:** `broken_authz`
+
+Identical pattern to Vuln 3. `verify_jwt = false`
+(`supabase/config.toml:103-104`). Auth runs only on `authorize`. Line 195 does
+`JSON.parse(state).restaurantId` on attacker-supplied JSON. Line 343 upserts
+`clover_connections` with the service role.
+
+**Worse than Vuln 3:** lines 378-397 auto-register a Clover webhook for the
+victim restaurant. That gives the attacker a persistent push channel into the
+victim's data pipeline, not one sync.
+
+---
+
+### Vuln 5 — HIGH — Auth bypass on a missing header
+
+**Location:** `supabase/functions/shift4-sync-data/index.ts:102-107, 222`
+**Category:** `broken_authz`
+
+`verify_jwt = false` (`supabase/config.toml:160-161`). `authenticateUser()`
+opens with `if (!authHeader) return null;` instead of a throw. The
+`user_restaurants` role check lives **inside** that function, after the early
+return. Line 222 stores the result as `userId` and never checks it. `userId`
+feeds optional logging only.
+
+Sibling functions get this right:
+
+- `supabase/functions/toast-sync-data/index.ts:371-374`
+- `supabase/functions/sling-sync-data/index.ts:259-262`
+
+Both return 401 on a missing header.
+
+**Exploit:** An anonymous caller POSTs with no `Authorization` header.
+
+```json
+{"restaurantId":"<uuid>","action":"initial_sync"}
+```
+
+The function decrypts that restaurant's stored Shift4 credentials server-side,
+calls the real Shift4 API, and writes sales rows and sync state. The response
+returns counts only. This is an unauthorized privileged action, not
+exfiltration. The practical attacker population is anyone who ever held an
+account at that restaurant, because they know the UUID.
+
+---
+
+### Vuln 6 — HIGH — Raw invitation token in the logs
+
+**Location:** `supabase/functions/validate-invitation/index.ts:32`
+**Category:** `secret_in_logs`
+
+```ts
+console.log('Plain token from URL:', token);
+```
+
+This prints the unhashed 32-byte invitation token. The database stores only its
+SHA-256 hash. The plaintext should exist only in the outbound email. Line 77
+also logs the plaintext email.
+
+**Exploit:** The token is the only secret that gates `signup-with-invitation`.
+That function calls `admin.updateUserById(existingUser.id, { password, ... })`
+at `supabase/functions/signup-with-invitation/index.ts:72-82`. It overwrites the
+password of an **existing** account.
+
+Verification found no single-use marker. `signup-with-invitation` never writes
+`invitations.status`. Only `accept-invitation/index.ts:174-183` does, and the
+frontend calls it after a separate manual sign-in. So the token stays `pending`
+and replayable for up to its full 7-day life.
+
+Anyone with log or log-drain access reads the token and the email, then takes
+over that account.
+
+**Scope:** Exploitation needs log access. This is an insider or lateral-movement
+finding, not remote. A grep of all other edge functions found no further
+plaintext-secret logs. Everything else logs a boolean, a length, or a truncated
+prefix.
+
+---
+
+### Vuln 7 — HIGH — No email verification, no bot defense
+
+**Location:** `src/pages/Auth.tsx:131-158` → `src/hooks/useAuth.tsx:170-194`
+**Category:** `authn_bot_defense_missing`
+
+`signUp` calls `supabase.auth.signUp` directly from the public form. A
+repo-wide grep for `captcha`, `turnstile`, `hcaptcha`, `recaptcha` returns zero
+hits. No disposable-email blocklist. No email normalization. No invite gate.
+
+Production auto-confirm is ON. See [Measured production state](#measured-production-state-2026-08-07).
+
+The client never reads `email_confirmed_at`. `handleAuthStateChange`
+(`src/hooks/useAuth.tsx:51-62`) treats any session as fully logged in.
+
+**Exploit:** A script drives `supabase.auth.signUp` for thousands of throwaway
+addresses, optionally `+`-aliased against one mailbox. Each account is instantly
+confirmed. It can then call `create_restaurant_with_owner` (Vuln 9) and reach
+every ungated AI endpoint (Vuln 11).
+
+---
+
+### Vuln 8 — MEDIUM — `get_users_by_ids` returns any email to `anon`
+
+**Location:** `supabase/migrations/20260104000001_add_get_users_by_ids_function.sql:1-25`
+**Category:** `broken_authz_rpc`
+
+The function is `SECURITY DEFINER`. It selects `id, email,
+raw_user_meta_data->>'full_name'` from `auth.users` for arbitrary
+caller-supplied UUIDs. It has no `auth.uid()` check and no membership check. The
+migration grants EXECUTE to `authenticated` but never revokes the default
+`PUBLIC` grant.
+
+Live check: `has_function_privilege('anon', ...)` returns `true`. A control
+comparison against `assign_membership_role`, which does revoke, returns `false`.
+This proves the grant state is real. `public` is API-exposed
+(`supabase/config.toml:7`), so it is callable as
+`POST /rest/v1/rpc/get_users_by_ids`.
+
+**Exploit:** The realistic path is authenticated, not anonymous. Verification
+found no anon-reachable source of a valid `auth.users.id`. `profiles` has an
+explicit `"Deny anonymous access to profiles"` policy. But any low-privilege
+authenticated user who picks up a teammate UUID from normal in-app data can
+replay it. The function has no restaurant scope, so it returns emails for users
+**outside** their tenant.
+
+---
+
+### Vuln 9 — MEDIUM — Unbounded tenant and trial creation
+
+**Location:** `supabase/migrations/20260129000000_add_subscription_system.sql:367-420`
+**Category:** `missing_authz_limit`
+
+`create_restaurant_with_owner` is `SECURITY DEFINER`, callable by
+`authenticated`. It has no cap, no cooldown, and no email-confirmation check.
+Each call writes a `restaurants` row with `subscription_tier = 'growth'`,
+`subscription_status = 'trialing'`, and a 14-day trial. It then grants the
+caller `owner`.
+
+The only guard is `pg_advisory_xact_lock` for a 5-second same-name dedup. A
+counter appended to the name defeats it. The client-side `canCreateRestaurant`
+flag in `src/contexts/RestaurantContext.tsx:96` does not constrain the RPC.
+
+**Warning: do not set a low cap.** Live data shows users who own 19 and 15
+restaurants. That is legitimate multi-unit use.
+
+---
+
+### Vuln 10 — MEDIUM — Cross-tenant notification trigger (IDOR)
+
+**Location:** `supabase/functions/send-time-off-notification/index.ts` and
+`supabase/functions/send-shift-notification/index.ts:229-241`
+**Category:** `idor`
+
+Both use a service-role client, which bypasses RLS.
+
+`send-time-off-notification` has no auth check at all. A grep for
+`getUser|user_restaurants|authHeader|role` returns one hit, and it is an
+**outbound** header at line 293.
+
+`send-shift-notification` does require a JWT (lines 107-120). But the
+`created`/`modified` path at lines 229-241 fetches the shift by `shiftId` alone.
+Its own sibling branch at lines 136-149 has the ownership check, with a comment
+that explains it closes this exact bug class. The fix never reached the primary
+path.
+
+**Impact limits, stated honestly:** No victim data returns to the attacker. The
+responses carry only `{ success, recipients: <count> }` and
+`{ message, emailId }`. Both ids are `gen_random_uuid()` primary keys, so the
+attacker must already know the id. This is a cross-tenant action trigger, not
+exfiltration.
+
+---
+
+### Vuln 11 — MEDIUM — AI-cost functions have no subscription check
+
+**Locations:** `supabase/functions/` — `process-receipt`, `enhanced-ocr`,
+`grok-ocr`, `ai-categorize-pos-sales`, `ai-categorize-transactions`,
+`enhance-product-ai`, `grok-recipe-enhance`, `process-expense-invoice`,
+`process-bank-statement`, `process-asset-document`
+**Category:** `missing_authz_spend`
+
+Only `generate-weekly-brief-worker/index.ts:79` calls
+`has_subscription_feature()`. Every other AI function listed calls OpenRouter or
+Grok with no tier check.
+
+`ai-chat-stream` checks `user_restaurants.role` but never calls
+`has_subscription_feature` server-side. The Pro gate lives only in
+`src/components/ai-chat/AiChatPanel.tsx:41`, which is client-side and
+bypassable.
+
+**Exploit:** Any authenticated member of any restaurant, on any tier, calls
+these functions directly and spends the OpenRouter budget. Combined with Vuln 7,
+a bot fleet reaches them with no payment and no email proof.
+
+**This is the real dollar-cost exposure** — more so than the Stripe path.
+
+**Correction to the first report:** A growth trial does **not** unlock the AI
+features. `ai_assistant`, `ops_inbox`, and `weekly_brief` require `pro` exactly.
+The exposure is that these endpoints have no gate at all.
+
+---
+
+### Vuln 12 — LOW — No password policy at signup
+
+**Location:** `src/pages/Auth.tsx:323-331`
+**Category:** `weak_password_policy`
+
+The signup password field has no `minLength`, no regex, and no zod schema. It
+has only `required`. Compare `src/pages/ResetPassword.tsx:13-17`, which requires
+8+ characters with mixed case and a digit.
+
+The Supabase security advisor also reports **Leaked Password Protection
+Disabled**, so breached passwords are accepted.
+
+---
+
+## Refuted — do not re-investigate
+
+| Claim | Verdict | Why |
+|---|---|---|
+| **This app is a card-testing oracle** | **REFUTED (9/10)** | A grep for `SetupIntent`, `PaymentIntent`, `paymentMethods.attach`, `confirmCardSetup`, `confirmCardPayment`, `CardElement`, `PaymentElement`, `createPaymentMethod`, `tokens.create` returns **zero matches**. All card entry happens on Stripe-hosted Checkout, behind Stripe Radar. There is no `$0` authorization path. The backend never sees a card number and never returns a live/dead signal. |
+| Stripe webhooks are forgeable | REFUTED | All three verify the signature with `constructEventAsync` before they trust the body: `stripe-subscription-webhook/index.ts:49`, `stripe-invoice-webhook/index.ts:39`, `stripe-financial-connections-webhook/index.ts:41`. The `test_local` bypass is gated on a deployment-controlled env check. |
+| `toast-oauth` callback hijack | REFUTED (7/10) | Same code pattern as Vulns 3-4. But `verify_jwt` defaults to `true`, and the callback writes columns the January 2026 Standard-API migration deleted (`20260106120000_toast_standard_api_migration.sql:6-44`). The write fails. Delete it as dead code. |
+| `square-webhooks` fail-open signature | REFUTED (7/10) | The fail-open control flow is real (`index.ts:31, 77-80`). But every handler re-fetches from Square's live API with the tenant's own OAuth token before a write (`index.ts:239, 427, 467`). No field from a forged body reaches the database. |
+| `revel-bulk-sync` anonymous trigger | REFUTED (7/10) | Reduces to a forced sync (excluded as resource use) plus a boolean connection-exists oracle, gated behind an unguessable UUID with no leak path. |
+| Invitation flows allow tenant escalation | REFUTED | `accept-invitation/index.ts:104-106` hard-checks `user.email !== invitation.email` and re-derives `role` server-side. `signup-with-invitation` matches token and email together. Tokens are 256-bit and hashed at rest. |
+| Signup trigger reads attacker metadata | REFUTED | `handle_new_user()` (`20250915204511_...sql:49-60`) is `SECURITY DEFINER` with `search_path` pinned. It reads only `full_name` from `raw_user_meta_data`. It writes no role and no tenant. **Use this function as the template for new RPCs.** |
+
+---
+
+## Systemic findings from the Supabase advisor feed
+
+The advisor returned 382 security lints. **No ERROR-level items exist.** All are
+WARN or INFO.
+
+| Item | Count | Link |
+|---|---|---|
+| Public can execute SECURITY DEFINER function (`anon`) | 146 | [lint 0028](https://supabase.com/docs/guides/database/database-linter?lint=0028_anon_security_definer_function_executable) |
+| Signed-in users can execute SECURITY DEFINER function | 153 | [lint 0029](https://supabase.com/docs/guides/database/database-linter?lint=0029_authenticated_security_definer_function_executable) |
+| Function search path mutable | 73 | [lint 0011](https://supabase.com/docs/guides/database/database-linter?lint=0011_function_search_path_mutable) |
+| Extension in public | 4 | [lint 0014](https://supabase.com/docs/guides/database/database-linter?lint=0014_extension_in_public) |
+| RLS enabled, no policy | 5 | [lint 0008](https://supabase.com/docs/guides/database/database-linter?lint=0008_rls_enabled_no_policy) |
+| Leaked password protection disabled | 1 | [password security](https://supabase.com/docs/guides/auth/password-security#password-strength-and-leaked-password-protection) |
+
+Most of the 146 `anon`-executable functions self-gate on `auth.uid()`, so they
+are not exploitable today. That safety relies on every author who remembers.
+`supabase/migrations/20260507120200_users_in_trial_email_window_rpc.sql:96-97`
+shows the correct pattern.
+
+**Also noted:** `profiles.role` is self-updatable and vestigial. No policy and
+no function reads it. Delete it before a future feature trusts it.

--- a/docs/SUPABASE_AUTH_HARDENING_CHECKLIST.md
+++ b/docs/SUPABASE_AUTH_HARDENING_CHECKLIST.md
@@ -55,12 +55,27 @@ hCaptcha.
 **Why:** A repo-wide grep for `captcha`, `turnstile`, `hcaptcha`, `recaptcha`
 returns zero hits. Nothing stands between a script and `supabase.auth.signUp`.
 
+**Warning: this step has two halves, and they are weeks apart.** The switch
+makes Supabase reject any `signUp` or `signInWithPassword` that carries no
+`captchaToken`. Three call sites send no token today:
+`src/hooks/useAuth.tsx:125`, `src/hooks/useAuth.tsx:177`, and
+`src/pages/AcceptInvitation.tsx:163-166`. Switch on enforcement before Task 8
+deploys, and every password sign-up and sign-in fails in production.
+
+### B2a — Provision. Do this at any time.
+
 - [ ] Create a Turnstile site at `dash.cloudflare.com` → Turnstile.
-- [ ] Paste the **secret key** into the Supabase dashboard.
 - [ ] Give the **site key** to the code session doing Task 8. It is public and
       safe to commit.
 - [ ] Create a second Turnstile site in **"Always passes"** test mode. Give that
       secret to the E2E environment so tests keep working.
+
+### B2b — Enforce. Do this only after Task 8 is live in production.
+
+- [ ] Confirm Task 8 is deployed, and that a real sign-up works.
+- [ ] Paste the **secret key** into the Supabase dashboard.
+- [ ] Switch on **Enable CAPTCHA protection**.
+- [ ] Test a sign-up, a sign-in, and an invitation sign-in right away.
 
 ---
 
@@ -141,7 +156,8 @@ almost certainly the project's own E2E suite hitting production.
 | Step | Effort | Blocks | Blocked by |
 |---|---|---|---|
 | B1 Confirm email | 15 min | Task 8, Task 10 step 3 | Task 8 step 4 (E2E fix) |
-| B2 CAPTCHA | 20 min | Task 8 | — |
+| B2a CAPTCHA provision | 15 min | Task 8 | — |
+| B2b CAPTCHA enforce | 5 min | — | **Task 8 deployed** |
 | B3 Leaked passwords | 2 min | — | — |
 | B4 Rate limits | 10 min | — | — |
 | B5 Cloudflare | 1-2 h | — | B1-B4 |

--- a/docs/SUPABASE_AUTH_HARDENING_CHECKLIST.md
+++ b/docs/SUPABASE_AUTH_HARDENING_CHECKLIST.md
@@ -1,0 +1,151 @@
+# Supabase Auth Hardening Checklist (Track B)
+
+**Owner:** Jose. Do these in the Supabase dashboard. No agent can do them.
+**Project:** `ncdujvdgqtaunuyigflp` (production).
+**Source:** `docs/SECURITY_AUDIT_ACCOUNT_CREATION_2026-08.md`
+**Code side:** `docs/plans/2026-08-07-account-creation-security-plan.md`
+
+These settings are **not** in `supabase/config.toml`. The `[auth]` block at
+`supabase/config.toml:11-15` has no `[auth.email]` sub-section, so the hosted
+dashboard is the only control.
+
+---
+
+## Warning: read this before step B1
+
+**Step B1 breaks the E2E suite.** 154 of 280 production accounts use `test.com`
+addresses and are unconfirmed. Every signup test creates one. Confirm email
+will block them all.
+
+**Do Task 8 step 4 of the code plan first, or on the same day.** That step
+changes `generateTestUser()` to create users through the admin API with
+`email_confirm: true`.
+
+---
+
+## B1 — Turn on Confirm email
+
+**Path:** Authentication → Providers → Email → **Confirm email** → ON.
+
+**Why:** Auto-confirm is ON today. Measured on 2026-08-07: 71 of 72 real-domain
+accounts show `email_confirmed_at` set, but only **3** ever had a confirmation
+email queued. 53 confirmed within 2 seconds of `created_at`. No human opens an
+inbox in 2 seconds. Email verification does not gate anything right now.
+
+**This is the single highest-value change in the whole audit.** It ends
+disposable-address account farming.
+
+- [ ] Check the email template first: Authentication → Email Templates → Confirm
+      signup. Confirm the redirect URL matches `site_url`.
+- [ ] Check your SMTP sender. The default Supabase sender has a low hourly cap
+      and will silently throttle real signups. Set a custom SMTP provider if you
+      have not.
+- [ ] Turn on Confirm email.
+- [ ] Register one real test account and confirm the email arrives.
+
+---
+
+## B2 — Turn on CAPTCHA
+
+**Path:** Authentication → Settings → **Enable CAPTCHA protection**.
+
+**Provider:** Cloudflare Turnstile (recommended — free, no user puzzle) or
+hCaptcha.
+
+**Why:** A repo-wide grep for `captcha`, `turnstile`, `hcaptcha`, `recaptcha`
+returns zero hits. Nothing stands between a script and `supabase.auth.signUp`.
+
+- [ ] Create a Turnstile site at `dash.cloudflare.com` → Turnstile.
+- [ ] Paste the **secret key** into the Supabase dashboard.
+- [ ] Give the **site key** to the code session doing Task 8. It is public and
+      safe to commit.
+- [ ] Create a second Turnstile site in **"Always passes"** test mode. Give that
+      secret to the E2E environment so tests keep working.
+
+---
+
+## B3 — Turn on Leaked Password Protection
+
+**Path:** Authentication → Settings → **Leaked password protection** → ON.
+
+**Why:** The Supabase security advisor flags this as disabled. Breached
+passwords are accepted today. This checks new passwords against HaveIBeenPwned
+with a k-anonymity hash prefix. No password leaves the service.
+
+- [ ] Turn it on.
+- [ ] Set **Minimum password length** to 8, to match
+      `src/pages/ResetPassword.tsx:13-17`.
+- [ ] Set required character types to lower + upper + digit, to match the same
+      file.
+
+This makes the code change in Task 8 a defense-in-depth duplicate rather than
+the only control. Do both.
+
+---
+
+## B4 — Lower the auth rate limits
+
+**Path:** Authentication → Rate Limits.
+
+**Why:** There is no application-layer throttle anywhere in the codebase. The
+dashboard limits are the only throttle that exists today.
+
+- [ ] **Sign ups / sign ins:** lower from the default. A real restaurant
+      operator signs up once. 30 per hour per IP is generous.
+- [ ] **Email sends:** set this to match your SMTP provider's real cap, or
+      confirmation emails will drop silently.
+- [ ] **Token refresh:** leave at the default. A low value logs out real users.
+- [ ] **Anonymous sign-ins:** set to 0 if you do not use them. Grep found no
+      `signInAnonymously` caller.
+
+Note the limits are **per IP**. A distributed bot fleet defeats them. They raise
+the cost; they do not stop a determined attacker. B1 and B2 do the real work.
+
+---
+
+## B5 — Consider Cloudflare in front
+
+Optional. Do it only after B1-B4.
+
+**Why:** Supabase's own rate limits are per IP and cannot see a pattern across
+IPs. Cloudflare adds bot scoring and a managed challenge.
+
+- [ ] Put the app domain behind Cloudflare.
+- [ ] Add a WAF rate-limit rule on the auth paths.
+- [ ] Turn on Bot Fight Mode.
+
+---
+
+## B6 — Clean up the test accounts
+
+**Do this last, and confirm the cause first.**
+
+154 of 280 accounts use `test.com` (RFC 2606 reserved, non-deliverable). All are
+unconfirmed. They account for every signup burst window in the data. This is
+almost certainly the project's own E2E suite hitting production.
+
+- [ ] **First, answer this:** does the E2E suite point at production? Check the
+      CI environment variables. If it does, point it at a branch database or a
+      separate project. **Do this before any deletion**, or the accounts come
+      straight back.
+- [ ] Only then delete the `test.com` accounts. Ask a Claude Code session to
+      write and review the delete statement. Production writes need your
+      explicit approval with exact row counts.
+- [ ] 169 of 280 accounts (60%) never joined a restaurant. Do **not** bulk-delete
+      those. Some are real people who signed up and stalled.
+
+---
+
+## Order and effort
+
+| Step | Effort | Blocks | Blocked by |
+|---|---|---|---|
+| B1 Confirm email | 15 min | Task 8, Task 10 step 3 | Task 8 step 4 (E2E fix) |
+| B2 CAPTCHA | 20 min | Task 8 | — |
+| B3 Leaked passwords | 2 min | — | — |
+| B4 Rate limits | 10 min | — | — |
+| B5 Cloudflare | 1-2 h | — | B1-B4 |
+| B6 Test cleanup | 30 min | — | CI environment fix |
+
+**Do B3 and B4 right now.** They take 12 minutes, break nothing, and need no
+code change.

--- a/docs/plans/2026-08-07-account-creation-security-plan.md
+++ b/docs/plans/2026-08-07-account-creation-security-plan.md
@@ -1,0 +1,413 @@
+# Account Creation Security Remediation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Each task below is one session and one PR.** Do not batch tasks. Start
+> every session with the `development-workflow` skill (`/dev`).
+> Read the evidence for a task in the audit before you write code.
+
+**Goal:** Close the 12 confirmed findings from the August 2026 account-creation
+security audit.
+**Architecture:** Fix each hole at the layer that owns it. RLS holes get a
+migration and a pgTAP test. Edge-function holes get a server-side check that
+matches the pattern in `toast-sync-data/index.ts:371-374`. Client holes get a
+zod schema and a Vitest test.
+**Tech Stack:** Supabase PostgreSQL (pgTAP), Deno edge functions, React,
+TypeScript, Vitest, Playwright.
+**Audit / evidence doc:** `docs/SECURITY_AUDIT_ACCOUNT_CREATION_2026-08.md`
+**Dashboard work (user, not agents):** `docs/SUPABASE_AUTH_HARDENING_CHECKLIST.md`
+
+---
+
+## Track split
+
+| Track | Owner | Content |
+|---|---|---|
+| **A — code** | Claude Code sessions | Tasks 1-11 below. Migrations, edge functions, frontend. |
+| **B — hosted settings** | Jose, in the Supabase dashboard | `docs/SUPABASE_AUTH_HARDENING_CHECKLIST.md`. Confirm email, CAPTCHA, leaked-password protection, auth rate limits. |
+
+**One hard dependency:** Task 8 (signup hardening) needs Track B step B1 and B2
+done first. Every other task is independent. Do them in any order, but keep the
+severity order below if you have no other reason to reorder.
+
+---
+
+## Order
+
+| Order | Task | Severity | Type |
+|---|---|---|---|
+| 1 | `user_restaurants` INSERT guard | CRITICAL | migration |
+| 2 | `restaurants` subscription column guard | HIGH | migration |
+| 3 | POS OAuth callback authz (Square + Clover) | HIGH | edge fn |
+| 4 | `shift4-sync-data` missing-header bypass | HIGH | edge fn |
+| 5 | Invitation token log + single use | HIGH | edge fn |
+| 6 | AI-cost subscription gates | MEDIUM | edge fn |
+| 7 | Notification IDOR | MEDIUM | edge fn |
+| 8 | Signup hardening (CAPTCHA, verify, password) | HIGH | frontend |
+| 9 | `get_users_by_ids` revoke and scope | MEDIUM | migration |
+| 10 | Cap `create_restaurant_with_owner` | MEDIUM | migration |
+| 11 | Systemic: REVOKE sweep + `search_path` pin | MEDIUM | migration |
+
+---
+
+### Task 1: Block self-grant of `owner` on `user_restaurants`
+
+Audit: Vuln 1. **Ship this first.** Any signed-up user can become owner of any
+restaurant today.
+
+**Files:**
+- Create: `supabase/migrations/20260807000000_restrict_user_restaurants_insert.sql`
+- Test: `supabase/tests/user_restaurants_insert_guard.test.sql`
+
+- [ ] **Step 1: Write the pgTAP test first.** Prove the hole exists, then prove
+      it closes. Cover these cases:
+      - A non-member INSERT with `role = 'owner'` on another restaurant **fails**.
+      - A non-member INSERT with `role = 'staff'` on another restaurant **fails**.
+      - A real owner CAN still add a member with any role.
+      - `create_restaurant_with_owner` still works end to end. It is
+        `SECURITY DEFINER`, so confirm whether RLS applies to its insert.
+      - `accept-invitation` still works. It uses the service role, which
+        bypasses RLS, so it must be unaffected.
+- [ ] **Step 2: Add the RESTRICTIVE INSERT policy.** Mirror the existing UPDATE
+      guard `"Prevent self-escalation to privileged roles"` exactly, so both
+      commands enforce the same rule.
+
+      ```sql
+      CREATE POLICY "Prevent self-grant of privileged roles on insert"
+        ON public.user_restaurants
+        AS RESTRICTIVE
+        FOR INSERT
+        TO authenticated
+        WITH CHECK (
+          is_restaurant_owner(restaurant_id, auth.uid())
+          OR (
+            role = ANY (ARRAY['staff','kiosk'])
+            AND (role_id IS NULL OR role_id = builtin_role_id_for(role))
+          )
+        );
+      ```
+
+- [ ] **Step 3: Decide the self-join question.** The clause above still lets a
+      stranger insert themselves as `staff` on any restaurant. Decide whether
+      self-join is a real product flow. If it is not, tighten the second branch
+      to also require an accepted invitation. Write the decision in the
+      migration comment.
+- [ ] **Step 4: Run `npm run test:db`.** All pgTAP suites must pass, not only
+      the new one. 113 policies depend on `is_restaurant_owner()`.
+- [ ] **Step 5: Run the permissions E2E suite.** `npm run test:e2e`.
+- [ ] **Step 6: Remove the stale deferral note** at
+      `supabase/migrations/20260730180000_close_role_id_self_escalation.sql:37-40`
+      — add a follow-up comment in the new migration that points back to it.
+
+---
+
+### Task 2: Stop owners from writing their own subscription tier
+
+Audit: Vuln 2.
+
+**Files:**
+- Create: `supabase/migrations/20260807000001_guard_restaurant_billing_columns.sql`
+- Test: `supabase/tests/restaurant_billing_columns.test.sql`
+
+- [ ] **Step 1: Write the pgTAP test.** Cases:
+      - An owner UPDATE that changes `subscription_tier` **fails**.
+      - An owner UPDATE that changes only `name`, `address`, or `timezone`
+        **succeeds**.
+      - A service-role UPDATE that changes `subscription_tier` **succeeds** —
+        the Stripe webhooks need this.
+      - Repeat for `subscription_status`, `subscription_period`,
+        `subscription_ends_at`, `subscription_cancel_at`, `trial_ends_at`,
+        `stripe_customer_id`, `stripe_subscription_id`,
+        `stripe_subscription_customer_id`.
+- [ ] **Step 2: Add a BEFORE UPDATE trigger** on `public.restaurants`. Raise an
+      exception when any billing column changes and the writer is not the
+      service role. Prefer a trigger over a policy split. A policy cannot
+      compare `OLD` to `NEW`.
+- [ ] **Step 3: Confirm the writer test works in this project.** Test both
+      `auth.role()` and `current_setting('request.jwt.claims', true)` inside
+      pgTAP. Migrations run as `postgres`, so the trigger must allow `postgres`
+      too or later migrations break.
+- [ ] **Step 4: Grep every caller.** Confirm no frontend or non-webhook edge
+      function writes these columns. Search for `subscription_tier`,
+      `trial_ends_at`, and `stripe_customer_id`.
+- [ ] **Step 5: Run `npm run test:db` and the subscription E2E flow.**
+
+---
+
+### Task 3: Require ownership on the POS OAuth callbacks
+
+Audit: Vulns 3 and 4. One PR — the two functions share the bug.
+
+**Files:**
+- Modify: `supabase/functions/square-oauth/index.ts`
+- Modify: `supabase/functions/clover-oauth/index.ts`
+- Create: `supabase/migrations/20260807000002_add_oauth_state_nonces.sql`
+- Delete: `supabase/functions/toast-oauth/` (dead code — see the audit's refuted list)
+
+- [ ] **Step 1: Add an `oauth_state_nonces` table.** Columns: `state` (text,
+      primary key, from `gen_random_uuid()`), `restaurant_id`, `user_id`,
+      `provider`, `created_at`, `expires_at` (10 minutes), `consumed_at`. Enable
+      RLS and add no policy. Only the service role touches it.
+- [ ] **Step 2: In the `authorize` branch of both functions,** insert a nonce
+      row after the existing auth check passes. Return that nonce as `state`.
+      Stop putting `restaurantId` in `state`.
+- [ ] **Step 3: In the `callback` branch of both functions,** look up the
+      nonce. Reject when it is missing, expired, or already consumed. Read
+      `restaurant_id` from the row, never from the request. Mark it consumed in
+      the same transaction.
+- [ ] **Step 4: Do not remove `verify_jwt = false`.** The OAuth provider
+      redirects the browser back with no JWT. The nonce is the control.
+- [ ] **Step 5: Delete `toast-oauth`.** Its callback writes columns that
+      `20260106120000_toast_standard_api_migration.sql:6-44` dropped. Remove
+      the `[functions.toast-oauth]` block from `supabase/config.toml` too.
+- [ ] **Step 6: Test the full connect flow** for Square and Clover against a
+      sandbox merchant. Verify the old `state = <restaurant_id>` payload now
+      returns an error.
+
+---
+
+### Task 4: Fix the missing-header auth bypass in `shift4-sync-data`
+
+Audit: Vuln 5. Small and self-contained.
+
+**Files:**
+- Modify: `supabase/functions/shift4-sync-data/index.ts`
+
+- [ ] **Step 1: Add the header guard before the call,** to match
+      `supabase/functions/toast-sync-data/index.ts:371-374`:
+
+      ```ts
+      const authHeader = req.headers.get('Authorization');
+      if (!authHeader) {
+        return jsonResponse({ error: 'Missing authorization' }, 401);
+      }
+      ```
+
+- [ ] **Step 2: Change `authenticateUser` to throw, not return null,** on a
+      missing header. The `return null` at line 102 is the root cause. A
+      function named `authenticateUser` must never return a success-shaped value
+      for an unauthenticated caller.
+- [ ] **Step 3: Grep every other edge function for `return null` inside an auth
+      helper.** Fix any sibling with the same shape in this PR.
+- [ ] **Step 4: Verify.** POST with no header must return 401. POST as a
+      `staff` member must return 403. POST as an owner must still sync.
+
+---
+
+### Task 5: Stop the invitation-token leak and make tokens single-use
+
+Audit: Vuln 6.
+
+**Files:**
+- Modify: `supabase/functions/validate-invitation/index.ts`
+- Modify: `supabase/functions/signup-with-invitation/index.ts`
+
+- [ ] **Step 1: Delete the plaintext logs.** Remove
+      `console.log('Plain token from URL:', token)` at line 32. Remove the
+      plaintext email log at line 77. Log a boolean or a hash prefix if you
+      need the trace.
+- [ ] **Step 2: Consume the invitation** in `signup-with-invitation`. After the
+      password write succeeds, set `invitations.status = 'accepted'` and stamp
+      `accepted_at`. Today only `accept-invitation/index.ts:174-183` does this,
+      so the token stays replayable for its full 7-day life.
+- [ ] **Step 3: Make the consumption atomic.** Use a conditional update
+      (`... WHERE status = 'pending'`) and check the affected row count, so two
+      concurrent redemptions cannot both win.
+- [ ] **Step 4: Audit the remaining logs in both files** for any other secret
+      or PII.
+- [ ] **Step 5: Test.** Redeem an invitation, then replay the same token. The
+      replay must fail.
+
+---
+
+### Task 6: Gate the AI-cost edge functions on the subscription tier
+
+Audit: Vuln 11. This is the largest real dollar exposure.
+
+**Files:**
+- Modify: `supabase/functions/process-receipt/index.ts`
+- Modify: `supabase/functions/enhanced-ocr/index.ts`
+- Modify: `supabase/functions/grok-ocr/index.ts`
+- Modify: `supabase/functions/ai-categorize-pos-sales/index.ts`
+- Modify: `supabase/functions/ai-categorize-transactions/index.ts`
+- Modify: `supabase/functions/enhance-product-ai/index.ts`
+- Modify: `supabase/functions/grok-recipe-enhance/index.ts`
+- Modify: `supabase/functions/process-expense-invoice/index.ts`
+- Modify: `supabase/functions/process-bank-statement/index.ts`
+- Modify: `supabase/functions/process-asset-document/index.ts`
+- Modify: `supabase/functions/ai-chat-stream/index.ts`
+- Create: `supabase/functions/_shared/requireSubscriptionFeature.ts`
+
+- [ ] **Step 1: Decide the feature key for each function first.** Write the map
+      into the plan before you touch code. `has_subscription_feature()` (see
+      `20260217210000_gate_ops_weekly_brief_pro.sql:10-101`) knows
+      `financial_intelligence`, `inventory_automation`, `scheduling`,
+      `ai_alerts`, `multi_location_dashboard`, `recipe_profitability`,
+      `ai_assistant`, `ops_inbox`, `weekly_brief`. Add a key if none fits.
+- [ ] **Step 2: Write the shared helper.** Follow the call pattern already used
+      at `generate-weekly-brief-worker/index.ts:79`. It must return a 402 or 403
+      JSON response, never throw an unhandled error.
+- [ ] **Step 3: Add the check to each function,** after the auth check and
+      before the first AI call.
+- [ ] **Step 4: Add the server-side gate to `ai-chat-stream`.** Today the Pro
+      gate lives only at `src/components/ai-chat/AiChatPanel.tsx:41`, which is
+      client-side and bypassable.
+- [ ] **Step 5: Check the free-tier product promise before you ship.** Some of
+      these run receipt OCR, which may be a free-tier feature. Confirm the
+      intended tier with the product owner. Do not lock out paying customers.
+- [ ] **Step 6: Test each function** on a `free`, a `growth`, and a `pro`
+      restaurant.
+
+---
+
+### Task 7: Add tenant checks to the notification functions
+
+Audit: Vuln 10.
+
+**Files:**
+- Modify: `supabase/functions/send-time-off-notification/index.ts`
+- Modify: `supabase/functions/send-shift-notification/index.ts`
+
+- [ ] **Step 1: Add a full auth check to `send-time-off-notification`.** It has
+      none today. Read the JWT, resolve the request's `restaurant_id`, then
+      check `user_restaurants`.
+- [ ] **Step 2: Add the ownership check to the `created`/`modified` path** of
+      `send-shift-notification` at lines 229-241. Copy the check its own sibling
+      branch already has at lines 136-149, which returns
+      `errorResponse('Access denied', 403)`.
+- [ ] **Step 3: Extract the check into one helper** used by both branches, so
+      the fix cannot drift out of one path again.
+- [ ] **Step 4: Test.** A member of restaurant A must get 403 for a shift or a
+      request that belongs to restaurant B.
+
+---
+
+### Task 8: Harden the signup form
+
+Audit: Vulns 7 and 12.
+
+> **BLOCKED until Track B steps B1 and B2 are done.** The CAPTCHA provider and
+> its site key must exist before this code can send a token.
+
+**Files:**
+- Modify: `src/pages/Auth.tsx`
+- Modify: `src/hooks/useAuth.tsx`
+- Modify: `tests/e2e/helpers/e2e-supabase.ts`
+- Create: `src/lib/validation/signupSchema.ts`
+- Test: `tests/unit/signupSchema.test.ts`
+
+- [ ] **Step 1: Write the zod password schema and its Vitest test.** Match
+      `src/pages/ResetPassword.tsx:13-17` — 8+ characters, upper, lower, digit.
+      Do not invent a different rule. Apply the same schema to
+      `src/pages/AcceptInvitation.tsx:468-479`, which allows 6 characters today.
+- [ ] **Step 2: Add the CAPTCHA widget to the signup and sign-in forms.** Pass
+      the token as `options.captchaToken` to `supabase.auth.signUp` and
+      `signInWithPassword`.
+- [ ] **Step 3: Handle the unconfirmed-email state.** After Track B turns on
+      Confirm email, `signUp` returns a session-less result. Show a
+      "check your email" screen. Today `handleAuthStateChange`
+      (`src/hooks/useAuth.tsx:51-62`) treats any session as fully logged in.
+- [ ] **Step 4: Fix the E2E suite.** 154 of 280 production accounts use
+      `test.com` and are unconfirmed. Once Confirm email is on, every signup
+      test breaks. Change `generateTestUser()` and the sign-up helper to create
+      users through the admin API with `email_confirm: true`, or to bypass the
+      CAPTCHA with a test secret key.
+- [ ] **Step 5: Run the full E2E suite** before you open the PR. Expect
+      failures in step 4's absence, and fix them here, not in a follow-up.
+
+---
+
+### Task 9: Revoke and scope `get_users_by_ids`
+
+Audit: Vuln 8.
+
+**Files:**
+- Create: `supabase/migrations/20260807000003_scope_get_users_by_ids.sql`
+- Test: `supabase/tests/get_users_by_ids_scope.test.sql`
+- Check caller: `src/hooks/useTipSplitAuditLog.ts:45`
+
+- [ ] **Step 1: Write the pgTAP test.** `anon` EXECUTE must fail. A user must
+      get rows for teammates in a shared restaurant. A user must get **no** row
+      for a user outside every shared restaurant.
+- [ ] **Step 2: Revoke the default grant.**
+      `REVOKE EXECUTE ON FUNCTION public.get_users_by_ids(uuid[]) FROM PUBLIC, anon;`
+      Follow the pattern at
+      `supabase/migrations/20260802110000_assign_membership_role.sql:223`.
+- [ ] **Step 3: Add the tenant scope inside the function.** Return only users
+      who share at least one restaurant with `auth.uid()`. Return an empty set,
+      not an error, for the rest.
+- [ ] **Step 4: Verify the only client caller still works** —
+      `src/hooks/useTipSplitAuditLog.ts:45`. Audit-log actors are always
+      same-restaurant, so the scope must not break it.
+
+---
+
+### Task 10: Cap tenant and trial creation
+
+Audit: Vuln 9.
+
+**Files:**
+- Create: `supabase/migrations/20260807000004_limit_restaurant_creation.sql`
+- Test: `supabase/tests/limit_restaurant_creation.test.sql`
+
+- [ ] **Step 1: Read the warning first.** Live users own 19 and 15 restaurants.
+      `stripe-subscription-checkout/index.ts:168-176` has a volume-discount
+      ladder at 3, 6, and 11+ locations. **Multi-unit ownership is a designed,
+      paid use case. Do not cap it at a small number.**
+- [ ] **Step 2: Cap only the unpaid case.** Recommended rule: an account with no
+      active paid subscription may hold at most 3 restaurants in `trialing`
+      status. An account with an active subscription has no cap.
+- [ ] **Step 3: Require a confirmed email.** Once Track B step B1 is on, add
+      `email_confirmed_at IS NOT NULL` to `create_restaurant_with_owner`.
+      Keep this step behind that dependency.
+- [ ] **Step 4: Add a cooldown.** The existing
+      `pg_advisory_xact_lock(hashtext(auth.uid() || name))` dedups the same name
+      for 5 seconds only. A counter in the name defeats it. Add a per-user
+      time-window limit instead.
+- [ ] **Step 5: Return a clear error the UI can show,** not a raw exception.
+      Update `src/contexts/RestaurantContext.tsx` to render it.
+
+---
+
+### Task 11: Systemic — revoke `PUBLIC` and pin `search_path`
+
+Audit: the systemic section. Mechanical and large. Do it last.
+
+**Files:**
+- Create: `supabase/migrations/20260807000005_revoke_public_execute_sweep.sql`
+- Create: `supabase/migrations/20260807000006_pin_function_search_path.sql`
+
+- [ ] **Step 1: List the targets from the live advisor feed,** not from a repo
+      grep. 146 functions are `anon`-executable (lint 0028). 73 have a mutable
+      `search_path` (lint 0011).
+- [ ] **Step 2: Split into two migrations.** Do not mix the revoke sweep and the
+      `search_path` pin. If one breaks production you must revert only that one.
+- [ ] **Step 3: For the revoke sweep, classify each function first.** Some must
+      stay `anon`-callable — anything the login page, the invitation page, or a
+      public marketing route hits. Grep `src/` for every RPC name before you
+      revoke it. Write the keep-list into the migration comment.
+- [ ] **Step 4: For the `search_path` pin, use `SET search_path = public`** to
+      match the correct existing pattern at
+      `20250915204511_f5de15c1-57d2-4c60-bd82-0da16bca991a.sql:49-60`.
+- [ ] **Step 5: Drop the vestigial `profiles.role` column** in a third, separate
+      migration. It is self-updatable and nothing reads it. Grep to confirm zero
+      readers before you drop it.
+- [ ] **Step 6: Run `npm run test:db` and the full E2E suite** after each of the
+      three migrations, not once at the end.
+
+---
+
+## Do not re-investigate
+
+The audit refuted these. Read
+`docs/SECURITY_AUDIT_ACCOUNT_CREATION_2026-08.md#refuted--do-not-re-investigate`
+before you spend time on any of them.
+
+- The card-testing oracle. This app has **no** card-tokenizing endpoint. All
+  card entry is on Stripe-hosted Checkout.
+- Stripe webhook forgery. All three verify the signature.
+- `square-webhooks` fail-open. Handlers re-fetch from Square's API.
+- `revel-bulk-sync` anonymous trigger.
+- Invitation tenant escalation in `accept-invitation`.
+- `handle_new_user()` metadata trust. This function is the correct template.
+- A growth trial unlocking Pro AI features. It does not.

--- a/docs/plans/2026-08-07-account-creation-security-plan.md
+++ b/docs/plans/2026-08-07-account-creation-security-plan.md
@@ -26,9 +26,22 @@ TypeScript, Vitest, Playwright.
 | **A — code** | Claude Code sessions | Tasks 1-11 below. Migrations, edge functions, frontend. |
 | **B — hosted settings** | Jose, in the Supabase dashboard | `docs/SUPABASE_AUTH_HARDENING_CHECKLIST.md`. Confirm email, CAPTCHA, leaked-password protection, auth rate limits. |
 
-**One hard dependency:** Task 8 (signup hardening) needs Track B step B1 and B2
-done first. Every other task is independent. Do them in any order, but keep the
-severity order below if you have no other reason to reorder.
+**Two hard dependencies, and they point in opposite directions:**
+
+1. Task 8 (signup hardening) needs Track B step **B1** (Confirm email) first.
+2. Track B step **B2** (CAPTCHA **enforcement**) needs Task 8 **deployed**
+   first. Reverse of what an earlier version of this plan said.
+
+Warning: do not switch on CAPTCHA enforcement before the client sends a token.
+`src/hooks/useAuth.tsx:125` and `:177` call `signInWithPassword` and `signUp`
+with no `captchaToken`. `src/pages/AcceptInvitation.tsx:163-166` does the same.
+Enforcement before the deploy breaks every password sign-up and sign-in.
+
+B2 therefore splits in two. Provision the provider and the site key at any
+time. Switch on enforcement only after Task 8 ships.
+
+Every other task is independent. Do them in any order, but keep the severity
+order below if you have no other reason to reorder.
 
 ---
 
@@ -50,48 +63,57 @@ severity order below if you have no other reason to reorder.
 
 ---
 
-### Task 1: Block self-grant of `owner` on `user_restaurants`
+### Task 1: Block self-grant of `owner` on `user_restaurants` — DONE
 
-Audit: Vuln 1. **Ship this first.** Any signed-up user can become owner of any
-restaurant today.
+Audit: Vuln 1. Shipped in
+[PR #725](https://github.com/toyiyo/nimble-pnl/pull/725).
+
+Design: `docs/superpowers/specs/2026-08-08-user-restaurants-insert-guard-design.md`.
+Plan: `docs/superpowers/plans/2026-08-08-user-restaurants-insert-guard-plan.md`.
 
 **Files:**
-- Create: `supabase/migrations/20260807000000_restrict_user_restaurants_insert.sql`
+- Create: `supabase/migrations/20260808100000_restrict_user_restaurants_insert.sql`
 - Test: `supabase/tests/user_restaurants_insert_guard.test.sql`
+- Delete: the dead `__inviteCollaborator` helper in
+  `tests/helpers/e2e-supabase.ts`
 
-- [ ] **Step 1: Write the pgTAP test first.** Prove the hole exists, then prove
-      it closes. Cover these cases:
-      - A non-member INSERT with `role = 'owner'` on another restaurant **fails**.
-      - A non-member INSERT with `role = 'staff'` on another restaurant **fails**.
-      - A real owner CAN still add a member with any role.
-      - `create_restaurant_with_owner` still works end to end. It is
-        `SECURITY DEFINER`, so confirm whether RLS applies to its insert.
-      - `accept-invitation` still works. It uses the service role, which
-        bypasses RLS, so it must be unaffected.
-- [ ] **Step 2: Add the RESTRICTIVE INSERT policy.** Mirror the existing UPDATE
-      guard `"Prevent self-escalation to privileged roles"` exactly, so both
-      commands enforce the same rule.
+**The shipped policy differs from the draft below it.** The draft mirrored the
+UPDATE guard and allowed `role IN ('staff','kiosk')`. That branch is wrong for
+INSERT. For UPDATE it permits a **downgrade** of a membership that already
+exists. For INSERT it permits a stranger to **join** a tenant they have no
+relationship with, and many tenant policies treat any `user_restaurants` row as
+authorization.
+
+Research answered the self-join question: **no product flow needs the
+permissive INSERT grant at all.** `src/` holds 7 `.select(` and 2 `.delete(`
+call sites on the table and zero `.insert(`. All five real writers bypass RLS —
+`create_restaurant_with_owner` is `SECURITY DEFINER` owned by `postgres`, and
+`accept-invitation`, `scim-v2`, and `create-kiosk-service-account` use the
+service-role key.
+
+- [x] **Step 1: Write the pgTAP test first.** 11 cases. Every deny case pins
+      SQLSTATE `42501`. `UNIQUE(user_id, restaurant_id)` raises `23505` before
+      RLS raises `42501`, so a bare `throws_ok` passes even with the guard
+      deleted.
+- [x] **Step 2: Drop the permissive policy and add a RESTRICTIVE one.**
 
       ```sql
-      CREATE POLICY "Prevent self-grant of privileged roles on insert"
+      DROP POLICY IF EXISTS "Users can insert their own restaurant associations"
+        ON public.user_restaurants;
+
+      DROP POLICY IF EXISTS "Only owners can insert restaurant associations"
+        ON public.user_restaurants;
+
+      CREATE POLICY "Only owners can insert restaurant associations"
         ON public.user_restaurants
         AS RESTRICTIVE
         FOR INSERT
-        TO authenticated
-        WITH CHECK (
-          is_restaurant_owner(restaurant_id, auth.uid())
-          OR (
-            role = ANY (ARRAY['staff','kiosk'])
-            AND (role_id IS NULL OR role_id = builtin_role_id_for(role))
-          )
-        );
+        TO public
+        WITH CHECK (is_restaurant_owner(restaurant_id, auth.uid()));
       ```
 
-- [ ] **Step 3: Decide the self-join question.** The clause above still lets a
-      stranger insert themselves as `staff` on any restaurant. Decide whether
-      self-join is a real product flow. If it is not, tighten the second branch
-      to also require an accepted invitation. Write the decision in the
-      migration comment.
+      Effective INSERT check afterwards:
+      `is_restaurant_owner(restaurant_id, auth.uid())`.
 - [ ] **Step 4: Run `npm run test:db`.** All pgTAP suites must pass, not only
       the new one. 113 policies depend on `is_restaurant_owner()`.
 - [ ] **Step 5: Run the permissions E2E suite.** `npm run test:e2e`.
@@ -201,22 +223,66 @@ Audit: Vuln 6.
 **Files:**
 - Modify: `supabase/functions/validate-invitation/index.ts`
 - Modify: `supabase/functions/signup-with-invitation/index.ts`
+- Create: a migration that adds `invitations.signup_claimed_at timestamptz`
+
+**Warning: do not set `status = 'accepted'` in `signup-with-invitation`.** The
+create-account path is two calls, not one. `signup-with-invitation` only makes
+the auth account (`src/pages/AcceptInvitation.tsx:211-219`). The user then
+signs in, and `AcceptInvitation.tsx:129` calls `accept-invitation`, which
+selects `.eq('status', 'pending')` (`accept-invitation/index.ts:71`) before it
+inserts the membership row. An early `accepted` makes that second call reject
+the token, and the new user never joins the restaurant.
+
+Claim the invitation with a **separate** column instead. `status` stays
+`pending`, so `accept-invitation` still works.
 
 - [ ] **Step 1: Delete the plaintext logs.** Remove
       `console.log('Plain token from URL:', token)` at line 32. Remove the
       plaintext email log at line 77. Log a boolean or a hash prefix if you
       need the trace.
-- [ ] **Step 2: Consume the invitation** in `signup-with-invitation`. After the
-      password write succeeds, set `invitations.status = 'accepted'` and stamp
-      `accepted_at`. Today only `accept-invitation/index.ts:174-183` does this,
-      so the token stays replayable for its full 7-day life.
-- [ ] **Step 3: Make the consumption atomic.** Use a conditional update
-      (`... WHERE status = 'pending'`) and check the affected row count, so two
-      concurrent redemptions cannot both win.
-- [ ] **Step 4: Audit the remaining logs in both files** for any other secret
+- [ ] **Step 2: Add `invitations.signup_claimed_at timestamptz` (nullable).**
+      One column. No change to `status`.
+- [ ] **Step 3: Claim the row BEFORE the password mutation.** Order matters.
+      `signup-with-invitation/index.ts:73` calls
+      `admin.updateUserById` to set the password on an account that already
+      exists. Two concurrent redemptions of a leaked token can both validate
+      the pending invitation and both change the password. A conditional
+      status update placed **after** the mutation cannot undo the loser's
+      password write, so the live password can belong to a request the
+      function reported as rejected.
+
+      Claim first:
+
+      ```ts
+      const { data: claimed } = await supabaseAdmin
+        .from('invitations')
+        .update({ signup_claimed_at: new Date().toISOString() })
+        .eq('id', invitation.id)
+        .is('signup_claimed_at', null)
+        .eq('status', 'pending')
+        .select('id');
+
+      if (!claimed?.length) return errorResponse('Invalid or expired invitation', 400);
+      ```
+
+      The row lock inside that one UPDATE serializes the two callers. Exactly
+      one gets a row back.
+- [ ] **Step 4: Release the claim on failure.** If `updateUserById` or
+      `createUser` fails, set `signup_claimed_at` back to `NULL`. A real
+      invitee must be able to retry after a transient error.
+- [ ] **Step 5: Reject an already-claimed token in `validate-invitation`,**
+      so the UI does not show a form that cannot succeed.
+- [ ] **Step 6: Audit the remaining logs in both files** for any other secret
       or PII.
-- [ ] **Step 5: Test.** Redeem an invitation, then replay the same token. The
-      replay must fail.
+- [ ] **Step 7: Test.** Three cases.
+      - Redeem an invitation through the create-account path, then replay the
+        same token. The replay must fail.
+      - After `signup-with-invitation` succeeds, `accept-invitation` must still
+        grant the membership. This is the regression the warning above
+        describes.
+      - Fire two concurrent `signup-with-invitation` calls with the same token
+        and different passwords. Exactly one must succeed, and the live
+        password must be the winner's.
 
 ---
 
@@ -286,15 +352,25 @@ Audit: Vuln 10.
 
 Audit: Vulns 7 and 12.
 
-> **BLOCKED until Track B steps B1 and B2 are done.** The CAPTCHA provider and
-> its site key must exist before this code can send a token.
+> **BLOCKED until Track B step B1 is done**, and until B2 provisions the
+> CAPTCHA provider and the site key. This code cannot send a token before the
+> key exists.
+>
+> **Warning: B2 enforcement must stay OFF until this task deploys.** The switch
+> is the last step, not the first. See "Track split" above.
 
 **Files:**
 - Modify: `src/pages/Auth.tsx`
 - Modify: `src/hooks/useAuth.tsx`
+- Modify: `src/pages/AcceptInvitation.tsx`
 - Modify: `tests/e2e/helpers/e2e-supabase.ts`
 - Create: `src/lib/validation/signupSchema.ts`
 - Test: `tests/unit/signupSchema.test.ts`
+
+`src/pages/AcceptInvitation.tsx:163-166` calls `supabase.auth.signInWithPassword`
+direct, not through `useAuth`. `/accept-invitation` is a live authentication
+path. Miss it, and every existing invitee fails CAPTCHA at the invitation
+screen.
 
 - [ ] **Step 1: Write the zod password schema and its Vitest test.** Match
       `src/pages/ResetPassword.tsx:13-17` — 8+ characters, upper, lower, digit.


### PR DESCRIPTION
## Summary

- Add the August 2026 account-creation security audit. It records 12 confirmed findings with `file:line` evidence, and 7 refuted claims so no later session repeats that work.
- Add Track A, the code-fix plan. 11 tasks, one PR each, in severity order.
- Add Track B, the Supabase dashboard checklist. These settings are not in `supabase/config.toml`. Only a human with dashboard access can change them.

## Two measured facts drive the order

Auto-confirm is ON in production. 71 of 72 real-domain accounts show `email_confirmed_at` set, but only 3 ever had a confirmation email sent. 53 confirmed within 2 seconds of `created_at`. Email verification gates nothing today.

Any signed-up user can `INSERT` an `owner` row on any restaurant. The RESTRICTIVE guard on `user_restaurants` has `cmd = 'UPDATE'`, so it never applies to INSERT. 113 policy definitions trust `is_restaurant_owner()`. `20260730180000_close_role_id_self_escalation.sql:37-40` documents this same gap as deferred.

## Test plan

Documentation only. No code changes. No tests apply.

## Next

Track A Task 1 closes the `user_restaurants` INSERT hole. It starts in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)