### PR TITLE
fix(security): block self-grant of restaurant membership

### DIFF
--- a/dev-tools/review_queue.json
+++ b/dev-tools/review_queue.json
@@ -102615,6 +102615,4426 @@
       "created_at": "2026-08-06T09:11:58.274Z",
       "updated_at": "2026-08-06T09:11:58.274Z",
       "tests_to_run": []
+    },
+    {
+      "source": "github-comment",
+      "origin_ref": {
+        "pr": "725",
+        "comment_id": 3740197443,
+        "file": "docs/superpowers/specs/2026-08-08-user-restaurants-insert-guard-design.md",
+        "line": 214
+      },
+      "title": "_📐 Maintainability & Code Quality_ | _🟡 Minor_ | _⚡ Quick win_",
+      "body": "_📐 Maintainability & Code Quality_ | _🟡 Minor_ | _⚡ Quick win_\n\n**Synchronize the test contract with the shipped pgTAP test.**\n\nThis table defines nine cases. `supabase/tests/user_restaurants_insert_guard.test.sql` defines eleven cases. It adds the non-vacuity control as case 8 and the anon-role boundary as case 11.\n\nAdd the omitted cases and update the case numbers. The design must describe the shipped security contract.\n\n<details>\n<summary>🤖 Prompt for AI Agents</summary>\n\n```\nVerify each finding against current code. Fix only still-valid issues, skip the\nrest with a brief reason, keep changes minimal, and validate.\n\nIn `@docs/superpowers/specs/2026-08-08-user-restaurants-insert-guard-design.md`\naround lines 192 - 212, Update the Tests table to match all eleven cases in\nuser_restaurants_insert_guard.test.sql, including the non-vacuity control and\nanon-role boundary cases. Renumber the existing policy-scope and dropped-policy\nchecks to their shipped positions, and document the expected outcome for each\nomitted case.\n```\n\n</details>\n\n<!-- fingerprinting:phantom:poseidon:tapir -->\n\n<!-- cr-indicator-types:potential_issue -->\n\n<!-- cr-comment:v1:8b86d37d4bb5e7e886f20019 -->\n\n<!-- This is an auto-generated reply by CodeRabbit -->\n\n✅ Confirmed as addressed by @jdelgado2002\n\n<!-- This is an auto-generated comment by CodeRabbit -->",
+      "severity": "info",
+      "id": "877874780fb8caab52a57128d9dd76d5989ed21b",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:48.954Z",
+      "updated_at": "2026-08-08T07:09:48.954Z",
+      "tests_to_run": []
+    },
+    {
+      "source": "github-comment",
+      "origin_ref": {
+        "pr": "725",
+        "comment_id": 3740197444,
+        "file": "supabase/tests/user_restaurants_insert_guard.test.sql",
+        "line": 183
+      },
+      "title": "_🔒 Security & Privacy_ | _🟡 Minor_ | _⚡ Quick win_",
+      "body": "_🔒 Security & Privacy_ | _🟡 Minor_ | _⚡ Quick win_\n\n**Constrain policy checks to the `public` schema.**\n\n`pg_policies` contains policies from all schemas. An identically named policy on another `user_restaurants` table can make the policy-presence assertion pass incorrectly.\n\nAdd `AND schemaname = 'public'` to both catalog subqueries.\n\n<details>\n<summary>🤖 Prompt for AI Agents</summary>\n\n```\nVerify each finding against current code. Fix only still-valid issues, skip the\nrest with a brief reason, keep changes minimal, and validate.\n\nIn `@supabase/tests/user_restaurants_insert_guard.test.sql` around lines 164 -\n181, Constrain both pg_policies subqueries in the user_restaurants policy\nassertions to the public schema by adding schemaname = 'public' alongside the\nexisting tablename and policyname filters. Keep the current checks for the\nrestrictive INSERT policy and removal of the old policy unchanged.\n```\n\n</details>\n\n<!-- fingerprinting:phantom:poseidon:tapir -->\n\n<!-- cr-indicator-types:potential_issue -->\n\n<!-- cr-comment:v1:c3ee87d46bf92a2ccc762eca -->\n\n<!-- This is an auto-generated reply by CodeRabbit -->\n\n✅ Confirmed as addressed by @jdelgado2002\n\n<!-- This is an auto-generated comment by CodeRabbit -->",
+      "severity": "info",
+      "id": "8898eaadcd224a5e860b85638a9e31ea3c3a725b",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:48.955Z",
+      "updated_at": "2026-08-08T07:09:48.955Z",
+      "tests_to_run": []
+    },
+    {
+      "source": "github-comment",
+      "origin_ref": {
+        "pr": "725",
+        "comment_id": 3740225616,
+        "file": "docs/superpowers/specs/2026-08-08-user-restaurants-insert-guard-design.md",
+        "line": 214
+      },
+      "title": "<!-- pr-triage: agreed -->",
+      "body": "<!-- pr-triage: agreed -->\n**✅ Agreed** — Updated the Tests table to list all 11 shipped cases: added case 8 (non-vacuity control) and case 11 (anon-role boundary), and renumbered the policy-scope and dropped-policy checks to 9 and 10. Fixed in `a4378ee37a217614f18042a49a5f73a8e5d10768`.",
+      "severity": "info",
+      "id": "eac053632c22a278b5d2abc1f48127d412a3f9a6",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:48.956Z",
+      "updated_at": "2026-08-08T07:09:48.956Z",
+      "tests_to_run": []
+    },
+    {
+      "source": "github-comment",
+      "origin_ref": {
+        "pr": "725",
+        "comment_id": 3740225870,
+        "file": "supabase/tests/user_restaurants_insert_guard.test.sql",
+        "line": 183
+      },
+      "title": "<!-- pr-triage: agreed -->",
+      "body": "<!-- pr-triage: agreed -->\n**✅ Agreed** — Added AND schemaname = 'public' to both pg_policies subqueries (cases 9 and 10). Fixed in `a4378ee37a217614f18042a49a5f73a8e5d10768`.",
+      "severity": "info",
+      "id": "9883b4a639e6125fee3d4c68a8d497080d1980ed",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:48.956Z",
+      "updated_at": "2026-08-08T07:09:48.956Z",
+      "tests_to_run": []
+    },
+    {
+      "source": "github-comment",
+      "origin_ref": {
+        "pr": "725",
+        "comment_id": 3740226220,
+        "file": "docs/superpowers/specs/2026-08-08-user-restaurants-insert-guard-design.md",
+        "line": 214
+      },
+      "title": "`@jdelgado2002`, thank you. The design test table now matches the shipped 11-case pgTAP security contract.",
+      "body": "`@jdelgado2002`, thank you. The design test table now matches the shipped 11-case pgTAP security contract.\n\n🐇 ✅\n\n<!-- <review_comment_addressed> -->\n\n---\n\n<!-- This is an auto-generated comment: tweet message by coderabbit.ai -->\n\nIf you found this review helpful, would you consider giving us a shout-out on [X](https://twitter.com/intent/tweet?related=CodeRabbitAI&text=Keep%20security%20docs%20aligned%20with%20shipped%20pgTAP%20tests%3A%20all%2011%20cases%2C%20including%20non-vacuity%20and%20anon-role%20boundaries.%20Catch%20contract%20drift%20fast%20with%20%40coderabbitai%20%F0%9F%94%8D%F0%9F%9B%A1%EF%B8%8F&url=https%3A%2F%2Fgithub.com%2Ftoyiyo%2Fnimble-pnl%2Fpull%2F725%23discussion_r3740197443)?\n\nThank you for using CodeRabbit!\n\n<!-- end of auto-generated comment: tweet message by coderabbit.ai -->\n\n<sub>You are interacting with an AI system.</sub>\n\n<!-- This is an auto-generated reply by CodeRabbit -->",
+      "severity": "info",
+      "id": "2437c39a25b7f97c5f08b0ec12bb6ba3b30d02b7",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:48.956Z",
+      "updated_at": "2026-08-08T07:09:48.956Z",
+      "tests_to_run": []
+    },
+    {
+      "source": "github-comment",
+      "origin_ref": {
+        "pr": "725",
+        "comment_id": 3740226228,
+        "file": "supabase/tests/user_restaurants_insert_guard.test.sql",
+        "line": 183
+      },
+      "title": "`@jdelgado2002`, confirmed. The two catalog checks now constrain `pg_policies` to the `public` schema. This resolves the finding.",
+      "body": "`@jdelgado2002`, confirmed. The two catalog checks now constrain `pg_policies` to the `public` schema. This resolves the finding.\n\n🐇 ✅\n\n<!-- <review_comment_addressed> -->\n\n---\n\n<!-- This is an auto-generated comment: tweet message by coderabbit.ai -->\n\nIf you found this review helpful, would you consider giving us a shout-out on [X](https://twitter.com/intent/tweet?related=CodeRabbitAI&text=Prevent%20false-positive%20RLS%20policy%20tests%20by%20scoping%20%60pg_policies%60%20checks%20to%20%60public%60.%20A%20small%20fix%20with%20real%20security%20impact%E2%80%94try%20%40coderabbitai%20%F0%9F%94%92&url=https%3A%2F%2Fgithub.com%2Ftoyiyo%2Fnimble-pnl%2Fpull%2F725%23discussion_r3740197444)?\n\nThank you for using CodeRabbit!\n\n<!-- end of auto-generated comment: tweet message by coderabbit.ai -->\n\n<sub>You are interacting with an AI system.</sub>\n\n<!-- This is an auto-generated reply by CodeRabbit -->",
+      "severity": "info",
+      "id": "7a74a0067ca4d5278264011d894d50a719a3c698",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:48.956Z",
+      "updated_at": "2026-08-08T07:09:48.956Z",
+      "tests_to_run": []
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "src/hooks/usePayroll.tsx",
+        "line": 532
+      },
+      "title": "@typescript-eslint/no-explicit-any in usePayroll.tsx",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/src/hooks/usePayroll.tsx"
+      ],
+      "id": "2990f93ada0ce4d8a5a1a09f3bfa5d100cdb10ae",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.001Z",
+      "updated_at": "2026-08-08T07:09:49.001Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "src/hooks/useShiftTemplates.tsx",
+        "line": 160
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.tsx",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/src/hooks/useShiftTemplates.tsx"
+      ],
+      "id": "a702ba96976ff5ff4c416a31e9ae52c26e8ad336",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.007Z",
+      "updated_at": "2026-08-08T07:09:49.007Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "src/hooks/useShiftTemplates.tsx",
+        "line": 352
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.tsx",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/src/hooks/useShiftTemplates.tsx"
+      ],
+      "id": "e5e3a7e55a7654e6261673bb5075d4d0a778cb30",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.007Z",
+      "updated_at": "2026-08-08T07:09:49.007Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "src/hooks/useShiftTemplates.tsx",
+        "line": 371
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.tsx",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/src/hooks/useShiftTemplates.tsx"
+      ],
+      "id": "e3b96942141832c575b6761e37fe965ae6512835",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.008Z",
+      "updated_at": "2026-08-08T07:09:49.008Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "src/pages/AvailableShiftsPage.tsx",
+        "line": 455
+      },
+      "title": "@typescript-eslint/no-explicit-any in AvailableShiftsPage.tsx",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/src/pages/AvailableShiftsPage.tsx"
+      ],
+      "id": "a3cddc99c6dc168f2cdae2123511c55841b83221",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.009Z",
+      "updated_at": "2026-08-08T07:09:49.009Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "src/pages/AvailableShiftsPage.tsx",
+        "line": 462
+      },
+      "title": "@typescript-eslint/no-explicit-any in AvailableShiftsPage.tsx",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/src/pages/AvailableShiftsPage.tsx"
+      ],
+      "id": "fd2a028a3a92b9209f783c178bb46a093f117e70",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.009Z",
+      "updated_at": "2026-08-08T07:09:49.009Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "src/pages/AvailableShiftsPage.tsx",
+        "line": 465
+      },
+      "title": "@typescript-eslint/no-explicit-any in AvailableShiftsPage.tsx",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/src/pages/AvailableShiftsPage.tsx"
+      ],
+      "id": "f07f40ba38f23b1014d4664914468a1977450a28",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.009Z",
+      "updated_at": "2026-08-08T07:09:49.009Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 306
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "7210d5c32c8831bed2ae2844274b44c502f032eb",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.019Z",
+      "updated_at": "2026-08-08T07:09:49.019Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 370
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "b45507e5b4897b4ae1cf697ad7632587c6b382ef",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.020Z",
+      "updated_at": "2026-08-08T07:09:49.020Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 404
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "4999bfb85601612061c053b8f31ee91c4e021dd7",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.020Z",
+      "updated_at": "2026-08-08T07:09:49.020Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 408
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "4ce64c8116fb962006f8b7fdf137c74fdde43b9f",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.020Z",
+      "updated_at": "2026-08-08T07:09:49.020Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 417
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "998e44fc0bea2c184ad8118e41dcd948936d2639",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.020Z",
+      "updated_at": "2026-08-08T07:09:49.020Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 423
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "a239042162282d291fb19b029969ef7f7c937fb9",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.020Z",
+      "updated_at": "2026-08-08T07:09:49.020Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 436
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "8a5ccf78a4d17e8a3aad862dc3d644a58c9cc975",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.020Z",
+      "updated_at": "2026-08-08T07:09:49.020Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 438
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "d15c908a0621e9e2272bd37502f8b353e9438d36",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.020Z",
+      "updated_at": "2026-08-08T07:09:49.020Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 439
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "12aacd97b0574c6619d7f1a1f8e3d01aee845cfe",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.020Z",
+      "updated_at": "2026-08-08T07:09:49.020Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 495
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "cf73ab56698101d172b847bbc18282da71f64647",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.020Z",
+      "updated_at": "2026-08-08T07:09:49.020Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 496
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "1abee3100d37387f2956ce565a607f0313e01025",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.020Z",
+      "updated_at": "2026-08-08T07:09:49.020Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 526
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "9913b71da27ac36d1db0bea0a6bd5c100b8ec0b5",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.021Z",
+      "updated_at": "2026-08-08T07:09:49.021Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 550
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "2efb82816e7777cfefd7d75d3b189229e724b6c3",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.021Z",
+      "updated_at": "2026-08-08T07:09:49.021Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 552
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "a7970caaf76a17cf3f7f364da0c1265b3f0c87d9",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.021Z",
+      "updated_at": "2026-08-08T07:09:49.021Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 553
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "014b1e1b37cc9ab17752b8867b663a5ce5dfb43a",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.021Z",
+      "updated_at": "2026-08-08T07:09:49.021Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 579
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "75463adc538f599b6492a1f9b54547dd994ef6f7",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.021Z",
+      "updated_at": "2026-08-08T07:09:49.021Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 582
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "588d16d826e19b1d8672e25c3204ab1ce60d6185",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.021Z",
+      "updated_at": "2026-08-08T07:09:49.021Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 603
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "a937790034c95451690300fe449d9b0c86ab67bc",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.021Z",
+      "updated_at": "2026-08-08T07:09:49.021Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 605
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "e5dd950f368a327e065a023db8a34a780249e2d7",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.021Z",
+      "updated_at": "2026-08-08T07:09:49.021Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 649
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "201a72452677a80ff9ee982e47ed7fd64fe97b1d",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.021Z",
+      "updated_at": "2026-08-08T07:09:49.021Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 667
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "0cf563278abf4a29aff46006aa06204b2ea7e758",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.022Z",
+      "updated_at": "2026-08-08T07:09:49.022Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 690
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "2295e7083638e5ad65de75ac043d13055833b1aa",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.022Z",
+      "updated_at": "2026-08-08T07:09:49.022Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 709
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "87a034335a3e831e8d1e23bd62e41849dd3e82d5",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.022Z",
+      "updated_at": "2026-08-08T07:09:49.022Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 726
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "9234a237061565de08eb3fd3501666c7f34674b9",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.022Z",
+      "updated_at": "2026-08-08T07:09:49.022Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 728
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "2a7127fafea6bd8447c24efca97221cb98169a7a",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.022Z",
+      "updated_at": "2026-08-08T07:09:49.022Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 747
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "bf9a6e671b4a9a0ab77de0a92a1e0ed64a420011",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.022Z",
+      "updated_at": "2026-08-08T07:09:49.022Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 748
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "45506d73aca2513cab06dfe8de037e7f5c073806",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.022Z",
+      "updated_at": "2026-08-08T07:09:49.022Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 751
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "123babfb33ee093c5cfff010d0f6c12f19a2bee4",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.022Z",
+      "updated_at": "2026-08-08T07:09:49.022Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 770
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "2adafe3ac37fafb6076ce1453a07a41a98e9039a",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.022Z",
+      "updated_at": "2026-08-08T07:09:49.022Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 772
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "c622431bd2487de0868684fb525214702e0d8530",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.022Z",
+      "updated_at": "2026-08-08T07:09:49.022Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 773
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "9fc8bee2f4444eeb6a05808bcac0a269ba112d7f",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.022Z",
+      "updated_at": "2026-08-08T07:09:49.022Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 776
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "9c2c04fe66ceab576eb7ef0c679dcb908ada4549",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.022Z",
+      "updated_at": "2026-08-08T07:09:49.022Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 823
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "89dfdd00bd95405fe9fdc1257dc6db22276034a8",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.023Z",
+      "updated_at": "2026-08-08T07:09:49.023Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 825
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "fcbb7d413636ed840764c5b1ec24c318eb70751d",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.023Z",
+      "updated_at": "2026-08-08T07:09:49.023Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 826
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "c50f3bd38fdf61744453b3d84a4931db9e0c4bf9",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.023Z",
+      "updated_at": "2026-08-08T07:09:49.023Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 884
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "3f9ca6ff7b3b632e46ed19284633ee8b5b36eb1b",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.023Z",
+      "updated_at": "2026-08-08T07:09:49.023Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 887
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "bd417d534f643dbc9dfba1aafa1031543105ac05",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.023Z",
+      "updated_at": "2026-08-08T07:09:49.023Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 901
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "7d8776bc9800cceaef089516c181c929e4b41fd2",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.023Z",
+      "updated_at": "2026-08-08T07:09:49.023Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 925
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "e2e01d2426d3e6753122ef5636c55d6409999b3f",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.023Z",
+      "updated_at": "2026-08-08T07:09:49.023Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 926
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "aeb665e341bfeb28298ec289f1b017cda05a0e01",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.023Z",
+      "updated_at": "2026-08-08T07:09:49.023Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 940
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "fc613353247b71d392e2e44a6eaf5feb510c65e7",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.023Z",
+      "updated_at": "2026-08-08T07:09:49.023Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 960
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "270e0a32a28a577f6abca22f208978649633377b",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.023Z",
+      "updated_at": "2026-08-08T07:09:49.023Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 1013
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "fa091f1c012ec13496717daa7ab7c5172d8c34f4",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.024Z",
+      "updated_at": "2026-08-08T07:09:49.024Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 1021
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "f529175b4de6735f03fe1cba7e61b65b45ff4ae2",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.024Z",
+      "updated_at": "2026-08-08T07:09:49.024Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 1072
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "d7943942e7cee674c70c614e4089b66c95480149",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.024Z",
+      "updated_at": "2026-08-08T07:09:49.024Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 1117
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "fcfd6b7e0c49d50473d2e46aa0076a3e568a5979",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.024Z",
+      "updated_at": "2026-08-08T07:09:49.024Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 1121
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "f0faa041b826650a573a2c5866f3befc2d867874",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.024Z",
+      "updated_at": "2026-08-08T07:09:49.024Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 1172
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "b736be79aae90541f5e7d4d325a2339ad0daf277",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.024Z",
+      "updated_at": "2026-08-08T07:09:49.024Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 1174
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "e4bf9437e631df0ed605d189e06efe2f9a1adabd",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.024Z",
+      "updated_at": "2026-08-08T07:09:49.024Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 1175
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "c601f7a78a76c2197658f6583b253631e429e359",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.024Z",
+      "updated_at": "2026-08-08T07:09:49.024Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 1256
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "2a8daa239781388ed4ff58e38c9fef7826ad1fe4",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.024Z",
+      "updated_at": "2026-08-08T07:09:49.024Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 1326
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "b2b082f12d04ce4a43726a8c29264524912e1041",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.025Z",
+      "updated_at": "2026-08-08T07:09:49.025Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 1328
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "44a7aa123a3fc79033ad9a98183d03e617ea256b",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.025Z",
+      "updated_at": "2026-08-08T07:09:49.025Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 1383
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "60dd509cb414da9a25c56f76ad4aa615396f1545",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.025Z",
+      "updated_at": "2026-08-08T07:09:49.025Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 1430
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "d65cdee4144b78b8aae7c44e44d941f530d8ba10",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.025Z",
+      "updated_at": "2026-08-08T07:09:49.025Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 1432
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "1ede27d3121b9d4f5384d0cdbb2a0abe7982fcc9",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.025Z",
+      "updated_at": "2026-08-08T07:09:49.025Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 1433
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "cf58395fcf3f446af7a060316f6aafbd34f4d643",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.025Z",
+      "updated_at": "2026-08-08T07:09:49.025Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 1437
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "7e48aa2d41faec5d59856e09194c43ff83075c38",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.025Z",
+      "updated_at": "2026-08-08T07:09:49.025Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 1652
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "ba1bd5a7d6245af3f6cf50c2b0cf0fef3f40d77e",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.025Z",
+      "updated_at": "2026-08-08T07:09:49.025Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 1654
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "6d5639ea1736deccd41685a12c2b6e1e9b87e3f8",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.025Z",
+      "updated_at": "2026-08-08T07:09:49.025Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 1655
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "84eabd846164bbbd1f9d0db4c48286b6378eb470",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.025Z",
+      "updated_at": "2026-08-08T07:09:49.025Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 1666
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "0697a51bcadebdfc1c9946581fbd2336e0a6f7ee",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.025Z",
+      "updated_at": "2026-08-08T07:09:49.025Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 1679
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "d9d7ae17439ccf8c2556d661ed45a37c05ccfdfb",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.025Z",
+      "updated_at": "2026-08-08T07:09:49.025Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 1690
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "a967c0be29cffc4a4a6c065f85a8cc35a8210aec",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.025Z",
+      "updated_at": "2026-08-08T07:09:49.025Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 1701
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "d1f2e5e3e9af69ff849bb233aca18434faaedd9f",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.025Z",
+      "updated_at": "2026-08-08T07:09:49.025Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 1724
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "18abae206decf6d25a0c96d29217251398e3b3fd",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.026Z",
+      "updated_at": "2026-08-08T07:09:49.026Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 1757
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "ab550111b7532b0b46e4db7caad7818b31319560",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.026Z",
+      "updated_at": "2026-08-08T07:09:49.026Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 1787
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "4e90463a4b344958e8222b5774d804102ae9bda1",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.026Z",
+      "updated_at": "2026-08-08T07:09:49.026Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 1788
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "74b88a66a1db968904d9656a07431f0c037f8b61",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.026Z",
+      "updated_at": "2026-08-08T07:09:49.026Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 1795
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "f5a96658d418cbaf42a7a6059346bcb07fbf1bc9",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.026Z",
+      "updated_at": "2026-08-08T07:09:49.026Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 1812
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "d6a20dabb3219d5c7916302c36fbf9064ac2c612",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.026Z",
+      "updated_at": "2026-08-08T07:09:49.026Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 1924
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "afa15de29b57098b75dd29130e6e10b32f28ed58",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.026Z",
+      "updated_at": "2026-08-08T07:09:49.026Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 1929
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "44496d5bae34d9ec8026290b9afe667578491378",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.026Z",
+      "updated_at": "2026-08-08T07:09:49.026Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 1978
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "0f343e58b4bbdd46dd3008d89f92b7b1521ef2c1",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.026Z",
+      "updated_at": "2026-08-08T07:09:49.026Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 1980
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "c64aaceb12cae90df3efb034bc64e5c797d2586d",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.026Z",
+      "updated_at": "2026-08-08T07:09:49.026Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2046
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "27274499e781e557f6a43043d38fa04ed50f1643",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.027Z",
+      "updated_at": "2026-08-08T07:09:49.027Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2048
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "73a42ce98a586d9fefd2321155dcaf1cddb3f317",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.027Z",
+      "updated_at": "2026-08-08T07:09:49.027Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2172
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "4be0183ccba5631cd9897a009cc3e17e88bcdafb",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.027Z",
+      "updated_at": "2026-08-08T07:09:49.027Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2175
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "2d59dc082207b069a7c316c5db45d98850362654",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.027Z",
+      "updated_at": "2026-08-08T07:09:49.027Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2225
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "2bf027457386117721283bed2fc05a54da47f371",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.027Z",
+      "updated_at": "2026-08-08T07:09:49.027Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2274
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "b410dc0d5f0ca1af8635c8d2f1cbcdbb7b86689e",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.027Z",
+      "updated_at": "2026-08-08T07:09:49.027Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2276
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "8b6c3ee15fa903892d8e91d196bebd90180b0625",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.027Z",
+      "updated_at": "2026-08-08T07:09:49.027Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2277
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "3d2e826706ff52387e802978f9bf9ab4636ae188",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.027Z",
+      "updated_at": "2026-08-08T07:09:49.027Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2326
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "94f4c44b184f30317e480dbc6717eb79c2e1d023",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.027Z",
+      "updated_at": "2026-08-08T07:09:49.027Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2341
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "347bfd4c3e451f2f919b540719f843011ab92751",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.027Z",
+      "updated_at": "2026-08-08T07:09:49.027Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2342
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "6786b2a26643637733547fc96f292d315f46783a",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.027Z",
+      "updated_at": "2026-08-08T07:09:49.027Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2349
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "5d156ba1b14722bb865216615a0b5b13022fa18e",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.027Z",
+      "updated_at": "2026-08-08T07:09:49.027Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2390
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "bd4dc0fb82a1d246e3b5971d128d5d410e835da5",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.028Z",
+      "updated_at": "2026-08-08T07:09:49.028Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2392
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "b541cd4ac2b13af479e7ee7344ffc1db989fb63c",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.028Z",
+      "updated_at": "2026-08-08T07:09:49.028Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2393
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "ce93b8adb5ca9c12897520b716a57020f648a3fe",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.028Z",
+      "updated_at": "2026-08-08T07:09:49.028Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2445
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "d0120dec5a45f76982b0827d230ccac75d49a946",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.028Z",
+      "updated_at": "2026-08-08T07:09:49.028Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2475
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "95bebb9a523f679dcf58422df9ae000e2ec27036",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.028Z",
+      "updated_at": "2026-08-08T07:09:49.028Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2477
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "0e6e3d2cec2716da10b030fd27865aaa5418792d",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.028Z",
+      "updated_at": "2026-08-08T07:09:49.028Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2478
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "bbcca2e5565be57de86e4dfcddc41dad9309da1c",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.028Z",
+      "updated_at": "2026-08-08T07:09:49.028Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2538
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "c9c6cea813578ab4635118016deda9259473f48c",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.028Z",
+      "updated_at": "2026-08-08T07:09:49.028Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2550
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "125b4433da2582f836349ebe531e923c65e9a479",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.028Z",
+      "updated_at": "2026-08-08T07:09:49.028Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2566
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "fc237054bb927cba6aa6fb75dec59bef106dc53b",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.028Z",
+      "updated_at": "2026-08-08T07:09:49.028Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2568
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "61309bb54cfbb9bc5e247c9b811ab7d6483e25e5",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.028Z",
+      "updated_at": "2026-08-08T07:09:49.028Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2569
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "8af6643076c00e8c2381cedcd0bb0575452b7f23",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.028Z",
+      "updated_at": "2026-08-08T07:09:49.028Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2622
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "4d6c8fbfc60a375bae9d45ceeb2a66485867419b",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.028Z",
+      "updated_at": "2026-08-08T07:09:49.028Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2670
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "99eeb921aeb27c37023ddac0377723b1e145260b",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.029Z",
+      "updated_at": "2026-08-08T07:09:49.029Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2673
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "461684985ac2d9b880cb701c2741461bedc06490",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.029Z",
+      "updated_at": "2026-08-08T07:09:49.029Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2708
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "4618163631660dd0041b8a7acb41454ed26d0400",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.029Z",
+      "updated_at": "2026-08-08T07:09:49.029Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2714
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "1dc0592a652bbe1aa36b6d652cfc6f03371261fe",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.029Z",
+      "updated_at": "2026-08-08T07:09:49.029Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2717
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "3b5de3a1e7b752c1ee3fe6221777961eeee29c7e",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.029Z",
+      "updated_at": "2026-08-08T07:09:49.029Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2721
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "2ff3ed5623ae549ce0f34497b6c972b66494c1f7",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.029Z",
+      "updated_at": "2026-08-08T07:09:49.029Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2781
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "a5ce518bf010ec55e396eea6d22836ad1860ac71",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.029Z",
+      "updated_at": "2026-08-08T07:09:49.029Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2819
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "14cf420ab69450325efcba7d22f274a5a460302c",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.029Z",
+      "updated_at": "2026-08-08T07:09:49.029Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2822
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "84de39920982088f906da8ad0fbfbd47ff6ce3d2",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.029Z",
+      "updated_at": "2026-08-08T07:09:49.029Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2828
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "cb458f2b8331382268e2a41fadccde1c441dd390",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.029Z",
+      "updated_at": "2026-08-08T07:09:49.029Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2838
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "ddf2dea41cd60237c68f196d0865dfdc8a4c00e8",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.030Z",
+      "updated_at": "2026-08-08T07:09:49.030Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2842
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "e8a48dd9b817f41f3e14df4e2cf22857a05e5455",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.030Z",
+      "updated_at": "2026-08-08T07:09:49.030Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2846
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "7cabef31497a8b86347d453481139a7524926898",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.030Z",
+      "updated_at": "2026-08-08T07:09:49.030Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2849
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "0b724d304ec7b3b03610c3310f5b3a900b1a9fb7",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.030Z",
+      "updated_at": "2026-08-08T07:09:49.030Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2850
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "c43fa011a6f3d842443088eb2e446995cb907491",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.030Z",
+      "updated_at": "2026-08-08T07:09:49.030Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2852
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "65256f6b33dfd353930785bcfef9756e015a143e",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.030Z",
+      "updated_at": "2026-08-08T07:09:49.030Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2869
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "6f3ca0f2d2cc86570a7d59e6133163e8617ff9f7",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.030Z",
+      "updated_at": "2026-08-08T07:09:49.030Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2948
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "a7f2f2c4bdc89129a7f07aa76c1ce7c869d2edb2",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.030Z",
+      "updated_at": "2026-08-08T07:09:49.030Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2950
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "285516f7382d23a13b234023cc848cd6f7521c3e",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.030Z",
+      "updated_at": "2026-08-08T07:09:49.030Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2951
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "4fd377cac40d0d9b6f31422fbc2ecdd5ce3db5e8",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.030Z",
+      "updated_at": "2026-08-08T07:09:49.030Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2964
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "07defb0061babbe6e6f13dac654e8d09776f4eed",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.030Z",
+      "updated_at": "2026-08-08T07:09:49.030Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 2984
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "ca04674d3ed29763aa3e6254eebccd01a28959e7",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.030Z",
+      "updated_at": "2026-08-08T07:09:49.030Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 3008
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "007e3522ce4c81d7471ec5f304a7b69ea4befd69",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.031Z",
+      "updated_at": "2026-08-08T07:09:49.031Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 3010
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "4f38da6db247dec251ef0ccd69a997850eb42290",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.031Z",
+      "updated_at": "2026-08-08T07:09:49.031Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 3011
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "9e2bcbb9d181ff4e18e71f90d9e3335e0d01999a",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.031Z",
+      "updated_at": "2026-08-08T07:09:49.031Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 3100
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "77039f39484d9a31c3fde1eba1c5c40a716c8631",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.031Z",
+      "updated_at": "2026-08-08T07:09:49.031Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 3149
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "fdaa7beafd74bb55505bdd5ace9fcb898807992a",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.031Z",
+      "updated_at": "2026-08-08T07:09:49.031Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 3206
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "cbb3ea509ddf4ef86cf4f199b052163ac5105cd1",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.031Z",
+      "updated_at": "2026-08-08T07:09:49.031Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 3208
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "5698b3f767ba3606c94c0253749f1e63b27b1299",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.031Z",
+      "updated_at": "2026-08-08T07:09:49.031Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 3209
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "b3363dacad07505e6fcbaf75dd7588a16a6f30c7",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.031Z",
+      "updated_at": "2026-08-08T07:09:49.031Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 3259
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "1c22383edb36a3813ca760c9bc0edaf42f358e11",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.031Z",
+      "updated_at": "2026-08-08T07:09:49.031Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 3283
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "de5edd89ba8908fdc0631fa6888568019bde0a8a",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.031Z",
+      "updated_at": "2026-08-08T07:09:49.031Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 3321
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "aaa290e070513b8df0b4c647482f11b469b02a35",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.031Z",
+      "updated_at": "2026-08-08T07:09:49.031Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 3371
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "36c5f1c2d5ac19be6a4e3fe8c4acc8e6803942b9",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.031Z",
+      "updated_at": "2026-08-08T07:09:49.031Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 3373
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "0b140b18ec6132b6b3ee5c23ed09bed2700d6fa4",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.032Z",
+      "updated_at": "2026-08-08T07:09:49.032Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 3374
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "d0d97e224d7cffd0cf9758cc23afd8e0162bb496",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.032Z",
+      "updated_at": "2026-08-08T07:09:49.032Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 3409
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "6260fd5e53cca8355896aa56870be7f232f62245",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.032Z",
+      "updated_at": "2026-08-08T07:09:49.032Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 3460
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "4556e239009ccc8b2128d45fe055422080e90747",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.032Z",
+      "updated_at": "2026-08-08T07:09:49.032Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 3462
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "76eeeaa53dc9339ce80d2cdb9941cf95fb9cc346",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.032Z",
+      "updated_at": "2026-08-08T07:09:49.032Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 3463
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "8929f1b2c97219b90c6e485895d754f3d7a4d92f",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.032Z",
+      "updated_at": "2026-08-08T07:09:49.032Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 3581
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "443ac9ac15f9c91c80cafead628b4936b3f070ee",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.032Z",
+      "updated_at": "2026-08-08T07:09:49.032Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 3583
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "a2ca0a6fa0e5988a137f950cd53dac253d77f5ea",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.032Z",
+      "updated_at": "2026-08-08T07:09:49.032Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "supabase/functions/ai-execute-tool/index.ts",
+        "line": 3585
+      },
+      "title": "@typescript-eslint/no-explicit-any in index.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/supabase/functions/ai-execute-tool/index.ts"
+      ],
+      "id": "c6c6b76b546433618741bb5bff388b05fb154e81",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.032Z",
+      "updated_at": "2026-08-08T07:09:49.032Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/e2e/permissions-roles.spec.ts",
+        "line": 10
+      },
+      "title": "@typescript-eslint/no-explicit-any in permissions-roles.spec.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/e2e/permissions-roles.spec.ts"
+      ],
+      "id": "f6752c6ad18d105b863130ea73bafdcf20b05826",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.048Z",
+      "updated_at": "2026-08-08T07:09:49.048Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/e2e/permissions-roles.spec.ts",
+        "line": 13
+      },
+      "title": "@typescript-eslint/no-explicit-any in permissions-roles.spec.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/e2e/permissions-roles.spec.ts"
+      ],
+      "id": "a86190ad1214370790c3d716ebe6a9e66bd2ebf8",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.048Z",
+      "updated_at": "2026-08-08T07:09:49.048Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/e2e/permissions-roles.spec.ts",
+        "line": 16
+      },
+      "title": "@typescript-eslint/no-explicit-any in permissions-roles.spec.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/e2e/permissions-roles.spec.ts"
+      ],
+      "id": "7046837175febbffaec12d3d4bc38e36c0c36399",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.048Z",
+      "updated_at": "2026-08-08T07:09:49.048Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/e2e/template-hours-cascade.spec.ts",
+        "line": 36
+      },
+      "title": "@typescript-eslint/no-explicit-any in template-hours-cascade.spec.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/e2e/template-hours-cascade.spec.ts"
+      ],
+      "id": "4d5e3dde93878659f705e5c36d241af90b241b99",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.058Z",
+      "updated_at": "2026-08-08T07:09:49.058Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/e2e/template-hours-cascade.spec.ts",
+        "line": 77
+      },
+      "title": "@typescript-eslint/no-explicit-any in template-hours-cascade.spec.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/e2e/template-hours-cascade.spec.ts"
+      ],
+      "id": "85a27effbdca2b8f17ed90e18016982401672bc7",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.058Z",
+      "updated_at": "2026-08-08T07:09:49.058Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/e2e/template-hours-cascade.spec.ts",
+        "line": 97
+      },
+      "title": "@typescript-eslint/no-explicit-any in template-hours-cascade.spec.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/e2e/template-hours-cascade.spec.ts"
+      ],
+      "id": "253a3ba64693c57db96082f599b5ad9c9527ad84",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.058Z",
+      "updated_at": "2026-08-08T07:09:49.058Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/e2e/template-hours-cascade.spec.ts",
+        "line": 149
+      },
+      "title": "@typescript-eslint/no-explicit-any in template-hours-cascade.spec.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/e2e/template-hours-cascade.spec.ts"
+      ],
+      "id": "db744017fa21fff59eef25857d1d36ec03dbfaaf",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.058Z",
+      "updated_at": "2026-08-08T07:09:49.058Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/e2e/template-hours-cascade.spec.ts",
+        "line": 174
+      },
+      "title": "@typescript-eslint/no-explicit-any in template-hours-cascade.spec.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/e2e/template-hours-cascade.spec.ts"
+      ],
+      "id": "570120f3c0737442cd8dabe1e53d29651a961ab0",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.058Z",
+      "updated_at": "2026-08-08T07:09:49.058Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/e2e/template-hours-cascade.spec.ts",
+        "line": 227
+      },
+      "title": "@typescript-eslint/no-explicit-any in template-hours-cascade.spec.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/e2e/template-hours-cascade.spec.ts"
+      ],
+      "id": "8eac6aa59ab47483ca41708a23a0589e98999436",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.058Z",
+      "updated_at": "2026-08-08T07:09:49.058Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/e2e/template-hours-cascade.spec.ts",
+        "line": 281
+      },
+      "title": "@typescript-eslint/no-explicit-any in template-hours-cascade.spec.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/e2e/template-hours-cascade.spec.ts"
+      ],
+      "id": "ed345a853f4a1b43144ed4101f11c278e6df3a5a",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.058Z",
+      "updated_at": "2026-08-08T07:09:49.058Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/e2e/template-hours-cascade.spec.ts",
+        "line": 294
+      },
+      "title": "@typescript-eslint/no-explicit-any in template-hours-cascade.spec.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/e2e/template-hours-cascade.spec.ts"
+      ],
+      "id": "3ed568f1079e302c00bc4319ec97fab899fd5d11",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.058Z",
+      "updated_at": "2026-08-08T07:09:49.058Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/e2e/template-hours-cascade.spec.ts",
+        "line": 323
+      },
+      "title": "@typescript-eslint/no-explicit-any in template-hours-cascade.spec.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/e2e/template-hours-cascade.spec.ts"
+      ],
+      "id": "00d2f2ee040935e7f8ad1708c95e26ae8a8a54ed",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.059Z",
+      "updated_at": "2026-08-08T07:09:49.059Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/e2e/template-hours-cascade.spec.ts",
+        "line": 370
+      },
+      "title": "@typescript-eslint/no-explicit-any in template-hours-cascade.spec.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/e2e/template-hours-cascade.spec.ts"
+      ],
+      "id": "47e92fe2d7bc949567fd2462f3e43bab8a32efbe",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.059Z",
+      "updated_at": "2026-08-08T07:09:49.059Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/e2e/template-hours-cascade.spec.ts",
+        "line": 403
+      },
+      "title": "@typescript-eslint/no-explicit-any in template-hours-cascade.spec.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/e2e/template-hours-cascade.spec.ts"
+      ],
+      "id": "d137709e2ebd84bd1c75514c145f483a62e46890",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.059Z",
+      "updated_at": "2026-08-08T07:09:49.059Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/e2e/template-hours-cascade.spec.ts",
+        "line": 452
+      },
+      "title": "@typescript-eslint/no-explicit-any in template-hours-cascade.spec.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/e2e/template-hours-cascade.spec.ts"
+      ],
+      "id": "15b4e78828034c32d5098e587e67fd892cc10ef6",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.059Z",
+      "updated_at": "2026-08-08T07:09:49.059Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/e2e/template-hours-cascade.spec.ts",
+        "line": 477
+      },
+      "title": "@typescript-eslint/no-explicit-any in template-hours-cascade.spec.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/e2e/template-hours-cascade.spec.ts"
+      ],
+      "id": "10825a907dcda3ce8a8db082218ed54dc8a54984",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.059Z",
+      "updated_at": "2026-08-08T07:09:49.059Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/e2e/template-hours-cascade.spec.ts",
+        "line": 522
+      },
+      "title": "@typescript-eslint/no-explicit-any in template-hours-cascade.spec.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/e2e/template-hours-cascade.spec.ts"
+      ],
+      "id": "5d778a70227010a8d9471352b9a08ef0ce6bde33",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.059Z",
+      "updated_at": "2026-08-08T07:09:49.059Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/e2e/template-hours-cascade.spec.ts",
+        "line": 559
+      },
+      "title": "@typescript-eslint/no-explicit-any in template-hours-cascade.spec.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/e2e/template-hours-cascade.spec.ts"
+      ],
+      "id": "97600c09da7f5d1f4b81a2a926b95c632394e6b2",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.059Z",
+      "updated_at": "2026-08-08T07:09:49.059Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/e2e/template-hours-cascade.spec.ts",
+        "line": 583
+      },
+      "title": "@typescript-eslint/no-explicit-any in template-hours-cascade.spec.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/e2e/template-hours-cascade.spec.ts"
+      ],
+      "id": "2de94d93c47c6c51fff64e447c74a27ca0a10a8d",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.059Z",
+      "updated_at": "2026-08-08T07:09:49.059Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/helpers/e2e-supabase.ts",
+        "line": 38
+      },
+      "title": "@typescript-eslint/no-explicit-any in e2e-supabase.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/helpers/e2e-supabase.ts"
+      ],
+      "id": "8f495be562fd16b176ec33dc45604ba8036cca6a",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.059Z",
+      "updated_at": "2026-08-08T07:09:49.059Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/helpers/e2e-supabase.ts",
+        "line": 41
+      },
+      "title": "@typescript-eslint/no-explicit-any in e2e-supabase.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/helpers/e2e-supabase.ts"
+      ],
+      "id": "a057132f9708b05be3017a00bd066c912b004aaf",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.059Z",
+      "updated_at": "2026-08-08T07:09:49.059Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/helpers/e2e-supabase.ts",
+        "line": 52
+      },
+      "title": "@typescript-eslint/no-explicit-any in e2e-supabase.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/helpers/e2e-supabase.ts"
+      ],
+      "id": "45cf7a25ecd5a3da108196afc6e0fa87b7836795",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.059Z",
+      "updated_at": "2026-08-08T07:09:49.059Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/helpers/e2e-supabase.ts",
+        "line": 54
+      },
+      "title": "@typescript-eslint/no-explicit-any in e2e-supabase.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/helpers/e2e-supabase.ts"
+      ],
+      "id": "5461d6208c8f50a6452181f4b77607f1ae3f97c6",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.059Z",
+      "updated_at": "2026-08-08T07:09:49.059Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/helpers/e2e-supabase.ts",
+        "line": 81
+      },
+      "title": "@typescript-eslint/no-explicit-any in e2e-supabase.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/helpers/e2e-supabase.ts"
+      ],
+      "id": "e992a8b7be0d9158313ceff2aa78cf5bc97d768c",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.060Z",
+      "updated_at": "2026-08-08T07:09:49.060Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/helpers/e2e-supabase.ts",
+        "line": 96
+      },
+      "title": "@typescript-eslint/no-explicit-any in e2e-supabase.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/helpers/e2e-supabase.ts"
+      ],
+      "id": "160c01038046370dcb330c4cee0a65406eb12b36",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.060Z",
+      "updated_at": "2026-08-08T07:09:49.060Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/helpers/e2e-supabase.ts",
+        "line": 117
+      },
+      "title": "@typescript-eslint/no-explicit-any in e2e-supabase.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/helpers/e2e-supabase.ts"
+      ],
+      "id": "276a29e2dcd098bbf704a729645c61f6bb4b4c29",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.060Z",
+      "updated_at": "2026-08-08T07:09:49.060Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/helpers/e2e-supabase.ts",
+        "line": 132
+      },
+      "title": "@typescript-eslint/no-explicit-any in e2e-supabase.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/helpers/e2e-supabase.ts"
+      ],
+      "id": "6e903f1d314784f8fbd0e8ec66520bcc710dbd53",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.060Z",
+      "updated_at": "2026-08-08T07:09:49.060Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/helpers/e2e-supabase.ts",
+        "line": 150
+      },
+      "title": "@typescript-eslint/no-explicit-any in e2e-supabase.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/helpers/e2e-supabase.ts"
+      ],
+      "id": "b57beee186f2497b9b82292c4ba14da962d6836f",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.060Z",
+      "updated_at": "2026-08-08T07:09:49.060Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/helpers/e2e-supabase.ts",
+        "line": 179
+      },
+      "title": "@typescript-eslint/no-explicit-any in e2e-supabase.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/helpers/e2e-supabase.ts"
+      ],
+      "id": "f0587925a270a1fc60f4786cfeaf32ddec6400fd",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.060Z",
+      "updated_at": "2026-08-08T07:09:49.060Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/helpers/e2e-supabase.ts",
+        "line": 188
+      },
+      "title": "@typescript-eslint/no-explicit-any in e2e-supabase.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/helpers/e2e-supabase.ts"
+      ],
+      "id": "b756fae3ec63a591f42820466817185b2da9e111",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.060Z",
+      "updated_at": "2026-08-08T07:09:49.060Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/helpers/e2e-supabase.ts",
+        "line": 197
+      },
+      "title": "@typescript-eslint/no-explicit-any in e2e-supabase.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/helpers/e2e-supabase.ts"
+      ],
+      "id": "97a57e5c8af0df1061631d7a973b794d99e5c18a",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.060Z",
+      "updated_at": "2026-08-08T07:09:49.060Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/helpers/e2e-supabase.ts",
+        "line": 213
+      },
+      "title": "@typescript-eslint/no-explicit-any in e2e-supabase.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/helpers/e2e-supabase.ts"
+      ],
+      "id": "42840ec399d49168613c3fb570fa8281afd397c8",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.061Z",
+      "updated_at": "2026-08-08T07:09:49.061Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/helpers/e2e-supabase.ts",
+        "line": 228
+      },
+      "title": "@typescript-eslint/no-explicit-any in e2e-supabase.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/helpers/e2e-supabase.ts"
+      ],
+      "id": "45a312d28b2d0a0b58ee786e35250a9d9b475aa2",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.061Z",
+      "updated_at": "2026-08-08T07:09:49.061Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/helpers/e2e-supabase.ts",
+        "line": 271
+      },
+      "title": "@typescript-eslint/no-explicit-any in e2e-supabase.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/helpers/e2e-supabase.ts"
+      ],
+      "id": "c4142d9220162c9e7438e1cab5be7709b5cfdecc",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.061Z",
+      "updated_at": "2026-08-08T07:09:49.061Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/helpers/e2e-supabase.ts",
+        "line": 330
+      },
+      "title": "@typescript-eslint/no-explicit-any in e2e-supabase.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/helpers/e2e-supabase.ts"
+      ],
+      "id": "66e978543cff005290c1cad3c955c6a5ea0a8167",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.061Z",
+      "updated_at": "2026-08-08T07:09:49.061Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/helpers/e2e-supabase.ts",
+        "line": 496
+      },
+      "title": "@typescript-eslint/no-explicit-any in e2e-supabase.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/helpers/e2e-supabase.ts"
+      ],
+      "id": "c195748192536a285596e8ac27a3afe00126ff08",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.061Z",
+      "updated_at": "2026-08-08T07:09:49.061Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/helpers/e2e-supabase.ts",
+        "line": 532
+      },
+      "title": "@typescript-eslint/no-explicit-any in e2e-supabase.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/helpers/e2e-supabase.ts"
+      ],
+      "id": "18e82a8cc36fac88fc8a8ec7623aeaa736f56d9d",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.061Z",
+      "updated_at": "2026-08-08T07:09:49.061Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/helpers/e2e-supabase.ts",
+        "line": 545
+      },
+      "title": "@typescript-eslint/no-explicit-any in e2e-supabase.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/helpers/e2e-supabase.ts"
+      ],
+      "id": "7287f52060cd2b93149f489d1511c37338c6adc6",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.061Z",
+      "updated_at": "2026-08-08T07:09:49.061Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/helpers/e2e-supabase.ts",
+        "line": 622
+      },
+      "title": "@typescript-eslint/no-explicit-any in e2e-supabase.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/helpers/e2e-supabase.ts"
+      ],
+      "id": "5378a97502879bf946b6acbdab3a41f6b49fee0b",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.061Z",
+      "updated_at": "2026-08-08T07:09:49.061Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/helpers/e2e-supabase.ts",
+        "line": 649
+      },
+      "title": "@typescript-eslint/no-explicit-any in e2e-supabase.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/helpers/e2e-supabase.ts"
+      ],
+      "id": "4dfdef28785c2ca314905c9183290334b5be6f9f",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.061Z",
+      "updated_at": "2026-08-08T07:09:49.061Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/helpers/e2e-supabase.ts",
+        "line": 667
+      },
+      "title": "@typescript-eslint/no-explicit-any in e2e-supabase.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/helpers/e2e-supabase.ts"
+      ],
+      "id": "41cc39598c47df0d1c512c582b780e59c0b0a253",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.061Z",
+      "updated_at": "2026-08-08T07:09:49.061Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/helpers/e2e-supabase.ts",
+        "line": 901
+      },
+      "title": "@typescript-eslint/no-explicit-any in e2e-supabase.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/helpers/e2e-supabase.ts"
+      ],
+      "id": "29a9517c6e77976856c60ff9d961dbe8a89b18cd",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.061Z",
+      "updated_at": "2026-08-08T07:09:49.061Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/helpers/e2e-supabase.ts",
+        "line": 946
+      },
+      "title": "@typescript-eslint/no-explicit-any in e2e-supabase.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/helpers/e2e-supabase.ts"
+      ],
+      "id": "91e122a417e269bd98e9789a0eb93422cde7f7f5",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.061Z",
+      "updated_at": "2026-08-08T07:09:49.061Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/helpers/e2e-supabase.ts",
+        "line": 1016
+      },
+      "title": "@typescript-eslint/no-explicit-any in e2e-supabase.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/helpers/e2e-supabase.ts"
+      ],
+      "id": "613fc34be18afb4c66072471de36690ab4c90461",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.062Z",
+      "updated_at": "2026-08-08T07:09:49.062Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/helpers/e2e-supabase.ts",
+        "line": 1202
+      },
+      "title": "@typescript-eslint/no-explicit-any in e2e-supabase.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/helpers/e2e-supabase.ts"
+      ],
+      "id": "216dec11306f3737bf4baf4afcece23ac7da184b",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.062Z",
+      "updated_at": "2026-08-08T07:09:49.062Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/helpers/e2e-supabase.ts",
+        "line": 1205
+      },
+      "title": "@typescript-eslint/no-explicit-any in e2e-supabase.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/helpers/e2e-supabase.ts"
+      ],
+      "id": "ec7932e868f42bfa9fc26a5f5c5c0d09363616e3",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.062Z",
+      "updated_at": "2026-08-08T07:09:49.062Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 135
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "9b175acc7a326af2369c2c401c9c2d256b6a4ece",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.071Z",
+      "updated_at": "2026-08-08T07:09:49.071Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 162
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "7c6e5c88622bbc1a515c33b0ba8fa3f1118b2961",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.071Z",
+      "updated_at": "2026-08-08T07:09:49.071Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 178
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "814c27d588da1ff13ea8e333c6724b942022b882",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.071Z",
+      "updated_at": "2026-08-08T07:09:49.071Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 198
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "c51dddb6c494f1975a782197c5ee6c6fe1402eb9",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.071Z",
+      "updated_at": "2026-08-08T07:09:49.071Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 222
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "f877df1231433165074b20f38e538d2711071a93",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.071Z",
+      "updated_at": "2026-08-08T07:09:49.071Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 245
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "b89785d6a318121e0975fc1f5e72f900a8a097d7",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.071Z",
+      "updated_at": "2026-08-08T07:09:49.071Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 271
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "54a5d8525f6d4c02b46b6198373018a91597579c",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.071Z",
+      "updated_at": "2026-08-08T07:09:49.071Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 292
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "711b6cdbaae7ef39ad27dfeef43084359173a841",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.071Z",
+      "updated_at": "2026-08-08T07:09:49.071Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 315
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "148c64afdac336f194098dfec1bf481d2e414a75",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.071Z",
+      "updated_at": "2026-08-08T07:09:49.071Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 340
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "532867bb91d645a32b1c527df09aad07545b1db2",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.071Z",
+      "updated_at": "2026-08-08T07:09:49.071Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 363
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "e0c3632bc77b55bc8fdaf9171e43fce3e26f6f86",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.071Z",
+      "updated_at": "2026-08-08T07:09:49.071Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 386
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "cf5490fa4f0a7212fff27d7c6c8f131d7ab09674",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.071Z",
+      "updated_at": "2026-08-08T07:09:49.071Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 407
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "4320b597bccc1e472e1bb6b48fd39207d1fc23fa",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.071Z",
+      "updated_at": "2026-08-08T07:09:49.071Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 428
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "df4c59c6628ba38458cc3fcbab34b9c9efe6cbf0",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.072Z",
+      "updated_at": "2026-08-08T07:09:49.072Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 448
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "c04187dfef5559cd63879d024fc93e7e2207e92e",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.072Z",
+      "updated_at": "2026-08-08T07:09:49.072Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 476
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "09906814902aed2a62ceec0c0cebffea0a050f9a",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.072Z",
+      "updated_at": "2026-08-08T07:09:49.072Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 506
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "d1ec25e113af2f6dffa4c56f92c8185903962cc8",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.072Z",
+      "updated_at": "2026-08-08T07:09:49.072Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 537
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "a90bd931660eecd4b7ae57041a5f8c637a0100dd",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.072Z",
+      "updated_at": "2026-08-08T07:09:49.072Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 574
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "8f722c4a8b0720f4daedb78a86c00f709e0b21b9",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.072Z",
+      "updated_at": "2026-08-08T07:09:49.072Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 605
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "60bb66d590a612d055f9bcbecf4ed4f941e21836",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.072Z",
+      "updated_at": "2026-08-08T07:09:49.072Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 625
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "96ce9e3d9937ae877bab69f0046561c0a419c648",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.072Z",
+      "updated_at": "2026-08-08T07:09:49.072Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 648
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "f9648800372d6d8d8bac03dd0c5dd75665129ccd",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.072Z",
+      "updated_at": "2026-08-08T07:09:49.072Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 673
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "df6ac1a92db54930bd364a8e26dcf66fe9580f53",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.072Z",
+      "updated_at": "2026-08-08T07:09:49.072Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 688
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "9ee46812702a76f8ecced6dc7cc76e5375055a1e",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.072Z",
+      "updated_at": "2026-08-08T07:09:49.072Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 698
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "ee31a37fd68d830b53461ebc5b07ae669b421af1",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.072Z",
+      "updated_at": "2026-08-08T07:09:49.072Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 702
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "03b60aced3d33e278a4bdb42142f3ee2b9298a38",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.072Z",
+      "updated_at": "2026-08-08T07:09:49.072Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 722
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "784b89c625d0069a3c14184f34b995e7caa4dad9",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.072Z",
+      "updated_at": "2026-08-08T07:09:49.072Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 729
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "239dad43c7ee62920ab12468c716d692d8a66e99",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.073Z",
+      "updated_at": "2026-08-08T07:09:49.073Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 770
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "1e1d48bb69748e9a4dfc06c2b733429b45266162",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.073Z",
+      "updated_at": "2026-08-08T07:09:49.073Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 793
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "0096197cec20662e60250f3041be3508881d5581",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.073Z",
+      "updated_at": "2026-08-08T07:09:49.073Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 809
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "508388aa28b485ceec0159f125bd2a90031fc9f0",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.073Z",
+      "updated_at": "2026-08-08T07:09:49.073Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 842
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "facc8d13e410e2cf8a8520e9b9388376b2c66126",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.073Z",
+      "updated_at": "2026-08-08T07:09:49.073Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 870
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "c38dea61f0e0c6caa972cff43eb44f6d28c69687",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.073Z",
+      "updated_at": "2026-08-08T07:09:49.073Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 901
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "cd44c0c0c127c18c1670f69f81f49022e4369957",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.073Z",
+      "updated_at": "2026-08-08T07:09:49.073Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 980
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "5e3f6ec32e7f885535200b6d78c5e6edc7a8e51b",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.073Z",
+      "updated_at": "2026-08-08T07:09:49.073Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 981
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "dd950973e101ae27d54a518404d17026864d4fe0",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.073Z",
+      "updated_at": "2026-08-08T07:09:49.073Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 1030
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "1f34060b909134324d4d99293c4e7624c29f5450",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.073Z",
+      "updated_at": "2026-08-08T07:09:49.073Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 1053
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "fbb0a51b5142003e70155fd60a9dae077ef94f0c",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.073Z",
+      "updated_at": "2026-08-08T07:09:49.073Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 1057
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "d100085537b21499078bc8ed0beab311c13c70bd",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.073Z",
+      "updated_at": "2026-08-08T07:09:49.073Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 1083
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "0ecc9412edbedf26b3b1278a4bcced95d3fd64e6",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.073Z",
+      "updated_at": "2026-08-08T07:09:49.073Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 1095
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "ef5f71be3048f1ea8258b9512b5480eb1d9c9815",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.073Z",
+      "updated_at": "2026-08-08T07:09:49.073Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 1119
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "610bfadbe049f6b356d5ee4736a53f39cd1712fc",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.074Z",
+      "updated_at": "2026-08-08T07:09:49.074Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 1139
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "9eef868a8c2160b66c54d0206d514d6b282957af",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.074Z",
+      "updated_at": "2026-08-08T07:09:49.074Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 1161
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "45cba6fe53da06f25c6a0ac919a75bbd8d2b7ead",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.074Z",
+      "updated_at": "2026-08-08T07:09:49.074Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 1183
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "9cb3450c62c8fbd4523966666e71bac8987dfea0",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.074Z",
+      "updated_at": "2026-08-08T07:09:49.074Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 1214
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "04cb21cf2e7f3011dc10037276e250707dbddee3",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.074Z",
+      "updated_at": "2026-08-08T07:09:49.074Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 1248
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "4f32d82d978b01cedeacd67cfcf9e61a815e71d8",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.074Z",
+      "updated_at": "2026-08-08T07:09:49.074Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useShiftTemplates.test.ts",
+        "line": 1271
+      },
+      "title": "@typescript-eslint/no-explicit-any in useShiftTemplates.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useShiftTemplates.test.ts"
+      ],
+      "id": "ee0aee67c1a1efcfa61498d8bd498639f4485211",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.074Z",
+      "updated_at": "2026-08-08T07:09:49.074Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useTemplateLinkedShifts.test.ts",
+        "line": 97
+      },
+      "title": "@typescript-eslint/no-explicit-any in useTemplateLinkedShifts.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useTemplateLinkedShifts.test.ts"
+      ],
+      "id": "eadd14b341a2f7fc4192fe2d816cfa12de3867ba",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.075Z",
+      "updated_at": "2026-08-08T07:09:49.075Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useTemplateLinkedShifts.test.ts",
+        "line": 98
+      },
+      "title": "@typescript-eslint/no-explicit-any in useTemplateLinkedShifts.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useTemplateLinkedShifts.test.ts"
+      ],
+      "id": "2b93eda78c35be7889a7971c5e18954969e7d7c3",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.075Z",
+      "updated_at": "2026-08-08T07:09:49.075Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useTemplateLinkedShifts.test.ts",
+        "line": 126
+      },
+      "title": "@typescript-eslint/no-explicit-any in useTemplateLinkedShifts.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useTemplateLinkedShifts.test.ts"
+      ],
+      "id": "e097afb93b9a3ac9825cd4737450eb29394b05ee",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.075Z",
+      "updated_at": "2026-08-08T07:09:49.075Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useTemplateLinkedShifts.test.ts",
+        "line": 127
+      },
+      "title": "@typescript-eslint/no-explicit-any in useTemplateLinkedShifts.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useTemplateLinkedShifts.test.ts"
+      ],
+      "id": "c709283764ddc2c6332d138408d2cb1c55e0b63f",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.075Z",
+      "updated_at": "2026-08-08T07:09:49.075Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useTemplateLinkedShifts.test.ts",
+        "line": 197
+      },
+      "title": "@typescript-eslint/no-explicit-any in useTemplateLinkedShifts.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useTemplateLinkedShifts.test.ts"
+      ],
+      "id": "d8607eeba5b34f42d6342390c2c33dfc8858750c",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.075Z",
+      "updated_at": "2026-08-08T07:09:49.075Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useTemplateLinkedShifts.test.ts",
+        "line": 242
+      },
+      "title": "@typescript-eslint/no-explicit-any in useTemplateLinkedShifts.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useTemplateLinkedShifts.test.ts"
+      ],
+      "id": "1412de79837fc90e50f3831481451fd42f8db72d",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.075Z",
+      "updated_at": "2026-08-08T07:09:49.075Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useTemplateLinkedShifts.test.ts",
+        "line": 243
+      },
+      "title": "@typescript-eslint/no-explicit-any in useTemplateLinkedShifts.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useTemplateLinkedShifts.test.ts"
+      ],
+      "id": "921430923de57166ffd7e329cb4ce31c0075d864",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.075Z",
+      "updated_at": "2026-08-08T07:09:49.075Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useTemplateLinkedShifts.test.ts",
+        "line": 244
+      },
+      "title": "@typescript-eslint/no-explicit-any in useTemplateLinkedShifts.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useTemplateLinkedShifts.test.ts"
+      ],
+      "id": "fa9e961411719d05ed9b1fd1cb6e49d3236ea888",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.075Z",
+      "updated_at": "2026-08-08T07:09:49.075Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useTemplateLinkedShifts.test.ts",
+        "line": 263
+      },
+      "title": "@typescript-eslint/no-explicit-any in useTemplateLinkedShifts.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useTemplateLinkedShifts.test.ts"
+      ],
+      "id": "c7762748db9ea006c6d772cbacd9b9134ff3ff3a",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.076Z",
+      "updated_at": "2026-08-08T07:09:49.076Z"
+    },
+    {
+      "source": "problems",
+      "origin_ref": {
+        "file": "tests/unit/useTemplateLinkedShifts.test.ts",
+        "line": 264
+      },
+      "title": "@typescript-eslint/no-explicit-any in useTemplateLinkedShifts.test.ts",
+      "body": "Unexpected any. Specify a different type.",
+      "severity": "major",
+      "tests_to_run": [
+        "npm run lint -- /Users/josedelgado/Documents/GitHub/nimble-pnl/.claude/worktrees/user-restaurants-insert-guard/tests/unit/useTemplateLinkedShifts.test.ts"
+      ],
+      "id": "7d17809b8daaf436b305f908313659048dfe5c44",
+      "status": "open",
+      "created_at": "2026-08-08T07:09:49.076Z",
+      "updated_at": "2026-08-08T07:09:49.076Z"
     }
   ]
 }

