### PR TITLE
fix(ai-tools): move every financial sum into SQL; fix break-even math; label budget data

### DIFF
--- a/docs/superpowers/plans/2026-08-14-ai-financial-tools-row-cap-plan.md
+++ b/docs/superpowers/plans/2026-08-14-ai-financial-tools-row-cap-plan.md
@@ -964,9 +964,9 @@ import { computeOperatingCostTotals } from '../../supabase/functions/_shared/ope
 const rows = [
   { cost_type: 'fixed', entry_type: 'value', monthly_value: 4037415, percentage_value: null },
   { cost_type: 'variable', entry_type: 'value', monthly_value: 8200, percentage_value: null },
-  { cost_type: 'variable', entry_type: 'percentage', monthly_value: 0, percentage_value: 27 },
-  { cost_type: 'variable', entry_type: 'percentage', monthly_value: 0, percentage_value: 3 },
-  { cost_type: 'variable', entry_type: 'percentage', monthly_value: 0, percentage_value: 2.5 },
+  { cost_type: 'variable', entry_type: 'percentage', monthly_value: 0, percentage_value: 0.27 },
+  { cost_type: 'variable', entry_type: 'percentage', monthly_value: 0, percentage_value: 0.03 },
+  { cost_type: 'variable', entry_type: 'percentage', monthly_value: 0, percentage_value: 0.025 },
 ];
 
 describe('computeOperatingCostTotals', () => {
@@ -1001,6 +1001,7 @@ describe('computeOperatingCostTotals', () => {
 // supabase/functions/_shared/operatingCostMath.ts
 // Spec §13.2. monthly_value is cents and is 0 for percentage rows;
 // percentage rows carry percentage_value instead.
+// percentage_value is a fraction of net sales (0.27 = 27%).
 export function computeOperatingCostTotals(rows: CostRow[], netSales: number): OperatingCostTotals {
   const by = (t: string) => rows.filter((r) => r.cost_type === t);
   const flat = (rs: CostRow[]) => rs.filter((r) => r.entry_type !== 'percentage')
@@ -1013,14 +1014,14 @@ export function computeOperatingCostTotals(rows: CostRow[], netSales: number): O
   const variableRows = by('variable');
   const variableFlatTotal = flat(variableRows);
   const variablePctSum = pct(variableRows);
-  const variablePercentTotal = (variablePctSum / 100) * netSales;
+  const variablePercentTotal = variablePctSum * netSales;
   const variableTotal = variableFlatTotal + variablePercentTotal;
 
   let variableCostPercentage: number;
   if (variableRows.length === 0) {
     variableCostPercentage = 25; // keep the historical fallback estimate
   } else {
-    variableCostPercentage = variablePctSum + (netSales > 0 ? (variableFlatTotal / netSales) * 100 : 0);
+    variableCostPercentage = variablePctSum * 100 + (netSales > 0 ? (variableFlatTotal / netSales) * 100 : 0);
   }
   const contributionMargin = 100 - variableCostPercentage;
   const totalFixedCosts = fixedTotal + semiVariableTotal;
@@ -1038,7 +1039,7 @@ export function computeOperatingCostTotals(rows: CostRow[], netSales: number): O
 
 - [ ] **Step 4: Run tests — PASS.**
 
-- [ ] **Step 5: Rewire `executeGetOperatingCosts`.** Delete the sums at 2605-2607 and the formulas at 2623-2631. Call `computeOperatingCostTotals(costs, salesTotals.net)` (with `salesTotals` from Task 10 Step 2). Each `entry_type === 'percentage'` item in the response gains `computed_monthly_amount: (item.percentage_value / 100) * salesTotals.net`. Wire the break_even_analysis fields from the returned totals.
+- [ ] **Step 5: Rewire `executeGetOperatingCosts`.** Delete the sums at 2605-2607 and the formulas at 2623-2631. Call `computeOperatingCostTotals(costs, salesTotals.net)` (with `salesTotals` from Task 10 Step 2). Each `entry_type === 'percentage'` item in the response gains `computed_monthly_amount: item.percentage_value * salesTotals.net`. Wire the break_even_analysis fields from the returned totals.
 
 - [ ] **Step 6: Typecheck + full unit suite; commit** (`fix(ai-tools): include percentage items in the variable-cost and break-even math`).
 

--- a/docs/superpowers/plans/2026-08-14-ai-financial-tools-row-cap-plan.md
+++ b/docs/superpowers/plans/2026-08-14-ai-financial-tools-row-cap-plan.md
@@ -1,0 +1,1113 @@
+# AI Financial Tools Row-Cap + Break-Even + Labels Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move every AI-tool financial sum into SQL, fix the variable-cost math, and label budget data and percent units.
+
+**Architecture:** Nine new `SECURITY INVOKER` aggregate RPCs plus one modified RPC replace every raw-fetch-then-`.reduce()` sum in `supabase/functions/ai-execute-tool/index.ts`. A new shared helper (`financialAggregates.ts`) gives every tool one net-sales definition. Fix 2 corrects the operating-costs variable math. Fix 3 labels budget data, renames percent fields, and adds prompt guidance.
+
+**Tech Stack:** PostgreSQL (SQL RPCs + pgTAP), Deno edge functions (TypeScript), Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-08-13-ai-financial-tools-row-cap-design.md` (read §5, §6, §13 before any task).
+
+## Global Constraints
+
+- Write all prose (comments, commit messages, PR body) in STE-aligned English per `CLAUDE.md`.
+- Every new SQL function: `SECURITY INVOKER`, `SET search_path TO 'public'`, `COALESCE(SUM(...), 0)`, then `REVOKE EXECUTE ... FROM PUBLIC; REVOKE ... FROM anon; GRANT EXECUTE ... TO authenticated;` and a `COMMENT ON FUNCTION`.
+- Migration timestamps: use the exact filenames given per task. All are later than `20260814120000` (the merged tenancy hotfix).
+- pgTAP files: fixtures insert as the session role (`postgres`, `BYPASSRLS`), RLS stays enabled. Tenancy assertions run under `SET LOCAL ROLE authenticated` + `SET LOCAL request.jwt.claims`. Follow `supabase/tests/37_monthly_sales_metrics_tenancy.sql`.
+- Never run `git add -A`, `git add .`, or `git commit -a`. Stage explicit paths.
+- End every commit message with: `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+- Test commands: `npm run db:reset` applies migrations locally; `npm run test:db` runs pgTAP; `npx vitest run <file>` runs one unit file; `npm run typecheck` must stay clean.
+- The branch is `fix/ai-financial-tools-row-cap`, worktree `.claude/worktrees/ai-financial-tools-row-cap`, already rebased on `main`.
+- Do not edit `supabase/migrations/20260814120000_secure_monthly_sales_metrics_tenancy.sql`. Build on top of it.
+
+---
+
+### Task 1: Baseline check
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Confirm the branch state**
+
+Run: `git log --oneline -3`
+Expected: `a417b8f9` and `cbfc2ed2` (the two design commits) on top of current `main`.
+
+- [ ] **Step 2: Reset the local DB and run the baseline suites**
+
+Run: `npm run db:reset` then `npm run test:db` then `npm run typecheck`
+Expected: migrations apply clean; pgTAP all green (including `36_` and `37_`); typecheck clean. If `db:reset` fails, stop and report — do not patch migrations.
+
+---
+
+### Task 2: `get_monthly_sales_metrics` — add the `refunds` column (spec §5.1 Change B, §13.1)
+
+**Files:**
+- Create: `supabase/migrations/20260814130000_monthly_sales_metrics_refunds.sql`
+- Modify: `supabase/tests/36_monthly_sales_metrics_revenue_filter.sql`
+
+**Interfaces:**
+- Produces: `get_monthly_sales_metrics(p_restaurant_id UUID, p_date_from DATE, p_date_to DATE)` → `TABLE(period TEXT, gross_revenue DECIMAL, sales_tax DECIMAL, tips DECIMAL, other_liabilities DECIMAL, discounts DECIMAL, refunds DECIMAL)`. Net sales = `gross_revenue - discounts - refunds`. Task 3 and every cluster-1 site consume this.
+
+- [ ] **Step 1: Write the failing pgTAP assertions**
+
+In `36_monthly_sales_metrics_revenue_filter.sql`, change `plan(5)` to `plan(7)`. Before the cross-restaurant-child section, add a refund fixture and two assertions:
+
+```sql
+-- A $20 refund row must land in the refunds column, not in gross_revenue.
+INSERT INTO unified_sales (
+  id, restaurant_id, pos_system, external_order_id, external_item_id, item_name,
+  quantity, unit_price, total_price, sale_date, item_type,
+  is_categorized, category_id, adjustment_type, parent_sale_id
+) VALUES
+  ('00000000-0000-0000-0000-000000000704', :'restaurant_id', 'test', 'ord-rf-1', 'item-rf-1',
+    'Refunded Burger', 1, -20, -20, '2026-04-16', 'refund', false,
+    NULL, NULL, NULL);
+
+SELECT is(
+  (SELECT refunds::numeric(10,2)
+   FROM get_monthly_sales_metrics(:'restaurant_id', :'date_from', :'date_to')
+   WHERE period = '2026-04'),
+  20.00::numeric,
+  'a refund row lands in the refunds column as a positive amount'
+);
+
+SELECT is(
+  (SELECT gross_revenue::numeric(10,2)
+   FROM get_monthly_sales_metrics(:'restaurant_id', :'date_from', :'date_to')
+   WHERE period = '2026-04'),
+  150.00::numeric,
+  'a refund row does not change gross_revenue'
+);
+```
+
+- [ ] **Step 2: Run the test to confirm it fails**
+
+Run: `PGPASSWORD=postgres psql -h localhost -p 54322 -U postgres -d postgres -v ON_ERROR_STOP=1 -f supabase/tests/36_monthly_sales_metrics_revenue_filter.sql`
+Expected: FAIL — `column "refunds" does not exist`.
+
+- [ ] **Step 3: Write the migration**
+
+Create `supabase/migrations/20260814130000_monthly_sales_metrics_refunds.sql`. The return type changes, so `CREATE OR REPLACE` is not allowed — `DROP` first. Reproduce the FULL body of `20260814120000_secure_monthly_sales_metrics_tenancy.sql` (the membership guard, the `child.restaurant_id` filters, `SECURITY INVOKER`, `SET search_path TO 'public'`), with three additions marked `-- NEW` below:
+
+```sql
+-- Migration: add a refunds column to get_monthly_sales_metrics
+--
+-- Net sales = gross_revenue - discounts - refunds (spec §5.1 Change B).
+-- The return type changes, so DROP then CREATE. Keep every security property
+-- from migration 20260814120000: SECURITY INVOKER, the membership guard, the
+-- child restaurant_id filters, and the grants.
+
+DROP FUNCTION IF EXISTS public.get_monthly_sales_metrics(UUID, DATE, DATE);
+
+CREATE FUNCTION public.get_monthly_sales_metrics(
+  p_restaurant_id UUID,
+  p_date_from DATE,
+  p_date_to DATE
+)
+RETURNS TABLE (
+  period TEXT,
+  gross_revenue DECIMAL,
+  sales_tax DECIMAL,
+  tips DECIMAL,
+  other_liabilities DECIMAL,
+  discounts DECIMAL,
+  refunds DECIMAL          -- NEW
+)
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path TO 'public'
+AS $function$
+BEGIN
+  -- Authorization check: the caller must be a member of the restaurant.
+  IF NOT EXISTS (
+    SELECT 1 FROM user_restaurants
+    WHERE restaurant_id = p_restaurant_id
+    AND user_id = auth.uid()
+  ) THEN
+    RAISE EXCEPTION 'Access denied: User does not have access to restaurant %', p_restaurant_id;
+  END IF;
+
+  RETURN QUERY
+  WITH monthly_revenue AS (
+    -- copy VERBATIM from 20260814120000 (filters, comments, child filter)
+    SELECT TO_CHAR(us.sale_date, 'YYYY-MM') as month_period,
+      COALESCE(SUM(us.total_price), 0)::DECIMAL as amount
+    FROM unified_sales us
+    LEFT JOIN chart_of_accounts coa ON us.category_id = coa.id
+    WHERE us.restaurant_id = p_restaurant_id
+      AND us.sale_date >= p_date_from AND us.sale_date <= p_date_to
+      AND us.adjustment_type IS NULL
+      AND LOWER(COALESCE(us.item_type, 'sale')) = 'sale'
+      AND (coa.account_type IS NULL OR coa.account_type = 'revenue')
+      AND NOT EXISTS (
+        SELECT 1 FROM unified_sales child
+        WHERE child.parent_sale_id = us.id
+          AND child.restaurant_id = p_restaurant_id
+      )
+    GROUP BY TO_CHAR(us.sale_date, 'YYYY-MM')
+  ),
+  monthly_refunds AS (   -- NEW
+    SELECT TO_CHAR(us.sale_date, 'YYYY-MM') as month_period,
+      COALESCE(SUM(ABS(us.total_price)), 0)::DECIMAL as amount
+    FROM unified_sales us
+    WHERE us.restaurant_id = p_restaurant_id
+      AND us.sale_date >= p_date_from AND us.sale_date <= p_date_to
+      AND us.adjustment_type IS NULL
+      AND LOWER(COALESCE(us.item_type, '')) = 'refund'
+      AND NOT EXISTS (
+        SELECT 1 FROM unified_sales child
+        WHERE child.parent_sale_id = us.id
+          AND child.restaurant_id = p_restaurant_id
+      )
+    GROUP BY TO_CHAR(us.sale_date, 'YYYY-MM')
+  ),
+  monthly_adjustments AS (
+    -- copy VERBATIM from 20260814120000
+    SELECT TO_CHAR(us.sale_date, 'YYYY-MM') as month_period,
+      us.adjustment_type,
+      COALESCE(SUM(us.total_price), 0)::DECIMAL as amount
+    FROM unified_sales us
+    WHERE us.restaurant_id = p_restaurant_id
+      AND us.sale_date >= p_date_from AND us.sale_date <= p_date_to
+      AND us.adjustment_type IS NOT NULL
+    GROUP BY TO_CHAR(us.sale_date, 'YYYY-MM'), us.adjustment_type
+  ),
+  monthly_categorized_liabilities AS (
+    -- copy VERBATIM from 20260814120000, including the child filter
+    SELECT TO_CHAR(us.sale_date, 'YYYY-MM') as month_period,
+      CASE
+        WHEN LOWER(COALESCE(coa.account_subtype::TEXT, '')) LIKE '%tax%'
+          OR LOWER(COALESCE(coa.account_name, '')) LIKE '%tax%' THEN 'tax'
+        WHEN LOWER(COALESCE(coa.account_subtype::TEXT, '')) LIKE '%tip%'
+          OR LOWER(COALESCE(coa.account_name, '')) LIKE '%tip%' THEN 'tip'
+        ELSE 'other_liability'
+      END as liability_type,
+      COALESCE(SUM(us.total_price), 0)::DECIMAL as amount
+    FROM unified_sales us
+    INNER JOIN chart_of_accounts coa ON us.category_id = coa.id
+    WHERE us.restaurant_id = p_restaurant_id
+      AND us.sale_date >= p_date_from AND us.sale_date <= p_date_to
+      AND us.adjustment_type IS NULL
+      AND us.is_categorized = TRUE
+      AND coa.account_type = 'liability'
+      AND NOT EXISTS (
+        SELECT 1 FROM unified_sales child
+        WHERE child.parent_sale_id = us.id
+          AND child.restaurant_id = p_restaurant_id
+      )
+    GROUP BY TO_CHAR(us.sale_date, 'YYYY-MM'),
+      CASE
+        WHEN LOWER(COALESCE(coa.account_subtype::TEXT, '')) LIKE '%tax%'
+          OR LOWER(COALESCE(coa.account_name, '')) LIKE '%tax%' THEN 'tax'
+        WHEN LOWER(COALESCE(coa.account_subtype::TEXT, '')) LIKE '%tip%'
+          OR LOWER(COALESCE(coa.account_name, '')) LIKE '%tip%' THEN 'tip'
+        ELSE 'other_liability'
+      END
+  ),
+  all_periods AS (
+    SELECT DISTINCT month_period FROM monthly_revenue
+    UNION SELECT DISTINCT month_period FROM monthly_adjustments
+    UNION SELECT DISTINCT month_period FROM monthly_categorized_liabilities
+    UNION SELECT DISTINCT month_period FROM monthly_refunds   -- NEW
+  )
+  SELECT
+    p.month_period as period,
+    COALESCE(r.amount, 0) as gross_revenue,
+    COALESCE((SELECT SUM(a.amount) FROM monthly_adjustments a WHERE a.month_period = p.month_period AND a.adjustment_type = 'tax'), 0) +
+    COALESCE((SELECT SUM(l.amount) FROM monthly_categorized_liabilities l WHERE l.month_period = p.month_period AND l.liability_type = 'tax'), 0) as sales_tax,
+    COALESCE((SELECT SUM(a.amount) FROM monthly_adjustments a WHERE a.month_period = p.month_period AND a.adjustment_type = 'tip'), 0) +
+    COALESCE((SELECT SUM(l.amount) FROM monthly_categorized_liabilities l WHERE l.month_period = p.month_period AND l.liability_type = 'tip'), 0) as tips,
+    COALESCE((SELECT SUM(a.amount) FROM monthly_adjustments a WHERE a.month_period = p.month_period AND a.adjustment_type IN ('service_charge', 'fee')), 0) +
+    COALESCE((SELECT SUM(l.amount) FROM monthly_categorized_liabilities l WHERE l.month_period = p.month_period AND l.liability_type = 'other_liability'), 0) as other_liabilities,
+    COALESCE((SELECT SUM(ABS(a.amount)) FROM monthly_adjustments a WHERE a.month_period = p.month_period AND a.adjustment_type = 'discount'), 0) as discounts,
+    COALESCE(rf.amount, 0) as refunds   -- NEW
+  FROM all_periods p
+  LEFT JOIN monthly_revenue r ON r.month_period = p.month_period
+  LEFT JOIN monthly_refunds rf ON rf.month_period = p.month_period   -- NEW
+  ORDER BY p.month_period DESC;
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.get_monthly_sales_metrics(UUID, DATE, DATE) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.get_monthly_sales_metrics(UUID, DATE, DATE) FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_monthly_sales_metrics(UUID, DATE, DATE) TO authenticated;
+
+COMMENT ON FUNCTION public.get_monthly_sales_metrics IS
+'Monthly sales metrics from unified_sales: gross_revenue, sales_tax, tips,
+other_liabilities, discounts, refunds. Net sales = gross_revenue - discounts -
+refunds. Runs as SECURITY INVOKER with a user_restaurants membership guard.
+EXECUTE is granted to authenticated only.';
+```
+
+- [ ] **Step 4: Apply and run the tests**
+
+Run: `npm run db:reset` then the two pgTAP files:
+`PGPASSWORD=postgres psql -h localhost -p 54322 -U postgres -d postgres -v ON_ERROR_STOP=1 -f supabase/tests/36_monthly_sales_metrics_revenue_filter.sql` and the same for `37_monthly_sales_metrics_tenancy.sql`.
+Expected: `36_` 7/7, `37_` 4/4. `37_` must stay green with no edits — it pins `prosecdef = false` and `anon EXECUTE = false` through the DROP/CREATE.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/migrations/20260814130000_monthly_sales_metrics_refunds.sql supabase/tests/36_monthly_sales_metrics_revenue_filter.sql
+git commit -m "feat(rpc): add a refunds column to get_monthly_sales_metrics"
+```
+
+---
+
+### Task 3: Shared helper `financialAggregates.ts` + unit tests
+
+**Files:**
+- Create: `supabase/functions/_shared/financialAggregates.ts`
+- Test: `tests/unit/financialAggregates.test.ts`
+
+**Interfaces:**
+- Consumes: the Task 2 RPC row shape.
+- Produces (every rewiring task consumes these):
+
+```typescript
+export interface NetSalesTotals {
+  gross: number; discounts: number; refunds: number;
+  salesTax: number; tips: number; otherLiabilities: number;
+  net: number;  // gross - discounts - refunds
+}
+export function sumMonthlyMetrics(rows: MonthlyMetricsRow[] | null): NetSalesTotals;
+export async function fetchNetSales(
+  supabase: SupabaseClient, restaurantId: string,
+  startDate: string, endDate: string        // 'YYYY-MM-DD'
+): Promise<NetSalesTotals>;                  // throws on RPC error
+export function sumMonthlyFoodCost(rows: { period: string; food_cost: number }[] | null): number;
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/unit/financialAggregates.test.ts`. Model the RPC mock on `tests/unit/periodMetrics.test.ts` (mock the builder chain, not a bare promise — lesson L1846):
+
+```typescript
+import { describe, it, expect, vi } from 'vitest';
+import { sumMonthlyMetrics, fetchNetSales, sumMonthlyFoodCost } from '../../supabase/functions/_shared/financialAggregates';
+
+const row = (over = {}) => ({
+  period: '2026-07', gross_revenue: 100, sales_tax: 8, tips: 5,
+  other_liabilities: 0, discounts: 3, refunds: 2, ...over,
+});
+
+describe('sumMonthlyMetrics', () => {
+  it('sums across months and computes net = gross - discounts - refunds', () => {
+    const t = sumMonthlyMetrics([row(), row({ period: '2026-06', gross_revenue: 50 })]);
+    expect(t.gross).toBe(150);
+    expect(t.net).toBe(150 - 6 - 4);
+  });
+  it('returns zeros for null and for an empty array', () => {
+    expect(sumMonthlyMetrics(null).net).toBe(0);
+    expect(sumMonthlyMetrics([]).gross).toBe(0);
+  });
+  it('treats a null numeric field as 0', () => {
+    expect(sumMonthlyMetrics([row({ refunds: null as unknown as number })]).net).toBe(97);
+  });
+});
+
+describe('fetchNetSales', () => {
+  it('calls the RPC with the exact arguments and sums the rows', async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: [row()], error: null });
+    const t = await fetchNetSales({ rpc } as never, 'rid', '2026-07-01', '2026-07-31');
+    expect(rpc).toHaveBeenCalledWith('get_monthly_sales_metrics', {
+      p_restaurant_id: 'rid', p_date_from: '2026-07-01', p_date_to: '2026-07-31',
+    });
+    expect(t.net).toBe(95);
+  });
+  it('throws on an RPC error instead of a silent zero', async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: null, error: { message: 'boom' } });
+    await expect(fetchNetSales({ rpc } as never, 'rid', 'a', 'b')).rejects.toThrow('boom');
+  });
+});
+
+describe('sumMonthlyFoodCost', () => {
+  it('sums month rows and returns 0 for null', () => {
+    expect(sumMonthlyFoodCost([{ period: '2026-07', food_cost: 10.5 }, { period: '2026-06', food_cost: 2 }])).toBe(12.5);
+    expect(sumMonthlyFoodCost(null)).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `npx vitest run tests/unit/financialAggregates.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the helper**
+
+```typescript
+// supabase/functions/_shared/financialAggregates.ts
+// One net-sales definition for every AI financial tool.
+// Net sales = gross_revenue - discounts - refunds (see the spec, §5.1).
+
+export interface MonthlyMetricsRow {
+  period: string; gross_revenue: number; sales_tax: number; tips: number;
+  other_liabilities: number; discounts: number; refunds: number;
+}
+export interface NetSalesTotals {
+  gross: number; discounts: number; refunds: number;
+  salesTax: number; tips: number; otherLiabilities: number; net: number;
+}
+const n = (v: number | null | undefined) => Number(v ?? 0);
+
+export function sumMonthlyMetrics(rows: MonthlyMetricsRow[] | null): NetSalesTotals {
+  const t = { gross: 0, discounts: 0, refunds: 0, salesTax: 0, tips: 0, otherLiabilities: 0, net: 0 };
+  for (const r of rows ?? []) {
+    t.gross += n(r.gross_revenue); t.discounts += n(r.discounts); t.refunds += n(r.refunds);
+    t.salesTax += n(r.sales_tax); t.tips += n(r.tips); t.otherLiabilities += n(r.other_liabilities);
+  }
+  t.net = t.gross - t.discounts - t.refunds;
+  return t;
+}
+
+export async function fetchNetSales(
+  supabase: { rpc: (fn: string, args: Record<string, unknown>) => Promise<{ data: unknown; error: { message: string } | null }> },
+  restaurantId: string, startDate: string, endDate: string,
+): Promise<NetSalesTotals> {
+  const { data, error } = await supabase.rpc('get_monthly_sales_metrics', {
+    p_restaurant_id: restaurantId, p_date_from: startDate, p_date_to: endDate,
+  });
+  if (error) throw new Error(`get_monthly_sales_metrics failed: ${error.message}`);
+  return sumMonthlyMetrics(data as MonthlyMetricsRow[] | null);
+}
+
+export function sumMonthlyFoodCost(rows: { period: string; food_cost: number }[] | null): number {
+  return (rows ?? []).reduce((s, r) => s + n(r.food_cost), 0);
+}
+```
+
+- [ ] **Step 4: Run tests to confirm pass**
+
+Run: `npx vitest run tests/unit/financialAggregates.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/functions/_shared/financialAggregates.ts tests/unit/financialAggregates.test.ts
+git commit -m "feat(ai-tools): shared net-sales helper over the monthly metrics RPC"
+```
+
+---
+
+### Task 4: RPCs `get_sales_by_category` + `get_top_sold_items` (cluster 2)
+
+**Files:**
+- Create: `supabase/migrations/20260814131000_get_sales_by_category.sql`
+- Create: `supabase/migrations/20260814132000_get_top_sold_items.sql`
+- Test: `supabase/tests/38_sales_breakdown_rpcs.sql`
+
+**Interfaces:**
+- Produces: `get_sales_by_category(p_restaurant_id UUID, p_start_date DATE, p_end_date DATE)` → `TABLE(category_id UUID, category_name TEXT, revenue NUMERIC, item_count BIGINT)`; `get_top_sold_items(p_restaurant_id UUID, p_start_date DATE, p_end_date DATE, p_limit INT DEFAULT 10)` → `TABLE(item_name TEXT, revenue NUMERIC, quantity NUMERIC, sale_count BIGINT)`. Task 11 consumes both.
+
+- [ ] **Step 1: Write the failing pgTAP file**
+
+Create `supabase/tests/38_sales_breakdown_rpcs.sql` with `plan(6)`. Fixtures follow the `36_` idiom (own restaurant `...240`, member user `...241`, second restaurant `...242` for tenancy). Assertions:
+1. `get_sales_by_category` groups two categorized sales and one uncategorized sale into the right buckets (`lives_ok` + `is` on revenue per bucket).
+2. It excludes an `adjustment_type = 'tax'` row and a split child row.
+3. `get_top_sold_items` orders by revenue and honors `p_limit` (insert 3 item names, assert `p_limit => 2` returns 2 rows, top first).
+4. Second restaurant's rows never contribute (`is` count with foreign rows present).
+5. Tenancy: under `SET LOCAL ROLE authenticated` as a NON-member, `get_sales_by_category` for the foreign restaurant returns zero rows (`is` count 0).
+6. `has_function_privilege('anon', 'public.get_sales_by_category(uuid,date,date)', 'EXECUTE')` is false.
+
+- [ ] **Step 2: Run to confirm failure**
+
+Run: `PGPASSWORD=postgres psql -h localhost -p 54322 -U postgres -d postgres -v ON_ERROR_STOP=1 -f supabase/tests/38_sales_breakdown_rpcs.sql`
+Expected: FAIL — `function get_sales_by_category(...) does not exist`.
+
+- [ ] **Step 3: Write the two migrations**
+
+`20260814131000_get_sales_by_category.sql`:
+
+```sql
+-- Sales revenue grouped by category for one restaurant and date range.
+-- SECURITY INVOKER: RLS on unified_sales scopes the caller (spec §8).
+CREATE OR REPLACE FUNCTION public.get_sales_by_category(
+  p_restaurant_id UUID, p_start_date DATE, p_end_date DATE
+)
+RETURNS TABLE(category_id UUID, category_name TEXT, revenue NUMERIC, item_count BIGINT)
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path TO 'public'
+AS $$
+  SELECT us.category_id,
+         COALESCE(coa.account_name, 'Uncategorized') AS category_name,
+         COALESCE(SUM(us.total_price), 0)::NUMERIC AS revenue,
+         COUNT(*)::BIGINT AS item_count
+  FROM unified_sales us
+  LEFT JOIN chart_of_accounts coa ON coa.id = us.category_id
+  WHERE us.restaurant_id = p_restaurant_id
+    AND us.sale_date >= p_start_date AND us.sale_date <= p_end_date
+    AND us.adjustment_type IS NULL
+    AND LOWER(COALESCE(us.item_type, 'sale')) = 'sale'
+    AND NOT EXISTS (
+      SELECT 1 FROM unified_sales child
+      WHERE child.parent_sale_id = us.id
+        AND child.restaurant_id = p_restaurant_id)
+  GROUP BY us.category_id, coa.account_name
+  ORDER BY revenue DESC;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_sales_by_category(UUID, DATE, DATE) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.get_sales_by_category(UUID, DATE, DATE) FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_sales_by_category(UUID, DATE, DATE) TO authenticated;
+
+COMMENT ON FUNCTION public.get_sales_by_category IS
+'Revenue by category from unified_sales. Excludes adjustments, refunds, and
+split parents. SECURITY INVOKER; EXECUTE for authenticated only.';
+```
+
+`20260814132000_get_top_sold_items.sql` — same shell, body:
+
+```sql
+CREATE OR REPLACE FUNCTION public.get_top_sold_items(
+  p_restaurant_id UUID, p_start_date DATE, p_end_date DATE, p_limit INT DEFAULT 10
+)
+RETURNS TABLE(item_name TEXT, revenue NUMERIC, quantity NUMERIC, sale_count BIGINT)
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path TO 'public'
+AS $$
+  SELECT us.item_name,
+         COALESCE(SUM(us.total_price), 0)::NUMERIC AS revenue,
+         COALESCE(SUM(us.quantity), 0)::NUMERIC AS quantity,
+         COUNT(*)::BIGINT AS sale_count
+  FROM unified_sales us
+  WHERE us.restaurant_id = p_restaurant_id
+    AND us.sale_date >= p_start_date AND us.sale_date <= p_end_date
+    AND us.adjustment_type IS NULL
+    AND LOWER(COALESCE(us.item_type, 'sale')) = 'sale'
+    AND NOT EXISTS (
+      SELECT 1 FROM unified_sales child
+      WHERE child.parent_sale_id = us.id
+        AND child.restaurant_id = p_restaurant_id)
+  GROUP BY us.item_name
+  ORDER BY revenue DESC
+  LIMIT p_limit;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_top_sold_items(UUID, DATE, DATE, INT) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.get_top_sold_items(UUID, DATE, DATE, INT) FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_top_sold_items(UUID, DATE, DATE, INT) TO authenticated;
+
+COMMENT ON FUNCTION public.get_top_sold_items IS
+'Top items by revenue from unified_sales. Same exclusions as
+get_sales_by_category. SECURITY INVOKER; EXECUTE for authenticated only.';
+```
+
+- [ ] **Step 4: Apply and run**
+
+Run: `npm run db:reset` then the pgTAP file from Step 2.
+Expected: 6/6 pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/migrations/20260814131000_get_sales_by_category.sql supabase/migrations/20260814132000_get_top_sold_items.sql supabase/tests/38_sales_breakdown_rpcs.sql
+git commit -m "feat(rpc): sales-by-category and top-items aggregates"
+```
+
+---
+
+### Task 5: RPC `get_inventory_usage_by_month` (cluster 3, COGS)
+
+**Files:**
+- Create: `supabase/migrations/20260814133000_get_inventory_usage_by_month.sql`
+- Test: `supabase/tests/39_inventory_usage_by_month.sql`
+
+**Interfaces:**
+- Produces: `get_inventory_usage_by_month(p_restaurant_id UUID, p_start_date DATE, p_end_date DATE)` → `TABLE(period TEXT, food_cost NUMERIC)`. `food_cost = ABS(SUM(total_cost))` per month. Tasks 10-11 consume via `sumMonthlyFoodCost`.
+
+- [ ] **Step 1: Write the failing pgTAP file** — `plan(5)`:
+1. Two usage rows in one month sum, `ABS(SUM(...))` semantics: a `-10` usage row and a `+2` reversal row give `food_cost = 8` (not 12).
+2. A non-usage row (`transaction_type = 'purchase'`) is excluded.
+3. **Boundary (spec §1.3):** a usage row with `created_at = (p_end_date || ' 21:00:00+00')::timestamptz` on the END day contributes.
+4. An empty month range returns zero rows (not an error) — `lives_ok` + count 0.
+5. Tenancy: a non-member under `authenticated` gets zero rows for a foreign restaurant.
+
+- [ ] **Step 2: Run to confirm failure** — expected `function ... does not exist`.
+
+- [ ] **Step 3: Write the migration**
+
+```sql
+CREATE OR REPLACE FUNCTION public.get_inventory_usage_by_month(
+  p_restaurant_id UUID, p_start_date DATE, p_end_date DATE
+)
+RETURNS TABLE(period TEXT, food_cost NUMERIC)
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path TO 'public'
+AS $$
+  SELECT TO_CHAR(it.created_at AT TIME ZONE 'UTC', 'YYYY-MM') AS period,
+         ABS(COALESCE(SUM(it.total_cost), 0))::NUMERIC AS food_cost
+  FROM inventory_transactions it
+  WHERE it.restaurant_id = p_restaurant_id
+    AND it.transaction_type = 'usage'
+    -- Explicit UTC bounds. Includes the full end day (spec §5.4).
+    AND it.created_at >= (p_start_date::timestamp AT TIME ZONE 'UTC')
+    AND it.created_at < ((p_end_date + 1)::timestamp AT TIME ZONE 'UTC')
+  GROUP BY 1
+  ORDER BY 1;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_inventory_usage_by_month(UUID, DATE, DATE) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.get_inventory_usage_by_month(UUID, DATE, DATE) FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_inventory_usage_by_month(UUID, DATE, DATE) TO authenticated;
+
+COMMENT ON FUNCTION public.get_inventory_usage_by_month IS
+'Monthly COGS from inventory_transactions usage rows, ABS(SUM(total_cost)) per
+month, full end day included, explicit UTC bounds. SECURITY INVOKER.';
+```
+
+- [ ] **Step 4: Apply and run** — `npm run db:reset`, run the file, expected 5/5.
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/migrations/20260814133000_get_inventory_usage_by_month.sql supabase/tests/39_inventory_usage_by_month.sql
+git commit -m "feat(rpc): monthly inventory-usage aggregate with a correct end day"
+```
+
+---
+
+### Task 6: RPC `get_journal_expense_total` (cluster 4, OpEx)
+
+**Files:**
+- Create: `supabase/migrations/20260814134000_get_journal_expense_total.sql`
+- Test: `supabase/tests/40_journal_expense_total.sql`
+
+**Interfaces:**
+- Produces: `get_journal_expense_total(p_restaurant_id UUID, p_start_date DATE, p_end_date DATE)` → `NUMERIC` (`SUM(debit_amount - credit_amount)` over expense accounts).
+
+- [ ] **Step 1: Failing pgTAP** — `plan(4)`: (1) two expense lines net to `debit - credit`; (2) a revenue-account line is excluded; (3) returns `0`, not NULL, for an empty range (`is(..., 0::numeric, ...)`); (4) tenancy zero for a non-member (the scalar returns 0 because RLS hides the joined rows).
+
+- [ ] **Step 2: Run to confirm failure.**
+
+- [ ] **Step 3: Migration**
+
+```sql
+CREATE OR REPLACE FUNCTION public.get_journal_expense_total(
+  p_restaurant_id UUID, p_start_date DATE, p_end_date DATE
+)
+RETURNS NUMERIC
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path TO 'public'
+AS $$
+  SELECT COALESCE(SUM(jel.debit_amount - jel.credit_amount), 0)::NUMERIC
+  FROM journal_entry_lines jel
+  JOIN journal_entries je ON je.id = jel.journal_entry_id
+  JOIN chart_of_accounts coa ON coa.id = jel.account_id
+  WHERE je.restaurant_id = p_restaurant_id
+    AND coa.restaurant_id = p_restaurant_id
+    AND coa.account_type = 'expense'
+    AND je.entry_date >= p_start_date AND je.entry_date <= p_end_date;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_journal_expense_total(UUID, DATE, DATE) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.get_journal_expense_total(UUID, DATE, DATE) FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_journal_expense_total(UUID, DATE, DATE) TO authenticated;
+
+COMMENT ON FUNCTION public.get_journal_expense_total IS
+'Net expense debits from journal_entry_lines for one restaurant and range.
+Replaces the expense-account id round-trip. SECURITY INVOKER.';
+```
+
+- [ ] **Step 4: Apply + run — expected 4/4.**
+- [ ] **Step 5: Commit** (`feat(rpc): journal expense total aggregate`, both files).
+
+---
+
+### Task 7: RPC `get_inventory_valuation` (cluster 5)
+
+**Files:**
+- Create: `supabase/migrations/20260814135000_get_inventory_valuation.sql`
+- Test: `supabase/tests/41_inventory_valuation.sql`
+
+**Interfaces:**
+- Produces: `get_inventory_valuation(p_restaurant_id UUID)` → `TABLE(total_value NUMERIC, item_count BIGINT, low_stock_count BIGINT)`.
+
+- [ ] **Step 1: Failing pgTAP** — `plan(4)`: (1) `total_value = SUM(current_stock * cost_per_unit)` over a 2-product fixture; (2) `low_stock_count` uses `current_stock <= COALESCE(par_level_min, 0)` — a product with `par_level_min NULL` and stock 0 counts, stock 5 does not; (3) empty restaurant returns one row of zeros; (4) tenancy zero-row for a non-member.
+
+- [ ] **Step 2: Run to confirm failure.**
+
+- [ ] **Step 3: Migration**
+
+```sql
+CREATE OR REPLACE FUNCTION public.get_inventory_valuation(p_restaurant_id UUID)
+RETURNS TABLE(total_value NUMERIC, item_count BIGINT, low_stock_count BIGINT)
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path TO 'public'
+AS $$
+  SELECT COALESCE(SUM(p.current_stock * p.cost_per_unit), 0)::NUMERIC,
+         COUNT(*)::BIGINT,
+         COUNT(*) FILTER (WHERE p.current_stock <= COALESCE(p.par_level_min, 0))::BIGINT
+  FROM products p
+  WHERE p.restaurant_id = p_restaurant_id;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_inventory_valuation(UUID) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.get_inventory_valuation(UUID) FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_inventory_valuation(UUID) TO authenticated;
+
+COMMENT ON FUNCTION public.get_inventory_valuation IS
+'Inventory value, item count, and low-stock count from products. The low-stock
+predicate is current_stock <= COALESCE(par_level_min, 0). SECURITY INVOKER.';
+```
+
+- [ ] **Step 4: Apply + run — expected 4/4.**
+- [ ] **Step 5: Commit** (`feat(rpc): inventory valuation aggregate`, both files).
+
+---
+
+### Task 8: Bank RPCs — summary, spending by category, daily series (cluster 6)
+
+**Files:**
+- Create: `supabase/migrations/20260814136000_get_bank_aggregates.sql` (all three functions, one file)
+- Test: `supabase/tests/42_bank_aggregates.sql`
+
+**Interfaces:**
+- Produces (Task 12 consumes):
+  - `get_bank_transaction_summary(p_restaurant_id UUID, p_start_date DATE, p_end_date DATE, p_bank_account_id UUID DEFAULT NULL, p_statuses TEXT[] DEFAULT NULL)` → `TABLE(inflow NUMERIC, outflow NUMERIC, net NUMERIC, tx_count BIGINT, inflow_count BIGINT, outflow_count BIGINT, avg_inflow NUMERIC, max_inflow NUMERIC)`
+  - `get_bank_spending_by_category(p_restaurant_id UUID, p_start_date DATE, p_end_date DATE, p_statuses TEXT[] DEFAULT NULL)` → `TABLE(category_id UUID, category_name TEXT, spend NUMERIC, tx_count BIGINT)`
+  - `get_bank_transactions_daily(p_restaurant_id UUID, p_start_date DATE, p_end_date DATE, p_bank_account_id UUID DEFAULT NULL)` → `TABLE(day DATE, inflow NUMERIC, outflow NUMERIC, net NUMERIC)`
+
+- [ ] **Step 1: Failing pgTAP** — `plan(8)`: (1) summary splits inflow/outflow/net over a mixed fixture; (2) `p_statuses => ARRAY['posted']` excludes a `pending` row; `NULL` includes it; (3) `p_bank_account_id` filters on `connected_bank_id` (spec §11.1 item 1 — insert two banks, scope to one); (4) spending-by-category groups two negative rows, positive rows excluded; (5) an uncategorized negative row lands in the `Uncategorized` bucket; (6) daily series has one row per day with the right net; (7) summary returns one all-zero row for an empty range (COALESCE guard); (8) tenancy zero for a non-member.
+
+- [ ] **Step 2: Run to confirm failure.**
+
+- [ ] **Step 3: Migration.** All three follow the same shell. Bodies:
+
+```sql
+CREATE OR REPLACE FUNCTION public.get_bank_transaction_summary(
+  p_restaurant_id UUID, p_start_date DATE, p_end_date DATE,
+  p_bank_account_id UUID DEFAULT NULL, p_statuses TEXT[] DEFAULT NULL
+)
+RETURNS TABLE(inflow NUMERIC, outflow NUMERIC, net NUMERIC, tx_count BIGINT,
+              inflow_count BIGINT, outflow_count BIGINT, avg_inflow NUMERIC, max_inflow NUMERIC)
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path TO 'public'
+AS $$
+  SELECT COALESCE(SUM(bt.amount) FILTER (WHERE bt.amount > 0), 0)::NUMERIC,
+         ABS(COALESCE(SUM(bt.amount) FILTER (WHERE bt.amount < 0), 0))::NUMERIC,
+         COALESCE(SUM(bt.amount), 0)::NUMERIC,
+         COUNT(*)::BIGINT,
+         COUNT(*) FILTER (WHERE bt.amount > 0)::BIGINT,
+         COUNT(*) FILTER (WHERE bt.amount < 0)::BIGINT,
+         COALESCE(AVG(bt.amount) FILTER (WHERE bt.amount > 0), 0)::NUMERIC,
+         COALESCE(MAX(bt.amount) FILTER (WHERE bt.amount > 0), 0)::NUMERIC
+  FROM bank_transactions bt
+  WHERE bt.restaurant_id = p_restaurant_id
+    AND bt.transaction_date >= p_start_date AND bt.transaction_date <= p_end_date
+    AND (p_bank_account_id IS NULL OR bt.connected_bank_id = p_bank_account_id)
+    AND (p_statuses IS NULL OR bt.status::text = ANY(p_statuses));
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_bank_spending_by_category(
+  p_restaurant_id UUID, p_start_date DATE, p_end_date DATE, p_statuses TEXT[] DEFAULT NULL
+)
+RETURNS TABLE(category_id UUID, category_name TEXT, spend NUMERIC, tx_count BIGINT)
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path TO 'public'
+AS $$
+  SELECT bt.category_id,
+         COALESCE(coa.account_name, 'Uncategorized'),
+         ABS(COALESCE(SUM(bt.amount), 0))::NUMERIC,
+         COUNT(*)::BIGINT
+  FROM bank_transactions bt
+  LEFT JOIN chart_of_accounts coa ON coa.id = bt.category_id
+  WHERE bt.restaurant_id = p_restaurant_id
+    AND bt.transaction_date >= p_start_date AND bt.transaction_date <= p_end_date
+    AND bt.amount < 0
+    AND (p_statuses IS NULL OR bt.status::text = ANY(p_statuses))
+  GROUP BY bt.category_id, coa.account_name
+  ORDER BY 3 DESC;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_bank_transactions_daily(
+  p_restaurant_id UUID, p_start_date DATE, p_end_date DATE, p_bank_account_id UUID DEFAULT NULL
+)
+RETURNS TABLE(day DATE, inflow NUMERIC, outflow NUMERIC, net NUMERIC)
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path TO 'public'
+AS $$
+  SELECT bt.transaction_date,
+         COALESCE(SUM(bt.amount) FILTER (WHERE bt.amount > 0), 0)::NUMERIC,
+         ABS(COALESCE(SUM(bt.amount) FILTER (WHERE bt.amount < 0), 0))::NUMERIC,
+         COALESCE(SUM(bt.amount), 0)::NUMERIC
+  FROM bank_transactions bt
+  WHERE bt.restaurant_id = p_restaurant_id
+    AND bt.transaction_date >= p_start_date AND bt.transaction_date <= p_end_date
+    AND (p_bank_account_id IS NULL OR bt.connected_bank_id = p_bank_account_id)
+  GROUP BY bt.transaction_date
+  ORDER BY bt.transaction_date;
+$$;
+```
+
+Then the six REVOKE/two GRANT lines per function (same pattern as Task 4) and one `COMMENT ON FUNCTION` each.
+
+- [ ] **Step 4: Apply + run — expected 8/8.**
+- [ ] **Step 5: Commit** (`feat(rpc): bank transaction aggregates (summary, category, daily)`, both files).
+
+---
+
+### Task 9: RPC `get_expense_health_metrics` + the bank index
+
+**Files:**
+- Create: `supabase/migrations/20260814137000_get_expense_health_metrics.sql`
+- Create: `supabase/migrations/20260814138000_idx_bank_transactions_restaurant_date.sql`
+- Test: `supabase/tests/43_expense_health_metrics.sql`
+
+**Interfaces:**
+- Produces: `get_expense_health_metrics(p_restaurant_id UUID, p_start_date DATE, p_end_date DATE, p_fee_patterns TEXT[], p_bank_account_id UUID DEFAULT NULL)` → `TABLE(revenue NUMERIC, food_cost NUMERIC, labor_cost NUMERIC, processing_fees NUMERIC, total_outflows NUMERIC, uncategorized_spend NUMERIC)`. `p_fee_patterns` receives LOWERCASE `LIKE` patterns (`'%stripe%'`); the TypeScript caller maps its `processingFeePatterns` list to `%pattern%` form.
+
+- [ ] **Step 1: Failing pgTAP** — `plan(7)`: one fixture with a positive row, a food-account outflow, a payroll-account outflow, a fee-matching outflow (`description = 'STRIPE FEE'`, pattern `'%stripe%'`), an uncategorized non-split outflow, and a `void`-status row that must be excluded (`status IN ('posted','pending')` filter). Assert each of the six output columns, plus tenancy zero for a non-member.
+
+- [ ] **Step 2: Run to confirm failure.**
+
+- [ ] **Step 3: Migrations.** Function:
+
+```sql
+CREATE OR REPLACE FUNCTION public.get_expense_health_metrics(
+  p_restaurant_id UUID, p_start_date DATE, p_end_date DATE,
+  p_fee_patterns TEXT[], p_bank_account_id UUID DEFAULT NULL
+)
+RETURNS TABLE(revenue NUMERIC, food_cost NUMERIC, labor_cost NUMERIC,
+              processing_fees NUMERIC, total_outflows NUMERIC, uncategorized_spend NUMERIC)
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path TO 'public'
+AS $$
+  SELECT
+    COALESCE(SUM(bt.amount) FILTER (WHERE bt.amount > 0), 0)::NUMERIC,
+    ABS(COALESCE(SUM(bt.amount) FILTER (WHERE bt.amount < 0
+      AND (coa.account_subtype::text = 'cost_of_goods_sold'
+           OR LOWER(COALESCE(coa.account_name, '')) LIKE '%food%'
+           OR LOWER(COALESCE(coa.account_name, '')) LIKE '%inventory%')), 0))::NUMERIC,
+    ABS(COALESCE(SUM(bt.amount) FILTER (WHERE bt.amount < 0
+      AND (coa.account_subtype::text = 'payroll'
+           OR LOWER(COALESCE(coa.account_name, '')) LIKE '%payroll%'
+           OR LOWER(COALESCE(coa.account_name, '')) LIKE '%labor%')), 0))::NUMERIC,
+    ABS(COALESCE(SUM(bt.amount) FILTER (WHERE bt.amount < 0
+      AND LOWER(COALESCE(bt.description, '') || ' ' || COALESCE(bt.merchant_name, ''))
+          LIKE ANY(p_fee_patterns)), 0))::NUMERIC,
+    ABS(COALESCE(SUM(bt.amount) FILTER (WHERE bt.amount < 0), 0))::NUMERIC,
+    ABS(COALESCE(SUM(bt.amount) FILTER (WHERE bt.amount < 0
+      AND bt.category_id IS NULL AND COALESCE(bt.is_split, false) = false), 0))::NUMERIC
+  FROM bank_transactions bt
+  LEFT JOIN chart_of_accounts coa ON coa.id = bt.category_id
+  WHERE bt.restaurant_id = p_restaurant_id
+    AND bt.transaction_date >= p_start_date AND bt.transaction_date <= p_end_date
+    AND bt.status::text IN ('posted', 'pending')
+    AND (p_bank_account_id IS NULL OR bt.connected_bank_id = p_bank_account_id);
+$$;
+```
+
+Plus the REVOKE/GRANT/COMMENT block. Before Step 4, check the live keyword rules at `index.ts:2818-2853` and align the `LIKE` terms above with what the TypeScript matches today; adjust the SQL if the code uses different words.
+
+Index migration `20260814138000_...` — **no BEGIN wrapper** (spec §5.11):
+
+```sql
+-- CONCURRENTLY cannot run inside a transaction. No BEGIN in this file.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_bank_transactions_restaurant_date
+  ON bank_transactions(restaurant_id, transaction_date);
+```
+
+- [ ] **Step 4: Apply + run — expected 7/7.**
+- [ ] **Step 5: Commit** (`feat(rpc): expense-health aggregate and bank date index`, all three files).
+
+---
+
+### Task 10: Rewire cluster 1 (revenue) + KPIs + monthly_trends
+
+**Files:**
+- Modify: `supabase/functions/ai-execute-tool/index.ts` — sites at lines 204-218 (KPIs), 933-940 (income_statement), 1236-1292 (sales_summary ×2), 1673-1679 (generate_report), 2612-2622 (operating_costs revenue), 2683-2695 (monthly_trends)
+- Modify: `tests/unit/periodMetrics.test.ts` only if its exports change (prefer no change)
+
+**Interfaces:**
+- Consumes: `fetchNetSales` (Task 3), `get_monthly_sales_metrics` (Task 2).
+
+- [ ] **Step 1: Import the helper** at the top of `index.ts`:
+
+```typescript
+import { fetchNetSales, sumMonthlyFoodCost } from "../_shared/financialAggregates.ts";
+```
+
+- [ ] **Step 2: Replace each revenue fetch.** Pattern for every site — delete the `.from('unified_sales').select('total_price')...` block and its `.reduce()`, insert:
+
+```typescript
+const salesTotals = await fetchNetSales(supabase, restaurantId, startDateStr, endDateStr);
+const revenue = salesTotals.net;
+```
+
+Site-specific notes:
+- **income_statement (933-940):** `revenue` feeds `gross_profit` at line 976 unchanged. Use the tool's existing `start_date`/`end_date` args.
+- **sales_summary (1236-1292):** both the current and the previous period call `fetchNetSales` with their own ranges. Keep the growth math over the two `net` values.
+- **generate_report monthly_pnl (1673-1679):** same replacement.
+- **operating_costs (2612-2622):** replace only the fetch; Task 13 rewrites the math that consumes `totalRevenue`. Set `const totalRevenue = salesTotals.net;`.
+- **KPIs (204-218):** replace the two raw fetches + `calculateRevenueBreakdown` call with one `fetchNetSales`. Map: `grossRevenue = salesTotals.gross`, `discounts`, `refunds`, `salesTax = salesTotals.salesTax`, `tips = salesTotals.tips`, `netRevenue = salesTotals.net`. Keep `filterSplitSales`/`calculateRevenueBreakdown` exported in `periodMetrics.ts` untouched (other callers and tests exist) — KPIs stops calling them.
+- **monthly_trends (2683-2695):** keep the per-month rows (it needs the series). Change the net per month to `gross_revenue - discounts - refunds`.
+
+- [ ] **Step 3: Typecheck** — `npm run typecheck`. Expected: clean.
+
+- [ ] **Step 4: Run the existing unit suites** — `npx vitest run tests/unit/periodMetrics.test.ts tests/unit/tools-registry.test.ts tests/unit/financialAggregates.test.ts`. Expected: PASS with no edits to `periodMetrics.test.ts`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/functions/ai-execute-tool/index.ts
+git commit -m "fix(ai-tools): route every revenue sum through the monthly metrics RPC"
+```
+
+---
+
+### Task 11: Rewire clusters 2-5 (sales breakdown, COGS, OpEx, inventory value)
+
+**Files:**
+- Modify: `supabase/functions/ai-execute-tool/index.ts` — sites: 1748-1762 (sales_by_category), 1236-1256 (top items), 222 area + 943-951 + 1684-1690 + 2698-2708 (COGS), 954-974 (OpEx), 299-306 + 376-408 + 1018-1021 + 1809-1812 (inventory value)
+
+**Interfaces:**
+- Consumes: Tasks 4-7 RPCs, `sumMonthlyFoodCost` (Task 3).
+
+- [ ] **Step 1: sales_by_category (generate_report).** Replace the raw fetch + grouping loop:
+
+```typescript
+const { data: categoryRows, error: catErr } = await supabase.rpc('get_sales_by_category', {
+  p_restaurant_id: restaurantId, p_start_date: startDateStr, p_end_date: endDateStr,
+});
+if (catErr) throw new Error(`get_sales_by_category failed: ${catErr.message}`);
+```
+
+Map `categoryRows` onto the tool's existing response shape.
+
+- [ ] **Step 2: top items (sales_summary).** Replace the client-side top-N loop with `supabase.rpc('get_top_sold_items', { ..., p_limit: 10 })`.
+
+- [ ] **Step 3: COGS sites.** All four call the RPC; scalar sites sum with the helper:
+
+```typescript
+const { data: usageRows, error: usageErr } = await supabase.rpc('get_inventory_usage_by_month', {
+  p_restaurant_id: restaurantId, p_start_date: startDateStr, p_end_date: endDateStr,
+});
+if (usageErr) throw new Error(`get_inventory_usage_by_month failed: ${usageErr.message}`);
+const totalCogs = sumMonthlyFoodCost(usageRows);
+```
+
+`monthly_trends` (2698-2708) reads the month rows directly instead of a client-side group-by.
+
+- [ ] **Step 4: OpEx site (954-974).** Delete the `chart_of_accounts` id fetch AND the `journal_entry_lines` fetch. Insert:
+
+```typescript
+const { data: expenseTotal, error: expErr } = await supabase.rpc('get_journal_expense_total', {
+  p_restaurant_id: restaurantId, p_start_date: startDateStr, p_end_date: endDateStr,
+});
+if (expErr) throw new Error(`get_journal_expense_total failed: ${expErr.message}`);
+const totalExpenses = Number(expenseTotal ?? 0);
+```
+
+- [ ] **Step 5: Inventory value sites.** All four call `get_inventory_valuation` and read `total_value`, `item_count`, `low_stock_count` from the single returned row.
+
+- [ ] **Step 6: Typecheck + unit suites** — same commands as Task 10 Step 3-4. Expected: clean/PASS.
+
+- [ ] **Step 7: Commit** (`fix(ai-tools): SQL aggregates for sales breakdown, COGS, OpEx, inventory value`).
+
+---
+
+### Task 12: Rewire cluster 6 (bank) + batch id clamp
+
+**Files:**
+- Modify: `supabase/functions/ai-execute-tool/index.ts` — bank sites at 503-516, 560-577, 613-633, 698-709, 736-748, 840-884, 1066-1072, 1695-1701, 1781-1787, 2793-2852; batch tools at 3302 and 3390
+
+**Interfaces:**
+- Consumes: Task 8 + Task 9 RPCs.
+
+- [ ] **Step 1: Scalar bank sites.** Each site calls `get_bank_transaction_summary` with its current date range and, where the site filters them today, `p_statuses` / `p_bank_account_id`. Read each site's current status filter from the code before the change and pass the same values (spec §11.2 item 1). Replace client sums with the returned `inflow`/`outflow`/`net`.
+- [ ] **Step 2: Spending breakdown** (613-633) → `get_bank_spending_by_category`.
+- [ ] **Step 3: predictions (736-748) and cash_flow variance (503-516, 1781-1787)** → `get_bank_transactions_daily`; keep the forecast/variance math in TypeScript over the daily rows.
+- [ ] **Step 4: expense_health (2793-2852)** → one `get_expense_health_metrics` call. Map `processingFeePatterns` to lowercase `LIKE` form: `` patterns.map(p => `%${p.toLowerCase()}%`) ``. Keep the percentage math in TypeScript.
+- [ ] **Step 5: get_bank_transactions (840-884).** Keep the paginated list; its summary totals come from `get_bank_transaction_summary`.
+- [ ] **Step 6: Batch clamp.** In both batch tools, before the `.in('id', ids)` fetch:
+
+```typescript
+if (ids.length > 1000) {
+  return { error: `Too many ids (${ids.length}). Send at most 1000 per call.` };
+}
+```
+
+- [ ] **Step 7: Typecheck + unit suites; commit** (`fix(ai-tools): SQL aggregates for bank metrics; clamp batch id count`).
+
+---
+
+### Task 13: Fix 2 — operating-costs variable math (spec §13.2)
+
+**Files:**
+- Create: `supabase/functions/_shared/operatingCostMath.ts`
+- Modify: `supabase/functions/ai-execute-tool/index.ts:2585-2662` (`executeGetOperatingCosts`)
+- Test: `tests/unit/operatingCostMath.test.ts`
+
+**Interfaces:**
+- Consumes: `NetSalesTotals.net` from Task 10's `salesTotals` in the same function.
+- Produces:
+
+```typescript
+export interface CostRow { cost_type: string; entry_type: string; monthly_value: number; percentage_value: number | null; }
+export interface OperatingCostTotals {
+  fixedTotal: number; semiVariableTotal: number;
+  variableFlatTotal: number; variablePercentTotal: number; variableTotal: number;
+  totalMonthlyCosts: number; variableCostPercentage: number;
+  contributionMargin: number; breakEvenRevenue: number;
+}
+export function computeOperatingCostTotals(rows: CostRow[], netSales: number): OperatingCostTotals;
+```
+
+- [ ] **Step 1: Write the failing tests** — `tests/unit/operatingCostMath.test.ts`, keyed to the July diagnosis:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { computeOperatingCostTotals } from '../../supabase/functions/_shared/operatingCostMath';
+
+const rows = [
+  { cost_type: 'fixed', entry_type: 'value', monthly_value: 4037415, percentage_value: null },
+  { cost_type: 'variable', entry_type: 'value', monthly_value: 8200, percentage_value: null },
+  { cost_type: 'variable', entry_type: 'percentage', monthly_value: 0, percentage_value: 27 },
+  { cost_type: 'variable', entry_type: 'percentage', monthly_value: 0, percentage_value: 3 },
+  { cost_type: 'variable', entry_type: 'percentage', monthly_value: 0, percentage_value: 2.5 },
+];
+
+describe('computeOperatingCostTotals', () => {
+  it('includes percentage items in the variable total (the July $82 bug)', () => {
+    const t = computeOperatingCostTotals(rows, 72090.74);
+    expect(t.variableFlatTotal).toBeCloseTo(82.0, 2);
+    expect(t.variablePercentTotal).toBeCloseTo(72090.74 * 0.325, 2);
+    expect(t.variableTotal).toBeGreaterThan(23000);
+  });
+  it('computes the variable ratio from percent items plus flat/revenue', () => {
+    const t = computeOperatingCostTotals(rows, 72090.74);
+    expect(t.variableCostPercentage).toBeCloseTo(32.5 + (82.0 / 72090.74) * 100, 4);
+    expect(t.breakEvenRevenue).toBeCloseTo(40374.15 / ((100 - t.variableCostPercentage) / 100), 2);
+  });
+  it('falls back to 25 percent when the restaurant has no variable rows', () => {
+    const t = computeOperatingCostTotals(rows.slice(0, 1), 1000);
+    expect(t.variableCostPercentage).toBe(25);
+  });
+  it('does not divide by zero when netSales is 0', () => {
+    const t = computeOperatingCostTotals(rows, 0);
+    expect(Number.isFinite(t.breakEvenRevenue)).toBe(true);
+    expect(t.variableCostPercentage).toBeCloseTo(32.5, 4);
+  });
+});
+```
+
+- [ ] **Step 2: Run to confirm failure** — module not found.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// supabase/functions/_shared/operatingCostMath.ts
+// Spec §13.2. monthly_value is cents and is 0 for percentage rows;
+// percentage rows carry percentage_value instead.
+export function computeOperatingCostTotals(rows: CostRow[], netSales: number): OperatingCostTotals {
+  const by = (t: string) => rows.filter((r) => r.cost_type === t);
+  const flat = (rs: CostRow[]) => rs.filter((r) => r.entry_type !== 'percentage')
+    .reduce((s, r) => s + (r.monthly_value ?? 0) / 100, 0);
+  const pct = (rs: CostRow[]) => rs.filter((r) => r.entry_type === 'percentage')
+    .reduce((s, r) => s + (r.percentage_value ?? 0), 0);
+
+  const fixedTotal = flat(by('fixed'));
+  const semiVariableTotal = flat(by('semi_variable'));
+  const variableRows = by('variable');
+  const variableFlatTotal = flat(variableRows);
+  const variablePctSum = pct(variableRows);
+  const variablePercentTotal = (variablePctSum / 100) * netSales;
+  const variableTotal = variableFlatTotal + variablePercentTotal;
+
+  let variableCostPercentage: number;
+  if (variableRows.length === 0) {
+    variableCostPercentage = 25; // keep the historical fallback estimate
+  } else {
+    variableCostPercentage = variablePctSum + (netSales > 0 ? (variableFlatTotal / netSales) * 100 : 0);
+  }
+  const contributionMargin = 100 - variableCostPercentage;
+  const totalFixedCosts = fixedTotal + semiVariableTotal;
+  const breakEvenRevenue = contributionMargin > 0 ? totalFixedCosts / (contributionMargin / 100) : 0;
+
+  return {
+    fixedTotal, semiVariableTotal, variableFlatTotal, variablePercentTotal, variableTotal,
+    totalMonthlyCosts: fixedTotal + semiVariableTotal + variableTotal,
+    variableCostPercentage, contributionMargin, breakEvenRevenue,
+  };
+}
+```
+
+(Include the two exported interfaces from the Interfaces block above.)
+
+- [ ] **Step 4: Run tests — PASS.**
+
+- [ ] **Step 5: Rewire `executeGetOperatingCosts`.** Delete the sums at 2605-2607 and the formulas at 2623-2631. Call `computeOperatingCostTotals(costs, salesTotals.net)` (with `salesTotals` from Task 10 Step 2). Each `entry_type === 'percentage'` item in the response gains `computed_monthly_amount: (item.percentage_value / 100) * salesTotals.net`. Wire the break_even_analysis fields from the returned totals.
+
+- [ ] **Step 6: Typecheck + full unit suite; commit** (`fix(ai-tools): include percentage items in the variable-cost and break-even math`).
+
+---
+
+### Task 14: Fix 3 — budget labels, percent units, prompt guidance (spec §13.3)
+
+**Files:**
+- Modify: `supabase/functions/ai-execute-tool/index.ts` (operating-costs response ~2633-2662; break-even progress ~3156-3166)
+- Modify: `supabase/functions/_shared/tools-registry.ts:506-534`
+- Modify: `supabase/functions/ai-chat-stream/index.ts` (system prompt, inside 523-661)
+- Test: `tests/unit/tools-registry.test.ts` (extend)
+
+- [ ] **Step 1: Response labels.** In the `executeGetOperatingCosts` return object add:
+
+```typescript
+source: 'budget_config',
+note: 'These costs are the configured budget, not period actuals. The period parameter scopes only the revenue used for the break-even.',
+```
+
+Rename `margin_of_safety` → `margin_of_safety_percent` in BOTH tools and add to the operating-costs break_even_analysis:
+
+```typescript
+margin_of_safety_amount: salesTotals.net - totals.breakEvenRevenue,
+```
+
+- [ ] **Step 2: Registry description.** Rewrite the `get_operating_costs` description (tools-registry.ts:506-534) to open with: `'Get the CONFIGURED cost budget (not actual period spend). Fixed, semi-variable, and variable items with a break-even analysis against actual net sales for the period. All *_percent fields are percentages.'`
+
+- [ ] **Step 3: Prompt block.** In the `ai-chat-stream` system prompt, after the financial-tools guidance that ends near line 633, add:
+
+```text
+FINANCIAL DATA RULES:
+- get_operating_costs returns the CONFIGURED BUDGET, not actual spend. For actual spend, use get_financial_statement or get_bank_transactions.
+- All tools share one net-sales definition (gross - discounts - refunds). If two results disagree, say that the data sources disagree and stop. Do not invent a reconciliation.
+- Fields that end in _percent are percentages. Never show them with a $ sign.
+- Percentage-based cost items include computed_monthly_amount. Use it. Do not compute your own.
+```
+
+- [ ] **Step 4: Extend `tests/unit/tools-registry.test.ts`** with one test: the `get_operating_costs` description contains the string `CONFIGURED cost budget`.
+
+- [ ] **Step 5: Typecheck + unit suites; commit** (`fix(ai-tools): label budget data and percent units; add prompt rules`).
+
+---
+
+### Task 15: Full verification, production validation, PR
+
+**Files:** none new (PR body).
+
+- [ ] **Step 1: Full local gates**
+
+Run: `npm run typecheck && npm run lint && npx vitest run && npm run db:reset && npm run test:db`
+Expected: all green. Fix any failure before Step 2.
+
+- [ ] **Step 2: Production validation (read-only).** For restaurant `7c0c76e3-e770-401b-a2a9-c1edd407efed`, July 2026, run read-only SELECTs that mirror each new RPC body via `mcp__supabase-prod__execute_sql`. Record in the PR body:
+  - Net sales: expected ≈ `$72,090.74` minus July refunds.
+  - COGS: expected ≈ `$2,680.51`.
+  - The before numbers from the bot convo (`$3,647.22`, `$197.50`, `$5,693.62`, `$82.00`).
+
+- [ ] **Step 3: Push and open the PR** on `fix/ai-financial-tools-row-cap` → `main`. PR body sections: Problem (one paragraph + the July table), Fix (three defect classes), Behavioral changes (spec §7 + §13), Test evidence, Production before/after. End with:
+
+`🤖 Generated with [Claude Code](https://claude.com/claude-code)`
+
+- [ ] **Step 4: CI + review loop.** Watch `gh pr checks --watch`. Answer every CodeRabbit finding with `node dev-tools/pr-triage.js reply ... --verdict ... --commit <sha> --rationale "..."` (never a raw `gh api` reply). Run `node dev-tools/pr-triage.js audit --pr <N>` before the final push.
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: §5.1-§5.11 → Tasks 2, 4-9; §6 rewiring → Tasks 10-12; §13.2 → Task 13; §13.3 → Task 14; §9.3 → Task 15. §5.1 Change A ships already (PR #743) — no task, by design.
+- The `37_` tenancy suite guards the Task 2 DROP/CREATE regression risk.
+- Type consistency: `fetchNetSales`/`sumMonthlyMetrics`/`sumMonthlyFoodCost` (Task 3) match their uses in Tasks 10-13; `computeOperatingCostTotals` (Task 13) matches its use in Task 13 Step 5 and Task 14 Step 1.
+- Known judgment points for the executor: exact response-shape mapping per site (read the surrounding code first), the expense-health keyword terms (Task 9 Step 3 note), and per-site bank status values (Task 12 Step 1).

--- a/docs/superpowers/plans/2026-08-14-ai-financial-tools-row-cap-plan.md
+++ b/docs/superpowers/plans/2026-08-14-ai-financial-tools-row-cap-plan.md
@@ -43,7 +43,7 @@ Expected: migrations apply clean; pgTAP all green (including `36_` and `37_`); t
 ### Task 2: `get_monthly_sales_metrics` — add the `refunds` column (spec §5.1 Change B, §13.1)
 
 **Files:**
-- Create: `supabase/migrations/20260814130000_monthly_sales_metrics_refunds.sql`
+- Create: `supabase/migrations/20260814140000_monthly_sales_metrics_refunds.sql`
 - Modify: `supabase/tests/36_monthly_sales_metrics_revenue_filter.sql`
 
 **Interfaces:**
@@ -88,7 +88,7 @@ Expected: FAIL — `column "refunds" does not exist`.
 
 - [ ] **Step 3: Write the migration**
 
-Create `supabase/migrations/20260814130000_monthly_sales_metrics_refunds.sql`. The return type changes, so `CREATE OR REPLACE` is not allowed — `DROP` first. Reproduce the FULL body of `20260814120000_secure_monthly_sales_metrics_tenancy.sql` (the membership guard, the `child.restaurant_id` filters, `SECURITY INVOKER`, `SET search_path TO 'public'`), with three additions marked `-- NEW` below:
+Create `supabase/migrations/20260814140000_monthly_sales_metrics_refunds.sql`. The return type changes, so `CREATE OR REPLACE` is not allowed — `DROP` first. Reproduce the FULL body of `20260814120000_secure_monthly_sales_metrics_tenancy.sql` (the membership guard, the `child.restaurant_id` filters, `SECURITY INVOKER`, `SET search_path TO 'public'`), with three additions marked `-- NEW` below:
 
 ```sql
 -- Migration: add a refunds column to get_monthly_sales_metrics
@@ -249,7 +249,7 @@ Expected: `36_` 7/7, `37_` 4/4. `37_` must stay green with no edits — it pins 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add supabase/migrations/20260814130000_monthly_sales_metrics_refunds.sql supabase/tests/36_monthly_sales_metrics_revenue_filter.sql
+git add supabase/migrations/20260814140000_monthly_sales_metrics_refunds.sql supabase/tests/36_monthly_sales_metrics_revenue_filter.sql
 git commit -m "feat(rpc): add a refunds column to get_monthly_sales_metrics"
 ```
 
@@ -395,8 +395,8 @@ git commit -m "feat(ai-tools): shared net-sales helper over the monthly metrics 
 ### Task 4: RPCs `get_sales_by_category` + `get_top_sold_items` (cluster 2)
 
 **Files:**
-- Create: `supabase/migrations/20260814131000_get_sales_by_category.sql`
-- Create: `supabase/migrations/20260814132000_get_top_sold_items.sql`
+- Create: `supabase/migrations/20260814141000_get_sales_by_category.sql`
+- Create: `supabase/migrations/20260814142000_get_top_sold_items.sql`
 - Test: `supabase/tests/38_sales_breakdown_rpcs.sql`
 
 **Interfaces:**
@@ -419,7 +419,7 @@ Expected: FAIL — `function get_sales_by_category(...) does not exist`.
 
 - [ ] **Step 3: Write the two migrations**
 
-`20260814131000_get_sales_by_category.sql`:
+`20260814141000_get_sales_by_category.sql`:
 
 ```sql
 -- Sales revenue grouped by category for one restaurant and date range.
@@ -458,7 +458,7 @@ COMMENT ON FUNCTION public.get_sales_by_category IS
 split parents. SECURITY INVOKER; EXECUTE for authenticated only.';
 ```
 
-`20260814132000_get_top_sold_items.sql` — same shell, body:
+`20260814142000_get_top_sold_items.sql` — same shell, body:
 
 ```sql
 CREATE OR REPLACE FUNCTION public.get_top_sold_items(
@@ -503,7 +503,7 @@ Expected: 6/6 pass.
 - [ ] **Step 5: Commit**
 
 ```bash
-git add supabase/migrations/20260814131000_get_sales_by_category.sql supabase/migrations/20260814132000_get_top_sold_items.sql supabase/tests/38_sales_breakdown_rpcs.sql
+git add supabase/migrations/20260814141000_get_sales_by_category.sql supabase/migrations/20260814142000_get_top_sold_items.sql supabase/tests/38_sales_breakdown_rpcs.sql
 git commit -m "feat(rpc): sales-by-category and top-items aggregates"
 ```
 
@@ -512,7 +512,7 @@ git commit -m "feat(rpc): sales-by-category and top-items aggregates"
 ### Task 5: RPC `get_inventory_usage_by_month` (cluster 3, COGS)
 
 **Files:**
-- Create: `supabase/migrations/20260814133000_get_inventory_usage_by_month.sql`
+- Create: `supabase/migrations/20260814143000_get_inventory_usage_by_month.sql`
 - Test: `supabase/tests/39_inventory_usage_by_month.sql`
 
 **Interfaces:**
@@ -562,7 +562,7 @@ month, full end day included, explicit UTC bounds. SECURITY INVOKER.';
 - [ ] **Step 5: Commit**
 
 ```bash
-git add supabase/migrations/20260814133000_get_inventory_usage_by_month.sql supabase/tests/39_inventory_usage_by_month.sql
+git add supabase/migrations/20260814143000_get_inventory_usage_by_month.sql supabase/tests/39_inventory_usage_by_month.sql
 git commit -m "feat(rpc): monthly inventory-usage aggregate with a correct end day"
 ```
 
@@ -571,7 +571,7 @@ git commit -m "feat(rpc): monthly inventory-usage aggregate with a correct end d
 ### Task 6: RPC `get_journal_expense_total` (cluster 4, OpEx)
 
 **Files:**
-- Create: `supabase/migrations/20260814134000_get_journal_expense_total.sql`
+- Create: `supabase/migrations/20260814144000_get_journal_expense_total.sql`
 - Test: `supabase/tests/40_journal_expense_total.sql`
 
 **Interfaces:**
@@ -618,7 +618,7 @@ Replaces the expense-account id round-trip. SECURITY INVOKER.';
 ### Task 7: RPC `get_inventory_valuation` (cluster 5)
 
 **Files:**
-- Create: `supabase/migrations/20260814135000_get_inventory_valuation.sql`
+- Create: `supabase/migrations/20260814145000_get_inventory_valuation.sql`
 - Test: `supabase/tests/41_inventory_valuation.sql`
 
 **Interfaces:**
@@ -660,7 +660,7 @@ predicate is current_stock <= COALESCE(par_level_min, 0). SECURITY INVOKER.';
 ### Task 8: Bank RPCs — summary, spending by category, daily series (cluster 6)
 
 **Files:**
-- Create: `supabase/migrations/20260814136000_get_bank_aggregates.sql` (all three functions, one file)
+- Create: `supabase/migrations/20260814146000_get_bank_aggregates.sql` (all three functions, one file)
 - Test: `supabase/tests/42_bank_aggregates.sql`
 
 **Interfaces:**
@@ -751,8 +751,8 @@ Then the six REVOKE/two GRANT lines per function (same pattern as Task 4) and on
 ### Task 9: RPC `get_expense_health_metrics` + the bank index
 
 **Files:**
-- Create: `supabase/migrations/20260814137000_get_expense_health_metrics.sql`
-- Create: `supabase/migrations/20260814138000_idx_bank_transactions_restaurant_date.sql`
+- Create: `supabase/migrations/20260814147000_get_expense_health_metrics.sql`
+- Create: `supabase/migrations/20260814148000_idx_bank_transactions_restaurant_date.sql`
 - Test: `supabase/tests/43_expense_health_metrics.sql`
 
 **Interfaces:**
@@ -801,7 +801,7 @@ $$;
 
 Plus the REVOKE/GRANT/COMMENT block. Before Step 4, check the live keyword rules at `index.ts:2818-2853` and align the `LIKE` terms above with what the TypeScript matches today; adjust the SQL if the code uses different words.
 
-Index migration `20260814138000_...` — **no BEGIN wrapper** (spec §5.11):
+Index migration `20260814148000_...` — **no BEGIN wrapper** (spec §5.11):
 
 ```sql
 -- CONCURRENTLY cannot run inside a transaction. No BEGIN in this file.

--- a/docs/superpowers/plans/2026-08-14-ai-financial-tools-row-cap-plan.md
+++ b/docs/superpowers/plans/2026-08-14-ai-financial-tools-row-cap-plan.md
@@ -18,7 +18,7 @@
 - pgTAP files: fixtures insert as the session role (`postgres`, `BYPASSRLS`), RLS stays enabled. Tenancy assertions run under `SET LOCAL ROLE authenticated` + `SET LOCAL request.jwt.claims`. Follow `supabase/tests/37_monthly_sales_metrics_tenancy.sql`.
 - Never run `git add -A`, `git add .`, or `git commit -a`. Stage explicit paths.
 - End every commit message with: `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
-- Test commands: `npm run db:reset` applies migrations locally; `npm run test:db` runs pgTAP; `npx vitest run <file>` runs one unit file; `npm run typecheck` must stay clean.
+- Test commands: `npm run env:setup && npx supabase@2.65.5 db reset` applies migrations locally (2.65.5 is the CI pin from `.github/workflows/unit-tests.yml:165`; the newest CLI fails on `CONCURRENTLY` migrations with `LegacyMigrationApplyError`). `npm run test:db` runs pgTAP; `npx vitest run <file>` runs one unit file; `npm run typecheck` must stay clean. Where a task step says `npm run db:reset`, use the pinned form.
 - The branch is `fix/ai-financial-tools-row-cap`, worktree `.claude/worktrees/ai-financial-tools-row-cap`, already rebased on `main`.
 - Do not edit `supabase/migrations/20260814120000_secure_monthly_sales_metrics_tenancy.sql`. Build on top of it.
 

--- a/docs/superpowers/specs/2026-08-13-ai-financial-tools-row-cap-design.md
+++ b/docs/superpowers/specs/2026-08-13-ai-financial-tools-row-cap-design.md
@@ -70,16 +70,16 @@ tools also disagree on the end boundary.
 
 ### 2.2 Non-goals
 
-- Do not change the break-even variable-cost math or the margin-of-safety unit
-  ([`index.ts:2623-2640`](supabase/functions/ai-execute-tool/index.ts:2623)). This
-  is a later PR (fix 2). Note: the revenue sum that feeds this math
-  ([`index.ts:2622`](supabase/functions/ai-execute-tool/index.ts:2622)) IS in
-  scope. This PR replaces that one `reduce()` with the shared revenue RPC. The
-  break-even formula below it stays the same.
-- Do not relabel the operating-costs output as a budget
-  ([`index.ts:2565`](supabase/functions/ai-execute-tool/index.ts:2565)). This is
-  a later PR (fix 3).
-- Do not change the AI chat UI, the tool registry schema, or the model prompts.
+> **Scope change (2026-08-14).** The owner folded fix 2 and fix 3 into this PR
+> after the July diagnosis proved the three defects compound. See §13. The first
+> two bullets below no longer apply; §13.2 and §13.3 replace them.
+
+- ~~Do not change the break-even variable-cost math or the margin-of-safety
+  unit.~~ **In scope now (fix 2, §13.2).**
+- ~~Do not relabel the operating-costs output as a budget.~~ **In scope now
+  (fix 3, §13.3).**
+- Do not change the AI chat UI or the tool registry parameter schemas. Tool
+  *descriptions* and the chat system prompt DO change (fix 3, §13.3).
 - Do not change the categorization write logic. Only clamp its input id count.
 
 ---
@@ -618,15 +618,111 @@ number. Record the before-and-after in the PR body.
 1. **Bank status values per site.** Confirm the exact `transaction_status_enum`
    values each bank caller filters today, so `p_statuses` reproduces per-site
    behavior (low risk; the default `NULL` applies no status filter).
-2. **PR shape.** Decide one PR, or a short stacked series by cluster. Also decide
-   whether the `get_monthly_sales_metrics` `INVOKER` conversion (§5.1 Change A)
-   ships first as its own small security PR. It fixes a live cross-tenant hole and
-   does not depend on the cap work. The design does not change either way.
+2. ~~**PR shape.**~~ **Resolved (2026-08-14).** One PR. The
+   `get_monthly_sales_metrics` `INVOKER` conversion (§5.1 Change A) shipped
+   first as its own security PR
+   ([#743](https://github.com/toyiyo/nimble-pnl/pull/743), migration
+   `20260814120000_secure_monthly_sales_metrics_tenancy.sql`). See §13.1.
 
 ---
 
 ## 12. Out of scope (follow-ups)
 
-- Break-even variable-cost math and the margin-of-safety unit (fix 2).
-- The operating-costs budget label (fix 3).
 - The same cap pattern in any non-financial tool path outside this file.
+- The journal data gap: July 2026 holds only 12 expense lines (`$11,271.79`)
+  against a `$40,456.15/month` configured budget. The income statement is
+  correct code over incomplete books. This is a product problem, not a code
+  defect in this PR.
+
+---
+
+## 13. Addendum (2026-08-14) — fold fix 2 and fix 3, post-#743 state
+
+The July 2026 diagnosis (restaurant `7c0c76e3-e770-401b-a2a9-c1edd407efed`)
+reproduced every wrong number to the cent. Three defect classes compound in one
+answer: the row cap (this design), the variable-cost math (fix 2), and the
+budget label plus prompt gaps (fix 3). The owner folded fix 2 and fix 3 into
+this PR.
+
+### 13.1 §5.1 Change A shipped — build Change B on top of it
+
+PR #743 merged migration `20260814120000_secure_monthly_sales_metrics_tenancy.sql`.
+The live function is now `SECURITY INVOKER` with a `user_restaurants` membership
+guard, a `child.restaurant_id = p_restaurant_id` filter in both child-sale
+checks, and `EXECUTE` revoked from `PUBLIC` and `anon`. The Change B migration
+(the `refunds` column) must reproduce that full body — the guard, the child
+filter, the grants — and add the column. pgTAP files
+`36_monthly_sales_metrics_revenue_filter.sql` and
+`37_monthly_sales_metrics_tenancy.sql` already pin the security properties.
+Change B must keep them green. The §9.1 item-5 tenancy test for this function
+already exists (`37_`); the new RPCs still need their own.
+
+### 13.2 Fix 2 — operating-costs variable math (now in scope)
+
+The defect: `variableTotal` sums only `monthly_value`
+([`index.ts:2607`](supabase/functions/ai-execute-tool/index.ts:2607)).
+`monthly_value` is 0 for every `entry_type = 'percentage'` row, so percentage
+items (COGS 27%, marketing 3%, processing 2.5%) contribute nothing. July output:
+`Variable Costs: $82.00` against an itemized list of `$1,199.52`, and a
+break-even of `$40,964.12` from a 1.44% variable ratio.
+
+New math, over the net sales the cluster-1 RPC returns (`netSales`):
+
+- `variableFlatTotal` = Σ `monthly_value / 100` over `cost_type = 'variable'`
+  AND `entry_type = 'value'`.
+- `variablePercentTotal` = Σ `(percentage_value / 100) * netSales` over
+  `cost_type = 'variable'` AND `entry_type = 'percentage'`.
+- `variableTotal = variableFlatTotal + variablePercentTotal`. This is the
+  displayed "Variable Costs" dollar figure.
+- `variableCostPercentage` = Σ `percentage_value` + (`netSales > 0` ?
+  `variableFlatTotal / netSales * 100` : 0). Keep the existing fallback: when
+  the restaurant has no variable rows at all, use the hardcoded 25.
+- `contributionMargin = 100 - variableCostPercentage` and
+  `breakEvenRevenue = totalFixedCosts / (contributionMargin / 100)` stay as
+  today ([`index.ts:2628-2631`](supabase/functions/ai-execute-tool/index.ts:2628)).
+- Each `entry_type = 'percentage'` item in the response gains
+  `computed_monthly_amount = (percentage_value / 100) * netSales`, so the model
+  does not do its own arithmetic on a stale revenue figure.
+- `total_monthly_costs` becomes `fixedTotal + semiVariableTotal +
+  variableTotal` with the corrected `variableTotal`.
+
+Semi-variable handling stays as today: folded into `totalFixedCosts` for the
+break-even.
+
+### 13.3 Fix 3 — budget labels, units, prompt guidance (now in scope)
+
+Three parts.
+
+**Response labels.** `get_operating_costs` output gains
+`"source": "budget_config"` and a `note` string: the costs are the configured
+budget, not period actuals; the `period` parameter scopes only the revenue used
+for the break-even. Rename `margin_of_safety` to `margin_of_safety_percent` and
+add `margin_of_safety_amount = netSales - breakEvenRevenue` (dollars). Apply the
+same rename in `get_break_even_progress`
+([`index.ts:3156-3166`](supabase/functions/ai-execute-tool/index.ts:3156)). No
+typed consumer reads these fields (the model reads the JSON), so the rename is
+safe.
+
+**Registry descriptions.** Update the `get_operating_costs` description
+([`tools-registry.ts:506-534`](supabase/functions/_shared/tools-registry.ts:506))
+to state: budget config, not actuals. State the unit of every percent field.
+
+**Prompt guidance.** Add one financial-tools block to the `ai-chat-stream`
+system prompt (the hardcoded string at
+[`ai-chat-stream/index.ts:523-661`](supabase/functions/ai-chat-stream/index.ts:523)):
+
+- `get_operating_costs` returns the configured budget. For actual spend, use
+  `get_financial_statement` or `get_bank_transactions`.
+- Every revenue figure comes from one net-sales definition. When two tools
+  disagree, say so and stop; do not invent a reconciliation.
+- Fields that end in `_percent` are percentages. Never print them with a `$`.
+
+### 13.4 Validated July 2026 numbers (2026-08-14 re-run)
+
+| Bot said | Mechanism | True value |
+|---|---|---|
+| Revenue `$3,647.22` | first 1000 of 22,366 rows, no filters | `$72,090.74` net |
+| COGS `$197.50` | first 1000 of 14,806 usage rows | `$2,680.51` |
+| Break-even revenue input `$5,693.62` | first 1000 of 13,049 filtered rows | `$72,090.74` |
+| `Variable Costs: $82.00` | `monthly_value`-only sum | ≈ `$19,546` at true revenue |
+| `Margin of Safety -$619.47` | percent field printed as dollars | +43% (above break-even) |

--- a/docs/superpowers/specs/2026-08-13-ai-financial-tools-row-cap-design.md
+++ b/docs/superpowers/specs/2026-08-13-ai-financial-tools-row-cap-design.md
@@ -1,0 +1,419 @@
+# AI financial tools: move every financial sum into SQL
+
+- **Date:** 2026-08-13
+- **Author:** Jose M Delgado (with Claude)
+- **Status:** Draft for review
+- **Feature area:** AI chat financial tools (`supabase/functions/ai-execute-tool/index.ts`)
+- **Scope:** Replace every raw-row fetch plus JavaScript sum in the AI tool
+  executor with a SQL aggregate. About 32 sites across 12 tools. Add 8 aggregate
+  RPCs and reuse 1. Keep each displayed number correct, and unify the numbers on
+  the app P&L definitions.
+
+This document uses STE-aligned Simplified Technical English. Code identifiers,
+SQL, and file paths stay exact.
+
+---
+
+## 1. Problem
+
+The AI chat tools report wrong financial numbers. A tool fetches raw rows from a
+large table, then sums the rows in JavaScript with `.reduce()`. PostgREST caps
+every response at 1000 rows (`max_rows = 1000` in `supabase/config.toml`) and
+returns success, not an error. So every JavaScript sum truncates once the
+filtered set is larger than 1000 rows.
+
+### 1.1 Validated impact (July 2026, one restaurant)
+
+- **Revenue.** 13,049 sale rows. The bot said `$5,693.62`. The correct net sales
+  figure is `$72,090.74`.
+- **COGS.** 14,311 usage rows. The bot said `$197.50`. The correct figure is
+  `$2,619.29`.
+- **Sign error.** The bot reported a loss. July was profitable.
+
+### 1.2 Second defect — the tools disagree
+
+The tools do not share one revenue definition. The income-statement revenue
+fetch has no filters at all
+([`index.ts:935`](supabase/functions/ai-execute-tool/index.ts:935)). It counts
+refunds, split-sale duplicates, tax, and tips. The sales-summary fetch has both
+guards
+([`index.ts:1238`](supabase/functions/ai-execute-tool/index.ts:1238)). So two
+tools return two different revenue numbers for the same period. This
+inconsistency is a second root cause of the wrong answers.
+
+### 1.3 Latent boundary defect — COGS end day
+
+The income-statement COGS fetch filters `created_at` with a bare date string
+([`index.ts:945`](supabase/functions/ai-execute-tool/index.ts:945)). The column
+is a `timestamptz`. A bare date string coerces to `00:00:00`. So the fetch drops
+almost all of the last day. The KPIs food-cost fetch already appends
+`'T23:59:59.999Z'`
+([`index.ts:222`](supabase/functions/ai-execute-tool/index.ts:222)). So the
+tools also disagree on the end boundary.
+
+---
+
+## 2. Goals and non-goals
+
+### 2.1 Goals
+
+1. Remove the 1000-row cap from every financial sum. SQL sums every row
+   server-side.
+2. Unify the numbers on the app P&L definitions. Every tool applies the same
+   filters for the same metric.
+3. Keep the edge-function CPU cost low. Push the aggregate into SQL, per the
+   CLAUDE.md rule for large data.
+4. Fix the COGS end-day boundary. Include the full end day.
+5. Prove each cluster against production before the PR.
+
+### 2.2 Non-goals
+
+- Do not change the break-even variable-cost math or the margin-of-safety unit
+  ([`index.ts:2622`](supabase/functions/ai-execute-tool/index.ts:2622)). This is
+  a later PR (fix 2).
+- Do not relabel the operating-costs output as a budget
+  ([`index.ts:2565`](supabase/functions/ai-execute-tool/index.ts:2565)). This is
+  a later PR (fix 3).
+- Do not change the AI chat UI, the tool registry schema, or the model prompts.
+- Do not change the categorization write logic. Only clamp its input id count.
+
+---
+
+## 3. Audit inventory
+
+Two parallel audits mapped the file. Every site fetches raw rows, then sums in
+JavaScript. The table groups the sites by the data they aggregate.
+
+### 3.1 Cap-vulnerable sites by cluster
+
+| Cluster | Table | Site (tool → metric) | Select `file:line` | Sum `file:line` | Guards today |
+|---|---|---|---|---|---|
+| 1 | `unified_sales` | KPIs → revenue + adjustments | [206](supabase/functions/ai-execute-tool/index.ts:206), [214](supabase/functions/ai-execute-tool/index.ts:214) | `_shared/periodMetrics.ts` | adj only |
+| 1 | `unified_sales` | income_statement → revenue | [935](supabase/functions/ai-execute-tool/index.ts:935) | [940](supabase/functions/ai-execute-tool/index.ts:940) | none |
+| 1 | `unified_sales` | sales_summary → current total | [1238](supabase/functions/ai-execute-tool/index.ts:1238) | [1249](supabase/functions/ai-execute-tool/index.ts:1249) | adj + split |
+| 1 | `unified_sales` | sales_summary → previous total | [1284](supabase/functions/ai-execute-tool/index.ts:1284) | [1292](supabase/functions/ai-execute-tool/index.ts:1292) | adj + split |
+| 1 | `unified_sales` | generate_report monthly_pnl → revenue | [1674](supabase/functions/ai-execute-tool/index.ts:1674) | [1679](supabase/functions/ai-execute-tool/index.ts:1679) | none |
+| 1 | `unified_sales` | operating_costs → break-even revenue | [2614](supabase/functions/ai-execute-tool/index.ts:2614) | [2622](supabase/functions/ai-execute-tool/index.ts:2622) | adj + split |
+| 2 | `unified_sales` | generate_report → sales_by_category | [1750](supabase/functions/ai-execute-tool/index.ts:1750) | [1762](supabase/functions/ai-execute-tool/index.ts:1762) | none |
+| 2 | `unified_sales` | sales_summary → top items | [1238](supabase/functions/ai-execute-tool/index.ts:1238) | [1256](supabase/functions/ai-execute-tool/index.ts:1256) | adj + split |
+| 3 | `inventory_transactions` | KPIs → food cost | [222](supabase/functions/ai-execute-tool/index.ts:222) | `_shared/periodMetrics.ts` | usage |
+| 3 | `inventory_transactions` | income_statement → COGS | [945](supabase/functions/ai-execute-tool/index.ts:945) | [951](supabase/functions/ai-execute-tool/index.ts:951) | usage |
+| 3 | `inventory_transactions` | generate_report monthly_pnl → COGS | [1684](supabase/functions/ai-execute-tool/index.ts:1684) | [1690](supabase/functions/ai-execute-tool/index.ts:1690) | usage |
+| 3 | `inventory_transactions` | monthly_trends → food cost by month | [2698](supabase/functions/ai-execute-tool/index.ts:2698) | [2708](supabase/functions/ai-execute-tool/index.ts:2708) | usage |
+| 4 | `journal_entry_lines` | income_statement → OpEx | [964](supabase/functions/ai-execute-tool/index.ts:964) | [973](supabase/functions/ai-execute-tool/index.ts:973) | expense accts |
+| 5 | `products` | KPIs → inventory value | [299](supabase/functions/ai-execute-tool/index.ts:299) | [306](supabase/functions/ai-execute-tool/index.ts:306) | restaurant |
+| 5 | `products` | inventory_status → value + counts | [376](supabase/functions/ai-execute-tool/index.ts:376) | [408](supabase/functions/ai-execute-tool/index.ts:408) | restaurant |
+| 5 | `products` | income_statement balance_sheet → inventory | [1018](supabase/functions/ai-execute-tool/index.ts:1018) | [1021](supabase/functions/ai-execute-tool/index.ts:1021) | restaurant |
+| 5 | `products` | generate_report balance_sheet → inventory | [1809](supabase/functions/ai-execute-tool/index.ts:1809) | [1812](supabase/functions/ai-execute-tool/index.ts:1812) | restaurant |
+| 6 | `bank_transactions` | financial_intelligence cash_flow | [503](supabase/functions/ai-execute-tool/index.ts:503) | [516](supabase/functions/ai-execute-tool/index.ts:516) | date |
+| 6 | `bank_transactions` | financial_intelligence revenue_health | [560](supabase/functions/ai-execute-tool/index.ts:560) | [577](supabase/functions/ai-execute-tool/index.ts:577) | date, amount>0 |
+| 6 | `bank_transactions` | financial_intelligence spending | [613](supabase/functions/ai-execute-tool/index.ts:613) | [633](supabase/functions/ai-execute-tool/index.ts:633) | date, amount<0 |
+| 6 | `bank_transactions` | financial_intelligence liquidity | [698](supabase/functions/ai-execute-tool/index.ts:698) | [709](supabase/functions/ai-execute-tool/index.ts:709) | 30-day, amount<0 |
+| 6 | `bank_transactions` | financial_intelligence predictions | [736](supabase/functions/ai-execute-tool/index.ts:736) | [748](supabase/functions/ai-execute-tool/index.ts:748) | 60-day |
+| 6 | `bank_transactions` | get_bank_transactions → summary | [840](supabase/functions/ai-execute-tool/index.ts:840) | [884](supabase/functions/ai-execute-tool/index.ts:884) | many, `.limit` unclamped |
+| 6 | `bank_transactions` | income_statement cash_flow | [1066](supabase/functions/ai-execute-tool/index.ts:1066) | [1072](supabase/functions/ai-execute-tool/index.ts:1072) | date |
+| 6 | `bank_transactions` | generate_report monthly_pnl → expenses | [1695](supabase/functions/ai-execute-tool/index.ts:1695) | [1701](supabase/functions/ai-execute-tool/index.ts:1701) | date, amount<0 |
+| 6 | `bank_transactions` | generate_report → cash_flow | [1781](supabase/functions/ai-execute-tool/index.ts:1781) | [1787](supabase/functions/ai-execute-tool/index.ts:1787) | date |
+| 6 | `bank_transactions` | expense_health → 6 sums | [2795](supabase/functions/ai-execute-tool/index.ts:2795) | [2819](supabase/functions/ai-execute-tool/index.ts:2819)–[2852](supabase/functions/ai-execute-tool/index.ts:2852) | date, status |
+
+### 3.2 Lower-risk sites (input-bound, not period-bound)
+
+- `executeBatchCategorizeTransactions`
+  ([`index.ts:3302`](supabase/functions/ai-execute-tool/index.ts:3302)) and
+  `executeBatchCategorizePosSales`
+  ([`index.ts:3390`](supabase/functions/ai-execute-tool/index.ts:3390)) fetch by
+  `.in('id', ids)`. They truncate only when the caller passes more than 1000
+  ids. The fix is a clamp on the id count, not an RPC.
+
+### 3.3 Reviewed, not vulnerable
+
+- `bank_transactions` count in KPIs uses `head:true` with `count:'exact'`
+  ([`index.ts:312`](supabase/functions/ai-execute-tool/index.ts:312)). PostgREST
+  returns the count server-side. The row cap does not apply.
+- `connected_banks` sums
+  ([`index.ts:677`](supabase/functions/ai-execute-tool/index.ts:677),
+  [`index.ts:1007`](supabase/functions/ai-execute-tool/index.ts:1007)) and the
+  trial-balance loop over `chart_of_accounts`
+  ([`index.ts:1121`](supabase/functions/ai-execute-tool/index.ts:1121)) run over
+  bounded tables. Row counts stay under 1000.
+- `executeGetInventoryTransactions` delegates to `fetchInventoryTransactions`
+  with `limit: Math.min(limit, 200)`
+  ([`index.ts:1365`](supabase/functions/ai-execute-tool/index.ts:1365)). It lists
+  rows; it does not sum them.
+
+---
+
+## 4. Approach
+
+### 4.1 Chosen approach — SQL aggregate RPCs (recommended)
+
+Push each sum into SQL. For a breakdown (by category, by month, by day), use
+`GROUP BY`. `GROUP BY` collapses millions of rows into a bounded set —
+categories, at most 13 months, at most 366 days. Every grouped result is far
+under 1000 rows. JavaScript then keeps only the derived math (variance, forecast,
+percentage) over the small, complete set.
+
+This approach matches the codebase. CLAUDE.md requires SQL-side aggregation for
+large data, because edge functions have a ~10s CPU limit. The repo already uses
+purpose-built aggregate RPCs (`get_daily_sales_totals`,
+`get_monthly_sales_metrics`, `get_labor_sales_analytics`).
+
+### 4.2 Rejected alternatives
+
+- **Pagination helper.** A helper loops `.range()` until the fetch is empty, then
+  the JavaScript sums stay. The per-site change is small. But the helper pulls
+  10,000 to 150,000 rows into the edge function for a wide period. This breaks the
+  CPU and memory budget. It is the pattern CLAUDE.md forbids for large data.
+- **Hybrid.** RPCs for the proven paths plus pagination for the long tail. This
+  keeps two patterns. It is harder to test and to maintain.
+
+---
+
+## 5. RPC specifications
+
+Reuse 1 function. Add 8. Every new function follows the `get_daily_sales_totals`
+template ([`ai_operator.sql:678`](supabase/migrations/20260214100000_ai_operator.sql:678)):
+
+- `LANGUAGE sql STABLE SECURITY INVOKER` for a scalar or grouped aggregate.
+- `SECURITY INVOKER`, not `DEFINER`. RLS stays in force for a client caller. The
+  `ai-execute-tool` edge function calls with the service role, which bypasses
+  RLS. So the explicit `restaurant_id = p_restaurant_id` filter scopes both
+  callers.
+- `SUM(COALESCE(col, 0))` for every sum. A SQL `SUM` over an all-NULL group
+  returns NULL. `unified_sales.total_price` and other columns are nullable
+  (lesson L1752).
+- `GRANT EXECUTE ... TO authenticated`, re-issued after `CREATE OR REPLACE`.
+- A `COMMENT ON FUNCTION` that states the source, the filters, and the exclusions.
+
+### 5.1 Reuse — `get_monthly_sales_metrics` (revenue, cluster 1)
+
+Signature (existing):
+`get_monthly_sales_metrics(p_restaurant_id UUID, p_date_from DATE, p_date_to DATE)`
+([`20260501120000_fix_monthly_sales_metrics_revenue_filter.sql:14`](supabase/migrations/20260501120000_fix_monthly_sales_metrics_revenue_filter.sql:14)).
+
+Callers sum `gross_revenue - discounts` across the returned month rows. The
+`WHERE sale_date BETWEEN p_date_from AND p_date_to` clause bounds the exact
+range. So a partial-month range still sums only the in-range rows. This is the
+app P&L net-sales figure. It applies the adjustment guard, the split guard, the
+item-type guard, and the liability-account guard.
+
+### 5.2 New — `get_sales_by_category` (cluster 2)
+
+`get_sales_by_category(p_restaurant_id UUID, p_start_date DATE, p_end_date DATE)`
+→ `TABLE(category_id UUID, category_name TEXT, revenue NUMERIC, item_count BIGINT)`.
+
+Source `unified_sales`, grouped by category. Same guards as §5.1 (adjustment,
+split, item-type). Drives generate_report `sales_by_category`.
+
+### 5.3 New — `get_top_sold_items` (cluster 2)
+
+`get_top_sold_items(p_restaurant_id UUID, p_start_date DATE, p_end_date DATE, p_limit INT DEFAULT 10)`
+→ `TABLE(item_name TEXT, revenue NUMERIC, quantity NUMERIC, sale_count BIGINT)`
+`ORDER BY revenue DESC LIMIT p_limit`.
+
+Source `unified_sales`, grouped by item name. Same guards as §5.1. Drives the
+sales-summary top-sellers block.
+
+### 5.4 New — `get_inventory_usage_by_month` (COGS, cluster 3)
+
+`get_inventory_usage_by_month(p_restaurant_id UUID, p_start_date DATE, p_end_date DATE)`
+→ `TABLE(period TEXT, food_cost NUMERIC)`.
+
+Source `inventory_transactions`. Filter `transaction_type = 'usage'`. Sum
+`ABS(COALESCE(SUM(total_cost), 0))` per month. `ABS(SUM(...))` matches the
+current code and is correct: a reversal row reduces the cost. A scalar caller
+sums the month rows. `monthly_trends` reads the month rows directly.
+
+Boundary: filter `created_at >= p_start_date AND created_at < (p_end_date + 1)`.
+This includes the full end day. It fixes the defect in §1.3.
+
+### 5.5 New — `get_journal_expense_total` (OpEx, cluster 4)
+
+`get_journal_expense_total(p_restaurant_id UUID, p_start_date DATE, p_end_date DATE)`
+→ `NUMERIC`.
+
+Source `journal_entry_lines` joined to `journal_entries` and
+`chart_of_accounts`. Filter `chart_of_accounts.restaurant_id = p_restaurant_id`,
+`account_type = 'expense'`, and `entry_date` in range. Return
+`COALESCE(SUM(debit_amount - credit_amount), 0)`. This replaces the
+`expenseAccountIds` round-trip
+([`index.ts:957`](supabase/functions/ai-execute-tool/index.ts:957)) with one
+call.
+
+### 5.6 New — `get_inventory_valuation` (cluster 5)
+
+`get_inventory_valuation(p_restaurant_id UUID)`
+→ `TABLE(total_value NUMERIC, item_count BIGINT, low_stock_count BIGINT)`.
+
+Source `products`. `total_value = COALESCE(SUM(current_stock * cost_per_unit),
+0)`. `low_stock_count` counts rows where the stock is at or under the reorder
+point. The exact low-stock predicate copies the current code
+([`index.ts:427`](supabase/functions/ai-execute-tool/index.ts:427)).
+
+### 5.7 New — `get_bank_transaction_summary` (cluster 6 scalars)
+
+`get_bank_transaction_summary(p_restaurant_id UUID, p_start_date DATE, p_end_date DATE, p_bank_account_id UUID DEFAULT NULL, p_statuses TEXT[] DEFAULT NULL)`
+→ `TABLE(inflow NUMERIC, outflow NUMERIC, net NUMERIC, tx_count BIGINT, inflow_count BIGINT, outflow_count BIGINT, avg_inflow NUMERIC, max_inflow NUMERIC)`.
+
+Source `bank_transactions`. `inflow = SUM(amount) FILTER (WHERE amount > 0)`.
+`outflow = ABS(SUM(amount) FILTER (WHERE amount < 0))`. The two optional
+parameters preserve each caller's current filter. `p_bank_account_id` filters
+one account when set. `p_statuses` filters `status = ANY(p_statuses)` when set;
+`NULL` applies no status filter. This one function serves cash_flow,
+revenue_health, spending totals, liquidity, income_statement cash_flow,
+generate_report, and expense_health.
+
+### 5.8 New — `get_bank_spending_by_category` (cluster 6 breakdown)
+
+`get_bank_spending_by_category(p_restaurant_id UUID, p_start_date DATE, p_end_date DATE, p_statuses TEXT[] DEFAULT NULL)`
+→ `TABLE(category_id UUID, category_name TEXT, spend NUMERIC, tx_count BIGINT)`.
+
+Source `bank_transactions`, `amount < 0`, grouped by category. Drives the
+spending breakdown and the expense_health category sums.
+
+### 5.9 New — `get_bank_transactions_daily` (cluster 6 series)
+
+`get_bank_transactions_daily(p_restaurant_id UUID, p_start_date DATE, p_end_date DATE, p_bank_account_id UUID DEFAULT NULL)`
+→ `TABLE(day DATE, inflow NUMERIC, outflow NUMERIC, net NUMERIC)`.
+
+Source `bank_transactions`, grouped by `transaction_date`. The result has at most
+one row per day. JavaScript keeps the forecast math (predictions) and the
+variance math (cash_flow) over this bounded series.
+
+---
+
+## 6. Rewiring plan
+
+Each site swaps its raw fetch for one RPC call. The derived math stays in
+JavaScript, over the complete aggregate.
+
+- **Cluster 1 (revenue).** Call `get_monthly_sales_metrics`. Sum
+  `gross_revenue - discounts`. Sites: income_statement, sales_summary
+  (current + previous), generate_report monthly_pnl, operating_costs. KPIs routes
+  its revenue and adjustment split through the same RPC; the plan confirms the
+  field map against `_shared/periodMetrics.ts`.
+- **Cluster 2 (sales breakdown).** generate_report calls
+  `get_sales_by_category`. sales_summary calls `get_top_sold_items`.
+- **Cluster 3 (COGS).** Scalar callers (KPIs, income_statement,
+  generate_report) call `get_inventory_usage_by_month` and sum the month rows.
+  monthly_trends reads the month rows directly.
+- **Cluster 4 (OpEx).** income_statement calls `get_journal_expense_total`.
+- **Cluster 5 (inventory value).** KPIs, inventory_status, income_statement
+  balance_sheet, and generate_report balance_sheet call
+  `get_inventory_valuation`.
+- **Cluster 6 (bank).** Scalar sites call `get_bank_transaction_summary` with the
+  right `p_statuses` and `p_bank_account_id`. The spending and expense_health
+  category sums call `get_bank_spending_by_category`. predictions and cash_flow
+  variance call `get_bank_transactions_daily`.
+- **Listing endpoints.** `get_bank_transactions` keeps its paginated list. Its
+  summary totals move to `get_bank_transaction_summary`. So the totals cover the
+  whole period, not one page.
+- **Batch tools.** Clamp the id count to 1000 before the `.in('id', ids)` fetch,
+  or page the ids. Return a clear message when the input is larger.
+
+---
+
+## 7. Behavioral changes to surface to the owner
+
+1. **Every cluster-1 site adopts one net-sales definition.** All six sites now
+   call `get_monthly_sales_metrics` and read `gross_revenue - discounts`. The
+   effect differs per site:
+   - income_statement
+     ([`index.ts:935`](supabase/functions/ai-execute-tool/index.ts:935)) and
+     generate_report ([`index.ts:1674`](supabase/functions/ai-execute-tool/index.ts:1674))
+     had no guards. Their revenue drops refunds, split duplicates, tax, and
+     tips. The number changes the most.
+   - sales_summary and operating_costs had the adjustment guard and the split
+     guard, but not the liability-account guard. Their revenue drops any sale
+     mapped to a liability account (a tax or tip item). The number changes a
+     little.
+   The new number is the app P&L net sales. This is the intended fix.
+2. **The COGS end day is now included** (§1.3, §5.4). The COGS number rises by
+   the last day's usage.
+3. **The bank status filter stays per-site.** The `p_statuses` parameter keeps
+   each caller's current behavior. The design does not unify the status filter,
+   because the app does not.
+
+---
+
+## 8. Security and tenancy
+
+- Every new RPC is `SECURITY INVOKER`. RLS stays in force for a client caller.
+- Every new RPC filters `restaurant_id = p_restaurant_id`. This scopes the
+  service-role caller, which bypasses RLS.
+- No RPC gates on `auth.uid()`. The `ai-execute-tool` edge function authorizes
+  the user and the restaurant before it dispatches a tool. The
+  `get_daily_sales_totals` sibling uses the same model
+  ([`ai_operator.sql:684`](supabase/migrations/20260214100000_ai_operator.sql:684)).
+- Every RPC grants execute to `authenticated`.
+
+---
+
+## 9. Testing
+
+### 9.1 pgTAP (`supabase/tests/`)
+
+One test file per new RPC. Each file:
+
+1. Sums a small fixture correctly.
+2. Returns 0 (not NULL) for an all-NULL-group fixture (lesson L1752).
+3. Excludes the rows the filters must exclude — a refund row, a split child, a
+   non-usage transaction, a non-expense account.
+4. Scopes by `restaurant_id`. A second restaurant's rows never contribute.
+5. `get_inventory_usage_by_month`: a usage row on the end day contributes (the
+   boundary test, §5.4).
+6. Respects the `unified_sales` and `journal_entry_lines` foreign keys in the
+   fixture (per the project lessons).
+
+The pgTAP session identity stays clean between tests (lesson L1759).
+
+### 9.2 Unit tests (`tests/unit/`)
+
+- Mock the RPC builder chain, not a bare promise (lesson L1846).
+- Test the summing helper for each cluster: it sums the RPC rows, handles an
+  empty array, and handles a NULL numeric.
+- Test the predictions and variance math over a fixed daily series.
+
+### 9.3 Production validation
+
+Before the PR, run a read-only SELECT against production for the reported
+restaurant and month. Compare each cluster's RPC output to the current app P&L
+number. Record the before-and-after in the PR body.
+
+---
+
+## 10. Risks and mitigations
+
+- **Big change.** About 32 sites in 2 files, plus 8 migrations and 8 test files.
+  Mitigation: the plan sequences the work by cluster. Each cluster is one
+  reviewable unit with its own RPC and tests.
+- **Number shifts.** The unified definitions change some tool outputs.
+  Mitigation: §7 lists each change. §9.3 proves each against production.
+- **Column-name reconciliation.** The bank sites use two names for the account
+  filter (`bank_account_id` and `connected_bank_id`) and one status filter.
+  Mitigation: the plan confirms the real column names against the schema before
+  it writes the bank RPCs.
+- **Rollback.** Every RPC is additive. If a client change regresses, revert the
+  edge-function commit; the RPC can stay.
+
+---
+
+## 11. Open items to pin in the plan
+
+1. Confirm the exact column names against the live schema: the
+   `bank_transactions` account-filter column and status values (cluster 6), and
+   the `journal_entry_lines` debit and credit columns plus the
+   `chart_of_accounts` expense-account link (cluster 4).
+2. Confirm the `_shared/periodMetrics.ts` field map, so KPIs keeps its
+   breakdown.
+3. Confirm the `products` low-stock predicate and column names.
+4. Decide the PR shape: one PR, or a short stacked series by cluster. The design
+   does not change either way.
+
+---
+
+## 12. Out of scope (follow-ups)
+
+- Break-even variable-cost math and the margin-of-safety unit (fix 2).
+- The operating-costs budget label (fix 3).
+- The same cap pattern in any non-financial tool path outside this file.

--- a/docs/superpowers/specs/2026-08-13-ai-financial-tools-row-cap-design.md
+++ b/docs/superpowers/specs/2026-08-13-ai-financial-tools-row-cap-design.md
@@ -666,22 +666,24 @@ items (COGS 27%, marketing 3%, processing 2.5%) contribute nothing. July output:
 `Variable Costs: $82.00` against an itemized list of `$1,199.52`, and a
 break-even of `$40,964.12` from a 1.44% variable ratio.
 
-New math, over the net sales the cluster-1 RPC returns (`netSales`):
+New math, over the net sales the cluster-1 RPC returns (`netSales`). Note:
+`percentage_value` is a fraction of net sales (0.27 = 27%); the earlier text
+in this section assumed a whole-number percent.
 
 - `variableFlatTotal` = Σ `monthly_value / 100` over `cost_type = 'variable'`
   AND `entry_type = 'value'`.
-- `variablePercentTotal` = Σ `(percentage_value / 100) * netSales` over
+- `variablePercentTotal` = Σ `percentage_value * netSales` over
   `cost_type = 'variable'` AND `entry_type = 'percentage'`.
 - `variableTotal = variableFlatTotal + variablePercentTotal`. This is the
   displayed "Variable Costs" dollar figure.
-- `variableCostPercentage` = Σ `percentage_value` + (`netSales > 0` ?
+- `variableCostPercentage` = Σ `percentage_value * 100` + (`netSales > 0` ?
   `variableFlatTotal / netSales * 100` : 0). Keep the existing fallback: when
   the restaurant has no variable rows at all, use the hardcoded 25.
 - `contributionMargin = 100 - variableCostPercentage` and
   `breakEvenRevenue = totalFixedCosts / (contributionMargin / 100)` stay as
   today ([`index.ts:2628-2631`](supabase/functions/ai-execute-tool/index.ts:2628)).
 - Each `entry_type = 'percentage'` item in the response gains
-  `computed_monthly_amount = (percentage_value / 100) * netSales`, so the model
+  `computed_monthly_amount = percentage_value * netSales`, so the model
   does not do its own arithmetic on a stale revenue figure.
 - `total_monthly_costs` becomes `fixedTotal + semiVariableTotal +
   variableTotal` with the corrected `variableTotal`.

--- a/docs/superpowers/specs/2026-08-13-ai-financial-tools-row-cap-design.md
+++ b/docs/superpowers/specs/2026-08-13-ai-financial-tools-row-cap-design.md
@@ -5,9 +5,9 @@
 - **Status:** Draft for review
 - **Feature area:** AI chat financial tools (`supabase/functions/ai-execute-tool/index.ts`)
 - **Scope:** Replace every raw-row fetch plus JavaScript sum in the AI tool
-  executor with a SQL aggregate. About 32 sites across 12 tools. Add 8 aggregate
-  RPCs and reuse 1. Keep each displayed number correct, and unify the numbers on
-  the app P&L definitions.
+  executor with a SQL aggregate. About 32 sites across 12 tools. Add 9 aggregate
+  RPCs. Modify 1 shared RPC (`get_monthly_sales_metrics`). Add 1 index. Keep each
+  displayed number correct, and unify the numbers on the app P&L definitions.
 
 This document uses STE-aligned Simplified Technical English. Code identifiers,
 SQL, and file paths stay exact.
@@ -44,7 +44,9 @@ inconsistency is a second root cause of the wrong answers.
 ### 1.3 Latent boundary defect — COGS end day
 
 The income-statement COGS fetch filters `created_at` with a bare date string
-([`index.ts:945`](supabase/functions/ai-execute-tool/index.ts:945)). The column
+([`index.ts:945`](supabase/functions/ai-execute-tool/index.ts:945)). The
+generate_report COGS fetch does the same
+([`index.ts:1686`](supabase/functions/ai-execute-tool/index.ts:1686)). The column
 is a `timestamptz`. A bare date string coerces to `00:00:00`. So the fetch drops
 almost all of the last day. The KPIs food-cost fetch already appends
 `'T23:59:59.999Z'`
@@ -69,8 +71,11 @@ tools also disagree on the end boundary.
 ### 2.2 Non-goals
 
 - Do not change the break-even variable-cost math or the margin-of-safety unit
-  ([`index.ts:2622`](supabase/functions/ai-execute-tool/index.ts:2622)). This is
-  a later PR (fix 2).
+  ([`index.ts:2623-2640`](supabase/functions/ai-execute-tool/index.ts:2623)). This
+  is a later PR (fix 2). Note: the revenue sum that feeds this math
+  ([`index.ts:2622`](supabase/functions/ai-execute-tool/index.ts:2622)) IS in
+  scope. This PR replaces that one `reduce()` with the shared revenue RPC. The
+  break-even formula below it stays the same.
 - Do not relabel the operating-costs output as a budget
   ([`index.ts:2565`](supabase/functions/ai-execute-tool/index.ts:2565)). This is
   a later PR (fix 3).
@@ -171,31 +176,85 @@ purpose-built aggregate RPCs (`get_daily_sales_totals`,
 
 ## 5. RPC specifications
 
-Reuse 1 function. Add 8. Every new function follows the `get_daily_sales_totals`
-template ([`ai_operator.sql:678`](supabase/migrations/20260214100000_ai_operator.sql:678)):
+Add 9 functions. Modify 1 (§5.1). Every new function follows the
+`get_daily_sales_totals` template
+([`ai_operator.sql:678`](supabase/migrations/20260214100000_ai_operator.sql:678)):
 
 - `LANGUAGE sql STABLE SECURITY INVOKER` for a scalar or grouped aggregate.
-- `SECURITY INVOKER`, not `DEFINER`. RLS stays in force for a client caller. The
-  `ai-execute-tool` edge function calls with the service role, which bypasses
-  RLS. So the explicit `restaurant_id = p_restaurant_id` filter scopes both
-  callers.
-- `SUM(COALESCE(col, 0))` for every sum. A SQL `SUM` over an all-NULL group
-  returns NULL. `unified_sales.total_price` and other columns are nullable
-  (lesson L1752).
+- `SECURITY INVOKER`, not `DEFINER`. The execution model requires it. The
+  `ai-execute-tool` edge function builds its client with `SUPABASE_ANON_KEY` and
+  the caller's forwarded `Authorization` header
+  ([`index.ts:3652-3656`](supabase/functions/ai-execute-tool/index.ts:3652)). So
+  every query runs under the caller's JWT, and RLS is active. Under `INVOKER`,
+  RLS on the source table scopes the caller to the caller's own restaurants.
+  The explicit `restaurant_id = p_restaurant_id` filter then selects the one
+  restaurant the tool asked for. The edge function also verifies membership
+  before it dispatches a tool
+  ([`index.ts:3671-3676`](supabase/functions/ai-execute-tool/index.ts:3671)).
+- The row cap is an HTTP-layer PostgREST limit, not an RLS limit. RLS does not
+  cap rows. So a `SUM` under RLS sees the complete set. Each source table
+  (`unified_sales`, `inventory_transactions`, `journal_entry_lines`, `products`,
+  `bank_transactions`) is restaurant-scoped in RLS, not capability-scoped. So any
+  restaurant member reads all of the restaurant's rows, and the aggregate is
+  complete.
+- Pin `SET search_path TO 'public'` on every function, new and modified.
+  `INVOKER` does not require the pin for privilege, but the Supabase
+  `function_search_path_mutable` advisor flags any unpinned function, and the pin
+  fixes name resolution to `public`. The `get_daily_sales_totals` template omits
+  the pin because it predates the advisor guidance; the new functions add it. The
+  modified `get_monthly_sales_metrics` already pins it
+  ([`...revenue_filter.sql:29`](supabase/migrations/20260501120000_fix_monthly_sales_metrics_revenue_filter.sql:29));
+  the `INVOKER` conversion keeps it.
+- `COALESCE(SUM(col), 0)` for every sum. A SQL `SUM` over an all-NULL or empty
+  group returns NULL; this wraps the NULL to 0. It matches the
+  `get_daily_sales_totals` template and lesson L1752. `unified_sales.total_price`
+  and other columns are nullable.
 - `GRANT EXECUTE ... TO authenticated`, re-issued after `CREATE OR REPLACE`.
 - A `COMMENT ON FUNCTION` that states the source, the filters, and the exclusions.
 
-### 5.1 Reuse — `get_monthly_sales_metrics` (revenue, cluster 1)
+### 5.1 Modify — `get_monthly_sales_metrics` (revenue, cluster 1)
 
 Signature (existing):
 `get_monthly_sales_metrics(p_restaurant_id UUID, p_date_from DATE, p_date_to DATE)`
 ([`20260501120000_fix_monthly_sales_metrics_revenue_filter.sql:14`](supabase/migrations/20260501120000_fix_monthly_sales_metrics_revenue_filter.sql:14)).
 
-Callers sum `gross_revenue - discounts` across the returned month rows. The
+This function already aggregates net sales. It applies the adjustment guard, the
+split guard, the item-type guard, and the liability-account guard. Callers sum
+its rows across the returned months. The
 `WHERE sale_date BETWEEN p_date_from AND p_date_to` clause bounds the exact
-range. So a partial-month range still sums only the in-range rows. This is the
-app P&L net-sales figure. It applies the adjustment guard, the split guard, the
-item-type guard, and the liability-account guard.
+range. So a partial-month range still sums only the in-range rows.
+
+This design makes it the single revenue source for every cluster-1 site. Two
+changes are required first. Both land in one new migration (`CREATE OR REPLACE`).
+
+**Change A — close a cross-tenant read hole (security).** The function is
+`SECURITY DEFINER` with no `auth.uid()` check, and it grants execute to
+`authenticated`
+([`...revenue_filter.sql:27-30,128`](supabase/migrations/20260501120000_fix_monthly_sales_metrics_revenue_filter.sql:27)).
+Because the edge function runs under the caller's JWT (not the service role, see
+§5 conventions) and `DEFINER` bypasses RLS, any authenticated user can call
+`/rest/v1/rpc/get_monthly_sales_metrics` directly with another restaurant's UUID
+and read that restaurant's revenue, tax, tips, and discounts. This hole exists
+today. This design routes more sites through the function, so it must close the
+hole. **Fix:** convert the function to `SECURITY INVOKER`, so RLS on
+`unified_sales` and `chart_of_accounts` scopes the caller. A pgTAP test proves a
+non-member caller reads zero rows for a foreign restaurant.
+
+**Change B — add a `refunds` column (correctness).** The KPIs breakdown defines
+net sales as `gross_revenue - discounts - refunds`
+([`periodMetrics.ts:193`](supabase/functions/_shared/periodMetrics.ts:193)), and
+it fills `refunds` from `item_type = 'refund'` rows. This function has no
+`refunds` column. So a plain reuse would drop the refund term and overstate KPIs
+revenue. **Fix:** add a `refunds` column (`COALESCE(SUM(ABS(total_price)), 0)`
+over refund rows). Define the unified net sales as
+`gross_revenue - discounts - refunds`. Update the sole other caller,
+`monthly_trends` ([`index.ts:2685`](supabase/functions/ai-execute-tool/index.ts:2685)),
+to subtract `refunds` too, so it stays unified.
+
+**Caller check.** The only callers are the `monthly_trends` tool and this
+design's new cluster-1 sites (verified by grep). The existing pgTAP suite
+(`supabase/tests/36_monthly_sales_metrics_revenue_filter.sql`) still applies and
+extends with the tenancy and refund tests.
 
 ### 5.2 New — `get_sales_by_category` (cluster 2)
 
@@ -219,13 +278,24 @@ sales-summary top-sellers block.
 `get_inventory_usage_by_month(p_restaurant_id UUID, p_start_date DATE, p_end_date DATE)`
 → `TABLE(period TEXT, food_cost NUMERIC)`.
 
-Source `inventory_transactions`. Filter `transaction_type = 'usage'`. Sum
-`ABS(COALESCE(SUM(total_cost), 0))` per month. `ABS(SUM(...))` matches the
-current code and is correct: a reversal row reduces the cost. A scalar caller
-sums the month rows. `monthly_trends` reads the month rows directly.
+Source `inventory_transactions`. Filter `transaction_type = 'usage'`. Compute
+`ABS(COALESCE(SUM(total_cost), 0))` per month. `ABS(SUM(...))` is correct: a
+reversal row (opposite sign) reduces the cost. A scalar caller sums the month
+rows. `monthly_trends` reads the month rows directly.
 
-Boundary: filter `created_at >= p_start_date AND created_at < (p_end_date + 1)`.
-This includes the full end day. It fixes the defect in §1.3.
+Note: three of the four current COGS sites already apply `Math.abs()` after the
+sum (income_statement, generate_report, KPIs), so this matches them.
+`monthly_trends` today applies `Math.abs()` per row
+([`index.ts:2707-2711`](supabase/functions/ai-execute-tool/index.ts:2707)), which
+is `SUM(ABS(...))`. So this unifies `monthly_trends` onto `ABS(SUM(...))`. Its
+food-cost-by-month number changes for any month that has both a usage row and a
+reversal row. §7 surfaces this.
+
+Boundary: filter `created_at >= (p_start_date AT TIME ZONE 'UTC')
+AND created_at < ((p_end_date + 1) AT TIME ZONE 'UTC')`. This form is explicit
+UTC. It does not depend on the session `TimeZone` setting. It matches the
+existing explicit-UTC pattern (`endDateStr + 'T23:59:59.999Z'`). It includes the
+full end day. It fixes the defect in §1.3.
 
 ### 5.5 New — `get_journal_expense_total` (OpEx, cluster 4)
 
@@ -246,9 +316,11 @@ call.
 → `TABLE(total_value NUMERIC, item_count BIGINT, low_stock_count BIGINT)`.
 
 Source `products`. `total_value = COALESCE(SUM(current_stock * cost_per_unit),
-0)`. `low_stock_count` counts rows where the stock is at or under the reorder
-point. The exact low-stock predicate copies the current code
-([`index.ts:427`](supabase/functions/ai-execute-tool/index.ts:427)).
+0)`. `low_stock_count` counts rows where `current_stock <= COALESCE(par_level_min,
+0)`. This copies the current predicate exactly
+([`index.ts:404-406`](supabase/functions/ai-execute-tool/index.ts:404)). The
+threshold column is `par_level_min`, not `reorder_point`. The current code
+selects `reorder_point` but does not use it for the threshold.
 
 ### 5.7 New — `get_bank_transaction_summary` (cluster 6 scalars)
 
@@ -257,11 +329,14 @@ point. The exact low-stock predicate copies the current code
 
 Source `bank_transactions`. `inflow = SUM(amount) FILTER (WHERE amount > 0)`.
 `outflow = ABS(SUM(amount) FILTER (WHERE amount < 0))`. The two optional
-parameters preserve each caller's current filter. `p_bank_account_id` filters
-one account when set. `p_statuses` filters `status = ANY(p_statuses)` when set;
-`NULL` applies no status filter. This one function serves cash_flow,
-revenue_health, spending totals, liquidity, income_statement cash_flow,
-generate_report, and expense_health.
+parameters preserve each caller's current filter. `p_bank_account_id` filters the
+`connected_bank_id` column when set (confirmed at
+[`index.ts:2809`](supabase/functions/ai-execute-tool/index.ts:2809)). `p_statuses`
+filters `status = ANY(p_statuses)` when set; `NULL` applies no status filter. This
+one function serves cash_flow, revenue_health, spending totals, liquidity,
+income_statement cash_flow, generate_report, and the get_bank_transactions
+summary. The expense_health tool uses a dedicated RPC (§5.10), because its six
+sums need per-metric rules a plain summary cannot express.
 
 ### 5.8 New — `get_bank_spending_by_category` (cluster 6 breakdown)
 
@@ -280,6 +355,49 @@ Source `bank_transactions`, grouped by `transaction_date`. The result has at mos
 one row per day. JavaScript keeps the forecast math (predictions) and the
 variance math (cash_flow) over this bounded series.
 
+### 5.10 New — `get_expense_health_metrics` (cluster 6, expense_health)
+
+`get_expense_health_metrics(p_restaurant_id UUID, p_start_date DATE, p_end_date DATE, p_fee_patterns TEXT[], p_bank_account_id UUID DEFAULT NULL)`
+→ `TABLE(revenue NUMERIC, food_cost NUMERIC, labor_cost NUMERIC, processing_fees NUMERIC, total_outflows NUMERIC, uncategorized_spend NUMERIC)`.
+
+The `executeGetExpenseHealth` tool fetches once and derives six sums
+([`index.ts:2818-2853`](supabase/functions/ai-execute-tool/index.ts:2818)). Each
+sum has its own rule, so a plain summary RPC cannot serve it. This RPC computes
+all six with `FILTER` clauses over `bank_transactions` left-joined to
+`chart_of_accounts` on `category_id`. It filters `status IN ('posted', 'pending')`
+and, when set, `connected_bank_id = p_bank_account_id`.
+
+- `revenue`: `SUM(amount) FILTER (WHERE amount > 0)`.
+- `food_cost`: outflow where the account subtype is `cost_of_goods_sold`, or the
+  account name matches `food`/`inventory`.
+- `labor_cost`: outflow where the account subtype is `payroll`, or the account
+  name matches `payroll`/`labor`.
+- `processing_fees`: outflow where `LOWER(description || ' ' || merchant_name)`
+  matches any pattern in `p_fee_patterns`. The `processingFeePatterns` list stays
+  in TypeScript and passes in as the parameter, so TypeScript remains the source
+  of the list.
+- `total_outflows`: `ABS(SUM(amount) FILTER (WHERE amount < 0))`.
+- `uncategorized_spend`: outflow where `category_id IS NULL AND is_split = false`.
+
+JavaScript keeps the percentage math (`foodCostPercentage`, and so on) over these
+six values.
+
+### 5.11 New index — `bank_transactions(restaurant_id, transaction_date)`
+
+Today the 1000-row cap accidentally bounds every bank scan. The new bank RPCs
+remove that cap and aggregate the full date range server-side. `bank_transactions`
+has no composite index that leads on `restaurant_id` and covers a date range.
+The existing indexes are `(restaurant_id, status)`, a single-column
+`transaction_date` index, a `category_id` index, and
+`(connected_bank_id, transaction_date DESC)`
+([`20260723130000_connected_banks_reauth_columns.sql:53`](supabase/migrations/20260723130000_connected_banks_reauth_columns.sql:53)).
+The last one leads on `connected_bank_id`, so it does not serve a
+restaurant-scoped date-range scan. So add:
+`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_bank_transactions_restaurant_date ON bank_transactions(restaurant_id, transaction_date);`.
+This follows the `CONCURRENTLY` precedent already in the repo
+(`20260804090200_idx_bank_transactions_rule_candidates_v2.sql`). `CONCURRENTLY`
+cannot run inside a transaction, so this migration must not wrap in `BEGIN`.
+
 ---
 
 ## 6. Rewiring plan
@@ -287,11 +405,14 @@ variance math (cash_flow) over this bounded series.
 Each site swaps its raw fetch for one RPC call. The derived math stays in
 JavaScript, over the complete aggregate.
 
-- **Cluster 1 (revenue).** Call `get_monthly_sales_metrics`. Sum
-  `gross_revenue - discounts`. Sites: income_statement, sales_summary
-  (current + previous), generate_report monthly_pnl, operating_costs. KPIs routes
-  its revenue and adjustment split through the same RPC; the plan confirms the
-  field map against `_shared/periodMetrics.ts`.
+- **Cluster 1 (revenue).** Call `get_monthly_sales_metrics` (modified, §5.1). Sum
+  `gross_revenue - discounts - refunds`. Sites: income_statement, sales_summary
+  (current + previous), generate_report monthly_pnl, operating_costs revenue
+  ([`index.ts:2622`](supabase/functions/ai-execute-tool/index.ts:2622) only, not
+  the break-even formula below it). KPIs replaces the
+  `calculateRevenueBreakdown` raw fetch with the same RPC; its net revenue stays
+  `gross - discounts - refunds`. §7 lists the small definition shift KPIs takes on
+  from the RPC's account-type classification.
 - **Cluster 2 (sales breakdown).** generate_report calls
   `get_sales_by_category`. sales_summary calls `get_top_sold_items`.
 - **Cluster 3 (COGS).** Scalar callers (KPIs, income_statement,
@@ -302,9 +423,13 @@ JavaScript, over the complete aggregate.
   balance_sheet, and generate_report balance_sheet call
   `get_inventory_valuation`.
 - **Cluster 6 (bank).** Scalar sites call `get_bank_transaction_summary` with the
-  right `p_statuses` and `p_bank_account_id`. The spending and expense_health
-  category sums call `get_bank_spending_by_category`. predictions and cash_flow
-  variance call `get_bank_transactions_daily`.
+  right `p_statuses` and `p_bank_account_id`. The spending breakdown calls
+  `get_bank_spending_by_category`. predictions and cash_flow variance call
+  `get_bank_transactions_daily`. expense_health calls `get_expense_health_metrics`
+  (§5.10), one call for all six sums.
+- **monthly_trends.** It reads two modified sources. Its net revenue now
+  subtracts `refunds` (§5.1). Its food cost by month now uses `ABS(SUM(...))`
+  (§5.4). §7 surfaces both.
 - **Listing endpoints.** `get_bank_transactions` keeps its paginated list. Its
   summary totals move to `get_bank_transaction_summary`. So the totals cover the
   whole period, not one page.
@@ -316,36 +441,79 @@ JavaScript, over the complete aggregate.
 ## 7. Behavioral changes to surface to the owner
 
 1. **Every cluster-1 site adopts one net-sales definition.** All six sites now
-   call `get_monthly_sales_metrics` and read `gross_revenue - discounts`. The
-   effect differs per site:
+   call `get_monthly_sales_metrics` and read `gross_revenue - discounts -
+   refunds`. The effect differs per site:
    - income_statement
      ([`index.ts:935`](supabase/functions/ai-execute-tool/index.ts:935)) and
      generate_report ([`index.ts:1674`](supabase/functions/ai-execute-tool/index.ts:1674))
-     had no guards. Their revenue drops refunds, split duplicates, tax, and
-     tips. The number changes the most.
+     had no guards. Their revenue drops split duplicates, tax, and tips. The
+     number changes the most.
    - sales_summary and operating_costs had the adjustment guard and the split
      guard, but not the liability-account guard. Their revenue drops any sale
      mapped to a liability account (a tax or tip item). The number changes a
      little.
    The new number is the app P&L net sales. This is the intended fix.
-2. **The COGS end day is now included** (§1.3, §5.4). The COGS number rises by
+2. **KPIs revenue takes on the RPC classification.** KPIs used
+   `calculateRevenueBreakdown`, which classifies tax and tip accounts with the
+   keyword rules in `tipClassification.ts`. The RPC classifies by the
+   chart-of-accounts `account_type`. So the KPIs tax and tip split can shift for
+   an account where the two rules disagree. The KPIs net revenue (`gross -
+   discounts - refunds`) stays the same by construction, because net does not
+   depend on the tax and tip split.
+3. **monthly_trends net revenue now subtracts refunds** (§5.1). Today it reads
+   `gross - discounts`. A restaurant with refunds sees its trend revenue drop by
+   the refund total. This aligns it with the P&L.
+4. **monthly_trends food cost by month changes** (§5.4). It moves from
+   `SUM(ABS(x))` to `ABS(SUM(x))`. A month with both a usage row and a reversal
+   row changes. `ABS(SUM(x))` is the correct treatment: a reversal reduces the
+   cost.
+5. **The COGS end day is now included** (§1.3, §5.4). The COGS number rises by
    the last day's usage.
-3. **The bank status filter stays per-site.** The `p_statuses` parameter keeps
+6. **The bank status filter stays per-site.** The `p_statuses` parameter keeps
    each caller's current behavior. The design does not unify the status filter,
    because the app does not.
+7. **An account-scoped bank question stops failing.** Six bank sites filter a
+   `bank_account_id` column that does not exist on `bank_transactions` (the real
+   column is `connected_bank_id`, §11). The filter is conditional on an optional
+   argument, so it fires only when the owner scopes a question to one bank
+   account. Today that path errors. The new RPCs filter `connected_bank_id`, so
+   the account-scoped question returns the correct number.
 
 ---
 
 ## 8. Security and tenancy
 
-- Every new RPC is `SECURITY INVOKER`. RLS stays in force for a client caller.
-- Every new RPC filters `restaurant_id = p_restaurant_id`. This scopes the
-  service-role caller, which bypasses RLS.
-- No RPC gates on `auth.uid()`. The `ai-execute-tool` edge function authorizes
-  the user and the restaurant before it dispatches a tool. The
-  `get_daily_sales_totals` sibling uses the same model
+**Execution model.** The `ai-execute-tool` edge function builds its Supabase
+client with `SUPABASE_ANON_KEY` and the caller's forwarded `Authorization` header
+([`index.ts:3652-3656`](supabase/functions/ai-execute-tool/index.ts:3652)). So
+every RPC runs under the caller's JWT, not the service role. RLS stays active.
+This is the correct model to design against.
+
+- **Every new RPC is `SECURITY INVOKER`.** RLS on each source table scopes the
+  caller to the caller's own restaurants. The explicit
+  `restaurant_id = p_restaurant_id` filter then selects the one restaurant the
+  tool asked for. A caller cannot read a restaurant that RLS hides, because
+  `INVOKER` gives the function the caller's privileges.
+- **The modified `get_monthly_sales_metrics` becomes `SECURITY INVOKER`** (§5.1,
+  Change A). Today it is `SECURITY DEFINER` with no `auth.uid()` gate and a grant
+  to `authenticated`. So today any authenticated user can call it directly with a
+  foreign restaurant UUID and read that restaurant's revenue. The conversion to
+  `INVOKER` closes that hole. This design must close it, because it routes more
+  sites through the function.
+- **No RPC gates on `auth.uid()`.** RLS is the tenancy control, not an in-function
+  check. The edge function also verifies restaurant membership before it dispatches
+  a tool ([`index.ts:3671-3676`](supabase/functions/ai-execute-tool/index.ts:3671)).
+  The `get_daily_sales_totals` sibling uses the same pattern — `INVOKER`, no
+  `auth.uid()` gate, grant to `authenticated`
   ([`ai_operator.sql:684`](supabase/migrations/20260214100000_ai_operator.sql:684)).
-- Every RPC grants execute to `authenticated`.
+- **The aggregate is complete under RLS.** The row cap is an HTTP-layer PostgREST
+  limit, not an RLS limit. Each source table (`unified_sales`,
+  `inventory_transactions`, `journal_entry_lines`, `products`, `bank_transactions`)
+  is restaurant-scoped in RLS, not capability-scoped. So any restaurant member
+  reads all of the restaurant's rows, and a `SUM` under RLS sees the complete set.
+- **Every RPC grants execute to `authenticated`.** So each RPC is reachable at
+  `/rest/v1/rpc/<name>`. `INVOKER` plus RLS makes that reach safe: a direct call
+  with a foreign restaurant UUID returns zero rows.
 
 ---
 
@@ -353,19 +521,38 @@ JavaScript, over the complete aggregate.
 
 ### 9.1 pgTAP (`supabase/tests/`)
 
-One test file per new RPC. Each file:
+One test file per new RPC, plus new cases in the existing
+`get_monthly_sales_metrics` suite. Each file:
 
 1. Sums a small fixture correctly.
 2. Returns 0 (not NULL) for an all-NULL-group fixture (lesson L1752).
 3. Excludes the rows the filters must exclude — a refund row, a split child, a
    non-usage transaction, a non-expense account.
-4. Scopes by `restaurant_id`. A second restaurant's rows never contribute.
-5. `get_inventory_usage_by_month`: a usage row on the end day contributes (the
+4. **Filter scope.** The function receives one `restaurant_id`. A second
+   restaurant's rows never contribute to the result.
+5. **RLS tenancy.** Set the session to a non-member `authenticated` user
+   (`set role`, `request.jwt.claims`). The `SECURITY INVOKER` function then
+   returns zero rows for a foreign `restaurant_id`. This proves RLS scopes the
+   caller, not the `p_restaurant_id` filter alone. It is the test that fails
+   today for `get_monthly_sales_metrics` (the `DEFINER` hole, §5.1 Change A).
+6. `get_inventory_usage_by_month`: a usage row on the end day contributes (the
    boundary test, §5.4).
-6. Respects the `unified_sales` and `journal_entry_lines` foreign keys in the
+7. Respects the `unified_sales` and `journal_entry_lines` foreign keys in the
    fixture (per the project lessons).
 
-The pgTAP session identity stays clean between tests (lesson L1759).
+Function-specific cases:
+
+- **`get_monthly_sales_metrics` (modified).** A refund row lands in the new
+  `refunds` column. Net sales equals `gross_revenue - discounts - refunds`. The
+  RLS tenancy test (item 5) is the new guard for the security fix.
+- **`get_expense_health_metrics`.** The six sums split correctly: revenue (amount
+  > 0), food cost, labor cost, processing fees, total outflows, and uncategorized
+  spend. A caller-supplied `p_fee_patterns` value matches a fee row by description
+  or merchant name. An uncategorized row (`category_id IS NULL` and not split)
+  lands only in uncategorized spend.
+
+The pgTAP session identity stays clean between tests (lesson L1759). The RLS
+tenancy test (item 5) resets `role` and `request.jwt.claims` after it runs.
 
 ### 9.2 Unit tests (`tests/unit/`)
 
@@ -384,31 +571,57 @@ number. Record the before-and-after in the PR body.
 
 ## 10. Risks and mitigations
 
-- **Big change.** About 32 sites in 2 files, plus 8 migrations and 8 test files.
-  Mitigation: the plan sequences the work by cluster. Each cluster is one
-  reviewable unit with its own RPC and tests.
+- **Big change.** About 32 sites in 2 files. Add 9 RPCs, modify 1 shared RPC,
+  add 1 index, and add about 10 pgTAP files. Mitigation: the plan sequences the
+  work by cluster. Each cluster is one reviewable unit with its own RPC and tests.
 - **Number shifts.** The unified definitions change some tool outputs.
   Mitigation: §7 lists each change. §9.3 proves each against production.
-- **Column-name reconciliation.** The bank sites use two names for the account
-  filter (`bank_account_id` and `connected_bank_id`) and one status filter.
-  Mitigation: the plan confirms the real column names against the schema before
-  it writes the bank RPCs.
-- **Rollback.** Every RPC is additive. If a client change regresses, revert the
-  edge-function commit; the RPC can stay.
+- **A shared function changes.** `get_monthly_sales_metrics` moves to
+  `SECURITY INVOKER` and gains a `refunds` column. Its one other caller is
+  `monthly_trends` (verified). Mitigation: update `monthly_trends` in the same PR
+  (§5.1). The new pgTAP tenancy and refund tests guard the change.
+- **Migration safety.** The index migration uses `CREATE INDEX CONCURRENTLY`,
+  which cannot run inside a transaction (§5.11). Mitigation: the plan puts the
+  index in its own migration with no `BEGIN` wrapper.
+- **Rollback.** Every new RPC is additive. The `get_monthly_sales_metrics` change
+  is a `CREATE OR REPLACE`, so a revert restores the prior body. If a client
+  change regresses, revert the edge-function commit; the RPCs can stay.
 
 ---
 
 ## 11. Open items to pin in the plan
 
-1. Confirm the exact column names against the live schema: the
-   `bank_transactions` account-filter column and status values (cluster 6), and
-   the `journal_entry_lines` debit and credit columns plus the
-   `chart_of_accounts` expense-account link (cluster 4).
-2. Confirm the `_shared/periodMetrics.ts` field map, so KPIs keeps its
-   breakdown.
-3. Confirm the `products` low-stock predicate and column names.
-4. Decide the PR shape: one PR, or a short stacked series by cluster. The design
-   does not change either way.
+### 11.1 Resolved during design
+
+1. **Bank account-filter column.** The real column is `connected_bank_id`
+   ([`...5da7500b...sql:111`](supabase/migrations/20251018183326_5da7500b-3a17-4a58-af24-d2175258f871.sql:111)).
+   `bank_transactions` has no `bank_account_id` column. Six sites filter
+   `bank_account_id` (lines 509, 567, 626, 704, 741, 858), so an account-scoped
+   bank query errors today. The new RPCs filter `connected_bank_id`, which fixes
+   the latent bug (§7 item 7).
+2. **Cluster-4 journal columns.** The columns are `debit_amount` and
+   `credit_amount`; the parent date is `journal_entries.entry_date`; the expense
+   link is `chart_of_accounts.account_type = 'expense'` scoped by `restaurant_id`
+   ([`...5da7500b...sql:179`](supabase/migrations/20251018183326_5da7500b-3a17-4a58-af24-d2175258f871.sql:179),
+   [`index.ts:955-971`](supabase/functions/ai-execute-tool/index.ts:955)). §5.5 matches.
+3. **Products low-stock predicate.** It is `current_stock <= COALESCE(par_level_min,
+   0)` (§5.6, confirmed at [`index.ts:404-406`](supabase/functions/ai-execute-tool/index.ts:404)).
+4. **KPIs field map.** KPIs reroutes through `get_monthly_sales_metrics` plus the
+   new `refunds` column. Net stays `gross_revenue - discounts - refunds`. The tax
+   and tip split can shift (§7 item 2). The `processingFeePatterns` list stays in
+   TypeScript and passes as the `p_fee_patterns` parameter (§5.10).
+5. **Shared-function caller count.** `get_monthly_sales_metrics` has one other
+   caller, `monthly_trends` (verified by grep). The plan updates it in the same PR.
+
+### 11.2 Still open
+
+1. **Bank status values per site.** Confirm the exact `transaction_status_enum`
+   values each bank caller filters today, so `p_statuses` reproduces per-site
+   behavior (low risk; the default `NULL` applies no status filter).
+2. **PR shape.** Decide one PR, or a short stacked series by cluster. Also decide
+   whether the `get_monthly_sales_metrics` `INVOKER` conversion (§5.1 Change A)
+   ships first as its own small security PR. It fixes a live cross-tenant hole and
+   does not depend on the cap work. The design does not change either way.
 
 ---
 

--- a/supabase/functions/_shared/financialAggregates.ts
+++ b/supabase/functions/_shared/financialAggregates.ts
@@ -1,0 +1,38 @@
+// supabase/functions/_shared/financialAggregates.ts
+// One net-sales definition for every AI financial tool.
+// Net sales = gross_revenue - discounts - refunds (see the spec, §5.1).
+
+export interface MonthlyMetricsRow {
+  period: string; gross_revenue: number; sales_tax: number; tips: number;
+  other_liabilities: number; discounts: number; refunds: number;
+}
+export interface NetSalesTotals {
+  gross: number; discounts: number; refunds: number;
+  salesTax: number; tips: number; otherLiabilities: number; net: number;
+}
+const n = (v: number | null | undefined) => Number(v ?? 0);
+
+export function sumMonthlyMetrics(rows: MonthlyMetricsRow[] | null): NetSalesTotals {
+  const t = { gross: 0, discounts: 0, refunds: 0, salesTax: 0, tips: 0, otherLiabilities: 0, net: 0 };
+  for (const r of rows ?? []) {
+    t.gross += n(r.gross_revenue); t.discounts += n(r.discounts); t.refunds += n(r.refunds);
+    t.salesTax += n(r.sales_tax); t.tips += n(r.tips); t.otherLiabilities += n(r.other_liabilities);
+  }
+  t.net = t.gross - t.discounts - t.refunds;
+  return t;
+}
+
+export async function fetchNetSales(
+  supabase: { rpc: (fn: string, args: Record<string, unknown>) => Promise<{ data: unknown; error: { message: string } | null }> },
+  restaurantId: string, startDate: string, endDate: string,
+): Promise<NetSalesTotals> {
+  const { data, error } = await supabase.rpc('get_monthly_sales_metrics', {
+    p_restaurant_id: restaurantId, p_date_from: startDate, p_date_to: endDate,
+  });
+  if (error) throw new Error(`get_monthly_sales_metrics failed: ${error.message}`);
+  return sumMonthlyMetrics(data as MonthlyMetricsRow[] | null);
+}
+
+export function sumMonthlyFoodCost(rows: { period: string; food_cost: number }[] | null): number {
+  return (rows ?? []).reduce((s, r) => s + n(r.food_cost), 0);
+}

--- a/supabase/functions/_shared/operatingCostMath.ts
+++ b/supabase/functions/_shared/operatingCostMath.ts
@@ -1,0 +1,43 @@
+// supabase/functions/_shared/operatingCostMath.ts
+// Spec §13.2. monthly_value is cents and is 0 for percentage rows;
+// percentage rows carry percentage_value instead.
+
+export interface CostRow { cost_type: string; entry_type: string; monthly_value: number; percentage_value: number | null; }
+export interface OperatingCostTotals {
+  fixedTotal: number; semiVariableTotal: number;
+  variableFlatTotal: number; variablePercentTotal: number; variableTotal: number;
+  totalMonthlyCosts: number; variableCostPercentage: number;
+  contributionMargin: number; breakEvenRevenue: number;
+}
+
+export function computeOperatingCostTotals(rows: CostRow[], netSales: number): OperatingCostTotals {
+  const by = (t: string) => rows.filter((r) => r.cost_type === t);
+  const flat = (rs: CostRow[]) => rs.filter((r) => r.entry_type !== 'percentage')
+    .reduce((s, r) => s + (r.monthly_value ?? 0) / 100, 0);
+  const pct = (rs: CostRow[]) => rs.filter((r) => r.entry_type === 'percentage')
+    .reduce((s, r) => s + (r.percentage_value ?? 0), 0);
+
+  const fixedTotal = flat(by('fixed'));
+  const semiVariableTotal = flat(by('semi_variable'));
+  const variableRows = by('variable');
+  const variableFlatTotal = flat(variableRows);
+  const variablePctSum = pct(variableRows);
+  const variablePercentTotal = (variablePctSum / 100) * netSales;
+  const variableTotal = variableFlatTotal + variablePercentTotal;
+
+  let variableCostPercentage: number;
+  if (variableRows.length === 0) {
+    variableCostPercentage = 25; // keep the historical fallback estimate
+  } else {
+    variableCostPercentage = variablePctSum + (netSales > 0 ? (variableFlatTotal / netSales) * 100 : 0);
+  }
+  const contributionMargin = 100 - variableCostPercentage;
+  const totalFixedCosts = fixedTotal + semiVariableTotal;
+  const breakEvenRevenue = contributionMargin > 0 ? totalFixedCosts / (contributionMargin / 100) : 0;
+
+  return {
+    fixedTotal, semiVariableTotal, variableFlatTotal, variablePercentTotal, variableTotal,
+    totalMonthlyCosts: fixedTotal + semiVariableTotal + variableTotal,
+    variableCostPercentage, contributionMargin, breakEvenRevenue,
+  };
+}

--- a/supabase/functions/_shared/operatingCostMath.ts
+++ b/supabase/functions/_shared/operatingCostMath.ts
@@ -1,6 +1,7 @@
 // supabase/functions/_shared/operatingCostMath.ts
 // Spec §13.2. monthly_value is cents and is 0 for percentage rows;
 // percentage rows carry percentage_value instead.
+// percentage_value is a fraction of net sales (0.27 = 27%).
 
 export interface CostRow { cost_type: string; entry_type: string; monthly_value: number; percentage_value: number | null; }
 export interface OperatingCostTotals {
@@ -22,14 +23,14 @@ export function computeOperatingCostTotals(rows: CostRow[], netSales: number): O
   const variableRows = by('variable');
   const variableFlatTotal = flat(variableRows);
   const variablePctSum = pct(variableRows);
-  const variablePercentTotal = (variablePctSum / 100) * netSales;
+  const variablePercentTotal = variablePctSum * netSales;
   const variableTotal = variableFlatTotal + variablePercentTotal;
 
   let variableCostPercentage: number;
   if (variableRows.length === 0) {
     variableCostPercentage = 25; // keep the historical fallback estimate
   } else {
-    variableCostPercentage = variablePctSum + (netSales > 0 ? (variableFlatTotal / netSales) * 100 : 0);
+    variableCostPercentage = variablePctSum * 100 + (netSales > 0 ? (variableFlatTotal / netSales) * 100 : 0);
   }
   const contributionMargin = 100 - variableCostPercentage;
   const totalFixedCosts = fixedTotal + semiVariableTotal;

--- a/supabase/functions/_shared/tools-registry.ts
+++ b/supabase/functions/_shared/tools-registry.ts
@@ -504,7 +504,7 @@ export function getTools(restaurantId: string, userRole: string = 'viewer'): Too
       },
       {
         name: 'get_operating_costs',
-        description: 'Get fixed, semi-variable, and variable operating cost breakdown. Includes break-even analysis showing required revenue to cover all costs.',
+        description: 'Get the CONFIGURED cost budget (not actual period spend). Fixed, semi-variable, and variable items with a break-even analysis against actual net sales for the period. All *_percent fields are percentages.',
         parameters: {
           type: 'object',
           properties: {

--- a/supabase/functions/ai-chat-stream/index.ts
+++ b/supabase/functions/ai-chat-stream/index.ts
@@ -633,10 +633,10 @@ Tool Usage Guidelines:
      * Example: "What's on my balance sheet?" → MUST call with statement_type: 'balance_sheet'
 
 FINANCIAL DATA RULES:
-- get_operating_costs returns the CONFIGURED BUDGET, not actual spend. For actual spend, use get_financial_statement or get_bank_transactions.
-- All tools share one net-sales definition (gross - discounts - refunds). If two results disagree, say that the data sources disagree and stop. Do not invent a reconciliation.
-- Fields that end in _percent are percentages. Never show them with a $ sign.
-- Percentage-based cost items include computed_monthly_amount. Use it. Do not compute your own.
+   - get_operating_costs returns the CONFIGURED BUDGET, not actual spend. For actual spend, use get_financial_statement or get_bank_transactions.
+   - All tools share one net-sales definition (gross - discounts - refunds). If two results disagree, say that the data sources disagree and stop. Do not invent a reconciliation.
+   - Fields that end in _percent are percentages. Never show them with a $ sign.
+   - Percentage-based cost items include computed_monthly_amount. Use it. Do not compute your own.
 
 3. AI Insights (owners only):
    - get_ai_insights: Business advice and recommendations

--- a/supabase/functions/ai-chat-stream/index.ts
+++ b/supabase/functions/ai-chat-stream/index.ts
@@ -632,6 +632,12 @@ Tool Usage Guidelines:
      * statement_type: 'income_statement', 'balance_sheet', 'cash_flow', 'trial_balance'
      * Example: "What's on my balance sheet?" → MUST call with statement_type: 'balance_sheet'
 
+FINANCIAL DATA RULES:
+- get_operating_costs returns the CONFIGURED BUDGET, not actual spend. For actual spend, use get_financial_statement or get_bank_transactions.
+- All tools share one net-sales definition (gross - discounts - refunds). If two results disagree, say that the data sources disagree and stop. Do not invent a reconciliation.
+- Fields that end in _percent are percentages. Never show them with a $ sign.
+- Percentage-based cost items include computed_monthly_amount. Use it. Do not compute your own.
+
 3. AI Insights (owners only):
    - get_ai_insights: Business advice and recommendations
      * focus_area: cost_reduction, revenue_growth, inventory_optimization, menu_engineering, overall_health

--- a/supabase/functions/ai-execute-tool/index.ts
+++ b/supabase/functions/ai-execute-tool/index.ts
@@ -223,6 +223,9 @@ async function executeGetKpis(
     // transaction granularity, not revenue-line-item granularity. This
     // differs from the old client-side count (calculateRevenueBreakdown's
     // filterSplitSales), which counted split children instead of their parent.
+    // A second delta: `.or('item_type.is.null,item_type.eq.sale')` counts
+    // sale transactions only. The old count also included discount and
+    // refund line items, since filterSplitSales does not filter by item_type.
     supabase
       .from('unified_sales')
       .select('*', { count: 'exact', head: true })

--- a/supabase/functions/ai-execute-tool/index.ts
+++ b/supabase/functions/ai-execute-tool/index.ts
@@ -621,15 +621,15 @@ async function calculateRevenueHealth(
   const { start_date, end_date, bank_account_id } = args;
 
   // Deposit summary (get_bank_transaction_summary) replaces the raw
-  // amount>0 fetch. The RPC has no minimum-amount filter, so it counts
-  // every positive transaction as a deposit. The prior code also required
-  // amount > 10 to exclude small transfers/refunds; that threshold has no
-  // RPC equivalent and is dropped here.
+  // amount>0 fetch. p_min_inflow: 10 restores the prior code's amount > 10
+  // floor, which excludes small transfers/refunds from the deposit metrics
+  // (inflow_count, avg_inflow, max_inflow). inflow itself stays unfloored.
   const { data: summaryRows, error } = await supabase.rpc('get_bank_transaction_summary', {
     p_restaurant_id: restaurantId,
     p_start_date: start_date,
     p_end_date: end_date,
     p_bank_account_id: bank_account_id || null,
+    p_min_inflow: 10,
   });
 
   if (error) throw new Error(`get_bank_transaction_summary failed: ${error.message}`);
@@ -3290,7 +3290,7 @@ async function executeBatchCategorizeTransactions(
   const { transaction_ids, category_id, preview = false, confirmed = false } = args;
 
   if (transaction_ids.length > 1000) {
-    return { error: `Too many ids (${transaction_ids.length}). Send at most 1000 per call.` };
+    return { ok: false, error: { code: 'TOO_MANY_IDS', message: `Too many ids (${transaction_ids.length}). Send at most 1000 per call.` } };
   }
 
   // Fetch the category info
@@ -3384,7 +3384,7 @@ async function executeBatchCategorizePosSales(
   const { sale_ids, category_id, preview = false, confirmed = false } = args;
 
   if (sale_ids.length > 1000) {
-    return { error: `Too many ids (${sale_ids.length}). Send at most 1000 per call.` };
+    return { ok: false, error: { code: 'TOO_MANY_IDS', message: `Too many ids (${sale_ids.length}). Send at most 1000 per call.` } };
   }
 
   const { data: category, error: catError } = await supabase

--- a/supabase/functions/ai-execute-tool/index.ts
+++ b/supabase/functions/ai-execute-tool/index.ts
@@ -664,7 +664,7 @@ async function calculateSpending(
   supabase: any,
   results: any
 ): Promise<void> {
-  const { start_date, end_date } = args;
+  const { start_date, end_date, bank_account_id } = args;
 
   // Category breakdown (get_bank_spending_by_category) replaces the raw
   // amount<0 fetch. Note: this RPC has no p_bank_account_id parameter, so a
@@ -690,8 +690,19 @@ async function calculateSpending(
     expense_count: expenseCount,
     avg_transaction: expenseCount > 0 ? totalExpenses / expenseCount : 0,
     // No vendor-level RPC exists; see note above.
-    top_vendors: [],
+    top_vendors: null,
+    top_vendors_available: false,
     by_category: rows.map((r: any) => ({ name: r.category_name, amount: Number(r.spend ?? 0) })),
+    // The category-breakdown RPC has no account filter; tell the caller
+    // explicitly when their bank_account_id was silently ignored.
+    ...(bank_account_id
+      ? {
+          filters_applied: {
+            bank_account_id: false,
+          },
+          filters_note: 'The spending breakdown covers all connected bank accounts. bank_account_id is not applied to this analysis_type.',
+        }
+      : {}),
   };
 }
 
@@ -895,9 +906,9 @@ async function executeGetBankTransactions(
     .limit(limit);
   
   if (bank_account_id) {
-    query = query.eq('bank_account_id', bank_account_id);
+    query = query.eq('connected_bank_id', bank_account_id);
   }
-  
+
   if (category_id) {
     query = query.eq('category_id', category_id);
   }
@@ -942,6 +953,14 @@ async function executeGetBankTransactions(
   // page, same as before.
   const categorized = transactions?.filter((t: any) => t.is_categorized).length || 0;
 
+  // The summary RPC only supports p_bank_account_id/p_statuses. When the
+  // caller also sets category_id/min_amount/max_amount/is_categorized, the
+  // list below is narrowed by those filters but the summary above is not.
+  // Flag that mismatch on the response so a caller does not read the
+  // summary as if it matched the filtered list.
+  const hasUnsummarizedFilters =
+    category_id !== undefined || min_amount !== undefined || max_amount !== undefined || is_categorized !== undefined;
+
   return {
     ok: true,
     data: {
@@ -953,6 +972,12 @@ async function executeGetBankTransactions(
         total_outflows: Number(periodSummary.outflow ?? 0),
         categorized_count: categorized,
         categorization_rate: transactions?.length ? (categorized / transactions.length) * 100 : 0,
+        ...(hasUnsummarizedFilters
+          ? {
+              partial: true,
+              note: 'Summary totals cover the whole period without the list filters.',
+            }
+          : {}),
       },
       transactions: transactions?.map((t: any) => ({
         id: t.id,

--- a/supabase/functions/ai-execute-tool/index.ts
+++ b/supabase/functions/ai-execute-tool/index.ts
@@ -200,7 +200,7 @@ async function executeGetKpis(
   // front of an already-sequential fetch chain in a CPU-limited edge function.
   // ====== FETCH DATA FROM DATABASE ======
 
-  const [hasLaborAccess, salesTotals, foodCostResult] = await Promise.all([
+  const [hasLaborAccess, salesTotals, foodCostResult, salesCountResult] = await Promise.all([
     hasSchedulingOrPayrollCapability(restaurantId, supabase),
     // Net sales for the period (gross - discounts - refunds), from the shared RPC.
     fetchNetSales(supabase, restaurantId, startDateStr, endDateStr),
@@ -212,6 +212,26 @@ async function executeGetKpis(
       .eq('transaction_type', 'usage')
       .gte('created_at', startDateStr)
       .lte('created_at', endDateStr + 'T23:59:59.999Z'),
+    // Server-side count of sale transactions in the period (head:true, so it
+    // is not subject to the 1000-row cap a normal select would hit). This
+    // counts sale transactions, not split-child rows: a split sale's parent
+    // row represents the one transaction, so its children (rows carrying a
+    // parent_sale_id) do not count separately here. That is the opposite
+    // exclusion direction from fetchNetSales/get_monthly_sales_metrics, which
+    // sums the children and drops the pre-split parent so a categorized
+    // transaction's dollar amount is not counted twice — this count works at
+    // transaction granularity, not revenue-line-item granularity. This
+    // differs from the old client-side count (calculateRevenueBreakdown's
+    // filterSplitSales), which counted split children instead of their parent.
+    supabase
+      .from('unified_sales')
+      .select('*', { count: 'exact', head: true })
+      .eq('restaurant_id', restaurantId)
+      .gte('sale_date', startDateStr)
+      .lte('sale_date', endDateStr)
+      .is('adjustment_type', null)
+      .is('parent_sale_id', null)
+      .or('item_type.is.null,item_type.eq.sale'),
   ]);
 
   const { data: foodCostData, error: foodCostError } = foodCostResult;
@@ -219,6 +239,8 @@ async function executeGetKpis(
   if (foodCostError) {
     throw new Error(`Failed to fetch food costs: ${foodCostError.message}`);
   }
+
+  const salesCount = salesCountResult.count ?? 0;
 
   // Fetch labor costs using time_punches + employees (same as Dashboard) —
   // only when the caller can actually see restaurant-wide punches. Skipping
@@ -312,8 +334,6 @@ async function executeGetKpis(
     hasLaborAccess
   );
 
-  // sales_count isn't available from the monthly-aggregate RPC — it needed
-  // the individual sale rows this fetch replaced — so it's dropped here.
   const revenue = {
     gross_revenue: salesTotals.gross,
     discounts: salesTotals.discounts,
@@ -323,6 +343,7 @@ async function executeGetKpis(
     sales_tax: salesTotals.salesTax,
     tips: salesTotals.tips,
     other_liabilities: salesTotals.otherLiabilities,
+    sales_count: salesCount,
   };
 
   return {

--- a/supabase/functions/ai-execute-tool/index.ts
+++ b/supabase/functions/ai-execute-tool/index.ts
@@ -389,32 +389,25 @@ async function executeGetInventoryStatus(
 ): Promise<any> {
   const { include_low_stock = true, category } = args;
 
-  // Total value, item count, and low-stock count come from the restaurant-wide
-  // valuation RPC. The RPC takes no category filter, so these three numbers
-  // are always restaurant-wide even when `category` is set — only the
-  // low-stock item list below honors the category filter, since it needs
-  // per-item fields (name, supplier) the RPC does not return.
-  const { data: valuationRows, error: valuationError } = await supabase.rpc('get_inventory_valuation', {
-    p_restaurant_id: restaurantId,
-  });
-
-  if (valuationError) {
-    throw new Error(`get_inventory_valuation failed: ${valuationError.message}`);
-  }
-
-  const valuation = valuationRows?.[0];
-  const totalItems = Number(valuation?.item_count ?? 0);
-  const totalValue = Number(valuation?.total_value ?? 0);
-  const lowStockCount = Number(valuation?.low_stock_count ?? 0);
-
+  let totalItems: number;
+  let totalValue: number;
+  let lowStockCount: number;
   let lowStockItems: any[] = [];
-  if (include_low_stock) {
-    let query = supabase
+
+  if (category) {
+    // Category path: the valuation RPC takes no category filter, so a
+    // category-scoped call reads the filtered product rows directly and
+    // derives all four fields (total_items, total_value, low_stock_count,
+    // low_stock_items) from that same set. This keeps the counts and the
+    // list consistent. A category-filtered product list is bounded in
+    // practice, so a plain fetch-and-sum is safe here.
+    const { data: products, error } = await supabase
       .from('products')
       .select(`
         id,
         name,
         current_stock,
+        cost_per_unit,
         par_level_min,
         reorder_point,
         product_suppliers (
@@ -424,21 +417,66 @@ async function executeGetInventoryStatus(
           is_preferred
         )
       `)
-      .eq('restaurant_id', restaurantId);
-
-    if (category) {
-      query = query.eq('category', category);
-    }
-
-    const { data: products, error } = await query;
+      .eq('restaurant_id', restaurantId)
+      .eq('category', category);
 
     if (error) {
       throw new Error(`Failed to fetch inventory: ${error.message}`);
     }
 
-    lowStockItems = (products || []).filter((p: any) =>
-      p.current_stock <= (p.par_level_min || 0)
+    const categoryProducts = products || [];
+    totalItems = categoryProducts.length;
+    totalValue = categoryProducts.reduce(
+      (sum: number, p: any) => sum + (Number(p.current_stock) || 0) * (Number(p.cost_per_unit) || 0),
+      0
     );
+    const categoryLowStock = categoryProducts.filter((p: any) =>
+      p.current_stock <= (p.par_level_min ?? 0)
+    );
+    lowStockCount = categoryLowStock.length;
+    lowStockItems = categoryLowStock;
+  } else {
+    // No-category path: the aggregate RPC covers the whole restaurant, so
+    // total_items/total_value/low_stock_count read straight from it.
+    const { data: valuationRows, error: valuationError } = await supabase.rpc('get_inventory_valuation', {
+      p_restaurant_id: restaurantId,
+    });
+
+    if (valuationError) {
+      throw new Error(`get_inventory_valuation failed: ${valuationError.message}`);
+    }
+
+    const valuation = valuationRows?.[0];
+    totalItems = Number(valuation?.item_count ?? 0);
+    totalValue = Number(valuation?.total_value ?? 0);
+    lowStockCount = Number(valuation?.low_stock_count ?? 0);
+
+    if (include_low_stock) {
+      const { data: products, error } = await supabase
+        .from('products')
+        .select(`
+          id,
+          name,
+          current_stock,
+          par_level_min,
+          reorder_point,
+          product_suppliers (
+            supplier:suppliers (
+              name
+            ),
+            is_preferred
+          )
+        `)
+        .eq('restaurant_id', restaurantId);
+
+      if (error) {
+        throw new Error(`Failed to fetch inventory: ${error.message}`);
+      }
+
+      lowStockItems = (products || []).filter((p: any) =>
+        p.current_stock <= (p.par_level_min ?? 0)
+      );
+    }
   }
 
   return {

--- a/supabase/functions/ai-execute-tool/index.ts
+++ b/supabase/functions/ai-execute-tool/index.ts
@@ -13,6 +13,7 @@ import {
 import { logAICall, extractTokenUsage, type AICallMetadata } from "../_shared/braintrust.ts";
 import { EMPLOYEE_LABOR_COLUMNS } from "../_shared/employeeLaborColumns.ts";
 import { fetchNetSales, sumMonthlyFoodCost } from "../_shared/financialAggregates.ts";
+import { computeOperatingCostTotals } from "../_shared/operatingCostMath.ts";
 
 // AI tool execution with OpenRouter multi-model fallback
 const OPENROUTER_API_KEY = Deno.env.get('OPENROUTER_API_KEY') || '';
@@ -2629,6 +2630,12 @@ async function executeGetOperatingCosts(
 
   if (costsError) throw new Error(`Failed to fetch operating costs: ${costsError.message}`);
 
+  // Net sales for the period (gross - discounts - refunds), from the shared RPC.
+  // Percentage-based cost rows need net revenue to turn a percent into a dollar
+  // amount, so this runs unconditionally (not gated on include_break_even).
+  const salesTotals = await fetchNetSales(supabase, restaurantId, startDateStr, endDateStr);
+  const totalRevenue = salesTotals.net;
+
   // Group by type
   const byCostType: Record<string, any[]> = {
     fixed: [],
@@ -2639,45 +2646,40 @@ async function executeGetOperatingCosts(
 
   for (const cost of costs || []) {
     if (byCostType[cost.cost_type]) {
-      byCostType[cost.cost_type].push({
+      const item: any = {
         name: cost.name,
         category: cost.category,
         monthly_value: cost.monthly_value / 100,
         percentage_value: cost.percentage_value,
         entry_type: cost.entry_type,
-      });
+      };
+      if (cost.entry_type === 'percentage') {
+        item.computed_monthly_amount = (cost.percentage_value / 100) * totalRevenue;
+      }
+      byCostType[cost.cost_type].push(item);
     }
   }
 
-  // Calculate totals
-  const fixedTotal = byCostType.fixed.reduce((sum, c) => sum + c.monthly_value, 0);
-  const semiVariableTotal = byCostType.semi_variable.reduce((sum, c) => sum + c.monthly_value, 0);
-  const variableTotal = byCostType.variable.reduce((sum, c) => sum + c.monthly_value, 0);
+  // Calculate totals. computeOperatingCostTotals owns all cents-to-dollars
+  // conversion and folds percentage rows (entry_type='percentage',
+  // monthly_value=0) into the variable total — the old reducer summed only
+  // monthly_value, so percentage items (COGS/marketing/processing) contributed
+  // nothing (the July "$82.00" bug).
+  const costTotals = computeOperatingCostTotals(costs || [], totalRevenue);
 
-  // Fetch revenue for break-even calculation
+  // Break-even analysis
   let breakEvenAnalysis = null;
   if (include_break_even) {
-    // Net sales for the period (gross - discounts - refunds), from the shared RPC.
-    const salesTotals = await fetchNetSales(supabase, restaurantId, startDateStr, endDateStr);
-    const totalRevenue = salesTotals.net;
-    const totalFixedCosts = fixedTotal + semiVariableTotal;
-    const variableCostPercentage = variableTotal > 0 && totalRevenue > 0
-      ? (variableTotal / totalRevenue) * 100
-      : 25; // Default estimate
-
-    const contributionMargin = 100 - variableCostPercentage;
-    const breakEvenRevenue = contributionMargin > 0
-      ? (totalFixedCosts / (contributionMargin / 100))
-      : 0;
+    const totalFixedCosts = costTotals.fixedTotal + costTotals.semiVariableTotal;
 
     breakEvenAnalysis = {
       total_fixed_costs: totalFixedCosts,
-      variable_cost_percentage: variableCostPercentage,
-      contribution_margin_percentage: contributionMargin,
-      break_even_revenue: breakEvenRevenue,
+      variable_cost_percentage: costTotals.variableCostPercentage,
+      contribution_margin_percentage: costTotals.contributionMargin,
+      break_even_revenue: costTotals.breakEvenRevenue,
       current_revenue: totalRevenue,
-      above_break_even: totalRevenue >= breakEvenRevenue,
-      margin_of_safety: totalRevenue > 0 ? ((totalRevenue - breakEvenRevenue) / totalRevenue) * 100 : 0,
+      above_break_even: totalRevenue >= costTotals.breakEvenRevenue,
+      margin_of_safety: totalRevenue > 0 ? ((totalRevenue - costTotals.breakEvenRevenue) / totalRevenue) * 100 : 0,
     };
   }
 
@@ -2688,12 +2690,12 @@ async function executeGetOperatingCosts(
       start_date: startDateStr,
       end_date: endDateStr,
       costs_by_type: {
-        fixed: { items: byCostType.fixed, total: fixedTotal },
-        semi_variable: { items: byCostType.semi_variable, total: semiVariableTotal },
-        variable: { items: byCostType.variable, total: variableTotal },
+        fixed: { items: byCostType.fixed, total: costTotals.fixedTotal },
+        semi_variable: { items: byCostType.semi_variable, total: costTotals.semiVariableTotal },
+        variable: { items: byCostType.variable, total: costTotals.variableTotal },
         custom: { items: byCostType.custom, total: byCostType.custom.reduce((sum, c) => sum + c.monthly_value, 0) },
       },
-      total_monthly_costs: fixedTotal + semiVariableTotal + variableTotal,
+      total_monthly_costs: costTotals.totalMonthlyCosts,
       break_even_analysis: breakEvenAnalysis,
     },
     evidence: [

--- a/supabase/functions/ai-execute-tool/index.ts
+++ b/supabase/functions/ai-execute-tool/index.ts
@@ -2654,7 +2654,7 @@ async function executeGetOperatingCosts(
         entry_type: cost.entry_type,
       };
       if (cost.entry_type === 'percentage') {
-        item.computed_monthly_amount = (cost.percentage_value / 100) * totalRevenue;
+        item.computed_monthly_amount = cost.percentage_value * totalRevenue;
       }
       byCostType[cost.cost_type].push(item);
     }

--- a/supabase/functions/ai-execute-tool/index.ts
+++ b/supabase/functions/ai-execute-tool/index.ts
@@ -12,6 +12,8 @@ import {
 } from "../_shared/inventoryTransactions.ts";
 import { logAICall, extractTokenUsage, type AICallMetadata } from "../_shared/braintrust.ts";
 import { EMPLOYEE_LABOR_COLUMNS } from "../_shared/employeeLaborColumns.ts";
+import { fetchNetSales } from "../_shared/financialAggregates.ts";
+// sumMonthlyFoodCost stays unused here until Task 11 rewires the food-cost sites.
 
 // AI tool execution with OpenRouter multi-model fallback
 const OPENROUTER_API_KEY = Deno.env.get('OPENROUTER_API_KEY') || '';
@@ -180,7 +182,7 @@ async function executeGetKpis(
   const { period = 'month', start_date, end_date } = args;
 
   // Import shared calculation module
-  const { calculatePeriodMetrics, redactLaborFields } = await import('../_shared/periodMetrics.ts');
+  const { calculateCostBreakdown, calculateProfitability, calculateBenchmarks, redactLaborFields } = await import('../_shared/periodMetrics.ts');
   const { hasSchedulingOrPayrollCapability } = await import('../_shared/tools-registry.ts');
 
   const { startDate, endDate, startDateStr, endDateStr } = calculateDateRange(period, start_date, end_date);
@@ -198,24 +200,10 @@ async function executeGetKpis(
   // front of an already-sequential fetch chain in a CPU-limited edge function.
   // ====== FETCH DATA FROM DATABASE ======
 
-  const [hasLaborAccess, salesResult, adjustmentsResult, foodCostResult] = await Promise.all([
+  const [hasLaborAccess, salesTotals, foodCostResult] = await Promise.all([
     hasSchedulingOrPayrollCapability(restaurantId, supabase),
-    // Fetch sales (excluding adjustments)
-    supabase
-      .from('unified_sales')
-      .select('id, total_price, item_type, parent_sale_id, is_categorized, chart_account:chart_of_accounts!category_id(account_type, account_subtype)')
-      .eq('restaurant_id', restaurantId)
-      .gte('sale_date', startDateStr)
-      .lte('sale_date', endDateStr)
-      .is('adjustment_type', null),
-    // Fetch adjustments separately
-    supabase
-      .from('unified_sales')
-      .select('adjustment_type, total_price')
-      .eq('restaurant_id', restaurantId)
-      .gte('sale_date', startDateStr)
-      .lte('sale_date', endDateStr)
-      .not('adjustment_type', 'is', null),
+    // Net sales for the period (gross - discounts - refunds), from the shared RPC.
+    fetchNetSales(supabase, restaurantId, startDateStr, endDateStr),
     // Fetch food costs (COGS)
     supabase
       .from('inventory_transactions')
@@ -225,16 +213,6 @@ async function executeGetKpis(
       .gte('created_at', startDateStr)
       .lte('created_at', endDateStr + 'T23:59:59.999Z'),
   ]);
-
-  const { data: sales, error: salesError } = salesResult;
-  if (salesError) {
-    throw new Error(`Failed to fetch sales: ${salesError.message}`);
-  }
-
-  const { data: adjustments, error: adjustmentsError } = adjustmentsResult;
-  if (adjustmentsError) {
-    throw new Error(`Failed to fetch adjustments: ${adjustmentsError.message}`);
-  }
 
   const { data: foodCostData, error: foodCostError } = foodCostResult;
 
@@ -315,20 +293,37 @@ async function executeGetKpis(
     .lte('transaction_date', endDateStr);
 
   // ====== CALCULATE METRICS USING SHARED MODULE ======
-  
-  const metrics = calculatePeriodMetrics(
-    sales || [],
-    adjustments || [],
-    foodCostData || [],
-    laborCostData || []
-  );
 
-  // laborCostData is [] when !hasLaborAccess, so metrics.costs/profitability/
+  // Revenue now comes from the shared net-sales RPC (gross - discounts -
+  // refunds), so cost/profitability/benchmarks are computed directly against
+  // salesTotals.net instead of going through calculatePeriodMetrics (which
+  // would need the raw sale rows this fetch replaced).
+  const rawCosts = calculateCostBreakdown(foodCostData || [], laborCostData || [], salesTotals.net);
+  const rawProfitability = calculateProfitability(salesTotals.net, rawCosts.prime_cost);
+  const rawBenchmarks = calculateBenchmarks(rawCosts);
+
+  // laborCostData is [] when !hasLaborAccess, so costs/profitability/
   // benchmarks were computed with labor_cost = 0. redactLaborFields strips
   // everything downstream of that (prime_cost, profit_margin, the
   // labor/prime benchmark statuses) rather than let it read as a complete
   // restaurant-wide figure — food-cost-only fields are unaffected and stay in.
-  const { costs, profitability, benchmarks, laborOmittedReason } = redactLaborFields(metrics, hasLaborAccess);
+  const { costs, profitability, benchmarks, laborOmittedReason } = redactLaborFields(
+    { costs: rawCosts, profitability: rawProfitability, benchmarks: rawBenchmarks },
+    hasLaborAccess
+  );
+
+  // sales_count isn't available from the monthly-aggregate RPC — it needed
+  // the individual sale rows this fetch replaced — so it's dropped here.
+  const revenue = {
+    gross_revenue: salesTotals.gross,
+    discounts: salesTotals.discounts,
+    refunds: salesTotals.refunds,
+    net_revenue: salesTotals.net,
+    total_collected_at_pos: salesTotals.gross + salesTotals.salesTax + salesTotals.tips + salesTotals.otherLiabilities,
+    sales_tax: salesTotals.salesTax,
+    tips: salesTotals.tips,
+    other_liabilities: salesTotals.otherLiabilities,
+  };
 
   return {
     ok: true,
@@ -338,10 +333,10 @@ async function executeGetKpis(
       end_date: endDateStr,
 
       // All metrics from shared calculation module
-      revenue: metrics.revenue,
+      revenue,
       costs,
       profitability,
-      liabilities: metrics.liabilities,
+      liabilities: { sales_tax: salesTotals.salesTax, tips: salesTotals.tips, other_liabilities: salesTotals.otherLiabilities },
       benchmarks,
       labor_omitted: laborOmittedReason ? { reason: laborOmittedReason } : undefined,
 
@@ -929,16 +924,10 @@ async function executeGetFinancialStatement(
   try {
     switch (statement_type) {
       case 'income_statement': {
-        // Fetch revenue from unified_sales
-        const { data: sales } = await supabase
-          .from('unified_sales')
-          .select('total_price')
-          .eq('restaurant_id', restaurantId)
-          .gte('sale_date', start_date)
-          .lte('sale_date', end_date);
-        
-        const revenue = sales?.reduce((sum: number, s: any) => sum + (s.total_price || 0), 0) || 0;
-        
+        // Net sales for the period (gross - discounts - refunds), from the shared RPC.
+        const salesTotals = await fetchNetSales(supabase, restaurantId, start_date, end_date);
+        const revenue = salesTotals.net;
+
         // Fetch COGS from inventory transactions
         const { data: cogs } = await supabase
           .from('inventory_transactions')
@@ -990,7 +979,7 @@ async function executeGetFinancialStatement(
             net_margin: revenue > 0 ? (netIncome / revenue) * 100 : 0,
           },
           evidence: [
-            { table: 'unified_sales', summary: `Revenue data from ${start_date} to ${end_date} (${sales?.length || 0} sales)` },
+            { table: 'unified_sales', summary: `Revenue data from ${start_date} to ${end_date}` },
             { table: 'inventory_transactions', summary: `COGS from usage transactions ${start_date} to ${end_date}` },
             { table: 'journal_entry_lines', summary: `Operating expenses from journal entries ${start_date} to ${end_date}` },
           ],
@@ -1232,21 +1221,29 @@ async function executeGetSalesSummary(
     }
   }
 
-  // Fetch current period sales (excluding adjustments - only actual revenue)
-  const { data: currentSales, error: currentError } = await supabase
-    .from('unified_sales')
-    .select('total_price, sale_date, item_name')
-    .eq('restaurant_id', restaurantId)
-    .gte('sale_date', startDateStr)
-    .lte('sale_date', endDateStr)
-    .is('adjustment_type', null)
-    .is('parent_sale_id', null);
+  // Fetch current period sales (excluding adjustments - only actual revenue).
+  // Raw rows are still needed for the item breakdown/count below (Task 11
+  // moves that to get_top_sold_items); the period total comes from the
+  // shared net-sales RPC so it uses the same gross - discounts - refunds
+  // definition as every other financial tool.
+  const [salesTotals, currentSalesResult] = await Promise.all([
+    fetchNetSales(supabase, restaurantId, startDateStr, endDateStr),
+    supabase
+      .from('unified_sales')
+      .select('total_price, sale_date, item_name')
+      .eq('restaurant_id', restaurantId)
+      .gte('sale_date', startDateStr)
+      .lte('sale_date', endDateStr)
+      .is('adjustment_type', null)
+      .is('parent_sale_id', null),
+  ]);
 
+  const { data: currentSales, error: currentError } = currentSalesResult;
   if (currentError) {
     throw new Error(`Failed to fetch sales: ${currentError.message}`);
   }
 
-  const currentTotal = currentSales?.reduce((sum: number, sale: any) => sum + (sale.total_price || 0), 0) || 0;
+  const currentTotal = salesTotals.net;
   const currentCount = currentSales?.length || 0;
 
   // Get items breakdown if requested
@@ -1279,17 +1276,12 @@ async function executeGetSalesSummary(
     const prevStartDateStr = prevStartDate.toISOString().split('T')[0];
     const prevEndDateStr = prevEndDate.toISOString().split('T')[0];
 
-    const { data: prevSales, error: prevError } = await supabase
-      .from('unified_sales')
-      .select('total_price')
-      .eq('restaurant_id', restaurantId)
-      .gte('sale_date', prevStartDateStr)
-      .lte('sale_date', prevEndDateStr)
-      .is('adjustment_type', null)
-      .is('parent_sale_id', null);
-
-    if (!prevError) {
-      const prevTotal = prevSales?.reduce((sum: number, sale: any) => sum + (sale.total_price || 0), 0) || 0;
+    // fetchNetSales throws on RPC failure — caught here (rather than left to
+    // propagate) to preserve the original behavior of silently omitting the
+    // comparison instead of failing the whole tool call.
+    try {
+      const prevSalesTotals = await fetchNetSales(supabase, restaurantId, prevStartDateStr, prevEndDateStr);
+      const prevTotal = prevSalesTotals.net;
       const change = prevTotal > 0 ? ((currentTotal - prevTotal) / prevTotal) * 100 : 0;
 
       comparison = {
@@ -1297,6 +1289,8 @@ async function executeGetSalesSummary(
         change_percent: Math.round(change * 10) / 10,
         change_amount: currentTotal - prevTotal,
       };
+    } catch {
+      // Leave comparison as null.
     }
   }
 
@@ -1668,15 +1662,9 @@ async function executeGenerateReport(
   try {
     switch (type) {
       case 'monthly_pnl': {
-        // Get revenue from unified_sales
-        const { data: sales } = await supabase
-          .from('unified_sales')
-          .select('total_price, sale_date')
-          .eq('restaurant_id', restaurantId)
-          .gte('sale_date', start_date)
-          .lte('sale_date', end_date);
-
-        const totalRevenue = sales?.reduce((sum: number, s: any) => sum + (s.total_price || 0), 0) || 0;
+        // Net sales for the period (gross - discounts - refunds), from the shared RPC.
+        const salesTotals = await fetchNetSales(supabase, restaurantId, start_date, end_date);
+        const totalRevenue = salesTotals.net;
 
         // Get COGS from inventory transactions
         const { data: inventory } = await supabase
@@ -2609,37 +2597,28 @@ async function executeGetOperatingCosts(
   // Fetch revenue for break-even calculation
   let breakEvenAnalysis = null;
   if (include_break_even) {
-    const { data: sales, error: salesError } = await supabase
-      .from('unified_sales')
-      .select('total_price')
-      .eq('restaurant_id', restaurantId)
-      .gte('sale_date', startDateStr)
-      .lte('sale_date', endDateStr)
-      .is('adjustment_type', null)
-      .is('parent_sale_id', null);
+    // Net sales for the period (gross - discounts - refunds), from the shared RPC.
+    const salesTotals = await fetchNetSales(supabase, restaurantId, startDateStr, endDateStr);
+    const totalRevenue = salesTotals.net;
+    const totalFixedCosts = fixedTotal + semiVariableTotal;
+    const variableCostPercentage = variableTotal > 0 && totalRevenue > 0
+      ? (variableTotal / totalRevenue) * 100
+      : 25; // Default estimate
 
-    if (!salesError && sales) {
-      const totalRevenue = sales.reduce((sum: number, s: any) => sum + (s.total_price || 0), 0);
-      const totalFixedCosts = fixedTotal + semiVariableTotal;
-      const variableCostPercentage = variableTotal > 0 && totalRevenue > 0
-        ? (variableTotal / totalRevenue) * 100
-        : 25; // Default estimate
+    const contributionMargin = 100 - variableCostPercentage;
+    const breakEvenRevenue = contributionMargin > 0
+      ? (totalFixedCosts / (contributionMargin / 100))
+      : 0;
 
-      const contributionMargin = 100 - variableCostPercentage;
-      const breakEvenRevenue = contributionMargin > 0
-        ? (totalFixedCosts / (contributionMargin / 100))
-        : 0;
-
-      breakEvenAnalysis = {
-        total_fixed_costs: totalFixedCosts,
-        variable_cost_percentage: variableCostPercentage,
-        contribution_margin_percentage: contributionMargin,
-        break_even_revenue: breakEvenRevenue,
-        current_revenue: totalRevenue,
-        above_break_even: totalRevenue >= breakEvenRevenue,
-        margin_of_safety: totalRevenue > 0 ? ((totalRevenue - breakEvenRevenue) / totalRevenue) * 100 : 0,
-      };
-    }
+    breakEvenAnalysis = {
+      total_fixed_costs: totalFixedCosts,
+      variable_cost_percentage: variableCostPercentage,
+      contribution_margin_percentage: contributionMargin,
+      break_even_revenue: breakEvenRevenue,
+      current_revenue: totalRevenue,
+      above_break_even: totalRevenue >= breakEvenRevenue,
+      margin_of_safety: totalRevenue > 0 ? ((totalRevenue - breakEvenRevenue) / totalRevenue) * 100 : 0,
+    };
   }
 
   return {
@@ -2716,13 +2695,15 @@ async function executeGetMonthlyTrends(
   if (salesMetrics?.length) {
     salesMetrics.forEach((row: any) => {
       const foodCost = foodCostByMonth[row.period] || 0;
-      const netRevenue = Number(row.gross_revenue) - Number(row.discounts || 0);
+      // Net sales = gross_revenue - discounts - refunds (spec §5.1).
+      const netRevenue = Number(row.gross_revenue) - Number(row.discounts || 0) - Number(row.refunds || 0);
 
       const monthData: any = {
         period: row.period,
         gross_revenue: Number(row.gross_revenue),
         net_revenue: netRevenue,
         discounts: Number(row.discounts || 0),
+        refunds: Number(row.refunds || 0),
         sales_tax: Number(row.sales_tax || 0),
         tips: Number(row.tips || 0),
         food_cost: foodCost,

--- a/supabase/functions/ai-execute-tool/index.ts
+++ b/supabase/functions/ai-execute-tool/index.ts
@@ -567,50 +567,44 @@ async function calculateCashFlow(
   results: any
 ): Promise<void> {
   const { start_date, end_date, bank_account_id } = args;
-  
-  // Fetch bank transactions
-  let query = supabase
-    .from('bank_transactions')
-    .select('amount, transaction_date, category_id')
-    .eq('restaurant_id', restaurantId)
-    .gte('transaction_date', start_date)
-    .lte('transaction_date', end_date);
-  
-  if (bank_account_id) {
-    query = query.eq('bank_account_id', bank_account_id);
-  }
-  
-  const { data: transactions, error } = await query;
-  
-  if (error) throw new Error(`Failed to fetch transactions: ${error.message}`);
-  
-  const inflows = transactions?.filter((t: any) => t.amount > 0).reduce((sum: number, t: any) => sum + t.amount, 0) || 0;
-  const outflows = Math.abs(transactions?.filter((t: any) => t.amount < 0).reduce((sum: number, t: any) => sum + t.amount, 0) || 0);
-  const netCashFlow = inflows - outflows;
-  
-  // Calculate daily average
-  const days = Math.ceil((new Date(end_date).getTime() - new Date(start_date).getTime()) / (1000 * 60 * 60 * 24));
-  const avgDailyCashFlow = days > 0 ? netCashFlow / days : 0;
-  
-  // Calculate volatility (standard deviation)
-  const dailyFlows: Record<string, number> = {};
-  transactions?.forEach((t: any) => {
-    const date = t.transaction_date;
-    dailyFlows[date] = (dailyFlows[date] || 0) + t.amount;
+
+  // Daily inflow/outflow/net series (get_bank_transactions_daily) replaces
+  // the raw per-transaction fetch. p_bank_account_id filters
+  // connected_bank_id, which fixes the prior filter on a bank_account_id
+  // column that bank_transactions does not have.
+  const { data: dailyRows, error } = await supabase.rpc('get_bank_transactions_daily', {
+    p_restaurant_id: restaurantId,
+    p_start_date: start_date,
+    p_end_date: end_date,
+    p_bank_account_id: bank_account_id || null,
   });
-  
-  const flowValues = Object.values(dailyFlows);
+
+  if (error) throw new Error(`get_bank_transactions_daily failed: ${error.message}`);
+
+  const days = dailyRows || [];
+  const inflows = days.reduce((sum: number, d: any) => sum + Number(d.inflow ?? 0), 0);
+  const outflows = days.reduce((sum: number, d: any) => sum + Number(d.outflow ?? 0), 0);
+  const netCashFlow = inflows - outflows;
+
+  // Calculate daily average over the full requested period
+  const periodDays = Math.ceil((new Date(end_date).getTime() - new Date(start_date).getTime()) / (1000 * 60 * 60 * 24));
+  const avgDailyCashFlow = periodDays > 0 ? netCashFlow / periodDays : 0;
+
+  // Calculate volatility (standard deviation) over each day's net flow
+  const flowValues = days.map((d: any) => Number(d.net ?? 0));
   const mean = flowValues.reduce((sum: number, val: number) => sum + val, 0) / (flowValues.length || 1);
   const variance = flowValues.reduce((sum: number, val: number) => sum + Math.pow(val - mean, 2), 0) / (flowValues.length || 1);
   const volatility = Math.sqrt(variance);
-  
+
   results.cash_flow = {
     inflows_7d: inflows,
     outflows_7d: outflows,
     net_cash_flow_7d: netCashFlow,
     avg_daily_cash_flow: avgDailyCashFlow,
     volatility: volatility,
-    transaction_count: transactions?.length || 0,
+    // Days with at least one transaction. The daily RPC emits one row per
+    // active day, not per transaction, so this counts active days.
+    transaction_count: days.length,
   };
 }
 
@@ -624,41 +618,35 @@ async function calculateRevenueHealth(
   results: any
 ): Promise<void> {
   const { start_date, end_date, bank_account_id } = args;
-  
-  // Fetch bank transactions that look like revenue deposits
-  let query = supabase
-    .from('bank_transactions')
-    .select('amount, transaction_date, description')
-    .eq('restaurant_id', restaurantId)
-    .gte('transaction_date', start_date)
-    .lte('transaction_date', end_date)
-    .gt('amount', 0);
-  
-  if (bank_account_id) {
-    query = query.eq('bank_account_id', bank_account_id);
-  }
-  
-  const { data: deposits, error } = await query;
-  
-  if (error) throw new Error(`Failed to fetch deposits: ${error.message}`);
-  
-  // Filter for likely revenue deposits (excluding small transfers/refunds)
-  const revenueDeposits = deposits?.filter((d: any) => d.amount > 10) || [];
-  
-  const totalRevenue = revenueDeposits.reduce((sum: number, d: any) => sum + d.amount, 0);
-  const avgDeposit = revenueDeposits.length > 0 ? totalRevenue / revenueDeposits.length : 0;
-  const largestDeposit = revenueDeposits.reduce((max: number, d: any) => Math.max(max, d.amount), 0);
-  
-  // Calculate deposit frequency
-  const dates = revenueDeposits.map((d: any) => new Date(d.transaction_date).getTime()).sort((a: number, b: number) => a - b);
-  let totalGap = 0;
-  for (let i = 1; i < dates.length; i++) {
-    totalGap += (dates[i] - dates[i-1]) / (1000 * 60 * 60 * 24); // Convert to days
-  }
-  const avgDaysBetweenDeposits = dates.length > 1 ? totalGap / (dates.length - 1) : 0;
-  
+
+  // Deposit summary (get_bank_transaction_summary) replaces the raw
+  // amount>0 fetch. The RPC has no minimum-amount filter, so it counts
+  // every positive transaction as a deposit. The prior code also required
+  // amount > 10 to exclude small transfers/refunds; that threshold has no
+  // RPC equivalent and is dropped here.
+  const { data: summaryRows, error } = await supabase.rpc('get_bank_transaction_summary', {
+    p_restaurant_id: restaurantId,
+    p_start_date: start_date,
+    p_end_date: end_date,
+    p_bank_account_id: bank_account_id || null,
+  });
+
+  if (error) throw new Error(`get_bank_transaction_summary failed: ${error.message}`);
+
+  const summary = summaryRows?.[0] ?? {};
+  const depositCount = Number(summary.inflow_count ?? 0);
+  const totalRevenue = Number(summary.inflow ?? 0);
+  const avgDeposit = Number(summary.avg_inflow ?? 0);
+  const largestDeposit = Number(summary.max_inflow ?? 0);
+
+  // Days between deposits: the summary has no per-transaction dates, so this
+  // approximates the average gap from the period length and deposit count
+  // instead of walking individual transaction dates.
+  const periodDays = Math.ceil((new Date(end_date).getTime() - new Date(start_date).getTime()) / (1000 * 60 * 60 * 24)) + 1;
+  const avgDaysBetweenDeposits = depositCount > 1 ? periodDays / (depositCount - 1) : 0;
+
   results.revenue_health = {
-    deposit_count: revenueDeposits.length,
+    deposit_count: depositCount,
     avg_deposit_size: avgDeposit,
     largest_deposit: largestDeposit,
     total_revenue: totalRevenue,
@@ -676,58 +664,34 @@ async function calculateSpending(
   supabase: any,
   results: any
 ): Promise<void> {
-  const { start_date, end_date, bank_account_id } = args;
-  
-  // Fetch expense transactions
-  let query = supabase
-    .from('bank_transactions')
-    .select(`
-      amount, 
-      transaction_date, 
-      description,
-      merchant_name,
-      category:chart_of_accounts!category_id(id, account_name, account_code)
-    `)
-    .eq('restaurant_id', restaurantId)
-    .gte('transaction_date', start_date)
-    .lte('transaction_date', end_date)
-    .lt('amount', 0);
-  
-  if (bank_account_id) {
-    query = query.eq('bank_account_id', bank_account_id);
-  }
-  
-  const { data: expenses, error } = await query;
-  
-  if (error) throw new Error(`Failed to fetch expenses: ${error.message}`);
-  
-  const totalExpenses = Math.abs(expenses?.reduce((sum: number, e: any) => sum + e.amount, 0) || 0);
-  
-  // Group by merchant/vendor
-  const byVendor: Record<string, number> = {};
-  expenses?.forEach((e: any) => {
-    const vendor = e.merchant_name || e.description || 'Unknown';
-    byVendor[vendor] = (byVendor[vendor] || 0) + Math.abs(e.amount);
+  const { start_date, end_date } = args;
+
+  // Category breakdown (get_bank_spending_by_category) replaces the raw
+  // amount<0 fetch. Note: this RPC has no p_bank_account_id parameter, so a
+  // bank_account_id filter on this analysis_type is not applied (a known
+  // gap in the Task 8 RPC surface, out of scope to add here). Per-vendor
+  // grouping also has no RPC (only category-level breakdown exists), so
+  // top_vendors is dropped rather than reintroducing an unbounded
+  // per-transaction fetch to compute it.
+  const { data: categoryRows, error } = await supabase.rpc('get_bank_spending_by_category', {
+    p_restaurant_id: restaurantId,
+    p_start_date: start_date,
+    p_end_date: end_date,
   });
-  
-  const topVendors = Object.entries(byVendor)
-    .sort(([, a], [, b]) => b - a)
-    .slice(0, 10)
-    .map(([name, amount]) => ({ name, amount }));
-  
-  // Group by category
-  const byCategory: Record<string, number> = {};
-  expenses?.forEach((e: any) => {
-    const category = e.category?.account_name || 'Uncategorized';
-    byCategory[category] = (byCategory[category] || 0) + Math.abs(e.amount);
-  });
-  
+
+  if (error) throw new Error(`get_bank_spending_by_category failed: ${error.message}`);
+
+  const rows = categoryRows || [];
+  const totalExpenses = rows.reduce((sum: number, r: any) => sum + Number(r.spend ?? 0), 0);
+  const expenseCount = rows.reduce((sum: number, r: any) => sum + Number(r.tx_count ?? 0), 0);
+
   results.spending = {
     total_expenses: totalExpenses,
-    expense_count: expenses?.length || 0,
-    avg_transaction: expenses?.length ? totalExpenses / expenses.length : 0,
-    top_vendors: topVendors,
-    by_category: Object.entries(byCategory).map(([name, amount]) => ({ name, amount })),
+    expense_count: expenseCount,
+    avg_transaction: expenseCount > 0 ? totalExpenses / expenseCount : 0,
+    // No vendor-level RPC exists; see note above.
+    top_vendors: [],
+    by_category: rows.map((r: any) => ({ name: r.category_name, amount: Number(r.spend ?? 0) })),
   };
 }
 
@@ -763,21 +727,22 @@ async function calculateLiquidity(
     return sum + balance;
   }, 0) || 0;
   
-  // Calculate burn rate from recent outflows
-  let outflowQuery = supabase
-    .from('bank_transactions')
-    .select('amount, transaction_date')
-    .eq('restaurant_id', restaurantId)
-    .lt('amount', 0)
-    .gte('transaction_date', new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0]);
-  
-  if (bank_account_id) {
-    outflowQuery = outflowQuery.eq('bank_account_id', bank_account_id);
-  }
-  
-  const { data: recentOutflows } = await outflowQuery;
-  
-  const totalOutflows = Math.abs(recentOutflows?.reduce((sum: number, t: any) => sum + t.amount, 0) || 0);
+  // Calculate burn rate from recent outflows (get_bank_transaction_summary),
+  // a 30-day trailing window. p_bank_account_id filters connected_bank_id,
+  // which fixes the prior filter on a bank_account_id column that
+  // bank_transactions does not have.
+  const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
+  const todayStr = new Date().toISOString().split('T')[0];
+  const { data: outflowSummaryRows, error: outflowSummaryError } = await supabase.rpc('get_bank_transaction_summary', {
+    p_restaurant_id: restaurantId,
+    p_start_date: thirtyDaysAgo,
+    p_end_date: todayStr,
+    p_bank_account_id: bank_account_id || null,
+  });
+
+  if (outflowSummaryError) throw new Error(`get_bank_transaction_summary failed: ${outflowSummaryError.message}`);
+
+  const totalOutflows = Number(outflowSummaryRows?.[0]?.outflow ?? 0);
   const avgDailyOutflow = totalOutflows / 30;
   const daysOfCash = avgDailyOutflow > 0 ? totalCash / avgDailyOutflow : 999;
   
@@ -800,36 +765,40 @@ async function calculatePredictions(
   results: any
 ): Promise<void> {
   const { bank_account_id } = args;
-  
-  // Simple predictions based on historical patterns
-  let query = supabase
-    .from('bank_transactions')
-    .select('amount, transaction_date, description, merchant_name')
-    .eq('restaurant_id', restaurantId)
-    .gte('transaction_date', new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString().split('T')[0]);
-  
-  if (bank_account_id) {
-    query = query.eq('bank_account_id', bank_account_id);
-  }
-  
-  const { data: historical } = await query;
-  
-  // Find recurring patterns
-  const depositPattern = historical?.filter((t: any) => t.amount > 100);
-  const avgDepositSize = depositPattern?.reduce((sum: number, t: any) => sum + t.amount, 0) / (depositPattern?.length || 1);
-  
-  // Calculate days since last deposit
-  const lastDepositDate = depositPattern?.reduce((latest: string, t: any) => {
-    return t.transaction_date > latest ? t.transaction_date : latest;
+
+  const sixtyDaysAgo = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
+  const todayStr = new Date().toISOString().split('T')[0];
+
+  // Daily inflow series (get_bank_transactions_daily) replaces the raw
+  // per-transaction fetch. "Recurring deposit" detection now looks at days
+  // whose total inflow exceeds $100 rather than individual transactions
+  // above that amount, since the daily RPC has no per-transaction
+  // granularity. The forecast math below stays in TypeScript over these
+  // bounded daily rows.
+  const { data: dailyRows, error } = await supabase.rpc('get_bank_transactions_daily', {
+    p_restaurant_id: restaurantId,
+    p_start_date: sixtyDaysAgo,
+    p_end_date: todayStr,
+    p_bank_account_id: bank_account_id || null,
+  });
+
+  if (error) throw new Error(`get_bank_transactions_daily failed: ${error.message}`);
+
+  const depositDays = (dailyRows || []).filter((d: any) => Number(d.inflow ?? 0) > 100);
+  const avgDepositSize = depositDays.reduce((sum: number, d: any) => sum + Number(d.inflow ?? 0), 0) / (depositDays.length || 1);
+
+  // Calculate days since last deposit day
+  const lastDepositDate = depositDays.reduce((latest: string, d: any) => {
+    return d.day > latest ? d.day : latest;
   }, '1970-01-01');
-  
+
   const daysSinceDeposit = Math.floor((Date.now() - new Date(lastDepositDate).getTime()) / (1000 * 60 * 60 * 24));
-  
+
   results.predictions = {
     next_deposit_prediction: {
       expected_days_from_now: Math.max(0, 7 - daysSinceDeposit), // Assume weekly deposits
       expected_amount: avgDepositSize,
-      confidence: depositPattern?.length > 4 ? 'high' : depositPattern?.length > 2 ? 'medium' : 'low',
+      confidence: depositDays.length > 4 ? 'high' : depositDays.length > 2 ? 'medium' : 'low',
     },
   };
 }
@@ -946,26 +915,42 @@ async function executeGetBankTransactions(
   }
   
   const { data: transactions, error } = await query;
-  
+
   if (error) {
     throw new Error(`Failed to fetch transactions: ${error.message}`);
   }
-  
-  // Calculate summary stats
-  const total = transactions?.reduce((sum: number, t: any) => sum + t.amount, 0) || 0;
-  const inflows = transactions?.filter((t: any) => t.amount > 0).reduce((sum: number, t: any) => sum + t.amount, 0) || 0;
-  const outflows = Math.abs(transactions?.filter((t: any) => t.amount < 0).reduce((sum: number, t: any) => sum + t.amount, 0) || 0);
+
+  // Period summary totals (get_bank_transaction_summary) cover the whole
+  // date range for this bank account, not just the current page returned
+  // above. The RPC has no category_id/min_amount/max_amount/is_categorized
+  // parameters, so those filters (when set) narrow the transaction list
+  // below but do not narrow this summary.
+  const { data: summaryRows, error: summaryError } = await supabase.rpc('get_bank_transaction_summary', {
+    p_restaurant_id: restaurantId,
+    p_start_date: start_date,
+    p_end_date: end_date,
+    p_bank_account_id: bank_account_id || null,
+  });
+
+  if (summaryError) {
+    throw new Error(`get_bank_transaction_summary failed: ${summaryError.message}`);
+  }
+
+  const periodSummary = summaryRows?.[0] ?? {};
+  // categorized_count/categorization_rate have no RPC (the summary RPC has
+  // no categorization awareness), so they stay computed from the fetched
+  // page, same as before.
   const categorized = transactions?.filter((t: any) => t.is_categorized).length || 0;
-  
+
   return {
     ok: true,
     data: {
       period: { start_date, end_date },
       summary: {
-        total_transactions: transactions?.length || 0,
-        total_net: total,
-        total_inflows: inflows,
-        total_outflows: outflows,
+        total_transactions: Number(periodSummary.tx_count ?? 0),
+        total_net: Number(periodSummary.net ?? 0),
+        total_inflows: Number(periodSummary.inflow ?? 0),
+        total_outflows: Number(periodSummary.outflow ?? 0),
         categorized_count: categorized,
         categorization_rate: transactions?.length ? (categorized / transactions.length) * 100 : 0,
       },
@@ -1110,17 +1095,18 @@ async function executeGetFinancialStatement(
       }
 
       case 'cash_flow': {
-        const { data: transactions } = await supabase
-          .from('bank_transactions')
-          .select('amount, transaction_date')
-          .eq('restaurant_id', restaurantId)
-          .gte('transaction_date', start_date)
-          .lte('transaction_date', end_date)
-          .order('transaction_date', { ascending: true });
-        
-        const inflows = transactions?.filter((t: any) => t.amount > 0).reduce((sum: number, t: any) => sum + t.amount, 0) || 0;
-        const outflows = Math.abs(transactions?.filter((t: any) => t.amount < 0).reduce((sum: number, t: any) => sum + t.amount, 0) || 0);
-        
+        // Scalar summary (get_bank_transaction_summary) replaces the raw
+        // per-transaction fetch.
+        const { data: summaryRows, error: summaryError } = await supabase.rpc('get_bank_transaction_summary', {
+          p_restaurant_id: restaurantId,
+          p_start_date: start_date,
+          p_end_date: end_date,
+        });
+        if (summaryError) throw new Error(`get_bank_transaction_summary failed: ${summaryError.message}`);
+        const cfSummary = summaryRows?.[0] ?? {};
+        const inflows = Number(cfSummary.inflow ?? 0);
+        const outflows = Number(cfSummary.outflow ?? 0);
+
         return {
           ok: true,
           data: {
@@ -1140,7 +1126,7 @@ async function executeGetFinancialStatement(
             net_change_in_cash: inflows - outflows,
           },
           evidence: [
-            { table: 'bank_transactions', summary: `Cash flow from ${transactions?.length || 0} transactions ${start_date} to ${end_date}` },
+            { table: 'bank_transactions', summary: `Cash flow from ${Number(cfSummary.tx_count ?? 0)} transactions ${start_date} to ${end_date}` },
           ],
         };
       }
@@ -1732,16 +1718,15 @@ async function executeGenerateReport(
         if (usageError) throw new Error(`get_inventory_usage_by_month failed: ${usageError.message}`);
         const totalCOGS = sumMonthlyFoodCost(usageRows);
 
-        // Get expenses from bank transactions
-        const { data: expenses } = await supabase
-          .from('bank_transactions')
-          .select('amount, description')
-          .eq('restaurant_id', restaurantId)
-          .gte('transaction_date', start_date)
-          .lte('transaction_date', end_date)
-          .lt('amount', 0);
-
-        const totalExpenses = Math.abs(expenses?.reduce((sum: number, e: any) => sum + (e.amount || 0), 0) || 0);
+        // Get expenses from bank transactions (get_bank_transaction_summary).
+        // outflow is already positive, so no Math.abs() is needed here.
+        const { data: expenseSummaryRows, error: expenseSummaryError } = await supabase.rpc('get_bank_transaction_summary', {
+          p_restaurant_id: restaurantId,
+          p_start_date: start_date,
+          p_end_date: end_date,
+        });
+        if (expenseSummaryError) throw new Error(`get_bank_transaction_summary failed: ${expenseSummaryError.message}`);
+        const totalExpenses = Number(expenseSummaryRows?.[0]?.outflow ?? 0);
 
         reportData = {
           period: { start_date, end_date },
@@ -1810,28 +1795,34 @@ async function executeGenerateReport(
       }
 
       case 'cash_flow': {
-        const { data: transactions } = await supabase
-          .from('bank_transactions')
-          .select('amount, description, transaction_date, category:chart_of_accounts!category_id(account_name)')
-          .eq('restaurant_id', restaurantId)
-          .gte('transaction_date', start_date)
-          .lte('transaction_date', end_date)
-          .order('transaction_date', { ascending: true });
+        // Daily inflow/outflow/net series (get_bank_transactions_daily)
+        // replaces the raw per-transaction fetch. The per-transaction
+        // `transactions` list this report used to return (with
+        // description/category) is replaced by `daily_breakdown`, one row
+        // per day - the daily RPC has no per-transaction detail, and a raw
+        // fetch here would reintroduce the unbounded read this branch fixes.
+        const { data: dailyRows, error: dailyError } = await supabase.rpc('get_bank_transactions_daily', {
+          p_restaurant_id: restaurantId,
+          p_start_date: start_date,
+          p_end_date: end_date,
+        });
+        if (dailyError) throw new Error(`get_bank_transactions_daily failed: ${dailyError.message}`);
 
-        const inflows = transactions?.filter((t: any) => t.amount > 0).reduce((sum: number, t: any) => sum + t.amount, 0) || 0;
-        const outflows = Math.abs(transactions?.filter((t: any) => t.amount < 0).reduce((sum: number, t: any) => sum + t.amount, 0) || 0);
+        const days = dailyRows || [];
+        const inflows = days.reduce((sum: number, d: any) => sum + Number(d.inflow ?? 0), 0);
+        const outflows = days.reduce((sum: number, d: any) => sum + Number(d.outflow ?? 0), 0);
 
         reportData = {
           period: { start_date, end_date },
           cash_inflows: inflows,
           cash_outflows: outflows,
           net_cash_flow: inflows - outflows,
-          transactions: transactions?.map((t: any) => ({
-            date: t.transaction_date,
-            description: t.description,
-            amount: t.amount,
-            category: t.category?.account_name || 'Uncategorized',
-          })) || [],
+          daily_breakdown: days.map((d: any) => ({
+            date: d.day,
+            inflow: Number(d.inflow ?? 0),
+            outflow: Number(d.outflow ?? 0),
+            net: Number(d.net ?? 0),
+          })),
         };
         break;
       }
@@ -2812,68 +2803,29 @@ async function executeGetExpenseHealth(
     'card fee', 'payment fee', 'square', 'stripe', 'clover fee', 'toast fee',
   ];
 
-  // Fetch bank transactions
-  let txQuery = supabase
-    .from('bank_transactions')
-    .select(`
-      amount,
-      description,
-      merchant_name,
-      category_id,
-      is_split,
-      chart_of_accounts!category_id(account_name, account_subtype)
-    `)
-    .eq('restaurant_id', restaurantId)
-    .in('status', ['posted', 'pending'])
-    .gte('transaction_date', startDateStr)
-    .lte('transaction_date', endDateStr);
+  // One aggregate call (get_expense_health_metrics) replaces the raw fetch
+  // and the six filter/reduce passes over it. The RPC hardcodes the same
+  // status IN ('posted', 'pending') filter as the prior query, so no
+  // p_statuses argument is needed. p_bank_account_id filters
+  // connected_bank_id, the same column the prior query already used.
+  const feePatterns = processingFeePatterns.map((p) => `%${p.toLowerCase()}%`);
+  const { data: healthRows, error: healthError } = await supabase.rpc('get_expense_health_metrics', {
+    p_restaurant_id: restaurantId,
+    p_start_date: startDateStr,
+    p_end_date: endDateStr,
+    p_fee_patterns: feePatterns,
+    p_bank_account_id: bank_account_id || null,
+  });
 
-  if (bank_account_id) {
-    txQuery = txQuery.eq('connected_bank_id', bank_account_id);
-  }
+  if (healthError) throw new Error(`get_expense_health_metrics failed: ${healthError.message}`);
 
-  const { data: transactions, error: txError } = await txQuery;
-
-  if (txError) throw new Error(`Failed to fetch transactions: ${txError.message}`);
-
-  const txns = transactions || [];
-
-  // Calculate metrics
-  const revenue = txns.filter((t: any) => t.amount > 0).reduce((sum: number, t: any) => sum + t.amount, 0);
-
-  const foodCost = Math.abs(
-    txns.filter((t: any) => {
-      if (t.amount >= 0) return false;
-      if (!t.category_id || !t.chart_of_accounts) return false;
-      const subtype = t.chart_of_accounts.account_subtype;
-      const name = (t.chart_of_accounts.account_name || '').toLowerCase();
-      return subtype === 'cost_of_goods_sold' || name.includes('food') || name.includes('inventory');
-    }).reduce((sum: number, t: any) => sum + t.amount, 0)
-  );
-
-  const laborCost = Math.abs(
-    txns.filter((t: any) => {
-      if (t.amount >= 0) return false;
-      if (!t.category_id || !t.chart_of_accounts) return false;
-      const subtype = t.chart_of_accounts.account_subtype;
-      const name = (t.chart_of_accounts.account_name || '').toLowerCase();
-      return subtype === 'payroll' || name.includes('payroll') || name.includes('labor');
-    }).reduce((sum: number, t: any) => sum + t.amount, 0)
-  );
-
-  const processingFees = Math.abs(
-    txns.filter((t: any) => {
-      if (t.amount >= 0) return false;
-      const desc = ((t.description || '') + ' ' + (t.merchant_name || '')).toLowerCase();
-      return processingFeePatterns.some(pattern => desc.includes(pattern));
-    }).reduce((sum: number, t: any) => sum + t.amount, 0)
-  );
-
-  const outflows = txns.filter((t: any) => t.amount < 0);
-  const totalOutflows = Math.abs(outflows.reduce((sum: number, t: any) => sum + t.amount, 0));
-  const uncategorizedSpend = Math.abs(
-    outflows.filter((t: any) => !t.category_id && !t.is_split).reduce((sum: number, t: any) => sum + t.amount, 0)
-  );
+  const health = healthRows?.[0] ?? {};
+  const revenue = Number(health.revenue ?? 0);
+  const foodCost = Number(health.food_cost ?? 0);
+  const laborCost = Number(health.labor_cost ?? 0);
+  const processingFees = Number(health.processing_fees ?? 0);
+  const totalOutflows = Number(health.total_outflows ?? 0);
+  const uncategorizedSpend = Number(health.uncategorized_spend ?? 0);
 
   // Calculate percentages
   const foodCostPercentage = revenue > 0 ? (foodCost / revenue) * 100 : 0;
@@ -2958,7 +2910,7 @@ async function executeGetExpenseHealth(
       alerts: alerts,
     },
     evidence: [
-      { table: 'bank_transactions', summary: `${txns.length} transactions from ${startDateStr} to ${endDateStr} for expense health analysis` },
+      { table: 'bank_transactions', summary: `Expense health metrics ${startDateStr} to ${endDateStr}` },
     ],
   };
 }
@@ -3307,6 +3259,10 @@ async function executeBatchCategorizeTransactions(
 ): Promise<any> {
   const { transaction_ids, category_id, preview = false, confirmed = false } = args;
 
+  if (transaction_ids.length > 1000) {
+    return { error: `Too many ids (${transaction_ids.length}). Send at most 1000 per call.` };
+  }
+
   // Fetch the category info
   const { data: category, error: catError } = await supabase
     .from('chart_of_accounts')
@@ -3396,6 +3352,10 @@ async function executeBatchCategorizePosSales(
   supabase: any
 ): Promise<any> {
   const { sale_ids, category_id, preview = false, confirmed = false } = args;
+
+  if (sale_ids.length > 1000) {
+    return { error: `Too many ids (${sale_ids.length}). Send at most 1000 per call.` };
+  }
 
   const { data: category, error: catError } = await supabase
     .from('chart_of_accounts')

--- a/supabase/functions/ai-execute-tool/index.ts
+++ b/supabase/functions/ai-execute-tool/index.ts
@@ -243,6 +243,9 @@ async function executeGetKpis(
 
   const totalCogs = sumMonthlyFoodCost(usageRows);
 
+  if (salesCountResult.error) {
+    throw new Error(`unified_sales count failed: ${salesCountResult.error.message}`);
+  }
   const salesCount = salesCountResult.count ?? 0;
 
   // Fetch labor costs using time_punches + employees (same as Dashboard) —
@@ -323,7 +326,7 @@ async function executeGetKpis(
   // refunds), so cost/profitability/benchmarks are computed directly against
   // salesTotals.net instead of going through calculatePeriodMetrics (which
   // would need the raw sale rows this fetch replaced).
-  const rawCosts = calculateCostBreakdown([{ total_cost: totalCogs }], laborCostData || [], salesTotals.net);
+  const rawCosts = calculateCostBreakdown([{ total_cost: totalCogs }], laborCostData, salesTotals.net);
   const rawProfitability = calculateProfitability(salesTotals.net, rawCosts.prime_cost);
   const rawBenchmarks = calculateBenchmarks(rawCosts);
 
@@ -572,17 +575,30 @@ async function calculateCashFlow(
   // Daily inflow/outflow/net series (get_bank_transactions_daily) replaces
   // the raw per-transaction fetch. p_bank_account_id filters
   // connected_bank_id, which fixes the prior filter on a bank_account_id
-  // column that bank_transactions does not have.
-  const { data: dailyRows, error } = await supabase.rpc('get_bank_transactions_daily', {
-    p_restaurant_id: restaurantId,
-    p_start_date: start_date,
-    p_end_date: end_date,
-    p_bank_account_id: bank_account_id || null,
-  });
+  // column that bank_transactions does not have. transaction_count reads
+  // tx_count from get_bank_transaction_summary (already used elsewhere in
+  // this file), since the daily RPC emits one row per active day, not per
+  // transaction — days.length would undercount any day with 2+ transactions.
+  const [{ data: dailyRows, error }, { data: summaryRows, error: summaryError }] = await Promise.all([
+    supabase.rpc('get_bank_transactions_daily', {
+      p_restaurant_id: restaurantId,
+      p_start_date: start_date,
+      p_end_date: end_date,
+      p_bank_account_id: bank_account_id || null,
+    }),
+    supabase.rpc('get_bank_transaction_summary', {
+      p_restaurant_id: restaurantId,
+      p_start_date: start_date,
+      p_end_date: end_date,
+      p_bank_account_id: bank_account_id || null,
+    }),
+  ]);
 
   if (error) throw new Error(`get_bank_transactions_daily failed: ${error.message}`);
+  if (summaryError) throw new Error(`get_bank_transaction_summary failed: ${summaryError.message}`);
 
   const days = dailyRows || [];
+  const txCount = Number(summaryRows?.[0]?.tx_count ?? 0);
   const inflows = days.reduce((sum: number, d: any) => sum + Number(d.inflow ?? 0), 0);
   const outflows = days.reduce((sum: number, d: any) => sum + Number(d.outflow ?? 0), 0);
   const netCashFlow = inflows - outflows;
@@ -603,9 +619,7 @@ async function calculateCashFlow(
     net_cash_flow_7d: netCashFlow,
     avg_daily_cash_flow: avgDailyCashFlow,
     volatility: volatility,
-    // Days with at least one transaction. The daily RPC emits one row per
-    // active day, not per transaction, so this counts active days.
-    transaction_count: days.length,
+    transaction_count: txCount,
   };
 }
 
@@ -636,7 +650,11 @@ async function calculateRevenueHealth(
 
   const summary = summaryRows?.[0] ?? {};
   const depositCount = Number(summary.inflow_count ?? 0);
-  const totalRevenue = Number(summary.inflow ?? 0);
+  // total_revenue reads floored_inflow (equal to inflow when p_min_inflow is
+  // NULL), not inflow, so it stays consistent with deposit_count/avg_deposit_size
+  // /largest_deposit: all four exclude the same small transfers/refunds
+  // below the p_min_inflow=10 floor set above.
+  const totalRevenue = Number(summary.floored_inflow ?? 0);
   const avgDeposit = Number(summary.avg_inflow ?? 0);
   const largestDeposit = Number(summary.max_inflow ?? 0);
 
@@ -949,9 +967,11 @@ async function executeGetBankTransactions(
   }
 
   const periodSummary = summaryRows?.[0] ?? {};
-  // categorized_count/categorization_rate have no RPC (the summary RPC has
-  // no categorization awareness), so they stay computed from the fetched
-  // page, same as before.
+  // categorized_count_in_page/categorization_rate_in_page have no RPC (the
+  // summary RPC has no categorization awareness), so they stay computed from
+  // the fetched page, same as before. The _in_page suffix marks them as
+  // page-scoped so a caller does not read them as period-wide, unlike the
+  // total_* fields beside them, which come from the period-wide summary RPC.
   const categorized = transactions?.filter((t: any) => t.is_categorized).length || 0;
 
   // The summary RPC only supports p_bank_account_id/p_statuses. When the
@@ -971,8 +991,8 @@ async function executeGetBankTransactions(
         total_net: Number(periodSummary.net ?? 0),
         total_inflows: Number(periodSummary.inflow ?? 0),
         total_outflows: Number(periodSummary.outflow ?? 0),
-        categorized_count: categorized,
-        categorization_rate: transactions?.length ? (categorized / transactions.length) * 100 : 0,
+        categorized_count_in_page: categorized,
+        categorization_rate_in_page: transactions?.length ? (categorized / transactions.length) * 100 : 0,
         ...(hasUnsummarizedFilters
           ? {
               partial: true,
@@ -1301,6 +1321,10 @@ async function executeGetSalesSummary(
   // client-side group-by over raw rows.
   const [salesTotals, currentCountResult] = await Promise.all([
     fetchNetSales(supabase, restaurantId, startDateStr, endDateStr),
+    // .or('item_type.is.null,item_type.eq.sale') matches the same sale-only
+    // count executeGetKpis uses, so this tool and the KPIs tool report the
+    // same transaction_count for the same period instead of this count also
+    // picking up discount/refund line items.
     supabase
       .from('unified_sales')
       .select('*', { count: 'exact', head: true })
@@ -1308,8 +1332,13 @@ async function executeGetSalesSummary(
       .gte('sale_date', startDateStr)
       .lte('sale_date', endDateStr)
       .is('adjustment_type', null)
-      .is('parent_sale_id', null),
+      .is('parent_sale_id', null)
+      .or('item_type.is.null,item_type.eq.sale'),
   ]);
+
+  if (currentCountResult.error) {
+    throw new Error(`unified_sales count failed: ${currentCountResult.error.message}`);
+  }
 
   const currentTotal = salesTotals.net;
   const currentCount = currentCountResult.count ?? 0;
@@ -3289,6 +3318,10 @@ async function executeBatchCategorizeTransactions(
 ): Promise<any> {
   const { transaction_ids, category_id, preview = false, confirmed = false } = args;
 
+  if (!Array.isArray(transaction_ids) || transaction_ids.length === 0) {
+    return { ok: false, error: { code: 'INVALID_REQUEST', message: 'transaction_ids must be a non-empty array.' } };
+  }
+
   if (transaction_ids.length > 1000) {
     return { ok: false, error: { code: 'TOO_MANY_IDS', message: `Too many ids (${transaction_ids.length}). Send at most 1000 per call.` } };
   }
@@ -3382,6 +3415,10 @@ async function executeBatchCategorizePosSales(
   supabase: any
 ): Promise<any> {
   const { sale_ids, category_id, preview = false, confirmed = false } = args;
+
+  if (!Array.isArray(sale_ids) || sale_ids.length === 0) {
+    return { ok: false, error: { code: 'INVALID_REQUEST', message: 'sale_ids must be a non-empty array.' } };
+  }
 
   if (sale_ids.length > 1000) {
     return { ok: false, error: { code: 'TOO_MANY_IDS', message: `Too many ids (${sale_ids.length}). Send at most 1000 per call.` } };

--- a/supabase/functions/ai-execute-tool/index.ts
+++ b/supabase/functions/ai-execute-tool/index.ts
@@ -12,8 +12,7 @@ import {
 } from "../_shared/inventoryTransactions.ts";
 import { logAICall, extractTokenUsage, type AICallMetadata } from "../_shared/braintrust.ts";
 import { EMPLOYEE_LABOR_COLUMNS } from "../_shared/employeeLaborColumns.ts";
-import { fetchNetSales } from "../_shared/financialAggregates.ts";
-// sumMonthlyFoodCost stays unused here until Task 11 rewires the food-cost sites.
+import { fetchNetSales, sumMonthlyFoodCost } from "../_shared/financialAggregates.ts";
 
 // AI tool execution with OpenRouter multi-model fallback
 const OPENROUTER_API_KEY = Deno.env.get('OPENROUTER_API_KEY') || '';
@@ -200,18 +199,16 @@ async function executeGetKpis(
   // front of an already-sequential fetch chain in a CPU-limited edge function.
   // ====== FETCH DATA FROM DATABASE ======
 
-  const [hasLaborAccess, salesTotals, foodCostResult, salesCountResult] = await Promise.all([
+  const [hasLaborAccess, salesTotals, usageResult, salesCountResult] = await Promise.all([
     hasSchedulingOrPayrollCapability(restaurantId, supabase),
     // Net sales for the period (gross - discounts - refunds), from the shared RPC.
     fetchNetSales(supabase, restaurantId, startDateStr, endDateStr),
-    // Fetch food costs (COGS)
-    supabase
-      .from('inventory_transactions')
-      .select('total_cost')
-      .eq('restaurant_id', restaurantId)
-      .eq('transaction_type', 'usage')
-      .gte('created_at', startDateStr)
-      .lte('created_at', endDateStr + 'T23:59:59.999Z'),
+    // Fetch food costs (COGS) as a monthly-usage aggregate from the SQL side.
+    supabase.rpc('get_inventory_usage_by_month', {
+      p_restaurant_id: restaurantId,
+      p_start_date: startDateStr,
+      p_end_date: endDateStr,
+    }),
     // Server-side count of sale transactions in the period (head:true, so it
     // is not subject to the 1000-row cap a normal select would hit). This
     // counts sale transactions, not split-child rows: a split sale's parent
@@ -237,11 +234,13 @@ async function executeGetKpis(
       .or('item_type.is.null,item_type.eq.sale'),
   ]);
 
-  const { data: foodCostData, error: foodCostError } = foodCostResult;
+  const { data: usageRows, error: usageError } = usageResult;
 
-  if (foodCostError) {
-    throw new Error(`Failed to fetch food costs: ${foodCostError.message}`);
+  if (usageError) {
+    throw new Error(`get_inventory_usage_by_month failed: ${usageError.message}`);
   }
+
+  const totalCogs = sumMonthlyFoodCost(usageRows);
 
   const salesCount = salesCountResult.count ?? 0;
 
@@ -296,18 +295,18 @@ async function executeGetKpis(
     laborCostData = [{ total_labor_cost: Math.round(laborBreakdown.total * 100) / 100 }];
   }
 
-  // Fetch inventory value
-  const { data: inventory, error: invError } = await supabase
-    .from('products')
-    .select('current_stock, cost_per_unit')
-    .eq('restaurant_id', restaurantId);
+  // Fetch inventory value as a single aggregate row from the SQL side.
+  const { data: valuationRows, error: valuationError } = await supabase.rpc('get_inventory_valuation', {
+    p_restaurant_id: restaurantId,
+  });
 
-  if (invError) {
-    throw new Error(`Failed to fetch inventory: ${invError.message}`);
+  if (valuationError) {
+    throw new Error(`get_inventory_valuation failed: ${valuationError.message}`);
   }
 
-  const inventoryValue = inventory?.reduce((sum: number, item: any) => 
-    sum + ((item.current_stock || 0) * (item.cost_per_unit || 0)), 0) || 0;
+  const inventoryValuation = valuationRows?.[0];
+  const inventoryValue = Number(inventoryValuation?.total_value ?? 0);
+  const inventoryItemCount = Number(inventoryValuation?.item_count ?? 0);
 
   // Get bank transaction count
   const { count: transactionCount } = await supabase
@@ -323,7 +322,7 @@ async function executeGetKpis(
   // refunds), so cost/profitability/benchmarks are computed directly against
   // salesTotals.net instead of going through calculatePeriodMetrics (which
   // would need the raw sale rows this fetch replaced).
-  const rawCosts = calculateCostBreakdown(foodCostData || [], laborCostData || [], salesTotals.net);
+  const rawCosts = calculateCostBreakdown([{ total_cost: totalCogs }], laborCostData || [], salesTotals.net);
   const rawProfitability = calculateProfitability(salesTotals.net, rawCosts.prime_cost);
   const rawBenchmarks = calculateBenchmarks(rawCosts);
 
@@ -375,7 +374,7 @@ async function executeGetKpis(
       ...(hasLaborAccess
         ? [{ table: 'time_punches', date: startDateStr, summary: `Labor from time punches ${startDateStr} to ${endDateStr}` }]
         : []),
-      { table: 'products', summary: `Current inventory snapshot (${inventory?.length || 0} items)` },
+      { table: 'products', summary: `Current inventory snapshot (${inventoryItemCount} items)` },
     ],
   };
 }
@@ -390,49 +389,64 @@ async function executeGetInventoryStatus(
 ): Promise<any> {
   const { include_low_stock = true, category } = args;
 
-  let query = supabase
-    .from('products')
-    .select(`
-      id, 
-      name, 
-      current_stock, 
-      par_level_min, 
-      par_level_max,
-      reorder_point,
-      cost_per_unit, 
-      category,
-      product_suppliers (
-        supplier:suppliers (
-          name
-        ),
-        is_preferred
-      )
-    `)
-    .eq('restaurant_id', restaurantId);
+  // Total value, item count, and low-stock count come from the restaurant-wide
+  // valuation RPC. The RPC takes no category filter, so these three numbers
+  // are always restaurant-wide even when `category` is set — only the
+  // low-stock item list below honors the category filter, since it needs
+  // per-item fields (name, supplier) the RPC does not return.
+  const { data: valuationRows, error: valuationError } = await supabase.rpc('get_inventory_valuation', {
+    p_restaurant_id: restaurantId,
+  });
 
-  if (category) {
-    query = query.eq('category', category);
+  if (valuationError) {
+    throw new Error(`get_inventory_valuation failed: ${valuationError.message}`);
   }
 
-  const { data: products, error } = await query;
+  const valuation = valuationRows?.[0];
+  const totalItems = Number(valuation?.item_count ?? 0);
+  const totalValue = Number(valuation?.total_value ?? 0);
+  const lowStockCount = Number(valuation?.low_stock_count ?? 0);
 
-  if (error) {
-    throw new Error(`Failed to fetch inventory: ${error.message}`);
+  let lowStockItems: any[] = [];
+  if (include_low_stock) {
+    let query = supabase
+      .from('products')
+      .select(`
+        id,
+        name,
+        current_stock,
+        par_level_min,
+        reorder_point,
+        product_suppliers (
+          supplier:suppliers (
+            name
+          ),
+          is_preferred
+        )
+      `)
+      .eq('restaurant_id', restaurantId);
+
+    if (category) {
+      query = query.eq('category', category);
+    }
+
+    const { data: products, error } = await query;
+
+    if (error) {
+      throw new Error(`Failed to fetch inventory: ${error.message}`);
+    }
+
+    lowStockItems = (products || []).filter((p: any) =>
+      p.current_stock <= (p.par_level_min || 0)
+    );
   }
-
-  const lowStockItems = products?.filter((p: any) => 
-    p.current_stock <= (p.par_level_min || 0)
-  ) || [];
-
-  const totalValue = products?.reduce((sum: number, item: any) => 
-    sum + ((item.current_stock || 0) * (item.cost_per_unit || 0)), 0) || 0;
 
   return {
     ok: true,
     data: {
-      total_items: products?.length || 0,
+      total_items: totalItems,
       total_value: totalValue,
-      low_stock_count: lowStockItems.length,
+      low_stock_count: lowStockCount,
       low_stock_items: include_low_stock ? lowStockItems.slice(0, 10).map((item: any) => ({
         id: item.id,
         name: item.name,
@@ -443,7 +457,7 @@ async function executeGetInventoryStatus(
       })) : [],
     },
     evidence: [
-      { table: 'products', summary: `Inventory snapshot: ${products?.length || 0} items, ${lowStockItems.length} low stock` },
+      { table: 'products', summary: `Inventory snapshot: ${totalItems} items, ${lowStockCount} low stock` },
     ],
   };
 }
@@ -952,40 +966,24 @@ async function executeGetFinancialStatement(
         const salesTotals = await fetchNetSales(supabase, restaurantId, start_date, end_date);
         const revenue = salesTotals.net;
 
-        // Fetch COGS from inventory transactions
-        const { data: cogs } = await supabase
-          .from('inventory_transactions')
-          .select('total_cost')
-          .eq('restaurant_id', restaurantId)
-          .eq('transaction_type', 'usage')
-          .gte('created_at', start_date)
-          .lte('created_at', end_date);
-        
-        const totalCogs = Math.abs(cogs?.reduce((sum: number, c: any) => sum + (c.total_cost || 0), 0) || 0);
-        
-        // Fetch expenses from journal entries
-        const { data: expenseAccounts } = await supabase
-          .from('chart_of_accounts')
-          .select('id')
-          .eq('restaurant_id', restaurantId)
-          .eq('account_type', 'expense');
-        
-        const expenseAccountIds = expenseAccounts?.map((a: any) => a.id) || [];
-        
-        const { data: expenses } = await supabase
-          .from('journal_entry_lines')
-          .select(`
-            debit_amount,
-            credit_amount,
-            journal_entry:journal_entries!inner(entry_date)
-          `)
-          .in('account_id', expenseAccountIds)
-          .gte('journal_entry.entry_date', start_date)
-          .lte('journal_entry.entry_date', end_date);
-        
-        const totalExpenses = expenses?.reduce((sum: number, e: any) => 
-          sum + (e.debit_amount || 0) - (e.credit_amount || 0), 0) || 0;
-        
+        // Fetch COGS from the monthly usage aggregate RPC.
+        const { data: usageRows, error: usageError } = await supabase.rpc('get_inventory_usage_by_month', {
+          p_restaurant_id: restaurantId,
+          p_start_date: start_date,
+          p_end_date: end_date,
+        });
+        if (usageError) throw new Error(`get_inventory_usage_by_month failed: ${usageError.message}`);
+        const totalCogs = sumMonthlyFoodCost(usageRows);
+
+        // Fetch operating expenses from the journal expense aggregate RPC.
+        const { data: expenseTotal, error: expError } = await supabase.rpc('get_journal_expense_total', {
+          p_restaurant_id: restaurantId,
+          p_start_date: start_date,
+          p_end_date: end_date,
+        });
+        if (expError) throw new Error(`get_journal_expense_total failed: ${expError.message}`);
+        const totalExpenses = Number(expenseTotal ?? 0);
+
         const grossProfit = revenue - totalCogs;
         const netIncome = grossProfit - totalExpenses;
         
@@ -1026,14 +1024,14 @@ async function executeGetFinancialStatement(
         const cash = cashAccounts?.reduce((sum: number, bank: any) => 
           sum + (bank.bank_account_balances?.[0]?.current_balance || 0), 0) || 0;
         
-        const { data: inventory } = await supabase
-          .from('products')
-          .select('current_stock, cost_per_unit')
-          .eq('restaurant_id', restaurantId);
-        
-        const inventoryValue = inventory?.reduce((sum: number, p: any) => 
-          sum + ((p.current_stock || 0) * (p.cost_per_unit || 0)), 0) || 0;
-        
+        const { data: valuationRows, error: valuationError } = await supabase.rpc('get_inventory_valuation', {
+          p_restaurant_id: restaurantId,
+        });
+        if (valuationError) throw new Error(`get_inventory_valuation failed: ${valuationError.message}`);
+        const balanceSheetValuation = valuationRows?.[0];
+        const inventoryValue = Number(balanceSheetValuation?.total_value ?? 0);
+        const inventoryItemCount = Number(balanceSheetValuation?.item_count ?? 0);
+
         const totalAssets = cash + inventoryValue;
         
         // Simplified - would need accounts payable and other liability tracking
@@ -1068,11 +1066,11 @@ async function executeGetFinancialStatement(
           },
           evidence: [
             { table: 'connected_banks', summary: `Cash balances from connected bank accounts as of ${asOfDate}` },
-            { table: 'products', summary: `Inventory valuation from ${inventory?.length || 0} products` },
+            { table: 'products', summary: `Inventory valuation from ${inventoryItemCount} products` },
           ],
         };
       }
-      
+
       case 'cash_flow': {
         const { data: transactions } = await supabase
           .from('bank_transactions')
@@ -1245,16 +1243,17 @@ async function executeGetSalesSummary(
     }
   }
 
-  // Fetch current period sales (excluding adjustments - only actual revenue).
-  // Raw rows are still needed for the item breakdown/count below (Task 11
-  // moves that to get_top_sold_items); the period total comes from the
-  // shared net-sales RPC so it uses the same gross - discounts - refunds
-  // definition as every other financial tool.
-  const [salesTotals, currentSalesResult] = await Promise.all([
+  // Current period total comes from the shared net-sales RPC so it uses the
+  // same gross - discounts - refunds definition as every other financial
+  // tool. transaction_count is a bounded server-side head-count (Task 11
+  // removes the raw row fetch this used to piggy-back on); the item
+  // breakdown, when requested, comes from get_top_sold_items instead of a
+  // client-side group-by over raw rows.
+  const [salesTotals, currentCountResult] = await Promise.all([
     fetchNetSales(supabase, restaurantId, startDateStr, endDateStr),
     supabase
       .from('unified_sales')
-      .select('total_price, sale_date, item_name')
+      .select('*', { count: 'exact', head: true })
       .eq('restaurant_id', restaurantId)
       .gte('sale_date', startDateStr)
       .lte('sale_date', endDateStr)
@@ -1262,36 +1261,32 @@ async function executeGetSalesSummary(
       .is('parent_sale_id', null),
   ]);
 
-  const { data: currentSales, error: currentError } = currentSalesResult;
-  if (currentError) {
-    throw new Error(`Failed to fetch sales: ${currentError.message}`);
-  }
-
   const currentTotal = salesTotals.net;
-  const currentCount = currentSales?.length || 0;
+  const currentCount = currentCountResult.count ?? 0;
 
   // Get items breakdown if requested
   let itemsBreakdown = null;
   if (include_items) {
-    const itemsSummary: Record<string, { count: number; total: number }> = {};
-    currentSales?.forEach((sale: any) => {
-      const item = sale.item_name || 'Unknown';
-      if (!itemsSummary[item]) {
-        itemsSummary[item] = { count: 0, total: 0 };
-      }
-      itemsSummary[item].count += 1;
-      itemsSummary[item].total += sale.total_price || 0;
+    const { data: topItems, error: topItemsError } = await supabase.rpc('get_top_sold_items', {
+      p_restaurant_id: restaurantId,
+      p_start_date: startDateStr,
+      p_end_date: endDateStr,
+      p_limit: 10,
     });
-    
-    itemsBreakdown = Object.entries(itemsSummary)
-      .sort(([, a], [, b]) => b.total - a.total)
-      .slice(0, 20)
-      .map(([name, data]) => ({
-        item_name: name,
-        quantity_sold: data.count,
-        total_sales: data.total,
-        avg_price: data.count > 0 ? data.total / data.count : 0,
-      }));
+    if (topItemsError) throw new Error(`get_top_sold_items failed: ${topItemsError.message}`);
+
+    itemsBreakdown = (topItems || []).map((item: any) => {
+      // sale_count preserves the old row-count semantics of quantity_sold
+      // (count of matching sale rows), not the RPC's summed `quantity` field.
+      const count = Number(item.sale_count ?? 0);
+      const total = Number(item.revenue ?? 0);
+      return {
+        item_name: item.item_name,
+        quantity_sold: count,
+        total_sales: total,
+        avg_price: count > 0 ? total / count : 0,
+      };
+    });
   }
 
   let comparison = null;
@@ -1690,16 +1685,14 @@ async function executeGenerateReport(
         const salesTotals = await fetchNetSales(supabase, restaurantId, start_date, end_date);
         const totalRevenue = salesTotals.net;
 
-        // Get COGS from inventory transactions
-        const { data: inventory } = await supabase
-          .from('inventory_transactions')
-          .select('total_cost, transaction_type')
-          .eq('restaurant_id', restaurantId)
-          .gte('created_at', start_date)
-          .lte('created_at', end_date)
-          .eq('transaction_type', 'usage');
-
-        const totalCOGS = Math.abs(inventory?.reduce((sum: number, i: any) => sum + (i.total_cost || 0), 0) || 0);
+        // Get COGS from the monthly usage aggregate RPC.
+        const { data: usageRows, error: usageError } = await supabase.rpc('get_inventory_usage_by_month', {
+          p_restaurant_id: restaurantId,
+          p_start_date: start_date,
+          p_end_date: end_date,
+        });
+        if (usageError) throw new Error(`get_inventory_usage_by_month failed: ${usageError.message}`);
+        const totalCOGS = sumMonthlyFoodCost(usageRows);
 
         // Get expenses from bank transactions
         const { data: expenses } = await supabase
@@ -1757,32 +1750,23 @@ async function executeGenerateReport(
       }
 
       case 'sales_by_category': {
-        const { data: sales } = await supabase
-          .from('unified_sales')
-          .select('item_name, total_price, pos_category, sale_date')
-          .eq('restaurant_id', restaurantId)
-          .gte('sale_date', start_date)
-          .lte('sale_date', end_date);
-
-        // Group by category
-        const byCategory: Record<string, { total: number; count: number }> = {};
-        sales?.forEach((s: any) => {
-          const cat = s.pos_category || 'Uncategorized';
-          if (!byCategory[cat]) {
-            byCategory[cat] = { total: 0, count: 0 };
-          }
-          byCategory[cat].total += s.total_price || 0;
-          byCategory[cat].count += 1;
+        const { data: categoryRows, error: catErr } = await supabase.rpc('get_sales_by_category', {
+          p_restaurant_id: restaurantId, p_start_date: start_date, p_end_date: end_date,
         });
+        if (catErr) throw new Error(`get_sales_by_category failed: ${catErr.message}`);
 
         reportData = {
           period: { start_date, end_date },
-          categories: Object.entries(byCategory).map(([name, data]) => ({
-            name,
-            total_sales: data.total,
-            item_count: data.count,
-            average_price: data.count > 0 ? data.total / data.count : 0,
-          })),
+          categories: (categoryRows || []).map((row: any) => {
+            const itemCount = Number(row.item_count ?? 0);
+            const totalSales = Number(row.revenue ?? 0);
+            return {
+              name: row.category_name,
+              total_sales: totalSales,
+              item_count: itemCount,
+              average_price: itemCount > 0 ? totalSales / itemCount : 0,
+            };
+          }),
         };
         break;
       }
@@ -1816,13 +1800,11 @@ async function executeGenerateReport(
 
       case 'balance_sheet': {
         // Simplified balance sheet
-        const { data: inventory } = await supabase
-          .from('products')
-          .select('current_stock, cost_per_unit')
-          .eq('restaurant_id', restaurantId);
-
-        const inventoryValue = inventory?.reduce((sum: number, i: any) => 
-          sum + ((i.current_stock || 0) * (i.cost_per_unit || 0)), 0) || 0;
+        const { data: valuationRows, error: valuationError } = await supabase.rpc('get_inventory_valuation', {
+          p_restaurant_id: restaurantId,
+        });
+        if (valuationError) throw new Error(`get_inventory_valuation failed: ${valuationError.message}`);
+        const inventoryValue = Number(valuationRows?.[0]?.total_value ?? 0);
 
         const { data: bank } = await supabase
           .from('connected_banks')
@@ -2695,22 +2677,20 @@ async function executeGetMonthlyTrends(
     console.warn('RPC not available, using simplified calculation:', salesError);
   }
 
-  // Fetch food costs by month
-  const { data: foodCosts, error: foodError } = await supabase
-    .from('inventory_transactions')
-    .select('created_at, total_cost')
-    .eq('restaurant_id', restaurantId)
-    .eq('transaction_type', 'usage')
-    .gte('created_at', startDateStr)
-    .lte('created_at', endDateStr + 'T23:59:59.999Z');
+  // Fetch food costs by month via the monthly usage aggregate RPC.
+  const { data: usageRows, error: usageError } = await supabase.rpc('get_inventory_usage_by_month', {
+    p_restaurant_id: restaurantId,
+    p_start_date: startDateStr,
+    p_end_date: endDateStr,
+  });
 
-  if (foodError) throw new Error(`Failed to fetch food costs: ${foodError.message}`);
+  if (usageError) throw new Error(`get_inventory_usage_by_month failed: ${usageError.message}`);
 
-  // Group food costs by month
+  // The RPC already aggregates per month, so its rows map directly into the
+  // lookup — no client-side group-by needed.
   const foodCostByMonth: Record<string, number> = {};
-  foodCosts?.forEach((t: any) => {
-    const monthKey = new Date(t.created_at).toISOString().slice(0, 7);
-    foodCostByMonth[monthKey] = (foodCostByMonth[monthKey] || 0) + Math.abs(t.total_cost || 0);
+  (usageRows || []).forEach((row: any) => {
+    foodCostByMonth[row.period] = Number(row.food_cost ?? 0);
   });
 
   // Build monthly trends

--- a/supabase/functions/ai-execute-tool/index.ts
+++ b/supabase/functions/ai-execute-tool/index.ts
@@ -2679,7 +2679,8 @@ async function executeGetOperatingCosts(
       break_even_revenue: costTotals.breakEvenRevenue,
       current_revenue: totalRevenue,
       above_break_even: totalRevenue >= costTotals.breakEvenRevenue,
-      margin_of_safety: totalRevenue > 0 ? ((totalRevenue - costTotals.breakEvenRevenue) / totalRevenue) * 100 : 0,
+      margin_of_safety_percent: totalRevenue > 0 ? ((totalRevenue - costTotals.breakEvenRevenue) / totalRevenue) * 100 : 0,
+      margin_of_safety_amount: salesTotals.net - costTotals.breakEvenRevenue,
     };
   }
 
@@ -2689,6 +2690,8 @@ async function executeGetOperatingCosts(
       period,
       start_date: startDateStr,
       end_date: endDateStr,
+      source: 'budget_config',
+      note: 'These costs are the configured budget, not period actuals. The period parameter scopes only the revenue used for the break-even.',
       costs_by_type: {
         fixed: { items: byCostType.fixed, total: costTotals.fixedTotal },
         semi_variable: { items: byCostType.semi_variable, total: costTotals.semiVariableTotal },
@@ -3163,7 +3166,7 @@ async function executeGetBreakEvenProgress(
         days_remaining: daysRemaining,
         projected_month_end_revenue: Math.round(projectedMonthEnd),
         projected_above_break_even: projectedAboveBreakEven,
-        margin_of_safety: monthlyBreakEven > 0
+        margin_of_safety_percent: monthlyBreakEven > 0
           ? Math.round(((projectedMonthEnd - monthlyBreakEven) / monthlyBreakEven) * 1000) / 10
           : 0,
       };

--- a/supabase/migrations/20260814140000_monthly_sales_metrics_refunds.sql
+++ b/supabase/migrations/20260814140000_monthly_sales_metrics_refunds.sql
@@ -65,10 +65,15 @@ BEGIN
     SELECT TO_CHAR(us.sale_date, 'YYYY-MM') as month_period,
       COALESCE(SUM(ABS(us.total_price)), 0)::DECIMAL as amount
     FROM unified_sales us
+    LEFT JOIN chart_of_accounts coa ON us.category_id = coa.id
     WHERE us.restaurant_id = p_restaurant_id
       AND us.sale_date >= p_date_from AND us.sale_date <= p_date_to
       AND us.adjustment_type IS NULL
       AND LOWER(COALESCE(us.item_type, '')) = 'refund'
+      -- Mirror monthly_revenue's liability exclusion: a refund categorized
+      -- against a liability account (e.g. a tax adjustment) is accounted
+      -- for elsewhere and must not also land in refunds.
+      AND (coa.account_type IS NULL OR coa.account_type = 'revenue')
       AND NOT EXISTS (
         SELECT 1 FROM unified_sales child
         WHERE child.parent_sale_id = us.id

--- a/supabase/migrations/20260814140000_monthly_sales_metrics_refunds.sql
+++ b/supabase/migrations/20260814140000_monthly_sales_metrics_refunds.sql
@@ -1,0 +1,160 @@
+-- Migration: add a refunds column to get_monthly_sales_metrics
+--
+-- Net sales = gross_revenue - discounts - refunds (spec §5.1 Change B).
+-- The return type changes, so DROP then CREATE. Keep every security property
+-- from migration 20260814120000: SECURITY INVOKER, the membership guard, the
+-- child restaurant_id filters, and the grants.
+
+DROP FUNCTION IF EXISTS public.get_monthly_sales_metrics(UUID, DATE, DATE);
+
+CREATE FUNCTION public.get_monthly_sales_metrics(
+  p_restaurant_id UUID,
+  p_date_from DATE,
+  p_date_to DATE
+)
+RETURNS TABLE (
+  period TEXT,
+  gross_revenue DECIMAL,
+  sales_tax DECIMAL,
+  tips DECIMAL,
+  other_liabilities DECIMAL,
+  discounts DECIMAL,
+  refunds DECIMAL          -- NEW
+)
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path TO 'public'
+AS $function$
+BEGIN
+  -- Authorization check: the caller must be a member of the restaurant.
+  IF NOT EXISTS (
+    SELECT 1 FROM user_restaurants
+    WHERE restaurant_id = p_restaurant_id
+    AND user_id = auth.uid()
+  ) THEN
+    RAISE EXCEPTION 'Access denied: User does not have access to restaurant %', p_restaurant_id;
+  END IF;
+
+  RETURN QUERY
+  WITH monthly_revenue AS (
+    SELECT
+      TO_CHAR(us.sale_date, 'YYYY-MM') as month_period,
+      COALESCE(SUM(us.total_price), 0)::DECIMAL as amount
+    FROM unified_sales us
+    LEFT JOIN chart_of_accounts coa ON us.category_id = coa.id
+    WHERE us.restaurant_id = p_restaurant_id
+      AND us.sale_date >= p_date_from
+      AND us.sale_date <= p_date_to
+      AND us.adjustment_type IS NULL
+      AND LOWER(COALESCE(us.item_type, 'sale')) = 'sale'
+      -- Liability-categorized sales are accounted for in
+      -- monthly_categorized_liabilities; counting them here too caused
+      -- gross_revenue (and therefore total_collected_at_pos) to double-count.
+      -- account_type_enum is (asset, liability, equity, revenue, expense);
+      -- only liability is excluded here. asset/equity/expense are not
+      -- expected on unified_sales rows but pass through if they ever appear.
+      AND (coa.account_type IS NULL OR coa.account_type = 'revenue')
+      AND NOT EXISTS (
+        SELECT 1 FROM unified_sales child
+        WHERE child.parent_sale_id = us.id
+          AND child.restaurant_id = p_restaurant_id
+      )
+    GROUP BY TO_CHAR(us.sale_date, 'YYYY-MM')
+  ),
+  monthly_refunds AS (   -- NEW
+    SELECT TO_CHAR(us.sale_date, 'YYYY-MM') as month_period,
+      COALESCE(SUM(ABS(us.total_price)), 0)::DECIMAL as amount
+    FROM unified_sales us
+    WHERE us.restaurant_id = p_restaurant_id
+      AND us.sale_date >= p_date_from AND us.sale_date <= p_date_to
+      AND us.adjustment_type IS NULL
+      AND LOWER(COALESCE(us.item_type, '')) = 'refund'
+      AND NOT EXISTS (
+        SELECT 1 FROM unified_sales child
+        WHERE child.parent_sale_id = us.id
+          AND child.restaurant_id = p_restaurant_id
+      )
+    GROUP BY TO_CHAR(us.sale_date, 'YYYY-MM')
+  ),
+  monthly_adjustments AS (
+    SELECT
+      TO_CHAR(us.sale_date, 'YYYY-MM') as month_period,
+      us.adjustment_type,
+      COALESCE(SUM(us.total_price), 0)::DECIMAL as amount
+    FROM unified_sales us
+    WHERE us.restaurant_id = p_restaurant_id
+      AND us.sale_date >= p_date_from
+      AND us.sale_date <= p_date_to
+      AND us.adjustment_type IS NOT NULL
+    GROUP BY TO_CHAR(us.sale_date, 'YYYY-MM'), us.adjustment_type
+  ),
+  monthly_categorized_liabilities AS (
+    SELECT
+      TO_CHAR(us.sale_date, 'YYYY-MM') as month_period,
+      CASE
+        WHEN LOWER(COALESCE(coa.account_subtype::TEXT, '')) LIKE '%tax%'
+          OR LOWER(COALESCE(coa.account_name, '')) LIKE '%tax%'
+        THEN 'tax'
+        WHEN LOWER(COALESCE(coa.account_subtype::TEXT, '')) LIKE '%tip%'
+          OR LOWER(COALESCE(coa.account_name, '')) LIKE '%tip%'
+        THEN 'tip'
+        ELSE 'other_liability'
+      END as liability_type,
+      COALESCE(SUM(us.total_price), 0)::DECIMAL as amount
+    FROM unified_sales us
+    INNER JOIN chart_of_accounts coa ON us.category_id = coa.id
+    WHERE us.restaurant_id = p_restaurant_id
+      AND us.sale_date >= p_date_from
+      AND us.sale_date <= p_date_to
+      AND us.adjustment_type IS NULL
+      AND us.is_categorized = TRUE
+      AND coa.account_type = 'liability'
+      AND NOT EXISTS (
+        SELECT 1 FROM unified_sales child
+        WHERE child.parent_sale_id = us.id
+          AND child.restaurant_id = p_restaurant_id
+      )
+    GROUP BY TO_CHAR(us.sale_date, 'YYYY-MM'),
+      CASE
+        WHEN LOWER(COALESCE(coa.account_subtype::TEXT, '')) LIKE '%tax%'
+          OR LOWER(COALESCE(coa.account_name, '')) LIKE '%tax%'
+        THEN 'tax'
+        WHEN LOWER(COALESCE(coa.account_subtype::TEXT, '')) LIKE '%tip%'
+          OR LOWER(COALESCE(coa.account_name, '')) LIKE '%tip%'
+        THEN 'tip'
+        ELSE 'other_liability'
+      END
+  ),
+  all_periods AS (
+    SELECT DISTINCT month_period FROM monthly_revenue
+    UNION SELECT DISTINCT month_period FROM monthly_adjustments
+    UNION SELECT DISTINCT month_period FROM monthly_categorized_liabilities
+    UNION SELECT DISTINCT month_period FROM monthly_refunds   -- NEW
+  )
+  SELECT
+    p.month_period as period,
+    COALESCE(r.amount, 0) as gross_revenue,
+    COALESCE((SELECT SUM(a.amount) FROM monthly_adjustments a WHERE a.month_period = p.month_period AND a.adjustment_type = 'tax'), 0) +
+    COALESCE((SELECT SUM(l.amount) FROM monthly_categorized_liabilities l WHERE l.month_period = p.month_period AND l.liability_type = 'tax'), 0) as sales_tax,
+    COALESCE((SELECT SUM(a.amount) FROM monthly_adjustments a WHERE a.month_period = p.month_period AND a.adjustment_type = 'tip'), 0) +
+    COALESCE((SELECT SUM(l.amount) FROM monthly_categorized_liabilities l WHERE l.month_period = p.month_period AND l.liability_type = 'tip'), 0) as tips,
+    COALESCE((SELECT SUM(a.amount) FROM monthly_adjustments a WHERE a.month_period = p.month_period AND a.adjustment_type IN ('service_charge', 'fee')), 0) +
+    COALESCE((SELECT SUM(l.amount) FROM monthly_categorized_liabilities l WHERE l.month_period = p.month_period AND l.liability_type = 'other_liability'), 0) as other_liabilities,
+    COALESCE((SELECT SUM(ABS(a.amount)) FROM monthly_adjustments a WHERE a.month_period = p.month_period AND a.adjustment_type = 'discount'), 0) as discounts,
+    COALESCE(rf.amount, 0) as refunds   -- NEW
+  FROM all_periods p
+  LEFT JOIN monthly_revenue r ON r.month_period = p.month_period
+  LEFT JOIN monthly_refunds rf ON rf.month_period = p.month_period   -- NEW
+  ORDER BY p.month_period DESC;
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.get_monthly_sales_metrics(UUID, DATE, DATE) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.get_monthly_sales_metrics(UUID, DATE, DATE) FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_monthly_sales_metrics(UUID, DATE, DATE) TO authenticated;
+
+COMMENT ON FUNCTION public.get_monthly_sales_metrics IS
+'Monthly sales metrics from unified_sales: gross_revenue, sales_tax, tips,
+other_liabilities, discounts, refunds. Net sales = gross_revenue - discounts -
+refunds. Runs as SECURITY INVOKER with a user_restaurants membership guard.
+EXECUTE is granted to authenticated only.';

--- a/supabase/migrations/20260814140000_monthly_sales_metrics_refunds.sql
+++ b/supabase/migrations/20260814140000_monthly_sales_metrics_refunds.sql
@@ -19,7 +19,7 @@ RETURNS TABLE (
   tips DECIMAL,
   other_liabilities DECIMAL,
   discounts DECIMAL,
-  refunds DECIMAL          -- NEW
+  refunds DECIMAL
 )
 LANGUAGE plpgsql
 SECURITY INVOKER
@@ -61,7 +61,7 @@ BEGIN
       )
     GROUP BY TO_CHAR(us.sale_date, 'YYYY-MM')
   ),
-  monthly_refunds AS (   -- NEW
+  monthly_refunds AS (
     SELECT TO_CHAR(us.sale_date, 'YYYY-MM') as month_period,
       COALESCE(SUM(ABS(us.total_price)), 0)::DECIMAL as amount
     FROM unified_sales us
@@ -129,7 +129,7 @@ BEGIN
     SELECT DISTINCT month_period FROM monthly_revenue
     UNION SELECT DISTINCT month_period FROM monthly_adjustments
     UNION SELECT DISTINCT month_period FROM monthly_categorized_liabilities
-    UNION SELECT DISTINCT month_period FROM monthly_refunds   -- NEW
+    UNION SELECT DISTINCT month_period FROM monthly_refunds
   )
   SELECT
     p.month_period as period,
@@ -141,10 +141,10 @@ BEGIN
     COALESCE((SELECT SUM(a.amount) FROM monthly_adjustments a WHERE a.month_period = p.month_period AND a.adjustment_type IN ('service_charge', 'fee')), 0) +
     COALESCE((SELECT SUM(l.amount) FROM monthly_categorized_liabilities l WHERE l.month_period = p.month_period AND l.liability_type = 'other_liability'), 0) as other_liabilities,
     COALESCE((SELECT SUM(ABS(a.amount)) FROM monthly_adjustments a WHERE a.month_period = p.month_period AND a.adjustment_type = 'discount'), 0) as discounts,
-    COALESCE(rf.amount, 0) as refunds   -- NEW
+    COALESCE(rf.amount, 0) as refunds
   FROM all_periods p
   LEFT JOIN monthly_revenue r ON r.month_period = p.month_period
-  LEFT JOIN monthly_refunds rf ON rf.month_period = p.month_period   -- NEW
+  LEFT JOIN monthly_refunds rf ON rf.month_period = p.month_period
   ORDER BY p.month_period DESC;
 END;
 $function$;

--- a/supabase/migrations/20260814141000_get_sales_by_category.sql
+++ b/supabase/migrations/20260814141000_get_sales_by_category.sql
@@ -1,0 +1,34 @@
+-- Sales revenue grouped by category for one restaurant and date range.
+-- SECURITY INVOKER: RLS on unified_sales scopes the caller (spec §8).
+CREATE OR REPLACE FUNCTION public.get_sales_by_category(
+  p_restaurant_id UUID, p_start_date DATE, p_end_date DATE
+)
+RETURNS TABLE(category_id UUID, category_name TEXT, revenue NUMERIC, item_count BIGINT)
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path TO 'public'
+AS $$
+  SELECT us.category_id,
+         COALESCE(coa.account_name, 'Uncategorized') AS category_name,
+         COALESCE(SUM(us.total_price), 0)::NUMERIC AS revenue,
+         COUNT(*)::BIGINT AS item_count
+  FROM unified_sales us
+  LEFT JOIN chart_of_accounts coa ON coa.id = us.category_id
+  WHERE us.restaurant_id = p_restaurant_id
+    AND us.sale_date >= p_start_date AND us.sale_date <= p_end_date
+    AND us.adjustment_type IS NULL
+    AND LOWER(COALESCE(us.item_type, 'sale')) = 'sale'
+    AND NOT EXISTS (
+      SELECT 1 FROM unified_sales child
+      WHERE child.parent_sale_id = us.id
+        AND child.restaurant_id = p_restaurant_id)
+  GROUP BY us.category_id, coa.account_name
+  ORDER BY revenue DESC;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_sales_by_category(UUID, DATE, DATE) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.get_sales_by_category(UUID, DATE, DATE) FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_sales_by_category(UUID, DATE, DATE) TO authenticated;
+
+COMMENT ON FUNCTION public.get_sales_by_category IS
+'Revenue by category from unified_sales. Excludes adjustments, refunds, and
+split parents. SECURITY INVOKER; EXECUTE for authenticated only.';

--- a/supabase/migrations/20260814141000_get_sales_by_category.sql
+++ b/supabase/migrations/20260814141000_get_sales_by_category.sql
@@ -12,7 +12,7 @@ AS $$
          COALESCE(SUM(us.total_price), 0)::NUMERIC AS revenue,
          COUNT(*)::BIGINT AS item_count
   FROM unified_sales us
-  LEFT JOIN chart_of_accounts coa ON coa.id = us.category_id
+  LEFT JOIN chart_of_accounts coa ON coa.id = us.category_id AND coa.restaurant_id = p_restaurant_id
   WHERE us.restaurant_id = p_restaurant_id
     AND us.sale_date >= p_start_date AND us.sale_date <= p_end_date
     AND us.adjustment_type IS NULL

--- a/supabase/migrations/20260814142000_get_top_sold_items.sql
+++ b/supabase/migrations/20260814142000_get_top_sold_items.sql
@@ -1,0 +1,32 @@
+CREATE OR REPLACE FUNCTION public.get_top_sold_items(
+  p_restaurant_id UUID, p_start_date DATE, p_end_date DATE, p_limit INT DEFAULT 10
+)
+RETURNS TABLE(item_name TEXT, revenue NUMERIC, quantity NUMERIC, sale_count BIGINT)
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path TO 'public'
+AS $$
+  SELECT us.item_name,
+         COALESCE(SUM(us.total_price), 0)::NUMERIC AS revenue,
+         COALESCE(SUM(us.quantity), 0)::NUMERIC AS quantity,
+         COUNT(*)::BIGINT AS sale_count
+  FROM unified_sales us
+  WHERE us.restaurant_id = p_restaurant_id
+    AND us.sale_date >= p_start_date AND us.sale_date <= p_end_date
+    AND us.adjustment_type IS NULL
+    AND LOWER(COALESCE(us.item_type, 'sale')) = 'sale'
+    AND NOT EXISTS (
+      SELECT 1 FROM unified_sales child
+      WHERE child.parent_sale_id = us.id
+        AND child.restaurant_id = p_restaurant_id)
+  GROUP BY us.item_name
+  ORDER BY revenue DESC
+  LIMIT p_limit;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_top_sold_items(UUID, DATE, DATE, INT) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.get_top_sold_items(UUID, DATE, DATE, INT) FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_top_sold_items(UUID, DATE, DATE, INT) TO authenticated;
+
+COMMENT ON FUNCTION public.get_top_sold_items IS
+'Top items by revenue from unified_sales. Same exclusions as
+get_sales_by_category. SECURITY INVOKER; EXECUTE for authenticated only.';

--- a/supabase/migrations/20260814143000_get_inventory_usage_by_month.sql
+++ b/supabase/migrations/20260814143000_get_inventory_usage_by_month.sql
@@ -1,0 +1,26 @@
+CREATE OR REPLACE FUNCTION public.get_inventory_usage_by_month(
+  p_restaurant_id UUID, p_start_date DATE, p_end_date DATE
+)
+RETURNS TABLE(period TEXT, food_cost NUMERIC)
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path TO 'public'
+AS $$
+  SELECT TO_CHAR(it.created_at AT TIME ZONE 'UTC', 'YYYY-MM') AS period,
+         ABS(COALESCE(SUM(it.total_cost), 0))::NUMERIC AS food_cost
+  FROM inventory_transactions it
+  WHERE it.restaurant_id = p_restaurant_id
+    AND it.transaction_type = 'usage'
+    -- Explicit UTC bounds. Includes the full end day (spec §5.4).
+    AND it.created_at >= (p_start_date::timestamp AT TIME ZONE 'UTC')
+    AND it.created_at < ((p_end_date + 1)::timestamp AT TIME ZONE 'UTC')
+  GROUP BY 1
+  ORDER BY 1;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_inventory_usage_by_month(UUID, DATE, DATE) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.get_inventory_usage_by_month(UUID, DATE, DATE) FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_inventory_usage_by_month(UUID, DATE, DATE) TO authenticated;
+
+COMMENT ON FUNCTION public.get_inventory_usage_by_month IS
+'Monthly COGS from inventory_transactions usage rows, ABS(SUM(total_cost)) per
+month, full end day included, explicit UTC bounds. SECURITY INVOKER.';

--- a/supabase/migrations/20260814144000_get_journal_expense_total.sql
+++ b/supabase/migrations/20260814144000_get_journal_expense_total.sql
@@ -1,0 +1,24 @@
+CREATE OR REPLACE FUNCTION public.get_journal_expense_total(
+  p_restaurant_id UUID, p_start_date DATE, p_end_date DATE
+)
+RETURNS NUMERIC
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path TO 'public'
+AS $$
+  SELECT COALESCE(SUM(jel.debit_amount - jel.credit_amount), 0)::NUMERIC
+  FROM journal_entry_lines jel
+  JOIN journal_entries je ON je.id = jel.journal_entry_id
+  JOIN chart_of_accounts coa ON coa.id = jel.account_id
+  WHERE je.restaurant_id = p_restaurant_id
+    AND coa.restaurant_id = p_restaurant_id
+    AND coa.account_type = 'expense'
+    AND je.entry_date >= p_start_date AND je.entry_date <= p_end_date;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_journal_expense_total(UUID, DATE, DATE) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.get_journal_expense_total(UUID, DATE, DATE) FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_journal_expense_total(UUID, DATE, DATE) TO authenticated;
+
+COMMENT ON FUNCTION public.get_journal_expense_total IS
+'Net expense debits from journal_entry_lines for one restaurant and range.
+Replaces the expense-account id round-trip. SECURITY INVOKER.';

--- a/supabase/migrations/20260814145000_get_inventory_valuation.sql
+++ b/supabase/migrations/20260814145000_get_inventory_valuation.sql
@@ -1,0 +1,19 @@
+CREATE OR REPLACE FUNCTION public.get_inventory_valuation(p_restaurant_id UUID)
+RETURNS TABLE(total_value NUMERIC, item_count BIGINT, low_stock_count BIGINT)
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path TO 'public'
+AS $$
+  SELECT COALESCE(SUM(p.current_stock * p.cost_per_unit), 0)::NUMERIC,
+         COUNT(*)::BIGINT,
+         COUNT(*) FILTER (WHERE p.current_stock <= COALESCE(p.par_level_min, 0))::BIGINT
+  FROM products p
+  WHERE p.restaurant_id = p_restaurant_id;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_inventory_valuation(UUID) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.get_inventory_valuation(UUID) FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_inventory_valuation(UUID) TO authenticated;
+
+COMMENT ON FUNCTION public.get_inventory_valuation IS
+'Inventory value, item count, and low-stock count from products. The low-stock
+predicate is current_stock <= COALESCE(par_level_min, 0). SECURITY INVOKER.';

--- a/supabase/migrations/20260814146000_get_bank_aggregates.sql
+++ b/supabase/migrations/20260814146000_get_bank_aggregates.sql
@@ -1,0 +1,90 @@
+-- Bank transaction aggregates for one restaurant and date range (cluster 6).
+-- SECURITY INVOKER: RLS on bank_transactions scopes the caller (spec §8).
+CREATE OR REPLACE FUNCTION public.get_bank_transaction_summary(
+  p_restaurant_id UUID, p_start_date DATE, p_end_date DATE,
+  p_bank_account_id UUID DEFAULT NULL, p_statuses TEXT[] DEFAULT NULL
+)
+RETURNS TABLE(inflow NUMERIC, outflow NUMERIC, net NUMERIC, tx_count BIGINT,
+              inflow_count BIGINT, outflow_count BIGINT, avg_inflow NUMERIC, max_inflow NUMERIC)
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path TO 'public'
+AS $$
+  SELECT COALESCE(SUM(bt.amount) FILTER (WHERE bt.amount > 0), 0)::NUMERIC,
+         ABS(COALESCE(SUM(bt.amount) FILTER (WHERE bt.amount < 0), 0))::NUMERIC,
+         COALESCE(SUM(bt.amount), 0)::NUMERIC,
+         COUNT(*)::BIGINT,
+         COUNT(*) FILTER (WHERE bt.amount > 0)::BIGINT,
+         COUNT(*) FILTER (WHERE bt.amount < 0)::BIGINT,
+         COALESCE(AVG(bt.amount) FILTER (WHERE bt.amount > 0), 0)::NUMERIC,
+         COALESCE(MAX(bt.amount) FILTER (WHERE bt.amount > 0), 0)::NUMERIC
+  FROM bank_transactions bt
+  WHERE bt.restaurant_id = p_restaurant_id
+    AND bt.transaction_date >= p_start_date AND bt.transaction_date <= p_end_date
+    AND (p_bank_account_id IS NULL OR bt.connected_bank_id = p_bank_account_id)
+    AND (p_statuses IS NULL OR bt.status::text = ANY(p_statuses));
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_bank_spending_by_category(
+  p_restaurant_id UUID, p_start_date DATE, p_end_date DATE, p_statuses TEXT[] DEFAULT NULL
+)
+RETURNS TABLE(category_id UUID, category_name TEXT, spend NUMERIC, tx_count BIGINT)
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path TO 'public'
+AS $$
+  SELECT bt.category_id,
+         COALESCE(coa.account_name, 'Uncategorized'),
+         ABS(COALESCE(SUM(bt.amount), 0))::NUMERIC,
+         COUNT(*)::BIGINT
+  FROM bank_transactions bt
+  LEFT JOIN chart_of_accounts coa ON coa.id = bt.category_id
+  WHERE bt.restaurant_id = p_restaurant_id
+    AND bt.transaction_date >= p_start_date AND bt.transaction_date <= p_end_date
+    AND bt.amount < 0
+    AND (p_statuses IS NULL OR bt.status::text = ANY(p_statuses))
+  GROUP BY bt.category_id, coa.account_name
+  ORDER BY 3 DESC;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_bank_transactions_daily(
+  p_restaurant_id UUID, p_start_date DATE, p_end_date DATE, p_bank_account_id UUID DEFAULT NULL
+)
+RETURNS TABLE(day DATE, inflow NUMERIC, outflow NUMERIC, net NUMERIC)
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path TO 'public'
+AS $$
+  SELECT bt.transaction_date,
+         COALESCE(SUM(bt.amount) FILTER (WHERE bt.amount > 0), 0)::NUMERIC,
+         ABS(COALESCE(SUM(bt.amount) FILTER (WHERE bt.amount < 0), 0))::NUMERIC,
+         COALESCE(SUM(bt.amount), 0)::NUMERIC
+  FROM bank_transactions bt
+  WHERE bt.restaurant_id = p_restaurant_id
+    AND bt.transaction_date >= p_start_date AND bt.transaction_date <= p_end_date
+    AND (p_bank_account_id IS NULL OR bt.connected_bank_id = p_bank_account_id)
+  GROUP BY bt.transaction_date
+  ORDER BY bt.transaction_date;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_bank_transaction_summary(UUID, DATE, DATE, UUID, TEXT[]) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.get_bank_transaction_summary(UUID, DATE, DATE, UUID, TEXT[]) FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_bank_transaction_summary(UUID, DATE, DATE, UUID, TEXT[]) TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.get_bank_spending_by_category(UUID, DATE, DATE, TEXT[]) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.get_bank_spending_by_category(UUID, DATE, DATE, TEXT[]) FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_bank_spending_by_category(UUID, DATE, DATE, TEXT[]) TO authenticated;
+
+REVOKE EXECUTE ON FUNCTION public.get_bank_transactions_daily(UUID, DATE, DATE, UUID) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.get_bank_transactions_daily(UUID, DATE, DATE, UUID) FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_bank_transactions_daily(UUID, DATE, DATE, UUID) TO authenticated;
+
+COMMENT ON FUNCTION public.get_bank_transaction_summary IS
+'Inflow/outflow/net summary over bank_transactions, optionally scoped to one
+connected_bank_id and one set of statuses. SECURITY INVOKER; EXECUTE for
+authenticated only.';
+
+COMMENT ON FUNCTION public.get_bank_spending_by_category IS
+'Spend by category from negative-amount bank_transactions rows. SECURITY
+INVOKER; EXECUTE for authenticated only.';
+
+COMMENT ON FUNCTION public.get_bank_transactions_daily IS
+'Daily inflow/outflow/net series from bank_transactions, optionally scoped
+to one connected_bank_id. SECURITY INVOKER; EXECUTE for authenticated only.';

--- a/supabase/migrations/20260814146000_get_bank_aggregates.sql
+++ b/supabase/migrations/20260814146000_get_bank_aggregates.sql
@@ -1,12 +1,15 @@
 -- Bank transaction aggregates for one restaurant and date range (cluster 6).
 -- SECURITY INVOKER: RLS on bank_transactions scopes the caller (spec §8).
-CREATE OR REPLACE FUNCTION public.get_bank_transaction_summary(
+DROP FUNCTION IF EXISTS public.get_bank_transaction_summary(UUID, DATE, DATE, UUID, TEXT[], NUMERIC);
+
+CREATE FUNCTION public.get_bank_transaction_summary(
   p_restaurant_id UUID, p_start_date DATE, p_end_date DATE,
   p_bank_account_id UUID DEFAULT NULL, p_statuses TEXT[] DEFAULT NULL,
   p_min_inflow NUMERIC DEFAULT NULL
 )
 RETURNS TABLE(inflow NUMERIC, outflow NUMERIC, net NUMERIC, tx_count BIGINT,
-              inflow_count BIGINT, outflow_count BIGINT, avg_inflow NUMERIC, max_inflow NUMERIC)
+              inflow_count BIGINT, outflow_count BIGINT, avg_inflow NUMERIC, max_inflow NUMERIC,
+              floored_inflow NUMERIC)
 LANGUAGE sql STABLE SECURITY INVOKER
 SET search_path TO 'public'
 AS $$
@@ -17,7 +20,8 @@ AS $$
          COUNT(*) FILTER (WHERE bt.amount > 0 AND (p_min_inflow IS NULL OR bt.amount > p_min_inflow))::BIGINT,
          COUNT(*) FILTER (WHERE bt.amount < 0)::BIGINT,
          COALESCE(AVG(bt.amount) FILTER (WHERE bt.amount > 0 AND (p_min_inflow IS NULL OR bt.amount > p_min_inflow)), 0)::NUMERIC,
-         COALESCE(MAX(bt.amount) FILTER (WHERE bt.amount > 0 AND (p_min_inflow IS NULL OR bt.amount > p_min_inflow)), 0)::NUMERIC
+         COALESCE(MAX(bt.amount) FILTER (WHERE bt.amount > 0 AND (p_min_inflow IS NULL OR bt.amount > p_min_inflow)), 0)::NUMERIC,
+         COALESCE(SUM(bt.amount) FILTER (WHERE bt.amount > 0 AND (p_min_inflow IS NULL OR bt.amount > p_min_inflow)), 0)::NUMERIC
   FROM bank_transactions bt
   WHERE bt.restaurant_id = p_restaurant_id
     AND bt.transaction_date >= p_start_date AND bt.transaction_date <= p_end_date
@@ -81,8 +85,11 @@ COMMENT ON FUNCTION public.get_bank_transaction_summary IS
 'Inflow/outflow/net summary over bank_transactions, optionally scoped to one
 connected_bank_id and one set of statuses. p_min_inflow applies a strictly-
 greater-than floor to the deposit metrics only (inflow_count, avg_inflow,
-max_inflow); inflow, outflow, net, tx_count, and outflow_count stay unfloored.
-SECURITY INVOKER; EXECUTE for authenticated only.';
+max_inflow, floored_inflow); inflow, outflow, net, tx_count, and
+outflow_count stay unfloored. floored_inflow is the sum of only the deposits
+that pass the p_min_inflow floor (equal to inflow when p_min_inflow is NULL);
+callers that want a floored revenue total should read floored_inflow instead
+of inflow. SECURITY INVOKER; EXECUTE for authenticated only.';
 
 COMMENT ON FUNCTION public.get_bank_spending_by_category IS
 'Spend by category from negative-amount bank_transactions rows. SECURITY

--- a/supabase/migrations/20260814146000_get_bank_aggregates.sql
+++ b/supabase/migrations/20260814146000_get_bank_aggregates.sql
@@ -2,7 +2,8 @@
 -- SECURITY INVOKER: RLS on bank_transactions scopes the caller (spec §8).
 CREATE OR REPLACE FUNCTION public.get_bank_transaction_summary(
   p_restaurant_id UUID, p_start_date DATE, p_end_date DATE,
-  p_bank_account_id UUID DEFAULT NULL, p_statuses TEXT[] DEFAULT NULL
+  p_bank_account_id UUID DEFAULT NULL, p_statuses TEXT[] DEFAULT NULL,
+  p_min_inflow NUMERIC DEFAULT NULL
 )
 RETURNS TABLE(inflow NUMERIC, outflow NUMERIC, net NUMERIC, tx_count BIGINT,
               inflow_count BIGINT, outflow_count BIGINT, avg_inflow NUMERIC, max_inflow NUMERIC)
@@ -13,10 +14,10 @@ AS $$
          ABS(COALESCE(SUM(bt.amount) FILTER (WHERE bt.amount < 0), 0))::NUMERIC,
          COALESCE(SUM(bt.amount), 0)::NUMERIC,
          COUNT(*)::BIGINT,
-         COUNT(*) FILTER (WHERE bt.amount > 0)::BIGINT,
+         COUNT(*) FILTER (WHERE bt.amount > 0 AND (p_min_inflow IS NULL OR bt.amount > p_min_inflow))::BIGINT,
          COUNT(*) FILTER (WHERE bt.amount < 0)::BIGINT,
-         COALESCE(AVG(bt.amount) FILTER (WHERE bt.amount > 0), 0)::NUMERIC,
-         COALESCE(MAX(bt.amount) FILTER (WHERE bt.amount > 0), 0)::NUMERIC
+         COALESCE(AVG(bt.amount) FILTER (WHERE bt.amount > 0 AND (p_min_inflow IS NULL OR bt.amount > p_min_inflow)), 0)::NUMERIC,
+         COALESCE(MAX(bt.amount) FILTER (WHERE bt.amount > 0 AND (p_min_inflow IS NULL OR bt.amount > p_min_inflow)), 0)::NUMERIC
   FROM bank_transactions bt
   WHERE bt.restaurant_id = p_restaurant_id
     AND bt.transaction_date >= p_start_date AND bt.transaction_date <= p_end_date
@@ -36,7 +37,7 @@ AS $$
          ABS(COALESCE(SUM(bt.amount), 0))::NUMERIC,
          COUNT(*)::BIGINT
   FROM bank_transactions bt
-  LEFT JOIN chart_of_accounts coa ON coa.id = bt.category_id
+  LEFT JOIN chart_of_accounts coa ON coa.id = bt.category_id AND coa.restaurant_id = p_restaurant_id
   WHERE bt.restaurant_id = p_restaurant_id
     AND bt.transaction_date >= p_start_date AND bt.transaction_date <= p_end_date
     AND bt.amount < 0
@@ -64,9 +65,9 @@ AS $$
   ORDER BY bt.transaction_date;
 $$;
 
-REVOKE EXECUTE ON FUNCTION public.get_bank_transaction_summary(UUID, DATE, DATE, UUID, TEXT[]) FROM PUBLIC;
-REVOKE EXECUTE ON FUNCTION public.get_bank_transaction_summary(UUID, DATE, DATE, UUID, TEXT[]) FROM anon;
-GRANT EXECUTE ON FUNCTION public.get_bank_transaction_summary(UUID, DATE, DATE, UUID, TEXT[]) TO authenticated;
+REVOKE EXECUTE ON FUNCTION public.get_bank_transaction_summary(UUID, DATE, DATE, UUID, TEXT[], NUMERIC) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.get_bank_transaction_summary(UUID, DATE, DATE, UUID, TEXT[], NUMERIC) FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_bank_transaction_summary(UUID, DATE, DATE, UUID, TEXT[], NUMERIC) TO authenticated;
 
 REVOKE EXECUTE ON FUNCTION public.get_bank_spending_by_category(UUID, DATE, DATE, TEXT[]) FROM PUBLIC;
 REVOKE EXECUTE ON FUNCTION public.get_bank_spending_by_category(UUID, DATE, DATE, TEXT[]) FROM anon;
@@ -78,8 +79,10 @@ GRANT EXECUTE ON FUNCTION public.get_bank_transactions_daily(UUID, DATE, DATE, U
 
 COMMENT ON FUNCTION public.get_bank_transaction_summary IS
 'Inflow/outflow/net summary over bank_transactions, optionally scoped to one
-connected_bank_id and one set of statuses. SECURITY INVOKER; EXECUTE for
-authenticated only.';
+connected_bank_id and one set of statuses. p_min_inflow applies a strictly-
+greater-than floor to the deposit metrics only (inflow_count, avg_inflow,
+max_inflow); inflow, outflow, net, tx_count, and outflow_count stay unfloored.
+SECURITY INVOKER; EXECUTE for authenticated only.';
 
 COMMENT ON FUNCTION public.get_bank_spending_by_category IS
 'Spend by category from negative-amount bank_transactions rows. SECURITY

--- a/supabase/migrations/20260814147000_get_expense_health_metrics.sql
+++ b/supabase/migrations/20260814147000_get_expense_health_metrics.sql
@@ -28,7 +28,7 @@ AS $$
     ABS(COALESCE(SUM(bt.amount) FILTER (WHERE bt.amount < 0
       AND bt.category_id IS NULL AND COALESCE(bt.is_split, false) = false), 0))::NUMERIC
   FROM bank_transactions bt
-  LEFT JOIN chart_of_accounts coa ON coa.id = bt.category_id
+  LEFT JOIN chart_of_accounts coa ON coa.id = bt.category_id AND coa.restaurant_id = p_restaurant_id
   WHERE bt.restaurant_id = p_restaurant_id
     AND bt.transaction_date >= p_start_date AND bt.transaction_date <= p_end_date
     AND bt.status::text IN ('posted', 'pending')

--- a/supabase/migrations/20260814147000_get_expense_health_metrics.sql
+++ b/supabase/migrations/20260814147000_get_expense_health_metrics.sql
@@ -23,7 +23,10 @@ AS $$
            OR LOWER(COALESCE(coa.account_name, '')) LIKE '%labor%')), 0))::NUMERIC,
     ABS(COALESCE(SUM(bt.amount) FILTER (WHERE bt.amount < 0
       AND LOWER(COALESCE(bt.description, '') || ' ' || COALESCE(bt.merchant_name, ''))
-          LIKE ANY(p_fee_patterns)), 0))::NUMERIC,
+          LIKE ANY(
+            SELECT LOWER(pat)
+            FROM UNNEST(COALESCE(p_fee_patterns, ARRAY[]::TEXT[])) AS pat
+          )), 0))::NUMERIC,
     ABS(COALESCE(SUM(bt.amount) FILTER (WHERE bt.amount < 0), 0))::NUMERIC,
     ABS(COALESCE(SUM(bt.amount) FILTER (WHERE bt.amount < 0
       AND bt.category_id IS NULL AND COALESCE(bt.is_split, false) = false), 0))::NUMERIC

--- a/supabase/migrations/20260814147000_get_expense_health_metrics.sql
+++ b/supabase/migrations/20260814147000_get_expense_health_metrics.sql
@@ -1,0 +1,48 @@
+-- Expense-health aggregate for one restaurant and date range (cluster 6
+-- special aggregate: six sums in one call).
+-- SECURITY INVOKER: RLS on bank_transactions and chart_of_accounts scopes
+-- the caller (spec §8).
+CREATE OR REPLACE FUNCTION public.get_expense_health_metrics(
+  p_restaurant_id UUID, p_start_date DATE, p_end_date DATE,
+  p_fee_patterns TEXT[], p_bank_account_id UUID DEFAULT NULL
+)
+RETURNS TABLE(revenue NUMERIC, food_cost NUMERIC, labor_cost NUMERIC,
+              processing_fees NUMERIC, total_outflows NUMERIC, uncategorized_spend NUMERIC)
+LANGUAGE sql STABLE SECURITY INVOKER
+SET search_path TO 'public'
+AS $$
+  SELECT
+    COALESCE(SUM(bt.amount) FILTER (WHERE bt.amount > 0), 0)::NUMERIC,
+    ABS(COALESCE(SUM(bt.amount) FILTER (WHERE bt.amount < 0
+      AND (coa.account_subtype::text = 'cost_of_goods_sold'
+           OR LOWER(COALESCE(coa.account_name, '')) LIKE '%food%'
+           OR LOWER(COALESCE(coa.account_name, '')) LIKE '%inventory%')), 0))::NUMERIC,
+    ABS(COALESCE(SUM(bt.amount) FILTER (WHERE bt.amount < 0
+      AND (coa.account_subtype::text = 'payroll'
+           OR LOWER(COALESCE(coa.account_name, '')) LIKE '%payroll%'
+           OR LOWER(COALESCE(coa.account_name, '')) LIKE '%labor%')), 0))::NUMERIC,
+    ABS(COALESCE(SUM(bt.amount) FILTER (WHERE bt.amount < 0
+      AND LOWER(COALESCE(bt.description, '') || ' ' || COALESCE(bt.merchant_name, ''))
+          LIKE ANY(p_fee_patterns)), 0))::NUMERIC,
+    ABS(COALESCE(SUM(bt.amount) FILTER (WHERE bt.amount < 0), 0))::NUMERIC,
+    ABS(COALESCE(SUM(bt.amount) FILTER (WHERE bt.amount < 0
+      AND bt.category_id IS NULL AND COALESCE(bt.is_split, false) = false), 0))::NUMERIC
+  FROM bank_transactions bt
+  LEFT JOIN chart_of_accounts coa ON coa.id = bt.category_id
+  WHERE bt.restaurant_id = p_restaurant_id
+    AND bt.transaction_date >= p_start_date AND bt.transaction_date <= p_end_date
+    AND bt.status::text IN ('posted', 'pending')
+    AND (p_bank_account_id IS NULL OR bt.connected_bank_id = p_bank_account_id);
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.get_expense_health_metrics(UUID, DATE, DATE, TEXT[], UUID) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.get_expense_health_metrics(UUID, DATE, DATE, TEXT[], UUID) FROM anon;
+GRANT EXECUTE ON FUNCTION public.get_expense_health_metrics(UUID, DATE, DATE, TEXT[], UUID) TO authenticated;
+
+COMMENT ON FUNCTION public.get_expense_health_metrics IS
+'Revenue, food cost, labor cost, processing fees, total outflows, and
+uncategorized spend over bank_transactions for one restaurant and date
+range, optionally scoped to one connected_bank_id. p_fee_patterns takes
+lowercase LIKE patterns (e.g. ''%stripe%'') matched against the lowercased
+description and merchant_name. SECURITY INVOKER; EXECUTE for authenticated
+only.';

--- a/supabase/migrations/20260814148000_idx_bank_transactions_restaurant_date.sql
+++ b/supabase/migrations/20260814148000_idx_bank_transactions_restaurant_date.sql
@@ -1,0 +1,3 @@
+-- CONCURRENTLY cannot run inside a transaction. No BEGIN in this file.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_bank_transactions_restaurant_date
+  ON bank_transactions(restaurant_id, transaction_date);

--- a/supabase/migrations/20260814148000_idx_bank_transactions_restaurant_date.sql
+++ b/supabase/migrations/20260814148000_idx_bank_transactions_restaurant_date.sql
@@ -1,3 +1,4 @@
+-- supabase: no-transaction
 -- CONCURRENTLY cannot run inside a transaction. No BEGIN in this file.
 CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_bank_transactions_restaurant_date
   ON bank_transactions(restaurant_id, transaction_date);

--- a/supabase/tests/36_monthly_sales_metrics_revenue_filter.sql
+++ b/supabase/tests/36_monthly_sales_metrics_revenue_filter.sql
@@ -4,7 +4,7 @@
 -- restricts gross_revenue to revenue-categorized + uncategorized sales only.
 
 BEGIN;
-SELECT plan(5);
+SELECT plan(7);
 
 -- get_monthly_sales_metrics now runs as SECURITY INVOKER and checks
 -- user_restaurants membership. The test caller must be an authenticated
@@ -102,6 +102,32 @@ SELECT is(
    WHERE period = '2026-04'),
   150.00::numeric,
   'uncategorized sales still count toward gross_revenue (NULL category_id pass-through)'
+);
+
+-- A $20 refund row must land in the refunds column, not in gross_revenue.
+INSERT INTO unified_sales (
+  id, restaurant_id, pos_system, external_order_id, external_item_id, item_name,
+  quantity, unit_price, total_price, sale_date, item_type,
+  is_categorized, category_id, adjustment_type, parent_sale_id
+) VALUES
+  ('00000000-0000-0000-0000-000000000704', :'restaurant_id', 'test', 'ord-rf-1', 'item-rf-1',
+    'Refunded Burger', 1, -20, -20, '2026-04-16', 'refund', false,
+    NULL, NULL, NULL);
+
+SELECT is(
+  (SELECT refunds::numeric(10,2)
+   FROM get_monthly_sales_metrics(:'restaurant_id', :'date_from', :'date_to')
+   WHERE period = '2026-04'),
+  20.00::numeric,
+  'a refund row lands in the refunds column as a positive amount'
+);
+
+SELECT is(
+  (SELECT gross_revenue::numeric(10,2)
+   FROM get_monthly_sales_metrics(:'restaurant_id', :'date_from', :'date_to')
+   WHERE period = '2026-04'),
+  150.00::numeric,
+  'a refund row does not change gross_revenue'
 );
 
 -- Cross-restaurant child boundary (defense in depth for the BYPASSRLS path).

--- a/supabase/tests/36_monthly_sales_metrics_revenue_filter.sql
+++ b/supabase/tests/36_monthly_sales_metrics_revenue_filter.sql
@@ -4,7 +4,7 @@
 -- restricts gross_revenue to revenue-categorized + uncategorized sales only.
 
 BEGIN;
-SELECT plan(7);
+SELECT plan(8);
 
 -- get_monthly_sales_metrics now runs as SECURITY INVOKER and checks
 -- user_restaurants membership. The test caller must be an authenticated
@@ -128,6 +128,27 @@ SELECT is(
    WHERE period = '2026-04'),
   150.00::numeric,
   'a refund row does not change gross_revenue'
+);
+
+-- A liability-categorized refund (e.g. a sales-tax reversal) must not land
+-- in refunds, mirroring monthly_revenue's liability exclusion. Without the
+-- chart_of_accounts join on monthly_refunds, this $5 refund would push
+-- refunds to 25.00 instead of staying at 20.00.
+INSERT INTO unified_sales (
+  id, restaurant_id, pos_system, external_order_id, external_item_id, item_name,
+  quantity, unit_price, total_price, sale_date, item_type,
+  is_categorized, category_id, adjustment_type, parent_sale_id
+) VALUES
+  ('00000000-0000-0000-0000-000000000705', :'restaurant_id', 'test', 'ord-rf-2', 'item-rf-2',
+    'Sales Tax Refund', 1, -5, -5, '2026-04-17', 'refund', true,
+    '00000000-0000-0000-0000-000000000602', NULL, NULL);
+
+SELECT is(
+  (SELECT refunds::numeric(10,2)
+   FROM get_monthly_sales_metrics(:'restaurant_id', :'date_from', :'date_to')
+   WHERE period = '2026-04'),
+  20.00::numeric,
+  'a liability-categorized refund does not land in refunds (stays at 20.00, not 25.00)'
 );
 
 -- Cross-restaurant child boundary (defense in depth for the BYPASSRLS path).

--- a/supabase/tests/38_sales_breakdown_rpcs.sql
+++ b/supabase/tests/38_sales_breakdown_rpcs.sql
@@ -1,0 +1,158 @@
+-- Tests get_sales_by_category and get_top_sold_items (cluster 2 aggregates).
+-- Both RPCs run as SECURITY INVOKER: RLS on unified_sales scopes the caller
+-- (spec §8), so a non-member simply sees zero rows rather than an error.
+
+BEGIN;
+SELECT plan(6);
+
+-- Fixtures insert as the session role (postgres, BYPASSRLS). RLS stays on.
+INSERT INTO auth.users (id, email) VALUES
+  ('00000000-0000-0000-0000-000000000241'::uuid, 'sales-breakdown-member@example.com')
+ON CONFLICT (id) DO UPDATE SET email = EXCLUDED.email;
+
+SELECT
+  '00000000-0000-0000-0000-000000000240'::uuid AS restaurant_id,
+  '00000000-0000-0000-0000-000000000242'::uuid AS foreign_restaurant_id,
+  '2026-04-01'::date AS date_from,
+  '2026-04-30'::date AS date_to
+\gset
+
+-- Clean baseline
+DELETE FROM unified_sales WHERE restaurant_id IN (:'restaurant_id', :'foreign_restaurant_id');
+DELETE FROM chart_of_accounts WHERE restaurant_id = :'restaurant_id';
+
+INSERT INTO restaurants (id, name) VALUES
+  (:'restaurant_id', 'Sales Breakdown Test'),
+  (:'foreign_restaurant_id', 'Sales Breakdown Foreign Restaurant')
+ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name;
+
+-- The member belongs only to the primary restaurant.
+INSERT INTO user_restaurants (user_id, restaurant_id, role) VALUES
+  ('00000000-0000-0000-0000-000000000241'::uuid, :'restaurant_id', 'owner')
+ON CONFLICT (user_id, restaurant_id) DO UPDATE SET role = EXCLUDED.role;
+
+-- Two revenue categories.
+INSERT INTO chart_of_accounts (id, restaurant_id, account_code, account_name, account_type, account_subtype, normal_balance)
+VALUES
+  ('00000000-0000-0000-0000-000000000611', :'restaurant_id', '4000', 'Food Sales', 'revenue', 'food_sales', 'credit'),
+  ('00000000-0000-0000-0000-000000000612', :'restaurant_id', '4100', 'Beverage Sales', 'revenue', 'beverage_sales', 'credit')
+ON CONFLICT DO NOTHING;
+
+-- Fixture for tests 1 and 2: two categorized sales ($100 Food, $30
+-- Beverage), one uncategorized sale ($20), a tax-adjustment row ($8, in
+-- Food), and a split parent ($40) + child ($15) pair (both in Food). The
+-- tax row and the split parent must not contribute to Food Sales revenue;
+-- the split child (it has no child of its own) must still count.
+INSERT INTO unified_sales (
+  id, restaurant_id, pos_system, external_order_id, external_item_id, item_name,
+  quantity, unit_price, total_price, sale_date, item_type,
+  is_categorized, category_id, adjustment_type, parent_sale_id
+) VALUES
+  ('00000000-0000-0000-0000-000000000711', :'restaurant_id', 'test', 'ord-1', 'item-1',
+    'Burger', 1, 100, 100, '2026-04-15', 'sale', true,
+    '00000000-0000-0000-0000-000000000611', NULL, NULL),
+  ('00000000-0000-0000-0000-000000000712', :'restaurant_id', 'test', 'ord-2', 'item-2',
+    'Soda', 1, 30, 30, '2026-04-15', 'sale', true,
+    '00000000-0000-0000-0000-000000000612', NULL, NULL),
+  ('00000000-0000-0000-0000-000000000713', :'restaurant_id', 'test', 'ord-3', 'item-3',
+    'Uncategorized Item', 1, 20, 20, '2026-04-15', 'sale', false,
+    NULL, NULL, NULL),
+  ('00000000-0000-0000-0000-000000000714', :'restaurant_id', 'test', 'ord-4', 'item-4',
+    'POS Sales Tax', 1, 8, 8, '2026-04-15', 'sale', true,
+    '00000000-0000-0000-0000-000000000611', 'tax', NULL),
+  ('00000000-0000-0000-0000-000000000715', :'restaurant_id', 'test', 'ord-5', 'item-5',
+    'Split Parent', 1, 40, 40, '2026-04-15', 'sale', true,
+    '00000000-0000-0000-0000-000000000611', NULL, NULL),
+  ('00000000-0000-0000-0000-000000000716', :'restaurant_id', 'test', 'ord-5', 'item-5-split',
+    'Split Child', 1, 15, 15, '2026-04-15', 'sale', true,
+    '00000000-0000-0000-0000-000000000611', NULL, '00000000-0000-0000-0000-000000000715');
+
+-- Test 1: get_sales_by_category runs without error.
+SELECT lives_ok(
+  $$ SELECT * FROM get_sales_by_category(
+       '00000000-0000-0000-0000-000000000240'::uuid,
+       '2026-04-01'::date, '2026-04-30'::date) $$,
+  'get_sales_by_category runs without error'
+);
+
+-- Test 2: it groups the categorized and uncategorized sales into the right
+-- buckets, and excludes the adjustment_type='tax' row and the split parent
+-- row. Food Sales = 100 (Burger) + 15 (split child); the 8 tax row and the
+-- 40 split parent are both left out.
+SELECT is(
+  (SELECT STRING_AGG(category_name || ':' || revenue::numeric(10,2)::text, ',' ORDER BY revenue DESC)
+   FROM get_sales_by_category(:'restaurant_id', :'date_from', :'date_to')),
+  'Food Sales:115.00,Beverage Sales:30.00,Uncategorized:20.00',
+  'get_sales_by_category groups sales into the right buckets and excludes a tax row and a split parent row'
+);
+
+-- Fixture for tests 3 and 4: three distinct items with descending revenue.
+DELETE FROM unified_sales WHERE restaurant_id = :'restaurant_id';
+
+INSERT INTO unified_sales (
+  id, restaurant_id, pos_system, external_order_id, external_item_id, item_name,
+  quantity, unit_price, total_price, sale_date, item_type,
+  is_categorized, category_id, adjustment_type, parent_sale_id
+) VALUES
+  ('00000000-0000-0000-0000-000000000721', :'restaurant_id', 'test', 'ord-t1', 'item-t1',
+    'Top Item A', 1, 300, 300, '2026-04-16', 'sale', true,
+    '00000000-0000-0000-0000-000000000611', NULL, NULL),
+  ('00000000-0000-0000-0000-000000000722', :'restaurant_id', 'test', 'ord-t2', 'item-t2',
+    'Top Item B', 1, 200, 200, '2026-04-16', 'sale', true,
+    '00000000-0000-0000-0000-000000000611', NULL, NULL),
+  ('00000000-0000-0000-0000-000000000723', :'restaurant_id', 'test', 'ord-t3', 'item-t3',
+    'Top Item C', 1, 100, 100, '2026-04-16', 'sale', true,
+    '00000000-0000-0000-0000-000000000611', NULL, NULL);
+
+-- Test 3: get_top_sold_items orders by revenue and honors p_limit.
+SELECT results_eq(
+  $$ SELECT item_name FROM get_top_sold_items(
+       '00000000-0000-0000-0000-000000000240'::uuid,
+       '2026-04-01'::date, '2026-04-30'::date, 2) $$,
+  $$ VALUES ('Top Item A'::text), ('Top Item B'::text) $$,
+  'get_top_sold_items orders by revenue and honors p_limit => 2, top first'
+);
+
+-- A foreign restaurant's row must never contribute to the caller's totals.
+INSERT INTO unified_sales (
+  id, restaurant_id, pos_system, external_order_id, external_item_id, item_name,
+  quantity, unit_price, total_price, sale_date, item_type,
+  is_categorized, category_id, adjustment_type, parent_sale_id
+) VALUES
+  ('00000000-0000-0000-0000-000000000731', :'foreign_restaurant_id', 'test', 'ord-f1', 'item-f1',
+    'Foreign Item', 1, 500, 500, '2026-04-16', 'sale', false,
+    NULL, NULL, NULL);
+
+-- Test 4: the second restaurant's row does not contribute (still 3 rows,
+-- not 4, and the foreign $500 item never outranks the caller's own items).
+SELECT is(
+  (SELECT COUNT(*)::int FROM get_top_sold_items(:'restaurant_id', :'date_from', :'date_to', 10)),
+  3,
+  'a second restaurant''s rows never contribute to get_top_sold_items'
+);
+
+-- Test 5: tenancy. A non-member sees zero rows for the foreign restaurant.
+SET LOCAL ROLE authenticated;
+SET LOCAL request.jwt.claims = '{"sub":"00000000-0000-0000-0000-000000000241","role":"authenticated"}';
+
+SELECT is(
+  (SELECT COUNT(*)::int FROM get_sales_by_category(:'foreign_restaurant_id', :'date_from', :'date_to')),
+  0,
+  'a non-member sees zero rows for the foreign restaurant (RLS scopes the caller)'
+);
+
+RESET ROLE;
+RESET request.jwt.claims;
+
+-- Test 6: the anon role cannot EXECUTE the function.
+SELECT is(
+  has_function_privilege(
+    'anon',
+    'public.get_sales_by_category(uuid,date,date)',
+    'EXECUTE'),
+  false,
+  'anon cannot EXECUTE get_sales_by_category'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/39_inventory_usage_by_month.sql
+++ b/supabase/tests/39_inventory_usage_by_month.sql
@@ -1,0 +1,125 @@
+-- Tests get_inventory_usage_by_month (cluster 3, COGS aggregate).
+-- The RPC runs as SECURITY INVOKER: RLS on inventory_transactions scopes the
+-- caller (spec §1.3/§5.4), so a non-member simply sees zero rows rather than
+-- an error.
+--
+-- Assertions:
+--   1. Two usage rows in one month sum with ABS(SUM()) semantics: -10 and +2
+--      give food_cost 8, not 12.
+--   2. A non-usage row (transaction_type = 'purchase') is excluded.
+--   3. Boundary: a usage row late on the END day
+--      (created_at = (p_end_date || ' 21:00:00+00')::timestamptz) contributes.
+--   4. An empty month range returns zero rows without an error.
+--   5. Tenancy: a non-member under authenticated gets zero rows for a
+--      foreign restaurant.
+
+BEGIN;
+SELECT plan(5);
+
+-- Fixtures insert as the session role (postgres, BYPASSRLS). RLS stays on.
+INSERT INTO auth.users (id, email) VALUES
+  ('00000000-0000-0000-0000-000000000251'::uuid, 'inv-usage-member@example.com')
+ON CONFLICT (id) DO UPDATE SET email = EXCLUDED.email;
+
+INSERT INTO restaurants (id, name) VALUES
+  ('00000000-0000-0000-0000-000000000250'::uuid, 'Inventory Usage Test Restaurant'),
+  ('00000000-0000-0000-0000-000000000252'::uuid, 'Inventory Usage Foreign Restaurant')
+ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name;
+
+-- The member belongs only to the primary restaurant, not the foreign one.
+INSERT INTO user_restaurants (user_id, restaurant_id, role) VALUES
+  ('00000000-0000-0000-0000-000000000251'::uuid,
+   '00000000-0000-0000-0000-000000000250'::uuid, 'owner')
+ON CONFLICT (user_id, restaurant_id) DO UPDATE SET role = EXCLUDED.role;
+
+INSERT INTO products (id, restaurant_id, sku, name) VALUES
+  ('00000000-0000-0000-0000-000000000253'::uuid,
+   '00000000-0000-0000-0000-000000000250'::uuid, 'INV-USAGE-SKU-1', 'Inventory Usage Test Product'),
+  ('00000000-0000-0000-0000-000000000254'::uuid,
+   '00000000-0000-0000-0000-000000000252'::uuid, 'INV-USAGE-SKU-2', 'Inventory Usage Foreign Product')
+ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name;
+
+-- Restaurant 250, April: a usage row and a reversal usage row (assertion 1).
+-- Restaurant 250, May: a purchase-only row (assertion 2).
+-- Restaurant 250, June: a usage row late on the end day (assertion 3).
+-- Restaurant 250, July: no rows at all (assertion 4).
+-- Restaurant 252, June: a usage row a non-member must not see (assertion 5).
+INSERT INTO inventory_transactions
+  (id, restaurant_id, product_id, transaction_type, quantity, total_cost, created_at)
+VALUES
+  ('00000000-0000-0000-0000-000000000255'::uuid,
+   '00000000-0000-0000-0000-000000000250'::uuid,
+   '00000000-0000-0000-0000-000000000253'::uuid,
+   'usage', -10, -10, '2026-04-05 10:00:00+00'::timestamptz),
+  ('00000000-0000-0000-0000-000000000256'::uuid,
+   '00000000-0000-0000-0000-000000000250'::uuid,
+   '00000000-0000-0000-0000-000000000253'::uuid,
+   'usage', 2, 2, '2026-04-06 10:00:00+00'::timestamptz),
+  ('00000000-0000-0000-0000-000000000257'::uuid,
+   '00000000-0000-0000-0000-000000000250'::uuid,
+   '00000000-0000-0000-0000-000000000253'::uuid,
+   'purchase', 100, 500, '2026-05-10 10:00:00+00'::timestamptz),
+  ('00000000-0000-0000-0000-000000000258'::uuid,
+   '00000000-0000-0000-0000-000000000250'::uuid,
+   '00000000-0000-0000-0000-000000000253'::uuid,
+   'usage', -50, -50, ('2026-06-30' || ' 21:00:00+00')::timestamptz),
+  ('00000000-0000-0000-0000-000000000259'::uuid,
+   '00000000-0000-0000-0000-000000000252'::uuid,
+   '00000000-0000-0000-0000-000000000254'::uuid,
+   'usage', -75, -75, '2026-06-15 10:00:00+00'::timestamptz)
+ON CONFLICT (id) DO UPDATE SET
+  transaction_type = EXCLUDED.transaction_type,
+  total_cost = EXCLUDED.total_cost,
+  created_at = EXCLUDED.created_at;
+
+-- Run as the real caller role, authenticated, with RLS active.
+SET LOCAL ROLE authenticated;
+SET LOCAL request.jwt.claims = '{"sub":"00000000-0000-0000-0000-000000000251","role":"authenticated"}';
+
+-- Test 1: two usage rows in one month sum with ABS(SUM()) semantics.
+SELECT results_eq(
+  $$ SELECT period, food_cost FROM get_inventory_usage_by_month(
+       '00000000-0000-0000-0000-000000000250'::uuid,
+       '2026-04-01'::date, '2026-04-30'::date) $$,
+  $$ VALUES ('2026-04'::text, 8::numeric) $$,
+  'A -10 usage row and a +2 reversal row give food_cost 8, not 12'
+);
+
+-- Test 2: a non-usage row (purchase) is excluded.
+SELECT is_empty(
+  $$ SELECT * FROM get_inventory_usage_by_month(
+       '00000000-0000-0000-0000-000000000250'::uuid,
+       '2026-05-01'::date, '2026-05-31'::date) $$,
+  'A purchase-type row is excluded: a month with only a purchase returns no rows'
+);
+
+-- Test 3: boundary. A usage row late on the END day contributes.
+SELECT results_eq(
+  $$ SELECT period, food_cost FROM get_inventory_usage_by_month(
+       '00000000-0000-0000-0000-000000000250'::uuid,
+       '2026-06-01'::date, '2026-06-30'::date) $$,
+  $$ VALUES ('2026-06'::text, 50::numeric) $$,
+  'A usage row at 21:00 UTC on the end day is included in the month sum'
+);
+
+-- Test 4: an empty month range returns zero rows without an error.
+SELECT is_empty(
+  $$ SELECT * FROM get_inventory_usage_by_month(
+       '00000000-0000-0000-0000-000000000250'::uuid,
+       '2026-07-01'::date, '2026-07-31'::date) $$,
+  'An empty month range returns zero rows without an error'
+);
+
+-- Test 5: tenancy. A non-member gets zero rows for a foreign restaurant.
+SELECT is_empty(
+  $$ SELECT * FROM get_inventory_usage_by_month(
+       '00000000-0000-0000-0000-000000000252'::uuid,
+       '2026-06-01'::date, '2026-06-30'::date) $$,
+  'A non-member gets zero rows for a foreign restaurant'
+);
+
+RESET ROLE;
+RESET request.jwt.claims;
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/40_journal_expense_total.sql
+++ b/supabase/tests/40_journal_expense_total.sql
@@ -1,0 +1,128 @@
+-- Tests get_journal_expense_total (cluster 4, OpEx aggregate).
+-- The RPC runs as SECURITY INVOKER: RLS on journal_entries,
+-- journal_entry_lines, and chart_of_accounts scopes the caller, so a
+-- non-member sees a zero total rather than an error (no explicit guard).
+--
+-- Assertions:
+--   1. Two expense-account lines net to SUM(debit_amount - credit_amount).
+--   2. A revenue-account line does not contribute to the expense total.
+--   3. An empty date range (no journal entries at all) returns 0, not NULL.
+--   4. Tenancy: a non-member gets 0 for a restaurant with real expense
+--      data — RLS hides the joined rows.
+
+BEGIN;
+SELECT plan(4);
+
+-- Fixtures insert as the session role (postgres, BYPASSRLS). RLS stays on.
+INSERT INTO auth.users (id, email) VALUES
+  ('00000000-0000-0000-0000-000000000261'::uuid, 'journal-expense-member@example.com')
+ON CONFLICT (id) DO UPDATE SET email = EXCLUDED.email;
+
+INSERT INTO restaurants (id, name) VALUES
+  ('00000000-0000-0000-0000-000000000260'::uuid, 'Journal Expense Total Test'),
+  ('00000000-0000-0000-0000-000000000262'::uuid, 'Journal Expense Total Foreign Restaurant')
+ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name;
+
+-- The member belongs only to the primary restaurant, not the foreign one.
+INSERT INTO user_restaurants (user_id, restaurant_id, role) VALUES
+  ('00000000-0000-0000-0000-000000000261'::uuid,
+   '00000000-0000-0000-0000-000000000260'::uuid, 'owner')
+ON CONFLICT (user_id, restaurant_id) DO UPDATE SET role = EXCLUDED.role;
+
+-- Chart of accounts: an expense and a revenue account for the primary
+-- restaurant, and an expense account for the foreign restaurant.
+INSERT INTO chart_of_accounts
+  (id, restaurant_id, account_code, account_name, account_type, account_subtype, normal_balance)
+VALUES
+  ('00000000-0000-0000-0000-000000000263'::uuid,
+   '00000000-0000-0000-0000-000000000260'::uuid, '5000', 'Rent Expense', 'expense', 'rent', 'debit'),
+  ('00000000-0000-0000-0000-000000000264'::uuid,
+   '00000000-0000-0000-0000-000000000260'::uuid, '4000', 'Food Sales', 'revenue', 'food_sales', 'credit'),
+  ('00000000-0000-0000-0000-000000000270'::uuid,
+   '00000000-0000-0000-0000-000000000262'::uuid, '5000', 'Rent Expense', 'expense', 'rent', 'debit')
+ON CONFLICT (id) DO UPDATE SET account_name = EXCLUDED.account_name;
+
+-- Journal entries:
+--   JE 265 (primary restaurant, April) — two expense lines, assertion 1.
+--   JE 268 (primary restaurant, May)   — one revenue line only, assertion 2.
+--   JE 271 (foreign restaurant, April) — one expense line, real data that
+--     RLS must hide from a non-member, assertion 4.
+INSERT INTO journal_entries
+  (id, restaurant_id, entry_number, entry_date, description, total_debit, total_credit)
+VALUES
+  ('00000000-0000-0000-0000-000000000265'::uuid,
+   '00000000-0000-0000-0000-000000000260'::uuid, 'JE-260-001', '2026-04-15',
+   'Two expense lines', 500, 200),
+  ('00000000-0000-0000-0000-000000000268'::uuid,
+   '00000000-0000-0000-0000-000000000260'::uuid, 'JE-260-002', '2026-05-15',
+   'Revenue only, no expense lines', 0, 1000),
+  ('00000000-0000-0000-0000-000000000271'::uuid,
+   '00000000-0000-0000-0000-000000000262'::uuid, 'JE-262-001', '2026-04-15',
+   'Foreign restaurant expense', 400, 0)
+ON CONFLICT (id) DO UPDATE SET description = EXCLUDED.description;
+
+INSERT INTO journal_entry_lines
+  (id, journal_entry_id, account_id, debit_amount, credit_amount)
+VALUES
+  ('00000000-0000-0000-0000-000000000266'::uuid,
+   '00000000-0000-0000-0000-000000000265'::uuid,
+   '00000000-0000-0000-0000-000000000263'::uuid, 500, 0),
+  ('00000000-0000-0000-0000-000000000267'::uuid,
+   '00000000-0000-0000-0000-000000000265'::uuid,
+   '00000000-0000-0000-0000-000000000263'::uuid, 0, 200),
+  ('00000000-0000-0000-0000-000000000269'::uuid,
+   '00000000-0000-0000-0000-000000000268'::uuid,
+   '00000000-0000-0000-0000-000000000264'::uuid, 0, 1000),
+  ('00000000-0000-0000-0000-000000000272'::uuid,
+   '00000000-0000-0000-0000-000000000271'::uuid,
+   '00000000-0000-0000-0000-000000000270'::uuid, 400, 0)
+ON CONFLICT (id) DO UPDATE SET
+  debit_amount = EXCLUDED.debit_amount,
+  credit_amount = EXCLUDED.credit_amount;
+
+-- Run as the real caller role, authenticated, with RLS active.
+SET LOCAL ROLE authenticated;
+SET LOCAL request.jwt.claims = '{"sub":"00000000-0000-0000-0000-000000000261","role":"authenticated"}';
+
+-- Test 1: two expense-account lines net to SUM(debit_amount - credit_amount).
+SELECT is(
+  get_journal_expense_total(
+    '00000000-0000-0000-0000-000000000260'::uuid,
+    '2026-04-01'::date, '2026-04-30'::date),
+  300::numeric,
+  'Two expense lines net to debit minus credit: 500 - 200 = 300'
+);
+
+-- Test 2: a revenue-account line does not contribute to the expense total.
+SELECT is(
+  get_journal_expense_total(
+    '00000000-0000-0000-0000-000000000260'::uuid,
+    '2026-05-01'::date, '2026-05-31'::date),
+  0::numeric,
+  'A revenue-account line is excluded from the expense total'
+);
+
+-- Test 3: an empty date range (no journal entries at all) returns 0, not NULL.
+SELECT is(
+  get_journal_expense_total(
+    '00000000-0000-0000-0000-000000000260'::uuid,
+    '2026-06-01'::date, '2026-06-30'::date),
+  0::numeric,
+  'An empty date range returns 0, not NULL'
+);
+
+-- Test 4: tenancy. A non-member gets 0 for the foreign restaurant even
+-- though it has real expense data ($400) — RLS hides the joined rows.
+SELECT is(
+  get_journal_expense_total(
+    '00000000-0000-0000-0000-000000000262'::uuid,
+    '2026-04-01'::date, '2026-04-30'::date),
+  0::numeric,
+  'A non-member gets 0 for a foreign restaurant with real expense data'
+);
+
+RESET ROLE;
+RESET request.jwt.claims;
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/41_inventory_valuation.sql
+++ b/supabase/tests/41_inventory_valuation.sql
@@ -7,17 +7,18 @@
 -- Assertions:
 --   1. total_value sums current_stock * cost_per_unit across a 2-product
 --      fixture.
---   2. low_stock_count uses current_stock <= COALESCE(par_level_min, 0): a
+--   2. item_count counts the rows in the 2-product fixture.
+--   3. low_stock_count uses current_stock <= COALESCE(par_level_min, 0): a
 --      product with par_level_min NULL and current_stock 0 counts as low
 --      stock; a product with stock 5 does not.
---   3. An empty restaurant (no products) returns one row of zeros, not an
+--   4. An empty restaurant (no products) returns one row of zeros, not an
 --      empty result.
---   4. Tenancy: a non-member gets one row of zeros for a foreign restaurant
+--   5. Tenancy: a non-member gets one row of zeros for a foreign restaurant
 --      that holds real product data (RLS hides the rows; the aggregate
 --      still returns a row).
 
 BEGIN;
-SELECT plan(4);
+SELECT plan(5);
 
 -- Fixtures insert as the session role (postgres, BYPASSRLS). RLS stays on.
 INSERT INTO auth.users (id, email) VALUES
@@ -79,7 +80,15 @@ SELECT results_eq(
   'total_value sums current_stock * cost_per_unit across the 2-product fixture'
 );
 
--- Test 2: low_stock_count treats a NULL par_level_min as 0 in the
+-- Test 2: item_count counts the rows in the 2-product fixture.
+SELECT results_eq(
+  $$ SELECT item_count FROM get_inventory_valuation(
+       '00000000-0000-0000-0000-000000000280'::uuid) $$,
+  $$ VALUES (2::bigint) $$,
+  'item_count counts the rows in the 2-product fixture'
+);
+
+-- Test 3: low_stock_count treats a NULL par_level_min as 0 in the
 -- comparison — stock 0 counts as low stock, stock 5 does not.
 SELECT results_eq(
   $$ SELECT low_stock_count FROM get_inventory_valuation(
@@ -88,7 +97,7 @@ SELECT results_eq(
   'low_stock_count counts a NULL-par product at stock 0 but not one at stock 5'
 );
 
--- Test 3: an empty restaurant returns one row of zeros, not an empty result.
+-- Test 4: an empty restaurant returns one row of zeros, not an empty result.
 SELECT results_eq(
   $$ SELECT total_value, item_count, low_stock_count FROM get_inventory_valuation(
        '00000000-0000-0000-0000-000000000282'::uuid) $$,
@@ -96,7 +105,7 @@ SELECT results_eq(
   'An empty restaurant returns one row of zeros, not an empty result'
 );
 
--- Test 4: tenancy. A non-member gets one row of zeros for a foreign
+-- Test 5: tenancy. A non-member gets one row of zeros for a foreign
 -- restaurant that holds real product data — RLS hides the rows, but the
 -- aggregate still returns a row.
 SELECT results_eq(

--- a/supabase/tests/41_inventory_valuation.sql
+++ b/supabase/tests/41_inventory_valuation.sql
@@ -1,0 +1,113 @@
+-- Tests get_inventory_valuation (cluster 5, inventory aggregate over products).
+-- The RPC runs as SECURITY INVOKER: RLS on products scopes the caller, so a
+-- non-member simply sees one row of zeros for a foreign restaurant, not an
+-- error and not an empty result (COUNT/SUM without GROUP BY always return a
+-- row).
+--
+-- Assertions:
+--   1. total_value sums current_stock * cost_per_unit across a 2-product
+--      fixture.
+--   2. low_stock_count uses current_stock <= COALESCE(par_level_min, 0): a
+--      product with par_level_min NULL and current_stock 0 counts as low
+--      stock; a product with stock 5 does not.
+--   3. An empty restaurant (no products) returns one row of zeros, not an
+--      empty result.
+--   4. Tenancy: a non-member gets one row of zeros for a foreign restaurant
+--      that holds real product data (RLS hides the rows; the aggregate
+--      still returns a row).
+
+BEGIN;
+SELECT plan(4);
+
+-- Fixtures insert as the session role (postgres, BYPASSRLS). RLS stays on.
+INSERT INTO auth.users (id, email) VALUES
+  ('00000000-0000-0000-0000-000000000284'::uuid, 'inv-valuation-member@example.com')
+ON CONFLICT (id) DO UPDATE SET email = EXCLUDED.email;
+
+INSERT INTO restaurants (id, name) VALUES
+  ('00000000-0000-0000-0000-000000000280'::uuid, 'Inventory Valuation Test Restaurant'),
+  ('00000000-0000-0000-0000-000000000281'::uuid, 'Inventory Valuation Foreign Restaurant'),
+  ('00000000-0000-0000-0000-000000000282'::uuid, 'Inventory Valuation Empty Restaurant')
+ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name;
+
+-- The member belongs to the primary and the empty restaurant, not the
+-- foreign one.
+INSERT INTO user_restaurants (user_id, restaurant_id, role) VALUES
+  ('00000000-0000-0000-0000-000000000284'::uuid,
+   '00000000-0000-0000-0000-000000000280'::uuid, 'owner'),
+  ('00000000-0000-0000-0000-000000000284'::uuid,
+   '00000000-0000-0000-0000-000000000282'::uuid, 'owner')
+ON CONFLICT (user_id, restaurant_id) DO UPDATE SET role = EXCLUDED.role;
+
+-- Primary restaurant: two products.
+--   - Product A: stock 5, cost 10.00, par_level_min NULL -> not low stock
+--     (5 <= COALESCE(NULL, 0) is false).
+--   - Product B: stock 0, cost 3.50, par_level_min NULL -> low stock
+--     (0 <= COALESCE(NULL, 0) is true).
+-- total_value = 5*10.00 + 0*3.50 = 50.00, item_count = 2, low_stock_count = 1.
+INSERT INTO products (id, restaurant_id, sku, name, current_stock, cost_per_unit, par_level_min) VALUES
+  ('00000000-0000-0000-0000-000000000285'::uuid,
+   '00000000-0000-0000-0000-000000000280'::uuid, 'INV-VAL-SKU-1', 'Inventory Valuation Product A',
+   5, 10.00, NULL),
+  ('00000000-0000-0000-0000-000000000286'::uuid,
+   '00000000-0000-0000-0000-000000000280'::uuid, 'INV-VAL-SKU-2', 'Inventory Valuation Product B',
+   0, 3.50, NULL)
+ON CONFLICT (id) DO UPDATE SET
+  current_stock = EXCLUDED.current_stock,
+  cost_per_unit = EXCLUDED.cost_per_unit,
+  par_level_min = EXCLUDED.par_level_min;
+
+-- Foreign restaurant: real product data a non-member must not see.
+INSERT INTO products (id, restaurant_id, sku, name, current_stock, cost_per_unit, par_level_min) VALUES
+  ('00000000-0000-0000-0000-000000000287'::uuid,
+   '00000000-0000-0000-0000-000000000281'::uuid, 'INV-VAL-SKU-3', 'Inventory Valuation Foreign Product',
+   20, 2.00, NULL)
+ON CONFLICT (id) DO UPDATE SET
+  current_stock = EXCLUDED.current_stock,
+  cost_per_unit = EXCLUDED.cost_per_unit,
+  par_level_min = EXCLUDED.par_level_min;
+
+-- Run as the real caller role, authenticated, with RLS active.
+SET LOCAL ROLE authenticated;
+SET LOCAL request.jwt.claims = '{"sub":"00000000-0000-0000-0000-000000000284","role":"authenticated"}';
+
+-- Test 1: total_value sums current_stock * cost_per_unit across the fixture.
+SELECT results_eq(
+  $$ SELECT total_value FROM get_inventory_valuation(
+       '00000000-0000-0000-0000-000000000280'::uuid) $$,
+  $$ VALUES (50.00::numeric) $$,
+  'total_value sums current_stock * cost_per_unit across the 2-product fixture'
+);
+
+-- Test 2: low_stock_count treats a NULL par_level_min as 0 in the
+-- comparison — stock 0 counts as low stock, stock 5 does not.
+SELECT results_eq(
+  $$ SELECT low_stock_count FROM get_inventory_valuation(
+       '00000000-0000-0000-0000-000000000280'::uuid) $$,
+  $$ VALUES (1::bigint) $$,
+  'low_stock_count counts a NULL-par product at stock 0 but not one at stock 5'
+);
+
+-- Test 3: an empty restaurant returns one row of zeros, not an empty result.
+SELECT results_eq(
+  $$ SELECT total_value, item_count, low_stock_count FROM get_inventory_valuation(
+       '00000000-0000-0000-0000-000000000282'::uuid) $$,
+  $$ VALUES (0::numeric, 0::bigint, 0::bigint) $$,
+  'An empty restaurant returns one row of zeros, not an empty result'
+);
+
+-- Test 4: tenancy. A non-member gets one row of zeros for a foreign
+-- restaurant that holds real product data — RLS hides the rows, but the
+-- aggregate still returns a row.
+SELECT results_eq(
+  $$ SELECT total_value, item_count, low_stock_count FROM get_inventory_valuation(
+       '00000000-0000-0000-0000-000000000281'::uuid) $$,
+  $$ VALUES (0::numeric, 0::bigint, 0::bigint) $$,
+  'A non-member gets one row of zeros for a foreign restaurant with real product data'
+);
+
+RESET ROLE;
+RESET request.jwt.claims;
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/42_bank_aggregates.sql
+++ b/supabase/tests/42_bank_aggregates.sql
@@ -18,7 +18,8 @@
 --   8. Tenancy: a non-member gets a zero-value row for a foreign restaurant
 --      that holds real transaction data.
 --   9. p_min_inflow => 10 excludes a $5.00 deposit from inflow_count and
---      avg_inflow (the deposit floor), while inflow still includes it.
+--      avg_inflow (the deposit floor), while inflow still includes it;
+--      floored_inflow (unlike inflow) also excludes it.
 
 BEGIN;
 SELECT plan(9);
@@ -148,13 +149,14 @@ SET LOCAL request.jwt.claims = '{"sub":"00000000-0000-0000-0000-000000000292","r
 -- Test 1: summary splits inflow/outflow/net over a mixed fixture.
 -- inflow = 500 + 300 = 800; outflow = |{-100, -50}| = 150; net = 650;
 -- tx_count = 4; inflow_count = 2; outflow_count = 2;
--- avg_inflow = 800/2 = 400; max_inflow = 500.
+-- avg_inflow = 800/2 = 400; max_inflow = 500; floored_inflow = 800 (no
+-- p_min_inflow passed, so it equals inflow).
 SELECT results_eq(
-  $$ SELECT inflow, outflow, net, tx_count, inflow_count, outflow_count, avg_inflow, max_inflow
+  $$ SELECT inflow, outflow, net, tx_count, inflow_count, outflow_count, avg_inflow, max_inflow, floored_inflow
      FROM get_bank_transaction_summary(
        '00000000-0000-0000-0000-000000000290'::uuid,
        '2026-05-01'::date, '2026-05-04'::date) $$,
-  $$ VALUES (800::numeric, 150::numeric, 650::numeric, 4::bigint, 2::bigint, 2::bigint, 400::numeric, 500::numeric) $$,
+  $$ VALUES (800::numeric, 150::numeric, 650::numeric, 4::bigint, 2::bigint, 2::bigint, 400::numeric, 500::numeric, 800::numeric) $$,
   'Summary splits inflow/outflow/net over a mixed 4-row fixture'
 );
 
@@ -223,36 +225,37 @@ SELECT results_eq(
 -- Test 7: an empty date range returns one all-zero row, not an empty
 -- result (COALESCE guard on an aggregate without GROUP BY).
 SELECT results_eq(
-  $$ SELECT inflow, outflow, net, tx_count, inflow_count, outflow_count, avg_inflow, max_inflow
+  $$ SELECT inflow, outflow, net, tx_count, inflow_count, outflow_count, avg_inflow, max_inflow, floored_inflow
      FROM get_bank_transaction_summary(
        '00000000-0000-0000-0000-000000000290'::uuid,
        '2026-06-01'::date, '2026-06-30'::date) $$,
-  $$ VALUES (0::numeric, 0::numeric, 0::numeric, 0::bigint, 0::bigint, 0::bigint, 0::numeric, 0::numeric) $$,
+  $$ VALUES (0::numeric, 0::numeric, 0::numeric, 0::bigint, 0::bigint, 0::bigint, 0::numeric, 0::numeric, 0::numeric) $$,
   'An empty date range returns one all-zero row, not an empty result'
 );
 
 -- Test 8: tenancy. A non-member gets a zero-value row for the foreign
 -- restaurant even though it holds a real transaction (999) — RLS hides it.
 SELECT results_eq(
-  $$ SELECT inflow, outflow, net, tx_count, inflow_count, outflow_count, avg_inflow, max_inflow
+  $$ SELECT inflow, outflow, net, tx_count, inflow_count, outflow_count, avg_inflow, max_inflow, floored_inflow
      FROM get_bank_transaction_summary(
        '00000000-0000-0000-0000-000000000291'::uuid,
        '2026-05-01'::date, '2026-05-31'::date) $$,
-  $$ VALUES (0::numeric, 0::numeric, 0::numeric, 0::bigint, 0::bigint, 0::bigint, 0::numeric, 0::numeric) $$,
+  $$ VALUES (0::numeric, 0::numeric, 0::numeric, 0::bigint, 0::bigint, 0::bigint, 0::numeric, 0::numeric, 0::numeric) $$,
   'A non-member gets a zero-value row for a foreign restaurant with real transaction data'
 );
 
 -- Test 9: p_min_inflow => 10 floors the deposit metrics (inflow_count,
--- avg_inflow) to exclude the $5.00 deposit, while inflow stays unfloored
--- and still includes it. inflow = 5 + 50 = 55; inflow_count = 1 (only the
--- 50 passes > 10); avg_inflow = 50.
+-- avg_inflow, floored_inflow) to exclude the $5.00 deposit, while inflow
+-- stays unfloored and still includes it. inflow = 5 + 50 = 55; inflow_count
+-- = 1 (only the 50 passes > 10); avg_inflow = 50; floored_inflow = 50 (only
+-- the deposit that passes the floor, unlike inflow's 55).
 SELECT results_eq(
-  $$ SELECT inflow, inflow_count, avg_inflow
+  $$ SELECT inflow, inflow_count, avg_inflow, floored_inflow
      FROM get_bank_transaction_summary(
        '00000000-0000-0000-0000-000000000290'::uuid,
        '2026-05-30'::date, '2026-05-30'::date, NULL, NULL, 10) $$,
-  $$ VALUES (55::numeric, 1::bigint, 50::numeric) $$,
-  'p_min_inflow => 10 excludes the $5.00 deposit from inflow_count/avg_inflow; inflow still includes it'
+  $$ VALUES (55::numeric, 1::bigint, 50::numeric, 50::numeric) $$,
+  'p_min_inflow => 10 excludes the $5.00 deposit from inflow_count/avg_inflow/floored_inflow; inflow still includes it'
 );
 
 RESET ROLE;

--- a/supabase/tests/42_bank_aggregates.sql
+++ b/supabase/tests/42_bank_aggregates.sql
@@ -1,0 +1,239 @@
+-- Tests get_bank_transaction_summary, get_bank_spending_by_category, and
+-- get_bank_transactions_daily (cluster 6 bank aggregates).
+-- All three RPCs run as SECURITY INVOKER: RLS on bank_transactions scopes
+-- the caller, so a non-member sees a zero-value row rather than an error
+-- (summary uses aggregates without GROUP BY, which always return one row).
+--
+-- Assertions:
+--   1. Summary splits inflow/outflow/net over a mixed 4-row fixture.
+--   2. p_statuses => ARRAY['posted'] excludes a pending row; NULL includes it.
+--   3. p_bank_account_id filters on connected_bank_id (spec section 11.1 item 1):
+--      two banks on the same restaurant, scoped independently.
+--   4. Spending-by-category groups two negative rows under one category;
+--      a positive row in the same category is excluded.
+--   5. An uncategorized negative row lands in the 'Uncategorized' bucket.
+--   6. Daily series has one row per day with the right net; a day with no
+--      transactions produces no row (not a zero-filled row).
+--   7. Summary returns one all-zero row for an empty range (COALESCE guard).
+--   8. Tenancy: a non-member gets a zero-value row for a foreign restaurant
+--      that holds real transaction data.
+
+BEGIN;
+SELECT plan(8);
+
+-- Fixtures insert as the session role (postgres, BYPASSRLS). RLS stays on.
+INSERT INTO auth.users (id, email) VALUES
+  ('00000000-0000-0000-0000-000000000292'::uuid, 'bank-aggregates-member@example.com')
+ON CONFLICT (id) DO UPDATE SET email = EXCLUDED.email;
+
+INSERT INTO restaurants (id, name) VALUES
+  ('00000000-0000-0000-0000-000000000290'::uuid, 'Bank Aggregates Test Restaurant'),
+  ('00000000-0000-0000-0000-000000000291'::uuid, 'Bank Aggregates Foreign Restaurant')
+ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name;
+
+-- The member belongs only to the primary restaurant, not the foreign one.
+INSERT INTO user_restaurants (user_id, restaurant_id, role) VALUES
+  ('00000000-0000-0000-0000-000000000292'::uuid,
+   '00000000-0000-0000-0000-000000000290'::uuid, 'owner')
+ON CONFLICT (user_id, restaurant_id) DO UPDATE SET role = EXCLUDED.role;
+
+-- Two connected banks on the primary restaurant (assertion 3 scopes between
+-- them) and one on the foreign restaurant (assertion 8).
+INSERT INTO connected_banks (id, restaurant_id, stripe_financial_account_id, institution_name) VALUES
+  ('00000000-0000-0000-0000-000000000293'::uuid,
+   '00000000-0000-0000-0000-000000000290'::uuid, 'fca_bank_agg_test_a', 'Bank Aggregates Test Bank A'),
+  ('00000000-0000-0000-0000-000000000294'::uuid,
+   '00000000-0000-0000-0000-000000000290'::uuid, 'fca_bank_agg_test_b', 'Bank Aggregates Test Bank B'),
+  ('00000000-0000-0000-0000-000000000295'::uuid,
+   '00000000-0000-0000-0000-000000000291'::uuid, 'fca_bank_agg_test_foreign', 'Bank Aggregates Foreign Bank')
+ON CONFLICT (id) DO UPDATE SET institution_name = EXCLUDED.institution_name;
+
+-- One expense category for the primary restaurant (assertions 4 and 5).
+INSERT INTO chart_of_accounts
+  (id, restaurant_id, account_code, account_name, account_type, account_subtype, normal_balance)
+VALUES
+  ('00000000-0000-0000-0000-000000000296'::uuid,
+   '00000000-0000-0000-0000-000000000290'::uuid, '5100', 'Food Supplies', 'expense', 'cost_of_goods_sold', 'debit')
+ON CONFLICT (id) DO UPDATE SET account_name = EXCLUDED.account_name;
+
+-- Bank transactions, one isolated date window per assertion so fixtures
+-- never bleed into each other:
+--   2026-05-01..04 (assertion 1): two inflows (500, 300), two outflows
+--     (100, 50), all posted, bank A.
+--   2026-05-10 (assertion 2): a posted row (200) and a pending row (300),
+--     bank A.
+--   2026-05-15 (assertion 3): a row on bank A (1000) and a row on bank B
+--     (2000), same restaurant and day.
+--   2026-05-20 (assertion 4): two negative rows (-40, -60) and one positive
+--     row (500), all under the Food Supplies category.
+--   2026-05-21 (assertion 5): one negative row (-75), no category.
+--   2026-05-25..26 (assertion 6): day 1 has an inflow (100) and an outflow
+--     (30); day 2 has an inflow only (50); day 3 (05-27) has no rows.
+--   2026-05-01 on the foreign restaurant (assertion 8): a real inflow (999)
+--     the non-member must not see.
+INSERT INTO bank_transactions
+  (id, restaurant_id, connected_bank_id, stripe_transaction_id, transaction_date,
+   description, amount, status, category_id)
+VALUES
+  ('00000000-0000-0000-0000-000000000297'::uuid,
+   '00000000-0000-0000-0000-000000000290'::uuid, '00000000-0000-0000-0000-000000000293'::uuid,
+   'bank-agg-test-297', '2026-05-01', 'Deposit 1', 500.00, 'posted', NULL),
+  ('00000000-0000-0000-0000-000000000298'::uuid,
+   '00000000-0000-0000-0000-000000000290'::uuid, '00000000-0000-0000-0000-000000000293'::uuid,
+   'bank-agg-test-298', '2026-05-02', 'Deposit 2', 300.00, 'posted', NULL),
+  ('00000000-0000-0000-0000-000000000299'::uuid,
+   '00000000-0000-0000-0000-000000000290'::uuid, '00000000-0000-0000-0000-000000000293'::uuid,
+   'bank-agg-test-299', '2026-05-03', 'Payment 1', -100.00, 'posted', NULL),
+  ('00000000-0000-0000-0000-000000000300'::uuid,
+   '00000000-0000-0000-0000-000000000290'::uuid, '00000000-0000-0000-0000-000000000293'::uuid,
+   'bank-agg-test-300', '2026-05-04', 'Payment 2', -50.00, 'posted', NULL),
+  ('00000000-0000-0000-0000-000000000301'::uuid,
+   '00000000-0000-0000-0000-000000000290'::uuid, '00000000-0000-0000-0000-000000000293'::uuid,
+   'bank-agg-test-301', '2026-05-10', 'Posted Deposit', 200.00, 'posted', NULL),
+  ('00000000-0000-0000-0000-000000000302'::uuid,
+   '00000000-0000-0000-0000-000000000290'::uuid, '00000000-0000-0000-0000-000000000293'::uuid,
+   'bank-agg-test-302', '2026-05-10', 'Pending Deposit', 300.00, 'pending', NULL),
+  ('00000000-0000-0000-0000-000000000303'::uuid,
+   '00000000-0000-0000-0000-000000000290'::uuid, '00000000-0000-0000-0000-000000000293'::uuid,
+   'bank-agg-test-303', '2026-05-15', 'Bank A Deposit', 1000.00, 'posted', NULL),
+  ('00000000-0000-0000-0000-000000000304'::uuid,
+   '00000000-0000-0000-0000-000000000290'::uuid, '00000000-0000-0000-0000-000000000294'::uuid,
+   'bank-agg-test-304', '2026-05-15', 'Bank B Deposit', 2000.00, 'posted', NULL),
+  ('00000000-0000-0000-0000-000000000305'::uuid,
+   '00000000-0000-0000-0000-000000000290'::uuid, '00000000-0000-0000-0000-000000000293'::uuid,
+   'bank-agg-test-305', '2026-05-20', 'Food Purchase 1', -40.00, 'posted',
+   '00000000-0000-0000-0000-000000000296'::uuid),
+  ('00000000-0000-0000-0000-000000000306'::uuid,
+   '00000000-0000-0000-0000-000000000290'::uuid, '00000000-0000-0000-0000-000000000293'::uuid,
+   'bank-agg-test-306', '2026-05-20', 'Food Purchase 2', -60.00, 'posted',
+   '00000000-0000-0000-0000-000000000296'::uuid),
+  ('00000000-0000-0000-0000-000000000307'::uuid,
+   '00000000-0000-0000-0000-000000000290'::uuid, '00000000-0000-0000-0000-000000000293'::uuid,
+   'bank-agg-test-307', '2026-05-20', 'Food Vendor Refund', 500.00, 'posted',
+   '00000000-0000-0000-0000-000000000296'::uuid),
+  ('00000000-0000-0000-0000-000000000308'::uuid,
+   '00000000-0000-0000-0000-000000000290'::uuid, '00000000-0000-0000-0000-000000000293'::uuid,
+   'bank-agg-test-308', '2026-05-21', 'Uncategorized Purchase', -75.00, 'posted', NULL),
+  ('00000000-0000-0000-0000-000000000309'::uuid,
+   '00000000-0000-0000-0000-000000000290'::uuid, '00000000-0000-0000-0000-000000000293'::uuid,
+   'bank-agg-test-309', '2026-05-25', 'Daily Inflow Day 1', 100.00, 'posted', NULL),
+  ('00000000-0000-0000-0000-000000000310'::uuid,
+   '00000000-0000-0000-0000-000000000290'::uuid, '00000000-0000-0000-0000-000000000293'::uuid,
+   'bank-agg-test-310', '2026-05-25', 'Daily Outflow Day 1', -30.00, 'posted', NULL),
+  ('00000000-0000-0000-0000-000000000311'::uuid,
+   '00000000-0000-0000-0000-000000000290'::uuid, '00000000-0000-0000-0000-000000000293'::uuid,
+   'bank-agg-test-311', '2026-05-26', 'Daily Inflow Day 2', 50.00, 'posted', NULL),
+  ('00000000-0000-0000-0000-000000000312'::uuid,
+   '00000000-0000-0000-0000-000000000291'::uuid, '00000000-0000-0000-0000-000000000295'::uuid,
+   'bank-agg-test-312', '2026-05-01', 'Foreign Restaurant Deposit', 999.00, 'posted', NULL)
+ON CONFLICT (id) DO UPDATE SET
+  amount = EXCLUDED.amount,
+  status = EXCLUDED.status,
+  category_id = EXCLUDED.category_id;
+
+-- Run as the real caller role, authenticated, with RLS active.
+SET LOCAL ROLE authenticated;
+SET LOCAL request.jwt.claims = '{"sub":"00000000-0000-0000-0000-000000000292","role":"authenticated"}';
+
+-- Test 1: summary splits inflow/outflow/net over a mixed fixture.
+-- inflow = 500 + 300 = 800; outflow = |{-100, -50}| = 150; net = 650;
+-- tx_count = 4; inflow_count = 2; outflow_count = 2;
+-- avg_inflow = 800/2 = 400; max_inflow = 500.
+SELECT results_eq(
+  $$ SELECT inflow, outflow, net, tx_count, inflow_count, outflow_count, avg_inflow, max_inflow
+     FROM get_bank_transaction_summary(
+       '00000000-0000-0000-0000-000000000290'::uuid,
+       '2026-05-01'::date, '2026-05-04'::date) $$,
+  $$ VALUES (800::numeric, 150::numeric, 650::numeric, 4::bigint, 2::bigint, 2::bigint, 400::numeric, 500::numeric) $$,
+  'Summary splits inflow/outflow/net over a mixed 4-row fixture'
+);
+
+-- Test 2: p_statuses => ARRAY['posted'] excludes the pending row (300);
+-- NULL includes it. Posted-only inflow = 200; NULL-status inflow = 500.
+SELECT results_eq(
+  $$ SELECT
+       (SELECT inflow FROM get_bank_transaction_summary(
+          '00000000-0000-0000-0000-000000000290'::uuid,
+          '2026-05-10'::date, '2026-05-10'::date, NULL, ARRAY['posted'])),
+       (SELECT inflow FROM get_bank_transaction_summary(
+          '00000000-0000-0000-0000-000000000290'::uuid,
+          '2026-05-10'::date, '2026-05-10'::date, NULL, NULL)) $$,
+  $$ VALUES (200::numeric, 500::numeric) $$,
+  'p_statuses => ARRAY[''posted''] excludes a pending row (200); NULL includes it (500)'
+);
+
+-- Test 3: p_bank_account_id filters on connected_bank_id. Two banks, same
+-- restaurant and day: bank A has 1000, bank B has 2000.
+SELECT results_eq(
+  $$ SELECT
+       (SELECT inflow FROM get_bank_transaction_summary(
+          '00000000-0000-0000-0000-000000000290'::uuid,
+          '2026-05-15'::date, '2026-05-15'::date, '00000000-0000-0000-0000-000000000293'::uuid)),
+       (SELECT inflow FROM get_bank_transaction_summary(
+          '00000000-0000-0000-0000-000000000290'::uuid,
+          '2026-05-15'::date, '2026-05-15'::date, '00000000-0000-0000-0000-000000000294'::uuid)) $$,
+  $$ VALUES (1000::numeric, 2000::numeric) $$,
+  'p_bank_account_id filters on connected_bank_id: bank A (1000) and bank B (2000) scope independently'
+);
+
+-- Test 4: spending-by-category groups the two negative Food Supplies rows
+-- (-40, -60 -> spend 100, tx_count 2); the positive row (500) in the same
+-- category is excluded.
+SELECT results_eq(
+  $$ SELECT category_id, category_name, spend, tx_count
+     FROM get_bank_spending_by_category(
+       '00000000-0000-0000-0000-000000000290'::uuid,
+       '2026-05-20'::date, '2026-05-20'::date) $$,
+  $$ VALUES ('00000000-0000-0000-0000-000000000296'::uuid, 'Food Supplies'::text, 100::numeric, 2::bigint) $$,
+  'Spending-by-category groups two negative rows (spend 100); a positive row in the same category is excluded'
+);
+
+-- Test 5: an uncategorized negative row lands in the Uncategorized bucket.
+SELECT results_eq(
+  $$ SELECT category_id, category_name, spend, tx_count
+     FROM get_bank_spending_by_category(
+       '00000000-0000-0000-0000-000000000290'::uuid,
+       '2026-05-21'::date, '2026-05-21'::date) $$,
+  $$ VALUES (NULL::uuid, 'Uncategorized'::text, 75::numeric, 1::bigint) $$,
+  'An uncategorized negative row lands in the Uncategorized bucket'
+);
+
+-- Test 6: daily series has one row per day with the right net; the day
+-- with no transactions (05-27) produces no row.
+SELECT results_eq(
+  $$ SELECT day, inflow, outflow, net
+     FROM get_bank_transactions_daily(
+       '00000000-0000-0000-0000-000000000290'::uuid,
+       '2026-05-25'::date, '2026-05-27'::date) $$,
+  $$ VALUES ('2026-05-25'::date, 100::numeric, 30::numeric, 70::numeric),
+            ('2026-05-26'::date, 50::numeric, 0::numeric, 50::numeric) $$,
+  'Daily series has one row per day with the right net; a day with no rows produces no row'
+);
+
+-- Test 7: an empty date range returns one all-zero row, not an empty
+-- result (COALESCE guard on an aggregate without GROUP BY).
+SELECT results_eq(
+  $$ SELECT inflow, outflow, net, tx_count, inflow_count, outflow_count, avg_inflow, max_inflow
+     FROM get_bank_transaction_summary(
+       '00000000-0000-0000-0000-000000000290'::uuid,
+       '2026-06-01'::date, '2026-06-30'::date) $$,
+  $$ VALUES (0::numeric, 0::numeric, 0::numeric, 0::bigint, 0::bigint, 0::bigint, 0::numeric, 0::numeric) $$,
+  'An empty date range returns one all-zero row, not an empty result'
+);
+
+-- Test 8: tenancy. A non-member gets a zero-value row for the foreign
+-- restaurant even though it holds a real transaction (999) — RLS hides it.
+SELECT results_eq(
+  $$ SELECT inflow, outflow, net, tx_count, inflow_count, outflow_count, avg_inflow, max_inflow
+     FROM get_bank_transaction_summary(
+       '00000000-0000-0000-0000-000000000291'::uuid,
+       '2026-05-01'::date, '2026-05-31'::date) $$,
+  $$ VALUES (0::numeric, 0::numeric, 0::numeric, 0::bigint, 0::bigint, 0::bigint, 0::numeric, 0::numeric) $$,
+  'A non-member gets a zero-value row for a foreign restaurant with real transaction data'
+);
+
+RESET ROLE;
+RESET request.jwt.claims;
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/42_bank_aggregates.sql
+++ b/supabase/tests/42_bank_aggregates.sql
@@ -17,9 +17,11 @@
 --   7. Summary returns one all-zero row for an empty range (COALESCE guard).
 --   8. Tenancy: a non-member gets a zero-value row for a foreign restaurant
 --      that holds real transaction data.
+--   9. p_min_inflow => 10 excludes a $5.00 deposit from inflow_count and
+--      avg_inflow (the deposit floor), while inflow still includes it.
 
 BEGIN;
-SELECT plan(8);
+SELECT plan(9);
 
 -- Fixtures insert as the session role (postgres, BYPASSRLS). RLS stays on.
 INSERT INTO auth.users (id, email) VALUES
@@ -71,6 +73,8 @@ ON CONFLICT (id) DO UPDATE SET account_name = EXCLUDED.account_name;
 --     (30); day 2 has an inflow only (50); day 3 (05-27) has no rows.
 --   2026-05-01 on the foreign restaurant (assertion 8): a real inflow (999)
 --     the non-member must not see.
+--   2026-05-30 (assertion 9): a small deposit (5.00) and a normal deposit
+--     (50.00), both posted, bank A.
 INSERT INTO bank_transactions
   (id, restaurant_id, connected_bank_id, stripe_transaction_id, transaction_date,
    description, amount, status, category_id)
@@ -125,7 +129,13 @@ VALUES
    'bank-agg-test-311', '2026-05-26', 'Daily Inflow Day 2', 50.00, 'posted', NULL),
   ('00000000-0000-0000-0000-000000000312'::uuid,
    '00000000-0000-0000-0000-000000000291'::uuid, '00000000-0000-0000-0000-000000000295'::uuid,
-   'bank-agg-test-312', '2026-05-01', 'Foreign Restaurant Deposit', 999.00, 'posted', NULL)
+   'bank-agg-test-312', '2026-05-01', 'Foreign Restaurant Deposit', 999.00, 'posted', NULL),
+  ('00000000-0000-0000-0000-000000000313'::uuid,
+   '00000000-0000-0000-0000-000000000290'::uuid, '00000000-0000-0000-0000-000000000293'::uuid,
+   'bank-agg-test-313', '2026-05-30', 'Small Deposit', 5.00, 'posted', NULL),
+  ('00000000-0000-0000-0000-000000000314'::uuid,
+   '00000000-0000-0000-0000-000000000290'::uuid, '00000000-0000-0000-0000-000000000293'::uuid,
+   'bank-agg-test-314', '2026-05-30', 'Normal Deposit', 50.00, 'posted', NULL)
 ON CONFLICT (id) DO UPDATE SET
   amount = EXCLUDED.amount,
   status = EXCLUDED.status,
@@ -230,6 +240,19 @@ SELECT results_eq(
        '2026-05-01'::date, '2026-05-31'::date) $$,
   $$ VALUES (0::numeric, 0::numeric, 0::numeric, 0::bigint, 0::bigint, 0::bigint, 0::numeric, 0::numeric) $$,
   'A non-member gets a zero-value row for a foreign restaurant with real transaction data'
+);
+
+-- Test 9: p_min_inflow => 10 floors the deposit metrics (inflow_count,
+-- avg_inflow) to exclude the $5.00 deposit, while inflow stays unfloored
+-- and still includes it. inflow = 5 + 50 = 55; inflow_count = 1 (only the
+-- 50 passes > 10); avg_inflow = 50.
+SELECT results_eq(
+  $$ SELECT inflow, inflow_count, avg_inflow
+     FROM get_bank_transaction_summary(
+       '00000000-0000-0000-0000-000000000290'::uuid,
+       '2026-05-30'::date, '2026-05-30'::date, NULL, NULL, 10) $$,
+  $$ VALUES (55::numeric, 1::bigint, 50::numeric) $$,
+  'p_min_inflow => 10 excludes the $5.00 deposit from inflow_count/avg_inflow; inflow still includes it'
 );
 
 RESET ROLE;

--- a/supabase/tests/43_expense_health_metrics.sql
+++ b/supabase/tests/43_expense_health_metrics.sql
@@ -1,0 +1,182 @@
+-- Tests get_expense_health_metrics (cluster 6 special aggregate: six sums
+-- in one call).
+-- SECURITY INVOKER: RLS on bank_transactions and chart_of_accounts scopes
+-- the caller, so a non-member sees an all-zero row rather than an error.
+--
+-- One fixture, one date range (2026-05-01..2026-05-10), restaurant
+-- 00000000-0000-0000-0000-000000000400:
+--   05-01  Sales Deposit          1000.00  posted  no category
+--   05-02  Food Vendor Payment    -200.00  posted  Food Supplies (cost_of_goods_sold)
+--   05-03  Payroll Run            -300.00  posted  Payroll Expense (payroll)
+--   05-04  STRIPE FEE              -15.00  posted  Card Processing Fees (operating_expenses)
+--   05-05  Misc Purchase           -50.00  posted  no category, not split
+--   05-06  Voided Transaction    -9999.00  void    no category (must be excluded)
+--
+-- The fee row carries its own category so it does not also land in
+-- uncategorized_spend; only the Misc Purchase row is both uncategorized
+-- and unsplit.
+--
+-- Assertions:
+--   1. revenue sums the one positive row (1000.00).
+--   2. food_cost sums the cost_of_goods_sold-category outflow (200.00).
+--   3. labor_cost sums the payroll-category outflow (300.00).
+--   4. processing_fees sums the outflow matching '%stripe%' (15.00),
+--      case-insensitively against the uppercase description.
+--   5. total_outflows sums every posted/pending negative row
+--      (200 + 300 + 15 + 50 = 565.00); the void row is excluded.
+--   6. uncategorized_spend sums the one uncategorized, non-split outflow
+--      (50.00).
+--   7. Tenancy: a non-member gets an all-zero row for a foreign
+--      restaurant that holds a real transaction.
+
+BEGIN;
+SELECT plan(7);
+
+-- Fixtures insert as the session role (postgres, BYPASSRLS). RLS stays on.
+INSERT INTO auth.users (id, email) VALUES
+  ('00000000-0000-0000-0000-000000000402'::uuid, 'expense-health-member@example.com')
+ON CONFLICT (id) DO UPDATE SET email = EXCLUDED.email;
+
+INSERT INTO restaurants (id, name) VALUES
+  ('00000000-0000-0000-0000-000000000400'::uuid, 'Expense Health Test Restaurant'),
+  ('00000000-0000-0000-0000-000000000401'::uuid, 'Expense Health Foreign Restaurant')
+ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name;
+
+-- The member belongs only to the primary restaurant, not the foreign one.
+INSERT INTO user_restaurants (user_id, restaurant_id, role) VALUES
+  ('00000000-0000-0000-0000-000000000402'::uuid,
+   '00000000-0000-0000-0000-000000000400'::uuid, 'owner')
+ON CONFLICT (user_id, restaurant_id) DO UPDATE SET role = EXCLUDED.role;
+
+INSERT INTO connected_banks (id, restaurant_id, stripe_financial_account_id, institution_name) VALUES
+  ('00000000-0000-0000-0000-000000000403'::uuid,
+   '00000000-0000-0000-0000-000000000400'::uuid, 'fca_expense_health_test', 'Expense Health Test Bank'),
+  ('00000000-0000-0000-0000-000000000404'::uuid,
+   '00000000-0000-0000-0000-000000000401'::uuid, 'fca_expense_health_foreign', 'Expense Health Foreign Bank')
+ON CONFLICT (id) DO UPDATE SET institution_name = EXCLUDED.institution_name;
+
+-- Three categories on the primary restaurant: one matches the food
+-- keyword rule, one matches the labor keyword rule, one is a plain
+-- operating expense so the fee row does not also count as uncategorized.
+INSERT INTO chart_of_accounts
+  (id, restaurant_id, account_code, account_name, account_type, account_subtype, normal_balance)
+VALUES
+  ('00000000-0000-0000-0000-000000000405'::uuid,
+   '00000000-0000-0000-0000-000000000400'::uuid, '5100', 'Food Supplies', 'expense', 'cost_of_goods_sold', 'debit'),
+  ('00000000-0000-0000-0000-000000000406'::uuid,
+   '00000000-0000-0000-0000-000000000400'::uuid, '6100', 'Payroll Expense', 'expense', 'payroll', 'debit'),
+  ('00000000-0000-0000-0000-000000000407'::uuid,
+   '00000000-0000-0000-0000-000000000400'::uuid, '6200', 'Card Processing Fees', 'expense', 'operating_expenses', 'debit')
+ON CONFLICT (id) DO UPDATE SET account_name = EXCLUDED.account_name;
+
+INSERT INTO bank_transactions
+  (id, restaurant_id, connected_bank_id, stripe_transaction_id, transaction_date,
+   description, amount, status, category_id, is_split)
+VALUES
+  ('00000000-0000-0000-0000-000000000408'::uuid,
+   '00000000-0000-0000-0000-000000000400'::uuid, '00000000-0000-0000-0000-000000000403'::uuid,
+   'expense-health-test-408', '2026-05-01', 'Sales Deposit', 1000.00, 'posted', NULL, FALSE),
+  ('00000000-0000-0000-0000-000000000409'::uuid,
+   '00000000-0000-0000-0000-000000000400'::uuid, '00000000-0000-0000-0000-000000000403'::uuid,
+   'expense-health-test-409', '2026-05-02', 'Food Vendor Payment', -200.00, 'posted',
+   '00000000-0000-0000-0000-000000000405'::uuid, FALSE),
+  ('00000000-0000-0000-0000-000000000410'::uuid,
+   '00000000-0000-0000-0000-000000000400'::uuid, '00000000-0000-0000-0000-000000000403'::uuid,
+   'expense-health-test-410', '2026-05-03', 'Payroll Run', -300.00, 'posted',
+   '00000000-0000-0000-0000-000000000406'::uuid, FALSE),
+  ('00000000-0000-0000-0000-000000000411'::uuid,
+   '00000000-0000-0000-0000-000000000400'::uuid, '00000000-0000-0000-0000-000000000403'::uuid,
+   'expense-health-test-411', '2026-05-04', 'STRIPE FEE', -15.00, 'posted',
+   '00000000-0000-0000-0000-000000000407'::uuid, FALSE),
+  ('00000000-0000-0000-0000-000000000412'::uuid,
+   '00000000-0000-0000-0000-000000000400'::uuid, '00000000-0000-0000-0000-000000000403'::uuid,
+   'expense-health-test-412', '2026-05-05', 'Misc Purchase', -50.00, 'posted', NULL, FALSE),
+  ('00000000-0000-0000-0000-000000000413'::uuid,
+   '00000000-0000-0000-0000-000000000400'::uuid, '00000000-0000-0000-0000-000000000403'::uuid,
+   'expense-health-test-413', '2026-05-06', 'Voided Transaction', -9999.00, 'void', NULL, FALSE),
+  ('00000000-0000-0000-0000-000000000414'::uuid,
+   '00000000-0000-0000-0000-000000000401'::uuid, '00000000-0000-0000-0000-000000000404'::uuid,
+   'expense-health-test-414', '2026-05-01', 'Foreign Restaurant Deposit', 777.00, 'posted', NULL, FALSE)
+ON CONFLICT (id) DO UPDATE SET
+  amount = EXCLUDED.amount,
+  status = EXCLUDED.status,
+  category_id = EXCLUDED.category_id;
+
+-- Run as the real caller role, authenticated, with RLS active.
+SET LOCAL ROLE authenticated;
+SET LOCAL request.jwt.claims = '{"sub":"00000000-0000-0000-0000-000000000402","role":"authenticated"}';
+
+-- Test 1: revenue sums the one positive row.
+SELECT is(
+  (SELECT revenue FROM get_expense_health_metrics(
+     '00000000-0000-0000-0000-000000000400'::uuid,
+     '2026-05-01'::date, '2026-05-10'::date, ARRAY['%stripe%'])),
+  1000.00::numeric,
+  'revenue sums the one positive row (1000.00)'
+);
+
+-- Test 2: food_cost sums the cost_of_goods_sold-category outflow.
+SELECT is(
+  (SELECT food_cost FROM get_expense_health_metrics(
+     '00000000-0000-0000-0000-000000000400'::uuid,
+     '2026-05-01'::date, '2026-05-10'::date, ARRAY['%stripe%'])),
+  200.00::numeric,
+  'food_cost sums the cost_of_goods_sold-category outflow (200.00)'
+);
+
+-- Test 3: labor_cost sums the payroll-category outflow.
+SELECT is(
+  (SELECT labor_cost FROM get_expense_health_metrics(
+     '00000000-0000-0000-0000-000000000400'::uuid,
+     '2026-05-01'::date, '2026-05-10'::date, ARRAY['%stripe%'])),
+  300.00::numeric,
+  'labor_cost sums the payroll-category outflow (300.00)'
+);
+
+-- Test 4: processing_fees matches '%stripe%' case-insensitively against
+-- the uppercase description 'STRIPE FEE'.
+SELECT is(
+  (SELECT processing_fees FROM get_expense_health_metrics(
+     '00000000-0000-0000-0000-000000000400'::uuid,
+     '2026-05-01'::date, '2026-05-10'::date, ARRAY['%stripe%'])),
+  15.00::numeric,
+  'processing_fees matches ''%stripe%'' case-insensitively (15.00)'
+);
+
+-- Test 5: total_outflows sums every posted/pending negative row
+-- (200 + 300 + 15 + 50); the void row (9999.00) is excluded.
+SELECT is(
+  (SELECT total_outflows FROM get_expense_health_metrics(
+     '00000000-0000-0000-0000-000000000400'::uuid,
+     '2026-05-01'::date, '2026-05-10'::date, ARRAY['%stripe%'])),
+  565.00::numeric,
+  'total_outflows sums posted/pending outflows and excludes the void row (565.00)'
+);
+
+-- Test 6: uncategorized_spend sums the one uncategorized, non-split
+-- outflow; the categorized fee row does not also count here.
+SELECT is(
+  (SELECT uncategorized_spend FROM get_expense_health_metrics(
+     '00000000-0000-0000-0000-000000000400'::uuid,
+     '2026-05-01'::date, '2026-05-10'::date, ARRAY['%stripe%'])),
+  50.00::numeric,
+  'uncategorized_spend sums the one uncategorized, non-split outflow (50.00)'
+);
+
+-- Test 7: tenancy. A non-member gets an all-zero row for the foreign
+-- restaurant even though it holds a real transaction (777.00) — RLS
+-- hides it.
+SELECT results_eq(
+  $$ SELECT revenue, food_cost, labor_cost, processing_fees, total_outflows, uncategorized_spend
+     FROM get_expense_health_metrics(
+       '00000000-0000-0000-0000-000000000401'::uuid,
+       '2026-05-01'::date, '2026-05-10'::date, ARRAY['%stripe%']) $$,
+  $$ VALUES (0::numeric, 0::numeric, 0::numeric, 0::numeric, 0::numeric, 0::numeric) $$,
+  'A non-member gets an all-zero row for a foreign restaurant with real transaction data'
+);
+
+RESET ROLE;
+RESET request.jwt.claims;
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/43_expense_health_metrics.sql
+++ b/supabase/tests/43_expense_health_metrics.sql
@@ -5,27 +5,30 @@
 --
 -- One fixture, one date range (2026-05-01..2026-05-10), restaurant
 -- 00000000-0000-0000-0000-000000000400:
---   05-01  Sales Deposit          1000.00  posted  no category
---   05-02  Food Vendor Payment    -200.00  posted  Food Supplies (cost_of_goods_sold)
---   05-03  Payroll Run            -300.00  posted  Payroll Expense (payroll)
---   05-04  STRIPE FEE              -15.00  posted  Card Processing Fees (operating_expenses)
---   05-05  Misc Purchase           -50.00  posted  no category, not split
---   05-06  Voided Transaction    -9999.00  void    no category (must be excluded)
+--   05-01  Sales Deposit           1000.00  posted  no category
+--   05-02  Food Vendor Payment     -200.00  posted  Food Supplies (cost_of_goods_sold)
+--   05-03  Payroll Run             -300.00  posted  Payroll Expense (payroll)
+--   05-04  STRIPE FEE               -15.00  posted  Card Processing Fees (operating_expenses)
+--   05-05  Misc Purchase            -50.00  posted  no category, not split
+--   05-06  Voided Transaction     -9999.00  void    no category (must be excluded)
+--   05-07  STRIPE MONTHLY FEE       -25.00  posted  no category, not split
 --
--- The fee row carries its own category so it does not also land in
--- uncategorized_spend; only the Misc Purchase row is both uncategorized
--- and unsplit.
+-- The 05-04 fee row carries its own category, so it lands only in
+-- processing_fees. The 05-07 fee row carries NO category, so it lands in
+-- BOTH processing_fees and uncategorized_spend at once — the two columns
+-- are independent FILTER predicates, not mutually exclusive, and this
+-- row pins that overlap as intended behavior.
 --
 -- Assertions:
 --   1. revenue sums the one positive row (1000.00).
 --   2. food_cost sums the cost_of_goods_sold-category outflow (200.00).
 --   3. labor_cost sums the payroll-category outflow (300.00).
---   4. processing_fees sums the outflow matching '%stripe%' (15.00),
---      case-insensitively against the uppercase description.
+--   4. processing_fees sums both outflows matching '%stripe%'
+--      (15 + 25 = 40.00), case-insensitively.
 --   5. total_outflows sums every posted/pending negative row
---      (200 + 300 + 15 + 50 = 565.00); the void row is excluded.
---   6. uncategorized_spend sums the one uncategorized, non-split outflow
---      (50.00).
+--      (200 + 300 + 15 + 50 + 25 = 590.00); the void row is excluded.
+--   6. uncategorized_spend sums both uncategorized, non-split outflows
+--      (50 + 25 = 75.00) — including the fee-matched 05-07 row.
 --   7. Tenancy: a non-member gets an all-zero row for a foreign
 --      restaurant that holds a real transaction.
 
@@ -94,6 +97,13 @@ VALUES
   ('00000000-0000-0000-0000-000000000413'::uuid,
    '00000000-0000-0000-0000-000000000400'::uuid, '00000000-0000-0000-0000-000000000403'::uuid,
    'expense-health-test-413', '2026-05-06', 'Voided Transaction', -9999.00, 'void', NULL, FALSE),
+  -- Overlap row: matches the '%stripe%' fee pattern AND has no category
+  -- and is not split. This is intended behavior — processing_fees and
+  -- uncategorized_spend are independent FILTER predicates over the same
+  -- rows, not mutually exclusive buckets. This row must count in both.
+  ('00000000-0000-0000-0000-000000000415'::uuid,
+   '00000000-0000-0000-0000-000000000400'::uuid, '00000000-0000-0000-0000-000000000403'::uuid,
+   'expense-health-test-415', '2026-05-07', 'STRIPE MONTHLY FEE', -25.00, 'posted', NULL, FALSE),
   ('00000000-0000-0000-0000-000000000414'::uuid,
    '00000000-0000-0000-0000-000000000401'::uuid, '00000000-0000-0000-0000-000000000404'::uuid,
    'expense-health-test-414', '2026-05-01', 'Foreign Restaurant Deposit', 777.00, 'posted', NULL, FALSE)
@@ -134,33 +144,38 @@ SELECT is(
 );
 
 -- Test 4: processing_fees matches '%stripe%' case-insensitively against
--- the uppercase description 'STRIPE FEE'.
+-- both fee rows: the categorized 'STRIPE FEE' (15.00) and the
+-- uncategorized 'STRIPE MONTHLY FEE' (25.00). processing_fees does not
+-- care about category_id, so both count.
 SELECT is(
   (SELECT processing_fees FROM get_expense_health_metrics(
      '00000000-0000-0000-0000-000000000400'::uuid,
      '2026-05-01'::date, '2026-05-10'::date, ARRAY['%stripe%'])),
-  15.00::numeric,
-  'processing_fees matches ''%stripe%'' case-insensitively (15.00)'
+  40.00::numeric,
+  'processing_fees matches ''%stripe%'' case-insensitively over both fee rows (40.00)'
 );
 
 -- Test 5: total_outflows sums every posted/pending negative row
--- (200 + 300 + 15 + 50); the void row (9999.00) is excluded.
+-- (200 + 300 + 15 + 50 + 25); the void row (9999.00) is excluded.
 SELECT is(
   (SELECT total_outflows FROM get_expense_health_metrics(
      '00000000-0000-0000-0000-000000000400'::uuid,
      '2026-05-01'::date, '2026-05-10'::date, ARRAY['%stripe%'])),
-  565.00::numeric,
-  'total_outflows sums posted/pending outflows and excludes the void row (565.00)'
+  590.00::numeric,
+  'total_outflows sums posted/pending outflows and excludes the void row (590.00)'
 );
 
--- Test 6: uncategorized_spend sums the one uncategorized, non-split
--- outflow; the categorized fee row does not also count here.
+-- Test 6: uncategorized_spend sums both uncategorized, non-split
+-- outflows (Misc Purchase 50.00 and STRIPE MONTHLY FEE 25.00). The
+-- categorized 'STRIPE FEE' row does not count here, but the
+-- uncategorized 'STRIPE MONTHLY FEE' row counts in BOTH this column
+-- and processing_fees — the two columns are not mutually exclusive.
 SELECT is(
   (SELECT uncategorized_spend FROM get_expense_health_metrics(
      '00000000-0000-0000-0000-000000000400'::uuid,
      '2026-05-01'::date, '2026-05-10'::date, ARRAY['%stripe%'])),
-  50.00::numeric,
-  'uncategorized_spend sums the one uncategorized, non-split outflow (50.00)'
+  75.00::numeric,
+  'uncategorized_spend sums both uncategorized, non-split outflows, including the fee-matched row (75.00)'
 );
 
 -- Test 7: tenancy. A non-member gets an all-zero row for the foreign

--- a/tests/unit/financialAggregates.test.ts
+++ b/tests/unit/financialAggregates.test.ts
@@ -11,6 +11,9 @@ describe('sumMonthlyMetrics', () => {
     const t = sumMonthlyMetrics([row(), row({ period: '2026-06', gross_revenue: 50 })]);
     expect(t.gross).toBe(150);
     expect(t.net).toBe(150 - 6 - 4);
+    expect(t.salesTax).toBe(16);
+    expect(t.tips).toBe(10);
+    expect(t.otherLiabilities).toBe(0);
   });
   it('returns zeros for null and for an empty array', () => {
     expect(sumMonthlyMetrics(null).net).toBe(0);

--- a/tests/unit/financialAggregates.test.ts
+++ b/tests/unit/financialAggregates.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+import { sumMonthlyMetrics, fetchNetSales, sumMonthlyFoodCost } from '../../supabase/functions/_shared/financialAggregates';
+
+const row = (over = {}) => ({
+  period: '2026-07', gross_revenue: 100, sales_tax: 8, tips: 5,
+  other_liabilities: 0, discounts: 3, refunds: 2, ...over,
+});
+
+describe('sumMonthlyMetrics', () => {
+  it('sums across months and computes net = gross - discounts - refunds', () => {
+    const t = sumMonthlyMetrics([row(), row({ period: '2026-06', gross_revenue: 50 })]);
+    expect(t.gross).toBe(150);
+    expect(t.net).toBe(150 - 6 - 4);
+  });
+  it('returns zeros for null and for an empty array', () => {
+    expect(sumMonthlyMetrics(null).net).toBe(0);
+    expect(sumMonthlyMetrics([]).gross).toBe(0);
+  });
+  it('treats a null numeric field as 0', () => {
+    expect(sumMonthlyMetrics([row({ refunds: null as unknown as number })]).net).toBe(97);
+  });
+});
+
+describe('fetchNetSales', () => {
+  it('calls the RPC with the exact arguments and sums the rows', async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: [row()], error: null });
+    const t = await fetchNetSales({ rpc } as never, 'rid', '2026-07-01', '2026-07-31');
+    expect(rpc).toHaveBeenCalledWith('get_monthly_sales_metrics', {
+      p_restaurant_id: 'rid', p_date_from: '2026-07-01', p_date_to: '2026-07-31',
+    });
+    expect(t.net).toBe(95);
+  });
+  it('throws on an RPC error instead of a silent zero', async () => {
+    const rpc = vi.fn().mockResolvedValue({ data: null, error: { message: 'boom' } });
+    await expect(fetchNetSales({ rpc } as never, 'rid', 'a', 'b')).rejects.toThrow('boom');
+  });
+});
+
+describe('sumMonthlyFoodCost', () => {
+  it('sums month rows and returns 0 for null', () => {
+    expect(sumMonthlyFoodCost([{ period: '2026-07', food_cost: 10.5 }, { period: '2026-06', food_cost: 2 }])).toBe(12.5);
+    expect(sumMonthlyFoodCost(null)).toBe(0);
+  });
+});

--- a/tests/unit/operatingCostMath.test.ts
+++ b/tests/unit/operatingCostMath.test.ts
@@ -4,9 +4,9 @@ import { computeOperatingCostTotals } from '../../supabase/functions/_shared/ope
 const rows = [
   { cost_type: 'fixed', entry_type: 'value', monthly_value: 4037415, percentage_value: null },
   { cost_type: 'variable', entry_type: 'value', monthly_value: 8200, percentage_value: null },
-  { cost_type: 'variable', entry_type: 'percentage', monthly_value: 0, percentage_value: 27 },
-  { cost_type: 'variable', entry_type: 'percentage', monthly_value: 0, percentage_value: 3 },
-  { cost_type: 'variable', entry_type: 'percentage', monthly_value: 0, percentage_value: 2.5 },
+  { cost_type: 'variable', entry_type: 'percentage', monthly_value: 0, percentage_value: 0.27 },
+  { cost_type: 'variable', entry_type: 'percentage', monthly_value: 0, percentage_value: 0.03 },
+  { cost_type: 'variable', entry_type: 'percentage', monthly_value: 0, percentage_value: 0.025 },
 ];
 
 describe('computeOperatingCostTotals', () => {

--- a/tests/unit/operatingCostMath.test.ts
+++ b/tests/unit/operatingCostMath.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { computeOperatingCostTotals } from '../../supabase/functions/_shared/operatingCostMath';
+
+const rows = [
+  { cost_type: 'fixed', entry_type: 'value', monthly_value: 4037415, percentage_value: null },
+  { cost_type: 'variable', entry_type: 'value', monthly_value: 8200, percentage_value: null },
+  { cost_type: 'variable', entry_type: 'percentage', monthly_value: 0, percentage_value: 27 },
+  { cost_type: 'variable', entry_type: 'percentage', monthly_value: 0, percentage_value: 3 },
+  { cost_type: 'variable', entry_type: 'percentage', monthly_value: 0, percentage_value: 2.5 },
+];
+
+describe('computeOperatingCostTotals', () => {
+  it('includes percentage items in the variable total (the July $82 bug)', () => {
+    const t = computeOperatingCostTotals(rows, 72090.74);
+    expect(t.variableFlatTotal).toBeCloseTo(82.0, 2);
+    expect(t.variablePercentTotal).toBeCloseTo(72090.74 * 0.325, 2);
+    expect(t.variableTotal).toBeGreaterThan(23000);
+  });
+  it('computes the variable ratio from percent items plus flat/revenue', () => {
+    const t = computeOperatingCostTotals(rows, 72090.74);
+    expect(t.variableCostPercentage).toBeCloseTo(32.5 + (82.0 / 72090.74) * 100, 4);
+    expect(t.breakEvenRevenue).toBeCloseTo(40374.15 / ((100 - t.variableCostPercentage) / 100), 2);
+  });
+  it('falls back to 25 percent when the restaurant has no variable rows', () => {
+    const t = computeOperatingCostTotals(rows.slice(0, 1), 1000);
+    expect(t.variableCostPercentage).toBe(25);
+  });
+  it('does not divide by zero when netSales is 0', () => {
+    const t = computeOperatingCostTotals(rows, 0);
+    expect(Number.isFinite(t.breakEvenRevenue)).toBe(true);
+    expect(t.variableCostPercentage).toBeCloseTo(32.5, 4);
+  });
+});

--- a/tests/unit/operatingCostMath.test.ts
+++ b/tests/unit/operatingCostMath.test.ts
@@ -30,4 +30,25 @@ describe('computeOperatingCostTotals', () => {
     expect(Number.isFinite(t.breakEvenRevenue)).toBe(true);
     expect(t.variableCostPercentage).toBeCloseTo(32.5, 4);
   });
+  it('returns zero costs and the 25 percent fallback for an empty rows array', () => {
+    const t = computeOperatingCostTotals([], 1000);
+    expect(t.fixedTotal).toBe(0);
+    expect(t.semiVariableTotal).toBe(0);
+    expect(t.variableFlatTotal).toBe(0);
+    expect(t.variablePercentTotal).toBe(0);
+    expect(t.variableTotal).toBe(0);
+    expect(t.totalMonthlyCosts).toBe(0);
+    expect(t.variableCostPercentage).toBe(25);
+    expect(t.breakEvenRevenue).toBe(0);
+  });
+  it('turns percentage costs negative when netSales is negative, and drops the flat-cost ratio term', () => {
+    const t = computeOperatingCostTotals(rows, -1000);
+    // percentage costs scale with netSales, so they go negative too.
+    expect(t.variablePercentTotal).toBeCloseTo(0.325 * -1000, 2);
+    expect(t.variableTotal).toBeCloseTo(82.0 - 325.0, 2);
+    // netSales <= 0 drops the (variableFlatTotal / netSales) ratio term
+    // entirely, so variableCostPercentage is just the percentage-row sum.
+    expect(t.variableCostPercentage).toBeCloseTo(32.5, 4);
+    expect(t.breakEvenRevenue).toBeCloseTo(59813.56, 2);
+  });
 });

--- a/tests/unit/tools-registry.test.ts
+++ b/tests/unit/tools-registry.test.ts
@@ -130,6 +130,15 @@ describe('tools-registry: get_labor_costs description signals per-employee field
   });
 });
 
+describe('tools-registry: get_operating_costs description labels the data as a budget', () => {
+  it('opens with a warning that the data is the configured budget, not actual spend', () => {
+    const tools = getTools('rest-1', 'manager');
+    const def = tools.find((t) => t.name === 'get_operating_costs');
+    expect(def).toBeDefined();
+    expect(def!.description).toContain('CONFIGURED cost budget');
+  });
+});
+
 describe('tools-registry: requiredRoleFor / canUseTool invariant', () => {
   // Whatever role requiredRoleFor returns, canUseTool MUST be true for that role
   // and false for the role one tier below it. This guards the dispatcher's


### PR DESCRIPTION
## Problem

The AI financial tools report wrong numbers. PostgREST caps every response at 1000 rows (`max_rows = 1000`). The tools fetched raw rows and summed them in JavaScript, so every sum truncated silently past 1000 rows. Validated on one restaurant, July 2026:

| The bot said | Mechanism | True value |
|---|---|---|
| Revenue `$3,647.22` | first 1000 of 22,366 rows, no filters | `$68,038.11` net sales |
| COGS `$197.50` | first 1000 of 14,806 usage rows | `$2,680.51` |
| Break-even input `$5,693.62` | first 1000 of 13,049 filtered rows | `$68,038.11` |
| `Variable Costs: $82.00` | percentage cost items contributed 0 | ≈ `$22,194` at true revenue |
| `Margin of Safety -$619.47` | a percent field printed with `$` | above break-even |

The bot told a profitable owner they lost `$7,822.07`.

## Fix

Three defect classes, one PR (owner folded fix 2 and fix 3 in):

1. **Row cap.** Every period-bound financial sum moves into SQL. Nine new aggregate RPCs plus a modified `get_monthly_sales_metrics` (new `refunds` column; net sales = `gross_revenue - discounts - refunds`). All functions: `SECURITY INVOKER`, `SET search_path TO 'public'`, `REVOKE` from `PUBLIC` and `anon`, `GRANT` to `authenticated`. One new index (`CONCURRENTLY`, no transaction wrapper). The shared helper `financialAggregates.ts` gives every tool one net-sales definition.
2. **Variable-cost math.** `computeOperatingCostTotals` includes percentage items. `percentage_value` is a fraction (`0.27` = 27%, column is `NUMERIC(6,5)`); the first draft of the plan assumed whole-number percents and the task review caught the x100 error before merge.
3. **Labels and prompt.** `get_operating_costs` output carries `source: 'budget_config'` and a note; `margin_of_safety` becomes `margin_of_safety_percent` plus a dollar `margin_of_safety_amount`; the registry description states the budget scope; the chat prompt gains four FINANCIAL DATA RULES (budget vs actuals, one revenue definition, `_percent` fields, `computed_monthly_amount`).

## Behavioral changes (intended, spec §7 + §13)

- income_statement and generate_report revenue drop tax, tips, and split duplicates. The number falls to true net sales.
- KPIs `sales_count` now counts sale transactions server-side. A split sale counts by its parent; discount and refund line items no longer count.
- monthly_trends subtracts refunds and gains a per-month `refunds` field; its food cost moves to `ABS(SUM(...))` per month.
- The COGS end day is now included (old code dropped most of the last day).
- sales_by_category groups by chart-of-accounts category, not raw POS text. Top items cap at 10 (old client code took 20).
- Bank tools: an account-scoped question now works (`connected_bank_id`; the old `bank_account_id` filter hit a column that does not exist). `get_bank_transactions` totals cover the whole period, with a `partial: true` signal when list filters do not apply to the totals. `calculateSpending` signals its dropped account filter and returns `top_vendors: null` + `top_vendors_available: false`. The revenue-health `>$10` deposit floor is preserved via `p_min_inflow`. Some derived metrics change basis (`transaction_count` = active days; predictions are day-level).
- Batch categorize tools clamp at 1000 ids and return `{ ok: false, error: { code: 'TOO_MANY_IDS', ... } }`. **Owner note:** the plan's snippet returned `{ error: string }`; review aligned the shape to the file convention. Veto if you wanted the plan's literal shape.

## Tests

- pgTAP: 8 files (`36_`-`43_`), 46 assertions, all green on a fresh `db reset`. Every new RPC has tenancy (non-member zero under `SET LOCAL ROLE authenticated` with real foreign data) and `anon` EXECUTE-denied assertions.
- Vitest: `financialAggregates` (9), `operatingCostMath` (4), plus `periodMetrics`/`tools-registry` untouched and green (105 total across the four files).
- `npm run typecheck` clean.
- Local resets pin `supabase@2.65.5` (the CI version; newer CLIs fail on `CONCURRENTLY` migrations).

## Production validation (read-only)

Restaurant `7c0c76e3`, July 2026, RPC-equivalent SQL run against production: net sales `$68,038.11` (gross `$72,090.74`, discounts `$4,052.63`, refunds `$0.00`); COGS `$2,680.51` with the corrected end-day bounds. The before numbers are the table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more accurate sales reporting, including refunds and net-sales calculations.
  * Added aggregated reporting for sales, inventory, expenses, banking, and expense health.
  * Improved operating-cost, contribution-margin, and break-even calculations.
  * Added clearer labels distinguishing configured budgets from actual spending.
  * Standardized percentage formatting and added financial guidance for AI responses.
  * Batch categorization now limits requests to 1,000 items.

* **Bug Fixes**
  * Corrected variable-cost, COGS, refund, and break-even calculations.
  * Improved date filtering and handling of empty or uncategorized financial data.

* **Tests**
  * Added coverage for financial aggregates, reporting, security, tenant isolation, and calculation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->