### PR TITLE
fix(dev-workflow): delete the stale hardcoded PRIOR STATE paragraph

### DIFF
--- a/.claude/workflows/dev-continue-verify-and-ship.js
+++ b/.claude/workflows/dev-continue-verify-and-ship.js
@@ -220,9 +220,8 @@ function envelope(body, { skillRef = false } = {}) {
     WAIT_DISCIPLINE,
     '',
     `PRIOR STATE: ${PRIOR_STATE}`,
-    WRITING_STANDARD,
     '',
-    'PRIOR STATE: Phases 4-7 are COMPLETE. All reviewers ran (security/performance/maintainability: no findings; ocr-rules + sound-logic minors fixed in c0872b91). One Codex major — tier-2 route-shell boundary had no resetKey — was escalated and has since been resolved by hand in commit ff3776c1, which adds src/components/RouteShellBoundary.tsx, amends the design doc\'s "Reset semantics" section, and adds tests/unit/RouteShellBoundary.test.tsx. Do NOT re-litigate that decision or re-run the reviewers.',
+    WRITING_STANDARD,
     '',
     body,
   ].join('\n')

--- a/tests/unit/workflowRunawayGuards.test.ts
+++ b/tests/unit/workflowRunawayGuards.test.ts
@@ -260,6 +260,51 @@ describe('dev-continue-verify-and-ship: same containment', () => {
   })
 })
 
+/**
+ * Regression for the incomplete #695 fix. envelope() emitted TWO "PRIOR
+ * STATE:" paragraphs: the parameterized one, then a stale hardcoded one from
+ * the error-boundary branch. The stale paragraph told every agent that phases
+ * 4-7 were complete and that commit ff3776c1 resolved a Codex finding. On
+ * every other branch both claims were false. The guard: each prompt carries
+ * exactly ONE "PRIOR STATE:" line, and its text comes only from
+ * args.priorState or the claim-free fallback.
+ */
+describe('dev-continue-verify-and-ship: PRIOR STATE comes only from the caller', () => {
+  const priorStateCount = (prompt: string) => prompt.split('PRIOR STATE:').length - 1
+
+  it('emits exactly one PRIOR STATE line, carrying the supplied text', async () => {
+    const SUPPLIED = 'The human fixed the fold-gate finding in commit abc1234 on this branch.'
+    const run = await runWorkflow(CONTINUE_SCRIPT, {
+      args: { ...BASE_ARGS, priorState: SUPPLIED },
+      onAgent: responder(),
+    })
+
+    expect(run.calls.length).toBeGreaterThan(0)
+    for (const call of run.calls) {
+      expect(priorStateCount(call.prompt), String(call.label)).toBe(1)
+      expect(call.prompt, String(call.label)).toContain(SUPPLIED)
+      // The stale paragraph's landmarks, none of which may survive anywhere.
+      expect(call.prompt, String(call.label)).not.toContain('ff3776c1')
+      expect(call.prompt, String(call.label)).not.toContain('c0872b91')
+      expect(call.prompt, String(call.label)).not.toContain('RouteShellBoundary')
+      expect(call.prompt, String(call.label)).not.toContain('Phases 4-7 are COMPLETE')
+    }
+  })
+
+  it('falls back to claim-free text that sends the agent to the records', async () => {
+    const run = await runWorkflow(CONTINUE_SCRIPT, { args: BASE_ARGS, onAgent: responder() })
+
+    expect(run.calls.length).toBeGreaterThan(0)
+    for (const call of run.calls) {
+      expect(priorStateCount(call.prompt), String(call.label)).toBe(1)
+      expect(call.prompt, String(call.label)).toContain('progress.md')
+      expect(call.prompt, String(call.label)).not.toContain('ff3776c1')
+      expect(call.prompt, String(call.label)).not.toContain('RouteShellBoundary')
+      expect(call.prompt, String(call.label)).not.toContain('Phases 4-7 are COMPLETE')
+    }
+  })
+})
+
 describe('both scripts still stop cleanly on ordinary gates', () => {
   it('missing args halts before any agent runs', async () => {
     for (const script of [BUILD_SCRIPT, CONTINUE_SCRIPT]) {


### PR DESCRIPTION
## Summary
- Commit 9a4e9afb (#695) parameterized `PRIOR_STATE` in `.claude/workflows/dev-continue-verify-and-ship.js`. It did not delete the old hardcoded literal in `envelope()`.
- Every run then sent two "PRIOR STATE:" paragraphs to each agent. The second paragraph asserted facts from the `feature/react-error-boundaries` branch: commit ff3776c1, `src/components/RouteShellBoundary.tsx`, and "Phases 4-7 are COMPLETE". On every other branch these claims were false. The paragraph also told the agent to not re-run the reviewers.
- `envelope()` now emits "PRIOR STATE:" once. The text comes from `args.priorState` or the claim-free fallback.
- Two regression tests in `tests/unit/workflowRunawayGuards.test.ts` pin the guard. Each prompt must carry exactly one "PRIOR STATE:" line. No prompt may contain `ff3776c1`, `c0872b91`, `RouteShellBoundary`, or "Phases 4-7 are COMPLETE".
- A grep of `.claude/workflows/*.js` finds no other hardcoded SHA or branch fact. `dev-build-and-ship.js` is clean.

## Test plan
- Run `npx vitest run tests/unit/workflowRunawayGuards.test.ts`.
- The two new tests failed before the fix with "expected 2 to be 1" on every phase prompt.
- All 23 tests pass after the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)