### PR TITLE
fix(scheduling): allow trade approval from the scheduling area grant

### DIFF
--- a/docs/superpowers/plans/2026-08-20-trade-approval-area-grant-plan.md
+++ b/docs/superpowers/plans/2026-08-20-trade-approval-area-grant-plan.md
@@ -1,0 +1,121 @@
+# Plan: shift-trade approval from the scheduling area grant
+
+Date: 2026-08-20
+Branch: `fix/trade-approval-area-grant`
+Design: docs/superpowers/specs/2026-08-20-trade-approval-area-grant-design.md
+Worktree: .claude/worktrees/trade-approval-area-grant
+
+Each step lists its tests first. Write the test, see it fail, write the
+code, see it pass, commit.
+
+## Step 1: Migration
+
+File: `supabase/migrations/<fresh-14-digit-timestamp>_trade_approval_area_grant.sql`.
+Check that the timestamp prefix is unique repo-wide before you commit.
+
+1. Write a provenance header. Name the source migration for each object:
+   - `approve_shift_trade`, `reject_shift_trade` from
+     `20260713010000_harden_accept_shift_trade.sql`.
+   - `create_shift_trade_for_employee` from
+     `20260814130000_allow_draft_shift_trade.sql`.
+   - The three policies from `20260104120000_create_shift_trades.sql`
+     and `20260105000000_fix_shift_trades_rls.sql`.
+2. Re-create `approve_shift_trade` and `reject_shift_trade` from the
+   latest bodies. Change only the guard condition to:
+   `IF NOT user_has_capability((SELECT restaurant_id FROM shift_trades WHERE id = p_trade_id), 'edit:scheduling') THEN`
+   with error `Unauthorized: schedule manage access required`.
+   Warning: keep the guard BEFORE the `FOR UPDATE` fetch. The order
+   prevents a trade-ID existence oracle (see the design doc).
+   Keep `SECURITY DEFINER`, `SET search_path = public, pg_temp`, the
+   `p_manager_user_id != auth.uid()` check, the GRANT statements, and
+   the COMMENT statements (update the comment text).
+3. Re-create `create_shift_trade_for_employee` from the latest body.
+   Same guard swap with `p_restaurant_id` as the helper argument. Write
+   a function comment that states: the guard mirrors the approve
+   audience; both move to `edit:scheduling` in this migration, so the
+   old "dead-end approval queue" rationale no longer applies.
+4. Drop and re-create the three policies with the SAME names:
+   - `"Managers can view all shift trades"` (SELECT)
+   - `"Managers can approve or reject trades"` (UPDATE, keep
+     `WITH CHECK (true)`)
+   - `"Managers can delete shift trades"` (DELETE)
+   Each with
+   `USING (user_has_capability(shift_trades.restaurant_id, 'edit:scheduling'))`.
+
+## Step 2: pgTAP tests
+
+New file `supabase/tests/<next-NN>_trade_approval_area_grant.test.sql`.
+Follow the BEGIN / plan(N) / finish() / ROLLBACK pattern. Non-vacuous
+subjects: each subject satisfies ONLY the clause under test.
+
+Tests:
+1. A member with `role = 'collaborator_custom'` and a custom role with
+   `role_areas('scheduling','manage')`: `approve_shift_trade` returns
+   `success = true`; `reject_shift_trade` returns `success = true` (on a
+   second trade); SELECT sees all restaurant trades; DELETE removes a
+   trade.
+2. The same shape at level `view`: both RPCs return
+   `Unauthorized: schedule manage access required`; SELECT sees zero
+   non-participant trades; DELETE removes zero rows.
+3. A legacy `operations_manager` with no `role_id`: approve succeeds.
+4. A caller with no membership row: approve and reject fail closed with
+   the generic error, for a real trade ID and for a random ID.
+
+Impersonate with `set_config('request.jwt.claims', ...)`. Add
+`SET LOCAL role = 'authenticated'` only for the RLS assertions. `RESET
+ROLE` before `finish()`.
+
+Change the existing suite `supabase/tests/53_directed_shift_trade_rls.sql`:
+- Test 6 (line ~180): change `0::bigint` to `1::bigint`.
+- Change the test comment and the header comment (lines 6-7): the
+  SELECT policy now admits every holder of `edit:scheduling`, dated
+  2026-08-20.
+
+Run: `npm run db:reset` then `npm run test:db`. All suites must pass.
+
+## Step 3: Frontend gate
+
+File: `src/pages/Scheduling.tsx`.
+
+1. Unit test first (`tests/unit/scheduling-trades-gate.test.tsx` or
+   similar): with `edit:scheduling` resolved, the trades tab shows; with
+   only `view:scheduling`, it does not; while unresolved, it does not.
+2. Import `usePermissions`. Compute
+   `const canManageSchedule = isResolved && hasCapability('edit:scheduling')`.
+3. Wrap the trades `TabsTrigger` (line ~906) and the trades
+   `TabsContent` (line ~1632) in `{canManageSchedule && (...)}`.
+4. Convert the `Tabs` at line ~881 to controlled state. Reset to
+   `'schedule'` when the active tab is `'trades'` and
+   `canManageSchedule` is false. Copy the pattern from
+   `src/pages/RestaurantSettings.tsx:420-438`.
+5. Run `npm run typecheck`, `npm run lint`, `npm run test`.
+
+## Step 4: E2E
+
+Extend `tests/e2e/manager-initiated-shift-trade.spec.ts` or add
+`tests/e2e/custom-role-trade-approval.spec.ts`:
+- Create a custom role with `scheduling@manage` (pattern:
+  `tests/e2e/roles-and-areas.spec.ts`).
+- Sign in as that member. Open the schedule page. The trades tab shows.
+- Approve a pending trade. The trade status changes to approved.
+- Negative check: a member with `scheduling@view` does not see the
+  trades tab.
+
+## Step 5: Verify
+
+- `npm run typecheck && npm run lint && npm run test`
+- `npm run db:reset && npm run test:db`
+- E2E for the touched specs.
+
+## Step 6: PR
+
+Title: `fix(scheduling): allow trade approval from the scheduling area grant`.
+Body: problem (Eden's error), the audience table from the design doc,
+the change list, the test evidence, and the out-of-scope note for
+open-shift claims.
+
+## Out of scope
+
+- `approve_open_shift_claim` / `reject_open_shift_claim` keep their
+  legacy guard. File a follow-up task after the PR.
+- `cancel_shift_trade` does not change.

--- a/docs/superpowers/specs/2026-08-20-trade-approval-area-grant-design.md
+++ b/docs/superpowers/specs/2026-08-20-trade-approval-area-grant-design.md
@@ -43,8 +43,8 @@ returned `Unauthorized: Manager access required`.
   The legacy CASE grants `edit:scheduling` to
   `('owner', 'manager', 'operations_manager', 'collaborator_operations_manager')`
   (supabase/migrations/20260730140000_user_has_capability_from_areas.sql:146).
-  The helper fails closed for a non-member (line 83) and for a member with
-  no `role_id` and no `role` string (line 90).
+  The helper fails closed for a non-member (line 80) and for a member with
+  no `role_id` and no `role` string (line 86).
 - RLS policies already call this helper in production. Example:
   `user_has_capability(restaurant_id, 'edit:scheduling')`
   (supabase/migrations/20260730150000_rewrite_collaborator_policies.sql:79).
@@ -101,14 +101,29 @@ The `operations_manager` rows are the deliberate product change that
   bodies from `20260713010000_harden_accept_shift_trade.sql` (the latest
   definitions; confirmed by
   `grep -rlE "FUNCTION\s+(public\.)?approve_shift_trade" supabase/migrations | sort`).
-  Change only the guard block:
-  `IF NOT user_has_capability(v_trade.restaurant_id, 'edit:scheduling') THEN`
+  Change only the guard condition. The current bodies run the guard
+  BEFORE the `FOR UPDATE` fetch, with a subquery for the restaurant
+  (20260713010000_harden_accept_shift_trade.sql:141). Keep that order.
+  The order prevents a trade-ID existence oracle: an unauthorized caller
+  gets the same generic error for a real ID and for a fake ID. The
+  sibling `approve_open_shift_claim` documents this pattern
+  (supabase/migrations/20260721140000_open_shift_claim_authz_guard.sql:391).
+  New guard:
+  `IF NOT user_has_capability((SELECT restaurant_id FROM shift_trades WHERE id = p_trade_id), 'edit:scheduling') THEN`
   with error `Unauthorized: schedule manage access required`.
+  A fake ID makes the subquery return NULL; the helper then finds no
+  membership row and fails closed, so the error stays generic.
   Keep `SECURITY DEFINER`, keep `SET search_path = public, pg_temp`, keep
   the `p_manager_user_id != auth.uid()` check, keep the grants and update
   the function comments.
 - Re-create `create_shift_trade_for_employee`. Source the body from
-  `20260814130000_allow_draft_shift_trade.sql`. Same guard swap.
+  `20260814130000_allow_draft_shift_trade.sql`. Same guard swap, with
+  `p_restaurant_id` as the helper argument. The source migration's
+  comment (lines 27-31) rejects `edit:scheduling` because it would
+  create a dead-end approval queue. That rationale is now stale: this
+  migration moves `approve_shift_trade` and `reject_shift_trade` to the
+  same predicate, so the "mirrors the approve audience" invariant stays
+  true. State this in the new function comment.
 - Drop and re-create the three policies with the same names and with
   `USING (user_has_capability(shift_trades.restaurant_id, 'edit:scheduling'))`:
   `"Managers can view all shift trades"` (SELECT),
@@ -118,9 +133,6 @@ The `operations_manager` rows are the deliberate product change that
   Keep the policy names so `16_shift_trades_security.sql:144` stays true.
 - Write a provenance header that names the source migration for each
   re-created object (lesson 2026-07-22).
-- Note: the trade row carries `restaurant_id`, so the guard reads
-  `v_trade.restaurant_id` after the `FOR UPDATE` fetch. The fetch happens
-  before the guard in the current bodies; keep that order.
 
 ### 2. pgTAP tests (new file)
 
@@ -143,14 +155,38 @@ Impersonate with `set_config('request.jwt.claims', ...)` for `auth.uid()`;
 add `SET LOCAL role = 'authenticated'` only for the RLS assertions; `RESET
 ROLE` before `finish()` (lesson 2026-07-22).
 
+Also change one existing suite. Test 6 in
+`supabase/tests/53_directed_shift_trade_rls.sql:180` asserts that an
+`operations_manager` sees zero directed trades. The widened SELECT policy
+makes that count 1. Change the assertion to `1::bigint`. Change the test
+comment and the file header (lines 6-7) to state the widened audience and
+the date. Without this change, `npm run test:db` fails.
+
 ### 3. Frontend
 
 Gate the manager trade surfaces on the same capability:
 
 - In `src/pages/Scheduling.tsx`, hide the trades `TabsTrigger`
   (line 906) and the trades `TabsContent` (line 1632) when
-  `hasCapability('edit:scheduling')` is false. This deletes the dead
-  approval queue that a chef sees today.
+  `isResolved && hasCapability('edit:scheduling')` is false. The page
+  does not import `usePermissions` today; add the import. The
+  `isResolved` guard follows the house pattern
+  (src/components/ReactivateEmployeeDialog.tsx:36,
+  src/pages/Expenses.tsx:94) and prevents a late tab pop-in for a
+  manager on first paint. This deletes the dead approval queue that a
+  chef sees today.
+- The `Tabs` at src/pages/Scheduling.tsx:881 is uncontrolled
+  (`defaultValue="schedule"`). When the trades tab hides while active,
+  an uncontrolled `Tabs` shows a blank panel. Convert the `Tabs` to
+  controlled state and reset to `schedule` when the active tab is not
+  allowed. Copy the pattern from
+  src/pages/RestaurantSettings.tsx:420-438.
+- The pending-trade badges (src/pages/Scheduling.tsx:911,
+  src/pages/Scheduling.tsx:1642) live inside the gated blocks and need
+  no separate gate. The `useShiftTrades(restaurantId,
+  'pending_approval', null)` fetch at src/pages/Scheduling.tsx:313
+  stays unconditional; after the RLS change it returns zero rows for a
+  non-manager, so it is a wasted fetch, not a leak.
 - No change in `TradeApprovalQueue` internals: after the gate, every
   viewer of the queue can act on it.
 
@@ -160,7 +196,9 @@ Gate the manager trade surfaces on the same capability:
   with only `view:scheduling` it does not.
 - E2E: extend `tests/e2e/manager-initiated-shift-trade.spec.ts` (or add a
   spec) so a member with a custom `scheduling@manage` role approves a
-  pending trade end to end.
+  pending trade end to end. The custom-role setup pattern is in
+  `tests/e2e/roles-and-areas.spec.ts` (there is no helper for it in
+  `tests/helpers/e2e-supabase.ts`).
 
 ## Out of scope (filed as follow-up)
 

--- a/docs/superpowers/specs/2026-08-20-trade-approval-area-grant-design.md
+++ b/docs/superpowers/specs/2026-08-20-trade-approval-area-grant-design.md
@@ -1,0 +1,182 @@
+# Design: shift-trade approval from the scheduling area grant
+
+Date: 2026-08-20
+Branch: `fix/trade-approval-area-grant`
+Ticket context: closes the product decision filed as `task_d9ab7984`
+(supabase/migrations/20260713000000_restrict_directed_shift_trade_visibility.sql:17).
+
+## Problem
+
+A member with a custom role can hold the `scheduling` area at the `manage`
+level. The schedule page then shows the trade approval queue to that member.
+The approve call fails. The database still checks the legacy role string.
+
+Production evidence: user `edenaragon184@gmail.com` holds the custom
+collaborator role "Operations lead". The role grants `scheduling` at
+`manage`. The member row has `role = 'collaborator_custom'`. The RPC
+returned `Unauthorized: Manager access required`.
+
+## Current behavior (cited)
+
+- `approve_shift_trade` rejects a caller when
+  `v_user_role IS NULL OR v_user_role NOT IN ('owner', 'manager')`
+  (supabase/migrations/20260713010000_harden_accept_shift_trade.sql:153).
+- `reject_shift_trade` has the same guard
+  (supabase/migrations/20260713010000_harden_accept_shift_trade.sql:230).
+- `create_shift_trade_for_employee` has the same guard in its latest body
+  (supabase/migrations/20260814130000_allow_draft_shift_trade.sql:42).
+- `cancel_shift_trade` is offerer-only and has no manager branch
+  (supabase/migrations/20260713010000_harden_accept_shift_trade.sql:287).
+  It does not change.
+- RLS policy `"Managers can view all shift trades"` (SELECT) checks
+  `role IN ('owner', 'manager')`
+  (supabase/migrations/20260104120000_create_shift_trades.sql:123).
+- RLS policy `"Managers can approve or reject trades"` (UPDATE) has the same
+  check (supabase/migrations/20260104120000_create_shift_trades.sql:135).
+- RLS policy `"Managers can delete shift trades"` (DELETE) has the same
+  check (supabase/migrations/20260105000000_fix_shift_trades_rls.sql:36).
+- The SQL helper `public.user_has_capability(p_restaurant_id, p_capability)`
+  resolves a capability from `role_areas` when the member has a `role_id`,
+  and from a legacy role CASE when the member does not
+  (supabase/migrations/20260730140000_user_has_capability_from_areas.sql:57).
+  The map row `('edit:scheduling', 'scheduling', 'manage')` is at line 226.
+  The legacy CASE grants `edit:scheduling` to
+  `('owner', 'manager', 'operations_manager', 'collaborator_operations_manager')`
+  (supabase/migrations/20260730140000_user_has_capability_from_areas.sql:146).
+  The helper fails closed for a non-member (line 83) and for a member with
+  no `role_id` and no `role` string (line 90).
+- RLS policies already call this helper in production. Example:
+  `user_has_capability(restaurant_id, 'edit:scheduling')`
+  (supabase/migrations/20260730150000_rewrite_collaborator_policies.sql:79).
+- The frontend derives the same capability from the same grants
+  (src/hooks/usePermissions.ts:140). The approve hook calls the RPC
+  (src/hooks/useShiftTrades.ts:448).
+- `Scheduling.tsx` shows the trades tab and the approval queue to every
+  member who can open the page. The tab trigger has no capability gate
+  (src/pages/Scheduling.tsx:906) and the queue render has no capability
+  gate (src/pages/Scheduling.tsx:1632). The queue mounts approve, reject,
+  and delete mutations (src/components/schedule/TradeApprovalQueue.tsx:117,
+  src/components/schedule/TradeApprovalQueue.tsx:155).
+- No frontend code matches on the error string
+  `Unauthorized: Manager access required` (grep of `src/` returned zero
+  rows), so the message can change.
+- pgTAP suites that touch these objects:
+  `supabase/tests/16_shift_trades_security.sql:144` asserts the policy name
+  `Managers can delete shift trades` exists.
+  `supabase/tests/17_shift_trade_functions_security.sql:174` asserts a
+  caller with no membership row fails closed on approve and reject.
+  `supabase/tests/53_directed_shift_trade_rls.sql` covers directed-trade
+  visibility.
+
+## Decision
+
+Make `user_has_capability(restaurant_id, 'edit:scheduling')` the single
+authorization predicate for every manager-side shift-trade surface: the
+three RPC guards and the three RLS policies. The read audience and the
+action audience stay equal (lesson 2026-07-13: a read grant without the
+matching action grant shows a dead queue).
+
+Audience change, stated plainly:
+
+| Caller | Before | After |
+|---|---|---|
+| owner, manager (legacy or migrated) | allowed | allowed |
+| custom role with `scheduling@manage` (Eden) | denied | allowed |
+| builtin `operations_manager` / `collaborator_operations_manager` | denied | allowed |
+| custom role with `scheduling@view` | denied | denied |
+| chef (has `view:scheduling` only) | denied | denied |
+| non-member, or member with no role data | denied | denied (fail closed) |
+
+The `operations_manager` rows are the deliberate product change that
+`task_d9ab7984` deferred. The user approved this direction in chat on
+2026-08-20.
+
+## Changes
+
+### 1. Migration (one file)
+
+`supabase/migrations/<fresh-timestamp>_trade_approval_area_grant.sql`:
+
+- Re-create `approve_shift_trade` and `reject_shift_trade`. Source the
+  bodies from `20260713010000_harden_accept_shift_trade.sql` (the latest
+  definitions; confirmed by
+  `grep -rlE "FUNCTION\s+(public\.)?approve_shift_trade" supabase/migrations | sort`).
+  Change only the guard block:
+  `IF NOT user_has_capability(v_trade.restaurant_id, 'edit:scheduling') THEN`
+  with error `Unauthorized: schedule manage access required`.
+  Keep `SECURITY DEFINER`, keep `SET search_path = public, pg_temp`, keep
+  the `p_manager_user_id != auth.uid()` check, keep the grants and update
+  the function comments.
+- Re-create `create_shift_trade_for_employee`. Source the body from
+  `20260814130000_allow_draft_shift_trade.sql`. Same guard swap.
+- Drop and re-create the three policies with the same names and with
+  `USING (user_has_capability(shift_trades.restaurant_id, 'edit:scheduling'))`:
+  `"Managers can view all shift trades"` (SELECT),
+  `"Managers can approve or reject trades"` (UPDATE, keep
+  `WITH CHECK (true)`),
+  `"Managers can delete shift trades"` (DELETE).
+  Keep the policy names so `16_shift_trades_security.sql:144` stays true.
+- Write a provenance header that names the source migration for each
+  re-created object (lesson 2026-07-22).
+- Note: the trade row carries `restaurant_id`, so the guard reads
+  `v_trade.restaurant_id` after the `FOR UPDATE` fetch. The fetch happens
+  before the guard in the current bodies; keep that order.
+
+### 2. pgTAP tests (new file)
+
+`supabase/tests/<NN>_trade_approval_area_grant.test.sql`, with per-clause,
+non-vacuous subjects (lesson 2026-07-13):
+
+1. A member whose only grant is a custom role with `scheduling@manage`
+   (no `employees` row, `role = 'collaborator_custom'`) can:
+   call `approve_shift_trade` with success; call `reject_shift_trade`
+   with success; SELECT all trades in the restaurant; DELETE a trade.
+2. A member with the same custom-role shape at `scheduling@view` gets
+   `Unauthorized: schedule manage access required` from both RPCs, sees
+   zero non-participant trades, and deletes zero rows.
+3. A legacy `operations_manager` (no `role_id`) can approve — this pins
+   the widened legacy audience.
+4. A caller with no membership row still fails closed (keeps the intent of
+   `17_shift_trade_functions_security.sql:174`).
+
+Impersonate with `set_config('request.jwt.claims', ...)` for `auth.uid()`;
+add `SET LOCAL role = 'authenticated'` only for the RLS assertions; `RESET
+ROLE` before `finish()` (lesson 2026-07-22).
+
+### 3. Frontend
+
+Gate the manager trade surfaces on the same capability:
+
+- In `src/pages/Scheduling.tsx`, hide the trades `TabsTrigger`
+  (line 906) and the trades `TabsContent` (line 1632) when
+  `hasCapability('edit:scheduling')` is false. This deletes the dead
+  approval queue that a chef sees today.
+- No change in `TradeApprovalQueue` internals: after the gate, every
+  viewer of the queue can act on it.
+
+### 4. Tests (TypeScript)
+
+- Unit test for the tab gate: with `edit:scheduling` the trades tab shows;
+  with only `view:scheduling` it does not.
+- E2E: extend `tests/e2e/manager-initiated-shift-trade.spec.ts` (or add a
+  spec) so a member with a custom `scheduling@manage` role approves a
+  pending trade end to end.
+
+## Out of scope (filed as follow-up)
+
+- Open-shift claims: `approve_open_shift_claim` keeps its
+  `('owner','manager','operations_manager')` guard. A custom-role member
+  with `scheduling@manage` cannot approve claims yet. Same pattern, its
+  own PR.
+- The stale-marketplace-trade visibility risk documented in
+  `20260805130000_self_scope_employee_reads.sql:60` is unrelated and
+  unchanged.
+
+## Decided trade-offs
+
+- The RPC guards and the RLS policies both call a `STABLE SECURITY
+  DEFINER` plpgsql helper. The policy rewrite migration `20260730150000`
+  set this precedent on hotter tables; trade volume is low.
+- `WITH CHECK (true)` on the UPDATE policy is kept as-is. Approve and
+  reject go through the SECURITY DEFINER RPCs; the policy exists for
+  direct updates by the same audience. Narrowing it is not this task.

--- a/src/pages/Scheduling.tsx
+++ b/src/pages/Scheduling.tsx
@@ -10,6 +10,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
 import { useRestaurantContext } from '@/contexts/RestaurantContext';
+import { usePermissions } from '@/hooks/usePermissions';
 import { useRestaurantClock } from '@/hooks/useRestaurantClock';
 import { useEmployees } from '@/hooks/useEmployees';
 import { FeatureGate } from '@/components/subscription';
@@ -224,6 +225,13 @@ const Scheduling = () => {
   const navigate = useNavigate();
   const { selectedRestaurant } = useRestaurantContext();
   const restaurantId = selectedRestaurant?.restaurant_id || null;
+  const { hasCapability, isResolved } = usePermissions();
+  // Gate for the manager trade surfaces (tab + approval queue). Matches the
+  // server-side capability the widened trade-visibility RLS policy checks
+  // (docs/superpowers/specs/2026-08-20-trade-approval-area-grant-design.md
+  // §3), so a chef with only `view:scheduling` no longer sees a tab that
+  // leads to a queue the server would reject their actions on anyway.
+  const canManageSchedule = isResolved && hasCapability('edit:scheduling');
   // Only an owner or a manager can post a trade for an employee. This mirrors
   // the create_shift_trade_for_employee RPC audience, so the offer action never
   // shows for a role the RPC would reject (e.g. operations_manager).
@@ -249,6 +257,7 @@ const Scheduling = () => {
   const { weekStart: currentWeekStart, setWeekStart: setCurrentWeekStart } = useSharedWeek();
   const { guardShiftChange, notifyAfterDeferredCommit, dialog: publishedShiftChangeDialog } =
     usePublishedShiftGuard();
+  const [activeTab, setActiveTab] = useState('schedule');
   const [employeeDialogOpen, setEmployeeDialogOpen] = useState(false);
   const [shiftDialogOpen, setShiftDialogOpen] = useState(false);
   const [timeOffDialogOpen, setTimeOffDialogOpen] = useState(false);
@@ -294,6 +303,16 @@ const Scheduling = () => {
       setUnpublishNotify(true);
     }
   }, [unpublishDialogOpen]);
+
+  // The trades tab hides for a viewer without edit:scheduling. If that
+  // viewer is on the trades tab when the gate closes (role change, or the
+  // capability resolves after first paint), fall back to the schedule tab
+  // instead of showing a blank panel.
+  useEffect(() => {
+    if (activeTab === 'trades' && !canManageSchedule) {
+      setActiveTab('schedule');
+    }
+  }, [activeTab, canManageSchedule]);
 
   // Memoized so downstream hook deps (useShifts, useWeekPublicationStatus, etc.)
   // and weekDayKeys/weekTimeOff memos are stable across drag/hover/selection re-renders.
@@ -878,7 +897,7 @@ const Scheduling = () => {
       />
 
       {/* Tabs for Schedule, Time-Off, and Availability */}
-      <Tabs defaultValue="schedule" className="space-y-4">
+      <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-4">
         <TabsList className="bg-muted/50 p-1 h-auto gap-1">
           <TabsTrigger
             value="schedule"
@@ -902,18 +921,20 @@ const Scheduling = () => {
             <CalendarClock className="h-4 w-4" />
             <span className="hidden sm:inline">Availability</span>
           </TabsTrigger>
-          <TabsTrigger
-            value="trades"
-            className="data-[state=active]:bg-background data-[state=active]:shadow-sm px-4 py-2.5 gap-2 relative"
-          >
-            <ArrowLeftRight className="h-4 w-4" />
-            <span className="hidden sm:inline">Shift Trades</span>
-            {pendingTradeCount > 0 && (
-              <Badge className="ml-1 h-5 min-w-5 px-1.5 bg-warning text-warning-foreground text-[10px] font-bold animate-pulse">
-                {pendingTradeCount}
-              </Badge>
-            )}
-          </TabsTrigger>
+          {canManageSchedule && (
+            <TabsTrigger
+              value="trades"
+              className="data-[state=active]:bg-background data-[state=active]:shadow-sm px-4 py-2.5 gap-2 relative"
+            >
+              <ArrowLeftRight className="h-4 w-4" />
+              <span className="hidden sm:inline">Shift Trades</span>
+              {pendingTradeCount > 0 && (
+                <Badge className="ml-1 h-5 min-w-5 px-1.5 bg-warning text-warning-foreground text-[10px] font-bold animate-pulse">
+                  {pendingTradeCount}
+                </Badge>
+              )}
+            </TabsTrigger>
+          )}
           <TabsTrigger
             value="planner"
             aria-label="Planner"
@@ -1629,33 +1650,35 @@ const Scheduling = () => {
         </TabsContent>
 
         {/* Shift Trades Tab */}
-        <TabsContent value="trades">
-          <Card className="border-border/50 overflow-hidden">
-            <CardHeader className="bg-gradient-to-r from-muted/30 via-muted/50 to-muted/30 border-b border-border/50 pb-4">
-              <div className="flex items-center gap-3">
-                <div className="p-2 rounded-lg bg-warning/10">
-                  <ArrowLeftRight className="h-5 w-5 text-warning" />
+        {canManageSchedule && (
+          <TabsContent value="trades">
+            <Card className="border-border/50 overflow-hidden">
+              <CardHeader className="bg-gradient-to-r from-muted/30 via-muted/50 to-muted/30 border-b border-border/50 pb-4">
+                <div className="flex items-center gap-3">
+                  <div className="p-2 rounded-lg bg-warning/10">
+                    <ArrowLeftRight className="h-5 w-5 text-warning" />
+                  </div>
+                  <div>
+                    <CardTitle className="text-lg flex items-center gap-2">
+                      Shift Trade Requests
+                      {pendingTradeCount > 0 && (
+                        <Badge className="bg-warning/15 text-warning border border-warning/30 text-xs">
+                          {pendingTradeCount} pending
+                        </Badge>
+                      )}
+                    </CardTitle>
+                    <CardDescription className="text-sm">
+                      Review and approve shift swap requests from your team
+                    </CardDescription>
+                  </div>
                 </div>
-                <div>
-                  <CardTitle className="text-lg flex items-center gap-2">
-                    Shift Trade Requests
-                    {pendingTradeCount > 0 && (
-                      <Badge className="bg-warning/15 text-warning border border-warning/30 text-xs">
-                        {pendingTradeCount} pending
-                      </Badge>
-                    )}
-                  </CardTitle>
-                  <CardDescription className="text-sm">
-                    Review and approve shift swap requests from your team
-                  </CardDescription>
-                </div>
-              </div>
-            </CardHeader>
-            <CardContent className="p-0">
-              <TradeApprovalQueue />
-            </CardContent>
-          </Card>
-        </TabsContent>
+              </CardHeader>
+              <CardContent className="p-0">
+                <TradeApprovalQueue />
+              </CardContent>
+            </Card>
+          </TabsContent>
+        )}
 
         <TabsContent value="planner">
           {restaurantId && (

--- a/src/pages/Scheduling.tsx
+++ b/src/pages/Scheduling.tsx
@@ -232,11 +232,13 @@ const Scheduling = () => {
   // §3), so a chef with only `view:scheduling` no longer sees a tab that
   // leads to a queue the server would reject their actions on anyway.
   const canManageSchedule = isResolved && hasCapability('edit:scheduling');
-  // Only an owner or a manager can post a trade for an employee. This mirrors
-  // the create_shift_trade_for_employee RPC audience, so the offer action never
-  // shows for a role the RPC would reject (e.g. operations_manager).
-  const canOfferTrade =
-    selectedRestaurant?.role === 'owner' || selectedRestaurant?.role === 'manager';
+  // Same capability as canManageSchedule. This mirrors the
+  // create_shift_trade_for_employee RPC audience
+  // (supabase/migrations/20260820120000_trade_approval_area_grant.sql),
+  // which now checks edit:scheduling instead of a hardcoded owner/manager
+  // role, so the offer action shows for every role the RPC would accept
+  // (operations_manager and a custom scheduling@manage role included).
+  const canOfferTrade = canManageSchedule;
   // `safeTz`, not `|| 'UTC'` — this value now feeds WRITE paths (drag-copy,
   // copy-week, planner create/update) where it decides the UTC instant that
   // gets stored, not just how a cell is labelled. `restaurants.timezone` is

--- a/supabase/migrations/20260820120000_trade_approval_area_grant.sql
+++ b/supabase/migrations/20260820120000_trade_approval_area_grant.sql
@@ -1,0 +1,299 @@
+-- Move the shift-trade approval audience from a fixed owner/manager role
+-- check to the edit:scheduling capability, so a role granted schedule
+-- management through the areas system (e.g. operations_manager) can act on
+-- trades too.
+--
+-- Design: docs/superpowers/specs/2026-08-20-trade-approval-area-grant-design.md
+--
+-- Provenance (source migration for each object re-created below):
+--   approve_shift_trade, reject_shift_trade
+--     <- 20260713010000_harden_accept_shift_trade.sql
+--   create_shift_trade_for_employee
+--     <- 20260814130000_allow_draft_shift_trade.sql
+--   "Managers can view all shift trades" (SELECT)
+--     <- 20260104120000_create_shift_trades.sql
+--   "Managers can approve or reject trades" (UPDATE)
+--     <- 20260104120000_create_shift_trades.sql
+--   "Managers can delete shift trades" (DELETE)
+--     <- 20260105000000_fix_shift_trades_rls.sql
+--
+-- Every body below is copied from its source migration verbatim except for
+-- the guard swap described in each block. The guard check stays BEFORE the
+-- `FOR UPDATE` trade fetch in approve_shift_trade and reject_shift_trade:
+-- moving it after would let an unauthorized caller learn whether a trade ID
+-- exists from the error message alone (a trade-ID existence oracle).
+
+-- Function to approve a shift trade (manager)
+-- This transfers shift ownership and updates trade status
+CREATE OR REPLACE FUNCTION approve_shift_trade(
+  p_trade_id UUID,
+  p_manager_user_id UUID,
+  p_manager_note TEXT DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_trade shift_trades;
+  v_shift shifts;
+BEGIN
+  -- Verify caller is the manager specified
+  IF p_manager_user_id != auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Unauthorized');
+  END IF;
+
+  -- Capability check replaces the owner/manager role literal check. This
+  -- admits any role granted edit:scheduling (owner, manager,
+  -- operations_manager, collaborator_operations_manager today), not only
+  -- owner/manager. Runs before the FOR UPDATE fetch below on purpose: see
+  -- the file header.
+  IF NOT user_has_capability((SELECT restaurant_id FROM shift_trades WHERE id = p_trade_id), 'edit:scheduling') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Unauthorized: schedule manage access required');
+  END IF;
+
+  -- Get the trade with row lock
+  SELECT * INTO v_trade
+  FROM shift_trades
+  WHERE id = p_trade_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Trade not found');
+  END IF;
+
+  -- Check trade is pending approval
+  IF v_trade.status != 'pending_approval' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Trade is not pending approval');
+  END IF;
+
+  -- Check accepting employee is set
+  IF v_trade.accepted_by_employee_id IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'No employee has accepted this trade');
+  END IF;
+
+  -- Transfer shift ownership
+  UPDATE shifts
+  SET
+    employee_id = v_trade.accepted_by_employee_id,
+    updated_at = NOW()
+  WHERE id = v_trade.offered_shift_id;
+
+  -- Update trade status
+  UPDATE shift_trades
+  SET
+    status = 'approved',
+    reviewed_by = p_manager_user_id,
+    reviewed_at = NOW(),
+    manager_note = p_manager_note,
+    updated_at = NOW()
+  WHERE id = p_trade_id;
+
+  RETURN jsonb_build_object('success', true);
+END;
+$$;
+
+-- Function to reject a shift trade (manager)
+CREATE OR REPLACE FUNCTION reject_shift_trade(
+  p_trade_id UUID,
+  p_manager_user_id UUID,
+  p_manager_note TEXT DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_trade shift_trades;
+BEGIN
+  -- Verify caller is the manager specified
+  IF p_manager_user_id != auth.uid() THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Unauthorized');
+  END IF;
+
+  -- Capability check replaces the owner/manager role literal check. See the
+  -- matching comment in approve_shift_trade above; the ordering rule (before
+  -- the FOR UPDATE fetch) is the same and for the same reason.
+  IF NOT user_has_capability((SELECT restaurant_id FROM shift_trades WHERE id = p_trade_id), 'edit:scheduling') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Unauthorized: schedule manage access required');
+  END IF;
+
+  -- Get the trade with row lock
+  SELECT * INTO v_trade
+  FROM shift_trades
+  WHERE id = p_trade_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Trade not found');
+  END IF;
+
+  -- Check trade is pending approval
+  IF v_trade.status != 'pending_approval' THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Trade is not pending approval');
+  END IF;
+
+  -- Update trade status
+  UPDATE shift_trades
+  SET
+    status = 'rejected',
+    reviewed_by = p_manager_user_id,
+    reviewed_at = NOW(),
+    manager_note = p_manager_note,
+    updated_at = NOW()
+  WHERE id = p_trade_id;
+
+  RETURN jsonb_build_object('success', true);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION approve_shift_trade(UUID, UUID, TEXT) TO authenticated;
+GRANT EXECUTE ON FUNCTION reject_shift_trade(UUID, UUID, TEXT) TO authenticated;
+
+COMMENT ON FUNCTION approve_shift_trade(UUID, UUID, TEXT) IS 'Manager (or any role with edit:scheduling) approves a shift trade and transfers ownership';
+COMMENT ON FUNCTION reject_shift_trade(UUID, UUID, TEXT) IS 'Manager (or any role with edit:scheduling) rejects a shift trade';
+
+-- Function to let a manager post a draft trade for an employee.
+--
+-- The guard mirrors the approve audience on purpose: both approve and post
+-- move to edit:scheduling in this migration, so the old "dead-end approval
+-- queue" rationale (posting with a wider audience than approving) no longer
+-- applies — the two now share the same audience.
+CREATE OR REPLACE FUNCTION create_shift_trade_for_employee(
+  p_restaurant_id UUID,
+  p_offered_shift_id UUID,
+  p_offered_by_employee_id UUID,
+  p_target_employee_id UUID DEFAULT NULL,
+  p_reason TEXT DEFAULT NULL
+)
+RETURNS UUID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_shift shifts;
+  v_new_trade_id UUID;
+BEGIN
+  -- Authorization: the caller must hold edit:scheduling for this restaurant.
+  IF NOT user_has_capability(p_restaurant_id, 'edit:scheduling') THEN
+    RAISE EXCEPTION 'Unauthorized: schedule manage access required';
+  END IF;
+
+  -- Load the offered shift. Filter by restaurant_id here, not in a separate
+  -- check after the load: a cross-restaurant shift id must raise the same
+  -- 'Shift not found' as a missing one, so the error never tells a caller
+  -- that a given id exists in someone else's restaurant.
+  SELECT * INTO v_shift
+  FROM shifts
+  WHERE id = p_offered_shift_id
+    AND restaurant_id = p_restaurant_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Shift not found';
+  END IF;
+
+  -- The shift must belong to the employee named as the offerer.
+  IF v_shift.employee_id IS DISTINCT FROM p_offered_by_employee_id THEN
+    RAISE EXCEPTION 'Shift does not belong to this employee';
+  END IF;
+
+  -- Only a live shift can be traded (allow-list, not deny-list).
+  IF v_shift.status NOT IN ('scheduled', 'confirmed') THEN
+    RAISE EXCEPTION 'Only a scheduled or confirmed shift can be traded';
+  END IF;
+
+  -- The offered employee must be active in this restaurant. Without this guard
+  -- a manager can post a trade for a terminated employee: deactivate_employee
+  -- auto-cancels only 'scheduled' shifts, so a 'confirmed' shift of an inactive
+  -- employee stays tradeable.
+  IF NOT EXISTS (
+    SELECT 1 FROM employees
+    WHERE id = p_offered_by_employee_id
+      AND restaurant_id = p_restaurant_id
+      AND is_active = true
+  ) THEN
+    RAISE EXCEPTION 'Offered employee is not active';
+  END IF;
+
+  -- Directed trade: the target must be a different, active employee of this
+  -- restaurant.
+  IF p_target_employee_id IS NOT NULL THEN
+    IF p_target_employee_id = p_offered_by_employee_id THEN
+      RAISE EXCEPTION 'Cannot direct a trade to the same employee';
+    END IF;
+    IF NOT EXISTS (
+      SELECT 1 FROM employees
+      WHERE id = p_target_employee_id
+        AND restaurant_id = p_restaurant_id
+        AND is_active = true
+    ) THEN
+      RAISE EXCEPTION 'Target employee not found or inactive';
+    END IF;
+  END IF;
+
+  -- Insert the trade. The partial unique index
+  -- idx_unique_active_trade_per_shift blocks a second active trade on the same
+  -- shift; translate that into a clear message instead of a raw 23505.
+  BEGIN
+    INSERT INTO shift_trades (
+      restaurant_id,
+      offered_shift_id,
+      offered_by_employee_id,
+      target_employee_id,
+      reason,
+      status
+    ) VALUES (
+      p_restaurant_id,
+      p_offered_shift_id,
+      p_offered_by_employee_id,
+      p_target_employee_id,
+      p_reason,
+      'open'
+    )
+    RETURNING id INTO v_new_trade_id;
+  EXCEPTION
+    WHEN unique_violation THEN
+      RAISE EXCEPTION 'This shift already has an active trade';
+  END;
+
+  RETURN v_new_trade_id;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION create_shift_trade_for_employee(UUID, UUID, UUID, UUID, TEXT) TO authenticated;
+
+COMMENT ON FUNCTION create_shift_trade_for_employee(UUID, UUID, UUID, UUID, TEXT) IS 'Any role with edit:scheduling posts a draft trade for an employee; mirrors the approve audience so posting and approving share one audience';
+
+-- Re-create the three shift_trades RLS policies on the edit:scheduling
+-- capability, same names, same USING semantics otherwise.
+DROP POLICY IF EXISTS "Managers can view all shift trades" ON shift_trades;
+DROP POLICY IF EXISTS "Managers can approve or reject trades" ON shift_trades;
+DROP POLICY IF EXISTS "Managers can delete shift trades" ON shift_trades;
+
+CREATE POLICY "Managers can view all shift trades"
+  ON shift_trades FOR SELECT
+  USING (user_has_capability(shift_trades.restaurant_id, 'edit:scheduling'));
+
+CREATE POLICY "Managers can approve or reject trades"
+  ON shift_trades FOR UPDATE
+  USING (user_has_capability(shift_trades.restaurant_id, 'edit:scheduling'))
+  WITH CHECK (
+    -- Managers can update any field and set any status
+    true
+  );
+
+CREATE POLICY "Managers can delete shift trades"
+  ON shift_trades FOR DELETE
+  USING (user_has_capability(shift_trades.restaurant_id, 'edit:scheduling'));
+
+COMMENT ON POLICY "Managers can view all shift trades" ON shift_trades IS
+  'Any role with edit:scheduling can view all shift trades in their restaurants.';
+
+COMMENT ON POLICY "Managers can approve or reject trades" ON shift_trades IS
+  'Any role with edit:scheduling can approve or reject shift trades in their restaurants.';
+
+COMMENT ON POLICY "Managers can delete shift trades" ON shift_trades IS
+  'Any role with edit:scheduling can delete any shift trades in their restaurants.';

--- a/supabase/tests/53_directed_shift_trade_rls.sql
+++ b/supabase/tests/53_directed_shift_trade_rls.sql
@@ -2,14 +2,16 @@
 -- Test: directed shift_trades visibility (RLS)
 --
 -- Directed trades (target_employee_id set) must be private to the target,
--- offerer, and accepter — plus owners/managers who see everything via the
--- separate "Managers can view all shift trades" policy (Policy 4, owner/manager
--- only; operations_manager is deliberately excluded to match the owner/manager-
--- only approve/reject RPCs). Today, Policy 1 ("Employees can view shift trades
--- in their restaurant") only checks restaurant membership, so ANY active
--- employee (a bystander) can read a directed trade. This test proves that gap
--- (RED) and locks in correct visibility once the follow-up migration tightens
--- Policy 1 (GREEN). Policy 4 is unchanged.
+-- offerer, and accepter — plus any holder of edit:scheduling, who sees
+-- everything via the separate "Managers can view all shift trades" policy
+-- (Policy 4). As of 2026-08-20, Policy 4 admits every role with
+-- edit:scheduling, not only owner/manager: operations_manager holds
+-- edit:scheduling in the legacy CASE, so it now sees the directed trade
+-- too, matching the approve/reject RPCs it can now call. Today, Policy 1
+-- ("Employees can view shift trades in their restaurant") only checks
+-- restaurant membership, so ANY active employee (a bystander) can read a
+-- directed trade. This test proves that gap (RED) and locks in correct
+-- visibility once the follow-up migration tightens Policy 1 (GREEN).
 --
 -- Migration under test (not yet applied when this test is written):
 --   supabase/migrations/<ts>_restrict_directed_shift_trade_visibility.sql
@@ -178,11 +180,12 @@ SELECT is(
 );
 
 -- ============================================================================
--- Test 6: Operations_manager O does NOT see the DIRECTED trade → 0 rows.
--- Policy 4 is deliberately left owner/manager-only: the approve/reject RPCs and
--- delete policy are owner/manager-only, so exposing trades to an operations_manager
--- who cannot action them would only surface a dead approval queue. O has no
--- employees row, so Policy 1 doesn't grant access either.
+-- Test 6: Operations_manager O sees the DIRECTED trade → 1 row.
+-- Policy 4 now admits every holder of edit:scheduling (2026-08-20), and the
+-- legacy CASE grants operations_manager edit:scheduling — the same
+-- capability the approve/reject RPCs now check — so O sees the trade via
+-- the manager policy, same as owner/manager. O has no employees row, so
+-- Policy 1 still grants nothing on its own; this row comes from Policy 4.
 -- ============================================================================
 RESET ROLE;
 SET LOCAL role = 'authenticated';
@@ -190,8 +193,8 @@ SELECT set_config('request.jwt.claims', '{"sub":"53000000-0000-0000-0000-0000000
 
 SELECT is(
   (SELECT COUNT(*) FROM shift_trades WHERE id = '53000000-0000-0000-0000-000000000051'),
-  0::bigint,
-  'Operations_manager O does NOT see the directed trade (Policy 4 is owner/manager only)'
+  1::bigint,
+  'Operations_manager O sees the directed trade via the manager policy (edit:scheduling)'
 );
 
 -- ============================================================================

--- a/supabase/tests/65_trade_approval_area_grant.test.sql
+++ b/supabase/tests/65_trade_approval_area_grant.test.sql
@@ -152,11 +152,11 @@ SELECT is(
   'Scenario 1: custom role at scheduling:manage sees all four restaurant trades via the manager SELECT policy'
 );
 
+DELETE FROM shift_trades WHERE id = '65000000-0000-0000-0000-000000000053';
+
 SELECT is(
-  (WITH deleted AS (
-    DELETE FROM shift_trades WHERE id = '65000000-0000-0000-0000-000000000053' RETURNING id
-  ) SELECT COUNT(*) FROM deleted),
-  1::bigint,
+  (SELECT COUNT(*) FROM shift_trades WHERE id = '65000000-0000-0000-0000-000000000053'),
+  0::bigint,
   'Scenario 1: custom role at scheduling:manage can delete a trade'
 );
 
@@ -192,11 +192,11 @@ SELECT is(
   'Scenario 2: custom role at scheduling:view only, a non-participant, sees zero restaurant trades'
 );
 
+DELETE FROM shift_trades WHERE id = '65000000-0000-0000-0000-000000000054';
+
 SELECT is(
-  (WITH deleted AS (
-    DELETE FROM shift_trades WHERE id = '65000000-0000-0000-0000-000000000054' RETURNING id
-  ) SELECT COUNT(*) FROM deleted),
-  0::bigint,
+  (SELECT COUNT(*) FROM shift_trades WHERE id = '65000000-0000-0000-0000-000000000054'),
+  1::bigint,
   'Scenario 2: custom role at scheduling:view only deletes zero rows'
 );
 

--- a/supabase/tests/65_trade_approval_area_grant.test.sql
+++ b/supabase/tests/65_trade_approval_area_grant.test.sql
@@ -152,11 +152,14 @@ SELECT is(
   'Scenario 1: custom role at scheduling:manage sees all four restaurant trades via the manager SELECT policy'
 );
 
-DELETE FROM shift_trades WHERE id = '65000000-0000-0000-0000-000000000053';
+WITH deleted AS (
+  DELETE FROM shift_trades WHERE id = '65000000-0000-0000-0000-000000000053' RETURNING id
+)
+SELECT COUNT(*) AS deleted_count FROM deleted \gset
 
 SELECT is(
-  (SELECT COUNT(*) FROM shift_trades WHERE id = '65000000-0000-0000-0000-000000000053'),
-  0::bigint,
+  :deleted_count::bigint,
+  1::bigint,
   'Scenario 1: custom role at scheduling:manage can delete a trade'
 );
 
@@ -192,11 +195,14 @@ SELECT is(
   'Scenario 2: custom role at scheduling:view only, a non-participant, sees zero restaurant trades'
 );
 
-DELETE FROM shift_trades WHERE id = '65000000-0000-0000-0000-000000000054';
+WITH deleted AS (
+  DELETE FROM shift_trades WHERE id = '65000000-0000-0000-0000-000000000054' RETURNING id
+)
+SELECT COUNT(*) AS deleted_count FROM deleted \gset
 
 SELECT is(
-  (SELECT COUNT(*) FROM shift_trades WHERE id = '65000000-0000-0000-0000-000000000054'),
-  1::bigint,
+  :deleted_count::bigint,
+  0::bigint,
   'Scenario 2: custom role at scheduling:view only deletes zero rows'
 );
 

--- a/supabase/tests/65_trade_approval_area_grant.test.sql
+++ b/supabase/tests/65_trade_approval_area_grant.test.sql
@@ -1,0 +1,257 @@
+-- ============================================================================
+-- Test: trade approval moves to the edit:scheduling capability
+--
+-- approve_shift_trade, reject_shift_trade, and the shift_trades RLS
+-- policies now gate on user_has_capability(restaurant_id, 'edit:scheduling')
+-- instead of a hardcoded owner/manager role check. This covers every
+-- audience shape that check now admits or still denies:
+--   1. A custom role at scheduling:manage (edit:scheduling) — approve,
+--      reject, SELECT (all trades), and DELETE all succeed.
+--   2. A custom role at scheduling:view only (view:scheduling, NOT
+--      edit:scheduling) — approve, reject, SELECT (non-participant), and
+--      DELETE all fail closed.
+--   3. A legacy operations_manager (role_id NULL) — approve succeeds,
+--      confirming the legacy CASE fallback still grants edit:scheduling to
+--      this role string.
+--   4. A caller with no user_restaurants row at all — approve and reject
+--      fail closed with the SAME error for a real trade ID and a random
+--      one, proving there is no trade-ID existence oracle.
+--
+-- Design: docs/superpowers/specs/2026-08-20-trade-approval-area-grant-design.md
+-- Migration under test: supabase/migrations/20260820120000_trade_approval_area_grant.sql
+--
+-- Fixture namespace: UUIDs starting with 65000000-...
+-- Function calls stay as role postgres (RLS bypassed) and impersonate only
+-- via set_config('request.jwt.claims', ...) — approve_shift_trade and
+-- reject_shift_trade are SECURITY DEFINER, so their own internal guard is
+-- what is under test, not RLS. SELECT/DELETE assertions switch to
+-- SET LOCAL role = 'authenticated' so they exercise the real RLS policies.
+-- ============================================================================
+
+BEGIN;
+SELECT plan(13);
+
+-- ============================================================================
+-- Setup (as postgres/superuser — bypasses RLS regardless of enable state)
+-- ============================================================================
+SET LOCAL role TO postgres;
+
+ALTER TABLE shift_trades DISABLE ROW LEVEL SECURITY;
+ALTER TABLE shifts DISABLE ROW LEVEL SECURITY;
+ALTER TABLE employees DISABLE ROW LEVEL SECURITY;
+ALTER TABLE restaurants DISABLE ROW LEVEL SECURITY;
+ALTER TABLE user_restaurants DISABLE ROW LEVEL SECURITY;
+ALTER TABLE roles DISABLE ROW LEVEL SECURITY;
+ALTER TABLE role_areas DISABLE ROW LEVEL SECURITY;
+
+-- Restaurant
+INSERT INTO restaurants (id, name) VALUES
+  ('65000000-0000-0000-0000-000000000001', 'Trade Area Grant Restaurant')
+ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name;
+
+-- Auth users: U1 (custom, manage), U2 (custom, view), U3 (legacy
+-- operations_manager), U4 (no membership), OE (offerer), AE (accepter)
+INSERT INTO auth.users (id, instance_id, aud, role, email, encrypted_password, email_confirmed_at, created_at, updated_at, confirmation_token, recovery_token, email_change_token_new, email_change)
+VALUES
+  ('65000000-0000-0000-0000-000000000011', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'tag-u1-65@test.com', crypt('password123', gen_salt('bf')), now(), now(), now(), '', '', '', ''),
+  ('65000000-0000-0000-0000-000000000012', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'tag-u2-65@test.com', crypt('password123', gen_salt('bf')), now(), now(), now(), '', '', '', ''),
+  ('65000000-0000-0000-0000-000000000013', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'tag-u3-65@test.com', crypt('password123', gen_salt('bf')), now(), now(), now(), '', '', '', ''),
+  ('65000000-0000-0000-0000-000000000014', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'tag-u4-65@test.com', crypt('password123', gen_salt('bf')), now(), now(), now(), '', '', '', ''),
+  ('65000000-0000-0000-0000-000000000015', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'tag-oe-65@test.com', crypt('password123', gen_salt('bf')), now(), now(), now(), '', '', '', ''),
+  ('65000000-0000-0000-0000-000000000016', '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated', 'tag-ae-65@test.com', crypt('password123', gen_salt('bf')), now(), now(), now(), '', '', '', '')
+ON CONFLICT (id) DO NOTHING;
+
+-- Employees: offerer OE and accepter AE. U1/U2/U3/U4 deliberately get no
+-- employees row — they must qualify (or be denied) purely on the
+-- edit:scheduling capability, not on being a trade participant.
+INSERT INTO employees (id, restaurant_id, user_id, name, email, position, is_active) VALUES
+  ('65000000-0000-0000-0000-000000000021', '65000000-0000-0000-0000-000000000001', '65000000-0000-0000-0000-000000000015', 'Offerer OE', 'tag-oe-65@test.com', 'Server', true),
+  ('65000000-0000-0000-0000-000000000022', '65000000-0000-0000-0000-000000000001', '65000000-0000-0000-0000-000000000016', 'Accepter AE', 'tag-ae-65@test.com', 'Server', true)
+ON CONFLICT (id) DO UPDATE SET is_active = true;
+
+-- Two custom roles: one at scheduling:manage (grants edit:scheduling), one
+-- at scheduling:view only (grants view:scheduling but NOT edit:scheduling).
+INSERT INTO public.roles (id, restaurant_id, name, description, flavor, builtin) VALUES
+  ('65000000-0000-0000-0000-0000000000c1', '65000000-0000-0000-0000-000000000001', 'Trade Manage Role', 'pgTAP fixture — scheduling:manage', 'platform', false),
+  ('65000000-0000-0000-0000-0000000000c2', '65000000-0000-0000-0000-000000000001', 'Trade View Role', 'pgTAP fixture — scheduling:view', 'platform', false)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.role_areas (role_id, area_key, level) VALUES
+  ('65000000-0000-0000-0000-0000000000c1', 'scheduling', 'manage'),
+  ('65000000-0000-0000-0000-0000000000c2', 'scheduling', 'view')
+ON CONFLICT (role_id, area_key) DO UPDATE SET level = EXCLUDED.level;
+
+-- Memberships: U1 (custom manage), U2 (custom view), U3 (legacy
+-- operations_manager, role_id NULL). U4 gets no user_restaurants row.
+INSERT INTO user_restaurants (id, user_id, restaurant_id, role, role_id) VALUES
+  ('65000000-0000-0000-0000-000000000031', '65000000-0000-0000-0000-000000000011', '65000000-0000-0000-0000-000000000001', 'collaborator_custom', '65000000-0000-0000-0000-0000000000c1'),
+  ('65000000-0000-0000-0000-000000000032', '65000000-0000-0000-0000-000000000012', '65000000-0000-0000-0000-000000000001', 'collaborator_custom', '65000000-0000-0000-0000-0000000000c2'),
+  ('65000000-0000-0000-0000-000000000033', '65000000-0000-0000-0000-000000000013', '65000000-0000-0000-0000-000000000001', 'operations_manager', NULL)
+ON CONFLICT (user_id, restaurant_id) DO UPDATE SET role = EXCLUDED.role, role_id = EXCLUDED.role_id;
+
+-- Four shifts owned by OE, one per trade, so the unique-active-trade-per-
+-- shift index never blocks a fixture insert.
+INSERT INTO shifts (id, restaurant_id, employee_id, start_time, end_time, position, break_duration) VALUES
+  ('65000000-0000-0000-0000-000000000041', '65000000-0000-0000-0000-000000000001', '65000000-0000-0000-0000-000000000021', '2026-09-01 09:00:00+00', '2026-09-01 17:00:00+00', 'Server', 30),
+  ('65000000-0000-0000-0000-000000000042', '65000000-0000-0000-0000-000000000001', '65000000-0000-0000-0000-000000000021', '2026-09-02 09:00:00+00', '2026-09-02 17:00:00+00', 'Server', 30),
+  ('65000000-0000-0000-0000-000000000043', '65000000-0000-0000-0000-000000000001', '65000000-0000-0000-0000-000000000021', '2026-09-03 09:00:00+00', '2026-09-03 17:00:00+00', 'Server', 30),
+  ('65000000-0000-0000-0000-000000000044', '65000000-0000-0000-0000-000000000001', '65000000-0000-0000-0000-000000000021', '2026-09-04 09:00:00+00', '2026-09-04 17:00:00+00', 'Server', 30)
+ON CONFLICT (id) DO UPDATE SET position = 'Server';
+
+DELETE FROM shift_trades WHERE restaurant_id = '65000000-0000-0000-0000-000000000001';
+
+-- tradeApprove / tradeReject: pending_approval with AE already accepted, so
+-- approve/reject can act on them. tradeDelete: open, for the DELETE
+-- assertions. tradeLegacyApprove: pending_approval, for the legacy-role
+-- approve assertion.
+INSERT INTO shift_trades (id, restaurant_id, offered_shift_id, offered_by_employee_id, target_employee_id, accepted_by_employee_id, status) VALUES
+  ('65000000-0000-0000-0000-000000000051', '65000000-0000-0000-0000-000000000001', '65000000-0000-0000-0000-000000000041', '65000000-0000-0000-0000-000000000021', NULL, '65000000-0000-0000-0000-000000000022', 'pending_approval'),
+  ('65000000-0000-0000-0000-000000000052', '65000000-0000-0000-0000-000000000001', '65000000-0000-0000-0000-000000000042', '65000000-0000-0000-0000-000000000021', NULL, '65000000-0000-0000-0000-000000000022', 'pending_approval'),
+  ('65000000-0000-0000-0000-000000000053', '65000000-0000-0000-0000-000000000001', '65000000-0000-0000-0000-000000000043', '65000000-0000-0000-0000-000000000021', NULL, NULL, 'open'),
+  ('65000000-0000-0000-0000-000000000054', '65000000-0000-0000-0000-000000000001', '65000000-0000-0000-0000-000000000044', '65000000-0000-0000-0000-000000000021', NULL, '65000000-0000-0000-0000-000000000022', 'pending_approval');
+
+-- CRITICAL: re-enable RLS on every table we disabled above (see
+-- 53_directed_shift_trade_rls.sql precedent).
+ALTER TABLE shift_trades ENABLE ROW LEVEL SECURITY;
+ALTER TABLE shifts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE employees ENABLE ROW LEVEL SECURITY;
+ALTER TABLE restaurants ENABLE ROW LEVEL SECURITY;
+ALTER TABLE user_restaurants ENABLE ROW LEVEL SECURITY;
+ALTER TABLE roles ENABLE ROW LEVEL SECURITY;
+ALTER TABLE role_areas ENABLE ROW LEVEL SECURITY;
+
+RESET ROLE;
+
+-- ============================================================================
+-- Scenario 1 (assertions 1-4): U1, custom role at scheduling:manage
+-- (edit:scheduling). Approve tradeApprove, reject tradeReject, SELECT sees
+-- every restaurant trade, DELETE removes tradeDelete.
+-- ============================================================================
+SET LOCAL role TO postgres;
+SELECT set_config('request.jwt.claims', '{"sub":"65000000-0000-0000-0000-000000000011","role":"authenticated"}', true);
+
+SELECT is(
+  (SELECT (approve_shift_trade('65000000-0000-0000-0000-000000000051', '65000000-0000-0000-0000-000000000011')->>'success')::boolean),
+  true,
+  'Scenario 1: custom role at scheduling:manage can approve a trade'
+);
+
+SELECT is(
+  (SELECT (reject_shift_trade('65000000-0000-0000-0000-000000000052', '65000000-0000-0000-0000-000000000011')->>'success')::boolean),
+  true,
+  'Scenario 1: custom role at scheduling:manage can reject a trade'
+);
+
+RESET ROLE;
+SET LOCAL role = 'authenticated';
+SELECT set_config('request.jwt.claims', '{"sub":"65000000-0000-0000-0000-000000000011","role":"authenticated"}', true);
+
+SELECT is(
+  (SELECT COUNT(*) FROM shift_trades WHERE restaurant_id = '65000000-0000-0000-0000-000000000001'),
+  4::bigint,
+  'Scenario 1: custom role at scheduling:manage sees all four restaurant trades via the manager SELECT policy'
+);
+
+SELECT is(
+  (WITH deleted AS (
+    DELETE FROM shift_trades WHERE id = '65000000-0000-0000-0000-000000000053' RETURNING id
+  ) SELECT COUNT(*) FROM deleted),
+  1::bigint,
+  'Scenario 1: custom role at scheduling:manage can delete a trade'
+);
+
+-- ============================================================================
+-- Scenario 2 (assertions 5-8): U2, custom role at scheduling:view only
+-- (view:scheduling, NOT edit:scheduling). Approve and reject on the still-
+-- pending tradeLegacyApprove must both fail closed; SELECT sees zero
+-- non-participant trades; DELETE removes zero rows.
+-- ============================================================================
+RESET ROLE;
+SET LOCAL role TO postgres;
+SELECT set_config('request.jwt.claims', '{"sub":"65000000-0000-0000-0000-000000000012","role":"authenticated"}', true);
+
+SELECT is(
+  (SELECT approve_shift_trade('65000000-0000-0000-0000-000000000054', '65000000-0000-0000-0000-000000000012')->>'error'),
+  'Unauthorized: schedule manage access required',
+  'Scenario 2: custom role at scheduling:view only is denied approve'
+);
+
+SELECT is(
+  (SELECT reject_shift_trade('65000000-0000-0000-0000-000000000054', '65000000-0000-0000-0000-000000000012')->>'error'),
+  'Unauthorized: schedule manage access required',
+  'Scenario 2: custom role at scheduling:view only is denied reject'
+);
+
+RESET ROLE;
+SET LOCAL role = 'authenticated';
+SELECT set_config('request.jwt.claims', '{"sub":"65000000-0000-0000-0000-000000000012","role":"authenticated"}', true);
+
+SELECT is(
+  (SELECT COUNT(*) FROM shift_trades WHERE restaurant_id = '65000000-0000-0000-0000-000000000001'),
+  0::bigint,
+  'Scenario 2: custom role at scheduling:view only, a non-participant, sees zero restaurant trades'
+);
+
+SELECT is(
+  (WITH deleted AS (
+    DELETE FROM shift_trades WHERE id = '65000000-0000-0000-0000-000000000054' RETURNING id
+  ) SELECT COUNT(*) FROM deleted),
+  0::bigint,
+  'Scenario 2: custom role at scheduling:view only deletes zero rows'
+);
+
+-- ============================================================================
+-- Scenario 3 (assertion 9): U3, legacy operations_manager (role_id NULL).
+-- The legacy CASE fallback still grants edit:scheduling to this role
+-- string, so approve of the still-pending tradeLegacyApprove succeeds.
+-- ============================================================================
+RESET ROLE;
+SET LOCAL role TO postgres;
+SELECT set_config('request.jwt.claims', '{"sub":"65000000-0000-0000-0000-000000000013","role":"authenticated"}', true);
+
+SELECT is(
+  (SELECT (approve_shift_trade('65000000-0000-0000-0000-000000000054', '65000000-0000-0000-0000-000000000013')->>'success')::boolean),
+  true,
+  'Scenario 3: legacy operations_manager (role_id NULL) can approve a trade'
+);
+
+-- ============================================================================
+-- Scenario 4 (assertions 10-13): U4, no user_restaurants row at all. Approve
+-- and reject must both fail closed with the SAME generic error for a real
+-- trade ID and for a random one — proving there is no trade-ID existence
+-- oracle.
+-- ============================================================================
+RESET ROLE;
+SET LOCAL role TO postgres;
+SELECT set_config('request.jwt.claims', '{"sub":"65000000-0000-0000-0000-000000000014","role":"authenticated"}', true);
+
+SELECT is(
+  (SELECT approve_shift_trade('65000000-0000-0000-0000-000000000054', '65000000-0000-0000-0000-000000000014')->>'error'),
+  'Unauthorized: schedule manage access required',
+  'Scenario 4: no membership, approve on a real trade ID fails closed'
+);
+
+SELECT is(
+  (SELECT approve_shift_trade('65000000-0000-0000-0000-000000000099', '65000000-0000-0000-0000-000000000014')->>'error'),
+  'Unauthorized: schedule manage access required',
+  'Scenario 4: no membership, approve on a random trade ID fails closed with the same error'
+);
+
+SELECT is(
+  (SELECT reject_shift_trade('65000000-0000-0000-0000-000000000054', '65000000-0000-0000-0000-000000000014')->>'error'),
+  'Unauthorized: schedule manage access required',
+  'Scenario 4: no membership, reject on a real trade ID fails closed'
+);
+
+SELECT is(
+  (SELECT reject_shift_trade('65000000-0000-0000-0000-000000000099', '65000000-0000-0000-0000-000000000014')->>'error'),
+  'Unauthorized: schedule manage access required',
+  'Scenario 4: no membership, reject on a random trade ID fails closed with the same error'
+);
+
+-- ============================================================================
+-- Cleanup
+-- ============================================================================
+RESET ROLE;
+SELECT * FROM finish();
+ROLLBACK;

--- a/tests/e2e/custom-role-trade-approval.spec.ts
+++ b/tests/e2e/custom-role-trade-approval.spec.ts
@@ -45,13 +45,19 @@ async function grantCustomSchedulingRole(
       const { data: { user } } = await supabase.auth.getUser();
       if (!user?.id) throw new Error('No session');
 
+      // flavor 'collaborator', not 'platform': the RLS INSERT policy on
+      // public.roles ("manage:collaborators holders can insert roles")
+      // requires flavor = 'collaborator' for any authenticated insert — see
+      // 20260730100000_roles_and_areas_tables.sql. scheduling's
+      // max_level_collaborator is 'manage', so a collaborator-flavored role
+      // can still hold scheduling@manage.
       const { data: role, error: roleErr } = await supabase
         .from('roles')
         .insert({
           restaurant_id: restId,
           name: `Trade Test Role ${level} ${Date.now()}`,
           description: 'e2e fixture role',
-          flavor: 'platform',
+          flavor: 'collaborator',
           builtin: false,
         })
         .select('id')

--- a/tests/e2e/custom-role-trade-approval.spec.ts
+++ b/tests/e2e/custom-role-trade-approval.spec.ts
@@ -1,0 +1,208 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// `(window as any).__supabase` / `__getRestaurantId` are the e2e page-side test
+// hooks exposed by exposeSupabaseHelpers — untyped by design, as in the
+// sibling scheduling e2e specs (manager-initiated-shift-trade.spec.ts,
+// shift-trade-accept.spec.ts).
+import { test, expect, type Page } from '@playwright/test';
+import { signUpAndCreateRestaurant, exposeSupabaseHelpers, generateTestUser } from '../helpers/e2e-supabase';
+
+/**
+ * E2E for the trade-approval area grant
+ * (docs/superpowers/specs/2026-08-20-trade-approval-area-grant-design.md):
+ * approve_shift_trade, reject_shift_trade, and the shift_trades RLS gate now
+ * check user_has_capability(restaurant_id, 'edit:scheduling') instead of a
+ * hardcoded owner/manager role, so a CUSTOM role granted scheduling@manage
+ * can approve trades too, and a custom role at scheduling@view only cannot.
+ *
+ * Real second sign-in is not used to become "that member": as established by
+ * roles-and-areas.spec.ts's simulateAcceptedCustomRole (see that file's
+ * header banner for the full rationale), this spec instead points the
+ * current session's own user_restaurants row at the new custom role and
+ * reloads — the exact membership shape a real invite-accept round trip would
+ * produce.
+ */
+
+interface WindowHelpers {
+  __supabase: any;
+  __getRestaurantId: () => Promise<string | null>;
+}
+
+/**
+ * Insert a restaurant-owned custom role granting `scheduling` at `level`,
+ * then point the current session's own user_restaurants row at it and
+ * reload — the same pattern as roles-and-areas.spec.ts's
+ * simulateAcceptedCustomRole, spelled out locally here rather than imported
+ * (a spec file is not a shared module).
+ */
+async function grantCustomSchedulingRole(
+  page: Page,
+  restaurantId: string,
+  level: 'manage' | 'view',
+): Promise<void> {
+  await page.evaluate(
+    async ({ restId, level }: { restId: string; level: 'manage' | 'view' }) => {
+      const supabase = (window as any).__supabase;
+      const { data: { user } } = await supabase.auth.getUser();
+      if (!user?.id) throw new Error('No session');
+
+      const { data: role, error: roleErr } = await supabase
+        .from('roles')
+        .insert({
+          restaurant_id: restId,
+          name: `Trade Test Role ${level} ${Date.now()}`,
+          description: 'e2e fixture role',
+          flavor: 'platform',
+          builtin: false,
+        })
+        .select('id')
+        .single();
+      if (roleErr) throw new Error(`role insert: ${roleErr.message}`);
+
+      const { error: areaErr } = await supabase
+        .from('role_areas')
+        .insert({ role_id: role.id, area_key: 'scheduling', level });
+      if (areaErr) throw new Error(`role_areas insert: ${areaErr.message}`);
+
+      const { error: memErr } = await supabase
+        .from('user_restaurants')
+        .update({ role: 'collaborator_custom', role_id: role.id })
+        .eq('user_id', user.id)
+        .eq('restaurant_id', restId);
+      if (memErr) throw new Error(`user_restaurants update: ${memErr.message}`);
+    },
+    { restId: restaurantId, level },
+  );
+  await page.reload();
+  await page.waitForLoadState('networkidle');
+}
+
+/**
+ * Seed an offerer employee (linked to the current session's user so the
+ * shift_trades INSERT RLS check — offered_by_employee_id belongs to the
+ * caller — is satisfied), an accepter employee (no user_id, same as every
+ * other directed-trade fixture in this suite), a future shift, and a trade
+ * already at 'pending_approval' with the accepter recorded — the exact state
+ * a real accept_shift_trade call would leave behind.
+ */
+async function seedPendingTrade(page: Page, restaurantId: string): Promise<{ tradeId: string }> {
+  return page.evaluate(async (restId: string) => {
+    const supabase = (window as any).__supabase;
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user?.id) throw new Error('No session');
+
+    const { data: offerer, error: offErr } = await supabase
+      .from('employees')
+      .insert({
+        restaurant_id: restId, user_id: user.id, name: 'Ollie Offerer', position: 'Server',
+        status: 'active', is_active: true, compensation_type: 'hourly', hourly_rate: 1500,
+      })
+      .select('id').single();
+    if (offErr) throw new Error(`offerer insert: ${offErr.message}`);
+
+    const { data: accepter, error: accErr } = await supabase
+      .from('employees')
+      .insert({
+        restaurant_id: restId, name: 'Alex Accepter', position: 'Server',
+        status: 'active', is_active: true, compensation_type: 'hourly', hourly_rate: 1500,
+      })
+      .select('id').single();
+    if (accErr) throw new Error(`accepter insert: ${accErr.message}`);
+
+    const start = new Date();
+    start.setDate(start.getDate() + 3);
+    start.setHours(16, 0, 0, 0);
+    const end = new Date(start);
+    end.setHours(22, 0, 0, 0);
+    const { data: shift, error: sErr } = await supabase
+      .from('shifts')
+      .insert({
+        restaurant_id: restId, employee_id: offerer.id,
+        start_time: start.toISOString(), end_time: end.toISOString(),
+        position: 'Server', status: 'scheduled', break_duration: 30,
+        is_published: true, locked: false,
+      })
+      .select('id').single();
+    if (sErr) throw new Error(`shift insert: ${sErr.message}`);
+
+    const { data: trade, error: tErr } = await supabase
+      .from('shift_trades')
+      .insert({
+        restaurant_id: restId, offered_shift_id: shift.id,
+        offered_by_employee_id: offerer.id, accepted_by_employee_id: accepter.id,
+        target_employee_id: null, status: 'pending_approval',
+      })
+      .select('id').single();
+    if (tErr) throw new Error(`trade insert: ${tErr.message}`);
+
+    return { tradeId: trade.id as string };
+  }, restaurantId);
+}
+
+test.describe('Trade approval from a custom scheduling role', () => {
+  test('a scheduling@manage custom role sees the trades tab and approves a pending trade', async ({ page }) => {
+    const owner = generateTestUser('trade-approve-owner');
+    await signUpAndCreateRestaurant(page, owner);
+    await exposeSupabaseHelpers(page);
+
+    const restaurantId = await page.evaluate(() => (window as unknown as WindowHelpers).__getRestaurantId());
+    expect(restaurantId).toBeTruthy();
+
+    const seed = await seedPendingTrade(page, restaurantId as string);
+
+    await grantCustomSchedulingRole(page, restaurantId as string, 'manage');
+
+    await page.goto('/scheduling');
+    await page.waitForURL(/\/scheduling/, { timeout: 15000 });
+
+    const tradesTab = page.getByRole('tab', { name: /shift trades/i });
+    await expect(tradesTab).toBeVisible({ timeout: 15000 });
+    await tradesTab.click();
+
+    const card = page.getByTestId('pending-trade').first();
+    await expect(card).toBeVisible({ timeout: 15000 });
+    await card.getByRole('button', { name: /approve/i }).click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog.getByText(/Approve Trade Request/i)).toBeVisible({ timeout: 5000 });
+    await dialog.getByRole('button', { name: /^approve$/i }).click();
+    await expect(dialog).not.toBeVisible({ timeout: 10000 });
+
+    // Authoritative: the trade status moved to 'approved'.
+    await expect
+      .poll(
+        async () =>
+          page.evaluate(async (tradeId: string) => {
+            const supabase = (window as any).__supabase;
+            const { data } = await supabase
+              .from('shift_trades')
+              .select('status')
+              .eq('id', tradeId)
+              .single();
+            return data?.status ?? null;
+          }, seed.tradeId),
+        { timeout: 15000 },
+      )
+      .toBe('approved');
+  });
+
+  test('a scheduling@view custom role does not see the trades tab', async ({ page }) => {
+    const owner = generateTestUser('trade-view-owner');
+    await signUpAndCreateRestaurant(page, owner);
+    await exposeSupabaseHelpers(page);
+
+    const restaurantId = await page.evaluate(() => (window as unknown as WindowHelpers).__getRestaurantId());
+    expect(restaurantId).toBeTruthy();
+
+    await grantCustomSchedulingRole(page, restaurantId as string, 'view');
+
+    await page.goto('/scheduling');
+    await page.waitForURL(/\/scheduling/, { timeout: 15000 });
+
+    // A scheduling@view role still lands on /scheduling (view:scheduling),
+    // but never edit:scheduling, so the trades tab must not render at all —
+    // a DOM-absence check, not merely "not visible" (Radix Tabs unmounts an
+    // absent trigger rather than hiding it).
+    await expect(page.getByRole('tab', { name: /schedule/i })).toBeVisible({ timeout: 15000 });
+    await expect(page.getByRole('tab', { name: /shift trades/i })).toHaveCount(0);
+  });
+});

--- a/tests/unit/scheduling-trades-gate.test.tsx
+++ b/tests/unit/scheduling-trades-gate.test.tsx
@@ -1,0 +1,310 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+// The Scheduling page showed the "Shift Trades" tab and its approval queue
+// to every viewer, regardless of role — a chef with only `view:scheduling`
+// could open it and reach approve/reject controls the server now also
+// blocks via RLS (design §3). This gates both the tab trigger and its
+// panel behind `isResolved && hasCapability('edit:scheduling')`, the same
+// capability the server checks (docs/superpowers/specs/
+// 2026-08-20-trade-approval-area-grant-design.md §3).
+
+const hasCapabilityMock = vi.fn();
+let isResolvedMock = true;
+vi.mock('@/hooks/usePermissions', () => ({
+  usePermissions: () => ({
+    hasCapability: hasCapabilityMock,
+    isResolved: isResolvedMock,
+  }),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => ({
+    selectedRestaurant: {
+      restaurant_id: 'r1',
+      role: 'manager',
+      restaurant: { timezone: 'America/Chicago' },
+    },
+    loading: false,
+  }),
+}));
+
+vi.mock('@/components/subscription', () => ({
+  FeatureGate: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/hooks/useRestaurantClock', () => ({
+  useRestaurantClock: () => ({ today: '2026-08-20' }),
+}));
+
+vi.mock('@/hooks/useEmployees', () => ({
+  useEmployees: () => ({ employees: [], loading: false, error: null }),
+}));
+
+vi.mock('@/hooks/useShifts', () => ({
+  useShifts: () => ({ shifts: [], loading: false, error: null }),
+  useDeleteShift: () => ({ mutateAsync: vi.fn(), mutate: vi.fn(), isPending: false }),
+  useDeleteShiftSeries: () => ({ mutateAsync: vi.fn(), mutate: vi.fn(), isPending: false }),
+  useUpdateShiftSeries: () => ({ mutateAsync: vi.fn(), mutate: vi.fn(), isPending: false }),
+  useSeriesInfo: () => ({ seriesCount: 0, lockedCount: 0 }),
+}));
+
+vi.mock('@/hooks/useShiftTrades', () => ({
+  useShiftTrades: () => ({ trades: [] }),
+}));
+
+vi.mock('@/hooks/useTimeOffRequests', () => ({
+  useTimeOffRequests: () => ({ timeOffRequests: [] }),
+}));
+
+vi.mock('@/pages/SchedulingTimeOffTabBadge', () => ({
+  TimeOffTabBadge: () => null,
+}));
+
+vi.mock('@/pages/SchedulingDayHeaderContent', () => ({
+  ScheduleDayHeaderContent: () => null,
+  TODAY_HEADER_CAP_RULE_CLASS: '',
+}));
+
+vi.mock('@/pages/SchedulingTimeOffCellContent', () => ({
+  SchedulingTimeOffCellContent: () => null,
+}));
+
+vi.mock('@/pages/SchedulingWeeklyAvailabilityChip', () => ({
+  WeeklyAvailabilityChip: () => null,
+}));
+
+vi.mock('@/pages/SchedulingShiftCard', () => ({
+  ShiftCard: () => null,
+  getShiftStatusClass: () => '',
+}));
+
+vi.mock('@/components/schedule/TradeRequestDialog', () => ({
+  TradeRequestDialog: () => null,
+}));
+
+vi.mock('@/components/scheduling/WeekScheduleMobile', () => ({
+  WeekScheduleMobile: () => null,
+}));
+
+vi.mock('@/hooks/useSchedulePublish', () => ({
+  usePublishSchedule: () => ({ mutateAsync: vi.fn(), mutate: vi.fn(), isPending: false }),
+  useUnpublishSchedule: () => ({ mutateAsync: vi.fn(), mutate: vi.fn(), isPending: false }),
+  useWeekPublicationStatus: () => ({ publication: null, isPublished: false, loading: false }),
+}));
+
+vi.mock('@/hooks/usePublishedShiftGuard', () => ({
+  usePublishedShiftGuard: () => ({
+    guardShiftChange: vi.fn((_opts: unknown, commit: () => void) => commit()),
+    notifyAfterDeferredCommit: vi.fn(),
+    dialog: null,
+  }),
+}));
+
+vi.mock('@/hooks/useScheduleChangeLogs', () => ({
+  useScheduleChangeLogs: () => ({ changeLogs: [], loading: false }),
+}));
+
+vi.mock('@/hooks/useScheduledLaborCosts', () => ({
+  useScheduledLaborCosts: () => ({ breakdown: [] }),
+}));
+
+vi.mock('@/hooks/useEmployeeLaborCosts', () => ({
+  useEmployeeLaborCosts: () => ({}),
+}));
+
+vi.mock('@/components/EmployeeDialog', () => ({
+  EmployeeDialog: () => null,
+}));
+
+vi.mock('@/hooks/useEmployeePositions', () => ({
+  useEmployeePositions: () => ({ positions: [], isLoading: false }),
+}));
+
+vi.mock('@/hooks/useEmployeeAreas', () => ({
+  useEmployeeAreas: () => ({ areas: [] }),
+}));
+
+vi.mock('@/hooks/useAvailability', () => ({
+  useEmployeeAvailability: () => ({ availability: [] }),
+  useAvailabilityExceptions: () => ({ exceptions: [] }),
+}));
+
+vi.mock('@/components/ShiftDialog', () => ({
+  ShiftDialog: () => null,
+}));
+
+vi.mock('@/components/TimeOffRequestDialog', () => ({
+  TimeOffRequestDialog: () => null,
+}));
+
+vi.mock('@/components/TimeOffList', () => ({
+  TimeOffList: () => null,
+}));
+
+vi.mock('@/components/AvailabilityDialog', () => ({
+  AvailabilityDialog: () => null,
+}));
+
+vi.mock('@/components/AvailabilityExceptionDialog', () => ({
+  AvailabilityExceptionDialog: () => null,
+}));
+
+vi.mock('@/components/ScheduleStatusBadge', () => ({
+  ScheduleStatusBadge: () => null,
+}));
+
+vi.mock('@/components/PublishScheduleDialog', () => ({
+  PublishScheduleDialog: () => null,
+}));
+
+vi.mock('@/components/scheduling/BroadcastOpenShiftsDialog', () => ({
+  BroadcastOpenShiftsDialog: () => null,
+}));
+
+vi.mock('@/components/ChangeLogDialog', () => ({
+  ChangeLogDialog: () => null,
+}));
+
+vi.mock('@/components/schedule/TradeApprovalQueue', () => ({
+  TradeApprovalQueue: () => <div data-testid="trade-approval-queue" />,
+}));
+
+vi.mock('@/components/scheduling/ScheduleMetricsRibbon', () => ({
+  ScheduleMetricsRibbon: () => null,
+}));
+
+vi.mock('@/hooks/useScheduleLaborBudget', () => ({
+  useScheduleLaborBudget: () => ({}),
+}));
+
+vi.mock('@/components/scheduling/ScheduleExportDialog', () => ({
+  ScheduleExportDialog: () => null,
+}));
+
+vi.mock('@/components/scheduling/ShiftPlanner', () => ({
+  ShiftPlannerTab: () => null,
+}));
+
+vi.mock('@/components/scheduling/ShiftImportSheet', () => ({
+  ShiftImportSheet: () => null,
+}));
+
+vi.mock('@/components/scheduling/ShiftPlanner/CopyWeekDialog', () => ({
+  CopyWeekDialog: () => null,
+}));
+
+vi.mock('@/components/scheduling/ShiftPlanner/AvailabilityConflictDialog', () => ({
+  AvailabilityConflictDialog: () => null,
+}));
+
+vi.mock('@/components/scheduling/TeamAvailabilityGrid', () => ({
+  TeamAvailabilityGrid: () => null,
+}));
+
+vi.mock('@/components/scheduling/DeleteAvailabilityDialog', () => ({
+  DeleteAvailabilityDialog: () => null,
+}));
+
+vi.mock('@/components/scheduling/useShiftCopyDnd', () => ({
+  useShiftCopyDnd: () => ({
+    sensors: [],
+    activeDragShift: null,
+    highlightedCellId: null,
+    conflictDialog: { open: false, data: null },
+    handleDragStart: vi.fn(),
+    handleDragEnd: vi.fn(),
+    handleDragCancel: vi.fn(),
+  }),
+}));
+
+vi.mock('@/components/scheduling/DraggableShiftCard', () => ({
+  DraggableShiftCard: () => null,
+}));
+
+vi.mock('@/components/scheduling/DroppableDayCell', () => ({
+  DroppableDayCell: () => null,
+}));
+
+vi.mock('@/components/scheduling/ShiftDragOverlay', () => ({
+  ShiftDragOverlay: () => null,
+}));
+
+vi.mock('@/hooks/useCopyWeekShifts', () => ({
+  useCopyWeekShifts: () => ({ mutateAsync: vi.fn(), mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock('@/hooks/useSharedWeek', () => ({
+  useSharedWeek: () => ({ weekStart: new Date('2026-08-17T00:00:00'), setWeekStart: vi.fn() }),
+}));
+
+vi.mock('@/hooks/useShiftTemplates', () => ({
+  useShiftTemplates: () => ({ templates: [] }),
+  templateAppliesToDay: () => false,
+}));
+
+vi.mock('@/hooks/useStaffingSettings', () => ({
+  useStaffingSettings: () => ({ effectiveSettings: {} }),
+}));
+
+vi.mock('@/components/scheduling/RecurringShiftActionDialog', () => ({
+  RecurringShiftActionDialog: () => null,
+  RecurringActionType: {},
+}));
+
+vi.mock('@/components/bulk-edit/BulkActionBar', () => ({
+  BulkActionBar: () => null,
+}));
+
+vi.mock('@/components/scheduling/BulkEditShiftsDialog', () => ({
+  BulkEditShiftsDialog: () => null,
+}));
+
+vi.mock('@/hooks/useBulkShiftActions', () => ({
+  useBulkShiftActions: () => ({ bulkDelete: vi.fn(), bulkEdit: vi.fn() }),
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+import Scheduling from '@/pages/Scheduling';
+
+describe('Scheduling page — Shift Trades tab capability gate', () => {
+  beforeEach(() => {
+    hasCapabilityMock.mockReset();
+    isResolvedMock = true;
+  });
+
+  it('shows the Shift Trades tab with edit:scheduling resolved', () => {
+    isResolvedMock = true;
+    hasCapabilityMock.mockImplementation((cap: string) => cap === 'edit:scheduling');
+
+    render(<Scheduling />);
+
+    expect(screen.getByRole('tab', { name: /shift trades/i })).toBeInTheDocument();
+  });
+
+  it('hides the Shift Trades tab with only view:scheduling', () => {
+    isResolvedMock = true;
+    hasCapabilityMock.mockImplementation((cap: string) => cap === 'view:scheduling');
+
+    render(<Scheduling />);
+
+    expect(screen.queryByRole('tab', { name: /shift trades/i })).not.toBeInTheDocument();
+  });
+
+  it('hides the Shift Trades tab while capabilities are still resolving', () => {
+    isResolvedMock = false;
+    hasCapabilityMock.mockImplementation(() => true);
+
+    render(<Scheduling />);
+
+    expect(screen.queryByRole('tab', { name: /shift trades/i })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Problem

A member with a custom role can hold the `scheduling` area at the
`manage` level. The schedule page then shows the trade approval queue
to that member. The approve call fails. The database still checks the
legacy role string.

Production evidence: user `edenaragon184@gmail.com` holds the custom
collaborator role "Operations lead". The role grants `scheduling` at
`manage`. The member row has `role = 'collaborator_custom'`. The RPC
returned `Unauthorized: Manager access required`.

## Audience change

| Caller | Before | After |
|---|---|---|
| owner, manager (legacy or migrated) | allowed | allowed |
| custom role with `scheduling@manage` (Eden) | denied | allowed |
| builtin `operations_manager` / `collaborator_operations_manager` | denied | allowed |
| custom role with `scheduling@view` | denied | denied |
| chef (has `view:scheduling` only) | denied | denied |
| non-member, or member with no role data | denied | denied (fail closed) |

The `operations_manager` rows are a deliberate product change. The
user approved this direction in chat on 2026-08-20.

## Changes

- New migration `supabase/migrations/20260820120000_trade_approval_area_grant.sql`.
  It re-creates `approve_shift_trade` and `reject_shift_trade` to check
  `user_has_capability(restaurant_id, 'edit:scheduling')` instead of
  the legacy `role IN ('owner', 'manager')` check. It re-creates the
  matching RLS policies (`SELECT`, `UPDATE`, `DELETE` on
  `shift_trades`) with the same predicate, so the read audience and
  the action audience stay equal.
- `src/pages/Scheduling.tsx` gates the Shift Trades tab and the
  approval queue on the `edit:scheduling` capability, so the UI only
  shows the queue to a member who can act on it.
- pgTAP suite `supabase/tests/65_trade_approval_area_grant.test.sql`
  (13 tests) covers the new audience: custom `scheduling@manage`
  allowed, custom `scheduling@view` denied, `operations_manager`
  allowed, non-member denied.
- `supabase/tests/53_directed_shift_trade_rls.sql` updated for the
  widened audience (no regression: 12/12 pass).
- `tests/unit/scheduling-trades-gate.test.tsx` (3 tests) covers the
  frontend capability gate.
- `tests/e2e/custom-role-trade-approval.spec.ts` (2 tests) is a new
  end-to-end spec for a custom-role member who trades.

## Test evidence

- `npm run typecheck` — clean.
- `npm run lint` on the three touched files — 0 errors, 8 pre-existing
  warnings.
- `npm run test` (full suite) — 787 files, 9455 tests, all pass.
- `65_trade_approval_area_grant.test.sql` — 13/13 pass (via direct
  `psql -f`, local Supabase shared with a sibling worktree).
- `53_directed_shift_trade_rls.sql` — 12/12 pass, no regression.
- `npx playwright test tests/e2e/custom-role-trade-approval.spec.ts` —
  2/2 pass.
- `tests/e2e/manager-initiated-shift-trade.spec.ts`,
  `tests/e2e/shift-trade-accept.spec.ts` (sibling specs, re-checked
  for regression) — 2/2 pass.
- `npx vitest run tests/unit/scheduling-trades-gate.test.tsx` — 3/3
  pass.

## Out of scope

- `approve_open_shift_claim` / `reject_open_shift_claim` keep their
  legacy guard. A follow-up task will cover them.
- `cancel_shift_trade` does not change. It stays offerer-only.

## Known deferred review findings

- `tests/e2e/custom-role-trade-approval.spec.ts:160` — minor —
  `page.goto('/scheduling')` hardcodes the route path instead of a
  shared constant. Deferred: every sibling e2e spec
  (`shift-template-areas.spec.ts`, `shift-planner.spec.ts`, and
  others) uses the same literal. No shared route constant exists in
  the test suite. A fix scoped to this one spec would create a new
  one-off pattern instead of following the existing one.

## Design doc

`docs/superpowers/specs/2026-08-20-trade-approval-area-grant-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