--- a/docs/superpowers/plans/2026-08-08-user-restaurants-insert-guard-plan.md
+++ b/docs/superpowers/plans/2026-08-08-user-restaurants-insert-guard-plan.md
@@ -1,0 +1,163 @@
+# Block self-grant of restaurant membership — implementation plan
+
+Date: 2026-08-08
+Branch: `fix/user-restaurants-insert-guard`
+Design: [2026-08-08-user-restaurants-insert-guard-design.md](../specs/2026-08-08-user-restaurants-insert-guard-design.md)
+Track A Task 1 of [2026-08-07-account-creation-security-plan.md](../../plans/2026-08-07-account-creation-security-plan.md)
+
+Build order follows TDD. Write the test first. See it fail. Write the
+migration. See it pass.
+
+## Step 1 — Write the pgTAP test
+
+Create `supabase/tests/user_restaurants_insert_guard.test.sql`.
+
+Copy the RLS harness from `supabase/tests/user_restaurants_role_id_test.sql:250-274`:
+
+```sql
+SET LOCAL ROLE authenticated;
+SET LOCAL request.jwt.claims = '{"sub":"<uuid>","role":"authenticated"}';
+-- assertions
+RESET ROLE;
+RESET request.jwt.claims;
+```
+
+As superuser the policies do not apply at all. The role switch is what makes
+the test real.
+
+### Fixtures
+
+Two restaurants and four users. Use a `d0000000-…` id prefix, so the ids do
+not collide with any other test file.
+
+| Fixture | Purpose |
+|---|---|
+| restaurant A | the victim tenant |
+| restaurant B | a second tenant, with no member from A |
+| user OWNER | `owner` of restaurant A |
+| user STRANGER | member of nothing |
+| user STAFF | `staff` of restaurant A only |
+| user TARGET | the person an owner adds; member of nothing |
+
+Insert the fixtures as superuser, before the first `SET LOCAL ROLE`.
+
+### Assertions
+
+| # | Actor | Statement | Expect |
+|---|---|---|---|
+| 1 | STRANGER | insert self into A as `owner` | `throws_ok … '42501'` |
+| 2 | STRANGER | insert self into A as `staff` | `throws_ok … '42501'` |
+| 3 | STRANGER | insert self into A as `manager` | `throws_ok … '42501'` |
+| 4 | STAFF of A | insert self into **B** as `owner` | `throws_ok … '42501'` |
+| 5 | OWNER | insert TARGET into A as `staff` | `lives_ok` |
+| 6 | OWNER | insert TARGET into A as `owner` | `lives_ok` |
+| 7 | STRANGER | `create_restaurant_with_owner('…')` | `lives_ok` |
+| 8 | — | `is_restaurant_owner('<A>', '<STRANGER>')` | `false` |
+| 9 | — | the new policy is RESTRICTIVE and INSERT-scoped | `is` |
+| 10 | — | `Users can insert their own restaurant associations` is gone | `is 0` |
+
+Cases 5 and 6 both write TARGET into A, so run 5 first, then delete the row,
+then run 6. A second insert of the same pair raises `23505`.
+
+Warning: never point a deny case at a restaurant the actor already belongs to.
+`UNIQUE(user_id, restaurant_id)`
+(`supabase/migrations/20250915210020_774bc2c1-abb6-4f03-b10f-5cfc85e9b772.sql:18`)
+raises `23505` before RLS raises `42501`. The SQLSTATE pin on cases 1-4 makes
+that mistake fail loudly instead of passing.
+
+Case 7 is the bootstrap regression guard. Run it as STRANGER, who owns nothing
+at that moment. It proves the `SECURITY DEFINER` bypass still works
+(`supabase/migrations/20260129000000_add_subscription_system.sql:414-416`).
+
+Case 8 is the non-vacuity control for cases 1-3. It proves STRANGER fails the
+new `WITH CHECK` predicate, so the deny comes from the new policy and not from
+some unrelated grant.
+
+Cases 9 and 10 read `pg_policies`:
+
+```sql
+SELECT is(
+  (SELECT permissive FROM pg_policies
+    WHERE tablename = 'user_restaurants'
+      AND policyname = 'Only owners can insert restaurant associations'),
+  'RESTRICTIVE', '…');
+```
+
+Run case 7 in its own `SET LOCAL` block, and place it **last** among the write
+cases. It creates a restaurant row that the earlier assertions do not expect.
+
+### See it fail
+
+```bash
+npm run test:db
+```
+
+Cases 1-4 must fail now, because the hole is open. Cases 9 and 10 must fail
+now, because the migration does not exist. Print the failure list before you
+continue. A test that already passes proves nothing.
+
+## Step 2 — Write the migration
+
+Create `supabase/migrations/20260808100000_restrict_user_restaurants_insert.sql`
+with the body in the design, section "Change".
+
+The prefix `20260808100000` is free. The newest prefix across all branches is
+`20260806130000`. `memory/lessons.md:896` records a deploy failure from a
+colliding prefix.
+
+Add a file header comment that states:
+- what the policy denies,
+- that every real writer bypasses RLS, with the four citations,
+- that a permissive policy can never deny (`memory/lessons.md:848`).
+
+## Step 3 — Delete the dead E2E helper that needs the hole
+
+`tests/helpers/e2e-supabase.ts:618-661` defines `window.__inviteCollaborator`.
+It calls `supabase.auth.signUp()`, which moves the browser session to the new
+user, then upserts that user into a restaurant they do not own
+(`tests/helpers/e2e-supabase.ts:645-655`). It works today only because of the
+`user_id = auth.uid()` disjunct this task removes.
+
+No spec calls it. A grep of `tests/` for `__inviteCollaborator` returns only
+its own definition. Delete the helper.
+
+Leave `window.__simulateCollaboratorRole`
+(`tests/helpers/e2e-supabase.ts:663-690`). It UPDATEs an existing row, so the
+INSERT guard does not reach it.
+
+No other test writes a membership. `tests/helpers/auth.ts:30-40` uses the
+service-role client and the RPC.
+
+## Step 4 — See it pass
+
+An already-applied migration needs a reset first (`memory/lessons.md:860`):
+
+```bash
+npm run db:reset && npm run test:db
+```
+
+All 10 cases must pass.
+
+## Step 5 — Verify the rest
+
+```bash
+npm run typecheck && npm run lint && npm run test
+```
+
+Then the E2E signup and permissions specs, in the foreground, bounded by the
+Bash tool `timeout` parameter. No poll loop (`CLAUDE.md`, "No Unbounded
+Waits"):
+
+```bash
+npx playwright test tests/e2e/permissions-roles.spec.ts --reporter=line
+```
+
+## Order and dependencies
+
+Step 1 first, and it must fail. Step 2 needs nothing. Step 3 is independent.
+Step 4 needs 1 and 2. Step 5 needs 3 and 4.
+
+## Out of scope
+
+The design lists it. No `role_id` agreement check on INSERT. No change to the
+DELETE path. No change to the permissive `FOR ALL` policy. Vuln 2 is Task 2.

--- a/docs/superpowers/plans/2026-08-08-user-restaurants-insert-guard-plan.md
+++ b/docs/superpowers/plans/2026-08-08-user-restaurants-insert-guard-plan.md
@@ -62,8 +62,10 @@ then run 6. A second insert of the same pair raises `23505`.
 Warning: never point a deny case at a restaurant the actor already belongs to.
 `UNIQUE(user_id, restaurant_id)`
 (`supabase/migrations/20250915210020_774bc2c1-abb6-4f03-b10f-5cfc85e9b772.sql:19`)
-raises `23505` before RLS raises `42501`. The SQLSTATE pin on cases 1-4 makes
-that mistake fail loudly instead of passing.
+rejects that row too, so the case has two reasons to fail. RLS reports first
+while the policy exists (`42501`). Delete the policy and the same statement
+reaches the index and reports `23505`. An unpinned `throws_ok` passes in both
+states. The SQLSTATE pin on cases 1-4 makes that mistake fail loudly.
 
 Case 7 is the bootstrap regression guard. Run it as STRANGER, who owns nothing
 at that moment. It proves the `SECURITY DEFINER` bypass still works

--- a/docs/superpowers/plans/2026-08-08-user-restaurants-insert-guard-plan.md
+++ b/docs/superpowers/plans/2026-08-08-user-restaurants-insert-guard-plan.md
@@ -61,7 +61,7 @@ then run 6. A second insert of the same pair raises `23505`.
 
 Warning: never point a deny case at a restaurant the actor already belongs to.
 `UNIQUE(user_id, restaurant_id)`
-(`supabase/migrations/20250915210020_774bc2c1-abb6-4f03-b10f-5cfc85e9b772.sql:18`)
+(`supabase/migrations/20250915210020_774bc2c1-abb6-4f03-b10f-5cfc85e9b772.sql:19`)
 raises `23505` before RLS raises `42501`. The SQLSTATE pin on cases 1-4 makes
 that mistake fail loudly instead of passing.
 

--- a/docs/superpowers/specs/2026-08-08-user-restaurants-insert-guard-design.md
+++ b/docs/superpowers/specs/2026-08-08-user-restaurants-insert-guard-design.md
@@ -220,7 +220,7 @@ nothing.
 
 **Warning: do not test a self-insert into a restaurant the subject already
 belongs to.** `public.user_restaurants` has `UNIQUE(user_id, restaurant_id)`
-(`supabase/migrations/20250915210020_774bc2c1-abb6-4f03-b10f-5cfc85e9b772.sql:18`).
+(`supabase/migrations/20250915210020_774bc2c1-abb6-4f03-b10f-5cfc85e9b772.sql:19`).
 That INSERT raises `23505` (`unique_violation`) before RLS ever reports `42501`.
 A bare `throws_ok` on such a case passes even if the RESTRICTIVE policy is
 deleted. The SQLSTATE pin makes the trap impossible: a `23505` no longer counts

--- a/docs/superpowers/specs/2026-08-08-user-restaurants-insert-guard-design.md
+++ b/docs/superpowers/specs/2026-08-08-user-restaurants-insert-guard-design.md
@@ -221,11 +221,19 @@ nothing.
 **Warning: do not test a self-insert into a restaurant the subject already
 belongs to.** `public.user_restaurants` has `UNIQUE(user_id, restaurant_id)`
 (`supabase/migrations/20250915210020_774bc2c1-abb6-4f03-b10f-5cfc85e9b772.sql:19`).
-That INSERT raises `23505` (`unique_violation`) before RLS ever reports `42501`.
-A bare `throws_ok` on such a case passes even if the RESTRICTIVE policy is
-deleted. The SQLSTATE pin makes the trap impossible: a `23505` no longer counts
-as a pass. Case 4 therefore targets **restaurant B**, where the subject holds no
-row.
+That INSERT has two reasons to fail, so a bare `throws_ok` passes even if the
+RESTRICTIVE policy is deleted.
+
+`ExecInsert` evaluates the RLS `WITH CHECK` before it writes the tuple or any
+index entry, so the policy reports first: `42501` while the policy exists.
+Delete the policy and the identical statement reaches the index and reports
+`23505` (`unique_violation`). The constraint is a fallback, not a pre-empt — it
+supplies the mutant with a different error, which is what keeps an unpinned
+assertion green.
+
+The SQLSTATE pin makes the trap impossible: a `23505` no longer counts as a
+pass. Case 4 targets **restaurant B** as well, where the subject holds no row,
+so exactly one thing can reject it.
 
 Case 7 guards the bootstrap path. A new user is not yet an owner when
 `create_restaurant_with_owner` writes their first membership row. The test

--- a/docs/superpowers/specs/2026-08-08-user-restaurants-insert-guard-design.md
+++ b/docs/superpowers/specs/2026-08-08-user-restaurants-insert-guard-design.md
@@ -1,0 +1,232 @@
+# Block self-grant of restaurant membership — design
+
+**Date:** 2026-08-08
+**Task:** Track A Task 1 of
+`docs/plans/2026-08-07-account-creation-security-plan.md`
+**Audit finding:** Vuln 1 (CRITICAL) in
+`docs/SECURITY_AUDIT_ACCOUNT_CREATION_2026-08.md`
+**Branch:** `fix/user-restaurants-insert-guard`
+
+---
+
+## Problem
+
+Any user who registers can INSERT a `user_restaurants` row for **any**
+restaurant, with **any** role, including `owner`.
+
+### The effective INSERT check today
+
+Four policies exist on `public.user_restaurants`. Two of them apply to INSERT.
+Both are PERMISSIVE, so Postgres ORs them. No RESTRICTIVE policy covers INSERT.
+
+Read live from production `pg_policies` on 2026-08-08:
+
+| Policy | Permissive | Cmd | `with_check` |
+|---|---|---|---|
+| `Owners can manage restaurant associations` | PERMISSIVE | ALL | `((user_id = auth.uid()) OR is_restaurant_owner(restaurant_id, auth.uid()))` |
+| `Users can insert their own restaurant associations` | PERMISSIVE | INSERT | `(user_id = auth.uid())` |
+| `Prevent self-escalation to privileged roles` | RESTRICTIVE | **UPDATE** | `(is_restaurant_owner(restaurant_id, auth.uid()) OR ((role = ANY (ARRAY['staff','kiosk'])) AND ((role_id IS NULL) OR (role_id = builtin_role_id_for(role)))))` |
+| `Users can view their restaurant associations` | PERMISSIVE | SELECT | — |
+
+The OR reduces to:
+
+```
+user_id = auth.uid() OR is_restaurant_owner(restaurant_id, auth.uid())
+```
+
+Neither disjunct constrains `role`. Neither constrains which `restaurant_id` a
+stranger may name. The first disjunct is the hole.
+
+The RESTRICTIVE guard has `cmd = 'UPDATE'`. A command-scoped policy never
+applies to another command, so it does nothing here.
+
+### Exploit
+
+```sql
+INSERT INTO user_restaurants (user_id, restaurant_id, role)
+VALUES (auth.uid(), '<any restaurant_id>', 'owner');
+```
+
+`is_restaurant_owner()` then returns true for the attacker. **113 policy
+definitions** in the migration history call that function. The attacker reads
+and writes the victim's P&L, payroll, bank connections, and inventory. The
+`FOR ALL` policy then lets them DELETE the real owner's membership row.
+
+### This gap is known and was deferred
+
+`supabase/migrations/20260730180000_close_role_id_self_escalation.sql:37-40`
+records it: the permissive INSERT policy "already lets a user insert their own
+membership row with role = 'owner' ... Not addressed here". It is still open.
+
+---
+
+## Which flows actually INSERT a membership row
+
+This decides whether a hard guard is safe. Four writers exist. **Every one of
+them bypasses RLS.**
+
+| Writer | Mechanism | Bypasses RLS? | Citation |
+|---|---|---|---|
+| `create_restaurant_with_owner` | `SECURITY DEFINER`, owner `postgres` | **Yes** | `supabase/migrations/20260129000000_add_subscription_system.sql:367-420` |
+| `accept-invitation` | service-role client | **Yes** | `supabase/functions/accept-invitation/index.ts:118-133` |
+| `scim-v2` | service-role client | **Yes** | `supabase/functions/scim-v2/index.ts:473-475` |
+| `assign_membership_role` | `SECURITY DEFINER`, owner `postgres` | **Yes** | `supabase/migrations/20260802110000_assign_membership_role.sql` |
+
+**No browser client inserts a membership row.** A grep of `src/` for
+`from('user_restaurants')` returns 7 `.select(` and 2 `.delete(` call sites and
+**zero** `.insert(` or `.upsert(` call sites.
+
+### Why the SECURITY DEFINER path is safe
+
+Read live from production on 2026-08-08:
+
+```
+relname           rls_enabled  rls_forced  table_owner
+user_restaurants  true         false       postgres
+```
+
+`relforcerowsecurity` is `false`, and `create_restaurant_with_owner` is owned by
+`postgres`, which owns the table. Postgres does not apply RLS to a table's owner
+unless `FORCE ROW LEVEL SECURITY` is set. No migration in the repo sets it —
+a grep for `FORCE ROW LEVEL SECURITY` returns zero hits.
+
+**Conclusion: the permissive INSERT grant for browser clients supports no
+product flow. It is pure attack surface.**
+
+---
+
+## Approach considered
+
+### Option A — mirror the UPDATE guard
+
+Add a RESTRICTIVE INSERT policy with the same allowlist the UPDATE guard uses:
+owner, or `role IN ('staff','kiosk')`.
+
+Rejected. The staff/kiosk branch makes sense for UPDATE, where it permits a
+**downgrade** of a membership that already exists. For INSERT it permits a
+stranger to join a tenant they have no relationship with. Joining as `staff`
+still grants access to that restaurant's data. That is the same class of
+cross-tenant breach, one privilege level down.
+
+### Option B — drop the redundant permissive policy only
+
+Drop `Users can insert their own restaurant associations`. It is fully subsumed
+by the `FOR ALL` policy's first disjunct.
+
+Rejected on its own. The `FOR ALL` policy still carries
+`user_id = auth.uid()`, so the hole survives.
+
+### Option C — drop the redundant policy AND add a RESTRICTIVE INSERT guard (chosen)
+
+1. Drop `Users can insert their own restaurant associations`. It grants nothing
+   the `FOR ALL` policy does not already grant, and nothing uses it.
+2. Add a RESTRICTIVE INSERT policy requiring
+   `is_restaurant_owner(restaurant_id, auth.uid())`.
+
+Effective INSERT check afterwards:
+
+```
+(user_id = auth.uid() OR is_restaurant_owner(...))   -- permissive, unchanged
+AND is_restaurant_owner(restaurant_id, auth.uid())   -- new restrictive
+⇒  is_restaurant_owner(restaurant_id, auth.uid())
+```
+
+A real owner can still add a member through a future UI. A stranger cannot
+insert at any role. Every service-role and `SECURITY DEFINER` writer is
+untouched.
+
+**Why RESTRICTIVE and not a narrower permissive policy:** a permissive policy
+can only widen access. It can never deny. `memory/lessons.md:848` records PR
+#568 making this exact mistake on this exact table — the deny-guard was
+permissive, the pre-existing `FOR ALL` policy ORed with it, and the escalation
+still worked. A follow-up fix that narrowed the guard's `USING` clause changed
+nothing.
+
+---
+
+## Change
+
+**File:** `supabase/migrations/20260808100000_restrict_user_restaurants_insert.sql`
+
+```sql
+DROP POLICY IF EXISTS "Users can insert their own restaurant associations"
+  ON public.user_restaurants;
+
+CREATE POLICY "Only owners can insert restaurant associations"
+  ON public.user_restaurants
+  AS RESTRICTIVE
+  FOR INSERT
+  TO public
+  WITH CHECK (is_restaurant_owner(restaurant_id, auth.uid()));
+```
+
+`TO public` matches every existing policy on this table. `auth.uid()` is NULL
+for `anon`, and `is_restaurant_owner` returns `EXISTS(...)`, which is `false`
+for a NULL argument — never NULL. So `anon` is denied without a special case.
+
+`is_restaurant_owner` reads `user_restaurants` from inside a policy **on**
+`user_restaurants`. This does not recurse: the function is
+`STABLE SECURITY DEFINER SET search_path TO 'public'` (read live from
+production), so its own read runs as `postgres` and skips RLS. The existing
+`FOR ALL` policy already calls it the same way.
+
+**Migration prefix:** `20260808100000`. The newest prefix across all branches is
+`20260806130000`, checked with
+`git log --all --diff-filter=A --name-only -- 'supabase/migrations/*'`.
+`memory/lessons.md:896` records a production deploy failure from a colliding
+prefix.
+
+---
+
+## Tests
+
+**File:** `supabase/tests/user_restaurants_insert_guard.test.sql`
+
+Every deny case uses `throws_ok`. `memory/lessons.md:851`: a deny-guard test
+that does not prove the exception fires is the only thing that catches the
+permissive-OR mistake.
+
+| # | Case | Expect |
+|---|---|---|
+| 1 | Stranger inserts self as `owner` on another restaurant | throws |
+| 2 | Stranger inserts self as `staff` on another restaurant | throws |
+| 3 | Stranger inserts self as `manager` on another restaurant | throws |
+| 4 | Existing `staff` member inserts self as `owner` on their own restaurant | throws |
+| 5 | Real owner inserts another user as `staff` | succeeds |
+| 6 | Real owner inserts another user as `owner` | succeeds |
+| 7 | `create_restaurant_with_owner` still creates the bootstrap owner row | succeeds |
+| 8 | Policy exists, is RESTRICTIVE, and is scoped to INSERT | passes |
+| 9 | The dropped policy is gone | passes |
+
+Case 4 matters most. It is the non-vacuous test: the subject is already a member
+of that exact restaurant, so the `user_id = auth.uid()` disjunct is satisfied and
+only the new restrictive policy can deny it. `memory/lessons.md:866` — a clause
+tested with a subject that another clause already authorizes proves nothing.
+
+Case 7 guards the bootstrap path. A new user is not yet an owner when
+`create_restaurant_with_owner` writes their first membership row. The test
+proves the `SECURITY DEFINER` bypass holds.
+
+---
+
+## Out of scope
+
+- **`role_id` agreement on INSERT.** The UPDATE guard checks
+  `role_id IS NULL OR role_id = builtin_role_id_for(role)`. The INSERT guard
+  does not. Only an owner can now insert, and an owner may already assign any
+  role, so this is a data-integrity concern, not a privilege one. Adding it
+  risks breaking the custom-role path that `accept-invitation` writes
+  (`role = 'collaborator_custom'` with a non-builtin `role_id`).
+- **The `user_id = auth.uid()` disjunct for DELETE.** It lets a user leave a
+  restaurant. `src/` has 2 `.delete(` call sites that rely on it. Keep it.
+- **Vuln 2** (`restaurants` subscription columns) is Task 2, a separate PR.
+
+## Decided trade-offs
+
+- The permissive `FOR ALL` policy keeps its `user_id = auth.uid()` disjunct.
+  Removing it would be cleaner but changes SELECT, UPDATE, and DELETE behaviour
+  at the same time. The restrictive INSERT policy neutralizes it for INSERT
+  alone, which is the smallest change that closes the hole.
+- No E2E test. The exploit is a direct PostgREST call, not a UI flow, and no UI
+  inserts memberships. pgTAP is the correct layer. Task 8's E2E work covers the
+  signup surface.

--- a/docs/superpowers/specs/2026-08-08-user-restaurants-insert-guard-design.md
+++ b/docs/superpowers/specs/2026-08-08-user-restaurants-insert-guard-design.md
@@ -62,15 +62,20 @@ membership row with role = 'owner' ... Not addressed here". It is still open.
 
 ## Which flows actually INSERT a membership row
 
-This decides whether a hard guard is safe. Four writers exist. **Every one of
-them bypasses RLS.**
+This decides whether a hard guard is safe. Four writers insert a row. **Every
+one of them bypasses RLS.**
 
 | Writer | Mechanism | Bypasses RLS? | Citation |
 |---|---|---|---|
 | `create_restaurant_with_owner` | `SECURITY DEFINER`, owner `postgres` | **Yes** | `supabase/migrations/20260129000000_add_subscription_system.sql:367-420` |
 | `accept-invitation` | service-role client | **Yes** | `supabase/functions/accept-invitation/index.ts:118-133` |
 | `scim-v2` | service-role client | **Yes** | `supabase/functions/scim-v2/index.ts:473-475` |
-| `assign_membership_role` | `SECURITY DEFINER`, owner `postgres` | **Yes** | `supabase/migrations/20260802110000_assign_membership_role.sql` |
+| `create-kiosk-service-account` | service-role client, `.upsert()` | **Yes** | `supabase/functions/create-kiosk-service-account/index.ts:38, 129-136` |
+
+`assign_membership_role` is **not** a writer of new rows. It only UPDATEs an
+existing row (`supabase/migrations/20260802110000_assign_membership_role.sql:200-203`).
+It is `SECURITY DEFINER` owned by `postgres`, so it bypasses RLS as well, but
+the new INSERT guard cannot reach it.
 
 **No browser client inserts a membership row.** A grep of `src/` for
 `from('user_restaurants')` returns 7 `.select(` and 2 `.delete(` call sites and
@@ -152,6 +157,12 @@ nothing.
 DROP POLICY IF EXISTS "Users can insert their own restaurant associations"
   ON public.user_restaurants;
 
+-- Drop the new policy by its own name first, so a re-run of this file is a
+-- refresh and not a "policy already exists" failure. Same pattern as
+-- 20260730180000_close_role_id_self_escalation.sql:45-47.
+DROP POLICY IF EXISTS "Only owners can insert restaurant associations"
+  ON public.user_restaurants;
+
 CREATE POLICY "Only owners can insert restaurant associations"
   ON public.user_restaurants
   AS RESTRICTIVE
@@ -182,30 +193,42 @@ prefix.
 
 **File:** `supabase/tests/user_restaurants_insert_guard.test.sql`
 
-Every deny case uses `throws_ok`. `memory/lessons.md:851`: a deny-guard test
-that does not prove the exception fires is the only thing that catches the
-permissive-OR mistake.
+Every deny case uses `throws_ok` **pinned to SQLSTATE `42501`**
+(`insufficient_privilege`). `memory/lessons.md:851`: a deny-guard test that does
+not prove the exception fires is the only thing that catches the permissive-OR
+mistake. A bare `throws_ok` is not enough here — see the warning below.
 
 | # | Case | Expect |
 |---|---|---|
-| 1 | Stranger inserts self as `owner` on another restaurant | throws |
-| 2 | Stranger inserts self as `staff` on another restaurant | throws |
-| 3 | Stranger inserts self as `manager` on another restaurant | throws |
-| 4 | Existing `staff` member inserts self as `owner` on their own restaurant | throws |
+| 1 | Stranger inserts self as `owner` on another restaurant | throws `42501` |
+| 2 | Stranger inserts self as `staff` on another restaurant | throws `42501` |
+| 3 | Stranger inserts self as `manager` on another restaurant | throws `42501` |
+| 4 | Existing `staff` member of A inserts self as `owner` on **restaurant B** | throws `42501` |
 | 5 | Real owner inserts another user as `staff` | succeeds |
 | 6 | Real owner inserts another user as `owner` | succeeds |
 | 7 | `create_restaurant_with_owner` still creates the bootstrap owner row | succeeds |
 | 8 | Policy exists, is RESTRICTIVE, and is scoped to INSERT | passes |
 | 9 | The dropped policy is gone | passes |
 
-Case 4 matters most. It is the non-vacuous test: the subject is already a member
-of that exact restaurant, so the `user_id = auth.uid()` disjunct is satisfied and
-only the new restrictive policy can deny it. `memory/lessons.md:866` — a clause
-tested with a subject that another clause already authorizes proves nothing.
+**Cases 1-4 are the non-vacuous ones.** Each is a *self*-insert, so
+`user_id = auth.uid()` holds by construction and the permissive set admits the
+row. Only the new RESTRICTIVE policy can deny it. `memory/lessons.md:866` — a
+clause tested with a subject that another clause already authorizes proves
+nothing.
+
+**Warning: do not test a self-insert into a restaurant the subject already
+belongs to.** `public.user_restaurants` has `UNIQUE(user_id, restaurant_id)`
+(`supabase/migrations/20250915210020_774bc2c1-abb6-4f03-b10f-5cfc85e9b772.sql:18`).
+That INSERT raises `23505` (`unique_violation`) before RLS ever reports `42501`.
+A bare `throws_ok` on such a case passes even if the RESTRICTIVE policy is
+deleted. The SQLSTATE pin makes the trap impossible: a `23505` no longer counts
+as a pass. Case 4 therefore targets **restaurant B**, where the subject holds no
+row.
 
 Case 7 guards the bootstrap path. A new user is not yet an owner when
 `create_restaurant_with_owner` writes their first membership row. The test
-proves the `SECURITY DEFINER` bypass holds.
+proves the `SECURITY DEFINER` bypass holds. This is the highest-risk regression
+in the change.
 
 ---
 

--- a/docs/superpowers/specs/2026-08-08-user-restaurants-insert-guard-design.md
+++ b/docs/superpowers/specs/2026-08-08-user-restaurants-insert-guard-design.md
@@ -207,8 +207,10 @@ mistake. A bare `throws_ok` is not enough here — see the warning below.
 | 5 | Real owner inserts another user as `staff` | succeeds |
 | 6 | Real owner inserts another user as `owner` | succeeds |
 | 7 | `create_restaurant_with_owner` still creates the bootstrap owner row | succeeds |
-| 8 | Policy exists, is RESTRICTIVE, and is scoped to INSERT | passes |
-| 9 | The dropped policy is gone | passes |
+| 8 | Non-vacuity control: `is_restaurant_owner` returns `false` for the stranger on A | passes |
+| 9 | The new policy exists, is RESTRICTIVE, and is scoped to INSERT | passes |
+| 10 | The dropped policy is gone | passes |
+| 11 | `anon` cannot insert, even granted table-level INSERT (RLS denies it) | throws `42501` |
 
 **Cases 1-4 are the non-vacuous ones.** Each is a *self*-insert, so
 `user_id = auth.uid()` holds by construction and the permissive set admits the

--- a/supabase/migrations/20260808100000_restrict_user_restaurants_insert.sql
+++ b/supabase/migrations/20260808100000_restrict_user_restaurants_insert.sql
@@ -1,0 +1,41 @@
+-- Block self-grant of restaurant membership through the browser client.
+--
+-- This policy denies an INSERT into user_restaurants unless the caller
+-- already owns the target restaurant. Before this migration, a signed-in
+-- stranger could insert a row for any restaurant_id, at any role, and grant
+-- themselves membership. The permissive "Users can insert their own
+-- restaurant associations" policy only checked user_id = auth.uid(), never
+-- who owned the restaurant.
+--
+-- Every real writer of a new membership row bypasses RLS, so this guard
+-- does not block a real product flow:
+--   1. create_restaurant_with_owner: SECURITY DEFINER, owner postgres.
+--      supabase/migrations/20260129000000_add_subscription_system.sql:367-420
+--   2. accept-invitation edge function: service-role client.
+--      supabase/functions/accept-invitation/index.ts:118-133
+--   3. scim-v2 edge function: service-role client.
+--      supabase/functions/scim-v2/index.ts:473-475
+--   4. create-kiosk-service-account edge function: service-role client,
+--      .upsert(). supabase/functions/create-kiosk-service-account/index.ts:38, 129-136
+--
+-- The new policy is RESTRICTIVE, not permissive. A permissive policy can
+-- only widen access; it can never deny. memory/lessons.md:848 records PR
+-- #568 making this exact mistake on this exact table: a permissive
+-- deny-guard ORed with the pre-existing FOR ALL policy, so the escalation
+-- still worked. Only a RESTRICTIVE policy narrows the effective check.
+
+DROP POLICY IF EXISTS "Users can insert their own restaurant associations"
+  ON public.user_restaurants;
+
+-- Drop the new policy by its own name first, so a re-run of this file is a
+-- refresh and not a "policy already exists" failure. Same pattern as
+-- 20260730180000_close_role_id_self_escalation.sql:45-47.
+DROP POLICY IF EXISTS "Only owners can insert restaurant associations"
+  ON public.user_restaurants;
+
+CREATE POLICY "Only owners can insert restaurant associations"
+  ON public.user_restaurants
+  AS RESTRICTIVE
+  FOR INSERT
+  TO public
+  WITH CHECK (is_restaurant_owner(restaurant_id, auth.uid()));

--- a/supabase/tests/user_restaurants_insert_guard.test.sql
+++ b/supabase/tests/user_restaurants_insert_guard.test.sql
@@ -163,7 +163,8 @@ SELECT is(
 -- ============================================================================
 SELECT is(
   (SELECT permissive FROM pg_policies
-    WHERE tablename = 'user_restaurants'
+    WHERE schemaname = 'public'
+      AND tablename = 'user_restaurants'
       AND policyname = 'Only owners can insert restaurant associations'
       AND cmd = 'INSERT'),
   'RESTRICTIVE',
@@ -175,7 +176,8 @@ SELECT is(
 -- ============================================================================
 SELECT is(
   (SELECT count(*)::int FROM pg_policies
-    WHERE tablename = 'user_restaurants'
+    WHERE schemaname = 'public'
+      AND tablename = 'user_restaurants'
       AND policyname = 'Users can insert their own restaurant associations'),
   0,
   'the old permissive self-insert policy no longer exists'
@@ -185,27 +187,32 @@ SELECT is(
 -- 11. Anon-role boundary. Runs as the real `anon` role (no `sub` claim), not
 --    as `authenticated` with a stub id.
 --
---    This case does NOT pin the new RESTRICTIVE policy or
---    is_restaurant_owner()'s NULL handling. By default `anon` has only
---    SELECT on public.user_restaurants (see
---    supabase/migrations/20260628000000_grant_user_restaurants_select.sql)
---    and Postgres checks table-level grants before RLS, so this INSERT is
---    denied at the grant-check stage — it never reaches the RESTRICTIVE
---    policy's WITH CHECK. Even granting anon INSERT for this test would not
---    reach the policy either: the pre-existing permissive "Owners can
---    manage restaurant associations" WITH CHECK
---    (user_id = auth.uid() OR is_restaurant_owner(...)) already denies any
---    anon insert on its own, since auth.uid() is NULL for anon and user_id
---    is never NULL.
+--    Whether `anon` holds a table-level INSERT grant on user_restaurants
+--    varies by environment: the local Supabase CLI runs migrations as
+--    `postgres`, whose default-privilege entry grants anon nothing beyond
+--    SELECT here, but CI (older CLI, as of 2.65.5) runs migrations as
+--    `supabase_admin`, whose default-privilege entry grants anon full CRUD
+--    on table creation — a grant that
+--    supabase/migrations/20260628000000_grant_user_restaurants_select.sql
+--    only ever adds SELECT to, never revokes. So relying on the ambient
+--    grant state makes this case pass locally and fail in CI (or the
+--    reverse), for a reason that has nothing to do with the guard this
+--    file exists to test.
 --
---    The weaker, true guarantee this case pins: the anon role cannot insert
---    into user_restaurants at all, today, for this exact reason (the
---    missing table grant). The error message is checked, not just the
---    SQLSTATE, so a future migration that grants anon INSERT — which would
---    change *why* anon is denied, even though anon would still end up
---    denied by the permissive policy above — fails here instead of shipping
---    a silently changed guarantee.
+--    GRANT INSERT explicitly here, inside this transaction, so both
+--    environments start from the same known state before the insert. The
+--    GRANT is undone by the ROLLBACK at the end of this file — it never
+--    touches the real table privileges.
+--
+--    With the grant in place, the insert reaches RLS evaluation. It is
+--    still denied: `auth.uid()` is NULL for anon, and every permissive
+--    INSERT policy plus the new RESTRICTIVE one requires
+--    `is_restaurant_owner(...)`, which is `false` — never NULL — for a NULL
+--    argument. This is the guarantee the design documents: anon is denied
+--    by the policy check itself, not by an accident of grant state.
 -- ============================================================================
+GRANT INSERT ON public.user_restaurants TO anon;
+
 SET LOCAL ROLE anon;
 SET LOCAL request.jwt.claims = '{"role":"anon"}';
 
@@ -213,8 +220,8 @@ SELECT throws_ok(
   $$ INSERT INTO public.user_restaurants (user_id, restaurant_id, role)
      VALUES ('d0000000-0000-0000-0000-000000000002', 'd0000000-0000-0000-0000-0000000000a1', 'owner') $$,
   '42501',
-  'permission denied for table user_restaurants',
-  'the anon role cannot insert into user_restaurants at all'
+  'new row violates row-level security policy for table "user_restaurants"',
+  'the anon role cannot insert into user_restaurants even with an INSERT grant'
 );
 
 RESET ROLE;

--- a/supabase/tests/user_restaurants_insert_guard.test.sql
+++ b/supabase/tests/user_restaurants_insert_guard.test.sql
@@ -20,7 +20,7 @@
 -- ============================================================================
 BEGIN;
 
-SELECT plan(10);
+SELECT plan(11);
 
 -- ----------------------------------------------------------------------------
 -- Fixtures: two restaurants, four users. `d0000000-…` prefix so the ids do
@@ -180,6 +180,30 @@ SELECT is(
   0,
   'the old permissive self-insert policy no longer exists'
 );
+
+-- ============================================================================
+-- 11. Anon-role boundary. Runs as the real `anon` role (no `sub` claim), not
+--    as `authenticated` with a stub id. auth.uid() is NULL for anon, and
+--    is_restaurant_owner() returns false for a NULL owner id, so the new
+--    RESTRICTIVE policy denies anon with no special case — the claim the
+--    migration header and design doc make. This case pins that claim to a
+--    real test, so a future edit that narrows the policy's `TO public` to
+--    `TO authenticated`, or a change to is_restaurant_owner's NULL
+--    handling, fails here instead of shipping silently.
+-- ============================================================================
+SET LOCAL ROLE anon;
+SET LOCAL request.jwt.claims = '{"role":"anon"}';
+
+SELECT throws_ok(
+  $$ INSERT INTO public.user_restaurants (user_id, restaurant_id, role)
+     VALUES ('d0000000-0000-0000-0000-000000000002', 'd0000000-0000-0000-0000-0000000000a1', 'owner') $$,
+  '42501',
+  NULL,
+  'the anon role cannot insert into user_restaurants at all'
+);
+
+RESET ROLE;
+RESET request.jwt.claims;
 
 SELECT * FROM finish();
 ROLLBACK;

--- a/supabase/tests/user_restaurants_insert_guard.test.sql
+++ b/supabase/tests/user_restaurants_insert_guard.test.sql
@@ -1,0 +1,185 @@
+-- ============================================================================
+-- user_restaurants_insert_guard.test.sql
+--
+-- pgTAP coverage for the fix that closes the self-grant hole on
+-- `public.user_restaurants` INSERT. See
+-- docs/superpowers/specs/2026-08-08-user-restaurants-insert-guard-design.md.
+--
+-- The problem: "Users can insert their own restaurant associations"
+-- (supabase/migrations/20250915210020_774bc2c1-abb6-4f03-b10f-5cfc85e9b772.sql:61)
+-- is PERMISSIVE and only checks `user_id = auth.uid()`. Any authenticated
+-- user can insert themselves into any restaurant as `owner`. The fix adds a
+-- RESTRICTIVE INSERT policy that requires the actor to already own the
+-- target restaurant, and drops the old permissive policy.
+--
+-- Run as the real `authenticated` role with JWT claims so RLS is actually
+-- enforced — as superuser these policies do not apply at all.
+--
+-- All fixture data (restaurant/user ids, emails) is fictional and exists
+-- only for the duration of this transaction (ROLLBACK).
+-- ============================================================================
+BEGIN;
+
+SELECT plan(10);
+
+-- ----------------------------------------------------------------------------
+-- Fixtures: two restaurants, four users. `d0000000-…` prefix so the ids do
+-- not collide with any other test file.
+--
+--   restaurant A (d0000000-...-00000000a1) — the victim tenant
+--   restaurant B (d0000000-...-00000000b1) — a second tenant, unrelated to A
+--   OWNER       (...01) — owner of restaurant A
+--   STRANGER    (...02) — member of nothing
+--   STAFF       (...03) — staff of restaurant A only
+--   TARGET      (...04) — the person an owner adds; member of nothing
+-- ----------------------------------------------------------------------------
+INSERT INTO auth.users (id, email) VALUES
+  ('d0000000-0000-0000-0000-000000000001', 'urig-owner@example.test'),
+  ('d0000000-0000-0000-0000-000000000002', 'urig-stranger@example.test'),
+  ('d0000000-0000-0000-0000-000000000003', 'urig-staff@example.test'),
+  ('d0000000-0000-0000-0000-000000000004', 'urig-target@example.test');
+
+INSERT INTO public.restaurants (id, name) VALUES
+  ('d0000000-0000-0000-0000-0000000000a1', 'Insert Guard Test Restaurant A'),
+  ('d0000000-0000-0000-0000-0000000000b1', 'Insert Guard Test Restaurant B');
+
+INSERT INTO public.user_restaurants (id, user_id, restaurant_id, role) VALUES
+  ('d0000000-0000-0000-0000-000000000101', 'd0000000-0000-0000-0000-000000000001', 'd0000000-0000-0000-0000-0000000000a1', 'owner'),
+  ('d0000000-0000-0000-0000-000000000102', 'd0000000-0000-0000-0000-000000000003', 'd0000000-0000-0000-0000-0000000000a1', 'staff');
+
+-- ============================================================================
+-- 1-3. STRANGER self-inserts into restaurant A at three different roles.
+--    Each is a self-insert (user_id = auth.uid()), so the permissive set
+--    already admits the row. Only the new RESTRICTIVE policy can deny it.
+--    Pinned to 42501 so a 23505 (unique_violation) never masquerades as a
+--    pass — see the warning in the plan for why that matters.
+-- ============================================================================
+SET LOCAL ROLE authenticated;
+SET LOCAL request.jwt.claims = '{"sub":"d0000000-0000-0000-0000-000000000002","role":"authenticated"}';
+
+SELECT throws_ok(
+  $$ INSERT INTO public.user_restaurants (user_id, restaurant_id, role)
+     VALUES ('d0000000-0000-0000-0000-000000000002', 'd0000000-0000-0000-0000-0000000000a1', 'owner') $$,
+  '42501',
+  NULL,
+  'a stranger cannot self-insert into another restaurant as owner'
+);
+
+SELECT throws_ok(
+  $$ INSERT INTO public.user_restaurants (user_id, restaurant_id, role)
+     VALUES ('d0000000-0000-0000-0000-000000000002', 'd0000000-0000-0000-0000-0000000000a1', 'staff') $$,
+  '42501',
+  NULL,
+  'a stranger cannot self-insert into another restaurant as staff'
+);
+
+SELECT throws_ok(
+  $$ INSERT INTO public.user_restaurants (user_id, restaurant_id, role)
+     VALUES ('d0000000-0000-0000-0000-000000000002', 'd0000000-0000-0000-0000-0000000000a1', 'manager') $$,
+  '42501',
+  NULL,
+  'a stranger cannot self-insert into another restaurant as manager'
+);
+
+RESET ROLE;
+RESET request.jwt.claims;
+
+-- ============================================================================
+-- 4. An existing member of A (staff) self-inserts into B, where they hold no
+--    row. Proves membership elsewhere does not grant insert rights on an
+--    unrelated tenant.
+-- ============================================================================
+SET LOCAL ROLE authenticated;
+SET LOCAL request.jwt.claims = '{"sub":"d0000000-0000-0000-0000-000000000003","role":"authenticated"}';
+
+SELECT throws_ok(
+  $$ INSERT INTO public.user_restaurants (user_id, restaurant_id, role)
+     VALUES ('d0000000-0000-0000-0000-000000000003', 'd0000000-0000-0000-0000-0000000000b1', 'owner') $$,
+  '42501',
+  NULL,
+  'a staff member of A cannot self-insert into unrelated restaurant B as owner'
+);
+
+RESET ROLE;
+RESET request.jwt.claims;
+
+-- ============================================================================
+-- 5-6. Real OWNER of A inserts TARGET into A. Positive control: the guard is
+--    not a blanket denial. Both cases write the same (TARGET, A) pair, so
+--    run 5, delete the row, then run 6 — a second insert raises 23505.
+-- ============================================================================
+SET LOCAL ROLE authenticated;
+SET LOCAL request.jwt.claims = '{"sub":"d0000000-0000-0000-0000-000000000001","role":"authenticated"}';
+
+SELECT lives_ok(
+  $$ INSERT INTO public.user_restaurants (user_id, restaurant_id, role)
+     VALUES ('d0000000-0000-0000-0000-000000000004', 'd0000000-0000-0000-0000-0000000000a1', 'staff') $$,
+  'an owner may insert another user into their restaurant as staff'
+);
+
+DELETE FROM public.user_restaurants
+ WHERE user_id = 'd0000000-0000-0000-0000-000000000004'
+   AND restaurant_id = 'd0000000-0000-0000-0000-0000000000a1';
+
+SELECT lives_ok(
+  $$ INSERT INTO public.user_restaurants (user_id, restaurant_id, role)
+     VALUES ('d0000000-0000-0000-0000-000000000004', 'd0000000-0000-0000-0000-0000000000a1', 'owner') $$,
+  'an owner may insert another user into their restaurant as owner'
+);
+
+RESET ROLE;
+RESET request.jwt.claims;
+
+-- ============================================================================
+-- 7. Bootstrap regression guard: create_restaurant_with_owner() must still
+--    work for a brand-new user who owns nothing yet. Proves the
+--    SECURITY DEFINER bypass still holds. Run last among the write cases —
+--    it creates a restaurant row the earlier assertions do not expect.
+-- ============================================================================
+SET LOCAL ROLE authenticated;
+SET LOCAL request.jwt.claims = '{"sub":"d0000000-0000-0000-0000-000000000002","role":"authenticated"}';
+
+SELECT lives_ok(
+  $$ SELECT public.create_restaurant_with_owner('Insert Guard Bootstrap Restaurant') $$,
+  'create_restaurant_with_owner still bootstraps a new owner row'
+);
+
+RESET ROLE;
+RESET request.jwt.claims;
+
+-- ============================================================================
+-- 8. Non-vacuity control for cases 1-3: STRANGER fails is_restaurant_owner
+--    on A. Proves the denial above comes from the new policy predicate, not
+--    from some unrelated grant.
+-- ============================================================================
+SELECT is(
+  public.is_restaurant_owner('d0000000-0000-0000-0000-0000000000a1', 'd0000000-0000-0000-0000-000000000002'),
+  false,
+  'stranger is not an owner of restaurant A'
+);
+
+-- ============================================================================
+-- 9. The new policy exists, is RESTRICTIVE, and is scoped to INSERT.
+-- ============================================================================
+SELECT is(
+  (SELECT permissive FROM pg_policies
+    WHERE tablename = 'user_restaurants'
+      AND policyname = 'Only owners can insert restaurant associations'
+      AND cmd = 'INSERT'),
+  'RESTRICTIVE',
+  'the new insert guard policy is RESTRICTIVE and scoped to INSERT'
+);
+
+-- ============================================================================
+-- 10. The old permissive self-insert policy is gone.
+-- ============================================================================
+SELECT is(
+  (SELECT count(*)::int FROM pg_policies
+    WHERE tablename = 'user_restaurants'
+      AND policyname = 'Users can insert their own restaurant associations'),
+  0,
+  'the old permissive self-insert policy no longer exists'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/user_restaurants_insert_guard.test.sql
+++ b/supabase/tests/user_restaurants_insert_guard.test.sql
@@ -183,13 +183,28 @@ SELECT is(
 
 -- ============================================================================
 -- 11. Anon-role boundary. Runs as the real `anon` role (no `sub` claim), not
---    as `authenticated` with a stub id. auth.uid() is NULL for anon, and
---    is_restaurant_owner() returns false for a NULL owner id, so the new
---    RESTRICTIVE policy denies anon with no special case — the claim the
---    migration header and design doc make. This case pins that claim to a
---    real test, so a future edit that narrows the policy's `TO public` to
---    `TO authenticated`, or a change to is_restaurant_owner's NULL
---    handling, fails here instead of shipping silently.
+--    as `authenticated` with a stub id.
+--
+--    This case does NOT pin the new RESTRICTIVE policy or
+--    is_restaurant_owner()'s NULL handling. By default `anon` has only
+--    SELECT on public.user_restaurants (see
+--    supabase/migrations/20260628000000_grant_user_restaurants_select.sql)
+--    and Postgres checks table-level grants before RLS, so this INSERT is
+--    denied at the grant-check stage — it never reaches the RESTRICTIVE
+--    policy's WITH CHECK. Even granting anon INSERT for this test would not
+--    reach the policy either: the pre-existing permissive "Owners can
+--    manage restaurant associations" WITH CHECK
+--    (user_id = auth.uid() OR is_restaurant_owner(...)) already denies any
+--    anon insert on its own, since auth.uid() is NULL for anon and user_id
+--    is never NULL.
+--
+--    The weaker, true guarantee this case pins: the anon role cannot insert
+--    into user_restaurants at all, today, for this exact reason (the
+--    missing table grant). The error message is checked, not just the
+--    SQLSTATE, so a future migration that grants anon INSERT — which would
+--    change *why* anon is denied, even though anon would still end up
+--    denied by the permissive policy above — fails here instead of shipping
+--    a silently changed guarantee.
 -- ============================================================================
 SET LOCAL ROLE anon;
 SET LOCAL request.jwt.claims = '{"role":"anon"}';
@@ -198,7 +213,7 @@ SELECT throws_ok(
   $$ INSERT INTO public.user_restaurants (user_id, restaurant_id, role)
      VALUES ('d0000000-0000-0000-0000-000000000002', 'd0000000-0000-0000-0000-0000000000a1', 'owner') $$,
   '42501',
-  NULL,
+  'permission denied for table user_restaurants',
   'the anon role cannot insert into user_restaurants at all'
 );
 

--- a/tests/helpers/e2e-supabase.ts
+++ b/tests/helpers/e2e-supabase.ts
@@ -613,53 +613,6 @@ export async function exposeSupabaseHelpers(page: Page) {
       ]);
     };
 
-    // Helper to invite a collaborator (for testing)
-    // IMPORTANT: Use generateTestUser() to create unique emails for each test
-    // The admin API is not available in browser context
-    (window as any).__inviteCollaborator = async (email: string, role: string, restaurantId: string) => {
-      // Create a test user for the collaborator
-      const { data: authUser, error: authError } = await supabase.auth.signUp({
-        email,
-        password: 'TestPassword123!',
-      });
-
-      if (authError) {
-        if (authError.message.includes('already registered')) {
-          throw new Error(
-            `Collaborator email "${email}" is already registered. ` +
-            'Use generateTestUser() to create unique test emails for each test run.'
-          );
-        }
-        throw new Error(`Failed to create collaborator user: ${authError.message}`);
-      }
-
-      // Get the user ID from signup response
-      const userId = authUser?.user?.id;
-      if (!userId) {
-        throw new Error(
-          'Could not create collaborator user - signup did not return a user ID. ' +
-          'Ensure the email is unique using generateTestUser().'
-        );
-      }
-
-      // Add user to restaurant with collaborator role
-      const { error: roleError } = await supabase
-        .from('user_restaurants')
-        .upsert({
-          user_id: userId,
-          restaurant_id: restaurantId,
-          role: role,
-        }, {
-          onConflict: 'user_id,restaurant_id'
-        });
-
-      if (roleError) {
-        throw new Error(`Failed to assign collaborator role: ${roleError.message}`);
-      }
-
-      return { userId, role };
-    };
-
     // Helper to simulate a different role for the current user (for testing routing)
     (window as any).__simulateCollaboratorRole = async (role: string) => {
       const user = await waitForUser();


### PR DESCRIPTION
## Summary

- Any registered user could INSERT a `user_restaurants` row for any
  restaurant, at any role, including `owner`. No RESTRICTIVE policy
  covered INSERT, so the permissive `user_id = auth.uid()` disjunct
  let a stranger self-grant.
- Drop the redundant permissive policy `Users can insert their own
  restaurant associations`. It grants nothing the `FOR ALL` policy
  does not already grant.
- Add a RESTRICTIVE INSERT policy: `is_restaurant_owner(restaurant_id,
  auth.uid())`. Only a real owner can now insert a membership row.
- No product flow used the removed grant. All four writers of new
  membership rows (`create_restaurant_with_owner`, `accept-invitation`,
  `scim-v2`, `create-kiosk-service-account`) bypass RLS through
  `SECURITY DEFINER` or the service-role client. No browser client
  calls `.insert(` or `.upsert(` on this table.
- Delete the dead E2E helper `window.__inviteCollaborator`. It called
  `supabase.auth.signUp()` then upserted the new user into a
  restaurant it did not own — the new guard now blocks that write,
  and no spec called this helper.

## Test plan

- [x] pgTAP: `supabase/tests/user_restaurants_insert_guard.test.sql`,
      11 cases, all pass — 4 deny cases pinned to SQLSTATE `42501`,
      2 owner-add positive controls, the bootstrap-owner control, 2
      policy-shape checks, and an `anon` grant-boundary check.
- [x] `npm run test:db` (full pgTAP suite): 2738/2739 pass. The 1
      failure is a pre-existing, environment-only issue unrelated to
      this branch's diff (confirmed with `git diff origin/main...HEAD --stat`).
- [x] `npm run test -- --run` (unit): 732 files passed, 1 skipped;
      9041 tests passed, 2 skipped; 0 failed.
- [x] `npm run test:e2e` (`permissions-roles.spec.ts`,
      `signup-and-create-restaurant.spec.ts`): 16 passed, 2 skipped,
      0 failed.
- [x] `npm run typecheck`: 1 pre-existing error, out of scope
      (`src/hooks/useReviewPages.ts`, confirmed untouched by this
      branch).
- [x] `npm run lint`: pre-existing repo-wide errors only; the one
      file this branch edits (`tests/helpers/e2e-supabase.ts`) adds
      no new lint error.
- [x] `npm run build`: succeeds.
- [x] Codex adversarial review: no finding.
- [x] Claude 5-reviewer pass + Codex, twice (initial and re-review):
      all findings folded — see `progress.md` phases 7b/7d for detail
      on the `anon` grant-boundary test fix.

Design doc:
[docs/superpowers/specs/2026-08-08-user-restaurants-insert-guard-design.md](https://github.com/toyiyo/nimble-pnl/blob/fix/user-restaurants-insert-guard/docs/superpowers/specs/2026-08-08-user-restaurants-insert-guard-design.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Restricted restaurant membership creation so only restaurant owners can add members.
  * Prevented unauthorized self-association and cross-restaurant membership inserts.
  * Continued blocking direct membership inserts by unauthenticated access.

* **Tests**
  * Added comprehensive database coverage for permitted and denied membership scenarios.

* **Chores**
  * Removed an obsolete browser-based collaborator invitation helper.
  * Added implementation and design documentation for the membership safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->