### PR TITLE
fix(banking): add membership guard to bank delete RPCs

### DIFF
--- a/docs/superpowers/plans/2026-08-20-bank-delete-rpcs-membership-guard-plan.md
+++ b/docs/superpowers/plans/2026-08-20-bank-delete-rpcs-membership-guard-plan.md
@@ -1,0 +1,86 @@
+# Plan: Membership guard for the bank delete RPCs
+
+Date: 2026-08-20
+Design: docs/superpowers/specs/2026-08-20-bank-delete-rpcs-membership-guard-design.md
+Branch: fix/bank-delete-rpcs-membership-guard
+
+Each task is small and commits on its own. Tasks 1–2 follow TDD order:
+tests first (RED), then the migration (GREEN).
+
+## Task 1 — pgTAP guard tests (RED)
+
+Create `supabase/tests/65_bank_delete_rpcs_membership_guard.sql`.
+
+Fixtures (all ids in a reserved `65...` uuid range, `ON CONFLICT` safe):
+- `auth.users`: member user, attacker user.
+- Victim restaurant + `user_restaurants` row for the member user.
+- Attacker restaurant + `user_restaurants` row for the attacker user.
+- Victim `connected_banks` row, four `bank_transactions` rows, one
+  `bank_transaction_splits` row, one tombstone row (insert direct into
+  `deleted_bank_transactions`).
+
+Tests (plan count matches the test bodies):
+1. Attacker claims set. `throws_ok` for each of the four functions with
+   message `Unauthorized: user does not have access to this restaurant`
+   (4 tests).
+2. Victim rows stay intact after the four failed calls: transaction count,
+   split count, tombstone count (3 tests).
+3. No claims set (`auth.uid()` NULL). `throws_ok` for each of the four
+   functions (4 tests).
+4. Member claims set. `delete_bank_transaction` returns `success: true`;
+   `bulk_delete_bank_transactions` returns `success: true`;
+   `restore_deleted_transaction` returns `success: true`;
+   `permanently_delete_tombstone` returns `success: true` (4 tests).
+
+Run `npm run test:db`. The new file must fail (attacker calls succeed
+today). Commit the RED state is not allowed to break CI on main — the
+commit for this task lands together with Task 2 only if the runner blocks
+red commits; otherwise commit RED first, then Task 2 turns it GREEN.
+
+## Task 2 — Guard migration (GREEN)
+
+Create
+`supabase/migrations/20260820120000_bank_delete_rpcs_membership_guard.sql`.
+
+- `CREATE OR REPLACE` all four functions from
+  `20260301000001_update_delete_functions_with_tombstone.sql` with the
+  membership guard as the first statement in each `BEGIN` block.
+- Guard text identical to
+  `20260709120000_categorize_preserve_metadata_on_noop.sql:57-65`.
+- Keep bodies byte-identical otherwise. Keep `SECURITY DEFINER`,
+  `SET search_path = public`, grants, and comments.
+- Run `npx supabase db reset` then `npm run test:db`. All green.
+
+## Task 3 — Update the existing tombstone test
+
+Change `supabase/tests/deleted_bank_transactions_tombstone.sql`:
+- Add an `auth.users` fixture row and a `user_restaurants` membership for
+  restaurant `a0000000-0000-0000-0000-000000000001`.
+- Set `request.jwt.claims` before the functional tests (Test 13 on).
+- Plan count stays 27.
+- Run `npm run test:db`. All green.
+
+## Task 4 — E2E cross-tenant spec
+
+Create `tests/e2e/bank-delete-cross-tenant.spec.ts`:
+- User A: `signUpAndCreateRestaurant`, `exposeSupabaseHelpers`, seed
+  `connected_banks` + one `bank_transactions` row (seed shape from
+  `tests/e2e/bulk-edit-transactions.spec.ts`).
+- User B in a second browser context: sign up, own restaurant.
+- User B calls `supabase.rpc('bulk_delete_bank_transactions', ...)` with
+  restaurant A's id. Assert the RPC returns an error.
+- User A confirms the transaction still exists.
+- User A calls the same RPC on own data. Assert success and row gone.
+- Run the spec locally.
+
+## Task 5 — Full verify
+
+- `npm run test`, `npm run test:db`, `npm run typecheck`, `npm run lint`,
+  `npm run build`, and the new E2E spec.
+- E2E gate statement: Covered — `tests/e2e/bank-delete-cross-tenant.spec.ts`
+  asserts the cross-tenant denial and the member success path end to end.
+
+## Dependencies
+
+Task 2 depends on Task 1 (TDD order). Task 3 depends on Task 2. Task 4
+depends on Task 2. Task 5 depends on all.

--- a/docs/superpowers/specs/2026-08-20-bank-delete-rpcs-membership-guard-design.md
+++ b/docs/superpowers/specs/2026-08-20-bank-delete-rpcs-membership-guard-design.md
@@ -105,6 +105,14 @@ Service-role note: `auth.uid()` is NULL for service-role calls, so the guard
 would raise. No edge function or cron job calls these four functions, so no
 service path breaks.
 
+Grant note: the migration grants EXECUTE to `authenticated`
+(`20260301000001_update_delete_functions_with_tombstone.sql:90,183,283,327`)
+and never revokes the default PUBLIC execute grant. The `anon` and
+`service_role` roles can still call these functions today. The guard closes
+that path because `auth.uid()` returns NULL for those callers, not because
+of a grant boundary. Grant hardening stays on the sibling branch
+`fix/secdef-execute-grants`.
+
 ## Tests
 
 ### pgTAP (new file `supabase/tests/65_bank_delete_rpcs_membership_guard.sql`)
@@ -124,9 +132,9 @@ Tests, member impersonated:
 - Each of the four functions returns `success: true` on the victim
   restaurant's own data.
 
-Test, no JWT claims (`auth.uid()` NULL):
-- `bulk_delete_bank_transactions` raises. This pins the service-role
-  behavior.
+Tests, no JWT claims (`auth.uid()` NULL):
+- Each of the four functions raises. This pins the service-role behavior
+  per function and catches a copy-paste error in any one guard insertion.
 
 ### pgTAP (change existing file)
 

