### PR TITLE
fix(roles): qualify the sensitive-data copy for the self-row read

### DIFF
--- a/docs/superpowers/plans/2026-08-09-roles-selfrow-copy-plan.md
+++ b/docs/superpowers/plans/2026-08-09-roles-selfrow-copy-plan.md
@@ -1,0 +1,79 @@
+# RoleEditor self-row copy fix — Implementation Plan
+
+> **For agentic workers:** This is a copy-only change with one test. Follow the
+> TDD steps in order.
+
+**Goal:** Fix one inaccurate sentence in the RoleEditor sensitive-data copy so
+it names the self-row read case.
+
+**Architecture:** Change text inside one `<p>` and one code comment in
+`src/components/roles/RoleEditor.tsx`. Add one assertion in the existing copy
+test.
+
+**Tech Stack:** React, TypeScript, Vitest, Testing Library.
+
+## Global Constraints
+
+- ASD-STE100 for all prose, copy, comments, and commit messages.
+- No SQL, no gating logic, no masked-view change. Copy-only.
+- Stage explicit paths. Never `git add -A`. Never stage `progress.md`.
+- Approved copy (exact): "Pay rates and contact details now gate real reads. A
+  role without the switch cannot see other employees' pay rates or contact
+  details. Each person still sees their own. Item costs follow area access. The
+  costs switch has no effect yet."
+
+---
+
+### Task 1: Update the copy test (RED), then the copy (GREEN)
+
+**Files:**
+- Test: `tests/unit/RoleEditor.test.tsx:298-309` (extend the existing block)
+- Modify: `src/components/roles/RoleEditor.tsx:656-666` (comment + paragraph)
+
+**Interfaces:**
+- Consumes: the existing `RoleEditor` render helper and `editorProps` in the test.
+- Produces: no new exports. Copy text only.
+
+- [ ] **Step 1: Write the failing assertions**
+
+Add to the test block at `tests/unit/RoleEditor.test.tsx:298`:
+
+```tsx
+// The guarantee is qualified to OTHER employees — the SQL self-row
+// exception keeps own-row pay and PII visible without the flag.
+expect(
+  screen.getByText(/cannot see other employees' pay rates or contact details/i),
+).toBeInTheDocument();
+expect(screen.getByText(/each person still sees their own/i)).toBeInTheDocument();
+// The stale absolute claim is gone.
+expect(screen.queryByText(/cannot see those fields/i)).not.toBeInTheDocument();
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+Run: `npm run test -- tests/unit/RoleEditor.test.tsx`
+Expected: FAIL. The current copy says "cannot see those fields".
+
+- [ ] **Step 3: Change the paragraph and the comment**
+
+In `src/components/roles/RoleEditor.tsx`, replace the paragraph text
+(`:662-666`) with the approved copy. Fix the comment (`:656-661`) so it names
+the self-row case too.
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+Run: `npm run test -- tests/unit/RoleEditor.test.tsx`
+Expected: PASS. All copy assertions pass, including the two existing ones.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/roles/RoleEditor.tsx tests/unit/RoleEditor.test.tsx
+git commit -m "fix(roles): qualify the sensitive-data copy for the self-row read"
+```
+
+## Self-Review
+
+- Spec coverage: the one change (reword paragraph + comment) is Task 1.
+- No placeholders.
+- Type consistency: no types touched.

--- a/docs/superpowers/specs/2026-08-09-roles-selfrow-copy-design.md
+++ b/docs/superpowers/specs/2026-08-09-roles-selfrow-copy-design.md
@@ -54,7 +54,8 @@ The first and last sentences stay the same, so the two existing copy tests
 
 ## Scope
 
-- The dialog input gate (`EmployeeDialog.tsx`) is correct and needs no change.
+- The dialog input gate (`EmployeeDialog.tsx:119,124`) is correct and needs no
+  change. `canSeePayRates` and `canSeePii` key only off `hasCapability(...)`.
   The admin surface has no self-row case there.
 - `view:costs` stays deferred. The copy keeps its caveat.
 

--- a/docs/superpowers/specs/2026-08-09-roles-selfrow-copy-design.md
+++ b/docs/superpowers/specs/2026-08-09-roles-selfrow-copy-design.md
@@ -1,0 +1,72 @@
+# RoleEditor self-row copy fix — Design
+
+**Goal:** Fix one inaccurate sentence in the RoleEditor sensitive-data copy.
+The copy overstates the read guarantee for a caller's own employee row.
+
+**Type:** Copy-only change to one React component. No SQL, no gating logic,
+no masked-view change.
+
+## Problem
+
+PR #731 shipped this copy in the "Sensitive data" band of the role editor
+(`src/components/roles/RoleEditor.tsx:662-666`):
+
+> Pay rates and contact details now gate real reads. A role without the switch
+> cannot see those fields. Item costs still follow area access. The costs switch
+> has no effect yet.
+
+The sentence "A role without the switch cannot see those fields" is too
+absolute. The masked view `employees_secure` keeps a caller's **own** pay and
+contact fields visible, with no flag.
+
+The Codex adversarial reviewer flagged this on the merged PR #731 as a P2:
+the categorical claim "misleads administrators" for a user with their own
+employee record.
+
+## Premise (existing code — verified)
+
+The view gates each sensitive column on the flag **or** the self-row:
+
+- `supabase/migrations/20260806110000_employee_column_gating.sql:90-94` —
+  pay fields use `CASE WHEN caps.pay OR caps.self THEN ...`.
+- `supabase/migrations/20260806110000_employee_column_gating.sql:95-97` —
+  email, phone, and date_of_birth use `CASE WHEN caps.pii OR caps.self THEN ...`.
+- `supabase/migrations/20260806110000_employee_column_gating.sql:104` —
+  `self` is `(e.user_id = auth.uid())`.
+
+So a caller always reads their own pay and contact data. A role without the
+switch hides only **other** employees' fields.
+
+## Change
+
+Replace the paragraph text and fix the matching comment
+(`src/components/roles/RoleEditor.tsx:656-661`) so both name the self-row case.
+
+Approved new wording:
+
+> Pay rates and contact details now gate real reads. A role without the switch
+> cannot see other employees' pay rates or contact details. Each person still
+> sees their own. Item costs follow area access. The costs switch has no effect
+> yet.
+
+The first and last sentences stay the same, so the two existing copy tests
+(`tests/unit/RoleEditor.test.tsx:302,304`) still pass.
+
+## Scope
+
+- The dialog input gate (`EmployeeDialog.tsx`) is correct and needs no change.
+  The admin surface has no self-row case there.
+- `view:costs` stays deferred. The copy keeps its caveat.
+
+## Testing
+
+Add one assertion to the existing copy test in
+`tests/unit/RoleEditor.test.tsx`: the copy names the "other employees'"
+qualification and the self-row exception, and the absolute phrase
+"cannot see those fields" is gone.
+
+## Decided trade-offs
+
+- Phase 5 (UI review) and Phase 6 (Simplify) skip: the diff changes only text
+  inside one existing `<p>` and one comment. No layout, token, state, or a11y
+  delta, and no code to simplify.

