### PR TITLE
fix(permissions): gate sensitive-data UI to match the merged SQL enforcement

### DIFF
--- a/docs/superpowers/plans/2026-08-09-sensitive-data-ui-gating-plan.md
+++ b/docs/superpowers/plans/2026-08-09-sensitive-data-ui-gating-plan.md
@@ -1,0 +1,559 @@
+# Sensitive-data UI gating Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Gate the Employee dialog inputs and fix the Role editor copy so the UI matches the SQL enforcement that PR #727 shipped.
+
+**Architecture:** Client-side gating only. Reuse the existing `usePermissions()` hook and the live `disabled={!canSeePayRates}` pattern. Add one derived value `canSeePii`, disable the three PII inputs and the four pay-schedule controls, and rewrite one RoleEditor paragraph plus its code comment. No SQL, no masked view, no column REVOKE.
+
+**Tech Stack:** React 18 + TypeScript + Vite, shadcn/ui (Radix `Select`, `Checkbox`, `Input`), Vitest + React Testing Library.
+
+## Global Constraints
+
+- Client-side gating only. Do NOT change SQL, the masked view `employees_secure`, or the column REVOKE.
+- ASD-STE100 for all prose and copy (chat, plan, commits, code comments).
+- Never commit to `main`. Work on branch `fix/sensitive-data-ui-gating` in worktree `.claude/worktrees/sensitive-data-ui-gating`.
+- Stage explicit paths with `git add <path>`. Never `git add -A`, `git add .`, or `git commit -a`.
+- Never stage `progress.md` (gitignored).
+- Commit messages end with: `Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>`.
+- Out of scope: the IncomeStatement "Payroll Expense (unposted)" residual (separate later PR).
+- Design doc: `docs/superpowers/specs/2026-08-09-sensitive-data-ui-gating-design.md`.
+
+---
+
+### Task 1: RoleEditor copy and comment (Fix 1)
+
+**Files:**
+- Modify: `src/components/roles/RoleEditor.tsx:656-665`
+- Test: `tests/unit/RoleEditor.test.tsx`
+
+**Interfaces:**
+- Consumes: nothing new. The paragraph is static text inside the "Sensitive data" band, above the `SENSITIVE_FLAGS.map(...)` (`src/components/roles/RoleEditor.tsx:667`). It renders for any role, including a blank draft (`role={null}`).
+- Produces: new user-visible copy. Later tasks do not depend on it.
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test inside the `describe('RoleEditor', ...)` block in `tests/unit/RoleEditor.test.tsx` (for example, after the test at line 296 that counts the three switches):
+
+```tsx
+it('states which sensitive-data flags are enforced and which is not', () => {
+  render(<RoleEditor {...editorProps} restaurantId="rest-1" role={null} onBack={vi.fn()} />, { wrapper });
+
+  // The enforced flags are named as enforced.
+  expect(screen.getByText(/pay rates and contact details now gate real reads/i)).toBeInTheDocument();
+  // The deferred flag is named as not yet in force.
+  expect(screen.getByText(/costs switch has no effect yet/i)).toBeInTheDocument();
+
+  // The stale "not enforced yet" framing is gone.
+  expect(screen.queryByText(/not enforced yet/i)).not.toBeInTheDocument();
+  expect(screen.queryByText(/per-field gating ships/i)).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run tests/unit/RoleEditor.test.tsx -t "states which sensitive-data flags"`
+Expected: FAIL. The old paragraph still says "not enforced yet" and "per-field gating ships", so the two `queryByText(...).not.toBeInTheDocument()` assertions fail and the two positive `getByText` assertions throw "Unable to find an element".
+
+- [ ] **Step 3: Rewrite the comment and the paragraph**
+
+In `src/components/roles/RoleEditor.tsx`, replace the comment at lines 656-661:
+
+```tsx
+                {/* State plainly what these switches do now. Pay rates and
+                    contact details gate real reads. PR #727 enforces them
+                    through employees_secure and the column REVOKE. A role
+                    without the switch cannot see those fields. view:costs is
+                    not gated yet. No screen and no RLS policy reads it, so its
+                    switch changes nothing. The copy below keeps that caveat. */}
+```
+
+Replace the paragraph at lines 662-665:
+
+```tsx
+                <p className="text-[12px] text-muted-foreground pb-2">
+                  Pay rates and contact details now gate real reads. A role without the switch
+                  cannot see those fields. Item costs still follow area access. The costs switch
+                  has no effect yet.
+                </p>
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run tests/unit/RoleEditor.test.tsx -t "states which sensitive-data flags"`
+Expected: PASS.
+
+- [ ] **Step 5: Run the whole RoleEditor suite to confirm no regression**
+
+Run: `npx vitest run tests/unit/RoleEditor.test.tsx`
+Expected: PASS (all tests, including the pre-existing copy assertions).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/roles/RoleEditor.tsx tests/unit/RoleEditor.test.tsx
+git commit -m "$(cat <<'EOF'
+fix(roles): correct the sensitive-data copy for the enforced flags
+
+PR #727 made view:pay_rates and view:employee_pii real in SQL. The
+RoleEditor paragraph still said the flags are "not enforced yet". State
+the split: pay rates and contact details gate real reads now; item costs
+still follow area access.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Gate the PII inputs in EmployeeDialog (Fix 2)
+
+**Files:**
+- Modify: `src/components/EmployeeDialog.tsx:119` (add `canSeePii`), `:1248` (email), `:1261` (phone), `:1358` (dateOfBirth)
+- Create: `tests/unit/EmployeeDialog.sensitiveGating.test.tsx`
+- Modify: `tests/unit/EmployeeDialog.maskedDob.test.tsx` (make the two premises honest under the new gate)
+
+**Interfaces:**
+- Consumes: `usePermissions()` → `{ hasCapability, isResolved }`, already imported (`src/components/EmployeeDialog.tsx:12`) and destructured (`:118`). Existing derived value `canSeePayRates` (`:119`).
+- Produces: `const canSeePii = isPermissionsResolved && hasCapability('view:employee_pii');`. Used by Task 2 only (the PII inputs). Task 3 uses the pre-existing `canSeePayRates`.
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `tests/unit/EmployeeDialog.sensitiveGating.test.tsx`:
+
+```tsx
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { EmployeeDialog } from '@/components/EmployeeDialog';
+
+// Per-test control of the capability check: some tests grant view:employee_pii,
+// some grant view:pay_rates, some grant nothing. vi.hoisted lets the factory
+// below close over one shared mock function.
+const { mockHasCapability } = vi.hoisted(() => ({ mockHasCapability: vi.fn() }));
+
+vi.mock('@/hooks/useEmployees', () => ({
+  useCreateEmployee: () => ({ mutateAsync: vi.fn().mockResolvedValue({ id: 'emp-1' }), isPending: false }),
+  useUpdateEmployee: () => ({ mutateAsync: vi.fn().mockResolvedValue({ id: 'emp-1' }), isPending: false }),
+}));
+
+vi.mock('@/hooks/useBulkSetAvailability', () => ({
+  useBulkSetAvailability: () => ({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false }),
+}));
+
+vi.mock('@/hooks/useShiftTemplates', () => {
+  const STABLE_TEMPLATES: never[] = [];
+  return {
+    useShiftTemplates: () => ({
+      templates: STABLE_TEMPLATES,
+      loading: false,
+      error: null,
+      createTemplate: () => Promise.resolve(),
+      updateTemplate: () => Promise.resolve(),
+      deleteTemplate: () => Promise.resolve(),
+    }),
+  };
+});
+
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => ({ selectedRestaurant: { restaurant: { id: 'r1', timezone: 'UTC' } } }),
+}));
+
+// EmployeeAppAccessRow (mounted by every EmployeeDialog render) calls useAuth,
+// which throws without an AuthProvider by design. Nothing here asserts on app
+// access — this just keeps the dialog mountable.
+vi.mock('@/hooks/useAuth', () => ({ useAuth: () => ({ user: { id: 'caller-1' } }) }));
+
+vi.mock('@/hooks/usePermissions', () => ({
+  usePermissions: () => ({ hasCapability: mockHasCapability, isResolved: true }),
+}));
+
+vi.mock('@/integrations/supabase/client', () => {
+  // Recursive fluent-builder mock — must be `any` because the chain can call
+  // any subset of methods in any order; a typed interface would require an
+  // exhaustive intersection of all Supabase builder return types.
+  function makeChain(): any { // eslint-disable-line @typescript-eslint/no-explicit-any
+    const chain: any = {}; // eslint-disable-line @typescript-eslint/no-explicit-any
+    chain.select = () => makeChain();
+    chain.eq = () => makeChain();
+    chain.not = () => makeChain();
+    chain.order = () => Promise.resolve({ data: [], error: null });
+    chain.is = () => makeChain();
+    chain.single = () => Promise.resolve({ data: null, error: null });
+    chain.upsert = () => Promise.resolve({ data: null, error: null });
+    chain.insert = () => makeChain();
+    chain.update = () => makeChain();
+    chain.then = (resolve: (v: { data: any[]; error: null }) => any) => // eslint-disable-line @typescript-eslint/no-explicit-any
+      Promise.resolve({ data: [], error: null }).then(resolve);
+    chain.catch = () => Promise.resolve({ data: [], error: null });
+    return chain;
+  }
+  return {
+    supabase: {
+      functions: { invoke: () => Promise.resolve({ data: null, error: null }) },
+      from: () => makeChain(),
+    },
+  };
+});
+
+const BASE_EMPLOYEE = {
+  id: 'emp-1',
+  restaurant_id: 'r1',
+  name: 'Alex Valdez',
+  position: 'Server',
+  status: 'active' as const,
+  is_active: true,
+  employment_type: 'full_time' as const,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+// One fixture per compensation type — the pay-schedule controls each render
+// only under their type: salary → Pay Period + Allocate Daily; contractor →
+// Payment Interval; daily_rate → Standard Work Days.
+const HOURLY_EMPLOYEE = { ...BASE_EMPLOYEE, compensation_type: 'hourly' as const, hourly_rate: 2000 };
+const SALARY_EMPLOYEE = { ...BASE_EMPLOYEE, compensation_type: 'salary' as const };
+const CONTRACTOR_EMPLOYEE = { ...BASE_EMPLOYEE, compensation_type: 'contractor' as const };
+const DAILY_RATE_EMPLOYEE = { ...BASE_EMPLOYEE, compensation_type: 'daily_rate' as const };
+
+function renderEdit(employee: typeof BASE_EMPLOYEE) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false, staleTime: Infinity } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      {/* cast: test fixture omits optional Employee fields */}
+      <EmployeeDialog open onOpenChange={vi.fn()} restaurantId="r1" employee={employee as any} /> {/* eslint-disable-line @typescript-eslint/no-explicit-any */}
+    </QueryClientProvider>,
+  );
+}
+
+describe('EmployeeDialog — sensitive-data input gating', () => {
+  beforeEach(() => {
+    mockHasCapability.mockReset();
+  });
+
+  it('disables email, phone, and date of birth when the caller lacks view:employee_pii', () => {
+    mockHasCapability.mockReturnValue(false);
+    renderEdit(HOURLY_EMPLOYEE);
+
+    expect(screen.getByLabelText(/employee email/i)).toBeDisabled();
+    expect(screen.getByLabelText(/employee phone number/i)).toBeDisabled();
+    expect(screen.getByLabelText(/date of birth/i)).toBeDisabled();
+  });
+
+  it('enables email, phone, and date of birth when the caller holds view:employee_pii', () => {
+    mockHasCapability.mockImplementation((c: string) => c === 'view:employee_pii');
+    renderEdit(HOURLY_EMPLOYEE);
+
+    expect(screen.getByLabelText(/employee email/i)).not.toBeDisabled();
+    expect(screen.getByLabelText(/employee phone number/i)).not.toBeDisabled();
+    expect(screen.getByLabelText(/date of birth/i)).not.toBeDisabled();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run tests/unit/EmployeeDialog.sensitiveGating.test.tsx -t "disables email"`
+Expected: FAIL. The three inputs have no `disabled` prop yet, so `toBeDisabled()` fails.
+
+- [ ] **Step 3: Add the `canSeePii` derived value**
+
+In `src/components/EmployeeDialog.tsx`, after the `canSeePayRates` line (`:119`), add:
+
+```tsx
+  // Contact details (email, phone, date of birth) gate on view:employee_pii,
+  // the same way pay amounts gate on view:pay_rates. The write path already
+  // strips these keys for a caller without the flag, so this gate makes the
+  // disabled state honest and stops a masked blank box from reading as a clear.
+  const canSeePii = isPermissionsResolved && hasCapability('view:employee_pii');
+```
+
+- [ ] **Step 4: Gate the three PII inputs**
+
+In `src/components/EmployeeDialog.tsx`, add `disabled={!canSeePii}` to each input.
+
+Email (`:1247-1255`):
+
+```tsx
+                  <Input
+                    id="email"
+                    type="email"
+                    value={email}
+                    onChange={(e) => handleEmailChange(e.target.value)}
+                    placeholder="john@example.com"
+                    aria-label="Employee email"
+                    disabled={!canSeePii}
+                    className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
+                  />
+```
+
+Phone (`:1260-1268`):
+
+```tsx
+                  <Input
+                    id="phone"
+                    type="tel"
+                    value={phone}
+                    onChange={(e) => setPhone(e.target.value)}
+                    placeholder="(555) 123-4567"
+                    aria-label="Employee phone number"
+                    disabled={!canSeePii}
+                    className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
+                  />
+```
+
+Date of birth (`:1357-1364`):
+
+```tsx
+                  <Input
+                    id="dateOfBirth"
+                    type="date"
+                    value={dateOfBirth}
+                    onChange={(e) => setDateOfBirth(e.target.value)}
+                    aria-label="Date of birth"
+                    disabled={!canSeePii}
+                    className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
+                  />
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npx vitest run tests/unit/EmployeeDialog.sensitiveGating.test.tsx`
+Expected: PASS (both PII tests).
+
+- [ ] **Step 6: Fix the two premises in `EmployeeDialog.maskedDob.test.tsx`**
+
+Fix 2 disables the date-of-birth input for a caller without `view:employee_pii`. The two tests in `tests/unit/EmployeeDialog.maskedDob.test.tsx` have opposite permission premises but no `usePermissions` mock, so both fall through to a null-role branch and the second test only stays green because `fireEvent.change` bypasses `disabled`. Make each premise honest and assert the gate.
+
+Add the hoisted mock. At the top of the file, after the imports (line 5) and before `const updateMock` (line 12), insert:
+
+```tsx
+const { mockHasCapability } = vi.hoisted(() => ({ mockHasCapability: vi.fn() }));
+```
+
+Add the `usePermissions` mock next to the other `vi.mock(...)` calls (for example after the `useAuth` mock at line 47):
+
+```tsx
+vi.mock('@/hooks/usePermissions', () => ({
+  usePermissions: () => ({ hasCapability: mockHasCapability, isResolved: true }),
+}));
+```
+
+In test 1 (`never sends date_of_birth: null for a masked (blank) date box on save`, line 119), set the no-PII premise and assert the box is disabled. Replace the body from `renderEdit();` (line 120) down to the `expect(dobInput.value).toBe('');` line (line 124) with:
+
+```tsx
+    // A masked (no-PII) caller: the date box is gated and blank.
+    mockHasCapability.mockImplementation((c: string) => c !== 'view:employee_pii');
+    renderEdit();
+
+    const dobInput = screen.getByLabelText(/date of birth/i) as HTMLInputElement;
+    expect(dobInput.value).toBe('');
+    expect(dobInput).toBeDisabled();
+```
+
+In test 2 (`sends date_of_birth: null when a caller who can see the date clears it`, line 138), set the has-PII premise and assert the box is enabled. Replace the body from `renderEdit(VISIBLE_DOB_EMPLOYEE);` (line 139) down to the `expect(dobInput.value).toBe('2000-01-01');` line (line 142) with:
+
+```tsx
+    // A caller who holds view:employee_pii: the date box is editable and shows
+    // the real date of birth.
+    mockHasCapability.mockReturnValue(true);
+    renderEdit(VISIBLE_DOB_EMPLOYEE);
+
+    const dobInput = screen.getByLabelText(/date of birth/i) as HTMLInputElement;
+    expect(dobInput.value).toBe('2000-01-01');
+    expect(dobInput).not.toBeDisabled();
+```
+
+- [ ] **Step 7: Run both EmployeeDialog suites to verify they pass**
+
+Run: `npx vitest run tests/unit/EmployeeDialog.maskedDob.test.tsx tests/unit/EmployeeDialog.sensitiveGating.test.tsx`
+Expected: PASS (four tests total).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/EmployeeDialog.tsx tests/unit/EmployeeDialog.sensitiveGating.test.tsx tests/unit/EmployeeDialog.maskedDob.test.tsx
+git commit -m "$(cat <<'EOF'
+fix(employees): gate the PII inputs on view:employee_pii
+
+Disable email, phone, and date of birth for a caller without
+view:employee_pii. The write path already strips these keys, so the gate
+makes the disabled state honest and stops a masked blank box from reading
+as an intent to clear. Also fix the two maskedDob test premises, which the
+new gate would otherwise make misleading.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Gate the pay-schedule controls in EmployeeDialog (Fix 3)
+
+**Files:**
+- Modify: `src/components/EmployeeDialog.tsx:1038` (Pay Period), `:1055` (Allocate Daily), `:1120` (Payment Interval), `:1186` (Standard Work Days)
+- Test: `tests/unit/EmployeeDialog.sensitiveGating.test.tsx` (extend)
+
+**Interfaces:**
+- Consumes: the pre-existing `canSeePayRates` (`src/components/EmployeeDialog.tsx:119`). No new value.
+- Produces: nothing new. These are the last four unguarded pay controls.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append these tests inside the `describe('EmployeeDialog — sensitive-data input gating', ...)` block in `tests/unit/EmployeeDialog.sensitiveGating.test.tsx` (after the two PII tests, before the closing `});`):
+
+```tsx
+  it('disables the salary pay-schedule controls when the caller lacks view:pay_rates', () => {
+    mockHasCapability.mockReturnValue(false);
+    renderEdit(SALARY_EMPLOYEE);
+
+    expect(screen.getByRole('combobox', { name: /pay period/i })).toBeDisabled();
+    expect(screen.getByRole('checkbox', { name: /allocate to daily/i })).toBeDisabled();
+  });
+
+  it('disables the contractor payment interval when the caller lacks view:pay_rates', () => {
+    mockHasCapability.mockReturnValue(false);
+    renderEdit(CONTRACTOR_EMPLOYEE);
+
+    expect(screen.getByRole('combobox', { name: /payment interval/i })).toBeDisabled();
+  });
+
+  it('disables the daily-rate standard work days when the caller lacks view:pay_rates', () => {
+    mockHasCapability.mockReturnValue(false);
+    renderEdit(DAILY_RATE_EMPLOYEE);
+
+    expect(screen.getByRole('combobox', { name: /standard work days/i })).toBeDisabled();
+  });
+
+  it('enables the salary pay-schedule controls when the caller holds view:pay_rates', () => {
+    mockHasCapability.mockImplementation((c: string) => c === 'view:pay_rates');
+    renderEdit(SALARY_EMPLOYEE);
+
+    expect(screen.getByRole('combobox', { name: /pay period/i })).not.toBeDisabled();
+    expect(screen.getByRole('checkbox', { name: /allocate to daily/i })).not.toBeDisabled();
+  });
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run tests/unit/EmployeeDialog.sensitiveGating.test.tsx -t "pay-schedule"`
+Expected: FAIL for the three "disables ..." tests. The four controls have no `disabled` prop yet, so `toBeDisabled()` fails. (The "enables ..." test may pass early since the controls are enabled by default — that is expected; it locks the enabled path.)
+
+- [ ] **Step 3: Gate the four pay-schedule controls**
+
+In `src/components/EmployeeDialog.tsx`, add `disabled={!canSeePayRates}` to each control.
+
+Pay Period `Select` root (`:1038-1041`):
+
+```tsx
+                    <Select
+                      value={payPeriodType}
+                      onValueChange={(value) => setPayPeriodType(value as PayPeriodType)}
+                      disabled={!canSeePayRates}
+                    >
+```
+
+Allocate Daily `Checkbox` (`:1055-1060`):
+
+```tsx
+                      <Checkbox
+                        id="allocateDaily"
+                        checked={allocateDaily}
+                        onCheckedChange={(checked) => setAllocateDaily(checked === true)}
+                        aria-label="Allocate to Daily P&L"
+                        disabled={!canSeePayRates}
+                      />
+```
+
+Payment Interval `Select` root (`:1120-1123`):
+
+```tsx
+                    <Select
+                      value={contractorPaymentInterval}
+                      onValueChange={(value) => setContractorPaymentInterval(value as ContractorPaymentInterval)}
+                      disabled={!canSeePayRates}
+                    >
+```
+
+Standard Work Days `Select` root (`:1186-1189`):
+
+```tsx
+                    <Select
+                      value={dailyRateStandardDays}
+                      onValueChange={setDailyRateStandardDays}
+                      disabled={!canSeePayRates}
+                    >
+```
+
+- [ ] **Step 4: Run the full sensitiveGating suite to verify it passes**
+
+Run: `npx vitest run tests/unit/EmployeeDialog.sensitiveGating.test.tsx`
+Expected: PASS (six tests: two PII, four pay-schedule).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/EmployeeDialog.tsx tests/unit/EmployeeDialog.sensitiveGating.test.tsx
+git commit -m "$(cat <<'EOF'
+fix(employees): gate the pay-schedule controls on view:pay_rates
+
+Disable Pay Period, Allocate to Daily, Payment Interval, and Standard Work
+Days for a caller without view:pay_rates. These set pay cadence next to the
+already-gated pay amounts; a role without pay-rate access must not change
+pay configuration.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Full verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the three touched suites together**
+
+Run: `npx vitest run tests/unit/RoleEditor.test.tsx tests/unit/EmployeeDialog.sensitiveGating.test.tsx tests/unit/EmployeeDialog.maskedDob.test.tsx tests/unit/EmployeeDialog.maskedRate.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 2: Typecheck**
+
+Run: `npm run typecheck`
+Expected: no errors.
+
+- [ ] **Step 3: Lint the changed files**
+
+Run: `npx eslint src/components/EmployeeDialog.tsx src/components/roles/RoleEditor.tsx tests/unit/EmployeeDialog.sensitiveGating.test.tsx tests/unit/EmployeeDialog.maskedDob.test.tsx`
+Expected: no errors.
+
+- [ ] **Step 4: Run the whole unit suite once**
+
+Run: `npm run test`
+Expected: PASS.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Fix 1 (RoleEditor copy + comment) → Task 1.
+- Fix 2 (PII inputs gated + `canSeePii`, email gated per the approved decision) → Task 2.
+- Fix 3 (four pay-schedule controls gated) → Task 3.
+- Test — new unit file `EmployeeDialog.sensitiveGating.test.tsx` → Task 2 (create) + Task 3 (extend).
+- Test — the maskedDob per-test premise fix → Task 2, Step 6.
+- No self-row exception → mirrored: `canSeePii` copies `canSeePayRates`, which has none.
+- E2E — design justified skipping; not a task. No route, RPC, or record-authorization seam changes.
+- Out of scope (IncomeStatement residual) → not a task. Correct.
+
+**Placeholder scan:** none. Every code step shows the exact code; every run step shows the exact command and expected result.
+
+**Type consistency:** `canSeePii` and `canSeePayRates` are `boolean`. `mockHasCapability` is `vi.fn()` returning `boolean`, called as `hasCapability(cap: string)`. `disabled` takes `boolean`. Radix `Select` root and `Checkbox` both accept `disabled` (verified in Phase 2.5). Selectors match the live `aria-label` values: "Employee email", "Employee phone number", "Date of birth", "Pay period", "Allocate to Daily P&L", "Payment interval", "Standard work days per week".

--- a/docs/superpowers/specs/2026-08-09-sensitive-data-ui-gating-design.md
+++ b/docs/superpowers/specs/2026-08-09-sensitive-data-ui-gating-design.md
@@ -138,7 +138,13 @@ Reasons:
 - A blank masked email that stays editable invites an accidental clear. Disable
   removes that trap.
 - Every builtin role that can reach this dialog holds `view:employee_pii`, so
-  standard invite flows keep working. Only a custom role set to manage
+  standard invite flows keep working. Only three builtin roles hold
+  `manage:employees`: `owner` (`src/lib/permissions/definitions.ts:75`),
+  `manager` (`src/lib/permissions/definitions.ts:139`), and
+  `operations_manager` (`src/lib/permissions/definitions.ts:186`). All three
+  also hold `view:employee_pii` (`src/lib/permissions/definitions.ts:88`,
+  `src/lib/permissions/definitions.ts:150`,
+  `src/lib/permissions/definitions.ts:194`). Only a custom role set to manage
   employees without the PII flag loses invite-by-typed-email — and that role
   cannot see any contact details anyway, so the block is consistent.
 
@@ -197,6 +203,36 @@ RoleEditor copy: a light assertion that the paragraph names the enforced flags
 and the deferred flag, if a RoleEditor test harness already exists; otherwise
 the copy is static text and the unit gate above is the primary coverage.
 
+### Fix an existing test that Fix 2 makes misleading
+
+`tests/unit/EmployeeDialog.maskedDob.test.tsx` has two tests with opposite
+permission premises, but no `usePermissions` mock. The real hook then falls
+through to a null-role branch, so `hasCapability` returns `false` for both
+tests. Test 1 (`tests/unit/EmployeeDialog.maskedDob.test.tsx:119`,
+`MASKED_EMPLOYEE`) expects a caller without `view:employee_pii`. Test 2
+(`tests/unit/EmployeeDialog.maskedDob.test.tsx:138`, `VISIBLE_DOB_EMPLOYEE`)
+expects a caller who holds `view:employee_pii` ("a caller who CAN see the
+date"). After Fix 2, `canSeePii` is `false` for both, so the date_of_birth
+input disables in test 2 too, and contradicts its own premise. The test still
+passes only because `fireEvent.change` writes the DOM value directly and
+bypasses the native `disabled` gate.
+
+A single file-level granting mock (the pattern at
+`tests/unit/EmployeeDialog.maskedRate.test.tsx:54`) fixes test 2 but falsifies
+test 1. So control `hasCapability` per test with `vi.hoisted`:
+
+```ts
+const { mockHasCapability } = vi.hoisted(() => ({ mockHasCapability: vi.fn() }));
+vi.mock('@/hooks/usePermissions', () => ({
+  usePermissions: () => ({ hasCapability: mockHasCapability, isResolved: true }),
+}));
+```
+
+- Test 1 (masked, no PII): `mockHasCapability.mockImplementation((c) => c !== 'view:employee_pii')`.
+- Test 2 (visible DOB): `mockHasCapability.mockReturnValue(true)`.
+
+This keeps both premises honest and keeps both assertions green.
+
 ### E2E
 
 Extend `tests/e2e/sensitive-data-flags.spec.ts` only if it already opens
@@ -219,3 +255,6 @@ already flagged at its call site.
   invite-by-email in this dialog. Accepted — that role has no PII access.
 - No new `enforced` field on `SENSITIVE_FLAGS`. The shared paragraph states the
   split in prose. Keeps the change to copy, not data.
+- Silent disable, no `title` tooltip on a disabled control. This matches the
+  five pay-amount controls already live (`src/components/EmployeeDialog.tsx:907`
+  and siblings). A hint is optional polish, not part of this PR.

--- a/docs/superpowers/specs/2026-08-09-sensitive-data-ui-gating-design.md
+++ b/docs/superpowers/specs/2026-08-09-sensitive-data-ui-gating-design.md
@@ -1,0 +1,221 @@
+# Sensitive-data UI gating — design
+
+**Date:** 2026-08-09
+**Branch:** `fix/sensitive-data-ui-gating` (off `main` f0c5f0db)
+**Type:** Follow-up debt from PR #727 (merged). Client-side gating only.
+
+## Goal
+
+Close three UI gaps that the Codex adversarial reviewer flagged on merged
+`main`. PR #727 made `view:pay_rates` and `view:employee_pii` real in SQL. The
+UI did not follow. Fix the copy and the input gating so the screen matches the
+enforcement.
+
+## Scope
+
+One PR. Three fixes. No SQL, no masked view, no column REVOKE change.
+
+`view:costs` stays deferred. No screen and no policy reads it yet.
+
+## Background — what is already enforced
+
+- The masked view `employees_secure` and the column REVOKE hide the eight
+  sensitive columns from a caller without the flag (PR #727, merged).
+- The two mutation hooks strip masked keys before the write, so a masked NULL
+  cannot overwrite a real value. Create path: `src/hooks/useEmployees.tsx:94`
+  → `src/hooks/useEmployees.tsx:101`. Update path:
+  `src/hooks/useEmployees.tsx:135` → `src/hooks/useEmployees.tsx:142`. Both
+  call `assertPermissionsResolved(isResolved)` first
+  (`src/hooks/useEmployees.tsx:90`, `src/hooks/useEmployees.tsx:133`).
+- The masked field lists are `PAY_RATE_FIELDS` (5 columns,
+  `src/lib/employeeMaskedFields.ts:16`) and `EMPLOYEE_PII_FIELDS`
+  (`email`, `phone`, `date_of_birth`, `src/lib/employeeMaskedFields.ts:25`).
+
+So a caller without `view:employee_pii` already writes nothing to the three PII
+columns, on create and on update. The PII inputs are non-functional for that
+caller today. The gating below makes that state honest, and stops a masked
+blank box from reading as an intent to clear.
+
+## The three flags render together
+
+`SENSITIVE_FLAGS` (`src/lib/permissions/areas.ts:87`) holds all three:
+
+- `view:costs` → "Item costs & margins" (`src/lib/permissions/areas.ts:94`)
+- `view:pay_rates` → "Employee pay rates" (`src/lib/permissions/areas.ts:100`)
+- `view:employee_pii` → "Contact details" (`src/lib/permissions/areas.ts:106`)
+
+`RoleEditor` maps over the array (`src/components/roles/RoleEditor.tsx:667`) and
+renders one shared paragraph above all three rows
+(`src/components/roles/RoleEditor.tsx:662`). That paragraph, and the code
+comment above it (`src/components/roles/RoleEditor.tsx:656`), now describe a
+state that is only true for one of the three flags.
+
+---
+
+## Fix 1 — RoleEditor copy and comment
+
+### Current state (false for two of three flags)
+
+The paragraph at `src/components/roles/RoleEditor.tsx:662`:
+
+> "Recorded on the role, but not enforced yet — these fields still follow area
+> access everywhere in the app. Set them for the role you want; they take
+> effect when per-field gating ships."
+
+The comment at `src/components/roles/RoleEditor.tsx:656` says "no screen and no
+RLS policy reads them yet, so leaving one off hides nothing."
+
+Both are now false for `view:pay_rates` and `view:employee_pii`.
+
+### Change
+
+Rewrite the shared paragraph to tell the enforced flags apart from the deferred
+one. Proposed copy (STE-aligned, final wording set in Phase 4):
+
+> "Employee pay rates and contact details are enforced. A role without the
+> switch cannot read those fields. Item costs and margins still follow area
+> access; that switch has no effect yet."
+
+Rewrite the comment to state the same split: two flags gate real reads and
+writes now; `view:costs` is not gated yet.
+
+No data change. No new prop. Copy and comment only.
+
+---
+
+## Fix 2 — Gate the PII inputs in EmployeeDialog
+
+### Current state
+
+`EmployeeDialog` derives one capability today
+(`src/components/EmployeeDialog.tsx:119`):
+
+```ts
+const canSeePayRates = isPermissionsResolved && hasCapability('view:pay_rates');
+```
+
+`usePermissions` is already imported (`src/components/EmployeeDialog.tsx:12`) and
+destructured (`src/components/EmployeeDialog.tsx:118`). The PII inputs are not
+gated:
+
+- email `<Input id="email">` (`src/components/EmployeeDialog.tsx:1248`)
+- phone `<Input id="phone">` (`src/components/EmployeeDialog.tsx:1261`)
+- dateOfBirth `<Input id="dateOfBirth">` (`src/components/EmployeeDialog.tsx:1358`)
+
+### Change
+
+Add next to line 119:
+
+```ts
+const canSeePii = isPermissionsResolved && hasCapability('view:employee_pii');
+```
+
+Add `disabled={!canSeePii}` to the three inputs above. Add a short comment,
+same shape as the pay-gate note.
+
+### No self-row exception
+
+The merged pay gate at `src/components/EmployeeDialog.tsx:119` does not
+special-case the current user. A grep of the file finds no `user_id`, `self`,
+or `own`-based gate on capability. `EmployeeDialog` is the admin edit surface,
+not the self-edit surface. So the PII gate mirrors the pay gate with no self
+exception, and the two stay consistent.
+
+### The email input is dual-purpose — decision
+
+Email is a PII field and the invite key. `findMemberByEmail`
+(`src/components/EmployeeDialog.tsx:121`) reads it, and the link RPC uses the
+match (`src/components/EmployeeDialog.tsx:495`, `p_user_id` at
+`src/components/EmployeeDialog.tsx:499`).
+
+**Decision (approved): gate email like phone and date_of_birth.**
+
+Reasons:
+
+- Email is in `EMPLOYEE_PII_FIELDS` (`src/lib/employeeMaskedFields.ts:25`). The
+  write path strips it for a no-PII caller on create and update, so the input
+  is already non-functional for that caller.
+- A blank masked email that stays editable invites an accidental clear. Disable
+  removes that trap.
+- Every builtin role that can reach this dialog holds `view:employee_pii`, so
+  standard invite flows keep working. Only a custom role set to manage
+  employees without the PII flag loses invite-by-typed-email — and that role
+  cannot see any contact details anyway, so the block is consistent.
+
+Trade-off accepted: a custom no-PII role loses invite-by-email in this dialog.
+
+---
+
+## Fix 3 — Gate the pay-schedule controls in EmployeeDialog
+
+### Current state
+
+Pay-amount controls already carry `disabled={!canSeePayRates}`
+(`src/components/EmployeeDialog.tsx:907`,
+`src/components/EmployeeDialog.tsx:947`,
+`src/components/EmployeeDialog.tsx:1015`,
+`src/components/EmployeeDialog.tsx:1112`,
+`src/components/EmployeeDialog.tsx:1175`). The pay-schedule controls do not:
+
+- Pay Period `<Select value={payPeriodType}>`
+  (`src/components/EmployeeDialog.tsx:1039`)
+- Allocate Daily `<Checkbox id="allocateDaily">`
+  (`src/components/EmployeeDialog.tsx:1056`)
+- Payment Interval `<Select value={contractorPaymentInterval}>`
+  (`src/components/EmployeeDialog.tsx:1121`)
+- Standard Work Days `<Select value={dailyRateStandardDays}>`
+  (`src/components/EmployeeDialog.tsx:1187`)
+
+### Change
+
+Add `disabled={!canSeePayRates}` to the four controls. The shadcn `Select` root
+and `Checkbox` both accept `disabled`.
+
+These controls set pay cadence, not a masked pay amount. Gate them for the same
+reason the amounts are gated: a role without pay-rate access must not change pay
+configuration.
+
+---
+
+## Testing
+
+### Unit (primary coverage)
+
+New file `tests/unit/EmployeeDialog.sensitiveGating.test.tsx`. Mock
+`usePermissions`, `useAuth`, `useRestaurantContext`, and the mutation hooks
+(`EmployeeDialog` mounts `EmployeeAppAccessRow`, which calls `useAuth` —
+`memory/lessons.md` line 2318). Assert:
+
+1. Without `view:employee_pii`: email, phone, dateOfBirth inputs are `disabled`.
+2. With `view:employee_pii`: the three inputs are enabled.
+3. Without `view:pay_rates`: the four pay-schedule controls are `disabled`.
+   Drive the compensation type through the `employee` prop so each control
+   renders (`salary` shows Pay Period + Allocate Daily, `contractor` shows
+   Payment Interval, `daily_rate` shows Standard Work Days).
+
+RoleEditor copy: a light assertion that the paragraph names the enforced flags
+and the deferred flag, if a RoleEditor test harness already exists; otherwise
+the copy is static text and the unit gate above is the primary coverage.
+
+### E2E
+
+Extend `tests/e2e/sensitive-data-flags.spec.ts` only if it already opens
+`EmployeeDialog` in a no-PII role session. Otherwise a justified exception: the
+SQL boundary (masked reads plus write strip) is already E2E-covered by that
+spec, and the unit tests assert the disabled state deterministically. This PR
+adds no route, no RPC, and no new record-authorization seam — it disables
+inputs on an existing dialog.
+
+---
+
+## Out of scope
+
+The IncomeStatement "Payroll Expense (unposted)" residual. Separate later PR,
+already flagged at its call site.
+
+## Decided trade-offs
+
+- Gate email with the other PII fields. A custom no-PII role loses
+  invite-by-email in this dialog. Accepted — that role has no PII access.
+- No new `enforced` field on `SENSITIVE_FLAGS`. The shared paragraph states the
+  split in prose. Keeps the change to copy, not data.

--- a/src/components/EmployeeDialog.tsx
+++ b/src/components/EmployeeDialog.tsx
@@ -117,6 +117,11 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
   // (which then silently strips it — see src/lib/employeeMaskedFields.ts).
   const { hasCapability, isResolved: isPermissionsResolved } = usePermissions();
   const canSeePayRates = isPermissionsResolved && hasCapability('view:pay_rates');
+  // Contact details (email, phone, date of birth) gate on view:employee_pii,
+  // the same way pay amounts gate on view:pay_rates. The write path already
+  // strips these keys for a caller without the flag, so this gate makes the
+  // disabled state honest and stops a masked blank box from reading as a clear.
+  const canSeePii = isPermissionsResolved && hasCapability('view:employee_pii');
   // null while loading, on error, and for non-members — all mean "behave normally".
   const existingMember = findMemberByEmail(restaurantMembers, email);
   // Both call sites pass the selected restaurant (Employees.tsx, Scheduling.tsx),
@@ -1251,6 +1256,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                     onChange={(e) => handleEmailChange(e.target.value)}
                     placeholder="john@example.com"
                     aria-label="Employee email"
+                    disabled={!canSeePii}
                     className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
                   />
                 </div>
@@ -1264,6 +1270,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                     onChange={(e) => setPhone(e.target.value)}
                     placeholder="(555) 123-4567"
                     aria-label="Employee phone number"
+                    disabled={!canSeePii}
                     className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
                   />
                 </div>
@@ -1360,6 +1367,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                     value={dateOfBirth}
                     onChange={(e) => setDateOfBirth(e.target.value)}
                     aria-label="Date of birth"
+                    disabled={!canSeePii}
                     className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg focus-visible:ring-1 focus-visible:ring-border"
                   />
                   {dateOfBirth && isMinor(dateOfBirth) && (

--- a/src/components/EmployeeDialog.tsx
+++ b/src/components/EmployeeDialog.tsx
@@ -969,6 +969,13 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                       onCheckedChange={setIsExempt}
                       className="data-[state=checked]:bg-foreground"
                       aria-label="Mark employee as exempt from overtime"
+                      // Overtime exemption is pay configuration, the same class
+                      // as pay period and payment interval below. Gate it on
+                      // view:pay_rates for the same reason (see canSeePayRates
+                      // above). employeeMaskedFields.ts strips is_exempt from
+                      // the write for the same caller, so a bypassed disabled
+                      // prop still cannot change it.
+                      disabled={!canSeePayRates}
                     />
                   </div>
 

--- a/src/components/EmployeeDialog.tsx
+++ b/src/components/EmployeeDialog.tsx
@@ -1040,9 +1040,10 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                         </Tooltip>
                       </TooltipProvider>
                     </Label>
-                    <Select 
-                      value={payPeriodType} 
+                    <Select
+                      value={payPeriodType}
                       onValueChange={(value) => setPayPeriodType(value as PayPeriodType)}
+                      disabled={!canSeePayRates}
                     >
                       <SelectTrigger id="payPeriodType" aria-label="Pay period" className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg">
                         <SelectValue />
@@ -1062,6 +1063,7 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                         checked={allocateDaily}
                         onCheckedChange={(checked) => setAllocateDaily(checked === true)}
                         aria-label="Allocate to Daily P&L"
+                        disabled={!canSeePayRates}
                       />
                       <Label htmlFor="allocateDaily" className="cursor-pointer flex items-center gap-1.5">
                         Allocate to Daily P&L
@@ -1122,9 +1124,10 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                     <Label htmlFor="contractorPaymentInterval">
                       Payment Interval <span className="text-destructive">*</span>
                     </Label>
-                    <Select 
-                      value={contractorPaymentInterval} 
+                    <Select
+                      value={contractorPaymentInterval}
                       onValueChange={(value) => setContractorPaymentInterval(value as ContractorPaymentInterval)}
+                      disabled={!canSeePayRates}
                     >
                       <SelectTrigger id="contractorPaymentInterval" aria-label="Payment interval" className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg">
                         <SelectValue />
@@ -1188,9 +1191,10 @@ export const EmployeeDialog = ({ open, onOpenChange, employee, restaurantId }: E
                     <Label htmlFor="dailyRateStandardDays">
                       Standard Work Days <span className="text-destructive">*</span>
                     </Label>
-                    <Select 
-                      value={dailyRateStandardDays} 
+                    <Select
+                      value={dailyRateStandardDays}
                       onValueChange={setDailyRateStandardDays}
+                      disabled={!canSeePayRates}
                     >
                       <SelectTrigger id="dailyRateStandardDays" aria-label="Standard work days per week" className="h-10 text-[14px] bg-muted/30 border-border/40 rounded-lg">
                         <SelectValue />

--- a/src/components/roles/RoleEditor.tsx
+++ b/src/components/roles/RoleEditor.tsx
@@ -653,16 +653,16 @@ export function RoleEditor({
                   either can or cannot see. */}
               <GroupHeader label="Sensitive data" legend="Off · On" />
               <div className="p-5 pt-4 space-y-1">
-                {/* Say plainly what these switches do today. They are stored on
-                    the role and resolvable through user_has_capability(), but no
-                    screen and no RLS policy reads them yet, so leaving one off
-                    hides nothing. Advertising them as protection they don't yet
-                    provide is worse than admitting the gap (Phase 7a security
-                    review); the copy comes out when the fields are gated. */}
+                {/* State plainly what these switches do now. Pay rates and
+                    contact details gate real reads. PR #727 enforces them
+                    through employees_secure and the column REVOKE. A role
+                    without the switch cannot see those fields. view:costs is
+                    not gated yet. No screen and no RLS policy reads it, so its
+                    switch changes nothing. The copy below keeps that caveat. */}
                 <p className="text-[12px] text-muted-foreground pb-2">
-                  Recorded on the role, but not enforced yet — these fields still follow area access
-                  everywhere in the app. Set them for the role you want; they take effect when
-                  per-field gating ships.
+                  Pay rates and contact details now gate real reads. A role without the switch
+                  cannot see those fields. Item costs still follow area access. The costs switch
+                  has no effect yet.
                 </p>
                 {SENSITIVE_FLAGS.map((s) => {
                   const available = flagAvailable(s, grants, builtinReadOnly);

--- a/src/lib/employeeMaskedFields.ts
+++ b/src/lib/employeeMaskedFields.ts
@@ -12,13 +12,27 @@
  * component protects one of them.
  */
 
-/** Masked by view:pay_rates. */
+/**
+ * Stripped from the write for a caller without view:pay_rates.
+ *
+ * The first five are the pay amounts that 20260806110000 masks on read. The
+ * caller sees a masked NULL for these, so the strip stops that NULL from
+ * overwriting a real stored value (see the file comment above).
+ *
+ * `is_exempt` is different: 20260806110000 grants SELECT on it to every
+ * authenticated caller (it is not one of the eight masked columns), and the
+ * table carries no column-level UPDATE grant at all — RLS governs the row,
+ * not the column. So this strip is the only guard on the overtime-exemption
+ * flag. It is here for write parity with the disabled Switch in
+ * EmployeeDialog (id="isExempt"), not because the value is ever masked.
+ */
 export const PAY_RATE_FIELDS = [
   'hourly_rate',
   'salary_amount',
   'contractor_payment_amount',
   'daily_rate_amount',
   'daily_rate_reference_weekly',
+  'is_exempt',
 ] as const;
 
 /** Masked by view:employee_pii. */

--- a/tests/unit/EmployeeDialog.maskedDob.test.tsx
+++ b/tests/unit/EmployeeDialog.maskedDob.test.tsx
@@ -9,6 +9,8 @@ import { EmployeeDialog } from '@/components/EmployeeDialog';
 // dialog prefills the date box as an empty string. On save, the box must NOT
 // be read as an explicit null — that would erase the stored date of birth.
 
+const { mockHasCapability } = vi.hoisted(() => ({ mockHasCapability: vi.fn() }));
+
 const updateMock = vi.fn().mockResolvedValue({ id: 'emp-1' });
 const createMock = vi.fn().mockResolvedValue({ id: 'emp-1' });
 
@@ -45,6 +47,10 @@ vi.mock('@/contexts/RestaurantContext', () => ({
 // which throws without an AuthProvider by design. Nothing here asserts on app
 // access — this just keeps the dialog mountable.
 vi.mock('@/hooks/useAuth', () => ({ useAuth: () => ({ user: { id: 'caller-1' } }) }));
+
+vi.mock('@/hooks/usePermissions', () => ({
+  usePermissions: () => ({ hasCapability: mockHasCapability, isResolved: true }),
+}));
 
 vi.mock('@/integrations/supabase/client', () => {
   // Recursive fluent-builder mock — must be `any` because the chain can call
@@ -117,11 +123,13 @@ describe('EmployeeDialog — masked date of birth is not erased', () => {
   });
 
   it('never sends date_of_birth: null for a masked (blank) date box on save', async () => {
+    // A masked (no-PII) caller: the date box is gated and blank.
+    mockHasCapability.mockImplementation((c: string) => c !== 'view:employee_pii');
     renderEdit();
 
-    // Confirm the fixture actually masks the date box, as the bug requires.
     const dobInput = screen.getByLabelText(/date of birth/i) as HTMLInputElement;
     expect(dobInput.value).toBe('');
+    expect(dobInput).toBeDisabled();
 
     const form = document.body.querySelector('form');
     expect(form).not.toBeNull();
@@ -136,10 +144,14 @@ describe('EmployeeDialog — masked date of birth is not erased', () => {
   // not start empty this time, so the clear must send an explicit null, not
   // silently keep the old value.
   it('sends date_of_birth: null when a caller who can see the date clears it', async () => {
+    // A caller who holds view:employee_pii: the date box is editable and shows
+    // the real date of birth.
+    mockHasCapability.mockReturnValue(true);
     renderEdit(VISIBLE_DOB_EMPLOYEE);
 
     const dobInput = screen.getByLabelText(/date of birth/i) as HTMLInputElement;
     expect(dobInput.value).toBe('2000-01-01');
+    expect(dobInput).not.toBeDisabled();
 
     fireEvent.change(dobInput, { target: { value: '' } });
     expect(dobInput.value).toBe('');

--- a/tests/unit/EmployeeDialog.sensitiveGating.test.tsx
+++ b/tests/unit/EmployeeDialog.sensitiveGating.test.tsx
@@ -129,4 +129,34 @@ describe('EmployeeDialog — sensitive-data input gating', () => {
     expect(screen.getByLabelText(/employee phone number/i)).not.toBeDisabled();
     expect(screen.getByLabelText(/date of birth/i)).not.toBeDisabled();
   });
+
+  it('disables the salary pay-schedule controls when the caller lacks view:pay_rates', () => {
+    mockHasCapability.mockReturnValue(false);
+    renderEdit(SALARY_EMPLOYEE);
+
+    expect(screen.getByRole('combobox', { name: /pay period/i })).toBeDisabled();
+    expect(screen.getByRole('checkbox', { name: /allocate to daily/i })).toBeDisabled();
+  });
+
+  it('disables the contractor payment interval when the caller lacks view:pay_rates', () => {
+    mockHasCapability.mockReturnValue(false);
+    renderEdit(CONTRACTOR_EMPLOYEE);
+
+    expect(screen.getByRole('combobox', { name: /payment interval/i })).toBeDisabled();
+  });
+
+  it('disables the daily-rate standard work days when the caller lacks view:pay_rates', () => {
+    mockHasCapability.mockReturnValue(false);
+    renderEdit(DAILY_RATE_EMPLOYEE);
+
+    expect(screen.getByRole('combobox', { name: /standard work days/i })).toBeDisabled();
+  });
+
+  it('enables the salary pay-schedule controls when the caller holds view:pay_rates', () => {
+    mockHasCapability.mockImplementation((c: string) => c === 'view:pay_rates');
+    renderEdit(SALARY_EMPLOYEE);
+
+    expect(screen.getByRole('combobox', { name: /pay period/i })).not.toBeDisabled();
+    expect(screen.getByRole('checkbox', { name: /allocate to daily/i })).not.toBeDisabled();
+  });
 });

--- a/tests/unit/EmployeeDialog.sensitiveGating.test.tsx
+++ b/tests/unit/EmployeeDialog.sensitiveGating.test.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { EmployeeDialog } from '@/components/EmployeeDialog';
+
+// Per-test control of the capability check: some tests grant view:employee_pii,
+// some grant view:pay_rates, some grant nothing. vi.hoisted lets the factory
+// below close over one shared mock function.
+const { mockHasCapability } = vi.hoisted(() => ({ mockHasCapability: vi.fn() }));
+
+vi.mock('@/hooks/useEmployees', () => ({
+  useCreateEmployee: () => ({ mutateAsync: vi.fn().mockResolvedValue({ id: 'emp-1' }), isPending: false }),
+  useUpdateEmployee: () => ({ mutateAsync: vi.fn().mockResolvedValue({ id: 'emp-1' }), isPending: false }),
+}));
+
+vi.mock('@/hooks/useBulkSetAvailability', () => ({
+  useBulkSetAvailability: () => ({ mutateAsync: vi.fn().mockResolvedValue({}), isPending: false }),
+}));
+
+vi.mock('@/hooks/useShiftTemplates', () => {
+  const STABLE_TEMPLATES: never[] = [];
+  return {
+    useShiftTemplates: () => ({
+      templates: STABLE_TEMPLATES,
+      loading: false,
+      error: null,
+      createTemplate: () => Promise.resolve(),
+      updateTemplate: () => Promise.resolve(),
+      deleteTemplate: () => Promise.resolve(),
+    }),
+  };
+});
+
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => ({ selectedRestaurant: { restaurant: { id: 'r1', timezone: 'UTC' } } }),
+}));
+
+// EmployeeAppAccessRow (mounted by every EmployeeDialog render) calls useAuth,
+// which throws without an AuthProvider by design. Nothing here asserts on app
+// access — this just keeps the dialog mountable.
+vi.mock('@/hooks/useAuth', () => ({ useAuth: () => ({ user: { id: 'caller-1' } }) }));
+
+vi.mock('@/hooks/usePermissions', () => ({
+  usePermissions: () => ({ hasCapability: mockHasCapability, isResolved: true }),
+}));
+
+vi.mock('@/integrations/supabase/client', () => {
+  // Recursive fluent-builder mock — must be `any` because the chain can call
+  // any subset of methods in any order; a typed interface would require an
+  // exhaustive intersection of all Supabase builder return types.
+  function makeChain(): any { // eslint-disable-line @typescript-eslint/no-explicit-any
+    const chain: any = {}; // eslint-disable-line @typescript-eslint/no-explicit-any
+    chain.select = () => makeChain();
+    chain.eq = () => makeChain();
+    chain.not = () => makeChain();
+    chain.order = () => Promise.resolve({ data: [], error: null });
+    chain.is = () => makeChain();
+    chain.single = () => Promise.resolve({ data: null, error: null });
+    chain.upsert = () => Promise.resolve({ data: null, error: null });
+    chain.insert = () => makeChain();
+    chain.update = () => makeChain();
+    chain.then = (resolve: (v: { data: any[]; error: null }) => any) => // eslint-disable-line @typescript-eslint/no-explicit-any
+      Promise.resolve({ data: [], error: null }).then(resolve);
+    chain.catch = () => Promise.resolve({ data: [], error: null });
+    return chain;
+  }
+  return {
+    supabase: {
+      functions: { invoke: () => Promise.resolve({ data: null, error: null }) },
+      from: () => makeChain(),
+    },
+  };
+});
+
+const BASE_EMPLOYEE = {
+  id: 'emp-1',
+  restaurant_id: 'r1',
+  name: 'Alex Valdez',
+  position: 'Server',
+  status: 'active' as const,
+  is_active: true,
+  employment_type: 'full_time' as const,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+// One fixture per compensation type — the pay-schedule controls each render
+// only under their type: salary → Pay Period + Allocate Daily; contractor →
+// Payment Interval; daily_rate → Standard Work Days.
+const HOURLY_EMPLOYEE = { ...BASE_EMPLOYEE, compensation_type: 'hourly' as const, hourly_rate: 2000 };
+const SALARY_EMPLOYEE = { ...BASE_EMPLOYEE, compensation_type: 'salary' as const };
+const CONTRACTOR_EMPLOYEE = { ...BASE_EMPLOYEE, compensation_type: 'contractor' as const };
+const DAILY_RATE_EMPLOYEE = { ...BASE_EMPLOYEE, compensation_type: 'daily_rate' as const };
+
+function renderEdit(employee: typeof BASE_EMPLOYEE) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false, refetchOnWindowFocus: false, staleTime: Infinity } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      {/* cast: test fixture omits optional Employee fields */}
+      <EmployeeDialog open onOpenChange={vi.fn()} restaurantId="r1" employee={employee as any} /> {/* eslint-disable-line @typescript-eslint/no-explicit-any */}
+    </QueryClientProvider>,
+  );
+}
+
+describe('EmployeeDialog — sensitive-data input gating', () => {
+  beforeEach(() => {
+    mockHasCapability.mockReset();
+  });
+
+  it('disables email, phone, and date of birth when the caller lacks view:employee_pii', () => {
+    mockHasCapability.mockReturnValue(false);
+    renderEdit(HOURLY_EMPLOYEE);
+
+    expect(screen.getByLabelText(/employee email/i)).toBeDisabled();
+    expect(screen.getByLabelText(/employee phone number/i)).toBeDisabled();
+    expect(screen.getByLabelText(/date of birth/i)).toBeDisabled();
+  });
+
+  it('enables email, phone, and date of birth when the caller holds view:employee_pii', () => {
+    mockHasCapability.mockImplementation((c: string) => c === 'view:employee_pii');
+    renderEdit(HOURLY_EMPLOYEE);
+
+    expect(screen.getByLabelText(/employee email/i)).not.toBeDisabled();
+    expect(screen.getByLabelText(/employee phone number/i)).not.toBeDisabled();
+    expect(screen.getByLabelText(/date of birth/i)).not.toBeDisabled();
+  });
+});

--- a/tests/unit/EmployeeDialog.sensitiveGating.test.tsx
+++ b/tests/unit/EmployeeDialog.sensitiveGating.test.tsx
@@ -130,6 +130,20 @@ describe('EmployeeDialog — sensitive-data input gating', () => {
     expect(screen.getByLabelText(/date of birth/i)).not.toBeDisabled();
   });
 
+  it('disables the exempt-from-overtime switch when the caller lacks view:pay_rates', () => {
+    mockHasCapability.mockReturnValue(false);
+    renderEdit(HOURLY_EMPLOYEE);
+
+    expect(screen.getByRole('switch', { name: /mark employee as exempt/i })).toBeDisabled();
+  });
+
+  it('enables the exempt-from-overtime switch when the caller holds view:pay_rates', () => {
+    mockHasCapability.mockImplementation((c: string) => c === 'view:pay_rates');
+    renderEdit(HOURLY_EMPLOYEE);
+
+    expect(screen.getByRole('switch', { name: /mark employee as exempt/i })).not.toBeDisabled();
+  });
+
   it('disables the salary pay-schedule controls when the caller lacks view:pay_rates', () => {
     mockHasCapability.mockReturnValue(false);
     renderEdit(SALARY_EMPLOYEE);

--- a/tests/unit/RoleEditor.test.tsx
+++ b/tests/unit/RoleEditor.test.tsx
@@ -295,6 +295,19 @@ describe('RoleEditor', () => {
     expect(screen.getAllByRole('switch')).toHaveLength(3);
   });
 
+  it('states which sensitive-data flags are enforced and which is not', () => {
+    render(<RoleEditor {...editorProps} restaurantId="rest-1" role={null} onBack={vi.fn()} />, { wrapper });
+
+    // The enforced flags are named as enforced.
+    expect(screen.getByText(/pay rates and contact details now gate real reads/i)).toBeInTheDocument();
+    // The deferred flag is named as not yet in force.
+    expect(screen.getByText(/costs switch has no effect yet/i)).toBeInTheDocument();
+
+    // The stale "not enforced yet" framing is gone.
+    expect(screen.queryByText(/not enforced yet/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/per-field gating ships/i)).not.toBeInTheDocument();
+  });
+
   it('disables a sensitive-data switch with a "Needs access to" hint until a requiring area is granted', async () => {
     const user = userEvent.setup();
     render(<RoleEditor {...editorProps} restaurantId="rest-1" role={null} onBack={vi.fn()} />, { wrapper });

--- a/tests/unit/employeeMaskedFields.test.ts
+++ b/tests/unit/employeeMaskedFields.test.ts
@@ -23,9 +23,19 @@ describe('maskedEmployeeFields', () => {
       .toEqual([...EMPLOYEE_PII_FIELDS]);
   });
 
-  it('should mask all eight fields when the caller holds neither flag', () => {
+  it('should mask all nine fields when the caller holds neither flag', () => {
     expect(maskedEmployeeFields({ payRates: false, employeePii: false }))
-      .toHaveLength(8);
+      .toHaveLength(9);
+  });
+
+  it('should mask is_exempt with the pay fields, though the column is not read-masked', () => {
+    // is_exempt keeps its SELECT grant for every caller (20260806110000). The
+    // strip below is the only guard on the write, so it must fire with the
+    // other pay fields, not only when a real masked NULL is on the line.
+    expect(maskedEmployeeFields({ payRates: false, employeePii: true }))
+      .toContain('is_exempt');
+    expect(maskedEmployeeFields({ payRates: true, employeePii: true }))
+      .not.toContain('is_exempt');
   });
 });
 


### PR DESCRIPTION
## Summary

PR #727 made `view:pay_rates` and `view:employee_pii` real in SQL. The masked
view `employees_secure` and the column REVOKE hide the sensitive columns from a
caller without the flag. The UI did not follow. This PR fixes the copy and the
input gates so the screen matches the enforcement.

Client-side gating only. No SQL, no masked view, no column REVOKE change.

The Codex adversarial reviewer flagged three gaps on merged `main`. This PR
fixes all three, plus one more gap that Codex found during the branch review.

## Changes

**1. RoleEditor copy and comment** (`src/components/roles/RoleEditor.tsx`)
The shared paragraph said the sensitive-data flags are "not enforced yet". That
text is now false for two of the three flags. New copy tells the flags apart:

> Pay rates and contact details now gate real reads. A role without the switch
> cannot see those fields. Item costs still follow area access. The costs switch
> has no effect yet.

**2. Gate the PII inputs** (`src/components/EmployeeDialog.tsx`)
Add `canSeePii = isPermissionsResolved && hasCapability('view:employee_pii')`.
Disable the email, phone, and date-of-birth inputs when the caller lacks the
flag. The write path already strips these keys, so the inputs did nothing for a
no-PII caller. The gate makes that state honest and stops a masked blank box
from reading as an intent to clear.

**3. Gate the pay-schedule controls** (`src/components/EmployeeDialog.tsx`)
Disable Pay Period, Allocate to Daily, Payment Interval, and Standard Work Days
when the caller lacks `view:pay_rates`. This matches the five pay-amount controls
that already carry the same gate.

**4. Gate the exempt-from-overtime switch** (Codex branch finding)
The `is_exempt` switch had no gate, unlike every sibling pay control. Add
`disabled={!canSeePayRates}`. Also add `is_exempt` to `PAY_RATE_FIELDS`
(`src/lib/employeeMaskedFields.ts`) so the write path strips it for a no-pay-rate
caller. The column keeps its SELECT grant for every caller, so this strip is the
only write guard.

## Testing

- New file `tests/unit/EmployeeDialog.sensitiveGating.test.tsx` (8 tests): the
  PII inputs and the pay controls disable and enable on the matching flag.
- `tests/unit/EmployeeDialog.maskedDob.test.tsx`: per-test `usePermissions` mock
  so both premises stay honest under the new PII gate.
- `tests/unit/RoleEditor.test.tsx`: assert the copy names the enforced flags and
  the deferred flag.
- `tests/unit/employeeMaskedFields.test.ts`: `is_exempt` strip test; field count
  updated to nine.
- Touched suites: 58/58 pass. Typecheck clean.

## Scope

`view:costs` stays deferred — no screen and no policy reads it yet. The
IncomeStatement "Payroll Expense (unposted)" residual is out of scope and flagged
at its call site.

Design: `docs/superpowers/specs/2026-08-09-sensitive-data-ui-gating-design.md`
Plan: `docs/superpowers/plans/2026-08-09-sensitive-data-ui-gating-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sensitive employee contact and date-of-birth fields are disabled without the appropriate permission.
  * Compensation and pay-schedule controls are disabled without pay-rate access.
  * Role settings now clarify which sensitive-data permissions are enforced.

* **Bug Fixes**
  * Improved handling of masked date-of-birth and pay-related fields while preserving existing save behavior.

* **Tests**
  * Added coverage for sensitive-field gating, role messaging, and masked compensation data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->