--- a/docs/superpowers/specs/2026-08-20-bank-delete-rpcs-membership-guard-design.md
+++ b/docs/superpowers/specs/2026-08-20-bank-delete-rpcs-membership-guard-design.md
@@ -1,0 +1,164 @@
+# Design: Membership guard for the bank delete RPCs
+
+Date: 2026-08-20
+Branch: fix/bank-delete-rpcs-membership-guard
+Author: Claude (task from Jose Delgado)
+
+## Problem
+
+Four SECURITY DEFINER functions delete or restore bank data. Each function
+has `GRANT EXECUTE ... TO authenticated`. No function checks that the caller
+is a member of `p_restaurant_id`. The caller supplies `p_restaurant_id` as an
+argument. An authenticated user from one tenant can pass another tenant's
+`restaurant_id` and delete that tenant's data.
+
+The four functions live in
+`supabase/migrations/20260301000001_update_delete_functions_with_tombstone.sql`.
+This migration holds the latest definition of each function
+(later migrations do not redefine them; only
+`20260201153920_add_bulk_delete_bank_transactions.sql` and
+`20260201170000_fix_delete_bank_transaction_security.sql` touch these names,
+and both are earlier):
+
+| Function | Definition | SECURITY DEFINER | Grant |
+|---|---|---|---|
+| `delete_bank_transaction(uuid, uuid)` | lines 10–87 | line 16 | line 90 |
+| `bulk_delete_bank_transactions(uuid[], uuid)` | lines 100–180 | line 106 | line 183 |
+| `restore_deleted_transaction(uuid, uuid)` | lines 194–280 | line 200 | line 283 |
+| `permanently_delete_tombstone(uuid, uuid)` | lines 293–324 | line 299 | line 327 |
+
+Each function filters rows by `p_restaurant_id` only. Example:
+`bulk_delete_bank_transactions` validates that the transactions belong to
+`p_restaurant_id` (lines 113–130) and then deletes them (lines 163–170). The
+only use of `auth.uid()` is the tombstone `deleted_by` value (line 157 for
+bulk, line 68 for single). The prior "security fix" migration
+(`20260201170000_fix_delete_bank_transaction_security.sql:20-31`) validated
+the transaction-to-restaurant link, not the caller's membership. The gap has
+existed since that migration.
+
+Impact per function for a cross-tenant caller:
+
+- `delete_bank_transaction`: deletes one `bank_transactions` row and its
+  `bank_transaction_splits` rows (lines 73–79).
+- `bulk_delete_bank_transactions`: deletes many rows and their splits
+  (lines 163–170).
+- `restore_deleted_transaction`: deletes tombstones and inserts rows into
+  `bank_transactions` (lines 231, 249–272).
+- `permanently_delete_tombstone`: deletes a tombstone, which re-opens the
+  re-import path for that transaction (lines 305–307).
+
+## Fix
+
+Add a caller membership guard as the first statement of each function body.
+Use the exact pattern from `categorize_bank_transaction`
+(`supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql:57-65`):
+
+```sql
+IF NOT EXISTS (
+  SELECT 1
+  FROM user_restaurants
+  WHERE restaurant_id = p_restaurant_id
+    AND user_id = auth.uid()
+) THEN
+  RAISE EXCEPTION 'Unauthorized: user does not have access to this restaurant';
+END IF;
+```
+
+`user_restaurants` is the canonical membership table. The access helper
+`user_has_restaurant_access` reads the same table
+(`supabase/migrations/20260521222200_create_user_has_restaurant_access_helper.sql:30-39`).
+Collaborator roles are rows in `user_restaurants` with a `role` value, so the
+guard does not block collaborators.
+
+One new migration re-creates all four functions with the guard. The rest of
+each body stays byte-identical. `CREATE OR REPLACE` keeps the existing
+grants. Migration file:
+`supabase/migrations/20260820120000_bank_delete_rpcs_membership_guard.sql`.
+
+## Approaches considered
+
+1. **Inline EXISTS guard per function (chosen).** Matches the
+   `categorize_bank_transaction` precedent and the task instruction. No new
+   dependency.
+2. **Call `user_has_restaurant_access(p_restaurant_id)`.** Same table, same
+   result. Rejected: the categorize precedent inlines the check, and the
+   task instruction names the inline pattern.
+3. **Revoke EXECUTE and route through an edge function.** Rejected: large
+   blast radius for the client hooks, no added protection over the guard.
+
+## Caller impact
+
+Only client hooks call these RPCs. No edge function calls them (grep over
+`supabase/functions/` finds no reference).
+
+- `src/hooks/useBankTransactions.tsx:465` — `delete_bank_transaction`.
+- `src/hooks/useBulkTransactionActions.tsx:308` — `bulk_delete_bank_transactions`.
+- `src/hooks/useDeletedBankTransactions.tsx:85,95` — restore and
+  permanent-delete.
+
+Each hook passes the selected restaurant's id from the app context. A
+legitimate caller is a member of that restaurant, so the guard passes. The
+guard raises only for cross-tenant calls, which surface as an RPC error in
+the hooks' existing error paths.
+
+Service-role note: `auth.uid()` is NULL for service-role calls, so the guard
+would raise. No edge function or cron job calls these four functions, so no
+service path breaks.
+
+## Tests
+
+### pgTAP (new file `supabase/tests/65_bank_delete_rpcs_membership_guard.sql`)
+
+Impersonation via `set_config('request.jwt.claims', '{"sub":"<uuid>","role":"authenticated"}', true)`,
+same as `supabase/tests/22_bulk_categorize_bank_transactions.sql:163`.
+
+Fixtures: victim restaurant with a connected bank, transactions, splits, and
+one tombstone; a member user of the victim restaurant; an attacker user who
+is a member of a different restaurant only.
+
+Tests, attacker impersonated (each of the four functions):
+- `throws_ok` with message `Unauthorized: user does not have access to this restaurant`.
+- Target rows stay intact after the failed call.
+
+Tests, member impersonated:
+- Each of the four functions returns `success: true` on the victim
+  restaurant's own data.
+
+Test, no JWT claims (`auth.uid()` NULL):
+- `bulk_delete_bank_transactions` raises. This pins the service-role
+  behavior.
+
+### pgTAP (change existing file)
+
+`supabase/tests/deleted_bank_transactions_tombstone.sql` calls all four
+functions as `postgres` with no JWT claims (lines 158–165, 189–196, 212–219,
+237–244, 268–275, 294–301, 315–322). After the guard, these calls raise. Fix:
+add an `auth.users` row plus a `user_restaurants` membership for the test
+restaurant, and set the JWT claims before the functional tests.
+
+### E2E (new file `tests/e2e/bank-delete-cross-tenant.spec.ts`)
+
+The seam is: browser client → PostgREST → RPC. Unit tests do not cover it.
+
+- Sign up user A, create restaurant A, seed a connected bank and one
+  transaction (same seed shape as `tests/e2e/bulk-edit-transactions.spec.ts`).
+- Sign up user B in a second browser context, create restaurant B.
+- As user B, call `supabase.rpc('bulk_delete_bank_transactions', ...)` with
+  restaurant A's id. Expect an error.
+- As user A, confirm the transaction still exists.
+- As user A, call the same RPC on own data. Expect success. This pins the
+  no-regression path.
+
+## Out of scope
+
+- A repository-wide audit of other SECURITY DEFINER functions. The sibling
+  branch `fix/secdef-execute-grants` tracks related work.
+- RLS changes on `bank_transactions` or `deleted_bank_transactions`.
+- Type regeneration: no function signature changes.
+
+## Decided trade-offs
+
+- The guard raises an exception instead of returning
+  `jsonb_build_object('success', false, ...)`. This matches
+  `categorize_bank_transaction` and makes cross-tenant calls loud. The
+  hooks already treat RPC errors as failures.

