### PR TITLE
Create journal entries when a pending outflow is matched

### DIFF
--- a/docs/superpowers/plans/2026-08-20-pending-outflow-match-journal-entries-plan.md
+++ b/docs/superpowers/plans/2026-08-20-pending-outflow-match-journal-entries-plan.md
@@ -1,0 +1,154 @@
+# Plan: create journal entries on pending-outflow match
+
+Design: `docs/superpowers/specs/2026-08-20-pending-outflow-match-journal-entries-design.md`
+Branch: `claude/optimistic-austin-73bb6a`
+
+Each task follows RED → GREEN → REFACTOR → COMMIT. Run
+`npx vitest run <file>` for the RED and GREEN steps. Stage explicit paths
+only.
+
+## Task 1: rewrite the confirmMatch category path
+
+Files: `src/hooks/usePendingOutflows.tsx`,
+`tests/unit/usePendingOutflows.test.ts`
+
+RED — add tests to the `confirmMatch` describe block:
+- "calls categorize_bank_transaction with the outflow category and the
+  merged notes": expect `supabase.rpc` called with
+  `('categorize_bank_transaction', { p_transaction_id, p_category_id:
+  'cat-456', p_description: 'Bank notes\n\nExpense notes',
+  p_normalized_payee: null, p_supplier_id: null })`.
+- "calls the RPC before the bank_transactions update": record call order
+  with a shared array.
+- "sends a metadata-only update": the `bank_transactions` update payload
+  has `matched_at`, `suggested_category_id`, `expense_invoice_upload_id`
+  and does NOT have `is_categorized`, `category_id`, or `notes`.
+- "keeps the bank notes unchanged when they already contain the outflow
+  notes": bank notes `'A\n\nB'`, outflow notes `'B'` → `p_description:
+  'A\n\nB'`.
+
+GREEN — in `confirmMatch.mutationFn`:
+1. Keep the two fetches (outflow with uploads; bank transaction `notes`).
+2. Compute `mergedNotes`: when `bankNotes?.includes(outflowNotes)`, use
+   `bankNotes`; else `[bankNotes, outflowNotes].filter(Boolean)
+   .join('\n\n')`. Normalize with `|| null`.
+3. When `pendingOutflow.category_id` exists, call
+   `supabase.rpc('categorize_bank_transaction', {...})` with
+   `p_description: mergedNotes`. Throw on error. Add a comment: the guard
+   substrings in `onError` come from
+   `supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql`.
+4. Build the metadata update: `matched_at`, `suggested_category_id` (when
+   a category exists), `expense_invoice_upload_id` (when an upload
+   exists). On the category path do not include `notes`.
+5. Keep the pending-outflow update unchanged.
+6. Return `{ pendingOutflowId, bankTransactionId, categorized: true }`.
+
+COMMIT: `fix(banking): create journal entries on pending-outflow match`
+
+## Task 2: no-category path and the success toast split
+
+Files: same as Task 1.
+
+RED:
+- "skips the RPC when the outflow has no category": `supabase.rpc` not
+  called; update payload has no `is_categorized`, no `category_id`, no
+  `suggested_category_id`; it has `matched_at` and `notes` (merged).
+- "shows the categorize reminder on a no-category match":
+  `toast.success` called with "Expense matched. Categorize the
+  transaction on the Banking page."
+- "shows the cleared toast on a categorized match": `toast.success`
+  called with "Expense matched and cleared".
+
+GREEN: branch on `pendingOutflow.category_id`; return
+`categorized: false` on the no-category path and include the merged
+`notes` in the metadata update; split the `onSuccess` toast on
+`data.categorized`.
+
+COMMIT: `fix(banking): keep an uncategorized transaction in review on match`
+
+## Task 3: guard-error mapping
+
+Files: same as Task 1.
+
+RED (use the verbatim RAISE text from the migration):
+- "maps the reconciled guard": rpc rejects with message
+  `Cannot categorize a reconciled transaction. Use reclassification
+  instead by updating the category of an already categorized
+  transaction.` → `toast.error` called with "This transaction is
+  reconciled. Reclassify it from the Banking page instead."; no
+  `bank_transactions` update; no `pending_outflows` update.
+- "maps the closed-period guard": message starts
+  `Cannot categorize transaction in closed fiscal period.` → toast
+  "This transaction is in a closed fiscal period. Reopen the period
+  before you match it."
+- "keeps the generic copy for other errors": message `boom` →
+  `Failed to confirm match: boom`.
+
+GREEN: map in `onError` with `message.includes('reconciled')` and
+`message.includes('closed fiscal period')`.
+
+COMMIT: `fix(banking): map the categorize guard errors on match`
+
+## Task 4: query invalidation extension
+
+Files: same as Task 1.
+
+RED: "invalidates the ledger queries on success": assert
+`invalidateQueries` for `['income-statement']`, `['balance-sheet']`,
+`['chart-of-accounts']` plus the existing three keys.
+
+GREEN: extend `onSuccess`.
+
+COMMIT: `fix(banking): invalidate ledger queries after a match`
+
+## Task 5: ManualMatchDialog error handling
+
+Files: `src/components/pending-outflows/ManualMatchDialog.tsx`,
+`tests/unit/manualMatchDialogError.test.tsx` (new; follow the
+`pendingOutflowsSingleDialog.test.tsx` mock style)
+
+RED: "keeps the dialog open when the match fails": mock the mutation to
+reject; click Confirm; expect `onClose` not called and no unhandled
+rejection.
+
+GREEN: wrap the `mutateAsync` call in try/catch; return on error.
+
+COMMIT: `fix(banking): keep the match dialog open on a failed confirm`
+
+## Task 6: Needs-category badge on the cleared card
+
+Files: `src/components/pending-outflows/PendingOutflowCard.tsx`,
+`tests/unit/pendingOutflowCardNeedsCategory.test.tsx` (new)
+
+RED: "shows the badge on a cleared no-category outflow" and "hides the
+badge on a cleared categorized outflow".
+
+GREEN: in the cleared branch, when `!outflow.category_id`, add a Badge
+"Needs category" beside the cleared date. Style: semantic tokens,
+`text-[11px] px-1.5 py-0.5 rounded-md bg-muted` per CLAUDE.md.
+
+COMMIT: `feat(banking): show a needs-category badge on a cleared match`
+
+## Task 7: E2E — match creates a journal entry
+
+Files: `tests/e2e/pending-outflow-match.spec.ts` (new)
+
+Follow `tests/e2e/bulk-edit-transactions.spec.ts`: `generateTestUser`,
+`signUpAndCreateRestaurant`, `exposeSupabaseHelpers`. Seed one connected
+bank, one uncategorized transaction (amount `-100`), one expense chart
+account, one pending outflow with that category and a near-equal amount.
+Open `/expenses`, open the manual match dialog (or a suggested match),
+confirm. Assert through the page Supabase helper:
+- one `journal_entries` row with `reference_type = 'bank_transaction'`
+  and `reference_id` = the transaction id, with two lines;
+- the transaction has `is_categorized = true` and `matched_at` set;
+- the outflow row has `status = 'cleared'`.
+
+Run: `npx playwright test pending-outflow-match --reporter=line` in the
+foreground.
+
+COMMIT: `test(banking): e2e for the pending-outflow match ledger write`
+
+## Task order
+
+1 → 2 → 3 → 4 (same files, sequential) → 5 → 6 → 7.

--- a/docs/superpowers/specs/2026-08-20-pending-outflow-match-journal-entries-design.md
+++ b/docs/superpowers/specs/2026-08-20-pending-outflow-match-journal-entries-design.md
@@ -1,0 +1,236 @@
+# Design: create journal entries on pending-outflow match
+
+Date: 2026-08-20
+Branch: `claude/optimistic-austin-73bb6a`
+Author: Claude (development-workflow)
+
+## Problem
+
+The pending-outflow match flow categorizes a bank transaction with a direct
+table update. It never creates a journal entry. The income statement reads
+only `journal_entry_lines`. A matched expense therefore shows $0.00 on the
+income statement.
+
+Production evidence (2026-08-19): 137 categorized transactions carry
+`matched_at` and have no journal entry. The absolute total is $103,148.41.
+
+The backfill for historical rows ships on the branch
+`fix/bulk-categorize-journal-entries`. This task stops the continuing
+producer only.
+
+## Root cause (citations)
+
+- `confirmMatch` builds a direct update with `is_categorized: true` and
+  `matched_at` ([usePendingOutflows.tsx:172-175](../../../src/hooks/usePendingOutflows.tsx)).
+- It copies `category_id` and `suggested_category_id` from the pending
+  outflow ([usePendingOutflows.tsx:177-186](../../../src/hooks/usePendingOutflows.tsx)).
+- It merges notes ([usePendingOutflows.tsx:188-194](../../../src/hooks/usePendingOutflows.tsx))
+  and links the invoice upload
+  ([usePendingOutflows.tsx:196-200](../../../src/hooks/usePendingOutflows.tsx)).
+- It writes all of this straight to `bank_transactions`
+  ([usePendingOutflows.tsx:202-208](../../../src/hooks/usePendingOutflows.tsx)).
+  No code path creates a journal entry.
+- The income statement reads only `journal_entry_lines`
+  ([IncomeStatement.tsx:207-221](../../../src/components/financial-statements/IncomeStatement.tsx)).
+- The authoritative categorize RPC `categorize_bank_transaction` creates the
+  journal entry and the lines
+  ([20260709120000_categorize_preserve_metadata_on_noop.sql:198-231](../../../supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql)),
+  handles reclassification
+  ([...sql:164-197](../../../supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql)),
+  and rebuilds account balances
+  ([...sql:246](../../../supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql)).
+
+A second defect sits in the same block. `pending_outflows.category_id` is
+nullable
+([20251107141500_pending_outflows.sql:6](../../../supabase/migrations/20251107141500_pending_outflows.sql));
+most historical rows have NULL
+([20260522120100_pending_outflows_category_index.sql:10](../../../supabase/migrations/20260522120100_pending_outflows_category_index.sql)).
+When the outflow has no category, `confirmMatch` still writes
+`is_categorized: true` with no `category_id`
+([usePendingOutflows.tsx:172-180](../../../src/hooks/usePendingOutflows.tsx)).
+The review queue filters on `is_categorized = false`
+([useBankTransactions.tsx:165-168](../../../src/hooks/useBankTransactions.tsx)),
+so that transaction leaves the queue and can never reach the income
+statement.
+
+## Approaches considered
+
+### A. Call the RPC from the hook; keep a slim metadata update (chosen)
+
+Replace the direct category write with a `categorize_bank_transaction` RPC
+call. Keep only the match-metadata fields in the direct update. This is the
+approach the task prescribes. The frontend already calls this RPC the same
+way in `useCategorizeTransaction`
+([useBankTransactions.tsx:424-430](../../../src/hooks/useBankTransactions.tsx)).
+
+- Pro: no migration. The RPC is authoritative and tested.
+- Pro: reclassification, closed-period, and reconciled guards come free.
+- Con: the flow spans three client calls. It is not atomic. See
+  "Decided trade-offs".
+
+### B. New server RPC `confirm_pending_outflow_match`
+
+One SECURITY DEFINER function does the categorize, the metadata write, and
+the outflow update in one transaction.
+
+- Pro: atomic.
+- Con: new migration, new pgTAP surface, duplicated categorize logic or a
+  nested call. Larger scope than the task asks for.
+
+### C. Append an RPC call after the existing direct update
+
+- Con: double-writes `category_id`. The direct update marks the transaction
+  categorized before the RPC guards run, so the RPC would treat the write as
+  a reclassification of the very same category and short-circuit without a
+  journal entry
+  ([...sql:89-113](../../../supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql)).
+  This approach cannot work. Rejected.
+
+Decision: **A**.
+
+## Design
+
+### `confirmMatch` flow (new order)
+
+1. Fetch the pending outflow with invoice uploads (unchanged,
+   [usePendingOutflows.tsx:142-159](../../../src/hooks/usePendingOutflows.tsx)).
+2. Fetch the bank transaction `notes` (unchanged shape,
+   [usePendingOutflows.tsx:161-169](../../../src/hooks/usePendingOutflows.tsx)).
+3. **If the outflow has a `category_id`:** call the RPC first:
+   ```ts
+   supabase.rpc('categorize_bank_transaction', {
+     p_transaction_id: bankTransactionId,
+     p_category_id: pendingOutflow.category_id,
+     p_description: null,
+     p_normalized_payee: null,
+     p_supplier_id: null,
+   })
+   ```
+   On error, throw. Nothing else has changed yet.
+4. Direct update to `bank_transactions` with **metadata only**:
+   `matched_at`, `suggested_category_id` (only when the outflow has a
+   category), merged `notes` (only when non-empty), and
+   `expense_invoice_upload_id` (only when an upload exists).
+   No `is_categorized`. No `category_id`.
+5. Update the pending outflow: `status: 'cleared'`,
+   `linked_bank_transaction_id`, `cleared_at` (unchanged,
+   [usePendingOutflows.tsx:210-220](../../../src/hooks/usePendingOutflows.tsx)).
+
+### Why the RPC runs first
+
+The RPC carries the guards: reconciled transactions
+([...sql:115-118](../../../supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql))
+and closed fiscal periods
+([...sql:131-142](../../../supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql)).
+When a guard fires, the mutation throws before any write. The match stays
+fully pending. The user sees one clear error.
+
+### Retry safety
+
+If step 4 or 5 fails after the RPC commits, the transaction is categorized
+with a correct journal entry, and the outflow stays pending. A retry calls
+the RPC again with the same category. The RPC short-circuits as a no-op and
+preserves metadata
+([...sql:89-113](../../../supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql)).
+Steps 4 and 5 then complete the match. The flow is safe to re-run.
+
+### Notes handling
+
+The RPC main path writes `notes = p_description` without COALESCE
+([...sql:239](../../../supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql)).
+The hook passes `p_description: null`, so the RPC clears `notes` for one
+step. Step 4 writes the merged notes back in the same mutation. The hook
+reads the pre-RPC `notes` in step 2, so no data is lost. When both notes are
+empty, the merged value is empty and step 4 skips the field; the cleared
+NULL equals the prior NULL.
+
+### No-category path (behavior change)
+
+When the outflow has no `category_id`, skip the RPC and do **not** set
+`is_categorized`, `category_id`, or `suggested_category_id`. Write only
+`matched_at`, merged notes, and the invoice link, then clear the outflow.
+The transaction stays in the review queue for real categorization later.
+The old behavior (categorized with no category) produced permanent
+journal-less rows.
+
+### UI error handling
+
+- `confirmMatch.onError` maps the two RPC guard errors to clear copy:
+  - message contains `reconciled` → "This transaction is reconciled.
+    Reclassify it from the Banking page instead."
+  - message contains `closed fiscal period` → "This transaction is in a
+    closed fiscal period. Reopen the period before you match it."
+  - any other error keeps the current
+    `Failed to confirm match: ${error.message}` form
+    ([usePendingOutflows.tsx:230-232](../../../src/hooks/usePendingOutflows.tsx)).
+- `ManualMatchDialog.handleConfirm` awaits `mutateAsync` and then calls
+  `onClose()` with no try/catch
+  ([ManualMatchDialog.tsx:180-189](../../../src/components/pending-outflows/ManualMatchDialog.tsx)).
+  A rejection leaves an unhandled promise and still closes nothing. Wrap the
+  await in try/catch: on error, keep the dialog open and return. The
+  mutation's `onError` toast already shows the message.
+
+### Query invalidation
+
+The match now moves ledger data. Extend `confirmMatch.onSuccess`
+([usePendingOutflows.tsx:224-229](../../../src/hooks/usePendingOutflows.tsx))
+with the same keys the bulk fix invalidates
+([useBulkTransactionActions.tsx:88-93](../../../src/hooks/useBulkTransactionActions.tsx)):
+`['income-statement']`, `['balance-sheet']`, `['chart-of-accounts']`.
+Keep the existing three keys.
+
+## Decided trade-offs
+
+1. **Non-atomic client orchestration.** Three sequential client calls can
+   stop mid-flow. The order (RPC first) makes every stop state safe and
+   every retry converge. A server-side atomic RPC (approach B) stays
+   available as a follow-up if partial states show up in production.
+2. **Guard errors block the whole match.** A reconciled or closed-period
+   transaction cannot take a metadata-only match. A silent metadata-only
+   match would recreate the journal-less state this task deletes.
+3. **Notes clear-then-restore window.** One RPC step clears `notes` before
+   step 4 restores the merged value. The window is one round trip inside one
+   mutation. Accepted; approach B would delete the window at the cost of a
+   migration.
+
+## Test plan
+
+### Unit (`tests/unit/usePendingOutflows.test.ts`, extend)
+
+The file already mocks `supabase.from` and `supabase.rpc`
+([usePendingOutflows.test.ts:8-30](../../../tests/unit/usePendingOutflows.test.ts)).
+Add cases:
+
+1. Match with category → RPC called with the outflow's category; direct
+   update contains no `is_categorized` and no `category_id`; outflow
+   cleared.
+2. RPC order → the RPC runs before the `bank_transactions` update.
+3. RPC guard error → mutation rejects; no `bank_transactions` update; no
+   outflow update; toast shows the mapped copy.
+4. No-category outflow → no RPC call; update contains only metadata; outflow
+   cleared.
+5. Notes merge preserved → merged notes still land in the direct update.
+
+### E2E (`tests/e2e/pending-outflow-match.spec.ts`, new)
+
+Follow the seeding pattern from
+[bulk-edit-transactions.spec.ts:1-77](../../../tests/e2e/bulk-edit-transactions.spec.ts):
+sign up, seed a connected bank, one uncategorized bank transaction, one
+expense category, and one pending outflow with that category. Drive the
+Expenses page ([Expenses.tsx:17-18](../../../src/pages/Expenses.tsx)) to
+confirm a match. Assert:
+
+- the pending outflow shows as cleared,
+- `journal_entries` has one row with `reference_type = 'bank_transaction'`
+  and `reference_id` = the transaction id (queried through the page's
+  Supabase helper),
+- the bank transaction has `matched_at` set and `is_categorized = true`.
+
+No pgTAP: this change adds no SQL.
+
+## Out of scope
+
+- Historical repair (owned by `fix/bulk-categorize-journal-entries`).
+- Approach B (atomic server RPC).
+- The Transfer-category read-path filtering (covered by an earlier fix, see
+  `memory/lessons.md` entry on `isTransferCategoryType`).

--- a/docs/superpowers/specs/2026-08-20-pending-outflow-match-journal-entries-design.md
+++ b/docs/superpowers/specs/2026-08-20-pending-outflow-match-journal-entries-design.md
@@ -11,8 +11,21 @@ table update. It never creates a journal entry. The income statement reads
 only `journal_entry_lines`. A matched expense therefore shows $0.00 on the
 income statement.
 
-Production evidence (2026-08-19): 137 categorized transactions carry
-`matched_at` and have no journal entry. The absolute total is $103,148.41.
+Production evidence (2026-08-19, from the task briefing): 137 categorized
+transactions carry `matched_at` and have no journal entry. The absolute
+total is $103,148.41. Reproduce with:
+
+```sql
+SELECT count(*), sum(abs(bt.amount))
+FROM bank_transactions bt
+WHERE bt.is_categorized
+  AND bt.matched_at IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM journal_entries je
+    WHERE je.reference_type = 'bank_transaction'
+      AND je.reference_id = bt.id
+  );
+```
 
 The backfill for historical rows ships on the branch
 `fix/bulk-categorize-journal-entries`. This task stops the continuing
@@ -96,23 +109,32 @@ Decision: **A**.
    [usePendingOutflows.tsx:142-159](../../../src/hooks/usePendingOutflows.tsx)).
 2. Fetch the bank transaction `notes` (unchanged shape,
    [usePendingOutflows.tsx:161-169](../../../src/hooks/usePendingOutflows.tsx)).
-3. **If the outflow has a `category_id`:** call the RPC first:
+3. Compute the merged notes with a containment guard:
+   - When the bank transaction `notes` already contains the outflow
+     `notes`, the merged value is the bank transaction `notes` unchanged.
+   - Otherwise join the two non-empty values with `\n\n` (current merge,
+     [usePendingOutflows.tsx:189-191](../../../src/hooks/usePendingOutflows.tsx)).
+   The guard makes a re-merge a no-op, so a retry cannot duplicate text.
+4. **If the outflow has a `category_id`:** call the RPC first:
    ```ts
    supabase.rpc('categorize_bank_transaction', {
      p_transaction_id: bankTransactionId,
      p_category_id: pendingOutflow.category_id,
-     p_description: null,
+     p_description: mergedNotes ?? null,
      p_normalized_payee: null,
      p_supplier_id: null,
    })
    ```
-   On error, throw. Nothing else has changed yet.
-4. Direct update to `bank_transactions` with **metadata only**:
+   On error, throw. Nothing else has changed yet. The RPC writes the
+   merged notes and the journal entry in one transaction
+   ([...sql:239](../../../supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql)).
+5. Direct update to `bank_transactions` with **metadata only**:
    `matched_at`, `suggested_category_id` (only when the outflow has a
-   category), merged `notes` (only when non-empty), and
-   `expense_invoice_upload_id` (only when an upload exists).
-   No `is_categorized`. No `category_id`.
-5. Update the pending outflow: `status: 'cleared'`,
+   category), and `expense_invoice_upload_id` (only when an upload
+   exists). No `is_categorized`. No `category_id`. On the category path,
+   no `notes` — the RPC already wrote them. On the no-category path,
+   include the merged `notes` (only when non-empty) in this update.
+6. Update the pending outflow: `status: 'cleared'`,
    `linked_bank_transaction_id`, `cleared_at` (unchanged,
    [usePendingOutflows.tsx:210-220](../../../src/hooks/usePendingOutflows.tsx)).
 
@@ -127,22 +149,32 @@ fully pending. The user sees one clear error.
 
 ### Retry safety
 
-If step 4 or 5 fails after the RPC commits, the transaction is categorized
-with a correct journal entry, and the outflow stays pending. A retry calls
-the RPC again with the same category. The RPC short-circuits as a no-op and
-preserves metadata
+If step 5 or 6 fails after the RPC commits, the transaction is categorized
+with a correct journal entry and the merged notes, and the outflow stays
+pending. A retry calls the RPC again with the same category. The RPC
+short-circuits as a no-op and preserves metadata
 ([...sql:89-113](../../../supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql)).
-Steps 4 and 5 then complete the match. The flow is safe to re-run.
+Steps 5 and 6 then complete the match. The flow is safe to re-run.
+
+The retry cannot lose or duplicate notes (Phase 2.5 supabase reviewer,
+major finding, fixed here):
+
+- The RPC writes the merged notes atomically with the categorize. No stop
+  state leaves `notes` cleared.
+- On retry, step 2 re-fetches notes that already contain the outflow
+  notes. The step-3 containment guard returns them unchanged, and the
+  RPC no-op branch preserves them with COALESCE
+  ([...sql:95-105](../../../supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql)).
 
 ### Notes handling
 
 The RPC main path writes `notes = p_description` without COALESCE
 ([...sql:239](../../../supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql)).
-The hook passes `p_description: null`, so the RPC clears `notes` for one
-step. Step 4 writes the merged notes back in the same mutation. The hook
-reads the pre-RPC `notes` in step 2, so no data is lost. When both notes are
-empty, the merged value is empty and step 4 skips the field; the cleared
-NULL equals the prior NULL.
+The hook therefore always passes the full desired notes value
+(`mergedNotes ?? null`) as `p_description`. When both notes are empty, the
+RPC writes NULL over NULL — no change. When only the bank transaction has
+notes, the merged value equals them — no change. The direct update no
+longer carries `notes` on the category path.
 
 ### No-category path (behavior change)
 
@@ -188,10 +220,17 @@ Keep the existing three keys.
 2. **Guard errors block the whole match.** A reconciled or closed-period
    transaction cannot take a metadata-only match. A silent metadata-only
    match would recreate the journal-less state this task deletes.
-3. **Notes clear-then-restore window.** One RPC step clears `notes` before
-   step 4 restores the merged value. The window is one round trip inside one
-   mutation. Accepted; approach B would delete the window at the cost of a
-   migration.
+3. **The journal entry description carries the merged notes.** The RPC
+   uses `p_description` for the journal entry description with a fallback
+   to the transaction description
+   ([...sql:174](../../../supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql),
+   [...sql:215](../../../supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql)).
+   When notes exist, the entry description shows them instead of the raw
+   transaction description. Accepted: the notes name the matched expense,
+   which is more informative in the ledger. This also fills
+   `transaction_reclassifications.reason` with the notes on a reclassify
+   ([...sql:191-197](../../../supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql));
+   with no notes, `reason` stays NULL (reviewer minor finding, accepted).
 
 ## Test plan
 
@@ -209,7 +248,11 @@ Add cases:
    outflow update; toast shows the mapped copy.
 4. No-category outflow → no RPC call; update contains only metadata; outflow
    cleared.
-5. Notes merge preserved → merged notes still land in the direct update.
+5. Notes merge preserved → the merged notes go to the RPC as
+   `p_description`; the direct update carries no `notes` on the category
+   path.
+6. Containment guard → when the bank notes already contain the outflow
+   notes, the merged value equals the bank notes (no duplication).
 
 ### E2E (`tests/e2e/pending-outflow-match.spec.ts`, new)
 

--- a/docs/superpowers/specs/2026-08-20-pending-outflow-match-journal-entries-design.md
+++ b/docs/superpowers/specs/2026-08-20-pending-outflow-match-journal-entries-design.md
@@ -171,19 +171,38 @@ major finding, fixed here):
 The RPC main path writes `notes = p_description` without COALESCE
 ([...sql:239](../../../supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql)).
 The hook therefore always passes the full desired notes value
-(`mergedNotes ?? null`) as `p_description`. When both notes are empty, the
-RPC writes NULL over NULL — no change. When only the bank transaction has
-notes, the merged value equals them — no change. The direct update no
-longer carries `notes` on the category path.
+(`mergedNotes || null`, with `||` so an empty string normalizes to NULL)
+as `p_description`. When both notes are empty, the RPC writes NULL — no
+visible change. Exception: a stored empty-string `notes` becomes NULL
+after a match; downstream reads treat both as empty (frontend reviewer,
+minor, accepted). When only the bank transaction has notes, the merged
+value equals them — no change. The direct update no longer carries
+`notes` on the category path.
 
 ### No-category path (behavior change)
 
 When the outflow has no `category_id`, skip the RPC and do **not** set
 `is_categorized`, `category_id`, or `suggested_category_id`. Write only
 `matched_at`, merged notes, and the invoice link, then clear the outflow.
-The transaction stays in the review queue for real categorization later.
+The transaction stays in the review queue for a real categorize later.
 The old behavior (categorized with no category) produced permanent
 journal-less rows.
+
+**User signal (Phase 2.5 frontend reviewer, major finding).** Without a
+signal, this state hides itself: the cleared card shows only
+"Cleared {date}"
+([PendingOutflowCard.tsx:229-233](../../../src/components/pending-outflows/PendingOutflowCard.tsx))
+and the Expenses totals exclude cleared outflows
+([Expenses.tsx:44-46](../../../src/pages/Expenses.tsx)). Two signals fix
+this:
+
+1. `confirmMatch` returns a `categorized` flag. `onSuccess` shows
+   "Expense matched and cleared" when true. When false it shows
+   "Expense matched. Categorize the transaction on the Banking page."
+2. The cleared branch of `PendingOutflowCard` adds a "Needs category"
+   badge when `outflow.category_id` is null. The state is client-derivable:
+   a cleared outflow with no category means the match skipped the
+   categorize step.
 
 ### UI error handling
 
@@ -245,9 +264,15 @@ Add cases:
    cleared.
 2. RPC order → the RPC runs before the `bank_transactions` update.
 3. RPC guard error → mutation rejects; no `bank_transactions` update; no
-   outflow update; toast shows the mapped copy.
+   outflow update; toast shows the mapped copy. Use the verbatim
+   `RAISE EXCEPTION` text from the migration
+   ([...sql:117](../../../supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql),
+   [...sql:141](../../../supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql))
+   in the test, so a future wording change in the SQL breaks the test
+   instead of a silent fallback (frontend reviewer, minor). Add a comment
+   in the hook that names the migration file next to the substrings.
 4. No-category outflow → no RPC call; update contains only metadata; outflow
-   cleared.
+   cleared; the success toast shows the categorize reminder copy.
 5. Notes merge preserved → the merged notes go to the RPC as
    `p_description`; the direct update carries no `notes` on the category
    path.
@@ -260,8 +285,13 @@ Follow the seeding pattern from
 [bulk-edit-transactions.spec.ts:1-77](../../../tests/e2e/bulk-edit-transactions.spec.ts):
 sign up, seed a connected bank, one uncategorized bank transaction, one
 expense category, and one pending outflow with that category. Drive the
-Expenses page ([Expenses.tsx:17-18](../../../src/pages/Expenses.tsx)) to
-confirm a match. Assert:
+Expenses page to confirm a match. Render chain: `Expenses.tsx` renders
+`PendingOutflowsList`
+([PendingOutflowsList.tsx:146-153](../../../src/components/pending-outflows/PendingOutflowsList.tsx)
+renders `PendingOutflowCard`), and the card renders `ManualMatchDialog`
+and `MatchSuggestionCard`
+([PendingOutflowCard.tsx:20-21](../../../src/components/pending-outflows/PendingOutflowCard.tsx)).
+Assert:
 
 - the pending outflow shows as cleared,
 - `journal_entries` has one row with `reference_type = 'bank_transaction'`
@@ -275,5 +305,8 @@ No pgTAP: this change adds no SQL.
 
 - Historical repair (owned by `fix/bulk-categorize-journal-entries`).
 - Approach B (atomic server RPC).
+- The Single Dialog Pattern violation: `ManualMatchDialog` mounts once per
+  card, not once at the list level (pre-existing; frontend reviewer,
+  minor). Risk stays low while outflow lists stay under 100 rows.
 - The Transfer-category read-path filtering (covered by an earlier fix, see
   `memory/lessons.md` entry on `isTransferCategoryType`).

--- a/src/components/pending-outflows/EditExpenseSheet.tsx
+++ b/src/components/pending-outflows/EditExpenseSheet.tsx
@@ -374,7 +374,13 @@ export function EditExpenseSheet({ expense, open, onOpenChange }: EditExpenseShe
                 }
                 filterByTypes={['expense', 'asset', 'cogs']}
                 placeholder="Select category (expense, COGS, or asset)..."
+                disabled={expense?.status === 'cleared'}
               />
+              {expense?.status === 'cleared' && (
+                <p className="text-xs text-muted-foreground">
+                  This expense is cleared. Change the category on the Banking page instead.
+                </p>
+              )}
             </div>
 
             {/* Notes */}

--- a/src/components/pending-outflows/EditExpenseSheet.tsx
+++ b/src/components/pending-outflows/EditExpenseSheet.tsx
@@ -34,6 +34,7 @@ interface EditExpenseSheetProps {
 }
 
 export function EditExpenseSheet({ expense, open, onOpenChange }: EditExpenseSheetProps) {
+  const isCleared = expense?.status === 'cleared';
   const { toast } = useToast();
   const { suppliers, createSupplier } = useSuppliers();
   const { updatePendingOutflow, deletePendingOutflow } = usePendingOutflowMutations();
@@ -374,9 +375,9 @@ export function EditExpenseSheet({ expense, open, onOpenChange }: EditExpenseShe
                 }
                 filterByTypes={['expense', 'asset', 'cogs']}
                 placeholder="Select category (expense, COGS, or asset)..."
-                disabled={expense?.status === 'cleared'}
+                disabled={isCleared}
               />
-              {expense?.status === 'cleared' && (
+              {isCleared && (
                 <p className="text-xs text-muted-foreground">
                   This expense is cleared. Change the category on the Banking page instead.
                 </p>

--- a/src/components/pending-outflows/ManualMatchDialog.tsx
+++ b/src/components/pending-outflows/ManualMatchDialog.tsx
@@ -180,10 +180,16 @@ export function ManualMatchDialog({
   async function handleConfirm(): Promise<void> {
     if (!selectedTransactionId) return;
 
-    await confirmMatch.mutateAsync({
-      pendingOutflowId: pendingOutflow.id,
-      bankTransactionId: selectedTransactionId,
-    });
+    try {
+      await confirmMatch.mutateAsync({
+        pendingOutflowId: pendingOutflow.id,
+        bankTransactionId: selectedTransactionId,
+      });
+    } catch {
+      // The mutation's onError already shows a toast. Keep the dialog
+      // open so the user can retry or pick a different transaction.
+      return;
+    }
 
     onClose();
   }

--- a/src/components/pending-outflows/ManualMatchDialog.tsx
+++ b/src/components/pending-outflows/ManualMatchDialog.tsx
@@ -131,6 +131,14 @@ export function ManualMatchDialog({
       .filter(t => {
         if (t.amount >= 0) return false;
 
+        // A transfer, an excluded row, or a split parent must never get a
+        // single-category journal entry — the bulk categorize RPC skips
+        // all three for the same reason (see
+        // supabase/migrations/20260819231210_add_bulk_categorize_bank_transactions.sql).
+        // A split parent's ledger lives in bank_transaction_splits, one row
+        // per allocation; a transfer or excluded row must not enter P&L.
+        if (t.is_transfer || t.is_split || t.excluded_reason) return false;
+
         if (!searchLower) return true;
 
         const textMatch =

--- a/src/components/pending-outflows/PendingOutflowCard.tsx
+++ b/src/components/pending-outflows/PendingOutflowCard.tsx
@@ -227,9 +227,19 @@ export const PendingOutflowCard = ({ outflow, onEdit, onPrintCheck }: PendingOut
                   </Button>
                 </div>
               ) : outflow.status === 'cleared' && outflow.cleared_at ? (
-                <span className="text-xs text-muted-foreground">
-                  Cleared {format(new Date(outflow.cleared_at), 'MMM d')}
-                </span>
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-muted-foreground">
+                    Cleared {format(new Date(outflow.cleared_at), 'MMM d')}
+                  </span>
+                  {!outflow.category_id && (
+                    <Badge
+                      variant="outline"
+                      className="text-[11px] px-1.5 py-0.5 rounded-md bg-muted"
+                    >
+                      Needs category
+                    </Badge>
+                  )}
+                </div>
               ) : null}
             </div>
           </div>

--- a/src/components/pending-outflows/PendingOutflowCard.tsx
+++ b/src/components/pending-outflows/PendingOutflowCard.tsx
@@ -234,7 +234,7 @@ export const PendingOutflowCard = ({ outflow, onEdit, onPrintCheck }: PendingOut
                   {!outflow.category_id && (
                     <Badge
                       variant="outline"
-                      className="text-[11px] px-1.5 py-0.5 rounded-md bg-muted"
+                      className="text-[11px] px-1.5 py-0.5 rounded-md bg-muted text-muted-foreground"
                     >
                       Needs category
                     </Badge>

--- a/src/hooks/useBankTransactions.tsx
+++ b/src/hooks/useBankTransactions.tsx
@@ -430,11 +430,28 @@ export function useCategorizeTransaction() {
       });
 
       if (error) throw error;
+
+      // A pending outflow can clear with no category when it was matched to
+      // an uncategorized transaction (usePendingOutflows.confirmMatch), and
+      // then shows a "Needs category" badge until this transaction gets a
+      // category. Categorizing it here must sync that outflow, or the badge
+      // never clears. Scoped to a cleared, still-uncategorized outflow so a
+      // normal (non-matched) categorization stays a no-op.
+      const { error: syncError } = await supabase
+        .from('pending_outflows')
+        .update({ category_id: categoryId })
+        .eq('linked_bank_transaction_id', transactionId)
+        .eq('status', 'cleared')
+        .is('category_id', null);
+
+      if (syncError) throw syncError;
+
       return data;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['bank-transactions'] });
       queryClient.invalidateQueries({ queryKey: ['chart-of-accounts'] });
+      queryClient.invalidateQueries({ queryKey: ['pending-outflows'] });
       toast({
         title: "Transaction categorized",
         description: "The transaction has been successfully categorized.",

--- a/src/hooks/usePendingOutflows.tsx
+++ b/src/hooks/usePendingOutflows.tsx
@@ -177,34 +177,40 @@ export function usePendingOutflowMutations() {
         ? bankNotes
         : ([bankNotes, outflowNotes].filter(Boolean).join('\n\n') || null);
 
+      // A bank transaction can carry a category_id with no journal entry,
+      // from a write path outside categorize_bank_transaction. Any code
+      // path that treats the transaction's existing category as ledger-
+      // backed must check this first, or it recreates a journal-less
+      // categorized state.
+      const hasJournalEntry = async () => {
+        const { data: existingEntry, error: journalCheckError } = await supabase
+          .from('journal_entries')
+          .select('id')
+          .eq('reference_type', 'bank_transaction')
+          .eq('reference_id', bankTransactionId)
+          .maybeSingle();
+
+        if (journalCheckError) throw journalCheckError;
+        return !!existingEntry;
+      };
+
       // Prepare the metadata-only update for bank_transactions.
       const bankTransactionUpdates: any = {
         matched_at: new Date().toISOString(),
       };
+
+      let categorized = false;
 
       if (pendingOutflow.category_id) {
         // The RPC returns journal_entry_id: null when the transaction
         // already has this exact category
         // (supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql:90-113).
         // That skip assumes a journal entry already exists from the first
-        // categorize. A transaction can be is_categorized with no journal
-        // entry, from a write path outside this RPC. Block the match in
-        // that case. A silent match would hide a missing journal entry
-        // (Codex review finding).
-        if (bankTransaction.category_id === pendingOutflow.category_id) {
-          const { data: existingEntry, error: journalCheckError } = await supabase
-            .from('journal_entries')
-            .select('id')
-            .eq('reference_type', 'bank_transaction')
-            .eq('reference_id', bankTransactionId)
-            .maybeSingle();
-
-          if (journalCheckError) throw journalCheckError;
-          if (!existingEntry) {
-            throw new Error(
-              'This transaction is already categorized but has no journal entry. Recategorize it on the Banking page, then match again.'
-            );
-          }
+        // categorize. Block the match when one does not.
+        if (bankTransaction.category_id === pendingOutflow.category_id && !(await hasJournalEntry())) {
+          throw new Error(
+            'This transaction is already categorized but has no journal entry. Recategorize it on the Banking page, then match again.'
+          );
         }
 
         // The RPC applies the category, writes the merged notes, and posts
@@ -225,6 +231,7 @@ export function usePendingOutflowMutations() {
         // Copy the category as the AI suggestion. Do not set category_id
         // or is_categorized here — the RPC above already wrote them.
         bankTransactionUpdates.suggested_category_id = pendingOutflow.category_id;
+        categorized = true;
       } else if (mergedNotes) {
         // No category to apply through the RPC. Write the merged notes directly.
         bankTransactionUpdates.notes = mergedNotes;
@@ -255,9 +262,12 @@ export function usePendingOutflowMutations() {
       // the cleared card (PendingOutflowCard.tsx). When the outflow had no
       // category but the matched transaction was already categorized, copy
       // that category onto the outflow so the badge does not show a false
-      // "needs category" state (sound-logic review finding).
-      if (!pendingOutflow.category_id && bankTransaction.category_id) {
+      // "needs category" state. Only copy it when a journal entry backs
+      // the transaction's category — otherwise the badge would hide the
+      // same journal-less state this task fixes.
+      if (!pendingOutflow.category_id && bankTransaction.category_id && (await hasJournalEntry())) {
         pendingOutflowUpdates.category_id = bankTransaction.category_id;
+        categorized = true;
       }
 
       const { error: poError } = await supabase
@@ -270,7 +280,7 @@ export function usePendingOutflowMutations() {
       return {
         pendingOutflowId,
         bankTransactionId,
-        categorized: !!(pendingOutflow.category_id || bankTransaction.category_id),
+        categorized,
       };
     },
     onSuccess: (data) => {

--- a/src/hooks/usePendingOutflows.tsx
+++ b/src/hooks/usePendingOutflows.tsx
@@ -232,13 +232,17 @@ export function usePendingOutflowMutations() {
 
       if (poError) throw poError;
 
-      return { pendingOutflowId, bankTransactionId, categorized: true };
+      return { pendingOutflowId, bankTransactionId, categorized: !!pendingOutflow.category_id };
     },
-    onSuccess: () => {
+    onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ['pending-outflows'] });
       queryClient.invalidateQueries({ queryKey: ['bank-transactions'] });
       queryClient.invalidateQueries({ queryKey: ['pending-outflow-matches'] });
-      toast.success('Expense matched and cleared');
+      toast.success(
+        data.categorized
+          ? 'Expense matched and cleared'
+          : 'Expense matched. Categorize the transaction on the Banking page.'
+      );
     },
     onError: (error) => {
       toast.error(`Failed to confirm match: ${error.message}`);

--- a/src/hooks/usePendingOutflows.tsx
+++ b/src/hooks/usePendingOutflows.tsx
@@ -183,6 +183,30 @@ export function usePendingOutflowMutations() {
       };
 
       if (pendingOutflow.category_id) {
+        // The RPC returns journal_entry_id: null when the transaction
+        // already has this exact category
+        // (supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql:90-113).
+        // That skip assumes a journal entry already exists from the first
+        // categorize. A transaction can be is_categorized with no journal
+        // entry, from a write path outside this RPC. Block the match in
+        // that case. A silent match would hide a missing journal entry
+        // (Codex review finding).
+        if (bankTransaction.category_id === pendingOutflow.category_id) {
+          const { data: existingEntry, error: journalCheckError } = await supabase
+            .from('journal_entries')
+            .select('id')
+            .eq('reference_type', 'bank_transaction')
+            .eq('reference_id', bankTransactionId)
+            .maybeSingle();
+
+          if (journalCheckError) throw journalCheckError;
+          if (!existingEntry) {
+            throw new Error(
+              'This transaction is already categorized but has no journal entry. Recategorize it on the Banking page, then match again.'
+            );
+          }
+        }
+
         // The RPC applies the category, writes the merged notes, and posts
         // the matching journal entry in one database transaction. It also
         // blocks a reconciled transaction and a closed fiscal period — the
@@ -221,18 +245,33 @@ export function usePendingOutflowMutations() {
       if (btError) throw btError;
 
       // Update pending outflow
+      const pendingOutflowUpdates: Record<string, unknown> = {
+        status: 'cleared',
+        linked_bank_transaction_id: bankTransactionId,
+        cleared_at: new Date().toISOString(),
+      };
+
+      // The outflow's own category_id drives the "Needs category" badge on
+      // the cleared card (PendingOutflowCard.tsx). When the outflow had no
+      // category but the matched transaction was already categorized, copy
+      // that category onto the outflow so the badge does not show a false
+      // "needs category" state (sound-logic review finding).
+      if (!pendingOutflow.category_id && bankTransaction.category_id) {
+        pendingOutflowUpdates.category_id = bankTransaction.category_id;
+      }
+
       const { error: poError } = await supabase
         .from('pending_outflows')
-        .update({
-          status: 'cleared',
-          linked_bank_transaction_id: bankTransactionId,
-          cleared_at: new Date().toISOString(),
-        })
+        .update(pendingOutflowUpdates)
         .eq('id', pendingOutflowId);
 
       if (poError) throw poError;
 
-      return { pendingOutflowId, bankTransactionId, categorized: !!pendingOutflow.category_id };
+      return {
+        pendingOutflowId,
+        bankTransactionId,
+        categorized: !!(pendingOutflow.category_id || bankTransaction.category_id),
+      };
     },
     onSuccess: (data) => {
       queryClient.invalidateQueries({ queryKey: ['pending-outflows'] });

--- a/src/hooks/usePendingOutflows.tsx
+++ b/src/hooks/usePendingOutflows.tsx
@@ -238,6 +238,9 @@ export function usePendingOutflowMutations() {
       queryClient.invalidateQueries({ queryKey: ['pending-outflows'] });
       queryClient.invalidateQueries({ queryKey: ['bank-transactions'] });
       queryClient.invalidateQueries({ queryKey: ['pending-outflow-matches'] });
+      queryClient.invalidateQueries({ queryKey: ['income-statement'] });
+      queryClient.invalidateQueries({ queryKey: ['balance-sheet'] });
+      queryClient.invalidateQueries({ queryKey: ['chart-of-accounts'] });
       toast.success(
         data.categorized
           ? 'Expense matched and cleared'

--- a/src/hooks/usePendingOutflows.tsx
+++ b/src/hooks/usePendingOutflows.tsx
@@ -161,12 +161,23 @@ export function usePendingOutflowMutations() {
       // Fetch current bank transaction to merge notes
       const { data: bankTransaction, error: btFetchError } = await supabase
         .from('bank_transactions')
-        .select('notes, category_id, suggested_category_id')
+        .select('notes, category_id, suggested_category_id, is_transfer, is_split, excluded_reason')
         .eq('id', bankTransactionId)
         .single();
 
       if (btFetchError) throw btFetchError;
       if (!bankTransaction) throw new Error('Bank transaction not found');
+
+      // A transfer, an excluded row, or a split parent must never get a
+      // single-category journal entry. ManualMatchDialog filters these out,
+      // but a stale row list or a direct call must not rely on the UI alone
+      // for a financial write — see the same guard the bulk categorize RPC
+      // applies (supabase/migrations/20260819231210_add_bulk_categorize_bank_transactions.sql).
+      if (bankTransaction.is_transfer || bankTransaction.is_split || bankTransaction.excluded_reason) {
+        throw new Error(
+          'This transaction is a transfer, a split, or excluded and cannot be matched here.'
+        );
+      }
 
       // Merge notes. A retry that already ran the merge must not duplicate
       // the outflow notes, so skip the merge when the bank notes already
@@ -195,7 +206,7 @@ export function usePendingOutflowMutations() {
       };
 
       // Prepare the metadata-only update for bank_transactions.
-      const bankTransactionUpdates: any = {
+      const bankTransactionUpdates: Record<string, unknown> = {
         matched_at: new Date().toISOString(),
       };
 

--- a/src/hooks/usePendingOutflows.tsx
+++ b/src/hooks/usePendingOutflows.tsx
@@ -168,28 +168,41 @@ export function usePendingOutflowMutations() {
       if (btFetchError) throw btFetchError;
       if (!bankTransaction) throw new Error('Bank transaction not found');
 
-      // Prepare updates for bank transaction
+      // Merge notes. A retry that already ran the merge must not duplicate
+      // the outflow notes, so skip the merge when the bank notes already
+      // contain them.
+      const bankNotes = bankTransaction.notes as string | null;
+      const outflowNotes = pendingOutflow.notes as string | null;
+      const mergedNotes = (bankNotes && outflowNotes && bankNotes.includes(outflowNotes))
+        ? bankNotes
+        : ([bankNotes, outflowNotes].filter(Boolean).join('\n\n') || null);
+
+      // Prepare the metadata-only update for bank_transactions.
       const bankTransactionUpdates: any = {
-        is_categorized: true,
         matched_at: new Date().toISOString(),
       };
 
-      // Copy category_id from pending outflow (overrides bank transaction's existing category)
       if (pendingOutflow.category_id) {
-        bankTransactionUpdates.category_id = pendingOutflow.category_id;
-      }
+        // The RPC applies the category, writes the merged notes, and posts
+        // the matching journal entry in one database transaction. It also
+        // blocks a reconciled transaction and a closed fiscal period — the
+        // guard text in onError matches
+        // supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql.
+        const { error: categorizeError } = await supabase.rpc('categorize_bank_transaction', {
+          p_transaction_id: bankTransactionId,
+          p_category_id: pendingOutflow.category_id,
+          p_description: mergedNotes,
+          p_normalized_payee: null,
+          p_supplier_id: null,
+        });
 
-      // Copy suggested_category_id from pending outflow's category as AI suggestion
-      if (pendingOutflow.category_id) {
+        if (categorizeError) throw categorizeError;
+
+        // Copy the category as the AI suggestion. Do not set category_id
+        // or is_categorized here — the RPC above already wrote them.
         bankTransactionUpdates.suggested_category_id = pendingOutflow.category_id;
-        // Note: AI confidence and reasoning would be set here if available from invoice processing
-      }
-
-      // Merge notes: append pending outflow notes to existing bank transaction notes
-      const mergedNotes = [bankTransaction.notes, pendingOutflow.notes]
-        .filter(Boolean)
-        .join('\n\n');
-      if (mergedNotes) {
+      } else if (mergedNotes) {
+        // No category to apply through the RPC. Write the merged notes directly.
         bankTransactionUpdates.notes = mergedNotes;
       }
 
@@ -219,7 +232,7 @@ export function usePendingOutflowMutations() {
 
       if (poError) throw poError;
 
-      return { pendingOutflowId, bankTransactionId };
+      return { pendingOutflowId, bankTransactionId, categorized: true };
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['pending-outflows'] });

--- a/src/hooks/usePendingOutflows.tsx
+++ b/src/hooks/usePendingOutflows.tsx
@@ -245,7 +245,16 @@ export function usePendingOutflowMutations() {
       );
     },
     onError: (error) => {
-      toast.error(`Failed to confirm match: ${error.message}`);
+      // Map the categorize_bank_transaction guard errors to Banking-page
+      // copy. The raw text comes from
+      // supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql.
+      if (error.message.includes('reconciled')) {
+        toast.error('This transaction is reconciled. Reclassify it from the Banking page instead.');
+      } else if (error.message.includes('closed fiscal period')) {
+        toast.error('This transaction is in a closed fiscal period. Reopen the period before you match it.');
+      } else {
+        toast.error(`Failed to confirm match: ${error.message}`);
+      }
     },
   });
 

--- a/src/hooks/usePendingOutflows.tsx
+++ b/src/hooks/usePendingOutflows.tsx
@@ -202,12 +202,18 @@ export function usePendingOutflowMutations() {
       let categorized = false;
 
       if (pendingOutflow.category_id) {
-        // The RPC returns journal_entry_id: null when the transaction
-        // already has this exact category
-        // (supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql:90-113).
-        // That skip assumes a journal entry already exists from the first
-        // categorize. Block the match when one does not.
-        if (bankTransaction.category_id === pendingOutflow.category_id && !(await hasJournalEntry())) {
+        // The RPC treats ANY already-categorized transaction as a
+        // reclassification, same category or not
+        // (supabase/migrations/20260709120000_categorize_preserve_metadata_on_noop.sql:84-87).
+        // The same-category branch (...sql:90-113) skips the journal entry
+        // outright. The different-category branch (...sql:164-197) credits
+        // the transaction's EXISTING category account without checking a
+        // journal entry backs it — a spurious credit with no offsetting
+        // debit when one does not. Both branches assume a journal entry
+        // already exists from the first categorize. Block the match
+        // whenever the transaction already carries any category and none
+        // does, not only when the categories match.
+        if (bankTransaction.category_id && !(await hasJournalEntry())) {
           throw new Error(
             'This transaction is already categorized but has no journal entry. Recategorize it on the Banking page, then match again.'
           );

--- a/tests/e2e/pending-outflow-match.spec.ts
+++ b/tests/e2e/pending-outflow-match.spec.ts
@@ -1,0 +1,152 @@
+import { test, expect } from '@playwright/test';
+import { exposeSupabaseHelpers, generateTestUser, signUpAndCreateRestaurant } from '../helpers/e2e-supabase';
+
+test.describe('Pending Outflow Match Journal Entry', () => {
+  test('manual match writes a balanced journal entry and clears the outflow', async ({ page }) => {
+    const user = generateTestUser('pending-outflow-match');
+    await signUpAndCreateRestaurant(page, user);
+
+    await exposeSupabaseHelpers(page);
+
+    // Seed one connected bank, one uncategorized transaction (-100), one
+    // expense chart account, and one pending outflow with that category and
+    // a near-equal amount.
+    const seed = await page.evaluate(async () => {
+      const authUser = await (window as any).__getAuthUser();
+      if (!authUser?.id) throw new Error('No user session');
+
+      const restaurantId = await (window as any).__getRestaurantId(authUser.id);
+      if (!restaurantId) throw new Error('No restaurant');
+
+      const { data: bank, error: bankError } = await (window as any).__supabase
+        .from('connected_banks')
+        .insert({
+          restaurant_id: restaurantId,
+          stripe_financial_account_id: `test-bank-${crypto.randomUUID()}`,
+          institution_name: 'Test Bank',
+          status: 'connected',
+        })
+        .select()
+        .single();
+      if (bankError) throw bankError;
+
+      const { data: transaction, error: txnError } = await (window as any).__supabase
+        .from('bank_transactions')
+        .insert({
+          restaurant_id: restaurantId,
+          connected_bank_id: bank.id,
+          stripe_transaction_id: `test-txn-${crypto.randomUUID()}`,
+          description: 'Match Test Vendor Payment',
+          amount: -100.0,
+          transaction_date: new Date().toISOString().split('T')[0],
+          is_categorized: false,
+        })
+        .select()
+        .single();
+      if (txnError) throw txnError;
+
+      const { data: account, error: acctError } = await (window as any).__supabase
+        .from('chart_of_accounts')
+        .select('id')
+        .eq('restaurant_id', restaurantId)
+        .eq('account_type', 'expense')
+        .limit(1)
+        .single();
+      if (acctError) throw acctError;
+
+      const { data: outflow, error: outflowError } = await (window as any).__supabase
+        .from('pending_outflows')
+        .insert({
+          restaurant_id: restaurantId,
+          vendor_name: 'Match Test Vendor',
+          category_id: account.id,
+          payment_method: 'check',
+          amount: 99.95,
+          issue_date: new Date().toISOString().split('T')[0],
+          status: 'pending',
+        })
+        .select()
+        .single();
+      if (outflowError) throw outflowError;
+
+      return { restaurantId, transactionId: transaction.id, outflowId: outflow.id };
+    });
+
+    await page.goto('/expenses');
+    await expect(page.getByRole('heading', { name: 'Expenses', exact: true })).toBeVisible();
+
+    // Open the manual match dialog for the seeded outflow.
+    const manualMatchButton = page.getByRole('button', { name: 'Manual match transaction' });
+    await expect(manualMatchButton).toBeVisible({ timeout: 10000 });
+    await manualMatchButton.click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog.getByRole('heading', { name: /manual match transaction/i })).toBeVisible();
+
+    // Select the seeded transaction and confirm the match.
+    const transactionRow = dialog.getByRole('button', { name: /Match Test Vendor Payment/i });
+    await expect(transactionRow).toBeVisible({ timeout: 10000 });
+    await transactionRow.click();
+
+    const confirmButton = dialog.getByRole('button', { name: /^confirm match$/i });
+    await expect(confirmButton).toBeEnabled();
+    await confirmButton.click();
+
+    // A category is set on the outflow, so confirmMatch runs the categorize
+    // RPC and reports the transaction as categorized in its success toast.
+    await expect(page.getByText(/expense matched and cleared/i)).toBeVisible({ timeout: 10000 });
+    await expect(dialog).toBeHidden({ timeout: 10000 });
+
+    // Verify the ledger write, the transaction metadata, and the outflow
+    // status through the page's own Supabase session.
+    const result = await page.evaluate(async ({ transactionId, outflowId }) => {
+      const { data: entries, error: entriesError } = await (window as any).__supabase
+        .from('journal_entries')
+        .select('id, reference_type, reference_id, is_balanced')
+        .eq('reference_type', 'bank_transaction')
+        .eq('reference_id', transactionId);
+      if (entriesError) throw entriesError;
+
+      const entry = entries?.[0];
+      let lineCount = 0;
+      if (entry) {
+        const { data: lines, error: linesError } = await (window as any).__supabase
+          .from('journal_entry_lines')
+          .select('id')
+          .eq('journal_entry_id', entry.id);
+        if (linesError) throw linesError;
+        lineCount = lines?.length ?? 0;
+      }
+
+      const { data: transaction, error: txnError } = await (window as any).__supabase
+        .from('bank_transactions')
+        .select('is_categorized, matched_at')
+        .eq('id', transactionId)
+        .single();
+      if (txnError) throw txnError;
+
+      const { data: outflow, error: outflowError } = await (window as any).__supabase
+        .from('pending_outflows')
+        .select('status')
+        .eq('id', outflowId)
+        .single();
+      if (outflowError) throw outflowError;
+
+      return {
+        entryCount: entries?.length ?? 0,
+        isBalanced: entry?.is_balanced ?? null,
+        lineCount,
+        isCategorized: transaction?.is_categorized ?? null,
+        matchedAt: transaction?.matched_at ?? null,
+        outflowStatus: outflow?.status ?? null,
+      };
+    }, { transactionId: seed.transactionId, outflowId: seed.outflowId });
+
+    expect(result.entryCount).toBe(1);
+    expect(result.isBalanced).toBe(true);
+    expect(result.lineCount).toBe(2);
+    expect(result.isCategorized).toBe(true);
+    expect(result.matchedAt).not.toBeNull();
+    expect(result.outflowStatus).toBe('cleared');
+  });
+});

--- a/tests/e2e/pending-outflow-match.spec.ts
+++ b/tests/e2e/pending-outflow-match.spec.ts
@@ -17,13 +17,14 @@ test.describe('Pending Outflow Match Journal Entry', () => {
     // expense chart account, and one pending outflow with that category and
     // a near-equal amount.
     const seed = await page.evaluate(async () => {
-      const authUser = await (window as unknown as E2EHelperWindow).__getAuthUser();
+      const win = window as unknown as E2EHelperWindow;
+      const authUser = await win.__getAuthUser();
       if (!authUser?.id) throw new Error('No user session');
 
-      const restaurantId = await (window as unknown as E2EHelperWindow).__getRestaurantId(authUser.id);
+      const restaurantId = await win.__getRestaurantId(authUser.id);
       if (!restaurantId) throw new Error('No restaurant');
 
-      const { data: bank, error: bankError } = await (window as unknown as E2EHelperWindow).__supabase
+      const { data: bank, error: bankError } = await win.__supabase
         .from('connected_banks')
         .insert({
           restaurant_id: restaurantId,
@@ -35,7 +36,7 @@ test.describe('Pending Outflow Match Journal Entry', () => {
         .single();
       if (bankError) throw bankError;
 
-      const { data: transaction, error: txnError } = await (window as unknown as E2EHelperWindow).__supabase
+      const { data: transaction, error: txnError } = await win.__supabase
         .from('bank_transactions')
         .insert({
           restaurant_id: restaurantId,
@@ -50,7 +51,7 @@ test.describe('Pending Outflow Match Journal Entry', () => {
         .single();
       if (txnError) throw txnError;
 
-      const { data: account, error: acctError } = await (window as unknown as E2EHelperWindow).__supabase
+      const { data: account, error: acctError } = await win.__supabase
         .from('chart_of_accounts')
         .select('id')
         .eq('restaurant_id', restaurantId)
@@ -59,7 +60,7 @@ test.describe('Pending Outflow Match Journal Entry', () => {
         .single();
       if (acctError) throw acctError;
 
-      const { data: outflow, error: outflowError } = await (window as unknown as E2EHelperWindow).__supabase
+      const { data: outflow, error: outflowError } = await win.__supabase
         .from('pending_outflows')
         .insert({
           restaurant_id: restaurantId,
@@ -105,7 +106,8 @@ test.describe('Pending Outflow Match Journal Entry', () => {
     // Verify the ledger write, the transaction metadata, and the outflow
     // status through the page's own Supabase session.
     const result = await page.evaluate(async ({ transactionId, outflowId }) => {
-      const { data: entries, error: entriesError } = await (window as unknown as E2EHelperWindow).__supabase
+      const win = window as unknown as E2EHelperWindow;
+      const { data: entries, error: entriesError } = await win.__supabase
         .from('journal_entries')
         .select('id, reference_type, reference_id, is_balanced')
         .eq('reference_type', 'bank_transaction')
@@ -115,7 +117,7 @@ test.describe('Pending Outflow Match Journal Entry', () => {
       const entry = entries?.[0];
       let lineCount = 0;
       if (entry) {
-        const { data: lines, error: linesError } = await (window as unknown as E2EHelperWindow).__supabase
+        const { data: lines, error: linesError } = await win.__supabase
           .from('journal_entry_lines')
           .select('id')
           .eq('journal_entry_id', entry.id);
@@ -123,14 +125,14 @@ test.describe('Pending Outflow Match Journal Entry', () => {
         lineCount = lines?.length ?? 0;
       }
 
-      const { data: transaction, error: txnError } = await (window as unknown as E2EHelperWindow).__supabase
+      const { data: transaction, error: txnError } = await win.__supabase
         .from('bank_transactions')
         .select('is_categorized, matched_at')
         .eq('id', transactionId)
         .single();
       if (txnError) throw txnError;
 
-      const { data: outflow, error: outflowError } = await (window as unknown as E2EHelperWindow).__supabase
+      const { data: outflow, error: outflowError } = await win.__supabase
         .from('pending_outflows')
         .select('status')
         .eq('id', outflowId)

--- a/tests/e2e/pending-outflow-match.spec.ts
+++ b/tests/e2e/pending-outflow-match.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from '@playwright/test';
-import { exposeSupabaseHelpers, generateTestUser, signUpAndCreateRestaurant } from '../helpers/e2e-supabase';
+import {
+  exposeSupabaseHelpers,
+  generateTestUser,
+  signUpAndCreateRestaurant,
+  type E2EHelperWindow,
+} from '../helpers/e2e-supabase';
 
 test.describe('Pending Outflow Match Journal Entry', () => {
   test('manual match writes a balanced journal entry and clears the outflow', async ({ page }) => {
@@ -12,13 +17,13 @@ test.describe('Pending Outflow Match Journal Entry', () => {
     // expense chart account, and one pending outflow with that category and
     // a near-equal amount.
     const seed = await page.evaluate(async () => {
-      const authUser = await (window as any).__getAuthUser();
+      const authUser = await (window as unknown as E2EHelperWindow).__getAuthUser();
       if (!authUser?.id) throw new Error('No user session');
 
-      const restaurantId = await (window as any).__getRestaurantId(authUser.id);
+      const restaurantId = await (window as unknown as E2EHelperWindow).__getRestaurantId(authUser.id);
       if (!restaurantId) throw new Error('No restaurant');
 
-      const { data: bank, error: bankError } = await (window as any).__supabase
+      const { data: bank, error: bankError } = await (window as unknown as E2EHelperWindow).__supabase
         .from('connected_banks')
         .insert({
           restaurant_id: restaurantId,
@@ -30,7 +35,7 @@ test.describe('Pending Outflow Match Journal Entry', () => {
         .single();
       if (bankError) throw bankError;
 
-      const { data: transaction, error: txnError } = await (window as any).__supabase
+      const { data: transaction, error: txnError } = await (window as unknown as E2EHelperWindow).__supabase
         .from('bank_transactions')
         .insert({
           restaurant_id: restaurantId,
@@ -45,7 +50,7 @@ test.describe('Pending Outflow Match Journal Entry', () => {
         .single();
       if (txnError) throw txnError;
 
-      const { data: account, error: acctError } = await (window as any).__supabase
+      const { data: account, error: acctError } = await (window as unknown as E2EHelperWindow).__supabase
         .from('chart_of_accounts')
         .select('id')
         .eq('restaurant_id', restaurantId)
@@ -54,7 +59,7 @@ test.describe('Pending Outflow Match Journal Entry', () => {
         .single();
       if (acctError) throw acctError;
 
-      const { data: outflow, error: outflowError } = await (window as any).__supabase
+      const { data: outflow, error: outflowError } = await (window as unknown as E2EHelperWindow).__supabase
         .from('pending_outflows')
         .insert({
           restaurant_id: restaurantId,
@@ -100,7 +105,7 @@ test.describe('Pending Outflow Match Journal Entry', () => {
     // Verify the ledger write, the transaction metadata, and the outflow
     // status through the page's own Supabase session.
     const result = await page.evaluate(async ({ transactionId, outflowId }) => {
-      const { data: entries, error: entriesError } = await (window as any).__supabase
+      const { data: entries, error: entriesError } = await (window as unknown as E2EHelperWindow).__supabase
         .from('journal_entries')
         .select('id, reference_type, reference_id, is_balanced')
         .eq('reference_type', 'bank_transaction')
@@ -110,7 +115,7 @@ test.describe('Pending Outflow Match Journal Entry', () => {
       const entry = entries?.[0];
       let lineCount = 0;
       if (entry) {
-        const { data: lines, error: linesError } = await (window as any).__supabase
+        const { data: lines, error: linesError } = await (window as unknown as E2EHelperWindow).__supabase
           .from('journal_entry_lines')
           .select('id')
           .eq('journal_entry_id', entry.id);
@@ -118,14 +123,14 @@ test.describe('Pending Outflow Match Journal Entry', () => {
         lineCount = lines?.length ?? 0;
       }
 
-      const { data: transaction, error: txnError } = await (window as any).__supabase
+      const { data: transaction, error: txnError } = await (window as unknown as E2EHelperWindow).__supabase
         .from('bank_transactions')
         .select('is_categorized, matched_at')
         .eq('id', transactionId)
         .single();
       if (txnError) throw txnError;
 
-      const { data: outflow, error: outflowError } = await (window as any).__supabase
+      const { data: outflow, error: outflowError } = await (window as unknown as E2EHelperWindow).__supabase
         .from('pending_outflows')
         .select('status')
         .eq('id', outflowId)

--- a/tests/unit/manualMatchDialogError.test.tsx
+++ b/tests/unit/manualMatchDialogError.test.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// Design doc: confirmMatch can reject (a guard error, a network error). The
+// dialog must stay open on a failed confirm, and the rejection must not
+// escape as an unhandled promise rejection from the click handler.
+
+// jsdom never runs layout, so every element's offsetHeight is 0.
+// @tanstack/react-virtual measures its scroll container via `offsetHeight`
+// and only computes a visible range when that size is > 0 — without this
+// stub, getVirtualItems() always returns [] and the row never renders.
+// Same pattern as tests/unit/VirtualizedProductGrid.test.tsx.
+let offsetHeightSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  offsetHeightSpy = vi
+    .spyOn(HTMLElement.prototype, 'offsetHeight', 'get')
+    .mockReturnValue(800);
+});
+
+afterEach(() => {
+  offsetHeightSpy.mockRestore();
+});
+
+const confirmMatchMutateAsync = vi.fn();
+
+vi.mock('@/hooks/usePendingOutflows', () => ({
+  usePendingOutflowMutations: () => ({
+    confirmMatch: { mutateAsync: confirmMatchMutateAsync, isPending: false },
+  }),
+}));
+
+vi.mock('@/hooks/useBankTransactions', () => ({
+  useBankTransactionsWithRelations: () => ({
+    data: [
+      {
+        id: 'txn-1',
+        restaurant_id: 'rest-1',
+        connected_bank_id: 'bank-1',
+        transaction_date: '2026-05-20',
+        posted_date: '2026-05-20',
+        amount: -100,
+        description: 'Vendor payment',
+        merchant_name: 'Acme Supply',
+        normalized_payee: 'acme supply',
+        category_id: null,
+        suggested_category_id: null,
+        suggested_payee: null,
+        supplier_id: null,
+        expense_invoice_upload_id: null,
+        status: 'active',
+        is_categorized: false,
+        is_reconciled: false,
+        is_split: false,
+        is_transfer: false,
+        transfer_pair_id: null,
+        excluded_reason: null,
+        ai_confidence: null,
+        ai_reasoning: null,
+        notes: null,
+        created_at: '2026-05-20T00:00:00Z',
+        updated_at: '2026-05-20T00:00:00Z',
+        connected_bank: { id: 'bank-1', institution_name: 'First National' },
+      },
+    ],
+    isLoading: false,
+  }),
+}));
+
+import { ManualMatchDialog } from '@/components/pending-outflows/ManualMatchDialog';
+import type { PendingOutflow } from '@/types/pending-outflows';
+
+const pendingOutflow: PendingOutflow = {
+  id: 'pof-1',
+  restaurant_id: 'rest-1',
+  vendor_name: 'Acme Supply',
+  category_id: null,
+  payment_method: 'check',
+  amount: 100,
+  issue_date: '2026-05-22',
+  due_date: null,
+  notes: null,
+  reference_number: null,
+  status: 'pending',
+  linked_bank_transaction_id: null,
+  cleared_at: null,
+  voided_at: null,
+  voided_reason: null,
+  created_at: '2026-05-22T00:00:00Z',
+  updated_at: '2026-05-22T00:00:00Z',
+  chart_account: null,
+};
+
+const capturedRejections: unknown[] = [];
+function captureRejection(reason: unknown): void {
+  capturedRejections.push(reason);
+}
+
+beforeEach(() => {
+  confirmMatchMutateAsync.mockReset();
+  capturedRejections.length = 0;
+  process.on('unhandledRejection', captureRejection);
+});
+
+afterEach(() => {
+  process.off('unhandledRejection', captureRejection);
+});
+
+describe('ManualMatchDialog — error handling on a failed confirm', () => {
+  it('keeps the dialog open when the match fails', async () => {
+    confirmMatchMutateAsync.mockRejectedValue(new Error('closed fiscal period'));
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <ManualMatchDialog
+        isOpen
+        onClose={onClose}
+        pendingOutflow={pendingOutflow}
+        restaurantId="rest-1"
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /Acme Supply/ }));
+    await user.click(screen.getByRole('button', { name: 'Confirm Match' }));
+
+    // Flush the macrotask queue so Node's unhandledRejection check (which
+    // runs after the microtask queue drains) has a chance to fire before
+    // the assertion below reads capturedRejections.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(confirmMatchMutateAsync).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(capturedRejections).toHaveLength(0);
+  });
+});

--- a/tests/unit/manualMatchDialogFilter.test.tsx
+++ b/tests/unit/manualMatchDialogFilter.test.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+// Codex review finding on PR #777: ManualMatchDialog filtered candidates by
+// amount < 0 only. A transfer, an excluded row, or a split parent must never
+// get a single-category journal entry (the bulk categorize RPC skips all
+// three for the same reason — see
+// supabase/migrations/20260819231210_add_bulk_categorize_bank_transactions.sql).
+// This proves the dialog hides all three states from the picker list.
+
+// jsdom never runs layout, so every element's offsetHeight is 0.
+// @tanstack/react-virtual measures its scroll container via `offsetHeight`
+// and only computes a visible range when that size is > 0 — without this
+// stub, getVirtualItems() always returns [] and no row renders. Same
+// pattern as tests/unit/manualMatchDialogError.test.tsx.
+let offsetHeightSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  offsetHeightSpy = vi
+    .spyOn(HTMLElement.prototype, 'offsetHeight', 'get')
+    .mockReturnValue(800);
+});
+
+afterEach(() => {
+  offsetHeightSpy.mockRestore();
+});
+
+const confirmMatchMutateAsync = vi.fn();
+
+vi.mock('@/hooks/usePendingOutflows', () => ({
+  usePendingOutflowMutations: () => ({
+    confirmMatch: { mutateAsync: confirmMatchMutateAsync, isPending: false },
+  }),
+}));
+
+const baseTransaction = {
+  restaurant_id: 'rest-1',
+  connected_bank_id: 'bank-1',
+  transaction_date: '2026-05-20',
+  posted_date: '2026-05-20',
+  amount: -100,
+  description: 'Vendor payment',
+  merchant_name: null,
+  normalized_payee: null,
+  category_id: null,
+  suggested_category_id: null,
+  suggested_payee: null,
+  supplier_id: null,
+  expense_invoice_upload_id: null,
+  status: 'active',
+  is_categorized: false,
+  is_reconciled: false,
+  is_split: false,
+  is_transfer: false,
+  transfer_pair_id: null,
+  excluded_reason: null,
+  ai_confidence: null,
+  ai_reasoning: null,
+  notes: null,
+  created_at: '2026-05-20T00:00:00Z',
+  updated_at: '2026-05-20T00:00:00Z',
+  connected_bank: { id: 'bank-1', institution_name: 'First National' },
+};
+
+vi.mock('@/hooks/useBankTransactions', () => ({
+  useBankTransactionsWithRelations: () => ({
+    data: [
+      { ...baseTransaction, id: 'txn-postable', merchant_name: 'Postable Vendor' },
+      { ...baseTransaction, id: 'txn-transfer', merchant_name: 'Transfer Vendor', is_transfer: true },
+      { ...baseTransaction, id: 'txn-split', merchant_name: 'Split Vendor', is_split: true },
+      { ...baseTransaction, id: 'txn-excluded', merchant_name: 'Excluded Vendor', excluded_reason: 'duplicate' },
+    ],
+    isLoading: false,
+  }),
+}));
+
+import { ManualMatchDialog } from '@/components/pending-outflows/ManualMatchDialog';
+import type { PendingOutflow } from '@/types/pending-outflows';
+
+const pendingOutflow: PendingOutflow = {
+  id: 'pof-1',
+  restaurant_id: 'rest-1',
+  vendor_name: 'Acme Supply',
+  category_id: null,
+  payment_method: 'check',
+  amount: 100,
+  issue_date: '2026-05-22',
+  due_date: null,
+  notes: null,
+  reference_number: null,
+  status: 'pending',
+  linked_bank_transaction_id: null,
+  cleared_at: null,
+  voided_at: null,
+  voided_reason: null,
+  created_at: '2026-05-22T00:00:00Z',
+  updated_at: '2026-05-22T00:00:00Z',
+  chart_account: null,
+};
+
+describe('ManualMatchDialog — non-postable transaction filter', () => {
+  it('shows a postable transaction and hides a transfer, a split, and an excluded row', () => {
+    render(
+      <ManualMatchDialog
+        isOpen
+        onClose={vi.fn()}
+        pendingOutflow={pendingOutflow}
+        restaurantId="rest-1"
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: /Postable Vendor/ })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Transfer Vendor/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Split Vendor/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Excluded Vendor/ })).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/pendingOutflowCardNeedsCategory.test.tsx
+++ b/tests/unit/pendingOutflowCardNeedsCategory.test.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// Needs-category badge on a cleared match (plan task 6): the cleared branch
+// shows a "Needs category" badge beside the cleared date when the outflow
+// has no category_id.
+vi.mock('@/hooks/usePermissions', () => ({
+  usePermissions: () => ({
+    hasCapability: vi.fn().mockReturnValue(true),
+    isResolved: true,
+  }),
+}));
+
+vi.mock('@/contexts/RestaurantContext', () => ({
+  useRestaurantContext: () => ({
+    selectedRestaurant: { id: 'restaurant-1', restaurant: { name: 'Test Restaurant' }, restaurant_id: 'restaurant-1' },
+  }),
+}));
+
+vi.mock('@/hooks/usePendingOutflows', () => ({
+  usePendingOutflowMutations: () => ({
+    voidPendingOutflow: { mutate: vi.fn() },
+    deletePendingOutflow: { mutate: vi.fn() },
+    updatePendingOutflow: { mutateAsync: vi.fn() },
+  }),
+  usePendingOutflowMatches: () => ({ data: [] }),
+}));
+
+vi.mock('@/components/pending-outflows/ManualMatchDialog', () => ({
+  ManualMatchDialog: () => null,
+}));
+
+import { PendingOutflowCard } from '@/components/pending-outflows/PendingOutflowCard';
+import type { PendingOutflow } from '@/types/pending-outflows';
+
+const baseClearedOutflow: PendingOutflow = {
+  id: 'outflow-1',
+  restaurant_id: 'restaurant-1',
+  vendor_name: 'Acme Produce',
+  category_id: null,
+  payment_method: 'check',
+  amount: 125.5,
+  issue_date: '2026-07-01',
+  due_date: null,
+  notes: null,
+  reference_number: null,
+  status: 'cleared',
+  linked_bank_transaction_id: 'bank-txn-1',
+  cleared_at: '2026-07-10T00:00:00.000Z',
+  voided_at: null,
+  voided_reason: null,
+  created_at: '2026-07-01T00:00:00.000Z',
+  updated_at: '2026-07-01T00:00:00.000Z',
+  chart_account: null,
+};
+
+const renderCard = (outflow: PendingOutflow) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <PendingOutflowCard outflow={outflow} />
+    </QueryClientProvider>,
+  );
+};
+
+describe('PendingOutflowCard — needs-category badge on a cleared match (plan task 6)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the badge on a cleared no-category outflow', () => {
+    renderCard(baseClearedOutflow);
+
+    expect(screen.getByText('Needs category')).toBeInTheDocument();
+  });
+
+  it('hides the badge on a cleared categorized outflow', () => {
+    renderCard({ ...baseClearedOutflow, category_id: 'category-1' });
+
+    expect(screen.queryByText('Needs category')).not.toBeInTheDocument();
+  });
+});

--- a/tests/unit/useBankTransactions.test.ts
+++ b/tests/unit/useBankTransactions.test.ts
@@ -2,11 +2,12 @@ import React, { ReactNode } from 'react';
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { useBankTransactions } from '@/hooks/useBankTransactions';
+import { useBankTransactions, useCategorizeTransaction } from '@/hooks/useBankTransactions';
 import type { TransactionFilters } from '@/types/transactions';
 
 const mockSupabase = vi.hoisted(() => ({
   from: vi.fn(),
+  rpc: vi.fn(),
 }));
 
 const mockRestaurantContext = vi.hoisted(() => ({
@@ -389,5 +390,83 @@ describe('useBankTransactions (paginated)', () => {
     expect(mockSupabase.from).not.toHaveBeenCalled();
 
     mockRestaurantContext.selectedRestaurant = { restaurant_id: 'rest-123' }; // restore for other tests
+  });
+});
+
+type UpdateResult = { error: { message: string } | null };
+
+const createPendingOutflowsSyncBuilder = (result: UpdateResult) => {
+  const builder = {
+    update: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    is: vi.fn().mockResolvedValue(result),
+  };
+  return builder;
+};
+
+describe('useCategorizeTransaction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('syncs the category onto a cleared, uncategorized pending outflow after the RPC succeeds', async () => {
+    mockSupabase.rpc.mockResolvedValue({ data: { success: true }, error: null });
+    const pendingOutflowsBuilder = createPendingOutflowsSyncBuilder({ error: null });
+    mockSupabase.from.mockImplementation(() => pendingOutflowsBuilder);
+
+    const { result } = renderHook(() => useCategorizeTransaction(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        transactionId: 'txn-1',
+        categoryId: 'cat-1',
+      });
+    });
+
+    expect(mockSupabase.rpc).toHaveBeenCalledWith('categorize_bank_transaction', expect.objectContaining({
+      p_transaction_id: 'txn-1',
+      p_category_id: 'cat-1',
+    }));
+    expect(mockSupabase.from).toHaveBeenCalledWith('pending_outflows');
+    expect(pendingOutflowsBuilder.update).toHaveBeenCalledWith({ category_id: 'cat-1' });
+    expect(pendingOutflowsBuilder.eq).toHaveBeenCalledWith('linked_bank_transaction_id', 'txn-1');
+    expect(pendingOutflowsBuilder.eq).toHaveBeenCalledWith('status', 'cleared');
+    expect(pendingOutflowsBuilder.is).toHaveBeenCalledWith('category_id', null);
+  });
+
+  it('does not run the sync update when the RPC errors', async () => {
+    mockSupabase.rpc.mockResolvedValue({ data: null, error: { message: 'RPC failed' } });
+
+    const { result } = renderHook(() => useCategorizeTransaction(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await expect(
+        result.current.mutateAsync({ transactionId: 'txn-1', categoryId: 'cat-1' })
+      ).rejects.toThrow();
+    });
+
+    expect(mockSupabase.from).not.toHaveBeenCalled();
+  });
+
+  it('throws when the sync update itself fails', async () => {
+    mockSupabase.rpc.mockResolvedValue({ data: { success: true }, error: null });
+    const pendingOutflowsBuilder = createPendingOutflowsSyncBuilder({
+      error: { message: 'sync failed' },
+    });
+    mockSupabase.from.mockImplementation(() => pendingOutflowsBuilder);
+
+    const { result } = renderHook(() => useCategorizeTransaction(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await expect(
+        result.current.mutateAsync({ transactionId: 'txn-1', categoryId: 'cat-1' })
+      ).rejects.toThrow();
+    });
   });
 });

--- a/tests/unit/usePendingOutflows.test.ts
+++ b/tests/unit/usePendingOutflows.test.ts
@@ -79,8 +79,9 @@ function setupConfirmMatchMocks(
     eq: vi.fn().mockResolvedValue({ error: null }),
   };
 
-  // Backs the pre-RPC "does a journal entry already exist" guard. Only hit
-  // when the outflow's category matches the transaction's existing category.
+  // Backs the pre-RPC "does a journal entry already exist" guard. Hit
+  // whenever the bank transaction already carries a category_id, same as
+  // the outflow's category or not.
   const journalEntriesQuery = {
     eq: vi.fn().mockReturnThis(),
     maybeSingle: vi.fn().mockResolvedValue({
@@ -167,7 +168,52 @@ describe('usePendingOutflowMutations', () => {
       });
     });
 
-    it('should handle cases where bank transaction already has category', async () => {
+    it('blocks a different-category match when the transaction has no journal entry', async () => {
+      const mockPendingOutflow = {
+        id: 'po-123',
+        category_id: 'cat-456',
+        notes: 'Expense notes',
+        expense_invoice_uploads: [],
+      };
+
+      // The transaction already carries a DIFFERENT category. The RPC
+      // would take the reclassification branch here, crediting
+      // "existing-cat" — a spurious credit unless a journal entry from
+      // the first categorize already debits that account.
+      const mockBankTransaction = {
+        notes: null,
+        category_id: 'existing-cat',
+        suggested_category_id: 'existing-suggested',
+      };
+
+      const { mockPendingOutflowBuilder, mockBankTransactionBuilder, mockJournalEntriesBuilder } =
+        setupConfirmMatchMocks(mockPendingOutflow, mockBankTransaction, {
+          existingJournalEntry: null,
+        });
+
+      const { result } = renderHook(() => usePendingOutflowMutations(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        try {
+          await result.current.confirmMatch.mutateAsync({
+            pendingOutflowId: 'po-123',
+            bankTransactionId: 'bt-456',
+          });
+        } catch {
+          // expected: the pre-RPC journal-entry guard rejects the match
+        }
+      });
+
+      expect(mockJournalEntriesBuilder.select).toHaveBeenCalledWith('id');
+      expect(mockSupabase.rpc).not.toHaveBeenCalled();
+      expect(mockBankTransactionBuilder.update).not.toHaveBeenCalled();
+      expect(mockPendingOutflowBuilder.update).not.toHaveBeenCalled();
+      expect(toast.error).toHaveBeenCalledWith(
+        expect.stringContaining('already categorized but has no journal entry')
+      );
+    });
+
+    it('allows a different-category match when a journal entry already exists', async () => {
       const mockPendingOutflow = {
         id: 'po-123',
         category_id: 'cat-456',
@@ -182,7 +228,9 @@ describe('usePendingOutflowMutations', () => {
       };
 
       const { mockBankTransactionBuilder } =
-        setupConfirmMatchMocks(mockPendingOutflow, mockBankTransaction);
+        setupConfirmMatchMocks(mockPendingOutflow, mockBankTransaction, {
+          existingJournalEntry: { id: 'je-1' },
+        });
       mockSupabase.rpc.mockResolvedValue({ data: null, error: null });
 
       const { result } = renderHook(() => usePendingOutflowMutations(), { wrapper: createWrapper() });

--- a/tests/unit/usePendingOutflows.test.ts
+++ b/tests/unit/usePendingOutflows.test.ts
@@ -105,6 +105,7 @@ describe('usePendingOutflowMutations', () => {
         }
         return mockPendingOutflowBuilder; // fallback
       });
+      mockSupabase.rpc.mockResolvedValue({ data: null, error: null });
 
       const { result } = renderHook(() => usePendingOutflowMutations(), { wrapper: createWrapper() });
 
@@ -123,14 +124,20 @@ describe('usePendingOutflowMutations', () => {
         cleared_at: expect.any(String),
       });
 
-      // Verify bank transaction was updated with copied data
+      // Verify the RPC applied the category and the merged notes
+      expect(mockSupabase.rpc).toHaveBeenCalledWith('categorize_bank_transaction', {
+        p_transaction_id: 'bt-456',
+        p_category_id: 'cat-456',
+        p_description: 'Bank notes\n\nExpense notes',
+        p_normalized_payee: null,
+        p_supplier_id: null,
+      });
+
+      // Verify bank transaction got a metadata-only update
       expect(mockSupabase.from).toHaveBeenCalledWith('bank_transactions');
       expect(mockBankTransactionBuilder.update).toHaveBeenCalledWith({
-        is_categorized: true,
         matched_at: expect.any(String),
-        category_id: 'cat-456', // copied from pending outflow
         suggested_category_id: 'cat-456', // copied as AI suggestion
-        notes: 'Bank notes\n\nExpense notes', // merged notes
         expense_invoice_upload_id: 'upload-789', // linked upload
       });
     });
@@ -186,6 +193,7 @@ describe('usePendingOutflowMutations', () => {
         }
         return mockBankTransactionBuilder;
       });
+      mockSupabase.rpc.mockResolvedValue({ data: null, error: null });
 
       const { result } = renderHook(() => usePendingOutflowMutations(), { wrapper: createWrapper() });
 
@@ -196,13 +204,257 @@ describe('usePendingOutflowMutations', () => {
         });
       });
 
-      // Expense category should override existing bank transaction category
+      // The category is applied through the RPC, not a direct column write
+      expect(mockSupabase.rpc).toHaveBeenCalledWith('categorize_bank_transaction', {
+        p_transaction_id: 'bt-456',
+        p_category_id: 'cat-456',
+        p_description: 'Expense notes',
+        p_normalized_payee: null,
+        p_supplier_id: null,
+      });
+
       expect(mockBankTransactionBuilder.update).toHaveBeenCalledWith({
-        is_categorized: true,
         matched_at: expect.any(String),
-        notes: 'Expense notes', // only expense notes since bank had none
-        category_id: 'cat-456', // expense category overrides existing
         suggested_category_id: 'cat-456', // expense category overrides existing
+      });
+    });
+
+    it('calls categorize_bank_transaction with the outflow category and the merged notes', async () => {
+      const mockPendingOutflow = {
+        id: 'po-123',
+        category_id: 'cat-456',
+        notes: 'Expense notes',
+        expense_invoice_uploads: [],
+      };
+
+      const mockBankTransaction = {
+        notes: 'Bank notes',
+        category_id: null,
+        suggested_category_id: null,
+      };
+
+      const mockPendingOutflowBuilder = {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: mockPendingOutflow, error: null }),
+        }),
+        update: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      };
+
+      const mockBankTransactionBuilder = {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: mockBankTransaction, error: null }),
+        }),
+        update: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      };
+
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === 'pending_outflows') return mockPendingOutflowBuilder;
+        if (table === 'bank_transactions') return mockBankTransactionBuilder;
+        return mockPendingOutflowBuilder;
+      });
+      mockSupabase.rpc.mockResolvedValue({ data: null, error: null });
+
+      const { result } = renderHook(() => usePendingOutflowMutations(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        await result.current.confirmMatch.mutateAsync({
+          pendingOutflowId: 'po-123',
+          bankTransactionId: 'bt-456',
+        });
+      });
+
+      expect(mockSupabase.rpc).toHaveBeenCalledWith('categorize_bank_transaction', {
+        p_transaction_id: 'bt-456',
+        p_category_id: 'cat-456',
+        p_description: 'Bank notes\n\nExpense notes',
+        p_normalized_payee: null,
+        p_supplier_id: null,
+      });
+    });
+
+    it('calls the RPC before the bank_transactions update', async () => {
+      const callOrder: string[] = [];
+
+      const mockPendingOutflow = {
+        id: 'po-123',
+        category_id: 'cat-456',
+        notes: 'Expense notes',
+        expense_invoice_uploads: [],
+      };
+
+      const mockBankTransaction = {
+        notes: 'Bank notes',
+        category_id: null,
+        suggested_category_id: null,
+      };
+
+      const mockPendingOutflowBuilder = {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: mockPendingOutflow, error: null }),
+        }),
+        update: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      };
+
+      const mockBankTransactionBuilder = {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: mockBankTransaction, error: null }),
+        }),
+        update: vi.fn((_payload: unknown) => {
+          callOrder.push('update');
+          return mockBankTransactionBuilder;
+        }),
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      };
+
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === 'pending_outflows') return mockPendingOutflowBuilder;
+        if (table === 'bank_transactions') return mockBankTransactionBuilder;
+        return mockPendingOutflowBuilder;
+      });
+      mockSupabase.rpc.mockImplementation(async () => {
+        callOrder.push('rpc');
+        return { data: null, error: null };
+      });
+
+      const { result } = renderHook(() => usePendingOutflowMutations(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        await result.current.confirmMatch.mutateAsync({
+          pendingOutflowId: 'po-123',
+          bankTransactionId: 'bt-456',
+        });
+      });
+
+      expect(callOrder).toEqual(['rpc', 'update']);
+    });
+
+    it('sends a metadata-only update', async () => {
+      const mockPendingOutflow = {
+        id: 'po-123',
+        category_id: 'cat-456',
+        notes: 'Expense notes',
+        expense_invoice_uploads: [{
+          id: 'upload-789',
+          raw_file_url: 'https://example.com/file.pdf',
+          file_name: 'invoice.pdf',
+          raw_ocr_data: null,
+          field_confidence: null,
+        }],
+      };
+
+      const mockBankTransaction = {
+        notes: 'Bank notes',
+        category_id: null,
+        suggested_category_id: null,
+      };
+
+      const mockPendingOutflowBuilder = {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: mockPendingOutflow, error: null }),
+        }),
+        update: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      };
+
+      const mockBankTransactionBuilder = {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: mockBankTransaction, error: null }),
+        }),
+        update: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      };
+
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === 'pending_outflows') return mockPendingOutflowBuilder;
+        if (table === 'bank_transactions') return mockBankTransactionBuilder;
+        return mockPendingOutflowBuilder;
+      });
+      mockSupabase.rpc.mockResolvedValue({ data: null, error: null });
+
+      const { result } = renderHook(() => usePendingOutflowMutations(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        await result.current.confirmMatch.mutateAsync({
+          pendingOutflowId: 'po-123',
+          bankTransactionId: 'bt-456',
+        });
+      });
+
+      expect(mockBankTransactionBuilder.update).toHaveBeenCalledWith({
+        matched_at: expect.any(String),
+        suggested_category_id: 'cat-456',
+        expense_invoice_upload_id: 'upload-789',
+      });
+
+      const updatePayload = mockBankTransactionBuilder.update.mock.calls[0][0];
+      expect(updatePayload).not.toHaveProperty('is_categorized');
+      expect(updatePayload).not.toHaveProperty('category_id');
+      expect(updatePayload).not.toHaveProperty('notes');
+    });
+
+    it('keeps the bank notes unchanged when they already contain the outflow notes', async () => {
+      const mockPendingOutflow = {
+        id: 'po-123',
+        category_id: 'cat-456',
+        notes: 'B',
+        expense_invoice_uploads: [],
+      };
+
+      const mockBankTransaction = {
+        notes: 'A\n\nB',
+        category_id: null,
+        suggested_category_id: null,
+      };
+
+      const mockPendingOutflowBuilder = {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: mockPendingOutflow, error: null }),
+        }),
+        update: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      };
+
+      const mockBankTransactionBuilder = {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: mockBankTransaction, error: null }),
+        }),
+        update: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      };
+
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === 'pending_outflows') return mockPendingOutflowBuilder;
+        if (table === 'bank_transactions') return mockBankTransactionBuilder;
+        return mockPendingOutflowBuilder;
+      });
+      mockSupabase.rpc.mockResolvedValue({ data: null, error: null });
+
+      const { result } = renderHook(() => usePendingOutflowMutations(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        await result.current.confirmMatch.mutateAsync({
+          pendingOutflowId: 'po-123',
+          bankTransactionId: 'bt-456',
+        });
+      });
+
+      expect(mockSupabase.rpc).toHaveBeenCalledWith('categorize_bank_transaction', {
+        p_transaction_id: 'bt-456',
+        p_category_id: 'cat-456',
+        p_description: 'A\n\nB',
+        p_normalized_payee: null,
+        p_supplier_id: null,
       });
     });
 

--- a/tests/unit/usePendingOutflows.test.ts
+++ b/tests/unit/usePendingOutflows.test.ts
@@ -109,6 +109,56 @@ describe('usePendingOutflowMutations', () => {
   });
 
   describe('confirmMatch', () => {
+    // Codex review finding on PR #777: ManualMatchDialog's own filter only
+    // excludes amount >= 0. A transfer, an excluded row, or a split parent
+    // must never get a single-category journal entry (the bulk categorize
+    // RPC skips all three for the same reason — see
+    // supabase/migrations/20260819231210_add_bulk_categorize_bank_transactions.sql).
+    // This is the defense-in-depth guard for a stale row list or a direct
+    // call that bypasses the dialog's own filter.
+    it.each([
+      ['a transfer', { is_transfer: true, is_split: false, excluded_reason: null }],
+      ['a split parent', { is_transfer: false, is_split: true, excluded_reason: null }],
+      ['an excluded row', { is_transfer: false, is_split: false, excluded_reason: 'duplicate' }],
+    ])('blocks a match onto %s', async (_label, flags) => {
+      const mockPendingOutflow = {
+        id: 'po-123',
+        category_id: 'cat-456',
+        notes: null,
+        expense_invoice_uploads: [],
+      };
+
+      const mockBankTransaction = {
+        notes: null,
+        category_id: null,
+        suggested_category_id: null,
+        ...flags,
+      };
+
+      const { mockBankTransactionBuilder, mockPendingOutflowBuilder } =
+        setupConfirmMatchMocks(mockPendingOutflow, mockBankTransaction);
+
+      const { result } = renderHook(() => usePendingOutflowMutations(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        try {
+          await result.current.confirmMatch.mutateAsync({
+            pendingOutflowId: 'po-123',
+            bankTransactionId: 'bt-456',
+          });
+        } catch {
+          // expected: the pre-RPC transfer/split/excluded guard rejects the match
+        }
+      });
+
+      expect(mockSupabase.rpc).not.toHaveBeenCalled();
+      expect(mockBankTransactionBuilder.update).not.toHaveBeenCalled();
+      expect(mockPendingOutflowBuilder.update).not.toHaveBeenCalled();
+      expect(toast.error).toHaveBeenCalledWith(
+        expect.stringContaining('transfer, a split, or excluded')
+      );
+    });
+
     it('should copy expense data to bank transaction when confirming match', async () => {
       const mockPendingOutflow = {
         id: 'po-123',

--- a/tests/unit/usePendingOutflows.test.ts
+++ b/tests/unit/usePendingOutflows.test.ts
@@ -442,7 +442,7 @@ describe('usePendingOutflowMutations', () => {
       expect(toast.success).toHaveBeenCalledWith('Expense matched and cleared');
     });
 
-    it('marks a no-category outflow as categorized when the matched transaction already has one', async () => {
+    it('marks a no-category outflow as categorized when the matched transaction already has a journal entry', async () => {
       const mockPendingOutflow = {
         id: 'po-123',
         category_id: null,
@@ -456,8 +456,10 @@ describe('usePendingOutflowMutations', () => {
         suggested_category_id: null,
       };
 
-      const { mockPendingOutflowBuilder } =
-        setupConfirmMatchMocks(mockPendingOutflow, mockBankTransaction);
+      const { mockPendingOutflowBuilder, mockJournalEntriesBuilder } =
+        setupConfirmMatchMocks(mockPendingOutflow, mockBankTransaction, {
+          existingJournalEntry: { id: 'je-1' },
+        });
 
       const { result } = renderHook(() => usePendingOutflowMutations(), { wrapper: createWrapper() });
 
@@ -471,6 +473,9 @@ describe('usePendingOutflowMutations', () => {
       // No category on the outflow, so the RPC never runs.
       expect(mockSupabase.rpc).not.toHaveBeenCalled();
 
+      // The journal entry check ran before the copy.
+      expect(mockJournalEntriesBuilder.select).toHaveBeenCalledWith('id');
+
       // The outflow copies the transaction's existing category so the
       // "Needs category" badge does not show a false positive.
       expect(mockPendingOutflowBuilder.update).toHaveBeenCalledWith({
@@ -481,6 +486,54 @@ describe('usePendingOutflowMutations', () => {
       });
 
       expect(toast.success).toHaveBeenCalledWith('Expense matched and cleared');
+    });
+
+    it('does not copy the category onto a no-category outflow when the matched transaction has no journal entry', async () => {
+      const mockPendingOutflow = {
+        id: 'po-123',
+        category_id: null,
+        notes: null,
+        expense_invoice_uploads: [],
+      };
+
+      // The transaction carries a category with no backing journal entry —
+      // the same legacy state the same-category RPC guard blocks above.
+      const mockBankTransaction = {
+        notes: null,
+        category_id: 'existing-cat',
+        suggested_category_id: null,
+      };
+
+      const { mockPendingOutflowBuilder, mockJournalEntriesBuilder } =
+        setupConfirmMatchMocks(mockPendingOutflow, mockBankTransaction, {
+          existingJournalEntry: null,
+        });
+
+      const { result } = renderHook(() => usePendingOutflowMutations(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        await result.current.confirmMatch.mutateAsync({
+          pendingOutflowId: 'po-123',
+          bankTransactionId: 'bt-456',
+        });
+      });
+
+      expect(mockSupabase.rpc).not.toHaveBeenCalled();
+      expect(mockJournalEntriesBuilder.select).toHaveBeenCalledWith('id');
+
+      // No journal entry backs the transaction's category, so the outflow
+      // does not copy it — the "Needs category" badge stays accurate.
+      expect(mockPendingOutflowBuilder.update).toHaveBeenCalledWith({
+        status: 'cleared',
+        linked_bank_transaction_id: 'bt-456',
+        cleared_at: expect.any(String),
+      });
+      const outflowUpdatePayload = mockPendingOutflowBuilder.update.mock.calls[0][0];
+      expect(outflowUpdatePayload).not.toHaveProperty('category_id');
+
+      expect(toast.success).toHaveBeenCalledWith(
+        'Expense matched. Categorize the transaction on the Banking page.'
+      );
     });
 
     it('skips the RPC when the outflow has no category', async () => {

--- a/tests/unit/usePendingOutflows.test.ts
+++ b/tests/unit/usePendingOutflows.test.ts
@@ -650,5 +650,192 @@ describe('usePendingOutflowMutations', () => {
 
       expect(toast.error).toHaveBeenCalledWith('Failed to confirm match: Not found');
     });
+
+    it('maps the reconciled guard', async () => {
+      const mockPendingOutflow = {
+        id: 'po-123',
+        category_id: 'cat-456',
+        notes: null,
+        expense_invoice_uploads: [],
+      };
+
+      const mockBankTransaction = {
+        notes: null,
+        category_id: null,
+        suggested_category_id: null,
+      };
+
+      const mockPendingOutflowBuilder = {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: mockPendingOutflow, error: null }),
+        }),
+        update: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      };
+
+      const mockBankTransactionBuilder = {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: mockBankTransaction, error: null }),
+        }),
+        update: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      };
+
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === 'pending_outflows') return mockPendingOutflowBuilder;
+        if (table === 'bank_transactions') return mockBankTransactionBuilder;
+        return mockPendingOutflowBuilder;
+      });
+      mockSupabase.rpc.mockResolvedValue({
+        data: null,
+        error: {
+          message:
+            'Cannot categorize a reconciled transaction. Use reclassification instead by updating the category of an already categorized transaction.',
+        },
+      });
+
+      const { result } = renderHook(() => usePendingOutflowMutations(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        try {
+          await result.current.confirmMatch.mutateAsync({
+            pendingOutflowId: 'po-123',
+            bankTransactionId: 'bt-456',
+          });
+        } catch {
+          // expected: the RPC rejects with the reconciled guard
+        }
+      });
+
+      expect(toast.error).toHaveBeenCalledWith(
+        'This transaction is reconciled. Reclassify it from the Banking page instead.'
+      );
+      expect(mockBankTransactionBuilder.update).not.toHaveBeenCalled();
+      expect(mockPendingOutflowBuilder.update).not.toHaveBeenCalled();
+    });
+
+    it('maps the closed-period guard', async () => {
+      const mockPendingOutflow = {
+        id: 'po-123',
+        category_id: 'cat-456',
+        notes: null,
+        expense_invoice_uploads: [],
+      };
+
+      const mockBankTransaction = {
+        notes: null,
+        category_id: null,
+        suggested_category_id: null,
+      };
+
+      const mockPendingOutflowBuilder = {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: mockPendingOutflow, error: null }),
+        }),
+        update: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      };
+
+      const mockBankTransactionBuilder = {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: mockBankTransaction, error: null }),
+        }),
+        update: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      };
+
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === 'pending_outflows') return mockPendingOutflowBuilder;
+        if (table === 'bank_transactions') return mockBankTransactionBuilder;
+        return mockPendingOutflowBuilder;
+      });
+      mockSupabase.rpc.mockResolvedValue({
+        data: null,
+        error: {
+          message: 'Cannot categorize transaction in closed fiscal period. Period closed on 2026-01-01',
+        },
+      });
+
+      const { result } = renderHook(() => usePendingOutflowMutations(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        try {
+          await result.current.confirmMatch.mutateAsync({
+            pendingOutflowId: 'po-123',
+            bankTransactionId: 'bt-456',
+          });
+        } catch {
+          // expected: the RPC rejects with the closed-period guard
+        }
+      });
+
+      expect(toast.error).toHaveBeenCalledWith(
+        'This transaction is in a closed fiscal period. Reopen the period before you match it.'
+      );
+      expect(mockBankTransactionBuilder.update).not.toHaveBeenCalled();
+      expect(mockPendingOutflowBuilder.update).not.toHaveBeenCalled();
+    });
+
+    it('keeps the generic copy for other errors', async () => {
+      const mockPendingOutflow = {
+        id: 'po-123',
+        category_id: 'cat-456',
+        notes: null,
+        expense_invoice_uploads: [],
+      };
+
+      const mockBankTransaction = {
+        notes: null,
+        category_id: null,
+        suggested_category_id: null,
+      };
+
+      const mockPendingOutflowBuilder = {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: mockPendingOutflow, error: null }),
+        }),
+        update: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      };
+
+      const mockBankTransactionBuilder = {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: mockBankTransaction, error: null }),
+        }),
+        update: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      };
+
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === 'pending_outflows') return mockPendingOutflowBuilder;
+        if (table === 'bank_transactions') return mockBankTransactionBuilder;
+        return mockPendingOutflowBuilder;
+      });
+      mockSupabase.rpc.mockResolvedValue({
+        data: null,
+        error: { message: 'boom' },
+      });
+
+      const { result } = renderHook(() => usePendingOutflowMutations(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        try {
+          await result.current.confirmMatch.mutateAsync({
+            pendingOutflowId: 'po-123',
+            bankTransactionId: 'bt-456',
+          });
+        } catch {
+          // expected: the RPC rejects with an unrelated error
+        }
+      });
+
+      expect(toast.error).toHaveBeenCalledWith('Failed to confirm match: boom');
+    });
   });
 });

--- a/tests/unit/usePendingOutflows.test.ts
+++ b/tests/unit/usePendingOutflows.test.ts
@@ -49,7 +49,10 @@ const createWrapper = () => {
 function setupConfirmMatchMocks(
   pendingOutflow: unknown,
   bankTransaction: unknown,
-  options: { onBankUpdate?: () => void } = {}
+  options: {
+    onBankUpdate?: () => void;
+    existingJournalEntry?: { id: string } | null;
+  } = {}
 ) {
   const mockPendingOutflowBuilder = {
     select: vi.fn().mockReturnValue({
@@ -76,13 +79,27 @@ function setupConfirmMatchMocks(
     eq: vi.fn().mockResolvedValue({ error: null }),
   };
 
+  // Backs the pre-RPC "does a journal entry already exist" guard. Only hit
+  // when the outflow's category matches the transaction's existing category.
+  const journalEntriesQuery = {
+    eq: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue({
+      data: options.existingJournalEntry ?? null,
+      error: null,
+    }),
+  };
+  const mockJournalEntriesBuilder = {
+    select: vi.fn().mockReturnValue(journalEntriesQuery),
+  };
+
   mockSupabase.from.mockImplementation((table: string) => {
     if (table === 'pending_outflows') return mockPendingOutflowBuilder;
     if (table === 'bank_transactions') return mockBankTransactionBuilder;
+    if (table === 'journal_entries') return mockJournalEntriesBuilder;
     return mockPendingOutflowBuilder;
   });
 
-  return { mockPendingOutflowBuilder, mockBankTransactionBuilder };
+  return { mockPendingOutflowBuilder, mockBankTransactionBuilder, mockJournalEntriesBuilder };
 }
 
 describe('usePendingOutflowMutations', () => {
@@ -341,6 +358,129 @@ describe('usePendingOutflowMutations', () => {
         p_normalized_payee: null,
         p_supplier_id: null,
       });
+    });
+
+    it('blocks a same-category match when the transaction has no journal entry', async () => {
+      const mockPendingOutflow = {
+        id: 'po-123',
+        category_id: 'cat-456',
+        notes: null,
+        expense_invoice_uploads: [],
+      };
+
+      // The transaction already carries this exact category. The RPC would
+      // short-circuit here (no journal entry created) — a legacy write path
+      // can leave a transaction like this with no journal entry at all.
+      const mockBankTransaction = {
+        notes: null,
+        category_id: 'cat-456',
+        suggested_category_id: null,
+      };
+
+      const { mockPendingOutflowBuilder, mockBankTransactionBuilder, mockJournalEntriesBuilder } =
+        setupConfirmMatchMocks(mockPendingOutflow, mockBankTransaction, {
+          existingJournalEntry: null,
+        });
+
+      const { result } = renderHook(() => usePendingOutflowMutations(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        try {
+          await result.current.confirmMatch.mutateAsync({
+            pendingOutflowId: 'po-123',
+            bankTransactionId: 'bt-456',
+          });
+        } catch {
+          // expected: the pre-RPC journal-entry guard rejects the match
+        }
+      });
+
+      expect(mockJournalEntriesBuilder.select).toHaveBeenCalledWith('id');
+      expect(mockSupabase.rpc).not.toHaveBeenCalled();
+      expect(mockBankTransactionBuilder.update).not.toHaveBeenCalled();
+      expect(mockPendingOutflowBuilder.update).not.toHaveBeenCalled();
+      expect(toast.error).toHaveBeenCalledWith(
+        expect.stringContaining('already categorized but has no journal entry')
+      );
+    });
+
+    it('allows a same-category match when a journal entry already exists', async () => {
+      const mockPendingOutflow = {
+        id: 'po-123',
+        category_id: 'cat-456',
+        notes: null,
+        expense_invoice_uploads: [],
+      };
+
+      const mockBankTransaction = {
+        notes: null,
+        category_id: 'cat-456',
+        suggested_category_id: null,
+      };
+
+      setupConfirmMatchMocks(mockPendingOutflow, mockBankTransaction, {
+        existingJournalEntry: { id: 'je-1' },
+      });
+      mockSupabase.rpc.mockResolvedValue({ data: null, error: null });
+
+      const { result } = renderHook(() => usePendingOutflowMutations(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        await result.current.confirmMatch.mutateAsync({
+          pendingOutflowId: 'po-123',
+          bankTransactionId: 'bt-456',
+        });
+      });
+
+      expect(mockSupabase.rpc).toHaveBeenCalledWith('categorize_bank_transaction', {
+        p_transaction_id: 'bt-456',
+        p_category_id: 'cat-456',
+        p_description: null,
+        p_normalized_payee: null,
+        p_supplier_id: null,
+      });
+      expect(toast.success).toHaveBeenCalledWith('Expense matched and cleared');
+    });
+
+    it('marks a no-category outflow as categorized when the matched transaction already has one', async () => {
+      const mockPendingOutflow = {
+        id: 'po-123',
+        category_id: null,
+        notes: null,
+        expense_invoice_uploads: [],
+      };
+
+      const mockBankTransaction = {
+        notes: null,
+        category_id: 'existing-cat',
+        suggested_category_id: null,
+      };
+
+      const { mockPendingOutflowBuilder } =
+        setupConfirmMatchMocks(mockPendingOutflow, mockBankTransaction);
+
+      const { result } = renderHook(() => usePendingOutflowMutations(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        await result.current.confirmMatch.mutateAsync({
+          pendingOutflowId: 'po-123',
+          bankTransactionId: 'bt-456',
+        });
+      });
+
+      // No category on the outflow, so the RPC never runs.
+      expect(mockSupabase.rpc).not.toHaveBeenCalled();
+
+      // The outflow copies the transaction's existing category so the
+      // "Needs category" badge does not show a false positive.
+      expect(mockPendingOutflowBuilder.update).toHaveBeenCalledWith({
+        status: 'cleared',
+        linked_bank_transaction_id: 'bt-456',
+        cleared_at: expect.any(String),
+        category_id: 'existing-cat',
+      });
+
+      expect(toast.success).toHaveBeenCalledWith('Expense matched and cleared');
     });
 
     it('skips the RPC when the outflow has no category', async () => {

--- a/tests/unit/usePendingOutflows.test.ts
+++ b/tests/unit/usePendingOutflows.test.ts
@@ -623,6 +623,67 @@ describe('usePendingOutflowMutations', () => {
       expect(toast.success).toHaveBeenCalledWith('Expense matched and cleared');
     });
 
+    it('invalidates the ledger queries on success', async () => {
+      const mockPendingOutflow = {
+        id: 'po-123',
+        category_id: 'cat-456',
+        notes: null,
+        expense_invoice_uploads: [],
+      };
+
+      const mockBankTransaction = {
+        notes: null,
+        category_id: null,
+        suggested_category_id: null,
+      };
+
+      const mockPendingOutflowBuilder = {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: mockPendingOutflow, error: null }),
+        }),
+        update: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      };
+
+      const mockBankTransactionBuilder = {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: mockBankTransaction, error: null }),
+        }),
+        update: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      };
+
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === 'pending_outflows') return mockPendingOutflowBuilder;
+        if (table === 'bank_transactions') return mockBankTransactionBuilder;
+        return mockPendingOutflowBuilder;
+      });
+      mockSupabase.rpc.mockResolvedValue({ data: null, error: null });
+
+      const invalidateSpy = vi.spyOn(QueryClient.prototype, 'invalidateQueries');
+
+      const { result } = renderHook(() => usePendingOutflowMutations(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        await result.current.confirmMatch.mutateAsync({
+          pendingOutflowId: 'po-123',
+          bankTransactionId: 'bt-456',
+        });
+      });
+
+      const invalidatedKeys = invalidateSpy.mock.calls.map((call) => call[0]?.queryKey);
+      expect(invalidatedKeys).toContainEqual(['pending-outflows']);
+      expect(invalidatedKeys).toContainEqual(['bank-transactions']);
+      expect(invalidatedKeys).toContainEqual(['pending-outflow-matches']);
+      expect(invalidatedKeys).toContainEqual(['income-statement']);
+      expect(invalidatedKeys).toContainEqual(['balance-sheet']);
+      expect(invalidatedKeys).toContainEqual(['chart-of-accounts']);
+
+      invalidateSpy.mockRestore();
+    });
+
     it('should handle errors gracefully', async () => {
       const pendingOutflowQuery = {
         select: vi.fn().mockReturnThis(),

--- a/tests/unit/usePendingOutflows.test.ts
+++ b/tests/unit/usePendingOutflows.test.ts
@@ -42,6 +42,49 @@ const createWrapper = () => {
   };
 };
 
+// Every confirmMatch test stubs the same pair of `supabase.from` tables and
+// routes them through `mockSupabase.from.mockImplementation`. This helper
+// builds both builders once so each test only supplies the fixture data (and,
+// rarely, a call-order hook) instead of ~20 lines of mock plumbing.
+function setupConfirmMatchMocks(
+  pendingOutflow: unknown,
+  bankTransaction: unknown,
+  options: { onBankUpdate?: () => void } = {}
+) {
+  const mockPendingOutflowBuilder = {
+    select: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: pendingOutflow, error: null }),
+    }),
+    update: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockResolvedValue({ error: null }),
+  };
+
+  const mockBankTransactionBuilder: {
+    select: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    eq: ReturnType<typeof vi.fn>;
+  } = {
+    select: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: bankTransaction, error: null }),
+    }),
+    update: vi.fn((_payload: unknown) => {
+      options.onBankUpdate?.();
+      return mockBankTransactionBuilder;
+    }),
+    eq: vi.fn().mockResolvedValue({ error: null }),
+  };
+
+  mockSupabase.from.mockImplementation((table: string) => {
+    if (table === 'pending_outflows') return mockPendingOutflowBuilder;
+    if (table === 'bank_transactions') return mockBankTransactionBuilder;
+    return mockPendingOutflowBuilder;
+  });
+
+  return { mockPendingOutflowBuilder, mockBankTransactionBuilder };
+}
+
 describe('usePendingOutflowMutations', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -68,43 +111,8 @@ describe('usePendingOutflowMutations', () => {
         suggested_category_id: null,
       };
 
-      const mockPendingOutflowSelectBuilder = {
-        eq: vi.fn().mockReturnThis(),
-        single: vi.fn().mockResolvedValue({
-          data: mockPendingOutflow,
-          error: null,
-        }),
-      };
-
-      const mockPendingOutflowBuilder = {
-        select: vi.fn().mockReturnValue(mockPendingOutflowSelectBuilder),
-        update: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      };
-
-      const mockBankTransactionSelectBuilder = {
-        eq: vi.fn().mockReturnThis(),
-        single: vi.fn().mockResolvedValue({
-          data: mockBankTransaction,
-          error: null,
-        }),
-      };
-
-      const mockBankTransactionBuilder = {
-        select: vi.fn().mockReturnValue(mockBankTransactionSelectBuilder),
-        update: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      };
-
-      mockSupabase.from.mockImplementation((table: string) => {
-        if (table === 'pending_outflows') {
-          return mockPendingOutflowBuilder;
-        }
-        if (table === 'bank_transactions') {
-          return mockBankTransactionBuilder;
-        }
-        return mockPendingOutflowBuilder; // fallback
-      });
+      const { mockPendingOutflowBuilder, mockBankTransactionBuilder } =
+        setupConfirmMatchMocks(mockPendingOutflow, mockBankTransaction);
       mockSupabase.rpc.mockResolvedValue({ data: null, error: null });
 
       const { result } = renderHook(() => usePendingOutflowMutations(), { wrapper: createWrapper() });
@@ -156,43 +164,8 @@ describe('usePendingOutflowMutations', () => {
         suggested_category_id: 'existing-suggested',
       };
 
-      const mockPendingOutflowSelectBuilder = {
-        eq: vi.fn().mockReturnThis(),
-        single: vi.fn().mockResolvedValue({
-          data: mockPendingOutflow,
-          error: null,
-        }),
-      };
-
-      const mockPendingOutflowBuilder = {
-        select: vi.fn().mockReturnValue(mockPendingOutflowSelectBuilder),
-        update: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      };
-
-      const mockBankTransactionSelectBuilder = {
-        eq: vi.fn().mockReturnThis(),
-        single: vi.fn().mockResolvedValue({
-          data: mockBankTransaction,
-          error: null,
-        }),
-      };
-
-      const mockBankTransactionBuilder = {
-        select: vi.fn().mockReturnValue(mockBankTransactionSelectBuilder),
-        update: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      };
-
-      mockSupabase.from.mockImplementation((table: string) => {
-        if (table === 'pending_outflows') {
-          return mockPendingOutflowBuilder;
-        }
-        if (table === 'bank_transactions') {
-          return mockBankTransactionBuilder;
-        }
-        return mockBankTransactionBuilder;
-      });
+      const { mockBankTransactionBuilder } =
+        setupConfirmMatchMocks(mockPendingOutflow, mockBankTransaction);
       mockSupabase.rpc.mockResolvedValue({ data: null, error: null });
 
       const { result } = renderHook(() => usePendingOutflowMutations(), { wrapper: createWrapper() });
@@ -233,29 +206,7 @@ describe('usePendingOutflowMutations', () => {
         suggested_category_id: null,
       };
 
-      const mockPendingOutflowBuilder = {
-        select: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnThis(),
-          single: vi.fn().mockResolvedValue({ data: mockPendingOutflow, error: null }),
-        }),
-        update: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      };
-
-      const mockBankTransactionBuilder = {
-        select: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnThis(),
-          single: vi.fn().mockResolvedValue({ data: mockBankTransaction, error: null }),
-        }),
-        update: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      };
-
-      mockSupabase.from.mockImplementation((table: string) => {
-        if (table === 'pending_outflows') return mockPendingOutflowBuilder;
-        if (table === 'bank_transactions') return mockBankTransactionBuilder;
-        return mockPendingOutflowBuilder;
-      });
+      setupConfirmMatchMocks(mockPendingOutflow, mockBankTransaction);
       mockSupabase.rpc.mockResolvedValue({ data: null, error: null });
 
       const { result } = renderHook(() => usePendingOutflowMutations(), { wrapper: createWrapper() });
@@ -292,31 +243,8 @@ describe('usePendingOutflowMutations', () => {
         suggested_category_id: null,
       };
 
-      const mockPendingOutflowBuilder = {
-        select: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnThis(),
-          single: vi.fn().mockResolvedValue({ data: mockPendingOutflow, error: null }),
-        }),
-        update: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      };
-
-      const mockBankTransactionBuilder = {
-        select: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnThis(),
-          single: vi.fn().mockResolvedValue({ data: mockBankTransaction, error: null }),
-        }),
-        update: vi.fn((_payload: unknown) => {
-          callOrder.push('update');
-          return mockBankTransactionBuilder;
-        }),
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      };
-
-      mockSupabase.from.mockImplementation((table: string) => {
-        if (table === 'pending_outflows') return mockPendingOutflowBuilder;
-        if (table === 'bank_transactions') return mockBankTransactionBuilder;
-        return mockPendingOutflowBuilder;
+      setupConfirmMatchMocks(mockPendingOutflow, mockBankTransaction, {
+        onBankUpdate: () => callOrder.push('update'),
       });
       mockSupabase.rpc.mockImplementation(async () => {
         callOrder.push('rpc');
@@ -355,29 +283,8 @@ describe('usePendingOutflowMutations', () => {
         suggested_category_id: null,
       };
 
-      const mockPendingOutflowBuilder = {
-        select: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnThis(),
-          single: vi.fn().mockResolvedValue({ data: mockPendingOutflow, error: null }),
-        }),
-        update: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      };
-
-      const mockBankTransactionBuilder = {
-        select: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnThis(),
-          single: vi.fn().mockResolvedValue({ data: mockBankTransaction, error: null }),
-        }),
-        update: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      };
-
-      mockSupabase.from.mockImplementation((table: string) => {
-        if (table === 'pending_outflows') return mockPendingOutflowBuilder;
-        if (table === 'bank_transactions') return mockBankTransactionBuilder;
-        return mockPendingOutflowBuilder;
-      });
+      const { mockBankTransactionBuilder } =
+        setupConfirmMatchMocks(mockPendingOutflow, mockBankTransaction);
       mockSupabase.rpc.mockResolvedValue({ data: null, error: null });
 
       const { result } = renderHook(() => usePendingOutflowMutations(), { wrapper: createWrapper() });
@@ -415,29 +322,7 @@ describe('usePendingOutflowMutations', () => {
         suggested_category_id: null,
       };
 
-      const mockPendingOutflowBuilder = {
-        select: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnThis(),
-          single: vi.fn().mockResolvedValue({ data: mockPendingOutflow, error: null }),
-        }),
-        update: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      };
-
-      const mockBankTransactionBuilder = {
-        select: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnThis(),
-          single: vi.fn().mockResolvedValue({ data: mockBankTransaction, error: null }),
-        }),
-        update: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      };
-
-      mockSupabase.from.mockImplementation((table: string) => {
-        if (table === 'pending_outflows') return mockPendingOutflowBuilder;
-        if (table === 'bank_transactions') return mockBankTransactionBuilder;
-        return mockPendingOutflowBuilder;
-      });
+      setupConfirmMatchMocks(mockPendingOutflow, mockBankTransaction);
       mockSupabase.rpc.mockResolvedValue({ data: null, error: null });
 
       const { result } = renderHook(() => usePendingOutflowMutations(), { wrapper: createWrapper() });
@@ -472,29 +357,8 @@ describe('usePendingOutflowMutations', () => {
         suggested_category_id: null,
       };
 
-      const mockPendingOutflowBuilder = {
-        select: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnThis(),
-          single: vi.fn().mockResolvedValue({ data: mockPendingOutflow, error: null }),
-        }),
-        update: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      };
-
-      const mockBankTransactionBuilder = {
-        select: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnThis(),
-          single: vi.fn().mockResolvedValue({ data: mockBankTransaction, error: null }),
-        }),
-        update: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      };
-
-      mockSupabase.from.mockImplementation((table: string) => {
-        if (table === 'pending_outflows') return mockPendingOutflowBuilder;
-        if (table === 'bank_transactions') return mockBankTransactionBuilder;
-        return mockPendingOutflowBuilder;
-      });
+      const { mockBankTransactionBuilder } =
+        setupConfirmMatchMocks(mockPendingOutflow, mockBankTransaction);
       mockSupabase.rpc.mockResolvedValue({ data: null, error: null });
 
       const { result } = renderHook(() => usePendingOutflowMutations(), { wrapper: createWrapper() });
@@ -533,29 +397,7 @@ describe('usePendingOutflowMutations', () => {
         suggested_category_id: null,
       };
 
-      const mockPendingOutflowBuilder = {
-        select: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnThis(),
-          single: vi.fn().mockResolvedValue({ data: mockPendingOutflow, error: null }),
-        }),
-        update: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      };
-
-      const mockBankTransactionBuilder = {
-        select: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnThis(),
-          single: vi.fn().mockResolvedValue({ data: mockBankTransaction, error: null }),
-        }),
-        update: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      };
-
-      mockSupabase.from.mockImplementation((table: string) => {
-        if (table === 'pending_outflows') return mockPendingOutflowBuilder;
-        if (table === 'bank_transactions') return mockBankTransactionBuilder;
-        return mockPendingOutflowBuilder;
-      });
+      setupConfirmMatchMocks(mockPendingOutflow, mockBankTransaction);
       mockSupabase.rpc.mockResolvedValue({ data: null, error: null });
 
       const { result } = renderHook(() => usePendingOutflowMutations(), { wrapper: createWrapper() });
@@ -586,29 +428,7 @@ describe('usePendingOutflowMutations', () => {
         suggested_category_id: null,
       };
 
-      const mockPendingOutflowBuilder = {
-        select: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnThis(),
-          single: vi.fn().mockResolvedValue({ data: mockPendingOutflow, error: null }),
-        }),
-        update: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      };
-
-      const mockBankTransactionBuilder = {
-        select: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnThis(),
-          single: vi.fn().mockResolvedValue({ data: mockBankTransaction, error: null }),
-        }),
-        update: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      };
-
-      mockSupabase.from.mockImplementation((table: string) => {
-        if (table === 'pending_outflows') return mockPendingOutflowBuilder;
-        if (table === 'bank_transactions') return mockBankTransactionBuilder;
-        return mockPendingOutflowBuilder;
-      });
+      setupConfirmMatchMocks(mockPendingOutflow, mockBankTransaction);
       mockSupabase.rpc.mockResolvedValue({ data: null, error: null });
 
       const { result } = renderHook(() => usePendingOutflowMutations(), { wrapper: createWrapper() });
@@ -637,29 +457,7 @@ describe('usePendingOutflowMutations', () => {
         suggested_category_id: null,
       };
 
-      const mockPendingOutflowBuilder = {
-        select: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnThis(),
-          single: vi.fn().mockResolvedValue({ data: mockPendingOutflow, error: null }),
-        }),
-        update: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      };
-
-      const mockBankTransactionBuilder = {
-        select: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnThis(),
-          single: vi.fn().mockResolvedValue({ data: mockBankTransaction, error: null }),
-        }),
-        update: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      };
-
-      mockSupabase.from.mockImplementation((table: string) => {
-        if (table === 'pending_outflows') return mockPendingOutflowBuilder;
-        if (table === 'bank_transactions') return mockBankTransactionBuilder;
-        return mockPendingOutflowBuilder;
-      });
+      setupConfirmMatchMocks(mockPendingOutflow, mockBankTransaction);
       mockSupabase.rpc.mockResolvedValue({ data: null, error: null });
 
       const invalidateSpy = vi.spyOn(QueryClient.prototype, 'invalidateQueries');
@@ -726,29 +524,8 @@ describe('usePendingOutflowMutations', () => {
         suggested_category_id: null,
       };
 
-      const mockPendingOutflowBuilder = {
-        select: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnThis(),
-          single: vi.fn().mockResolvedValue({ data: mockPendingOutflow, error: null }),
-        }),
-        update: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      };
-
-      const mockBankTransactionBuilder = {
-        select: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnThis(),
-          single: vi.fn().mockResolvedValue({ data: mockBankTransaction, error: null }),
-        }),
-        update: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      };
-
-      mockSupabase.from.mockImplementation((table: string) => {
-        if (table === 'pending_outflows') return mockPendingOutflowBuilder;
-        if (table === 'bank_transactions') return mockBankTransactionBuilder;
-        return mockPendingOutflowBuilder;
-      });
+      const { mockPendingOutflowBuilder, mockBankTransactionBuilder } =
+        setupConfirmMatchMocks(mockPendingOutflow, mockBankTransaction);
       mockSupabase.rpc.mockResolvedValue({
         data: null,
         error: {
@@ -791,29 +568,8 @@ describe('usePendingOutflowMutations', () => {
         suggested_category_id: null,
       };
 
-      const mockPendingOutflowBuilder = {
-        select: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnThis(),
-          single: vi.fn().mockResolvedValue({ data: mockPendingOutflow, error: null }),
-        }),
-        update: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      };
-
-      const mockBankTransactionBuilder = {
-        select: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnThis(),
-          single: vi.fn().mockResolvedValue({ data: mockBankTransaction, error: null }),
-        }),
-        update: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      };
-
-      mockSupabase.from.mockImplementation((table: string) => {
-        if (table === 'pending_outflows') return mockPendingOutflowBuilder;
-        if (table === 'bank_transactions') return mockBankTransactionBuilder;
-        return mockPendingOutflowBuilder;
-      });
+      const { mockPendingOutflowBuilder, mockBankTransactionBuilder } =
+        setupConfirmMatchMocks(mockPendingOutflow, mockBankTransaction);
       mockSupabase.rpc.mockResolvedValue({
         data: null,
         error: {
@@ -855,29 +611,7 @@ describe('usePendingOutflowMutations', () => {
         suggested_category_id: null,
       };
 
-      const mockPendingOutflowBuilder = {
-        select: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnThis(),
-          single: vi.fn().mockResolvedValue({ data: mockPendingOutflow, error: null }),
-        }),
-        update: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      };
-
-      const mockBankTransactionBuilder = {
-        select: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnThis(),
-          single: vi.fn().mockResolvedValue({ data: mockBankTransaction, error: null }),
-        }),
-        update: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockResolvedValue({ error: null }),
-      };
-
-      mockSupabase.from.mockImplementation((table: string) => {
-        if (table === 'pending_outflows') return mockPendingOutflowBuilder;
-        if (table === 'bank_transactions') return mockBankTransactionBuilder;
-        return mockPendingOutflowBuilder;
-      });
+      setupConfirmMatchMocks(mockPendingOutflow, mockBankTransaction);
       mockSupabase.rpc.mockResolvedValue({
         data: null,
         error: { message: 'boom' },

--- a/tests/unit/usePendingOutflows.test.ts
+++ b/tests/unit/usePendingOutflows.test.ts
@@ -458,6 +458,171 @@ describe('usePendingOutflowMutations', () => {
       });
     });
 
+    it('skips the RPC when the outflow has no category', async () => {
+      const mockPendingOutflow = {
+        id: 'po-123',
+        category_id: null,
+        notes: 'Expense notes',
+        expense_invoice_uploads: [],
+      };
+
+      const mockBankTransaction = {
+        notes: 'Bank notes',
+        category_id: null,
+        suggested_category_id: null,
+      };
+
+      const mockPendingOutflowBuilder = {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: mockPendingOutflow, error: null }),
+        }),
+        update: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      };
+
+      const mockBankTransactionBuilder = {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: mockBankTransaction, error: null }),
+        }),
+        update: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      };
+
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === 'pending_outflows') return mockPendingOutflowBuilder;
+        if (table === 'bank_transactions') return mockBankTransactionBuilder;
+        return mockPendingOutflowBuilder;
+      });
+      mockSupabase.rpc.mockResolvedValue({ data: null, error: null });
+
+      const { result } = renderHook(() => usePendingOutflowMutations(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        await result.current.confirmMatch.mutateAsync({
+          pendingOutflowId: 'po-123',
+          bankTransactionId: 'bt-456',
+        });
+      });
+
+      expect(mockSupabase.rpc).not.toHaveBeenCalled();
+
+      expect(mockBankTransactionBuilder.update).toHaveBeenCalledWith({
+        matched_at: expect.any(String),
+        notes: 'Bank notes\n\nExpense notes',
+      });
+
+      const updatePayload = mockBankTransactionBuilder.update.mock.calls[0][0];
+      expect(updatePayload).not.toHaveProperty('is_categorized');
+      expect(updatePayload).not.toHaveProperty('category_id');
+      expect(updatePayload).not.toHaveProperty('suggested_category_id');
+    });
+
+    it('shows the categorize reminder on a no-category match', async () => {
+      const mockPendingOutflow = {
+        id: 'po-123',
+        category_id: null,
+        notes: null,
+        expense_invoice_uploads: [],
+      };
+
+      const mockBankTransaction = {
+        notes: null,
+        category_id: null,
+        suggested_category_id: null,
+      };
+
+      const mockPendingOutflowBuilder = {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: mockPendingOutflow, error: null }),
+        }),
+        update: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      };
+
+      const mockBankTransactionBuilder = {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: mockBankTransaction, error: null }),
+        }),
+        update: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      };
+
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === 'pending_outflows') return mockPendingOutflowBuilder;
+        if (table === 'bank_transactions') return mockBankTransactionBuilder;
+        return mockPendingOutflowBuilder;
+      });
+      mockSupabase.rpc.mockResolvedValue({ data: null, error: null });
+
+      const { result } = renderHook(() => usePendingOutflowMutations(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        await result.current.confirmMatch.mutateAsync({
+          pendingOutflowId: 'po-123',
+          bankTransactionId: 'bt-456',
+        });
+      });
+
+      expect(toast.success).toHaveBeenCalledWith(
+        'Expense matched. Categorize the transaction on the Banking page.'
+      );
+    });
+
+    it('shows the cleared toast on a categorized match', async () => {
+      const mockPendingOutflow = {
+        id: 'po-123',
+        category_id: 'cat-456',
+        notes: null,
+        expense_invoice_uploads: [],
+      };
+
+      const mockBankTransaction = {
+        notes: null,
+        category_id: null,
+        suggested_category_id: null,
+      };
+
+      const mockPendingOutflowBuilder = {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: mockPendingOutflow, error: null }),
+        }),
+        update: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      };
+
+      const mockBankTransactionBuilder = {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: mockBankTransaction, error: null }),
+        }),
+        update: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      };
+
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === 'pending_outflows') return mockPendingOutflowBuilder;
+        if (table === 'bank_transactions') return mockBankTransactionBuilder;
+        return mockPendingOutflowBuilder;
+      });
+      mockSupabase.rpc.mockResolvedValue({ data: null, error: null });
+
+      const { result } = renderHook(() => usePendingOutflowMutations(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        await result.current.confirmMatch.mutateAsync({
+          pendingOutflowId: 'po-123',
+          bankTransactionId: 'bt-456',
+        });
+      });
+
+      expect(toast.success).toHaveBeenCalledWith('Expense matched and cleared');
+    });
+
     it('should handle errors gracefully', async () => {
       const pendingOutflowQuery = {
         select: vi.fn().mockReturnThis(),

--- a/tests/unit/usePendingOutflows.test.ts
+++ b/tests/unit/usePendingOutflows.test.ts
@@ -168,26 +168,30 @@ describe('usePendingOutflowMutations', () => {
       });
     });
 
+    // Shared by the two guard tests below (block vs. allow): the same
+    // different-category pending outflow and bank transaction fixtures.
+    // Only the `existingJournalEntry` option passed to
+    // setupConfirmMatchMocks differs between them. The transaction
+    // already carries a DIFFERENT category, so the RPC would take the
+    // reclassification branch here, crediting "existing-cat" — a
+    // spurious credit unless a journal entry from the first categorize
+    // already debits that account.
+    const differentCategoryPendingOutflow = {
+      id: 'po-123',
+      category_id: 'cat-456',
+      notes: 'Expense notes',
+      expense_invoice_uploads: [],
+    };
+
+    const differentCategoryBankTransaction = {
+      notes: null,
+      category_id: 'existing-cat',
+      suggested_category_id: 'existing-suggested',
+    };
+
     it('blocks a different-category match when the transaction has no journal entry', async () => {
-      const mockPendingOutflow = {
-        id: 'po-123',
-        category_id: 'cat-456',
-        notes: 'Expense notes',
-        expense_invoice_uploads: [],
-      };
-
-      // The transaction already carries a DIFFERENT category. The RPC
-      // would take the reclassification branch here, crediting
-      // "existing-cat" — a spurious credit unless a journal entry from
-      // the first categorize already debits that account.
-      const mockBankTransaction = {
-        notes: null,
-        category_id: 'existing-cat',
-        suggested_category_id: 'existing-suggested',
-      };
-
       const { mockPendingOutflowBuilder, mockBankTransactionBuilder, mockJournalEntriesBuilder } =
-        setupConfirmMatchMocks(mockPendingOutflow, mockBankTransaction, {
+        setupConfirmMatchMocks(differentCategoryPendingOutflow, differentCategoryBankTransaction, {
           existingJournalEntry: null,
         });
 
@@ -214,21 +218,8 @@ describe('usePendingOutflowMutations', () => {
     });
 
     it('allows a different-category match when a journal entry already exists', async () => {
-      const mockPendingOutflow = {
-        id: 'po-123',
-        category_id: 'cat-456',
-        notes: 'Expense notes',
-        expense_invoice_uploads: [],
-      };
-
-      const mockBankTransaction = {
-        notes: null,
-        category_id: 'existing-cat',
-        suggested_category_id: 'existing-suggested',
-      };
-
       const { mockBankTransactionBuilder } =
-        setupConfirmMatchMocks(mockPendingOutflow, mockBankTransaction, {
+        setupConfirmMatchMocks(differentCategoryPendingOutflow, differentCategoryBankTransaction, {
           existingJournalEntry: { id: 'je-1' },
         });
       mockSupabase.rpc.mockResolvedValue({ data: null, error: null });


### PR DESCRIPTION
## Summary
- Rewrite `confirmMatch` in `usePendingOutflows.tsx` to call the `categorize_bank_transaction` RPC first, then run a metadata-only update on the bank transaction. This makes the RPC (not the hook) the single writer of the journal entry.
- Merge bank and outflow notes into one description for the RPC call, without duplicate text.
- Skip the RPC on a no-category outflow. Keep the transaction in review and show a reminder toast to categorize it on the Banking page.
- Map the RPC's guard errors (reconciled transaction, closed fiscal period) to clear toast copy on the Banking page.
- Block a match that would skip the journal entry: a same-category match with no existing journal entry, and a different-category match with no existing journal entry, both throw before the RPC call.
- Invalidate `income-statement`, `balance-sheet`, and `chart-of-accounts` queries on a successful match, in addition to the existing pending-outflow and bank-transaction queries.
- Keep `ManualMatchDialog` open on a failed match (wrap `mutateAsync` in try/catch).
- Show a "Needs category" badge on a cleared outflow card when the outflow still has no category.
- Disable the category selector on a cleared outflow in `EditExpenseSheet`, with a hint to use the Banking page instead. This closes a path where editing a cleared outflow could clear the "Needs category" signal with no ledger write.
- Add an e2e test that seeds a bank transaction and a pending outflow, confirms a manual match, and asserts one balanced `journal_entries` row plus the correct transaction and outflow state.

## Test plan
- `npm run test` — 788 files passed, 1 skipped; 9471 tests passed, 2 skipped; 0 failed.
- `npm run test:db:reset` — 2961/2961 pgTAP tests passed on a quiet machine.
- `npm run test:e2e` — full 229-test suite: 182 passed / 35 failed / 12 skipped under machine load; a `--last-failed` retry on a quiet machine passed 34/35, and the last remaining test (outside this diff) passed alone. Every non-skipped e2e test passed in at least one run. `tests/e2e/pending-outflow-match.spec.ts` (new in this PR) passed on every run.
- `npm run typecheck` — exit 0.
- `npm run lint` — scoped to the 8 changed files: only the pre-existing baseline error at `usePendingOutflows.tsx:198` remains (confirmed on `origin/main`, out of scope).
- `npm run build` — exit 0.

Design doc: [docs/superpowers/specs/2026-08-20-pending-outflow-match-journal-entries-design.md](docs/superpowers/specs/2026-08-20-pending-outflow-match-journal-entries-design.md)

## Known deferred review findings
- **minor** — `tests/unit/usePendingOutflows.test.ts:188` — ocr-rules: 15 of the confirmMatch tests repeat the identical 7-line renderHook+act+mutateAsync block instead of a shared helper. The setupConfirmMatchMocks helper already dedupes mock setup; this remaining boilerplate was not folded in.
  Reason: Not a one-line mechanical change: extracting a shared runner would need to handle differing shapes across call sites (some expect rejection inside try/catch, most expect success, assertions vary between RPC-call checks and toast checks). Left for a dedicated test-refactor pass rather than risking behavior drift inside a bug-fix commit.
- **info** — `src/hooks/usePendingOutflows.tsx` — maintainability: full review of the 3 source files and tests found no issue reaching the 80-confidence bar; explicitly checked and ruled out a comment-precedent question, mutationFn length, a pre-existing any type, and pre-existing import-order gaps.
  Reason: Informational completion note, not an actionable defect. Nothing to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pending outflows can now be matched while creating the appropriate journal entry and updating transaction categories.
  * Cleared outflows without a category display a “Needs category” badge and guidance for completing categorization.
  * Notes are preserved and merged without duplication during matching.

* **Bug Fixes**
  * Failed manual matches now keep the dialog open for retry.
  * Added clearer success and error messages for categorization and ledger safeguards.
  * Financial views refresh automatically after matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->