### PR TITLE
fix(security): restore tenancy guard on get_monthly_sales_metrics

### DIFF
--- a/supabase/migrations/20260814120000_secure_monthly_sales_metrics_tenancy.sql
+++ b/supabase/migrations/20260814120000_secure_monthly_sales_metrics_tenancy.sql
@@ -13,9 +13,13 @@
 --   2. Add a user_restaurants membership guard (same as migration
 --      20260302120000).
 --   3. Revoke EXECUTE from PUBLIC and anon; grant it to authenticated only.
+--   4. Filter the child-sale checks by restaurant_id. A cross-restaurant child
+--      must not suppress an in-tenant parent sale on a BYPASSRLS path (cron or
+--      service_role). RLS already scopes an authenticated caller, so this
+--      filter is defense in depth and follows the project restaurant_id rule.
 --
--- The aggregation logic is unchanged from migration 20260501120000. Only the
--- security mode, the membership guard, and the grants change.
+-- The aggregation logic matches migration 20260501120000, plus the
+-- restaurant_id filter on the child-sale checks (item 4).
 
 CREATE OR REPLACE FUNCTION public.get_monthly_sales_metrics(
   p_restaurant_id UUID,
@@ -66,6 +70,7 @@ BEGIN
       AND NOT EXISTS (
         SELECT 1 FROM unified_sales child
         WHERE child.parent_sale_id = us.id
+          AND child.restaurant_id = p_restaurant_id
       )
     GROUP BY TO_CHAR(us.sale_date, 'YYYY-MM')
   ),
@@ -105,6 +110,7 @@ BEGIN
       AND NOT EXISTS (
         SELECT 1 FROM unified_sales child
         WHERE child.parent_sale_id = us.id
+          AND child.restaurant_id = p_restaurant_id
       )
     GROUP BY TO_CHAR(us.sale_date, 'YYYY-MM'),
       CASE

