### PR TITLE
Add unpublish notify choice, thread schedule emails, fix help docs

### DIFF
--- a/docs/superpowers/plans/2026-08-18-schedule-notification-residue-plan.md
+++ b/docs/superpowers/plans/2026-08-18-schedule-notification-residue-plan.md
@@ -1,0 +1,174 @@
+# Plan: close the three gaps left after the quiet-publish change
+
+Design: docs/superpowers/specs/2026-08-18-schedule-notification-residue-design.md
+Branch: claude/confident-lewin-8e0379
+Worktree: .claude/worktrees/upbeat-wing-771b94
+
+Each task is one TDD unit: write the failing test, make it pass, commit.
+
+No migration and no RPC change. No pgTAP test applies.
+
+## Gap 1: give unpublish a notify choice
+
+1. **Add `skippedDescription` to `NotificationToastCopy`.**
+   File: `src/hooks/useSchedulePublish.tsx:155`. Add the optional field next
+   to `successDescription`. The `skipped` branch at `:183` uses it when
+   present, and keeps "No notifications were sent." when absent.
+   Tests: `tests/unit/useSchedulePublish.test.ts`, the
+   "notificationToast copy per outcome" describe at `:215`. Two cases:
+   field present, field absent. No dependency.
+
+2. **Add `notify` to `UnpublishScheduleParams`.**
+   File: `src/hooks/useSchedulePublish.tsx:21`. Default `true` in the
+   `mutationFn` signature. Gate the invoke at `:341` with the publish
+   pattern from `:274`. Pass `skippedDescription` at the `:367` call site,
+   with both shift-count branches from the design.
+   Tests: `tests/unit/useSchedulePublish.test.ts`, the
+   "unpublish notification outcomes" describe at `:230`. Mirror the publish
+   tests at `:177`, `:190`, `:202`. Cases: zero invoke calls when `notify`
+   is false; one call when true; one call when absent; toast text for
+   `shiftCount > 0` and for `shiftCount === 0`.
+   Depends on task 1.
+
+3. **Add the checkbox and the conditional copy to the unpublish dialog.**
+   File: `src/pages/Scheduling.tsx`. Six edits:
+   - Add `const [unpublishNotify, setUnpublishNotify] = useState(true);`
+     next to `unpublishDialogOpen` at `:270`.
+   - Reset it to `true` when the dialog opens, the same as
+     `PublishScheduleDialog` does.
+   - Pass `notify: unpublishNotify` in the `unpublishSchedule.mutate` call
+     inside `handleUnpublishSchedule` at `:793`.
+   - Add the `Checkbox` and `Label` pair inside `AlertDialogContent`, with
+     `id="unpublish-notify-employees"`. Copy the markup shape from
+     `src/components/scheduling/PublishedShiftChangeDialog.tsx:70`.
+   - Replace the description at `:1786` with the two exact strings from the
+     design, chosen on `unpublishNotify`.
+   - Guard the action: `event.preventDefault()` plus
+     `disabled={unpublishSchedule.isPending}` on the action, the cancel, and
+     the checkbox. Copy `PublishedShiftChangeDialog.tsx:52` and `:85-86`.
+   - Change `text-lg` at `:1783` to `text-[17px]` and `text-sm` at `:1785`
+     to `text-[13px]`.
+   Tests: Playwright, task 9.
+   Depends on task 2.
+
+## Gap 2: collapse schedule email on restaurant and week
+
+4. **Add an optional `headers` parameter to `sendEmailResult`.**
+   File: `supabase/functions/_shared/emailQueue.ts:94`. Add the sixth
+   parameter `headers?: Record<string, string>`. Add it to the Resend body
+   at `:111` only when it holds at least one key.
+   Tests: `tests/unit/emailQueue.test.ts`. Three cases: five-argument call
+   sends no `headers` key; a filled object reaches the body; an empty object
+   sends no `headers` key. No dependency.
+
+5. **Create `scheduleEmailThread.ts`.**
+   New file `supabase/functions/_shared/scheduleEmailThread.ts`. Two
+   exports:
+   - `scheduleThreadHeaders(restaurantId, weekStartDate)` returns
+     `{ References, 'In-Reply-To' }` from the design's id format.
+   - `shiftBusinessDay(iso, timezone)` returns `YYYY-MM-DD` through
+     `Intl.DateTimeFormat('en-CA', { timeZone: safeTz(timezone) })`, or
+     `null` for a missing, non-string, or unparseable value.
+   Tests: new file `tests/unit/scheduleEmailThread.test.ts`. Cases: header
+   id format; a shift late in the evening lands on the correct business day
+   in `America/New_York`; an invalid timezone falls back and does not throw;
+   a missing `start_time` returns `null`. No dependency.
+
+6. **Thread the two schedule-level notifiers.**
+   Files: `supabase/functions/notify-schedule-published/index.ts:261` and
+   `supabase/functions/notify-schedule-unpublished/index.ts:267`. Build the
+   headers once, before the send loop. The publish function uses the payload
+   `restaurantId` and `weekStart` from `:55`. The unpublish function uses
+   `retraction.week_start_date` from `:260`.
+   Tests: task 5 covers the header builder. No unit test harness exists for
+   these two functions; state the manual check in the PR body.
+   Depends on tasks 4 and 5.
+
+7. **Fix the timezone and thread `notify-shift-changed`.**
+   File: `supabase/functions/notify-shift-changed/index.ts`. Three edits:
+   - Import `safeTz` and change `:170` to `safeTz(restaurant?.timezone)`.
+     This fixes a live crash: an invalid stored timezone already throws in
+     `buildShiftChangeMessage`
+     (`supabase/functions/_shared/shiftChangedNotification.ts:95`).
+   - Read the covering publication once, before the per-recipient loop at
+     `:180`. Use the bounded query from the design, with
+     `week_start_date >= day - 6 days`.
+   - Pass the headers into `sendEmailResult` at `:191`. No covering row and
+     no business day both mean no header. Never throw.
+   Tests: task 5 covers the pure parts.
+   Depends on tasks 4 and 5.
+
+## Gap 3: fix the in-product help
+
+8. **Rewrite four places in the help article.**
+   File: `src/content/help/scheduling-and-time/build-publish-weekly-schedule.md`.
+
+   **Line 76**, replace the whole note with:
+
+   > **Note:** A published shift stays editable. When you save a change to a
+   > published shift, a confirm dialog opens. The dialog names the employee
+   > who can see the shift. It also carries a **Notify employees** checkbox.
+   > Clear the checkbox to save the change with no email and no push.
+
+   **Line 151**, replace with:
+
+   > Publishing makes the schedule visible to all employees. It also notifies
+   > staff, unless you clear the **Notify employees** checkbox.
+
+   **After line 156**, add one step to the numbered list:
+
+   > 5. Clear **Notify employees about this schedule** to publish with no
+   >    notification. The box is checked each time the dialog opens.
+
+   **Lines 159 to 163**, replace the "Once published" list with:
+
+   > Once published:
+   > - The schedule is visible to your entire team.
+   > - Shifts stay editable. A change to a published shift asks you to
+   >   confirm first.
+   > - Staff receive a notification, unless you cleared the checkbox.
+   > - A status badge appears next to the week range showing the schedule is
+   >   published.
+
+   **Lines 167 to 174**, replace the whole section with:
+
+   > ## Unpublish the schedule to withdraw the week
+   >
+   > Unpublish takes the week back from your team. Use it when the whole week
+   > is wrong. To fix one shift, edit the shift in place — see
+   > [Edit or delete a single shift](#edit-or-delete-a-single-shift).
+   >
+   > 1. Click **Unpublish** in the toolbar. It shows only when the current
+   >    week is published.
+   > 2. Clear **Notify employees** to withdraw the week with no notification.
+   > 3. Confirm the action in the alert dialog.
+   >
+   > The week is no longer visible to your team. Publish again when it is
+   > ready.
+
+   The old heading anchor `#unpublish-the-schedule-to-make-corrections` dies
+   with this rename. The only link to it sits in the line 76 note, which this
+   task rewrites without that link. Grep the repo for the old anchor after the
+   edit and check that no reference is left.
+   Tests: none. This file is prose. No dependency.
+
+## Verification
+
+9. **Extend the E2E spec.**
+   File: `tests/e2e/schedule-quiet-publish-live-edit.spec.ts`. Add one test:
+   publish a week, then unpublish it with **Notify employees** clear. Check
+   three things: the checkbox is checked when the dialog opens; the week
+   returns to the unpublished state; the toast names the shift count and says
+   nobody was notified. Reuse `publishWeek`, `seedEmployeeAndShift`, and
+   `exposeSupabaseHelpers`.
+   Depends on task 3.
+
+10. **Run the gates.**
+    `npm run typecheck`, `npm run lint`, `npm run test`, then the E2E spec.
+
+## Out of scope
+
+- No coalesce timer. The design records why.
+- No GiST index and no migration. The design records why.
+- No change to any employee-facing email subject or body. Commits `790718c1`
+  and `809f1b9c` set that copy.

--- a/docs/superpowers/specs/2026-08-18-schedule-notification-residue-design.md
+++ b/docs/superpowers/specs/2026-08-18-schedule-notification-residue-design.md
@@ -44,7 +44,7 @@ whenever `shiftCount > 0`. There is no flag to stop it.
 four fields. `notify` is not one of them.
 
 Publish got the choice at `src/components/PublishScheduleDialog.tsx:176`.
-Unpublish did not. The unpublish dialog at `src/pages/Scheduling.tsx:1787`
+Unpublish did not. The unpublish dialog at `src/pages/Scheduling.tsx:1786`
 promises "and notify employees that the schedule has changed" with no way to
 decline.
 
@@ -110,18 +110,59 @@ This copies the publish pattern at `src/hooks/useSchedulePublish.tsx:274`.
 That description drops the shift count the manager needs. Add an optional
 `skippedDescription` to `NotificationToastCopy`, next to `successDescription`.
 The `skipped` branch uses it when present, and keeps the current string when
-absent. The unpublish call site at `src/hooks/useSchedulePublish.tsx:367`
-passes "N shifts have been unlocked for editing. Nobody was notified."
+absent.
+
+The `skipped` status wins before the code reads `shiftCount`, so
+`skippedDescription` needs its own zero case. This matches the two-branch
+`successDescription` at `src/hooks/useSchedulePublish.tsx:367`. The call site
+passes:
+
+```ts
+skippedDescription: shiftCount > 0
+  ? `${shiftCount} shift${shiftCount !== 1 ? 's' : ''} are unlocked for editing. Nobody was notified.`
+  : 'Nothing was published for this week, so nothing changed.',
+```
 
 **UI.** Add a checkbox to the unpublish `AlertDialog` at
-`src/pages/Scheduling.tsx:1776`. Mirror `src/components/PublishScheduleDialog.tsx:174`:
-`Checkbox` plus `Label`, checked by default.
+`src/pages/Scheduling.tsx:1776`.
 
-Reset it to `true` when the dialog opens, the same as
+Copy the `AlertDialog` precedent, not the `Dialog` one.
+`src/components/PublishScheduleDialog.tsx:176` sits in a plain `Dialog`.
+`src/components/scheduling/PublishedShiftChangeDialog.tsx` is the correct
+model: it is an `AlertDialog` with a `Checkbox`, from the same #756 change.
+Copy three details from it:
+
+1. `event.preventDefault()` in the confirm handler
+   (`src/components/scheduling/PublishedShiftChangeDialog.tsx:52`). Radix
+   closes an `AlertDialogAction` on click. The unpublish mutation waits up to
+   `NOTIFICATION_TIMEOUT_MS` (`src/hooks/useSchedulePublish.tsx:72`), so an
+   auto-close hides the work in progress.
+2. `disabled={unpublishSchedule.isPending}` on the action, the cancel, and the
+   checkbox (`PublishedShiftChangeDialog.tsx:74`, `:85`, `:86`). The current
+   action at `src/pages/Scheduling.tsx:1792` has no such guard.
+3. A distinct checkbox `id`. Use `unpublish-notify-employees`, next to the
+   existing `published-shift-change-notify`
+   (`PublishedShiftChangeDialog.tsx:71`) and `publish-notify-employees`
+   (`src/components/PublishScheduleDialog.tsx:177`).
+
+Reset the checkbox to `true` when the dialog opens, the same as
 `PublishScheduleDialog` does for its own checkbox.
 
-Make the description at `src/pages/Scheduling.tsx:1787` conditional. It must
-not promise a notification the manager declined.
+**Handler.** `handleUnpublishSchedule` at `src/pages/Scheduling.tsx:793` calls
+`unpublishSchedule.mutate` with four fields. Pass the new checkbox value as a
+fifth field, `notify`. Without this step the checkbox changes nothing.
+
+**Dialog copy.** The description at `src/pages/Scheduling.tsx:1786` promises a
+notification. Make it conditional. Use these two exact strings:
+
+- Notify checked: "This unlocks every shift in the week and tells the
+  scheduled employees that the week is being revised."
+- Notify clear: "This unlocks every shift in the week. Nobody is notified."
+
+**Typography.** The block already breaks the CLAUDE.md scale:
+`src/pages/Scheduling.tsx:1783` uses `text-lg` for the title and `:1785` uses
+`text-sm` for the description. Change them to `text-[17px]` and `text-[13px]`
+while this block is open.
 
 **No RPC change.** `unpublish_schedule` still runs on both paths. The flag
 gates the edge-function invoke only, in the client. No pgTAP test applies.
@@ -131,6 +172,12 @@ gates the edge-function invoke only, in the client. No pgTAP test applies.
 **Mechanism.** RFC 5322 `References` and `In-Reply-To` headers. A mail client
 groups messages that share a `References` chain. This is the email equal of
 the push `tag`.
+
+Resend supports this. The `POST /emails` body accepts a `headers` object,
+described as "Custom headers to add to the email"
+(https://resend.com/docs/api-reference/emails/send-email). The Resend
+changelog names `In-Reply-To` and `References` as the threading use for that
+field (https://resend.com/changelog/custom-email-headers).
 
 **New shared module** `supabase/functions/_shared/scheduleEmailThread.ts`:
 
@@ -155,7 +202,9 @@ arguments and keeps its behavior.
 **Call sites.**
 
 1. `supabase/functions/notify-schedule-published/index.ts:261` — the function
-   already holds `restaurantId` and the publication row.
+   destructures `restaurantId` and `weekStart` from the request payload at
+   `supabase/functions/notify-schedule-published/index.ts:55`. Both values are
+   in scope. The function reads no publication row.
 2. `supabase/functions/notify-schedule-unpublished/index.ts:267` — use
    `retraction.week_start_date`, read at
    `supabase/functions/notify-schedule-unpublished/index.ts:260`.
@@ -167,28 +216,71 @@ column. `supabase/migrations/20251123000000_schedule_publishing.sql:23` lists
 its columns.
 
 Do not re-derive the week from the shift date. The codebase holds two week
-conventions: `src/pages/Scheduling.tsx:291` uses `weekStartsOn: 1`, and
-`src/hooks/usePeriodNavigation.ts:32` uses a `WEEK_STARTS_ON` constant. A
-re-derived week can miss the stored one.
+constants: `src/pages/Scheduling.tsx:291` uses a literal `weekStartsOn: 1`, and
+`src/hooks/usePeriodNavigation.ts:32` uses `WEEK_STARTS_ON`. Both resolve to
+`1` today (`src/lib/dateConfig.ts:8`), so a re-derived week is correct now. A
+change to the constant would break it silently. Read the stored value instead.
 
-Read the stored value instead. `publish_schedule` buckets a shift into a week
-with `(s.start_time AT TIME ZONE v_tz)::date` between `p_week_start` and
+`publish_schedule` buckets a shift into a week with
+`(s.start_time AT TIME ZONE v_tz)::date` between `p_week_start` and
 `p_week_end`, at
 `supabase/migrations/20260729120000_publish_schedule_tz_bucketing.sql:101`.
 
 So:
 
 1. Take the shift start from `after_data.start_time`, or `before_data.start_time`
-   for a delete. `supabase/migrations/20251123000000_schedule_publishing.sql:114`
-   writes `row_to_json(OLD)` and `row_to_json(NEW)` into those columns.
+   for a delete. `supabase/migrations/20251123000000_schedule_publishing.sql:134`
+   and `:153` write both `row_to_json(OLD)` and `row_to_json(NEW)` for an
+   update. `:114` writes only `row_to_json(OLD)`, because a delete has no NEW.
 2. Convert it to the restaurant business day with `Intl.DateTimeFormat` and the
-   `en-CA` locale, which gives `YYYY-MM-DD`. The function already reads
-   `restaurant.timezone` at
-   `supabase/functions/notify-shift-changed/index.ts:170`.
-3. Select the covering publication:
-   `.eq('restaurant_id', ...).lte('week_start_date', day).gte('week_end_date', day)`,
-   ordered by `published_at` descending, limit 1.
+   `en-CA` locale, which gives `YYYY-MM-DD`.
+3. Select the covering publication.
 4. No row found means no thread header. Send the email with no header.
+5. A missing or non-string `start_time` also means no thread header. Send the
+   email with no header. Never throw.
+
+**Timezone safety.** `supabase/functions/notify-shift-changed/index.ts:170`
+reads `restaurant?.timezone || "UTC"`. This guards an empty value, not an
+invalid one. `supabase/functions/_shared/timezone.ts:22` records the lesson: an
+invalid IANA string makes `Intl.DateTimeFormat` throw a `RangeError`.
+
+This is a live defect, not a new one. `buildShiftChangeMessage` already passes
+that value to `toLocaleString` at
+`supabase/functions/_shared/shiftChangedNotification.ts:95` and `:103`. A bad
+stored timezone therefore aborts the whole invocation today, and kills the push
+as well as the email.
+
+Fix it. Route the value through `safeTz` from
+`supabase/functions/_shared/timezone.ts:25`, the same way
+`supabase/functions/notify-schedule-published/index.ts:120` does. The new
+business-day conversion then reuses the validated value.
+
+**Index cost.** The lookup query is:
+
+```ts
+.eq('restaurant_id', restaurantId)
+.gte('week_start_date', minWeekStart)   // day minus 6 days
+.lte('week_start_date', day)
+.gte('week_end_date', day)
+.order('published_at', { ascending: false })
+.limit(1)
+```
+
+The lower bound on `week_start_date` is the important part. Without it,
+Postgres scans every publication of that restaurant with
+`week_start_date <= day`, which grows one row per published week forever.
+
+The bound is safe by a database rule, not by convention. A trigger rejects any
+`schedule_publications` row whose span is negative or longer than 6 days
+(`supabase/migrations/20260727180000_schedule_publication_range_check.sql:29`).
+A publication that covers `day` therefore always has
+`week_start_date >= day - 6 days`.
+
+With the bound, the existing composite index
+`idx_schedule_publications_week_lookup (restaurant_id, week_start_date, published_at DESC)`
+(`supabase/migrations/20260802120000_schedule_retractions.sql:44`) serves the
+query as a range scan over at most 7 days of publications. No new
+index and no migration are needed.
 
 The lookup runs once per invocation, before the per-recipient loop, not once
 per recipient.
@@ -206,6 +298,9 @@ Rewrite four places in
   unpublishing" with the confirm-dialog behavior.
 - **Lines 167 to 175** — rewrite the unpublish section. Unpublish now means
   "withdraw the week", not "the way to edit". Add the new Notify checkbox.
+
+The plan holds the exact replacement text. This file is manager-only: its front
+matter sets `audience: ["owner", "manager"]` at line 5, so no employee reads it.
 
 ## 4. Employee-facing copy
 
@@ -250,14 +345,51 @@ a republish follows soon after. That fallback applied only if the lock stayed.
 The lock is gone, so unpublish is now rare. A defer timer would need a queue and
 a cron drain for one rare event. Rejected as cost without benefit.
 
+**A bounded range scan, not a GiST containment index.** The Supabase reviewer
+offered a GiST index on `daterange(week_start_date, week_end_date, '[]')` as the
+stronger fix. That is rejected for this change. It needs a migration and a pgTAP
+test for one lookup that runs once per shift edit, over at most 7 days of one
+restaurant's rows. The `week_start_date` lower bound gives the same bounded scan
+with no schema change. Revisit the GiST index if this lookup ever runs per
+recipient or per row of a batch.
+
 ## 6. Tests
 
 | Change | Test | File |
 |---|---|---|
 | `notify` flag on unpublish | Vitest | `tests/unit/useSchedulePublish.test.ts` |
-| `skippedDescription` in `notificationToast` | Vitest | `tests/unit/useSchedulePublish.test.ts` |
+| `skippedDescription`, both shift-count cases | Vitest | `tests/unit/useSchedulePublish.test.ts` |
 | `scheduleThreadHeaders` key format | Vitest | `tests/unit/scheduleEmailThread.test.ts` |
-| `sendEmailResult` forwards headers | Vitest | `tests/unit/scheduleEmailThread.test.ts` |
+| `sendEmailResult` forwards headers, and omits an empty object | Vitest | `tests/unit/emailQueue.test.ts` |
+| Business day from an invalid timezone falls back, never throws | Vitest | `tests/unit/scheduleEmailThread.test.ts` |
+| Missing `start_time` returns no header | Vitest | `tests/unit/scheduleEmailThread.test.ts` |
 | Unpublish notify checkbox | Playwright | `tests/e2e/schedule-quiet-publish-live-edit.spec.ts` |
 
 No pgTAP test. No RPC and no migration changes in this work.
+
+## 7. Review record
+
+Phase 2.5 ran two reviewers. Both passed the premise check with no critical
+finding. Every major concern is fixed in the text above.
+
+**`supabase-design-reviewer`**
+
+- major, week lookup had no covering index — fixed. See "Index cost".
+- major, no timezone validation — fixed. See "Timezone safety".
+- minor, `schedule_publishing.sql:114` citation named the wrong branch — fixed.
+- minor, `Scheduling.tsx:1787` was one line off — fixed to `:1786`.
+- minor, `notify-schedule-published` holds no publication row — fixed.
+- minor, missing `start_time` case was undefined — fixed.
+- minor, Resend `headers` support was unverified — fixed with two citations.
+
+**`frontend-design-reviewer`**
+
+- major, `handleUnpublishSchedule` was not named — fixed. See "Handler".
+- major, the conditional dialog copy was not written out — fixed. See
+  "Dialog copy".
+- major, the design pointed at a `Dialog` precedent for an `AlertDialog` —
+  fixed. See "UI", which now copies `PublishedShiftChangeDialog`.
+- minor, no checkbox `id` — fixed to `unpublish-notify-employees`.
+- minor, `text-lg` and `text-sm` break the CLAUDE.md scale — fixed.
+- minor, `skippedDescription` had no zero-shift case — fixed.
+- minor, Gap 3 gave no replacement text — deferred to the plan, and stated.

--- a/docs/superpowers/specs/2026-08-18-schedule-notification-residue-design.md
+++ b/docs/superpowers/specs/2026-08-18-schedule-notification-residue-design.md
@@ -1,0 +1,263 @@
+# Design: close the three gaps left after the quiet-publish change
+
+Date: 2026-08-18
+Branch: `claude/confident-lewin-8e0379`
+
+## 1. The task premise is out of date
+
+The task asks for a fix that is already on `main`.
+
+Commit `26e9e296` ("feat(scheduling): quiet publish and live edit of published
+shifts (#756)") merged on 2026-08-15. It removed the lock:
+
+- `src/hooks/usePublishedShiftGuard.tsx:1` holds the guard hook. It reads
+  `shifts.locked` fresh, then opens a confirm dialog for a published shift.
+- `src/components/scheduling/PublishedShiftChangeDialog.tsx:1` holds that
+  dialog. It carries a Notify checkbox.
+- `supabase/functions/notify-shift-changed/index.ts:1` sends one email that
+  names the change.
+- `src/hooks/useSchedulePublish.tsx:274` skips the publish email when the
+  manager clears the Notify checkbox.
+
+The two lines the task quotes no longer exist:
+
+- `src/components/PublishScheduleDialog.tsx:151` now reads
+  "Editable — a change to a published shift asks you to confirm first".
+- `src/components/ShiftDialog.tsx` has no "Shift is Locked" banner. Commit
+  `fd7d765b` deleted it.
+
+The employee copy constraint is also already met. Commit `790718c1` deleted the
+"Schedule not published yet" alert and the "Draft — not confirmed" badge.
+Commit `809f1b9c` deleted the retraction alert. `src/components/employee/ShiftRow.tsx:98`
+now carries a hue and a screen-reader-only "Draft" label, with no text badge.
+
+## 2. What is still broken
+
+Three gaps remain. The user approved all three.
+
+### Gap 1 — Unpublish has no notify choice
+
+`src/hooks/useSchedulePublish.tsx:341` invokes `notify-schedule-unpublished`
+whenever `shiftCount > 0`. There is no flag to stop it.
+
+`src/hooks/useSchedulePublish.tsx:21` defines `UnpublishScheduleParams` with
+four fields. `notify` is not one of them.
+
+Publish got the choice at `src/components/PublishScheduleDialog.tsx:176`.
+Unpublish did not. The unpublish dialog at `src/pages/Scheduling.tsx:1787`
+promises "and notify employees that the schedule has changed" with no way to
+decline.
+
+### Gap 2 — Email does not collapse
+
+Push collapses. Each function passes a `tag`:
+
+- `supabase/functions/notify-schedule-published/index.ts:305` — `"schedule-published"`
+- `supabase/functions/notify-schedule-unpublished/index.ts:310` — `"schedule-unpublished"`
+- `supabase/functions/notify-shift-changed/index.ts:213` — `` `shift-changed-${row.shift_id}-${employee.id}` ``
+
+Email does not. `supabase/functions/_shared/emailQueue.ts:94` defines
+`sendEmailResult(resendApiKey, from, to, subject, html)`. It posts
+`{ from, to, subject, html }` to Resend at
+`supabase/functions/_shared/emailQueue.ts:111`. There is no header field, so
+each message stands alone in the inbox.
+
+Five edits to one published week therefore send five separate
+`notify-shift-changed` emails per employee.
+
+### Gap 3 — The in-product help still teaches the deleted workflow
+
+`src/content/help/scheduling-and-time/build-publish-weekly-schedule.md:76`
+says the save button is disabled and "You must unpublish the schedule first".
+
+Line 160 says "All shifts are locked and cannot be edited without unpublishing."
+
+Line 167 heads a section "Unpublish the schedule to make corrections", and
+line 169 opens it with "If you need to edit shifts after publishing:".
+
+Line 151 says publishing "sends push notifications to staff", with no mention
+of the Notify checkbox that `src/components/PublishScheduleDialog.tsx:176`
+added.
+
+A manager who reads this help still runs the unpublish/republish cycle that
+#756 deleted. This is the closest live match to the owner feedback.
+
+## 3. The fix
+
+### Gap 1 — Add `notify` to unpublish
+
+**Hook.** Add `notify?: boolean` to `UnpublishScheduleParams`
+(`src/hooks/useSchedulePublish.tsx:21`). Default it to `true` in the
+`mutationFn` signature, so every existing caller keeps its behavior.
+
+Gate the invoke at `src/hooks/useSchedulePublish.tsx:341`:
+
+```ts
+const notification: NotificationOutcome =
+  !notify
+    ? { status: 'skipped' }
+    : shiftCount > 0
+      ? await invokeScheduleNotification('notify-schedule-unpublished', { ... })
+      : { status: 'sent', sent: 0 };
+```
+
+This copies the publish pattern at `src/hooks/useSchedulePublish.tsx:274`.
+
+**Toast.** `notificationToast` already handles `skipped` at
+`src/hooks/useSchedulePublish.tsx:183`. It returns the plain title and
+"No notifications were sent."
+
+That description drops the shift count the manager needs. Add an optional
+`skippedDescription` to `NotificationToastCopy`, next to `successDescription`.
+The `skipped` branch uses it when present, and keeps the current string when
+absent. The unpublish call site at `src/hooks/useSchedulePublish.tsx:367`
+passes "N shifts have been unlocked for editing. Nobody was notified."
+
+**UI.** Add a checkbox to the unpublish `AlertDialog` at
+`src/pages/Scheduling.tsx:1776`. Mirror `src/components/PublishScheduleDialog.tsx:174`:
+`Checkbox` plus `Label`, checked by default.
+
+Reset it to `true` when the dialog opens, the same as
+`PublishScheduleDialog` does for its own checkbox.
+
+Make the description at `src/pages/Scheduling.tsx:1787` conditional. It must
+not promise a notification the manager declined.
+
+**No RPC change.** `unpublish_schedule` still runs on both paths. The flag
+gates the edge-function invoke only, in the client. No pgTAP test applies.
+
+### Gap 2 — Thread schedule email on restaurant and week
+
+**Mechanism.** RFC 5322 `References` and `In-Reply-To` headers. A mail client
+groups messages that share a `References` chain. This is the email equal of
+the push `tag`.
+
+**New shared module** `supabase/functions/_shared/scheduleEmailThread.ts`:
+
+```ts
+export const scheduleThreadHeaders = (
+  restaurantId: string,
+  weekStartDate: string,
+): Record<string, string> => {
+  const id = `<schedule-${restaurantId}-${weekStartDate}@easyshifthq.com>`;
+  return { References: id, 'In-Reply-To': id };
+};
+```
+
+The key is `restaurant_id` plus `week_start_date`, as the task asks.
+
+**Sender change.** Add an optional sixth parameter `headers` to
+`sendEmailResult` at `supabase/functions/_shared/emailQueue.ts:94`. Forward it
+into the Resend request body at `supabase/functions/_shared/emailQueue.ts:111`
+only when it holds at least one key. Every current caller passes five
+arguments and keeps its behavior.
+
+**Call sites.**
+
+1. `supabase/functions/notify-schedule-published/index.ts:261` — the function
+   already holds `restaurantId` and the publication row.
+2. `supabase/functions/notify-schedule-unpublished/index.ts:267` — use
+   `retraction.week_start_date`, read at
+   `supabase/functions/notify-schedule-unpublished/index.ts:260`.
+3. `supabase/functions/notify-shift-changed/index.ts:191` — the row has no
+   week. Resolve it, see below.
+
+**Week lookup for `notify-shift-changed`.** `schedule_change_logs` has no week
+column. `supabase/migrations/20251123000000_schedule_publishing.sql:23` lists
+its columns.
+
+Do not re-derive the week from the shift date. The codebase holds two week
+conventions: `src/pages/Scheduling.tsx:291` uses `weekStartsOn: 1`, and
+`src/hooks/usePeriodNavigation.ts:32` uses a `WEEK_STARTS_ON` constant. A
+re-derived week can miss the stored one.
+
+Read the stored value instead. `publish_schedule` buckets a shift into a week
+with `(s.start_time AT TIME ZONE v_tz)::date` between `p_week_start` and
+`p_week_end`, at
+`supabase/migrations/20260729120000_publish_schedule_tz_bucketing.sql:101`.
+
+So:
+
+1. Take the shift start from `after_data.start_time`, or `before_data.start_time`
+   for a delete. `supabase/migrations/20251123000000_schedule_publishing.sql:114`
+   writes `row_to_json(OLD)` and `row_to_json(NEW)` into those columns.
+2. Convert it to the restaurant business day with `Intl.DateTimeFormat` and the
+   `en-CA` locale, which gives `YYYY-MM-DD`. The function already reads
+   `restaurant.timezone` at
+   `supabase/functions/notify-shift-changed/index.ts:170`.
+3. Select the covering publication:
+   `.eq('restaurant_id', ...).lte('week_start_date', day).gte('week_end_date', day)`,
+   ordered by `published_at` descending, limit 1.
+4. No row found means no thread header. Send the email with no header.
+
+The lookup runs once per invocation, before the per-recipient loop, not once
+per recipient.
+
+### Gap 3 — Fix the help doc
+
+Rewrite four places in
+`src/content/help/scheduling-and-time/build-publish-weekly-schedule.md`:
+
+- **Line 76** — replace the lock note. A published shift now opens a confirm
+  dialog with a Notify checkbox.
+- **Line 151** — say that publishing notifies staff when the Notify checkbox
+  stays checked.
+- **Line 160** — replace "All shifts are locked and cannot be edited without
+  unpublishing" with the confirm-dialog behavior.
+- **Lines 167 to 175** — rewrite the unpublish section. Unpublish now means
+  "withdraw the week", not "the way to edit". Add the new Notify checkbox.
+
+## 4. Employee-facing copy
+
+The constraint from commits `790718c1` and `809f1b9c`: employee copy must never
+read as "your shifts are not real".
+
+This change writes no new employee copy. It adds headers to existing emails and
+adds a manager-facing checkbox and help text.
+
+The unpublish subject at
+`supabase/functions/notify-schedule-unpublished/index.ts:271` stays as it is.
+`supabase/migrations/20260802120000_schedule_retractions.sql:1` holds the
+retraction design that set it. A retraction email only goes out after a real
+publish, so it corrects a wrong belief. That is the same reason `790718c1`
+gave for keeping the retraction alert at the time.
+
+## 5. Decided trade-offs
+
+**Threading does not force one thread across every event type.** Gmail groups
+on the `References` chain and on a matching subject. The four subjects differ:
+
+- `supabase/functions/notify-schedule-published/index.ts:267` — "New Schedule Published: ..."
+- `supabase/functions/notify-schedule-published/index.ts:266` — "Updated Schedule: ... — changes made"
+- `supabase/functions/notify-schedule-unpublished/index.ts:271` — "Schedule update: ... is being revised"
+- `supabase/functions/notify-shift-changed/index.ts:195` — "{title} - {restaurant}"
+
+Apple Mail, Outlook, and Thunderbird thread on `References` alone, so all four
+collapse there. Gmail collapses repeated messages of the same kind, because
+those share a subject.
+
+The storm case is repeated edits to one week. Those all send
+"Shift Updated - {restaurant}", one subject, so they collapse in Gmail too.
+
+The alternative is one stable subject for all four kinds. That is rejected: the
+subject is the only part an employee reads in a notification list, and a shared
+subject would hide whether the week was published, withdrawn, or moved by an
+hour. Losing that distinction is the failure mode commits `790718c1` and
+`809f1b9c` fixed.
+
+**No coalesce timer.** The task's fallback asked to hold the unpublish mail when
+a republish follows soon after. That fallback applied only if the lock stayed.
+The lock is gone, so unpublish is now rare. A defer timer would need a queue and
+a cron drain for one rare event. Rejected as cost without benefit.
+
+## 6. Tests
+
+| Change | Test | File |
+|---|---|---|
+| `notify` flag on unpublish | Vitest | `tests/unit/useSchedulePublish.test.ts` |
+| `skippedDescription` in `notificationToast` | Vitest | `tests/unit/useSchedulePublish.test.ts` |
+| `scheduleThreadHeaders` key format | Vitest | `tests/unit/scheduleEmailThread.test.ts` |
+| `sendEmailResult` forwards headers | Vitest | `tests/unit/scheduleEmailThread.test.ts` |
+| Unpublish notify checkbox | Playwright | `tests/e2e/schedule-quiet-publish-live-edit.spec.ts` |
+
+No pgTAP test. No RPC and no migration changes in this work.

--- a/src/content/help/scheduling-and-time/build-publish-weekly-schedule.md
+++ b/src/content/help/scheduling-and-time/build-publish-weekly-schedule.md
@@ -73,7 +73,10 @@ If the employee has a time-off request or availability conflict for the chosen t
 **To delete:**
 - Click the **trash icon** that appears when you hover over a shift card. Confirm the deletion in the alert that appears.
 
-> **Note:** If a shift belongs to a published schedule, it is locked. The dialog shows a "Shift is Locked" warning and the save button is disabled. You must unpublish the schedule first (see [Unpublish the schedule](#unpublish-the-schedule-to-make-corrections) below).
+> **Note:** A published shift stays editable. When you save a change to a
+> published shift, a confirm dialog opens. The dialog names the employee
+> who can see the shift. It also carries a **Notify employees** checkbox.
+> Clear the checkbox to save the change with no email and no push.
 
 ---
 
@@ -148,30 +151,40 @@ Use **Import** to bulk-add shifts from a spreadsheet export.
 
 ## Publish the schedule
 
-Publishing makes the schedule visible to all employees and sends push notifications to staff.
+Publishing makes the schedule visible to all employees. It also notifies
+staff, unless you clear the **Notify employees** checkbox.
 
 1. Click **Publish** in the toolbar. The button is disabled if there are no shifts on the current week.
 2. The **Publish Schedule** dialog shows a summary: the number of shifts, employees scheduled, and total hours for the week.
 3. If any open shift slots still need staff, a warning appears in the dialog.
 4. Optionally add notes in the **Notes** field (for example, "Holiday weekend — extra coverage needed").
-5. Click **Publish Schedule** to confirm.
+5. Clear **Notify employees about this schedule** to publish with no
+   notification. The box is checked each time the dialog opens.
+6. Click **Publish Schedule** to confirm.
 
 Once published:
-- All shifts are locked and cannot be edited without unpublishing.
 - The schedule is visible to your entire team.
-- Staff receive a push notification.
-- A status badge appears next to the week range showing the schedule is published.
+- Shifts stay editable. A change to a published shift asks you to
+  confirm first.
+- Staff receive a notification, unless you cleared the checkbox.
+- A status badge appears next to the week range showing the schedule is
+  published.
 
 ---
 
-## Unpublish the schedule to make corrections
+## Unpublish the schedule to withdraw the week
 
-If you need to edit shifts after publishing:
+Unpublish takes the week back from your team. Use it when the whole week
+is wrong. To fix one shift, edit the shift in place — see
+[Edit or delete a single shift](#edit-or-delete-a-single-shift).
 
-1. Click **Unpublish** in the toolbar (visible only when the current week is published).
-2. Confirm the action in the alert dialog.
+1. Click **Unpublish** in the toolbar. It shows only when the current
+   week is published.
+2. Clear **Notify employees** to withdraw the week with no notification.
+3. Confirm the action in the alert dialog.
 
-All shifts for that week are unlocked. Make your corrections, then publish again when ready.
+The week is no longer visible to your team. Publish again when it is
+ready.
 
 ---
 

--- a/src/content/help/scheduling-and-time/build-publish-weekly-schedule.md
+++ b/src/content/help/scheduling-and-time/build-publish-weekly-schedule.md
@@ -180,7 +180,8 @@ is wrong. To fix one shift, edit the shift in place — see
 
 1. Click **Unpublish** in the toolbar. It shows only when the current
    week is published.
-2. Clear **Notify employees** to withdraw the week with no notification.
+2. Clear **Notify scheduled employees** to withdraw the week with no
+   notification.
 3. Confirm the action in the alert dialog.
 
 The week is no longer visible to your team. Publish again when it is
@@ -223,8 +224,10 @@ After publishing, every shift creation, edit, and deletion is recorded.
 **The Publish button is grayed out.**
 There are no shifts on the current week. Add at least one shift before publishing.
 
-**A shift card shows "Shift is Locked" when I try to edit it.**
-The schedule for that week has already been published. Click **Unpublish** in the toolbar, make your edits, then publish again.
+**A "This shift is published" dialog appears when I save an edit.**
+This is expected — a published shift stays editable. Click **Save
+change** to confirm. Clear the notify checkbox first if you do not want
+to email or push-notify the employee about this one change.
 
 **Copy Week is grayed out.**
 The current week has no shifts to copy. Build the schedule first, then use Copy Week.

--- a/src/hooks/useSchedulePublish.tsx
+++ b/src/hooks/useSchedulePublish.tsx
@@ -23,6 +23,11 @@ interface UnpublishScheduleParams {
   weekStart: Date;
   weekEnd: Date;
   reason?: string;
+  /**
+   * Whether to notify employees. Defaults to true when absent, so every
+   * existing caller keeps its current behaviour without a change.
+   */
+  notify?: boolean;
 }
 
 /**
@@ -319,7 +324,13 @@ export const useUnpublishSchedule = () => {
   const { toast } = useToast();
 
   return useMutation({
-    mutationFn: async ({ restaurantId, weekStart, weekEnd, reason }: UnpublishScheduleParams) => {
+    mutationFn: async ({
+      restaurantId,
+      weekStart,
+      weekEnd,
+      reason,
+      notify = true,
+    }: UnpublishScheduleParams) => {
       // Format dates as YYYY-MM-DD (local calendar day, not UTC)
       const weekStartStr = formatLocalDate(weekStart);
       const weekEndStr = formatLocalDate(weekEnd);
@@ -341,8 +352,11 @@ export const useUnpublishSchedule = () => {
 
       // Nothing was actually retracted, so there is nobody to tell. Skipping
       // the invoke keeps a double-tap on Unpublish off the error path.
-      const notification: NotificationOutcome =
-        shiftCount > 0
+      // `notify: false` is a quiet unpublish -- the caller chose not to tell
+      // employees, so the invoke never happens, same as usePublishSchedule.
+      const notification: NotificationOutcome = !notify
+        ? { status: 'skipped' }
+        : shiftCount > 0
           ? await invokeScheduleNotification('notify-schedule-unpublished', {
               restaurantId,
               weekStart: weekStartStr,
@@ -371,6 +385,13 @@ export const useUnpublishSchedule = () => {
             shiftCount > 0
               ? `${shiftCount} shift${shiftCount !== 1 ? 's' : ''} have been unlocked for editing. Affected employees have been told the week is being revised.`
               : 'Nothing was published for this week, so no shifts changed and nobody was notified.',
+          // The 'skipped' status wins before shiftCount is read, so this needs
+          // its own zero case -- same reason as successDescription above, but
+          // for `notify: false` instead of the fan-out having nobody to reach.
+          skippedDescription:
+            shiftCount > 0
+              ? `${shiftCount} shift${shiftCount !== 1 ? 's' : ''} are unlocked for editing. Nobody was notified.`
+              : 'Nothing was published for this week, so nothing changed.',
         }),
       );
     },

--- a/src/hooks/useSchedulePublish.tsx
+++ b/src/hooks/useSchedulePublish.tsx
@@ -5,6 +5,7 @@ import { SchedulePublication, Shift } from '@/types/scheduling';
 import { useToast } from '@/hooks/use-toast';
 import { formatLocalDate } from '@/lib/shiftInterval';
 import { safeTz } from '@/lib/restaurantClock';
+import { pluralize } from '@/lib/scheduling/deletionCopy';
 
 interface PublishScheduleParams {
   restaurantId: string;
@@ -393,7 +394,7 @@ export const useUnpublishSchedule = () => {
           // for `notify: false` instead of the fan-out having nobody to reach.
           skippedDescription:
             shiftCount > 0
-              ? `${shiftCount} shift${shiftCount !== 1 ? 's' : ''} ${shiftCount !== 1 ? 'are' : 'is'} unlocked for editing. Nobody was notified.`
+              ? `${shiftCount} ${pluralize(shiftCount, 'shift is', 'shifts are')} unlocked for editing. Nobody was notified.`
               : 'Nothing was published for this week, so nothing changed.',
         }),
       );

--- a/src/hooks/useSchedulePublish.tsx
+++ b/src/hooks/useSchedulePublish.tsx
@@ -155,6 +155,11 @@ async function invokeAndInterpret(
 interface NotificationToastCopy {
   title: string;
   successDescription: string;
+  /**
+   * Description for the 'skipped' outcome. When absent, the toast uses
+   * "No notifications were sent."
+   */
+  skippedDescription?: string;
 }
 
 interface ToastPayload {
@@ -171,7 +176,7 @@ interface ToastPayload {
  */
 export function notificationToast(
   outcome: NotificationOutcome,
-  { title, successDescription }: NotificationToastCopy,
+  { title, successDescription, skippedDescription }: NotificationToastCopy,
 ): ToastPayload {
   switch (outcome.status) {
     case 'sent':
@@ -181,7 +186,7 @@ export function notificationToast(
     // '-- some/nobody notified' destructive copy used for a fan-out that
     // tried and fell short.
     case 'skipped':
-      return { title, description: 'No notifications were sent.' };
+      return { title, description: skippedDescription ?? 'No notifications were sent.' };
     case 'partial':
       return {
         title: `${title} — some employees not notified`,

--- a/src/hooks/useSchedulePublish.tsx
+++ b/src/hooks/useSchedulePublish.tsx
@@ -393,7 +393,7 @@ export const useUnpublishSchedule = () => {
           // for `notify: false` instead of the fan-out having nobody to reach.
           skippedDescription:
             shiftCount > 0
-              ? `${shiftCount} shift${shiftCount !== 1 ? 's' : ''} are unlocked for editing. Nobody was notified.`
+              ? `${shiftCount} shift${shiftCount !== 1 ? 's' : ''} ${shiftCount !== 1 ? 'are' : 'is'} unlocked for editing. Nobody was notified.`
               : 'Nothing was published for this week, so nothing changed.',
         }),
       );

--- a/src/hooks/useSchedulePublish.tsx
+++ b/src/hooks/useSchedulePublish.tsx
@@ -354,14 +354,17 @@ export const useUnpublishSchedule = () => {
       // the invoke keeps a double-tap on Unpublish off the error path.
       // `notify: false` is a quiet unpublish -- the caller chose not to tell
       // employees, so the invoke never happens, same as usePublishSchedule.
-      const notification: NotificationOutcome = !notify
-        ? { status: 'skipped' }
-        : shiftCount > 0
-          ? await invokeScheduleNotification('notify-schedule-unpublished', {
-              restaurantId,
-              weekStart: weekStartStr,
-            })
-          : { status: 'sent', sent: 0 };
+      let notification: NotificationOutcome;
+      if (!notify) {
+        notification = { status: 'skipped' };
+      } else if (shiftCount > 0) {
+        notification = await invokeScheduleNotification('notify-schedule-unpublished', {
+          restaurantId,
+          weekStart: weekStartStr,
+        });
+      } else {
+        notification = { status: 'sent', sent: 0 };
+      }
 
       return { shiftCount, restaurantId, notification };
     },

--- a/src/pages/Scheduling.tsx
+++ b/src/pages/Scheduling.tsx
@@ -7,6 +7,8 @@ import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
 import { useRestaurantContext } from '@/contexts/RestaurantContext';
 import { useRestaurantClock } from '@/hooks/useRestaurantClock';
 import { useEmployees } from '@/hooks/useEmployees';
@@ -268,6 +270,7 @@ const Scheduling = () => {
   const [publishDialogOpen, setPublishDialogOpen] = useState(false);
   const [changeLogDialogOpen, setChangeLogDialogOpen] = useState(false);
   const [unpublishDialogOpen, setUnpublishDialogOpen] = useState(false);
+  const [unpublishNotify, setUnpublishNotify] = useState(true);
   const [exportDialogOpen, setExportDialogOpen] = useState(false);
   const [broadcastDialogOpen, setBroadcastDialogOpen] = useState(false);
   const [shiftImportOpen, setShiftImportOpen] = useState(false);
@@ -284,6 +287,13 @@ const Scheduling = () => {
   const [bulkEditDialogOpen, setBulkEditDialogOpen] = useState(false);
   const [bulkDeleteDialogOpen, setBulkDeleteDialogOpen] = useState(false);
   const [isBulkOperating, setIsBulkOperating] = useState(false);
+
+  // The unpublish notify checkbox starts checked every time the dialog opens.
+  useEffect(() => {
+    if (unpublishDialogOpen) {
+      setUnpublishNotify(true);
+    }
+  }, [unpublishDialogOpen]);
 
   // Memoized so downstream hook deps (useShifts, useWeekPublicationStatus, etc.)
   // and weekDayKeys/weekTimeOff memos are stable across drag/hover/selection re-renders.
@@ -798,6 +808,7 @@ const Scheduling = () => {
           weekStart: currentWeekStart,
           weekEnd,
           reason: 'Schedule unpublished for corrections',
+          notify: unpublishNotify,
         },
         {
           onSuccess: () => {
@@ -1780,17 +1791,42 @@ const Scheduling = () => {
               <div className="p-2 rounded-lg bg-warning/10">
                 <Unlock className="h-5 w-5 text-warning" />
               </div>
-              <AlertDialogTitle className="text-lg">Unpublish Schedule</AlertDialogTitle>
+              <AlertDialogTitle className="text-[17px]">Unpublish Schedule</AlertDialogTitle>
             </div>
-            <AlertDialogDescription className="text-sm leading-relaxed">
-              Are you sure you want to unpublish this schedule? This will unlock all shifts for editing
-              and notify employees that the schedule has changed.
+            <AlertDialogDescription className="text-[13px] leading-relaxed">
+              {unpublishNotify
+                ? 'This unlocks every shift in the week and tells the scheduled employees that the week is being revised.'
+                : 'This unlocks every shift in the week. Nobody is notified.'}
             </AlertDialogDescription>
           </AlertDialogHeader>
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="unpublish-notify-employees"
+              checked={unpublishNotify}
+              onCheckedChange={(checked) => setUnpublishNotify(checked === true)}
+              disabled={unpublishSchedule.isPending}
+            />
+            <Label
+              htmlFor="unpublish-notify-employees"
+              className="text-[13px] font-normal text-foreground"
+            >
+              Notify scheduled employees
+            </Label>
+          </div>
           <AlertDialogFooter className="gap-2 sm:gap-0">
-            <AlertDialogCancel className="text-sm">Cancel</AlertDialogCancel>
+            <AlertDialogCancel className="text-sm" disabled={unpublishSchedule.isPending}>
+              Cancel
+            </AlertDialogCancel>
             <AlertDialogAction
-              onClick={handleUnpublishSchedule}
+              onClick={(event) => {
+                // AlertDialogAction closes the dialog on click by default.
+                // Block that: the unpublish mutation is async, so an
+                // auto-close would hide the work in progress.
+                event.preventDefault();
+                if (unpublishSchedule.isPending) return;
+                handleUnpublishSchedule();
+              }}
+              disabled={unpublishSchedule.isPending}
               className="bg-warning text-warning-foreground hover:bg-warning/90 text-sm shadow-sm"
             >
               <Unlock className="h-4 w-4 mr-2" />

--- a/src/pages/Scheduling.tsx
+++ b/src/pages/Scheduling.tsx
@@ -820,6 +820,15 @@ const Scheduling = () => {
     }
   };
 
+  // AlertDialogAction closes the dialog on click by default. Block that: the
+  // unpublish mutation is async, so an auto-close would hide the work in
+  // progress.
+  const handleUnpublishConfirmClick = (event: React.MouseEvent) => {
+    event.preventDefault();
+    if (unpublishSchedule.isPending) return;
+    handleUnpublishSchedule();
+  };
+
   // Get unique employees scheduled this week (respecting position filter, including inactive)
   const scheduledEmployeeIds = new Set(
     shifts
@@ -1818,14 +1827,7 @@ const Scheduling = () => {
               Cancel
             </AlertDialogCancel>
             <AlertDialogAction
-              onClick={(event) => {
-                // AlertDialogAction closes the dialog on click by default.
-                // Block that: the unpublish mutation is async, so an
-                // auto-close would hide the work in progress.
-                event.preventDefault();
-                if (unpublishSchedule.isPending) return;
-                handleUnpublishSchedule();
-              }}
+              onClick={handleUnpublishConfirmClick}
               disabled={unpublishSchedule.isPending}
               className="bg-warning text-warning-foreground hover:bg-warning/90 text-sm shadow-sm"
             >

--- a/supabase/functions/_shared/emailQueue.ts
+++ b/supabase/functions/_shared/emailQueue.ts
@@ -97,6 +97,7 @@ export const sendEmailResult = async (
   to: string | string[],
   subject: string,
   html: string,
+  headers?: Record<string, string>,
 ): Promise<EmailSendResult> => {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
@@ -113,6 +114,7 @@ export const sendEmailResult = async (
         to: Array.isArray(to) ? to : [to],
         subject,
         html,
+        ...(headers && Object.keys(headers).length > 0 ? { headers } : {}),
       }),
       signal: controller.signal,
     });

--- a/supabase/functions/_shared/scheduleEmailThread.ts
+++ b/supabase/functions/_shared/scheduleEmailThread.ts
@@ -1,0 +1,52 @@
+/**
+ * scheduleEmailThread.ts
+ *
+ * Threads schedule-related emails (publish, unpublish, shift change) into
+ * one conversation per restaurant and week, using RFC 5322 `References` /
+ * `In-Reply-To` headers. This is the email equal of the push `tag`.
+ *
+ * See docs/superpowers/specs/2026-08-18-schedule-notification-residue-design.md
+ * ("Gap 2 — Thread schedule email on restaurant and week").
+ */
+
+import { safeTz } from './timezone.ts';
+
+/**
+ * Build the `References` and `In-Reply-To` headers for a schedule email.
+ * Both headers carry the same id, keyed on `restaurantId` and
+ * `weekStartDate`, so a mail client groups every email for one restaurant's
+ * one week into a single thread.
+ */
+export const scheduleThreadHeaders = (
+  restaurantId: string,
+  weekStartDate: string,
+): Record<string, string> => {
+  const id = `<schedule-${restaurantId}-${weekStartDate}@easyshifthq.com>`;
+  return { References: id, 'In-Reply-To': id };
+};
+
+/**
+ * Convert a shift's `start_time` to the restaurant's business day
+ * (`YYYY-MM-DD`) in its own timezone, via the `en-CA` locale, which formats
+ * as `YYYY-MM-DD`.
+ *
+ * Returns `null` instead of throwing for a missing, non-string, or
+ * unparseable `start_time`. An invalid `timezone` falls back to the
+ * platform default through `safeTz` rather than throwing.
+ */
+export const shiftBusinessDay = (
+  startTime: string | null | undefined,
+  timezone: string | null | undefined,
+): string | null => {
+  if (typeof startTime !== 'string' || startTime.length === 0) {
+    return null;
+  }
+  const date = new Date(startTime);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  const formatter = new Intl.DateTimeFormat('en-CA', {
+    timeZone: safeTz(timezone),
+  });
+  return formatter.format(date);
+};

--- a/supabase/functions/notify-schedule-published/index.ts
+++ b/supabase/functions/notify-schedule-published/index.ts
@@ -8,6 +8,7 @@ import { sendWebPushToUser } from "../_shared/webPushHelper.ts";
 import { notifySchedulePublishedPush } from "../_shared/schedulePublishedPush.ts";
 import { resolveChannels, type SupabaseLike } from "../_shared/resolveChannels.ts";
 import { safeTz } from "../_shared/timezone.ts";
+import { scheduleThreadHeaders } from "../_shared/scheduleEmailThread.ts";
 
 const RESEND_API_KEY = Deno.env.get("RESEND_API_KEY");
 
@@ -252,6 +253,10 @@ serve(async (req) => {
             </div>
           `;
 
+    // Built once, outside the loop: every recipient in one publish shares the
+    // same restaurant and week, so the thread id is the same for all of them.
+    const emailThreadHeaders = scheduleThreadHeaders(restaurantId, weekStart);
+
     // Paced rather than fanned out. Resend allows 2 requests/second and this
     // used to fire every recipient at once through Promise.allSettled, so any
     // roster past a handful started collecting 429s that nothing looked at.
@@ -265,7 +270,8 @@ serve(async (req) => {
           isRepublish
             ? `Updated Schedule: ${weekStartFormatted} - ${weekEndFormatted} at ${restaurant.name} — changes made`
             : `New Schedule Published: ${weekStartFormatted} - ${weekEndFormatted}`,
-          buildEmailHtml(employee.name)
+          buildEmailHtml(employee.name),
+          emailThreadHeaders
         ),
       { label: `schedule-published ${publicationId}` }
     );

--- a/supabase/functions/notify-schedule-unpublished/index.ts
+++ b/supabase/functions/notify-schedule-unpublished/index.ts
@@ -30,6 +30,7 @@ import {
 import { resolveChannels, type SupabaseLike } from "../_shared/resolveChannels.ts";
 import { sendWebPushToUsers } from "../_shared/webPushHelper.ts";
 import { runBounded } from "../_shared/webPushFanout.ts";
+import { scheduleThreadHeaders } from "../_shared/scheduleEmailThread.ts";
 
 const RESEND_API_KEY = Deno.env.get("RESEND_API_KEY");
 
@@ -261,6 +262,12 @@ serve(async (req) => {
       const scheduleUrl = `${APP_URL}${SCHEDULE_PATH}`;
 
       const emailRecipients = (ch.email ? audience : []).filter((emp) => emp.email);
+
+      // Built once, outside the loop: every recipient in one retraction
+      // shares the same restaurant and week, so the thread id matches the
+      // one the publish notifier used for the same schedule.
+      const emailThreadHeaders = scheduleThreadHeaders(restaurantId, retraction.week_start_date);
+
       const emailResults = await sendPaced(
         emailRecipients,
         (employee) =>
@@ -270,6 +277,7 @@ serve(async (req) => {
             employee.email as string,
             `Schedule update: ${weekRange} at ${restaurant.name} is being revised`,
             buildEmailHtml(employee.name, restaurant.name, weekRange, scheduleUrl),
+            emailThreadHeaders,
           ),
         { label: `schedule-unpublished ${retraction.id}` },
       );

--- a/supabase/functions/notify-shift-changed/index.ts
+++ b/supabase/functions/notify-shift-changed/index.ts
@@ -183,17 +183,19 @@ serve(async (req) => {
       // the shift's business day, then find the publication that covers it.
       // A missing business day or a missing publication both mean no header
       // — never throw for either (design doc, "Gap 2 — Thread schedule
-      // email").
-      const shiftDataForDay =
-        (row.after_data as Record<string, unknown> | null) ??
-        (row.before_data as Record<string, unknown> | null);
-      const businessDay = shiftBusinessDay(
-        shiftDataForDay?.start_time as string | null | undefined,
-        timezone,
-      );
-
-      let emailThreadHeaders: Record<string, string> | undefined;
-      if (businessDay) {
+      // email"). Resolved per recipient, not once per row: a reassignment
+      // across a week boundary sends a "removed" email to the old employee
+      // and an "assigned" email to the new one, and each belongs in the
+      // thread for its own week — "removed" uses before_data's business
+      // day, "assigned"/"updated" use after_data's (falling back to
+      // before_data when after_data carries no start_time).
+      const resolveEmailThreadHeaders = async (
+        startTime: string | null | undefined,
+      ): Promise<Record<string, string> | undefined> => {
+        const businessDay = shiftBusinessDay(startTime, timezone);
+        if (!businessDay) {
+          return undefined;
+        }
         const minWeekStart = new Date(`${businessDay}T00:00:00Z`);
         minWeekStart.setUTCDate(minWeekStart.getUTCDate() - 6);
         const minWeekStartStr = minWeekStart.toISOString().slice(0, 10);
@@ -211,10 +213,12 @@ serve(async (req) => {
 
         if (pubError) {
           console.error("notify-shift-changed: covering publication lookup failed", pubError);
-        } else if (publication) {
-          emailThreadHeaders = scheduleThreadHeaders(row.restaurant_id, publication.week_start_date);
+          return undefined;
         }
-      }
+        return publication
+          ? scheduleThreadHeaders(row.restaurant_id, publication.week_start_date)
+          : undefined;
+      };
 
       let sent = 0;
       let failed = 0;
@@ -228,6 +232,15 @@ serve(async (req) => {
         }
 
         const message = buildShiftChangeMessage(recipient, row as ShiftChangeLogRow, timezone);
+        const beforeStartTime = (row.before_data as Record<string, unknown> | null)?.start_time as
+          | string
+          | undefined;
+        const afterStartTime = (row.after_data as Record<string, unknown> | null)?.start_time as
+          | string
+          | undefined;
+        const recipientStartTime =
+          recipient.role === "removed" ? beforeStartTime : afterStartTime ?? beforeStartTime;
+        const emailThreadHeaders = await resolveEmailThreadHeaders(recipientStartTime);
         let recipientReached = false;
 
         if (employee.email && RESEND_API_KEY) {

--- a/supabase/functions/notify-shift-changed/index.ts
+++ b/supabase/functions/notify-shift-changed/index.ts
@@ -19,6 +19,8 @@ import {
 } from "../_shared/notificationHelpers.ts";
 import { sendWebPushToUser } from "../_shared/webPushHelper.ts";
 import { escapeHtml } from "../_shared/emailTemplates.ts";
+import { safeTz } from "../_shared/timezone.ts";
+import { scheduleThreadHeaders, shiftBusinessDay } from "../_shared/scheduleEmailThread.ts";
 import {
   checkShiftChangeValidity,
   deriveShiftChangeRecipients,
@@ -167,11 +169,52 @@ serve(async (req) => {
         throw new Error(`Failed to fetch restaurant: ${restError.message}`);
       }
 
-      const timezone = restaurant?.timezone || "UTC";
+      // safeTz guards an invalid stored value, not just an empty one — a bad
+      // IANA string here used to throw inside buildShiftChangeMessage and
+      // kill the whole invocation (design doc, "Timezone safety").
+      const timezone = safeTz(restaurant?.timezone);
       const restaurantName = restaurant?.name ?? "EasyShiftHQ";
       const employeeById = new Map(
         ((employees ?? []) as RecipientEmployee[]).map((e) => [e.id, e]),
       );
+
+      // Thread this email into the same conversation as the publish/unpublish
+      // emails for its week. The change log has no week column, so resolve
+      // the shift's business day, then find the publication that covers it.
+      // A missing business day or a missing publication both mean no header
+      // — never throw for either (design doc, "Gap 2 — Thread schedule
+      // email").
+      const shiftDataForDay =
+        (row.after_data as Record<string, unknown> | null) ??
+        (row.before_data as Record<string, unknown> | null);
+      const businessDay = shiftBusinessDay(
+        shiftDataForDay?.start_time as string | null | undefined,
+        timezone,
+      );
+
+      let emailThreadHeaders: Record<string, string> | undefined;
+      if (businessDay) {
+        const minWeekStart = new Date(`${businessDay}T00:00:00Z`);
+        minWeekStart.setUTCDate(minWeekStart.getUTCDate() - 6);
+        const minWeekStartStr = minWeekStart.toISOString().slice(0, 10);
+
+        const { data: publication, error: pubError } = await serviceClient
+          .from("schedule_publications")
+          .select("week_start_date")
+          .eq("restaurant_id", row.restaurant_id)
+          .gte("week_start_date", minWeekStartStr)
+          .lte("week_start_date", businessDay)
+          .gte("week_end_date", businessDay)
+          .order("published_at", { ascending: false })
+          .limit(1)
+          .maybeSingle();
+
+        if (pubError) {
+          console.error("notify-shift-changed: covering publication lookup failed", pubError);
+        } else if (publication) {
+          emailThreadHeaders = scheduleThreadHeaders(row.restaurant_id, publication.week_start_date);
+        }
+      }
 
       let sent = 0;
       let failed = 0;
@@ -194,6 +237,7 @@ serve(async (req) => {
             employee.email,
             `${message.title} - ${restaurantName}`,
             `<p>Hi ${escapeHtml(employee.name ?? "there")},</p><p>${escapeHtml(message.body)}</p>`,
+            emailThreadHeaders,
           );
           if (emailResult.ok) {
             recipientReached = true;

--- a/tests/e2e/schedule-quiet-publish-live-edit.spec.ts
+++ b/tests/e2e/schedule-quiet-publish-live-edit.spec.ts
@@ -2,11 +2,14 @@ import { test, expect, Page } from '@playwright/test';
 import { signUpAndCreateRestaurant, exposeSupabaseHelpers, generateTestUser } from '../helpers/e2e-supabase';
 
 /**
- * Task 15 (design: docs/superpowers/specs/2026-08-15-quiet-publish-live-edit-design.md).
- * Covers the two flows the plan calls out:
+ * Task 15 (design: docs/superpowers/specs/2026-08-15-quiet-publish-live-edit-design.md)
+ * and task 9 (design: docs/superpowers/specs/2026-08-18-schedule-notification-residue-design.md).
+ * Covers the flows those plans call out:
  *   - a manager publishes with "Notify employees" unchecked and the week still publishes;
  *   - a manager edits a shift that is already published, sees one warning dialog, saves
- *     the change, and the week stays published (no forced unpublish).
+ *     the change, and the week stays published (no forced unpublish);
+ *   - a manager unpublishes with "Notify employees" unchecked, the week still unpublishes,
+ *     and the toast names the shift count and says nobody was notified.
  *
  * Timezone is pinned for the same reason as the sibling scheduling specs: CI runs UTC,
  * and week-bucketing bugs are invisible there.
@@ -184,5 +187,53 @@ test.describe('Quiet publish and live edit of a published shift', () => {
     const reopenedDialog = page.getByRole('dialog', { name: /edit shift/i });
     await expect(reopenedDialog).toBeVisible({ timeout: 5000 });
     await expect(reopenedDialog.getByLabel('Shift end time')).toHaveValue(newEndTime);
+  });
+
+  test('unpublishing with "Notify employees" unchecked still unpublishes and reports the count', async ({ page }) => {
+    const testUser = generateTestUser('quietunpub');
+    await signUpAndCreateRestaurant(page, testUser);
+    await exposeSupabaseHelpers(page);
+
+    // `window` has no type declarations for the test-only helpers exposeSupabaseHelpers attaches.
+    const restaurantId = await page.evaluate(() =>
+      (window as unknown as { __getRestaurantId: () => Promise<string> }).__getRestaurantId()
+    );
+    expect(restaurantId).toBeTruthy();
+
+    await seedEmployeeAndShift(page, restaurantId, 'Uma Unpublisher');
+
+    await publishWeek(page, { notify: true });
+
+    await page.goto('/scheduling');
+    await page.waitForLoadState('networkidle');
+    const unpublishBtn = page.getByRole('button', { name: /^unpublish$/i });
+    await expect(unpublishBtn).toBeVisible({ timeout: 15000 });
+    await unpublishBtn.click();
+
+    const dialog = page.getByRole('alertdialog', { name: /unpublish schedule/i });
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    // Checked by default on every open — same pattern as the publish dialog.
+    const notifyCheckbox = dialog.getByRole('checkbox', { name: /notify scheduled employees/i });
+    await expect(notifyCheckbox).toBeChecked();
+    await notifyCheckbox.click();
+    await expect(notifyCheckbox).not.toBeChecked();
+
+    const responsePromise = page.waitForResponse(
+      (resp) => resp.url().includes('unpublish_schedule') && resp.status() === 200,
+      { timeout: 20000 },
+    );
+    await dialog.getByRole('button', { name: /^unpublish schedule$/i }).click();
+    await responsePromise;
+
+    // The toast names the shift count and says nobody was notified.
+    await expect(page.getByText(/^schedule unpublished$/i)).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(/1 shift.*unlocked for editing\.\s*nobody was notified\./i)).toBeVisible();
+
+    // The week actually returns to the unpublished state: a fresh load shows
+    // the action button flip back from Unpublish to Publish.
+    await page.goto('/scheduling');
+    await page.waitForLoadState('networkidle');
+    await expect(page.getByRole('button', { name: 'Publish', exact: true })).toBeEnabled({ timeout: 15000 });
   });
 });

--- a/tests/unit/emailQueue.test.ts
+++ b/tests/unit/emailQueue.test.ts
@@ -101,6 +101,35 @@ describe('sendEmailResult', () => {
     const body = JSON.parse(vi.mocked(fetch).mock.calls[0][1]?.body as string);
     expect(body.to).toEqual(['to@x.com']);
   });
+
+  it('sends no headers key when the caller omits the headers argument', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response('{}', { status: 200 }));
+
+    await sendEmailResult('key', 'from@x.com', 'to@x.com', 'Subj', '<p>hi</p>');
+
+    const body = JSON.parse(vi.mocked(fetch).mock.calls[0][1]?.body as string);
+    expect(body).not.toHaveProperty('headers');
+  });
+
+  it('sends the headers object in the Resend body when it holds keys', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response('{}', { status: 200 }));
+
+    await sendEmailResult('key', 'from@x.com', 'to@x.com', 'Subj', '<p>hi</p>', {
+      'X-Entity-Ref-ID': 'abc-123',
+    });
+
+    const body = JSON.parse(vi.mocked(fetch).mock.calls[0][1]?.body as string);
+    expect(body.headers).toEqual({ 'X-Entity-Ref-ID': 'abc-123' });
+  });
+
+  it('sends no headers key when the caller passes an empty object', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response('{}', { status: 200 }));
+
+    await sendEmailResult('key', 'from@x.com', 'to@x.com', 'Subj', '<p>hi</p>', {});
+
+    const body = JSON.parse(vi.mocked(fetch).mock.calls[0][1]?.body as string);
+    expect(body).not.toHaveProperty('headers');
+  });
 });
 
 describe('sendPaced', () => {

--- a/tests/unit/scheduleEmailThread.test.ts
+++ b/tests/unit/scheduleEmailThread.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import {
+  scheduleThreadHeaders,
+  shiftBusinessDay,
+} from '../../supabase/functions/_shared/scheduleEmailThread';
+
+describe('scheduleThreadHeaders', () => {
+  it('builds References and In-Reply-To from the same id', () => {
+    const headers = scheduleThreadHeaders(
+      'aaaaaaaa-1111-2222-3333-444444444444',
+      '2026-08-17',
+    );
+    const expectedId =
+      '<schedule-aaaaaaaa-1111-2222-3333-444444444444-2026-08-17@easyshifthq.com>';
+    expect(headers).toEqual({
+      References: expectedId,
+      'In-Reply-To': expectedId,
+    });
+  });
+});
+
+describe('shiftBusinessDay', () => {
+  it('lands a late-evening shift on the correct business day in America/New_York', () => {
+    // 2026-08-17T23:30:00-04:00 is 2026-08-18T03:30:00Z. In UTC this is
+    // already the 18th, but in America/New_York it is still the 17th.
+    const result = shiftBusinessDay(
+      '2026-08-18T03:30:00.000Z',
+      'America/New_York',
+    );
+    expect(result).toBe('2026-08-17');
+  });
+
+  it('falls back to the default timezone for an invalid IANA string instead of throwing', () => {
+    expect(() =>
+      shiftBusinessDay('2026-08-18T03:30:00.000Z', 'Not/A_Real_Zone'),
+    ).not.toThrow();
+    const result = shiftBusinessDay(
+      '2026-08-18T03:30:00.000Z',
+      'Not/A_Real_Zone',
+    );
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('returns null for a missing start_time', () => {
+    expect(shiftBusinessDay(undefined, 'America/New_York')).toBeNull();
+    expect(shiftBusinessDay(null, 'America/New_York')).toBeNull();
+  });
+
+  it('returns null for a non-string start_time', () => {
+    expect(shiftBusinessDay(12345 as unknown as string, 'America/New_York')).toBeNull();
+  });
+
+  it('returns null for an unparseable start_time', () => {
+    expect(shiftBusinessDay('not-a-date', 'America/New_York')).toBeNull();
+  });
+});

--- a/tests/unit/scheduleEmailThread.test.ts
+++ b/tests/unit/scheduleEmailThread.test.ts
@@ -31,22 +31,24 @@ describe('shiftBusinessDay', () => {
   });
 
   it('falls back to the default timezone for an invalid IANA string instead of throwing', () => {
-    expect(() =>
-      shiftBusinessDay('2026-08-18T03:30:00.000Z', 'Not/A_Real_Zone'),
-    ).not.toThrow();
-    const result = shiftBusinessDay(
-      '2026-08-18T03:30:00.000Z',
-      'Not/A_Real_Zone',
+    const startTime = '2026-08-18T03:30:00.000Z';
+    expect(() => shiftBusinessDay(startTime, 'Not/A_Real_Zone')).not.toThrow();
+    // The invalid zone must resolve through the same default the missing
+    // (`undefined`) case uses, not merely some valid-looking date string.
+    expect(shiftBusinessDay(startTime, 'Not/A_Real_Zone')).toBe(
+      shiftBusinessDay(startTime, undefined),
     );
-    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   });
 
   it('returns null for a missing start_time', () => {
+    expect(shiftBusinessDay('', 'America/New_York')).toBeNull();
     expect(shiftBusinessDay(undefined, 'America/New_York')).toBeNull();
     expect(shiftBusinessDay(null, 'America/New_York')).toBeNull();
   });
 
   it('returns null for a non-string start_time', () => {
+    expect(shiftBusinessDay(0 as unknown as string, 'America/New_York')).toBeNull();
+    expect(shiftBusinessDay(-1 as unknown as string, 'America/New_York')).toBeNull();
     expect(shiftBusinessDay(12345 as unknown as string, 'America/New_York')).toBeNull();
   });
 

--- a/tests/unit/useSchedulePublish.test.ts
+++ b/tests/unit/useSchedulePublish.test.ts
@@ -308,44 +308,25 @@ describe('unpublish notification outcomes', () => {
     expect(toasted.title).toContain('nobody was notified');
   });
 
-  it('skips the notification invoke when notify is false, even with retracted shifts', async () => {
-    mockSupabase.rpc.mockResolvedValue({ data: 63, error: null });
-    const { weekStart, weekEnd } = makeWeek();
+  it.each([
+    [63, '63 shifts are unlocked for editing. Nobody was notified.'],
+    [1, '1 shift is unlocked for editing. Nobody was notified.'],
+    [0, 'Nothing was published for this week, so nothing changed.'],
+  ])(
+    'skips the notification invoke when notify is false (%i shifts)',
+    async (shiftCount, expectedDescription) => {
+      mockSupabase.rpc.mockResolvedValue({ data: shiftCount, error: null });
+      const { weekStart, weekEnd } = makeWeek();
 
-    const { result } = renderHook(() => useUnpublishSchedule(), { wrapper: createWrapper() });
-    await act(async () => {
-      await result.current.mutateAsync({ restaurantId: 'r1', weekStart, weekEnd, notify: false });
-    });
+      const { result } = renderHook(() => useUnpublishSchedule(), { wrapper: createWrapper() });
+      await act(async () => {
+        await result.current.mutateAsync({ restaurantId: 'r1', weekStart, weekEnd, notify: false });
+      });
 
-    expect(mockSupabase.functions.invoke).not.toHaveBeenCalled();
-    expect(lastToast().description).toBe('63 shifts are unlocked for editing. Nobody was notified.');
-  });
-
-  it('matches singular grammar in the skipped copy for exactly one shift', async () => {
-    mockSupabase.rpc.mockResolvedValue({ data: 1, error: null });
-    const { weekStart, weekEnd } = makeWeek();
-
-    const { result } = renderHook(() => useUnpublishSchedule(), { wrapper: createWrapper() });
-    await act(async () => {
-      await result.current.mutateAsync({ restaurantId: 'r1', weekStart, weekEnd, notify: false });
-    });
-
-    expect(mockSupabase.functions.invoke).not.toHaveBeenCalled();
-    expect(lastToast().description).toBe('1 shift is unlocked for editing. Nobody was notified.');
-  });
-
-  it('reports the zero-shift skipped copy when notify is false and nothing was retracted', async () => {
-    mockSupabase.rpc.mockResolvedValue({ data: 0, error: null });
-    const { weekStart, weekEnd } = makeWeek();
-
-    const { result } = renderHook(() => useUnpublishSchedule(), { wrapper: createWrapper() });
-    await act(async () => {
-      await result.current.mutateAsync({ restaurantId: 'r1', weekStart, weekEnd, notify: false });
-    });
-
-    expect(mockSupabase.functions.invoke).not.toHaveBeenCalled();
-    expect(lastToast().description).toBe('Nothing was published for this week, so nothing changed.');
-  });
+      expect(mockSupabase.functions.invoke).not.toHaveBeenCalled();
+      expect(lastToast().description).toBe(expectedDescription);
+    },
+  );
 
   it('calls the notification invoke once when notify is true and shifts were retracted', async () => {
     mockSupabase.rpc.mockResolvedValue({ data: 63, error: null });

--- a/tests/unit/useSchedulePublish.test.ts
+++ b/tests/unit/useSchedulePublish.test.ts
@@ -225,6 +225,30 @@ describe('notificationToast copy per outcome', () => {
     expect(toasted.description).toBe('No notifications were sent.');
     expect(toasted.variant).toBeUndefined();
   });
+
+  it('uses skippedDescription for a skipped outcome when the caller sets it', () => {
+    const toasted = notificationToast(
+      { status: 'skipped' },
+      {
+        title: 'Schedule Updated',
+        successDescription: 'The schedule has been updated.',
+        skippedDescription: 'Shift times changed. No new notifications were sent.',
+      },
+    );
+
+    expect(toasted.title).toBe('Schedule Updated');
+    expect(toasted.description).toBe('Shift times changed. No new notifications were sent.');
+    expect(toasted.variant).toBeUndefined();
+  });
+
+  it('falls back to the plain skipped copy when skippedDescription is absent', () => {
+    const toasted = notificationToast(
+      { status: 'skipped' },
+      { title: 'Schedule Updated', successDescription: 'The schedule has been updated.' },
+    );
+
+    expect(toasted.description).toBe('No notifications were sent.');
+  });
 });
 
 describe('unpublish notification outcomes', () => {

--- a/tests/unit/useSchedulePublish.test.ts
+++ b/tests/unit/useSchedulePublish.test.ts
@@ -321,6 +321,19 @@ describe('unpublish notification outcomes', () => {
     expect(lastToast().description).toBe('63 shifts are unlocked for editing. Nobody was notified.');
   });
 
+  it('matches singular grammar in the skipped copy for exactly one shift', async () => {
+    mockSupabase.rpc.mockResolvedValue({ data: 1, error: null });
+    const { weekStart, weekEnd } = makeWeek();
+
+    const { result } = renderHook(() => useUnpublishSchedule(), { wrapper: createWrapper() });
+    await act(async () => {
+      await result.current.mutateAsync({ restaurantId: 'r1', weekStart, weekEnd, notify: false });
+    });
+
+    expect(mockSupabase.functions.invoke).not.toHaveBeenCalled();
+    expect(lastToast().description).toBe('1 shift is unlocked for editing. Nobody was notified.');
+  });
+
   it('reports the zero-shift skipped copy when notify is false and nothing was retracted', async () => {
     mockSupabase.rpc.mockResolvedValue({ data: 0, error: null });
     const { weekStart, weekEnd } = makeWeek();

--- a/tests/unit/useSchedulePublish.test.ts
+++ b/tests/unit/useSchedulePublish.test.ts
@@ -307,6 +307,58 @@ describe('unpublish notification outcomes', () => {
     expect(toasted.variant).toBe('destructive');
     expect(toasted.title).toContain('nobody was notified');
   });
+
+  it('skips the notification invoke when notify is false, even with retracted shifts', async () => {
+    mockSupabase.rpc.mockResolvedValue({ data: 63, error: null });
+    const { weekStart, weekEnd } = makeWeek();
+
+    const { result } = renderHook(() => useUnpublishSchedule(), { wrapper: createWrapper() });
+    await act(async () => {
+      await result.current.mutateAsync({ restaurantId: 'r1', weekStart, weekEnd, notify: false });
+    });
+
+    expect(mockSupabase.functions.invoke).not.toHaveBeenCalled();
+    expect(lastToast().description).toBe('63 shifts are unlocked for editing. Nobody was notified.');
+  });
+
+  it('reports the zero-shift skipped copy when notify is false and nothing was retracted', async () => {
+    mockSupabase.rpc.mockResolvedValue({ data: 0, error: null });
+    const { weekStart, weekEnd } = makeWeek();
+
+    const { result } = renderHook(() => useUnpublishSchedule(), { wrapper: createWrapper() });
+    await act(async () => {
+      await result.current.mutateAsync({ restaurantId: 'r1', weekStart, weekEnd, notify: false });
+    });
+
+    expect(mockSupabase.functions.invoke).not.toHaveBeenCalled();
+    expect(lastToast().description).toBe('Nothing was published for this week, so nothing changed.');
+  });
+
+  it('calls the notification invoke once when notify is true and shifts were retracted', async () => {
+    mockSupabase.rpc.mockResolvedValue({ data: 63, error: null });
+    mockSupabase.functions.invoke.mockResolvedValue({ data: { sent: 12, failed: 0 }, error: null });
+    const { weekStart, weekEnd } = makeWeek();
+
+    const { result } = renderHook(() => useUnpublishSchedule(), { wrapper: createWrapper() });
+    await act(async () => {
+      await result.current.mutateAsync({ restaurantId: 'r1', weekStart, weekEnd, notify: true });
+    });
+
+    expect(mockSupabase.functions.invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('defaults notify to true when the param is absent', async () => {
+    mockSupabase.rpc.mockResolvedValue({ data: 63, error: null });
+    mockSupabase.functions.invoke.mockResolvedValue({ data: { sent: 12, failed: 0 }, error: null });
+    const { weekStart, weekEnd } = makeWeek();
+
+    const { result } = renderHook(() => useUnpublishSchedule(), { wrapper: createWrapper() });
+    await act(async () => {
+      await result.current.mutateAsync({ restaurantId: 'r1', weekStart, weekEnd });
+    });
+
+    expect(mockSupabase.functions.invoke).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('notification timeout', () => {


### PR DESCRIPTION
## Summary

- Add a **Notify employees** checkbox to the unpublish dialog. It mirrors the checkbox already on the publish dialog and on the published-shift-change dialog. The toast text names the shift count and states whether the app sent a notification.
- Thread the three schedule email notifiers (`notify-schedule-published`, `notify-schedule-unpublished`, `notify-shift-changed`) with `References`/`In-Reply-To` headers keyed on restaurant and week. Emails for the same week now group into one thread in the inbox.
- Fix a live crash in `notify-shift-changed`: an invalid stored restaurant timezone reached `buildShiftChangeMessage` and threw. The fix routes the timezone through the existing `safeTz` helper first.
- Rewrite four sections of the in-product help article for scheduling. The article now describes the notify checkbox on publish, edit, and unpublish, and the renamed unpublish flow.

Design: [`docs/superpowers/specs/2026-08-18-schedule-notification-residue-design.md`](https://github.com/toyiyo/nimble-pnl/blob/claude/confident-lewin-8e0379/docs/superpowers/specs/2026-08-18-schedule-notification-residue-design.md)

## Test plan

- `npm run typecheck` — clean.
- `npm run lint` — no new errors on any file this PR touches (11 files). The full-repo run shows the same pre-existing `@typescript-eslint/no-explicit-any` baseline as `main`.
- `npm run test` (`vitest run`, full suite) — 772 files passed, 1 skipped; 9336 tests passed, 2 skipped. No failures.
- `npm run build` — exit 0, `dist/` written.
- `npx playwright test tests/e2e/schedule-quiet-publish-live-edit.spec.ts tests/e2e/employee-schedule-retraction.spec.ts --project=e2e` — 4 passed.
- `npm run test:db` — not re-run in the final pass; no SQL file changed in this PR, and an earlier pass at the same code ran it green (2908/2908).
- Manual check needed for the email-threading wiring at the three call sites (`notify-schedule-published/index.ts`, `notify-schedule-unpublished/index.ts`, `notify-shift-changed/index.ts`): publish a week, edit a published shift, then unpublish the week, and confirm all three emails land in one thread in a mail client that groups by `References`/`In-Reply-To`. No automated test covers this wiring — see the deferred finding below.

## Known deferred review findings

- `src/pages/Scheduling.tsx:1811` — **major** — The unpublish dialog duplicates a third copy of the notify-checkbox pattern (state + reset-on-open effect + Checkbox/Label JSX) already present in `src/components/PublishScheduleDialog.tsx:56-62,176-188` and `src/components/scheduling/PublishedShiftChangeDialog.tsx:36-43,69-82`. Extract a shared hook or presentational component instead of a third copy-paste.
  Deferred because: not a bug/security/correctness finding, so outside this phase's mandatory-fix scope. A real fix touches two files outside this PR's approved design (both pre-existing from #756), and the design doc explicitly directed copying the AlertDialog precedent, reviewed and accepted in Phase 2.5 with no duplication concern raised. Spawned as follow-up `task_0513277a`.
- **info** — The vercel-react-best-practices / requesting-code-review skill tools were unavailable to the sound-logic reviewer; it used the manual checklist fallback instead.
  Deferred because: this is a meta-note about reviewer tooling, not a code finding. No action is possible or needed.
- **info** — The sound-logic reviewer found no issues at confidence >= 80. The code matches the approved design doc.
  Deferred because: this is a confirmation, not a defect. No action is needed.
- `supabase/functions/notify-schedule-published/index.ts:258` — **minor** — The call-site wiring that builds `emailThreadHeaders` and threads it through `notify-schedule-published`, `notify-schedule-unpublished`, and `notify-shift-changed` has no automated test. Only the pure helpers `scheduleThreadHeaders`/`shiftBusinessDay` are unit tested.
  Deferred because: this is a documented, accepted gap in the design doc's Timezone safety section. No unit test harness exists for these edge functions, and the design directs a manual check, stated in the PR body above, instead.
- `supabase/functions/_shared/scheduleEmailThread.ts:49` — **minor** — `shiftBusinessDay` falls back to America/Chicago (through `safeTz`) on an invalid restaurant timezone. The pre-existing `publish_schedule`/`unpublish_schedule` SQL functions fall back to UTC for the same case. A shift near midnight UTC, at a restaurant with an invalid timezone, can miss the covering publication lookup and send its shift-change email with no thread headers. This degrades gracefully — the email itself still sends.
  Deferred because: the design doc directs `safeTz` but does not reconcile the two fallback constants. A correct fix needs a design decision on which constant is canonical, not a mechanical patch. Spawned as follow-up `task_f03a7ef2`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unpublishing a week now lets you choose whether to notify scheduled employees.
  * Published shifts can be edited with confirmation and optional employee notifications.
  * Schedule emails are grouped into consistent conversation threads.
  * Scheduling help content now explains editing, publishing, and unpublishing workflows.

* **Bug Fixes**
  * Improved timezone handling for shift-related notifications.
  * Added clearer feedback when notifications are skipped, including shift counts.

* **Tests**
  * Expanded coverage for quiet unpublishing, email threading, timezone handling, and notification options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->