### PR TITLE
fix(tips): read the real employees.name column in tip server earnings

### DIFF
--- a/src/hooks/tipServerEarningsSelect.ts
+++ b/src/hooks/tipServerEarningsSelect.ts
@@ -1,0 +1,7 @@
+// Column projection for the tip_server_earnings read query. The employees embed
+// must name only columns that exist on public.employees. That table has a single
+// `name` column (no first_name / last_name). A phantom column makes PostgREST
+// throw, so tests/unit/useTipServerEarnings.select.test.ts pins this against the
+// generated schema. This module stays dependency-free so the test can import it
+// without loading the Supabase client.
+export const TIP_SERVER_EARNINGS_SELECT = '*, employees(name)';

--- a/src/hooks/useTipServerEarnings.tsx
+++ b/src/hooks/useTipServerEarnings.tsx
@@ -1,6 +1,9 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
+import { TIP_SERVER_EARNINGS_SELECT } from '@/hooks/tipServerEarningsSelect';
+
+export { TIP_SERVER_EARNINGS_SELECT };
 
 export interface TipServerEarning {
   id: string;
@@ -31,13 +34,13 @@ export function useTipServerEarnings(splitId: string | null) {
 
       const { data, error } = await supabase
         .from('tip_server_earnings')
-        .select('*, employees(first_name, last_name)')
+        .select(TIP_SERVER_EARNINGS_SELECT)
         .eq('tip_split_id', splitId);
 
       if (error) throw error;
 
       type EarningRow = Omit<TipServerEarning, 'employee_name'> & {
-        employees: { first_name: string; last_name: string } | null;
+        employees: { name: string } | null;
       };
 
       return ((data ?? []) as unknown as EarningRow[]).map((row) => ({
@@ -48,9 +51,7 @@ export function useTipServerEarnings(splitId: string | null) {
         retained_amount: row.retained_amount,
         refunded_amount: row.refunded_amount,
         created_at: row.created_at,
-        employee_name: row.employees
-          ? `${row.employees.first_name} ${row.employees.last_name}`
-          : undefined,
+        employee_name: row.employees ? row.employees.name : undefined,
       }));
     },
     enabled: !!splitId,

--- a/tests/unit/useTipServerEarnings.select.test.ts
+++ b/tests/unit/useTipServerEarnings.select.test.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { TIP_SERVER_EARNINGS_SELECT } from '../../src/hooks/tipServerEarningsSelect';
+
+/**
+ * Read the real column names of public.employees from the generated Supabase
+ * types. This pins the embed against the actual schema, so a phantom column
+ * (like the old first_name / last_name) fails the test instead of the query.
+ */
+function employeesColumns(): Set<string> {
+  const typesPath = resolve(process.cwd(), 'src/integrations/supabase/types.ts');
+  const src = readFileSync(typesPath, 'utf8');
+
+  const tableStart = src.indexOf('\n      employees: {');
+  if (tableStart === -1) {
+    throw new Error('employees table not found in generated types');
+  }
+  const rowStart = src.indexOf('Row: {', tableStart);
+  const rowEnd = src.indexOf('\n        }', rowStart);
+  const rowBlock = src.slice(rowStart, rowEnd);
+
+  const columns = new Set<string>();
+  for (const match of rowBlock.matchAll(/^ {10}([a-z_][a-z0-9_]*):/gim)) {
+    columns.add(match[1]);
+  }
+  return columns;
+}
+
+/** Pull the column list out of the employees(...) embed in the select string. */
+function embedColumns(select: string): string[] {
+  const match = select.match(/employees\(([^)]*)\)/);
+  if (!match) return [];
+  return match[1]
+    .split(',')
+    .map((token) => token.trim().split(':').pop()!.trim())
+    .filter(Boolean);
+}
+
+describe('TIP_SERVER_EARNINGS_SELECT', () => {
+  it('parses the employees column snapshot from the generated types', () => {
+    const columns = employeesColumns();
+    // Guard against a broken parse that would make the checks below vacuous.
+    expect(columns.has('name')).toBe(true);
+    expect(columns.has('id')).toBe(true);
+    expect(columns.has('restaurant_id')).toBe(true);
+    // The bug: these columns never existed on employees.
+    expect(columns.has('first_name')).toBe(false);
+    expect(columns.has('last_name')).toBe(false);
+  });
+
+  it('embeds the employees relation', () => {
+    expect(TIP_SERVER_EARNINGS_SELECT).toMatch(/employees\(/);
+    expect(embedColumns(TIP_SERVER_EARNINGS_SELECT).length).toBeGreaterThan(0);
+  });
+
+  it('names only columns that exist on employees', () => {
+    const valid = employeesColumns();
+    for (const column of embedColumns(TIP_SERVER_EARNINGS_SELECT)) {
+      expect(valid.has(column)).toBe(true);
+    }
+  });
+
+  it('reads the single name column, not first_name / last_name', () => {
+    const embedded = embedColumns(TIP_SERVER_EARNINGS_SELECT);
+    expect(embedded).toContain('name');
+    expect(embedded).not.toContain('first_name');
+    expect(embedded).not.toContain('last_name');
+  });
+});

--- a/tests/unit/useTipServerEarnings.test.tsx
+++ b/tests/unit/useTipServerEarnings.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useTipServerEarnings, TIP_SERVER_EARNINGS_SELECT } from '@/hooks/useTipServerEarnings';
+import { supabase } from '@/integrations/supabase/client';
+import React, { type ReactNode } from 'react';
+
+// Mock the Supabase client. The read path is from().select().eq().
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: vi.fn(),
+  },
+}));
+
+// Mock the toast hook. The mutation path calls it, the read path does not.
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+describe('useTipServerEarnings', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    vi.clearAllMocks();
+  });
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  /** Build a from().select().eq() chain that resolves to the given result. */
+  function mockReadChain(result: { data: unknown; error: unknown }) {
+    const eq = vi.fn().mockResolvedValue(result);
+    const select = vi.fn().mockReturnValue({ eq });
+    vi.mocked(supabase.from).mockReturnValue({ select } as never);
+    return { select, eq };
+  }
+
+  it('reads the single name column, not first_name / last_name', () => {
+    expect(TIP_SERVER_EARNINGS_SELECT).toBe('*, employees(name)');
+  });
+
+  it('maps employee_name from the single employees.name column', async () => {
+    const { select, eq } = mockReadChain({
+      data: [
+        {
+          id: 'earn-1',
+          tip_split_id: 'split-123',
+          employee_id: 'emp-1',
+          earned_amount: 100,
+          retained_amount: 10,
+          refunded_amount: 0,
+          created_at: '2026-01-03T10:00:00Z',
+          employees: { name: 'Jane Doe' },
+        },
+      ],
+      error: null,
+    });
+
+    const { result } = renderHook(() => useTipServerEarnings('split-123'), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // The select must name only columns that exist on employees.
+    expect(select).toHaveBeenCalledWith('*, employees(name)');
+    expect(eq).toHaveBeenCalledWith('tip_split_id', 'split-123');
+    expect(result.current.earnings).toHaveLength(1);
+    expect(result.current.earnings[0]).toMatchObject({
+      id: 'earn-1',
+      employee_id: 'emp-1',
+      earned_amount: 100,
+      employee_name: 'Jane Doe',
+    });
+  });
+
+  it('leaves employee_name undefined when the employees embed is null', async () => {
+    mockReadChain({
+      data: [
+        {
+          id: 'earn-2',
+          tip_split_id: 'split-123',
+          employee_id: 'emp-2',
+          earned_amount: 50,
+          retained_amount: 5,
+          refunded_amount: 0,
+          created_at: '2026-01-03T11:00:00Z',
+          employees: null,
+        },
+      ],
+      error: null,
+    });
+
+    const { result } = renderHook(() => useTipServerEarnings('split-123'), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.earnings).toHaveLength(1);
+    expect(result.current.earnings[0].employee_name).toBeUndefined();
+  });
+
+  it('does not query when splitId is null', async () => {
+    const { result } = renderHook(() => useTipServerEarnings(null), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.earnings).toEqual([]);
+    expect(supabase.from).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a read error', async () => {
+    mockReadChain({ data: null, error: { message: 'boom' } });
+
+    const { result } = renderHook(() => useTipServerEarnings('split-123'), { wrapper });
+
+    await waitFor(() => expect(result.current.error).toBeTruthy());
+
+    expect(result.current.earnings).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

`src/hooks/useTipServerEarnings.tsx` read tip server earnings with this embed:

```
.select('*, employees(first_name, last_name)')
```

`public.employees` has no `first_name` and no `last_name` column. It has one
`name` column. PostgREST rejects a phantom column, so the query threw an error
each time a tip split detail loaded. The row type used an `as unknown as` cast,
so TypeScript did not catch the mismatch.

This bug is pre-existing on `main`. It is unrelated to the sensitive-data-flags
work.

## Fix

- Change the embed to `employees(name)`.
- Update the `EarningRow` type to the single `name` column.
- Update the `employee_name` mapping to read `employees.name`.

## Tests

- Move the select string into `src/hooks/tipServerEarningsSelect.ts`. The module
  stays dependency-free, so a test imports it without the Supabase client.
- `tests/unit/useTipServerEarnings.select.test.ts` pins the embed against the
  generated schema. It fails if the embed names a column that does not exist on
  `employees`.
- `tests/unit/useTipServerEarnings.test.tsx` mocks Supabase and checks the
  `employee_name` mapping, the null-embed case, the disabled query, and the
  error path.

## Verification

- `npx tsc --noEmit` — exit 0
- `npx eslint` on the four changed files — clean
- `npm run test` — 9050 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)