### PR TITLE
feat(speed-insights): add Vercel Speed Insights (web only)

### DIFF
--- a/docs/superpowers/plans/2026-08-09-vercel-speed-insights-plan.md
+++ b/docs/superpowers/plans/2026-08-09-vercel-speed-insights-plan.md
@@ -1,0 +1,269 @@
+# Vercel Speed Insights Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Vercel Speed Insights to collect Core Web Vitals from real production web users.
+
+**Architecture:** Add the `@vercel/speed-insights` package. Wrap `<SpeedInsights />` in a small component `SpeedInsightsGate` that renders on the web and returns `null` on native Capacitor builds. Mount the gate once in `src/App.tsx` inside `<BrowserRouter>`.
+
+**Tech Stack:** React 18.3, TypeScript, Vite, React Router 6, `@vercel/speed-insights` v2, `@capacitor/core`, Vitest, `@testing-library/react`.
+
+Design doc: `docs/superpowers/specs/2026-08-09-vercel-speed-insights-design.md`
+
+## Global Constraints
+
+- Write every word of prose in ASD-STE100 Simplified Technical English.
+- Use `@vercel/speed-insights` v2. Import from `@vercel/speed-insights/react`.
+- Render Speed Insights on the web only. Gate the render with `Capacitor.isNativePlatform()`. Native returns `null`.
+- Add no environment flag. A runtime platform check gates the render.
+- Add no `@vercel/analytics` (web analytics). PostHog already covers product analytics.
+- Keep the file name `tests/unit/appNoVercelAnalytics.test.ts`. Two tests reference it by name.
+- Stage explicit paths. Never `git add -A` or `git add .`. Never stage `progress.md`.
+
+---
+
+### Task 1: Add the `@vercel/speed-insights` dependency
+
+**Files:**
+- Modify: `package.json` (dependencies)
+- Modify: `package-lock.json` (lockfile)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: the module `@vercel/speed-insights/react`, which exports the `SpeedInsights` React component. Task 2 imports it.
+
+- [ ] **Step 1: Install the package**
+
+Run from the worktree root:
+
+```bash
+npm install @vercel/speed-insights@^2 --no-audit --no-fund
+```
+
+- [ ] **Step 2: Confirm the package resolves**
+
+Run: `npm ls @vercel/speed-insights`
+Expected: prints `@vercel/speed-insights@2.x.x` (a 2.x version), no "missing" error.
+
+- [ ] **Step 3: Confirm the react entry point resolves**
+
+Run: `node -e "console.log(require.resolve('@vercel/speed-insights/package.json'))"`
+Expected: prints an absolute path under `node_modules/@vercel/speed-insights`.
+
+- [ ] **Step 4: Confirm package.json lists the dependency**
+
+Run: `grep '"@vercel/speed-insights"' package.json`
+Expected: prints one line in the `dependencies` block with a `^2` range.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add package.json package-lock.json
+git diff --cached --name-only
+git commit -m "chore(deps): add @vercel/speed-insights v2"
+```
+
+---
+
+### Task 2: Create `SpeedInsightsGate` with a behavior test (TDD)
+
+**Files:**
+- Create: `src/components/SpeedInsightsGate.tsx`
+- Test: `tests/unit/speedInsightsGate.test.tsx`
+
+**Interfaces:**
+- Consumes: `SpeedInsights` from `@vercel/speed-insights/react` (Task 1); `Capacitor` from `@capacitor/core`.
+- Produces: `SpeedInsightsGate` — a named export, a component with no props. Renders `<SpeedInsights />` on the web, `null` on native. Task 3 imports it.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/speedInsightsGate.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Capacitor } from '@capacitor/core';
+import { SpeedInsightsGate } from '@/components/SpeedInsightsGate';
+
+// Mock the platform check so each test picks web or native.
+vi.mock('@capacitor/core', () => ({
+  Capacitor: { isNativePlatform: vi.fn() },
+}));
+
+// Mock the Vercel component. The real one injects a script tag; the test
+// only checks that the gate renders it or skips it.
+vi.mock('@vercel/speed-insights/react', () => ({
+  SpeedInsights: () => <div data-testid="speed-insights" />,
+}));
+
+describe('SpeedInsightsGate', () => {
+  beforeEach(() => {
+    vi.mocked(Capacitor.isNativePlatform).mockReset();
+  });
+
+  it('renders Speed Insights on the web', () => {
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(false);
+    render(<SpeedInsightsGate />);
+    expect(screen.queryByTestId('speed-insights')).not.toBeNull();
+  });
+
+  it('renders nothing on native', () => {
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);
+    render(<SpeedInsightsGate />);
+    expect(screen.queryByTestId('speed-insights')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test -- speedInsightsGate`
+Expected: FAIL. The error names a missing module `@/components/SpeedInsightsGate`.
+
+- [ ] **Step 3: Write the minimal component**
+
+Create `src/components/SpeedInsightsGate.tsx`:
+
+```tsx
+import { Capacitor } from '@capacitor/core';
+import { SpeedInsights } from '@vercel/speed-insights/react';
+
+/**
+ * Render Vercel Speed Insights on the web only.
+ *
+ * Native Capacitor builds serve the app from a local WebView, where the
+ * Vercel script `/_vercel/speed-insights/script.js` 404s (BUG-001,
+ * docs/superpowers/specs/2026-07-04-script-error-noise-design.md). So skip the
+ * beacon on native platforms. See
+ * docs/superpowers/specs/2026-08-09-vercel-speed-insights-design.md.
+ */
+export function SpeedInsightsGate() {
+  if (Capacitor.isNativePlatform()) {
+    return null;
+  }
+  return <SpeedInsights />;
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm run test -- speedInsightsGate`
+Expected: PASS. Both cases green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/SpeedInsightsGate.tsx tests/unit/speedInsightsGate.test.tsx
+git diff --cached --name-only
+git commit -m "feat(speed-insights): add SpeedInsightsGate, web-only beacon"
+```
+
+---
+
+### Task 3: Wire the gate into App.tsx and update the guard test
+
+**Files:**
+- Modify: `src/App.tsx` (add import; render `<SpeedInsightsGate />` at line 351)
+- Modify: `tests/unit/appNoVercelAnalytics.test.ts` (delete the speed-insights assertion; update the comment)
+
+**Interfaces:**
+- Consumes: `SpeedInsightsGate` from `@/components/SpeedInsightsGate` (Task 2).
+- Produces: nothing for later tasks. This is the last task.
+
+- [ ] **Step 1: Update the guard test first (RED for the change)**
+
+Replace the whole body of `tests/unit/appNoVercelAnalytics.test.ts` with:
+
+```ts
+import { readFileSync } from 'fs';
+import path from 'path';
+
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Regression guard: `src/App.tsx` does not add Vercel Web Analytics
+ * (`@vercel/analytics`). PostHog already captures product analytics
+ * (pageviews and pageleaves in `src/main.tsx`), so Web Analytics would
+ * duplicate it. See
+ * docs/superpowers/specs/2026-08-09-vercel-speed-insights-design.md.
+ *
+ * BUG-001 history: this file once also banned `@vercel/speed-insights`,
+ * because the app ran on Lovable, where the Vercel script 404s. Production
+ * now deploys to Vercel, so Speed Insights is deliberately reintroduced
+ * through `src/components/SpeedInsightsGate.tsx` (web only, off on native
+ * Capacitor builds). So the speed-insights ban is gone; the
+ * `@vercel/analytics` ban stays. See
+ * docs/superpowers/specs/2026-07-04-script-error-noise-design.md.
+ */
+describe('App.tsx does not import Vercel Web Analytics', () => {
+  const appSource = readFileSync(
+    path.resolve(__dirname, '../../src/App.tsx'),
+    'utf-8'
+  );
+
+  it('does not contain the "@vercel/analytics" specifier', () => {
+    expect(appSource).not.toContain('@vercel/analytics');
+  });
+});
+```
+
+- [ ] **Step 2: Run the guard test to confirm it still passes**
+
+Run: `npm run test -- appNoVercelAnalytics`
+Expected: PASS. One test. `src/App.tsx` does not yet import anything Vercel.
+
+- [ ] **Step 3: Add the import to `src/App.tsx`**
+
+Find the import of `InstallBanner` in `src/App.tsx` (the `@/components/InstallBanner` line). Add this line directly below it:
+
+```tsx
+import { SpeedInsightsGate } from '@/components/SpeedInsightsGate';
+```
+
+- [ ] **Step 4: Render the gate in `src/App.tsx`**
+
+At `src/App.tsx:351`, change:
+
+```tsx
+        <BrowserRouter>
+          <InstallBanner />
+          <Routes>
+```
+
+to:
+
+```tsx
+        <BrowserRouter>
+          <InstallBanner />
+          <SpeedInsightsGate />
+          <Routes>
+```
+
+- [ ] **Step 5: Run the guard test again**
+
+Run: `npm run test -- appNoVercelAnalytics`
+Expected: PASS. `src/App.tsx` imports `@/components/SpeedInsightsGate`, not `@vercel/analytics`, so the ban holds.
+
+- [ ] **Step 6: Typecheck and build**
+
+Run: `npm run typecheck`
+Expected: PASS. No type error.
+
+Run: `npm run build`
+Expected: PASS. The bundle includes `@vercel/speed-insights`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/App.tsx tests/unit/appNoVercelAnalytics.test.ts
+git diff --cached --name-only
+git commit -m "feat(speed-insights): mount SpeedInsightsGate in App"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** Task 1 adds the package. Task 2 builds the web-only gate plus its behavior test. Task 3 mounts the gate and updates the BUG-001 guard test. The design's "no web analytics" and "no route prop" trade-offs need no task; they are decisions, not code. The Vercel dashboard step is a post-merge operational item; it goes in the PR body, not a task.
+- **Type consistency:** `SpeedInsightsGate` — same name in Task 2 (created), Task 3 (imported). No props anywhere.
+- **File name:** the guard-test file keeps its name `appNoVercelAnalytics.test.ts`, so the references in `appLaborRoute.test.ts:9` and `App.viewModeWiring.test.ts:9` stay valid.

--- a/docs/superpowers/specs/2026-08-09-vercel-speed-insights-design.md
+++ b/docs/superpowers/specs/2026-08-09-vercel-speed-insights-design.md
@@ -1,0 +1,142 @@
+# Design: Add Vercel Speed Insights
+
+Date: 2026-08-09
+Branch: `feature/vercel-speed-insights`
+
+## Goal
+
+Collect Core Web Vitals from real production users. Production now deploys to
+Vercel, so Vercel Speed Insights can report field performance data.
+
+## Problem
+
+The app sends no Core Web Vitals data today. `src/App.tsx` has no
+`@vercel/speed-insights` import (verified — `grep '@vercel/' src/` returns
+nothing). `package.json` has no `@vercel/speed-insights` dependency (verified —
+`grep 'vercel' package.json` returns 0 matches). PostHog captures product
+analytics only: pageviews (`src/main.tsx:27`) and pageleaves
+(`src/main.tsx:28`). Grafana Faro captures frontend errors and traces
+(`src/main.tsx:11`). Neither reports Largest Contentful Paint, Cumulative
+Layout Shift, or the other Web Vitals that Speed Insights measures.
+
+## Prior art: this reverses part of BUG-001
+
+BUG-001 removed the Vercel analytics packages
+(`docs/superpowers/specs/2026-07-04-script-error-noise-design.md:48-58`). The
+reason was the host: the app ran on Lovable, where `<Analytics />` and
+`<SpeedInsights />` tried to load `/_vercel/insights/script.js`, which 404s off
+Vercel (`docs/superpowers/specs/2026-07-04-script-error-noise-design.md:38-41`).
+The removal added a regression guard: a source-text test that asserts
+`src/App.tsx` imports neither `@vercel/analytics` nor `@vercel/speed-insights`
+(`tests/unit/appNoVercelAnalytics.test.ts:22-28`). The BUG-001 author scoped
+the guard to the two exact specifiers "so a deliberate future reintroduction
+stays legible" (`tests/unit/appNoVercelAnalytics.test.ts:12-14`).
+
+Production now moves to Vercel. The 404 premise no longer holds for Speed
+Insights. This design reverses the Speed Insights half of BUG-001 part 1. The
+BUG-001 PostHog `before_send` filter (`src/main.tsx:29-30`) and the
+mobile-sidebar accessibility fix stay unchanged.
+
+## Hosting decision (user-confirmed 2026-08-09)
+
+Vercel is the sole production host. So Speed Insights renders unconditionally.
+No environment flag gates it. An environment flag would add a silent-no-op
+risk: a missing flag would disable the feature with no error.
+
+## Approved design
+
+### 1. Add the dependency
+
+Add `@vercel/speed-insights` (v2) to `dependencies` in `package.json`. Run
+`npm install` in the worktree.
+
+### 2. Wire the component in `src/App.tsx`
+
+Add the import:
+
+```tsx
+import { SpeedInsights } from '@vercel/speed-insights/react';
+```
+
+The `/react` entry point is the correct one for a Vite plus React app. The app
+uses React Router 6 (`react-router-dom` `^6.30.1`, `package.json:118`), not
+Next.js.
+
+Render `<SpeedInsights />` inside `<BrowserRouter>` (`src/App.tsx:350`), next to
+`<InstallBanner />` (`src/App.tsx:351`). This groups the beacon component with
+the other global chrome, inside the router scope.
+
+### 3. Change the guard test
+
+Change `tests/unit/appNoVercelAnalytics.test.ts`:
+
+- Flip the `@vercel/speed-insights` assertion. The old test asserts `src/App.tsx`
+  does not import the specifier (`tests/unit/appNoVercelAnalytics.test.ts:26-28`).
+  The new test asserts `src/App.tsx` imports `@vercel/speed-insights/react` and
+  renders `<SpeedInsights`.
+- Keep the `@vercel/analytics` assertion
+  (`tests/unit/appNoVercelAnalytics.test.ts:22-24`). The app does not add web
+  analytics.
+- Rename the file to `appAnalyticsWiring.test.ts`. The old name describes the
+  old, fully-negative intent.
+- Change the file doc comment to cite this design and the Vercel-only fact.
+
+The source-text guard is the established pattern for `src/App.tsx`. This file is
+excluded from unit-test coverage (`vitest.config.ts:42`), as is `src/main.tsx`
+(`vitest.config.ts:43`).
+
+## Decided trade-offs
+
+### No web analytics (`@vercel/analytics`)
+
+The app adds Speed Insights only. PostHog already captures pageviews
+(`src/main.tsx:27`) and pageleaves (`src/main.tsx:28`), so Vercel Web Analytics
+would duplicate that product-analytics data. Speed Insights is complementary: it
+adds Core Web Vitals, which PostHog does not measure. The user asked for Speed
+Insights only.
+
+### No `route` prop (dynamic-route grouping deferred)
+
+The `/react` variant does not auto-set the `route` prop. Only Next.js, Nuxt,
+SvelteKit, and Remix auto-detect the route pattern. So the five dynamic routes
+report concrete paths, not grouped patterns:
+
+- `/r/:slug` (`src/App.tsx:359`)
+- `/purchase-orders/:id` (`src/App.tsx:391`)
+- `/invoices/:id` (`src/App.tsx:410`)
+- `/invoices/:id/edit` (`src/App.tsx:411`)
+- `/help/:slug` (`src/App.tsx:429`)
+
+The app renders routes with element-based `<Routes>` (`src/App.tsx:352`), not the
+`createBrowserRouter` data router. So there is no `useMatches` hook to read the
+matched pattern cheaply. A `route`-prop helper is a documented future
+enhancement. It is not needed for a first integration, and most routes are
+static.
+
+## Testing
+
+- **Unit:** the changed source-text guard on `src/App.tsx`.
+- **Typecheck:** `npm run typecheck` proves the import resolves and the props
+  type-check.
+- **Build:** `npm run build` proves the package bundles.
+- **E2E — justified exception:** `<SpeedInsights />` renders no visible output.
+  It sends beacons only from Vercel production, which local and CI Playwright
+  cannot exercise. The existing E2E suite already proves the app boots. A new
+  E2E would assert nothing that the unit guard and the build do not already
+  cover.
+
+## Risks
+
+- **Console 404 off Vercel.** In local dev the injected script
+  `/_vercel/speed-insights/script.js` 404s. The package auto-enables `debug`
+  mode when `NODE_ENV` is development or test, so it sends no beacons and logs a
+  debug note instead of a hard error. Production on Vercel serves the script, so
+  no 404 reaches real users. This is the exact failure mode BUG-001 fixed for
+  Lovable; Vercel hosting removes the cause.
+
+## Non-goals
+
+- No change to PostHog, Faro, or the BUG-001 `before_send` filter.
+- No Vercel Web Analytics.
+- No `route`-prop dynamic-route grouping.
+- No environment flag.

--- a/docs/superpowers/specs/2026-08-09-vercel-speed-insights-design.md
+++ b/docs/superpowers/specs/2026-08-09-vercel-speed-insights-design.md
@@ -5,8 +5,8 @@ Branch: `feature/vercel-speed-insights`
 
 ## Goal
 
-Collect Core Web Vitals from real production users. Production now deploys to
-Vercel, so Vercel Speed Insights can report field performance data.
+Collect Core Web Vitals from real production web users. Production now deploys
+to Vercel, so Vercel Speed Insights can report field performance data.
 
 ## Problem
 
@@ -16,8 +16,9 @@ nothing). `package.json` has no `@vercel/speed-insights` dependency (verified �
 `grep 'vercel' package.json` returns 0 matches). PostHog captures product
 analytics only: pageviews (`src/main.tsx:27`) and pageleaves
 (`src/main.tsx:28`). Grafana Faro captures frontend errors and traces
-(`src/main.tsx:11`). Neither reports Largest Contentful Paint, Cumulative
-Layout Shift, or the other Web Vitals that Speed Insights measures.
+(`initFaro()` at `src/main.tsx:11`; config in `src/lib/faro.ts`). Neither
+reports Largest Contentful Paint, Cumulative Layout Shift, or the other Web
+Vitals that Speed Insights measures.
 
 ## Prior art: this reverses part of BUG-001
 
@@ -32,16 +33,32 @@ The removal added a regression guard: a source-text test that asserts
 the guard to the two exact specifiers "so a deliberate future reintroduction
 stays legible" (`tests/unit/appNoVercelAnalytics.test.ts:12-14`).
 
-Production now moves to Vercel. The 404 premise no longer holds for Speed
-Insights. This design reverses the Speed Insights half of BUG-001 part 1. The
+Production now moves to Vercel. The 404 premise no longer holds for the web
+build. This design reverses the Speed Insights half of BUG-001 part 1. The
 BUG-001 PostHog `before_send` filter (`src/main.tsx:29-30`) and the
 mobile-sidebar accessibility fix stay unchanged.
 
-## Hosting decision (user-confirmed 2026-08-09)
+## Two production surfaces (both matter)
 
-Vercel is the sole production host. So Speed Insights renders unconditionally.
-No environment flag gates it. An environment flag would add a silent-no-op
-risk: a missing flag would disable the feature with no error.
+The app has two production surfaces:
+
+1. **Web on Vercel.** The sole production web host (user-confirmed 2026-08-09).
+2. **Native Capacitor apps for iOS and Android.** `@capacitor/ios`
+   (`package.json:46`) and `@capacitor/android` (`package.json:39`) are
+   dependencies. Native builds serve the bundled app from a local WebView
+   (`webDir: 'dist'`, no `server.url` — `capacitor.config.ts:6`), not the Vercel
+   URL.
+
+Speed Insights works on the web surface only. On native, the injected script
+`/_vercel/speed-insights/script.js` resolves against the local WebView origin
+and 404s on every page load — the exact BUG-001 symptom. So Speed Insights must
+render on the web only, not on native.
+
+A runtime platform check gates the render. No environment flag gates it. An
+environment flag would add a silent-no-op risk: a missing flag would disable the
+feature with no error. `Capacitor.isNativePlatform()` cannot be unset or
+misconfigured; the codebase already uses it in 15 files
+(for example `src/components/InstallBanner.tsx:22`).
 
 ## Approved design
 
@@ -50,40 +67,70 @@ risk: a missing flag would disable the feature with no error.
 Add `@vercel/speed-insights` (v2) to `dependencies` in `package.json`. Run
 `npm install` in the worktree.
 
-### 2. Wire the component in `src/App.tsx`
+### 2. Add a platform-gated component `src/components/SpeedInsightsGate.tsx`
 
-Add the import:
+Create a small component that renders Speed Insights on the web only:
 
 ```tsx