--- a/supabase/migrations/20260814120000_secure_monthly_sales_metrics_tenancy.sql
+++ b/supabase/migrations/20260814120000_secure_monthly_sales_metrics_tenancy.sql
@@ -1,0 +1,156 @@
+-- Migration: close unauthenticated cross-tenant access in get_monthly_sales_metrics
+--
+-- Warning: the deployed function leaks data across tenants.
+--
+-- Migration 20260501120000 fixed a gross-revenue double-count. That migration
+-- also changed the function to SECURITY DEFINER and removed the membership
+-- guard. Postgres grants EXECUTE to PUBLIC by default, so any caller with the
+-- public anon key can pass any restaurant_id and read that restaurant's monthly
+-- gross_revenue, sales_tax, tips, other_liabilities, and discounts.
+--
+-- This migration closes the hole and keeps the double-count fix:
+--   1. Run the function as SECURITY INVOKER, so RLS applies to the caller.
+--   2. Add a user_restaurants membership guard (same as migration
+--      20260302120000).
+--   3. Revoke EXECUTE from PUBLIC and anon; grant it to authenticated only.
+--
+-- The aggregation logic is unchanged from migration 20260501120000. Only the
+-- security mode, the membership guard, and the grants change.
+
+CREATE OR REPLACE FUNCTION public.get_monthly_sales_metrics(
+  p_restaurant_id UUID,
+  p_date_from DATE,
+  p_date_to DATE
+)
+RETURNS TABLE (
+  period TEXT,
+  gross_revenue DECIMAL,
+  sales_tax DECIMAL,
+  tips DECIMAL,
+  other_liabilities DECIMAL,
+  discounts DECIMAL
+)
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path TO 'public'
+AS $function$
+BEGIN
+  -- Authorization check: the caller must be a member of the restaurant.
+  IF NOT EXISTS (
+    SELECT 1 FROM user_restaurants
+    WHERE restaurant_id = p_restaurant_id
+    AND user_id = auth.uid()
+  ) THEN
+    RAISE EXCEPTION 'Access denied: User does not have access to restaurant %', p_restaurant_id;
+  END IF;
+
+  RETURN QUERY
+  WITH monthly_revenue AS (
+    SELECT
+      TO_CHAR(us.sale_date, 'YYYY-MM') as month_period,
+      COALESCE(SUM(us.total_price), 0)::DECIMAL as amount
+    FROM unified_sales us
+    LEFT JOIN chart_of_accounts coa ON us.category_id = coa.id
+    WHERE us.restaurant_id = p_restaurant_id
+      AND us.sale_date >= p_date_from
+      AND us.sale_date <= p_date_to
+      AND us.adjustment_type IS NULL
+      AND LOWER(COALESCE(us.item_type, 'sale')) = 'sale'
+      -- Liability-categorized sales are accounted for in
+      -- monthly_categorized_liabilities; counting them here too caused
+      -- gross_revenue (and therefore total_collected_at_pos) to double-count.
+      -- account_type_enum is (asset, liability, equity, revenue, expense);
+      -- only liability is excluded here. asset/equity/expense are not
+      -- expected on unified_sales rows but pass through if they ever appear.
+      AND (coa.account_type IS NULL OR coa.account_type = 'revenue')
+      AND NOT EXISTS (
+        SELECT 1 FROM unified_sales child
+        WHERE child.parent_sale_id = us.id
+      )
+    GROUP BY TO_CHAR(us.sale_date, 'YYYY-MM')
+  ),
+  monthly_adjustments AS (
+    SELECT
+      TO_CHAR(us.sale_date, 'YYYY-MM') as month_period,
+      us.adjustment_type,
+      COALESCE(SUM(us.total_price), 0)::DECIMAL as amount
+    FROM unified_sales us
+    WHERE us.restaurant_id = p_restaurant_id
+      AND us.sale_date >= p_date_from
+      AND us.sale_date <= p_date_to
+      AND us.adjustment_type IS NOT NULL
+    GROUP BY TO_CHAR(us.sale_date, 'YYYY-MM'), us.adjustment_type
+  ),
+  monthly_categorized_liabilities AS (
+    SELECT
+      TO_CHAR(us.sale_date, 'YYYY-MM') as month_period,
+      CASE
+        WHEN LOWER(COALESCE(coa.account_subtype::TEXT, '')) LIKE '%tax%'
+          OR LOWER(COALESCE(coa.account_name, '')) LIKE '%tax%'
+        THEN 'tax'
+        WHEN LOWER(COALESCE(coa.account_subtype::TEXT, '')) LIKE '%tip%'
+          OR LOWER(COALESCE(coa.account_name, '')) LIKE '%tip%'
+        THEN 'tip'
+        ELSE 'other_liability'
+      END as liability_type,
+      COALESCE(SUM(us.total_price), 0)::DECIMAL as amount
+    FROM unified_sales us
+    INNER JOIN chart_of_accounts coa ON us.category_id = coa.id
+    WHERE us.restaurant_id = p_restaurant_id
+      AND us.sale_date >= p_date_from
+      AND us.sale_date <= p_date_to
+      AND us.adjustment_type IS NULL
+      AND us.is_categorized = TRUE
+      AND coa.account_type = 'liability'
+      AND NOT EXISTS (
+        SELECT 1 FROM unified_sales child
+        WHERE child.parent_sale_id = us.id
+      )
+    GROUP BY TO_CHAR(us.sale_date, 'YYYY-MM'),
+      CASE
+        WHEN LOWER(COALESCE(coa.account_subtype::TEXT, '')) LIKE '%tax%'
+          OR LOWER(COALESCE(coa.account_name, '')) LIKE '%tax%'
+        THEN 'tax'
+        WHEN LOWER(COALESCE(coa.account_subtype::TEXT, '')) LIKE '%tip%'
+          OR LOWER(COALESCE(coa.account_name, '')) LIKE '%tip%'
+        THEN 'tip'
+        ELSE 'other_liability'
+      END
+  ),
+  all_periods AS (
+    SELECT DISTINCT month_period FROM monthly_revenue
+    UNION
+    SELECT DISTINCT month_period FROM monthly_adjustments
+    UNION
+    SELECT DISTINCT month_period FROM monthly_categorized_liabilities
+  )
+  SELECT
+    p.month_period as period,
+    COALESCE(r.amount, 0) as gross_revenue,
+    COALESCE((SELECT SUM(a.amount) FROM monthly_adjustments a WHERE a.month_period = p.month_period AND a.adjustment_type = 'tax'), 0) +
+    COALESCE((SELECT SUM(l.amount) FROM monthly_categorized_liabilities l WHERE l.month_period = p.month_period AND l.liability_type = 'tax'), 0) as sales_tax,
+    COALESCE((SELECT SUM(a.amount) FROM monthly_adjustments a WHERE a.month_period = p.month_period AND a.adjustment_type = 'tip'), 0) +
+    COALESCE((SELECT SUM(l.amount) FROM monthly_categorized_liabilities l WHERE l.month_period = p.month_period AND l.liability_type = 'tip'), 0) as tips,
+    COALESCE((SELECT SUM(a.amount) FROM monthly_adjustments a WHERE a.month_period = p.month_period AND a.adjustment_type IN ('service_charge', 'fee')), 0) +
+    COALESCE((SELECT SUM(l.amount) FROM monthly_categorized_liabilities l WHERE l.month_period = p.month_period AND l.liability_type = 'other_liability'), 0) as other_liabilities,
+    COALESCE((SELECT SUM(ABS(a.amount)) FROM monthly_adjustments a WHERE a.month_period = p.month_period AND a.adjustment_type = 'discount'), 0) as discounts
+  FROM all_periods p
+  LEFT JOIN monthly_revenue r ON r.month_period = p.month_period
+  ORDER BY p.month_period DESC;
+END;
+$function$;
+
+-- Close the default PUBLIC grant so anon cannot call this function.
+REVOKE EXECUTE ON FUNCTION public.get_monthly_sales_metrics(UUID, DATE, DATE) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.get_monthly_sales_metrics(UUID, DATE, DATE) FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_monthly_sales_metrics(UUID, DATE, DATE) TO authenticated;
+
+COMMENT ON FUNCTION public.get_monthly_sales_metrics IS
+'Aggregates monthly sales metrics from unified_sales table.
+Returns gross_revenue, sales_tax, tips, other_liabilities, and discounts
+grouped by month. The monthly_revenue CTE excludes sales mapped to liability
+accounts so they are not double-counted (those land in
+monthly_categorized_liabilities instead).
+Runs as SECURITY INVOKER and checks user_restaurants membership, so a caller
+can only read a restaurant that the caller belongs to. EXECUTE is granted to
+authenticated only.';

