### PR TITLE
fix(shift-trades): drop gated email column from employees embeds

### DIFF
--- a/src/hooks/useShiftTrades.ts
+++ b/src/hooks/useShiftTrades.ts
@@ -146,13 +146,11 @@ export const useShiftTrades = (
           offered_by:employees!offered_by_employee_id(
             id,
             name,
-            email,
             position
           ),
           accepted_by:employees!accepted_by_employee_id(
             id,
             name,
-            email,
             position
           ),
           target_employee:employees!target_employee_id(
@@ -252,14 +250,12 @@ export const useMyTradeActivity = (
           offered_by:employees!offered_by_employee_id(
             id,
             name,
-            email,
             position,
             area
           ),
           accepted_by:employees!accepted_by_employee_id(
             id,
             name,
-            email,
             position
           )
         `)
@@ -315,7 +311,7 @@ export const useCreateShiftTrade = () => {
         .select(`
           *,
           offered_shift:shifts!offered_shift_id(start_time, end_time, position),
-          offered_by:employees!offered_by_employee_id(name, email)
+          offered_by:employees!offered_by_employee_id(name)
         `)
         .single();
 

--- a/tests/unit/employeesSecureViewReaders.test.ts
+++ b/tests/unit/employeesSecureViewReaders.test.ts
@@ -80,3 +80,26 @@ describe('no base-table read names a masked column', () => {
     expect(named).toEqual([]);
   });
 });
+
+// A PostgREST embed reads the base `employees` table too, even though the
+// syntax differs from a plain .from('employees').select(...). The shift-trade
+// hooks embed the offerer and the claimant with `employees!<fk>(...)`. An
+// embed that names a masked column breaks the same way — "permission denied
+// for table employees" for every caller — but the base-table scan above does
+// not see it. Scan the embed column lists as well.
+const employeeEmbedColumnLists = (source: string): string[] =>
+  [...source.matchAll(/employees![a-z_]+\(([^)]*)\)/g)].map((m) => m[1]);
+
+describe('no employees embed names a masked column', () => {
+  it.each([
+    ['src/hooks/useShiftTrades.ts'],
+    ['src/hooks/useEmployeeTips.tsx'],
+    ['src/hooks/useTemplateLinkedShifts.ts'],
+  ])('%s embeds no masked column from employees', (path) => {
+    const embedded = employeeEmbedColumnLists(readSource(path)).join(',');
+    const named = MASKED_COLUMNS.filter((column) =>
+      new RegExp(`\\b${column}\\b`).test(embedded)
+    );
+    expect(named).toEqual([]);
+  });
+});

--- a/tests/unit/employeesSecureViewReaders.test.ts
+++ b/tests/unit/employeesSecureViewReaders.test.ts
@@ -95,8 +95,13 @@ describe('no employees embed names a masked column', () => {
     ['src/hooks/useShiftTrades.ts'],
     ['src/hooks/useEmployeeTips.tsx'],
     ['src/hooks/useTemplateLinkedShifts.ts'],
-  ])('%s embeds no masked column from employees', (path) => {
-    const embedded = employeeEmbedColumnLists(readSource(path)).join(',');
+  ])('CRITICAL: %s embeds no masked column from employees', (path) => {
+    // The guard must scan at least one embed. An empty match list would let
+    // the masked-column check pass without reading anything, so a renamed hook
+    // or a changed embed syntax would silently disarm the guard.
+    const embeddedColumns = employeeEmbedColumnLists(readSource(path));
+    expect(embeddedColumns).not.toHaveLength(0);
+    const embedded = embeddedColumns.join(',');
     const named = MASKED_COLUMNS.filter((column) =>
       new RegExp(`\\b${column}\\b`).test(embedded)
     );


### PR DESCRIPTION
## Emergency hotfix

Employees get `permission denied for table employees` (Postgres 42501) when they open or post a shift trade. The shift-trade page is blocked for every non-privileged user.

## Root cause

Migration `20260806110000_employee_column_gating` revokes table-level `SELECT` on `public.employees` from `authenticated` and re-grants only a safe column subset. It excludes 8 pay and PII columns — `email` among them. A read that names `email` fails with a GRANT-level error (42501), not a masked `NULL`.

The #727 work moved 11 direct readers to the `employees_secure` view but missed 4 PostgREST embeds in the shift-trade hooks. Each embed still asked for `email`:

| Hook | Embeds fixed |
|------|--------------|
| `useShiftTrades` | `offered_by`, `accepted_by` |
| `useMyTradeActivity` | `offered_by`, `accepted_by` |
| `useCreateShiftTrade` | `offered_by` |

A PostgREST embed (`employees!<fk>(...)`) reads the base `employees` table, so it fails the same way as a direct `.select()`. The base-table scan in the existing guard test did not see embeds.

## Fix

Remove the unused `email` column from all 5 embed positions. No caller reads the embedded `email`. Notification email is sent server-side under `service_role`, which keeps full table `SELECT`, so trade notifications are unaffected.

## Guard test

`employeesSecureViewReaders.test.ts` now scans the `employees!<fk>(...)` embed column lists, not only plain `.from('employees').select(...)`. The test was RED before this fix and is GREEN now. It blocks any embed from re-adding a gated column.

## Verify

- 82 shift-trade hook tests pass
- Guard test 11/11 pass (was 10 pass / 1 fail)
- `npm run typecheck` clean
- `npm run lint` clean
- `npm run build` OK

## Production evidence

- `has_table_privilege('authenticated','public.employees','SELECT')` = `false`
- `has_column_privilege('authenticated','public.employees','email','SELECT')` = `false`
- `employees_secure` view exists; both Aug-6 migrations applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved privacy in shift-trade details by preventing employee email addresses from appearing for offered or accepted trades.
  * New shift-trade responses no longer include the offered employee’s email address.

* **Tests**
  * Added coverage to ensure masked employee information is not exposed through shift-trade data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->