### PR TITLE
fix(schedule): read the restaurant clock in ShiftRow

### DIFF
--- a/docs/superpowers/plans/2026-08-19-shiftrow-restaurant-clock-plan.md
+++ b/docs/superpowers/plans/2026-08-19-shiftrow-restaurant-clock-plan.md
@@ -1,0 +1,136 @@
+# Plan: read the restaurant clock in `ShiftRow`
+
+Date: 2026-08-19
+Design: `docs/superpowers/specs/2026-08-19-shiftrow-restaurant-clock-design.md`
+Branch: `claude/vigorous-jemison-90a798`
+
+## Scope
+
+Change `src/components/employee/ShiftRow.tsx` to read the restaurant clock.
+Pass the clock from `src/pages/EmployeeSchedule.tsx` as a required prop.
+
+No DB change. No migration. No RPC. No edge function. Display only.
+
+## Task order
+
+The order is TDD. Task 1 writes a test that fails. Task 2 makes it pass.
+
+### Task 1 — write the failing timezone test
+
+File: `tests/unit/ShiftRow.restaurantTz.test.tsx` (new)
+
+1. Copy the `pinHostTzToPhoenix` guard from
+   `tests/unit/useShiftsRecurringCreateTz.test.ts:92`. The guard sets
+   `process.env.TZ = 'America/Phoenix'` and then asserts
+   `getTimezoneOffset() === 420`. The assignment can fail without an error,
+   and a silent failure makes the test vacuous.
+2. Add a local `makeClock(tz, today)` helper. Build it from
+   `formatInstant` and `toBusinessDay` in `src/lib/restaurantClock.ts`, so the
+   fake cannot drift from production behaviour.
+3. Pick instants where Phoenix and `Pacific/Auckland` name different calendar
+   days and different wall-clock hours.
+4. Write the four cases from design section 5.4:
+   - the `day` variant shows the restaurant wall-clock time;
+   - the `upcoming` variant shows the restaurant weekday, day and month;
+   - a shift that is today in Auckland shows `Today`;
+   - a shift that is not today in Auckland does not show `Today`.
+5. Each case asserts the wanted string AND the absence of the host-zone string.
+
+Expect: the file does not compile, because `ShiftRow` has no `clock` prop yet.
+That is the failing state.
+
+### Task 2 — change `ShiftRow`
+
+File: `src/components/employee/ShiftRow.tsx`
+
+1. Import `RestaurantClock` from `@/hooks/useRestaurantClock`.
+2. Add `clock: RestaurantClock` to `ShiftRowProps`. Make it required.
+3. Change the signature to `getShiftStatusBadge(shift, clock)`.
+4. Replace `isToday(startTime)` with
+   `clock.toBusinessDay(shift.start_time) === clock.today`.
+5. Replace each `format(parseISO(x), p)` with `clock.formatInstant(x, p)`.
+   Seven call sites: lines 143, 146, 149, 154, 155, 187, 188.
+6. Change `canTrade` to `isFuture(new Date(shift.start_time))`.
+7. Delete `format`, `parseISO` and `isToday` from the `date-fns` import.
+   Keep `isPast`, `isFuture` and `differenceInMinutes`.
+8. Add a comment above `getShiftStatusBadge`. Name which questions are
+   calendar-day questions and which are instant questions. State that
+   `isPast`, `isFuture` and the `now` range check must stay.
+
+Expect: Task 1's test passes.
+
+### Task 3 — wire the two call sites
+
+File: `src/pages/EmployeeSchedule.tsx`
+
+1. Pass `clock={clock}` at line 282 (`upcoming` variant).
+2. Pass `clock={clock}` at line 383 (`day` variant).
+
+Expect: `npm run typecheck` passes.
+
+### Task 4 — update the existing `ShiftRow` tests
+
+File: `tests/unit/ShiftRow.test.tsx`
+
+1. Add a `makeClock` helper, the same shape as Task 1's.
+2. Pass `clock={...}` in the six existing cases.
+3. Add case 5: a shift that ended one hour ago shows `Completed`.
+4. Add case 6: a shift in progress shows `In Progress`.
+5. Run cases 5 and 6 a second time with the host zone pinned to
+   `America/Phoenix`. Check the badge does not change. Both branches compare
+   instants, so the zone must not matter.
+
+### Task 5 — check the `EmployeeSchedule` test workaround
+
+File: `tests/unit/EmployeeSchedule.restaurantTz.test.tsx`
+
+1. Run the file. The `dayHeader` helper at line 129 scopes the `Today` query,
+   because `ShiftRow` used to show a second, host-clock `Today`.
+2. After Task 2, the row badge follows the restaurant clock. Two correct
+   `Today` strings can now appear in the same row.
+3. Decide from the test run, not from this plan. Keep the scoping if the
+   collision is real and correct. Delete the workaround and its comment only
+   if the query is unambiguous.
+
+### Task 6 — negative control
+
+1. Revert Task 2's two changes by hand, in a scratch copy.
+2. Run `tests/unit/ShiftRow.restaurantTz.test.tsx`.
+3. Check that it FAILS. A test that passes against the old code proves
+   nothing.
+4. Restore the fixed file.
+
+## Verify
+
+```bash
+npm run typecheck
+npx eslint src/components/employee/ShiftRow.tsx src/pages/EmployeeSchedule.tsx tests/unit/ShiftRow.test.tsx tests/unit/ShiftRow.restaurantTz.test.tsx
+npx vitest run tests/unit/ShiftRow.test.tsx tests/unit/ShiftRow.restaurantTz.test.tsx tests/unit/EmployeeSchedule.restaurantTz.test.tsx
+npm run test
+```
+
+Run the full unit suite once under `TZ=UTC`. `memory/lessons.md:1324` says that
+one command reproduces the CI-versus-dev zone difference that a green local run
+hides.
+
+```bash
+TZ=UTC npm run test
+```
+
+## E2E
+
+No E2E change. The fix has no new route, no new user flow and no new data
+write. The unit tests pin the zone behaviour, which an E2E cannot do better:
+an E2E runs one host zone at a time, and `memory/lessons.md:1011` warns against
+an E2E that asserts exact clock strings.
+
+## Out of scope
+
+- Badge staleness. `getShiftStatusBadge` reads `new Date()` at render, and no
+  ticker re-renders the row. See design section 6.
+- Other host-clock surfaces in the employee portal.
+
+## Rollback
+
+Revert the three source commits. The change is display-only, so no data needs
+repair.

