### PR TITLE
feat(permissions): enforce view:pay_rates and view:employee_pii in SQL

### DIFF
--- a/docs/superpowers/plans/2026-08-06-sensitive-data-flags.md
+++ b/docs/superpowers/plans/2026-08-06-sensitive-data-flags.md
@@ -1,0 +1,1379 @@
+# Sensitive Data Flags Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `view:pay_rates` and `view:employee_pii` gate the eight sensitive columns of `public.employees` in Postgres.
+
+**Architecture:** Revoke `SELECT` on the eight columns from `authenticated`. Add an owner-rights view `public.employees_secure` that returns `NULL` for a column the caller has no flag for. Point every client reader at the view. Seed the two flags onto the five builtin roles that already hold `view:employees`, so no user loses access on deploy day.
+
+**Tech Stack:** Postgres 15 (Supabase), PostgREST, React 18 + TypeScript, React Query, Vitest, pgTAP, Playwright.
+
+**Design doc:** `docs/superpowers/specs/2026-08-06-sensitive-data-flags-design.md`
+
+## Global Constraints
+
+- Write every comment, commit message, and PR body in ASD-STE100. See `docs/STE100_STYLE.md`.
+- Never commit to `main`. All work lands on `fix/sensitive-data-flags`.
+- Stage explicit paths. Never run `git add -A`, `git add .`, or `git commit -a`.
+- Never edit `test_expected_capabilities` in `roles_seed_test.sql` to make a test pass, unless `ROLE_CAPABILITIES` moves in the same commit.
+- Semantic color tokens only. No `bg-white`, no `text-black`.
+- Every `hasCapability(...)` call in the UI pairs with `isResolved`. The idiom is at `src/pages/Expenses.tsx:94`.
+- Migration timestamps must not collide with `main`. The latest migration on `origin/main` is `20260805160000_template_cascade_undo_restores_template.sql`. This plan uses `20260806100000` and `20260806110000`.
+- One local Supabase instance serves about 28 worktrees. Before `npm run db:reset`, confirm no other worktree runs a test.
+- Vitest takes `--reporter=dot`. `--reporter=line` is a Playwright reporter and crashes Vitest.
+- In zsh, quote a glob argument: `grep -rn x --include='*.ts'`.
+
+## File Structure
+
+**Create**
+
+| File | Responsibility |
+|---|---|
+| `supabase/migrations/20260806100000_seed_employee_sensitive_flags.sql` | Seed the two flags onto five builtin roles |
+| `supabase/migrations/20260806110000_employee_column_gating.sql` | REVOKE/GRANT, the `employees_secure` view, the compensation-history policy |
+| `supabase/tests/employee_column_gating_test.sql` | pgTAP for the grant posture and the view |
+| `src/lib/employeeMaskedFields.ts` | The masked-field lists and the payload strip |
+| `tests/unit/employeeMaskedFields.test.ts` | Vitest for the strip |
+| `tests/e2e/sensitive-data-flags.spec.ts` | Playwright end-to-end proof |
+
+**Modify**
+
+| File | Responsibility |
+|---|---|
+| `src/lib/permissions/definitions.ts` | Add both flags to five roles |
+| `src/lib/permissions/areas.ts` | Correct the `view:employee_pii` label and hint |
+| `supabase/tests/roles_seed_test.sql` | Feed `role_flags` into the round trip |
+| `src/integrations/supabase/types.ts` | Declare the `employees_secure` view |
+| `src/types/scheduling.ts` | Add `is_minor` to `Employee` |
+| `src/hooks/useEmployees.tsx` | Read the view, strip masked keys on write |
+| `src/hooks/useCurrentEmployee.tsx` | Read the view |
+| `src/hooks/useMonthlyMetrics.tsx` | Read the view |
+| `src/hooks/useTimePunches.tsx` | Read the view |
+| `src/hooks/useShifts.tsx` | Narrow the embed to granted columns |
+| `src/hooks/useTimeOffRequests.tsx` | Narrow the embed to granted columns |
+| `src/hooks/useScheduleChangeLogs.tsx` | Narrow the embed to granted columns |
+| `src/components/EmployeeDialog.tsx` | Hide the eight fields, stop the erase |
+| `src/components/EmployeeList.tsx` | Stop rendering a masked rate as `$0.00/hr`, read `is_minor` |
+| `src/components/ReactivateEmployeeDialog.tsx` | Stop reporting a masked rate as "Not set" |
+| `src/components/scheduling/WeekScheduleMobile.tsx` | Read `is_minor` |
+| `src/components/scheduling/ShiftPlanner/EmployeeSidebar.tsx` | Read `is_minor` |
+| `src/pages/Scheduling.tsx` | Read `is_minor` |
+| `src/hooks/useEmployeeLaborCosts.tsx` | Stop understating labor cost on a masked rate |
+| `src/components/scheduling/LaborCostBreakdown.tsx` | Render a masked cost as `—` |
+| `src/components/scheduling/ScheduleMetricsRibbon.tsx` | Say when a total leaves rows out |
+
+---
+
+## Task 1: Seed the flags onto the builtin roles
+
+**Warning: this task must land first.** Every builtin role holds zero `role_flags` rows today. A gate added before the seed locks out 72 production owners.
+
+**Files:**
+- Modify: `src/lib/permissions/definitions.ts`
+- Create: `supabase/migrations/20260806100000_seed_employee_sensitive_flags.sql`
+- Modify: `supabase/tests/roles_seed_test.sql:397-403`, `:439-449`, and the `test_expected_capabilities` fixture
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `user_has_capability(rid, 'view:pay_rates')` returns `TRUE` for a member whose role is Owner, Manager, Operations Manager, Accountant, or Operations Manager (Collaborator). Same for `view:employee_pii`.
+
+**Why these five roles.** Each one already holds `view:employees`. Accountant and Operations Manager (Collaborator) also hold `view:payroll`. A three-role seed takes pay data away from the Accountant, who runs payroll today.
+
+- [ ] **Step 1: Extend the round trip to read `role_flags`**
+
+`derived_capabilities` at `supabase/tests/roles_seed_test.sql:397-403` reads `role_areas` only. A seeded flag is invisible to it, so the round trip would report every new flag as an under-grant. Replace the whole `CREATE TEMP TABLE` statement:
+
+```sql
+CREATE TEMP TABLE derived_capabilities AS
+SELECT r.name AS role_name, acal.capability
+FROM public.roles r
+JOIN public.role_areas ra ON ra.role_id = r.id
+JOIN test_area_capability_at_level acal
+  ON acal.area_key = ra.area_key AND acal.level = ra.level
+WHERE r.builtin = true AND r.restaurant_id IS NULL
+UNION ALL
+-- A sensitive flag is a capability with no area behind it. user_has_capability
+-- resolves it straight off role_flags (20260805120000_page_areas.sql:322-327),
+-- so the round trip must read the same source.
+SELECT r.name AS role_name, rf.flag AS capability
+FROM public.roles r
+JOIN public.role_flags rf ON rf.role_id = r.id
+WHERE r.builtin = true AND r.restaurant_id IS NULL;
+```
+
+- [ ] **Step 2: Replace the zero-rows assertion with the exact expected set**
+
+Replace `supabase/tests/roles_seed_test.sql:439-449` — the comment block and the `SELECT is(...)` under it — with:
+
+```sql
+-- ============================================================================
+-- 2. The two employee flags are seeded onto exactly the five builtin roles
+--    that hold view:employees. view:costs stays unseeded: its gate is not
+--    built yet, so seeding it would grant a capability nothing reads.
+-- ============================================================================
+SELECT set_eq(
+  $$SELECT r.name || '|' || rf.flag
+    FROM public.role_flags rf
+    JOIN public.roles r ON r.id = rf.role_id
+    WHERE r.builtin = true AND r.restaurant_id IS NULL$$,
+  ARRAY[
+    'Owner|view:pay_rates',
+    'Owner|view:employee_pii',
+    'Manager|view:pay_rates',
+    'Manager|view:employee_pii',
+    'Operations Manager|view:pay_rates',
+    'Operations Manager|view:employee_pii',
+    'Accountant|view:pay_rates',
+    'Accountant|view:employee_pii',
+    'Operations Manager (Collaborator)|view:pay_rates',
+    'Operations Manager (Collaborator)|view:employee_pii'
+  ],
+  'the two employee flags are seeded onto exactly the five view:employees roles'
+);
+```
+
+- [ ] **Step 3: Add the ten fixture rows**
+
+`test_expected_capabilities` transcribes `ROLE_CAPABILITIES`. Add two rows for each of the five roles. Put each pair directly after that role's last existing row in the `INSERT INTO test_expected_capabilities ... VALUES` list. For Owner, the last row is `('Owner', 'manage:reviews'),` — insert after it:
+
+```sql
+  ('Owner', 'view:pay_rates'),
+  ('Owner', 'view:employee_pii'),
+```
+
+Repeat for `'Manager'`, `'Operations Manager'`, `'Accountant'`, and `'Operations Manager (Collaborator)'`, each with its own role name. Find each role's last row with:
+
+```bash
+grep -n "^  ('Accountant'," supabase/tests/roles_seed_test.sql | tail -1
+```
+
+- [ ] **Step 4: Run the test to verify it fails**
+
+```bash
+npm run test:db
+```
+
+Expected: FAIL. `roles_seed_test.sql` reports the `set_eq` mismatch (zero rows found, ten expected) and ten under-grants across the five roles.
+
+- [ ] **Step 5: Add the flags to `ROLE_CAPABILITIES`**
+
+In `src/lib/permissions/definitions.ts`, append the two capability strings to five role arrays. Each of the five arrays ends with `'view:reviews',` then `'manage:reviews',`. Insert after `'manage:reviews',` in the `owner`, `manager`, `operations_manager`, `collaborator_accountant`, and `collaborator_operations_manager` blocks:
+
+```typescript
+    // Sensitive-data flags. These five roles hold view:employees, so the
+    // Employees page and the Payroll page are already open to them. Without
+    // the flags, 20260806110000 masks pay and contact data for every user.
+    'view:pay_rates',
+    'view:employee_pii',
+```
+
+Confirm the five blocks with:
+
+```bash
+grep -n "^  owner:\|^  manager:\|^  operations_manager:\|^  collaborator_accountant:\|^  collaborator_operations_manager:" src/lib/permissions/definitions.ts
+```
+
+- [ ] **Step 6: Write the seed migration**
+
+Create `supabase/migrations/20260806100000_seed_employee_sensitive_flags.sql`:
+
+```sql
+-- Seed view:pay_rates and view:employee_pii onto the five builtin roles that
+-- hold view:employees.
+--
+-- Every builtin role holds zero role_flags rows today, and every membership in
+-- production carries a non-null role_id. So user_has_capability takes the flag
+-- branch (20260805120000_page_areas.sql:322-327) and returns FALSE for every
+-- caller. The column gate in 20260806110000 would therefore mask pay and
+-- contact data for every user, including the restaurant owner.
+--
+-- This migration must run before that gate.
+--
+-- view:costs stays unseeded on purpose. Nothing reads it yet, so a grant would
+-- express an intent no code enforces.
+--
+-- The list below matches ROLE_CAPABILITIES in src/lib/permissions/definitions.ts.
+-- supabase/tests/roles_seed_test.sql asserts both sides byte-for-byte.
+
+INSERT INTO public.role_flags (role_id, flag)
+SELECT r.id, f.flag
+FROM public.roles r
+CROSS JOIN LATERAL (VALUES ('view:pay_rates'), ('view:employee_pii')) AS f(flag)
+WHERE r.builtin = true
+  AND r.restaurant_id IS NULL
+  AND r.name IN (
+    'Owner',
+    'Manager',
+    'Operations Manager',
+    'Accountant',
+    'Operations Manager (Collaborator)'
+  )
+ON CONFLICT (role_id, flag) DO NOTHING;
+```
+
+- [ ] **Step 7: Confirm no trigger blocks the insert**
+
+`role_flags_block_builtin_mutation` at `20260730100000_roles_and_areas_tables.sql:467` fires `BEFORE UPDATE OR DELETE`, not `BEFORE INSERT`. So the seed passes with no `DISABLE TRIGGER`. Do not add one — `20260802100000_roles_legacy_role.sql:35` and `20260805120000_page_areas.sql:15` disable their triggers because they run `UPDATE`.
+
+`role_flags` carries `PRIMARY KEY (role_id, flag)`, so the `ON CONFLICT (role_id, flag)` clause resolves. Confirm both facts before you continue:
+
+```bash
+grep -n -A 3 "CREATE TRIGGER role_flags_block_builtin_mutation" supabase/migrations/20260730100000_roles_and_areas_tables.sql
+```
+
+Expected: `BEFORE UPDATE OR DELETE ON public.role_flags`.
+
+- [ ] **Step 8: Reset the local database and run both suites**
+
+```bash
+npm run db:reset && npm run test:db
+```
+
+Expected: PASS. `roles_seed_test.sql` reports 25 of 25.
+
+```bash
+npx vitest run tests/unit/routeAreas.test.ts --reporter=dot
+```
+
+Expected: PASS. The four collaborator allow-lists in that test are area-derived and must not move.
+
+- [ ] **Step 9: Run the full unit suite**
+
+```bash
+npm run test -- --reporter=dot
+```
+
+Expected: PASS. If a test asserts an exact `ROLE_CAPABILITIES` length or set, update it to include the two new strings.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/lib/permissions/definitions.ts supabase/migrations/20260806100000_seed_employee_sensitive_flags.sql supabase/tests/roles_seed_test.sql
+git commit -m "feat(permissions): seed the employee flags onto the five view:employees roles"
+```
+
+---
+
+## Task 2: Stop the write path from erasing masked data
+
+**Warning: a masked column arrives as `NULL`, and the save path writes it back.** This task lands before the gate, so no deploy order can lose data.
+
+**Files:**
+- Create: `src/lib/employeeMaskedFields.ts`
+- Create: `tests/unit/employeeMaskedFields.test.ts`
+- Modify: `src/hooks/useEmployees.tsx:71-101` and `:103-134`
+- Modify: `src/components/EmployeeDialog.tsx:551-553`, `:623`, `:872`, `:937`, `:1034`
+
+**Interfaces:**
+- Produces:
+  - `PAY_RATE_FIELDS: readonly MaskedEmployeeField[]`
+  - `EMPLOYEE_PII_FIELDS: readonly MaskedEmployeeField[]`
+  - `type MaskedEmployeeField`
+  - `maskedEmployeeFields(held: { payRates: boolean; employeePii: boolean }): MaskedEmployeeField[]`
+  - `stripMaskedEmployeeFields<T extends object>(payload: T, masked: readonly MaskedEmployeeField[]): T`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/employeeMaskedFields.test.ts`:
+
+```typescript
+import { describe, expect, it } from 'vitest';
+import {
+  EMPLOYEE_PII_FIELDS,
+  PAY_RATE_FIELDS,
+  maskedEmployeeFields,
+  stripMaskedEmployeeFields,
+} from '@/lib/employeeMaskedFields';
+
+describe('maskedEmployeeFields', () => {
+  it('masks nothing when the caller holds both flags', () => {
+    expect(maskedEmployeeFields({ payRates: true, employeePii: true })).toEqual([]);
+  });
+
+  it('masks the pay fields when the caller lacks view:pay_rates', () => {
+    expect(maskedEmployeeFields({ payRates: false, employeePii: true }))
+      .toEqual([...PAY_RATE_FIELDS]);
+  });
+
+  it('masks the contact fields when the caller lacks view:employee_pii', () => {
+    expect(maskedEmployeeFields({ payRates: true, employeePii: false }))
+      .toEqual([...EMPLOYEE_PII_FIELDS]);
+  });
+
+  it('masks all eight fields when the caller holds neither flag', () => {
+    expect(maskedEmployeeFields({ payRates: false, employeePii: false }))
+      .toHaveLength(8);
+  });
+});
+
+describe('stripMaskedEmployeeFields', () => {
+  it('drops every masked key from the payload', () => {
+    const payload = {
+      id: 'e1',
+      name: 'Ada',
+      hourly_rate: 0,
+      salary_amount: undefined,
+      email: undefined,
+      date_of_birth: null,
+    };
+
+    const result = stripMaskedEmployeeFields(payload, [
+      'hourly_rate',
+      'salary_amount',
+      'email',
+      'date_of_birth',
+    ]);
+
+    expect(result).toEqual({ id: 'e1', name: 'Ada' });
+  });
+
+  it('keeps a key that is not masked, even when its value is null', () => {
+    const result = stripMaskedEmployeeFields(
+      { id: 'e1', notes: null, hourly_rate: 0 },
+      ['hourly_rate']
+    );
+
+    expect(result).toEqual({ id: 'e1', notes: null });
+  });
+
+  it('returns a new object and does not change the input', () => {
+    const payload = { id: 'e1', hourly_rate: 0 };
+    const result = stripMaskedEmployeeFields(payload, ['hourly_rate']);
+
+    expect(result).not.toBe(payload);
+    expect(payload).toEqual({ id: 'e1', hourly_rate: 0 });
+  });
+
+  it('drops nothing when the masked list is empty', () => {
+    const payload = { id: 'e1', hourly_rate: 1500 };
+    expect(stripMaskedEmployeeFields(payload, [])).toEqual(payload);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+npx vitest run tests/unit/employeeMaskedFields.test.ts --reporter=dot
+```
+
+Expected: FAIL with `Failed to resolve import "@/lib/employeeMaskedFields"`.
+
+- [ ] **Step 3: Write the module**
+
+Create `src/lib/employeeMaskedFields.ts`:
+
+```typescript
+/**
+ * The eight columns of public.employees that 20260806110000 masks.
+ *
+ * The masking view returns NULL for a column the caller has no flag for. The
+ * Edit Employee form then loads that NULL into its state and writes it back on
+ * save. The column keeps its UPDATE grant, so the write succeeds and the real
+ * value is gone.
+ *
+ * The strip below is the fix. It runs in the mutation hooks, not in the form:
+ * four call sites write employees (EmployeeDialog, ShiftImportSheet,
+ * TimePunchUploadSheet, useSlingEmployeeMapping), and a per-field gate in one
+ * component protects one of them.
+ */
+
+/** Masked by view:pay_rates. */
+export const PAY_RATE_FIELDS = [
+  'hourly_rate',
+  'salary_amount',
+  'contractor_payment_amount',
+  'daily_rate_amount',
+  'daily_rate_reference_weekly',
+] as const;
+
+/** Masked by view:employee_pii. */
+export const EMPLOYEE_PII_FIELDS = [
+  'email',
+  'phone',
+  'date_of_birth',
+] as const;
+
+export type MaskedEmployeeField =
+  | (typeof PAY_RATE_FIELDS)[number]
+  | (typeof EMPLOYEE_PII_FIELDS)[number];
+
+/** Which fields the caller may not read, and therefore may not write. */
+export function maskedEmployeeFields(held: {
+  payRates: boolean;
+  employeePii: boolean;
+}): MaskedEmployeeField[] {
+  const masked: MaskedEmployeeField[] = [];
+  if (!held.payRates) masked.push(...PAY_RATE_FIELDS);
+  if (!held.employeePii) masked.push(...EMPLOYEE_PII_FIELDS);
+  return masked;
+}
+
+/** Remove every masked key. Returns a new object. */
+export function stripMaskedEmployeeFields<T extends object>(
+  payload: T,
+  masked: readonly MaskedEmployeeField[]
+): T {
+  if (masked.length === 0) return { ...payload };
+
+  const blocked = new Set<string>(masked);
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(payload)) {
+    if (!blocked.has(key)) result[key] = value;
+  }
+
+  return result as T;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+npx vitest run tests/unit/employeeMaskedFields.test.ts --reporter=dot
+```
+
+Expected: PASS, 8 tests.
+
+- [ ] **Step 5: Wire the strip into both mutation hooks**
+
+In `src/hooks/useEmployees.tsx`, add to the import block after line 3:
+
+```typescript
+import { usePermissions } from '@/hooks/usePermissions';
+import {
+  maskedEmployeeFields,
+  stripMaskedEmployeeFields,
+} from '@/lib/employeeMaskedFields';
+```
+
+Replace `useCreateEmployee` (lines 71-101) with:
+
+```typescript
+export const useCreateEmployee = () => {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const { hasCapability, isResolved } = usePermissions();
+
+  return useMutation({
+    mutationFn: async (employee: Omit<Employee, 'id' | 'created_at' | 'updated_at'>) => {
+      // A caller with no flag cannot read these columns, so the form holds
+      // NULL for them. Writing that NULL back would erase the stored value.
+      const masked = maskedEmployeeFields({
+        payRates: isResolved && hasCapability('view:pay_rates'),
+        employeePii: isResolved && hasCapability('view:employee_pii'),
+      });
+
+      const { data, error } = await supabase
+        .from('employees')
+        .insert(stripMaskedEmployeeFields(employee, masked))
+        .select('id, restaurant_id, name')
+        .single();
+
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['employees', data.restaurant_id] });
+      toast({
+        title: 'Employee created',
+        description: `${data.name} has been added to the team.`,
+      });
+    },
+    onError: (error: Error) => {
+      toast({
+        title: 'Error creating employee',
+        description: error.message,
+        variant: 'destructive',
+      });
+    },
+  });
+};
+```
+
+Replace `useUpdateEmployee` (lines 103-134) with:
+
+```typescript
+export const useUpdateEmployee = () => {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const { hasCapability, isResolved } = usePermissions();
+
+  return useMutation({
+    mutationFn: async ({ id, ...updates }: Partial<Employee> & { id: string }) => {
+      const masked = maskedEmployeeFields({
+        payRates: isResolved && hasCapability('view:pay_rates'),
+        employeePii: isResolved && hasCapability('view:employee_pii'),
+      });
+
+      const { data, error } = await supabase
+        .from('employees')
+        .update(stripMaskedEmployeeFields(updates, masked))
+        .eq('id', id)
+        .select('id, restaurant_id, name')
+        .single();
+
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['employees', data.restaurant_id] });
+      toast({
+        title: 'Employee updated',
+        description: `${data.name}'s information has been updated.`,
+      });
+    },
+    onError: (error: Error) => {
+      toast({
+        title: 'Error updating employee',
+        description: error.message,
+        variant: 'destructive',
+      });
+    },
+  });
+};
+```
+
+The bare `.select()` becomes `.select('id, restaurant_id, name')`. A bare `.select()` after a mutation sends `Prefer: return=representation`, which needs SELECT on every column of the row. Task 3 revokes eight of them, so the bare form starts to fail with `permission denied for column hourly_rate`. Only those three fields reach `onSuccess`.
+
+- [ ] **Step 6: Stop the dialog from fabricating a zero rate**
+
+In `src/components/EmployeeDialog.tsx`, replace lines 551-553:
+
+```typescript
+    const hourlyRateInCents = compensationType === 'hourly' 
+      ? Math.round(Number.parseFloat(hourlyRate || '0') * 100)
+      : 0;
+```
+
+with:
+
+```typescript
+    // An empty box is "unknown", not "zero". A fabricated 0 reaches
+    // hasCompensationChanged below, compares unequal to the real rate, and
+    // writes a permanent $0.00 row into the compensation history.
+    const hourlyRateInCents = compensationType === 'hourly' && hourlyRate.trim() !== ''
+      ? Math.round(Number.parseFloat(hourlyRate) * 100)
+      : undefined;
+```
+
+- [ ] **Step 7: Fix the two call sites that assume a number**
+
+Three declarations type the value as `number`. Change each to `number | undefined`:
+
+- line 323 — the field on the `hasCompensationChanged` payload interface
+- line 354 — the `buildHistoryPayload` parameter
+- line 608 — the `proceedWithSubmit` parameter
+
+```bash
+grep -n "hourlyRateInCents" src/components/EmployeeDialog.tsx
+```
+
+Two sites then read the value. Line 336 compares `existing.hourly_rate !== payload.hourlyRateInCents`. Lines 360-361 test `hourlyRateInCents > 0` before they build a history row; `undefined > 0` is `false`, so that site already skips an unknown rate.
+
+Inside `hasCompensationChanged`, add a first guard so an unknown rate never counts as a change:
+
+```typescript
+  if (next.compensationType === 'hourly' && next.hourlyRateInCents === undefined) {
+    return false;
+  }
+```
+
+`buildHistoryPayload` needs no new guard. Its `hourlyRateInCents > 0` test at line 360 already returns `undefined` for an unknown rate, because `undefined > 0` is `false`. Change the parameter type only.
+
+- [ ] **Step 8: Stop the dialog from erasing the date of birth**
+
+Replace `src/components/EmployeeDialog.tsx:623`:
+
+```typescript
+      date_of_birth: dateOfBirth || null,
+```
+
+with:
+
+```typescript
+      // undefined drops out of the JSON body. null would erase a stored date
+      // whenever the box is empty — which it always is under a masked read.
+      date_of_birth: dateOfBirth || undefined,
+```
+
+- [ ] **Step 9: Drop `required` from the three pay inputs**
+
+Three pay inputs carry `required`: `hourlyRate` at line 872, `salaryAmount` at line 937, and `contractorPaymentAmount` at line 1034. A masked field renders empty, so `required` blocks every save. Delete all three lines.
+
+```bash
+grep -n "^                      required$" src/components/EmployeeDialog.tsx
+```
+
+Expected before the edit: lines 872, 937, 1034. Expected after: no output.
+
+- [ ] **Step 10: Type-check and run the unit suite**
+
+```bash
+npm run typecheck && npm run test -- --reporter=dot
+```
+
+Expected: PASS both.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/lib/employeeMaskedFields.ts tests/unit/employeeMaskedFields.test.ts src/hooks/useEmployees.tsx src/components/EmployeeDialog.tsx
+git commit -m "fix(employees): stop the save path from erasing a field the caller cannot read"
+```
+
+---
+
+## Task 3: Add the column gate
+
+**Files:**
+- Create: `supabase/migrations/20260806110000_employee_column_gating.sql`
+- Create: `supabase/tests/employee_column_gating_test.sql`
+
+**Interfaces:**
+- Consumes: `public.user_has_capability(uuid, text)` from `20260805120000_page_areas.sql`. The five seeded roles from Task 1.
+- Produces: `public.employees_secure`, a view with 38 columns plus `is_minor boolean`. `authenticated` holds SELECT on it and on 30 columns of `public.employees`.
+
+- [ ] **Step 1: Write the failing pgTAP test**
+
+Create `supabase/tests/employee_column_gating_test.sql`:
+
+```sql
+-- ============================================================================
+-- employee_column_gating_test.sql
+--
+-- Coverage for 20260806110000: the eight sensitive columns of public.employees
+-- are revoked from `authenticated`, and public.employees_secure is the only
+-- path to them.
+--
+-- Warning: a normal test role cannot read another role's column grants.
+-- has_column_privilege raises "permission denied" unless the session is a
+-- superuser. `SET LOCAL role TO postgres` is required, not decorative. The
+-- same idiom is at supabase/tests/review_responses_rls_test.sql:98-110.
+--
+-- Warning: a grant-posture assertion that passes on a bare local Postgres has
+-- proven nothing. Production creates every public table under `ALTER DEFAULT
+-- PRIVILEGES ... GRANT ALL ON TABLES TO service_role`, and a local instance
+-- has no such default to revoke. Read pg_default_acl before you trust a green.
+-- ============================================================================
+BEGIN;
+
+SELECT plan(14);
+
+SET LOCAL role TO postgres;
+
+-- ----------------------------------------------------------------------------
+-- 1. The eight sensitive columns are closed to `authenticated`.
+-- ----------------------------------------------------------------------------
+SELECT is(
+  has_column_privilege('authenticated', 'public.employees', 'hourly_rate', 'SELECT'),
+  FALSE, 'authenticated cannot SELECT employees.hourly_rate'
+);
+SELECT is(
+  has_column_privilege('authenticated', 'public.employees', 'salary_amount', 'SELECT'),
+  FALSE, 'authenticated cannot SELECT employees.salary_amount'
+);
+SELECT is(
+  has_column_privilege('authenticated', 'public.employees', 'contractor_payment_amount', 'SELECT'),
+  FALSE, 'authenticated cannot SELECT employees.contractor_payment_amount'
+);
+SELECT is(
+  has_column_privilege('authenticated', 'public.employees', 'daily_rate_amount', 'SELECT'),
+  FALSE, 'authenticated cannot SELECT employees.daily_rate_amount'
+);
+SELECT is(
+  has_column_privilege('authenticated', 'public.employees', 'daily_rate_reference_weekly', 'SELECT'),
+  FALSE, 'authenticated cannot SELECT employees.daily_rate_reference_weekly'
+);
+SELECT is(
+  has_column_privilege('authenticated', 'public.employees', 'email', 'SELECT'),
+  FALSE, 'authenticated cannot SELECT employees.email'
+);
+SELECT is(
+  has_column_privilege('authenticated', 'public.employees', 'phone', 'SELECT'),
+  FALSE, 'authenticated cannot SELECT employees.phone'
+);
+SELECT is(
+  has_column_privilege('authenticated', 'public.employees', 'date_of_birth', 'SELECT'),
+  FALSE, 'authenticated cannot SELECT employees.date_of_birth'
+);
+
+-- ----------------------------------------------------------------------------
+-- 2. The 30 plain columns stay open, and anon stays shut.
+-- ----------------------------------------------------------------------------
+SELECT is(
+  has_column_privilege('authenticated', 'public.employees', 'name', 'SELECT'),
+  TRUE, 'authenticated can still SELECT employees.name'
+);
+SELECT is(
+  has_column_privilege('authenticated', 'public.employees', 'restaurant_id', 'SELECT'),
+  TRUE, 'authenticated can still SELECT employees.restaurant_id'
+);
+SELECT is(
+  has_table_privilege('anon', 'public.employees_secure', 'SELECT'),
+  FALSE, 'anon cannot SELECT the masking view'
+);
+SELECT is(
+  has_table_privilege('authenticated', 'public.employees_secure', 'SELECT'),
+  TRUE, 'authenticated can SELECT the masking view'
+);
+
+-- ----------------------------------------------------------------------------
+-- 3. The view runs with owner rights and carries its own row predicate.
+--    security_invoker must stay off: the caller no longer holds the column
+--    privilege, so an invoker-rights view fails for everyone.
+-- ----------------------------------------------------------------------------
+SELECT is(
+  (SELECT COALESCE(
+     (SELECT option FROM unnest(c.reloptions) AS option
+      WHERE option LIKE 'security_invoker=%'), 'unset')
+   FROM pg_class c
+   JOIN pg_namespace n ON n.oid = c.relnamespace
+   WHERE n.nspname = 'public' AND c.relname = 'employees_secure'),
+  'unset',
+  'employees_secure does not set security_invoker'
+);
+
+SELECT ok(
+  (SELECT pg_get_viewdef('public.employees_secure'::regclass) LIKE '%user_restaurants%'),
+  'employees_secure carries its own row predicate against user_restaurants'
+);
+
+SELECT * FROM finish();
+ROLLBACK;
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+npm run test:db
+```
+
+Expected: FAIL. `employee_column_gating_test.sql` reports `relation "public.employees_secure" does not exist`.
+
+- [ ] **Step 3: Write the migration**
+
+Create `supabase/migrations/20260806110000_employee_column_gating.sql`:
+
+```sql
+-- Gate the eight sensitive columns of public.employees behind view:pay_rates
+-- and view:employee_pii.
+--
+-- RLS filters rows. It cannot mask a column. A column GRANT is a role-level
+-- privilege, so it cannot depend on user_has_capability. The mechanism is
+-- therefore a column REVOKE plus a view that applies the capability check per
+-- row.
+--
+-- The REVOKE is the control. The view is the accessor. A caller who goes
+-- around the view hits the column ACL and gets "permission denied for column
+-- hourly_rate". PostgREST cannot bypass the ACL.
+--
+-- Prerequisite: 20260806100000 seeds the two flags onto the five builtin roles
+-- that hold view:employees. Without that seed this migration masks pay and
+-- contact data for every user, the owner included.
+
+-- ============================================================================
+-- Step 1: the masking view
+-- ============================================================================
+--
+-- security_invoker stays OFF, unlike its siblings active_employees and
+-- inactive_employees. Do not "fix" this view to match them. The caller no
+-- longer holds SELECT on the eight columns, so an invoker-rights view would
+-- fail for everyone, flag or no flag.
+--
+-- An owner-rights view bypasses the base table's RLS, so the view carries its
+-- own row predicate. That predicate is the union of the SELECT-capable
+-- policies on public.employees:
+--   "Team members can view coworkers in their restaurant" (membership)
+--   "Users can view employees for their restaurants"      (view:employees)
+--   "Owners and managers can manage employees"            (user_has_role)
+--   "Employees can view their own record"                 (self)
+-- The first is the widest: user_has_capability and user_has_role both read
+-- user_restaurants, so both are subsets of the membership test. No user gains
+-- or loses a row.
+--
+-- security_barrier protects the ROW filter from a cheap user-supplied
+-- function that leaks values before the predicate runs. It does not protect
+-- the column mask: a CASE in a target list is not a qual, and Postgres does
+-- not reorder target-list evaluation.
+--
+-- The CROSS JOIN LATERAL computes the two booleans once per row. Eight
+-- separate user_has_capability calls would be eight distinct expression
+-- nodes, each evaluated per row — 1,600 calls for a 200-employee roster to
+-- answer two questions. STABLE does not memoize across rows.
+--
+-- is_minor goes to every member. isMinor(date_of_birth) returns false for a
+-- null date, so a masked date would silently delete the "Minor" badge from the
+-- roster. That badge is a labor-compliance cue. The raw date stays gated.
+CREATE VIEW public.employees_secure
+WITH (security_barrier = true) AS
+SELECT
+  e.id,
+  e.restaurant_id,
+  e.name,
+  e.position,
+  e.area,
+  e.status,
+  e.hire_date,
+  e.termination_date,
+  e.notes,
+  e.created_at,
+  e.updated_at,
+  e.user_id,
+  e.compensation_type,
+  e.pay_period_type,
+  e.contractor_payment_interval,
+  e.allocate_daily,
+  e.tip_eligible,
+  e.requires_time_punch,
+  e.is_active,
+  e.deactivation_reason,
+  e.deactivated_at,
+  e.deactivated_by,
+  e.reactivated_at,
+  e.reactivated_by,
+  e.last_active_date,
+  e.daily_rate_reference_days,
+  e.is_exempt,
+  e.exempt_changed_at,
+  e.exempt_changed_by,
+  e.employment_type,
+  CASE WHEN caps.pay THEN e.hourly_rate END                 AS hourly_rate,
+  CASE WHEN caps.pay THEN e.salary_amount END               AS salary_amount,
+  CASE WHEN caps.pay THEN e.contractor_payment_amount END   AS contractor_payment_amount,
+  CASE WHEN caps.pay THEN e.daily_rate_amount END           AS daily_rate_amount,
+  CASE WHEN caps.pay THEN e.daily_rate_reference_weekly END AS daily_rate_reference_weekly,
+  CASE WHEN caps.pii THEN e.email END                       AS email,
+  CASE WHEN caps.pii THEN e.phone END                       AS phone,
+  CASE WHEN caps.pii THEN e.date_of_birth END               AS date_of_birth,
+  (e.date_of_birth IS NOT NULL
+   AND e.date_of_birth > (CURRENT_DATE - INTERVAL '18 years')) AS is_minor
+FROM public.employees e
+CROSS JOIN LATERAL (
+  SELECT public.user_has_capability(e.restaurant_id, 'view:pay_rates')    AS pay,
+         public.user_has_capability(e.restaurant_id, 'view:employee_pii') AS pii
+) caps
+WHERE e.restaurant_id IN (
+        SELECT ur.restaurant_id
+        FROM public.user_restaurants ur
+        WHERE ur.user_id = auth.uid())
+   OR e.user_id = auth.uid();
+
+COMMENT ON VIEW public.employees_secure IS
+  'Read path for public.employees. Returns NULL for a pay or contact column '
+  'the caller has no flag for. Owner rights on purpose: authenticated holds '
+  'no SELECT on those columns, so an invoker-rights view would fail for all.';
+
+-- ============================================================================
+-- Step 2: the grant posture
+-- ============================================================================
+--
+-- Revoke from every role the stock ALTER DEFAULT PRIVILEGES entry grants to.
+-- REVOKE ... FROM PUBLIC cannot undo a direct grant to anon or to
+-- service_role, so name each one.
+REVOKE SELECT ON public.employees FROM PUBLIC, anon, authenticated, service_role;
+
+GRANT SELECT (
+  id, restaurant_id, name, position, area, status, hire_date,
+  termination_date, notes, created_at, updated_at, user_id,
+  compensation_type, pay_period_type, contractor_payment_interval,
+  allocate_daily, tip_eligible, requires_time_punch, is_active,
+  deactivation_reason, deactivated_at, deactivated_by, reactivated_at,
+  reactivated_by, last_active_date, daily_rate_reference_days,
+  is_exempt, exempt_changed_at, exempt_changed_by, employment_type
+) ON public.employees TO authenticated;
+
+-- service_role keeps the whole table. The payroll edge functions need pay, and
+-- rolbypassrls makes the table ACL the only control behind that role. State
+-- the grant. Do not inherit it.
+GRANT SELECT ON public.employees TO service_role;
+
+GRANT  SELECT ON public.employees_secure TO authenticated;
+REVOKE SELECT ON public.employees_secure FROM PUBLIC, anon;
+
+-- ============================================================================
+-- Step 3: employee_compensation_history
+-- ============================================================================
+--
+-- The whole table is pay data, so a row policy states the rule exactly. No
+-- view and no column grant are needed. PostgREST drops the embedded rows
+-- under RLS with no error for the client to handle.
+DROP POLICY IF EXISTS "Users can view compensation history for their restaurants"
+  ON public.employee_compensation_history;
+
+CREATE POLICY "Users can view compensation history for their restaurants"
+  ON public.employee_compensation_history
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.user_restaurants ur
+      WHERE ur.restaurant_id = employee_compensation_history.restaurant_id
+        AND ur.user_id = auth.uid()
+    )
+    AND public.user_has_capability(
+      employee_compensation_history.restaurant_id, 'view:pay_rates')
+  );
+```
+
+- [ ] **Step 4: Reset the database and run the pgTAP suite**
+
+```bash
+npm run db:reset && npm run test:db
+```
+
+Expected: PASS. `employee_column_gating_test.sql` reports 14 of 14.
+
+- [ ] **Step 5: Verify PostgREST resolves the embed from the view**
+
+The client embeds `employee_compensation_history` off the employee row. PostgREST infers a view-to-table relationship only when the view column traces to the base column through `pg_depend`. `employees_secure.id` is a plain `e.id`, so the trace holds. Confirm it before the client work depends on it:
+
+```bash
+curl -s "http://127.0.0.1:54321/rest/v1/employees_secure?select=id,name,compensation_history:employee_compensation_history(id)&limit=1" \
+  -H "apikey: $(grep ANON .env.local | head -1 | cut -d= -f2)" | head -c 400
+```
+
+Expected: `[]` or a JSON array. A body containing `"code":"PGRST200"` means the embed does not resolve. In that case, change Task 4 Step 3 to fetch compensation history in a second query keyed by `employee_id`, and record the change in the plan.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add supabase/migrations/20260806110000_employee_column_gating.sql supabase/tests/employee_column_gating_test.sql
+git commit -m "feat(employees): gate the pay and contact columns behind the two flags"
+```
+
+---
+
+## Task 4: Point every reader at the view
+
+**Files:**
+- Modify: `src/integrations/supabase/types.ts`
+- Modify: `src/types/scheduling.ts:27-80`
+- Modify: `src/hooks/useEmployees.tsx:33-38`
+- Modify: `src/hooks/useCurrentEmployee.tsx:20-27`
+- Modify: `src/hooks/useMonthlyMetrics.tsx:406-409`
+- Modify: `src/hooks/useTimePunches.tsx:597-602`
+- Modify: `src/hooks/useShifts.tsx:58-61`
+- Modify: `src/hooks/useTimeOffRequests.tsx:13-20`
+- Modify: `src/hooks/useScheduleChangeLogs.tsx:12-14`
+- Modify: `src/components/EmployeeList.tsx:221-236` and `:294`
+- Modify: `src/components/scheduling/WeekScheduleMobile.tsx:91`
+- Modify: `src/components/scheduling/ShiftPlanner/EmployeeSidebar.tsx:32`, `:159`, `:180`
+- Modify: `src/pages/Scheduling.tsx:1286`
+- Modify: `src/hooks/useEmployeeLaborCosts.tsx:5-22`, `:40-46`, `:56-120`, `:129-148`
+- Modify: `src/components/scheduling/LaborCostBreakdown.tsx`
+- Modify: `src/components/scheduling/ScheduleMetricsRibbon.tsx:175`, `:241`
+- Modify: `src/components/ReactivateEmployeeDialog.tsx:73-75`
+- Modify: `src/lib/permissions/areas.ts:105-110`
+- Create: `tests/e2e/sensitive-data-flags.spec.ts`
+
+**Interfaces:**
+- Consumes: `public.employees_secure` from Task 3.
+- Produces: `Employee.is_minor?: boolean`.
+
+- [ ] **Step 1: Declare the view in the generated types**
+
+The repository has no type-generation script, so hand-add the entry. In `src/integrations/supabase/types.ts`, insert a new key inside the `Views` block that starts at line 10276. Put it after the `active_employees` block ends (the `]` and `}` at lines 10379-10380) and before `inactive_employees:`:
+
+```typescript
+      employees_secure: {
+        Row: {
+          allocate_daily: boolean | null
+          area: string | null
+          compensation_type: string | null
+          contractor_payment_amount: number | null
+          contractor_payment_interval: string | null
+          created_at: string | null
+          daily_rate_amount: number | null
+          daily_rate_reference_days: number | null
+          daily_rate_reference_weekly: number | null
+          date_of_birth: string | null
+          deactivated_at: string | null
+          deactivated_by: string | null
+          deactivation_reason: string | null
+          email: string | null
+          employment_type: string | null
+          exempt_changed_at: string | null
+          exempt_changed_by: string | null
+          hire_date: string | null
+          hourly_rate: number | null
+          id: string | null
+          is_active: boolean | null
+          is_exempt: boolean | null
+          is_minor: boolean | null
+          last_active_date: string | null
+          name: string | null
+          notes: string | null
+          pay_period_type: string | null
+          phone: string | null
+          position: string | null
+          reactivated_at: string | null
+          reactivated_by: string | null
+          requires_time_punch: boolean | null
+          restaurant_id: string | null
+          salary_amount: number | null
+          status: string | null
+          termination_date: string | null
+          tip_eligible: boolean | null
+          updated_at: string | null
+          user_id: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "employees_restaurant_id_fkey"
+            columns: ["restaurant_id"]
+            isOneToOne: false
+            referencedRelation: "restaurants"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+```
+
+Then add a fourth entry to the `Relationships` array of `employee_compensation_history`, next to the three that already name `active_employees`, `employees`, and `inactive_employees` (around line 2330). Copy the `employees` entry and change one field:
+
+```typescript
+          {
+            foreignKeyName: "employee_compensation_history_employee_id_fkey"
+            columns: ["employee_id"]
+            isOneToOne: false
+            referencedRelation: "employees_secure"
+            referencedColumns: ["id"]
+          },
+```
+
+- [ ] **Step 2: Add `is_minor` to the `Employee` type**
+
+In `src/types/scheduling.ts`, add to the `Employee` interface after the `date_of_birth` field:
+
+```typescript
+  /**
+   * Computed by public.employees_secure, not by the client.
+   *
+   * date_of_birth is masked behind view:employee_pii, and isMinor() returns
+   * false for a null date. Reading the badge off the raw date would delete a
+   * labor-compliance cue for every user without the flag. The view returns
+   * the boolean to every member and keeps the date gated.
+   */
+  is_minor?: boolean;
+```
+
+If `date_of_birth` is absent from the interface, add both fields together:
+
+```typescript
+  date_of_birth?: string;
+```
+
+- [ ] **Step 3: Point the four direct readers at the view**
+
+`src/hooks/useEmployees.tsx:34` — change `.from('employees')` to `.from('employees_secure')`. Leave the select string as it is.
+
+`src/hooks/useCurrentEmployee.tsx:22` — change `.from('employees')` to `.from('employees_secure')`.
+
+`src/hooks/useMonthlyMetrics.tsx:408` — change `.from('employees')` to `.from('employees_secure')`.
+
+`src/hooks/useTimePunches.tsx:599` — change `.from('employees')` to `.from('employees_secure')`.
+
+- [ ] **Step 4: Narrow the three embeds**
+
+A PostgREST resource embed resolves against the base table, not the view. `employees(*)` would ask for eight revoked columns and fail with `permission denied for column hourly_rate`. Replace `employees(*)` with an explicit list of granted columns at each site.
+
+`src/hooks/useShifts.tsx:60`:
+
+```typescript
+        .select('*, employee:employees(id, name, position, area, status, is_active, employment_type, user_id)')
+```
+
+`src/hooks/useTimeOffRequests.tsx:15-18` — replace `employee:employees(*)` inside the template string with:
+
+```typescript
+          employee:employees(id, name, position, area, status, is_active, employment_type, user_id)
+```
+
+`src/hooks/useScheduleChangeLogs.tsx:17` — same replacement.
+
+The three consumers read `employee.id`, `employee.name`, `employee.position`, `employee.is_active`, and `employee.employment_type`. None reads a masked column off a shift. Confirm before you commit:
+
+```bash
+grep -rn "employee\?\?\.\|\.employee\?\.\|\.employee\." src/components/scheduling src/pages/Scheduling.tsx | grep -o "employee[?]\{0,1\}\.[a-z_]*" | sort -u
+```
+
+Expected output: only `employee.id`, `employee.name`, `employee.position`, `employee.is_active`, `employee.employment_type`, and `employee.date_of_birth`. Every `date_of_birth` hit comes from the employees list, not from a shift embed — Step 5 replaces those.
+
+- [ ] **Step 5: Read `is_minor` from the row**
+
+Four components call `isMinor(employee.date_of_birth)`. Replace each call with `employee.is_minor`.
+
+`src/components/EmployeeList.tsx:294` — `{isMinor(employee.date_of_birth) && (` becomes `{employee.is_minor && (`. Delete `isMinor` from the import at line 13 if nothing else in the file uses it.
+
+`src/components/scheduling/WeekScheduleMobile.tsx:91` — `const isMinorEmployee = isMinor(employee.date_of_birth);` becomes `const isMinorEmployee = employee.is_minor === true;`. Delete the import at line 6.
+
+`src/pages/Scheduling.tsx:1286` — same replacement. Delete the import at line 80.
+
+`src/components/scheduling/ShiftPlanner/EmployeeSidebar.tsx` — replace `date_of_birth?: string;` at line 32 with `is_minor?: boolean;`, replace the call at line 159 with `{employee.is_minor && (`, and replace the memo comparison at line 180:
+
+```typescript
+    prev.employee.is_minor === next.employee.is_minor &&
+```
+
+`src/components/EmployeeDialog.tsx:1287` keeps `isMinor(dateOfBirth)`. That call reads the form's own state, which holds the value the user just typed. Leave it, and leave `computeAge` in `src/lib/employeeUtils.ts`.
+
+- [ ] **Step 6: Stop rendering a masked rate as money**
+
+In `src/components/EmployeeList.tsx`, replace `getCompensationDisplay` at lines 225-236:
+
+```typescript
+  const getCompensationDisplay = () => {
+    // A masked column arrives as null. `$0.00/hr` would read as a real rate.
+    switch (employee.compensation_type) {
+      case 'hourly':
+        return employee.hourly_rate == null
+          ? 'Hidden'
+          : `${formatCurrency(employee.hourly_rate)}/hr`;
+      case 'salary':
+        return employee.salary_amount == null
+          ? 'Hidden'
+          : `${formatCurrency(employee.salary_amount)}/${employee.pay_period_type}`;
+      case 'contractor':
+        return employee.contractor_payment_amount == null
+          ? 'Hidden'
+          : `${formatCurrency(employee.contractor_payment_amount)}/${employee.contractor_payment_interval}`;
+      default:
+        return '';
+    }
+  };
+```
+
+In `src/components/ReactivateEmployeeDialog.tsx:73-75`, read the current text first. Change the fallback so a `null` rate reads `Hidden`, not `Not set`.
+
+- [ ] **Step 7: Stop understating labor cost**
+
+All four branches of the switch at `src/hooks/useEmployeeLaborCosts.tsx:61-100` produce `cost = 0` for a masked value. The `hourly` branch reads `(emp.hourly_rate || 0)`. The other three sit behind an `if (emp.<column> && …)` that a `null` fails. So the page reports a labor cost far below the real one, and the P&L follows it.
+
+Mark the row instead. Add the two fields first — `src/hooks/useEmployeeLaborCosts.tsx:5-22`:
+
+```typescript
+export interface EmployeeLaborCost {
+  id: string;
+  name: string;
+  position: string;
+  hours: number;
+  rate: number; // Effective hourly rate in dollars
+  cost: number; // Total cost in dollars
+  compensationType: string;
+  isOutlier: boolean;
+  outlierLevel: 'none' | 'warning' | 'critical';
+  /** True when the caller has no view:pay_rates, so cost and rate are unknown. */
+  costIsHidden: boolean;
+}
+
+export interface LaborCostSummary {
+  totalCost: number;
+  totalHours: number;
+  averageHourlyRate: number;
+  isAverageHigh: boolean;
+  employeeCosts: EmployeeLaborCost[];
+  /** How many employees the totals leave out because their pay is masked. */
+  hiddenCostCount: number;
+}
+```
+
+Add `hiddenCostCount: 0` to the early return at lines 40-46.
+
+Insert the guard directly after `const hours = …` at line 56, before `let rate = 0;`:
+
+```typescript
+      // A masked pay column arrives as null. A $0 cost understates labor and
+      // drives a wrong P&L, so mark the row unknown and leave it out of the
+      // totals. The hours stay visible: they are not pay data.
+      const payIsHidden =
+        (emp.compensation_type === 'hourly' && emp.hourly_rate == null) ||
+        (emp.compensation_type === 'salary' && emp.salary_amount == null) ||
+        (emp.compensation_type === 'daily_rate' && emp.daily_rate_amount == null) ||
+        (emp.compensation_type === 'contractor' && emp.contractor_payment_amount == null);
+```
+
+Guard the switch so a masked row never enters it. Replace `switch (emp.compensation_type) {` at line 61 with:
+
+```typescript
+      if (!payIsHidden) switch (emp.compensation_type) {
+```
+
+Add the field to the `employeeCostsMap.set` call at lines 110-120:
+
+```typescript
+        outlierLevel,
+        costIsHidden: payIsHidden,
+```
+
+A masked row keeps `rate = 0`, so `outlierLevel` stays `'none'` and no false typo warning appears.
+
+Exclude masked rows from every total. Replace lines 129-136:
+
+```typescript
+    // A masked row has no cost to add. Counting its 0 would drag the average
+    // down and understate the total.
+    const visibleCosts = employeeCosts.filter(e => !e.costIsHidden);
+    const hiddenCostCount = employeeCosts.length - visibleCosts.length;
+
+    // Calculate totals (only from hourly employees for meaningful average)
+    const hourlyEmployees = visibleCosts.filter(e => e.compensationType === 'hourly');
+    const totalHourlyCost = hourlyEmployees.reduce((sum, e) => sum + e.cost, 0);
+    const totalHourlyHours = hourlyEmployees.reduce((sum, e) => sum + e.hours, 0);
+
+    const totalCost = visibleCosts.reduce((sum, e) => sum + e.cost, 0);
+    const totalHours = visibleCosts.reduce((sum, e) => sum + e.hours, 0);
+```
+
+Add `hiddenCostCount,` to the returned object at lines 142-148.
+
+Then fix the two consumers.
+
+`src/components/scheduling/LaborCostBreakdown.tsx` renders a row per `EmployeeLaborCost`. Find the line that prints the cost and show `—` when the row is masked:
+
+```typescript
+{employee.costIsHidden ? '—' : `$${employee.cost.toFixed(2)}`}
+```
+
+Give the dash an accessible name so a screen reader states the reason:
+
+```typescript
+<span aria-label={employee.costIsHidden ? 'Labor cost hidden' : undefined}>
+```
+
+`src/components/scheduling/ScheduleMetricsRibbon.tsx:175` and `:241` print `${laborCostSummary.averageHourlyRate.toFixed(2)}/hr`. A partial total must say so. Add next to each:
+
+```typescript
+{laborCostSummary.hiddenCostCount > 0 && (
+  <span className="text-[11px] text-muted-foreground ml-1">
+    ({laborCostSummary.hiddenCostCount} hidden)
+  </span>
+)}
+```
+
+- [ ] **Step 8: Correct the flag label and hint**
+
+In `src/lib/permissions/areas.ts`, replace lines 107-108:
+
+```typescript
+    name: 'Contact details & tax IDs',
+    hint: 'Phone, address, last 4 of SSN',
+```
+
+with:
+
+```typescript
+    name: 'Contact details',
+    hint: 'Email, phone, date of birth',
+```
+
+Schema `public` has no `ssn` column, no `tax_id` column, and no employee address column. The old text named data the app does not store.
+
+- [ ] **Step 9: Type-check, lint, and run the unit suite**
+
+```bash
+npm run typecheck && npm run lint && npm run test -- --reporter=dot
+```
+
+Expected: PASS all three.
+
+- [ ] **Step 10: Write the end-to-end proof**
+
+Create `tests/e2e/sensitive-data-flags.spec.ts`:
+
+```typescript
+import { expect, test } from '@playwright/test';
+import { generateTestUser } from '../helpers/e2e-supabase';
+
+// A role without view:pay_rates opens the roster and sees no pay.
+//
+// The gate is in Postgres, so the check that matters is the response body, not
+// the rendered text. A client-only gate would still ship the rate over the
+// wire, and this role is collaborator-flavored — an external person who can
+// call PostgREST with their own token.
+test('a role without view:pay_rates receives no rate from PostgREST', async ({ page }) => {
+  const user = generateTestUser();
+
+  // Fill in the project's own sign-in and seed helpers here. Read
+  // tests/e2e/helpers/e2e-supabase.ts and copy the pattern an existing spec
+  // uses to create a restaurant, a custom role with the scheduling area and no
+  // sensitive flag, and a membership for `user`.
+
+  const bodies: unknown[] = [];
+  page.on('response', async (response) => {
+    if (response.url().includes('/rest/v1/employees_secure')) {
+      bodies.push(await response.json().catch(() => null));
+    }
+  });
+
+  await page.goto('/scheduling');
+  await expect(page.getByRole('heading', { name: /schedule/i })).toBeVisible();
+
+  const rows = bodies.flat().filter(Boolean) as Array<Record<string, unknown>>;
+  expect(rows.length).toBeGreaterThan(0);
+  for (const row of rows) {
+    expect(row.hourly_rate).toBeNull();
+    expect(row.email).toBeNull();
+  }
+});
+```
+
+Read an existing spec in `tests/e2e/` first and copy its sign-in and seed helpers into the marked block. Do not invent a helper name.
+
+- [ ] **Step 11: Run the end-to-end suite**
+
+```bash
+npm run test:e2e -- tests/e2e/sensitive-data-flags.spec.ts --reporter=line
+```
+
+Expected: PASS. The Bash tool's own `timeout` parameter bounds this run. Do not write a poll loop.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add src/integrations/supabase/types.ts src/types/scheduling.ts src/hooks/useEmployees.tsx src/hooks/useCurrentEmployee.tsx src/hooks/useMonthlyMetrics.tsx src/hooks/useTimePunches.tsx src/hooks/useShifts.tsx src/hooks/useTimeOffRequests.tsx src/hooks/useScheduleChangeLogs.tsx src/hooks/useEmployeeLaborCosts.tsx src/components/EmployeeList.tsx src/components/ReactivateEmployeeDialog.tsx src/components/scheduling/WeekScheduleMobile.tsx src/components/scheduling/LaborCostBreakdown.tsx src/components/scheduling/ScheduleMetricsRibbon.tsx src/components/scheduling/ShiftPlanner/EmployeeSidebar.tsx src/pages/Scheduling.tsx src/lib/permissions/areas.ts tests/e2e/sensitive-data-flags.spec.ts
+git commit -m "feat(employees): read pay and contact data through the masking view"
+```
+
+---
+
+## Verification
+
+- [ ] **Run every suite**
+
+```bash
+npm run typecheck && npm run lint && npm run test:all
+```
+
+- [ ] **Check the grant posture against production defaults**
+
+A grant assertion that passes locally has proven nothing. A bare local Postgres has no default privileges to revoke. Read them:
+
+```sql
+SELECT defaclrole::regrole, defaclobjtype, defaclacl FROM pg_default_acl;
+```
+
+If a default grants `ALL ON TABLES` to `service_role`, the migration's `REVOKE` is load-bearing and the local green is not proof. Confirm the same posture in the CI run.
+
+- [ ] **Check the migration version against `main`**
+
+A version collision with `main` is invisible to every local run and to the `push` event. Only the `pull_request` event catches it.
+
+```bash
+git fetch origin main && git ls-tree --name-only origin/main supabase/migrations/ | tail -3
+```
+
+Expected: no file named `20260806100000_*` or `20260806110000_*`.
+
+- [ ] **Confirm no reader still hits the base table**
+
+```bash
+grep -rn "from('employees')" src/ --include='*.ts' --include='*.tsx'
+```
+
+Expected: only the two mutation hooks in `src/hooks/useEmployees.tsx`, the writers in `ShiftImportSheet.tsx`, `TimePunchUploadSheet.tsx`, and `useSlingEmployeeMapping.ts`, and `useDeleteEmployee`. A view with `CASE` expressions is not writable, so every write stays on the base table.
+
+## Known limits
+
+- **Row access to `employees` stays broad.** `20260411100000_staff_can_view_coworkers.sql` states why: staff must see coworker names for shift trades. This plan gates columns, not rows.
+- **`view:costs` is out of scope.** 25 columns across 14 tables, and two paths that auto-write recomputed costs on page load.
+- **The `employees` UPDATE mismatch stays open.** `UPDATE` needs `user_has_role(restaurant_id, ARRAY['owner','manager','operations_manager'])`, and `user_has_role` matches the legacy `user_restaurants.role` string, which is `collaborator_custom` for a custom collaborator. So the "Update Employee" button fails for that user. A write-path authorization change does not belong in a read-path security patch.

--- a/docs/superpowers/specs/2026-08-06-sensitive-data-flags-design.md
+++ b/docs/superpowers/specs/2026-08-06-sensitive-data-flags-design.md
@@ -1,0 +1,217 @@
+# Make the three sensitive-data flags real
+
+**Date:** 2026-08-06
+**Branch:** `fix/sensitive-data-flags`
+**Base:** `main` at `6d648062`
+
+## Problem
+
+The role editor shows three sensitive-data switches. All three are decorative.
+A role can hold none of them and the holder still reads the data.
+
+| Toggle | Flag | Enforced in the client | Enforced in SQL |
+|---|---|---|---|
+| Item costs & margins | `view:costs` | no | no |
+| Employee pay rates | `view:pay_rates` | no | no |
+| Contact details & tax IDs | `view:employee_pii` | no | no |
+
+### Evidence
+
+1. The catalog defines the three flags at
+   [`src/lib/permissions/areas.ts:78`](../../../src/lib/permissions/areas.ts) and
+   `areas.ts:87-111`.
+2. The flags reach the capability list correctly.
+   `membershipCapabilities.ts:57-64` expands `role_flags` into capabilities, and
+   `usePermissions.ts:141` passes `includeSensitiveFlags`. The plumbing works.
+3. No consumer asks. A repository grep for the three flag names finds hits only
+   in `src/lib/permissions/`, in the migrations that define them, and in tests.
+   No component and no RLS policy reads any of the three.
+4. `products` SELECT gates on `user_has_capability(restaurant_id,'view:inventory')`.
+   `recipes` SELECT gates on `view:recipes`. Page access equals cost access.
+5. `employee_compensation_history` SELECT is `EXISTS (SELECT 1 FROM
+   user_restaurants WHERE restaurant_id = ... AND user_id = auth.uid())` —
+   plain membership, no capability predicate. This table holds the full pay
+   history. `useEmployees.tsx:35-38` pulls it with
+   `select('*, compensation_history:employee_compensation_history(*)')`.
+6. The third toggle's hint at `areas.ts:108` promises "Phone, address, last 4 of
+   SSN". Schema `public` has no `ssn` column, no `tax_id` column, and no
+   employee address column. Employee PII is `email`, `phone`, `date_of_birth`.
+
+### Live proof
+
+User `josema92@hotmail.com` at "Wetzel's - Cold Stone - Alamo Ranch" holds the
+custom collaborator role "Operations lead"
+(`d9cf6461-b1d3-4a5a-bb85-6e27b3f10b05`). The role holds seven areas. It does
+**not** hold `employees`. Its only flag is `view:costs`. That user reads every
+employee row in full, which includes one minor's `date_of_birth` and every
+`hourly_rate`.
+
+### Why a client-side gate is not a fix
+
+"Operations lead" is collaborator-flavored. A collaborator is an external
+person who can call PostgREST directly with their own token. Enforcement must
+be in Postgres. The client gate is a second, separate requirement — see
+"The client gate prevents data loss" below.
+
+## What this design does NOT change
+
+`supabase/migrations/20260411100000_staff_can_view_coworkers.sql:1-10` states
+why every restaurant member reads every employee row: staff must see coworker
+names for shift trades and scheduling. That is a deliberate product decision
+from April. This design keeps broad **row** access and gates **columns**.
+
+A line cook keeps seeing the roster. A line cook stops seeing pay and dates of
+birth.
+
+## Architecture
+
+Postgres RLS filters rows. It cannot mask a column. So the mechanism is a
+column privilege plus a masking view.
+
+```
+authenticated ──X── employees.hourly_rate        (REVOKE SELECT on the column)
+authenticated ──✓── employees.name               (GRANT SELECT on the column)
+authenticated ──✓── employees_secure             (view, owner rights)
+                       └─ CASE WHEN user_has_capability(restaurant_id,
+                                'view:pay_rates') THEN hourly_rate END
+```
+
+The column REVOKE is the control. The view is the accessor. A caller who goes
+around the view hits the column ACL and gets `permission denied for column
+hourly_rate`. The ACL cannot be bypassed by PostgREST, by a raw REST call, or
+by a crafted embed.
+
+### Three tables, three treatments
+
+| Table | Sensitive columns | Treatment |
+|---|---|---|
+| `employees` | `hourly_rate`, `salary_amount`, `daily_rate_amount`, `contractor_payment_amount`, `email`, `phone`, `date_of_birth` | column REVOKE + `employees_secure` view |
+| `employee_compensation_history` | every row is pay | row policy — add `user_has_capability(restaurant_id,'view:pay_rates')` |
+| `products`, `recipes` | `products.cost_per_unit`, `recipes.estimated_cost` | column REVOKE + `products_secure`, `recipes_secure` views |
+
+`employee_compensation_history` needs no view. The whole table is pay data, so
+a row policy expresses the rule exactly. This is the cheaper mechanism and it
+applies wherever the table is single-purpose.
+
+### View definition shape
+
+```sql
+CREATE VIEW public.employees_secure
+WITH (security_barrier = true) AS
+SELECT
+  e.id, e.restaurant_id, e.name, e.position, ...,
+  CASE WHEN public.user_has_capability(e.restaurant_id, 'view:pay_rates')
+       THEN e.hourly_rate END AS hourly_rate,
+  ...
+  CASE WHEN public.user_has_capability(e.restaurant_id, 'view:employee_pii')
+       THEN e.email END AS email,
+  ...
+FROM public.employees e
+WHERE e.restaurant_id IN (
+        SELECT ur.restaurant_id FROM public.user_restaurants ur
+        WHERE ur.user_id = auth.uid())
+   OR e.user_id = auth.uid();
+```
+
+The view runs with owner rights (`security_invoker` stays off). Owner rights
+are required: the caller no longer holds the column privilege, so an invoker
+-rights view would fail for everyone. Because the view bypasses the base
+table's RLS, the view carries its own row predicate. That predicate reproduces
+today's broadest `employees` SELECT policy exactly, so no user loses a row.
+
+`security_barrier = true` stops a leaky operator in a user-supplied `WHERE`
+from reading a masked value before the CASE runs.
+
+### Grants
+
+Lessons [2026-08-02] and [2026-08-03] apply. Revoke from every role the stock
+`ALTER DEFAULT PRIVILEGES` entry grants to, then grant back exactly what each
+role needs.
+
+```sql
+REVOKE SELECT ON public.employees FROM PUBLIC, anon, authenticated, service_role;
+GRANT  SELECT (id, restaurant_id, name, position, ... non-sensitive ...)
+       ON public.employees TO authenticated;
+GRANT  SELECT ON public.employees TO service_role;   -- payroll edge functions
+GRANT  SELECT ON public.employees_secure TO authenticated;
+REVOKE SELECT ON public.employees_secure FROM PUBLIC, anon;
+```
+
+`service_role` keeps the whole table. Payroll edge functions need pay, and
+`rolbypassrls` means the table ACL is the only control standing behind that
+role — so state the grant, do not inherit it.
+
+## The client gate prevents data loss
+
+This is not cosmetic. `EmployeeDialog.tsx:238-258` loads `employee.email`,
+`employee.phone`, `employee.date_of_birth`, `employee.hourly_rate` and
+`employee.salary_amount` into form state. The save path writes those state
+values back.
+
+**Warning: an unauthorized editor who opens and saves the dialog erases the
+real values.** A masked column arrives as `NULL`, the form renders it empty,
+and the save writes the empty value over the true one.
+
+So the client must do two things when `hasCapability('view:pay_rates')` or
+`hasCapability('view:employee_pii')` is false:
+
+1. Hide the field.
+2. Omit the field from the update payload. Do not send `NULL`.
+
+## Files
+
+### Migrations (create)
+
+- `supabase/migrations/<ts>_sensitive_column_gating.sql` — the REVOKE/GRANT
+  set, the three views, and the `employee_compensation_history` policy
+  rewrite.
+
+The timestamp must not collide with any migration on `main`. Lesson
+[2026-08-05]: `tests/unit/migrationVersionUniqueness.test.ts` fails only on the
+`pull_request` event, so a collision is invisible to every local run.
+
+### Client (modify)
+
+- `src/hooks/useEmployees.tsx:34` — read `employees_secure`, not `employees`.
+- `src/hooks/useProducts.tsx`, `src/hooks/useRecipes.tsx` — same swap.
+- `src/components/EmployeeDialog.tsx` — gate the five fields, omit them from
+  the payload when masked.
+- Every remaining `select('*')` on the three tables. Six sites on `employees`,
+  eight on `products`, zero on `recipes`.
+- `src/lib/permissions/areas.ts:108` — fix the hint to "Email, phone, date of
+  birth".
+
+### Tests (create)
+
+- `supabase/tests/sensitive_column_gating_test.sql` — pgTAP. Assert the column
+  ACL with `has_column_privilege`, not only with `throws_ok`. Lesson
+  [2026-08-02]: a grant-posture assertion that passes locally has proven
+  nothing.
+- `tests/unit/employeeDialogMasking.test.tsx` — assert the payload omits a
+  masked field.
+- `tests/e2e/sensitive-data-flags.spec.ts` — a role without `view:pay_rates`
+  opens the roster and sees no pay.
+
+## Non-goals
+
+- **Row access to `employees` stays broad.** See "What this design does NOT
+  change".
+- **The `employees` UPDATE mismatch.** The Edit Employee dialog offers an
+  "Update Employee" button that RLS refuses for a custom collaborator:
+  `UPDATE` needs `user_has_role(restaurant_id, ARRAY['owner','manager',
+  'operations_manager'])`, and `user_has_role` matches the legacy
+  `user_restaurants.role` string, which for this user is `collaborator_custom`.
+  This is a separate defect. Fixing it here would mix a write-path
+  authorization change into a read-path security patch.
+- **The `view:costs` blast radius beyond `products` and `recipes`.** Derived
+  cost appears in reports and P&L. Those pages are gated by their own areas.
+  This design gates the two source columns.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| A missed `select('*')` breaks a page at runtime | The failure is loud — `permission denied for column`. Grep is exhaustive; the e2e suite covers the main routes. |
+| An edge function loses pay access | `service_role` keeps the whole table, stated explicitly in the migration. |
+| The view's row predicate drifts from the table's policy | The predicate is copied from `20260411100000_staff_can_view_coworkers.sql:15-21`. A pgTAP test asserts the row counts match. |
+| Local pgTAP passes, CI fails on grants | Read `pg_default_acl` before trusting a local green. Lesson [2026-08-02]. |

--- a/docs/superpowers/specs/2026-08-06-sensitive-data-flags-design.md
+++ b/docs/superpowers/specs/2026-08-06-sensitive-data-flags-design.md
@@ -52,6 +52,11 @@ END IF;
 **Warning: a gate on these flags locks out every owner today.** Seed the
 builtin roles before you add the gate. See "Task order" below.
 
+Seed both flags to every builtin that already holds `view:employees`. Five
+roles qualify: Owner, Manager, Operations Manager, Accountant, and Operations
+Manager (Collaborator). The last two also hold `view:payroll`. A three-role
+seed takes pay data away from the Accountant, who runs payroll today.
+
 ## Architecture
 
 Postgres RLS filters rows. It cannot mask a column. A column `GRANT` is a
@@ -210,7 +215,7 @@ The timestamp must not collide with any migration on `main`. Lesson
 | `useEmployeeLaborCosts.tsx:64` | a masked rate must not understate labor cost |
 | `employeeUtils.ts` | read `is_minor` from the row, not `isMinor(date_of_birth)` |
 | `areas.ts:107-108` | name → "Contact details", hint → "Email, phone, date of birth" |
-| `definitions.ts` | add both flags to Owner, Manager, Operations Manager |
+| `definitions.ts` | add both flags to the five roles that hold `view:employees` |
 
 A post-mutation read-back goes through `employees_secure`, not a hand-written
 column list. A hand-written list at 6 sites drifts the day a column is added.
@@ -224,7 +229,10 @@ column list. A hand-written list at 6 sites drifts the day a column is added.
   for one sample user.
 - `roles_seed_test.sql:439-449` asserts zero `role_flags` rows for every
   builtin. Replace the count with the exact expected set. Do not delete the
-  assertion.
+  assertion. The `derived_capabilities` temp table at
+  `roles_seed_test.sql:397-403` reads `role_areas` only. Add a `UNION ALL`
+  branch for `role_flags`, or the round trip reports every new flag as an
+  under-grant.
 - `tests/unit/employeeUpdatePayload.test.ts` — the hook drops a masked key.
 - `tests/e2e/sensitive-data-flags.spec.ts` — a role without `view:pay_rates`
   opens the roster and sees no pay.
@@ -233,11 +241,11 @@ column list. A hand-written list at 6 sites drifts the day a column is added.
 
 The seed must land before the gate, or every owner loses access.
 
-1. Add both flags to `ROLE_CAPABILITIES` for Owner, Manager, and Operations
-   Manager in `definitions.ts`. Seed the matching `role_flags` rows. Change the
-   `roles_seed_test.sql` assertion. The round-trip property in that test
-   compares SQL-derived capabilities against `ROLE_CAPABILITIES`, so both sides
-   must move together.
+1. Add both flags to `ROLE_CAPABILITIES` for the five roles that hold
+   `view:employees` in `definitions.ts`. Seed the matching `role_flags` rows.
+   Change the `roles_seed_test.sql` assertions. The round-trip property in that
+   test compares SQL-derived capabilities against `ROLE_CAPABILITIES`, so both
+   sides must move together.
 2. Strip masked keys in `useUpdateEmployee`, and fix the dialog's write path.
 3. Add the view, the REVOKE/GRANT set, and the policy change.
 4. Point every reader at `employees_secure`.

--- a/docs/superpowers/specs/2026-08-06-sensitive-data-flags-design.md
+++ b/docs/superpowers/specs/2026-08-06-sensitive-data-flags-design.md
@@ -1,4 +1,4 @@
-# Make the three sensitive-data flags real
+# Make the employee pay and PII flags real
 
 **Date:** 2026-08-06
 **Branch:** `fix/sensitive-data-flags`
@@ -6,131 +6,140 @@
 
 ## Problem
 
-The role editor shows three sensitive-data switches. All three are decorative.
-A role can hold none of them and the holder still reads the data.
+The role editor shows three sensitive-data switches. None of them gates
+anything. This design makes two of them real on one table, `public.employees`:
 
-| Toggle | Flag | Enforced in the client | Enforced in SQL |
-|---|---|---|---|
-| Item costs & margins | `view:costs` | no | no |
-| Employee pay rates | `view:pay_rates` | no | no |
-| Contact details & tax IDs | `view:employee_pii` | no | no |
+| Toggle | Flag |
+|---|---|
+| Employee pay rates | `view:pay_rates` |
+| Contact details & tax IDs | `view:employee_pii` |
+
+`view:costs` needs 25 columns across 14 tables and two auto-write paths that
+would zero stored costs. It gets its own PR.
+
+A collaborator can call PostgREST directly with their own token. A client-only
+check does not hold. The gate must be in Postgres.
 
 ### Evidence
 
-1. The catalog defines the three flags at
-   [`src/lib/permissions/areas.ts:78`](../../../src/lib/permissions/areas.ts) and
-   `areas.ts:87-111`.
-2. The flags reach the capability list correctly.
-   `membershipCapabilities.ts:57-64` expands `role_flags` into capabilities, and
-   `usePermissions.ts:141` passes `includeSensitiveFlags`. The plumbing works.
-3. No consumer asks. A repository grep for the three flag names finds hits only
-   in `src/lib/permissions/`, in the migrations that define them, and in tests.
-   No component and no RLS policy reads any of the three.
-4. `products` SELECT gates on `user_has_capability(restaurant_id,'view:inventory')`.
-   `recipes` SELECT gates on `view:recipes`. Page access equals cost access.
-5. `employee_compensation_history` SELECT is `EXISTS (SELECT 1 FROM
-   user_restaurants WHERE restaurant_id = ... AND user_id = auth.uid())` —
-   plain membership, no capability predicate. This table holds the full pay
-   history. `useEmployees.tsx:35-38` pulls it with
-   `select('*, compensation_history:employee_compensation_history(*)')`.
-6. The third toggle's hint at `areas.ts:108` promises "Phone, address, last 4 of
-   SSN". Schema `public` has no `ssn` column, no `tax_id` column, and no
-   employee address column. Employee PII is `email`, `phone`, `date_of_birth`.
+1. No component and no RLS policy reads the three flag names. A repository grep
+   finds hits only in `src/lib/permissions/`, in the migrations that define
+   them, and in tests.
+2. `employee_compensation_history` SELECT is plain membership, with no
+   capability predicate. That table holds the full pay history.
+   `useEmployees.tsx:35-38` pulls it with an embed.
+3. The `view:employee_pii` label and hint at `areas.ts:107-108` name data the
+   app does not store. Schema `public` has no `ssn` column, no `tax_id` column,
+   and no employee address column. Employee PII is `email`, `phone`,
+   `date_of_birth`.
 
-### Live proof
+### The flags are unheld, not only unread
 
-User `josema92@hotmail.com` at "Wetzel's - Cold Stone - Alamo Ranch" holds the
-custom collaborator role "Operations lead"
-(`d9cf6461-b1d3-4a5a-bb85-6e27b3f10b05`). The role holds seven areas. It does
-**not** hold `employees`. Its only flag is `view:costs`. That user reads every
-employee row in full, which includes one minor's `date_of_birth` and every
-`hourly_rate`.
+Every builtin role holds zero rows in `role_flags`. Owner, Manager, Operations
+Manager, and Accountant all hold none. Every one of the 157 memberships in
+production carries a non-null `role_id`, so `user_has_capability` always takes
+the flag branch at `20260805120000_page_areas.sql:322-327`:
 
-### Why a client-side gate is not a fix
+```sql
+IF p_capability IN ('view:costs','view:pay_rates','view:employee_pii') THEN
+  RETURN EXISTS (SELECT 1 FROM role_flags rf
+                 WHERE rf.role_id = v_role_id AND rf.flag = p_capability);
+END IF;
+```
 
-"Operations lead" is collaborator-flavored. A collaborator is an external
-person who can call PostgREST directly with their own token. Enforcement must
-be in Postgres. The client gate is a second, separate requirement — see
-"The client gate prevents data loss" below.
+`expandAreas` at `areas.ts:380` agrees. No area grant implies a flag.
 
-## What this design does NOT change
-
-`supabase/migrations/20260411100000_staff_can_view_coworkers.sql:1-10` states
-why every restaurant member reads every employee row: staff must see coworker
-names for shift trades and scheduling. That is a deliberate product decision
-from April. This design keeps broad **row** access and gates **columns**.
-
-A line cook keeps seeing the roster. A line cook stops seeing pay and dates of
-birth.
+**Warning: a gate on these flags locks out every owner today.** Seed the
+builtin roles before you add the gate. See "Task order" below.
 
 ## Architecture
 
-Postgres RLS filters rows. It cannot mask a column. So the mechanism is a
-column privilege plus a masking view.
+Postgres RLS filters rows. It cannot mask a column. A column `GRANT` is a
+role-level privilege, so it cannot depend on `user_has_capability`. The
+mechanism is therefore a column REVOKE plus an owner-rights view.
 
 ```
 authenticated ──X── employees.hourly_rate        (REVOKE SELECT on the column)
 authenticated ──✓── employees.name               (GRANT SELECT on the column)
 authenticated ──✓── employees_secure             (view, owner rights)
-                       └─ CASE WHEN user_has_capability(restaurant_id,
-                                'view:pay_rates') THEN hourly_rate END
 ```
 
 The column REVOKE is the control. The view is the accessor. A caller who goes
 around the view hits the column ACL and gets `permission denied for column
-hourly_rate`. The ACL cannot be bypassed by PostgREST, by a raw REST call, or
-by a crafted embed.
+hourly_rate`. PostgREST cannot bypass the ACL.
 
-### Three tables, three treatments
+### Masked columns
 
-| Table | Sensitive columns | Treatment |
-|---|---|---|
-| `employees` | `hourly_rate`, `salary_amount`, `daily_rate_amount`, `contractor_payment_amount`, `email`, `phone`, `date_of_birth` | column REVOKE + `employees_secure` view |
-| `employee_compensation_history` | every row is pay | row policy — add `user_has_capability(restaurant_id,'view:pay_rates')` |
-| `products`, `recipes` | `products.cost_per_unit`, `recipes.estimated_cost` | column REVOKE + `products_secure`, `recipes_secure` views |
+| Flag | Columns |
+|---|---|
+| `view:pay_rates` | `hourly_rate`, `salary_amount`, `contractor_payment_amount`, `daily_rate_amount`, `daily_rate_reference_weekly` |
+| `view:employee_pii` | `email`, `phone`, `date_of_birth` |
 
-`employee_compensation_history` needs no view. The whole table is pay data, so
-a row policy expresses the rule exactly. This is the cheaper mechanism and it
-applies wherever the table is single-purpose.
+The other 30 columns stay granted to `authenticated`.
 
-### View definition shape
+### The view
 
 ```sql
 CREATE VIEW public.employees_secure
 WITH (security_barrier = true) AS
 SELECT
-  e.id, e.restaurant_id, e.name, e.position, ...,
-  CASE WHEN public.user_has_capability(e.restaurant_id, 'view:pay_rates')
-       THEN e.hourly_rate END AS hourly_rate,
-  ...
-  CASE WHEN public.user_has_capability(e.restaurant_id, 'view:employee_pii')
-       THEN e.email END AS email,
-  ...
+  e.id, e.restaurant_id, e.name, e.position, /* ...30 plain columns... */
+  CASE WHEN caps.pay THEN e.hourly_rate END                 AS hourly_rate,
+  CASE WHEN caps.pay THEN e.salary_amount END               AS salary_amount,
+  CASE WHEN caps.pay THEN e.contractor_payment_amount END   AS contractor_payment_amount,
+  CASE WHEN caps.pay THEN e.daily_rate_amount END           AS daily_rate_amount,
+  CASE WHEN caps.pay THEN e.daily_rate_reference_weekly END AS daily_rate_reference_weekly,
+  CASE WHEN caps.pii THEN e.email END                       AS email,
+  CASE WHEN caps.pii THEN e.phone END                       AS phone,
+  CASE WHEN caps.pii THEN e.date_of_birth END               AS date_of_birth,
+  (e.date_of_birth IS NOT NULL
+   AND e.date_of_birth > (CURRENT_DATE - INTERVAL '18 years')) AS is_minor
 FROM public.employees e
+CROSS JOIN LATERAL (
+  SELECT public.user_has_capability(e.restaurant_id, 'view:pay_rates')    AS pay,
+         public.user_has_capability(e.restaurant_id, 'view:employee_pii') AS pii
+) caps
 WHERE e.restaurant_id IN (
         SELECT ur.restaurant_id FROM public.user_restaurants ur
         WHERE ur.user_id = auth.uid())
    OR e.user_id = auth.uid();
 ```
 
-The view runs with owner rights (`security_invoker` stays off). Owner rights
-are required: the caller no longer holds the column privilege, so an invoker
--rights view would fail for everyone. Because the view bypasses the base
-table's RLS, the view carries its own row predicate. That predicate reproduces
-today's broadest `employees` SELECT policy exactly, so no user loses a row.
+Three parts need a reason.
 
-`security_barrier = true` stops a leaky operator in a user-supplied `WHERE`
-from reading a masked value before the CASE runs.
+**Owner rights.** `security_invoker` stays off. The caller no longer holds the
+column privilege, so an invoker-rights view fails for everyone. Note the
+divergence: `active_employees` and `inactive_employees` both set
+`security_invoker = true`. State the reason in the migration comment, so a
+later reader does not "fix" this view to match its siblings.
+
+**The row predicate.** An owner-rights view bypasses the base table's RLS, so
+the view carries its own predicate. That predicate is the union of the two
+active SELECT policies: membership from
+`20260411100000_staff_can_view_coworkers.sql:15-21`, and self-view from
+`20260220000000_add_staff_tip_read_policies.sql:14-16`. No user gains or loses
+a row.
+
+**The `LATERAL` join.** A separate `user_has_capability` call per masked column
+runs 8 times per row. For a 200-employee roster that is 1,600 calls to answer
+two questions. The `LATERAL` computes both booleans once per row.
+
+**`is_minor`.** `isMinor(date_of_birth)` returns `false` for a null date, so a
+masked date deletes the "Minor" badge from the roster. That badge is a labor
+compliance cue. Five call sites read it: `EmployeeDialog.tsx:1287`,
+`EmployeeList.tsx:294`, `WeekScheduleMobile.tsx:91`,
+`EmployeeSidebar.tsx:159`, `Scheduling.tsx:1286`. The view computes the boolean
+and shows it to every member. The raw date stays gated.
 
 ### Grants
 
 Lessons [2026-08-02] and [2026-08-03] apply. Revoke from every role the stock
-`ALTER DEFAULT PRIVILEGES` entry grants to, then grant back exactly what each
-role needs.
+`ALTER DEFAULT PRIVILEGES` entry grants to. Then grant back what each role
+needs.
 
 ```sql
 REVOKE SELECT ON public.employees FROM PUBLIC, anon, authenticated, service_role;
-GRANT  SELECT (id, restaurant_id, name, position, ... non-sensitive ...)
+GRANT  SELECT (id, restaurant_id, name, position, /* ...the 30 plain columns... */)
        ON public.employees TO authenticated;
 GRANT  SELECT ON public.employees TO service_role;   -- payroll edge functions
 GRANT  SELECT ON public.employees_secure TO authenticated;
@@ -138,80 +147,114 @@ REVOKE SELECT ON public.employees_secure FROM PUBLIC, anon;
 ```
 
 `service_role` keeps the whole table. Payroll edge functions need pay, and
-`rolbypassrls` means the table ACL is the only control standing behind that
-role — so state the grant, do not inherit it.
+`rolbypassrls` makes the table ACL the only control behind that role. State the
+grant. Do not inherit it.
 
-## The client gate prevents data loss
+### `employee_compensation_history`
 
-This is not cosmetic. `EmployeeDialog.tsx:238-258` loads `employee.email`,
-`employee.phone`, `employee.date_of_birth`, `employee.hourly_rate` and
-`employee.salary_amount` into form state. The save path writes those state
-values back.
+Add one predicate to the existing SELECT policy:
+`user_has_capability(restaurant_id,'view:pay_rates')`. No view, no column
+grant. The whole table is pay data, so a row policy states the rule exactly.
+PostgREST drops the embedded rows under RLS with no error to handle.
 
-**Warning: an unauthorized editor who opens and saves the dialog erases the
-real values.** A masked column arrives as `NULL`, the form renders it empty,
-and the save writes the empty value over the true one.
+## The write path erases data
 
-So the client must do two things when `hasCapability('view:pay_rates')` or
-`hasCapability('view:employee_pii')` is false:
+**Warning: a masked column arrives as `NULL`, and the save path writes it
+back.** Seven paths turn the migration into data loss. Two need care.
 
-1. Hide the field.
-2. Omit the field from the update payload. Do not send `NULL`.
+`EmployeeDialog.tsx:551-553` sends `hourly_rate: 0`, not `undefined`.
+`EmployeeDialog.tsx:623` sends `date_of_birth: dateOfBirth || null`, which
+erases the date on any save. `EmployeeDialog.tsx:651-670` then compares the
+fabricated `0` against the real rate and inserts a permanent `$0.00` row into
+the compensation history.
+
+Fix this once, in the hook, not per field in the dialog. `useUpdateEmployee`
+strips every masked key from the payload before the write. `EmployeeDialog` is
+not the only writer: `ShiftImportSheet.tsx`, `TimePunchUploadSheet.tsx`, and
+`useSlingEmployeeMapping.ts:83-97` also create employees. A per-field gate in
+one component protects one of four call sites.
+
+The dialog still hides the fields, and drops the `required` attribute from the
+`hourlyRate` input at `EmployeeDialog.tsx:864`. Pair every `hasCapability` call
+with `isResolved`, the idiom at `Expenses.tsx:94` and
+`PendingOutflowCard.tsx:179`. Without it the gate reads a false negative while
+the membership resolves.
 
 ## Files
 
-### Migrations (create)
+### Migration (create)
 
-- `supabase/migrations/<ts>_sensitive_column_gating.sql` — the REVOKE/GRANT
-  set, the three views, and the `employee_compensation_history` policy
-  rewrite.
+`supabase/migrations/<ts>_employee_column_gating.sql` — the builtin flag seed,
+the REVOKE/GRANT set, the `employees_secure` view, and the
+`employee_compensation_history` policy change.
 
 The timestamp must not collide with any migration on `main`. Lesson
 [2026-08-05]: `tests/unit/migrationVersionUniqueness.test.ts` fails only on the
-`pull_request` event, so a collision is invisible to every local run.
+`pull_request` event.
 
 ### Client (modify)
 
-- `src/hooks/useEmployees.tsx:34` — read `employees_secure`, not `employees`.
-- `src/hooks/useProducts.tsx`, `src/hooks/useRecipes.tsx` — same swap.
-- `src/components/EmployeeDialog.tsx` — gate the five fields, omit them from
-  the payload when masked.
-- Every remaining `select('*')` on the three tables. Six sites on `employees`,
-  eight on `products`, zero on `recipes`.
-- `src/lib/permissions/areas.ts:108` — fix the hint to "Email, phone, date of
-  birth".
+| File | Change |
+|---|---|
+| `useEmployees.tsx:35` | read `employees_secure` |
+| `useEmployees.tsx:80,113` | read back through `employees_secure`, not a bare `.select()` |
+| `useEmployees.tsx:103-134` | strip masked keys from the update payload |
+| `useCurrentEmployee.tsx:22` | read `employees_secure` |
+| `useMonthlyMetrics.tsx:408` | read `employees_secure` |
+| `useTimePunches.tsx:599` | read `employees_secure` |
+| `useShifts.tsx:60` | embed resolves to the base table — needs an explicit column list |
+| `useTimeOffRequests.tsx:15-18` | same |
+| `useScheduleChangeLogs.tsx:17` | same |
+| `EmployeeDialog.tsx` | hide the 8 fields, drop `required` at line 864 |
+| `EmployeeList.tsx:221-236` | a masked rate must not render as `$0.00/hr` |
+| `useEmployeeLaborCosts.tsx:64` | a masked rate must not understate labor cost |
+| `employeeUtils.ts` | read `is_minor` from the row, not `isMinor(date_of_birth)` |
+| `areas.ts:107-108` | name → "Contact details", hint → "Email, phone, date of birth" |
+| `definitions.ts` | add both flags to Owner, Manager, Operations Manager |
 
-### Tests (create)
+A post-mutation read-back goes through `employees_secure`, not a hand-written
+column list. A hand-written list at 6 sites drifts the day a column is added.
 
-- `supabase/tests/sensitive_column_gating_test.sql` — pgTAP. Assert the column
-  ACL with `has_column_privilege`, not only with `throws_ok`. Lesson
-  [2026-08-02]: a grant-posture assertion that passes locally has proven
-  nothing.
-- `tests/unit/employeeDialogMasking.test.tsx` — assert the payload omits a
-  masked field.
+### Tests
+
+- `supabase/tests/employee_column_gating_test.sql` — pgTAP. Copy the idiom at
+  `review_responses_rls_test.sql:98-110`: `SET LOCAL role TO postgres;` then
+  `has_column_privilege(...)`. A normal test role cannot read another role's
+  column grants. Assert the view's row count equals the base table's row count
+  for one sample user.
+- `roles_seed_test.sql:439-449` asserts zero `role_flags` rows for every
+  builtin. Replace the count with the exact expected set. Do not delete the
+  assertion.
+- `tests/unit/employeeUpdatePayload.test.ts` — the hook drops a masked key.
 - `tests/e2e/sensitive-data-flags.spec.ts` — a role without `view:pay_rates`
   opens the roster and sees no pay.
 
+## Task order
+
+The seed must land before the gate, or every owner loses access.
+
+1. Add both flags to `ROLE_CAPABILITIES` for Owner, Manager, and Operations
+   Manager in `definitions.ts`. Seed the matching `role_flags` rows. Change the
+   `roles_seed_test.sql` assertion. The round-trip property in that test
+   compares SQL-derived capabilities against `ROLE_CAPABILITIES`, so both sides
+   must move together.
+2. Strip masked keys in `useUpdateEmployee`, and fix the dialog's write path.
+3. Add the view, the REVOKE/GRANT set, and the policy change.
+4. Point every reader at `employees_secure`.
+
 ## Non-goals
 
-- **Row access to `employees` stays broad.** See "What this design does NOT
-  change".
-- **The `employees` UPDATE mismatch.** The Edit Employee dialog offers an
-  "Update Employee" button that RLS refuses for a custom collaborator:
-  `UPDATE` needs `user_has_role(restaurant_id, ARRAY['owner','manager',
-  'operations_manager'])`, and `user_has_role` matches the legacy
-  `user_restaurants.role` string, which for this user is `collaborator_custom`.
-  This is a separate defect. Fixing it here would mix a write-path
-  authorization change into a read-path security patch.
-- **The `view:costs` blast radius beyond `products` and `recipes`.** Derived
-  cost appears in reports and P&L. Those pages are gated by their own areas.
-  This design gates the two source columns.
-
-## Risks
-
-| Risk | Mitigation |
-|---|---|
-| A missed `select('*')` breaks a page at runtime | The failure is loud — `permission denied for column`. Grep is exhaustive; the e2e suite covers the main routes. |
-| An edge function loses pay access | `service_role` keeps the whole table, stated explicitly in the migration. |
-| The view's row predicate drifts from the table's policy | The predicate is copied from `20260411100000_staff_can_view_coworkers.sql:15-21`. A pgTAP test asserts the row counts match. |
-| Local pgTAP passes, CI fails on grants | Read `pg_default_acl` before trusting a local green. Lesson [2026-08-02]. |
+- **Row access to `employees` stays broad.**
+  `20260411100000_staff_can_view_coworkers.sql` states why: staff must see
+  coworker names for shift trades and scheduling. This design gates columns,
+  not rows. A collaborator with no people area still reads `position`,
+  `hire_date`, `employment_type`, `status`, and `notes` for every coworker.
+  That is a separate product decision.
+- **`view:costs`.** 25 columns, 14 tables, and two paths that auto-write
+  recomputed costs on page load. Its own PR.
+- **The `employees` UPDATE mismatch.** `UPDATE` needs
+  `user_has_role(restaurant_id, ARRAY['owner','manager','operations_manager'])`,
+  and `user_has_role` matches the legacy `user_restaurants.role` string, which
+  for a custom collaborator is `collaborator_custom`. So the "Update Employee"
+  button fails for that user. A write-path authorization change does not belong
+  in a read-path security patch.

--- a/docs/superpowers/specs/2026-08-06-sensitive-data-flags-design.md
+++ b/docs/superpowers/specs/2026-08-06-sensitive-data-flags-design.md
@@ -57,6 +57,46 @@ roles qualify: Owner, Manager, Operations Manager, Accountant, and Operations
 Manager (Collaborator). The last two also hold `view:payroll`. A three-role
 seed takes pay data away from the Accountant, who runs payroll today.
 
+### The seed alone is not enough — the legacy path also denies both flags
+
+The paragraph above says every production membership carries a non-null
+`role_id`. That is true today. It is not true of the next restaurant.
+
+`public.create_restaurant_with_owner` writes `(user_id, restaurant_id, role)`
+and leaves `user_restaurants.role_id` NULL. All four
+`INSERT INTO public.user_restaurants` sites do the same.
+`backfill_user_restaurants_role_id()` ran once, at migration time
+(`20260730120000_add_user_restaurants_role_id.sql:66`), so it filled the rows
+that existed then and nothing since.
+
+A NULL `role_id` sends `user_has_capability` down its legacy CASE. That CASE
+predates both flags and denies them through its `ELSE FALSE`. With the column
+gate in place, the owner of a new restaurant reads NULL for every pay and
+contact column — the same defect this design fixes, moved to new users.
+
+The local database proved it: 55 owner memberships from e2e signup, all with
+`role_id IS NULL`. Six e2e specs failed for exactly this reason.
+
+**Warning: seed the builtin roles AND answer the two flags on the legacy path.
+One without the other leaves a class of owners locked out.**
+
+`20260806140000_legacy_role_sensitive_flags.sql` adds the second half. It
+answers the two flags before the legacy CASE, for the five legacy role strings
+that hold `view:employees`:
+
+```sql
+IF v_role_id IS NULL AND p_capability IN ('view:pay_rates', 'view:employee_pii') THEN
+  RETURN v_role IN (
+    'owner', 'manager', 'operations_manager',
+    'collaborator_accountant', 'collaborator_operations_manager'
+  );
+END IF;
+```
+
+Those five match `ROLE_CAPABILITIES` in `src/lib/permissions/definitions.ts`,
+whose own legacy path already granted both flags. The client and the database
+disagreed. The client was right. `view:costs` stays denied on both paths.
+
 ## Architecture
 
 Postgres RLS filters rows. It cannot mask a column. A column `GRANT` is a
@@ -193,6 +233,9 @@ the membership resolves.
 the REVOKE/GRANT set, the `employees_secure` view, and the
 `employee_compensation_history` policy change.
 
+`supabase/migrations/<ts>_legacy_role_sensitive_flags.sql` — answers the two
+flags on a NULL `role_id` membership. See "The seed alone is not enough" above.
+
 The timestamp must not collide with any migration on `main`. Lesson
 [2026-08-05]: `tests/unit/migrationVersionUniqueness.test.ts` fails only on the
 `pull_request` event.
@@ -249,6 +292,8 @@ The seed must land before the gate, or every owner loses access.
 2. Strip masked keys in `useUpdateEmployee`, and fix the dialog's write path.
 3. Add the view, the REVOKE/GRANT set, and the policy change.
 4. Point every reader at `employees_secure`.
+5. Answer the two flags on the legacy `role_id IS NULL` path. Step 1 covers
+   only the memberships that carry a `role_id`.
 
 ## Non-goals
 

--- a/docs/superpowers/specs/2026-08-06-sensitive-data-flags-design.md
+++ b/docs/superpowers/specs/2026-08-06-sensitive-data-flags-design.md
@@ -129,20 +129,21 @@ CREATE VIEW public.employees_secure
 WITH (security_barrier = true) AS
 SELECT
   e.id, e.restaurant_id, e.name, e.position, /* ...30 plain columns... */
-  CASE WHEN caps.pay THEN e.hourly_rate END                 AS hourly_rate,
-  CASE WHEN caps.pay THEN e.salary_amount END               AS salary_amount,
-  CASE WHEN caps.pay THEN e.contractor_payment_amount END   AS contractor_payment_amount,
-  CASE WHEN caps.pay THEN e.daily_rate_amount END           AS daily_rate_amount,
-  CASE WHEN caps.pay THEN e.daily_rate_reference_weekly END AS daily_rate_reference_weekly,
-  CASE WHEN caps.pii THEN e.email END                       AS email,
-  CASE WHEN caps.pii THEN e.phone END                       AS phone,
-  CASE WHEN caps.pii THEN e.date_of_birth END               AS date_of_birth,
+  CASE WHEN caps.pay OR caps.self THEN e.hourly_rate END                 AS hourly_rate,
+  CASE WHEN caps.pay OR caps.self THEN e.salary_amount END               AS salary_amount,
+  CASE WHEN caps.pay OR caps.self THEN e.contractor_payment_amount END   AS contractor_payment_amount,
+  CASE WHEN caps.pay OR caps.self THEN e.daily_rate_amount END           AS daily_rate_amount,
+  CASE WHEN caps.pay OR caps.self THEN e.daily_rate_reference_weekly END AS daily_rate_reference_weekly,
+  CASE WHEN caps.pii OR caps.self THEN e.email END                       AS email,
+  CASE WHEN caps.pii OR caps.self THEN e.phone END                       AS phone,
+  CASE WHEN caps.pii OR caps.self THEN e.date_of_birth END               AS date_of_birth,
   (e.date_of_birth IS NOT NULL
    AND e.date_of_birth > (CURRENT_DATE - INTERVAL '18 years')) AS is_minor
 FROM public.employees e
 CROSS JOIN LATERAL (
   SELECT public.user_has_capability(e.restaurant_id, 'view:pay_rates')    AS pay,
-         public.user_has_capability(e.restaurant_id, 'view:employee_pii') AS pii
+         public.user_has_capability(e.restaurant_id, 'view:employee_pii') AS pii,
+         (e.user_id = auth.uid())                                        AS self
 ) caps
 WHERE e.restaurant_id IN (
         SELECT ur.restaurant_id FROM public.user_restaurants ur
@@ -150,7 +151,17 @@ WHERE e.restaurant_id IN (
    OR e.user_id = auth.uid();
 ```
 
-Three parts need a reason.
+Five parts need a reason.
+
+**The self-row exception.** `caps.self` is `(e.user_id = auth.uid())`. A
+person always reads their own wage and their own contact data — a role flag
+gates a coworker's data, not your own. `/employee/pay` exists to show a staff
+member their own pay, so the column mask must carry the same exception the
+row predicate already has. `e.user_id` is nullable. An employee row with no
+linked account must not unmask for a caller with a `NULL` `auth.uid()`:
+`NULL = auth.uid()` evaluates to `NULL`, and `caps.pay OR NULL` is `NULL`
+(not `TRUE`) when `caps.pay` is `false`, so the `CASE WHEN` takes the `ELSE`
+branch and the column stays masked.
 
 **Owner rights.** `security_invoker` stays off. The caller no longer holds the
 column privilege, so an invoker-rights view fails for everyone. Note the

--- a/src/components/EmployeeDialog.tsx
+++ b/src/components/EmployeeDialog.tsx
@@ -631,7 +631,9 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
       position,
       area: area.trim() || null,
       employment_type: employmentType,
-      date_of_birth: dateOfBirth || null,
+      // undefined drops out of the JSON body. null would erase a stored date
+      // whenever the box is empty — which it always is under a masked read.
+      date_of_birth: dateOfBirth || undefined,
       status,
       hire_date: hireDate || undefined,
       termination_date: (status === 'inactive' || status === 'terminated') && terminationDate 

--- a/src/components/EmployeeDialog.tsx
+++ b/src/components/EmployeeDialog.tsx
@@ -320,13 +320,21 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
     existing: Employee,
     payload: {
       compensationType: CompensationType;
-      hourlyRateInCents: number;
+      hourlyRateInCents: number | undefined;
       salaryAmountInCents?: number;
       payPeriodType?: PayPeriodType;
       contractorAmountInCents?: number;
       contractorInterval?: ContractorPaymentInterval;
     }
   ) => {
+    // An unknown (masked) rate is not a change. Without this guard, a
+    // caller without view:pay_rates would compare the real stored rate
+    // against `undefined`, always read as "changed", and open the
+    // effective-date modal for a rate the caller cannot even see.
+    if (payload.compensationType === 'hourly' && payload.hourlyRateInCents === undefined) {
+      return false;
+    }
+
     if (existing.compensation_type !== payload.compensationType) {
       return true;
     }
@@ -351,7 +359,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
 
   const buildHistoryPayload = (
     restaurant: string,
-    hourlyRateInCents: number,
+    hourlyRateInCents: number | undefined,
     salaryAmountInCents?: number,
     contractorAmountInCents?: number
   ): CompensationHistoryPayload | null => {
@@ -608,7 +616,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
   };
 
   const proceedWithSubmit = async (
-    hourlyRateInCents: number,
+    hourlyRateInCents: number | undefined,
     salaryAmountInCents: number | undefined,
     contractorAmountInCents: number | undefined,
     dailyRateWeeklyInCents: number | undefined,

--- a/src/components/EmployeeDialog.tsx
+++ b/src/components/EmployeeDialog.tsx
@@ -9,6 +9,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Switch } from '@/components/ui/switch';
 import { Employee, EmployeeStatus, CompensationType, PayPeriodType, ContractorPaymentInterval, EmploymentType } from '@/types/scheduling';
 import { useCreateEmployee, useUpdateEmployee } from '@/hooks/useEmployees';
+import { usePermissions } from '@/hooks/usePermissions';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 import { PositionCombobox } from '@/components/PositionCombobox';
@@ -94,6 +95,13 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
   // catch (memory/lessons.md:1303-1304).
   const { selectedRestaurant } = useRestaurantContext();
   const restaurantTimezone = safeTz(selectedRestaurant?.restaurant?.timezone);
+  // A caller without view:pay_rates sees a blank (masked) amount box, not a
+  // real stored value — typing into it and saving would write a fabricated
+  // rate. Disable the rate-setting controls below until the role resolves
+  // and grants the flag, instead of letting a blind write reach the mutation
+  // (which then silently strips it — see src/lib/employeeMaskedFields.ts).
+  const { hasCapability, isResolved: isPermissionsResolved } = usePermissions();
+  const canSeePayRates = isPermissionsResolved && hasCapability('view:pay_rates');
   // null while loading, on error, and for non-members — all mean "behave normally".
   const existingMember = findMemberByEmail(restaurantMembers, email);
   // Both call sites pass the selected restaurant (Employees.tsx, Scheduling.tsx),
@@ -596,6 +604,29 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
       ? Math.round(dailyRateWeeklyInCents / dailyRateDays)
       : undefined;
 
+    // Block a compensation-type change when the new type's amount is
+    // undefined. A masked caller sees a blank box for the current type, so a
+    // blank box is normal there — but a real type change with no new amount
+    // must not reach hasCompensationChanged, which would read "unchanged"
+    // and write an inconsistent record (old type, no new amount, no history row).
+    if (employee && employee.compensation_type !== compensationType) {
+      const newTypeAmountInCents = {
+        hourly: hourlyRateInCents,
+        salary: salaryAmountInCents,
+        contractor: contractorAmountInCents,
+        daily_rate: dailyRateAmountInCents,
+      }[compensationType];
+
+      if (newTypeAmountInCents === undefined) {
+        toast({
+          title: 'Amount needed',
+          description: 'Enter an amount for the new compensation type before you save.',
+          variant: 'destructive',
+        });
+        return;
+      }
+    }
+
     // Check for unusually high hourly rate. hourlyRateInCents is undefined
     // for a masked or blank box, so this division reads NaN. NaN > threshold
     // is false, so the check below skips the warning instead of throwing —
@@ -863,6 +894,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                     setCompensationType(newType);
                     if (newType !== 'hourly') setIsExempt(false);
                   }}
+                  disabled={!canSeePayRates}
                 >
                   <SelectTrigger id="compensationType" aria-label="Compensation type" className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg">
                     <SelectValue />
@@ -902,6 +934,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                       onChange={(e) => setHourlyRate(e.target.value)}
                       placeholder="15.00"
                       aria-label="Hourly rate in dollars"
+                      disabled={!canSeePayRates}
                       className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
                     />
                   </div>
@@ -966,6 +999,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                       onChange={(e) => setSalaryAmount(e.target.value)}
                       placeholder="52000.00"
                       aria-label="Salary amount in dollars"
+                      disabled={!canSeePayRates}
                       className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
                     />
                   </div>
@@ -1062,6 +1096,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                       onChange={(e) => setContractorPaymentAmount(e.target.value)}
                       placeholder="2500.00"
                       aria-label="Payment amount in dollars"
+                      disabled={!canSeePayRates}
                       className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
                     />
                   </div>
@@ -1124,6 +1159,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                         placeholder="1000.00"
                         required
                         aria-label="Weekly reference amount"
+                        disabled={!canSeePayRates}
                         className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
                       />
                       <span className="text-sm text-muted-foreground whitespace-nowrap">per week</span>

--- a/src/components/EmployeeDialog.tsx
+++ b/src/components/EmployeeDialog.tsx
@@ -106,6 +106,10 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
   const [area, setArea] = useState('');
   const [employmentType, setEmploymentType] = useState<EmploymentType>('full_time');
   const [dateOfBirth, setDateOfBirth] = useState('');
+  // The date the dialog opened with. Empty means either "no date on file" or
+  // "the caller lacks view:employee_pii and the box reads masked". The submit
+  // payload below needs to tell those two apart from an intentional clear.
+  const [initialDateOfBirth, setInitialDateOfBirth] = useState('');
   const [status, setStatus] = useState<EmployeeStatus>('active');
   const [hireDate, setHireDate] = useState('');
   const [terminationDate, setTerminationDate] = useState('');
@@ -241,6 +245,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
       setArea(employee.area || '');
       setEmploymentType(employee.employment_type || 'full_time');
       setDateOfBirth(employee.date_of_birth || '');
+      setInitialDateOfBirth(employee.date_of_birth || '');
       setStatus(employee.status);
       setHireDate(employee.hire_date || '');
       setTerminationDate(employee.termination_date || '');
@@ -293,6 +298,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
     setArea('');
     setEmploymentType('full_time');
     setDateOfBirth('');
+    setInitialDateOfBirth('');
     setStatus('active');
     setHireDate('');
     setTerminationDate('');
@@ -327,11 +333,17 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
       contractorInterval?: ContractorPaymentInterval;
     }
   ) => {
-    // An unknown (masked) rate is not a change. Without this guard, a
-    // caller without view:pay_rates would compare the real stored rate
+    // An unknown (masked) amount is not a change. Without this guard, a
+    // caller without view:pay_rates would compare the real stored amount
     // against `undefined`, always read as "changed", and open the
-    // effective-date modal for a rate the caller cannot even see.
+    // effective-date modal for an amount the caller cannot even see.
     if (payload.compensationType === 'hourly' && payload.hourlyRateInCents === undefined) {
+      return false;
+    }
+    if (payload.compensationType === 'salary' && payload.salaryAmountInCents === undefined) {
+      return false;
+    }
+    if (payload.compensationType === 'contractor' && payload.contractorAmountInCents === undefined) {
       return false;
     }
 
@@ -584,7 +596,10 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
       ? Math.round(dailyRateWeeklyInCents / dailyRateDays)
       : undefined;
 
-    // Check for unusually high hourly rate
+    // Check for unusually high hourly rate. hourlyRateInCents is undefined
+    // for a masked or blank box, so this division reads NaN. NaN > threshold
+    // is false, so the check below skips the warning instead of throwing —
+    // the same intentional short-circuit as the guard in hasCompensationChanged.
     const hourlyRateInDollars = hourlyRateInCents / 100;
     if (compensationType === 'hourly' && hourlyRateInDollars > HIGH_RATE_THRESHOLD) {
       const suggestions = suggestRateCorrections(hourlyRateInDollars);
@@ -631,9 +646,13 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
       position,
       area: area.trim() || null,
       employment_type: employmentType,
-      // undefined drops out of the JSON body. null would erase a stored date
-      // whenever the box is empty — which it always is under a masked read.
-      date_of_birth: dateOfBirth || undefined,
+      // undefined drops out of the JSON body; null writes a real erase.
+      // An empty box is ambiguous by itself: a masked read starts empty with
+      // nothing to erase, but a caller who can see the date can also clear
+      // it on purpose. `initialDateOfBirth` tells the two apart -- it only
+      // holds a real date when the box opened with one visible, so a clear
+      // against a masked-empty box still sends undefined, not null.
+      date_of_birth: dateOfBirth ? dateOfBirth : initialDateOfBirth ? null : undefined,
       status,
       hire_date: hireDate || undefined,
       termination_date: (status === 'inactive' || status === 'terminated') && terminationDate 

--- a/src/components/EmployeeDialog.tsx
+++ b/src/components/EmployeeDialog.tsx
@@ -912,7 +912,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                       <div className="flex items-start gap-2 rounded-lg bg-amber-500/10 border border-amber-500/20 p-3">
                         <AlertTriangle className="h-4 w-4 text-amber-500 mt-0.5 shrink-0" />
                         <p className="text-[13px] text-amber-700 dark:text-amber-400">
-                          { }
+                          {/* eslint-disable-next-line no-restricted-syntax -- toLocaleString here formats a NUMBER (annualizedPay), not a date; the selector matches any toLocaleString member regardless of receiver type. */}
                           This employee's annualized pay (${annualizedPay.toLocaleString('en-US', { maximumFractionDigits: 0 })}/year) is below the FLSA exempt threshold ($35,568/year). Consult labor law before classifying as exempt.
                         </p>
                       </div>

--- a/src/components/EmployeeDialog.tsx
+++ b/src/components/EmployeeDialog.tsx
@@ -70,6 +70,21 @@ function invitePayloadFor(role: RoleWithGrants | null) {
   };
 }
 
+// undefined drops out of the JSON body; null writes a real erase. An empty
+// box is ambiguous by itself: a masked read starts empty with nothing to
+// erase, but a caller who can see the date can also clear it on purpose.
+// `initialDateOfBirth` tells the two apart — it only holds a real date when
+// the box opened with one visible, so a clear against a masked-empty box
+// still sends undefined, not null.
+function resolveDateOfBirthForSubmit(
+  dateOfBirth: string,
+  initialDateOfBirth: string
+): string | null | undefined {
+  if (dateOfBirth) return dateOfBirth;
+  if (initialDateOfBirth) return null;
+  return undefined;
+}
+
 export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: EmployeeDialogProps) => {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
@@ -677,13 +692,8 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
       position,
       area: area.trim() || null,
       employment_type: employmentType,
-      // undefined drops out of the JSON body; null writes a real erase.
-      // An empty box is ambiguous by itself: a masked read starts empty with
-      // nothing to erase, but a caller who can see the date can also clear
-      // it on purpose. `initialDateOfBirth` tells the two apart -- it only
-      // holds a real date when the box opened with one visible, so a clear
-      // against a masked-empty box still sends undefined, not null.
-      date_of_birth: dateOfBirth ? dateOfBirth : initialDateOfBirth ? null : undefined,
+      // See resolveDateOfBirthForSubmit for the undefined-vs-null rule.
+      date_of_birth: resolveDateOfBirthForSubmit(dateOfBirth, initialDateOfBirth),
       status,
       hire_date: hireDate || undefined,
       termination_date: (status === 'inactive' || status === 'terminated') && terminationDate 
@@ -960,12 +970,15 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                   {(() => {
                     const annualizedPay = Number.parseFloat(hourlyRate || '0') * 2080;
                     if (!isExempt || annualizedPay >= 35568) return null;
+                    // annualizedPay is a NUMBER, not a date, so toLocaleString is safe
+                    // here; the restaurant-clock rule flags any toLocaleString call.
+                    // eslint-disable-next-line no-restricted-syntax
+                    const annualizedPayDisplay = annualizedPay.toLocaleString('en-US', { maximumFractionDigits: 0 });
                     return (
                       <div className="flex items-start gap-2 rounded-lg bg-amber-500/10 border border-amber-500/20 p-3">
                         <AlertTriangle className="h-4 w-4 text-amber-500 mt-0.5 shrink-0" />
                         <p className="text-[13px] text-amber-700 dark:text-amber-400">
-                          {/* eslint-disable-next-line no-restricted-syntax -- toLocaleString here formats a NUMBER (annualizedPay), not a date; the selector matches any toLocaleString member regardless of receiver type. */}
-                          This employee's annualized pay (${annualizedPay.toLocaleString('en-US', { maximumFractionDigits: 0 })}/year) is below the FLSA exempt threshold ($35,568/year). Consult labor law before classifying as exempt.
+                          This employee's annualized pay (${annualizedPayDisplay}/year) is below the FLSA exempt threshold ($35,568/year). Consult labor law before classifying as exempt.
                         </p>
                       </div>
                     );

--- a/src/components/EmployeeDialog.tsx
+++ b/src/components/EmployeeDialog.tsx
@@ -548,9 +548,12 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
     e.preventDefault();
 
     // Build compensation data based on type
-    const hourlyRateInCents = compensationType === 'hourly' 
-      ? Math.round(Number.parseFloat(hourlyRate || '0') * 100)
-      : 0;
+    // An empty box is "unknown", not "zero". A fabricated 0 reaches
+    // hasCompensationChanged below, compares unequal to the real rate, and
+    // writes a permanent $0.00 row into the compensation history.
+    const hourlyRateInCents = compensationType === 'hourly' && hourlyRate.trim() !== ''
+      ? Math.round(Number.parseFloat(hourlyRate) * 100)
+      : undefined;
     
     const salaryAmountInCents = compensationType === 'salary' && salaryAmount
       ? Math.round(Number.parseFloat(salaryAmount) * 100)
@@ -900,7 +903,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                       <div className="flex items-start gap-2 rounded-lg bg-amber-500/10 border border-amber-500/20 p-3">
                         <AlertTriangle className="h-4 w-4 text-amber-500 mt-0.5 shrink-0" />
                         <p className="text-[13px] text-amber-700 dark:text-amber-400">
-                          {/* eslint-disable-next-line no-restricted-syntax -- toLocaleString here formats a NUMBER (annualizedPay), not a date; the selector matches any toLocaleString member regardless of receiver type. */}
+                          { }
                           This employee's annualized pay (${annualizedPay.toLocaleString('en-US', { maximumFractionDigits: 0 })}/year) is below the FLSA exempt threshold ($35,568/year). Consult labor law before classifying as exempt.
                         </p>
                       </div>

--- a/src/components/EmployeeDialog.tsx
+++ b/src/components/EmployeeDialog.tsx
@@ -882,7 +882,6 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                       value={hourlyRate}
                       onChange={(e) => setHourlyRate(e.target.value)}
                       placeholder="15.00"
-                      required
                       aria-label="Hourly rate in dollars"
                       className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
                     />
@@ -947,7 +946,6 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                       value={salaryAmount}
                       onChange={(e) => setSalaryAmount(e.target.value)}
                       placeholder="52000.00"
-                      required
                       aria-label="Salary amount in dollars"
                       className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
                     />
@@ -1044,7 +1042,6 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                       value={contractorPaymentAmount}
                       onChange={(e) => setContractorPaymentAmount(e.target.value)}
                       placeholder="2500.00"
-                      required
                       aria-label="Payment amount in dollars"
                       className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
                     />

--- a/src/components/EmployeeList.tsx
+++ b/src/components/EmployeeList.tsx
@@ -10,7 +10,6 @@ import { Employee } from '@/types/scheduling';
 import { Users, UserX, UsersRound, Plus, RotateCcw, Edit, UserMinus, HelpCircle } from 'lucide-react';
 import { format } from 'date-fns';
 import { cn } from '@/lib/utils';
-import { isMinor } from '@/lib/employeeUtils';
 import {
   Tooltip,
   TooltipContent,
@@ -291,7 +290,7 @@ const EmployeeCard = ({ employee, onEdit, onDeactivate, onReactivate, variant }:
               <span className="text-[11px] px-1.5 py-0.5 rounded-md bg-muted shrink-0">
                 {employee.employment_type === 'part_time' ? 'PT' : 'FT'}
               </span>
-              {isMinor(employee.date_of_birth) && (
+              {employee.is_minor && (
                 <span className="text-[11px] px-1.5 py-0.5 rounded-md bg-amber-500/10 text-amber-600 font-medium shrink-0">
                   Minor
                 </span>

--- a/src/components/EmployeeList.tsx
+++ b/src/components/EmployeeList.tsx
@@ -225,15 +225,15 @@ const EmployeeCard = ({ employee, onEdit, onDeactivate, onReactivate, variant }:
     // A masked column arrives as null. `$0.00/hr` would read as a real rate.
     switch (employee.compensation_type) {
       case 'hourly':
-        return employee.hourly_rate == null
+        return employee.hourly_rate === null || employee.hourly_rate === undefined
           ? 'Hidden'
           : `${formatCurrency(employee.hourly_rate)}/hr`;
       case 'salary':
-        return employee.salary_amount == null
+        return employee.salary_amount === null || employee.salary_amount === undefined
           ? 'Hidden'
           : `${formatCurrency(employee.salary_amount)}/${employee.pay_period_type}`;
       case 'contractor':
-        return employee.contractor_payment_amount == null
+        return employee.contractor_payment_amount === null || employee.contractor_payment_amount === undefined
           ? 'Hidden'
           : `${formatCurrency(employee.contractor_payment_amount)}/${employee.contractor_payment_interval}`;
       default:

--- a/src/components/EmployeeList.tsx
+++ b/src/components/EmployeeList.tsx
@@ -10,6 +10,7 @@ import { Employee } from '@/types/scheduling';
 import { Users, UserX, UsersRound, Plus, RotateCcw, Edit, UserMinus, HelpCircle } from 'lucide-react';
 import { format } from 'date-fns';
 import { cn } from '@/lib/utils';
+import { isCompensationHidden } from '@/lib/employeeMaskedFields';
 import {
   Tooltip,
   TooltipContent,
@@ -223,19 +224,17 @@ const EmployeeCard = ({ employee, onEdit, onDeactivate, onReactivate, variant }:
 
   const getCompensationDisplay = () => {
     // A masked column arrives as null. `$0.00/hr` would read as a real rate.
+    if (isCompensationHidden(employee)) return 'Hidden';
+
     switch (employee.compensation_type) {
       case 'hourly':
-        return employee.hourly_rate === null || employee.hourly_rate === undefined
-          ? 'Hidden'
-          : `${formatCurrency(employee.hourly_rate)}/hr`;
+        return `${formatCurrency(employee.hourly_rate)}/hr`;
       case 'salary':
-        return employee.salary_amount === null || employee.salary_amount === undefined
-          ? 'Hidden'
-          : `${formatCurrency(employee.salary_amount)}/${employee.pay_period_type}`;
+        return `${formatCurrency(employee.salary_amount)}/${employee.pay_period_type}`;
+      case 'daily_rate':
+        return `${formatCurrency(employee.daily_rate_amount)}/day`;
       case 'contractor':
-        return employee.contractor_payment_amount === null || employee.contractor_payment_amount === undefined
-          ? 'Hidden'
-          : `${formatCurrency(employee.contractor_payment_amount)}/${employee.contractor_payment_interval}`;
+        return `${formatCurrency(employee.contractor_payment_amount)}/${employee.contractor_payment_interval}`;
       default:
         return '';
     }

--- a/src/components/EmployeeList.tsx
+++ b/src/components/EmployeeList.tsx
@@ -222,13 +222,20 @@ const EmployeeCard = ({ employee, onEdit, onDeactivate, onReactivate, variant }:
   };
 
   const getCompensationDisplay = () => {
+    // A masked column arrives as null. `$0.00/hr` would read as a real rate.
     switch (employee.compensation_type) {
       case 'hourly':
-        return `${formatCurrency(employee.hourly_rate)}/hr`;
+        return employee.hourly_rate == null
+          ? 'Hidden'
+          : `${formatCurrency(employee.hourly_rate)}/hr`;
       case 'salary':
-        return `${formatCurrency(employee.salary_amount || 0)}/${employee.pay_period_type}`;
+        return employee.salary_amount == null
+          ? 'Hidden'
+          : `${formatCurrency(employee.salary_amount)}/${employee.pay_period_type}`;
       case 'contractor':
-        return `${formatCurrency(employee.contractor_payment_amount || 0)}/${employee.contractor_payment_interval}`;
+        return employee.contractor_payment_amount == null
+          ? 'Hidden'
+          : `${formatCurrency(employee.contractor_payment_amount)}/${employee.contractor_payment_interval}`;
       default:
         return '';
     }

--- a/src/components/MonthlyBreakdownTable.tsx
+++ b/src/components/MonthlyBreakdownTable.tsx
@@ -26,6 +26,8 @@ interface MonthlyData {
   pending_labor_cost: number;
   actual_labor_cost: number;
   has_data: boolean;
+  /** True when at least one employee row is masked (no view:pay_rates), so labor_cost is unknown, not zero. */
+  labor_cost_hidden: boolean;
 }
 
 interface MonthlyBreakdownTableProps {
@@ -312,21 +314,31 @@ export const MonthlyBreakdownTable = ({ monthlyData }: MonthlyBreakdownTableProp
                           </div>
                         </td>
                         <td className="text-right py-2 px-2 sm:py-3 sm:px-4">
-                          <div className="flex flex-col items-end gap-0.5 sm:gap-1">
-                            <span className="font-semibold text-xs sm:text-sm">{formatCurrency(laborCost)}</span>
-                            <span className="text-[10px] sm:text-xs text-amber-600 flex items-center gap-1 justify-end">
-                              Pending: {formatCurrency(pendingLaborCost)} ({pendingLaborPercent.toFixed(1)}%)
-                              {perf.laborBasis === 'accrued' && (
-                                <span className="text-[9px] px-1 py-0.5 rounded bg-muted text-muted-foreground uppercase tracking-wide">counted</span>
-                              )}
-                            </span>
-                            <span className="text-[10px] sm:text-xs text-blue-600 flex items-center gap-1 justify-end">
-                              Actual: {formatCurrency(actualLaborCost)} ({actualLaborPercent.toFixed(1)}%)
-                              {perf.laborBasis === 'paid' && (
-                                <span className="text-[9px] px-1 py-0.5 rounded bg-muted text-muted-foreground uppercase tracking-wide">counted</span>
-                              )}
-                            </span>
-                          </div>
+                          {month.labor_cost_hidden ? (
+                            <div
+                              className="flex flex-col items-end gap-0.5 sm:gap-1"
+                              title="Pay rates are hidden from this role. Ask an owner or manager for the labor cost."
+                            >
+                              <span className="font-semibold text-xs sm:text-sm text-muted-foreground">Unavailable</span>
+                              <span className="text-[10px] sm:text-xs text-muted-foreground">Pay rates hidden</span>
+                            </div>
+                          ) : (
+                            <div className="flex flex-col items-end gap-0.5 sm:gap-1">
+                              <span className="font-semibold text-xs sm:text-sm">{formatCurrency(laborCost)}</span>
+                              <span className="text-[10px] sm:text-xs text-amber-600 flex items-center gap-1 justify-end">
+                                Pending: {formatCurrency(pendingLaborCost)} ({pendingLaborPercent.toFixed(1)}%)
+                                {perf.laborBasis === 'accrued' && (
+                                  <span className="text-[9px] px-1 py-0.5 rounded bg-muted text-muted-foreground uppercase tracking-wide">counted</span>
+                                )}
+                              </span>
+                              <span className="text-[10px] sm:text-xs text-blue-600 flex items-center gap-1 justify-end">
+                                Actual: {formatCurrency(actualLaborCost)} ({actualLaborPercent.toFixed(1)}%)
+                                {perf.laborBasis === 'paid' && (
+                                  <span className="text-[9px] px-1 py-0.5 rounded bg-muted text-muted-foreground uppercase tracking-wide">counted</span>
+                                )}
+                              </span>
+                            </div>
+                          )}
                         </td>
                         <td className="text-right py-2 px-2 sm:py-3 sm:px-4">
                           <div className="flex flex-col items-end gap-0.5 sm:gap-1">
@@ -337,38 +349,48 @@ export const MonthlyBreakdownTable = ({ monthlyData }: MonthlyBreakdownTableProp
                           </div>
                         </td>
                         <td className="text-right py-2 px-2 sm:py-3 sm:px-4">
-                          <div className="flex flex-col items-end gap-0.5 sm:gap-1">
-                            <span className={`font-bold text-xs sm:text-sm ${
-                              actualNetProfit > 0 ? 'text-primary'
-                                : actualNetProfit < 0 ? 'text-destructive'
-                                : 'text-foreground'
-                            }`}>
-                              {formatCurrency(actualNetProfit)}
-                            </span>
-                            <span className="text-[10px] sm:text-xs text-blue-600">
-                              Actual
-                              {month.net_revenue > 0
-                                ? ` (${((actualNetProfit / month.net_revenue) * 100).toFixed(1)}%)`
-                                : ''}
-                            </span>
-                            {pendingLaborCost > 0 && (
-                              <>
-                                <span className={`font-semibold text-xs sm:text-sm ${
-                                  accrualNetProfit > 0 ? 'text-primary'
-                                    : accrualNetProfit < 0 ? 'text-destructive'
-                                    : 'text-foreground'
-                                }`}>
-                                  {formatCurrency(accrualNetProfit)}
-                                </span>
-                                <span className="text-[10px] sm:text-xs text-amber-600">
-                                  Accrual basis (matches hours worked)
-                                  {month.net_revenue > 0
-                                    ? ` (${((accrualNetProfit / month.net_revenue) * 100).toFixed(1)}%)`
-                                    : ''}
-                                </span>
-                              </>
-                            )}
-                          </div>
+                          {month.labor_cost_hidden ? (
+                            <div
+                              className="flex flex-col items-end gap-0.5 sm:gap-1"
+                              title="Net profit needs the labor cost, which pay-rate permissions hide from this role."
+                            >
+                              <span className="font-bold text-xs sm:text-sm text-muted-foreground">Unavailable</span>
+                              <span className="text-[10px] sm:text-xs text-muted-foreground">Labor cost hidden</span>
+                            </div>
+                          ) : (
+                            <div className="flex flex-col items-end gap-0.5 sm:gap-1">
+                              <span className={`font-bold text-xs sm:text-sm ${
+                                actualNetProfit > 0 ? 'text-primary'
+                                  : actualNetProfit < 0 ? 'text-destructive'
+                                  : 'text-foreground'
+                              }`}>
+                                {formatCurrency(actualNetProfit)}
+                              </span>
+                              <span className="text-[10px] sm:text-xs text-blue-600">
+                                Actual
+                                {month.net_revenue > 0
+                                  ? ` (${((actualNetProfit / month.net_revenue) * 100).toFixed(1)}%)`
+                                  : ''}
+                              </span>
+                              {pendingLaborCost > 0 && (
+                                <>
+                                  <span className={`font-semibold text-xs sm:text-sm ${
+                                    accrualNetProfit > 0 ? 'text-primary'
+                                      : accrualNetProfit < 0 ? 'text-destructive'
+                                      : 'text-foreground'
+                                  }`}>
+                                    {formatCurrency(accrualNetProfit)}
+                                  </span>
+                                  <span className="text-[10px] sm:text-xs text-amber-600">
+                                    Accrual basis (matches hours worked)
+                                    {month.net_revenue > 0
+                                      ? ` (${((accrualNetProfit / month.net_revenue) * 100).toFixed(1)}%)`
+                                      : ''}
+                                  </span>
+                                </>
+                              )}
+                            </div>
+                          )}
                         </td>
                         <td className="text-right py-2 px-2 sm:py-3 sm:px-4">
                           {month.profitChangePercent !== null ? (
@@ -446,7 +468,7 @@ export const MonthlyBreakdownTable = ({ monthlyData }: MonthlyBreakdownTableProp
                               ) : (
                                 <>
                                   {/* Data Availability Warnings */}
-                                  {(month.food_cost === 0 && month.labor_cost === 0) && (
+                                  {(month.food_cost === 0 && month.labor_cost === 0 && !month.labor_cost_hidden) && (
                                     <div className="flex items-start gap-2 p-3 rounded bg-blue-50 dark:bg-blue-950/20 border border-blue-200 dark:border-blue-800">
                                       <Info className="h-4 w-4 text-blue-600 mt-0.5 flex-shrink-0" />
                                       <div className="text-xs text-blue-700 dark:text-blue-400 space-y-1">

--- a/src/components/ReactivateEmployeeDialog.tsx
+++ b/src/components/ReactivateEmployeeDialog.tsx
@@ -72,7 +72,7 @@ export const ReactivateEmployeeDialog = ({
 
   const currentRateDisplay = employee.hourly_rate
     ? `$${(employee.hourly_rate / 100).toFixed(2)}/hr`
-    : 'Not set';
+    : 'Hidden';
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/components/ReactivateEmployeeDialog.tsx
+++ b/src/components/ReactivateEmployeeDialog.tsx
@@ -13,6 +13,7 @@ import { Input } from '@/components/ui/input';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { useReactivateEmployee } from '@/hooks/useEmployees';
+import { usePermissions } from '@/hooks/usePermissions';
 import { Employee } from '@/types/scheduling';
 import { CheckCircle, RotateCcw, Info } from 'lucide-react';
 
@@ -31,6 +32,8 @@ export const ReactivateEmployeeDialog = ({
   const [updateRate, setUpdateRate] = useState(false);
 
   const reactivateMutation = useReactivateEmployee();
+  const { hasCapability, isResolved } = usePermissions();
+  const canSeePayRates = isResolved && hasCapability('view:pay_rates');
 
   const resetForm = () => {
     setHourlyRate('');
@@ -70,9 +73,14 @@ export const ReactivateEmployeeDialog = ({
 
   if (!employee) return null;
 
-  const currentRateDisplay = employee.hourly_rate
-    ? `$${(employee.hourly_rate / 100).toFixed(2)}/hr`
-    : 'Hidden';
+  // A masked rate arrives as null because the caller lacks view:pay_rates —
+  // show "Hidden" only for that case. A resolved rate of 0 or null is a real
+  // "Not set", not a masked value, so it must not read as "Hidden" too.
+  const currentRateDisplay = !canSeePayRates
+    ? 'Hidden'
+    : employee.hourly_rate
+      ? `$${(employee.hourly_rate / 100).toFixed(2)}/hr`
+      : 'Not set';
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/components/ReactivateEmployeeDialog.tsx
+++ b/src/components/ReactivateEmployeeDialog.tsx
@@ -76,11 +76,14 @@ export const ReactivateEmployeeDialog = ({
   // A masked rate arrives as null because the caller lacks view:pay_rates —
   // show "Hidden" only for that case. A resolved rate of 0 or null is a real
   // "Not set", not a masked value, so it must not read as "Hidden" too.
-  const currentRateDisplay = !canSeePayRates
-    ? 'Hidden'
-    : employee.hourly_rate
-      ? `$${(employee.hourly_rate / 100).toFixed(2)}/hr`
-      : 'Not set';
+  let currentRateDisplay: string;
+  if (!canSeePayRates) {
+    currentRateDisplay = 'Hidden';
+  } else if (employee.hourly_rate) {
+    currentRateDisplay = `$${(employee.hourly_rate / 100).toFixed(2)}/hr`;
+  } else {
+    currentRateDisplay = 'Not set';
+  }
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -142,6 +145,7 @@ export const ReactivateEmployeeDialog = ({
                 id="update-rate"
                 checked={updateRate}
                 onCheckedChange={(checked) => setUpdateRate(checked as boolean)}
+                disabled={!canSeePayRates}
               />
               <div className="grid gap-1 leading-none flex-1">
                 <Label
@@ -174,6 +178,7 @@ export const ReactivateEmployeeDialog = ({
                     placeholder="15.00"
                     value={hourlyRate}
                     onChange={(e) => setHourlyRate(e.target.value)}
+                    disabled={!canSeePayRates}
                     className="max-w-[150px] h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
                   />
                   <span className="text-[13px] text-muted-foreground">/hour</span>

--- a/src/components/financial-statements/IncomeStatement.tsx
+++ b/src/components/financial-statements/IncomeStatement.tsx
@@ -127,7 +127,12 @@ interface IncomeStatementProps {
 
 export function IncomeStatement({ restaurantId, dateFrom, dateTo }: IncomeStatementProps) {
   const { toast } = useToast();
-  const { hasCapability } = usePermissions();
+  const { hasCapability, isResolved } = usePermissions();
+  // Force this false until the role finishes resolving, so a caller who
+  // will end up without view:pay_rates cannot get one query run with the
+  // capability wrongly true, then have the true-run result cached under a
+  // queryKey that never changes again for this render.
+  const canSeePayRates = isResolved && hasCapability('view:pay_rates');
   const [glOnly, setGlOnly] = useState(false);
   const [accrualMode, setAccrualMode] = useState<'actual' | 'projected'>('actual');
   
@@ -186,7 +191,7 @@ export function IncomeStatement({ restaurantId, dateFrom, dateTo }: IncomeStatem
   });
 
   const { data: incomeData, isLoading } = useQuery({
-    queryKey: ['income-statement', restaurantId, dateFrom, dateTo, glOnly, accrualMode, unifiedCOGS.totalCOGS],
+    queryKey: ['income-statement', restaurantId, dateFrom, dateTo, glOnly, accrualMode, unifiedCOGS.totalCOGS, canSeePayRates],
     queryFn: async () => {
       // Fetch all chart of accounts for this restaurant
       const { data: accounts, error: accountsError } = await supabase
@@ -314,7 +319,6 @@ export function IncomeStatement({ restaurantId, dateFrom, dateTo }: IncomeStatem
         // as salary/contractor even though the amount is hidden — that is
         // enough to know payrollFallback below is an undercount, not a zero.
         let payrollDataHidden = false;
-        const canSeePayRates = hasCapability('view:pay_rates');
 
         // If still zero, derive daily allocations from salary/contractor employees
         // Uses calculateSalaryForPeriod/calculateContractorPayForPeriod which respect hire_date
@@ -388,7 +392,10 @@ export function IncomeStatement({ restaurantId, dateFrom, dateTo }: IncomeStatem
         cogs: accountsWithBalances.filter(a => a.account_type === 'cogs'),
       };
     },
-    enabled: !!restaurantId,
+    // Wait for the role to resolve before running: canSeePayRates is part of
+    // the queryKey above, but the first render (isResolved false) would
+    // otherwise still fire one query under the false-permission key.
+    enabled: !!restaurantId && isResolved,
   });
 
   const formatCurrency = (amount: number) => {
@@ -768,7 +775,12 @@ export function IncomeStatement({ restaurantId, dateFrom, dateTo }: IncomeStatem
     });
   };
 
-  if (isLoading || revenueLoading || unifiedCOGS.isLoading || uncategorized.isLoading) {
+  // !isResolved covers the gap `enabled: !!restaurantId && isResolved` opens:
+  // React Query's `isLoading` is `isPending && isFetching`, and a disabled
+  // query never fetches, so isLoading reads false while permissions are
+  // still resolving — without this check the render below would run against
+  // an undefined incomeData.
+  if (isLoading || !isResolved || revenueLoading || unifiedCOGS.isLoading || uncategorized.isLoading) {
     return (
       <Card>
         <CardContent className="pt-6 flex items-center justify-center py-12">

--- a/src/components/financial-statements/IncomeStatement.tsx
+++ b/src/components/financial-statements/IncomeStatement.tsx
@@ -12,6 +12,7 @@ import { useUnifiedCOGS } from '@/hooks/useUnifiedCOGS';
 import { useUncategorizedTotals } from '@/hooks/useUncategorizedTotals';
 import { calculateSalaryForPeriod, calculateContractorPayForPeriod } from '@/utils/compensationCalculations';
 import type { Employee } from '@/types/scheduling';
+import { usePermissions } from '@/hooks/usePermissions';
 import { useState } from 'react';
 import { Switch } from '@/components/ui/switch';
 import { Label } from '@/components/ui/label';
@@ -126,6 +127,7 @@ interface IncomeStatementProps {
 
 export function IncomeStatement({ restaurantId, dateFrom, dateTo }: IncomeStatementProps) {
   const { toast } = useToast();
+  const { hasCapability } = usePermissions();
   const [glOnly, setGlOnly] = useState(false);
   const [accrualMode, setAccrualMode] = useState<'actual' | 'projected'>('actual');
   
@@ -306,6 +308,14 @@ export function IncomeStatement({ restaurantId, dateFrom, dateTo }: IncomeStatem
         let payrollFallback =
           Math.abs(Number(hourlyAgg?.sum) || 0) + Math.abs(Number(allocationAgg?.sum) || 0);
 
+        // True when a salary or contractor employee's amount reads as masked
+        // (employees_secure returns NULL for a caller without view:pay_rates).
+        // compensation_type is a plain column, so it still names the employee
+        // as salary/contractor even though the amount is hidden — that is
+        // enough to know payrollFallback below is an undercount, not a zero.
+        let payrollDataHidden = false;
+        const canSeePayRates = hasCapability('view:pay_rates');
+
         // If still zero, derive daily allocations from salary/contractor employees
         // Uses calculateSalaryForPeriod/calculateContractorPayForPeriod which respect hire_date
         if (payrollFallback === 0) {
@@ -322,34 +332,40 @@ export function IncomeStatement({ restaurantId, dateFrom, dateTo }: IncomeStatem
             const now = new Date();
             now.setHours(23, 59, 59, 999);
             const effectiveEndDate = accrualMode === 'actual' && dateTo > now ? now : dateTo;
-            
+
             employees.forEach(emp => {
               if (emp.allocate_daily === false) return;
-              
+
               // Cast to Employee type for the calculation functions
               const employee = emp as unknown as Employee;
-              
+
               if (emp.compensation_type === 'salary' && emp.salary_amount && emp.pay_period_type) {
                 // calculateSalaryForPeriod respects hire_date and termination_date
                 const periodCostCents = calculateSalaryForPeriod(employee, dateFrom, effectiveEndDate);
                 payrollFallback += periodCostCents / 100; // cents to dollars
+              } else if (emp.compensation_type === 'salary' && !canSeePayRates) {
+                payrollDataHidden = true;
               }
               if (emp.compensation_type === 'contractor' && emp.contractor_payment_amount && emp.contractor_payment_interval) {
                 // calculateContractorPayForPeriod respects hire_date and termination_date
                 const periodCostCents = calculateContractorPayForPeriod(employee, dateFrom, effectiveEndDate);
                 payrollFallback += periodCostCents / 100; // cents to dollars
+              } else if (emp.compensation_type === 'contractor' && !canSeePayRates) {
+                payrollDataHidden = true;
               }
             });
           }
         }
 
-        if (payrollFallback > 0) {
+        if (payrollFallback > 0 || payrollDataHidden) {
           accountsWithBalances = [
             ...accountsWithBalances,
             {
               id: 'payroll-expense-fallback',
               account_code: 'PAYROLL-EXP',
-              account_name: 'Payroll Expense (unposted)',
+              account_name: payrollDataHidden
+                ? 'Payroll Expense (unposted, incomplete — pay rates hidden from this role)'
+                : 'Payroll Expense (unposted)',
               account_type: 'expense' as const,
               account_subtype: 'payroll' as const,
               normal_balance: 'debit',

--- a/src/components/financial-statements/IncomeStatement.tsx
+++ b/src/components/financial-statements/IncomeStatement.tsx
@@ -310,7 +310,7 @@ export function IncomeStatement({ restaurantId, dateFrom, dateTo }: IncomeStatem
         // Uses calculateSalaryForPeriod/calculateContractorPayForPeriod which respect hire_date
         if (payrollFallback === 0) {
           const { data: employees, error: empErr } = await supabase
-            .from('employees')
+            .from('employees_secure')
             .select('id, restaurant_id, name, position, compensation_type, salary_amount, pay_period_type, contractor_payment_amount, contractor_payment_interval, allocate_daily, hire_date, termination_date, hourly_rate, is_active')
             .eq('restaurant_id', restaurantId)
             .eq('is_active', true);

--- a/src/components/scheduling/LaborCostBreakdown.tsx
+++ b/src/components/scheduling/LaborCostBreakdown.tsx
@@ -62,12 +62,15 @@ export const LaborCostBreakdown = ({
               </div>
             </div>
             <div className="flex items-center gap-2 shrink-0">
-              <span className={cn(
-                "text-sm font-semibold",
-                emp.outlierLevel === 'critical' && "text-destructive",
-                emp.outlierLevel === 'warning' && "text-accent-foreground"
-              )}>
-                ${emp.cost.toFixed(2)}
+              <span
+                className={cn(
+                  "text-sm font-semibold",
+                  emp.outlierLevel === 'critical' && "text-destructive",
+                  emp.outlierLevel === 'warning' && "text-accent-foreground"
+                )}
+                aria-label={emp.costIsHidden ? 'Labor cost hidden' : undefined}
+              >
+                {emp.costIsHidden ? '—' : `$${emp.cost.toFixed(2)}`}
               </span>
               <Edit className="h-3.5 w-3.5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity" />
             </div>

--- a/src/components/scheduling/LaborCostBreakdown.tsx
+++ b/src/components/scheduling/LaborCostBreakdown.tsx
@@ -57,7 +57,11 @@ export const LaborCostBreakdown = ({
               <div className="min-w-0">
                 <div className="text-sm font-medium truncate">{emp.name}</div>
                 <div className="text-xs text-muted-foreground">
-                  {emp.hours.toFixed(1)}h × ${emp.rate.toFixed(2)}/hr
+                  {/* A hidden rate is 0, a placeholder. "$0.00/hr" next to the
+                      dash above would read as the real rate. */}
+                  {emp.costIsHidden
+                    ? `${emp.hours.toFixed(1)}h · rate hidden`
+                    : `${emp.hours.toFixed(1)}h × $${emp.rate.toFixed(2)}/hr`}
                 </div>
               </div>
             </div>

--- a/src/components/scheduling/ScheduleMetricsRibbon.tsx
+++ b/src/components/scheduling/ScheduleMetricsRibbon.tsx
@@ -173,6 +173,11 @@ export function ScheduleMetricsRibbon({
           <span className="inline-flex items-center gap-1 text-[12px] text-muted-foreground">
             <TrendingUp className="h-3 w-3" />
             ${laborCostSummary.averageHourlyRate.toFixed(2)}/hr avg
+            {laborCostSummary.hiddenCostCount > 0 && (
+              <span className="text-[11px] text-muted-foreground ml-1">
+                ({laborCostSummary.hiddenCostCount} hidden)
+              </span>
+            )}
           </span>
         )}
       </div>
@@ -239,6 +244,11 @@ export function ScheduleMetricsRibbon({
                 <span className="text-muted-foreground">Avg Rate</span>
                 <span className={cn('font-medium tabular-nums', laborCostSummary.isAverageHigh && 'text-destructive')}>
                   ${laborCostSummary.averageHourlyRate.toFixed(2)}/hr
+                  {laborCostSummary.hiddenCostCount > 0 && (
+                    <span className="text-[11px] text-muted-foreground ml-1">
+                      ({laborCostSummary.hiddenCostCount} hidden)
+                    </span>
+                  )}
                 </span>
               </div>
             )}

--- a/src/components/scheduling/ScheduleMetricsRibbon.tsx
+++ b/src/components/scheduling/ScheduleMetricsRibbon.tsx
@@ -47,6 +47,16 @@ function MetricPill({ icon: Icon, value, unit, tone = 'text-foreground', childre
   );
 }
 
+/** How many rows the average rate above leaves out because their pay is masked. */
+function HiddenCostNote({ count }: { count: number }) {
+  if (count <= 0) return null;
+  return (
+    <span className="text-[11px] text-muted-foreground ml-1">
+      ({count} hidden)
+    </span>
+  );
+}
+
 export function ScheduleMetricsRibbon({
   activeEmployeeCount,
   totalScheduledHours,
@@ -173,11 +183,7 @@ export function ScheduleMetricsRibbon({
           <span className="inline-flex items-center gap-1 text-[12px] text-muted-foreground">
             <TrendingUp className="h-3 w-3" />
             ${laborCostSummary.averageHourlyRate.toFixed(2)}/hr avg
-            {laborCostSummary.hiddenCostCount > 0 && (
-              <span className="text-[11px] text-muted-foreground ml-1">
-                ({laborCostSummary.hiddenCostCount} hidden)
-              </span>
-            )}
+            <HiddenCostNote count={laborCostSummary.hiddenCostCount} />
           </span>
         )}
       </div>
@@ -244,11 +250,7 @@ export function ScheduleMetricsRibbon({
                 <span className="text-muted-foreground">Avg Rate</span>
                 <span className={cn('font-medium tabular-nums', laborCostSummary.isAverageHigh && 'text-destructive')}>
                   ${laborCostSummary.averageHourlyRate.toFixed(2)}/hr
-                  {laborCostSummary.hiddenCostCount > 0 && (
-                    <span className="text-[11px] text-muted-foreground ml-1">
-                      ({laborCostSummary.hiddenCostCount} hidden)
-                    </span>
-                  )}
+                  <HiddenCostNote count={laborCostSummary.hiddenCostCount} />
                 </span>
               </div>
             )}

--- a/src/components/scheduling/ShiftPlanner/EmployeeSidebar.tsx
+++ b/src/components/scheduling/ShiftPlanner/EmployeeSidebar.tsx
@@ -15,8 +15,6 @@ import { computeHoursPerEmployee } from '@/hooks/useShiftPlanner';
 
 import { cn } from '@/lib/utils';
 
-import { isMinor } from '@/lib/employeeUtils';
-
 import { EmployeeMiniWeek } from './EmployeeMiniWeek';
 
 // ---------------------------------------------------------------------------
@@ -29,7 +27,7 @@ interface Employee {
   position: string | null;
   area?: string;
   employment_type?: 'full_time' | 'part_time';
-  date_of_birth?: string;
+  is_minor?: boolean;
 }
 
 export function filterEmployees(
@@ -156,7 +154,7 @@ const DraggableEmployee = memo(
             <p className="text-[11px] text-muted-foreground truncate">
               {employee.position}
             </p>
-            {isMinor(employee.date_of_birth) && (
+            {employee.is_minor && (
               <span className="text-[10px] px-1 py-0.5 rounded bg-amber-500/10 text-amber-600 font-medium shrink-0">
                 Minor
               </span>
@@ -177,7 +175,7 @@ const DraggableEmployee = memo(
     prev.employee.id === next.employee.id &&
     prev.employee.name === next.employee.name &&
     prev.employee.position === next.employee.position &&
-    prev.employee.date_of_birth === next.employee.date_of_birth &&
+    prev.employee.is_minor === next.employee.is_minor &&
     prev.shiftCount === next.shiftCount &&
     prev.hours === next.hours &&
     prev.onSelect === next.onSelect &&

--- a/src/components/scheduling/WeekScheduleMobile.tsx
+++ b/src/components/scheduling/WeekScheduleMobile.tsx
@@ -3,7 +3,6 @@ import { format, isToday as isDateToday } from 'date-fns';
 import { Edit, Plus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
-import { isMinor } from '@/lib/employeeUtils';
 import { pickDefaultMobileDay } from '@/lib/scheduleMobile';
 import { type WeekAvailabilitySummary } from '@/lib/effectiveAvailability';
 import type { EmployeeWeekTimeOff } from '@/lib/scheduleTimeOff';
@@ -88,7 +87,7 @@ function EmployeeCardHeader({
   selectionMode,
   onEditEmployee,
 }: Readonly<EmployeeCardHeaderProps>) {
-  const isMinorEmployee = isMinor(employee.date_of_birth);
+  const isMinorEmployee = employee.is_minor === true;
 
   return (
     <div className="flex items-center justify-between gap-3">

--- a/src/hooks/useAccountlessEmployees.ts
+++ b/src/hooks/useAccountlessEmployees.ts
@@ -24,7 +24,7 @@ export function useAccountlessEmployees(restaurantId: string | undefined) {
     staleTime: 30000,
     queryFn: async (): Promise<AccountlessEmployee[]> => {
       const { data, error } = await supabase
-        .from('employees')
+        .from('employees_secure')
         .select('id, name, email')
         .eq('restaurant_id', restaurantId)
         .is('user_id', null)

--- a/src/hooks/useCurrentEmployee.tsx
+++ b/src/hooks/useCurrentEmployee.tsx
@@ -18,7 +18,7 @@ export const useCurrentEmployee = (restaurantId: string | null) => {
 
       // Find employee record linked to this user
       const { data, error } = await supabase
-        .from('employees')
+        .from('employees_secure')
         .select('*')
         .eq('user_id', user.id)
         .eq('restaurant_id', restaurantId)

--- a/src/hooks/useEmployeeLaborCosts.tsx
+++ b/src/hooks/useEmployeeLaborCosts.tsx
@@ -12,6 +12,8 @@ export interface EmployeeLaborCost {
   compensationType: string;
   isOutlier: boolean;
   outlierLevel: 'none' | 'warning' | 'critical';
+  /** True when the caller has no view:pay_rates, so cost and rate are unknown. */
+  costIsHidden: boolean;
 }
 
 export interface LaborCostSummary {
@@ -20,6 +22,8 @@ export interface LaborCostSummary {
   averageHourlyRate: number;
   isAverageHigh: boolean;
   employeeCosts: EmployeeLaborCost[];
+  /** How many employees the totals leave out because their pay is masked. */
+  hiddenCostCount: number;
 }
 
 // Rate thresholds for outlier detection (in dollars)
@@ -43,6 +47,7 @@ export function useEmployeeLaborCosts(
         averageHourlyRate: 0,
         isAverageHigh: false,
         employeeCosts: [],
+        hiddenCostCount: 0,
       };
     }
 
@@ -54,12 +59,21 @@ export function useEmployeeLaborCosts(
       if (empShifts.length === 0) return;
 
       const hours = empShifts.reduce((sum, s) => sum + calculateShiftHours(s), 0);
-      
+
+      // A masked pay column arrives as null. A $0 cost understates labor and
+      // drives a wrong P&L, so mark the row unknown and leave it out of the
+      // totals. The hours stay visible: they are not pay data.
+      const payIsHidden =
+        (emp.compensation_type === 'hourly' && emp.hourly_rate == null) ||
+        (emp.compensation_type === 'salary' && emp.salary_amount == null) ||
+        (emp.compensation_type === 'daily_rate' && emp.daily_rate_amount == null) ||
+        (emp.compensation_type === 'contractor' && emp.contractor_payment_amount == null);
+
       // Calculate effective rate based on compensation type
       let rate = 0;
       let cost = 0;
-      
-      switch (emp.compensation_type) {
+
+      if (!payIsHidden) switch (emp.compensation_type) {
         case 'hourly':
           rate = (emp.hourly_rate || 0) / 100; // Convert cents to dollars
           cost = hours * rate;
@@ -117,6 +131,7 @@ export function useEmployeeLaborCosts(
         compensationType: emp.compensation_type || 'hourly',
         isOutlier: outlierLevel !== 'none',
         outlierLevel,
+        costIsHidden: payIsHidden,
       });
     });
 
@@ -125,14 +140,19 @@ export function useEmployeeLaborCosts(
       .filter(e => e.hours > 0)
       .sort((a, b) => b.cost - a.cost);
 
+    // A masked row has no cost to add. Counting its 0 would drag the average
+    // down and understate the total.
+    const visibleCosts = employeeCosts.filter(e => !e.costIsHidden);
+    const hiddenCostCount = employeeCosts.length - visibleCosts.length;
+
     // Calculate totals (only from hourly employees for meaningful average)
-    const hourlyEmployees = employeeCosts.filter(e => e.compensationType === 'hourly');
+    const hourlyEmployees = visibleCosts.filter(e => e.compensationType === 'hourly');
     const totalHourlyCost = hourlyEmployees.reduce((sum, e) => sum + e.cost, 0);
     const totalHourlyHours = hourlyEmployees.reduce((sum, e) => sum + e.hours, 0);
-    
-    const totalCost = employeeCosts.reduce((sum, e) => sum + e.cost, 0);
-    const totalHours = employeeCosts.reduce((sum, e) => sum + e.hours, 0);
-    
+
+    const totalCost = visibleCosts.reduce((sum, e) => sum + e.cost, 0);
+    const totalHours = visibleCosts.reduce((sum, e) => sum + e.hours, 0);
+
     // Average hourly rate is only meaningful for hourly employees
     const averageHourlyRate = totalHourlyHours > 0 ? totalHourlyCost / totalHourlyHours : 0;
     
@@ -145,6 +165,7 @@ export function useEmployeeLaborCosts(
       averageHourlyRate,
       isAverageHigh,
       employeeCosts,
+      hiddenCostCount,
     };
   }, [shifts, employees]);
 }

--- a/src/hooks/useEmployeeLaborCosts.tsx
+++ b/src/hooks/useEmployeeLaborCosts.tsx
@@ -73,44 +73,46 @@ export function useEmployeeLaborCosts(
       let rate = 0;
       let cost = 0;
 
-      if (!payIsHidden) switch (emp.compensation_type) {
-        case 'hourly':
-          rate = (emp.hourly_rate || 0) / 100; // Convert cents to dollars
-          cost = hours * rate;
-          break;
-        case 'salary':
-          // For salary, show the estimated daily cost divided by hours
-          if (emp.salary_amount && emp.pay_period_type) {
-            const weeksPerPeriod = emp.pay_period_type === 'weekly' ? 1 
-              : emp.pay_period_type === 'bi-weekly' ? 2 
-              : emp.pay_period_type === 'semi-monthly' ? 2.17 
-              : 4.33;
-            const dailyCost = (emp.salary_amount / 100) / (weeksPerPeriod * 7);
-            const daysWorked = new Set(empShifts.map(s => s.start_time.split('T')[0])).size;
-            cost = dailyCost * daysWorked;
-            rate = hours > 0 ? cost / hours : 0;
-          }
-          break;
-        case 'daily_rate':
-          if (emp.daily_rate_amount) {
-            const dailyRate = emp.daily_rate_amount / 100;
-            const daysWorked = new Set(empShifts.map(s => s.start_time.split('T')[0])).size;
-            cost = dailyRate * daysWorked;
-            rate = hours > 0 ? cost / hours : 0;
-          }
-          break;
-        case 'contractor':
-          if (emp.contractor_payment_amount && emp.contractor_payment_interval) {
-            const daysPerInterval = emp.contractor_payment_interval === 'weekly' ? 7 
-              : emp.contractor_payment_interval === 'bi-weekly' ? 14 
-              : emp.contractor_payment_interval === 'monthly' ? 30 
-              : 7;
-            const dailyCost = (emp.contractor_payment_amount / 100) / daysPerInterval;
-            const daysWorked = new Set(empShifts.map(s => s.start_time.split('T')[0])).size;
-            cost = dailyCost * daysWorked;
-            rate = hours > 0 ? cost / hours : 0;
-          }
-          break;
+      if (!payIsHidden) {
+        switch (emp.compensation_type) {
+          case 'hourly':
+            rate = (emp.hourly_rate || 0) / 100; // Convert cents to dollars
+            cost = hours * rate;
+            break;
+          case 'salary':
+            // For salary, show the estimated daily cost divided by hours
+            if (emp.salary_amount && emp.pay_period_type) {
+              const weeksPerPeriod = emp.pay_period_type === 'weekly' ? 1
+                : emp.pay_period_type === 'bi-weekly' ? 2
+                : emp.pay_period_type === 'semi-monthly' ? 2.17
+                : 4.33;
+              const dailyCost = (emp.salary_amount / 100) / (weeksPerPeriod * 7);
+              const daysWorked = new Set(empShifts.map(s => s.start_time.split('T')[0])).size;
+              cost = dailyCost * daysWorked;
+              rate = hours > 0 ? cost / hours : 0;
+            }
+            break;
+          case 'daily_rate':
+            if (emp.daily_rate_amount) {
+              const dailyRate = emp.daily_rate_amount / 100;
+              const daysWorked = new Set(empShifts.map(s => s.start_time.split('T')[0])).size;
+              cost = dailyRate * daysWorked;
+              rate = hours > 0 ? cost / hours : 0;
+            }
+            break;
+          case 'contractor':
+            if (emp.contractor_payment_amount && emp.contractor_payment_interval) {
+              const daysPerInterval = emp.contractor_payment_interval === 'weekly' ? 7
+                : emp.contractor_payment_interval === 'bi-weekly' ? 14
+                : emp.contractor_payment_interval === 'monthly' ? 30
+                : 7;
+              const dailyCost = (emp.contractor_payment_amount / 100) / daysPerInterval;
+              const daysWorked = new Set(empShifts.map(s => s.start_time.split('T')[0])).size;
+              cost = dailyCost * daysWorked;
+              rate = hours > 0 ? cost / hours : 0;
+            }
+            break;
+        }
       }
 
       // Determine outlier level

--- a/src/hooks/useEmployeeLaborCosts.tsx
+++ b/src/hooks/useEmployeeLaborCosts.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { Shift, Employee } from '@/types/scheduling';
 import { calculateShiftHours } from '@/lib/scheduleRoster';
+import { isCompensationHidden } from '@/lib/employeeMaskedFields';
 
 export interface EmployeeLaborCost {
   id: string;
@@ -63,11 +64,7 @@ export function useEmployeeLaborCosts(
       // A masked pay column arrives as null. A $0 cost understates labor and
       // drives a wrong P&L, so mark the row unknown and leave it out of the
       // totals. The hours stay visible: they are not pay data.
-      const payIsHidden =
-        (emp.compensation_type === 'hourly' && emp.hourly_rate == null) ||
-        (emp.compensation_type === 'salary' && emp.salary_amount == null) ||
-        (emp.compensation_type === 'daily_rate' && emp.daily_rate_amount == null) ||
-        (emp.compensation_type === 'contractor' && emp.contractor_payment_amount == null);
+      const payIsHidden = isCompensationHidden(emp);
 
       // Calculate effective rate based on compensation type
       let rate = 0;

--- a/src/hooks/useEmployees.tsx
+++ b/src/hooks/useEmployees.tsx
@@ -37,7 +37,7 @@ export const useEmployees = (
       if (!restaurantId) return [];
 
       let query = supabase
-        .from('employees')
+        .from('employees_secure')
         .select(`
           *,
           compensation_history:employee_compensation_history(*)

--- a/src/hooks/useEmployees.tsx
+++ b/src/hooks/useEmployees.tsx
@@ -2,6 +2,11 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { Employee } from '@/types/scheduling';
 import { useToast } from '@/hooks/use-toast';
+import { usePermissions } from '@/hooks/usePermissions';
+import {
+  maskedEmployeeFields,
+  stripMaskedEmployeeFields,
+} from '@/lib/employeeMaskedFields';
 
 export type EmployeeStatusFilter = 'active' | 'inactive' | 'all';
 
@@ -76,13 +81,21 @@ export const useEmployees = (
 export const useCreateEmployee = () => {
   const queryClient = useQueryClient();
   const { toast } = useToast();
+  const { hasCapability, isResolved } = usePermissions();
 
   return useMutation({
     mutationFn: async (employee: Omit<Employee, 'id' | 'created_at' | 'updated_at'>) => {
+      // A caller with no flag cannot read these columns, so the form holds
+      // NULL for them. Writing that NULL back would erase the stored value.
+      const masked = maskedEmployeeFields({
+        payRates: isResolved && hasCapability('view:pay_rates'),
+        employeePii: isResolved && hasCapability('view:employee_pii'),
+      });
+
       const { data, error } = await supabase
         .from('employees')
-        .insert(employee)
-        .select()
+        .insert(stripMaskedEmployeeFields(employee, masked))
+        .select('id, restaurant_id, name')
         .single();
 
       if (error) throw error;
@@ -108,14 +121,20 @@ export const useCreateEmployee = () => {
 export const useUpdateEmployee = () => {
   const queryClient = useQueryClient();
   const { toast } = useToast();
+  const { hasCapability, isResolved } = usePermissions();
 
   return useMutation({
     mutationFn: async ({ id, ...updates }: Partial<Employee> & { id: string }) => {
+      const masked = maskedEmployeeFields({
+        payRates: isResolved && hasCapability('view:pay_rates'),
+        employeePii: isResolved && hasCapability('view:employee_pii'),
+      });
+
       const { data, error } = await supabase
         .from('employees')
-        .update(updates)
+        .update(stripMaskedEmployeeFields(updates, masked))
         .eq('id', id)
-        .select()
+        .select('id, restaurant_id, name')
         .single();
 
       if (error) throw error;

--- a/src/hooks/useEmployees.tsx
+++ b/src/hooks/useEmployees.tsx
@@ -85,11 +85,18 @@ export const useCreateEmployee = () => {
 
   return useMutation({
     mutationFn: async (employee: Omit<Employee, 'id' | 'created_at' | 'updated_at'>) => {
+      // Reject here, before the mask runs. isResolved false would otherwise
+      // read as "no flags" and strip every pay and contact field — a silent
+      // partial write, not the explicit retry this error gives the caller.
+      if (!isResolved) {
+        throw new Error('Permissions are still loading. Try again in a moment.');
+      }
+
       // A caller with no flag cannot read these columns, so the form holds
       // NULL for them. Writing that NULL back would erase the stored value.
       const masked = maskedEmployeeFields({
-        payRates: isResolved && hasCapability('view:pay_rates'),
-        employeePii: isResolved && hasCapability('view:employee_pii'),
+        payRates: hasCapability('view:pay_rates'),
+        employeePii: hasCapability('view:employee_pii'),
       });
 
       const { data, error } = await supabase
@@ -125,9 +132,16 @@ export const useUpdateEmployee = () => {
 
   return useMutation({
     mutationFn: async ({ id, ...updates }: Partial<Employee> & { id: string }) => {
+      // Reject here, before the mask runs. isResolved false would otherwise
+      // read as "no flags" and strip every pay and contact field — a silent
+      // partial write, not the explicit retry this error gives the caller.
+      if (!isResolved) {
+        throw new Error('Permissions are still loading. Try again in a moment.');
+      }
+
       const masked = maskedEmployeeFields({
-        payRates: isResolved && hasCapability('view:pay_rates'),
-        employeePii: isResolved && hasCapability('view:employee_pii'),
+        payRates: hasCapability('view:pay_rates'),
+        employeePii: hasCapability('view:employee_pii'),
       });
 
       const { data, error } = await supabase

--- a/src/hooks/useEmployees.tsx
+++ b/src/hooks/useEmployees.tsx
@@ -4,6 +4,7 @@ import { Employee } from '@/types/scheduling';
 import { useToast } from '@/hooks/use-toast';
 import { usePermissions } from '@/hooks/usePermissions';
 import {
+  assertPermissionsResolved,
   maskedEmployeeFields,
   stripMaskedEmployeeFields,
 } from '@/lib/employeeMaskedFields';
@@ -85,12 +86,8 @@ export const useCreateEmployee = () => {
 
   return useMutation({
     mutationFn: async (employee: Omit<Employee, 'id' | 'created_at' | 'updated_at'>) => {
-      // Reject here, before the mask runs. isResolved false would otherwise
-      // read as "no flags" and strip every pay and contact field — a silent
-      // partial write, not the explicit retry this error gives the caller.
-      if (!isResolved) {
-        throw new Error('Permissions are still loading. Try again in a moment.');
-      }
+      // Reject here, before the mask runs. See assertPermissionsResolved.
+      assertPermissionsResolved(isResolved);
 
       // A caller with no flag cannot read these columns, so the form holds
       // NULL for them. Writing that NULL back would erase the stored value.
@@ -132,12 +129,8 @@ export const useUpdateEmployee = () => {
 
   return useMutation({
     mutationFn: async ({ id, ...updates }: Partial<Employee> & { id: string }) => {
-      // Reject here, before the mask runs. isResolved false would otherwise
-      // read as "no flags" and strip every pay and contact field — a silent
-      // partial write, not the explicit retry this error gives the caller.
-      if (!isResolved) {
-        throw new Error('Permissions are still loading. Try again in a moment.');
-      }
+      // Reject here, before the mask runs. See assertPermissionsResolved.
+      assertPermissionsResolved(isResolved);
 
       const masked = maskedEmployeeFields({
         payRates: hasCapability('view:pay_rates'),
@@ -258,6 +251,7 @@ export interface ReactivateEmployeeParams {
 export const useReactivateEmployee = () => {
   const queryClient = useQueryClient();
   const { toast } = useToast();
+  const { hasCapability, isResolved } = usePermissions();
 
   return useMutation({
     mutationFn: async ({ employeeId, hourlyRate }: ReactivateEmployeeParams) => {
@@ -265,11 +259,17 @@ export const useReactivateEmployee = () => {
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) throw new Error('User not authenticated');
 
+      // A caller with no view:pay_rates cannot read the real rate, so the
+      // dialog disables the rate box. Drop any value here too, in case a
+      // caller reaches this hook another way: the dialog's disable is a UI
+      // hint, not the gate.
+      const canSetRate = isResolved && hasCapability('view:pay_rates');
+
       // Call the database function for reactivation
       const { data, error } = await supabase.rpc('reactivate_employee', {
         p_employee_id: employeeId,
         p_reactivated_by: user.id,
-        p_new_hourly_rate: hourlyRate || null,
+        p_new_hourly_rate: canSetRate ? (hourlyRate || null) : null,
       });
 
       if (error) throw error;

--- a/src/hooks/useMonthlyMetrics.tsx
+++ b/src/hooks/useMonthlyMetrics.tsx
@@ -17,6 +17,7 @@ import { lookaheadPunchFetchRange } from '@/utils/punchWindow';
 import { fetchAllRows } from '@/utils/fetchAllRows';
 import { useRestaurantClock } from './useRestaurantClock';
 import { toDateOnlyString } from '@/lib/dateOnly';
+import { isCompensationHidden } from '@/lib/employeeMaskedFields';
 
 export interface MonthlyMetrics {
   period: string; // 'YYYY-MM'
@@ -51,6 +52,25 @@ export interface MonthRevenueTotals {
 
 const toC = (n: number): number =>
   Number.isFinite(n) ? Math.sign(n) * Math.round(Math.abs(n) * 100) : 0;
+
+/**
+ * True when an employee's employment window overlaps a month. Scopes the
+ * `labor_cost_hidden` check below to employees who could actually book cost
+ * in that month — a masked employee hired last week must not blank out a
+ * year of earlier months, and a masked employee gone since last year must
+ * not blank out this month.
+ */
+const isEmployedDuringMonth = (
+  emp: { hire_date?: string | null; termination_date?: string | null },
+  monthStart: Date,
+  monthEnd: Date
+): boolean => {
+  const hireDate = emp.hire_date ? new Date(`${emp.hire_date}T12:00:00`) : null;
+  if (hireDate && hireDate > monthEnd) return false;
+  const terminationDate = emp.termination_date ? new Date(`${emp.termination_date}T12:00:00`) : null;
+  if (terminationDate && terminationDate < monthStart) return false;
+  return true;
+};
 
 /**
  * Pull revenue + pass-through totals for the period from the same RPCs that
@@ -185,6 +205,8 @@ export function useMonthlyMetrics(
         pending_labor_cost: number; // cents
         actual_labor_cost: number; // cents
         has_data: boolean;
+        /** True when a masked employee's window overlaps this month. Per-month, not roster-wide — see isEmployedDuringMonth. */
+        labor_cost_hidden: boolean;
       }>();
 
       const ensureMonth = (monthKey: string) => {
@@ -194,7 +216,7 @@ export function useMonthlyMetrics(
             gross_revenue: 0, total_collected_at_pos: 0, net_revenue: 0,
             discounts: 0, refunds: 0, sales_tax: 0, tips: 0, other_liabilities: 0,
             food_cost: 0, labor_cost: 0, pending_labor_cost: 0, actual_labor_cost: 0,
-            has_data: false,
+            has_data: false, labor_cost_hidden: false,
           });
         }
         return monthlyMap.get(monthKey)!;
@@ -414,22 +436,6 @@ export function useMonthlyMetrics(
         console.warn('Failed to fetch employees for labor calculation:', employeesError);
       }
 
-      // A masked pay column arrives as null from employees_secure, and a null
-      // rate computes as a $0 cost — a wrong number, not a hidden one. Same
-      // masked-row check as useEmployeeLaborCosts.tsx. One employee's masked
-      // row makes the whole labor_cost figure unknown, so the Dashboard must
-      // show it as unavailable instead of a number the caller could read as
-      // real.
-      const laborCostHidden = (employeesData ?? []).some((emp) => {
-        const compType = emp.compensation_type ?? 'hourly';
-        return (
-          (compType === 'hourly' && (emp.hourly_rate === null || emp.hourly_rate === undefined)) ||
-          (compType === 'salary' && (emp.salary_amount === null || emp.salary_amount === undefined)) ||
-          (compType === 'daily_rate' && (emp.daily_rate_amount === null || emp.daily_rate_amount === undefined)) ||
-          (compType === 'contractor' && (emp.contractor_payment_amount === null || emp.contractor_payment_amount === undefined))
-        );
-      });
-
       // Fetch per-job contractor payments (manual payments stored as source='per-job')
       const { data: manualPaymentsData, error: manualPaymentsError } = await supabase
         .from('daily_labor_allocations')
@@ -565,6 +571,14 @@ export function useMonthlyMetrics(
         const month = ensureMonth(monthKey);
         month.pending_labor_cost += actualLaborCents + monthPerJobCents;
         month.labor_cost += actualLaborCents + monthPerJobCents;
+
+        // A masked pay column arrives as null from employees_secure, and a
+        // null rate computes as a $0 cost — a wrong number, not a hidden
+        // one. Scoped to employees whose employment window overlaps this
+        // month, so a masked hire last week does not blank out last year.
+        month.labor_cost_hidden = typedEmployees.some(
+          (emp) => isEmployedDuringMonth(emp, clampedStart, clampedEnd) && isCompensationHidden(emp)
+        );
       }
 
       // Aggregate actual labor costs from bank transactions
@@ -611,7 +625,7 @@ export function useMonthlyMetrics(
         pending_labor_cost: Math.round(month.pending_labor_cost) / 100,
         actual_labor_cost: Math.round(month.actual_labor_cost) / 100,
         has_data: month.has_data,
-        labor_cost_hidden: laborCostHidden,
+        labor_cost_hidden: month.labor_cost_hidden,
         net_revenue: Math.round(month.net_revenue) / 100,
         total_collected_at_pos: Math.round(month.total_collected_at_pos) / 100,
       }));

--- a/src/hooks/useMonthlyMetrics.tsx
+++ b/src/hooks/useMonthlyMetrics.tsx
@@ -404,7 +404,7 @@ export function useMonthlyMetrics(
       }
 
       const { data: employeesData, error: employeesError } = await supabase
-        .from('employees')
+        .from('employees_secure')
         .select('*')
         .eq('restaurant_id', restaurantId);
 

--- a/src/hooks/useMonthlyMetrics.tsx
+++ b/src/hooks/useMonthlyMetrics.tsx
@@ -33,6 +33,8 @@ export interface MonthlyMetrics {
   pending_labor_cost: number;
   actual_labor_cost: number;
   has_data: boolean;
+  /** True when at least one employee row is masked (no view:pay_rates), so labor_cost is unknown, not zero. */
+  labor_cost_hidden: boolean;
 }
 
 const PASS_THROUGH_OTHER_LIABILITY_TYPES = new Set(['service_charge', 'fee']);
@@ -412,6 +414,22 @@ export function useMonthlyMetrics(
         console.warn('Failed to fetch employees for labor calculation:', employeesError);
       }
 
+      // A masked pay column arrives as null from employees_secure, and a null
+      // rate computes as a $0 cost — a wrong number, not a hidden one. Same
+      // masked-row check as useEmployeeLaborCosts.tsx. One employee's masked
+      // row makes the whole labor_cost figure unknown, so the Dashboard must
+      // show it as unavailable instead of a number the caller could read as
+      // real.
+      const laborCostHidden = (employeesData ?? []).some((emp) => {
+        const compType = emp.compensation_type ?? 'hourly';
+        return (
+          (compType === 'hourly' && (emp.hourly_rate === null || emp.hourly_rate === undefined)) ||
+          (compType === 'salary' && (emp.salary_amount === null || emp.salary_amount === undefined)) ||
+          (compType === 'daily_rate' && (emp.daily_rate_amount === null || emp.daily_rate_amount === undefined)) ||
+          (compType === 'contractor' && (emp.contractor_payment_amount === null || emp.contractor_payment_amount === undefined))
+        );
+      });
+
       // Fetch per-job contractor payments (manual payments stored as source='per-job')
       const { data: manualPaymentsData, error: manualPaymentsError } = await supabase
         .from('daily_labor_allocations')
@@ -593,6 +611,7 @@ export function useMonthlyMetrics(
         pending_labor_cost: Math.round(month.pending_labor_cost) / 100,
         actual_labor_cost: Math.round(month.actual_labor_cost) / 100,
         has_data: month.has_data,
+        labor_cost_hidden: laborCostHidden,
         net_revenue: Math.round(month.net_revenue) / 100,
         total_collected_at_pos: Math.round(month.total_collected_at_pos) / 100,
       }));

--- a/src/hooks/useReviewPages.ts
+++ b/src/hooks/useReviewPages.ts
@@ -195,7 +195,7 @@ export function useReviewPages(restaurantId?: string) {
       // error, so the updated row travels straight through as the receipt.
       await withSlugCollisionRetry(rest.slug, async (slug) => {
         const { data, error } = await updateReviewPageRow(id, restaurantId, { ...rest, slug });
-        return { data: data as { id: string } | null, error };
+        return { data: data as unknown as { id: string } | null, error };
       });
     },
     onSuccess: () => {

--- a/src/hooks/useScheduleChangeLogs.tsx
+++ b/src/hooks/useScheduleChangeLogs.tsx
@@ -34,7 +34,7 @@ const fetchChangeLogs = async ({ restaurantId, shiftId, startDate, endDate }: Ch
 
   const { data, error } = await query.order('changed_at', { ascending: false });
   if (error) throw error;
-  return data as ScheduleChangeLog[];
+  return data as unknown as ScheduleChangeLog[];
 };
 
 export const useScheduleChangeLogs = (

--- a/src/hooks/useScheduleChangeLogs.tsx
+++ b/src/hooks/useScheduleChangeLogs.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { ScheduleChangeLog } from '@/types/scheduling';
+import { EMPLOYEE_EMBED_COLUMNS } from '@/lib/employeeMaskedFields';
 
 type ChangeLogParams = {
   restaurantId?: string | null;
@@ -14,7 +15,7 @@ const fetchChangeLogs = async ({ restaurantId, shiftId, startDate, endDate }: Ch
 
   let query = supabase
     .from('schedule_change_logs')
-    .select('*, employee:employees(id, name, position, area, status, is_active, employment_type, user_id)');
+    .select(`*, employee:employees(${EMPLOYEE_EMBED_COLUMNS})`);
 
   if (restaurantId) {
     query = query.eq('restaurant_id', restaurantId);

--- a/src/hooks/useScheduleChangeLogs.tsx
+++ b/src/hooks/useScheduleChangeLogs.tsx
@@ -14,7 +14,7 @@ const fetchChangeLogs = async ({ restaurantId, shiftId, startDate, endDate }: Ch
 
   let query = supabase
     .from('schedule_change_logs')
-    .select('*, employee:employees(*)');
+    .select('*, employee:employees(id, name, position, area, status, is_active, employment_type, user_id)');
 
   if (restaurantId) {
     query = query.eq('restaurant_id', restaurantId);

--- a/src/hooks/useShifts.tsx
+++ b/src/hooks/useShifts.tsx
@@ -7,6 +7,7 @@ import { RecurringActionScope, getSeriesParentId } from '@/utils/recurringShiftH
 import { generateRecurringDates } from '@/utils/recurrenceUtils';
 import { buildShiftDeletedInvoke, DeletableShift } from '@/lib/shiftDeleteNotification';
 import { ShiftInterval, formatLocalDate, formatLocalDateInTz, formatLocalHHMMInTz, localDayOffsetInTz, requireTz } from '@/lib/shiftInterval';
+import { EMPLOYEE_EMBED_COLUMNS } from '@/lib/employeeMaskedFields';
 
 import { Shift, RecurrencePattern } from '@/types/scheduling';
 import { Json } from '@/integrations/supabase/types';
@@ -81,7 +82,7 @@ function useShiftsQuery(
 
       let query = supabase
         .from('shifts')
-        .select('*, employee:employees(id, name, position, area, status, is_active, employment_type, user_id)')
+        .select(`*, employee:employees(${EMPLOYEE_EMBED_COLUMNS})`)
         .eq('restaurant_id', restaurantId);
 
       if (employeeId) {

--- a/src/hooks/useShifts.tsx
+++ b/src/hooks/useShifts.tsx
@@ -81,7 +81,7 @@ function useShiftsQuery(
 
       let query = supabase
         .from('shifts')
-        .select('*, employee:employees(*)')
+        .select('*, employee:employees(id, name, position, area, status, is_active, employment_type, user_id)')
         .eq('restaurant_id', restaurantId);
 
       if (employeeId) {

--- a/src/hooks/useSlingEmployeeMapping.ts
+++ b/src/hooks/useSlingEmployeeMapping.ts
@@ -31,7 +31,7 @@ export function useSlingEmployeeMapping(restaurantId: string) {
         .eq('restaurant_id', restaurantId)
         .eq('is_active', true),
       supabase
-        .from('employees')
+        .from('employees_secure')
         .select('id, name, position, restaurant_id, status, email, phone, hire_date, notes, created_at, updated_at, is_active, compensation_type, hourly_rate')
         .eq('restaurant_id', restaurantId),
     ]);

--- a/src/hooks/useTimeOffRequests.tsx
+++ b/src/hooks/useTimeOffRequests.tsx
@@ -14,7 +14,7 @@ export const useTimeOffRequests = (restaurantId: string | null) => {
         .from('time_off_requests')
         .select(`
           *,
-          employee:employees(*)
+          employee:employees(id, name, position, area, status, is_active, employment_type, user_id)
         `)
         .eq('restaurant_id', restaurantId)
         .order('start_date', { ascending: false });

--- a/src/hooks/useTimeOffRequests.tsx
+++ b/src/hooks/useTimeOffRequests.tsx
@@ -3,6 +3,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { TimeOffRequest } from '@/types/scheduling';
 import { useToast } from '@/hooks/use-toast';
 import { useCreateEntity, useUpdateEntity, useDeleteEntity } from './useCRUDEntity';
+import { EMPLOYEE_EMBED_COLUMNS } from '@/lib/employeeMaskedFields';
 
 export const useTimeOffRequests = (restaurantId: string | null) => {
   const { data, isLoading, error } = useQuery({
@@ -14,7 +15,7 @@ export const useTimeOffRequests = (restaurantId: string | null) => {
         .from('time_off_requests')
         .select(`
           *,
-          employee:employees(id, name, position, area, status, is_active, employment_type, user_id)
+          employee:employees(${EMPLOYEE_EMBED_COLUMNS})
         `)
         .eq('restaurant_id', restaurantId)
         .order('start_date', { ascending: false });

--- a/src/hooks/useTimePunches.tsx
+++ b/src/hooks/useTimePunches.tsx
@@ -594,9 +594,13 @@ export const useCurrentEmployee = (restaurantId: string | null) => {
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) return null;
 
+      // Explicit projection, not select('*'): this hook only feeds the PIN
+      // and kiosk-clock flows below, which read only `id` and `name`. A
+      // wildcard select through employees_secure would also pull pay-rate
+      // and PII columns into this cache for no reason.
       const { data, error } = await supabase
         .from('employees_secure')
-        .select('*')
+        .select('id, name')
         .eq('restaurant_id', restaurantId)
         .eq('user_id', user.id)
         .single();

--- a/src/hooks/useTimePunches.tsx
+++ b/src/hooks/useTimePunches.tsx
@@ -595,7 +595,7 @@ export const useCurrentEmployee = (restaurantId: string | null) => {
       if (!user) return null;
 
       const { data, error } = await supabase
-        .from('employees')
+        .from('employees_secure')
         .select('*')
         .eq('restaurant_id', restaurantId)
         .eq('user_id', user.id)

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -2350,6 +2350,13 @@ export type Database = {
             referencedColumns: ["id"]
           },
           {
+            foreignKeyName: "employee_compensation_history_employee_id_fkey"
+            columns: ["employee_id"]
+            isOneToOne: false
+            referencedRelation: "employees_secure"
+            referencedColumns: ["id"]
+          },
+          {
             foreignKeyName: "employee_compensation_history_restaurant_id_fkey"
             columns: ["restaurant_id"]
             isOneToOne: false
@@ -10367,6 +10374,58 @@ export type Database = {
           tip_eligible?: boolean | null
           updated_at?: string | null
           user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "employees_restaurant_id_fkey"
+            columns: ["restaurant_id"]
+            isOneToOne: false
+            referencedRelation: "restaurants"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      employees_secure: {
+        Row: {
+          allocate_daily: boolean | null
+          area: string | null
+          compensation_type: string | null
+          contractor_payment_amount: number | null
+          contractor_payment_interval: string | null
+          created_at: string | null
+          daily_rate_amount: number | null
+          daily_rate_reference_days: number | null
+          daily_rate_reference_weekly: number | null
+          date_of_birth: string | null
+          deactivated_at: string | null
+          deactivated_by: string | null
+          deactivation_reason: string | null
+          email: string | null
+          employment_type: string | null
+          exempt_changed_at: string | null
+          exempt_changed_by: string | null
+          hire_date: string | null
+          hourly_rate: number | null
+          id: string | null
+          is_active: boolean | null
+          is_exempt: boolean | null
+          is_minor: boolean | null
+          last_active_date: string | null
+          name: string | null
+          notes: string | null
+          pay_period_type: string | null
+          phone: string | null
+          position: string | null
+          reactivated_at: string | null
+          reactivated_by: string | null
+          requires_time_punch: boolean | null
+          restaurant_id: string | null
+          salary_amount: number | null
+          status: string | null
+          termination_date: string | null
+          tip_eligible: boolean | null
+          updated_at: string | null
+          user_id: string | null
         }
         Relationships: [
           {

--- a/src/lib/employeeMaskedFields.ts
+++ b/src/lib/employeeMaskedFields.ts
@@ -59,3 +59,15 @@ export function stripMaskedEmployeeFields<T extends object>(
 
   return result as T;
 }
+
+/**
+ * The columns an `employee:employees(...)` resource embed may ask for.
+ *
+ * A PostgREST resource embed resolves against the base table, not
+ * employees_secure (20260806110000). `employees(*)` would ask for the eight
+ * masked columns and fail with "permission denied for column hourly_rate".
+ * Every embed lists only the columns its consumer reads (useShifts,
+ * useTimeOffRequests, useScheduleChangeLogs).
+ */
+export const EMPLOYEE_EMBED_COLUMNS =
+  'id, name, position, area, status, is_active, employment_type, user_id';

--- a/src/lib/employeeMaskedFields.ts
+++ b/src/lib/employeeMaskedFields.ts
@@ -71,3 +71,50 @@ export function stripMaskedEmployeeFields<T extends object>(
  */
 export const EMPLOYEE_EMBED_COLUMNS =
   'id, name, position, area, status, is_active, employment_type, user_id';
+
+/** The pay fields `isCompensationHidden` reads, one per compensation type. */
+export interface CompensationPayFields {
+  compensation_type?: string | null;
+  hourly_rate?: number | null;
+  salary_amount?: number | null;
+  daily_rate_amount?: number | null;
+  contractor_payment_amount?: number | null;
+}
+
+/**
+ * True when the pay field for this employee's own compensation type is
+ * masked (null or undefined). `employees_secure` returns null for a pay
+ * column the caller cannot see, and a null rate must read as "unknown," not
+ * as a real $0.
+ *
+ * One shared check for the three call sites that render or total pay:
+ * `useEmployeeLaborCosts`, `useMonthlyMetrics` (`labor_cost_hidden`), and
+ * `EmployeeList` (`getCompensationDisplay`).
+ */
+export function isCompensationHidden(employee: CompensationPayFields): boolean {
+  const compensationType = employee.compensation_type ?? 'hourly';
+  switch (compensationType) {
+    case 'hourly':
+      return employee.hourly_rate === null || employee.hourly_rate === undefined;
+    case 'salary':
+      return employee.salary_amount === null || employee.salary_amount === undefined;
+    case 'daily_rate':
+      return employee.daily_rate_amount === null || employee.daily_rate_amount === undefined;
+    case 'contractor':
+      return employee.contractor_payment_amount === null || employee.contractor_payment_amount === undefined;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Throw when permissions are still loading. An unresolved `isResolved`
+ * would otherwise read as "no flags" and strip every pay and contact field
+ * from the write — a silent partial write, not the explicit retry this
+ * gives the caller.
+ */
+export function assertPermissionsResolved(isResolved: boolean): void {
+  if (!isResolved) {
+    throw new Error('Permissions are still loading. Try again in a moment.');
+  }
+}

--- a/src/lib/employeeMaskedFields.ts
+++ b/src/lib/employeeMaskedFields.ts
@@ -1,0 +1,61 @@
+/**
+ * The eight columns of public.employees that 20260806110000 masks.
+ *
+ * The masking view returns NULL for a column the caller has no flag for. The
+ * Edit Employee form then loads that NULL into its state and writes it back on
+ * save. The column keeps its UPDATE grant, so the write succeeds and the real
+ * value is gone.
+ *
+ * The strip below is the fix. It runs in the mutation hooks, not in the form:
+ * four call sites write employees (EmployeeDialog, ShiftImportSheet,
+ * TimePunchUploadSheet, useSlingEmployeeMapping), and a per-field gate in one
+ * component protects one of them.
+ */
+
+/** Masked by view:pay_rates. */
+export const PAY_RATE_FIELDS = [
+  'hourly_rate',
+  'salary_amount',
+  'contractor_payment_amount',
+  'daily_rate_amount',
+  'daily_rate_reference_weekly',
+] as const;
+
+/** Masked by view:employee_pii. */
+export const EMPLOYEE_PII_FIELDS = [
+  'email',
+  'phone',
+  'date_of_birth',
+] as const;
+
+export type MaskedEmployeeField =
+  | (typeof PAY_RATE_FIELDS)[number]
+  | (typeof EMPLOYEE_PII_FIELDS)[number];
+
+/** Which fields the caller may not read, and therefore may not write. */
+export function maskedEmployeeFields(held: {
+  payRates: boolean;
+  employeePii: boolean;
+}): MaskedEmployeeField[] {
+  const masked: MaskedEmployeeField[] = [];
+  if (!held.payRates) masked.push(...PAY_RATE_FIELDS);
+  if (!held.employeePii) masked.push(...EMPLOYEE_PII_FIELDS);
+  return masked;
+}
+
+/** Remove every masked key. Returns a new object. */
+export function stripMaskedEmployeeFields<T extends object>(
+  payload: T,
+  masked: readonly MaskedEmployeeField[]
+): T {
+  if (masked.length === 0) return { ...payload };
+
+  const blocked = new Set<string>(masked);
+  const result: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(payload)) {
+    if (!blocked.has(key)) result[key] = value;
+  }
+
+  return result as T;
+}

--- a/src/lib/permissions/areas.ts
+++ b/src/lib/permissions/areas.ts
@@ -104,8 +104,8 @@ export const SENSITIVE_FLAGS: ReadonlyArray<{
   },
   {
     flag: 'view:employee_pii',
-    name: 'Contact details & tax IDs',
-    hint: 'Phone, address, last 4 of SSN',
+    name: 'Contact details',
+    hint: 'Email, phone, date of birth',
     requires: ['employees'],
   },
 ];

--- a/src/lib/permissions/definitions.ts
+++ b/src/lib/permissions/definitions.ts
@@ -81,6 +81,11 @@ export const ROLE_CAPABILITIES: Record<Role, readonly Capability[]> = {
     'manage:collaborators',
     'view:reviews',
     'manage:reviews',
+    // Sensitive-data flags. These five roles hold view:employees, so the
+    // Employees page and the Payroll page are already open to them. Without
+    // the flags, 20260806110000 masks pay and contact data for every user.
+    'view:pay_rates',
+    'view:employee_pii',
   ],
 
   manager: [
@@ -138,6 +143,11 @@ export const ROLE_CAPABILITIES: Record<Role, readonly Capability[]> = {
     'manage:collaborators',
     'view:reviews',
     'manage:reviews',
+    // Sensitive-data flags. These five roles hold view:employees, so the
+    // Employees page and the Payroll page are already open to them. Without
+    // the flags, 20260806110000 masks pay and contact data for every user.
+    'view:pay_rates',
+    'view:employee_pii',
   ],
 
   operations_manager: [
@@ -177,6 +187,11 @@ export const ROLE_CAPABILITIES: Record<Role, readonly Capability[]> = {
     'view:settings',
     'view:reviews',
     'manage:reviews',
+    // Sensitive-data flags. These five roles hold view:employees, so the
+    // Employees page and the Payroll page are already open to them. Without
+    // the flags, 20260806110000 masks pay and contact data for every user.
+    'view:pay_rates',
+    'view:employee_pii',
   ],
 
   chef: [
@@ -236,6 +251,11 @@ export const ROLE_CAPABILITIES: Record<Role, readonly Capability[]> = {
     'view:payroll', // Read-only payroll for bookkeeping
     'view:employees', // See employee names for payroll context
     'view:settings',
+    // Sensitive-data flags. These five roles hold view:employees, so the
+    // Employees page and the Payroll page are already open to them. Without
+    // the flags, 20260806110000 masks pay and contact data for every user.
+    'view:pay_rates',
+    'view:employee_pii',
   ],
 
   collaborator_inventory: [
@@ -297,6 +317,11 @@ export const ROLE_CAPABILITIES: Record<Role, readonly Capability[]> = {
     'view:payroll', // Read-only payroll for labor context
     'view:employees', // Read-only, required to assign shifts
     'view:settings',
+    // Sensitive-data flags. These five roles hold view:employees, so the
+    // Employees page and the Payroll page are already open to them. Without
+    // the flags, 20260806110000 masks pay and contact data for every user.
+    'view:pay_rates',
+    'view:employee_pii',
   ],
 } as const;
 

--- a/src/pages/Scheduling.tsx
+++ b/src/pages/Scheduling.tsx
@@ -77,7 +77,6 @@ import { BulkEditShiftsDialog } from '@/components/scheduling/BulkEditShiftsDial
 import { useBulkShiftActions } from '@/hooks/useBulkShiftActions';
 import { useToast } from '@/hooks/use-toast';
 import { cn } from '@/lib/utils';
-import { isMinor } from '@/lib/employeeUtils';
 import { buildWeekTimeOff, summarizeOff } from '@/lib/scheduleTimeOff';
 import {
   computeEffectiveAvailability,
@@ -1283,7 +1282,7 @@ const Scheduling = () => {
                         {!isCollapsed && group.employees.map((employee, idx) => {
                           const empOff = weekTimeOff.get(employee.id);
                           const off = empOff ? summarizeOff(empOff) : null;
-                          const isMinorEmployee = isMinor(employee.date_of_birth);
+                          const isMinorEmployee = employee.is_minor === true;
                           const weekAvailability = weekAvailabilityByEmployee.get(employee.id);
                           return (
                           <tr

--- a/src/types/scheduling.ts
+++ b/src/types/scheduling.ts
@@ -79,6 +79,15 @@ export interface Employee {
   // Employment classification
   employment_type?: EmploymentType; // Defaults to 'full_time' at DB level
   date_of_birth?: string; // YYYY-MM-DD, optional
+  /**
+   * Computed by public.employees_secure, not by the client.
+   *
+   * date_of_birth is masked behind view:employee_pii, and isMinor() returns
+   * false for a null date. Reading the badge off the raw date would delete a
+   * labor-compliance cue for every user without the flag. The view returns
+   * the boolean to every member and keeps the date gated.
+   */
+  is_minor?: boolean;
 
   // Compensation history (optional join)
   compensation_history?: CompensationHistoryEntry[];

--- a/supabase/migrations/20260806100000_seed_employee_sensitive_flags.sql
+++ b/supabase/migrations/20260806100000_seed_employee_sensitive_flags.sql
@@ -1,0 +1,31 @@
+-- Seed view:pay_rates and view:employee_pii onto the five builtin roles that
+-- hold view:employees.
+--
+-- Every builtin role holds zero role_flags rows today, and every membership in
+-- production carries a non-null role_id. So user_has_capability takes the flag
+-- branch (20260805120000_page_areas.sql:322-327) and returns FALSE for every
+-- caller. The column gate in 20260806110000 would therefore mask pay and
+-- contact data for every user, including the restaurant owner.
+--
+-- This migration must run before that gate.
+--
+-- view:costs stays unseeded on purpose. Nothing reads it yet, so a grant would
+-- express an intent no code enforces.
+--
+-- The list below matches ROLE_CAPABILITIES in src/lib/permissions/definitions.ts.
+-- supabase/tests/roles_seed_test.sql asserts both sides byte-for-byte.
+
+INSERT INTO public.role_flags (role_id, flag)
+SELECT r.id, f.flag
+FROM public.roles r
+CROSS JOIN LATERAL (VALUES ('view:pay_rates'), ('view:employee_pii')) AS f(flag)
+WHERE r.builtin = true
+  AND r.restaurant_id IS NULL
+  AND r.name IN (
+    'Owner',
+    'Manager',
+    'Operations Manager',
+    'Accountant',
+    'Operations Manager (Collaborator)'
+  )
+ON CONFLICT (role_id, flag) DO NOTHING;

--- a/supabase/migrations/20260806110000_employee_column_gating.sql
+++ b/supabase/migrations/20260806110000_employee_column_gating.sql
@@ -105,3 +105,53 @@ COMMENT ON VIEW public.employees_secure IS
   'Read path for public.employees. Returns NULL for a pay or contact column '
   'the caller has no flag for. Owner rights on purpose: authenticated holds '
   'no SELECT on those columns, so an invoker-rights view would fail for all.';
+
+-- ============================================================================
+-- Step 2: the grant posture
+-- ============================================================================
+--
+-- Revoke from every role the stock ALTER DEFAULT PRIVILEGES entry grants to.
+-- REVOKE ... FROM PUBLIC cannot undo a direct grant to anon or to
+-- service_role, so name each one.
+REVOKE SELECT ON public.employees FROM PUBLIC, anon, authenticated, service_role;
+
+GRANT SELECT (
+  id, restaurant_id, name, position, area, status, hire_date,
+  termination_date, notes, created_at, updated_at, user_id,
+  compensation_type, pay_period_type, contractor_payment_interval,
+  allocate_daily, tip_eligible, requires_time_punch, is_active,
+  deactivation_reason, deactivated_at, deactivated_by, reactivated_at,
+  reactivated_by, last_active_date, daily_rate_reference_days,
+  is_exempt, exempt_changed_at, exempt_changed_by, employment_type
+) ON public.employees TO authenticated;
+
+-- service_role keeps the whole table. The payroll edge functions need pay, and
+-- rolbypassrls makes the table ACL the only control behind that role. State
+-- the grant. Do not inherit it.
+GRANT SELECT ON public.employees TO service_role;
+
+GRANT  SELECT ON public.employees_secure TO authenticated;
+REVOKE SELECT ON public.employees_secure FROM PUBLIC, anon;
+
+-- ============================================================================
+-- Step 3: employee_compensation_history
+-- ============================================================================
+--
+-- The whole table is pay data, so a row policy states the rule exactly. No
+-- view and no column grant are needed. PostgREST drops the embedded rows
+-- under RLS with no error for the client to handle.
+DROP POLICY IF EXISTS "Users can view compensation history for their restaurants"
+  ON public.employee_compensation_history;
+
+CREATE POLICY "Users can view compensation history for their restaurants"
+  ON public.employee_compensation_history
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.user_restaurants ur
+      WHERE ur.restaurant_id = employee_compensation_history.restaurant_id
+        AND ur.user_id = auth.uid()
+    )
+    AND public.user_has_capability(
+      employee_compensation_history.restaurant_id, 'view:pay_rates')
+  );

--- a/supabase/migrations/20260806110000_employee_column_gating.sql
+++ b/supabase/migrations/20260806110000_employee_column_gating.sql
@@ -47,6 +47,13 @@
 -- is_minor goes to every member. isMinor(date_of_birth) returns false for a
 -- null date, so a masked date would silently delete the "Minor" badge from the
 -- roster. That badge is a labor-compliance cue. The raw date stays gated.
+--
+-- Self-row exception: a caller always reads their own pay and their own
+-- contact data, flag or no flag. Your own wage and your own contact details
+-- are your own data, and /employee/pay exists to show them. caps.self is
+-- (e.user_id = auth.uid()). e.user_id is nullable, so an employee row with no
+-- linked account must stay masked: NULL = auth.uid() evaluates to NULL, which
+-- OR treats as FALSE, so the row does not unmask.
 CREATE VIEW public.employees_secure
 WITH (security_barrier = true) AS
 SELECT
@@ -80,20 +87,21 @@ SELECT
   e.exempt_changed_at,
   e.exempt_changed_by,
   e.employment_type,
-  CASE WHEN caps.pay THEN e.hourly_rate END                 AS hourly_rate,
-  CASE WHEN caps.pay THEN e.salary_amount END               AS salary_amount,
-  CASE WHEN caps.pay THEN e.contractor_payment_amount END   AS contractor_payment_amount,
-  CASE WHEN caps.pay THEN e.daily_rate_amount END           AS daily_rate_amount,
-  CASE WHEN caps.pay THEN e.daily_rate_reference_weekly END AS daily_rate_reference_weekly,
-  CASE WHEN caps.pii THEN e.email END                       AS email,
-  CASE WHEN caps.pii THEN e.phone END                       AS phone,
-  CASE WHEN caps.pii THEN e.date_of_birth END               AS date_of_birth,
+  CASE WHEN caps.pay OR caps.self THEN e.hourly_rate END                 AS hourly_rate,
+  CASE WHEN caps.pay OR caps.self THEN e.salary_amount END               AS salary_amount,
+  CASE WHEN caps.pay OR caps.self THEN e.contractor_payment_amount END   AS contractor_payment_amount,
+  CASE WHEN caps.pay OR caps.self THEN e.daily_rate_amount END           AS daily_rate_amount,
+  CASE WHEN caps.pay OR caps.self THEN e.daily_rate_reference_weekly END AS daily_rate_reference_weekly,
+  CASE WHEN caps.pii OR caps.self THEN e.email END                       AS email,
+  CASE WHEN caps.pii OR caps.self THEN e.phone END                       AS phone,
+  CASE WHEN caps.pii OR caps.self THEN e.date_of_birth END               AS date_of_birth,
   (e.date_of_birth IS NOT NULL
    AND e.date_of_birth > (CURRENT_DATE - INTERVAL '18 years')) AS is_minor
 FROM public.employees e
 CROSS JOIN LATERAL (
   SELECT public.user_has_capability(e.restaurant_id, 'view:pay_rates')    AS pay,
-         public.user_has_capability(e.restaurant_id, 'view:employee_pii') AS pii
+         public.user_has_capability(e.restaurant_id, 'view:employee_pii') AS pii,
+         (e.user_id = auth.uid())                                        AS self
 ) caps
 WHERE e.restaurant_id IN (
         SELECT ur.restaurant_id
@@ -103,8 +111,10 @@ WHERE e.restaurant_id IN (
 
 COMMENT ON VIEW public.employees_secure IS
   'Read path for public.employees. Returns NULL for a pay or contact column '
-  'the caller has no flag for. Owner rights on purpose: authenticated holds '
-  'no SELECT on those columns, so an invoker-rights view would fail for all.';
+  'the caller has no flag for, unless the row is the caller''s own record '
+  '(e.user_id = auth.uid()) — a person always reads their own pay and their '
+  'own contact data. Owner rights on purpose: authenticated holds no SELECT '
+  'on those columns, so an invoker-rights view would fail for all.';
 
 -- ============================================================================
 -- Step 2: the grant posture

--- a/supabase/migrations/20260806110000_employee_column_gating.sql
+++ b/supabase/migrations/20260806110000_employee_column_gating.sql
@@ -1,0 +1,107 @@
+-- Gate the eight sensitive columns of public.employees behind view:pay_rates
+-- and view:employee_pii.
+--
+-- RLS filters rows. It cannot mask a column. A column GRANT is a role-level
+-- privilege, so it cannot depend on user_has_capability. The mechanism is
+-- therefore a column REVOKE plus a view that applies the capability check per
+-- row.
+--
+-- The REVOKE is the control. The view is the accessor. A caller who goes
+-- around the view hits the column ACL and gets "permission denied for column
+-- hourly_rate". PostgREST cannot bypass the ACL.
+--
+-- Prerequisite: 20260806100000 seeds the two flags onto the five builtin roles
+-- that hold view:employees. Without that seed this migration masks pay and
+-- contact data for every user, the owner included.
+
+-- ============================================================================
+-- Step 1: the masking view
+-- ============================================================================
+--
+-- security_invoker stays OFF, unlike its siblings active_employees and
+-- inactive_employees. Do not "fix" this view to match them. The caller no
+-- longer holds SELECT on the eight columns, so an invoker-rights view would
+-- fail for everyone, flag or no flag.
+--
+-- An owner-rights view bypasses the base table's RLS, so the view carries its
+-- own row predicate. That predicate is the union of the SELECT-capable
+-- policies on public.employees:
+--   "Team members can view coworkers in their restaurant" (membership)
+--   "Users can view employees for their restaurants"      (view:employees)
+--   "Owners and managers can manage employees"            (user_has_role)
+--   "Employees can view their own record"                 (self)
+-- The first is the widest: user_has_capability and user_has_role both read
+-- user_restaurants, so both are subsets of the membership test. No user gains
+-- or loses a row.
+--
+-- security_barrier protects the ROW filter from a cheap user-supplied
+-- function that leaks values before the predicate runs. It does not protect
+-- the column mask: a CASE in a target list is not a qual, and Postgres does
+-- not reorder target-list evaluation.
+--
+-- The CROSS JOIN LATERAL computes the two booleans once per row. Eight
+-- separate user_has_capability calls would be eight distinct expression
+-- nodes, each evaluated per row — 1,600 calls for a 200-employee roster to
+-- answer two questions. STABLE does not memoize across rows.
+--
+-- is_minor goes to every member. isMinor(date_of_birth) returns false for a
+-- null date, so a masked date would silently delete the "Minor" badge from the
+-- roster. That badge is a labor-compliance cue. The raw date stays gated.
+CREATE VIEW public.employees_secure
+WITH (security_barrier = true) AS
+SELECT
+  e.id,
+  e.restaurant_id,
+  e.name,
+  e.position,
+  e.area,
+  e.status,
+  e.hire_date,
+  e.termination_date,
+  e.notes,
+  e.created_at,
+  e.updated_at,
+  e.user_id,
+  e.compensation_type,
+  e.pay_period_type,
+  e.contractor_payment_interval,
+  e.allocate_daily,
+  e.tip_eligible,
+  e.requires_time_punch,
+  e.is_active,
+  e.deactivation_reason,
+  e.deactivated_at,
+  e.deactivated_by,
+  e.reactivated_at,
+  e.reactivated_by,
+  e.last_active_date,
+  e.daily_rate_reference_days,
+  e.is_exempt,
+  e.exempt_changed_at,
+  e.exempt_changed_by,
+  e.employment_type,
+  CASE WHEN caps.pay THEN e.hourly_rate END                 AS hourly_rate,
+  CASE WHEN caps.pay THEN e.salary_amount END               AS salary_amount,
+  CASE WHEN caps.pay THEN e.contractor_payment_amount END   AS contractor_payment_amount,
+  CASE WHEN caps.pay THEN e.daily_rate_amount END           AS daily_rate_amount,
+  CASE WHEN caps.pay THEN e.daily_rate_reference_weekly END AS daily_rate_reference_weekly,
+  CASE WHEN caps.pii THEN e.email END                       AS email,
+  CASE WHEN caps.pii THEN e.phone END                       AS phone,
+  CASE WHEN caps.pii THEN e.date_of_birth END               AS date_of_birth,
+  (e.date_of_birth IS NOT NULL
+   AND e.date_of_birth > (CURRENT_DATE - INTERVAL '18 years')) AS is_minor
+FROM public.employees e
+CROSS JOIN LATERAL (
+  SELECT public.user_has_capability(e.restaurant_id, 'view:pay_rates')    AS pay,
+         public.user_has_capability(e.restaurant_id, 'view:employee_pii') AS pii
+) caps
+WHERE e.restaurant_id IN (
+        SELECT ur.restaurant_id
+        FROM public.user_restaurants ur
+        WHERE ur.user_id = auth.uid())
+   OR e.user_id = auth.uid();
+
+COMMENT ON VIEW public.employees_secure IS
+  'Read path for public.employees. Returns NULL for a pay or contact column '
+  'the caller has no flag for. Owner rights on purpose: authenticated holds '
+  'no SELECT on those columns, so an invoker-rights view would fail for all.';

--- a/supabase/migrations/20260806140000_legacy_role_sensitive_flags.sql
+++ b/supabase/migrations/20260806140000_legacy_role_sensitive_flags.sql
@@ -1,0 +1,298 @@
+-- Answer the two sensitive flags on a legacy membership.
+--
+-- public.create_restaurant_with_owner still writes
+-- (user_id, restaurant_id, role) and leaves user_restaurants.role_id NULL.
+-- backfill_user_restaurants_role_id() ran once, at migration time, so it
+-- filled the rows that existed then and nothing since. Every restaurant
+-- created from now on therefore has an owner on the legacy path.
+--
+-- That path ends in the legacy CASE, which predates both flags and denies
+-- them through its ELSE FALSE. With the column gate of 20260806110000 in
+-- place, that owner reads NULL for every pay and contact column — the same
+-- defect this design set out to fix, moved to a new set of users.
+--
+-- The fix answers the two flags before the fallback, for the five legacy role
+-- strings that hold view:employees. Those five are the legacy equivalents of
+-- the five builtin roles that 20260806100000 seeds, so both paths agree.
+--
+-- view:costs stays denied on both paths. No code reads it yet.
+--
+-- The legacy CASE itself stays byte-for-byte unchanged. Every other line of
+-- this function is copied verbatim from
+-- 20260805120000_page_areas.sql:149-409.
+--
+-- Coverage: supabase/tests/user_has_capability_areas_test.sql, section 2b.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.user_has_capability(
+  p_restaurant_id UUID,
+  p_capability TEXT
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_role TEXT;
+  v_role_id UUID;
+  v_area_key TEXT;
+  v_required_level TEXT;
+BEGIN
+  SELECT role, role_id INTO v_role, v_role_id
+  FROM user_restaurants ur
+  WHERE ur.restaurant_id = p_restaurant_id
+    AND ur.user_id = auth.uid();
+
+  -- Membership is decided by whether a row was found, not by whether `role`
+  -- is populated: `user_restaurants.role` is nullable (it has always been
+  -- `role TEXT ... DEFAULT 'staff'`, never NOT NULL), so a row carrying only
+  -- a role_id — the shape this migration is moving toward — would otherwise
+  -- be read as "not a member" and lose every capability its areas grant.
+  IF NOT FOUND THEN
+    RETURN FALSE;
+  END IF;
+
+  -- Nothing to resolve from: no role_id to read areas off, and no legacy role
+  -- string for the fallback CASE below to match. Fail closed.
+  IF v_role_id IS NULL AND v_role IS NULL THEN
+    RETURN FALSE;
+  END IF;
+
+  -- The two sensitive flags answer here, before the legacy CASE below. That
+  -- CASE predates them and denies them through its ELSE FALSE. These five
+  -- role strings are the legacy equivalents of the five builtin roles that
+  -- 20260806100000 seeds, and they match view:employees exactly.
+  IF v_role_id IS NULL AND p_capability IN ('view:pay_rates', 'view:employee_pii') THEN
+    RETURN v_role IN (
+      'owner', 'manager', 'operations_manager',
+      'collaborator_accountant', 'collaborator_operations_manager'
+    );
+  END IF;
+
+  -- ==========================================================================
+  -- role_id IS NULL: legacy fallback, verbatim transcription of the CASE
+  -- body from 20260723120000_add_collaborator_operations_manager_role.sql.
+  -- Do not "clean up" or reorder branches here.
+  -- ==========================================================================
+  IF v_role_id IS NULL THEN
+    RETURN CASE p_capability
+      WHEN 'view:ai_assistant' THEN
+        v_role IN ('owner', 'manager', 'operations_manager', 'collaborator_operations_manager') AND
+        has_subscription_feature(p_restaurant_id, 'ai_assistant')
+
+      WHEN 'view:financial_intelligence' THEN
+        v_role IN ('owner', 'manager', 'collaborator_accountant') AND
+        has_subscription_feature(p_restaurant_id, 'financial_intelligence')
+
+      WHEN 'view:dashboard' THEN v_role IN ('owner', 'manager', 'operations_manager', 'chef', 'collaborator_operations_manager')
+
+      WHEN 'view:transactions' THEN v_role IN ('owner', 'manager', 'collaborator_accountant')
+      WHEN 'edit:transactions' THEN v_role IN ('owner', 'manager', 'collaborator_accountant')
+      WHEN 'view:banking' THEN v_role IN ('owner', 'manager', 'collaborator_accountant')
+      WHEN 'edit:banking' THEN v_role IN ('owner', 'manager', 'collaborator_accountant')
+      WHEN 'view:expenses' THEN v_role IN ('owner', 'manager', 'collaborator_accountant')
+      WHEN 'edit:expenses' THEN v_role IN ('owner', 'manager', 'collaborator_accountant')
+      WHEN 'view:financial_statements' THEN v_role IN ('owner', 'manager', 'collaborator_accountant')
+      WHEN 'view:chart_of_accounts' THEN v_role IN ('owner', 'manager', 'collaborator_accountant')
+      WHEN 'edit:chart_of_accounts' THEN v_role IN ('owner', 'collaborator_accountant')
+      WHEN 'view:invoices' THEN v_role IN ('owner', 'manager', 'collaborator_accountant')
+      WHEN 'edit:invoices' THEN v_role IN ('owner', 'manager', 'collaborator_accountant')
+      WHEN 'view:customers' THEN v_role IN ('owner', 'manager', 'collaborator_accountant')
+      WHEN 'edit:customers' THEN v_role IN ('owner', 'manager', 'collaborator_accountant')
+      WHEN 'view:pending_outflows' THEN v_role IN ('owner', 'manager', 'collaborator_accountant')
+      WHEN 'edit:pending_outflows' THEN v_role IN ('owner', 'manager', 'collaborator_accountant')
+      WHEN 'view:assets' THEN v_role IN ('owner', 'manager', 'collaborator_accountant')
+      WHEN 'edit:assets' THEN v_role IN ('owner', 'manager', 'collaborator_accountant')
+
+      WHEN 'view:inventory' THEN v_role IN ('owner', 'manager', 'operations_manager', 'chef', 'collaborator_inventory', 'collaborator_chef', 'collaborator_operations_manager')
+      WHEN 'edit:inventory' THEN v_role IN ('owner', 'manager', 'operations_manager', 'chef', 'collaborator_inventory', 'collaborator_operations_manager')
+      WHEN 'view:inventory_audit' THEN v_role IN ('owner', 'manager', 'operations_manager', 'chef', 'collaborator_inventory', 'collaborator_operations_manager')
+      WHEN 'edit:inventory_audit' THEN v_role IN ('owner', 'manager', 'operations_manager', 'chef', 'collaborator_inventory', 'collaborator_operations_manager')
+      WHEN 'view:purchase_orders' THEN v_role IN ('owner', 'manager', 'operations_manager', 'chef', 'collaborator_inventory', 'collaborator_operations_manager')
+      WHEN 'edit:purchase_orders' THEN v_role IN ('owner', 'manager', 'operations_manager', 'collaborator_inventory', 'collaborator_operations_manager')
+      WHEN 'view:receipt_import' THEN v_role IN ('owner', 'manager', 'operations_manager', 'chef', 'collaborator_inventory', 'collaborator_operations_manager')
+      WHEN 'edit:receipt_import' THEN v_role IN ('owner', 'manager', 'operations_manager', 'chef', 'collaborator_inventory', 'collaborator_operations_manager')
+      WHEN 'view:reports' THEN v_role IN ('owner', 'manager', 'operations_manager', 'chef', 'collaborator_inventory', 'collaborator_operations_manager')
+      WHEN 'view:inventory_transactions' THEN v_role IN ('owner', 'manager', 'operations_manager', 'chef', 'collaborator_inventory', 'collaborator_operations_manager')
+      WHEN 'edit:inventory_transactions' THEN v_role IN ('owner', 'manager', 'operations_manager', 'chef', 'collaborator_inventory', 'collaborator_operations_manager')
+
+      WHEN 'view:recipes' THEN v_role IN ('owner', 'manager', 'operations_manager', 'chef', 'collaborator_chef', 'collaborator_operations_manager')
+      WHEN 'edit:recipes' THEN v_role IN ('owner', 'manager', 'operations_manager', 'chef', 'collaborator_chef', 'collaborator_operations_manager')
+      WHEN 'view:prep_recipes' THEN v_role IN ('owner', 'manager', 'operations_manager', 'chef', 'collaborator_chef', 'collaborator_operations_manager')
+      WHEN 'edit:prep_recipes' THEN v_role IN ('owner', 'manager', 'operations_manager', 'chef', 'collaborator_chef', 'collaborator_operations_manager')
+      WHEN 'view:batches' THEN v_role IN ('owner', 'manager', 'operations_manager', 'chef', 'collaborator_chef', 'collaborator_operations_manager')
+      WHEN 'edit:batches' THEN v_role IN ('owner', 'manager', 'operations_manager', 'chef', 'collaborator_chef', 'collaborator_operations_manager')
+
+      WHEN 'view:pos_sales' THEN v_role IN ('owner', 'manager', 'operations_manager', 'chef', 'collaborator_operations_manager')
+      WHEN 'view:scheduling' THEN v_role IN ('owner', 'manager', 'operations_manager', 'chef', 'collaborator_operations_manager')
+      WHEN 'edit:scheduling' THEN v_role IN ('owner', 'manager', 'operations_manager', 'collaborator_operations_manager')
+
+      -- Mirrors the role_areas grants inserted above: Owner/Manager/Operations
+      -- Manager get 'manage', Chef gets 'view', nobody else (including every
+      -- collaborator) gets anything — there is no role_areas row for them.
+      WHEN 'view:reviews' THEN v_role IN ('owner', 'manager', 'operations_manager', 'chef')
+      WHEN 'manage:reviews' THEN v_role IN ('owner', 'manager', 'operations_manager')
+
+      WHEN 'view:payroll' THEN v_role IN ('owner', 'manager', 'operations_manager', 'collaborator_accountant', 'collaborator_operations_manager')
+      WHEN 'edit:payroll' THEN v_role IN ('owner', 'manager', 'operations_manager')
+      WHEN 'view:tips' THEN v_role IN ('owner', 'manager', 'operations_manager', 'collaborator_operations_manager')
+      WHEN 'edit:tips' THEN v_role IN ('owner', 'manager', 'operations_manager', 'collaborator_operations_manager')
+      WHEN 'view:time_punches' THEN v_role IN ('owner', 'manager', 'operations_manager', 'collaborator_operations_manager')
+      WHEN 'edit:time_punches' THEN v_role IN ('owner', 'manager', 'operations_manager', 'collaborator_operations_manager')
+
+      WHEN 'view:team' THEN v_role IN ('owner', 'manager', 'operations_manager')
+      WHEN 'manage:team' THEN v_role IN ('owner', 'manager', 'operations_manager')
+      WHEN 'view:employees' THEN v_role IN ('owner', 'manager', 'operations_manager', 'collaborator_accountant', 'collaborator_operations_manager')
+      WHEN 'manage:employees' THEN v_role IN ('owner', 'manager', 'operations_manager')
+      WHEN 'view:settings' THEN v_role NOT IN ('kiosk')
+      WHEN 'edit:settings' THEN v_role IN ('owner')
+      WHEN 'view:integrations' THEN v_role IN ('owner', 'manager')
+      WHEN 'manage:integrations' THEN v_role IN ('owner')
+      WHEN 'view:collaborators' THEN v_role IN ('owner', 'manager')
+      WHEN 'manage:collaborators' THEN v_role IN ('owner', 'manager')
+
+      WHEN 'manage:subscription' THEN v_role = 'owner'
+
+      ELSE FALSE
+    END;
+  END IF;
+
+  -- ==========================================================================
+  -- role_id IS NOT NULL: area/level/flag resolution.
+  -- ==========================================================================
+
+  -- Direct role_id check — not area-shaped in the legacy CASE either.
+  IF p_capability = 'manage:subscription' THEN
+    RETURN v_role_id = 'b0000000-0000-0000-0000-000000000001'::uuid;
+  END IF;
+
+  -- Subscription-gated capabilities: area check AND has_subscription_feature.
+  IF p_capability = 'view:ai_assistant' THEN
+    RETURN EXISTS (
+      SELECT 1 FROM role_areas ra
+      WHERE ra.role_id = v_role_id AND ra.area_key = 'reports' AND ra.level = 'manage'
+    ) AND has_subscription_feature(p_restaurant_id, 'ai_assistant');
+  END IF;
+
+  IF p_capability = 'view:financial_intelligence' THEN
+    RETURN EXISTS (
+      SELECT 1 FROM role_areas ra
+      WHERE ra.role_id = v_role_id AND ra.area_key = 'financial_intelligence' AND ra.level IN ('view', 'manage')
+    ) AND has_subscription_feature(p_restaurant_id, 'financial_intelligence');
+  END IF;
+
+  -- pending_outflows is read by two pages, not one: /print-checks (its own
+  -- area) and /expenses (Expenses.tsx calls usePendingOutflows
+  -- unconditionally). Either area, held at the matching level, must satisfy
+  -- it — a plain single-area VALUES row can't express an OR, so this stays
+  -- a hardcoded branch instead of two rows below.
+  IF p_capability = 'view:pending_outflows' THEN
+    RETURN EXISTS (
+      SELECT 1 FROM role_areas ra
+      WHERE ra.role_id = v_role_id
+        AND ra.area_key IN ('print_checks', 'expenses')
+        AND ra.level IN ('view', 'manage')
+    );
+  END IF;
+
+  IF p_capability = 'edit:pending_outflows' THEN
+    RETURN EXISTS (
+      SELECT 1 FROM role_areas ra
+      WHERE ra.role_id = v_role_id
+        AND ra.area_key IN ('print_checks', 'expenses')
+        AND ra.level = 'manage'
+    );
+  END IF;
+
+  -- Sensitive flags: independent of area grants, no legacy equivalent.
+  IF p_capability IN ('view:costs', 'view:pay_rates', 'view:employee_pii') THEN
+    RETURN EXISTS (
+      SELECT 1 FROM role_flags rf
+      WHERE rf.role_id = v_role_id AND rf.flag = p_capability
+    );
+  END IF;
+
+  -- Every remaining capability is a plain area+level lookup.
+  SELECT m.area_key, m.required_level INTO v_area_key, v_required_level
+  FROM (VALUES
+    ('view:dashboard',              'dashboard',           'view'),
+    ('view:reports',                'reports',             'view'),
+    ('view:pos_sales',              'sales',               'view'),
+    ('view:inventory',              'inventory',           'view'),
+    ('edit:inventory',              'inventory',           'manage'),
+    ('view:inventory_audit',        'inventory_audit',     'view'),
+    ('edit:inventory_audit',        'inventory_audit',     'manage'),
+    ('view:receipt_import',         'inventory',           'manage'),
+    ('edit:receipt_import',         'inventory',           'manage'),
+    ('view:inventory_transactions', 'inventory',           'manage'),
+    ('edit:inventory_transactions', 'inventory',           'manage'),
+    ('view:purchase_orders',        'purchasing',          'view'),
+    ('edit:purchase_orders',        'purchasing',          'manage'),
+    ('view:recipes',                'recipes',             'view'),
+    ('edit:recipes',                'recipes',             'manage'),
+    ('view:prep_recipes',           'prep_recipes',        'view'),
+    ('edit:prep_recipes',           'prep_recipes',        'manage'),
+    ('view:batches',                'recipes',             'view'),
+    ('edit:batches',                'recipes',             'manage'),
+    ('view:scheduling',             'scheduling',          'view'),
+    ('edit:scheduling',             'scheduling',          'manage'),
+    ('view:tips',                   'tips',                'view'),
+    ('edit:tips',                   'tips',                'manage'),
+    ('view:time_punches',           'time_punches',        'view'),
+    ('edit:time_punches',           'time_punches',        'manage'),
+    ('view:transactions',           'transactions',        'view'),
+    ('edit:transactions',           'transactions',        'manage'),
+    ('view:banking',                'banking',             'view'),
+    ('edit:banking',                'banking',             'manage'),
+    ('view:expenses',               'expenses',            'view'),
+    ('edit:expenses',               'expenses',            'manage'),
+    ('view:financial_statements',   'financial_statements', 'view'),
+    ('view:invoices',               'invoices',            'view'),
+    ('edit:invoices',               'invoices',            'manage'),
+    ('view:customers',              'customers',           'view'),
+    ('edit:customers',              'customers',           'manage'),
+    -- view:pending_outflows / edit:pending_outflows are NOT here — they're
+    -- satisfied by either 'print_checks' or 'expenses', so they're resolved
+    -- by the hardcoded IF branches above instead of a single-area row.
+    ('view:assets',                 'assets',              'view'),
+    ('edit:assets',                 'assets',              'manage'),
+    ('view:chart_of_accounts',      'chart_of_accounts',   'view'),
+    ('edit:chart_of_accounts',      'chart_of_accounts',   'manage'),
+    ('view:payroll',                'payroll',             'view'),
+    ('edit:payroll',                'payroll',             'manage'),
+    ('view:employees',              'employees',           'view'),
+    ('manage:employees',            'employees',           'manage'),
+    ('view:team',                   'team',                'view'),
+    ('manage:team',                 'team',                'manage'),
+    ('view:collaborators',          'collaborators',       'view'),
+    ('manage:collaborators',        'collaborators',       'manage'),
+    ('view:settings',               'settings',            'view'),
+    ('edit:settings',               'settings',            'manage'),
+    ('view:integrations',           'integrations',        'view'),
+    ('manage:integrations',         'integrations',        'manage'),
+    ('view:reviews',                'reviews',             'view'),
+    ('manage:reviews',              'reviews',             'manage')
+  ) AS m(capability, area_key, required_level)
+  WHERE m.capability = p_capability;
+
+  -- Unrecognized capability: fail closed, matching the legacy CASE's ELSE FALSE.
+  IF v_area_key IS NULL THEN
+    RETURN FALSE;
+  END IF;
+
+  IF v_required_level = 'manage' THEN
+    RETURN EXISTS (
+      SELECT 1 FROM role_areas ra
+      WHERE ra.role_id = v_role_id AND ra.area_key = v_area_key AND ra.level = 'manage'
+    );
+  ELSE
+    -- 'view' tier: manage also satisfies it (manage is a superset of view).
+    RETURN EXISTS (
+      SELECT 1 FROM role_areas ra
+      WHERE ra.role_id = v_role_id AND ra.area_key = v_area_key AND ra.level IN ('view', 'manage')
+    );
+  END IF;
+END;
+$$;

--- a/supabase/tests/employee_column_gating_test.sql
+++ b/supabase/tests/employee_column_gating_test.sql
@@ -1,0 +1,102 @@
+-- ============================================================================
+-- employee_column_gating_test.sql
+--
+-- Coverage for 20260806110000: the eight sensitive columns of public.employees
+-- are revoked from `authenticated`, and public.employees_secure is the only
+-- path to them.
+--
+-- Warning: a normal test role cannot read another role's column grants.
+-- has_column_privilege raises "permission denied" unless the session is a
+-- superuser. `SET LOCAL role TO postgres` is required, not decorative. The
+-- same idiom is at supabase/tests/review_responses_rls_test.sql:98-110.
+--
+-- Warning: a grant-posture assertion that passes on a bare local Postgres has
+-- proven nothing. Production creates every public table under `ALTER DEFAULT
+-- PRIVILEGES ... GRANT ALL ON TABLES TO service_role`, and a local instance
+-- has no such default to revoke. Read pg_default_acl before you trust a green.
+-- ============================================================================
+BEGIN;
+
+SELECT plan(14);
+
+SET LOCAL role TO postgres;
+
+-- ----------------------------------------------------------------------------
+-- 1. The eight sensitive columns are closed to `authenticated`.
+-- ----------------------------------------------------------------------------
+SELECT is(
+  has_column_privilege('authenticated', 'public.employees', 'hourly_rate', 'SELECT'),
+  FALSE, 'authenticated cannot SELECT employees.hourly_rate'
+);
+SELECT is(
+  has_column_privilege('authenticated', 'public.employees', 'salary_amount', 'SELECT'),
+  FALSE, 'authenticated cannot SELECT employees.salary_amount'
+);
+SELECT is(
+  has_column_privilege('authenticated', 'public.employees', 'contractor_payment_amount', 'SELECT'),
+  FALSE, 'authenticated cannot SELECT employees.contractor_payment_amount'
+);
+SELECT is(
+  has_column_privilege('authenticated', 'public.employees', 'daily_rate_amount', 'SELECT'),
+  FALSE, 'authenticated cannot SELECT employees.daily_rate_amount'
+);
+SELECT is(
+  has_column_privilege('authenticated', 'public.employees', 'daily_rate_reference_weekly', 'SELECT'),
+  FALSE, 'authenticated cannot SELECT employees.daily_rate_reference_weekly'
+);
+SELECT is(
+  has_column_privilege('authenticated', 'public.employees', 'email', 'SELECT'),
+  FALSE, 'authenticated cannot SELECT employees.email'
+);
+SELECT is(
+  has_column_privilege('authenticated', 'public.employees', 'phone', 'SELECT'),
+  FALSE, 'authenticated cannot SELECT employees.phone'
+);
+SELECT is(
+  has_column_privilege('authenticated', 'public.employees', 'date_of_birth', 'SELECT'),
+  FALSE, 'authenticated cannot SELECT employees.date_of_birth'
+);
+
+-- ----------------------------------------------------------------------------
+-- 2. The 30 plain columns stay open, and anon stays shut.
+-- ----------------------------------------------------------------------------
+SELECT is(
+  has_column_privilege('authenticated', 'public.employees', 'name', 'SELECT'),
+  TRUE, 'authenticated can still SELECT employees.name'
+);
+SELECT is(
+  has_column_privilege('authenticated', 'public.employees', 'restaurant_id', 'SELECT'),
+  TRUE, 'authenticated can still SELECT employees.restaurant_id'
+);
+SELECT is(
+  has_table_privilege('anon', 'public.employees_secure', 'SELECT'),
+  FALSE, 'anon cannot SELECT the masking view'
+);
+SELECT is(
+  has_table_privilege('authenticated', 'public.employees_secure', 'SELECT'),
+  TRUE, 'authenticated can SELECT the masking view'
+);
+
+-- ----------------------------------------------------------------------------
+-- 3. The view runs with owner rights and carries its own row predicate.
+--    security_invoker must stay off: the caller no longer holds the column
+--    privilege, so an invoker-rights view fails for everyone.
+-- ----------------------------------------------------------------------------
+SELECT is(
+  (SELECT COALESCE(
+     (SELECT option FROM unnest(c.reloptions) AS option
+      WHERE option LIKE 'security_invoker=%'), 'unset')
+   FROM pg_class c
+   JOIN pg_namespace n ON n.oid = c.relnamespace
+   WHERE n.nspname = 'public' AND c.relname = 'employees_secure'),
+  'unset',
+  'employees_secure does not set security_invoker'
+);
+
+SELECT ok(
+  (SELECT pg_get_viewdef('public.employees_secure'::regclass) LIKE '%user_restaurants%'),
+  'employees_secure carries its own row predicate against user_restaurants'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/employee_column_gating_test.sql
+++ b/supabase/tests/employee_column_gating_test.sql
@@ -17,7 +17,7 @@
 -- ============================================================================
 BEGIN;
 
-SELECT plan(14);
+SELECT plan(19);
 
 SET LOCAL role TO postgres;
 
@@ -96,6 +96,86 @@ SELECT is(
 SELECT ok(
   (SELECT pg_get_viewdef('public.employees_secure'::regclass) LIKE '%user_restaurants%'),
   'employees_secure carries its own row predicate against user_restaurants'
+);
+
+-- ----------------------------------------------------------------------------
+-- 4. The self-row exception: a caller always reads their own pay and contact
+--    data, flag or no flag. A coworker's row stays masked. A row with no
+--    linked account (user_id IS NULL) stays masked for a caller with no
+--    flags, never unmasked by a NULL-equals-NULL accident.
+-- ----------------------------------------------------------------------------
+SET LOCAL role TO postgres;
+ALTER TABLE public.employees DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.restaurants DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_restaurants DISABLE ROW LEVEL SECURITY;
+
+INSERT INTO public.restaurants (id, name) VALUES
+  ('b1111111-0000-0000-0000-000000000001', 'Self-Row Test Restaurant')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO auth.users (
+  id, instance_id, aud, role, email, encrypted_password, email_confirmed_at,
+  created_at, updated_at, confirmation_token, recovery_token,
+  email_change_token_new, email_change
+) VALUES
+  ('b1111111-0000-0000-0000-000000000010', '00000000-0000-0000-0000-000000000000',
+   'authenticated', 'authenticated', 'self_staff@test.com',
+   crypt('password123', gen_salt('bf')), now(), now(), now(), '', '', '', ''),
+  ('b1111111-0000-0000-0000-000000000020', '00000000-0000-0000-0000-000000000000',
+   'authenticated', 'authenticated', 'coworker_staff@test.com',
+   crypt('password123', gen_salt('bf')), now(), now(), now(), '', '', '', '')
+ON CONFLICT (id) DO NOTHING;
+
+-- Both are plain 'staff': the legacy CASE denies view:pay_rates and
+-- view:employee_pii to that role string, so any unmasking below can only
+-- come from the self-row exception, not from a flag.
+INSERT INTO public.user_restaurants (user_id, restaurant_id, role) VALUES
+  ('b1111111-0000-0000-0000-000000000010', 'b1111111-0000-0000-0000-000000000001', 'staff'),
+  ('b1111111-0000-0000-0000-000000000020', 'b1111111-0000-0000-0000-000000000001', 'staff')
+ON CONFLICT (user_id, restaurant_id) DO UPDATE SET role = EXCLUDED.role;
+
+INSERT INTO public.employees (id, restaurant_id, user_id, name, email, hourly_rate, compensation_type, position, is_active)
+VALUES
+  ('b1111111-0000-0000-0000-000000000011', 'b1111111-0000-0000-0000-000000000001',
+   'b1111111-0000-0000-0000-000000000010', 'Self Staff', 'self_staff@test.com', 1500, 'hourly', 'Server', true),
+  ('b1111111-0000-0000-0000-000000000021', 'b1111111-0000-0000-0000-000000000001',
+   'b1111111-0000-0000-0000-000000000020', 'Coworker Staff', 'coworker_staff@test.com', 2000, 'hourly', 'Server', true),
+  ('b1111111-0000-0000-0000-000000000031', 'b1111111-0000-0000-0000-000000000001',
+   NULL, 'Unlinked Row', 'unlinked@test.com', 999, 'hourly', 'Server', true)
+ON CONFLICT (id) DO UPDATE SET
+  hourly_rate = EXCLUDED.hourly_rate, email = EXCLUDED.email, user_id = EXCLUDED.user_id;
+
+ALTER TABLE public.employees ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.restaurants ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_restaurants ENABLE ROW LEVEL SECURITY;
+
+SET LOCAL role TO authenticated;
+SET LOCAL request.jwt.claim.sub TO 'b1111111-0000-0000-0000-000000000010'; -- Self Staff
+
+SELECT is(
+  (SELECT hourly_rate FROM public.employees_secure WHERE id = 'b1111111-0000-0000-0000-000000000011'),
+  1500,
+  'a staff member reads their own hourly_rate, unmasked, flag or no flag'
+);
+SELECT is(
+  (SELECT email FROM public.employees_secure WHERE id = 'b1111111-0000-0000-0000-000000000011'),
+  'self_staff@test.com'::text,
+  'a staff member reads their own email, unmasked, flag or no flag'
+);
+SELECT is(
+  (SELECT hourly_rate FROM public.employees_secure WHERE id = 'b1111111-0000-0000-0000-000000000021'),
+  NULL::integer,
+  'the same staff member reads NULL for a coworker''s hourly_rate'
+);
+SELECT is(
+  (SELECT email FROM public.employees_secure WHERE id = 'b1111111-0000-0000-0000-000000000021'),
+  NULL::text,
+  'the same staff member reads NULL for a coworker''s email'
+);
+SELECT is(
+  (SELECT hourly_rate FROM public.employees_secure WHERE id = 'b1111111-0000-0000-0000-000000000031'),
+  NULL::integer,
+  'a row with no linked account (user_id IS NULL) stays masked for a caller without the flags'
 );
 
 SELECT * FROM finish();

--- a/supabase/tests/employee_column_gating_test.sql
+++ b/supabase/tests/employee_column_gating_test.sql
@@ -17,7 +17,7 @@
 -- ============================================================================
 BEGIN;
 
-SELECT plan(19);
+SELECT plan(27);
 
 SET LOCAL role TO postgres;
 
@@ -176,6 +176,132 @@ SELECT is(
   (SELECT hourly_rate FROM public.employees_secure WHERE id = 'b1111111-0000-0000-0000-000000000031'),
   NULL::integer,
   'a row with no linked account (user_id IS NULL) stays masked for a caller without the flags'
+);
+
+-- ----------------------------------------------------------------------------
+-- 5. Each flag alone, and both flags together, on a COWORKER row (not self).
+--    The self-row exception cannot explain any result here, so every read
+--    below comes only from role_flags. Three role_id-based custom roles,
+--    each on the same restaurant as the self-row fixtures above, holding
+--    respectively: view:pay_rates only, view:employee_pii only, both.
+-- ----------------------------------------------------------------------------
+SET LOCAL role TO postgres;
+ALTER TABLE public.roles DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.role_flags DISABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_restaurants DISABLE ROW LEVEL SECURITY;
+
+INSERT INTO public.roles (id, restaurant_id, name, flavor, builtin) VALUES
+  ('b1111111-0000-0000-0000-0000000000c1', 'b1111111-0000-0000-0000-000000000001', 'Pay Only', 'collaborator', false),
+  ('b1111111-0000-0000-0000-0000000000c2', 'b1111111-0000-0000-0000-000000000001', 'PII Only', 'collaborator', false),
+  ('b1111111-0000-0000-0000-0000000000c3', 'b1111111-0000-0000-0000-000000000001', 'Both Flags', 'collaborator', false)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.role_flags (role_id, flag) VALUES
+  ('b1111111-0000-0000-0000-0000000000c1', 'view:pay_rates'),
+  ('b1111111-0000-0000-0000-0000000000c2', 'view:employee_pii'),
+  ('b1111111-0000-0000-0000-0000000000c3', 'view:pay_rates'),
+  ('b1111111-0000-0000-0000-0000000000c3', 'view:employee_pii')
+ON CONFLICT (role_id, flag) DO NOTHING;
+
+INSERT INTO auth.users (
+  id, instance_id, aud, role, email, encrypted_password, email_confirmed_at,
+  created_at, updated_at, confirmation_token, recovery_token,
+  email_change_token_new, email_change
+) VALUES
+  ('b1111111-0000-0000-0000-000000000040', '00000000-0000-0000-0000-000000000000',
+   'authenticated', 'authenticated', 'pay_only@test.com',
+   crypt('password123', gen_salt('bf')), now(), now(), now(), '', '', '', ''),
+  ('b1111111-0000-0000-0000-000000000050', '00000000-0000-0000-0000-000000000000',
+   'authenticated', 'authenticated', 'pii_only@test.com',
+   crypt('password123', gen_salt('bf')), now(), now(), now(), '', '', '', ''),
+  ('b1111111-0000-0000-0000-000000000060', '00000000-0000-0000-0000-000000000000',
+   'authenticated', 'authenticated', 'both_flags@test.com',
+   crypt('password123', gen_salt('bf')), now(), now(), now(), '', '', '', '')
+ON CONFLICT (id) DO NOTHING;
+
+-- role_id is set, role stays NULL: user_has_capability resolves the two
+-- flags from role_flags, never touching the legacy CASE.
+INSERT INTO public.user_restaurants (user_id, restaurant_id, role_id) VALUES
+  ('b1111111-0000-0000-0000-000000000040', 'b1111111-0000-0000-0000-000000000001', 'b1111111-0000-0000-0000-0000000000c1'),
+  ('b1111111-0000-0000-0000-000000000050', 'b1111111-0000-0000-0000-000000000001', 'b1111111-0000-0000-0000-0000000000c2'),
+  ('b1111111-0000-0000-0000-000000000060', 'b1111111-0000-0000-0000-000000000001', 'b1111111-0000-0000-0000-0000000000c3')
+ON CONFLICT (user_id, restaurant_id) DO UPDATE SET role_id = EXCLUDED.role_id;
+
+ALTER TABLE public.roles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.role_flags ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_restaurants ENABLE ROW LEVEL SECURITY;
+
+SET LOCAL role TO authenticated;
+SET LOCAL request.jwt.claim.sub TO 'b1111111-0000-0000-0000-000000000040'; -- Pay Only
+
+SELECT is(
+  (SELECT hourly_rate FROM public.employees_secure WHERE id = 'b1111111-0000-0000-0000-000000000021'),
+  2000,
+  'view:pay_rates alone unmasks a coworker''s hourly_rate'
+);
+SELECT is(
+  (SELECT email FROM public.employees_secure WHERE id = 'b1111111-0000-0000-0000-000000000021'),
+  NULL::text,
+  'view:pay_rates alone still masks a coworker''s email'
+);
+
+SET LOCAL request.jwt.claim.sub TO 'b1111111-0000-0000-0000-000000000050'; -- PII Only
+
+SELECT is(
+  (SELECT hourly_rate FROM public.employees_secure WHERE id = 'b1111111-0000-0000-0000-000000000021'),
+  NULL::integer,
+  'view:employee_pii alone still masks a coworker''s hourly_rate'
+);
+SELECT is(
+  (SELECT email FROM public.employees_secure WHERE id = 'b1111111-0000-0000-0000-000000000021'),
+  'coworker_staff@test.com'::text,
+  'view:employee_pii alone unmasks a coworker''s email'
+);
+
+SET LOCAL request.jwt.claim.sub TO 'b1111111-0000-0000-0000-000000000060'; -- Both Flags
+
+SELECT is(
+  (SELECT hourly_rate FROM public.employees_secure WHERE id = 'b1111111-0000-0000-0000-000000000021'),
+  2000,
+  'both flags together unmask a coworker''s hourly_rate'
+);
+SELECT is(
+  (SELECT email FROM public.employees_secure WHERE id = 'b1111111-0000-0000-0000-000000000021'),
+  'coworker_staff@test.com'::text,
+  'both flags together unmask a coworker''s email'
+);
+
+-- ----------------------------------------------------------------------------
+-- 6. employee_compensation_history (Step 3 of 20260806110000): the SELECT
+--    policy now requires view:pay_rates, not bare membership. A caller who
+--    holds view:employee_pii but not view:pay_rates reads zero rows, not an
+--    error — RLS drops the rows silently.
+-- ----------------------------------------------------------------------------
+SET LOCAL role TO postgres;
+
+INSERT INTO public.employee_compensation_history
+  (employee_id, restaurant_id, compensation_type, amount_cents, effective_date)
+VALUES
+  ('b1111111-0000-0000-0000-000000000021', 'b1111111-0000-0000-0000-000000000001',
+   'hourly', 2000, CURRENT_DATE)
+ON CONFLICT (employee_id, effective_date) DO NOTHING;
+
+SET LOCAL role TO authenticated;
+SET LOCAL request.jwt.claim.sub TO 'b1111111-0000-0000-0000-000000000060'; -- Both Flags: holds view:pay_rates
+
+SELECT ok(
+  (SELECT count(*) FROM public.employee_compensation_history
+   WHERE restaurant_id = 'b1111111-0000-0000-0000-000000000001') >= 1,
+  'a caller with view:pay_rates reads the restaurant''s compensation history'
+);
+
+SET LOCAL request.jwt.claim.sub TO 'b1111111-0000-0000-0000-000000000050'; -- PII Only: lacks view:pay_rates
+
+SELECT is(
+  (SELECT count(*) FROM public.employee_compensation_history
+   WHERE restaurant_id = 'b1111111-0000-0000-0000-000000000001'),
+  0::bigint,
+  'a caller without view:pay_rates reads zero compensation history rows'
 );
 
 SELECT * FROM finish();

--- a/supabase/tests/roles_seed_test.sql
+++ b/supabase/tests/roles_seed_test.sql
@@ -210,6 +210,8 @@ INSERT INTO test_expected_capabilities (role_name, capability) VALUES
   ('Owner', 'manage:collaborators'),
   ('Owner', 'view:reviews'),
   ('Owner', 'manage:reviews'),
+  ('Owner', 'view:pay_rates'),
+  ('Owner', 'view:employee_pii'),
   ('Manager', 'view:dashboard'),
   ('Manager', 'view:ai_assistant'),
   ('Manager', 'view:transactions'),
@@ -263,6 +265,8 @@ INSERT INTO test_expected_capabilities (role_name, capability) VALUES
   ('Manager', 'manage:collaborators'),
   ('Manager', 'view:reviews'),
   ('Manager', 'manage:reviews'),
+  ('Manager', 'view:pay_rates'),
+  ('Manager', 'view:employee_pii'),
   ('Operations Manager', 'view:dashboard'),
   ('Operations Manager', 'view:ai_assistant'),
   ('Operations Manager', 'view:inventory'),
@@ -298,6 +302,8 @@ INSERT INTO test_expected_capabilities (role_name, capability) VALUES
   ('Operations Manager', 'view:settings'),
   ('Operations Manager', 'view:reviews'),
   ('Operations Manager', 'manage:reviews'),
+  ('Operations Manager', 'view:pay_rates'),
+  ('Operations Manager', 'view:employee_pii'),
   ('Chef', 'view:dashboard'),
   ('Chef', 'view:inventory'),
   ('Chef', 'edit:inventory'),
@@ -339,6 +345,8 @@ INSERT INTO test_expected_capabilities (role_name, capability) VALUES
   ('Accountant', 'view:payroll'),
   ('Accountant', 'view:employees'),
   ('Accountant', 'view:settings'),
+  ('Accountant', 'view:pay_rates'),
+  ('Accountant', 'view:employee_pii'),
   ('Inventory Helper', 'view:inventory'),
   ('Inventory Helper', 'edit:inventory'),
   ('Inventory Helper', 'view:inventory_audit'),
@@ -386,7 +394,9 @@ INSERT INTO test_expected_capabilities (role_name, capability) VALUES
   ('Operations Manager (Collaborator)', 'edit:tips'),
   ('Operations Manager (Collaborator)', 'view:payroll'),
   ('Operations Manager (Collaborator)', 'view:employees'),
-  ('Operations Manager (Collaborator)', 'view:settings');
+  ('Operations Manager (Collaborator)', 'view:settings'),
+  ('Operations Manager (Collaborator)', 'view:pay_rates'),
+  ('Operations Manager (Collaborator)', 'view:employee_pii');
 
 -- ----------------------------------------------------------------------------
 -- derived_capabilities: what the seed actually produces, computed purely

--- a/supabase/tests/roles_seed_test.sql
+++ b/supabase/tests/roles_seed_test.sql
@@ -445,16 +445,28 @@ SELECT set_eq(
 );
 
 -- ============================================================================
--- 2. No role_flags rows are seeded for any builtin: the three sensitive
---    flags have no equivalent in the legacy Capability union, so seeding any
---    of them here would immediately break the round-trip property below.
+-- 2. The two employee flags are seeded onto exactly the five builtin roles
+--    that hold view:employees. view:costs stays unseeded: its gate is not
+--    built yet, so seeding it would grant a capability nothing reads.
 -- ============================================================================
-SELECT is(
-  (SELECT count(*)::int FROM public.role_flags rf
-   JOIN public.roles r ON r.id = rf.role_id
-   WHERE r.builtin = true AND r.restaurant_id IS NULL),
-  0,
-  'zero role_flags rows are seeded for any builtin role'
+SELECT set_eq(
+  $$SELECT r.name || '|' || rf.flag
+    FROM public.role_flags rf
+    JOIN public.roles r ON r.id = rf.role_id
+    WHERE r.builtin = true AND r.restaurant_id IS NULL$$,
+  ARRAY[
+    'Owner|view:pay_rates',
+    'Owner|view:employee_pii',
+    'Manager|view:pay_rates',
+    'Manager|view:employee_pii',
+    'Operations Manager|view:pay_rates',
+    'Operations Manager|view:employee_pii',
+    'Accountant|view:pay_rates',
+    'Accountant|view:employee_pii',
+    'Operations Manager (Collaborator)|view:pay_rates',
+    'Operations Manager (Collaborator)|view:employee_pii'
+  ],
+  'the two employee flags are seeded onto exactly the five view:employees roles'
 );
 
 -- ============================================================================

--- a/supabase/tests/roles_seed_test.sql
+++ b/supabase/tests/roles_seed_test.sql
@@ -400,6 +400,14 @@ FROM public.roles r
 JOIN public.role_areas ra ON ra.role_id = r.id
 JOIN test_area_capability_at_level acal
   ON acal.area_key = ra.area_key AND acal.level = ra.level
+WHERE r.builtin = true AND r.restaurant_id IS NULL
+UNION ALL
+-- A sensitive flag is a capability with no area behind it. user_has_capability
+-- resolves it straight off role_flags (20260805120000_page_areas.sql:322-327),
+-- so the round trip must read the same source.
+SELECT r.name AS role_name, rf.flag AS capability
+FROM public.roles r
+JOIN public.role_flags rf ON rf.role_id = r.id
 WHERE r.builtin = true AND r.restaurant_id IS NULL;
 
 -- ============================================================================

--- a/supabase/tests/user_has_capability_areas_test.sql
+++ b/supabase/tests/user_has_capability_areas_test.sql
@@ -20,19 +20,29 @@
 --    public.user_has_capability() must return exactly what the legacy
 --    fixture returns for that builtin's legacy role string.
 --
---    ONE sanctioned, documented exception: collaborator_inventory (Inventory
---    Helper) + view:reports. The legacy CASE granted it (line ~120 of
---    20260723120000: 'view:reports' includes collaborator_inventory). The
---    seed migration (20260730110000_seed_builtin_roles.sql) deliberately did
---    NOT grant Inventory Helper a 'reports' area at all, following
---    ROLE_CAPABILITIES (src/lib/permissions/definitions.ts), which never
---    granted collaborator_inventory view:reports either (see PR #596, and
---    the design doc's "Three real defects" section, defect 3: zero
---    production memberships/invitations on this role justified fixing the
---    drift by tightening to match the TypeScript source of truth rather
---    than widening the seed to preserve the SQL-only grant). This is the
---    one cell excluded from the aggregate mismatch count below and asserted
---    explicitly, in both directions, instead.
+--    ELEVEN sanctioned, documented exceptions, each excluded from the
+--    aggregate mismatch count below and asserted explicitly instead:
+--
+--    - collaborator_inventory (Inventory Helper) + view:reports. The legacy
+--      CASE granted it (line ~120 of 20260723120000: 'view:reports' includes
+--      collaborator_inventory). The seed migration
+--      (20260730110000_seed_builtin_roles.sql) deliberately did NOT grant
+--      Inventory Helper a 'reports' area at all, following ROLE_CAPABILITIES
+--      (src/lib/permissions/definitions.ts), which never granted
+--      collaborator_inventory view:reports either (see PR #596, and the
+--      design doc's "Three real defects" section, defect 3: zero production
+--      memberships/invitations on this role justified fixing the drift by
+--      tightening to match the TypeScript source of truth rather than
+--      widening the seed to preserve the SQL-only grant).
+--
+--    - Ten more: view:pay_rates and view:employee_pii, each granted TRUE on
+--      owner, manager, operations_manager, collaborator_accountant, and
+--      collaborator_operations_manager by
+--      20260806100000_seed_employee_sensitive_flags.sql (the sensitive-data
+--      flags design). The legacy CASE predates both flags and denies them
+--      through its ELSE FALSE on every role, so this is intended drift, not
+--      a bug: the whole point of that migration is to make these flags real
+--      for the five roles that hold view:employees.
 --
 -- 2. user_restaurants.role_id IS NULL falls back to the legacy CASE
 --    (denied capability first, then a granted one).
@@ -71,7 +81,7 @@
 
 BEGIN;
 
-SELECT plan(29);
+SELECT plan(31);
 
 -- ----------------------------------------------------------------------------
 -- Fixture: legacy CASE, transcribed verbatim and parameterized on p_role.
@@ -321,18 +331,49 @@ SELECT is(
   'new area-based function: Inventory Helper denies view:reports — sanctioned drift from the legacy CASE per the design''s defect-3 resolution (follow TypeScript/ROLE_CAPABILITIES, PR #596); Task 2''s seed intentionally grants no reports area to this role'
 );
 
+-- The ten more sanctioned exceptions from the sensitive-data flags seed,
+-- checked as one bag rather than twenty individual assertions.
+CREATE TEMP TABLE test_sensitive_flag_exceptions (legacy_role TEXT, capability TEXT) ON COMMIT DROP;
+INSERT INTO test_sensitive_flag_exceptions (legacy_role, capability) VALUES
+  ('owner', 'view:pay_rates'), ('owner', 'view:employee_pii'),
+  ('manager', 'view:pay_rates'), ('manager', 'view:employee_pii'),
+  ('operations_manager', 'view:pay_rates'), ('operations_manager', 'view:employee_pii'),
+  ('collaborator_accountant', 'view:pay_rates'), ('collaborator_accountant', 'view:employee_pii'),
+  ('collaborator_operations_manager', 'view:pay_rates'), ('collaborator_operations_manager', 'view:employee_pii');
+
+SELECT is(
+  (
+    SELECT count(*)::int FROM test_sensitive_flag_exceptions x
+    JOIN test_expected_results e USING (legacy_role, capability)
+    WHERE e.expected = FALSE
+  ),
+  10,
+  'legacy CASE fixture: all ten (role, sensitive flag) pairs denied — both flags postdate the legacy CASE'
+);
+SELECT is(
+  (
+    SELECT count(*)::int FROM test_sensitive_flag_exceptions x
+    JOIN test_actual_results a USING (legacy_role, capability)
+    WHERE a.actual = TRUE
+  ),
+  10,
+  'new area-based function: all ten (role, sensitive flag) pairs granted — 20260806100000_seed_employee_sensitive_flags.sql'
+);
+
 -- Full-matrix aggregate: every other cell (10 roles x 61 capabilities, minus
--- the one documented exception) must match exactly, in both directions.
+-- the eleven documented exceptions) must match exactly, in both directions.
 SELECT is(
   (
     SELECT count(*)::int
     FROM test_actual_results a
     JOIN test_expected_results e USING (legacy_role, capability)
+    LEFT JOIN test_sensitive_flag_exceptions x USING (legacy_role, capability)
     WHERE a.actual IS DISTINCT FROM e.expected
       AND NOT (a.legacy_role = 'collaborator_inventory' AND a.capability = 'view:reports')
+      AND x.legacy_role IS NULL
   ),
   0,
-  'user_has_capability(role_id-based) matches the legacy CASE byte-for-byte across all ten builtins x 61 capabilities, with exactly the one documented, sanctioned exception excluded above'
+  'user_has_capability(role_id-based) matches the legacy CASE byte-for-byte across all ten builtins x 61 capabilities, with exactly the eleven documented, sanctioned exceptions excluded above'
 );
 
 -- ============================================================================

--- a/supabase/tests/user_has_capability_areas_test.sql
+++ b/supabase/tests/user_has_capability_areas_test.sql
@@ -40,9 +40,14 @@
 --      collaborator_operations_manager by
 --      20260806100000_seed_employee_sensitive_flags.sql (the sensitive-data
 --      flags design). The legacy CASE predates both flags and denies them
---      through its ELSE FALSE on every role, so this is intended drift, not
---      a bug: the whole point of that migration is to make these flags real
---      for the five roles that hold view:employees.
+--      through its ELSE FALSE on every role.
+--
+--      This drift is a property of the CASE literal only. It is not the
+--      behaviour a caller sees. 20260806140000_legacy_role_sensitive_flags.sql
+--      answers both flags before control reaches the CASE, for the same five
+--      role strings. Section 2b below tests that path. The legacy denial was
+--      a bug, and that migration fixes it; the CASE keeps its old text
+--      because the new branch runs first.
 --
 -- 2. user_restaurants.role_id IS NULL falls back to the legacy CASE
 --    (denied capability first, then a granted one).

--- a/supabase/tests/user_has_capability_areas_test.sql
+++ b/supabase/tests/user_has_capability_areas_test.sql
@@ -47,6 +47,12 @@
 -- 2. user_restaurants.role_id IS NULL falls back to the legacy CASE
 --    (denied capability first, then a granted one).
 --
+-- 2b. The two sensitive flags answer BEFORE that fallback. The legacy CASE
+--    denies them through its ELSE FALSE, and create_restaurant_with_owner
+--    still leaves role_id NULL, so every new restaurant's owner would lose
+--    pay and contact data to the column gate. The branch grants both flags to
+--    the five legacy role strings that hold view:employees, and to no other.
+--
 -- 3. A custom role holding {inventory: manage} gets edit:inventory and not
 --    edit:recipes (denied first, then granted).
 --
@@ -81,7 +87,7 @@
 
 BEGIN;
 
-SELECT plan(31);
+SELECT plan(36);
 
 -- ----------------------------------------------------------------------------
 -- Fixture: legacy CASE, transcribed verbatim and parameterized on p_role.
@@ -404,6 +410,63 @@ SELECT is(
   public.user_has_capability('5a000000-0000-0000-0000-000000000099'::uuid, 'view:recipes'),
   TRUE,
   'role_id IS NULL fallback: legacy chef granted view:recipes (legacy CASE)'
+);
+
+-- ============================================================================
+-- 2b. The two sensitive flags on a legacy membership.
+--
+-- create_restaurant_with_owner still writes (user_id, restaurant_id, role)
+-- and leaves role_id NULL, so the owner of every restaurant created from now
+-- on lands on the legacy path. The legacy CASE predates both flags and denies
+-- them through its ELSE FALSE. Without the branch under test, the column gate
+-- in 20260806110000 hides pay and contact data from that owner.
+--
+-- The five role strings below are the legacy equivalents of the five builtin
+-- roles that 20260806100000 seeds, and they match view:employees exactly.
+-- view:costs stays denied on both paths: no code reads it yet.
+-- ============================================================================
+INSERT INTO auth.users (id, email)
+VALUES ('5a000000-0000-0000-0000-000000000202', 'task5-legacy-owner-flags@example.com')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.user_restaurants (user_id, restaurant_id, role, role_id)
+VALUES ('5a000000-0000-0000-0000-000000000202', '5a000000-0000-0000-0000-000000000099', 'owner', NULL)
+ON CONFLICT (user_id, restaurant_id) DO UPDATE SET role = 'owner', role_id = NULL;
+
+SELECT set_config('request.jwt.claims', '{"sub":"5a000000-0000-0000-0000-000000000202","role":"authenticated"}', true);
+
+SELECT is(
+  public.user_has_capability('5a000000-0000-0000-0000-000000000099'::uuid, 'view:pay_rates'),
+  TRUE,
+  'role_id IS NULL: legacy owner holds view:pay_rates'
+);
+
+SELECT is(
+  public.user_has_capability('5a000000-0000-0000-0000-000000000099'::uuid, 'view:employee_pii'),
+  TRUE,
+  'role_id IS NULL: legacy owner holds view:employee_pii'
+);
+
+SELECT is(
+  public.user_has_capability('5a000000-0000-0000-0000-000000000099'::uuid, 'view:costs'),
+  FALSE,
+  'role_id IS NULL: legacy owner denied view:costs (no code reads it yet)'
+);
+
+-- The legacy chef holds view:employees on neither path, so it holds neither
+-- flag. Same membership row as section 2.
+SELECT set_config('request.jwt.claims', '{"sub":"5a000000-0000-0000-0000-000000000201","role":"authenticated"}', true);
+
+SELECT is(
+  public.user_has_capability('5a000000-0000-0000-0000-000000000099'::uuid, 'view:pay_rates'),
+  FALSE,
+  'role_id IS NULL: legacy chef denied view:pay_rates'
+);
+
+SELECT is(
+  public.user_has_capability('5a000000-0000-0000-0000-000000000099'::uuid, 'view:employee_pii'),
+  FALSE,
+  'role_id IS NULL: legacy chef denied view:employee_pii'
 );
 
 -- ============================================================================

--- a/tests/e2e/broadcast-open-shifts.spec.ts
+++ b/tests/e2e/broadcast-open-shifts.spec.ts
@@ -39,7 +39,7 @@ test.describe('Broadcast Open Shifts', () => {
           compensation_type: 'hourly',
           hourly_rate: 1500,
         })
-        .select()
+        .select('id, name')
         .single();
       if (empError) throw new Error(`employees insert failed: ${empError.message}`);
 

--- a/tests/e2e/employee-schedule-retraction.spec.ts
+++ b/tests/e2e/employee-schedule-retraction.spec.ts
@@ -32,7 +32,7 @@ async function seedSelfAsEmployeeWithShift(page: Page, restaurantId: string): Pr
         compensation_type: 'hourly',
         hourly_rate: 1500,
       })
-      .select()
+      .select('id, name')
       .single();
     if (empError) throw new Error(`employees insert failed: ${empError.message}`);
 

--- a/tests/e2e/impact-aware-deletion.spec.ts
+++ b/tests/e2e/impact-aware-deletion.spec.ts
@@ -61,7 +61,7 @@ test.describe('Impact-Aware Deletion', () => {
           compensation_type: 'hourly',
           hourly_rate: 1500,
         })
-        .select()
+        .select('id, name')
         .single();
       if (empError) throw new Error(`employees insert failed: ${empError.message}`);
 

--- a/tests/e2e/open-shift-claim-approval.spec.ts
+++ b/tests/e2e/open-shift-claim-approval.spec.ts
@@ -97,7 +97,7 @@ async function seedPendingClaim(page: Page, slug: string, employeeName: string):
           compensation_type: 'hourly',
           hourly_rate: 1500,
         })
-        .select()
+        .select('id, name')
         .single();
       if (empError) throw new Error(`employees insert failed: ${empError.message}`);
 

--- a/tests/e2e/open-shift-claiming.spec.ts
+++ b/tests/e2e/open-shift-claiming.spec.ts
@@ -422,7 +422,7 @@ test.describe('Open Shift Claiming', () => {
       const { data: other, error: otherErr } = await supabase.from('employees').insert({
         restaurant_id: restId, name: 'Other Server', position: 'Server',
         status: 'active', is_active: true, compensation_type: 'hourly', hourly_rate: 1500,
-      }).select().single();
+      }).select('id, name').single();
       if (otherErr) throw new Error(`other employee insert failed: ${otherErr.message}`);
 
       // Anchor to explicit UTC so the seed is independent of the CI runner's tz

--- a/tests/e2e/schedule-publish-week-range.spec.ts
+++ b/tests/e2e/schedule-publish-week-range.spec.ts
@@ -38,7 +38,7 @@ test.describe('Schedule publish week range', () => {
           compensation_type: 'hourly',
           hourly_rate: 1500,
         })
-        .select()
+        .select('id, name')
         .single();
       if (empError) throw new Error(`employees insert failed: ${empError.message}`);
 

--- a/tests/e2e/sensitive-data-flags.spec.ts
+++ b/tests/e2e/sensitive-data-flags.spec.ts
@@ -14,13 +14,19 @@ test('a role without view:pay_rates receives no rate from PostgREST', async ({ p
   // 1. Sign the member up first, purely to mint a real auth.users row — the
   //    membership row's user_id is a foreign key, so it cannot be faked.
   await page.goto('/auth');
+  // Clear any stale session left by another test before signing up — a
+  // leftover session here would sign the member in as the wrong user.
+  await page.evaluate(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
   await exposeSupabaseHelpers(page);
   await page.getByRole('tab', { name: /sign up/i }).click();
   await page.getByLabel(/email/i).first().fill(member.email);
   await page.getByLabel(/full name/i).fill(member.fullName);
   await page.getByLabel(/password/i).first().fill(member.password);
   await page.getByRole('button', { name: /sign up|create account/i }).click();
-  await page.waitForURL('/', { timeout: 15000 });
+  await page.waitForURL('/', { timeout: 10000 });
 
   const memberUserId = await page.evaluate(async () => {
     // `any`: test-only global attached by exposeSupabaseHelpers, no typed surface.
@@ -42,7 +48,7 @@ test('a role without view:pay_rates receives no rate from PostgREST', async ({ p
   //    view:pay_rates, no view:employee_pii role_flags row at all), the
   //    member's membership on that role, and one employee row with a real
   //    rate and a real email — proof of what a leak would look like.
-  const roleName = `Scheduler ${Date.now()}`;
+  const roleName = `Scheduler ${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   await page.evaluate(
     async ({ memberUserId, roleName }) => {
       // `any`: both are test-only globals attached by exposeSupabaseHelpers, no typed surface.
@@ -94,7 +100,7 @@ test('a role without view:pay_rates receives no rate from PostgREST', async ({ p
   await page.getByLabel(/email/i).first().fill(member.email);
   await page.getByLabel(/password/i).first().fill(member.password);
   await page.getByRole('button', { name: /^sign in$/i }).click();
-  await page.waitForURL((url) => !url.pathname.startsWith('/auth'), { timeout: 15000 });
+  await page.waitForURL((url) => !url.pathname.startsWith('/auth'), { timeout: 10000 });
 
   // Some other query on the page (the caller's own self-scope employee
   // lookup) also hits employees_secure, via `.single()`, and 406s here

--- a/tests/e2e/sensitive-data-flags.spec.ts
+++ b/tests/e2e/sensitive-data-flags.spec.ts
@@ -1,18 +1,12 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 import { generateTestUser, signUpAndCreateRestaurant, exposeSupabaseHelpers } from '../helpers/e2e-supabase';
 
-// A role without view:pay_rates opens the roster and sees no pay.
-//
-// The gate is in Postgres, so the check that matters is the response body, not
-// the rendered text. A client-only gate would still ship the rate over the
-// wire, and this role is collaborator-flavored — an external person who can
-// call PostgREST with their own token.
-test('a role without view:pay_rates receives no rate from PostgREST', async ({ page }) => {
-  const member = generateTestUser('no-pay-member');
-  const owner = generateTestUser('no-pay-owner');
+type TestUser = ReturnType<typeof generateTestUser>;
 
-  // 1. Sign the member up first, purely to mint a real auth.users row — the
-  //    membership row's user_id is a foreign key, so it cannot be faked.
+// Sign the member up first, purely to mint a real auth.users row — the
+// membership row's user_id is a foreign key, so it cannot be faked. Return
+// the new user id and sign back out, so the caller can seed as the owner.
+async function signUpMemberReturnId(page: Page, member: TestUser): Promise<string> {
   await page.goto('/auth');
   // Clear any stale session left by another test before signing up — a
   // leftover session here would sign the member in as the wrong user.
@@ -33,12 +27,37 @@ test('a role without view:pay_rates receives no rate from PostgREST', async ({ p
     const user = await (window as any).__getAuthUser();
     return user?.id as string;
   });
-  expect(memberUserId).toBeTruthy();
 
   await page.evaluate(async () => {
     // `any`: test-only global attached by exposeSupabaseHelpers, no typed surface.
     await (window as any).__supabase.auth.signOut();
   });
+
+  return memberUserId;
+}
+
+// Sign in with a real credentialed session, not the owner's.
+async function signIn(page: Page, user: TestUser): Promise<void> {
+  await page.goto('/auth');
+  await page.getByLabel(/email/i).first().fill(user.email);
+  await page.getByLabel(/password/i).first().fill(user.password);
+  await page.getByRole('button', { name: /^sign in$/i }).click();
+  await page.waitForURL((url) => !url.pathname.startsWith('/auth'), { timeout: 10000 });
+}
+
+// A role without view:pay_rates opens the roster and sees no pay.
+//
+// The gate is in Postgres, so the check that matters is the response body, not
+// the rendered text. A client-only gate would still ship the rate over the
+// wire, and this role is collaborator-flavored — an external person who can
+// call PostgREST with their own token.
+test('a role without view:pay_rates receives no rate from PostgREST', async ({ page }) => {
+  const member = generateTestUser('no-pay-member');
+  const owner = generateTestUser('no-pay-owner');
+
+  // 1. Mint the member's auth.users row, then sign back out.
+  const memberUserId = await signUpMemberReturnId(page, member);
+  expect(memberUserId).toBeTruthy();
 
   // 2. Owner signs up and creates the restaurant.
   await signUpAndCreateRestaurant(page, owner);
@@ -96,11 +115,7 @@ test('a role without view:pay_rates receives no rate from PostgREST', async ({ p
   });
 
   // 4. Sign in as the member — a real credentialed session, not the owner's.
-  await page.goto('/auth');
-  await page.getByLabel(/email/i).first().fill(member.email);
-  await page.getByLabel(/password/i).first().fill(member.password);
-  await page.getByRole('button', { name: /^sign in$/i }).click();
-  await page.waitForURL((url) => !url.pathname.startsWith('/auth'), { timeout: 10000 });
+  await signIn(page, member);
 
   // Some other query on the page (the caller's own self-scope employee
   // lookup) also hits employees_secure, via `.single()`, and 406s here
@@ -132,4 +147,182 @@ test('a role without view:pay_rates receives no rate from PostgREST', async ({ p
     expect(row.hourly_rate).toBeNull();
     expect(row.email).toBeNull();
   }
+});
+
+// A staff member sees their OWN pay and PII, but every coworker stays masked.
+//
+// The masked view carries a self-row exception: `e.user_id = auth.uid()`
+// unmasks a member's own row, even without view:pay_rates. This proves a
+// staff user reads their own rate on /employee/pay, and that the exception
+// does not leak a coworker's rate or a row linked to nobody.
+test('a staff member sees own pay and PII, coworkers stay masked', async ({ page }) => {
+  const member = generateTestUser('self-pay-member');
+  const owner = generateTestUser('self-pay-owner');
+
+  // 1. Mint the member's auth.users row, then sign back out.
+  const memberUserId = await signUpMemberReturnId(page, member);
+  expect(memberUserId).toBeTruthy();
+
+  // 2. Owner signs up and creates the restaurant.
+  await signUpAndCreateRestaurant(page, owner);
+  await exposeSupabaseHelpers(page);
+
+  // 3. Owner seeds: a plain staff membership (no view:pay_rates, no
+  //    view:employee_pii), the member's OWN employee row linked by user_id,
+  //    and a coworker row linked to nobody.
+  await page.evaluate(
+    async ({ memberUserId }) => {
+      // `any`: both are test-only globals attached by exposeSupabaseHelpers, no typed surface.
+      const supabase = (window as any).__supabase;
+      const restaurantId = await (window as any).__getRestaurantId();
+
+      const { error: memberError } = await supabase.from('user_restaurants').insert({
+        user_id: memberUserId,
+        restaurant_id: restaurantId,
+        role: 'staff',
+      });
+      if (memberError) throw new Error(`membership insert failed: ${memberError.message}`);
+
+      // The member's own row — the self-row exception must unmask it.
+      const { error: selfError } = await supabase.from('employees').insert({
+        restaurant_id: restaurantId,
+        user_id: memberUserId,
+        name: 'Self Carrier',
+        email: 'self-carrier@example.com',
+        position: 'Server',
+        status: 'active',
+        is_active: true,
+        compensation_type: 'hourly',
+        hourly_rate: 2500,
+      });
+      if (selfError) throw new Error(`self employee insert failed: ${selfError.message}`);
+
+      // A coworker row, linked to nobody — must stay masked for the member.
+      const { error: coworkerError } = await supabase.from('employees').insert({
+        restaurant_id: restaurantId,
+        name: 'Coworker Carrier',
+        email: 'coworker-carrier@example.com',
+        position: 'Cook',
+        status: 'active',
+        is_active: true,
+        compensation_type: 'hourly',
+        hourly_rate: 1800,
+      });
+      if (coworkerError) throw new Error(`coworker employee insert failed: ${coworkerError.message}`);
+    },
+    { memberUserId }
+  );
+
+  await page.evaluate(async () => {
+    // `any`: test-only global attached by exposeSupabaseHelpers, no typed surface.
+    await (window as any).__supabase.auth.signOut();
+  });
+
+  // 4. Sign in as the member.
+  await signIn(page, member);
+
+  // 5. /employee/pay shows the member's own rate — a real number, not $0.00/hr.
+  //    The rate renders twice (the header subtitle and the wages breakdown),
+  //    so match the first node — the assertion is presence, not count.
+  await page.goto('/employee/pay');
+  await expect(page.getByText(/\$25\.00\/hr/).first()).toBeVisible({ timeout: 10000 });
+  await expect(page.getByText(/\$0\.00\/hr/)).toHaveCount(0);
+
+  // 6. employees_secure returns the member's own row unmasked and every other
+  //    row masked. The self-row exception must not leak a coworker's data.
+  await exposeSupabaseHelpers(page);
+  const rows = await page.evaluate(async () => {
+    // `any`: test-only global attached by exposeSupabaseHelpers, no typed surface.
+    const supabase = (window as any).__supabase;
+    const restaurantId = await (window as any).__getRestaurantId();
+    const { data, error } = await supabase
+      .from('employees_secure')
+      .select('user_id, hourly_rate, email')
+      .eq('restaurant_id', restaurantId);
+    if (error) throw new Error(error.message);
+    return data as Array<{ user_id: string | null; hourly_rate: number | null; email: string | null }>;
+  });
+
+  const ownRows = rows.filter((row) => row.user_id === memberUserId);
+  const otherRows = rows.filter((row) => row.user_id !== memberUserId);
+
+  // The member's own row is unmasked.
+  expect(ownRows).toHaveLength(1);
+  expect(ownRows[0].hourly_rate).toBe(2500);
+  expect(ownRows[0].email).toBe('self-carrier@example.com');
+
+  // Every other row stays masked — the coworker linked to nobody included.
+  expect(otherRows.length).toBeGreaterThan(0);
+  for (const row of otherRows) {
+    expect(row.hourly_rate).toBeNull();
+    expect(row.email).toBeNull();
+  }
+});
+
+// A role without view:pay_rates reads the dashboard labor cost as "Unavailable".
+//
+// A masked rate arrives as null, and a null rate would compute as a $0 labor
+// cost — a wrong number that understates labor and inflates margin. The
+// dashboard must mark the Labor and Net Profit cells "Unavailable" instead.
+// The `chef` legacy role reaches the dashboard (view:dashboard) but holds no
+// view:pay_rates, so employees_secure masks every rate for it.
+test('a role without view:pay_rates sees dashboard labor cost as Unavailable', async ({ page }) => {
+  const member = generateTestUser('no-pay-chef');
+  const owner = generateTestUser('dash-owner');
+
+  // 1. Mint the member's auth.users row, then sign back out.
+  const memberUserId = await signUpMemberReturnId(page, member);
+  expect(memberUserId).toBeTruthy();
+
+  // 2. Owner signs up and creates the restaurant.
+  await signUpAndCreateRestaurant(page, owner);
+  await exposeSupabaseHelpers(page);
+
+  // 3. Owner seeds: a chef membership (reaches the dashboard, no view:pay_rates)
+  //    and one active hourly employee with a real rate. The chef reads null
+  //    for that rate, which would compute as a $0 labor cost without the fix.
+  await page.evaluate(
+    async ({ memberUserId }) => {
+      // `any`: both are test-only globals attached by exposeSupabaseHelpers, no typed surface.
+      const supabase = (window as any).__supabase;
+      const restaurantId = await (window as any).__getRestaurantId();
+
+      const { error: memberError } = await supabase.from('user_restaurants').insert({
+        user_id: memberUserId,
+        restaurant_id: restaurantId,
+        role: 'chef',
+      });
+      if (memberError) throw new Error(`membership insert failed: ${memberError.message}`);
+
+      const { error: employeeError } = await supabase.from('employees').insert({
+        restaurant_id: restaurantId,
+        name: 'Rate Carrier',
+        position: 'Cook',
+        status: 'active',
+        is_active: true,
+        compensation_type: 'hourly',
+        hourly_rate: 1800,
+        hire_date: '2020-01-01',
+      });
+      if (employeeError) throw new Error(`employee insert failed: ${employeeError.message}`);
+    },
+    { memberUserId }
+  );
+
+  await page.evaluate(async () => {
+    // `any`: test-only global attached by exposeSupabaseHelpers, no typed surface.
+    await (window as any).__supabase.auth.signOut();
+  });
+
+  // 4. Sign in as the member and open the dashboard.
+  await signIn(page, member);
+  await page.goto('/');
+  // The heading renders twice (the page section and the table card), so match
+  // the first node — the assertion is presence, not count.
+  await expect(page.getByRole('heading', { name: /monthly performance/i }).first()).toBeVisible({ timeout: 15000 });
+
+  // The Labor and Net Profit cells for a month with a masked rate read
+  // "Unavailable", never a $0 labor cost.
+  await expect(page.getByText('Pay rates hidden').first()).toBeVisible({ timeout: 10000 });
+  await expect(page.getByText('Labor cost hidden').first()).toBeVisible();
 });

--- a/tests/e2e/sensitive-data-flags.spec.ts
+++ b/tests/e2e/sensitive-data-flags.spec.ts
@@ -1,0 +1,115 @@
+import { expect, test } from '@playwright/test';
+import { generateTestUser, signUpAndCreateRestaurant, exposeSupabaseHelpers } from '../helpers/e2e-supabase';
+
+// A role without view:pay_rates opens the roster and sees no pay.
+//
+// The gate is in Postgres, so the check that matters is the response body, not
+// the rendered text. A client-only gate would still ship the rate over the
+// wire, and this role is collaborator-flavored — an external person who can
+// call PostgREST with their own token.
+test('a role without view:pay_rates receives no rate from PostgREST', async ({ page }) => {
+  const member = generateTestUser('no-pay-member');
+  const owner = generateTestUser('no-pay-owner');
+
+  // 1. Sign the member up first, purely to mint a real auth.users row — the
+  //    membership row's user_id is a foreign key, so it cannot be faked.
+  await page.goto('/auth');
+  await exposeSupabaseHelpers(page);
+  await page.getByRole('tab', { name: /sign up/i }).click();
+  await page.getByLabel(/email/i).first().fill(member.email);
+  await page.getByLabel(/full name/i).fill(member.fullName);
+  await page.getByLabel(/password/i).first().fill(member.password);
+  await page.getByRole('button', { name: /sign up|create account/i }).click();
+  await page.waitForURL('/', { timeout: 15000 });
+
+  const memberUserId = await page.evaluate(async () => {
+    // `any`: test-only global attached by exposeSupabaseHelpers, no typed surface.
+    const user = await (window as any).__getAuthUser();
+    return user?.id as string;
+  });
+  expect(memberUserId).toBeTruthy();
+
+  await page.evaluate(async () => {
+    // `any`: test-only global attached by exposeSupabaseHelpers, no typed surface.
+    await (window as any).__supabase.auth.signOut();
+  });
+
+  // 2. Owner signs up and creates the restaurant.
+  await signUpAndCreateRestaurant(page, owner);
+  await exposeSupabaseHelpers(page);
+
+  // 3. Owner seeds: a custom role holding only the scheduling area (no
+  //    view:pay_rates, no view:employee_pii role_flags row at all), the
+  //    member's membership on that role, and one employee row with a real
+  //    rate and a real email — proof of what a leak would look like.
+  const roleName = `Scheduler ${Date.now()}`;
+  await page.evaluate(
+    async ({ memberUserId, roleName }) => {
+      // `any`: both are test-only globals attached by exposeSupabaseHelpers, no typed surface.
+      const supabase = (window as any).__supabase;
+      const restaurantId = await (window as any).__getRestaurantId();
+
+      const { data: role, error: roleError } = await supabase
+        .from('roles')
+        .insert({ restaurant_id: restaurantId, name: roleName, flavor: 'collaborator', builtin: false })
+        .select('id')
+        .single();
+      if (roleError) throw new Error(`role insert failed: ${roleError.message}`);
+
+      const { error: areaError } = await supabase
+        .from('role_areas')
+        .insert({ role_id: role.id, area_key: 'scheduling', level: 'view' });
+      if (areaError) throw new Error(`area insert failed: ${areaError.message}`);
+
+      const { error: memberError } = await supabase.from('user_restaurants').insert({
+        user_id: memberUserId,
+        restaurant_id: restaurantId,
+        role: 'collaborator_custom',
+        role_id: role.id,
+      });
+      if (memberError) throw new Error(`membership insert failed: ${memberError.message}`);
+
+      const { error: employeeError } = await supabase.from('employees').insert({
+        restaurant_id: restaurantId,
+        name: 'Rate Carrier',
+        email: 'rate-carrier@example.com',
+        position: 'Cook',
+        status: 'active',
+        is_active: true,
+        compensation_type: 'hourly',
+        hourly_rate: 1800,
+      });
+      if (employeeError) throw new Error(`employee insert failed: ${employeeError.message}`);
+    },
+    { memberUserId, roleName }
+  );
+
+  await page.evaluate(async () => {
+    // `any`: test-only global attached by exposeSupabaseHelpers, no typed surface.
+    await (window as any).__supabase.auth.signOut();
+  });
+
+  // 4. Sign in as the member — a real credentialed session, not the owner's.
+  await page.goto('/auth');
+  await page.getByLabel(/email/i).first().fill(member.email);
+  await page.getByLabel(/password/i).first().fill(member.password);
+  await page.getByRole('button', { name: /^sign in$/i }).click();
+  await page.waitForURL((url) => !url.pathname.startsWith('/auth'), { timeout: 15000 });
+
+  const bodies: unknown[] = [];
+  page.on('response', async (response) => {
+    if (response.url().includes('/rest/v1/employees_secure')) {
+      bodies.push(await response.json().catch(() => null));
+    }
+  });
+
+  await page.goto('/scheduling');
+  await expect(page.getByRole('heading', { name: /schedule/i })).toBeVisible({ timeout: 10000 });
+
+  const rows = bodies.flat().filter(Boolean) as Array<Record<string, unknown>>;
+  expect(rows.length).toBeGreaterThan(0);
+  for (const row of rows) {
+    expect(row.hourly_rate).toBeNull();
+    expect(row.email).toBeNull();
+  }
+});

--- a/tests/e2e/sensitive-data-flags.spec.ts
+++ b/tests/e2e/sensitive-data-flags.spec.ts
@@ -96,15 +96,29 @@ test('a role without view:pay_rates receives no rate from PostgREST', async ({ p
   await page.getByRole('button', { name: /^sign in$/i }).click();
   await page.waitForURL((url) => !url.pathname.startsWith('/auth'), { timeout: 15000 });
 
+  // Some other query on the page (the caller's own self-scope employee
+  // lookup) also hits employees_secure, via `.single()`, and 406s here
+  // because this member has no linked employee record. That is a
+  // different request from the roster fetch this test cares about, so
+  // only keep responses whose body is a row array — the roster shape.
   const bodies: unknown[] = [];
   page.on('response', async (response) => {
     if (response.url().includes('/rest/v1/employees_secure')) {
-      bodies.push(await response.json().catch(() => null));
+      const json = await response.json().catch(() => null);
+      if (Array.isArray(json)) bodies.push(json);
     }
   });
 
+  // Wait for the roster fetch specifically — the row-array shape, not the
+  // caller's own `.single()` self-scope lookup on the same table.
+  const rosterResponse = page.waitForResponse(async (response) => {
+    if (!response.url().includes('/rest/v1/employees_secure')) return false;
+    const json = await response.json().catch(() => null);
+    return Array.isArray(json);
+  }, { timeout: 10000 });
   await page.goto('/scheduling');
   await expect(page.getByRole('heading', { name: /schedule/i })).toBeVisible({ timeout: 10000 });
+  await rosterResponse;
 
   const rows = bodies.flat().filter(Boolean) as Array<Record<string, unknown>>;
   expect(rows.length).toBeGreaterThan(0);

--- a/tests/e2e/shift-create-timezone.spec.ts
+++ b/tests/e2e/shift-create-timezone.spec.ts
@@ -85,7 +85,7 @@ async function createEmployee(page: Page, restaurantId: string, name: string) {
           compensation_type: 'hourly',
           hourly_rate: 1500,
         })
-        .select()
+        .select('id, name')
         .single();
       if (error) throw new Error(`employees insert failed: ${error.message}`);
       return data;

--- a/tests/e2e/shift-trade-accept.spec.ts
+++ b/tests/e2e/shift-trade-accept.spec.ts
@@ -43,7 +43,7 @@ test.describe('Shift Trade Acceptance (accept_shift_trade authz)', () => {
             restaurant_id: restId, user_id: pUserId, name: 'Pat Offerer', position: 'Server',
             status: 'active', is_active: true, compensation_type: 'hourly', hourly_rate: 1500,
           })
-          .select().single();
+          .select('id, name').single();
         if (pErr) throw new Error(`P employee insert: ${pErr.message}`);
 
         // P's future published shift.
@@ -89,7 +89,7 @@ test.describe('Shift Trade Acceptance (accept_shift_trade authz)', () => {
             restaurant_id: restId, user_id: qUserId, name: 'Quinn Acceptor', position: 'Server',
             status: 'active', is_active: true, compensation_type: 'hourly', hourly_rate: 1500,
           })
-          .select().single();
+          .select('id, name').single();
         if (qEmpErr) throw new Error(`Q employee insert: ${qEmpErr.message}`);
 
         const { error: memErr } = await supabase

--- a/tests/helpers/e2e-supabase.ts
+++ b/tests/helpers/e2e-supabase.ts
@@ -85,7 +85,7 @@ export async function exposeSupabaseHelpers(page: Page) {
           ...emp,
           restaurant_id: restaurantId,
         })))
-        .select();
+        .select('id, name');
 
       if (error) {
         throw new Error(error.message);
@@ -987,7 +987,7 @@ export async function seedTemplateWithShifts(
             hourly_rate: 1500,
           }))
         )
-        .select();
+        .select('id, name');
       if (empError) throw new Error(`employees insert failed: ${empError.message}`);
 
       const employeeIdByName = new Map<string, string>((employees ?? []).map((e: any) => [e.name, e.id]));

--- a/tests/helpers/e2e-supabase.ts
+++ b/tests/helpers/e2e-supabase.ts
@@ -98,7 +98,9 @@ export async function exposeSupabaseHelpers(page: Page) {
         throw new Error(error.message);
       }
 
-      const ids = (inserted ?? []).map((row: any) => row.id);
+      // any: PostgREST's row shape here is untyped in this helper file, same
+      // as every other row map above.
+      const ids = (inserted ?? []).map((row: any) => row.id); // eslint-disable-line @typescript-eslint/no-explicit-any
       const { data, error: readError } = await supabase
         .from('employees_secure')
         .select('*')
@@ -110,7 +112,8 @@ export async function exposeSupabaseHelpers(page: Page) {
 
       // Keep the caller's insert order. `.in()` does not promise it, and specs
       // pair the returned rows with their own seed array by index.
-      const byId = new Map((data ?? []).map((row: any) => [row.id, row]));
+      // any: same untyped row shape as the map above.
+      const byId = new Map((data ?? []).map((row: any) => [row.id, row])); // eslint-disable-line @typescript-eslint/no-explicit-any
       return ids.map((id: string) => byId.get(id));
     };
 

--- a/tests/helpers/e2e-supabase.ts
+++ b/tests/helpers/e2e-supabase.ts
@@ -104,7 +104,8 @@ export async function exposeSupabaseHelpers(page: Page) {
       const { data, error: readError } = await supabase
         .from('employees_secure')
         .select('*')
-        .in('id', ids);
+        .in('id', ids)
+        .eq('restaurant_id', restaurantId);
 
       if (readError) {
         throw new Error(readError.message);

--- a/tests/helpers/e2e-supabase.ts
+++ b/tests/helpers/e2e-supabase.ts
@@ -79,18 +79,39 @@ export async function exposeSupabaseHelpers(page: Page) {
     };
 
     (window as any).__insertEmployees = async (employees: any[], restaurantId: string) => {
-      const { data, error } = await supabase
+      // Two steps, on purpose. A bare .select() after the insert sends
+      // Prefer: return=representation, so PostgREST runs INSERT ... RETURNING *
+      // and reads the eight masked columns that `authenticated` no longer holds.
+      // Ask the insert for `id` alone, then read the full row back through
+      // `employees_secure`. The seeding user is the owner, who holds both
+      // sensitive flags, so the view returns every column unmasked. Callers
+      // read `position`, `area`, and `hourly_rate` off these rows.
+      const { data: inserted, error } = await supabase
         .from('employees')
         .insert(employees.map(emp => ({
           ...emp,
           restaurant_id: restaurantId,
         })))
-        .select('id, name');
+        .select('id');
 
       if (error) {
         throw new Error(error.message);
       }
-      return data;
+
+      const ids = (inserted ?? []).map((row: any) => row.id);
+      const { data, error: readError } = await supabase
+        .from('employees_secure')
+        .select('*')
+        .in('id', ids);
+
+      if (readError) {
+        throw new Error(readError.message);
+      }
+
+      // Keep the caller's insert order. `.in()` does not promise it, and specs
+      // pair the returned rows with their own seed array by index.
+      const byId = new Map((data ?? []).map((row: any) => [row.id, row]));
+      return ids.map((id: string) => byId.get(id));
     };
 
     (window as any).__insertTimePunches = async (punches: any[], restaurantId: string) => {

--- a/tests/unit/EmployeeDialog.maskedDob.test.tsx
+++ b/tests/unit/EmployeeDialog.maskedDob.test.tsx
@@ -91,14 +91,21 @@ const MASKED_EMPLOYEE = {
   updated_at: '2026-01-01T00:00:00Z',
 };
 
-function renderEdit() {
+// An unmasked row: the caller holds view:employee_pii, so the real date of
+// birth arrives and is visible in the box.
+const VISIBLE_DOB_EMPLOYEE = {
+  ...MASKED_EMPLOYEE,
+  date_of_birth: '2000-01-01',
+};
+
+function renderEdit(employee: typeof MASKED_EMPLOYEE = MASKED_EMPLOYEE) {
   const qc = new QueryClient({
     defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false, staleTime: Infinity } },
   });
   return render(
     <QueryClientProvider client={qc}>
       {/* cast: test fixture omits optional Employee fields */}
-      <EmployeeDialog open onOpenChange={vi.fn()} restaurantId="r1" employee={MASKED_EMPLOYEE as any} /> {/* eslint-disable-line @typescript-eslint/no-explicit-any */}
+      <EmployeeDialog open onOpenChange={vi.fn()} restaurantId="r1" employee={employee as any} /> {/* eslint-disable-line @typescript-eslint/no-explicit-any */}
     </QueryClientProvider>,
   );
 }
@@ -122,5 +129,26 @@ describe('EmployeeDialog — masked date of birth is not erased', () => {
 
     await waitFor(() => expect(updateMock).toHaveBeenCalled());
     expect(updateMock.mock.calls[0][0].date_of_birth).not.toBe(null);
+  });
+
+  // Regression test for the companion bug Codex found in the fix above: a
+  // caller who CAN see the date of birth clears it on purpose. The box did
+  // not start empty this time, so the clear must send an explicit null, not
+  // silently keep the old value.
+  it('sends date_of_birth: null when a caller who can see the date clears it', async () => {
+    renderEdit(VISIBLE_DOB_EMPLOYEE);
+
+    const dobInput = screen.getByLabelText(/date of birth/i) as HTMLInputElement;
+    expect(dobInput.value).toBe('2000-01-01');
+
+    fireEvent.change(dobInput, { target: { value: '' } });
+    expect(dobInput.value).toBe('');
+
+    const form = document.body.querySelector('form');
+    expect(form).not.toBeNull();
+    fireEvent.submit(form as HTMLFormElement);
+
+    await waitFor(() => expect(updateMock).toHaveBeenCalled());
+    expect(updateMock.mock.calls[0][0].date_of_birth).toBe(null);
   });
 });

--- a/tests/unit/EmployeeDialog.maskedDob.test.tsx
+++ b/tests/unit/EmployeeDialog.maskedDob.test.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { EmployeeDialog } from '@/components/EmployeeDialog';
+
+// Regression test for the "erased date of birth" bug: a manager without
+// view:employee_pii reads a masked employee row (date_of_birth: null). The
+// dialog prefills the date box as an empty string. On save, the box must NOT
+// be read as an explicit null — that would erase the stored date of birth.
+
+const updateMock = vi.fn().mockResolvedValue({ id: 'emp-1' });
+const createMock = vi.fn().mockResolvedValue({ id: 'emp-1' });
+
+vi.mock('@/hooks/useEmployees', () => ({
+  useCreateEmployee: () => ({ mutateAsync: createMock, isPending: false }),
+  useUpdateEmployee: () => ({ mutateAsync: updateMock, isPending: false }),
+}));
+
+vi.mock('@/hooks/useBulkSetAvailability', () => ({
+  useBulkSetAvailability: () => ({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false }),
+}));
+
+vi.mock('@/hooks/useShiftTemplates', () => {
+  const STABLE_TEMPLATES: never[] = [];
+  return {
+    useShiftTemplates: () => ({
+      templates: STABLE_TEMPLATES,
+      loading: false,
+      error: null,
+      createTemplate: () => Promise.resolve(),
+      updateTemplate: () => Promise.resolve(),
+      deleteTemplate: () => Promise.resolve(),
+    }),
+  };
+});
+
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => ({ selectedRestaurant: { restaurant: { id: 'r1', timezone: 'UTC' } } }),
+}));
+
+// EmployeeAppAccessRow (mounted by every EmployeeDialog render) calls useAuth,
+// which throws without an AuthProvider by design. Nothing here asserts on app
+// access — this just keeps the dialog mountable.
+vi.mock('@/hooks/useAuth', () => ({ useAuth: () => ({ user: { id: 'caller-1' } }) }));
+
+vi.mock('@/integrations/supabase/client', () => {
+  // Recursive fluent-builder mock — must be `any` because the chain can call
+  // any subset of methods in any order; a typed interface would require an
+  // exhaustive intersection of all Supabase builder return types.
+  function makeChain(): any { // eslint-disable-line @typescript-eslint/no-explicit-any
+    const chain: any = {}; // eslint-disable-line @typescript-eslint/no-explicit-any
+    chain.select = () => makeChain();
+    chain.eq = () => makeChain();
+    chain.not = () => makeChain();
+    chain.order = () => Promise.resolve({ data: [], error: null });
+    chain.is = () => makeChain();
+    chain.single = () => Promise.resolve({ data: null, error: null });
+    chain.upsert = () => Promise.resolve({ data: null, error: null });
+    chain.insert = () => makeChain();
+    chain.update = () => makeChain();
+    chain.then = (resolve: (v: { data: any[]; error: null }) => any) => // eslint-disable-line @typescript-eslint/no-explicit-any
+      Promise.resolve({ data: [], error: null }).then(resolve);
+    chain.catch = () => Promise.resolve({ data: [], error: null });
+    return chain;
+  }
+  return {
+    supabase: {
+      functions: { invoke: () => Promise.resolve({ data: null, error: null }) },
+      from: () => makeChain(),
+    },
+  };
+});
+
+// A masked row: the caller lacks view:employee_pii, so employees_secure
+// returns date_of_birth: null even though a date of birth is on file.
+const MASKED_EMPLOYEE = {
+  id: 'emp-1',
+  restaurant_id: 'r1',
+  name: 'Alex Valdez',
+  position: 'Server',
+  status: 'active' as const,
+  is_active: true,
+  compensation_type: 'hourly' as const,
+  hourly_rate: 2000,
+  date_of_birth: null,
+  employment_type: 'full_time' as const,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+function renderEdit() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false, staleTime: Infinity } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      {/* cast: test fixture omits optional Employee fields */}
+      <EmployeeDialog open onOpenChange={vi.fn()} restaurantId="r1" employee={MASKED_EMPLOYEE as any} /> {/* eslint-disable-line @typescript-eslint/no-explicit-any */}
+    </QueryClientProvider>,
+  );
+}
+
+describe('EmployeeDialog — masked date of birth is not erased', () => {
+  beforeEach(() => {
+    updateMock.mockClear();
+    createMock.mockClear();
+  });
+
+  it('never sends date_of_birth: null for a masked (blank) date box on save', async () => {
+    renderEdit();
+
+    // Confirm the fixture actually masks the date box, as the bug requires.
+    const dobInput = screen.getByLabelText(/date of birth/i) as HTMLInputElement;
+    expect(dobInput.value).toBe('');
+
+    const form = document.body.querySelector('form');
+    expect(form).not.toBeNull();
+    fireEvent.submit(form as HTMLFormElement);
+
+    await waitFor(() => expect(updateMock).toHaveBeenCalled());
+    expect(updateMock.mock.calls[0][0].date_of_birth).not.toBe(null);
+  });
+});

--- a/tests/unit/EmployeeDialog.maskedRate.test.tsx
+++ b/tests/unit/EmployeeDialog.maskedRate.test.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { EmployeeDialog } from '@/components/EmployeeDialog';
 
@@ -111,7 +110,6 @@ describe('EmployeeDialog — masked hourly rate is not fabricated as zero', () =
   });
 
   it('never sends hourly_rate: 0 for a masked (blank) rate box on save', async () => {
-    const user = userEvent.setup();
     renderEdit();
 
     // Confirm the fixture actually masks the rate box, as the bug requires.
@@ -127,14 +125,12 @@ describe('EmployeeDialog — masked hourly rate is not fabricated as zero', () =
     expect(form).not.toBeNull();
     fireEvent.submit(form as HTMLFormElement);
 
-    // A changed hourly rate opens the effective-date confirmation modal
-    // before the update is sent.
-    await waitFor(() =>
-      expect(screen.getByRole('heading', { name: /apply new compensation rate/i })).toBeInTheDocument(),
-    );
-    await user.click(screen.getByRole('button', { name: /save new rate/i }));
-
+    // An unknown (masked) rate is not a compensation change, so the dialog
+    // saves the row directly and never opens the effective-date modal.
     await waitFor(() => expect(updateMock).toHaveBeenCalled());
     expect(updateMock.mock.calls[0][0].hourly_rate).not.toBe(0);
+    expect(
+      screen.queryByRole('heading', { name: /apply new compensation rate/i }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/EmployeeDialog.maskedRate.test.tsx
+++ b/tests/unit/EmployeeDialog.maskedRate.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { EmployeeDialog } from '@/components/EmployeeDialog';
 
@@ -36,7 +37,8 @@ vi.mock('@/hooks/useShiftTemplates', () => {
   };
 });
 
-vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+const toastMock = vi.fn();
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: toastMock }) }));
 
 vi.mock('@/contexts/RestaurantContext', () => ({
   useRestaurantContext: () => ({ selectedRestaurant: { restaurant: { id: 'r1', timezone: 'UTC' } } }),
@@ -46,6 +48,12 @@ vi.mock('@/contexts/RestaurantContext', () => ({
 // which throws without an AuthProvider by design. Nothing here asserts on app
 // access — this just keeps the dialog mountable.
 vi.mock('@/hooks/useAuth', () => ({ useAuth: () => ({ user: { id: 'caller-1' } }) }));
+
+// This suite tests the masked-rate save path, not the view:pay_rates gate
+// itself — grant the flag so the compensation controls stay interactive.
+vi.mock('@/hooks/usePermissions', () => ({
+  usePermissions: () => ({ hasCapability: () => true, isResolved: true }),
+}));
 
 vi.mock('@/integrations/supabase/client', () => {
   // Recursive fluent-builder mock — must be `any` because the chain can call
@@ -107,6 +115,7 @@ describe('EmployeeDialog — masked hourly rate is not fabricated as zero', () =
   beforeEach(() => {
     updateMock.mockClear();
     createMock.mockClear();
+    toastMock.mockClear();
   });
 
   it('never sends hourly_rate: 0 for a masked (blank) rate box on save', async () => {
@@ -132,5 +141,28 @@ describe('EmployeeDialog — masked hourly rate is not fabricated as zero', () =
     expect(
       screen.queryByRole('heading', { name: /apply new compensation rate/i }),
     ).not.toBeInTheDocument();
+  });
+
+  // Regression test for a related bug: a caller switches the compensation
+  // type on a masked row (rate box blank) but never enters the new type's
+  // amount. hasCompensationChanged must not read this as "unchanged" — that
+  // would silently write the old type with no new amount and no history row.
+  it('blocks save and shows an error when a compensation-type change has no new amount', async () => {
+    renderEdit();
+
+    await userEvent.click(screen.getByRole('combobox', { name: /compensation type/i }));
+    await userEvent.click(await screen.findByRole('option', { name: /^salary$/i }));
+
+    const form = document.body.querySelector('form');
+    expect(form).not.toBeNull();
+    fireEvent.submit(form as HTMLFormElement);
+
+    await waitFor(() =>
+      expect(toastMock).toHaveBeenCalledWith(
+        expect.objectContaining({ variant: 'destructive' }),
+      ),
+    );
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(createMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/EmployeeDialog.maskedRate.test.tsx
+++ b/tests/unit/EmployeeDialog.maskedRate.test.tsx
@@ -1,0 +1,140 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { EmployeeDialog } from '@/components/EmployeeDialog';
+
+// Regression test for the "fabricated zero rate" bug: a manager without
+// view:pay_rates reads a masked employee row (hourly_rate: null). The dialog
+// prefills the rate box as an empty string. On save, the box must NOT be
+// read as a real $0.00 rate — that would overwrite the true rate on the row
+// and write a permanent $0.00 entry to the compensation history.
+
+const updateMock = vi.fn().mockResolvedValue({ id: 'emp-1' });
+const createMock = vi.fn().mockResolvedValue({ id: 'emp-1' });
+
+vi.mock('@/hooks/useEmployees', () => ({
+  useCreateEmployee: () => ({ mutateAsync: createMock, isPending: false }),
+  useUpdateEmployee: () => ({ mutateAsync: updateMock, isPending: false }),
+}));
+
+vi.mock('@/hooks/useBulkSetAvailability', () => ({
+  useBulkSetAvailability: () => ({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false }),
+}));
+
+vi.mock('@/hooks/useShiftTemplates', () => {
+  const STABLE_TEMPLATES: never[] = [];
+  return {
+    useShiftTemplates: () => ({
+      templates: STABLE_TEMPLATES,
+      loading: false,
+      error: null,
+      createTemplate: () => Promise.resolve(),
+      updateTemplate: () => Promise.resolve(),
+      deleteTemplate: () => Promise.resolve(),
+    }),
+  };
+});
+
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => ({ selectedRestaurant: { restaurant: { id: 'r1', timezone: 'UTC' } } }),
+}));
+
+// EmployeeAppAccessRow (mounted by every EmployeeDialog render) calls useAuth,
+// which throws without an AuthProvider by design. Nothing here asserts on app
+// access — this just keeps the dialog mountable.
+vi.mock('@/hooks/useAuth', () => ({ useAuth: () => ({ user: { id: 'caller-1' } }) }));
+
+vi.mock('@/integrations/supabase/client', () => {
+  // Recursive fluent-builder mock — must be `any` because the chain can call
+  // any subset of methods in any order; a typed interface would require an
+  // exhaustive intersection of all Supabase builder return types.
+  function makeChain(): any { // eslint-disable-line @typescript-eslint/no-explicit-any
+    const chain: any = {}; // eslint-disable-line @typescript-eslint/no-explicit-any
+    chain.select = () => makeChain();
+    chain.eq = () => makeChain();
+    chain.not = () => makeChain();
+    chain.order = () => Promise.resolve({ data: [], error: null });
+    chain.is = () => makeChain();
+    chain.single = () => Promise.resolve({ data: null, error: null });
+    chain.upsert = () => Promise.resolve({ data: null, error: null });
+    chain.insert = () => makeChain();
+    chain.update = () => makeChain();
+    chain.then = (resolve: (v: { data: any[]; error: null }) => any) => // eslint-disable-line @typescript-eslint/no-explicit-any
+      Promise.resolve({ data: [], error: null }).then(resolve);
+    chain.catch = () => Promise.resolve({ data: [], error: null });
+    return chain;
+  }
+  return {
+    supabase: {
+      functions: { invoke: () => Promise.resolve({ data: null, error: null }) },
+      from: () => makeChain(),
+    },
+  };
+});
+
+// A masked row: the caller lacks view:pay_rates, so employees_secure returns
+// hourly_rate: null even though the employee is paid hourly.
+const MASKED_EMPLOYEE = {
+  id: 'emp-1',
+  restaurant_id: 'r1',
+  name: 'Alex Valdez',
+  position: 'Server',
+  status: 'active' as const,
+  is_active: true,
+  compensation_type: 'hourly' as const,
+  hourly_rate: null,
+  employment_type: 'full_time' as const,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+function renderEdit() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false, staleTime: Infinity } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      {/* cast: test fixture omits optional Employee fields */}
+      <EmployeeDialog open onOpenChange={vi.fn()} restaurantId="r1" employee={MASKED_EMPLOYEE as any} /> {/* eslint-disable-line @typescript-eslint/no-explicit-any */}
+    </QueryClientProvider>,
+  );
+}
+
+describe('EmployeeDialog — masked hourly rate is not fabricated as zero', () => {
+  beforeEach(() => {
+    updateMock.mockClear();
+    createMock.mockClear();
+  });
+
+  it('never sends hourly_rate: 0 for a masked (blank) rate box on save', async () => {
+    const user = userEvent.setup();
+    renderEdit();
+
+    // Confirm the fixture actually masks the rate box, as the bug requires.
+    const rateInput = screen.getByLabelText(/hourly rate in dollars/i) as HTMLInputElement;
+    expect(rateInput.value).toBe('');
+
+    // Submit without touching the rate box. Use fireEvent.submit to bypass
+    // the input's `required` attribute — that HTML5 gate is a separate,
+    // later fix (plan Step 9) and is not what this test checks.
+    // Radix Dialog renders the form into a portal on document.body, so
+    // query from there rather than the render() container.
+    const form = document.body.querySelector('form');
+    expect(form).not.toBeNull();
+    fireEvent.submit(form as HTMLFormElement);
+
+    // A changed hourly rate opens the effective-date confirmation modal
+    // before the update is sent.
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: /apply new compensation rate/i })).toBeInTheDocument(),
+    );
+    await user.click(screen.getByRole('button', { name: /save new rate/i }));
+
+    await waitFor(() => expect(updateMock).toHaveBeenCalled());
+    expect(updateMock.mock.calls[0][0].hourly_rate).not.toBe(0);
+  });
+});

--- a/tests/unit/EmployeeDialog.maskedRequired.test.tsx
+++ b/tests/unit/EmployeeDialog.maskedRequired.test.tsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { EmployeeDialog } from '@/components/EmployeeDialog';
+
+// Regression test for the "required blocks every save" bug: a masked pay
+// field (hourly rate, salary amount, or contractor payment amount) renders
+// as an empty box. The HTML5 `required` attribute then blocks every save,
+// even one that never touches the pay box. The fix drops `required` from
+// all three pay inputs.
+
+const updateMock = vi.fn().mockResolvedValue({ id: 'emp-1' });
+const createMock = vi.fn().mockResolvedValue({ id: 'emp-1' });
+
+vi.mock('@/hooks/useEmployees', () => ({
+  useCreateEmployee: () => ({ mutateAsync: createMock, isPending: false }),
+  useUpdateEmployee: () => ({ mutateAsync: updateMock, isPending: false }),
+}));
+
+vi.mock('@/hooks/useBulkSetAvailability', () => ({
+  useBulkSetAvailability: () => ({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false }),
+}));
+
+vi.mock('@/hooks/useShiftTemplates', () => {
+  const STABLE_TEMPLATES: never[] = [];
+  return {
+    useShiftTemplates: () => ({
+      templates: STABLE_TEMPLATES,
+      loading: false,
+      error: null,
+      createTemplate: () => Promise.resolve(),
+      updateTemplate: () => Promise.resolve(),
+      deleteTemplate: () => Promise.resolve(),
+    }),
+  };
+});
+
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => ({ selectedRestaurant: { restaurant: { id: 'r1', timezone: 'UTC' } } }),
+}));
+
+// EmployeeAppAccessRow (mounted by every EmployeeDialog render) calls useAuth,
+// which throws without an AuthProvider by design. Nothing here asserts on app
+// access — this just keeps the dialog mountable.
+vi.mock('@/hooks/useAuth', () => ({ useAuth: () => ({ user: { id: 'caller-1' } }) }));
+
+vi.mock('@/integrations/supabase/client', () => {
+  // Recursive fluent-builder mock — must be `any` because the chain can call
+  // any subset of methods in any order; a typed interface would require an
+  // exhaustive intersection of all Supabase builder return types.
+  function makeChain(): any { // eslint-disable-line @typescript-eslint/no-explicit-any
+    const chain: any = {}; // eslint-disable-line @typescript-eslint/no-explicit-any
+    chain.select = () => makeChain();
+    chain.eq = () => makeChain();
+    chain.not = () => makeChain();
+    chain.order = () => Promise.resolve({ data: [], error: null });
+    chain.is = () => makeChain();
+    chain.single = () => Promise.resolve({ data: null, error: null });
+    chain.upsert = () => Promise.resolve({ data: null, error: null });
+    chain.insert = () => makeChain();
+    chain.update = () => makeChain();
+    chain.then = (resolve: (v: { data: any[]; error: null }) => any) => // eslint-disable-line @typescript-eslint/no-explicit-any
+      Promise.resolve({ data: [], error: null }).then(resolve);
+    chain.catch = () => Promise.resolve({ data: [], error: null });
+    return chain;
+  }
+  return {
+    supabase: {
+      functions: { invoke: () => Promise.resolve({ data: null, error: null }) },
+      from: () => makeChain(),
+    },
+  };
+});
+
+function renderEdit(employee: Record<string, unknown>) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false, staleTime: Infinity } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      {/* cast: test fixture omits optional Employee fields */}
+      <EmployeeDialog open onOpenChange={vi.fn()} restaurantId="r1" employee={employee as any} /> {/* eslint-disable-line @typescript-eslint/no-explicit-any */}
+    </QueryClientProvider>,
+  );
+}
+
+describe('EmployeeDialog — masked pay boxes are not required', () => {
+  it('does not mark the hourly rate box required', () => {
+    renderEdit({
+      id: 'emp-1',
+      restaurant_id: 'r1',
+      name: 'Alex Valdez',
+      position: 'Server',
+      status: 'active' as const,
+      is_active: true,
+      compensation_type: 'hourly' as const,
+      hourly_rate: null,
+      employment_type: 'full_time' as const,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    });
+
+    const rateInput = screen.getByLabelText(/hourly rate in dollars/i);
+    expect(rateInput).not.toBeRequired();
+  });
+
+  it('does not mark the salary amount box required', () => {
+    renderEdit({
+      id: 'emp-1',
+      restaurant_id: 'r1',
+      name: 'Alex Valdez',
+      position: 'Manager',
+      status: 'active' as const,
+      is_active: true,
+      compensation_type: 'salary' as const,
+      salary_amount: null,
+      employment_type: 'full_time' as const,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    });
+
+    const salaryInput = screen.getByLabelText(/salary amount in dollars/i);
+    expect(salaryInput).not.toBeRequired();
+  });
+
+  it('does not mark the contractor payment amount box required', () => {
+    renderEdit({
+      id: 'emp-1',
+      restaurant_id: 'r1',
+      name: 'Alex Valdez',
+      position: 'Consultant',
+      status: 'active' as const,
+      is_active: true,
+      compensation_type: 'contractor' as const,
+      contractor_payment_amount: null,
+      employment_type: 'full_time' as const,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+    });
+
+    const paymentInput = screen.getByLabelText(/payment amount in dollars/i);
+    expect(paymentInput).not.toBeRequired();
+  });
+});

--- a/tests/unit/EmployeeDialog.statusSync.test.tsx
+++ b/tests/unit/EmployeeDialog.statusSync.test.tsx
@@ -43,6 +43,12 @@ vi.mock('@/contexts/RestaurantContext', () => ({
 // access — this just keeps the dialog mountable.
 vi.mock('@/hooks/useAuth', () => ({ useAuth: () => ({ user: { id: 'caller-1' } }) }));
 
+// This suite tests the is_active/status sync, not the view:pay_rates gate —
+// grant the flag so the compensation controls stay interactive.
+vi.mock('@/hooks/usePermissions', () => ({
+  usePermissions: () => ({ hasCapability: () => true, isResolved: true }),
+}));
+
 vi.mock('@/integrations/supabase/client', () => {
   // Recursive fluent-builder mock — must be `any` because the chain can call
   // any subset of methods in any order; a typed interface would require an

--- a/tests/unit/EmployeeListMaskedRate.test.tsx
+++ b/tests/unit/EmployeeListMaskedRate.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { EmployeeList } from '@/components/EmployeeList';
+import type { Employee } from '@/types/scheduling';
+
+// A masked column arrives as null (the row policy strips it). The card must
+// read "Hidden", never a fabricated "$0.00/hr" or similar.
+const maskedHourlyEmployee = {
+  id: 'emp-1',
+  name: 'Ann Lee',
+  position: 'Server',
+  compensation_type: 'hourly',
+  hourly_rate: null,
+  is_active: true,
+  status: 'active',
+} as unknown as Employee;
+
+vi.mock('@/hooks/useEmployees', () => ({
+  useEmployees: (_restaurantId: string, opts: { status?: string }) => {
+    if (opts?.status === 'active') {
+      return { employees: [maskedHourlyEmployee], loading: false, error: null };
+    }
+    return { employees: [], loading: false, error: null };
+  },
+}));
+
+const renderList = () =>
+  render(
+    <MemoryRouter>
+      <EmployeeList restaurantId="rest-1" />
+    </MemoryRouter>
+  );
+
+describe('EmployeeList compensation display for a masked rate', () => {
+  it('shows "Hidden" for a null hourly_rate', () => {
+    renderList();
+    expect(screen.getByText('Hidden')).toBeInTheDocument();
+  });
+
+  it('never renders a fabricated $0.00 rate', () => {
+    renderList();
+    expect(screen.queryByText(/\$0\.00/)).toBeNull();
+  });
+});

--- a/tests/unit/LaborCostBreakdownMaskedRow.test.tsx
+++ b/tests/unit/LaborCostBreakdownMaskedRow.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { LaborCostBreakdown } from '@/components/scheduling/LaborCostBreakdown';
+import type { EmployeeLaborCost } from '@/hooks/useEmployeeLaborCosts';
+
+// A masked pay row carries cost 0 as a placeholder, not a real figure.
+// Showing "$0.00" would read as a fact. The row must show a dash and name
+// the reason for a screen reader.
+const maskedRow: EmployeeLaborCost = {
+  id: 'emp-1',
+  name: 'Ann Lee',
+  position: 'Server',
+  hours: 8,
+  rate: 0,
+  cost: 0,
+  compensationType: 'hourly',
+  isOutlier: false,
+  outlierLevel: 'none',
+  costIsHidden: true,
+};
+
+const visibleRow: EmployeeLaborCost = {
+  id: 'emp-2',
+  name: 'Bo Ray',
+  position: 'Cook',
+  hours: 8,
+  rate: 20,
+  cost: 160,
+  compensationType: 'hourly',
+  isOutlier: false,
+  outlierLevel: 'none',
+  costIsHidden: false,
+};
+
+describe('LaborCostBreakdown masked row', () => {
+  it('shows a dash instead of $0.00 for a masked-cost row', () => {
+    render(
+      <LaborCostBreakdown employeeCosts={[maskedRow]} onEditEmployee={vi.fn()} />
+    );
+    expect(screen.getByText('—')).toBeInTheDocument();
+    expect(screen.queryByText('$0.00')).not.toBeInTheDocument();
+  });
+
+  it('gives the dash an accessible name explaining why cost is hidden', () => {
+    render(
+      <LaborCostBreakdown employeeCosts={[maskedRow]} onEditEmployee={vi.fn()} />
+    );
+    expect(screen.getByLabelText('Labor cost hidden')).toBeInTheDocument();
+  });
+
+  it('still shows the real dollar figure for a visible row', () => {
+    render(
+      <LaborCostBreakdown employeeCosts={[visibleRow]} onEditEmployee={vi.fn()} />
+    );
+    expect(screen.getByText('$160.00')).toBeInTheDocument();
+  });
+});

--- a/tests/unit/LaborCostBreakdownMaskedRow.test.tsx
+++ b/tests/unit/LaborCostBreakdownMaskedRow.test.tsx
@@ -49,6 +49,14 @@ describe('LaborCostBreakdown masked row', () => {
     expect(screen.getByLabelText('Labor cost hidden')).toBeInTheDocument();
   });
 
+  it('does not show a fabricated $0.00/hr rate under a masked row', () => {
+    render(
+      <LaborCostBreakdown employeeCosts={[maskedRow]} onEditEmployee={vi.fn()} />
+    );
+    expect(screen.getByText('8.0h · rate hidden')).toBeInTheDocument();
+    expect(screen.queryByText(/\$0\.00\/hr/)).not.toBeInTheDocument();
+  });
+
   it('still shows the real dollar figure for a visible row', () => {
     render(
       <LaborCostBreakdown employeeCosts={[visibleRow]} onEditEmployee={vi.fn()} />

--- a/tests/unit/MonthlyBreakdownTable.labor.test.tsx
+++ b/tests/unit/MonthlyBreakdownTable.labor.test.tsx
@@ -15,6 +15,7 @@ const monthlyData = [{
   net_revenue: 100000, discounts: 0, refunds: 0, sales_tax: 0, tips: 0,
   other_liabilities: 0, food_cost: 25000, labor_cost: 20000,
   pending_labor_cost: 20000, actual_labor_cost: 18000, has_data: true,
+  labor_cost_hidden: false,
 }];
 
 describe('MonthlyBreakdownTable labor cell', () => {
@@ -27,5 +28,43 @@ describe('MonthlyBreakdownTable labor cell', () => {
     // basis is accrued ($20,000); the double-count would render $38,000.
     expect(screen.getByText('$20,000')).toBeInTheDocument();
     expect(screen.queryByText('$38,000')).not.toBeInTheDocument();
+  });
+});
+
+// labor_cost_hidden means the hook could not compute a real labor number for
+// this month (a masked employee row) — the table must say so, not print a
+// number that reads as real. See src/hooks/useMonthlyMetrics.tsx.
+describe('MonthlyBreakdownTable labor_cost_hidden', () => {
+  const hiddenMonthlyData = [{
+    ...monthlyData[0],
+    // These would render as real $0 costs and a real net profit if the
+    // hidden flag were ignored — the assertions below prove that never happens.
+    labor_cost: 0,
+    pending_labor_cost: 0,
+    actual_labor_cost: 0,
+    labor_cost_hidden: true,
+  }];
+
+  it('shows Unavailable for labor cost instead of a $0 figure', () => {
+    render(
+      <MemoryRouter>
+        <MonthlyBreakdownTable monthlyData={hiddenMonthlyData} />
+      </MemoryRouter>
+    );
+    expect(screen.getAllByText('Unavailable').length).toBeGreaterThan(0);
+    // The masked-out Pending/Actual sub-lines must not render at all — not
+    // even as a $0 figure that reads as a real, computed number.
+    expect(screen.queryByText(/Pending:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Actual:/)).not.toBeInTheDocument();
+  });
+
+  it('shows Unavailable for net profit too, since it depends on labor cost', () => {
+    render(
+      <MemoryRouter>
+        <MonthlyBreakdownTable monthlyData={hiddenMonthlyData} />
+      </MemoryRouter>
+    );
+    // One "Unavailable" for the Labor cell, one for the Net Profit cell.
+    expect(screen.getAllByText('Unavailable')).toHaveLength(2);
   });
 });

--- a/tests/unit/MonthlyBreakdownTable.test.tsx
+++ b/tests/unit/MonthlyBreakdownTable.test.tsx
@@ -73,6 +73,7 @@ const aprilFixture = {
   pending_labor_cost: 16528,
   actual_labor_cost: 32959,
   has_data: true,
+  labor_cost_hidden: false,
 };
 
 describe('MonthlyBreakdownTable — single source of truth', () => {

--- a/tests/unit/ReactivateEmployeeDialog.test.tsx
+++ b/tests/unit/ReactivateEmployeeDialog.test.tsx
@@ -5,11 +5,19 @@ import { ReactivateEmployeeDialog } from '@/components/ReactivateEmployeeDialog'
 import type { Employee } from '@/types/scheduling';
 
 const mockMutate = vi.fn();
+let canSeePayRates = true;
 
 vi.mock('@/hooks/useEmployees', () => ({
   useReactivateEmployee: () => ({
     mutate: mockMutate,
     isPending: false,
+  }),
+}));
+
+vi.mock('@/hooks/usePermissions', () => ({
+  usePermissions: () => ({
+    hasCapability: (cap: string) => cap === 'view:pay_rates' && canSeePayRates,
+    isResolved: true,
   }),
 }));
 
@@ -23,14 +31,15 @@ const employee = {
   deactivation_reason: 'seasonal',
 } as unknown as Employee;
 
-const renderDialog = () =>
+const renderDialog = (employeeOverride: Employee = employee) =>
   render(
-    <ReactivateEmployeeDialog open onOpenChange={() => {}} employee={employee} />
+    <ReactivateEmployeeDialog open onOpenChange={() => {}} employee={employeeOverride} />
   );
 
 describe('ReactivateEmployeeDialog', () => {
   beforeEach(() => {
     mockMutate.mockClear();
+    canSeePayRates = true;
   });
 
   it('does not render an "Enable kiosk PIN" checkbox', () => {
@@ -54,5 +63,18 @@ describe('ReactivateEmployeeDialog', () => {
   it('top info alert mentions the existing kiosk PIN', () => {
     renderDialog();
     expect(screen.getByText(/kiosk PIN/i)).toBeInTheDocument();
+  });
+
+  it('shows "Hidden" for the rate when the caller lacks view:pay_rates', () => {
+    canSeePayRates = false;
+    renderDialog();
+    expect(screen.getByText('Hidden')).toBeInTheDocument();
+  });
+
+  it('shows "Not set" (not "Hidden") for a real null rate when the caller can see pay rates', () => {
+    const noRateEmployee = { ...employee, hourly_rate: null } as unknown as Employee;
+    renderDialog(noRateEmployee);
+    expect(screen.getByText('Not set')).toBeInTheDocument();
+    expect(screen.queryByText('Hidden')).toBeNull();
   });
 });

--- a/tests/unit/ScheduleMetricsRibbon.test.tsx
+++ b/tests/unit/ScheduleMetricsRibbon.test.tsx
@@ -21,8 +21,9 @@ const summary: LaborCostSummary = {
   averageHourlyRate: 10,
   isAverageHigh: false,
   employeeCosts: [
-    { id: 'e1', name: 'Shy Harrison', position: 'Server', hours: 33, rate: 10, cost: 330, compensationType: 'hourly', isOutlier: false, outlierLevel: 'none' },
+    { id: 'e1', name: 'Shy Harrison', position: 'Server', hours: 33, rate: 10, cost: 330, compensationType: 'hourly', isOutlier: false, outlierLevel: 'none', costIsHidden: false },
   ],
+  hiddenCostCount: 0,
 };
 
 const budget: LaborBudgetData = {
@@ -60,6 +61,16 @@ describe('ScheduleMetricsRibbon', () => {
     // "labor cost" text is relied on by employee-payroll.spec.ts (PR #630) to
     // locate the labor figure on the scheduling page — keep it discoverable.
     expect(screen.getByText(/labor cost/i)).toBeInTheDocument();
+  });
+
+  it('says how many employees the average rate leaves out when some pay is masked', () => {
+    renderRibbon({ laborCostSummary: { ...summary, hiddenCostCount: 2 } });
+    expect(screen.getByText('(2 hidden)')).toBeInTheDocument();
+  });
+
+  it('does not mention hidden employees when every row is visible', () => {
+    renderRibbon();
+    expect(screen.queryByText(/hidden/)).not.toBeInTheDocument();
   });
 
   it('toggles the details panel and flips aria-expanded', () => {

--- a/tests/unit/ScheduleMetricsRibbon.test.tsx
+++ b/tests/unit/ScheduleMetricsRibbon.test.tsx
@@ -63,12 +63,12 @@ describe('ScheduleMetricsRibbon', () => {
     expect(screen.getByText(/labor cost/i)).toBeInTheDocument();
   });
 
-  it('says how many employees the average rate leaves out when some pay is masked', () => {
+  it('should show the hidden employee count when some pay is masked', () => {
     renderRibbon({ laborCostSummary: { ...summary, hiddenCostCount: 2 } });
     expect(screen.getByText('(2 hidden)')).toBeInTheDocument();
   });
 
-  it('does not mention hidden employees when every row is visible', () => {
+  it('should omit hidden employees when every row is visible', () => {
     renderRibbon();
     expect(screen.queryByText(/hidden/)).not.toBeInTheDocument();
   });

--- a/tests/unit/areas.sensitiveFlagLabels.test.ts
+++ b/tests/unit/areas.sensitiveFlagLabels.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { SENSITIVE_FLAGS } from '@/lib/permissions/areas';
+
+describe('SENSITIVE_FLAGS labels match stored columns', () => {
+  it('names the view:employee_pii flag after data the app stores', () => {
+    const flag = SENSITIVE_FLAGS.find((f) => f.flag === 'view:employee_pii');
+    expect(flag?.name).toBe('Contact details');
+    expect(flag?.hint).toBe('Email, phone, date of birth');
+  });
+});

--- a/tests/unit/areas.test.ts
+++ b/tests/unit/areas.test.ts
@@ -239,7 +239,7 @@ describe('expandAreas reconstructs each builtin from its seeded area grants', ()
       payroll: 'manage', employees: 'manage', team: 'manage', collaborators: 'manage',
       settings: 'manage', integrations: 'manage',
     };
-    const result = new Set(expandAreas(grants));
+    const result = new Set(expandAreas(grants, ['view:pay_rates', 'view:employee_pii']));
     const expected = new Set([...ROLE_CAPABILITIES.owner, 'view:assets', 'edit:assets']);
     expect(result).toEqual(expected);
   });
@@ -258,7 +258,7 @@ describe('expandAreas reconstructs each builtin from its seeded area grants', ()
       payroll: 'manage', employees: 'manage', team: 'manage', collaborators: 'manage',
       settings: 'view', integrations: 'view',
     };
-    const result = new Set(expandAreas(grants));
+    const result = new Set(expandAreas(grants, ['view:pay_rates', 'view:employee_pii']));
     const expected = new Set([...ROLE_CAPABILITIES.manager, 'view:assets', 'edit:assets']);
     expect(result).toEqual(expected);
   });
@@ -272,7 +272,7 @@ describe('expandAreas reconstructs each builtin from its seeded area grants', ()
       reviews: 'manage', payroll: 'manage', employees: 'manage',
       team: 'manage', settings: 'view',
     };
-    const result = new Set(expandAreas(grants));
+    const result = new Set(expandAreas(grants, ['view:pay_rates', 'view:employee_pii']));
     const expected = new Set(ROLE_CAPABILITIES.operations_manager);
     expect(result).toEqual(expected);
   });
@@ -310,7 +310,7 @@ describe('expandAreas reconstructs each builtin from its seeded area grants', ()
       chart_of_accounts: 'manage', payroll: 'view', employees: 'view',
       settings: 'view',
     };
-    const result = new Set(expandAreas(grants));
+    const result = new Set(expandAreas(grants, ['view:pay_rates', 'view:employee_pii']));
     // books@manage newly includes view:assets/edit:assets (defect 1, closed):
     // the legacy SQL CASE already granted both to collaborator_accountant
     // (`WHEN 'view:assets' THEN v_role IN ('owner', 'manager',
@@ -345,7 +345,7 @@ describe('expandAreas reconstructs each builtin from its seeded area grants', ()
       scheduling: 'manage', time_punches: 'manage', tips: 'manage',
       payroll: 'view', employees: 'view', settings: 'view',
     };
-    const result = new Set(expandAreas(grants));
+    const result = new Set(expandAreas(grants, ['view:pay_rates', 'view:employee_pii']));
     const expected = new Set(ROLE_CAPABILITIES.collaborator_operations_manager);
     expect(result).toEqual(expected);
   });

--- a/tests/unit/collaboratorOperationsManagerRole.test.ts
+++ b/tests/unit/collaboratorOperationsManagerRole.test.ts
@@ -54,6 +54,8 @@ const GRANTED: Capability[] = [
   'view:payroll',
   'view:employees',
   'view:settings',
+  'view:pay_rates',
+  'view:employee_pii',
 ];
 
 const DENIED: Capability[] = [

--- a/tests/unit/employeeActivation.test.ts
+++ b/tests/unit/employeeActivation.test.ts
@@ -40,6 +40,13 @@ vi.mock('@/hooks/use-toast', () => ({
   }),
 }));
 
+vi.mock('@/hooks/usePermissions', () => ({
+  usePermissions: () => ({
+    hasCapability: () => true,
+    isResolved: true,
+  }),
+}));
+
 // Test wrapper with QueryClient
 let queryClient: QueryClient;
 

--- a/tests/unit/employeeActivation.test.ts
+++ b/tests/unit/employeeActivation.test.ts
@@ -93,7 +93,7 @@ describe('Employee Activation Status', () => {
         expect(result.current.loading).toBe(false);
       });
 
-      expect(mockSupabase.from).toHaveBeenCalledWith('employees');
+      expect(mockSupabase.from).toHaveBeenCalledWith('employees_secure');
       expect(mockChain.eq).toHaveBeenCalledWith('restaurant_id', 'restaurant-123');
       expect(mockChain.eq).toHaveBeenCalledWith('is_active', true);
       expect(result.current.employees).toHaveLength(2);

--- a/tests/unit/employeeEmbedsNarrowed.test.ts
+++ b/tests/unit/employeeEmbedsNarrowed.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+// Task 4 Step 4: a PostgREST resource embed resolves against the base
+// table, not the view. `employees(*)` asks for eight revoked columns
+// and fails with `permission denied for column hourly_rate`. Each
+// embed must list only the columns its consumer reads.
+
+const readSource = (relativePath: string): string =>
+  readFileSync(resolve(__dirname, '../..', relativePath), 'utf8');
+
+const NARROW_EMBED =
+  'employee:employees(id, name, position, area, status, is_active, employment_type, user_id)';
+
+describe('employee resource embeds are narrowed to granted columns', () => {
+  it('useShifts.tsx no longer embeds employees(*)', () => {
+    const source = readSource('src/hooks/useShifts.tsx');
+    expect(source).not.toContain('employee:employees(*)');
+  });
+
+  it('useShifts.tsx embeds the explicit column list', () => {
+    const source = readSource('src/hooks/useShifts.tsx');
+    expect(source).toContain(`.select('*, ${NARROW_EMBED}')`);
+  });
+
+  it('useTimeOffRequests.tsx no longer embeds employees(*)', () => {
+    const source = readSource('src/hooks/useTimeOffRequests.tsx');
+    expect(source).not.toContain('employee:employees(*)');
+  });
+
+  it('useTimeOffRequests.tsx embeds the explicit column list', () => {
+    const source = readSource('src/hooks/useTimeOffRequests.tsx');
+    expect(source).toContain(`          ${NARROW_EMBED}`);
+  });
+
+  it('useScheduleChangeLogs.tsx no longer embeds employees(*)', () => {
+    const source = readSource('src/hooks/useScheduleChangeLogs.tsx');
+    expect(source).not.toContain('employee:employees(*)');
+  });
+
+  it('useScheduleChangeLogs.tsx embeds the explicit column list', () => {
+    const source = readSource('src/hooks/useScheduleChangeLogs.tsx');
+    expect(source).toContain(`.select('*, ${NARROW_EMBED}')`);
+  });
+});

--- a/tests/unit/employeeEmbedsNarrowed.test.ts
+++ b/tests/unit/employeeEmbedsNarrowed.test.ts
@@ -1,27 +1,34 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
+import { EMPLOYEE_EMBED_COLUMNS } from '@/lib/employeeMaskedFields';
 
 // Task 4 Step 4: a PostgREST resource embed resolves against the base
 // table, not the view. `employees(*)` asks for eight revoked columns
 // and fails with `permission denied for column hourly_rate`. Each
 // embed must list only the columns its consumer reads.
+//
+// All three sites share one column list, EMPLOYEE_EMBED_COLUMNS, so this
+// file pins that constant once and checks each site references it.
 
 const readSource = (relativePath: string): string =>
   readFileSync(resolve(__dirname, '../..', relativePath), 'utf8');
 
-const NARROW_EMBED =
-  'employee:employees(id, name, position, area, status, is_active, employment_type, user_id)';
-
 describe('employee resource embeds are narrowed to granted columns', () => {
+  it('EMPLOYEE_EMBED_COLUMNS lists only the columns these three hooks read', () => {
+    expect(EMPLOYEE_EMBED_COLUMNS).toBe(
+      'id, name, position, area, status, is_active, employment_type, user_id'
+    );
+  });
+
   it('useShifts.tsx no longer embeds employees(*)', () => {
     const source = readSource('src/hooks/useShifts.tsx');
     expect(source).not.toContain('employee:employees(*)');
   });
 
-  it('useShifts.tsx embeds the explicit column list', () => {
+  it('useShifts.tsx embeds the shared column list', () => {
     const source = readSource('src/hooks/useShifts.tsx');
-    expect(source).toContain(`.select('*, ${NARROW_EMBED}')`);
+    expect(source).toContain('employee:employees(${EMPLOYEE_EMBED_COLUMNS})');
   });
 
   it('useTimeOffRequests.tsx no longer embeds employees(*)', () => {
@@ -29,9 +36,9 @@ describe('employee resource embeds are narrowed to granted columns', () => {
     expect(source).not.toContain('employee:employees(*)');
   });
 
-  it('useTimeOffRequests.tsx embeds the explicit column list', () => {
+  it('useTimeOffRequests.tsx embeds the shared column list', () => {
     const source = readSource('src/hooks/useTimeOffRequests.tsx');
-    expect(source).toContain(`          ${NARROW_EMBED}`);
+    expect(source).toContain('employee:employees(${EMPLOYEE_EMBED_COLUMNS})');
   });
 
   it('useScheduleChangeLogs.tsx no longer embeds employees(*)', () => {
@@ -39,8 +46,8 @@ describe('employee resource embeds are narrowed to granted columns', () => {
     expect(source).not.toContain('employee:employees(*)');
   });
 
-  it('useScheduleChangeLogs.tsx embeds the explicit column list', () => {
+  it('useScheduleChangeLogs.tsx embeds the shared column list', () => {
     const source = readSource('src/hooks/useScheduleChangeLogs.tsx');
-    expect(source).toContain(`.select('*, ${NARROW_EMBED}')`);
+    expect(source).toContain('employee:employees(${EMPLOYEE_EMBED_COLUMNS})');
   });
 });

--- a/tests/unit/employeeIsMinorFromRow.test.ts
+++ b/tests/unit/employeeIsMinorFromRow.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+// Task 4 Step 5: `employees_secure` masks `date_of_birth` for a caller
+// without `view:employee_pii`. The four components below must read the
+// server-computed `is_minor` flag instead of computing it client-side
+// from a column that may not be there.
+
+const readSource = (relativePath: string): string =>
+  readFileSync(resolve(__dirname, '../..', relativePath), 'utf8');
+
+describe('components read is_minor from the row instead of computing it', () => {
+  it('EmployeeList.tsx no longer calls isMinor(employee.date_of_birth)', () => {
+    const source = readSource('src/components/EmployeeList.tsx');
+    expect(source).not.toContain('isMinor(employee.date_of_birth)');
+  });
+
+  it('EmployeeList.tsx reads employee.is_minor', () => {
+    const source = readSource('src/components/EmployeeList.tsx');
+    expect(source).toContain('{employee.is_minor && (');
+  });
+
+  it('EmployeeList.tsx no longer imports isMinor', () => {
+    const source = readSource('src/components/EmployeeList.tsx');
+    expect(source).not.toContain("import { isMinor } from '@/lib/employeeUtils';");
+  });
+
+  it('WeekScheduleMobile.tsx no longer calls isMinor(employee.date_of_birth)', () => {
+    const source = readSource('src/components/scheduling/WeekScheduleMobile.tsx');
+    expect(source).not.toContain('isMinor(employee.date_of_birth)');
+  });
+
+  it('WeekScheduleMobile.tsx reads employee.is_minor', () => {
+    const source = readSource('src/components/scheduling/WeekScheduleMobile.tsx');
+    expect(source).toContain('const isMinorEmployee = employee.is_minor === true;');
+  });
+
+  it('WeekScheduleMobile.tsx no longer imports isMinor', () => {
+    const source = readSource('src/components/scheduling/WeekScheduleMobile.tsx');
+    expect(source).not.toContain("import { isMinor } from '@/lib/employeeUtils';");
+  });
+
+  it('Scheduling.tsx no longer calls isMinor(employee.date_of_birth)', () => {
+    const source = readSource('src/pages/Scheduling.tsx');
+    expect(source).not.toContain('isMinor(employee.date_of_birth)');
+  });
+
+  it('Scheduling.tsx reads employee.is_minor', () => {
+    const source = readSource('src/pages/Scheduling.tsx');
+    expect(source).toContain('const isMinorEmployee = employee.is_minor === true;');
+  });
+
+  it('Scheduling.tsx no longer imports isMinor', () => {
+    const source = readSource('src/pages/Scheduling.tsx');
+    expect(source).not.toContain("import { isMinor } from '@/lib/employeeUtils';");
+  });
+
+  it('EmployeeSidebar.tsx declares is_minor on its local Employee type', () => {
+    const source = readSource('src/components/scheduling/ShiftPlanner/EmployeeSidebar.tsx');
+    expect(source).toContain('is_minor?: boolean;');
+  });
+
+  it('EmployeeSidebar.tsx no longer calls isMinor(employee.date_of_birth)', () => {
+    const source = readSource('src/components/scheduling/ShiftPlanner/EmployeeSidebar.tsx');
+    expect(source).not.toContain('isMinor(employee.date_of_birth)');
+  });
+
+  it('EmployeeSidebar.tsx reads employee.is_minor', () => {
+    const source = readSource('src/components/scheduling/ShiftPlanner/EmployeeSidebar.tsx');
+    expect(source).toContain('{employee.is_minor && (');
+  });
+
+  it('EmployeeSidebar.tsx compares is_minor in its memo comparator', () => {
+    const source = readSource('src/components/scheduling/ShiftPlanner/EmployeeSidebar.tsx');
+    expect(source).toContain('prev.employee.is_minor === next.employee.is_minor &&');
+  });
+
+  it('EmployeeSidebar.tsx no longer imports isMinor', () => {
+    const source = readSource('src/components/scheduling/ShiftPlanner/EmployeeSidebar.tsx');
+    expect(source).not.toContain("import { isMinor } from '@/lib/employeeUtils';");
+  });
+});

--- a/tests/unit/employeeMaskedFields.test.ts
+++ b/tests/unit/employeeMaskedFields.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
   EMPLOYEE_PII_FIELDS,
   PAY_RATE_FIELDS,
+  assertPermissionsResolved,
+  isCompensationHidden,
   maskedEmployeeFields,
   stripMaskedEmployeeFields,
 } from '@/lib/employeeMaskedFields';
@@ -68,5 +70,55 @@ describe('stripMaskedEmployeeFields', () => {
   it('should drop nothing when the masked list is empty', () => {
     const payload = { id: 'e1', hourly_rate: 1500 };
     expect(stripMaskedEmployeeFields(payload, [])).toEqual(payload);
+  });
+});
+
+describe('isCompensationHidden', () => {
+  it('should read true for a masked hourly rate (null)', () => {
+    expect(isCompensationHidden({ compensation_type: 'hourly', hourly_rate: null })).toBe(true);
+  });
+
+  it('should read true for a masked hourly rate (undefined)', () => {
+    expect(isCompensationHidden({ compensation_type: 'hourly' })).toBe(true);
+  });
+
+  it('should read false for a visible hourly rate, even a real $0', () => {
+    expect(isCompensationHidden({ compensation_type: 'hourly', hourly_rate: 0 })).toBe(false);
+  });
+
+  it('should default to the hourly field when compensation_type is missing', () => {
+    expect(isCompensationHidden({ hourly_rate: null })).toBe(true);
+    expect(isCompensationHidden({ hourly_rate: 1500 })).toBe(false);
+  });
+
+  it('should read the salary field for a salaried employee', () => {
+    expect(isCompensationHidden({ compensation_type: 'salary', salary_amount: null })).toBe(true);
+    expect(isCompensationHidden({ compensation_type: 'salary', salary_amount: 50000 })).toBe(false);
+  });
+
+  it('should read the daily-rate field for a daily-rate employee', () => {
+    expect(isCompensationHidden({ compensation_type: 'daily_rate', daily_rate_amount: null })).toBe(true);
+    expect(isCompensationHidden({ compensation_type: 'daily_rate', daily_rate_amount: 12000 })).toBe(false);
+  });
+
+  it('should read the contractor field for a contractor', () => {
+    expect(isCompensationHidden({ compensation_type: 'contractor', contractor_payment_amount: null })).toBe(true);
+    expect(isCompensationHidden({ compensation_type: 'contractor', contractor_payment_amount: 75000 })).toBe(false);
+  });
+
+  it('should read false for an unrecognized compensation_type', () => {
+    expect(isCompensationHidden({ compensation_type: 'unknown_type' })).toBe(false);
+  });
+});
+
+describe('assertPermissionsResolved', () => {
+  it('should throw when permissions are still loading', () => {
+    expect(() => assertPermissionsResolved(false)).toThrow(
+      'Permissions are still loading. Try again in a moment.'
+    );
+  });
+
+  it('should not throw once permissions have resolved', () => {
+    expect(() => assertPermissionsResolved(true)).not.toThrow();
   });
 });

--- a/tests/unit/employeeMaskedFields.test.ts
+++ b/tests/unit/employeeMaskedFields.test.ts
@@ -7,28 +7,28 @@ import {
 } from '@/lib/employeeMaskedFields';
 
 describe('maskedEmployeeFields', () => {
-  it('masks nothing when the caller holds both flags', () => {
+  it('should mask nothing when the caller holds both flags', () => {
     expect(maskedEmployeeFields({ payRates: true, employeePii: true })).toEqual([]);
   });
 
-  it('masks the pay fields when the caller lacks view:pay_rates', () => {
+  it('should mask the pay fields when the caller lacks view:pay_rates', () => {
     expect(maskedEmployeeFields({ payRates: false, employeePii: true }))
       .toEqual([...PAY_RATE_FIELDS]);
   });
 
-  it('masks the contact fields when the caller lacks view:employee_pii', () => {
+  it('should mask the contact fields when the caller lacks view:employee_pii', () => {
     expect(maskedEmployeeFields({ payRates: true, employeePii: false }))
       .toEqual([...EMPLOYEE_PII_FIELDS]);
   });
 
-  it('masks all eight fields when the caller holds neither flag', () => {
+  it('should mask all eight fields when the caller holds neither flag', () => {
     expect(maskedEmployeeFields({ payRates: false, employeePii: false }))
       .toHaveLength(8);
   });
 });
 
 describe('stripMaskedEmployeeFields', () => {
-  it('drops every masked key from the payload', () => {
+  it('should drop every masked key from the payload', () => {
     const payload = {
       id: 'e1',
       name: 'Ada',
@@ -48,7 +48,7 @@ describe('stripMaskedEmployeeFields', () => {
     expect(result).toEqual({ id: 'e1', name: 'Ada' });
   });
 
-  it('keeps a key that is not masked, even when its value is null', () => {
+  it('should keep a key that is not masked, even when its value is null', () => {
     const result = stripMaskedEmployeeFields(
       { id: 'e1', notes: null, hourly_rate: 0 },
       ['hourly_rate']
@@ -57,7 +57,7 @@ describe('stripMaskedEmployeeFields', () => {
     expect(result).toEqual({ id: 'e1', notes: null });
   });
 
-  it('returns a new object and does not change the input', () => {
+  it('should return a new object and not change the input', () => {
     const payload = { id: 'e1', hourly_rate: 0 };
     const result = stripMaskedEmployeeFields(payload, ['hourly_rate']);
 
@@ -65,7 +65,7 @@ describe('stripMaskedEmployeeFields', () => {
     expect(payload).toEqual({ id: 'e1', hourly_rate: 0 });
   });
 
-  it('drops nothing when the masked list is empty', () => {
+  it('should drop nothing when the masked list is empty', () => {
     const payload = { id: 'e1', hourly_rate: 1500 };
     expect(stripMaskedEmployeeFields(payload, [])).toEqual(payload);
   });

--- a/tests/unit/employeeMaskedFields.test.ts
+++ b/tests/unit/employeeMaskedFields.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EMPLOYEE_PII_FIELDS,
+  PAY_RATE_FIELDS,
+  maskedEmployeeFields,
+  stripMaskedEmployeeFields,
+} from '@/lib/employeeMaskedFields';
+
+describe('maskedEmployeeFields', () => {
+  it('masks nothing when the caller holds both flags', () => {
+    expect(maskedEmployeeFields({ payRates: true, employeePii: true })).toEqual([]);
+  });
+
+  it('masks the pay fields when the caller lacks view:pay_rates', () => {
+    expect(maskedEmployeeFields({ payRates: false, employeePii: true }))
+      .toEqual([...PAY_RATE_FIELDS]);
+  });
+
+  it('masks the contact fields when the caller lacks view:employee_pii', () => {
+    expect(maskedEmployeeFields({ payRates: true, employeePii: false }))
+      .toEqual([...EMPLOYEE_PII_FIELDS]);
+  });
+
+  it('masks all eight fields when the caller holds neither flag', () => {
+    expect(maskedEmployeeFields({ payRates: false, employeePii: false }))
+      .toHaveLength(8);
+  });
+});
+
+describe('stripMaskedEmployeeFields', () => {
+  it('drops every masked key from the payload', () => {
+    const payload = {
+      id: 'e1',
+      name: 'Ada',
+      hourly_rate: 0,
+      salary_amount: undefined,
+      email: undefined,
+      date_of_birth: null,
+    };
+
+    const result = stripMaskedEmployeeFields(payload, [
+      'hourly_rate',
+      'salary_amount',
+      'email',
+      'date_of_birth',
+    ]);
+
+    expect(result).toEqual({ id: 'e1', name: 'Ada' });
+  });
+
+  it('keeps a key that is not masked, even when its value is null', () => {
+    const result = stripMaskedEmployeeFields(
+      { id: 'e1', notes: null, hourly_rate: 0 },
+      ['hourly_rate']
+    );
+
+    expect(result).toEqual({ id: 'e1', notes: null });
+  });
+
+  it('returns a new object and does not change the input', () => {
+    const payload = { id: 'e1', hourly_rate: 0 };
+    const result = stripMaskedEmployeeFields(payload, ['hourly_rate']);
+
+    expect(result).not.toBe(payload);
+    expect(payload).toEqual({ id: 'e1', hourly_rate: 0 });
+  });
+
+  it('drops nothing when the masked list is empty', () => {
+    const payload = { id: 'e1', hourly_rate: 1500 };
+    expect(stripMaskedEmployeeFields(payload, [])).toEqual(payload);
+  });
+});

--- a/tests/unit/employeesSecureViewReaders.test.ts
+++ b/tests/unit/employeesSecureViewReaders.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+// Task 4 Step 3: four hooks read employee rows directly from the base
+// `employees` table. That table now hides pay and PII columns from a
+// caller without the matching flag (Task 3), but a plain SELECT still
+// returns NULL for those columns rather than routing through the
+// masking view. Point each read at `employees_secure` so the mask
+// applies uniformly. Mutations (insert/update/delete) stay on the base
+// table — the view is not writable.
+
+const readSource = (relativePath: string): string =>
+  readFileSync(resolve(__dirname, '../..', relativePath), 'utf8');
+
+describe('direct employees readers use employees_secure', () => {
+  it('useEmployees.tsx reads the list query from employees_secure', () => {
+    const source = readSource('src/hooks/useEmployees.tsx');
+    expect(source).toContain("let query = supabase\n        .from('employees_secure')");
+  });
+
+  it('useEmployees.tsx still writes create/update/delete to the base table', () => {
+    const source = readSource('src/hooks/useEmployees.tsx');
+    const fromCalls = [...source.matchAll(/\.from\('(employees|employees_secure)'\)/g)].map(
+      (m) => m[1]
+    );
+    // One read (employees_secure) plus three writes (employees): insert, update, delete.
+    expect(fromCalls.filter((t) => t === 'employees_secure')).toHaveLength(1);
+    expect(fromCalls.filter((t) => t === 'employees')).toHaveLength(3);
+  });
+
+  it('useCurrentEmployee.tsx reads from employees_secure', () => {
+    const source = readSource('src/hooks/useCurrentEmployee.tsx');
+    expect(source).toContain("const { data, error } = await supabase\n        .from('employees_secure')");
+  });
+
+  it('useMonthlyMetrics.tsx reads the labor employees query from employees_secure', () => {
+    const source = readSource('src/hooks/useMonthlyMetrics.tsx');
+    expect(source).toContain(
+      "const { data: employeesData, error: employeesError } = await supabase\n        .from('employees_secure')"
+    );
+  });
+
+  it('useTimePunches.tsx reads the employees join from employees_secure', () => {
+    const source = readSource('src/hooks/useTimePunches.tsx');
+    expect(source).toContain("const { data, error } = await supabase\n        .from('employees_secure')");
+  });
+});

--- a/tests/unit/employeesSecureViewReaders.test.ts
+++ b/tests/unit/employeesSecureViewReaders.test.ts
@@ -46,3 +46,37 @@ describe('direct employees readers use employees_secure', () => {
     expect(source).toContain("const { data, error } = await supabase\n        .from('employees_secure')");
   });
 });
+
+// A read that names a masked column on the base table does not return NULL.
+// It fails with "permission denied for table employees", because
+// 20260806110000 revokes SELECT on those eight columns from `authenticated`.
+// Each reader below names at least one of them, so each one breaks its page
+// for every user until it moves to the view.
+const MASKED_COLUMNS = [
+  'hourly_rate',
+  'salary_amount',
+  'contractor_payment_amount',
+  'daily_rate_amount',
+  'daily_rate_reference_weekly',
+  'email',
+  'phone',
+  'date_of_birth',
+];
+
+/** Every column list of a `.select(...)` that reads the base `employees` table. */
+const baseTableSelects = (source: string): string[] =>
+  [...source.matchAll(/\.from\('employees'\)\s*\n\s*\.select\(\s*'([^']*)'/g)].map((m) => m[1]);
+
+describe('no base-table read names a masked column', () => {
+  it.each([
+    ['src/components/financial-statements/IncomeStatement.tsx'],
+    ['src/hooks/useSlingEmployeeMapping.ts'],
+    ['src/hooks/useAccountlessEmployees.ts'],
+  ])('%s selects no masked column from employees', (path) => {
+    const selected = baseTableSelects(readSource(path)).join(',');
+    const named = MASKED_COLUMNS.filter((column) =>
+      new RegExp(`\\b${column}\\b`).test(selected)
+    );
+    expect(named).toEqual([]);
+  });
+});

--- a/tests/unit/incomeStatement.test.tsx
+++ b/tests/unit/incomeStatement.test.tsx
@@ -49,10 +49,12 @@ vi.mock('@/hooks/use-toast', () => ({
 }));
 
 // IncomeStatement now reads view:pay_rates to flag hidden payroll data.
-// Default every test to a caller who can see pay rates, so the existing
-// cases below keep their old behavior (payrollDataHidden stays false).
+// Default every test to a resolved caller who can see pay rates, so the
+// existing cases below keep their old behavior (payrollDataHidden stays
+// false). isResolvedMock lets one test drive the still-resolving case.
+const { isResolvedMock } = vi.hoisted(() => ({ isResolvedMock: vi.fn(() => true) }));
 vi.mock('@/hooks/usePermissions', () => ({
-  usePermissions: () => ({ hasCapability: () => true }),
+  usePermissions: () => ({ hasCapability: () => true, isResolved: isResolvedMock() }),
 }));
 
 const renderIncomeStatement = () =>
@@ -71,6 +73,7 @@ describe('IncomeStatement P&L behavior', () => {
     mockUseRevenueBreakdown.mockReset();
     mockUseUnifiedCOGS.mockReset();
     mockUseUncategorizedTotals.mockReset();
+    isResolvedMock.mockReturnValue(true);
     // Default: no unified COGS data (hook loaded but zero total)
     mockUseUnifiedCOGS.mockReturnValue({
       totalCOGS: 0,
@@ -478,5 +481,18 @@ describe('IncomeStatement P&L behavior', () => {
     const netIncomeRow = screen.getByText('Net Income').closest('div');
     expect(netIncomeRow).not.toBeNull();
     expect(within(netIncomeRow as HTMLElement).getByText('-$100.00')).toBeInTheDocument();
+  });
+
+  it('shows the loading state, not a crash, while the role is still resolving', () => {
+    isResolvedMock.mockReturnValue(false);
+    mockUseRevenueBreakdown.mockReturnValue({
+      revenue: 0, discounts: 0, refunds: 0, passThroughSales: 0, isLoading: false,
+    });
+
+    currentIncomeData = { revenue: [], cogs: [], expenses: [] };
+
+    renderIncomeStatement();
+
+    expect(screen.queryByText('Total Revenue')).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/incomeStatement.test.tsx
+++ b/tests/unit/incomeStatement.test.tsx
@@ -48,6 +48,13 @@ vi.mock('@/hooks/use-toast', () => ({
   useToast: () => ({ toast: vi.fn() }),
 }));
 
+// IncomeStatement now reads view:pay_rates to flag hidden payroll data.
+// Default every test to a caller who can see pay rates, so the existing
+// cases below keep their old behavior (payrollDataHidden stays false).
+vi.mock('@/hooks/usePermissions', () => ({
+  usePermissions: () => ({ hasCapability: () => true }),
+}));
+
 const renderIncomeStatement = () =>
   render(
     <MemoryRouter>

--- a/tests/unit/useAccountlessEmployees.test.ts
+++ b/tests/unit/useAccountlessEmployees.test.ts
@@ -39,7 +39,7 @@ function createWrapper() {
  */
 function stubQuery(result: { data: unknown; error: unknown }) {
   mockSupabase.from.mockImplementation((table: string) => {
-    if (table === 'employees') {
+    if (table === 'employees_secure') {
       return {
         select: vi.fn().mockReturnValue({
           eq: vi.fn().mockReturnValue({
@@ -92,7 +92,7 @@ describe('useAccountlessEmployees query', () => {
     const eqStatusActive = vi.fn().mockResolvedValue({ data: [], error: null });
 
     mockSupabase.from.mockImplementation((table: string) => {
-      if (table === 'employees') {
+      if (table === 'employees_secure') {
         return {
           select: vi.fn((columns: string) => {
             expect(columns).toBe('id, name, email');

--- a/tests/unit/useEmployeeLaborCosts.hiddenCost.test.ts
+++ b/tests/unit/useEmployeeLaborCosts.hiddenCost.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useEmployeeLaborCosts } from '@/hooks/useEmployeeLaborCosts';
+import { Employee, Shift } from '@/types/scheduling';
+
+// A masked pay column arrives as null (the row policy strips it, not the
+// caller). A $0 cost for that row would understate labor and feed a wrong
+// P&L. The hook must mark the row unknown and leave it out of the totals.
+
+const shiftFor = (employeeId: string, id: string): Shift =>
+  ({
+    id,
+    employee_id: employeeId,
+    start_time: '2026-01-05T09:00:00Z',
+    end_time: '2026-01-05T17:00:00Z',
+  } as unknown as Shift);
+
+const visibleHourly = {
+  id: 'emp-visible',
+  name: 'Ann Lee',
+  position: 'Server',
+  compensation_type: 'hourly',
+  hourly_rate: 2000, // $20.00/hr in cents
+} as unknown as Employee;
+
+const maskedHourly = {
+  id: 'emp-hourly-masked',
+  name: 'Bo Ray',
+  position: 'Server',
+  compensation_type: 'hourly',
+  hourly_rate: null,
+} as unknown as Employee;
+
+const maskedSalary = {
+  id: 'emp-salary-masked',
+  name: 'Cy Doe',
+  position: 'Manager',
+  compensation_type: 'salary',
+  salary_amount: null,
+  pay_period_type: 'bi-weekly',
+} as unknown as Employee;
+
+const maskedDailyRate = {
+  id: 'emp-daily-masked',
+  name: 'Di Fox',
+  position: 'Cook',
+  compensation_type: 'daily_rate',
+  daily_rate_amount: null,
+} as unknown as Employee;
+
+const maskedContractor = {
+  id: 'emp-contractor-masked',
+  name: 'Ed Kim',
+  position: 'Consultant',
+  compensation_type: 'contractor',
+  contractor_payment_amount: null,
+  contractor_payment_interval: 'weekly',
+} as unknown as Employee;
+
+describe('useEmployeeLaborCosts — masked pay handling', () => {
+  it('marks each masked compensation type as hidden with hours intact and rate/cost at 0', () => {
+    const employees = [maskedHourly, maskedSalary, maskedDailyRate, maskedContractor];
+    const shifts = employees.map(e => shiftFor(e.id, `shift-${e.id}`));
+
+    const { result } = renderHook(() => useEmployeeLaborCosts(shifts, employees));
+
+    for (const row of result.current.employeeCosts) {
+      expect(row.costIsHidden).toBe(true);
+      expect(row.cost).toBe(0);
+      expect(row.rate).toBe(0);
+      expect(row.hours).toBeGreaterThan(0);
+      expect(row.outlierLevel).toBe('none');
+    }
+  });
+
+  it('excludes masked rows from totalCost, totalHours and averageHourlyRate, and counts them', () => {
+    const employees = [visibleHourly, maskedHourly];
+    const shifts = employees.map(e => shiftFor(e.id, `shift-${e.id}`));
+
+    const { result } = renderHook(() => useEmployeeLaborCosts(shifts, employees));
+
+    // 8 hours * $20/hr = $160 for the one visible employee only.
+    expect(result.current.totalCost).toBe(160);
+    expect(result.current.totalHours).toBe(8);
+    expect(result.current.averageHourlyRate).toBe(20);
+    expect(result.current.hiddenCostCount).toBe(1);
+  });
+
+  it('reports hiddenCostCount 0 when the employee list is empty', () => {
+    const { result } = renderHook(() => useEmployeeLaborCosts([], []));
+    expect(result.current.hiddenCostCount).toBe(0);
+  });
+
+  it('keeps a fully visible hourly employee unaffected (costIsHidden false)', () => {
+    const shifts = [shiftFor(visibleHourly.id, 'shift-visible')];
+    const { result } = renderHook(() => useEmployeeLaborCosts(shifts, [visibleHourly]));
+
+    expect(result.current.employeeCosts[0].costIsHidden).toBe(false);
+    expect(result.current.hiddenCostCount).toBe(0);
+  });
+});

--- a/tests/unit/useEmployees.maskedFields.test.tsx
+++ b/tests/unit/useEmployees.maskedFields.test.tsx
@@ -109,7 +109,7 @@ describe('useCreateEmployee — masked field strip', () => {
     hasCapabilityMock.mockReturnValue(false);
 
     const { result } = renderHook(() => useCreateEmployee(), { wrapper });
-    await result.current.mutateAsync(fullEmployeePayload() as any);
+    await result.current.mutateAsync(fullEmployeePayload() as any); // eslint-disable-line @typescript-eslint/no-explicit-any
 
     expect(insertMock).toHaveBeenCalledTimes(1);
     const insertedRow = insertMock.mock.calls[0][0];
@@ -122,7 +122,7 @@ describe('useCreateEmployee — masked field strip', () => {
 
     const { result } = renderHook(() => useCreateEmployee(), { wrapper });
     const payload = fullEmployeePayload();
-    await result.current.mutateAsync(payload as any);
+    await result.current.mutateAsync(payload as any); // eslint-disable-line @typescript-eslint/no-explicit-any
 
     expect(insertMock).toHaveBeenCalledWith(payload);
   });
@@ -132,7 +132,7 @@ describe('useCreateEmployee — masked field strip', () => {
     hasCapabilityMock.mockReturnValue(true);
 
     const { result } = renderHook(() => useCreateEmployee(), { wrapper });
-    await result.current.mutateAsync(fullEmployeePayload() as any);
+    await result.current.mutateAsync(fullEmployeePayload() as any); // eslint-disable-line @typescript-eslint/no-explicit-any
 
     const insertedRow = insertMock.mock.calls[0][0];
     expect(insertedRow).toEqual({ restaurant_id: 'r1', name: 'Ada' });
@@ -143,7 +143,7 @@ describe('useCreateEmployee — masked field strip', () => {
     hasCapabilityMock.mockReturnValue(true);
 
     const { result } = renderHook(() => useCreateEmployee(), { wrapper });
-    await result.current.mutateAsync(fullEmployeePayload() as any);
+    await result.current.mutateAsync(fullEmployeePayload() as any); // eslint-disable-line @typescript-eslint/no-explicit-any
 
     expect(insertSelectArgsMock).toHaveBeenCalledWith('id, restaurant_id, name');
   });
@@ -160,7 +160,7 @@ describe('useUpdateEmployee — masked field strip', () => {
     hasCapabilityMock.mockReturnValue(false);
 
     const { result } = renderHook(() => useUpdateEmployee(), { wrapper });
-    await result.current.mutateAsync({ id: 'e1', ...fullEmployeePayload() } as any);
+    await result.current.mutateAsync({ id: 'e1', ...fullEmployeePayload() } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
 
     expect(updateMock).toHaveBeenCalledTimes(1);
     const updatedRow = updateMock.mock.calls[0][0];
@@ -174,7 +174,7 @@ describe('useUpdateEmployee — masked field strip', () => {
 
     const { result } = renderHook(() => useUpdateEmployee(), { wrapper });
     const payload = fullEmployeePayload();
-    await result.current.mutateAsync({ id: 'e1', ...payload } as any);
+    await result.current.mutateAsync({ id: 'e1', ...payload } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
 
     expect(updateMock).toHaveBeenCalledWith(payload);
   });
@@ -184,7 +184,7 @@ describe('useUpdateEmployee — masked field strip', () => {
     hasCapabilityMock.mockReturnValue(true);
 
     const { result } = renderHook(() => useUpdateEmployee(), { wrapper });
-    await result.current.mutateAsync({ id: 'e1', ...fullEmployeePayload() } as any);
+    await result.current.mutateAsync({ id: 'e1', ...fullEmployeePayload() } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
 
     expect(updateSelectArgsMock).toHaveBeenCalledWith('id, restaurant_id, name');
   });

--- a/tests/unit/useEmployees.maskedFields.test.tsx
+++ b/tests/unit/useEmployees.maskedFields.test.tsx
@@ -127,15 +127,16 @@ describe('useCreateEmployee — masked field strip', () => {
     expect(insertMock).toHaveBeenCalledWith(payload);
   });
 
-  it('treats an unresolved permission state as holding neither flag', async () => {
+  it('rejects immediately, before any insert, when permissions are still resolving', async () => {
     isResolvedMock.mockReturnValue(false);
     hasCapabilityMock.mockReturnValue(true);
 
     const { result } = renderHook(() => useCreateEmployee(), { wrapper });
-    await result.current.mutateAsync(fullEmployeePayload() as any); // eslint-disable-line @typescript-eslint/no-explicit-any -- fixture omits Employee fields the mutation hook never reads
+    await expect(
+      result.current.mutateAsync(fullEmployeePayload() as any), // eslint-disable-line @typescript-eslint/no-explicit-any -- fixture omits Employee fields the mutation hook never reads
+    ).rejects.toThrow(/still loading/i);
 
-    const insertedRow = insertMock.mock.calls[0][0];
-    expect(insertedRow).toEqual({ restaurant_id: 'r1', name: 'Ada' });
+    expect(insertMock).not.toHaveBeenCalled();
   });
 
   it('selects only id, restaurant_id, name — not a bare select()', async () => {
@@ -187,5 +188,17 @@ describe('useUpdateEmployee — masked field strip', () => {
     await result.current.mutateAsync({ id: 'e1', ...fullEmployeePayload() } as any); // eslint-disable-line @typescript-eslint/no-explicit-any -- fixture omits Employee fields the mutation hook never reads
 
     expect(updateSelectArgsMock).toHaveBeenCalledWith('id, restaurant_id, name');
+  });
+
+  it('rejects immediately, before any update, when permissions are still resolving', async () => {
+    isResolvedMock.mockReturnValue(false);
+    hasCapabilityMock.mockReturnValue(true);
+
+    const { result } = renderHook(() => useUpdateEmployee(), { wrapper });
+    await expect(
+      result.current.mutateAsync({ id: 'e1', ...fullEmployeePayload() } as any), // eslint-disable-line @typescript-eslint/no-explicit-any -- fixture omits Employee fields the mutation hook never reads
+    ).rejects.toThrow(/still loading/i);
+
+    expect(updateMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/useEmployees.maskedFields.test.tsx
+++ b/tests/unit/useEmployees.maskedFields.test.tsx
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { useCreateEmployee, useUpdateEmployee } from '@/hooks/useEmployees';
+
+// A caller with no `view:pay_rates` or `view:employee_pii` flag reads NULL
+// for the masked columns (Task 3's view). The Edit Employee form then holds
+// that NULL and would write it back on save, erasing the stored value. The
+// mutation hooks strip the masked keys from the payload before the write so
+// the caller can only ever touch columns it can read.
+
+const {
+  hasCapabilityMock,
+  isResolvedMock,
+  insertMock,
+  insertSingleMock,
+  insertSelectArgsMock,
+  updateMock,
+  updateEqMock,
+  updateSingleMock,
+  updateSelectArgsMock,
+  toastMock,
+} = vi.hoisted(() => ({
+  hasCapabilityMock: vi.fn(),
+  isResolvedMock: vi.fn(),
+  insertMock: vi.fn(),
+  insertSingleMock: vi.fn(),
+  insertSelectArgsMock: vi.fn(),
+  updateMock: vi.fn(),
+  updateEqMock: vi.fn(),
+  updateSingleMock: vi.fn(),
+  updateSelectArgsMock: vi.fn(),
+  toastMock: vi.fn(),
+}));
+
+vi.mock('@/hooks/usePermissions', () => ({
+  usePermissions: () => ({
+    hasCapability: hasCapabilityMock,
+    isResolved: isResolvedMock(),
+  }),
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: toastMock }),
+}));
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: () => ({
+      insert: (...args: unknown[]) => {
+        insertMock(...args);
+        return {
+          select: (...selectArgs: unknown[]) => {
+            insertSelectArgsMock(...selectArgs);
+            return { single: insertSingleMock };
+          },
+        };
+      },
+      update: (...args: unknown[]) => {
+        updateMock(...args);
+        return {
+          eq: (...eqArgs: unknown[]) => {
+            updateEqMock(...eqArgs);
+            return {
+              select: (...selectArgs: unknown[]) => {
+                updateSelectArgsMock(...selectArgs);
+                return { single: updateSingleMock };
+              },
+            };
+          },
+        };
+      },
+    }),
+  },
+}));
+
+const wrapper = ({ children }: { children: React.ReactNode }) => {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+};
+
+const okResponse = () => ({
+  data: { id: 'e1', restaurant_id: 'r1', name: 'Ada' },
+  error: null,
+});
+
+const fullEmployeePayload = () => ({
+  restaurant_id: 'r1',
+  name: 'Ada',
+  hourly_rate: 25,
+  salary_amount: 60000,
+  contractor_payment_amount: 500,
+  daily_rate_amount: 100,
+  daily_rate_reference_weekly: 500,
+  email: 'ada@example.com',
+  phone: '555-1234',
+  date_of_birth: '1990-01-01',
+});
+
+describe('useCreateEmployee — masked field strip', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    insertSingleMock.mockResolvedValue(okResponse());
+  });
+
+  it('strips pay-rate and PII fields when the caller holds neither flag', async () => {
+    isResolvedMock.mockReturnValue(true);
+    hasCapabilityMock.mockReturnValue(false);
+
+    const { result } = renderHook(() => useCreateEmployee(), { wrapper });
+    await result.current.mutateAsync(fullEmployeePayload() as any);
+
+    expect(insertMock).toHaveBeenCalledTimes(1);
+    const insertedRow = insertMock.mock.calls[0][0];
+    expect(insertedRow).toEqual({ restaurant_id: 'r1', name: 'Ada' });
+  });
+
+  it('keeps every field when the caller holds both flags', async () => {
+    isResolvedMock.mockReturnValue(true);
+    hasCapabilityMock.mockReturnValue(true);
+
+    const { result } = renderHook(() => useCreateEmployee(), { wrapper });
+    const payload = fullEmployeePayload();
+    await result.current.mutateAsync(payload as any);
+
+    expect(insertMock).toHaveBeenCalledWith(payload);
+  });
+
+  it('treats an unresolved permission state as holding neither flag', async () => {
+    isResolvedMock.mockReturnValue(false);
+    hasCapabilityMock.mockReturnValue(true);
+
+    const { result } = renderHook(() => useCreateEmployee(), { wrapper });
+    await result.current.mutateAsync(fullEmployeePayload() as any);
+
+    const insertedRow = insertMock.mock.calls[0][0];
+    expect(insertedRow).toEqual({ restaurant_id: 'r1', name: 'Ada' });
+  });
+
+  it('selects only id, restaurant_id, name — not a bare select()', async () => {
+    isResolvedMock.mockReturnValue(true);
+    hasCapabilityMock.mockReturnValue(true);
+
+    const { result } = renderHook(() => useCreateEmployee(), { wrapper });
+    await result.current.mutateAsync(fullEmployeePayload() as any);
+
+    expect(insertSelectArgsMock).toHaveBeenCalledWith('id, restaurant_id, name');
+  });
+});
+
+describe('useUpdateEmployee — masked field strip', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    updateSingleMock.mockResolvedValue(okResponse());
+  });
+
+  it('strips pay-rate and PII fields when the caller holds neither flag', async () => {
+    isResolvedMock.mockReturnValue(true);
+    hasCapabilityMock.mockReturnValue(false);
+
+    const { result } = renderHook(() => useUpdateEmployee(), { wrapper });
+    await result.current.mutateAsync({ id: 'e1', ...fullEmployeePayload() } as any);
+
+    expect(updateMock).toHaveBeenCalledTimes(1);
+    const updatedRow = updateMock.mock.calls[0][0];
+    expect(updatedRow).toEqual({ restaurant_id: 'r1', name: 'Ada' });
+    expect(updateEqMock).toHaveBeenCalledWith('id', 'e1');
+  });
+
+  it('keeps every field when the caller holds both flags', async () => {
+    isResolvedMock.mockReturnValue(true);
+    hasCapabilityMock.mockReturnValue(true);
+
+    const { result } = renderHook(() => useUpdateEmployee(), { wrapper });
+    const payload = fullEmployeePayload();
+    await result.current.mutateAsync({ id: 'e1', ...payload } as any);
+
+    expect(updateMock).toHaveBeenCalledWith(payload);
+  });
+
+  it('selects only id, restaurant_id, name — not a bare select()', async () => {
+    isResolvedMock.mockReturnValue(true);
+    hasCapabilityMock.mockReturnValue(true);
+
+    const { result } = renderHook(() => useUpdateEmployee(), { wrapper });
+    await result.current.mutateAsync({ id: 'e1', ...fullEmployeePayload() } as any);
+
+    expect(updateSelectArgsMock).toHaveBeenCalledWith('id, restaurant_id, name');
+  });
+});

--- a/tests/unit/useEmployees.maskedFields.test.tsx
+++ b/tests/unit/useEmployees.maskedFields.test.tsx
@@ -109,7 +109,7 @@ describe('useCreateEmployee — masked field strip', () => {
     hasCapabilityMock.mockReturnValue(false);
 
     const { result } = renderHook(() => useCreateEmployee(), { wrapper });
-    await result.current.mutateAsync(fullEmployeePayload() as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+    await result.current.mutateAsync(fullEmployeePayload() as any); // eslint-disable-line @typescript-eslint/no-explicit-any -- fixture omits Employee fields the mutation hook never reads
 
     expect(insertMock).toHaveBeenCalledTimes(1);
     const insertedRow = insertMock.mock.calls[0][0];
@@ -122,7 +122,7 @@ describe('useCreateEmployee — masked field strip', () => {
 
     const { result } = renderHook(() => useCreateEmployee(), { wrapper });
     const payload = fullEmployeePayload();
-    await result.current.mutateAsync(payload as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+    await result.current.mutateAsync(payload as any); // eslint-disable-line @typescript-eslint/no-explicit-any -- fixture omits Employee fields the mutation hook never reads
 
     expect(insertMock).toHaveBeenCalledWith(payload);
   });
@@ -132,7 +132,7 @@ describe('useCreateEmployee — masked field strip', () => {
     hasCapabilityMock.mockReturnValue(true);
 
     const { result } = renderHook(() => useCreateEmployee(), { wrapper });
-    await result.current.mutateAsync(fullEmployeePayload() as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+    await result.current.mutateAsync(fullEmployeePayload() as any); // eslint-disable-line @typescript-eslint/no-explicit-any -- fixture omits Employee fields the mutation hook never reads
 
     const insertedRow = insertMock.mock.calls[0][0];
     expect(insertedRow).toEqual({ restaurant_id: 'r1', name: 'Ada' });
@@ -143,7 +143,7 @@ describe('useCreateEmployee — masked field strip', () => {
     hasCapabilityMock.mockReturnValue(true);
 
     const { result } = renderHook(() => useCreateEmployee(), { wrapper });
-    await result.current.mutateAsync(fullEmployeePayload() as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+    await result.current.mutateAsync(fullEmployeePayload() as any); // eslint-disable-line @typescript-eslint/no-explicit-any -- fixture omits Employee fields the mutation hook never reads
 
     expect(insertSelectArgsMock).toHaveBeenCalledWith('id, restaurant_id, name');
   });
@@ -160,7 +160,7 @@ describe('useUpdateEmployee — masked field strip', () => {
     hasCapabilityMock.mockReturnValue(false);
 
     const { result } = renderHook(() => useUpdateEmployee(), { wrapper });
-    await result.current.mutateAsync({ id: 'e1', ...fullEmployeePayload() } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+    await result.current.mutateAsync({ id: 'e1', ...fullEmployeePayload() } as any); // eslint-disable-line @typescript-eslint/no-explicit-any -- fixture omits Employee fields the mutation hook never reads
 
     expect(updateMock).toHaveBeenCalledTimes(1);
     const updatedRow = updateMock.mock.calls[0][0];
@@ -174,7 +174,7 @@ describe('useUpdateEmployee — masked field strip', () => {
 
     const { result } = renderHook(() => useUpdateEmployee(), { wrapper });
     const payload = fullEmployeePayload();
-    await result.current.mutateAsync({ id: 'e1', ...payload } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+    await result.current.mutateAsync({ id: 'e1', ...payload } as any); // eslint-disable-line @typescript-eslint/no-explicit-any -- fixture omits Employee fields the mutation hook never reads
 
     expect(updateMock).toHaveBeenCalledWith(payload);
   });
@@ -184,7 +184,7 @@ describe('useUpdateEmployee — masked field strip', () => {
     hasCapabilityMock.mockReturnValue(true);
 
     const { result } = renderHook(() => useUpdateEmployee(), { wrapper });
-    await result.current.mutateAsync({ id: 'e1', ...fullEmployeePayload() } as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+    await result.current.mutateAsync({ id: 'e1', ...fullEmployeePayload() } as any); // eslint-disable-line @typescript-eslint/no-explicit-any -- fixture omits Employee fields the mutation hook never reads
 
     expect(updateSelectArgsMock).toHaveBeenCalledWith('id, restaurant_id, name');
   });

--- a/tests/unit/useMonthlyMetrics.laborBasis.test.ts
+++ b/tests/unit/useMonthlyMetrics.laborBasis.test.ts
@@ -123,7 +123,7 @@ function bankLaborRow(transaction_date: string, amountDollars: number): any {
 function mockSupabaseClient(opts: { timePunches: unknown[]; employees: unknown[]; bankLabor: unknown[] }) {
   const fromMock = vi.fn((table: string) => {
     if (table === 'time_punches') return makeTimePunchesChain(opts.timePunches);
-    if (table === 'employees') return makeChainable(opts.employees);
+    if (table === 'employees_secure') return makeChainable(opts.employees);
     if (table === 'bank_transactions') return makeChainable(opts.bankLabor);
     return makeChainable([]);
   });

--- a/tests/unit/useMonthlyMetrics.maskedLabor.test.ts
+++ b/tests/unit/useMonthlyMetrics.maskedLabor.test.ts
@@ -14,9 +14,9 @@ vi.mock('@/contexts/RestaurantContext', () => ({
   }),
 }));
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- stub for the Supabase query builder; each method returns the same object, a shape the SDK's generic builder type does not describe
 function makeChainable(data: unknown = []): any {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- see makeChainable above; the object gains its methods below, one property at a time
   const chain: any = {};
   ['select', 'eq', 'in', 'order', 'gte', 'lte', 'lt', 'is', 'or', 'limit', 'maybeSingle'].forEach((m) => {
     chain[m] = vi.fn(() => chain);
@@ -25,9 +25,9 @@ function makeChainable(data: unknown = []): any {
   return chain;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- stub for the Supabase query builder; see makeChainable above
 function makeTimePunchesChain(data: unknown[]): any {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- see makeChainable above; the object gains its methods below, one property at a time
   const chain: any = {};
   ['select', 'eq', 'gte', 'lte', 'order'].forEach((m) => {
     chain[m] = vi.fn(() => chain);
@@ -45,7 +45,7 @@ const createWrapper = () => {
   };
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- builds a raw DB punch row; the return type would just repeat the object literal below
 function toDbPunch(employee_id: string, punch_time: string, punch_type: 'clock_in' | 'clock_out', id: string): any {
   return {
     id, employee_id, restaurant_id: RESTAURANT,
@@ -60,13 +60,13 @@ const EMPLOYEE_ID = 'emp-masked-1';
 
 // hourly_rate is null: the caller (e.g. Chef) has no view:pay_rates, so
 // employees_secure masked this column instead of returning a real amount.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- a partial employees_secure row; only the fields this test reads are set
 const maskedEmployee: any = {
   id: EMPLOYEE_ID, restaurant_id: RESTAURANT,
   status: 'active', compensation_type: 'hourly', hourly_rate: null,
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- see maskedEmployee above
 const unmaskedEmployee: any = {
   id: 'emp-visible-1', restaurant_id: RESTAURANT,
   status: 'active', compensation_type: 'hourly', hourly_rate: 2000, // $20.00/hr
@@ -154,5 +154,39 @@ describe('useMonthlyMetrics labor_cost_hidden (masked employees_secure rows)', (
     const july = result.current.data?.find((m) => m.period === '2026-07');
     expect(july).toBeDefined();
     expect(july!.labor_cost_hidden).toBe(true);
+  });
+
+  it('should mark labor_cost_hidden only for months the masked employee was employed', async () => {
+    // Hired mid-July: June is before the hire date, so it must stay
+    // "not hidden" even though the same employee row masks July and August.
+    const maskedEmployeeHiredMidJuly = {
+      ...maskedEmployee,
+      hire_date: '2026-07-10',
+      termination_date: null,
+    };
+    mockSupabaseClient([maskedEmployeeHiredMidJuly]);
+
+    const { useMonthlyMetrics } = await import('@/hooks/useMonthlyMetrics');
+
+    const multiMonthFrom = new Date(2026, 5, 1); // June 1
+    const multiMonthTo = new Date(2026, 7, 31, 23, 59, 59, 999); // Aug 31
+
+    const { result } = renderHook(
+      () => useMonthlyMetrics(RESTAURANT, multiMonthFrom, multiMonthTo),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toBeNull();
+
+    const june = result.current.data?.find((m) => m.period === '2026-06');
+    const july = result.current.data?.find((m) => m.period === '2026-07');
+    const august = result.current.data?.find((m) => m.period === '2026-08');
+    expect(june).toBeDefined();
+    expect(july).toBeDefined();
+    expect(august).toBeDefined();
+    expect(june!.labor_cost_hidden).toBe(false);
+    expect(july!.labor_cost_hidden).toBe(true);
+    expect(august!.labor_cost_hidden).toBe(true);
   });
 });

--- a/tests/unit/useMonthlyMetrics.maskedLabor.test.ts
+++ b/tests/unit/useMonthlyMetrics.maskedLabor.test.ts
@@ -1,0 +1,158 @@
+import React, { type ReactNode } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// A masked employee row (no view:pay_rates) arrives from employees_secure
+// with hourly_rate === null. useMonthlyMetrics must mark labor_cost_hidden
+// true for every month in the result, so the Dashboard shows "Unavailable"
+// instead of a $0 labor cost that reads as real. See
+// docs/superpowers/specs/2026-08-06-sensitive-data-flags-design.md.
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => ({
+    selectedRestaurant: { restaurant: { timezone: 'America/Chicago' } },
+  }),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeChainable(data: unknown = []): any {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = {};
+  ['select', 'eq', 'in', 'order', 'gte', 'lte', 'lt', 'is', 'or', 'limit', 'maybeSingle'].forEach((m) => {
+    chain[m] = vi.fn(() => chain);
+  });
+  chain.then = (resolve: (v: { data: unknown; error: null }) => void) => resolve({ data, error: null });
+  return chain;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeTimePunchesChain(data: unknown[]): any {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const chain: any = {};
+  ['select', 'eq', 'gte', 'lte', 'order'].forEach((m) => {
+    chain[m] = vi.fn(() => chain);
+  });
+  chain.range = vi.fn(() => Promise.resolve({ data, error: null }));
+  return chain;
+}
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function toDbPunch(employee_id: string, punch_time: string, punch_type: 'clock_in' | 'clock_out', id: string): any {
+  return {
+    id, employee_id, restaurant_id: RESTAURANT,
+    punch_time, punch_type, created_at: punch_time, updated_at: punch_time,
+    shift_id: null, notes: null, photo_path: null, device_info: null,
+    location: null, created_by: null, modified_by: null,
+  };
+}
+
+const RESTAURANT = 'rest-masked-labor-1';
+const EMPLOYEE_ID = 'emp-masked-1';
+
+// hourly_rate is null: the caller (e.g. Chef) has no view:pay_rates, so
+// employees_secure masked this column instead of returning a real amount.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const maskedEmployee: any = {
+  id: EMPLOYEE_ID, restaurant_id: RESTAURANT,
+  status: 'active', compensation_type: 'hourly', hourly_rate: null,
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const unmaskedEmployee: any = {
+  id: 'emp-visible-1', restaurant_id: RESTAURANT,
+  status: 'active', compensation_type: 'hourly', hourly_rate: 2000, // $20.00/hr
+};
+
+const shiftPunches = [
+  toDbPunch(EMPLOYEE_ID, '2026-07-15T09:00:00.000Z', 'clock_in', 'punch-in-1'),
+  toDbPunch(EMPLOYEE_ID, '2026-07-15T14:00:00.000Z', 'clock_out', 'punch-out-1'),
+];
+
+function mockSupabaseClient(employees: unknown[]) {
+  const fromMock = vi.fn((table: string) => {
+    if (table === 'time_punches') return makeTimePunchesChain(shiftPunches);
+    if (table === 'employees_secure') return makeChainable(employees);
+    return makeChainable([]);
+  });
+  const rpcMock = vi.fn(() => Promise.resolve({ data: [], error: null }));
+
+  vi.doMock('@/integrations/supabase/client', () => ({
+    supabase: {
+      from: (...args: [string]) => fromMock(...args),
+      rpc: (...args: unknown[]) => rpcMock(...args),
+    },
+  }));
+}
+
+const dateFrom = new Date(2026, 6, 1);
+const dateTo = new Date(2026, 6, 31, 23, 59, 59, 999);
+
+describe('useMonthlyMetrics labor_cost_hidden (masked employees_secure rows)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it('marks labor_cost_hidden true when an employee row is masked, and never reports a bare $0', async () => {
+    mockSupabaseClient([maskedEmployee]);
+
+    const { useMonthlyMetrics } = await import('@/hooks/useMonthlyMetrics');
+
+    const { result } = renderHook(
+      () => useMonthlyMetrics(RESTAURANT, dateFrom, dateTo),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toBeNull();
+
+    const july = result.current.data?.find((m) => m.period === '2026-07');
+    expect(july).toBeDefined();
+    expect(july!.labor_cost_hidden).toBe(true);
+  });
+
+  it('leaves labor_cost_hidden false when every employee row carries a real rate', async () => {
+    mockSupabaseClient([unmaskedEmployee]);
+
+    const { useMonthlyMetrics } = await import('@/hooks/useMonthlyMetrics');
+
+    const { result } = renderHook(
+      () => useMonthlyMetrics(RESTAURANT, dateFrom, dateTo),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toBeNull();
+
+    const july = result.current.data?.find((m) => m.period === '2026-07');
+    expect(july).toBeDefined();
+    expect(july!.labor_cost_hidden).toBe(false);
+  });
+
+  it('marks labor_cost_hidden true when even one employee among several is masked', async () => {
+    mockSupabaseClient([unmaskedEmployee, maskedEmployee]);
+
+    const { useMonthlyMetrics } = await import('@/hooks/useMonthlyMetrics');
+
+    const { result } = renderHook(
+      () => useMonthlyMetrics(RESTAURANT, dateFrom, dateTo),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toBeNull();
+
+    const july = result.current.data?.find((m) => m.period === '2026-07');
+    expect(july).toBeDefined();
+    expect(july!.labor_cost_hidden).toBe(true);
+  });
+});

--- a/tests/unit/useMonthlyMetrics.maskedLabor.test.ts
+++ b/tests/unit/useMonthlyMetrics.maskedLabor.test.ts
@@ -102,7 +102,7 @@ describe('useMonthlyMetrics labor_cost_hidden (masked employees_secure rows)', (
     vi.resetModules();
   });
 
-  it('marks labor_cost_hidden true when an employee row is masked, and never reports a bare $0', async () => {
+  it('should mark labor_cost_hidden true and never report a bare $0 when an employee row is masked', async () => {
     mockSupabaseClient([maskedEmployee]);
 
     const { useMonthlyMetrics } = await import('@/hooks/useMonthlyMetrics');
@@ -120,7 +120,7 @@ describe('useMonthlyMetrics labor_cost_hidden (masked employees_secure rows)', (
     expect(july!.labor_cost_hidden).toBe(true);
   });
 
-  it('leaves labor_cost_hidden false when every employee row carries a real rate', async () => {
+  it('should leave labor_cost_hidden false when every employee row carries a real rate', async () => {
     mockSupabaseClient([unmaskedEmployee]);
 
     const { useMonthlyMetrics } = await import('@/hooks/useMonthlyMetrics');
@@ -138,7 +138,7 @@ describe('useMonthlyMetrics labor_cost_hidden (masked employees_secure rows)', (
     expect(july!.labor_cost_hidden).toBe(false);
   });
 
-  it('marks labor_cost_hidden true when even one employee among several is masked', async () => {
+  it('should mark labor_cost_hidden true when even one employee among several is masked', async () => {
     mockSupabaseClient([unmaskedEmployee, maskedEmployee]);
 
     const { useMonthlyMetrics } = await import('@/hooks/useMonthlyMetrics');

--- a/tests/unit/useMonthlyMetrics.pagination.test.ts
+++ b/tests/unit/useMonthlyMetrics.pagination.test.ts
@@ -175,7 +175,7 @@ describe('useMonthlyMetrics time_punches pagination (1000-row cap fix)', () => {
 
     const fromMock = vi.fn((table: string) => {
       if (table === 'time_punches') return timePunchesChain;
-      if (table === 'employees') return makeChainable(employees);
+      if (table === 'employees_secure') return makeChainable(employees);
       return makeChainable([]);
     });
     const rpcMock = vi.fn(() => Promise.resolve({ data: [], error: null }));

--- a/tests/unit/useMyPayroll.test.ts
+++ b/tests/unit/useMyPayroll.test.ts
@@ -66,7 +66,7 @@ const restaurantScopedChains: Record<string, ReturnType<typeof makeChainable>> =
 };
 
 const allChains: Record<string, ReturnType<typeof makeChainable>> = {
-  employees: employeesChain,
+  employees_secure: employeesChain,
   ...perEmployeeTableChains,
   ...restaurantScopedChains,
 };
@@ -140,7 +140,7 @@ describe('useMyPayroll (self-scoped)', () => {
       expect(fromMock).toHaveBeenCalledWith(table);
       expect(chain.calls).toContainEqual({ method: 'eq', args: ['employee_id', 'emp-1'] });
     });
-    expect(fromMock).toHaveBeenCalledWith('employees');
+    expect(fromMock).toHaveBeenCalledWith('employees_secure');
     expect(employeesChain.calls).toContainEqual({ method: 'eq', args: ['id', 'emp-1'] });
   });
 

--- a/tests/unit/useMyShifts.test.ts
+++ b/tests/unit/useMyShifts.test.ts
@@ -171,7 +171,10 @@ describe('useShifts (admin) — regression guard for the shared implementation',
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     expect(mockSupabase.from).toHaveBeenCalledWith('shifts');
-    expect(calls).toContainEqual({ method: 'select', args: ['*, employee:employees(*)'] });
+    expect(calls).toContainEqual({
+      method: 'select',
+      args: ['*, employee:employees(id, name, position, area, status, is_active, employment_type, user_id)'],
+    });
     expect(calls).toContainEqual({ method: 'eq', args: ['restaurant_id', restaurantId] });
     expect(calls).toContainEqual({ method: 'gte', args: ['start_time', startDate.toISOString()] });
     expect(calls).toContainEqual({ method: 'lte', args: ['start_time', endDate.toISOString()] });

--- a/tests/unit/useSlingEmployeeMapping.test.ts
+++ b/tests/unit/useSlingEmployeeMapping.test.ts
@@ -161,7 +161,7 @@ describe('useSlingEmployeeMapping', () => {
 
       mockSupabase.from.mockImplementation((table: string) => {
         if (table === 'sling_users') return slingChain;
-        if (table === 'employees') return empChain;
+        if (table === 'employees_secure') return empChain;
         return mockFromChain;
       });
 
@@ -177,7 +177,7 @@ describe('useSlingEmployeeMapping', () => {
 
       // Verify supabase from calls
       expect(mockSupabase.from).toHaveBeenCalledWith('sling_users');
-      expect(mockSupabase.from).toHaveBeenCalledWith('employees');
+      expect(mockSupabase.from).toHaveBeenCalledWith('employees_secure');
 
       // matchEmployees should be called with derived csv names + employees
       expect(mockMatchEmployees).toHaveBeenCalledWith(
@@ -210,7 +210,7 @@ describe('useSlingEmployeeMapping', () => {
 
       mockSupabase.from.mockImplementation((table: string) => {
         if (table === 'sling_users') return slingChain;
-        if (table === 'employees') return empChain;
+        if (table === 'employees_secure') return empChain;
         return mockFromChain;
       });
 
@@ -239,7 +239,7 @@ describe('useSlingEmployeeMapping', () => {
 
       mockSupabase.from.mockImplementation((table: string) => {
         if (table === 'sling_users') return slingChain;
-        if (table === 'employees') return empChain;
+        if (table === 'employees_secure') return empChain;
         return mockFromChain;
       });
 
@@ -277,7 +277,7 @@ describe('useSlingEmployeeMapping', () => {
 
       mockSupabase.from.mockImplementation((table: string) => {
         if (table === 'sling_users') return slingChain;
-        if (table === 'employees') return empChain;
+        if (table === 'employees_secure') return empChain;
         return mockFromChain;
       });
 
@@ -351,7 +351,7 @@ describe('useSlingEmployeeMapping', () => {
 
       mockSupabase.from.mockImplementation((table: string) => {
         if (table === 'sling_users') return slingChain;
-        if (table === 'employees') return empChain;
+        if (table === 'employees_secure') return empChain;
         return mockFromChain;
       });
 
@@ -515,7 +515,7 @@ describe('useSlingEmployeeMapping', () => {
 
       mockSupabase.from.mockImplementation((table: string) => {
         if (table === 'sling_users') return slingChain;
-        if (table === 'employees') return empChain;
+        if (table === 'employees_secure') return empChain;
         return mockFromChain;
       });
 
@@ -600,7 +600,7 @@ describe('useSlingEmployeeMapping', () => {
 
       mockSupabase.from.mockImplementation((table: string) => {
         if (table === 'sling_users') return slingChain;
-        if (table === 'employees') return empChain;
+        if (table === 'employees_secure') return empChain;
         return mockFromChain;
       });
 
@@ -647,7 +647,7 @@ describe('useSlingEmployeeMapping', () => {
 
       mockSupabase.from.mockImplementation((table: string) => {
         if (table === 'sling_users') return slingChain;
-        if (table === 'employees') return empChain;
+        if (table === 'employees_secure') return empChain;
         return mockFromChain;
       });
 
@@ -726,7 +726,7 @@ describe('useSlingEmployeeMapping', () => {
 
       mockSupabase.from.mockImplementation((table: string) => {
         if (table === 'sling_users') return slingChain;
-        if (table === 'employees') return empChain;
+        if (table === 'employees_secure') return empChain;
         return mockFromChain;
       });
 
@@ -806,7 +806,7 @@ describe('useSlingEmployeeMapping', () => {
 
       mockSupabase.from.mockImplementation((table: string) => {
         if (table === 'sling_users') return slingChain;
-        if (table === 'employees') return empChain;
+        if (table === 'employees_secure') return empChain;
         return mockFromChain;
       });
 
@@ -854,7 +854,7 @@ describe('useSlingEmployeeMapping', () => {
 
       mockSupabase.from.mockImplementation((table: string) => {
         if (table === 'sling_users') return slingChain;
-        if (table === 'employees') return empChain;
+        if (table === 'employees_secure') return empChain;
         return mockFromChain;
       });
 


### PR DESCRIPTION
## Problem

The three sensitive-data flags were decorative. `view:pay_rates`,
`view:employee_pii`, and `view:costs` were stored in `role_flags`, editable
in RoleEditor, and resolved by `user_has_capability` — but no component and
no RLS policy read them. A collaborator without the pay flag still read every
employee's `hourly_rate`, `date_of_birth`, and `email`, both on screen and
through a direct PostgREST call.

Live proof (production, read-only): user `josema92@hotmail.com` at "Wetzel's -
Cold Stone - Alamo Ranch" held a custom collaborator role with only
`view:costs`, yet read a minor employee's full row.

## Scope

This PR makes `view:pay_rates` and `view:employee_pii` real. `view:costs`
stays deferred — page access already equals cost access today.

## Mechanism: revoke the columns, add a masked view

- **`employees_secure`** — a view that runs with owner rights. It carries its
  own membership predicate (`restaurant_id IN (memberships) OR user_id =
  auth.uid()`) and masks the eight pay and PII columns with
  `CASE WHEN caps.pay OR caps.self THEN e.col END`. It adds a computed
  `is_minor`, shown to everyone.
- **Self-row exception** — `caps.self = (e.user_id = auth.uid())` unmasks a
  member's own linked row, even without `view:pay_rates`. A member reads their
  own pay on the `/employee` views; a coworker's row and a row linked to
  nobody stay masked.
- **Column REVOKE** — the base `employees` table drops the SELECT grant on the
  eight columns, so a direct PostgREST call cannot bypass the view.
- **Write path** — the four mutation call sites strip the masked keys before
  the write, so a masked null cannot overwrite a real value.
- **Embeds** — the three `employee:employees(...)` resource embeds list only
  granted columns.
- **Legacy membership path** — `user_has_capability` answers the two flags
  before the legacy `CASE`, so a legacy role string still resolves them.

## Dashboard and display

A masked pay column arrives as `null`. A null rate would compute as a `$0`
labor cost — a wrong number that understates labor and inflates margin. The
Monthly Performance table now marks the Labor and Net Profit cells
"Unavailable" for a month whose roster has a masked rate. `EmployeeList`, the
scheduling Top Earners row, and `useEmployeeLaborCosts` follow the same rule.

## Tests

- **pgTAP** — `roles_seed_test.sql` pins the exact flag set on every builtin
  role. `test_expected_capabilities` stays the fixed point.
- **Unit** — 101 tests cover the masked-field helpers, the write-path strip,
  the labor-cost hidden logic, and every touched reader.
- **E2E** — three Playwright tests:
  1. A role without `view:pay_rates` receives no rate from PostgREST (the
     response body, not the rendered text).
  2. A staff member reads their own pay and PII; every coworker stays masked.
  3. A role without `view:pay_rates` reads the dashboard labor cost as
     "Unavailable".

## Known residual

The Income Statement fallback estimate for "Payroll Expense (unposted)"
understates for a caller without `view:pay_rates`, because a masked rate reads
as `$0`. The code flags this at the call site. A later PR fixes it.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