+import { Capacitor } from '@capacitor/core';
 import { SpeedInsights } from '@vercel/speed-insights/react';
+
+// Render Vercel Speed Insights on the web only. Native Capacitor builds serve
+// the app from a local WebView, where the Vercel script 404s (BUG-001). So skip
+// the beacon on native platforms.
+export function SpeedInsightsGate() {
+  if (Capacitor.isNativePlatform()) {
+    return null;
+  }
+  return <SpeedInsights />;
+}
 ```
 
 The `/react` entry point is the correct one for a Vite plus React app. The app
 uses React Router 6 (`react-router-dom` `^6.30.1`, `package.json:118`), not
-Next.js.
+Next.js. The native guard copies the pattern in
+`src/components/InstallBanner.tsx:22-24`.
 
-Render `<SpeedInsights />` inside `<BrowserRouter>` (`src/App.tsx:350`), next to
-`<InstallBanner />` (`src/App.tsx:351`). This groups the beacon component with
-the other global chrome, inside the router scope.
+### 3. Wire the gate in `src/App.tsx`
 
-### 3. Change the guard test
+Add the import:
+
+```tsx
+import { SpeedInsightsGate } from '@/components/SpeedInsightsGate';
+```
+
+Render `<SpeedInsightsGate />` inside `<BrowserRouter>` (`src/App.tsx:350`), next
+to `<InstallBanner />` (`src/App.tsx:351`). This groups the beacon with the other
+global chrome, inside the router scope.
+
+### 4. Change the guard test and add a behavior test
 
 Change `tests/unit/appNoVercelAnalytics.test.ts`:
 
-- Flip the `@vercel/speed-insights` assertion. The old test asserts `src/App.tsx`
-  does not import the specifier (`tests/unit/appNoVercelAnalytics.test.ts:26-28`).
-  The new test asserts `src/App.tsx` imports `@vercel/speed-insights/react` and
-  renders `<SpeedInsights`.
+- Delete the `@vercel/speed-insights` negative assertion
+  (`tests/unit/appNoVercelAnalytics.test.ts:26-28`). Speed Insights is now a
+  deliberate dependency, wired through `SpeedInsightsGate`.
 - Keep the `@vercel/analytics` assertion
   (`tests/unit/appNoVercelAnalytics.test.ts:22-24`). The app does not add web
   analytics.
-- Rename the file to `appAnalyticsWiring.test.ts`. The old name describes the
-  old, fully-negative intent.
-- Change the file doc comment to cite this design and the Vercel-only fact.
+- Change the file doc comment to cite this design.
 
-The source-text guard is the established pattern for `src/App.tsx`. This file is
-excluded from unit-test coverage (`vitest.config.ts:42`), as is `src/main.tsx`
-(`vitest.config.ts:43`).
+Keep the file name `appNoVercelAnalytics.test.ts`. The name stays accurate: the
+file still bans `@vercel/analytics`. Two other tests reference it by name
+(`tests/unit/appLaborRoute.test.ts:9`, `tests/unit/App.viewModeWiring.test.ts:9`);
+a rename would break those comments.
+
+Add `tests/unit/speedInsightsGate.test.tsx`:
+
+- Mock `@capacitor/core` and `@vercel/speed-insights/react`.
+- Web case (`isNativePlatform` returns false): assert `SpeedInsights` renders.
+- Native case (`isNativePlatform` returns true): assert `SpeedInsights` does not
+  render.
+
+`src/components/SpeedInsightsGate.tsx` is excluded from coverage in both
+`vitest.config.ts` (`src/components/**`) and `sonar-project.properties`
+(`src/components/**/*.tsx`). The behavior test still runs and guards the native
+logic; the exclusion only drops the file from the coverage percent.
 
 ## Decided trade-offs
 
@@ -115,28 +162,44 @@ static.
 
 ## Testing
 
-- **Unit:** the changed source-text guard on `src/App.tsx`.
+- **Unit (behavior):** `tests/unit/speedInsightsGate.test.tsx` proves the gate
+  renders Speed Insights on the web and renders nothing on native.
+- **Unit (guard):** the changed `tests/unit/appNoVercelAnalytics.test.ts` keeps
+  the `@vercel/analytics` ban.
 - **Typecheck:** `npm run typecheck` proves the import resolves and the props
   type-check.
 - **Build:** `npm run build` proves the package bundles.
-- **E2E — justified exception:** `<SpeedInsights />` renders no visible output.
-  It sends beacons only from Vercel production, which local and CI Playwright
-  cannot exercise. The existing E2E suite already proves the app boots. A new
-  E2E would assert nothing that the unit guard and the build do not already
-  cover.
+- **E2E — justified exception:** the gate renders no visible output. It sends
+  beacons only from Vercel production, which local and CI Playwright cannot
+  exercise. The existing E2E suite already proves the app boots
+  (`tests/e2e/navigate-in-app.spec.ts` loads `/auth` and asserts on the rendered
+  UI). A new E2E would assert nothing that the gate behavior test and the build
+  do not already cover.
+
+## Post-merge operational step
+
+Enable Speed Insights in the Vercel project dashboard after the PR ships. Open
+the project, select the Speed Insights tab, and enable it. Vercel provisions the
+`/_vercel/speed-insights/*` route only after this step; the npm package alone
+does not create it. Add this as a checklist item in the PR description so an
+operator does not forget it.
 
 ## Risks
 
-- **Console 404 off Vercel.** In local dev the injected script
-  `/_vercel/speed-insights/script.js` 404s. The package auto-enables `debug`
-  mode when `NODE_ENV` is development or test, so it sends no beacons and logs a
-  debug note instead of a hard error. Production on Vercel serves the script, so
-  no 404 reaches real users. This is the exact failure mode BUG-001 fixed for
-  Lovable; Vercel hosting removes the cause.
+- **Native WebView 404.** Native Capacitor builds serve the app from a local
+  WebView, where `/_vercel/speed-insights/script.js` 404s (BUG-001). The
+  `SpeedInsightsGate` native guard fixes this: it renders nothing on native.
+- **Vercel dashboard step.** Vercel provisions the `/_vercel/speed-insights/*`
+  route only after an operator enables Speed Insights in the project dashboard.
+  If the operator skips this step, the feature collects no data. See the
+  post-merge operational step.
+- **Local-dev 404.** In local dev the script 404s. The package auto-enables
+  `debug` mode when `NODE_ENV` is development or test, so it sends no beacons and
+  logs a debug note, not a hard error.
 
 ## Non-goals
 
 - No change to PostHog, Faro, or the BUG-001 `before_send` filter.
 - No Vercel Web Analytics.
 - No `route`-prop dynamic-route grouping.
-- No environment flag.
+- No environment flag (a runtime platform check gates the render instead).

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "@tanstack/react-query": "^5.83.0",
         "@tanstack/react-virtual": "^3.13.18",
         "@types/papaparse": "^5.3.16",
+        "@vercel/speed-insights": "^2.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -5337,6 +5338,44 @@
       "optionalDependencies": {
         "d3-selection": "^3.0.0",
         "d3-transition": "^3.0.1"
+      }
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-2.0.0.tgz",
+      "integrity": "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/@vitejs/plugin-react-swc": {

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "@tanstack/react-query": "^5.83.0",
     "@tanstack/react-virtual": "^3.13.18",
     "@types/papaparse": "^5.3.16",
+    "@vercel/speed-insights": "^2.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { AppHeader } from "@/components/AppHeader";
 import { AppSidebar } from "@/components/AppSidebar";
 import { SidebarProvider } from "@/components/ui/sidebar";
 import { InstallBanner } from "@/components/InstallBanner";
+import { SpeedInsightsGate } from '@/components/SpeedInsightsGate';
 import { PersonalViewBanner } from "@/components/PersonalViewBanner";
 import { useIsMobile } from '@/hooks/use-mobile';
 import { MobileLayout } from '@/components/employee/MobileLayout';
@@ -349,6 +350,7 @@ const App = () => (
         <Sonner />
         <BrowserRouter>
           <InstallBanner />
+          <SpeedInsightsGate />
           <Routes>
             <Route path="/" element={<ProtectedRoute><Index /></ProtectedRoute>} />
             <Route path="/auth" element={<Auth />} />

--- a/src/components/SpeedInsightsGate.tsx
+++ b/src/components/SpeedInsightsGate.tsx
@@ -1,0 +1,18 @@
+import { Capacitor } from '@capacitor/core';
+import { SpeedInsights } from '@vercel/speed-insights/react';
+
+/**
+ * Render Vercel Speed Insights on the web only.
+ *
+ * Native Capacitor builds serve the app from a local WebView, where the
+ * Vercel script `/_vercel/speed-insights/script.js` 404s (BUG-001,
+ * docs/superpowers/specs/2026-07-04-script-error-noise-design.md). So skip the
+ * beacon on native platforms. See
+ * docs/superpowers/specs/2026-08-09-vercel-speed-insights-design.md.
+ */
+export function SpeedInsightsGate() {
+  if (Capacitor.isNativePlatform()) {
+    return null;
+  }
+  return <SpeedInsights />;
+}