--- a/docs/superpowers/specs/2026-08-19-shiftrow-restaurant-clock-design.md
+++ b/docs/superpowers/specs/2026-08-19-shiftrow-restaurant-clock-design.md
@@ -62,7 +62,7 @@ Keep all five. A change here adds risk and fixes nothing.
 formatInstant, toBusinessDay, toWallClockInput, parseWallClock}`
 ([useRestaurantClock.ts:15-24](src/hooks/useRestaurantClock.ts:15)). Its
 `today` comes from `useTodayInTimezone(tz)`
-([useRestaurantClock.ts:39](src/hooks/useRestaurantClock.ts:39)), which rolls
+([useRestaurantClock.ts:42](src/hooks/useRestaurantClock.ts:42)), which rolls
 over at restaurant midnight.
 
 `formatInstant(value, tz, pattern)`
@@ -91,11 +91,21 @@ Call sites need no change.
 Two costs:
 
 1. **One timer per row.** `useTodayInTimezone` starts a 60-second
-   `setInterval` and two window listeners for each hook instance
-   ([useTodayInTimezone.ts:28-35](src/hooks/useTodayInTimezone.ts:28)). A full
-   week grid plus the Upcoming card renders tens of rows, so the page would
-   hold tens of timers that all compute the same string. CLAUDE.md:315 says a
-   row component must have no hooks inside and take all data as props.
+   `setInterval` at
+   [useTodayInTimezone.ts:27](src/hooks/useTodayInTimezone.ts:27) and two
+   window listeners at
+   [useTodayInTimezone.ts:31-32](src/hooks/useTodayInTimezone.ts:31), once per
+   hook instance. A full week grid plus the Upcoming card renders tens of rows,
+   so the page would hold tens of timers that all compute the same string.
+
+   [CLAUDE.md:315](CLAUDE.md:315) says a row component must have no hooks
+   inside and take all data as props. That rule sits under the heading "Row
+   components in virtualized lists" ([CLAUDE.md:313](CLAUDE.md:313)).
+   `ShiftRow` renders in a 7-day grid and a short Upcoming card, both far below
+   the 100-item threshold that CLAUDE.md sets for virtualization. The rule
+   therefore does not apply to `ShiftRow` today. Read it as a forward-looking
+   alignment, not as a present violation. The timer count above is the argument
+   that stands on its own.
 2. **The row stops working without a provider.** `useRestaurantContext` throws
    when no provider is above it
    ([RestaurantContext.tsx:25-27](src/contexts/RestaurantContext.tsx:25)).
@@ -109,7 +119,9 @@ Add `clock: RestaurantClock` to `ShiftRowProps`. `EmployeeSchedule` passes the
 object it already has.
 
 - One timer for the page, not one per row.
-- The row stays a pure presentational component, per CLAUDE.md:315.
+- The row stays a pure presentational component. See the CLAUDE.md:315
+  caveat under Option A: the rule scopes to virtualized lists, so this is an
+  alignment, not a rule the current code breaks.
 - A **required** prop makes a forgetful future caller a `tsc` error, not a
   silent host-clock regression. This is the property Option A cannot give.
 - The hook documents a stable object identity
@@ -172,8 +184,25 @@ Cases:
 4. A shift that is today in Phoenix and yesterday in Auckland does not show
    `Today`.
 
-Each case asserts both the wanted string and the absence of the host-zone
+Cases 1 to 4 assert both the wanted string and the absence of the host-zone
 string.
+
+The Phase 2.5 frontend reviewer found a coverage gap. `getShiftStatusBadge` has
+five branches. The six cases in `tests/unit/ShiftRow.test.tsx` all use a shift
+seven days out, so they reach `Cancelled`, `Today` and `Upcoming` only. No test
+reaches `Completed` ([ShiftRow.tsx:43](src/components/employee/ShiftRow.tsx:43))
+or `In Progress` ([ShiftRow.tsx:52](src/components/employee/ShiftRow.tsx:52)).
+This task edits that same function and that same import line, so a mistake in
+those two branches would ship. Close the gap:
+
+5. A shift that ended one hour ago shows `Completed`.
+6. A shift that started one hour ago and ends in one hour shows `In Progress`.
+
+Cases 5 and 6 belong in `tests/unit/ShiftRow.test.tsx`, not in the new
+timezone file. They pin branch order, not zone behaviour. Both branches compare
+instants, so the badge must be the same under every host zone. Assert that:
+run each case a second time with the host zone pinned to `America/Phoenix` and
+check the badge does not change.
 
 ### 5.5 `tests/unit/EmployeeSchedule.restaurantTz.test.tsx`
 

--- a/docs/superpowers/specs/2026-08-19-shiftrow-restaurant-clock-design.md
+++ b/docs/superpowers/specs/2026-08-19-shiftrow-restaurant-clock-design.md
@@ -1,0 +1,202 @@
+# Design: read the restaurant clock in `ShiftRow`
+
+Date: 2026-08-19
+Branch: `claude/vigorous-jemison-90a798`
+Status: proposed
+
+## 1. Problem
+
+`src/components/employee/ShiftRow.tsx` renders an employee's shift. It reads
+the host browser clock for every date question. The employee portal is the one
+surface a traveling employee opens from another zone.
+
+Two defect classes exist in the file.
+
+**Wall-clock labels.** The row prints the start and end time with
+`format(parseISO(shift.start_time), 'h:mm a')`
+([ShiftRow.tsx:154](src/components/employee/ShiftRow.tsx:154),
+[ShiftRow.tsx:187](src/components/employee/ShiftRow.tsx:187)). The `upcoming`
+variant also prints the weekday, day number and month with the same call
+([ShiftRow.tsx:143](src/components/employee/ShiftRow.tsx:143),
+[ShiftRow.tsx:146](src/components/employee/ShiftRow.tsx:146),
+[ShiftRow.tsx:149](src/components/employee/ShiftRow.tsx:149)). `format` reads
+an instant in the host zone. An employee in Denver reads a Chicago 5 p.m. shift
+as "4:00 PM". The date block can name the wrong weekday and the wrong month.
+
+**The `Today` badge.** `getShiftStatusBadge` decides the badge with
+`isToday(startTime)` ([ShiftRow.tsx:61](src/components/employee/ShiftRow.tsx:61)),
+where `startTime` is `new Date(shift.start_time)`
+([ShiftRow.tsx:30](src/components/employee/ShiftRow.tsx:30)). `isToday`
+compares host calendar days. A shift that the restaurant calls today gets
+`Upcoming` when the viewer's zone is behind, and the reverse when it is ahead.
+
+This is the same defect class that commit `5b1e1490` fixed one level up, in
+`shiftsByDay` and the day-header badge of
+[EmployeeSchedule.tsx](src/pages/EmployeeSchedule.tsx). That commit's test had
+to scope its `Today` query to the day-header strip, because `ShiftRow` renders
+a second, host-clock `Today` inside the same row
+([EmployeeSchedule.restaurantTz.test.tsx:129](tests/unit/EmployeeSchedule.restaurantTz.test.tsx:129)).
+That workaround is the evidence for this task.
+
+## 2. What is already correct — do not change
+
+Three call sites compare instants, not calendar days. An instant comparison
+gives the same answer in every zone.
+
+- `isPast(endTime)` ([ShiftRow.tsx:43](src/components/employee/ShiftRow.tsx:43))
+- `now >= startTime && now <= endTime`
+  ([ShiftRow.tsx:52](src/components/employee/ShiftRow.tsx:52))
+- `isFuture(startTime)` ([ShiftRow.tsx:70](src/components/employee/ShiftRow.tsx:70))
+  and `canTrade`'s `isFuture(parseISO(shift.start_time))`
+  ([ShiftRow.tsx:117](src/components/employee/ShiftRow.tsx:117))
+
+`formatShiftDuration` subtracts two instants with `differenceInMinutes`
+([ShiftRow.tsx:23](src/components/employee/ShiftRow.tsx:23)). This is also
+zone-independent.
+
+Keep all five. A change here adds risk and fixes nothing.
+
+## 3. Where the clock comes from
+
+`useRestaurantClock()` returns `{tz, tzAbbrev, viewerTzDiffers, today,
+formatInstant, toBusinessDay, toWallClockInput, parseWallClock}`
+([useRestaurantClock.ts:15-24](src/hooks/useRestaurantClock.ts:15)). Its
+`today` comes from `useTodayInTimezone(tz)`
+([useRestaurantClock.ts:39](src/hooks/useRestaurantClock.ts:39)), which rolls
+over at restaurant midnight.
+
+`formatInstant(value, tz, pattern)`
+([restaurantClock.ts:122](src/lib/restaurantClock.ts:122)) and
+`toBusinessDay(value, tz)`
+([restaurantClock.ts:128](src/lib/restaurantClock.ts:128)) are the two library
+functions the clock wraps.
+
+`EmployeeSchedule` already holds a clock at
+[EmployeeSchedule.tsx:81](src/pages/EmployeeSchedule.tsx:81). It renders
+`ShiftRow` at two sites:
+[EmployeeSchedule.tsx:282](src/pages/EmployeeSchedule.tsx:282) (`upcoming`
+variant) and [EmployeeSchedule.tsx:383](src/pages/EmployeeSchedule.tsx:383)
+(`day` variant). These are the only two call sites in `src`.
+
+## 4. Options
+
+### Option A — call `useRestaurantClock()` inside `ShiftRow`
+
+Matches the majority pattern. Leaf components already do this, for example
+[EmployeeAuditDetail.tsx:69](src/components/payroll/EmployeeAuditDetail.tsx:69)
+and
+[ReviewFeedbackDetail.tsx:41](src/components/reviews/ReviewFeedbackDetail.tsx:41).
+Call sites need no change.
+
+Two costs:
+
+1. **One timer per row.** `useTodayInTimezone` starts a 60-second
+   `setInterval` and two window listeners for each hook instance
+   ([useTodayInTimezone.ts:28-35](src/hooks/useTodayInTimezone.ts:28)). A full
+   week grid plus the Upcoming card renders tens of rows, so the page would
+   hold tens of timers that all compute the same string. CLAUDE.md:315 says a
+   row component must have no hooks inside and take all data as props.
+2. **The row stops working without a provider.** `useRestaurantContext` throws
+   when no provider is above it
+   ([RestaurantContext.tsx:25-27](src/contexts/RestaurantContext.tsx:25)).
+   `tests/unit/ShiftRow.test.tsx` renders the row bare, for example at
+   [ShiftRow.test.tsx:35](tests/unit/ShiftRow.test.tsx:35). Every case in that
+   file would need a context mock.
+
+### Option B — pass the clock as a required prop (recommended)
+
+Add `clock: RestaurantClock` to `ShiftRowProps`. `EmployeeSchedule` passes the
+object it already has.
+
+- One timer for the page, not one per row.
+- The row stays a pure presentational component, per CLAUDE.md:315.
+- A **required** prop makes a forgetful future caller a `tsc` error, not a
+  silent host-clock regression. This is the property Option A cannot give.
+- The hook documents a stable object identity
+  ([useRestaurantClock.ts:26-33](src/hooks/useRestaurantClock.ts:26)), so the
+  prop does not defeat future memoization.
+- Cost: the six existing cases in `tests/unit/ShiftRow.test.tsx` must pass a
+  clock. A local `makeClock(tz, today)` helper covers this in a few lines.
+
+### Option C — pass `timezone: string` and `today: string`
+
+Same benefits as B with two props instead of one. Rejected: it splits one
+concept across two arguments, and a caller can pass a `today` from a different
+zone than `timezone`.
+
+**Recommendation: Option B.**
+
+## 5. The change
+
+### 5.1 `src/components/employee/ShiftRow.tsx`
+
+1. Add `clock: RestaurantClock` to `ShiftRowProps`, required.
+2. Change `getShiftStatusBadge(shift)` to `getShiftStatusBadge(shift, clock)`.
+   Replace `isToday(startTime)` with
+   `clock.toBusinessDay(shift.start_time) === clock.today`.
+3. Replace every `format(parseISO(x), p)` with `clock.formatInstant(x, p)`.
+   This covers the four patterns `'h:mm a'`, `'EEE'`, `'d'` and `'MMM'`.
+4. Delete `format`, `parseISO` and `isToday` from the `date-fns` import
+   ([ShiftRow.tsx:1](src/components/employee/ShiftRow.tsx:1)). Keep `isPast`,
+   `isFuture` and `differenceInMinutes`.
+5. `canTrade` keeps `isFuture`, but on `new Date(shift.start_time)` after
+   `parseISO` goes. Both parse the same ISO string to the same instant.
+6. Add a comment that names which questions are calendar-day questions and
+   which are instant questions, so the next reader does not "fix" section 2.
+
+### 5.2 `src/pages/EmployeeSchedule.tsx`
+
+Pass `clock={clock}` at
+[EmployeeSchedule.tsx:282](src/pages/EmployeeSchedule.tsx:282) and
+[EmployeeSchedule.tsx:383](src/pages/EmployeeSchedule.tsx:383).
+
+### 5.3 `tests/unit/ShiftRow.test.tsx`
+
+Add a `makeClock` helper and pass it in the six existing cases. The helper
+builds a real clock from `src/lib/restaurantClock.ts`, so it cannot drift from
+production behaviour.
+
+### 5.4 `tests/unit/ShiftRow.restaurantTz.test.tsx` (new)
+
+Pin the host zone to `America/Phoenix` and the restaurant to
+`Pacific/Auckland`. Copy the `pinHostTzToPhoenix` guard from
+[useShiftsRecurringCreateTz.test.ts:92](tests/unit/useShiftsRecurringCreateTz.test.ts:92).
+The guard asserts `getTimezoneOffset() === 420`, because the `process.env.TZ`
+assignment can fail without an error and leave a vacuous test.
+
+Cases:
+
+1. The `day` variant prints the restaurant wall-clock time, not the host one.
+2. The `upcoming` variant prints the restaurant weekday, day number and month.
+3. A shift that is today in Auckland and tomorrow in Phoenix shows `Today`.
+4. A shift that is today in Phoenix and yesterday in Auckland does not show
+   `Today`.
+
+Each case asserts both the wanted string and the absence of the host-zone
+string.
+
+### 5.5 `tests/unit/EmployeeSchedule.restaurantTz.test.tsx`
+
+Delete the `dayHeader` scoping workaround and its comment
+([EmployeeSchedule.restaurantTz.test.tsx:129](tests/unit/EmployeeSchedule.restaurantTz.test.tsx:129))
+only if the row badge no longer collides. Keep the scoping if two `Today`
+strings still appear for a correct reason. Decide from the test run, not from
+this document.
+
+## 6. Out of scope
+
+- **Badge staleness.** `getShiftStatusBadge` reads `new Date()` at render
+  ([ShiftRow.tsx:32](src/components/employee/ShiftRow.tsx:32)). No ticker
+  re-renders the row, so `Upcoming` does not become `In Progress` while the
+  page stays open. `memory/lessons.md:1242` describes the `useNowTick` fix for
+  this class. It is a different defect and it needs its own design.
+- **Other host-clock surfaces** in the employee portal.
+
+## 7. Risk
+
+Low. The change is display-only. No data write, no query, no RLS surface, no
+migration. The worst failure is a wrong label, and the new tests fail on a
+wrong label by construction.
+
+The one real risk is a silent revert: a future component renders `ShiftRow`
+and the required `clock` prop stops that at compile time.

--- a/memory/lessons.md
+++ b/memory/lessons.md
@@ -2966,8 +2966,8 @@
 ## Category: Data Accuracy (continued)
 
 ### [2026-08-19] Split a date into a calendar-day question and an instant question (PR #764)
-- **Mistake risk, avoided:** The task brief said `ShiftRow` uses `isToday`, `isPast`, `isFuture` and `new Date()` on the host clock, and asked to move the page to the restaurant timezone. A blanket rewrite of all four would have been wrong.
-- **Correction:** The design split the five badge branches by the question each one asks. "Is this shift today?" is a calendar-day question, so it now reads `clock.toBusinessDay(shift.start_time) === clock.today`. "Is this shift over?" and "is it in progress?" compare instants, and an instant compares the same way in every zone, so `isPast`, `isFuture` and the `now` range check stay unchanged. Both Phase 2.5 reviewers confirmed the split. Commit 7a74b35b carries the rule as a comment above the function.
+- **Mistake risk, avoided:** The task brief said `ShiftRow` uses `isToday`, `isPast`, `isFuture` and `new Date()` on the host clock, and asked to move the page to the restaurant timezone. A change to all four calls would have been wrong.
+- **Correction:** The design split the five badge branches by the question each one asks. "Is this shift today?" is a calendar-day question, so it now reads `clock.toBusinessDay(shift.start_time) === clock.today`. "Is this shift over?" and "is it in progress?" compare instants, and an instant compares the same way in every zone, so `isPast`, `isFuture` and the `now` range check stay unchanged. Both Phase 2.5 reviewers confirmed the split. Commit 7a74b35b puts the rule in a comment above the function.
 - **Rule:** Before you route a date through the restaurant clock, name the question it answers. A calendar-day question needs the zone. An instant comparison does not, and the clock adds risk with no gain. Write the split into the code as a comment, or the next author reverts it.
 
 ### [2026-08-19] Test count is not branch count (PR #764)
@@ -2975,13 +2975,18 @@
 - **Correction:** A Phase 2.5 reviewer read the branches, not the test names, and found the gap. The plan gained two cases plus a re-run with the host zone pinned to `America/Phoenix`, which proves the two instant branches do not move with the host clock.
 - **Rule:** Count the branches in the function, then map each test to a branch. A fixture reused across every case can pin the code to one branch and hide the rest.
 
+### [2026-08-19] An `as` cast lets a wrong field name into a fixture (PR #764)
+- **Mistake:** `tests/unit/ShiftRow.publishes.test.tsx` built its `Shift` fixture with `break_minutes: 0`. The type names the field `break_duration` (`src/types/scheduling.ts:117`). The `as Shift` cast silenced `tsc`, so `break_duration` stayed `undefined` and every row in that file rendered `NaNh NaNm`. Three tests passed anyway, because none of them read the duration. CodeRabbit found it.
+- **Correction:** The fixture now sets `break_duration: 0`. A fourth case asserts the row shows `8h 0m` and contains no `NaN`, so the wrong field name cannot come back unseen.
+- **Rule:** An `as T` cast on a test fixture turns a wrong field name into silent `undefined`. Build fixtures with a typed factory, or assert one rendered value that depends on each field. A passing test proves nothing about a field it never reads.
+
 ## Category: Dev workflow / Worktree hygiene (continued)
 
-### [2026-08-19] Green CI does not mean mergeable; check both (PR #764)
-- **Mistake:** The workflow finished, opened PR #764, and reported all checks green. `gh pr view --json mergeable` then returned `CONFLICTING`. PR #761 had landed on main and touched both changed files. Nothing in the check output showed this.
+### [2026-08-19] A pass on every check does not mean the branch merges (PR #764)
+- **Mistake:** The workflow finished, opened PR #764, and reported a pass on every check. `gh pr view --json mergeable` then returned `CONFLICTING`. PR #761 had landed on main and touched both changed files. Nothing in the check output showed this.
 - **Correction:** `git merge origin/main` produced 8 conflicts: 2 in `ShiftRow.tsx` and 6 in `EmployeeSchedule.tsx`. The resolution kept main's shared `getRestaurantWeekStart` helper over the equivalent inline code on this branch, and kept both new props on `ShiftRow`. Nine tests then failed for two reasons that no conflict marker showed: main's new test file did not pass the required `clock` prop, and the merged page called `useRestaurantPublishes`, which runs a React Query query that three timezone tests did not mock.
-- **Rule:** After CI turns green, query `mergeable` before you report the PR ready. When you merge main into a branch, run the full suite after the merge. A clean conflict resolution still breaks tests that neither side changed.
+- **Rule:** After every check passes, query `mergeable` before you report the PR ready. When you merge main into a branch, run the full suite after the merge. A clean conflict resolution still breaks tests that neither side changed.
 
 ### [2026-08-19] `npm run typecheck` does not read the test folder (PR #764)
 - **Mistake:** `tests/unit/ShiftRow.publishes.test.tsx` rendered `ShiftRow` without the new required `clock` prop. `npm run typecheck` passed. `tsconfig.app.json` sets `"include": ["src"]`, so `tsc` never read the file. Only the test run found it, as a runtime `TypeError` on `undefined.toBusinessDay`.
-- **Rule:** When you add a required prop to a shared component, grep the test folder for the component name. Do not treat a green `typecheck` as proof that the call sites compile — confirm which folders the tsconfig includes.
+- **Rule:** When you add a required prop to a shared component, grep the test folder for the component name. A `typecheck` pass does not prove the call sites compile. Check which folders the tsconfig includes.

--- a/memory/lessons.md
+++ b/memory/lessons.md
@@ -2962,3 +2962,26 @@
 - **Mistake:** `dev-tools/review_queue.json` conflicted with `main` after the workflow finished. Two branches each appended review findings to the same 6000-item file. `gh pr view` reported `mergeStateStatus: DIRTY` after every check had already passed.
 - **Correction:** A three-way compare showed pure additions on both sides, and zero changed items. The fix took the union by `id`: every item from `main`, then the 34 items this branch adds. The serialization had to match `main` exactly — `json.dumps(d, indent=2, ensure_ascii=False)` with no trailing newline — or the diff read as 1401 changed lines instead of 580 added ones.
 - **Rule:** Before you fix a conflict in a machine-written JSON file, compare base, ours, and theirs as parsed objects, not as text. Check whether either side changed an existing record. Then reproduce the writer's exact serialization, and confirm the diff against `main` is additions only.
+
+## Category: Data Accuracy (continued)
+
+### [2026-08-19] Split a date into a calendar-day question and an instant question (PR #764)
+- **Mistake risk, avoided:** The task brief said `ShiftRow` uses `isToday`, `isPast`, `isFuture` and `new Date()` on the host clock, and asked to move the page to the restaurant timezone. A blanket rewrite of all four would have been wrong.
+- **Correction:** The design split the five badge branches by the question each one asks. "Is this shift today?" is a calendar-day question, so it now reads `clock.toBusinessDay(shift.start_time) === clock.today`. "Is this shift over?" and "is it in progress?" compare instants, and an instant compares the same way in every zone, so `isPast`, `isFuture` and the `now` range check stay unchanged. Both Phase 2.5 reviewers confirmed the split. Commit 7a74b35b carries the rule as a comment above the function.
+- **Rule:** Before you route a date through the restaurant clock, name the question it answers. A calendar-day question needs the zone. An instant comparison does not, and the clock adds risk with no gain. Write the split into the code as a comment, or the next author reverts it.
+
+### [2026-08-19] Test count is not branch count (PR #764)
+- **Mistake:** `tests/unit/ShiftRow.test.tsx` held six cases for a function with five branches. Every case used a shift seven days out, so `Completed` and `In Progress` never ran. The suite looked complete and covered three of five branches.
+- **Correction:** A Phase 2.5 reviewer read the branches, not the test names, and found the gap. The plan gained two cases plus a re-run with the host zone pinned to `America/Phoenix`, which proves the two instant branches do not move with the host clock.
+- **Rule:** Count the branches in the function, then map each test to a branch. A fixture reused across every case can pin the code to one branch and hide the rest.
+
+## Category: Dev workflow / Worktree hygiene (continued)
+
+### [2026-08-19] Green CI does not mean mergeable; check both (PR #764)
+- **Mistake:** The workflow finished, opened PR #764, and reported all checks green. `gh pr view --json mergeable` then returned `CONFLICTING`. PR #761 had landed on main and touched both changed files. Nothing in the check output showed this.
+- **Correction:** `git merge origin/main` produced 8 conflicts: 2 in `ShiftRow.tsx` and 6 in `EmployeeSchedule.tsx`. The resolution kept main's shared `getRestaurantWeekStart` helper over the equivalent inline code on this branch, and kept both new props on `ShiftRow`. Nine tests then failed for two reasons that no conflict marker showed: main's new test file did not pass the required `clock` prop, and the merged page called `useRestaurantPublishes`, which runs a React Query query that three timezone tests did not mock.
+- **Rule:** After CI turns green, query `mergeable` before you report the PR ready. When you merge main into a branch, run the full suite after the merge. A clean conflict resolution still breaks tests that neither side changed.
+
+### [2026-08-19] `npm run typecheck` does not read the test folder (PR #764)
+- **Mistake:** `tests/unit/ShiftRow.publishes.test.tsx` rendered `ShiftRow` without the new required `clock` prop. `npm run typecheck` passed. `tsconfig.app.json` sets `"include": ["src"]`, so `tsc` never read the file. Only the test run found it, as a runtime `TypeError` on `undefined.toBusinessDay`.
+- **Rule:** When you add a required prop to a shared component, grep the test folder for the component name. Do not treat a green `typecheck` as proof that the call sites compile — confirm which folders the tsconfig includes.

--- a/src/components/employee/ShiftRow.tsx
+++ b/src/components/employee/ShiftRow.tsx
@@ -11,9 +11,9 @@ import {
   MapPin,
   XCircle,
 } from 'lucide-react';
+import { RestaurantClock } from '@/hooks/useRestaurantClock';
 import { Shift } from '@/types/scheduling';
 import { cn } from '@/lib/utils';
-import { RestaurantClock } from '@/hooks/useRestaurantClock';
 
 function formatShiftDuration(startTime: string, endTime: string, breakMinutes: number): string {
   const start = new Date(startTime);

--- a/src/components/employee/ShiftRow.tsx
+++ b/src/components/employee/ShiftRow.tsx
@@ -1,4 +1,4 @@
-import { format, parseISO, isToday, isFuture, isPast, differenceInMinutes } from 'date-fns';
+import { isFuture, isPast, differenceInMinutes } from 'date-fns';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react';
 import { Shift } from '@/types/scheduling';
 import { cn } from '@/lib/utils';
+import { RestaurantClock } from '@/hooks/useRestaurantClock';
 
 function formatShiftDuration(startTime: string, endTime: string, breakMinutes: number): string {
   const start = new Date(startTime);
@@ -26,7 +27,13 @@ function formatShiftDuration(startTime: string, endTime: string, breakMinutes: n
   return `${hours}h ${minutes}m`;
 }
 
-function getShiftStatusBadge(shift: Shift): JSX.Element | null {
+// Two kinds of question live here. "Is this shift today?" is a calendar-day
+// question: it must use the restaurant's business day (`clock.toBusinessDay`
+// vs `clock.today`), not the viewer's. "Is this shift over, in progress, or
+// not yet started?" is an instant question: an instant compares the same way
+// in every timezone, so `isPast`, `isFuture` and the `now` range check stay
+// exactly as they are — do not route them through the clock.
+function getShiftStatusBadge(shift: Shift, clock: RestaurantClock): JSX.Element | null {
   const startTime = new Date(shift.start_time);
   const endTime = new Date(shift.end_time);
   const now = new Date();
@@ -58,7 +65,7 @@ function getShiftStatusBadge(shift: Shift): JSX.Element | null {
     );
   }
 
-  if (isToday(startTime)) {
+  if (clock.toBusinessDay(shift.start_time) === clock.today) {
     return (
       <Badge variant="default" className="flex items-center gap-1">
         <Clock className="h-3 w-3" />
@@ -90,6 +97,7 @@ interface ShiftRowProps {
    */
   variant?: ShiftRowVariant;
   onTrade?: (shift: Shift) => void;
+  clock: RestaurantClock;
 }
 
 /** Cancelled outranks draft, which outranks the per-variant default. */
@@ -100,7 +108,7 @@ function getSurfaceClass(isCancelled: boolean, isDraft: boolean, variant: ShiftR
   return 'bg-muted/50';
 }
 
-export function ShiftRow({ shift, variant = 'day', onTrade }: ShiftRowProps): JSX.Element {
+export function ShiftRow({ shift, variant = 'day', onTrade, clock }: ShiftRowProps): JSX.Element {
   const isDraft = !shift.is_published;
   const isCancelled = shift.status === 'cancelled';
 
@@ -114,7 +122,7 @@ export function ShiftRow({ shift, variant = 'day', onTrade }: ShiftRowProps): JS
   const surface = getSurfaceClass(isCancelled, isDraft, variant);
   const timeText = isDraft ? 'font-normal text-muted-foreground' : 'font-medium';
 
-  const canTrade = !!onTrade && !isCancelled && isFuture(parseISO(shift.start_time));
+  const canTrade = !!onTrade && !isCancelled && isFuture(new Date(shift.start_time));
 
   const tradeButton = canTrade ? (
     <Button
@@ -128,7 +136,7 @@ export function ShiftRow({ shift, variant = 'day', onTrade }: ShiftRowProps): JS
     </Button>
   ) : null;
 
-  const statusBadge = getShiftStatusBadge(shift);
+  const statusBadge = getShiftStatusBadge(shift, clock);
 
   // Color and border alone would fail a screen reader and WCAG 1.4.1.
   const draftSrLabel =
@@ -140,19 +148,19 @@ export function ShiftRow({ shift, variant = 'day', onTrade }: ShiftRowProps): JS
         <div className="flex items-center gap-4">
           <div className="text-center">
             <div className="text-sm font-medium text-muted-foreground">
-              {format(parseISO(shift.start_time), 'EEE')}
+              {clock.formatInstant(shift.start_time, 'EEE')}
             </div>
             <div className={cn('text-2xl', isDraft ? 'font-normal text-muted-foreground' : 'font-bold')}>
-              {format(parseISO(shift.start_time), 'd')}
+              {clock.formatInstant(shift.start_time, 'd')}
             </div>
             <div className="text-xs text-muted-foreground">
-              {format(parseISO(shift.start_time), 'MMM')}
+              {clock.formatInstant(shift.start_time, 'MMM')}
             </div>
           </div>
           <div>
             <div className={timeText}>
-              {format(parseISO(shift.start_time), 'h:mm a')} -{' '}
-              {format(parseISO(shift.end_time), 'h:mm a')}
+              {clock.formatInstant(shift.start_time, 'h:mm a')} -{' '}
+              {clock.formatInstant(shift.end_time, 'h:mm a')}
             </div>
             <div className="text-sm text-muted-foreground flex items-center gap-2">
               <MapPin className="h-3 w-3" />
@@ -184,8 +192,8 @@ export function ShiftRow({ shift, variant = 'day', onTrade }: ShiftRowProps): JS
       <div className="flex items-center gap-4">
         <div>
           <div className={timeText}>
-            {format(parseISO(shift.start_time), 'h:mm a')} -{' '}
-            {format(parseISO(shift.end_time), 'h:mm a')}
+            {clock.formatInstant(shift.start_time, 'h:mm a')} -{' '}
+            {clock.formatInstant(shift.end_time, 'h:mm a')}
           </div>
           <div className="text-sm text-muted-foreground">{shift.position}</div>
         </div>

--- a/src/pages/EmployeeSchedule.tsx
+++ b/src/pages/EmployeeSchedule.tsx
@@ -279,7 +279,7 @@ const EmployeeSchedule = () => {
           <CardContent>
             <div className="space-y-3">
               {upcomingShifts.map((shift) => (
-                <ShiftRow key={shift.id} shift={shift} variant="upcoming" />
+                <ShiftRow key={shift.id} shift={shift} variant="upcoming" clock={clock} />
               ))}
             </div>
           </CardContent>
@@ -380,7 +380,7 @@ const EmployeeSchedule = () => {
                     ) : (
                       <div className="space-y-2">
                         {dayShifts.map((shift) => (
-                          <ShiftRow key={shift.id} shift={shift} onTrade={handleTradeShift} />
+                          <ShiftRow key={shift.id} shift={shift} onTrade={handleTradeShift} clock={clock} />
                         ))}
                       </div>
                     )}

--- a/src/pages/EmployeeSchedule.tsx
+++ b/src/pages/EmployeeSchedule.tsx
@@ -35,12 +35,12 @@ import {
   subWeeks,
   addWeeks,
   eachDayOfInterval,
-  parseISO,
-  isToday,
   differenceInMinutes,
 } from 'date-fns';
 import { WEEK_STARTS_ON } from '@/lib/dateConfig';
-import { safeTz } from '@/lib/restaurantClock';
+import { useRestaurantClock } from '@/hooks/useRestaurantClock';
+import { toBusinessDay } from '@/lib/restaurantClock';
+import { toDateOnlyString } from '@/lib/dateOnly';
 import { formatLocalDate } from '@/lib/shiftInterval';
 import {
   computeScheduleFingerprint,
@@ -72,7 +72,15 @@ const EmployeeSchedule = () => {
     refetch: refetchShifts,
   } = useMyShifts(restaurantId, currentEmployee?.id ?? null, currentWeekStart, weekEnd);
 
-  const restaurantTimezone = safeTz(selectedRestaurant?.restaurant?.timezone);
+  // The restaurant's clock, never the host browser's. Two questions on this
+  // page are calendar-day questions -- "which day column does this shift belong
+  // to" and "which day is today" -- and only the restaurant's calendar answers
+  // them. An employee who opens the page from another zone (travel, a remote
+  // manager, a phone that never left the last airport) otherwise reads a
+  // different week than the one the restaurant published.
+  const clock = useRestaurantClock();
+  const restaurantTimezone = clock.tz;
+  const restaurantToday = clock.today;
 
   // What this week actually IS, as opposed to what the rows look like: a week
   // that was announced and then pulled back is otherwise indistinguishable
@@ -129,19 +137,26 @@ const EmployeeSchedule = () => {
   // Group shifts by day
   const shiftsByDay = useMemo(() => {
     const grouped = new Map<string, Shift[]>();
+    // `weekDays` are calendar days the user navigated to, held as host-local
+    // midnight `Date`s -- `toDateOnlyString` reads their fields, it does not
+    // convert an instant.
     weekDays.forEach((day) => {
-      grouped.set(format(day, 'yyyy-MM-dd'), []);
+      grouped.set(toDateOnlyString(day), []);
     });
 
     myShifts.forEach((shift) => {
-      const dayKey = format(parseISO(shift.start_time), 'yyyy-MM-dd');
+      // `start_time` IS an instant, so it needs the restaurant's zone to name
+      // a day. The old `format(parseISO(...))` read it in the viewer's zone:
+      // a 9 p.m. shift seen from a zone one day ahead landed in the next day's
+      // column, and on the week's last day it matched no column and vanished.
+      const dayKey = toBusinessDay(shift.start_time, restaurantTimezone);
       if (grouped.has(dayKey)) {
         grouped.get(dayKey)!.push(shift);
       }
     });
 
     return grouped;
-  }, [myShifts, weekDays]);
+  }, [myShifts, weekDays, restaurantTimezone]);
 
   // Calculate weekly totals
   const weeklyStats = useMemo(() => {
@@ -336,13 +351,14 @@ const EmployeeSchedule = () => {
           ) : (
             <div className="space-y-3">
               {weekDays.map((day) => {
-                const dayKey = format(day, 'yyyy-MM-dd');
+                const dayKey = toDateOnlyString(day);
                 const dayShifts = shiftsByDay.get(dayKey) || [];
-                const isDayToday = isToday(day);
+                const isDayToday = dayKey === restaurantToday;
 
                 return (
                   <div
                     key={dayKey}
+                    data-testid={`schedule-day-${dayKey}`}
                     className={`p-4 rounded-lg border ${
                       isDayToday ? 'bg-primary/5 border-primary/20' : 'bg-card'
                     }`}

--- a/src/pages/EmployeeSchedule.tsx
+++ b/src/pages/EmployeeSchedule.tsx
@@ -65,14 +65,14 @@ const EmployeeSchedule = () => {
   const restaurantToday = clock.today;
 
   // The week itself must start from the restaurant's calendar day, not the
-  // host's. `shiftsByDay` below keys every shift by `clock.toBusinessDay` --
-  // if the week anchor came from the host's `new Date()` instead, the two
-  // clocks could disagree about which week "now" falls in near a week
-  // boundary (host America/Phoenix, restaurant Pacific/Auckland is ~19-20h
-  // apart), and a shift for the restaurant's actual current day would match
-  // no column here and silently vanish from the grid.
+  // host's. `shiftsByDay` below keys every shift by the `toBusinessDay`
+  // helper -- if the week anchor came from the host's `new Date()` instead,
+  // the two clocks could disagree about which week "now" falls in near a
+  // week boundary (host America/Phoenix, restaurant Pacific/Auckland is
+  // ~19-20h apart), and a shift for the restaurant's actual current day
+  // would match no column here and silently vanish from the grid.
   const [currentWeekStart, setCurrentWeekStart] = useState(() =>
-    startOfWeek(parseDateOnly(clock.today), { weekStartsOn: WEEK_STARTS_ON })
+    startOfWeek(parseDateOnly(restaurantToday), { weekStartsOn: WEEK_STARTS_ON })
   );
   const [tradeDialogOpen, setTradeDialogOpen] = useState(false);
   const pageHeaderRef = useRef<HTMLDivElement>(null);

--- a/src/pages/EmployeeSchedule.tsx
+++ b/src/pages/EmployeeSchedule.tsx
@@ -39,7 +39,7 @@ import {
   differenceInMinutes,
 } from 'date-fns';
 import { WEEK_STARTS_ON } from '@/lib/dateConfig';
-import { toBusinessDay } from '@/lib/restaurantClock';
+import { toBusinessDay, businessDayRangeToInstants } from '@/lib/restaurantClock';
 import { toDateOnlyString, parseDateOnly } from '@/lib/dateOnly';
 import { formatLocalDate } from '@/lib/shiftInterval';
 import {
@@ -81,13 +81,31 @@ const EmployeeSchedule = () => {
   const weekEnd = endOfWeek(currentWeekStart, { weekStartsOn: WEEK_STARTS_ON });
   const weekDays = eachDayOfInterval({ start: currentWeekStart, end: weekEnd });
 
+  // Calendar-day strings for the visible week, read from host-local `Date`
+  // fields. `currentWeekStart` was itself seeded from the restaurant's
+  // calendar day (`restaurantToday`), so these strings already name the
+  // restaurant's week, not the host's.
+  const weekStartStr = formatLocalDate(currentWeekStart);
+  const weekEndStr = formatLocalDate(weekEnd);
+
+  // The shift query needs UTC instants, not host-local `Date`s. Calling
+  // `.toISOString()` on `currentWeekStart`/`weekEnd` would bound the query in
+  // the HOST's zone: for a Phoenix viewer and an Auckland restaurant the two
+  // windows sit ~19h apart, so most of Auckland's Monday shifts would fall
+  // outside the query and never load. `businessDayRangeToInstants` resolves
+  // restaurant-local midnight for both ends instead.
+  const { start: queryStart, end: queryEnd } = useMemo(
+    () => businessDayRangeToInstants(weekStartStr, weekEndStr, restaurantTimezone),
+    [weekStartStr, weekEndStr, restaurantTimezone]
+  );
+
   const { currentEmployee, loading: employeeLoading } = useCurrentEmployee(restaurantId);
   const {
     shifts: myShifts,
     loading: shiftsLoading,
     error: shiftsError,
     refetch: refetchShifts,
-  } = useMyShifts(restaurantId, currentEmployee?.id ?? null, currentWeekStart, weekEnd);
+  } = useMyShifts(restaurantId, currentEmployee?.id ?? null, queryStart, queryEnd);
 
   // What this week actually IS, as opposed to what the rows look like: a week
   // that was announced and then pulled back is otherwise indistinguishable
@@ -118,7 +136,6 @@ const EmployeeSchedule = () => {
     [publication?.published_at, myShifts]
   );
 
-  const weekStartStr = formatLocalDate(currentWeekStart);
   const employeeId = currentEmployee?.id ?? null;
 
   const [seenFingerprint, setSeenFingerprint] = useState<string | null>(null);

--- a/src/pages/EmployeeSchedule.tsx
+++ b/src/pages/EmployeeSchedule.tsx
@@ -8,6 +8,7 @@ import { useRestaurantContext } from '@/contexts/RestaurantContext';
 import { useCurrentEmployee } from '@/hooks/useCurrentEmployee';
 import { useMyShifts } from '@/hooks/useShifts';
 import { useWeekScheduleStatus } from '@/hooks/useSchedulePublish';
+import { useRestaurantClock } from '@/hooks/useRestaurantClock';
 import { TradeRequestDialog } from '@/components/schedule/TradeRequestDialog';
 import { MyShiftTradesCard } from '@/components/schedule/MyShiftTradesCard';
 import {
@@ -38,9 +39,8 @@ import {
   differenceInMinutes,
 } from 'date-fns';
 import { WEEK_STARTS_ON } from '@/lib/dateConfig';
-import { useRestaurantClock } from '@/hooks/useRestaurantClock';
 import { toBusinessDay } from '@/lib/restaurantClock';
-import { toDateOnlyString } from '@/lib/dateOnly';
+import { toDateOnlyString, parseDateOnly } from '@/lib/dateOnly';
 import { formatLocalDate } from '@/lib/shiftInterval';
 import {
   computeScheduleFingerprint,
@@ -54,8 +54,25 @@ const EmployeeSchedule = () => {
   const { selectedRestaurant } = useRestaurantContext();
   const restaurantId = selectedRestaurant?.restaurant_id || null;
 
-  const [currentWeekStart, setCurrentWeekStart] = useState(
-    startOfWeek(new Date(), { weekStartsOn: WEEK_STARTS_ON })
+  // The restaurant's clock, never the host browser's. Two questions on this
+  // page are calendar-day questions -- "which day column does this shift belong
+  // to" and "which day is today" -- and only the restaurant's calendar answers
+  // them. An employee who opens the page from another zone (travel, a remote
+  // manager, a phone that never left the last airport) otherwise reads a
+  // different week than the one the restaurant published.
+  const clock = useRestaurantClock();
+  const restaurantTimezone = clock.tz;
+  const restaurantToday = clock.today;
+
+  // The week itself must start from the restaurant's calendar day, not the
+  // host's. `shiftsByDay` below keys every shift by `clock.toBusinessDay` --
+  // if the week anchor came from the host's `new Date()` instead, the two
+  // clocks could disagree about which week "now" falls in near a week
+  // boundary (host America/Phoenix, restaurant Pacific/Auckland is ~19-20h
+  // apart), and a shift for the restaurant's actual current day would match
+  // no column here and silently vanish from the grid.
+  const [currentWeekStart, setCurrentWeekStart] = useState(() =>
+    startOfWeek(parseDateOnly(clock.today), { weekStartsOn: WEEK_STARTS_ON })
   );
   const [tradeDialogOpen, setTradeDialogOpen] = useState(false);
   const pageHeaderRef = useRef<HTMLDivElement>(null);
@@ -71,16 +88,6 @@ const EmployeeSchedule = () => {
     error: shiftsError,
     refetch: refetchShifts,
   } = useMyShifts(restaurantId, currentEmployee?.id ?? null, currentWeekStart, weekEnd);
-
-  // The restaurant's clock, never the host browser's. Two questions on this
-  // page are calendar-day questions -- "which day column does this shift belong
-  // to" and "which day is today" -- and only the restaurant's calendar answers
-  // them. An employee who opens the page from another zone (travel, a remote
-  // manager, a phone that never left the last airport) otherwise reads a
-  // different week than the one the restaurant published.
-  const clock = useRestaurantClock();
-  const restaurantTimezone = clock.tz;
-  const restaurantToday = clock.today;
 
   // What this week actually IS, as opposed to what the rows look like: a week
   // that was announced and then pulled back is otherwise indistinguishable
@@ -205,7 +212,7 @@ const EmployeeSchedule = () => {
   };
 
   const handleToday = () => {
-    setCurrentWeekStart(startOfWeek(new Date(), { weekStartsOn: WEEK_STARTS_ON }));
+    setCurrentWeekStart(startOfWeek(parseDateOnly(restaurantToday), { weekStartsOn: WEEK_STARTS_ON }));
   };
 
   if (!restaurantId) {

--- a/tests/e2e/employee-schedule-retraction.spec.ts
+++ b/tests/e2e/employee-schedule-retraction.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, Page } from '@playwright/test';
-import { signUpAndCreateRestaurant, exposeSupabaseHelpers, generateTestUser } from '../helpers/e2e-supabase';
+import { signUpAndCreateRestaurant, exposeSupabaseHelpers, generateTestUser, E2EHelperWindow } from '../helpers/e2e-supabase';
 
 /**
  * The whole point of the banner is that an employee can tell a draft week from
@@ -26,8 +26,7 @@ test.use({ timezoneId: 'America/New_York' });
 async function setRestaurantTimezone(page: Page, restaurantId: string, timezone: string): Promise<void> {
   const result = await page.evaluate(
     async ({ restId, tz }) => {
-      // `window` has no type declarations for the test-only Supabase client exposeSupabaseHelpers attaches.
-      const supabase = (window as any).__supabase;
+      const supabase = (window as unknown as E2EHelperWindow).__supabase;
       const { error } = await supabase.from('restaurants').update({ timezone: tz }).eq('id', restId);
       if (error) return { ok: false, message: error.message };
       return { ok: true };

--- a/tests/e2e/employee-schedule-retraction.spec.ts
+++ b/tests/e2e/employee-schedule-retraction.spec.ts
@@ -9,8 +9,33 @@ import { signUpAndCreateRestaurant, exposeSupabaseHelpers, generateTestUser } fr
  *
  * Timezone is pinned for the same reason as schedule-publish-week-range.spec.ts:
  * CI runs UTC, and week bucketing bugs are invisible there.
+ *
+ * The seeded shift's "10:00 AM" text is read from the restaurant clock (My
+ * Schedule renders every shift in the restaurant's own timezone, not the
+ * device's — see ShiftRow.tsx). `signUpAndCreateRestaurant` leaves
+ * `restaurants.timezone` at its DB default, `America/Chicago`, so pointing the
+ * restaurant at the same zone the browser is pinned to keeps the "10:00 AM"
+ * built from browser-local `new Date()` math true under either clock.
  */
 test.use({ timezoneId: 'America/New_York' });
+
+/**
+ * Points the restaurant at the same zone the browser is pinned to (see file
+ * header). Ported from shift-create-timezone.spec.ts's helper of the same name.
+ */
+async function setRestaurantTimezone(page: Page, restaurantId: string, timezone: string): Promise<void> {
+  const result = await page.evaluate(
+    async ({ restId, tz }) => {
+      // `window` has no type declarations for the test-only Supabase client exposeSupabaseHelpers attaches.
+      const supabase = (window as any).__supabase;
+      const { error } = await supabase.from('restaurants').update({ timezone: tz }).eq('id', restId);
+      if (error) return { ok: false, message: error.message };
+      return { ok: true };
+    },
+    { restId: restaurantId, tz: timezone },
+  );
+  if (!result.ok) throw new Error(`restaurants timezone update failed: ${result.message}`);
+}
 
 /** The owner is also the employee, so one session can both publish and read the result. */
 async function seedSelfAsEmployeeWithShift(page: Page, restaurantId: string): Promise<void> {
@@ -111,6 +136,7 @@ test.describe('Employee schedule publish states', () => {
     const restaurantId = await page.evaluate(() => (window as any).__getRestaurantId());
     expect(restaurantId).toBeTruthy();
 
+    await setRestaurantTimezone(page, restaurantId, 'America/New_York');
     await seedSelfAsEmployeeWithShift(page, restaurantId);
 
     // --- State A: nothing published yet. The shift is visible, with a quiet

--- a/tests/helpers/restaurantClock.ts
+++ b/tests/helpers/restaurantClock.ts
@@ -1,0 +1,26 @@
+import { formatInstant, toBusinessDay } from '@/lib/restaurantClock';
+import type { RestaurantClock } from '@/hooks/useRestaurantClock';
+
+/**
+ * Build a real `RestaurantClock` from the production library functions
+ * (`src/lib/restaurantClock.ts`), so a test fake cannot drift from production
+ * behaviour. `tz` fixes the restaurant zone. `today` defaults to `tz`'s
+ * current business day when omitted; pass it explicitly to pin "Today" to a
+ * fixed calendar day regardless of the system clock.
+ *
+ * `toWallClockInput` and `parseWallClock` exist only to satisfy the
+ * `RestaurantClock` shape — the components under test in this suite do not
+ * call them.
+ */
+export function makeClock(tz = 'UTC', today: string = toBusinessDay(new Date(), tz)): RestaurantClock {
+  return {
+    tz,
+    tzAbbrev: '',
+    viewerTzDiffers: false,
+    today,
+    formatInstant: (value, pattern) => formatInstant(value, tz, pattern),
+    toBusinessDay: (value) => toBusinessDay(value, tz),
+    toWallClockInput: (value) => formatInstant(value, tz, "yyyy-MM-dd'T'HH:mm"),
+    parseWallClock: (wallClock) => wallClock,
+  };
+}

--- a/tests/helpers/timezone.ts
+++ b/tests/helpers/timezone.ts
@@ -10,6 +10,14 @@ import { expect } from 'vitest';
  * Phoenix is a fixed UTC-7 and never observes DST, so `getTimezoneOffset()`
  * must report 420 on every date.
  *
+ * The check date matters: it must land inside another US zone's DST
+ * window, so a leaked host zone reports an offset that differs from
+ * Phoenix's fixed 420. `2026-03-09` sits after the 2026 US DST switch
+ * (2026-03-08), so America/Denver reports 360 there, not 420 -- a date
+ * outside DST (e.g. January) would let a Denver host pass this guard
+ * with the wrong zone still in effect, because Denver's winter offset
+ * also happens to be 420.
+ *
  * Shared by every restaurant-clock regression suite so the guard cannot
  * drift between copies. Call in `beforeEach`, and restore
  * `process.env.TZ` in `afterEach` (save the original value before the
@@ -17,5 +25,5 @@ import { expect } from 'vitest';
  */
 export function pinHostTzToPhoenix(): void {
   process.env.TZ = 'America/Phoenix';
-  expect(new Date('2026-01-01T12:00:00Z').getTimezoneOffset()).toBe(420);
+  expect(new Date('2026-03-09T12:00:00Z').getTimezoneOffset()).toBe(420);
 }

--- a/tests/helpers/timezone.ts
+++ b/tests/helpers/timezone.ts
@@ -1,0 +1,21 @@
+import { expect } from 'vitest';
+
+/**
+ * Pin the HOST zone to America/Phoenix and prove the pin took effect.
+ *
+ * Assigning `process.env.TZ` can fail SILENTLY: a Node worker caches the
+ * host offset table on first `Date` use, so an earlier `Date` call in the
+ * same worker can freeze it, and a runner that pre-sets TZ would leave the
+ * assignment inert. Assert the offset instead of trusting the assignment.
+ * Phoenix is a fixed UTC-7 and never observes DST, so `getTimezoneOffset()`
+ * must report 420 on every date.
+ *
+ * Shared by every restaurant-clock regression suite so the guard cannot
+ * drift between copies. Call in `beforeEach`, and restore
+ * `process.env.TZ` in `afterEach` (save the original value before the
+ * first call).
+ */
+export function pinHostTzToPhoenix(): void {
+  process.env.TZ = 'America/Phoenix';
+  expect(new Date('2026-01-01T12:00:00Z').getTimezoneOffset()).toBe(420);
+}

--- a/tests/unit/EmployeeSchedule.queryBoundsTz.test.tsx
+++ b/tests/unit/EmployeeSchedule.queryBoundsTz.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * Regression guard for a bug found in PR #764 review: `EmployeeSchedule.tsx`
+ * passed `currentWeekStart`/`weekEnd` -- host-local calendar `Date`s -- straight
+ * into `useMyShifts`, which serializes them with `.toISOString()` for the
+ * `gte`/`lte` query bounds. That works only when the host and restaurant sit
+ * in the same zone. For a Phoenix viewer and an Auckland restaurant the two
+ * windows are ~19h apart, so most of Auckland's Monday shifts would fall
+ * outside the query and never load -- the wrong day row shows "No shifts
+ * scheduled" not because the shift is missing, but because it was never
+ * fetched.
+ *
+ * The fix derives the query instants from `businessDayRangeToInstants`,
+ * which resolves restaurant-local midnight, not host-local midnight. This
+ * test asserts `useMyShifts` receives those restaurant-zoned instants.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import type { Shift } from '@/types/scheduling';
+import { pinHostTzToPhoenix } from '../helpers/timezone';
+
+const RESTAURANT_TZ = 'Pacific/Auckland';
+
+/**
+ * Same pinned moment as `EmployeeSchedule.weekBoundaryTz.test.tsx`:
+ *   America/Phoenix   -> Sun 2026-07-26 23:30 (host week: Jul 20 - Jul 26)
+ *   Pacific/Auckland  -> Mon 2026-07-27 18:30 (restaurant week: Jul 27 - Aug 2)
+ */
+const NOW_UTC = '2026-07-27T06:30:00.000Z';
+
+/** The restaurant-zoned instant bounds `businessDayRangeToInstants` must produce. */
+const EXPECTED_QUERY_START = '2026-07-26T12:00:00.000Z'; // Auckland Mon Jul 27 00:00:00.000
+const EXPECTED_QUERY_END = '2026-08-02T11:59:59.999Z'; // Auckland Sun Aug 2 23:59:59.999
+
+/**
+ * The bug's bounds: host-local (Phoenix, fixed UTC-7) midnight of the SAME
+ * calendar-day strings, run through `.toISOString()`. If `useMyShifts` ever
+ * receives these instead, the fix has regressed.
+ */
+const BUGGY_HOST_QUERY_START = '2026-07-27T07:00:00.000Z';
+const BUGGY_HOST_QUERY_END = '2026-08-03T06:59:59.999Z';
+
+const useMyShiftsMock = vi.fn().mockReturnValue({
+  shifts: [] as Shift[],
+  loading: false,
+  error: null,
+  refetch: vi.fn(),
+});
+
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => ({
+    selectedRestaurant: {
+      restaurant_id: 'r1',
+      role: 'staff',
+      restaurant: { name: 'Test Cafe', timezone: RESTAURANT_TZ },
+    },
+  }),
+}));
+
+vi.mock('@/hooks/useCurrentEmployee', () => ({
+  useCurrentEmployee: () => ({
+    currentEmployee: { id: 'e1', name: 'Sam Rivera', position: 'Line Cook' },
+    loading: false,
+  }),
+}));
+
+vi.mock('@/hooks/useShifts', () => ({
+  useMyShifts: (...args: unknown[]) => useMyShiftsMock(...args),
+}));
+
+vi.mock('@/hooks/useSchedulePublish', () => ({
+  useWeekScheduleStatus: () => ({
+    state: 'published',
+    publication: null,
+    loading: false,
+  }),
+}));
+
+vi.mock('@/components/schedule/MyShiftTradesCard', () => ({
+  MyShiftTradesCard: () => null,
+}));
+vi.mock('@/components/schedule/TradeRequestDialog', () => ({
+  TradeRequestDialog: () => null,
+}));
+
+import EmployeeSchedule from '@/pages/EmployeeSchedule';
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <EmployeeSchedule />
+    </MemoryRouter>
+  );
+}
+
+describe('EmployeeSchedule — the shift query is bounded by the restaurant clock, not the host', () => {
+  const originalTz = process.env.TZ;
+
+  beforeEach(() => {
+    useMyShiftsMock.mockClear();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date(NOW_UTC));
+    pinHostTzToPhoenix();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (originalTz === undefined) delete process.env.TZ;
+    else process.env.TZ = originalTz;
+  });
+
+  it('calls useMyShifts with restaurant-local week-start/end instants', () => {
+    renderPage();
+
+    expect(useMyShiftsMock).toHaveBeenCalled();
+    const [, , startDate, endDate] = useMyShiftsMock.mock.calls[0] as [
+      string,
+      string,
+      Date,
+      Date,
+    ];
+
+    expect(startDate.toISOString()).toBe(EXPECTED_QUERY_START);
+    expect(endDate.toISOString()).toBe(EXPECTED_QUERY_END);
+  });
+
+  it('does not fall back to the host-local instants the bug used to send', () => {
+    renderPage();
+
+    const [, , startDate, endDate] = useMyShiftsMock.mock.calls[0] as [
+      string,
+      string,
+      Date,
+      Date,
+    ];
+
+    expect(startDate.toISOString()).not.toBe(BUGGY_HOST_QUERY_START);
+    expect(endDate.toISOString()).not.toBe(BUGGY_HOST_QUERY_END);
+  });
+});

--- a/tests/unit/EmployeeSchedule.restaurantTz.test.tsx
+++ b/tests/unit/EmployeeSchedule.restaurantTz.test.tsx
@@ -126,10 +126,13 @@ function pinHostTzToPhoenix(): void {
  * The day row's header strip -- the row's first child, which holds the weekday
  * name, the date and the "Today" badge.
  *
- * The badge query must stay inside this strip. A `ShiftRow` renders a "Today"
- * badge of its own from date-fns `isToday(start_time)`, which still reads the
- * HOST clock. That badge is a separate defect in `ShiftRow.tsx`, outside this
- * fix, and a row-wide query would match it and hide a regression here.
+ * The badge query must stay inside this strip. `ShiftRow` now reads the same
+ * restaurant clock as this page (see ShiftRow.tsx), so it renders its own
+ * "Today" badge on a shift that falls on the restaurant's current business
+ * day. On the restaurant day row, that badge is correct and expected, not a
+ * defect -- it sits next to the header's "Today" badge in the same row. A
+ * row-wide query would find both and fail with "multiple elements", so the
+ * query must stay scoped to the header strip.
  */
 function dayHeader(dayKey: string): HTMLElement {
   const row = screen.getByTestId(`schedule-day-${dayKey}`);

--- a/tests/unit/EmployeeSchedule.restaurantTz.test.tsx
+++ b/tests/unit/EmployeeSchedule.restaurantTz.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * Regression test for CodeRabbit comment 3814790876 on PR #761.
+ *
+ * `EmployeeSchedule.tsx` used to bucket a shift with
+ *   format(parseISO(shift.start_time), 'yyyy-MM-dd')
+ * and to mark a column with date-fns `isToday(day)`. Both read the HOST
+ * browser's clock. The page shows the RESTAURANT's week, so a viewer in
+ * another zone saw shifts in the wrong day row, and the "Today" badge on the
+ * wrong day. The fix routes both through the restaurant clock:
+ *   toBusinessDay(shift.start_time, restaurantTimezone)
+ *   dayKey === clock.today
+ *
+ * The test mounts the real page. The host runs at America/Phoenix (fixed
+ * UTC-7, no DST) and the restaurant at Pacific/Auckland (UTC+12 in July), so
+ * the two calendars disagree by one day at the pinned instant. A host-anchored
+ * implementation and a restaurant-anchored one therefore CANNOT produce the
+ * same output, and a silent host-timezone coincidence cannot make this pass.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import type { Shift } from '@/types/scheduling';
+
+const RESTAURANT_TZ = 'Pacific/Auckland';
+
+/**
+ * The pinned moment. Read it two ways:
+ *   America/Phoenix   -> Mon 2026-07-27 21:00  (the host's "today")
+ *   Pacific/Auckland  -> Tue 2026-07-28 16:00  (the restaurant's "today")
+ * Both days sit inside the same Monday-start week, so the week the page
+ * renders is identical under either clock and only the DAY differs.
+ */
+const NOW_UTC = '2026-07-28T04:00:00.000Z';
+
+/**
+ * One shift, 30 minutes after "now":
+ *   America/Phoenix   -> Mon 2026-07-27 21:30
+ *   Pacific/Auckland  -> Tue 2026-07-28 16:30
+ */
+const SHIFT_START_UTC = '2026-07-28T04:30:00.000Z';
+const SHIFT_END_UTC = '2026-07-28T08:30:00.000Z';
+
+const HOST_DAY = '2026-07-27'; // Monday
+const RESTAURANT_DAY = '2026-07-28'; // Tuesday
+
+const shift: Shift = {
+  id: 'shift-1',
+  restaurant_id: 'r1',
+  employee_id: 'e1',
+  start_time: SHIFT_START_UTC,
+  end_time: SHIFT_END_UTC,
+  break_duration: 0,
+  position: 'Line Cook',
+  status: 'scheduled',
+  is_published: true,
+  locked: false,
+  source: 'manual',
+  created_at: NOW_UTC,
+  updated_at: NOW_UTC,
+};
+
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => ({
+    selectedRestaurant: {
+      restaurant_id: 'r1',
+      role: 'staff',
+      restaurant: { name: 'Test Cafe', timezone: RESTAURANT_TZ },
+    },
+  }),
+}));
+
+vi.mock('@/hooks/useCurrentEmployee', () => ({
+  useCurrentEmployee: () => ({
+    currentEmployee: { id: 'e1', name: 'Sam Rivera', position: 'Line Cook' },
+    loading: false,
+  }),
+}));
+
+vi.mock('@/hooks/useShifts', () => ({
+  useMyShifts: () => ({
+    shifts: [shift],
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useSchedulePublish', () => ({
+  useWeekScheduleStatus: () => ({
+    state: 'published',
+    publication: null,
+    loading: false,
+  }),
+}));
+
+// Both pull their own Supabase data and neither takes part in day bucketing.
+vi.mock('@/components/schedule/MyShiftTradesCard', () => ({
+  MyShiftTradesCard: () => null,
+}));
+vi.mock('@/components/schedule/TradeRequestDialog', () => ({
+  TradeRequestDialog: () => null,
+}));
+
+import EmployeeSchedule from '@/pages/EmployeeSchedule';
+
+/**
+ * Pin the HOST zone to Phoenix and prove the pin took effect.
+ *
+ * Assigning `process.env.TZ` is the only lever available, and it can fail
+ * SILENTLY: Node caches the zone on first use, so an earlier `Date` in the
+ * same worker can freeze it, and a runner that pre-sets TZ would leave the
+ * assignment inert. If the host then happens to match the restaurant, a
+ * host-anchored implementation and a restaurant-anchored one agree, and the
+ * test passes while proving nothing.
+ *
+ * So assert the offset instead of trusting the assignment. Phoenix is a fixed
+ * UTC-7 and never observes DST, so `getTimezoneOffset()` must report 420.
+ */
+function pinHostTzToPhoenix(): void {
+  process.env.TZ = 'America/Phoenix';
+  expect(new Date(NOW_UTC).getTimezoneOffset()).toBe(420);
+}
+
+/**
+ * The day row's header strip -- the row's first child, which holds the weekday
+ * name, the date and the "Today" badge.
+ *
+ * The badge query must stay inside this strip. A `ShiftRow` renders a "Today"
+ * badge of its own from date-fns `isToday(start_time)`, which still reads the
+ * HOST clock. That badge is a separate defect in `ShiftRow.tsx`, outside this
+ * fix, and a row-wide query would match it and hide a regression here.
+ */
+function dayHeader(dayKey: string): HTMLElement {
+  const row = screen.getByTestId(`schedule-day-${dayKey}`);
+  const header = row.firstElementChild;
+  if (!(header instanceof HTMLElement)) {
+    throw new Error(`day row ${dayKey} has no header strip`);
+  }
+  return header;
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <EmployeeSchedule />
+    </MemoryRouter>
+  );
+}
+
+describe('EmployeeSchedule — day rows follow the restaurant timezone, not the host', () => {
+  const originalTz = process.env.TZ;
+
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date(NOW_UTC));
+    pinHostTzToPhoenix();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (originalTz === undefined) delete process.env.TZ;
+    else process.env.TZ = originalTz;
+  });
+
+  it('proves the two clocks disagree at the pinned instant', () => {
+    // Without this the two assertions below could both hold for a
+    // host-anchored implementation.
+    expect(new Date(NOW_UTC).getDate()).toBe(27); // host: Monday
+    expect(
+      new Intl.DateTimeFormat('en-CA', { timeZone: RESTAURANT_TZ }).format(new Date(NOW_UTC))
+    ).toBe(RESTAURANT_DAY); // restaurant: Tuesday
+  });
+
+  it('puts the shift in the restaurant Tuesday row, not the host Monday row', () => {
+    renderPage();
+
+    const restaurantRow = screen.getByTestId(`schedule-day-${RESTAURANT_DAY}`);
+    const hostRow = screen.getByTestId(`schedule-day-${HOST_DAY}`);
+
+    expect(within(restaurantRow).getByText('Line Cook')).toBeInTheDocument();
+    expect(within(hostRow).getByText('No shifts scheduled')).toBeInTheDocument();
+  });
+
+  it('marks the restaurant business day as Today, not the host day', () => {
+    renderPage();
+
+    expect(within(dayHeader(RESTAURANT_DAY)).getByText('Today')).toBeInTheDocument();
+    expect(within(dayHeader(HOST_DAY)).queryByText('Today')).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/EmployeeSchedule.restaurantTz.test.tsx
+++ b/tests/unit/EmployeeSchedule.restaurantTz.test.tsx
@@ -1,6 +1,4 @@
 /**
- * Regression test for CodeRabbit comment 3814790876 on PR #761.
- *
  * `EmployeeSchedule.tsx` used to bucket a shift with
  *   format(parseISO(shift.start_time), 'yyyy-MM-dd')
  * and to mark a column with date-fns `isToday(day)`. Both read the HOST
@@ -21,6 +19,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import type { Shift } from '@/types/scheduling';
+import { pinHostTzToPhoenix } from '../helpers/timezone';
 
 const RESTAURANT_TZ = 'Pacific/Auckland';
 
@@ -103,24 +102,6 @@ vi.mock('@/components/schedule/TradeRequestDialog', () => ({
 }));
 
 import EmployeeSchedule from '@/pages/EmployeeSchedule';
-
-/**
- * Pin the HOST zone to Phoenix and prove the pin took effect.
- *
- * Assigning `process.env.TZ` is the only lever available, and it can fail
- * SILENTLY: Node caches the zone on first use, so an earlier `Date` in the
- * same worker can freeze it, and a runner that pre-sets TZ would leave the
- * assignment inert. If the host then happens to match the restaurant, a
- * host-anchored implementation and a restaurant-anchored one agree, and the
- * test passes while proving nothing.
- *
- * So assert the offset instead of trusting the assignment. Phoenix is a fixed
- * UTC-7 and never observes DST, so `getTimezoneOffset()` must report 420.
- */
-function pinHostTzToPhoenix(): void {
-  process.env.TZ = 'America/Phoenix';
-  expect(new Date(NOW_UTC).getTimezoneOffset()).toBe(420);
-}
 
 /**
  * The day row's header strip -- the row's first child, which holds the weekday

--- a/tests/unit/EmployeeSchedule.weekBoundaryTz.test.tsx
+++ b/tests/unit/EmployeeSchedule.weekBoundaryTz.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * Regression guard for a bug in the restaurant-clock fix itself: the week
+ * grid used to anchor on `startOfWeek(new Date(), ...)` -- the HOST clock --
+ * while `shiftsByDay` bucketed each shift by `clock.toBusinessDay` -- the
+ * RESTAURANT clock. The two clocks agree on which week "now" falls in almost
+ * always, so `tests/unit/EmployeeSchedule.restaurantTz.test.tsx` (which picks
+ * an instant deliberately inside one shared week) could not catch it.
+ *
+ * This file pins an instant where the host (America/Phoenix, fixed UTC-7)
+ * reads Sunday of one week and the restaurant (Pacific/Auckland, ~19h ahead
+ * in July) already reads Monday of the next. A host-anchored week grid does
+ * not contain the restaurant's current day at all, so a shift scheduled for
+ * that day matches no column and silently disappears -- the exact "matched
+ * no column and vanished" defect class this fix (EmployeeSchedule.tsx) is
+ * meant to close, reintroduced from the opposite direction.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import type { Shift } from '@/types/scheduling';
+import { pinHostTzToPhoenix } from '../helpers/timezone';
+
+const RESTAURANT_TZ = 'Pacific/Auckland';
+
+/**
+ * The pinned moment. Read it two ways:
+ *   America/Phoenix   -> Sun 2026-07-26 23:30  (host: last day of the
+ *                        Mon 2026-07-20 - Sun 2026-07-26 week)
+ *   Pacific/Auckland  -> Mon 2026-07-27 18:30  (restaurant: first day of the
+ *                        Mon 2026-07-27 - Sun 2026-08-02 week)
+ * The two clocks disagree about which WEEK "now" falls in, not just which
+ * day -- the case the sibling `EmployeeSchedule.restaurantTz.test.tsx`
+ * deliberately does not exercise.
+ */
+const NOW_UTC = '2026-07-27T06:30:00.000Z';
+
+/** 30 minutes after "now", still Monday 2026-07-27 in Auckland. */
+const SHIFT_START_UTC = '2026-07-27T07:00:00.000Z';
+const SHIFT_END_UTC = '2026-07-27T11:00:00.000Z';
+
+const RESTAURANT_WEEK_MONDAY = '2026-07-27';
+const RESTAURANT_WEEK_SUNDAY = '2026-08-02';
+const HOST_WEEK_SUNDAY = '2026-07-26';
+
+const shift: Shift = {
+  id: 'shift-1',
+  restaurant_id: 'r1',
+  employee_id: 'e1',
+  start_time: SHIFT_START_UTC,
+  end_time: SHIFT_END_UTC,
+  break_duration: 0,
+  position: 'Line Cook',
+  status: 'scheduled',
+  is_published: true,
+  locked: false,
+  source: 'manual',
+  created_at: NOW_UTC,
+  updated_at: NOW_UTC,
+};
+
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => ({
+    selectedRestaurant: {
+      restaurant_id: 'r1',
+      role: 'staff',
+      restaurant: { name: 'Test Cafe', timezone: RESTAURANT_TZ },
+    },
+  }),
+}));
+
+vi.mock('@/hooks/useCurrentEmployee', () => ({
+  useCurrentEmployee: () => ({
+    currentEmployee: { id: 'e1', name: 'Sam Rivera', position: 'Line Cook' },
+    loading: false,
+  }),
+}));
+
+vi.mock('@/hooks/useShifts', () => ({
+  useMyShifts: () => ({
+    shifts: [shift],
+    loading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useSchedulePublish', () => ({
+  useWeekScheduleStatus: () => ({
+    state: 'published',
+    publication: null,
+    loading: false,
+  }),
+}));
+
+// Both pull their own Supabase data and neither takes part in day bucketing.
+vi.mock('@/components/schedule/MyShiftTradesCard', () => ({
+  MyShiftTradesCard: () => null,
+}));
+vi.mock('@/components/schedule/TradeRequestDialog', () => ({
+  TradeRequestDialog: () => null,
+}));
+
+import EmployeeSchedule from '@/pages/EmployeeSchedule';
+
+function dayHeader(dayKey: string): HTMLElement {
+  const row = screen.getByTestId(`schedule-day-${dayKey}`);
+  const header = row.firstElementChild;
+  if (!(header instanceof HTMLElement)) {
+    throw new Error(`day row ${dayKey} has no header strip`);
+  }
+  return header;
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <EmployeeSchedule />
+    </MemoryRouter>
+  );
+}
+
+describe('EmployeeSchedule — the week grid follows the restaurant clock across a week boundary', () => {
+  const originalTz = process.env.TZ;
+
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(new Date(NOW_UTC));
+    pinHostTzToPhoenix();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (originalTz === undefined) delete process.env.TZ;
+    else process.env.TZ = originalTz;
+  });
+
+  it('proves the two clocks disagree about which WEEK "now" falls in', () => {
+    // Host: Sunday, last day of the Jul 20 week. Restaurant: Monday, first
+    // day of the Jul 27 week. A host-anchored `startOfWeek(new Date())`
+    // and a restaurant-anchored one therefore pick DIFFERENT weeks.
+    expect(new Date(NOW_UTC).getDay()).toBe(0); // host: Sunday
+    expect(
+      new Intl.DateTimeFormat('en-CA', { timeZone: RESTAURANT_TZ }).format(new Date(NOW_UTC))
+    ).toBe(RESTAURANT_WEEK_MONDAY); // restaurant: Monday, the next week
+  });
+
+  it('renders the restaurant week (Mon Jul 27 - Sun Aug 2), not the host week', () => {
+    renderPage();
+
+    expect(screen.getByTestId(`schedule-day-${RESTAURANT_WEEK_MONDAY}`)).toBeInTheDocument();
+    expect(screen.getByTestId(`schedule-day-${RESTAURANT_WEEK_SUNDAY}`)).toBeInTheDocument();
+    // The host's week never appears -- a host-anchored grid would show this
+    // day instead of Jul 27, and the shift below would have no column.
+    expect(screen.queryByTestId(`schedule-day-${HOST_WEEK_SUNDAY}`)).not.toBeInTheDocument();
+  });
+
+  it('does not drop the shift scheduled for the restaurant current day', () => {
+    renderPage();
+
+    const restaurantTodayRow = screen.getByTestId(`schedule-day-${RESTAURANT_WEEK_MONDAY}`);
+    expect(within(restaurantTodayRow).getByText('Line Cook')).toBeInTheDocument();
+    expect(within(dayHeader(RESTAURANT_WEEK_MONDAY)).getByText('Today')).toBeInTheDocument();
+  });
+});

--- a/tests/unit/ShiftRow.publishes.test.tsx
+++ b/tests/unit/ShiftRow.publishes.test.tsx
@@ -11,7 +11,11 @@ const draft = {
   end_time: '2026-08-20T20:00:00Z',
   status: 'scheduled',
   is_published: false,
-  break_minutes: 0,
+  // `Shift` names this field `break_duration` (src/types/scheduling.ts:117).
+  // A fixture that spells it `break_minutes` leaves `break_duration`
+  // undefined, and the row then renders "NaNh NaNm". The `as Shift` cast
+  // hides that from `tsc`.
+  break_duration: 0,
 } as Shift;
 
 describe('ShiftRow draft treatment', () => {
@@ -30,5 +34,12 @@ describe('ShiftRow draft treatment', () => {
   it('marks a draft by default, so current call sites do not change', () => {
     render(<ShiftRow shift={draft} clock={makeClock()} />);
     expect(screen.getByText('Draft')).toBeInTheDocument();
+  });
+
+  it('renders a real duration, so the fixture cannot go back to break_minutes', () => {
+    const { container } = render(<ShiftRow shift={draft} clock={makeClock()} />);
+
+    expect(container.textContent).toContain('8h 0m');
+    expect(container.textContent).not.toContain('NaN');
   });
 });

--- a/tests/unit/ShiftRow.restaurantTz.test.tsx
+++ b/tests/unit/ShiftRow.restaurantTz.test.tsx
@@ -4,8 +4,7 @@ import { render, screen } from '@testing-library/react';
 
 import { ShiftRow } from '@/components/employee/ShiftRow';
 import { Shift } from '@/types/scheduling';
-import { formatInstant, toBusinessDay } from '@/lib/restaurantClock';
-import type { RestaurantClock } from '@/hooks/useRestaurantClock';
+import { makeClock } from '../helpers/restaurantClock';
 
 /**
  * Regression guard: `ShiftRow` must read every wall-clock date from the
@@ -23,26 +22,6 @@ import type { RestaurantClock } from '@/hooks/useRestaurantClock';
 function pinHostTzToPhoenix(): void {
   process.env.TZ = 'America/Phoenix';
   expect(new Date('2026-01-31T12:00:00Z').getTimezoneOffset()).toBe(420);
-}
-
-/**
- * Builds a real clock from the production library functions
- * (`src/lib/restaurantClock.ts`), so the fake cannot drift from production
- * behaviour. Only `formatInstant` and `toBusinessDay` are exercised by
- * `ShiftRow`; the other two fields exist to satisfy the `RestaurantClock`
- * shape.
- */
-function makeClock(tz: string, today: string): RestaurantClock {
-  return {
-    tz,
-    tzAbbrev: '',
-    viewerTzDiffers: false,
-    today,
-    formatInstant: (value, pattern) => formatInstant(value, tz, pattern),
-    toBusinessDay: (value) => toBusinessDay(value, tz),
-    toWallClockInput: (value) => formatInstant(value, tz, "yyyy-MM-dd'T'HH:mm"),
-    parseWallClock: (wallClock) => wallClock,
-  };
 }
 
 /**

--- a/tests/unit/ShiftRow.restaurantTz.test.tsx
+++ b/tests/unit/ShiftRow.restaurantTz.test.tsx
@@ -5,6 +5,7 @@ import { render, screen } from '@testing-library/react';
 import { ShiftRow } from '@/components/employee/ShiftRow';
 import { Shift } from '@/types/scheduling';
 import { makeClock } from '../helpers/restaurantClock';
+import { pinHostTzToPhoenix } from '../helpers/timezone';
 
 /**
  * Regression guard: `ShiftRow` must read every wall-clock date from the
@@ -13,16 +14,7 @@ import { makeClock } from '../helpers/restaurantClock';
  * Pacific/Auckland (UTC+13 in January, NZDT). The two zones name a
  * different calendar day and a different hour for the same instant, so a
  * host-clock leak shows up as the wrong string on screen.
- *
- * The `process.env.TZ` assignment can fail SILENTLY. A Node worker caches
- * the host offset table on first `Date` use, so an earlier `Date` call in
- * the same worker can freeze it. Assert the offset instead of trusting the
- * assignment (copied from tests/unit/useShiftsRecurringCreateTz.test.ts:92).
  */
-function pinHostTzToPhoenix(): void {
-  process.env.TZ = 'America/Phoenix';
-  expect(new Date('2026-01-31T12:00:00Z').getTimezoneOffset()).toBe(420);
-}
 
 /**
  * `2026-01-31T20:00:00Z`: Phoenix reads Sat, Jan 31, 1:00 PM. Auckland reads

--- a/tests/unit/ShiftRow.restaurantTz.test.tsx
+++ b/tests/unit/ShiftRow.restaurantTz.test.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { ShiftRow } from '@/components/employee/ShiftRow';
+import { Shift } from '@/types/scheduling';
+import { formatInstant, toBusinessDay } from '@/lib/restaurantClock';
+import type { RestaurantClock } from '@/hooks/useRestaurantClock';
+
+/**
+ * Regression guard: `ShiftRow` must read every wall-clock date from the
+ * restaurant clock, not from the host browser clock. Pin the host to
+ * America/Phoenix (fixed UTC-7, no DST) and the restaurant to
+ * Pacific/Auckland (UTC+13 in January, NZDT). The two zones name a
+ * different calendar day and a different hour for the same instant, so a
+ * host-clock leak shows up as the wrong string on screen.
+ *
+ * The `process.env.TZ` assignment can fail SILENTLY. A Node worker caches
+ * the host offset table on first `Date` use, so an earlier `Date` call in
+ * the same worker can freeze it. Assert the offset instead of trusting the
+ * assignment (copied from tests/unit/useShiftsRecurringCreateTz.test.ts:92).
+ */
+function pinHostTzToPhoenix(): void {
+  process.env.TZ = 'America/Phoenix';
+  expect(new Date('2026-01-31T12:00:00Z').getTimezoneOffset()).toBe(420);
+}
+
+/**
+ * Builds a real clock from the production library functions
+ * (`src/lib/restaurantClock.ts`), so the fake cannot drift from production
+ * behaviour. Only `formatInstant` and `toBusinessDay` are exercised by
+ * `ShiftRow`; the other two fields exist to satisfy the `RestaurantClock`
+ * shape.
+ */
+function makeClock(tz: string, today: string): RestaurantClock {
+  return {
+    tz,
+    tzAbbrev: '',
+    viewerTzDiffers: false,
+    today,
+    formatInstant: (value, pattern) => formatInstant(value, tz, pattern),
+    toBusinessDay: (value) => toBusinessDay(value, tz),
+    toWallClockInput: (value) => formatInstant(value, tz, "yyyy-MM-dd'T'HH:mm"),
+    parseWallClock: (wallClock) => wallClock,
+  };
+}
+
+/**
+ * `2026-01-31T20:00:00Z`: Phoenix reads Sat, Jan 31, 1:00 PM. Auckland reads
+ * Sun, Feb 1, 9:00 AM. Different weekday, day, month and hour in one instant.
+ */
+function makeShift(overrides: Partial<Shift> = {}): Shift {
+  return {
+    id: 'shift-1',
+    restaurant_id: 'r1',
+    employee_id: 'e1',
+    start_time: '2026-01-31T20:00:00Z',
+    end_time: '2026-02-01T04:00:00Z',
+    position: 'Server',
+    status: 'scheduled',
+    break_duration: 30,
+    is_published: true,
+    locked: false,
+    source: 'manual',
+    created_at: '2020-01-01T00:00:00Z',
+    updated_at: '2020-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('ShiftRow reads the restaurant clock, not the host clock', () => {
+  const originalTz = process.env.TZ;
+
+  beforeEach(() => {
+    pinHostTzToPhoenix();
+    // Fixed well before every shift in this file, so `isPast`/`isFuture`
+    // land on the same branch in every case. Only the clock decides `Today`.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2020-01-01T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (originalTz === undefined) delete process.env.TZ;
+    else process.env.TZ = originalTz;
+  });
+
+  it('day variant shows the restaurant wall-clock time, not the host wall-clock time', () => {
+    const clock = makeClock('Pacific/Auckland', '2026-02-01');
+    const { container } = render(<ShiftRow shift={makeShift()} clock={clock} />);
+
+    expect(container.textContent).toContain('9:00 AM');
+    expect(container.textContent).not.toContain('1:00 PM');
+  });
+
+  it('upcoming variant shows the restaurant weekday, day and month, not the host ones', () => {
+    const clock = makeClock('Pacific/Auckland', '2026-02-01');
+    render(<ShiftRow shift={makeShift()} clock={clock} variant="upcoming" />);
+
+    expect(screen.getByText('Sun')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('Feb')).toBeInTheDocument();
+    expect(screen.queryByText('Sat')).not.toBeInTheDocument();
+    expect(screen.queryByText('31')).not.toBeInTheDocument();
+    expect(screen.queryByText('Jan')).not.toBeInTheDocument();
+  });
+
+  it('a shift that is today in Auckland shows the Today badge', () => {
+    const clock = makeClock('Pacific/Auckland', '2026-02-01');
+    const { container } = render(<ShiftRow shift={makeShift()} clock={clock} />);
+
+    expect(screen.getByText('Today')).toBeInTheDocument();
+    expect(container.textContent).not.toContain('1:00 PM');
+  });
+
+  it('a shift that is not today in Auckland does not show the Today badge', () => {
+    const clock = makeClock('Pacific/Auckland', '2026-02-01');
+    const { container } = render(
+      <ShiftRow
+        shift={makeShift({
+          start_time: '2026-01-31T09:00:00Z',
+          end_time: '2026-01-31T17:00:00Z',
+        })}
+        clock={clock}
+      />
+    );
+
+    expect(screen.queryByText('Today')).not.toBeInTheDocument();
+    expect(screen.getByText('Upcoming')).toBeInTheDocument();
+    expect(container.textContent).toContain('10:00 PM');
+    expect(container.textContent).not.toContain('2:00 AM');
+  });
+});

--- a/tests/unit/ShiftRow.test.tsx
+++ b/tests/unit/ShiftRow.test.tsx
@@ -6,6 +6,7 @@ import userEvent from '@testing-library/user-event';
 import { ShiftRow } from '@/components/employee/ShiftRow';
 import { Shift } from '@/types/scheduling';
 import { makeClock } from '../helpers/restaurantClock';
+import { pinHostTzToPhoenix } from '../helpers/timezone';
 
 /** Far enough out that `isFuture` stays true whatever day the suite runs. */
 const FUTURE = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
@@ -137,12 +138,7 @@ describe('ShiftRow draft treatment', () => {
   it('keeps the Completed and In Progress badges unchanged with the host zone pinned to America/Phoenix', () => {
     const originalTz = process.env.TZ;
 
-    // `America/Phoenix` is a fixed UTC-7, no DST. Assert the offset instead
-    // of trusting the assignment: a Node worker caches the host offset table
-    // on first `Date` use, so an earlier `Date` call in the same worker can
-    // freeze it silently (see tests/unit/ShiftRow.restaurantTz.test.tsx).
-    process.env.TZ = 'America/Phoenix';
-    expect(new Date('2026-01-31T12:00:00Z').getTimezoneOffset()).toBe(420);
+    pinHostTzToPhoenix();
 
     try {
       assertCompletedAndInProgressBadges();

--- a/tests/unit/ShiftRow.test.tsx
+++ b/tests/unit/ShiftRow.test.tsx
@@ -5,8 +5,7 @@ import userEvent from '@testing-library/user-event';
 
 import { ShiftRow } from '@/components/employee/ShiftRow';
 import { Shift } from '@/types/scheduling';
-import { formatInstant, toBusinessDay } from '@/lib/restaurantClock';
-import type { RestaurantClock } from '@/hooks/useRestaurantClock';
+import { makeClock } from '../helpers/restaurantClock';
 
 /** Far enough out that `isFuture` stays true whatever day the suite runs. */
 const FUTURE = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
@@ -14,25 +13,6 @@ const futureAt = (hoursOffset: number) =>
   new Date(FUTURE.getTime() + hoursOffset * 60 * 60 * 1000).toISOString();
 const nowAt = (hoursOffset: number) =>
   new Date(Date.now() + hoursOffset * 60 * 60 * 1000).toISOString();
-
-/**
- * Builds a real clock from the production library functions
- * (`src/lib/restaurantClock.ts`), so the fake cannot drift from production
- * behaviour. `tz` fixes the restaurant zone; `today` follows it so the far-
- * future shift in `makeShift` never lands on the Today branch by accident.
- */
-function makeClock(tz = 'UTC'): RestaurantClock {
-  return {
-    tz,
-    tzAbbrev: '',
-    viewerTzDiffers: false,
-    today: toBusinessDay(new Date(), tz),
-    formatInstant: (value, pattern) => formatInstant(value, tz, pattern),
-    toBusinessDay: (value) => toBusinessDay(value, tz),
-    toWallClockInput: (value) => formatInstant(value, tz, "yyyy-MM-dd'T'HH:mm"),
-    parseWallClock: (wallClock) => wallClock,
-  };
-}
 
 function makeShift(overrides: Partial<Shift> = {}): Shift {
   return {

--- a/tests/unit/ShiftRow.test.tsx
+++ b/tests/unit/ShiftRow.test.tsx
@@ -1,15 +1,38 @@
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { ShiftRow } from '@/components/employee/ShiftRow';
 import { Shift } from '@/types/scheduling';
+import { formatInstant, toBusinessDay } from '@/lib/restaurantClock';
+import type { RestaurantClock } from '@/hooks/useRestaurantClock';
 
 /** Far enough out that `isFuture` stays true whatever day the suite runs. */
 const FUTURE = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
 const futureAt = (hoursOffset: number) =>
   new Date(FUTURE.getTime() + hoursOffset * 60 * 60 * 1000).toISOString();
+const nowAt = (hoursOffset: number) =>
+  new Date(Date.now() + hoursOffset * 60 * 60 * 1000).toISOString();
+
+/**
+ * Builds a real clock from the production library functions
+ * (`src/lib/restaurantClock.ts`), so the fake cannot drift from production
+ * behaviour. `tz` fixes the restaurant zone; `today` follows it so the far-
+ * future shift in `makeShift` never lands on the Today branch by accident.
+ */
+function makeClock(tz = 'UTC'): RestaurantClock {
+  return {
+    tz,
+    tzAbbrev: '',
+    viewerTzDiffers: false,
+    today: toBusinessDay(new Date(), tz),
+    formatInstant: (value, pattern) => formatInstant(value, tz, pattern),
+    toBusinessDay: (value) => toBusinessDay(value, tz),
+    toWallClockInput: (value) => formatInstant(value, tz, "yyyy-MM-dd'T'HH:mm"),
+    parseWallClock: (wallClock) => wallClock,
+  };
+}
 
 function makeShift(overrides: Partial<Shift> = {}): Shift {
   return {
@@ -30,9 +53,27 @@ function makeShift(overrides: Partial<Shift> = {}): Shift {
   };
 }
 
+/**
+ * `Completed` and `In Progress` compare instants (`isPast`, `now >= start &&
+ * now <= end`), so the host zone must not change the result. Both cases run
+ * once under the suite's default zone and once with the host pinned to
+ * `America/Phoenix`.
+ */
+function assertCompletedAndInProgressBadges(): void {
+  const completedShift = makeShift({ start_time: nowAt(-3), end_time: nowAt(-1) });
+  render(<ShiftRow shift={completedShift} clock={makeClock()} />);
+  expect(screen.getByText('Completed')).toBeInTheDocument();
+  cleanup();
+
+  const inProgressShift = makeShift({ start_time: nowAt(-1), end_time: nowAt(1) });
+  render(<ShiftRow shift={inProgressShift} clock={makeClock()} />);
+  expect(screen.getByText('In Progress')).toBeInTheDocument();
+  cleanup();
+}
+
 describe('ShiftRow draft treatment', () => {
   it('shows no explanatory draft copy on an unpublished shift', () => {
-    render(<ShiftRow shift={makeShift({ is_published: false })} />);
+    render(<ShiftRow shift={makeShift({ is_published: false })} clock={makeClock()} />);
 
     // Many restaurants never publish. Words like "not confirmed" on a real
     // shift caused a no-show. The draft state is a hue, not a warning.
@@ -41,7 +82,7 @@ describe('ShiftRow draft treatment', () => {
   });
 
   it('keeps a screen-reader-only Draft label on an unpublished shift', () => {
-    render(<ShiftRow shift={makeShift({ is_published: false })} />);
+    render(<ShiftRow shift={makeShift({ is_published: false })} clock={makeClock()} />);
 
     // The hue alone would fail a screen reader and WCAG 1.4.1. The label is
     // sr-only, so sighted users see no extra copy.
@@ -51,7 +92,9 @@ describe('ShiftRow draft treatment', () => {
 
   it('offers a Trade button on a draft shift', async () => {
     const onTrade = vi.fn();
-    render(<ShiftRow shift={makeShift({ is_published: false })} onTrade={onTrade} />);
+    render(
+      <ShiftRow shift={makeShift({ is_published: false })} onTrade={onTrade} clock={makeClock()} />
+    );
 
     // The draft-trade design allows a trade before publication.
     await userEvent.click(screen.getByRole('button', { name: /trade/i }));
@@ -60,7 +103,7 @@ describe('ShiftRow draft treatment', () => {
 
   it('shows the normal status badge and no Draft label once published', async () => {
     const onTrade = vi.fn();
-    render(<ShiftRow shift={makeShift()} onTrade={onTrade} />);
+    render(<ShiftRow shift={makeShift()} onTrade={onTrade} clock={makeClock()} />);
 
     expect(screen.queryByText('Draft')).not.toBeInTheDocument();
     expect(screen.getByText('Upcoming')).toBeInTheDocument();
@@ -71,7 +114,11 @@ describe('ShiftRow draft treatment', () => {
 
   it('keeps a cancelled shift reading as cancelled, not as a draft', () => {
     render(
-      <ShiftRow shift={makeShift({ status: 'cancelled', is_published: false })} onTrade={vi.fn()} />
+      <ShiftRow
+        shift={makeShift({ status: 'cancelled', is_published: false })}
+        onTrade={vi.fn()}
+        clock={makeClock()}
+      />
     );
 
     expect(screen.getByText('Cancelled')).toBeInTheDocument();
@@ -81,9 +128,47 @@ describe('ShiftRow draft treatment', () => {
   });
 
   it('takes the same draft branch in the Upcoming card as in the day grid', () => {
-    render(<ShiftRow shift={makeShift({ is_published: false })} variant="upcoming" />);
+    render(
+      <ShiftRow shift={makeShift({ is_published: false })} variant="upcoming" clock={makeClock()} />
+    );
 
     expect(screen.queryByText('Draft — not confirmed')).not.toBeInTheDocument();
     expect(screen.getByText('Draft')).toHaveClass('sr-only');
+  });
+
+  it('shows Completed on a shift that ended one hour ago', () => {
+    const shift = makeShift({ start_time: nowAt(-3), end_time: nowAt(-1) });
+    render(<ShiftRow shift={shift} clock={makeClock()} />);
+
+    expect(screen.getByText('Completed')).toBeInTheDocument();
+  });
+
+  it('shows In Progress on a shift that is happening now', () => {
+    const shift = makeShift({ start_time: nowAt(-1), end_time: nowAt(1) });
+    render(<ShiftRow shift={shift} clock={makeClock()} />);
+
+    expect(screen.getByText('In Progress')).toBeInTheDocument();
+  });
+
+  it('keeps the Completed and In Progress badges unchanged under the default host zone', () => {
+    assertCompletedAndInProgressBadges();
+  });
+
+  it('keeps the Completed and In Progress badges unchanged with the host zone pinned to America/Phoenix', () => {
+    const originalTz = process.env.TZ;
+
+    // `America/Phoenix` is a fixed UTC-7, no DST. Assert the offset instead
+    // of trusting the assignment: a Node worker caches the host offset table
+    // on first `Date` use, so an earlier `Date` call in the same worker can
+    // freeze it silently (see tests/unit/ShiftRow.restaurantTz.test.tsx).
+    process.env.TZ = 'America/Phoenix';
+    expect(new Date('2026-01-31T12:00:00Z').getTimezoneOffset()).toBe(420);
+
+    try {
+      assertCompletedAndInProgressBadges();
+    } finally {
+      if (originalTz === undefined) delete process.env.TZ;
+      else process.env.TZ = originalTz;
+    }
   });
 });

--- a/tests/unit/useShiftsRecurringCreateTz.test.ts
+++ b/tests/unit/useShiftsRecurringCreateTz.test.ts
@@ -23,6 +23,7 @@ import { renderHook, waitFor, act } from '@testing-library/react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useCreateShift } from '@/hooks/useShifts';
+import { pinHostTzToPhoenix } from '../helpers/timezone';
 
 const mockToast = vi.hoisted(() => vi.fn());
 vi.mock('@/hooks/use-toast', () => ({
@@ -68,30 +69,6 @@ function setupSupabaseMock(insertCalls: unknown[]) {
       });
     },
   }));
-}
-
-/**
- * Pin the HOST zone to Phoenix and prove the pin took effect.
- *
- * Every test here is a differential one: it distinguishes a correct
- * restaurant-anchored implementation from a host-anchored one purely by the
- * two zones disagreeing. Assigning `process.env.TZ` is the only lever we
- * have, and it is not guaranteed to be honoured — Node caches the zone on
- * first use, so an earlier `Date` in the same worker can freeze it, and a
- * runner that pre-sets TZ differently would leave the assignment inert. In
- * every one of those cases the assignment fails SILENTLY: if the host then
- * happens to be America/Chicago, a host-local implementation and a
- * restaurant-local one produce identical output and the test passes while
- * proving nothing.
- *
- * So assert the offset rather than trusting the assignment. Phoenix is a
- * fixed UTC-7 (never observes DST), and 2026-03-09 is inside Chicago's DST
- * window — so a Chicago host would report 300, not 420, and this throws
- * instead of quietly going vacuous.
- */
-function pinHostTzToPhoenix(): void {
-  process.env.TZ = 'America/Phoenix';
-  expect(new Date('2026-03-09T12:00:00Z').getTimezoneOffset()).toBe(420);
 }
 
 describe('useCreateShift — recurring children anchor to the restaurant timezone', () => {


### PR DESCRIPTION
## Summary
- `ShiftRow` used the host browser clock for shift times, the date block, and the Today badge. A traveling employee saw wrong times and a wrong Today badge.
- `ShiftRow` now takes a required `clock: RestaurantClock` prop. It formats times and dates with `clock.formatInstant` and derives the Today badge from `clock.toBusinessDay`, matching the restaurant zone.
- `EmployeeSchedule` passes its existing clock into both `ShiftRow` call sites (`upcoming` and `day` variants).
- `currentWeekStart` and the Today-button reset in `EmployeeSchedule` now derive from `clock.today` instead of the host `new Date()`, so the week grid cannot name a different week than the day-bucketing near a week boundary.
- Kept the five instant comparisons (`isPast`, `isFuture`, the live-shift range check, `differenceInMinutes`) unchanged — they compare instants, not calendar days, so they are zone-independent already.
- Extracted the duplicated `pinHostTzToPhoenix` test helper into `tests/helpers/timezone.ts`, shared by five test files. Fixed a DST-window bug in that helper's guard check.
- Extracted the duplicated `ShiftRow` test clock builder into a shared helper.

## Test plan
- `npm run test`: 9405/9407 pass (2 pre-existing skips).
- `npm run typecheck`: pass.
- `npm run build`: pass.
- `npm run test:db`: 2908/2908 pass.
- `npm run test:e2e`: full suite passes; fixed one spec (`employee-schedule-retraction.spec.ts`) that assumed the old host-clock display and did not pin the restaurant timezone.
- `npm run lint`: no new problems from this PR's diff (checked every touched file against `origin/main`).
- New tests: `tests/unit/ShiftRow.restaurantTz.test.tsx` (host Phoenix vs restaurant Chicago), `tests/unit/EmployeeSchedule.weekBoundaryTz.test.tsx` (week-boundary defect, with a negative control run).

Design doc: [docs/superpowers/specs/2026-08-19-shiftrow-restaurant-clock-design.md](docs/superpowers/specs/2026-08-19-shiftrow-restaurant-clock-design.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a clearer schedule experience with viewed-week labels, next-week shift hints, and next-shift information when enabled.
  - Unpublished shifts are shown as drafts only when the restaurant publishes schedules.

- **Bug Fixes**
  - Schedule dates, times, day columns, and “Today” indicators now reflect the restaurant’s timezone.
  - Corrected shifts appearing under the wrong day or week across timezone boundaries.
  - Preserved accurate shift status and trade eligibility calculations.

- **Tests**
  - Added coverage for timezone differences, week boundaries, date formatting, and status badges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->