### PR TITLE
fix: journal entries use the restaurant-local day

### DIFF
--- a/docs/superpowers/plans/2026-08-20-journal-entry-date-timezone-plan.md
+++ b/docs/superpowers/plans/2026-08-20-journal-entry-date-timezone-plan.md
@@ -1,0 +1,1451 @@
+# Journal Entry Date Timezone Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Journal entries for bank transactions carry the restaurant-local
+calendar day, not the UTC day, for real timestamps; date-anchored values keep
+the UTC day.
+
+**Architecture:** One SQL helper `bank_txn_entry_day(timestamptz, text)`
+holds the hybrid convention. Four SQL functions and one client hook call it.
+A one-time migration re-dates existing rows. The design doc is
+`docs/superpowers/specs/2026-08-20-journal-entry-date-timezone-design.md` —
+read it first; it holds the decision rationale and the production
+measurements.
+
+**Tech Stack:** PostgreSQL (plpgsql, pgTAP), Supabase migrations, React
+Query hook, Vitest.
+
+## Global Constraints
+
+- Write all prose (comments, commit messages) in ASD-STE100 style. See
+  `docs/STE100_STYLE.md`.
+- Migration file names start at `20260820210000_` and go up. They must sort
+  after `20260819232450_`.
+- The convention lives in `bank_txn_entry_day` only. Never write a second
+  `AT TIME ZONE` cast for an entry day. Every closed-period guard uses the
+  same helper output as its insert (lesson [2026-08-20], PR #766).
+- Tests must not read the host clock for timezone assertions. Use fixed UTC
+  instants and fixed expected dates (lesson [2026-08-19]).
+- pgTAP suites use `BEGIN; SELECT plan(N); ... SELECT * FROM finish();
+  ROLLBACK;`.
+- Local database: run `npm run db:start` once, then `npm run db:reset` after
+  each new migration. Run pgTAP with `npm run test:db`.
+- Stage explicit paths only. Never `git add -A`. Never stage `progress.md`
+  or `.env.local`.
+- End every commit message with:
+  `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+
+---
+
+### Task 1: The `bank_txn_entry_day` helper
+
+**Files:**
+- Create: `supabase/migrations/20260820210000_bank_txn_entry_day.sql`
+- Test: `supabase/tests/65_bank_txn_entry_day.sql`
+
+**Interfaces:**
+- Produces: `public.bank_txn_entry_day(p_ts timestamptz, p_tz text) RETURNS
+  date`. STABLE. `EXECUTE` granted to `authenticated`. Every later task
+  calls it with exactly these argument types.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `supabase/tests/65_bank_txn_entry_day.sql`:
+
+```sql
+-- File: supabase/tests/65_bank_txn_entry_day.sql
+-- Description: pins the hybrid entry-day convention in bank_txn_entry_day.
+-- A value at exactly 00:00:00 or 12:00:00 UTC is a date anchor and keeps
+-- the UTC day. A real instant takes the restaurant-local day. See
+-- docs/superpowers/specs/2026-08-20-journal-entry-date-timezone-design.md.
+
+BEGIN;
+SELECT plan(12);
+
+-- The helper must not depend on the session TimeZone. Pin an east-of-UTC
+-- zone so a hidden session cast fails these tests loudly.
+SET LOCAL timezone TO 'Asia/Tokyo';
+
+SELECT is(
+  bank_txn_entry_day('2026-01-15 00:00:00+00'::timestamptz, 'America/Chicago'),
+  '2026-01-15'::date,
+  'midnight UTC anchor keeps the UTC day');
+
+SELECT is(
+  bank_txn_entry_day('2026-01-15 12:00:00+00'::timestamptz, 'America/Chicago'),
+  '2026-01-15'::date,
+  'noon UTC anchor keeps the UTC day');
+
+SELECT is(
+  bank_txn_entry_day('2026-01-16 02:30:00+00'::timestamptz, 'America/Chicago'),
+  '2026-01-15'::date,
+  'evening instant takes the restaurant-local day');
+
+SELECT is(
+  bank_txn_entry_day('2026-01-15 18:45:00+00'::timestamptz, 'America/Chicago'),
+  '2026-01-15'::date,
+  'midday instant keeps the same day');
+
+SELECT is(
+  bank_txn_entry_day(NULL::timestamptz, 'America/Chicago'),
+  NULL::date,
+  'NULL timestamp returns NULL');
+
+SELECT is(
+  bank_txn_entry_day('2026-01-16 02:30:00+00'::timestamptz, NULL),
+  '2026-01-15'::date,
+  'NULL timezone uses the America/Chicago column default');
+
+SELECT is(
+  bank_txn_entry_day('2026-01-16 02:30:00+00'::timestamptz, 'Not/AZone'),
+  '2026-01-16'::date,
+  'invalid timezone falls back to the UTC day');
+
+SELECT is(
+  bank_txn_entry_day('2026-01-15 20:30:00+00'::timestamptz, 'Asia/Tokyo'),
+  '2026-01-16'::date,
+  'east-of-UTC instant takes the next local day');
+
+-- DST fall-back: 2026-11-01 ends CDT. 05:30Z on 2026-11-02 is 23:30 CST
+-- on 2026-11-01.
+SELECT is(
+  bank_txn_entry_day('2026-11-02 05:30:00+00'::timestamptz, 'America/Chicago'),
+  '2026-11-01'::date,
+  'fall-back day uses the CST offset');
+
+-- DST spring-forward: 2026-03-08 starts CDT. 04:30Z on 2026-03-09 is
+-- 23:30 CDT on 2026-03-08.
+SELECT is(
+  bank_txn_entry_day('2026-03-09 04:30:00+00'::timestamptz, 'America/Chicago'),
+  '2026-03-08'::date,
+  'day after spring-forward uses the CDT offset');
+
+SELECT ok(
+  has_function_privilege('authenticated', 'bank_txn_entry_day(timestamptz, text)', 'EXECUTE'),
+  'authenticated can EXECUTE bank_txn_entry_day');
+
+-- Same instant, second session zone: the answer must not move.
+SET LOCAL timezone TO 'UTC';
+SELECT is(
+  bank_txn_entry_day('2026-01-16 02:30:00+00'::timestamptz, 'America/Chicago'),
+  '2026-01-15'::date,
+  'result does not depend on the session TimeZone');
+
+SELECT * FROM finish();
+ROLLBACK;
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test:db`
+Expected: suite 65 FAILS with `function bank_txn_entry_day(timestamp with
+time zone, unknown) does not exist`.
+
+- [ ] **Step 3: Write the migration**
+
+Create `supabase/migrations/20260820210000_bank_txn_entry_day.sql`:
+
+```sql
+-- One expression for the journal entry day of a bank transaction.
+--
+-- bank_transactions.transaction_date is timestamptz. journal_entries.entry_date
+-- is date. Production holds three value populations (measured 2026-08-20):
+-- 3,991 rows at exactly 00:00:00 UTC (date-only statement imports), 2,552 at
+-- exactly 12:00:00 UTC (Stripe noon-anchored dates), and ~1,775 real instants.
+-- A date-anchored value already names its calendar day; a local cast would
+-- move it one day early. A real instant belongs to the restaurant-local day.
+-- This function holds that branch. Every entry insert AND every closed-period
+-- guard must call it — never write the cast twice (PR #766 lesson).
+-- See docs/superpowers/specs/2026-08-20-journal-entry-date-timezone-design.md.
+
+CREATE OR REPLACE FUNCTION public.bank_txn_entry_day(p_ts timestamptz, p_tz text)
+RETURNS date
+LANGUAGE plpgsql
+STABLE
+SET search_path = public, pg_catalog
+AS $$
+BEGIN
+  IF p_ts IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  -- A time of exactly 00:00:00 or 12:00:00 UTC marks a date-only source
+  -- value. Keep its UTC day. Misclassification window for a real instant:
+  -- one second twice a day, and the result equals the old behavior.
+  IF (p_ts AT TIME ZONE 'UTC')::time IN ('00:00:00', '12:00:00') THEN
+    RETURN (p_ts AT TIME ZONE 'UTC')::date;
+  END IF;
+
+  BEGIN
+    RETURN (p_ts AT TIME ZONE COALESCE(p_tz, 'America/Chicago'))::date;
+  EXCEPTION WHEN invalid_parameter_value THEN
+    -- Garbage timezone string: keep the UTC day (the old behavior). Do not
+    -- probe pg_timezone_names per call — the subtransaction guard is ~100x
+    -- cheaper and only a bad zone pays for it (check_timeoff_conflict lesson).
+    RETURN (p_ts AT TIME ZONE 'UTC')::date;
+  END;
+END;
+$$;
+
+COMMENT ON FUNCTION public.bank_txn_entry_day(timestamptz, text) IS
+  'Entry day for a bank transaction. Date anchors (00:00/12:00 UTC) keep the UTC day; real instants take the restaurant-local day.';
+
+-- The opening-balance hook calls this through PostgREST.
+GRANT EXECUTE ON FUNCTION public.bank_txn_entry_day(timestamptz, text) TO authenticated;
+```
+
+- [ ] **Step 4: Apply and run the test to verify it passes**
+
+Run: `npm run db:reset && npm run test:db`
+Expected: suite 65 passes 12/12. No other suite changes state.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/migrations/20260820210000_bank_txn_entry_day.sql supabase/tests/65_bank_txn_entry_day.sql
+git commit -m "feat(ledger): add bank_txn_entry_day helper for local entry days"
+```
+
+---
+
+### Task 2: `categorize_bank_transaction` uses the helper
+
+**Files:**
+- Create: `supabase/migrations/20260820210100_categorize_local_entry_day.sql`
+- Test: `supabase/tests/66_categorize_local_entry_day.sql`
+- Reference (copy source): `supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql`
+
+**Interfaces:**
+- Consumes: `bank_txn_entry_day(timestamptz, text)` from Task 1.
+- Produces: same RPC signature as today. New behavior only: `entry_date`
+  from the helper; the fiscal guard compares the helper output; the
+  existing-entry UPDATE branch also sets `entry_date`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `supabase/tests/66_categorize_local_entry_day.sql`:
+
+```sql
+-- File: supabase/tests/66_categorize_local_entry_day.sql
+-- Description: categorize_bank_transaction derives entry_date with
+-- bank_txn_entry_day. Covers: evening-instant bank entry, reclass entry,
+-- the heal of an existing entry, and the closed-period guard on the
+-- helper basis. See
+-- docs/superpowers/specs/2026-08-20-journal-entry-date-timezone-design.md.
+
+BEGIN;
+SELECT plan(5);
+
+SET LOCAL role TO postgres;
+SET LOCAL timezone TO 'Asia/Tokyo';  -- session TZ must not leak into dates
+
+-- Fixtures -----------------------------------------------------------------
+INSERT INTO auth.users (id, email) VALUES
+  ('00000000-0000-0000-0000-000000006601'::uuid, 'entry-day-test@example.com')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO restaurants (id, name, timezone) VALUES
+  ('00000000-0000-0000-0000-000000006610'::uuid, 'Entry Day Restaurant', 'America/Chicago')
+ON CONFLICT (id) DO UPDATE SET timezone = 'America/Chicago';
+
+INSERT INTO user_restaurants (user_id, restaurant_id, role) VALUES
+  ('00000000-0000-0000-0000-000000006601'::uuid, '00000000-0000-0000-0000-000000006610'::uuid, 'owner')
+ON CONFLICT (user_id, restaurant_id) DO UPDATE SET role = 'owner';
+
+INSERT INTO chart_of_accounts (id, restaurant_id, account_code, account_name, account_type, account_subtype, normal_balance, is_active) VALUES
+  ('00000000-0000-0000-0000-000000006611'::uuid, '00000000-0000-0000-0000-000000006610'::uuid, '1000', 'Cash', 'asset', 'cash', 'debit', true),
+  ('00000000-0000-0000-0000-000000006612'::uuid, '00000000-0000-0000-0000-000000006610'::uuid, '6000', 'Supplies Expense', 'expense', 'operating_expenses', 'debit', true),
+  ('00000000-0000-0000-0000-000000006613'::uuid, '00000000-0000-0000-0000-000000006610'::uuid, '6010', 'Repairs Expense', 'expense', 'operating_expenses', 'debit', true)
+ON CONFLICT (id) DO UPDATE SET account_name = EXCLUDED.account_name, is_active = true;
+
+INSERT INTO connected_banks (id, restaurant_id, stripe_financial_account_id, institution_name, status) VALUES
+  ('00000000-0000-0000-0000-000000006615'::uuid, '00000000-0000-0000-0000-000000006610'::uuid, 'fa_test_entry_day_001', 'Test Bank', 'connected')
+ON CONFLICT (id) DO NOTHING;
+
+-- Closed period for the guard test below.
+INSERT INTO fiscal_periods (id, restaurant_id, period_start, period_end, is_closed, closed_at) VALUES
+  ('00000000-0000-0000-0000-000000006640'::uuid, '00000000-0000-0000-0000-000000006610'::uuid,
+   DATE '2026-01-01', DATE '2026-01-31', true, now())
+ON CONFLICT (id) DO UPDATE SET is_closed = true;
+
+INSERT INTO bank_transactions (
+  id, restaurant_id, connected_bank_id, stripe_transaction_id,
+  transaction_date, amount, description, status, is_categorized, is_transfer, is_reconciled
+) VALUES
+  -- Evening instant: 03:30Z on Feb 2 = 21:30 CST on Feb 1.
+  ('00000000-0000-0000-0000-000000006701'::uuid, '00000000-0000-0000-0000-000000006610'::uuid,
+   '00000000-0000-0000-0000-000000006615'::uuid, 'txn-entry-day-evening-1',
+   TIMESTAMPTZ '2026-02-02 03:30:00+00', -50.00, 'Evening purchase', 'posted', false, false, false),
+  -- Heal case: entry-less flag off; a wrong-day entry exists (seeded below).
+  ('00000000-0000-0000-0000-000000006702'::uuid, '00000000-0000-0000-0000-000000006610'::uuid,
+   '00000000-0000-0000-0000-000000006615'::uuid, 'txn-entry-day-heal-1',
+   TIMESTAMPTZ '2026-02-05 03:30:00+00', -60.00, 'Heal me', 'posted', false, false, false),
+  -- Closed-period boundary: 23:30Z on Jan 31 = 17:30 CST on Jan 31, inside
+  -- the closed period. The old raw-timestamptz guard let this row through.
+  ('00000000-0000-0000-0000-000000006703'::uuid, '00000000-0000-0000-0000-000000006610'::uuid,
+   '00000000-0000-0000-0000-000000006615'::uuid, 'txn-entry-day-closed-1',
+   TIMESTAMPTZ '2026-01-31 23:30:00+00', -70.00, 'Late on closed last day', 'posted', false, false, false)
+ON CONFLICT (id) DO UPDATE SET is_categorized = false, category_id = NULL;
+
+-- Wrong-day entry for the heal case (UTC day 2026-02-05; local day is 02-04).
+INSERT INTO journal_entries (
+  restaurant_id, entry_date, entry_number, description,
+  reference_type, reference_id, total_debit, total_credit
+) VALUES (
+  '00000000-0000-0000-0000-000000006610'::uuid, DATE '2026-02-05',
+  'BANK-txn-entry-day-heal-1-SEED', 'Heal me',
+  'bank_transaction', '00000000-0000-0000-0000-000000006702'::uuid,
+  60.00, 60.00
+);
+
+SELECT set_config('request.jwt.claims', '{"sub":"00000000-0000-0000-0000-000000006601","role":"authenticated"}', true);
+
+-- Tests --------------------------------------------------------------------
+
+-- 1. Categorize the evening instant: entry lands on the local day.
+SELECT lives_ok(
+  $$SELECT categorize_bank_transaction(
+      '00000000-0000-0000-0000-000000006701'::uuid,
+      '00000000-0000-0000-0000-000000006612'::uuid)$$,
+  'categorize succeeds for the evening instant');
+
+SELECT is(
+  (SELECT entry_date FROM journal_entries
+   WHERE reference_type = 'bank_transaction'
+     AND reference_id = '00000000-0000-0000-0000-000000006701'::uuid),
+  DATE '2026-02-01',
+  'bank entry lands on the restaurant-local day');
+
+-- 2. Reclassify the same transaction: the reclass entry uses the same day.
+SELECT lives_ok(
+  $$SELECT categorize_bank_transaction(
+      '00000000-0000-0000-0000-000000006701'::uuid,
+      '00000000-0000-0000-0000-000000006613'::uuid)$$,
+  'reclassification succeeds');
+
+SELECT is(
+  (SELECT je.entry_date
+   FROM journal_entries je
+   JOIN transaction_reclassifications tr ON tr.reclass_journal_entry_id = je.id
+   WHERE tr.bank_transaction_id = '00000000-0000-0000-0000-000000006701'::uuid
+   ORDER BY je.created_at DESC LIMIT 1),
+  DATE '2026-02-01',
+  'reclass entry lands on the restaurant-local day');
+
+-- 3. Heal: categorize with an existing wrong-day entry updates entry_date.
+SELECT categorize_bank_transaction(
+  '00000000-0000-0000-0000-000000006702'::uuid,
+  '00000000-0000-0000-0000-000000006612'::uuid);
+
+SELECT is(
+  (SELECT entry_date FROM journal_entries
+   WHERE reference_type = 'bank_transaction'
+     AND reference_id = '00000000-0000-0000-0000-000000006702'::uuid),
+  DATE '2026-02-04',
+  'existing entry heals to the restaurant-local day');
+
+SELECT * FROM finish();
+ROLLBACK;
+```
+
+Then append the closed-period guard test before `finish()` and bump the
+plan to 6 (write it now, in the same file):
+
+```sql
+-- 4. Closed-period guard fires on the helper day, not the raw timestamptz.
+SELECT throws_like(
+  $$SELECT categorize_bank_transaction(
+      '00000000-0000-0000-0000-000000006703'::uuid,
+      '00000000-0000-0000-0000-000000006612'::uuid)$$,
+  'Cannot categorize transaction in closed fiscal period%',
+  'guard blocks a late instant on the closed period''s last day');
+```
+
+Final file has `SELECT plan(6);`.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test:db`
+Expected: suite 66 FAILS. Test 2 returns `2026-02-02` (UTC day). Test 4
+does not raise (the raw-timestamptz guard misses the boundary row). The
+heal test returns `2026-02-05`.
+
+- [ ] **Step 3: Write the migration**
+
+Create `supabase/migrations/20260820210100_categorize_local_entry_day.sql`.
+Copy the whole `CREATE OR REPLACE FUNCTION public.categorize_bank_transaction`
+statement from `20260709120000_categorize_preserve_metadata_on_noop.sql`
+(lines 25-255). Keep every part byte-identical except these five changes:
+
+Change 1 — add two variables to the end of the DECLARE block:
+
+```sql
+  v_timezone text;
+  v_entry_day date;
+```
+
+Change 2 — compute the day once, directly above the fiscal-period guard
+(the `SELECT id INTO v_fiscal_period_id FROM fiscal_periods ...` block):
+
+```sql
+  -- One expression for the entry day; the guard below and both inserts use
+  -- it. Never derive the day a second way (PR #766 lesson).
+  SELECT timezone INTO v_timezone
+  FROM restaurants
+  WHERE id = v_transaction.restaurant_id;
+
+  v_entry_day := bank_txn_entry_day(v_transaction.transaction_date, v_timezone);
+```
+
+Change 3 — the guard compares the helper day. Replace:
+
+```sql
+    AND v_transaction.transaction_date >= period_start
+    AND v_transaction.transaction_date <= period_end
+```
+
+with:
+
+```sql
+    AND v_entry_day >= period_start
+    AND v_entry_day <= period_end
+```
+
+Change 4 — both inserts pass the day. In the RECLASS insert and in the
+BANK insert, replace the VALUES item
+`v_transaction.restaurant_id, v_transaction.transaction_date,` with:
+
+```sql
+      v_transaction.restaurant_id, v_entry_day,
+```
+
+Change 5 — the existing-entry UPDATE branch heals the day. The function
+has one `UPDATE journal_entries SET ...` branch for a found existing
+entry (near the "journal entry already exists" check). Add
+`entry_date = v_entry_day,` as the first SET item of that UPDATE. Do not
+change the other SET items.
+
+Add a header comment that names the design doc and states: this migration
+changes only the entry-day derivation and the guard basis.
+
+- [ ] **Step 4: Apply and run the test to verify it passes**
+
+Run: `npm run db:reset && npm run test:db`
+Expected: suite 66 passes 6/6. Suite `categorize_noop_preserves_metadata`
+and every other suite stay green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/migrations/20260820210100_categorize_local_entry_day.sql supabase/tests/66_categorize_local_entry_day.sql
+git commit -m "fix(ledger): categorize_bank_transaction writes the local entry day"
+```
+
+---
+
+### Task 3: `bulk_categorize_bank_transactions` uses the helper
+
+**Files:**
+- Create: `supabase/migrations/20260820210200_bulk_categorize_local_entry_day.sql`
+- Modify: `supabase/tests/22_bulk_categorize_bank_transactions.sql`
+- Reference (copy source): `supabase/migrations/20260819231210_add_bulk_categorize_bank_transactions.sql`
+
+**Interfaces:**
+- Consumes: `bank_txn_entry_day(timestamptz, text)` from Task 1.
+- Produces: same RPC signature as today
+  (`p_restaurant_id`, `p_category_id`, `p_transaction_ids`,
+  `p_skip_rebuild`). New behavior only, as in Task 2.
+
+- [ ] **Step 1: Write the failing test**
+
+In `supabase/tests/22_bulk_categorize_bank_transactions.sql`:
+
+1. Change `SELECT plan(34);` to `SELECT plan(35);`.
+2. Directly above `SELECT * FROM finish();`, add:
+
+```sql
+-- ---------------------------------------------------------------------------
+-- Local entry day: an evening instant lands on the restaurant-local day.
+-- 03:30Z on 2026-02-02 = 21:30 CST on 2026-02-01 (restaurant timezone
+-- defaults to America/Chicago).
+-- ---------------------------------------------------------------------------
+INSERT INTO bank_transactions (
+  id, restaurant_id, connected_bank_id, stripe_transaction_id,
+  transaction_date, amount, description, status, is_categorized, is_transfer, is_reconciled
+) VALUES (
+  '00000000-0000-0000-0000-000000000760'::uuid,
+  '00000000-0000-0000-0000-000000000610'::uuid,
+  '00000000-0000-0000-0000-000000000615'::uuid,
+  'txn-bulk-evening-instant-1',
+  TIMESTAMPTZ '2026-02-02 03:30:00+00', -33.00, 'Evening instant', 'posted', false, false, false
+)
+ON CONFLICT (id) DO UPDATE SET is_categorized = false, category_id = NULL;
+
+SELECT bulk_categorize_bank_transactions(
+  p_restaurant_id   => '00000000-0000-0000-0000-000000000610'::uuid,
+  p_category_id     => '00000000-0000-0000-0000-000000000612'::uuid,
+  p_transaction_ids => ARRAY['00000000-0000-0000-0000-000000000760'::uuid],
+  p_skip_rebuild    => true
+);
+
+SELECT is(
+  (SELECT entry_date FROM journal_entries
+   WHERE reference_type = 'bank_transaction'
+     AND reference_id = '00000000-0000-0000-0000-000000000760'::uuid),
+  DATE '2026-02-01',
+  'bulk categorize writes the restaurant-local entry day');
+```
+
+If the RPC's parameter names differ from the ones above, read the
+signature in `20260819231210_add_bulk_categorize_bank_transactions.sql`
+and match them exactly.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test:db`
+Expected: suite 22 FAILS on the new assertion with `2026-02-02` (UTC day).
+The other 34 tests stay green.
+
+- [ ] **Step 3: Write the migration**
+
+Create
+`supabase/migrations/20260820210200_bulk_categorize_local_entry_day.sql`.
+Copy the whole `CREATE OR REPLACE FUNCTION
+public.bulk_categorize_bank_transactions` statement from
+`20260819231210_add_bulk_categorize_bank_transactions.sql`. Keep every part
+byte-identical except these five changes:
+
+Change 1 — add to the DECLARE block:
+
+```sql
+  v_timezone text;
+  v_entry_day date;
+```
+
+Change 2 — one timezone lookup per call, directly above the `FOR` loop
+over the transaction ids (`p_restaurant_id` scopes the whole call):
+
+```sql
+  SELECT timezone INTO v_timezone
+  FROM restaurants
+  WHERE id = p_restaurant_id;
+```
+
+Change 3 — inside the loop, directly above the fiscal-period guard
+(the `SELECT id INTO v_fiscal_period_id FROM fiscal_periods ...` block):
+
+```sql
+      v_entry_day := bank_txn_entry_day(v_transaction.transaction_date, v_timezone);
+```
+
+Then the guard compares the helper day. Replace:
+
+```sql
+        AND v_transaction.transaction_date >= period_start
+        AND v_transaction.transaction_date <= period_end
+```
+
+with:
+
+```sql
+        AND v_entry_day >= period_start
+        AND v_entry_day <= period_end
+```
+
+Change 4 — both inserts pass the day. In the RECLASS insert and in the
+BANK insert, replace the VALUES item
+`(v_transaction.transaction_date AT TIME ZONE 'UTC')::date,` with:
+
+```sql
+          v_entry_day,
+```
+
+Change 5 — the existing-entry UPDATE branch heals the day. The function
+has one `UPDATE journal_entries SET ...` branch for a found existing
+entry. Add `entry_date = v_entry_day,` as the first SET item of that
+UPDATE. Do not change the other SET items.
+
+- [ ] **Step 4: Apply and run the test to verify it passes**
+
+Run: `npm run db:reset && npm run test:db`
+Expected: suite 22 passes 35/35.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/migrations/20260820210200_bulk_categorize_local_entry_day.sql supabase/tests/22_bulk_categorize_bank_transactions.sql
+git commit -m "fix(ledger): bulk categorize writes the local entry day"
+```
+
+---
+
+### Task 4: `apply_rules_to_bank_transactions_internal` uses the helper
+
+**Files:**
+- Create: `supabase/migrations/20260820210300_sweep_local_entry_day.sql`
+- Modify: `supabase/tests/categorization_background_rules.test.sql`
+- Reference (copy source): `supabase/migrations/20260804090300_bounded_categorization_sweep.sql`
+
+**Interfaces:**
+- Consumes: `bank_txn_entry_day(timestamptz, text)` from Task 1.
+- Produces: same function signature as today
+  (`apply_rules_to_bank_transactions_internal(uuid, integer, boolean)`).
+  Grants unchanged (service_role only; the migration must re-state the
+  existing REVOKE/GRANT statements if the copy source carries them).
+
+- [ ] **Step 1: Write the failing test**
+
+In `supabase/tests/categorization_background_rules.test.sql`:
+
+1. Change `SELECT plan(27);` to `SELECT plan(28);`.
+2. Directly above `SELECT * FROM finish();`, add (rule H matches
+   description `VENDOR-H` in restaurant H; the restaurant's timezone is the
+   `America/Chicago` default):
+
+```sql
+-- ============================================================
+-- Test (o): the internal bank engine writes the restaurant-local entry day.
+-- 03:30Z on 2026-02-02 = 21:30 CST on 2026-02-01.
+-- ============================================================
+ALTER TABLE public.bank_transactions DISABLE TRIGGER auto_categorize_bank_transaction;
+
+INSERT INTO public.bank_transactions
+  (id, restaurant_id, connected_bank_id, stripe_transaction_id,
+   transaction_date, description, amount, is_categorized)
+VALUES
+  ('c1a00008-0000-0000-0000-000000000102',
+   'c1a00008-0000-0000-0000-000000000801',
+   'c1a00008-0000-0000-0000-0000000000b8',
+   'cbt-stripe-txn-h02',
+   TIMESTAMPTZ '2026-02-02 03:30:00+00',
+   'Payment to VENDOR-H Corp evening run',
+   -75.00,
+   false)
+ON CONFLICT (id) DO NOTHING;
+
+ALTER TABLE public.bank_transactions ENABLE TRIGGER auto_categorize_bank_transaction;
+
+SET LOCAL "request.jwt.claims" TO '';
+
+SELECT apply_rules_to_bank_transactions_internal(
+  'c1a00008-0000-0000-0000-000000000801'::uuid, 100);
+
+SELECT is(
+  (SELECT entry_date FROM public.journal_entries
+   WHERE reference_type = 'bank_transaction'
+     AND reference_id = 'c1a00008-0000-0000-0000-000000000102'),
+  DATE '2026-02-01',
+  '(o) internal bank engine writes the restaurant-local entry day');
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test:db`
+Expected: the suite FAILS on test (o) with `2026-02-02` (UTC day). The
+other 27 tests stay green.
+
+- [ ] **Step 3: Write the migration**
+
+Create `supabase/migrations/20260820210300_sweep_local_entry_day.sql`.
+Copy the whole `CREATE OR REPLACE FUNCTION
+public.apply_rules_to_bank_transactions_internal` statement from
+`20260804090300_bounded_categorization_sweep.sql` (the two later
+migrations, `20260804090700` and `20260804091000`, only call it — do not
+copy from them). Keep every part byte-identical except these five changes:
+
+Change 1 — add to the DECLARE block:
+
+```sql
+  v_timezone text;
+  v_entry_day date;
+```
+
+Change 2 — one timezone lookup per call, directly above the
+`FOR v_transaction IN` loop:
+
+```sql
+  SELECT timezone INTO v_timezone
+  FROM restaurants
+  WHERE id = p_restaurant_id;
+```
+
+Change 3 — inside the loop's `BEGIN` block, directly above the
+fiscal-period `SELECT id INTO v_fiscal_period_id`:
+
+```sql
+      v_entry_day := bank_txn_entry_day(v_transaction.transaction_date, v_timezone);
+```
+
+Then replace the guard comparisons:
+
+```sql
+        AND v_transaction.transaction_date >= period_start
+        AND v_transaction.transaction_date <= period_end
+```
+
+with:
+
+```sql
+        AND v_entry_day >= period_start
+        AND v_entry_day <= period_end
+```
+
+Change 4 — the insert passes the day. Replace the VALUES item
+`v_transaction.transaction_date,` with:
+
+```sql
+          v_entry_day,
+```
+
+Change 5 — the existing-entry UPDATE branch heals the day. The function
+has one `UPDATE journal_entries SET ...` branch for a found existing
+entry. Add `entry_date = v_entry_day,` as the first SET item of that
+UPDATE. Do not change the other SET items.
+
+After the function body, re-state the privilege statements exactly as the
+copy source has them (REVOKE from PUBLIC/authenticated/anon, GRANT to
+service_role) so the replace does not widen access. Check the copy source
+for them; `CREATE OR REPLACE` keeps existing ACLs, so add them only if the
+copy source itself carries them.
+
+- [ ] **Step 4: Apply and run the test to verify it passes**
+
+Run: `npm run db:reset && npm run test:db`
+Expected: `categorization_background_rules` passes 28/28.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/migrations/20260820210300_sweep_local_entry_day.sql supabase/tests/categorization_background_rules.test.sql
+git commit -m "fix(ledger): rule sweep writes the local entry day"
+```
+
+---
+
+### Task 5: `backfill_bank_transaction_journal_entries` uses the helper
+
+**Files:**
+- Create: `supabase/migrations/20260820210400_backfill_local_entry_day.sql`
+- Modify: `supabase/tests/23_backfill_bank_transaction_journal_entries.sql`
+- Reference (copy source): `supabase/migrations/20260819232450_backfill_bank_transaction_journal_entries.sql`
+
+**Interfaces:**
+- Consumes: `bank_txn_entry_day(timestamptz, text)` from Task 1.
+- Produces: same function signature
+  (`backfill_bank_transaction_journal_entries() RETURNS jsonb`).
+
+- [ ] **Step 1: Write the failing test**
+
+In `supabase/tests/23_backfill_bank_transaction_journal_entries.sql`:
+
+1. Change `SELECT plan(19);` to `SELECT plan(20);`.
+2. Add one row to the candidate `INSERT INTO bank_transactions` VALUES
+   list (before the `ON CONFLICT` clause):
+
+```sql
+  -- Local entry day: evening instant. 03:30Z on 2026-02-02 = 21:30 CST on
+  -- 2026-02-01 (R_BF_MAIN timezone defaults to America/Chicago).
+  ('00000000-0000-0000-0000-000000000910'::uuid, '00000000-0000-0000-0000-000000000810'::uuid, '00000000-0000-0000-0000-000000000815'::uuid,
+   'txn-backfill-evening-1', TIMESTAMPTZ '2026-02-02 03:30:00+00', -44.00, 'Evening instant, entry-less', 'posted', true, false, false,
+   '00000000-0000-0000-0000-000000000812'::uuid, NULL),
+```
+
+3. Directly above `SELECT * FROM finish();`, add:
+
+```sql
+SELECT is(
+  (SELECT entry_date FROM journal_entries
+   WHERE reference_type = 'bank_transaction'
+     AND reference_id = '00000000-0000-0000-0000-000000000910'::uuid),
+  DATE '2026-02-01',
+  'backfill writes the restaurant-local entry day');
+```
+
+4. The suite counts created entries in its earlier assertions. Find every
+   assertion that counts backfill results (for example an
+   `entries_created` count from the first call) and raise the expected
+   count by one for the new eligible row. Read each failing assertion's
+   description; change only counts that include eligible rows.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test:db`
+Expected: suite 23 FAILS on the new assertion with `2026-02-02`.
+
+- [ ] **Step 3: Write the migration**
+
+Create `supabase/migrations/20260820210400_backfill_local_entry_day.sql`.
+Copy the whole `CREATE OR REPLACE FUNCTION
+public.backfill_bank_transaction_journal_entries` statement from
+`20260819232450_backfill_bank_transaction_journal_entries.sql`. Keep every
+part byte-identical except these four changes:
+
+Change 1 — the candidate table carries the timezone. In the
+`CREATE TEMP TABLE tmp_backfill_candidates ON COMMIT DROP AS SELECT` list,
+after `bt.transaction_date,` add:
+
+```sql
+    r.timezone,
+```
+
+and after the `JOIN chart_of_accounts cat ...` join block add:
+
+```sql
+  JOIN restaurants r
+    ON r.id = bt.restaurant_id
+```
+
+Change 2 — the closed-period guard uses the helper. Replace both cast
+lines inside the `NOT EXISTS (SELECT 1 FROM fiscal_periods fp ...)`:
+
+```sql
+        AND (bt.transaction_date AT TIME ZONE 'UTC')::date >= fp.period_start
+        AND (bt.transaction_date AT TIME ZONE 'UTC')::date <= fp.period_end
+```
+
+with:
+
+```sql
+        AND bank_txn_entry_day(bt.transaction_date, r.timezone) >= fp.period_start
+        AND bank_txn_entry_day(bt.transaction_date, r.timezone) <= fp.period_end
+```
+
+Change 3 — the insert uses the helper. Replace:
+
+```sql
+      (c.transaction_date AT TIME ZONE 'UTC')::date,
+```
+
+with:
+
+```sql
+      bank_txn_entry_day(c.transaction_date, c.timezone),
+```
+
+Change 4 — rewrite the two stale comments that explain the UTC cast (the
+one above the guard and the one above the insert). State the new rule in
+one sentence each: the guard and the insert derive the day from
+`bank_txn_entry_day`, the single convention expression.
+
+- [ ] **Step 4: Apply and run the test to verify it passes**
+
+Run: `npm run db:reset && npm run test:db`
+Expected: suite 23 passes 20/20.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/migrations/20260820210400_backfill_local_entry_day.sql supabase/tests/23_backfill_bank_transaction_journal_entries.sql
+git commit -m "fix(ledger): backfill writes the local entry day"
+```
+
+---
+
+### Task 6: One-time re-date of existing entries
+
+**Files:**
+- Create: `supabase/migrations/20260820210500_redate_bank_journal_entries.sql`
+- Test: `supabase/tests/67_redate_bank_journal_entries.sql`
+
+**Interfaces:**
+- Consumes: `bank_txn_entry_day(timestamptz, text)` from Task 1.
+- Produces: a data-only migration. No schema or function changes.
+
+- [ ] **Step 1: Write the test**
+
+A data-only migration cannot follow the red-green cycle: the migration is
+one statement, and the test must inline that statement to prove it. The
+test seeds wrong-day entries, runs the same two UPDATE statements the
+migration runs, and asserts the moves, the skips, and the report-level
+effect. Keep the statements byte-identical between the test and the
+migration.
+
+Create `supabase/tests/67_redate_bank_journal_entries.sql`:
+
+```sql
+-- File: supabase/tests/67_redate_bank_journal_entries.sql
+-- Description: proves the one-time re-date statement shape used by
+-- migration 20260820210500_redate_bank_journal_entries.sql. Seeds a
+-- wrong-day bank entry, a wrong-day reclass entry, a date-anchored entry,
+-- and a closed-period collision; runs the same UPDATEs; asserts the moves
+-- and the skips. Also proves the report-level effect: a mid-window as-of
+-- balance changes after the re-date.
+
+BEGIN;
+SELECT plan(8);
+
+SET LOCAL role TO postgres;
+SET LOCAL timezone TO 'Asia/Tokyo';
+
+-- Fixtures -----------------------------------------------------------------
+INSERT INTO restaurants (id, name, timezone) VALUES
+  ('00000000-0000-0000-0000-000000006710'::uuid, 'Redate Restaurant', 'America/Chicago')
+ON CONFLICT (id) DO UPDATE SET timezone = 'America/Chicago';
+
+INSERT INTO chart_of_accounts (id, restaurant_id, account_code, account_name, account_type, account_subtype, normal_balance, is_active) VALUES
+  ('00000000-0000-0000-0000-000000006711'::uuid, '00000000-0000-0000-0000-000000006710'::uuid, '1000', 'Cash', 'asset', 'cash', 'debit', true),
+  ('00000000-0000-0000-0000-000000006712'::uuid, '00000000-0000-0000-0000-000000006710'::uuid, '6000', 'Supplies Expense', 'expense', 'operating_expenses', 'debit', true)
+ON CONFLICT (id) DO UPDATE SET is_active = true;
+
+INSERT INTO connected_banks (id, restaurant_id, stripe_financial_account_id, institution_name, status) VALUES
+  ('00000000-0000-0000-0000-000000006715'::uuid, '00000000-0000-0000-0000-000000006710'::uuid, 'fa_test_redate_001', 'Test Bank', 'connected')
+ON CONFLICT (id) DO NOTHING;
+
+-- Closed period that must protect entry 6904 below.
+INSERT INTO fiscal_periods (id, restaurant_id, period_start, period_end, is_closed, closed_at) VALUES
+  ('00000000-0000-0000-0000-000000006740'::uuid, '00000000-0000-0000-0000-000000006710'::uuid,
+   DATE '2026-03-01', DATE '2026-03-31', true, now())
+ON CONFLICT (id) DO UPDATE SET is_closed = true;
+
+INSERT INTO bank_transactions (
+  id, restaurant_id, connected_bank_id, stripe_transaction_id,
+  transaction_date, amount, description, status, is_categorized, is_transfer, is_reconciled
+) VALUES
+  -- 6801: evening instant, entry on the wrong UTC day.
+  ('00000000-0000-0000-0000-000000006801'::uuid, '00000000-0000-0000-0000-000000006710'::uuid,
+   '00000000-0000-0000-0000-000000006715'::uuid, 'txn-redate-evening-1',
+   TIMESTAMPTZ '2026-02-02 03:30:00+00', -50.00, 'Evening instant', 'posted', true, false, false),
+  -- 6802: date anchor, entry already right.
+  ('00000000-0000-0000-0000-000000006802'::uuid, '00000000-0000-0000-0000-000000006710'::uuid,
+   '00000000-0000-0000-0000-000000006715'::uuid, 'txn-redate-anchor-1',
+   TIMESTAMPTZ '2026-02-10 00:00:00+00', -20.00, 'Date anchor', 'posted', true, false, false),
+  -- 6803: evening instant with a reclass entry.
+  ('00000000-0000-0000-0000-000000006803'::uuid, '00000000-0000-0000-0000-000000006710'::uuid,
+   '00000000-0000-0000-0000-000000006715'::uuid, 'txn-redate-reclass-1',
+   TIMESTAMPTZ '2026-02-16 02:15:00+00', -30.00, 'Reclassed instant', 'posted', true, false, false),
+  -- 6804: the new day (2026-03-31) falls inside the closed period; the
+  -- old day (2026-04-01, UTC) does not. The re-date must skip it.
+  ('00000000-0000-0000-0000-000000006804'::uuid, '00000000-0000-0000-0000-000000006710'::uuid,
+   '00000000-0000-0000-0000-000000006715'::uuid, 'txn-redate-closed-1',
+   TIMESTAMPTZ '2026-04-01 03:30:00+00', -40.00, 'Closed-period collision', 'posted', true, false, false)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO journal_entries (
+  id, restaurant_id, entry_date, entry_number, description,
+  reference_type, reference_id, total_debit, total_credit
+) VALUES
+  ('00000000-0000-0000-0000-000000006901'::uuid, '00000000-0000-0000-0000-000000006710'::uuid,
+   DATE '2026-02-02', 'BANK-txn-redate-evening-1-SEED', 'Evening instant',
+   'bank_transaction', '00000000-0000-0000-0000-000000006801'::uuid, 50.00, 50.00),
+  ('00000000-0000-0000-0000-000000006902'::uuid, '00000000-0000-0000-0000-000000006710'::uuid,
+   DATE '2026-02-10', 'BANK-txn-redate-anchor-1-SEED', 'Date anchor',
+   'bank_transaction', '00000000-0000-0000-0000-000000006802'::uuid, 20.00, 20.00),
+  ('00000000-0000-0000-0000-000000006903'::uuid, '00000000-0000-0000-0000-000000006710'::uuid,
+   DATE '2026-02-16', 'RECLASS-txn-redate-reclass-1-SEED', 'Reclassed instant',
+   'reclassification', gen_random_uuid(), 30.00, 30.00),
+  ('00000000-0000-0000-0000-000000006904'::uuid, '00000000-0000-0000-0000-000000006710'::uuid,
+   DATE '2026-04-01', 'BANK-txn-redate-closed-1-SEED', 'Closed-period collision',
+   'bank_transaction', '00000000-0000-0000-0000-000000006804'::uuid, 40.00, 40.00);
+
+-- Lines for 6901 so the report-effect assertion has an amount to sum.
+INSERT INTO journal_entry_lines (journal_entry_id, account_id, debit_amount, credit_amount, description) VALUES
+  ('00000000-0000-0000-0000-000000006901'::uuid, '00000000-0000-0000-0000-000000006712'::uuid, 50.00, 0, 'Supplies'),
+  ('00000000-0000-0000-0000-000000006901'::uuid, '00000000-0000-0000-0000-000000006711'::uuid, 0, 50.00, 'Cash payment');
+
+INSERT INTO transaction_reclassifications (
+  restaurant_id, bank_transaction_id, original_category_id,
+  new_category_id, reclass_journal_entry_id, reason
+) VALUES (
+  '00000000-0000-0000-0000-000000006710'::uuid,
+  '00000000-0000-0000-0000-000000006803'::uuid,
+  '00000000-0000-0000-0000-000000006712'::uuid,
+  '00000000-0000-0000-0000-000000006712'::uuid,
+  '00000000-0000-0000-0000-000000006903'::uuid,
+  'redate test');
+
+-- Report-level effect, BEFORE: the mid-window as-of day (2026-02-01) sees
+-- no expense yet, because the entry still sits on 2026-02-02.
+SELECT is(
+  compute_account_balance('00000000-0000-0000-0000-000000006712'::uuid, DATE '2026-02-01'),
+  0.00::numeric,
+  'before the re-date, the mid-window balance excludes the entry');
+
+-- The migration statements ---------------------------------------------------
+-- Keep these two UPDATEs byte-identical to
+-- supabase/migrations/20260820210500_redate_bank_journal_entries.sql.
+
+UPDATE journal_entries je
+SET entry_date = bank_txn_entry_day(bt.transaction_date, r.timezone),
+    updated_at = now()
+FROM bank_transactions bt
+JOIN restaurants r ON r.id = bt.restaurant_id
+WHERE je.reference_type = 'bank_transaction'
+  AND je.reference_id = bt.id
+  AND je.restaurant_id = bt.restaurant_id
+  AND je.entry_date IS DISTINCT FROM bank_txn_entry_day(bt.transaction_date, r.timezone)
+  AND NOT EXISTS (
+    SELECT 1 FROM fiscal_periods fp
+    WHERE fp.restaurant_id = je.restaurant_id
+      AND bank_txn_entry_day(bt.transaction_date, r.timezone) >= fp.period_start
+      AND bank_txn_entry_day(bt.transaction_date, r.timezone) <= fp.period_end
+      AND fp.is_closed = true
+  );
+
+UPDATE journal_entries je
+SET entry_date = bank_txn_entry_day(bt.transaction_date, r.timezone),
+    updated_at = now()
+FROM transaction_reclassifications tr
+JOIN bank_transactions bt ON bt.id = tr.bank_transaction_id
+JOIN restaurants r ON r.id = bt.restaurant_id
+WHERE je.id = tr.reclass_journal_entry_id
+  AND je.reference_type = 'reclassification'
+  AND je.entry_date IS DISTINCT FROM bank_txn_entry_day(bt.transaction_date, r.timezone)
+  AND NOT EXISTS (
+    SELECT 1 FROM fiscal_periods fp
+    WHERE fp.restaurant_id = je.restaurant_id
+      AND bank_txn_entry_day(bt.transaction_date, r.timezone) >= fp.period_start
+      AND bank_txn_entry_day(bt.transaction_date, r.timezone) <= fp.period_end
+      AND fp.is_closed = true
+  );
+
+-- Assertions -----------------------------------------------------------------
+SELECT is(
+  (SELECT entry_date FROM journal_entries WHERE id = '00000000-0000-0000-0000-000000006901'::uuid),
+  DATE '2026-02-01',
+  'bank entry moves to the restaurant-local day');
+
+SELECT is(
+  (SELECT entry_date FROM journal_entries WHERE id = '00000000-0000-0000-0000-000000006902'::uuid),
+  DATE '2026-02-10',
+  'date-anchored entry does not move');
+
+SELECT is(
+  (SELECT entry_date FROM journal_entries WHERE id = '00000000-0000-0000-0000-000000006903'::uuid),
+  DATE '2026-02-15',
+  'reclass entry moves via transaction_reclassifications');
+
+SELECT is(
+  (SELECT entry_date FROM journal_entries WHERE id = '00000000-0000-0000-0000-000000006904'::uuid),
+  DATE '2026-04-01',
+  'closed-period collision keeps its old day');
+
+-- Report-level effect, AFTER: the same as-of day now includes the entry.
+SELECT is(
+  compute_account_balance('00000000-0000-0000-0000-000000006712'::uuid, DATE '2026-02-01'),
+  50.00::numeric,
+  'after the re-date, the mid-window balance includes the entry');
+
+-- Idempotence: a second run changes no row.
+CREATE TEMP TABLE redate_before AS
+  SELECT id, entry_date FROM journal_entries
+  WHERE restaurant_id = '00000000-0000-0000-0000-000000006710'::uuid;
+
+UPDATE journal_entries je
+SET entry_date = bank_txn_entry_day(bt.transaction_date, r.timezone),
+    updated_at = now()
+FROM bank_transactions bt
+JOIN restaurants r ON r.id = bt.restaurant_id
+WHERE je.reference_type = 'bank_transaction'
+  AND je.reference_id = bt.id
+  AND je.restaurant_id = bt.restaurant_id
+  AND je.entry_date IS DISTINCT FROM bank_txn_entry_day(bt.transaction_date, r.timezone)
+  AND NOT EXISTS (
+    SELECT 1 FROM fiscal_periods fp
+    WHERE fp.restaurant_id = je.restaurant_id
+      AND bank_txn_entry_day(bt.transaction_date, r.timezone) >= fp.period_start
+      AND bank_txn_entry_day(bt.transaction_date, r.timezone) <= fp.period_end
+      AND fp.is_closed = true
+  );
+
+SELECT is(
+  (SELECT count(*)::int FROM journal_entries je
+   JOIN redate_before b ON b.id = je.id
+   WHERE je.entry_date IS DISTINCT FROM b.entry_date),
+  0,
+  'a second run is a no-op');
+
+-- Compute_account_balance signature check (guards a signature drift that
+-- would break the report assertions silently).
+SELECT ok(
+  has_function_privilege('postgres', 'compute_account_balance(uuid, date)', 'EXECUTE'),
+  'compute_account_balance(uuid, date) exists');
+
+SELECT * FROM finish();
+ROLLBACK;
+```
+
+Check the fixture expectations: `2026-02-16 02:15:00+00` is 20:15 CST on
+2026-02-15, so the reclass entry must land on `2026-02-15`.
+`2026-04-01 03:30:00+00` is 22:30 CDT on 2026-03-31, inside the closed
+March period, so the skip must hold.
+
+- [ ] **Step 2: Run the test to verify the statements**
+
+Run: `npm run test:db`
+Expected: suite 67 passes — this task proves the migration statements,
+not a code change. If an assertion fails, fix the statement in the test
+first, then copy the fixed statement into the migration in Step 3.
+
+- [ ] **Step 3: Write the migration**
+
+Create `supabase/migrations/20260820210500_redate_bank_journal_entries.sql`
+with a header comment (production expectation: 179 bank entries + 2
+reclass entries move; 0 closed-period skips; counts drift with the cron —
+the statements compute their own row set) and a DO block that runs the two
+UPDATE statements from the test **byte-identical**, each followed by
+`GET DIAGNOSTICS` and a `RAISE NOTICE` with the row count:
+
+```sql
+DO $$
+DECLARE
+  v_bank_rows int;
+  v_reclass_rows int;
+BEGIN
+  UPDATE journal_entries je
+  SET entry_date = bank_txn_entry_day(bt.transaction_date, r.timezone),
+      updated_at = now()
+  FROM bank_transactions bt
+  JOIN restaurants r ON r.id = bt.restaurant_id
+  WHERE je.reference_type = 'bank_transaction'
+    AND je.reference_id = bt.id
+    AND je.restaurant_id = bt.restaurant_id
+    AND je.entry_date IS DISTINCT FROM bank_txn_entry_day(bt.transaction_date, r.timezone)
+    AND NOT EXISTS (
+      SELECT 1 FROM fiscal_periods fp
+      WHERE fp.restaurant_id = je.restaurant_id
+        AND bank_txn_entry_day(bt.transaction_date, r.timezone) >= fp.period_start
+        AND bank_txn_entry_day(bt.transaction_date, r.timezone) <= fp.period_end
+        AND fp.is_closed = true
+    );
+  GET DIAGNOSTICS v_bank_rows = ROW_COUNT;
+
+  UPDATE journal_entries je
+  SET entry_date = bank_txn_entry_day(bt.transaction_date, r.timezone),
+      updated_at = now()
+  FROM transaction_reclassifications tr
+  JOIN bank_transactions bt ON bt.id = tr.bank_transaction_id
+  JOIN restaurants r ON r.id = bt.restaurant_id
+  WHERE je.id = tr.reclass_journal_entry_id
+    AND je.reference_type = 'reclassification'
+    AND je.entry_date IS DISTINCT FROM bank_txn_entry_day(bt.transaction_date, r.timezone)
+    AND NOT EXISTS (
+      SELECT 1 FROM fiscal_periods fp
+      WHERE fp.restaurant_id = je.restaurant_id
+        AND bank_txn_entry_day(bt.transaction_date, r.timezone) >= fp.period_start
+        AND bank_txn_entry_day(bt.transaction_date, r.timezone) <= fp.period_end
+        AND fp.is_closed = true
+    );
+  GET DIAGNOSTICS v_reclass_rows = ROW_COUNT;
+
+  RAISE NOTICE 'redate_bank_journal_entries: % bank entries, % reclass entries', v_bank_rows, v_reclass_rows;
+END;
+$$;
+```
+
+Do not call `rebuild_account_balances` — the design doc explains why
+(backward moves cannot cross the `CURRENT_DATE` bound).
+
+- [ ] **Step 4: Apply and run the full suite**
+
+Run: `npm run db:reset && npm run test:db`
+Expected: all suites pass; the reset log shows the two NOTICE counts
+(0 and 0 on an empty local database).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/migrations/20260820210500_redate_bank_journal_entries.sql supabase/tests/67_redate_bank_journal_entries.sql
+git commit -m "fix(ledger): re-date existing bank journal entries to local days"
+```
+
+---
+
+### Task 7: Opening-balance hook derives its day from the helper
+
+**Files:**
+- Modify: `src/hooks/useCalculateOpeningBalance.tsx:68-77`
+- Modify: `src/integrations/supabase/types.ts` (Functions section,
+  alphabetical position near `builtin_role_id_for`)
+- Test: `tests/unit/useCalculateOpeningBalance.test.ts`
+
+**Interfaces:**
+- Consumes: the `bank_txn_entry_day` RPC (Task 1 granted `authenticated`).
+- Produces: no interface change; `mutationFn` still takes `restaurantId:
+  string`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/useCalculateOpeningBalance.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+const mocks = vi.hoisted(() => ({
+  rpc: vi.fn(),
+  from: vi.fn(),
+}));
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { rpc: mocks.rpc, from: mocks.from },
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { useCalculateOpeningBalance } from '@/hooks/useCalculateOpeningBalance';
+
+// A chainable thenable: every method returns the chain; awaiting it
+// resolves to the canned response.
+function chain(response: unknown) {
+  const proxy: any = new Proxy(() => proxy, {
+    get(_t, prop) {
+      if (prop === 'then') {
+        return (resolve: (v: unknown) => unknown) =>
+          Promise.resolve(response).then(resolve);
+      }
+      return () => proxy;
+    },
+  });
+  return proxy;
+}
+
+const EARLIEST_TS = '2026-02-02T03:30:00+00:00';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return React.createElement(
+    QueryClientProvider,
+    { client: new QueryClient() },
+    children,
+  );
+}
+
+describe('useCalculateOpeningBalance entry day', () => {
+  let insertedEntry: Record<string, unknown> | null;
+  let upsertedBoundary: Record<string, unknown> | null;
+  let tableCalls: Record<string, number>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    insertedEntry = null;
+    upsertedBoundary = null;
+    tableCalls = {};
+
+    mocks.from.mockImplementation((table: string) => {
+      tableCalls[table] = (tableCalls[table] ?? 0) + 1;
+      const n = tableCalls[table];
+      if (table === 'bank_account_balances') {
+        return chain({
+          data: [{ current_balance: 1000, as_of_date: '2026-08-01' }],
+          error: null,
+        });
+      }
+      if (table === 'bank_transactions' && n === 1) {
+        return chain({
+          data: [{ amount: 200, transaction_date: EARLIEST_TS }],
+          error: null,
+        });
+      }
+      if (table === 'bank_transactions') {
+        return chain({ data: { transaction_date: EARLIEST_TS }, error: null });
+      }
+      if (table === 'chart_of_accounts' && n === 1) {
+        return chain({ data: { id: 'cash-id', account_name: 'Cash' }, error: null });
+      }
+      if (table === 'chart_of_accounts') {
+        return chain({ data: { id: 'equity-id', account_name: 'Equity' }, error: null });
+      }
+      if (table === 'restaurants') {
+        return chain({ data: { timezone: 'America/New_York' }, error: null });
+      }
+      if (table === 'journal_entries' && n === 1) {
+        return chain({ data: null, error: null });
+      }
+      if (table === 'journal_entries') {
+        return {
+          insert: (payload: Record<string, unknown>) => {
+            insertedEntry = payload;
+            return chain({ data: { id: 'je-id' }, error: null });
+          },
+        };
+      }
+      if (table === 'journal_entry_lines') {
+        return { insert: () => chain({ error: null }) };
+      }
+      if (table === 'reconciliation_boundaries') {
+        return {
+          upsert: (payload: Record<string, unknown>) => {
+            upsertedBoundary = payload;
+            return chain({ error: null });
+          },
+        };
+      }
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    mocks.rpc.mockImplementation((fn: string) => {
+      if (fn === 'bank_txn_entry_day') {
+        return Promise.resolve({ data: '2026-02-01', error: null });
+      }
+      if (fn === 'rebuild_account_balances') {
+        return Promise.resolve({ data: null, error: null });
+      }
+      throw new Error(`unexpected rpc: ${fn}`);
+    });
+  });
+
+  it('derives the opening date from the bank_txn_entry_day RPC', async () => {
+    const { result } = renderHook(() => useCalculateOpeningBalance(), { wrapper });
+
+    await result.current.mutateAsync('rest-1');
+
+    expect(mocks.rpc).toHaveBeenCalledWith('bank_txn_entry_day', {
+      p_ts: EARLIEST_TS,
+      p_tz: 'America/New_York',
+    });
+    expect(insertedEntry?.entry_date).toBe('2026-02-01');
+    expect(upsertedBoundary?.balance_start_date).toBe('2026-02-01');
+  });
+
+  it('falls back to today when no transaction exists', async () => {
+    // Pin only Date so the fallback assertion does not race the host
+    // clock. Real timers stay live for React Query.
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-08-20T15:00:00Z'));
+
+    mocks.from.mockImplementation((table: string) => {
+      tableCalls[table] = (tableCalls[table] ?? 0) + 1;
+      const n = tableCalls[table];
+      if (table === 'bank_account_balances') {
+        return chain({
+          data: [{ current_balance: 1000, as_of_date: '2026-08-01' }],
+          error: null,
+        });
+      }
+      if (table === 'bank_transactions' && n === 1) {
+        return chain({ data: [], error: null });
+      }
+      if (table === 'bank_transactions') {
+        return chain({ data: null, error: null });
+      }
+      if (table === 'chart_of_accounts' && n === 1) {
+        return chain({ data: { id: 'cash-id', account_name: 'Cash' }, error: null });
+      }
+      if (table === 'chart_of_accounts') {
+        return chain({ data: { id: 'equity-id', account_name: 'Equity' }, error: null });
+      }
+      if (table === 'journal_entries' && n === 1) {
+        return chain({ data: null, error: null });
+      }
+      if (table === 'journal_entries') {
+        return {
+          insert: (payload: Record<string, unknown>) => {
+            insertedEntry = payload;
+            return chain({ data: { id: 'je-id' }, error: null });
+          },
+        };
+      }
+      if (table === 'journal_entry_lines') {
+        return { insert: () => chain({ error: null }) };
+      }
+      if (table === 'reconciliation_boundaries') {
+        return { upsert: () => chain({ error: null }) };
+      }
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    const { result } = renderHook(() => useCalculateOpeningBalance(), { wrapper });
+    await result.current.mutateAsync('rest-1');
+
+    const rpcNames = mocks.rpc.mock.calls.map((c) => c[0]);
+    expect(rpcNames).not.toContain('bank_txn_entry_day');
+    expect(insertedEntry?.entry_date).toBe('2026-08-20');
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+});
+```
+
+Note the no-transaction variant never queries `restaurants`; the mock
+throws on an unexpected table, which pins that.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run tests/unit/useCalculateOpeningBalance.test.ts`
+Expected: FAIL. The first test asserts the `bank_txn_entry_day` RPC call;
+the current hook never calls it and inserts `entry_date` as the raw
+timestamptz string.
+
+- [ ] **Step 3: Change the hook**
+
+In `src/hooks/useCalculateOpeningBalance.tsx`, replace Step 6 (lines
+68-77):
+
+```typescript
+      // Step 6: Get earliest transaction date for the journal entry date.
+      // bank_txn_entry_day holds the entry-day convention (date anchors keep
+      // the UTC day; real instants take the restaurant-local day). The
+      // client never derives the day itself.
+      const { data: earliestTxn } = await supabase
+        .from('bank_transactions')
+        .select('transaction_date')
+        .eq('restaurant_id', restaurantId)
+        .order('transaction_date', { ascending: true })
+        .limit(1)
+        .maybeSingle();
+
+      let openingDate = new Date().toISOString().split('T')[0];
+      if (earliestTxn?.transaction_date) {
+        const { data: restaurant, error: tzError } = await supabase
+          .from('restaurants')
+          .select('timezone')
+          .eq('id', restaurantId)
+          .single();
+        if (tzError) throw tzError;
+
+        const { data: entryDay, error: entryDayError } = await supabase.rpc(
+          'bank_txn_entry_day',
+          { p_ts: earliestTxn.transaction_date, p_tz: restaurant.timezone },
+        );
+        if (entryDayError) throw entryDayError;
+        openingDate = entryDay ?? openingDate;
+      }
+```
+
+In `src/integrations/supabase/types.ts`, add to the `Functions` section in
+alphabetical position (before `builtin_role_id_for`):
+
+```typescript
+      bank_txn_entry_day: {
+        Args: { p_ts: string; p_tz: string | null }
+        Returns: string
+      }
+```
+
+- [ ] **Step 4: Run the tests and the type check to verify they pass**
+
+Run: `npx vitest run tests/unit/useCalculateOpeningBalance.test.ts && npm run typecheck`
+Expected: both PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useCalculateOpeningBalance.tsx src/integrations/supabase/types.ts tests/unit/useCalculateOpeningBalance.test.ts
+git commit -m "fix(ledger): opening balance derives its day from bank_txn_entry_day"
+```
+
+---
+
+## Task Dependencies
+
+- Task 1 blocks every other task.
+- Tasks 2, 3, 4, 5 are independent of one another; run them in order for
+  clean migration timestamps.
+- Task 6 needs Task 1 only, but run it after Tasks 2-5 so the migration
+  timeline reads: convention lands, then data moves.
+- Task 7 needs Task 1 only.
+
+## Production Rollout Note (for the PR body)
+
+The migrations deploy in one release. The re-date migration prints its row
+counts as NOTICEs. Expected production effect at measurement time: 179
+bank entries + 2 reclass entries move, 0 closed-period skips; counts drift
+with the backfill cron. Reports (TrialBalance, BalanceSheet,
+IncomeStatement) show corrected numbers for date ranges that cut through
+an affected day — this is the intended fix.

--- a/docs/superpowers/specs/2026-08-20-journal-entry-date-timezone-design.md
+++ b/docs/superpowers/specs/2026-08-20-journal-entry-date-timezone-design.md
@@ -1,0 +1,228 @@
+# Design: journal entry dates in the restaurant day frame
+
+Date: 2026-08-20
+Branch: claude/friendly-kare-5ade92
+Status: draft for Phase 2.5 review
+
+## Problem
+
+`bank_transactions.transaction_date` is `TIMESTAMPTZ`
+(supabase/migrations/20251021195308_82a73d7e-12b8-49e6-b3ab-975a7b822f5c.sql:3-6).
+`journal_entries.entry_date` is `DATE`
+(supabase/migrations/20251018183326_5da7500b-3a17-4a58-af24-d2175258f871.sql:165).
+Every write path casts the timestamp to a date in the UTC frame. A card swipe
+at 21:00 America/Chicago is 02:00 UTC on the next day. The journal entry for
+that swipe lands on the wrong local day. The income statement then shows the
+expense one day late.
+
+All production restaurants sit west of UTC. The `restaurants.timezone` column
+holds an IANA name with default `'America/Chicago'`
+(supabase/migrations/20251001022351_2147ffdb-edc4-4d22-8812-8120871aaf6f.sql:3).
+
+## Production measurement (read-only, 2026-08-20)
+
+Project `ncdujvdgqtaunuyigflp` was confirmed with `get_project_url` before the
+first query. The time-of-day distribution of `transaction_date` splits the
+data into three populations:
+
+| Population | Rows | Meaning |
+|---|---|---|
+| Exactly `00:00:00` UTC | 3,991 | Date-only values. Statement imports write `transaction.date`, a plain date string (supabase/functions/process-bank-statement/index.ts:911). |
+| Exactly `12:00:00` UTC | 2,552 | Stripe noon-anchored date-only values. The sync writes `transacted_at` epoch seconds (supabase/functions/stripe-sync-transactions/index.ts:278). |
+| Other times | 1,775 | Real instants from Stripe `transacted_at`. |
+
+Impact counts, with the restaurant timezone applied to real instants only:
+
+| Measure | Count |
+|---|---|
+| Bank transactions whose UTC day differs from the local day | 208 (all `America/Chicago`) |
+| `journal_entries` rows with `reference_type = 'bank_transaction'` | 4,908 |
+| Of those, rows not on the UTC day today | 0 |
+| Bank entries that need a re-date | 179 |
+| Reclassification entries that need a re-date | 2 |
+| Re-dates that land inside a closed fiscal period | 0 |
+| Source transactions where the day shift crosses a month boundary | 3 |
+
+The zero in row three confirms the current convention is uniformly UTC.
+
+## Decision: a hybrid day convention
+
+A blanket restaurant-local cast is wrong for this data. A date-only value
+stored at midnight UTC already names the intended calendar day. `2025-01-15
+00:00:00Z` cast with `America/Chicago` becomes `2025-01-14` — one day early
+for 3,991 rows. The convention must branch on the shape of the stored value:
+
+- Time-of-day is exactly `00:00:00` or `12:00:00` UTC → the value is a date
+  anchor. The entry day is the UTC calendar day.
+- Any other time-of-day → the value is a real instant. The entry day is the
+  restaurant-local calendar day.
+
+For every US timezone the two branches agree on noon-anchored rows, so the
+`12:00:00` case only matters as protection for east-of-UTC zones, where a
+local cast of noon UTC would shift the day forward.
+
+A real instant that lands on exactly `00:00:00` or `12:00:00` UTC is
+misclassified as an anchor. The window is one second twice a day, and the
+result equals today's behavior. Accepted trade-off.
+
+### One expression, one place
+
+A prior period guard diverged from its insert because the two casts were
+written twice (lesson [2026-08-20], PR #766). To prevent that class, the
+convention lives in one SQL function:
+
+```sql
+CREATE OR REPLACE FUNCTION public.bank_txn_entry_day(p_ts timestamptz, p_tz text)
+RETURNS date
+LANGUAGE plpgsql
+STABLE
+AS $$
+BEGIN
+  IF p_ts IS NULL THEN
+    RETURN NULL;
+  END IF;
+  IF (p_ts AT TIME ZONE 'UTC')::time IN ('00:00:00', '12:00:00') THEN
+    RETURN (p_ts AT TIME ZONE 'UTC')::date;
+  END IF;
+  BEGIN
+    RETURN (p_ts AT TIME ZONE COALESCE(p_tz, 'America/Chicago'))::date;
+  EXCEPTION WHEN invalid_parameter_value THEN
+    RETURN (p_ts AT TIME ZONE 'UTC')::date;
+  END;
+END;
+$$;
+```
+
+The `BEGIN … EXCEPTION` guard follows the lesson from `check_timeoff_conflict`
+([2026-07-23]): do not probe `pg_timezone_names` per call; a plain cast is
+~100× cheaper and only an invalid zone pays for the subtransaction. The
+fallback for a garbage timezone is the UTC day — today's behavior. The
+`COALESCE` default matches the column default `'America/Chicago'`.
+
+Every caller passes `restaurants.timezone` for the transaction's restaurant.
+
+## Write paths to change (one release)
+
+Four functions write `entry_date` from `transaction_date`. Each gets a
+`CREATE OR REPLACE` migration that swaps the cast for
+`bank_txn_entry_day(v_transaction.transaction_date, v_timezone)` and aligns
+its period guard to the same expression.
+
+1. **`categorize_bank_transaction`** — current definition in
+   supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql.
+   Two inserts pass the raw timestamptz: the reclassification insert (line
+   172) and the bank insert (line 213). Both take the implicit session-TZ
+   cast; Supabase sessions run UTC. The closed-period guard compares the raw
+   timestamptz with the `DATE` bounds (lines 135-136) — a mixed-basis
+   comparison. The existing-entry UPDATE branch (line 202) does not touch
+   `entry_date`; it must now also set `entry_date` so a recategorize call
+   heals an old row.
+2. **`bulk_categorize_bank_transactions`** — current definition in
+   supabase/migrations/20260819231210_add_bulk_categorize_bank_transactions.sql.
+   Two inserts use the explicit UTC cast (lines 187, 238). The closed-period
+   guard compares the raw timestamptz with the bounds (lines 169-171). The
+   existing-entry UPDATE branch (line 226) must also set `entry_date`.
+3. **`apply_rules_to_bank_transactions_internal`** — current definition in
+   supabase/migrations/20260804090300_bounded_categorization_sweep.sql (the
+   two later migrations only call it). One insert passes the raw timestamptz
+   (line 478). The closed-period guard is mixed-basis (lines 395-396). The
+   existing-entry UPDATE branch (line 464) must also set `entry_date`.
+4. **`backfill_bank_transaction_journal_entries`** — current definition in
+   supabase/migrations/20260819232450_backfill_bank_transaction_journal_entries.sql.
+   One insert uses the explicit UTC cast (line 115). Its closed-period guard
+   already matches its insert (lines 93-94); both move to the helper.
+
+The trigger `auto_apply_bank_categorization_rules`
+(supabase/migrations/20260703090000_categorization_background_and_supplier_assign.sql:224)
+sets only `category_id` on the transaction row and writes no journal entry.
+No other current function writes `entry_date` from a bank transaction.
+`post_asset_depreciation`
+(supabase/migrations/20260122000000_create_assets_equipment.sql:449) takes a
+`DATE` parameter directly and is out of scope.
+
+### Guard basis rule
+
+Every closed-period comparison inside these functions must use the exact
+helper output, not the raw timestamptz and not a second hand-written cast
+(lesson [2026-08-20]: "a guard and a write derive a day from the same
+timestamptz, both must use one expression"). The guard change also fixes a
+latent guard bug: today a 23:30Z row on the last day of a closed period
+passes the raw-timestamptz guard in `categorize_bank_transaction`.
+
+## One-time re-date migration
+
+A second migration re-dates existing rows:
+
+1. Bank entries: join `journal_entries` (`reference_type =
+   'bank_transaction'`) to `bank_transactions` on `reference_id` and to
+   `restaurants` for the timezone. Set `entry_date =
+   bank_txn_entry_day(...)` where the values differ.
+2. Reclassification entries: reclass rows carry a random `reference_id`
+   (20260709120000_categorize_preserve_metadata_on_noop.sql:166), so the join
+   goes through `transaction_reclassifications.reclass_journal_entry_id` and
+   `bank_transaction_id` (same file, lines 191-197).
+3. Skip a row when the new day falls inside a closed fiscal period, with the
+   comparison on the helper output. Production count of such rows is 0
+   today; the guard protects other environments and future reruns.
+4. Do not call `rebuild_account_balances`. `compute_account_balance` sums
+   lines with `entry_date <= p_as_of_date`, default `CURRENT_DATE`
+   (supabase/migrations/20251019021231_942cf575-c06d-491f-9f5f-77c57b85d1a2.sql:25-54).
+   West-of-UTC re-dates move a date backward one day, so no historical row
+   crosses the `CURRENT_DATE` bound and every stored balance is unchanged.
+   East-of-UTC zones have no affected rows (all 208 shifts are
+   `America/Chicago`).
+
+Expected production effect: 181 rows updated (179 + 2), 3 of them across a
+month boundary. The statement touches at most a few thousand joined rows;
+no `statement_timeout` risk.
+
+## What does not change (non-goals)
+
+- `bank_transactions.transaction_date` values. The source data stays as
+  stored; only the derived `entry_date` convention changes.
+- The ingest paths (stripe-sync-transactions, process-bank-statement).
+- POS sales, `unified_sales`, and their categorization paths — no
+  `entry_date` write from a `timestamptz` exists there.
+- Asset depreciation entries (`DATE` parameter, no cast).
+- UI date rendering for bank transactions. The Transactions page shows the
+  source timestamp; that display is a separate product surface.
+- `fiscal_periods.period_start/period_end` semantics (already local days).
+
+## Tests
+
+- New pgTAP suite for `bank_txn_entry_day`: midnight anchor, noon anchor,
+  real evening instant (day shift), real midday instant (no shift), NULL
+  timezone, invalid timezone string, DST boundary instants
+  (`America/Chicago` spring-forward and fall-back days).
+- New pgTAP suite for the re-date migration path: seed a UTC-dated entry
+  from an evening instant, run the re-date statement shape, assert the new
+  day; seed a date-anchored row, assert no change; seed a closed-period
+  collision, assert the skip.
+- Extend `supabase/tests/22_bulk_categorize_bank_transactions.sql` and
+  `supabase/tests/23_backfill_bank_transaction_journal_entries.sql` with one
+  evening-instant fixture each, asserting the local-day `entry_date`.
+- Extend the categorize suite with an evening-instant fixture and with a
+  recategorize-heals-entry_date assertion.
+- Per lesson [2026-08-19], any test that asserts restaurant-timezone
+  behavior must not read the host clock; all fixtures use explicit UTC
+  instants and fixed expected dates.
+
+## E2E position
+
+The change is a SQL-only re-derivation of one column; no route, dialog, or
+request path changes. The seam is covered by pgTAP at the function boundary.
+Planned position: justified exception under the Phase 8 gate, with the
+categorization E2E flow already exercising the RPCs end to end. Phase 8
+re-evaluates this claim against the final diff.
+
+## Decided trade-offs
+
+- A 1-second misclassification window at exactly `00:00:00`/`12:00:00` UTC
+  for real instants: result equals current behavior; accepted.
+- Noon-anchor recognition also treats a genuine noon-UTC instant as an
+  anchor. For west-of-UTC zones both branches give the same day; accepted.
+- The helper is `STABLE`, not `IMMUTABLE`: the tz database can change
+  between calls. No index uses the function, so this costs nothing.
+- Rules created by `apply_rules_to_bank_transactions_internal` run under
+  cron without `auth.uid()`; the function change keeps its permission
+  posture untouched.

--- a/docs/superpowers/specs/2026-08-20-journal-entry-date-timezone-design.md
+++ b/docs/superpowers/specs/2026-08-20-journal-entry-date-timezone-design.md
@@ -106,6 +106,21 @@ The `BEGIN … EXCEPTION` guard follows the lesson from `check_timeoff_conflict`
 fallback for a garbage timezone is the UTC day — today's behavior. The
 `COALESCE` default matches the column default `'America/Chicago'`.
 
+Performance note (reviewed 2026-08-20, decision: accept). The
+`BEGIN … EXCEPTION` block opens a subtransaction on each entry, also when
+no exception fires. A Phase 7b reviewer flagged this as a per-row cost
+inside the loops (500 rows per bulk call, 1000 rows per sweep run). The
+cost is bounded and small: a no-write subtransaction entry costs single-digit
+microseconds, so a full 1000-row sweep pays ~10 ms against its 40-second
+budget. A local benchmark of 100k calls showed the helper within 1% of a
+bare inline cast. Two more facts lower the real cost: 79% of production
+rows are date anchors and return before the exception block, and
+`restaurants.timezone` is an app-controlled column, so the exception path
+is a safety net, not a hot path. The alternative — a pre-validated-timezone
+parameter — moves validation to five call sites and reintroduces the
+multi-site duplication this design exists to delete. Keep the signature
+and the body as written.
+
 Every caller passes `restaurants.timezone` for the transaction's restaurant.
 Each SQL function loads that timezone once, with one `restaurants` lookup,
 into a local variable. The migration also grants `EXECUTE` on the helper to

--- a/docs/superpowers/specs/2026-08-20-journal-entry-date-timezone-design.md
+++ b/docs/superpowers/specs/2026-08-20-journal-entry-date-timezone-design.md
@@ -2,7 +2,7 @@
 
 Date: 2026-08-20
 Branch: claude/friendly-kare-5ade92
-Status: draft for Phase 2.5 review
+Status: Phase 2.5 review folded in (2 critical, 3 major, 2 minor — all fixed)
 
 ## Problem
 
@@ -27,7 +27,7 @@ data into three populations:
 
 | Population | Rows | Meaning |
 |---|---|---|
-| Exactly `00:00:00` UTC | 3,991 | Date-only values. Statement imports write `transaction.date`, a plain date string (supabase/functions/process-bank-statement/index.ts:911). |
+| Exactly `00:00:00` UTC | 3,991 | Date-only values. The OCR function writes a plain date string into the staging table `bank_statement_lines` (supabase/functions/process-bank-statement/index.ts:911). The import hook copies the staged value into `bank_transactions.transaction_date` (src/hooks/useBankStatementImport.tsx:475, insert at 489-491). |
 | Exactly `12:00:00` UTC | 2,552 | Stripe noon-anchored date-only values. The sync writes `transacted_at` epoch seconds (supabase/functions/stripe-sync-transactions/index.ts:278). |
 | Other times | 1,775 | Real instants from Stripe `transacted_at`. |
 
@@ -44,6 +44,12 @@ Impact counts, with the restaurant timezone applied to real instants only:
 | Source transactions where the day shift crosses a month boundary | 3 |
 
 The zero in row three confirms the current convention is uniformly UTC.
+
+These counts are a snapshot. The bank-entry count grew from 4,908 to 5,470
+within hours of the first measurement (the backfill cron runs every 5
+minutes). Treat each number as reproducible from its query, not as a fixed
+value. The re-date migration computes its own row set at run time and does
+not depend on these counts.
 
 ## Decision: a hybrid day convention
 
@@ -76,6 +82,7 @@ CREATE OR REPLACE FUNCTION public.bank_txn_entry_day(p_ts timestamptz, p_tz text
 RETURNS date
 LANGUAGE plpgsql
 STABLE
+SET search_path = public, pg_catalog
 AS $$
 BEGIN
   IF p_ts IS NULL THEN
@@ -100,13 +107,17 @@ fallback for a garbage timezone is the UTC day — today's behavior. The
 `COALESCE` default matches the column default `'America/Chicago'`.
 
 Every caller passes `restaurants.timezone` for the transaction's restaurant.
+Each SQL function loads that timezone once, with one `restaurants` lookup,
+into a local variable. The migration also grants `EXECUTE` on the helper to
+`authenticated`, because the opening-balance hook (path 5 below) calls it
+through PostgREST.
 
 ## Write paths to change (one release)
 
-Four functions write `entry_date` from `transaction_date`. Each gets a
-`CREATE OR REPLACE` migration that swaps the cast for
-`bank_txn_entry_day(v_transaction.transaction_date, v_timezone)` and aligns
-its period guard to the same expression.
+Four SQL functions and one client hook write `entry_date` from
+`transaction_date`. Each function gets a `CREATE OR REPLACE` migration that
+swaps the cast for `bank_txn_entry_day(v_transaction.transaction_date,
+v_timezone)` and aligns its period guard to the same expression.
 
 1. **`categorize_bank_transaction`** — current definition in
    supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql.
@@ -130,7 +141,20 @@ its period guard to the same expression.
 4. **`backfill_bank_transaction_journal_entries`** — current definition in
    supabase/migrations/20260819232450_backfill_bank_transaction_journal_entries.sql.
    One insert uses the explicit UTC cast (line 115). Its closed-period guard
-   already matches its insert (lines 93-94); both move to the helper.
+   already matches its insert (lines 93-94); both move to the helper. The
+   `tmp_backfill_candidates` query has no `restaurants` join today (lines
+   50-96). The replacement adds `JOIN restaurants r ON r.id =
+   bt.restaurant_id`, carries `r.timezone` as a candidate column, and passes
+   it to the helper in the insert and in the guard.
+5. **`useCalculateOpeningBalance`** (client hook) —
+   src/hooks/useCalculateOpeningBalance.tsx reads the earliest
+   `bank_transactions.transaction_date` (lines 69-77) and inserts that value
+   as `journal_entries.entry_date` with `reference_type =
+   'opening_balance'` (line 97). PostgREST coerces the timestamptz string to
+   `DATE` at the UTC day. The fix: the hook fetches `restaurants.timezone`,
+   then calls the `bank_txn_entry_day` RPC to derive the day. The convention
+   stays in one SQL expression; the client holds no copy of the rule. The
+   fallback when no transaction exists (line 77) stays as today.
 
 The trigger `auto_apply_bank_categorization_rules`
 (supabase/migrations/20260703090000_categorization_background_and_supplier_assign.sql:224)
@@ -171,10 +195,35 @@ A second migration re-dates existing rows:
    crosses the `CURRENT_DATE` bound and every stored balance is unchanged.
    East-of-UTC zones have no affected rows (all 208 shifts are
    `America/Chicago`).
+5. Do not re-date `opening_balance` entries. Production has 4 such entries.
+   For all 4, the earliest transaction is date-anchored, so the new
+   convention gives the same day as the UTC cast — the convention change
+   moves zero of these rows. Their `entry_date` values do differ from the
+   day of today's earliest transaction, but that is anchor drift: imports
+   and deletions after creation changed which transaction is earliest. A
+   re-date from today's earliest transaction would move entries by months,
+   not by a one-day timezone correction, and would desync
+   `reconciliation_boundaries.balance_start_date`. That repair is a separate
+   pre-existing problem, out of scope here.
 
 Expected production effect: 181 rows updated (179 + 2), 3 of them across a
 month boundary. The statement touches at most a few thousand joined rows;
 no `statement_timeout` risk.
+
+## Report-level effects
+
+Three report components read `entry_date` with caller-chosen date bounds:
+`TrialBalance` passes an arbitrary `p_as_of_date` to the balance RPC
+(src/components/financial-statements/TrialBalance.tsx:53); `BalanceSheet`
+filters `journal_entry.entry_date <= asOf`
+(src/components/financial-statements/BalanceSheet.tsx:80-82);
+`IncomeStatement` filters a `gte`/`lte` range
+(src/components/financial-statements/IncomeStatement.tsx:215-220). After the
+re-date, an affected entry moves from the UTC day to the local day, so a
+report bounded inside that window shows different numbers. This shift is the
+intended correction, not a side effect. A pgTAP test must show it:
+compute a balance with an as-of date between the old day and the new day,
+before and after the re-date statement, and assert the entry now counts.
 
 ## What does not change (non-goals)
 
@@ -187,6 +236,8 @@ no `statement_timeout` risk.
 - UI date rendering for bank transactions. The Transactions page shows the
   source timestamp; that display is a separate product surface.
 - `fiscal_periods.period_start/period_end` semantics (already local days).
+- Existing `opening_balance` entry dates and their anchor drift (see
+  re-date item 5). Only the forward path of the hook changes.
 
 ## Tests
 
@@ -203,6 +254,11 @@ no `statement_timeout` risk.
   evening-instant fixture each, asserting the local-day `entry_date`.
 - Extend the categorize suite with an evening-instant fixture and with a
   recategorize-heals-entry_date assertion.
+- Re-date suite: assert the before/after balance shift from the
+  report-level-effects section (mid-window as-of date).
+- New Vitest unit test for the changed `useCalculateOpeningBalance` date
+  derivation: mock the RPC, assert the hook passes the fetched timezone and
+  uses the RPC result as `entry_date`; assert the no-transaction fallback.
 - Per lesson [2026-08-19], any test that asserts restaurant-timezone
   behavior must not read the host clock; all fixtures use explicit UTC
   instants and fixed expected dates.

--- a/src/hooks/useCalculateOpeningBalance.tsx
+++ b/src/hooks/useCalculateOpeningBalance.tsx
@@ -65,7 +65,10 @@ export const useCalculateOpeningBalance = () => {
 
       if (equityError) throw equityError;
 
-      // Step 6: Get earliest transaction date for the journal entry date
+      // Step 6: Get earliest transaction date for the journal entry date.
+      // bank_txn_entry_day holds the entry-day convention (date anchors keep
+      // the UTC day; real instants take the restaurant-local day). The
+      // client never derives the day itself.
       const { data: earliestTxn } = await supabase
         .from('bank_transactions')
         .select('transaction_date')
@@ -74,7 +77,22 @@ export const useCalculateOpeningBalance = () => {
         .limit(1)
         .maybeSingle();
 
-      const openingDate = earliestTxn?.transaction_date || new Date().toISOString().split('T')[0];
+      let openingDate = new Date().toISOString().split('T')[0];
+      if (earliestTxn?.transaction_date) {
+        const { data: restaurant, error: tzError } = await supabase
+          .from('restaurants')
+          .select('timezone')
+          .eq('id', restaurantId)
+          .single();
+        if (tzError) throw tzError;
+
+        const { data: entryDay, error: entryDayError } = await supabase.rpc(
+          'bank_txn_entry_day',
+          { p_ts: earliestTxn.transaction_date, p_tz: restaurant.timezone },
+        );
+        if (entryDayError) throw entryDayError;
+        openingDate = entryDay ?? openingDate;
+      }
 
       // Step 7: Check if opening balance already exists
       const { data: existingEntry } = await supabase

--- a/src/hooks/useCalculateOpeningBalance.tsx
+++ b/src/hooks/useCalculateOpeningBalance.tsx
@@ -65,34 +65,19 @@ export const useCalculateOpeningBalance = () => {
 
       if (equityError) throw equityError;
 
-      // Step 6: Get earliest transaction date for the journal entry date.
-      // bank_txn_entry_day holds the entry-day convention (date anchors keep
-      // the UTC day; real instants take the restaurant-local day). The
-      // client never derives the day itself.
-      const { data: earliestTxn } = await supabase
-        .from('bank_transactions')
-        .select('transaction_date')
-        .eq('restaurant_id', restaurantId)
-        .order('transaction_date', { ascending: true })
-        .limit(1)
-        .maybeSingle();
-
-      let openingDate = new Date().toISOString().split('T')[0];
-      if (earliestTxn?.transaction_date) {
-        const { data: restaurant, error: tzError } = await supabase
-          .from('restaurants')
-          .select('timezone')
-          .eq('id', restaurantId)
-          .single();
-        if (tzError) throw tzError;
-
-        const { data: entryDay, error: entryDayError } = await supabase.rpc(
-          'bank_txn_entry_day',
-          { p_ts: earliestTxn.transaction_date, p_tz: restaurant.timezone },
-        );
-        if (entryDayError) throw entryDayError;
-        openingDate = entryDay ?? openingDate;
-      }
+      // Step 6: Get the entry day for the opening balance.
+      // min_bank_txn_entry_day returns the minimum derived entry day
+      // across the restaurant's transactions. The minimum raw timestamp
+      // is not enough: a date anchor keeps its UTC day while a later
+      // instant can land one local day earlier. The server derives the
+      // day; the client never does. NULL means no readable transaction:
+      // fall back to the current UTC day.
+      const { data: minEntryDay, error: minEntryDayError } = await supabase.rpc(
+        'min_bank_txn_entry_day',
+        { p_restaurant_id: restaurantId },
+      );
+      if (minEntryDayError) throw minEntryDayError;
+      const openingDate = minEntryDay ?? new Date().toISOString().split('T')[0];
 
       // Step 7: Check if opening balance already exists
       const { data: existingEntry } = await supabase

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -10700,6 +10700,10 @@ export type Database = {
           user_id: string
         }[]
       }
+      bank_txn_entry_day: {
+        Args: { p_ts: string; p_tz: string | null }
+        Returns: string
+      }
       builtin_role_id_for: { Args: { p_role: string }; Returns: string }
       bulk_categorize_bank_transactions: {
         Args: {

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -11622,6 +11622,10 @@ export type Database = {
         Args: { p_rule_id: string; p_sale: Json }
         Returns: boolean
       }
+      min_bank_txn_entry_day: {
+        Args: { p_restaurant_id: string }
+        Returns: string
+      }
       no_plan: { Args: never; Returns: boolean[] }
       num_failed: { Args: never; Returns: number }
       os_name: { Args: never; Returns: string }

--- a/supabase/migrations/20260820210000_bank_txn_entry_day.sql
+++ b/supabase/migrations/20260820210000_bank_txn_entry_day.sql
@@ -1,0 +1,46 @@
+-- One expression for the journal entry day of a bank transaction.
+--
+-- bank_transactions.transaction_date is timestamptz. journal_entries.entry_date
+-- is date. Production holds three value populations (measured 2026-08-20):
+-- 3,991 rows at exactly 00:00:00 UTC (date-only statement imports), 2,552 at
+-- exactly 12:00:00 UTC (Stripe noon-anchored dates), and ~1,775 real instants.
+-- A date-anchored value already names its calendar day; a local cast would
+-- move it one day early. A real instant belongs to the restaurant-local day.
+-- This function holds that branch. Every entry insert AND every closed-period
+-- guard must call it — never write the cast twice (PR #766 lesson).
+-- See docs/superpowers/specs/2026-08-20-journal-entry-date-timezone-design.md.
+
+CREATE OR REPLACE FUNCTION public.bank_txn_entry_day(p_ts timestamptz, p_tz text)
+RETURNS date
+LANGUAGE plpgsql
+STABLE
+SET search_path = public, pg_catalog
+AS $$
+BEGIN
+  IF p_ts IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  -- A time of exactly 00:00:00 or 12:00:00 UTC marks a date-only source
+  -- value. Keep its UTC day. Misclassification window for a real instant:
+  -- one second twice a day, and the result equals the old behavior.
+  IF (p_ts AT TIME ZONE 'UTC')::time IN ('00:00:00', '12:00:00') THEN
+    RETURN (p_ts AT TIME ZONE 'UTC')::date;
+  END IF;
+
+  BEGIN
+    RETURN (p_ts AT TIME ZONE COALESCE(p_tz, 'America/Chicago'))::date;
+  EXCEPTION WHEN invalid_parameter_value THEN
+    -- Garbage timezone string: keep the UTC day (the old behavior). Do not
+    -- probe pg_timezone_names per call — the subtransaction guard is ~100x
+    -- cheaper and only a bad zone pays for it (check_timeoff_conflict lesson).
+    RETURN (p_ts AT TIME ZONE 'UTC')::date;
+  END;
+END;
+$$;
+
+COMMENT ON FUNCTION public.bank_txn_entry_day(timestamptz, text) IS
+  'Entry day for a bank transaction. Date anchors (00:00/12:00 UTC) keep the UTC day; real instants take the restaurant-local day.';
+
+-- The opening-balance hook calls this through PostgREST.
+GRANT EXECUTE ON FUNCTION public.bank_txn_entry_day(timestamptz, text) TO authenticated;

--- a/supabase/migrations/20260820210100_categorize_local_entry_day.sql
+++ b/supabase/migrations/20260820210100_categorize_local_entry_day.sql
@@ -1,0 +1,258 @@
+-- categorize_bank_transaction writes the restaurant-local entry day
+--
+-- Change: this migration changes only the entry-day derivation and the
+-- fiscal-period guard basis. It replaces the raw transaction_date cast
+-- with bank_txn_entry_day(transaction_date, restaurant.timezone) in three
+-- places: the closed-period guard, the RECLASS journal entry insert, and
+-- the BANK journal entry insert. It also heals entry_date on the
+-- existing-entry UPDATE branch, so a re-categorize call fixes a
+-- previously wrong-day entry instead of leaving it stale.
+--
+-- This migration is a CREATE OR REPLACE of the function body from
+-- supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql.
+-- Every other line of that function body is byte-identical.
+--
+-- See docs/superpowers/specs/2026-08-20-journal-entry-date-timezone-design.md.
+
+CREATE OR REPLACE FUNCTION public.categorize_bank_transaction(
+  p_transaction_id uuid,
+  p_category_id uuid,
+  p_description text DEFAULT NULL,
+  p_normalized_payee text DEFAULT NULL,
+  p_supplier_id uuid DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_transaction RECORD;
+  v_category RECORD;
+  v_is_reclassification boolean := false;
+  v_original_category_id uuid;
+  v_journal_entry_id uuid;
+  v_cash_account RECORD;
+  v_fiscal_period RECORD;
+  v_existing_journal_entry uuid;
+  v_reclass_reference_id uuid;
+  v_timezone text;
+  v_entry_day date;
+BEGIN
+  -- Get transaction details
+  SELECT * INTO v_transaction
+  FROM bank_transactions
+  WHERE id = p_transaction_id;
+
+  IF v_transaction.id IS NULL THEN
+    RAISE EXCEPTION 'Transaction not found';
+  END IF;
+
+  -- Verify user has access to this restaurant
+  IF NOT EXISTS (
+    SELECT 1
+    FROM user_restaurants
+    WHERE restaurant_id = v_transaction.restaurant_id
+      AND user_id = auth.uid()
+  ) THEN
+    RAISE EXCEPTION 'Unauthorized: user does not have access to this restaurant';
+  END IF;
+
+  -- Tenant-scope p_supplier_id before ANY write path uses it. This function is
+  -- SECURITY DEFINER (bypasses RLS) and bank_transactions.supplier_id only has a
+  -- plain FK to suppliers(id), so an unscoped write would let a user with access
+  -- to this restaurant link the transaction to another tenant's supplier by UUID.
+  -- If the supplier isn't visible to this restaurant, silently drop it (fall back
+  -- to preserving the existing supplier_id via COALESCE downstream) rather than
+  -- raising. Hoisted here so BOTH the no-op short-circuit and the main
+  -- categorize/reclassify UPDATE below are covered by a single guard.
+  IF p_supplier_id IS NOT NULL AND NOT EXISTS (
+    SELECT 1 FROM suppliers
+    WHERE id = p_supplier_id
+      AND restaurant_id = v_transaction.restaurant_id
+  ) THEN
+    p_supplier_id := NULL;
+  END IF;
+
+  -- Check if this is a reclassification
+  IF v_transaction.is_categorized AND v_transaction.category_id IS NOT NULL THEN
+    v_is_reclassification := true;
+    v_original_category_id := v_transaction.category_id;
+  END IF;
+
+  -- Short-circuit when category doesn't actually change (avoid no-op reclassifications)
+  IF v_is_reclassification AND v_original_category_id = p_category_id THEN
+    -- Category unchanged: no journal entry needed (skipping rebuild_account_balances
+    -- is correct — no ledger movement), but still persist metadata edits
+    -- (payee / supplier / notes) so a UI "Save" is not a silent no-op.
+    -- p_supplier_id was already tenant-scoped above (hoisted guard).
+    UPDATE bank_transactions
+    SET
+      normalized_payee = COALESCE(p_normalized_payee, normalized_payee),
+      supplier_id      = COALESCE(p_supplier_id, supplier_id),
+      -- COALESCE (preserve-on-null), NOT the main path's unconditional
+      -- `notes = p_description`: Transactions.tsx calls this RPC with
+      -- p_description = NULL, so an unconditional write here would wipe a user's
+      -- note on a same-category call. Intentional asymmetry — do not "fix".
+      notes            = COALESCE(p_description, notes),
+      updated_at       = now()
+    WHERE id = p_transaction_id;
+
+    RETURN jsonb_build_object(
+      'success', true,
+      'journal_entry_id', NULL,
+      'is_reclassification', false,
+      'transaction_id', p_transaction_id
+    );
+  END IF;
+
+  -- Block initial categorization of reconciled transactions
+  IF v_transaction.is_reconciled AND NOT v_is_reclassification THEN
+    RAISE EXCEPTION 'Cannot categorize a reconciled transaction. Use reclassification instead by updating the category of an already categorized transaction.';
+  END IF;
+
+  -- Get category details
+  SELECT * INTO v_category
+  FROM chart_of_accounts
+  WHERE id = p_category_id
+    AND restaurant_id = v_transaction.restaurant_id
+    AND is_active = true;
+
+  IF v_category.id IS NULL THEN
+    RAISE EXCEPTION 'Category not found or inactive';
+  END IF;
+
+  -- One expression for the entry day; the guard below and both inserts use
+  -- it. Never derive the day a second way (PR #766 lesson).
+  SELECT timezone INTO v_timezone
+  FROM restaurants
+  WHERE id = v_transaction.restaurant_id;
+
+  v_entry_day := bank_txn_entry_day(v_transaction.transaction_date, v_timezone);
+
+  -- Check if transaction falls in a closed fiscal period
+  SELECT * INTO v_fiscal_period
+  FROM fiscal_periods
+  WHERE restaurant_id = v_transaction.restaurant_id
+    AND v_entry_day >= period_start
+    AND v_entry_day <= period_end
+    AND is_closed = true
+  LIMIT 1;
+
+  IF v_fiscal_period.id IS NOT NULL THEN
+    RAISE EXCEPTION 'Cannot categorize transaction in closed fiscal period. Period closed on %', v_fiscal_period.closed_at;
+  END IF;
+
+  -- Get cash account
+  SELECT * INTO v_cash_account
+  FROM chart_of_accounts
+  WHERE restaurant_id = v_transaction.restaurant_id
+    AND account_code = '1000'
+  LIMIT 1;
+
+  IF v_cash_account.id IS NULL THEN
+    RAISE EXCEPTION 'Cash account (1000) not found';
+  END IF;
+
+  -- Check if a journal entry already exists
+  SELECT id INTO v_existing_journal_entry
+  FROM journal_entries
+  WHERE reference_type = 'bank_transaction'
+    AND reference_id = v_transaction.id
+    AND restaurant_id = v_transaction.restaurant_id
+  LIMIT 1;
+
+  -- Handle reclassification
+  IF v_is_reclassification THEN
+    -- Generate a unique reference_id for this reclassification
+    v_reclass_reference_id := gen_random_uuid();
+
+    INSERT INTO journal_entries (
+      restaurant_id, entry_date, entry_number, description,
+      reference_type, reference_id, total_debit, total_credit, created_by
+    ) VALUES (
+      v_transaction.restaurant_id, v_entry_day,
+      'RECLASS-' || v_transaction.id::text || '-' || TO_CHAR(now(), 'YYYYMMDD-HH24MISS-US'),
+      COALESCE(p_description, 'Reclassification: ' || v_transaction.description),
+      'reclassification', v_reclass_reference_id,  -- Use unique reference_id
+      ABS(v_transaction.amount), ABS(v_transaction.amount), auth.uid()
+    ) RETURNING id INTO v_journal_entry_id;
+
+    IF v_transaction.amount < 0 THEN
+      INSERT INTO journal_entry_lines (journal_entry_id, account_id, debit_amount, credit_amount, description)
+      VALUES
+        (v_journal_entry_id, p_category_id, ABS(v_transaction.amount), 0, 'Reclassify to ' || v_category.account_name),
+        (v_journal_entry_id, v_original_category_id, 0, ABS(v_transaction.amount), 'Reclassify from previous category');
+    ELSE
+      INSERT INTO journal_entry_lines (journal_entry_id, account_id, debit_amount, credit_amount, description)
+      VALUES
+        (v_journal_entry_id, v_original_category_id, ABS(v_transaction.amount), 0, 'Reclassify from previous category'),
+        (v_journal_entry_id, p_category_id, 0, ABS(v_transaction.amount), 'Reclassify to ' || v_category.account_name);
+    END IF;
+
+    INSERT INTO transaction_reclassifications (
+      restaurant_id, bank_transaction_id, original_category_id,
+      new_category_id, reclass_journal_entry_id, reason, created_by
+    ) VALUES (
+      v_transaction.restaurant_id, v_transaction.id, v_original_category_id,
+      p_category_id, v_journal_entry_id, p_description, auth.uid()
+    );
+  ELSE
+    IF v_existing_journal_entry IS NOT NULL THEN
+      v_journal_entry_id := v_existing_journal_entry;
+      DELETE FROM journal_entry_lines WHERE journal_entry_id = v_existing_journal_entry;
+      UPDATE journal_entries
+      SET entry_date = v_entry_day,
+          description = COALESCE(p_description, v_transaction.description),
+          total_debit = ABS(v_transaction.amount),
+          total_credit = ABS(v_transaction.amount),
+          updated_at = now()
+      WHERE id = v_existing_journal_entry;
+    ELSE
+      INSERT INTO journal_entries (
+        restaurant_id, entry_date, entry_number, description,
+        reference_type, reference_id, total_debit, total_credit, created_by
+      ) VALUES (
+        v_transaction.restaurant_id, v_entry_day,
+        'BANK-' || COALESCE(v_transaction.stripe_transaction_id, v_transaction.id::text) || '-' || TO_CHAR(now(), 'YYYYMMDD-HH24MISS-US'),
+        COALESCE(p_description, v_transaction.description),
+        'bank_transaction', v_transaction.id,
+        ABS(v_transaction.amount), ABS(v_transaction.amount), auth.uid()
+      ) RETURNING id INTO v_journal_entry_id;
+    END IF;
+
+    IF v_transaction.amount < 0 THEN
+      INSERT INTO journal_entry_lines (journal_entry_id, account_id, debit_amount, credit_amount, description)
+      VALUES
+        (v_journal_entry_id, p_category_id, ABS(v_transaction.amount), 0, v_category.account_name),
+        (v_journal_entry_id, v_cash_account.id, 0, ABS(v_transaction.amount), 'Cash payment');
+    ELSE
+      INSERT INTO journal_entry_lines (journal_entry_id, account_id, debit_amount, credit_amount, description)
+      VALUES
+        (v_journal_entry_id, v_cash_account.id, ABS(v_transaction.amount), 0, 'Cash received'),
+        (v_journal_entry_id, p_category_id, 0, ABS(v_transaction.amount), v_category.account_name);
+    END IF;
+  END IF;
+
+  -- Update transaction with notes, payee, and supplier (preserve supplier_id with COALESCE)
+  UPDATE bank_transactions
+  SET
+    category_id = p_category_id,
+    is_categorized = true,
+    notes = p_description,
+    normalized_payee = COALESCE(p_normalized_payee, normalized_payee),
+    supplier_id = COALESCE(p_supplier_id, supplier_id),
+    updated_at = now()
+  WHERE id = p_transaction_id;
+
+  -- Rebuild account balances
+  PERFORM rebuild_account_balances(v_transaction.restaurant_id);
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'journal_entry_id', v_journal_entry_id,
+    'is_reclassification', v_is_reclassification,
+    'transaction_id', p_transaction_id
+  );
+END;
+$function$;

--- a/supabase/migrations/20260820210200_bulk_categorize_local_entry_day.sql
+++ b/supabase/migrations/20260820210200_bulk_categorize_local_entry_day.sql
@@ -1,0 +1,297 @@
+-- bulk_categorize_bank_transactions writes the restaurant-local entry day
+--
+-- Change: this migration changes only the entry-day derivation and the
+-- fiscal-period guard basis. It replaces the raw transaction_date cast
+-- with bank_txn_entry_day(transaction_date, restaurant.timezone), looked
+-- up once per call, in four places: the closed-period guard, the RECLASS
+-- journal entry insert, the BANK journal entry insert, and the
+-- existing-entry UPDATE branch. It also heals entry_date on the
+-- existing-entry UPDATE branch, so a re-categorize call fixes a
+-- previously wrong-day entry instead of leaving it stale.
+--
+-- This migration is a CREATE OR REPLACE of the function body from
+-- supabase/migrations/20260819231210_add_bulk_categorize_bank_transactions.sql.
+-- Every other line of that function body is byte-identical.
+--
+-- See docs/superpowers/specs/2026-08-20-journal-entry-date-timezone-design.md.
+
+CREATE OR REPLACE FUNCTION public.bulk_categorize_bank_transactions(
+  p_transaction_ids uuid[],
+  p_category_id uuid,
+  p_restaurant_id uuid,
+  p_skip_rebuild boolean DEFAULT false
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+SET statement_timeout TO '120s'
+AS $function$
+DECLARE
+  v_category RECORD;
+  v_cash_account RECORD;
+  v_fiscal_period RECORD;
+  v_transaction RECORD;
+  v_is_reclassification boolean;
+  v_original_category_id uuid;
+  v_journal_entry_id uuid;
+  v_existing_journal_entry uuid;
+  v_reclass_reference_id uuid;
+  v_missing_id uuid;
+  v_categorized_count int := 0;
+  v_reclassified_count int := 0;
+  v_unchanged_count int := 0;
+  v_skipped jsonb := '[]'::jsonb;
+  v_any_change boolean := false;
+  v_timezone text;
+  v_entry_day date;
+BEGIN
+  -- Guard 1: membership.
+  IF NOT EXISTS (
+    SELECT 1 FROM user_restaurants
+    WHERE restaurant_id = p_restaurant_id
+      AND user_id = auth.uid()
+  ) THEN
+    RAISE EXCEPTION 'Unauthorized: user does not have access to this restaurant';
+  END IF;
+
+  -- Guard 2: category exists, belongs to this tenant, is active.
+  SELECT * INTO v_category
+  FROM chart_of_accounts
+  WHERE id = p_category_id
+    AND restaurant_id = p_restaurant_id
+    AND is_active = true;
+
+  IF v_category.id IS NULL THEN
+    RAISE EXCEPTION 'Category not found or inactive';
+  END IF;
+
+  -- Guard 3: the restaurant has a cash account (1000).
+  SELECT * INTO v_cash_account
+  FROM chart_of_accounts
+  WHERE restaurant_id = p_restaurant_id
+    AND account_code = '1000'
+  LIMIT 1;
+
+  IF v_cash_account.id IS NULL THEN
+    RAISE EXCEPTION 'Cash account (1000) not found';
+  END IF;
+
+  -- Guard 4: input bounds. No silent truncation above 500 ids.
+  -- Messages here use 'p_param must ...' wording, matching precedent in
+  -- supabase/migrations/20260804090300_bounded_categorization_sweep.sql:85
+  -- (guards 1-3 above use their own fixed wording, not this pattern).
+  -- supabase/tests/22_bulk_categorize_bank_transactions.sql checks them
+  -- with throws_like('%...%'), not an exact-text match.
+  IF p_transaction_ids IS NULL OR array_length(p_transaction_ids, 1) IS NULL THEN
+    RAISE EXCEPTION 'p_transaction_ids must not be empty';
+  END IF;
+
+  IF array_length(p_transaction_ids, 1) > 500 THEN
+    RAISE EXCEPTION 'p_transaction_ids must contain 500 ids or fewer, got %', array_length(p_transaction_ids, 1);
+  END IF;
+
+  -- One expression for the entry day; the guard below and both inserts use
+  -- it. Never derive the day a second way (PR #766 lesson).
+  SELECT timezone INTO v_timezone
+  FROM restaurants
+  WHERE id = p_restaurant_id;
+
+  -- Per-row loop. An id outside this tenant does not match the filter and
+  -- is reported below in skipped with reason not_found.
+  -- Explicit column list, not SELECT *: bank_transactions.raw_data is a
+  -- JSONB column holding the full Stripe/Plaid payload and this loop never
+  -- reads it. Fetching it for up to 500 rows per call would be a large,
+  -- needless amplification of the single-row categorize_bank_transaction
+  -- RPC's own SELECT * (which pays that cost for only one row).
+  FOR v_transaction IN
+    SELECT id, category_id, is_categorized, is_reconciled, transaction_date,
+           amount, description, stripe_transaction_id, is_transfer,
+           excluded_reason, is_split
+    FROM bank_transactions
+    WHERE id = ANY(p_transaction_ids)
+      AND restaurant_id = p_restaurant_id
+  LOOP
+    BEGIN
+      v_is_reclassification := false;
+      v_original_category_id := NULL;
+      v_journal_entry_id := NULL;
+      v_existing_journal_entry := NULL;
+
+      -- Skip a row that must never carry a P&L journal entry: a transfer,
+      -- a row marked excluded, or a split parent. A split parent keeps
+      -- category_id NULL even when is_categorized is true (its ledger
+      -- lives in bank_transaction_splits, one row per allocation) — left
+      -- unfiltered, this call would open the "else" branch below, insert
+      -- a single-category journal entry for it, and leave is_split and the
+      -- split rows untouched, so the UI and the ledger would disagree.
+      IF v_transaction.is_transfer OR v_transaction.excluded_reason IS NOT NULL THEN
+        v_skipped := v_skipped || jsonb_build_object('id', v_transaction.id, 'reason', 'excluded');
+        CONTINUE;
+      END IF;
+
+      IF v_transaction.is_split THEN
+        v_skipped := v_skipped || jsonb_build_object('id', v_transaction.id, 'reason', 'split');
+        CONTINUE;
+      END IF;
+
+      IF v_transaction.is_categorized AND v_transaction.category_id IS NOT NULL THEN
+        v_is_reclassification := true;
+        v_original_category_id := v_transaction.category_id;
+      END IF;
+
+      -- Short-circuit: category unchanged, no ledger movement.
+      IF v_is_reclassification AND v_original_category_id = p_category_id THEN
+        v_unchanged_count := v_unchanged_count + 1;
+        CONTINUE;
+      END IF;
+
+      -- Block initial categorization of a reconciled transaction.
+      IF v_transaction.is_reconciled AND NOT v_is_reclassification THEN
+        v_skipped := v_skipped || jsonb_build_object('id', v_transaction.id, 'reason', 'reconciled');
+        CONTINUE;
+      END IF;
+
+      v_entry_day := bank_txn_entry_day(v_transaction.transaction_date, v_timezone);
+
+      -- Skip a transaction dated inside a closed fiscal period.
+      SELECT * INTO v_fiscal_period
+      FROM fiscal_periods
+      WHERE restaurant_id = p_restaurant_id
+        AND v_entry_day >= period_start
+        AND v_entry_day <= period_end
+        AND is_closed = true
+      LIMIT 1;
+
+      IF v_fiscal_period.id IS NOT NULL THEN
+        v_skipped := v_skipped || jsonb_build_object('id', v_transaction.id, 'reason', 'closed_period');
+        CONTINUE;
+      END IF;
+
+      IF v_is_reclassification THEN
+        v_reclass_reference_id := gen_random_uuid();
+
+        INSERT INTO journal_entries (
+          restaurant_id, entry_date, entry_number, description,
+          reference_type, reference_id, total_debit, total_credit, created_by
+        ) VALUES (
+          p_restaurant_id,
+          v_entry_day,
+          'RECLASS-' || v_transaction.id::text || '-' || TO_CHAR(clock_timestamp(), 'YYYYMMDD-HH24MISS-US'),
+          'Reclassification: ' || v_transaction.description,
+          'reclassification', v_reclass_reference_id,
+          ABS(v_transaction.amount), ABS(v_transaction.amount), auth.uid()
+        ) RETURNING id INTO v_journal_entry_id;
+
+        IF v_transaction.amount < 0 THEN
+          INSERT INTO journal_entry_lines (journal_entry_id, account_id, debit_amount, credit_amount, description)
+          VALUES
+            (v_journal_entry_id, p_category_id, ABS(v_transaction.amount), 0, 'Reclassify to ' || v_category.account_name),
+            (v_journal_entry_id, v_original_category_id, 0, ABS(v_transaction.amount), 'Reclassify from previous category');
+        ELSE
+          INSERT INTO journal_entry_lines (journal_entry_id, account_id, debit_amount, credit_amount, description)
+          VALUES
+            (v_journal_entry_id, v_original_category_id, ABS(v_transaction.amount), 0, 'Reclassify from previous category'),
+            (v_journal_entry_id, p_category_id, 0, ABS(v_transaction.amount), 'Reclassify to ' || v_category.account_name);
+        END IF;
+
+        INSERT INTO transaction_reclassifications (
+          restaurant_id, bank_transaction_id, original_category_id,
+          new_category_id, reclass_journal_entry_id, reason, created_by
+        ) VALUES (
+          p_restaurant_id, v_transaction.id, v_original_category_id,
+          p_category_id, v_journal_entry_id, NULL, auth.uid()
+        );
+
+        v_reclassified_count := v_reclassified_count + 1;
+      ELSE
+        SELECT id INTO v_existing_journal_entry
+        FROM journal_entries
+        WHERE reference_type = 'bank_transaction'
+          AND reference_id = v_transaction.id
+          AND restaurant_id = p_restaurant_id
+        LIMIT 1;
+
+        IF v_existing_journal_entry IS NOT NULL THEN
+          v_journal_entry_id := v_existing_journal_entry;
+          DELETE FROM journal_entry_lines WHERE journal_entry_id = v_existing_journal_entry;
+          UPDATE journal_entries
+          SET entry_date = v_entry_day,
+              description = v_transaction.description,
+              total_debit = ABS(v_transaction.amount),
+              total_credit = ABS(v_transaction.amount),
+              updated_at = now()
+          WHERE id = v_existing_journal_entry;
+        ELSE
+          INSERT INTO journal_entries (
+            restaurant_id, entry_date, entry_number, description,
+            reference_type, reference_id, total_debit, total_credit, created_by
+          ) VALUES (
+            p_restaurant_id,
+            v_entry_day,
+            'BANK-' || COALESCE(v_transaction.stripe_transaction_id, v_transaction.id::text) || '-' || TO_CHAR(clock_timestamp(), 'YYYYMMDD-HH24MISS-US'),
+            v_transaction.description,
+            'bank_transaction', v_transaction.id,
+            ABS(v_transaction.amount), ABS(v_transaction.amount), auth.uid()
+          ) RETURNING id INTO v_journal_entry_id;
+        END IF;
+
+        IF v_transaction.amount < 0 THEN
+          INSERT INTO journal_entry_lines (journal_entry_id, account_id, debit_amount, credit_amount, description)
+          VALUES
+            (v_journal_entry_id, p_category_id, ABS(v_transaction.amount), 0, v_category.account_name),
+            (v_journal_entry_id, v_cash_account.id, 0, ABS(v_transaction.amount), 'Cash payment');
+        ELSE
+          INSERT INTO journal_entry_lines (journal_entry_id, account_id, debit_amount, credit_amount, description)
+          VALUES
+            (v_journal_entry_id, v_cash_account.id, ABS(v_transaction.amount), 0, 'Cash received'),
+            (v_journal_entry_id, p_category_id, 0, ABS(v_transaction.amount), v_category.account_name);
+        END IF;
+
+        v_categorized_count := v_categorized_count + 1;
+      END IF;
+
+      -- Bulk-only behavior kept from the current hook: clear the AI
+      -- suggestion. The single RPC does not; this is deliberate.
+      UPDATE bank_transactions
+      SET category_id = p_category_id,
+          is_categorized = true,
+          suggested_category_id = NULL,
+          updated_at = now()
+      WHERE id = v_transaction.id;
+
+      v_any_change := true;
+    EXCEPTION WHEN OTHERS THEN
+      -- One bad row must not abort the batch.
+      v_skipped := v_skipped || jsonb_build_object('id', v_transaction.id, 'reason', SQLERRM);
+    END;
+  END LOOP;
+
+  -- Ids in the input that do not resolve to a row in this tenant.
+  FOR v_missing_id IN
+    SELECT unnest(p_transaction_ids)
+    EXCEPT
+    SELECT id FROM bank_transactions
+    WHERE id = ANY(p_transaction_ids)
+      AND restaurant_id = p_restaurant_id
+  LOOP
+    v_skipped := v_skipped || jsonb_build_object('id', v_missing_id, 'reason', 'not_found');
+  END LOOP;
+
+  IF v_any_change AND NOT p_skip_rebuild THEN
+    PERFORM rebuild_account_balances(p_restaurant_id);
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'categorized_count', v_categorized_count,
+    'reclassified_count', v_reclassified_count,
+    'unchanged_count', v_unchanged_count,
+    'skipped', v_skipped
+  );
+END;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.bulk_categorize_bank_transactions(uuid[], uuid, uuid, boolean) FROM PUBLIC;
+REVOKE EXECUTE ON FUNCTION public.bulk_categorize_bank_transactions(uuid[], uuid, uuid, boolean) FROM anon;
+GRANT EXECUTE ON FUNCTION public.bulk_categorize_bank_transactions(uuid[], uuid, uuid, boolean) TO authenticated;

--- a/supabase/migrations/20260820210300_sweep_local_entry_day.sql
+++ b/supabase/migrations/20260820210300_sweep_local_entry_day.sql
@@ -1,0 +1,369 @@
+-- apply_rules_to_bank_transactions_internal writes the restaurant-local entry day
+--
+-- Change: this migration changes only the entry-day derivation and the
+-- fiscal-period guard basis. It replaces the raw transaction_date cast
+-- with bank_txn_entry_day(transaction_date, restaurant.timezone), looked
+-- up once per call, in three places: the closed-period guard, the
+-- new-entry journal entry insert, and the existing-entry UPDATE branch.
+-- It also heals entry_date on the existing-entry UPDATE branch, so a
+-- re-sweep call fixes a previously wrong-day entry instead of leaving it
+-- stale.
+--
+-- This migration is a CREATE OR REPLACE of the function body from
+-- supabase/migrations/20260804090300_bounded_categorization_sweep.sql.
+-- Every other line of that function body is byte-identical.
+--
+-- See docs/superpowers/specs/2026-08-20-journal-entry-date-timezone-design.md.
+
+CREATE OR REPLACE FUNCTION apply_rules_to_bank_transactions_internal(
+  p_restaurant_id UUID,
+  p_batch_limit   INTEGER DEFAULT 100,
+  p_skip_rebuild  BOOLEAN DEFAULT FALSE
+)
+RETURNS TABLE (
+  applied_count INTEGER,
+  total_count   INTEGER
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  v_transaction         RECORD;
+  v_applied_count       INTEGER := 0;
+  v_total_count         INTEGER := 0;
+  v_splits_with_amounts JSONB;
+  v_split               JSONB;
+  v_splits_array        JSONB[] := ARRAY[]::JSONB[];
+  v_cash_account_id     UUID;
+  v_category            RECORD;
+  v_fiscal_period_id    UUID;
+  v_journal_entry_id    UUID;
+  v_existing_journal_entry UUID;
+  v_total_split_amount  NUMERIC;
+  v_split_rec           RECORD;
+  v_entry_prefix        TEXT;
+  v_entry_description   TEXT;
+  v_rules_changed_at    TIMESTAMPTZ;
+  v_batch_ids           UUID[];
+  v_timezone            text;
+  v_entry_day           date;
+BEGIN
+  -- Guard: reject NULL or non-positive batch limits (LIMIT NULL removes cap; negative aborts loops).
+  IF p_batch_limit IS NULL OR p_batch_limit < 1 THEN
+    RAISE EXCEPTION 'p_batch_limit must be a positive integer, got %', p_batch_limit;
+  END IF;
+
+  -- No permission check: this function is for background/service-role callers.
+  -- The public wrapper apply_rules_to_bank_transactions enforces owner/manager membership.
+
+  SELECT id INTO v_cash_account_id
+  FROM chart_of_accounts
+  WHERE restaurant_id = p_restaurant_id
+    AND account_code = '1000'
+  LIMIT 1;
+
+  IF v_cash_account_id IS NULL THEN
+    RAISE EXCEPTION 'Cash account (1000) not found for restaurant %', p_restaurant_id;
+  END IF;
+
+  -- Rule watermark. Single definition, shared with the POS sweep and with
+  -- drain_categorization_backlog's retirement guard -- see the function's
+  -- comment for why it must not be re-derived inline.
+  v_rules_changed_at := public.categorization_rules_watermark(p_restaurant_id, 'bank_transactions');
+
+  -- No rule can match: equivalent to running to completion with zero matches,
+  -- minus all the work. Deliberately writes nothing.
+  IF v_rules_changed_at IS NULL THEN
+    RETURN QUERY SELECT 0, 0;
+    RETURN;
+  END IF;
+
+  -- One expression for the entry day; the guard below and the insert use
+  -- it. Never derive the day a second way (PR #766 lesson).
+  SELECT timezone INTO v_timezone
+  FROM restaurants
+  WHERE id = p_restaurant_id;
+
+  -- Statement 1: select and stamp the batch BEFORE any matching happens.
+  -- MATERIALIZED is required -- PG12+ inlines single-reference CTEs, which
+  -- would dissolve the LIMIT back into the outer query and reintroduce the
+  -- bug.
+  --
+  -- This UPDATE fires reset_bank_transactions_rules_evaluated_at, but that
+  -- trigger only resets when description/amount/supplier_id change, and this
+  -- statement touches none of them -- so the stamp it just wrote survives.
+  --
+  -- FOR UPDATE SKIP LOCKED makes the batch a claim rather than a guess, for
+  -- the same reason as the POS sweep above. It matters more here: the apply
+  -- path INSERTs into bank_transaction_splits, which has no uniqueness
+  -- constraint, so two sweeps claiming the same row would duplicate splits.
+  WITH batch AS MATERIALIZED (
+    SELECT bt.id
+    FROM bank_transactions bt
+    WHERE bt.restaurant_id = p_restaurant_id
+      AND (bt.is_categorized = false OR bt.category_id IS NULL)
+      AND bt.is_split = false
+      AND bt.excluded_reason IS NULL
+      AND bt.rules_evaluated_at < v_rules_changed_at
+    ORDER BY bt.transaction_date DESC
+    LIMIT p_batch_limit
+    FOR UPDATE SKIP LOCKED
+  ), stamped AS (
+    UPDATE bank_transactions u
+       SET rules_evaluated_at = v_rules_changed_at
+      FROM batch b
+     WHERE u.id = b.id
+    RETURNING u.id
+  )
+  SELECT COALESCE(array_agg(id), '{}'::uuid[]) INTO v_batch_ids FROM stamped;
+
+  -- Candidates CLAIMED, not matched -- see the note in
+  -- apply_rules_to_pos_sales_internal. Callers loop on this, not applied_count.
+  v_total_count := COALESCE(array_length(v_batch_ids, 1), 0);
+
+  -- ORDER BY restored: id = ANY(uuid[]) does not preserve the batch ordering.
+  FOR v_transaction IN
+    SELECT
+      bt.id,
+      bt.amount,
+      bt.description,
+      bt.supplier_id,
+      bt.transaction_date,
+      bt.stripe_transaction_id,
+      matched.rule_id,
+      matched.rule_name,
+      matched.category_id AS rule_category_id,
+      matched.is_split_rule,
+      matched.split_categories,
+      matched.supplier_id AS rule_supplier_id   -- NEW: rule's supplier for assign-not-filter
+    FROM bank_transactions bt
+    CROSS JOIN LATERAL find_matching_rules_for_bank_transaction(
+      p_restaurant_id,
+      jsonb_build_object(
+        'description', bt.description,
+        'amount',      bt.amount,
+        'supplier_id', bt.supplier_id
+      )
+    ) matched
+    WHERE bt.id = ANY(v_batch_ids)
+      AND matched.rule_id IS NOT NULL
+    ORDER BY bt.transaction_date DESC
+  LOOP
+    BEGIN
+      v_entry_day := bank_txn_entry_day(v_transaction.transaction_date, v_timezone);
+
+      SELECT id INTO v_fiscal_period_id
+      FROM fiscal_periods
+      WHERE restaurant_id = p_restaurant_id
+        AND v_entry_day >= period_start
+        AND v_entry_day <= period_end
+        AND is_closed = true
+      LIMIT 1;
+
+      IF v_fiscal_period_id IS NOT NULL THEN
+        RAISE EXCEPTION 'Transaction % in closed fiscal period', v_transaction.id;
+      END IF;
+
+      IF v_transaction.is_split_rule AND v_transaction.split_categories IS NOT NULL THEN
+        -- Split path
+        v_splits_array := ARRAY[]::JSONB[];
+        v_total_split_amount := 0;
+
+        FOR v_split IN SELECT * FROM jsonb_array_elements(v_transaction.split_categories)
+        LOOP
+          v_splits_array := v_splits_array || jsonb_build_object(
+            'category_id', v_split->>'category_id',
+            'amount', CASE
+              WHEN v_split->>'percentage' IS NOT NULL
+              THEN ROUND((ABS(v_transaction.amount) * (v_split->>'percentage')::NUMERIC / 100.0), 2)
+              ELSE (v_split->>'amount')::NUMERIC
+            END,
+            'description', COALESCE(v_split->>'description', '')
+          );
+        END LOOP;
+
+        v_splits_with_amounts := to_jsonb(v_splits_array);
+
+        SELECT COALESCE(SUM((elem->>'amount')::NUMERIC), 0)
+        INTO v_total_split_amount
+        FROM jsonb_array_elements(v_splits_with_amounts) AS elem;
+
+        IF ABS(ABS(v_transaction.amount) - v_total_split_amount) > 0.01 THEN
+          RAISE EXCEPTION 'Split amounts (%) do not match transaction amount (%) for txn %',
+            v_total_split_amount, ABS(v_transaction.amount), v_transaction.id;
+        END IF;
+
+        v_entry_prefix := 'SPLIT';
+        v_entry_description := 'Split transaction: ' || v_transaction.description;
+      ELSE
+        -- Non-split path: validate category
+        SELECT * INTO v_category
+        FROM chart_of_accounts
+        WHERE id = v_transaction.rule_category_id
+          AND restaurant_id = p_restaurant_id
+          AND is_active = true;
+
+        IF v_category.id IS NULL THEN
+          RAISE EXCEPTION 'Category not found or inactive for txn %', v_transaction.id;
+        END IF;
+
+        v_entry_prefix := 'BANK';
+        v_entry_description := 'Auto-categorized by rule: ' || v_transaction.rule_name;
+      END IF;
+
+      -- Upsert journal entry (shared by both paths).
+      -- created_by uses auth.uid() which returns NULL in service-role/cron context —
+      -- journal_entries.created_by is NULLABLE so NULL inserts are valid.
+      SELECT id INTO v_existing_journal_entry
+      FROM journal_entries
+      WHERE reference_type = 'bank_transaction'
+        AND reference_id = v_transaction.id
+        AND restaurant_id = p_restaurant_id
+      LIMIT 1;
+
+      IF v_existing_journal_entry IS NOT NULL THEN
+        v_journal_entry_id := v_existing_journal_entry;
+        DELETE FROM journal_entry_lines WHERE journal_entry_id = v_existing_journal_entry;
+        UPDATE journal_entries
+        SET
+          entry_date   = v_entry_day,
+          entry_number = v_entry_prefix || '-' || COALESCE(v_transaction.stripe_transaction_id, v_transaction.id::text) || '-' || TO_CHAR(now(), 'YYYYMMDD-HH24MISS-US'),
+          description  = v_entry_description,
+          total_debit  = ABS(v_transaction.amount),
+          total_credit = ABS(v_transaction.amount),
+          updated_at   = now()
+        WHERE id = v_existing_journal_entry;
+      ELSE
+        INSERT INTO journal_entries (
+          restaurant_id, entry_date, entry_number, description,
+          reference_type, reference_id, total_debit, total_credit, created_by
+        ) VALUES (
+          p_restaurant_id,
+          v_entry_day,
+          v_entry_prefix || '-' || COALESCE(v_transaction.stripe_transaction_id, v_transaction.id::text) || '-' || TO_CHAR(now(), 'YYYYMMDD-HH24MISS-US'),
+          v_entry_description,
+          'bank_transaction',
+          v_transaction.id,
+          ABS(v_transaction.amount),
+          ABS(v_transaction.amount),
+          auth.uid()   -- NULL in service-role/cron context; column is NULLABLE
+        ) RETURNING id INTO v_journal_entry_id;
+      END IF;
+
+      -- Create journal lines (path-specific)
+      IF v_transaction.is_split_rule AND v_transaction.split_categories IS NOT NULL THEN
+        FOR v_split_rec IN
+          SELECT * FROM jsonb_to_recordset(v_splits_with_amounts)
+            AS x(category_id uuid, amount numeric, description text)
+        LOOP
+          SELECT * INTO v_category
+          FROM chart_of_accounts
+          WHERE id = v_split_rec.category_id
+            AND restaurant_id = p_restaurant_id
+            AND is_active = true;
+
+          IF v_category.id IS NULL THEN
+            RAISE EXCEPTION 'Category not found or inactive: %', v_split_rec.category_id;
+          END IF;
+
+          INSERT INTO bank_transaction_splits (
+            transaction_id, category_id, amount, description
+          ) VALUES (
+            v_transaction.id, v_split_rec.category_id,
+            v_split_rec.amount, v_split_rec.description
+          );
+
+          IF v_transaction.amount < 0 THEN
+            INSERT INTO journal_entry_lines (journal_entry_id, account_id, debit_amount, credit_amount, description)
+            VALUES (v_journal_entry_id, v_split_rec.category_id, v_split_rec.amount, 0,
+                    COALESCE(v_split_rec.description, v_category.account_name));
+          ELSE
+            INSERT INTO journal_entry_lines (journal_entry_id, account_id, debit_amount, credit_amount, description)
+            VALUES (v_journal_entry_id, v_split_rec.category_id, 0, v_split_rec.amount,
+                    COALESCE(v_split_rec.description, v_category.account_name));
+          END IF;
+        END LOOP;
+
+        -- Offsetting cash line for split
+        IF v_transaction.amount < 0 THEN
+          INSERT INTO journal_entry_lines (journal_entry_id, account_id, debit_amount, credit_amount, description)
+          VALUES (v_journal_entry_id, v_cash_account_id, 0, ABS(v_transaction.amount), 'Cash payment (split)');
+        ELSE
+          INSERT INTO journal_entry_lines (journal_entry_id, account_id, debit_amount, credit_amount, description)
+          VALUES (v_journal_entry_id, v_cash_account_id, ABS(v_transaction.amount), 0, 'Cash received (split)');
+        END IF;
+
+        UPDATE bank_transactions
+        SET
+          is_split       = true,
+          is_categorized = true,
+          category_id    = NULL,
+          -- Supplier assignment on split path: same assign-not-filter semantics as non-split.
+          -- Transaction's own supplier wins; rule supplier assigned when transaction has none.
+          supplier_id    = COALESCE(v_transaction.supplier_id, v_transaction.rule_supplier_id, supplier_id),
+          updated_at     = now()
+        WHERE id = v_transaction.id;
+      ELSE
+        -- Non-split journal lines
+        IF v_transaction.amount < 0 THEN
+          INSERT INTO journal_entry_lines (journal_entry_id, account_id, debit_amount, credit_amount, description)
+          VALUES
+            (v_journal_entry_id, v_transaction.rule_category_id, ABS(v_transaction.amount), 0, v_category.account_name),
+            (v_journal_entry_id, v_cash_account_id, 0, ABS(v_transaction.amount), 'Cash payment');
+        ELSE
+          INSERT INTO journal_entry_lines (journal_entry_id, account_id, debit_amount, credit_amount, description)
+          VALUES
+            (v_journal_entry_id, v_cash_account_id, ABS(v_transaction.amount), 0, 'Cash received'),
+            (v_journal_entry_id, v_transaction.rule_category_id, 0, ABS(v_transaction.amount), v_category.account_name);
+        END IF;
+
+        UPDATE bank_transactions
+        SET
+          category_id    = v_transaction.rule_category_id,
+          is_categorized = true,
+          notes          = 'Auto-categorized by rule: ' || v_transaction.rule_name,
+          -- Supplier assignment (assign-not-filter semantics from §1):
+          --   1. Transaction's own supplier wins if already set.
+          --   2. Rule's supplier is assigned when the transaction has none.
+          --   3. Database value preserved as last resort (no clobber).
+          supplier_id    = COALESCE(v_transaction.supplier_id, v_transaction.rule_supplier_id, supplier_id),
+          updated_at     = now()
+        WHERE id = v_transaction.id;
+      END IF;
+
+      v_applied_count := v_applied_count + 1;
+      UPDATE categorization_rules
+      SET apply_count = apply_count + 1, last_applied_at = now()
+      WHERE id = v_transaction.rule_id;
+    EXCEPTION WHEN OTHERS THEN
+      RAISE NOTICE 'Error categorizing transaction %: %', v_transaction.id, SQLERRM;
+      -- A rule matched, but the apply raised (closed fiscal period, inactive
+      -- category, split-amount mismatch, etc.). Statement 1 already stamped
+      -- this row at the current watermark; leaving that stamp in place would
+      -- permanently exclude it from every future sweep even after the
+      -- blocking condition clears (period reopened, category reactivated).
+      -- Reset it so the row stays a candidate for retry.
+      UPDATE bank_transactions SET rules_evaluated_at = '-infinity' WHERE id = v_transaction.id;
+    END;
+  END LOOP;
+
+  IF v_applied_count > 0 AND NOT p_skip_rebuild THEN
+    PERFORM rebuild_account_balances(p_restaurant_id);
+  END IF;
+
+  RETURN QUERY SELECT v_applied_count, v_total_count;
+END;
+$$;
+
+COMMENT ON FUNCTION apply_rules_to_bank_transactions_internal(uuid, integer, boolean) IS
+  'Background/service-role rule sweep for bank_transactions. Evaluates at most '
+  'p_batch_limit rows per call, stamping rules_evaluated_at so unmatched rows '
+  'are not re-evaluated until a rule changes. Returns (applied_count, '
+  'total_count) where total_count is the number of candidates CLAIMED this '
+  'call, not the number matched: loop on total_count > 0, not applied_count > 0.';
+
+REVOKE EXECUTE ON FUNCTION apply_rules_to_bank_transactions_internal(uuid, integer, boolean)
+  FROM PUBLIC, anon, authenticated;
+GRANT  EXECUTE ON FUNCTION apply_rules_to_bank_transactions_internal(uuid, integer, boolean)
+  TO service_role;

--- a/supabase/migrations/20260820210400_backfill_local_entry_day.sql
+++ b/supabase/migrations/20260820210400_backfill_local_entry_day.sql
@@ -1,16 +1,18 @@
--- Bulk categorize must create journal entries — backfill.
+-- backfill_bank_transaction_journal_entries writes the restaurant-local entry day
 --
--- The bug fixed in 20260819231210_add_bulk_categorize_bank_transactions.sql
--- stops new bulk categorizations from skipping the ledger. This migration
--- repairs the 2,328 rows the old bulk hook already left with no journal
--- entry (6 restaurants, verified against production on 2026-08-19).
+-- Change: this migration changes only the entry-day derivation and the
+-- fiscal-period guard basis. It replaces the raw transaction_date cast
+-- with bank_txn_entry_day(transaction_date, restaurant.timezone) in two
+-- places: the closed-period guard on tmp_backfill_candidates, and the
+-- entry_date column of the journal_entries insert. It adds a JOIN to
+-- restaurants so the candidate query carries the restaurant's timezone
+-- (r.timezone) through to both call sites.
 --
--- The function stays in the database (kept, rerunnable) so a later repair
--- (for example after the trigger-producer and pending-outflow-producer
--- fixes land) is one call. See
--- docs/superpowers/specs/2026-08-19-bulk-categorize-journal-entries-design.md
--- section 7 for the candidate predicate, insert shape, and entry-number
--- format this pins.
+-- This migration is a CREATE OR REPLACE of the function body from
+-- supabase/migrations/20260819232450_backfill_bank_transaction_journal_entries.sql.
+-- Every other line of that function body is byte-identical.
+--
+-- See docs/superpowers/specs/2026-08-20-journal-entry-date-timezone-design.md.
 
 CREATE OR REPLACE FUNCTION public.backfill_bank_transaction_journal_entries()
 RETURNS jsonb

--- a/supabase/migrations/20260820210400_backfill_local_entry_day.sql
+++ b/supabase/migrations/20260820210400_backfill_local_entry_day.sql
@@ -1,0 +1,194 @@
+-- Bulk categorize must create journal entries — backfill.
+--
+-- The bug fixed in 20260819231210_add_bulk_categorize_bank_transactions.sql
+-- stops new bulk categorizations from skipping the ledger. This migration
+-- repairs the 2,328 rows the old bulk hook already left with no journal
+-- entry (6 restaurants, verified against production on 2026-08-19).
+--
+-- The function stays in the database (kept, rerunnable) so a later repair
+-- (for example after the trigger-producer and pending-outflow-producer
+-- fixes land) is one call. See
+-- docs/superpowers/specs/2026-08-19-bulk-categorize-journal-entries-design.md
+-- section 7 for the candidate predicate, insert shape, and entry-number
+-- format this pins.
+
+CREATE OR REPLACE FUNCTION public.backfill_bank_transaction_journal_entries()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+DECLARE
+  v_entries_created int := 0;
+  v_lines_created int := 0;
+  v_restaurants_rebuilt int := 0;
+  v_restaurant_id uuid;
+BEGIN
+  -- A rerun inside the same session (for example two calls in one pgTAP
+  -- transaction, which never commits mid-test) must not collide with the
+  -- previous call's temp tables. ON COMMIT DROP only fires at COMMIT.
+  DROP TABLE IF EXISTS tmp_backfill_candidates;
+  DROP TABLE IF EXISTS tmp_backfill_created_entries;
+
+  -- Candidate predicate: categorized, not a transfer, not reconciled, not
+  -- marked excluded, no existing journal entry for this bank_transaction,
+  -- not inside a closed fiscal period, and the restaurant has a cash
+  -- account 1000. The reconciled guard matches the bulk RPC: a reconciled
+  -- row is settled and a backfill must not change its ledger. Production
+  -- has 0 reconciled candidates (verified 2026-08-19), so this guard
+  -- protects only a later rerun. The
+  -- LEFT JOIN LATERAL mirrors the single RPC's cash-account LIMIT 1 so two
+  -- accounts coded 1000 on one restaurant cannot fan out a row. A split
+  -- parent needs no explicit filter here: category_id IS NOT NULL below
+  -- already excludes it, because bank_transactions never carries both
+  -- is_split = true and a non-null category_id (confirmed against
+  -- production: 0 rows). The excluded_reason filter guards a case
+  -- production does not currently have (0 of the 2,328 rows this backfill
+  -- targets carry it) but this function stays in the database for a later
+  -- rerun, so a future excluded+categorized row must not gain an entry
+  -- either (same finding as the bulk RPC's guard, codex review on this PR).
+  CREATE TEMP TABLE tmp_backfill_candidates ON COMMIT DROP AS
+  SELECT
+    bt.id AS bank_transaction_id,
+    bt.restaurant_id,
+    bt.category_id,
+    bt.amount,
+    bt.description,
+    bt.stripe_transaction_id,
+    bt.transaction_date,
+    r.timezone,
+    cat.account_name AS category_account_name,
+    cash.id AS cash_account_id,
+    row_number() OVER (ORDER BY bt.id) AS rn
+  FROM bank_transactions bt
+  JOIN chart_of_accounts cat
+    ON cat.id = bt.category_id
+   AND cat.restaurant_id = bt.restaurant_id
+   AND cat.is_active = true
+  JOIN restaurants r
+    ON r.id = bt.restaurant_id
+  LEFT JOIN LATERAL (
+    SELECT coa.id
+    FROM chart_of_accounts coa
+    WHERE coa.restaurant_id = bt.restaurant_id
+      AND coa.account_code = '1000'
+    LIMIT 1
+  ) cash ON true
+  WHERE bt.is_categorized = true
+    AND bt.category_id IS NOT NULL
+    AND bt.is_transfer = false
+    AND bt.is_reconciled = false
+    AND bt.excluded_reason IS NULL
+    AND cash.id IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM journal_entries je
+      WHERE je.reference_type = 'bank_transaction'
+        AND je.reference_id = bt.id
+        AND je.restaurant_id = bt.restaurant_id
+    )
+    -- Compare on the same restaurant-local day the entry insert below uses
+    -- for entry_date, from bank_txn_entry_day. A raw timestamptz >= date
+    -- comparison casts at the session TimeZone and lets a transaction late
+    -- on the period's last local day write an entry_date inside the
+    -- closed period.
+    AND NOT EXISTS (
+      SELECT 1 FROM fiscal_periods fp
+      WHERE fp.restaurant_id = bt.restaurant_id
+        AND bank_txn_entry_day(bt.transaction_date, r.timezone) >= fp.period_start
+        AND bank_txn_entry_day(bt.transaction_date, r.timezone) <= fp.period_end
+        AND fp.is_closed = true
+    );
+
+  -- Statement 1: the CTE insert into journal_entries. ON CONFLICT DO
+  -- NOTHING keeps a rerun idempotent (constraint unique_journal_entry_reference
+  -- on reference_type, reference_id); RETURNING captures only the rows this
+  -- call actually created, so a partial prior run does not double-count.
+  -- entry_date comes from bank_txn_entry_day, the single convention
+  -- expression: a date-anchored transaction_date keeps its UTC day, a real
+  -- instant takes the restaurant-local day.
+  -- The row_number() suffix on entry_number guarantees uniqueness inside
+  -- this one statement even when clock_timestamp() repeats for two rows.
+  CREATE TEMP TABLE tmp_backfill_created_entries ON COMMIT DROP AS
+  WITH ins AS (
+    INSERT INTO journal_entries (
+      restaurant_id, entry_date, entry_number, description,
+      reference_type, reference_id, total_debit, total_credit, created_by
+    )
+    SELECT
+      c.restaurant_id,
+      bank_txn_entry_day(c.transaction_date, c.timezone),
+      'BANK-' || COALESCE(c.stripe_transaction_id, c.bank_transaction_id::text) || '-' ||
+        TO_CHAR(clock_timestamp(), 'YYYYMMDD-HH24MISS-US') || '-' || c.rn::text,
+      c.description,
+      'bank_transaction', c.bank_transaction_id,
+      ABS(c.amount), ABS(c.amount), NULL
+    FROM tmp_backfill_candidates c
+    ON CONFLICT ON CONSTRAINT unique_journal_entry_reference DO NOTHING
+    RETURNING id, reference_id, restaurant_id
+  )
+  SELECT id, reference_id, restaurant_id FROM ins;
+
+  GET DIAGNOSTICS v_entries_created = ROW_COUNT;
+
+  -- Statement 2: two lines per entry actually created above, same sign
+  -- convention as the single RPC (negative amount debits the category and
+  -- credits cash; positive amount debits cash and credits the category).
+  -- Joining only against tmp_backfill_created_entries means a rerun, which
+  -- finds that table empty, inserts no lines twice.
+  INSERT INTO journal_entry_lines (journal_entry_id, account_id, debit_amount, credit_amount, description)
+  SELECT
+    e.id,
+    CASE WHEN c.amount < 0 THEN c.category_id ELSE c.cash_account_id END,
+    ABS(c.amount),
+    0,
+    CASE WHEN c.amount < 0 THEN c.category_account_name ELSE 'Cash received' END
+  FROM tmp_backfill_created_entries e
+  JOIN tmp_backfill_candidates c ON c.bank_transaction_id = e.reference_id
+  UNION ALL
+  SELECT
+    e.id,
+    CASE WHEN c.amount < 0 THEN c.cash_account_id ELSE c.category_id END,
+    0,
+    ABS(c.amount),
+    CASE WHEN c.amount < 0 THEN 'Cash payment' ELSE c.category_account_name END
+  FROM tmp_backfill_created_entries e
+  JOIN tmp_backfill_candidates c ON c.bank_transaction_id = e.reference_id;
+
+  GET DIAGNOSTICS v_lines_created = ROW_COUNT;
+
+  FOR v_restaurant_id IN
+    SELECT DISTINCT restaurant_id FROM tmp_backfill_created_entries
+  LOOP
+    PERFORM rebuild_account_balances(v_restaurant_id);
+    v_restaurants_rebuilt := v_restaurants_rebuilt + 1;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'entries_created', v_entries_created,
+    'lines_created', v_lines_created,
+    'restaurants_rebuilt', v_restaurants_rebuilt
+  );
+END;
+$function$;
+
+-- Maintenance function, not an API. The revoke from PUBLIC also strips
+-- service_role, so the explicit grant below is required for the reuse
+-- story (a later repair calls this again). Precedents that pair the
+-- revoke with the grant: 20260804090300_bounded_categorization_sweep.sql
+-- and 20260721150000_revel_sold_at_timezone_backfill.sql.
+REVOKE EXECUTE ON FUNCTION public.backfill_bank_transaction_journal_entries() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.backfill_bank_transaction_journal_entries() TO service_role;
+
+-- Run the backfill once, now. Local db reset runs this against an empty
+-- database — the function returns zeros and this is a no-op there.
+SET statement_timeout = 0;
+
+DO $$
+DECLARE
+  v_result jsonb;
+BEGIN
+  v_result := public.backfill_bank_transaction_journal_entries();
+  RAISE NOTICE 'backfill_bank_transaction_journal_entries: %', v_result;
+END $$;
+
+RESET statement_timeout;

--- a/supabase/migrations/20260820210500_redate_bank_journal_entries.sql
+++ b/supabase/migrations/20260820210500_redate_bank_journal_entries.sql
@@ -9,9 +9,16 @@
 --
 -- Production expectation (measured 2026-08-20, read-only): 179 bank-entry
 -- rows and 2 reclassification-entry rows move; 0 rows are skipped for a
--- closed period. These counts drift with the sync cron between the
--- measurement and the deploy — the two UPDATE statements below compute
--- their own row set at run time, so a drifted count is not a bug.
+-- closed period (production holds 0 closed fiscal_periods rows). These
+-- counts drift with the sync cron between the measurement and the deploy
+-- — the two UPDATE statements below compute their own row set at run
+-- time, so a drifted count is not a bug.
+--
+-- The closed-period guard is symmetric: a row does not move when its NEW
+-- day falls inside a closed period, and it does not move when its OLD
+-- entry_date sits inside one. A move out of a closed period changes that
+-- period's historical totals just as a move into one does (PR #772
+-- review, codex P2).
 --
 -- The two UPDATE statements are byte-identical to the ones proven in
 -- supabase/tests/67_redate_bank_journal_entries.sql. Keep them in sync.
@@ -44,9 +51,12 @@ BEGIN
     AND NOT EXISTS (
       SELECT 1 FROM fiscal_periods fp
       WHERE fp.restaurant_id = je.restaurant_id
-        AND bank_txn_entry_day(bt.transaction_date, r.timezone) >= fp.period_start
-        AND bank_txn_entry_day(bt.transaction_date, r.timezone) <= fp.period_end
         AND fp.is_closed = true
+        AND (
+          bank_txn_entry_day(bt.transaction_date, r.timezone)
+            BETWEEN fp.period_start AND fp.period_end
+          OR je.entry_date BETWEEN fp.period_start AND fp.period_end
+        )
     );
 
   GET DIAGNOSTICS v_bank_entries_moved = ROW_COUNT;
@@ -66,9 +76,12 @@ BEGIN
     AND NOT EXISTS (
       SELECT 1 FROM fiscal_periods fp
       WHERE fp.restaurant_id = je.restaurant_id
-        AND bank_txn_entry_day(bt.transaction_date, r.timezone) >= fp.period_start
-        AND bank_txn_entry_day(bt.transaction_date, r.timezone) <= fp.period_end
         AND fp.is_closed = true
+        AND (
+          bank_txn_entry_day(bt.transaction_date, r.timezone)
+            BETWEEN fp.period_start AND fp.period_end
+          OR je.entry_date BETWEEN fp.period_start AND fp.period_end
+        )
     );
 
   GET DIAGNOSTICS v_reclass_entries_moved = ROW_COUNT;

--- a/supabase/migrations/20260820210500_redate_bank_journal_entries.sql
+++ b/supabase/migrations/20260820210500_redate_bank_journal_entries.sql
@@ -1,0 +1,77 @@
+-- One-time re-date of existing bank journal entries to the restaurant-local
+-- day.
+--
+-- Tasks 1-5 in this series make new journal entries use
+-- bank_txn_entry_day(transaction_date, timezone): a date-anchored
+-- transaction_date (00:00:00 or 12:00:00 UTC) keeps its UTC day; a real
+-- instant takes the restaurant-local day. This migration moves the entries
+-- that already exist so they follow the same rule.
+--
+-- Production expectation (measured 2026-08-20, read-only): 179 bank-entry
+-- rows and 2 reclassification-entry rows move; 0 rows are skipped for a
+-- closed period. These counts drift with the sync cron between the
+-- measurement and the deploy — the two UPDATE statements below compute
+-- their own row set at run time, so a drifted count is not a bug.
+--
+-- The two UPDATE statements are byte-identical to the ones proven in
+-- supabase/tests/67_redate_bank_journal_entries.sql. Keep them in sync.
+--
+-- No call to rebuild_account_balances(): that function walks forward from
+-- a restaurant's earliest entry and stops at CURRENT_DATE. A backward move
+-- (an entry re-dated to a day before its old day) is already inside that
+-- walk and needs no rebuild trigger; a forward move past CURRENT_DATE
+-- cannot happen here because bank_txn_entry_day never produces a future
+-- day for an already-posted transaction. See the design doc, section
+-- "Re-date migration", for the full argument.
+
+SET statement_timeout = 0;
+
+DO $$
+DECLARE
+  v_bank_entries_moved int := 0;
+  v_reclass_entries_moved int := 0;
+BEGIN
+  -- Statement 1: bank-transaction entries.
+  UPDATE journal_entries je
+  SET entry_date = bank_txn_entry_day(bt.transaction_date, r.timezone),
+      updated_at = now()
+  FROM bank_transactions bt
+  JOIN restaurants r ON r.id = bt.restaurant_id
+  WHERE je.reference_type = 'bank_transaction'
+    AND je.reference_id = bt.id
+    AND je.restaurant_id = bt.restaurant_id
+    AND je.entry_date IS DISTINCT FROM bank_txn_entry_day(bt.transaction_date, r.timezone)
+    AND NOT EXISTS (
+      SELECT 1 FROM fiscal_periods fp
+      WHERE fp.restaurant_id = je.restaurant_id
+        AND bank_txn_entry_day(bt.transaction_date, r.timezone) >= fp.period_start
+        AND bank_txn_entry_day(bt.transaction_date, r.timezone) <= fp.period_end
+        AND fp.is_closed = true
+    );
+
+  GET DIAGNOSTICS v_bank_entries_moved = ROW_COUNT;
+  RAISE NOTICE 'redate_bank_journal_entries: bank-transaction entries moved = %', v_bank_entries_moved;
+
+  -- Statement 2: reclassification entries.
+  UPDATE journal_entries je
+  SET entry_date = bank_txn_entry_day(bt.transaction_date, r.timezone),
+      updated_at = now()
+  FROM transaction_reclassifications tr
+  JOIN bank_transactions bt ON bt.id = tr.bank_transaction_id
+  JOIN restaurants r ON r.id = bt.restaurant_id
+  WHERE je.id = tr.reclass_journal_entry_id
+    AND je.reference_type = 'reclassification'
+    AND je.entry_date IS DISTINCT FROM bank_txn_entry_day(bt.transaction_date, r.timezone)
+    AND NOT EXISTS (
+      SELECT 1 FROM fiscal_periods fp
+      WHERE fp.restaurant_id = je.restaurant_id
+        AND bank_txn_entry_day(bt.transaction_date, r.timezone) >= fp.period_start
+        AND bank_txn_entry_day(bt.transaction_date, r.timezone) <= fp.period_end
+        AND fp.is_closed = true
+    );
+
+  GET DIAGNOSTICS v_reclass_entries_moved = ROW_COUNT;
+  RAISE NOTICE 'redate_bank_journal_entries: reclassification entries moved = %', v_reclass_entries_moved;
+END $$;
+
+RESET statement_timeout;

--- a/supabase/migrations/20260820210500_redate_bank_journal_entries.sql
+++ b/supabase/migrations/20260820210500_redate_bank_journal_entries.sql
@@ -61,6 +61,7 @@ BEGIN
   JOIN restaurants r ON r.id = bt.restaurant_id
   WHERE je.id = tr.reclass_journal_entry_id
     AND je.reference_type = 'reclassification'
+    AND je.restaurant_id = bt.restaurant_id
     AND je.entry_date IS DISTINCT FROM bank_txn_entry_day(bt.transaction_date, r.timezone)
     AND NOT EXISTS (
       SELECT 1 FROM fiscal_periods fp

--- a/supabase/migrations/20260820210600_min_bank_txn_entry_day.sql
+++ b/supabase/migrations/20260820210600_min_bank_txn_entry_day.sql
@@ -1,0 +1,31 @@
+-- Minimum entry day across a restaurant's bank transactions.
+--
+-- The opening-balance hook needs the earliest journal-entry day. The
+-- minimum raw transaction_date does not give it. An anchor at
+-- 2026-02-01 00:00Z keeps February 1. A later instant at
+-- 2026-02-01 03:30Z takes January 31 in America/Chicago. The minimum
+-- must range over the derived days, not the raw timestamps. This
+-- function computes that minimum on the server. The client never
+-- derives a day itself (PR #772 review, codex P1).
+--
+-- SECURITY INVOKER: RLS on bank_transactions limits the scan to
+-- restaurants the caller can read. An unauthorized caller gets NULL,
+-- not an error.
+
+CREATE OR REPLACE FUNCTION public.min_bank_txn_entry_day(p_restaurant_id uuid)
+RETURNS date
+LANGUAGE sql
+STABLE
+SET search_path = public, pg_catalog
+AS $$
+  SELECT MIN(public.bank_txn_entry_day(bt.transaction_date, r.timezone))
+  FROM public.bank_transactions bt
+  JOIN public.restaurants r ON r.id = bt.restaurant_id
+  WHERE bt.restaurant_id = p_restaurant_id;
+$$;
+
+COMMENT ON FUNCTION public.min_bank_txn_entry_day(uuid) IS
+  'Minimum bank_txn_entry_day across a restaurant''s bank transactions. NULL when the caller can read none.';
+
+-- The opening-balance hook calls this through PostgREST.
+GRANT EXECUTE ON FUNCTION public.min_bank_txn_entry_day(uuid) TO authenticated;

--- a/supabase/tests/22_bulk_categorize_bank_transactions.sql
+++ b/supabase/tests/22_bulk_categorize_bank_transactions.sql
@@ -580,9 +580,13 @@ SELECT is(
 
 -- ---------------------------------------------------------------------------
 -- Local entry day: an evening instant lands on the restaurant-local day.
--- 03:30Z on 2026-02-02 = 21:30 CST on 2026-02-01 (restaurant timezone
--- defaults to America/Chicago).
+-- 03:30Z on 2026-02-02 = 21:30 CST on 2026-02-01 (America/Chicago).
+-- Pin the timezone the assertion depends on. Do not rely on the column
+-- default.
 -- ---------------------------------------------------------------------------
+UPDATE restaurants SET timezone = 'America/Chicago'
+  WHERE id = '00000000-0000-0000-0000-000000000610'::uuid;
+
 INSERT INTO bank_transactions (
   id, restaurant_id, connected_bank_id, stripe_transaction_id,
   transaction_date, amount, description, status, is_categorized, is_transfer, is_reconciled

--- a/supabase/tests/22_bulk_categorize_bank_transactions.sql
+++ b/supabase/tests/22_bulk_categorize_bank_transactions.sql
@@ -6,7 +6,7 @@
 -- section 5 for the guard order and per-row branch semantics this pins.
 
 BEGIN;
-SELECT plan(34);
+SELECT plan(35);
 
 SET LOCAL role TO postgres;
 
@@ -577,6 +577,37 @@ SELECT is(
   0,
   'Split parent gains no journal entry from the bulk call'
 );
+
+-- ---------------------------------------------------------------------------
+-- Local entry day: an evening instant lands on the restaurant-local day.
+-- 03:30Z on 2026-02-02 = 21:30 CST on 2026-02-01 (restaurant timezone
+-- defaults to America/Chicago).
+-- ---------------------------------------------------------------------------
+INSERT INTO bank_transactions (
+  id, restaurant_id, connected_bank_id, stripe_transaction_id,
+  transaction_date, amount, description, status, is_categorized, is_transfer, is_reconciled
+) VALUES (
+  '00000000-0000-0000-0000-000000000760'::uuid,
+  '00000000-0000-0000-0000-000000000610'::uuid,
+  '00000000-0000-0000-0000-000000000615'::uuid,
+  'txn-bulk-evening-instant-1',
+  TIMESTAMPTZ '2026-02-02 03:30:00+00', -33.00, 'Evening instant', 'posted', false, false, false
+)
+ON CONFLICT (id) DO UPDATE SET is_categorized = false, category_id = NULL;
+
+SELECT bulk_categorize_bank_transactions(
+  p_restaurant_id   => '00000000-0000-0000-0000-000000000610'::uuid,
+  p_category_id     => '00000000-0000-0000-0000-000000000612'::uuid,
+  p_transaction_ids => ARRAY['00000000-0000-0000-0000-000000000760'::uuid],
+  p_skip_rebuild    => true
+);
+
+SELECT is(
+  (SELECT entry_date FROM journal_entries
+   WHERE reference_type = 'bank_transaction'
+     AND reference_id = '00000000-0000-0000-0000-000000000760'::uuid),
+  DATE '2026-02-01',
+  'bulk categorize writes the restaurant-local entry day');
 
 SELECT * FROM finish();
 ROLLBACK;

--- a/supabase/tests/23_backfill_bank_transaction_journal_entries.sql
+++ b/supabase/tests/23_backfill_bank_transaction_journal_entries.sql
@@ -18,9 +18,10 @@ SET LOCAL role TO postgres;
 -- R_BF_MAIN: fully provisioned (cash account 1000, one active category, one
 -- inactive category). Carries one row per exclusion rule plus the one row
 -- that must gain an entry.
-INSERT INTO restaurants (id, name) VALUES
-  ('00000000-0000-0000-0000-000000000810'::uuid, 'Backfill Main Restaurant')
-ON CONFLICT (id) DO NOTHING;
+-- Pin the timezone: the local-entry-day assertion below depends on it.
+INSERT INTO restaurants (id, name, timezone) VALUES
+  ('00000000-0000-0000-0000-000000000810'::uuid, 'Backfill Main Restaurant', 'America/Chicago')
+ON CONFLICT (id) DO UPDATE SET timezone = 'America/Chicago';
 
 INSERT INTO chart_of_accounts (id, restaurant_id, account_code, account_name, account_type, account_subtype, normal_balance, is_active) VALUES
   ('00000000-0000-0000-0000-000000000811'::uuid, '00000000-0000-0000-0000-000000000810'::uuid, '1000', 'Cash', 'asset', 'cash', 'debit', true),
@@ -105,7 +106,7 @@ INSERT INTO bank_transactions (
    'txn-backfill-eligible-positive-1', CURRENT_DATE, 75.00, 'Categorized deposit, entry-less', 'posted', true, false, false,
    '00000000-0000-0000-0000-000000000812'::uuid, NULL),
   -- Local entry day: evening instant. 03:30Z on 2026-02-02 = 21:30 CST on
-  -- 2026-02-01 (R_BF_MAIN timezone defaults to America/Chicago).
+  -- 2026-02-01 (R_BF_MAIN timezone pinned to America/Chicago above).
   ('00000000-0000-0000-0000-000000000910'::uuid, '00000000-0000-0000-0000-000000000810'::uuid, '00000000-0000-0000-0000-000000000815'::uuid,
    'txn-backfill-evening-1', TIMESTAMPTZ '2026-02-02 03:30:00+00', -44.00, 'Evening instant, entry-less', 'posted', true, false, false,
    '00000000-0000-0000-0000-000000000812'::uuid, NULL)

--- a/supabase/tests/23_backfill_bank_transaction_journal_entries.sql
+++ b/supabase/tests/23_backfill_bank_transaction_journal_entries.sql
@@ -7,7 +7,7 @@
 -- section 7 for the candidate predicate and insert shape this pins.
 
 BEGIN;
-SELECT plan(19);
+SELECT plan(20);
 
 SET LOCAL role TO postgres;
 
@@ -103,6 +103,11 @@ INSERT INTO bank_transactions (
   -- test 1).
   ('00000000-0000-0000-0000-000000000909'::uuid, '00000000-0000-0000-0000-000000000810'::uuid, '00000000-0000-0000-0000-000000000815'::uuid,
    'txn-backfill-eligible-positive-1', CURRENT_DATE, 75.00, 'Categorized deposit, entry-less', 'posted', true, false, false,
+   '00000000-0000-0000-0000-000000000812'::uuid, NULL),
+  -- Local entry day: evening instant. 03:30Z on 2026-02-02 = 21:30 CST on
+  -- 2026-02-01 (R_BF_MAIN timezone defaults to America/Chicago).
+  ('00000000-0000-0000-0000-000000000910'::uuid, '00000000-0000-0000-0000-000000000810'::uuid, '00000000-0000-0000-0000-000000000815'::uuid,
+   'txn-backfill-evening-1', TIMESTAMPTZ '2026-02-02 03:30:00+00', -44.00, 'Evening instant, entry-less', 'posted', true, false, false,
    '00000000-0000-0000-0000-000000000812'::uuid, NULL)
 ON CONFLICT (id) DO UPDATE SET
   is_categorized = EXCLUDED.is_categorized,
@@ -128,14 +133,14 @@ SELECT ok(
 
 SELECT is(
   (SELECT (result ->> 'entries_created')::int FROM backfill_call_1),
-  2,
-  'First call reports entries_created = 2 (one negative and one positive eligible row)'
+  3,
+  'First call reports entries_created = 3 (two negative and one positive eligible row)'
 );
 
 SELECT is(
   (SELECT (result ->> 'lines_created')::int FROM backfill_call_1),
-  4,
-  'First call reports lines_created = 4 (two entries, two lines each)'
+  6,
+  'First call reports lines_created = 6 (three entries, two lines each)'
 );
 
 SELECT is(
@@ -291,6 +296,17 @@ SELECT is(
   75.00::numeric,
   'Positive amount: category line is credited ABS(amount)'
 );
+
+-- ---------------------------------------------------------------------------
+-- Local entry day: an evening instant writes the restaurant-local day, not
+-- the UTC day.
+-- ---------------------------------------------------------------------------
+SELECT is(
+  (SELECT entry_date FROM journal_entries
+   WHERE reference_type = 'bank_transaction'
+     AND reference_id = '00000000-0000-0000-0000-000000000910'::uuid),
+  DATE '2026-02-01',
+  'backfill writes the restaurant-local entry day');
 
 SELECT * FROM finish();
 ROLLBACK;

--- a/supabase/tests/65_bank_txn_entry_day.sql
+++ b/supabase/tests/65_bank_txn_entry_day.sql
@@ -1,0 +1,80 @@
+-- File: supabase/tests/65_bank_txn_entry_day.sql
+-- Description: pins the hybrid entry-day convention in bank_txn_entry_day.
+-- A value at exactly 00:00:00 or 12:00:00 UTC is a date anchor and keeps
+-- the UTC day. A real instant takes the restaurant-local day. See
+-- docs/superpowers/specs/2026-08-20-journal-entry-date-timezone-design.md.
+
+BEGIN;
+SELECT plan(12);
+
+-- The helper must not depend on the session TimeZone. Pin an east-of-UTC
+-- zone so a hidden session cast fails these tests loudly.
+SET LOCAL timezone TO 'Asia/Tokyo';
+
+SELECT is(
+  bank_txn_entry_day('2026-01-15 00:00:00+00'::timestamptz, 'America/Chicago'),
+  '2026-01-15'::date,
+  'midnight UTC anchor keeps the UTC day');
+
+SELECT is(
+  bank_txn_entry_day('2026-01-15 12:00:00+00'::timestamptz, 'America/Chicago'),
+  '2026-01-15'::date,
+  'noon UTC anchor keeps the UTC day');
+
+SELECT is(
+  bank_txn_entry_day('2026-01-16 02:30:00+00'::timestamptz, 'America/Chicago'),
+  '2026-01-15'::date,
+  'evening instant takes the restaurant-local day');
+
+SELECT is(
+  bank_txn_entry_day('2026-01-15 18:45:00+00'::timestamptz, 'America/Chicago'),
+  '2026-01-15'::date,
+  'midday instant keeps the same day');
+
+SELECT is(
+  bank_txn_entry_day(NULL::timestamptz, 'America/Chicago'),
+  NULL::date,
+  'NULL timestamp returns NULL');
+
+SELECT is(
+  bank_txn_entry_day('2026-01-16 02:30:00+00'::timestamptz, NULL),
+  '2026-01-15'::date,
+  'NULL timezone uses the America/Chicago column default');
+
+SELECT is(
+  bank_txn_entry_day('2026-01-16 02:30:00+00'::timestamptz, 'Not/AZone'),
+  '2026-01-16'::date,
+  'invalid timezone falls back to the UTC day');
+
+SELECT is(
+  bank_txn_entry_day('2026-01-15 20:30:00+00'::timestamptz, 'Asia/Tokyo'),
+  '2026-01-16'::date,
+  'east-of-UTC instant takes the next local day');
+
+-- DST fall-back: 2026-11-01 ends CDT. 05:30Z on 2026-11-02 is 23:30 CST
+-- on 2026-11-01.
+SELECT is(
+  bank_txn_entry_day('2026-11-02 05:30:00+00'::timestamptz, 'America/Chicago'),
+  '2026-11-01'::date,
+  'fall-back day uses the CST offset');
+
+-- DST spring-forward: 2026-03-08 starts CDT. 04:30Z on 2026-03-09 is
+-- 23:30 CDT on 2026-03-08.
+SELECT is(
+  bank_txn_entry_day('2026-03-09 04:30:00+00'::timestamptz, 'America/Chicago'),
+  '2026-03-08'::date,
+  'day after spring-forward uses the CDT offset');
+
+SELECT ok(
+  has_function_privilege('authenticated', 'bank_txn_entry_day(timestamptz, text)', 'EXECUTE'),
+  'authenticated can EXECUTE bank_txn_entry_day');
+
+-- Same instant, second session zone: the answer must not move.
+SET LOCAL timezone TO 'UTC';
+SELECT is(
+  bank_txn_entry_day('2026-01-16 02:30:00+00'::timestamptz, 'America/Chicago'),
+  '2026-01-15'::date,
+  'result does not depend on the session TimeZone');
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/66_categorize_local_entry_day.sql
+++ b/supabase/tests/66_categorize_local_entry_day.sql
@@ -1,0 +1,128 @@
+-- File: supabase/tests/66_categorize_local_entry_day.sql
+-- Description: categorize_bank_transaction derives entry_date with
+-- bank_txn_entry_day. Covers: evening-instant bank entry, reclass entry,
+-- the heal of an existing entry, and the closed-period guard on the
+-- helper basis. See
+-- docs/superpowers/specs/2026-08-20-journal-entry-date-timezone-design.md.
+
+BEGIN;
+SELECT plan(6);
+
+SET LOCAL role TO postgres;
+SET LOCAL timezone TO 'Asia/Tokyo';  -- session TZ must not leak into dates
+
+-- Fixtures -----------------------------------------------------------------
+INSERT INTO auth.users (id, email) VALUES
+  ('00000000-0000-0000-0000-000000006601'::uuid, 'entry-day-test@example.com')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO restaurants (id, name, timezone) VALUES
+  ('00000000-0000-0000-0000-000000006610'::uuid, 'Entry Day Restaurant', 'America/Chicago')
+ON CONFLICT (id) DO UPDATE SET timezone = 'America/Chicago';
+
+INSERT INTO user_restaurants (user_id, restaurant_id, role) VALUES
+  ('00000000-0000-0000-0000-000000006601'::uuid, '00000000-0000-0000-0000-000000006610'::uuid, 'owner')
+ON CONFLICT (user_id, restaurant_id) DO UPDATE SET role = 'owner';
+
+INSERT INTO chart_of_accounts (id, restaurant_id, account_code, account_name, account_type, account_subtype, normal_balance, is_active) VALUES
+  ('00000000-0000-0000-0000-000000006611'::uuid, '00000000-0000-0000-0000-000000006610'::uuid, '1000', 'Cash', 'asset', 'cash', 'debit', true),
+  ('00000000-0000-0000-0000-000000006612'::uuid, '00000000-0000-0000-0000-000000006610'::uuid, '6000', 'Supplies Expense', 'expense', 'operating_expenses', 'debit', true),
+  ('00000000-0000-0000-0000-000000006613'::uuid, '00000000-0000-0000-0000-000000006610'::uuid, '6010', 'Repairs Expense', 'expense', 'operating_expenses', 'debit', true)
+ON CONFLICT (id) DO UPDATE SET account_name = EXCLUDED.account_name, is_active = true;
+
+INSERT INTO connected_banks (id, restaurant_id, stripe_financial_account_id, institution_name, status) VALUES
+  ('00000000-0000-0000-0000-000000006615'::uuid, '00000000-0000-0000-0000-000000006610'::uuid, 'fa_test_entry_day_001', 'Test Bank', 'connected')
+ON CONFLICT (id) DO NOTHING;
+
+-- Closed period for the guard test below.
+INSERT INTO fiscal_periods (id, restaurant_id, period_start, period_end, is_closed, closed_at) VALUES
+  ('00000000-0000-0000-0000-000000006640'::uuid, '00000000-0000-0000-0000-000000006610'::uuid,
+   DATE '2026-01-01', DATE '2026-01-31', true, now())
+ON CONFLICT (id) DO UPDATE SET is_closed = true;
+
+INSERT INTO bank_transactions (
+  id, restaurant_id, connected_bank_id, stripe_transaction_id,
+  transaction_date, amount, description, status, is_categorized, is_transfer, is_reconciled
+) VALUES
+  -- Evening instant: 03:30Z on Feb 2 = 21:30 CST on Feb 1.
+  ('00000000-0000-0000-0000-000000006701'::uuid, '00000000-0000-0000-0000-000000006610'::uuid,
+   '00000000-0000-0000-0000-000000006615'::uuid, 'txn-entry-day-evening-1',
+   TIMESTAMPTZ '2026-02-02 03:30:00+00', -50.00, 'Evening purchase', 'posted', false, false, false),
+  -- Heal case: entry-less flag off; a wrong-day entry exists (seeded below).
+  ('00000000-0000-0000-0000-000000006702'::uuid, '00000000-0000-0000-0000-000000006610'::uuid,
+   '00000000-0000-0000-0000-000000006615'::uuid, 'txn-entry-day-heal-1',
+   TIMESTAMPTZ '2026-02-05 03:30:00+00', -60.00, 'Heal me', 'posted', false, false, false),
+  -- Closed-period boundary: 23:30Z on Jan 31 = 17:30 CST on Jan 31, inside
+  -- the closed period. The old raw-timestamptz guard let this row through.
+  ('00000000-0000-0000-0000-000000006703'::uuid, '00000000-0000-0000-0000-000000006610'::uuid,
+   '00000000-0000-0000-0000-000000006615'::uuid, 'txn-entry-day-closed-1',
+   TIMESTAMPTZ '2026-01-31 23:30:00+00', -70.00, 'Late on closed last day', 'posted', false, false, false)
+ON CONFLICT (id) DO UPDATE SET is_categorized = false, category_id = NULL;
+
+-- Wrong-day entry for the heal case (UTC day 2026-02-05; local day is 02-04).
+INSERT INTO journal_entries (
+  restaurant_id, entry_date, entry_number, description,
+  reference_type, reference_id, total_debit, total_credit
+) VALUES (
+  '00000000-0000-0000-0000-000000006610'::uuid, DATE '2026-02-05',
+  'BANK-txn-entry-day-heal-1-SEED', 'Heal me',
+  'bank_transaction', '00000000-0000-0000-0000-000000006702'::uuid,
+  60.00, 60.00
+);
+
+SELECT set_config('request.jwt.claims', '{"sub":"00000000-0000-0000-0000-000000006601","role":"authenticated"}', true);
+
+-- Tests --------------------------------------------------------------------
+
+-- 1. Categorize the evening instant: entry lands on the local day.
+SELECT lives_ok(
+  $$SELECT categorize_bank_transaction(
+      '00000000-0000-0000-0000-000000006701'::uuid,
+      '00000000-0000-0000-0000-000000006612'::uuid)$$,
+  'categorize succeeds for the evening instant');
+
+SELECT is(
+  (SELECT entry_date FROM journal_entries
+   WHERE reference_type = 'bank_transaction'
+     AND reference_id = '00000000-0000-0000-0000-000000006701'::uuid),
+  DATE '2026-02-01',
+  'bank entry lands on the restaurant-local day');
+
+-- 2. Reclassify the same transaction: the reclass entry uses the same day.
+SELECT lives_ok(
+  $$SELECT categorize_bank_transaction(
+      '00000000-0000-0000-0000-000000006701'::uuid,
+      '00000000-0000-0000-0000-000000006613'::uuid)$$,
+  'reclassification succeeds');
+
+SELECT is(
+  (SELECT je.entry_date
+   FROM journal_entries je
+   JOIN transaction_reclassifications tr ON tr.reclass_journal_entry_id = je.id
+   WHERE tr.bank_transaction_id = '00000000-0000-0000-0000-000000006701'::uuid
+   ORDER BY je.created_at DESC LIMIT 1),
+  DATE '2026-02-01',
+  'reclass entry lands on the restaurant-local day');
+
+-- 3. Heal: categorize with an existing wrong-day entry updates entry_date.
+SELECT categorize_bank_transaction(
+  '00000000-0000-0000-0000-000000006702'::uuid,
+  '00000000-0000-0000-0000-000000006612'::uuid);
+
+SELECT is(
+  (SELECT entry_date FROM journal_entries
+   WHERE reference_type = 'bank_transaction'
+     AND reference_id = '00000000-0000-0000-0000-000000006702'::uuid),
+  DATE '2026-02-04',
+  'existing entry heals to the restaurant-local day');
+
+-- 4. Closed-period guard fires on the helper day, not the raw timestamptz.
+SELECT throws_like(
+  $$SELECT categorize_bank_transaction(
+      '00000000-0000-0000-0000-000000006703'::uuid,
+      '00000000-0000-0000-0000-000000006612'::uuid)$$,
+  'Cannot categorize transaction in closed fiscal period%',
+  'guard blocks a late instant on the closed period''s last day');
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/67_redate_bank_journal_entries.sql
+++ b/supabase/tests/67_redate_bank_journal_entries.sql
@@ -2,12 +2,13 @@
 -- Description: proves the one-time re-date statement shape used by
 -- migration 20260820210500_redate_bank_journal_entries.sql. Seeds a
 -- wrong-day bank entry, a wrong-day reclass entry, a date-anchored entry,
--- and a closed-period collision; runs the same UPDATEs; asserts the moves
--- and the skips. Also proves the report-level effect: a mid-window as-of
--- balance changes after the re-date.
+-- and two closed-period collisions (one on the new day, one on the old
+-- day); runs the same UPDATEs; asserts the moves and the skips. Also
+-- proves the report-level effect: a mid-window as-of balance changes
+-- after the re-date.
 
 BEGIN;
-SELECT plan(8);
+SELECT plan(9);
 
 SET LOCAL role TO postgres;
 SET LOCAL timezone TO 'Asia/Tokyo';
@@ -52,7 +53,14 @@ INSERT INTO bank_transactions (
   -- old day (2026-04-01, UTC) does not. The re-date must skip it.
   ('00000000-0000-0000-0000-000000006804'::uuid, '00000000-0000-0000-0000-000000006710'::uuid,
    '00000000-0000-0000-0000-000000006715'::uuid, 'txn-redate-closed-1',
-   TIMESTAMPTZ '2026-04-01 03:30:00+00', -40.00, 'Closed-period collision', 'posted', true, false, false)
+   TIMESTAMPTZ '2026-04-01 03:30:00+00', -40.00, 'Closed-period collision', 'posted', true, false, false),
+  -- 6805: the mirror case. The old day (2026-03-01, UTC) sits inside the
+  -- closed period; the new day (2026-02-28, local) does not. A move
+  -- would pull activity out of the closed period. The re-date must skip
+  -- it too.
+  ('00000000-0000-0000-0000-000000006805'::uuid, '00000000-0000-0000-0000-000000006710'::uuid,
+   '00000000-0000-0000-0000-000000006715'::uuid, 'txn-redate-closed-2',
+   TIMESTAMPTZ '2026-03-01 03:30:00+00', -45.00, 'Closed-period source collision', 'posted', true, false, false)
 ON CONFLICT (id) DO NOTHING;
 
 INSERT INTO journal_entries (
@@ -70,7 +78,10 @@ INSERT INTO journal_entries (
    'reclassification', gen_random_uuid(), 30.00, 30.00),
   ('00000000-0000-0000-0000-000000006904'::uuid, '00000000-0000-0000-0000-000000006710'::uuid,
    DATE '2026-04-01', 'BANK-txn-redate-closed-1-SEED', 'Closed-period collision',
-   'bank_transaction', '00000000-0000-0000-0000-000000006804'::uuid, 40.00, 40.00);
+   'bank_transaction', '00000000-0000-0000-0000-000000006804'::uuid, 40.00, 40.00),
+  ('00000000-0000-0000-0000-000000006905'::uuid, '00000000-0000-0000-0000-000000006710'::uuid,
+   DATE '2026-03-01', 'BANK-txn-redate-closed-2-SEED', 'Closed-period source collision',
+   'bank_transaction', '00000000-0000-0000-0000-000000006805'::uuid, 45.00, 45.00);
 
 -- Lines for 6901 so the report-effect assertion has an amount to sum.
 INSERT INTO journal_entry_lines (journal_entry_id, account_id, debit_amount, credit_amount, description) VALUES
@@ -111,9 +122,12 @@ WHERE je.reference_type = 'bank_transaction'
   AND NOT EXISTS (
     SELECT 1 FROM fiscal_periods fp
     WHERE fp.restaurant_id = je.restaurant_id
-      AND bank_txn_entry_day(bt.transaction_date, r.timezone) >= fp.period_start
-      AND bank_txn_entry_day(bt.transaction_date, r.timezone) <= fp.period_end
       AND fp.is_closed = true
+      AND (
+        bank_txn_entry_day(bt.transaction_date, r.timezone)
+          BETWEEN fp.period_start AND fp.period_end
+        OR je.entry_date BETWEEN fp.period_start AND fp.period_end
+      )
   );
 
 UPDATE journal_entries je
@@ -129,9 +143,12 @@ WHERE je.id = tr.reclass_journal_entry_id
   AND NOT EXISTS (
     SELECT 1 FROM fiscal_periods fp
     WHERE fp.restaurant_id = je.restaurant_id
-      AND bank_txn_entry_day(bt.transaction_date, r.timezone) >= fp.period_start
-      AND bank_txn_entry_day(bt.transaction_date, r.timezone) <= fp.period_end
       AND fp.is_closed = true
+      AND (
+        bank_txn_entry_day(bt.transaction_date, r.timezone)
+          BETWEEN fp.period_start AND fp.period_end
+        OR je.entry_date BETWEEN fp.period_start AND fp.period_end
+      )
   );
 
 -- Assertions -----------------------------------------------------------------
@@ -154,6 +171,11 @@ SELECT is(
   (SELECT entry_date FROM journal_entries WHERE id = '00000000-0000-0000-0000-000000006904'::uuid),
   DATE '2026-04-01',
   'closed-period collision keeps its old day');
+
+SELECT is(
+  (SELECT entry_date FROM journal_entries WHERE id = '00000000-0000-0000-0000-000000006905'::uuid),
+  DATE '2026-03-01',
+  'an entry inside a closed period does not move out of it');
 
 -- Report-level effect, AFTER: the same as-of day now includes the entry.
 SELECT is(
@@ -178,9 +200,12 @@ WHERE je.reference_type = 'bank_transaction'
   AND NOT EXISTS (
     SELECT 1 FROM fiscal_periods fp
     WHERE fp.restaurant_id = je.restaurant_id
-      AND bank_txn_entry_day(bt.transaction_date, r.timezone) >= fp.period_start
-      AND bank_txn_entry_day(bt.transaction_date, r.timezone) <= fp.period_end
       AND fp.is_closed = true
+      AND (
+        bank_txn_entry_day(bt.transaction_date, r.timezone)
+          BETWEEN fp.period_start AND fp.period_end
+        OR je.entry_date BETWEEN fp.period_start AND fp.period_end
+      )
   );
 
 SELECT is(

--- a/supabase/tests/67_redate_bank_journal_entries.sql
+++ b/supabase/tests/67_redate_bank_journal_entries.sql
@@ -1,0 +1,199 @@
+-- File: supabase/tests/67_redate_bank_journal_entries.sql
+-- Description: proves the one-time re-date statement shape used by
+-- migration 20260820210500_redate_bank_journal_entries.sql. Seeds a
+-- wrong-day bank entry, a wrong-day reclass entry, a date-anchored entry,
+-- and a closed-period collision; runs the same UPDATEs; asserts the moves
+-- and the skips. Also proves the report-level effect: a mid-window as-of
+-- balance changes after the re-date.
+
+BEGIN;
+SELECT plan(8);
+
+SET LOCAL role TO postgres;
+SET LOCAL timezone TO 'Asia/Tokyo';
+
+-- Fixtures -----------------------------------------------------------------
+INSERT INTO restaurants (id, name, timezone) VALUES
+  ('00000000-0000-0000-0000-000000006710'::uuid, 'Redate Restaurant', 'America/Chicago')
+ON CONFLICT (id) DO UPDATE SET timezone = 'America/Chicago';
+
+INSERT INTO chart_of_accounts (id, restaurant_id, account_code, account_name, account_type, account_subtype, normal_balance, is_active) VALUES
+  ('00000000-0000-0000-0000-000000006711'::uuid, '00000000-0000-0000-0000-000000006710'::uuid, '1000', 'Cash', 'asset', 'cash', 'debit', true),
+  ('00000000-0000-0000-0000-000000006712'::uuid, '00000000-0000-0000-0000-000000006710'::uuid, '6000', 'Supplies Expense', 'expense', 'operating_expenses', 'debit', true)
+ON CONFLICT (id) DO UPDATE SET is_active = true;
+
+INSERT INTO connected_banks (id, restaurant_id, stripe_financial_account_id, institution_name, status) VALUES
+  ('00000000-0000-0000-0000-000000006715'::uuid, '00000000-0000-0000-0000-000000006710'::uuid, 'fa_test_redate_001', 'Test Bank', 'connected')
+ON CONFLICT (id) DO NOTHING;
+
+-- Closed period that must protect entry 6904 below.
+INSERT INTO fiscal_periods (id, restaurant_id, period_start, period_end, is_closed, closed_at) VALUES
+  ('00000000-0000-0000-0000-000000006740'::uuid, '00000000-0000-0000-0000-000000006710'::uuid,
+   DATE '2026-03-01', DATE '2026-03-31', true, now())
+ON CONFLICT (id) DO UPDATE SET is_closed = true;
+
+INSERT INTO bank_transactions (
+  id, restaurant_id, connected_bank_id, stripe_transaction_id,
+  transaction_date, amount, description, status, is_categorized, is_transfer, is_reconciled
+) VALUES
+  -- 6801: evening instant, entry on the wrong UTC day.
+  ('00000000-0000-0000-0000-000000006801'::uuid, '00000000-0000-0000-0000-000000006710'::uuid,
+   '00000000-0000-0000-0000-000000006715'::uuid, 'txn-redate-evening-1',
+   TIMESTAMPTZ '2026-02-02 03:30:00+00', -50.00, 'Evening instant', 'posted', true, false, false),
+  -- 6802: date anchor, entry already right.
+  ('00000000-0000-0000-0000-000000006802'::uuid, '00000000-0000-0000-0000-000000006710'::uuid,
+   '00000000-0000-0000-0000-000000006715'::uuid, 'txn-redate-anchor-1',
+   TIMESTAMPTZ '2026-02-10 00:00:00+00', -20.00, 'Date anchor', 'posted', true, false, false),
+  -- 6803: evening instant with a reclass entry.
+  ('00000000-0000-0000-0000-000000006803'::uuid, '00000000-0000-0000-0000-000000006710'::uuid,
+   '00000000-0000-0000-0000-000000006715'::uuid, 'txn-redate-reclass-1',
+   TIMESTAMPTZ '2026-02-16 02:15:00+00', -30.00, 'Reclassed instant', 'posted', true, false, false),
+  -- 6804: the new day (2026-03-31) falls inside the closed period; the
+  -- old day (2026-04-01, UTC) does not. The re-date must skip it.
+  ('00000000-0000-0000-0000-000000006804'::uuid, '00000000-0000-0000-0000-000000006710'::uuid,
+   '00000000-0000-0000-0000-000000006715'::uuid, 'txn-redate-closed-1',
+   TIMESTAMPTZ '2026-04-01 03:30:00+00', -40.00, 'Closed-period collision', 'posted', true, false, false)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO journal_entries (
+  id, restaurant_id, entry_date, entry_number, description,
+  reference_type, reference_id, total_debit, total_credit
+) VALUES
+  ('00000000-0000-0000-0000-000000006901'::uuid, '00000000-0000-0000-0000-000000006710'::uuid,
+   DATE '2026-02-02', 'BANK-txn-redate-evening-1-SEED', 'Evening instant',
+   'bank_transaction', '00000000-0000-0000-0000-000000006801'::uuid, 50.00, 50.00),
+  ('00000000-0000-0000-0000-000000006902'::uuid, '00000000-0000-0000-0000-000000006710'::uuid,
+   DATE '2026-02-10', 'BANK-txn-redate-anchor-1-SEED', 'Date anchor',
+   'bank_transaction', '00000000-0000-0000-0000-000000006802'::uuid, 20.00, 20.00),
+  ('00000000-0000-0000-0000-000000006903'::uuid, '00000000-0000-0000-0000-000000006710'::uuid,
+   DATE '2026-02-16', 'RECLASS-txn-redate-reclass-1-SEED', 'Reclassed instant',
+   'reclassification', gen_random_uuid(), 30.00, 30.00),
+  ('00000000-0000-0000-0000-000000006904'::uuid, '00000000-0000-0000-0000-000000006710'::uuid,
+   DATE '2026-04-01', 'BANK-txn-redate-closed-1-SEED', 'Closed-period collision',
+   'bank_transaction', '00000000-0000-0000-0000-000000006804'::uuid, 40.00, 40.00);
+
+-- Lines for 6901 so the report-effect assertion has an amount to sum.
+INSERT INTO journal_entry_lines (journal_entry_id, account_id, debit_amount, credit_amount, description) VALUES
+  ('00000000-0000-0000-0000-000000006901'::uuid, '00000000-0000-0000-0000-000000006712'::uuid, 50.00, 0, 'Supplies'),
+  ('00000000-0000-0000-0000-000000006901'::uuid, '00000000-0000-0000-0000-000000006711'::uuid, 0, 50.00, 'Cash payment');
+
+INSERT INTO transaction_reclassifications (
+  restaurant_id, bank_transaction_id, original_category_id,
+  new_category_id, reclass_journal_entry_id, reason
+) VALUES (
+  '00000000-0000-0000-0000-000000006710'::uuid,
+  '00000000-0000-0000-0000-000000006803'::uuid,
+  '00000000-0000-0000-0000-000000006712'::uuid,
+  '00000000-0000-0000-0000-000000006712'::uuid,
+  '00000000-0000-0000-0000-000000006903'::uuid,
+  'redate test');
+
+-- Report-level effect, BEFORE: the mid-window as-of day (2026-02-01) sees
+-- no expense yet, because the entry still sits on 2026-02-02.
+SELECT is(
+  compute_account_balance('00000000-0000-0000-0000-000000006712'::uuid, DATE '2026-02-01'),
+  0.00::numeric,
+  'before the re-date, the mid-window balance excludes the entry');
+
+-- The migration statements ---------------------------------------------------
+-- Keep these two UPDATEs byte-identical to
+-- supabase/migrations/20260820210500_redate_bank_journal_entries.sql.
+
+UPDATE journal_entries je
+SET entry_date = bank_txn_entry_day(bt.transaction_date, r.timezone),
+    updated_at = now()
+FROM bank_transactions bt
+JOIN restaurants r ON r.id = bt.restaurant_id
+WHERE je.reference_type = 'bank_transaction'
+  AND je.reference_id = bt.id
+  AND je.restaurant_id = bt.restaurant_id
+  AND je.entry_date IS DISTINCT FROM bank_txn_entry_day(bt.transaction_date, r.timezone)
+  AND NOT EXISTS (
+    SELECT 1 FROM fiscal_periods fp
+    WHERE fp.restaurant_id = je.restaurant_id
+      AND bank_txn_entry_day(bt.transaction_date, r.timezone) >= fp.period_start
+      AND bank_txn_entry_day(bt.transaction_date, r.timezone) <= fp.period_end
+      AND fp.is_closed = true
+  );
+
+UPDATE journal_entries je
+SET entry_date = bank_txn_entry_day(bt.transaction_date, r.timezone),
+    updated_at = now()
+FROM transaction_reclassifications tr
+JOIN bank_transactions bt ON bt.id = tr.bank_transaction_id
+JOIN restaurants r ON r.id = bt.restaurant_id
+WHERE je.id = tr.reclass_journal_entry_id
+  AND je.reference_type = 'reclassification'
+  AND je.entry_date IS DISTINCT FROM bank_txn_entry_day(bt.transaction_date, r.timezone)
+  AND NOT EXISTS (
+    SELECT 1 FROM fiscal_periods fp
+    WHERE fp.restaurant_id = je.restaurant_id
+      AND bank_txn_entry_day(bt.transaction_date, r.timezone) >= fp.period_start
+      AND bank_txn_entry_day(bt.transaction_date, r.timezone) <= fp.period_end
+      AND fp.is_closed = true
+  );
+
+-- Assertions -----------------------------------------------------------------
+SELECT is(
+  (SELECT entry_date FROM journal_entries WHERE id = '00000000-0000-0000-0000-000000006901'::uuid),
+  DATE '2026-02-01',
+  'bank entry moves to the restaurant-local day');
+
+SELECT is(
+  (SELECT entry_date FROM journal_entries WHERE id = '00000000-0000-0000-0000-000000006902'::uuid),
+  DATE '2026-02-10',
+  'date-anchored entry does not move');
+
+SELECT is(
+  (SELECT entry_date FROM journal_entries WHERE id = '00000000-0000-0000-0000-000000006903'::uuid),
+  DATE '2026-02-15',
+  'reclass entry moves via transaction_reclassifications');
+
+SELECT is(
+  (SELECT entry_date FROM journal_entries WHERE id = '00000000-0000-0000-0000-000000006904'::uuid),
+  DATE '2026-04-01',
+  'closed-period collision keeps its old day');
+
+-- Report-level effect, AFTER: the same as-of day now includes the entry.
+SELECT is(
+  compute_account_balance('00000000-0000-0000-0000-000000006712'::uuid, DATE '2026-02-01'),
+  50.00::numeric,
+  'after the re-date, the mid-window balance includes the entry');
+
+-- Idempotence: a second run changes no row.
+CREATE TEMP TABLE redate_before AS
+  SELECT id, entry_date FROM journal_entries
+  WHERE restaurant_id = '00000000-0000-0000-0000-000000006710'::uuid;
+
+UPDATE journal_entries je
+SET entry_date = bank_txn_entry_day(bt.transaction_date, r.timezone),
+    updated_at = now()
+FROM bank_transactions bt
+JOIN restaurants r ON r.id = bt.restaurant_id
+WHERE je.reference_type = 'bank_transaction'
+  AND je.reference_id = bt.id
+  AND je.restaurant_id = bt.restaurant_id
+  AND je.entry_date IS DISTINCT FROM bank_txn_entry_day(bt.transaction_date, r.timezone)
+  AND NOT EXISTS (
+    SELECT 1 FROM fiscal_periods fp
+    WHERE fp.restaurant_id = je.restaurant_id
+      AND bank_txn_entry_day(bt.transaction_date, r.timezone) >= fp.period_start
+      AND bank_txn_entry_day(bt.transaction_date, r.timezone) <= fp.period_end
+      AND fp.is_closed = true
+  );
+
+SELECT is(
+  (SELECT count(*)::int FROM journal_entries je
+   JOIN redate_before b ON b.id = je.id
+   WHERE je.entry_date IS DISTINCT FROM b.entry_date),
+  0,
+  'a second run is a no-op');
+
+-- Compute_account_balance signature check (guards a signature drift that
+-- would break the report assertions silently).
+SELECT ok(
+  has_function_privilege('postgres', 'compute_account_balance(uuid, date)', 'EXECUTE'),
+  'compute_account_balance(uuid, date) exists');
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/67_redate_bank_journal_entries.sql
+++ b/supabase/tests/67_redate_bank_journal_entries.sql
@@ -124,6 +124,7 @@ JOIN bank_transactions bt ON bt.id = tr.bank_transaction_id
 JOIN restaurants r ON r.id = bt.restaurant_id
 WHERE je.id = tr.reclass_journal_entry_id
   AND je.reference_type = 'reclassification'
+  AND je.restaurant_id = bt.restaurant_id
   AND je.entry_date IS DISTINCT FROM bank_txn_entry_day(bt.transaction_date, r.timezone)
   AND NOT EXISTS (
     SELECT 1 FROM fiscal_periods fp

--- a/supabase/tests/68_min_bank_txn_entry_day.sql
+++ b/supabase/tests/68_min_bank_txn_entry_day.sql
@@ -1,0 +1,62 @@
+-- File: supabase/tests/68_min_bank_txn_entry_day.sql
+-- Description: pins min_bank_txn_entry_day. The minimum ranges over the
+-- derived entry days, not the raw timestamps. An anchor at 00:00Z keeps
+-- its UTC day. A later instant can land one local day earlier.
+
+BEGIN;
+SELECT plan(4);
+
+SET LOCAL role TO postgres;
+
+-- The result must not depend on the session TimeZone. Pin an
+-- east-of-UTC zone so a hidden session cast fails these tests loudly.
+SET LOCAL timezone TO 'Asia/Tokyo';
+
+-- Fixtures -----------------------------------------------------------------
+INSERT INTO restaurants (id, name, timezone) VALUES
+  ('00000000-0000-0000-0000-000000006810'::uuid, 'MinDay Restaurant', 'America/Chicago')
+ON CONFLICT (id) DO UPDATE SET timezone = 'America/Chicago';
+
+INSERT INTO connected_banks (id, restaurant_id, stripe_financial_account_id, institution_name, status) VALUES
+  ('00000000-0000-0000-0000-000000006815'::uuid, '00000000-0000-0000-0000-000000006810'::uuid, 'fa_test_minday_001', 'Test Bank', 'connected')
+ON CONFLICT (id) DO NOTHING;
+
+-- The anchor holds the minimum RAW timestamp. The instant maps to the
+-- earlier LOCAL day (03:30Z on 2026-02-01 = 21:30 CST on 2026-01-31).
+INSERT INTO bank_transactions (
+  id, restaurant_id, connected_bank_id, stripe_transaction_id,
+  transaction_date, amount, description, status, is_categorized, is_transfer, is_reconciled
+) VALUES
+  ('00000000-0000-0000-0000-000000006851'::uuid, '00000000-0000-0000-0000-000000006810'::uuid,
+   '00000000-0000-0000-0000-000000006815'::uuid, 'txn-minday-anchor-1',
+   TIMESTAMPTZ '2026-02-01 00:00:00+00', -10.00, 'Date anchor', 'posted', true, false, false),
+  ('00000000-0000-0000-0000-000000006852'::uuid, '00000000-0000-0000-0000-000000006810'::uuid,
+   '00000000-0000-0000-0000-000000006815'::uuid, 'txn-minday-instant-1',
+   TIMESTAMPTZ '2026-02-01 03:30:00+00', -20.00, 'Evening instant', 'posted', true, false, false)
+ON CONFLICT (id) DO NOTHING;
+
+-- Assertions -----------------------------------------------------------------
+SELECT is(
+  min_bank_txn_entry_day('00000000-0000-0000-0000-000000006810'::uuid),
+  DATE '2026-01-31',
+  'the minimum ranges over derived entry days, not raw timestamps');
+
+DELETE FROM bank_transactions
+  WHERE id = '00000000-0000-0000-0000-000000006852'::uuid;
+
+SELECT is(
+  min_bank_txn_entry_day('00000000-0000-0000-0000-000000006810'::uuid),
+  DATE '2026-02-01',
+  'an anchor-only restaurant keeps the anchor day');
+
+SELECT is(
+  min_bank_txn_entry_day('00000000-0000-0000-0000-000000006999'::uuid),
+  NULL::date,
+  'a restaurant without transactions returns NULL');
+
+SELECT ok(
+  has_function_privilege('authenticated', 'min_bank_txn_entry_day(uuid)', 'EXECUTE'),
+  'authenticated can EXECUTE min_bank_txn_entry_day');
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/categorization_background_rules.test.sql
+++ b/supabase/tests/categorization_background_rules.test.sql
@@ -83,7 +83,7 @@
 --     Sale I:          c1a00009-...-000000000201  (item_name='Delivery Fee', is_categorized=false)
 
 BEGIN;
-SELECT plan(27);
+SELECT plan(28);
 
 -- ============================================================
 -- Setup
@@ -834,6 +834,40 @@ SELECT is(
   true,
   '(n) backfill loop drains POS backlog: Delivery Fee row is_categorized=true'
 );
+
+-- ============================================================
+-- Test (o): the internal bank engine writes the restaurant-local entry day.
+-- 03:30Z on 2026-02-02 = 21:30 CST on 2026-02-01.
+-- ============================================================
+ALTER TABLE public.bank_transactions DISABLE TRIGGER auto_categorize_bank_transaction;
+
+INSERT INTO public.bank_transactions
+  (id, restaurant_id, connected_bank_id, stripe_transaction_id,
+   transaction_date, description, amount, is_categorized)
+VALUES
+  ('c1a00008-0000-0000-0000-000000000102',
+   'c1a00008-0000-0000-0000-000000000801',
+   'c1a00008-0000-0000-0000-0000000000b8',
+   'cbt-stripe-txn-h02',
+   TIMESTAMPTZ '2026-02-02 03:30:00+00',
+   'Payment to VENDOR-H Corp evening run',
+   -75.00,
+   false)
+ON CONFLICT (id) DO NOTHING;
+
+ALTER TABLE public.bank_transactions ENABLE TRIGGER auto_categorize_bank_transaction;
+
+SET LOCAL "request.jwt.claims" TO '';
+
+SELECT apply_rules_to_bank_transactions_internal(
+  'c1a00008-0000-0000-0000-000000000801'::uuid, 100);
+
+SELECT is(
+  (SELECT entry_date FROM public.journal_entries
+   WHERE reference_type = 'bank_transaction'
+     AND reference_id = 'c1a00008-0000-0000-0000-000000000102'),
+  DATE '2026-02-01',
+  '(o) internal bank engine writes the restaurant-local entry day');
 
 SELECT * FROM finish();
 ROLLBACK;

--- a/supabase/tests/categorization_background_rules.test.sql
+++ b/supabase/tests/categorization_background_rules.test.sql
@@ -837,8 +837,12 @@ SELECT is(
 
 -- ============================================================
 -- Test (o): the internal bank engine writes the restaurant-local entry day.
--- 03:30Z on 2026-02-02 = 21:30 CST on 2026-02-01.
+-- 03:30Z on 2026-02-02 = 21:30 CST on 2026-02-01. Pin the timezone the
+-- assertion depends on. Do not rely on the column default.
 -- ============================================================
+UPDATE public.restaurants SET timezone = 'America/Chicago'
+  WHERE id = 'c1a00008-0000-0000-0000-000000000801';
+
 ALTER TABLE public.bank_transactions DISABLE TRIGGER auto_categorize_bank_transaction;
 
 INSERT INTO public.bank_transactions

--- a/tests/unit/useCalculateOpeningBalance.test.ts
+++ b/tests/unit/useCalculateOpeningBalance.test.ts
@@ -21,6 +21,9 @@ import { useCalculateOpeningBalance } from '@/hooks/useCalculateOpeningBalance';
 // A chainable thenable: every method returns the chain; awaiting it
 // resolves to the canned response.
 function chain(response: unknown) {
+  // `any`: the Proxy returns itself from every property access, so its
+  // real type is a self-reference TypeScript cannot express. The proxy
+  // only stands in for the Supabase query builder's chained calls.
   const proxy: any = new Proxy(() => proxy, {
     get(_t, prop) {
       if (prop === 'then') {

--- a/tests/unit/useCalculateOpeningBalance.test.ts
+++ b/tests/unit/useCalculateOpeningBalance.test.ts
@@ -24,6 +24,7 @@ function chain(response: unknown) {
   // `any`: the Proxy returns itself from every property access, so its
   // real type is a self-reference TypeScript cannot express. The proxy
   // only stands in for the Supabase query builder's chained calls.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const proxy: any = new Proxy(() => proxy, {
     get(_t, prop) {
       if (prop === 'then') {

--- a/tests/unit/useCalculateOpeningBalance.test.ts
+++ b/tests/unit/useCalculateOpeningBalance.test.ts
@@ -37,8 +37,6 @@ function chain(response: unknown) {
   return proxy;
 }
 
-const EARLIEST_TS = '2026-02-02T03:30:00+00:00';
-
 function wrapper({ children }: { children: React.ReactNode }) {
   return React.createElement(
     QueryClientProvider,
@@ -52,12 +50,11 @@ describe('useCalculateOpeningBalance entry day', () => {
   let upsertedBoundary: Record<string, unknown> | null;
   let tableCalls: Record<string, number>;
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-    insertedEntry = null;
-    upsertedBoundary = null;
+  // The from-mock throws on any table or extra call the hook must not
+  // make. bank_transactions may be queried exactly once (the net-change
+  // sum); the entry day comes from the min_bank_txn_entry_day RPC.
+  function installFromMock() {
     tableCalls = {};
-
     mocks.from.mockImplementation((table: string) => {
       tableCalls[table] = (tableCalls[table] ?? 0) + 1;
       const n = tableCalls[table];
@@ -69,26 +66,20 @@ describe('useCalculateOpeningBalance entry day', () => {
       }
       if (table === 'bank_transactions' && n === 1) {
         return chain({
-          data: [{ amount: 200, transaction_date: EARLIEST_TS }],
+          data: [{ amount: 200, transaction_date: '2026-02-01T00:00:00+00:00' }],
           error: null,
         });
-      }
-      if (table === 'bank_transactions') {
-        return chain({ data: { transaction_date: EARLIEST_TS }, error: null });
       }
       if (table === 'chart_of_accounts' && n === 1) {
         return chain({ data: { id: 'cash-id', account_name: 'Cash' }, error: null });
       }
-      if (table === 'chart_of_accounts') {
+      if (table === 'chart_of_accounts' && n === 2) {
         return chain({ data: { id: 'equity-id', account_name: 'Equity' }, error: null });
-      }
-      if (table === 'restaurants') {
-        return chain({ data: { timezone: 'America/New_York' }, error: null });
       }
       if (table === 'journal_entries' && n === 1) {
         return chain({ data: null, error: null });
       }
-      if (table === 'journal_entries') {
+      if (table === 'journal_entries' && n === 2) {
         return {
           insert: (payload: Record<string, unknown>) => {
             insertedEntry = payload;
@@ -96,10 +87,10 @@ describe('useCalculateOpeningBalance entry day', () => {
           },
         };
       }
-      if (table === 'journal_entry_lines') {
+      if (table === 'journal_entry_lines' && n === 1) {
         return { insert: () => chain({ error: null }) };
       }
-      if (table === 'reconciliation_boundaries') {
+      if (table === 'reconciliation_boundaries' && n === 1) {
         return {
           upsert: (payload: Record<string, unknown>) => {
             upsertedBoundary = payload;
@@ -107,94 +98,71 @@ describe('useCalculateOpeningBalance entry day', () => {
           },
         };
       }
-      throw new Error(`unexpected table: ${table}`);
+      throw new Error(`unexpected query: ${table} call ${n}`);
     });
+  }
 
+  function installRpcMock(minEntryDayResponse: unknown) {
     mocks.rpc.mockImplementation((fnName: string) => {
-      if (fnName === 'bank_txn_entry_day') {
-        return chain({ data: '2026-02-01', error: null });
+      if (fnName === 'min_bank_txn_entry_day') {
+        return chain(minEntryDayResponse);
       }
       if (fnName === 'rebuild_account_balances') {
         return chain({ data: null, error: null });
       }
       throw new Error(`unexpected rpc: ${fnName}`);
     });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    insertedEntry = null;
+    upsertedBoundary = null;
+    installFromMock();
+    installRpcMock({ data: '2026-01-31', error: null });
   });
 
   afterEach(() => {
     vi.useRealTimers();
   });
 
-  it('derives the opening date from the bank_txn_entry_day RPC', async () => {
+  it('derives the opening date from the min_bank_txn_entry_day RPC', async () => {
     const { result } = renderHook(() => useCalculateOpeningBalance(), { wrapper });
 
     await result.current.mutateAsync('rest-1');
 
-    expect(mocks.rpc).toHaveBeenCalledWith('bank_txn_entry_day', {
-      p_ts: EARLIEST_TS,
-      p_tz: 'America/New_York',
+    // The RPC returns the minimum DERIVED day (2026-01-31), one local
+    // day before the minimum raw timestamp's UTC day (2026-02-01). The
+    // hook must use the RPC value, not order raw timestamps itself.
+    expect(mocks.rpc).toHaveBeenCalledWith('min_bank_txn_entry_day', {
+      p_restaurant_id: 'rest-1',
     });
-    expect(insertedEntry?.entry_date).toBe('2026-02-01');
-    expect(upsertedBoundary?.balance_start_date).toBe('2026-02-01');
+    expect(insertedEntry?.entry_date).toBe('2026-01-31');
+    expect(upsertedBoundary?.balance_start_date).toBe('2026-01-31');
   });
 
-  it('falls back to today when no transaction exists', async () => {
+  it('falls back to today when the restaurant has no transaction', async () => {
     vi.useFakeTimers({ toFake: ['Date'] });
     vi.setSystemTime(new Date('2026-08-20T15:00:00Z'));
-
-    tableCalls = {};
-    mocks.from.mockImplementation((table: string) => {
-      tableCalls[table] = (tableCalls[table] ?? 0) + 1;
-      const n = tableCalls[table];
-      if (table === 'bank_account_balances') {
-        return chain({
-          data: [{ current_balance: 1000, as_of_date: '2026-08-01' }],
-          error: null,
-        });
-      }
-      if (table === 'bank_transactions' && n === 1) {
-        return chain({ data: [], error: null });
-      }
-      if (table === 'bank_transactions') {
-        return chain({ data: null, error: null });
-      }
-      if (table === 'chart_of_accounts' && n === 1) {
-        return chain({ data: { id: 'cash-id', account_name: 'Cash' }, error: null });
-      }
-      if (table === 'chart_of_accounts') {
-        return chain({ data: { id: 'equity-id', account_name: 'Equity' }, error: null });
-      }
-      if (table === 'journal_entries' && n === 1) {
-        return chain({ data: null, error: null });
-      }
-      if (table === 'journal_entries') {
-        return {
-          insert: (payload: Record<string, unknown>) => {
-            insertedEntry = payload;
-            return chain({ data: { id: 'je-id' }, error: null });
-          },
-        };
-      }
-      if (table === 'journal_entry_lines') {
-        return { insert: () => chain({ error: null }) };
-      }
-      if (table === 'reconciliation_boundaries') {
-        return {
-          upsert: (payload: Record<string, unknown>) => {
-            upsertedBoundary = payload;
-            return chain({ error: null });
-          },
-        };
-      }
-      throw new Error(`unexpected table: ${table}`);
-    });
+    installRpcMock({ data: null, error: null });
 
     const { result } = renderHook(() => useCalculateOpeningBalance(), { wrapper });
 
     await result.current.mutateAsync('rest-1');
 
-    const rpcCallNames = mocks.rpc.mock.calls.map((call) => call[0]);
-    expect(rpcCallNames).not.toContain('bank_txn_entry_day');
+    expect(mocks.rpc).toHaveBeenCalledWith('min_bank_txn_entry_day', {
+      p_restaurant_id: 'rest-1',
+    });
     expect(insertedEntry?.entry_date).toBe('2026-08-20');
+  });
+
+  it('throws when the entry-day RPC fails and writes nothing', async () => {
+    installRpcMock({ data: null, error: new Error('rpc down') });
+
+    const { result } = renderHook(() => useCalculateOpeningBalance(), { wrapper });
+
+    await expect(result.current.mutateAsync('rest-1')).rejects.toThrow('rpc down');
+    expect(insertedEntry).toBeNull();
+    expect(upsertedBoundary).toBeNull();
   });
 });

--- a/tests/unit/useCalculateOpeningBalance.test.ts
+++ b/tests/unit/useCalculateOpeningBalance.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+
+const mocks = vi.hoisted(() => ({
+  rpc: vi.fn(),
+  from: vi.fn(),
+}));
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: { rpc: mocks.rpc, from: mocks.from },
+}));
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { useCalculateOpeningBalance } from '@/hooks/useCalculateOpeningBalance';
+
+// A chainable thenable: every method returns the chain; awaiting it
+// resolves to the canned response.
+function chain(response: unknown) {
+  const proxy: any = new Proxy(() => proxy, {
+    get(_t, prop) {
+      if (prop === 'then') {
+        return (resolve: (v: unknown) => unknown) =>
+          Promise.resolve(response).then(resolve);
+      }
+      return () => proxy;
+    },
+  });
+  return proxy;
+}
+
+const EARLIEST_TS = '2026-02-02T03:30:00+00:00';
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return React.createElement(
+    QueryClientProvider,
+    { client: new QueryClient() },
+    children,
+  );
+}
+
+describe('useCalculateOpeningBalance entry day', () => {
+  let insertedEntry: Record<string, unknown> | null;
+  let upsertedBoundary: Record<string, unknown> | null;
+  let tableCalls: Record<string, number>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    insertedEntry = null;
+    upsertedBoundary = null;
+    tableCalls = {};
+
+    mocks.from.mockImplementation((table: string) => {
+      tableCalls[table] = (tableCalls[table] ?? 0) + 1;
+      const n = tableCalls[table];
+      if (table === 'bank_account_balances') {
+        return chain({
+          data: [{ current_balance: 1000, as_of_date: '2026-08-01' }],
+          error: null,
+        });
+      }
+      if (table === 'bank_transactions' && n === 1) {
+        return chain({
+          data: [{ amount: 200, transaction_date: EARLIEST_TS }],
+          error: null,
+        });
+      }
+      if (table === 'bank_transactions') {
+        return chain({ data: { transaction_date: EARLIEST_TS }, error: null });
+      }
+      if (table === 'chart_of_accounts' && n === 1) {
+        return chain({ data: { id: 'cash-id', account_name: 'Cash' }, error: null });
+      }
+      if (table === 'chart_of_accounts') {
+        return chain({ data: { id: 'equity-id', account_name: 'Equity' }, error: null });
+      }
+      if (table === 'restaurants') {
+        return chain({ data: { timezone: 'America/New_York' }, error: null });
+      }
+      if (table === 'journal_entries' && n === 1) {
+        return chain({ data: null, error: null });
+      }
+      if (table === 'journal_entries') {
+        return {
+          insert: (payload: Record<string, unknown>) => {
+            insertedEntry = payload;
+            return chain({ data: { id: 'je-id' }, error: null });
+          },
+        };
+      }
+      if (table === 'journal_entry_lines') {
+        return { insert: () => chain({ error: null }) };
+      }
+      if (table === 'reconciliation_boundaries') {
+        return {
+          upsert: (payload: Record<string, unknown>) => {
+            upsertedBoundary = payload;
+            return chain({ error: null });
+          },
+        };
+      }
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    mocks.rpc.mockImplementation((fnName: string) => {
+      if (fnName === 'bank_txn_entry_day') {
+        return chain({ data: '2026-02-01', error: null });
+      }
+      if (fnName === 'rebuild_account_balances') {
+        return chain({ data: null, error: null });
+      }
+      throw new Error(`unexpected rpc: ${fnName}`);
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('derives the opening date from the bank_txn_entry_day RPC', async () => {
+    const { result } = renderHook(() => useCalculateOpeningBalance(), { wrapper });
+
+    await result.current.mutateAsync('rest-1');
+
+    expect(mocks.rpc).toHaveBeenCalledWith('bank_txn_entry_day', {
+      p_ts: EARLIEST_TS,
+      p_tz: 'America/New_York',
+    });
+    expect(insertedEntry?.entry_date).toBe('2026-02-01');
+    expect(upsertedBoundary?.balance_start_date).toBe('2026-02-01');
+  });
+
+  it('falls back to today when no transaction exists', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-08-20T15:00:00Z'));
+
+    tableCalls = {};
+    mocks.from.mockImplementation((table: string) => {
+      tableCalls[table] = (tableCalls[table] ?? 0) + 1;
+      const n = tableCalls[table];
+      if (table === 'bank_account_balances') {
+        return chain({
+          data: [{ current_balance: 1000, as_of_date: '2026-08-01' }],
+          error: null,
+        });
+      }
+      if (table === 'bank_transactions' && n === 1) {
+        return chain({ data: [], error: null });
+      }
+      if (table === 'bank_transactions') {
+        return chain({ data: null, error: null });
+      }
+      if (table === 'chart_of_accounts' && n === 1) {
+        return chain({ data: { id: 'cash-id', account_name: 'Cash' }, error: null });
+      }
+      if (table === 'chart_of_accounts') {
+        return chain({ data: { id: 'equity-id', account_name: 'Equity' }, error: null });
+      }
+      if (table === 'journal_entries' && n === 1) {
+        return chain({ data: null, error: null });
+      }
+      if (table === 'journal_entries') {
+        return {
+          insert: (payload: Record<string, unknown>) => {
+            insertedEntry = payload;
+            return chain({ data: { id: 'je-id' }, error: null });
+          },
+        };
+      }
+      if (table === 'journal_entry_lines') {
+        return { insert: () => chain({ error: null }) };
+      }
+      if (table === 'reconciliation_boundaries') {
+        return {
+          upsert: (payload: Record<string, unknown>) => {
+            upsertedBoundary = payload;
+            return chain({ error: null });
+          },
+        };
+      }
+      throw new Error(`unexpected table: ${table}`);
+    });
+
+    const { result } = renderHook(() => useCalculateOpeningBalance(), { wrapper });
+
+    await result.current.mutateAsync('rest-1');
+
+    const rpcCallNames = mocks.rpc.mock.calls.map((call) => call[0]);
+    expect(rpcCallNames).not.toContain('bank_txn_entry_day');
+    expect(insertedEntry?.entry_date).toBe('2026-08-20');
+  });
+});


### PR DESCRIPTION
## Summary

- `journal_entries.entry_date` came from a UTC-day cast of `bank_transactions.transaction_date`. A transaction at 21:00 America/New_York is 01:00 UTC the next day. The entry landed on the wrong local day in the income statement.
- The new convention is a hybrid. A timestamp at exactly 00:00:00 or 12:00:00 UTC is a date anchor and keeps the UTC day. Every other timestamp is a real instant and takes the restaurant-local day.
- Reason for the hybrid: 3,991 of 8,318 production rows are date-only values stored at midnight UTC. A blanket local cast moves each of them back one day.
- One SQL helper, `bank_txn_entry_day(p_ts timestamptz, p_tz text)`, holds the convention. Every write path and every closed-period guard calls it: `categorize_bank_transaction`, `bulk_categorize_bank_transactions`, `apply_rules_to_bank_transactions_internal`, `backfill_bank_transaction_journal_entries`, and the `useCalculateOpeningBalance` client hook. The hook calls `min_bank_txn_entry_day(p_restaurant_id)`, which returns the minimum derived entry day across the restaurant's transactions on the server.
- A one-time migration re-dates existing entries from their source transactions. The closed-period guard is symmetric: a row does not move when its old day or its new day sits inside a closed period. Production blast radius (read-only count, 2026-08-20): 179 bank entries and 2 reclassification entries change `entry_date`; 0 sit in closed fiscal periods (production holds 0 closed periods).
- An invalid timezone string falls back to the UTC day (`invalid_parameter_value` handler). A null timezone falls back to `America/Chicago` (`COALESCE`), which matches the `restaurants.timezone` column default. The design doc carries a Performance note: the per-call subtransaction cost was reviewed and accepted (commit 2620351b).
- `npm run lint` fails on 1540 pre-existing errors across the wider codebase. Zero are in files this branch touches. CI has no lint step. A separate cleanup task is planned.

Design doc: [docs/superpowers/specs/2026-08-20-journal-entry-date-timezone-design.md](docs/superpowers/specs/2026-08-20-journal-entry-date-timezone-design.md)

## Test plan

- `npm run test`: 787 files, 9454 tests, 0 failures.
- `npm run test:db` (pgTAP): 2990/2990 pass. New suites: 65 (helper, 12 tests), 66 (categorize, 6), 67 (re-date, 9), 68 (minimum entry day, 4); suites 22 and 23 extended.
- `npm run test:e2e`: 215 passed, 12 skipped. One timeout in `tests/e2e/employee-payroll.spec.ts` (a file this branch does not touch) passed alone in 12.2s — environmental.
- `npm run typecheck`: exit 0. `npm run build`: pass (44.08s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