--- a/supabase/migrations/20260820120000_bank_delete_rpcs_membership_guard.sql
+++ b/supabase/migrations/20260820120000_bank_delete_rpcs_membership_guard.sql
@@ -1,0 +1,373 @@
+-- Migration: Membership guard for bank delete RPCs
+-- Purpose: delete_bank_transaction, bulk_delete_bank_transactions,
+--          restore_deleted_transaction, and permanently_delete_tombstone
+--          trust p_restaurant_id from the caller with no membership check.
+--          A user who is a member of restaurant A can pass restaurant B's ID
+--          and delete, bulk-delete, restore, or purge restaurant B's bank
+--          data. Add a membership guard as the first statement in each
+--          function, matching the pattern used in categorize_bank_transaction
+--          (see 20260709120000_categorize_preserve_metadata_on_noop.sql:57-65).
+-- See: docs/superpowers/specs/2026-08-20-bank-delete-rpcs-membership-guard-design.md
+
+-- ============================================================
+-- 1. delete_bank_transaction(uuid, uuid)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.delete_bank_transaction(
+  p_transaction_id uuid,
+  p_restaurant_id uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_transaction RECORD;
+  v_fingerprint TEXT;
+BEGIN
+  -- Verify user has access to this restaurant
+  IF NOT EXISTS (
+    SELECT 1
+    FROM user_restaurants
+    WHERE restaurant_id = p_restaurant_id
+      AND user_id = auth.uid()
+  ) THEN
+    RAISE EXCEPTION 'Unauthorized: user does not have access to this restaurant';
+  END IF;
+
+  -- Get the transaction and verify it exists AND belongs to this restaurant
+  SELECT * INTO v_transaction
+  FROM bank_transactions
+  WHERE id = p_transaction_id
+  AND restaurant_id = p_restaurant_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Transaction not found or does not belong to this restaurant'
+    );
+  END IF;
+
+  -- Compute fingerprint for CSV/PDF matching
+  -- Cast transaction_date to DATE (column is TIMESTAMPTZ in bank_transactions)
+  v_fingerprint := compute_transaction_fingerprint(
+    v_transaction.transaction_date::DATE,
+    v_transaction.amount,
+    v_transaction.description
+  );
+
+  -- Insert tombstone record (ON CONFLICT DO NOTHING for idempotency)
+  INSERT INTO deleted_bank_transactions (
+    restaurant_id,
+    connected_bank_id,
+    source,
+    external_transaction_id,
+    fingerprint,
+    transaction_date,
+    amount,
+    currency,
+    description,
+    merchant_name,
+    deleted_by
+  ) VALUES (
+    v_transaction.restaurant_id,
+    v_transaction.connected_bank_id,
+    COALESCE(v_transaction.source, 'bank_integration'),
+    v_transaction.stripe_transaction_id,
+    v_fingerprint,
+    v_transaction.transaction_date::DATE,
+    v_transaction.amount,
+    v_transaction.currency,
+    v_transaction.description,
+    v_transaction.merchant_name,
+    auth.uid()
+  )
+  ON CONFLICT DO NOTHING;
+
+  -- Delete related bank_transaction_splits first (foreign key constraint)
+  DELETE FROM bank_transaction_splits
+  WHERE transaction_id = p_transaction_id;
+
+  -- Delete the bank transaction
+  DELETE FROM bank_transactions
+  WHERE id = p_transaction_id
+  AND restaurant_id = p_restaurant_id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'transaction_id', p_transaction_id,
+    'message', 'Transaction deleted (tombstone preserved for re-import prevention)'
+  );
+END;
+$$;
+
+-- Grant execute to authenticated users
+GRANT EXECUTE ON FUNCTION public.delete_bank_transaction(uuid, uuid) TO authenticated;
+
+COMMENT ON FUNCTION public.delete_bank_transaction(uuid, uuid) IS
+'Deletes a single bank transaction after validating restaurant ownership.
+Writes a tombstone record to deleted_bank_transactions for re-import prevention.';
+
+-- ============================================================
+-- 2. bulk_delete_bank_transactions(uuid[], uuid)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.bulk_delete_bank_transactions(
+  p_transaction_ids uuid[],
+  p_restaurant_id uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_deleted_count int := 0;
+  v_invalid_ids uuid[] := '{}';
+BEGIN
+  -- Verify user has access to this restaurant
+  IF NOT EXISTS (
+    SELECT 1
+    FROM user_restaurants
+    WHERE restaurant_id = p_restaurant_id
+      AND user_id = auth.uid()
+  ) THEN
+    RAISE EXCEPTION 'Unauthorized: user does not have access to this restaurant';
+  END IF;
+
+  -- Validate that all transaction IDs belong to this restaurant
+  SELECT array_agg(id) INTO v_invalid_ids
+  FROM unnest(p_transaction_ids) AS id
+  WHERE id NOT IN (
+    SELECT bt.id
+    FROM bank_transactions bt
+    WHERE bt.id = ANY(p_transaction_ids)
+    AND bt.restaurant_id = p_restaurant_id
+  );
+
+  -- If any invalid IDs found, return error
+  IF array_length(v_invalid_ids, 1) > 0 THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Some transactions do not belong to this restaurant or do not exist',
+      'invalid_ids', v_invalid_ids
+    );
+  END IF;
+
+  -- Bulk insert tombstone records (ON CONFLICT DO NOTHING for idempotency)
+  INSERT INTO deleted_bank_transactions (
+    restaurant_id,
+    connected_bank_id,
+    source,
+    external_transaction_id,
+    fingerprint,
+    transaction_date,
+    amount,
+    currency,
+    description,
+    merchant_name,
+    deleted_by
+  )
+  SELECT
+    bt.restaurant_id,
+    bt.connected_bank_id,
+    COALESCE(bt.source, 'bank_integration'),
+    bt.stripe_transaction_id,
+    compute_transaction_fingerprint(bt.transaction_date::DATE, bt.amount, bt.description),
+    bt.transaction_date::DATE,
+    bt.amount,
+    bt.currency,
+    bt.description,
+    bt.merchant_name,
+    auth.uid()
+  FROM bank_transactions bt
+  WHERE bt.id = ANY(p_transaction_ids)
+  AND bt.restaurant_id = p_restaurant_id
+  ON CONFLICT DO NOTHING;
+
+  -- Delete related bank_transaction_splits first (foreign key constraint)
+  DELETE FROM bank_transaction_splits
+  WHERE transaction_id = ANY(p_transaction_ids);
+
+  -- Delete the bank transactions
+  DELETE FROM bank_transactions
+  WHERE id = ANY(p_transaction_ids)
+  AND restaurant_id = p_restaurant_id;
+
+  GET DIAGNOSTICS v_deleted_count = ROW_COUNT;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'deleted_count', v_deleted_count,
+    'message', format('%s transaction(s) deleted (tombstones preserved)', v_deleted_count)
+  );
+END;
+$$;
+
+-- Grant execute to authenticated users
+GRANT EXECUTE ON FUNCTION public.bulk_delete_bank_transactions(uuid[], uuid) TO authenticated;
+
+COMMENT ON FUNCTION public.bulk_delete_bank_transactions IS
+'Bulk deletes bank transactions after validating restaurant ownership.
+Writes tombstone records to deleted_bank_transactions for re-import prevention.
+Cascades to bank_transaction_splits.';
+
+-- ============================================================
+-- 3. restore_deleted_transaction(uuid, uuid)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.restore_deleted_transaction(
+  p_tombstone_id uuid,
+  p_restaurant_id uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_tombstone RECORD;
+  v_existing_id UUID;
+  v_stripe_txn_id TEXT;
+BEGIN
+  -- Verify user has access to this restaurant
+  IF NOT EXISTS (
+    SELECT 1
+    FROM user_restaurants
+    WHERE restaurant_id = p_restaurant_id
+      AND user_id = auth.uid()
+  ) THEN
+    RAISE EXCEPTION 'Unauthorized: user does not have access to this restaurant';
+  END IF;
+
+  -- Read the tombstone row and verify restaurant
+  SELECT * INTO v_tombstone
+  FROM deleted_bank_transactions
+  WHERE id = p_tombstone_id
+  AND restaurant_id = p_restaurant_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Tombstone not found or does not belong to this restaurant'
+    );
+  END IF;
+
+  -- Check if an active transaction with the same external_transaction_id already exists
+  -- (idempotent case: someone already restored or the transaction was re-imported)
+  IF v_tombstone.external_transaction_id IS NOT NULL THEN
+    SELECT id INTO v_existing_id
+    FROM bank_transactions
+    WHERE stripe_transaction_id = v_tombstone.external_transaction_id
+    AND restaurant_id = p_restaurant_id;
+
+    IF FOUND THEN
+      -- Active row exists; just remove the tombstone and return success
+      DELETE FROM deleted_bank_transactions WHERE id = p_tombstone_id;
+
+      RETURN jsonb_build_object(
+        'success', true,
+        'transaction_id', v_existing_id,
+        'message', 'Active transaction already exists; tombstone removed'
+      );
+    END IF;
+  END IF;
+
+  -- Determine stripe_transaction_id for the restored row
+  -- Use external_transaction_id if present, otherwise generate a unique ID
+  v_stripe_txn_id := COALESCE(
+    v_tombstone.external_transaction_id,
+    'restored_' || p_tombstone_id::text
+  );
+
+  -- Re-insert into bank_transactions from tombstone data
+  INSERT INTO bank_transactions (
+    restaurant_id,
+    connected_bank_id,
+    stripe_transaction_id,
+    transaction_date,
+    description,
+    merchant_name,
+    amount,
+    currency,
+    source
+  ) VALUES (
+    v_tombstone.restaurant_id,
+    v_tombstone.connected_bank_id,
+    v_stripe_txn_id,
+    v_tombstone.transaction_date,
+    COALESCE(v_tombstone.description, ''),
+    v_tombstone.merchant_name,
+    v_tombstone.amount,
+    COALESCE(v_tombstone.currency, 'USD'),
+    COALESCE(v_tombstone.source, 'bank_integration')
+  );
+
+  -- Delete the tombstone
+  DELETE FROM deleted_bank_transactions WHERE id = p_tombstone_id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'stripe_transaction_id', v_stripe_txn_id,
+    'message', 'Transaction restored from tombstone'
+  );
+END;
+$$;
+
+-- Grant execute to authenticated users
+GRANT EXECUTE ON FUNCTION public.restore_deleted_transaction(uuid, uuid) TO authenticated;
+
+COMMENT ON FUNCTION public.restore_deleted_transaction IS
+'Restores a previously deleted bank transaction from the tombstone table back to bank_transactions.
+If an active transaction with the same external ID already exists, just removes the tombstone.';
+
+-- ============================================================
+-- 4. permanently_delete_tombstone(uuid, uuid)
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.permanently_delete_tombstone(
+  p_tombstone_id uuid,
+  p_restaurant_id uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_deleted_count int;
+BEGIN
+  -- Verify user has access to this restaurant
+  IF NOT EXISTS (
+    SELECT 1
+    FROM user_restaurants
+    WHERE restaurant_id = p_restaurant_id
+      AND user_id = auth.uid()
+  ) THEN
+    RAISE EXCEPTION 'Unauthorized: user does not have access to this restaurant';
+  END IF;
+
+  DELETE FROM deleted_bank_transactions
+  WHERE id = p_tombstone_id
+  AND restaurant_id = p_restaurant_id;
+
+  GET DIAGNOSTICS v_deleted_count = ROW_COUNT;
+
+  IF v_deleted_count = 0 THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Tombstone not found or does not belong to this restaurant'
+    );
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'tombstone_id', p_tombstone_id,
+    'message', 'Tombstone permanently deleted (transaction can be re-imported)'
+  );
+END;
+$$;
+
+-- Grant execute to authenticated users
+GRANT EXECUTE ON FUNCTION public.permanently_delete_tombstone(uuid, uuid) TO authenticated;
+
+COMMENT ON FUNCTION public.permanently_delete_tombstone IS
+'Permanently removes a tombstone record from deleted_bank_transactions.
+After removal, the transaction can be re-imported by sync/CSV/PDF pipelines.';