--- a/tests/unit/appNoVercelAnalytics.test.ts
+++ b/tests/unit/appNoVercelAnalytics.test.ts
@@ -4,16 +4,21 @@ import path from 'path';
 import { describe, expect, it } from 'vitest';
 
 /**
- * Regression guard (BUG-001): the app is hosted on Lovable, not Vercel, so
- * `@vercel/analytics` and `@vercel/speed-insights` try to load
- * `/_vercel/insights/script.js`, which 404s on every page load for every
- * user. These packages must not be imported from `src/App.tsx`.
+ * Regression guard: `src/App.tsx` does not add Vercel Web Analytics
+ * (`@vercel/analytics`). PostHog already captures product analytics
+ * (pageviews and pageleaves in `src/main.tsx`), so Web Analytics would
+ * duplicate it. See
+ * docs/superpowers/specs/2026-08-09-vercel-speed-insights-design.md.
  *
- * Scoped to the two exact specifiers (not a blanket ban on the `@vercel/`
- * prefix) so a deliberate future reintroduction stays legible — see
+ * BUG-001 history: this file once also banned `@vercel/speed-insights`,
+ * because the app ran on Lovable, where the Vercel script 404s. Production
+ * now deploys to Vercel, so Speed Insights is deliberately reintroduced
+ * through `src/components/SpeedInsightsGate.tsx` (web only, off on native
+ * Capacitor builds). So the speed-insights ban is gone; the
+ * `@vercel/analytics` ban stays. See
  * docs/superpowers/specs/2026-07-04-script-error-noise-design.md.
  */
