### PR TITLE
feat(scheduling): quiet publish and live edit of published shifts

### DIFF
--- a/docs/superpowers/plans/2026-08-15-quiet-publish-live-edit-plan.md
+++ b/docs/superpowers/plans/2026-08-15-quiet-publish-live-edit-plan.md
@@ -1,0 +1,110 @@
+# Plan: Quiet publish and live edit
+
+Design: docs/superpowers/specs/2026-08-15-quiet-publish-live-edit-design.md
+Branch: feature/quiet-publish-live-edit
+Worktree: .claude/worktrees/quiet-publish-live-edit
+
+Each task is one TDD unit: write the failing test, make it pass, commit.
+
+## Feature A: quiet publish
+
+1. **Add `'skipped'` to `NotificationOutcome`.**
+   File: `src/hooks/useSchedulePublish.tsx`. Add the variant and the
+   `notificationToast` branch: title unchanged, description
+   "No notifications were sent." Tests: `tests/unit/` toast copy per
+   outcome. No dependency.
+
+2. **Add `notify` to `PublishScheduleParams`.**
+   File: `src/hooks/useSchedulePublish.tsx`. When `notify === false`,
+   do not call `invokeScheduleNotification`; return
+   `{ status: 'skipped' }`. Default `true` when absent. Tests: mock the
+   invoke; check zero calls when false, one call when true.
+   Depends on task 1.
+
+3. **Add the "Notify employees" checkbox to `PublishScheduleDialog`.**
+   Files: `src/components/PublishScheduleDialog.tsx`,
+   `src/pages/Scheduling.tsx` (`handlePublishSchedule`). Checkbox with
+   `Label htmlFor`/`id`, checked by default. `useEffect` on `open`
+   resets `notify` to `true` and `notes` to `''`. `onConfirm(notes,
+   notify)`. Tests: default state, reset on reopen, callback arguments.
+   Depends on task 2.
+
+4. **Change the retraction gate in `notify-schedule-unpublished`.**
+   File: `supabase/functions/notify-schedule-unpublished/index.ts`
+   (`:180-187`). Gate the send on the retracted publication row, not on
+   `notification_sent`. Tests: per repo precedent for edge-function
+   tests; otherwise document manual check in the PR. No dependency.
+
+## Feature B: live edit of a published shift
+
+5. **Migration: `schedule_change_logs.notified_at`.**
+   New file under `supabase/migrations/`. Nullable `TIMESTAMPTZ`, no
+   default. pgTAP: column exists, is nullable. No dependency.
+
+6. **Add `allowPublished` to the `useShifts` mutations.**
+   File: `src/hooks/useShifts.tsx`. `useUpdateShift`,
+   `useUpdateShiftSeries`, `useDeleteShift`, `useDeleteShiftSeries`
+   accept the option; `true` skips `assertShiftNotLocked` / the series
+   throw / maps to `p_include_locked`. Absent → unchanged. Tests: both
+   states per mutation. No dependency.
+
+7. **Add `allowPublished` to the validated pipeline.**
+   Files: `src/lib/shiftMutationPipeline.ts`,
+   `src/hooks/useValidatedShiftMutations.ts`. Thread the option past
+   `assertNotLockedClient` at all 8 call sites. Absent → unchanged.
+   Tests: both states. No dependency.
+
+8. **Build `PublishedShiftChangeDialog`.**
+   New file `src/components/scheduling/PublishedShiftChangeDialog.tsx`.
+   Per the design's dialog section (AlertDialog, typography scale,
+   checkbox as sibling of the description, pending-disable on confirm).
+   Tests: render, checkbox default, callback payload, disabled while
+   pending. No dependency.
+
+9. **Build `usePublishedShiftGuard`.**
+   New file `src/hooks/usePublishedShiftGuard.ts`. One instance per
+   page; fresh SELECT of `locked, employee_id`; not locked → run
+   directly; locked → dialog → run with `allowPublished: true`.
+   Tests: fresh-read decision, deferred run, cancel path.
+   Depends on tasks 6, 8.
+
+10. **Wire `ShiftDialog` save through the guard.**
+    Files: `src/components/ShiftDialog.tsx`, `src/pages/Scheduling.tsx`.
+    Covers `WeekScheduleMobile` (it opens `ShiftDialog`).
+    Depends on task 9.
+
+11. **Wire the delete flows through the guard.**
+    File: `src/pages/Scheduling.tsx` (`useDeleteShift`,
+    `useDeleteShiftSeries` call sites). Depends on task 9.
+
+12. **Wire the timeline through the guard.**
+    Files: `src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx`
+    (`:694`, `:734`), `TimelineShiftPopover.tsx`; delete the
+    `if (locked) return;` gates in `useTimelineBarDrag.ts:20,198`.
+    Depends on tasks 7, 9.
+
+13. **Build the `notify-shift-changed` edge function.**
+    New dir `supabase/functions/notify-shift-changed/`. The nine-step
+    order from the design: auth → read row (service role) →
+    `user_has_capability` check → validity checks → `notified_at` latch
+    → derive → recipients → send (email + `sendWebPushToUser`) →
+    `{ sent, failed }`. Tests: derive/validity logic per repo precedent.
+    Depends on task 5.
+
+14. **Client notify step after a guarded change.**
+    File: `src/hooks/usePublishedShiftGuard.ts`. Scoped log-row lookup
+    (`shift_id`, `changed_by`, `changed_at >= start`), then
+    `invokeScheduleNotification('notify-shift-changed', { changeLogId })`
+    with the "Shift updated" toast copy. Tests: lookup filter, skip
+    when the checkbox was unchecked. Depends on tasks 9, 13.
+
+15. **E2E.**
+    File: `tests/e2e/employee-schedule-retraction.spec.ts` (extend) or a
+    new spec. Scenarios: publish with notify unchecked succeeds; edit a
+    published shift → warning dialog shows → save → shift changed and
+    week stays published. Depends on tasks 3, 10.
+
+## Order
+
+5 → 13 in parallel with 1 → 2 → 3.
+6, 7, 8 in parallel; then 9; then 10, 11, 12, 14; then 4, 15.

--- a/docs/superpowers/specs/2026-08-15-quiet-publish-live-edit-design.md
+++ b/docs/superpowers/specs/2026-08-15-quiet-publish-live-edit-design.md
@@ -47,6 +47,14 @@ alarmist banners; this design removes the cycle that produced them.
 - Add a `Checkbox` "Notify employees" to `PublishScheduleDialog`,
   checked on every open. `onConfirm` gains a second argument:
   `onConfirm(notes: string | undefined, notify: boolean)`.
+  - Reset mechanism: the dialog stays mounted in
+    `src/pages/Scheduling.tsx:1710-1724`, and the current `notes` reset
+    runs only in `handleConfirm`/`handleCancel`
+    (`src/components/PublishScheduleDialog.tsx:56-64`) — an Escape or
+    overlay close bypasses both. Reset `notify` to `true` (and `notes`
+    to `''`) in a `useEffect` keyed on `open`.
+  - Pair the checkbox with `<Label htmlFor>` / `<Checkbox id>`, same as
+    the Notes field (`src/components/PublishScheduleDialog.tsx:154-162`).
 - Add `notify: boolean` to `PublishScheduleParams`
   (`src/hooks/useSchedulePublish.tsx:9`). When `notify` is `false`, do
   not call `invokeScheduleNotification`. Return the outcome
@@ -54,10 +62,20 @@ alarmist banners; this design removes the cycle that produced them.
 - Add `'skipped'` to `NotificationOutcome`
   (`src/hooks/useSchedulePublish.tsx:36`). The toast for `skipped` is
   neutral: "Schedule Published" / "No notifications were sent."
-- No database change. `notification_sent` stays `false`, which is true.
-- No edge function change. The function is not called on a quiet
-  publish, so the lesson of 2026-07-20 (derive the message from DB
-  state) is not violated — there is no message.
+- No database change for the publish path. `notification_sent` stays
+  `false`, which is true.
+- The publish notify function is not called on a quiet publish, so the
+  lesson of 2026-07-20 (derive the message from DB state) is not
+  violated — there is no message.
+- **Retraction gate change (from Phase 2.5 review).**
+  `notify-schedule-unpublished` gates every retraction notice on
+  `schedule_publications.notification_sent`
+  (`supabase/functions/notify-schedule-unpublished/index.ts:180-187`).
+  A quiet publish leaves that flag `false`, so a later real retraction
+  of a live, visible week would send nothing. Change the gate: send the
+  retraction notice when the retracted publication row exists,
+  regardless of `notification_sent`. A published week is visible to
+  employees whether or not the publish was announced.
 
 ## Feature B: Change a published shift, with a warning
 
@@ -82,64 +100,167 @@ alarmist banners; this design removes the cycle that produced them.
 
 ### Change: the confirm flow
 
-- Delete the throw in `assertShiftNotLocked` callers. Replace with a
-  page-level confirm dialog, one instance per page (single-dialog
-  pattern, per CLAUDE.md).
-- New component `src/components/scheduling/PublishedShiftChangeDialog.tsx`:
-  an `AlertDialog` with:
-  - Title: "This shift is published"
-  - Body: "{Employee} can see this shift. Save the change anyway?"
-  - A `Checkbox` "Notify {employee} about this change", checked by
-    default. On a reassignment the label names both employees.
-  - Buttons: "Cancel" and "Save change".
-- New hook `usePublishedShiftGuard`. It wraps a mutation call. When the
-  target shift has `locked = true`, it opens the dialog and defers the
-  mutation until confirm. When not locked, it calls through directly.
-- Call sites to wire:
-  - `ShiftDialog` save path (`src/components/ShiftDialog.tsx`).
-  - Delete flows in `src/pages/Scheduling.tsx` and the timeline.
-  - Drag commit in the timeline
-    (`src/components/scheduling/ShiftTimeline/useTimelineBarDrag.ts`).
-  - `WeekScheduleMobile` edit path
-    (`src/components/scheduling/WeekScheduleMobile.tsx`).
+Two independent client-side lock mechanisms exist. Both get the same
+opt-in bypass:
+
+1. `assertShiftNotLocked` in `src/hooks/useShifts.tsx:377-389`, called
+   by `useUpdateShift` (`:317`) and mirrored by the throw in
+   `useUpdateShiftSeries` (`:627-628`).
+2. `assertNotLockedClient` in `src/lib/shiftMutationPipeline.ts:81-85`,
+   called 8 times in `src/hooks/useValidatedShiftMutations.ts`
+   (lines 363, 408, 446, 494, 530, 574, 602, 614). This pipeline serves
+   `TimelineShiftPopover.tsx`, `ShiftTimelineTab.tsx`, and
+   `useShiftPlanner.ts`.
+
+Changes:
+
+- Add an `allowPublished?: boolean` option to the mutations behind both
+  mechanisms. When `true`, skip the lock assertion. When absent, current
+  behavior is unchanged — the assertions stay as the last-line backstop.
+- New hook `usePublishedShiftGuard`, instantiated **once** in
+  `src/pages/Scheduling.tsx`. It renders the **single**
+  `PublishedShiftChangeDialog` instance for the page and exposes one
+  callback: `guardShiftChange({ shiftId, run })`. Child surfaces receive
+  the callback through props (single-dialog pattern, per CLAUDE.md).
+- `guardShiftChange` does a **fresh** SELECT of
+  `shifts.locked, employee_id` (the same query `assertShiftNotLocked`
+  already does at `src/hooks/useShifts.tsx:377-384`) — never the React
+  Query cache. A stale cache can say `locked: false` for a shift another
+  tab published seconds ago; the fresh read closes that hole.
+  - Fresh read says not locked → call `run({ allowPublished: false })`.
+    The inner assertion still backstops the small window between read
+    and write.
+  - Fresh read says locked → open the dialog. On confirm, call
+    `run({ allowPublished: true })`, then the notify step when checked.
+- Call sites to wire (each passes its mutation as `run`):
+  - `ShiftDialog` save path (`src/components/ShiftDialog.tsx`). This
+    also covers `WeekScheduleMobile.tsx`, which holds no mutation hook
+    and only opens `ShiftDialog` via `onEditShift`.
+  - Delete flows in `src/pages/Scheduling.tsx`, including
+    `useDeleteShift` and `useDeleteShiftSeries`
+    (`src/pages/Scheduling.tsx:322`).
+  - Timeline commit paths in
+    `src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx:694`
+    and `:734` (`validateAndUpdateTime` / `forceUpdateTime`), and the
+    edits in `TimelineShiftPopover.tsx`.
+  - Delete the gesture gates `if (locked) return;` in
+    `src/components/scheduling/ShiftTimeline/useTimelineBarDrag.ts:20`
+    and `:198`. Today they stop a drag on a locked shift before any
+    commit. With the guard in place, the gesture must start so the
+    commit can reach the dialog.
+- `useShiftPlanner.ts` keeps the current throw. The planner is a
+  programmatic bulk path; a per-shift dialog does not fit it. Same
+  category as `BulkEditShiftsDialog` (see Out of scope).
 - The shift stays `is_published = true, locked = true` after the edit.
   The week stays published. No banner changes on the employee page —
   the employee sees the updated shift, plus a notification when the
   manager chose one.
 
+### The dialog (`src/components/scheduling/PublishedShiftChangeDialog.tsx`)
+
+- An `AlertDialog` (installed; keeps the Radix focus trap and focus
+  return).
+- Title: "This shift is published". Style
+  `text-[17px] font-semibold text-foreground` — not the shadcn default
+  `text-lg`.
+- Description (`AlertDialogDescription`,
+  `text-[13px] text-muted-foreground`): "{Employee} can see this shift.
+  Save the change anyway?" On a reassignment, the copy names both
+  employees.
+- The `Checkbox` "Notify {employee} about this change" is a **sibling**
+  of the description, not inside it — an interactive control must not
+  sit in the `aria-describedby` block. Pair it with
+  `<Label htmlFor>` / `<Checkbox id>`, the same pattern as the Notes
+  field (`src/components/PublishScheduleDialog.tsx:154-162`). Checked
+  each time the dialog opens.
+- Buttons: "Cancel" and "Save change". Disable "Save change" while the
+  deferred mutation or the notify invoke is in flight — a fast
+  double-click must not fire twice.
+
 ### Change: the notification
 
+- New migration: add `notified_at TIMESTAMPTZ` (nullable) to
+  `schedule_change_logs`. This is the idempotency latch. The precedent
+  is `schedule_retractions.notified_at`
+  (`supabase/functions/notify-schedule-unpublished/index.ts:187-200`).
 - New edge function `supabase/functions/notify-shift-changed/index.ts`.
 - Request body: `{ changeLogId: string }` only. The body carries no
   decision fields (lesson 2026-07-20).
-- The function:
-  1. Authenticates the caller. Checks the caller has role
-     `owner`/`manager` on the log row's `restaurant_id` — same pattern
-     as `notify-schedule-published`.
+- The function, in this exact order:
+  1. Authenticates the caller (JWT present and valid).
   2. Reads the `schedule_change_logs` row by id with the service-role
-     client. Refuses (404/409) when the row is absent or older than 10
-     minutes — a stale id is not valid to notify on.
-  3. Derives everything from the row: `change_type`
+     client. Refuses (404) when the row is absent.
+  3. Checks the caller can edit the schedule for the row's
+     `restaurant_id`: `user_has_capability(restaurant_id,
+     'edit:scheduling')` — the same gate as the `shifts` UPDATE RLS
+     policy (`supabase/migrations/20260730150000_rewrite_collaborator_policies.sql:140-144`).
+     Refuses (403) on failure. The order matters: `restaurant_id` is
+     only known after step 2, and nothing sends before step 3 passes.
+  4. Refuses (409) when the row is older than 10 minutes, when
+     `change_type` is not `updated` or `deleted`, or when `shift_id`
+     is null. Restaurant-level `unpublished` rows have no `shift_id`
+     (`supabase/migrations/20251123000000_schedule_publishing.sql:243-259`)
+     and are not valid targets.
+  5. Claims the latch:
+     `UPDATE schedule_change_logs SET notified_at = now()
+      WHERE id = $1 AND notified_at IS NULL RETURNING id`.
+     Zero rows returned → already notified → answer 200 with
+     `{ sent: 0, alreadyNotified: true }`. A double-click or client
+     retry cannot send twice.
+  6. Derives everything from the row: `change_type`
      (`updated`/`deleted`), the shift fields from
      `before_data`/`after_data`, and the recipients.
-  4. Recipients: `before_data.employee_id`, plus `after_data.employee_id`
-     when different (reassignment). Resolve names/emails from
-     `employees`, push subscriptions via the existing
-     `webPushFanout` helper (`supabase/functions/_shared/webPushFanout.ts`).
-  5. Sends one email + push per recipient with the concrete change:
+  7. Recipients: `before_data.employee_id`, plus `after_data.employee_id`
+     when different (reassignment). When every recipient slot is null
+     (an open shift), answer 200 with `{ sent: 0 }`. Resolve
+     names/emails from `employees`. Send push via `sendWebPushToUser`
+     in `supabase/functions/_shared/webPushHelper.ts:98` — the same
+     helper `notify-schedule-published/index.ts:296` uses.
+     (`webPushFanout.ts` holds only the dedup filter and the bounded
+     loop, not the sender.)
+  8. Sends one email + push per recipient with the concrete change:
      "Your Tue 5:00 PM shift changed to 6:00 PM", "Your Tue shift was
      removed", "You have a new shift".
-  6. Returns `{ sent, failed }` — same contract that
+  9. Returns `{ sent, failed }` — same contract that
      `invokeScheduleNotification` already parses
      (`src/hooks/useSchedulePublish.tsx:115-136`).
 - Client: after the guarded mutation commits and when the manager left