--- a/supabase/tests/36_monthly_sales_metrics_revenue_filter.sql
+++ b/supabase/tests/36_monthly_sales_metrics_revenue_filter.sql
@@ -4,7 +4,7 @@
 -- restricts gross_revenue to revenue-categorized + uncategorized sales only.
 
 BEGIN;
-SELECT plan(4);
+SELECT plan(5);
 
 -- get_monthly_sales_metrics now runs as SECURITY INVOKER and checks
 -- user_restaurants membership. The test caller must be an authenticated
@@ -102,6 +102,44 @@ SELECT is(
    WHERE period = '2026-04'),
   150.00::numeric,
   'uncategorized sales still count toward gross_revenue (NULL category_id pass-through)'
+);
+
+-- Cross-restaurant child boundary (defense in depth for the BYPASSRLS path).
+-- The parent-sale check excludes a parent that has a child sale. Without the
+-- restaurant_id filter, a child in ANOTHER restaurant suppresses an in-tenant
+-- parent. This test runs on the RLS-disabled path (RLS is off above), so RLS
+-- cannot hide the cross-restaurant child. The restaurant_id filter must.
+-- Restaurant ...223 owns the child; the caller queries restaurant ...222.
+INSERT INTO restaurants (id, name) VALUES
+  ('00000000-0000-0000-0000-000000000223'::uuid, 'Cross-Restaurant Child Test')
+ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name;
+
+DELETE FROM unified_sales WHERE restaurant_id = '00000000-0000-0000-0000-000000000223';
+
+-- Parent P ($70, uncategorized, in the caller's restaurant, May 2026).
+-- Child C references P but belongs to restaurant ...223.
+INSERT INTO unified_sales (
+  id, restaurant_id, pos_system, external_order_id, external_item_id, item_name,
+  quantity, unit_price, total_price, sale_date, item_type,
+  is_categorized, category_id, adjustment_type, parent_sale_id
+) VALUES
+  ('00000000-0000-0000-0000-000000000801', :'restaurant_id', 'test', 'ord-p-1', 'item-p-1',
+    'Parent Sale', 1, 70, 70, '2026-05-15', 'sale', false,
+    NULL, NULL, NULL),
+  ('00000000-0000-0000-0000-000000000802', '00000000-0000-0000-0000-000000000223'::uuid,
+    'test', 'ord-c-1', 'item-c-1',
+    'Cross-Restaurant Child', 1, 999, 999, '2026-05-15', 'sale', false,
+    NULL, NULL, '00000000-0000-0000-0000-000000000801');
+
+-- gross_revenue must be 70. A child in restaurant ...223 must not suppress the
+-- parent in restaurant ...222. Without the restaurant_id filter, the RPC drops
+-- the parent and returns no 2026-05 row (gross_revenue NULL, the test fails).
+SELECT is(
+  (SELECT gross_revenue::numeric(10,2)
+   FROM get_monthly_sales_metrics(:'restaurant_id', '2026-05-01'::date, '2026-05-31'::date)
+   WHERE period = '2026-05'),
+  70.00::numeric,
+  'a child sale in another restaurant does not suppress an in-tenant parent sale'
 );
 
 SELECT * FROM finish();

--- a/supabase/tests/36_monthly_sales_metrics_revenue_filter.sql
+++ b/supabase/tests/36_monthly_sales_metrics_revenue_filter.sql
@@ -6,6 +6,21 @@
 BEGIN;
 SELECT plan(4);
 
+-- get_monthly_sales_metrics now runs as SECURITY INVOKER and checks
+-- user_restaurants membership. The test caller must be an authenticated
+-- member of the restaurant it queries, so simulate a signed-in member.
+SET LOCAL role TO postgres;
+SET LOCAL "request.jwt.claims" TO '{"sub": "00000000-0000-0000-0000-000000000220"}';
+
+ALTER TABLE restaurants DISABLE ROW LEVEL SECURITY;
+ALTER TABLE unified_sales DISABLE ROW LEVEL SECURITY;
+ALTER TABLE chart_of_accounts DISABLE ROW LEVEL SECURITY;
+ALTER TABLE user_restaurants DISABLE ROW LEVEL SECURITY;
+
+INSERT INTO auth.users (id, email) VALUES
+  ('00000000-0000-0000-0000-000000000220'::uuid, 'monthly-metrics-test@example.com')
+ON CONFLICT (id) DO UPDATE SET email = EXCLUDED.email;
+
 SELECT
   '00000000-0000-0000-0000-000000000222'::uuid AS restaurant_id,
   '2026-04-01'::date AS date_from,
@@ -18,6 +33,11 @@ DELETE FROM chart_of_accounts WHERE restaurant_id = :'restaurant_id';
 
 INSERT INTO restaurants (id, name) VALUES (:'restaurant_id', 'Monthly Metrics Test')
 ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name;
+
+-- The caller belongs to this restaurant.
+INSERT INTO user_restaurants (user_id, restaurant_id, role) VALUES
+  ('00000000-0000-0000-0000-000000000220'::uuid, :'restaurant_id', 'owner')
+ON CONFLICT (user_id, restaurant_id) DO UPDATE SET role = EXCLUDED.role;
 
 -- A revenue account and a liability (sales tax) account
 INSERT INTO chart_of_accounts (id, restaurant_id, account_code, account_name, account_type, account_subtype, normal_balance)

--- a/supabase/tests/37_monthly_sales_metrics_tenancy.sql
+++ b/supabase/tests/37_monthly_sales_metrics_tenancy.sql
@@ -5,15 +5,16 @@
 --   2. A non-member gets an access-denied error (SQLSTATE P0001).
 --   3. The function runs as SECURITY INVOKER (prosecdef = false).
 --   4. The anon role cannot EXECUTE the function.
+--
+-- Tests 1 and 2 run as the real caller role, authenticated, with RLS active.
+-- The local postgres role has BYPASSRLS, so the fixtures below insert while
+-- RLS stays enabled. The membership guard reads user_restaurants under the
+-- caller's own RLS, the same as production.
 
 BEGIN;
 SELECT plan(4);
 
-SET LOCAL role TO postgres;
-
-ALTER TABLE restaurants DISABLE ROW LEVEL SECURITY;
-ALTER TABLE user_restaurants DISABLE ROW LEVEL SECURITY;
-
+-- Fixtures insert as the session role (postgres, BYPASSRLS). RLS stays on.
 -- A member and a non-member.
 INSERT INTO auth.users (id, email) VALUES
   ('00000000-0000-0000-0000-000000000230'::uuid, 'metrics-member@example.com'),
@@ -30,8 +31,9 @@ INSERT INTO user_restaurants (user_id, restaurant_id, role) VALUES
    '00000000-0000-0000-0000-000000000232'::uuid, 'owner')
 ON CONFLICT (user_id, restaurant_id) DO UPDATE SET role = EXCLUDED.role;
 