--- a/supabase/tests/65_bank_delete_rpcs_membership_guard.sql
+++ b/supabase/tests/65_bank_delete_rpcs_membership_guard.sql
@@ -1,11 +1,13 @@
 -- File: supabase/tests/65_bank_delete_rpcs_membership_guard.sql
--- Description: RED-phase pgTAP tests for the missing membership guard on the
--- four bank-delete RPCs (delete_bank_transaction, bulk_delete_bank_transactions,
--- restore_deleted_transaction, permanently_delete_tombstone). Today none of
--- these functions check that the caller belongs to p_restaurant_id, so a user
--- from a different restaurant can delete, bulk-delete, restore, or purge
--- another tenant's bank data. Every throws_ok test below must fail against
--- the current schema (the attacker calls succeed today). See
+-- Description: pgTAP tests for the membership guard on the four bank-delete
+-- RPCs (delete_bank_transaction, bulk_delete_bank_transactions,
+-- restore_deleted_transaction, permanently_delete_tombstone). Each function
+-- must check caller membership on p_restaurant_id before it deletes,
+-- bulk-deletes, restores, or purges bank data. Without the check, a user
+-- from a different restaurant could do each of these to another tenant's
+-- bank data. The guard lives in
+-- supabase/migrations/20260820120000_bank_delete_rpcs_membership_guard.sql.
+-- These throws_ok tests pass against the current schema. See
 -- docs/superpowers/specs/2026-08-20-bank-delete-rpcs-membership-guard-design.md.
 
 BEGIN;

