### PR TITLE
feat(banking): add Cash Flow Insights view

### DIFF
--- a/docs/superpowers/plans/2026-08-19-cashflow-insights-plan.md
+++ b/docs/superpowers/plans/2026-08-19-cashflow-insights-plan.md
@@ -1,0 +1,189 @@
+# Cash Flow Insights — Plan
+
+Date: 2026-08-19
+Branch: `feature/cashflow-insights`
+Design: docs/superpowers/specs/2026-08-19-cashflow-insights-design.md
+Approval: the user approved the design mockup on 2026-08-19.
+
+## Rules for every task
+
+- Write the failing test first. Run it. Then write the code. Run it again.
+- Use semantic color tokens only. No hex values in components.
+- Use `format(date, 'yyyy-MM-dd')` from `date-fns` for every date string.
+- Keep the CLAUDE.md typography scale. The one exception is the
+  `text-[28px]` net figure.
+- Commit after each task with explicit paths. Never use `git add -A`.
+
+## Task 1: aggregation core
+
+Files: `src/lib/cashflowInsights.ts`, `tests/unit/cashflowInsights.test.ts`.
+
+1. Define the types: `CashFlowRow`, `CashFlowPeriod`, `Interval`,
+   `CashFlowAggregates`.
+2. Test and build `defaultInterval(period)`: `day` up to 31 days, `week` up
+   to 120 days, `month` above.
+3. Test and build `computeTotals(rows, options)`: moneyIn, moneyOut, net.
+   The `excludeTransfers` option drops rows with `is_transfer = true`.
+4. Test and build `bucketSeries(rows, period, interval)`: buckets with
+   per-category signed sums and moneyIn/moneyOut sums. Only rows inside the
+   period count.
+5. Test the zero-row input: empty buckets, zero totals.
+
+Verify: `npm run test -- cashflowInsights`.
+
+## Task 2: folding and breakdown
+
+Files: same as Task 1.
+
+1. Test and build the payee fallback: `normalized_payee ?? merchant_name ??
+   description`.
+2. Test and build `topCategories(rows)`: five largest by absolute sum, the
+   rest fold into `Other`. Transfers fold into `Transfers`. Null categories
+   fold into `Uncategorized`.
+3. Test and build `breakdown(rows, direction, by)`: top eight payees or
+   categories, a `Remaining` fold, and `pctOfTotal` per row.
+
+Verify: `npm run test -- cashflowInsights`.
+
+## Task 3: sankey builder
+
+Files: same as Task 1.
+
+1. Test and build `buildSankey(rows)`: left nodes = top inflow payees plus
+   `Transfers in`; center node = `Money in`; right nodes = top outflow
+   payees plus `Transfers out` and the net remainder.
+2. Test the conservation rule: the sum of left links equals the sum of
+   right links.
+
+Verify: `npm run test -- cashflowInsights`.
+
+## Task 4: insight engine
+
+Files: same as Task 1.
+
+1. Test and build the subscription rule: 3+ charges to one payee in the 90
+   days before `period.to`, a 25–35 day cadence, under 10% amount variance.
+2. Test the cadence-miss negative case: irregular charges emit nothing.
+3. Test and build the revenue-change rule: the last full calendar month
+   before `period.to` against the mean of the three preceding months.
+4. Test and build the top-source rule: emit only when the delta is 20% or
+   more.
+5. Test the zero-insight fallback: the engine returns an empty list and the
+   caller shows "No notable changes for this period."
+6. Test the anchor rule: a historical `period.to` moves every window.
+
+Verify: `npm run test -- cashflowInsights`.
+
+## Task 5: data hook
+
+Files: `src/hooks/useCashFlowInsights.tsx`.
+
+1. Build the hook. Query key: `['cashflow-insights', restaurantId, from,
+   to, bankAccountId]`. Options: `staleTime: 30000`,
+   `refetchOnWindowFocus: true`.
+2. Filter: `restaurant_id`, `status = 'posted'`, and `connected_bank_id`
+   when the bank filter is not `'all'` (same shape as
+   src/hooks/useCashFlowMetrics.tsx:33-44).
+3. Select explicit fields plus the embed
+   `category:chart_of_accounts(id, name)`.
+4. Fetch window: `min(period.from, startOfMonth(subMonths(period.to, 4)))`
+   to `period.to`.
+5. Page with `.range()` in 1000-row pages, ordered by `transaction_date`
+   ascending. Stop at 20 pages and set `truncated: true`.
+6. Memoize the aggregates and the insights from the row set.
+
+Verify: `npm run typecheck` and `npm run lint`.
+
+## Task 6: TimelineBrush
+
+Files: `src/components/banking/cashflow/TimelineBrush.tsx`.
+
+1. Build the two-thumb slider on `SliderPrimitive` directly. Thumbs are
+   `h-6 w-6` (24px). Step: one day at `sm` and above, seven days below.
+2. Month ticks: every month at `lg` and above, every third month below.
+3. `onValueCommit` calls `onPeriodChange` with `type: 'custom'`.
+4. External period changes move the thumbs.
+5. `aria-label`s: "Start date", "End date".
+
+Verify: `npm run typecheck`.
+
+## Task 7: headline and narrative
+
+Files: `src/components/banking/cashflow/CashFlowHeadline.tsx`,
+`src/components/banking/cashflow/CashFlowNarrative.tsx`.
+
+1. Headline: Net cashflow at `text-[28px] font-semibold tracking-tight`,
+   Money in, Money out. Negative net gets `text-destructive`.
+2. Narrative: visible insight list per the design. Amount and payee spans
+   get the `bg-muted rounded-md px-1` chip look. Caption: "Trends are
+   generated and may include inaccuracies."
+
+Verify: `npm run typecheck`.
+
+## Task 8: chart
+
+Files: `src/components/banking/cashflow/CashFlowChart.tsx`.
+
+1. Controls: cashflow Select, mode `ToggleGroup` (Flow | By category |
+   In vs out), interval Select (hidden in Flow mode).
+2. Flow mode: Recharts `Sankey` from `buildSankey`.
+3. Category mode: stacked bars, positive up, negative down,
+   `hsl(var(--chart-N))` fills.
+4. In-vs-out mode: paired bars with `--success` / `--destructive`.
+5. Each mode: `role="img"`, an `aria-label` from the aggregate strings, and
+   one visible caption wired with `aria-describedby`.
+
+Verify: `npm run typecheck`.
+
+## Task 9: breakdown tables
+
+Files: `src/components/banking/cashflow/MoneyBreakdownTable.tsx`.
+
+1. Card with total, underline tabs (Source|Category — Recipient|Category
+   for money out), and rows: name, percent, percent-of-total track,
+   right-aligned amount. Top eight rows plus `Remaining`.
+
+Verify: `npm run typecheck`.
+
+## Task 10: composition and prop thread
+
+Files: `src/components/banking/CashFlowTab.tsx`,
+`src/components/banking/BankingIntelligenceDashboard.tsx`,
+`src/pages/FinancialIntelligence.tsx`.
+
+1. Rewrite `CashFlowTab`: brush, headline, narrative|chart grid, tables
+   grid. Single column below `lg`.
+2. Gate the whole composition on the one `useCashFlowInsights` result:
+   Skeleton on load, one retry card on error, one empty state on zero
+   rows, one notice line when `truncated`.
+3. Thread `onPeriodChange` from `FinancialIntelligence` through
+   `BankingIntelligenceDashboard` to `CashFlowTab`.
+4. Delete the old metric cards, pie chart, and volatility gauge from this
+   tab only.
+
+Verify: `npm run typecheck`, `npm run lint`, `npm run test`.
+
+## Task 11: E2E test
+
+Files: `tests/e2e/financial-intelligence-cashflow.spec.ts`.
+
+1. Seed a connected bank, two accounts, and transactions across four
+   months (pattern: tests/e2e/bank-transaction-filtering.spec.ts:36-176).
+2. Assert: headline totals; visible narrative text; mode switch renders
+   category bars and in-out bars; breakdown tab switch; the bank-account
+   filter changes the totals; the empty state shows for a period with no
+   transactions.
+3. Use `page.getByRole()` and `page.getByLabel()` selectors.
+
+Verify: `npm run test:e2e -- financial-intelligence-cashflow`.
+
+## Task 12: full verification
+
+1. Run `npm run typecheck`, `npm run lint`, `npm run test`.
+2. Run the E2E spec.
+3. Check both themes in the preview: light and dark.
+
+## Out of scope
+
+Same as the design doc: no AI narrative, no export, no compare control, no
+change to the other four tabs, no `unified_sales` data.

--- a/docs/superpowers/specs/2026-08-19-cashflow-insights-design.md
+++ b/docs/superpowers/specs/2026-08-19-cashflow-insights-design.md
@@ -1,0 +1,255 @@
+# Cash Flow Insights — Design
+
+Date: 2026-08-19
+Branch: `feature/cashflow-insights`
+Reference: Mercury Insights page (user screenshot, 2026-08-19).
+
+## Goal
+
+Rebuild the Cash Flow tab of `/financial-intelligence` in the Mercury Insights
+style. The user must:
+
+- Filter dates with a range slider and with date pickers.
+- Filter by bank account.
+- See the money movement in three visual modes: a Sankey flow, a stacked-bar
+  timeline by category, and an in-versus-out timeline.
+- Read a visible text narrative that explains the numbers.
+- See "Money in" and "Money out" breakdown tables with source/category tabs,
+  percent-of-total bars, and amounts.
+
+## Current state (cited)
+
+- The route `/financial-intelligence` renders `FinancialIntelligence` inside
+  `ProtectedRoute` (src/App.tsx:418).
+- The page owns two filter states: `selectedPeriod` and `selectedBankAccount`
+  (src/pages/FinancialIntelligence.tsx:16-22). It renders `PeriodSelector`,
+  `BankAccountFilter`, and `BankingIntelligenceDashboard`
+  (src/pages/FinancialIntelligence.tsx:39-57).
+- `PeriodSelector` gives preset periods and a custom `DateRangePicker`
+  (src/components/PeriodSelector.tsx:26-33 and
+  src/components/PeriodSelector.tsx:100-104). It has no slider.
+- `BankAccountFilter` is a `Select` over `connectedBanks` with an "all" option
+  (src/components/banking/BankAccountFilter.tsx:39-63).
+- `BankingIntelligenceDashboard` shows five tabs. The `cash-flow` tab renders
+  `CashFlowTab` with `selectedPeriod` and `selectedBankAccount` only — no
+  period setter (src/components/banking/BankingIntelligenceDashboard.tsx:59-61).
+- The current `CashFlowTab` shows three metric cards, an area chart, a pie
+  chart, and a volatility gauge (src/components/banking/CashFlowTab.tsx:83-251).
+  It does not show a Sankey, a category timeline, a narrative, or breakdown
+  tables.
+- `useCashFlowMetrics` queries `bank_transactions` with a
+  `connected_bank_id` filter and `status = 'posted'`
+  (src/hooks/useCashFlowMetrics.tsx:33-44). It selects only
+  `transaction_date, amount, status` (src/hooks/useCashFlowMetrics.tsx:35).
+- `bank_transactions` has the columns this feature needs: `amount`
+  (src/integrations/supabase/types.ts:871), `is_transfer`
+  (src/integrations/supabase/types.ts:884), `merchant_name`
+  (src/integrations/supabase/types.ts:888), `normalized_payee`
+  (src/integrations/supabase/types.ts:889), `transaction_date`
+  (src/integrations/supabase/types.ts:905), `category_id`
+  (src/integrations/supabase/types.ts:872), `description`
+  (src/integrations/supabase/types.ts:876).
+- The foreign key `bank_transactions_category_id_fkey` points to
+  `chart_of_accounts` (src/integrations/supabase/types.ts:996-1001), so a
+  PostgREST embed `category:chart_of_accounts(id, name)` is valid.
+- Recharts is installed (package.json:121). A Recharts `Sankey` already works
+  in this codebase (src/components/dashboard/CashFlowSankeyChart.tsx:3).
+- The shadcn `Slider` wraps Radix and renders one thumb
+  (src/components/ui/slider.tsx:10-19). A range brush needs two thumbs, so a
+  new component must use `SliderPrimitive` directly.
+- Chart color tokens `--chart-1`..`--chart-5` exist for light and dark themes
+  (src/index.css:58-62 and src/index.css:129-133). `--success` and
+  `--destructive` tokens exist (src/index.css:32 and src/index.css:29).
+- An E2E pattern for the seed of `connected_banks`, `bank_account_balances`,
+  and `bank_transactions` exists
+  (tests/e2e/bank-transaction-filtering.spec.ts:36-90).
+
+## Lessons applied (Phase 0)
+
+- Narrative text must be visible copy, not only `aria-label`/`sr-only`
+  (memory/lessons.md, 2026-07-22 "insight text only as aria-label"). The
+  narrative panel is the product here. Render it as visible text. Give charts
+  an accessible name from the same strings.
+- A calendar-day token has two correct serializations; do not use
+  `toISOString().split('T')[0]` on a local-midnight `Date`
+  (memory/lessons.md, 2026-07-28). Use `format(date, 'yyyy-MM-dd')` from
+  `date-fns`, as `useCashFlowMetrics` already does
+  (src/hooks/useCashFlowMetrics.tsx:38-39).
+
+## Decisions
+
+The session runs without a human in the loop. The screenshot and the request
+text are the approved brief. The decisions below follow from them.
+
+1. **Scope**: change only the Cash Flow tab plus the prop threads it needs.
+   The other four tabs stay unchanged.
+2. **No DB change**: all aggregation runs on the client from one
+   `bank_transactions` query. No migration, no edge function, no RPC.
+3. **Slider placement**: the timeline brush renders inside the new Cash Flow
+   view, above the headline numbers. It writes the same page-level
+   `selectedPeriod` state. `FinancialIntelligence` passes `onPeriodChange`
+   down through `BankingIntelligenceDashboard` to `CashFlowTab`.
+4. **Charts**: Recharts only. The Sankey mode reuses the Recharts `Sankey`
+   element. No new chart library.
+5. **Colors**: chart series read `hsl(var(--chart-N))`, `hsl(var(--success))`,
+   `hsl(var(--destructive))`. No hardcoded colors in new code.
+6. **Narrative**: deterministic client-side rules. No AI call. The insight
+   engine is a pure function with unit tests.
+
+## New architecture
+
+```text
+src/lib/cashflowInsights.ts          pure aggregation + insight engine
+src/hooks/useCashFlowInsights.tsx    React Query fetch + memoized aggregation
+src/components/banking/cashflow/
+  TimelineBrush.tsx                  two-thumb month-scale range slider
+  CashFlowHeadline.tsx               Net cashflow / Money in / Money out
+  CashFlowNarrative.tsx              visible insight list
+  CashFlowChart.tsx                  three modes: flow | category | in-out
+  MoneyBreakdownTable.tsx            Money in / Money out tables
+src/components/banking/CashFlowTab.tsx   rewritten composition
+```
+
+### Data fetch (`useCashFlowInsights`)
+
+One query per (restaurant, from, to, bankAccount) key:
+
+- Table: `bank_transactions`, filter `restaurant_id`, `status = 'posted'`,
+  and `connected_bank_id` when the bank filter is not `'all'` — the same
+  filter shape as src/hooks/useCashFlowMetrics.tsx:33-44.
+- Select explicit fields only: `transaction_date, amount, is_transfer,
+  normalized_payee, merchant_name, description,
+  category:chart_of_accounts(id, name)`.
+- Date window: from `min(period.from, startOfMonth(subMonths(period.to, 4)))`
+  to `period.to`. The wide window feeds the three-month comparison in the
+  narrative. The visual aggregates use only rows inside the period.
+- React Query options: `staleTime: 30000`, `refetchOnWindowFocus: true`
+  (CLAUDE.md data-fetch rule).
+
+### Aggregation (`cashflowInsights.ts`, pure)
+
+Input: rows + period + interval. Output:
+
+- `totals`: moneyIn, moneyOut, net (transfers excluded when the cashflow
+  filter is `exclude-transfers`).
+- `series`: buckets by interval (`day` | `week` | `month`) with per-category
+  signed sums, and with `moneyIn`/`moneyOut` sums.
+- `topCategories`: the five largest categories by absolute sum; the rest fold
+  into `Other`. Rows with `is_transfer = true` fold into `Transfers`.
+  Rows with no category fold into `Uncategorized`.
+- `sources` / `recipients`: payee = `normalized_payee ?? merchant_name ??
+  description`. Top eight by amount, the rest fold into a `Remaining` row.
+  Each row carries `pctOfTotal`.
+- `categoryBreakdown`: same shape per category, for the Category tab of each
+  table.
+- `sankey`: nodes and links. Left: top inflow payees + `Transfers in`.
+  Middle: `Money in`. Right: `Expenses` split to top outflow payees +
+  `Transfers out`.
+- `insights`: ordered list of `{ id, title, body }`:
+  1. **Subscriptions**: outflow payees with 3+ charges in the trailing 90
+     days, a 25–35 day cadence, and under 10% amount variance. Title:
+     "N notable transactions". Body: "We noticed N subscriptions you may
+     want to review".
+  2. **Revenue change**: money in for the period, plus the last full calendar
+     month against the mean of the three preceding calendar months. Title:
+     "Revenue increased" or "Revenue decreased".
+  3. **Top source change**: the payee with the largest inflow in the last
+     full calendar month, against that payee's mean over the three preceding
+     months. Emit only when the delta is 20% or more.
+  An insight that fails its data threshold does not render.
+
+Interval default: `day` for periods up to 31 days, `week` up to 120 days,
+`month` above. The user can override with a Select.
+
+### Components
+
+**TimelineBrush** — a horizontal rail with month tick labels over the domain
+`[startOfMonth(subMonths(today, 23)), endOfDay(today)]`, capped at the
+earliest transaction when known. Two thumbs (Radix `SliderPrimitive` with a
+two-value array), step = one day. On commit (`onValueCommit`), it calls
+`onPeriodChange` with `type: 'custom'`. When the period changes from the
+presets or the picker, the thumbs follow. Both thumbs get `aria-label`s
+("Start date", "End date").
+
+**CashFlowHeadline** — three figures in one row: Net cashflow (large),
+Money in, Money out. Typography per CLAUDE.md scale. Negative net renders
+with `text-destructive`.
+
+**CashFlowNarrative** — the insight list, left column on desktop. Each item:
+an arrow glyph, a `text-[14px] font-medium` title, a
+`text-[13px] text-muted-foreground` body. Amount and payee spans get a
+subtle `bg-muted rounded-md px-1` chip look. Below the list, one caption:
+"Trends are generated and may include inaccuracies." All of it is visible
+text (lesson 2026-07-22).
+
+**CashFlowChart** — right column. Controls:
+- Cashflow filter Select: `All cashflow` | `Exclude transfers`.
+- Mode segmented control (three icon+label buttons): `Flow` (Sankey),
+  `By category` (stacked bars, positive up / negative down), `In vs out`
+  (paired bars, out negated below zero).
+- Interval Select: Day / Week / Month (hidden in Flow mode).
+Bars use `hsl(var(--chart-N))` fills; the in-vs-out mode uses
+`--success` / `--destructive`. Tooltip follows the existing token style
+(src/components/banking/CashFlowTab.tsx:141-147). Each mode renders inside
+`role="img"` with an `aria-label` built from the same aggregate strings.
+Loading renders `Skeleton`; error renders retry card; empty renders an
+empty state (CLAUDE.md three-state rule).
+
+**MoneyBreakdownTable** — two cards side by side ("Money in", "Money out").
+Each card: total, a two-option underline tab (Source|Category — Recipient|
+Category for money out), then rows: name, percent, a thin
+percent-of-total track (`bg-muted` track, `bg-primary` fill), right-aligned
+amount. Top eight rows plus `Remaining`.
+
+**CashFlowTab (rewrite)** — composition:
+
+```text
+[TimelineBrush]
+[CashFlowHeadline]
+[grid: CashFlowNarrative | CashFlowChart]
+[grid: MoneyBreakdownTable in | MoneyBreakdownTable out]
+```
+
+Single column below `lg`. The old metric cards, pie chart, and volatility
+gauge leave this tab. `BankingIntelligenceDashboard` and
+`FinancialIntelligence` gain the `onPeriodChange` prop thread.
+
+## Visual direction (frontend-design)
+
+Refined-minimal, Apple/Notion per CLAUDE.md. The identity of the view is the
+Mercury-style composition itself: a quiet full-width brush, one oversized net
+figure (`text-[28px] font-semibold tracking-tight`), hairline `border-border/40`
+separations, and a calm five-hue categorical palette from the `--chart-*`
+tokens. Motion: one staggered fade-in on load (existing `animate-fade-in`
+utility, src/components/banking/CashFlowTab.tsx:81); bars animate on mount via
+Recharts defaults. No gradients, no decorative chrome.
+
+## Tests
+
+- `tests/unit/cashflowInsights.test.ts` — bucket math, transfer folding,
+  payee fallback order, top-N folding, percent math, subscription detection
+  (positive + cadence-miss negative), revenue delta vs three-month mean,
+  top-source threshold, interval default.
+- `tests/e2e/financial-intelligence-cashflow.spec.ts` — seed a connected
+  bank, two accounts, and transactions across four months (pattern:
+  tests/e2e/bank-transaction-filtering.spec.ts:36-90). Assert: headline
+  totals; narrative text visible; mode switch renders category bars and
+  in-out bars; breakdown tab switch (Source → Category); bank-account filter
+  changes the totals.
+
+## Out of scope
+
+- AI-generated narrative.
+- Export button, "Compare to" control, saved data views (Mercury features
+  not requested).
+- Changes to the other four intelligence tabs.
+- `unified_sales` or POS data — this view reads bank data only.
+
+## Decided trade-offs
+
+- The brush and the preset tabs both write `selectedPeriod`; a preset click
+  snaps the thumbs. This is one source of truth, no dual state.
+- Subscription detection is heuristic (cadence + variance). False negatives
+  are acceptable; the threshold favors precision.
+- The Sankey mode ignores the interval control; a flow diagram has no time
+  axis.

--- a/docs/superpowers/specs/2026-08-19-cashflow-insights-design.md
+++ b/docs/superpowers/specs/2026-08-19-cashflow-insights-design.md
@@ -62,7 +62,11 @@ style. The user must:
   `--destructive` tokens exist (src/index.css:32 and src/index.css:29).
 - An E2E pattern for the seed of `connected_banks`, `bank_account_balances`,
   and `bank_transactions` exists
-  (tests/e2e/bank-transaction-filtering.spec.ts:36-90).
+  (tests/e2e/bank-transaction-filtering.spec.ts:36-176). The
+  `bank_transactions` insert sits at
+  tests/e2e/bank-transaction-filtering.spec.ts:111-176.
+- Sibling hooks page long reads with `.range()`
+  (src/hooks/useBankTransactions.tsx:286).
 
 ## Lessons applied (Phase 0)
 
@@ -123,6 +127,16 @@ One query per (restaurant, from, to, bankAccount) key:
 - Date window: from `min(period.from, startOfMonth(subMonths(period.to, 4)))`
   to `period.to`. The wide window feeds the three-month comparison in the
   narrative. The visual aggregates use only rows inside the period.
+- **Paging**: PostgREST caps a response at 1000 rows. The query orders by
+  `transaction_date` ascending and pages with `.range()` in 1000-row pages,
+  the same pattern as src/hooks/useBankTransactions.tsx:286. Hard stop at
+  20 pages (20,000 rows); above the stop, the hook sets a `truncated` flag
+  and the view shows a notice.
+- RLS coupling: the embed on `chart_of_accounts` works because
+  `view:transactions` and `view:chart_of_accounts` map to the same role set
+  today. If the two capabilities diverge, the embed returns `category: null`
+  for the excluded roles without an error. The aggregation folds such rows
+  into `Uncategorized`, so the failure stays visible, not silent.
 - React Query options: `staleTime: 30000`, `refetchOnWindowFocus: true`
   (CLAUDE.md data-fetch rule).
 
@@ -156,7 +170,11 @@ Input: rows + period + interval. Output:
   3. **Top source change**: the payee with the largest inflow in the last
      full calendar month, against that payee's mean over the three preceding
      months. Emit only when the delta is 20% or more.
-  An insight that fails its data threshold does not render.
+  All time anchors ("trailing 90 days", "last full calendar month") anchor
+  to `period.to`, not to today, so a historical period reads correctly.
+  An insight that fails its data threshold does not render. When zero
+  insights pass, the panel shows one line: "No notable changes for this
+  period."
 
 Interval default: `day` for periods up to 31 days, `week` up to 120 days,
 `month` above. The user can override with a Select.
@@ -166,10 +184,13 @@ Interval default: `day` for periods up to 31 days, `week` up to 120 days,
 **TimelineBrush** — a horizontal rail with month tick labels over the domain
 `[startOfMonth(subMonths(today, 23)), endOfDay(today)]`, capped at the
 earliest transaction when known. Two thumbs (Radix `SliderPrimitive` with a
-two-value array), step = one day. On commit (`onValueCommit`), it calls
-`onPeriodChange` with `type: 'custom'`. When the period changes from the
-presets or the picker, the thumbs follow. Both thumbs get `aria-label`s
-("Start date", "End date").
+two-value array). Thumb size is at least `h-6 w-6` (24px) to meet the WCAG
+2.5.8 target-size minimum. Step = one day at `sm` and above; step = seven
+days below `sm`, where one day maps to under half a pixel. Month tick
+labels show every month at `lg` and above, every third month below. On
+commit (`onValueCommit`), it calls `onPeriodChange` with `type: 'custom'`.
+When the period changes from the presets or the picker, the thumbs follow.
+Both thumbs get `aria-label`s ("Start date", "End date").
 
 **CashFlowHeadline** — three figures in one row: Net cashflow (large),
 Money in, Money out. Typography per CLAUDE.md scale. Negative net renders
@@ -184,7 +205,7 @@ text (lesson 2026-07-22).
 
 **CashFlowChart** — right column. Controls:
 - Cashflow filter Select: `All cashflow` | `Exclude transfers`.
-- Mode segmented control (three icon+label buttons): `Flow` (Sankey),
+- Mode control: a shadcn `ToggleGroup` with three items: `Flow` (Sankey),
   `By category` (stacked bars, positive up / negative down), `In vs out`
   (paired bars, out negated below zero).
 - Interval Select: Day / Week / Month (hidden in Flow mode).
@@ -192,8 +213,9 @@ Bars use `hsl(var(--chart-N))` fills; the in-vs-out mode uses
 `--success` / `--destructive`. Tooltip follows the existing token style
 (src/components/banking/CashFlowTab.tsx:141-147). Each mode renders inside
 `role="img"` with an `aria-label` built from the same aggregate strings.
-Loading renders `Skeleton`; error renders retry card; empty renders an
-empty state (CLAUDE.md three-state rule).
+Under every mode, one visible caption states the period totals in a
+sentence; the chart's `aria-describedby` points at it. This gives the
+Sankey a fuller description than one label.
 
 **MoneyBreakdownTable** — two cards side by side ("Money in", "Money out").
 Each card: total, a two-option underline tab (Source|Category — Recipient|
@@ -214,6 +236,13 @@ Single column below `lg`. The old metric cards, pie chart, and volatility
 gauge leave this tab. `BankingIntelligenceDashboard` and
 `FinancialIntelligence` gain the `onPeriodChange` prop thread.
 
+State gate: `CashFlowTab` gates the whole composition on the single
+`useCashFlowInsights` result. Loading renders `Skeleton` blocks in the
+final layout shape. Error renders one retry card. Zero transactions in the
+period renders one empty state. Child components receive data only
+(CLAUDE.md three-state rule). When the hook reports `truncated`, the tab
+shows one notice line above the headline.
+
 ## Visual direction (frontend-design)
 
 Refined-minimal, Apple/Notion per CLAUDE.md. The identity of the view is the
@@ -224,18 +253,24 @@ tokens. Motion: one staggered fade-in on load (existing `animate-fade-in`
 utility, src/components/banking/CashFlowTab.tsx:81); bars animate on mount via
 Recharts defaults. No gradients, no decorative chrome.
 
+The net figure uses `text-[28px] font-semibold tracking-tight`. This is a
+deliberate exception to the CLAUDE.md typography scale, for the one
+headline metric only. All other text stays on the scale.
+
 ## Tests
 
 - `tests/unit/cashflowInsights.test.ts` — bucket math, transfer folding,
   payee fallback order, top-N folding, percent math, subscription detection
   (positive + cadence-miss negative), revenue delta vs three-month mean,
-  top-source threshold, interval default.
+  top-source threshold, interval default, zero-row input (empty aggregates,
+  zero insights), time anchors at `period.to`.
 - `tests/e2e/financial-intelligence-cashflow.spec.ts` — seed a connected
   bank, two accounts, and transactions across four months (pattern:
-  tests/e2e/bank-transaction-filtering.spec.ts:36-90). Assert: headline
+  tests/e2e/bank-transaction-filtering.spec.ts:36-176). Assert: headline
   totals; narrative text visible; mode switch renders category bars and
   in-out bars; breakdown tab switch (Source → Category); bank-account filter
-  changes the totals.
+  changes the totals; the empty state shows for a period with no
+  transactions.
 
 ## Out of scope
 

--- a/src/components/PeriodSelector.tsx
+++ b/src/components/PeriodSelector.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { Calendar } from 'lucide-react';
 import { DateRangePicker } from '@/components/ui/date-range-picker';
-import { startOfWeek, endOfDay, startOfMonth, startOfQuarter, subDays, format, startOfDay } from 'date-fns';
+import { customPeriodLabel, presetPeriod, PRESET_PERIOD_TYPES } from '@/lib/periodUrlState';
 
 export type PeriodType = 'today' | 'week' | 'month' | 'quarter' | 'last30' | 'last90' | 'custom';
 
@@ -21,24 +21,12 @@ export function PeriodSelector({ selectedPeriod, onPeriodChange }: PeriodSelecto
   const [showDatePicker, setShowDatePicker] = useState(false);
 
   const today = new Date();
-  const endToday = endOfDay(today);
 
-  const periods: Array<{ type: PeriodType; label: string; from: Date; to: Date }> = [
-    { type: 'today', label: 'Today', from: startOfDay(today), to: endToday },
-    { type: 'week', label: 'This Week', from: startOfDay(startOfWeek(today, { weekStartsOn: 1 })), to: endToday },
-    { type: 'month', label: 'This Month', from: startOfDay(startOfMonth(today)), to: endToday },
-    { type: 'quarter', label: 'This Quarter', from: startOfDay(startOfQuarter(today)), to: endToday },
-    { type: 'last30', label: 'Last 30 Days', from: startOfDay(subDays(endToday, 29)), to: endToday },
-    { type: 'last90', label: 'Last 90 Days', from: startOfDay(subDays(endToday, 89)), to: endToday },
-  ];
+  // presetPeriod is shared with the URL codec, so a decoded link matches a tab click.
+  const periods: Period[] = PRESET_PERIOD_TYPES.map((type) => presetPeriod(type, today));
 
-  const handlePeriodSelect = (period: typeof periods[0]) => {
-    onPeriodChange({
-      type: period.type,
-      from: period.from,
-      to: period.to,
-      label: period.label,
-    });
+  const handlePeriodSelect = (period: Period) => {
+    onPeriodChange(period);
     setShowDatePicker(false);
   };
 
@@ -48,7 +36,7 @@ export function PeriodSelector({ selectedPeriod, onPeriodChange }: PeriodSelecto
         type: 'custom',
         from: range.from,
         to: range.to,
-        label: `${format(range.from, 'MMM d')} - ${format(range.to, 'MMM d, yyyy')}`,
+        label: customPeriodLabel(range.from, range.to),
       });
       setShowDatePicker(false);
     }

--- a/src/components/banking/BankingIntelligenceDashboard.tsx
+++ b/src/components/banking/BankingIntelligenceDashboard.tsx
@@ -13,11 +13,13 @@ import type { Period } from "@/components/PeriodSelector";
 interface BankingIntelligenceDashboardProps {
   selectedPeriod: Period;
   selectedBankAccount: string;
+  onPeriodChange: (period: Period) => void;
 }
 
 export function BankingIntelligenceDashboard({
   selectedPeriod,
   selectedBankAccount,
+  onPeriodChange,
 }: BankingIntelligenceDashboardProps) {
   const [activeTab, setActiveTab] = useState("cash-flow");
 
@@ -57,7 +59,11 @@ export function BankingIntelligenceDashboard({
         </TabsList>
 
         <TabsContent value="cash-flow" className="mt-6">
-          <CashFlowTab selectedPeriod={selectedPeriod} selectedBankAccount={selectedBankAccount} />
+          <CashFlowTab
+            selectedPeriod={selectedPeriod}
+            selectedBankAccount={selectedBankAccount}
+            onPeriodChange={onPeriodChange}
+          />
         </TabsContent>
 
         <TabsContent value="revenue" className="mt-6">

--- a/src/components/banking/BankingIntelligenceDashboard.tsx
+++ b/src/components/banking/BankingIntelligenceDashboard.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
 import { TrendingUp, DollarSign, PieChart, Sparkles, AlertTriangle } from "lucide-react";
@@ -9,6 +10,10 @@ import { SpendingAnalysisTab } from "./SpendingAnalysisTab";
 import { LiquidityTab } from "./LiquidityTab";
 import { PredictionsTab } from "./PredictionsTab";
 import type { Period } from "@/components/PeriodSelector";
+import { readEnumParam } from "@/lib/periodUrlState";
+
+const DASHBOARD_TABS = ["cash-flow", "revenue", "spending", "liquidity", "predictions"] as const;
+type DashboardTab = (typeof DASHBOARD_TABS)[number];
 
 interface BankingIntelligenceDashboardProps {
   selectedPeriod: Period;
@@ -21,7 +26,20 @@ export function BankingIntelligenceDashboard({
   selectedBankAccount,
   onPeriodChange,
 }: BankingIntelligenceDashboardProps) {
-  const [activeTab, setActiveTab] = useState("cash-flow");
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [activeTab, setActiveTab] = useState<DashboardTab>(
+    () => readEnumParam(searchParams, "tab", DASHBOARD_TABS) ?? "cash-flow",
+  );
+
+  const handleTabChange = (value: string) => {
+    const tab = value as DashboardTab;
+    setActiveTab(tab);
+    // Read the live search string, not the hook value. The page writes the
+    // period params and the hook value can lag one render behind.
+    const params = new URLSearchParams(window.location.search);
+    params.set("tab", tab);
+    setSearchParams(params, { replace: true });
+  };
 
   return (
     <div className="space-y-6">
@@ -29,7 +47,7 @@ export function BankingIntelligenceDashboard({
       <FinancialPulseHero selectedPeriod={selectedPeriod} selectedBankAccount={selectedBankAccount} />
 
       {/* Intelligence Tabs */}
-      <Tabs value={activeTab} onValueChange={setActiveTab}>
+      <Tabs value={activeTab} onValueChange={handleTabChange}>
         <TabsList className="grid w-full grid-cols-2 sm:grid-cols-5 h-auto">
           <TabsTrigger value="cash-flow" className="gap-2 py-2.5">
             <TrendingUp className="h-4 w-4" />

--- a/src/components/banking/CashFlowTab.tsx
+++ b/src/components/banking/CashFlowTab.tsx
@@ -1,21 +1,28 @@
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
-import { DashboardMetricCard } from "@/components/DashboardMetricCard";
-import { TrendingUp, TrendingDown, DollarSign, Activity, AlertCircle } from "lucide-react";
-import { useCashFlowMetrics } from "@/hooks/useCashFlowMetrics";
+import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
-import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, PieChart, Pie, Cell } from 'recharts';
-import { format, subDays, differenceInDays } from "date-fns";
+import { AlertCircle } from "lucide-react";
+import { useCashFlowInsights } from "@/hooks/useCashFlowInsights";
+import { TimelineBrush } from "@/components/banking/cashflow/TimelineBrush";
+import { CashFlowHeadline } from "@/components/banking/cashflow/CashFlowHeadline";
+import { CashFlowNarrative } from "@/components/banking/cashflow/CashFlowNarrative";
+import { CashFlowChart } from "@/components/banking/cashflow/CashFlowChart";
+import { MoneyBreakdownTable } from "@/components/banking/cashflow/MoneyBreakdownTable";
 import type { Period } from "@/components/PeriodSelector";
 
 interface CashFlowTabProps {
   selectedPeriod: Period;
   selectedBankAccount: string;
+  onPeriodChange: (period: Period) => void;
 }
 
-export function CashFlowTab({ selectedPeriod, selectedBankAccount }: CashFlowTabProps) {
-  const { data: metrics, isLoading, error, refetch } = useCashFlowMetrics(selectedPeriod.from, selectedPeriod.to, selectedBankAccount);
-  const periodDays = differenceInDays(selectedPeriod.to, selectedPeriod.from) + 1;
+/**
+ * Mercury-style cash flow view: brush, headline, a narrative|chart grid,
+ * and Money in / Money out tables. Gated on the single
+ * `useCashFlowInsights` result (CLAUDE.md three-state rule).
+ */
+export function CashFlowTab({ selectedPeriod, selectedBankAccount, onPeriodChange }: CashFlowTabProps) {
+  const { data, isLoading, error, refetch } = useCashFlowInsights(selectedPeriod, selectedBankAccount);
 
   if (error) {
     return (
@@ -34,221 +41,62 @@ export function CashFlowTab({ selectedPeriod, selectedBankAccount }: CashFlowTab
 
   if (isLoading) {
     return (
-      <div className="space-y-6">
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          {[...Array(3)].map((_, i) => (
-            <Skeleton key={i} className="h-40" />
-          ))}
+      <div className="space-y-6" role="status" aria-live="polite" aria-label="Loading cash flow">
+        <Skeleton className="h-16" />
+        <Skeleton className="h-16" />
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <Skeleton className="h-80" />
+          <Skeleton className="h-80" />
         </div>
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-          {[...Array(2)].map((_, i) => (
-            <Skeleton key={i} className="h-80" />
-          ))}
+          <Skeleton className="h-64" />
+          <Skeleton className="h-64" />
         </div>
       </div>
     );
   }
 
-  if (!metrics) {
+  if (!data || data.rows.length === 0) {
     return (
       <div className="text-center py-12">
-        <p className="text-muted-foreground">No transaction data available</p>
+        <p className="text-muted-foreground">No transactions for this period</p>
       </div>
     );
   }
-
-  // Prepare daily cash flow data for chart
-  const trendDays = Math.min(14, periodDays);
-  const dailyChartData = metrics.trend.map((value, index) => ({
-    date: format(subDays(selectedPeriod.to, trendDays - 1 - index), 'MMM dd'),
-    amount: value,
-  }));
-
-  // Prepare inflows vs outflows comparison
-  const comparisonData = [
-    { name: 'Inflows', value: metrics.netInflows30d, color: 'hsl(var(--success))' },
-    { name: 'Outflows', value: metrics.netOutflows30d, color: 'hsl(var(--destructive))' },
-  ];
-
-  const volatilityScore = Math.max(0, 100 - (metrics.volatility / 100));
-  const getVolatilityVariant = () => {
-    if (volatilityScore >= 80) return 'success';
-    if (volatilityScore >= 60) return 'warning';
-    return 'danger';
-  };
 
   return (
     <div className="space-y-6 animate-fade-in">
-      {/* Primary Metrics */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <DashboardMetricCard
-          title="Net Inflows"
-          value={`$${metrics.netInflows30d.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`}
-          icon={TrendingUp}
-          variant="success"
-          subtitle="Total incoming cash"
-          periodLabel={selectedPeriod.label}
-        />
-        <DashboardMetricCard
-          title="Net Outflows"
-          value={`$${metrics.netOutflows30d.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`}
-          icon={TrendingDown}
-          variant="danger"
-          subtitle="Total outgoing cash"
-          periodLabel={selectedPeriod.label}
-        />
-        <DashboardMetricCard
-          title="Net Cash Flow"
-          value={`$${metrics.netCashFlow30d.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`}
-          icon={Activity}
-          variant={metrics.netCashFlow30d >= 0 ? 'success' : 'danger'}
-          subtitle="Net position"
-          periodLabel={selectedPeriod.label}
-        />
-      </div>
+      {data.truncated && (
+        <p className="text-[13px] text-muted-foreground">
+          This period has more transactions than we could load. Totals may be incomplete.
+        </p>
+      )}
 
-      {/* Charts */}
+      <TimelineBrush selectedPeriod={selectedPeriod} onPeriodChange={onPeriodChange} />
+
+      <CashFlowHeadline totals={data.aggregates.totals} />
+
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {/* Daily Cash Flow Chart */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Activity className="h-5 w-5 text-primary" />
-              Daily Cash Flow Trend
-            </CardTitle>
-            <CardDescription>Last {Math.min(14, periodDays)} days</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <ResponsiveContainer width="100%" height={280}>
-              <AreaChart data={dailyChartData}>
-                <defs>
-                  <linearGradient id="colorAmount" x1="0" y1="0" x2="0" y2="1">
-                    <stop offset="5%" stopColor="hsl(var(--primary))" stopOpacity={0.3}/>
-                    <stop offset="95%" stopColor="hsl(var(--primary))" stopOpacity={0}/>
-                  </linearGradient>
-                </defs>
-                <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                <XAxis 
-                  dataKey="date" 
-                  className="text-xs text-muted-foreground"
-                  tick={{ fill: 'hsl(var(--muted-foreground))' }}
-                />
-                <YAxis 
-                  className="text-xs text-muted-foreground"
-                  tick={{ fill: 'hsl(var(--muted-foreground))' }}
-                  tickFormatter={(value) => `$${(value / 1000).toFixed(0)}k`}
-                />
-                <Tooltip 
-                  contentStyle={{ 
-                    backgroundColor: 'hsl(var(--background))',
-                    border: '1px solid hsl(var(--border))',
-                    borderRadius: '8px'
-                  }}
-                  formatter={(value: number) => [`$${value.toLocaleString()}`, 'Amount']}
-                />
-                <Area 
-                  type="monotone" 
-                  dataKey="amount" 
-                  stroke="hsl(var(--primary))" 
-                  strokeWidth={2}
-                  fill="url(#colorAmount)"
-                />
-              </AreaChart>
-            </ResponsiveContainer>
-          </CardContent>
-        </Card>
-
-        {/* Inflows vs Outflows */}
-        <Card>
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <DollarSign className="h-5 w-5 text-primary" />
-              Inflows vs. Outflows
-            </CardTitle>
-            <CardDescription>{selectedPeriod.label} breakdown</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="flex items-center justify-center">
-              <ResponsiveContainer width="100%" height={280}>
-                <PieChart>
-                  <Pie
-                    data={comparisonData}
-                    cx="50%"
-                    cy="50%"
-                    labelLine={false}
-                    label={({ name, value }) => `${name}: $${value.toLocaleString()}`}
-                    outerRadius={100}
-                    fill="#8884d8"
-                    dataKey="value"
-                  >
-                    {comparisonData.map((entry, index) => (
-                      <Cell key={`cell-${index}`} fill={entry.color} />
-                    ))}
-                  </Pie>
-                  <Tooltip 
-                    formatter={(value: number) => `$${value.toLocaleString()}`}
-                    contentStyle={{ 
-                      backgroundColor: 'hsl(var(--background))',
-                      border: '1px solid hsl(var(--border))',
-                      borderRadius: '8px'
-                    }}
-                  />
-                </PieChart>
-              </ResponsiveContainer>
-            </div>
-            
-            <div className="mt-4 space-y-2">
-              <div className="flex items-center justify-between p-3 rounded-lg bg-success/10">
-                <span className="text-sm font-medium">Net Position</span>
-                <span className={`text-sm font-bold ${metrics.netCashFlow30d >= 0 ? 'text-success' : 'text-destructive'}`}>
-                  {metrics.netCashFlow30d >= 0 ? '+' : ''}${metrics.netCashFlow30d.toLocaleString()}
-                </span>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
+        <CashFlowNarrative insights={data.insights} />
+        <CashFlowChart rows={data.rows} period={selectedPeriod} />
       </div>
 
-      {/* Volatility Gauge */}
-      <Card className={`border-${getVolatilityVariant() === 'success' ? 'green' : getVolatilityVariant() === 'warning' ? 'yellow' : 'red'}-200`}>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            Cash Flow Volatility
-          </CardTitle>
-          <CardDescription>Stability score (higher is better)</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-4">
-            <div className="flex items-center justify-between">
-              <span className="text-4xl font-bold">{volatilityScore.toFixed(0)}/100</span>
-              <span className={`px-3 py-1 rounded-full text-sm font-medium ${
-                volatilityScore >= 80 ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900 dark:text-emerald-300' :
-                volatilityScore >= 60 ? 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-300' :
-                'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300'
-              }`}>
-                {volatilityScore >= 80 ? 'Low Volatility' : volatilityScore >= 60 ? 'Medium Volatility' : 'High Volatility'}
-              </span>
-            </div>
-            <div className="w-full bg-muted rounded-full h-4">
-              <div 
-                className={`h-4 rounded-full transition-all duration-1000 ${
-                  volatilityScore >= 80 ? 'bg-gradient-to-r from-emerald-500 to-green-600' :
-                  volatilityScore >= 60 ? 'bg-gradient-to-r from-yellow-500 to-orange-600' :
-                  'bg-gradient-to-r from-red-500 to-rose-600'
-                }`}
-                style={{ width: `${volatilityScore}%` }}
-              />
-            </div>
-            <p className="text-sm text-muted-foreground">
-              {volatilityScore >= 80 
-                ? 'Your cash flow is stable and predictable.' 
-                : volatilityScore >= 60 
-                ? 'Some fluctuation in your cash flow. Monitor closely.' 
-                : 'High cash flow variability detected. Consider smoothing expenses or revenue timing.'}
-            </p>
-          </div>
-        </CardContent>
-      </Card>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <MoneyBreakdownTable
+          title="Money in"
+          total={data.aggregates.totals.moneyIn}
+          primaryTabLabel="Source"
+          primaryRows={data.sources}
+          categoryRows={data.categoryBreakdownIn}
+        />
+        <MoneyBreakdownTable
+          title="Money out"
+          total={data.aggregates.totals.moneyOut}
+          primaryTabLabel="Recipient"
+          primaryRows={data.recipients}
+          categoryRows={data.categoryBreakdownOut}
+        />
+      </div>
     </div>
   );
 }

--- a/src/components/banking/CashFlowTab.tsx
+++ b/src/components/banking/CashFlowTab.tsx
@@ -80,9 +80,14 @@ export function CashFlowTab({ selectedPeriod, selectedBankAccount, onPeriodChang
 
       <CashFlowHeadline totals={data.aggregates.totals} />
 
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <CashFlowNarrative insights={data.insights} />
-        <CashFlowChart rows={data.rows} period={selectedPeriod} />
+      {/* The chart needs the width: two of three columns on large screens. */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="rounded-xl border border-border/40 bg-background p-4 lg:col-span-1">
+          <CashFlowNarrative insights={data.insights} />
+        </div>
+        <div className="rounded-xl border border-border/40 bg-background p-4 lg:col-span-2">
+          <CashFlowChart rows={data.rows} period={selectedPeriod} />
+        </div>
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">

--- a/src/components/banking/CashFlowTab.tsx
+++ b/src/components/banking/CashFlowTab.tsx
@@ -58,8 +58,12 @@ export function CashFlowTab({ selectedPeriod, selectedBankAccount, onPeriodChang
 
   if (!data || data.rows.length === 0) {
     return (
-      <div className="text-center py-12">
-        <p className="text-muted-foreground">No transactions for this period</p>
+      <div className="space-y-6 animate-fade-in">
+        {/* Keep the brush visible so the user can brush back out of an empty range. */}
+        <TimelineBrush selectedPeriod={selectedPeriod} onPeriodChange={onPeriodChange} />
+        <div className="text-center py-12">
+          <p className="text-muted-foreground">No transactions for this period</p>
+        </div>
       </div>
     );
   }

--- a/src/components/banking/cashflow/CashFlowChart.tsx
+++ b/src/components/banking/cashflow/CashFlowChart.tsx
@@ -1,4 +1,4 @@
-import { useId, useMemo, useState } from 'react';
+import { useEffect, useId, useMemo, useState } from 'react';
 import { Bar, BarChart, CartesianGrid, Layer, ResponsiveContainer, Sankey, Tooltip, XAxis, YAxis } from 'recharts';
 
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
@@ -63,6 +63,14 @@ export function CashFlowChart({ rows, period, className }: CashFlowChartProps) {
   const [filter, setFilter] = useState<CashflowFilter>('all');
   const [interval, setIntervalValue] = useState<Interval>(() => defaultInterval(period));
 
+  // The default interval depends on the period length. Re-derive it whenever
+  // the period changes, so a longer or shorter range gets the right bucket
+  // size even after the user has manually picked one for a prior period.
+  useEffect(() => {
+    setIntervalValue(defaultInterval(period));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [period.from.getTime(), period.to.getTime()]);
+
   const filteredRows = useMemo(
     () => (filter === 'exclude-transfers' ? rows.filter((row) => !row.is_transfer) : rows),
     [rows, filter],
@@ -72,10 +80,30 @@ export function CashFlowChart({ rows, period, className }: CashFlowChartProps) {
   const sankeyData = useMemo(() => buildSankey(filteredRows), [filteredRows]);
   const series = useMemo(() => bucketSeries(filteredRows, period, interval), [filteredRows, period, interval]);
   const categories = useMemo(() => topCategories(filteredRows), [filteredRows]);
+  // The top-5-plus-Other category set, computed once across the whole
+  // period. Buckets must fold into this same set, or a category outside
+  // the top 5 renders no Bar and silently drops from the stacked chart.
+  const topCategoryNames = useMemo(
+    () => new Set(categories.filter((category) => category.name !== 'Other').map((category) => category.name)),
+    [categories],
+  );
 
   const categoryChartData = useMemo(
-    () => series.map((bucket) => ({ bucketStart: bucket.bucketStart, ...bucket.byCategory })),
-    [series],
+    () =>
+      series.map((bucket) => {
+        const point: Record<string, string | number> = { bucketStart: bucket.bucketStart };
+        let otherAmount = 0;
+        for (const [name, amount] of Object.entries(bucket.byCategory)) {
+          if (topCategoryNames.has(name)) {
+            point[name] = amount;
+          } else {
+            otherAmount += amount;
+          }
+        }
+        if (otherAmount !== 0) point['Other'] = otherAmount;
+        return point;
+      }),
+    [series, topCategoryNames],
   );
   const inOutChartData = useMemo(
     () => series.map((bucket) => ({ bucketStart: bucket.bucketStart, moneyIn: bucket.moneyIn, moneyOut: bucket.moneyOut })),

--- a/src/components/banking/cashflow/CashFlowChart.tsx
+++ b/src/components/banking/cashflow/CashFlowChart.tsx
@@ -1,0 +1,207 @@
+import { useId, useMemo, useState } from 'react';
+import { Bar, BarChart, CartesianGrid, Layer, ResponsiveContainer, Sankey, Tooltip, XAxis, YAxis } from 'recharts';
+
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { cn } from '@/lib/utils';
+import {
+  bucketSeries,
+  buildSankey,
+  computeTotals,
+  defaultInterval,
+  topCategories,
+  type CashFlowPeriod,
+  type CashFlowRow,
+  type Interval,
+} from '@/lib/cashflowInsights';
+
+interface CashFlowChartProps {
+  rows: CashFlowRow[];
+  period: CashFlowPeriod;
+  className?: string;
+}
+
+type ChartMode = 'flow' | 'category' | 'inout';
+type CashflowFilter = 'all' | 'exclude-transfers';
+
+const MODE_LABELS: Record<ChartMode, string> = {
+  flow: 'Flow',
+  category: 'By category',
+  inout: 'In vs out',
+};
+
+const CATEGORY_COLORS = [
+  'hsl(var(--chart-1))',
+  'hsl(var(--chart-2))',
+  'hsl(var(--chart-3))',
+  'hsl(var(--chart-4))',
+  'hsl(var(--chart-5))',
+  'hsl(var(--muted-foreground))',
+];
+
+function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  }).format(amount);
+}
+
+function SankeyNode(props: { x?: number; y?: number; width?: number; height?: number; payload?: { name: string } }) {
+  const { x = 0, y = 0, width = 0, height = 0, payload } = props;
+  return (
+    <Layer>
+      <rect x={x} y={y} width={width} height={height} fill="hsl(var(--chart-2))" rx={2} />
+      <text x={x + width + 6} y={y + height / 2} dy={4} fontSize={12} fill="hsl(var(--foreground))">
+        {payload?.name}
+      </text>
+    </Layer>
+  );
+}
+
+/**
+ * The Cash Flow chart panel: Flow (Sankey), By category (stacked bars),
+ * and In vs out (paired bars). Each mode carries an accessible name and a
+ * visible caption wired with `aria-describedby`.
+ */
+export function CashFlowChart({ rows, period, className }: CashFlowChartProps) {
+  const captionId = useId();
+  const [mode, setMode] = useState<ChartMode>('flow');
+  const [filter, setFilter] = useState<CashflowFilter>('all');
+  const [interval, setIntervalValue] = useState<Interval>(() => defaultInterval(period));
+
+  const filteredRows = useMemo(
+    () => (filter === 'exclude-transfers' ? rows.filter((row) => !row.is_transfer) : rows),
+    [rows, filter],
+  );
+
+  const totals = useMemo(() => computeTotals(filteredRows), [filteredRows]);
+  const sankeyData = useMemo(() => buildSankey(filteredRows), [filteredRows]);
+  const series = useMemo(() => bucketSeries(filteredRows, period, interval), [filteredRows, period, interval]);
+  const categories = useMemo(() => topCategories(filteredRows), [filteredRows]);
+
+  const categoryChartData = useMemo(
+    () => series.map((bucket) => ({ bucketStart: bucket.bucketStart, ...bucket.byCategory })),
+    [series],
+  );
+  const inOutChartData = useMemo(
+    () => series.map((bucket) => ({ bucketStart: bucket.bucketStart, moneyIn: bucket.moneyIn, moneyOut: bucket.moneyOut })),
+    [series],
+  );
+
+  const modeLabel = MODE_LABELS[mode];
+  const ariaLabel = `${modeLabel} view of cash flow, net ${formatCurrency(totals.net)}`;
+  const caption = `${modeLabel} view: money in ${formatCurrency(totals.moneyIn)}, money out ${formatCurrency(
+    Math.abs(totals.moneyOut),
+  )}, net ${formatCurrency(totals.net)}.`;
+
+  return (
+    <div className={cn('space-y-4', className)}>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <Select name="cashflow-filter" value={filter} onValueChange={(value) => setFilter(value as CashflowFilter)}>
+          <SelectTrigger aria-label="Cashflow filter" className="h-9 w-[168px] text-[13px] bg-muted/30 border-border/40 rounded-lg">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All cashflow</SelectItem>
+            <SelectItem value="exclude-transfers">Exclude transfers</SelectItem>
+          </SelectContent>
+        </Select>
+
+        <ToggleGroup
+          type="single"
+          value={mode}
+          onValueChange={(value) => value && setMode(value as ChartMode)}
+          aria-label="Chart mode"
+        >
+          <ToggleGroupItem value="flow" aria-label="Flow">
+            Flow
+          </ToggleGroupItem>
+          <ToggleGroupItem value="category" aria-label="By category">
+            By category
+          </ToggleGroupItem>
+          <ToggleGroupItem value="inout" aria-label="In vs out">
+            In vs out
+          </ToggleGroupItem>
+        </ToggleGroup>
+
+        {mode !== 'flow' && (
+          <Select name="interval" value={interval} onValueChange={(value) => setIntervalValue(value as Interval)}>
+            <SelectTrigger aria-label="Interval" className="h-9 w-[104px] text-[13px] bg-muted/30 border-border/40 rounded-lg">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="day">Day</SelectItem>
+              <SelectItem value="week">Week</SelectItem>
+              <SelectItem value="month">Month</SelectItem>
+            </SelectContent>
+          </Select>
+        )}
+      </div>
+
+      <div role="img" aria-label={ariaLabel} aria-describedby={captionId} className="h-[280px]">
+        {mode === 'flow' && (
+          <ResponsiveContainer width="100%" height="100%">
+            <Sankey
+              data={sankeyData}
+              node={<SankeyNode />}
+              link={{ stroke: 'hsl(var(--muted-foreground))', strokeOpacity: 0.3 }}
+              nodePadding={24}
+              nodeWidth={10}
+            />
+          </ResponsiveContainer>
+        )}
+
+        {mode === 'category' && (
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={categoryChartData}>
+              <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+              <XAxis dataKey="bucketStart" tick={{ fill: 'hsl(var(--muted-foreground))' }} className="text-xs" />
+              <YAxis tick={{ fill: 'hsl(var(--muted-foreground))' }} className="text-xs" />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: 'hsl(var(--background))',
+                  border: '1px solid hsl(var(--border))',
+                  borderRadius: '8px',
+                }}
+                formatter={(value: number) => formatCurrency(value)}
+              />
+              {categories.map((category, index) => (
+                <Bar
+                  key={category.name}
+                  dataKey={category.name}
+                  stackId="categories"
+                  fill={CATEGORY_COLORS[index % CATEGORY_COLORS.length]}
+                />
+              ))}
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+
+        {mode === 'inout' && (
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={inOutChartData}>
+              <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+              <XAxis dataKey="bucketStart" tick={{ fill: 'hsl(var(--muted-foreground))' }} className="text-xs" />
+              <YAxis tick={{ fill: 'hsl(var(--muted-foreground))' }} className="text-xs" />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: 'hsl(var(--background))',
+                  border: '1px solid hsl(var(--border))',
+                  borderRadius: '8px',
+                }}
+                formatter={(value: number) => formatCurrency(value)}
+              />
+              <Bar dataKey="moneyIn" fill="hsl(var(--success))" />
+              <Bar dataKey="moneyOut" fill="hsl(var(--destructive))" />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+
+      <p id={captionId} className="text-[13px] text-muted-foreground">
+        {caption}
+      </p>
+    </div>
+  );
+}

--- a/src/components/banking/cashflow/CashFlowChart.tsx
+++ b/src/components/banking/cashflow/CashFlowChart.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useId, useMemo, useState } from 'react';
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { Bar, BarChart, CartesianGrid, Layer, ResponsiveContainer, Sankey, Tooltip, XAxis, YAxis } from 'recharts';
 
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
@@ -11,12 +12,14 @@ import {
   defaultInterval,
   formatCompactCurrency,
   formatCurrency,
+  formatPercentOfTotal,
   isInternalTransfer,
   topCategories,
   type CashFlowPeriod,
   type CashFlowRow,
   type Interval,
 } from '@/lib/cashflowInsights';
+import { readEnumParam } from '@/lib/periodUrlState';
 
 interface CashFlowChartProps {
   rows: CashFlowRow[];
@@ -24,7 +27,9 @@ interface CashFlowChartProps {
   className?: string;
 }
 
-type ChartMode = 'flow' | 'category' | 'inout';
+const CHART_MODES = ['flow', 'category', 'inout'] as const;
+type ChartMode = (typeof CHART_MODES)[number];
+const INTERVALS = ['day', 'week', 'month'] as const;
 type CashflowFilter = 'all' | 'exclude-transfers';
 
 const MODE_LABELS: Record<ChartMode, string> = {
@@ -108,16 +113,18 @@ interface SankeyNodeProps {
   y?: number;
   width?: number;
   height?: number;
-  payload?: { name: string; value?: number; targetLinks?: number[] };
+  payload?: { name: string; value?: number; sourceLinks?: number[]; targetLinks?: number[] };
+  totalFlow?: number;
 }
 
 /**
  * One Sankey node with its label. A sink node (no outgoing links) sits in
  * the last column. Its label anchors to the left of the bar, so long payee
- * names stay inside the chart.
+ * names stay inside the chart. Each source and sink also shows its share
+ * of the total flow; the center hub is the total, so it shows none.
  */
 function SankeyNode(props: SankeyNodeProps) {
-  const { x = 0, y = 0, width = 0, height = 0, payload } = props;
+  const { x = 0, y = 0, width = 0, height = 0, payload, totalFlow = 0 } = props;
   // Recharts fills `targetLinks` with the outgoing link indices. A sink
   // node has none, so it sits in the last column.
   const isRightSide = (payload?.targetLinks?.length ?? 0) === 0;
@@ -127,6 +134,11 @@ function SankeyNode(props: SankeyNodeProps) {
   const name = payload?.name ?? '';
   const label = name.length > SANKEY_NODE_LABEL_MAX ? `${name.slice(0, SANKEY_NODE_LABEL_MAX - 1)}…` : name;
 
+  // The hub has incoming and outgoing links. Its value is the whole flow,
+  // so a share on it reads "100%" and carries no information.
+  const isHub = (payload?.sourceLinks?.length ?? 0) > 0 && (payload?.targetLinks?.length ?? 0) > 0;
+  const share = payload?.value !== undefined && !isHub ? formatPercentOfTotal(payload.value, totalFlow) : '';
+
   return (
     <Layer>
       <rect x={x} y={y} width={width} height={height} fill="hsl(var(--chart-2))" rx={2} />
@@ -135,7 +147,7 @@ function SankeyNode(props: SankeyNodeProps) {
       </text>
       {payload?.value !== undefined && (
         <text x={textX} y={y + height / 2} dy={12} fontSize={11} textAnchor={anchor} fill="hsl(var(--muted-foreground))">
-          {formatCurrency(payload.value)}
+          {share ? `${formatCurrency(payload.value)} · ${share}` : formatCurrency(payload.value)}
         </text>
       )}
     </Layer>
@@ -150,17 +162,47 @@ function SankeyNode(props: SankeyNodeProps) {
  */
 export function CashFlowChart({ rows, period, className }: CashFlowChartProps) {
   const captionId = useId();
-  const [mode, setMode] = useState<ChartMode>('flow');
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [mode, setMode] = useState<ChartMode>(() => readEnumParam(searchParams, 'view', CHART_MODES) ?? 'flow');
   const [filter, setFilter] = useState<CashflowFilter>('exclude-transfers');
-  const [interval, setIntervalValue] = useState<Interval>(() => defaultInterval(period));
+  const [interval, setIntervalValue] = useState<Interval>(
+    () => readEnumParam(searchParams, 'interval', INTERVALS) ?? defaultInterval(period),
+  );
+
+  const setParams = (mutate: (params: URLSearchParams) => void) => {
+    // Read the live search string, not the hook value. The page writes the
+    // period params and the hook value can lag one render behind.
+    const params = new URLSearchParams(window.location.search);
+    mutate(params);
+    setSearchParams(params, { replace: true });
+  };
+
+  const handleModeChange = (value: string) => {
+    if (!value) return;
+    setMode(value as ChartMode);
+    setParams((params) => params.set('view', value));
+  };
+
+  const handleIntervalChange = (value: string) => {
+    setIntervalValue(value as Interval);
+    setParams((params) => params.set('interval', value));
+  };
 
   // The default interval depends on the period length. Re-derive it whenever
   // the period changes, so a longer or shorter range gets the right bucket
   // size even after the user has manually picked one for a prior period.
+  // The first render must not reset: it can carry an interval from the URL.
+  const periodKey = `${period.from.getTime()}:${period.to.getTime()}`;
+  const prevPeriodKey = useRef(periodKey);
   useEffect(() => {
+    if (prevPeriodKey.current === periodKey) return;
+    prevPeriodKey.current = periodKey;
     setIntervalValue(defaultInterval(period));
+    if (new URLSearchParams(window.location.search).has('interval')) {
+      setParams((params) => params.delete('interval'));
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [period.from.getTime(), period.to.getTime()]);
+  }, [periodKey]);
 
   const filteredRows = useMemo(
     () => (filter === 'exclude-transfers' ? rows.filter((row) => !isInternalTransfer(row)) : rows),
@@ -169,6 +211,25 @@ export function CashFlowChart({ rows, period, className }: CashFlowChartProps) {
 
   const totals = useMemo(() => computeTotals(filteredRows), [filteredRows]);
   const sankeyData = useMemo(() => buildSankey(filteredRows), [filteredRows]);
+  // Node 0 is the 'Money in' hub (buildSankey adds it first). The links into
+  // the hub sum to the whole flow, the base for every node's share.
+  const sankeyTotal = useMemo(
+    () => sankeyData.links.reduce((sum, link) => (link.target === 0 ? sum + link.value : sum), 0),
+    [sankeyData],
+  );
+
+  // Tooltip line with the amount and its share of money in or money out.
+  const formatBarTooltipValue = (value: number) => {
+    const base = value >= 0 ? totals.moneyIn : Math.abs(totals.moneyOut);
+    const share = formatPercentOfTotal(value, base);
+    if (!share) return formatCurrency(value);
+    return `${formatCurrency(value)} · ${share} of money ${value >= 0 ? 'in' : 'out'}`;
+  };
+
+  const formatSankeyTooltipValue = (value: number) => {
+    const share = formatPercentOfTotal(value, sankeyTotal);
+    return share ? `${formatCurrency(value)} · ${share}` : formatCurrency(value);
+  };
   const series = useMemo(() => bucketSeries(filteredRows, period, interval), [filteredRows, period, interval]);
   const categories = useMemo(() => topCategories(filteredRows), [filteredRows]);
   // The top-5-plus-Other category set, computed once across the whole
@@ -233,7 +294,7 @@ export function CashFlowChart({ rows, period, className }: CashFlowChartProps) {
         <ToggleGroup
           type="single"
           value={mode}
-          onValueChange={(value) => value && setMode(value as ChartMode)}
+          onValueChange={handleModeChange}
           aria-label="Chart mode"
         >
           <ToggleGroupItem value="flow" aria-label="Flow">
@@ -248,7 +309,7 @@ export function CashFlowChart({ rows, period, className }: CashFlowChartProps) {
         </ToggleGroup>
 
         {mode !== 'flow' && (
-          <Select name="interval" value={interval} onValueChange={(value) => setIntervalValue(value as Interval)}>
+          <Select name="interval" value={interval} onValueChange={handleIntervalChange}>
             <SelectTrigger aria-label="Interval" className="h-9 w-[104px] text-[13px] bg-muted/30 border-border/40 rounded-lg">
               <SelectValue />
             </SelectTrigger>
@@ -266,13 +327,13 @@ export function CashFlowChart({ rows, period, className }: CashFlowChartProps) {
           <ResponsiveContainer width="100%" height="100%">
             <Sankey
               data={sankeyData}
-              node={<SankeyNode />}
+              node={<SankeyNode totalFlow={sankeyTotal} />}
               link={{ stroke: 'hsl(var(--muted-foreground))', strokeOpacity: 0.25 }}
               nodePadding={28}
               nodeWidth={8}
               margin={{ top: 12, right: 12, bottom: 12, left: 12 }}
             >
-              <Tooltip contentStyle={TOOLTIP_STYLE} formatter={(value: number) => formatCurrency(value)} />
+              <Tooltip contentStyle={TOOLTIP_STYLE} formatter={formatSankeyTooltipValue} />
             </Sankey>
           </ResponsiveContainer>
         )}
@@ -303,7 +364,7 @@ export function CashFlowChart({ rows, period, className }: CashFlowChartProps) {
               <Tooltip
                 contentStyle={TOOLTIP_STYLE}
                 labelFormatter={(value: string) => formatBucketLabel(value, interval)}
-                formatter={(value: number) => formatCurrency(value)}
+                formatter={formatBarTooltipValue}
               />
               {categories.map((category, index) => (
                 <Bar
@@ -342,7 +403,7 @@ export function CashFlowChart({ rows, period, className }: CashFlowChartProps) {
               <Tooltip
                 contentStyle={TOOLTIP_STYLE}
                 labelFormatter={(value: string) => formatBucketLabel(value, interval)}
-                formatter={(value: number) => formatCurrency(value)}
+                formatter={formatBarTooltipValue}
               />
               {/* The mount animation can complete with zero geometry and leave
                   the chart blank. Render the bars without animation. */}

--- a/src/components/banking/cashflow/CashFlowChart.tsx
+++ b/src/components/banking/cashflow/CashFlowChart.tsx
@@ -9,7 +9,9 @@ import {
   buildSankey,
   computeTotals,
   defaultInterval,
+  formatCompactCurrency,
   formatCurrency,
+  isInternalTransfer,
   topCategories,
   type CashFlowPeriod,
   type CashFlowRow,
@@ -40,14 +42,102 @@ const CATEGORY_COLORS = [
   'hsl(var(--muted-foreground))',
 ];
 
-function SankeyNode(props: { x?: number; y?: number; width?: number; height?: number; payload?: { name: string } }) {
+const MONEY_IN_COLOR = 'hsl(var(--success))';
+const MONEY_OUT_COLOR = 'hsl(var(--destructive))';
+const SANKEY_NODE_LABEL_MAX = 22;
+
+const AXIS_TICK = { fill: 'hsl(var(--muted-foreground))', fontSize: 11 };
+const TOOLTIP_STYLE = {
+  backgroundColor: 'hsl(var(--background))',
+  border: '1px solid hsl(var(--border))',
+  borderRadius: '8px',
+  fontSize: '12px',
+};
+
+const MONTH_SHORT = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+const MONTH_LONG = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+
+/**
+ * Split a 'yyyy-MM-dd' bucket key. The key names a calendar day, not an
+ * instant, so no Date object and no timezone is involved.
+ */
+function splitBucketKey(bucketStart: string): { year: number; month: number; day: number } {
+  const [year, month, day] = bucketStart.split('-').map(Number);
+  return { year, month, day };
+}
+
+/** Short axis label for a bucket: 'Aug 4' for day and week, 'Aug' for month. */
+function formatBucketTick(bucketStart: string, interval: Interval): string {
+  const { month, day } = splitBucketKey(bucketStart);
+  if (interval === 'month') return MONTH_SHORT[month - 1];
+  return `${MONTH_SHORT[month - 1]} ${day}`;
+}
+
+/** Full tooltip label for a bucket: the day, the week start, or the month. */
+function formatBucketLabel(bucketStart: string, interval: Interval): string {
+  const { year, month, day } = splitBucketKey(bucketStart);
+  if (interval === 'month') return `${MONTH_LONG[month - 1]} ${year}`;
+  const dayLabel = `${MONTH_SHORT[month - 1]} ${day}, ${year}`;
+  return interval === 'week' ? `Week of ${dayLabel}` : dayLabel;
+}
+
+interface LegendItem {
+  name: string;
+  color: string;
+}
+
+/** A row of color chips that names each series in the active chart. */
+function ChartLegend({ items }: { items: LegendItem[] }) {
+  return (
+    <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+      {items.map((item) => (
+        <span key={item.name} className="inline-flex items-center gap-1.5 text-[12px] text-muted-foreground">
+          <span aria-hidden="true" className="h-2.5 w-2.5 rounded-[3px]" style={{ backgroundColor: item.color }} />
+          {item.name}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+interface SankeyNodeProps {
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+  payload?: { name: string; value?: number; targetLinks?: number[] };
+}
+
+/**
+ * One Sankey node with its label. A sink node (no outgoing links) sits in
+ * the last column. Its label anchors to the left of the bar, so long payee
+ * names stay inside the chart.
+ */
+function SankeyNode(props: SankeyNodeProps) {
   const { x = 0, y = 0, width = 0, height = 0, payload } = props;
+  // Recharts fills `targetLinks` with the outgoing link indices. A sink
+  // node has none, so it sits in the last column.
+  const isRightSide = (payload?.targetLinks?.length ?? 0) === 0;
+  const textX = isRightSide ? x - 6 : x + width + 6;
+  const anchor = isRightSide ? 'end' : 'start';
+
+  const name = payload?.name ?? '';
+  const label = name.length > SANKEY_NODE_LABEL_MAX ? `${name.slice(0, SANKEY_NODE_LABEL_MAX - 1)}…` : name;
+
   return (
     <Layer>
       <rect x={x} y={y} width={width} height={height} fill="hsl(var(--chart-2))" rx={2} />
-      <text x={x + width + 6} y={y + height / 2} dy={4} fontSize={12} fill="hsl(var(--foreground))">
-        {payload?.name}
+      <text x={textX} y={y + height / 2} dy={-1} fontSize={12} textAnchor={anchor} fill="hsl(var(--foreground))">
+        {label}
       </text>
+      {payload?.value !== undefined && (
+        <text x={textX} y={y + height / 2} dy={12} fontSize={11} textAnchor={anchor} fill="hsl(var(--muted-foreground))">
+          {formatCurrency(payload.value)}
+        </text>
+      )}
     </Layer>
   );
 }
@@ -55,12 +145,13 @@ function SankeyNode(props: { x?: number; y?: number; width?: number; height?: nu
 /**
  * The Cash Flow chart panel: Flow (Sankey), By category (stacked bars),
  * and In vs out (paired bars). Each mode carries an accessible name and a
- * visible caption wired with `aria-describedby`.
+ * visible caption wired with `aria-describedby`. Internal transfers stay
+ * hidden until the user picks "All cashflow".
  */
 export function CashFlowChart({ rows, period, className }: CashFlowChartProps) {
   const captionId = useId();
   const [mode, setMode] = useState<ChartMode>('flow');
-  const [filter, setFilter] = useState<CashflowFilter>('all');
+  const [filter, setFilter] = useState<CashflowFilter>('exclude-transfers');
   const [interval, setIntervalValue] = useState<Interval>(() => defaultInterval(period));
 
   // The default interval depends on the period length. Re-derive it whenever
@@ -72,7 +163,7 @@ export function CashFlowChart({ rows, period, className }: CashFlowChartProps) {
   }, [period.from.getTime(), period.to.getTime()]);
 
   const filteredRows = useMemo(
-    () => (filter === 'exclude-transfers' ? rows.filter((row) => !row.is_transfer) : rows),
+    () => (filter === 'exclude-transfers' ? rows.filter((row) => !isInternalTransfer(row)) : rows),
     [rows, filter],
   );
 
@@ -91,16 +182,17 @@ export function CashFlowChart({ rows, period, className }: CashFlowChartProps) {
   const categoryChartData = useMemo(
     () =>
       series.map((bucket) => {
-        const point: Record<string, string | number> = { bucketStart: bucket.bucketStart };
-        let otherAmount = 0;
+        // Every category gets an explicit 0. The sign stack offset turns a
+        // missing key into NaN and then draws no bar at all.
+        const point: Record<string, string | number> = { bucketStart: bucket.bucketStart, Other: 0 };
+        for (const name of topCategoryNames) point[name] = 0;
         for (const [name, amount] of Object.entries(bucket.byCategory)) {
           if (topCategoryNames.has(name)) {
             point[name] = amount;
           } else {
-            otherAmount += amount;
+            point['Other'] = (point['Other'] as number) + amount;
           }
         }
-        if (otherAmount !== 0) point['Other'] = otherAmount;
         return point;
       }),
     [series, topCategoryNames],
@@ -109,6 +201,15 @@ export function CashFlowChart({ rows, period, className }: CashFlowChartProps) {
     () => series.map((bucket) => ({ bucketStart: bucket.bucketStart, moneyIn: bucket.moneyIn, moneyOut: bucket.moneyOut })),
     [series],
   );
+
+  const categoryLegend = useMemo<LegendItem[]>(
+    () => categories.map((category, index) => ({ name: category.name, color: CATEGORY_COLORS[index % CATEGORY_COLORS.length] })),
+    [categories],
+  );
+  const inOutLegend: LegendItem[] = [
+    { name: 'Money in', color: MONEY_IN_COLOR },
+    { name: 'Money out', color: MONEY_OUT_COLOR },
+  ];
 
   const modeLabel = MODE_LABELS[mode];
   const ariaLabel = `${modeLabel} view of cash flow, net ${formatCurrency(totals.net)}`;
@@ -124,8 +225,8 @@ export function CashFlowChart({ rows, period, className }: CashFlowChartProps) {
             <SelectValue />
           </SelectTrigger>
           <SelectContent>
+            <SelectItem value="exclude-transfers">Excludes transfers</SelectItem>
             <SelectItem value="all">All cashflow</SelectItem>
-            <SelectItem value="exclude-transfers">Exclude transfers</SelectItem>
           </SelectContent>
         </Select>
 
@@ -160,31 +261,48 @@ export function CashFlowChart({ rows, period, className }: CashFlowChartProps) {
         )}
       </div>
 
-      <div role="img" aria-label={ariaLabel} aria-describedby={captionId} className="h-[280px]">
+      <div role="img" aria-label={ariaLabel} aria-describedby={captionId} className="h-[300px]">
         {mode === 'flow' && (
           <ResponsiveContainer width="100%" height="100%">
             <Sankey
               data={sankeyData}
               node={<SankeyNode />}
-              link={{ stroke: 'hsl(var(--muted-foreground))', strokeOpacity: 0.3 }}
-              nodePadding={24}
-              nodeWidth={10}
-            />
+              link={{ stroke: 'hsl(var(--muted-foreground))', strokeOpacity: 0.25 }}
+              nodePadding={28}
+              nodeWidth={8}
+              margin={{ top: 12, right: 12, bottom: 12, left: 12 }}
+            >
+              <Tooltip contentStyle={TOOLTIP_STYLE} formatter={(value: number) => formatCurrency(value)} />
+            </Sankey>
           </ResponsiveContainer>
         )}
 
         {mode === 'category' && (
           <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={categoryChartData}>
-              <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-              <XAxis dataKey="bucketStart" tick={{ fill: 'hsl(var(--muted-foreground))' }} className="text-xs" />
-              <YAxis tick={{ fill: 'hsl(var(--muted-foreground))' }} className="text-xs" />
+            {/* stackOffset="sign" stacks the inflows up and the outflows down.
+                The default offset overlaps mixed-sign segments. */}
+            <BarChart data={categoryChartData} stackOffset="sign" margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
+              <CartesianGrid vertical={false} stroke="hsl(var(--border))" strokeOpacity={0.5} />
+              <XAxis
+                dataKey="bucketStart"
+                tick={AXIS_TICK}
+                tickLine={false}
+                axisLine={false}
+                tickMargin={8}
+                minTickGap={24}
+                tickFormatter={(value: string) => formatBucketTick(value, interval)}
+              />
+              <YAxis
+                tick={AXIS_TICK}
+                tickLine={false}
+                axisLine={false}
+                width={56}
+                domain={['auto', 'auto']}
+                tickFormatter={(value: number) => formatCompactCurrency(value)}
+              />
               <Tooltip
-                contentStyle={{
-                  backgroundColor: 'hsl(var(--background))',
-                  border: '1px solid hsl(var(--border))',
-                  borderRadius: '8px',
-                }}
+                contentStyle={TOOLTIP_STYLE}
+                labelFormatter={(value: string) => formatBucketLabel(value, interval)}
                 formatter={(value: number) => formatCurrency(value)}
               />
               {categories.map((category, index) => (
@@ -192,7 +310,9 @@ export function CashFlowChart({ rows, period, className }: CashFlowChartProps) {
                   key={category.name}
                   dataKey={category.name}
                   stackId="categories"
+                  maxBarSize={28}
                   fill={CATEGORY_COLORS[index % CATEGORY_COLORS.length]}
+                  isAnimationActive={false}
                 />
               ))}
             </BarChart>
@@ -201,24 +321,40 @@ export function CashFlowChart({ rows, period, className }: CashFlowChartProps) {
 
         {mode === 'inout' && (
           <ResponsiveContainer width="100%" height="100%">
-            <BarChart data={inOutChartData}>
-              <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-              <XAxis dataKey="bucketStart" tick={{ fill: 'hsl(var(--muted-foreground))' }} className="text-xs" />
-              <YAxis tick={{ fill: 'hsl(var(--muted-foreground))' }} className="text-xs" />
+            <BarChart data={inOutChartData} margin={{ top: 8, right: 8, bottom: 0, left: 0 }}>
+              <CartesianGrid vertical={false} stroke="hsl(var(--border))" strokeOpacity={0.5} />
+              <XAxis
+                dataKey="bucketStart"
+                tick={AXIS_TICK}
+                tickLine={false}
+                axisLine={false}
+                tickMargin={8}
+                minTickGap={24}
+                tickFormatter={(value: string) => formatBucketTick(value, interval)}
+              />
+              <YAxis
+                tick={AXIS_TICK}
+                tickLine={false}
+                axisLine={false}
+                width={56}
+                tickFormatter={(value: number) => formatCompactCurrency(value)}
+              />
               <Tooltip
-                contentStyle={{
-                  backgroundColor: 'hsl(var(--background))',
-                  border: '1px solid hsl(var(--border))',
-                  borderRadius: '8px',
-                }}
+                contentStyle={TOOLTIP_STYLE}
+                labelFormatter={(value: string) => formatBucketLabel(value, interval)}
                 formatter={(value: number) => formatCurrency(value)}
               />
-              <Bar dataKey="moneyIn" fill="hsl(var(--success))" />
-              <Bar dataKey="moneyOut" fill="hsl(var(--destructive))" />
+              {/* The mount animation can complete with zero geometry and leave
+                  the chart blank. Render the bars without animation. */}
+              <Bar name="Money in" dataKey="moneyIn" fill={MONEY_IN_COLOR} maxBarSize={20} radius={[3, 3, 0, 0]} isAnimationActive={false} />
+              <Bar name="Money out" dataKey="moneyOut" fill={MONEY_OUT_COLOR} maxBarSize={20} radius={[0, 0, 3, 3]} isAnimationActive={false} />
             </BarChart>
           </ResponsiveContainer>
         )}
       </div>
+
+      {mode === 'category' && <ChartLegend items={categoryLegend} />}
+      {mode === 'inout' && <ChartLegend items={inOutLegend} />}
 
       <p id={captionId} className="text-[13px] text-muted-foreground">
         {caption}

--- a/src/components/banking/cashflow/CashFlowChart.tsx
+++ b/src/components/banking/cashflow/CashFlowChart.tsx
@@ -9,6 +9,7 @@ import {
   buildSankey,
   computeTotals,
   defaultInterval,
+  formatCurrency,
   topCategories,
   type CashFlowPeriod,
   type CashFlowRow,
@@ -38,14 +39,6 @@ const CATEGORY_COLORS = [
   'hsl(var(--chart-5))',
   'hsl(var(--muted-foreground))',
 ];
-
-function formatCurrency(amount: number): string {
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'USD',
-    maximumFractionDigits: 0,
-  }).format(amount);
-}
 
 function SankeyNode(props: { x?: number; y?: number; width?: number; height?: number; payload?: { name: string } }) {
   const { x = 0, y = 0, width = 0, height = 0, payload } = props;

--- a/src/components/banking/cashflow/CashFlowHeadline.tsx
+++ b/src/components/banking/cashflow/CashFlowHeadline.tsx
@@ -12,7 +12,10 @@ export function CashFlowHeadline({ totals, className }: CashFlowHeadlineProps) {
 
   return (
     <div className={cn('flex flex-wrap items-baseline gap-x-8 gap-y-2', className)}>
-      <div>
+      {/* `role="group"` plus `aria-label` gives each stat an accessible name, so
+          a test can scope to it with `getByRole('group', { name: ... })` instead
+          of walking the DOM. */}
+      <div role="group" aria-label="Net cashflow">
         <div className="text-[13px] text-muted-foreground">Net cashflow</div>
         <div
           className={cn(
@@ -23,11 +26,11 @@ export function CashFlowHeadline({ totals, className }: CashFlowHeadlineProps) {
           {formatCurrency(totals.net)}
         </div>
       </div>
-      <div>
+      <div role="group" aria-label="Money in">
         <div className="text-[13px] text-muted-foreground">Money in</div>
         <div className="text-[15px] font-medium text-foreground">{formatCurrency(totals.moneyIn)}</div>
       </div>
-      <div>
+      <div role="group" aria-label="Money out">
         <div className="text-[13px] text-muted-foreground">Money out</div>
         <div className="text-[15px] font-medium text-foreground">
           {formatCurrency(Math.abs(totals.moneyOut))}

--- a/src/components/banking/cashflow/CashFlowHeadline.tsx
+++ b/src/components/banking/cashflow/CashFlowHeadline.tsx
@@ -1,17 +1,9 @@
 import { cn } from '@/lib/utils';
-import type { CashFlowTotals } from '@/lib/cashflowInsights';
+import { formatCurrency, type CashFlowTotals } from '@/lib/cashflowInsights';
 
 interface CashFlowHeadlineProps {
   totals: CashFlowTotals;
   className?: string;
-}
-
-function formatCurrency(amount: number): string {
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'USD',
-    maximumFractionDigits: 0,
-  }).format(amount);
 }
 
 /** Net cashflow, Money in, and Money out for the selected period. */

--- a/src/components/banking/cashflow/CashFlowHeadline.tsx
+++ b/src/components/banking/cashflow/CashFlowHeadline.tsx
@@ -1,0 +1,46 @@
+import { cn } from '@/lib/utils';
+import type { CashFlowTotals } from '@/lib/cashflowInsights';
+
+interface CashFlowHeadlineProps {
+  totals: CashFlowTotals;
+  className?: string;
+}
+
+function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  }).format(amount);
+}
+
+/** Net cashflow, Money in, and Money out for the selected period. */
+export function CashFlowHeadline({ totals, className }: CashFlowHeadlineProps) {
+  const isNegative = totals.net < 0;
+
+  return (
+    <div className={cn('flex flex-wrap items-baseline gap-x-8 gap-y-2', className)}>
+      <div>
+        <div className="text-[13px] text-muted-foreground">Net cashflow</div>
+        <div
+          className={cn(
+            'text-[28px] font-semibold tracking-tight',
+            isNegative ? 'text-destructive' : 'text-foreground'
+          )}
+        >
+          {formatCurrency(totals.net)}
+        </div>
+      </div>
+      <div>
+        <div className="text-[13px] text-muted-foreground">Money in</div>
+        <div className="text-[15px] font-medium text-foreground">{formatCurrency(totals.moneyIn)}</div>
+      </div>
+      <div>
+        <div className="text-[13px] text-muted-foreground">Money out</div>
+        <div className="text-[15px] font-medium text-foreground">
+          {formatCurrency(Math.abs(totals.moneyOut))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/banking/cashflow/CashFlowHeadline.tsx
+++ b/src/components/banking/cashflow/CashFlowHeadline.tsx
@@ -14,8 +14,10 @@ export function CashFlowHeadline({ totals, className }: CashFlowHeadlineProps) {
     <div className={cn('flex flex-wrap items-baseline gap-x-8 gap-y-2', className)}>
       {/* `role="group"` plus `aria-label` gives each stat an accessible name, so
           a test can scope to it with `getByRole('group', { name: ... })` instead
-          of walking the DOM. */}
-      <div role="group" aria-label="Net cashflow">
+          of walking the DOM. No native element carries the group role here:
+          `fieldset` is a form element, and a `section` per stat would add
+          three landmark regions of noise. */}
+      <div role="group" aria-label="Net cashflow">{/* NOSONAR: see the comment above */}
         <div className="text-[13px] text-muted-foreground">Net cashflow</div>
         <div
           className={cn(
@@ -26,11 +28,11 @@ export function CashFlowHeadline({ totals, className }: CashFlowHeadlineProps) {
           {formatCurrency(totals.net)}
         </div>
       </div>
-      <div role="group" aria-label="Money in">
+      <div role="group" aria-label="Money in">{/* NOSONAR: group role, see above */}
         <div className="text-[13px] text-muted-foreground">Money in</div>
         <div className="text-[15px] font-medium text-foreground">{formatCurrency(totals.moneyIn)}</div>
       </div>
-      <div role="group" aria-label="Money out">
+      <div role="group" aria-label="Money out">{/* NOSONAR: group role, see above */}
         <div className="text-[13px] text-muted-foreground">Money out</div>
         <div className="text-[15px] font-medium text-foreground">
           {formatCurrency(Math.abs(totals.moneyOut))}

--- a/src/components/banking/cashflow/CashFlowNarrative.tsx
+++ b/src/components/banking/cashflow/CashFlowNarrative.tsx
@@ -47,7 +47,7 @@ function renderBody(body: string, payee?: string): ReactNode[] {
 /** The deterministic insight list for the cash flow view. All copy is visible text. */
 export function CashFlowNarrative({ insights, className }: CashFlowNarrativeProps) {
   return (
-    <div className={cn(className)}>
+    <div role="region" aria-label="Cash flow narrative" className={cn(className)}>
       {insights.length === 0 ? (
         <p className="text-[13px] text-muted-foreground">No notable trends for this period.</p>
       ) : (

--- a/src/components/banking/cashflow/CashFlowNarrative.tsx
+++ b/src/components/banking/cashflow/CashFlowNarrative.tsx
@@ -74,9 +74,6 @@ export function CashFlowNarrative({ insights, className }: CashFlowNarrativeProp
           })}
         </ul>
       )}
-      <p className="mt-4 text-[12px] text-muted-foreground">
-        Trends are generated and may include inaccuracies.
-      </p>
     </section>
   );
 }

--- a/src/components/banking/cashflow/CashFlowNarrative.tsx
+++ b/src/components/banking/cashflow/CashFlowNarrative.tsx
@@ -21,8 +21,8 @@ function payeeFor(insight: CashFlowInsight): string | undefined {
 }
 
 function iconFor(insight: CashFlowInsight): LucideIcon {
-  if (/ increased$/.test(insight.title)) return TrendingUp;
-  if (/ decreased$/.test(insight.title)) return TrendingDown;
+  if (insight.title.endsWith(' increased')) return TrendingUp;
+  if (insight.title.endsWith(' decreased')) return TrendingDown;
   return Info;
 }
 
@@ -33,21 +33,27 @@ function renderBody(body: string, payee?: string): ReactNode[] {
   const splitPattern = new RegExp(`(${patterns.join('|')})`, 'g');
   const matchPattern = new RegExp(`^(${patterns.join('|')})$`);
 
-  return body.split(splitPattern).map((part, index) =>
-    part && matchPattern.test(part) ? (
-      <span key={index} className="bg-muted rounded-md px-1">
+  // A key from the part text plus its occurrence count is stable across
+  // re-renders, unlike the array index.
+  const seen = new Map<string, number>();
+  return body.split(splitPattern).map((part) => {
+    const occurrence = seen.get(part) ?? 0;
+    seen.set(part, occurrence + 1);
+    const key = `${part}#${occurrence}`;
+    return part && matchPattern.test(part) ? (
+      <span key={key} className="bg-muted rounded-md px-1">
         {part}
       </span>
     ) : (
-      <span key={index}>{part}</span>
-    )
-  );
+      <span key={key}>{part}</span>
+    );
+  });
 }
 
 /** The deterministic insight list for the cash flow view. All copy is visible text. */
 export function CashFlowNarrative({ insights, className }: CashFlowNarrativeProps) {
   return (
-    <div role="region" aria-label="Cash flow narrative" className={cn(className)}>
+    <section aria-label="Cash flow narrative" className={cn(className)}>
       {insights.length === 0 ? (
         <p className="text-[13px] text-muted-foreground">No notable trends for this period.</p>
       ) : (
@@ -71,6 +77,6 @@ export function CashFlowNarrative({ insights, className }: CashFlowNarrativeProp
       <p className="mt-4 text-[12px] text-muted-foreground">
         Trends are generated and may include inaccuracies.
       </p>
-    </div>
+    </section>
   );
 }

--- a/src/components/banking/cashflow/CashFlowNarrative.tsx
+++ b/src/components/banking/cashflow/CashFlowNarrative.tsx
@@ -1,0 +1,76 @@
+import type { ReactNode } from 'react';
+import { Info, TrendingDown, TrendingUp, type LucideIcon } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import type { CashFlowInsight } from '@/lib/cashflowInsights';
+
+interface CashFlowNarrativeProps {
+  insights: CashFlowInsight[];
+  className?: string;
+}
+
+const CURRENCY_PATTERN = '\\$\\d{1,3}(?:,\\d{3})*(?:\\.\\d+)?';
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** The payee name for a top-source insight, read back out of its title. */
+function payeeFor(insight: CashFlowInsight): string | undefined {
+  if (insight.id !== 'top-source-change') return undefined;
+  return insight.title.replace(/ (increased|decreased)$/, '');
+}
+
+function iconFor(insight: CashFlowInsight): LucideIcon {
+  if (/ increased$/.test(insight.title)) return TrendingUp;
+  if (/ decreased$/.test(insight.title)) return TrendingDown;
+  return Info;
+}
+
+/** Split the body on amount and payee substrings, chip-styling each one. */
+function renderBody(body: string, payee?: string): ReactNode[] {
+  const patterns = [CURRENCY_PATTERN];
+  if (payee) patterns.push(escapeRegExp(payee));
+  const splitPattern = new RegExp(`(${patterns.join('|')})`, 'g');
+  const matchPattern = new RegExp(`^(${patterns.join('|')})$`);
+
+  return body.split(splitPattern).map((part, index) =>
+    part && matchPattern.test(part) ? (
+      <span key={index} className="bg-muted rounded-md px-1">
+        {part}
+      </span>
+    ) : (
+      <span key={index}>{part}</span>
+    )
+  );
+}
+
+/** The deterministic insight list for the cash flow view. All copy is visible text. */
+export function CashFlowNarrative({ insights, className }: CashFlowNarrativeProps) {
+  return (
+    <div className={cn(className)}>
+      {insights.length === 0 ? (
+        <p className="text-[13px] text-muted-foreground">No notable trends for this period.</p>
+      ) : (
+        <ul className="space-y-4">
+          {insights.map((insight) => {
+            const Icon = iconFor(insight);
+            return (
+              <li key={insight.id} className="flex items-start gap-3">
+                <Icon className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+                <div>
+                  <div className="text-[14px] font-medium text-foreground">{insight.title}</div>
+                  <div className="text-[13px] text-muted-foreground">
+                    {renderBody(insight.body, payeeFor(insight))}
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+      <p className="mt-4 text-[12px] text-muted-foreground">
+        Trends are generated and may include inaccuracies.
+      </p>
+    </div>
+  );
+}

--- a/src/components/banking/cashflow/MoneyBreakdownTable.tsx
+++ b/src/components/banking/cashflow/MoneyBreakdownTable.tsx
@@ -1,0 +1,106 @@
+import { useState } from 'react';
+
+import { cn } from '@/lib/utils';
+import type { BreakdownRow } from '@/lib/cashflowInsights';
+
+interface MoneyBreakdownTableProps {
+  /** Card title: "Money in" or "Money out". */
+  title: string;
+  total: number;
+  /** Label for the first tab: "Source" (money in) or "Recipient" (money out). */
+  primaryTabLabel: string;
+  primaryRows: BreakdownRow[];
+  categoryRows: BreakdownRow[];
+  className?: string;
+}
+
+type Tab = 'primary' | 'category';
+
+function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  }).format(Math.abs(amount));
+}
+
+function formatPct(pct: number): string {
+  return `${Math.round(pct)}%`;
+}
+
+/**
+ * One breakdown card: a total, an underline tab pair (Source|Category or
+ * Recipient|Category), and up to eight rows plus a folded Remaining row.
+ * Each row shows a name, a percent, a percent-of-total track, and a
+ * right-aligned amount.
+ */
+export function MoneyBreakdownTable({
+  title,
+  total,
+  primaryTabLabel,
+  primaryRows,
+  categoryRows,
+  className,
+}: MoneyBreakdownTableProps) {
+  const [tab, setTab] = useState<Tab>('primary');
+  const rows = tab === 'primary' ? primaryRows : categoryRows;
+
+  return (
+    <div className={cn('rounded-xl border border-border/40 bg-background p-4', className)}>
+      <div className="flex items-baseline justify-between">
+        <div className="text-[14px] font-medium text-foreground">{title}</div>
+        <div className="text-[15px] font-medium text-foreground">{formatCurrency(total)}</div>
+      </div>
+
+      <div role="tablist" className="mt-3 flex border-b border-border/40">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={tab === 'primary'}
+          onClick={() => setTab('primary')}
+          className={cn(
+            'relative px-0 py-2 mr-6 text-[13px] font-medium transition-colors',
+            tab === 'primary' ? 'text-foreground' : 'text-muted-foreground hover:text-foreground',
+          )}
+        >
+          {primaryTabLabel}
+          {tab === 'primary' && <div className="absolute bottom-0 left-0 right-0 h-[2px] bg-foreground" />}
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={tab === 'category'}
+          onClick={() => setTab('category')}
+          className={cn(
+            'relative px-0 py-2 text-[13px] font-medium transition-colors',
+            tab === 'category' ? 'text-foreground' : 'text-muted-foreground hover:text-foreground',
+          )}
+        >
+          Category
+          {tab === 'category' && <div className="absolute bottom-0 left-0 right-0 h-[2px] bg-foreground" />}
+        </button>
+      </div>
+
+      <div className="mt-3 space-y-3">
+        {rows.map((row) => (
+          <div key={row.label} className="flex items-center gap-3">
+            <div className="w-28 shrink-0 truncate text-[13px] text-foreground">{row.label}</div>
+            <div className="w-10 shrink-0 text-right text-[12px] text-muted-foreground">
+              {formatPct(row.pctOfTotal)}
+            </div>
+            <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-muted">
+              <div
+                data-testid={`breakdown-track-${row.label}`}
+                className="h-full rounded-full bg-primary"
+                style={{ width: `${Math.min(100, Math.max(0, row.pctOfTotal))}%` }}
+              />
+            </div>
+            <div className="w-20 shrink-0 text-right text-[13px] font-medium text-foreground">
+              {formatCurrency(row.amount)}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/banking/cashflow/MoneyBreakdownTable.tsx
+++ b/src/components/banking/cashflow/MoneyBreakdownTable.tsx
@@ -93,12 +93,12 @@ export function MoneyBreakdownTable({
 
       <div id={panelId} role="tabpanel" className="mt-3 space-y-3">
         {rows.length === 0 && <p className="text-[13px] text-muted-foreground">No activity for this period.</p>}
-        {/* `role="list"`/`role="listitem"` give each row an accessible name
-            (its label), so a test can find one row with
-            `getByRole('listitem', { name: ... })` instead of a data-testid. */}
-        <div role="list" className="space-y-3">
+        {/* Native `ul`/`li` keep the list semantics, so a test can find one
+            row with `getByRole('listitem', { name: ... })` instead of a
+            data-testid. */}
+        <ul className="list-none space-y-3 p-0 m-0">
           {rows.map((row) => (
-            <div key={row.label} role="listitem" aria-label={row.label} className="flex items-center gap-3">
+            <li key={row.label} aria-label={row.label} className="flex items-center gap-3">
               <div className="w-28 shrink-0 truncate text-[13px] text-foreground">{row.label}</div>
               <div className="w-10 shrink-0 text-right text-[12px] text-muted-foreground">
                 {formatPct(row.pctOfTotal)}
@@ -113,9 +113,9 @@ export function MoneyBreakdownTable({
               <div className="w-20 shrink-0 text-right text-[13px] font-medium text-foreground">
                 {formatCurrency(Math.abs(row.amount))}
               </div>
-            </div>
+            </li>
           ))}
-        </div>
+        </ul>
       </div>
     </div>
   );

--- a/src/components/banking/cashflow/MoneyBreakdownTable.tsx
+++ b/src/components/banking/cashflow/MoneyBreakdownTable.tsx
@@ -20,6 +20,33 @@ function formatPct(pct: number): string {
   return `${Math.round(pct)}%`;
 }
 
+interface TabButtonProps {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+  className?: string;
+}
+
+/** One underline tab button, shared by the primary and Category tabs. */
+function TabButton({ label, active, onClick, className }: TabButtonProps) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      className={cn(
+        'relative px-0 py-2 text-[13px] font-medium transition-colors',
+        active ? 'text-foreground' : 'text-muted-foreground hover:text-foreground',
+        className,
+      )}
+    >
+      {label}
+      {active && <div className="absolute bottom-0 left-0 right-0 h-[2px] bg-foreground" />}
+    </button>
+  );
+}
+
 /**
  * One breakdown card: a total, an underline tab pair (Source|Category or
  * Recipient|Category), and up to eight rows plus a folded Remaining row.
@@ -45,32 +72,13 @@ export function MoneyBreakdownTable({
       </div>
 
       <div role="tablist" className="mt-3 flex border-b border-border/40">
-        <button
-          type="button"
-          role="tab"
-          aria-selected={tab === 'primary'}
+        <TabButton
+          label={primaryTabLabel}
+          active={tab === 'primary'}
           onClick={() => setTab('primary')}
-          className={cn(
-            'relative px-0 py-2 mr-6 text-[13px] font-medium transition-colors',
-            tab === 'primary' ? 'text-foreground' : 'text-muted-foreground hover:text-foreground',
-          )}
-        >
-          {primaryTabLabel}
-          {tab === 'primary' && <div className="absolute bottom-0 left-0 right-0 h-[2px] bg-foreground" />}
-        </button>
-        <button
-          type="button"
-          role="tab"
-          aria-selected={tab === 'category'}
-          onClick={() => setTab('category')}
-          className={cn(
-            'relative px-0 py-2 text-[13px] font-medium transition-colors',
-            tab === 'category' ? 'text-foreground' : 'text-muted-foreground hover:text-foreground',
-          )}
-        >
-          Category
-          {tab === 'category' && <div className="absolute bottom-0 left-0 right-0 h-[2px] bg-foreground" />}
-        </button>
+          className="mr-6"
+        />
+        <TabButton label="Category" active={tab === 'category'} onClick={() => setTab('category')} />
       </div>
 
       <div className="mt-3 space-y-3">

--- a/src/components/banking/cashflow/MoneyBreakdownTable.tsx
+++ b/src/components/banking/cashflow/MoneyBreakdownTable.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { cn } from '@/lib/utils';
-import type { BreakdownRow } from '@/lib/cashflowInsights';
+import { formatCurrency, type BreakdownRow } from '@/lib/cashflowInsights';
 
 interface MoneyBreakdownTableProps {
   /** Card title: "Money in" or "Money out". */
@@ -15,14 +15,6 @@ interface MoneyBreakdownTableProps {
 }
 
 type Tab = 'primary' | 'category';
-
-function formatCurrency(amount: number): string {
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'USD',
-    maximumFractionDigits: 0,
-  }).format(Math.abs(amount));
-}
 
 function formatPct(pct: number): string {
   return `${Math.round(pct)}%`;
@@ -49,7 +41,7 @@ export function MoneyBreakdownTable({
     <div className={cn('rounded-xl border border-border/40 bg-background p-4', className)}>
       <div className="flex items-baseline justify-between">
         <div className="text-[14px] font-medium text-foreground">{title}</div>
-        <div className="text-[15px] font-medium text-foreground">{formatCurrency(total)}</div>
+        <div className="text-[15px] font-medium text-foreground">{formatCurrency(Math.abs(total))}</div>
       </div>
 
       <div role="tablist" className="mt-3 flex border-b border-border/40">
@@ -96,7 +88,7 @@ export function MoneyBreakdownTable({
               />
             </div>
             <div className="w-20 shrink-0 text-right text-[13px] font-medium text-foreground">
-              {formatCurrency(row.amount)}
+              {formatCurrency(Math.abs(row.amount))}
             </div>
           </div>
         ))}

--- a/src/components/banking/cashflow/MoneyBreakdownTable.tsx
+++ b/src/components/banking/cashflow/MoneyBreakdownTable.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useId, useState } from 'react';
 
 import { cn } from '@/lib/utils';
 import { formatCurrency, type BreakdownRow } from '@/lib/cashflowInsights';
@@ -24,16 +24,18 @@ interface TabButtonProps {
   label: string;
   active: boolean;
   onClick: () => void;
+  controls: string;
   className?: string;
 }
 
 /** One underline tab button, shared by the primary and Category tabs. */
-function TabButton({ label, active, onClick, className }: TabButtonProps) {
+function TabButton({ label, active, onClick, controls, className }: TabButtonProps) {
   return (
     <button
       type="button"
       role="tab"
       aria-selected={active}
+      aria-controls={controls}
       onClick={onClick}
       className={cn(
         'relative px-0 py-2 text-[13px] font-medium transition-colors',
@@ -63,6 +65,8 @@ export function MoneyBreakdownTable({
 }: MoneyBreakdownTableProps) {
   const [tab, setTab] = useState<Tab>('primary');
   const rows = tab === 'primary' ? primaryRows : categoryRows;
+  const baseId = useId();
+  const panelId = `${baseId}-panel`;
 
   return (
     <div className={cn('rounded-xl border border-border/40 bg-background p-4', className)}>
@@ -76,30 +80,42 @@ export function MoneyBreakdownTable({
           label={primaryTabLabel}
           active={tab === 'primary'}
           onClick={() => setTab('primary')}
+          controls={panelId}
           className="mr-6"
         />
-        <TabButton label="Category" active={tab === 'category'} onClick={() => setTab('category')} />
+        <TabButton
+          label="Category"
+          active={tab === 'category'}
+          onClick={() => setTab('category')}
+          controls={panelId}
+        />
       </div>
 
-      <div className="mt-3 space-y-3">
-        {rows.map((row) => (
-          <div key={row.label} className="flex items-center gap-3">
-            <div className="w-28 shrink-0 truncate text-[13px] text-foreground">{row.label}</div>
-            <div className="w-10 shrink-0 text-right text-[12px] text-muted-foreground">
-              {formatPct(row.pctOfTotal)}
+      <div id={panelId} role="tabpanel" className="mt-3 space-y-3">
+        {rows.length === 0 && <p className="text-[13px] text-muted-foreground">No activity for this period.</p>}
+        {/* `role="list"`/`role="listitem"` give each row an accessible name
+            (its label), so a test can find one row with
+            `getByRole('listitem', { name: ... })` instead of a data-testid. */}
+        <div role="list" className="space-y-3">
+          {rows.map((row) => (
+            <div key={row.label} role="listitem" aria-label={row.label} className="flex items-center gap-3">
+              <div className="w-28 shrink-0 truncate text-[13px] text-foreground">{row.label}</div>
+              <div className="w-10 shrink-0 text-right text-[12px] text-muted-foreground">
+                {formatPct(row.pctOfTotal)}
+              </div>
+              <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-muted">
+                <div
+                  data-testid={`breakdown-track-${row.label}`}
+                  className="h-full rounded-full bg-primary"
+                  style={{ width: `${Math.min(100, Math.max(0, row.pctOfTotal))}%` }}
+                />
+              </div>
+              <div className="w-20 shrink-0 text-right text-[13px] font-medium text-foreground">
+                {formatCurrency(Math.abs(row.amount))}
+              </div>
             </div>
-            <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-muted">
-              <div
-                data-testid={`breakdown-track-${row.label}`}
-                className="h-full rounded-full bg-primary"
-                style={{ width: `${Math.min(100, Math.max(0, row.pctOfTotal))}%` }}
-              />
-            </div>
-            <div className="w-20 shrink-0 text-right text-[13px] font-medium text-foreground">
-              {formatCurrency(Math.abs(row.amount))}
-            </div>
-          </div>
-        ))}
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/src/components/banking/cashflow/MoneyBreakdownTable.tsx
+++ b/src/components/banking/cashflow/MoneyBreakdownTable.tsx
@@ -99,7 +99,9 @@ export function MoneyBreakdownTable({
         <ul className="list-none space-y-3 p-0 m-0">
           {rows.map((row) => (
             <li key={row.label} aria-label={row.label} className="flex items-center gap-3">
-              <div className="w-28 shrink-0 truncate text-[13px] text-foreground">{row.label}</div>
+              <div title={row.label} className="w-40 shrink-0 truncate text-[13px] text-foreground">
+                {row.label}
+              </div>
               <div className="w-10 shrink-0 text-right text-[12px] text-muted-foreground">
                 {formatPct(row.pctOfTotal)}
               </div>

--- a/src/components/banking/cashflow/TimelineBrush.tsx
+++ b/src/components/banking/cashflow/TimelineBrush.tsx
@@ -11,6 +11,7 @@ import {
 } from 'date-fns';
 import { cn } from '@/lib/utils';
 import type { Period } from '@/components/PeriodSelector';
+import { useMediaQuery } from '@/hooks/useMediaQuery';
 
 interface TimelineBrushProps {
   /** The page-level period. The brush both reads and writes it. */
@@ -19,22 +20,6 @@ interface TimelineBrushProps {
   /** Earliest known transaction date, when known. Caps the domain start. */
   earliestTransaction?: Date | null;
   className?: string;
-}
-
-function useMediaQuery(query: string): boolean {
-  const [matches, setMatches] = useState(() =>
-    typeof window === 'undefined' ? false : window.matchMedia(query).matches
-  );
-
-  useEffect(() => {
-    const mql = window.matchMedia(query);
-    const onChange = () => setMatches(mql.matches);
-    onChange();
-    mql.addEventListener('change', onChange);
-    return () => mql.removeEventListener('change', onChange);
-  }, [query]);
-
-  return matches;
 }
 
 function domainFor(earliestTransaction?: Date | null): { start: Date; end: Date } {

--- a/src/components/banking/cashflow/TimelineBrush.tsx
+++ b/src/components/banking/cashflow/TimelineBrush.tsx
@@ -22,9 +22,13 @@ interface TimelineBrushProps {
   className?: string;
 }
 
-function domainFor(earliestTransaction?: Date | null): { start: Date; end: Date } {
+function domainFor(earliestTransaction: Date | null | undefined, selectedPeriodEnd: Date): { start: Date; end: Date } {
   const today = new Date();
-  const end = endOfDay(today);
+  const defaultEnd = endOfDay(today);
+  // A custom period can end in the future (the date picker allows it).
+  // Extend the domain to cover it, or the thumb clamps to today and a
+  // commit silently overwrites the period with an earlier end date.
+  const end = selectedPeriodEnd > defaultEnd ? endOfDay(selectedPeriodEnd) : defaultEnd;
   const defaultStart = startOfMonth(subMonths(today, 23));
   const start = earliestTransaction && earliestTransaction > defaultStart
     ? startOfDay(earliestTransaction)
@@ -52,7 +56,7 @@ export function TimelineBrush({
   const isLgUp = useMediaQuery('(min-width: 1024px)');
   const step = isSmUp ? 1 : 7;
 
-  const { start: domainStart, end: domainEnd } = domainFor(earliestTransaction);
+  const { start: domainStart, end: domainEnd } = domainFor(earliestTransaction, selectedPeriod.to);
   const totalDays = Math.max(differenceInCalendarDays(domainEnd, domainStart), 1);
 
   const dateToIndex = (date: Date) => clamp(differenceInCalendarDays(date, domainStart), 0, totalDays);
@@ -75,11 +79,12 @@ export function TimelineBrush({
   const handleCommit = (next: number[]) => {
     const [startIndex, endIndex] = next as [number, number];
     const { from, to } = indexToRange(startIndex, endIndex);
+    const sameYear = from.getFullYear() === to.getFullYear();
     onPeriodChange({
       type: 'custom',
       from,
       to,
-      label: `${format(from, 'MMM d')} - ${format(to, 'MMM d, yyyy')}`,
+      label: `${format(from, sameYear ? 'MMM d' : 'MMM d, yyyy')} - ${format(to, 'MMM d, yyyy')}`,
     });
   };
 

--- a/src/components/banking/cashflow/TimelineBrush.tsx
+++ b/src/components/banking/cashflow/TimelineBrush.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useState } from 'react';
+import * as SliderPrimitive from '@radix-ui/react-slider';
+import {
+  addDays,
+  differenceInCalendarDays,
+  endOfDay,
+  format,
+  startOfDay,
+  startOfMonth,
+  subMonths,
+} from 'date-fns';
+import { cn } from '@/lib/utils';
+import type { Period } from '@/components/PeriodSelector';
+
+interface TimelineBrushProps {
+  /** The page-level period. The brush both reads and writes it. */
+  selectedPeriod: Period;
+  onPeriodChange: (period: Period) => void;
+  /** Earliest known transaction date, when known. Caps the domain start. */
+  earliestTransaction?: Date | null;
+  className?: string;
+}
+
+function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(() =>
+    typeof window === 'undefined' ? false : window.matchMedia(query).matches
+  );
+
+  useEffect(() => {
+    const mql = window.matchMedia(query);
+    const onChange = () => setMatches(mql.matches);
+    onChange();
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  }, [query]);
+
+  return matches;
+}
+
+function domainFor(earliestTransaction?: Date | null): { start: Date; end: Date } {
+  const today = new Date();
+  const end = endOfDay(today);
+  const defaultStart = startOfMonth(subMonths(today, 23));
+  const start = earliestTransaction && earliestTransaction > defaultStart
+    ? startOfDay(earliestTransaction)
+    : defaultStart;
+  return { start, end };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+/**
+ * Two-thumb range slider over a 24-month window of dates. It reads and
+ * writes the page-level `selectedPeriod` state, the same state the preset
+ * tabs write. Dragging (or arrow-keying) a thumb to commit calls
+ * `onPeriodChange` with `type: 'custom'`.
+ */
+export function TimelineBrush({
+  selectedPeriod,
+  onPeriodChange,
+  earliestTransaction = null,
+  className,
+}: TimelineBrushProps) {
+  const isSmUp = useMediaQuery('(min-width: 640px)');
+  const isLgUp = useMediaQuery('(min-width: 1024px)');
+  const step = isSmUp ? 1 : 7;
+
+  const { start: domainStart, end: domainEnd } = domainFor(earliestTransaction);
+  const totalDays = Math.max(differenceInCalendarDays(domainEnd, domainStart), 1);
+
+  const dateToIndex = (date: Date) => clamp(differenceInCalendarDays(date, domainStart), 0, totalDays);
+  const indexToRange = (startIndex: number, endIndex: number): { from: Date; to: Date } => ({
+    from: startOfDay(addDays(domainStart, startIndex)),
+    to: endOfDay(addDays(domainStart, endIndex)),
+  });
+
+  const [value, setValue] = useState<[number, number]>(() => [
+    dateToIndex(selectedPeriod.from),
+    dateToIndex(selectedPeriod.to),
+  ]);
+
+  // External period changes (preset tabs, the date picker) move the thumbs.
+  useEffect(() => {
+    setValue([dateToIndex(selectedPeriod.from), dateToIndex(selectedPeriod.to)]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedPeriod.from.getTime(), selectedPeriod.to.getTime(), domainStart.getTime()]);
+
+  const handleCommit = (next: number[]) => {
+    const [startIndex, endIndex] = next as [number, number];
+    const { from, to } = indexToRange(startIndex, endIndex);
+    onPeriodChange({
+      type: 'custom',
+      from,
+      to,
+      label: `${format(from, 'MMM d')} - ${format(to, 'MMM d, yyyy')}`,
+    });
+  };
+
+  const tickEvery = isLgUp ? 1 : 3;
+  const ticks: { key: string; label: string; percent: number }[] = [];
+  let monthIndex = 0;
+  for (let d = startOfMonth(domainStart); d <= domainEnd; d = startOfMonth(addDays(d, 32))) {
+    if (d >= domainStart && monthIndex % tickEvery === 0) {
+      const dayOffset = differenceInCalendarDays(d, domainStart);
+      ticks.push({
+        key: d.toISOString(),
+        label: format(d, 'MMM yyyy'),
+        percent: (dayOffset / totalDays) * 100,
+      });
+    }
+    monthIndex += 1;
+  }
+
+  return (
+    <div className={cn('space-y-2', className)} data-timeline-step={String(step)}>
+      <SliderPrimitive.Root
+        className="relative flex w-full touch-none select-none items-center py-3"
+        min={0}
+        max={totalDays}
+        step={step}
+        value={value}
+        minStepsBetweenThumbs={1}
+        onValueChange={(next) => setValue(next as [number, number])}
+        onValueCommit={handleCommit}
+      >
+        <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-muted">
+          <SliderPrimitive.Range className="absolute h-full bg-foreground/70" />
+        </SliderPrimitive.Track>
+        <SliderPrimitive.Thumb
+          aria-label="Start date"
+          className="block h-6 w-6 rounded-full border-2 border-foreground bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
+        />
+        <SliderPrimitive.Thumb
+          aria-label="End date"
+          className="block h-6 w-6 rounded-full border-2 border-foreground bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
+        />
+      </SliderPrimitive.Root>
+      <div className="relative h-4 w-full">
+        {ticks.map((tick) => (
+          <span
+            key={tick.key}
+            data-testid="timeline-brush-tick"
+            className="absolute -translate-x-1/2 whitespace-nowrap text-[11px] text-muted-foreground"
+            style={{ left: `${tick.percent}%` }}
+          >
+            {tick.label}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/banking/cashflow/TimelineBrush.tsx
+++ b/src/components/banking/cashflow/TimelineBrush.tsx
@@ -12,6 +12,7 @@ import {
 import { cn } from '@/lib/utils';
 import type { Period } from '@/components/PeriodSelector';
 import { useMediaQuery } from '@/hooks/useMediaQuery';
+import { customPeriodLabel } from '@/lib/periodUrlState';
 
 interface TimelineBrushProps {
   /** The page-level period. The brush both reads and writes it. */
@@ -38,6 +39,27 @@ function domainFor(earliestTransaction: Date | null | undefined, selectedPeriodE
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
+}
+
+const THUMB_CLASS =
+  'relative block h-6 w-6 rounded-full border-2 border-foreground bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50';
+
+/**
+ * The date above a thumb. Visible while a pointer drags the slider, and on
+ * keyboard focus, so an arrow-key user sees the date too.
+ */
+function ThumbDateBubble({ label, visible }: { label: string; visible: boolean }) {
+  return (
+    <span
+      data-testid="brush-thumb-date"
+      className={cn(
+        'pointer-events-none absolute -top-9 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-md border border-border/40 bg-background px-2 py-1 text-[11px] font-medium text-foreground shadow-sm transition-opacity',
+        visible ? 'opacity-100' : 'opacity-0 group-focus-visible:opacity-100',
+      )}
+    >
+      {label}
+    </span>
+  );
 }
 
 /**
@@ -69,6 +91,13 @@ export function TimelineBrush({
     dateToIndex(selectedPeriod.from),
     dateToIndex(selectedPeriod.to),
   ]);
+  // True while a pointer drags a thumb. Shows the date bubbles.
+  const [isDragging, setIsDragging] = useState(false);
+
+  const thumbDates: [string, string] = [
+    format(addDays(domainStart, value[0]), 'MMM d, yyyy'),
+    format(addDays(domainStart, value[1]), 'MMM d, yyyy'),
+  ];
 
   // External period changes (preset tabs, the date picker) move the thumbs.
   useEffect(() => {
@@ -77,14 +106,14 @@ export function TimelineBrush({
   }, [selectedPeriod.from.getTime(), selectedPeriod.to.getTime(), domainStart.getTime()]);
 
   const handleCommit = (next: number[]) => {
+    setIsDragging(false);
     const [startIndex, endIndex] = next as [number, number];
     const { from, to } = indexToRange(startIndex, endIndex);
-    const sameYear = from.getFullYear() === to.getFullYear();
     onPeriodChange({
       type: 'custom',
       from,
       to,
-      label: `${format(from, sameYear ? 'MMM d' : 'MMM d, yyyy')} - ${format(to, 'MMM d, yyyy')}`,
+      label: customPeriodLabel(from, to),
     });
   };
 
@@ -114,18 +143,27 @@ export function TimelineBrush({
         minStepsBetweenThumbs={1}
         onValueChange={(next) => setValue(next as [number, number])}
         onValueCommit={handleCommit}
+        onPointerDown={() => setIsDragging(true)}
+        onPointerUp={() => setIsDragging(false)}
+        onPointerCancel={() => setIsDragging(false)}
       >
         <SliderPrimitive.Track className="relative h-1.5 w-full grow overflow-hidden rounded-full bg-muted">
           <SliderPrimitive.Range className="absolute h-full bg-foreground/70" />
         </SliderPrimitive.Track>
         <SliderPrimitive.Thumb
           aria-label="Start date"
-          className="block h-6 w-6 rounded-full border-2 border-foreground bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
-        />
+          aria-valuetext={thumbDates[0]}
+          className={cn(THUMB_CLASS, 'group')}
+        >
+          <ThumbDateBubble label={thumbDates[0]} visible={isDragging} />
+        </SliderPrimitive.Thumb>
         <SliderPrimitive.Thumb
           aria-label="End date"
-          className="block h-6 w-6 rounded-full border-2 border-foreground bg-background ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
-        />
+          aria-valuetext={thumbDates[1]}
+          className={cn(THUMB_CLASS, 'group')}
+        >
+          <ThumbDateBubble label={thumbDates[1]} visible={isDragging} />
+        </SliderPrimitive.Thumb>
       </SliderPrimitive.Root>
       <div className="relative h-4 w-full">
         {ticks.map((tick) => (

--- a/src/hooks/useCashFlowInsights.tsx
+++ b/src/hooks/useCashFlowInsights.tsx
@@ -1,0 +1,171 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { startOfMonth, subMonths } from 'date-fns';
+import { supabase } from '@/integrations/supabase/client';
+import { useRestaurantContext } from '@/contexts/RestaurantContext';
+import { toDateOnlyString } from '@/lib/dateOnly';
+import {
+  type CashFlowRow,
+  type CashFlowPeriod,
+  type CashFlowAggregates,
+  type CashFlowInsight,
+  type SankeyData,
+  type CategoryTotal,
+  type BreakdownRow,
+  defaultInterval,
+  computeTotals,
+  bucketSeries,
+  topCategories,
+  breakdown,
+  buildSankey,
+  computeInsights,
+} from '@/lib/cashflowInsights';
+
+const PAGE_SIZE = 1000;
+const MAX_PAGES = 20;
+const HISTORY_MONTHS = 4;
+
+/** The full aggregate output the Cash Flow Insights view reads from one hook call. */
+export interface CashFlowInsightsData {
+  /** Rows inside the display period only (not the wider fetch window). */
+  rows: CashFlowRow[];
+  aggregates: CashFlowAggregates;
+  topCategories: CategoryTotal[];
+  /** Money in, grouped by payee. */
+  sources: BreakdownRow[];
+  /** Money out, grouped by payee. */
+  recipients: BreakdownRow[];
+  categoryBreakdownIn: BreakdownRow[];
+  categoryBreakdownOut: BreakdownRow[];
+  sankey: SankeyData;
+  /** Computed from the full wide-window row set, not just the display period. */
+  insights: CashFlowInsight[];
+  /** True when the fetch hit the 20-page cap before reaching a short page. */
+  truncated: boolean;
+}
+
+const EMPTY_DATA: CashFlowInsightsData = {
+  rows: [],
+  aggregates: { totals: { moneyIn: 0, moneyOut: 0, net: 0 }, series: [] },
+  topCategories: [],
+  sources: [],
+  recipients: [],
+  categoryBreakdownIn: [],
+  categoryBreakdownOut: [],
+  sankey: { nodes: [], links: [] },
+  insights: [],
+  truncated: false,
+};
+
+interface FetchResult {
+  rows: CashFlowRow[];
+  truncated: boolean;
+}
+
+/**
+ * Fetch every posted `bank_transactions` row in the window, in 1000-row
+ * pages ordered by `transaction_date` ascending. Stops at 20 pages
+ * (20,000 rows) and reports `truncated: true` when the cap is hit before
+ * a page comes back short.
+ */
+async function fetchAllRows(
+  restaurantId: string,
+  fetchFrom: string,
+  fetchTo: string,
+  bankAccountId: string,
+): Promise<FetchResult> {
+  const rows: CashFlowRow[] = [];
+
+  for (let page = 0; page < MAX_PAGES; page += 1) {
+    let query = supabase
+      .from('bank_transactions')
+      .select(
+        'transaction_date, amount, is_transfer, normalized_payee, merchant_name, description, category:chart_of_accounts!category_id(id, name:account_name)',
+      )
+      .eq('restaurant_id', restaurantId)
+      .eq('status', 'posted')
+      .gte('transaction_date', fetchFrom)
+      .lte('transaction_date', fetchTo);
+
+    if (bankAccountId && bankAccountId !== 'all') {
+      query = query.eq('connected_bank_id', bankAccountId);
+    }
+
+    const from = page * PAGE_SIZE;
+    const to = from + PAGE_SIZE - 1;
+    const { data, error } = await query.order('transaction_date', { ascending: true }).range(from, to);
+
+    if (error) throw error;
+
+    const pageRows = (data ?? []) as unknown as CashFlowRow[];
+    rows.push(...pageRows);
+
+    if (pageRows.length < PAGE_SIZE) {
+      return { rows, truncated: false };
+    }
+  }
+
+  return { rows, truncated: true };
+}
+
+/**
+ * Fetch and aggregate the rows behind the Cash Flow Insights view.
+ *
+ * Fetches a window from `min(period.from, startOfMonth(subMonths(period.to,
+ * 4)))` to `period.to` so the narrative's month-over-month comparisons have
+ * history, then memoizes the visual aggregates (totals, series, breakdowns,
+ * Sankey) from rows inside `period` only, and the insights from the full
+ * wide-window row set.
+ */
+export function useCashFlowInsights(period: CashFlowPeriod, bankAccountId: string = 'all') {
+  const { selectedRestaurant } = useRestaurantContext();
+  const restaurantId = selectedRestaurant?.restaurant_id;
+
+  const periodFromKey = toDateOnlyString(period.from);
+  const periodToKey = toDateOnlyString(period.to);
+
+  const fetchFromKey = useMemo(() => {
+    const historyStart = startOfMonth(subMonths(period.to, HISTORY_MONTHS));
+    return period.from < historyStart ? periodFromKey : toDateOnlyString(historyStart);
+  }, [period.from, period.to, periodFromKey]);
+
+  const query = useQuery({
+    queryKey: ['cashflow-insights', restaurantId, periodFromKey, periodToKey, bankAccountId],
+    queryFn: () => fetchAllRows(restaurantId as string, fetchFromKey, periodToKey, bankAccountId),
+    enabled: !!restaurantId,
+    staleTime: 30000,
+    refetchOnWindowFocus: true,
+  });
+
+  const allRows = useMemo(() => query.data?.rows ?? [], [query.data]);
+  const truncated = query.data?.truncated ?? false;
+
+  const periodRows = useMemo(
+    () => allRows.filter((row) => row.transaction_date >= periodFromKey && row.transaction_date <= periodToKey),
+    [allRows, periodFromKey, periodToKey],
+  );
+
+  const data = useMemo<CashFlowInsightsData>(() => {
+    if (!query.data) return EMPTY_DATA;
+
+    const interval = defaultInterval(period);
+
+    return {
+      rows: periodRows,
+      aggregates: {
+        totals: computeTotals(periodRows),
+        series: bucketSeries(periodRows, period, interval),
+      },
+      topCategories: topCategories(periodRows),
+      sources: breakdown(periodRows, 'in', 'payee'),
+      recipients: breakdown(periodRows, 'out', 'payee'),
+      categoryBreakdownIn: breakdown(periodRows, 'in', 'category'),
+      categoryBreakdownOut: breakdown(periodRows, 'out', 'category'),
+      sankey: buildSankey(periodRows),
+      insights: computeInsights(allRows, period),
+      truncated,
+    };
+  }, [query.data, periodRows, allRows, period, truncated]);
+
+  return { ...query, data };
+}

--- a/src/hooks/useCashFlowInsights.tsx
+++ b/src/hooks/useCashFlowInsights.tsx
@@ -9,15 +9,10 @@ import {
   type CashFlowPeriod,
   type CashFlowAggregates,
   type CashFlowInsight,
-  type SankeyData,
-  type CategoryTotal,
   type BreakdownRow,
   defaultInterval,
-  computeTotals,
-  bucketSeries,
-  topCategories,
+  computeCashFlowAggregates,
   breakdown,
-  buildSankey,
   computeInsights,
 } from '@/lib/cashflowInsights';
 
@@ -30,14 +25,12 @@ export interface CashFlowInsightsData {
   /** Rows inside the display period only (not the wider fetch window). */
   rows: CashFlowRow[];
   aggregates: CashFlowAggregates;
-  topCategories: CategoryTotal[];
   /** Money in, grouped by payee. */
   sources: BreakdownRow[];
   /** Money out, grouped by payee. */
   recipients: BreakdownRow[];
   categoryBreakdownIn: BreakdownRow[];
   categoryBreakdownOut: BreakdownRow[];
-  sankey: SankeyData;
   /** Computed from the full wide-window row set, not just the display period. */
   insights: CashFlowInsight[];
   /** True when the fetch hit the 20-page cap before reaching a short page. */
@@ -47,12 +40,10 @@ export interface CashFlowInsightsData {
 const EMPTY_DATA: CashFlowInsightsData = {
   rows: [],
   aggregates: { totals: { moneyIn: 0, moneyOut: 0, net: 0 }, series: [] },
-  topCategories: [],
   sources: [],
   recipients: [],
   categoryBreakdownIn: [],
   categoryBreakdownOut: [],
-  sankey: { nodes: [], links: [] },
   insights: [],
   truncated: false,
 };
@@ -113,9 +104,10 @@ async function fetchAllRows(
  *
  * Fetches a window from `min(period.from, startOfMonth(subMonths(period.to,
  * 4)))` to `period.to` so the narrative's month-over-month comparisons have
- * history, then memoizes the visual aggregates (totals, series, breakdowns,
- * Sankey) from rows inside `period` only, and the insights from the full
- * wide-window row set.
+ * history, then memoizes the visual aggregates (totals, series, breakdowns)
+ * from rows inside `period` only, and the insights from the full wide-window
+ * row set. `CashFlowChart` derives the Sankey and top-category views itself
+ * from `data.rows`, filtered by its own in-chart controls.
  */
 export function useCashFlowInsights(period: CashFlowPeriod, bankAccountId: string = 'all') {
   const { selectedRestaurant } = useRestaurantContext();
@@ -152,16 +144,11 @@ export function useCashFlowInsights(period: CashFlowPeriod, bankAccountId: strin
 
     return {
       rows: periodRows,
-      aggregates: {
-        totals: computeTotals(periodRows),
-        series: bucketSeries(periodRows, period, interval),
-      },
-      topCategories: topCategories(periodRows),
+      aggregates: computeCashFlowAggregates(periodRows, period, interval),
       sources: breakdown(periodRows, 'in', 'payee'),
       recipients: breakdown(periodRows, 'out', 'payee'),
       categoryBreakdownIn: breakdown(periodRows, 'in', 'category'),
       categoryBreakdownOut: breakdown(periodRows, 'out', 'category'),
-      sankey: buildSankey(periodRows),
       insights: computeInsights(allRows, period),
       truncated,
     };

--- a/src/hooks/useCashFlowInsights.tsx
+++ b/src/hooks/useCashFlowInsights.tsx
@@ -71,7 +71,7 @@ async function fetchAllRows(
     let query = supabase
       .from('bank_transactions')
       .select(
-        'transaction_date, amount, is_transfer, normalized_payee, merchant_name, description, category:chart_of_accounts!category_id(id, name:account_name)',
+        'id, transaction_date, amount, is_transfer, normalized_payee, merchant_name, description, category:chart_of_accounts!category_id(id, name:account_name)',
       )
       .eq('restaurant_id', restaurantId)
       .eq('status', 'posted')
@@ -84,7 +84,13 @@ async function fetchAllRows(
 
     const from = page * PAGE_SIZE;
     const to = from + PAGE_SIZE - 1;
-    const { data, error } = await query.order('transaction_date', { ascending: true }).range(from, to);
+    // `transaction_date` is not unique, so a second order on the primary key
+    // gives every page a total order. Without it, rows tied at a page
+    // boundary can be skipped or duplicated across pages.
+    const { data, error } = await query
+      .order('transaction_date', { ascending: true })
+      .order('id', { ascending: true })
+      .range(from, to);
 
     if (error) throw error;
 

--- a/src/hooks/useCashFlowInsights.tsx
+++ b/src/hooks/useCashFlowInsights.tsx
@@ -10,6 +10,7 @@ import {
   type CashFlowAggregates,
   type CashFlowInsight,
   type BreakdownRow,
+  dayKeyOf,
   defaultInterval,
   computeCashFlowAggregates,
   breakdown,
@@ -71,12 +72,14 @@ async function fetchAllRows(
     let query = supabase
       .from('bank_transactions')
       .select(
-        'id, transaction_date, amount, is_transfer, normalized_payee, merchant_name, description, category:chart_of_accounts!category_id(id, name:account_name)',
+        'id, transaction_date, amount, is_transfer, normalized_payee, merchant_name, description, category:chart_of_accounts!category_id(id, name:account_name, account_type, account_subtype)',
       )
       .eq('restaurant_id', restaurantId)
       .eq('status', 'posted')
       .gte('transaction_date', fetchFrom)
-      .lte('transaction_date', fetchTo);
+      // `transaction_date` is timestamptz. A bare 'yyyy-MM-dd' bound reads
+      // as midnight and drops the whole final day.
+      .lte('transaction_date', `${fetchTo}T23:59:59.999Z`);
 
     if (bankAccountId && bankAccountId !== 'all') {
       query = query.eq('connected_bank_id', bankAccountId);
@@ -139,7 +142,11 @@ export function useCashFlowInsights(period: CashFlowPeriod, bankAccountId: strin
   const truncated = query.data?.truncated ?? false;
 
   const periodRows = useMemo(
-    () => allRows.filter((row) => row.transaction_date >= periodFromKey && row.transaction_date <= periodToKey),
+    () =>
+      allRows.filter((row) => {
+        const dayKey = dayKeyOf(row.transaction_date);
+        return dayKey >= periodFromKey && dayKey <= periodToKey;
+      }),
     [allRows, periodFromKey, periodToKey],
   );
 
@@ -150,7 +157,9 @@ export function useCashFlowInsights(period: CashFlowPeriod, bankAccountId: strin
 
     return {
       rows: periodRows,
-      aggregates: computeCashFlowAggregates(periodRows, period, interval),
+      // Internal transfers stay out of the headline and the breakdown
+      // totals. The chart adds them back through its own filter control.
+      aggregates: computeCashFlowAggregates(periodRows, period, interval, { excludeTransfers: true }),
       sources: breakdown(periodRows, 'in', 'payee'),
       recipients: breakdown(periodRows, 'out', 'payee'),
       categoryBreakdownIn: breakdown(periodRows, 'in', 'category'),

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Track a CSS media query's match state. Reads `window.matchMedia` on
+ * mount and updates on `change` events. Returns `false` before mount
+ * (server render / no `window`).
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(() =>
+    typeof window === 'undefined' ? false : window.matchMedia(query).matches,
+  );
+
+  useEffect(() => {
+    const mql = window.matchMedia(query);
+    const onChange = () => setMatches(mql.matches);
+    onChange();
+    mql.addEventListener('change', onChange);
+    return () => mql.removeEventListener('change', onChange);
+  }, [query]);
+
+  return matches;
+}

--- a/src/lib/cashflowInsights.ts
+++ b/src/lib/cashflowInsights.ts
@@ -5,15 +5,23 @@
  * fetches the rows; this file turns rows into totals and time buckets.
  */
 
+import { isTransferCategoryType } from '@/lib/chartOfAccountsUtils';
+
 /** One bank transaction row, as read from `bank_transactions`. */
 export interface CashFlowRow {
-  transaction_date: string; // 'yyyy-MM-dd'
+  /** 'yyyy-MM-dd' or a full ISO timestamp such as '2026-08-19T12:47:12+00:00'. */
+  transaction_date: string;
   amount: number; // negative for outflow, positive for inflow
   is_transfer: boolean;
   normalized_payee: string | null;
   merchant_name: string | null;
   description: string | null;
-  category: { id: string; name: string } | null;
+  category: {
+    id: string;
+    name: string;
+    account_type: string | null;
+    account_subtype: string | null;
+  } | null;
 }
 
 /** The date window the aggregation runs over. */
@@ -93,8 +101,27 @@ export function defaultInterval(period: CashFlowPeriod): Interval {
   return 'month';
 }
 
+/**
+ * Detect a movement between the restaurant's own accounts.
+ *
+ * The `is_transfer` flag marks only pairs from the Transfer dialog. The
+ * `categorize_bank_transaction` RPC assigns categories such as "Transfer
+ * Clearing Account" without the flag (see
+ * docs/superpowers/specs/2026-04-26-transfer-category-classification-design.md).
+ * A blanket non-P&L exclusion is wrong here: a loan payment or an owner
+ * contribution is real external cash. So a category counts as internal
+ * only when it is non-P&L AND is a cash account or carries "transfer" in
+ * its name.
+ */
+export function isInternalTransfer(row: CashFlowRow): boolean {
+  if (row.is_transfer) return true;
+  const category = row.category;
+  if (!category || !isTransferCategoryType(category.account_type)) return false;
+  return category.account_subtype === 'cash' || /transfer/i.test(category.name);
+}
+
 function categoryLabel(row: CashFlowRow): string {
-  if (row.is_transfer) return 'Transfers';
+  if (isInternalTransfer(row)) return 'Transfers';
   if (row.category?.name) return row.category.name;
   return 'Uncategorized';
 }
@@ -106,7 +133,7 @@ export function computeTotals(rows: CashFlowRow[], options: ComputeTotalsOptions
   let moneyOut = 0;
 
   for (const row of rows) {
-    if (excludeTransfers && row.is_transfer) continue;
+    if (excludeTransfers && isInternalTransfer(row)) continue;
     if (row.amount >= 0) {
       moneyIn += row.amount;
     } else {
@@ -117,8 +144,17 @@ export function computeTotals(rows: CashFlowRow[], options: ComputeTotalsOptions
   return { moneyIn, moneyOut, net: moneyIn + moneyOut };
 }
 
+/**
+ * The 'yyyy-MM-dd' day of a `transaction_date` value. The column is
+ * timestamptz in production, so PostgREST returns full ISO timestamps;
+ * the first ten characters are always the day.
+ */
+export function dayKeyOf(dateStr: string): string {
+  return dateStr.slice(0, 10);
+}
+
 function parseDateKey(dateStr: string): Date {
-  const [year, month, day] = dateStr.split('-').map(Number);
+  const [year, month, day] = dayKeyOf(dateStr).split('-').map(Number);
   return new Date(year, month - 1, day);
 }
 
@@ -185,26 +221,41 @@ const TOP_BREAKDOWN_COUNT = 8;
 /**
  * Pick a display name for a transaction's other party.
  * Falls back through `normalized_payee`, `merchant_name`, `description`,
- * then `'Unknown'` when all three are null.
+ * then `'Unknown'` when all three are empty. Bank descriptions arrive as
+ * semicolon lists ("SYGMA Network; Payment; CAMILUKE FLAVORS LLC - ...");
+ * the first segment is the payee.
  */
 export function payeeFor(row: CashFlowRow): string {
-  return row.normalized_payee ?? row.merchant_name ?? row.description ?? 'Unknown';
+  const raw = row.normalized_payee ?? row.merchant_name ?? row.description;
+  if (!raw) return 'Unknown';
+  const firstSegment = raw.split(';')[0].replace(/\s+/g, ' ').trim();
+  return firstSegment || 'Unknown';
 }
 
+/**
+ * Group rows and sum their amounts. Keys fold case ("OLO # 24329" and
+ * "Olo # 24329" are one group); the first-seen spelling is the label.
+ */
 function sumByKey(rows: CashFlowRow[], keyFor: (row: CashFlowRow) => string): { key: string; amount: number }[] {
-  const sums = new Map<string, number>();
+  const sums = new Map<string, { label: string; amount: number }>();
   const order: string[] = [];
 
   for (const row of rows) {
-    const key = keyFor(row);
-    if (!sums.has(key)) {
-      sums.set(key, 0);
-      order.push(key);
+    const label = keyFor(row);
+    const foldedKey = label.toLocaleUpperCase();
+    let entry = sums.get(foldedKey);
+    if (!entry) {
+      entry = { label, amount: 0 };
+      sums.set(foldedKey, entry);
+      order.push(foldedKey);
     }
-    sums.set(key, sums.get(key)! + row.amount);
+    entry.amount += row.amount;
   }
 
-  return order.map((key) => ({ key, amount: sums.get(key)! }));
+  return order.map((foldedKey) => {
+    const { label, amount } = sums.get(foldedKey)!;
+    return { key: label, amount };
+  });
 }
 
 /**
@@ -239,7 +290,9 @@ export function topCategories(rows: CashFlowRow[]): CategoryTotal[] {
  * into a `Remaining` row, each with `pctOfTotal`.
  */
 export function breakdown(rows: CashFlowRow[], direction: CashFlowDirection, by: BreakdownBy): BreakdownRow[] {
-  const filtered = rows.filter((row) => (direction === 'in' ? row.amount >= 0 : row.amount < 0));
+  const filtered = rows.filter(
+    (row) => !isInternalTransfer(row) && (direction === 'in' ? row.amount >= 0 : row.amount < 0),
+  );
   const keyFor = by === 'payee' ? payeeFor : categoryLabel;
 
   const total = filtered.reduce((sum, row) => sum + Math.abs(row.amount), 0);
@@ -288,14 +341,14 @@ const SANKEY_TOP_PAYEE_COUNT = 5;
  * The sum of left link values equals the sum of right link values.
  */
 export function buildSankey(rows: CashFlowRow[]): SankeyData {
-  const inflowRows = rows.filter((row) => row.amount >= 0 && !row.is_transfer);
-  const outflowRows = rows.filter((row) => row.amount < 0 && !row.is_transfer);
+  const inflowRows = rows.filter((row) => row.amount >= 0 && !isInternalTransfer(row));
+  const outflowRows = rows.filter((row) => row.amount < 0 && !isInternalTransfer(row));
 
   const transferInTotal = rows
-    .filter((row) => row.amount >= 0 && row.is_transfer)
+    .filter((row) => row.amount >= 0 && isInternalTransfer(row))
     .reduce((sum, row) => sum + row.amount, 0);
   const transferOutTotal = Math.abs(
-    rows.filter((row) => row.amount < 0 && row.is_transfer).reduce((sum, row) => sum + row.amount, 0),
+    rows.filter((row) => row.amount < 0 && isInternalTransfer(row)).reduce((sum, row) => sum + row.amount, 0),
   );
 
   const inflowEntries = sumByKey(inflowRows, payeeFor).sort((a, b) => b.amount - a.amount);
@@ -380,6 +433,16 @@ export function formatCurrency(amount: number): string {
   );
 }
 
+/** Format an amount as short USD ("$48K", "$1.2M"), for chart axis ticks. */
+export function formatCompactCurrency(amount: number): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    notation: 'compact',
+    maximumFractionDigits: 1,
+  }).format(amount);
+}
+
 function monthKeyFromDateStr(dateStr: string): string {
   return dateStr.slice(0, 7);
 }
@@ -421,7 +484,7 @@ function countSubscriptionPayees(rows: CashFlowRow[], to: Date): number {
 
   const byPayee = new Map<string, { date: Date; amount: number }[]>();
   for (const row of rows) {
-    if (row.is_transfer || row.amount >= 0) continue;
+    if (isInternalTransfer(row) || row.amount >= 0) continue;
     const rowDate = parseDateKey(row.transaction_date);
     if (rowDate < windowStart || rowDate > toMidnight) continue;
 
@@ -455,7 +518,9 @@ function countSubscriptionPayees(rows: CashFlowRow[], to: Date): number {
 /** Sum non-transfer money in for one calendar month (`YYYY-MM`). */
 function monthlyRevenue(rows: CashFlowRow[], monthKey: string): number {
   return rows
-    .filter((row) => !row.is_transfer && row.amount >= 0 && monthKeyFromDateStr(row.transaction_date) === monthKey)
+    .filter(
+      (row) => !isInternalTransfer(row) && row.amount >= 0 && monthKeyFromDateStr(row.transaction_date) === monthKey,
+    )
     .reduce((sum, row) => sum + row.amount, 0);
 }
 
@@ -495,7 +560,7 @@ function buildTopSourceInsight(
   precedingKeys: string[],
 ): CashFlowInsight | null {
   const lastMonthInflowRows = rows.filter(
-    (row) => !row.is_transfer && row.amount >= 0 && monthKeyFromDateStr(row.transaction_date) === lastMonthKey,
+    (row) => !isInternalTransfer(row) && row.amount >= 0 && monthKeyFromDateStr(row.transaction_date) === lastMonthKey,
   );
   if (lastMonthInflowRows.length === 0) return null;
 
@@ -506,10 +571,10 @@ function buildTopSourceInsight(
       const monthTotal = rows
         .filter(
           (row) =>
-            !row.is_transfer &&
+            !isInternalTransfer(row) &&
             row.amount >= 0 &&
             monthKeyFromDateStr(row.transaction_date) === key &&
-            payeeFor(row) === top.key,
+            payeeFor(row).toLocaleUpperCase() === top.key.toLocaleUpperCase(),
         )
         .reduce((s, row) => s + row.amount, 0);
       return sum + monthTotal;
@@ -570,8 +635,9 @@ export function computeCashFlowAggregates(
   interval: Interval,
   options: ComputeTotalsOptions = {},
 ): CashFlowAggregates {
+  const effectiveRows = options.excludeTransfers ? rows.filter((row) => !isInternalTransfer(row)) : rows;
   return {
-    totals: computeTotals(rows, options),
-    series: bucketSeries(rows, period, interval),
+    totals: computeTotals(effectiveRows),
+    series: bucketSeries(effectiveRows, period, interval),
   };
 }

--- a/src/lib/cashflowInsights.ts
+++ b/src/lib/cashflowInsights.ts
@@ -252,6 +252,89 @@ export function breakdown(rows: CashFlowRow[], direction: CashFlowDirection, by:
   return top;
 }
 
+/** One node in `buildSankey`'s output. */
+export interface SankeyNode {
+  name: string;
+}
+
+/** One link in `buildSankey`'s output. `source`/`target` are node indexes. */
+export interface SankeyLink {
+  source: number;
+  target: number;
+  value: number;
+}
+
+/** Nodes and links for the Flow (Sankey) chart mode. */
+export interface SankeyData {
+  nodes: SankeyNode[];
+  links: SankeyLink[];
+}
+
+const SANKEY_TOP_PAYEE_COUNT = 5;
+
+/**
+ * Build Sankey nodes and links for the Flow chart mode.
+ * Left: top inflow payees plus `Transfers in`.
+ * Center: `Money in`.
+ * Right: top outflow payees plus `Transfers out` and `Net savings`.
+ * The sum of left link values equals the sum of right link values.
+ */
+export function buildSankey(rows: CashFlowRow[]): SankeyData {
+  const inflowRows = rows.filter((row) => row.amount >= 0 && !row.is_transfer);
+  const outflowRows = rows.filter((row) => row.amount < 0 && !row.is_transfer);
+
+  const transferInTotal = rows
+    .filter((row) => row.amount >= 0 && row.is_transfer)
+    .reduce((sum, row) => sum + row.amount, 0);
+  const transferOutTotal = Math.abs(
+    rows.filter((row) => row.amount < 0 && row.is_transfer).reduce((sum, row) => sum + row.amount, 0),
+  );
+
+  const inflowEntries = sumByKey(inflowRows, payeeFor).sort((a, b) => b.amount - a.amount);
+  const outflowEntries = sumByKey(outflowRows, payeeFor)
+    .map(({ key, amount }) => ({ key, amount: Math.abs(amount) }))
+    .sort((a, b) => b.amount - a.amount);
+
+  const topInflow = inflowEntries.slice(0, SANKEY_TOP_PAYEE_COUNT);
+  const otherIncome = inflowEntries.slice(SANKEY_TOP_PAYEE_COUNT).reduce((sum, entry) => sum + entry.amount, 0);
+
+  const topOutflow = outflowEntries.slice(0, SANKEY_TOP_PAYEE_COUNT);
+  const otherExpenses = outflowEntries.slice(SANKEY_TOP_PAYEE_COUNT).reduce((sum, entry) => sum + entry.amount, 0);
+
+  const nodes: SankeyNode[] = [];
+  const links: SankeyLink[] = [];
+  const addNode = (name: string): number => nodes.push({ name }) - 1;
+
+  const centerIndex = addNode('Money in');
+
+  for (const entry of topInflow) {
+    links.push({ source: addNode(entry.key), target: centerIndex, value: entry.amount });
+  }
+  if (otherIncome > 0) {
+    links.push({ source: addNode('Other income'), target: centerIndex, value: otherIncome });
+  }
+  if (transferInTotal > 0) {
+    links.push({ source: addNode('Transfers in'), target: centerIndex, value: transferInTotal });
+  }
+
+  for (const entry of topOutflow) {
+    links.push({ source: centerIndex, target: addNode(entry.key), value: entry.amount });
+  }
+  if (otherExpenses > 0) {
+    links.push({ source: centerIndex, target: addNode('Other expenses'), value: otherExpenses });
+  }
+  if (transferOutTotal > 0) {
+    links.push({ source: centerIndex, target: addNode('Transfers out'), value: transferOutTotal });
+  }
+
+  const netRemainder = Math.max(computeTotals(rows).net, 0);
+  if (netRemainder > 0) {
+    links.push({ source: centerIndex, target: addNode('Net savings'), value: netRemainder });
+  }
+
+  return { nodes, links };
+}
+
 /** Compute totals and the bucketed series in one call. */
 export function computeCashFlowAggregates(
   rows: CashFlowRow[],

--- a/src/lib/cashflowInsights.ts
+++ b/src/lib/cashflowInsights.ts
@@ -473,7 +473,14 @@ function buildRevenueChangeInsight(
   const delta = (lastMonthRevenue - precedingMean) / precedingMean;
   // A zero delta is neither an increase nor a decrease. Say so, or the
   // title claims growth that did not happen.
-  const direction = delta > 0 ? 'increased' : delta < 0 ? 'decreased' : 'stayed flat';
+  let direction: string;
+  if (delta > 0) {
+    direction = 'increased';
+  } else if (delta < 0) {
+    direction = 'decreased';
+  } else {
+    direction = 'stayed flat';
+  }
 
   return {
     id: 'revenue-change',

--- a/src/lib/cashflowInsights.ts
+++ b/src/lib/cashflowInsights.ts
@@ -449,6 +449,37 @@ export function formatCompactCurrency(amount: number): string {
   return `${sign}$${Math.round(abs)}`;
 }
 
+/**
+ * The share of `total` that `amount` covers, as "42%". The rounding matches
+ * the breakdown tables. A non-zero share under one half percent reads "<1%",
+ * so a small slice does not display as "0%". Returns an empty string when
+ * the total is not positive, so the caller can drop the share cleanly.
+ */
+export function formatPercentOfTotal(amount: number, total: number): string {
+  if (total <= 0) return '';
+  const pct = (Math.abs(amount) / total) * 100;
+  if (pct > 0 && pct < 0.5) return '<1%';
+  return `${Math.round(pct)}%`;
+}
+
+/** Format a charge amount with cents only when it has them ("$15.99", "$45"). */
+function formatChargeAmount(amount: number): string {
+  const isWholeDollar = Math.round(amount * 100) % 100 === 0;
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: isWholeDollar ? 0 : 2,
+    maximumFractionDigits: 2,
+  }).format(amount);
+}
+
+/** Join names as a sentence list: "A", "A and B", "A, B, and C". */
+function listJoin(items: string[]): string {
+  if (items.length <= 1) return items[0] ?? '';
+  if (items.length === 2) return `${items[0]} and ${items[1]}`;
+  return `${items.slice(0, -1).join(', ')}, and ${items[items.length - 1]}`;
+}
+
 function monthKeyFromDateStr(dateStr: string): string {
   return dateStr.slice(0, 7);
 }
@@ -478,12 +509,18 @@ function lastFullCalendarMonth(to: Date): YearMonth {
   return shiftMonth({ year, month }, -1);
 }
 
+interface SubscriptionPayee {
+  payee: string;
+  meanAmount: number;
+}
+
 /**
- * Count outflow payees that look like subscriptions: 3+ charges in the
+ * Find outflow payees that look like subscriptions: 3+ charges in the
  * trailing 90 days before `to`, a 25-35 day cadence between every charge,
- * and under 10% variance across their amounts.
+ * and under 10% variance across their amounts. Returns the payees with
+ * their mean charge, largest first, so the insight can name them.
  */
-function countSubscriptionPayees(rows: CashFlowRow[], to: Date): number {
+function findSubscriptionPayees(rows: CashFlowRow[], to: Date): SubscriptionPayee[] {
   const toMidnight = new Date(to.getFullYear(), to.getMonth(), to.getDate());
   const windowStart = new Date(toMidnight);
   windowStart.setDate(windowStart.getDate() - SUBSCRIPTION_WINDOW_DAYS);
@@ -500,8 +537,8 @@ function countSubscriptionPayees(rows: CashFlowRow[], to: Date): number {
     byPayee.set(key, charges);
   }
 
-  let count = 0;
-  for (const charges of byPayee.values()) {
+  const found: SubscriptionPayee[] = [];
+  for (const [payee, charges] of byPayee) {
     if (charges.length < SUBSCRIPTION_MIN_CHARGES) continue;
     charges.sort((a, b) => a.date.getTime() - b.date.getTime());
 
@@ -515,10 +552,10 @@ function countSubscriptionPayees(rows: CashFlowRow[], to: Date): number {
     const amounts = charges.map((c) => c.amount);
     const mean = amounts.reduce((sum, a) => sum + a, 0) / amounts.length;
     const variance = mean === 0 ? 0 : (Math.max(...amounts) - Math.min(...amounts)) / mean;
-    if (variance < SUBSCRIPTION_VARIANCE_MAX) count += 1;
+    if (variance < SUBSCRIPTION_VARIANCE_MAX) found.push({ payee, meanAmount: mean });
   }
 
-  return count;
+  return found.sort((a, b) => b.meanAmount - a.meanAmount);
 }
 
 /** Sum non-transfer money in for one calendar month (`YYYY-MM`). */
@@ -609,13 +646,12 @@ function buildTopSourceInsight(
 export function computeInsights(rows: CashFlowRow[], period: CashFlowPeriod): CashFlowInsight[] {
   const insights: CashFlowInsight[] = [];
 
-  const subscriptionCount = countSubscriptionPayees(rows, period.to);
-  if (subscriptionCount > 0) {
-    const isSingleSubscription = subscriptionCount === 1;
-    const title = isSingleSubscription ? '1 notable transaction' : `${subscriptionCount} notable transactions`;
-    const body = isSingleSubscription
-      ? 'We noticed 1 subscription you may want to review'
-      : `We noticed ${subscriptionCount} subscriptions you may want to review`;
+  const subscriptions = findSubscriptionPayees(rows, period.to);
+  if (subscriptions.length > 0) {
+    const names = subscriptions.map((s) => `${s.payee} (${formatChargeAmount(s.meanAmount)})`);
+    const title = subscriptions.length === 1 ? '1 recurring charge' : `${subscriptions.length} recurring charges`;
+    const noun = subscriptions.length === 1 ? 'A steady monthly charge' : 'Steady monthly charges';
+    const body = `${noun} in the last ${SUBSCRIPTION_WINDOW_DAYS} days: ${listJoin(names)}.`;
     insights.push({ id: 'subscriptions', title, body });
   }
 

--- a/src/lib/cashflowInsights.ts
+++ b/src/lib/cashflowInsights.ts
@@ -1,0 +1,174 @@
+/**
+ * Pure aggregation for the Cash Flow Insights view.
+ *
+ * This file has no side effects and no Supabase calls. `useCashFlowInsights`
+ * fetches the rows; this file turns rows into totals and time buckets.
+ */
+
+/** One bank transaction row, as read from `bank_transactions`. */
+export interface CashFlowRow {
+  transaction_date: string; // 'yyyy-MM-dd'
+  amount: number; // negative for outflow, positive for inflow
+  is_transfer: boolean;
+  normalized_payee: string | null;
+  merchant_name: string | null;
+  description: string | null;
+  category: { id: string; name: string } | null;
+}
+
+/** The date window the aggregation runs over. */
+export interface CashFlowPeriod {
+  from: Date;
+  to: Date;
+}
+
+/** Bucket size for `bucketSeries`. */
+export type Interval = 'day' | 'week' | 'month';
+
+/** Options for `computeTotals`. */
+export interface ComputeTotalsOptions {
+  excludeTransfers?: boolean;
+}
+
+/** Totals across a set of rows. */
+export interface CashFlowTotals {
+  moneyIn: number;
+  moneyOut: number;
+  net: number;
+}
+
+/** One time bucket in `bucketSeries`. */
+export interface CashFlowBucket {
+  /** Start of the bucket, 'yyyy-MM-dd'. */
+  bucketStart: string;
+  moneyIn: number;
+  moneyOut: number;
+  /** Signed sum per category name (negative amounts stay negative). */
+  byCategory: Record<string, number>;
+}
+
+/** The full aggregate output for the Cash Flow view. */
+export interface CashFlowAggregates {
+  totals: CashFlowTotals;
+  series: CashFlowBucket[];
+}
+
+const DAY_INTERVAL_MAX_DAYS = 31;
+const WEEK_INTERVAL_MAX_DAYS = 120;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function daysBetween(period: CashFlowPeriod): number {
+  const fromMidnight = new Date(period.from.getFullYear(), period.from.getMonth(), period.from.getDate());
+  const toMidnight = new Date(period.to.getFullYear(), period.to.getMonth(), period.to.getDate());
+  return Math.round((toMidnight.getTime() - fromMidnight.getTime()) / MS_PER_DAY) + 1;
+}
+
+/**
+ * Pick the default bucket interval for a period.
+ * Day for periods up to 31 days, week up to 120 days, month above.
+ */
+export function defaultInterval(period: CashFlowPeriod): Interval {
+  const days = daysBetween(period);
+  if (days <= DAY_INTERVAL_MAX_DAYS) return 'day';
+  if (days <= WEEK_INTERVAL_MAX_DAYS) return 'week';
+  return 'month';
+}
+
+function categoryLabel(row: CashFlowRow): string {
+  if (row.is_transfer) return 'Transfers';
+  if (row.category?.name) return row.category.name;
+  return 'Uncategorized';
+}
+
+/** Sum money in, money out, and net across a set of rows. */
+export function computeTotals(rows: CashFlowRow[], options: ComputeTotalsOptions = {}): CashFlowTotals {
+  const { excludeTransfers = false } = options;
+  let moneyIn = 0;
+  let moneyOut = 0;
+
+  for (const row of rows) {
+    if (excludeTransfers && row.is_transfer) continue;
+    if (row.amount >= 0) {
+      moneyIn += row.amount;
+    } else {
+      moneyOut += row.amount;
+    }
+  }
+
+  return { moneyIn, moneyOut, net: moneyIn + moneyOut };
+}
+
+function parseDateKey(dateStr: string): Date {
+  const [year, month, day] = dateStr.split('-').map(Number);
+  return new Date(year, month - 1, day);
+}
+
+function startOfWeekMonday(date: Date): Date {
+  const day = date.getDay(); // 0 = Sunday
+  const diff = day === 0 ? -6 : 1 - day;
+  const result = new Date(date.getFullYear(), date.getMonth(), date.getDate() + diff);
+  return result;
+}
+
+function formatDateKey(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function bucketStartFor(date: Date, interval: Interval): string {
+  if (interval === 'day') return formatDateKey(date);
+  if (interval === 'week') return formatDateKey(startOfWeekMonday(date));
+  return formatDateKey(new Date(date.getFullYear(), date.getMonth(), 1));
+}
+
+/**
+ * Group rows into time buckets. Only rows inside the period count.
+ * Each bucket carries moneyIn/moneyOut sums and a per-category signed sum.
+ */
+export function bucketSeries(rows: CashFlowRow[], period: CashFlowPeriod, interval: Interval): CashFlowBucket[] {
+  const fromMidnight = new Date(period.from.getFullYear(), period.from.getMonth(), period.from.getDate());
+  const toMidnight = new Date(period.to.getFullYear(), period.to.getMonth(), period.to.getDate());
+
+  const bucketsByKey = new Map<string, CashFlowBucket>();
+  const orderedKeys: string[] = [];
+
+  for (const row of rows) {
+    const rowDate = parseDateKey(row.transaction_date);
+    if (rowDate < fromMidnight || rowDate > toMidnight) continue;
+
+    const bucketStart = bucketStartFor(rowDate, interval);
+    let bucket = bucketsByKey.get(bucketStart);
+    if (!bucket) {
+      bucket = { bucketStart, moneyIn: 0, moneyOut: 0, byCategory: {} };
+      bucketsByKey.set(bucketStart, bucket);
+      orderedKeys.push(bucketStart);
+    }
+
+    if (row.amount >= 0) {
+      bucket.moneyIn += row.amount;
+    } else {
+      bucket.moneyOut += row.amount;
+    }
+
+    const label = categoryLabel(row);
+    bucket.byCategory[label] = (bucket.byCategory[label] ?? 0) + row.amount;
+  }
+
+  orderedKeys.sort();
+  return orderedKeys.map((key) => bucketsByKey.get(key)!);
+}
+
+/** Compute totals and the bucketed series in one call. */
+export function computeCashFlowAggregates(
+  rows: CashFlowRow[],
+  period: CashFlowPeriod,
+  interval: Interval,
+  options: ComputeTotalsOptions = {},
+): CashFlowAggregates {
+  return {
+    totals: computeTotals(rows, options),
+    series: bucketSeries(rows, period, interval),
+  };
+}

--- a/src/lib/cashflowInsights.ts
+++ b/src/lib/cashflowInsights.ts
@@ -523,12 +523,11 @@ export function computeInsights(rows: CashFlowRow[], period: CashFlowPeriod): Ca
 
   const subscriptionCount = countSubscriptionPayees(rows, period.to);
   if (subscriptionCount > 0) {
-    const title =
-      subscriptionCount === 1 ? '1 notable transaction' : `${subscriptionCount} notable transactions`;
-    const body =
-      subscriptionCount === 1
-        ? 'We noticed 1 subscription you may want to review'
-        : `We noticed ${subscriptionCount} subscriptions you may want to review`;
+    const isSingleSubscription = subscriptionCount === 1;
+    const title = isSingleSubscription ? '1 notable transaction' : `${subscriptionCount} notable transactions`;
+    const body = isSingleSubscription
+      ? 'We noticed 1 subscription you may want to review'
+      : `We noticed ${subscriptionCount} subscriptions you may want to review`;
     insights.push({ id: 'subscriptions', title, body });
   }
 

--- a/src/lib/cashflowInsights.ts
+++ b/src/lib/cashflowInsights.ts
@@ -360,7 +360,8 @@ const MONTH_NAMES = [
   'July', 'August', 'September', 'October', 'November', 'December',
 ];
 
-function formatCurrency(amount: number): string {
+/** Format a signed amount as whole-dollar USD, for insight text and the cashflow UI. */
+export function formatCurrency(amount: number): string {
   return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(
     amount,
   );

--- a/src/lib/cashflowInsights.ts
+++ b/src/lib/cashflowInsights.ts
@@ -219,7 +219,15 @@ export function topCategories(rows: CashFlowRow[]): CategoryTotal[] {
 
   if (rest.length > 0) {
     const otherAmount = rest.reduce((sum, entry) => sum + entry.amount, 0);
-    top.push({ name: 'Other', amount: otherAmount });
+    // A real category can already be named 'Other' and land in the top
+    // five. Fold into that entry instead of pushing a second one with the
+    // same name — a duplicate name renders as one doubled bar in the chart.
+    const existingOther = top.find((entry) => entry.name === 'Other');
+    if (existingOther) {
+      existingOther.amount += otherAmount;
+    } else {
+      top.push({ name: 'Other', amount: otherAmount });
+    }
   }
 
   return top;
@@ -463,7 +471,9 @@ function buildRevenueChangeInsight(
   if (precedingMean <= 0) return null;
 
   const delta = (lastMonthRevenue - precedingMean) / precedingMean;
-  const direction = delta >= 0 ? 'increased' : 'decreased';
+  // A zero delta is neither an increase nor a decrease. Say so, or the
+  // title claims growth that did not happen.
+  const direction = delta > 0 ? 'increased' : delta < 0 ? 'decreased' : 'stayed flat';
 
   return {
     id: 'revenue-change',

--- a/src/lib/cashflowInsights.ts
+++ b/src/lib/cashflowInsights.ts
@@ -242,7 +242,7 @@ function sumByKey(rows: CashFlowRow[], keyFor: (row: CashFlowRow) => string): { 
 
   for (const row of rows) {
     const label = keyFor(row);
-    const foldedKey = label.toLocaleUpperCase();
+    const foldedKey = label.toUpperCase();
     let entry = sums.get(foldedKey);
     if (!entry) {
       entry = { label, amount: 0 };
@@ -273,7 +273,7 @@ export function topCategories(rows: CashFlowRow[]): CategoryTotal[] {
     // A real category can already be named 'Other' and land in the top
     // five. Fold into that entry instead of pushing a second one with the
     // same name — a duplicate name renders as one doubled bar in the chart.
-    const existingOther = top.find((entry) => entry.name === 'Other');
+    const existingOther = top.find((entry) => entry.name.toUpperCase() === 'OTHER');
     if (existingOther) {
       existingOther.amount += otherAmount;
     } else {
@@ -580,7 +580,7 @@ function buildTopSourceInsight(
             !isInternalTransfer(row) &&
             row.amount >= 0 &&
             monthKeyFromDateStr(row.transaction_date) === key &&
-            payeeFor(row).toLocaleUpperCase() === top.key.toLocaleUpperCase(),
+            payeeFor(row).toUpperCase() === top.key.toUpperCase(),
         )
         .reduce((s, row) => s + row.amount, 0);
       return sum + monthTotal;

--- a/src/lib/cashflowInsights.ts
+++ b/src/lib/cashflowInsights.ts
@@ -445,7 +445,12 @@ export function formatCompactCurrency(amount: number): string {
     return `${sign}$${text}${suffix}`;
   };
   if (abs >= 1_000_000) return short(abs / 1_000_000, 'M');
-  if (abs >= 1_000) return short(abs / 1_000, 'K');
+  if (abs >= 1_000) {
+    // 999950 rounds to 1000 thousands. Promote it to the M branch, not "$1000K".
+    const roundedThousands = Math.round((abs / 1_000) * 10) / 10;
+    if (roundedThousands >= 1_000) return short(abs / 1_000_000, 'M');
+    return short(abs / 1_000, 'K');
+  }
   return `${sign}$${Math.round(abs)}`;
 }
 

--- a/src/lib/cashflowInsights.ts
+++ b/src/lib/cashflowInsights.ts
@@ -175,7 +175,7 @@ export function bucketSeries(rows: CashFlowRow[], period: CashFlowPeriod, interv
     bucket.byCategory[label] = (bucket.byCategory[label] ?? 0) + row.amount;
   }
 
-  orderedKeys.sort();
+  orderedKeys.sort((a, b) => a.localeCompare(b));
   return orderedKeys.map((key) => bucketsByKey.get(key)!);
 }
 

--- a/src/lib/cashflowInsights.ts
+++ b/src/lib/cashflowInsights.ts
@@ -335,6 +335,210 @@ export function buildSankey(rows: CashFlowRow[]): SankeyData {
   return { nodes, links };
 }
 
+/** One deterministic insight for the Narrative panel. */
+export interface CashFlowInsight {
+  id: string;
+  title: string;
+  body: string;
+}
+
+interface YearMonth {
+  year: number;
+  month: number; // 0-indexed
+}
+
+const SUBSCRIPTION_MIN_CHARGES = 3;
+const SUBSCRIPTION_WINDOW_DAYS = 90;
+const SUBSCRIPTION_CADENCE_MIN_DAYS = 25;
+const SUBSCRIPTION_CADENCE_MAX_DAYS = 35;
+const SUBSCRIPTION_VARIANCE_MAX = 0.1;
+const TOP_SOURCE_DELTA_MIN = 0.2;
+const PRECEDING_MONTH_COUNT = 3;
+
+const MONTH_NAMES = [
+  'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December',
+];
+
+function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(
+    amount,
+  );
+}
+
+function monthKeyFromDateStr(dateStr: string): string {
+  return dateStr.slice(0, 7);
+}
+
+function shiftMonth({ year, month }: YearMonth, delta: number): YearMonth {
+  const total = year * 12 + month + delta;
+  return { year: Math.floor(total / 12), month: ((total % 12) + 12) % 12 };
+}
+
+function monthKeyFromYearMonth({ year, month }: YearMonth): string {
+  return `${year}-${String(month + 1).padStart(2, '0')}`;
+}
+
+function monthLabel(ym: YearMonth): string {
+  return `${MONTH_NAMES[ym.month]} ${ym.year}`;
+}
+
+/**
+ * The most recent calendar month that has fully elapsed by `to`.
+ * When `to` lands on the last day of its month, that month counts as full.
+ */
+function lastFullCalendarMonth(to: Date): YearMonth {
+  const year = to.getFullYear();
+  const month = to.getMonth();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  if (to.getDate() === daysInMonth) return { year, month };
+  return shiftMonth({ year, month }, -1);
+}
+
+/**
+ * Count outflow payees that look like subscriptions: 3+ charges in the
+ * trailing 90 days before `to`, a 25-35 day cadence between every charge,
+ * and under 10% variance across their amounts.
+ */
+function countSubscriptionPayees(rows: CashFlowRow[], to: Date): number {
+  const toMidnight = new Date(to.getFullYear(), to.getMonth(), to.getDate());
+  const windowStart = new Date(toMidnight);
+  windowStart.setDate(windowStart.getDate() - SUBSCRIPTION_WINDOW_DAYS);
+
+  const byPayee = new Map<string, { date: Date; amount: number }[]>();
+  for (const row of rows) {
+    if (row.is_transfer || row.amount >= 0) continue;
+    const rowDate = parseDateKey(row.transaction_date);
+    if (rowDate < windowStart || rowDate > toMidnight) continue;
+
+    const key = payeeFor(row);
+    const charges = byPayee.get(key) ?? [];
+    charges.push({ date: rowDate, amount: Math.abs(row.amount) });
+    byPayee.set(key, charges);
+  }
+
+  let count = 0;
+  for (const charges of byPayee.values()) {
+    if (charges.length < SUBSCRIPTION_MIN_CHARGES) continue;
+    charges.sort((a, b) => a.date.getTime() - b.date.getTime());
+
+    const cadenceOk = charges.every((charge, i) => {
+      if (i === 0) return true;
+      const gapDays = Math.round((charge.date.getTime() - charges[i - 1].date.getTime()) / MS_PER_DAY);
+      return gapDays >= SUBSCRIPTION_CADENCE_MIN_DAYS && gapDays <= SUBSCRIPTION_CADENCE_MAX_DAYS;
+    });
+    if (!cadenceOk) continue;
+
+    const amounts = charges.map((c) => c.amount);
+    const mean = amounts.reduce((sum, a) => sum + a, 0) / amounts.length;
+    const variance = mean === 0 ? 0 : (Math.max(...amounts) - Math.min(...amounts)) / mean;
+    if (variance < SUBSCRIPTION_VARIANCE_MAX) count += 1;
+  }
+
+  return count;
+}
+
+/** Sum non-transfer money in for one calendar month (`YYYY-MM`). */
+function monthlyRevenue(rows: CashFlowRow[], monthKey: string): number {
+  return rows
+    .filter((row) => !row.is_transfer && row.amount >= 0 && monthKeyFromDateStr(row.transaction_date) === monthKey)
+    .reduce((sum, row) => sum + row.amount, 0);
+}
+
+function buildRevenueChangeInsight(
+  rows: CashFlowRow[],
+  lastFullMonth: YearMonth,
+  lastMonthKey: string,
+  precedingKeys: string[],
+): CashFlowInsight | null {
+  const lastMonthRevenue = monthlyRevenue(rows, lastMonthKey);
+  const precedingMean =
+    precedingKeys.reduce((sum, key) => sum + monthlyRevenue(rows, key), 0) / precedingKeys.length;
+  if (precedingMean <= 0) return null;
+
+  const delta = (lastMonthRevenue - precedingMean) / precedingMean;
+  const direction = delta >= 0 ? 'increased' : 'decreased';
+
+  return {
+    id: 'revenue-change',
+    title: `Revenue ${direction}`,
+    body: `Money in for ${monthLabel(lastFullMonth)} was ${formatCurrency(lastMonthRevenue)}, versus an average of ${formatCurrency(precedingMean)} over the previous three months.`,
+  };
+}
+
+function buildTopSourceInsight(
+  rows: CashFlowRow[],
+  lastMonthKey: string,
+  precedingKeys: string[],
+): CashFlowInsight | null {
+  const lastMonthInflowRows = rows.filter(
+    (row) => !row.is_transfer && row.amount >= 0 && monthKeyFromDateStr(row.transaction_date) === lastMonthKey,
+  );
+  if (lastMonthInflowRows.length === 0) return null;
+
+  const [top] = sumByKey(lastMonthInflowRows, payeeFor).sort((a, b) => b.amount - a.amount);
+
+  const precedingMean =
+    precedingKeys.reduce((sum, key) => {
+      const monthTotal = rows
+        .filter(
+          (row) =>
+            !row.is_transfer &&
+            row.amount >= 0 &&
+            monthKeyFromDateStr(row.transaction_date) === key &&
+            payeeFor(row) === top.key,
+        )
+        .reduce((s, row) => s + row.amount, 0);
+      return sum + monthTotal;
+    }, 0) / precedingKeys.length;
+  if (precedingMean <= 0) return null;
+
+  const delta = (top.amount - precedingMean) / precedingMean;
+  if (Math.abs(delta) < TOP_SOURCE_DELTA_MIN) return null;
+
+  const direction = delta >= 0 ? 'increased' : 'decreased';
+
+  return {
+    id: 'top-source-change',
+    title: `${top.key} ${direction}`,
+    body: `${top.key} brought in ${formatCurrency(top.amount)} last month, versus an average of ${formatCurrency(precedingMean)} over the previous three months.`,
+  };
+}
+
+/**
+ * Build the deterministic insight list for the Narrative panel.
+ * Every time window anchors to `period.to`, never to the caller's clock,
+ * so a historical period reads correctly. An insight that fails its data
+ * threshold does not render; the caller shows a fallback line when the
+ * list comes back empty.
+ */
+export function computeInsights(rows: CashFlowRow[], period: CashFlowPeriod): CashFlowInsight[] {
+  const insights: CashFlowInsight[] = [];
+
+  const subscriptionCount = countSubscriptionPayees(rows, period.to);
+  if (subscriptionCount > 0) {
+    insights.push({
+      id: 'subscriptions',
+      title: `${subscriptionCount} notable transactions`,
+      body: `We noticed ${subscriptionCount} subscriptions you may want to review`,
+    });
+  }
+
+  const lastFullMonth = lastFullCalendarMonth(period.to);
+  const lastMonthKey = monthKeyFromYearMonth(lastFullMonth);
+  const precedingKeys = Array.from({ length: PRECEDING_MONTH_COUNT }, (_, i) =>
+    monthKeyFromYearMonth(shiftMonth(lastFullMonth, -(i + 1))),
+  );
+
+  const revenueInsight = buildRevenueChangeInsight(rows, lastFullMonth, lastMonthKey, precedingKeys);
+  if (revenueInsight) insights.push(revenueInsight);
+
+  const topSourceInsight = buildTopSourceInsight(rows, lastMonthKey, precedingKeys);
+  if (topSourceInsight) insights.push(topSourceInsight);
+
+  return insights;
+}
+
 /** Compute totals and the bucketed series in one call. */
 export function computeCashFlowAggregates(
   rows: CashFlowRow[],

--- a/src/lib/cashflowInsights.ts
+++ b/src/lib/cashflowInsights.ts
@@ -53,6 +53,25 @@ export interface CashFlowAggregates {
   series: CashFlowBucket[];
 }
 
+/** One row's signed total for a category, from `topCategories`. */
+export interface CategoryTotal {
+  name: string;
+  amount: number;
+}
+
+/** Direction filter for `breakdown`. */
+export type CashFlowDirection = 'in' | 'out';
+
+/** Group key for `breakdown`. */
+export type BreakdownBy = 'payee' | 'category';
+
+/** One row in a `breakdown` table. */
+export interface BreakdownRow {
+  label: string;
+  amount: number;
+  pctOfTotal: number;
+}
+
 const DAY_INTERVAL_MAX_DAYS = 31;
 const WEEK_INTERVAL_MAX_DAYS = 120;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
@@ -158,6 +177,79 @@ export function bucketSeries(rows: CashFlowRow[], period: CashFlowPeriod, interv
 
   orderedKeys.sort();
   return orderedKeys.map((key) => bucketsByKey.get(key)!);
+}
+
+const TOP_CATEGORY_COUNT = 5;
+const TOP_BREAKDOWN_COUNT = 8;
+
+/**
+ * Pick a display name for a transaction's other party.
+ * Falls back through `normalized_payee`, `merchant_name`, `description`,
+ * then `'Unknown'` when all three are null.
+ */
+export function payeeFor(row: CashFlowRow): string {
+  return row.normalized_payee ?? row.merchant_name ?? row.description ?? 'Unknown';
+}
+
+function sumByKey(rows: CashFlowRow[], keyFor: (row: CashFlowRow) => string): { key: string; amount: number }[] {
+  const sums = new Map<string, number>();
+  const order: string[] = [];
+
+  for (const row of rows) {
+    const key = keyFor(row);
+    if (!sums.has(key)) {
+      sums.set(key, 0);
+      order.push(key);
+    }
+    sums.set(key, sums.get(key)! + row.amount);
+  }
+
+  return order.map((key) => ({ key, amount: sums.get(key)! }));
+}
+
+/**
+ * Sum rows by category. Returns the five largest by absolute sum;
+ * the rest fold into `Other`.
+ */
+export function topCategories(rows: CashFlowRow[]): CategoryTotal[] {
+  const entries = sumByKey(rows, categoryLabel).sort((a, b) => Math.abs(b.amount) - Math.abs(a.amount));
+
+  const top = entries.slice(0, TOP_CATEGORY_COUNT).map(({ key, amount }) => ({ name: key, amount }));
+  const rest = entries.slice(TOP_CATEGORY_COUNT);
+
+  if (rest.length > 0) {
+    const otherAmount = rest.reduce((sum, entry) => sum + entry.amount, 0);
+    top.push({ name: 'Other', amount: otherAmount });
+  }
+
+  return top;
+}
+
+/**
+ * Sum rows in one direction (money in or money out), grouped by payee or
+ * category. Returns the top eight rows by absolute amount, the rest folded
+ * into a `Remaining` row, each with `pctOfTotal`.
+ */
+export function breakdown(rows: CashFlowRow[], direction: CashFlowDirection, by: BreakdownBy): BreakdownRow[] {
+  const filtered = rows.filter((row) => (direction === 'in' ? row.amount >= 0 : row.amount < 0));
+  const keyFor = by === 'payee' ? payeeFor : categoryLabel;
+
+  const total = filtered.reduce((sum, row) => sum + Math.abs(row.amount), 0);
+  const pctOfTotal = (amount: number) => (total === 0 ? 0 : (Math.abs(amount) / total) * 100);
+
+  const entries = sumByKey(filtered, keyFor).sort((a, b) => Math.abs(b.amount) - Math.abs(a.amount));
+
+  const top = entries
+    .slice(0, TOP_BREAKDOWN_COUNT)
+    .map(({ key, amount }) => ({ label: key, amount, pctOfTotal: pctOfTotal(amount) }));
+  const rest = entries.slice(TOP_BREAKDOWN_COUNT);
+
+  if (rest.length > 0) {
+    const remainingAmount = rest.reduce((sum, entry) => sum + entry.amount, 0);
+    top.push({ label: 'Remaining', amount: remainingAmount, pctOfTotal: pctOfTotal(remainingAmount) });
+  }
+
+  return top;
 }
 
 /** Compute totals and the bucketed series in one call. */

--- a/src/lib/cashflowInsights.ts
+++ b/src/lib/cashflowInsights.ts
@@ -435,12 +435,18 @@ export function formatCurrency(amount: number): string {
 
 /** Format an amount as short USD ("$48K", "$1.2M"), for chart axis ticks. */
 export function formatCompactCurrency(amount: number): string {
-  return new Intl.NumberFormat('en-US', {
-    style: 'currency',
-    currency: 'USD',
-    notation: 'compact',
-    maximumFractionDigits: 1,
-  }).format(amount);
+  // Intl compact notation keeps a trailing zero on some Node ICU builds
+  // ("$48.0K" versus "$48K"). Format by hand for a stable output.
+  const sign = amount < 0 ? '-' : '';
+  const abs = Math.abs(amount);
+  const short = (value: number, suffix: string) => {
+    const rounded = Math.round(value * 10) / 10;
+    const text = Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+    return `${sign}$${text}${suffix}`;
+  };
+  if (abs >= 1_000_000) return short(abs / 1_000_000, 'M');
+  if (abs >= 1_000) return short(abs / 1_000, 'K');
+  return `${sign}$${Math.round(abs)}`;
 }
 
 function monthKeyFromDateStr(dateStr: string): string {

--- a/src/lib/cashflowInsights.ts
+++ b/src/lib/cashflowInsights.ts
@@ -327,9 +327,14 @@ export function buildSankey(rows: CashFlowRow[]): SankeyData {
     links.push({ source: centerIndex, target: addNode('Transfers out'), value: transferOutTotal });
   }
 
-  const netRemainder = Math.max(computeTotals(rows).net, 0);
-  if (netRemainder > 0) {
-    links.push({ source: centerIndex, target: addNode('Net savings'), value: netRemainder });
+  // Keep the diagram flow-conserving in a loss period too: a positive net
+  // becomes a `Net savings` link out of the center; a negative net becomes
+  // a `From savings` link into the center, so left and right totals match.
+  const net = computeTotals(rows).net;
+  if (net > 0) {
+    links.push({ source: centerIndex, target: addNode('Net savings'), value: net });
+  } else if (net < 0) {
+    links.push({ source: addNode('From savings'), target: centerIndex, value: Math.abs(net) });
   }
 
   return { nodes, links };
@@ -518,11 +523,13 @@ export function computeInsights(rows: CashFlowRow[], period: CashFlowPeriod): Ca
 
   const subscriptionCount = countSubscriptionPayees(rows, period.to);
   if (subscriptionCount > 0) {
-    insights.push({
-      id: 'subscriptions',
-      title: `${subscriptionCount} notable transactions`,
-      body: `We noticed ${subscriptionCount} subscriptions you may want to review`,
-    });
+    const title =
+      subscriptionCount === 1 ? '1 notable transaction' : `${subscriptionCount} notable transactions`;
+    const body =
+      subscriptionCount === 1
+        ? 'We noticed 1 subscription you may want to review'
+        : `We noticed ${subscriptionCount} subscriptions you may want to review`;
+    insights.push({ id: 'subscriptions', title, body });
   }
 
   const lastFullMonth = lastFullCalendarMonth(period.to);

--- a/src/lib/periodUrlState.ts
+++ b/src/lib/periodUrlState.ts
@@ -1,0 +1,120 @@
+/**
+ * URL search-param state for the /financial-intelligence page.
+ *
+ * The page keeps its period, dashboard tab, chart view, and chart interval
+ * in the URL, so a refresh or a shared link restores the same view. This
+ * file is the single codec. Components read with `readPeriodParams` /
+ * `readEnumParam` and write with `writePeriodParams` / `URLSearchParams.set`.
+ */
+
+import { endOfDay, format, startOfDay, startOfMonth, startOfQuarter, startOfWeek, subDays } from 'date-fns';
+
+import type { Period } from '@/components/PeriodSelector';
+import { toDateOnlyString } from '@/lib/dateOnly';
+
+export const PERIOD_PARAM = 'period';
+export const FROM_PARAM = 'from';
+export const TO_PARAM = 'to';
+
+export const PRESET_PERIOD_TYPES = ['today', 'week', 'month', 'quarter', 'last30', 'last90'] as const;
+export type PresetPeriodType = (typeof PRESET_PERIOD_TYPES)[number];
+
+const PRESET_LABELS: Record<PresetPeriodType, string> = {
+  today: 'Today',
+  week: 'This Week',
+  month: 'This Month',
+  quarter: 'This Quarter',
+  last30: 'Last 30 Days',
+  last90: 'Last 90 Days',
+};
+
+const DATE_PARAM_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Build a preset period relative to `today`. The preset tabs and the URL
+ * codec share this one builder, so a decoded link matches a tab click.
+ */
+export function presetPeriod(type: PresetPeriodType, today: Date = new Date()): Period {
+  const to = endOfDay(today);
+  let from: Date;
+  switch (type) {
+    case 'today':
+      from = startOfDay(today);
+      break;
+    case 'week':
+      from = startOfDay(startOfWeek(today, { weekStartsOn: 1 }));
+      break;
+    case 'month':
+      from = startOfDay(startOfMonth(today));
+      break;
+    case 'quarter':
+      from = startOfDay(startOfQuarter(today));
+      break;
+    case 'last30':
+      from = startOfDay(subDays(today, 29));
+      break;
+    case 'last90':
+      from = startOfDay(subDays(today, 89));
+      break;
+  }
+  return { type, from, to, label: PRESET_LABELS[type] };
+}
+
+/** Label for a custom period. The start year appears when the range crosses a year boundary. */
+export function customPeriodLabel(from: Date, to: Date): string {
+  const sameYear = from.getFullYear() === to.getFullYear();
+  return `${format(from, sameYear ? 'MMM d' : 'MMM d, yyyy')} - ${format(to, 'MMM d, yyyy')}`;
+}
+
+function parseDateParam(value: string | null): Date | null {
+  if (!value || !DATE_PARAM_PATTERN.test(value)) return null;
+  const [year, month, day] = value.split('-').map(Number);
+  const date = new Date(year, month - 1, day);
+  // Reject a rolled-over date such as 2026-02-31.
+  if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) return null;
+  return date;
+}
+
+/**
+ * Read the period from the URL. A preset type rebuilds its dates relative
+ * to `today`; a custom period restores its exact dates. Returns null when
+ * the params are absent or invalid, so the caller falls back to a default.
+ */
+export function readPeriodParams(params: URLSearchParams, today: Date = new Date()): Period | null {
+  const type = params.get(PERIOD_PARAM);
+  if (!type) return null;
+  if ((PRESET_PERIOD_TYPES as readonly string[]).includes(type)) {
+    return presetPeriod(type as PresetPeriodType, today);
+  }
+  if (type !== 'custom') return null;
+
+  const from = parseDateParam(params.get(FROM_PARAM));
+  const to = parseDateParam(params.get(TO_PARAM));
+  if (!from || !to || from > to) return null;
+
+  const fromDay = startOfDay(from);
+  const toDay = endOfDay(to);
+  return { type: 'custom', from: fromDay, to: toDay, label: customPeriodLabel(fromDay, toDay) };
+}
+
+/** Write the period into `params`. A preset stores its type; custom stores its dates. */
+export function writePeriodParams(params: URLSearchParams, period: Period): void {
+  params.set(PERIOD_PARAM, period.type);
+  if (period.type === 'custom') {
+    params.set(FROM_PARAM, toDateOnlyString(period.from));
+    params.set(TO_PARAM, toDateOnlyString(period.to));
+  } else {
+    params.delete(FROM_PARAM);
+    params.delete(TO_PARAM);
+  }
+}
+
+/** Read a URL param constrained to a known value list. Returns null for anything else. */
+export function readEnumParam<T extends string>(
+  params: URLSearchParams,
+  key: string,
+  allowed: readonly T[],
+): T | null {
+  const value = params.get(key);
+  return value !== null && (allowed as readonly string[]).includes(value) ? (value as T) : null;
+}

--- a/src/pages/FinancialIntelligence.tsx
+++ b/src/pages/FinancialIntelligence.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { PageHeader } from '@/components/PageHeader';
 import { PeriodSelector, Period } from '@/components/PeriodSelector';
 import { BankingIntelligenceDashboard } from '@/components/banking/BankingIntelligenceDashboard';
@@ -7,19 +8,25 @@ import { useConnectedBanks } from '@/hooks/useConnectedBanks';
 import { useRestaurantContext } from '@/contexts/RestaurantContext';
 import { FeatureGate } from '@/components/subscription';
 import { Brain } from 'lucide-react';
-import { startOfMonth, endOfDay } from 'date-fns';
 import { Skeleton } from '@/components/ui/skeleton';
+import { presetPeriod, readPeriodParams, writePeriodParams } from '@/lib/periodUrlState';
 
 export default function FinancialIntelligence() {
-  const today = new Date();
   const { selectedRestaurant } = useRestaurantContext();
-  const [selectedPeriod, setSelectedPeriod] = useState<Period>({
-    type: 'month',
-    from: startOfMonth(today),
-    to: endOfDay(today),
-    label: 'This Month',
-  });
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [selectedPeriod, setSelectedPeriod] = useState<Period>(
+    () => readPeriodParams(searchParams) ?? presetPeriod('month'),
+  );
   const [selectedBankAccount, setSelectedBankAccount] = useState<string>('all');
+
+  const handlePeriodChange = (period: Period) => {
+    setSelectedPeriod(period);
+    // Read the live search string, not the hook value. The chart writes its
+    // own params and the hook value can lag one render behind.
+    const params = new URLSearchParams(window.location.search);
+    writePeriodParams(params, period);
+    setSearchParams(params, { replace: true });
+  };
 
   const { data: connectedBanks = [], isLoading: banksLoading } = useConnectedBanks(
     selectedRestaurant?.restaurant_id,
@@ -38,7 +45,7 @@ export default function FinancialIntelligence() {
         <FeatureGate featureKey="financial_intelligence">
           <PeriodSelector
             selectedPeriod={selectedPeriod}
-            onPeriodChange={setSelectedPeriod}
+            onPeriodChange={handlePeriodChange}
           />
 
           {banksLoading ? (
@@ -54,7 +61,7 @@ export default function FinancialIntelligence() {
           <BankingIntelligenceDashboard
             selectedPeriod={selectedPeriod}
             selectedBankAccount={selectedBankAccount}
-            onPeriodChange={setSelectedPeriod}
+            onPeriodChange={handlePeriodChange}
           />
         </FeatureGate>
       </div>

--- a/src/pages/FinancialIntelligence.tsx
+++ b/src/pages/FinancialIntelligence.tsx
@@ -54,6 +54,7 @@ export default function FinancialIntelligence() {
           <BankingIntelligenceDashboard
             selectedPeriod={selectedPeriod}
             selectedBankAccount={selectedBankAccount}
+            onPeriodChange={setSelectedPeriod}
           />
         </FeatureGate>
       </div>

--- a/tests/e2e/financial-intelligence-cashflow.spec.ts
+++ b/tests/e2e/financial-intelligence-cashflow.spec.ts
@@ -21,13 +21,14 @@ function dateDaysAgo(page: Page, daysAgo: number): Promise<string> {
 
 /**
  * Read a headline value ("$2,400") next to its label ("Net cashflow").
- * CashFlowHeadline puts each label and value in the same wrapper div, so
- * this scopes to that wrapper instead of matching the value text page-wide
- * (breakdown cards repeat "Money in" / "Money out" as card titles).
+ * CashFlowHeadline gives each stat a `role="group"` with the label as its
+ * accessible name, so this scopes by role instead of matching the value
+ * text page-wide (breakdown cards repeat "Money in" / "Money out" as card
+ * titles).
  */
 async function expectHeadlineValue(page: Page, label: string, value: string) {
-  const wrapper = page.getByText(label, { exact: true }).first().locator('..');
-  await expect(wrapper.getByText(value, { exact: true })).toBeVisible({ timeout: 10000 });
+  const group = page.getByRole('group', { name: label });
+  await expect(group.getByText(value, { exact: true })).toBeVisible({ timeout: 10000 });
 }
 
 test.describe('Financial Intelligence — Cash Flow view', () => {
@@ -168,7 +169,7 @@ test.describe('Financial Intelligence — Cash Flow view', () => {
       { rid: restaurantId, day2, day3, day32, day33, day62, day87 },
     );
 
-    await page.goto('/financial-intelligence');
+    await page.goto('/financial-intelligence', { timeout: 10000 });
 
     // Switch to a period wide enough to hold every seeded row (the page
     // opens on "This Month", which would miss the older rows).
@@ -180,7 +181,11 @@ test.describe('Financial Intelligence — Cash Flow view', () => {
     await expectHeadlineValue(page, 'Money out', '$1,600');
 
     // --- Narrative: always-visible caption text ------------------------
-    await expect(page.getByText('Trends are generated and may include inaccuracies.')).toBeVisible();
+    // The insight list itself is calendar-dependent (it compares full
+    // calendar months against "today"), so this only pins the region's
+    // always-visible disclaimer through a semantic selector.
+    const narrative = page.getByRole('region', { name: 'Cash flow narrative' });
+    await expect(narrative.getByText('Trends are generated and may include inaccuracies.')).toBeVisible();
 
     // --- Chart mode switch: category bars and in/out bars ---------------
     await expect(page.getByRole('img', { name: /Flow view of cash flow/i })).toBeVisible();
@@ -192,15 +197,18 @@ test.describe('Financial Intelligence — Cash Flow view', () => {
     await expect(page.getByRole('img', { name: /In vs out view of cash flow, net \$2,400/i })).toBeVisible();
 
     // --- Breakdown tab switch: Source rows vs. folded Category rows ----
-    await expect(page.locator('[data-testid="breakdown-track-Client Payment Alpha"]')).toBeVisible();
-    await expect(page.locator('[data-testid="breakdown-track-Second Bank Income"]')).toBeVisible();
+    // Each breakdown row carries `role="listitem"` with its label as the
+    // accessible name (MoneyBreakdownTable.tsx), so a row can be found
+    // without a data-testid.
+    await expect(page.getByRole('listitem', { name: 'Client Payment Alpha' })).toBeVisible();
+    await expect(page.getByRole('listitem', { name: 'Second Bank Income' })).toBeVisible();
 
     const sourceTab = page.getByRole('tab', { name: 'Source' });
     const categoryTabInMoneyIn = sourceTab.locator('..').getByRole('tab', { name: 'Category' });
     await categoryTabInMoneyIn.click();
 
-    await expect(page.locator('[data-testid="breakdown-track-Client Payment Alpha"]')).not.toBeVisible();
-    await expect(page.locator('[data-testid="breakdown-track-Uncategorized"]')).toBeVisible();
+    await expect(page.getByRole('listitem', { name: 'Client Payment Alpha' })).not.toBeVisible();
+    await expect(page.getByRole('listitem', { name: 'Uncategorized' })).toBeVisible();
 
     // --- Bank-account filter changes the totals -------------------------
     await page.getByRole('combobox').filter({ hasText: 'All Accounts' }).click();

--- a/tests/e2e/financial-intelligence-cashflow.spec.ts
+++ b/tests/e2e/financial-intelligence-cashflow.spec.ts
@@ -175,17 +175,21 @@ test.describe('Financial Intelligence — Cash Flow view', () => {
     // opens on "This Month", which would miss the older rows).
     await page.getByRole('button', { name: 'Last 90 Days' }).click();
 
+    // --- URL state: the period preset lands in the search params --------
+    await expect(page).toHaveURL(/period=last90/);
+
     // --- Headline totals: all accounts combined -----------------------
     await expectHeadlineValue(page, 'Net cashflow', '$2,400');
     await expectHeadlineValue(page, 'Money in', '$4,000');
     await expectHeadlineValue(page, 'Money out', '$1,600');
 
-    // --- Narrative: always-visible caption text ------------------------
+    // --- Narrative: region present, no static disclaimer ----------------
     // The insight list itself is calendar-dependent (it compares full
-    // calendar months against "today"), so this only pins the region's
-    // always-visible disclaimer through a semantic selector.
+    // calendar months against "today"), so this only pins the region and
+    // the absence of the old boilerplate disclaimer.
     const narrative = page.getByRole('region', { name: 'Cash flow narrative' });
-    await expect(narrative.getByText('Trends are generated and may include inaccuracies.')).toBeVisible();
+    await expect(narrative).toBeVisible();
+    await expect(narrative.getByText(/Trends are generated/)).toHaveCount(0);
 
     // --- Chart mode switch: category bars and in/out bars ---------------
     await expect(page.getByRole('img', { name: /Flow view of cash flow/i })).toBeVisible();
@@ -195,6 +199,13 @@ test.describe('Financial Intelligence — Cash Flow view', () => {
 
     await page.getByRole('radio', { name: 'In vs out', exact: true }).click();
     await expect(page.getByRole('img', { name: /In vs out view of cash flow, net \$2,400/i })).toBeVisible();
+
+    // --- URL state: view and period survive a reload ---------------------
+    await expect(page).toHaveURL(/view=inout/);
+    await page.reload();
+    await expect(
+      page.getByRole('img', { name: /In vs out view of cash flow, net \$2,400/i }),
+    ).toBeVisible({ timeout: 10000 });
 
     // --- Breakdown tab switch: Source rows vs. folded Category rows ----
     // Each breakdown row carries `role="listitem"` with its label as the

--- a/tests/e2e/financial-intelligence-cashflow.spec.ts
+++ b/tests/e2e/financial-intelligence-cashflow.spec.ts
@@ -1,0 +1,217 @@
+import { test, expect, Page } from '@playwright/test';
+import { signUpAndCreateRestaurant, generateTestUser, exposeSupabaseHelpers } from '../helpers/e2e-supabase';
+
+const getRestaurantId = (page: Page) =>
+  page.evaluate<string | null>(async () => {
+    const helperWindow = window as Window & {
+      __getRestaurantId?: () => Promise<string | null> | string | null;
+    };
+    const fn = helperWindow.__getRestaurantId;
+    return fn ? await fn() : null;
+  });
+
+/** 'yyyy-MM-dd' for N days before today, in the browser's local time. */
+function dateDaysAgo(page: Page, daysAgo: number): Promise<string> {
+  return page.evaluate((n) => {
+    const d = new Date();
+    d.setDate(d.getDate() - n);
+    return d.toISOString().slice(0, 10);
+  }, daysAgo);
+}
+
+/**
+ * Read a headline value ("$2,400") next to its label ("Net cashflow").
+ * CashFlowHeadline puts each label and value in the same wrapper div, so
+ * this scopes to that wrapper instead of matching the value text page-wide
+ * (breakdown cards repeat "Money in" / "Money out" as card titles).
+ */
+async function expectHeadlineValue(page: Page, label: string, value: string) {
+  const wrapper = page.getByText(label, { exact: true }).first().locator('..');
+  await expect(wrapper.getByText(value, { exact: true })).toBeVisible({ timeout: 10000 });
+}
+
+test.describe('Financial Intelligence — Cash Flow view', () => {
+  test('shows totals, narrative, chart modes, breakdown tabs, account filter, and empty state', async ({ page }) => {
+    const user = generateTestUser();
+
+    await signUpAndCreateRestaurant(page, user);
+    await exposeSupabaseHelpers(page);
+
+    const restaurantId = await getRestaurantId(page);
+    expect(restaurantId).toBeTruthy();
+
+    // Compute the 'yyyy-MM-dd' dates the seed rows need before entering the
+    // page.evaluate sandbox (dates there must stay JSON-serializable).
+    const day2 = await dateDaysAgo(page, 2);
+    const day3 = await dateDaysAgo(page, 3);
+    const day32 = await dateDaysAgo(page, 32);
+    const day33 = await dateDaysAgo(page, 33);
+    const day62 = await dateDaysAgo(page, 62);
+    const day87 = await dateDaysAgo(page, 87);
+
+    // Seed two connected banks (one per account, mirroring production's
+    // one-row-per-Stripe-account shape) and transactions spread across the
+    // last ~3 months, all inside the 90-day window the test switches to.
+    await page.evaluate(
+      async ({ rid, day2, day3, day32, day33, day62, day87 }) => {
+        const { supabase } = await import('/src/integrations/supabase/client');
+
+        const timestamp = Date.now();
+        const random = crypto.randomUUID().slice(0, 8);
+
+        const { data: bank1, error: bank1Error } = await supabase
+          .from('connected_banks')
+          .insert({
+            restaurant_id: rid,
+            institution_name: 'Chase Test Bank',
+            stripe_financial_account_id: `fca_cf1_${timestamp}_${random}`,
+            account_mask: '1111',
+            status: 'connected',
+          })
+          .select()
+          .single();
+        if (bank1Error) throw new Error(`Failed to create bank1: ${bank1Error.message}`);
+
+        const { data: bank2, error: bank2Error } = await supabase
+          .from('connected_banks')
+          .insert({
+            restaurant_id: rid,
+            institution_name: 'Wells Test Bank',
+            stripe_financial_account_id: `fca_cf2_${timestamp}_${random}`,
+            account_mask: '2222',
+            status: 'connected',
+          })
+          .select()
+          .single();
+        if (bank2Error) throw new Error(`Failed to create bank2: ${bank2Error.message}`);
+
+        const { error: balancesError } = await supabase.from('bank_account_balances').insert([
+          {
+            connected_bank_id: bank1.id,
+            stripe_financial_account_id: `fa_cf1_${timestamp}_${random}`,
+            account_name: 'Checking Account',
+            account_type: 'checking',
+            account_mask: '1111',
+            current_balance: 10000,
+            as_of_date: new Date().toISOString(),
+          },
+          {
+            connected_bank_id: bank2.id,
+            stripe_financial_account_id: `fa_cf2_${timestamp}_${random}`,
+            account_name: 'Savings Account',
+            account_type: 'savings',
+            account_mask: '2222',
+            current_balance: 20000,
+            as_of_date: new Date().toISOString(),
+          },
+        ]);
+        if (balancesError) throw new Error(`Failed to create balances: ${balancesError.message}`);
+
+        const { error: txError } = await supabase.from('bank_transactions').insert([
+          {
+            restaurant_id: rid,
+            connected_bank_id: bank1.id,
+            stripe_transaction_id: `txn_cf_1_${timestamp}_${random}`,
+            transaction_date: day2,
+            description: 'Client Payment Alpha',
+            amount: 2000,
+            status: 'posted',
+          },
+          {
+            restaurant_id: rid,
+            connected_bank_id: bank1.id,
+            stripe_transaction_id: `txn_cf_2_${timestamp}_${random}`,
+            transaction_date: day32,
+            description: 'Vendor Payment Beta',
+            amount: -800,
+            status: 'posted',
+          },
+          {
+            restaurant_id: rid,
+            connected_bank_id: bank1.id,
+            stripe_transaction_id: `txn_cf_3_${timestamp}_${random}`,
+            transaction_date: day62,
+            description: 'Client Payment Alpha',
+            amount: 1500,
+            status: 'posted',
+          },
+          {
+            restaurant_id: rid,
+            connected_bank_id: bank1.id,
+            stripe_transaction_id: `txn_cf_4_${timestamp}_${random}`,
+            transaction_date: day87,
+            description: 'Vendor Payment Gamma',
+            amount: -600,
+            status: 'posted',
+          },
+          {
+            restaurant_id: rid,
+            connected_bank_id: bank2.id,
+            stripe_transaction_id: `txn_cf_5_${timestamp}_${random}`,
+            transaction_date: day3,
+            description: 'Second Bank Income',
+            amount: 500,
+            status: 'posted',
+          },
+          {
+            restaurant_id: rid,
+            connected_bank_id: bank2.id,
+            stripe_transaction_id: `txn_cf_6_${timestamp}_${random}`,
+            transaction_date: day33,
+            description: 'Second Bank Expense',
+            amount: -200,
+            status: 'posted',
+          },
+        ]);
+        if (txError) throw new Error(`Failed to create transactions: ${txError.message}`);
+      },
+      { rid: restaurantId, day2, day3, day32, day33, day62, day87 },
+    );
+
+    await page.goto('/financial-intelligence');
+
+    // Switch to a period wide enough to hold every seeded row (the page
+    // opens on "This Month", which would miss the older rows).
+    await page.getByRole('button', { name: 'Last 90 Days' }).click();
+
+    // --- Headline totals: all accounts combined -----------------------
+    await expectHeadlineValue(page, 'Net cashflow', '$2,400');
+    await expectHeadlineValue(page, 'Money in', '$4,000');
+    await expectHeadlineValue(page, 'Money out', '$1,600');
+
+    // --- Narrative: always-visible caption text ------------------------
+    await expect(page.getByText('Trends are generated and may include inaccuracies.')).toBeVisible();
+
+    // --- Chart mode switch: category bars and in/out bars ---------------
+    await expect(page.getByRole('img', { name: /Flow view of cash flow/i })).toBeVisible();
+
+    await page.getByRole('radio', { name: 'By category', exact: true }).click();
+    await expect(page.getByRole('img', { name: /By category view of cash flow, net \$2,400/i })).toBeVisible();
+
+    await page.getByRole('radio', { name: 'In vs out', exact: true }).click();
+    await expect(page.getByRole('img', { name: /In vs out view of cash flow, net \$2,400/i })).toBeVisible();
+
+    // --- Breakdown tab switch: Source rows vs. folded Category rows ----
+    await expect(page.locator('[data-testid="breakdown-track-Client Payment Alpha"]')).toBeVisible();
+    await expect(page.locator('[data-testid="breakdown-track-Second Bank Income"]')).toBeVisible();
+
+    const sourceTab = page.getByRole('tab', { name: 'Source' });
+    const categoryTabInMoneyIn = sourceTab.locator('..').getByRole('tab', { name: 'Category' });
+    await categoryTabInMoneyIn.click();
+
+    await expect(page.locator('[data-testid="breakdown-track-Client Payment Alpha"]')).not.toBeVisible();
+    await expect(page.locator('[data-testid="breakdown-track-Uncategorized"]')).toBeVisible();
+
+    // --- Bank-account filter changes the totals -------------------------
+    await page.getByRole('combobox').filter({ hasText: 'All Accounts' }).click();
+    await page.getByRole('option', { name: /Wells Test Bank/i }).click();
+
+    await expectHeadlineValue(page, 'Net cashflow', '$300');
+    await expectHeadlineValue(page, 'Money in', '$500');
+    await expectHeadlineValue(page, 'Money out', '$200');
+
+    // --- Empty state: a period with no transactions ---------------------
+    await page.getByRole('button', { name: 'Today' }).click();
+    await expect(page.getByText('No transactions for this period')).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/tests/unit/BankingIntelligenceDashboard.cashflowThread.test.tsx
+++ b/tests/unit/BankingIntelligenceDashboard.cashflowThread.test.tsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 
 import { BankingIntelligenceDashboard } from '@/components/banking/BankingIntelligenceDashboard';
 import type { Period } from '@/components/PeriodSelector';
@@ -27,10 +28,15 @@ vi.mock('@/components/banking/PredictionsTab', () => ({ PredictionsTab: () => nu
 
 const period: Period = { type: 'month', from: new Date(2026, 0, 1), to: new Date(2026, 0, 31), label: 'January' };
 
+// The dashboard reads and writes the URL tab param, so it needs a router.
+function renderDashboard(ui: React.ReactElement, initialEntries: string[] = ['/']) {
+  return render(<MemoryRouter initialEntries={initialEntries}>{ui}</MemoryRouter>);
+}
+
 describe('BankingIntelligenceDashboard cash flow thread', () => {
   it('forwards onPeriodChange to CashFlowTab', () => {
     const onPeriodChange = vi.fn();
-    render(
+    renderDashboard(
       <BankingIntelligenceDashboard
         selectedPeriod={period}
         selectedBankAccount="all"
@@ -39,5 +45,17 @@ describe('BankingIntelligenceDashboard cash flow thread', () => {
     );
     screen.getByText('cashflow-tab-stub').click();
     expect(onPeriodChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('restores the active tab from the URL tab param', () => {
+    renderDashboard(
+      <BankingIntelligenceDashboard
+        selectedPeriod={period}
+        selectedBankAccount="all"
+        onPeriodChange={vi.fn()}
+      />,
+      ['/?tab=revenue']
+    );
+    expect(screen.getByRole('tab', { name: /revenue/i })).toHaveAttribute('aria-selected', 'true');
   });
 });

--- a/tests/unit/BankingIntelligenceDashboard.cashflowThread.test.tsx
+++ b/tests/unit/BankingIntelligenceDashboard.cashflowThread.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * Pins the `onPeriodChange` prop thread from
+ * src/components/banking/BankingIntelligenceDashboard.tsx down to
+ * `CashFlowTab`, on the default-active Cash Flow tab.
+ */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { BankingIntelligenceDashboard } from '@/components/banking/BankingIntelligenceDashboard';
+import type { Period } from '@/components/PeriodSelector';
+
+vi.mock('@/components/banking/CashFlowTab', () => ({
+  CashFlowTab: ({ onPeriodChange }: { onPeriodChange: (period: Period) => void }) =>
+    React.createElement(
+      'button',
+      { onClick: () => onPeriodChange({ type: 'custom', from: new Date(), to: new Date(), label: 'Custom' }) },
+      'cashflow-tab-stub'
+    ),
+}));
+
+vi.mock('@/components/banking/FinancialPulseHero', () => ({ FinancialPulseHero: () => null }));
+vi.mock('@/components/banking/RevenueHealthTab', () => ({ RevenueHealthTab: () => null }));
+vi.mock('@/components/banking/SpendingAnalysisTab', () => ({ SpendingAnalysisTab: () => null }));
+vi.mock('@/components/banking/LiquidityTab', () => ({ LiquidityTab: () => null }));
+vi.mock('@/components/banking/PredictionsTab', () => ({ PredictionsTab: () => null }));
+
+const period: Period = { type: 'month', from: new Date(2026, 0, 1), to: new Date(2026, 0, 31), label: 'January' };
+
+describe('BankingIntelligenceDashboard cash flow thread', () => {
+  it('forwards onPeriodChange to CashFlowTab', () => {
+    const onPeriodChange = vi.fn();
+    render(
+      <BankingIntelligenceDashboard
+        selectedPeriod={period}
+        selectedBankAccount="all"
+        onPeriodChange={onPeriodChange}
+      />
+    );
+    screen.getByText('cashflow-tab-stub').click();
+    expect(onPeriodChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/CashFlowChart.test.tsx
+++ b/tests/unit/CashFlowChart.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * Behavioral tests for src/components/banking/cashflow/CashFlowChart.tsx
+ *
+ * Pins the three chart modes (Flow / By category / In vs out), the
+ * cashflow and interval controls, and the accessible name/caption pair
+ * each mode must carry.
+ */
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { CashFlowChart } from '@/components/banking/cashflow/CashFlowChart';
+import type { CashFlowRow, CashFlowPeriod } from '@/lib/cashflowInsights';
+
+vi.mock('@/components/ui/select', () => ({
+  Select: ({
+    name,
+    value,
+    onValueChange,
+    children,
+  }: {
+    name: string;
+    value: string;
+    onValueChange: (value: string) => void;
+    children: React.ReactNode;
+  }) =>
+    React.createElement(
+      'select',
+      {
+        'data-testid': name,
+        value,
+        onChange: (e: React.ChangeEvent<HTMLSelectElement>) => onValueChange(e.target.value),
+      },
+      children,
+    ),
+  SelectContent: ({ children }: { children: React.ReactNode }) => children,
+  SelectItem: ({ value, children }: { value: string; children: React.ReactNode }) =>
+    React.createElement('option', { value }, children),
+  SelectTrigger: () => null,
+  SelectValue: () => null,
+}));
+
+const period: CashFlowPeriod = { from: new Date(2026, 5, 1), to: new Date(2026, 5, 30) };
+
+const rows: CashFlowRow[] = [
+  {
+    transaction_date: '2026-06-03',
+    amount: 5000,
+    is_transfer: false,
+    normalized_payee: 'Client A',
+    merchant_name: null,
+    description: null,
+    category: { id: 'c1', name: 'Sales' },
+  },
+  {
+    transaction_date: '2026-06-05',
+    amount: -2000,
+    is_transfer: false,
+    normalized_payee: 'Vendor B',
+    merchant_name: null,
+    description: null,
+    category: { id: 'c2', name: 'Supplies' },
+  },
+  {
+    transaction_date: '2026-06-10',
+    amount: -1500,
+    is_transfer: true,
+    normalized_payee: 'Savings sweep',
+    merchant_name: null,
+    description: null,
+    category: null,
+  },
+];
+
+describe('CashFlowChart', () => {
+  it('defaults to Flow mode: role="img", aria-label mentions Flow, interval select hidden', () => {
+    render(<CashFlowChart rows={rows} period={period} />);
+
+    const chart = screen.getByRole('img', { name: /flow/i });
+    expect(chart).toBeInTheDocument();
+    expect(screen.queryByTestId('interval')).not.toBeInTheDocument();
+  });
+
+  it('wires the visible caption to the chart via aria-describedby', () => {
+    render(<CashFlowChart rows={rows} period={period} />);
+
+    const chart = screen.getByRole('img', { name: /flow/i });
+    const describedById = chart.getAttribute('aria-describedby');
+    expect(describedById).toBeTruthy();
+
+    const caption = document.getElementById(describedById!);
+    expect(caption).not.toBeNull();
+    expect(caption).toBeVisible();
+    expect(caption!.textContent).toMatch(/money in/i);
+    expect(caption!.textContent).toMatch(/money out/i);
+    expect(caption!.textContent).toMatch(/\$5,000/);
+    expect(caption!.textContent).toMatch(/\$3,500/);
+  });
+
+  it('switches to By category mode: shows the interval select and updates the aria-label', () => {
+    render(<CashFlowChart rows={rows} period={period} />);
+
+    fireEvent.click(screen.getByText('By category'));
+
+    expect(screen.getByRole('img', { name: /category/i })).toBeInTheDocument();
+    expect(screen.getByTestId('interval')).toBeInTheDocument();
+  });
+
+  it('switches to In vs out mode: updates the aria-label and hides the interval select is still shown', () => {
+    render(<CashFlowChart rows={rows} period={period} />);
+
+    fireEvent.click(screen.getByText('In vs out'));
+
+    expect(screen.getByRole('img', { name: /in vs out/i })).toBeInTheDocument();
+    expect(screen.getByTestId('interval')).toBeInTheDocument();
+  });
+
+  it('going back to Flow mode hides the interval select again', () => {
+    render(<CashFlowChart rows={rows} period={period} />);
+
+    fireEvent.click(screen.getByText('By category'));
+    expect(screen.getByTestId('interval')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('Flow'));
+    expect(screen.queryByTestId('interval')).not.toBeInTheDocument();
+  });
+
+  it('the cashflow filter select excludes transfer rows from the caption totals when set to Exclude transfers', () => {
+    render(<CashFlowChart rows={rows} period={period} />);
+
+    const chart = screen.getByRole('img', { name: /flow/i });
+    const describedById = chart.getAttribute('aria-describedby')!;
+    expect(document.getElementById(describedById)!.textContent).toMatch(/\$3,500/);
+
+    fireEvent.change(screen.getByTestId('cashflow-filter'), { target: { value: 'exclude-transfers' } });
+
+    const captionAfter = document.getElementById(chart.getAttribute('aria-describedby')!)!;
+    expect(captionAfter.textContent).not.toMatch(/\$3,500/);
+    expect(captionAfter.textContent).toMatch(/\$2,000/);
+  });
+
+  it('renders an empty flow gracefully for zero rows', () => {
+    render(<CashFlowChart rows={[]} period={period} />);
+
+    expect(screen.getByRole('img', { name: /flow/i })).toBeInTheDocument();
+  });
+});

--- a/tests/unit/CashFlowChart.test.tsx
+++ b/tests/unit/CashFlowChart.test.tsx
@@ -8,6 +8,7 @@
 import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 
 import { CashFlowChart } from '@/components/banking/cashflow/CashFlowChart';
 import type { CashFlowRow, CashFlowPeriod } from '@/lib/cashflowInsights';
@@ -72,9 +73,14 @@ const rows: CashFlowRow[] = [
   },
 ];
 
+// The chart reads and writes URL search params, so it needs a router.
+function renderChart(ui: React.ReactElement, initialEntries: string[] = ['/']) {
+  return render(<MemoryRouter initialEntries={initialEntries}>{ui}</MemoryRouter>);
+}
+
 describe('CashFlowChart', () => {
   it('defaults to Flow mode: role="img", aria-label mentions Flow, interval select hidden', () => {
-    render(<CashFlowChart rows={rows} period={period} />);
+    renderChart(<CashFlowChart rows={rows} period={period} />);
 
     const chart = screen.getByRole('img', { name: /flow/i });
     expect(chart).toBeInTheDocument();
@@ -82,7 +88,7 @@ describe('CashFlowChart', () => {
   });
 
   it('wires the visible caption to the chart via aria-describedby', () => {
-    render(<CashFlowChart rows={rows} period={period} />);
+    renderChart(<CashFlowChart rows={rows} period={period} />);
 
     const chart = screen.getByRole('img', { name: /flow/i });
     const describedById = chart.getAttribute('aria-describedby');
@@ -99,7 +105,7 @@ describe('CashFlowChart', () => {
   });
 
   it('switches to By category mode: shows the interval select and updates the aria-label', () => {
-    render(<CashFlowChart rows={rows} period={period} />);
+    renderChart(<CashFlowChart rows={rows} period={period} />);
 
     fireEvent.click(screen.getByText('By category'));
 
@@ -108,7 +114,7 @@ describe('CashFlowChart', () => {
   });
 
   it('switches to In vs out mode: updates the aria-label and keeps the interval select shown', () => {
-    render(<CashFlowChart rows={rows} period={period} />);
+    renderChart(<CashFlowChart rows={rows} period={period} />);
 
     fireEvent.click(screen.getByText('In vs out'));
 
@@ -117,7 +123,7 @@ describe('CashFlowChart', () => {
   });
 
   it('going back to Flow mode hides the interval select again', () => {
-    render(<CashFlowChart rows={rows} period={period} />);
+    renderChart(<CashFlowChart rows={rows} period={period} />);
 
     fireEvent.click(screen.getByText('By category'));
     expect(screen.getByTestId('interval')).toBeInTheDocument();
@@ -127,7 +133,7 @@ describe('CashFlowChart', () => {
   });
 
   it('excludes transfer rows by default and adds them back when set to All cashflow', () => {
-    render(<CashFlowChart rows={rows} period={period} />);
+    renderChart(<CashFlowChart rows={rows} period={period} />);
 
     const chart = screen.getByRole('img', { name: /flow/i });
     const describedById = chart.getAttribute('aria-describedby')!;
@@ -142,7 +148,26 @@ describe('CashFlowChart', () => {
   });
 
   it('renders an empty flow gracefully for zero rows', () => {
-    render(<CashFlowChart rows={[]} period={period} />);
+    renderChart(<CashFlowChart rows={[]} period={period} />);
+
+    expect(screen.getByRole('img', { name: /flow/i })).toBeInTheDocument();
+  });
+
+  it('restores the view from the URL view param', () => {
+    renderChart(<CashFlowChart rows={rows} period={period} />, ['/?view=inout']);
+
+    expect(screen.getByRole('img', { name: /in vs out/i })).toBeInTheDocument();
+  });
+
+  it('restores the interval from the URL interval param', () => {
+    renderChart(<CashFlowChart rows={rows} period={period} />, ['/?view=category&interval=month']);
+
+    expect(screen.getByRole('img', { name: /category/i })).toBeInTheDocument();
+    expect(screen.getByTestId('interval')).toHaveValue('month');
+  });
+
+  it('falls back to Flow mode for an unknown view param', () => {
+    renderChart(<CashFlowChart rows={rows} period={period} />, ['/?view=bogus']);
 
     expect(screen.getByRole('img', { name: /flow/i })).toBeInTheDocument();
   });

--- a/tests/unit/CashFlowChart.test.tsx
+++ b/tests/unit/CashFlowChart.test.tsx
@@ -106,7 +106,7 @@ describe('CashFlowChart', () => {
     expect(screen.getByTestId('interval')).toBeInTheDocument();
   });
 
-  it('switches to In vs out mode: updates the aria-label and hides the interval select is still shown', () => {
+  it('switches to In vs out mode: updates the aria-label and keeps the interval select shown', () => {
     render(<CashFlowChart rows={rows} period={period} />);
 
     fireEvent.click(screen.getByText('In vs out'));

--- a/tests/unit/CashFlowChart.test.tsx
+++ b/tests/unit/CashFlowChart.test.tsx
@@ -50,7 +50,7 @@ const rows: CashFlowRow[] = [
     normalized_payee: 'Client A',
     merchant_name: null,
     description: null,
-    category: { id: 'c1', name: 'Sales' },
+    category: { id: 'c1', name: 'Sales', account_type: 'revenue', account_subtype: null },
   },
   {
     transaction_date: '2026-06-05',
@@ -59,7 +59,7 @@ const rows: CashFlowRow[] = [
     normalized_payee: 'Vendor B',
     merchant_name: null,
     description: null,
-    category: { id: 'c2', name: 'Supplies' },
+    category: { id: 'c2', name: 'Supplies', account_type: 'expense', account_subtype: null },
   },
   {
     transaction_date: '2026-06-10',
@@ -93,8 +93,9 @@ describe('CashFlowChart', () => {
     expect(caption).toBeVisible();
     expect(caption!.textContent).toMatch(/money in/i);
     expect(caption!.textContent).toMatch(/money out/i);
+    // The default filter excludes the transfer row, so money out is $2,000.
     expect(caption!.textContent).toMatch(/\$5,000/);
-    expect(caption!.textContent).toMatch(/\$3,500/);
+    expect(caption!.textContent).toMatch(/\$2,000/);
   });
 
   it('switches to By category mode: shows the interval select and updates the aria-label', () => {
@@ -125,18 +126,19 @@ describe('CashFlowChart', () => {
     expect(screen.queryByTestId('interval')).not.toBeInTheDocument();
   });
 
-  it('the cashflow filter select excludes transfer rows from the caption totals when set to Exclude transfers', () => {
+  it('excludes transfer rows by default and adds them back when set to All cashflow', () => {
     render(<CashFlowChart rows={rows} period={period} />);
 
     const chart = screen.getByRole('img', { name: /flow/i });
     const describedById = chart.getAttribute('aria-describedby')!;
-    expect(document.getElementById(describedById)!.textContent).toMatch(/\$3,500/);
+    // The default filter is 'exclude-transfers': the $1,500 transfer is out.
+    expect(document.getElementById(describedById)!.textContent).toMatch(/\$2,000/);
 
-    fireEvent.change(screen.getByTestId('cashflow-filter'), { target: { value: 'exclude-transfers' } });
+    fireEvent.change(screen.getByTestId('cashflow-filter'), { target: { value: 'all' } });
 
     const captionAfter = document.getElementById(chart.getAttribute('aria-describedby')!)!;
-    expect(captionAfter.textContent).not.toMatch(/\$3,500/);
-    expect(captionAfter.textContent).toMatch(/\$2,000/);
+    expect(captionAfter.textContent).not.toMatch(/\$2,000/);
+    expect(captionAfter.textContent).toMatch(/\$3,500/);
   });
 
   it('renders an empty flow gracefully for zero rows', () => {

--- a/tests/unit/CashFlowHeadline.test.tsx
+++ b/tests/unit/CashFlowHeadline.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CashFlowHeadline } from '@/components/banking/cashflow/CashFlowHeadline';
+import type { CashFlowTotals } from '@/lib/cashflowInsights';
+
+describe('CashFlowHeadline', () => {
+  it('shows Net cashflow, Money in, and Money out', () => {
+    const totals: CashFlowTotals = { moneyIn: 12000, moneyOut: -8000, net: 4000 };
+    render(<CashFlowHeadline totals={totals} />);
+
+    expect(screen.getByText('Net cashflow')).toBeInTheDocument();
+    expect(screen.getByText('$4,000')).toBeInTheDocument();
+    expect(screen.getByText('Money in')).toBeInTheDocument();
+    expect(screen.getByText('$12,000')).toBeInTheDocument();
+    expect(screen.getByText('Money out')).toBeInTheDocument();
+    expect(screen.getByText('$8,000')).toBeInTheDocument();
+  });
+
+  it('renders a positive net without the destructive class', () => {
+    const totals: CashFlowTotals = { moneyIn: 12000, moneyOut: -8000, net: 4000 };
+    render(<CashFlowHeadline totals={totals} />);
+
+    const net = screen.getByText('$4,000');
+    expect(net.className).not.toContain('text-destructive');
+    expect(net.className).toContain('text-[28px]');
+    expect(net.className).toContain('font-semibold');
+    expect(net.className).toContain('tracking-tight');
+  });
+
+  it('renders a negative net with the destructive class', () => {
+    const totals: CashFlowTotals = { moneyIn: 3000, moneyOut: -8000, net: -5000 };
+    render(<CashFlowHeadline totals={totals} />);
+
+    const net = screen.getByText('-$5,000');
+    expect(net.className).toContain('text-destructive');
+  });
+});

--- a/tests/unit/CashFlowNarrative.test.tsx
+++ b/tests/unit/CashFlowNarrative.test.tsx
@@ -51,11 +51,9 @@ describe('CashFlowNarrative', () => {
     expect(payeeChip.className).toContain('px-1');
   });
 
-  it('always shows the trends caption', () => {
+  it('shows no static disclaimer text', () => {
     render(<CashFlowNarrative insights={[]} />);
-    expect(
-      screen.getByText('Trends are generated and may include inaccuracies.')
-    ).toBeInTheDocument();
+    expect(screen.queryByText(/Trends are generated/)).not.toBeInTheDocument();
   });
 
   it('shows a fallback line when there are no insights', () => {

--- a/tests/unit/CashFlowNarrative.test.tsx
+++ b/tests/unit/CashFlowNarrative.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { CashFlowNarrative } from '@/components/banking/cashflow/CashFlowNarrative';
+import type { CashFlowInsight } from '@/lib/cashflowInsights';
+
+describe('CashFlowNarrative', () => {
+  it('shows each insight title and body as visible text', () => {
+    const insights: CashFlowInsight[] = [
+      {
+        id: 'revenue-change',
+        title: 'Revenue increased',
+        body: 'Money in for July 2026 was $12,000, versus an average of $9,500 over the previous three months.',
+      },
+    ];
+    render(<CashFlowNarrative insights={insights} />);
+
+    expect(screen.getByText('Revenue increased')).toBeInTheDocument();
+    expect(screen.getByText(/Money in for July 2026 was/)).toBeInTheDocument();
+  });
+
+  it('wraps a dollar amount in the body in a chip span', () => {
+    const insights: CashFlowInsight[] = [
+      {
+        id: 'revenue-change',
+        title: 'Revenue increased',
+        body: 'Money in for July 2026 was $12,000, versus an average of $9,500 over the previous three months.',
+      },
+    ];
+    render(<CashFlowNarrative insights={insights} />);
+
+    const chip = screen.getByText('$12,000');
+    expect(chip.className).toContain('bg-muted');
+    expect(chip.className).toContain('rounded-md');
+    expect(chip.className).toContain('px-1');
+  });
+
+  it('wraps the payee name in the body in a chip span for a top-source insight', () => {
+    const insights: CashFlowInsight[] = [
+      {
+        id: 'top-source-change',
+        title: 'Acme Distributors increased',
+        body: 'Acme Distributors brought in $5,000 last month, versus an average of $3,000 over the previous three months.',
+      },
+    ];
+    render(<CashFlowNarrative insights={insights} />);
+
+    const payeeChip = screen.getByText('Acme Distributors', { selector: 'span' });
+    expect(payeeChip.className).toContain('bg-muted');
+    expect(payeeChip.className).toContain('rounded-md');
+    expect(payeeChip.className).toContain('px-1');
+  });
+
+  it('always shows the trends caption', () => {
+    render(<CashFlowNarrative insights={[]} />);
+    expect(
+      screen.getByText('Trends are generated and may include inaccuracies.')
+    ).toBeInTheDocument();
+  });
+
+  it('shows a fallback line when there are no insights', () => {
+    render(<CashFlowNarrative insights={[]} />);
+    expect(screen.getByText(/No notable trends/)).toBeInTheDocument();
+  });
+});

--- a/tests/unit/CashFlowTab.test.tsx
+++ b/tests/unit/CashFlowTab.test.tsx
@@ -57,12 +57,10 @@ const period: Period = { type: 'month', from: new Date(2026, 0, 1), to: new Date
 const EMPTY_DATA: CashFlowInsightsData = {
   rows: [],
   aggregates: { totals: { moneyIn: 0, moneyOut: 0, net: 0 }, series: [] },
-  topCategories: [],
   sources: [],
   recipients: [],
   categoryBreakdownIn: [],
   categoryBreakdownOut: [],
-  sankey: { nodes: [], links: [] },
   insights: [],
   truncated: false,
 };

--- a/tests/unit/CashFlowTab.test.tsx
+++ b/tests/unit/CashFlowTab.test.tsx
@@ -12,6 +12,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { CashFlowTab } from '@/components/banking/CashFlowTab';
 import type { Period } from '@/components/PeriodSelector';
 import type { CashFlowInsightsData } from '@/hooks/useCashFlowInsights';
+import type { CashFlowRow, BreakdownRow, CashFlowInsight } from '@/lib/cashflowInsights';
 
 const mockUseCashFlowInsights = vi.hoisted(() => vi.fn());
 const mockRefetch = vi.hoisted(() => vi.fn());
@@ -66,23 +67,28 @@ const EMPTY_DATA: CashFlowInsightsData = {
 };
 
 function dataWithRows(overrides: Partial<CashFlowInsightsData> = {}): CashFlowInsightsData {
+  const row: CashFlowRow = {
+    transaction_date: '2026-01-05',
+    amount: 5000,
+    is_transfer: false,
+    normalized_payee: 'Client A',
+    merchant_name: null,
+    description: null,
+    category: null,
+  };
+  const source: BreakdownRow = { label: 'Client A', amount: 5000, pctOfTotal: 100 };
+  // moneyOut and BreakdownRow amounts for outflow stay negative, matching
+  // CashFlowRow's amount convention (negative = money out).
+  const recipient: BreakdownRow = { label: 'Vendor B', amount: -2000, pctOfTotal: 100 };
+  const insight: CashFlowInsight = { id: 'revenue-change', title: 'Revenue increased', body: 'Body' };
+
   return {
     ...EMPTY_DATA,
-    rows: [
-      {
-        transaction_date: '2026-01-05',
-        amount: 5000,
-        is_transfer: false,
-        normalized_payee: 'Client A',
-        merchant_name: null,
-        description: null,
-        category: null,
-      } as never,
-    ],
-    aggregates: { totals: { moneyIn: 5000, moneyOut: 2000, net: 3000 }, series: [] },
-    sources: [{ name: 'Client A', amount: 5000, pctOfTotal: 1 } as never],
-    recipients: [{ name: 'Vendor B', amount: 2000, pctOfTotal: 1 } as never],
-    insights: [{ id: 'revenue-change', title: 'Revenue increased', body: 'Body' } as never],
+    rows: [row],
+    aggregates: { totals: { moneyIn: 5000, moneyOut: -2000, net: 3000 }, series: [] },
+    sources: [source],
+    recipients: [recipient],
+    insights: [insight],
     ...overrides,
   };
 }
@@ -126,6 +132,14 @@ describe('CashFlowTab', () => {
     expect(screen.queryByTestId('headline')).not.toBeInTheDocument();
   });
 
+  it('keeps the brush visible in the empty state, so a user can brush back out', () => {
+    mockUseCashFlowInsights.mockReturnValue({ data: EMPTY_DATA, isLoading: false, error: null, refetch: mockRefetch });
+    const { onPeriodChange } = renderTab();
+    expect(screen.getByText(/no transactions/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByText('commit-brush'));
+    expect(onPeriodChange).toHaveBeenCalledTimes(1);
+  });
+
   it('shows one notice line when the hook reports truncated', () => {
     mockUseCashFlowInsights.mockReturnValue({
       data: dataWithRows({ truncated: true }),
@@ -160,7 +174,7 @@ describe('CashFlowTab', () => {
     expect(screen.getByTestId('narrative')).toHaveTextContent('insights:1');
     expect(screen.getByTestId('chart')).toHaveTextContent('rows:1');
     expect(screen.getByTestId('table-Money in')).toHaveTextContent('Money in:5000:Source');
-    expect(screen.getByTestId('table-Money out')).toHaveTextContent('Money out:2000:Recipient');
+    expect(screen.getByTestId('table-Money out')).toHaveTextContent('Money out:-2000:Recipient');
   });
 
   it('forwards a TimelineBrush commit to the onPeriodChange prop', () => {

--- a/tests/unit/CashFlowTab.test.tsx
+++ b/tests/unit/CashFlowTab.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * Behavioral tests for src/components/banking/CashFlowTab.tsx
+ *
+ * Pins the single-hook state gate (loading / error / empty / truncated /
+ * success) and the prop thread from CashFlowTab down to each cashflow
+ * child component, plus the onPeriodChange thread up from TimelineBrush.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { CashFlowTab } from '@/components/banking/CashFlowTab';
+import type { Period } from '@/components/PeriodSelector';
+import type { CashFlowInsightsData } from '@/hooks/useCashFlowInsights';
+
+const mockUseCashFlowInsights = vi.hoisted(() => vi.fn());
+const mockRefetch = vi.hoisted(() => vi.fn());
+
+vi.mock('@/hooks/useCashFlowInsights', () => ({
+  useCashFlowInsights: mockUseCashFlowInsights,
+}));
+
+vi.mock('@/components/banking/cashflow/TimelineBrush', () => ({
+  TimelineBrush: ({ onPeriodChange }: { onPeriodChange: (period: Period) => void }) =>
+    React.createElement(
+      'button',
+      {
+        onClick: () =>
+          onPeriodChange({ type: 'custom', from: new Date(2026, 0, 1), to: new Date(2026, 0, 31), label: 'Custom' }),
+      },
+      'commit-brush'
+    ),
+}));
+
+vi.mock('@/components/banking/cashflow/CashFlowHeadline', () => ({
+  CashFlowHeadline: ({ totals }: { totals: { net: number } }) =>
+    React.createElement('div', { 'data-testid': 'headline' }, `net:${totals.net}`),
+}));
+
+vi.mock('@/components/banking/cashflow/CashFlowNarrative', () => ({
+  CashFlowNarrative: ({ insights }: { insights: unknown[] }) =>
+    React.createElement('div', { 'data-testid': 'narrative' }, `insights:${insights.length}`),
+}));
+
+vi.mock('@/components/banking/cashflow/CashFlowChart', () => ({
+  CashFlowChart: ({ rows }: { rows: unknown[] }) =>
+    React.createElement('div', { 'data-testid': 'chart' }, `rows:${rows.length}`),
+}));
+
+vi.mock('@/components/banking/cashflow/MoneyBreakdownTable', () => ({
+  MoneyBreakdownTable: ({ title, total, primaryTabLabel }: { title: string; total: number; primaryTabLabel: string }) =>
+    React.createElement('div', { 'data-testid': `table-${title}` }, `${title}:${total}:${primaryTabLabel}`),
+}));
+
+const period: Period = { type: 'month', from: new Date(2026, 0, 1), to: new Date(2026, 0, 31), label: 'January' };
+
+const EMPTY_DATA: CashFlowInsightsData = {
+  rows: [],
+  aggregates: { totals: { moneyIn: 0, moneyOut: 0, net: 0 }, series: [] },
+  topCategories: [],
+  sources: [],
+  recipients: [],
+  categoryBreakdownIn: [],
+  categoryBreakdownOut: [],
+  sankey: { nodes: [], links: [] },
+  insights: [],
+  truncated: false,
+};
+
+function dataWithRows(overrides: Partial<CashFlowInsightsData> = {}): CashFlowInsightsData {
+  return {
+    ...EMPTY_DATA,
+    rows: [
+      {
+        transaction_date: '2026-01-05',
+        amount: 5000,
+        is_transfer: false,
+        normalized_payee: 'Client A',
+        merchant_name: null,
+        description: null,
+        category: null,
+      } as never,
+    ],
+    aggregates: { totals: { moneyIn: 5000, moneyOut: 2000, net: 3000 }, series: [] },
+    sources: [{ name: 'Client A', amount: 5000, pctOfTotal: 1 } as never],
+    recipients: [{ name: 'Vendor B', amount: 2000, pctOfTotal: 1 } as never],
+    insights: [{ id: 'revenue-change', title: 'Revenue increased', body: 'Body' } as never],
+    ...overrides,
+  };
+}
+
+function renderTab(onPeriodChange = vi.fn()) {
+  return { onPeriodChange, ...render(
+    <CashFlowTab selectedPeriod={period} selectedBankAccount="all" onPeriodChange={onPeriodChange} />
+  ) };
+}
+
+beforeEach(() => {
+  mockUseCashFlowInsights.mockReset();
+  mockRefetch.mockReset();
+});
+
+describe('CashFlowTab', () => {
+  it('shows a loading affordance and no data while the hook is loading', () => {
+    mockUseCashFlowInsights.mockReturnValue({ data: undefined, isLoading: true, error: null, refetch: mockRefetch });
+    renderTab();
+    expect(screen.getByRole('status', { name: /loading cash flow/i })).toBeInTheDocument();
+    expect(screen.queryByTestId('headline')).not.toBeInTheDocument();
+  });
+
+  it('shows one retry card on error and calls refetch on click', () => {
+    mockUseCashFlowInsights.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('network down'),
+      refetch: mockRefetch,
+    });
+    renderTab();
+    expect(screen.getByText('network down')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+    expect(mockRefetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows one empty state when the period has zero rows', () => {
+    mockUseCashFlowInsights.mockReturnValue({ data: EMPTY_DATA, isLoading: false, error: null, refetch: mockRefetch });
+    renderTab();
+    expect(screen.getByText(/no transactions/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('headline')).not.toBeInTheDocument();
+  });
+
+  it('shows one notice line when the hook reports truncated', () => {
+    mockUseCashFlowInsights.mockReturnValue({
+      data: dataWithRows({ truncated: true }),
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    });
+    renderTab();
+    expect(screen.getByText(/more transactions than we could load/i)).toBeInTheDocument();
+  });
+
+  it('does not show the truncated notice when the flag is false', () => {
+    mockUseCashFlowInsights.mockReturnValue({
+      data: dataWithRows({ truncated: false }),
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    });
+    renderTab();
+    expect(screen.queryByText(/more transactions than we could load/i)).not.toBeInTheDocument();
+  });
+
+  it('threads the hook data down to each child on success', () => {
+    mockUseCashFlowInsights.mockReturnValue({
+      data: dataWithRows(),
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    });
+    renderTab();
+    expect(screen.getByTestId('headline')).toHaveTextContent('net:3000');
+    expect(screen.getByTestId('narrative')).toHaveTextContent('insights:1');
+    expect(screen.getByTestId('chart')).toHaveTextContent('rows:1');
+    expect(screen.getByTestId('table-Money in')).toHaveTextContent('Money in:5000:Source');
+    expect(screen.getByTestId('table-Money out')).toHaveTextContent('Money out:2000:Recipient');
+  });
+
+  it('forwards a TimelineBrush commit to the onPeriodChange prop', () => {
+    mockUseCashFlowInsights.mockReturnValue({
+      data: dataWithRows(),
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    });
+    const { onPeriodChange } = renderTab();
+    fireEvent.click(screen.getByText('commit-brush'));
+    expect(onPeriodChange).toHaveBeenCalledTimes(1);
+    expect(onPeriodChange).toHaveBeenCalledWith(expect.objectContaining({ type: 'custom' }));
+  });
+});

--- a/tests/unit/MoneyBreakdownTable.test.tsx
+++ b/tests/unit/MoneyBreakdownTable.test.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MoneyBreakdownTable } from '@/components/banking/cashflow/MoneyBreakdownTable';
+import type { BreakdownRow } from '@/lib/cashflowInsights';
+
+const sourceRows: BreakdownRow[] = [
+  { label: 'Square Payouts', amount: 9000, pctOfTotal: 75 },
+  { label: 'Remaining', amount: 3000, pctOfTotal: 25 },
+];
+
+const categoryRows: BreakdownRow[] = [
+  { label: 'Sales', amount: 10000, pctOfTotal: 83 },
+  { label: 'Remaining', amount: 2000, pctOfTotal: 17 },
+];
+
+describe('MoneyBreakdownTable', () => {
+  it('shows the title and the formatted total', () => {
+    render(
+      <MoneyBreakdownTable
+        title="Money in"
+        total={12000}
+        primaryTabLabel="Source"
+        primaryRows={sourceRows}
+        categoryRows={categoryRows}
+      />,
+    );
+
+    expect(screen.getByText('Money in')).toBeInTheDocument();
+    expect(screen.getByText('$12,000')).toBeInTheDocument();
+  });
+
+  it('shows the Source and Category underline tabs, Source active by default', () => {
+    render(
+      <MoneyBreakdownTable
+        title="Money in"
+        total={12000}
+        primaryTabLabel="Source"
+        primaryRows={sourceRows}
+        categoryRows={categoryRows}
+      />,
+    );
+
+    const sourceTab = screen.getByRole('tab', { name: 'Source' });
+    const categoryTab = screen.getByRole('tab', { name: 'Category' });
+    expect(sourceTab).toHaveAttribute('aria-selected', 'true');
+    expect(categoryTab).toHaveAttribute('aria-selected', 'false');
+    expect(screen.getByText('Square Payouts')).toBeInTheDocument();
+  });
+
+  it('uses Recipient as the primary tab label for money out', () => {
+    render(
+      <MoneyBreakdownTable
+        title="Money out"
+        total={-11000}
+        primaryTabLabel="Recipient"
+        primaryRows={sourceRows}
+        categoryRows={categoryRows}
+      />,
+    );
+
+    expect(screen.getByRole('tab', { name: 'Recipient' })).toBeInTheDocument();
+  });
+
+  it('switches to the category rows when the Category tab is clicked', () => {
+    render(
+      <MoneyBreakdownTable
+        title="Money in"
+        total={12000}
+        primaryTabLabel="Source"
+        primaryRows={sourceRows}
+        categoryRows={categoryRows}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Category' }));
+
+    expect(screen.getByRole('tab', { name: 'Category' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByText('Sales')).toBeInTheDocument();
+    expect(screen.queryByText('Square Payouts')).not.toBeInTheDocument();
+  });
+
+  it('shows each row with its percent, a percent-of-total track, and a right-aligned amount', () => {
+    render(
+      <MoneyBreakdownTable
+        title="Money in"
+        total={12000}
+        primaryTabLabel="Source"
+        primaryRows={sourceRows}
+        categoryRows={categoryRows}
+      />,
+    );
+
+    expect(screen.getByText('75%')).toBeInTheDocument();
+    expect(screen.getByText('$9,000')).toBeInTheDocument();
+    const amount = screen.getByText('$9,000');
+    expect(amount.className).toContain('text-right');
+
+    const track = screen.getByTestId('breakdown-track-Square Payouts');
+    expect(track).toHaveStyle({ width: '75%' });
+  });
+
+  it('shows a Remaining row for the folded rest', () => {
+    render(
+      <MoneyBreakdownTable
+        title="Money in"
+        total={12000}
+        primaryTabLabel="Source"
+        primaryRows={sourceRows}
+        categoryRows={categoryRows}
+      />,
+    );
+
+    expect(screen.getByText('Remaining')).toBeInTheDocument();
+    expect(screen.getByText('25%')).toBeInTheDocument();
+  });
+
+  it('shows out-of-money amounts as a positive, formatted currency', () => {
+    const outRows: BreakdownRow[] = [{ label: 'Rent Co', amount: -5000, pctOfTotal: 100 }];
+    render(
+      <MoneyBreakdownTable
+        title="Money out"
+        total={-5000}
+        primaryTabLabel="Recipient"
+        primaryRows={outRows}
+        categoryRows={outRows}
+      />,
+    );
+
+    expect(screen.getAllByText('$5,000').length).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/MoneyBreakdownTable.test.tsx
+++ b/tests/unit/MoneyBreakdownTable.test.tsx
@@ -127,6 +127,9 @@ describe('MoneyBreakdownTable', () => {
       />,
     );
 
-    expect(screen.getAllByText('$5,000').length).toBeGreaterThan(0);
+    // One for the header total, one for the row amount.
+    expect(screen.getAllByText('$5,000')).toHaveLength(2);
+    const rowAmount = screen.getAllByText('$5,000').find((el) => el.className.includes('text-right'));
+    expect(rowAmount).toBeDefined();
   });
 });

--- a/tests/unit/TimelineBrush.test.tsx
+++ b/tests/unit/TimelineBrush.test.tsx
@@ -1,0 +1,185 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { startOfDay, endOfDay, subDays } from 'date-fns';
+import { TimelineBrush } from '@/components/banking/cashflow/TimelineBrush';
+import type { Period } from '@/components/PeriodSelector';
+
+function mockMatchMedia(matches: Record<string, boolean>) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: matches[query] ?? false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+function makePeriod(from: Date, to: Date): Period {
+  return {
+    type: 'custom',
+    from: startOfDay(from),
+    to: endOfDay(to),
+    label: 'custom',
+  };
+}
+
+describe('TimelineBrush', () => {
+  beforeEach(() => {
+    // Desktop by default: sm and lg both match.
+    mockMatchMedia({
+      '(min-width: 640px)': true,
+      '(min-width: 1024px)': true,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders a start and end thumb with the required aria-labels', () => {
+    const today = new Date();
+    render(
+      <TimelineBrush
+        selectedPeriod={makePeriod(subDays(today, 30), today)}
+        onPeriodChange={vi.fn()}
+      />
+    );
+
+    expect(screen.getByRole('slider', { name: 'Start date' })).toBeInTheDocument();
+    expect(screen.getByRole('slider', { name: 'End date' })).toBeInTheDocument();
+  });
+
+  it('gives both thumbs a 24px (h-6 w-6) target size', () => {
+    const today = new Date();
+    render(
+      <TimelineBrush
+        selectedPeriod={makePeriod(subDays(today, 30), today)}
+        onPeriodChange={vi.fn()}
+      />
+    );
+
+    for (const thumb of screen.getAllByRole('slider')) {
+      expect(thumb.className).toMatch(/\bh-6\b/);
+      expect(thumb.className).toMatch(/\bw-6\b/);
+    }
+  });
+
+  it('calls onPeriodChange with type "custom" when a thumb commits a new value', () => {
+    const today = new Date();
+    const onPeriodChange = vi.fn();
+    render(
+      <TimelineBrush
+        selectedPeriod={makePeriod(subDays(today, 30), today)}
+        onPeriodChange={onPeriodChange}
+      />
+    );
+
+    const endThumb = screen.getByRole('slider', { name: 'End date' });
+    endThumb.focus();
+    fireEvent.keyDown(endThumb, { key: 'ArrowLeft' });
+
+    expect(onPeriodChange).toHaveBeenCalled();
+    const [call] = onPeriodChange.mock.calls.at(-1)!;
+    expect(call.type).toBe('custom');
+    expect(call.from).toBeInstanceOf(Date);
+    expect(call.to).toBeInstanceOf(Date);
+  });
+
+  it('moves the thumbs when the period changes externally (e.g. a preset click)', () => {
+    const today = new Date();
+    const { rerender } = render(
+      <TimelineBrush
+        selectedPeriod={makePeriod(subDays(today, 30), today)}
+        onPeriodChange={vi.fn()}
+      />
+    );
+
+    const before = screen
+      .getByRole('slider', { name: 'Start date' })
+      .getAttribute('aria-valuenow');
+
+    rerender(
+      <TimelineBrush
+        selectedPeriod={makePeriod(subDays(today, 5), today)}
+        onPeriodChange={vi.fn()}
+      />
+    );
+
+    const after = screen
+      .getByRole('slider', { name: 'Start date' })
+      .getAttribute('aria-valuenow');
+
+    expect(after).not.toBe(before);
+  });
+
+  it('uses a one-day step at sm and above', () => {
+    const today = new Date();
+    render(
+      <TimelineBrush
+        selectedPeriod={makePeriod(subDays(today, 30), today)}
+        onPeriodChange={vi.fn()}
+      />
+    );
+
+    const startThumb = screen.getByRole('slider', { name: 'Start date' });
+    // Radix exposes the step via the underlying `step` attribute passed to Root,
+    // which shows up as aria-valuenow deltas; assert the wrapper's data attribute instead.
+    expect(startThumb.closest('[data-timeline-step]')?.getAttribute('data-timeline-step')).toBe(
+      '1'
+    );
+  });
+
+  it('uses a seven-day step below sm', () => {
+    mockMatchMedia({
+      '(min-width: 640px)': false,
+      '(min-width: 1024px)': false,
+    });
+    const today = new Date();
+    render(
+      <TimelineBrush
+        selectedPeriod={makePeriod(subDays(today, 30), today)}
+        onPeriodChange={vi.fn()}
+      />
+    );
+
+    const startThumb = screen.getByRole('slider', { name: 'Start date' });
+    expect(startThumb.closest('[data-timeline-step]')?.getAttribute('data-timeline-step')).toBe(
+      '7'
+    );
+  });
+
+  it('shows a tick for every month at lg and above', () => {
+    const today = new Date();
+    render(
+      <TimelineBrush
+        selectedPeriod={makePeriod(subDays(today, 30), today)}
+        onPeriodChange={vi.fn()}
+      />
+    );
+
+    const ticks = screen.getAllByTestId('timeline-brush-tick');
+    // 24-month domain -> every month shown means >= 20 ticks.
+    expect(ticks.length).toBeGreaterThanOrEqual(20);
+  });
+
+  it('thins ticks to every third month below lg', () => {
+    mockMatchMedia({
+      '(min-width: 640px)': true,
+      '(min-width: 1024px)': false,
+    });
+    const today = new Date();
+    render(
+      <TimelineBrush
+        selectedPeriod={makePeriod(subDays(today, 30), today)}
+        onPeriodChange={vi.fn()}
+      />
+    );
+
+    const ticks = screen.getAllByTestId('timeline-brush-tick');
+    expect(ticks.length).toBeLessThanOrEqual(10);
+  });
+});

--- a/tests/unit/TimelineBrush.test.tsx
+++ b/tests/unit/TimelineBrush.test.tsx
@@ -1,21 +1,27 @@
 import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { startOfDay, endOfDay, subDays } from 'date-fns';
+import { startOfDay, endOfDay, subDays, addDays } from 'date-fns';
 import { TimelineBrush } from '@/components/banking/cashflow/TimelineBrush';
 import type { Period } from '@/components/PeriodSelector';
 
 function mockMatchMedia(matches: Record<string, boolean>) {
-  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
-    matches: matches[query] ?? false,
-    media: query,
-    onchange: null,
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    addListener: vi.fn(),
-    removeListener: vi.fn(),
-    dispatchEvent: vi.fn(),
-  }));
+  // `restoreAllMocks` does not undo a direct `window.matchMedia =` assignment.
+  // Stub it through `vi.stubGlobal` so `vi.unstubAllGlobals()` in `afterEach`
+  // restores the original value between tests.
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockImplementation((query: string) => ({
+      matches: matches[query] ?? false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  );
 }
 
 function makePeriod(from: Date, to: Date): Period {
@@ -38,6 +44,7 @@ describe('TimelineBrush', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it('renders a start and end thumb with the required aria-labels', () => {
@@ -181,5 +188,42 @@ describe('TimelineBrush', () => {
 
     const ticks = screen.getAllByTestId('timeline-brush-tick');
     expect(ticks.length).toBeLessThanOrEqual(10);
+  });
+
+  it('includes the start year in the label when the range crosses a year boundary', () => {
+    const from = new Date(2026, 11, 20); // Dec 20, 2026
+    const to = new Date(2027, 0, 5); // Jan 5, 2027
+    const onPeriodChange = vi.fn();
+    render(<TimelineBrush selectedPeriod={makePeriod(from, to)} onPeriodChange={onPeriodChange} />);
+
+    const endThumb = screen.getByRole('slider', { name: 'End date' });
+    endThumb.focus();
+    fireEvent.keyDown(endThumb, { key: 'ArrowLeft' });
+
+    expect(onPeriodChange).toHaveBeenCalled();
+    const [call] = onPeriodChange.mock.calls.at(-1)!;
+    expect(call.label).toMatch(/^Dec 20, 2026 - /);
+  });
+
+  it('extends the domain to a future custom period end instead of clamping it to today', () => {
+    const today = new Date();
+    const futureTo = addDays(today, 10);
+    const onPeriodChange = vi.fn();
+    render(
+      <TimelineBrush
+        selectedPeriod={makePeriod(subDays(today, 5), futureTo)}
+        onPeriodChange={onPeriodChange}
+      />
+    );
+
+    // Move only the start thumb; the end thumb's index should already
+    // reflect the future end date, not a value clamped to today.
+    const startThumb = screen.getByRole('slider', { name: 'Start date' });
+    startThumb.focus();
+    fireEvent.keyDown(startThumb, { key: 'ArrowRight' });
+
+    expect(onPeriodChange).toHaveBeenCalled();
+    const [call] = onPeriodChange.mock.calls.at(-1)!;
+    expect(startOfDay(call.to).getTime()).toBe(startOfDay(futureTo).getTime());
   });
 });

--- a/tests/unit/TimelineBrush.test.tsx
+++ b/tests/unit/TimelineBrush.test.tsx
@@ -205,6 +205,32 @@ describe('TimelineBrush', () => {
     expect(call.label).toMatch(/^Dec 20, 2026 - /);
   });
 
+  it('exposes the thumb dates through aria-valuetext', () => {
+    const from = new Date(2026, 6, 1); // Jul 1, 2026
+    const to = new Date(2026, 7, 19); // Aug 19, 2026
+    render(<TimelineBrush selectedPeriod={makePeriod(from, to)} onPeriodChange={vi.fn()} />);
+
+    expect(screen.getByRole('slider', { name: 'Start date' })).toHaveAttribute(
+      'aria-valuetext',
+      'Jul 1, 2026'
+    );
+    expect(screen.getByRole('slider', { name: 'End date' })).toHaveAttribute(
+      'aria-valuetext',
+      'Aug 19, 2026'
+    );
+  });
+
+  it('renders a date bubble on each thumb with the thumb date', () => {
+    const from = new Date(2026, 6, 1); // Jul 1, 2026
+    const to = new Date(2026, 7, 19); // Aug 19, 2026
+    render(<TimelineBrush selectedPeriod={makePeriod(from, to)} onPeriodChange={vi.fn()} />);
+
+    const bubbles = screen.getAllByTestId('brush-thumb-date');
+    expect(bubbles).toHaveLength(2);
+    expect(bubbles[0]).toHaveTextContent('Jul 1, 2026');
+    expect(bubbles[1]).toHaveTextContent('Aug 19, 2026');
+  });
+
   it('extends the domain to a future custom period end instead of clamping it to today', () => {
     const today = new Date();
     const futureTo = addDays(today, 10);

--- a/tests/unit/cashflowInsights.test.ts
+++ b/tests/unit/cashflowInsights.test.ts
@@ -33,7 +33,7 @@ describe('defaultInterval', () => {
   });
 
   it('returns week for periods between 32 and 120 days', () => {
-    expect(defaultInterval(period('2026-05-01', '2026-08-31'))).toBe('week');
+    expect(defaultInterval(period('2026-06-01', '2026-08-31'))).toBe('week');
   });
 
   it('returns month for periods above 120 days', () => {

--- a/tests/unit/cashflowInsights.test.ts
+++ b/tests/unit/cashflowInsights.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from 'vitest';
+import {
+  defaultInterval,
+  computeTotals,
+  bucketSeries,
+  type CashFlowRow,
+  type CashFlowPeriod,
+} from '@/lib/cashflowInsights';
+
+function makeRow(overrides: Partial<CashFlowRow>): CashFlowRow {
+  return {
+    transaction_date: '2026-08-01',
+    amount: 100,
+    is_transfer: false,
+    normalized_payee: 'Acme Foods',
+    merchant_name: null,
+    description: null,
+    category: { id: 'cat-1', name: 'Food' },
+    ...overrides,
+  };
+}
+
+function period(fromStr: string, toStr: string): CashFlowPeriod {
+  const [fy, fm, fd] = fromStr.split('-').map(Number);
+  const [ty, tm, td] = toStr.split('-').map(Number);
+  return { from: new Date(fy, fm - 1, fd), to: new Date(ty, tm - 1, td) };
+}
+
+describe('defaultInterval', () => {
+  it('returns day for periods up to 31 days', () => {
+    expect(defaultInterval(period('2026-08-01', '2026-08-31'))).toBe('day');
+    expect(defaultInterval(period('2026-08-01', '2026-08-01'))).toBe('day');
+  });
+
+  it('returns week for periods between 32 and 120 days', () => {
+    expect(defaultInterval(period('2026-05-01', '2026-08-31'))).toBe('week');
+  });
+
+  it('returns month for periods above 120 days', () => {
+    expect(defaultInterval(period('2025-01-01', '2026-08-01'))).toBe('month');
+  });
+});
+
+describe('computeTotals', () => {
+  it('sums money in, money out, and net', () => {
+    const rows = [
+      makeRow({ amount: 500 }),
+      makeRow({ amount: -200 }),
+      makeRow({ amount: -50 }),
+    ];
+
+    const totals = computeTotals(rows);
+
+    expect(totals.moneyIn).toBe(500);
+    expect(totals.moneyOut).toBe(-250);
+    expect(totals.net).toBe(250);
+  });
+
+  it('drops transfer rows when excludeTransfers is set', () => {
+    const rows = [
+      makeRow({ amount: 500 }),
+      makeRow({ amount: -300, is_transfer: true }),
+      makeRow({ amount: -50 }),
+    ];
+
+    const totals = computeTotals(rows, { excludeTransfers: true });
+
+    expect(totals.moneyIn).toBe(500);
+    expect(totals.moneyOut).toBe(-50);
+    expect(totals.net).toBe(450);
+  });
+
+  it('keeps transfer rows when excludeTransfers is not set', () => {
+    const rows = [makeRow({ amount: 500 }), makeRow({ amount: -300, is_transfer: true })];
+
+    const totals = computeTotals(rows);
+
+    expect(totals.moneyIn).toBe(500);
+    expect(totals.moneyOut).toBe(-300);
+    expect(totals.net).toBe(200);
+  });
+
+  it('returns zero totals for an empty row list', () => {
+    const totals = computeTotals([]);
+
+    expect(totals).toEqual({ moneyIn: 0, moneyOut: 0, net: 0 });
+  });
+});
+
+describe('bucketSeries', () => {
+  it('groups rows into day buckets with per-category signed sums', () => {
+    const rows = [
+      makeRow({ transaction_date: '2026-08-01', amount: 100, category: { id: 'c1', name: 'Food' } }),
+      makeRow({ transaction_date: '2026-08-01', amount: -30, category: { id: 'c2', name: 'Rent' } }),
+      makeRow({ transaction_date: '2026-08-02', amount: 50, category: { id: 'c1', name: 'Food' } }),
+    ];
+
+    const buckets = bucketSeries(rows, period('2026-08-01', '2026-08-02'), 'day');
+
+    expect(buckets).toHaveLength(2);
+    expect(buckets[0]).toEqual({
+      bucketStart: '2026-08-01',
+      moneyIn: 100,
+      moneyOut: -30,
+      byCategory: { Food: 100, Rent: -30 },
+    });
+    expect(buckets[1]).toEqual({
+      bucketStart: '2026-08-02',
+      moneyIn: 50,
+      moneyOut: 0,
+      byCategory: { Food: 50 },
+    });
+  });
+
+  it('folds transfer rows into a Transfers category', () => {
+    const rows = [makeRow({ amount: -75, is_transfer: true, category: { id: 'c1', name: 'Food' } })];
+
+    const buckets = bucketSeries(rows, period('2026-08-01', '2026-08-01'), 'day');
+
+    expect(buckets[0].byCategory).toEqual({ Transfers: -75 });
+  });
+
+  it('folds rows with no category into Uncategorized', () => {
+    const rows = [makeRow({ amount: 40, category: null })];
+
+    const buckets = bucketSeries(rows, period('2026-08-01', '2026-08-01'), 'day');
+
+    expect(buckets[0].byCategory).toEqual({ Uncategorized: 40 });
+  });
+
+  it('excludes rows outside the period', () => {
+    const rows = [
+      makeRow({ transaction_date: '2026-07-31', amount: 999 }),
+      makeRow({ transaction_date: '2026-08-01', amount: 10 }),
+      makeRow({ transaction_date: '2026-08-03', amount: 999 }),
+    ];
+
+    const buckets = bucketSeries(rows, period('2026-08-01', '2026-08-01'), 'day');
+
+    expect(buckets).toHaveLength(1);
+    expect(buckets[0].moneyIn).toBe(10);
+  });
+
+  it('groups rows into week buckets starting on Monday', () => {
+    const rows = [
+      // Monday 2026-08-03 and Wednesday 2026-08-05 fall in the same ISO week.
+      makeRow({ transaction_date: '2026-08-03', amount: 100 }),
+      makeRow({ transaction_date: '2026-08-05', amount: 20 }),
+      // Monday 2026-08-10 starts the next week.
+      makeRow({ transaction_date: '2026-08-10', amount: 5 }),
+    ];
+
+    const buckets = bucketSeries(rows, period('2026-08-03', '2026-08-10'), 'week');
+
+    expect(buckets).toHaveLength(2);
+    expect(buckets[0]).toMatchObject({ bucketStart: '2026-08-03', moneyIn: 120 });
+    expect(buckets[1]).toMatchObject({ bucketStart: '2026-08-10', moneyIn: 5 });
+  });
+
+  it('groups rows into month buckets', () => {
+    const rows = [
+      makeRow({ transaction_date: '2026-06-15', amount: 100 }),
+      makeRow({ transaction_date: '2026-06-28', amount: -40 }),
+      makeRow({ transaction_date: '2026-07-02', amount: 60 }),
+    ];
+
+    const buckets = bucketSeries(rows, period('2026-06-01', '2026-07-31'), 'month');
+
+    expect(buckets).toHaveLength(2);
+    expect(buckets[0]).toMatchObject({ bucketStart: '2026-06-01', moneyIn: 100, moneyOut: -40 });
+    expect(buckets[1]).toMatchObject({ bucketStart: '2026-07-01', moneyIn: 60, moneyOut: 0 });
+  });
+
+  it('returns an empty series for an empty row list', () => {
+    const buckets = bucketSeries([], period('2026-08-01', '2026-08-31'), 'day');
+
+    expect(buckets).toEqual([]);
+  });
+});

--- a/tests/unit/cashflowInsights.test.ts
+++ b/tests/unit/cashflowInsights.test.ts
@@ -47,7 +47,7 @@ describe('defaultInterval', () => {
 });
 
 describe('computeTotals', () => {
-  it('sums money in, money out, and net', () => {
+  it('CRITICAL: sums money in, money out, and net', () => {
     const rows = [
       makeRow({ amount: 500 }),
       makeRow({ amount: -200 }),
@@ -258,6 +258,23 @@ describe('topCategories', () => {
   it('returns an empty list for an empty row list', () => {
     expect(topCategories([])).toEqual([]);
   });
+
+  it('folds the remainder into a real category already named Other', () => {
+    const rows = [
+      makeRow({ amount: 500, category: { id: 'c1', name: 'A' } }),
+      makeRow({ amount: -400, category: { id: 'c2', name: 'B' } }),
+      makeRow({ amount: 300, category: { id: 'c3', name: 'C' } }),
+      makeRow({ amount: -200, category: { id: 'c4', name: 'D' } }),
+      makeRow({ amount: 190, category: { id: 'c5', name: 'Other' } }),
+      makeRow({ amount: -50, category: { id: 'c6', name: 'F' } }),
+      makeRow({ amount: -10, category: { id: 'c7', name: 'G' } }),
+    ];
+
+    const result = topCategories(rows);
+
+    // Exactly one 'Other' entry — the real category plus the folded rest.
+    expect(result.filter((entry) => entry.name === 'Other')).toEqual([{ name: 'Other', amount: 130 }]);
+  });
 });
 
 describe('breakdown', () => {
@@ -437,6 +454,22 @@ describe('computeInsights', () => {
     expect(revenue?.body).toContain('July 2026');
     expect(revenue?.body).toContain('$1,500');
     expect(revenue?.body).toContain('$1,000');
+  });
+
+  it('reports "stayed flat" when last month exactly matches the preceding mean', () => {
+    const rows = [
+      inflowRow('2026-04-15', 'Client A', 1000),
+      inflowRow('2026-05-15', 'Client A', 1000),
+      inflowRow('2026-06-15', 'Client A', 1000),
+      inflowRow('2026-07-15', 'Client A', 1000),
+    ];
+
+    const insights = computeInsights(rows, period('2026-01-01', '2026-07-31'));
+
+    const revenue = insights.find((i) => i.id === 'revenue-change');
+    // A zero delta is neither growth nor decline, so the title must say
+    // neither "increased" nor "decreased".
+    expect(revenue?.title).toBe('Revenue stayed flat');
   });
 
   it('emits a top-source insight only when the delta is 20% or more', () => {

--- a/tests/unit/cashflowInsights.test.ts
+++ b/tests/unit/cashflowInsights.test.ts
@@ -279,6 +279,25 @@ describe('topCategories', () => {
     // Exactly one 'Other' entry — the real category plus the folded rest.
     expect(result.filter((entry) => entry.name === 'Other')).toEqual([{ name: 'Other', amount: 130 }]);
   });
+
+  it('folds the remainder into a real category named other in lower case', () => {
+    const rows = [
+      makeRow({ amount: 500, category: { id: 'c1', name: 'A', account_type: 'expense', account_subtype: null } }),
+      makeRow({ amount: -400, category: { id: 'c2', name: 'B', account_type: 'expense', account_subtype: null } }),
+      makeRow({ amount: 300, category: { id: 'c3', name: 'C', account_type: 'expense', account_subtype: null } }),
+      makeRow({ amount: -200, category: { id: 'c4', name: 'D', account_type: 'expense', account_subtype: null } }),
+      makeRow({ amount: 190, category: { id: 'c5', name: 'other', account_type: 'expense', account_subtype: null } }),
+      makeRow({ amount: -50, category: { id: 'c6', name: 'F', account_type: 'expense', account_subtype: null } }),
+      makeRow({ amount: -10, category: { id: 'c7', name: 'G', account_type: 'expense', account_subtype: null } }),
+    ];
+
+    const result = topCategories(rows);
+
+    // One entry only, with the first-seen label 'other'.
+    expect(result.filter((entry) => entry.name.toUpperCase() === 'OTHER')).toEqual([
+      { name: 'other', amount: 130 },
+    ]);
+  });
 });
 
 describe('breakdown', () => {

--- a/tests/unit/cashflowInsights.test.ts
+++ b/tests/unit/cashflowInsights.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect } from 'vitest';
 import {
   defaultInterval,
   computeTotals,
+  computeCashFlowAggregates,
   bucketSeries,
+  dayKeyOf,
+  formatCompactCurrency,
+  isInternalTransfer,
   payeeFor,
   topCategories,
   breakdown,
@@ -20,7 +24,7 @@ function makeRow(overrides: Partial<CashFlowRow>): CashFlowRow {
     normalized_payee: 'Acme Foods',
     merchant_name: null,
     description: null,
-    category: { id: 'cat-1', name: 'Food' },
+    category: { id: 'cat-1', name: 'Food', account_type: 'expense', account_subtype: null },
     ...overrides,
   };
 }
@@ -95,9 +99,9 @@ describe('computeTotals', () => {
 describe('bucketSeries', () => {
   it('groups rows into day buckets with per-category signed sums', () => {
     const rows = [
-      makeRow({ transaction_date: '2026-08-01', amount: 100, category: { id: 'c1', name: 'Food' } }),
-      makeRow({ transaction_date: '2026-08-01', amount: -30, category: { id: 'c2', name: 'Rent' } }),
-      makeRow({ transaction_date: '2026-08-02', amount: 50, category: { id: 'c1', name: 'Food' } }),
+      makeRow({ transaction_date: '2026-08-01', amount: 100, category: { id: 'c1', name: 'Food', account_type: 'expense', account_subtype: null } }),
+      makeRow({ transaction_date: '2026-08-01', amount: -30, category: { id: 'c2', name: 'Rent', account_type: 'expense', account_subtype: null } }),
+      makeRow({ transaction_date: '2026-08-02', amount: 50, category: { id: 'c1', name: 'Food', account_type: 'expense', account_subtype: null } }),
     ];
 
     const buckets = bucketSeries(rows, period('2026-08-01', '2026-08-02'), 'day');
@@ -118,7 +122,7 @@ describe('bucketSeries', () => {
   });
 
   it('folds transfer rows into a Transfers category', () => {
-    const rows = [makeRow({ amount: -75, is_transfer: true, category: { id: 'c1', name: 'Food' } })];
+    const rows = [makeRow({ amount: -75, is_transfer: true, category: { id: 'c1', name: 'Food', account_type: 'expense', account_subtype: null } })];
 
     const buckets = bucketSeries(rows, period('2026-08-01', '2026-08-01'), 'day');
 
@@ -212,8 +216,8 @@ describe('payeeFor', () => {
 describe('topCategories', () => {
   it('returns every category signed sum when there are 5 or fewer', () => {
     const rows = [
-      makeRow({ amount: 100, category: { id: 'c1', name: 'Food' } }),
-      makeRow({ amount: -50, category: { id: 'c2', name: 'Rent' } }),
+      makeRow({ amount: 100, category: { id: 'c1', name: 'Food', account_type: 'expense', account_subtype: null } }),
+      makeRow({ amount: -50, category: { id: 'c2', name: 'Rent', account_type: 'expense', account_subtype: null } }),
     ];
 
     expect(topCategories(rows)).toEqual([
@@ -224,13 +228,13 @@ describe('topCategories', () => {
 
   it('folds categories beyond the top 5 by absolute sum into Other', () => {
     const rows = [
-      makeRow({ amount: 500, category: { id: 'c1', name: 'A' } }),
-      makeRow({ amount: -400, category: { id: 'c2', name: 'B' } }),
-      makeRow({ amount: 300, category: { id: 'c3', name: 'C' } }),
-      makeRow({ amount: -200, category: { id: 'c4', name: 'D' } }),
-      makeRow({ amount: 100, category: { id: 'c5', name: 'E' } }),
-      makeRow({ amount: -50, category: { id: 'c6', name: 'F' } }),
-      makeRow({ amount: -10, category: { id: 'c7', name: 'G' } }),
+      makeRow({ amount: 500, category: { id: 'c1', name: 'A', account_type: 'expense', account_subtype: null } }),
+      makeRow({ amount: -400, category: { id: 'c2', name: 'B', account_type: 'expense', account_subtype: null } }),
+      makeRow({ amount: 300, category: { id: 'c3', name: 'C', account_type: 'expense', account_subtype: null } }),
+      makeRow({ amount: -200, category: { id: 'c4', name: 'D', account_type: 'expense', account_subtype: null } }),
+      makeRow({ amount: 100, category: { id: 'c5', name: 'E', account_type: 'expense', account_subtype: null } }),
+      makeRow({ amount: -50, category: { id: 'c6', name: 'F', account_type: 'expense', account_subtype: null } }),
+      makeRow({ amount: -10, category: { id: 'c7', name: 'G', account_type: 'expense', account_subtype: null } }),
     ];
 
     expect(topCategories(rows)).toEqual([
@@ -244,7 +248,7 @@ describe('topCategories', () => {
   });
 
   it('folds transfer rows into Transfers', () => {
-    const rows = [makeRow({ amount: -75, is_transfer: true, category: { id: 'c1', name: 'Food' } })];
+    const rows = [makeRow({ amount: -75, is_transfer: true, category: { id: 'c1', name: 'Food', account_type: 'expense', account_subtype: null } })];
 
     expect(topCategories(rows)).toEqual([{ name: 'Transfers', amount: -75 }]);
   });
@@ -261,13 +265,13 @@ describe('topCategories', () => {
 
   it('folds the remainder into a real category already named Other', () => {
     const rows = [
-      makeRow({ amount: 500, category: { id: 'c1', name: 'A' } }),
-      makeRow({ amount: -400, category: { id: 'c2', name: 'B' } }),
-      makeRow({ amount: 300, category: { id: 'c3', name: 'C' } }),
-      makeRow({ amount: -200, category: { id: 'c4', name: 'D' } }),
-      makeRow({ amount: 190, category: { id: 'c5', name: 'Other' } }),
-      makeRow({ amount: -50, category: { id: 'c6', name: 'F' } }),
-      makeRow({ amount: -10, category: { id: 'c7', name: 'G' } }),
+      makeRow({ amount: 500, category: { id: 'c1', name: 'A', account_type: 'expense', account_subtype: null } }),
+      makeRow({ amount: -400, category: { id: 'c2', name: 'B', account_type: 'expense', account_subtype: null } }),
+      makeRow({ amount: 300, category: { id: 'c3', name: 'C', account_type: 'expense', account_subtype: null } }),
+      makeRow({ amount: -200, category: { id: 'c4', name: 'D', account_type: 'expense', account_subtype: null } }),
+      makeRow({ amount: 190, category: { id: 'c5', name: 'Other', account_type: 'expense', account_subtype: null } }),
+      makeRow({ amount: -50, category: { id: 'c6', name: 'F', account_type: 'expense', account_subtype: null } }),
+      makeRow({ amount: -10, category: { id: 'c7', name: 'G', account_type: 'expense', account_subtype: null } }),
     ];
 
     const result = topCategories(rows);
@@ -293,9 +297,9 @@ describe('breakdown', () => {
 
   it('groups money-out rows by category with pctOfTotal, dropping inflows', () => {
     const rows = [
-      makeRow({ amount: -300, category: { id: 'c1', name: 'Rent' } }),
-      makeRow({ amount: -100, category: { id: 'c2', name: 'Food' } }),
-      makeRow({ amount: 200, category: { id: 'c1', name: 'Rent' } }),
+      makeRow({ amount: -300, category: { id: 'c1', name: 'Rent', account_type: 'expense', account_subtype: null } }),
+      makeRow({ amount: -100, category: { id: 'c2', name: 'Food', account_type: 'expense', account_subtype: null } }),
+      makeRow({ amount: 200, category: { id: 'c1', name: 'Rent', account_type: 'expense', account_subtype: null } }),
     ];
 
     expect(breakdown(rows, 'out', 'category')).toEqual([
@@ -519,5 +523,174 @@ describe('computeInsights', () => {
 
     expect(julyAnchored.find((i) => i.id === 'revenue-change')?.body).toContain('July 2026');
     expect(juneAnchored.find((i) => i.id === 'revenue-change')?.body).toContain('June 2026');
+  });
+});
+
+describe('isInternalTransfer', () => {
+  it('returns true for a row with the is_transfer flag', () => {
+    expect(isInternalTransfer(makeRow({ is_transfer: true, category: null }))).toBe(true);
+  });
+
+  it('CRITICAL: returns true for an unflagged row in a non-P&L cash account', () => {
+    // Production: categorize_bank_transaction assigns "Transfer Clearing
+    // Account" (asset/cash) without setting is_transfer.
+    const row = makeRow({
+      is_transfer: false,
+      category: { id: 'c1', name: 'Transfer Clearing Account', account_type: 'asset', account_subtype: 'cash' },
+    });
+
+    expect(isInternalTransfer(row)).toBe(true);
+  });
+
+  it('returns true for a non-P&L account with "transfer" in its name', () => {
+    const row = makeRow({
+      is_transfer: false,
+      category: { id: 'c2', name: 'Inter-Account Transfer', account_type: 'equity', account_subtype: 'owners_equity' },
+    });
+
+    expect(isInternalTransfer(row)).toBe(true);
+  });
+
+  it('CRITICAL: returns false for real external non-P&L cash movement', () => {
+    // An owner contribution, a loan payment, and an equipment purchase are
+    // non-P&L, but they are real money in or out.
+    const contribution = makeRow({
+      category: { id: 'c3', name: 'Owner Contributions', account_type: 'equity', account_subtype: 'owners_equity' },
+    });
+    const loan = makeRow({
+      category: { id: 'c4', name: 'SBA Loan Payable', account_type: 'liability', account_subtype: null },
+    });
+    const equipment = makeRow({
+      category: { id: 'c5', name: 'Kitchen Equipment', account_type: 'asset', account_subtype: 'fixed_assets' },
+    });
+
+    expect(isInternalTransfer(contribution)).toBe(false);
+    expect(isInternalTransfer(loan)).toBe(false);
+    expect(isInternalTransfer(equipment)).toBe(false);
+  });
+
+  it('returns false for a P&L row and for an uncategorized row', () => {
+    expect(isInternalTransfer(makeRow({}))).toBe(false);
+    expect(isInternalTransfer(makeRow({ category: null }))).toBe(false);
+  });
+});
+
+describe('dayKeyOf', () => {
+  it('returns a bare date key unchanged', () => {
+    expect(dayKeyOf('2026-08-19')).toBe('2026-08-19');
+  });
+
+  it('CRITICAL: strips the time from a timestamptz ISO string', () => {
+    expect(dayKeyOf('2026-08-19T12:47:12+00:00')).toBe('2026-08-19');
+    expect(dayKeyOf('2026-08-19T00:00:00.000Z')).toBe('2026-08-19');
+  });
+});
+
+describe('bucketSeries with timestamptz dates', () => {
+  it('CRITICAL: buckets a full ISO timestamp by its date, not by local time parsing', () => {
+    const rows = [makeRow({ transaction_date: '2026-08-01T23:30:00+00:00', amount: 10 })];
+
+    const buckets = bucketSeries(rows, period('2026-08-01', '2026-08-01'), 'day');
+
+    expect(buckets).toHaveLength(1);
+    expect(buckets[0]).toMatchObject({ bucketStart: '2026-08-01', moneyIn: 10 });
+  });
+});
+
+describe('payeeFor with bank-format descriptions', () => {
+  it('CRITICAL: keeps the first segment of a semicolon description', () => {
+    const row = makeRow({
+      normalized_payee: null,
+      merchant_name: null,
+      description: 'SYGMA Network; Payment; CAMILUKE FLAVORS LLC - The SYGMA Net',
+    });
+
+    expect(payeeFor(row)).toBe('SYGMA Network');
+  });
+
+  it('collapses repeated whitespace inside the payee', () => {
+    const row = makeRow({ normalized_payee: null, merchant_name: null, description: '  OLO   #  24329  ; deposit' });
+
+    expect(payeeFor(row)).toBe('OLO # 24329');
+  });
+
+  it('returns Unknown for a description that is only separators', () => {
+    const row = makeRow({ normalized_payee: null, merchant_name: null, description: ' ; Payment' });
+
+    expect(payeeFor(row)).toBe('Unknown');
+  });
+});
+
+describe('breakdown case folding', () => {
+  it('CRITICAL: groups case variants of one payee into one row', () => {
+    const rows = [
+      makeRow({ amount: 100, normalized_payee: 'OLO # 24329' }),
+      makeRow({ amount: 50, normalized_payee: 'Olo # 24329' }),
+    ];
+
+    const result = breakdown(rows, 'in', 'payee');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].label).toBe('OLO # 24329');
+    expect(result[0].amount).toBe(150);
+  });
+});
+
+describe('breakdown transfer exclusion', () => {
+  it('excludes unflagged clearing-account rows', () => {
+    const rows = [
+      makeRow({ amount: 500, normalized_payee: 'Client A' }),
+      makeRow({
+        amount: 400,
+        normalized_payee: 'Sweep',
+        category: { id: 'c9', name: 'Transfer Clearing Account', account_type: 'asset', account_subtype: 'cash' },
+      }),
+    ];
+
+    const result = breakdown(rows, 'in', 'payee');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].label).toBe('Client A');
+  });
+});
+
+describe('formatCompactCurrency', () => {
+  it('formats thousands and millions in short form', () => {
+    expect(formatCompactCurrency(48000)).toBe('$48K');
+    expect(formatCompactCurrency(1200000)).toBe('$1.2M');
+    expect(formatCompactCurrency(-2500)).toBe('-$2.5K');
+    expect(formatCompactCurrency(0)).toBe('$0');
+  });
+});
+
+describe('computeCashFlowAggregates', () => {
+  it('CRITICAL: drops internal transfers from totals and series when excludeTransfers is set', () => {
+    const rows = [
+      makeRow({ transaction_date: '2026-08-01', amount: 500 }),
+      makeRow({
+        transaction_date: '2026-08-01',
+        amount: -400,
+        is_transfer: false,
+        category: { id: 'c9', name: 'Transfer Clearing Account', account_type: 'asset', account_subtype: 'cash' },
+      }),
+    ];
+
+    const aggregates = computeCashFlowAggregates(rows, period('2026-08-01', '2026-08-01'), 'day', {
+      excludeTransfers: true,
+    });
+
+    expect(aggregates.totals).toEqual({ moneyIn: 500, moneyOut: 0, net: 500 });
+    expect(aggregates.series[0].byCategory).toEqual({ Food: 500 });
+  });
+
+  it('keeps internal transfers when excludeTransfers is not set', () => {
+    const rows = [
+      makeRow({ transaction_date: '2026-08-01', amount: 500 }),
+      makeRow({ transaction_date: '2026-08-01', amount: -400, is_transfer: true }),
+    ];
+
+    const aggregates = computeCashFlowAggregates(rows, period('2026-08-01', '2026-08-01'), 'day');
+
+    expect(aggregates.totals).toEqual({ moneyIn: 500, moneyOut: -400, net: 100 });
   });
 });

--- a/tests/unit/cashflowInsights.test.ts
+++ b/tests/unit/cashflowInsights.test.ts
@@ -6,6 +6,7 @@ import {
   bucketSeries,
   dayKeyOf,
   formatCompactCurrency,
+  formatPercentOfTotal,
   isInternalTransfer,
   payeeFor,
   topCategories,
@@ -448,8 +449,24 @@ describe('computeInsights', () => {
 
     expect(insights).toContainEqual({
       id: 'subscriptions',
-      title: '1 notable transaction',
-      body: 'We noticed 1 subscription you may want to review',
+      title: '1 recurring charge',
+      body: 'A steady monthly charge in the last 90 days: Netflix ($15.99).',
+    });
+  });
+
+  it('names every recurring payee with its mean charge, largest first', () => {
+    const rows = [
+      ...subscriptionCharges('Netflix', ['2026-06-01', '2026-07-01', '2026-08-01'], 15.99),
+      ...subscriptionCharges('Adobe', ['2026-06-03', '2026-07-03', '2026-08-03'], 54.99),
+      ...subscriptionCharges('Hosting Co', ['2026-06-05', '2026-07-05', '2026-08-05'], 20),
+    ];
+
+    const insights = computeInsights(rows, period('2026-08-01', '2026-08-19'));
+
+    expect(insights).toContainEqual({
+      id: 'subscriptions',
+      title: '3 recurring charges',
+      body: 'Steady monthly charges in the last 90 days: Adobe ($54.99), Hosting Co ($20), and Netflix ($15.99).',
     });
   });
 
@@ -711,5 +728,29 @@ describe('computeCashFlowAggregates', () => {
     const aggregates = computeCashFlowAggregates(rows, period('2026-08-01', '2026-08-01'), 'day');
 
     expect(aggregates.totals).toEqual({ moneyIn: 500, moneyOut: -400, net: 100 });
+  });
+});
+
+describe('formatPercentOfTotal', () => {
+  it('rounds to a whole percent, the same as the breakdown tables', () => {
+    expect(formatPercentOfTotal(2000, 4800)).toBe('42%');
+    expect(formatPercentOfTotal(1200, 4800)).toBe('25%');
+  });
+
+  it('uses the absolute amount, so an outflow shares the same scale', () => {
+    expect(formatPercentOfTotal(-2000, 4800)).toBe('42%');
+  });
+
+  it('shows "<1%" for a small non-zero share instead of "0%"', () => {
+    expect(formatPercentOfTotal(1, 1000)).toBe('<1%');
+  });
+
+  it('shows "0%" for a zero amount', () => {
+    expect(formatPercentOfTotal(0, 1000)).toBe('0%');
+  });
+
+  it('returns an empty string when the total is not positive', () => {
+    expect(formatPercentOfTotal(100, 0)).toBe('');
+    expect(formatPercentOfTotal(100, -50)).toBe('');
   });
 });

--- a/tests/unit/cashflowInsights.test.ts
+++ b/tests/unit/cashflowInsights.test.ts
@@ -6,6 +6,7 @@ import {
   payeeFor,
   topCategories,
   breakdown,
+  buildSankey,
   type CashFlowRow,
   type CashFlowPeriod,
 } from '@/lib/cashflowInsights';
@@ -298,5 +299,73 @@ describe('breakdown', () => {
     const rows = [makeRow({ amount: 100 })];
 
     expect(breakdown(rows, 'out', 'payee')).toEqual([]);
+  });
+});
+
+describe('buildSankey', () => {
+  it('builds left payees + Transfers in, a Money in center, and right payees + Transfers out + Net savings', () => {
+    const rows = [
+      makeRow({ amount: 300, normalized_payee: 'Client A' }),
+      makeRow({ amount: 200, normalized_payee: 'Client B' }),
+      makeRow({ amount: 50, normalized_payee: 'Bank Transfer', is_transfer: true }),
+      makeRow({ amount: -120, normalized_payee: 'Vendor X' }),
+      makeRow({ amount: -80, normalized_payee: 'Vendor Y' }),
+      makeRow({ amount: -30, normalized_payee: 'Bank Transfer', is_transfer: true }),
+    ];
+
+    const sankey = buildSankey(rows);
+
+    expect(sankey.nodes).toEqual([
+      { name: 'Money in' },
+      { name: 'Client A' },
+      { name: 'Client B' },
+      { name: 'Transfers in' },
+      { name: 'Vendor X' },
+      { name: 'Vendor Y' },
+      { name: 'Transfers out' },
+      { name: 'Net savings' },
+    ]);
+    expect(sankey.links).toEqual([
+      { source: 1, target: 0, value: 300 },
+      { source: 2, target: 0, value: 200 },
+      { source: 3, target: 0, value: 50 },
+      { source: 0, target: 4, value: 120 },
+      { source: 0, target: 5, value: 80 },
+      { source: 0, target: 6, value: 30 },
+      { source: 0, target: 7, value: 320 },
+    ]);
+  });
+
+  it('folds payees beyond the top five into Other income and Other expenses', () => {
+    const rows = [
+      ...Array.from({ length: 7 }, (_, i) => makeRow({ amount: 100 - i * 5, normalized_payee: `Client ${i}` })),
+      ...Array.from({ length: 7 }, (_, i) => makeRow({ amount: -(90 - i * 5), normalized_payee: `Vendor ${i}` })),
+    ];
+
+    const sankey = buildSankey(rows);
+
+    expect(sankey.nodes.map((n) => n.name)).toContain('Other income');
+    expect(sankey.nodes.map((n) => n.name)).toContain('Other expenses');
+  });
+
+  it('conserves flow: the sum of left links equals the sum of right links', () => {
+    const rows = [
+      makeRow({ amount: 400, normalized_payee: 'Client A' }),
+      makeRow({ amount: 250, normalized_payee: 'Client B' }),
+      makeRow({ amount: 90, normalized_payee: 'Client C' }),
+      makeRow({ amount: 60, normalized_payee: 'Bank Transfer', is_transfer: true }),
+      makeRow({ amount: -180, normalized_payee: 'Vendor X' }),
+      makeRow({ amount: -95, normalized_payee: 'Vendor Y' }),
+      makeRow({ amount: -40, normalized_payee: 'Vendor Z' }),
+      makeRow({ amount: -25, normalized_payee: 'Bank Transfer', is_transfer: true }),
+    ];
+
+    const sankey = buildSankey(rows);
+    const centerIndex = sankey.nodes.findIndex((n) => n.name === 'Money in');
+
+    const leftTotal = sankey.links.filter((l) => l.target === centerIndex).reduce((sum, l) => sum + l.value, 0);
+    const rightTotal = sankey.links.filter((l) => l.source === centerIndex).reduce((sum, l) => sum + l.value, 0);
+
+    expect(leftTotal).toBe(rightTotal);
   });
 });

--- a/tests/unit/cashflowInsights.test.ts
+++ b/tests/unit/cashflowInsights.test.ts
@@ -697,6 +697,12 @@ describe('formatCompactCurrency', () => {
     expect(formatCompactCurrency(-2500)).toBe('-$2.5K');
     expect(formatCompactCurrency(0)).toBe('$0');
   });
+
+  it('promotes a value that rounds to 1000 thousands into the M branch', () => {
+    expect(formatCompactCurrency(999950)).toBe('$1M');
+    expect(formatCompactCurrency(-999950)).toBe('-$1M');
+    expect(formatCompactCurrency(999949)).toBe('$999.9K');
+  });
 });
 
 describe('computeCashFlowAggregates', () => {

--- a/tests/unit/cashflowInsights.test.ts
+++ b/tests/unit/cashflowInsights.test.ts
@@ -3,6 +3,9 @@ import {
   defaultInterval,
   computeTotals,
   bucketSeries,
+  payeeFor,
+  topCategories,
+  breakdown,
   type CashFlowRow,
   type CashFlowPeriod,
 } from '@/lib/cashflowInsights';
@@ -175,5 +178,125 @@ describe('bucketSeries', () => {
     const buckets = bucketSeries([], period('2026-08-01', '2026-08-31'), 'day');
 
     expect(buckets).toEqual([]);
+  });
+});
+
+describe('payeeFor', () => {
+  it('prefers normalized_payee', () => {
+    const row = makeRow({ normalized_payee: 'Acme', merchant_name: 'Other Co', description: 'desc' });
+
+    expect(payeeFor(row)).toBe('Acme');
+  });
+
+  it('falls back to merchant_name when normalized_payee is null', () => {
+    const row = makeRow({ normalized_payee: null, merchant_name: 'Merchant Co', description: 'desc' });
+
+    expect(payeeFor(row)).toBe('Merchant Co');
+  });
+
+  it('falls back to description when normalized_payee and merchant_name are null', () => {
+    const row = makeRow({ normalized_payee: null, merchant_name: null, description: 'Check #100' });
+
+    expect(payeeFor(row)).toBe('Check #100');
+  });
+
+  it('falls back to Unknown when all three fields are null', () => {
+    const row = makeRow({ normalized_payee: null, merchant_name: null, description: null });
+
+    expect(payeeFor(row)).toBe('Unknown');
+  });
+});
+
+describe('topCategories', () => {
+  it('returns every category signed sum when there are 5 or fewer', () => {
+    const rows = [
+      makeRow({ amount: 100, category: { id: 'c1', name: 'Food' } }),
+      makeRow({ amount: -50, category: { id: 'c2', name: 'Rent' } }),
+    ];
+
+    expect(topCategories(rows)).toEqual([
+      { name: 'Food', amount: 100 },
+      { name: 'Rent', amount: -50 },
+    ]);
+  });
+
+  it('folds categories beyond the top 5 by absolute sum into Other', () => {
+    const rows = [
+      makeRow({ amount: 500, category: { id: 'c1', name: 'A' } }),
+      makeRow({ amount: -400, category: { id: 'c2', name: 'B' } }),
+      makeRow({ amount: 300, category: { id: 'c3', name: 'C' } }),
+      makeRow({ amount: -200, category: { id: 'c4', name: 'D' } }),
+      makeRow({ amount: 100, category: { id: 'c5', name: 'E' } }),
+      makeRow({ amount: -50, category: { id: 'c6', name: 'F' } }),
+      makeRow({ amount: -10, category: { id: 'c7', name: 'G' } }),
+    ];
+
+    expect(topCategories(rows)).toEqual([
+      { name: 'A', amount: 500 },
+      { name: 'B', amount: -400 },
+      { name: 'C', amount: 300 },
+      { name: 'D', amount: -200 },
+      { name: 'E', amount: 100 },
+      { name: 'Other', amount: -60 },
+    ]);
+  });
+
+  it('folds transfer rows into Transfers', () => {
+    const rows = [makeRow({ amount: -75, is_transfer: true, category: { id: 'c1', name: 'Food' } })];
+
+    expect(topCategories(rows)).toEqual([{ name: 'Transfers', amount: -75 }]);
+  });
+
+  it('folds rows with no category into Uncategorized', () => {
+    const rows = [makeRow({ amount: 40, category: null })];
+
+    expect(topCategories(rows)).toEqual([{ name: 'Uncategorized', amount: 40 }]);
+  });
+
+  it('returns an empty list for an empty row list', () => {
+    expect(topCategories([])).toEqual([]);
+  });
+});
+
+describe('breakdown', () => {
+  it('groups money-in rows by payee with pctOfTotal, dropping outflows', () => {
+    const rows = [
+      makeRow({ amount: 300, normalized_payee: 'Client A' }),
+      makeRow({ amount: 100, normalized_payee: 'Client B' }),
+      makeRow({ amount: -50, normalized_payee: 'Client A' }),
+    ];
+
+    expect(breakdown(rows, 'in', 'payee')).toEqual([
+      { label: 'Client A', amount: 300, pctOfTotal: 75 },
+      { label: 'Client B', amount: 100, pctOfTotal: 25 },
+    ]);
+  });
+
+  it('groups money-out rows by category with pctOfTotal, dropping inflows', () => {
+    const rows = [
+      makeRow({ amount: -300, category: { id: 'c1', name: 'Rent' } }),
+      makeRow({ amount: -100, category: { id: 'c2', name: 'Food' } }),
+      makeRow({ amount: 200, category: { id: 'c1', name: 'Rent' } }),
+    ];
+
+    expect(breakdown(rows, 'out', 'category')).toEqual([
+      { label: 'Rent', amount: -300, pctOfTotal: 75 },
+      { label: 'Food', amount: -100, pctOfTotal: 25 },
+    ]);
+  });
+
+  it('folds payees beyond the top 8 into a Remaining row', () => {
+    const rows = Array.from({ length: 9 }, (_, i) => makeRow({ amount: -(100 - i * 5), normalized_payee: `Payee ${i}` }));
+
+    const result = breakdown(rows, 'out', 'payee');
+
+    expect(result).toHaveLength(9);
+    expect(result[8]).toEqual({ label: 'Remaining', amount: -60, pctOfTotal: (60 / 720) * 100 });
+  });
+
+  it('returns an empty list when no rows match the direction', () => {
+    const rows = [makeRow({ amount: 100 })];
+
+    expect(breakdown(rows, 'out', 'payee')).toEqual([]);
   });
 });

--- a/tests/unit/cashflowInsights.test.ts
+++ b/tests/unit/cashflowInsights.test.ts
@@ -7,6 +7,7 @@ import {
   topCategories,
   breakdown,
   buildSankey,
+  computeInsights,
   type CashFlowRow,
   type CashFlowPeriod,
 } from '@/lib/cashflowInsights';
@@ -367,5 +368,104 @@ describe('buildSankey', () => {
     const rightTotal = sankey.links.filter((l) => l.source === centerIndex).reduce((sum, l) => sum + l.value, 0);
 
     expect(leftTotal).toBe(rightTotal);
+  });
+});
+
+function subscriptionCharges(payee: string, dates: string[], amount: number): CashFlowRow[] {
+  return dates.map((date) =>
+    makeRow({ transaction_date: date, amount: -amount, normalized_payee: payee, is_transfer: false }),
+  );
+}
+
+function inflowRow(date: string, payee: string, amount: number): CashFlowRow {
+  return makeRow({ transaction_date: date, amount, normalized_payee: payee, is_transfer: false });
+}
+
+describe('computeInsights', () => {
+  it('finds a subscription: 3+ charges, 25-35 day cadence, under 10% amount variance', () => {
+    const rows = subscriptionCharges('Netflix', ['2026-06-01', '2026-07-01', '2026-08-01'], 15.99);
+
+    const insights = computeInsights(rows, period('2026-08-01', '2026-08-19'));
+
+    expect(insights).toContainEqual({
+      id: 'subscriptions',
+      title: '1 notable transactions',
+      body: 'We noticed 1 subscriptions you may want to review',
+    });
+  });
+
+  it('emits no subscription insight for an irregular cadence', () => {
+    const rows = subscriptionCharges('Gym', ['2026-06-01', '2026-06-10', '2026-08-01'], 40);
+
+    const insights = computeInsights(rows, period('2026-08-01', '2026-08-19'));
+
+    expect(insights.find((i) => i.id === 'subscriptions')).toBeUndefined();
+  });
+
+  it('reports a revenue change: last full calendar month vs the mean of the three before it', () => {
+    const rows = [
+      inflowRow('2026-04-15', 'Client A', 1000),
+      inflowRow('2026-05-15', 'Client A', 1000),
+      inflowRow('2026-06-15', 'Client A', 1000),
+      inflowRow('2026-07-15', 'Client A', 1500),
+    ];
+
+    // period.to on the last day of July makes July the last full calendar month.
+    const insights = computeInsights(rows, period('2026-01-01', '2026-07-31'));
+
+    const revenue = insights.find((i) => i.id === 'revenue-change');
+    expect(revenue?.title).toBe('Revenue increased');
+    expect(revenue?.body).toContain('July 2026');
+    expect(revenue?.body).toContain('$1,500');
+    expect(revenue?.body).toContain('$1,000');
+  });
+
+  it('emits a top-source insight only when the delta is 20% or more', () => {
+    const flatRows = [
+      inflowRow('2026-04-15', 'Payee B', 700),
+      inflowRow('2026-05-15', 'Payee B', 700),
+      inflowRow('2026-06-15', 'Payee B', 700),
+      inflowRow('2026-07-15', 'Payee A', 100),
+      inflowRow('2026-07-15', 'Payee B', 830), // (830-700)/700 = 18.6%, below the 20% floor
+    ];
+    const flat = computeInsights(flatRows, period('2026-01-01', '2026-07-31'));
+    expect(flat.find((i) => i.id === 'top-source-change')).toBeUndefined();
+
+    const spikeRows = [
+      inflowRow('2026-04-15', 'Payee B', 700),
+      inflowRow('2026-05-15', 'Payee B', 700),
+      inflowRow('2026-06-15', 'Payee B', 700),
+      inflowRow('2026-07-15', 'Payee A', 100),
+      inflowRow('2026-07-15', 'Payee B', 1000), // (1000-700)/700 = 42.9%, above the floor
+    ];
+    const spike = computeInsights(spikeRows, period('2026-01-01', '2026-07-31'));
+    const topSource = spike.find((i) => i.id === 'top-source-change');
+    expect(topSource?.title).toBe('Payee B increased');
+    expect(topSource?.body).toContain('$1,000');
+    expect(topSource?.body).toContain('$700');
+  });
+
+  it('returns an empty list when no rule clears its data threshold', () => {
+    const rows = [inflowRow('2026-07-15', 'Client A', 250), inflowRow('2026-07-20', 'Vendor X', -60)];
+
+    const insights = computeInsights(rows, period('2026-07-01', '2026-07-31'));
+
+    expect(insights).toEqual([]);
+  });
+
+  it('anchors every time window to period.to, not to today', () => {
+    const rows = [
+      inflowRow('2026-03-15', 'Client A', 1000),
+      inflowRow('2026-04-15', 'Client A', 1000),
+      inflowRow('2026-05-15', 'Client A', 1000),
+      inflowRow('2026-06-15', 'Client A', 1000),
+      inflowRow('2026-07-15', 'Client A', 2000),
+    ];
+
+    const julyAnchored = computeInsights(rows, period('2026-01-01', '2026-07-31'));
+    const juneAnchored = computeInsights(rows, period('2026-01-01', '2026-06-30'));
+
+    expect(julyAnchored.find((i) => i.id === 'revenue-change')?.body).toContain('July 2026');
+    expect(juneAnchored.find((i) => i.id === 'revenue-change')?.body).toContain('June 2026');
   });
 });

--- a/tests/unit/cashflowInsights.test.ts
+++ b/tests/unit/cashflowInsights.test.ts
@@ -369,6 +369,25 @@ describe('buildSankey', () => {
 
     expect(leftTotal).toBe(rightTotal);
   });
+
+  it('conserves flow in a loss period by adding a From savings link on the left', () => {
+    const rows = [
+      makeRow({ amount: 1000, normalized_payee: 'Client A' }),
+      makeRow({ amount: -1500, normalized_payee: 'Vendor X' }),
+    ];
+
+    const sankey = buildSankey(rows);
+    const centerIndex = sankey.nodes.findIndex((n) => n.name === 'Money in');
+
+    expect(sankey.nodes.map((n) => n.name)).toContain('From savings');
+    expect(sankey.nodes.map((n) => n.name)).not.toContain('Net savings');
+
+    const leftTotal = sankey.links.filter((l) => l.target === centerIndex).reduce((sum, l) => sum + l.value, 0);
+    const rightTotal = sankey.links.filter((l) => l.source === centerIndex).reduce((sum, l) => sum + l.value, 0);
+
+    expect(leftTotal).toBe(rightTotal);
+    expect(leftTotal).toBe(1500);
+  });
 });
 
 function subscriptionCharges(payee: string, dates: string[], amount: number): CashFlowRow[] {
@@ -389,8 +408,8 @@ describe('computeInsights', () => {
 
     expect(insights).toContainEqual({
       id: 'subscriptions',
-      title: '1 notable transactions',
-      body: 'We noticed 1 subscriptions you may want to review',
+      title: '1 notable transaction',
+      body: 'We noticed 1 subscription you may want to review',
     });
   });
 

--- a/tests/unit/periodUrlState.test.ts
+++ b/tests/unit/periodUrlState.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+import { endOfDay, startOfDay } from 'date-fns';
+
+import {
+  customPeriodLabel,
+  presetPeriod,
+  readEnumParam,
+  readPeriodParams,
+  writePeriodParams,
+  PRESET_PERIOD_TYPES,
+} from '@/lib/periodUrlState';
+import type { Period } from '@/components/PeriodSelector';
+
+const TODAY = new Date(2026, 7, 19); // Aug 19, 2026 (a Wednesday)
+
+describe('presetPeriod', () => {
+  it('builds This Month from the first of the month through the end of today', () => {
+    const period = presetPeriod('month', TODAY);
+    expect(period).toEqual({
+      type: 'month',
+      label: 'This Month',
+      from: new Date(2026, 7, 1),
+      to: endOfDay(TODAY),
+    });
+  });
+
+  it('builds This Week from Monday', () => {
+    const period = presetPeriod('week', TODAY);
+    expect(period.from).toEqual(new Date(2026, 7, 17));
+    expect(period.to).toEqual(endOfDay(TODAY));
+  });
+
+  it('builds Last 30 Days as a 30-day range that includes today', () => {
+    const period = presetPeriod('last30', TODAY);
+    expect(period.from).toEqual(new Date(2026, 6, 21));
+    expect(period.label).toBe('Last 30 Days');
+  });
+
+  it('builds This Quarter from the first day of the quarter', () => {
+    const period = presetPeriod('quarter', TODAY);
+    expect(period.from).toEqual(new Date(2026, 6, 1));
+  });
+});
+
+describe('writePeriodParams / readPeriodParams round trip', () => {
+  it('stores a preset as its type only', () => {
+    const params = new URLSearchParams();
+    writePeriodParams(params, presetPeriod('last90', TODAY));
+    expect(params.toString()).toBe('period=last90');
+  });
+
+  it('restores every preset type relative to today', () => {
+    for (const type of PRESET_PERIOD_TYPES) {
+      const params = new URLSearchParams();
+      writePeriodParams(params, presetPeriod(type, TODAY));
+      expect(readPeriodParams(params, TODAY)).toEqual(presetPeriod(type, TODAY));
+    }
+  });
+
+  it('stores a custom period with its exact dates', () => {
+    const custom: Period = {
+      type: 'custom',
+      from: startOfDay(new Date(2026, 5, 3)),
+      to: endOfDay(new Date(2026, 6, 9)),
+      label: 'Jun 3 - Jul 9, 2026',
+    };
+    const params = new URLSearchParams();
+    writePeriodParams(params, custom);
+    expect(params.get('period')).toBe('custom');
+    expect(params.get('from')).toBe('2026-06-03');
+    expect(params.get('to')).toBe('2026-07-09');
+    expect(readPeriodParams(params, TODAY)).toEqual(custom);
+  });
+
+  it('deletes stale custom dates when a preset replaces a custom period', () => {
+    const params = new URLSearchParams('period=custom&from=2026-06-03&to=2026-07-09');
+    writePeriodParams(params, presetPeriod('today', TODAY));
+    expect(params.toString()).toBe('period=today');
+  });
+
+  it('labels a custom period across a year boundary with both years', () => {
+    const params = new URLSearchParams('period=custom&from=2025-12-20&to=2026-01-10');
+    expect(readPeriodParams(params, TODAY)?.label).toBe('Dec 20, 2025 - Jan 10, 2026');
+  });
+});
+
+describe('readPeriodParams validation', () => {
+  it('returns null when the params are absent', () => {
+    expect(readPeriodParams(new URLSearchParams(), TODAY)).toBeNull();
+  });
+
+  it('returns null for an unknown period type', () => {
+    expect(readPeriodParams(new URLSearchParams('period=fortnight'), TODAY)).toBeNull();
+  });
+
+  it('returns null for a custom period with a missing date', () => {
+    expect(readPeriodParams(new URLSearchParams('period=custom&from=2026-06-03'), TODAY)).toBeNull();
+  });
+
+  it('returns null for a malformed date', () => {
+    expect(
+      readPeriodParams(new URLSearchParams('period=custom&from=06-03-2026&to=2026-07-09'), TODAY),
+    ).toBeNull();
+  });
+
+  it('returns null for a rolled-over date such as February 31', () => {
+    expect(
+      readPeriodParams(new URLSearchParams('period=custom&from=2026-02-31&to=2026-07-09'), TODAY),
+    ).toBeNull();
+  });
+
+  it('returns null when from is after to', () => {
+    expect(
+      readPeriodParams(new URLSearchParams('period=custom&from=2026-07-09&to=2026-06-03'), TODAY),
+    ).toBeNull();
+  });
+});
+
+describe('customPeriodLabel', () => {
+  it('omits the start year inside one year', () => {
+    expect(customPeriodLabel(new Date(2026, 5, 3), new Date(2026, 6, 9))).toBe('Jun 3 - Jul 9, 2026');
+  });
+
+  it('shows both years across a year boundary', () => {
+    expect(customPeriodLabel(new Date(2025, 11, 20), new Date(2026, 0, 10))).toBe(
+      'Dec 20, 2025 - Jan 10, 2026',
+    );
+  });
+});
+
+describe('readEnumParam', () => {
+  const MODES = ['flow', 'category', 'inout'] as const;
+
+  it('returns a listed value', () => {
+    expect(readEnumParam(new URLSearchParams('view=inout'), 'view', MODES)).toBe('inout');
+  });
+
+  it('returns null for an unlisted value', () => {
+    expect(readEnumParam(new URLSearchParams('view=bogus'), 'view', MODES)).toBeNull();
+  });
+
+  it('returns null when the param is absent', () => {
+    expect(readEnumParam(new URLSearchParams(), 'view', MODES)).toBeNull();
+  });
+});

--- a/tests/unit/useCashFlowInsights.test.tsx
+++ b/tests/unit/useCashFlowInsights.test.tsx
@@ -1,0 +1,189 @@
+import React, { ReactNode } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useCashFlowInsights } from '@/hooks/useCashFlowInsights';
+
+const mockSupabase = vi.hoisted(() => ({
+  from: vi.fn(),
+}));
+
+const mockRestaurantContext = vi.hoisted(() => ({
+  selectedRestaurant: { restaurant_id: 'rest-123' } as { restaurant_id: string } | null,
+}));
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: mockSupabase,
+}));
+
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => mockRestaurantContext,
+}));
+
+type Row = {
+  transaction_date: string;
+  amount: number;
+  is_transfer: boolean;
+  normalized_payee: string | null;
+  merchant_name: string | null;
+  description: string | null;
+  category: { id: string; name: string } | null;
+};
+
+type QueryBuilder = {
+  select: ReturnType<typeof vi.fn>;
+  eq: ReturnType<typeof vi.fn>;
+  gte: ReturnType<typeof vi.fn>;
+  lte: ReturnType<typeof vi.fn>;
+  order: ReturnType<typeof vi.fn>;
+  range: ReturnType<typeof vi.fn>;
+};
+
+/** One query builder whose `.range()` returns `pages[callIndex]`, in order. */
+function createPagedBuilder(pages: Row[][]): QueryBuilder {
+  let call = 0;
+  const builder: QueryBuilder = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    gte: vi.fn().mockReturnThis(),
+    lte: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    range: vi.fn().mockImplementation(() => {
+      const page = pages[call] ?? [];
+      call += 1;
+      return Promise.resolve({ data: page, error: null });
+    }),
+  };
+  return builder;
+}
+
+function row(overrides: Partial<Row>): Row {
+  return {
+    transaction_date: '2026-08-01',
+    amount: 100,
+    is_transfer: false,
+    normalized_payee: 'Acme Co',
+    merchant_name: null,
+    description: null,
+    category: { id: 'cat-1', name: 'Revenue' },
+    ...overrides,
+  };
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+const period = { from: new Date(2026, 7, 1), to: new Date(2026, 7, 15) };
+
+describe('useCashFlowInsights', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRestaurantContext.selectedRestaurant = { restaurant_id: 'rest-123' };
+  });
+
+  it('filters by restaurant_id, status=posted, and skips the bank filter when "all"', async () => {
+    const builder = createPagedBuilder([[row({})]]);
+    mockSupabase.from.mockReturnValue(builder);
+
+    const { result } = renderHook(() => useCashFlowInsights(period, 'all'), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockSupabase.from).toHaveBeenCalledWith('bank_transactions');
+    expect(builder.eq).toHaveBeenCalledWith('restaurant_id', 'rest-123');
+    expect(builder.eq).toHaveBeenCalledWith('status', 'posted');
+    expect(builder.eq).not.toHaveBeenCalledWith('connected_bank_id', expect.anything());
+  });
+
+  it('applies the connected_bank_id filter when a specific bank is selected', async () => {
+    const builder = createPagedBuilder([[]]);
+    mockSupabase.from.mockReturnValue(builder);
+
+    const { result } = renderHook(() => useCashFlowInsights(period, 'bank-1'), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(builder.eq).toHaveBeenCalledWith('connected_bank_id', 'bank-1');
+  });
+
+  it('fetches from min(period.from, startOfMonth(subMonths(period.to, 4))) to period.to', async () => {
+    const builder = createPagedBuilder([[]]);
+    mockSupabase.from.mockReturnValue(builder);
+
+    const { result } = renderHook(() => useCashFlowInsights(period, 'all'), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // period.to = 2026-08-15; 4 months back, start of month => 2026-04-01,
+    // which is earlier than period.from (2026-08-01), so the wide window wins.
+    expect(builder.gte).toHaveBeenCalledWith('transaction_date', '2026-04-01');
+    expect(builder.lte).toHaveBeenCalledWith('transaction_date', '2026-08-15');
+    expect(builder.order).toHaveBeenCalledWith('transaction_date', { ascending: true });
+  });
+
+  it('pages with .range() in 1000-row pages until a short page ends the fetch', async () => {
+    const fullPage = Array.from({ length: 1000 }, (_, i) => row({ transaction_date: '2026-08-01', amount: i }));
+    const shortPage = [row({ transaction_date: '2026-08-02' })];
+    const builder = createPagedBuilder([fullPage, shortPage]);
+    mockSupabase.from.mockReturnValue(builder);
+
+    const { result } = renderHook(() => useCashFlowInsights(period, 'all'), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(builder.range).toHaveBeenNthCalledWith(1, 0, 999);
+    expect(builder.range).toHaveBeenNthCalledWith(2, 1000, 1999);
+    expect(builder.range).toHaveBeenCalledTimes(2);
+    expect(result.current.data?.truncated).toBe(false);
+  });
+
+  it('stops at 20 pages and sets truncated: true', async () => {
+    const fullPage = Array.from({ length: 1000 }, (_, i) => row({ transaction_date: '2026-08-01', amount: i }));
+    const pages = Array.from({ length: 25 }, () => fullPage);
+    const builder = createPagedBuilder(pages);
+    mockSupabase.from.mockReturnValue(builder);
+
+    const { result } = renderHook(() => useCashFlowInsights(period, 'all'), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(builder.range).toHaveBeenCalledTimes(20);
+    expect(result.current.data?.truncated).toBe(true);
+  });
+
+  it('memoizes totals and series from rows inside the display period only', async () => {
+    const rows = [
+      row({ transaction_date: '2026-07-01', amount: 500 }), // outside period, feeds insights only
+      row({ transaction_date: '2026-08-05', amount: 200 }),
+      row({ transaction_date: '2026-08-06', amount: -50 }),
+    ];
+    const builder = createPagedBuilder([rows]);
+    mockSupabase.from.mockReturnValue(builder);
+
+    const { result } = renderHook(() => useCashFlowInsights(period, 'all'), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.aggregates.totals).toEqual({ moneyIn: 200, moneyOut: -50, net: 150 });
+    expect(result.current.data?.rows).toHaveLength(2);
+  });
+
+  it('returns an empty result set without querying when no restaurant is selected', async () => {
+    mockRestaurantContext.selectedRestaurant = null;
+    const builder = createPagedBuilder([[]]);
+    mockSupabase.from.mockReturnValue(builder);
+
+    const { result } = renderHook(() => useCashFlowInsights(period, 'all'), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess || result.current.isLoading === false).toBe(true));
+
+    expect(mockSupabase.from).not.toHaveBeenCalled();
+    expect(result.current.data?.rows ?? []).toHaveLength(0);
+  });
+});

--- a/tests/unit/useCashFlowInsights.test.tsx
+++ b/tests/unit/useCashFlowInsights.test.tsx
@@ -122,8 +122,9 @@ describe('useCashFlowInsights', () => {
 
     // period.to = 2026-08-15; 4 months back, start of month => 2026-04-01,
     // which is earlier than period.from (2026-08-01), so the wide window wins.
+    // The column is timestamptz, so the end bound must cover the full final day.
     expect(builder.gte).toHaveBeenCalledWith('transaction_date', '2026-04-01');
-    expect(builder.lte).toHaveBeenCalledWith('transaction_date', '2026-08-15');
+    expect(builder.lte).toHaveBeenCalledWith('transaction_date', '2026-08-15T23:59:59.999Z');
     expect(builder.order).toHaveBeenCalledWith('transaction_date', { ascending: true });
   });
 


### PR DESCRIPTION
## Summary

- Add a Mercury-style Cash Flow view under Financial Intelligence: a two-thumb timeline brush, a headline (net cash flow, money in, money out), a plain-language narrative panel, a chart with three modes (Flow / By category / In vs out), and Source/Category breakdown tables for both money in and money out.
- Build a deterministic insight engine (`src/lib/cashflowInsights.ts`) that finds subscriptions, revenue changes, and top-source changes from bank transaction rows. No AI call.
- Add a data hook (`src/hooks/useCashFlowInsights.tsx`) that pages bank transactions, flags a truncated result, and memoizes aggregates and insights.
- Rewrite `CashFlowTab.tsx` on the new components and thread `onPeriodChange` through `BankingIntelligenceDashboard.tsx` and `FinancialIntelligence.tsx` so brush changes move the page-level period.
- All aggregation runs client-side. No database change.

Design doc: `docs/superpowers/specs/2026-08-19-cashflow-insights-design.md`

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx eslint` on the 10 touched source/hook/lib files — 0 problems
- [x] `npm run test -- --run` — 794 files / 9524 tests passed, 2 skipped
- [x] `npx playwright test tests/e2e/financial-intelligence-cashflow.spec.ts --project=e2e` — 1 passed
- [x] `npm run test:db` (after a clean `db reset`) — 2908/2908 passed
- [x] `npm run test:e2e` full run — 215 passed, 12 skipped, 2 failed; both failures are in unrelated pre-existing specs (`schedule-clock-audit.spec.ts`, `schedule-quiet-publish-live-edit.spec.ts`) and a targeted re-run of those two files passed 4/4 clean
- [x] `npm run build` — exit 0
- [x] Checked light and dark theme by hand against a seeded restaurant with two banks and six transactions

## Known deferred review findings

- `src/components/banking/cashflow/CashFlowNarrative.tsx:1089` — major — `CashFlowNarrative` rebuilds structure (amount and payee spans) from the rendered insight text with a hand-duplicated `CURRENCY_PATTERN` regex and a `payeeFor()` that strips `' increased'`/`' decreased'` off the title. Neither path reads from or is tested against the real `computeInsights` output; the test file hand-writes matching fixture strings instead of running the actual engine. If `formatCurrency`'s fraction digits or a title/body wording changes in `cashflowInsights.ts`, chip highlighting stops working with no signal that ties the two together. The reviewer's suggested fix: have `computeInsights` return structured parts (amount values, payee name) next to the body string, so the component renders chips from data instead of re-parsing formatted text.
  - Deferred because: no live bug exists today — all `CashFlowNarrative` and `cashflowInsights` tests pass, and chips render correctly for every current insight shape. The fix needs a wider `CashFlowInsight` interface (today it is `id`/`title`/`body`, matching the design doc's documented shape) and touches all three insight builders plus the component and its tests. That is a larger, riskier refactor than fits a review-fold pass. It is a good candidate for a dedicated follow-up task instead of an improvised design-adjacent interface change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a redesigned Cash Flow Insights experience with date-range controls, bank-account filtering, and URL-persisted selections.
  * View net cash flow, money in/out totals, trends, category and payee breakdowns, flow visualizations, and narrative insights.
  * Added responsive layouts, accessibility labels, and clear loading, empty, error, and truncated-data states.
* **Tests**
  * Added comprehensive unit and end-to-end coverage for calculations, interactions, filtering, and dashboard states.
* **Documentation**
  * Added design and implementation specifications for Cash Flow Insights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->