-describe('App.tsx does not import dead Vercel analytics packages', () => {
+describe('App.tsx does not import Vercel Web Analytics', () => {
   const appSource = readFileSync(
     path.resolve(__dirname, '../../src/App.tsx'),
     'utf-8'
@@ -21,9 +26,5 @@ describe('App.tsx does not import dead Vercel analytics packages', () => {
 
   it('does not contain the "@vercel/analytics" specifier', () => {
     expect(appSource).not.toContain('@vercel/analytics');
-  });
-
-  it('does not contain the "@vercel/speed-insights" specifier', () => {
-    expect(appSource).not.toContain('@vercel/speed-insights');
   });
 });

--- a/tests/unit/speedInsightsGate.test.tsx
+++ b/tests/unit/speedInsightsGate.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Capacitor } from '@capacitor/core';
+import { SpeedInsightsGate } from '@/components/SpeedInsightsGate';
+
+// Mock the platform check so each test picks web or native.
+vi.mock('@capacitor/core', () => ({
+  Capacitor: { isNativePlatform: vi.fn() },
+}));
+
+// Mock the Vercel component. The real one injects a script tag; the test
+// only checks that the gate renders it or skips it.
+vi.mock('@vercel/speed-insights/react', () => ({
+  SpeedInsights: () => <div data-testid="speed-insights" />,
+}));
+
+describe('SpeedInsightsGate', () => {
+  beforeEach(() => {
+    vi.mocked(Capacitor.isNativePlatform).mockReset();
+  });
+
+  it('renders Speed Insights on the web', () => {
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(false);
+    render(<SpeedInsightsGate />);
+    expect(screen.queryByTestId('speed-insights')).not.toBeNull();
+  });
+
+  it('renders nothing on native', () => {
+    vi.mocked(Capacitor.isNativePlatform).mockReturnValue(true);
+    render(<SpeedInsightsGate />);
+    expect(screen.queryByTestId('speed-insights')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Add the `@vercel/speed-insights` package (v2).
- Add `SpeedInsightsGate`. It renders `<SpeedInsights />` on the web. It returns `null` on native Capacitor builds.
- Mount the gate once in `src/App.tsx` inside `<BrowserRouter>`.

Speed Insights collects Core Web Vitals from real web users. Production deploys to Vercel.

**Why web only.** Native Capacitor builds serve the app from a local WebView. There the Vercel script `/_vercel/speed-insights/script.js` returns 404 (BUG-001 history). So the gate skips the beacon on native platforms.

**Why no web analytics.** PostHog already captures pageviews and pageleaves. `@vercel/analytics` would duplicate that data. A guard test keeps `@vercel/analytics` out of `src/App.tsx`.

## Test plan

- `npm run test -- speedInsightsGate` — 2 tests pass (web renders the beacon; native renders nothing).
- `npm run test -- appNoVercelAnalytics` — 1 test passes (no `@vercel/analytics` import in `src/App.tsx`).
- `npm run typecheck` — pass.
- `npm run build` — pass. The bundle includes `@vercel/speed-insights`.

## Design doc

`docs/superpowers/specs/2026-08-09-vercel-speed-insights-design.md`

## Post-merge step (manual)

Warning: the beacon needs the dashboard toggle, or Vercel collects no data.

After merge and deploy, enable Speed Insights in the Vercel dashboard: project → Speed Insights → Enable.

## Known deferred review findings

Two minor findings stay open by design. All other reviewer notes were positive confirmations (info level). The review found no critical, major, or logic issue in the diff.

1. **`src/components/SpeedInsightsGate.tsx:17` (Codex, minor).** `<SpeedInsights />` has no `route` prop. So the beacon reports raw paths, not grouped patterns, for 5 dynamic routes (`/r/:slug`, `/purchase-orders/:id`, `/invoices/:id`, `/invoices/:id/edit`, `/help/:slug`). The design doc accepts this trade-off in the "No route prop" section. A fix needs new route-match logic (no `useMatches` hook with element-based `Routes`) and deviates from the approved design. Out of scope for this PR.

2. **`tests/unit/speedInsightsGate.test.tsx:2` (ocr-rules, minor).** The rule flags `import React from 'react'` as dead code. This is a false positive. I removed the line and ran the suite. Both tests failed with `ReferenceError: React is not defined`. I restored the line. Do not delete it.

## Local test note

The local `test:db`, `test:e2e`, and `lint` runs fail on this machine from shared local Supabase state, not from this branch. The branch diff touches no tip, sale, e2e, or db files. The main "Unit Tests" CI is green. CI runs on isolated databases and is the real gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Vercel Speed Insights for production web deployments.
  * Speed Insights are automatically omitted from native app builds.
* **Tests**
  * Added coverage confirming web-only rendering across supported platforms.
  * Updated analytics safeguards to allow the new Speed Insights integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->