--- a/supabase/tests/65_bank_delete_rpcs_membership_guard.sql
+++ b/supabase/tests/65_bank_delete_rpcs_membership_guard.sql
@@ -1,0 +1,237 @@
+-- File: supabase/tests/65_bank_delete_rpcs_membership_guard.sql
+-- Description: RED-phase pgTAP tests for the missing membership guard on the
+-- four bank-delete RPCs (delete_bank_transaction, bulk_delete_bank_transactions,
+-- restore_deleted_transaction, permanently_delete_tombstone). Today none of
+-- these functions check that the caller belongs to p_restaurant_id, so a user
+-- from a different restaurant can delete, bulk-delete, restore, or purge
+-- another tenant's bank data. Every throws_ok test below must fail against
+-- the current schema (the attacker calls succeed today). See
+-- docs/superpowers/specs/2026-08-20-bank-delete-rpcs-membership-guard-design.md.
+
+BEGIN;
+SELECT plan(15);
+
+SET LOCAL role TO postgres;
+
+-- ---------------------------------------------------------------------------
+-- Fixtures (reserved 65... uuid range)
+-- ---------------------------------------------------------------------------
+
+-- Member user: belongs to the victim restaurant.
+INSERT INTO auth.users (id, email) VALUES
+  ('65000000-0000-0000-0000-000000000001'::uuid, 'guard-member@example.com')
+ON CONFLICT (id) DO NOTHING;
+
+-- Attacker user: belongs to a different restaurant only.
+INSERT INTO auth.users (id, email) VALUES
+  ('65000000-0000-0000-0000-000000000002'::uuid, 'guard-attacker@example.com')
+ON CONFLICT (id) DO NOTHING;
+
+-- Victim restaurant, owned by the member user.
+INSERT INTO restaurants (id, name) VALUES
+  ('65000000-0000-0000-0000-000000000010'::uuid, 'Guard Victim Restaurant')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO user_restaurants (user_id, restaurant_id, role) VALUES
+  ('65000000-0000-0000-0000-000000000001'::uuid, '65000000-0000-0000-0000-000000000010'::uuid, 'owner')
+ON CONFLICT (user_id, restaurant_id) DO UPDATE SET role = 'owner';
+
+-- Attacker restaurant, owned by the attacker user. No membership on the
+-- victim restaurant.
+INSERT INTO restaurants (id, name) VALUES
+  ('65000000-0000-0000-0000-000000000020'::uuid, 'Guard Attacker Restaurant')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO user_restaurants (user_id, restaurant_id, role) VALUES
+  ('65000000-0000-0000-0000-000000000002'::uuid, '65000000-0000-0000-0000-000000000020'::uuid, 'owner')
+ON CONFLICT (user_id, restaurant_id) DO UPDATE SET role = 'owner';
+
+-- Victim's connected bank.
+INSERT INTO connected_banks (id, restaurant_id, stripe_financial_account_id, institution_name) VALUES
+  ('65000000-0000-0000-0000-000000000030'::uuid, '65000000-0000-0000-0000-000000000010'::uuid, 'fa_test_guard_030', 'Guard Test Bank')
+ON CONFLICT (id) DO NOTHING;
+
+-- Victim category, used by the split fixture below.
+INSERT INTO chart_of_accounts (id, restaurant_id, account_code, account_name, account_type, account_subtype, normal_balance, is_active) VALUES
+  ('65000000-0000-0000-0000-000000000040'::uuid, '65000000-0000-0000-0000-000000000010'::uuid, '6500', 'Guard Test Expense', 'expense', 'operating_expenses', 'debit', true)
+ON CONFLICT (id) DO UPDATE SET account_name = EXCLUDED.account_name;
+
+-- Four victim bank_transactions rows.
+INSERT INTO bank_transactions (id, restaurant_id, connected_bank_id, stripe_transaction_id, transaction_date, description, amount, source) VALUES
+  ('65000000-0000-0000-0000-000000000101'::uuid, '65000000-0000-0000-0000-000000000010'::uuid, '65000000-0000-0000-0000-000000000030'::uuid, 'guard_txn_101', DATE '2026-02-01', 'Guard Test Txn 101', -10.00, 'bank_integration'),
+  ('65000000-0000-0000-0000-000000000102'::uuid, '65000000-0000-0000-0000-000000000010'::uuid, '65000000-0000-0000-0000-000000000030'::uuid, 'guard_txn_102', DATE '2026-02-02', 'Guard Test Txn 102', -20.00, 'bank_integration'),
+  ('65000000-0000-0000-0000-000000000103'::uuid, '65000000-0000-0000-0000-000000000010'::uuid, '65000000-0000-0000-0000-000000000030'::uuid, 'guard_txn_103', DATE '2026-02-03', 'Guard Test Txn 103', -30.00, 'bank_integration'),
+  ('65000000-0000-0000-0000-000000000104'::uuid, '65000000-0000-0000-0000-000000000010'::uuid, '65000000-0000-0000-0000-000000000030'::uuid, 'guard_txn_104', DATE '2026-02-04', 'Guard Test Txn 104', -40.00, 'bank_integration')
+ON CONFLICT (id) DO NOTHING;
+
+-- One split row on transaction 101.
+INSERT INTO bank_transaction_splits (id, transaction_id, category_id, amount, description) VALUES
+  ('65000000-0000-0000-0000-000000000050'::uuid, '65000000-0000-0000-0000-000000000101'::uuid, '65000000-0000-0000-0000-000000000040'::uuid, -10.00, 'Guard Test Split')
+ON CONFLICT (id) DO NOTHING;
+
+-- One tombstone row, inserted directly (not via delete_bank_transaction).
+INSERT INTO deleted_bank_transactions (id, restaurant_id, connected_bank_id, source, external_transaction_id, fingerprint, transaction_date, amount, description) VALUES
+  ('65000000-0000-0000-0000-000000000060'::uuid, '65000000-0000-0000-0000-000000000010'::uuid, '65000000-0000-0000-0000-000000000030'::uuid, 'bank_integration', 'guard_txn_060', compute_transaction_fingerprint(DATE '2026-02-05', -50.00, 'Guard Test Tombstone 060'), DATE '2026-02-05', -50.00, 'Guard Test Tombstone 060')
+ON CONFLICT (id) DO NOTHING;
+
+-- ---------------------------------------------------------------------------
+-- Section 1: attacker claims set. Every call must be rejected (4 tests).
+-- ---------------------------------------------------------------------------
+SELECT set_config('request.jwt.claims', '{"sub":"65000000-0000-0000-0000-000000000002","role":"authenticated"}', true);
+
+SELECT throws_ok(
+  $$ SELECT delete_bank_transaction(
+       '65000000-0000-0000-0000-000000000102'::uuid,
+       '65000000-0000-0000-0000-000000000010'::uuid
+     ) $$,
+  'Unauthorized: user does not have access to this restaurant',
+  'Attacker cannot call delete_bank_transaction on the victim restaurant'
+);
+
+SELECT throws_ok(
+  $$ SELECT bulk_delete_bank_transactions(
+       ARRAY['65000000-0000-0000-0000-000000000103'::uuid, '65000000-0000-0000-0000-000000000104'::uuid],
+       '65000000-0000-0000-0000-000000000010'::uuid
+     ) $$,
+  'Unauthorized: user does not have access to this restaurant',
+  'Attacker cannot call bulk_delete_bank_transactions on the victim restaurant'
+);
+
+SELECT throws_ok(
+  $$ SELECT restore_deleted_transaction(
+       '65000000-0000-0000-0000-000000000060'::uuid,
+       '65000000-0000-0000-0000-000000000010'::uuid
+     ) $$,
+  'Unauthorized: user does not have access to this restaurant',
+  'Attacker cannot call restore_deleted_transaction on the victim restaurant'
+);
+
+SELECT throws_ok(
+  $$ SELECT permanently_delete_tombstone(
+       '65000000-0000-0000-0000-000000000060'::uuid,
+       '65000000-0000-0000-0000-000000000010'::uuid
+     ) $$,
+  'Unauthorized: user does not have access to this restaurant',
+  'Attacker cannot call permanently_delete_tombstone on the victim restaurant'
+);
+
+-- ---------------------------------------------------------------------------
+-- Section 2: victim rows stay intact after the four failed calls (3 tests).
+-- ---------------------------------------------------------------------------
+SELECT is(
+  (SELECT count(*)::int FROM bank_transactions WHERE restaurant_id = '65000000-0000-0000-0000-000000000010'::uuid),
+  4,
+  'Victim bank_transactions count is unchanged after attacker calls'
+);
+
+SELECT is(
+  (SELECT count(*)::int FROM bank_transaction_splits WHERE transaction_id = '65000000-0000-0000-0000-000000000101'::uuid),
+  1,
+  'Victim bank_transaction_splits count is unchanged after attacker calls'
+);
+
+SELECT is(
+  (SELECT count(*)::int FROM deleted_bank_transactions WHERE restaurant_id = '65000000-0000-0000-0000-000000000010'::uuid),
+  1,
+  'Victim deleted_bank_transactions count is unchanged after attacker calls'
+);
+
+-- ---------------------------------------------------------------------------
+-- Section 3: no claims set (auth.uid() is NULL). Every call must be
+-- rejected (4 tests).
+-- ---------------------------------------------------------------------------
+SELECT set_config('request.jwt.claims', NULL, true);
+
+SELECT throws_ok(
+  $$ SELECT delete_bank_transaction(
+       '65000000-0000-0000-0000-000000000102'::uuid,
+       '65000000-0000-0000-0000-000000000010'::uuid
+     ) $$,
+  'Unauthorized: user does not have access to this restaurant',
+  'No claims: delete_bank_transaction is rejected'
+);
+
+SELECT throws_ok(
+  $$ SELECT bulk_delete_bank_transactions(
+       ARRAY['65000000-0000-0000-0000-000000000103'::uuid, '65000000-0000-0000-0000-000000000104'::uuid],
+       '65000000-0000-0000-0000-000000000010'::uuid
+     ) $$,
+  'Unauthorized: user does not have access to this restaurant',
+  'No claims: bulk_delete_bank_transactions is rejected'
+);
+
+SELECT throws_ok(
+  $$ SELECT restore_deleted_transaction(
+       '65000000-0000-0000-0000-000000000060'::uuid,
+       '65000000-0000-0000-0000-000000000010'::uuid
+     ) $$,
+  'Unauthorized: user does not have access to this restaurant',
+  'No claims: restore_deleted_transaction is rejected'
+);
+
+SELECT throws_ok(
+  $$ SELECT permanently_delete_tombstone(
+       '65000000-0000-0000-0000-000000000060'::uuid,
+       '65000000-0000-0000-0000-000000000010'::uuid
+     ) $$,
+  'Unauthorized: user does not have access to this restaurant',
+  'No claims: permanently_delete_tombstone is rejected'
+);
+
+-- ---------------------------------------------------------------------------
+-- Section 4: member claims set. Every call succeeds (4 tests).
+-- ---------------------------------------------------------------------------
+SELECT set_config('request.jwt.claims', '{"sub":"65000000-0000-0000-0000-000000000001","role":"authenticated"}', true);
+
+SELECT is(
+  (delete_bank_transaction(
+    '65000000-0000-0000-0000-000000000102'::uuid,
+    '65000000-0000-0000-0000-000000000010'::uuid
+  ))->>'success',
+  'true',
+  'Member: delete_bank_transaction succeeds on the victim restaurant'
+);
+
+SELECT is(
+  (bulk_delete_bank_transactions(
+    ARRAY['65000000-0000-0000-0000-000000000103'::uuid, '65000000-0000-0000-0000-000000000104'::uuid],
+    '65000000-0000-0000-0000-000000000010'::uuid
+  ))->>'success',
+  'true',
+  'Member: bulk_delete_bank_transactions succeeds on the victim restaurant'
+);
+
+SELECT is(
+  (restore_deleted_transaction(
+    '65000000-0000-0000-0000-000000000060'::uuid,
+    '65000000-0000-0000-0000-000000000010'::uuid
+  ))->>'success',
+  'true',
+  'Member: restore_deleted_transaction succeeds on the victim restaurant'
+);
+
+-- Tombstone left behind by the delete_bank_transaction call above, used to
+-- exercise the success path for permanently_delete_tombstone.
+DO $$
+DECLARE
+  v_tombstone_id UUID;
+BEGIN
+  SELECT id INTO v_tombstone_id
+  FROM deleted_bank_transactions
+  WHERE restaurant_id = '65000000-0000-0000-0000-000000000010'::uuid
+  AND external_transaction_id = 'guard_txn_102';
+
+  PERFORM set_config('test.guard_tombstone_id', v_tombstone_id::text, true);
+END $$;
+
+SELECT is(
+  (permanently_delete_tombstone(
+    (current_setting('test.guard_tombstone_id'))::uuid,
+    '65000000-0000-0000-0000-000000000010'::uuid
+  ))->>'success',
+  'true',
+  'Member: permanently_delete_tombstone succeeds on the victim restaurant'
+);
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/65_bank_delete_rpcs_membership_guard.sql
+++ b/supabase/tests/65_bank_delete_rpcs_membership_guard.sql
@@ -22,17 +22,17 @@ SET LOCAL role TO postgres;
 -- Member user: belongs to the victim restaurant.
 INSERT INTO auth.users (id, email) VALUES
   ('65000000-0000-0000-0000-000000000001'::uuid, 'guard-member@example.com')