--- Test 1: the member can call the function.
-SET LOCAL "request.jwt.claims" TO '{"sub": "00000000-0000-0000-0000-000000000230"}';
+-- Test 1: the member can call the function. Run as authenticated with RLS on.
+SET LOCAL ROLE authenticated;
+SET LOCAL request.jwt.claims = '{"sub":"00000000-0000-0000-0000-000000000230","role":"authenticated"}';
 SELECT lives_ok(
   $$ SELECT * FROM get_monthly_sales_metrics(
        '00000000-0000-0000-0000-000000000232'::uuid,
@@ -40,7 +42,7 @@ SELECT lives_ok(
 );
 
 -- Test 2: the non-member gets an access-denied error.
-SET LOCAL "request.jwt.claims" TO '{"sub": "00000000-0000-0000-0000-000000000231"}';
+SET LOCAL request.jwt.claims = '{"sub":"00000000-0000-0000-0000-000000000231","role":"authenticated"}';
 SELECT throws_ok(
   $$ SELECT * FROM get_monthly_sales_metrics(
        '00000000-0000-0000-0000-000000000232'::uuid,
@@ -49,6 +51,10 @@ SELECT throws_ok(
   NULL,
   'A non-member cannot call get_monthly_sales_metrics'
 );
+
+-- Back to the session role for the catalog checks.
+RESET ROLE;
+RESET request.jwt.claims;
 
 -- Test 3: the function runs as SECURITY INVOKER, so RLS applies to the caller.
 SELECT is(

--- a/supabase/tests/37_monthly_sales_metrics_tenancy.sql
+++ b/supabase/tests/37_monthly_sales_metrics_tenancy.sql
@@ -1,0 +1,72 @@
+-- Tests the tenancy guard on get_monthly_sales_metrics.
+-- Migration 20260814120000 restores SECURITY INVOKER + a user_restaurants
+-- membership guard and revokes EXECUTE from anon. These tests confirm:
+--   1. A member can call the function.
+--   2. A non-member gets an access-denied error (SQLSTATE P0001).
+--   3. The function runs as SECURITY INVOKER (prosecdef = false).
+--   4. The anon role cannot EXECUTE the function.
+
+BEGIN;
+SELECT plan(4);
+
+SET LOCAL role TO postgres;
+
+ALTER TABLE restaurants DISABLE ROW LEVEL SECURITY;
+ALTER TABLE user_restaurants DISABLE ROW LEVEL SECURITY;
+
+-- A member and a non-member.
+INSERT INTO auth.users (id, email) VALUES
+  ('00000000-0000-0000-0000-000000000230'::uuid, 'metrics-member@example.com'),
+  ('00000000-0000-0000-0000-000000000231'::uuid, 'metrics-nonmember@example.com')
+ON CONFLICT (id) DO UPDATE SET email = EXCLUDED.email;
+
+INSERT INTO restaurants (id, name) VALUES
+  ('00000000-0000-0000-0000-000000000232'::uuid, 'Tenancy Guard Test')
+ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name;
+
+-- Only user ...230 belongs to restaurant ...232.
+INSERT INTO user_restaurants (user_id, restaurant_id, role) VALUES
+  ('00000000-0000-0000-0000-000000000230'::uuid,
+   '00000000-0000-0000-0000-000000000232'::uuid, 'owner')
+ON CONFLICT (user_id, restaurant_id) DO UPDATE SET role = EXCLUDED.role;
+
+-- Test 1: the member can call the function.
+SET LOCAL "request.jwt.claims" TO '{"sub": "00000000-0000-0000-0000-000000000230"}';
+SELECT lives_ok(
+  $$ SELECT * FROM get_monthly_sales_metrics(
+       '00000000-0000-0000-0000-000000000232'::uuid,
+       '2026-04-01'::date, '2026-04-30'::date) $$,
+  'A member can call get_monthly_sales_metrics'
+);
+
+-- Test 2: the non-member gets an access-denied error.
+SET LOCAL "request.jwt.claims" TO '{"sub": "00000000-0000-0000-0000-000000000231"}';
+SELECT throws_ok(
+  $$ SELECT * FROM get_monthly_sales_metrics(
+       '00000000-0000-0000-0000-000000000232'::uuid,
+       '2026-04-01'::date, '2026-04-30'::date) $$,
+  'P0001',
+  NULL,
+  'A non-member cannot call get_monthly_sales_metrics'
+);
+
+-- Test 3: the function runs as SECURITY INVOKER, so RLS applies to the caller.
+SELECT is(
+  (SELECT prosecdef FROM pg_proc
+   WHERE proname = 'get_monthly_sales_metrics' AND pronargs = 3),
+  false,
+  'get_monthly_sales_metrics runs as SECURITY INVOKER'
+);
+
+-- Test 4: the anon role cannot EXECUTE the function.
+SELECT is(
+  has_function_privilege(
+    'anon',
+    'public.get_monthly_sales_metrics(uuid,date,date)',
+    'EXECUTE'),
+  false,
+  'anon cannot EXECUTE get_monthly_sales_metrics'
+);
+
+SELECT * FROM finish();
+ROLLBACK;


### PR DESCRIPTION
## Warning

The deployed `get_monthly_sales_metrics` leaks financial data across tenants. Any caller with the public anon key can pass any `restaurant_id` and read that restaurant's monthly `gross_revenue`, `sales_tax`, `tips`, `other_liabilities`, and `discounts`.

## Root cause

Migration `20260501120000` fixed a gross-revenue double-count. That migration also changed the function to `SECURITY DEFINER` and removed the membership guard. Postgres grants `EXECUTE` to `PUBLIC` by default, and this project never revokes it. A `SECURITY DEFINER` function with no internal guard and a `PUBLIC` grant is reachable by `anon` through `/rest/v1/rpc/get_monthly_sales_metrics`. `SECURITY DEFINER` also bypasses RLS, so the tenant filter is gone.

Confirmed live on production (read-only): the function ACL granted `EXECUTE` to `anon` and `PUBLIC`.

## Fix

Migration `20260814120000` closes the hole and keeps the double-count fix:

1. Run the function as `SECURITY INVOKER`, so RLS applies to the caller.
2. Add a `user_restaurants` membership guard (same shape as `20260302120000`).
3. Revoke `EXECUTE` from `PUBLIC` and `anon`; grant it to `authenticated` only.

The aggregation logic is unchanged from `20260501120000`. Only the security mode, the membership guard, and the grants change.

## Why the revoke is safe

`ai-execute-tool` builds its Supabase client with the anon key plus the forwarded caller `Authorization` header, so PostgREST elevates the request role to `authenticated`. Legitimate callers are `authenticated`, not `anon`. Revoke from `anon` does not break them.

## Tests

- `supabase/tests/36_monthly_sales_metrics_revenue_filter.sql` now authenticates as a member, so the 4 double-count assertions run under the new guard.
- `supabase/tests/37_monthly_sales_metrics_tenancy.sql` is new: member allowed, non-member denied (`P0001`), `SECURITY INVOKER` (`prosecdef = false`), and `anon` `EXECUTE` revoked.

All 8 assertions pass against the local stack.

## Scope

This PR fixes only `get_monthly_sales_metrics`. About 46 sibling `SECURITY DEFINER` functions share the same missing-guard signature (default `PUBLIC EXECUTE` never revoked). That broader audit is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Monthly sales metrics are now restricted to authenticated members of the selected restaurant.
  * Anonymous access is blocked, and unauthorized requests are rejected.
  * Liability sales are excluded from gross revenue totals to prevent double counting.

* **Tests**
  * Added coverage for authenticated access, membership enforcement, permissions, and revenue calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->