-  "Notify" checked, look up the newest `schedule_change_logs` row for
-  that shift (SELECT is allowed to restaurant members per
+  "Notify" checked, look up the log row (SELECT is allowed to restaurant
+  members per
   `supabase/migrations/20251123000000_schedule_publishing.sql:74-83`),
-  then call the function with its id. Reuse `invokeScheduleNotification`
-  for outcome handling and toasts.
+  then call the function with its id.
+  - The lookup is scoped, not "newest for the shift": filter on
+    `shift_id`, `changed_by = auth.uid()`, and
+    `changed_at >= <mutation start time>`, order by `changed_at`
+    descending, limit 1. Another manager's concurrent edit can never be
+    picked — `changed_by` excludes it.
+  - Toast copy: pass `{ title: 'Shift updated', successDescription:
+    '{Employee} was notified.' }` to `notificationToast`. Its non-`sent`
+    branches build titles from the passed title
+    (`src/hooks/useSchedulePublish.tsx:173-204`), so the failure toast
+    reads "Shift updated — some employees not notified", which is
+    correct for this context.
 - When the manager unchecks "Notify": no call. The change log row still
   exists — the audit trail does not depend on the notification.
+
+## Decided trade-offs
+
+- **Check-then-write window.** `guardShiftChange` reads `locked` fresh,
+  then writes. A publish can land between the two. The inner lock
+  assertion catches that case and shows the existing error toast. Full
+  atomicity needs a DB-level guard; the window is under a second and the
+  failure mode is a blocked write, not a silent one. Accepted.
+- **Own-edit rapid-fire race.** One manager, two edits to the same
+  shift inside the lookup window: the scoped lookup picks the newest of
+  the manager's own rows. The notification then describes the final
+  state, which is the message the employee needs. The `notified_at`
+  latch stops any double-send per row. The reviewer's stronger fix (an
+  RPC that returns the trigger's log id via `RETURNING`) needs a new
+  RPC that re-implements the shift UPDATE; deferred unless the build
+  finds the lookup fragile in tests.
+- **`useShiftPlanner` and `BulkEditShiftsDialog` keep the throw.**
+  Bulk paths need a batch notification design; one dialog per shift
+  does not fit. Follow-up work.
 
 ### Why the client passes a `changeLogId` and not the change itself
 
@@ -166,8 +287,12 @@ happened, to the people it actually happened to.
   skips the invoke when `notify` is false; `notificationToast` copy for
   `skipped`; `PublishedShiftChangeDialog` render + callbacks;
   `usePublishedShiftGuard` gates locked shifts and passes unlocked ones.
-- pgTAP: none needed — no schema change, no RPC change. The
-  `log_shift_change` trigger already has coverage.
+- Unit (Feature B additions): `allowPublished` skips both lock
+  assertions and leaves default behavior unchanged; the guard's fresh
+  read (not cache) decides the dialog; the log-row lookup filter
+  (`shift_id` + `changed_by` + `changed_at`).
+- pgTAP: the new migration — `schedule_change_logs.notified_at` exists,
+  is nullable, and defaults to NULL.
 - E2E (`tests/e2e/`): extend the publish-states spec: publish with
   notify unchecked (assert the publish succeeds), edit a published shift
   via the guard dialog (assert the warning shows, the change saves, and

--- a/docs/superpowers/specs/2026-08-15-quiet-publish-live-edit-design.md
+++ b/docs/superpowers/specs/2026-08-15-quiet-publish-live-edit-design.md
@@ -1,0 +1,176 @@
+# Design: Quiet publish and live edit of a published schedule
+
+Date: 2026-08-15
+Author: Claude (with Jose)
+Status: Draft for Phase 2.5 review
+
+## Problem
+
+Managers republish after a small change. Each publish notifies every
+scheduled employee (`src/hooks/useSchedulePublish.tsx:260`). Each edit
+of a published week requires a full unpublish first, because the client
+throws on any change to a locked shift (`src/hooks/useShifts.tsx:386`).
+The unpublish then notifies everyone again
+(`src/hooks/useSchedulePublish.tsx:325`). The result is a loud
+publish/unpublish cycle for a one-shift correction. Employees get
+repeated notifications that contradict each other. PR #753 removed the
+alarmist banners; this design removes the cycle that produced them.
+
+## Decisions (approved by Jose, 2026-08-15)
+
+1. The publish dialog gets a "Notify employees" option, checked by
+   default on every open.
+2. Every change path to a published shift shows one warning flow: the
+   edit dialog, the delete flow, and the timeline drag.
+3. On a reassignment, both the old and the new employee can get the
+   change notification.
+
+## Feature A: Publish without notifications
+
+### Current behavior (cited)
+
+- `PublishScheduleDialog` collects only `notes`, then calls
+  `onConfirm(notes)` (`src/components/PublishScheduleDialog.tsx:34`,
+  `:56-59`).
+- `usePublishSchedule` always awaits
+  `invokeScheduleNotification('notify-schedule-published', …)` after the
+  `publish_schedule` RPC commits
+  (`src/hooks/useSchedulePublish.tsx:260`).
+- `schedule_publications.notification_sent` defaults to `false`
+  (`supabase/migrations/20251123000000_schedule_publishing.sql:17`). The
+  only writer that sets it `true` is the edge function after a
+  successful fan-out
+  (`supabase/functions/notify-schedule-published/index.ts:338`).
+
+### Change
+
+- Add a `Checkbox` "Notify employees" to `PublishScheduleDialog`,
+  checked on every open. `onConfirm` gains a second argument:
+  `onConfirm(notes: string | undefined, notify: boolean)`.
+- Add `notify: boolean` to `PublishScheduleParams`
+  (`src/hooks/useSchedulePublish.tsx:9`). When `notify` is `false`, do
+  not call `invokeScheduleNotification`. Return the outcome
+  `{ status: 'skipped' }`.
+- Add `'skipped'` to `NotificationOutcome`
+  (`src/hooks/useSchedulePublish.tsx:36`). The toast for `skipped` is
+  neutral: "Schedule Published" / "No notifications were sent."
+- No database change. `notification_sent` stays `false`, which is true.
+- No edge function change. The function is not called on a quiet
+  publish, so the lesson of 2026-07-20 (derive the message from DB
+  state) is not violated — there is no message.
+
+## Feature B: Change a published shift, with a warning
+
+### Current behavior (cited)
+
+- `useUpdateShift` calls `assertShiftNotLocked(id)` and throws
+  "Cannot modify a locked shift. The schedule has been published."
+  (`src/hooks/useShifts.tsx:317`, `:377-389`).
+- `useUpdateShiftSeries` throws the same way for a locked occurrence
+  (`src/hooks/useShifts.tsx:627-628`).
+- `useDeleteShift` deletes without a lock check, but the series delete
+  RPC takes `p_include_locked` and reports a `locked_count`
+  (`src/hooks/useShifts.tsx:517`, `:525`).
+- The `log_shift_changes` trigger records every UPDATE and DELETE of a
+  published shift into `schedule_change_logs`, with `change_type`,
+  `employee_id`, `changed_by`, `before_data`, and `after_data`
+  (`supabase/migrations/20251123000000_schedule_publishing.sql:97-166`).
+- The publish RPC sets `locked = true` on every shift in the week
+  (`supabase/migrations/20260729120000_publish_schedule_tz_bucketing.sql:97`).
+  No trigger or RLS policy blocks an update to a locked shift — the
+  block is client-side only (`src/hooks/useShifts.tsx:386`).
+
+### Change: the confirm flow
+
+- Delete the throw in `assertShiftNotLocked` callers. Replace with a
+  page-level confirm dialog, one instance per page (single-dialog
+  pattern, per CLAUDE.md).
+- New component `src/components/scheduling/PublishedShiftChangeDialog.tsx`:
+  an `AlertDialog` with:
+  - Title: "This shift is published"
+  - Body: "{Employee} can see this shift. Save the change anyway?"
+  - A `Checkbox` "Notify {employee} about this change", checked by
+    default. On a reassignment the label names both employees.
+  - Buttons: "Cancel" and "Save change".
+- New hook `usePublishedShiftGuard`. It wraps a mutation call. When the
+  target shift has `locked = true`, it opens the dialog and defers the
+  mutation until confirm. When not locked, it calls through directly.
+- Call sites to wire:
+  - `ShiftDialog` save path (`src/components/ShiftDialog.tsx`).
+  - Delete flows in `src/pages/Scheduling.tsx` and the timeline.
+  - Drag commit in the timeline
+    (`src/components/scheduling/ShiftTimeline/useTimelineBarDrag.ts`).
+  - `WeekScheduleMobile` edit path
+    (`src/components/scheduling/WeekScheduleMobile.tsx`).
+- The shift stays `is_published = true, locked = true` after the edit.
+  The week stays published. No banner changes on the employee page —
+  the employee sees the updated shift, plus a notification when the
+  manager chose one.
+
+### Change: the notification
+
+- New edge function `supabase/functions/notify-shift-changed/index.ts`.
+- Request body: `{ changeLogId: string }` only. The body carries no
+  decision fields (lesson 2026-07-20).
+- The function:
+  1. Authenticates the caller. Checks the caller has role
+     `owner`/`manager` on the log row's `restaurant_id` — same pattern
+     as `notify-schedule-published`.
+  2. Reads the `schedule_change_logs` row by id with the service-role
+     client. Refuses (404/409) when the row is absent or older than 10
+     minutes — a stale id is not valid to notify on.
+  3. Derives everything from the row: `change_type`
+     (`updated`/`deleted`), the shift fields from
+     `before_data`/`after_data`, and the recipients.
+  4. Recipients: `before_data.employee_id`, plus `after_data.employee_id`
+     when different (reassignment). Resolve names/emails from
+     `employees`, push subscriptions via the existing
+     `webPushFanout` helper (`supabase/functions/_shared/webPushFanout.ts`).
+  5. Sends one email + push per recipient with the concrete change:
+     "Your Tue 5:00 PM shift changed to 6:00 PM", "Your Tue shift was
+     removed", "You have a new shift".
+  6. Returns `{ sent, failed }` — same contract that
+     `invokeScheduleNotification` already parses
+     (`src/hooks/useSchedulePublish.tsx:115-136`).
+- Client: after the guarded mutation commits and when the manager left
+  "Notify" checked, look up the newest `schedule_change_logs` row for
+  that shift (SELECT is allowed to restaurant members per
+  `supabase/migrations/20251123000000_schedule_publishing.sql:74-83`),
+  then call the function with its id. Reuse `invokeScheduleNotification`
+  for outcome handling and toasts.
+- When the manager unchecks "Notify": no call. The change log row still
+  exists — the audit trail does not depend on the notification.
+
+### Why the client passes a `changeLogId` and not the change itself
+
+The trigger writes the log row in the same transaction as the shift
+change (`supabase/migrations/20251123000000_schedule_publishing.sql:164-166`,
+AFTER trigger). By the time the client calls the function, the row is
+committed truth. The function trusts only that row. A malicious or
+buggy caller can only cause a notification that matches what actually
+happened, to the people it actually happened to.
+
+## Out of scope
+
+- `BulkEditShiftsDialog` and the shift import keep the current locked
+  behavior. A bulk path can batch many change-log rows; one notification
+  per row would spam. Defer to a follow-up.
+- Per-restaurant defaults ("never notify") — a settings surface, not
+  this change.
+- The unpublish flow keeps its notification (it still exists for real
+  retractions), but with Feature B managers should rarely need it.
+
+## Testing
+
+- Unit: `PublishScheduleDialog` checkbox behavior; `usePublishSchedule`
+  skips the invoke when `notify` is false; `notificationToast` copy for
+  `skipped`; `PublishedShiftChangeDialog` render + callbacks;
+  `usePublishedShiftGuard` gates locked shifts and passes unlocked ones.
+- pgTAP: none needed — no schema change, no RPC change. The
+  `log_shift_change` trigger already has coverage.
+- E2E (`tests/e2e/`): extend the publish-states spec: publish with
+  notify unchecked (assert the publish succeeds), edit a published shift
+  via the guard dialog (assert the warning shows, the change saves, and
+  the week stays published — no unpublish).
+- Edge function: deno unit test for the derive-from-log logic if the
+  repo has precedent; otherwise cover the request-shape guards.

--- a/src/components/PublishScheduleDialog.tsx
+++ b/src/components/PublishScheduleDialog.tsx
@@ -147,9 +147,8 @@ export const PublishScheduleDialog = ({
             <AlertDescription className="text-sm">
               <strong>Important:</strong> Once published, the schedule will be:
               <ul className="list-disc list-inside mt-2 space-y-1 text-xs">
-                <li>Locked and cannot be edited without unpublishing</li>
                 <li>Visible to all employees</li>
-                <li>Sent via push notifications to staff</li>
+                <li>Editable — a change to a published shift asks you to confirm first</li>
               </ul>
             </AlertDescription>
           </Alert>

--- a/src/components/PublishScheduleDialog.tsx
+++ b/src/components/PublishScheduleDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -9,6 +9,7 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { 
@@ -31,7 +32,7 @@ interface PublishScheduleDialogProps {
   openShiftCount: number;
   openShiftsEnabled: boolean;
   broadcastDate?: string | null;
-  onConfirm: (notes?: string) => void;
+  onConfirm: (notes: string | undefined, notify: boolean) => void;
   onNavigateToSettings?: () => void;
   isPublishing: boolean;
 }
@@ -52,9 +53,18 @@ export const PublishScheduleDialog = ({
   isPublishing,
 }: PublishScheduleDialogProps) => {
   const [notes, setNotes] = useState('');
+  const [notify, setNotify] = useState(true);
+
+  // Every time the dialog opens, it starts clean: notify checked, notes empty.
+  useEffect(() => {
+    if (open) {
+      setNotify(true);
+      setNotes('');
+    }
+  }, [open]);
 
   const handleConfirm = () => {
-    onConfirm(notes.trim() || undefined);
+    onConfirm(notes.trim() || undefined, notify);
     setNotes('');
   };
 
@@ -160,6 +170,22 @@ export const PublishScheduleDialog = ({
               className="min-h-[80px]"
               disabled={isPublishing}
             />
+          </div>
+
+          {/* Notify Employees Checkbox */}
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="publish-notify-employees"
+              checked={notify}
+              onCheckedChange={(checked) => setNotify(checked === true)}
+              disabled={isPublishing}
+            />
+            <Label
+              htmlFor="publish-notify-employees"
+              className="text-[13px] font-normal text-foreground"
+            >
+              Notify employees about this schedule
+            </Label>
           </div>
         </div>
 

--- a/src/components/PublishScheduleDialog.tsx
+++ b/src/components/PublishScheduleDialog.tsx
@@ -198,7 +198,7 @@ export const PublishScheduleDialog = ({
           */}
           <span role="status" aria-live="polite" className="sr-only">
             {isPublishing
-              ? employeeCount > 0
+              ? notify && employeeCount > 0
                 ? `Publishing. Notifying ${employeeCount} ${employeeCount === 1 ? 'employee' : 'employees'}.`
                 : 'Publishing.'
               : ''}
@@ -228,7 +228,7 @@ export const PublishScheduleDialog = ({
                 <Clock className="h-4 w-4 mr-2 animate-spin" aria-hidden="true" />
                 {/* Not a live region: the sr-only one above owns the announcement. */}
                 <span>
-                  {employeeCount > 0 ? `Notifying ${employeeCount}...` : 'Publishing...'}
+                  {notify && employeeCount > 0 ? `Notifying ${employeeCount}...` : 'Publishing...'}
                 </span>
               </>
             ) : (

--- a/src/components/ShiftDialog.tsx
+++ b/src/components/ShiftDialog.tsx
@@ -16,6 +16,7 @@ import { formatLocalDateInTz, formatLocalHHMMInTz, wallClockToInstant } from '@/
 import { CustomRecurrenceDialog } from '@/components/CustomRecurrenceDialog';
 import { getRecurrencePresetsForDate, getRecurrenceDescription } from '@/utils/recurrenceUtils';
 import { AlertTriangle, Repeat } from 'lucide-react';
+import { GuardShiftChangeOptions } from '@/hooks/usePublishedShiftGuard';
 
 interface ShiftDialogProps {
   open: boolean;
@@ -25,6 +26,12 @@ interface ShiftDialogProps {
   timezone?: string; // Restaurant timezone for formatting availability times
   defaultDate?: Date;
   defaultEmployee?: DefaultEmployee;
+  /**
+   * Gate for a save that touches a published shift. The edit path always
+   * routes through it — a create can never target a locked shift. Provided
+   * once per page by `usePublishedShiftGuard`.
+   */
+  guardShiftChange: (options: GuardShiftChangeOptions) => void | Promise<void>;
 }
 
 export interface DefaultEmployee {
@@ -45,14 +52,13 @@ const POSITIONS = [
   'Other',
 ];
 
-function getSubmitLabel(isSaving: boolean, isLocked: boolean, isEditing: boolean): string {
+function getSubmitLabel(isSaving: boolean, isEditing: boolean): string {
   if (isSaving) return 'Saving...';
-  if (isLocked) return 'Locked';
   if (isEditing) return 'Update Shift';
   return 'Create Shift';
 }
 
-export function ShiftDialog({ open, onOpenChange, shift, restaurantId, timezone = 'UTC', defaultDate, defaultEmployee }: ShiftDialogProps) {
+export function ShiftDialog({ open, onOpenChange, shift, restaurantId, timezone = 'UTC', defaultDate, defaultEmployee, guardShiftChange }: ShiftDialogProps) {
   const [employeeId, setEmployeeId] = useState('');
   const [startDate, setStartDate] = useState('');
   const [startTime, setStartTime] = useState('');
@@ -195,33 +201,47 @@ export function ShiftDialog({ open, onOpenChange, shift, restaurantId, timezone 
     };
 
     if (shift) {
-      // If we have an edit scope (from recurring action dialog), use series update
-      if (editScope && editScope !== 'this') {
-        updateShiftSeries.mutate(
-          {
-            shift,
-            scope: editScope,
-            updates: shiftData,
-            restaurantId,
-          },
-          {
-            onSuccess: () => {
-              onOpenChange(false);
-              resetForm();
-            },
+      const employeeName = employees.find((emp) => emp.id === shift.employee_id)?.name ?? '';
+      const isReassignment = employeeId !== shift.employee_id;
+      const secondEmployeeName = isReassignment
+        ? employees.find((emp) => emp.id === employeeId)?.name
+        : undefined;
+
+      guardShiftChange({
+        shiftId: shift.id,
+        employeeName,
+        secondEmployeeName,
+        run: ({ allowPublished }) => {
+          // If we have an edit scope (from recurring action dialog), use series update
+          if (editScope && editScope !== 'this') {
+            updateShiftSeries.mutate(
+              {
+                shift,
+                scope: editScope,
+                updates: shiftData,
+                restaurantId,
+                allowPublished,
+              },
+              {
+                onSuccess: () => {
+                  onOpenChange(false);
+                  resetForm();
+                },
+              }
+            );
+          } else {
+            updateShift.mutate(
+              { id: shift.id, ...shiftData, allowPublished },
+              {
+                onSuccess: () => {
+                  onOpenChange(false);
+                  resetForm();
+                },
+              }
+            );
           }
-        );
-      } else {
-        updateShift.mutate(
-          { id: shift.id, ...shiftData },
-          {
-            onSuccess: () => {
-              onOpenChange(false);
-              resetForm();
-            },
-          }
-        );
-      }
+        },
+      });
     } else {
       createShift.mutate(shiftData as any, {
         onSuccess: () => {
@@ -500,11 +520,10 @@ export function ShiftDialog({ open, onOpenChange, shift, restaurantId, timezone 
             </Button>
             <Button
               type="submit"
-              disabled={createShift.isPending || updateShift.isPending || updateShiftSeries.isPending || shift?.locked}
+              disabled={createShift.isPending || updateShift.isPending || updateShiftSeries.isPending}
             >
               {getSubmitLabel(
                 createShift.isPending || updateShift.isPending || updateShiftSeries.isPending,
-                shift?.locked ?? false,
                 !!shift,
               )}
             </Button>

--- a/src/components/ShiftDialog.tsx
+++ b/src/components/ShiftDialog.tsx
@@ -209,6 +209,7 @@ export function ShiftDialog({ open, onOpenChange, shift, restaurantId, timezone 
 
       guardShiftChange({
         shiftId: shift.id,
+        restaurantId,
         employeeName,
         secondEmployeeName,
         // Awaited, not fire-and-forget `.mutate()` — `usePublishedShiftGuard`

--- a/src/components/ShiftDialog.tsx
+++ b/src/components/ShiftDialog.tsx
@@ -211,35 +211,24 @@ export function ShiftDialog({ open, onOpenChange, shift, restaurantId, timezone 
         shiftId: shift.id,
         employeeName,
         secondEmployeeName,
-        run: ({ allowPublished }) => {
+        // Awaited, not fire-and-forget `.mutate()` — `usePublishedShiftGuard`
+        // looks up the change-log row right after `run` resolves, and that
+        // row only exists once this UPDATE (and its trigger) have committed.
+        run: async ({ allowPublished }) => {
           // If we have an edit scope (from recurring action dialog), use series update
           if (editScope && editScope !== 'this') {
-            updateShiftSeries.mutate(
-              {
-                shift,
-                scope: editScope,
-                updates: shiftData,
-                restaurantId,
-                allowPublished,
-              },
-              {
-                onSuccess: () => {
-                  onOpenChange(false);
-                  resetForm();
-                },
-              }
-            );
+            await updateShiftSeries.mutateAsync({
+              shift,
+              scope: editScope,
+              updates: shiftData,
+              restaurantId,
+              allowPublished,
+            });
           } else {
-            updateShift.mutate(
-              { id: shift.id, ...shiftData, allowPublished },
-              {
-                onSuccess: () => {
-                  onOpenChange(false);
-                  resetForm();
-                },
-              }
-            );
+            await updateShift.mutateAsync({ id: shift.id, ...shiftData, allowPublished });
           }
+          onOpenChange(false);
+          resetForm();
         },
       });
     } else {

--- a/src/components/ShiftDialog.tsx
+++ b/src/components/ShiftDialog.tsx
@@ -301,35 +301,6 @@ export function ShiftDialog({ open, onOpenChange, shift, restaurantId, timezone 
         </DialogHeader>
         <form onSubmit={handleSubmit}>
           <div className="space-y-4 py-4">
-            {/* Lock Warning for Published Shifts */}
-            {shift?.locked && (
-              <div className="p-4 bg-yellow-50 dark:bg-yellow-950/20 border border-yellow-200 dark:border-yellow-800 rounded-lg">
-                <div className="flex items-center gap-2 text-yellow-800 dark:text-yellow-200">
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    width="20"
-                    height="20"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <rect width="18" height="11" x="3" y="11" rx="2" ry="2" />
-                    <path d="M7 11V7a5 5 0 0 1 10 0v4" />
-                  </svg>
-                  <div>
-                    <div className="font-semibold text-sm">Shift is Locked</div>
-                    <div className="text-xs mt-1">
-                      This shift is part of a published schedule and cannot be edited.
-                      You must unpublish the schedule first to make changes.
-                    </div>
-                  </div>
-                </div>
-              </div>
-            )}
-
             <div className="space-y-2">
               <Label htmlFor="employee">
                 Employee <span className="text-destructive">*</span>

--- a/src/components/ShiftDialog.tsx
+++ b/src/components/ShiftDialog.tsx
@@ -8,7 +8,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Shift, RecurrencePattern, RecurrenceType, ConflictCheck } from '@/types/scheduling';
 import { formatConflictLine } from '@/lib/conflictFormatUtils';
 import { useCreateShift, useUpdateShift, useUpdateShiftSeries } from '@/hooks/useShifts';
-import { RecurringActionScope } from '@/utils/recurringShiftHelpers';
+import { RecurringActionScope, getSeriesParentId } from '@/utils/recurringShiftHelpers';
 import { useEmployees } from '@/hooks/useEmployees';
 import { useCheckConflicts } from '@/hooks/useConflictDetection';
 import { format, getDay } from 'date-fns';
@@ -185,6 +185,10 @@ export function ShiftDialog({ open, onOpenChange, shift, restaurantId, timezone 
       return;
     }
 
+    // No is_published/locked here. An edit must never touch the publish
+    // flags: writing false would silently retract a published shift the
+    // manager only meant to move. The create path adds them below — a new
+    // shift always starts as an unlocked draft.
     const shiftData = {
       restaurant_id: restaurantId,
       employee_id: employeeId,
@@ -196,8 +200,6 @@ export function ShiftDialog({ open, onOpenChange, shift, restaurantId, timezone 
       notes: notes || undefined,
       recurrence_pattern: recurrencePattern,
       is_recurring: recurrencePattern !== null,
-      is_published: false,
-      locked: false,
     };
 
     if (shift) {
@@ -212,6 +214,18 @@ export function ShiftDialog({ open, onOpenChange, shift, restaurantId, timezone 
         restaurantId,
         employeeName,
         secondEmployeeName,
+        // A 'following'/'all' edit touches sibling occurrences too. The
+        // guard must warn when ANY shift in scope is locked, not only the
+        // anchor — an unlocked anchor with locked siblings would otherwise
+        // skip the dialog while the RPC touches published shifts.
+        series:
+          editScope && editScope !== 'this'
+            ? {
+                parentId: getSeriesParentId(shift),
+                scope: editScope,
+                fromTime: editScope === 'following' ? shift.start_time : undefined,
+              }
+            : undefined,
         // Awaited, not fire-and-forget `.mutate()` — `usePublishedShiftGuard`
         // looks up the change-log row right after `run` resolves, and that
         // row only exists once this UPDATE (and its trigger) have committed.
@@ -233,7 +247,8 @@ export function ShiftDialog({ open, onOpenChange, shift, restaurantId, timezone 
         },
       });
     } else {
-      createShift.mutate(shiftData as any, {
+      // A new shift always starts as an unlocked draft.
+      createShift.mutate({ ...shiftData, is_published: false, locked: false } as any, {
         onSuccess: () => {
           onOpenChange(false);
           resetForm();

--- a/src/components/scheduling/PublishedShiftChangeDialog.tsx
+++ b/src/components/scheduling/PublishedShiftChangeDialog.tsx
@@ -13,6 +13,8 @@ import {
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
 
+import { formatNamesLabel } from '@/lib/scheduling/formatNamesLabel';
+
 interface PublishedShiftChangeDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -21,11 +23,6 @@ interface PublishedShiftChangeDialogProps {
   secondEmployeeName?: string;
   isPending: boolean;
   onConfirm: (options: { notify: boolean }) => void;
-}
-
-/** "Alex" or "Alex and Sam" — shared with usePublishedShiftGuard's notify toast. */
-export function formatNamesLabel(employeeName: string, secondEmployeeName?: string): string {
-  return secondEmployeeName ? `${employeeName} and ${secondEmployeeName}` : employeeName;
 }
 
 export function PublishedShiftChangeDialog({

--- a/src/components/scheduling/PublishedShiftChangeDialog.tsx
+++ b/src/components/scheduling/PublishedShiftChangeDialog.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState, type MouseEvent } from 'react';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+
+interface PublishedShiftChangeDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  employeeName: string;
+  /** Set on a reassignment. The dialog then names both employees. */
+  secondEmployeeName?: string;
+  isPending: boolean;
+  onConfirm: (options: { notify: boolean }) => void;
+}
+
+export function PublishedShiftChangeDialog({
+  open,
+  onOpenChange,
+  employeeName,
+  secondEmployeeName,
+  isPending,
+  onConfirm,
+}: Readonly<PublishedShiftChangeDialogProps>) {
+  const [notify, setNotify] = useState(true);
+
+  // The checkbox starts checked every time the dialog opens.
+  useEffect(() => {
+    if (open) {
+      setNotify(true);
+    }
+  }, [open]);
+
+  const namesLabel = secondEmployeeName
+    ? `${employeeName} and ${secondEmployeeName}`
+    : employeeName;
+
+  const handleConfirm = (event: MouseEvent) => {
+    // AlertDialogAction closes the dialog on click by default. Block that
+    // while the mutation is in flight so a fast double-click cannot fire twice.
+    if (isPending) {
+      event.preventDefault();
+      return;
+    }
+    onConfirm({ notify });
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent className="sm:max-w-md">
+        <AlertDialogHeader>
+          <AlertDialogTitle className="text-[17px] font-semibold text-foreground">
+            This shift is published
+          </AlertDialogTitle>
+          <AlertDialogDescription className="text-[13px] text-muted-foreground">
+            {namesLabel} can see this shift. Save the change anyway?
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="published-shift-change-notify"
+            checked={notify}
+            onCheckedChange={(checked) => setNotify(checked === true)}
+            disabled={isPending}
+          />
+          <Label
+            htmlFor="published-shift-change-notify"
+            className="text-[13px] font-normal text-foreground"
+          >
+            Notify {namesLabel} about this change
+          </Label>
+        </div>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={handleConfirm} disabled={isPending}>
+            Save change
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/scheduling/PublishedShiftChangeDialog.tsx
+++ b/src/components/scheduling/PublishedShiftChangeDialog.tsx
@@ -23,6 +23,11 @@ interface PublishedShiftChangeDialogProps {
   onConfirm: (options: { notify: boolean }) => void;
 }
 
+/** "Alex" or "Alex and Sam" — shared with usePublishedShiftGuard's notify toast. */
+export function formatNamesLabel(employeeName: string, secondEmployeeName?: string): string {
+  return secondEmployeeName ? `${employeeName} and ${secondEmployeeName}` : employeeName;
+}
+
 export function PublishedShiftChangeDialog({
   open,
   onOpenChange,
@@ -40,9 +45,7 @@ export function PublishedShiftChangeDialog({
     }
   }, [open]);
 
-  const namesLabel = secondEmployeeName
-    ? `${employeeName} and ${secondEmployeeName}`
-    : employeeName;
+  const namesLabel = formatNamesLabel(employeeName, secondEmployeeName);
 
   const handleConfirm = (event: MouseEvent) => {
     // AlertDialogAction closes the dialog on click by default. Block that

--- a/src/components/scheduling/PublishedShiftChangeDialog.tsx
+++ b/src/components/scheduling/PublishedShiftChangeDialog.tsx
@@ -48,12 +48,12 @@ export function PublishedShiftChangeDialog({
   const namesLabel = formatNamesLabel(employeeName, secondEmployeeName);
 
   const handleConfirm = (event: MouseEvent) => {
-    // AlertDialogAction closes the dialog on click by default. Block that
-    // while the mutation is in flight so a fast double-click cannot fire twice.
-    if (isPending) {
-      event.preventDefault();
-      return;
-    }
+    // AlertDialogAction closes the dialog on click by default. Always block
+    // that: `onConfirm` is async and the guard clears `pending` itself only
+    // once the change actually commits, so a Radix auto-close here would
+    // race ahead of a failed mutation and leave it unretryable.
+    event.preventDefault();
+    if (isPending) return;
     onConfirm({ notify });
   };
 

--- a/src/components/scheduling/ShiftPlanner/ShiftPlannerTab.tsx
+++ b/src/components/scheduling/ShiftPlanner/ShiftPlannerTab.tsx
@@ -479,7 +479,7 @@ export function ShiftPlannerTab({
       setTimeout(() => setHighlightCellId(null), 600);
       // `day` is a date-only token parsed at local midnight; this reads the
       // weekday of that calendar day, so local fields are correct here.
-       
+      // eslint-disable-next-line no-restricted-syntax
       const dayLabel = new Date(day + 'T00:00:00').toLocaleDateString('en-US', { weekday: 'short' });
       toast({ title: `${employee.name} assigned to ${template.name} — ${dayLabel}` });
     } else if (result.pendingConflicts?.length || result.pendingWarnings?.length) {

--- a/src/components/scheduling/ShiftPlanner/ShiftPlannerTab.tsx
+++ b/src/components/scheduling/ShiftPlanner/ShiftPlannerTab.tsx
@@ -60,11 +60,18 @@ import { useEmployeeAvailability, useAvailabilityExceptions } from '@/hooks/useA
 import { computeEffectiveAvailability } from '@/lib/effectiveAvailability';
 import { GenerateScheduleDialog } from './GenerateScheduleDialog';
 import { ShiftTimelineTab } from '../ShiftTimeline/ShiftTimelineTab';
+import type { GuardShiftChangeOptions } from '@/hooks/usePublishedShiftGuard';
 
 interface ShiftPlannerTabProps {
   restaurantId: string;
   weekStart: Date;
   onWeekStartChange: (next: Date) => void;
+  /**
+   * The page's single `usePublishedShiftGuard` instance (design doc: one
+   * guard per page, threaded down to every surface that can change a
+   * shift). Forwarded straight through to the timeline tab.
+   */
+  guardShiftChange: (options: GuardShiftChangeOptions) => void | Promise<void>;
 }
 
 /** Format a template's slot label for CoverageDetail headings.
@@ -112,6 +119,7 @@ export function ShiftPlannerTab({
   restaurantId,
   weekStart: externalWeekStart,
   onWeekStartChange,
+  guardShiftChange,
 }: Readonly<ShiftPlannerTabProps>) {
   const { selectedRestaurant } = useRestaurantContext();
   const restaurantName = selectedRestaurant?.restaurant?.name;
@@ -471,7 +479,7 @@ export function ShiftPlannerTab({
       setTimeout(() => setHighlightCellId(null), 600);
       // `day` is a date-only token parsed at local midnight; this reads the
       // weekday of that calendar day, so local fields are correct here.
-      // eslint-disable-next-line no-restricted-syntax
+       
       const dayLabel = new Date(day + 'T00:00:00').toLocaleDateString('en-US', { weekday: 'short' });
       toast({ title: `${employee.name} assigned to ${template.name} — ${dayLabel}` });
     } else if (result.pendingConflicts?.length || result.pendingWarnings?.length) {
@@ -810,6 +818,7 @@ export function ShiftPlannerTab({
           loading={false}
           error={null}
           availabilityByEmployee={availabilityByEmployee}
+          guardShiftChange={guardShiftChange}
         />
       )}
 

--- a/src/components/scheduling/ShiftPlanner/ShiftPlannerTab.tsx
+++ b/src/components/scheduling/ShiftPlanner/ShiftPlannerTab.tsx
@@ -60,7 +60,10 @@ import { useEmployeeAvailability, useAvailabilityExceptions } from '@/hooks/useA
 import { computeEffectiveAvailability } from '@/lib/effectiveAvailability';
 import { GenerateScheduleDialog } from './GenerateScheduleDialog';
 import { ShiftTimelineTab } from '../ShiftTimeline/ShiftTimelineTab';
-import type { GuardShiftChangeOptions } from '@/hooks/usePublishedShiftGuard';
+import type {
+  GuardShiftChangeOptions,
+  NotifyAfterDeferredCommitArgs,
+} from '@/hooks/usePublishedShiftGuard';
 
 interface ShiftPlannerTabProps {
   restaurantId: string;
@@ -72,6 +75,12 @@ interface ShiftPlannerTabProps {
    * shift). Forwarded straight through to the timeline tab.
    */
   guardShiftChange: (options: GuardShiftChangeOptions) => void | Promise<void>;
+  /**
+   * Same guard instance's deferred-notify step, for a `run` that surfaced a
+   * conflict dialog instead of committing. Forwarded straight through to the
+   * timeline tab.
+   */
+  notifyAfterDeferredCommit: (args: NotifyAfterDeferredCommitArgs) => void | Promise<void>;
 }
 
 /** Format a template's slot label for CoverageDetail headings.
@@ -120,6 +129,7 @@ export function ShiftPlannerTab({
   weekStart: externalWeekStart,
   onWeekStartChange,
   guardShiftChange,
+  notifyAfterDeferredCommit,
 }: Readonly<ShiftPlannerTabProps>) {
   const { selectedRestaurant } = useRestaurantContext();
   const restaurantName = selectedRestaurant?.restaurant?.name;
@@ -819,6 +829,7 @@ export function ShiftPlannerTab({
           error={null}
           availabilityByEmployee={availabilityByEmployee}
           guardShiftChange={guardShiftChange}
+          notifyAfterDeferredCommit={notifyAfterDeferredCommit}
         />
       )}
 

--- a/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
+++ b/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
@@ -41,6 +41,7 @@ import type { GroupByMode } from '@/lib/scheduleGrouping';
 import type { EffectiveAvailability } from '@/lib/effectiveAvailability';
 import { buildDraftShiftValues, mergeDraftShift, type PaintRange, type DragShiftDraft } from '@/lib/timelineDraft';
 import type { ShiftMinuteRange } from '@/lib/timelineDragMath';
+import type { GuardShiftChangeOptions } from '@/hooks/usePublishedShiftGuard';
 
 // ─── Constants (Fix 2 — visible "Add shift" button) ────────────────────────────
 
@@ -103,6 +104,12 @@ interface ShiftTimelineTabProps {
   readonly loading: boolean;
   /** Forwarded from the parent's error state; renders an inline message. */
   readonly error: Error | null;
+  /**
+   * The page's single `usePublishedShiftGuard` instance. Every change to an
+   * existing shift — drag-move, drag-resize, and the popover's edit-save —
+   * must run through this so a published shift asks for confirmation first.
+   */
+  readonly guardShiftChange: (options: GuardShiftChangeOptions) => void | Promise<void>;
 }
 
 /**
@@ -265,6 +272,7 @@ export function ShiftTimelineTab({
   availabilityByEmployee,
   loading,
   error,
+  guardShiftChange,
 }: ShiftTimelineTabProps) {
   // ── Local state ────────────────────────────────────────────────────────────
   const [selectedDayState, setSelectedDay] = useState<string>(() => defaultDay(weekDays));
@@ -310,6 +318,7 @@ export function ShiftTimelineTab({
     endIso: string;
     conflicts: ConflictDialogData['conflicts'];
     warnings: ConflictDialogData['warnings'];
+    allowPublished: boolean;
   } | null>(null);
 
   // ── Transient change highlight (Fix 3) ─────────────────────────────────────
@@ -672,7 +681,9 @@ export function ShiftTimelineTab({
 
   /**
    * Drag/resize release (Stage D3): builds ISO instants via `minutesToIso`
-   * and routes through the same `validateAndUpdateTime` pipeline the edit
+   * and routes through `guardShiftChange`. A published shift shows the
+   * confirm dialog first; an unpublished shift runs straight away. Either
+   * way `run` calls the same `validateAndUpdateTime` pipeline the edit
    * popover's Save uses. On success the draft is cleared (the mutation's own
    * optimistic `setQueriesData` update means the bar never jumps waiting for
    * a refetch). On pending conflicts/warnings, the draft is KEPT (so the bar
@@ -690,37 +701,46 @@ export function ShiftTimelineTab({
 
       const startIso = minutesToIso(selectedDay, range.startMin, tz);
       const endIso = minutesToIso(selectedDay, range.endMin, tz);
+      const employeeName = employees.find((e) => e.id === shift.employee_id)?.name ?? '';
 
-      const outcome = await validateAndUpdateTime({
-        shift,
-        startIso,
-        endIso,
-        businessDate: selectedDay,
+      await guardShiftChange({
+        shiftId: shift.id,
+        employeeName,
+        run: async ({ allowPublished }) => {
+          const outcome = await validateAndUpdateTime({
+            shift,
+            startIso,
+            endIso,
+            businessDate: selectedDay,
+            allowPublished,
+          });
+
+          if (outcome.updated) {
+            setDragDraft(null);
+            flashHighlight(shiftId);
+            return;
+          }
+
+          if (outcome.pendingConflicts?.length || outcome.pendingWarnings?.length) {
+            setDragConflict({
+              shift,
+              startIso,
+              endIso,
+              conflicts: outcome.pendingConflicts ?? [],
+              warnings: outcome.pendingWarnings ?? [],
+              allowPublished,
+            });
+            return;
+          }
+
+          // Validation failed outright (e.g. an interval-construction error)
+          // with no pending issues to confirm — snap back rather than leave
+          // a dangling draft.
+          setDragDraft(null);
+        },
       });
-
-      if (outcome.updated) {
-        setDragDraft(null);
-        flashHighlight(shiftId);
-        return;
-      }
-
-      if (outcome.pendingConflicts?.length || outcome.pendingWarnings?.length) {
-        setDragConflict({
-          shift,
-          startIso,
-          endIso,
-          conflicts: outcome.pendingConflicts ?? [],
-          warnings: outcome.pendingWarnings ?? [],
-        });
-        return;
-      }
-
-      // Validation failed outright (e.g. a locked shift returns `updated:
-      // false`, or an interval-construction error) with no pending issues to
-      // confirm — snap back rather than leave a dangling draft.
-      setDragDraft(null);
     },
-    [dayShifts, selectedDay, tz, validateAndUpdateTime, flashHighlight],
+    [dayShifts, selectedDay, tz, validateAndUpdateTime, flashHighlight, guardShiftChange, employees],
   );
 
   const handleDragConflictCancel = useCallback(() => {
@@ -730,8 +750,8 @@ export function ShiftTimelineTab({
 
   const handleDragConflictConfirm = useCallback(async () => {
     if (!dragConflict) return;
-    const { shift, startIso, endIso } = dragConflict;
-    const ok = await forceUpdateTime({ shift, startIso, endIso, businessDate: selectedDay });
+    const { shift, startIso, endIso, allowPublished } = dragConflict;
+    const ok = await forceUpdateTime({ shift, startIso, endIso, businessDate: selectedDay, allowPublished });
     if (ok) {
       setDragConflict(null);
       setDragDraft(null);
@@ -1077,6 +1097,7 @@ export function ShiftTimelineTab({
         onSaved={handleShiftSaved}
         validationResult={validationResult}
         clearValidation={clearValidation}
+        guardShiftChange={guardShiftChange}
       />
 
       {/* Drag-commit conflict dialog (Stage D3) — the same AvailabilityConflictDialog

--- a/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
+++ b/src/components/scheduling/ShiftTimeline/ShiftTimelineTab.tsx
@@ -41,7 +41,10 @@ import type { GroupByMode } from '@/lib/scheduleGrouping';
 import type { EffectiveAvailability } from '@/lib/effectiveAvailability';
 import { buildDraftShiftValues, mergeDraftShift, type PaintRange, type DragShiftDraft } from '@/lib/timelineDraft';
 import type { ShiftMinuteRange } from '@/lib/timelineDragMath';
-import type { GuardShiftChangeOptions } from '@/hooks/usePublishedShiftGuard';
+import type {
+  GuardShiftChangeOptions,
+  NotifyAfterDeferredCommitArgs,
+} from '@/hooks/usePublishedShiftGuard';
 
 // ─── Constants (Fix 2 — visible "Add shift" button) ────────────────────────────
 
@@ -110,6 +113,15 @@ interface ShiftTimelineTabProps {
    * must run through this so a published shift asks for confirmation first.
    */
   readonly guardShiftChange: (options: GuardShiftChangeOptions) => void | Promise<void>;
+  /**
+   * Same guard instance's deferred-notify step. A drag-commit or the
+   * popover's edit-save can surface a conflict dialog instead of committing
+   * right away; once that conflict is confirmed and the write actually
+   * lands, this fires the notify the guard itself skipped.
+   */
+  readonly notifyAfterDeferredCommit: (
+    args: NotifyAfterDeferredCommitArgs,
+  ) => void | Promise<void>;
 }
 
 /**
@@ -273,6 +285,7 @@ export function ShiftTimelineTab({
   loading,
   error,
   guardShiftChange,
+  notifyAfterDeferredCommit,
 }: ShiftTimelineTabProps) {
   // ── Local state ────────────────────────────────────────────────────────────
   const [selectedDayState, setSelectedDay] = useState<string>(() => defaultDay(weekDays));
@@ -319,6 +332,10 @@ export function ShiftTimelineTab({
     conflicts: ConflictDialogData['conflicts'];
     warnings: ConflictDialogData['warnings'];
     allowPublished: boolean;
+    // Carried from the guard's `run` call so the deferred-commit notify
+    // below can fire the manager's actual checkbox choice, not a guess.
+    notify: boolean;
+    employeeName: string;
   } | null>(null);
 
   // ── Transient change highlight (Fix 3) ─────────────────────────────────────
@@ -705,8 +722,9 @@ export function ShiftTimelineTab({
 
       await guardShiftChange({
         shiftId: shift.id,
+        restaurantId,
         employeeName,
-        run: async ({ allowPublished }) => {
+        run: async ({ allowPublished, notify }) => {
           const outcome = await validateAndUpdateTime({
             shift,
             startIso,
@@ -729,8 +747,14 @@ export function ShiftTimelineTab({
               conflicts: outcome.pendingConflicts ?? [],
               warnings: outcome.pendingWarnings ?? [],
               allowPublished,
+              notify,
+              employeeName,
             });
-            return;
+            // Nothing has committed yet — the conflict dialog still needs a
+            // confirm. Tell the guard to skip its own notify step; the
+            // confirm path below fires `notifyAfterDeferredCommit` once the
+            // forced write actually lands.
+            return { deferred: true };
           }
 
           // Validation failed outright (e.g. an interval-construction error)
@@ -740,7 +764,16 @@ export function ShiftTimelineTab({
         },
       });
     },
-    [dayShifts, selectedDay, tz, validateAndUpdateTime, flashHighlight, guardShiftChange, employees],
+    [
+      dayShifts,
+      selectedDay,
+      tz,
+      validateAndUpdateTime,
+      flashHighlight,
+      guardShiftChange,
+      employees,
+      restaurantId,
+    ],
   );
 
   const handleDragConflictCancel = useCallback(() => {
@@ -750,14 +783,18 @@ export function ShiftTimelineTab({
 
   const handleDragConflictConfirm = useCallback(async () => {
     if (!dragConflict) return;
-    const { shift, startIso, endIso, allowPublished } = dragConflict;
+    const { shift, startIso, endIso, allowPublished, notify, employeeName } = dragConflict;
+    const startedAt = new Date().toISOString();
     const ok = await forceUpdateTime({ shift, startIso, endIso, businessDate: selectedDay, allowPublished });
     if (ok) {
       setDragConflict(null);
       setDragDraft(null);
       flashHighlight(shift.id);
+      if (notify) {
+        await notifyAfterDeferredCommit({ shiftId: shift.id, employeeName, startedAt });
+      }
     }
-  }, [dragConflict, forceUpdateTime, selectedDay, flashHighlight]);
+  }, [dragConflict, forceUpdateTime, selectedDay, flashHighlight, notifyAfterDeferredCommit]);
 
   const dragConflictData: ConflictDialogData | null = dragConflict
     ? {
@@ -1098,6 +1135,7 @@ export function ShiftTimelineTab({
         validationResult={validationResult}
         clearValidation={clearValidation}
         guardShiftChange={guardShiftChange}
+        notifyAfterDeferredCommit={notifyAfterDeferredCommit}
       />
 
       {/* Drag-commit conflict dialog (Stage D3) — the same AvailabilityConflictDialog

--- a/src/components/scheduling/ShiftTimeline/TimelineBar.tsx
+++ b/src/components/scheduling/ShiftTimeline/TimelineBar.tsx
@@ -68,9 +68,10 @@ interface TimelineBarProps {
  * narrow edge strips are resize handles. `useTimelineBarDrag` disambiguates a
  * tap (< 5px movement — a no-op, left to the native `onClick` below) from a
  * real drag (calls `onDraftChange` each frame, `onDragCommit` on release).
- * Locked shifts and touch pointers never drag — `touch-action: none` is
- * scoped to the body + handles only so the lane's own pan-to-scroll behavior
- * is unaffected. After a real drag, the browser still dispatches a trailing
+ * A locked (published) shift drags the same as any other — the guard at the
+ * commit call site asks for confirmation before the change lands. Touch
+ * pointers never drag — `touch-action: none` is scoped to the body + handles
+ * only so the lane's own pan-to-scroll behavior is unaffected. After a real drag, the browser still dispatches a trailing
  * `click` on the bar; `handleTap` consults `consumeJustDragged()` and skips
  * `onSelect` for exactly that one click (Codex P2 fix) so a drag never also
  * reopens the edit popover.
@@ -93,7 +94,6 @@ function TimelineBarImpl({
   tz,
 }: TimelineBarProps) {
   const { leftMin, endMin, label, ariaLabel, color, shift } = bar;
-  const locked = shift.locked;
 
   const handleDraftChange = useCallback(
     (range: ShiftMinuteRange | null) => onDraftChange(shift.id, range),
@@ -110,7 +110,6 @@ function TimelineBarImpl({
   const { dragState, handleBodyPointerDown, handleStartHandlePointerDown, handleEndHandlePointerDown, handlePointerMove, handlePointerUp, handlePointerCancel, consumeJustDragged } =
     useTimelineBarDrag({
       original: { startMin: leftMin, endMin },
-      locked,
       getPlotRect,
       getWindow,
       onDraftChange: handleDraftChange,
@@ -178,7 +177,7 @@ function TimelineBarImpl({
           'relative h-full w-full rounded-md border px-1.5 text-left text-[11px] font-medium truncate',
           'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
           'transition-opacity hover:opacity-90 active:opacity-80',
-          !locked && 'cursor-grab touch-none',
+          'cursor-grab touch-none',
           highlighted && 'ring-2 ring-ring',
           color.bg,
           color.border,
@@ -189,28 +188,24 @@ function TimelineBarImpl({
       >
         {label}
 
-        {!locked && (
-          <>
-            <span
-              data-testid="resize-handle-start"
-              aria-hidden="true"
-              onPointerDown={handleStartHandlePointerDown}
-              onPointerMove={handlePointerMove}
-              onPointerUp={handlePointerUp}
-              onPointerCancel={handlePointerCancel}
-              className="absolute inset-y-0 left-0 w-1.5 cursor-ew-resize touch-none"
-            />
-            <span
-              data-testid="resize-handle-end"
-              aria-hidden="true"
-              onPointerDown={handleEndHandlePointerDown}
-              onPointerMove={handlePointerMove}
-              onPointerUp={handlePointerUp}
-              onPointerCancel={handlePointerCancel}
-              className="absolute inset-y-0 right-0 w-1.5 cursor-ew-resize touch-none"
-            />
-          </>
-        )}
+        <span
+          data-testid="resize-handle-start"
+          aria-hidden="true"
+          onPointerDown={handleStartHandlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onPointerCancel={handlePointerCancel}
+          className="absolute inset-y-0 left-0 w-1.5 cursor-ew-resize touch-none"
+        />
+        <span
+          data-testid="resize-handle-end"
+          aria-hidden="true"
+          onPointerDown={handleEndHandlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          onPointerCancel={handlePointerCancel}
+          className="absolute inset-y-0 right-0 w-1.5 cursor-ew-resize touch-none"
+        />
       </button>
 
       {dragState && (

--- a/src/components/scheduling/ShiftTimeline/TimelineBar.tsx
+++ b/src/components/scheduling/ShiftTimeline/TimelineBar.tsx
@@ -71,10 +71,11 @@ interface TimelineBarProps {
  * A locked (published) shift drags the same as any other — the guard at the
  * commit call site asks for confirmation before the change lands. Touch
  * pointers never drag — `touch-action: none` is scoped to the body + handles
- * only so the lane's own pan-to-scroll behavior is unaffected. After a real drag, the browser still dispatches a trailing
- * `click` on the bar; `handleTap` consults `consumeJustDragged()` and skips
- * `onSelect` for exactly that one click (Codex P2 fix) so a drag never also
- * reopens the edit popover.
+ * only so the lane's own pan-to-scroll behavior is unaffected. After a real
+ * drag, the browser still dispatches a trailing `click` on the bar;
+ * `handleTap` consults `consumeJustDragged()` and skips `onSelect` for
+ * exactly that one click (Codex P2 fix) so a drag never also reopens the
+ * edit popover.
  *
  * Memoized (Stage D1b): re-renders only when this bar's identity/geometry/
  * label/color actually changes, so a drag frame only re-renders the dragged

--- a/src/components/scheduling/ShiftTimeline/TimelineShiftPopover.tsx
+++ b/src/components/scheduling/ShiftTimeline/TimelineShiftPopover.tsx
@@ -41,7 +41,10 @@ import type {
   CreateAtTimeOutcome,
   CreateAtTimeInput,
 } from '@/hooks/useValidatedShiftMutations';
-import type { GuardShiftChangeOptions } from '@/hooks/usePublishedShiftGuard';
+import type {
+  GuardShiftChangeOptions,
+  NotifyAfterDeferredCommitArgs,
+} from '@/hooks/usePublishedShiftGuard';
 
 /** Minimal shape needed to anchor the Radix popper to an arbitrary rect. */
 interface VirtualAnchor {
@@ -154,6 +157,15 @@ interface TimelineShiftPopoverProps {
    * confirmation before it applies.
    */
   readonly guardShiftChange: (options: GuardShiftChangeOptions) => void | Promise<void>;
+  /**
+   * Same guard instance's deferred-notify step. Save (edit mode) can surface
+   * a conflict dialog instead of committing right away; once that conflict
+   * is confirmed and the write actually lands, this fires the notify the
+   * guard itself skipped.
+   */
+  readonly notifyAfterDeferredCommit: (
+    args: NotifyAfterDeferredCommitArgs,
+  ) => void | Promise<void>;
 }
 
 /** Build the initial editor values from a shift + the day's timezone. */
@@ -217,6 +229,7 @@ export function TimelineShiftPopover({
   anchorRect,
   collisionBoundary,
   guardShiftChange,
+  notifyAfterDeferredCommit,
 }: TimelineShiftPopoverProps) {
   const [mode, setMode] = useState<'view' | 'edit'>('view');
   const [editValues, setEditValues] = useState<TimelineShiftEditorValues | null>(null);
@@ -224,14 +237,26 @@ export function TimelineShiftPopover({
     createDraft?.values ?? null,
   );
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
-  // `allowPublished` is optional: only the edit-mode Save path (below) ever
-  // sets it. The create-mode dialog (`TimelineCreateDialog`) shares this same
-  // state slot but never reads or writes `allowPublished` — a new shift has
-  // no lock to guard against.
+  // Edit-mode's own pending-conflict slot. Carries the guard's `notify`
+  // choice and the employee name(s) so the deferred-commit notify below can
+  // fire the manager's actual checkbox choice, not a guess, once the forced
+  // write lands. A new shift (create mode, below) has no lock to guard
+  // against and no guard-issued `notify`, so it keeps its own separate slot
+  // instead of widening this one.
   const [pendingIssues, setPendingIssues] = useState<{
     conflicts: ConflictCheck[];
     warnings: ValidationIssue[];
     allowPublished?: boolean;
+    notify: boolean;
+    employeeName: string;
+    secondEmployeeName?: string;
+  } | null>(null);
+  // Create-mode's pending-conflict slot (`TimelineCreateDialog` below) — a
+  // brand-new shift has no lock and no guard `run`, so this stays the plain
+  // conflicts/warnings shape rather than sharing `pendingIssues` above.
+  const [createPendingIssues, setCreatePendingIssues] = useState<{
+    conflicts: ConflictCheck[];
+    warnings: ValidationIssue[];
   } | null>(null);
   const [saving, setSaving] = useState(false);
 
@@ -249,6 +274,7 @@ export function TimelineShiftPopover({
     setEditValues(null);
     setShowDeleteConfirm(false);
     setPendingIssues(null);
+    setCreatePendingIssues(null);
     setSaving(false);
     clearValidation();
   }, [clearValidation]);
@@ -264,7 +290,7 @@ export function TimelineShiftPopover({
   // draft replaces the old one while the popover is open.
   useEffect(() => {
     setCreateValues(createDraft?.values ?? null);
-    setPendingIssues(null);
+    setCreatePendingIssues(null);
   }, [createDraft]);
 
   const isCreateMode = !activeShift && Boolean(createDraft);
@@ -283,8 +309,8 @@ export function TimelineShiftPopover({
         existingShifts={existingShifts}
         validateAndCreateAtTime={validateAndCreateAtTime}
         forceCreateAtTime={forceCreateAtTime}
-        pendingIssues={pendingIssues}
-        setPendingIssues={setPendingIssues}
+        pendingIssues={createPendingIssues}
+        setPendingIssues={setCreatePendingIssues}
         saving={saving}
         setSaving={setSaving}
         onClose={handleClose}
@@ -354,9 +380,10 @@ export function TimelineShiftPopover({
     try {
       await guardShiftChange({
         shiftId: activeShift.id,
+        restaurantId,
         employeeName,
         secondEmployeeName,
-        run: async ({ allowPublished }) => {
+        run: async ({ allowPublished, notify }) => {
           const outcome = await validateAndUpdateShift({
             shift: activeShift,
             startIso,
@@ -379,7 +406,15 @@ export function TimelineShiftPopover({
               conflicts: outcome.pendingConflicts ?? [],
               warnings: outcome.pendingWarnings ?? [],
               allowPublished,
+              notify,
+              employeeName,
+              secondEmployeeName,
             });
+            // Nothing has committed yet — the conflict dialog still needs a
+            // confirm. Tell the guard to skip its own notify step;
+            // handleConfirmConflicts below fires `notifyAfterDeferredCommit`
+            // once the forced write actually lands.
+            return { deferred: true };
           }
         },
       });
@@ -395,6 +430,7 @@ export function TimelineShiftPopover({
 
     const startIso = minutesToIso(dateStr, startMin, tz);
     const endIso = minutesToIso(dateStr, endMinValue, tz);
+    const startedAt = new Date().toISOString();
 
     setSaving(true);
     try {
@@ -413,6 +449,14 @@ export function TimelineShiftPopover({
         setPendingIssues(null);
         onSaved?.(activeShift);
         handleClose();
+        if (pendingIssues.notify) {
+          await notifyAfterDeferredCommit({
+            shiftId: activeShift.id,
+            employeeName: pendingIssues.employeeName,
+            secondEmployeeName: pendingIssues.secondEmployeeName,
+            startedAt,
+          });
+        }
       }
     } finally {
       setSaving(false);

--- a/src/components/scheduling/ShiftTimeline/TimelineShiftPopover.tsx
+++ b/src/components/scheduling/ShiftTimeline/TimelineShiftPopover.tsx
@@ -41,6 +41,7 @@ import type {
   CreateAtTimeOutcome,
   CreateAtTimeInput,
 } from '@/hooks/useValidatedShiftMutations';
+import type { GuardShiftChangeOptions } from '@/hooks/usePublishedShiftGuard';
 
 /** Minimal shape needed to anchor the Radix popper to an arbitrary rect. */
 interface VirtualAnchor {
@@ -82,6 +83,7 @@ interface TimelineShiftPopoverProps {
     startIso: string;
     endIso: string;
     businessDate: string;
+    allowPublished?: boolean;
   }) => Promise<UpdateTimeOutcome>;
   /** Force-apply a time change after the user confirms the conflict dialog. Used by the DRAG path (time-only). */
   readonly forceUpdateTime: (input: {
@@ -89,6 +91,7 @@ interface TimelineShiftPopoverProps {
     startIso: string;
     endIso: string;
     businessDate: string;
+    allowPublished?: boolean;
   }) => Promise<boolean>;
   /**
    * Validate a full-field edit (time + employee + break + notes); returns
@@ -103,6 +106,7 @@ interface TimelineShiftPopoverProps {
     employeeId: string;
     breakDuration: number;
     notes: string;
+    allowPublished?: boolean;
   }) => Promise<UpdateShiftOutcome>;
   /** Force-apply a full-field edit after the user confirms the conflict dialog. */
   readonly forceUpdateShift: (input: {
@@ -113,6 +117,7 @@ interface TimelineShiftPopoverProps {
     employeeId: string;
     breakDuration: number;
     notes: string;
+    allowPublished?: boolean;
   }) => Promise<UpdateShiftOutcome>;
   /** Validate a create-at-time (quick-add) request; returns pending issues instead of throwing. */
   readonly validateAndCreateAtTime?: (input: CreateAtTimeInput) => Promise<CreateAtTimeOutcome>;
@@ -143,6 +148,12 @@ interface TimelineShiftPopoverProps {
   readonly anchorRect?: DOMRect | null;
   /** The scrollable plot container, used as the Radix collision boundary. */
   readonly collisionBoundary?: Element | null;
+  /**
+   * The page's single `usePublishedShiftGuard` instance. Save (edit mode)
+   * routes every change through this so a published shift asks for
+   * confirmation before it applies.
+   */
+  readonly guardShiftChange: (options: GuardShiftChangeOptions) => void | Promise<void>;
 }
 
 /** Build the initial editor values from a shift + the day's timezone. */
@@ -205,6 +216,7 @@ export function TimelineShiftPopover({
   clearValidation,
   anchorRect,
   collisionBoundary,
+  guardShiftChange,
 }: TimelineShiftPopoverProps) {
   const [mode, setMode] = useState<'view' | 'edit'>('view');
   const [editValues, setEditValues] = useState<TimelineShiftEditorValues | null>(null);
@@ -212,9 +224,14 @@ export function TimelineShiftPopover({
     createDraft?.values ?? null,
   );
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  // `allowPublished` is optional: only the edit-mode Save path (below) ever
+  // sets it. The create-mode dialog (`TimelineCreateDialog`) shares this same
+  // state slot but never reads or writes `allowPublished` — a new shift has
+  // no lock to guard against.
   const [pendingIssues, setPendingIssues] = useState<{
     conflicts: ConflictCheck[];
     warnings: ValidationIssue[];
+    allowPublished?: boolean;
   } | null>(null);
   const [saving, setSaving] = useState(false);
 
@@ -327,38 +344,52 @@ export function TimelineShiftPopover({
 
     const startIso = minutesToIso(dateStr, startMin, tz);
     const endIso = minutesToIso(dateStr, endMinValue, tz);
+    const employeeName = employees.find((e) => e.id === activeShift.employee_id)?.name ?? '';
+    const isReassignment = editValues.employeeId !== activeShift.employee_id;
+    const secondEmployeeName = isReassignment
+      ? employees.find((e) => e.id === editValues.employeeId)?.name
+      : undefined;
 
     setSaving(true);
     try {
-      const outcome = await validateAndUpdateShift({
-        shift: activeShift,
-        startIso,
-        endIso,
-        businessDate: dateStr,
-        employeeId: editValues.employeeId,
-        breakDuration: Number(editValues.breakDuration) || 0,
-        notes: editValues.notes,
+      await guardShiftChange({
+        shiftId: activeShift.id,
+        employeeName,
+        secondEmployeeName,
+        run: async ({ allowPublished }) => {
+          const outcome = await validateAndUpdateShift({
+            shift: activeShift,
+            startIso,
+            endIso,
+            businessDate: dateStr,
+            employeeId: editValues.employeeId,
+            breakDuration: Number(editValues.breakDuration) || 0,
+            notes: editValues.notes,
+            allowPublished,
+          });
+
+          if (outcome.updated) {
+            onSaved?.(activeShift);
+            handleClose();
+            return;
+          }
+
+          if (outcome.pendingConflicts?.length || outcome.pendingWarnings?.length) {
+            setPendingIssues({
+              conflicts: outcome.pendingConflicts ?? [],
+              warnings: outcome.pendingWarnings ?? [],
+              allowPublished,
+            });
+          }
+        },
       });
-
-      if (outcome.updated) {
-        onSaved?.(activeShift);
-        handleClose();
-        return;
-      }
-
-      if (outcome.pendingConflicts?.length || outcome.pendingWarnings?.length) {
-        setPendingIssues({
-          conflicts: outcome.pendingConflicts ?? [],
-          warnings: outcome.pendingWarnings ?? [],
-        });
-      }
     } finally {
       setSaving(false);
     }
   };
 
   const handleConfirmConflicts = async () => {
-    if (!editValues) return;
+    if (!editValues || !pendingIssues) return;
 
     const { startMin, endMin: endMinValue } = resolveOvernightMinutes(editValues.startTime, editValues.endTime);
 
@@ -375,6 +406,7 @@ export function TimelineShiftPopover({
         employeeId: editValues.employeeId,
         breakDuration: Number(editValues.breakDuration) || 0,
         notes: editValues.notes,
+        allowPublished: pendingIssues.allowPublished ?? false,
       });
 
       if (outcome.updated) {
@@ -480,7 +512,6 @@ export function TimelineShiftPopover({
                   Delete
                 </Button>
                 <Button
-                  disabled={isLocked}
                   onClick={handleEditClick}
                   className="h-9 px-4 rounded-lg bg-foreground text-background hover:bg-foreground/90 text-[13px] font-medium"
                 >

--- a/src/components/scheduling/ShiftTimeline/useTimelineBarDrag.ts
+++ b/src/components/scheduling/ShiftTimeline/useTimelineBarDrag.ts
@@ -16,8 +16,6 @@ export interface BarDragState {
 interface UseTimelineBarDragOptions {
   /** The bar's current (committed) minute range — the drag's baseline. */
   original: ShiftMinuteRange;
-  /** True when the shift is locked; disables all drag/resize gestures. */
-  locked: boolean;
   /** Returns the plot region's bounding rect, read fresh on every pointer event. */
   getPlotRect: () => DOMRect | null;
   /** Returns the current visible window, read fresh on every pointer event (never a stale closure). */
@@ -71,7 +69,6 @@ const DRAG_THRESHOLD_PX = 5;
  */
 export function useTimelineBarDrag({
   original,
-  locked,
   getPlotRect,
   getWindow,
   onDraftChange,
@@ -195,7 +192,6 @@ export function useTimelineBarDrag({
       // never fired (e.g. the bar relaid out under the pointer), the flag would
       // stay `true` forever and silently eat the next legitimate click.
       justDraggedRef.current = false;
-      if (locked) return;
       // Touch never drags — a tap opens the popover via the bar's own onClick;
       // every drag outcome is reachable through the popover's time fields.
       if (event.pointerType === 'touch') return;
@@ -220,7 +216,7 @@ export function useTimelineBarDrag({
       (event.currentTarget as unknown as { setPointerCapture?: (id: number) => void })
         .setPointerCapture?.(event.pointerId);
     },
-    [locked, getPlotRect, getWindow],
+    [getPlotRect, getWindow],
   );
 
   const handlePointerMove = useCallback(

--- a/src/hooks/usePublishedShiftGuard.tsx
+++ b/src/hooks/usePublishedShiftGuard.tsx
@@ -32,6 +32,18 @@ export interface GuardShiftChangeOptions {
    * `run` performed the write itself, and the guard notifies right after.
    */
   run: GuardedRun;
+  /**
+   * Set for a 'following'/'all' series edit. The lock check then covers
+   * every shift in scope, not only `shiftId` — an unlocked anchor with
+   * locked siblings must still warn, because the series RPC touches the
+   * locked rows when `allowPublished` is true.
+   */
+  series?: {
+    parentId: string;
+    scope: 'following' | 'all';
+    /** Required for the 'following' scope: only shifts at or after this instant. */
+    fromTime?: string;
+  };
 }
 
 interface PendingChange {
@@ -72,6 +84,7 @@ export function usePublishedShiftGuard() {
       employeeName,
       secondEmployeeName,
       run,
+      series,
     }: GuardShiftChangeOptions) => {
       // None of this function's callers await/catch it (the Save button's
       // onClick is synchronous), so a rejection here becomes an unhandled
@@ -79,18 +92,34 @@ export function usePublishedShiftGuard() {
       // instead of throwing.
       let locked: boolean;
       try {
-        // Scoped to restaurantId too, not just id — RLS already isolates
-        // tenants, but a stray cross-tenant id must read as "not found"
-        // here, not fall through to another restaurant's lock state.
-        const { data, error } = await supabase
-          .from('shifts')
-          .select('locked, employee_id')
-          .eq('id', shiftId)
-          .eq('restaurant_id', restaurantId)
-          .single();
+        if (series) {
+          // Any locked shift in scope means the warning must show.
+          let query = supabase
+            .from('shifts')
+            .select('id', { count: 'exact', head: true })
+            .eq('restaurant_id', restaurantId)
+            .eq('locked', true)
+            .or(`id.eq.${series.parentId},recurrence_parent_id.eq.${series.parentId}`);
+          if (series.scope === 'following' && series.fromTime) {
+            query = query.gte('start_time', series.fromTime);
+          }
+          const { count, error } = await query;
+          if (error) throw error;
+          locked = (count ?? 0) > 0;
+        } else {
+          // Scoped to restaurantId too, not just id — RLS already isolates
+          // tenants, but a stray cross-tenant id must read as "not found"
+          // here, not fall through to another restaurant's lock state.
+          const { data, error } = await supabase
+            .from('shifts')
+            .select('locked, employee_id')
+            .eq('id', shiftId)
+            .eq('restaurant_id', restaurantId)
+            .single();
 
-        if (error) throw error;
-        locked = data.locked;
+          if (error) throw error;
+          locked = data.locked;
+        }
       } catch (error) {
         toast({
           title: 'Could not check the shift',
@@ -149,7 +178,17 @@ export function usePublishedShiftGuard() {
           .order('changed_at', { ascending: false })
           .limit(1);
 
-        if (error || !rows || rows.length === 0) return;
+        if (error || !rows || rows.length === 0) {
+          // The shift write committed; only the notification cannot go out.
+          // Silence here would break the manager's expectation that the
+          // employee was told.
+          toast({
+            title: 'Shift updated — notification not sent',
+            description: `We could not find the change record. Please tell ${namesLabel} directly.`,
+            variant: 'destructive',
+          });
+          return;
+        }
 
         const outcome = await invokeScheduleNotification('notify-shift-changed', {
           changeLogId: rows[0].id,

--- a/src/hooks/usePublishedShiftGuard.tsx
+++ b/src/hooks/usePublishedShiftGuard.tsx
@@ -1,0 +1,82 @@
+import { useCallback, useState } from 'react';
+
+import { supabase } from '@/integrations/supabase/client';
+import { PublishedShiftChangeDialog } from '@/components/scheduling/PublishedShiftChangeDialog';
+
+export interface GuardShiftChangeOptions {
+  shiftId: string;
+  /** Name shown in the dialog. The caller already has it from the edited shift. */
+  employeeName: string;
+  /** Set on a reassignment. The dialog then names both employees. */
+  secondEmployeeName?: string;
+  run: (options: { allowPublished: boolean }) => void | Promise<void>;
+}
+
+interface PendingChange {
+  employeeName: string;
+  secondEmployeeName?: string;
+  run: (options: { allowPublished: boolean }) => void | Promise<void>;
+}
+
+/**
+ * One instance per page. Renders the single `PublishedShiftChangeDialog`
+ * for that page and exposes `guardShiftChange`. Each call does a fresh
+ * SELECT of `shifts.locked` — never the React Query cache, since another
+ * tab may have published the week seconds ago.
+ *
+ * Not locked: `run` fires straight away with `allowPublished: false`.
+ * Locked: the dialog opens; `run` fires with `allowPublished: true` only
+ * if the manager confirms.
+ */
+export function usePublishedShiftGuard() {
+  const [pending, setPending] = useState<PendingChange | null>(null);
+  const [isPending, setIsPending] = useState(false);
+
+  const guardShiftChange = useCallback(
+    async ({ shiftId, employeeName, secondEmployeeName, run }: GuardShiftChangeOptions) => {
+      const { data, error } = await supabase
+        .from('shifts')
+        .select('locked, employee_id')
+        .eq('id', shiftId)
+        .single();
+
+      if (error) throw error;
+
+      if (!data.locked) {
+        await run({ allowPublished: false });
+        return;
+      }
+
+      setPending({ employeeName, secondEmployeeName, run });
+    },
+    []
+  );
+
+  const handleOpenChange = useCallback((open: boolean) => {
+    if (!open) setPending(null);
+  }, []);
+
+  const handleConfirm = useCallback(async () => {
+    if (!pending) return;
+    setIsPending(true);
+    try {
+      await pending.run({ allowPublished: true });
+      setPending(null);
+    } finally {
+      setIsPending(false);
+    }
+  }, [pending]);
+
+  const dialog = (
+    <PublishedShiftChangeDialog
+      open={pending !== null}
+      onOpenChange={handleOpenChange}
+      employeeName={pending?.employeeName ?? ''}
+      secondEmployeeName={pending?.secondEmployeeName}
+      isPending={isPending}
+      onConfirm={handleConfirm}
+    />
+  );
+
+  return { guardShiftChange, dialog };
+}

--- a/src/hooks/usePublishedShiftGuard.tsx
+++ b/src/hooks/usePublishedShiftGuard.tsx
@@ -8,6 +8,14 @@ import {
 import { useToast } from '@/hooks/use-toast';
 import { invokeScheduleNotification, notificationToast } from '@/hooks/useSchedulePublish';
 
+/**
+ * A guarded write. `deferred: true` means nothing committed yet (e.g. a
+ * conflict dialog opened instead) — see `GuardShiftChangeOptions.run`.
+ */
+type GuardedRun = (
+  options: { allowPublished: boolean; notify: boolean }
+) => void | Promise<void | { deferred: boolean }>;
+
 export interface GuardShiftChangeOptions {
   shiftId: string;
   /** Scopes the fresh `shifts` read so one tenant never sees another's lock state. */
@@ -25,18 +33,14 @@ export interface GuardShiftChangeOptions {
    * later write actually lands. Omitting `deferred` (the common case) means
    * `run` performed the write itself, and the guard notifies right after.
    */
-  run: (
-    options: { allowPublished: boolean; notify: boolean }
-  ) => void | Promise<void | { deferred: boolean }>;
+  run: GuardedRun;
 }
 
 interface PendingChange {
   shiftId: string;
   employeeName: string;
   secondEmployeeName?: string;
-  run: (
-    options: { allowPublished: boolean; notify: boolean }
-  ) => void | Promise<void | { deferred: boolean }>;
+  run: GuardedRun;
 }
 
 /** Args for {@link usePublishedShiftGuard}'s `notifyAfterDeferredCommit`. */
@@ -123,35 +127,53 @@ export function usePublishedShiftGuard() {
    * notify function. Design:
    * docs/superpowers/specs/2026-08-15-quiet-publish-live-edit-design.md
    * ("Client: after the guarded mutation commits...").
+   *
+   * Never throws. Both callers (`handleConfirm` and
+   * `notifyAfterDeferredCommit`) run after the shift write already
+   * committed, so a rejection here must not read as a failed save. Every
+   * exit resolves; a lookup failure gets its own toast instead of an
+   * unhandled promise rejection.
    */
   const notifyShiftChange = useCallback(
     async (shiftId: string, startedAt: string, namesLabel: string) => {
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      if (!user) return;
+      try {
+        const {
+          data: { user },
+        } = await supabase.auth.getUser();
+        if (!user) return;
 
-      const { data: rows, error } = await supabase
-        .from('schedule_change_logs')
-        .select('id')
-        .eq('shift_id', shiftId)
-        .eq('changed_by', user.id)
-        .gte('changed_at', startedAt)
-        .order('changed_at', { ascending: false })
-        .limit(1);
+        const { data: rows, error } = await supabase
+          .from('schedule_change_logs')
+          .select('id')
+          .eq('shift_id', shiftId)
+          .eq('changed_by', user.id)
+          .gte('changed_at', startedAt)
+          .order('changed_at', { ascending: false })
+          .limit(1);
 
-      if (error || !rows || rows.length === 0) return;
+        if (error || !rows || rows.length === 0) return;
 
-      const outcome = await invokeScheduleNotification('notify-shift-changed', {
-        changeLogId: rows[0].id,
-      });
+        const outcome = await invokeScheduleNotification('notify-shift-changed', {
+          changeLogId: rows[0].id,
+        });
 
-      toast(
-        notificationToast(outcome, {
-          title: 'Shift updated',
-          successDescription: `${namesLabel} was notified.`,
-        })
-      );
+        toast(
+          notificationToast(outcome, {
+            title: 'Shift updated',
+            successDescription: `${namesLabel} was notified.`,
+          })
+        );
+      } catch (error) {
+        // The shift write already committed. Only the notify step failed —
+        // tell the manager to notify the team by hand, do not imply the
+        // save itself failed.
+        toast({
+          title: 'Shift updated — could not notify',
+          description:
+            error instanceof Error ? error.message : 'Please tell the team directly.',
+          variant: 'destructive',
+        });
+      }
     },
     [toast]
   );

--- a/src/hooks/usePublishedShiftGuard.tsx
+++ b/src/hooks/usePublishedShiftGuard.tsx
@@ -2,6 +2,8 @@ import { useCallback, useState } from 'react';
 
 import { supabase } from '@/integrations/supabase/client';
 import { PublishedShiftChangeDialog } from '@/components/scheduling/PublishedShiftChangeDialog';
+import { useToast } from '@/hooks/use-toast';
+import { invokeScheduleNotification, notificationToast } from '@/hooks/useSchedulePublish';
 
 export interface GuardShiftChangeOptions {
   shiftId: string;
@@ -13,6 +15,7 @@ export interface GuardShiftChangeOptions {
 }
 
 interface PendingChange {
+  shiftId: string;
   employeeName: string;
   secondEmployeeName?: string;
   run: (options: { allowPublished: boolean }) => void | Promise<void>;
@@ -31,6 +34,7 @@ interface PendingChange {
 export function usePublishedShiftGuard() {
   const [pending, setPending] = useState<PendingChange | null>(null);
   const [isPending, setIsPending] = useState(false);
+  const { toast } = useToast();
 
   const guardShiftChange = useCallback(
     async ({ shiftId, employeeName, secondEmployeeName, run }: GuardShiftChangeOptions) => {
@@ -47,7 +51,7 @@ export function usePublishedShiftGuard() {
         return;
       }
 
-      setPending({ employeeName, secondEmployeeName, run });
+      setPending({ shiftId, employeeName, secondEmployeeName, run });
     },
     []
   );
@@ -56,16 +60,65 @@ export function usePublishedShiftGuard() {
     if (!open) setPending(null);
   }, []);
 
-  const handleConfirm = useCallback(async () => {
-    if (!pending) return;
-    setIsPending(true);
-    try {
-      await pending.run({ allowPublished: true });
-      setPending(null);
-    } finally {
-      setIsPending(false);
-    }
-  }, [pending]);
+  /**
+   * Looks up the change-log row the confirmed `run` just wrote, scoped so a
+   * concurrent edit from another manager can never be picked, then fires the
+   * notify function. Design:
+   * docs/superpowers/specs/2026-08-15-quiet-publish-live-edit-design.md
+   * ("Client: after the guarded mutation commits...").
+   */
+  const notifyShiftChange = useCallback(
+    async (shiftId: string, startedAt: string, namesLabel: string) => {
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+      if (!user) return;
+
+      const { data: rows, error } = await supabase
+        .from('schedule_change_logs')
+        .select('id')
+        .eq('shift_id', shiftId)
+        .eq('changed_by', user.id)
+        .gte('changed_at', startedAt)
+        .order('changed_at', { ascending: false })
+        .limit(1);
+
+      if (error || !rows || rows.length === 0) return;
+
+      const outcome = await invokeScheduleNotification('notify-shift-changed', {
+        changeLogId: rows[0].id,
+      });
+
+      toast(
+        notificationToast(outcome, {
+          title: 'Shift updated',
+          successDescription: `${namesLabel} was notified.`,
+        })
+      );
+    },
+    [toast]
+  );
+
+  const handleConfirm = useCallback(
+    async ({ notify }: { notify: boolean }) => {
+      if (!pending) return;
+      setIsPending(true);
+      try {
+        const startedAt = new Date().toISOString();
+        await pending.run({ allowPublished: true });
+        if (notify) {
+          const namesLabel = pending.secondEmployeeName
+            ? `${pending.employeeName} and ${pending.secondEmployeeName}`
+            : pending.employeeName;
+          await notifyShiftChange(pending.shiftId, startedAt, namesLabel);
+        }
+        setPending(null);
+      } finally {
+        setIsPending(false);
+      }
+    },
+    [pending, notifyShiftChange]
+  );
 
   const dialog = (
     <PublishedShiftChangeDialog

--- a/src/hooks/usePublishedShiftGuard.tsx
+++ b/src/hooks/usePublishedShiftGuard.tsx
@@ -1,7 +1,10 @@
 import { useCallback, useState } from 'react';
 
 import { supabase } from '@/integrations/supabase/client';
-import { PublishedShiftChangeDialog } from '@/components/scheduling/PublishedShiftChangeDialog';
+import {
+  formatNamesLabel,
+  PublishedShiftChangeDialog,
+} from '@/components/scheduling/PublishedShiftChangeDialog';
 import { useToast } from '@/hooks/use-toast';
 import { invokeScheduleNotification, notificationToast } from '@/hooks/useSchedulePublish';
 
@@ -38,22 +41,41 @@ export function usePublishedShiftGuard() {
 
   const guardShiftChange = useCallback(
     async ({ shiftId, employeeName, secondEmployeeName, run }: GuardShiftChangeOptions) => {
-      const { data, error } = await supabase
-        .from('shifts')
-        .select('locked, employee_id')
-        .eq('id', shiftId)
-        .single();
+      // None of this function's callers await/catch it (the Save button's
+      // onClick is synchronous), so a rejection here becomes an unhandled
+      // promise rejection with no visible error. Every exit below resolves
+      // instead of throwing.
+      let locked: boolean;
+      try {
+        const { data, error } = await supabase
+          .from('shifts')
+          .select('locked, employee_id')
+          .eq('id', shiftId)
+          .single();
 
-      if (error) throw error;
+        if (error) throw error;
+        locked = data.locked;
+      } catch (error) {
+        toast({
+          title: 'Could not check the shift',
+          description: error instanceof Error ? error.message : 'Please try again.',
+          variant: 'destructive',
+        });
+        return;
+      }
 
-      if (!data.locked) {
-        await run({ allowPublished: false });
+      if (!locked) {
+        try {
+          await run({ allowPublished: false });
+        } catch {
+          // The mutation's own onError toast already told the user.
+        }
         return;
       }
 
       setPending({ shiftId, employeeName, secondEmployeeName, run });
     },
-    []
+    [toast]
   );
 
   const handleOpenChange = useCallback((open: boolean) => {
@@ -107,12 +129,14 @@ export function usePublishedShiftGuard() {
         const startedAt = new Date().toISOString();
         await pending.run({ allowPublished: true });
         if (notify) {
-          const namesLabel = pending.secondEmployeeName
-            ? `${pending.employeeName} and ${pending.secondEmployeeName}`
-            : pending.employeeName;
+          const namesLabel = formatNamesLabel(pending.employeeName, pending.secondEmployeeName);
           await notifyShiftChange(pending.shiftId, startedAt, namesLabel);
         }
         setPending(null);
+      } catch {
+        // The mutation's own onError toast already told the user. Leave
+        // `pending` set so the dialog stays open and the manager can retry
+        // or cancel, instead of the confirm silently going nowhere.
       } finally {
         setIsPending(false);
       }

--- a/src/hooks/usePublishedShiftGuard.tsx
+++ b/src/hooks/usePublishedShiftGuard.tsx
@@ -1,10 +1,8 @@
 import { useCallback, useState } from 'react';
 
 import { supabase } from '@/integrations/supabase/client';
-import {
-  formatNamesLabel,
-  PublishedShiftChangeDialog,
-} from '@/components/scheduling/PublishedShiftChangeDialog';
+import { PublishedShiftChangeDialog } from '@/components/scheduling/PublishedShiftChangeDialog';
+import { formatNamesLabel } from '@/lib/scheduling/formatNamesLabel';
 import { useToast } from '@/hooks/use-toast';
 import { invokeScheduleNotification, notificationToast } from '@/hooks/useSchedulePublish';
 

--- a/src/hooks/usePublishedShiftGuard.tsx
+++ b/src/hooks/usePublishedShiftGuard.tsx
@@ -10,18 +10,42 @@ import { invokeScheduleNotification, notificationToast } from '@/hooks/useSchedu
 
 export interface GuardShiftChangeOptions {
   shiftId: string;
+  /** Scopes the fresh `shifts` read so one tenant never sees another's lock state. */
+  restaurantId: string;
   /** Name shown in the dialog. The caller already has it from the edited shift. */
   employeeName: string;
   /** Set on a reassignment. The dialog then names both employees. */
   secondEmployeeName?: string;
-  run: (options: { allowPublished: boolean }) => void | Promise<void>;
+  /**
+   * `notify` carries the checkbox choice through to callers that cannot
+   * commit right away (e.g. a drag/edit that surfaces a conflict dialog
+   * instead of writing). Such a `run` must resolve with `{ deferred: true }`
+   * instead of committing — the guard then skips its own notify step, and
+   * the caller notifies itself via `notifyAfterDeferredCommit` once its own
+   * later write actually lands. Omitting `deferred` (the common case) means
+   * `run` performed the write itself, and the guard notifies right after.
+   */
+  run: (
+    options: { allowPublished: boolean; notify: boolean }
+  ) => void | Promise<void | { deferred: boolean }>;
 }
 
 interface PendingChange {
   shiftId: string;
   employeeName: string;
   secondEmployeeName?: string;
-  run: (options: { allowPublished: boolean }) => void | Promise<void>;
+  run: (
+    options: { allowPublished: boolean; notify: boolean }
+  ) => void | Promise<void | { deferred: boolean }>;
+}
+
+/** Args for {@link usePublishedShiftGuard}'s `notifyAfterDeferredCommit`. */
+export interface NotifyAfterDeferredCommitArgs {
+  shiftId: string;
+  employeeName: string;
+  secondEmployeeName?: string;
+  /** ISO instant captured right before the caller's own deferred write. */
+  startedAt: string;
 }
 
 /**
@@ -40,17 +64,27 @@ export function usePublishedShiftGuard() {
   const { toast } = useToast();
 
   const guardShiftChange = useCallback(
-    async ({ shiftId, employeeName, secondEmployeeName, run }: GuardShiftChangeOptions) => {
+    async ({
+      shiftId,
+      restaurantId,
+      employeeName,
+      secondEmployeeName,
+      run,
+    }: GuardShiftChangeOptions) => {
       // None of this function's callers await/catch it (the Save button's
       // onClick is synchronous), so a rejection here becomes an unhandled
       // promise rejection with no visible error. Every exit below resolves
       // instead of throwing.
       let locked: boolean;
       try {
+        // Scoped to restaurantId too, not just id — RLS already isolates
+        // tenants, but a stray cross-tenant id must read as "not found"
+        // here, not fall through to another restaurant's lock state.
         const { data, error } = await supabase
           .from('shifts')
           .select('locked, employee_id')
           .eq('id', shiftId)
+          .eq('restaurant_id', restaurantId)
           .single();
 
         if (error) throw error;
@@ -66,7 +100,8 @@ export function usePublishedShiftGuard() {
 
       if (!locked) {
         try {
-          await run({ allowPublished: false });
+          // No dialog shown, so no notify choice exists to carry through.
+          await run({ allowPublished: false, notify: false });
         } catch {
           // The mutation's own onError toast already told the user.
         }
@@ -127,8 +162,15 @@ export function usePublishedShiftGuard() {
       setIsPending(true);
       try {
         const startedAt = new Date().toISOString();
-        await pending.run({ allowPublished: true });
-        if (notify) {
+        const result = await pending.run({ allowPublished: true, notify });
+        // A deferred `run` (e.g. it surfaced a conflict dialog instead of
+        // writing) has not committed anything yet — nothing to notify about
+        // here. The caller notifies itself later via
+        // `notifyAfterDeferredCommit`, once its own write actually lands.
+        // `result` can be `void` (most callers) — narrow with a runtime
+        // check instead of `?.`, which does not treat `void` as absent.
+        const deferred = typeof result === 'object' && result !== null && result.deferred === true;
+        if (notify && !deferred) {
           const namesLabel = formatNamesLabel(pending.employeeName, pending.secondEmployeeName);
           await notifyShiftChange(pending.shiftId, startedAt, namesLabel);
         }
@@ -144,6 +186,22 @@ export function usePublishedShiftGuard() {
     [pending, notifyShiftChange]
   );
 
+  /**
+   * For a `run` that deferred instead of committing (returned
+   * `{ deferred: true }`): the caller invokes this itself once its own later
+   * write actually succeeds, so the notify step still reflects a real
+   * commit. `startedAt` must be captured right before that write, not
+   * before the original guard confirm, or the change-log lookup can miss
+   * the row (or pick up an unrelated earlier one).
+   */
+  const notifyAfterDeferredCommit = useCallback(
+    async ({ shiftId, employeeName, secondEmployeeName, startedAt }: NotifyAfterDeferredCommitArgs) => {
+      const namesLabel = formatNamesLabel(employeeName, secondEmployeeName);
+      await notifyShiftChange(shiftId, startedAt, namesLabel);
+    },
+    [notifyShiftChange]
+  );
+
   const dialog = (
     <PublishedShiftChangeDialog
       open={pending !== null}
@@ -155,5 +213,5 @@ export function usePublishedShiftGuard() {
     />
   );
 
-  return { guardShiftChange, dialog };
+  return { guardShiftChange, dialog, notifyAfterDeferredCommit };
 }

--- a/src/hooks/useSchedulePublish.tsx
+++ b/src/hooks/useSchedulePublish.tsx
@@ -11,6 +11,11 @@ interface PublishScheduleParams {
   weekStart: Date;
   weekEnd: Date;
   notes?: string;
+  /**
+   * Whether to notify employees. Defaults to true when absent, so every
+   * existing caller keeps its current behaviour without a change.
+   */
+  notify?: boolean;
 }
 
 interface UnpublishScheduleParams {
@@ -244,7 +249,7 @@ export const usePublishSchedule = () => {
   const { toast } = useToast();
 
   return useMutation({
-    mutationFn: async ({ restaurantId, weekStart, weekEnd, notes }: PublishScheduleParams) => {
+    mutationFn: async ({ restaurantId, weekStart, weekEnd, notes, notify = true }: PublishScheduleParams) => {
       // Format dates as YYYY-MM-DD (local calendar day, not UTC)
       const weekStartStr = formatLocalDate(weekStart);
       const weekEndStr = formatLocalDate(weekEnd);
@@ -264,12 +269,16 @@ export const usePublishSchedule = () => {
       // Awaited, unlike before. The old call was fire-and-forget with a
       // console.error, so a fan-out that reached nobody still produced a
       // "Employees will be notified" toast and the manager had no way to know.
-      const notification = await invokeScheduleNotification('notify-schedule-published', {
-        publicationId,
-        restaurantId,
-        weekStart: weekStartStr,
-        weekEnd: weekEndStr,
-      });
+      // `notify: false` is a quiet publish -- the caller chose not to tell
+      // employees, so the invoke never happens.
+      const notification: NotificationOutcome = notify
+        ? await invokeScheduleNotification('notify-schedule-published', {
+            publicationId,
+            restaurantId,
+            weekStart: weekStartStr,
+            weekEnd: weekEndStr,
+          })
+        : { status: 'skipped' };
 
       return { publicationId, restaurantId, notification };
     },

--- a/src/hooks/useSchedulePublish.tsx
+++ b/src/hooks/useSchedulePublish.tsx
@@ -38,7 +38,8 @@ export type NotificationOutcome =
   | { status: 'partial'; sent: number; failed: number }
   | { status: 'failed'; failed: number }
   | { status: 'error' }
-  | { status: 'unknown'; message: string };
+  | { status: 'unknown'; message: string }
+  | { status: 'skipped' };
 
 interface InvokeError {
   context?: { json?: () => Promise<unknown> };
@@ -163,13 +164,19 @@ interface ToastPayload {
  * varies — and a manager who knows three people weren't emailed can go tell
  * them, which is the entire point.
  */
-function notificationToast(
+export function notificationToast(
   outcome: NotificationOutcome,
   { title, successDescription }: NotificationToastCopy,
 ): ToastPayload {
   switch (outcome.status) {
     case 'sent':
       return { title, description: successDescription };
+    // The caller chose not to notify (a quiet publish). This is not a
+    // failure -- the title stays the plain success title, not the
+    // '-- some/nobody notified' destructive copy used for a fan-out that
+    // tried and fell short.
+    case 'skipped':
+      return { title, description: 'No notifications were sent.' };
     case 'partial':
       return {
         title: `${title} — some employees not notified`,

--- a/src/hooks/useShifts.tsx
+++ b/src/hooks/useShifts.tsx
@@ -681,6 +681,7 @@ export function useUpdateShiftSeries() {
         p_from_time: scope === 'following' ? shift.start_time : null,
         p_start_time_delta: startTimeDelta,
         p_end_time_delta: endTimeDelta,
+        p_include_locked: allowPublished ?? false,
       });
 
       if (error) throw error;

--- a/src/hooks/useShifts.tsx
+++ b/src/hooks/useShifts.tsx
@@ -312,9 +312,12 @@ export function useUpdateShift() {
     mutationFn: async ({
       id,
       restaurant_id: restaurantId,
+      allowPublished,
       ...updates
-    }: Partial<Shift> & { id: string; restaurant_id: string }) => {
-      await assertShiftNotLocked(id);
+    }: Partial<Shift> & { id: string; restaurant_id: string; allowPublished?: boolean }) => {
+      if (!allowPublished) {
+        await assertShiftNotLocked(id);
+      }
 
       const { employee: _employee, ...shiftUpdates } = updates;
 
@@ -332,7 +335,7 @@ export function useUpdateShift() {
       if (error) throw error;
       return toTypedShift(data);
     },
-    onMutate: async ({ id, restaurant_id: restaurantId, ...updates }) => {
+    onMutate: async ({ id, restaurant_id: restaurantId, allowPublished: _allowPublished, ...updates }) => {
       await queryClient.cancelQueries({ queryKey: ['shifts', restaurantId] });
 
       const previousData = queryClient.getQueriesData<Shift[]>({ queryKey: ['shifts', restaurantId] });
@@ -413,6 +416,13 @@ export function useDeleteShift(options: UseDeleteShiftOptions = {}) {
       id: string;
       restaurantId: string;
       shift?: DeletableShift;
+      /**
+       * Accepted for API parity with the other shift mutations (the guard
+       * calls all four the same way). `useDeleteShift` has no lock check to
+       * bypass — a single delete already proceeds against a locked shift —
+       * so this option is a no-op here.
+       */
+      allowPublished?: boolean;
     }) => {
       const { data: deletedRows, error } = await supabase
         .from('shifts')
@@ -475,7 +485,7 @@ interface SeriesOperationParams {
   shift: Shift;
   scope: RecurringActionScope;
   restaurantId: string;
-  includePublished?: boolean;
+  allowPublished?: boolean;
 }
 
 interface SeriesOperationResult {
@@ -496,7 +506,7 @@ export function useDeleteShiftSeries() {
   const { toast } = useToast();
 
   return useMutation({
-    mutationFn: async ({ shift, scope, restaurantId, includePublished }: SeriesOperationParams): Promise<SeriesOperationResult> => {
+    mutationFn: async ({ shift, scope, restaurantId, allowPublished }: SeriesOperationParams): Promise<SeriesOperationResult> => {
       if (scope === 'this') {
         const { error } = await supabase
           .from('shifts')
@@ -514,7 +524,7 @@ export function useDeleteShiftSeries() {
         p_restaurant_id: restaurantId,
         p_scope: scope,
         p_from_time: scope === 'following' ? shift.start_time : null,
-        p_include_locked: includePublished ?? false,
+        p_include_locked: allowPublished ?? false,
       });
 
       if (error) throw error;
@@ -526,7 +536,7 @@ export function useDeleteShiftSeries() {
         restaurantId,
       };
     },
-    onMutate: async ({ shift, scope, restaurantId, includePublished }) => {
+    onMutate: async ({ shift, scope, restaurantId, allowPublished }) => {
       await queryClient.cancelQueries({ queryKey: ['shifts', restaurantId] });
 
       const previousData = queryClient.getQueriesData<Shift[]>({ queryKey: ['shifts', restaurantId] });
@@ -537,7 +547,7 @@ export function useDeleteShiftSeries() {
         if (!old) return old;
 
         return old.filter((s) => {
-          if (s.locked && !includePublished) return true;
+          if (s.locked && !allowPublished) return true;
 
           const isInSeries = s.id === parentId || s.recurrence_parent_id === parentId;
           if (!isInSeries) return true;
@@ -605,7 +615,7 @@ export function useUpdateShiftSeries() {
   const { toast } = useToast();
 
   return useMutation({
-    mutationFn: async ({ shift, scope, updates, restaurantId }: SeriesUpdateParams): Promise<SeriesOperationResult> => {
+    mutationFn: async ({ shift, scope, updates, restaurantId, allowPublished }: SeriesUpdateParams): Promise<SeriesOperationResult> => {
       const {
         employee: _employee,
         recurrence_pattern,
@@ -624,7 +634,7 @@ export function useUpdateShiftSeries() {
       };
 
       if (scope === 'this') {
-        if (shift.locked) {
+        if (shift.locked && !allowPublished) {
           throw new Error('Cannot update a locked shift. The schedule has been published.');
         }
 

--- a/src/hooks/useShifts.tsx
+++ b/src/hooks/useShifts.tsx
@@ -423,6 +423,17 @@ export function useDeleteShift(options: UseDeleteShiftOptions = {}) {
        * so this option is a no-op here.
        */
       allowPublished?: boolean;
+      /**
+       * True when the caller already owns the employee notification via
+       * `usePublishedShiftGuard` (the manager's "Notify" checkbox and
+       * `notify-shift-changed`, which also handles `change_type: 'deleted'`).
+       * Skips the legacy `send-shift-notification` invoke below so a
+       * published delete is never notified twice, and so an unchecked
+       * "Notify" box is honored instead of ignored. Defaults to false —
+       * every caller outside the guarded flow keeps today's unconditional
+       * send.
+       */
+      skipLegacyNotify?: boolean;
     }) => {
       const { data: deletedRows, error } = await supabase
         .from('shifts')
@@ -440,13 +451,17 @@ export function useDeleteShift(options: UseDeleteShiftOptions = {}) {
       const deletedCount = deletedRows?.length ?? 0;
       return { id, restaurantId, shift: deletedCount > 0 ? shift : undefined };
     },
-    onSuccess: (data) => {
+    onSuccess: (data, variables) => {
       queryClient.invalidateQueries({ queryKey: ['shifts', data.restaurantId] });
 
       // Notify FIRST, unconditionally on snapshot presence — fire-and-forget,
       // must sit above the `if (silent) return` below. `silent` (suppress
       // toast) and "should notify" are orthogonal concerns.
-      const notifyBody = data.shift ? buildShiftDeletedInvoke(data.shift) : null;
+      const notifyBody = variables.skipLegacyNotify
+        ? null
+        : data.shift
+          ? buildShiftDeletedInvoke(data.shift)
+          : null;
       if (notifyBody) {
         // supabase.functions.invoke resolves with { data, error } on HTTP
         // failures (it does NOT reject), so both branches must be handled —
@@ -677,7 +692,7 @@ export function useUpdateShiftSeries() {
         restaurantId,
       };
     },
-    onMutate: async ({ shift, scope, updates, restaurantId }) => {
+    onMutate: async ({ shift, scope, updates, restaurantId, allowPublished }) => {
       await queryClient.cancelQueries({ queryKey: ['shifts', restaurantId] });
 
       const previousData = queryClient.getQueriesData<Shift[]>({ queryKey: ['shifts', restaurantId] });
@@ -702,7 +717,9 @@ export function useUpdateShiftSeries() {
         if (!old) return old;
 
         return old.map((s) => {
-          if (s.locked) return s;
+          // Matches useDeleteShiftSeries.onMutate: a locked shift is only
+          // skipped when the guard did not confirm `allowPublished`.
+          if (s.locked && !allowPublished) return s;
 
           const isInSeries = s.id === parentId || s.recurrence_parent_id === parentId;
           if (!isInSeries) return s;

--- a/src/hooks/useValidatedShiftMutations.ts
+++ b/src/hooks/useValidatedShiftMutations.ts
@@ -49,6 +49,8 @@ export interface UpdateTimeInput {
   startIso: string;
   endIso: string;
   businessDate: string;
+  /** Skip the lock assertion for a shift the caller already confirmed the change against. */
+  allowPublished?: boolean;
 }
 
 /**
@@ -66,11 +68,15 @@ export interface UpdateShiftInput {
   employeeId: string;
   breakDuration: number;
   notes: string;
+  /** Skip the lock assertion for a shift the caller already confirmed the change against. */
+  allowPublished?: boolean;
 }
 
 export interface ReassignInput {
   shift: Shift;
   newEmployeeId: string;
+  /** Skip the lock assertion for a shift the caller already confirmed the change against. */
+  allowPublished?: boolean;
 }
 
 export interface CreateOutcome {
@@ -137,7 +143,7 @@ export interface UseValidatedShiftMutationsReturn {
   forceUpdateShift: (input: UpdateShiftInput) => Promise<UpdateShiftOutcome>;
   validateAndReassign: (input: ReassignInput) => Promise<ReassignOutcome>;
   forceReassign: (input: ReassignInput) => Promise<boolean>;
-  deleteShift: (shiftId: string) => void;
+  deleteShift: (shiftId: string, allowPublished?: boolean) => void;
   /**
    * Awaitable, lock-guarded delete: runs the same `assertNotLockedClient` guard
    * as `deleteShift`, then awaits the underlying mutation and resolves only
@@ -147,7 +153,7 @@ export interface UseValidatedShiftMutationsReturn {
    * `deleteShift` above can't provide that guarantee, so it's kept for callers
    * (e.g. the planner) that don't need to await/react to the outcome.
    */
-  deleteShiftAsync: (shiftId: string) => Promise<void>;
+  deleteShiftAsync: (shiftId: string, allowPublished?: boolean) => Promise<void>;
   validationResult: ValidationResult | null;
   clearValidation: () => void;
 }
@@ -360,7 +366,7 @@ export function useValidatedShiftMutations(
       if (!restaurantId) return { updated: false };
 
       try {
-        assertNotLockedClient(input.shift);
+        assertNotLockedClient(input.shift, input.allowPublished);
 
         const interval = ShiftInterval.fromTimestamps(
           input.startIso,
@@ -405,7 +411,7 @@ export function useValidatedShiftMutations(
       if (!restaurantId) return false;
 
       try {
-        assertNotLockedClient(input.shift);
+        assertNotLockedClient(input.shift, input.allowPublished);
 
         const interval = ShiftInterval.fromTimestamps(
           input.startIso,
@@ -443,7 +449,7 @@ export function useValidatedShiftMutations(
       if (!restaurantId) return { updated: false };
 
       try {
-        assertNotLockedClient(input.shift);
+        assertNotLockedClient(input.shift, input.allowPublished);
 
         const interval = ShiftInterval.fromTimestamps(
           input.startIso,
@@ -491,7 +497,7 @@ export function useValidatedShiftMutations(
       if (!restaurantId) return { updated: false };
 
       try {
-        assertNotLockedClient(input.shift);
+        assertNotLockedClient(input.shift, input.allowPublished);
 
         const interval = ShiftInterval.fromTimestamps(
           input.startIso,
@@ -527,7 +533,7 @@ export function useValidatedShiftMutations(
     async (input: ReassignInput): Promise<ReassignOutcome> => {
       if (!restaurantId) return { reassigned: false };
 
-      assertNotLockedClient(input.shift);
+      assertNotLockedClient(input.shift, input.allowPublished);
 
       try {
         const interval = ShiftInterval.fromTimestamps(
@@ -571,7 +577,7 @@ export function useValidatedShiftMutations(
     async (input: ReassignInput): Promise<boolean> => {
       if (!restaurantId) return false;
 
-      assertNotLockedClient(input.shift);
+      assertNotLockedClient(input.shift, input.allowPublished);
 
       try {
         await updateShift.mutateAsync({
@@ -595,11 +601,11 @@ export function useValidatedShiftMutations(
   // ---------------------------------------------------------------------------
 
   const handleDeleteShift = useCallback(
-    (shiftId: string) => {
+    (shiftId: string, allowPublished?: boolean) => {
       if (!restaurantId) return;
 
       const shift = findShiftOrThrow(shifts, shiftId);
-      assertNotLockedClient(shift);
+      assertNotLockedClient(shift, allowPublished);
 
       deleteShiftMutation.mutate({ id: shiftId, restaurantId });
     },
@@ -607,11 +613,11 @@ export function useValidatedShiftMutations(
   );
 
   const deleteShiftAsync = useCallback(
-    async (shiftId: string): Promise<void> => {
+    async (shiftId: string, allowPublished?: boolean): Promise<void> => {
       if (!restaurantId) return;
 
       const shift = findShiftOrThrow(shifts, shiftId);
-      assertNotLockedClient(shift);
+      assertNotLockedClient(shift, allowPublished);
 
       await deleteShiftMutation.mutateAsync({ id: shiftId, restaurantId });
     },

--- a/src/hooks/useValidatedShiftMutations.ts
+++ b/src/hooks/useValidatedShiftMutations.ts
@@ -394,6 +394,7 @@ export function useValidatedShiftMutations(
           restaurant_id: restaurantId,
           start_time: interval.startAt.toISOString(),
           end_time: interval.endAt.toISOString(),
+          allowPublished: input.allowPublished,
         });
 
         setValidationResult(null);
@@ -424,6 +425,7 @@ export function useValidatedShiftMutations(
           restaurant_id: restaurantId,
           start_time: interval.startAt.toISOString(),
           end_time: interval.endAt.toISOString(),
+          allowPublished: input.allowPublished,
         });
 
         setValidationResult(null);
@@ -480,6 +482,7 @@ export function useValidatedShiftMutations(
           employee_id: input.employeeId,
           break_duration: input.breakDuration,
           notes: input.notes,
+          allowPublished: input.allowPublished,
         });
 
         setValidationResult(null);
@@ -513,6 +516,7 @@ export function useValidatedShiftMutations(
           employee_id: input.employeeId,
           break_duration: input.breakDuration,
           notes: input.notes,
+          allowPublished: input.allowPublished,
         });
 
         setValidationResult(null);
@@ -561,6 +565,7 @@ export function useValidatedShiftMutations(
           id: input.shift.id,
           restaurant_id: restaurantId,
           employee_id: input.newEmployeeId,
+          allowPublished: input.allowPublished,
         });
 
         setValidationResult(null);
@@ -584,6 +589,7 @@ export function useValidatedShiftMutations(
           id: input.shift.id,
           restaurant_id: restaurantId,
           employee_id: input.newEmployeeId,
+          allowPublished: input.allowPublished,
         });
 
         setValidationResult(null);

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -12066,6 +12066,7 @@ export type Database = {
         Args: {
           p_end_time_delta?: string
           p_from_time?: string
+          p_include_locked?: boolean
           p_parent_id: string
           p_restaurant_id: string
           p_scope: string

--- a/src/lib/scheduling/formatNamesLabel.ts
+++ b/src/lib/scheduling/formatNamesLabel.ts
@@ -1,0 +1,8 @@
+/**
+ * "Alex" or "Alex and Sam" — shared by PublishedShiftChangeDialog and
+ * usePublishedShiftGuard's notify toast. Lives outside the component file
+ * so the file exports only a component (react-refresh/only-export-components).
+ */
+export function formatNamesLabel(employeeName: string, secondEmployeeName?: string): string {
+  return secondEmployeeName ? `${employeeName} and ${secondEmployeeName}` : employeeName;
+}

--- a/src/lib/shiftMutationPipeline.ts
+++ b/src/lib/shiftMutationPipeline.ts
@@ -77,9 +77,14 @@ export class LockedShiftError extends Error {
   }
 }
 
-/** Throws `LockedShiftError` if the shift is locked; no-op otherwise. */
-export function assertNotLockedClient(shift: Shift): void {
-  if (shift.locked) {
+/**
+ * Throws `LockedShiftError` if the shift is locked; no-op otherwise.
+ * Pass `allowPublished: true` to skip the check for a shift the caller has
+ * already confirmed the change against (the published-shift guard dialog).
+ * Absent or `false` keeps the assertion as the last-line backstop.
+ */
+export function assertNotLockedClient(shift: Shift, allowPublished?: boolean): void {
+  if (shift.locked && !allowPublished) {
     throw new LockedShiftError(shift.id);
   }
 }

--- a/src/pages/Scheduling.tsx
+++ b/src/pages/Scheduling.tsx
@@ -39,6 +39,7 @@ import {
 } from '@/lib/scheduleVisibility';
 import { ShiftDialog } from '@/components/ShiftDialog';
 import type { DefaultEmployee } from '@/components/ShiftDialog';
+import { usePublishedShiftGuard } from '@/hooks/usePublishedShiftGuard';
 import { TimeOffRequestDialog } from '@/components/TimeOffRequestDialog';
 import { TimeOffList } from '@/components/TimeOffList';
 import { AvailabilityDialog } from '@/components/AvailabilityDialog';
@@ -244,6 +245,7 @@ const Scheduling = () => {
   const { effectiveSettings: staffingSettings } = useStaffingSettings(restaurantId);
 
   const { weekStart: currentWeekStart, setWeekStart: setCurrentWeekStart } = useSharedWeek();
+  const { guardShiftChange, dialog: publishedShiftChangeDialog } = usePublishedShiftGuard();
   const [employeeDialogOpen, setEmployeeDialogOpen] = useState(false);
   const [shiftDialogOpen, setShiftDialogOpen] = useState(false);
   const [timeOffDialogOpen, setTimeOffDialogOpen] = useState(false);
@@ -1642,7 +1644,9 @@ const Scheduling = () => {
             timezone={restaurantTimezone}
             defaultDate={defaultShiftDate}
             defaultEmployee={defaultShiftEmployee}
+            guardShiftChange={guardShiftChange}
           />
+          {publishedShiftChangeDialog}
           {tradeShift && (
             <TradeRequestDialog
               open={tradeDialogOpen}

--- a/src/pages/Scheduling.tsx
+++ b/src/pages/Scheduling.tsx
@@ -711,15 +711,22 @@ const Scheduling = () => {
     if (!shift || !restaurantId) return;
 
     if (actionType === 'delete') {
-      // Delete with scope
-      deleteShiftSeries.mutate(
-        { shift, scope, restaurantId, allowPublished: true },
-        {
-          onSuccess: () => {
-            setRecurringActionDialog({ open: false, shift: null, actionType: 'edit' });
-          },
-        }
-      );
+      // Delete with scope, guarded when the series holds a published shift
+      const employeeName = allEmployees.find((e) => e.id === shift.employee_id)?.name ?? '';
+      guardShiftChange({
+        shiftId: shift.id,
+        employeeName,
+        run: ({ allowPublished }) => {
+          deleteShiftSeries.mutate(
+            { shift, scope, restaurantId, allowPublished },
+            {
+              onSuccess: () => {
+                setRecurringActionDialog({ open: false, shift: null, actionType: 'edit' });
+              },
+            }
+          );
+        },
+      });
     } else {
       // For edit, close the dialog and open the shift editor
       // The scope will be handled by the ShiftDialog
@@ -738,14 +745,21 @@ const Scheduling = () => {
 
   const confirmDeleteShift = () => {
     if (shiftToDelete && restaurantId) {
-      deleteShift.mutate(
-        { id: shiftToDelete.id, restaurantId, shift: shiftToDelete },
-        {
-          onSuccess: () => {
-            setShiftToDelete(null);
-          },
-        }
-      );
+      const employeeName = allEmployees.find((e) => e.id === shiftToDelete.employee_id)?.name ?? '';
+      guardShiftChange({
+        shiftId: shiftToDelete.id,
+        employeeName,
+        run: ({ allowPublished }) => {
+          deleteShift.mutate(
+            { id: shiftToDelete.id, restaurantId, shift: shiftToDelete, allowPublished },
+            {
+              onSuccess: () => {
+                setShiftToDelete(null);
+              },
+            }
+          );
+        },
+      });
     }
   };
 

--- a/src/pages/Scheduling.tsx
+++ b/src/pages/Scheduling.tsx
@@ -711,7 +711,7 @@ const Scheduling = () => {
     if (actionType === 'delete') {
       // Delete with scope
       deleteShiftSeries.mutate(
-        { shift, scope, restaurantId, includePublished: true },
+        { shift, scope, restaurantId, allowPublished: true },
         {
           onSuccess: () => {
             setRecurringActionDialog({ open: false, shift: null, actionType: 'edit' });

--- a/src/pages/Scheduling.tsx
+++ b/src/pages/Scheduling.tsx
@@ -747,7 +747,7 @@ const Scheduling = () => {
     }
   };
 
-  const handlePublishSchedule = (notes?: string) => {
+  const handlePublishSchedule = (notes: string | undefined, notify: boolean) => {
     if (restaurantId) {
       publishSchedule.mutate(
         {
@@ -755,6 +755,7 @@ const Scheduling = () => {
           weekStart: currentWeekStart,
           weekEnd,
           notes,
+          notify,
         },
         {
           onSuccess: () => {

--- a/src/pages/Scheduling.tsx
+++ b/src/pages/Scheduling.tsx
@@ -716,15 +716,12 @@ const Scheduling = () => {
       guardShiftChange({
         shiftId: shift.id,
         employeeName,
-        run: ({ allowPublished }) => {
-          deleteShiftSeries.mutate(
-            { shift, scope, restaurantId, allowPublished },
-            {
-              onSuccess: () => {
-                setRecurringActionDialog({ open: false, shift: null, actionType: 'edit' });
-              },
-            }
-          );
+        // Awaited, not fire-and-forget `.mutate()` — `usePublishedShiftGuard`
+        // looks up the change-log row right after `run` resolves, and that
+        // row only exists once this DELETE (and its trigger) have committed.
+        run: async ({ allowPublished }) => {
+          await deleteShiftSeries.mutateAsync({ shift, scope, restaurantId, allowPublished });
+          setRecurringActionDialog({ open: false, shift: null, actionType: 'edit' });
         },
       });
     } else {
@@ -749,15 +746,22 @@ const Scheduling = () => {
       guardShiftChange({
         shiftId: shiftToDelete.id,
         employeeName,
-        run: ({ allowPublished }) => {
-          deleteShift.mutate(
-            { id: shiftToDelete.id, restaurantId, shift: shiftToDelete, allowPublished },
-            {
-              onSuccess: () => {
-                setShiftToDelete(null);
-              },
-            }
-          );
+        // Awaited, not fire-and-forget `.mutate()` — see the series-delete
+        // branch above for why. `skipLegacyNotify: true`: the guard's own
+        // notify step (the "Notify" checkbox, `notify-shift-changed`) now
+        // owns the employee notification for this guarded delete, so the
+        // unconditional legacy `send-shift-notification` invoke in
+        // `useDeleteShift` must not also fire — that would ignore an
+        // unchecked box and could double-notify when checked.
+        run: async ({ allowPublished }) => {
+          await deleteShift.mutateAsync({
+            id: shiftToDelete.id,
+            restaurantId,
+            shift: shiftToDelete,
+            allowPublished,
+            skipLegacyNotify: true,
+          });
+          setShiftToDelete(null);
         },
       });
     }

--- a/src/pages/Scheduling.tsx
+++ b/src/pages/Scheduling.tsx
@@ -22,6 +22,7 @@ import { ShiftCard } from './SchedulingShiftCard';
 import { TradeRequestDialog } from '@/components/schedule/TradeRequestDialog';
 import { WeekScheduleMobile } from '@/components/scheduling/WeekScheduleMobile';
 import { usePublishSchedule, useUnpublishSchedule, useWeekPublicationStatus } from '@/hooks/useSchedulePublish';
+import { usePublishedShiftGuard } from '@/hooks/usePublishedShiftGuard';
 import { useScheduleChangeLogs } from '@/hooks/useScheduleChangeLogs';
 import { useScheduledLaborCosts } from '@/hooks/useScheduledLaborCosts';
 import { useEmployeeLaborCosts } from '@/hooks/useEmployeeLaborCosts';
@@ -39,7 +40,6 @@ import {
 } from '@/lib/scheduleVisibility';
 import { ShiftDialog } from '@/components/ShiftDialog';
 import type { DefaultEmployee } from '@/components/ShiftDialog';
-import { usePublishedShiftGuard } from '@/hooks/usePublishedShiftGuard';
 import { TimeOffRequestDialog } from '@/components/TimeOffRequestDialog';
 import { TimeOffList } from '@/components/TimeOffList';
 import { AvailabilityDialog } from '@/components/AvailabilityDialog';

--- a/src/pages/Scheduling.tsx
+++ b/src/pages/Scheduling.tsx
@@ -245,7 +245,8 @@ const Scheduling = () => {
   const { effectiveSettings: staffingSettings } = useStaffingSettings(restaurantId);
 
   const { weekStart: currentWeekStart, setWeekStart: setCurrentWeekStart } = useSharedWeek();
-  const { guardShiftChange, dialog: publishedShiftChangeDialog } = usePublishedShiftGuard();
+  const { guardShiftChange, notifyAfterDeferredCommit, dialog: publishedShiftChangeDialog } =
+    usePublishedShiftGuard();
   const [employeeDialogOpen, setEmployeeDialogOpen] = useState(false);
   const [shiftDialogOpen, setShiftDialogOpen] = useState(false);
   const [timeOffDialogOpen, setTimeOffDialogOpen] = useState(false);
@@ -715,6 +716,7 @@ const Scheduling = () => {
       const employeeName = allEmployees.find((e) => e.id === shift.employee_id)?.name ?? '';
       guardShiftChange({
         shiftId: shift.id,
+        restaurantId,
         employeeName,
         // Awaited, not fire-and-forget `.mutate()` — `usePublishedShiftGuard`
         // looks up the change-log row right after `run` resolves, and that
@@ -745,6 +747,7 @@ const Scheduling = () => {
       const employeeName = allEmployees.find((e) => e.id === shiftToDelete.employee_id)?.name ?? '';
       guardShiftChange({
         shiftId: shiftToDelete.id,
+        restaurantId,
         employeeName,
         // Awaited, not fire-and-forget `.mutate()` — see the series-delete
         // branch above for why. `skipLegacyNotify: true`: the guard's own
@@ -1641,6 +1644,7 @@ const Scheduling = () => {
               weekStart={currentWeekStart}
               onWeekStartChange={setCurrentWeekStart}
               guardShiftChange={guardShiftChange}
+              notifyAfterDeferredCommit={notifyAfterDeferredCommit}
             />
           )}
         </TabsContent>

--- a/src/pages/Scheduling.tsx
+++ b/src/pages/Scheduling.tsx
@@ -1636,6 +1636,7 @@ const Scheduling = () => {
               restaurantId={restaurantId}
               weekStart={currentWeekStart}
               onWeekStartChange={setCurrentWeekStart}
+              guardShiftChange={guardShiftChange}
             />
           )}
         </TabsContent>

--- a/supabase/functions/_shared/shiftChangedNotification.ts
+++ b/supabase/functions/_shared/shiftChangedNotification.ts
@@ -1,0 +1,139 @@
+/**
+ * Pure derive/validity logic for the "your published shift changed"
+ * notification (design doc, "Change: the notification").
+ *
+ * Kept import-free of Deno-only modules so vitest can exercise it directly,
+ * the same precedent as shiftDeletedNotification.ts. The edge function
+ * (notify-shift-changed/index.ts) owns the DB reads, the auth/capability
+ * checks, the notified_at latch, and the actual send.
+ */
+
+export interface ShiftChangeLogRow {
+  id: string;
+  restaurant_id: string;
+  shift_id: string | null;
+  change_type: string;
+  changed_at: string; // ISO
+  before_data: Record<string, unknown> | null;
+  after_data: Record<string, unknown> | null;
+}
+
+export type ShiftChangeValidity =
+  | { valid: true }
+  | { valid: false; reason: 'too-old' | 'wrong-change-type' | 'no-shift-id' };
+
+const MAX_AGE_MS = 10 * 60 * 1000;
+
+/**
+ * Design step 4: refuse rows that are too old, the wrong kind of change, or
+ * restaurant-level (no shift_id — the `unpublished` change_type has none,
+ * see 20251123000000_schedule_publishing.sql:243-259, and is not a valid
+ * target here).
+ */
+export function checkShiftChangeValidity(
+  row: Pick<ShiftChangeLogRow, 'change_type' | 'changed_at' | 'shift_id'>,
+  now: Date = new Date(),
+): ShiftChangeValidity {
+  if (row.change_type !== 'updated' && row.change_type !== 'deleted') {
+    return { valid: false, reason: 'wrong-change-type' };
+  }
+  if (!row.shift_id) {
+    return { valid: false, reason: 'no-shift-id' };
+  }
+  const ageMs = now.getTime() - new Date(row.changed_at).getTime();
+  if (ageMs > MAX_AGE_MS) {
+    return { valid: false, reason: 'too-old' };
+  }
+  return { valid: true };
+}
+
+export type ShiftChangeRole = 'removed' | 'assigned' | 'updated';
+
+export interface ShiftChangeRecipient {
+  employeeId: string;
+  role: ShiftChangeRole;
+}
+
+const employeeIdOf = (data: Record<string, unknown> | null | undefined): string | null => {
+  const id = data?.employee_id;
+  return typeof id === 'string' ? id : null;
+};
+
+/**
+ * Design steps 6-7: derive who to tell and what happened to each of them,
+ * from the row alone. `before_data.employee_id` plus `after_data.employee_id`
+ * when different (reassignment). An open shift (both sides null) yields no
+ * recipients.
+ */
+export function deriveShiftChangeRecipients(
+  row: Pick<ShiftChangeLogRow, 'change_type' | 'before_data' | 'after_data'>,
+): ShiftChangeRecipient[] {
+  const beforeId = employeeIdOf(row.before_data);
+  const afterId = employeeIdOf(row.after_data);
+
+  if (row.change_type === 'deleted') {
+    return beforeId ? [{ employeeId: beforeId, role: 'removed' }] : [];
+  }
+
+  // updated
+  if (beforeId && afterId && beforeId !== afterId) {
+    return [
+      { employeeId: beforeId, role: 'removed' },
+      { employeeId: afterId, role: 'assigned' },
+    ];
+  }
+  const sameId = afterId ?? beforeId;
+  return sameId ? [{ employeeId: sameId, role: 'updated' }] : [];
+}
+
+export interface ShiftChangeMessage {
+  title: string;
+  body: string;
+}
+
+const formatWeekdayTime = (iso: string, timeZone: string): string =>
+  new Date(iso).toLocaleString('en-US', {
+    weekday: 'short',
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZone,
+  });
+
+const formatTimeOnly = (iso: string, timeZone: string): string =>
+  new Date(iso).toLocaleString('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZone,
+  });
+
+/**
+ * Design step 8: the concrete per-recipient message, e.g. "Your Tue 5:00 PM
+ * shift changed to 6:00 PM", "Your Tue shift was removed", "You have a new
+ * shift".
+ */
+export function buildShiftChangeMessage(
+  recipient: ShiftChangeRecipient,
+  row: Pick<ShiftChangeLogRow, 'before_data' | 'after_data'>,
+  timeZone: string,
+): ShiftChangeMessage {
+  if (recipient.role === 'removed') {
+    const start = row.before_data?.start_time;
+    const when = typeof start === 'string' ? formatWeekdayTime(start, timeZone) : '';
+    return {
+      title: 'Shift Removed',
+      body: when ? `Your ${when} shift was removed.` : 'Your shift was removed.',
+    };
+  }
+  if (recipient.role === 'assigned') {
+    return { title: 'New Shift Assigned', body: 'You have a new shift.' };
+  }
+  // updated
+  const oldStart = row.before_data?.start_time;
+  const newStart = row.after_data?.start_time;
+  if (typeof oldStart === 'string' && typeof newStart === 'string') {
+    const oldWhen = formatWeekdayTime(oldStart, timeZone);
+    const newWhen = formatTimeOnly(newStart, timeZone);
+    return { title: 'Shift Updated', body: `Your ${oldWhen} shift changed to ${newWhen}.` };
+  }
+  return { title: 'Shift Updated', body: 'Your shift changed.' };
+}

--- a/supabase/functions/_shared/shiftChangedNotification.ts
+++ b/supabase/functions/_shared/shiftChangedNotification.ts
@@ -130,10 +130,21 @@ export function buildShiftChangeMessage(
   // updated
   const oldStart = row.before_data?.start_time;
   const newStart = row.after_data?.start_time;
+  const oldEnd = row.before_data?.end_time;
+  const newEnd = row.after_data?.end_time;
   if (typeof oldStart === 'string' && typeof newStart === 'string') {
     const oldWhen = formatWeekdayTime(oldStart, timeZone);
-    const newWhen = formatTimeOnly(newStart, timeZone);
-    return { title: 'Shift Updated', body: `Your ${oldWhen} shift changed to ${newWhen}.` };
+    if (oldStart !== newStart) {
+      const newWhen = formatTimeOnly(newStart, timeZone);
+      return { title: 'Shift Updated', body: `Your ${oldWhen} shift changed to ${newWhen}.` };
+    }
+    // Start unchanged. "changed to <same time>" would read as no change,
+    // so name the part that moved.
+    if (typeof oldEnd === 'string' && typeof newEnd === 'string' && oldEnd !== newEnd) {
+      const newEndWhen = formatTimeOnly(newEnd, timeZone);
+      return { title: 'Shift Updated', body: `Your ${oldWhen} shift now ends at ${newEndWhen}.` };
+    }
+    return { title: 'Shift Updated', body: `Your ${oldWhen} shift was updated.` };
   }
   return { title: 'Shift Updated', body: 'Your shift changed.' };
 }

--- a/supabase/functions/notify-schedule-unpublished/index.ts
+++ b/supabase/functions/notify-schedule-unpublished/index.ts
@@ -175,18 +175,13 @@ serve(async (req) => {
       return noop(`retraction ${retraction.id} has no publication to walk back`);
     }
 
-    const { data: publication, error: publicationError } = await serviceClient
-      .from("schedule_publications")
-      .select("notification_sent")
-      .eq("id", retraction.publication_id)
-      .maybeSingle();
-
-    if (publicationError) {
-      throw new Error(`Failed to read publication: ${publicationError.message}`);
-    }
-    if (!publication?.notification_sent) {
-      return noop(`publication ${retraction.publication_id} was never announced`);
-    }
+    // Gate on the retracted publication row, not on
+    // `schedule_publications.notification_sent` (Phase 2.5 review). A quiet
+    // publish leaves `notification_sent` false, but the week is still live
+    // and visible to employees -- a later retraction of it must still
+    // announce. `retraction.publication_id` already proves that row exists
+    // (checked above), so no further read of `schedule_publications` is
+    // needed here.
 
     // Claim before sending, not after. Two managers unpublishing in quick
     // succession, or a client retry, would otherwise each read notified_at as

--- a/supabase/functions/notify-shift-changed/index.ts
+++ b/supabase/functions/notify-shift-changed/index.ts
@@ -18,6 +18,7 @@ import {
   sendEmailResult,
 } from "../_shared/notificationHelpers.ts";
 import { sendWebPushToUser } from "../_shared/webPushHelper.ts";
+import { escapeHtml } from "../_shared/emailTemplates.ts";
 import {
   checkShiftChangeValidity,
   deriveShiftChangeRecipients,
@@ -176,7 +177,7 @@ serve(async (req) => {
           NOTIFICATION_FROM,
           employee.email,
           `${message.title} - ${restaurantName}`,
-          `<p>Hi ${employee.name ?? "there"},</p><p>${message.body}</p>`,
+          `<p>Hi ${escapeHtml(employee.name ?? "there")},</p><p>${escapeHtml(message.body)}</p>`,
         );
         if (emailResult.ok) {
           recipientReached = true;

--- a/supabase/functions/notify-shift-changed/index.ts
+++ b/supabase/functions/notify-shift-changed/index.ts
@@ -119,100 +119,130 @@ serve(async (req) => {
       });
     }
 
-    // Steps 6-7: derive everything else from the row alone, not the request.
-    const recipients = deriveShiftChangeRecipients(row as ShiftChangeLogRow);
-    if (recipients.length === 0) {
-      // An open shift (both sides null) — nothing to tell anyone.
-      return new Response(JSON.stringify({ sent: 0, failed: 0 }), {
+    // The claim above is a lock. From here on, a failure must release it,
+    // or a real change log can never be retried and its notification is
+    // lost for good. `release` clears `notified_at` back to null; only a
+    // send that reaches at least one recipient leaves the claim in place.
+    const release = async () => {
+      const { error } = await serviceClient
+        .from("schedule_change_logs")
+        .update({ notified_at: null })
+        .eq("id", changeLogId);
+      if (error) {
+        console.error(`Failed to release change log ${changeLogId}:`, error);
+      }
+    };
+
+    try {
+      // Steps 6-7: derive everything else from the row alone, not the request.
+      const recipients = deriveShiftChangeRecipients(row as ShiftChangeLogRow);
+      if (recipients.length === 0) {
+        // An open shift (both sides null) — nothing to tell anyone. Not a
+        // failure, so the claim stands; a retry would find the same result.
+        return new Response(JSON.stringify({ sent: 0, failed: 0 }), {
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+          status: 200,
+        });
+      }
+
+      const employeeIds = recipients.map((r) => r.employeeId);
+      const [{ data: employees, error: empError }, { data: restaurant, error: restError }] =
+        await Promise.all([
+          serviceClient
+            .from("employees")
+            .select("id, name, email, user_id")
+            .eq("restaurant_id", row.restaurant_id)
+            .in("id", employeeIds),
+          serviceClient
+            .from("restaurants")
+            .select("name, timezone")
+            .eq("id", row.restaurant_id)
+            .maybeSingle(),
+        ]);
+
+      if (empError) {
+        throw new Error(`Failed to fetch employees: ${empError.message}`);
+      }
+      if (restError) {
+        throw new Error(`Failed to fetch restaurant: ${restError.message}`);
+      }
+
+      const timezone = restaurant?.timezone || "UTC";
+      const restaurantName = restaurant?.name ?? "EasyShiftHQ";
+      const employeeById = new Map(
+        ((employees ?? []) as RecipientEmployee[]).map((e) => [e.id, e]),
+      );
+
+      let sent = 0;
+      let failed = 0;
+
+      // Step 8: send one email + push per recipient with the concrete change.
+      for (const recipient of recipients) {
+        const employee = employeeById.get(recipient.employeeId);
+        if (!employee) {
+          failed++;
+          continue;
+        }
+
+        const message = buildShiftChangeMessage(recipient, row as ShiftChangeLogRow, timezone);
+        let recipientReached = false;
+
+        if (employee.email && RESEND_API_KEY) {
+          const emailResult = await sendEmailResult(
+            RESEND_API_KEY,
+            NOTIFICATION_FROM,
+            employee.email,
+            `${message.title} - ${restaurantName}`,
+            `<p>Hi ${escapeHtml(employee.name ?? "there")},</p><p>${escapeHtml(message.body)}</p>`,
+          );
+          if (emailResult.ok) {
+            recipientReached = true;
+          } else {
+            console.error(
+              `notify-shift-changed: email failed for employee ${employee.id}`,
+              emailResult.error,
+            );
+          }
+        }
+
+        if (employee.user_id) {
+          const push = await sendWebPushToUser(serviceClient, employee.user_id, row.restaurant_id, {
+            title: message.title,
+            body: message.body,
+            url: SCHEDULE_PATH,
+            tag: `shift-changed-${row.shift_id}-${employee.id}`,
+          });
+          if (push.sent > 0) {
+            recipientReached = true;
+          }
+        }
+
+        if (recipientReached) {
+          sent++;
+        } else {
+          failed++;
+        }
+      }
+
+      // Reached nobody: release the claim so a retry can try again, and
+      // signal the caller this attempt did not actually deliver anything.
+      if (sent === 0) {
+        await release();
+        return new Response(JSON.stringify({ sent, failed }), {
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+          status: 502,
+        });
+      }
+
+      // Step 9.
+      return new Response(JSON.stringify({ sent, failed }), {
         headers: { ...corsHeaders, "Content-Type": "application/json" },
         status: 200,
       });
+    } catch (error) {
+      await release();
+      throw error;
     }
-
-    const employeeIds = recipients.map((r) => r.employeeId);
-    const [{ data: employees, error: empError }, { data: restaurant, error: restError }] =
-      await Promise.all([
-        serviceClient
-          .from("employees")
-          .select("id, name, email, user_id")
-          .eq("restaurant_id", row.restaurant_id)
-          .in("id", employeeIds),
-        serviceClient
-          .from("restaurants")
-          .select("name, timezone")
-          .eq("id", row.restaurant_id)
-          .maybeSingle(),
-      ]);
-
-    if (empError) {
-      throw new Error(`Failed to fetch employees: ${empError.message}`);
-    }
-    if (restError) {
-      throw new Error(`Failed to fetch restaurant: ${restError.message}`);
-    }
-
-    const timezone = restaurant?.timezone || "UTC";
-    const restaurantName = restaurant?.name ?? "EasyShiftHQ";
-    const employeeById = new Map(
-      ((employees ?? []) as RecipientEmployee[]).map((e) => [e.id, e]),
-    );
-
-    let sent = 0;
-    let failed = 0;
-
-    // Step 8: send one email + push per recipient with the concrete change.
-    for (const recipient of recipients) {
-      const employee = employeeById.get(recipient.employeeId);
-      if (!employee) {
-        failed++;
-        continue;
-      }
-
-      const message = buildShiftChangeMessage(recipient, row as ShiftChangeLogRow, timezone);
-      let recipientReached = false;
-
-      if (employee.email && RESEND_API_KEY) {
-        const emailResult = await sendEmailResult(
-          RESEND_API_KEY,
-          NOTIFICATION_FROM,
-          employee.email,
-          `${message.title} - ${restaurantName}`,
-          `<p>Hi ${escapeHtml(employee.name ?? "there")},</p><p>${escapeHtml(message.body)}</p>`,
-        );
-        if (emailResult.ok) {
-          recipientReached = true;
-        } else {
-          console.error(
-            `notify-shift-changed: email failed for employee ${employee.id}`,
-            emailResult.error,
-          );
-        }
-      }
-
-      if (employee.user_id) {
-        const push = await sendWebPushToUser(serviceClient, employee.user_id, row.restaurant_id, {
-          title: message.title,
-          body: message.body,
-          url: SCHEDULE_PATH,
-          tag: `shift-changed-${row.shift_id}-${employee.id}`,
-        });
-        if (push.sent > 0) {
-          recipientReached = true;
-        }
-      }
-
-      if (recipientReached) {
-        sent++;
-      } else {
-        failed++;
-      }
-    }
-
-    // Step 9.
-    return new Response(JSON.stringify({ sent, failed }), {
-      headers: { ...corsHeaders, "Content-Type": "application/json" },
-      status: 200,
-    });
   } catch (error: unknown) {
     console.error("Error in notify-shift-changed:", error);
     const message = error instanceof Error ? error.message : "An error occurred";

--- a/supabase/functions/notify-shift-changed/index.ts
+++ b/supabase/functions/notify-shift-changed/index.ts
@@ -1,0 +1,220 @@
+// Tell an employee that a published shift they hold changed after the fact.
+//
+// Design: docs/superpowers/specs/2026-08-15-quiet-publish-live-edit-design.md,
+// "Change: the notification". The request body carries only {changeLogId} —
+// no decision fields (lesson 2026-07-20). Everything sent is derived from the
+// schedule_change_logs row the trigger wrote in the same transaction as the
+// shift change, so a malicious or buggy caller can only cause a notification
+// that matches what actually happened, to the people it happened to.
+
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import {
+  authenticateRequest,
+  corsHeaders,
+  errorResponse,
+  handleCorsPreflightRequest,
+  NOTIFICATION_FROM,
+  sendEmailResult,
+} from "../_shared/notificationHelpers.ts";
+import { sendWebPushToUser } from "../_shared/webPushHelper.ts";
+import {
+  checkShiftChangeValidity,
+  deriveShiftChangeRecipients,
+  buildShiftChangeMessage,
+  type ShiftChangeLogRow,
+} from "../_shared/shiftChangedNotification.ts";
+
+const RESEND_API_KEY = Deno.env.get("RESEND_API_KEY") ?? "";
+
+/** Where both the email link and the push point. */
+const SCHEDULE_PATH = "/employee/schedule";
+
+interface NotifyShiftChangedPayload {
+  changeLogId: string;
+}
+
+interface RecipientEmployee {
+  id: string;
+  name: string | null;
+  email: string | null;
+  user_id: string | null;
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return handleCorsPreflightRequest();
+  }
+
+  try {
+    // Step 1: authenticate the caller. `supabase` here forwards the caller's
+    // JWT — the capability check in step 3 needs auth.uid() to resolve, so
+    // this client (not a service-role one) is what carries that check.
+    const { supabase } = await authenticateRequest(req);
+
+    const { changeLogId }: NotifyShiftChangedPayload = await req.json();
+    if (!changeLogId) {
+      return errorResponse("changeLogId is required", 400);
+    }
+
+    const serviceClient = createClient(
+      Deno.env.get("SUPABASE_URL") ?? "",
+      Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "",
+    );
+
+    // Step 2: read the row with the service-role client. Refuse when absent.
+    const { data: row, error: rowError } = await serviceClient
+      .from("schedule_change_logs")
+      .select("id, restaurant_id, shift_id, change_type, changed_at, before_data, after_data")
+      .eq("id", changeLogId)
+      .maybeSingle();
+
+    if (rowError) {
+      throw new Error(`Failed to read change log: ${rowError.message}`);
+    }
+    if (!row) {
+      return errorResponse("Change log not found", 404);
+    }
+
+    // Step 3: the caller must be able to edit this restaurant's schedule —
+    // the same gate as the shifts UPDATE RLS policy
+    // (20260730150000_rewrite_collaborator_policies.sql:140-144).
+    // restaurant_id is only known after step 2, so nothing sends before this
+    // check passes.
+    const { data: canEdit, error: capError } = await supabase.rpc("user_has_capability", {
+      p_restaurant_id: row.restaurant_id,
+      p_capability: "edit:scheduling",
+    });
+    if (capError) {
+      console.error("notify-shift-changed: capability check failed", capError);
+    }
+    if (!canEdit) {
+      return errorResponse("Access denied", 403);
+    }
+
+    // Step 4: validity checks (age, change_type, shift_id).
+    const validity = checkShiftChangeValidity(row as ShiftChangeLogRow);
+    if (!validity.valid) {
+      return errorResponse(`Change log is not a valid notify target: ${validity.reason}`, 409);
+    }
+
+    // Step 5: claim the notified_at latch. Zero rows back means another
+    // call already sent this — a double-click or client retry cannot send
+    // twice.
+    const { data: claimed, error: claimError } = await serviceClient
+      .from("schedule_change_logs")
+      .update({ notified_at: new Date().toISOString() })
+      .eq("id", changeLogId)
+      .is("notified_at", null)
+      .select("id");
+
+    if (claimError) {
+      throw new Error(`Failed to claim change log: ${claimError.message}`);
+    }
+    if (!claimed?.length) {
+      return new Response(JSON.stringify({ sent: 0, alreadyNotified: true }), {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+        status: 200,
+      });
+    }
+
+    // Steps 6-7: derive everything else from the row alone, not the request.
+    const recipients = deriveShiftChangeRecipients(row as ShiftChangeLogRow);
+    if (recipients.length === 0) {
+      // An open shift (both sides null) — nothing to tell anyone.
+      return new Response(JSON.stringify({ sent: 0, failed: 0 }), {
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+        status: 200,
+      });
+    }
+
+    const employeeIds = recipients.map((r) => r.employeeId);
+    const [{ data: employees, error: empError }, { data: restaurant, error: restError }] =
+      await Promise.all([
+        serviceClient
+          .from("employees")
+          .select("id, name, email, user_id")
+          .eq("restaurant_id", row.restaurant_id)
+          .in("id", employeeIds),
+        serviceClient
+          .from("restaurants")
+          .select("name, timezone")
+          .eq("id", row.restaurant_id)
+          .maybeSingle(),
+      ]);
+
+    if (empError) {
+      throw new Error(`Failed to fetch employees: ${empError.message}`);
+    }
+    if (restError) {
+      throw new Error(`Failed to fetch restaurant: ${restError.message}`);
+    }
+
+    const timezone = restaurant?.timezone || "UTC";
+    const restaurantName = restaurant?.name ?? "EasyShiftHQ";
+    const employeeById = new Map(
+      ((employees ?? []) as RecipientEmployee[]).map((e) => [e.id, e]),
+    );
+
+    let sent = 0;
+    let failed = 0;
+
+    // Step 8: send one email + push per recipient with the concrete change.
+    for (const recipient of recipients) {
+      const employee = employeeById.get(recipient.employeeId);
+      if (!employee) {
+        failed++;
+        continue;
+      }
+
+      const message = buildShiftChangeMessage(recipient, row as ShiftChangeLogRow, timezone);
+      let recipientReached = false;
+
+      if (employee.email && RESEND_API_KEY) {
+        const emailResult = await sendEmailResult(
+          RESEND_API_KEY,
+          NOTIFICATION_FROM,
+          employee.email,
+          `${message.title} - ${restaurantName}`,
+          `<p>Hi ${employee.name ?? "there"},</p><p>${message.body}</p>`,
+        );
+        if (emailResult.ok) {
+          recipientReached = true;
+        } else {
+          console.error(
+            `notify-shift-changed: email failed for employee ${employee.id}`,
+            emailResult.error,
+          );
+        }
+      }
+
+      if (employee.user_id) {
+        const push = await sendWebPushToUser(serviceClient, employee.user_id, row.restaurant_id, {
+          title: message.title,
+          body: message.body,
+          url: SCHEDULE_PATH,
+          tag: `shift-changed-${row.shift_id}-${employee.id}`,
+        });
+        if (push.sent > 0) {
+          recipientReached = true;
+        }
+      }
+
+      if (recipientReached) {
+        sent++;
+      } else {
+        failed++;
+      }
+    }
+
+    // Step 9.
+    return new Response(JSON.stringify({ sent, failed }), {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+      status: 200,
+    });
+  } catch (error: unknown) {
+    console.error("Error in notify-shift-changed:", error);
+    const message = error instanceof Error ? error.message : "An error occurred";
+    return errorResponse(message, message === "Access denied" ? 403 : 500);
+  }
+});

--- a/supabase/migrations/20260815100000_schedule_change_logs_notified_at.sql
+++ b/supabase/migrations/20260815100000_schedule_change_logs_notified_at.sql
@@ -1,0 +1,5 @@
+-- Add notified_at to schedule_change_logs.
+-- Tracks when the notify-shift-changed job sent an alert for a log row.
+-- Null means no alert went out yet.
+ALTER TABLE schedule_change_logs
+  ADD COLUMN IF NOT EXISTS notified_at TIMESTAMPTZ;

--- a/supabase/migrations/20260815110000_allow_update_locked_shift_series.sql
+++ b/supabase/migrations/20260815110000_allow_update_locked_shift_series.sql
@@ -1,0 +1,95 @@
+-- Allow updates to locked (published) shift series when explicitly requested.
+-- Adds p_include_locked to update_shift_series, mirroring the
+-- p_include_locked param added to delete_shift_series in
+-- 20260408000000_allow_delete_locked_shifts.sql.
+--
+-- Without this, a manager who confirms "This shift is published" for a
+-- 'following' or 'all' scope edit sees the confirm dialog, but the RPC
+-- silently skips every locked shift in scope anyway — the edit for a
+-- 'this'-scope shift saves, but the rest of the series does not.
+
+DROP FUNCTION IF EXISTS update_shift_series(UUID, UUID, TEXT, JSONB, TIMESTAMPTZ, INTERVAL, INTERVAL);
+
+CREATE OR REPLACE FUNCTION update_shift_series(
+  p_parent_id UUID,
+  p_restaurant_id UUID,
+  p_scope TEXT, -- 'all' or 'following'
+  p_updates JSONB,
+  p_from_time TIMESTAMPTZ DEFAULT NULL, -- required for 'following' scope
+  p_start_time_delta INTERVAL DEFAULT NULL, -- optional: offset to apply to start_time
+  p_end_time_delta INTERVAL DEFAULT NULL, -- optional: offset to apply to end_time
+  p_include_locked BOOLEAN DEFAULT false
+)
+RETURNS TABLE(updated_count INT, locked_count INT)
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_updated_count INT := 0;
+  v_locked_count INT := 0;
+BEGIN
+  IF p_scope = 'following' THEN
+    -- Count locked shifts that will NOT be updated (only when not force-updating)
+    IF NOT p_include_locked THEN
+      SELECT COUNT(*) INTO v_locked_count
+      FROM shifts
+      WHERE (id = p_parent_id OR recurrence_parent_id = p_parent_id)
+        AND restaurant_id = p_restaurant_id
+        AND start_time >= p_from_time
+        AND locked = true;
+    END IF;
+
+    -- Update shifts (include locked if requested)
+    WITH updated AS (
+      UPDATE shifts
+      SET
+        employee_id = COALESCE((p_updates->>'employee_id')::UUID, employee_id),
+        position = COALESCE(p_updates->>'position', position),
+        notes = CASE WHEN p_updates ? 'notes' THEN p_updates->>'notes' ELSE notes END,
+        status = COALESCE(p_updates->>'status', status),
+        break_duration = COALESCE((p_updates->>'break_duration')::INT, break_duration),
+        start_time = CASE WHEN p_start_time_delta IS NOT NULL THEN start_time + p_start_time_delta ELSE start_time END,
+        end_time = CASE WHEN p_end_time_delta IS NOT NULL THEN end_time + p_end_time_delta ELSE end_time END,
+        updated_at = NOW()
+      WHERE (id = p_parent_id OR recurrence_parent_id = p_parent_id)
+        AND restaurant_id = p_restaurant_id
+        AND start_time >= p_from_time
+        AND (locked = false OR p_include_locked = true)
+      RETURNING id
+    )
+    SELECT COUNT(*) INTO v_updated_count FROM updated;
+  ELSE -- 'all'
+    -- Count locked shifts that will NOT be updated (only when not force-updating)
+    IF NOT p_include_locked THEN
+      SELECT COUNT(*) INTO v_locked_count
+      FROM shifts
+      WHERE (id = p_parent_id OR recurrence_parent_id = p_parent_id)
+        AND restaurant_id = p_restaurant_id
+        AND locked = true;
+    END IF;
+
+    -- Update shifts (include locked if requested)
+    WITH updated AS (
+      UPDATE shifts
+      SET
+        employee_id = COALESCE((p_updates->>'employee_id')::UUID, employee_id),
+        position = COALESCE(p_updates->>'position', position),
+        notes = CASE WHEN p_updates ? 'notes' THEN p_updates->>'notes' ELSE notes END,
+        status = COALESCE(p_updates->>'status', status),
+        break_duration = COALESCE((p_updates->>'break_duration')::INT, break_duration),
+        start_time = CASE WHEN p_start_time_delta IS NOT NULL THEN start_time + p_start_time_delta ELSE start_time END,
+        end_time = CASE WHEN p_end_time_delta IS NOT NULL THEN end_time + p_end_time_delta ELSE end_time END,
+        updated_at = NOW()
+      WHERE (id = p_parent_id OR recurrence_parent_id = p_parent_id)
+        AND restaurant_id = p_restaurant_id
+        AND (locked = false OR p_include_locked = true)
+      RETURNING id
+    )
+    SELECT COUNT(*) INTO v_updated_count FROM updated;
+  END IF;
+
+  RETURN QUERY SELECT v_updated_count, v_locked_count;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION update_shift_series(UUID, UUID, TEXT, JSONB, TIMESTAMPTZ, INTERVAL, INTERVAL, BOOLEAN) TO authenticated;

--- a/supabase/migrations/20260815110000_allow_update_locked_shift_series.sql
+++ b/supabase/migrations/20260815110000_allow_update_locked_shift_series.sql
@@ -23,11 +23,18 @@ CREATE OR REPLACE FUNCTION update_shift_series(
 RETURNS TABLE(updated_count INT, locked_count INT)
 LANGUAGE plpgsql
 SECURITY DEFINER
+SET search_path = public, pg_temp
 AS $$
 DECLARE
   v_updated_count INT := 0;
   v_locked_count INT := 0;
 BEGIN
+  -- SECURITY DEFINER bypasses RLS, so the function must check tenancy
+  -- itself. Same gate as the shifts UPDATE policy.
+  IF NOT public.user_has_capability(p_restaurant_id, 'edit:scheduling') THEN
+    RAISE EXCEPTION 'Access denied: you cannot edit shifts for this restaurant';
+  END IF;
+
   IF p_scope = 'following' THEN
     -- Count locked shifts that will NOT be updated (only when not force-updating)
     IF NOT p_include_locked THEN

--- a/supabase/tests/allow_update_locked_shift_series.test.sql
+++ b/supabase/tests/allow_update_locked_shift_series.test.sql
@@ -1,0 +1,140 @@
+-- Test: update_shift_series with p_include_locked parameter
+-- Verifies default behavior skips locked shifts, and p_include_locked=true updates them
+
+BEGIN;
+
+SELECT plan(5);
+
+-- Setup: Create test restaurant, user, and employee
+INSERT INTO restaurants (id, name, address, phone)
+VALUES ('00000000-0000-0000-0000-000000000901'::uuid, 'Series Update Lock Test Restaurant', '123 Lock St', '555-LOCK')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO auth.users (id, email)
+VALUES ('00000000-0000-0000-0000-000000000902'::uuid, 'series-lock-test@test.com')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO employees (id, restaurant_id, name, position, hourly_rate)
+VALUES ('00000000-0000-0000-0000-000000000903'::uuid,
+        '00000000-0000-0000-0000-000000000901'::uuid,
+        'Series Lock Test Employee', 'Server', 1500)
+ON CONFLICT (id) DO NOTHING;
+
+\set rest_id '''00000000-0000-0000-0000-000000000901'''
+\set emp_id '''00000000-0000-0000-0000-000000000903'''
+
+-- ============================================================
+-- Test Group 1: Default behavior (p_include_locked = false)
+-- Parent is locked, one child unlocked, one child locked
+-- ============================================================
+
+INSERT INTO shifts (id, restaurant_id, employee_id, start_time, end_time, position, locked, recurrence_parent_id)
+VALUES
+  ('00000000-0000-0000-0000-000000000910'::uuid, :rest_id::uuid, :emp_id::uuid,
+   '2026-04-14 09:00:00+00', '2026-04-14 17:00:00+00', 'Server', true, NULL),
+  ('00000000-0000-0000-0000-000000000911'::uuid, :rest_id::uuid, :emp_id::uuid,
+   '2026-04-15 09:00:00+00', '2026-04-15 17:00:00+00', 'Server', false,
+   '00000000-0000-0000-0000-000000000910'::uuid),
+  ('00000000-0000-0000-0000-000000000912'::uuid, :rest_id::uuid, :emp_id::uuid,
+   '2026-04-16 09:00:00+00', '2026-04-16 17:00:00+00', 'Server', true,
+   '00000000-0000-0000-0000-000000000910'::uuid);
+
+-- Test 1: Default updates only the 1 unlocked child, reports 2 locked (parent + child)
+SELECT results_eq(
+  $$SELECT updated_count, locked_count FROM update_shift_series(
+    '00000000-0000-0000-0000-000000000910'::uuid,
+    '00000000-0000-0000-0000-000000000901'::uuid,
+    'all',
+    '{"position": "Host"}'::jsonb
+  )$$,
+  $$VALUES (1, 2)$$,
+  'Default scope=all: updates 1 unlocked, reports 2 locked'
+);
+
+-- Test 2: Verify the 2 locked shifts kept their original position
+SELECT is(
+  (SELECT COUNT(*)::int FROM shifts
+   WHERE (id = '00000000-0000-0000-0000-000000000910'::uuid
+     OR recurrence_parent_id = '00000000-0000-0000-0000-000000000910'::uuid)
+     AND restaurant_id = '00000000-0000-0000-0000-000000000901'::uuid
+     AND locked = true
+     AND position = 'Server'),
+  2,
+  'Locked shifts should keep their original position after default update'
+);
+
+-- ============================================================
+-- Test Group 2: p_include_locked = true with scope='all'
+-- ============================================================
+
+INSERT INTO shifts (id, restaurant_id, employee_id, start_time, end_time, position, locked, recurrence_parent_id)
+VALUES
+  ('00000000-0000-0000-0000-000000000920'::uuid, :rest_id::uuid, :emp_id::uuid,
+   '2026-04-21 09:00:00+00', '2026-04-21 17:00:00+00', 'Server', true, NULL),
+  ('00000000-0000-0000-0000-000000000921'::uuid, :rest_id::uuid, :emp_id::uuid,
+   '2026-04-22 09:00:00+00', '2026-04-22 17:00:00+00', 'Server', false,
+   '00000000-0000-0000-0000-000000000920'::uuid),
+  ('00000000-0000-0000-0000-000000000922'::uuid, :rest_id::uuid, :emp_id::uuid,
+   '2026-04-23 09:00:00+00', '2026-04-23 17:00:00+00', 'Server', true,
+   '00000000-0000-0000-0000-000000000920'::uuid);
+
+-- Test 3: p_include_locked=true updates all 3 shifts, reports 0 locked
+SELECT results_eq(
+  $$SELECT updated_count, locked_count FROM update_shift_series(
+    '00000000-0000-0000-0000-000000000920'::uuid,
+    '00000000-0000-0000-0000-000000000901'::uuid,
+    'all',
+    '{"position": "Host"}'::jsonb,
+    NULL,
+    NULL,
+    NULL,
+    true
+  )$$,
+  $$VALUES (3, 0)$$,
+  'p_include_locked=true scope=all: updates all 3, locked_count=0'
+);
+
+-- Test 4: Verify all 3 shifts now carry the new position
+SELECT is(
+  (SELECT COUNT(*)::int FROM shifts
+   WHERE (id = '00000000-0000-0000-0000-000000000920'::uuid
+     OR recurrence_parent_id = '00000000-0000-0000-0000-000000000920'::uuid)
+     AND restaurant_id = '00000000-0000-0000-0000-000000000901'::uuid
+     AND position = 'Host'),
+  3,
+  'All 3 shifts should have the new position after force update'
+);
+
+-- ============================================================
+-- Test Group 3: p_include_locked = true with scope='following'
+-- ============================================================
+
+INSERT INTO shifts (id, restaurant_id, employee_id, start_time, end_time, position, locked, recurrence_parent_id)
+VALUES
+  ('00000000-0000-0000-0000-000000000930'::uuid, :rest_id::uuid, :emp_id::uuid,
+   '2026-04-28 09:00:00+00', '2026-04-28 17:00:00+00', 'Server', true, NULL),
+  ('00000000-0000-0000-0000-000000000931'::uuid, :rest_id::uuid, :emp_id::uuid,
+   '2026-04-29 09:00:00+00', '2026-04-29 17:00:00+00', 'Server', true,
+   '00000000-0000-0000-0000-000000000930'::uuid),
+  ('00000000-0000-0000-0000-000000000932'::uuid, :rest_id::uuid, :emp_id::uuid,
+   '2026-04-30 09:00:00+00', '2026-04-30 17:00:00+00', 'Server', true,
+   '00000000-0000-0000-0000-000000000930'::uuid);
+
+-- Test 5: p_include_locked=true, scope='following' from Apr 29 updates 2 shifts with locked_count=0
+SELECT results_eq(
+  $$SELECT updated_count, locked_count FROM update_shift_series(
+    '00000000-0000-0000-0000-000000000930'::uuid,
+    '00000000-0000-0000-0000-000000000901'::uuid,
+    'following',
+    '{"position": "Host"}'::jsonb,
+    '2026-04-29 00:00:00+00'::timestamptz,
+    NULL,
+    NULL,
+    true
+  )$$,
+  $$VALUES (2, 0)$$,
+  'p_include_locked=true scope=following: updates 2, locked_count=0'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/allow_update_locked_shift_series.test.sql
+++ b/supabase/tests/allow_update_locked_shift_series.test.sql
@@ -3,7 +3,7 @@
 
 BEGIN;
 
-SELECT plan(5);
+SELECT plan(7);
 
 -- Setup: Create test restaurant, user, and employee
 INSERT INTO restaurants (id, name, address, phone)
@@ -22,6 +22,15 @@ ON CONFLICT (id) DO NOTHING;
 
 \set rest_id '''00000000-0000-0000-0000-000000000901'''
 \set emp_id '''00000000-0000-0000-0000-000000000903'''
+
+-- The function is SECURITY DEFINER and checks user_has_capability itself,
+-- so every call below needs an authenticated owner of the restaurant.
+INSERT INTO public.user_restaurants (user_id, restaurant_id, role)
+VALUES ('00000000-0000-0000-0000-000000000902'::uuid,
+        '00000000-0000-0000-0000-000000000901'::uuid, 'owner')
+ON CONFLICT DO NOTHING;
+
+SELECT set_config('request.jwt.claims', '{"sub":"00000000-0000-0000-0000-000000000902","role":"authenticated"}', true);
 
 -- ============================================================
 -- Test Group 1: Default behavior (p_include_locked = false)
@@ -134,6 +143,31 @@ SELECT results_eq(
   )$$,
   $$VALUES (2, 0)$$,
   'p_include_locked=true scope=following: updates 2, locked_count=0'
+);
+
+-- ============================================================
+-- Test Group 3: tenancy gate
+-- ============================================================
+
+-- Test 6: the function pins search_path (SECURITY DEFINER hardening)
+SELECT ok(
+  pg_get_functiondef('update_shift_series(UUID, UUID, TEXT, JSONB, TIMESTAMPTZ, INTERVAL, INTERVAL, BOOLEAN)'::regprocedure)
+    LIKE '%search_path%',
+  'update_shift_series pins search_path'
+);
+
+-- Test 7: a caller with no membership in the restaurant is refused
+SELECT set_config('request.jwt.claims', '{"sub":"00000000-0000-0000-0000-000000000999","role":"authenticated"}', true);
+
+SELECT throws_ok(
+  $$SELECT * FROM update_shift_series(
+    '00000000-0000-0000-0000-000000000910'::uuid,
+    '00000000-0000-0000-0000-000000000901'::uuid,
+    'all',
+    '{"position": "Host"}'::jsonb
+  )$$,
+  'Access denied: you cannot edit shifts for this restaurant',
+  'update_shift_series refuses a caller outside the restaurant'
 );
 
 SELECT * FROM finish();

--- a/supabase/tests/schedule_change_logs_notified_at.test.sql
+++ b/supabase/tests/schedule_change_logs_notified_at.test.sql
@@ -1,0 +1,11 @@
+BEGIN;
+SELECT plan(2);
+
+SELECT has_column('schedule_change_logs', 'notified_at',
+  'schedule_change_logs should have notified_at column');
+
+SELECT col_is_null('schedule_change_logs', 'notified_at',
+  'notified_at should be nullable');
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/shift_series_operations.sql
+++ b/supabase/tests/shift_series_operations.sql
@@ -14,6 +14,18 @@ INSERT INTO employees (id, restaurant_id, name, email, position, status, is_acti
 VALUES ('22222222-2222-2222-2222-222222222222', '11111111-1111-1111-1111-111111111111', 'Test Employee', 'test@example.com', 'Server', 'active', true)
 ON CONFLICT (id) DO NOTHING;
 
+-- update_shift_series checks user_has_capability itself (SECURITY DEFINER,
+-- migration 20260815110000), so the calls below need an authenticated owner.
+INSERT INTO auth.users (id, email)
+VALUES ('33333333-3333-3333-3333-333333333333', 'series-ops-owner@test.com')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.user_restaurants (user_id, restaurant_id, role)
+VALUES ('33333333-3333-3333-3333-333333333333', '11111111-1111-1111-1111-111111111111', 'owner')
+ON CONFLICT DO NOTHING;
+
+SELECT set_config('request.jwt.claims', '{"sub":"33333333-3333-3333-3333-333333333333","role":"authenticated"}', true);
+
 -- Create a parent shift and its children for testing
 INSERT INTO shifts (id, restaurant_id, employee_id, start_time, end_time, position, status, is_recurring, recurrence_parent_id, locked)
 VALUES

--- a/tests/e2e/employee-schedule-retraction.spec.ts
+++ b/tests/e2e/employee-schedule-retraction.spec.ts
@@ -119,7 +119,9 @@ test.describe('Employee schedule publish states', () => {
     await page.goto('/employee/schedule');
     await page.waitForLoadState('networkidle');
 
-    await expect(page.getByText(/upcoming/i).first()).toBeVisible({ timeout: 15000 });
+    // The seeded 10:00 AM shift row, not a status badge: the badge text
+    // depends on the day the suite runs (past shifts wear "Completed").
+    await expect(page.getByText(/10:00 AM/).first()).toBeVisible({ timeout: 15000 });
     await expect(page.getByText(/schedule not published yet/i)).not.toBeVisible();
     await expect(page.getByText(/draft — not confirmed/i)).not.toBeVisible();
 
@@ -140,7 +142,9 @@ test.describe('Employee schedule publish states', () => {
     await page.goto('/employee/schedule');
     await page.waitForLoadState('networkidle');
 
-    await expect(page.getByText(/upcoming/i).first()).toBeVisible({ timeout: 15000 });
+    // The seeded 10:00 AM shift row, not a status badge: the badge text
+    // depends on the day the suite runs (past shifts wear "Completed").
+    await expect(page.getByText(/10:00 AM/).first()).toBeVisible({ timeout: 15000 });
     await expect(page.getByText(/pulled back for changes/i)).not.toBeVisible();
     await expect(page.getByText(/^Published /)).not.toBeVisible();
   });

--- a/tests/e2e/schedule-quiet-publish-live-edit.spec.ts
+++ b/tests/e2e/schedule-quiet-publish-live-edit.spec.ts
@@ -180,7 +180,7 @@ test.describe('Quiet publish and live edit of a published shift', () => {
     await expect(page.getByRole('button', { name: /^unpublish$/i })).toBeVisible({ timeout: 10000 });
 
     // The shift actually changed: reopening the editor shows the new end time.
-    await shiftCard.click();
+    await editShiftButton.click();
     const reopenedDialog = page.getByRole('dialog', { name: /edit shift/i });
     await expect(reopenedDialog).toBeVisible({ timeout: 5000 });
     await expect(reopenedDialog.getByLabel('Shift end time')).toHaveValue(newEndTime);

--- a/tests/e2e/schedule-quiet-publish-live-edit.spec.ts
+++ b/tests/e2e/schedule-quiet-publish-live-edit.spec.ts
@@ -134,15 +134,16 @@ test.describe('Quiet publish and live edit of a published shift', () => {
     await page.waitForLoadState('networkidle');
     await expect(page.getByRole('button', { name: /^unpublish$/i })).toBeVisible({ timeout: 15000 });
 
-    // Open the shift for edit. The shift is locked (published), but opening the
-    // editor is never blocked — only saving a change is guarded.
+    // Open the shift for edit. The shift is locked (published), but opening
+    // the editor is never blocked — only saving a change is guarded. The
+    // dialog no longer shows a "Shift is Locked" banner (fd7d765b): a
+    // published shift is now editable, so that copy would be false.
     const shiftCard = page.getByTestId('shift-card').first();
     await expect(shiftCard).toBeVisible({ timeout: 15000 });
     await shiftCard.click();
 
     const editDialog = page.getByRole('dialog', { name: /edit shift/i });
     await expect(editDialog).toBeVisible({ timeout: 5000 });
-    await expect(editDialog.getByText(/shift is locked/i)).toBeVisible();
 
     const endTimeInput = editDialog.getByLabel('Shift end time');
     const currentEndTime = await endTimeInput.inputValue();

--- a/tests/e2e/schedule-quiet-publish-live-edit.spec.ts
+++ b/tests/e2e/schedule-quiet-publish-live-edit.spec.ts
@@ -1,0 +1,179 @@
+import { test, expect, Page } from '@playwright/test';
+import { signUpAndCreateRestaurant, exposeSupabaseHelpers, generateTestUser } from '../helpers/e2e-supabase';
+
+/**
+ * Task 15 (design: docs/superpowers/specs/2026-08-15-quiet-publish-live-edit-design.md).
+ * Covers the two flows the plan calls out:
+ *   - a manager publishes with "Notify employees" unchecked and the week still publishes;
+ *   - a manager edits a shift that is already published, sees one warning dialog, saves
+ *     the change, and the week stays published (no forced unpublish).
+ *
+ * Timezone is pinned for the same reason as the sibling scheduling specs: CI runs UTC,
+ * and week-bucketing bugs are invisible there.
+ */
+test.use({ timezoneId: 'America/New_York' });
+
+/** Seed one active employee and a Wednesday shift, safely inside the current Mon..Sun week. */
+async function seedEmployeeAndShift(
+  page: Page,
+  restaurantId: string,
+  employeeName: string,
+): Promise<{ employeeName: string }> {
+  return page.evaluate(
+    async ({ restId, name }) => {
+      // `window` has no type declarations for the test-only Supabase client exposeSupabaseHelpers attaches.
+      const supabase = (window as any).__supabase;
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user?.id) throw new Error('No authenticated user found');
+
+      const { data: employee, error: empError } = await supabase
+        .from('employees')
+        .insert({
+          restaurant_id: restId,
+          user_id: user.id,
+          name,
+          position: 'Server',
+          status: 'active',
+          is_active: true,
+          compensation_type: 'hourly',
+          hourly_rate: 1500,
+        })
+        .select('id, name')
+        .single();
+      if (empError) throw new Error(`employees insert failed: ${empError.message}`);
+
+      // Wednesday of the current local week — safely inside Mon..Sun no matter
+      // which day the suite runs on.
+      const now = new Date();
+      const monday = new Date(now);
+      monday.setDate(now.getDate() - ((now.getDay() + 6) % 7));
+      const wednesday = new Date(monday);
+      wednesday.setDate(monday.getDate() + 2);
+      wednesday.setHours(10, 0, 0, 0);
+      const end = new Date(wednesday);
+      end.setHours(16, 0, 0, 0);
+
+      const { error: shiftError } = await supabase.from('shifts').insert({
+        restaurant_id: restId,
+        employee_id: employee.id,
+        start_time: wednesday.toISOString(),
+        end_time: end.toISOString(),
+        position: 'Server',
+      });
+      if (shiftError) throw new Error(`shifts insert failed: ${shiftError.message}`);
+
+      return { employeeName: employee.name as string };
+    },
+    { restId: restaurantId, name: employeeName },
+  );
+}
+
+/** Opens the Publish dialog, sets the notify checkbox, confirms, and waits for the RPC. */
+async function publishWeek(page: Page, options: { notify: boolean }): Promise<void> {
+  await page.goto('/scheduling');
+  await page.waitForLoadState('networkidle');
+
+  const publishBtn = page.getByRole('button', { name: 'Publish', exact: true });
+  await expect(publishBtn).toBeEnabled({ timeout: 10000 });
+  await publishBtn.click();
+
+  const dialog = page.getByRole('dialog', { name: /publish schedule/i });
+  await expect(dialog).toBeVisible({ timeout: 5000 });
+
+  // Checked by default on every open — see PublishScheduleDialog's own tests.
+  const notifyCheckbox = dialog.getByRole('checkbox', { name: /notify employees about this schedule/i });
+  await expect(notifyCheckbox).toBeChecked();
+  if (!options.notify) {
+    await notifyCheckbox.click();
+    await expect(notifyCheckbox).not.toBeChecked();
+  }
+
+  const responsePromise = page.waitForResponse(
+    (resp) => resp.url().includes('publish_schedule') && resp.status() === 200,
+    { timeout: 20000 },
+  );
+  await dialog.getByRole('button', { name: /publish schedule/i }).click();
+  await responsePromise;
+}
+
+test.describe('Quiet publish and live edit of a published shift', () => {
+  test('publishing with "Notify employees" unchecked still publishes the week', async ({ page }) => {
+    const testUser = generateTestUser('quietpub');
+    await signUpAndCreateRestaurant(page, testUser);
+    await exposeSupabaseHelpers(page);
+
+    // `window` has no type declarations for the test-only helpers exposeSupabaseHelpers attaches.
+    const restaurantId = await page.evaluate(() => (window as any).__getRestaurantId());
+    expect(restaurantId).toBeTruthy();
+
+    await seedEmployeeAndShift(page, restaurantId, 'Quinn Quietly');
+
+    await publishWeek(page, { notify: false });
+
+    // Publish succeeded despite the unchecked box: a fresh load shows the week
+    // as published, so the action button flips from Publish to Unpublish.
+    await page.goto('/scheduling');
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByRole('button', { name: /^unpublish$/i })).toBeVisible({ timeout: 15000 });
+  });
+
+  test('editing a published shift shows one warning dialog, saves, and keeps the week published', async ({ page }) => {
+    const testUser = generateTestUser('liveedit');
+    await signUpAndCreateRestaurant(page, testUser);
+    await exposeSupabaseHelpers(page);
+
+    // `window` has no type declarations for the test-only helpers exposeSupabaseHelpers attaches.
+    const restaurantId = await page.evaluate(() => (window as any).__getRestaurantId());
+    expect(restaurantId).toBeTruthy();
+
+    const { employeeName } = await seedEmployeeAndShift(page, restaurantId, 'Casey Editor');
+
+    await publishWeek(page, { notify: true });
+
+    await page.goto('/scheduling');
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByRole('button', { name: /^unpublish$/i })).toBeVisible({ timeout: 15000 });
+
+    // Open the shift for edit. The shift is locked (published), but opening the
+    // editor is never blocked — only saving a change is guarded.
+    const shiftCard = page.getByTestId('shift-card').first();
+    await expect(shiftCard).toBeVisible({ timeout: 15000 });
+    await shiftCard.click();
+
+    const editDialog = page.getByRole('dialog', { name: /edit shift/i });
+    await expect(editDialog).toBeVisible({ timeout: 5000 });
+    await expect(editDialog.getByText(/shift is locked/i)).toBeVisible();
+
+    const endTimeInput = editDialog.getByLabel('Shift end time');
+    const currentEndTime = await endTimeInput.inputValue();
+    const [hh, mm] = currentEndTime.split(':').map(Number);
+    const newEndTime = `${((hh + 2) % 24).toString().padStart(2, '0')}:${mm.toString().padStart(2, '0')}`;
+    await endTimeInput.fill(newEndTime);
+
+    await editDialog.getByRole('button', { name: /^update shift$/i }).click();
+
+    // Saving a change to a published shift raises exactly one warning dialog.
+    const warningDialog = page.getByRole('alertdialog', { name: /this shift is published/i });
+    await expect(warningDialog).toBeVisible({ timeout: 5000 });
+    await expect(warningDialog.getByText(new RegExp(`^${employeeName} can see this shift`, 'i'))).toBeVisible();
+
+    const patchPromise = page.waitForResponse(
+      (resp) => resp.url().includes('/rest/v1/shifts') && resp.request().method() === 'PATCH' && resp.ok(),
+      { timeout: 15000 },
+    );
+    await warningDialog.getByRole('button', { name: /^save change$/i }).click();
+    await patchPromise;
+
+    await expect(warningDialog).not.toBeVisible({ timeout: 5000 });
+    await expect(editDialog).not.toBeVisible({ timeout: 5000 });
+
+    // This was a live edit, not an unpublish: the week stays published.
+    await expect(page.getByRole('button', { name: /^unpublish$/i })).toBeVisible({ timeout: 10000 });
+
+    // The shift actually changed: reopening the editor shows the new end time.
+    await shiftCard.click();
+    const reopenedDialog = page.getByRole('dialog', { name: /edit shift/i });
+    await expect(reopenedDialog).toBeVisible({ timeout: 5000 });
+    await expect(reopenedDialog.getByLabel('Shift end time')).toHaveValue(newEndTime);
+  });
+});

--- a/tests/e2e/schedule-quiet-publish-live-edit.spec.ts
+++ b/tests/e2e/schedule-quiet-publish-live-edit.spec.ts
@@ -138,10 +138,12 @@ test.describe('Quiet publish and live edit of a published shift', () => {
     // the editor is never blocked — only saving a change is guarded. The
     // dialog no longer shows a "Shift is Locked" banner (fd7d765b): a
     // published shift is now editable, so that copy would be false.
-    // TimelineBar renders each shift as a `<button>` with an accessible name
-    // built from the employee, position, and time (src/lib/timelineModel.ts) —
-    // no `data-testid` exists on it, so match by that name instead.
-    const shiftCard = page.getByRole('button', { name: new RegExp(employeeName) }).first();
+    // The week grid (src/pages/SchedulingShiftCard.tsx) marks the shift
+    // surface with data-testid="shift-card". Its accessible name carries
+    // only the time and position, not the employee name — a name-based
+    // query instead matches the row's "Edit {employee}" button and opens
+    // the wrong dialog.
+    const shiftCard = page.getByTestId('shift-card').first();
     await expect(shiftCard).toBeVisible({ timeout: 15000 });
     await shiftCard.click();
 

--- a/tests/e2e/schedule-quiet-publish-live-edit.spec.ts
+++ b/tests/e2e/schedule-quiet-publish-live-edit.spec.ts
@@ -22,6 +22,7 @@ async function seedEmployeeAndShift(
   return page.evaluate(
     async ({ restId, name }) => {
       // `window` has no type declarations for the test-only Supabase client exposeSupabaseHelpers attaches.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const supabase = (window as any).__supabase;
       const { data: { user } } = await supabase.auth.getUser();
       if (!user?.id) throw new Error('No authenticated user found');
@@ -103,7 +104,9 @@ test.describe('Quiet publish and live edit of a published shift', () => {
     await exposeSupabaseHelpers(page);
 
     // `window` has no type declarations for the test-only helpers exposeSupabaseHelpers attaches.
-    const restaurantId = await page.evaluate(() => (window as any).__getRestaurantId());
+    const restaurantId = await page.evaluate(() =>
+      (window as unknown as { __getRestaurantId: () => Promise<string> }).__getRestaurantId()
+    );
     expect(restaurantId).toBeTruthy();
 
     await seedEmployeeAndShift(page, restaurantId, 'Quinn Quietly');
@@ -123,7 +126,9 @@ test.describe('Quiet publish and live edit of a published shift', () => {
     await exposeSupabaseHelpers(page);
 
     // `window` has no type declarations for the test-only helpers exposeSupabaseHelpers attaches.
-    const restaurantId = await page.evaluate(() => (window as any).__getRestaurantId());
+    const restaurantId = await page.evaluate(() =>
+      (window as unknown as { __getRestaurantId: () => Promise<string> }).__getRestaurantId()
+    );
     expect(restaurantId).toBeTruthy();
 
     const { employeeName } = await seedEmployeeAndShift(page, restaurantId, 'Casey Editor');

--- a/tests/e2e/schedule-quiet-publish-live-edit.spec.ts
+++ b/tests/e2e/schedule-quiet-publish-live-edit.spec.ts
@@ -143,14 +143,12 @@ test.describe('Quiet publish and live edit of a published shift', () => {
     // the editor is never blocked — only saving a change is guarded. The
     // dialog no longer shows a "Shift is Locked" banner (fd7d765b): a
     // published shift is now editable, so that copy would be false.
-    // The week grid (src/pages/SchedulingShiftCard.tsx) marks the shift
-    // surface with data-testid="shift-card". Its accessible name carries
-    // only the time and position, not the employee name — a name-based
-    // query instead matches the row's "Edit {employee}" button and opens
-    // the wrong dialog.
-    const shiftCard = page.getByTestId('shift-card').first();
-    await expect(shiftCard).toBeVisible({ timeout: 15000 });
-    await shiftCard.click();
+    // Use the card's "Edit shift" button (aria-label in
+    // SchedulingShiftCard.tsx) — exact, so it cannot match the employee
+    // row's "Edit {employee}" button, which a name-based query once hit.
+    const editShiftButton = page.getByRole('button', { name: 'Edit shift', exact: true }).first();
+    await expect(editShiftButton).toBeVisible({ timeout: 15000 });
+    await editShiftButton.click();
 
     const editDialog = page.getByRole('dialog', { name: /edit shift/i });
     await expect(editDialog).toBeVisible({ timeout: 5000 });

--- a/tests/e2e/schedule-quiet-publish-live-edit.spec.ts
+++ b/tests/e2e/schedule-quiet-publish-live-edit.spec.ts
@@ -138,7 +138,10 @@ test.describe('Quiet publish and live edit of a published shift', () => {
     // the editor is never blocked — only saving a change is guarded. The
     // dialog no longer shows a "Shift is Locked" banner (fd7d765b): a
     // published shift is now editable, so that copy would be false.
-    const shiftCard = page.getByTestId('shift-card').first();
+    // TimelineBar renders each shift as a `<button>` with an accessible name
+    // built from the employee, position, and time (src/lib/timelineModel.ts) —
+    // no `data-testid` exists on it, so match by that name instead.
+    const shiftCard = page.getByRole('button', { name: new RegExp(employeeName) }).first();
     await expect(shiftCard).toBeVisible({ timeout: 15000 });
     await shiftCard.click();
 

--- a/tests/unit/PublishScheduleDialog.test.tsx
+++ b/tests/unit/PublishScheduleDialog.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { PublishScheduleDialog } from '@/components/PublishScheduleDialog';
+
+const onOpenChange = vi.fn();
+const onConfirm = vi.fn();
+
+const defaultProps = {
+  weekStart: new Date('2026-08-17T00:00:00'),
+  weekEnd: new Date('2026-08-23T00:00:00'),
+  shiftCount: 10,
+  employeeCount: 5,
+  totalHours: 40,
+  openShiftCount: 0,
+  openShiftsEnabled: false,
+  isPublishing: false,
+};
+
+const renderDialog = (overrides: Partial<React.ComponentProps<typeof PublishScheduleDialog>> = {}) =>
+  render(
+    <PublishScheduleDialog
+      open
+      onOpenChange={onOpenChange}
+      onConfirm={onConfirm}
+      {...defaultProps}
+      {...overrides}
+    />
+  );
+
+describe('PublishScheduleDialog notify checkbox', () => {
+  beforeEach(() => {
+    onOpenChange.mockClear();
+    onConfirm.mockClear();
+  });
+
+  it('checks the notify checkbox by default', () => {
+    renderDialog();
+    const checkbox = screen.getByRole('checkbox', { name: /Notify employees/i });
+    expect(checkbox).toHaveAttribute('data-state', 'checked');
+  });
+
+  it('resets notify to true and notes to empty on reopen', () => {
+    const { rerender } = renderDialog();
+    const checkbox = screen.getByRole('checkbox', { name: /Notify employees/i });
+    fireEvent.click(checkbox);
+    fireEvent.change(screen.getByLabelText(/Notes/i), { target: { value: 'Holiday coverage' } });
+    expect(checkbox).toHaveAttribute('data-state', 'unchecked');
+    expect(screen.getByLabelText(/Notes/i)).toHaveValue('Holiday coverage');
+
+    rerender(
+      <PublishScheduleDialog
+        open={false}
+        onOpenChange={onOpenChange}
+        onConfirm={onConfirm}
+        {...defaultProps}
+      />
+    );
+    rerender(
+      <PublishScheduleDialog
+        open
+        onOpenChange={onOpenChange}
+        onConfirm={onConfirm}
+        {...defaultProps}
+      />
+    );
+
+    expect(screen.getByRole('checkbox', { name: /Notify employees/i })).toHaveAttribute(
+      'data-state',
+      'checked'
+    );
+    expect(screen.getByLabelText(/Notes/i)).toHaveValue('');
+  });
+
+  it('calls onConfirm with notes and notify true when the checkbox stays checked', () => {
+    renderDialog();
+    fireEvent.click(screen.getByRole('button', { name: /Publish Schedule/i }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm).toHaveBeenCalledWith(undefined, true);
+  });
+
+  it('calls onConfirm with notify false after the checkbox is unchecked', () => {
+    renderDialog();
+    fireEvent.click(screen.getByRole('checkbox', { name: /Notify employees/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Publish Schedule/i }));
+    expect(onConfirm).toHaveBeenCalledWith(undefined, false);
+  });
+
+  it('passes trimmed notes alongside the notify flag', () => {
+    renderDialog();
+    fireEvent.change(screen.getByLabelText(/Notes/i), { target: { value: '  Big event  ' } });
+    fireEvent.click(screen.getByRole('button', { name: /Publish Schedule/i }));
+    expect(onConfirm).toHaveBeenCalledWith('Big event', true);
+  });
+});

--- a/tests/unit/PublishScheduleDialog.test.tsx
+++ b/tests/unit/PublishScheduleDialog.test.tsx
@@ -92,4 +92,38 @@ describe('PublishScheduleDialog notify checkbox', () => {
     fireEvent.click(screen.getByRole('button', { name: /Publish Schedule/i }));
     expect(onConfirm).toHaveBeenCalledWith('Big event', true);
   });
+
+  it('shows "Notifying N..." while publishing when the checkbox stays checked', () => {
+    const { rerender } = renderDialog();
+
+    rerender(
+      <PublishScheduleDialog
+        open
+        onOpenChange={onOpenChange}
+        onConfirm={onConfirm}
+        {...defaultProps}
+        isPublishing
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /Notifying 5\.\.\./i })).toBeInTheDocument();
+  });
+
+  it('shows plain "Publishing..." while publishing after the checkbox is unchecked', () => {
+    const { rerender } = renderDialog();
+    fireEvent.click(screen.getByRole('checkbox', { name: /Notify employees/i }));
+
+    rerender(
+      <PublishScheduleDialog
+        open
+        onOpenChange={onOpenChange}
+        onConfirm={onConfirm}
+        {...defaultProps}
+        isPublishing
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /^Publishing\.\.\.$/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Notifying/i })).not.toBeInTheDocument();
+  });
 });

--- a/tests/unit/PublishedShiftChangeDialog.test.tsx
+++ b/tests/unit/PublishedShiftChangeDialog.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { PublishedShiftChangeDialog } from '@/components/scheduling/PublishedShiftChangeDialog';
+
+const onOpenChange = vi.fn();
+const onConfirm = vi.fn();
+
+const renderDialog = (overrides: Partial<React.ComponentProps<typeof PublishedShiftChangeDialog>> = {}) =>
+  render(
+    <PublishedShiftChangeDialog
+      open
+      onOpenChange={onOpenChange}
+      employeeName="Alex Rivera"
+      isPending={false}
+      onConfirm={onConfirm}
+      {...overrides}
+    />
+  );
+
+describe('PublishedShiftChangeDialog', () => {
+  beforeEach(() => {
+    onOpenChange.mockClear();
+    onConfirm.mockClear();
+  });
+
+  it('renders the title, description, and both buttons', () => {
+    renderDialog();
+    expect(screen.getByText('This shift is published')).toBeInTheDocument();
+    expect(
+      screen.getByText('Alex Rivera can see this shift. Save the change anyway?')
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save change' })).toBeInTheDocument();
+  });
+
+  it('names both employees on a reassignment', () => {
+    renderDialog({ secondEmployeeName: 'Jamie Chen' });
+    expect(
+      screen.getByText('Alex Rivera and Jamie Chen can see this shift. Save the change anyway?')
+    ).toBeInTheDocument();
+  });
+
+  it('checks the notify checkbox by default', () => {
+    renderDialog();
+    const checkbox = screen.getByRole('checkbox', { name: /Notify Alex Rivera about this change/i });
+    expect(checkbox).toHaveAttribute('data-state', 'checked');
+  });
+
+  it('calls onConfirm with notify: true when the checkbox stays checked', () => {
+    renderDialog();
+    fireEvent.click(screen.getByRole('button', { name: 'Save change' }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm).toHaveBeenCalledWith({ notify: true });
+  });
+
+  it('calls onConfirm with notify: false after the checkbox is unchecked', () => {
+    renderDialog();
+    fireEvent.click(screen.getByRole('checkbox', { name: /Notify Alex Rivera about this change/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save change' }));
+    expect(onConfirm).toHaveBeenCalledWith({ notify: false });
+  });
+
+  it('disables both buttons while pending', () => {
+    renderDialog({ isPending: true });
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Save change' })).toBeDisabled();
+  });
+});

--- a/tests/unit/ShiftDialogGuard.test.tsx
+++ b/tests/unit/ShiftDialogGuard.test.tsx
@@ -118,6 +118,11 @@ describe('ShiftDialog save through the guard', () => {
     expect(mockUpdateMutateAsync).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'shift-1', allowPublished: true })
     );
+    // The edit payload must never carry the publish flags: is_published:
+    // false in an update silently retracts a published shift.
+    const updatePayload = mockUpdateMutateAsync.mock.calls[0][0];
+    expect(updatePayload).not.toHaveProperty('is_published');
+    expect(updatePayload).not.toHaveProperty('locked');
     expect(mockUpdateMutate).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/ShiftDialogGuard.test.tsx
+++ b/tests/unit/ShiftDialogGuard.test.tsx
@@ -12,12 +12,25 @@ import { Shift } from '@/types/scheduling';
 
 const mockCreateMutate = vi.fn();
 const mockUpdateMutate = vi.fn();
+const mockUpdateMutateAsync = vi.fn().mockResolvedValue(undefined);
 const mockUpdateSeriesMutate = vi.fn();
+const mockUpdateSeriesMutateAsync = vi.fn().mockResolvedValue(undefined);
 
 vi.mock('@/hooks/useShifts', () => ({
   useCreateShift: () => ({ mutate: mockCreateMutate, isPending: false }),
-  useUpdateShift: () => ({ mutate: mockUpdateMutate, isPending: false }),
-  useUpdateShiftSeries: () => ({ mutate: mockUpdateSeriesMutate, isPending: false }),
+  // ShiftDialog awaits `mutateAsync` on the guarded edit path (a fresh
+  // SELECT for the change-log row follows right after `run` resolves), so
+  // both the sync and async forms need a mock here.
+  useUpdateShift: () => ({
+    mutate: mockUpdateMutate,
+    mutateAsync: mockUpdateMutateAsync,
+    isPending: false,
+  }),
+  useUpdateShiftSeries: () => ({
+    mutate: mockUpdateSeriesMutate,
+    mutateAsync: mockUpdateSeriesMutateAsync,
+    isPending: false,
+  }),
 }));
 
 vi.mock('@/hooks/useEmployees', () => ({
@@ -99,9 +112,12 @@ describe('ShiftDialog save through the guard', () => {
     const { run } = guardShiftChange.mock.calls[0][0];
     await run({ allowPublished: true });
 
-    expect(mockUpdateMutate).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'shift-1', allowPublished: true }),
-      expect.anything()
+    // `run` awaits `mutateAsync`, not the fire-and-forget `mutate` — the
+    // guard's post-save change-log lookup depends on the UPDATE having
+    // actually committed by the time `run` resolves.
+    expect(mockUpdateMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'shift-1', allowPublished: true })
     );
+    expect(mockUpdateMutate).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/ShiftDialogGuard.test.tsx
+++ b/tests/unit/ShiftDialogGuard.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * Unit tests: ShiftDialog save path goes through usePublishedShiftGuard's
+ * `guardShiftChange` instead of calling the mutation directly.
+ * Design: docs/superpowers/specs/2026-08-15-quiet-publish-live-edit-design.md
+ */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { ShiftDialog } from '@/components/ShiftDialog';
+import { Shift } from '@/types/scheduling';
+
+const mockCreateMutate = vi.fn();
+const mockUpdateMutate = vi.fn();
+const mockUpdateSeriesMutate = vi.fn();
+
+vi.mock('@/hooks/useShifts', () => ({
+  useCreateShift: () => ({ mutate: mockCreateMutate, isPending: false }),
+  useUpdateShift: () => ({ mutate: mockUpdateMutate, isPending: false }),
+  useUpdateShiftSeries: () => ({ mutate: mockUpdateSeriesMutate, isPending: false }),
+}));
+
+vi.mock('@/hooks/useEmployees', () => ({
+  useEmployees: () => ({
+    employees: [
+      { id: 'emp-1', name: 'Alex Rivera', position: 'Server', is_active: true },
+      { id: 'emp-2', name: 'Jamie Lee', position: 'Cook', is_active: true },
+    ],
+  }),
+}));
+
+vi.mock('@/hooks/useConflictDetection', () => ({
+  useCheckConflicts: () => ({ conflicts: [], hasConflicts: false }),
+}));
+
+const lockedShift: Shift = {
+  id: 'shift-1',
+  restaurant_id: 'rest-1',
+  employee_id: 'emp-1',
+  start_time: '2026-08-17T17:00:00.000Z',
+  end_time: '2026-08-17T22:00:00.000Z',
+  break_duration: 30,
+  position: 'Server',
+  status: 'scheduled',
+  is_published: true,
+  locked: true,
+  source: 'manual',
+  created_at: '2026-08-15T00:00:00.000Z',
+  updated_at: '2026-08-15T00:00:00.000Z',
+};
+
+describe('ShiftDialog save through the guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('routes an edit to a published shift through guardShiftChange, not the mutation directly', () => {
+    const guardShiftChange = vi.fn();
+
+    render(
+      <ShiftDialog
+        open
+        onOpenChange={() => {}}
+        shift={lockedShift}
+        restaurantId="rest-1"
+        timezone="UTC"
+        guardShiftChange={guardShiftChange}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Update Shift' }));
+
+    expect(guardShiftChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        shiftId: 'shift-1',
+        employeeName: 'Alex Rivera',
+        run: expect.any(Function),
+      })
+    );
+    expect(mockUpdateMutate).not.toHaveBeenCalled();
+  });
+
+  it('runs the update with allowPublished passed through once the guard confirms', async () => {
+    const guardShiftChange = vi.fn();
+
+    render(
+      <ShiftDialog
+        open
+        onOpenChange={() => {}}
+        shift={lockedShift}
+        restaurantId="rest-1"
+        timezone="UTC"
+        guardShiftChange={guardShiftChange}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Update Shift' }));
+
+    const { run } = guardShiftChange.mock.calls[0][0];
+    await run({ allowPublished: true });
+
+    expect(mockUpdateMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'shift-1', allowPublished: true }),
+      expect.anything()
+    );
+  });
+});

--- a/tests/unit/TimelineShiftPopover.test.tsx
+++ b/tests/unit/TimelineShiftPopover.test.tsx
@@ -77,6 +77,11 @@ function defaultProps(overrides: Partial<React.ComponentProps<typeof TimelineShi
     onDelete: vi.fn(),
     validationResult: null,
     clearValidation: vi.fn(),
+    // Not locked: guardShiftChange runs `run` straight away, mirroring
+    // usePublishedShiftGuard's own real behavior for an unpublished shift.
+    guardShiftChange: vi.fn(async ({ run }: { run: (options: { allowPublished: boolean }) => void | Promise<void> }) => {
+      await run({ allowPublished: false });
+    }),
     ...overrides,
   };
 }
@@ -118,7 +123,7 @@ describe('TimelineShiftPopover', () => {
     expect(screen.getByRole('button', { name: /^delete$/i })).toBeTruthy();
   });
 
-  it('locked shift shows a lock icon and disables Edit/Delete', () => {
+  it('locked shift shows a lock icon and disables Delete, but not Edit', () => {
     render(
       <TimelineShiftPopover
         {...defaultProps({ activeShift: makeShift({ locked: true }) })}
@@ -126,7 +131,7 @@ describe('TimelineShiftPopover', () => {
     );
 
     expect(screen.getByLabelText(/locked/i)).toBeTruthy();
-    expect(screen.getByRole('button', { name: /^edit$/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /^edit$/i })).not.toBeDisabled();
     expect(screen.getByRole('button', { name: /^delete$/i })).toBeDisabled();
   });
 
@@ -203,6 +208,34 @@ describe('TimelineShiftPopover', () => {
 
     expect(onDelete).not.toHaveBeenCalled();
     await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull());
+  });
+
+  it('Save on a locked shift routes through guardShiftChange before calling validateAndUpdateShift', async () => {
+    const user = userEvent.setup();
+    const validateAndUpdateShift = vi.fn().mockResolvedValue({ updated: true });
+    const guardShiftChange = vi.fn(
+      async ({ run }: { run: (options: { allowPublished: boolean }) => void | Promise<void> }) => {
+        await run({ allowPublished: true });
+      },
+    );
+
+    render(
+      <TimelineShiftPopover
+        {...defaultProps({
+          activeShift: makeShift({ locked: true }),
+          validateAndUpdateShift,
+          guardShiftChange,
+        })}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /^edit$/i }));
+    await user.click(screen.getByRole('button', { name: /^save$/i }));
+
+    await waitFor(() => expect(guardShiftChange).toHaveBeenCalledTimes(1));
+    expect(guardShiftChange.mock.calls[0][0].shiftId).toBe('shift-1');
+    await waitFor(() => expect(validateAndUpdateShift).toHaveBeenCalledTimes(1));
+    expect(validateAndUpdateShift.mock.calls[0][0].allowPublished).toBe(true);
   });
 
   it('Save with no pending issues calls validateAndUpdateShift and closes the popover', async () => {

--- a/tests/unit/TimelineShiftPopover.test.tsx
+++ b/tests/unit/TimelineShiftPopover.test.tsx
@@ -82,6 +82,7 @@ function defaultProps(overrides: Partial<React.ComponentProps<typeof TimelineShi
     guardShiftChange: vi.fn(async ({ run }: { run: (options: { allowPublished: boolean }) => void | Promise<void> }) => {
       await run({ allowPublished: false });
     }),
+    notifyAfterDeferredCommit: vi.fn(),
     ...overrides,
   };
 }

--- a/tests/unit/shiftChangedNotification.test.ts
+++ b/tests/unit/shiftChangedNotification.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest';
+import {
+  checkShiftChangeValidity,
+  deriveShiftChangeRecipients,
+  buildShiftChangeMessage,
+  type ShiftChangeLogRow,
+} from '../../supabase/functions/_shared/shiftChangedNotification';
+
+const NOW = new Date('2026-08-15T12:00:00.000Z');
+
+const baseRow: ShiftChangeLogRow = {
+  id: 'log-1',
+  restaurant_id: 'rest-1',
+  shift_id: 'shift-1',
+  change_type: 'updated',
+  changed_at: NOW.toISOString(),
+  before_data: { employee_id: 'emp-1', start_time: '2026-08-11T17:00:00.000Z' },
+  after_data: { employee_id: 'emp-1', start_time: '2026-08-11T18:00:00.000Z' },
+};
+
+describe('checkShiftChangeValidity', () => {
+  it('accepts a fresh updated row with a shift_id', () => {
+    expect(checkShiftChangeValidity(baseRow, NOW)).toEqual({ valid: true });
+  });
+
+  it('accepts a fresh deleted row with a shift_id', () => {
+    expect(checkShiftChangeValidity({ ...baseRow, change_type: 'deleted' }, NOW)).toEqual({
+      valid: true,
+    });
+  });
+
+  it('rejects a row older than 10 minutes', () => {
+    const old = { ...baseRow, changed_at: '2026-08-15T11:49:00.000Z' };
+    expect(checkShiftChangeValidity(old, NOW)).toEqual({ valid: false, reason: 'too-old' });
+  });
+
+  it('rejects an unpublished change_type', () => {
+    expect(checkShiftChangeValidity({ ...baseRow, change_type: 'unpublished' }, NOW)).toEqual({
+      valid: false,
+      reason: 'wrong-change-type',
+    });
+  });
+
+  it('rejects a created change_type', () => {
+    expect(checkShiftChangeValidity({ ...baseRow, change_type: 'created' }, NOW)).toEqual({
+      valid: false,
+      reason: 'wrong-change-type',
+    });
+  });
+
+  it('rejects a row with no shift_id (restaurant-level unpublish)', () => {
+    expect(checkShiftChangeValidity({ ...baseRow, shift_id: null }, NOW)).toEqual({
+      valid: false,
+      reason: 'no-shift-id',
+    });
+  });
+});
+
+describe('deriveShiftChangeRecipients', () => {
+  it('returns the before employee on delete', () => {
+    expect(
+      deriveShiftChangeRecipients({
+        change_type: 'deleted',
+        before_data: { employee_id: 'emp-1' },
+        after_data: null,
+      }),
+    ).toEqual([{ employeeId: 'emp-1', role: 'removed' }]);
+  });
+
+  it('returns nothing on delete with no employee', () => {
+    expect(
+      deriveShiftChangeRecipients({
+        change_type: 'deleted',
+        before_data: { employee_id: null },
+        after_data: null,
+      }),
+    ).toEqual([]);
+  });
+
+  it('returns one updated recipient when the employee is unchanged', () => {
+    expect(deriveShiftChangeRecipients(baseRow)).toEqual([{ employeeId: 'emp-1', role: 'updated' }]);
+  });
+
+  it('returns both employees on a reassignment', () => {
+    const row = {
+      change_type: 'updated',
+      before_data: { employee_id: 'emp-1' },
+      after_data: { employee_id: 'emp-2' },
+    };
+    expect(deriveShiftChangeRecipients(row)).toEqual([
+      { employeeId: 'emp-1', role: 'removed' },
+      { employeeId: 'emp-2', role: 'assigned' },
+    ]);
+  });
+
+  it('returns nothing for an open shift (both sides null)', () => {
+    const row = {
+      change_type: 'updated',
+      before_data: { employee_id: null },
+      after_data: { employee_id: null },
+    };
+    expect(deriveShiftChangeRecipients(row)).toEqual([]);
+  });
+});
+
+describe('buildShiftChangeMessage', () => {
+  it('builds the removed message with the old day and time', () => {
+    const msg = buildShiftChangeMessage(
+      { employeeId: 'emp-1', role: 'removed' },
+      baseRow,
+      'UTC',
+    );
+    expect(msg.title).toBe('Shift Removed');
+    expect(msg.body).toContain('Tue');
+    expect(msg.body).toContain('removed');
+  });
+
+  it('builds the assigned message', () => {
+    const msg = buildShiftChangeMessage(
+      { employeeId: 'emp-2', role: 'assigned' },
+      baseRow,
+      'UTC',
+    );
+    expect(msg).toEqual({ title: 'New Shift Assigned', body: 'You have a new shift.' });
+  });
+
+  it('builds the updated message with old and new times', () => {
+    const msg = buildShiftChangeMessage(
+      { employeeId: 'emp-1', role: 'updated' },
+      baseRow,
+      'UTC',
+    );
+    expect(msg.title).toBe('Shift Updated');
+    expect(msg.body).toContain('changed to');
+  });
+});

--- a/tests/unit/shiftChangedNotification.test.ts
+++ b/tests/unit/shiftChangedNotification.test.ts
@@ -133,4 +133,42 @@ describe('buildShiftChangeMessage', () => {
     expect(msg.title).toBe('Shift Updated');
     expect(msg.body).toContain('changed to');
   });
+
+  it('names the new end time when only the end time changed', () => {
+    const msg = buildShiftChangeMessage(
+      { employeeId: 'emp-1', role: 'updated' },
+      {
+        ...baseRow,
+        before_data: {
+          employee_id: 'emp-1',
+          start_time: '2026-08-11T17:00:00.000Z',
+          end_time: '2026-08-11T21:00:00.000Z',
+        },
+        after_data: {
+          employee_id: 'emp-1',
+          start_time: '2026-08-11T17:00:00.000Z',
+          end_time: '2026-08-11T23:00:00.000Z',
+        },
+      },
+      'UTC',
+    );
+    // "changed to <same start time>" reads as no change at all.
+    expect(msg.body).not.toContain('changed to');
+    expect(msg.body).toContain('now ends at');
+    expect(msg.body).toContain('11:00 PM');
+  });
+
+  it('falls back to a generic update when the times are unchanged', () => {
+    const msg = buildShiftChangeMessage(
+      { employeeId: 'emp-1', role: 'updated' },
+      {
+        ...baseRow,
+        after_data: { employee_id: 'emp-1', start_time: '2026-08-11T17:00:00.000Z' },
+        before_data: { employee_id: 'emp-1', start_time: '2026-08-11T17:00:00.000Z' },
+      },
+      'UTC',
+    );
+    expect(msg.body).not.toContain('changed to');
+    expect(msg.body).toContain('was updated');
+  });
 });

--- a/tests/unit/shiftMutationPipeline.test.ts
+++ b/tests/unit/shiftMutationPipeline.test.ts
@@ -192,4 +192,22 @@ describe('assertNotLockedClient', () => {
       expect((err as Error).message).toMatch(/locked/i);
     }
   });
+
+  it('does not throw for a locked shift when allowPublished is true', () => {
+    expect(() =>
+      assertNotLockedClient(makeShift({ locked: true }), true),
+    ).not.toThrow();
+  });
+
+  it('still throws for a locked shift when allowPublished is false', () => {
+    expect(() =>
+      assertNotLockedClient(makeShift({ locked: true }), false),
+    ).toThrow(LockedShiftError);
+  });
+
+  it('still throws for a locked shift when allowPublished is absent (unchanged default)', () => {
+    expect(() => assertNotLockedClient(makeShift({ locked: true }))).toThrow(
+      LockedShiftError,
+    );
+  });
 });

--- a/tests/unit/shiftPlannerTab.availabilityWiring.test.tsx
+++ b/tests/unit/shiftPlannerTab.availabilityWiring.test.tsx
@@ -169,6 +169,7 @@ const DEFAULT_PROPS = {
   guardShiftChange: vi.fn(async ({ run }: { run: (options: { allowPublished: boolean }) => void | Promise<void> }) => {
     await run({ allowPublished: false });
   }),
+  notifyAfterDeferredCommit: vi.fn(),
 } as const;
 
 function renderTab(props = DEFAULT_PROPS) {

--- a/tests/unit/shiftPlannerTab.availabilityWiring.test.tsx
+++ b/tests/unit/shiftPlannerTab.availabilityWiring.test.tsx
@@ -166,6 +166,9 @@ const DEFAULT_PROPS = {
   restaurantId: 'r1',
   weekStart: WEEK_START,
   onWeekStartChange: vi.fn(),
+  guardShiftChange: vi.fn(async ({ run }: { run: (options: { allowPublished: boolean }) => void | Promise<void> }) => {
+    await run({ allowPublished: false });
+  }),
 } as const;
 
 function renderTab(props = DEFAULT_PROPS) {

--- a/tests/unit/shiftPlannerTab.hideTemplates.test.tsx
+++ b/tests/unit/shiftPlannerTab.hideTemplates.test.tsx
@@ -197,6 +197,7 @@ const DEFAULT_PROPS = {
   guardShiftChange: vi.fn(async ({ run }: { run: (options: { allowPublished: boolean }) => void | Promise<void> }) => {
     await run({ allowPublished: false });
   }),
+  notifyAfterDeferredCommit: vi.fn(),
 } as const;
 
 function renderTab(props = DEFAULT_PROPS) {

--- a/tests/unit/shiftPlannerTab.hideTemplates.test.tsx
+++ b/tests/unit/shiftPlannerTab.hideTemplates.test.tsx
@@ -194,6 +194,9 @@ const DEFAULT_PROPS = {
   restaurantId: 'r1',
   weekStart: new Date('2026-07-06T00:00:00Z'),
   onWeekStartChange: vi.fn(),
+  guardShiftChange: vi.fn(async ({ run }: { run: (options: { allowPublished: boolean }) => void | Promise<void> }) => {
+    await run({ allowPublished: false });
+  }),
 } as const;
 
 function renderTab(props = DEFAULT_PROPS) {

--- a/tests/unit/shiftPlannerTab.laborEfficiency.test.tsx
+++ b/tests/unit/shiftPlannerTab.laborEfficiency.test.tsx
@@ -140,6 +140,7 @@ const DEFAULT_PROPS = {
   guardShiftChange: vi.fn(async ({ run }: { run: (options: { allowPublished: boolean }) => void | Promise<void> }) => {
     await run({ allowPublished: false });
   }),
+  notifyAfterDeferredCommit: vi.fn(),
 } as const;
 
 function renderTab(props = DEFAULT_PROPS) {

--- a/tests/unit/shiftPlannerTab.laborEfficiency.test.tsx
+++ b/tests/unit/shiftPlannerTab.laborEfficiency.test.tsx
@@ -137,6 +137,9 @@ const DEFAULT_PROPS = {
   restaurantId: 'r1',
   weekStart: new Date('2026-07-06T00:00:00Z'),
   onWeekStartChange: vi.fn(),
+  guardShiftChange: vi.fn(async ({ run }: { run: (options: { allowPublished: boolean }) => void | Promise<void> }) => {
+    await run({ allowPublished: false });
+  }),
 } as const;
 
 function renderTab(props = DEFAULT_PROPS) {

--- a/tests/unit/shiftPlannerTab.viewToggle.test.tsx
+++ b/tests/unit/shiftPlannerTab.viewToggle.test.tsx
@@ -132,6 +132,9 @@ const DEFAULT_PROPS = {
   restaurantId: 'r1',
   weekStart: new Date('2026-07-06T00:00:00Z'),
   onWeekStartChange: vi.fn(),
+  guardShiftChange: vi.fn(async ({ run }: { run: (options: { allowPublished: boolean }) => void | Promise<void> }) => {
+    await run({ allowPublished: false });
+  }),
 } as const;
 
 function renderTab(props = DEFAULT_PROPS) {

--- a/tests/unit/shiftPlannerTab.viewToggle.test.tsx
+++ b/tests/unit/shiftPlannerTab.viewToggle.test.tsx
@@ -135,6 +135,7 @@ const DEFAULT_PROPS = {
   guardShiftChange: vi.fn(async ({ run }: { run: (options: { allowPublished: boolean }) => void | Promise<void> }) => {
     await run({ allowPublished: false });
   }),
+  notifyAfterDeferredCommit: vi.fn(),
 } as const;
 
 function renderTab(props = DEFAULT_PROPS) {

--- a/tests/unit/shiftTimelineTab.mobileLayout.test.tsx
+++ b/tests/unit/shiftTimelineTab.mobileLayout.test.tsx
@@ -116,6 +116,7 @@ const BASE_PROPS = {
   guardShiftChange: vi.fn(async ({ run }: { run: (options: { allowPublished: boolean }) => void | Promise<void> }) => {
     await run({ allowPublished: false });
   }),
+  notifyAfterDeferredCommit: vi.fn(),
 } as const;
 
 // A shift on Mon 2026-01-05 (16:00Z = 10:00 CST, UTC-6 in January)

--- a/tests/unit/shiftTimelineTab.mobileLayout.test.tsx
+++ b/tests/unit/shiftTimelineTab.mobileLayout.test.tsx
@@ -113,6 +113,9 @@ const BASE_PROPS = {
   tz: 'America/Chicago',
   loading: false,
   error: null,
+  guardShiftChange: vi.fn(async ({ run }: { run: (options: { allowPublished: boolean }) => void | Promise<void> }) => {
+    await run({ allowPublished: false });
+  }),
 } as const;
 
 // A shift on Mon 2026-01-05 (16:00Z = 10:00 CST, UTC-6 in January)

--- a/tests/unit/shiftTimelineTab.test.tsx
+++ b/tests/unit/shiftTimelineTab.test.tsx
@@ -124,6 +124,7 @@ const BASE_PROPS = {
   guardShiftChange: vi.fn(async ({ run }: { run: (options: { allowPublished: boolean }) => void | Promise<void> }) => {
     await run({ allowPublished: false });
   }),
+  notifyAfterDeferredCommit: vi.fn(),
 } as const;
 
 // ─── Tests ────────────────────────────────────────────────────────────────────

--- a/tests/unit/shiftTimelineTab.test.tsx
+++ b/tests/unit/shiftTimelineTab.test.tsx
@@ -119,6 +119,11 @@ const BASE_PROPS = {
   tz: 'America/Chicago',
   loading: false,
   error: null,
+  // Not locked: guardShiftChange runs `run` straight away, mirroring
+  // usePublishedShiftGuard's own real behavior for an unpublished shift.
+  guardShiftChange: vi.fn(async ({ run }: { run: (options: { allowPublished: boolean }) => void | Promise<void> }) => {
+    await run({ allowPublished: false });
+  }),
 } as const;
 
 // ─── Tests ────────────────────────────────────────────────────────────────────

--- a/tests/unit/shiftTimelineTabOverlay.test.tsx
+++ b/tests/unit/shiftTimelineTabOverlay.test.tsx
@@ -178,6 +178,9 @@ const BASE_PROPS = {
   tz: 'America/Chicago',
   loading: false,
   error: null,
+  guardShiftChange: vi.fn(async ({ run }: { run: (options: { allowPublished: boolean }) => void | Promise<void> }) => {
+    await run({ allowPublished: false });
+  }),
 } as const;
 
 describe('ShiftTimelineTab — activeOverlay wiring (B3)', () => {

--- a/tests/unit/shiftTimelineTabOverlay.test.tsx
+++ b/tests/unit/shiftTimelineTabOverlay.test.tsx
@@ -181,6 +181,7 @@ const BASE_PROPS = {
   guardShiftChange: vi.fn(async ({ run }: { run: (options: { allowPublished: boolean }) => void | Promise<void> }) => {
     await run({ allowPublished: false });
   }),
+  notifyAfterDeferredCommit: vi.fn(),
 } as const;
 
 describe('ShiftTimelineTab — activeOverlay wiring (B3)', () => {

--- a/tests/unit/timelineBarDrag.test.tsx
+++ b/tests/unit/timelineBarDrag.test.tsx
@@ -1,8 +1,9 @@
 /**
  * Unit tests for TimelineBar's pointer drag-move / edge-resize gesture
  * (Stage D1):
- *   - A locked shift renders no resize handles and never drags — pointer
- *     sequences on its body are inert (no onDraftChange/onDragCommit calls).
+ *   - A locked (published) shift renders resize handles and drags the same
+ *     as an unlocked shift — the guard at the commit call site is the gate,
+ *     not this hook.
  *   - A sub-threshold pointer sequence (movement below the 5px drag
  *     threshold) never fires onDraftChange/onDragCommit, leaving the bar's
  *     native onClick as the only path to onSelect — preserving tap-to-edit.
@@ -22,7 +23,7 @@
  */
 import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { TimelineBar } from '@/components/scheduling/ShiftTimeline/TimelineBar';
@@ -116,7 +117,7 @@ function renderBar(overrides: RenderBarOptions = {}) {
       onDragCommit={onDragCommit}
     />,
   );
-  const button = screen.getByRole('button');
+  const button = within(utils.container).getByRole('button');
   return { ...utils, button, onSelect, onDraftChange, onDragCommit };
 }
 
@@ -138,10 +139,10 @@ afterEach(() => {
 });
 
 describe('TimelineBar drag — locked shifts', () => {
-  it('renders no resize handles for a locked shift', () => {
+  it('renders resize handles for a locked shift too', () => {
     renderBar({ bar: makeBar({ shift: makeShift({ locked: true }) }) });
-    expect(screen.queryByTestId('resize-handle-start')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('resize-handle-end')).not.toBeInTheDocument();
+    expect(screen.getByTestId('resize-handle-start')).toBeInTheDocument();
+    expect(screen.getByTestId('resize-handle-end')).toBeInTheDocument();
   });
 
   it('renders resize handles for an unlocked shift', () => {
@@ -150,8 +151,8 @@ describe('TimelineBar drag — locked shifts', () => {
     expect(screen.getByTestId('resize-handle-end')).toBeInTheDocument();
   });
 
-  it('does not drag a locked bar — a pointer drag on the body never calls onDraftChange or onDragCommit', () => {
-    const { button, onDraftChange, onDragCommit, onSelect } = renderBar({
+  it('drags a locked bar — the gesture starts and calls onDraftChange and onDragCommit; the guard gates the commit later, not this hook', () => {
+    const { button, onDraftChange, onDragCommit } = renderBar({
       bar: makeBar({ shift: makeShift({ locked: true }) }),
     });
 
@@ -159,21 +160,18 @@ describe('TimelineBar drag — locked shifts', () => {
     fireEvent.pointerMove(button, { pointerId: 1, clientX: 200, pointerType: 'mouse' });
     fireEvent.pointerUp(button, { pointerId: 1, clientX: 200, pointerType: 'mouse' });
 
-    expect(onDraftChange).not.toHaveBeenCalled();
-    expect(onDragCommit).not.toHaveBeenCalled();
-    expect(onSelect).not.toHaveBeenCalled();
+    expect(onDraftChange).toHaveBeenCalled();
+    expect(onDragCommit).toHaveBeenCalled();
   });
 
-  it('applies cursor-grab and touch-none only to unlocked bars', () => {
+  it('applies cursor-grab and touch-none to every bar, locked or not', () => {
     const { button: unlockedBtn } = renderBar({ bar: makeBar({ shift: makeShift({ locked: false }) }) });
     expect(unlockedBtn.className).toContain('cursor-grab');
     expect(unlockedBtn.className).toContain('touch-none');
-  });
 
-  it('does not apply cursor-grab or touch-none to a locked bar', () => {
     const { button: lockedBtn } = renderBar({ bar: makeBar({ shift: makeShift({ locked: true }) }) });
-    expect(lockedBtn.className).not.toContain('cursor-grab');
-    expect(lockedBtn.className).not.toContain('touch-none');
+    expect(lockedBtn.className).toContain('cursor-grab');
+    expect(lockedBtn.className).toContain('touch-none');
   });
 });
 

--- a/tests/unit/usePublishedShiftGuard.test.tsx
+++ b/tests/unit/usePublishedShiftGuard.test.tsx
@@ -84,12 +84,27 @@ function setupChainWithChangeLog(
   return { logEq, logGte, logOrder, logLimit, logSelect };
 }
 
+/** Mocks the series count query: `select(..., {head:true})` ending in an awaited chain. */
+function setupSeriesCountChain(count: number) {
+  const chain: Record<string, unknown> = {};
+  chain.eq = vi.fn().mockReturnValue(chain);
+  chain.or = vi.fn().mockReturnValue(chain);
+  chain.gte = vi.fn().mockReturnValue(chain);
+  chain.then = (resolve: (value: { count: number; error: null }) => void) =>
+    resolve({ count, error: null });
+  const seriesSelect = vi.fn().mockReturnValue(chain);
+  mockSupabase.from.mockReturnValue({ select: seriesSelect });
+  return { chain, seriesSelect };
+}
+
 function TestHarness({
   run,
   shiftId = 'shift-1',
+  series,
 }: {
   run: (options: { allowPublished: boolean }) => void;
   shiftId?: string;
+  series?: { parentId: string; scope: 'following' | 'all'; fromTime?: string };
 }) {
   const { guardShiftChange, dialog } = usePublishedShiftGuard();
   return (
@@ -101,6 +116,7 @@ function TestHarness({
             restaurantId: 'rest-1',
             employeeName: 'Alex Rivera',
             run,
+            series,
           })
         }
       >
@@ -129,6 +145,40 @@ describe('usePublishedShiftGuard', () => {
     expect(mockSupabase.from).toHaveBeenCalledWith('shifts');
     expect(mockEq).toHaveBeenCalledWith('id', 'shift-1');
     expect(mockEq).toHaveBeenCalledWith('restaurant_id', 'rest-1');
+    expect(screen.queryByText('This shift is published')).not.toBeInTheDocument();
+  });
+
+  it('opens the dialog when any shift in the series scope is locked', async () => {
+    // The anchor itself is not read: the series count query decides.
+    const { chain } = setupSeriesCountChain(2);
+    const run = vi.fn();
+    render(
+      <TestHarness
+        run={run}
+        series={{ parentId: 'parent-1', scope: 'following', fromTime: '2026-08-12T00:00:00Z' }}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger' }));
+
+    await waitFor(() =>
+      expect(screen.getByText('This shift is published')).toBeInTheDocument()
+    );
+    expect(run).not.toHaveBeenCalled();
+    expect(chain.or).toHaveBeenCalledWith('id.eq.parent-1,recurrence_parent_id.eq.parent-1');
+    expect(chain.gte).toHaveBeenCalledWith('start_time', '2026-08-12T00:00:00Z');
+  });
+
+  it('runs directly when no shift in the series scope is locked', async () => {
+    setupSeriesCountChain(0);
+    const run = vi.fn();
+    render(<TestHarness run={run} series={{ parentId: 'parent-1', scope: 'all' }} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger' }));
+
+    await waitFor(() =>
+      expect(run).toHaveBeenCalledWith({ allowPublished: false, notify: false })
+    );
     expect(screen.queryByText('This shift is published')).not.toBeInTheDocument();
   });
 

--- a/tests/unit/usePublishedShiftGuard.test.tsx
+++ b/tests/unit/usePublishedShiftGuard.test.tsx
@@ -209,6 +209,37 @@ describe('usePublishedShiftGuard', () => {
     );
   });
 
+  it('reports a destructive toast, not an unhandled rejection, when the notify lookup throws', async () => {
+    setupChainWithChangeLog(
+      { data: { locked: true, employee_id: 'emp-1' }, error: null },
+      [{ id: 'log-1' }]
+    );
+    // The commit (`run`) already succeeded by this point — only the
+    // post-commit notify lookup fails here.
+    mockSupabase.auth.getUser.mockRejectedValue(new Error('network down'));
+    const run = vi.fn();
+    render(<TestHarness run={run} shiftId="shift-1" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger' }));
+    await waitFor(() =>
+      expect(screen.getByText('This shift is published')).toBeInTheDocument()
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Save change' }));
+
+    await waitFor(() =>
+      expect(run).toHaveBeenCalledWith({ allowPublished: true, notify: true })
+    );
+    await waitFor(() =>
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Shift updated — could not notify',
+          variant: 'destructive',
+        })
+      )
+    );
+    expect(mockInvokeScheduleNotification).not.toHaveBeenCalled();
+  });
+
   it('skips the lookup and the notify call when the checkbox is unchecked', async () => {
     setupChainWithChangeLog(
       { data: { locked: true, employee_id: 'emp-1' }, error: null },

--- a/tests/unit/usePublishedShiftGuard.test.tsx
+++ b/tests/unit/usePublishedShiftGuard.test.tsx
@@ -38,7 +38,10 @@ vi.mock('@/hooks/useSchedulePublish', async () => {
 
 function setupChain(resolvedValue: { data: unknown; error: unknown }) {
   mockSingle.mockResolvedValue(resolvedValue);
-  mockEq.mockReturnValue({ single: mockSingle });
+  // Chains twice — `.eq('id', ...).eq('restaurant_id', ...).single()` — so
+  // `eq` must keep returning an object that still offers both `eq` and
+  // `single`, not just `single`.
+  mockEq.mockReturnValue({ eq: mockEq, single: mockSingle });
   mockSelect.mockReturnValue({ eq: mockEq });
   mockSupabase.from.mockReturnValue({ select: mockSelect });
 }
@@ -65,7 +68,7 @@ function setupChainWithChangeLog(
   logSelect.mockReturnValue({ eq: logEq });
 
   mockSingle.mockResolvedValue(shiftsResolvedValue);
-  mockEq.mockReturnValue({ single: mockSingle });
+  mockEq.mockReturnValue({ eq: mockEq, single: mockSingle });
   mockSelect.mockReturnValue({ eq: mockEq });
 
   mockSupabase.from.mockImplementation((table: string) => {
@@ -92,7 +95,14 @@ function TestHarness({
   return (
     <>
       <button
-        onClick={() => guardShiftChange({ shiftId, employeeName: 'Alex Rivera', run })}
+        onClick={() =>
+          guardShiftChange({
+            shiftId,
+            restaurantId: 'rest-1',
+            employeeName: 'Alex Rivera',
+            run,
+          })
+        }
       >
         Trigger
       </button>
@@ -113,9 +123,12 @@ describe('usePublishedShiftGuard', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Trigger' }));
 
-    await waitFor(() => expect(run).toHaveBeenCalledWith({ allowPublished: false }));
+    await waitFor(() =>
+      expect(run).toHaveBeenCalledWith({ allowPublished: false, notify: false })
+    );
     expect(mockSupabase.from).toHaveBeenCalledWith('shifts');
     expect(mockEq).toHaveBeenCalledWith('id', 'shift-1');
+    expect(mockEq).toHaveBeenCalledWith('restaurant_id', 'rest-1');
     expect(screen.queryByText('This shift is published')).not.toBeInTheDocument();
   });
 
@@ -144,7 +157,9 @@ describe('usePublishedShiftGuard', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Save change' }));
 
-    await waitFor(() => expect(run).toHaveBeenCalledWith({ allowPublished: true }));
+    await waitFor(() =>
+      expect(run).toHaveBeenCalledWith({ allowPublished: true, notify: true })
+    );
   });
 
   it('does not run when the manager cancels', async () => {
@@ -211,7 +226,9 @@ describe('usePublishedShiftGuard', () => {
     );
     fireEvent.click(screen.getByRole('button', { name: 'Save change' }));
 
-    await waitFor(() => expect(run).toHaveBeenCalledWith({ allowPublished: true }));
+    await waitFor(() =>
+      expect(run).toHaveBeenCalledWith({ allowPublished: true, notify: false })
+    );
     expect(mockInvokeScheduleNotification).not.toHaveBeenCalled();
     expect(mockSupabase.from).not.toHaveBeenCalledWith('schedule_change_logs');
   });

--- a/tests/unit/usePublishedShiftGuard.test.tsx
+++ b/tests/unit/usePublishedShiftGuard.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * Unit tests: usePublishedShiftGuard — the single per-page guard that
+ * decides, off a fresh read (never the React Query cache), whether a shift
+ * change needs the "This shift is published" confirm dialog.
+ * Design: docs/superpowers/specs/2026-08-15-quiet-publish-live-edit-design.md
+ */
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { usePublishedShiftGuard } from '@/hooks/usePublishedShiftGuard';
+
+const mockSingle = vi.fn();
+const mockEq = vi.fn();
+const mockSelect = vi.fn();
+const mockSupabase = vi.hoisted(() => ({ from: vi.fn() }));
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: mockSupabase,
+}));
+
+function setupChain(resolvedValue: { data: unknown; error: unknown }) {
+  mockSingle.mockResolvedValue(resolvedValue);
+  mockEq.mockReturnValue({ single: mockSingle });
+  mockSelect.mockReturnValue({ eq: mockEq });
+  mockSupabase.from.mockReturnValue({ select: mockSelect });
+}
+
+function TestHarness({ run }: { run: (options: { allowPublished: boolean }) => void }) {
+  const { guardShiftChange, dialog } = usePublishedShiftGuard();
+  return (
+    <>
+      <button
+        onClick={() =>
+          guardShiftChange({ shiftId: 'shift-1', employeeName: 'Alex Rivera', run })
+        }
+      >
+        Trigger
+      </button>
+      {dialog}
+    </>
+  );
+}
+
+describe('usePublishedShiftGuard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('runs directly when the fresh read says the shift is not locked', async () => {
+    setupChain({ data: { locked: false, employee_id: 'emp-1' }, error: null });
+    const run = vi.fn();
+    render(<TestHarness run={run} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger' }));
+
+    await waitFor(() => expect(run).toHaveBeenCalledWith({ allowPublished: false }));
+    expect(mockSupabase.from).toHaveBeenCalledWith('shifts');
+    expect(mockEq).toHaveBeenCalledWith('id', 'shift-1');
+    expect(screen.queryByText('This shift is published')).not.toBeInTheDocument();
+  });
+
+  it('opens the dialog and defers the run when the fresh read says locked', async () => {
+    setupChain({ data: { locked: true, employee_id: 'emp-1' }, error: null });
+    const run = vi.fn();
+    render(<TestHarness run={run} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger' }));
+
+    await waitFor(() =>
+      expect(screen.getByText('This shift is published')).toBeInTheDocument()
+    );
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('runs with allowPublished: true after the manager confirms', async () => {
+    setupChain({ data: { locked: true, employee_id: 'emp-1' }, error: null });
+    const run = vi.fn();
+    render(<TestHarness run={run} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger' }));
+    await waitFor(() =>
+      expect(screen.getByText('This shift is published')).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save change' }));
+
+    await waitFor(() => expect(run).toHaveBeenCalledWith({ allowPublished: true }));
+  });
+
+  it('does not run when the manager cancels', async () => {
+    setupChain({ data: { locked: true, employee_id: 'emp-1' }, error: null });
+    const run = vi.fn();
+    render(<TestHarness run={run} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger' }));
+    await waitFor(() =>
+      expect(screen.getByText('This shift is published')).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() =>
+      expect(screen.queryByText('This shift is published')).not.toBeInTheDocument()
+    );
+    expect(run).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/usePublishedShiftGuard.test.tsx
+++ b/tests/unit/usePublishedShiftGuard.test.tsx
@@ -13,11 +13,26 @@ import { usePublishedShiftGuard } from '@/hooks/usePublishedShiftGuard';
 const mockSingle = vi.fn();
 const mockEq = vi.fn();
 const mockSelect = vi.fn();
-const mockSupabase = vi.hoisted(() => ({ from: vi.fn() }));
+const mockGetUser = vi.fn();
+const mockSupabase = vi.hoisted(() => ({ from: vi.fn(), auth: { getUser: vi.fn() } }));
+const mockToast = vi.fn();
+const mockInvokeScheduleNotification = vi.fn();
 
 vi.mock('@/integrations/supabase/client', () => ({
   supabase: mockSupabase,
 }));
+
+vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: mockToast }) }));
+
+vi.mock('@/hooks/useSchedulePublish', async () => {
+  const actual = await vi.importActual<typeof import('@/hooks/useSchedulePublish')>(
+    '@/hooks/useSchedulePublish'
+  );
+  return {
+    ...actual,
+    invokeScheduleNotification: mockInvokeScheduleNotification,
+  };
+});
 
 function setupChain(resolvedValue: { data: unknown; error: unknown }) {
   mockSingle.mockResolvedValue(resolvedValue);
@@ -26,14 +41,54 @@ function setupChain(resolvedValue: { data: unknown; error: unknown }) {
   mockSupabase.from.mockReturnValue({ select: mockSelect });
 }
 
-function TestHarness({ run }: { run: (options: { allowPublished: boolean }) => void }) {
+/**
+ * Sets up two distinct `from()` targets: the `shifts` fresh-read (as
+ * `setupChain` does) and the `schedule_change_logs` lookup the notify step
+ * runs after a confirmed change. The lookup chain records every `eq`/`gte`
+ * call so tests can assert the scoped filter.
+ */
+function setupChainWithChangeLog(
+  shiftsResolvedValue: { data: unknown; error: unknown },
+  changeLogRows: Array<{ id: string }>
+) {
+  const logEq = vi.fn();
+  const logGte = vi.fn();
+  const logOrder = vi.fn();
+  const logLimit = vi.fn().mockResolvedValue({ data: changeLogRows, error: null });
+  const logSelect = vi.fn();
+
+  logOrder.mockReturnValue({ limit: logLimit });
+  logGte.mockReturnValue({ order: logOrder });
+  logEq.mockImplementation(() => ({ eq: logEq, gte: logGte }));
+  logSelect.mockReturnValue({ eq: logEq });
+
+  mockSingle.mockResolvedValue(shiftsResolvedValue);
+  mockEq.mockReturnValue({ single: mockSingle });
+  mockSelect.mockReturnValue({ eq: mockEq });
+
+  mockSupabase.from.mockImplementation((table: string) => {
+    if (table === 'schedule_change_logs') return { select: logSelect };
+    return { select: mockSelect };
+  });
+
+  mockGetUser.mockResolvedValue({ data: { user: { id: 'manager-1' } }, error: null });
+  mockSupabase.auth.getUser = mockGetUser;
+
+  return { logEq, logGte, logOrder, logLimit, logSelect };
+}
+
+function TestHarness({
+  run,
+  shiftId = 'shift-1',
+}: {
+  run: (options: { allowPublished: boolean }) => void;
+  shiftId?: string;
+}) {
   const { guardShiftChange, dialog } = usePublishedShiftGuard();
   return (
     <>
       <button
-        onClick={() =>
-          guardShiftChange({ shiftId: 'shift-1', employeeName: 'Alex Rivera', run })
-        }
+        onClick={() => guardShiftChange({ shiftId, employeeName: 'Alex Rivera', run })}
       >
         Trigger
       </button>
@@ -104,5 +159,56 @@ describe('usePublishedShiftGuard', () => {
       expect(screen.queryByText('This shift is published')).not.toBeInTheDocument()
     );
     expect(run).not.toHaveBeenCalled();
+  });
+
+  it('looks up the change log scoped to shift, actor, and time, then notifies', async () => {
+    const { logEq, logGte } = setupChainWithChangeLog(
+      { data: { locked: true, employee_id: 'emp-1' }, error: null },
+      [{ id: 'log-1' }]
+    );
+    mockInvokeScheduleNotification.mockResolvedValue({ status: 'sent', sent: 1 });
+    const run = vi.fn();
+    render(<TestHarness run={run} shiftId="shift-1" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger' }));
+    await waitFor(() =>
+      expect(screen.getByText('This shift is published')).toBeInTheDocument()
+    );
+    // The notify checkbox stays checked by default.
+    fireEvent.click(screen.getByRole('button', { name: 'Save change' }));
+
+    await waitFor(() =>
+      expect(mockInvokeScheduleNotification).toHaveBeenCalledWith('notify-shift-changed', {
+        changeLogId: 'log-1',
+      })
+    );
+    expect(logEq).toHaveBeenCalledWith('shift_id', 'shift-1');
+    expect(logEq).toHaveBeenCalledWith('changed_by', 'manager-1');
+    expect(logGte).toHaveBeenCalledWith('changed_at', expect.any(String));
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Shift updated' })
+    );
+  });
+
+  it('skips the lookup and the notify call when the checkbox is unchecked', async () => {
+    setupChainWithChangeLog(
+      { data: { locked: true, employee_id: 'emp-1' }, error: null },
+      [{ id: 'log-1' }]
+    );
+    const run = vi.fn();
+    render(<TestHarness run={run} shiftId="shift-1" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Trigger' }));
+    await waitFor(() =>
+      expect(screen.getByText('This shift is published')).toBeInTheDocument()
+    );
+    fireEvent.click(
+      screen.getByLabelText('Notify Alex Rivera about this change')
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Save change' }));
+
+    await waitFor(() => expect(run).toHaveBeenCalledWith({ allowPublished: true }));
+    expect(mockInvokeScheduleNotification).not.toHaveBeenCalled();
+    expect(mockSupabase.from).not.toHaveBeenCalledWith('schedule_change_logs');
   });
 });

--- a/tests/unit/usePublishedShiftGuard.test.tsx
+++ b/tests/unit/usePublishedShiftGuard.test.tsx
@@ -13,10 +13,12 @@ import { usePublishedShiftGuard } from '@/hooks/usePublishedShiftGuard';
 const mockSingle = vi.fn();
 const mockEq = vi.fn();
 const mockSelect = vi.fn();
-const mockGetUser = vi.fn();
-const mockSupabase = vi.hoisted(() => ({ from: vi.fn(), auth: { getUser: vi.fn() } }));
+const mockSupabase = vi.hoisted(() => ({
+  from: vi.fn(),
+  auth: { getUser: vi.fn().mockResolvedValue({ data: { user: null }, error: null }) },
+}));
 const mockToast = vi.fn();
-const mockInvokeScheduleNotification = vi.fn();
+const mockInvokeScheduleNotification = vi.hoisted(() => vi.fn());
 
 vi.mock('@/integrations/supabase/client', () => ({
   supabase: mockSupabase,
@@ -71,8 +73,10 @@ function setupChainWithChangeLog(
     return { select: mockSelect };
   });
 
-  mockGetUser.mockResolvedValue({ data: { user: { id: 'manager-1' } }, error: null });
-  mockSupabase.auth.getUser = mockGetUser;
+  mockSupabase.auth.getUser.mockResolvedValue({
+    data: { user: { id: 'manager-1' } },
+    error: null,
+  });
 
   return { logEq, logGte, logOrder, logLimit, logSelect };
 }

--- a/tests/unit/useSchedulePublish.test.ts
+++ b/tests/unit/useSchedulePublish.test.ts
@@ -173,6 +173,43 @@ describe('publish notification outcomes', () => {
     expect(result.current.isError).toBe(false);
     expect(lastToast().title).toMatch(/^Schedule Published/);
   });
+
+  it('skips the notification invoke when notify is false', async () => {
+    const { weekStart, weekEnd } = makeWeek();
+
+    const { result } = renderHook(() => usePublishSchedule(), { wrapper: createWrapper() });
+    await act(async () => {
+      await result.current.mutateAsync({ restaurantId: 'r1', weekStart, weekEnd, notify: false });
+    });
+
+    expect(mockSupabase.functions.invoke).not.toHaveBeenCalled();
+    expect(result.current.isError).toBe(false);
+    expect(lastToast().description).toBe('No notifications were sent.');
+  });
+
+  it('calls the notification invoke once when notify is true', async () => {
+    mockSupabase.functions.invoke.mockResolvedValue({ data: { sent: 11, failed: 0 }, error: null });
+    const { weekStart, weekEnd } = makeWeek();
+
+    const { result } = renderHook(() => usePublishSchedule(), { wrapper: createWrapper() });
+    await act(async () => {
+      await result.current.mutateAsync({ restaurantId: 'r1', weekStart, weekEnd, notify: true });
+    });
+
+    expect(mockSupabase.functions.invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('defaults notify to true when the param is absent', async () => {
+    mockSupabase.functions.invoke.mockResolvedValue({ data: { sent: 11, failed: 0 }, error: null });
+    const { weekStart, weekEnd } = makeWeek();
+
+    const { result } = renderHook(() => usePublishSchedule(), { wrapper: createWrapper() });
+    await act(async () => {
+      await result.current.mutateAsync({ restaurantId: 'r1', weekStart, weekEnd });
+    });
+
+    expect(mockSupabase.functions.invoke).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('notificationToast copy per outcome', () => {

--- a/tests/unit/useSchedulePublish.test.ts
+++ b/tests/unit/useSchedulePublish.test.ts
@@ -17,6 +17,7 @@ vi.mock('@/hooks/use-toast', () => ({ useToast: () => ({ toast: mockToast }) }))
 
 import {
   invokeScheduleNotification,
+  notificationToast,
   usePublishSchedule,
   useUnpublishSchedule,
 } from '@/hooks/useSchedulePublish';
@@ -171,6 +172,21 @@ describe('publish notification outcomes', () => {
     // get through.
     expect(result.current.isError).toBe(false);
     expect(lastToast().title).toMatch(/^Schedule Published/);
+  });
+});
+
+describe('notificationToast copy per outcome', () => {
+  it('reports no notifications were sent for a skipped outcome', () => {
+    const toasted = notificationToast(
+      { status: 'skipped' },
+      { title: 'Schedule Published', successDescription: 'The schedule has been published.' },
+    );
+
+    // Title stays the plain success title -- 'skipped' is not a failure, so it
+    // must not read like the '-- some/nobody notified' destructive branches.
+    expect(toasted.title).toBe('Schedule Published');
+    expect(toasted.description).toBe('No notifications were sent.');
+    expect(toasted.variant).toBeUndefined();
   });
 });
 

--- a/tests/unit/useShiftsSeries.test.ts
+++ b/tests/unit/useShiftsSeries.test.ts
@@ -343,6 +343,63 @@ describe('useDeleteShiftSeries', () => {
     });
   });
 
+  describe('allowPublished', () => {
+    it('allowPublished: true maps to p_include_locked: true on the RPC', async () => {
+      let capturedParams: Record<string, unknown> | null = null;
+      mockSupabase.rpc.mockImplementation((fnName: string, params: Record<string, unknown>) => {
+        if (fnName === 'delete_shift_series') {
+          capturedParams = params;
+          return Promise.resolve({ data: [{ deleted_count: 2, locked_count: 0 }], error: null });
+        }
+        return Promise.resolve({ data: null, error: null });
+      });
+
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(() => useDeleteShiftSeries(), { wrapper: Wrapper });
+
+      await waitFor(() => expect(result.current.mutateAsync).toBeDefined());
+
+      const shift = createMockShift({ is_recurring: true, recurrence_parent_id: null });
+
+      await result.current.mutateAsync({
+        shift,
+        scope: 'all',
+        restaurantId: 'rest-123',
+        allowPublished: true,
+      });
+
+      expect(capturedParams).not.toBeNull();
+      expect(capturedParams?.p_include_locked).toBe(true);
+    });
+
+    it('allowPublished absent maps to p_include_locked: false (unchanged)', async () => {
+      let capturedParams: Record<string, unknown> | null = null;
+      mockSupabase.rpc.mockImplementation((fnName: string, params: Record<string, unknown>) => {
+        if (fnName === 'delete_shift_series') {
+          capturedParams = params;
+          return Promise.resolve({ data: [{ deleted_count: 2, locked_count: 1 }], error: null });
+        }
+        return Promise.resolve({ data: null, error: null });
+      });
+
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(() => useDeleteShiftSeries(), { wrapper: Wrapper });
+
+      await waitFor(() => expect(result.current.mutateAsync).toBeDefined());
+
+      const shift = createMockShift({ is_recurring: true, recurrence_parent_id: null });
+
+      await result.current.mutateAsync({
+        shift,
+        scope: 'all',
+        restaurantId: 'rest-123',
+      });
+
+      expect(capturedParams).not.toBeNull();
+      expect(capturedParams?.p_include_locked).toBe(false);
+    });
+  });
+
   describe('Error Handling', () => {
     it('should handle Supabase error and show destructive toast', async () => {
       const dbError = { message: 'Database error' };
@@ -434,6 +491,36 @@ describe('useUpdateShiftSeries', () => {
           restaurantId: 'rest-123',
         })
       ).rejects.toThrow('Cannot update a locked shift');
+    });
+
+    it('allowPublished: true skips the lock throw for scope "this"', async () => {
+      const updatedShift = { id: 'locked-shift' };
+      mockSupabase.from.mockImplementation(() => ({
+        update: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              select: vi.fn().mockResolvedValue({ data: [updatedShift], error: null }),
+            }),
+          }),
+        }),
+      }));
+
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(() => useUpdateShiftSeries(), { wrapper: Wrapper });
+
+      await waitFor(() => expect(result.current.mutateAsync).toBeDefined());
+
+      const lockedShift = createMockShift({ id: 'locked-shift', locked: true });
+
+      const response = await result.current.mutateAsync({
+        shift: lockedShift,
+        scope: 'this',
+        updates: { position: 'Cook' },
+        restaurantId: 'rest-123',
+        allowPublished: true,
+      });
+
+      expect(response.updatedCount).toBe(1);
     });
 
     it('should include time changes for scope "this"', async () => {

--- a/tests/unit/useShiftsSeries.test.ts
+++ b/tests/unit/useShiftsSeries.test.ts
@@ -659,6 +659,65 @@ describe('useUpdateShiftSeries', () => {
     });
   });
 
+  describe('allowPublished', () => {
+    it('allowPublished: true maps to p_include_locked: true on the RPC', async () => {
+      let capturedParams: Record<string, unknown> | null = null;
+      mockSupabase.rpc.mockImplementation((fnName: string, params: Record<string, unknown>) => {
+        if (fnName === 'update_shift_series') {
+          capturedParams = params;
+          return Promise.resolve({ data: [{ updated_count: 3, locked_count: 0 }], error: null });
+        }
+        return Promise.resolve({ data: null, error: null });
+      });
+
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(() => useUpdateShiftSeries(), { wrapper: Wrapper });
+
+      await waitFor(() => expect(result.current.mutateAsync).toBeDefined());
+
+      const shift = createMockShift({ is_recurring: true, recurrence_parent_id: null, locked: true });
+
+      await result.current.mutateAsync({
+        shift,
+        scope: 'all',
+        updates: { position: 'Host' },
+        restaurantId: 'rest-123',
+        allowPublished: true,
+      });
+
+      expect(capturedParams).not.toBeNull();
+      expect(capturedParams?.p_include_locked).toBe(true);
+    });
+
+    it('allowPublished absent maps to p_include_locked: false (unchanged)', async () => {
+      let capturedParams: Record<string, unknown> | null = null;
+      mockSupabase.rpc.mockImplementation((fnName: string, params: Record<string, unknown>) => {
+        if (fnName === 'update_shift_series') {
+          capturedParams = params;
+          return Promise.resolve({ data: [{ updated_count: 2, locked_count: 1 }], error: null });
+        }
+        return Promise.resolve({ data: null, error: null });
+      });
+
+      const { Wrapper } = createWrapper();
+      const { result } = renderHook(() => useUpdateShiftSeries(), { wrapper: Wrapper });
+
+      await waitFor(() => expect(result.current.mutateAsync).toBeDefined());
+
+      const shift = createMockShift({ is_recurring: true, recurrence_parent_id: null });
+
+      await result.current.mutateAsync({
+        shift,
+        scope: 'all',
+        updates: { position: 'Host' },
+        restaurantId: 'rest-123',
+      });
+
+      expect(capturedParams).not.toBeNull();
+      expect(capturedParams?.p_include_locked).toBe(false);
+    });
+  });
+
   describe('Error Handling', () => {
     it('should handle Supabase error and show destructive toast', async () => {
       mockSupabase.from.mockImplementation(() => ({

--- a/tests/unit/useShiftsSingleMutations.test.ts
+++ b/tests/unit/useShiftsSingleMutations.test.ts
@@ -246,6 +246,64 @@ describe('useUpdateShift — optimistic cache update', () => {
   });
 });
 
+describe('useUpdateShift — allowPublished', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('allowPublished: true skips the lock check and updates the shift', async () => {
+    let capturedPayload: Record<string, unknown> | null = null;
+    const updateSingle = vi.fn().mockResolvedValue({
+      data: { id: 'shift-1', restaurant_id: 'rest-123' },
+      error: null,
+    });
+    const updateSelect = vi.fn().mockReturnValue({ single: updateSingle });
+    const updateEqRestaurant = vi.fn().mockReturnValue({ select: updateSelect });
+    const updateEqId = vi.fn().mockReturnValue({ eq: updateEqRestaurant });
+    const update = vi.fn().mockImplementation((payload: Record<string, unknown>) => {
+      capturedPayload = payload;
+      return { eq: updateEqId };
+    });
+    // No `select` mock provided: if assertShiftNotLocked still ran, calling
+    // `.select()` on this object returns undefined and the next `.eq()` throws.
+    mockSupabase.from.mockReturnValue({ update });
+
+    const { result } = renderHook(() => useUpdateShift(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      result.current.mutate({
+        id: 'shift-1',
+        restaurant_id: 'rest-123',
+        status: 'confirmed' as const,
+        allowPublished: true,
+      });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(update).toHaveBeenCalled();
+    expect(capturedPayload).not.toHaveProperty('allowPublished');
+  });
+
+  it('allowPublished absent still throws on a locked shift (unchanged)', async () => {
+    const lockCheckSingle = vi.fn().mockResolvedValue({ data: { locked: true }, error: null });
+    const lockCheckEq = vi.fn().mockReturnValue({ single: lockCheckSingle });
+    const lockCheckSelect = vi.fn().mockReturnValue({ eq: lockCheckEq });
+    mockSupabase.from.mockReturnValue({ select: lockCheckSelect });
+
+    const { result } = renderHook(() => useUpdateShift(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      result.current.mutate({
+        id: 'shift-1',
+        restaurant_id: 'rest-123',
+        status: 'confirmed' as const,
+      });
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
 describe('useDeleteShift — explicit restaurant_id filter', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -292,6 +350,32 @@ describe('useDeleteShift — explicit restaurant_id filter', () => {
     });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it('accepts allowPublished: true without changing delete behavior', async () => {
+    const { deleteEqRestaurant } = setupDeleteChain({ error: null });
+
+    const { result } = renderHook(() => useDeleteShift(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      result.current.mutate({ id: 'shift-1', restaurantId: 'rest-123', allowPublished: true });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(deleteEqRestaurant).toHaveBeenCalledWith('restaurant_id', 'rest-123');
+  });
+
+  it('allowPublished absent deletes as before (unchanged)', async () => {
+    const { deleteEqRestaurant } = setupDeleteChain({ error: null });
+
+    const { result } = renderHook(() => useDeleteShift(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      result.current.mutate({ id: 'shift-1', restaurantId: 'rest-123' });
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(deleteEqRestaurant).toHaveBeenCalledWith('restaurant_id', 'rest-123');
   });
 });
 

--- a/tests/unit/useValidatedShiftMutations.test.tsx
+++ b/tests/unit/useValidatedShiftMutations.test.tsx
@@ -385,6 +385,24 @@ describe('useValidatedShiftMutations — validateAndUpdateTime', () => {
     );
   });
 
+  it('updates a locked shift when allowPublished is true', async () => {
+    const { result } = renderPipeline([]);
+    const lockedShift = makeShift({ id: 'shift-locked', locked: true });
+
+    const outcome = await result.current.validateAndUpdateTime({
+      shift: lockedShift,
+      startIso: '2026-02-01T15:00:00.000Z',
+      endIso: '2026-02-01T23:00:00.000Z',
+      businessDate: '2026-02-01',
+      allowPublished: true,
+    });
+
+    expect(outcome.updated).toBe(true);
+    expect(mockUpdateMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'shift-locked' }),
+    );
+  });
+
   it('TZ regression: builds the interval via ShiftInterval.fromTimestamps (restaurant-local wall clock preserved), not host-TZ split+create', async () => {
     // Restaurant TZ is America/Los_Angeles; host test-runner TZ is whatever CI uses (unpinned) —
     // fromTimestamps operates purely on the ISO instant, so the wall-clock components of the
@@ -523,6 +541,27 @@ describe('useValidatedShiftMutations — validateAndUpdateShift (persists employ
     expect(outcome).toEqual({ updated: false });
     expect(mockUpdateMutateAsync).not.toHaveBeenCalled();
   });
+
+  it('updates a locked shift when allowPublished is true', async () => {
+    const { result } = renderPipeline([]);
+    const lockedShift = makeShift({ id: 'shift-locked', locked: true });
+
+    const outcome = await result.current.validateAndUpdateShift({
+      shift: lockedShift,
+      startIso: '2026-02-01T15:00:00.000Z',
+      endIso: '2026-02-01T23:00:00.000Z',
+      businessDate: '2026-02-01',
+      employeeId: lockedShift.employee_id,
+      breakDuration: 0,
+      notes: '',
+      allowPublished: true,
+    });
+
+    expect(outcome.updated).toBe(true);
+    expect(mockUpdateMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'shift-locked' }),
+    );
+  });
 });
 
 describe('useValidatedShiftMutations — forceUpdateShift', () => {
@@ -573,6 +612,27 @@ describe('useValidatedShiftMutations — forceUpdateShift', () => {
     expect(outcome.updated).toBe(false);
     expect(mockUpdateMutateAsync).not.toHaveBeenCalled();
   });
+
+  it('updates a locked shift when allowPublished is true', async () => {
+    const { result } = renderPipeline([]);
+    const lockedShift = makeShift({ id: 'shift-locked', locked: true });
+
+    const outcome = await result.current.forceUpdateShift({
+      shift: lockedShift,
+      startIso: '2026-02-01T15:00:00.000Z',
+      endIso: '2026-02-01T23:00:00.000Z',
+      businessDate: '2026-02-01',
+      employeeId: lockedShift.employee_id,
+      breakDuration: 0,
+      notes: '',
+      allowPublished: true,
+    });
+
+    expect(outcome.updated).toBe(true);
+    expect(mockUpdateMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'shift-locked' }),
+    );
+  });
 });
 
 describe('useValidatedShiftMutations — forceUpdateTime', () => {
@@ -617,6 +677,24 @@ describe('useValidatedShiftMutations — forceUpdateTime', () => {
       ),
     );
   });
+
+  it('updates a locked shift when allowPublished is true', async () => {
+    const { result } = renderPipeline([]);
+    const lockedShift = makeShift({ id: 'shift-locked', locked: true });
+
+    const updated = await result.current.forceUpdateTime({
+      shift: lockedShift,
+      startIso: '2026-02-01T15:00:00.000Z',
+      endIso: '2026-02-01T23:00:00.000Z',
+      businessDate: '2026-02-01',
+      allowPublished: true,
+    });
+
+    expect(updated).toBe(true);
+    expect(mockUpdateMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'shift-locked' }),
+    );
+  });
 });
 
 describe('useValidatedShiftMutations — validateAndReassign', () => {
@@ -659,6 +737,22 @@ describe('useValidatedShiftMutations — validateAndReassign', () => {
     ).rejects.toBeInstanceOf(LockedShiftError);
     expect(mockUpdateMutateAsync).not.toHaveBeenCalled();
   });
+
+  it('reassigns a locked shift when allowPublished is true', async () => {
+    const { result } = renderPipeline([]);
+    const lockedShift = makeShift({ id: 'shift-locked', locked: true });
+
+    const outcome = await result.current.validateAndReassign({
+      shift: lockedShift,
+      newEmployeeId: 'emp-2',
+      allowPublished: true,
+    });
+
+    expect(outcome.reassigned).toBe(true);
+    expect(mockUpdateMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'shift-locked', employee_id: 'emp-2' }),
+    );
+  });
 });
 
 describe('useValidatedShiftMutations — forceReassign', () => {
@@ -685,6 +779,22 @@ describe('useValidatedShiftMutations — forceReassign', () => {
     ).rejects.toBeInstanceOf(LockedShiftError);
     expect(mockUpdateMutateAsync).not.toHaveBeenCalled();
   });
+
+  it('reassigns a locked shift when allowPublished is true', async () => {
+    const { result } = renderPipeline([]);
+    const lockedShift = makeShift({ id: 'shift-locked', locked: true });
+
+    const reassigned = await result.current.forceReassign({
+      shift: lockedShift,
+      newEmployeeId: 'emp-2',
+      allowPublished: true,
+    });
+
+    expect(reassigned).toBe(true);
+    expect(mockUpdateMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'shift-locked', employee_id: 'emp-2' }),
+    );
+  });
 });
 
 describe('useValidatedShiftMutations — deleteShift', () => {
@@ -704,6 +814,15 @@ describe('useValidatedShiftMutations — deleteShift', () => {
     expect(() => result.current.deleteShift('shift-locked')).toThrow(LockedShiftError);
     expect(mockDeleteMutate).not.toHaveBeenCalled();
   });
+
+  it('deletes a locked shift when allowPublished is true', () => {
+    const lockedShift = makeShift({ id: 'shift-locked', locked: true });
+    const { result } = renderPipeline([lockedShift]);
+
+    result.current.deleteShift('shift-locked', true);
+
+    expect(mockDeleteMutate).toHaveBeenCalledWith({ id: 'shift-locked', restaurantId: 'rest-1' });
+  });
 });
 
 describe('useValidatedShiftMutations — deleteShiftAsync (awaitable, lock-guarded)', () => {
@@ -722,6 +841,15 @@ describe('useValidatedShiftMutations — deleteShiftAsync (awaitable, lock-guard
 
     await expect(result.current.deleteShiftAsync('shift-locked')).rejects.toBeInstanceOf(LockedShiftError);
     expect(mockDeleteMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('deletes a locked shift when allowPublished is true', async () => {
+    const lockedShift = makeShift({ id: 'shift-locked', locked: true });
+    const { result } = renderPipeline([lockedShift]);
+
+    await expect(result.current.deleteShiftAsync('shift-locked', true)).resolves.toBeUndefined();
+
+    expect(mockDeleteMutateAsync).toHaveBeenCalledWith({ id: 'shift-locked', restaurantId: 'rest-1' });
   });
 
   it('rejects when the underlying mutateAsync rejects', async () => {

--- a/tests/unit/useValidatedShiftMutations.test.tsx
+++ b/tests/unit/useValidatedShiftMutations.test.tsx
@@ -399,7 +399,7 @@ describe('useValidatedShiftMutations — validateAndUpdateTime', () => {
 
     expect(outcome.updated).toBe(true);
     expect(mockUpdateMutateAsync).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'shift-locked' }),
+      expect.objectContaining({ id: 'shift-locked', allowPublished: true }),
     );
   });
 
@@ -559,7 +559,7 @@ describe('useValidatedShiftMutations — validateAndUpdateShift (persists employ
 
     expect(outcome.updated).toBe(true);
     expect(mockUpdateMutateAsync).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'shift-locked' }),
+      expect.objectContaining({ id: 'shift-locked', allowPublished: true }),
     );
   });
 });
@@ -630,7 +630,7 @@ describe('useValidatedShiftMutations — forceUpdateShift', () => {
 
     expect(outcome.updated).toBe(true);
     expect(mockUpdateMutateAsync).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'shift-locked' }),
+      expect.objectContaining({ id: 'shift-locked', allowPublished: true }),
     );
   });
 });
@@ -692,7 +692,7 @@ describe('useValidatedShiftMutations — forceUpdateTime', () => {
 
     expect(updated).toBe(true);
     expect(mockUpdateMutateAsync).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'shift-locked' }),
+      expect.objectContaining({ id: 'shift-locked', allowPublished: true }),
     );
   });
 });
@@ -750,7 +750,7 @@ describe('useValidatedShiftMutations — validateAndReassign', () => {
 
     expect(outcome.reassigned).toBe(true);
     expect(mockUpdateMutateAsync).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'shift-locked', employee_id: 'emp-2' }),
+      expect.objectContaining({ id: 'shift-locked', employee_id: 'emp-2', allowPublished: true }),
     );
   });
 });
@@ -792,7 +792,7 @@ describe('useValidatedShiftMutations — forceReassign', () => {
 
     expect(reassigned).toBe(true);
     expect(mockUpdateMutateAsync).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'shift-locked', employee_id: 'emp-2' }),
+      expect.objectContaining({ id: 'shift-locked', employee_id: 'emp-2', allowPublished: true }),
     );
   });
 });


### PR DESCRIPTION
## Summary

- The publish dialog gets a "Notify employees" checkbox, checked by default. Unchecked, the publish sends no notifications and the toast says "No notifications were sent."
- A manager can change a published shift without an unpublish. One warning dialog shows: "This shift is published." It offers "Notify {employee} about this change", checked by default. A reassignment names and notifies both employees.
- New edge function `notify-shift-changed` derives the message from the `schedule_change_logs` row the trigger writes — the request body carries only `{ changeLogId }`. A `notified_at` latch stops duplicate sends.
- The retraction notice gate in `notify-schedule-unpublished` now keys on the retracted publication row, not on `notification_sent` — a quiet publish must not silence a later real retraction.
- One migration: nullable `schedule_change_logs.notified_at`.

Design doc: `docs/superpowers/specs/2026-08-15-quiet-publish-live-edit-design.md` (includes the Phase 2.5 review decisions and decided trade-offs).

## Test plan

- Unit: 9,303 tests pass (includes new suites for the dialog, the guard, both lock-bypass paths, the publish skip, and the notification derive logic).
- pgTAP: 2,847 pass (includes the `notified_at` migration).
- E2E: `tests/e2e/schedule-quiet-publish-live-edit.spec.ts` — quiet publish publishes the week; a guarded edit warns once, saves, and the week stays published.
- Typecheck and build: clean. Full-repo lint carries pre-existing debt only; the branch-changed files introduce zero new findings.

## Known deferred review findings

- `usePublishedShiftGuard` reads `shifts.locked` fresh on every call by design (stale-cache race, see the design doc). Reviewer suggested the cache; declined.
- `assertShiftNotLocked` performs a second SELECT after the guard's fresh read; kept as the last-line backstop by design.
- `employees.find(...)?.name` repeats across 6 call sites; a shared lookup helper is follow-up work.
- The per-recipient send loop in `notify-shift-changed` is sequential; at most two recipients per call, so bounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Publish schedules quietly by choosing whether to notify employees.
  * Edit, reassign, move, resize, or delete shifts after publication with confirmation.
  * Receive optional notifications when published shifts change.
  * View clear publishing and change-confirmation messaging, including notification status.
* **Bug Fixes**
  * Retraction notifications now work for quietly published schedules.
* **Documentation**
  * Added design and implementation documentation for quiet publishing and live editing.
* **Tests**
  * Added unit, integration, and end-to-end coverage for publishing, editing, notifications, and locked-shift workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->