-ON CONFLICT (id) DO NOTHING;
+ON CONFLICT (id) DO UPDATE SET email = EXCLUDED.email;
 
 -- Attacker user: belongs to a different restaurant only.
 INSERT INTO auth.users (id, email) VALUES
   ('65000000-0000-0000-0000-000000000002'::uuid, 'guard-attacker@example.com')
-ON CONFLICT (id) DO NOTHING;
+ON CONFLICT (id) DO UPDATE SET email = EXCLUDED.email;
 
 -- Victim restaurant, owned by the member user.
 INSERT INTO restaurants (id, name) VALUES
   ('65000000-0000-0000-0000-000000000010'::uuid, 'Guard Victim Restaurant')
-ON CONFLICT (id) DO NOTHING;
+ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name;
 
 INSERT INTO user_restaurants (user_id, restaurant_id, role) VALUES
   ('65000000-0000-0000-0000-000000000001'::uuid, '65000000-0000-0000-0000-000000000010'::uuid, 'owner')
@@ -42,7 +42,7 @@ ON CONFLICT (user_id, restaurant_id) DO UPDATE SET role = 'owner';
 -- victim restaurant.
 INSERT INTO restaurants (id, name) VALUES
   ('65000000-0000-0000-0000-000000000020'::uuid, 'Guard Attacker Restaurant')
-ON CONFLICT (id) DO NOTHING;
+ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name;
 
 INSERT INTO user_restaurants (user_id, restaurant_id, role) VALUES
   ('65000000-0000-0000-0000-000000000002'::uuid, '65000000-0000-0000-0000-000000000020'::uuid, 'owner')
@@ -51,7 +51,10 @@ ON CONFLICT (user_id, restaurant_id) DO UPDATE SET role = 'owner';
 -- Victim's connected bank.
 INSERT INTO connected_banks (id, restaurant_id, stripe_financial_account_id, institution_name) VALUES
   ('65000000-0000-0000-0000-000000000030'::uuid, '65000000-0000-0000-0000-000000000010'::uuid, 'fa_test_guard_030', 'Guard Test Bank')
-ON CONFLICT (id) DO NOTHING;
+ON CONFLICT (id) DO UPDATE SET
+  restaurant_id = EXCLUDED.restaurant_id,
+  stripe_financial_account_id = EXCLUDED.stripe_financial_account_id,
+  institution_name = EXCLUDED.institution_name;
 
 -- Victim category, used by the split fixture below.
 INSERT INTO chart_of_accounts (id, restaurant_id, account_code, account_name, account_type, account_subtype, normal_balance, is_active) VALUES
@@ -64,17 +67,36 @@ INSERT INTO bank_transactions (id, restaurant_id, connected_bank_id, stripe_tran
   ('65000000-0000-0000-0000-000000000102'::uuid, '65000000-0000-0000-0000-000000000010'::uuid, '65000000-0000-0000-0000-000000000030'::uuid, 'guard_txn_102', DATE '2026-02-02', 'Guard Test Txn 102', -20.00, 'bank_integration'),
   ('65000000-0000-0000-0000-000000000103'::uuid, '65000000-0000-0000-0000-000000000010'::uuid, '65000000-0000-0000-0000-000000000030'::uuid, 'guard_txn_103', DATE '2026-02-03', 'Guard Test Txn 103', -30.00, 'bank_integration'),
   ('65000000-0000-0000-0000-000000000104'::uuid, '65000000-0000-0000-0000-000000000010'::uuid, '65000000-0000-0000-0000-000000000030'::uuid, 'guard_txn_104', DATE '2026-02-04', 'Guard Test Txn 104', -40.00, 'bank_integration')
-ON CONFLICT (id) DO NOTHING;
+ON CONFLICT (id) DO UPDATE SET
+  restaurant_id = EXCLUDED.restaurant_id,
+  connected_bank_id = EXCLUDED.connected_bank_id,
+  stripe_transaction_id = EXCLUDED.stripe_transaction_id,
+  transaction_date = EXCLUDED.transaction_date,
+  description = EXCLUDED.description,
+  amount = EXCLUDED.amount,
+  source = EXCLUDED.source;
 
 -- One split row on transaction 101.
 INSERT INTO bank_transaction_splits (id, transaction_id, category_id, amount, description) VALUES
   ('65000000-0000-0000-0000-000000000050'::uuid, '65000000-0000-0000-0000-000000000101'::uuid, '65000000-0000-0000-0000-000000000040'::uuid, -10.00, 'Guard Test Split')
-ON CONFLICT (id) DO NOTHING;
+ON CONFLICT (id) DO UPDATE SET
+  transaction_id = EXCLUDED.transaction_id,
+  category_id = EXCLUDED.category_id,
+  amount = EXCLUDED.amount,
+  description = EXCLUDED.description;
 
 -- One tombstone row, inserted directly (not via delete_bank_transaction).
 INSERT INTO deleted_bank_transactions (id, restaurant_id, connected_bank_id, source, external_transaction_id, fingerprint, transaction_date, amount, description) VALUES
   ('65000000-0000-0000-0000-000000000060'::uuid, '65000000-0000-0000-0000-000000000010'::uuid, '65000000-0000-0000-0000-000000000030'::uuid, 'bank_integration', 'guard_txn_060', compute_transaction_fingerprint(DATE '2026-02-05', -50.00, 'Guard Test Tombstone 060'), DATE '2026-02-05', -50.00, 'Guard Test Tombstone 060')
-ON CONFLICT (id) DO NOTHING;
+ON CONFLICT (id) DO UPDATE SET
+  restaurant_id = EXCLUDED.restaurant_id,
+  connected_bank_id = EXCLUDED.connected_bank_id,
+  source = EXCLUDED.source,
+  external_transaction_id = EXCLUDED.external_transaction_id,
+  fingerprint = EXCLUDED.fingerprint,
+  transaction_date = EXCLUDED.transaction_date,
+  amount = EXCLUDED.amount,
+  description = EXCLUDED.description;
 
 -- ---------------------------------------------------------------------------
 -- Section 1: attacker claims set. Every call must be rejected (4 tests).

--- a/supabase/tests/deleted_bank_transactions_tombstone.sql
+++ b/supabase/tests/deleted_bank_transactions_tombstone.sql
@@ -152,6 +152,18 @@ BEGIN
   );
 END $$;
 