--- a/src/components/roles/RoleEditor.tsx
+++ b/src/components/roles/RoleEditor.tsx
@@ -656,13 +656,16 @@ export function RoleEditor({
                 {/* State plainly what these switches do now. Pay rates and
                     contact details gate real reads. PR #727 enforces them
                     through employees_secure and the column REVOKE. A role
-                    without the switch cannot see those fields. view:costs is
-                    not gated yet. No screen and no RLS policy reads it, so its
-                    switch changes nothing. The copy below keeps that caveat. */}
+                    without the switch cannot see other employees' pay or PII.
+                    The employees_secure view keeps own-row data visible
+                    through the caps.self exception. view:costs is not gated
+                    yet. No screen and no RLS policy reads it, so its switch
+                    changes nothing. The copy below keeps that caveat. */}
                 <p className="text-[12px] text-muted-foreground pb-2">
                   Pay rates and contact details now gate real reads. A role without the switch
-                  cannot see those fields. Item costs still follow area access. The costs switch
-                  has no effect yet.
+                  cannot see other employees' pay rates or contact details. Each person still
+                  sees their own. Item costs follow area access. The costs switch has no effect
+                  yet.
                 </p>
                 {SENSITIVE_FLAGS.map((s) => {
                   const available = flagAvailable(s, grants, builtinReadOnly);

--- a/tests/unit/RoleEditor.test.tsx
+++ b/tests/unit/RoleEditor.test.tsx
@@ -300,9 +300,17 @@ describe('RoleEditor', () => {
 
     // The enforced flags are named as enforced.
     expect(screen.getByText(/pay rates and contact details now gate real reads/i)).toBeInTheDocument();
+    // The guarantee is qualified to OTHER employees. The SQL self-row
+    // exception keeps own-row pay and PII visible without the flag.
+    expect(
+      screen.getByText(/cannot see other employees' pay rates or contact details/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/each person still sees their own/i)).toBeInTheDocument();
     // The deferred flag is named as not yet in force.
     expect(screen.getByText(/costs switch has no effect yet/i)).toBeInTheDocument();
 
+    // The stale absolute claim is gone.
+    expect(screen.queryByText(/cannot see those fields/i)).not.toBeInTheDocument();
     // The stale "not enforced yet" framing is gone.
     expect(screen.queryByText(/not enforced yet/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/per-field gating ships/i)).not.toBeInTheDocument();


### PR DESCRIPTION
## Problem

PR #731 shipped this copy in the "Sensitive data" band of the role editor:

> A role without the switch cannot see those fields.

The claim is too absolute. It is false for a caller who reads their own
employee row. The Codex reviewer flagged this on the merged PR #731 as a P2.

## Root cause

The masked view `employees_secure` gates each sensitive column on the flag
**or** the self-row (`supabase/migrations/20260806110000_employee_column_gating.sql`):

- Lines 90–94: pay fields use `CASE WHEN caps.pay OR caps.self THEN ...`.
- Lines 95–97: `email`, `phone`, `date_of_birth` use `CASE WHEN caps.pii OR caps.self THEN ...`.
- Line 104: `self` is `(e.user_id = auth.uid())`.

So a caller always reads their own pay and contact data. A role without the
flag hides only **other** employees' fields.

## Fix

- Qualify the copy to "other employees'".
- State that each person still sees their own data.
- Fix the matching code comment so it names the self-row case.
- Extend the copy test in `tests/unit/RoleEditor.test.tsx`.

New copy:

> Pay rates and contact details now gate real reads. A role without the switch
> cannot see other employees' pay rates or contact details. Each person still
> sees their own. Item costs follow area access. The costs switch has no effect
> yet.

## Scope

Copy-only. No SQL, no gating logic, no masked-view change. `view:costs` stays
deferred, and the copy keeps its caveat.

## Testing

- `tests/unit/RoleEditor.test.tsx`: 27/27 pass.
- `npm run typecheck`: clean.
- ESLint on the two touched files: clean.

Follow-up to #731.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Clarified sensitive-data guidance in role settings: pay rates and contact details are restricted for other employees while remaining visible for an individual’s own record.
  * Clarified that item costs follow area access, with no change to the existing costs control.
  * Added supporting documentation and coverage to verify the updated wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->