### PR TITLE
fix(scheduling): show the draft state as a hue, not a warning

### DIFF
--- a/src/components/employee/ScheduleStatusBanner.tsx
+++ b/src/components/employee/ScheduleStatusBanner.tsx
@@ -1,7 +1,5 @@
 import { ReactNode } from 'react';
-import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
-import { AlertTriangle } from 'lucide-react';
 import { WeekScheduleState } from '@/hooks/useSchedulePublish';
 import { SchedulePublication } from '@/types/scheduling';
 import { formatDayLabel, formatLocalDateInTz, formatLocalHHMMInTz } from '@/lib/shiftInterval';
@@ -14,10 +12,7 @@ function slot(children: ReactNode): JSX.Element {
 interface ScheduleStatusBannerProps {
   state: WeekScheduleState | null;
   publication: SchedulePublication | null;
-  weekRange: string;
   timezone: string;
-  /** `schedule_retractions.reason`, set only when a manager wrote one. */
-  retractionReason?: string | null;
 }
 
 /**
@@ -29,22 +24,24 @@ interface ScheduleStatusBannerProps {
  * a layout shift, and on mobile a live mis-tap hazard for anyone who started
  * tapping during that beat.
  *
- * Draft states say nothing here. Many restaurants never publish a schedule, so
- * a "not published yet" alert told their employees every week that their real
- * shifts were tentative — and caused a no-show. The muted row treatment in
- * `ShiftRow` is now the only draft signal. Only a retraction gets an alert:
- * that state exists only after a real publish, and it corrects a belief the
- * employee may already hold.
+ * This component never warns. Many restaurants use publish/unpublish as a
+ * routine edit cycle, or never publish at all. Every alert this slot has
+ * carried — "not published yet", "still being finalized", "pulled back for
+ * changes" — read as "your shifts are not real" and caused no-shows. The
+ * muted row treatment in `ShiftRow` is the only draft signal. The one output
+ * here is a quiet "Published {date}" line when a publication exists.
  */
 export function ScheduleStatusBanner({
   state,
   publication,
-  weekRange,
   timezone,
-  retractionReason,
 }: ScheduleStatusBannerProps): JSX.Element {
-  // Loading, or the lookup failed. A wrong banner is worse than no banner.
+  // Loading, or the lookup failed. A wrong line is worse than no line.
   if (!state) return slot(null);
+
+  if (state !== 'published' && state !== 'published_revising') {
+    return slot(null);
+  }
 
   // Restaurant timezone, not the browser's. An employee travelling, or a
   // manager publishing at 11pm from one zone over, must not see a date that
@@ -53,43 +50,10 @@ export function ScheduleStatusBanner({
     ? `${formatDayLabel(formatLocalDateInTz(new Date(publication.published_at), timezone))} at ${formatLocalHHMMInTz(publication.published_at, timezone)}`
     : null;
 
-  if (state === 'not_published') {
-    return slot(null);
-  }
-
-  // 'published' and 'published_revising' both reduce to the same quiet line.
-  // A revised week still was published; the draft rows carry their own hue.
-  if (state === 'published' || state === 'published_revising') {
-    return slot(
-      publishedOn ? (
-        <p className="text-[13px] text-muted-foreground">Published {publishedOn}</p>
-      ) : null
-    );
-  }
-
-  // Retracted. The one state where being unmissable outranks being quiet — it
-  // is actively correcting a belief the employee may already hold from a "New
-  // Schedule Published" email sitting in their inbox. Keeps the primitive's
-  // assertive role.
-  // No boilerplate filter needed: `schedule_retractions.reason` stores the
-  // manager's `p_reason` verbatim and stays NULL when they gave none. The RPC's
-  // "Schedule unpublished for date range…" default is written only to
-  // `schedule_change_logs`, which this never reads.
-  const showReason = !!retractionReason?.trim();
-
   return slot(
-    <Alert className="bg-destructive/10 border-destructive/30 text-foreground">
-      <AlertTriangle className="h-4 w-4 text-destructive" />
-      <AlertTitle className="text-[14px] font-semibold text-foreground">
-        This schedule was pulled back for changes
-      </AlertTitle>
-      <AlertDescription className="text-[13px] text-muted-foreground">
-        Your manager published {weekRange}
-        {publishedOn ? ` on ${publishedOn}` : ''}, then unpublished it to make edits. Nothing below
-        is final — check back once it's republished.
-        {showReason && <span className="block mt-1">Reason: {retractionReason}</span>}
-      </AlertDescription>
-    </Alert>
+    publishedOn ? (
+      <p className="text-[13px] text-muted-foreground">Published {publishedOn}</p>
+    ) : null
   );
 }
 

--- a/src/components/employee/ScheduleStatusBanner.tsx
+++ b/src/components/employee/ScheduleStatusBanner.tsx
@@ -1,10 +1,9 @@
 import { ReactNode } from 'react';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
-import { AlertTriangle, Clock } from 'lucide-react';
+import { AlertTriangle } from 'lucide-react';
 import { WeekScheduleState } from '@/hooks/useSchedulePublish';
 import { SchedulePublication } from '@/types/scheduling';
-import { pluralize } from '@/lib/scheduling/deletionCopy';
 import { formatDayLabel, formatLocalDateInTz, formatLocalHHMMInTz } from '@/lib/shiftInterval';
 
 /** The fixed-height slot every state renders into; see the banner's own doc comment. */
@@ -15,8 +14,6 @@ function slot(children: ReactNode): JSX.Element {
 interface ScheduleStatusBannerProps {
   state: WeekScheduleState | null;
   publication: SchedulePublication | null;
-  publishedCount: number;
-  draftCount: number;
   weekRange: string;
   timezone: string;
   /** `schedule_retractions.reason`, set only when a manager wrote one. */
@@ -26,25 +23,27 @@ interface ScheduleStatusBannerProps {
 /**
  * Owns a fixed-height slot at the top of the page.
  *
- * The height is constant across all four states on purpose. If the slot
- * collapsed while the publication lookup was in flight, the banner's arrival
- * would push `MyShiftTradesCard` and everything under it down on an
- * already-painted page — a layout shift, and on mobile a live mis-tap hazard
- * for anyone who started tapping during that beat. State B, which has no
- * banner, fills the slot with the same information in one quiet line.
+ * The height is constant across all states on purpose. If the slot collapsed
+ * while the publication lookup was in flight, the banner's arrival would push
+ * `MyShiftTradesCard` and everything under it down on an already-painted page —
+ * a layout shift, and on mobile a live mis-tap hazard for anyone who started
+ * tapping during that beat.
+ *
+ * Draft states say nothing here. Many restaurants never publish a schedule, so
+ * a "not published yet" alert told their employees every week that their real
+ * shifts were tentative — and caused a no-show. The muted row treatment in
+ * `ShiftRow` is now the only draft signal. Only a retraction gets an alert:
+ * that state exists only after a real publish, and it corrects a belief the
+ * employee may already hold.
  */
 export function ScheduleStatusBanner({
   state,
   publication,
-  publishedCount,
-  draftCount,
   weekRange,
   timezone,
   retractionReason,
 }: ScheduleStatusBannerProps): JSX.Element {
-  // Loading, or the lookup failed. A wrong banner is worse than no banner:
-  // telling someone their week is "not published yet" when it is would have
-  // them ignore real shifts.
+  // Loading, or the lookup failed. A wrong banner is worse than no banner.
   if (!state) return slot(null);
 
   // Restaurant timezone, not the browser's. An employee travelling, or a
@@ -54,52 +53,17 @@ export function ScheduleStatusBanner({
     ? `${formatDayLabel(formatLocalDateInTz(new Date(publication.published_at), timezone))} at ${formatLocalHHMMInTz(publication.published_at, timezone)}`
     : null;
 
-  if (state === 'published') {
+  if (state === 'not_published') {
+    return slot(null);
+  }
+
+  // 'published' and 'published_revising' both reduce to the same quiet line.
+  // A revised week still was published; the draft rows carry their own hue.
+  if (state === 'published' || state === 'published_revising') {
     return slot(
       publishedOn ? (
         <p className="text-[13px] text-muted-foreground">Published {publishedOn}</p>
       ) : null
-    );
-  }
-
-  if (state === 'not_published') {
-    return slot(
-      <Alert role="status" className="bg-muted/30 border-border/40">
-        <Clock className="h-4 w-4" />
-        <AlertTitle className="text-[14px] font-semibold text-foreground">
-          Schedule not published yet
-        </AlertTitle>
-        <AlertDescription className="text-[13px] text-muted-foreground">
-          Your manager hasn't finalized the week of {weekRange}.{' '}
-          {draftCount > 0 && (
-            <>
-              The {draftCount} {pluralize(draftCount, 'shift', 'shifts')} below{' '}
-              {pluralize(draftCount, 'is', 'are')} still {pluralize(draftCount, 'a draft', 'drafts')} —
-              nothing is confirmed yet.{' '}
-            </>
-          )}
-          Check back soon.
-        </AlertDescription>
-      </Alert>
-    );
-  }
-
-  if (state === 'published_revising') {
-    return slot(
-      <Alert role="status" className="bg-warning/10 border-warning/20 text-foreground">
-        <AlertTriangle className="h-4 w-4 text-warning" />
-        <AlertTitle className="text-[14px] font-semibold text-foreground">
-          Some shifts are still being finalized
-        </AlertTitle>
-        <AlertDescription className="text-[13px] text-muted-foreground">
-          {publishedCount} of your {publishedCount + draftCount}{' '}
-          {pluralize(publishedCount + draftCount, 'shift', 'shifts')} this week{' '}
-          {pluralize(publishedCount, 'is', 'are')} confirmed. {draftCount} more{' '}
-          {pluralize(draftCount, 'is a draft', 'are drafts')} your manager hasn't published yet —
-          treat {pluralize(draftCount, 'it', 'them')} as tentative until{' '}
-          {pluralize(draftCount, 'it shows', 'they show')} a "Confirmed" badge.
-        </AlertDescription>
-      </Alert>
     );
   }
 

--- a/src/components/employee/ShiftRow.tsx
+++ b/src/components/employee/ShiftRow.tsx
@@ -9,7 +9,6 @@ import {
   ClockIcon,
   Coffee,
   MapPin,
-  PencilLine,
   XCircle,
 } from 'lucide-react';
 import { Shift } from '@/types/scheduling';
@@ -80,23 +79,6 @@ function getShiftStatusBadge(shift: Shift): JSX.Element | null {
   return null;
 }
 
-/**
- * Deliberately NOT variant="outline". The pre-existing "Upcoming" badge is an
- * outline pill in this exact slot, so an outline draft badge would be a second
- * identical grey pill and read as just another status — the precise failure the
- * tentative treatment exists to avoid. The `warning` token matches the "being
- * revised" banner so "amber = not final" is one language across the page. The
- * icon is supplementary; the text carries the meaning.
- */
-function DraftBadge(): JSX.Element {
-  return (
-    <Badge className="flex items-center gap-1 bg-warning/15 text-foreground border-warning/30 hover:bg-warning/15">
-      <PencilLine className="h-3 w-3" />
-      Draft — not confirmed
-    </Badge>
-  );
-}
-
 type ShiftRowVariant = 'day' | 'upcoming';
 
 interface ShiftRowProps {
@@ -122,11 +104,12 @@ export function ShiftRow({ shift, variant = 'day', onTrade }: ShiftRowProps): JS
   const isDraft = !shift.is_published;
   const isCancelled = shift.status === 'cancelled';
 
-  // Every draft signal below is load-bearing and redundant on purpose: the
-  // dashed surface, the badge copy and the muted type each say "not final"
-  // on their own, because the banner above may go unread on a fast mobile
-  // glance. The Trade button is NOT a draft signal anymore: the draft-trade
-  // design (docs/superpowers/specs/2026-08-14-draft-shift-trade-design.md)
+  // Drafts get a visual treatment only, no explanatory copy: many restaurants
+  // never publish, so words like "not confirmed" read as a threat on shifts
+  // that are, in practice, final. The dashed muted surface and the lighter
+  // type mark "draft" for sighted users; the sr-only label below carries the
+  // same fact to screen readers. The Trade button is NOT a draft signal: the
+  // draft-trade design (docs/superpowers/specs/2026-08-14-draft-shift-trade-design.md)
   // lets an employee offer a draft shift, marked tentative on the trade side.
   const surface = getSurfaceClass(isCancelled, isDraft, variant);
   const timeText = isDraft ? 'font-normal text-muted-foreground' : 'font-medium';
@@ -145,15 +128,11 @@ export function ShiftRow({ shift, variant = 'day', onTrade }: ShiftRowProps): JS
     </Button>
   ) : null;
 
-  // "Is this real" outranks "when is this", so the draft badge takes the slot
-  // the status badge would otherwise occupy rather than sitting beside it.
-  //
-  // Cancelled still outranks draft, matching getSurfaceClass. An unpublished
-  // cancelled shift is reachable — unpublishing flips is_published on every
-  // shift in the week, cancelled ones included — and it would otherwise wear a
-  // struck-through destructive row under a badge reading "Draft — not
-  // confirmed". "It's cancelled" is the fact the employee has to leave with.
-  const statusBadge = isDraft && !isCancelled ? <DraftBadge /> : getShiftStatusBadge(shift);
+  const statusBadge = getShiftStatusBadge(shift);
+
+  // Color and border alone would fail a screen reader and WCAG 1.4.1.
+  const draftSrLabel =
+    isDraft && !isCancelled ? <span className="sr-only">Draft</span> : null;
 
   if (variant === 'upcoming') {
     return (
@@ -189,6 +168,7 @@ export function ShiftRow({ shift, variant = 'day', onTrade }: ShiftRowProps): JS
             </div>
           )}
           {statusBadge}
+          {draftSrLabel}
         </div>
       </div>
     );
@@ -221,6 +201,7 @@ export function ShiftRow({ shift, variant = 'day', onTrade }: ShiftRowProps): JS
           </div>
         )}
         {statusBadge}
+        {draftSrLabel}
         {tradeButton}
       </div>
     </div>

--- a/src/hooks/useSchedulePublish.tsx
+++ b/src/hooks/useSchedulePublish.tsx
@@ -477,46 +477,6 @@ export const useWeekScheduleStatus = (
   };
 };
 
-/**
- * The reason a manager gave when pulling a week back, if they gave one.
- *
- * Gated on `enabled` so the overwhelmingly common case — a published week —
- * costs nothing. `schedule_retractions` is the right source rather than
- * `schedule_change_logs`: it is scoped to the week, carries the SELECT policy
- * and grant employees actually have, and stores the reason verbatim instead of
- * the RPC's `COALESCE(...)` boilerplate.
- */
-export const useWeekRetractionReason = (
-  restaurantId: string | null,
-  weekStart: Date,
-  enabled: boolean
-): string | null => {
-  const weekStartStr = formatLocalDate(weekStart);
-
-  const { data } = useQuery({
-    queryKey: ['week_retraction_reason', restaurantId, weekStartStr],
-    queryFn: async () => {
-      if (!restaurantId) return null;
-
-      const { data, error } = await supabase
-        .from('schedule_retractions')
-        .select('reason')
-        .eq('restaurant_id', restaurantId)
-        .eq('week_start_date', weekStartStr)
-        .order('retracted_at', { ascending: false })
-        .limit(1)
-        .maybeSingle();
-
-      if (error) throw error;
-      return data?.reason ?? null;
-    },
-    enabled: !!restaurantId && enabled,
-    staleTime: 30000,
-  });
-
-  return data ?? null;
-};
-
 export const useWeekPublicationStatus = (
   restaurantId: string | null,
   weekStart: Date,

--- a/src/pages/EmployeeSchedule.tsx
+++ b/src/pages/EmployeeSchedule.tsx
@@ -80,8 +80,6 @@ const EmployeeSchedule = () => {
   const {
     state,
     publication,
-    publishedCount,
-    draftCount,
     loading: statusLoading,
     // `employeeLoading` too, not just `shiftsLoading`: `useMyShifts` stays
     // disabled until `employeeId` resolves, and a disabled query reports
@@ -241,8 +239,6 @@ const EmployeeSchedule = () => {
       <ScheduleStatusBanner
         state={state}
         publication={publication}
-        publishedCount={publishedCount}
-        draftCount={draftCount}
         weekRange={`${format(currentWeekStart, 'MMM d')} - ${format(weekEnd, 'MMM d, yyyy')}`}
         timezone={restaurantTimezone}
         retractionReason={retractionReason}

--- a/src/pages/EmployeeSchedule.tsx
+++ b/src/pages/EmployeeSchedule.tsx
@@ -7,7 +7,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { useRestaurantContext } from '@/contexts/RestaurantContext';
 import { useCurrentEmployee } from '@/hooks/useCurrentEmployee';
 import { useMyShifts } from '@/hooks/useShifts';
-import { useWeekScheduleStatus, useWeekRetractionReason } from '@/hooks/useSchedulePublish';
+import { useWeekScheduleStatus } from '@/hooks/useSchedulePublish';
 import { TradeRequestDialog } from '@/components/schedule/TradeRequestDialog';
 import { MyShiftTradesCard } from '@/components/schedule/MyShiftTradesCard';
 import {
@@ -90,11 +90,6 @@ const EmployeeSchedule = () => {
     currentWeekStart,
     myShifts,
     shiftsLoading || employeeLoading
-  );
-  const retractionReason = useWeekRetractionReason(
-    restaurantId,
-    currentWeekStart,
-    state === 'retracted'
   );
 
   // "Has anything moved since I last looked?" There is no server-side read
@@ -234,14 +229,11 @@ const EmployeeSchedule = () => {
         </Link>
       </div>
 
-      {/* Is this week actually mine? Above everything, because a retracted week
-          contradicts an email the employee may already have acted on. */}
+      {/* One quiet "Published {date}" line, or nothing. Never a warning. */}
       <ScheduleStatusBanner
         state={state}
         publication={publication}
-        weekRange={`${format(currentWeekStart, 'MMM d')} - ${format(weekEnd, 'MMM d, yyyy')}`}
         timezone={restaurantTimezone}
-        retractionReason={retractionReason}
       />
 
       {/* My shift trades — poster tracker + claimant status */}

--- a/tests/e2e/employee-schedule-retraction.spec.ts
+++ b/tests/e2e/employee-schedule-retraction.spec.ts
@@ -131,16 +131,17 @@ test.describe('Employee schedule publish states', () => {
 
     await expect(page.getByText(/^Published /)).toBeVisible({ timeout: 15000 });
 
-    // --- State D: pulled back. This is the state the old UI could not express
-    // at all — the employee was left reading a week nobody had told them was
-    // no longer final.
+    // --- State D: pulled back. Managers unpublish as a routine edit cycle.
+    // The old "pulled back for changes" alert told employees their real
+    // shifts were void, and confused people. The rows return to the draft
+    // hue; the banner shows no warning and no stale "Published" line.
     await unpublishCurrentWeek(page);
 
     await page.goto('/employee/schedule');
     await page.waitForLoadState('networkidle');
 
-    const retractedAlert = page.getByRole('alert').filter({ hasText: /pulled back for changes/i });
-    await expect(retractedAlert).toBeVisible({ timeout: 15000 });
-    await expect(retractedAlert).toContainText(/nothing below is final/i);
+    await expect(page.getByText(/upcoming/i).first()).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText(/pulled back for changes/i)).not.toBeVisible();
+    await expect(page.getByText(/^Published /)).not.toBeVisible();
   });
 });

--- a/tests/e2e/employee-schedule-retraction.spec.ts
+++ b/tests/e2e/employee-schedule-retraction.spec.ts
@@ -113,12 +113,15 @@ test.describe('Employee schedule publish states', () => {
 
     await seedSelfAsEmployeeWithShift(page, restaurantId);
 
-    // --- State A: nothing published yet. The shift is visible but tentative.
+    // --- State A: nothing published yet. The shift is visible, with a quiet
+    // draft hue and no warning copy — many restaurants never publish, and the
+    // old "not published yet" alert caused a real no-show.
     await page.goto('/employee/schedule');
     await page.waitForLoadState('networkidle');
 
-    await expect(page.getByText(/schedule not published yet/i)).toBeVisible({ timeout: 15000 });
-    await expect(page.getByText(/draft — not confirmed/i).first()).toBeVisible();
+    await expect(page.getByText(/upcoming/i).first()).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText(/schedule not published yet/i)).not.toBeVisible();
+    await expect(page.getByText(/draft — not confirmed/i)).not.toBeVisible();
 
     // --- State B: published. The draft badge is gone and the banner steps aside.
     await publishCurrentWeek(page);
@@ -127,8 +130,6 @@ test.describe('Employee schedule publish states', () => {
     await page.waitForLoadState('networkidle');
 
     await expect(page.getByText(/^Published /)).toBeVisible({ timeout: 15000 });
-    await expect(page.getByText(/schedule not published yet/i)).not.toBeVisible();
-    await expect(page.getByText(/draft — not confirmed/i)).not.toBeVisible();
 
     // --- State D: pulled back. This is the state the old UI could not express
     // at all — the employee was left reading a week nobody had told them was
@@ -141,8 +142,5 @@ test.describe('Employee schedule publish states', () => {
     const retractedAlert = page.getByRole('alert').filter({ hasText: /pulled back for changes/i });
     await expect(retractedAlert).toBeVisible({ timeout: 15000 });
     await expect(retractedAlert).toContainText(/nothing below is final/i);
-
-    // The shifts themselves are drafts again, so they read as tentative too.
-    await expect(page.getByText(/draft — not confirmed/i).first()).toBeVisible();
   });
 });

--- a/tests/unit/ScheduleStatusBanner.test.tsx
+++ b/tests/unit/ScheduleStatusBanner.test.tsx
@@ -32,8 +32,6 @@ function renderBanner(props: Partial<React.ComponentProps<typeof ScheduleStatusB
     <ScheduleStatusBanner
       state="published"
       publication={publication()}
-      publishedCount={4}
-      draftCount={0}
       weekRange={WEEK_RANGE}
       timezone={TZ}
       {...props}
@@ -60,42 +58,29 @@ describe('ScheduleStatusBanner', () => {
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 
-  it('tells an employee a draft-only week is not theirs yet', () => {
-    renderBanner({ state: 'not_published', publication: null, publishedCount: 0, draftCount: 3 });
+  it('says nothing about an unpublished week', () => {
+    const { container } = renderBanner({ state: 'not_published', publication: null });
 
-    const banner = screen.getByRole('status');
-    expect(banner).toHaveTextContent('Schedule not published yet');
-    expect(banner).toHaveTextContent(`Your manager hasn't finalized the week of ${WEEK_RANGE}`);
-    // The count is the part that connects the banner to the rows below it.
-    expect(banner).toHaveTextContent('The 3 shifts below are still drafts');
+    // Many restaurants never publish a schedule. A weekly "not published yet"
+    // alert told their employees that real shifts were tentative — and caused
+    // a no-show. The draft hue on each row is now the only draft signal.
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(container.querySelector('.min-h-\\[76px\\]')).toBeInTheDocument();
   });
 
-  it('omits the shift-count sentence when there is nothing on the grid to explain', () => {
-    renderBanner({ state: 'not_published', publication: null, publishedCount: 0, draftCount: 0 });
+  it('shows only the quiet published line while a week is being revised', () => {
+    renderBanner({ state: 'published_revising' });
 
-    expect(screen.getByRole('status')).not.toHaveTextContent('shifts below');
-  });
-
-  it('singularizes the draft sentence for a lone shift', () => {
-    renderBanner({ state: 'not_published', publication: null, publishedCount: 0, draftCount: 1 });
-
-    expect(screen.getByRole('status')).toHaveTextContent('The 1 shift below is still a draft');
-  });
-
-  it('splits confirmed from unconfirmed while a week is being revised', () => {
-    renderBanner({ state: 'published_revising', publishedCount: 3, draftCount: 2 });
-
-    const banner = screen.getByRole('status');
-    expect(banner).toHaveTextContent('Some shifts are still being finalized');
-    // "3 of your shifts" leaves the denominator to the reader, and the number
-    // they reach for is the one they can see -- five rows on the page. Naming
-    // the total is what makes the sentence answer "how many are left?".
-    expect(banner).toHaveTextContent('3 of your 5 shifts this week are confirmed');
-    expect(banner).toHaveTextContent('2 more are drafts');
+    // A revised week still was published. The draft rows carry their own hue;
+    // the banner does not lecture about them.
+    expect(screen.getByText(/Published Sat, Aug 1 at 10:00/)).toBeInTheDocument();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 
   it('announces a retraction assertively, naming when the week had been published', () => {
-    renderBanner({ state: 'retracted', publishedCount: 0, draftCount: 5 });
+    renderBanner({ state: 'retracted' });
 
     // role="alert", not "status": this is correcting a belief the employee may
     // already hold from a "New Schedule Published" email in their inbox.
@@ -108,8 +93,6 @@ describe('ScheduleStatusBanner', () => {
   it('passes along a reason a manager actually wrote', () => {
     renderBanner({
       state: 'retracted',
-      publishedCount: 0,
-      draftCount: 5,
       retractionReason: 'Two callouts, rebuilding the weekend',
     });
 
@@ -125,8 +108,6 @@ describe('ScheduleStatusBanner', () => {
     // for a manager who opened the box and typed nothing.
     renderBanner({
       state: 'retracted',
-      publishedCount: 0,
-      draftCount: 5,
       retractionReason: '   ',
     });
 
@@ -134,7 +115,7 @@ describe('ScheduleStatusBanner', () => {
   });
 
   it('still renders the retraction when the publication row is missing', () => {
-    renderBanner({ state: 'retracted', publication: null, publishedCount: 0, draftCount: 5 });
+    renderBanner({ state: 'retracted', publication: null });
 
     const banner = screen.getByRole('alert');
     expect(banner).toHaveTextContent('This schedule was pulled back for changes');

--- a/tests/unit/ScheduleStatusBanner.test.tsx
+++ b/tests/unit/ScheduleStatusBanner.test.tsx
@@ -6,7 +6,6 @@ import { ScheduleStatusBanner } from '@/components/employee/ScheduleStatusBanner
 import { SchedulePublication } from '@/types/scheduling';
 
 const TZ = 'America/Chicago';
-const WEEK_RANGE = 'Aug 3 - Aug 9';
 
 function publication(overrides: Partial<SchedulePublication> = {}): SchedulePublication {
   return {
@@ -32,19 +31,24 @@ function renderBanner(props: Partial<React.ComponentProps<typeof ScheduleStatusB
     <ScheduleStatusBanner
       state="published"
       publication={publication()}
-      weekRange={WEEK_RANGE}
       timezone={TZ}
       {...props}
     />
   );
 }
 
+/**
+ * The banner never warns. Every alert this slot has carried — "not published
+ * yet", "still being finalized", "pulled back for changes" — told employees
+ * their real shifts were tentative, and caused no-shows at restaurants that
+ * use publish/unpublish as a routine edit cycle or never publish at all.
+ */
 describe('ScheduleStatusBanner', () => {
   it('says nothing at all while the status is still unknown', () => {
     const { container } = renderBanner({ state: null });
 
-    // A wrong banner is worse than no banner. The slot still occupies its
-    // height so the page does not jump when the answer arrives.
+    // The slot still occupies its height so the page does not jump when the
+    // answer arrives.
     expect(screen.queryByRole('status')).not.toBeInTheDocument();
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
     expect(container.querySelector('.min-h-\\[76px\\]')).toBeInTheDocument();
@@ -61,67 +65,35 @@ describe('ScheduleStatusBanner', () => {
   it('says nothing about an unpublished week', () => {
     const { container } = renderBanner({ state: 'not_published', publication: null });
 
-    // Many restaurants never publish a schedule. A weekly "not published yet"
-    // alert told their employees that real shifts were tentative — and caused
-    // a no-show. The draft hue on each row is now the only draft signal.
-    expect(screen.queryByRole('status')).not.toBeInTheDocument();
-    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(container.textContent).toBe('');
     expect(container.querySelector('.min-h-\\[76px\\]')).toBeInTheDocument();
   });
 
   it('shows only the quiet published line while a week is being revised', () => {
     renderBanner({ state: 'published_revising' });
 
-    // A revised week still was published. The draft rows carry their own hue;
-    // the banner does not lecture about them.
     expect(screen.getByText(/Published Sat, Aug 1 at 10:00/)).toBeInTheDocument();
     expect(screen.queryByRole('status')).not.toBeInTheDocument();
     expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 
-  it('announces a retraction assertively, naming when the week had been published', () => {
+  it('says nothing about a retracted week', () => {
+    // The "pulled back for changes" alert was the exact message a confused
+    // employee quoted. Restaurants unpublish to edit; the alert read as
+    // "your shifts are cancelled".
+    const { container } = renderBanner({ state: 'retracted' });
+
+    expect(container.textContent).toBe('');
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(container.querySelector('.min-h-\\[76px\\]')).toBeInTheDocument();
+  });
+
+  it('shows no stale "Published" line on a retracted week', () => {
+    // A retracted week still has a publication row with a published_at. The
+    // line must not appear: "Published Fri at 22:17" over draft-hued rows
+    // would claim a publish state the week no longer has.
     renderBanner({ state: 'retracted' });
 
-    // role="alert", not "status": this is correcting a belief the employee may
-    // already hold from a "New Schedule Published" email in their inbox.
-    const banner = screen.getByRole('alert');
-    expect(banner).toHaveTextContent('This schedule was pulled back for changes');
-    expect(banner).toHaveTextContent(`Your manager published ${WEEK_RANGE} on Sat, Aug 1 at 10:00`);
-    expect(banner).toHaveTextContent("check back once it's republished");
-  });
-
-  it('passes along a reason a manager actually wrote', () => {
-    renderBanner({
-      state: 'retracted',
-      retractionReason: 'Two callouts, rebuilding the weekend',
-    });
-
-    expect(screen.getByRole('alert')).toHaveTextContent(
-      'Reason: Two callouts, rebuilding the weekend'
-    );
-  });
-
-  it('omits the reason line when the manager gave none', () => {
-    // `schedule_retractions.reason` is NULL in that case — the RPC's
-    // "Schedule unpublished for date range…" default goes to
-    // schedule_change_logs, which the banner never reads. Whitespace stands in
-    // for a manager who opened the box and typed nothing.
-    renderBanner({
-      state: 'retracted',
-      retractionReason: '   ',
-    });
-
-    expect(screen.getByRole('alert')).not.toHaveTextContent('Reason:');
-  });
-
-  it('still renders the retraction when the publication row is missing', () => {
-    renderBanner({ state: 'retracted', publication: null });
-
-    const banner = screen.getByRole('alert');
-    expect(banner).toHaveTextContent('This schedule was pulled back for changes');
-    // With no publication row there is no published_at to format, so the
-    // " on {day} at {time}" clause must be absent entirely -- not rendered
-    // empty, which would read as "published  on , then unpublished it".
-    expect(banner).not.toHaveTextContent(/ on \w/);
+    expect(screen.queryByText(/Published/)).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/ShiftRow.test.tsx
+++ b/tests/unit/ShiftRow.test.tsx
@@ -31,32 +31,38 @@ function makeShift(overrides: Partial<Shift> = {}): Shift {
 }
 
 describe('ShiftRow draft treatment', () => {
-  it('labels an unpublished shift as an unconfirmed draft', () => {
+  it('shows no explanatory draft copy on an unpublished shift', () => {
     render(<ShiftRow shift={makeShift({ is_published: false })} />);
 
-    // The badge text is the signal that survives a screen reader, a
-    // colour-blind viewer and a greyscale phone -- the dashed border alone
-    // would not.
-    expect(screen.getByText('Draft — not confirmed')).toBeInTheDocument();
+    // Many restaurants never publish. Words like "not confirmed" on a real
+    // shift caused a no-show. The draft state is a hue, not a warning.
+    expect(screen.queryByText('Draft — not confirmed')).not.toBeInTheDocument();
+    expect(screen.getByText('Upcoming')).toBeInTheDocument();
   });
 
-  it('offers a Trade button on a draft shift and marks the row as a draft', async () => {
+  it('keeps a screen-reader-only Draft label on an unpublished shift', () => {
+    render(<ShiftRow shift={makeShift({ is_published: false })} />);
+
+    // The hue alone would fail a screen reader and WCAG 1.4.1. The label is
+    // sr-only, so sighted users see no extra copy.
+    const label = screen.getByText('Draft');
+    expect(label).toHaveClass('sr-only');
+  });
+
+  it('offers a Trade button on a draft shift', async () => {
     const onTrade = vi.fn();
     render(<ShiftRow shift={makeShift({ is_published: false })} onTrade={onTrade} />);
 
-    // The draft-trade design allows a trade before publication. The row
-    // must still read as a draft next to the button.
-    expect(screen.getByText('Draft — not confirmed')).toBeInTheDocument();
-
+    // The draft-trade design allows a trade before publication.
     await userEvent.click(screen.getByRole('button', { name: /trade/i }));
     expect(onTrade).toHaveBeenCalledTimes(1);
   });
 
-  it('shows the normal status badge and Trade button once published', async () => {
+  it('shows the normal status badge and no Draft label once published', async () => {
     const onTrade = vi.fn();
     render(<ShiftRow shift={makeShift()} onTrade={onTrade} />);
 
-    expect(screen.queryByText('Draft — not confirmed')).not.toBeInTheDocument();
+    expect(screen.queryByText('Draft')).not.toBeInTheDocument();
     expect(screen.getByText('Upcoming')).toBeInTheDocument();
 
     await userEvent.click(screen.getByRole('button', { name: /trade/i }));
@@ -64,17 +70,20 @@ describe('ShiftRow draft treatment', () => {
   });
 
   it('keeps a cancelled shift reading as cancelled, not as a draft', () => {
-    render(<ShiftRow shift={makeShift({ status: 'cancelled' })} onTrade={vi.fn()} />);
+    render(
+      <ShiftRow shift={makeShift({ status: 'cancelled', is_published: false })} onTrade={vi.fn()} />
+    );
 
     expect(screen.getByText('Cancelled')).toBeInTheDocument();
+    // "It's cancelled" is the fact the employee has to leave with.
+    expect(screen.queryByText('Draft')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /trade/i })).not.toBeInTheDocument();
   });
 
   it('takes the same draft branch in the Upcoming card as in the day grid', () => {
     render(<ShiftRow shift={makeShift({ is_published: false })} variant="upcoming" />);
 
-    // The Upcoming card is the one an employee reads first on mobile; a draft
-    // that looked confirmed there is the exact reported confusion.
-    expect(screen.getByText('Draft — not confirmed')).toBeInTheDocument();
+    expect(screen.queryByText('Draft — not confirmed')).not.toBeInTheDocument();
+    expect(screen.getByText('Draft')).toHaveClass('sr-only');
   });
 });


### PR DESCRIPTION
## Problem

Some restaurants never publish a schedule, or use publish/unpublish as a routine edit cycle. The employee page answered both patterns with warnings: a "Schedule not published yet" alert, a "Draft — not confirmed" badge on every shift, and a "This schedule was pulled back for changes … Nothing below is final" alert after every unpublish. An employee read that copy, treated a real shift as void, and did not come to work.

## Fix

Draft is now a visual state. The banner never warns.

- The banner shows one quiet "Published {date}" line, or nothing.
- The `not_published` and `retracted` states show nothing. A retracted week also shows no stale "Published" line.
- `ShiftRow` keeps the draft hue: muted surface, dashed border, muted time text. The "Draft — not confirmed" badge is gone. Draft shifts show the normal status badge.
- A screen-reader-only "Draft" label keeps the state accessible. Color alone would fail WCAG 1.4.1.
- Delete the `retractionReason` prop and the `useWeekRetractionReason` hook. The employee page was their only caller.

## Tests

- 21 unit tests pass across the three related suites.
- The e2e spec `employee-schedule-retraction.spec.ts` now checks that no warning appears in any state.
- `npm run typecheck` shows one pre-existing error in `SpeedInsightsGate.tsx` (missing local dependency, not from this change).

## Process note

This is a hotfix. Jose authorized a bypass of the full development workflow to ship in minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)