+-- Member user: belongs to the test restaurant. The four delete/restore RPCs
+-- now check membership, so the functional tests below need a real caller.
+INSERT INTO auth.users (id, email) VALUES
+  ('a0000000-0000-0000-0000-000000000099'::uuid, 'tombstone-member@example.com')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO user_restaurants (user_id, restaurant_id, role) VALUES
+  ('a0000000-0000-0000-0000-000000000099'::uuid, 'a0000000-0000-0000-0000-000000000001'::uuid, 'owner')
+ON CONFLICT (user_id, restaurant_id) DO UPDATE SET role = 'owner';
+
+SELECT set_config('request.jwt.claims', '{"sub":"a0000000-0000-0000-0000-000000000099","role":"authenticated"}', true);
+
 -- ============================================================
 -- Test 13: delete_bank_transaction creates tombstone and removes active row
 -- ============================================================

--- a/tests/e2e/bank-delete-cross-tenant.spec.ts
+++ b/tests/e2e/bank-delete-cross-tenant.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect } from '@playwright/test';
+import { exposeSupabaseHelpers, generateTestUser, signUpAndCreateRestaurant } from '../helpers/e2e-supabase';
+
+/**
+ * E2E: `bulk_delete_bank_transactions` must reject a caller who does not
+ * belong to the target restaurant, and must still work for a caller who
+ * does. Guards supabase/migrations/20260820120000_bank_delete_rpcs_membership_guard.sql.
+ */
+test('bulk_delete_bank_transactions rejects a caller from another restaurant', async ({
+  page,
+  browser,
+}) => {
+  // User A: owns the restaurant and the transaction under attack.
+  const userA = generateTestUser('cross-tenant-a');
+  await signUpAndCreateRestaurant(page, userA);
+  await exposeSupabaseHelpers(page);
+
+  const restaurantIdA = await page.evaluate(() => (window as any).__getRestaurantId()); // eslint-disable-line @typescript-eslint/no-explicit-any
+  expect(restaurantIdA).toBeTruthy();
+
+  const transactionId = await page.evaluate(async (restaurantId: string) => {
+    const supabase = (window as any).__supabase; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+    const stripeAccountId = `test-bank-${crypto.randomUUID()}`;
+    const { data: bank, error: bankError } = await supabase
+      .from('connected_banks')
+      .insert({
+        restaurant_id: restaurantId,
+        stripe_financial_account_id: stripeAccountId,
+        institution_name: 'Test Bank',
+        status: 'connected',
+      })
+      .select()
+      .single();
+    if (bankError) throw bankError;
+
+    const { data: txn, error: txnError } = await supabase
+      .from('bank_transactions')
+      .insert({
+        restaurant_id: restaurantId,
+        connected_bank_id: bank.id,
+        stripe_transaction_id: `test-txn-${crypto.randomUUID()}`,
+        description: 'Cross-Tenant Guard Test Transaction',
+        amount: -42.0,
+        transaction_date: new Date().toISOString().split('T')[0],
+        is_categorized: false,
+      })
+      .select()
+      .single();
+    if (txnError) throw txnError;
+    return txn.id as string;
+  }, restaurantIdA);
+
+  expect(transactionId).toBeTruthy();
+
+  // User B: a second person, in a second browser context, with their own
+  // restaurant. No membership on restaurant A at all.
+  const userBContext = await browser.newContext();
+  const userBPage = await userBContext.newPage();
+  const userB = generateTestUser('cross-tenant-b');
+  await signUpAndCreateRestaurant(userBPage, userB);
+
+  const attackResult = await userBPage.evaluate(
+    async ({ txnId, restaurantId }: { txnId: string; restaurantId: string }) => {
+      const supabase = (window as any).__supabase; // eslint-disable-line @typescript-eslint/no-explicit-any
+      const { data, error } = await supabase.rpc('bulk_delete_bank_transactions', {
+        p_transaction_ids: [txnId],
+        p_restaurant_id: restaurantId,
+      });
+      return { data, error: error ? { message: error.message } : null };
+    },
+    { txnId: transactionId, restaurantId: restaurantIdA }
+  );
+
+  expect(attackResult.error).toBeTruthy();
+  expect(attackResult.error?.message).toMatch(/unauthorized/i);
+
+  await userBContext.close();
+
+  // User A's transaction survived the attack.
+  const stillExists = await page.evaluate(async (txnId: string) => {
+    const supabase = (window as any).__supabase; // eslint-disable-line @typescript-eslint/no-explicit-any
+    const { data, error } = await supabase
+      .from('bank_transactions')
+      .select('id')
+      .eq('id', txnId)
+      .maybeSingle();
+    if (error) throw error;
+    return Boolean(data);
+  }, transactionId);
+  expect(stillExists).toBe(true);
+
+  // User A deletes their own transaction through the same RPC: this must
+  // still succeed, so the guard does not block the legitimate owner.
+  const ownResult = await page.evaluate(
+    async ({ txnId, restaurantId }: { txnId: string; restaurantId: string }) => {
+      const supabase = (window as any).__supabase; // eslint-disable-line @typescript-eslint/no-explicit-any
+      const { data, error } = await supabase.rpc('bulk_delete_bank_transactions', {
+        p_transaction_ids: [txnId],
+        p_restaurant_id: restaurantId,
+      });
+      return { data, error: error ? { message: error.message } : null };
+    },
+    { txnId: transactionId, restaurantId: restaurantIdA }
+  );
+
+  expect(ownResult.error).toBeNull();
+  expect(ownResult.data?.success).toBe(true);
+  expect(ownResult.data?.deleted_count).toBe(1);
+
+  const goneAfterOwnerDelete = await page.evaluate(async (txnId: string) => {
+    const supabase = (window as any).__supabase; // eslint-disable-line @typescript-eslint/no-explicit-any
+    const { data, error } = await supabase
+      .from('bank_transactions')
+      .select('id')
+      .eq('id', txnId)
+      .maybeSingle();
+    if (error) throw error;
+    return Boolean(data);
+  }, transactionId);
+  expect(goneAfterOwnerDelete).toBe(false);
+});

--- a/tests/e2e/bank-delete-cross-tenant.spec.ts
+++ b/tests/e2e/bank-delete-cross-tenant.spec.ts
@@ -1,11 +1,33 @@
-import { test, expect } from '@playwright/test';
-import { exposeSupabaseHelpers, generateTestUser, signUpAndCreateRestaurant } from '../helpers/e2e-supabase';
+import { test, expect, type Page } from '@playwright/test';
+import {
+  exposeSupabaseHelpers,
+  generateTestUser,
+  signUpAndCreateRestaurant,
+  type E2EHelperWindow,
+} from '../helpers/e2e-supabase';
 
 /**
  * E2E: `bulk_delete_bank_transactions` must reject a caller who does not
  * belong to the target restaurant, and must still work for a caller who
  * does. Guards supabase/migrations/20260820120000_bank_delete_rpcs_membership_guard.sql.
  */
+
+// True when a `bank_transactions` row with `txnId` still exists. Shared by
+// both the pre-attack and post-delete checks below, so the two assertions
+// stay in sync with each other.
+async function transactionExists(page: Page, txnId: string): Promise<boolean> {
+  return page.evaluate(async (id: string) => {
+    const supabase = (window as E2EHelperWindow).__supabase;
+    const { data, error } = await supabase
+      .from('bank_transactions')
+      .select('id')
+      .eq('id', id)
+      .maybeSingle();
+    if (error) throw error;
+    return Boolean(data);
+  }, txnId);
+}
+
 test('bulk_delete_bank_transactions rejects a caller from another restaurant', async ({
   page,
   browser,
@@ -15,11 +37,11 @@ test('bulk_delete_bank_transactions rejects a caller from another restaurant', a
   await signUpAndCreateRestaurant(page, userA);
   await exposeSupabaseHelpers(page);
 
-  const restaurantIdA = await page.evaluate(() => (window as any).__getRestaurantId()); // eslint-disable-line @typescript-eslint/no-explicit-any
+  const restaurantIdA = await page.evaluate(() => (window as E2EHelperWindow).__getRestaurantId());
   expect(restaurantIdA).toBeTruthy();
 
   const transactionId = await page.evaluate(async (restaurantId: string) => {
-    const supabase = (window as any).__supabase; // eslint-disable-line @typescript-eslint/no-explicit-any
+    const supabase = (window as E2EHelperWindow).__supabase;
 
     const stripeAccountId = `test-bank-${crypto.randomUUID()}`;
     const { data: bank, error: bankError } = await supabase
@@ -62,7 +84,7 @@ test('bulk_delete_bank_transactions rejects a caller from another restaurant', a
 
   const attackResult = await userBPage.evaluate(
     async ({ txnId, restaurantId }: { txnId: string; restaurantId: string }) => {
-      const supabase = (window as any).__supabase; // eslint-disable-line @typescript-eslint/no-explicit-any
+      const supabase = (window as E2EHelperWindow).__supabase;
       const { data, error } = await supabase.rpc('bulk_delete_bank_transactions', {
         p_transaction_ids: [txnId],
         p_restaurant_id: restaurantId,
@@ -78,23 +100,14 @@ test('bulk_delete_bank_transactions rejects a caller from another restaurant', a
   await userBContext.close();
 
   // User A's transaction survived the attack.
-  const stillExists = await page.evaluate(async (txnId: string) => {
-    const supabase = (window as any).__supabase; // eslint-disable-line @typescript-eslint/no-explicit-any
-    const { data, error } = await supabase
-      .from('bank_transactions')
-      .select('id')
-      .eq('id', txnId)
-      .maybeSingle();
-    if (error) throw error;
-    return Boolean(data);
-  }, transactionId);
+  const stillExists = await transactionExists(page, transactionId);
   expect(stillExists).toBe(true);
 
   // User A deletes their own transaction through the same RPC: this must
   // still succeed, so the guard does not block the legitimate owner.
   const ownResult = await page.evaluate(
     async ({ txnId, restaurantId }: { txnId: string; restaurantId: string }) => {
-      const supabase = (window as any).__supabase; // eslint-disable-line @typescript-eslint/no-explicit-any
+      const supabase = (window as E2EHelperWindow).__supabase;
       const { data, error } = await supabase.rpc('bulk_delete_bank_transactions', {
         p_transaction_ids: [txnId],
         p_restaurant_id: restaurantId,
@@ -108,15 +121,6 @@ test('bulk_delete_bank_transactions rejects a caller from another restaurant', a
   expect(ownResult.data?.success).toBe(true);
   expect(ownResult.data?.deleted_count).toBe(1);
 
-  const goneAfterOwnerDelete = await page.evaluate(async (txnId: string) => {
-    const supabase = (window as any).__supabase; // eslint-disable-line @typescript-eslint/no-explicit-any
-    const { data, error } = await supabase
-      .from('bank_transactions')
-      .select('id')
-      .eq('id', txnId)
-      .maybeSingle();
-    if (error) throw error;
-    return Boolean(data);
-  }, transactionId);
+  const goneAfterOwnerDelete = await transactionExists(page, transactionId);
   expect(goneAfterOwnerDelete).toBe(false);
 });


### PR DESCRIPTION
## Summary
- Add a membership guard to four SECURITY DEFINER bank delete RPCs: `delete_bank_transaction`, `bulk_delete_bank_transactions`, `restore_deleted_transaction`, `permanently_delete_tombstone`.
- Before this fix, each function filtered rows by `p_restaurant_id` only. No function checked that the caller belongs to that restaurant. An authenticated user from one tenant could pass another tenant's `restaurant_id` and delete that tenant's bank data.
- The guard matches the existing pattern in `categorize_bank_transaction`: an inline `EXISTS` check against `user_restaurants`, first statement in each function body. `CREATE OR REPLACE` keeps bodies otherwise byte-identical, plus existing grants.
- New migration: `supabase/migrations/20260820120000_bank_delete_rpcs_membership_guard.sql`.
- Update the tombstone pgTAP test to set JWT claims for a member user, since the guard now rejects the old no-claims calls.
- Add a new pgTAP suite (`supabase/tests/65_bank_delete_rpcs_membership_guard.sql`) and a new Playwright E2E spec (`tests/e2e/bank-delete-cross-tenant.spec.ts`) that proves a cross-tenant caller gets rejected and the row survives.

Design doc: [docs/superpowers/specs/2026-08-20-bank-delete-rpcs-membership-guard-design.md](https://github.com/toyiyo/nimble-pnl/blob/fix/bank-delete-rpcs-membership-guard/docs/superpowers/specs/2026-08-20-bank-delete-rpcs-membership-guard-design.md)

## Test plan
- [x] `npm run test` — 786 files, 9452 tests pass, 2 skipped.
- [x] `npm run test:db` — 2976/2976 pgTAP tests pass, 0 failed (after `npm run db:reset`).
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — 0 errors in this branch's files (1540 pre-existing errors elsewhere, out of scope).
- [x] `npm run build` — succeeds.
- [x] `npx playwright test tests/e2e/bank-delete-cross-tenant.spec.ts --project=e2e --reporter=line` — 1 passed, run twice with real evidence (21.8s and 16.5s).
- [ ] Full `npm run test:e2e` suite (229 specs) — not run to completion locally. The shared local Supabase stack on this dev machine had sustained, concurrent `supabase db reset` calls from sibling worktrees during this work. By human decision, CI's isolated environment is the authoritative gate for this check. See `progress.md` Phase 8 for the full trace.

## Known deferred review findings
- `supabase/migrations/20260820120000_bank_delete_rpcs_membership_guard.sql:31` — major — Codex: the guard checks restaurant membership only, not role. A collaborator_accountant member can call delete_bank_transaction or bulk_delete_bank_transactions directly through the RPC and pass the guard, even though the RLS delete policy on bank_transactions restricts DELETE to owner/manager roles only. SECURITY DEFINER makes the function bypass that RLS policy. — Fixing this would widen this design's scope to add role enforcement, which the approved design doc explicitly rejects here (design.md: "the guard does not block collaborators"; Out of scope section names sibling branch fix/secdef-execute-grants as the tracking location). Phase 7a already triaged this identical finding and reached the same verdict: PLAUSIBLE, pre-existing (predates this migration), not a regression introduced by this diff. Not escalating to needs_human because the approved design already made this call explicitly; re-fixing here would be an unapproved design change, not a bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added membership authorization to bank transaction deletion, bulk deletion, restoration, and permanent removal operations.
  - Authorized restaurant members can continue managing records, while cross-restaurant and unauthenticated requests are rejected.
- **Bug Fixes**
  - Prevented unauthorized users from modifying or deleting another restaurant’s bank data.
  - Added safeguards ensuring rejected requests leave existing records unchanged.
- **Tests**
  - Added database and end-to-end coverage for authorized, unauthorized, and cross-restaurant scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->